### PR TITLE
Fix temp-column/shard eviction race: 1s minimum item lifetime + atomic LRU

### DIFF
--- a/storage/cache.go
+++ b/storage/cache.go
@@ -58,6 +58,7 @@ type softItem struct {
 	getScore      func(pointer any) float64 // optional type-specific telemetry
 	heapIndex     int                       // position in heap (-1 if not in heap)
 	dynamicScore  float64                   // scratch field for Phase 2
+	registeredAt  int64                     // UnixNano; set once in addInternal as fallback for items whose lastAccessed starts at zero
 }
 
 // softItemHeap implements container/heap.Interface as a max-heap on evictionScore.
@@ -373,6 +374,7 @@ func (cm *CacheManager) addInternal(item *softItem) {
 		cm.itemMap[item.pointer] = item
 		return
 	}
+	item.registeredAt = time.Now().UnixNano()
 	cm.itemMap[item.pointer] = item
 	cm.currentMemory += item.size
 	scm.AdjustMemStats(item.size)
@@ -489,6 +491,15 @@ func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFi
 		c := candidates[i]
 		// check again — previous cleanup in this loop may have freed this item recursively
 		if _, ok := cm.itemMap[c.pointer]; !ok {
+			continue
+		}
+		// guarantee minimum lifetime of 1s: use the later of registeredAt and getLastUsed
+		lastActive := c.registeredAt
+		if lu := c.getLastUsed(c.pointer).UnixNano(); lu > lastActive {
+			lastActive = lu
+		}
+		if now.UnixNano()-lastActive < int64(time.Second) {
+			heap.Push(&cm.h, c)
 			continue
 		}
 		if !c.cleanup(c.pointer, &freedByType) {

--- a/storage/database.go
+++ b/storage/database.go
@@ -19,10 +19,10 @@ package storage
 import "os"
 import "fmt"
 import "sync"
+import "sync/atomic"
 import "time"
 import "runtime"
 import "strings"
-import "sync/atomic"
 import "encoding/json"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/NonLockingReadMap"
@@ -740,10 +740,6 @@ func RenameTable(schema, oldname, newname string) {
 // MUST NOT use Lock on schemalock (deadlock: CreateTable holds schemalock → AddItem → evict → here).
 // Returns false if the schemalock is busy (item pushed back for later retry).
 func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTypes]int64) bool {
-	// lease active: defer eviction, CacheManager will retry later
-	if time.Now().UnixNano() < atomic.LoadInt64(&tbl.leaseUntil) {
-		return false
-	}
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Println("error: keytableCleanup panic for", schemaName+"."+tbl.Name, ":", r)
@@ -789,16 +785,16 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 func keytableLastUsed(ptr any) time.Time {
 	tbl := ptr.(*table)
 	// use the newest shard lastAccessed as proxy
-	var latest time.Time
+	var latestNs uint64
 	for _, s := range tbl.Shards {
-		if s.lastAccessed.After(latest) {
-			latest = s.lastAccessed
+		if v := atomic.LoadUint64(&s.lastAccessed); v > latestNs {
+			latestNs = v
 		}
 	}
 	for _, s := range tbl.PShards {
-		if s.lastAccessed.After(latest) {
-			latest = s.lastAccessed
+		if v := atomic.LoadUint64(&s.lastAccessed); v > latestNs {
+			latestNs = v
 		}
 	}
-	return latest
+	return time.Unix(0, int64(latestNs))
 }

--- a/storage/index.go
+++ b/storage/index.go
@@ -632,7 +632,7 @@ func indexCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 
 func indexLastUsed(ptr any) time.Time {
 	// use the parent shard's lastAccessed as proxy
-	return ptr.(*StorageIndex).t.lastAccessed
+	return time.Unix(0, int64(atomic.LoadUint64(&ptr.(*StorageIndex).t.lastAccessed)))
 }
 
 func indexGetScore(ptr any) float64 {

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -19,6 +19,7 @@ package storage
 import "fmt"
 import "sort"
 import "sync"
+import "sync/atomic"
 import "time"
 import "runtime"
 import "strings"
@@ -808,7 +809,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 	// Register new PShards with CacheManager
 	if t.PersistencyMode != Memory && !strings.HasPrefix(t.Name, ".") {
 		for _, s := range newshards {
-			s.lastAccessed = time.Now()
+			atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 			GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 		}
 	}

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -235,25 +235,14 @@ func safeLogScan(schema, table string, ordered bool, filter, order string, input
 	t.Insert(cols, [][]scm.Scmer{row}, nil, scm.NewNil(), false, nil)
 }
 
-// touchTempColumns updates lastAccessed on temp columns used by this scan (lock-free).
+// touchTempColumns updates lastAccessed on all temp columns of the table (lock-free).
+// Touching every temp column (not just the ones in the scan's column lists) prevents
+// a concurrent eviction from modifying t.Columns while the scan is in progress.
 func touchTempColumns(t *table, colSets ...[]string) {
 	now := time.Now().UnixNano()
 	for _, c := range t.Columns {
-		if !c.IsTemp {
-			continue
-		}
-		for _, cols := range colSets {
-			found := false
-			for _, col := range cols {
-				if col == c.Name {
-					atomic.StoreInt64(&c.lastAccessed, now)
-					found = true
-					break
-				}
-			}
-			if found {
-				break
-			}
+		if c.IsTemp {
+			atomic.StoreInt64(&c.lastAccessed, now)
 		}
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -53,7 +53,7 @@ type storageShard struct {
 
 	// lazy-loading/shared-resource state
 	srState      SharedState
-	lastAccessed time.Time // updated on GetRead/GetExclusive for LRU eviction
+	lastAccessed uint64 // UnixNano, atomic; updated on GetRead/GetExclusive for LRU eviction
 
 	// repartition drain tracking: counts in-flight scans on this shard
 	activeScanners atomic.Int32
@@ -303,13 +303,13 @@ func (s *storageShard) GetRead() func() {
 	if s.srState == COLD {
 		s.srState = SHARED
 	}
-	s.lastAccessed = time.Now()
+	atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 	return func() {}
 }
 func (s *storageShard) GetExclusive() func() {
 	s.ensureLoaded()
 	s.srState = WRITE
-	s.lastAccessed = time.Now()
+	atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 	return func() {}
 }
 
@@ -334,7 +334,7 @@ func (s *storageShard) ensureLoaded() {
 		s.srState = SHARED
 	}
 	s.mu.Unlock()
-	s.lastAccessed = time.Now()
+	atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 	// register with CacheManager (skip temp tables and Memory-engine shards)
 	if s.t.PersistencyMode != Memory && !strings.HasPrefix(s.t.Name, ".") {
 		GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
@@ -375,7 +375,7 @@ func shardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 }
 
 func shardLastUsed(ptr any) time.Time {
-	return ptr.(*storageShard).lastAccessed
+	return time.Unix(0, int64(atomic.LoadUint64(&ptr.(*storageShard).lastAccessed)))
 }
 
 func NewShard(t *table) *storageShard {
@@ -1558,7 +1558,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 	result.mu.Unlock()
 	resultLocked = false
 	// Register the new shard with CacheManager
-	result.lastAccessed = time.Now()
+	atomic.StoreUint64(&result.lastAccessed, uint64(time.Now().UnixNano()))
 	if result.t.PersistencyMode != Memory && !strings.HasPrefix(result.t.Name, ".") {
 		GlobalCache.AddItem(result, int64(result.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,11 +20,11 @@ import "fmt"
 import "io"
 import "sort"
 import "sync"
+import "sync/atomic"
 import "time"
 import "strconv"
 import "reflect"
 import "strings"
-import "sync/atomic"
 import units "github.com/docker/go-units"
 import "github.com/launix-de/memcp/scm"
 
@@ -1185,7 +1185,19 @@ func Init(en scm.Env) {
 			if tbl == nil {
 				return scm.NewBool(false)
 			}
-			atomic.StoreInt64(&tbl.leaseUntil, time.Now().Add(time.Second).UnixNano())
+			now := time.Now()
+			nowNs := uint64(now.UnixNano())
+			for _, s := range tbl.Shards {
+				atomic.StoreUint64(&s.lastAccessed, nowNs)
+			}
+			for _, s := range tbl.PShards {
+				atomic.StoreUint64(&s.lastAccessed, nowNs)
+			}
+			for _, c := range tbl.Columns {
+				if c.IsTemp {
+					atomic.StoreInt64(&c.lastAccessed, now.UnixNano())
+				}
+			}
 			return scm.NewBool(true)
 		}, false, false, nil,
 		nil,

--- a/storage/table.go
+++ b/storage/table.go
@@ -152,9 +152,6 @@ type table struct {
 	Charset         string
 	Comment         string
 
-	// lease: CacheManager defers eviction until this time (UnixNano, atomic)
-	leaseUntil int64
-
 	// index column frequency: used to sort equality columns by frequency
 	// so that the most-queried columns come first, maximizing prefix overlap.
 	colFreq   map[string]int64


### PR DESCRIPTION
## Summary

Cherry-pick of the Go storage fixes from c988df4, without the queryplan.scm scalar-subquery changes.

- **cache.go**: add `registeredAt int64` to `softItem`; `evict()` skips any item whose `max(registeredAt, lastUsed)` is less than 1s old — guarantees minimum lifetime for every cached item
- **scan_helper.go**: `touchTempColumns` now refreshes **all** temp columns of the scanned table (not just those in the scan's column lists), preventing concurrent eviction during an active scan
- **shard.go / partition.go / database.go / storage.go / index.go**: change `storageShard.lastAccessed` from `time.Time` (non-atomic 24-byte struct) to `uint64` UnixNano with `atomic.LoadUint64`/`StoreUint64` everywhere — removes the data race on `shardLastUsed()` / `indexLastUsed()` / `keytableLastUsed()`

## Test plan
- [ ] CI green on the Go storage tests
- [ ] Memory pressure / eviction tests (29/29 pass on original commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)