### PR TITLE
fix: reorder DELETE USING before simple DELETE in trigger parser

### DIFF
--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -518,13 +518,8 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		) (if (> (count tbls) 1)
 				(list '!update_multi tbls assignments where)
 				(list '!update (match (car tbls) '(alias _) alias) assignments where)))
-		/* DELETE FROM table WHERE condition[;] */
-		(parser '(
-			(atom "DELETE" true) (atom "FROM" true) (define tbl sql_identifier)
-			(? (atom "WHERE" true) (define where sql_expression))
-			(? (atom ";" false))
-		) (list '!delete tbl where))
 		/* DELETE FROM table USING table, table2 [AS alias] WHERE condition[;] (multi-table in trigger) */
+		/* Must be before simple DELETE FROM — otherwise the simple variant greedily matches the table name */
 		(parser '(
 			(atom "DELETE" true) (atom "FROM" true) (define target sql_identifier)
 			(atom "USING" true)
@@ -535,6 +530,12 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(? (atom "WHERE" true) (define where sql_expression))
 			(? (atom ";" false))
 		) (list '!delete_using target tbls where))
+		/* DELETE FROM table WHERE condition[;] */
+		(parser '(
+			(atom "DELETE" true) (atom "FROM" true) (define tbl sql_identifier)
+			(? (atom "WHERE" true) (define where sql_expression))
+			(? (atom ";" false))
+		) (list '!delete tbl where))
 	)))
 
 	/* Full trigger statement parser including IF...THEN...[ELSE...]END IF */
@@ -1357,21 +1358,21 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			/* TODO: ignorecase */
 			(define updaterows (+ (parser '((define col sql_identifier) (atom "=" false) (define value sql_expression)) '(col value)) ","))
 		) updaterows)))
-		) (begin
-				/* policy: write access check */
-				(if policy (policy (coalesce schema2 schema) tbl true) true)
-				(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
-				(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-				(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
-				(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
-					(begin
-						(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
-						(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
-					'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
-						(if (and ignoreexists (nil? updaterows))
-							'((quote lambda) '() 0)
-							(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
-						false '('lambda '('id) '('session "last_insert_id" 'id))))
+	) (begin
+			/* policy: write access check */
+			(if policy (policy (coalesce schema2 schema) tbl true) true)
+			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
+			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
+			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
+				(begin
+					(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
+					(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
+				'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
+					(if (and ignoreexists (nil? updaterows))
+						'((quote lambda) '() 0)
+						(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
+					false '('lambda '('id) '('session "last_insert_id" 'id))))
 	)))
 
 	(define sql_insert_values_select (parser '(
@@ -1562,11 +1563,11 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	/* TODO: ignore comments wherever they occur --> Lexer */
 	(define p (parser (or
 		(parser (atom "SHUTDOWN" true) (begin (if policy (policy "system" true true) true) '(shutdown)))
-			(parser (define query sql_select) (build_queryplan_term query))
-			(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
-			sql_insert_values_select
-			sql_insert_into
-			sql_insert_select
+		(parser (define query sql_select) (build_queryplan_term query))
+		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
+		sql_insert_values_select
+		sql_insert_into
+		sql_insert_select
 		sql_create_table
 		sql_alter_table
 		sql_update

--- a/tests/81_trigger_compat.yaml
+++ b/tests/81_trigger_compat.yaml
@@ -8,25 +8,50 @@ setup:
   - sql: "DROP TABLE IF EXISTS `bill`"
   - sql: "DROP TABLE IF EXISTS `billElement`"
   - sql: "DROP TABLE IF EXISTS `fop_journal`"
+  - sql: "DROP TABLE IF EXISTS trig_assoc"
+  - sql: "DROP TABLE IF EXISTS trig_history"
+  - sql: "DROP TABLE IF EXISTS trig_main"
+  - sql: "DROP TABLE IF EXISTS trig_journal"
+  - sql: "DROP TABLE IF EXISTS trig_invoice"
+  - sql: "DROP TABLE IF EXISTS trig_invitem"
+  - sql: "DROP TABLE IF EXISTS trig_year"
   - sql: "DROP TRIGGER IF EXISTS after_items_insert"
   - sql: "DROP TRIGGER IF EXISTS after_bill_insert"
   - sql: "DROP TRIGGER IF EXISTS trig_no_begin"
+  - sql: "DROP TRIGGER IF EXISTS `trig_main.ia`"
+  - sql: "DROP TRIGGER IF EXISTS `trig_year.ia`"
   - sql: "CREATE TABLE trig_log (id int, msg text)"
   - sql: "CREATE TABLE trig_items (id int, name text, val float)"
   - sql: "CREATE TABLE `billElement` (id int, name text, amount float)"
   - sql: "CREATE TABLE `fop_journal` (id int, ref text, amount float)"
   - sql: "CREATE TABLE `bill` (id int, betrag float, ist float)"
+  - sql: "CREATE TABLE trig_assoc (id INT AUTO_INCREMENT PRIMARY KEY, mainid INT, val INT)"
+  - sql: "CREATE TABLE trig_history (id INT AUTO_INCREMENT PRIMARY KEY, ref INT, note TEXT)"
+  - sql: "CREATE TABLE trig_main (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT)"
+  - sql: "CREATE TABLE trig_journal (id INT AUTO_INCREMENT PRIMARY KEY, `invoice:year:debit` INT, `invoice:debit` INT, `item:debit` INT, amount DECIMAL(10,2))"
+  - sql: "CREATE TABLE trig_invoice (ID INT AUTO_INCREMENT PRIMARY KEY, rnr TEXT, rdate INT)"
+  - sql: "CREATE TABLE trig_invitem (ID INT AUTO_INCREMENT PRIMARY KEY, invoice INT, amount DECIMAL(10,2))"
+  - sql: "CREATE TABLE trig_year (ID INT AUTO_INCREMENT PRIMARY KEY, xstart INT, xend INT, mode INT)"
 
 cleanup:
   - sql: "DROP TRIGGER IF EXISTS after_items_insert"
   - sql: "DROP TRIGGER IF EXISTS after_bill_insert"
   - sql: "DROP TRIGGER IF EXISTS after_billelement_insert"
   - sql: "DROP TRIGGER IF EXISTS trig_no_begin"
+  - sql: "DROP TRIGGER IF EXISTS `trig_main.ia`"
+  - sql: "DROP TRIGGER IF EXISTS `trig_year.ia`"
   - sql: "DROP TABLE IF EXISTS trig_log"
   - sql: "DROP TABLE IF EXISTS trig_items"
   - sql: "DROP TABLE IF EXISTS `bill`"
   - sql: "DROP TABLE IF EXISTS `billElement`"
   - sql: "DROP TABLE IF EXISTS `fop_journal`"
+  - sql: "DROP TABLE IF EXISTS trig_assoc"
+  - sql: "DROP TABLE IF EXISTS trig_history"
+  - sql: "DROP TABLE IF EXISTS trig_main"
+  - sql: "DROP TABLE IF EXISTS trig_journal"
+  - sql: "DROP TABLE IF EXISTS trig_invoice"
+  - sql: "DROP TABLE IF EXISTS trig_invitem"
+  - sql: "DROP TABLE IF EXISTS trig_year"
 
 test_cases:
 
@@ -126,3 +151,64 @@ test_cases:
       rows: 1
       data:
         - {cnt: 2}
+
+  # --- DELETE FROM ... USING (multi-table DELETE in trigger body) ---
+
+  - name: "CREATE TRIGGER with DELETE USING and INSERT IGNORE SELECT"
+    sql: "CREATE TRIGGER `trig_main.ia` AFTER INSERT ON `trig_main` FOR EACH ROW BEGIN DELETE FROM `trig_history` USING `trig_history`, `trig_assoc` AS `ASSOCIATED` WHERE `trig_history`.`ref` = `ASSOCIATED`.`id` AND NEW.`id` = `ASSOCIATED`.`mainid`; INSERT IGNORE INTO `trig_history`(`ref`, `note`) SELECT `id`, 'created' FROM `trig_assoc` AS `ASSOCIATED` WHERE NEW.`id` = `ASSOCIATED`.`mainid`; END"
+    expect:
+      affected_rows: 1
+
+  - name: "Setup assoc row for DELETE USING trigger test"
+    sql: "INSERT INTO trig_assoc (mainid, val) VALUES (1, 42)"
+    expect:
+      affected_rows: 1
+
+  - name: "INSERT fires DELETE USING trigger"
+    sql: "INSERT INTO trig_main (name) VALUES ('test')"
+    expect:
+      affected_rows: 1
+
+  - name: "Trigger INSERT IGNORE wrote to trig_history"
+    sql: "SELECT ref, note FROM trig_history WHERE ref = 1"
+    expect:
+      rows: 1
+      data:
+        - {ref: 1, note: "created"}
+
+  # --- Colon-containing aliases in trigger INSERT...SELECT ---
+
+  - name: "CREATE TRIGGER with colon-containing aliases in INSERT SELECT"
+    sql: |
+      CREATE TRIGGER `trig_year.ia` AFTER INSERT ON `trig_year` FOR EACH ROW BEGIN
+        IF (NEW.`mode`) = (0) THEN
+          INSERT INTO `trig_journal` (`invoice:year:debit`, `invoice:debit`, `item:debit`, `amount`)
+            SELECT NEW.`ID`, `invoice:debit`.`ID`, `item:debit`.`ID`, `item:debit`.`amount`
+            FROM `trig_invoice` AS `invoice:debit`, `trig_invitem` AS `item:debit`
+            WHERE (NEW.`ID`) = (`item:debit`.`invoice`);
+        END IF;
+      END
+    expect:
+      affected_rows: 1
+
+  - name: "Setup invoice for colon-alias trigger"
+    sql: "INSERT INTO trig_invoice (rnr, rdate) VALUES ('INV-001', 50)"
+    expect:
+      affected_rows: 1
+
+  - name: "Setup item for colon-alias trigger"
+    sql: "INSERT INTO trig_invitem (invoice, amount) VALUES (1, 100.50)"
+    expect:
+      affected_rows: 1
+
+  - name: "INSERT fires colon-alias trigger"
+    sql: "INSERT INTO trig_year (xstart, xend, mode) VALUES (1, 100, 0)"
+    expect:
+      affected_rows: 1
+
+  - name: "Colon-alias trigger wrote correct data to journal"
+    sql: "SELECT `invoice:year:debit`, `invoice:debit`, `item:debit`, amount FROM trig_journal"
+    expect:
+      rows: 1
+      data:
+        - {"invoice:year:debit": 1, "invoice:debit": 1, "item:debit": 1, amount: 100.5}


### PR DESCRIPTION
## Summary
- Reorder `DELETE FROM ... USING` before simple `DELETE FROM` in `sql_trigger_simple_stmt` — the simpler variant greedily matched the table name, leaving `USING` unparseable. This caused all triggers containing multi-table DELETE to fail with "Parser failed at column 2".
- Adds tests for DELETE USING, INSERT IGNORE SELECT, and colon-containing aliases in trigger INSERT...SELECT bodies.

## Test plan
- [x] `tests/81_trigger_compat.yaml` — 22/22 pass (new tests for DELETE USING, INSERT IGNORE SELECT, colon-aliases)
- [x] `tests/38_trigger_insert_select.yaml` — 17/17 pass (no regression)
- [x] `tests/01_basic_sql.yaml`, `tests/06_edge_cases.yaml` — pass (no regression)
- [x] Full `make test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)