### PR TITLE
storage: fix backwards-compat for StorageDecimal and StorageEnum

### DIFF
--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -158,39 +158,26 @@ func (s *StorageDecimal) finish() {
 	s.inner.finish()
 }
 
-// storageDecimalVersion is the current binary format version for StorageDecimal.
-// Increment this constant and add a new deserializeDecimalV* helper whenever the
-// layout after the magic byte changes.  Never delete old helpers.
-const storageDecimalVersion = 0
-
 // StorageDecimal binary layout (magic byte 13 consumed by shard loader):
 //
-//	[version uint8]      ← first byte read by Deserialize
 //	[scaleExp int8]      ← power-of-ten exponent: real_value = stored_int * 10^scaleExp
-//	[inner StorageInt]   ← with its own magic byte 10 and version byte
+//	[inner StorageInt]   ← with its own magic byte 10
 //
 // Version history:
 //
-//	0 (current): layout as above; no prior format existed so no legacy detection needed.
+//	v0 (original, no version byte): layout as above.  The first byte after the
+//	magic is scaleExp (int8, typically non-zero), so there is no safe location
+//	for an inline version byte.  Format changes require a NEW magic byte in
+//	storages[] (storage.go); keep magic 13 as a legacy reader forever.
 func (s *StorageDecimal) Serialize(f io.Writer) {
 	binary.Write(f, binary.LittleEndian, uint8(13))
-	binary.Write(f, binary.LittleEndian, uint8(storageDecimalVersion)) // version byte
 	binary.Write(f, binary.LittleEndian, s.scaleExp)
 	s.inner.Serialize(f) // writes magic 10 + data
 }
 
 func (s *StorageDecimal) Deserialize(f io.Reader) uint {
-	var version uint8
-	binary.Read(f, binary.LittleEndian, &version)
-	switch version {
-	case 0:
-		return s.deserializeDecimalV0(f)
-	default:
-		panic(fmt.Sprintf("StorageDecimal: unknown version %d", version))
-	}
-}
-
-func (s *StorageDecimal) deserializeDecimalV0(f io.Reader) uint {
+	// No version byte: the first byte is scaleExp (int8).
+	// Format changes require a new magic byte.
 	binary.Read(f, binary.LittleEndian, &s.scaleExp)
 	return s.inner.DeserializeEx(f, true) // reads magic 10 + data
 }

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -435,16 +435,10 @@ func (s *StorageEnum) findChunk(idx int) int {
 	return lo
 }
 
-// storageEnumVersion is the current binary format version for StorageEnum.
-// Increment this constant and add a new deserializeEnumV* helper whenever the
-// layout after the magic byte changes.  Never delete old helpers.
-const storageEnumVersion = 0
-
 // --- Serialization ---
 //
 // StorageEnum binary layout (magic byte 40 consumed by shard loader):
 //
-//	[version uint8]        ← first byte read by Deserialize
 //	[k uint8]              ← number of symbols (2..8)
 //	[count uint64]
 //	[jumpL1Stride uint32]
@@ -459,12 +453,13 @@ const storageEnumVersion = 0
 //
 // Version history:
 //
-//	0 (current): layout as above.  StorageEnum was introduced after the
-//	             versioning scheme, so no legacy format exists.
+//	v0 (original, no version byte): layout as above.  The first byte after the
+//	magic is k (uint8, always 2..8), so there is no safe location for an inline
+//	version byte.  Format changes require a NEW magic byte in storages[]
+//	(storage.go); keep magic 40 as a legacy reader forever.
 
 func (s *StorageEnum) Serialize(f io.Writer) {
-	binary.Write(f, binary.LittleEndian, uint8(40))                 // magic byte 40 = StorageEnum
-	binary.Write(f, binary.LittleEndian, uint8(storageEnumVersion)) // version byte
+	binary.Write(f, binary.LittleEndian, uint8(40)) // magic byte 40 = StorageEnum
 	binary.Write(f, binary.LittleEndian, uint8(s.k))
 	binary.Write(f, binary.LittleEndian, uint64(s.count))
 	binary.Write(f, binary.LittleEndian, uint32(s.jumpL1Stride))
@@ -499,17 +494,8 @@ func (s *StorageEnum) Serialize(f io.Writer) {
 }
 
 func (s *StorageEnum) Deserialize(f io.Reader) uint {
-	var version uint8
-	binary.Read(f, binary.LittleEndian, &version)
-	switch version {
-	case 0:
-		return s.deserializeEnumV0(f)
-	default:
-		panic(fmt.Sprintf("StorageEnum: unknown version %d", version))
-	}
-}
-
-func (s *StorageEnum) deserializeEnumV0(f io.Reader) uint {
+	// No version byte: the first byte is k (number of symbols).
+	// Format changes require a new magic byte.
 	binary.Read(f, binary.LittleEndian, &s.k)
 	binary.Read(f, binary.LittleEndian, &s.count)
 	var stride uint32

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -83,12 +83,13 @@ type ColumnStorage interface {
 //  5. Data written before this versioning scheme was introduced is "version 0"
 //     (or a named legacy constant).  Each type documents what version 0 means.
 //
-// Exception — magic bytes 1 (StorageSCMER) and 2 (StorageSparse):
+// Exception — magic bytes 1, 2, 13, 40 (StorageSCMER, StorageSparse, StorageDecimal, StorageEnum):
 //   These types existed before the versioning scheme and had NO padding byte in
 //   their original layout, so there is no safe location for an inline version
-//   byte without corrupting existing data.  They read count directly, with NO
-//   version byte.  If either format must change, register a NEW magic byte
-//   (e.g. 101/102) for the new layout and keep 1/2 as read-only legacy readers.
+//   byte without corrupting existing data.  They read their first field directly
+//   with NO version byte.  If any of their formats must change, register a NEW
+//   magic byte for the new layout and keep the old magic as a read-only legacy
+//   reader forever.
 //
 // Current magic byte assignments:
 //
@@ -97,11 +98,11 @@ type ColumnStorage interface {
 //	10  StorageInt     – bit-packed integer
 //	11  StorageSeq     – sequential/auto-increment integer
 //	12  StorageFloat   – 64-bit float
-//	13  StorageDecimal – fixed-precision decimal
+//	13  StorageDecimal – fixed-precision decimal      (no version byte — see above)
 //	20  StorageString  – dictionary-compressed or buffer string
 //	21  StoragePrefix  – prefix-compressed string (experimental)
 //	31  OverlayBlob    – large binary/blob overlay
-//	40  StorageEnum    – rANS-entropy-coded enum
+//	40  StorageEnum    – rANS-entropy-coded enum         (no version byte — see above)
 //	50  StorageComputeProxy – computed/cached column
 var storages = map[uint8]reflect.Type{
 	1:  reflect.TypeOf(StorageSCMER{}),


### PR DESCRIPTION
## Summary

Follow-up to #19: two more storage types had no padding byte in their original format and were broken by the version-byte scheme introduced in that PR.

- **StorageDecimal (magic 13)**: first byte after magic was `scaleExp` (int8, always non-zero for decimal columns). Version-byte code read it as version → `unknown version N` panic.
- **StorageEnum (magic 40)**: first byte after magic was `k` (number of symbols, 2–8). Version-byte code read it as version → `unknown version K` panic.

Both types revert to the original no-version-byte format. Format changes for these types require a **new magic byte** in `storages[]`, same rule as magic 1 and 2.

Updated `storage.go` exception comment to list all four affected magic bytes (1, 2, 13, 40).

## Test plan
- [ ] Start server against existing `data/` directory — no panic on loading StorageDecimal or StorageEnum columns
- [ ] `tests/96_string_compression.yaml` passes
- [ ] `tests/75_serializer_coverage.yaml` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)