### PR TITLE
feat: access constraints — UNIQUE key, DROP cascade, idempotent GRANT

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -813,21 +813,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		))
 
 		/* GRANT syntax (PostgreSQL-style) -> reflect only admin and database-level access */
-		/* GRANT <any> ON DATABASE db TO user */
+		/* GRANT <any> ON DATABASE db TO user (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "DATABASE" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)))
+				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
-		/* GRANT <any> ON SCHEMA db TO user */
+		/* GRANT <any> ON SCHEMA db TO user (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "SCHEMA" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)))
+				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 		/* GRANT ALL PRIVILEGES ON ALL DATABASES is non-standard; ignore */
-		/* Treat GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA db TO user as db-level access */
+		/* Treat GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA db TO user as db-level access (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "ALL" true) (atom "TABLES" true) (atom "IN" true) (atom "SCHEMA" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)))
+				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 
 		/* REVOKE syntax (PostgreSQL-style) -> mirror GRANT behavior */

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1463,17 +1463,25 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "CREATE" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define ifnot (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true))) (define id sql_identifier) (? (atom "DEFAULT" true)) (atom "CHARACTER" true) (atom "SET" true) sql_identifier (? (atom "COLLATE" true) sql_identifier)) (begin (if policy (policy "system" true true) true) '((quote createdatabase) id (if ifnot true false) nil nil)))
 		/* CREATE {DATABASE | SCHEMA} name [SET key=val, ...] */
 		(parser '((atom "CREATE" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define ifnot (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true))) (define id sql_identifier) (define opts (? (atom "SET" true) (+ (parser '((define k sql_identifier) "=" (define v sql_literal)) '(k v)) ",")))) (begin (if policy (policy "system" true true) true) '((quote createdatabase) id (if ifnot true false) (if opts (cons (quote list) (merge opts)) nil) nil)))
-		/* DROP USER [IF EXISTS] user — deletes from system.user */
+		/* DROP USER [IF EXISTS] user — deletes from system.user and cascades to system.access */
 		(parser '((atom "DROP" true) (atom "USER" true) (? (atom "IF" true) (atom "EXISTS" true)) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) "system" "user"
-					'('list "username")
-					'((quote lambda) '((quote username)) '((quote equal??) (quote username) username))
-					'(list "$update")
-					'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
-					(quote +)
-					0
-				)
+				(cons '!begin (list
+					'((quote scan) "system" "access"
+						'('list "username")
+						'((quote lambda) '('username) '((quote equal??) (quote username) username))
+						'(list "$update")
+						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
+						(quote +)
+						0)
+					'((quote scan) "system" "user"
+						'('list "username")
+						'((quote lambda) '('username) '((quote equal??) (quote username) username))
+						'(list "$update")
+						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
+						(quote +)
+						0)
+				))
 		))
 		(parser '((atom "CREATE" true) (atom "USER" true) (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true)) (define username sql_user_ident)
 			(? '((atom "IDENTIFIED" true) (atom "BY" true) (define password sql_expression))))
@@ -1495,15 +1503,15 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan) "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
 		))
-		/* GRANT <anything> ON db.* TO user -> insert access */
+		/* GRANT <anything> ON db.* TO user -> insert access (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) (or (atom "*" true) sql_identifier) (atom "TO" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)))
+				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
-		/* GRANT <anything> ON db.table TO user -> also insert access at db level */
+		/* GRANT <anything> ON db.table TO user -> also insert access at db level (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) sql_identifier (atom "TO" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)))
+				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 
 		/* REVOKE syntax (MySQL-style) -> mirror GRANT behavior */
@@ -1609,7 +1617,19 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "SET" true) (atom "NAMES" true) (define charset sql_expression)) (quote true)) /* ignore */
 
 
-		(parser '((atom "DROP" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id (if if_exists true false))))
+		(parser '((atom "DROP" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier))
+			(begin (if policy (policy "system" true true) true)
+				(cons '!begin (list
+					'((quote scan) "system" "access"
+						'('list "database")
+						'((quote lambda) '('database) '((quote equal??) (quote database) id))
+						'(list "$update")
+						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
+						(quote +)
+						0)
+					'((quote dropdatabase) id (if if_exists true false))
+				))
+		))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname sql_identifier) (atom "TO" true) (define newname sql_identifier)) '((quote renametable) schema oldname newname))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -163,6 +163,13 @@ qry    — query text (pass "" when unknown) */
 	(eval (parse_sql "system" "CREATE TABLE `access`(username text, database text) ENGINE=SAFE" (lambda (schema table write) true)))
 ))
 
+/* migration: ensure unique (username, database) constraint on system.access */
+(try (lambda () (begin
+	(if (has? (show "system") "access")
+		(createkey "system" "access" "uniq_user_db" true '("username" "database"))
+		true)
+)) (lambda (e) true))
+
 /* global variables exposed via @@ and SHOW VARIABLES */
 (set globalvars (newsession))
 (globalvars "lower_case_table_names" 0)

--- a/tests/21_grant_revoke.yaml
+++ b/tests/21_grant_revoke.yaml
@@ -134,4 +134,67 @@ test_cases:
     sql: "REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM alice"
     expect: {}
 
-cleanup: []
+  # === UNIQUE constraint on system.access ===
+  - name: "duplicate GRANT does not create second access entry"
+    sql: "GRANT ALL PRIVILEGES ON `memcp-tests`.* TO alice"
+    expect: {}
+  - name: "second GRANT: still only one access row"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='alice' AND database='memcp-tests'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
+  - name: "cleanup duplicate grant"
+    sql: "REVOKE ALL PRIVILEGES ON `memcp-tests`.* FROM alice"
+    expect: { affected_rows: 1 }
+
+  # === DROP USER cascades to system.access ===
+  - name: "grant access to alice before drop"
+    sql: "GRANT ALL PRIVILEGES ON `memcp-tests`.* TO alice"
+    expect: {}
+  - name: "verify access entry exists before drop"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='alice'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
+  - name: "DROP USER alice removes access entries too"
+    sql: "DROP USER alice"
+    expect: {}
+  - name: "access entry gone after DROP USER"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='alice'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 0 }
+
+  # === DROP DATABASE cascades to system.access ===
+  - name: "create user bob for db-drop test"
+    sql: "CREATE USER bob IDENTIFIED BY 'pw'"
+    expect: { affected_rows: 1 }
+  - name: "create database to drop"
+    sql: "CREATE DATABASE drop_test_db"
+    expect: {}
+  - name: "grant bob access to drop_test_db"
+    sql: "GRANT ALL PRIVILEGES ON `drop_test_db`.* TO bob"
+    expect: {}
+  - name: "verify access entry before drop db"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='bob' AND database='drop_test_db'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
+  - name: "DROP DATABASE removes access entries"
+    sql: "DROP DATABASE drop_test_db"
+    expect: {}
+  - name: "access entry gone after DROP DATABASE"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='bob' AND database='drop_test_db'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 0 }
+
+cleanup:
+  - sql: "DROP USER IF EXISTS alice"
+  - sql: "DROP USER IF EXISTS bob"
+  - sql: "DROP DATABASE IF EXISTS drop_test_db"


### PR DESCRIPTION
## Summary

- **UNIQUE(username, database)** constraint added to `system.access` on startup via a safe try/ignore migration — existing deployments upgrade without data loss
- **DROP USER** now cascade-deletes all `system.access` rows for the dropped user
- **DROP DATABASE** now cascade-deletes all `system.access` rows for the dropped database
- **GRANT handlers** (MySQL + PostgreSQL syntax) are now idempotent: duplicate grants silently succeed (return 1 affected row) instead of raising a unique constraint violation

## Test plan

- [x] `tests/21_grant_revoke.yaml` extended with 12 new cases covering: UNIQUE constraint enforcement, duplicate GRANT idempotency, DROP USER cascade, DROP DATABASE cascade
- [x] All 35/35 grant/revoke tests pass
- [x] Full pre-commit test suite passes (110 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)