### PR TITLE
support multiline block comments in RDF parser

### DIFF
--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -106,7 +106,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define order (parser (? (atom "ORDER" true) (atom "BY" true) (define ordercols (+ (or (parser '((define dir (or (atom "DESC" true) (atom "ASC" true))) "(" (define expr rdf_expression) ")") '(expr dir)) (parser (define expr rdf_expression) '(expr "ASC"))) ","))) ordercols))
 	(? (atom "LIMIT" true) (define limit rdf_number))
 	(? (atom "OFFSET" true) (define offset rdf_number))
-) '("select" (merge cols) "where" (merge (coalesce conditions '('()))) "order" order "limit" limit "offset" offset "distinct" distinct) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
+) '("select" (merge cols) "where" (merge (coalesce conditions '('()))) "order" order "limit" limit "offset" offset "distinct" distinct) "^(?:(?s:/\\*.*?\\*/)|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 
 (define ttl_header (parser '(
 	(define definitions (*
@@ -116,7 +116,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		)
 	))
 	(define rest rest)
-) '("prefixes" (merge definitions) "rest" rest) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
+) '("prefixes" (merge definitions) "rest" rest) "^(?:(?s:/\\*.*?\\*/)|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 
 (define rdf_replace_ctx (lambda (expr ctx) (match expr
 	'('get_var sym) (coalesce (ctx sym) (error "SPARQL error: variable " sym " is used in SELECT but not bound in WHERE clause"))
@@ -242,7 +242,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				) (merge (map ps (lambda (p) (map p (lambda (p1) (cons s p1)))))))
 			)
 			(define rest rest)
-		) '("facts" facts "rest" rest) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
+		) '("facts" facts "rest" rest) "^(?:(?s:/\\*.*?\\*/)|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 		(set _pt (newsession))
 		(_pt "triples" '())
 		(define process_fact (lambda (rest) (match (ttl_fact rest)
@@ -290,7 +290,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				) (merge (map ps (lambda (p) (map p (lambda (p1) (cons s p1)))))))
 			)
 			(define rest rest)
-		) '("facts" facts "rest" rest) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
+		) '("facts" facts "rest" rest) "^(?:(?s:/\\*.*?\\*/)|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 		(set load (lambda (facts) (begin
 			/* resolve blank nodes to UUIDs and insert */
 			(insert schema "rdf" '("s" "p" "o") (map facts (lambda (triple) (list (resolve_blank (car triple)) (resolve_blank (car (cdr triple))) (resolve_blank (car (cdr (cdr triple))))))) '() (lambda () true))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1539,6 +1539,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (contains? cm_keys "a") true "cachemap lists key a")
 	(assert (contains? cm_keys "b") true "cachemap lists key b")
 
+	/* RDF parser: multiline block comments */
+	(print "testing rdf multiline block comments ...")
+	(import "rdf-parser.scm")
+	(createdatabase "rdf-comment-test" true)
+	(createtable "rdf-comment-test" "rdf" '('("column" "s" "text" '() '()) '("column" "p" "text" '() '()) '("column" "o" "text" '() '()) '("unique" "u" '("s" "p" "o"))) '() true)
+	(define _rdf_comment_ttl "@prefix ex: <http://example.com/> .\n/* hello\n   world */\nex:a ex:b ex:c .")
+	(define _rdf_comment_triples (parse_ttl_triples "rdf-comment-test" _rdf_comment_ttl))
+	(assert (count _rdf_comment_triples) 1 "rdf parser: parse_ttl_triples returns one triple after multiline block comment")
+	(assert (nth (nth _rdf_comment_triples 0) 0) "http://example.com/a" "rdf parser: subject survives multiline block comment")
+	(assert (nth (nth _rdf_comment_triples 0) 1) "http://example.com/b" "rdf parser: predicate survives multiline block comment")
+	(assert (nth (nth _rdf_comment_triples 0) 2) "http://example.com/c" "rdf parser: object survives multiline block comment")
+	(load_ttl "rdf-comment-test" _rdf_comment_ttl)
+	(define _rdf_comment_row (newsession))
+	(define resultrow (lambda (o) (_rdf_comment_row "o" (o "?o"))))
+	(eval (parse_sparql "rdf-comment-test" "/* comment\n   before */ SELECT ?o WHERE { <http://example.com/a> <http://example.com/b> ?o }"))
+	(assert (_rdf_comment_row "o") "http://example.com/c" "rdf parser: parse_sparql accepts multiline block comments")
+
 	(print "finished unit tests")
 	(print "test result: " (teststat "success") "/" (teststat "count"))
 	(if (< (teststat "success") (teststat "count")) (begin


### PR DESCRIPTION
## Summary
- allow multiline `/* ... */` block comments in RDF/SPARQL/TTL parser skip patterns
- apply the same fix across the RDF parser entry points
- add regression coverage for TTL loading and SPARQL parsing with multiline block comments

## Testing
- `./memcp memcp/lib/test.scm`