### PR TITLE
build: fix Makefile versioning and document release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,52 @@ Before merging any PR that touches storage, persistence, DDL, or cleanup code:
 - [ ] ENGINE semantics table above remains accurate (update if behaviour changes).
 - [ ] `AfterDropTable` / trigger callbacks reviewed for unintended side-effects.
 
+## Release Process
+
+### Version Numbering
+- Scheme: `MAJOR.MINOR` — no dates in the version string.
+- `0.x` while the API is still evolving; bump to `1.0` for the first stable API.
+- Bump `MINOR` for every normal release; bump `MAJOR` only for breaking API changes.
+
+### CHANGELOG.md Format
+The first line of `CHANGELOG.md` must be the bare version number followed by an em-dash and ISO date:
+```
+0.2 — 2026-03-XX
+=================
+- feat: short description
+- fix: short description
+```
+The Makefile reads `VERSION` from the first word of that line (`awk '{print $1}'`).
+
+### Release Steps
+1. Add a new entry at the top of `CHANGELOG.md` with the new version and date.
+2. Commit the changelog update to `master` (via PR as usual).
+3. Tag the release commit:
+   ```
+   git tag -a v0.2 -m "Release 0.2"
+   git push origin v0.2
+   ```
+4. Build artefacts:
+   ```
+   make memcp_0.2_amd64.deb memcp_0.2_x86_64.rpm
+   ```
+   Output filenames include version and arch automatically (e.g. `memcp_0.2_amd64.deb`, `memcp_0.2_x86_64.rpm`).
+5. Create GitHub release with artefacts:
+   ```
+   gh release create v0.2 memcp_0.2_amd64.deb memcp_0.2_x86_64.rpm \
+     --title "v0.2" --notes-file <(sed -n '/^0\.2/,/^[0-9]/p' CHANGELOG.md | head -n -2)
+   ```
+6. Push Docker image (requires `docker login` once):
+   ```
+   make docker-release
+   ```
+   This tags `carli2/memcp:0.2` **and** `carli2/memcp:latest` and pushes both.
+
+### Makefile Variables
+- `VERSION` — auto-read from `CHANGELOG.md`; override with `make VERSION=0.2 memcp_0.2_amd64.deb`.
+- `DEB_ARCH` — defaults to `dpkg --print-architecture` (e.g. `amd64`).
+- `RPM_ARCH` — defaults to `uname -m` (e.g. `x86_64`).
+
 ## MySQL ↔ MemCP Parallel Run Plan
 - Goal: operate MemCP alongside MySQL for months with minimal risk, validating correctness and performance before cutover.
 

--- a/Makefile
+++ b/Makefile
@@ -43,41 +43,48 @@ test:
 memcp.sif:
 	sudo singularity build memcp.sif memcp.singularity.recipe
 
-DEB_VERSION ?= $(shell head -1 CHANGELOG.md | tr -d '= \n')
-DEB_ARCH    ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
-DEB_DIR     := memcp_$(DEB_VERSION)_$(DEB_ARCH)
+# Version is the first word of the first line of CHANGELOG.md (e.g. "0.2")
+VERSION     ?= $(shell head -1 CHANGELOG.md | awk '{print $$1}')
 
-memcp.deb: all
+DEB_ARCH    ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
+DEB_DIR     := memcp_$(VERSION)_$(DEB_ARCH)
+DEB_OUT     := memcp_$(VERSION)_$(DEB_ARCH).deb
+
+# RPM uses the native arch name (x86_64, aarch64, …)
+RPM_ARCH    ?= $(shell uname -m)
+RPM_OUT     := memcp_$(VERSION)_$(RPM_ARCH).rpm
+
+memcp.deb: $(DEB_OUT)
+$(DEB_OUT): all
 	rm -rf $(DEB_DIR)
 	mkdir -p $(DEB_DIR)/DEBIAN
 	$(MAKE) install DESTDIR=$(DEB_DIR) PREFIX=/usr SYSTEMD_DIR=/usr/lib/systemd/system
-	printf "Package: memcp\nVersion: $(DEB_VERSION)\nArchitecture: $(DEB_ARCH)\nMaintainer: Carl-Philip Hänsch <hänsch@launix.de>\nDescription: memcp smart clusterable distributed database\n" \
+	printf "Package: memcp\nVersion: $(VERSION)\nArchitecture: $(DEB_ARCH)\nMaintainer: Carl-Philip Hänsch <hänsch@launix.de>\nDescription: memcp smart clusterable distributed database\n" \
 		> $(DEB_DIR)/DEBIAN/control
 	install -m 755 debian/postinst $(DEB_DIR)/DEBIAN/postinst
 	install -m 755 debian/prerm    $(DEB_DIR)/DEBIAN/prerm
 	install -m 755 debian/postrm   $(DEB_DIR)/DEBIAN/postrm
 	echo "/etc/memcp/memcp.conf" > $(DEB_DIR)/DEBIAN/conffiles
-	dpkg-deb --build --root-owner-group $(DEB_DIR) memcp.deb
+	dpkg-deb --build --root-owner-group $(DEB_DIR) $(DEB_OUT)
 	rm -rf $(DEB_DIR)
 
-RPM_VERSION ?= $(DEB_VERSION)
-RPM_ARCH    ?= $(shell uname -m)
-
-memcp.rpm: all
+memcp.rpm: $(RPM_OUT)
+$(RPM_OUT): all
 	mkdir -p .rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 	rpmbuild -bb memcp.spec \
 		--define "_topdir $(PWD)/.rpmbuild" \
-		--define "_version $(RPM_VERSION)" \
+		--define "_version $(VERSION)" \
 		--define "_arch $(RPM_ARCH)" \
 		--define "_srcdir $(PWD)"
-	find .rpmbuild/RPMS/$(RPM_ARCH)/ -name 'memcp-*.rpm' -exec cp {} memcp.rpm \;
+	find .rpmbuild/RPMS/$(RPM_ARCH)/ -name 'memcp-*.rpm' -exec cp {} $(RPM_OUT) \;
 	rm -rf .rpmbuild
 
 docs:
 	./memcp -write-docu docs
 
 docker-release:
-	sudo docker build -t carli2/memcp:latest .
+	sudo docker build -t carli2/memcp:$(VERSION) -t carli2/memcp:latest .
+	sudo docker push carli2/memcp:$(VERSION)
 	sudo docker push carli2/memcp:latest
 
-.PHONY: memcp.sif memcp.deb memcp.rpm docs
+.PHONY: memcp.sif memcp.deb memcp.rpm docs docker-release


### PR DESCRIPTION
## Summary
- Fix `VERSION` extraction in Makefile via `awk` (was broken by em-dash in CHANGELOG)
- DEB/RPM output filenames now include version and arch (e.g. `memcp_0.1_amd64.deb`, `memcp_0.1_x86_64.rpm`)
- `docker-release` target now tags both `:VERSION` and `:latest` before pushing
- `docker-release` added to `.PHONY`
- `AGENTS.md`: new **Release Process** section documenting version scheme, CHANGELOG format, and step-by-step release instructions (tag → build → GitHub release → DockerHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)