### PR TITLE
feat: add limitPartitionCols to scan_order for per-partition LIMIT/OFFSET

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -299,7 +299,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				(if (dashboard_check_admin req) (begin
 					(define items (scan_order "system_statistic" "logs"
 						'() (lambda () true)
-						'("datetime") '(>) 0 100
+						'("datetime") '(>) 0 0 100
 						'("datetime" "message")
 						(lambda (dt msg) (json_encode_assoc (list "datetime" dt "message" msg)))
 						(lambda (acc item) (if (equal? acc "") item (concat acc "," item)))
@@ -406,7 +406,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(try (lambda () (begin
 			(define cnt (scan "system_statistic" "logs" '() (lambda () true) '() (lambda () 1) + 0))
 			(if (> cnt max_print)
-				(scan_order "system_statistic" "logs" '() (lambda () true) '("datetime") '(<) 0 (- cnt max_print) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
+				(scan_order "system_statistic" "logs" '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_print) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
 			)
 		)) (lambda (e) true))
 	))
@@ -416,7 +416,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(try (lambda () (begin
 			(define cnt (scan "system_statistic" "errors" '() (lambda () true) '() (lambda () 1) + 0))
 			(if (> cnt max_err)
-				(scan_order "system_statistic" "errors" '() (lambda () true) '("datetime") '(<) 0 (- cnt max_err) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
+				(scan_order "system_statistic" "errors" '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_err) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
 			)
 		)) (lambda (e) true))
 	))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -109,7 +109,7 @@ update_fn embeds delete_fn/insert_fn as proc literals in its body (no closure ca
 	(if (equal? result neutral) nil result)
 )))
 (define scalar_scan_order (lambda (schema tbl filtercols filterfn sortcols sortdirs offset limit mapcols mapfn reduce neutral) (begin
-	(define result (scan_order schema tbl filtercols filterfn sortcols sortdirs offset limit mapcols mapfn reduce neutral))
+	(define result (scan_order schema tbl filtercols filterfn sortcols sortdirs 0 offset limit mapcols mapfn reduce neutral))
 	(if (equal? result neutral) nil result)
 )))
 
@@ -1355,6 +1355,7 @@ WHAT IT MUST NOT DO:
 														)
 														(cons list ordercols)
 														(cons list dirs)
+														0
 														(coalesceNil stage_offset 0)
 														(coalesceNil stage_limit -1)
 														(cons list cur_cols)
@@ -1495,6 +1496,7 @@ WHAT IT MUST NOT DO:
 										)
 										(cons list ordercols)
 										(cons list dirs)
+										0
 										(coalesceNil stage_offset 0)
 										(coalesceNil stage_limit -1)
 										(cons list '())
@@ -2988,7 +2990,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 															'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
 															(cons list ordercols)
 															(cons list sort_dirs)
-															0 -1
+															0 0 -1
 															(cons list stride_cols)
 															mapfn_ast
 															reducer_ast
@@ -3000,7 +3002,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 													'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
 													(cons list ordercols)
 													(cons list sort_dirs)
-													0 -1
+													0 0 -1
 													(cons list stride_cols)
 													mapfn_ast
 													reducer_ast
@@ -3026,7 +3028,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 																'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
 																(cons list ordercols)
 																(cons list sort_dirs)
-																0 -1
+																0 0 -1
 																(cons list stride_cols)
 																mapfn_ast
 																reducer_ast
@@ -3038,7 +3040,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 														'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
 														(cons list ordercols)
 														(cons list sort_dirs)
-														0 -1
+														0 0 -1
 														(cons list stride_cols)
 														mapfn_ast
 														reducer_ast
@@ -3109,6 +3111,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										/* sortcols, sortdirs */
 										(cons list ordercols)
 										(cons list dirs)
+										0
 										scan_offset
 										scan_limit
 										/* extract columns and store them into variables */

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -379,7 +379,7 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 	t.scan_order(
 		condCols, condFn,
 		sortcolsScmer, sortdirsFns,
-		0, -1,
+		0, 0, -1,
 		scanCallbackCols,
 		scanMapFn,
 		scanReduceFn,

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
+import "sort"
 import "github.com/carli2/hybridsort"
 import "time"
 import "strings"
@@ -27,26 +28,60 @@ import "github.com/launix-de/memcp/scm"
 
 // optimizeScanOrder is the Optimize hook for the scan_order declaration.
 // scan_order args: 1=schema, 2=table, 3=filterCols, 4=filter, 5=sortcols, 6=sortdirs,
-// 7=offset, 8=limit, 9=mapCols, 10=map, 11=reduce, 12=neutral, 13=isOuter
+// 7=limitPartitionCols, 8=offset, 9=limit, 10=mapCols, 11=map, 12=reduce, 13=neutral, 14=isOuter
 func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
-	// Optimize args 1-10 normally
-	for i := 1; i <= 10 && i < len(v); i++ {
+	// Optimize args 1-11 normally
+	for i := 1; i <= 11 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
-	// Arg 11 (reduce callback): set callback ownership before optimizing
-	if len(v) > 11 && !v[11].IsNil() {
+	// Arg 12 (reduce callback): set callback ownership before optimizing
+	if len(v) > 12 && !v[12].IsNil() {
 		oc.SetCallbackOwned([]bool{true, false}) // acc is owned
-		v[11], _ = oc.OptimizeSub(v[11], true)
-	}
-	// Arg 12 (neutral)
-	if len(v) > 12 {
 		v[12], _ = oc.OptimizeSub(v[12], true)
 	}
-	// Arg 13 (isOuter)
+	// Arg 13 (neutral)
 	if len(v) > 13 {
 		v[13], _ = oc.OptimizeSub(v[13], true)
 	}
+	// Arg 14 (isOuter)
+	if len(v) > 14 {
+		v[14], _ = oc.OptimizeSub(v[14], true)
+	}
 	return scm.NewSlice(v), nil
+}
+
+// pkEqual compares two partition key slices element-wise.
+func pkEqual(a, b []scm.Scmer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !scm.Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// skipPartition uses binary search to skip all remaining items in the current
+// partition of a shardqueue. Since items are sorted by (partition_key, order_key),
+// all items of the same partition are contiguous — sort.Search finds the first
+// item of the next partition in O(log n).
+func skipPartition(q *globalqueue, qx *shardqueue, pk []scm.Scmer, n int) {
+	idx := sort.Search(len(qx.items), func(i int) bool {
+		for c := 0; c < n; c++ {
+			if !scm.Equal(qx.scols[c](qx.items[i]), pk[c]) {
+				return true
+			}
+		}
+		return false
+	})
+	qx.items = qx.items[idx:]
+	if len(qx.items) > 0 {
+		heap.Fix(q, 0)
+	} else {
+		heap.Pop(q)
+	}
 }
 
 type shardqueue struct {
@@ -139,7 +174,7 @@ func (s *globalqueue) Pop() any {
 // TODO: helper function for priority-q. golangs implementation is kinda quirky, so do our own. container/heap especially lacks the function to test the value at front instead of popping it
 
 // map reduce implementation based on scheme scripts
-func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
 	ss := scm.GetCurrentSessionState()
 	if ss != nil && ss.IsKilled() {
 		panic("query killed")
@@ -279,7 +314,7 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 
 	// total_limit helps the shard-scanners to early-out
 	total_limit := -1
-	if limit >= 0 {
+	if limitPartitionCols == 0 && limit >= 0 {
 		total_limit = offset + limit
 	}
 
@@ -310,7 +345,7 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 					q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 				}
 			}()
-			res := s.scan_order(boundaries, lower, upperLast, conditionCols, condition, sortcols, sortdirs, total_limit, callbackCols)
+			res := s.scan_order(boundaries, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, total_limit, callbackCols)
 			q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
 		})
 		close(q_)
@@ -348,6 +383,13 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 	bufN := 0
 	var bufShard *shardqueue
 	breakCaught := false
+
+	// Per-partition offset/limit state. When limitPartitionCols == 0 this
+	// degenerates to a single partition covering all rows (= global limit).
+	var prevPK []scm.Scmer
+	partOffset := offset
+	partLimit := limit
+
 	for !breakCaught && len(q.q) > 0 {
 		qx := q.q[0]
 
@@ -356,10 +398,31 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 			continue
 		}
 
-		if offset > 0 {
-			// offset skip (typically small)
+		// Extract partition key from leading sort columns (empty slice when limitPartitionCols == 0)
+		peekItem := qx.items[0]
+		curPK := make([]scm.Scmer, limitPartitionCols)
+		for c := 0; c < limitPartitionCols && c < len(qx.scols); c++ {
+			curPK[c] = qx.scols[c](peekItem)
+		}
+		// Detect partition change (first row or key differs)
+		if prevPK == nil || !pkEqual(prevPK, curPK) {
+			// Flush buffer before partition switch
+			if bufN > 0 && bufShard != nil {
+				akkumulator, breakCaught = streamOrBreak(bufShard.mapper, akkumulator, buf[:bufN])
+				hadValue = true
+				bufN = 0
+				if breakCaught {
+					break
+				}
+			}
+			partOffset = offset
+			partLimit = limit
+			prevPK = curPK
+		}
+		// Per-partition offset skip
+		if partOffset > 0 {
+			partOffset--
 			qx.items = qx.items[1:]
-			offset--
 			if len(qx.items) > 0 {
 				heap.Fix(&q, 0)
 			} else {
@@ -367,10 +430,17 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 			}
 			continue
 		}
-
-		if limit == 0 {
+		// Per-partition limit exhausted
+		if partLimit == 0 {
+			if limitPartitionCols > 0 {
+				// Bulk-skip rest of partition via binary search (O(log n))
+				skipPartition(&q, qx, prevPK, limitPartitionCols)
+				continue // proceed to next partition
+			}
+			// limitPartitionCols == 0: single partition = all done
 			break
 		}
+		partLimit--
 
 		// Pop one item from the global merge
 		item := qx.items[0]
@@ -391,9 +461,6 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 		buf[bufN] = item
 		bufN++
 		outCount++
-		if limit >= 0 {
-			limit--
-		}
 
 		// Flush if buffer full
 		if bufN == len(buf) {
@@ -478,7 +545,7 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limit int, callbackCols []string) (result *shardqueue) {
+func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	defaultSortDir := func(args ...scm.Scmer) scm.Scmer {
@@ -719,6 +786,33 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	if (maxInsertIndex > 0 || true) && len(sortcols) > 0 {
 		hybridsort.Slice(result.items, result.Less)
 		// or: quicksort but those segments above offset+limit can be omitted
+	}
+	// Shard-local per-partition pruning: keep at most offset+limit items per
+	// partition. This reduces what goes into the cross-shard globalqueue merge.
+	// When limitPartitionCols == 0 this is a single partition (= global limit).
+	if limit >= 0 {
+		perPart := offset + limit
+		if perPart < 0 {
+			perPart = len(result.items) // overflow guard
+		}
+		var pruned []uint32
+		var prevPK []scm.Scmer
+		partCount := 0
+		for _, idx := range result.items {
+			curPK := make([]scm.Scmer, limitPartitionCols)
+			for c := 0; c < limitPartitionCols; c++ {
+				curPK[c] = result.scols[c](idx)
+			}
+			if prevPK == nil || !pkEqual(prevPK, curPK) {
+				partCount = 0
+				prevPK = curPK
+			}
+			if partCount < perPart {
+				pruned = append(pruned, idx)
+			}
+			partCount++
+		}
+		result.items = pruned
 	}
 	return
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -301,7 +301,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		"scan_order", "does an ordered parallel filter and serial map-reduce pass on a single table and returns the reduced result",
-		10, 13,
+		11, 14,
 		[]scm.DeclarationParameter{
 			scm.DeclarationParameter{"schema", "string", "database where the table is located", nil},
 			scm.DeclarationParameter{"table", "string", "name of the table to scan", nil},
@@ -309,6 +309,7 @@ func Init(en scm.Env) {
 			scm.DeclarationParameter{"filter", "func", "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", nil},
 			scm.DeclarationParameter{"sortcols", "list", "list of columns to sort. Each column is either a string to point to an existing column or a func(cols...)->any to compute a sortable value", nil},
 			scm.DeclarationParameter{"sortdirs", "list", "list of column directions to sort. Must be same length as sortcols. < means ascending, > means descending, (collate ...) will add collations", nil},
+			scm.DeclarationParameter{"limitPartitionCols", "number", "number of leading sort columns that form the partition key for per-partition offset/limit. 0 (default) means global offset/limit.", nil},
 			scm.DeclarationParameter{"offset", "number", "number of items to skip before the first one is fed into map", nil},
 			scm.DeclarationParameter{"limit", "number", "max number of items to read", nil},
 			scm.DeclarationParameter{"mapColumns", "list", "list of columns that are fed into map", nil},
@@ -321,15 +322,16 @@ func Init(en scm.Env) {
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[2], "filterColumns"))
 			sortcolsVals := mustScmerSlice(a[4], "sortcols")
 			sortdirsVals := mustScmerSlice(a[5], "sortdirs")
-			mapcols := scmerSliceToStrings(mustScmerSlice(a[8], "mapColumns"))
+			limitPartitionCols := scm.ToInt(a[6])
+			mapcols := scmerSliceToStrings(mustScmerSlice(a[9], "mapColumns"))
 
 			aggregate := scm.NewNil()
-			if len(a) > 10 {
-				aggregate = a[10]
+			if len(a) > 11 {
+				aggregate = a[11]
 			}
 			neutral := scm.NewNil()
-			if len(a) > 11 {
-				neutral = a[11]
+			if len(a) > 12 {
+				neutral = a[12]
 			}
 
 			sortdirs := make([]func(...scm.Scmer) scm.Scmer, len(sortcolsVals))
@@ -337,13 +339,13 @@ func Init(en scm.Env) {
 				sortdirs[i] = scm.OptimizeProcToSerialFunction(dir)
 			}
 
-			isOuter := len(a) > 12 && scm.ToBool(a[12])
+			isOuter := len(a) > 13 && scm.ToBool(a[13])
 
 			if list, ok := scmerSlice(a[1]); ok {
 				result := neutral
 				filterfn := scm.OptimizeProcToSerialFunction(a[3])
 				filterparams := make([]scm.Scmer, len(filtercols))
-				mapfn := scm.OptimizeProcToSerialFunction(a[9])
+				mapfn := scm.OptimizeProcToSerialFunction(a[10])
 				mapparams := make([]scm.Scmer, len(mapcols))
 				reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
 				if !aggregate.IsNil() {
@@ -399,8 +401,8 @@ func Init(en scm.Env) {
 					}
 					return false
 				})
-				offset := int(scm.ToInt(a[6]))
-				limit := int(scm.ToInt(a[7]))
+				offset := int(scm.ToInt(a[7]))
+				limit := int(scm.ToInt(a[8]))
 				hadValue := false
 				count := 0
 				for idx, val := range filtered {
@@ -437,7 +439,7 @@ func Init(en scm.Env) {
 				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
 			}
 
-			return t.scan_order(filtercols, a[3], sortcolsVals, sortdirs, scm.ToInt(a[6]), scm.ToInt(a[7]), mapcols, a[9], aggregate, neutral, isOuter)
+			return t.scan_order(filtercols, a[3], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[7]), scm.ToInt(a[8]), mapcols, a[10], aggregate, neutral, isOuter)
 		}, false, false, &scm.TypeDescriptor{Optimize: optimizeScanOrder},
 		nil,
 	})

--- a/tests/103_scan_order_partition.yaml
+++ b/tests/103_scan_order_partition.yaml
@@ -1,0 +1,101 @@
+# Per-partition LIMIT/OFFSET for scan_order via limitPartitionCols parameter.
+# Tests use scm: blocks to call scan_order directly with partition semantics.
+
+metadata:
+  version: "1.0"
+  description: "scan_order limitPartitionCols: per-partition LIMIT/OFFSET with pruning"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS part_test"
+  - sql: |
+      CREATE TABLE part_test (
+        id INT PRIMARY KEY,
+        dept INT,
+        name VARCHAR(30),
+        salary INT
+      )
+  - sql: |
+      INSERT INTO part_test VALUES
+        (1, 1, 'Alice', 90000),
+        (2, 1, 'Bob', 80000),
+        (3, 1, 'Frank', 95000),
+        (4, 2, 'Carol', 70000),
+        (5, 2, 'Dave', 75000),
+        (6, 3, 'Eve', 60000),
+        (7, 3, 'Grace', 65000),
+        (8, 3, 'Henry', 50000)
+
+test_cases:
+
+  - name: "per-partition LIMIT 1: top earner per dept"
+    scm: |
+      (begin
+        (set s (newsession))
+        (s "cnt" 0)
+        (scan_order "memcp-tests" "part_test"
+          '() (lambda () true)
+          '("dept" "salary") '(< >)
+          1 0 1
+          '("dept" "name" "salary")
+          (lambda (dept name salary) (begin (s "cnt" (+ (s "cnt") 1)) nil))
+          (lambda (a b) b) nil false)
+        (if (equal? (s "cnt") 3) "ok" (error (concat "expected 3 rows but got " (s "cnt")))))
+
+  - name: "per-partition LIMIT 2: top 2 earners per dept"
+    scm: |
+      (begin
+        (set s (newsession))
+        (s "cnt" 0)
+        (scan_order "memcp-tests" "part_test"
+          '() (lambda () true)
+          '("dept" "salary") '(< >)
+          1 0 2
+          '("dept" "name" "salary")
+          (lambda (dept name salary) (begin (s "cnt" (+ (s "cnt") 1)) nil))
+          (lambda (a b) b) nil false)
+        (if (equal? (s "cnt") 6) "ok" (error (concat "expected 6 rows but got " (s "cnt")))))
+
+  - name: "per-partition OFFSET 1 LIMIT 1: second-best earner per dept"
+    scm: |
+      (begin
+        (set s (newsession))
+        (s "cnt" 0)
+        (scan_order "memcp-tests" "part_test"
+          '() (lambda () true)
+          '("dept" "salary") '(< >)
+          1 1 1
+          '("dept" "name" "salary")
+          (lambda (dept name salary) (begin (s "cnt" (+ (s "cnt") 1)) nil))
+          (lambda (a b) b) nil false)
+        (if (equal? (s "cnt") 3) "ok" (error (concat "expected 3 rows but got " (s "cnt")))))
+
+  - name: "limitPartitionCols=0 is global limit (regression)"
+    scm: |
+      (begin
+        (set s (newsession))
+        (s "cnt" 0)
+        (scan_order "memcp-tests" "part_test"
+          '() (lambda () true)
+          '("salary") '(>)
+          0 0 2
+          '("salary")
+          (lambda (salary) (begin (s "cnt" (+ (s "cnt") 1)) nil))
+          (lambda (a b) b) nil false)
+        (if (equal? (s "cnt") 2) "ok" (error (concat "expected 2 rows but got " (s "cnt")))))
+
+  - name: "pruning: map called only limit*partitions times"
+    scm: |
+      (begin
+        (set s (newsession))
+        (s "cnt" 0)
+        (scan_order "memcp-tests" "part_test"
+          '() (lambda () true)
+          '("dept" "salary") '(< >)
+          1 0 1
+          '("dept" "salary")
+          (lambda (dept salary) (begin (s "cnt" (+ (s "cnt") 1)) nil))
+          (lambda (a b) b) nil false)
+        (if (<= (s "cnt") 3) "ok" (error (concat "map called " (s "cnt") " times, expected at most 3"))))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS part_test"


### PR DESCRIPTION
## Summary
- New optional parameter `limitPartitionCols` (int, position 7, before offset/limit) for `scan_order`
- When > 0, the first N sort columns are partition keys; offset/limit apply per partition
- Two-level pruning: shard-local (after sort) + global merge (sort.Search bulk skip)
- `limitPartitionCols == 0` (default) = global offset/limit (no behavior change)

## Motivation
Needed for Neumann-style subquery unnesting (BTW 2015/2025): correlated `ORDER BY + LIMIT` subqueries decorrelate into per-domain sorted scans. Based on Galindo-Legaria's Segment+Top operator concept (SIGMOD 2007).

## Test plan
- [x] `tests/103_scan_order_partition.yaml`: per-partition LIMIT 1/2, OFFSET, global regression, pruning counter
- [x] All existing tests pass (pre-commit hook)
- [x] Window function tests (LAG/LEAD) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)