### PR TITLE
fix: claim repartitionActive under t.mu to prevent concurrent repartitions

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -394,12 +394,18 @@ func (db *database) rebuild(all bool, repartition bool) {
 			// Decide on repartition while holding t.mu, but execute it
 			// OUTSIDE the table lock so concurrent inserts can proceed
 			// and the dual-write mechanism works correctly.
+			// Also claim repartitionActive under t.mu so a concurrent
+			// rebuild (e.g. the 15-min scheduler) sees the flag and
+			// skips its own repartition instead of racing.
 			var shardCandidates []shardDimension
 			doRepart := false
-			if repartition && !hasColdShard {
+			if repartition && !hasColdShard && !t.repartitionActive {
 				var shouldChange bool
 				shardCandidates, shouldChange = t.proposerepartition(maincount)
 				doRepart = shouldChange || (t.ShardMode == ShardModeFree && t.Shards != nil)
+			}
+			if doRepart {
+				t.repartitionActive = true // claim under t.mu — atomic with the doRepart decision
 			}
 
 			t.mu.Unlock()

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -442,9 +442,11 @@ func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimen
 //
 // This function is called WITHOUT t.mu held (t.mu is released by the caller
 // before invoking repartition). It manages its own shard-level locking.
+// repartitionActive is already set to true by the caller under t.mu before
+// releasing it, so this guard only catches direct calls from outside db.rebuild.
 func (t *table) repartition(shardCandidates []shardDimension) {
-	// Guard against concurrent repartitions — only one at a time per table.
-	if t.repartitionActive {
+	// Safety-net: if somehow called directly without the flag being set.
+	if t.repartitionActive && t.PShards != nil {
 		return
 	}
 
@@ -511,7 +513,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 	}
 	t.PShards = newshards
 	t.PDimensions = shardCandidates
-	t.repartitionActive = true
+	// repartitionActive was already set to true by db.rebuild() under t.mu.
 	// From this point, all concurrent inserts/updates go to BOTH shard sets.
 
 	// ── Phase B: Snapshot deletion baselines ──


### PR DESCRIPTION
## Summary
- Fixes a race condition where two goroutines (e.g. the 15-min scheduler and a test-triggered `(rebuild)`) could both pass the `repartitionActive` guard in `repartition()` before either set the flag — resulting in two concurrent repartitions on the same table
- Root cause of intermittent CI timeouts (`(rebuild)` hanging >600s under load)

## What changed
- `db.rebuild()` now sets `t.repartitionActive = true` **under `t.mu`** immediately after the `doRepart` decision — the claim is atomic with the decision
- Added `!t.repartitionActive` to the `doRepart` condition so a second rebuild early-outs cleanly
- Removed the now-redundant Phase A assignment of `repartitionActive = true` in `repartition()`
- Safety-net guard in `repartition()` updated to check both `repartitionActive && PShards != nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)