### PR TITLE
fix: MySQL-compatible string→INT coercion in column sanitizer

### DIFF
--- a/storage/table.go
+++ b/storage/table.go
@@ -480,12 +480,22 @@ func (c *column) UpdateSanitizer() {
 		inner = func(v scm.Scmer) scm.Scmer {
 			tag := v.GetTag()
 			if tag == scm.TagString || tag == scm.TagSymbol {
-				// try numeric string
-				if _, err := strconv.ParseInt(v.String(), 10, 64); err != nil {
-					if _, err2 := strconv.ParseFloat(v.String(), 64); err2 != nil {
-						panic("cannot convert string to INT for column " + name + ": " + v.String())
-					}
+				s := v.String()
+				// MySQL-compatible: parse leading integer part of string (e.g. "2026-03-11" -> 2026)
+				i := 0
+				if i < len(s) && (s[i] == '-' || s[i] == '+') {
+					i++
 				}
+				for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+					i++
+				}
+				if i == 0 || (i == 1 && (s[0] == '-' || s[0] == '+')) {
+					return scm.NewInt(0)
+				}
+				if n, err := strconv.ParseInt(s[:i], 10, 64); err == nil {
+					return scm.NewInt(n)
+				}
+				return scm.NewInt(0)
 			}
 			return scm.NewInt(int64(scm.ToInt(v)))
 		}

--- a/tests/44_decimal_sanitizer.yaml
+++ b/tests/44_decimal_sanitizer.yaml
@@ -174,7 +174,7 @@ test_cases:
     expect:
       error: true
 
-  # === INT sanitizer: string rejection ===
+  # === INT sanitizer: MySQL-compatible string coercion ===
 
   - name: "Insert int into INT column"
     sql: "INSERT INTO int_strict (id, n) VALUES (1, 42)"
@@ -193,15 +193,41 @@ test_cases:
       data:
         - { n: 7 }
 
-  - name: "Insert string into INT column must fail"
+  - name: "Insert non-numeric string into INT column yields 0 (MySQL-compatible)"
     sql: "INSERT INTO int_strict (id, n) VALUES (3, 'hello')"
     expect:
-      error: true
+      affected_rows: 1
 
-  - name: "UPDATE INT column with string must fail"
+  - name: "Readback non-numeric string → 0"
+    sql: "SELECT n FROM int_strict WHERE id = 3"
+    expect:
+      rows: 1
+      data:
+        - { n: 0 }
+
+  - name: "UPDATE INT column with non-numeric string yields 0 (MySQL-compatible)"
     sql: "UPDATE int_strict SET n = 'world' WHERE id = 1"
     expect:
-      error: true
+      affected_rows: 1
+
+  - name: "Readback updated value → 0"
+    sql: "SELECT n FROM int_strict WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - { n: 0 }
+
+  - name: "Insert date-like string into INT → leading integer part"
+    sql: "INSERT INTO int_strict (id, n) VALUES (4, '2026-03-11')"
+    expect:
+      affected_rows: 1
+
+  - name: "Readback date-like string → 2026"
+    sql: "SELECT n FROM int_strict WHERE id = 4"
+    expect:
+      rows: 1
+      data:
+        - { n: 2026 }
 
   # === FLOAT sanitizer: string rejection ===
 


### PR DESCRIPTION
## Summary

- MySQL truncates strings at the first non-numeric character when inserting into INT columns — e.g. `FROM_UNIXTIME(...)` result `'2026-03-11 21:42:46'` → `2026`, `'hello'` → `0`
- Previously MemCP panicked with `cannot convert string to INT for column X`
- Now parses the leading integer part of the string, returning `0` for purely non-numeric strings

## Test plan

- [ ] `INSERT INTO t (n) VALUES ('hello')` → stores `0`, no error
- [ ] `INSERT INTO t (n) VALUES ('2026-03-11')` → stores `2026`
- [ ] `tests/44_decimal_sanitizer.yaml` updated to reflect MySQL-compatible behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)