### PR TITLE
fix: root password setup, system user, config file parsing

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -106,6 +106,13 @@ if the user is not allowed to access this property, the function will throw an e
 	) true)
 )) (lambda (e) true))
 
+/* migration: ensure root always has admin=true */
+(try (lambda () (begin
+	(if (has? (show "system") "user")
+		(scan "system" "user" '("username") (lambda (username) (equal? username "root")) '("$update") (lambda ($update) ($update '("admin" true))))
+		true)
+)) (lambda (e) true))
+
 /* ensure unique username constraint to avoid duplicates */
 (try (lambda () (begin
 	(if (has? (show "system") "user")

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import "runtime/pprof"
 import "runtime/debug"
 import "github.com/google/uuid"
 import "github.com/fsnotify/fsnotify"
+import "github.com/jtolds/gls"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/memcp/storage"
 
@@ -592,47 +593,56 @@ func main() {
 	}
 
 	storage.Basepath = basepath
-	storage.LoadDatabases()
-	// scripts initialization
-	if len(imports) == 0 {
-		// search for lib/main.scm in well-known locations
-		exePath, _ := os.Executable()
-		exeDir := filepath.Dir(exePath)
-		candidates := []string{
-			filepath.Join(wd, "lib/main.scm"),
-			filepath.Join(exeDir, "lib/main.scm"),
-			"/usr/local/lib/memcp/lib/main.scm",
-			"/usr/lib/memcp/lib/main.scm",
-		}
-		found := false
-		for _, candidate := range candidates {
-			if _, err := os.Stat(candidate); err == nil {
-				fmt.Println("Loading " + candidate + " ...")
-				dir := filepath.Dir(candidate)
-				base := filepath.Base(candidate)
-				getImport(dir)(scm.NewString(base))
-				found = true
-				break
+	// Run initialization inside a gls.Go goroutine so that storage operations
+	// (scans, inserts, triggers) always have a valid GLS goroutine ID.
+	// Without this, hasWriteOwner/enterMutationOwner silently no-op (goid==0),
+	// breaking reentrancy guards and causing deadlocks.
+	initDone := make(chan struct{})
+	gls.Go(func() {
+		defer close(initDone)
+		storage.LoadDatabases()
+		// scripts initialization
+		if len(imports) == 0 {
+			// search for lib/main.scm in well-known locations
+			exePath, _ := os.Executable()
+			exeDir := filepath.Dir(exePath)
+			candidates := []string{
+				filepath.Join(wd, "lib/main.scm"),
+				filepath.Join(exeDir, "lib/main.scm"),
+				"/usr/local/lib/memcp/lib/main.scm",
+				"/usr/lib/memcp/lib/main.scm",
+			}
+			found := false
+			for _, candidate := range candidates {
+				if _, err := os.Stat(candidate); err == nil {
+					fmt.Println("Loading " + candidate + " ...")
+					dir := filepath.Dir(candidate)
+					base := filepath.Base(candidate)
+					getImport(dir)(scm.NewString(base))
+					found = true
+					break
+				}
+			}
+			if !found {
+				fmt.Fprintf(os.Stderr, "error: could not find lib/main.scm; tried: %v\n", candidates)
+				os.Exit(1)
+			}
+		} else {
+			// load scripts from command line
+			for _, scmfile := range imports {
+				fmt.Println("Loading " + scmfile + " ...")
+				IOEnv.Vars["import"].Func()(scm.NewString(scmfile))
 			}
 		}
-		if !found {
-			fmt.Fprintf(os.Stderr, "error: could not find lib/main.scm; tried: %v\n", candidates)
-			os.Exit(1)
+		for _, command := range commands {
+			fmt.Println("Executing " + command + " ...")
+			code := scm.Read("command line", command)
+			scm.Validate(code, "any")
+			code = scm.Optimize(code, &IOEnv)
+			scm.Eval(code, &IOEnv)
 		}
-	} else {
-		// load scripts from command line
-		for _, scmfile := range imports {
-			fmt.Println("Loading " + scmfile + " ...")
-			IOEnv.Vars["import"].Func()(scm.NewString(scmfile))
-		}
-	}
-	for _, command := range commands {
-		fmt.Println("Executing " + command + " ...")
-		code := scm.Read("command line", command)
-		scm.Validate(code, "any")
-		code = scm.Optimize(code, &IOEnv)
-		scm.Eval(code, &IOEnv)
-	}
+	})
+	<-initDone
 
 	// install exit handler
 	cancelChan := make(chan os.Signal, 1)
@@ -659,9 +669,9 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	// start cron
+	// start cron (inside gls.Go so storage scans in Rebuild have a valid GLS id)
 	exitable.Add(1)
-	go cronroutine()
+	gls.Go(cronroutine)
 
 	// REPL shell or wait for signal
 	if noRepl {
@@ -671,7 +681,12 @@ func main() {
 		<-sig
 	} else {
 		signal.Stop(cancelChan) // let readline handle SIGINT/SIGTERM in REPL mode
-		scm.Repl(&IOEnv)
+		replDone := make(chan struct{})
+		gls.Go(func() {
+			defer close(replDone)
+			scm.Repl(&IOEnv)
+		})
+		<-replDone
 	}
 
 	// normal shutdown

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -20,6 +20,7 @@ import (
 	"container/heap"
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -100,11 +101,31 @@ const systemFreeThreshold = 10 // percent
 // systemPressureCheckInterval is the minimum time between /proc/meminfo reads.
 const systemPressureCheckInterval = time.Second
 
-// systemMemInfo returns (freeBytes, totalBytes) of physical RAM via syscall.Sysinfo.
-// freeBytes is MemFree — hard-unallocated RAM, not counting reclaimable page cache.
-// Freeing our own cache directly increases this value.
+// systemMemInfo returns (freeBytes, totalBytes) of physical RAM.
+// freeBytes is MemAvailable from /proc/meminfo — includes page cache and reclaimable
+// memory, which is the correct metric for "how much RAM can we use before the OS
+// starts swapping". Falls back to syscall.Sysinfo.Freeram if /proc/meminfo is unavailable.
 // Returns (0, 0) on error.
 func systemMemInfo() (free, total int64) {
+	if f, err := os.Open("/proc/meminfo"); err == nil {
+		defer f.Close()
+		var available, totalkb int64
+		buf := make([]byte, 4096)
+		n, _ := f.Read(buf)
+		for _, line := range strings.SplitN(string(buf[:n]), "\n", 64) {
+			var kb int64
+			if strings.HasPrefix(line, "MemTotal:") {
+				fmt.Sscanf(strings.TrimPrefix(line, "MemTotal:"), "%d", &kb)
+				totalkb = kb
+			} else if strings.HasPrefix(line, "MemAvailable:") {
+				fmt.Sscanf(strings.TrimPrefix(line, "MemAvailable:"), "%d", &kb)
+				available = kb
+			}
+			if totalkb > 0 && available > 0 {
+				return available * 1024, totalkb * 1024
+			}
+		}
+	}
 	var info syscall.Sysinfo_t
 	if err := syscall.Sysinfo(&info); err != nil {
 		return 0, 0

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -63,7 +63,7 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	}
 
 	// Fast path 2: valid bit set → value in delta or main
-	if p.validMask.Get(idx) {
+	if p.validMask.Get(uint(idx)) {
 		p.mu.RLock()
 		if val, ok := p.delta[idx]; ok {
 			p.mu.RUnlock()
@@ -85,7 +85,7 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	p.mu.Lock()
 	p.delta[idx] = val
 	p.mu.Unlock()
-	p.validMask.Set(idx, true)
+	p.validMask.Set(uint(idx), true)
 
 	return val
 }
@@ -121,7 +121,7 @@ func (p *StorageComputeProxy) Compress() {
 		if val, ok := p.delta[idx]; ok {
 			return val
 		}
-		if p.main != nil && p.validMask.Get(idx) {
+		if p.main != nil && p.validMask.Get(uint(idx)) {
 			return p.main.GetValue(idx)
 		}
 		// compute
@@ -191,7 +191,7 @@ func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.S
 				colvalues[j] = readers[j].GetValue(i)
 			}
 			p.delta[i] = fn(colvalues...)
-			p.validMask.Set(i, true)
+			p.validMask.Set(uint(i), true)
 		}
 	}
 	// Don't set compressed=true → unmatched rows stay lazy for on-demand GetValue
@@ -216,7 +216,7 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 		// main is compressed type → can't SetValue → fall back to lazy
 		p.compressed = false
 	}
-	p.validMask.Set(idx, false)
+	p.validMask.Set(uint(idx), false)
 	delete(p.delta, idx)
 }
 
@@ -226,7 +226,7 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !p.compressed && !p.validMask.Get(idx) {
+	if !p.compressed && !p.validMask.Get(uint(idx)) {
 		return // not valid → will be computed fresh on next read
 	}
 	var oldVal scm.Scmer
@@ -253,7 +253,7 @@ func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
 		// non-compressed, mark all rows as valid so IncrementalUpdate works for
 		// other indices too. Values not in delta will fall through to main.
 		for i := uint32(0); i < p.count; i++ {
-			p.validMask.Set(i, true)
+			p.validMask.Set(uint(i), true)
 		}
 	}
 }
@@ -364,7 +364,7 @@ func (p *StorageComputeProxy) Serialize(f io.Writer) {
 	// validMask: serialize set bits
 	validCount := p.validMask.Count()
 	binary.Write(f, binary.LittleEndian, uint32(validCount))
-	p.validMask.Iterate(func(idx uint32) {
+	p.validMask.Iterate(func(idx uint) {
 		binary.Write(f, binary.LittleEndian, idx)
 	})
 }
@@ -446,7 +446,7 @@ func (p *StorageComputeProxy) deserializeComputeProxyV0(f io.Reader) uint {
 	for i := uint32(0); i < validCount; i++ {
 		var idx uint32
 		binary.Read(f, binary.LittleEndian, &idx)
-		p.validMask.Set(idx, true)
+		p.validMask.Set(uint(idx), true)
 	}
 
 	// shard back-reference is set by post-load hook in ensureColumnLoaded

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -520,7 +520,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 	// Take a brief RLock on each old shard to snapshot its deletion bitmap
 	// and inserts count. This gives us a consistent baseline for reconciliation.
 	type shardSnapshot struct {
-		deletions   interface{ Get(uint32) bool } // deletion bitmap copy
+		deletions   interface{ Get(uint) bool } // deletion bitmap copy
 		insertCount int                           // number of delta inserts at snapshot time
 		mainCount   uint32                        // main_count at snapshot time
 	}
@@ -531,7 +531,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		s.mu.RLock()
 		total_count += uint64(s.Count())
 		snapshots[si] = shardSnapshot{
-			deletions:   func() interface{ Get(uint32) bool } { c := s.deletions.Copy(); return &c }(),
+			deletions:   func() interface{ Get(uint) bool } { c := s.deletions.Copy(); return &c }(),
 			insertCount: len(s.inserts),
 			mainCount:   s.main_count,
 		}
@@ -656,9 +656,9 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		if deltaLen > 0 {
 			// Shift deletion bitmap: bits in [0, deltaLen) move to [mainN, mainN+deltaLen)
 			for i := uint32(0); i < uint32(deltaLen); i++ {
-				if s.deletions.Get(i) {
-					s.deletions.Set(uint32(mainN)+i, true)
-					s.deletions.Set(i, false)
+				if s.deletions.Get(uint(i)) {
+					s.deletions.Set(uint(uint32(mainN)+i), true)
+					s.deletions.Set(uint(i), false)
 				}
 			}
 			// Rebuild hashmaps with shifted keys
@@ -737,7 +737,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		snap := snapshots[si]
 		// Check main storage deletions
 		for idx := uint32(0); idx < snap.mainCount; idx++ {
-			if s.deletions.Get(idx) && !snap.deletions.Get(idx) {
+			if s.deletions.Get(uint(idx)) && !snap.deletions.Get(uint(idx)) {
 				for nsi, items := range datasetids {
 					if items == nil {
 						continue
@@ -745,7 +745,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 					oldItems := items[si]
 					for newIdx, oldIdx := range oldItems {
 						if oldIdx == idx {
-							newshards[nsi].deletions.Set(uint32(newIdx), true)
+							newshards[nsi].deletions.Set(uint(uint32(newIdx)), true)
 							goto nextDeletion
 						}
 					}
@@ -756,7 +756,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		// Check delta storage deletions
 		for idx := 0; idx < snap.insertCount; idx++ {
 			absIdx := snap.mainCount + uint32(idx)
-			if s.deletions.Get(absIdx) && !snap.deletions.Get(absIdx) {
+			if s.deletions.Get(uint(absIdx)) && !snap.deletions.Get(uint(absIdx)) {
 				for nsi, items := range datasetids {
 					if items == nil {
 						continue
@@ -764,7 +764,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 					oldItems := items[si]
 					for newIdx, oldIdx := range oldItems {
 						if oldIdx == absIdx {
-							newshards[nsi].deletions.Set(uint32(newIdx), true)
+							newshards[nsi].deletions.Set(uint(uint32(newIdx)), true)
 							goto nextDeltaDeletion
 						}
 					}
@@ -833,7 +833,7 @@ func (s *storageShard) partition(schema []shardDimension) (result map[int][]uint
 		maincols[i], _ = s.columns[sd.Column]
 	}
 	for idx := uint32(0); idx < s.main_count; idx++ {
-		if s.deletions.Get(idx) {
+		if s.deletions.Get(uint(idx)) {
 			continue
 		}
 		for i, cs := range maincols {
@@ -850,7 +850,7 @@ func (s *storageShard) partition(schema []shardDimension) (result map[int][]uint
 		deltacols[i], _ = s.deltaColumns[sd.Column]
 	}
 	for idx, dataset := range s.inserts {
-		if s.deletions.Get(s.main_count + uint32(idx)) {
+		if s.deletions.Get(uint(s.main_count + uint32(idx))) {
 			continue
 		}
 		for i, cs := range deltacols {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -149,26 +149,6 @@ func (t *table) scan(conditionCols []string, condition scm.Scmer, callbackCols [
 			}
 			akkumulator = fn(akkumulator, scm.Apply(callback, nullRow...)) // outer join: push one NULL row
 		}
-		// log statistics for unordered scan (best-effort, async so it doesn't add latency)
-		execNs := time.Since(execStart).Nanoseconds()
-		if inputCount > int64(Settings.AnalyzeMinItems) {
-			// log statistics for unordered scan (best-effort, async so it doesn't add latency)
-			go func(anNs, exNs int64) {
-				defer func() { _ = recover() }()
-				filterEnc := ""
-				if proc, ok := condition.Any().(scm.Proc); ok {
-					var params []scm.Scmer
-					if proc.Params.IsSlice() {
-						params = proc.Params.Slice()
-					} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
-						params = arr
-					}
-					filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
-				}
-				safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", inputCount, outCount, anNs, exNs)
-			}(analyzeNs, execNs)
-		}
-		return akkumulator
 	} else if !aggregate.IsNil() {
 		fn := scm.OptimizeProcToSerialFunction(aggregate)
 		for msg := range values {
@@ -189,25 +169,6 @@ func (t *table) scan(conditionCols []string, condition scm.Scmer, callbackCols [
 			}
 			akkumulator = fn(akkumulator, scm.Apply(callback, nullRow...)) // outer join: push one NULL row
 		}
-		execNs := time.Since(execStart).Nanoseconds()
-		if inputCount > int64(Settings.AnalyzeMinItems) {
-			// log statistics (async)
-			go func(anNs, exNs int64) {
-				defer func() { _ = recover() }()
-				filterEnc := ""
-				if proc, ok := condition.Any().(scm.Proc); ok {
-					var params []scm.Scmer
-					if proc.Params.IsSlice() {
-						params = proc.Params.Slice()
-					} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
-						params = arr
-					}
-					filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
-				}
-				safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", inputCount, outCount, anNs, exNs)
-			}(analyzeNs, execNs)
-		}
-		return akkumulator
 	} else {
 		for msg := range values {
 			if msg.err.r != nil {
@@ -224,26 +185,27 @@ func (t *table) scan(conditionCols []string, condition scm.Scmer, callbackCols [
 			}
 			scm.Apply(callback, nullRow...) // outer join: push one NULL row
 		}
-		execNs := time.Since(execStart).Nanoseconds()
-		if inputCount > int64(Settings.AnalyzeMinItems) {
-			// log statistics (async)
-			go func(anNs, exNs int64) {
-				defer func() { _ = recover() }()
-				filterEnc := ""
-				if proc, ok := condition.Any().(scm.Proc); ok {
-					var params []scm.Scmer
-					if proc.Params.IsSlice() {
-						params = proc.Params.Slice()
-					} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
-						params = arr
-					}
-					filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
-				}
-				safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", inputCount, outCount, anNs, exNs)
-			}(analyzeNs, execNs)
-		}
-		return akkumulator
 	}
+	// log statistics (best-effort, async so it doesn't add latency)
+	execNs := time.Since(execStart).Nanoseconds()
+	if Settings.ScanDebugging || inputCount > int64(Settings.AnalyzeMinItems) {
+		go func(anNs, exNs int64) {
+			defer func() { _ = recover() }()
+			filterEnc := ""
+			if proc, ok := condition.Any().(scm.Proc); ok {
+				var params []scm.Scmer
+				if proc.Params.IsSlice() {
+					params = proc.Params.Slice()
+				} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
+					params = arr
+				}
+				filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
+			}
+			indexColsEnc := boundaryIndexCols(boundaries)
+			safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", indexColsEnc, inputCount, outCount, anNs, exNs)
+		}(analyzeNs, execNs)
+	}
+	return akkumulator
 }
 
 func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer) (scm.Scmer, int64) {
@@ -283,12 +245,12 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	// condition column readers
 	ccols := make([]ColumnStorage, len(conditionCols))
 	for i, k := range conditionCols {
-		ccols[i] = t.getColumnStorageOrPanic(k)
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	// MapReducer for map+reduce phase (builds column readers internally)
-	mapper := t.OpenMapReducer(callbackCols, callback, aggregate)
+	mapper := t.openMapReducerEx(callbackCols, callback, aggregate, skipShardReadLock)
 	defer mapper.Close()
 	// Use a guarded lock that will always be released on panic to avoid leaked locks.
 	locked := false
@@ -322,7 +284,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 				continue
 			}
 			if hasMutationCallback && (currentTx == nil || currentTx.Mode != TxACID) {
-				if t.deletions.Get(effectiveIdx) {
+				if t.deletions.Get(uint(effectiveIdx)) {
 					if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(effectiveIdx); ok {
 						effectiveIdx = followIdx
 					} else {
@@ -340,7 +302,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 				if !currentTx.IsVisible(t, effectiveIdx) {
 					continue
 				}
-			} else if t.deletions.Get(effectiveIdx) {
+			} else if t.deletions.Get(uint(effectiveIdx)) {
 				continue // item is on delete list
 			}
 

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+// BenchmarkScanFixedCosts measures per-scan overhead on an empty Memory table.
+//
+// Run with:
+//
+//	go test ./storage/ -bench BenchmarkScanFixed -benchtime=5s -count=3
+//
+// Three variants let you isolate individual overhead layers:
+//
+//	_NoSession   – plain scan, no GLS context (goroutine overhead only)
+//	_WithGLS     – scan inside gls.SetValues (GLS marks on stack, shallow context)
+//	_WithAutocommit – full HTTP handler path: GLS + autocommit transaction
+import (
+	"context"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func benchScanTable(b *testing.B, name string) *table {
+	b.Helper()
+	CreateDatabase("bench_scan_fc_"+name, true)
+	tbl, _ := CreateTable("bench_scan_fc_"+name, "empty", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	return tbl
+}
+
+// BenchmarkScanFixedCosts_NoSession: scan without any GLS session.
+// Establishes the pure goroutine + channel overhead baseline.
+func BenchmarkScanFixedCosts_NoSession(b *testing.B) {
+	tbl := benchScanTable(b, "nosession")
+	trueFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	nilFn := scm.NewNil()
+	neutral := scm.NewNil()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tbl.scan(
+			[]string{"id"}, trueFn,
+			[]string{"id"}, trueFn,
+			nilFn, neutral, nilFn, false,
+		)
+	}
+}
+
+// BenchmarkScanFixedCosts_WithGLS: scan inside gls.SetValues.
+// Measures GLS overhead added on top of the goroutine baseline.
+func BenchmarkScanFixedCosts_WithGLS(b *testing.B) {
+	tbl := benchScanTable(b, "withgls")
+	trueFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	nilFn := scm.NewNil()
+	neutral := scm.NewNil()
+	session := scm.NewSession()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.SetValues(map[string]any{"session": session}, func() {
+			tbl.scan(
+				[]string{"id"}, trueFn,
+				[]string{"id"}, trueFn,
+				nilFn, neutral, nilFn, false,
+			)
+		})
+	}
+}
+
+// BenchmarkScanFixedCosts_WithAutocommit: full HTTP handler path.
+// GLS context (SetValues) + autocommit transaction wrapping + scan.
+func BenchmarkScanFixedCosts_WithAutocommit(b *testing.B) {
+	tbl := benchScanTable(b, "autocommit")
+	trueFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	nilFn := scm.NewNil()
+	neutral := scm.NewNil()
+	session := scm.NewSession()
+	sessionFn := session.Func()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.SetValues(map[string]any{"session": session}, func() {
+			WithAutocommit(sessionFn, scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+				return tbl.scan(
+					[]string{"id"}, trueFn,
+					[]string{"id"}, trueFn,
+					nilFn, neutral, nilFn, false,
+				)
+			}))
+		})
+	}
+}
+
+// BenchmarkScanFixedCosts_DeepStack: scan called from a deep-ish call stack.
+// Simulates GLS stack-scan cost when marks are far below current frame
+// (as happens when scan is called from deep Scheme evaluation).
+func BenchmarkScanFixedCosts_DeepStack(b *testing.B) {
+	tbl := benchScanTable(b, "deepstack")
+	trueFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	nilFn := scm.NewNil()
+	neutral := scm.NewNil()
+	session := scm.NewSession()
+
+	// helper that recurses to a given depth then calls fn
+	var recurse func(depth int, fn func())
+	recurse = func(depth int, fn func()) {
+		if depth == 0 {
+			fn()
+			return
+		}
+		recurse(depth-1, fn)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.SetValues(map[string]any{"session": session}, func() {
+			// simulate ~80 extra frames of Scheme evaluation above the scan call
+			recurse(80, func() {
+				tbl.scan(
+					[]string{"id"}, trueFn,
+					[]string{"id"}, trueFn,
+					nilFn, neutral, nilFn, false,
+				)
+			})
+		})
+	}
+}
+
+// BenchmarkGLSGetValue measures raw cost of a single GLS GetValue call.
+// Establishes per-call overhead for CurrentTx() GLS lookups inside shard goroutines.
+func BenchmarkGLSGetValue(b *testing.B) {
+	session := scm.NewSession()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.SetValues(map[string]any{"session": session}, func() {
+			for j := 0; j < 10; j++ {
+				scm.GetCurrentTx() // simulates per-shard CurrentTx() cost
+			}
+		})
+	}
+}
+
+// BenchmarkNewContext measures the overhead of scm.NewContext (used by HTTP handler).
+func BenchmarkNewContext(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.NewContext(context.TODO(), func() {})
+	}
+}

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -273,11 +273,13 @@ func ensureSystemStatistic() {
 		{"ordered", "BOOL"},
 		{"filter", "TEXT"},
 		{"order", "TEXT"},
+		{"index_cols", "TEXT"},
 		{"inputCount", "INT"},
 		{"outputCount", "INT"},
 		// TODO: measurements are temporary; remove later (store in nanoseconds)
 		{"analyze_ns", "INT"},
 		{"exec_ns", "INT"},
+		{"timestamp", "INT"},
 	}
 	have := make(map[string]bool)
 	if t != nil {
@@ -295,7 +297,7 @@ func ensureSystemStatistic() {
 
 // safeLogScan writes a single row into system_statistic.scans. Failures are ignored.
 // TODO: measurements are temporary; remove later (nanoseconds)
-func safeLogScan(schema, table string, ordered bool, filter, order string, inputCount, outputCount, analyzeNs, execNs int64) {
+func safeLogScan(schema, table string, ordered bool, filter, order, indexCols string, inputCount, outputCount, analyzeNs, execNs int64) {
 	defer func() { _ = recover() }()
 	db := GetDatabase("system_statistic")
 	if db == nil {
@@ -306,19 +308,37 @@ func safeLogScan(schema, table string, ordered bool, filter, order string, input
 		return
 	}
 
-	cols := []string{"schema", "table", "ordered", "filter", "order", "inputCount", "outputCount", "analyze_ns", "exec_ns"}
+	cols := []string{"schema", "table", "ordered", "filter", "order", "index_cols", "inputCount", "outputCount", "analyze_ns", "exec_ns", "timestamp"}
 	row := []scm.Scmer{
 		scm.NewString(schema),
 		scm.NewString(table),
 		scm.NewBool(ordered),
 		scm.NewString(filter),
 		scm.NewString(order),
+		scm.NewString(indexCols),
 		scm.NewInt(inputCount),
 		scm.NewInt(outputCount),
 		scm.NewInt(analyzeNs),
 		scm.NewInt(execNs),
+		scm.NewInt(time.Now().UnixNano()),
 	}
 	t.Insert(cols, [][]scm.Scmer{row}, nil, scm.NewNil(), false, nil)
+}
+
+// boundaryIndexCols returns a comma-separated list of column names from boundaries,
+// representing the columns used for index lookup in this scan.
+func boundaryIndexCols(b boundaries) string {
+	if len(b) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, bc := range b {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(bc.col)
+	}
+	return sb.String()
 }
 
 // touchTempColumns updates lastAccessed on all temp columns of the table (lock-free).

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -402,8 +402,8 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 		akkumulator = aggregateFn(akkumulator, callbackFn(nullRow...)) // outer join: call once with NULLs
 	}
 	execNs := time.Since(execStart).Nanoseconds()
-	// log statistics for ordered scan (best-effort, async) if threshold met
-	if inputCount > int64(Settings.AnalyzeMinItems) {
+	// log statistics for ordered scan (best-effort, async) if threshold met or ScanDebugging
+	if Settings.ScanDebugging || inputCount > int64(Settings.AnalyzeMinItems) {
 		go func(anNs, exNs int64) {
 			defer func() { _ = recover() }()
 			filterEnc := ""
@@ -428,7 +428,8 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 				}
 			}
 			orderEnc := sb.String()
-			safeLogScan(t.schema.Name, t.Name, true, filterEnc, orderEnc, inputCount, outCount, anNs, exNs)
+			indexColsEnc := boundaryIndexCols(boundaries)
+			safeLogScan(t.schema.Name, t.Name, true, filterEnc, orderEnc, indexColsEnc, inputCount, outCount, anNs, exNs)
 		}(analyzeNs, execNs)
 	}
 	return akkumulator
@@ -559,14 +560,14 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		adjustedSortdirs[i] = cmpFn
 	}
 
-	// main storage
-	ccols := make([]ColumnStorage, len(conditionCols))
-	for i, k := range conditionCols { // iterate over columns
-		ccols[i] = t.getColumnStorageOrPanic(k)
-	}
-
 	currentTx := CurrentTx()
 	skipShardReadLock := t.hasWriteOwner() || (currentTx != nil && currentTx.HasShardWrite(t))
+
+	// main storage — use skipShardReadLock to avoid redundant hasWriteOwner() per column
+	ccols := make([]ColumnStorage, len(conditionCols))
+	for i, k := range conditionCols { // iterate over columns
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+	}
 	// initialize main_count lazily if needed
 	t.ensureMainCount(skipShardReadLock)
 	// scan loop in read lock
@@ -598,7 +599,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					if !currentTx.IsVisible(t, idx) {
 						continue
 					}
-				} else if t.deletions.Get(idx) {
+				} else if t.deletions.Get(uint(idx)) {
 					continue // item is on delete list
 				}
 

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -43,7 +43,7 @@ type SettingsT struct {
 	MetricsTracingInterval int   // interval in seconds (0 = default 60s)
 	ShutdownDrainSeconds   int   // seconds to wait for in-flight requests during shutdown (0 = default 10s)
 	LogJIT                 bool  // when true, log JIT compilation (serialized proc + hexdump)
-	ScanDebugging          bool  // when true, log every scan/scan_order: db+table+boundaries+index
+	ScanDebugging          bool  // when true, log every scan/scan_order: db+table+boundaries+index; also overrides AnalyzeMinItems for scan statistics
 	ExplainWidth           int   // max chars before EXPLAIN pretty-prints a sub-expression on multiple lines (0 = default 20)
 }
 

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -24,10 +24,10 @@ import "time"
 import "strings"
 import "reflect"
 import "runtime"
-import "strconv"
 import "encoding/json"
 import "encoding/binary"
 import "github.com/google/uuid"
+import "github.com/jtolds/gls"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/NonLockingReadMap"
 
@@ -146,7 +146,7 @@ func (u *storageShard) load(t *table) {
 			numEntriesRestored++
 			switch l := logentry.(type) {
 			case LogEntryDelete:
-				u.deletions.Set(uint32(l.idx), true) // mark deletion
+				u.deletions.Set(uint(l.idx), true) // mark deletion
 			case LogEntryInsert:
 				u.insertDatasetFromLog(l.cols, l.values)
 			default:
@@ -291,7 +291,31 @@ func (u *storageShard) getColumnStorageOrPanicEx(colName string, alreadyLocked b
 		}
 		return u.ensureColumnLoaded(colName, true)
 	}
-	return u.getColumnStorageOrPanic(colName)
+	// alreadyLocked=false: caller guarantees ownsWrite=false — skip hasWriteOwner().
+	if tx := CurrentTx(); tx != nil && tx.HasShardWrite(u) {
+		return u.getColumnStorageOrPanicEx(colName, true)
+	}
+	u.mu.RLock()
+	cs, present := u.columns[colName]
+	u.mu.RUnlock()
+	if !present {
+		for _, c := range u.t.Columns {
+			if c.Name == colName {
+				u.mu.Lock()
+				if _, present2 := u.columns[colName]; !present2 {
+					u.columns[colName] = new(StorageSparse)
+				}
+				cs2 := u.columns[colName]
+				u.mu.Unlock()
+				return cs2
+			}
+		}
+		panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
+	}
+	if cs != nil {
+		return cs
+	}
+	return u.ensureColumnLoaded(colName, false)
 }
 
 // ensureMainCount guarantees main_count is initialized by loading one column if needed.
@@ -464,18 +488,11 @@ func (t *storageShard) Count() uint32 {
 }
 
 func currentGoroutineID() uint64 {
-	var b [64]byte
-	n := runtime.Stack(b[:], false)
-	line := string(b[:n])
-	fields := strings.Fields(line)
-	if len(fields) < 2 {
+	id, ok := gls.GetGoroutineId()
+	if !ok {
 		return 0
 	}
-	id, err := strconv.ParseUint(fields[1], 10, 64)
-	if err != nil {
-		return 0
-	}
-	return id
+	return uint64(id)
 }
 
 func (t *storageShard) enterWriteOwner() {
@@ -546,7 +563,7 @@ func (t *storageShard) resolveVisiblePrimaryRecidLocked(staleRecid uint32) (uint
 	limit := t.main_count + uint32(len(t.inserts))
 	for recid := limit; recid > 0; recid-- {
 		candidate := recid - 1
-		if candidate == staleRecid || t.deletions.Get(candidate) {
+		if candidate == staleRecid || t.deletions.Get(uint(candidate)) {
 			continue
 		}
 		match := true
@@ -601,7 +618,7 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 				if (func() bool {
 					tx := CurrentTx()
 					return tx == nil || tx.Mode != TxACID
-				})() && t.deletions.Get(targetIdx) {
+				})() && t.deletions.Get(uint(targetIdx)) {
 					followed := false
 					for attempt := 0; attempt < 256; attempt++ {
 						if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(targetIdx); ok {
@@ -779,15 +796,15 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 				// unique constraint checking
 				if uniqueCheckNeeded {
 					payloadCols, payloadRow := buildPayload()
-					wasDeletedBefore := t.deletions.Get(targetIdx)
-					t.deletions.Set(targetIdx, true) // mark as deleted temporarily for unique check
+					wasDeletedBefore := t.deletions.Get(uint(targetIdx))
+					t.deletions.Set(uint(targetIdx), true) // mark as deleted temporarily for unique check
 					t.mu.Unlock()                    // release write lock, so the scan can be performed
 					t.t.ProcessUniqueCollision(payloadCols, [][]scm.Scmer{payloadRow}, false, func(values [][]scm.Scmer) {
 						t.mu.Lock() // start write lock
 					}, nil, func(errmsg string, data []scm.Scmer) {
 						t.mu.Lock() // start write lock
 						if !wasDeletedBefore {
-							t.deletions.Set(targetIdx, false) // restore only if we changed visibility here
+							t.deletions.Set(uint(targetIdx), false) // restore only if we changed visibility here
 						}
 						panic("Unique key constraint violated in table " + t.t.Name + ": " + errmsg)
 					}, 0)
@@ -796,7 +813,7 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 					// non-ACID mode. This avoids transient "row disappears" gaps that
 					// make concurrent UPDATE scans miss rows.
 					if acidMode {
-						t.deletions.Set(targetIdx, true) // staged delete in ACID overlay flow
+						t.deletions.Set(uint(targetIdx), true) // staged delete in ACID overlay flow
 					}
 				}
 
@@ -806,9 +823,9 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 				if !acidMode && !uniqueCheckNeeded {
 					// Atomic visibility switch under shard write lock:
 					// make new row hidden first, then delete old, then publish new.
-					t.deletions.Set(newRecid, true)
-					t.deletions.Set(targetIdx, true)
-					t.deletions.Set(newRecid, false)
+					t.deletions.Set(uint(newRecid), true)
+					t.deletions.Set(uint(targetIdx), true)
+					t.deletions.Set(uint(newRecid), false)
 					// Maintain the non-ACID invariant: at most one visible row per
 					// PRIMARY key. Under heavy concurrent UPDATE chains, stale targets
 					// can leave older versions visible; collapse them here.
@@ -830,7 +847,7 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 						}
 						limit := t.main_count + uint32(len(t.inserts))
 						for recid := uint32(0); recid < limit; recid++ {
-							if recid == newRecid || t.deletions.Get(recid) {
+							if recid == newRecid || t.deletions.Get(uint(recid)) {
 								continue
 							}
 							match := true
@@ -841,7 +858,7 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 								}
 							}
 							if match {
-								t.deletions.Set(recid, true)
+								t.deletions.Set(uint(recid), true)
 							}
 						}
 					}
@@ -854,22 +871,20 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 
 				if currentTx != nil && currentTx.Mode == TxACID {
 					// Check if old row was staged by this tx (in UndeleteMask)
-					currentTx.mu.Lock()
-					um := currentTx.UndeleteMask[t]
-					currentTx.mu.Unlock()
-					wasStaged := um != nil && um.Has(targetIdx)
+					st := currentTx.getShardTx(t)
+					wasStaged := st != nil && st.UndeleteMask.Get(uint(targetIdx))
 					if wasStaged {
 						// Row was staged by this tx → remove from UndeleteMask.
 						// Keep shard.deletions[targetIdx]=true (already globally hidden).
 						// Don't add to DeleteMask (not a pre-existing row).
-						um.Bitmap.Set(targetIdx, false)
+						st.UndeleteMask.Set(uint(targetIdx), false)
 					} else {
 						// Pre-existing committed row → undo temporary global deletion
-						t.deletions.Set(targetIdx, false)
+						t.deletions.Set(uint(targetIdx), false)
 						currentTx.AddToDeleteMask(t, targetIdx)
 					}
 					// Stage new version: hide globally, add to undelete mask
-					t.deletions.Set(uint32(newRecid), true)
+					t.deletions.Set(uint(newRecid), true)
 					currentTx.AddToUndeleteMask(t, newRecid)
 					// Only log the insert (delete applied at commit)
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
@@ -888,15 +903,13 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 				t.t.dualWriteInsert(dualWriteCols, dualWriteRow)
 			}
 			// transaction bookkeeping + deferred sync
+			// (shard is already registered via OpenMapReducer — no per-row RegisterTouchedShard)
 			if result {
 				if tx := CurrentTx(); tx != nil {
 					switch tx.Mode {
-					case TxACID:
-						tx.RegisterTouchedShard(t)
 					case TxCursorStability:
 						tx.LogDelete(t, targetIdx)
 						tx.LogInsert(t, newRecid)
-						tx.RegisterTouchedShard(t)
 					}
 				} else if t.t.PersistencyMode == Safe && t.logfile != nil {
 					defer t.logfile.Sync()
@@ -961,19 +974,17 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 
 			if tx := CurrentTx(); tx != nil && tx.Mode == TxACID {
 				// Check if row was staged by this tx
-				tx.mu.Lock()
-				um := tx.UndeleteMask[t]
-				tx.mu.Unlock()
-				wasStaged := um != nil && um.Has(idx)
+				st2 := tx.getShardTx(t)
+				wasStaged := st2 != nil && st2.UndeleteMask.Get(uint(idx))
 				if wasStaged {
 					// Row was staged by this tx → remove from UndeleteMask.
 					// Keep shard.deletions[idx]=true (already globally hidden).
-					um.Bitmap.Set(uint32(idx), false)
+					st2.UndeleteMask.Set(uint(idx), false)
 				} else {
 					// Pre-existing committed row → add to delete mask
 					tx.AddToDeleteMask(t, idx)
 				}
-				tx.RegisterTouchedShard(t)
+				// shard already registered via OpenMapReducer
 				result = true
 			} else {
 				func() {
@@ -982,15 +993,14 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 						defer t.mu.Unlock() // write lock
 					}
 
-					t.deletions.Set(uint32(idx), true) // mark as deleted
+					t.deletions.Set(uint(idx), true) // mark as deleted
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 						t.logfile.Write(LogEntryDelete{idx})
 					}
 					result = true
 				}()
-				// deferred sync
+				// deferred sync (shard already registered via OpenMapReducer)
 				if tx != nil {
-					tx.RegisterTouchedShard(t)
 					tx.LogDelete(t, idx)
 				} else if t.t.PersistencyMode == Safe && t.logfile != nil {
 					defer t.logfile.Sync()
@@ -1011,7 +1021,7 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 		if result && t.next != nil {
 			// also change in next storage
 			// idx translation (subtract the amount of deletions from that idx)
-			idx2 := targetIdx - uint32(t.deletions.CountUntil(targetIdx))
+			idx2 := targetIdx - uint32(t.deletions.CountUntil(uint(targetIdx)))
 			t.next.UpdateFunction(idx2, false, false)(a...) // propagate to succeeding shard
 		}
 		return scm.NewBool(result) // maybe instead return UpdateFunction for newly inserted item??
@@ -1051,6 +1061,10 @@ type ShardMapReducer struct {
 	mainCount       uint32
 	hasUpdateCol    bool
 	hasIncrementCol bool
+	// shardWriteLocked is true when the caller already holds shard.mu (write lock)
+	// and registered write ownership before opening this mapper. When true,
+	// processMainBlock/processDeltaBlock must NOT try to re-acquire the lock.
+	shardWriteLocked bool
 }
 
 // OpenMapReducer creates a MapReducer for the given columns. Column readers and
@@ -1058,21 +1072,29 @@ type ShardMapReducer struct {
 // mapFn and reduceFn are stored as Scmer for future network serialization;
 // OptimizeProcToSerialFunction is called here (TODO: replace with JIT compilation).
 func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn scm.Scmer) *ShardMapReducer {
+	return t.openMapReducerEx(cols, mapFn, reduceFn, false)
+}
+
+// openMapReducerEx is the implementation of OpenMapReducer.
+// alreadyLocked=true skips the hasWriteOwner() check per column (caller already holds
+// the write lock or has confirmed ownsWrite=false via skipShardReadLock).
+func (t *storageShard) openMapReducerEx(cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool) *ShardMapReducer {
 	mr := &ShardMapReducer{
-		shard:           t,
-		mainCols:        make([]ColumnStorage, len(cols)),
-		colNames:        cols,
-		isUpdate:        make([]bool, len(cols)),
-		isInvalidate:    make([]bool, len(cols)),
-		invalidateProxy: make([]*StorageComputeProxy, len(cols)),
-		isIncrement:     make([]bool, len(cols)),
-		incrementProxy:  make([]*StorageComputeProxy, len(cols)),
-		args:            make([]scm.Scmer, len(cols)),
-		mapFn:           scm.OptimizeProcToSerialFunction(mapFn),
-		reduceFn:        scm.OptimizeProcToSerialFunction(reduceFn),
-		mapScmer:        mapFn,
-		reduceScmer:     reduceFn,
-		mainCount:       t.main_count,
+		shard:            t,
+		mainCols:         make([]ColumnStorage, len(cols)),
+		colNames:         cols,
+		isUpdate:         make([]bool, len(cols)),
+		isInvalidate:     make([]bool, len(cols)),
+		invalidateProxy:  make([]*StorageComputeProxy, len(cols)),
+		isIncrement:      make([]bool, len(cols)),
+		incrementProxy:   make([]*StorageComputeProxy, len(cols)),
+		args:             make([]scm.Scmer, len(cols)),
+		mapFn:            scm.OptimizeProcToSerialFunction(mapFn),
+		reduceFn:         scm.OptimizeProcToSerialFunction(reduceFn),
+		mapScmer:         mapFn,
+		reduceScmer:      reduceFn,
+		mainCount:        t.main_count,
+		shardWriteLocked: alreadyLocked,
 	}
 	for i, col := range cols {
 		if col == "$update" {
@@ -1084,7 +1106,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		} else if len(col) > 12 && col[:12] == "$invalidate:" {
 			mr.isInvalidate[i] = true
 			cacheColName := col[12:]
-			cs := t.getColumnStorageOrPanic(cacheColName)
+			cs := t.getColumnStorageOrPanicEx(cacheColName, alreadyLocked)
 			if proxy, ok := cs.(*StorageComputeProxy); ok {
 				mr.invalidateProxy[i] = proxy
 			}
@@ -1092,12 +1114,18 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			mr.isIncrement[i] = true
 			mr.hasIncrementCol = true
 			cacheColName := col[11:]
-			cs := t.getColumnStorageOrPanic(cacheColName)
+			cs := t.getColumnStorageOrPanicEx(cacheColName, alreadyLocked)
 			if proxy, ok := cs.(*StorageComputeProxy); ok {
 				mr.incrementProxy[i] = proxy
 			}
 		} else {
-			mr.mainCols[i] = t.getColumnStorageOrPanic(col)
+			mr.mainCols[i] = t.getColumnStorageOrPanicEx(col, alreadyLocked)
+		}
+	}
+	// Register shard for deferred fsync once, not per row.
+	if mr.hasUpdateCol {
+		if tx := CurrentTx(); tx != nil {
+			tx.RegisterTouchedShard(t)
 		}
 	}
 	return mr
@@ -1130,24 +1158,28 @@ func (m *ShardMapReducer) Stream(acc scm.Scmer, recids []uint32) scm.Scmer {
 // processMainBlock is a tight loop over main-storage records – no branching
 // on main vs delta, direct ColumnStorage.GetValue calls. JIT candidate.
 func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
+	// Hoist write-lock acquisition out of the per-row loop.
+	// shardWriteLocked is set by openMapReducerEx when the caller (scan.go) already
+	// holds shard.mu; in that case we must NOT re-acquire it. For the rare case
+	// where a mapper is opened without the shard being locked (e.g. NEW. columns
+	// outside a mutation scan), acquire once for the whole batch instead of per-row.
+	if (m.hasUpdateCol || m.hasIncrementCol) && !m.shardWriteLocked {
+		currentTx := CurrentTx()
+		m.shard.mu.Lock()
+		defer m.shard.mu.Unlock()
+		m.shard.enterWriteOwner()
+		defer m.shard.exitWriteOwner()
+		if currentTx != nil {
+			currentTx.EnterShardWrite(m.shard)
+			defer currentTx.ExitShardWrite(m.shard)
+		}
+	}
 	for _, id := range recids {
 		func() {
 			effectiveID := id
 			if m.hasUpdateCol || m.hasIncrementCol {
-				currentTx := CurrentTx()
-				holdsWrite := m.shard.hasWriteOwner()
-				if !holdsWrite {
-					m.shard.mu.Lock()
-					defer m.shard.mu.Unlock()
-					m.shard.enterWriteOwner()
-					defer m.shard.exitWriteOwner()
-					if currentTx != nil {
-						currentTx.EnterShardWrite(m.shard)
-						defer currentTx.ExitShardWrite(m.shard)
-					}
-				}
 				if tx := CurrentTx(); tx == nil || tx.Mode != TxACID {
-					if m.shard.deletions.Get(effectiveID) {
+					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
 							return
@@ -1197,24 +1229,24 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 
 // processDeltaBlock handles delta-storage records via getDelta. JIT candidate.
 func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
+	// Same hoisting as processMainBlock (see comment there).
+	if (m.hasUpdateCol || m.hasIncrementCol) && !m.shardWriteLocked {
+		currentTx := CurrentTx()
+		m.shard.mu.Lock()
+		defer m.shard.mu.Unlock()
+		m.shard.enterWriteOwner()
+		defer m.shard.exitWriteOwner()
+		if currentTx != nil {
+			currentTx.EnterShardWrite(m.shard)
+			defer currentTx.ExitShardWrite(m.shard)
+		}
+	}
 	for _, id := range recids {
 		func() {
 			effectiveID := id
 			if m.hasUpdateCol || m.hasIncrementCol {
-				currentTx := CurrentTx()
-				holdsWrite := m.shard.hasWriteOwner()
-				if !holdsWrite {
-					m.shard.mu.Lock()
-					defer m.shard.mu.Unlock()
-					m.shard.enterWriteOwner()
-					defer m.shard.exitWriteOwner()
-					if currentTx != nil {
-						currentTx.EnterShardWrite(m.shard)
-						defer currentTx.ExitShardWrite(m.shard)
-					}
-				}
 				if tx := CurrentTx(); tx == nil || tx.Mode != TxACID {
-					if m.shard.deletions.Get(effectiveID) {
+					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
 							return
@@ -1320,7 +1352,7 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 			// ACID: hide rows globally, add to undelete mask so this tx can see them
 			for i := range values {
 				recid := firstNewRecid + uint32(i)
-				t.deletions.Set(uint32(recid), true)
+				t.deletions.Set(uint(recid), true)
 				tx.AddToUndeleteMask(t, recid)
 			}
 			tx.RegisterTouchedShard(t)
@@ -1546,7 +1578,7 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 					present = true
 					return false
 				}
-			} else if !t.deletions.Get(uint32(idx)) {
+			} else if !t.deletions.Get(uint(idx)) {
 				result = idx
 				present = true
 				return false
@@ -1833,12 +1865,12 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			}
 			sortPerm = make([]uint32, 0, int(t.main_count)+maxInsertIndex)
 			for i := uint32(0); i < t.main_count; i++ {
-				if !deletions.Get(i) {
+				if !deletions.Get(uint(i)) {
 					sortPerm = append(sortPerm, i)
 				}
 			}
 			for i := 0; i < maxInsertIndex; i++ {
-				if !deletions.Get(t.main_count + uint32(i)) {
+				if !deletions.Get(uint(t.main_count) + uint(i)) {
 					sortPerm = append(sortPerm, t.main_count+uint32(i))
 				}
 			}
@@ -1897,7 +1929,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				} else {
 					// scan main
 					for idx := uint32(0); idx < t.main_count; idx++ {
-						if deletions.Get(uint32(idx)) {
+						if deletions.Get(uint(idx)) {
 							continue
 						}
 						newcol.scan(i, reader.GetValue(idx))
@@ -1905,7 +1937,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 					}
 					// scan delta
 					for idx := 0; idx < maxInsertIndex; idx++ {
-						if deletions.Get(uint32(t.main_count + uint32(idx))) {
+						if deletions.Get(uint(t.main_count + uint32(idx))) {
 							continue
 						}
 						newcol.scan(i, t.getDelta(idx, col))
@@ -1944,7 +1976,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			} else {
 				// build main
 				for idx := uint32(0); idx < t.main_count; idx++ {
-					if deletions.Get(uint32(idx)) {
+					if deletions.Get(uint(idx)) {
 						continue
 					}
 					newcol.build(i, reader.GetValue(idx))
@@ -1952,7 +1984,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				}
 				// build delta
 				for idx := 0; idx < maxInsertIndex; idx++ {
-					if deletions.Get(uint32(t.main_count + uint32(idx))) {
+					if deletions.Get(uint(t.main_count + uint32(idx))) {
 						continue
 					}
 					newcol.build(i, t.getDelta(idx, col))

--- a/storage/table.go
+++ b/storage/table.go
@@ -699,12 +699,18 @@ func (t *table) CreateColumn(name string, typ string, typdimensions []int, extra
 	cp := &c
 	t.Columns = append(t.Columns, cp)
 	for _, s := range t.Shards {
+		if s == nil {
+			continue
+		}
 		// mutate shard column map under shard lock to avoid races with readers
 		s.mu.Lock()
 		s.columns[name] = new(StorageSparse)
 		s.mu.Unlock()
 	}
 	for _, s := range t.PShards {
+		if s == nil {
+			continue
+		}
 		// mutate shard column map under shard lock to avoid races with readers
 		s.mu.Lock()
 		s.columns[name] = new(StorageSparse)
@@ -1204,7 +1210,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 					if currentTx := CurrentTx(); currentTx != nil && currentTx.Mode == TxACID {
 						isVisible = currentTx.IsVisible(s, uid)
 					} else {
-						isVisible = !s.deletions.Get(uid)
+						isVisible = !s.deletions.Get(uint(uid))
 					}
 				}
 				if isVisible {

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -21,13 +21,13 @@ import "sort"
 import "sync"
 import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
-import "github.com/launix-de/NonLockingReadMap"
+import NonLockingReadMap "github.com/launix-de/NonLockingReadMap"
 
 // TxMode selects the transaction isolation strategy.
 type TxMode uint8
 
 const (
-	TxCursorStability TxMode = iota // default: direct writes + undo log
+	TxCursorStability TxMode = iota // default: direct writes + undo masks
 	TxACID                          // snapshot isolation + OCC commit
 )
 
@@ -40,49 +40,52 @@ const (
 	TxAborted
 )
 
-// UndoType identifies the kind of undo operation (cursor-stability only).
-type UndoType int
+// storageShardTransaction holds all per-shard state for a transaction.
+//
+// All four NonBlockingBitMaps are embedded as values — they are zero-alloc
+// (lazy) until the first Set call, so allocating a storageShardTransaction
+// for a shard that is only read-checked costs only the struct allocation.
+//
+// The bitmaps are written exclusively under st.mu (plain Set is safe).
+// Reads in the hot-path visibility check (IsVisible) happen lock-free via Get.
+//
+// Fields by transaction mode:
+//
+//	CursorStability  InsertMask / InsertRecids  — inserted rows (undo = delete)
+//	                 DeletedMask / DeletedRecids — deleted rows  (undo = undelete)
+//	ACID             DeleteMask  / DeleteRecids  — rows to delete at commit
+//	                 UndeleteMask/ UndeleteRecids — staged rows visible to this tx
+type storageShardTransaction struct {
+	// cursor-stability undo bitmaps
+	InsertMask  NonLockingReadMap.NonBlockingBitMap
+	DeletedMask NonLockingReadMap.NonBlockingBitMap
+	// ACID overlay bitmaps
+	DeleteMask   NonLockingReadMap.NonBlockingBitMap
+	UndeleteMask NonLockingReadMap.NonBlockingBitMap
 
-const (
-	UndoInsert UndoType = iota // rollback: mark inserted row as deleted
-	UndoDelete                 // rollback: undelete the deleted row
-)
+	// Recids for iteration at rollback/commit time.
+	// Append-only; protected by mu.
+	InsertRecids   []uint32
+	DeletedRecids  []uint32
+	DeleteRecids   []uint32
+	UndeleteRecids []uint32
 
-// UndoEntry records one reversible storage operation (cursor-stability only).
-type UndoEntry struct {
-	Type     UndoType
-	Shard    *storageShard
-	RowIndex uint32
+	mu sync.Mutex
 }
 
-// shardOverlay provides O(1) visibility checks via bitmap and an iteration
-// list of recids for commit-time application.
-type shardOverlay struct {
-	Bitmap NonLockingReadMap.NonBlockingBitMap // O(1) visibility check in scan hot path
-	Recids []uint32                            // for commit-time iteration
-	mu     sync.Mutex                          // protects Recids append from parallel workers
-}
-
-// Add records a recid in both the bitmap and the iteration list.
-func (o *shardOverlay) Add(recid uint32) {
-	o.Bitmap.Set(recid, true)
-	o.mu.Lock()
-	o.Recids = append(o.Recids, recid)
-	o.mu.Unlock()
-}
-
-// Has checks whether a recid is in this overlay (O(1) via bitmap).
-func (o *shardOverlay) Has(recid uint32) bool {
-	return o.Bitmap.Get(recid)
+// shardSavepoint records the Recids slice lengths for one shard at a savepoint.
+type shardSavepoint struct {
+	InsertLen   int
+	DeletedLen  int
+	DeleteLen   int
+	UndeleteLen int
 }
 
 // Savepoint captures the state of a transaction at a point in time.
 // Used for nested transactions (trigger recovery, savepoints).
 type Savepoint struct {
-	UndoLogLen       int                   // cursor-stability: UndoLog length at savepoint
-	DeleteMaskLens   map[*storageShard]int // ACID: Recids length per shard in DeleteMask
-	UndeleteMaskLens map[*storageShard]int // ACID: Recids length per shard in UndeleteMask
-	Depth            uint32                // nesting depth at creation
+	shardLens map[*storageShard]shardSavepoint
+	Depth     uint32
 }
 
 // global transaction ID counter
@@ -92,24 +95,25 @@ var txIDCounter uint64
 var GlobalCommitEpoch uint64
 
 // TxContext holds the state for one transaction.
+//
+// All per-shard state lives in a single shards map, keyed by *storageShard.
+// The map is nil until the first write operation, so read-only transactions
+// (the common case with with_autocommit) allocate nothing beyond the
+// TxContext struct itself.
 type TxContext struct {
 	ID            uint64
 	Mode          TxMode
 	State         TxState
 	SnapshotEpoch uint64 // ACID: snapshot boundary
-	Depth         uint32 // for savepoint/trigger nesting (future)
+	Depth         uint32 // nesting depth for savepoints / triggers
 
-	// Cursor-stability: undo log
-	UndoLog []UndoEntry
+	// Per-shard state, nil until first write (zero-alloc for read-only transactions).
+	shards map[*storageShard]*storageShardTransaction
 
-	// ACID: per-shard overlays
-	DeleteMask   map[*storageShard]*shardOverlay // recids this tx wants to delete
-	UndeleteMask map[*storageShard]*shardOverlay // staged insert recids visible to this tx
-
-	// Deferred sync (§10)
+	// Deferred sync: shards with pending log writes that need fsync at commit.
 	touchedShards sync.Map // map[*storageShard]bool
 	autoCommit    bool
-	writeHeld     map[*storageShard]uint32 // reentrant write-lock marker per shard
+	writeHeld     map[*storageShard]uint32 // reentrant write-lock depth per shard
 
 	mu sync.Mutex
 }
@@ -117,26 +121,52 @@ type TxContext struct {
 // NewTxContext creates a new active transaction context with the given mode.
 func NewTxContext(mode TxMode) *TxContext {
 	tx := &TxContext{
-		ID:        atomic.AddUint64(&txIDCounter, 1),
-		State:     TxActive,
-		Mode:      mode,
-		writeHeld: make(map[*storageShard]uint32),
+		ID:    atomic.AddUint64(&txIDCounter, 1),
+		State: TxActive,
+		Mode:  mode,
 	}
-	switch mode {
-	case TxCursorStability:
-		tx.UndoLog = make([]UndoEntry, 0, 16)
-	case TxACID:
+	if mode == TxACID {
 		tx.SnapshotEpoch = atomic.LoadUint64(&GlobalCommitEpoch)
-		tx.DeleteMask = make(map[*storageShard]*shardOverlay)
-		tx.UndeleteMask = make(map[*storageShard]*shardOverlay)
 	}
 	return tx
 }
 
-// EnterShardWrite marks that the current transaction context holds a write lock
-// on the given shard in this call stack.
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// getOrCreateShardTxLocked returns the storageShardTransaction for a shard,
+// creating it if it does not exist. Must be called with tx.mu held.
+func (tx *TxContext) getOrCreateShardTxLocked(shard *storageShard) *storageShardTransaction {
+	if tx.shards == nil {
+		tx.shards = make(map[*storageShard]*storageShardTransaction)
+	}
+	st := tx.shards[shard]
+	if st == nil {
+		st = new(storageShardTransaction)
+		tx.shards[shard] = st
+	}
+	return st
+}
+
+// getShardTx returns the storageShardTransaction for a shard, or nil if none exists.
+func (tx *TxContext) getShardTx(shard *storageShard) *storageShardTransaction {
+	tx.mu.Lock()
+	st := tx.shards[shard] // nil map returns nil safely
+	tx.mu.Unlock()
+	return st
+}
+
+// ---------------------------------------------------------------------------
+// Write-lock tracking (reentrant depth counter per shard)
+// ---------------------------------------------------------------------------
+
+// EnterShardWrite marks that the current transaction holds a write lock on shard.
 func (tx *TxContext) EnterShardWrite(shard *storageShard) {
 	tx.mu.Lock()
+	if tx.writeHeld == nil {
+		tx.writeHeld = make(map[*storageShard]uint32)
+	}
 	tx.writeHeld[shard]++
 	tx.mu.Unlock()
 }
@@ -153,141 +183,89 @@ func (tx *TxContext) ExitShardWrite(shard *storageShard) {
 }
 
 // HasShardWrite returns true when this tx context currently holds a write lock
-// on the shard in this call stack. It is used to avoid re-entering shard read
-// locks from nested scans (self-join/subquery in update mapper).
+// on the shard. Used to avoid re-entering shard read locks from nested scans.
 func (tx *TxContext) HasShardWrite(shard *storageShard) bool {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 	return tx.writeHeld[shard] > 0
 }
 
-// CreateSavepoint captures the current transaction state for later rollback.
-func (tx *TxContext) CreateSavepoint() Savepoint {
-	tx.mu.Lock()
-	defer tx.mu.Unlock()
-	sp := Savepoint{Depth: tx.Depth}
-	tx.Depth++
-	switch tx.Mode {
-	case TxCursorStability:
-		sp.UndoLogLen = len(tx.UndoLog)
-	case TxACID:
-		sp.DeleteMaskLens = make(map[*storageShard]int, len(tx.DeleteMask))
-		for s, overlay := range tx.DeleteMask {
-			overlay.mu.Lock()
-			sp.DeleteMaskLens[s] = len(overlay.Recids)
-			overlay.mu.Unlock()
-		}
-		sp.UndeleteMaskLens = make(map[*storageShard]int, len(tx.UndeleteMask))
-		for s, overlay := range tx.UndeleteMask {
-			overlay.mu.Lock()
-			sp.UndeleteMaskLens[s] = len(overlay.Recids)
-			overlay.mu.Unlock()
-		}
-	}
-	return sp
-}
-
-// RollbackToSavepoint undoes all changes made since the savepoint was created.
-func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
-	tx.mu.Lock()
-	defer tx.mu.Unlock()
-	tx.Depth = sp.Depth
-	switch tx.Mode {
-	case TxCursorStability:
-		// Replay undo entries from current position back to savepoint
-		for i := len(tx.UndoLog) - 1; i >= sp.UndoLogLen; i-- {
-			entry := tx.UndoLog[i]
-			entry.Shard.mu.Lock()
-			switch entry.Type {
-			case UndoInsert:
-				entry.Shard.deletions.Set(entry.RowIndex, true)
-				if entry.Shard.logfile != nil {
-					entry.Shard.logfile.Write(LogEntryDelete{entry.RowIndex})
-				}
-			case UndoDelete:
-				entry.Shard.deletions.Set(entry.RowIndex, false)
-			}
-			entry.Shard.mu.Unlock()
-		}
-		tx.UndoLog = tx.UndoLog[:sp.UndoLogLen]
-	case TxACID:
-		// Rollback DeleteMask entries added since savepoint
-		for shard, overlay := range tx.DeleteMask {
-			savedLen := sp.DeleteMaskLens[shard] // 0 if shard was new
-			overlay.mu.Lock()
-			for i := len(overlay.Recids) - 1; i >= savedLen; i-- {
-				recid := overlay.Recids[i]
-				overlay.Bitmap.Set(recid, false)
-			}
-			overlay.Recids = overlay.Recids[:savedLen]
-			overlay.mu.Unlock()
-		}
-		// Rollback UndeleteMask entries added since savepoint
-		for shard, overlay := range tx.UndeleteMask {
-			savedLen := sp.UndeleteMaskLens[shard] // 0 if shard was new
-			overlay.mu.Lock()
-			for i := len(overlay.Recids) - 1; i >= savedLen; i-- {
-				recid := overlay.Recids[i]
-				overlay.Bitmap.Set(recid, false)
-				// Re-hide the row globally (it was un-hidden by AddToUndeleteMask)
-				shard.deletions.Set(recid, true)
-			}
-			overlay.Recids = overlay.Recids[:savedLen]
-			overlay.mu.Unlock()
-		}
-	}
-}
+// ---------------------------------------------------------------------------
+// Cursor-stability undo log
+// ---------------------------------------------------------------------------
 
 // LogInsert records that a row was inserted; on rollback it will be deleted.
 // Cursor-stability only.
 func (tx *TxContext) LogInsert(shard *storageShard, rowIndex uint32) {
 	tx.mu.Lock()
-	tx.UndoLog = append(tx.UndoLog, UndoEntry{
-		Type:     UndoInsert,
-		Shard:    shard,
-		RowIndex: rowIndex,
-	})
+	st := tx.getOrCreateShardTxLocked(shard)
 	tx.mu.Unlock()
+	st.mu.Lock()
+	st.InsertMask.Set(uint(rowIndex), true)
+	st.InsertRecids = append(st.InsertRecids, rowIndex)
+	st.mu.Unlock()
 }
 
 // LogDelete records that a row was deleted; on rollback it will be undeleted.
 // Cursor-stability only.
 func (tx *TxContext) LogDelete(shard *storageShard, rowIndex uint32) {
 	tx.mu.Lock()
-	tx.UndoLog = append(tx.UndoLog, UndoEntry{
-		Type:     UndoDelete,
-		Shard:    shard,
-		RowIndex: rowIndex,
-	})
+	st := tx.getOrCreateShardTxLocked(shard)
 	tx.mu.Unlock()
+	st.mu.Lock()
+	st.DeletedMask.Set(uint(rowIndex), true)
+	st.DeletedRecids = append(st.DeletedRecids, rowIndex)
+	st.mu.Unlock()
 }
 
-// AddToDeleteMask records that this ACID tx wants to delete a row.
+// ---------------------------------------------------------------------------
+// ACID overlay masks
+// ---------------------------------------------------------------------------
+
+// AddToDeleteMask records that this ACID tx wants to delete a row at commit.
 func (tx *TxContext) AddToDeleteMask(shard *storageShard, recid uint32) {
 	tx.mu.Lock()
-	overlay, ok := tx.DeleteMask[shard]
-	if !ok {
-		overlay = new(shardOverlay)
-		tx.DeleteMask[shard] = overlay
-	}
+	st := tx.getOrCreateShardTxLocked(shard)
 	tx.mu.Unlock()
-	overlay.Add(recid)
+	st.mu.Lock()
+	st.DeleteMask.Set(uint(recid), true)
+	st.DeleteRecids = append(st.DeleteRecids, recid)
+	st.mu.Unlock()
 }
 
-// AddToUndeleteMask records that this ACID tx can see a staged row.
+// AddToUndeleteMask records that this ACID tx can see a staged (inserted) row.
 func (tx *TxContext) AddToUndeleteMask(shard *storageShard, recid uint32) {
 	tx.mu.Lock()
-	overlay, ok := tx.UndeleteMask[shard]
-	if !ok {
-		overlay = new(shardOverlay)
-		tx.UndeleteMask[shard] = overlay
-	}
+	st := tx.getOrCreateShardTxLocked(shard)
 	tx.mu.Unlock()
-	overlay.Add(recid)
+	st.mu.Lock()
+	st.UndeleteMask.Set(uint(recid), true)
+	st.UndeleteRecids = append(st.UndeleteRecids, recid)
+	st.mu.Unlock()
 }
 
+// UnstageRow removes recid from UndeleteMask (ACID UPDATE/DELETE of a staged row).
+// Returns true if the row was staged by this tx and has been un-staged.
+func (tx *TxContext) UnstageRow(shard *storageShard, recid uint32) bool {
+	st := tx.getShardTx(shard)
+	if st == nil || !st.UndeleteMask.Get(uint(recid)) {
+		return false
+	}
+	// plain Set is safe: caller holds the shard write lock
+	st.UndeleteMask.Set(uint(recid), false)
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Deferred fsync
+// ---------------------------------------------------------------------------
+
 // RegisterTouchedShard marks a shard as having pending writes for deferred sync.
+// Only Safe-engine shards need an fsync; Memory/Cache/Sloppy shards are skipped.
 func (tx *TxContext) RegisterTouchedShard(shard *storageShard) {
+	if shard.t.PersistencyMode != Safe {
+		return
+	}
 	tx.touchedShards.Store(shard, true)
 }
 
@@ -300,33 +278,130 @@ func (tx *TxContext) SyncTouchedShards() {
 		}
 		return true
 	})
-	tx.touchedShards = sync.Map{} // clear for next query/transaction
+	tx.touchedShards = sync.Map{}
 }
+
+// ---------------------------------------------------------------------------
+// Visibility (ACID)
+// ---------------------------------------------------------------------------
 
 // IsVisible determines whether a row is visible to this ACID transaction.
-// Formula: (!shard->delete[i] && !tx->delete[i]) || tx->undelete[i]
-// UndeleteMask always wins — it is the only way an ACID tx sees its own inserts.
+//
+//	UndeleteMask wins — it is the only way an ACID tx sees its own inserts.
+//	Otherwise: not globally deleted AND not locally (tx-level) deleted.
 func (tx *TxContext) IsVisible(shard *storageShard, recid uint32) bool {
-	tx.mu.Lock()
-	dm := tx.DeleteMask[shard]
-	um := tx.UndeleteMask[shard]
-	tx.mu.Unlock()
-	// undelete mask overrides everything — this tx staged this row
-	if um != nil && um.Has(recid) {
+	st := tx.getShardTx(shard)
+	if st == nil {
+		return !shard.deletions.Get(uint(recid))
+	}
+	if st.UndeleteMask.Get(uint(recid)) {
 		return true
 	}
-	// otherwise: not globally deleted AND not locally deleted
-	return !shard.deletions.Get(recid) && (dm == nil || !dm.Has(recid))
+	return !shard.deletions.Get(uint(recid)) && !st.DeleteMask.Get(uint(recid))
 }
 
-// Commit finalizes the transaction. For cursor-stability it discards the undo
-// log. For ACID it runs OCC validation and applies overlay masks.
+// ---------------------------------------------------------------------------
+// Savepoints
+// ---------------------------------------------------------------------------
+
+// CreateSavepoint captures the current transaction state for later rollback.
+func (tx *TxContext) CreateSavepoint() Savepoint {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	sp := Savepoint{Depth: tx.Depth}
+	tx.Depth++
+	if len(tx.shards) > 0 {
+		sp.shardLens = make(map[*storageShard]shardSavepoint, len(tx.shards))
+		for s, st := range tx.shards {
+			st.mu.Lock()
+			sp.shardLens[s] = shardSavepoint{
+				InsertLen:   len(st.InsertRecids),
+				DeletedLen:  len(st.DeletedRecids),
+				DeleteLen:   len(st.DeleteRecids),
+				UndeleteLen: len(st.UndeleteRecids),
+			}
+			st.mu.Unlock()
+		}
+	}
+	return sp
+}
+
+// RollbackToSavepoint undoes all changes made since the savepoint was created.
+func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	tx.Depth = sp.Depth
+	for shard, st := range tx.shards {
+		lens := sp.shardLens[shard] // zero value (all zeros) if shard is new since savepoint
+		st.mu.Lock()
+		switch tx.Mode {
+		case TxCursorStability:
+			// Undo inserts: mark as globally deleted
+			for i := len(st.InsertRecids) - 1; i >= lens.InsertLen; i-- {
+				recid := st.InsertRecids[i]
+				st.InsertMask.Set(uint(recid), false)
+				shard.mu.Lock()
+				shard.deletions.Set(uint(recid), true)
+				if shard.logfile != nil {
+					shard.logfile.Write(LogEntryDelete{recid})
+				}
+				shard.mu.Unlock()
+			}
+			st.InsertRecids = st.InsertRecids[:lens.InsertLen]
+			// Undo deletes: restore global visibility
+			for i := len(st.DeletedRecids) - 1; i >= lens.DeletedLen; i-- {
+				recid := st.DeletedRecids[i]
+				st.DeletedMask.Set(uint(recid), false)
+				shard.mu.Lock()
+				shard.deletions.Set(uint(recid), false)
+				if shard.logfile != nil && recid >= shard.main_count {
+					deltaIdx := int(recid - shard.main_count)
+					if deltaIdx < len(shard.inserts) {
+						row := shard.inserts[deltaIdx]
+						cols := make([]string, 0, len(shard.deltaColumns))
+						vals := make([]scm.Scmer, 0, len(shard.deltaColumns))
+						for name, idx := range shard.deltaColumns {
+							if idx < len(row) {
+								cols = append(cols, name)
+								vals = append(vals, row[idx])
+							}
+						}
+						shard.logfile.Write(LogEntryInsert{cols, [][]scm.Scmer{vals}})
+					}
+				}
+				shard.mu.Unlock()
+			}
+			st.DeletedRecids = st.DeletedRecids[:lens.DeletedLen]
+
+		case TxACID:
+			// Rollback DeleteMask additions
+			for i := len(st.DeleteRecids) - 1; i >= lens.DeleteLen; i-- {
+				st.DeleteMask.Set(uint(st.DeleteRecids[i]), false)
+			}
+			st.DeleteRecids = st.DeleteRecids[:lens.DeleteLen]
+			// Rollback UndeleteMask additions (re-hide the staged rows)
+			for i := len(st.UndeleteRecids) - 1; i >= lens.UndeleteLen; i-- {
+				recid := st.UndeleteRecids[i]
+				st.UndeleteMask.Set(uint(recid), false)
+				shard.deletions.Set(uint(recid), true)
+			}
+			st.UndeleteRecids = st.UndeleteRecids[:lens.UndeleteLen]
+		}
+		st.mu.Unlock()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+// Commit finalizes the transaction.
 func (tx *TxContext) Commit() error {
 	switch tx.Mode {
 	case TxCursorStability:
 		tx.mu.Lock()
 		tx.State = TxCommitted
-		tx.UndoLog = nil
+		tx.shards = nil
 		tx.mu.Unlock()
 		tx.SyncTouchedShards()
 	case TxACID:
@@ -341,38 +416,29 @@ func (tx *TxContext) Commit() error {
 // and applies overlay masks to global state.
 func (tx *TxContext) commitACID() error {
 	tx.mu.Lock()
-	// Collect all shards that have overlays
-	shardSet := make(map[*storageShard]bool)
-	for s := range tx.DeleteMask {
-		shardSet[s] = true
-	}
-	for s := range tx.UndeleteMask {
-		shardSet[s] = true
+	shards := make([]*storageShard, 0, len(tx.shards))
+	for s := range tx.shards {
+		shards = append(shards, s)
 	}
 	tx.mu.Unlock()
 
-	// Sort shards by UUID string for deterministic lock ordering
-	shards := make([]*storageShard, 0, len(shardSet))
-	for s := range shardSet {
-		shards = append(shards, s)
-	}
+	// Deterministic lock ordering prevents deadlocks.
 	sort.Slice(shards, func(i, j int) bool {
 		return shards[i].uuid.String() < shards[j].uuid.String()
 	})
-
-	// Lock all touched shards
 	for _, s := range shards {
 		s.mu.Lock()
 	}
 
-	// Validate: for each recid in DeleteMask, check it's not already
-	// globally deleted (another tx committed first → conflict → abort)
-	// Note: DeleteMask bits are never cleared, so no bitmap skip needed.
-	for shard, overlay := range tx.DeleteMask {
-		for _, recid := range overlay.Recids {
-			if shard.deletions.Get(recid) {
-				// Conflict: row was already deleted by another committed tx
-				// Unlock and abort
+	// Validate: for each recid in DeleteMask, check it hasn't already been
+	// globally deleted by another committed tx (write-write conflict → abort).
+	for _, shard := range shards {
+		st := tx.shards[shard]
+		for _, recid := range st.DeleteRecids {
+			if !st.DeleteMask.Get(uint(recid)) {
+				continue // bit was rolled back via savepoint
+			}
+			if shard.deletions.Get(uint(recid)) {
 				for _, s := range shards {
 					s.mu.Unlock()
 				}
@@ -384,47 +450,50 @@ func (tx *TxContext) commitACID() error {
 		}
 	}
 
-	// Apply: merge DeleteMask → set global deletions + log
-	for shard, overlay := range tx.DeleteMask {
-		for _, recid := range overlay.Recids {
-			shard.deletions.Set(recid, true)
+	// Apply DeleteMask → set global deletions + write log
+	for _, shard := range shards {
+		st := tx.shards[shard]
+		for _, recid := range st.DeleteRecids {
+			if !st.DeleteMask.Get(uint(recid)) {
+				continue
+			}
+			shard.deletions.Set(uint(recid), true)
 			if shard.logfile != nil {
 				shard.logfile.Write(LogEntryDelete{recid})
 			}
 		}
 	}
-	// Apply: merge UndeleteMask → clear global deletions (make staged rows visible)
-	for shard, overlay := range tx.UndeleteMask {
-		for _, recid := range overlay.Recids {
-			if !overlay.Bitmap.Get(recid) {
-				continue // removed (e.g., staged row superseded by UPDATE/DELETE in same tx)
+	// Apply UndeleteMask → clear global deletions (make staged rows visible)
+	for _, shard := range shards {
+		st := tx.shards[shard]
+		for _, recid := range st.UndeleteRecids {
+			if !st.UndeleteMask.Get(uint(recid)) {
+				continue // un-staged (row overwritten/deleted in same tx)
 			}
-			shard.deletions.Set(recid, false)
-			// The row data was already inserted globally; just making it visible.
-			// The logfile already has the Insert entry from when the row was staged.
+			shard.deletions.Set(uint(recid), false)
 		}
 	}
 
-	// Advance global commit epoch
 	atomic.AddUint64(&GlobalCommitEpoch, 1)
 
-	// Unlock shards
 	for _, s := range shards {
 		s.mu.Unlock()
 	}
 
 	tx.mu.Lock()
 	tx.State = TxCommitted
-	tx.DeleteMask = nil
-	tx.UndeleteMask = nil
+	tx.shards = nil
 	tx.mu.Unlock()
 
 	tx.SyncTouchedShards()
 	return nil
 }
 
-// Rollback undoes the transaction. For cursor-stability it replays the undo
-// log. For ACID it discards overlay masks (staged rows stay as garbage).
+// ---------------------------------------------------------------------------
+// Rollback
+// ---------------------------------------------------------------------------
+
+// Rollback undoes the transaction.
 func (tx *TxContext) Rollback() {
 	switch tx.Mode {
 	case TxCursorStability:
@@ -434,66 +503,66 @@ func (tx *TxContext) Rollback() {
 	}
 }
 
-// rollbackCursorStability replays the undo log in reverse order.
+// rollbackCursorStability replays undo masks in reverse to restore global state.
 func (tx *TxContext) rollbackCursorStability() {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
-	for i := len(tx.UndoLog) - 1; i >= 0; i-- {
-		entry := tx.UndoLog[i]
-		entry.Shard.mu.Lock()
-		switch entry.Type {
-		case UndoInsert:
-			// undo an insert: mark the inserted row as deleted
-			entry.Shard.deletions.Set(entry.RowIndex, true)
-			if entry.Shard.logfile != nil {
-				entry.Shard.logfile.Write(LogEntryDelete{entry.RowIndex})
+	for shard, st := range tx.shards {
+		st.mu.Lock()
+		// Undo inserts (reverse order): mark as globally deleted
+		for i := len(st.InsertRecids) - 1; i >= 0; i-- {
+			recid := st.InsertRecids[i]
+			shard.mu.Lock()
+			shard.deletions.Set(uint(recid), true)
+			if shard.logfile != nil {
+				shard.logfile.Write(LogEntryDelete{recid})
 			}
-		case UndoDelete:
-			// undo a delete: undelete the row
-			entry.Shard.deletions.Set(entry.RowIndex, false)
-			if entry.Shard.logfile != nil {
-				t := entry.Shard
-				if entry.RowIndex >= t.main_count {
-					deltaIdx := int(entry.RowIndex - t.main_count)
-					if deltaIdx < len(t.inserts) {
-						row := t.inserts[deltaIdx]
-						cols := make([]string, 0, len(t.deltaColumns))
-						vals := make([]scm.Scmer, 0, len(t.deltaColumns))
-						for name, idx := range t.deltaColumns {
-							if idx < len(row) {
-								cols = append(cols, name)
-								vals = append(vals, row[idx])
-							}
-						}
-						t.logfile.Write(LogEntryInsert{cols, [][]scm.Scmer{vals}})
-					}
-				}
-				// For main storage rows, persistence after rollback of
-				// main-row deletes is imperfect across restarts.
-			}
+			shard.mu.Unlock()
 		}
-		entry.Shard.mu.Unlock()
+		// Undo deletes (reverse order): restore global visibility
+		for i := len(st.DeletedRecids) - 1; i >= 0; i-- {
+			recid := st.DeletedRecids[i]
+			shard.mu.Lock()
+			shard.deletions.Set(uint(recid), false)
+			if shard.logfile != nil && recid >= shard.main_count {
+				deltaIdx := int(recid - shard.main_count)
+				if deltaIdx < len(shard.inserts) {
+					row := shard.inserts[deltaIdx]
+					cols := make([]string, 0, len(shard.deltaColumns))
+					vals := make([]scm.Scmer, 0, len(shard.deltaColumns))
+					for name, idx := range shard.deltaColumns {
+						if idx < len(row) {
+							cols = append(cols, name)
+							vals = append(vals, row[idx])
+						}
+					}
+					shard.logfile.Write(LogEntryInsert{cols, [][]scm.Scmer{vals}})
+				}
+			}
+			shard.mu.Unlock()
+		}
+		st.mu.Unlock()
 	}
 	tx.State = TxAborted
-	tx.UndoLog = nil
-	// No sync needed for rollback — discard touched shards
+	tx.shards = nil
 	tx.touchedShards = sync.Map{}
 }
 
 // rollbackACID discards overlay masks. Staged rows that were globally hidden
-// remain as garbage for GC.
+// remain as garbage (collected by the next GC/compaction pass).
 func (tx *TxContext) rollbackACID() {
 	tx.mu.Lock()
 	tx.State = TxAborted
-	tx.DeleteMask = nil
-	tx.UndeleteMask = nil
+	tx.shards = nil
 	tx.mu.Unlock()
-	// No sync needed — discard touched shards
 	tx.touchedShards = sync.Map{}
 }
 
-// CurrentTx returns the active TxContext from the goroutine-local storage,
-// or nil if no transaction is active.
+// ---------------------------------------------------------------------------
+// GLS / session helpers
+// ---------------------------------------------------------------------------
+
+// CurrentTx returns the active TxContext from goroutine-local storage, or nil.
 func CurrentTx() *TxContext {
 	txAny := scm.GetCurrentTx()
 	if txAny == nil {
@@ -503,8 +572,6 @@ func CurrentTx() *TxContext {
 	return tx
 }
 
-// initTransaction registers the tx_begin, tx_begin_acid, tx_commit,
-// tx_rollback builtins.
 // WithAutocommit executes fn inside an implicit TxCursorStability transaction
 // if no explicit transaction is already active in session, and commits it
 // afterwards. If an explicit transaction is active (session["transaction"] != nil),
@@ -515,12 +582,10 @@ func CurrentTx() *TxContext {
 // every SQL statement executed via the HTTP or MySQL frontend runs inside a
 // transaction, enabling a single fsync per statement instead of one per write.
 func WithAutocommit(sessionFn func(...scm.Scmer) scm.Scmer, fn scm.Scmer) scm.Scmer {
-	// If an explicit transaction is active, just run fn — nothing to manage.
 	if !sessionFn(scm.NewString("transaction")).IsNil() {
 		return scm.Apply(fn)
 	}
 
-	// Start an implicit auto-commit transaction.
 	tx := NewTxContext(TxCursorStability)
 	sessionFn(scm.NewString("__memcp_tx"), scm.NewAny(tx))
 
@@ -536,7 +601,6 @@ func WithAutocommit(sessionFn func(...scm.Scmer) scm.Scmer, fn scm.Scmer) scm.Sc
 	}()
 
 	if panicVal != nil {
-		// Rollback on error, clear session tx, then re-raise.
 		if tx.State == TxActive {
 			tx.Rollback()
 		}
@@ -544,13 +608,10 @@ func WithAutocommit(sessionFn func(...scm.Scmer) scm.Scmer, fn scm.Scmer) scm.Sc
 		panic(panicVal)
 	}
 
-	// If the query itself issued a BEGIN, session["transaction"] is now set and
-	// tx_begin already committed the auto-commit tx implicitly — do not commit again.
 	if !sessionFn(scm.NewString("transaction")).IsNil() {
 		return result
 	}
 
-	// Commit the auto-commit transaction (single fsync here).
 	if err := tx.Commit(); err != nil {
 		sessionFn(scm.NewString("__memcp_tx"), scm.NewNil())
 		panic("autocommit failed: " + err.Error())
@@ -573,7 +634,6 @@ func initTransaction(en scm.Env) {
 		Returns: "bool",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
-			// Check if there's already an active transaction — implicit commit
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
 			if !existingTx.IsNil() {
 				if tx, ok := existingTx.Any().(*TxContext); ok && tx.State == TxActive {
@@ -598,7 +658,6 @@ func initTransaction(en scm.Env) {
 		Returns: "bool",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
-			// Check if there's already an active transaction — implicit commit
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
 			if !existingTx.IsNil() {
 				if tx, ok := existingTx.Any().(*TxContext); ok && tx.State == TxActive {
@@ -614,7 +673,7 @@ func initTransaction(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name:         "tx_commit",
-		Desc:         "Commits the current transaction. For cursor-stability: discards undo log. For ACID: validates and applies overlay masks.",
+		Desc:         "Commits the current transaction.",
 		MinParameter: 1,
 		MaxParameter: 1,
 		Params: []scm.DeclarationParameter{
@@ -641,7 +700,7 @@ func initTransaction(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name:         "tx_rollback",
-		Desc:         "Rolls back the current transaction. For cursor-stability: replays undo log. For ACID: discards overlay masks.",
+		Desc:         "Rolls back the current transaction.",
 		MinParameter: 1,
 		MaxParameter: 1,
 		Params: []scm.DeclarationParameter{

--- a/third_party/NonLockingReadMap/bitmap.go
+++ b/third_party/NonLockingReadMap/bitmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2024-2026  Carl-Philip Hänsch
+Copyright (C) 2024  Carl-Philip Hänsch
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,11 +21,33 @@ import "math/bits"
 import "sync/atomic"
 
 /*
-this is a size-flexible threadsafe bitmap. It grows on write.
+NonBlockingBitMap is a size-flexible, lazily allocated bitmap.
 
-properties of this map:
-  - non-blocking read
-  - non-blocking write
+Concurrency model
+-----------------
+There are two families of operations, distinguished by their name prefix:
+
+  Atomic* operations (AtomicSet, AtomicGet, AtomicOrFrom, …)
+    Each word-level read-modify-write is an atomic CAS loop, so multiple
+    goroutines may call these concurrently without external locking.
+    Use these when the bitmap is shared between goroutines.
+
+  Plain operations (Set, Get, OrFrom, …)
+    Perform direct (non-CAS) word reads/writes. They are NOT safe for
+    concurrent use — the caller must guarantee exclusive access (e.g.
+    under an external mutex). They are faster because they avoid the
+    CAS retry overhead.
+
+Slice-pointer growth
+    Both families use a CAS on the atomic.Pointer to extend the backing
+    []uint64 slice. Growing is therefore always safe across goroutines.
+    After growth the returned slice is used directly; in the plain
+    family this assumes single-writer, so no second goroutine will
+    replace the slice pointer while a plain write is in flight.
+
+Lazy allocation
+    The backing slice is nil until the first write. A zero-value
+    NonBlockingBitMap is ready to use and occupies only one pointer word.
 */
 type NonBlockingBitMap struct {
 	data atomic.Pointer[[]uint64]
@@ -64,59 +86,121 @@ func (b *NonBlockingBitMap) Copy() (result NonBlockingBitMap) {
 	return
 }
 
-func (b *NonBlockingBitMap) Get(i uint32) bool {
+// ensureWord grows the backing slice to include wordIdx if necessary.
+// It returns the (possibly newly allocated) slice. Safe to call from multiple
+// goroutines because it uses a CAS on the slice pointer.
+//
+// The copy of existing elements uses atomic.LoadUint64 to avoid a race with
+// concurrent Atomic* writes on the old slice: a plain copy() would conflict
+// with a CompareAndSwapUint64 on the same element.
+func (b *NonBlockingBitMap) ensureWord(wordIdx uint) []uint64 {
+	for {
+		dataptr := b.data.Load()
+		var data []uint64
+		if dataptr != nil {
+			data = *dataptr
+		}
+		if wordIdx < uint(len(data)) {
+			return data
+		}
+		newdata := make([]uint64, wordIdx+1)
+		for i := range data {
+			newdata[i] = atomic.LoadUint64(&data[i])
+		}
+		if b.data.CompareAndSwap(dataptr, &newdata) {
+			return newdata
+		}
+		// Lost the race — retry with the updated pointer.
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+// Get returns the bit at position i using a plain (non-atomic) word read.
+// Safe only when no concurrent writes are happening — e.g. while holding
+// an external read lock that excludes all writers, or in exclusive single-
+// goroutine use. If concurrent Atomic* writes are possible, use AtomicGet.
+func (b *NonBlockingBitMap) Get(i uint) bool {
 	ptr := b.data.Load()
 	if ptr == nil {
 		return false
 	}
 	data := *ptr
-	if (i >> 6) >= uint32(len(data)) {
+	if (i >> 6) >= uint(len(data)) {
 		return false
 	}
-	return ((data[i>>6] >> (i & 0b111111)) & 1) != 0
+	return ((data[i>>6] >> (i & 63)) & 1) != 0
 }
 
-// DataPtr returns a pointer to the underlying data slice for direct read access.
+// AtomicGet returns the bit at position i using an atomic word load.
+// Provides strict Go memory-model happens-before guarantees with AtomicSet.
+func (b *NonBlockingBitMap) AtomicGet(i uint) bool {
+	ptr := b.data.Load()
+	if ptr == nil {
+		return false
+	}
+	data := *ptr
+	if (i >> 6) >= uint(len(data)) {
+		return false
+	}
+	return (atomic.LoadUint64(&data[i>>6])>>(i&63))&1 != 0
+}
+
+// DataPtr returns the raw pointer to the underlying []uint64 slice.
+// Useful for JIT compilation where the pointer can be embedded as an
+// immediate value. The returned pointer may be nil if no bits have been
+// set yet. The slice data is safe to read concurrently.
 func (b *NonBlockingBitMap) DataPtr() *[]uint64 {
 	return b.data.Load()
 }
 
-func (b *NonBlockingBitMap) Set(i uint32, val bool) {
-	// first step: load array and ensure it is big enough
-	var data []uint64
-	for {
-		dataptr := b.data.Load()
-		if dataptr == nil {
-			data = []uint64{}
-		} else {
-			data = *dataptr
-		}
-		if (i >> 6) >= uint32(len(data)) {
-			// first step: increase data size
-			newdata := append(data, 0) // allocate new element
-			if b.data.CompareAndSwap(dataptr, &newdata) {
-				continue
-			}
-		} else {
-			// finished: our data is now big enough
-			break
-		}
+// ---------------------------------------------------------------------------
+// Single-bit write — plain (single-writer, no CAS on the word)
+// ---------------------------------------------------------------------------
+
+// Set writes bit i to val.
+// Requires exclusive access: must not be called concurrently with any
+// other write on this bitmap. Use AtomicSet when concurrent writes are
+// possible.
+func (b *NonBlockingBitMap) Set(i uint, val bool) {
+	data := b.ensureWord(i >> 6)
+	bit := uint64(1) << (i & 63)
+	if val {
+		data[i>>6] |= bit
+	} else {
+		data[i>>6] &^= bit
 	}
-	// second step: set & replace
-	bit := uint64(1 << (uint64(i) & 0b111111))
+}
+
+// ---------------------------------------------------------------------------
+// Single-bit write — atomic (CAS loop, concurrent-safe)
+// ---------------------------------------------------------------------------
+
+// AtomicSet writes bit i to val using a CAS loop.
+// The read-modify-write is atomic: concurrent AtomicSet calls on the same
+// or different bits are safe without external locking.
+func (b *NonBlockingBitMap) AtomicSet(i uint, val bool) {
+	data := b.ensureWord(i >> 6)
+	bit := uint64(1) << (i & 63)
 	for {
-		cell := data[i>>6]
+		old := atomic.LoadUint64(&data[i>>6])
 		var ncell uint64
 		if val {
-			ncell = cell | bit
+			ncell = old | bit
 		} else {
-			ncell = cell & ^bit
+			ncell = old &^ bit
 		}
-		if atomic.CompareAndSwapUint64(&data[i>>6], cell, ncell) {
-			break
+		if atomic.CompareAndSwapUint64(&data[i>>6], old, ncell) {
+			return
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
 
 func (b *NonBlockingBitMap) Size() uint {
 	dataptr := b.data.Load()
@@ -137,40 +221,264 @@ func (b *NonBlockingBitMap) Count() (result uint) {
 	return
 }
 
-// Iterate calls fn for each set bit index.
-func (b *NonBlockingBitMap) Iterate(fn func(uint32)) {
+// Iterate calls fn for each bit index that is set, in ascending order.
+func (b *NonBlockingBitMap) Iterate(fn func(uint)) {
 	dataptr := b.data.Load()
 	if dataptr == nil {
 		return
 	}
-	for i, v := range *dataptr {
-		for v != 0 {
-			bit := uint32(bits.TrailingZeros64(v))
-			fn(uint32(i)*64 + bit)
-			v &= v - 1 // clear lowest set bit
+	for wi, word := range *dataptr {
+		for word != 0 {
+			bit := uint(bits.TrailingZeros64(word))
+			fn(uint(wi)*64 + bit)
+			word &^= 1 << bit
 		}
 	}
 }
 
-func (b *NonBlockingBitMap) CountUntil(idx uint32) (result uint) {
+func (b *NonBlockingBitMap) CountUntil(idx uint) (result uint) {
 	dataptr := b.data.Load()
 	if dataptr == nil {
 		return 0
 	}
-	for i := uint32(0); i < (idx >> 6); i++ {
-		if i >= uint32(len(*dataptr)) {
+	for i := uint(0); i < (idx >> 6); i++ {
+		if i >= uint(len(*dataptr)) {
 			return
 		}
 		result += uint(bits.OnesCount64((*dataptr)[i]))
 	}
-	if (idx >> 6) >= uint32(len(*dataptr)) {
+	if (idx >> 6) >= uint(len(*dataptr)) {
 		return
 	}
 	currentCell := (*dataptr)[idx>>6]
-	for i := uint32(0); i < (idx & 0b111111); i++ {
+	for i := uint(0); i < (idx & 63); i++ {
 		if ((currentCell >> i) & 1) != 0 {
 			result++
 		}
 	}
 	return
+}
+
+// ---------------------------------------------------------------------------
+// Bulk operations — plain (single-writer, direct word writes)
+//
+// Each function maps bits from other (at position i) into b (at position
+// i+offset). The offset is in bits; non-word-aligned offsets are handled by
+// splitting each source word across two destination words.
+//
+// Requires exclusive write access on b. Safe to use when b is private to
+// the calling goroutine (e.g. under an external mutex).
+// ---------------------------------------------------------------------------
+
+// OrFrom sets bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b |= (other << offset) in bitmap terms.
+// Requires exclusive access to b.
+func (b *NonBlockingBitMap) OrFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		lo := v << bitOffset
+		if lo != 0 {
+			data := b.ensureWord(uint(i) + wordOffset)
+			data[uint(i)+wordOffset] |= lo
+		}
+		if bitOffset > 0 {
+			hi := v >> (64 - bitOffset)
+			if hi != 0 {
+				data := b.ensureWord(uint(i) + wordOffset + 1)
+				data[uint(i)+wordOffset+1] |= hi
+			}
+		}
+	}
+}
+
+// XorFrom flips bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b ^= (other << offset) in bitmap terms.
+// Requires exclusive access to b.
+func (b *NonBlockingBitMap) XorFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		lo := v << bitOffset
+		if lo != 0 {
+			data := b.ensureWord(uint(i) + wordOffset)
+			data[uint(i)+wordOffset] ^= lo
+		}
+		if bitOffset > 0 {
+			hi := v >> (64 - bitOffset)
+			if hi != 0 {
+				data := b.ensureWord(uint(i) + wordOffset + 1)
+				data[uint(i)+wordOffset+1] ^= hi
+			}
+		}
+	}
+}
+
+// AndNotFrom clears bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b &= ^(other << offset) in bitmap terms.
+// Bits beyond b's current size are unaffected (already zero).
+// Requires exclusive access to b.
+func (b *NonBlockingBitMap) AndNotFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	bPtr := b.data.Load()
+	if bPtr == nil {
+		return
+	}
+	bData := *bPtr
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		lo := v << bitOffset
+		if lo != 0 {
+			dstIdx := uint(i) + wordOffset
+			if dstIdx < uint(len(bData)) {
+				bData[dstIdx] &^= lo
+			}
+		}
+		if bitOffset > 0 {
+			hi := v >> (64 - bitOffset)
+			if hi != 0 {
+				dstIdx := uint(i) + wordOffset + 1
+				if dstIdx < uint(len(bData)) {
+					bData[dstIdx] &^= hi
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bulk operations — atomic (CAS loops, concurrent-safe)
+//
+// Same semantics as the plain variants above, but each word update uses a
+// CAS loop so multiple goroutines may call these concurrently.
+// ---------------------------------------------------------------------------
+
+func (b *NonBlockingBitMap) atomicOrWord(wordIdx uint, mask uint64) {
+	if mask == 0 {
+		return
+	}
+	data := b.ensureWord(wordIdx)
+	for {
+		old := atomic.LoadUint64(&data[wordIdx])
+		if atomic.CompareAndSwapUint64(&data[wordIdx], old, old|mask) {
+			return
+		}
+	}
+}
+
+func (b *NonBlockingBitMap) atomicXorWord(wordIdx uint, mask uint64) {
+	if mask == 0 {
+		return
+	}
+	data := b.ensureWord(wordIdx)
+	for {
+		old := atomic.LoadUint64(&data[wordIdx])
+		if atomic.CompareAndSwapUint64(&data[wordIdx], old, old^mask) {
+			return
+		}
+	}
+}
+
+func (b *NonBlockingBitMap) atomicAndNotWord(wordIdx uint, mask uint64) {
+	if mask == 0 {
+		return
+	}
+	dataptr := b.data.Load()
+	if dataptr == nil {
+		return
+	}
+	data := *dataptr
+	if wordIdx >= uint(len(data)) {
+		return
+	}
+	for {
+		old := atomic.LoadUint64(&data[wordIdx])
+		if atomic.CompareAndSwapUint64(&data[wordIdx], old, old&^mask) {
+			return
+		}
+	}
+}
+
+// AtomicOrFrom sets bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b |= (other << offset) in bitmap terms.
+// Concurrent-safe: each word update is a CAS loop.
+func (b *NonBlockingBitMap) AtomicOrFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		b.atomicOrWord(uint(i)+wordOffset, v<<bitOffset)
+		if bitOffset > 0 {
+			b.atomicOrWord(uint(i)+wordOffset+1, v>>(64-bitOffset))
+		}
+	}
+}
+
+// AtomicXorFrom flips bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b ^= (other << offset) in bitmap terms.
+// Concurrent-safe: each word update is a CAS loop.
+func (b *NonBlockingBitMap) AtomicXorFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		b.atomicXorWord(uint(i)+wordOffset, v<<bitOffset)
+		if bitOffset > 0 {
+			b.atomicXorWord(uint(i)+wordOffset+1, v>>(64-bitOffset))
+		}
+	}
+}
+
+// AtomicAndNotFrom clears bits in b at positions i+offset for each bit i set in other.
+// Equivalent to: b &= ^(other << offset) in bitmap terms.
+// Concurrent-safe: each word update is a CAS loop.
+func (b *NonBlockingBitMap) AtomicAndNotFrom(other *NonBlockingBitMap, offset uint) {
+	otherPtr := other.data.Load()
+	if otherPtr == nil {
+		return
+	}
+	wordOffset := offset >> 6
+	bitOffset := offset & 63
+	for i, v := range *otherPtr {
+		if v == 0 {
+			continue
+		}
+		b.atomicAndNotWord(uint(i)+wordOffset, v<<bitOffset)
+		if bitOffset > 0 {
+			b.atomicAndNotWord(uint(i)+wordOffset+1, v>>(64-bitOffset))
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- **Root cause fix**: `readConfigFile` passed `-data /var/lib/memcp` as a single string — flag parser never matched `-data`, so `Basepath` stayed at default `"data"`. Data landed in CWD-relative `data/` instead of `/var/lib/memcp`, root user was never created, login failed.
- **Password init**: memcp starts once briefly during `dpkg install` to initialize `system.user` with the chosen password — password is never stored in `memcp.conf`
- **System user**: `postinst` creates `memcp` system user; init run and service both execute as `memcp`; `postrm` removes user only on purge
- **Service**: `User=memcp`, `Group=memcp`, `StateDirectory=memcp`, `ConfigurationDirectory=memcp`
- **RPM**: `%pre` creates `memcp` user; `%postun` removes it only on full uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)