### PR TITLE
Introduce group aliases for HAVING decorrelation

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1126,18 +1126,19 @@ get_column markers and may no longer run schema-based repair heuristics. */
 	(define so (coalesceNil (stage_order_list stage) '()))
 	(define sl (stage_limit_val stage))
 	(define soff (stage_offset_val stage))
+	(define sga (stage_group_alias stage))
 	(define spa (stage_partition_aliases stage))
 	(if (stage_is_dedup stage)
-		(stage_preserve_cache_meta stage (make_dedup_stage (map sg fin) spa))
+		(stage_preserve_cache_meta stage (make_dedup_stage (map sg fin) sga spa))
 		(if (and (not (nil? spa)) (or (nil? sg) (equal? sg '())))
 			(stage_preserve_cache_meta stage (make_partition_stage spa
 				(map so (lambda (o) (match o '(c d) (list (fin c) d))))
-				(coalesceNil (stage_limit_partition_cols stage) 0) sl soff (stage_init_code stage)))
+				(coalesceNil (stage_limit_partition_cols stage) 0) sl soff (stage_init_code stage) sga))
 			(stage_preserve_cache_meta stage (make_group_stage
 				(map sg fin)
 				(fin sh)
 				(map so (lambda (o) (match o '(c d) (list (fin c) d))))
-				sl soff spa (stage_init_code stage)))))
+				sl soff sga spa (stage_init_code stage)))))
 )))
 (define finalize_logical_stage (lambda (stage all_schemas rewrite_expr enforce_contract)
 	(finalize_logical_stage_scoped stage all_schemas all_schemas rewrite_expr enforce_contract)
@@ -1148,7 +1149,7 @@ get_column markers and may no longer run schema-based repair heuristics. */
 /* group stage constructors and accessors - shared between untangle_query and build_queryplan
 All stages have partition-aliases (scope): nil = global (all tables), list = scoped to those tables.
 All stages have init: nil = no init code, or code to run before the scan. */
-(define make_group_stage (lambda (group having order limit offset aliases init)
+(define make_group_stage (lambda (group having order limit offset group_alias aliases init)
 	(list
 		(cons (quote group-cols) (coalesce group '()))
 		(list (quote having) having)
@@ -1156,12 +1157,13 @@ All stages have init: nil = no init code, or code to run before the scan. */
 		(list (quote limit-partition-cols) 0)
 		(list (quote limit) limit)
 		(list (quote offset) offset)
+		(list (quote group-alias) group_alias)
 		(list (quote dedup) false)
 		(list (quote partition-aliases) aliases)
 		(list (quote init) init)
 	)
 ))
-(define make_partition_stage (lambda (aliases order partition_cols limit offset init)
+(define make_partition_stage (lambda (aliases order partition_cols limit offset init group_alias)
 	(list
 		(cons (quote group-cols) '())
 		(list (quote having) nil)
@@ -1169,12 +1171,13 @@ All stages have init: nil = no init code, or code to run before the scan. */
 		(list (quote limit-partition-cols) partition_cols)
 		(list (quote limit) limit)
 		(list (quote offset) offset)
+		(list (quote group-alias) group_alias)
 		(list (quote dedup) false)
 		(list (quote partition-aliases) aliases)
 		(list (quote init) init)
 	)
 ))
-(define make_dedup_stage (lambda (group aliases)
+(define make_dedup_stage (lambda (group group_alias aliases)
 	(list
 		(cons (quote group-cols) (coalesce group '()))
 		(list (quote having) nil)
@@ -1182,6 +1185,7 @@ All stages have init: nil = no init code, or code to run before the scan. */
 		(list (quote limit-partition-cols) 0)
 		(list (quote limit) nil)
 		(list (quote offset) nil)
+		(list (quote group-alias) group_alias)
 		(list (quote dedup) true)
 		(list (quote partition-aliases) aliases)
 		(list (quote init) nil)
@@ -1214,6 +1218,12 @@ All stages have init: nil = no init code, or code to run before the scan. */
 (define stage_offset_val (lambda (stage) (reduce stage (lambda (acc item)
 	(if (nil? acc) (match item
 		(cons (quote offset) rest) (if (nil? rest) nil (car rest))
+		_ nil
+	) acc)
+) nil)))
+(define stage_group_alias (lambda (stage) (reduce stage (lambda (acc item)
+	(if (nil? acc) (match item
+		(cons (quote group-alias) rest) (if (nil? rest) nil (car rest))
 		_ nil
 	) acc)
 ) nil)))
@@ -1898,7 +1908,7 @@ or generate runtime scan code (build_queryplan).
 						(define groups2 (coalesceNil groups2 '()))
 						(define groups2 (if (or (nil? groups2) (equal? groups2 '()))
 							(if (or raw_group raw_having raw_order raw_limit raw_offset)
-								(list (make_group_stage raw_group raw_having raw_order raw_limit raw_offset nil nil))
+								(list (make_group_stage raw_group raw_having raw_order raw_limit raw_offset nil nil nil))
 								groups2)
 							groups2))
 						(define replace_find_column_subselect (make_replace_find_column_subselect schemas2 outer_schemas))
@@ -2262,7 +2272,7 @@ or generate runtime scan code (build_queryplan).
 								(define groups2_us (coalesceNil groups2_us '()))
 								(define groups2_us (if (or (nil? groups2_us) (equal? groups2_us '()))
 									(if (or raw_group_us raw_having_us raw_order_us raw_limit_us raw_offset_us)
-										(list (make_group_stage raw_group_us raw_having_us raw_order_us raw_limit_us raw_offset_us nil _nt_virtual_init))
+										(list (make_group_stage raw_group_us raw_having_us raw_order_us raw_limit_us raw_offset_us nil nil _nt_virtual_init))
 										groups2_us)
 									groups2_us))
 								/* resolve columns against inner and outer schemas */
@@ -2452,7 +2462,7 @@ or generate runtime scan code (build_queryplan).
 												(define us_group_stage
 													(stage_with_cache_query
 														(stage_with_cache_policy
-															(make_group_stage us_new_group us_new_having us_new_order us_orig_limit_a us_orig_offset_a us_inner_aliases nil)
+															(make_group_stage us_new_group us_new_having us_new_order us_orig_limit_a us_orig_offset_a nil us_inner_aliases nil)
 															(count_subquery_cache_policy subquery))
 														(if (nil? (count_subquery_cache_policy subquery)) nil subquery)))
 												/* propagate inner scoped stages with prefix */
@@ -2462,7 +2472,7 @@ or generate runtime scan code (build_queryplan).
 													(define _pso (map (coalesceNil (stage_order_list s) '()) (lambda (o) (match o '(c d) (list (_us_prefix_ria c) d) o))))
 													(define _psa (map (coalesceNil (stage_partition_aliases s) '()) (lambda (a) (coalesceNil (_us_lookup a) a))))
 													(stage_preserve_cache_meta s
-														(make_group_stage _psg _psh _pso (stage_limit_val s) (stage_offset_val s) _psa (stage_init_code s)))))))
+														(make_group_stage _psg _psh _pso (stage_limit_val s) (stage_offset_val s) (stage_group_alias s) _psa (stage_init_code s)))))))
 												/* register prefixed tables */
 												(sq_cache "tables" (merge us_prefixed_tables (coalesceNil (sq_cache "tables") '())))
 												/* register scoped GROUP stage + propagated inner stages */
@@ -2576,7 +2586,7 @@ or generate runtime scan code (build_queryplan).
 															(b) explicit LIMIT from SQL, (c) uncorrelated needs global limit=1.
 															Indirect-only correlations skip: join chain guarantees 1 row. */
 															(if (or (not (equal? us_part_order '())) us_has_limit (not us_has_outer)) (begin
-																(define us_part_stage (make_partition_stage (list us_sq_prefix) us_part_order us_dom_count (coalesceNil us_orig_limit 1) (coalesceNil us_orig_offset 0) nil))
+																(define us_part_stage (make_partition_stage (list us_sq_prefix) us_part_order us_dom_count (coalesceNil us_orig_limit 1) (coalesceNil us_orig_offset 0) nil nil))
 																(sq_cache "partition_stages" (cons us_part_stage (coalesceNil (sq_cache "partition_stages") '()))))))
 														/* propagate inner scoped stages with renaming */
 														(if (not (equal? _us_inner_stages '()))
@@ -2587,7 +2597,7 @@ or generate runtime scan code (build_queryplan).
 																	(define _pso (map (coalesceNil (stage_order_list s) '()) (lambda (o) (match o '(c d) (list (_us_ria c) d) o))))
 																	(define _psa (map (coalesceNil (stage_partition_aliases s) '()) (lambda (a) (coalesceNil (_us_lookup a) a))))
 																	(stage_preserve_cache_meta s
-																		(make_group_stage _psg _psh _pso (stage_limit_val s) (stage_offset_val s) _psa (stage_init_code s))))))
+																		(make_group_stage _psg _psh _pso (stage_limit_val s) (stage_offset_val s) (stage_group_alias s) _psa (stage_init_code s))))))
 																(coalesceNil (sq_cache "groups") '()))))
 														/* direct table entry with join condition (like non-agg non-LIMIT path) */
 														(define us_join_lim (map us_outer_parts (lambda (p) (_us_ria (_us_ror p)))))
@@ -3388,14 +3398,15 @@ or generate runtime scan code (build_queryplan).
 					(merge
 						(map (coalesce _cd_user_group '()) finalize_visible_expr)
 						(map _cd_distinct_exprs (lambda (e) (replace_find_column (finalize_visible_expr e)))))
+					nil
 					nil)
 				(make_group_stage
 					(if (nil? _cd_user_group) '(1) (map _cd_user_group (lambda (e) (replace_find_column (finalize_visible_expr e)))))
 					(_cd_replace (finalize_visible_expr _cd_having))
 					(map (coalesce _cd_order '()) (lambda (o) (match o '(col dir) (list (_cd_replace (finalize_visible_expr col)) dir))))
-					_cd_limit _cd_offset nil nil))
+					_cd_limit _cd_offset nil nil nil))
 			/* normal: single group stage */
-			(if (or group having order limit offset) (list (make_group_stage group having order limit offset nil nil)) '()))))
+			(if (or group having order limit offset) (list (make_group_stage group having order limit offset nil nil nil)) '()))))
 	/* Contract boundary: untangle_query returns canonical logical IR.
 	All case-insensitive parser markers are resolved here, before build_queryplan
 	starts creating keytables/prejoins or serializing canonical expression names. */
@@ -3687,6 +3698,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 	(set rest_groups (coalesceNil rest_groups '()))
 	(define stage_group (if stage (stage_group_cols stage) nil))
 	(define stage_having (if stage (stage_having_expr stage) nil))
+	(define stage_group_alias_name (if stage (stage_group_alias stage) nil))
 	(define stage_order (if stage (stage_order_list stage) nil))
 	(define stage_partcols (if stage (coalesceNil (stage_limit_partition_cols stage) 0) 0))
 	(define stage_limit (if stage (stage_limit_val stage) nil))
@@ -4425,6 +4437,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				(define keytable_init (car (cdr kt_result)))
 				(define fk_pk_col (car (cdr (cdr kt_result))))
 				(define is_fk_reuse (not (nil? fk_pk_col)))
+				(define effective_group_alias (coalesce stage_group_alias_name grouptbl))
 
 				/* make_collect: builds collect plan with optional WHERE filter
 				with_filter=true: apply WHERE condition (for DEDUP)
@@ -4489,6 +4502,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							(map (coalesce (stage_order_list s) '()) (lambda (o) (match o '(col dir) (list (_dedup_resolve col) dir))))
 							(stage_limit_val s)
 							(stage_offset_val s)
+							(stage_group_alias s)
 							(stage_partition_aliases s)
 							(stage_init_code s)))
 					)))
@@ -4514,10 +4528,43 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						(define agg_col_name (lambda (ag)
 							(concat (expr_name ag) "|" (expr_name condition) (runtime_cache_suffix_from_exprs (list ag condition)))))
 						(define replace_agg_with_fetch (make_col_replacer grouptbl condition false expr_name tblvar agg_col_name))
+						(define resolved_stage_group_key_names (map resolved_stage_group (lambda (expr)
+							(if is_fk_reuse fk_pk_col (expr_name expr)))))
+						(define replace_stage_group_alias_ref (lambda (expr) (match expr
+							'((symbol get_column) alias_ false col false)
+							(if (and (equal?? alias_ effective_group_alias) (has? resolved_stage_group_key_names col))
+								(list (quote get_column) grouptbl false col false)
+								nil)
+							'((quote get_column) alias_ false col false)
+							(if (and (equal?? alias_ effective_group_alias) (has? resolved_stage_group_key_names col))
+								(list (quote get_column) grouptbl false col false)
+								nil)
+							'((symbol outer) outer_sym)
+							(begin
+								(define parts (split (string outer_sym) "."))
+								(match parts
+									(list alias_ col)
+									(if (and (equal?? alias_ effective_group_alias) (has? resolved_stage_group_key_names col))
+										(list (quote get_column) grouptbl false col false)
+										nil)
+									nil))
+							'((quote outer) outer_sym)
+							(begin
+								(define parts (split (string outer_sym) "."))
+								(match parts
+									(list alias_ col)
+									(if (and (equal?? alias_ effective_group_alias) (has? resolved_stage_group_key_names col))
+										(list (quote get_column) grouptbl false col false)
+										nil)
+									nil))
+							nil)))
 						(define replace_group_key_or_fetch (lambda (expr) (if
-							(reduce resolved_stage_group (lambda (acc group_expr) (or acc (equal? group_expr expr))) false)
-							'('get_column grouptbl false (if is_fk_reuse fk_pk_col (expr_name expr)) false)
-							(replace_agg_with_fetch expr)
+							(not (nil? (replace_stage_group_alias_ref expr)))
+							(replace_stage_group_alias_ref expr)
+							(if
+								(reduce resolved_stage_group (lambda (acc group_expr) (or acc (equal? group_expr expr))) false)
+								'('get_column grouptbl false (if is_fk_reuse fk_pk_col (expr_name expr)) false)
+								(replace_agg_with_fetch expr))
 						)))
 						/* scoped GROUP stages from unnesting must not eagerly rewrite later
 						outer aggregates like COUNT(*) in the SELECT list. Those belong to
@@ -4618,8 +4665,8 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 
 						(define grouped_order (if (nil? stage_order) nil (map stage_order (lambda (o) (match o '(col dir) (list (replace_group_key_or_fetch col) dir))))))
 						(define next_groups (merge
-							(if (coalesce grouped_order stage_limit stage_offset) (list (make_group_stage nil nil grouped_order stage_limit stage_offset nil nil)) '())
-							(if _needs_synthetic_outer_group (list (make_group_stage '(1) nil nil nil nil nil nil)) '())
+							(if (coalesce grouped_order stage_limit stage_offset) (list (make_group_stage nil nil grouped_order stage_limit stage_offset nil nil nil)) '())
+							(if _needs_synthetic_outer_group (list (make_group_stage '(1) nil nil nil nil nil nil nil)) '())
 							rest_groups
 						))
 						/* FK reuse: extract child FK column name */
@@ -5475,7 +5522,26 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				(define grouped_fields (map_assoc raw_fields (lambda (k v)
 					(lower_prejoin_lineage_expr v))))
 				(define grouped_keys (map (coalesce raw_stage_group '()) lower_prejoin_lineage_expr))
-				(define grouped_having (lower_prejoin_lineage_expr raw_stage_having))
+				(define grouped_stage_alias_result (if (nil? grouped_keys)
+					nil
+					(make_keytable_schema schema prejointbl grouped_keys prejoin_alias)))
+				(define grouped_stage_alias (if (nil? grouped_stage_alias_result) nil
+					(car grouped_stage_alias_result)))
+				(define grouped_stage_key_names (if (nil? grouped_stage_alias_result) '()
+					(car (cdr grouped_stage_alias_result))))
+				(define rewrite_group_key_to_group_alias (lambda (expr)
+					(coalesce
+						(reduce (produceN (count grouped_keys)) (lambda (found i)
+							(if (not (nil? found))
+								found
+								(if (equal? expr (nth grouped_keys i))
+									(list (quote get_column) grouped_stage_alias false (nth grouped_stage_key_names i) false)
+									nil)))
+							nil)
+						(match expr
+							(cons sym args) (cons sym (map args rewrite_group_key_to_group_alias))
+							expr))))
+				(define grouped_having (rewrite_group_key_to_group_alias (lower_prejoin_lineage_expr raw_stage_having)))
 				(define grouped_order (if (nil? raw_stage_order) nil
 					(map raw_stage_order (lambda (o) (match o '(col dir)
 						(list (lower_prejoin_lineage_expr col) dir))))))
@@ -5558,9 +5624,10 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				Post-group predicates continue as grouped_plan condition so recursive
 				planning uses a single filter path instead of a nested HAVING special case. */
 				(define grouped_stage (if is_dedup
-					(make_dedup_stage grouped_keys
+					(make_dedup_stage grouped_keys grouped_stage_alias
 						(if (nil? _stage_scope) nil (list prejoin_alias)))
 					(make_group_stage grouped_keys nil grouped_order stage_limit stage_offset
+						grouped_stage_alias
 						(if (nil? _stage_scope) nil (list prejoin_alias))
 						nil)))
 				(define grouped_fields_for_recursive (if is_dedup
@@ -5576,6 +5643,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							(stage_preserve_cache_meta s
 								(make_dedup_stage
 									(map _sg recursive_replace_find_column)
+									(stage_group_alias s)
 									_spa))
 							(if (and (not (nil? _spa)) (or (nil? _sg) (equal? _sg '())))
 								(stage_preserve_cache_meta s
@@ -5585,7 +5653,8 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										(coalesceNil (stage_limit_partition_cols s) 0)
 										(stage_limit_val s)
 										(stage_offset_val s)
-										(stage_init_code s)))
+										(stage_init_code s)
+										(stage_group_alias s)))
 								(stage_preserve_cache_meta s
 									(make_group_stage
 										(map _sg recursive_replace_find_column)
@@ -5593,6 +5662,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
 										(stage_limit_val s)
 										(stage_offset_val s)
+										(stage_group_alias s)
 										_spa
 										(stage_init_code s))))))))
 				(define grouped_all_stages (cons grouped_stage


### PR DESCRIPTION
## What
- add a canonical group_alias to logical group/partition/dedup stages
- rewrite grouped HAVING key references onto that group-domain alias before recursive prejoin planning
- resolve group_alias refs back to the concrete keytable columns during grouped scan planning
- preserve the existing IN/NOT IN count-subselect path by keeping generic post-group conditions on their original lineage

## Why
HAVING EXISTS on grouped keys still relied on a half-special path where base-table aliases leaked into recursive grouped planning. Giving grouped stages an explicit alias makes the grouped domain first-class and fixes the remaining correlated HAVING EXISTS failure without regressing multi-table IN/NOT IN unnesting.

## Verification
- python3 run_sql_tests.py tests/98_in_subselect_multitable.yaml
- python3 run_sql_tests.py tests/106_subselect_in_clauses.yaml
- python3 run_sql_tests.py tests/66_exists_session_var.yaml
- make test
