### PR TITLE
fix: close planner and MySQL compatibility gaps

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -793,44 +793,43 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 								(define _sq_hash (fnv_hash (concat tables2 "|" fields2 "|" condition2)))
 								(define _sq_acc_name (concat "accsess_" _sq_hash))
 								(define _sq_rr_name  (concat "__scalar_resultrow_" _sq_hash))
-								/* dedup: if identical subquery already generated, reuse its accumulator */
-								(if (not (nil? (sq_cache _sq_hash)))
-									(sq_cache _sq_hash)
-									/* first occurrence: generate full setup+subplan */
-									(begin
-										(define replace_resultrow (lambda (expr) (match expr
-											(cons sym args) (if (equal? sym (quote resultrow))
-												(cons (symbol _sq_rr_name) (map args replace_resultrow))
-												(if (and (equal? sym (quote symbol)) (equal? args '("resultrow")))
-													(list (quote symbol) _sq_rr_name)
-													(cons (replace_resultrow sym) (map args replace_resultrow))
-												)
+								/*
+								* Do not reuse the naked accumulator read expression for identical scalar subqueries.
+								* In projection+aggregate pipelines the cached `accsess_*` read can be emitted
+								* without the local `!begin` that initializes the session, which breaks at runtime.
+								* Keeping the full setup per occurrence is slower but preserves correctness.
+								*/
+								(begin
+									(define replace_resultrow (lambda (expr) (match expr
+										(cons sym args) (if (equal? sym (quote resultrow))
+											(cons (symbol _sq_rr_name) (map args replace_resultrow))
+											(if (and (equal? sym (quote symbol)) (equal? args '("resultrow")))
+												(list (quote symbol) _sq_rr_name)
+												(cons (replace_resultrow sym) (map args replace_resultrow))
 											)
-											expr
-										)))
-										(define subplan (replace_resultrow (build_queryplan schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column_subselect)))
-										/* cache the read expression so duplicate subqueries skip the subplan */
-										(sq_cache _sq_hash (list (quote if) (list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral) nil (list (symbol _sq_acc_name) "acc")))
-										(list (quote !begin)
-											(list (quote set) (symbol _sq_acc_name) (list (quote newsession)))
-											(list (symbol _sq_acc_name) "acc" scalar_neutral)
-											(list (quote set) (symbol _sq_rr_name)
-												(list (quote lambda) (list (symbol "row"))
-													(list (quote begin)
-														(list (symbol _sq_acc_name) "acc"
-															(list scalar_reduce
-																(list (symbol _sq_acc_name) "acc")
-																(list (quote nth) (symbol "row") 1)))
-														true
-													)
-												)
-											)
-											subplan
-											(list (quote if)
-												(list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral)
-												nil
-												(list (symbol _sq_acc_name) "acc"))
 										)
+										expr
+									)))
+									(define subplan (replace_resultrow (build_queryplan schema2 tables2 fields2 condition2 groups2 schemas2 replace_find_column_subselect)))
+									(list (quote !begin)
+										(list (quote set) (symbol _sq_acc_name) (list (quote newsession)))
+										(list (symbol _sq_acc_name) "acc" scalar_neutral)
+										(list (quote set) (symbol _sq_rr_name)
+											(list (quote lambda) (list (symbol "row"))
+												(list (quote begin)
+													(list (symbol _sq_acc_name) "acc"
+														(list scalar_reduce
+															(list (symbol _sq_acc_name) "acc")
+															(list (quote nth) (symbol "row") 1)))
+													true
+												)
+											)
+										)
+										subplan
+										(list (quote if)
+											(list (quote equal?) (list (symbol _sq_acc_name) "acc") scalar_neutral)
+											nil
+											(list (symbol _sq_acc_name) "acc"))
 									)
 								)
 							)
@@ -1468,10 +1467,17 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 				'((symbol strlike) a b c) (begin
 					(define default_collation "utf8mb4_general_ci")
 					(define find_column_collation (lambda (tblalias colname) (begin
-						(define cols (schemas tblalias))
-						(define coldef (reduce cols (lambda (a coldef)
-							(if (or a (equal?? (coldef "Field") colname)) a coldef)
-						) nil))
+						(define tblalias_str (if (string? tblalias) tblalias (string tblalias)))
+						(define alias_lookup
+							(coalesce
+								(if (has_assoc? schemas tblalias_str) tblalias_str nil)
+								nil))
+						(define cols (if (nil? alias_lookup) nil (schemas alias_lookup)))
+						(define coldef (if (list? cols)
+							(reduce cols (lambda (a coldef)
+								(if (or a (equal?? (coldef "Field") colname)) a coldef)
+							) nil)
+							nil))
 						(coalesce (and coldef (coldef "Collation")) default_collation)
 					)))
 					(match a
@@ -1833,7 +1839,10 @@ e.g. ORDER BY SUM(amount) works even if SUM(amount) only appears in ORDER BY.
 								'()))))
 
 						(define agg_plans (map ags (lambda (ag) (match ag '(expr reduce neutral) (begin
-							(set cols (extract_columns_for_tblvar tblvar expr))
+							(set cols (merge_unique (list
+								(extract_columns_for_tblvar tblvar expr)
+								(extract_outer_columns_for_tblvar tblvar expr)
+							)))
 							/* COUNT column itself must not filter by itself (circular); all others filter by COUNT>0 */
 							(define this_options (if (and needs_count (equal? (agg_col_name ag) count_col_name)) '(list "temp" true) createcol_options))
 							'((quote createcolumn) schema grouptbl (agg_col_name ag) "any" '(list) this_options

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1357,21 +1357,49 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			/* TODO: ignorecase */
 			(define updaterows (+ (parser '((define col sql_identifier) (atom "=" false) (define value sql_expression)) '(col value)) ","))
 		) updaterows)))
+		) (begin
+				/* policy: write access check */
+				(if policy (policy (coalesce schema2 schema) tbl true) true)
+				(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
+				(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
+				(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+				(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
+					(begin
+						(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
+						(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
+					'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
+						(if (and ignoreexists (nil? updaterows))
+							'((quote lambda) '() 0)
+							(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
+						false '('lambda '('id) '('session "last_insert_id" 'id))))
+	)))
+
+	(define sql_insert_values_select (parser '(
+		(atom "INSERT" true)
+		(define ignoreexists (? (atom "IGNORE" true true true)))
+		(atom "INTO" true)
+		(? (define schema2 sql_identifier) ".")
+		(define tbl sql_identifier) /* TODO: ignorecase */
+		(? "("
+			(define coldesc (*
+				sql_identifier
+				","))
+			")")
+		(atom "VALUES" true)
+		(define inner sql_select)
+		(define updaterows (? (parser '(
+			(atom "ON" true)
+			(atom "DUPLICATE" true)
+			(atom "KEY" true)
+			(atom "UPDATE" true)
+			(define updaterows (+ (parser '((define col sql_identifier) (atom "=" false) (define value sql_expression)) '(col value)) ","))
+		) updaterows)))
 	) (begin
-			/* policy: write access check */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
-			(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
-				(begin
-					(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
-					(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
-				'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
-					(if (and ignoreexists (nil? updaterows))
-						'((quote lambda) '() 0)
-						(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
-					false '('lambda '('id) '('session "last_insert_id" 'id))))
+			(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols)
 	)))
 
 	(define sql_insert_select (parser '(
@@ -1534,10 +1562,11 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	/* TODO: ignore comments wherever they occur --> Lexer */
 	(define p (parser (or
 		(parser (atom "SHUTDOWN" true) (begin (if policy (policy "system" true true) true) '(shutdown)))
-		(parser (define query sql_select) (build_queryplan_term query))
-		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
-		sql_insert_into
-		sql_insert_select
+			(parser (define query sql_select) (build_queryplan_term query))
+			(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
+			sql_insert_values_select
+			sql_insert_into
+			sql_insert_select
 		sql_create_table
 		sql_alter_table
 		sql_update

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -213,6 +213,42 @@ type ErrorWrapper string
 func (s ErrorWrapper) Error() string {
 	return string(s)
 }
+
+func updateMySQLFieldMetadata(field *querypb.Field, val sqltypes.Value) {
+	field.Type = val.Type()
+	switch val.Type() {
+	case querypb.Type_TEXT, querypb.Type_VARCHAR, querypb.Type_CHAR, querypb.Type_BLOB:
+		field.Charset = 45 // utf8mb4_general_ci
+	default:
+		field.Charset = 0
+	}
+}
+
+func appendMySQLResultRow(result *sqltypes.Result, colmap map[string]int, item []Scmer) []sqltypes.Value {
+	newitem := make([]sqltypes.Value, len(result.Fields))
+	for i := 0; i < len(item)-1; i += 2 {
+		val := ScmerToMySQL(item[i+1])
+
+		colname := item[i].String()
+		colid, ok := colmap[colname]
+		if ok {
+			duplicateAliasInRow := colid < len(newitem) && !newitem[colid].IsNull()
+			newitem[colid] = val
+			if duplicateAliasInRow || result.Fields[colid].Type == querypb.Type_NULL_TYPE {
+				updateMySQLFieldMetadata(result.Fields[colid], val)
+			}
+		} else {
+			colmap[colname] = len(result.Fields)
+			newcol := new(querypb.Field)
+			newcol.Name = colname
+			updateMySQLFieldMetadata(newcol, val)
+			result.Fields = append(result.Fields, newcol)
+			newitem = append(newitem, val)
+		}
+	}
+	return newitem
+}
+
 func isSelectQuery(query string) bool {
 	trimmed := strings.TrimSpace(query)
 	for {
@@ -306,30 +342,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			defer resultlock.Unlock()
 			updateFlags(session, sessionFunc) // set transaction status
 
-			newitem := make([]sqltypes.Value, len(result.Fields))
-			for i := 0; i < len(item)-1; i += 2 {
-				val := ScmerToMySQL(item[i+1])
-
-				colname := item[i].String()
-				colid, ok := colmap[colname]
-				if ok {
-					newitem[colid] = val
-					if result.Fields[colid].Type == querypb.Type_NULL_TYPE {
-						result.Fields[colid].Type = val.Type()
-					}
-				} else {
-					// add row to result
-					colmap[colname] = len(result.Fields)
-					newcol := new(querypb.Field)
-					newcol.Name = colname
-					newcol.Type = val.Type()
-					if val.Type() == querypb.Type_TEXT || val.Type() == querypb.Type_VARCHAR || val.Type() == querypb.Type_CHAR || val.Type() == querypb.Type_BLOB {
-						newcol.Charset = 45 // utf8mb4_general_ci
-					}
-					result.Fields = append(result.Fields, newcol)
-					newitem = append(newitem, val)
-				}
-			}
+			newitem := appendMySQLResultRow(&result, colmap, item)
 			if len(result.Rows) == cap(result.Rows) {
 				// flush
 				callback(&result)

--- a/scm/mysql_test.go
+++ b/scm/mysql_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2023-2026  Carl-Philip Hänsch
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"testing"
+
+	querypb "github.com/launix-de/go-mysqlstack/sqlparser/depends/query"
+	"github.com/launix-de/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+func TestAppendMySQLResultRowDuplicateAliasUsesLastValueType(t *testing.T) {
+	result := sqltypes.Result{}
+	colmap := map[string]int{}
+
+	row := appendMySQLResultRow(&result, colmap, []Scmer{
+		NewString("x"), NewInt(1),
+		NewString("x"), NewString("EUR"),
+	})
+
+	if len(result.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(result.Fields))
+	}
+	if result.Fields[0].Type != querypb.Type_VARCHAR {
+		t.Fatalf("expected varchar metadata, got %v", result.Fields[0].Type)
+	}
+	if result.Fields[0].Charset != 45 {
+		t.Fatalf("expected utf8mb4 charset, got %d", result.Fields[0].Charset)
+	}
+	if got := row[0].ToString(); got != "EUR" {
+		t.Fatalf("expected last duplicate value, got %q", got)
+	}
+}

--- a/storage/compute_concurrency_test.go
+++ b/storage/compute_concurrency_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jtolds/gls"
+	"github.com/launix-de/memcp/scm"
+)
+
+func setupComputeConcurrencyTest(t *testing.T) func() {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "memcp-compute-concurrency-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBasepath := Basepath
+	Basepath = dir
+	Init(scm.Globalenv)
+	LoadDatabases()
+	return func() {
+		databases.Remove("compconc")
+		Basepath = oldBasepath
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func countCollapsedComputor() scm.Scmer {
+	filter := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("uid"),
+			scm.NewSymbol("form"),
+			scm.NewSymbol("subid"),
+			scm.NewSymbol("k"),
+		}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("and"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal??"), scm.NewNthLocalVar(0), scm.NewNil()}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal??"), scm.NewNthLocalVar(1), scm.NewString("wf:userconfig:edit")}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal??"), scm.NewNthLocalVar(2), scm.NewString("Offers")}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal??"), scm.NewNthLocalVar(3), scm.NewString("collapsed")}),
+		}),
+		En:      &scm.Globalenv,
+		NumVars: 4,
+	})
+	mapFn := scm.NewProcStruct(scm.Proc{
+		Params:  scm.NewSlice([]scm.Scmer{}),
+		Body:    scm.NewInt(1),
+		En:      &scm.Globalenv,
+		NumVars: 0,
+	})
+	return scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("group")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("scan"),
+			scm.NewString("compconc"),
+			scm.NewString("feature"),
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("list"),
+				scm.NewString("uid"),
+				scm.NewString("form"),
+				scm.NewString("subid"),
+				scm.NewString("k"),
+			}),
+			filter,
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("list")}),
+			mapFn,
+			scm.NewSymbol("+"),
+			scm.NewInt(0),
+			scm.NewNil(),
+			scm.NewBool(false),
+		}),
+		En:      &scm.Globalenv,
+		NumVars: 1,
+	})
+}
+
+func TestGlobalAggregateComputeAndInsertDoNotDeadlock(t *testing.T) {
+	defer setupComputeConcurrencyTest(t)()
+
+	CreateDatabase("compconc", false)
+	src, _ := CreateTable("compconc", "feature", Memory, false)
+	src.CreateColumn("uid", "INT", nil, nil)
+	src.CreateColumn("form", "TEXT", nil, nil)
+	src.CreateColumn("subid", "TEXT", nil, nil)
+	src.CreateColumn("k", "TEXT", nil, nil)
+	src.CreateColumn("value", "TEXT", nil, nil)
+
+	keytable, _ := CreateTable("compconc", ".feature:(1)", Memory, true)
+	keytable.CreateColumn("1", "ANY", nil, nil)
+	keytable.CreateColumn("counted", "ANY", nil, nil)
+	keytable.Insert([]string{"1"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+
+	computor := countCollapsedComputor()
+	keytable.ComputeColumn("counted", []string{"1"}, computor, nil, scm.NewNil())
+
+	row := []scm.Scmer{
+		scm.NewNil(),
+		scm.NewString("wf:userconfig:edit"),
+		scm.NewString("Offers"),
+		scm.NewString("collapsed"),
+		scm.NewString("0"),
+	}
+
+	const computeWorkers = 4
+	const insertWorkers = 4
+	const iterations = 25
+
+	errCh := make(chan error, computeWorkers+insertWorkers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for worker := 0; worker < computeWorkers; worker++ {
+		wg.Add(1)
+		gls.Go(func(worker int) func() {
+			return func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						errCh <- fmt.Errorf("compute worker %d panic: %v", worker, r)
+					}
+				}()
+				<-start
+				for iter := 0; iter < iterations; iter++ {
+					keytable.ComputeColumn("counted", []string{"1"}, computor, nil, scm.NewNil())
+				}
+			}
+		}(worker))
+	}
+
+	for worker := 0; worker < insertWorkers; worker++ {
+		wg.Add(1)
+		gls.Go(func(worker int) func() {
+			return func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						errCh <- fmt.Errorf("insert worker %d panic: %v", worker, r)
+					}
+				}()
+				<-start
+				for iter := 0; iter < iterations; iter++ {
+					src.Insert([]string{"uid", "form", "subid", "k", "value"}, [][]scm.Scmer{row}, nil, scm.NewNil(), false, nil)
+				}
+			}
+		}(worker))
+	}
+
+	close(start)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent global aggregate recompute and insert timed out")
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}

--- a/storage/index.go
+++ b/storage/index.go
@@ -561,7 +561,12 @@ start_scan:
 		return
 	}
 	snapMainIndexes := s.mainIndexes
-	snapDeltaBtree := s.deltaBtree
+	var snapDeltaBtree *btree.BTreeG[indexPair]
+	if s.deltaBtree != nil {
+		// Clone under the index lock so scans can iterate a stable delta snapshot
+		// while concurrent inserts keep mutating the live tree.
+		snapDeltaBtree = s.deltaBtree.Clone()
+	}
 	isNative := s.Native
 	s.mu.Unlock()
 

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -307,6 +307,16 @@ func (u *storageShard) getColumnStorageOrPanicEx(colName string, alreadyLocked b
 	if alreadyLocked {
 		cs, present := u.columns[colName]
 		if !present {
+			// Shards can lag behind table schema changes (for example when a
+			// column was added after the shard was created and the old shard was
+			// later reloaded from disk). Mirror the fallback from the unlocked
+			// path so scans can still proceed under the shard write lock.
+			for _, c := range u.t.Columns {
+				if c.Name == colName {
+					u.columns[colName] = new(StorageSparse)
+					return u.columns[colName]
+				}
+			}
 			panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
 		}
 		if cs != nil {
@@ -1395,14 +1405,42 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 	if t.t.tableLockOwner.Load() != nil {
 		t.t.waitTableLock(scm.GetCurrentSessionState(), true)
 	}
-	// Execute BEFORE INSERT triggers (can modify values; isIgnore skips failing rows)
-	if len(t.t.Triggers) > 0 {
-		columns, values = t.t.ExecuteBeforeInsertTriggers(columns, values, isIgnore)
-		if len(values) == 0 {
-			return // all rows skipped by triggers
+	beforeInsertTriggers := t.t.GetTriggers(BeforeInsert)
+	if len(beforeInsertTriggers) > 0 {
+		preparedColumns := make([][]string, 0, len(values))
+		preparedRows := make([][]scm.Scmer, 0, len(values))
+		for _, row := range values {
+			rowColumns, preparedRow, ok := t.t.executeBeforeInsertTriggerRow(columns, row, isIgnore)
+			if !ok {
+				continue
+			}
+			sanitized := t.t.sanitizeInsertRows(rowColumns, [][]scm.Scmer{preparedRow}, isIgnore)
+			if len(sanitized) == 0 {
+				continue
+			}
+			preparedColumns = append(preparedColumns, rowColumns)
+			preparedRows = append(preparedRows, sanitized[0])
 		}
+		if len(preparedRows) == 0 {
+			return
+		}
+		if !alreadyLocked {
+			t.mu.Lock()
+		}
+		firstInsertId := onFirstInsertId
+		for i, row := range preparedRows {
+			t.insertPreparedLocked(preparedColumns[i], [][]scm.Scmer{row}, firstInsertId)
+			if firstInsertId != nil {
+				firstInsertId = nil
+			}
+		}
+		if !alreadyLocked {
+			t.mu.Unlock()
+		}
+		return
 	}
-	// Re-apply sanitizers after BEFORE INSERT trigger mutations.
+
+	// Re-apply sanitizers after trigger-free INSERT input preparation.
 	values = t.t.sanitizeInsertRows(columns, values, isIgnore)
 	if len(values) == 0 {
 		return // all rows skipped by sanitizer in INSERT IGNORE mode
@@ -1411,6 +1449,13 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 	if !alreadyLocked {
 		t.mu.Lock()
 	}
+	t.insertPreparedLocked(columns, values, onFirstInsertId)
+	if !alreadyLocked {
+		t.mu.Unlock()
+	}
+}
+
+func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scmer, onFirstInsertId func(int64)) {
 	// capture starting row index for undo logging
 	firstNewRecid := t.main_count + uint32(len(t.inserts))
 	firstNewInsertIdx := len(t.inserts) // for capturing actual rows after insertDataset fills auto-increment
@@ -1453,9 +1498,6 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 		// also insert into next storage
 		t.next.Insert(columns, values, false, nil, false)
 	}
-	if !alreadyLocked {
-		t.mu.Unlock()
-	}
 	// transaction bookkeeping
 	if tx := CurrentTx(); tx != nil {
 		switch tx.Mode {
@@ -1477,11 +1519,17 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 	} else if t.t.PersistencyMode == Safe && t.logfile != nil {
 		t.logfile.Sync() // write barrier; no tx means immediate sync
 	}
-	// execute AFTER INSERT triggers
+	// execute AFTER INSERT triggers outside the shard write lock, matching the
+	// AFTER UPDATE/DELETE paths and avoiding lock inversion with computed-column
+	// invalidation on shared keytables.
 	if len(t.t.Triggers) > 0 {
-		for _, row := range triggerInsertRows {
-			t.t.ExecuteTriggers(AfterInsert, nil, row)
-		}
+		func() {
+			t.mu.Unlock()
+			defer t.mu.Lock()
+			for _, row := range triggerInsertRows {
+				t.t.ExecuteTriggers(AfterInsert, nil, row)
+			}
+		}()
 	}
 }
 

--- a/storage/shard_missing_column_test.go
+++ b/storage/shard_missing_column_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "testing"
+
+func TestGetColumnStorageOrPanicExAddsSchemaColumnWhenLocked(t *testing.T) {
+	db := &database{Name: "system"}
+	tbl := &table{
+		schema:          db,
+		Name:            "access",
+		PersistencyMode: Memory,
+		Columns: []*column{
+			{Name: "username"},
+			{Name: "database"},
+		},
+	}
+	shard := &storageShard{
+		t:            tbl,
+		columns:      map[string]ColumnStorage{"username": new(StorageSparse)},
+		deltaColumns: make(map[string]int),
+		writeOwners:  make(map[uint64]uint32),
+	}
+
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	col := shard.getColumnStorageOrPanicEx("database", true)
+	if col == nil {
+		t.Fatal("expected sparse storage for schema column missing from shard map")
+	}
+	if _, ok := col.(*StorageSparse); !ok {
+		t.Fatalf("expected *StorageSparse, got %T", col)
+	}
+	if _, ok := shard.columns["database"]; !ok {
+		t.Fatal("expected column to be inserted into shard map")
+	}
+}

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -210,6 +210,40 @@ func (t *table) dictToRow(dict scm.Scmer, columns []string) dataset {
 	return row
 }
 
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *table) beforeInsertOutputColumns(dict scm.Scmer, columns []string) []string {
+	result := make([]string, 0, len(t.Columns))
+	seen := make(map[string]struct{}, len(columns))
+	for _, col := range columns {
+		result = append(result, col)
+		seen[col] = struct{}{}
+	}
+	if !dict.IsFastDict() {
+		return result
+	}
+	fd := dict.FastDict()
+	for _, col := range t.Columns {
+		if _, ok := seen[col.Name]; ok {
+			continue
+		}
+		if _, ok := fd.Get(scm.NewString(col.Name)); ok {
+			result = append(result, col.Name)
+		}
+	}
+	return result
+}
+
 // ExecuteTriggers executes all triggers for a specific timing (AFTER triggers).
 // oldRow is nil for INSERT, newRow is nil for DELETE.
 // If a transaction is active, a savepoint is created before each trigger;
@@ -304,91 +338,117 @@ func (t *table) ExecuteTableLifecycleTriggers(timing TriggerTiming) {
 
 // ExecuteBeforeInsertTriggers executes BEFORE INSERT triggers and returns modified rows.
 // The trigger function can modify NEW values by returning a modified dict, including
-// columns not present in the original INSERT. The returned columns slice is expanded to
-// ALL table columns so trigger-set values are not discarded.
+// columns not present in the original INSERT.
 // When isIgnore is true, rows whose triggers panic are silently skipped
 // and any partial transaction effects are rolled back via savepoints.
 // When isIgnore is false, trigger panics propagate to the caller.
+func (t *table) executeBeforeInsertTriggerRow(columns []string, row dataset, isIgnore bool) ([]string, dataset, bool) {
+	triggers := t.GetTriggers(BeforeInsert)
+	if len(triggers) == 0 {
+		return columns, row, true
+	}
+
+	// Build dict using the columns that are being inserted.
+	newDict := t.rowToDictWithColumns(row, columns)
+	triggerOk := true
+	for _, tr := range triggers {
+		if tr.Func.IsNil() {
+			continue
+		}
+		if isIgnore {
+			// Per-row savepoint + panic recovery for INSERT IGNORE.
+			func() {
+				tx := CurrentTx()
+				var sp Savepoint
+				hasSavepoint := false
+				if tx != nil {
+					sp = tx.CreateSavepoint()
+					hasSavepoint = true
+				}
+				defer func() {
+					if r := recover(); r != nil {
+						if hasSavepoint {
+							tx.RollbackToSavepoint(sp)
+						}
+						triggerOk = false
+					}
+				}()
+				returned := scm.Apply(tr.Func, scm.NewNil(), newDict)
+				if !returned.IsNil() && returned.IsFastDict() {
+					newDict = returned
+				}
+			}()
+			if !triggerOk {
+				break
+			}
+		} else {
+			// Normal mode: savepoint for proper rollback on propagated panic.
+			func() {
+				tx := CurrentTx()
+				var sp Savepoint
+				hasSavepoint := false
+				if tx != nil {
+					sp = tx.CreateSavepoint()
+					hasSavepoint = true
+				}
+				defer func() {
+					if r := recover(); r != nil {
+						if hasSavepoint {
+							tx.RollbackToSavepoint(sp)
+						}
+						panic(fmt.Sprintf("trigger %s (BEFORE INSERT) on %s failed: %v", tr.Name, t.Name, r))
+					}
+				}()
+				returned := scm.Apply(tr.Func, scm.NewNil(), newDict)
+				if !returned.IsNil() && returned.IsFastDict() {
+					newDict = returned
+				}
+			}()
+		}
+	}
+	if !triggerOk {
+		return nil, nil, false
+	}
+	rowColumns := t.beforeInsertOutputColumns(newDict, columns)
+	return rowColumns, t.dictToRow(newDict, rowColumns), true
+}
+
 func (t *table) ExecuteBeforeInsertTriggers(columns []string, values [][]scm.Scmer, isIgnore bool) ([]string, [][]scm.Scmer) {
 	triggers := t.GetTriggers(BeforeInsert)
 	if len(triggers) == 0 {
 		return columns, values
 	}
 
-	// Expand output to all table columns so trigger-set columns are preserved.
-	allColumns := make([]string, len(t.Columns))
-	for i, col := range t.Columns {
-		allColumns[i] = col.Name
-	}
-
+	resultColumns := append([]string(nil), columns...)
+	rowColumns := make([][]string, 0, len(values))
 	result := make([][]scm.Scmer, 0, len(values))
 	for _, row := range values {
-		// Build dict using the columns that are being inserted
-		newDict := t.rowToDictWithColumns(row, columns)
-		triggerOk := true
-		// Execute all BEFORE INSERT triggers, each can modify NEW
-		for _, tr := range triggers {
-			if tr.Func.IsNil() {
-				continue
-			}
-			if isIgnore {
-				// Per-row savepoint + panic recovery for INSERT IGNORE
-				func() {
-					tx := CurrentTx()
-					var sp Savepoint
-					hasSavepoint := false
-					if tx != nil {
-						sp = tx.CreateSavepoint()
-						hasSavepoint = true
-					}
-					defer func() {
-						if r := recover(); r != nil {
-							if hasSavepoint {
-								tx.RollbackToSavepoint(sp)
-							}
-							triggerOk = false
-						}
-					}()
-					returned := scm.Apply(tr.Func, scm.NewNil(), newDict)
-					if !returned.IsNil() && returned.IsFastDict() {
-						newDict = returned
-					}
-				}()
-				if !triggerOk {
-					break
-				}
-			} else {
-				// Normal mode: savepoint for proper rollback on propagated panic
-				func() {
-					tx := CurrentTx()
-					var sp Savepoint
-					hasSavepoint := false
-					if tx != nil {
-						sp = tx.CreateSavepoint()
-						hasSavepoint = true
-					}
-					defer func() {
-						if r := recover(); r != nil {
-							if hasSavepoint {
-								tx.RollbackToSavepoint(sp)
-							}
-							panic(fmt.Sprintf("trigger %s (BEFORE INSERT) on %s failed: %v", tr.Name, t.Name, r))
-						}
-					}()
-					returned := scm.Apply(tr.Func, scm.NewNil(), newDict)
-					if !returned.IsNil() && returned.IsFastDict() {
-						newDict = returned
-					}
-				}()
-			}
+		newColumns, newRow, ok := t.executeBeforeInsertTriggerRow(columns, row, isIgnore)
+		if !ok {
+			continue
 		}
-		if triggerOk {
-			// Convert modified dict back to row using ALL table columns
-			// so trigger-set values on columns not in the INSERT are preserved.
-			result = append(result, t.dictToRow(newDict, allColumns))
+		if len(result) == 0 {
+			resultColumns = append([]string(nil), newColumns...)
+		}
+		rowColumns = append(rowColumns, newColumns)
+		result = append(result, newRow)
+	}
+	if len(result) == 0 {
+		return resultColumns, result
+	}
+	for _, cols := range rowColumns[1:] {
+		if !stringSlicesEqual(resultColumns, cols) {
+			allColumns := make([]string, len(t.Columns))
+			for i, col := range t.Columns {
+				allColumns[i] = col.Name
+			}
+			for i, row := range result {
+				result[i] = t.dictToRow(t.rowToDictWithColumns(row, rowColumns[i]), allColumns)
+			}
+			return allColumns, result
 		}
 	}
-	return allColumns, result
+	return resultColumns, result
 }
 
 // ExecuteBeforeUpdateTriggers executes BEFORE UPDATE triggers.

--- a/tests/17_strings_like.yaml
+++ b/tests/17_strings_like.yaml
@@ -70,6 +70,26 @@ test_cases:
       data:
         - r: false
 
+  - name: "Qualified LIKE left-hand side"
+    sql: |
+      CREATE TABLE like_qualified (id INT PRIMARY KEY, txt VARCHAR(50))
+    expect:
+      affected_rows: 1
+
+  - name: "Qualified LIKE left-hand side insert"
+    sql: |
+      INSERT INTO like_qualified (id, txt) VALUES (1, 'alpha'), (2, 'beta')
+    expect:
+      affected_rows: 2
+
+  - name: "Qualified LIKE left-hand side filter"
+    sql: |
+      SELECT id FROM like_qualified WHERE like_qualified.txt LIKE 'a%' ORDER BY id
+    expect:
+      rows: 1
+      data:
+        - id: 1
+
   # --- NOT LIKE ---
   - name: "Create NOT LIKE test table"
     sql: "CREATE TABLE notlike_test (id INT PRIMARY KEY, name VARCHAR(50))"
@@ -100,4 +120,5 @@ test_cases:
         - id: 7
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS like_qualified"
   - sql: "DROP TABLE IF EXISTS notlike_test"

--- a/tests/32_expr_subselects.yaml
+++ b/tests/32_expr_subselects.yaml
@@ -505,6 +505,34 @@ test_cases:
           filename: other.pdf
           can_view: true
 
+  - name: "Aggregate over correlated scalar subselect keeps outer reference inputs"
+    setup:
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_currency"
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_offer"
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_offer_element"
+      - sql: "CREATE TABLE expr32_scalar_currency (id INT PRIMARY KEY, wkz VARCHAR(10))"
+      - sql: "CREATE TABLE expr32_scalar_offer (id INT PRIMARY KEY, waehrung INT)"
+      - sql: "CREATE TABLE expr32_scalar_offer_element (id INT PRIMARY KEY, angebot INT, einzelpreis INT, menge INT)"
+      - sql: "INSERT INTO expr32_scalar_currency (id, wkz) VALUES (1, 'EUR')"
+      - sql: "INSERT INTO expr32_scalar_offer (id, waehrung) VALUES (1, 1)"
+      - sql: "INSERT INTO expr32_scalar_offer_element (id, angebot, einzelpreis, menge) VALUES (1, 1, 10, 2)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_offer_element"
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_offer"
+      - sql: "DROP TABLE IF EXISTS expr32_scalar_currency"
+    sql: >
+      SELECT MAX((
+        SELECT c.wkz FROM expr32_scalar_currency c
+        WHERE c.id = (SELECT o.waehrung FROM expr32_scalar_offer o WHERE o.id = oe.angebot LIMIT 1)
+        LIMIT 1
+      )) AS unit2
+      FROM expr32_scalar_offer_element oe
+      WHERE oe.angebot = 1
+    expect:
+      rows: 1
+      data:
+        - unit2: EUR
+
   - name: "Scalar subselect multiple rows errors"
     sql: "SELECT (SELECT val FROM t2 WHERE owner = 2) AS v"
     expect:

--- a/tests/37_triggers.yaml
+++ b/tests/37_triggers.yaml
@@ -11,6 +11,8 @@ cleanup:
     sql: "DROP TABLE IF EXISTS trigger_test"
   - action: "Clean up log table"
     sql: "DROP TABLE IF EXISTS trigger_log"
+  - action: "Clean up auto increment trigger table"
+    sql: "DROP TABLE IF EXISTS trigger_auto_bi"
 
 setup:
   - action: "Create test table"
@@ -117,6 +119,40 @@ test_cases:
 
   - name: "DROP expression trigger"
     sql: "DROP TRIGGER calc_trigger"
+    expect:
+      affected_rows: 0
+
+  - name: "Create AUTO_INCREMENT table for BEFORE INSERT trigger"
+    sql: "CREATE TABLE trigger_auto_bi (id INT AUTO_INCREMENT PRIMARY KEY, val INT, name VARCHAR(50))"
+    expect:
+      affected_rows: 0
+
+  - name: "CREATE BEFORE INSERT trigger on AUTO_INCREMENT table"
+    sql: "CREATE TRIGGER trigger_auto_bi_before BEFORE INSERT ON trigger_auto_bi FOR EACH ROW SET NEW.val = COALESCE(NEW.val, 123)"
+    expect:
+      affected_rows: 0
+
+  - name: "INSERT without explicit id keeps AUTO_INCREMENT under BEFORE INSERT trigger"
+    sql: "INSERT INTO trigger_auto_bi (name) VALUES ('auto_before_insert')"
+    expect:
+      affected_rows: 1
+
+  - name: "Verify BEFORE INSERT trigger did not NULL out AUTO_INCREMENT id"
+    sql: "SELECT id, val, name FROM trigger_auto_bi"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          val: 123
+          name: "auto_before_insert"
+
+  - name: "DROP AUTO_INCREMENT BEFORE INSERT trigger"
+    sql: "DROP TRIGGER IF EXISTS trigger_auto_bi_before"
+    expect:
+      affected_rows: 0
+
+  - name: "Drop AUTO_INCREMENT trigger table"
+    sql: "DROP TABLE IF EXISTS trigger_auto_bi"
     expect:
       affected_rows: 0
 

--- a/tests/43_dbcheck_ddl_compat.yaml
+++ b/tests/43_dbcheck_ddl_compat.yaml
@@ -107,6 +107,10 @@ test_cases:
     sql: "INSERT IGNORE INTO dbc_t (id, name, email, status, active) SELECT id+100, name, CONCAT(name, '@copy.com'), status, active FROM dbc_t"
     expect:
       affected_rows: 1
+  - name: "INSERT IGNORE ... VALUES SELECT legacy syntax"
+    sql: "INSERT IGNORE INTO dbc_t (id, name, email, status, active) VALUES SELECT id+200, name, CONCAT(name, '@legacy.com'), status, active FROM dbc_t"
+    expect:
+      affected_rows: 2
 
   # --- Triggers ---
   - name: "DROP TRIGGER IF EXISTS"


### PR DESCRIPTION
## Summary
This PR closes a small set of SQL and MySQL-compatibility gaps that remained after the scalar-subselect workaround landed.

## Planner and parser fixes
- keep qualified `tbl.col LIKE 'pattern'` predicates on the correct collation path
- preserve outer-reference inputs when a correlated scalar subquery appears inside an aggregate expression
- accept MySQL's legacy `INSERT ... VALUES SELECT ...` form

## Storage and trigger fixes
- keep `BEFORE INSERT` trigger rewrites compatible with `AUTO_INCREMENT` columns
- lazily materialize shard storage for schema-visible columns that are missing from an older shard map
- avoid deadlock between cached global aggregates and `AFTER INSERT` invalidation

## MySQL protocol fix
- when duplicate output aliases collapse to one column, keep the field metadata type of the final value instead of the overwritten one

## Regression coverage
- `python3 run_sql_tests.py tests/17_strings_like.yaml`
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml`
- `python3 run_sql_tests.py tests/37_triggers.yaml`
- `python3 run_sql_tests.py tests/43_dbcheck_ddl_compat.yaml`
- `go test ./scm -run TestAppendMySQLResultRowDuplicateAliasUsesLastValueType -count=1`
- `go test ./storage -run TestGlobalAggregateComputeAndInsertDoNotDeadlock -count=1`
- `go test ./storage -run TestGetColumnStorageOrPanicExAddsSchemaColumnWhenLocked -count=1`