### PR TITLE
storage: StorageDecimal.String() includes inner storage info

### DIFF
--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -100,7 +100,7 @@ func (s *StorageDecimal) ComputeSize() uint {
 }
 
 func (s *StorageDecimal) String() string {
-	return fmt.Sprintf("decimal[1e%d]", s.scaleExp)
+	return fmt.Sprintf("decimal[1e%d %s]", s.scaleExp, s.inner.String())
 }
 
 func (s *StorageDecimal) GetCachedReader() ColumnReader { return s }


### PR DESCRIPTION
## Summary
- `StorageDecimal.String()` zeigte bisher nur `decimal[1e%d]`, ohne Info über den darunterliegenden `StorageInt`
- Analog zu `StorageSeq` (`seq[%dx %s/%s]`) und `StorageString` wird jetzt `s.inner.String()` mit ausgegeben: z.B. `decimal[1e-2 int8[...]]`

## Test plan
- [ ] `go build` erfolgreich
- [ ] Manuell: Storage-Info-Ausgaben prüfen ob inner-Info erscheint

🤖 Generated with [Claude Code](https://claude.com/claude-code)