### PR TITLE
Work around correlated scalar subselect flattening

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -333,8 +333,8 @@ condition_suffix: if non-nil, appended to name (for dedup stages with WHERE) */
 )))
 
 /* build_agg_window_plan: generates the full plan for aggregate window functions (SUM/COUNT/MIN/MAX OVER).
-   Uses keytable infrastructure (same as GROUP BY): make_keytable + collect + createcolumn + scalar fetch.
-   Result query runs on the BASE table; window_func expressions are replaced with scalar keytable scans. */
+Uses keytable infrastructure (same as GROUP BY): make_keytable + collect + createcolumn + scalar fetch.
+Result query runs on the BASE table; window_func expressions are replaced with scalar keytable scans. */
 (define build_agg_window_plan (lambda (schema tbl tblvar tables over_partition wf_resolved condition groups schemas replace_find_column fields isOuter replace_columns_from_expr extract_columns_for_tblvar scan_wrapper) (begin
 	(define has_partition (not (equal? over_partition '())))
 	(define partition_exprs (map over_partition replace_find_column))
@@ -344,79 +344,79 @@ condition_suffix: if non-nil, appended to name (for dedup stages with WHERE) */
 	(set condition (replace_find_column (coalesceNil condition true)))
 	(define kt_result (make_keytable schema tbl group_keys tblvar nil))
 	(match kt_result '(grouptbl keytable_init fk_pk_col) (begin
-	(define is_fk_reuse (not (nil? fk_pk_col)))
-	(define tblvar_cols (if has_partition (merge_unique (map group_keys (lambda (col) (extract_columns_for_tblvar tblvar col)))) '()))
-	(set filtercols (if has_partition (extract_columns_for_tblvar tblvar condition) '()))
-	/* collect plan */
-	(define collect_plan (if (equal? group_keys '(1))
-		'('insert schema grouptbl '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
-		(begin
-			(define keycols (merge_unique (map group_keys (lambda (expr) (extract_columns_for_tblvar tblvar expr)))))
-			(scan_wrapper 'scan schema tbl
-				(cons list filtercols)
-				'('lambda (map filtercols (lambda (col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-				(cons list keycols)
-				'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
-				'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
-				'(list)
-				'('lambda '('acc 'sharddict) '('insert schema grouptbl (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
-				isOuter))))
-	/* aggregate descriptors */
-	(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition))))
-	(define fk_child_col (if is_fk_reuse (if has_partition (match (car group_keys) '('get_column _ false scol false) scol) nil) nil))
-	(define ags (map wf_resolved (lambda (wf) (match wf '(fn args _) (begin
-		/* args already resolved via replace_find_column in wf_resolved */
-		(define map_expr (if (equal? fn "COUNT") 1 (if (nil? args) 1 (car args))))
-		(define sep (if (and (equal? fn "GROUP_CONCAT") (> (count args) 1)) (cadr args) ","))
-		(match fn "SUM" (list map_expr '+ 0) "COUNT" (list 1 '+ 0) "MIN" (list map_expr 'min nil) "MAX" (list map_expr 'max nil)
-			"GROUP_CONCAT" (list '('concat map_expr) '('lambda '('a 'b) '('if '('nil? 'a) 'b '('concat 'a sep 'b))) nil)
-			(error (concat "unsupported aggregate window function: " fn))))))))
-	/* createcolumn on KEYTABLE */
-	(define agg_plans (map ags (lambda (ag) (match ag '(expr reduce neutral) (begin
-		(define cols (extract_columns_for_tblvar tblvar expr))
-		'('createcolumn schema grouptbl (agg_col_name ag) "any" '(list) '(list "temp" true)
-			(cons list (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
-			'('lambda (map group_keys (lambda (col) (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))
+		(define is_fk_reuse (not (nil? fk_pk_col)))
+		(define tblvar_cols (if has_partition (merge_unique (map group_keys (lambda (col) (extract_columns_for_tblvar tblvar col)))) '()))
+		(set filtercols (if has_partition (extract_columns_for_tblvar tblvar condition) '()))
+		/* collect plan */
+		(define collect_plan (if (equal? group_keys '(1))
+			'('insert schema grouptbl '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
+			(begin
+				(define keycols (merge_unique (map group_keys (lambda (expr) (extract_columns_for_tblvar tblvar expr)))))
 				(scan_wrapper 'scan schema tbl
-					(cons list (merge tblvar_cols filtercols))
-					'('lambda (map (merge tblvar_cols filtercols) (lambda (col) (symbol (concat tblvar "." col)))) (optimize (cons 'and (cons (replace_columns_from_expr condition) (map group_keys (lambda (col) '('equal? (replace_columns_from_expr col) '('outer (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))))))))
-					(cons list cols)
-					'('lambda (map cols (lambda (col) (symbol (concat tblvar "." col)))) (replace_columns_from_expr expr))
-					reduce neutral nil isOuter))))))))
-	(define compute_plan (cons 'parallel agg_plans))
-	/* replace window_func with scalar fetch */
-	(define replace_wf_with_fetch (lambda (expr) (match expr
-		(cons (symbol window_func) wf_rest) (begin
-			(define wf_fn (car wf_rest))
-			(define wf_args (cadr wf_rest))
-			(define map_expr (if (equal? wf_fn "COUNT") 1 (if (nil? wf_args) 1 (replace_find_column (car wf_args)))))
-			(define sep (if (and (equal? wf_fn "GROUP_CONCAT") (> (count wf_args) 1)) (cadr wf_args) ","))
-			(define ag_col (agg_col_name (match wf_fn "SUM" (list map_expr '+ 0) "COUNT" (list 1 '+ 0) "MIN" (list map_expr 'min nil) "MAX" (list map_expr 'max nil)
+					(cons list filtercols)
+					'('lambda (map filtercols (lambda (col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
+					(cons list keycols)
+					'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
+					'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
+					'(list)
+					'('lambda '('acc 'sharddict) '('insert schema grouptbl (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
+					isOuter))))
+		/* aggregate descriptors */
+		(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition))))
+		(define fk_child_col (if is_fk_reuse (if has_partition (match (car group_keys) '('get_column _ false scol false) scol) nil) nil))
+		(define ags (map wf_resolved (lambda (wf) (match wf '(fn args _) (begin
+			/* args already resolved via replace_find_column in wf_resolved */
+			(define map_expr (if (equal? fn "COUNT") 1 (if (nil? args) 1 (car args))))
+			(define sep (if (and (equal? fn "GROUP_CONCAT") (> (count args) 1)) (cadr args) ","))
+			(match fn "SUM" (list map_expr '+ 0) "COUNT" (list 1 '+ 0) "MIN" (list map_expr 'min nil) "MAX" (list map_expr 'max nil)
 				"GROUP_CONCAT" (list '('concat map_expr) '('lambda '('a 'b) '('if '('nil? 'a) 'b '('concat 'a sep 'b))) nil)
-				(list map_expr '+ 0))))
-			(if has_partition (begin
-				(define kt_key_names (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
-				/* outer refs need raw column names (tblvar.col), not canonical expr_name */
-				(define raw_col_names (map group_keys (lambda (col) (match col '('get_column _ _ c _) c (expr_name col)))))
-				(list 'scan schema grouptbl
-					(cons 'list kt_key_names)
-					/* filter: (equal? grouptbl.kt_key (outer tblvar.raw_col)) — zip kt_key_names with raw_col_names */
+				(error (concat "unsupported aggregate window function: " fn))))))))
+		/* createcolumn on KEYTABLE */
+		(define agg_plans (map ags (lambda (ag) (match ag '(expr reduce neutral) (begin
+			(define cols (extract_columns_for_tblvar tblvar expr))
+			'('createcolumn schema grouptbl (agg_col_name ag) "any" '(list) '(list "temp" true)
+				(cons list (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
+				'('lambda (map group_keys (lambda (col) (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))
+					(scan_wrapper 'scan schema tbl
+						(cons list (merge tblvar_cols filtercols))
+						'('lambda (map (merge tblvar_cols filtercols) (lambda (col) (symbol (concat tblvar "." col)))) (optimize (cons 'and (cons (replace_columns_from_expr condition) (map group_keys (lambda (col) '('equal? (replace_columns_from_expr col) '('outer (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))))))))
+						(cons list cols)
+						'('lambda (map cols (lambda (col) (symbol (concat tblvar "." col)))) (replace_columns_from_expr expr))
+						reduce neutral nil isOuter))))))))
+		(define compute_plan (cons 'parallel agg_plans))
+		/* replace window_func with scalar fetch */
+		(define replace_wf_with_fetch (lambda (expr) (match expr
+			(cons (symbol window_func) wf_rest) (begin
+				(define wf_fn (car wf_rest))
+				(define wf_args (cadr wf_rest))
+				(define map_expr (if (equal? wf_fn "COUNT") 1 (if (nil? wf_args) 1 (replace_find_column (car wf_args)))))
+				(define sep (if (and (equal? wf_fn "GROUP_CONCAT") (> (count wf_args) 1)) (cadr wf_args) ","))
+				(define ag_col (agg_col_name (match wf_fn "SUM" (list map_expr '+ 0) "COUNT" (list 1 '+ 0) "MIN" (list map_expr 'min nil) "MAX" (list map_expr 'max nil)
+					"GROUP_CONCAT" (list '('concat map_expr) '('lambda '('a 'b) '('if '('nil? 'a) 'b '('concat 'a sep 'b))) nil)
+					(list map_expr '+ 0))))
+				(if has_partition (begin
+					(define kt_key_names (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
+					/* outer refs need raw column names (tblvar.col), not canonical expr_name */
+					(define raw_col_names (map group_keys (lambda (col) (match col '('get_column _ _ c _) c (expr_name col)))))
+					(list 'scan schema grouptbl
+						(cons 'list kt_key_names)
+						/* filter: (equal? grouptbl.kt_key (outer tblvar.raw_col)) — zip kt_key_names with raw_col_names */
 						(list 'lambda
-						(map kt_key_names (lambda (kn) (symbol (concat grouptbl "." kn))))
-						(cons 'and (map (produceN (count kt_key_names) (lambda (i) i)) (lambda (i)
-							(list 'equal? (symbol (concat grouptbl "." (nth kt_key_names i))) (list 'outer (symbol (concat tblvar "." (nth raw_col_names i)))))))))
-					(list 'list ag_col)
-					'('lambda '('__v) '__v)
-					'('lambda '('__a '__b) '__b) nil nil false))
-				(list 'scan schema grouptbl '(list) '('lambda '() true)
-					(list 'list ag_col)
-					'('lambda '('__v) '__v)
-					'('lambda '('__a '__b) '__b) nil nil false)))
-		(cons sym args_) (cons sym (map args_ replace_wf_with_fetch))
-		expr)))
-	(define new_fields (map_assoc fields (lambda (k v) (replace_wf_with_fetch (replace_find_column v)))))
-	(define scan_plan (build_queryplan schema tables new_fields condition groups schemas replace_find_column))
-	(list 'begin keytable_init '('time collect_plan "collect") '('time compute_plan "compute") scan_plan)))
+							(map kt_key_names (lambda (kn) (symbol (concat grouptbl "." kn))))
+							(cons 'and (map (produceN (count kt_key_names) (lambda (i) i)) (lambda (i)
+								(list 'equal? (symbol (concat grouptbl "." (nth kt_key_names i))) (list 'outer (symbol (concat tblvar "." (nth raw_col_names i)))))))))
+						(list 'list ag_col)
+						'('lambda '('__v) '__v)
+						'('lambda '('__a '__b) '__b) nil nil false))
+					(list 'scan schema grouptbl '(list) '('lambda '() true)
+						(list 'list ag_col)
+						'('lambda '('__v) '__v)
+						'('lambda '('__a '__b) '__b) nil nil false)))
+			(cons sym args_) (cons sym (map args_ replace_wf_with_fetch))
+			expr)))
+		(define new_fields (map_assoc fields (lambda (k v) (replace_wf_with_fetch (replace_find_column v)))))
+		(define scan_plan (build_queryplan schema tables new_fields condition groups schemas replace_find_column))
+		(list 'begin keytable_init '('time collect_plan "collect") '('time compute_plan "compute") scan_plan)))
 )))
 
 /* make_col_replacer: create a function that rewrites column/aggregate references to point at a group table
@@ -528,7 +528,7 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 ))
 
 /* recursively preprocess a query and return the flattened query. The returned parameterset will be passed to build_queryplan */
-(define untangle_query (lambda (schema tables fields condition group having order limit offset) (begin
+(define untangle_query (lambda (schema tables fields condition group having order limit offset outer_schemas_chain) (begin
 	/* TODO: unnest arbitrary queries -> turn them into a left join limit 1 */
 	/* TODO: multiple group levels, limit+offset for each group level */
 	(set rename_prefix (coalesce rename_prefix ""))
@@ -586,6 +586,24 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				(cons only _) only
 			)
 		)))
+		(define canonical_column_in_schema (lambda (schemas alias_name table_insensitive column_name column_insensitive) (begin
+			(define matched_alias (column_exists_in_schema schemas alias_name table_insensitive column_name column_insensitive))
+			(if (nil? matched_alias)
+				nil
+				(begin
+					(define matched_cols (schemas matched_alias))
+					(define matched_coldef (if matched_cols
+						(reduce matched_cols (lambda (acc coldef)
+							(if (and (nil? acc) ((if column_insensitive equal?? equal?) (coldef "Field") column_name))
+								coldef
+								acc)) nil)
+						nil))
+					(if matched_coldef
+						(matched_coldef "Field")
+						nil)
+				)
+			)
+		)))
 		/* wrap_outer_leaves: replace get_column leaf nodes with (outer tblvar.col) symbol references
 		so that derived-table computed columns are accessible via the optimizer's outer-scope mechanism */
 		(define is_get_column_sym (lambda (sym)
@@ -597,7 +615,11 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 		(define wrap_outer_leaves (lambda (expr) (match expr
 			(cons sym args) (if (is_get_column_sym sym)
 				(match args
-					'(tblvar _ col _) (if (nil? tblvar) expr (list (quote outer) (symbol (concat tblvar "." col))))
+					'(tblvar _ col _) (if (nil? tblvar)
+						expr
+						(begin
+							(define outer_col (coalesce (canonical_column_in_schema _o tblvar false col true) col))
+							(list (quote outer) (symbol (concat tblvar "." outer_col)))))
 					_ (cons (wrap_outer_leaves sym) (map args wrap_outer_leaves))
 				)
 				(cons (wrap_outer_leaves sym) (map args wrap_outer_leaves))
@@ -606,15 +628,17 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 		)))
 		(define replace_get_column_subselect (lambda (alias_name table_insensitive column_name column_insensitive expr) (begin
 			(define inner_alias (column_exists_in_schema _s alias_name table_insensitive column_name column_insensitive))
+			(define inner_column (canonical_column_in_schema _s alias_name table_insensitive column_name column_insensitive))
 			(define inner_alias_exists (and (not (nil? alias_name)) (alias_exists_in_schema _s alias_name table_insensitive)))
 			(if (and inner_alias_exists (nil? inner_alias))
 				(error (concat "column " alias_name "." column_name " does not exist in subquery"))
 				(if (not (nil? inner_alias))
 					(if (or (nil? alias_name) table_insensitive column_insensitive)
-						'((quote get_column) inner_alias false column_name false)
+						(list (quote get_column) inner_alias false (coalesce inner_column column_name) false)
 						expr)
 					(begin
 						(define outer_alias (column_exists_in_schema _o alias_name table_insensitive column_name column_insensitive))
+						(define outer_column (canonical_column_in_schema _o alias_name table_insensitive column_name column_insensitive))
 						(if (nil? outer_alias)
 							(if (nil? alias_name)
 								(error (concat "column " column_name " does not exist in outer query"))
@@ -622,14 +646,15 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 							(begin
 								/* check if the outer column is a computed expression (derived table) */
 								(define outer_cols (_o outer_alias))
-								(define outer_coldef (reduce outer_cols (lambda (a coldef) (if (and (nil? a) (equal? (coldef "Field") column_name)) coldef a)) nil))
+								(define outer_colname (coalesce outer_column column_name))
+								(define outer_coldef (reduce outer_cols (lambda (a coldef) (if (and (nil? a) (equal? (coldef "Field") outer_colname)) coldef a)) nil))
 								(define outer_expr (if outer_coldef (outer_coldef "Expr") nil))
 								(if outer_expr
 									/* derived table computed column: inline expression with leaf get_column
 									nodes replaced by (outer sym) references for optimizer resolution */
 									(wrap_outer_leaves outer_expr)
 									/* real table column: symbol lookup in outer scope */
-									(list (quote outer) (symbol (concat outer_alias "." column_name))))))
+									(list (quote outer) (symbol (concat outer_alias "." outer_colname))))))
 					)
 				)
 			)
@@ -661,7 +686,10 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				(define raw_order (nth raw_vals 2))
 				(define raw_limit (nth raw_vals 3))
 				(define raw_offset (nth raw_vals 4))
-				(match (apply untangle_query subquery)
+				(match (untangle_query
+					(nth subquery 0) (nth subquery 1) (nth subquery 2) (nth subquery 3)
+					(nth subquery 4) (nth subquery 5) (nth subquery 6) (nth subquery 7)
+					(nth subquery 8) outer_schemas)
 					'(schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column2)
 					(begin
 						(define groups2 (coalesceNil groups2 '()))
@@ -833,7 +861,10 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				(define raw_order (nth raw_vals 2))
 				(define raw_limit (nth raw_vals 3))
 				(define raw_offset (nth raw_vals 4))
-				(match (apply untangle_query subquery)
+				(match (untangle_query
+					(nth subquery 0) (nth subquery 1) (nth subquery 2) (nth subquery 3)
+					(nth subquery 4) (nth subquery 5) (nth subquery 6) (nth subquery 7)
+					(nth subquery 8) outer_schemas)
 					'(schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column2)
 					(begin
 						(define groups2 (coalesceNil groups2 '()))
@@ -992,7 +1023,10 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				(define raw_order (nth raw_vals 2))
 				(define raw_limit (nth raw_vals 3))
 				(define raw_offset (nth raw_vals 4))
-				(match (apply untangle_query subquery)
+				(match (untangle_query
+					(nth subquery 0) (nth subquery 1) (nth subquery 2) (nth subquery 3)
+					(nth subquery 4) (nth subquery 5) (nth subquery 6) (nth subquery 7)
+					(nth subquery 8) outer_schemas)
 					'(schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column2)
 					(begin
 						(define groups2 (coalesceNil groups2 '()))
@@ -1213,132 +1247,163 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 								(list id (map output_cols (lambda (col) '("Field" col "Type" "any"))))
 							)
 						))
-						(match (apply untangle_query subquery) '(schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column2) (begin
-							/* helper function add prefix to tblalias of every expression */
-							(define replace_column_alias (lambda (expr) (match expr
-								'((symbol get_column) nil ti col ci) (begin
-									/* resolve unqualified column against inner schemas2; must match exactly one table.
-									Skip aliases that contain ':' — those are prefixed from flattened derived tables
-									and should not participate in unqualified column resolution. */
-									(define matches (reduce_assoc schemas2 (lambda (acc alias cols)
-										(if (and (equal? (replace alias ":" "") alias)
-											(reduce cols (lambda (a coldef) (or a ((if ci equal?? equal?) (coldef "Field") col))) false))
-											(cons alias acc)
-											acc)) '()))
-									(match matches
-										(cons only '()) '('get_column (concat id ":" only) ti col ci)
-										'() (begin
-											/* column not in schemas2 - check if it's a SELECT alias in fields2 */
-											(if (nil? (fields2 col))
-												(error (concat "column " col " does not exist in subquery"))
-												/* found in fields2 - resolve to the underlying expression */
-												(replace_column_alias (fields2 col))
+						(match (untangle_query
+							(nth subquery 0) (nth subquery 1) (nth subquery 2) (nth subquery 3)
+							(nth subquery 4) (nth subquery 5) (nth subquery 6) (nth subquery 7)
+							(nth subquery 8) '()) '(schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column2) (begin
+								/* helper function add prefix to tblalias of every expression */
+								(define replace_column_alias (lambda (expr) (match expr
+									'((symbol get_column) nil ti col ci) (begin
+										/* resolve unqualified column against inner schemas2; must match exactly one table.
+										Skip aliases that contain ':' — those are prefixed from flattened derived tables
+										and should not participate in unqualified column resolution. */
+										(define matches (reduce_assoc schemas2 (lambda (acc alias cols)
+											(if (and (equal? (replace alias ":" "") alias)
+												(reduce cols (lambda (a coldef) (or a ((if ci equal?? equal?) (coldef "Field") col))) false))
+												(cons alias acc)
+												acc)) '()))
+										(match matches
+											(cons only '()) (begin
+												(define matched_cols (schemas2 only))
+												(define matched_coldef (reduce matched_cols (lambda (acc coldef)
+													(if (and (nil? acc) ((if ci equal?? equal?) (coldef "Field") col))
+														coldef
+														acc)) nil))
+												'('get_column (concat id ":" only) false (if matched_coldef (matched_coldef "Field") col) false))
+											'() (begin
+												/* column not in schemas2 - check if it's a SELECT alias in fields2 */
+												(if (nil? (fields2 col))
+													(error (concat "column " col " does not exist in subquery"))
+													/* found in fields2 - resolve to the underlying expression */
+													(replace_column_alias (fields2 col))
+												)
 											)
+											(cons _ _) (error (concat "ambiguous column " col " in subquery"))
 										)
-										(cons _ _) (error (concat "ambiguous column " col " in subquery"))
 									)
-								)
-								'((symbol get_column) alias_ ti col ci) '('get_column (concat id ":" alias_) ti col ci)
-								'((symbol outer) outer_arg) (begin
-									/* prefix outer variable reference if it refers to a table in schemas2 */
-									(define s (string outer_arg))
-									(define parts (split s "."))
-									(match parts
-										(list tbl col) (if (not (nil? (schemas2 tbl)))
-											(list (quote outer) (symbol (concat id ":" tbl "." col)))
-											(list (quote outer) outer_arg))
-										_ (list (quote outer) (replace_column_alias outer_arg))
-									)
-								)
-								(cons sym args) /* function call */ (cons (replace_column_alias sym) (map args replace_column_alias))
-								expr
-							)))
-							/* prefix all table aliases and transform their joinexprs */
-							(set tablesPrefixed (map tables2 (lambda (x) (match x '(alias schema tbl a innerJoinexpr)
-								(list (concat id ":" alias) schema tbl a (if (nil? innerJoinexpr) nil (replace_column_alias innerJoinexpr)))))))
-							/* helper function to transform joinexpr: only transform references to subquery alias id */
-							(define transform_joinexpr (lambda (expr) (match expr
-								'((symbol get_column) alias_ ti col ci) (if (equal?? alias_ id)
-									/* reference to subquery alias -> resolve against inner schemas by passing nil alias */
-									(replace_column_alias (list (quote get_column) nil ti col ci))
-									/* reference to outer table -> keep as-is */
-									expr)
-								(cons sym args) /* function call */ (cons sym (map args transform_joinexpr))
-								expr
-							)))
-							/* transform and attach joinexpr to first table in tablesPrefixed */
-							(set joinexpr2 (if (nil? joinexpr) nil (transform_joinexpr joinexpr)))
-							/* for LEFT JOIN (isOuter=true), integrate condition2 into joinexpr to preserve LEFT JOIN semantics */
-							(set condition2_transformed (replace_column_alias condition2))
-							(set joinexpr2 (if isOuter
-								/* merge condition2 into joinexpr for outer joins */
-								(if (nil? joinexpr2)
-									condition2_transformed
-									(if (or (nil? condition2_transformed) (equal? condition2_transformed true))
-										joinexpr2
-										(list (quote and) joinexpr2 condition2_transformed)))
-								joinexpr2))
-							(if (and (not (nil? joinexpr2)) (not (nil? tablesPrefixed)))
-								(set tablesPrefixed (cons
-									/* inherit isOuter from the subquery's join type, not from inner table */
-									(match (car tablesPrefixed) '(a s t io je) (list a s t isOuter joinexpr2))
-									(cdr tablesPrefixed)))
-							)
-							/* window functions in subquery require materialization (cannot flatten because window needs its own ordering) */
-							(define subquery_has_window (not (equal? (merge (extract_assoc fields2 (lambda (k v) (extract_window_funcs v)))) '())))
-							/* TODO: group+order+limit+offset -> ordered scan list with aggregation layers (to avoid materialization) */
-							/* Note: flat defines avoid nested begin scopes — (set) only updates the innermost Nodefine=false env */
-							(define groups2_present (and (not (nil? groups2)) (not (equal? groups2 '()))))
-							(define unsupported_groups (if groups2_present
-								(reduce groups2 (lambda (acc stage)
-									(or acc
-										(begin
-											(define g (stage_group_cols stage))
-											(and (not (nil? g)) (not (equal? g '())))
+									'((symbol get_column) alias_ ti col ci) (begin
+										(define matched_cols (schemas2 alias_))
+										(define matched_coldef (if matched_cols
+											(reduce matched_cols (lambda (acc coldef)
+												(if (and (nil? acc) ((if ci equal?? equal?) (coldef "Field") col))
+													coldef
+													acc)) nil)
+											nil))
+										'('get_column (concat id ":" alias_) false (if matched_coldef (matched_coldef "Field") col) false))
+									'((symbol outer) outer_arg) (begin
+										/* prefix outer variable reference if it refers to a table in schemas2 */
+										(define s (string outer_arg))
+										(define parts (split s "."))
+										(match parts
+											(list tbl col) (if (not (nil? (schemas2 tbl)))
+												(list (quote outer) (symbol (concat id ":" tbl "." col)))
+												(list (quote outer) outer_arg))
+											_ (list (quote outer) (replace_column_alias outer_arg))
 										)
-										(not (nil? (stage_having_expr stage)))
-										(not (nil? (stage_limit_val stage)))
-										(not (nil? (stage_offset_val stage)))
 									)
-								) false)
-								false))
-							(define use_materialize (or subquery_has_window unsupported_groups))
-							/* if groups2 had only pass-through stages (no GROUP/HAVING/LIMIT/OFFSET), strip them for flattening */
-							(if (and groups2_present (not unsupported_groups))
-								(set groups2 nil))
-							(if use_materialize
-								(begin
-									(define output_cols_sub (extract_assoc fields2 (lambda (k v) k)))
-									(define rows_sym (symbol (concat "__from_subquery_rows:" id)))
-									(define resultrow_sym (symbol (concat "__from_subquery_resultrow:" id)))
-									(define materialized_rows (list (quote begin)
-										(list (quote set) rows_sym (list (quote newsession)))
-										(list rows_sym "rows" '())
-										(list (quote set) resultrow_sym (symbol "resultrow"))
-										(list (quote set) (symbol "resultrow")
-											(list (quote lambda) (list (symbol "item"))
-												(list rows_sym "rows"
-													(list (quote cons) (symbol "item") (list rows_sym "rows"))))
+									(cons sym args) /* function call */ (cons (replace_column_alias sym) (map args replace_column_alias))
+									expr
+								)))
+								/* prefix all table aliases and transform their joinexprs */
+								(set tablesPrefixed (map tables2 (lambda (x) (match x '(alias schema tbl a innerJoinexpr)
+									(list (concat id ":" alias) schema tbl a (if (nil? innerJoinexpr) nil (replace_column_alias innerJoinexpr)))))))
+								/* helper function to transform joinexpr: only transform references to subquery alias id */
+								(define transform_joinexpr (lambda (expr) (match expr
+									'((symbol get_column) alias_ ti col ci) (if (equal?? alias_ id)
+										/* reference to subquery alias -> resolve against inner schemas by passing nil alias */
+										(replace_column_alias (list (quote get_column) nil ti col ci))
+										/* reference to outer table -> keep as-is */
+										expr)
+									(cons sym args) /* function call */ (cons sym (map args transform_joinexpr))
+									expr
+								)))
+								/* transform and attach joinexpr to first table in tablesPrefixed */
+								(set joinexpr2 (if (nil? joinexpr) nil (transform_joinexpr joinexpr)))
+								/* for LEFT JOIN (isOuter=true), integrate condition2 into joinexpr to preserve LEFT JOIN semantics */
+								(set condition2_transformed (replace_column_alias condition2))
+								(set joinexpr2 (if isOuter
+									/* merge condition2 into joinexpr for outer joins */
+									(if (nil? joinexpr2)
+										condition2_transformed
+										(if (or (nil? condition2_transformed) (equal? condition2_transformed true))
+											joinexpr2
+											(list (quote and) joinexpr2 condition2_transformed)))
+									joinexpr2))
+								(if (and (not (nil? joinexpr2)) (not (nil? tablesPrefixed)))
+									(set tablesPrefixed (cons
+										/* inherit isOuter from the subquery's join type, not from inner table */
+										(match (car tablesPrefixed) '(a s t io je) (list a s t isOuter joinexpr2))
+										(cdr tablesPrefixed)))
+								)
+								(define wrap_outer_join_projection (lambda (expr)
+									(if (and isOuter
+										(not (equal? joinexpr true))
+										(not (nil? joinexpr2))
+										(not (equal? joinexpr2 true)))
+										(list (quote if) joinexpr2 expr nil)
+										expr
+									)
+								))
+								/* window functions in subquery require materialization (cannot flatten because window needs its own ordering) */
+								(define subquery_has_window (not (equal? (merge (extract_assoc fields2 (lambda (k v) (extract_window_funcs v)))) '())))
+								/* TODO: group+order+limit+offset -> ordered scan list with aggregation layers (to avoid materialization) */
+								/* Note: flat defines avoid nested begin scopes — (set) only updates the innermost Nodefine=false env */
+								(define groups2_present (and (not (nil? groups2)) (not (equal? groups2 '()))))
+								(define unsupported_groups (if groups2_present
+									(reduce groups2 (lambda (acc stage)
+										(or acc
+											(begin
+												(define g (stage_group_cols stage))
+												(and (not (nil? g)) (not (equal? g '())))
+											)
+											(not (nil? (stage_having_expr stage)))
+											(not (nil? (stage_limit_val stage)))
+											(not (nil? (stage_offset_val stage)))
 										)
-										(build_queryplan_term subquery)
-										(list (quote set) (symbol "resultrow") resultrow_sym)
-										(list rows_sym "rows")
-									))
-									(list
-										(list (list id schemax materialized_rows isOuter joinexpr))
-										'()
-										true
-										(list id (map output_cols_sub (lambda (col) '("Field" col "Type" "any"))))
+									) false)
+									false))
+								(define use_materialize (or subquery_has_window unsupported_groups))
+								/* if groups2 had only pass-through stages (no GROUP/HAVING/LIMIT/OFFSET), strip them for flattening */
+								(if (and groups2_present (not unsupported_groups))
+									(set groups2 nil))
+								(if use_materialize
+									(begin
+										(define output_cols_sub (extract_assoc fields2 (lambda (k v) k)))
+										(define rows_sym (symbol (concat "__from_subquery_rows:" id)))
+										(define resultrow_sym (symbol (concat "__from_subquery_resultrow:" id)))
+										(define materialized_rows (list (quote begin)
+											(list (quote set) rows_sym (list (quote newsession)))
+											(list rows_sym "rows" '())
+											(list (quote set) resultrow_sym (symbol "resultrow"))
+											(list (quote set) (symbol "resultrow")
+												(list (quote lambda) (list (symbol "item"))
+													(list rows_sym "rows"
+														(list (quote cons) (symbol "item") (list rows_sym "rows"))))
+											)
+											(build_queryplan_term subquery)
+											(list (quote set) (symbol "resultrow") resultrow_sym)
+											(list rows_sym "rows")
+										))
+										(list
+											(list (list id schemax materialized_rows isOuter joinexpr))
+											'()
+											true
+											(list id (map output_cols_sub (lambda (col) '("Field" col "Type" "any"))))
+										)
+									)
+									(begin
+										/* for LEFT JOIN: condition2 was integrated into joinexpr, so return true as global filter */
+										/* for INNER JOIN: condition2 becomes global filter (can be reordered) */
+										(set globalFilter (if isOuter true (replace_column_alias condition2)))
+										(list tablesPrefixed
+											(list id (map_assoc fields2 (lambda (k v) (wrap_outer_join_projection (replace_column_alias v)))))
+											globalFilter
+											(merge
+												(list id (extract_assoc fields2 (lambda (k v) (list "Field" k "Type" "any" "Expr" (wrap_outer_join_projection (replace_column_alias v))))))
+												(merge (extract_assoc schemas2 (lambda (k v) (list (concat id ":" k) v))))))
 									)
 								)
-								(begin
-									/* for LEFT JOIN: condition2 was integrated into joinexpr, so return true as global filter */
-									/* for INNER JOIN: condition2 becomes global filter (can be reordered) */
-									(set globalFilter (if isOuter true (replace_column_alias condition2)))
-									(list tablesPrefixed (list id (map_assoc fields2 (lambda (k v) (replace_column_alias v)))) globalFilter (merge (list id (extract_assoc fields2 (lambda (k v) (list "Field" k "Type" "any" "Expr" (replace_column_alias v))))) (merge (extract_assoc schemas2 (lambda (k v) (list (concat id ":" k) v))))))
-								)
-							)
-						) (error "non matching return value for untangle_query"))
+							) (error "non matching return value for untangle_query"))
 					)
 				)
 				(error (concat "unknown tabledesc: " tbldesc))
@@ -1371,6 +1436,30 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 			/* set group to 1 if fields contain aggregates even if not */
 			(define group (coalesce group (if (reduce_assoc fields (lambda (a key v) (or a (expr_find_aggregate v))) false) '(1) nil)))
 
+			(define canonical_bound_column (lambda (schemas alias_name table_insensitive column_name column_insensitive prefer_main) (begin
+				(define col_cmp (if column_insensitive equal?? equal?))
+				(define tbl_cmp (if table_insensitive equal?? equal?))
+				(define find_in_aliases (lambda (main_only) (reduce_assoc schemas (lambda (acc alias cols)
+					(if acc acc
+						(begin
+							(define alias_ok (or (nil? alias_name) (tbl_cmp alias_name alias)))
+							(define main_ok (or (not main_only) (not (strlike (string alias) "%:%"))))
+							(define coldef (if (and alias_ok main_ok)
+								(reduce cols (lambda (acc item)
+									(if (and (nil? acc) (col_cmp (item "Field") column_name))
+										item
+										acc)) nil)
+								nil))
+							(if coldef
+								(list alias (coldef "Field"))
+								nil)
+						)
+					)
+				) nil)))
+				(if prefer_main
+					(coalesce (find_in_aliases true) (find_in_aliases false))
+					(find_in_aliases false))
+			)))
 			/* find those columns that have no table */
 			(define replace_find_column (lambda (expr) (match expr
 				/* Ensure MySQL LIKE uses a collation at compile time:
@@ -1417,28 +1506,26 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				)
 				/* Unqualified column: prefer main tables (no ':' prefix) over subquery tables (prefixed with ':') */
 				'((symbol get_column) nil _ col ci) (begin
-					/* First try main tables (aliases without ':') */
-					(define main_match (reduce_assoc schemas (lambda (a alias cols)
-						(if (and (not (strlike (string alias) "%:%")) (reduce cols (lambda (a coldef) (or a ((if ci equal?? equal?) (coldef "Field") col))) false))
-							alias a)) nil))
-					/* If not found in main tables, try subquery tables (aliases with ':') */
-					(define any_match (if (nil? main_match)
-						(reduce_assoc schemas (lambda (a alias cols)
-							(if (reduce cols (lambda (a coldef) (or a ((if ci equal?? equal?) (coldef "Field") col))) false)
-								alias a)) nil)
-						main_match))
-					'((quote get_column) (coalesce any_match (error (concat "column " col " does not exist in tables"))) false col false)
+					(define resolved (canonical_bound_column schemas nil false col ci true))
+					(if resolved
+						(list (quote get_column) (car resolved) false (nth resolved 1) false)
+						(error (concat "column " col " does not exist in tables")))
 				)
-				'((symbol get_column) alias_ ti col ci) (if (or ti ci) '((quote get_column) (coalesce (reduce_assoc schemas (lambda (a alias cols) (if (and ((if ti equal?? equal?) alias_ alias) (reduce cols (lambda (a coldef) (or a ((if ci equal?? equal?) (coldef "Field") col))) false)) alias a)) nil) (error (concat "column " alias_ "." col " does not exist in tables"))) false col false) expr) /* omit false false, otherwise freshly created columns wont be found */
+				'((symbol get_column) alias_ ti col ci) (begin
+					(define resolved (canonical_bound_column schemas alias_ ti col true false))
+					(if resolved
+						(list (quote get_column) (car resolved) false (nth resolved 1) false)
+						expr)) /* omit false false when unresolved, otherwise freshly created columns wont be found */
 				(cons sym args) /* function call */ (cons sym (map args replace_find_column))
 				expr
 			)))
 
-			(set fields (map_assoc fields (lambda (k v) (replace_inner_selects v schemas))))
-			(set condition (replace_inner_selects condition schemas))
-			(set group (map group (lambda (g) (replace_inner_selects g schemas))))
-			(set having (replace_inner_selects having schemas))
-			(set order (map order (lambda (o) (match o '(col dir) (list (replace_inner_selects col schemas) dir)))))
+			(define _outer_schemas_merged (merge_assoc schemas outer_schemas_chain))
+			(set fields (map_assoc fields (lambda (k v) (replace_inner_selects v _outer_schemas_merged))))
+			(set condition (replace_inner_selects condition _outer_schemas_merged))
+			(set group (map group (lambda (g) (replace_inner_selects g _outer_schemas_merged))))
+			(set having (replace_inner_selects having _outer_schemas_merged))
+			(set order (map order (lambda (o) (match o '(col dir) (list (replace_inner_selects col _outer_schemas_merged) dir)))))
 
 			/* apply renamelist (assoc of assoc of expr) */
 			(define replace_rename (lambda (expr) (match expr
@@ -1456,7 +1543,9 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 								(if (has_assoc? renamelist alias_sym)
 									(renamelist alias_sym)
 									nil))))
-						(if (nil? rename_fn) expr (rename_fn col))
+						(define resolved (canonical_bound_column schemas alias_ false col true false))
+						(define canonical_col (if resolved (nth resolved 1) col))
+						(if (nil? rename_fn) expr (rename_fn canonical_col))
 					)
 				)
 				(cons sym args) /* function call */ (cons sym (map args replace_rename))
@@ -1508,7 +1597,10 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 	(define union_parts (query_union_all_parts query))
 	(if (nil? union_parts)
 		(if (query_is_select_core query)
-			(apply build_queryplan (apply untangle_query query))
+			(apply build_queryplan (untangle_query
+				(nth query 0) (nth query 1) (nth query 2) (nth query 3)
+				(nth query 4) (nth query 5) (nth query 6) (nth query 7)
+				(nth query 8) '()))
 			(error "invalid SELECT query term"))
 		(match union_parts '(branches order limit offset) (begin
 			(if (or (nil? branches) (equal? branches '()))
@@ -1955,7 +2047,7 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 					(list fn (map args replace_find_column) over)))))
 				/* ========= ORC window function descriptors ========= */
 				/* Build a mapfn that passes $set + N extra values through as (list $set composite).
-				   For 1 col: composite = scalar; for N>1: composite = (list v0 v1 ...). */
+				For 1 col: composite = scalar; for N>1: composite = (list v0 v1 ...). */
 				(define build_key_mapfn (lambda (col_names) (begin
 					(define key_params (map (produceN (count col_names) (lambda (i) i)) (lambda (i) (symbol (concat "__k" i)))))
 					(define key_expr (if (equal? (count key_params) 1) (car key_params) (cons (quote list) key_params)))
@@ -1974,8 +2066,8 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 					'((symbol get_column) _ _ c _) c
 					'((quote get_column) _ _ c _) c
 					_ nil)))
-				/* orc_window_descriptor: fn × args × sort_col_names → (extra_mapcols mapfn reducefn reduceinit)
-				   Returns nil for non-ORC functions (LAG/LEAD stay on window_mut path). */
+			/* orc_window_descriptor: fn × args × sort_col_names → (extra_mapcols mapfn reducefn reduceinit)
+				Returns nil for non-ORC functions (LAG/LEAD stay on window_mut path). */
 				(define orc_window_descriptor (lambda (fn wf_args sort_col_names)
 					(match fn
 						"ROW_NUMBER" (list '()
@@ -2036,7 +2128,7 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 															((car mapped) new_acc)
 															new_acc))
 														agg_neutral))))))))
-					)))
+				)))
 				(define is_orc_window (lambda (wf) (match wf '(fn args _) (not (nil? (orc_window_descriptor fn args '()))))))
 				/* aggregate window: look up fn in sql_aggregates registry → (reduce neutral ordered) */
 				(define is_agg_window (lambda (wf) (match wf '(fn _ _) (not (nil? (sql_aggregates fn))))))
@@ -2045,251 +2137,225 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 					(define reg (sql_aggregates fn))
 					(if (nil? reg) false (nth reg 2))))))
 				/* classify: ORC (has ORDER BY + ORC-eligible or ordered aggregate),
-				   aggregate (no ORDER BY, or non-ordered aggregate ignoring ORDER BY),
-				   LAG/LEAD (everything else) */
+				aggregate (no ORDER BY, or non-ordered aggregate ignoring ORDER BY),
+				LAG/LEAD (everything else) */
 				(define has_over_order (not (equal? over_order '())))
 				(define all_orc_window (and has_over_order (reduce wf_resolved (lambda (acc wf) (and acc (or (is_orc_window wf) (is_ordered_agg wf)))) true)))
 				/* agg window: non-ordered aggs always, OR ordered aggs WITHOUT ORDER BY (keytable, not ORC) */
 				(define all_agg_window (and (not all_orc_window) (reduce wf_resolved (lambda (acc wf) (and acc (is_agg_window wf) (or (not (is_ordered_agg wf)) (not has_over_order)))) true)))
 				(if all_orc_window
-				(match tables
-					/* ========= ORC materialization (ROW_NUMBER, RANK, DENSE_RANK, ...) ========= */
-					'('(tblvar schema tbl isOuter _)) (begin
-						/* extract ORC sort columns from OVER ORDER BY */
-						(define orc_sort_col_names (map over_order (lambda (o) (match o '(col dir) (match col
-							'((symbol get_column) _ _ c _) c
-							'((quote get_column) _ _ c _) c
-							_ (match (replace_find_column col)
+					(match tables
+						/* ========= ORC materialization (ROW_NUMBER, RANK, DENSE_RANK, ...) ========= */
+						'('(tblvar schema tbl isOuter _)) (begin
+							/* extract ORC sort columns from OVER ORDER BY */
+							(define orc_sort_col_names (map over_order (lambda (o) (match o '(col dir) (match col
 								'((symbol get_column) _ _ c _) c
 								'((quote get_column) _ _ c _) c
-								_ (error (concat "unsupported ORC sort expression: " col))))))))
-						(define orc_sort_dirs_vals (map over_order (lambda (o) (match o '(col dir)
-							(if (equal? dir >) true false)))))
-						/* get descriptor for the first window function (all share same OVER) */
-						(define first_wf (car wf_resolved))
-						(define wf_fn (car first_wf))
-						(define wf_args (cadr first_wf))
-						(define descriptor (orc_window_descriptor wf_fn wf_args orc_sort_col_names))
-						(define inner_extra_mapcols (nth descriptor 0))
-						(define inner_mapfn (nth descriptor 1))
-						(define inner_reducefn (nth descriptor 2))
-						(define inner_reduceinit (nth descriptor 3))
-						/* partition wrapper: prepend partition cols, wrap reducer with boundary reset */
-						(define has_partition (not (equal? over_partition '())))
-						(define partition_col_names (if has_partition
-							(map over_partition (lambda (pe) (match pe
-								'((symbol get_column) _ _ c _) c
-								'((quote get_column) _ _ c _) c
-								_ (match (replace_find_column pe)
+								_ (match (replace_find_column col)
 									'((symbol get_column) _ _ c _) c
 									'((quote get_column) _ _ c _) c
-									_ (error (concat "unsupported partition expression: " pe))))))
-							'()))
-						(define extra_mapcols (if has_partition (merge partition_col_names inner_extra_mapcols) inner_extra_mapcols))
-						(define orc_mapfn (if has_partition (begin
+									_ (error (concat "unsupported ORC sort expression: " col))))))))
+							(define orc_sort_dirs_vals (map over_order (lambda (o) (match o '(col dir)
+								(if (equal? dir >) true false)))))
+							/* get descriptor for the first window function (all share same OVER) */
+							(define first_wf (car wf_resolved))
+							(define wf_fn (car first_wf))
+							(define wf_args (cadr first_wf))
+							(define descriptor (orc_window_descriptor wf_fn wf_args orc_sort_col_names))
+							(define inner_extra_mapcols (nth descriptor 0))
+							(define inner_mapfn (nth descriptor 1))
+							(define inner_reducefn (nth descriptor 2))
+							(define inner_reduceinit (nth descriptor 3))
+							/* partition wrapper: prepend partition cols, wrap reducer with boundary reset */
+							(define has_partition (not (equal? over_partition '())))
+							(define partition_col_names (if has_partition
+								(map over_partition (lambda (pe) (match pe
+									'((symbol get_column) _ _ c _) c
+									'((quote get_column) _ _ c _) c
+									_ (match (replace_find_column pe)
+										'((symbol get_column) _ _ c _) c
+										'((quote get_column) _ _ c _) c
+										_ (error (concat "unsupported partition expression: " pe))))))
+								'()))
+							(define extra_mapcols (if has_partition (merge partition_col_names inner_extra_mapcols) inner_extra_mapcols))
+							(define orc_mapfn (if has_partition (begin
 							/* build mapfn: ($set part_cols... inner_cols...) → (cons partition_key inner_mapped)
-							   The inner reducer sees (cdr mapped); wrapper sees (car mapped) as partition key. */
-							(define n_part (count partition_col_names))
-							(define n_inner (count inner_extra_mapcols))
-							(define all_params (cons (symbol "$set")
-								(map (produceN (+ n_part n_inner) (lambda (i) i)) (lambda (i) (symbol (concat "__p" i))))))
-							(define part_syms (slice all_params 1 (+ 1 n_part)))
-							(define inner_syms (slice all_params (+ 1 n_part) (+ 1 n_part n_inner)))
-							(define pk_expr (if (equal? n_part 1) (car part_syms) (cons (quote list) part_syms)))
-							(define inner_call (cons inner_mapfn (cons (symbol "$set") inner_syms)))
-							(eval (list (quote lambda) all_params (list (quote cons) pk_expr inner_call))))
-							inner_mapfn))
-						(define orc_reducefn (if has_partition (begin
-							/* wrap: acc = (list inner_acc prev_pk); mapped = (cons pk inner_mapped) */
-							(lambda (acc mapped)
-								(begin
-									(define pk (car mapped))
-									(define inner_mapped (cdr mapped))
-									(define prev_pk (cadr acc))
-									(define inner_acc (car acc))
-									(define eff_acc (if (or (nil? prev_pk) (equal? pk prev_pk)) inner_acc inner_reduceinit))
-									(define new_inner (inner_reducefn eff_acc inner_mapped))
-									(list new_inner pk))))
-							inner_reducefn))
-						(define orc_reduceinit (if has_partition (list inner_reduceinit nil) inner_reduceinit))
-						(define orc_partitioncount (count partition_col_names))
-						/* unique temp column name */
-						(define orc_col_name (concat ".orc_" wf_fn "_" tbl))
-						/* compile time: add bare column so the scan plan can reference it */
-						(createcolumn schema tbl orc_col_name "any" '() '("temp" true))
-						/* replace window_func references with ORC column read */
-						(define replace_wf (lambda (expr) (match expr
-							(cons (symbol window_func) _) '((quote get_column) (eval tblvar) false (eval orc_col_name) false)
-							(cons sym args_) (cons sym (map args_ replace_wf))
-							expr)))
-						(define new_fields (map_assoc fields (lambda (k v) (replace_wf v))))
-						/* runtime plan: createcolumn with ORC params, then the actual scan */
-						/* sortcols: partition cols (ASC) first, then ORDER BY cols */
-						(define full_sort_cols (if has_partition (merge partition_col_names orc_sort_col_names) orc_sort_col_names))
-						(define full_sort_dirs (if has_partition
-							(merge (map partition_col_names (lambda (_) false)) orc_sort_dirs_vals)
-							orc_sort_dirs_vals))
-						(define orc_setup (lambda ()
-							(createcolumn schema tbl orc_col_name "any" '()
-								(list "sortcols" full_sort_cols "sortdirs" full_sort_dirs
-									"partitioncount" orc_partitioncount "mapcols" extra_mapcols
-									"mapfn" orc_mapfn "reducefn" orc_reducefn
-									"reduceinit" orc_reduceinit "temp" true))))
-						(define scan_plan (build_queryplan schema tables new_fields condition groups schemas replace_find_column))
-						(list (quote begin) (list orc_setup) scan_plan)
-					)
-					(error "window functions on joined tables not yet supported"))
-				(if all_agg_window
-				(match tables
-					'('(tblvar schema tbl isOuter _))
-						(build_agg_window_plan schema tbl tblvar tables over_partition wf_resolved condition groups schemas replace_find_column fields isOuter replace_columns_from_expr extract_columns_for_tblvar scan_wrapper)
-					(error "window functions on joined tables not yet supported"))
-				(begin
-					/* ========= LAG/LEAD scan path (unchanged) ========= */
-					/* Case 3: conflicting ORDER BY */
-					(if (and (not (equal? stage_order_resolved '())) (not (equal? effective_sort stage_order_resolved)))
-						(error "window ORDER BY with outer ORDER BY not yet supported"))
-					(if (reduce wf_resolved (lambda (acc wf) (match wf '(fn _ _)
-						(or acc (and (not (equal? fn "LAG")) (not (equal? fn "LEAD")))))) false)
-						(error (concat "unsupported window function in LAG/LEAD context: " (car (car wf_resolved)))))
-					/* single table only */
-					(match tables
-					'('(tblvar schema tbl isOuter _)) (begin
-						(set condition (replace_find_column (coalesceNil condition true)))
-						(define has_partition (not (equal? over_partition '())))
-						/* compute stride_cols: all columns needed in output and window args */
-						(define non_window_cols (merge_unique (extract_assoc fields (lambda (k v)
-							(extract_columns_for_tblvar tblvar (replace_find_column v))))))
-						(define wf_arg_cols (merge_unique (map wf_resolved (lambda (wf) (match wf '(fn args _)
-							(merge_unique (map args (lambda (a) (extract_columns_for_tblvar tblvar a)))))))))
-						(define partition_col_names (merge_unique (map over_partition (lambda (pe) (match pe
-							'((symbol get_column) _ _ col _) '(col)
-							'((quote get_column) _ _ col _) '(col)
-							'())))))
-						(define stride_cols (merge_unique (list non_window_cols wf_arg_cols partition_col_names)))
-						(define stride (count stride_cols))
-						/* window parameters */
-						(define max_lag (reduce wf_resolved (lambda (acc wf) (match wf '(fn args _)
-							(if (equal? fn "LAG") (max acc (if (> (count args) 1) (cadr args) 1)) acc))) 0))
-						(define max_lead (reduce wf_resolved (lambda (acc wf) (match wf '(fn args _)
-							(if (equal? fn "LEAD") (max acc (if (> (count args) 1) (cadr args) 1)) acc))) 0))
-						(define window_size (+ max_lag 1 max_lead))
-						(define skip max_lead)
-						(define flush_count skip)
-						(define current_row_pos (- window_size 1 skip))
-						/* emit_fn parameter symbols */
-						(define num_emit_params (* window_size stride))
-						(define emit_params (map (produceN num_emit_params (lambda (i) i)) (lambda (i) (symbol (concat "__w" i)))))
-						/* helper: find column index in stride_cols */
-						(define col_index (lambda (col) (car (reduce stride_cols (lambda (acc c) (match acc '(idx found)
-							(if found acc (if (equal?? c col) (list idx true) (list (+ idx 1) false))))) (list 0 false)))))
-						/* rewrite field expression for emit_fn */
-						(define rewrite_for_emit (lambda (expr row_pos) (match expr
-							(cons (symbol window_func) wf_rest) (begin
-								(define fn (car wf_rest))
-								(define wf_args (cadr wf_rest))
-								(define wf_offset (if (> (count wf_args) 1) (cadr wf_args) 1))
-								(define wf_pos (if (equal? fn "LAG") (- current_row_pos wf_offset) (+ current_row_pos wf_offset)))
-								(rewrite_for_emit (replace_find_column (car wf_args)) wf_pos))
-							'((symbol get_column) (eval tblvar) _ col _) (nth emit_params (+ (* row_pos stride) (col_index col)))
-							'((quote get_column) (eval tblvar) _ col _) (nth emit_params (+ (* row_pos stride) (col_index col)))
-							'((symbol get_column) nil _ col _) (rewrite_for_emit (replace_find_column expr) row_pos)
-							(cons sym args_) (cons sym (map args_ (lambda (a) (rewrite_for_emit a row_pos))))
-							expr)))
-						/* build emit_fn: (lambda (__w0 __w1 ...) (resultrow (list field_rewrites...))) */
-						(define emit_body '((symbol "resultrow") (cons (symbol "list") (map_assoc fields (lambda (k v) (rewrite_for_emit v current_row_pos))))))
-						(define emit_fn_ast (list (quote lambda) emit_params emit_body))
-						/* build neutral */
-						(define neutral_list (merge (list skip 0 stride) (produceN (* window_size stride) (lambda (_) nil))))
-						(define neutral_ast (cons (quote list) neutral_list))
-						/* sort cols/dirs from effective_sort */
-						(define ordercols (merge (map effective_sort (lambda (order_item) (match order_item '(col dir) (match col
-							'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
-							'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
-							_ '()))))))
-						(define sort_dirs (merge (map effective_sort (lambda (order_item) (match order_item '(col dir) (match col
-							'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
-							'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
-							_ '()))))))
-						/* filter setup */
-						(define filtercols (extract_columns_for_tblvar tblvar condition))
-						/* symbols for emit_fn and fresh neutral */
-						(define efn_sym (symbol "__emit_fn"))
-						(define nfn_sym (symbol "__fresh_neutral"))
-						(if has_partition (begin
-							/* === Case 4: PARTITION BY + ORDER BY === */
-							(define window_end (+ 3 (* window_size stride)))
-							/* partition key expression in mapfn */
-							(define partition_col_syms (map over_partition (lambda (pe) (match pe
-								'((symbol get_column) _ _ col _) (symbol (concat tblvar "." col))
-								'((quote get_column) _ _ col _) (symbol (concat tblvar "." col))))))
-							(define pk_value_expr (if (equal? (count partition_col_syms) 1)
-								(car partition_col_syms)
-								(cons (quote list) partition_col_syms)))
-							/* mapfn: returns (list stride_vals... partition_key) */
-							(define mapfn_ast (list (quote lambda)
-								(map stride_cols (lambda (col) (symbol (concat tblvar "." col))))
-								(list (quote append)
-									(cons (quote list) (map stride_cols (lambda (col) (symbol (concat tblvar "." col)))))
-									pk_value_expr)))
-							/* neutral with nil partition key */
-							(define neutral_partition_ast (cons (quote list) (merge neutral_list (list nil))))
-							/* partition-aware reducer */
-							(define reducer_ast (list (quote lambda) '('acc 'mapped) (list (quote begin)
-								'('define 'pk '('nth 'mapped stride))
-								'('define 'vs '('slice 'mapped 0 stride))
-								'('define 'prev_pk '('nth 'acc window_end))
-								'('define 'win '('slice 'acc 0 window_end))
-								(list (quote if) '('or '('nil? 'prev_pk) '('equal? 'pk 'prev_pk))
-									'('append '('window_mut 'win efn_sym 'vs) 'pk)
-									(list (quote begin)
-										(if (> flush_count 0) '('window_flush 'win efn_sym flush_count) true)
-										'('append '('window_mut nfn_sym efn_sym 'vs) 'pk))))))
-							/* build scan with post-flush */
-							(define scan_plan (list (quote begin)
-								(list (quote define) efn_sym emit_fn_ast)
-								(list (quote define) nfn_sym neutral_ast)
-								(if (> flush_count 0) (begin
-									(list (quote begin)
-										(list (quote define) (symbol "__scan_result")
-											(scan_wrapper 'scan_order schema tbl
-												(cons list filtercols)
-												'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-												(cons list ordercols)
-												(cons list sort_dirs)
-												0 -1
-												(cons list stride_cols)
-												mapfn_ast
-												reducer_ast
-												neutral_partition_ast
-												isOuter))
-										(list (quote window_flush) (list (quote slice) (symbol "__scan_result") 0 window_end) efn_sym flush_count)))
-									(scan_wrapper 'scan_order schema tbl
-										(cons list filtercols)
-										'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-										(cons list ordercols)
-										(cons list sort_dirs)
-										0 -1
-										(cons list stride_cols)
-										mapfn_ast
-										reducer_ast
-										neutral_partition_ast
-										isOuter))))
-							scan_plan
-						) (begin
-								/* === Case 1: ORDER BY only, no partition === */
-								/* mapfn: returns (list stride_vals...) */
-								(define mapfn_ast '((quote lambda)
-									(map stride_cols (lambda (col) (symbol (concat tblvar "." col))))
-									(cons (quote list) (map stride_cols (lambda (col) (symbol (concat tblvar "." col)))))))
-								/* simple reducer */
-								(define reducer_ast '((quote lambda) '('acc 'mapped) '('window_mut 'acc efn_sym 'mapped)))
-								/* build scan with post-flush */
-								(define scan_plan (list (quote begin)
-									(list (quote define) efn_sym emit_fn_ast)
-									(if (> flush_count 0) (begin
-										(list (quote begin)
-											(list (quote define) (symbol "__scan_result")
+								The inner reducer sees (cdr mapped); wrapper sees (car mapped) as partition key. */
+								(define n_part (count partition_col_names))
+								(define n_inner (count inner_extra_mapcols))
+								(define all_params (cons (symbol "$set")
+									(map (produceN (+ n_part n_inner) (lambda (i) i)) (lambda (i) (symbol (concat "__p" i))))))
+								(define part_syms (slice all_params 1 (+ 1 n_part)))
+								(define inner_syms (slice all_params (+ 1 n_part) (+ 1 n_part n_inner)))
+								(define pk_expr (if (equal? n_part 1) (car part_syms) (cons (quote list) part_syms)))
+								(define inner_call (cons inner_mapfn (cons (symbol "$set") inner_syms)))
+								(eval (list (quote lambda) all_params (list (quote cons) pk_expr inner_call))))
+								inner_mapfn))
+							(define orc_reducefn (if has_partition (begin
+								/* wrap: acc = (list inner_acc prev_pk); mapped = (cons pk inner_mapped) */
+								(lambda (acc mapped)
+									(begin
+										(define pk (car mapped))
+										(define inner_mapped (cdr mapped))
+										(define prev_pk (cadr acc))
+										(define inner_acc (car acc))
+										(define eff_acc (if (or (nil? prev_pk) (equal? pk prev_pk)) inner_acc inner_reduceinit))
+										(define new_inner (inner_reducefn eff_acc inner_mapped))
+										(list new_inner pk))))
+								inner_reducefn))
+							(define orc_reduceinit (if has_partition (list inner_reduceinit nil) inner_reduceinit))
+							(define orc_partitioncount (count partition_col_names))
+							/* unique temp column name */
+							(define orc_col_name (concat ".orc_" wf_fn "_" tbl))
+							/* compile time: add bare column so the scan plan can reference it */
+							(createcolumn schema tbl orc_col_name "any" '() '("temp" true))
+							/* replace window_func references with ORC column read */
+							(define replace_wf (lambda (expr) (match expr
+								(cons (symbol window_func) _) '((quote get_column) (eval tblvar) false (eval orc_col_name) false)
+								(cons sym args_) (cons sym (map args_ replace_wf))
+								expr)))
+							(define new_fields (map_assoc fields (lambda (k v) (replace_wf v))))
+							/* runtime plan: createcolumn with ORC params, then the actual scan */
+							/* sortcols: partition cols (ASC) first, then ORDER BY cols */
+							(define full_sort_cols (if has_partition (merge partition_col_names orc_sort_col_names) orc_sort_col_names))
+							(define full_sort_dirs (if has_partition
+								(merge (map partition_col_names (lambda (_) false)) orc_sort_dirs_vals)
+								orc_sort_dirs_vals))
+							(define orc_setup (lambda ()
+								(createcolumn schema tbl orc_col_name "any" '()
+									(list "sortcols" full_sort_cols "sortdirs" full_sort_dirs
+										"partitioncount" orc_partitioncount "mapcols" extra_mapcols
+										"mapfn" orc_mapfn "reducefn" orc_reducefn
+										"reduceinit" orc_reduceinit "temp" true))))
+							(define scan_plan (build_queryplan schema tables new_fields condition groups schemas replace_find_column))
+							(list (quote begin) (list orc_setup) scan_plan)
+						)
+						(error "window functions on joined tables not yet supported"))
+					(if all_agg_window
+						(match tables
+							'('(tblvar schema tbl isOuter _))
+							(build_agg_window_plan schema tbl tblvar tables over_partition wf_resolved condition groups schemas replace_find_column fields isOuter replace_columns_from_expr extract_columns_for_tblvar scan_wrapper)
+							(error "window functions on joined tables not yet supported"))
+						(begin
+							/* ========= LAG/LEAD scan path (unchanged) ========= */
+							/* Case 3: conflicting ORDER BY */
+							(if (and (not (equal? stage_order_resolved '())) (not (equal? effective_sort stage_order_resolved)))
+								(error "window ORDER BY with outer ORDER BY not yet supported"))
+							(if (reduce wf_resolved (lambda (acc wf) (match wf '(fn _ _)
+								(or acc (and (not (equal? fn "LAG")) (not (equal? fn "LEAD")))))) false)
+								(error (concat "unsupported window function in LAG/LEAD context: " (car (car wf_resolved)))))
+							/* single table only */
+							(match tables
+								'('(tblvar schema tbl isOuter _)) (begin
+									(set condition (replace_find_column (coalesceNil condition true)))
+									(define has_partition (not (equal? over_partition '())))
+									/* compute stride_cols: all columns needed in output and window args */
+									(define non_window_cols (merge_unique (extract_assoc fields (lambda (k v)
+										(extract_columns_for_tblvar tblvar (replace_find_column v))))))
+									(define wf_arg_cols (merge_unique (map wf_resolved (lambda (wf) (match wf '(fn args _)
+										(merge_unique (map args (lambda (a) (extract_columns_for_tblvar tblvar a)))))))))
+									(define partition_col_names (merge_unique (map over_partition (lambda (pe) (match pe
+										'((symbol get_column) _ _ col _) '(col)
+										'((quote get_column) _ _ col _) '(col)
+										'())))))
+									(define stride_cols (merge_unique (list non_window_cols wf_arg_cols partition_col_names)))
+									(define stride (count stride_cols))
+									/* window parameters */
+									(define max_lag (reduce wf_resolved (lambda (acc wf) (match wf '(fn args _)
+										(if (equal? fn "LAG") (max acc (if (> (count args) 1) (cadr args) 1)) acc))) 0))
+									(define max_lead (reduce wf_resolved (lambda (acc wf) (match wf '(fn args _)
+										(if (equal? fn "LEAD") (max acc (if (> (count args) 1) (cadr args) 1)) acc))) 0))
+									(define window_size (+ max_lag 1 max_lead))
+									(define skip max_lead)
+									(define flush_count skip)
+									(define current_row_pos (- window_size 1 skip))
+									/* emit_fn parameter symbols */
+									(define num_emit_params (* window_size stride))
+									(define emit_params (map (produceN num_emit_params (lambda (i) i)) (lambda (i) (symbol (concat "__w" i)))))
+									/* helper: find column index in stride_cols */
+									(define col_index (lambda (col) (car (reduce stride_cols (lambda (acc c) (match acc '(idx found)
+										(if found acc (if (equal?? c col) (list idx true) (list (+ idx 1) false))))) (list 0 false)))))
+									/* rewrite field expression for emit_fn */
+									(define rewrite_for_emit (lambda (expr row_pos) (match expr
+										(cons (symbol window_func) wf_rest) (begin
+											(define fn (car wf_rest))
+											(define wf_args (cadr wf_rest))
+											(define wf_offset (if (> (count wf_args) 1) (cadr wf_args) 1))
+											(define wf_pos (if (equal? fn "LAG") (- current_row_pos wf_offset) (+ current_row_pos wf_offset)))
+											(rewrite_for_emit (replace_find_column (car wf_args)) wf_pos))
+										'((symbol get_column) (eval tblvar) _ col _) (nth emit_params (+ (* row_pos stride) (col_index col)))
+										'((quote get_column) (eval tblvar) _ col _) (nth emit_params (+ (* row_pos stride) (col_index col)))
+										'((symbol get_column) nil _ col _) (rewrite_for_emit (replace_find_column expr) row_pos)
+										(cons sym args_) (cons sym (map args_ (lambda (a) (rewrite_for_emit a row_pos))))
+										expr)))
+									/* build emit_fn: (lambda (__w0 __w1 ...) (resultrow (list field_rewrites...))) */
+									(define emit_body '((symbol "resultrow") (cons (symbol "list") (map_assoc fields (lambda (k v) (rewrite_for_emit v current_row_pos))))))
+									(define emit_fn_ast (list (quote lambda) emit_params emit_body))
+									/* build neutral */
+									(define neutral_list (merge (list skip 0 stride) (produceN (* window_size stride) (lambda (_) nil))))
+									(define neutral_ast (cons (quote list) neutral_list))
+									/* sort cols/dirs from effective_sort */
+									(define ordercols (merge (map effective_sort (lambda (order_item) (match order_item '(col dir) (match col
+										'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
+										'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
+										_ '()))))))
+									(define sort_dirs (merge (map effective_sort (lambda (order_item) (match order_item '(col dir) (match col
+										'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
+										'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
+										_ '()))))))
+									/* filter setup */
+									(define filtercols (extract_columns_for_tblvar tblvar condition))
+									/* symbols for emit_fn and fresh neutral */
+									(define efn_sym (symbol "__emit_fn"))
+									(define nfn_sym (symbol "__fresh_neutral"))
+									(if has_partition (begin
+										/* === Case 4: PARTITION BY + ORDER BY === */
+										(define window_end (+ 3 (* window_size stride)))
+										/* partition key expression in mapfn */
+										(define partition_col_syms (map over_partition (lambda (pe) (match pe
+											'((symbol get_column) _ _ col _) (symbol (concat tblvar "." col))
+											'((quote get_column) _ _ col _) (symbol (concat tblvar "." col))))))
+										(define pk_value_expr (if (equal? (count partition_col_syms) 1)
+											(car partition_col_syms)
+											(cons (quote list) partition_col_syms)))
+										/* mapfn: returns (list stride_vals... partition_key) */
+										(define mapfn_ast (list (quote lambda)
+											(map stride_cols (lambda (col) (symbol (concat tblvar "." col))))
+											(list (quote append)
+												(cons (quote list) (map stride_cols (lambda (col) (symbol (concat tblvar "." col)))))
+												pk_value_expr)))
+										/* neutral with nil partition key */
+										(define neutral_partition_ast (cons (quote list) (merge neutral_list (list nil))))
+										/* partition-aware reducer */
+										(define reducer_ast (list (quote lambda) '('acc 'mapped) (list (quote begin)
+											'('define 'pk '('nth 'mapped stride))
+											'('define 'vs '('slice 'mapped 0 stride))
+											'('define 'prev_pk '('nth 'acc window_end))
+											'('define 'win '('slice 'acc 0 window_end))
+											(list (quote if) '('or '('nil? 'prev_pk) '('equal? 'pk 'prev_pk))
+												'('append '('window_mut 'win efn_sym 'vs) 'pk)
+												(list (quote begin)
+													(if (> flush_count 0) '('window_flush 'win efn_sym flush_count) true)
+													'('append '('window_mut nfn_sym efn_sym 'vs) 'pk))))))
+										/* build scan with post-flush */
+										(define scan_plan (list (quote begin)
+											(list (quote define) efn_sym emit_fn_ast)
+											(list (quote define) nfn_sym neutral_ast)
+											(if (> flush_count 0) (begin
+												(list (quote begin)
+													(list (quote define) (symbol "__scan_result")
+														(scan_wrapper 'scan_order schema tbl
+															(cons list filtercols)
+															'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
+															(cons list ordercols)
+															(cons list sort_dirs)
+															0 -1
+															(cons list stride_cols)
+															mapfn_ast
+															reducer_ast
+															neutral_partition_ast
+															isOuter))
+													(list (quote window_flush) (list (quote slice) (symbol "__scan_result") 0 window_end) efn_sym flush_count)))
 												(scan_wrapper 'scan_order schema tbl
 													(cons list filtercols)
 													'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
@@ -2299,24 +2365,50 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 													(cons list stride_cols)
 													mapfn_ast
 													reducer_ast
-													neutral_ast
-													isOuter))
-											(list (quote window_flush) (symbol "__scan_result") efn_sym flush_count)))
-										(scan_wrapper 'scan_order schema tbl
-											(cons list filtercols)
-											'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-											(cons list ordercols)
-											(cons list sort_dirs)
-											0 -1
-											(cons list stride_cols)
-											mapfn_ast
-											reducer_ast
-											neutral_ast
-											isOuter))))
-								scan_plan
-						))
-					)
-					(error "window functions on joined tables not yet supported")
+													neutral_partition_ast
+													isOuter))))
+										scan_plan
+									) (begin
+											/* === Case 1: ORDER BY only, no partition === */
+											/* mapfn: returns (list stride_vals...) */
+											(define mapfn_ast '((quote lambda)
+												(map stride_cols (lambda (col) (symbol (concat tblvar "." col))))
+												(cons (quote list) (map stride_cols (lambda (col) (symbol (concat tblvar "." col)))))))
+											/* simple reducer */
+											(define reducer_ast '((quote lambda) '('acc 'mapped) '('window_mut 'acc efn_sym 'mapped)))
+											/* build scan with post-flush */
+											(define scan_plan (list (quote begin)
+												(list (quote define) efn_sym emit_fn_ast)
+												(if (> flush_count 0) (begin
+													(list (quote begin)
+														(list (quote define) (symbol "__scan_result")
+															(scan_wrapper 'scan_order schema tbl
+																(cons list filtercols)
+																'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
+																(cons list ordercols)
+																(cons list sort_dirs)
+																0 -1
+																(cons list stride_cols)
+																mapfn_ast
+																reducer_ast
+																neutral_ast
+																isOuter))
+														(list (quote window_flush) (symbol "__scan_result") efn_sym flush_count)))
+													(scan_wrapper 'scan_order schema tbl
+														(cons list filtercols)
+														'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
+														(cons list ordercols)
+														(cons list sort_dirs)
+														0 -1
+														(cons list stride_cols)
+														mapfn_ast
+														reducer_ast
+														neutral_ast
+														isOuter))))
+											scan_plan
+									))
+								)
+								(error "window functions on joined tables not yet supported")
 				))))
 			) (if (coalesce stage_order stage_limit stage_offset) (begin
 					/* ordered or limited scan */

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -18,9 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (define sql_builtins (coalesce sql_builtins (newsession)))
 
 /* Aggregate function registry: maps uppercase name → (reduce neutral ordered).
-   ordered=false: ORDER BY in OVER() can be ignored (result independent of row order)
-   ordered=true: ORDER BY matters → ORC running aggregate (e.g. GROUP_CONCAT)
-   Users can register custom aggregates: (sql_aggregates "PRODUCT" '(* 1 false)) */
+ordered=false: ORDER BY in OVER() can be ignored (result independent of row order)
+ordered=true: ORDER BY matters → ORC running aggregate (e.g. GROUP_CONCAT)
+Users can register custom aggregates: (sql_aggregates "PRODUCT" '(* 1 false)) */
 (define sql_aggregates (coalesce sql_aggregates (newsession)))
 (sql_aggregates "SUM" '(+ 0 false))
 (sql_aggregates "MIN" '(min nil false))
@@ -727,7 +727,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(if (sql_aggregates (toUpper fn))
 				'('window_func (toUpper fn) (list arg) _over)
 				'('window_func (toUpper fn) (list arg) _over)))
-	
+
 		(parser '((atom "DATABASE" true) "(" ")") schema)
 		(parser '((atom "UNIX_TIMESTAMP" true) "(" ")") '('unix_timestamp))
 		(parser '((atom "UNIX_TIMESTAMP" true) "(" (define p sql_expression) ")") '('unix_timestamp p))
@@ -884,6 +884,61 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 				(sql_select_offset right))
 			(match right_parts '(branches order limit offset)
 				(list (quote union_all) (cons left branches) order limit offset)))
+	)))
+	(define sql_inner_select_kind (lambda (sym) (begin
+		(if (equal?? sym "inner_select")
+			(quote inner_select)
+			(if (equal?? sym "inner_select_in")
+				(quote inner_select_in)
+				(if (equal?? sym "inner_select_exists")
+					(quote inner_select_exists)
+					(match sym
+						(symbol inner_select) (quote inner_select)
+						'inner_select (quote inner_select)
+						'(quote inner_select) (quote inner_select)
+						(symbol inner_select_in) (quote inner_select_in)
+						'inner_select_in (quote inner_select_in)
+						'(quote inner_select_in) (quote inner_select_in)
+						(symbol inner_select_exists) (quote inner_select_exists)
+						'inner_select_exists (quote inner_select_exists)
+						'(quote inner_select_exists) (quote inner_select_exists)
+						_ nil)
+				)
+			)
+		)
+	)))
+	(define sql_expr_contains_inner_select (lambda (expr) (match expr
+		(cons sym args) (or
+			(not (nil? (sql_inner_select_kind sym)))
+			(reduce args (lambda (a b) (or a (sql_expr_contains_inner_select b))) false))
+		_ false
+	)))
+	(define sql_dataset_contains_inner_select (lambda (dataset)
+		(reduce dataset (lambda (a b) (or a (sql_expr_contains_inner_select b))) false)
+	))
+	(define sql_values_row_query (lambda (schema2 coldesc dataset)
+		(list schema2 '()
+			(merge (map (produceN (count coldesc)) (lambda (i) (list (nth coldesc i) (nth dataset i)))))
+			true nil nil nil nil nil)
+	))
+	(define sql_values_to_select_query (lambda (schema2 coldesc datasets)
+		(match datasets
+			(cons only '()) (sql_values_row_query schema2 coldesc only)
+			(cons first rest) (reduce rest (lambda (acc row)
+				(sql_union_all_query acc (sql_values_row_query schema2 coldesc row)))
+				(sql_values_row_query schema2 coldesc first))
+			_ (error "INSERT VALUES requires at least one row")
+		)
+	))
+	(define sql_insert_select_plan (lambda (schema2 tbl coldesc inner ignoreexists updaterows updaterows2 updatecols) (begin
+		'('begin
+			'('set 'resultrow '('lambda '('item) '('insert schema2 tbl (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols)
+				(if (and ignoreexists (nil? updaterows))
+					'((quote lambda) '() 0)
+					(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
+				'('lambda '('id) '('session "last_insert_id" 'id)))))
+			(build_queryplan_term inner)
+		)
 	)))
 	(define sql_select_core (parser '(
 		(atom "SELECT" true)
@@ -1308,11 +1363,15 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
-			'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
-				(if (and ignoreexists (nil? updaterows))
-					'((quote lambda) '() 0)
-					(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
-				false '('lambda '('id) '('session "last_insert_id" 'id)))
+			(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
+				(begin
+					(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
+					(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
+				'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
+					(if (and ignoreexists (nil? updaterows))
+						'((quote lambda) '() 0)
+						(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
+					false '('lambda '('id) '('session "last_insert_id" 'id))))
 	)))
 
 	(define sql_insert_select (parser '(
@@ -1346,14 +1405,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
-			'('begin
-				'('set 'resultrow '('lambda '('item) '('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols)
-					(if (and ignoreexists (nil? updaterows))
-						'((quote lambda) '() 0)
-						(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
-					'('lambda '('id) '('session "last_insert_id" 'id)))))
-				(build_queryplan_term inner)
-			)
+			(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols)
 	)))
 
 	(define sql_foreign_key_mode (parser (or

--- a/tests/32_expr_subselects.yaml
+++ b/tests/32_expr_subselects.yaml
@@ -9,10 +9,22 @@ setup:
   - sql: "DROP TABLE IF EXISTS t2"
   - sql: "DROP TABLE IF EXISTS t3"
   - sql: "DROP TABLE IF EXISTS t4"
+  - sql: "DROP TABLE IF EXISTS doc"
+  - sql: "DROP TABLE IF EXISTS doc_revision"
+  - sql: "DROP TABLE IF EXISTS fop_files"
+  - sql: "DROP TABLE IF EXISTS docType"
+  - sql: "DROP TABLE IF EXISTS login"
+  - sql: "DROP TABLE IF EXISTS userconfig"
   - sql: "CREATE TABLE t1 (id INT PRIMARY KEY)"
   - sql: "CREATE TABLE t2 (owner INT, val INT)"
   - sql: "CREATE TABLE t3 (id INT PRIMARY KEY, ref INT)"
   - sql: "CREATE TABLE t4 (id INT PRIMARY KEY, description VARCHAR(20))"
+  - sql: "CREATE TABLE doc (id INT PRIMARY KEY, type INT, archive BOOL)"
+  - sql: "CREATE TABLE doc_revision (id INT PRIMARY KEY, doc INT, created INT, file INT)"
+  - sql: "CREATE TABLE fop_files (id INT PRIMARY KEY, filename VARCHAR(255), type VARCHAR(255))"
+  - sql: "CREATE TABLE docType (ID INT PRIMARY KEY, name VARCHAR(255))"
+  - sql: "CREATE TABLE login (ID INT PRIMARY KEY)"
+  - sql: "CREATE TABLE userconfig (ID INT PRIMARY KEY, Tables_Doc_defaultDoctype INT)"
   - sql: "INSERT INTO t1 (id) VALUES (4)"
   - sql: "INSERT INTO t2 (owner, val) VALUES (1, 42)"
   - sql: "INSERT INTO t2 (owner, val) VALUES (2, 41)"
@@ -26,6 +38,15 @@ setup:
   - sql: "INSERT INTO t3 (id, ref) VALUES (4, NULL)"
   - sql: "INSERT INTO t4 (id, description) VALUES (10, 'alpha')"
   - sql: "INSERT INTO t4 (id, description) VALUES (11, 'beta')"
+  - sql: "INSERT INTO doc (id, type, archive) VALUES (1, 7, FALSE)"
+  - sql: "INSERT INTO doc (id, type, archive) VALUES (2, NULL, FALSE)"
+  - sql: "INSERT INTO fop_files (id, filename, type) VALUES (1, 'Basics.pdf', 'application/pdf')"
+  - sql: "INSERT INTO fop_files (id, filename, type) VALUES (3, 'Angebot.pdf', 'application/pdf')"
+  - sql: "INSERT INTO doc_revision (id, doc, created, file) VALUES (1, 1, 1000, 1)"
+  - sql: "INSERT INTO doc_revision (id, doc, created, file) VALUES (2, 2, 2000, 3)"
+  - sql: "INSERT INTO docType (ID, name) VALUES (7, 'General')"
+  - sql: "INSERT INTO login (ID) VALUES (1)"
+  - sql: "INSERT INTO userconfig (ID, Tables_Doc_defaultDoctype) VALUES (1, 7)"
 
 test_cases:
   - name: "IN subselect simple"
@@ -151,8 +172,346 @@ test_cases:
         - x: 4
           cnt: 1
 
+  - name: "Scalar subselect in boolean NULL-or-equals expression"
+    sql: >
+      SELECT COUNT(1) AS cnt
+      FROM doc
+      WHERE (((((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1)) IS NULL) AND ((doc.type) IS NULL))
+      OR ((doc.type) = ((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1))))
+      AND (NOT (doc.archive))
+    expect:
+      rows: 1
+      data:
+        - cnt: 1
+
+  - name: "Scalar COUNT subselect in SELECT list with outer FROM table"
+    sql: >
+      SELECT 1,
+      (SELECT COUNT(1) FROM doc
+      WHERE (((((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1)) IS NULL) AND ((doc.type) IS NULL))
+      OR ((doc.type) = ((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1))))
+      AND (NOT (doc.archive))
+      LIMIT 1) AS badgeDoc
+      FROM login WHERE ID = 1
+    expect:
+      rows: 1
+      data:
+        - badgeDoc: 1
+
+  - name: "Sibling scalar subselects in outer projection stay isolated"
+    sql: >
+      SELECT
+      (SELECT COUNT(1) FROM doc
+      WHERE (((((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1)) IS NULL) AND ((doc.type) IS NULL))
+      OR ((doc.type) = ((SELECT Tables_Doc_defaultDoctype FROM userconfig WHERE userconfig.ID = 1 LIMIT 1))))
+      AND (NOT (doc.archive))
+      LIMIT 1) AS badgeDoc,
+      (SELECT SUM(1) FROM t2 WHERE owner = 2 LIMIT 1) AS siblingCount
+      FROM login WHERE ID = 1
+    expect:
+      rows: 1
+      data:
+        - badgeDoc: 1
+          siblingCount: 2
+
+  - name: "Derived table star keeps aliases built from doubly nested scalar subselects"
+    sql: >
+      SELECT t.* FROM (
+        SELECT
+          id,
+          (SELECT file FROM doc_revision WHERE doc = doc.id ORDER BY created DESC LIMIT 1) AS file,
+          (SELECT filename FROM fop_files
+            WHERE id = (
+              SELECT file FROM doc_revision WHERE doc = doc.id ORDER BY created DESC LIMIT 1
+            )
+          ) AS filename
+        FROM doc
+      ) AS t
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          file: 1
+          filename: Basics.pdf
+        - id: 2
+          file: 3
+          filename: Angebot.pdf
+
+  - name: "Raw lowercase columns resolve on derived table aliases with uppercase fields"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_alias_src"
+      - sql: "CREATE TABLE expr32_alias_src (id INT PRIMARY KEY, kind INT)"
+      - sql: "INSERT INTO expr32_alias_src (id, kind) VALUES (1, 7), (2, NULL)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_alias_src"
+    sql: >
+      SELECT x.id, x.type
+      FROM (
+        SELECT ID AS ID, kind AS TYPE
+        FROM expr32_alias_src
+      ) AS x
+      WHERE x.id = 2
+    expect:
+      rows: 1
+      data:
+        - id: 2
+          type: null
+
+  - name: "Qualified uppercase column resolves in nested scalar subselect"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_file"
+      - sql: "CREATE TABLE expr32_ns_cmp_src (id INT PRIMARY KEY)"
+      - sql: "CREATE TABLE expr32_ns_cmp_rev (id INT PRIMARY KEY, src INT, created INT, file INT)"
+      - sql: "CREATE TABLE expr32_ns_cmp_file (id INT PRIMARY KEY, mime VARCHAR(255))"
+      - sql: "INSERT INTO expr32_ns_cmp_src (id) VALUES (2)"
+      - sql: "INSERT INTO expr32_ns_cmp_file (id, mime) VALUES (3, 'application/pdf')"
+      - sql: "INSERT INTO expr32_ns_cmp_rev (id, src, created, file) VALUES (1, 2, 2000, 3)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_cmp_file"
+    sql: >
+      SELECT
+        (((SELECT f.mime FROM expr32_ns_cmp_file f
+        WHERE f.ID = (
+          SELECT r.file FROM expr32_ns_cmp_rev r WHERE r.src = expr32_ns_cmp_src.ID ORDER BY r.created DESC LIMIT 1
+        )
+        LIMIT 1)) = ('application/pdf')) AS is_pdf
+      FROM expr32_ns_cmp_src
+      WHERE ID = 2
+    expect:
+      rows: 1
+      data:
+        - is_pdf: true
+
+  - name: "Qualified uppercase column resolves in nested scalar and sibling projection"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_file"
+      - sql: "CREATE TABLE expr32_ns_proj_src (id INT PRIMARY KEY)"
+      - sql: "CREATE TABLE expr32_ns_proj_rev (id INT PRIMARY KEY, src INT, created INT, file INT)"
+      - sql: "CREATE TABLE expr32_ns_proj_file (id INT PRIMARY KEY, filename VARCHAR(255), mime VARCHAR(255))"
+      - sql: "INSERT INTO expr32_ns_proj_src (id) VALUES (2)"
+      - sql: "INSERT INTO expr32_ns_proj_file (id, filename, mime) VALUES (3, 'sample.pdf', 'application/pdf')"
+      - sql: "INSERT INTO expr32_ns_proj_rev (id, src, created, file) VALUES (1, 2, 2000, 3)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_ns_proj_file"
+    sql: >
+      SELECT
+        (((SELECT f.mime FROM expr32_ns_proj_file f
+        WHERE f.ID = (
+          SELECT r.file FROM expr32_ns_proj_rev r WHERE r.src = expr32_ns_proj_src.ID ORDER BY r.created DESC LIMIT 1
+        )
+        LIMIT 1)) = ('application/pdf')) AS is_pdf,
+        (SELECT f.filename FROM expr32_ns_proj_file f
+        WHERE f.ID = (
+          SELECT r.file FROM expr32_ns_proj_rev r WHERE r.src = expr32_ns_proj_src.ID ORDER BY r.created DESC LIMIT 1
+        )
+        LIMIT 1) AS filename
+      FROM expr32_ns_proj_src
+      WHERE ID = 2
+    expect:
+      rows: 1
+      data:
+        - is_pdf: true
+          filename: sample.pdf
+
+  - name: "Derived join view subset keeps nested scalar file metadata"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_view_src"
+      - sql: "DROP TABLE IF EXISTS expr32_view_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_view_file"
+      - sql: "DROP TABLE IF EXISTS expr32_view_kind"
+      - sql: "CREATE TABLE expr32_view_src (ID INT PRIMARY KEY, kind INT)"
+      - sql: "CREATE TABLE expr32_view_rev (id INT PRIMARY KEY, src INT, created INT, file INT)"
+      - sql: "CREATE TABLE expr32_view_file (id INT PRIMARY KEY, filename VARCHAR(255), mime VARCHAR(255))"
+      - sql: "CREATE TABLE expr32_view_kind (ID INT PRIMARY KEY, name VARCHAR(255))"
+      - sql: "INSERT INTO expr32_view_src (ID, kind) VALUES (2, NULL)"
+      - sql: "INSERT INTO expr32_view_file (id, filename, mime) VALUES (3, 'sample.pdf', 'application/pdf')"
+      - sql: "INSERT INTO expr32_view_rev (id, src, created, file) VALUES (1, 2, 2000, 3)"
+      - sql: "INSERT INTO expr32_view_kind (ID, name) VALUES (7, 'General')"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_view_src"
+      - sql: "DROP TABLE IF EXISTS expr32_view_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_view_file"
+      - sql: "DROP TABLE IF EXISTS expr32_view_kind"
+    sql: >
+      SELECT
+        expr32_view_src.ID AS ID,
+        (SELECT r.file FROM expr32_view_rev r WHERE r.src = expr32_view_src.ID ORDER BY r.created DESC LIMIT 1) AS file,
+        (SELECT f.filename FROM expr32_view_file f
+          WHERE f.ID = (
+            SELECT r.file FROM expr32_view_rev r WHERE r.src = expr32_view_src.ID ORDER BY r.created DESC LIMIT 1
+          )
+          LIMIT 1) AS filename,
+        (((SELECT f.mime FROM expr32_view_file f
+          WHERE f.ID = (
+            SELECT r.file FROM expr32_view_rev r WHERE r.src = expr32_view_src.ID ORDER BY r.created DESC LIMIT 1
+          )
+          LIMIT 1)) = ('application/pdf')) AS `operation::60832d378812d11989e4915f`,
+        ref_type.`type:description` AS `type::description`,
+        ref_type.`type:canView` AS `type::canView`,
+        TRUE AS `operation::edit`,
+        TRUE AS `operation::view`
+      FROM expr32_view_src
+      LEFT JOIN (
+        SELECT ID AS `type:ID`, name AS `type:description`, TRUE AS `type:canView`
+        FROM expr32_view_kind
+      ) AS ref_type ON ref_type.`type:ID` = expr32_view_src.kind
+      WHERE ID = 2
+    expect:
+      rows: 1
+      data:
+        - ID: 2
+          file: 3
+          filename: sample.pdf
+          operation::60832d378812d11989e4915f: true
+          type::description: null
+          type::canView: null
+          operation::edit: true
+          operation::view: true
+
+  - name: "Wrapped derived view keeps nested scalar file metadata with inner LEFT JOIN"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_src"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_file"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_kind"
+      - sql: "CREATE TABLE expr32_wrap_src (ID INT PRIMARY KEY, kind INT, archive BOOL)"
+      - sql: "CREATE TABLE expr32_wrap_rev (id INT PRIMARY KEY, src INT, created INT, file INT)"
+      - sql: "CREATE TABLE expr32_wrap_file (id INT PRIMARY KEY, filename VARCHAR(255), mime VARCHAR(255))"
+      - sql: "CREATE TABLE expr32_wrap_kind (ID INT PRIMARY KEY, name VARCHAR(255))"
+      - sql: "INSERT INTO expr32_wrap_src (ID, kind, archive) VALUES (1, 7, FALSE), (2, NULL, FALSE)"
+      - sql: "INSERT INTO expr32_wrap_file (id, filename, mime) VALUES (100, 'one.pdf', 'application/pdf'), (101, 'two.pdf', 'application/pdf')"
+      - sql: "INSERT INTO expr32_wrap_rev (id, src, created, file) VALUES (1, 1, 1000, 100), (2, 2, 2000, 101)"
+      - sql: "INSERT INTO expr32_wrap_kind (ID, name) VALUES (7, 'General')"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_src"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_rev"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_file"
+      - sql: "DROP TABLE IF EXISTS expr32_wrap_kind"
+    sql: >
+      SELECT t.ID, t.file, t.filename, t.`operation::pdf`, t.`type::description`, t.`type::canView`
+      FROM (
+        SELECT
+          expr32_wrap_src.ID AS ID,
+          expr32_wrap_src.archive AS archive,
+          (SELECT r.file FROM expr32_wrap_rev r WHERE r.src = expr32_wrap_src.ID ORDER BY r.created DESC LIMIT 1) AS file,
+          (SELECT f.filename FROM expr32_wrap_file f
+            WHERE f.ID = (
+              SELECT r.file FROM expr32_wrap_rev r WHERE r.src = expr32_wrap_src.ID ORDER BY r.created DESC LIMIT 1
+            )
+            LIMIT 1) AS filename,
+          (((SELECT f.mime FROM expr32_wrap_file f
+            WHERE f.ID = (
+              SELECT r.file FROM expr32_wrap_rev r WHERE r.src = expr32_wrap_src.ID ORDER BY r.created DESC LIMIT 1
+            )
+            LIMIT 1)) = ('application/pdf')) AS `operation::pdf`,
+          ref_type.`type:description` AS `type::description`,
+          ref_type.`type:canView` AS `type::canView`
+        FROM expr32_wrap_src
+        LEFT JOIN (
+          SELECT ID AS `type:ID`, name AS `type:description`, TRUE AS `type:canView`
+          FROM expr32_wrap_kind
+        ) AS ref_type ON ref_type.`type:ID` = expr32_wrap_src.kind
+        WHERE TRUE
+      ) AS t
+      WHERE COALESCE(t.archive, FALSE) IN (FALSE, NULL)
+      ORDER BY t.ID
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+          file: 100
+          filename: one.pdf
+          operation::pdf: true
+          type::description: General
+          type::canView: true
+        - ID: 2
+          file: 101
+          filename: two.pdf
+          operation::pdf: true
+          type::description: null
+          type::canView: null
+
+  - name: "INSERT VALUES accepts scalar subselect in value expression"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_ins_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ins_dst"
+      - sql: "CREATE TABLE expr32_ins_src (id INT PRIMARY KEY, val INT)"
+      - sql: "CREATE TABLE expr32_ins_dst (id INT PRIMARY KEY, picked INT)"
+      - sql: "INSERT INTO expr32_ins_src (id, val) VALUES (1, 10), (2, 20)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_ins_src"
+      - sql: "DROP TABLE IF EXISTS expr32_ins_dst"
+    sql: >
+      INSERT INTO expr32_ins_dst (id, picked)
+      VALUES (1, (SELECT s.val FROM expr32_ins_src s ORDER BY s.id DESC LIMIT 1))
+    expect:
+      affected_rows: 1
+
+  - name: "No-FROM projection accepts scalar subselect alongside literal field"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_ins_src"
+      - sql: "CREATE TABLE expr32_ins_src (id INT PRIMARY KEY, val INT)"
+      - sql: "INSERT INTO expr32_ins_src (id, val) VALUES (1, 10), (2, 20)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_ins_src"
+    sql: >
+      SELECT 1 AS id,
+        (SELECT s.val FROM expr32_ins_src s ORDER BY s.id DESC LIMIT 1) AS picked
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          picked: 20
+
+  - name: "EXISTS with UNION ALL branches over outer file id in select list"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_exists_file"
+      - sql: "DROP TABLE IF EXISTS expr32_exists_refa"
+      - sql: "DROP TABLE IF EXISTS expr32_exists_refb"
+      - sql: "CREATE TABLE expr32_exists_file (id INT PRIMARY KEY, filename VARCHAR(255))"
+      - sql: "CREATE TABLE expr32_exists_refa (id INT PRIMARY KEY, file INT)"
+      - sql: "CREATE TABLE expr32_exists_refb (id INT PRIMARY KEY, file INT)"
+      - sql: "INSERT INTO expr32_exists_file (id, filename) VALUES (3, 'offer.pdf'), (4, 'other.pdf')"
+      - sql: "INSERT INTO expr32_exists_refa (id, file) VALUES (1, 3)"
+      - sql: "INSERT INTO expr32_exists_refb (id, file) VALUES (1, 4)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_exists_file"
+      - sql: "DROP TABLE IF EXISTS expr32_exists_refa"
+      - sql: "DROP TABLE IF EXISTS expr32_exists_refb"
+    sql: >
+      SELECT f.id, f.filename, EXISTS (
+        SELECT a.id FROM expr32_exists_refa a WHERE a.file = f.id
+        UNION ALL
+        SELECT b.id FROM expr32_exists_refb b WHERE b.file = f.id
+      ) AS can_view
+      FROM expr32_exists_file f
+      ORDER BY f.id
+    expect:
+      rows: 2
+      data:
+        - id: 3
+          filename: offer.pdf
+          can_view: true
+        - id: 4
+          filename: other.pdf
+          can_view: true
+
   - name: "Scalar subselect multiple rows errors"
     sql: "SELECT (SELECT val FROM t2 WHERE owner = 2) AS v"
+    expect:
+      error: true
+
+  - name: "Correlated scalar subselect multiple rows errors"
+    sql: "SELECT (SELECT val FROM t2 WHERE owner = t1.id) AS v FROM (SELECT 2 AS id) AS t1"
     expect:
       error: true
 
@@ -190,6 +549,11 @@ test_cases:
         - id: 4
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS userconfig"
+  - sql: "DROP TABLE IF EXISTS login"
+  - sql: "DROP TABLE IF EXISTS fop_files"
+  - sql: "DROP TABLE IF EXISTS doc_revision"
+  - sql: "DROP TABLE IF EXISTS doc"
   - sql: "DROP TABLE IF EXISTS t4"
   - sql: "DROP TABLE IF EXISTS t3"
   - sql: "DROP TABLE IF EXISTS t2"


### PR DESCRIPTION
## What\n- route correlated scalar subselects through the existing scalar-subselect path\n- fix the correlated multirow test so it actually exercises the runtime error path\n\n## Why\nThe current flattening path for correlated non-aggregate scalar subselects loses scalar semantics in nested cases. This workaround restores correct behavior for the failing expr subselect cases and the ERP reproducer while a clean workaround-free unnesting implementation is prepared separately.\n\n## Validation\n- python3 run_sql_tests.py tests/32_expr_subselects.yaml\n- ERP workload against the workaround instance, including the critical doubly nested DMS upload path\n\n## Note\nFull pre-commit/make test was intentionally skipped for this branch update on request (no-verify).