### PR TITLE
Fix rebuild concurrency and lock convoy regressions

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -410,7 +410,7 @@ raw _unn_* occurrence aliases into physical temp column names. */
 						_
 						(rewrite_materialized_source_columns tbl tblvar node)))))))
 		(lower_node expr)
-	)))
+)))
 
 /* returns a list of all tblvar aliases referenced via get_column in expr */
 (define extract_tblvars (lambda (expr)
@@ -944,7 +944,9 @@ condition_suffix: if non-nil, appended to name (for dedup stages with WHERE) */
 					'())))))
 			/* create at compile time (needed for recursive build_queryplan) */
 			(createtable schema keytable_name kt_cols '("engine" "sloppy") true)
-			(partitiontable schema keytable_name kt_partition)
+			(if (not (equal? kt_partition '()))
+				(partitiontable schema keytable_name kt_partition)
+				false)
 			/* build runtime init code to re-create after potential cache eviction (mirrors prejoin pattern) */
 			(define kt_cols_code (cons 'list
 				(cons
@@ -956,7 +958,9 @@ condition_suffix: if non-nil, appended to name (for dedup stages with WHERE) */
 					'()))))))
 			(define init_code (list 'begin
 				(list 'createtable schema keytable_name kt_cols_code (list 'list "engine" "sloppy") true)
-				(list 'partitiontable schema keytable_name kt_partition_code)
+				(if (equal? kt_partition '())
+					false
+					(list 'partitiontable schema keytable_name kt_partition_code))
 				(list 'touch_keytable schema keytable_name)))
 			/* return (name init_code nil) — third element nil means no FK reuse */
 			(list keytable_name init_code nil)))
@@ -1206,7 +1210,7 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW) ...) and eval'd,
 						td))))
 				(build_pj_insert_scan rewritten_rest
 					combined_condition
-				trigger_tv is_outermost pj_schema pjtbl mat_cols mat_col_names)
+					trigger_tv is_outermost pj_schema pjtbl mat_cols mat_col_names)
 			)
 			/* scan this other table */
 			(begin
@@ -2374,54 +2378,54 @@ or generate runtime scan code (build_queryplan).
 	COUNT(*) aggregates via _unnest_count_subselect, then decorrelated via Path A.
 	Returns the rewritten expression with subselects replaced by get_column refs
 	or comparison expressions on the unnested aggregate columns. */
-		(define replace_inner_selects (lambda (expr outer_schemas) (match expr
-			(cons sym args) (begin
-				(define kind (inner_select_kind sym))
-				/* handle NOT IN / NOT EXISTS */
-				(define not_expr (if (not_symbol sym)
-					(match args
-						(cons inner_expr '()) (match inner_expr
-							(cons inner_sym inner_args) (begin
-								(define inner_kind (inner_select_kind inner_sym))
-								(if (equal?? inner_kind (quote inner_select_in))
+	(define replace_inner_selects (lambda (expr outer_schemas) (match expr
+		(cons sym args) (begin
+			(define kind (inner_select_kind sym))
+			/* handle NOT IN / NOT EXISTS */
+			(define not_expr (if (not_symbol sym)
+				(match args
+					(cons inner_expr '()) (match inner_expr
+						(cons inner_sym inner_args) (begin
+							(define inner_kind (inner_select_kind inner_sym))
+							(if (equal?? inner_kind (quote inner_select_in))
+								(match inner_args
+									(cons target_expr (cons subquery '()))
+									(coalesce (_unnest_count_subselect subquery outer_schemas target_expr (quote equal?)) expr)
+									_ nil)
+								(if (equal?? inner_kind (quote inner_select_exists))
 									(match inner_args
-										(cons target_expr (cons subquery '()))
-										(coalesce (_unnest_count_subselect subquery outer_schemas target_expr (quote equal?)) expr)
+										(cons subquery '())
+										(if (expr_uses_session_state subquery)
+											(list (quote not) (build_exists_subselect subquery outer_schemas))
+											(coalesce (_unnest_count_subselect subquery outer_schemas nil (quote equal?))
+												(list (quote not) (build_exists_subselect subquery outer_schemas))))
 										_ nil)
-									(if (equal?? inner_kind (quote inner_select_exists))
-										(match inner_args
-											(cons subquery '())
-											(if (expr_uses_session_state subquery)
-												(list (quote not) (build_exists_subselect subquery outer_schemas))
-												(coalesce (_unnest_count_subselect subquery outer_schemas nil (quote equal?))
-													(list (quote not) (build_exists_subselect subquery outer_schemas))))
-											_ nil)
-										nil)))
-							_ nil)
+									nil)))
 						_ nil)
-					nil))
-				(if (nil? not_expr)
-					(match kind
-						(quote inner_select) (match args
-							(cons subquery '()) (coalesce
-								(_try_unnest_scalar_subselect subquery outer_schemas)
-								(build_scalar_subselect subquery outer_schemas))
-							_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
-						(quote inner_select_in) (match args
-							(cons target_expr (cons subquery '()))
-							(coalesce (_unnest_count_subselect subquery outer_schemas target_expr (quote >)) expr)
-							_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
-						(quote inner_select_exists) (match args
-							(cons subquery '())
-							(if (expr_uses_session_state subquery)
-								(build_exists_subselect subquery outer_schemas)
-								(coalesce (_unnest_count_subselect subquery outer_schemas nil (quote >))
-									(build_exists_subselect subquery outer_schemas)))
-							_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
+					_ nil)
+				nil))
+			(if (nil? not_expr)
+				(match kind
+					(quote inner_select) (match args
+						(cons subquery '()) (coalesce
+							(_try_unnest_scalar_subselect subquery outer_schemas)
+							(build_scalar_subselect subquery outer_schemas))
 						_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
-					not_expr))
-			expr
-		)))
+					(quote inner_select_in) (match args
+						(cons target_expr (cons subquery '()))
+						(coalesce (_unnest_count_subselect subquery outer_schemas target_expr (quote >)) expr)
+						_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
+					(quote inner_select_exists) (match args
+						(cons subquery '())
+						(if (expr_uses_session_state subquery)
+							(build_exists_subselect subquery outer_schemas)
+							(coalesce (_unnest_count_subselect subquery outer_schemas nil (quote >))
+								(build_exists_subselect subquery outer_schemas)))
+						_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
+					_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
+				not_expr))
+		expr
+	)))
 
 	/* no-FROM rewrite: inject virtual one-row table ".(1)" (like Oracle DUAL).
 	Dot prefix hides from SHOW TABLES. Eliminates the no-table special case.
@@ -2942,7 +2946,7 @@ or generate runtime scan code (build_queryplan).
 		(replace_rename (replace_find_column expr)))))
 
 	/* return parameter list for build_queryplan */
-		(set conditionAll (cons 'and (filter (cons (replace_rename (canonicalize_for_rename condition)) conditionList) (lambda (x) (not (nil? x))))))
+	(set conditionAll (cons 'and (filter (cons (replace_rename (canonicalize_for_rename condition)) conditionList) (lambda (x) (not (nil? x))))))
 	(set tables (map tables (lambda (td) (match td
 		'(tv tschema ttbl toisOuter tje)
 		(list tv tschema ttbl toisOuter
@@ -3048,8 +3052,8 @@ WHAT IT MUST NOT DO:
 				(define _uq_result (apply untangle_query (merge query (list nil))))
 				(define _uq_init (if (>= (count _uq_result) 8) (nth _uq_result 7) '()))
 				(define _uq_7tuple (list (nth _uq_result 0) (nth _uq_result 1) (nth _uq_result 2) (nth _uq_result 3) (nth _uq_result 4) (nth _uq_result 5) (nth _uq_result 6)))
-					(define _plan (apply build_queryplan (merge (apply join_reorder _uq_7tuple) (list nil))))
-					(if (equal? _uq_init '()) _plan (cons (quote begin) (merge _uq_init (list _plan)))))
+				(define _plan (apply build_queryplan (merge (apply join_reorder _uq_7tuple) (list nil))))
+				(if (equal? _uq_init '()) _plan (cons (quote begin) (merge _uq_init (list _plan)))))
 			(error "invalid SELECT query term"))
 		(match union_parts '(branches order limit offset) (begin
 			(if (or (nil? branches) (equal? branches '()))
@@ -4149,16 +4153,16 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						equality already emitted into that ON-clause must not survive as an
 						additional post-group filter, otherwise NOT IN / NOT EXISTS lose the
 						empty-match row (NULL keytable side fails the redundant equality). */
-							/* Design contract: every scoped GROUP stage re-attaches its keytable to
-							the preserved outer row stream, even for global `(1)` groups, but only
-							when such a real outer stream actually exists. The synthetic no-FROM
-							DUAL `.(1)` row is just a planner helper; treating it as a preserved
-							outer stream here would force unnecessary LEFT JOIN semantics and can
-							drop top-level NOT IN / EXISTS filters. */
-							(define _real_outer_ps_tables (filter _grp_ps_tables (lambda (td) (match td
-								'(_ _ ttbl _ _) (not (equal? ttbl ".(1)"))
-								true))))
-							(define _kt_is_outer (and (not (nil? _stage_scope)) (not (equal? _real_outer_ps_tables '()))))
+						/* Design contract: every scoped GROUP stage re-attaches its keytable to
+						the preserved outer row stream, even for global `(1)` groups, but only
+						when such a real outer stream actually exists. The synthetic no-FROM
+						DUAL `.(1)` row is just a planner helper; treating it as a preserved
+						outer stream here would force unnecessary LEFT JOIN semantics and can
+						drop top-level NOT IN / EXISTS filters. */
+						(define _real_outer_ps_tables (filter _grp_ps_tables (lambda (td) (match td
+							'(_ _ ttbl _ _) (not (equal? ttbl ".(1)"))
+							true))))
+						(define _kt_is_outer (and (not (nil? _stage_scope)) (not (equal? _real_outer_ps_tables '()))))
 						(define _kt_terms (if _kt_is_outer
 							(filter (map _cond_non_agg _grp_join_term) (lambda (x) (not (nil? x))))
 							'()))
@@ -4193,22 +4197,22 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							_marker_in_fields
 							_marker_in_having
 							_marker_in_order))
-							/* SQL GROUP BY semantics: unscoped non-global groups only exist for row
-							keys that survive the pre-group row domain. Keep the logical aggregate
-							sentinels until build_scan, but enforce this domain invariant here via
-							COUNT(*) > 0 instead of materializing helper-side phantom groups.
-							Global helper stages still use the narrower suppression rule so
-							user-visible SELECT COUNT(*) FROM ... on empty input keeps its single
-							neutral row. Scoped GROUP stages must not suppress empty matches here,
-							because NOT EXISTS / NOT IN rely on the later LEFT JOIN + coalesceNil. */
-							(define filter_empty_groups (and
-								(nil? _stage_scope)
-								(or
-									(not (equal? resolved_stage_group '(1)))
-									(and
-										(not _marker_in_fields)
-										(not _marker_in_having)
-										(not _marker_in_order)))))
+						/* SQL GROUP BY semantics: unscoped non-global groups only exist for row
+						keys that survive the pre-group row domain. Keep the logical aggregate
+						sentinels until build_scan, but enforce this domain invariant here via
+						COUNT(*) > 0 instead of materializing helper-side phantom groups.
+						Global helper stages still use the narrower suppression rule so
+						user-visible SELECT COUNT(*) FROM ... on empty input keeps its single
+						neutral row. Scoped GROUP stages must not suppress empty matches here,
+						because NOT EXISTS / NOT IN rely on the later LEFT JOIN + coalesceNil. */
+						(define filter_empty_groups (and
+							(nil? _stage_scope)
+							(or
+								(not (equal? resolved_stage_group '(1)))
+								(and
+									(not _marker_in_fields)
+									(not _marker_in_having)
+									(not _marker_in_order)))))
 						(define ags (if needs_count (merge_unique ags (list count_ag)) ags))
 						(define count_col_name (if needs_count (agg_col_name count_ag) nil))
 						(define keytable_schema_def (merge
@@ -4383,8 +4387,33 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 									)
 							))
 						)))))
+						/* COUNT is a dependency for filtered aggregates: non-count keytable
+						columns may filter on COUNT>0 and therefore must not race the COUNT
+						createcolumn itself. Keep COUNT synchronous, then parallelize the
+						remaining independent aggregate columns. */
+						(define agg_plan_indices (produceN (count ags)))
+						(define count_plan (if needs_count
+							(reduce agg_plan_indices (lambda (found i)
+								(if (not (nil? found))
+									found
+									(if (equal? (agg_col_name (nth ags i)) count_col_name)
+										(nth agg_plans i)
+										nil)))
+								nil)
+							nil))
+						(define non_count_agg_plans (reduce agg_plan_indices (lambda (acc i)
+							(if (and needs_count (equal? (agg_col_name (nth ags i)) count_col_name))
+								acc
+								(merge acc (list (nth agg_plans i)))))
+							'()))
 						(define compute_plan
-							'('time (cons 'parallel agg_plans) "compute"))
+							(if (nil? count_plan)
+								'('time (cons 'parallel agg_plans) "compute")
+								(if (equal? non_count_agg_plans '())
+									(list 'time count_plan "compute")
+									(list 'begin
+										(list 'time count_plan "compute-count")
+										(list 'time (cons 'parallel non_count_agg_plans) "compute")))))
 
 						/* invalidation is handled by registerComputeTriggers in ComputeColumn:
 						DML triggers on the base table invalidate computed columns automatically.
@@ -4507,7 +4536,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 											grouped_plan))))))))
 				))
 			)
-				(begin /* multi-table GROUP BY via prejoin materialization */
+			(begin /* multi-table GROUP BY via prejoin materialization */
 				/* Scoped groups only materialize the tables inside their domain. Outer
 				tables stay outside so the recursive single-table GROUP path can keep the
 				keytable LEFT-joined to the surrounding row stream. Global multi-table
@@ -4956,16 +4985,16 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					(map raw_stage_order (lambda (o) (match o '(col dir)
 						(list (lower_prejoin_lineage_expr col) dir))))))
 				/* rebuild group stage for recursive call */
-					(define grouped_stage (if is_dedup
-						(make_dedup_stage grouped_keys
-							(if (nil? _stage_scope) nil (list prejoin_alias)))
-						(make_group_stage grouped_keys grouped_having grouped_order stage_limit stage_offset
-							(if (nil? _stage_scope) nil (list prejoin_alias))
-							nil)))
-					(define grouped_outer_tables (map _grp_ps_tables (lambda (td) (match td
-						'(tv tschema ttbl toisOuter je)
-						(list (if (nil? tv) ttbl tv) tschema ttbl toisOuter je)
-						td))))
+				(define grouped_stage (if is_dedup
+					(make_dedup_stage grouped_keys
+						(if (nil? _stage_scope) nil (list prejoin_alias)))
+					(make_group_stage grouped_keys grouped_having grouped_order stage_limit stage_offset
+						(if (nil? _stage_scope) nil (list prejoin_alias))
+						nil)))
+				(define grouped_outer_tables (map _grp_ps_tables (lambda (td) (match td
+					'(tv tschema ttbl toisOuter je)
+					(list (if (nil? tv) ttbl tv) tschema ttbl toisOuter je)
+					td))))
 				(define grouped_outer_aliases (map grouped_outer_tables (lambda (td) (match td '(tv _ _ _ _) tv ""))))
 				(define grouped_outer_schema_bindings (merge (map grouped_outer_tables (lambda (td) (match td
 					'(tv tschema ttbl _ _)
@@ -4976,8 +5005,8 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				expressions can still read them after the keytable LEFT JOIN. */
 				(define grouped_plan_condition (if (equal? raw_post_group_condition true) nil
 					(lower_prejoin_lineage_expr raw_post_group_condition)))
-					(define recursive_replace_find_column (lambda (expr)
-						(match expr
+				(define recursive_replace_find_column (lambda (expr)
+					(match expr
 						'((symbol get_column) alias_ _ _ _) (begin
 							(define resolved (replace_find_column expr))
 							(match resolved
@@ -5002,53 +5031,53 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 									resolved
 									(rewrite_as_prejoin_column resolved))
 								_ resolved))
-							(cons sym args) (cons sym (map args recursive_replace_find_column))
-							expr)))
-					(define grouped_fields_for_recursive (if is_dedup
-						(map_assoc raw_fields (lambda (k v)
-							(recursive_replace_find_column v)))
-						grouped_fields))
-					(define transform_recursive_stage (lambda (s)
-						(begin
-							(define _sg (coalesceNil (stage_group_cols s) '()))
-							(define _so (coalesceNil (stage_order_list s) '()))
-							(define _spa (stage_partition_aliases s))
-							(if (stage_is_dedup s)
+						(cons sym args) (cons sym (map args recursive_replace_find_column))
+						expr)))
+				(define grouped_fields_for_recursive (if is_dedup
+					(map_assoc raw_fields (lambda (k v)
+						(recursive_replace_find_column v)))
+					grouped_fields))
+				(define transform_recursive_stage (lambda (s)
+					(begin
+						(define _sg (coalesceNil (stage_group_cols s) '()))
+						(define _so (coalesceNil (stage_order_list s) '()))
+						(define _spa (stage_partition_aliases s))
+						(if (stage_is_dedup s)
+							(stage_preserve_cache_meta s
+								(make_dedup_stage
+									(map _sg recursive_replace_find_column)
+									_spa))
+							(if (and (not (nil? _spa)) (or (nil? _sg) (equal? _sg '())))
 								(stage_preserve_cache_meta s
-									(make_dedup_stage
+									(make_partition_stage
+										_spa
+										(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
+										(coalesceNil (stage_limit_partition_cols s) 0)
+										(stage_limit_val s)
+										(stage_offset_val s)
+										(stage_init_code s)))
+								(stage_preserve_cache_meta s
+									(make_group_stage
 										(map _sg recursive_replace_find_column)
-										_spa))
-								(if (and (not (nil? _spa)) (or (nil? _sg) (equal? _sg '())))
-									(stage_preserve_cache_meta s
-										(make_partition_stage
-											_spa
-											(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
-											(coalesceNil (stage_limit_partition_cols s) 0)
-											(stage_limit_val s)
-											(stage_offset_val s)
-											(stage_init_code s)))
-									(stage_preserve_cache_meta s
-										(make_group_stage
-											(map _sg recursive_replace_find_column)
-											(recursive_replace_find_column (stage_having_expr s))
-											(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
-											(stage_limit_val s)
-											(stage_offset_val s)
-											_spa
-											(stage_init_code s))))))))
-					(define grouped_all_stages (cons grouped_stage
-						(if is_dedup
-							(map rest_groups transform_recursive_stage)
-							rest_groups)))
-					/* drop partition stages covered by the prejoin (all tables materialized) */
-					(define remaining_partition_stages (filter partition_stages (lambda (ps)
+										(recursive_replace_find_column (stage_having_expr s))
+										(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
+										(stage_limit_val s)
+										(stage_offset_val s)
+										_spa
+										(stage_init_code s))))))))
+				(define grouped_all_stages (cons grouped_stage
+					(if is_dedup
+						(map rest_groups transform_recursive_stage)
+						rest_groups)))
+				/* drop partition stages covered by the prejoin (all tables materialized) */
+				(define remaining_partition_stages (filter partition_stages (lambda (ps)
 					(not (reduce (coalesceNil (stage_partition_aliases ps) '()) (lambda (acc a)
 						(or acc (has? known_table_aliases a))) false)))))
-					(define grouped_result (build_queryplan schema
-						(merge (list (list prejoin_alias schema prejointbl false nil)) grouped_outer_tables)
-						grouped_fields_for_recursive
-						grouped_plan_condition
-						(merge grouped_all_stages remaining_partition_stages)
+				(define grouped_result (build_queryplan schema
+					(merge (list (list prejoin_alias schema prejointbl false nil)) grouped_outer_tables)
+					grouped_fields_for_recursive
+					grouped_plan_condition
+					(merge grouped_all_stages remaining_partition_stages)
 					(merge schemas (list prejoin_alias prejoin_schema_def) grouped_outer_schema_bindings)
 					recursive_replace_find_column
 					update_target))
@@ -5680,62 +5709,62 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 											(extract_columns_for_tblvar tblvar effective_later_condition)
 											(extract_outer_columns_for_tblvar tblvar effective_later_condition))))
 										(set filtercols (merge_unique (list (extract_columns_for_tblvar tblvar now_condition) (extract_outer_columns_for_tblvar tblvar now_condition))))
-											/* optimize: skip .(1) DUAL scan when no columns needed (1 row, no data) */
-											(if (and (equal? tbl ".(1)") (equal? cols (list)) (equal? filtercols (list)))
-												(begin
-													/* The skipped DUAL row still carries any constant/materialized
-													predicate that split_scan_condition classified as now_condition.
-													Forward it explicitly, otherwise no-FROM predicates like
-													NOT IN (subselect) vanish before the materialized temp scan
-													can lower their aggregate sentinel. */
-													(define deferred_condition (combine_and_terms (merge
-														(flatten_and_terms now_condition)
-														(flatten_and_terms effective_later_condition))))
-													(build_scan tables deferred_condition last_scan_ctx))
-												(begin
-													/* check partition_stages: does this table have a per-table partition limit? */
-													(define _ps (reduce partition_stages (lambda (a s) (if (nil? a) (if (has? (coalesceNil (stage_partition_aliases s) '()) tblvar) s nil) a)) nil))
-													(if (not (nil? _ps))
-														/* === partition-limited scan_order === */
-														(begin
-															(define _ps_filtercols (merge_unique (list (extract_columns_for_tblvar tblvar now_condition) (extract_outer_columns_for_tblvar tblvar now_condition))))
-															(define _ps_order (coalesceNil (stage_order_list _ps) '()))
-															(define _ps_partcols (coalesceNil (stage_limit_partition_cols _ps) 0))
-															(define _ps_limit (coalesceNil (stage_limit_val _ps) -1))
-															(define _ps_offset (coalesceNil (stage_offset_val _ps) 0))
-															(define _ps_ordercols (merge (map _ps_order (lambda (oi) (match oi '(col dir) (match col
-																'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
-																'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
-																_ '()))))))
-															(define _ps_dirs (merge (map _ps_order (lambda (oi) (match oi '(col dir) (match col
-																'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
-																'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
-																_ '()))))))
-															/* emit init code from partition stage if present */
-															(define _ps_init2 (stage_init_code _ps))
-															(define _ps_scan (scan_wrapper 'scan_order schema tbl
-																(cons list (merge_unique _ps_filtercols cols))
-																'((quote lambda) (map (merge_unique _ps_filtercols cols) (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
-																(cons list _ps_ordercols)
-																(cons list _ps_dirs)
-																_ps_partcols _ps_offset _ps_limit
-																scan_mapcols
-																(list (symbol "lambda") scan_mapfn_params (build_scan tables effective_later_condition (list schema tbl tblvar)))
-																nil nil isOuter))
-															(if (nil? _ps_init2) _ps_scan (list (quote begin) _ps_init2 _ps_scan)))
-														/* === regular scan === */
-														(scan_wrapper 'scan schema tbl
-															(cons list filtercols)
-															'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
+										/* optimize: skip .(1) DUAL scan when no columns needed (1 row, no data) */
+										(if (and (equal? tbl ".(1)") (equal? cols (list)) (equal? filtercols (list)))
+											(begin
+												/* The skipped DUAL row still carries any constant/materialized
+												predicate that split_scan_condition classified as now_condition.
+												Forward it explicitly, otherwise no-FROM predicates like
+												NOT IN (subselect) vanish before the materialized temp scan
+												can lower their aggregate sentinel. */
+												(define deferred_condition (combine_and_terms (merge
+													(flatten_and_terms now_condition)
+													(flatten_and_terms effective_later_condition))))
+												(build_scan tables deferred_condition last_scan_ctx))
+											(begin
+												/* check partition_stages: does this table have a per-table partition limit? */
+												(define _ps (reduce partition_stages (lambda (a s) (if (nil? a) (if (has? (coalesceNil (stage_partition_aliases s) '()) tblvar) s nil) a)) nil))
+												(if (not (nil? _ps))
+													/* === partition-limited scan_order === */
+													(begin
+														(define _ps_filtercols (merge_unique (list (extract_columns_for_tblvar tblvar now_condition) (extract_outer_columns_for_tblvar tblvar now_condition))))
+														(define _ps_order (coalesceNil (stage_order_list _ps) '()))
+														(define _ps_partcols (coalesceNil (stage_limit_partition_cols _ps) 0))
+														(define _ps_limit (coalesceNil (stage_limit_val _ps) -1))
+														(define _ps_offset (coalesceNil (stage_offset_val _ps) 0))
+														(define _ps_ordercols (merge (map _ps_order (lambda (oi) (match oi '(col dir) (match col
+															'((symbol get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
+															'((quote get_column) alias_ ti col _) (if ((if ti equal?? equal?) alias_ tblvar) (list col) '())
+															_ '()))))))
+														(define _ps_dirs (merge (map _ps_order (lambda (oi) (match oi '(col dir) (match col
+															'((symbol get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
+															'((quote get_column) alias_ ti _ _) (if ((if ti equal?? equal?) alias_ tblvar) (list dir) '())
+															_ '()))))))
+														/* emit init code from partition stage if present */
+														(define _ps_init2 (stage_init_code _ps))
+														(define _ps_scan (scan_wrapper 'scan_order schema tbl
+															(cons list (merge_unique _ps_filtercols cols))
+															'((quote lambda) (map (merge_unique _ps_filtercols cols) (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
+															(cons list _ps_ordercols)
+															(cons list _ps_dirs)
+															_ps_partcols _ps_offset _ps_limit
 															scan_mapcols
 															(list (symbol "lambda") scan_mapfn_params (build_scan tables effective_later_condition (list schema tbl tblvar)))
-															(if is_update_target (symbol "+") nil)
-															(if is_update_target 0 nil)
-															nil
-															isOuter
-													))))
-										))
-									)
+															nil nil isOuter))
+														(if (nil? _ps_init2) _ps_scan (list (quote begin) _ps_init2 _ps_scan)))
+													/* === regular scan === */
+													(scan_wrapper 'scan schema tbl
+														(cons list filtercols)
+														'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
+														scan_mapcols
+														(list (symbol "lambda") scan_mapfn_params (build_scan tables effective_later_condition (list schema tbl tblvar)))
+														(if is_update_target (symbol "+") nil)
+														(if is_update_target 0 nil)
+														nil
+														isOuter
+										))))
+									))
+								)
 								'() /* final inner (=scalar) */ (if (nil? update_target)
 									(begin
 										(define emit_fields (if (nil? last_scan_ctx) fields
@@ -5757,7 +5786,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							)
 						))
 						(build_scan tables (replace_find_column condition) nil)
+			)))
 	)))
-)))
 )))
 )

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1684,7 +1684,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(define body sql_trigger_body)
 		) (begin
 				(define compiled (compile_trigger_body schema timing (car (cdr body))))
-				(list 'createtrigger schema tbl name timing (car body) (eval compiled) true)
+				(list 'createtrigger schema tbl name timing (car body) (list 'quote (list 'deferred_trigger compiled)) true)
 		))
 		/* DROP TRIGGER syntax */
 		(parser '((atom "DROP" true) (atom "TRIGGER" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define name sql_identifier))

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -36,7 +36,14 @@ func newCachedColumnReader(col ColumnStorage) ColumnReader {
 	return col.GetCachedReader()
 }
 
-func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {
+func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {
+	t.schema.schemalock.Lock()
+	metadataLocked := true
+	defer func() {
+		if metadataLocked {
+			t.schema.schemalock.Unlock()
+		}
+	}()
 	for i, c := range t.Columns {
 		if c.Name == name {
 			// found the column
@@ -44,6 +51,8 @@ func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scme
 			t.Columns[i].ComputorInputCols = inputCols
 			// register cache invalidation triggers on source tables
 			t.registerComputeTriggers(name, computor)
+			t.schema.schemalock.Unlock()
+			metadataLocked = false
 			done := make(chan error, 6)
 			shardlist := t.ActiveShards()
 			for i, s := range shardlist {
@@ -61,8 +70,6 @@ func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scme
 							s = s.rebuild(false)
 							shardlist[i] = s
 							t.mu.Unlock()
-							// persist new shard UUID after publishing
-							t.schema.save()
 						}
 						done <- nil
 					}
@@ -82,10 +89,20 @@ func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scme
 				}
 				GlobalCache.UpdateSize(c, totalRows*16) // ~16 bytes per value estimate
 			}
+			t.schema.schemalock.Lock()
+			metadataLocked = true
+			t.finishSchemaMutationLocked()
+			metadataLocked = false
 			return
 		}
 	}
 	panic("column " + t.Name + "." + name + " does not exist")
+}
+
+func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {
+	t.ddlMu.Lock()
+	defer t.ddlMu.Unlock()
+	t.computeColumnDDLLocked(name, inputCols, computor, filterCols, filter)
 }
 
 func (s *storageShard) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer, parallel bool) bool {
@@ -159,9 +176,10 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 // mapFn:     (lambda ($set mapCols...) ...) — passes data through to reduceFn
 // reduceFn:  (lambda (acc mapped) ...) — calls ($set newVal), returns new acc
 // reduceInit: initial accumulator value
-func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
+func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
 	found := false
 	paramsChanged := false
+	t.schema.schemalock.Lock()
 	for i, c := range t.Columns {
 		if c.Name == name {
 			// Detect parameter changes (different OVER clause on same column).
@@ -179,12 +197,19 @@ func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []
 		}
 	}
 	if !found {
+		t.schema.schemalock.Unlock()
 		panic("ComputeOrderedColumn: column " + t.Name + "." + name + " does not exist")
 	}
 
+	// Register triggers while the table-local DDL contract is held and persist
+	// the new ORC metadata atomically into schema.json before any rebuild can
+	// publish a stale shard snapshot of this table.
+	t.registerORCTriggers(name)
+	t.finishSchemaMutationLocked()
+
 	// Ensure every shard has an ORC proxy (lazy: no eager recompute).
 	// If ORC params changed (different OVER clause), invalidate all proxies.
-	for _, s := range t.ActiveShards() {
+	for _, s := range t.maintenanceShards() {
 		t.initORCShard(s, name)
 		if paramsChanged {
 			s.mu.RLock()
@@ -195,12 +220,12 @@ func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []
 			}
 		}
 	}
+}
 
-	// Register triggers: mutations → partial invalidation.
-	t.registerORCTriggers(name)
-
-	// Persist ORC parameters and trigger registrations.
-	t.schema.save()
+func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
+	t.ddlMu.Lock()
+	defer t.ddlMu.Unlock()
+	t.computeOrderedColumnDDLLocked(name, sortCols, sortDirs, partCount, mapCols, mapFn, reduceFn, reduceInit)
 }
 
 // initORCShard ensures a StorageComputeProxy with isOrdered=true exists on shard s.
@@ -243,7 +268,7 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 	defer func() {
 		// Record recompute cost for invalidation telemetry
 		recomputeNs := time.Since(recomputeStart).Nanoseconds()
-		for _, s := range t.ActiveShards() {
+		for _, s := range t.maintenanceShards() {
 			s.mu.RLock()
 			if proxy, ok := s.columns[name].(*StorageComputeProxy); ok {
 				proxy.ResetInvalidationTelemetry(recomputeNs)
@@ -409,13 +434,13 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 	// Telemetry debounce: if cumulative invalidation cost exceeds last recompute
 	// cost, skip selective invalidation — just mark all dirty. The next read will
 	// do a single full recompute instead of many small ones.
-	for _, s := range t.ActiveShards() {
+	for _, s := range t.maintenanceShards() {
 		s.mu.RLock()
 		if proxy, ok := s.columns[colName].(*StorageComputeProxy); ok {
 			if proxy.ShouldSkipSelectiveInvalidation() {
 				s.mu.RUnlock()
 				// Full invalidation is cheaper at this point
-				for _, s2 := range t.ActiveShards() {
+				for _, s2 := range t.maintenanceShards() {
 					s2.mu.RLock()
 					if p2, ok := s2.columns[colName].(*StorageComputeProxy); ok {
 						p2.InvalidateAll()
@@ -492,7 +517,7 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 	}
 
 	// Parallel invalidation across shards using index-accelerated iteration.
-	shards := t.ActiveShards()
+	shards := t.maintenanceShards()
 	var wg sync.WaitGroup
 	wg.Add(len(shards))
 	for _, s := range shards {

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -51,6 +51,50 @@ type StorageComputeProxy struct {
 	lastRecomputeNs       atomic.Int64 // nanoseconds of the last full/suffix recompute
 }
 
+// cloneComputeProxyRows ports a compute/ORC proxy onto a rebuilt shard without
+// evaluating the computor. Cached rows stay cached, invalid rows stay lazy.
+func cloneComputeProxyRows(oldProxy *StorageComputeProxy, newShard *storageShard, oldRowIDs []uint32) *StorageComputeProxy {
+	newProxy := &StorageComputeProxy{
+		delta:     make(map[uint32]scm.Scmer),
+		computor:  oldProxy.computor,
+		inputCols: oldProxy.inputCols,
+		shard:     newShard,
+		colName:   oldProxy.colName,
+		count:     uint32(len(oldRowIDs)),
+		isOrdered: oldProxy.isOrdered,
+	}
+	appendComputeProxyRows(newProxy, oldProxy, oldRowIDs, 0)
+	return newProxy
+}
+
+func appendComputeProxyRows(newProxy *StorageComputeProxy, oldProxy *StorageComputeProxy, oldRowIDs []uint32, startIdx uint32) uint32 {
+	if oldProxy.isOrdered && oldProxy.shard != nil && oldProxy.shard.t != nil {
+		// Ordered-reduce proxies are populated under table.orcMu. Rebuild must
+		// not snapshot them mid-recompute, otherwise a background rebuild can
+		// publish an all-invalid proxy even though a foreground query just
+		// materialized the values on the old shard.
+		oldProxy.shard.t.orcMu.Lock()
+		defer oldProxy.shard.t.orcMu.Unlock()
+	}
+	oldProxy.mu.RLock()
+	defer oldProxy.mu.RUnlock()
+	newIdx := startIdx
+	for _, oldIdx := range oldRowIDs {
+		if !oldProxy.compressed && !oldProxy.validMask.Get(uint(oldIdx)) {
+			newIdx++
+			continue
+		}
+		val, inDelta := oldProxy.delta[oldIdx]
+		if !inDelta && oldProxy.main != nil {
+			val = oldProxy.main.GetValue(oldIdx)
+		}
+		newProxy.delta[newIdx] = val
+		newProxy.validMask.Set(uint(newIdx), true)
+		newIdx++
+	}
+	return newIdx
+}
+
 func (p *StorageComputeProxy) String() string {
 	return "compute-proxy"
 }
@@ -65,7 +109,6 @@ func (p *StorageComputeProxy) orcCol() *column {
 	return nil
 }
 
-
 func (p *StorageComputeProxy) ComputeSize() uint {
 	var sz uint = 128 // struct overhead
 	sz += p.validMask.ComputeSize()
@@ -75,7 +118,6 @@ func (p *StorageComputeProxy) ComputeSize() uint {
 	}
 	return sz
 }
-
 
 // GetValue returns the value at idx, computing on demand if necessary.
 func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
@@ -378,51 +420,6 @@ func (p *StorageComputeProxy) ResetInvalidationTelemetry(recomputeNs int64) {
 	}
 }
 
-// safeProxyReader wraps a StorageComputeProxy for use during shard rebuild.
-// It reads only cached/valid values without triggering the computor lambda,
-// preventing infinite recursion when the computor scans other tables that
-// are being concurrently rebuilt. Invalid rows return nil.
-type safeProxyReader struct {
-	proxy *StorageComputeProxy
-}
-
-func (s *safeProxyReader) GetValue(idx uint32) scm.Scmer {
-	p := s.proxy
-	if p.compressed {
-		if p.main != nil {
-			return p.main.GetValue(idx)
-		}
-		return scm.NewNil()
-	}
-	if p.validMask.Get(uint(idx)) {
-		p.mu.RLock()
-		if val, ok := p.delta[idx]; ok {
-			p.mu.RUnlock()
-			return val
-		}
-		p.mu.RUnlock()
-		if p.main != nil {
-			return p.main.GetValue(idx)
-		}
-	}
-	return scm.NewNil() // invalid row — skip computor, return nil
-}
-
-func (s *safeProxyReader) GetCachedReader() ColumnReader { return s }
-func (s *safeProxyReader) String() string                { return "safe-proxy-reader" }
-func (s *safeProxyReader) ComputeSize() uint             { return s.proxy.ComputeSize() }
-func (s *safeProxyReader) proposeCompression(i uint32) ColumnStorage { return nil }
-func (s *safeProxyReader) prepare()                      { /* delegated to outer rebuild loop */ }
-func (s *safeProxyReader) scan(i uint32, v scm.Scmer)    { /* delegated */ }
-func (s *safeProxyReader) init(i uint32)                  { /* delegated */ }
-func (s *safeProxyReader) build(i uint32, v scm.Scmer)   { /* delegated */ }
-func (s *safeProxyReader) finish()                        { /* delegated */ }
-func (s *safeProxyReader) Serialize(w io.Writer)             { /* not persisted */ }
-func (s *safeProxyReader) Deserialize(r io.Reader) uint      { return 0 }
-
-// proposeCompression returns nil — the proxy does not participate in shard
-// rebuild's compression loop. During rebuild, the old proxy is READ via
-// GetCachedReader/GetValue and a NEW storage is built by the rebuild loop.
 func (p *StorageComputeProxy) proposeCompression(i uint32) ColumnStorage {
 	return nil
 }
@@ -446,8 +443,8 @@ func (p *StorageComputeProxy) finish() {
 // Serialize writes the proxy to the given writer.
 // storageComputeProxyVersion is the current binary format version for StorageComputeProxy.
 // Increment this constant and add a new deserializeComputeProxyV* helper whenever the
-// layout after the magic byte changes.  Never delete old helpers.
-const storageComputeProxyVersion = 1
+// layout after the magic byte changes. Never delete old helpers.
+const storageComputeProxyVersion = 2
 
 // StorageComputeProxy binary layout (magic byte 50 consumed by shard loader):
 //
@@ -467,7 +464,9 @@ const storageComputeProxyVersion = 1
 // Version history:
 //
 //	0: layout as above.
-//	1: adds [isOrdered uint8] after validMask (1=ORC column, 0=regular computed column).
+//	1: adds [isOrdered uint8] after validMask, but validMask indices were written
+//	   via binary.Write(uint), so persisted data may miss the bitmap payload.
+//	2: writes validMask indices as uint32 and keeps the trailing isOrdered byte.
 func (p *StorageComputeProxy) Serialize(f io.Writer) {
 	binary.Write(f, binary.LittleEndian, uint8(50))                         // magic byte
 	binary.Write(f, binary.LittleEndian, uint8(storageComputeProxyVersion)) // version byte
@@ -519,7 +518,7 @@ func (p *StorageComputeProxy) Serialize(f io.Writer) {
 	validCount := p.validMask.Count()
 	binary.Write(f, binary.LittleEndian, uint32(validCount))
 	p.validMask.Iterate(func(idx uint) {
-		binary.Write(f, binary.LittleEndian, idx)
+		binary.Write(f, binary.LittleEndian, uint32(idx))
 	})
 
 	// v1: isOrdered flag
@@ -540,9 +539,40 @@ func (p *StorageComputeProxy) Deserialize(f io.Reader) uint {
 		return p.deserializeComputeProxyV0(f)
 	case 1:
 		return p.deserializeComputeProxyV1(f)
+	case 2:
+		return p.deserializeComputeProxyV2(f)
 	default:
 		panic(fmt.Sprintf("StorageComputeProxy: unknown version %d", version))
 	}
+}
+
+func (p *StorageComputeProxy) restoreValidMaskFromPayload() {
+	p.validMask = NonLockingReadMap.NonBlockingBitMap{}
+	if p.compressed && p.main != nil {
+		for idx := uint32(0); idx < p.count; idx++ {
+			p.validMask.Set(uint(idx), true)
+		}
+		return
+	}
+	for idx := range p.delta {
+		p.validMask.Set(uint(idx), true)
+	}
+}
+
+func (p *StorageComputeProxy) readValidMaskV2(f io.Reader) error {
+	p.validMask = NonLockingReadMap.NonBlockingBitMap{}
+	var validCount uint32
+	if err := binary.Read(f, binary.LittleEndian, &validCount); err != nil {
+		return err
+	}
+	for i := uint32(0); i < validCount; i++ {
+		var idx uint32
+		if err := binary.Read(f, binary.LittleEndian, &idx); err != nil {
+			return err
+		}
+		p.validMask.Set(uint(idx), true)
+	}
+	return nil
 }
 
 func (p *StorageComputeProxy) deserializeComputeProxyV0(f io.Reader) uint {
@@ -600,25 +630,32 @@ func (p *StorageComputeProxy) deserializeComputeProxyV0(f io.Reader) uint {
 		}
 	}
 
-	// validMask
 	if p.delta == nil {
 		p.delta = make(map[uint32]scm.Scmer)
 	}
-	var validCount uint32
-	binary.Read(f, binary.LittleEndian, &validCount)
-	for i := uint32(0); i < validCount; i++ {
-		var idx uint32
-		binary.Read(f, binary.LittleEndian, &idx)
-		p.validMask.Set(uint(idx), true)
+	if err := p.readValidMaskV2(f); err != nil {
+		// Legacy proxy files before v2 wrote the bitmap payload incorrectly.
+		// Reconstruct validity from the persisted value payload instead of
+		// treating every row as invalid after reload.
+		p.restoreValidMaskFromPayload()
 	}
 
-	// shard back-reference is set by post-load hook in ensureColumnLoaded
+	// shard/column runtime bindings are restored by the post-load hook in
+	// ensureColumnLoaded.
 	return uint(p.count)
 }
 
 func (p *StorageComputeProxy) deserializeComputeProxyV1(f io.Reader) uint {
 	n := p.deserializeComputeProxyV0(f)
 	// v1 adds isOrdered byte after validMask
+	var isOrderedByte uint8
+	binary.Read(f, binary.LittleEndian, &isOrderedByte)
+	p.isOrdered = isOrderedByte != 0
+	return n
+}
+
+func (p *StorageComputeProxy) deserializeComputeProxyV2(f io.Reader) uint {
+	n := p.deserializeComputeProxyV0(f)
 	var isOrderedByte uint8
 	binary.Read(f, binary.LittleEndian, &isOrderedByte)
 	p.isOrdered = isOrderedByte != 0

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -80,12 +80,25 @@ func appendComputeProxyRows(newProxy *StorageComputeProxy, oldProxy *StorageComp
 	defer oldProxy.mu.RUnlock()
 	newIdx := startIdx
 	for _, oldIdx := range oldRowIDs {
-		if !oldProxy.compressed && !oldProxy.validMask.Get(uint(oldIdx)) {
-			newIdx++
-			continue
-		}
 		val, inDelta := oldProxy.delta[oldIdx]
-		if !inDelta && oldProxy.main != nil {
+		if !inDelta {
+			// Proxy row ids may refer to forwarded delta rows that were inserted
+			// after the proxy's main storage was materialized. Those rows are only
+			// safe to port if they have an explicit cached delta entry; otherwise
+			// they must stay lazy-invalid on the rebuilt shard instead of reading
+			// past the old main storage.
+			if oldIdx >= oldProxy.count {
+				newIdx++
+				continue
+			}
+			if !oldProxy.compressed && !oldProxy.validMask.Get(uint(oldIdx)) {
+				newIdx++
+				continue
+			}
+			if oldProxy.main == nil {
+				newIdx++
+				continue
+			}
 			val = oldProxy.main.GetValue(oldIdx)
 		}
 		newProxy.delta[newIdx] = val
@@ -156,34 +169,37 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 			return val
 		}
 		p.mu.RUnlock()
-		if p.main != nil {
+		if idx < p.count && p.main != nil {
 			return p.main.GetValue(idx)
 		}
 		return scm.NewNil()
 	}
 
-	// Fast path 1: fully compressed → all values in main
-	if p.compressed {
+	// Delta entries shadow main storage and are also used for rows appended
+	// after the proxy's materialized main storage was built.
+	p.mu.RLock()
+	if val, ok := p.delta[idx]; ok {
+		p.mu.RUnlock()
+		return val
+	}
+	p.mu.RUnlock()
+
+	// Fast path 1: fully compressed → value is in main storage for main rows.
+	if p.compressed && idx < p.count && p.main != nil {
 		return p.main.GetValue(idx)
 	}
 
-	// Fast path 2: valid bit set → value in delta or main
-	if p.validMask.Get(uint(idx)) {
-		p.mu.RLock()
-		if val, ok := p.delta[idx]; ok {
-			p.mu.RUnlock()
-			return val
-		}
-		p.mu.RUnlock()
-		if p.main != nil {
-			return p.main.GetValue(idx)
-		}
+	// Fast path 2: valid bit set → value is cached in main storage for main rows.
+	if p.validMask.Get(uint(idx)) && idx < p.count && p.main != nil {
+		return p.main.GetValue(idx)
 	}
 
 	// Slow path: compute on demand
 	colvalues := make([]scm.Scmer, len(p.inputCols))
 	for i, col := range p.inputCols {
-		colvalues[i] = p.shard.getColumnStorageOrPanic(col).GetValue(idx)
+		// Delta rows must be read via the shard-level ColumnReader; direct
+		// ColumnStorage access only understands main-row indexes.
+		colvalues[i] = p.shard.ColumnReader(col)(idx)
 	}
 	val := scm.Apply(p.computor, colvalues...)
 

--- a/storage/database.go
+++ b/storage/database.go
@@ -35,8 +35,23 @@ type database struct {
 	// snapshots. Heavy table maintenance must snapshot under finer-grained
 	// locks and release schemalock before doing expensive work.
 	schemalock sync.RWMutex `json:"-"`
-	saveMu     sync.Mutex   `json:"-"`
-	blobMu     sync.Mutex   `json:"-"` // serializes IncrBlobRefcount/DecrBlobRefcount
+	// saveMu/ saveCond serialize schema.json commits per database.
+	// Software contract:
+	//   - every caller still waits until its schema mutation is persisted
+	//   - concurrent callers may coalesce into one later snapshot write
+	//     instead of forcing N full schema.json rewrites in sequence
+	//   - durable=true (Safe engine metadata) upgrades the coalesced write to
+	//     a fully synced commit; non-durable callers may piggyback on it
+	saveMu          sync.Mutex `json:"-"`
+	saveCondOnce    sync.Once  `json:"-"`
+	saveCond        *sync.Cond `json:"-"`
+	saveRequested   uint64     `json:"-"`
+	saveCompleted   uint64     `json:"-"`
+	saveInFlight    bool       `json:"-"`
+	savePending     []byte     `json:"-"`
+	savePendingSync bool       `json:"-"`
+	savePanic       any        `json:"-"`
+	blobMu          sync.Mutex `json:"-"` // serializes IncrBlobRefcount/DecrBlobRefcount
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
@@ -45,6 +60,10 @@ type database struct {
 type rebuildDatabaseResult struct {
 	replaced []*storageShard
 	errors   []string
+}
+
+type schemaWriteOptions interface {
+	WriteSchemaWithMode(schema []byte, durable bool)
 }
 
 // Custom JSON to persist private tables field
@@ -206,6 +225,78 @@ func LoadDatabases() {
 	ensureSystemStatistic()
 }
 
+func (db *database) writeSchema(jsonbytes []byte, durable bool) {
+	if writer, ok := db.persistence.(schemaWriteOptions); ok {
+		writer.WriteSchemaWithMode(jsonbytes, durable)
+		return
+	}
+	db.persistence.WriteSchema(jsonbytes)
+}
+
+func (db *database) getSaveCond() *sync.Cond {
+	db.saveCondOnce.Do(func() {
+		db.saveCond = sync.NewCond(&db.saveMu)
+	})
+	return db.saveCond
+}
+
+func (db *database) commitSchemaSnapshot(jsonbytes []byte, durable bool) {
+	db.saveMu.Lock()
+	cond := db.getSaveCond()
+	db.saveRequested++
+	seq := db.saveRequested
+	db.savePending = jsonbytes
+	db.savePendingSync = db.savePendingSync || durable
+	if db.savePanic != nil && !db.saveInFlight {
+		db.savePanic = nil
+	}
+	if db.saveInFlight {
+		for db.saveCompleted < seq && db.savePanic == nil {
+			cond.Wait()
+		}
+		panicVal := db.savePanic
+		db.saveMu.Unlock()
+		if panicVal != nil {
+			panic(panicVal)
+		}
+		return
+	}
+	db.saveInFlight = true
+	db.savePanic = nil
+	for {
+		snapshot := db.savePending
+		writeSync := db.savePendingSync
+		targetSeq := db.saveRequested
+		db.savePending = nil
+		db.savePendingSync = false
+		db.saveMu.Unlock()
+
+		var panicVal any
+		func() {
+			defer func() {
+				panicVal = recover()
+			}()
+			db.writeSchema(snapshot, writeSync)
+		}()
+
+		db.saveMu.Lock()
+		if panicVal != nil {
+			db.savePanic = panicVal
+			db.saveInFlight = false
+			cond.Broadcast()
+			db.saveMu.Unlock()
+			panic(panicVal)
+		}
+		db.saveCompleted = targetSeq
+		cond.Broadcast()
+		if db.savePending == nil {
+			db.saveInFlight = false
+			db.saveMu.Unlock()
+			return
+		}
+	}
+}
+
 func (db *database) save() {
 	if db.srState == COLD {
 		// Do not serialize a cold database; keep existing schema.json intact
@@ -213,10 +304,8 @@ func (db *database) save() {
 	}
 	db.schemalock.RLock()
 	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
-	db.saveMu.Lock()
 	db.schemalock.RUnlock()
-	defer db.saveMu.Unlock()
-	db.persistence.WriteSchema(jsonbytes)
+	db.commitSchemaSnapshot(jsonbytes, true)
 	// shards are written while rebuild
 }
 
@@ -224,15 +313,17 @@ func (db *database) save() {
 // releases schemalock before performing the synchronous schema write.
 // Callers must already hold db.schemalock.Lock().
 func (db *database) saveLockedAndUnlock() {
+	db.saveLockedWithDurabilityAndUnlock(true)
+}
+
+func (db *database) saveLockedWithDurabilityAndUnlock(durable bool) {
 	if db.srState == COLD {
 		db.schemalock.Unlock()
 		return
 	}
 	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
-	db.saveMu.Lock()
 	db.schemalock.Unlock()
-	defer db.saveMu.Unlock()
-	db.persistence.WriteSchema(jsonbytes)
+	db.commitSchemaSnapshot(jsonbytes, durable)
 }
 
 // ensureLoaded loads schema.json into the database struct exactly once.
@@ -343,11 +434,12 @@ func (db *database) GetTable(name string) *table {
 func (db *database) ShowTables() scm.Scmer {
 	db.ensureLoaded()
 	tables := db.tables.GetAll()
-	result := make([]scm.Scmer, len(tables))
-	i := 0
+	result := make([]scm.Scmer, 0, len(tables))
 	for _, t := range tables {
-		result[i] = scm.NewString(t.Name)
-		i = i + 1
+		if t.isHiddenFromShowTables() {
+			continue
+		}
+		result = append(result, scm.NewString(t.Name))
 	}
 	return scm.NewSlice(result)
 }
@@ -372,7 +464,9 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 		go func(t *table) {
 			tableLocked := false
 			rebuildClaimed := false
+			t.ddlMu.RLock()
 			defer func() {
+				t.ddlMu.RUnlock()
 				if r := recover(); r != nil {
 					errmsg := fmt.Sprintf("rebuild failed for table %s.%s: %v", db.Name, t.Name, r)
 					fmt.Println("error:", errmsg)
@@ -394,6 +488,9 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 				}
 				done.Done()
 			}()
+			if t.isEphemeralQueryTable() {
+				return
+			}
 			t.mu.Lock() // table lock
 			tableLocked = true
 			if t.rebuilding {
@@ -538,6 +635,15 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 			// Decide on repartition while holding t.mu, but execute it
 			// OUTSIDE the table lock so concurrent inserts can proceed
 			// and the dual-write mechanism works correctly.
+			//
+			// Contract:
+			//   - manual/queryplan partitiontable drives explicit repartitioning
+			//   - db.rebuild() only repartitions when proposerepartition says the
+			//     physical layout should actually change
+			//   - a plain rebuild must not silently convert every free table into
+			//     "partitioned with one shard", because that touches unrelated
+			//     tables during shared rebuild tests without any layout benefit
+			//
 			// Also claim repartitionActive under t.mu so a concurrent
 			// rebuild (e.g. the 15-min scheduler) sees the flag and
 			// skips its own repartition instead of racing.
@@ -546,7 +652,23 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 			if repartition && !hasColdShard && !t.repartitionActive {
 				var shouldChange bool
 				shardCandidates, shouldChange = t.proposerepartition(maincount)
-				doRepart = shouldChange || (t.ShardMode == ShardModeFree && t.Shards != nil)
+				if shouldChange {
+					if len(shardCandidates) > 0 {
+						doRepart = true
+					} else {
+						// No explicit partition dimensions means repartition() would
+						// fall back to generic parallel sharding. Only do that when
+						// it would actually create more than one shard; otherwise a
+						// small free table would be pointlessly converted into
+						// "partitioned with one shard" during a global rebuild.
+						desiredShards := int(1 + (2*maincount)/Settings.ShardSize)
+						minShards := 2 * runtime.NumCPU()
+						if desiredShards < minShards && maincount > Settings.ShardSize {
+							desiredShards = minShards
+						}
+						doRepart = desiredShards > 1
+					}
+				}
 			}
 			if doRepart {
 				t.repartitionActive = true // claim under t.mu — atomic with the doRepart decision
@@ -558,7 +680,7 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 			tableLocked = false
 
 			if doRepart {
-				t.repartition(shardCandidates)
+				t.repartitionDDLReadLocked(shardCandidates)
 			}
 		}(t)
 	}
@@ -793,7 +915,7 @@ func CreateTable(schema, name string, pm PersistencyMode, ifnotexists bool) (*ta
 		db.schemalock.Unlock()
 		return t, false
 	}
-	db.saveLockedAndUnlock()
+	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 	registerCreatedTable(t)
 	return t, true
 }
@@ -854,7 +976,7 @@ func DropTable(schema, name string, ifexists bool) {
 		panic("Table " + schema + "." + name + " does not exist")
 	}
 	db.tables.Remove(name)
-	db.saveLockedAndUnlock()
+	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 	// fire AfterDropTable triggers after releasing schemalock (avoids deadlock on cascading drops)
 	t.ExecuteTableLifecycleTriggers(AfterDropTable)
 
@@ -899,7 +1021,7 @@ func RenameTable(schema, oldname, newname string) {
 	db.tables.Remove(oldname)
 	t.Name = newname
 	db.tables.Set(t)
-	db.saveLockedAndUnlock()
+	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 }
 
 // keytableCleanup is called by the CacheManager when evicting a temp keytable.
@@ -919,7 +1041,7 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 			return false // schemalock is held (e.g. by CreateTable); retry later
 		}
 		db.tables.Remove(tbl.Name) // no-op if already removed by DropTable
-		db.saveLockedAndUnlock()
+		db.saveLockedWithDurabilityAndUnlock(tbl.PersistencyMode == Safe)
 	}
 	// remove all shard+index+temp column registrations for this table (recursive)
 	for _, c := range tbl.Columns {

--- a/storage/database.go
+++ b/storage/database.go
@@ -31,8 +31,12 @@ type database struct {
 	Name        string                                             `json:"name"`
 	persistence PersistenceEngine                                  `json:"-"`
 	tables      NonLockingReadMap.NonLockingReadMap[table, string] `json:"-"`
-	schemalock  sync.RWMutex                                       `json:"-"` // TODO: rw-locks for schemalock
-	blobMu      sync.Mutex                                         `json:"-"` // serializes IncrBlobRefcount/DecrBlobRefcount
+	// schemalock protects database-local schema membership and metadata
+	// snapshots. Heavy table maintenance must snapshot under finer-grained
+	// locks and release schemalock before doing expensive work.
+	schemalock sync.RWMutex `json:"-"`
+	saveMu     sync.Mutex   `json:"-"`
+	blobMu     sync.Mutex   `json:"-"` // serializes IncrBlobRefcount/DecrBlobRefcount
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
@@ -207,9 +211,28 @@ func (db *database) save() {
 		// Do not serialize a cold database; keep existing schema.json intact
 		return
 	}
+	db.schemalock.RLock()
 	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
+	db.saveMu.Lock()
+	db.schemalock.RUnlock()
+	defer db.saveMu.Unlock()
 	db.persistence.WriteSchema(jsonbytes)
 	// shards are written while rebuild
+}
+
+// saveLockedAndUnlock snapshots the schema while schemalock is held, then
+// releases schemalock before performing the synchronous schema write.
+// Callers must already hold db.schemalock.Lock().
+func (db *database) saveLockedAndUnlock() {
+	if db.srState == COLD {
+		db.schemalock.Unlock()
+		return
+	}
+	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
+	db.saveMu.Lock()
+	db.schemalock.Unlock()
+	defer db.saveMu.Unlock()
+	db.persistence.WriteSchema(jsonbytes)
 }
 
 // ensureLoaded loads schema.json into the database struct exactly once.
@@ -263,6 +286,49 @@ func (db *database) ensureLoaded() {
 	db.srState = SHARED
 }
 
+func triggerTimingSQL(timing TriggerTiming) string {
+	switch timing {
+	case BeforeInsert:
+		return "BEFORE INSERT"
+	case AfterInsert:
+		return "AFTER INSERT"
+	case BeforeUpdate:
+		return "BEFORE UPDATE"
+	case AfterUpdate:
+		return "AFTER UPDATE"
+	case BeforeDelete:
+		return "BEFORE DELETE"
+	case AfterDelete:
+		return "AFTER DELETE"
+	case AfterDropTable:
+		return "AFTER DROP TABLE"
+	case AfterDropColumn:
+		return "AFTER DROP COLUMN"
+	case AfterInvalidate:
+		return "AFTER INVALIDATE"
+	default:
+		panic("unknown trigger timing")
+	}
+}
+
+func loadPersistedTriggerPlan(schemaName, tableName string, trigger *TriggerDescription) {
+	if !triggerScmerMissing(trigger.Func) || !triggerScmerMissing(trigger.FuncPlan) || trigger.SourceSQL == "" {
+		return
+	}
+	parseSQL := scm.Globalenv.Vars[scm.Symbol("parse_sql")]
+	allow := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	sql := fmt.Sprintf("CREATE TRIGGER `%s` %s ON `%s` FOR EACH ROW %s", trigger.Name, triggerTimingSQL(trigger.Timing), tableName, trigger.SourceSQL)
+	plan := scm.Apply(parseSQL, scm.NewString(schemaName), scm.NewString(sql), allow)
+	if !plan.IsSlice() {
+		panic("persisted trigger parse did not return an AST")
+	}
+	items := plan.Slice()
+	if len(items) < 7 {
+		panic("persisted trigger AST is incomplete")
+	}
+	trigger.Func, trigger.FuncPlan = unwrapDeferredTriggerBody(items[6])
+}
+
 // SharedResource impl for database
 func (db *database) GetState() SharedState { return db.srState }
 func (db *database) GetRead() func()       { db.ensureLoaded(); return func() {} }
@@ -305,6 +371,7 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 	for _, t := range dbs {
 		go func(t *table) {
 			tableLocked := false
+			rebuildClaimed := false
 			defer func() {
 				if r := recover(); r != nil {
 					errmsg := fmt.Sprintf("rebuild failed for table %s.%s: %v", db.Name, t.Name, r)
@@ -317,15 +384,34 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 						func() { defer func() { _ = recover() }(); t.mu.Unlock() }()
 					}
 				}
+				if rebuildClaimed {
+					func() {
+						defer func() { _ = recover() }()
+						t.mu.Lock()
+						t.rebuilding = false
+						t.mu.Unlock()
+					}()
+				}
 				done.Done()
 			}()
 			t.mu.Lock() // table lock
 			tableLocked = true
+			if t.rebuilding {
+				t.mu.Unlock()
+				tableLocked = false
+				return
+			}
+			t.rebuilding = true
+			rebuildClaimed = true
 			// TODO: check LRU statistics and remove unused computed columns
 
-			// rebuild shards without mutating the live shard list; swap when complete
+			// Snapshot the active shard list, then release t.mu while the
+			// expensive shard rebuild runs. Writers must not be blocked on
+			// the whole sdone.Wait() phase.
 			targetIsP := t.ShardMode == ShardModePartition
-			origShardList := t.ActiveShards()
+			origShardList := append([]*storageShard(nil), t.ActiveShards()...)
+			t.mu.Unlock()
+			tableLocked = false
 			newShardList := make([]*storageShard, len(origShardList))
 			// Track if any shard is still COLD to avoid triggering repartition logic
 			hasColdShard := false
@@ -413,31 +499,33 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 				errMu.Lock()
 				rebuildErrors = append(rebuildErrors, shardErrors...)
 				errMu.Unlock()
+				t.mu.Lock()
+				t.rebuilding = false
 				t.mu.Unlock()
-				tableLocked = false
+				rebuildClaimed = false
 				return
 			}
+
+			t.mu.Lock()
+			tableLocked = true
 
 			// Collect pre-rebuild shards that were replaced so we can clean them up.
 			var replaced []*storageShard
 			// Publish the new shard list only after completion.
-			// To avoid slice header races for concurrent readers, update in place.
 			if targetIsP {
-				for i := range newShardList {
-					if origShardList[i] != nil && origShardList[i] != newShardList[i] && origShardList[i].uuid != newShardList[i].uuid {
-						replaced = append(replaced, origShardList[i])
+				for i, oldShard := range origShardList {
+					if oldShard != nil && oldShard != newShardList[i] && oldShard.uuid != newShardList[i].uuid {
+						replaced = append(replaced, oldShard)
 					}
-					origShardList[i] = newShardList[i]
 				}
-				t.PShards = origShardList
+				t.PShards = newShardList
 			} else {
-				for i := range newShardList {
-					if origShardList[i] != nil && origShardList[i] != newShardList[i] && origShardList[i].uuid != newShardList[i].uuid {
-						replaced = append(replaced, origShardList[i])
+				for i, oldShard := range origShardList {
+					if oldShard != nil && oldShard != newShardList[i] && oldShard.uuid != newShardList[i].uuid {
+						replaced = append(replaced, oldShard)
 					}
-					origShardList[i] = newShardList[i]
 				}
-				t.Shards = origShardList
+				t.Shards = newShardList
 			}
 
 			// Collect replaced shards for deferred cleanup (see comment above).
@@ -463,6 +551,8 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 			if doRepart {
 				t.repartitionActive = true // claim under t.mu — atomic with the doRepart decision
 			}
+			t.rebuilding = false
+			rebuildClaimed = false
 
 			t.mu.Unlock()
 			tableLocked = false
@@ -698,14 +788,24 @@ func CreateTable(schema, name string, pm PersistencyMode, ifnotexists bool) (*ta
 	}
 	db.ensureLoaded()
 	db.schemalock.Lock()
+	t, created := db.createTableLocked(name, pm, ifnotexists)
+	if !created {
+		db.schemalock.Unlock()
+		return t, false
+	}
+	db.saveLockedAndUnlock()
+	registerCreatedTable(t)
+	return t, true
+}
+
+// createTableLocked mutates db.tables while db.schemalock is held but does
+// not persist schema.json yet. Callers must follow up with saveLockedAndUnlock.
+func (db *database) createTableLocked(name string, pm PersistencyMode, ifnotexists bool) (*table, bool) {
 	t := db.tables.Get(name)
 	if t != nil {
-		db.schemalock.Unlock()
 		if ifnotexists {
-			// Touch table timestamp so CacheManager does not evict a
-			// keytable that is about to be used by the current query.
 			atomic.StoreUint64(&t.lastAccessed, uint64(time.Now().UnixNano()))
-			return t, false // return the table found
+			return t, false
 		}
 		panic("Table " + name + " already exists")
 	}
@@ -718,27 +818,24 @@ func CreateTable(schema, name string, pm PersistencyMode, ifnotexists bool) (*ta
 	t.Shards = make([]*storageShard, 1)
 	t.Shards[0] = NewShard(t)
 	t.Auto_increment = 1
-	t2 := db.tables.Set(t)
-	if t2 != nil {
-		db.schemalock.Unlock()
-		// concurrent create
+	if existing := db.tables.Set(t); existing != nil {
 		panic("Table " + name + " already exists")
-	} else {
-		db.save()
 	}
-	db.schemalock.Unlock()
+	return t, true
+}
+
+func registerCreatedTable(t *table) {
 	// register temp keytable with CacheManager AFTER releasing schemalock
 	// to avoid deadlock: AddItem → run() → evict → keytableCleanup → TryLock(schemalock)
-	if strings.HasPrefix(name, ".") {
-		schemaName := schema
+	if strings.HasPrefix(t.Name, ".") {
+		schemaName := t.schema.Name
 		GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeTempKeytable, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
 			return keytableCleanup(ptr.(*table), schemaName, freedByType)
 		}, keytableLastUsed, nil)
-	} else if pm == Cache {
+	} else if t.PersistencyMode == Cache {
 		// Register the initial shard so eviction can reach it before the first rebuild.
 		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 	}
-	return t, true
 }
 
 func DropTable(schema, name string, ifexists bool) {
@@ -757,8 +854,7 @@ func DropTable(schema, name string, ifexists bool) {
 		panic("Table " + schema + "." + name + " does not exist")
 	}
 	db.tables.Remove(name)
-	db.save()
-	db.schemalock.Unlock()
+	db.saveLockedAndUnlock()
 	// fire AfterDropTable triggers after releasing schemalock (avoids deadlock on cascading drops)
 	t.ExecuteTableLifecycleTriggers(AfterDropTable)
 
@@ -791,18 +887,19 @@ func RenameTable(schema, oldname, newname string) {
 	}
 	db.ensureLoaded()
 	db.schemalock.Lock()
-	defer db.schemalock.Unlock()
 	t := db.tables.Get(oldname)
 	if t == nil {
+		db.schemalock.Unlock()
 		panic("Table " + schema + "." + oldname + " does not exist")
 	}
 	if db.tables.Get(newname) != nil {
+		db.schemalock.Unlock()
 		panic("Table " + schema + "." + newname + " already exists")
 	}
 	db.tables.Remove(oldname)
 	t.Name = newname
 	db.tables.Set(t)
-	db.save()
+	db.saveLockedAndUnlock()
 }
 
 // keytableCleanup is called by the CacheManager when evicting a temp keytable.
@@ -822,8 +919,7 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 			return false // schemalock is held (e.g. by CreateTable); retry later
 		}
 		db.tables.Remove(tbl.Name) // no-op if already removed by DropTable
-		db.save()
-		db.schemalock.Unlock()
+		db.saveLockedAndUnlock()
 	}
 	// remove all shard+index+temp column registrations for this table (recursive)
 	for _, c := range tbl.Columns {

--- a/storage/database.go
+++ b/storage/database.go
@@ -115,12 +115,16 @@ func recoverAsError(context string) (err error) {
 }
 
 func Rebuild(all bool, repartition bool) string {
+	return rebuildDatabases(all, repartition, false)
+}
+
+func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string {
 	start := time.Now()
 	dbs := databases.GetAll()
 	var errs []string
 	for _, db := range dbs {
 		func(db *database) {
-			result := db.rebuild(all, repartition)
+			result := db.rebuild(all, repartition, includeEphemeral)
 			if len(result.errors) > 0 {
 				errs = append(errs, result.errors...)
 				return
@@ -152,7 +156,10 @@ func Rebuild(all bool, repartition bool) string {
 }
 
 func UnloadDatabases() {
-	fmt.Println("table compression done in ", Rebuild(false, false))
+	// Clean shutdown may flush ephemeral query tables as well. They remain
+	// excluded from online/global rebuilds to avoid interfering with live
+	// query-local scratch state.
+	fmt.Println("table compression done in ", rebuildDatabases(false, false, true))
 	data, _ := json.Marshal(Settings)
 	if settings, err := os.OpenFile(Basepath+"/settings.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640); err == nil {
 		defer settings.Close()
@@ -444,7 +451,7 @@ func (db *database) ShowTables() scm.Scmer {
 	return scm.NewSlice(result)
 }
 
-func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
+func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) rebuildDatabaseResult {
 	if db.srState == COLD {
 		// do nothing for cold databases; avoid loading during rebuild
 		return rebuildDatabaseResult{}
@@ -488,7 +495,7 @@ func (db *database) rebuild(all bool, repartition bool) rebuildDatabaseResult {
 				}
 				done.Done()
 			}()
-			if t.isEphemeralQueryTable() {
+			if t.isEphemeralQueryTable() && !includeEphemeral {
 				return
 			}
 			t.mu.Lock() // table lock

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -24,6 +24,7 @@ import "time"
 import "runtime"
 import "strings"
 import "github.com/jtolds/gls"
+import "github.com/launix-de/NonLockingReadMap"
 import "github.com/launix-de/memcp/scm"
 
 type shardDimension struct {
@@ -349,6 +350,65 @@ type partitioningSet struct {
 	items   map[int][]uint // TODO: use uintrange instead, so we don't need so much allocations
 }
 
+type shardPartitionSnapshot struct {
+	deletions NonLockingReadMap.NonBlockingBitMap
+	inserts   [][]scm.Scmer
+	mainCount uint32
+	mainCols  []ColumnStorage
+	deltaCols []int
+}
+
+func (s *storageShard) snapshotPartitionState(schema []shardDimension) shardPartitionSnapshot {
+	snap := shardPartitionSnapshot{
+		mainCols:  make([]ColumnStorage, len(schema)),
+		deltaCols: make([]int, len(schema)),
+	}
+	s.mu.RLock()
+	snap.deletions = s.deletions.Copy()
+	snap.inserts = append([][]scm.Scmer(nil), s.inserts...)
+	snap.mainCount = s.main_count
+	for i, sd := range schema {
+		snap.mainCols[i], _ = s.columns[sd.Column]
+		snap.deltaCols[i], _ = s.deltaColumns[sd.Column]
+	}
+	s.mu.RUnlock()
+	return snap
+}
+
+func (snap shardPartitionSnapshot) count() uint64 {
+	return uint64(snap.mainCount) + uint64(len(snap.inserts)) - uint64(snap.deletions.Count())
+}
+
+func (snap shardPartitionSnapshot) partition(schema []shardDimension) (result map[int][]uint32) {
+	result = make(map[int][]uint32)
+	values := make([]scm.Scmer, len(schema))
+
+	for idx := uint32(0); idx < snap.mainCount; idx++ {
+		if snap.deletions.Get(uint(idx)) {
+			continue
+		}
+		for i, cs := range snap.mainCols {
+			values[i] = cs.GetValue(idx)
+		}
+		shardnum := computeShardIndex(schema, values)
+		result[shardnum] = append(result[shardnum], idx)
+	}
+
+	for idx, row := range snap.inserts {
+		recid := snap.mainCount + uint32(idx)
+		if snap.deletions.Get(uint(recid)) {
+			continue
+		}
+		for i, colIdx := range snap.deltaCols {
+			values[i] = row[colIdx]
+		}
+		shardnum := computeShardIndex(schema, values)
+		result[shardnum] = append(result[shardnum], recid)
+	}
+
+	return
+}
+
 func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimension, shouldChange bool) { // this happens inside t.mu.Lock()
 	// reevaluate partitioning schema
 	for _, c := range t.Columns {
@@ -520,28 +580,27 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 	// Take a brief RLock on each old shard to snapshot its deletion bitmap
 	// and inserts count. This gives us a consistent baseline for reconciliation.
 	type shardSnapshot struct {
-		deletions   interface{ Get(uint) bool } // deletion bitmap copy
-		insertCount int                         // number of delta inserts at snapshot time
-		mainCount   uint32                      // main_count at snapshot time
+		deletions   NonLockingReadMap.NonBlockingBitMap
+		insertCount int
+		mainCount   uint32
 	}
 	snapshots := make([]shardSnapshot, len(oldshards))
 	datasetids := make([][][]uint32, totalShards) // newshard -> oldshard -> []rowIdx
 	total_count := uint64(0)
 	for si, s := range oldshards {
-		s.mu.RLock()
-		total_count += uint64(s.Count())
+		snap := s.snapshotPartitionState(shardCandidates)
+		total_count += snap.count()
 		snapshots[si] = shardSnapshot{
-			deletions:   func() interface{ Get(uint) bool } { c := s.deletions.Copy(); return &c }(),
-			insertCount: len(s.inserts),
-			mainCount:   s.main_count,
+			deletions:   snap.deletions,
+			insertCount: len(snap.inserts),
+			mainCount:   snap.mainCount,
 		}
-		for idx, items := range s.partition(shardCandidates) {
+		for idx, items := range snap.partition(shardCandidates) {
 			if datasetids[idx] == nil {
 				datasetids[idx] = make([][]uint32, len(oldshards))
 			}
 			datasetids[idx][si] = items
 		}
-		s.mu.RUnlock()
 	}
 
 	// ── Phase C: Build main storage (no locks held — long phase) ──
@@ -802,10 +861,12 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 	// so any stragglers would still dual-write.
 	for si, s := range oldshards {
 		s.mu.RLock()
+		currentDeletions := s.deletions.Copy()
+		s.mu.RUnlock()
 		snap := snapshots[si]
 		// Check main storage deletions
 		for idx := uint32(0); idx < snap.mainCount; idx++ {
-			if s.deletions.Get(uint(idx)) && !snap.deletions.Get(uint(idx)) {
+			if currentDeletions.Get(uint(idx)) && !snap.deletions.Get(uint(idx)) {
 				for nsi, items := range datasetids {
 					if items == nil {
 						continue
@@ -824,7 +885,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		// Check delta storage deletions
 		for idx := 0; idx < snap.insertCount; idx++ {
 			absIdx := snap.mainCount + uint32(idx)
-			if s.deletions.Get(uint(absIdx)) && !snap.deletions.Get(uint(absIdx)) {
+			if currentDeletions.Get(uint(absIdx)) && !snap.deletions.Get(uint(absIdx)) {
 				for nsi, items := range datasetids {
 					if items == nil {
 						continue
@@ -840,7 +901,6 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 			nextDeltaDeletion:
 			}
 		}
-		s.mu.RUnlock()
 	}
 
 	// Phase E complete — all deletions reconciled. Now safe to clear dual-write.
@@ -861,8 +921,7 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 
 	// ── Phase G: Cleanup ──
 	t.schema.schemalock.Lock()
-	t.schema.save()
-	t.schema.schemalock.Unlock()
+	t.schema.saveLockedAndUnlock()
 
 	// Nil out old shards after the schema is saved, so no FreeShard
 	// code path can reference them. At this point, ShardMode is Partition,

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -505,6 +505,12 @@ func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimen
 // repartitionActive is already set to true by the caller under t.mu before
 // releasing it, so this guard only catches direct calls from outside db.rebuild.
 func (t *table) repartition(shardCandidates []shardDimension) {
+	t.ddlMu.RLock()
+	defer t.ddlMu.RUnlock()
+	t.repartitionDDLReadLocked(shardCandidates)
+}
+
+func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	// Safety-net: if somehow called directly without the flag being set.
 	if t.repartitionActive && t.PShards != nil {
 		return
@@ -687,23 +693,11 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 										newIdx++
 									}
 								} else {
-									// Old shard has proxy — port valid/invalid status
-									for _, item := range items {
-										idx := uint32(item)
-										if oldProxy.compressed || oldProxy.validMask.Get(uint(idx)) {
-											// Valid: read cached value without triggering computor
-											oldProxy.mu.RLock()
-											val, inDelta := oldProxy.delta[idx]
-											oldProxy.mu.RUnlock()
-											if !inDelta && oldProxy.main != nil {
-												val = oldProxy.main.GetValue(idx)
-											}
-											newProxy.delta[newIdx] = val
-											newProxy.validMask.Set(uint(newIdx), true)
-										}
-										// else: invalid row — leave validMask=false for lazy recompute
-										newIdx++
+									oldRowIDs := make([]uint32, len(items))
+									for i, item := range items {
+										oldRowIDs[i] = uint32(item)
 									}
+									newIdx = appendComputeProxyRows(newProxy, oldProxy, oldRowIDs, newIdx)
 								}
 							}
 							built.columns[col.Name] = newProxy
@@ -903,9 +897,6 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 		}
 	}
 
-	// Phase E complete — all deletions reconciled. Now safe to clear dual-write.
-	t.repartitionActive = false
-
 	// Verify transformation result
 	total_count2 := uint64(0)
 	for _, s := range newshards {
@@ -921,13 +912,16 @@ func (t *table) repartition(shardCandidates []shardDimension) {
 
 	// ── Phase G: Cleanup ──
 	t.schema.schemalock.Lock()
-	t.schema.saveLockedAndUnlock()
+	t.schema.saveLockedWithDurabilityAndUnlock(t.schemaWriteDurable())
 
 	// Nil out old shards after the schema is saved, so no FreeShard
 	// code path can reference them. At this point, ShardMode is Partition,
-	// so new inserts use PShards exclusively.
+	// so new inserts use PShards exclusively. Clearing repartitionActive here
+	// keeps the dual-write contract alive until the new schema is published.
 	t.mu.Lock()
 	t.Shards = nil
+	t.repartitionActive = false
+	t.getRepartitionCond().Broadcast()
 	t.mu.Unlock()
 
 	for _, s := range oldshards {

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -59,6 +59,10 @@ func (f *FileStorage) ReadSchema() []byte {
 }
 
 func (s *FileStorage) WriteSchema(jsonbytes []byte) {
+	s.WriteSchemaWithMode(jsonbytes, true)
+}
+
+func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
 	os.MkdirAll(s.path, 0750)
 	if stat, err := os.Stat(s.path + "schema.json"); err == nil && stat.Size() > 0 {
 		// rescue a copy of schema.json in case the schema is not serializable
@@ -72,13 +76,15 @@ func (s *FileStorage) WriteSchema(jsonbytes []byte) {
 	if _, err := f.Write(jsonbytes); err != nil {
 		panic(err)
 	}
-	if err := f.Sync(); err != nil {
-		panic(err)
-	}
-	if dir, err := os.Open(s.path); err == nil {
-		defer dir.Close()
-		if err := dir.Sync(); err != nil {
+	if durable {
+		if err := f.Sync(); err != nil {
 			panic(err)
+		}
+		if dir, err := os.Open(s.path); err == nil {
+			defer dir.Close()
+			if err := dir.Sync(); err != nil {
+				panic(err)
+			}
 		}
 	}
 }

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -69,7 +69,18 @@ func (s *FileStorage) WriteSchema(jsonbytes []byte) {
 		panic(err)
 	}
 	defer f.Close()
-	f.Write(jsonbytes)
+	if _, err := f.Write(jsonbytes); err != nil {
+		panic(err)
+	}
+	if err := f.Sync(); err != nil {
+		panic(err)
+	}
+	if dir, err := os.Open(s.path); err == nil {
+		defer dir.Close()
+		if err := dir.Sync(); err != nil {
+			panic(err)
+		}
+	}
 }
 
 func (s *FileStorage) ReadColumn(shard string, column string) io.ReadCloser {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -133,6 +133,35 @@ type globalqueue struct {
 	q []*shardqueue
 }
 
+type topKHeap struct {
+	items []uint32
+	less  func(a, b uint32) bool
+}
+
+func (h *topKHeap) Len() int {
+	return len(h.items)
+}
+
+func (h *topKHeap) Less(i, j int) bool {
+	// Reverse the user-facing ordering so heap[0] stays the current worst item.
+	return h.less(h.items[j], h.items[i])
+}
+
+func (h *topKHeap) Swap(i, j int) {
+	h.items[i], h.items[j] = h.items[j], h.items[i]
+}
+
+func (h *topKHeap) Push(x any) {
+	h.items = append(h.items, x.(uint32))
+}
+
+func (h *topKHeap) Pop() any {
+	n := len(h.items)
+	item := h.items[n-1]
+	h.items = h.items[:n-1]
+	return item
+}
+
 // sort interface for global shard-queue
 func (s *globalqueue) Len() int {
 	return len(s.q)
@@ -181,6 +210,35 @@ func (s *globalqueue) Pop() any {
 	s.q[len(s.q)-1] = nil // already free the memory, so GC can also run during an uncompleted ordered scan
 	s.q = s.q[0 : len(s.q)-1]
 	return result
+}
+
+func topKByOrder(items []uint32, keep int, less func(a, b uint32) bool) []uint32 {
+	if keep <= 0 || len(items) == 0 {
+		return nil
+	}
+	if keep >= len(items) {
+		out := append([]uint32(nil), items...)
+		hybridsort.Slice(out, func(i, j int) bool {
+			return less(out[i], out[j])
+		})
+		return out
+	}
+	h := &topKHeap{less: less}
+	for _, item := range items {
+		if h.Len() < keep {
+			heap.Push(h, item)
+			continue
+		}
+		if less(item, h.items[0]) {
+			h.items[0] = item
+			heap.Fix(h, 0)
+		}
+	}
+	out := append([]uint32(nil), h.items...)
+	hybridsort.Slice(out, func(i, j int) bool {
+		return less(out[i], out[j])
+	})
+	return out
 }
 
 // TODO: helper function for priority-q. golangs implementation is kinda quirky, so do our own. container/heap especially lacks the function to test the value at front instead of popping it
@@ -778,6 +836,27 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 
 	// and now sort result!
 	result.sortdirs = adjustedSortdirs
+	itemPos := make(map[uint32]int, len(result.items))
+	for i, idx := range result.items {
+		itemPos[idx] = i
+	}
+	lessByID := func(a, b uint32) bool {
+		cmpCount := len(result.scols)
+		if len(result.sortdirs) < cmpCount {
+			cmpCount = len(result.sortdirs)
+		}
+		for c := 0; c < cmpCount; c++ {
+			av := result.scols[c](a)
+			bv := result.scols[c](b)
+			if scm.ToBool(result.sortdirs[c](av, bv)) {
+				return true
+			}
+			if scm.ToBool(result.sortdirs[c](bv, av)) {
+				return false
+			}
+		}
+		return itemPos[a] < itemPos[b]
+	}
 	// TODO: find conditions when exactly we don't need to sort anymore.
 	// The sort can be skipped when ALL of these hold:
 	// 1. The index used by iterateIndex covers the ORDER BY columns in
@@ -792,9 +871,18 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	//    order matches ORDER BY and there are no deltas, the sort is free.
 	// When these conditions are met, the same knowledge could also be
 	// used to exit early during iterateIndex (stop after OFFSET+LIMIT).
-	if (maxInsertIndex > 0 || true) && len(sortcols) > 0 {
-		hybridsort.Slice(result.items, result.Less)
-		// or: quicksort but those segments above offset+limit can be omitted
+	if len(sortcols) > 0 {
+		if limit >= 0 && limitPartitionCols == 0 {
+			// ORDER BY ... LIMIT only needs the best k rows from each shard.
+			// Keeping all matching rows and fully sorting them makes small-LIMIT
+			// queries degenerate into an expensive full sort with dynamic Scheme
+			// comparators, which dominated the multishard regression.
+			result.items = topKByOrder(result.items, offset+limit, lessByID)
+		} else {
+			hybridsort.Slice(result.items, func(i, j int) bool {
+				return lessByID(result.items[i], result.items[j])
+			})
+		}
 	}
 	// Shard-local per-partition pruning: keep at most offset+limit items per
 	// partition. This reduces what goes into the cross-shard globalqueue merge.

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -195,6 +195,72 @@ func (u *storageShard) load(t *table) {
 	}
 }
 
+func (u *storageShard) schemaColumn(colName string) *column {
+	for _, c := range u.t.Columns {
+		if c.Name == colName {
+			return c
+		}
+	}
+	return nil
+}
+
+func (u *storageShard) makeComputedColumnProxy(colName string, col *column) ColumnStorage {
+	if col == nil || len(col.OrcSortCols) == 0 {
+		return nil
+	}
+	return &StorageComputeProxy{
+		delta:     make(map[uint32]scm.Scmer),
+		shard:     u,
+		colName:   colName,
+		count:     u.main_count,
+		isOrdered: true,
+	}
+}
+
+func (u *storageShard) attachColumnRuntime(colName string, columnstorage ColumnStorage) ColumnStorage {
+	if blob, ok := columnstorage.(*OverlayBlob); ok {
+		blob.SetSchema(u.t.schema)
+	}
+	col := u.schemaColumn(colName)
+	if proxy, ok := columnstorage.(*StorageComputeProxy); ok {
+		// StorageComputeProxy persists only durable state. Runtime bindings to
+		// the owning shard/column must be restored when the storage is loaded.
+		proxy.shard = u
+		proxy.colName = colName
+		if col != nil && len(col.OrcSortCols) > 0 {
+			proxy.isOrdered = true
+		}
+		return proxy
+	}
+	// ORC columns are a runtime contract, not a best-effort cache. Older or
+	// partially rebuilt shards may still have a plain placeholder storage on
+	// disk (`StorageSparse`, `const[nil]`, ...). Rehydrate those columns into an
+	// ordered proxy so readers/rebuilds never publish the placeholder as a real
+	// user-visible value column.
+	if proxy := u.makeComputedColumnProxy(colName, col); proxy != nil {
+		return proxy
+	}
+	return columnstorage
+}
+
+// Most loaded storages are already runtime-ready. Only blob/computed/ORC-backed
+// columns require a re-attach step on access. Keeping plain columns on the
+// read-only fast path avoids self-deadlocks when a scan callback recursively
+// scans the same shard while already holding u.mu.RLock().
+func (u *storageShard) needsRuntimeAttach(colName string, columnstorage ColumnStorage) bool {
+	if columnstorage == nil {
+		return false
+	}
+	if _, ok := columnstorage.(*OverlayBlob); ok {
+		return true
+	}
+	if _, ok := columnstorage.(*StorageComputeProxy); ok {
+		return true
+	}
+	col := u.schemaColumn(colName)
+	return col != nil && isRuntimeComputedColumn(col)
+}
+
 // ensureColumnLoaded loads a single column storage when first accessed.
 // If alreadyLocked is true, the caller must hold u.mu.Lock() and no locks
 // are taken inside this function. Otherwise, it acquires the appropriate
@@ -207,10 +273,16 @@ func (u *storageShard) ensureColumnLoaded(colName string, alreadyLocked bool) Co
 			panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
 		}
 		if cs != nil {
+			cs = u.attachColumnRuntime(colName, cs)
+			u.columns[colName] = cs
 			return cs
 		}
 		if u.t.PersistencyMode == Memory || u.t.PersistencyMode == Cache {
-			u.columns[colName] = new(StorageSparse)
+			if proxy := u.makeComputedColumnProxy(colName, u.schemaColumn(colName)); proxy != nil {
+				u.columns[colName] = proxy
+			} else {
+				u.columns[colName] = new(StorageSparse)
+			}
 			return u.columns[colName]
 		}
 		release := acquireLoadSlot()
@@ -225,15 +297,10 @@ func (u *storageShard) ensureColumnLoaded(colName string, alreadyLocked bool) Co
 		columnstorage := reflect.New(storages[magicbyte]).Interface().(ColumnStorage)
 		cnt := columnstorage.Deserialize(f)
 		f.Close()
-		if blob, ok := columnstorage.(*OverlayBlob); ok {
-			blob.SetSchema(u.t.schema)
-		}
-		if proxy, ok := columnstorage.(*StorageComputeProxy); ok {
-			proxy.shard = u
-		}
 		if uint32(cnt) > u.main_count {
 			u.main_count = uint32(cnt)
 		}
+		columnstorage = u.attachColumnRuntime(colName, columnstorage)
 		u.columns[colName] = columnstorage
 		return columnstorage
 	}
@@ -250,6 +317,13 @@ func (u *storageShard) ensureColumnLoaded(colName string, alreadyLocked bool) Co
 		panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
 	}
 	if cs != nil {
+		if !u.needsRuntimeAttach(colName, cs) {
+			return cs
+		}
+		u.mu.Lock()
+		defer u.mu.Unlock()
+		cs = u.attachColumnRuntime(colName, u.columns[colName])
+		u.columns[colName] = cs
 		return cs
 	}
 	// Acquire write lock and load
@@ -324,15 +398,22 @@ func (u *storageShard) getColumnStorageOrPanicEx(colName string, alreadyLocked b
 			// column was added after the shard was created and the old shard was
 			// later reloaded from disk). Mirror the fallback from the unlocked
 			// path so scans can still proceed under the shard write lock.
-			for _, c := range u.t.Columns {
-				if c.Name == colName {
+			if col := u.schemaColumn(colName); col != nil {
+				if proxy := u.makeComputedColumnProxy(colName, col); proxy != nil {
+					u.columns[colName] = proxy
+				} else {
 					u.columns[colName] = new(StorageSparse)
-					return u.columns[colName]
 				}
+				return u.columns[colName]
 			}
 			panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
 		}
 		if cs != nil {
+			if !u.needsRuntimeAttach(colName, cs) {
+				return cs
+			}
+			cs = u.attachColumnRuntime(colName, cs)
+			u.columns[colName] = cs
 			return cs
 		}
 		return u.ensureColumnLoaded(colName, true)
@@ -345,20 +426,29 @@ func (u *storageShard) getColumnStorageOrPanicEx(colName string, alreadyLocked b
 	cs, present := u.columns[colName]
 	u.mu.RUnlock()
 	if !present {
-		for _, c := range u.t.Columns {
-			if c.Name == colName {
-				u.mu.Lock()
-				if _, present2 := u.columns[colName]; !present2 {
+		if col := u.schemaColumn(colName); col != nil {
+			u.mu.Lock()
+			if _, present2 := u.columns[colName]; !present2 {
+				if proxy := u.makeComputedColumnProxy(colName, col); proxy != nil {
+					u.columns[colName] = proxy
+				} else {
 					u.columns[colName] = new(StorageSparse)
 				}
-				cs2 := u.columns[colName]
-				u.mu.Unlock()
-				return cs2
 			}
+			cs2 := u.columns[colName]
+			u.mu.Unlock()
+			return cs2
 		}
 		panic("Column does not exist: `" + u.t.schema.Name + "`.`" + u.t.Name + "`.`" + colName + "`")
 	}
 	if cs != nil {
+		if !u.needsRuntimeAttach(colName, cs) {
+			return cs
+		}
+		u.mu.Lock()
+		defer u.mu.Unlock()
+		cs = u.attachColumnRuntime(colName, u.columns[colName])
+		u.columns[colName] = cs
 		return cs
 	}
 	return u.ensureColumnLoaded(colName, false)
@@ -641,6 +731,10 @@ func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocke
 	return t.UpdateFunctionBatch(idx, withTrigger, alreadyLocked, nil)
 }
 
+func isRuntimeComputedColumn(colDesc *column) bool {
+	return len(colDesc.OrcSortCols) > 0 || !colDesc.Computor.IsNil() || len(colDesc.ComputorInputCols) > 0
+}
+
 func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, alreadyLocked bool, batch *triggerBatch) func(...scm.Scmer) scm.Scmer {
 	// returns a callback with which you can delete or update an item
 	return func(a ...scm.Scmer) scm.Scmer {
@@ -720,6 +814,9 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 				// can write delta rows that miss PK/other fields.
 				d2 := make([]scm.Scmer, 0, len(t.t.Columns))
 				for _, colDesc := range t.t.Columns {
+					if isRuntimeComputedColumn(colDesc) {
+						continue
+					}
 					k := colDesc.Name
 					cs := t.getColumnStorageOrPanicEx(k, true)
 					colidx, ok := t.deltaColumns[k]
@@ -740,11 +837,12 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					pCols := make([]string, 0, len(t.t.Columns))
 					pRow := make([]scm.Scmer, 0, len(t.t.Columns))
 					for _, colDesc := range t.t.Columns {
+						if isRuntimeComputedColumn(colDesc) {
+							continue
+						}
 						colName := colDesc.Name
 						pos, ok := t.deltaColumns[colName]
 						if !ok || pos >= len(d2) {
-							pCols = append(pCols, colName)
-							pRow = append(pRow, scm.NewNil())
 							continue
 						}
 						pCols = append(pCols, colName)
@@ -1130,21 +1228,21 @@ type ShardMapReducer struct {
 	isBreak         []bool // true for $break column
 	hasBreakCol     bool
 	// tagClosure hoisted fn ptrs — allocated once per mapper, reused per row
-	setClosureFn    []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
-	incrClosureFn   []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
-	invClosureFn    []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
-	noopClosureFn   *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
-	breakClosureFn  *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
-	args            []scm.Scmer                             // pre-allocated args buffer
-	mapFn           func(...scm.Scmer) scm.Scmer
-	reduceFn        func(...scm.Scmer) scm.Scmer
-	mapScmer        scm.Scmer // original Scmer for network serialization
-	deleteBatch     *triggerBatch // when set, DELETE triggers are batched instead of per-row
+	setClosureFn   []*func(uint32, ...scm.Scmer) scm.Scmer // per $set col
+	incrClosureFn  []*func(uint32, ...scm.Scmer) scm.Scmer // per $increment col
+	invClosureFn   []*func(uint32, ...scm.Scmer) scm.Scmer // per $invalidate col
+	noopClosureFn  *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
+	breakClosureFn *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
+	args           []scm.Scmer                             // pre-allocated args buffer
+	mapFn          func(...scm.Scmer) scm.Scmer
+	reduceFn       func(...scm.Scmer) scm.Scmer
+	mapScmer       scm.Scmer     // original Scmer for network serialization
+	deleteBatch    *triggerBatch // when set, DELETE triggers are batched instead of per-row
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
-	invalidateBatch map[*StorageComputeProxy]bool                  // proxies to InvalidateAll after scan
-	reduceScmer     scm.Scmer // original Scmer for network serialization
+	invalidateBatch map[*StorageComputeProxy]bool                 // proxies to InvalidateAll after scan
+	reduceScmer     scm.Scmer                                     // original Scmer for network serialization
 	mainCount       uint32
 	hasUpdateCol    bool
 	hasIncrementCol bool
@@ -1883,6 +1981,14 @@ func (t *storageShard) getDelta(idx int, col string) scm.Scmer {
 			return item[colidx]
 		}
 	}
+	// Computed / ORC columns have no physical delta slot. Their value contract is
+	// defined by the column runtime, so delta rows must read through the proxy
+	// instead of silently degrading to NULL.
+	if cs, ok := t.columns[col]; ok {
+		if proxy, ok := cs.(*StorageComputeProxy); ok {
+			return proxy.GetValue(t.main_count + uint32(idx))
+		}
+	}
 	return scm.NewNil()
 }
 
@@ -2200,6 +2306,27 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 		}
 		t.mu.RUnlock()
 
+		rowCap := int(t.main_count) + maxInsertIndex - int(deletions.Count())
+		if rowCap < 0 {
+			rowCap = 0
+		}
+		rebuiltRowIDs := make([]uint32, 0, rowCap)
+		if sortPerm != nil {
+			rebuiltRowIDs = append(rebuiltRowIDs, sortPerm...)
+		} else {
+			for idx := uint32(0); idx < t.main_count; idx++ {
+				if !deletions.Get(uint(idx)) {
+					rebuiltRowIDs = append(rebuiltRowIDs, idx)
+				}
+			}
+			for idx := 0; idx < maxInsertIndex; idx++ {
+				globalID := t.main_count + uint32(idx)
+				if !deletions.Get(uint(globalID)) {
+					rebuiltRowIDs = append(rebuiltRowIDs, globalID)
+				}
+			}
+		}
+
 		// copy column data in two phases: scan, build (if delta is non-empty)
 		isFirst := true
 		for col, c := range columnSnapshot {
@@ -2209,13 +2336,19 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				b.WriteString(", ")
 			}
 
-			// StorageComputeProxy: read only VALID cached values, skip computor
-			// for invalid rows (use nil instead). This avoids infinite recursion
-			// when the computor scans other tables during concurrent rebuild.
-			// The proxy is NOT ported — values are materialized into static storage.
-			// After rebuild, createcolumn will re-create the proxy if needed.
 			if oldProxy, ok := c.(*StorageComputeProxy); ok {
-				c = &safeProxyReader{proxy: oldProxy}
+				newProxy := cloneComputeProxyRows(oldProxy, result, rebuiltRowIDs)
+				result.columns[col] = newProxy
+				result.main_count = uint32(len(rebuiltRowIDs))
+				b.WriteString(col)
+				b.WriteString(" ")
+				b.WriteString(newProxy.String())
+				if t.t.PersistencyMode != Memory && t.t.PersistencyMode != Cache {
+					f := result.t.schema.persistence.WriteColumn(result.uuid.String(), col)
+					newProxy.Serialize(f)
+					f.Close()
+				}
+				continue
 			}
 
 			var newcol ColumnStorage = new(StorageSCMER) // currently only scmer-storages

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -131,7 +131,7 @@ func TestDatabaseRebuildSkipsEphemeralQueryTables(t *testing.T) {
 	ephemeralUUID := ephemeral.Shards[0].uuid
 	durableInternalUUID := durableInternal.Shards[0].uuid
 
-	result := db.rebuild(true, false)
+	result := db.rebuild(true, false, false)
 	if len(result.errors) > 0 {
 		t.Fatalf("rebuild errors: %v", result.errors)
 	}
@@ -248,7 +248,7 @@ func TestDatabaseRebuildDoesNotForceFreeTableIntoSingleShardPartition(t *testing
 		{scm.NewInt(3), scm.NewInt(3)},
 	}, nil, scm.NewNil(), false, nil)
 
-	result := db.rebuild(true, true)
+	result := db.rebuild(true, true, false)
 	if len(result.errors) > 0 {
 		t.Fatalf("rebuild errors: %v", result.errors)
 	}
@@ -437,7 +437,7 @@ func TestDatabaseRebuildWaitsForTableDDL(t *testing.T) {
 	tbl.ddlMu.Lock()
 	done := make(chan rebuildDatabaseResult, 1)
 	go func() {
-		done <- db.rebuild(true, false)
+		done <- db.rebuild(true, false, false)
 	}()
 
 	select {
@@ -831,6 +831,50 @@ func TestShardRebuildWaitsForOrderedProxySnapshot(t *testing.T) {
 	}
 	if got := rebuiltProxy.delta[1].Int(); got != 300 {
 		t.Fatalf("rebuilt ordered proxy value[1] = %d, want 300", got)
+	}
+}
+
+func TestAppendComputeProxyRowsSkipsUncachedDeltaRecids(t *testing.T) {
+	proxy := &StorageComputeProxy{
+		delta: make(map[uint32]scm.Scmer),
+		count: 2,
+		main: &StorageSCMER{
+			values: []scm.Scmer{scm.NewString("a"), scm.NewString("b")},
+		},
+	}
+	proxy.validMask.Set(0, true)
+	proxy.validMask.Set(1, true)
+
+	newProxy := &StorageComputeProxy{delta: make(map[uint32]scm.Scmer), count: 3}
+	newIdx := appendComputeProxyRows(newProxy, proxy, []uint32{0, 1, 2}, 0)
+	if newIdx != 3 {
+		t.Fatalf("appendComputeProxyRows returned %d, want 3", newIdx)
+	}
+	if !newProxy.validMask.Get(0) || !newProxy.validMask.Get(1) {
+		t.Fatal("valid main rows were not ported")
+	}
+	if newProxy.validMask.Get(2) {
+		t.Fatal("uncached forwarded delta row must stay invalid after port")
+	}
+	if !scm.Equal(newProxy.delta[0], scm.NewString("a")) {
+		t.Fatalf("row 0 = %v, want %v", newProxy.delta[0], scm.NewString("a"))
+	}
+	if !scm.Equal(newProxy.delta[1], scm.NewString("b")) {
+		t.Fatalf("row 1 = %v, want %v", newProxy.delta[1], scm.NewString("b"))
+	}
+}
+
+func TestComputeProxyGetValueUsesDeltaBeyondMainCount(t *testing.T) {
+	proxy := &StorageComputeProxy{
+		delta:      map[uint32]scm.Scmer{2: scm.NewString("delta")},
+		count:      2,
+		compressed: true,
+		main: &StorageSCMER{
+			values: []scm.Scmer{scm.NewString("a"), scm.NewString("b")},
+		},
+	}
+	if !scm.Equal(proxy.GetValue(2), scm.NewString("delta")) {
+		t.Fatalf("proxy.GetValue(2) = %v, want %v", proxy.GetValue(2), scm.NewString("delta"))
 	}
 }
 

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -26,6 +26,15 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+func callBuiltin(t *testing.T, name string, args ...scm.Scmer) scm.Scmer {
+	t.Helper()
+	fn, ok := scm.Globalenv.Vars[scm.Symbol(name)]
+	if !ok {
+		t.Fatalf("builtin %s not found", name)
+	}
+	return scm.Apply(fn, args...)
+}
+
 func TestShardRebuildForwardsConcurrentInsertsViaNext(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-shard-rebuild-*")
 	if err != nil {
@@ -83,5 +92,831 @@ func TestShardRebuildForwardsConcurrentInsertsViaNext(t *testing.T) {
 	}
 	if got, want := rebuilt.Count(), uint32(len(initialRows)+len(extraRows)); got != want {
 		t.Fatalf("rebuilt shard count = %d, want %d", got, want)
+	}
+}
+
+func TestDatabaseRebuildSkipsEphemeralQueryTables(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-db-rebuild-ephemeral-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("trebuildephemeral")
+
+	CreateDatabase("trebuildephemeral", false)
+	db := GetDatabase("trebuildephemeral")
+	if db == nil {
+		t.Fatal("database not found")
+	}
+
+	base, _ := CreateTable("trebuildephemeral", "base", Safe, false)
+	base.CreateColumn("id", "INT", nil, nil)
+	base.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+
+	ephemeral, _ := CreateTable("trebuildephemeral", ".temp:key", Sloppy, false)
+	ephemeral.CreateColumn("id", "INT", nil, nil)
+	ephemeral.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+
+	durableInternal, _ := CreateTable("trebuildephemeral", ".blobs_like", Safe, false)
+	durableInternal.CreateColumn("id", "INT", nil, nil)
+	durableInternal.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+
+	baseUUID := base.Shards[0].uuid
+	ephemeralUUID := ephemeral.Shards[0].uuid
+	durableInternalUUID := durableInternal.Shards[0].uuid
+
+	result := db.rebuild(true, false)
+	if len(result.errors) > 0 {
+		t.Fatalf("rebuild errors: %v", result.errors)
+	}
+
+	if base.Shards[0].uuid == baseUUID {
+		t.Fatal("durable user table was not rebuilt")
+	}
+	if ephemeral.Shards[0].uuid != ephemeralUUID {
+		t.Fatal("ephemeral query table should be skipped by global rebuild")
+	}
+	if durableInternal.Shards[0].uuid == durableInternalUUID {
+		t.Fatal("durable internal table must still participate in rebuild")
+	}
+}
+
+func TestManualRepartitionForwardsConcurrentInserts(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-manual-repartition-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tmanualrepartition")
+
+	CreateDatabase("tmanualrepartition", false)
+	tbl, _ := CreateTable("tmanualrepartition", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("payload", "TEXT", nil, nil)
+
+	initialRows := make([][]scm.Scmer, 0, 20000)
+	for i := 0; i < 20000; i++ {
+		initialRows = append(initialRows, []scm.Scmer{
+			scm.NewInt(int64(i + 1)),
+			scm.NewString(fmt.Sprintf("%032x", i+1)),
+		})
+	}
+	tbl.Insert([]string{"id", "payload"}, initialRows, nil, scm.NewNil(), false, nil)
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+		close(done)
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		tbl.mu.Lock()
+		active := tbl.repartitionActive
+		hasPShards := tbl.PShards != nil
+		tbl.mu.Unlock()
+		if active && hasPShards {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("manual repartition never entered dual-write mode")
+		}
+		runtime.Gosched()
+	}
+
+	extraRows := make([][]scm.Scmer, 0, 2000)
+	for i := 0; i < 2000; i++ {
+		extraRows = append(extraRows, []scm.Scmer{
+			scm.NewInt(int64(20001 + i)),
+			scm.NewString(fmt.Sprintf("%032x", 20001+i)),
+		})
+	}
+	tbl.Insert([]string{"id", "payload"}, extraRows, nil, scm.NewNil(), false, nil)
+	<-done
+
+	total := uint32(0)
+	for _, s := range tbl.ActiveShards() {
+		total += s.Count()
+	}
+	if got, want := total, uint32(len(initialRows)+len(extraRows)); got != want {
+		t.Fatalf("manual repartition count = %d, want %d", got, want)
+	}
+}
+
+func TestDatabaseRebuildDoesNotForceFreeTableIntoSingleShardPartition(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-db-rebuild-free-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("trebuildfree")
+
+	CreateDatabase("trebuildfree", false)
+	db := GetDatabase("trebuildfree")
+	if db == nil {
+		t.Fatal("database not found")
+	}
+
+	tbl, _ := CreateTable("trebuildfree", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("grp", "INT", nil, nil)
+	tbl.Insert([]string{"id", "grp"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(1)},
+		{scm.NewInt(2), scm.NewInt(2)},
+		{scm.NewInt(3), scm.NewInt(3)},
+	}, nil, scm.NewNil(), false, nil)
+
+	result := db.rebuild(true, true)
+	if len(result.errors) > 0 {
+		t.Fatalf("rebuild errors: %v", result.errors)
+	}
+	if tbl.ShardMode != ShardModeFree {
+		t.Fatalf("small free table was repartitioned unexpectedly: mode=%v", tbl.ShardMode)
+	}
+	if tbl.PShards != nil {
+		t.Fatal("small free table should not have partition shards after rebuild")
+	}
+	if len(tbl.Shards) != 1 {
+		t.Fatalf("small free table should still have one free shard, got %d", len(tbl.Shards))
+	}
+	if got := tbl.Shards[0].Count(); got != 3 {
+		t.Fatalf("rebuilt free shard count = %d, want 3", got)
+	}
+}
+
+func TestPartitionTableEmptySpecKeepsFreeShardMode(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-empty-partition-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("temptypartition")
+
+	CreateDatabase("temptypartition", false)
+	tbl, _ := CreateTable("temptypartition", "items", Sloppy, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}, {scm.NewInt(2)}}, nil, scm.NewNil(), false, nil)
+	origUUID := tbl.Shards[0].uuid
+
+	res := callBuiltin(t, "partitiontable",
+		scm.NewString("temptypartition"),
+		scm.NewString("items"),
+		scm.NewSlice(nil),
+	)
+	if scm.ToBool(res) {
+		t.Fatal("empty partition spec should not claim a repartition")
+	}
+	if tbl.ShardMode != ShardModeFree {
+		t.Fatalf("empty partition spec changed shard mode to %v", tbl.ShardMode)
+	}
+	if tbl.PShards != nil {
+		t.Fatal("empty partition spec must not create partition shards")
+	}
+	if len(tbl.Shards) != 1 {
+		t.Fatalf("empty partition spec changed free shard count to %d", len(tbl.Shards))
+	}
+	if tbl.Shards[0].uuid != origUUID {
+		t.Fatal("empty partition spec unexpectedly rebuilt the free shard")
+	}
+	if got := tbl.Shards[0].Count(); got != 2 {
+		t.Fatalf("free shard count = %d, want 2", got)
+	}
+}
+
+func TestPartitionTableNestedAssocAppliesRealPartitioning(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-nested-partition-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tnestedpartition")
+
+	CreateDatabase("tnestedpartition", false)
+	tbl, _ := CreateTable("tnestedpartition", "items", Sloppy, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+		{scm.NewInt(3)},
+		{scm.NewInt(4)},
+	}, nil, scm.NewNil(), false, nil)
+
+	res := callBuiltin(t, "partitiontable",
+		scm.NewString("tnestedpartition"),
+		scm.NewString("items"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{
+				scm.NewString("id"),
+				scm.NewSlice([]scm.Scmer{scm.NewInt(2)}),
+			}),
+		}),
+	)
+	if !scm.ToBool(res) {
+		t.Fatal("nested assoc partition spec should trigger repartition")
+	}
+	if tbl.ShardMode != ShardModePartition {
+		t.Fatalf("nested assoc partition spec did not switch shard mode: %v", tbl.ShardMode)
+	}
+	if len(tbl.PDimensions) != 1 || tbl.PDimensions[0].Column != "id" {
+		t.Fatalf("unexpected partition schema: %+v", tbl.PDimensions)
+	}
+	if len(tbl.PShards) != 2 {
+		t.Fatalf("expected 2 partition shards, got %d", len(tbl.PShards))
+	}
+	total := uint32(0)
+	for _, s := range tbl.PShards {
+		total += s.Count()
+	}
+	if total != 4 {
+		t.Fatalf("partitioned row count = %d, want 4", total)
+	}
+}
+
+func TestPartitionTableSinglePartitionSpecIsNoop(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-single-partition-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tsinglepartition")
+
+	CreateDatabase("tsinglepartition", false)
+	tbl, _ := CreateTable("tsinglepartition", "items", Sloppy, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}, {scm.NewInt(2)}}, nil, scm.NewNil(), false, nil)
+	origUUID := tbl.Shards[0].uuid
+
+	res := callBuiltin(t, "partitiontable",
+		scm.NewString("tsinglepartition"),
+		scm.NewString("items"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{
+				scm.NewString("id"),
+				scm.NewSlice(nil),
+			}),
+		}),
+	)
+	if scm.ToBool(res) {
+		t.Fatal("single-partition spec should not trigger repartition")
+	}
+	if tbl.ShardMode != ShardModeFree {
+		t.Fatalf("single-partition spec changed shard mode to %v", tbl.ShardMode)
+	}
+	if tbl.PShards != nil {
+		t.Fatal("single-partition spec must not create partition shards")
+	}
+	if tbl.Shards[0].uuid != origUUID {
+		t.Fatal("single-partition spec unexpectedly rebuilt the shard")
+	}
+}
+
+func TestDatabaseRebuildWaitsForTableDDL(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-db-rebuild-ddl-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("trebuildddl")
+
+	CreateDatabase("trebuildddl", false)
+	db := GetDatabase("trebuildddl")
+	if db == nil {
+		t.Fatal("database not found")
+	}
+
+	tbl, _ := CreateTable("trebuildddl", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+
+	tbl.ddlMu.Lock()
+	done := make(chan rebuildDatabaseResult, 1)
+	go func() {
+		done <- db.rebuild(true, false)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("global rebuild ignored the table-local DDL lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	tbl.ddlMu.Unlock()
+	result := <-done
+	if len(result.errors) > 0 {
+		t.Fatalf("rebuild errors: %v", result.errors)
+	}
+}
+
+func TestCreateColumnWaitsForTableRebuildLock(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-create-column-ddl-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tcreatecolumnddl")
+
+	CreateDatabase("tcreatecolumnddl", false)
+	tbl, _ := CreateTable("tcreatecolumnddl", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+
+	tbl.ddlMu.RLock()
+	done := make(chan bool, 1)
+	go func() {
+		done <- tbl.CreateColumn("payload", "TEXT", nil, nil)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("CreateColumn bypassed the table-local rebuild/read lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	tbl.ddlMu.RUnlock()
+	if ok := <-done; !ok {
+		t.Fatal("CreateColumn failed after rebuild/read lock was released")
+	}
+}
+
+func TestShardRebuildPreservesComputeProxyColumns(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-rebuild-proxy-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("trebuildproxy")
+
+	CreateDatabase("trebuildproxy", false)
+	tbl, _ := CreateTable("trebuildproxy", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+	}, nil, scm.NewNil(), false, nil)
+
+	shard := tbl.Shards[0]
+	shard.mu.Lock()
+	proxy := &StorageComputeProxy{
+		delta:     make(map[uint32]scm.Scmer),
+		shard:     shard,
+		colName:   "running",
+		count:     shard.main_count,
+		isOrdered: true,
+	}
+	proxy.delta[0] = scm.NewInt(100)
+	proxy.validMask.Set(0, true)
+	shard.columns["running"] = proxy
+	shard.mu.Unlock()
+
+	rebuilt := shard.rebuild(true)
+	rebuilt.mu.RLock()
+	rebuiltCol := rebuilt.columns["running"]
+	rebuilt.mu.RUnlock()
+
+	rebuiltProxy, ok := rebuiltCol.(*StorageComputeProxy)
+	if !ok {
+		t.Fatalf("rebuild materialized compute proxy into %T", rebuiltCol)
+	}
+	if !rebuiltProxy.isOrdered {
+		t.Fatal("rebuild lost ordered-compute proxy flag")
+	}
+	if !rebuiltProxy.validMask.Get(0) {
+		t.Fatal("rebuild lost cached valid row in compute proxy")
+	}
+	rebuiltProxy.mu.RLock()
+	got := rebuiltProxy.delta[0]
+	rebuiltProxy.mu.RUnlock()
+	if got.Int() != 100 {
+		t.Fatalf("rebuilt proxy cached value = %v, want 100", got)
+	}
+	if rebuiltProxy.validMask.Get(1) {
+		t.Fatal("rebuild should keep invalid rows lazy instead of materializing them")
+	}
+}
+
+func TestEnsureColumnLoadedRestoresComputeProxyRuntimeBindings(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-load-proxy-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tloadproxy")
+
+	CreateDatabase("tloadproxy", false)
+	tbl, _ := CreateTable("tloadproxy", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+	}, nil, scm.NewNil(), false, nil)
+
+	shard := tbl.Shards[0]
+	shard.mu.Lock()
+	proxy := &StorageComputeProxy{
+		delta:     make(map[uint32]scm.Scmer),
+		shard:     shard,
+		colName:   "running",
+		count:     shard.main_count,
+		isOrdered: true,
+	}
+	proxy.delta[0] = scm.NewInt(123)
+	proxy.validMask.Set(0, true)
+	shard.columns["running"] = proxy
+	shard.mu.Unlock()
+
+	f := tbl.schema.persistence.WriteColumn(shard.uuid.String(), "running")
+	proxy.Serialize(f)
+	f.Close()
+
+	shard.mu.Lock()
+	shard.columns["running"] = nil
+	shard.mu.Unlock()
+
+	loadedCol := shard.ensureColumnLoaded("running", false)
+	loadedProxy, ok := loadedCol.(*StorageComputeProxy)
+	if !ok {
+		t.Fatalf("loaded column is %T, want *StorageComputeProxy", loadedCol)
+	}
+	if loadedProxy.shard != shard {
+		t.Fatal("ensureColumnLoaded did not restore proxy shard binding")
+	}
+	if loadedProxy.colName != "running" {
+		t.Fatalf("ensureColumnLoaded restored proxy colName=%q, want %q", loadedProxy.colName, "running")
+	}
+	if !loadedProxy.isOrdered {
+		t.Fatal("ensureColumnLoaded lost ordered-proxy flag")
+	}
+	if got := loadedProxy.GetValue(0).Int(); got != 123 {
+		t.Fatalf("loaded proxy cached value = %d, want 123", got)
+	}
+}
+
+func TestEnsureColumnLoadedRehydratesOrderedProxyFromSchemaPlaceholder(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-load-orc-placeholder-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tloadorcplaceholder")
+
+	CreateDatabase("tloadorcplaceholder", false)
+	tbl, _ := CreateTable("tloadorcplaceholder", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("day", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id", "day"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10)},
+		{scm.NewInt(2), scm.NewInt(20)},
+	}, nil, scm.NewNil(), false, nil)
+
+	tbl.ddlMu.Lock()
+	tbl.computeOrderedColumnDDLLocked(
+		"running",
+		[]string{"day"},
+		[]bool{false},
+		0,
+		[]string{"id"},
+		scm.NewNil(),
+		scm.NewNil(),
+		scm.NewNil(),
+	)
+	tbl.ddlMu.Unlock()
+
+	shard := tbl.Shards[0]
+	shard.mu.Lock()
+	shard.columns["running"] = new(StorageSparse)
+	shard.mu.Unlock()
+
+	f := tbl.schema.persistence.WriteColumn(shard.uuid.String(), "running")
+	(&StorageSparse{}).Serialize(f)
+	f.Close()
+
+	shard.mu.Lock()
+	shard.columns["running"] = nil
+	shard.mu.Unlock()
+
+	loadedCol := shard.ensureColumnLoaded("running", false)
+	loadedProxy, ok := loadedCol.(*StorageComputeProxy)
+	if !ok {
+		t.Fatalf("loaded column is %T, want *StorageComputeProxy", loadedCol)
+	}
+	if loadedProxy.shard != shard {
+		t.Fatal("ensureColumnLoaded did not restore placeholder proxy shard binding")
+	}
+	if loadedProxy.colName != "running" {
+		t.Fatalf("ensureColumnLoaded restored placeholder proxy colName=%q, want %q", loadedProxy.colName, "running")
+	}
+	if !loadedProxy.isOrdered {
+		t.Fatal("ensureColumnLoaded lost ordered-proxy contract for placeholder-backed ORC column")
+	}
+	if loadedProxy.validMask.Count() != 0 {
+		t.Fatal("placeholder-backed ORC proxy must stay invalid until foreground recompute")
+	}
+}
+
+func TestCreateColumnBuiltinUpgradesExistingColumnToORC(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-createcolumn-orc-upgrade-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tcreatecolumnorc")
+
+	CreateDatabase("tcreatecolumnorc", false)
+	tbl, _ := CreateTable("tcreatecolumnorc", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("day", "INT", nil, nil)
+	tbl.CreateColumn("amount", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id", "day", "amount"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10), scm.NewInt(100)},
+		{scm.NewInt(2), scm.NewInt(20), scm.NewInt(200)},
+	}, nil, scm.NewNil(), false, nil)
+
+	mapFn := scm.Eval(scm.Read("test", "(lambda ($set v) (list $set v))"), &scm.Globalenv)
+	reduceFn := scm.Eval(scm.Read("test", "(lambda (acc mapped) (begin (define new_acc (+ acc (cadr mapped))) ((car mapped) new_acc) new_acc))"), &scm.Globalenv)
+	options := scm.NewSlice([]scm.Scmer{
+		scm.NewString("sortcols"), scm.NewSlice([]scm.Scmer{scm.NewString("day")}),
+		scm.NewString("sortdirs"), scm.NewSlice([]scm.Scmer{scm.NewBool(false)}),
+		scm.NewString("partitioncount"), scm.NewInt(0),
+		scm.NewString("mapcols"), scm.NewSlice([]scm.Scmer{scm.NewString("amount")}),
+		scm.NewString("mapfn"), mapFn,
+		scm.NewString("reducefn"), reduceFn,
+		scm.NewString("reduceinit"), scm.NewInt(0),
+	})
+	createcolumn := scm.Globalenv.Vars[scm.Symbol("createcolumn")]
+	result := scm.Apply(
+		createcolumn,
+		scm.NewString("tcreatecolumnorc"),
+		scm.NewString("items"),
+		scm.NewString("running"),
+		scm.NewString("INT"),
+		scm.NewSlice(nil),
+		options,
+	)
+	if !result.Bool() {
+		t.Fatal("createcolumn should report success when upgrading an existing column to ORC")
+	}
+
+	shard := tbl.Shards[0]
+	shard.mu.RLock()
+	col := shard.columns["running"]
+	shard.mu.RUnlock()
+	proxy, ok := col.(*StorageComputeProxy)
+	if !ok {
+		t.Fatalf("running column is %T, want *StorageComputeProxy", col)
+	}
+	if !proxy.isOrdered {
+		t.Fatal("createcolumn upgrade did not mark proxy as ordered")
+	}
+	if got := proxy.GetValue(0).Int(); got != 100 {
+		t.Fatalf("running[0] = %d, want 100", got)
+	}
+	if got := proxy.GetValue(1).Int(); got != 300 {
+		t.Fatalf("running[1] = %d, want 300", got)
+	}
+	if got := shard.getDelta(0, "running").Int(); got != 100 {
+		t.Fatalf("delta running[0] = %d, want 100", got)
+	}
+	if got := shard.getDelta(1, "running").Int(); got != 300 {
+		t.Fatalf("delta running[1] = %d, want 300", got)
+	}
+}
+
+func TestShardRebuildWaitsForOrderedProxySnapshot(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-rebuild-orc-snapshot-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("trebuildorc")
+
+	CreateDatabase("trebuildorc", false)
+	tbl, _ := CreateTable("trebuildorc", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+	}, nil, scm.NewNil(), false, nil)
+
+	shard := tbl.Shards[0]
+	shard.mu.Lock()
+	proxy := &StorageComputeProxy{
+		delta:     make(map[uint32]scm.Scmer),
+		shard:     shard,
+		colName:   "running",
+		count:     shard.main_count,
+		isOrdered: true,
+	}
+	shard.columns["running"] = proxy
+	shard.mu.Unlock()
+
+	tbl.orcMu.Lock()
+	done := make(chan *storageShard, 1)
+	go func() {
+		done <- shard.rebuild(true)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("rebuild cloned ordered proxy before ORC snapshot was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	proxy.mu.Lock()
+	proxy.delta[0] = scm.NewInt(100)
+	proxy.delta[1] = scm.NewInt(300)
+	proxy.validMask.Set(0, true)
+	proxy.validMask.Set(1, true)
+	proxy.mu.Unlock()
+	tbl.orcMu.Unlock()
+
+	rebuilt := <-done
+	rebuilt.mu.RLock()
+	rebuiltCol := rebuilt.columns["running"]
+	rebuilt.mu.RUnlock()
+	rebuiltProxy, ok := rebuiltCol.(*StorageComputeProxy)
+	if !ok {
+		t.Fatalf("rebuilt column is %T, want *StorageComputeProxy", rebuiltCol)
+	}
+	if !rebuiltProxy.validMask.Get(0) || !rebuiltProxy.validMask.Get(1) {
+		t.Fatal("rebuild did not snapshot ordered proxy values published before orcMu release")
+	}
+	if got := rebuiltProxy.delta[0].Int(); got != 100 {
+		t.Fatalf("rebuilt ordered proxy value[0] = %d, want 100", got)
+	}
+	if got := rebuiltProxy.delta[1].Int(); got != 300 {
+		t.Fatalf("rebuilt ordered proxy value[1] = %d, want 300", got)
+	}
+}
+
+func TestInvalidateORCHitsShadowRebuildShards(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-orc-shadow-invalidate-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("torcshadow")
+
+	CreateDatabase("torcshadow", false)
+	tbl, _ := CreateTable("torcshadow", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("day", "INT", nil, nil)
+	tbl.CreateColumn("running", "INT", nil, nil)
+	tbl.Insert([]string{"id", "day"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10)},
+		{scm.NewInt(2), scm.NewInt(20)},
+	}, nil, scm.NewNil(), false, nil)
+	for i := range tbl.Columns {
+		if tbl.Columns[i].Name == "running" {
+			tbl.Columns[i].OrcSortCols = []string{"day"}
+			tbl.Columns[i].OrcSortDirs = []bool{false}
+			break
+		}
+	}
+
+	makeDayCol := func(vals ...int64) *StorageSCMER {
+		col := new(StorageSCMER)
+		col.init(uint32(len(vals)))
+		for i, v := range vals {
+			col.build(uint32(i), scm.NewInt(v))
+		}
+		col.finish()
+		return col
+	}
+	makeProxy := func(sh *storageShard) *StorageComputeProxy {
+		proxy := &StorageComputeProxy{
+			delta:     make(map[uint32]scm.Scmer),
+			shard:     sh,
+			colName:   "running",
+			count:     2,
+			isOrdered: true,
+		}
+		proxy.delta[0] = scm.NewInt(100)
+		proxy.delta[1] = scm.NewInt(300)
+		proxy.validMask.Set(0, true)
+		proxy.validMask.Set(1, true)
+		return proxy
+	}
+
+	base := tbl.Shards[0]
+	base.mu.Lock()
+	base.main_count = 2
+	base.columns["day"] = makeDayCol(10, 20)
+	base.columns["running"] = makeProxy(base)
+	base.mu.Unlock()
+
+	shadow := NewShard(tbl)
+	shadow.mu.Lock()
+	shadow.main_count = 2
+	shadow.columns["day"] = makeDayCol(10, 20)
+	shadow.columns["running"] = makeProxy(shadow)
+	shadow.mu.Unlock()
+	base.storeNext(shadow)
+
+	tbl.invalidateORCFromSortKey("running", []scm.Scmer{scm.NewInt(5)})
+
+	base.mu.RLock()
+	baseProxy := base.columns["running"].(*StorageComputeProxy)
+	base.mu.RUnlock()
+	shadow.mu.RLock()
+	shadowProxy := shadow.columns["running"].(*StorageComputeProxy)
+	shadow.mu.RUnlock()
+
+	if baseProxy.validMask.Get(0) || baseProxy.validMask.Get(1) {
+		t.Fatal("active shard ORC proxy stayed valid after invalidateORC")
+	}
+	if shadowProxy.validMask.Get(0) || shadowProxy.validMask.Get(1) {
+		t.Fatal("shadow rebuild shard ORC proxy stayed valid after invalidateORC")
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1416,19 +1416,14 @@ func Init(en scm.Env) {
 				})
 			}
 
-			// Keytable membership is a set, not a multiset. AFTER INSERT / UPDATE
-			// therefore only need to add a key when the base-table group transitions
-			// from empty -> non-empty. In AFTER triggers the mutated row is already
-			// visible, so COUNT==1 means this write created the first row of that
-			// group. This avoids redundant INSERT IGNORE traffic and removes the
-			// race where collect/materialize and trigger maintenance try to add the
-			// same key concurrently.
-			buildInsertIfFirst := func(dictSym string) scm.Scmer {
-				return scm.NewSlice([]scm.Scmer{
-					scm.NewSymbol("if"),
-					scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal?"), scm.NewInt(1), buildCountScan(dictSym)}),
-					buildInsert(dictSym),
-				})
+			// Keytable membership is a set, not a multiset. Always attempt an
+			// idempotent INSERT IGNORE on AFTER INSERT / UPDATE instead of trying
+			// to detect the first row via COUNT==1: a single logical source-row
+			// trigger may insert multiple base rows of the same group in one batch,
+			// so all rows are already visible when the first AFTER INSERT trigger
+			// fires. COUNT==1 would then miss the new group entirely.
+			buildInsertIfMissing := func(dictSym string) scm.Scmer {
+				return buildInsert(dictSym)
 			}
 
 			// AfterDelete body: if count=0 then delete from keytable
@@ -1440,7 +1435,7 @@ func Init(en scm.Env) {
 
 			// AfterInsert body: only add a key when this INSERT created the first
 			// row for the group. Existing groups already have their keytable row.
-			insertBody := buildInsertIfFirst("NEW")
+			insertBody := buildInsertIfMissing("NEW")
 
 			// AfterUpdate body: if key changed, clean up old + insert new
 			keyChangedCheck := buildAndEquals(getAssocs("OLD", baseCols), getAssocs("NEW", baseCols))
@@ -1454,7 +1449,7 @@ func Init(en scm.Env) {
 						scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal?"), scm.NewInt(0), buildCountScan("OLD")}),
 						buildDeleteScan("OLD"),
 					}),
-					buildInsertIfFirst("NEW"),
+					buildInsertIfMissing("NEW"),
 				}),
 			})
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -159,12 +159,38 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 	if t == nil {
 		panic("LOCK TABLES: unknown table: " + schema + "." + name)
 	}
-	// Wait for any existing lock to be released, then claim ownership
-	t.waitTableLock(ss, true) // acquiring any lock requires exclusive wait
+	// LOCK TABLES itself is serialized FIFO per table. This avoids a thundering
+	// herd when many sessions repeatedly lock the same hot table (e.g. cron).
+	cond := t.getTableLockCond()
+	if ss != nil {
+		ss.SetState("Waiting for table lock")
+	}
+	t.tableLockMu.Lock()
+	myTicket := t.tableLockNext
+	t.tableLockNext++
+	for myTicket != t.tableLockServe || t.tableLockOwner.Load() != nil {
+		cond.Wait()
+	}
+	t.tableLockMu.Unlock()
 	// Drain in-flight shard readers by acquiring each shard's write lock.
 	// We MUST set tableLockOwner while still holding the last shard write lock
 	// so that any new scan that does RLock → tableLockOwner.Load() sees the
 	// owner set before it can proceed past its own RLock.
+	acquired := false
+	defer func() {
+		if acquired {
+			return
+		}
+		t.tableLockMu.Lock()
+		if t.tableLockServe == myTicket {
+			t.tableLockServe++
+		}
+		cond.Broadcast()
+		t.tableLockMu.Unlock()
+		if ss != nil {
+			ss.SetState("")
+		}
+	}()
 	shards := t.ActiveShards()
 	for _, s := range shards {
 		s.mu.Lock()
@@ -174,6 +200,7 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 	for _, s := range shards {
 		s.mu.Unlock()
 	}
+	acquired = true
 	if ss != nil {
 		ss.SetState("")
 		ss.AddLock(t.unlockTable)
@@ -299,7 +326,7 @@ func Init(en scm.Env) {
 				{Kind: "func", Params: []*scm.TypeDescriptor{{Transfer: true}, nil}, ParamName: "reduce2", ParamDesc: "(optional) second stage reduce function that will apply a result of reduce to the neutral element/accumulator", Optional: true},
 				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "any"},
+			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScan,
 		},
 	})
@@ -446,7 +473,7 @@ func Init(en scm.Env) {
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
 				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "any"},
+			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrder,
 		},
 	})
@@ -512,7 +539,13 @@ func Init(en scm.Env) {
 			pm := parsePersistencyMode(engine)
 
 			ifnotexists := len(a) > 4 && scm.ToBool(a[4])
-			t, created := CreateTable(scm.String(a[0]), scm.String(a[1]), pm, ifnotexists)
+			db := GetDatabase(scm.String(a[0]))
+			if db == nil {
+				panic("database " + scm.String(a[0]) + " does not exist")
+			}
+			db.ensureLoaded()
+			db.schemalock.Lock()
+			t, created := db.createTableLocked(scm.String(a[1]), pm, ifnotexists)
 			t.Collation = collation
 			t.Charset = charset
 			t.Comment = comment
@@ -560,7 +593,9 @@ func Init(en scm.Env) {
 							dimensions[i] = scm.ToInt(d)
 						}
 						typeparams := mustScmerSlice(def[4], "column typeparams")
-						t.CreateColumn(colname, typename, dimensions, typeparams)
+						if _, ok := t.createColumnLocked(colname, typename, dimensions, typeparams); !ok {
+							panic("column " + t.Name + "." + colname + " already exists")
+						}
 					default:
 						panic("unknown column definition: " + head)
 					}
@@ -578,6 +613,10 @@ func Init(en scm.Env) {
 						}
 					}
 				}
+			}
+			db.saveLockedAndUnlock()
+			if created {
+				registerCreatedTable(t)
 			}
 			return scm.NewBool(true)
 		},
@@ -704,15 +743,15 @@ func Init(en scm.Env) {
 			name := scm.String(a[2])
 
 			db.schemalock.Lock()
-			defer db.schemalock.Unlock()
 			for _, u := range t.Unique {
 				if u.Id == name {
+					db.schemalock.Unlock()
 					return scm.NewBool(false)
 				}
 			}
 
 			t.Unique = append(t.Unique, uniqueKey{name, cols})
-			db.save()
+			db.saveLockedAndUnlock()
 
 			return scm.NewBool(true)
 		},
@@ -749,9 +788,9 @@ func Init(en scm.Env) {
 			cols2 := scmerSliceToStrings(mustScmerSlice(a[5], "foreign cols2"))
 
 			db.schemalock.Lock()
-			defer db.schemalock.Unlock()
 			for _, u := range t1.Foreign {
 				if u.Id == id {
+					db.schemalock.Unlock()
 					return scm.NewBool(false)
 				}
 			}
@@ -763,7 +802,7 @@ func Init(en scm.Env) {
 			// auto-generate system triggers for FK enforcement
 			installFKTriggers(db, t1, t2, k)
 
-			db.save()
+			db.saveLockedAndUnlock()
 
 			return scm.NewBool(true)
 		},
@@ -1599,7 +1638,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Return: &scm.TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
@@ -1705,17 +1744,17 @@ func Init(en scm.Env) {
 						shardRows = append(shardRows, showBuildShardRow(t, i, s))
 					}
 					// build trigger info
-				triggerRows := make([]scm.Scmer, 0, len(t.Triggers))
-				for _, tr := range t.Triggers {
-					triggerRows = append(triggerRows, scm.NewSlice([]scm.Scmer{
-						scm.NewString("name"), scm.NewString(tr.Name),
-						scm.NewString("timing"), scm.NewString(string(tr.Timing)),
-						scm.NewString("hidden"), scm.NewBool(tr.Hidden),
-						scm.NewString("system"), scm.NewBool(tr.IsSystem),
-						scm.NewString("priority"), scm.NewInt(int64(tr.Priority)),
-					}))
-				}
-				return scm.NewSlice([]scm.Scmer{
+					triggerRows := make([]scm.Scmer, 0, len(t.Triggers))
+					for _, tr := range t.Triggers {
+						triggerRows = append(triggerRows, scm.NewSlice([]scm.Scmer{
+							scm.NewString("name"), scm.NewString(tr.Name),
+							scm.NewString("timing"), scm.NewString(string(tr.Timing)),
+							scm.NewString("hidden"), scm.NewBool(tr.Hidden),
+							scm.NewString("system"), scm.NewBool(tr.IsSystem),
+							scm.NewString("priority"), scm.NewInt(int64(tr.Priority)),
+						}))
+					}
+					return scm.NewSlice([]scm.Scmer{
 						scm.NewString("columns"), t.ShowColumns(),
 						scm.NewString("meta"), showBuildMeta(db, t),
 						scm.NewString("shards"), scm.NewSlice(shardRows),
@@ -1980,7 +2019,7 @@ func Init(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "settings",
 		Desc: "reads or writes a global settings value. This modifies your data/settings.json.",
-		Fn: ChangeSettings,
+		Fn:   ChangeSettings,
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", ParamName: "key", ParamDesc: "name of the key to set or get (for reference, rts)", Optional: true},
@@ -2031,21 +2070,23 @@ func Init(en scm.Env) {
 			}
 
 			sourceSQL := scm.String(a[4])
-			body := a[5]
+			body, deferredPlan := unwrapDeferredTriggerBody(a[5])
 			visible := scm.ToBool(a[6])
 
-			// Idempotent: replace any existing trigger with the same name
-			t.RemoveTrigger(name)
 			trigger := TriggerDescription{
 				Name:      name,
 				Timing:    timing,
 				Func:      body,
+				FuncPlan:  deferredPlan,
 				SourceSQL: sourceSQL,
 				Hidden:    !visible,
 				Priority:  0,
 			}
+			db.schemalock.Lock()
+			// Idempotent: replace any existing trigger with the same name
+			t.RemoveTrigger(name)
 			t.AddTrigger(trigger)
-			t.schema.save()
+			db.saveLockedAndUnlock()
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
@@ -2074,13 +2115,15 @@ func Init(en scm.Env) {
 			}
 
 			name := scm.String(a[1])
+			db.schemalock.Lock()
 			// Search all tables for the trigger
 			for _, t := range db.tables.GetAll() {
 				if t.RemoveTrigger(name) {
-					t.schema.save()
+					db.saveLockedAndUnlock()
 					return scm.NewBool(true)
 				}
 			}
+			db.schemalock.Unlock()
 
 			if scm.ToBool(a[2]) {
 				return scm.NewBool(false)
@@ -2104,7 +2147,7 @@ func Init(en scm.Env) {
 	scm.DeclareInSection("Sync", &en, &scm.Declaration{
 		Name: "newcachemap",
 		Desc: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys.",
-		Fn: NewCacheMap,
+		Fn:   NewCacheMap,
 		Type: &scm.TypeDescriptor{
 			Return: &scm.TypeDescriptor{Kind: "func"},
 		},
@@ -2348,7 +2391,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", ParamName: "values", ParamDesc: "FK values to check"},
 				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "nil"},
+			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
 		},
 	})
@@ -2393,7 +2436,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
 				{Kind: "string", ParamName: "mode", ParamDesc: "RESTRICT, CASCADE, or SETNULL"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "nil"},
+			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
 		},
 	})
@@ -2452,7 +2495,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
 				{Kind: "string", ParamName: "mode", ParamDesc: "RESTRICT, CASCADE, or SETNULL"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "nil"},
+			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
 		},
 	})

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -35,6 +35,36 @@ type ColumnReader interface {
 	GetValue(uint32) scm.Scmer
 }
 
+func normalizePartitionDataset(arg scm.Scmer) dataset {
+	raw := mustScmerSlice(arg, "partition columns")
+	if len(raw) == 0 {
+		return dataset(raw)
+	}
+	flat := true
+	for _, item := range raw {
+		pair, ok := scmerSlice(item)
+		if !ok {
+			continue
+		}
+		if len(pair) == 2 && (pair[0].IsString() || pair[0].GetTag() == scm.TagSymbol) {
+			flat = false
+			break
+		}
+	}
+	if flat {
+		return dataset(raw)
+	}
+	normalized := make(dataset, 0, len(raw)*2)
+	for _, item := range raw {
+		pair := mustScmerSlice(item, "partition column pair")
+		if len(pair) != 2 {
+			panic("invalid partition column pair")
+		}
+		normalized = append(normalized, pair[0], pair[1])
+	}
+	return normalized
+}
+
 // THE basic storage pattern
 type ColumnStorage interface {
 	// info
@@ -544,80 +574,109 @@ func Init(en scm.Env) {
 				panic("database " + scm.String(a[0]) + " does not exist")
 			}
 			db.ensureLoaded()
+			tblName := scm.String(a[1])
+			newTable := new(table)
+			newTable.schema = db
+			newTable.Name = tblName
+			newTable.PersistencyMode = pm
+			newTable.ShardMode = ShardModeFree
+			newTable.lastAccessed = uint64(time.Now().UnixNano())
+			newTable.Shards = make([]*storageShard, 1)
+			newTable.Shards[0] = NewShard(newTable)
+			newTable.Auto_increment = 1
+			newTable.Collation = collation
+			newTable.Charset = charset
+			newTable.Comment = comment
+			newTable.Auto_increment = autoIncrement
+
+			for _, coldef := range mustScmerSlice(a[2], "columns") {
+				def := mustScmerSlice(coldef, "column definition")
+				if len(def) == 0 {
+					continue
+				}
+				head := scm.String(def[0])
+				switch head {
+				case "unique":
+					cols := scmerSliceToStrings(mustScmerSlice(def[2], "unique columns"))
+					newTable.Unique = append(newTable.Unique, uniqueKey{scm.String(def[1]), cols})
+				case "foreign":
+					cols1 := scmerSliceToStrings(mustScmerSlice(def[2], "foreign cols1"))
+					cols2 := scmerSliceToStrings(mustScmerSlice(def[4], "foreign cols2"))
+					var updatemode foreignKeyMode
+					if len(def) > 5 {
+						updatemode = getForeignKeyMode(def[5])
+					}
+					var deletemode foreignKeyMode
+					if len(def) > 6 {
+						deletemode = getForeignKeyMode(def[6])
+					}
+					newTable.Foreign = append(newTable.Foreign, foreignKey{
+						Id:         scm.String(def[1]),
+						Tbl1:       newTable.Name,
+						Cols1:      cols1,
+						Tbl2:       scm.String(def[3]),
+						Cols2:      cols2,
+						Updatemode: updatemode,
+						Deletemode: deletemode,
+					})
+				case "column":
+					colname := scm.String(def[1])
+					typename := scm.String(def[2])
+					dimVals := mustScmerSlice(def[3], "column dimensions")
+					dimensions := make([]int, len(dimVals))
+					for i, d := range dimVals {
+						dimensions[i] = scm.ToInt(d)
+					}
+					typeparams := mustScmerSlice(def[4], "column typeparams")
+					if _, ok := newTable.createColumnLocked(colname, typename, dimensions, typeparams); !ok {
+						panic("column " + newTable.Name + "." + colname + " already exists")
+					}
+				default:
+					panic("unknown column definition: " + head)
+				}
+			}
+
 			db.schemalock.Lock()
-			t, created := db.createTableLocked(scm.String(a[1]), pm, ifnotexists)
-			t.Collation = collation
-			t.Charset = charset
-			t.Comment = comment
-			if created {
-				t.Auto_increment = autoIncrement // new table: use specified value (0 = start from scratch)
-			} else if autoIncrement > t.Auto_increment {
-				t.Auto_increment = autoIncrement // existing table: only advance, never reset
-			}
-			if created {
-				for _, coldef := range mustScmerSlice(a[2], "columns") {
-					def := mustScmerSlice(coldef, "column definition")
-					if len(def) == 0 {
-						continue
-					}
-					head := scm.String(def[0])
-					switch head {
-					case "unique":
-						cols := scmerSliceToStrings(mustScmerSlice(def[2], "unique columns"))
-						t.Unique = append(t.Unique, uniqueKey{scm.String(def[1]), cols})
-					case "foreign":
-						cols1 := scmerSliceToStrings(mustScmerSlice(def[2], "foreign cols1"))
-						cols2 := scmerSliceToStrings(mustScmerSlice(def[4], "foreign cols2"))
-						t2name := scm.String(def[3])
-						t2 := t.schema.GetTable(t2name)
-						var updatemode foreignKeyMode
-						if len(def) > 5 {
-							updatemode = getForeignKeyMode(def[5])
-						}
-						var deletemode foreignKeyMode
-						if len(def) > 6 {
-							deletemode = getForeignKeyMode(def[6])
-						}
-						fk := foreignKey{scm.String(def[1]), t.Name, cols1, t2name, cols2, updatemode, deletemode}
-						t.Foreign = append(t.Foreign, fk)
-						if t2 != nil {
-							t2.Foreign = append(t2.Foreign, fk)
-							installFKTriggers(t.schema, t, t2, fk)
-						}
-					case "column":
-						colname := scm.String(def[1])
-						typename := scm.String(def[2])
-						dimVals := mustScmerSlice(def[3], "column dimensions")
-						dimensions := make([]int, len(dimVals))
-						for i, d := range dimVals {
-							dimensions[i] = scm.ToInt(d)
-						}
-						typeparams := mustScmerSlice(def[4], "column typeparams")
-						if _, ok := t.createColumnLocked(colname, typename, dimensions, typeparams); !ok {
-							panic("column " + t.Name + "." + colname + " already exists")
-						}
-					default:
-						panic("unknown column definition: " + head)
-					}
+			existing := db.tables.Get(tblName)
+			if existing != nil {
+				if !ifnotexists {
+					db.schemalock.Unlock()
+					panic("Table " + tblName + " already exists")
 				}
-				// add constraints that are added onto us (forward-declared FKs)
-				for _, t2 := range t.schema.tables.GetAll() {
-					if t2 != t {
-						for _, foreign := range t2.Foreign {
-							if foreign.Tbl2 == t.Name {
-								// copy forward declaration to our definition list
-								t.Foreign = append(t.Foreign, foreign)
-								// install FK triggers now that parent table exists
-								installFKTriggers(t.schema, t2, t, foreign)
-							}
+				existing.Collation = collation
+				existing.Charset = charset
+				existing.Comment = comment
+				if autoIncrement > existing.Auto_increment {
+					existing.Auto_increment = autoIncrement
+				}
+				db.saveLockedWithDurabilityAndUnlock(existing.PersistencyMode == Safe)
+				return scm.NewBool(true)
+			}
+
+			if prev := db.tables.Set(newTable); prev != nil {
+				db.schemalock.Unlock()
+				panic("Table " + tblName + " already exists")
+			}
+
+			for _, fk := range newTable.Foreign {
+				if t2 := newTable.schema.GetTable(fk.Tbl2); t2 != nil {
+					t2.Foreign = append(t2.Foreign, fk)
+					installFKTriggers(newTable.schema, newTable, t2, fk)
+				}
+			}
+			// add constraints that are added onto us (forward-declared FKs)
+			for _, t2 := range newTable.schema.tables.GetAll() {
+				if t2 != newTable {
+					for _, foreign := range t2.Foreign {
+						if foreign.Tbl2 == newTable.Name {
+							newTable.Foreign = append(newTable.Foreign, foreign)
+							installFKTriggers(newTable.schema, t2, newTable, foreign)
 						}
 					}
 				}
 			}
-			db.saveLockedAndUnlock()
-			if created {
-				registerCreatedTable(t)
-			}
+			db.saveLockedWithDurabilityAndUnlock(newTable.PersistencyMode == Safe)
+			registerCreatedTable(newTable)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
@@ -654,7 +713,6 @@ func Init(en scm.Env) {
 				dimensions[i] = scm.ToInt(d)
 			}
 			typeparams := mustScmerSlice(a[5], "typeparams")
-			ok := t.CreateColumn(colname, typename, dimensions, typeparams)
 
 			// ORC column: sortcols in options signals ordered-reduce computed column.
 			// Extract ORC params from the options assoc list.
@@ -684,9 +742,21 @@ func Init(en scm.Env) {
 					orcReduceInit = val
 				}
 			}
+			t.ddlMu.Lock()
+			defer t.ddlMu.Unlock()
+			created := t.createColumnDDLLocked(colname, typename, dimensions, typeparams)
+
+			// Software contract:
+			// createcolumn is the table-local DDL entrypoint for both "create a new
+			// physical column" and "upgrade/configure an existing temp/base column".
+			//
+			// Query planning relies on this for window/temp columns: the planner may
+			// predeclare a bare temp column so later expressions can reference it, and
+			// the runtime createcolumn call must then install the actual ORC/computed
+			// semantics on the already-existing column instead of silently no-oping.
 			if len(orcSortCols) > 0 {
-				t.ComputeOrderedColumn(colname, orcSortCols, orcSortDirs, 0, orcMapCols, orcMapFn, orcReduceFn, orcReduceInit)
-				return scm.NewBool(ok)
+				t.computeOrderedColumnDDLLocked(colname, orcSortCols, orcSortDirs, 0, orcMapCols, orcMapFn, orcReduceFn, orcReduceInit)
+				return scm.NewBool(true)
 			}
 
 			// Regular per-row computed column.
@@ -703,10 +773,11 @@ func Init(en scm.Env) {
 						filter = typeparams[i+1]
 					}
 				}
-				t.ComputeColumn(colname, paramNames, a[7], filterCols, filter)
+				t.computeColumnDDLLocked(colname, paramNames, a[7], filterCols, filter)
+				return scm.NewBool(true)
 			}
 
-			return scm.NewBool(ok)
+			return scm.NewBool(created)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
@@ -751,7 +822,7 @@ func Init(en scm.Env) {
 			}
 
 			t.Unique = append(t.Unique, uniqueKey{name, cols})
-			db.saveLockedAndUnlock()
+			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 
 			return scm.NewBool(true)
 		},
@@ -802,7 +873,7 @@ func Init(en scm.Env) {
 			// auto-generate system triggers for FK enforcement
 			installFKTriggers(db, t1, t2, k)
 
-			db.saveLockedAndUnlock()
+			db.saveLockedWithDurabilityAndUnlock(t1.PersistencyMode == Safe || t2.PersistencyMode == Safe)
 
 			return scm.NewBool(true)
 		},
@@ -877,7 +948,13 @@ func Init(en scm.Env) {
 			if t == nil {
 				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
 			}
-			cols := dataset(mustScmerSlice(a[2], "partition columns"))
+			cols := normalizePartitionDataset(a[2])
+			// Contract: an empty partition schema carries no physical partitioning
+			// information. Keep the table in free-shard mode instead of forcing a
+			// degenerate "partitioned with one shard" rebuild for scratch/key tables.
+			if len(cols) == 0 {
+				return scm.NewBool(false)
+			}
 			if t.ShardMode == ShardModeFree {
 				// apply partitioning schema
 				ps := make([]shardDimension, len(cols)/2)
@@ -886,8 +963,21 @@ func Init(en scm.Env) {
 					ps[i].Pivots = mustScmerSlice(cols[2*i+1], "partition pivots")
 					ps[i].NumPartitions = len(ps[i].Pivots) + 1
 				}
+				trimmed := make([]shardDimension, 0, len(ps))
+				for _, dim := range ps {
+					if dim.NumPartitions > 1 {
+						trimmed = append(trimmed, dim)
+					}
+				}
+				ps = trimmed
+				if len(ps) == 0 {
+					return scm.NewBool(false)
+				}
 				if len(ps) > Settings.PartitionMaxDimensions {
 					ps = ps[:Settings.PartitionMaxDimensions]
+				}
+				if !t.beginManualRepartition() {
+					return scm.NewBool(false)
 				}
 				t.repartition(ps) // perform repartitioning immediately
 				return scm.NewBool(true)
@@ -1114,7 +1204,7 @@ func Init(en scm.Env) {
 				return scm.NewBool(false)
 			}
 			colName := scm.String(a[2])
-			for _, s := range t.ActiveShards() {
+			for _, s := range t.maintenanceShards() {
 				s.mu.RLock()
 				col := s.columns[colName]
 				s.mu.RUnlock()
@@ -1326,6 +1416,21 @@ func Init(en scm.Env) {
 				})
 			}
 
+			// Keytable membership is a set, not a multiset. AFTER INSERT / UPDATE
+			// therefore only need to add a key when the base-table group transitions
+			// from empty -> non-empty. In AFTER triggers the mutated row is already
+			// visible, so COUNT==1 means this write created the first row of that
+			// group. This avoids redundant INSERT IGNORE traffic and removes the
+			// race where collect/materialize and trigger maintenance try to add the
+			// same key concurrently.
+			buildInsertIfFirst := func(dictSym string) scm.Scmer {
+				return scm.NewSlice([]scm.Scmer{
+					scm.NewSymbol("if"),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal?"), scm.NewInt(1), buildCountScan(dictSym)}),
+					buildInsert(dictSym),
+				})
+			}
+
 			// AfterDelete body: if count=0 then delete from keytable
 			deleteBody := scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("if"),
@@ -1333,8 +1438,9 @@ func Init(en scm.Env) {
 				buildDeleteScan("OLD"),
 			})
 
-			// AfterInsert body: insert new key into keytable (INSERT IGNORE)
-			insertBody := buildInsert("NEW")
+			// AfterInsert body: only add a key when this INSERT created the first
+			// row for the group. Existing groups already have their keytable row.
+			insertBody := buildInsertIfFirst("NEW")
 
 			// AfterUpdate body: if key changed, clean up old + insert new
 			keyChangedCheck := buildAndEquals(getAssocs("OLD", baseCols), getAssocs("NEW", baseCols))
@@ -1348,7 +1454,7 @@ func Init(en scm.Env) {
 						scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal?"), scm.NewInt(0), buildCountScan("OLD")}),
 						buildDeleteScan("OLD"),
 					}),
-					buildInsert("NEW"),
+					buildInsertIfFirst("NEW"),
 				}),
 			})
 
@@ -1671,6 +1777,9 @@ func Init(en scm.Env) {
 					tables := db.tables.GetAll()
 					rows := make([]scm.Scmer, 0, len(tables))
 					for _, t := range tables {
+						if t.isHiddenFromShowTables() {
+							continue
+						}
 						engine := showEngineStr(t)
 						var rowCount int64
 						var sizeBytes int64
@@ -2082,11 +2191,13 @@ func Init(en scm.Env) {
 				Hidden:    !visible,
 				Priority:  0,
 			}
+			t.ddlMu.Lock()
+			defer t.ddlMu.Unlock()
 			db.schemalock.Lock()
 			// Idempotent: replace any existing trigger with the same name
 			t.RemoveTrigger(name)
 			t.AddTrigger(trigger)
-			db.saveLockedAndUnlock()
+			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
@@ -2115,15 +2226,20 @@ func Init(en scm.Env) {
 			}
 
 			name := scm.String(a[1])
-			db.schemalock.Lock()
-			// Search all tables for the trigger
-			for _, t := range db.tables.GetAll() {
+			tables := db.tables.GetAll()
+			// Search all tables for the trigger. Take the table-local DDL lock
+			// before the database schemalock to keep the DDL lock order stable.
+			for _, t := range tables {
+				t.ddlMu.Lock()
+				db.schemalock.Lock()
 				if t.RemoveTrigger(name) {
-					db.saveLockedAndUnlock()
+					db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+					t.ddlMu.Unlock()
 					return scm.NewBool(true)
 				}
+				db.schemalock.Unlock()
+				t.ddlMu.Unlock()
 			}
-			db.schemalock.Unlock()
 
 			if scm.ToBool(a[2]) {
 				return scm.NewBool(false)

--- a/storage/table.go
+++ b/storage/table.go
@@ -265,14 +265,28 @@ type table struct {
 
 	lastAccessed uint64 // atomic; UnixNano timestamp for CacheManager LRU of TempKeytable
 
+	// ddlMu is the table-local schema contract:
+	//   - Lock(): column/trigger/ORC metadata on this table may change
+	//   - RLock(): rebuild/repartition may assume table-local schema stability
+	// This keeps long maintenance work local to one table instead of blocking
+	// unrelated tables behind the database-global schemalock.
+	ddlMu sync.RWMutex
+
 	// storage: ShardMode controls which shard set is the read/write target
-	ShardMode         ShardMode
-	rebuilding        bool
-	repartitionActive bool            // true when dual-write is in progress
-	shardModeMu       sync.RWMutex    // protects ShardMode reads in iterateShards vs Phase F flip
-	Shards            []*storageShard // unordered shards (used when ShardMode == ShardModeFree)
-	PShards           []*storageShard // partitioned shards according to PDimensions (used when ShardMode == ShardModePartition)
-	PDimensions       []shardDimension
+	ShardMode   ShardMode
+	rebuilding  bool
+	shardModeMu sync.RWMutex    // protects ShardMode reads in iterateShards vs Phase F flip
+	Shards      []*storageShard // unordered shards (used when ShardMode == ShardModeFree)
+	PShards     []*storageShard // partitioned shards according to PDimensions (used when ShardMode == ShardModePartition)
+	PDimensions []shardDimension
+
+	// repartitionActive is the table-local contract for live repartition:
+	// while true, concurrent DML must dual-write into both shard sets.
+	// It is protected by t.mu and is claimed before a repartition starts,
+	// not only by background rebuilds but also by direct/manual partitiontable calls.
+	repartitionActive bool
+	repartitionOnce   sync.Once
+	repartitionCond   *sync.Cond
 }
 
 func (t *table) enterMutationOwner() {
@@ -338,6 +352,118 @@ func (t *table) ActiveShards() []*storageShard {
 		return t.PShards
 	}
 	return t.Shards
+}
+
+// maintenanceShards returns every shard set that must observe derived-column
+// maintenance immediately:
+//   - the currently authoritative shard set
+//   - any staging shard set of an in-progress repartition
+//   - per-shard rebuild successors reachable via shard.next
+//
+// Contract:
+// mutations may dual-write rows into these shadow shards before they become
+// authoritative. Invalidation of ORC/computed proxies must therefore touch the
+// same maintenance set, otherwise a later publish can surface stale caches.
+func (t *table) maintenanceShards() []*storageShard {
+	active := t.ActiveShards()
+	seen := make(map[*storageShard]struct{}, len(active)*2)
+	result := make([]*storageShard, 0, len(active)*2)
+	appendShard := func(s *storageShard) {
+		if s == nil {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		result = append(result, s)
+	}
+	for _, s := range active {
+		appendShard(s)
+		appendShard(s.loadNext())
+	}
+	if t.repartitionActive {
+		if t.ShardMode == ShardModePartition {
+			for _, s := range t.Shards {
+				appendShard(s)
+			}
+		} else {
+			for _, s := range t.PShards {
+				appendShard(s)
+			}
+		}
+	}
+	return result
+}
+
+func (t *table) getRepartitionCond() *sync.Cond {
+	t.repartitionOnce.Do(func() {
+		t.repartitionCond = sync.NewCond(&t.mu)
+	})
+	return t.repartitionCond
+}
+
+// beginManualRepartition serializes direct partitiontable-triggered repartitions.
+// Contract:
+//   - callers wait until any already-running repartition on this table finishes
+//   - if the table became partitioned while waiting, no new immediate repartition starts
+//   - otherwise repartitionActive is claimed under t.mu before returning
+func (t *table) beginManualRepartition() bool {
+	cond := t.getRepartitionCond()
+	t.mu.Lock()
+	for t.repartitionActive {
+		cond.Wait()
+	}
+	if t.ShardMode != ShardModeFree {
+		t.mu.Unlock()
+		return false
+	}
+	t.repartitionActive = true
+	t.mu.Unlock()
+	return true
+}
+
+// isEphemeralQueryTable identifies query-local scratch tables (keytables,
+// prejoins, scalar helper tables, etc.). These are dot-prefixed and created
+// with non-durable engines so they can be recreated from the query plan after
+// eviction. Global rebuild/repartition must skip them; otherwise a background
+// "(rebuild)" can rebuild a live query's scratch tables and interfere with the
+// in-flight scan.
+//
+// Contract:
+//   - durable internal tables such as ".blobs" are NOT ephemeral and must
+//     continue to participate in rebuild/persistence.
+//   - query-local temp tables are dot-prefixed AND use a non-durable engine.
+func (t *table) isEphemeralQueryTable() bool {
+	if !strings.HasPrefix(t.Name, ".") {
+		return false
+	}
+	switch t.PersistencyMode {
+	case Sloppy, Memory, Cache:
+		return true
+	default:
+		return false
+	}
+}
+
+// schemaWriteDurable reports whether schema.json must be flushed with Sync for
+// DDL on this table. Safe tables keep the full durability contract; other
+// engines still write schema.json synchronously, but without fsync.
+func (t *table) schemaWriteDurable() bool {
+	return t.PersistencyMode == Safe
+}
+
+func (t *table) finishSchemaMutationLocked() {
+	t.schema.saveLockedWithDurabilityAndUnlock(t.schemaWriteDurable())
+}
+
+// isHiddenFromShowTables implements the SQL metadata contract for internal
+// helper tables. Dot-prefixed tables are planner/storage internals and must not
+// leak through SHOW TABLES / INFORMATION_SCHEMA.TABLES listings, otherwise a
+// metadata query ends up materializing live keytables/prejoins/materialized
+// helper relations from unrelated requests.
+func (t *table) isHiddenFromShowTables() bool {
+	return strings.HasPrefix(t.Name, ".")
 }
 
 func (t *table) getTableLockCond() *sync.Cond {
@@ -849,7 +975,7 @@ func (t *table) registerTempColumn(cp *column) {
 					delete(s.columns, colName)
 					s.mu.Unlock()
 				}
-				tbl.schema.saveLockedAndUnlock()
+				tbl.schema.schemalock.Unlock()
 				return true
 			}
 		}
@@ -858,7 +984,7 @@ func (t *table) registerTempColumn(cp *column) {
 	}, tempColumnLastUsed, nil)
 }
 
-func (t *table) CreateColumn(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) bool {
+func (t *table) createColumnDDLLocked(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) bool {
 	// one early out without schemalock (especially for computed columns)
 	for _, c := range t.Columns {
 		if c.Name == name {
@@ -872,14 +998,20 @@ func (t *table) CreateColumn(name string, typ string, typdimensions []int, extra
 		t.schema.schemalock.Unlock()
 		return false
 	}
-	t.schema.saveLockedAndUnlock()
+	t.finishSchemaMutationLocked()
 	if cp.IsTemp {
 		t.registerTempColumn(cp)
 	}
 	return true
 }
 
-func (t *table) DropColumn(name string) bool {
+func (t *table) CreateColumn(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) bool {
+	t.ddlMu.Lock()
+	defer t.ddlMu.Unlock()
+	return t.createColumnDDLLocked(name, typ, typdimensions, extrainfo)
+}
+
+func (t *table) dropColumnDDLLocked(name string) bool {
 	t.schema.schemalock.Lock()
 	var removedCol *column
 	for i, c := range t.Columns {
@@ -900,7 +1032,7 @@ func (t *table) DropColumn(name string) bool {
 			// remove cache invalidation triggers from source tables
 			t.removeComputeTriggers(name)
 
-			t.schema.saveLockedAndUnlock()
+			t.finishSchemaMutationLocked()
 			// Fire lifecycle hooks after unlock so dependents (e.g. prejoin caches)
 			// can invalidate without lock-ordering cycles.
 			t.ExecuteTableLifecycleTriggers(AfterDropColumn)
@@ -913,6 +1045,12 @@ func (t *table) DropColumn(name string) bool {
 	}
 	t.schema.schemalock.Unlock()
 	panic("drop column does not exist: " + t.Name + "." + name)
+}
+
+func (t *table) DropColumn(name string) bool {
+	t.ddlMu.Lock()
+	defer t.ddlMu.Unlock()
+	return t.dropColumnDDLLocked(name)
 }
 
 func (t *table) DropColumnIfExists(name string) bool {

--- a/storage/table.go
+++ b/storage/table.go
@@ -51,9 +51,9 @@ type column struct {
 	OrcSortCols   []string  `json:",omitempty"` // ORDER BY column names (partition cols first, then order cols)
 	OrcSortDirs   []bool    `json:",omitempty"` // false=ASC, true=DESC, one per OrcSortCol
 	OrcMapCols    []string  `json:",omitempty"` // additional input columns passed to OrcMapFn
-	OrcMapFn      scm.Scmer                    // (lambda ($set mapcols...) ...) — passes data to reduceFn
-	OrcReduceFn   scm.Scmer                    // (lambda (acc mapped) ...) — accumulates and writes via $set
-	OrcReduceInit scm.Scmer                    // initial accumulator value (neutral element)
+	OrcMapFn      scm.Scmer // (lambda ($set mapcols...) ...) — passes data to reduceFn
+	OrcReduceFn   scm.Scmer // (lambda (acc mapped) ...) — accumulates and writes via $set
+	OrcReduceInit scm.Scmer // initial accumulator value (neutral element)
 }
 
 // OrcFirstSortCol returns the first sort column name.
@@ -226,15 +226,23 @@ type table struct {
 	uniquelock      sync.Mutex           // unique insert lock
 	// LOCK TABLES: variable-based lock that is cheap for scans to check but
 	// expensive to acquire (drains shard readers first via waitTableLock).
+	// Software contract:
+	//   - tableLockOwner/tableLockWrite describe the currently granted user lock.
+	//   - tableLockNext/tableLockServe serialize LOCK TABLES acquisition FIFO per table,
+	//     so many concurrent waiters (e.g. cron workers) do not stampede on unlock.
+	//   - Regular scans/writes only consult waitTableLock; they never participate in
+	//     the FIFO queue and are released together once the owner unlocks.
 	// tableLockOwner and tableLockWrite are read from every shard goroutine on
 	// every scan; isolate them on their own cache line to prevent false sharing
 	// with Auto_increment (written on every INSERT).
 	tableLockMu    sync.Mutex                       // guards cond waits + acquisition
 	tableLockOnce  sync.Once                        // lazy-inits tableLockCond
 	tableLockCond  *sync.Cond                       // broadcast on unlock
+	tableLockNext  uint64                           // next FIFO ticket for LOCK TABLES acquisition
+	tableLockServe uint64                           // currently served FIFO ticket
 	tableLockOwner atomic.Pointer[scm.SessionState] // nil = no lock; points to owning *SessionState
 	tableLockWrite atomic.Bool                      // true = WRITE lock, false = READ lock
-	_              [55]byte                         // pad to cache-line boundary
+	_              [39]byte                         // pad to cache-line boundary
 	Auto_increment uint64                           // this dosen't scale over multiple cores, so assign auto_increment ranges to each shard
 	Collation      string
 	Charset        string
@@ -252,13 +260,14 @@ type table struct {
 	mutationOwners map[uint64]uint32
 
 	// orcMu serializes ORC recomputes: only one full scan_order pass at a time per table.
-	orcMu         sync.Mutex
+	orcMu          sync.Mutex
 	orcRecomputing int32 // atomic: >0 means an ORC recompute is in progress (skip re-entry in GetValue)
 
 	lastAccessed uint64 // atomic; UnixNano timestamp for CacheManager LRU of TempKeytable
 
 	// storage: ShardMode controls which shard set is the read/write target
 	ShardMode         ShardMode
+	rebuilding        bool
 	repartitionActive bool            // true when dual-write is in progress
 	shardModeMu       sync.RWMutex    // protects ShardMode reads in iterateShards vs Phase F flip
 	Shards            []*storageShard // unordered shards (used when ShardMode == ShardModeFree)
@@ -382,6 +391,7 @@ func (t *table) unlockTable() {
 	t.tableLockOwner.Store(nil)
 	cond := t.getTableLockCond()
 	t.tableLockMu.Lock()
+	t.tableLockServe++
 	cond.Broadcast()
 	t.tableLockMu.Unlock()
 }
@@ -744,20 +754,13 @@ func (d dataset) GetI(key string) (scm.Scmer, bool) { // case insensitive
 	return scm.NewNil(), false
 }
 
-func (t *table) CreateColumn(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) bool {
-	// one early out without schemalock (especially for computed columns)
+// createColumnLocked mutates table metadata while the database schemalock is
+// held. It does not persist schema.json yet; callers must follow up with a
+// single saveLockedAndUnlock once the whole DDL mutation is complete.
+func (t *table) createColumnLocked(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) (*column, bool) {
 	for _, c := range t.Columns {
 		if c.Name == name {
-			return false // column already exists
-		}
-	}
-
-	t.schema.schemalock.Lock()
-
-	for _, c := range t.Columns {
-		if c.Name == name {
-			t.schema.schemalock.Unlock()
-			return false // column already exists
+			return nil, false // column already exists
 		}
 	}
 
@@ -819,40 +822,59 @@ func (t *table) CreateColumn(name string, typ string, typdimensions []int, extra
 		s.columns[name] = new(StorageSparse)
 		s.mu.Unlock()
 	}
-	isTemp := c.IsTemp
-	t.schema.save()
-	t.schema.schemalock.Unlock()
+	return cp, true
+}
+
+func (t *table) registerTempColumn(cp *column) {
 	// register temp column with CacheManager AFTER releasing schemalock
 	// to avoid deadlock: AddItem → run() → evict → cleanup → TryLock(schemalock)
-	if isTemp {
-		tbl := t
-		colName := name
-		GlobalCache.AddItem(cp, 0, TypeTempColumn, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
-			// We're inside the CacheManager goroutine. MUST NOT call GlobalCache.Remove.
-			// Use TryLock to avoid blocking the CacheManager if schema is locked.
-			if !tbl.schema.schemalock.TryLock() {
-				return false // busy, retry later
-			}
-			for i, col := range tbl.Columns {
-				if col.Name == colName {
-					tbl.Columns = append(tbl.Columns[:i], tbl.Columns[i+1:]...)
-					for _, s := range tbl.Shards {
-						s.mu.Lock()
-						delete(s.columns, colName)
-						s.mu.Unlock()
-					}
-					for _, s := range tbl.PShards {
-						s.mu.Lock()
-						delete(s.columns, colName)
-						s.mu.Unlock()
-					}
-					tbl.schema.save()
-					break
+	tbl := t
+	colName := cp.Name
+	GlobalCache.AddItem(cp, 0, TypeTempColumn, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
+		// We're inside the CacheManager goroutine. MUST NOT call GlobalCache.Remove.
+		// Use TryLock to avoid blocking the CacheManager if schema is locked.
+		if !tbl.schema.schemalock.TryLock() {
+			return false // busy, retry later
+		}
+		for i, col := range tbl.Columns {
+			if col.Name == colName {
+				tbl.Columns = append(tbl.Columns[:i], tbl.Columns[i+1:]...)
+				for _, s := range tbl.Shards {
+					s.mu.Lock()
+					delete(s.columns, colName)
+					s.mu.Unlock()
 				}
+				for _, s := range tbl.PShards {
+					s.mu.Lock()
+					delete(s.columns, colName)
+					s.mu.Unlock()
+				}
+				tbl.schema.saveLockedAndUnlock()
+				return true
 			}
-			tbl.schema.schemalock.Unlock()
-			return true
-		}, tempColumnLastUsed, nil)
+		}
+		tbl.schema.schemalock.Unlock()
+		return true
+	}, tempColumnLastUsed, nil)
+}
+
+func (t *table) CreateColumn(name string, typ string, typdimensions []int, extrainfo []scm.Scmer) bool {
+	// one early out without schemalock (especially for computed columns)
+	for _, c := range t.Columns {
+		if c.Name == name {
+			return false // column already exists
+		}
+	}
+
+	t.schema.schemalock.Lock()
+	cp, ok := t.createColumnLocked(name, typ, typdimensions, extrainfo)
+	if !ok {
+		t.schema.schemalock.Unlock()
+		return false
+	}
+	t.schema.saveLockedAndUnlock()
+	if cp.IsTemp {
+		t.registerTempColumn(cp)
 	}
 	return true
 }
@@ -878,8 +900,7 @@ func (t *table) DropColumn(name string) bool {
 			// remove cache invalidation triggers from source tables
 			t.removeComputeTriggers(name)
 
-			t.schema.save()
-			t.schema.schemalock.Unlock()
+			t.schema.saveLockedAndUnlock()
 			// Fire lifecycle hooks after unlock so dependents (e.g. prejoin caches)
 			// can invalidate without lock-ordering cycles.
 			t.ExecuteTableLifecycleTriggers(AfterDropColumn)

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -16,7 +16,6 @@ Copyright (C) 2025, 2026  Carl-Philip Hänsch
 */
 package storage
 
-import "os"
 import "fmt"
 import "errors"
 import "encoding/json"
@@ -131,27 +130,153 @@ func (tt *TriggerTiming) UnmarshalJSON(data []byte) error {
 
 // TriggerDescription holds all information about a trigger
 type TriggerDescription struct {
-	Name      string        `json:"name"`                 // Trigger name (user-defined or auto-generated)
-	Timing    TriggerTiming `json:"timing"`               // BEFORE/AFTER INSERT/UPDATE/DELETE
-	Func      scm.Scmer     `json:"func"`                 // The trigger function (compiled Scheme procedure)
-	SourceSQL string        `json:"source_sql,omitempty"` // Original SQL body text (for SHOW TRIGGERS)
-	IsSystem  bool          `json:"is_system,omitempty"`  // True for Go-internal triggers (FK etc.) — not persisted via createtrigger
+	Name       string        `json:"name"`                 // Trigger name (user-defined or auto-generated)
+	Timing     TriggerTiming `json:"timing"`               // BEFORE/AFTER INSERT/UPDATE/DELETE
+	Func       scm.Scmer     `json:"func"`                 // The trigger function (compiled Scheme procedure)
+	FuncPlan   scm.Scmer     `json:"-"`                    // Unevaluated lambda AST for SQL triggers; compiled lazily on first use
+	SourceSQL  string        `json:"source_sql,omitempty"` // Original SQL body text (for SHOW TRIGGERS)
+	IsSystem   bool          `json:"is_system,omitempty"`  // True for Go-internal triggers (FK etc.) — not persisted via createtrigger
 	Hidden     bool          `json:"hidden,omitempty"`     // True for Scheme-internal triggers — persisted but hidden from SHOW TRIGGERS
 	Priority   int           `json:"priority,omitempty"`   // Execution order (lower = earlier)
 	Async      bool          `json:"async,omitempty"`      // Run trigger in background goroutine (fire-and-forget, no transaction context)
 	VectorFunc scm.Scmer     `json:"-"`                    // Vectorized trigger: (lambda (OLD_batch NEW_batch) ...) for batch execution
 }
 
+type persistedTriggerDescription struct {
+	Name      string        `json:"name"`
+	Timing    TriggerTiming `json:"timing"`
+	Func      *scm.Scmer    `json:"func,omitempty"`
+	SourceSQL string        `json:"source_sql,omitempty"`
+	IsSystem  bool          `json:"is_system,omitempty"`
+	Hidden    bool          `json:"hidden,omitempty"`
+	Priority  int           `json:"priority,omitempty"`
+	Async     bool          `json:"async,omitempty"`
+}
+
+func (tr TriggerDescription) MarshalJSON() ([]byte, error) {
+	persist := persistedTriggerDescription{
+		Name:      tr.Name,
+		Timing:    tr.Timing,
+		SourceSQL: tr.SourceSQL,
+		IsSystem:  tr.IsSystem,
+		Hidden:    tr.Hidden,
+		Priority:  tr.Priority,
+		Async:     tr.Async,
+	}
+	// SQL triggers can be restored from source_sql on load; persisting the
+	// compiled Scheme AST would bloat schema.json dramatically.
+	if tr.SourceSQL == "" {
+		fn := tr.Func
+		persist.Func = &fn
+	}
+	return json.Marshal(persist)
+}
+
+func (tr *TriggerDescription) UnmarshalJSON(data []byte) error {
+	var persist persistedTriggerDescription
+	if err := json.Unmarshal(data, &persist); err != nil {
+		return err
+	}
+	tr.Name = persist.Name
+	tr.Timing = persist.Timing
+	tr.SourceSQL = persist.SourceSQL
+	tr.IsSystem = persist.IsSystem
+	tr.Hidden = persist.Hidden
+	tr.Priority = persist.Priority
+	tr.Async = persist.Async
+	tr.FuncPlan = scm.NewNil()
+	tr.VectorFunc = scm.NewNil()
+	if persist.Func != nil {
+		tr.Func = *persist.Func
+	} else {
+		tr.Func = scm.NewNil()
+	}
+	return nil
+}
+
+func triggerScmerMissing(v scm.Scmer) bool {
+	return v.IsNil()
+}
+
+func unwrapDeferredTriggerBody(body scm.Scmer) (scm.Scmer, scm.Scmer) {
+	if !body.IsSlice() {
+		return body, scm.NewNil()
+	}
+	items := body.Slice()
+	if len(items) == 2 && scm.String(items[0]) == "quote" {
+		return unwrapDeferredTriggerBody(items[1])
+	}
+	if len(items) != 2 || scm.String(items[0]) != "deferred_trigger" {
+		return body, scm.NewNil()
+	}
+	return scm.NewNil(), items[1]
+}
+
+func finalizeTriggerCompilation(trigger *TriggerDescription) {
+	if triggerScmerMissing(trigger.Func) {
+		return
+	}
+	if (trigger.IsSystem || trigger.Hidden || trigger.SourceSQL == "") && trigger.VectorFunc.IsNil() {
+		if vf := VectorizeTrigger(trigger.Func); !vf.IsNil() {
+			trigger.VectorFunc = vf
+		}
+	}
+}
+
+func compileTriggerForUse(schemaName, tableName string, trigger *TriggerDescription) {
+	if !triggerScmerMissing(trigger.Func) {
+		finalizeTriggerCompilation(trigger)
+		return
+	}
+	if !triggerScmerMissing(trigger.FuncPlan) {
+		trigger.Func = scm.Eval(trigger.FuncPlan, &scm.Globalenv)
+		trigger.FuncPlan = scm.NewNil()
+		finalizeTriggerCompilation(trigger)
+		return
+	}
+	loadPersistedTriggerPlan(schemaName, tableName, trigger)
+	if !triggerScmerMissing(trigger.FuncPlan) {
+		trigger.Func = scm.Eval(trigger.FuncPlan, &scm.Globalenv)
+		trigger.FuncPlan = scm.NewNil()
+	}
+	finalizeTriggerCompilation(trigger)
+}
+
 // GetTriggers returns all triggers for a specific timing
 func (t *table) GetTriggers(timing TriggerTiming) []TriggerDescription {
 	t.mu.Lock()
 	result := make([]TriggerDescription, 0, len(t.Triggers))
-	for _, tr := range t.Triggers {
-		if tr.Timing == timing {
-			result = append(result, tr)
+	type lazyTrigger struct {
+		triggerIndex int
+		resultIndex  int
+	}
+	lazy := make([]lazyTrigger, 0)
+	for i, tr := range t.Triggers {
+		if tr.Timing != timing {
+			continue
+		}
+		result = append(result, tr)
+		if triggerScmerMissing(tr.Func) && (!triggerScmerMissing(tr.FuncPlan) || tr.SourceSQL != "") {
+			lazy = append(lazy, lazyTrigger{triggerIndex: i, resultIndex: len(result) - 1})
 		}
 	}
 	t.mu.Unlock()
+	for _, item := range lazy {
+		tr := result[item.resultIndex]
+		compileTriggerForUse(t.schema.Name, t.Name, &tr)
+		result[item.resultIndex] = tr
+
+		t.mu.Lock()
+		if item.triggerIndex < len(t.Triggers) {
+			current := &t.Triggers[item.triggerIndex]
+			if current.Name == tr.Name && current.Timing == tr.Timing && triggerScmerMissing(current.Func) {
+				current.Func = tr.Func
+				current.FuncPlan = tr.FuncPlan
+				current.VectorFunc = tr.VectorFunc
+			}
+		}
+		t.mu.Unlock()
+	}
 	return result
 }
 
@@ -159,51 +284,11 @@ func (t *table) GetTriggers(timing TriggerTiming) []TriggerDescription {
 // the trigger for batch execution (DELETE/INSERT patterns on prejoin tables).
 func (t *table) AddTrigger(trigger TriggerDescription) {
 	// Auto-vectorize: try to produce a batch-aware version of the trigger
-	if trigger.VectorFunc.IsNil() && !trigger.Func.IsNil() {
-		if trigger.Timing == AfterDelete {
-			fmt.Fprintln(os.Stderr, "[AT-DEL]", trigger.Name, "isProc:", trigger.Func.IsProc())
-			if trigger.Func.IsProc() {
-				b := trigger.Func.Proc().Body
-				fmt.Fprintln(os.Stderr, "  body isSlice:", b.IsSlice())
-				if b.IsSlice() {
-					items := b.Slice()
-					fmt.Fprintln(os.Stderr, "  len:", len(items))
-					if len(items) > 4 {
-						fmt.Fprintln(os.Stderr, "  head:", scm.String(items[0]), "isSymbol:", items[0].IsSymbol())
-						fmt.Fprintln(os.Stderr, "  items[4] tag:", items[4].GetTag(), "isSlice:", items[4].IsSlice())
-						if items[4].IsSlice() {
-							sl := items[4].Slice()
-							if len(sl) >= 3 {
-								fmt.Fprintln(os.Stderr, "  lambda body:", scm.String(sl[2]))
-								if sl[2].IsSlice() {
-									bs := sl[2].Slice()
-									fmt.Fprintln(os.Stderr, "  body[0]:", scm.String(bs[0]), "isSymbol:", bs[0].IsSymbol(), "declName:", declName(bs[0]))
-									if len(bs) == 3 {
-										fmt.Fprintln(os.Stderr, "  body[2]:", scm.String(bs[2]), "isSlice:", bs[2].IsSlice())
-										if bs[2].IsSlice() {
-											ga := bs[2].Slice()
-											fmt.Fprintln(os.Stderr, "  getassoc head:", scm.String(ga[0]), "declName:", declName(ga[0]))
-											fmt.Fprintln(os.Stderr, "  getassoc[1]:", scm.String(ga[1]), "isSymbol:", ga[1].IsSymbol())
-											fmt.Fprintln(os.Stderr, "  getassoc[2]:", scm.String(ga[2]), "isString:", ga[2].IsString(), "isSymbol:", ga[2].IsSymbol())
-										}
-									}
-								}
-							}
-						}
-						key := extractGetAssocOldKey(items[4])
-						fmt.Fprintln(os.Stderr, "  extracted key:", key)
-						if len(items) > 5 {
-							fmt.Fprintln(os.Stderr, "  containsUpdate:", containsUpdateCol(items[5]))
-						}
-					}
-				}
-			}
-		}
-		if vf := VectorizeTrigger(trigger.Func); !vf.IsNil() {
-			trigger.VectorFunc = vf
-			fmt.Fprintln(os.Stderr, "[VECTORIZED]", trigger.Name)
-		}
-	}
+	// Contract: only internal/system triggers participate in automatic
+	// vectorization. User-facing SQL triggers may have very large bodies;
+	// walking their full AST during CREATE TRIGGER would make schema setup
+	// disproportionately expensive without improving correctness.
+	finalizeTriggerCompilation(&trigger)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	// Keep trigger list ordered by priority (lower = earlier). For equal

--- a/storage/trigger_vectorize.go
+++ b/storage/trigger_vectorize.go
@@ -16,8 +16,6 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
-import "os"
-import "fmt"
 import "github.com/launix-de/memcp/scm"
 
 // VectorizeTrigger analyzes a trigger body and produces a vectorized version
@@ -25,16 +23,18 @@ import "github.com/launix-de/memcp/scm"
 // body cannot be vectorized (falls back to per-row execution).
 //
 // Currently recognizes the prejoin DELETE pattern:
-//   (lambda (OLD NEW) (scan schema tbl condCols
-//       (lambda (cols...) (equal? col (get_assoc OLD key)))
-//       (list "$update") (lambda ($update) ($update)) + 0 nil false))
+//
+//	(lambda (OLD NEW) (scan schema tbl condCols
+//	    (lambda (cols...) (equal? col (get_assoc OLD key)))
+//	    (list "$update") (lambda ($update) ($update)) + 0 nil false))
 //
 // Vectorized form:
-//   (lambda (OLD_batch NEW_batch)
-//       (define vals (map OLD_batch (lambda (OLD) (get_assoc OLD key))))
-//       (scan schema tbl condCols
-//           (lambda (cols...) (has? vals col))
-//           (list "$update") (lambda ($update) ($update)) + 0 nil false))
+//
+//	(lambda (OLD_batch NEW_batch)
+//	    (define vals (map OLD_batch (lambda (OLD) (get_assoc OLD key))))
+//	    (scan schema tbl condCols
+//	        (lambda (cols...) (has? vals col))
+//	        (list "$update") (lambda ($update) ($update)) + 0 nil false))
 func VectorizeTrigger(triggerFn scm.Scmer) scm.Scmer {
 	// Extract the proc body
 	if !triggerFn.IsProc() {
@@ -156,13 +156,6 @@ func VectorizeTrigger(triggerFn scm.Scmer) scm.Scmer {
 // Returns "" if the pattern is not found.
 func extractGetAssocOldKey(filterFn scm.Scmer) string {
 	var body scm.Scmer
-	fmt.Fprintln(os.Stderr, "  [extractKey] isProc:", filterFn.IsProc(), "isSlice:", filterFn.IsSlice())
-	if filterFn.IsSlice() {
-		sl := filterFn.Slice()
-		if len(sl) >= 3 {
-			fmt.Fprintln(os.Stderr, "  [extractKey] sl[0]:", scm.String(sl[0]), "isSymbol:", sl[0].IsSymbol(), "tag:", sl[0].GetTag())
-		}
-	}
 	if filterFn.IsProc() {
 		body = filterFn.Proc().Body
 	} else if filterFn.IsSlice() {

--- a/tests/14_order_limit.yaml
+++ b/tests/14_order_limit.yaml
@@ -1,9 +1,9 @@
 # ORDER BY and LIMIT/OFFSET
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Ordering by multiple keys with pagination"
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS ord_t"

--- a/tests/16_group_by_sum.yaml
+++ b/tests/16_group_by_sum.yaml
@@ -1,7 +1,6 @@
 # GROUP BY SUM Test Suite
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Validate SELECT a, SUM(b) FROM tbl GROUP BY a"
 

--- a/tests/56_multishard.yaml
+++ b/tests/56_multishard.yaml
@@ -6,9 +6,9 @@
 # - cross-shard DELETE, UPDATE, aggregation
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Multi-shard scan, order, and DML coverage"
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS `ms_data`"

--- a/tests/66_circular_queryplan.yaml
+++ b/tests/66_circular_queryplan.yaml
@@ -8,7 +8,7 @@
 metadata:
   version: "1.0"
   description: "Circular query plan from complex derived-table LEFT JOIN"
-  isolate: true
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS cqp_task"

--- a/tests/66_compute_proxy_repartition.yaml
+++ b/tests/66_compute_proxy_repartition.yaml
@@ -9,7 +9,7 @@
 metadata:
   version: "1.0"
   description: "StorageComputeProxy during rebuild/repartition"
-  isolate: true
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS cpr_orders"

--- a/tests/66_derived_table_count_regressions_minimal.yaml
+++ b/tests/66_derived_table_count_regressions_minimal.yaml
@@ -16,7 +16,7 @@
 metadata:
   version: "1.0"
   description: "Minimal derived-table COUNT and reuse regressions"
-  isolate: true
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS dtc_parent"

--- a/tests/66_left_join_correlated_on.yaml
+++ b/tests/66_left_join_correlated_on.yaml
@@ -8,7 +8,7 @@
 metadata:
   version: "1.0"
   description: "LEFT JOIN with correlated subselect in ON condition"
-  isolate: true
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS ljco_vehicle"

--- a/tests/71_repartition_concurrent.yaml
+++ b/tests/71_repartition_concurrent.yaml
@@ -3,7 +3,6 @@
 # Uses the parallel test directive to launch rebuild and DML operations simultaneously.
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Concurrent repartition: dual-write correctness"
   disabled: true  # bulk insert of 61k rows with PK times out; needs unique check optimization

--- a/tests/82_ordered_computed_column.yaml
+++ b/tests/82_ordered_computed_column.yaml
@@ -8,7 +8,6 @@
 metadata:
   version: "1.0"
   description: "ORC Phase 1: ROW_NUMBER, running SUM, post-mutation lazy recompute"
-  isolated: true
 
 test_cases:
 

--- a/tests/84_incremental_invalidation.yaml
+++ b/tests/84_incremental_invalidation.yaml
@@ -1,7 +1,6 @@
 metadata:
   version: "1.0"
   description: "Incremental invalidation: SUM/COUNT DELETE, ORC partition-scoped, concurrency"
-  isolated: true
 
 test_cases:
 

--- a/tests/84_information_schema.yaml
+++ b/tests/84_information_schema.yaml
@@ -7,6 +7,7 @@ metadata:
 
 setup:
   - sql: "CREATE TABLE IF NOT EXISTS is_test_tbl (id INT, name VARCHAR(50), score DOUBLE)"
+  - scm: '(createtable "memcp-tests" ".is_hidden_meta" (list (list "column" "id" "int" (list) (list))) (list "engine" "sloppy") true)'
 
 test_cases:
 
@@ -43,6 +44,11 @@ test_cases:
 
   - name: "TABLES: non-existent table returns empty"
     sql: "SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'nonexistent_xyz_99' LIMIT 1"
+    expect:
+      rows: 0
+
+  - name: "TABLES: hidden dot-table is not listed"
+    sql: "SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '.is_hidden_meta' LIMIT 1"
     expect:
       rows: 0
 
@@ -122,3 +128,4 @@ test_cases:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS is_test_tbl"
+  - sql: "DROP TABLE IF EXISTS `.is_hidden_meta`"

--- a/tests/85_suffix_recompute.yaml
+++ b/tests/85_suffix_recompute.yaml
@@ -1,7 +1,6 @@
 metadata:
   version: "1.0"
   description: "ORC suffix recompute: correctness under INSERT/DELETE/UPDATE at various positions"
-  isolated: true
 
 test_cases:
 

--- a/tests/86_reversed_comparisons.yaml
+++ b/tests/86_reversed_comparisons.yaml
@@ -3,7 +3,6 @@
 # Also tests IS NULL boundary extraction for index usage.
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Reversed comparisons and IS NULL boundary extraction"
 

--- a/tests/87_in_list_like_prefix.yaml
+++ b/tests/87_in_list_like_prefix.yaml
@@ -2,7 +2,6 @@
 # IN (1,2,3) → range [min,max]; LIKE 'foo%' → range [prefix, prefix+1)
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "IN-list and LIKE prefix boundary extraction"
 

--- a/tests/88_exclusive_bounds.yaml
+++ b/tests/88_exclusive_bounds.yaml
@@ -4,7 +4,6 @@
 metadata:
   version: "1.0"
   description: "Exclusive bound index scan optimization"
-  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS exbound"

--- a/tests/89_native_index.yaml
+++ b/tests/89_native_index.yaml
@@ -3,7 +3,6 @@
 # so no in-memory index structure is needed (zero memory cost).
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Physical sort by hottest index (Native index)"
 

--- a/tests/90_eager_index_rebuild.yaml
+++ b/tests/90_eager_index_rebuild.yaml
@@ -3,7 +3,6 @@
 # so the first query does not pay a cold-start full-scan penalty.
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Eager index rebuild after shard rebuild"
 

--- a/tests/90_perf_basic.yaml
+++ b/tests/90_perf_basic.yaml
@@ -7,9 +7,9 @@
 # {rows} and {database} are template placeholders filled by the test runner
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Performance tests: aggregation, joins, ordering"
+  isolated: true
 
 test_cases:
   # COUNT aggregation with data generation

--- a/tests/91_perf_unique_insert.yaml
+++ b/tests/91_perf_unique_insert.yaml
@@ -5,9 +5,9 @@
 # {rows} and {database} are template placeholders filled by the test runner
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Performance tests: unique key inserts"
+  isolated: true
 
 test_cases:
   # INSERT IGNORE with non-overlapping keys into empty table (fresh delta insert)

--- a/tests/92_unique_main_delta.yaml
+++ b/tests/92_unique_main_delta.yaml
@@ -6,7 +6,6 @@
 # Uses scm:"(rebuild)" to trigger main storage compaction between operations
 
 metadata:
-  isolated: true
   version: "1.0"
   description: "Unique constraint: main vs delta storage corner cases"
 

--- a/tests/93_index_delta_merge.yaml
+++ b/tests/93_index_delta_merge.yaml
@@ -7,7 +7,6 @@
 metadata:
   version: "1.0"
   description: "Non-unique index: delta+main streaming merge, matrix multiply"
-  isolated: true
 
 test_cases:
   # ==============================================================

--- a/tests/96_string_compression.yaml
+++ b/tests/96_string_compression.yaml
@@ -1,5 +1,4 @@
 metadata:
-  isolated: true
   version: "1.0"
   description: "String compression: round-trip correctness for UUID, hex, phone, decimal, datetime, raw"
 


### PR DESCRIPTION
## Summary

- fix rebuild/repartition concurrency so shard rebuild and repartition work on snapshots instead of holding long-lived locks
- serialize LOCK TABLES acquisition fairly to avoid lock convoys
- persist schema changes with synced writes and store triggers in deferred form instead of persisting compiled trigger functions
- retain isolated execution for explicit introspection and heavy stress suites

## Testing

- full repository regression suite
- targeted derived-table and concurrency suites
- private downstream compatibility validation; local tooling and environment details are intentionally not published