### PR TITLE
fix: deb config file readable by memcp service user

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -96,7 +96,8 @@ EOF
 		# disable both TCP and Unix socket when MySQL is disabled
 		printf -- "--disable-mysql\n--mysql-socket=\n" >> "$CONFIG"
 	fi
-	chmod 600 "$CONFIG"
+	chown root:memcp "$CONFIG"
+	chmod 640 "$CONFIG"
 
 	# One-time DB initialization: start memcp briefly to create system.user with the chosen password.
 	# Only needed on fresh installs (no existing data dir).


### PR DESCRIPTION
## Summary
- `postinst` wrote `/etc/memcp/memcp.conf` as `root:root` with mode `600`
- Service runs as `User=memcp` and could not read it → immediate `exit-code 1` on every start
- Fix: `chown root:memcp` + `chmod 640` — only the memcp group can read it, not world-readable

## Test plan
- [ ] Install DEB, verify service starts successfully
- [ ] Confirm `ls -la /etc/memcp/memcp.conf` shows `root:memcp 640`

🤖 Generated with [Claude Code](https://claude.com/claude-code)