### PR TITLE
Fix double-unlock panic in ProcessUniqueCollision (multi-UNIQUE tables)

### DIFF
--- a/storage/table.go
+++ b/storage/table.go
@@ -1101,7 +1101,18 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 				if isVisible {
 					// found a unique collision
 					if j != last_j {
-						t.ProcessUniqueCollision(columns, values[last_j:j], mergeNull, success, onCollisionCols, failure, idx+1) // flush
+						// If the inner check panics (unique violation in a later constraint),
+						// it will have released our lock via its own defer chain. Clear
+						// uniquelockHeld so our outer defer does not double-unlock.
+						var flushPanic interface{}
+						func() {
+							defer func() { flushPanic = recover() }()
+							t.ProcessUniqueCollision(columns, values[last_j:j], mergeNull, success, onCollisionCols, failure, idx+1) // flush
+						}()
+						if flushPanic != nil {
+							uniquelockHeld = false
+							panic(flushPanic)
+						}
 					}
 					last_j = j + 1
 					lock.Unlock()
@@ -1148,7 +1159,16 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 			}
 		}
 		if len(values) != last_j {
-			t.ProcessUniqueCollision(columns, values[last_j:], mergeNull, success, onCollisionCols, failure, idx+1) // flush the rest
+			// Same as above: clear uniquelockHeld if inner call releases the lock via panic.
+			var flushPanic interface{}
+			func() {
+				defer func() { flushPanic = recover() }()
+				t.ProcessUniqueCollision(columns, values[last_j:], mergeNull, success, onCollisionCols, failure, idx+1) // flush the rest
+			}()
+			if flushPanic != nil {
+				uniquelockHeld = false
+				panic(flushPanic)
+			}
 		}
 		if (!allowPruning || len(t.Unique) > 1) && idx == 0 {
 			lock.Unlock()


### PR DESCRIPTION
## Summary

- **Root cause**: tables with multiple UNIQUE constraints (e.g. `id PRIMARY KEY, email UNIQUE`) crash the server with `fatal: sync: unlock of unlocked mutex` when a constraint violation is detected in the second constraint (idx=1).
- **Why**: `ProcessUniqueCollision` is recursive — idx=0 holds `t.uniquelock`, calls idx=1 which does not own the lock. On a panic in `failure()`, idx=1's defer chain releases the lock, then idx=0's outer defer tries to release it again → fatal double-unlock, server crash.
- **Fix**: wrap both recursive flush calls with a recovery closure that sets `uniquelockHeld=false` before re-panicking, so idx=0's outer defer knows the lock was already released.
- Non-panic paths (UPSERT, INSERT IGNORE) are completely unaffected.

## Test plan
- [x] `tests/92_unique_main_delta.yaml` — 45/45 (was crashing the server before)
- [x] `tests/29_mysql_upsert.yaml` — 25/25 (UPSERT on secondary UNIQUE keys)
- [x] `tests/33_collations_order.yaml` — 4/4 (was failing as secondary victim of the server crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)