### PR TITLE
feat: support multi-table IN subselects via Neumann unnesting

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -473,50 +473,50 @@ is_dedup=false: replace aggregates with column fetches (for normal group stages)
 						))
 						(set fields2 (map_assoc fields2 (lambda (k v) (replace_find_column_subselect v))))
 						(set condition2 (replace_find_column_subselect (coalesceNil condition2 true)))
-					/* hash of inner query after column-resolution — used as dedup key and unique name suffix */
-					(define _sq_hash (fnv_hash (concat tables2 "|" fields2 "|" condition2)))
-					(define _sq_acc_name (concat "accsess_" _sq_hash))
-					(define _sq_rr_name  (concat "__scalar_resultrow_" _sq_hash))
-					/* dedup: if identical subquery already generated, reuse its accumulator */
-					(if (not (nil? (sq_cache _sq_hash)))
-						(sq_cache _sq_hash)
-						/* first occurrence: generate full setup+subplan */
-						(begin
-							(define replace_resultrow (lambda (expr) (match expr
-								(cons sym args) (if (equal? sym (quote resultrow))
-									(cons (symbol _sq_rr_name) (map args replace_resultrow))
-									(if (and (equal? sym (quote symbol)) (equal? args '("resultrow")))
-										(list (quote symbol) _sq_rr_name)
-										(cons (replace_resultrow sym) (map args replace_resultrow))
-									)
-								)
-								expr
-							)))
-							(define subplan (replace_resultrow (build_queryplan schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column_subselect)))
-							/* cache the read expression so duplicate subqueries skip the subplan */
-							(sq_cache _sq_hash (list (quote if) (list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral) nil (list (symbol _sq_acc_name) "acc")))
-							(list (quote !begin)
-								(list (quote set) (symbol _sq_acc_name) (list (quote newsession)))
-								(list (symbol _sq_acc_name) "acc" scalar_neutral)
-								(list (quote set) (symbol _sq_rr_name)
-									(list (quote lambda) (list (symbol "row"))
-										(list (quote begin)
-											(list (symbol _sq_acc_name) "acc"
-												(list scalar_reduce
-													(list (symbol _sq_acc_name) "acc")
-													(list (quote nth) (symbol "row") 1)))
-											true
+						/* hash of inner query after column-resolution — used as dedup key and unique name suffix */
+						(define _sq_hash (fnv_hash (concat tables2 "|" fields2 "|" condition2)))
+						(define _sq_acc_name (concat "accsess_" _sq_hash))
+						(define _sq_rr_name  (concat "__scalar_resultrow_" _sq_hash))
+						/* dedup: if identical subquery already generated, reuse its accumulator */
+						(if (not (nil? (sq_cache _sq_hash)))
+							(sq_cache _sq_hash)
+							/* first occurrence: generate full setup+subplan */
+							(begin
+								(define replace_resultrow (lambda (expr) (match expr
+									(cons sym args) (if (equal? sym (quote resultrow))
+										(cons (symbol _sq_rr_name) (map args replace_resultrow))
+										(if (and (equal? sym (quote symbol)) (equal? args '("resultrow")))
+											(list (quote symbol) _sq_rr_name)
+											(cons (replace_resultrow sym) (map args replace_resultrow))
 										)
 									)
+									expr
+								)))
+								(define subplan (replace_resultrow (build_queryplan schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column_subselect)))
+								/* cache the read expression so duplicate subqueries skip the subplan */
+								(sq_cache _sq_hash (list (quote if) (list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral) nil (list (symbol _sq_acc_name) "acc")))
+								(list (quote !begin)
+									(list (quote set) (symbol _sq_acc_name) (list (quote newsession)))
+									(list (symbol _sq_acc_name) "acc" scalar_neutral)
+									(list (quote set) (symbol _sq_rr_name)
+										(list (quote lambda) (list (symbol "row"))
+											(list (quote begin)
+												(list (symbol _sq_acc_name) "acc"
+													(list scalar_reduce
+														(list (symbol _sq_acc_name) "acc")
+														(list (quote nth) (symbol "row") 1)))
+												true
+											)
+										)
+									)
+									subplan
+									(list (quote if)
+										(list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral)
+										nil
+										(list (symbol _sq_acc_name) "acc"))
 								)
-								subplan
-								(list (quote if)
-									(list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral)
-									nil
-									(list (symbol _sq_acc_name) "acc"))
 							)
 						)
-					)
 					)
 				)
 			)
@@ -582,79 +582,97 @@ is_dedup=false: replace aggregates with column fetches (for normal group stages)
 									(list (quote and) condition2 (list (quote equal??) target_expr value_expr)))
 							)
 							(begin
-								(if (not (and (list? tables2) (equal? (count tables2) 1)))
-									(error "IN subselect with multiple tables not supported yet")
-								)
-								(define tdesc (car tables2))
-								(if (not (and (list? tdesc) (equal? (count tdesc) 5)))
-									(error "IN subselect with multiple tables not supported yet")
-								)
-								(define tblvar (nth tdesc 0))
-								(define schema3 (nth tdesc 1))
-								(define tbl (nth tdesc 2))
-								(define isOuter (nth tdesc 3))
-								(define joinexpr (nth tdesc 4))
-								(if (not (nil? joinexpr)) (error "IN subselect joins not supported yet"))
-								(define filtercols (extract_columns_for_tblvar tblvar condition2))
-								(define mapcols (extract_columns_for_tblvar tblvar value_expr))
+								/* OR-reduce for semi-join membership test */
+								(define in_reduce (list (quote lambda) (list (symbol "acc") (symbol "v"))
+									(list (quote or) (quote acc) (quote v))
+								))
+								(define in_neutral false)
 								(define use_ordered (or (and (not (nil? stage_order)) (not (equal? stage_order '()))) (not (nil? stage_limit)) (not (nil? stage_offset))))
+								(if (and use_ordered (not (equal? (count tables2) 1)))
+									(error "IN subselect ORDER BY with multiple tables not supported yet")
+								)
+								/* for single-table ordered case: extract sort columns from the one table */
+								(define tblvar0 (nth (car tables2) 0))
 								(define ordercols (merge (map stage_order (lambda (order_item) (match order_item '(col dir) (match col
-									'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
-									'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
+									'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar0) (list col) '())
+									'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar0) (list col) '())
 									_ '()
 								))))))
 								(define dirs (merge (map stage_order (lambda (order_item) (match order_item '(col dir) (match col
-									'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
-									'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
+									'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar0) (list dir) '())
+									'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar0) (list dir) '())
 									_ '()
 								))))))
 								(if (and use_ordered (not (equal? stage_order '())) (not (equal? (count ordercols) (count stage_order))))
 									(error "IN subselect ORDER BY must use direct columns")
 								)
-								(define in_reduce (list (quote lambda) (list (symbol "acc") (symbol "v"))
-									(list (quote or) (quote acc) (quote v))
+								/* recursive nested-scan builder: push dependent semi-join down through tables (Neumann unnesting) */
+								(define build_in_scan (lambda (scan_tables scan_condition)
+									(match scan_tables
+										(cons '(tblvar schema3 tbl3 isOuter3 _) rest_tables) (begin
+											/* columns from this table needed at this and inner scan levels */
+											(define cur_cols (merge_unique (list
+												(merge_unique (cons
+													(extract_columns_for_tblvar tblvar scan_condition)
+													(list (extract_columns_for_tblvar tblvar value_expr))
+												))
+												(merge_unique (cons
+													(extract_outer_columns_for_tblvar tblvar scan_condition)
+													(list (extract_outer_columns_for_tblvar tblvar value_expr))
+												))
+											)))
+											/* split condition: evaluate now vs defer to inner tables */
+											(match (split_condition (coalesceNil scan_condition true) rest_tables) '(now_condition later_condition) (begin
+												(define cur_filtercols (merge_unique (list
+													(extract_columns_for_tblvar tblvar now_condition)
+													(extract_outer_columns_for_tblvar tblvar now_condition)
+												)))
+												(if (and use_ordered (equal? rest_tables '()))
+													/* single-table ordered path */
+													(list (quote scan_order)
+														schema3 tbl3
+														(cons list cur_filtercols)
+														(list (quote lambda)
+															(map cur_filtercols (lambda (col) (symbol (concat tblvar "." col))))
+															(optimize (replace_columns_from_expr now_condition))
+														)
+														(cons list ordercols)
+														(cons list dirs)
+														(coalesceNil stage_offset 0)
+														(coalesceNil stage_limit -1)
+														(cons list cur_cols)
+														(list (quote lambda)
+															(map cur_cols (lambda (col) (symbol (concat tblvar "." col))))
+															(list (quote equal??) (replace_columns_from_expr target_expr) (replace_columns_from_expr value_expr))
+														)
+														in_reduce
+														in_neutral
+													)
+													/* unordered path: nest scans (Neumann dependent join push-down) */
+													(scan_wrapper 'scan schema3 tbl3
+														(cons list cur_filtercols)
+														(list (quote lambda)
+															(map cur_filtercols (lambda (col) (symbol (concat tblvar "." col))))
+															(optimize (replace_columns_from_expr now_condition))
+														)
+														(cons list cur_cols)
+														(list (quote lambda)
+															(map cur_cols (lambda (col) (symbol (concat tblvar "." col))))
+															(build_in_scan rest_tables later_condition)
+														)
+														in_reduce
+														in_neutral
+														in_reduce
+														isOuter3
+													)
+												)
+											))
+										)
+										/* base case: all tables visited, test membership equality */
+										'() (list (quote equal??) (replace_columns_from_expr target_expr) (replace_columns_from_expr value_expr))
+									)
 								))
-								(define in_neutral false)
-								(define map_expr (list (quote equal??) (replace_columns_from_expr target_expr) (replace_columns_from_expr value_expr)))
-								(if use_ordered
-									(list (quote scan_order)
-										schema3
-										tbl
-										(cons list filtercols)
-										(list (quote lambda)
-											(map filtercols (lambda (col) (symbol (concat tblvar "." col))))
-											(optimize (replace_columns_from_expr condition2))
-										)
-										(cons list ordercols)
-										(cons list dirs)
-										(coalesceNil stage_offset 0)
-										(coalesceNil stage_limit -1)
-										(cons list mapcols)
-										(list (quote lambda)
-											(map mapcols (lambda (col) (symbol (concat tblvar "." col))))
-											map_expr
-										)
-										in_reduce
-										in_neutral
-									)
-									(list (quote scan)
-										schema3
-										tbl
-										(cons list filtercols)
-										(list (quote lambda)
-											(map filtercols (lambda (col) (symbol (concat tblvar "." col))))
-											(optimize (replace_columns_from_expr condition2))
-										)
-										(cons list mapcols)
-										(list (quote lambda)
-											(map mapcols (lambda (col) (symbol (concat tblvar "." col))))
-											map_expr
-										)
-										in_reduce
-										in_neutral
-										in_reduce
-									)
-								)
+								(build_in_scan tables2 condition2)
 							)
 						))
 						in_expr

--- a/tests/32_expr_subselects.yaml
+++ b/tests/32_expr_subselects.yaml
@@ -168,7 +168,9 @@ test_cases:
         WHERE TRUE
       )
     expect:
-      error: true
+      rows: 1
+      data:
+        - id: 4
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS t4"

--- a/tests/98_in_subselect_multitable.yaml
+++ b/tests/98_in_subselect_multitable.yaml
@@ -1,0 +1,54 @@
+# IN subselect with multiple tables (multi-table JOIN inside IN)
+
+metadata:
+  version: "1.0"
+  description: "IN subselect with multi-table join (Neumann unnesting)"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS insub_post"
+  - sql: "DROP TABLE IF EXISTS insub_author"
+  - sql: "CREATE TABLE insub_author (id INT, name VARCHAR(100))"
+  - sql: "CREATE TABLE insub_post (id INT, author_id INT, title VARCHAR(200))"
+  - sql: "INSERT INTO insub_author (id, name) VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Carol')"
+  - sql: "INSERT INTO insub_post (id, author_id, title) VALUES (1, 1, 'Hello'), (2, 1, 'World'), (3, 2, 'Foo')"
+
+test_cases:
+  - name: "IN subselect single table (baseline)"
+    sql: "SELECT name FROM insub_author WHERE id IN (SELECT author_id FROM insub_post)"
+    expect:
+      rows: 2
+      data:
+        - name: Alice
+        - name: Bob
+
+  - name: "IN subselect multi-table inner join"
+    sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id WHERE a.name <> 'Carol')"
+    expect:
+      rows: 2
+      data:
+        - name: Alice
+        - name: Bob
+
+  - name: "IN subselect multi-table LEFT JOIN"
+    sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p LEFT JOIN insub_author a ON p.author_id = a.id)"
+    expect:
+      rows: 2
+      data:
+        - name: Alice
+        - name: Bob
+
+  - name: "IN subselect multi-table join no match"
+    sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id WHERE a.name = 'Carol')"
+    expect:
+      rows: 0
+
+  - name: "NOT IN subselect multi-table join"
+    sql: "SELECT name FROM insub_author WHERE id NOT IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id)"
+    expect:
+      rows: 1
+      data:
+        - name: Carol
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS insub_post"
+  - sql: "DROP TABLE IF EXISTS insub_author"


### PR DESCRIPTION
## Summary

- Replaces the `"IN subselect with multiple tables not supported yet"` panic with a recursive nested-scan builder in `build_in_subselect`
- Based on Neumann & Kemper "Unnesting Arbitrary Queries" (TUM): dependent semi-join is pushed down through each subquery table in turn (no extra materialization)
- `split_condition` distributes join predicates correctly across nested scan levels, same pattern as the outer `build_scan`
- OR-reduce (`acc or v`) propagates the boolean membership test up through all scan levels
- LEFT JOIN semantics preserved via `isOuter` flag on each `scan_wrapper` call
- Single-table ordered (`scan_order`) path is kept as a special case inside the same recursive builder

## Test plan

- [x] New test file `tests/98_in_subselect_multitable.yaml`: inner join, LEFT JOIN, no-match, NOT IN cases
- [x] `tests/32_expr_subselects.yaml`: DISTINCT+derived-table+LEFT JOIN IN subselect now passes (was `error: true`)
- [x] Full `make test` showed no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)