### PR TITLE
rpm: skip config re-prompting on upgrade

### DIFF
--- a/memcp.spec
+++ b/memcp.spec
@@ -19,71 +19,67 @@ make -C %{_srcdir} install DESTDIR=%{buildroot} PREFIX=/usr SYSTEMD_DIR=/usr/lib
 CONFIG=/etc/memcp/memcp.conf
 
 configure() {
-    # Load existing values or defaults
     DATA=/var/lib/memcp
-    API_PORT=4321
-    ENABLE_API=true
-    MYSQL_PORT=3307
-    ENABLE_MYSQL=true
-    MYSQL_SOCKET=/run/memcp/memcp.sock
-    ROOT_PASSWORD=admin
 
     if [ -f "$CONFIG" ]; then
+        # Upgrade: config already exists — keep it, just find DATA dir for DB init check
         while IFS= read -r line; do
             case "$line" in
-                -data*)          DATA="${line#-data }" ;;
-                --api-port=*)    API_PORT="${line#--api-port=}" ;;
-                --disable-api)   ENABLE_API=false ;;
-                --mysql-port=*)  MYSQL_PORT="${line#--mysql-port=}" ;;
-                --disable-mysql) ENABLE_MYSQL=false ;;
-                --mysql-socket=*)MYSQL_SOCKET="${line#--mysql-socket=}" ;;
+                -data*) DATA="${line#-data }" ;;
             esac
         done < "$CONFIG"
-    fi
+    else
+        # Fresh install: prompt interactively, then write config
+        API_PORT=4321
+        ENABLE_API=true
+        MYSQL_PORT=3307
+        ENABLE_MYSQL=true
+        MYSQL_SOCKET=/run/memcp/memcp.sock
+        ROOT_PASSWORD=admin
 
-    if [ -t 0 ]; then
-        printf "\n=== memcp configuration ===\n\n"
+        if [ -t 0 ]; then
+            printf "\n=== memcp configuration ===\n\n"
 
-        printf "Data directory [%s]: " "$DATA"
-        read ans; [ -n "$ans" ] && DATA="$ans"
+            printf "Data directory [%s]: " "$DATA"
+            read ans; [ -n "$ans" ] && DATA="$ans"
 
-        printf "Enable HTTP API? (true/false) [%s]: " "$ENABLE_API"
-        read ans
-        case "$ans" in true|false) ENABLE_API="$ans" ;; esac
-
-        if [ "$ENABLE_API" = "true" ]; then
-            printf "HTTP API port [%s]: " "$API_PORT"
-            read ans; [ -n "$ans" ] && API_PORT="$ans"
-        fi
-
-        printf "Enable MySQL protocol? (true/false) [%s]: " "$ENABLE_MYSQL"
-        read ans
-        case "$ans" in true|false) ENABLE_MYSQL="$ans" ;; esac
-
-        if [ "$ENABLE_MYSQL" = "true" ]; then
-            printf "MySQL TCP port [%s]: " "$MYSQL_PORT"
-            read ans; [ -n "$ans" ] && MYSQL_PORT="$ans"
-
-            printf "MySQL Unix socket path (empty to disable) [%s]: " "$MYSQL_SOCKET"
+            printf "Enable HTTP API? (true/false) [%s]: " "$ENABLE_API"
             read ans
-            if [ "$ans" = "-" ]; then
-                MYSQL_SOCKET=""
-            elif [ -n "$ans" ]; then
-                MYSQL_SOCKET="$ans"
+            case "$ans" in true|false) ENABLE_API="$ans" ;; esac
+
+            if [ "$ENABLE_API" = "true" ]; then
+                printf "HTTP API port [%s]: " "$API_PORT"
+                read ans; [ -n "$ans" ] && API_PORT="$ans"
             fi
+
+            printf "Enable MySQL protocol? (true/false) [%s]: " "$ENABLE_MYSQL"
+            read ans
+            case "$ans" in true|false) ENABLE_MYSQL="$ans" ;; esac
+
+            if [ "$ENABLE_MYSQL" = "true" ]; then
+                printf "MySQL TCP port [%s]: " "$MYSQL_PORT"
+                read ans; [ -n "$ans" ] && MYSQL_PORT="$ans"
+
+                printf "MySQL Unix socket path (empty to disable) [%s]: " "$MYSQL_SOCKET"
+                read ans
+                if [ "$ans" = "-" ]; then
+                    MYSQL_SOCKET=""
+                elif [ -n "$ans" ]; then
+                    MYSQL_SOCKET="$ans"
+                fi
+            fi
+
+            printf "root password [admin]: "
+            stty -echo 2>/dev/null || true
+            read ans
+            stty echo 2>/dev/null || true
+            printf "\n"
+            [ -n "$ans" ] && ROOT_PASSWORD="$ans"
         fi
 
-        printf "root password [admin]: "
-        stty -echo 2>/dev/null || true
-        read ans
-        stty echo 2>/dev/null || true
-        printf "\n"
-        [ -n "$ans" ] && ROOT_PASSWORD="$ans"
-    fi
-
-    # write config (root password is not stored — applied once during DB init below)
-    mkdir -p "$(dirname "$CONFIG")"
-    cat > "$CONFIG" <<EOF
+        # write config (root password is not stored — applied once during DB init below)
+        mkdir -p "$(dirname "$CONFIG")"
+        cat > "$CONFIG" <<EOF
 # memcp daemon configuration
 # One CLI argument per line. Lines starting with # are ignored.
 # After editing, run: systemctl restart memcp
@@ -92,17 +88,18 @@ configure() {
 
 --api-port=$API_PORT
 EOF
-    if [ "$ENABLE_API" = "false" ]; then
-        printf -- "--disable-api\n" >> "$CONFIG"
+        if [ "$ENABLE_API" = "false" ]; then
+            printf -- "--disable-api\n" >> "$CONFIG"
+        fi
+        printf "\n" >> "$CONFIG"
+        if [ "$ENABLE_MYSQL" = "true" ]; then
+            printf -- "--mysql-port=%s\n--mysql-socket=%s\n" "$MYSQL_PORT" "$MYSQL_SOCKET" >> "$CONFIG"
+        else
+            printf -- "--disable-mysql\n--mysql-socket=\n" >> "$CONFIG"
+        fi
+        chown root:memcp "$CONFIG"
+        chmod 640 "$CONFIG"
     fi
-    printf "\n" >> "$CONFIG"
-    if [ "$ENABLE_MYSQL" = "true" ]; then
-        printf -- "--mysql-port=%s\n--mysql-socket=%s\n" "$MYSQL_PORT" "$MYSQL_SOCKET" >> "$CONFIG"
-    else
-        printf -- "--disable-mysql\n--mysql-socket=\n" >> "$CONFIG"
-    fi
-    chown root:memcp "$CONFIG"
-    chmod 640 "$CONFIG"
 
     # One-time DB initialization: only on fresh installs (no existing data dir)
     if [ ! -d "$DATA/system" ]; then


### PR DESCRIPTION
## Summary
- On upgrade (`rpm -U`), `%post` is called with an existing config — keep it as-is
- Interactive prompts and config rewrite only happen on fresh installs (no existing `/etc/memcp/memcp.conf`)
- Only reads `DATA` dir from existing config to guard the one-time DB init

Follow-up to #42 (rpm-parity) and in sync with deb PR #44.

## Test plan
- [ ] Fresh RPM install: prompts appear, config written
- [ ] `rpm -U` on existing install: no prompts, config untouched, service restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)