### PR TITLE
Restore channel-based shard result draining

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -52,7 +52,7 @@ func computeShardIndex(schema []shardDimension, values []scm.Scmer) (result int)
 	return // schema[0] has the higest stride; schema[len(schema)-1] is the least significant bit
 }
 
-func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_old func(*storageShard, bool)) {
+func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
 	callback := callback_old
 	if scm.Trace != nil {
 		// hook on tracing
@@ -63,7 +63,7 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 		}
 	}
 
-	runWorkers := func(shards []*storageShard, onDone func(*storageShard)) {
+	runWorkers := func(shards []*storageShard, onDone func(*storageShard)) <-chan struct{} {
 		workers := runtime.NumCPU()
 		if workers < 1 {
 			workers = 1
@@ -72,7 +72,8 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 			workers = len(shards)
 		}
 
-		jobs := make(chan *storageShard, workers)
+		jobs := make(chan *storageShard, len(shards))
+		doneCh := make(chan struct{})
 		var done sync.WaitGroup
 		done.Add(len(shards))
 		for i := 0; i < workers; i++ {
@@ -92,7 +93,11 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 			jobs <- s
 		}
 		close(jobs)
-		done.Wait()
+		go func() {
+			done.Wait()
+			close(doneCh)
+		}()
+		return doneCh
 	}
 
 	// Hold shardModeMu.RLock while reading ShardMode and capturing shard list.
@@ -115,7 +120,7 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 		t.shardModeMu.RUnlock()
 
 		if len(relevant) == 0 {
-			return
+			return nil
 		}
 		if len(relevant) == 1 {
 			s := relevant[0]
@@ -123,25 +128,25 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 			callback(s, true)
 			release()
 			s.activeScanners.Add(-1)
-			return
+			return nil
 		}
-		runWorkers(relevant, func(s *storageShard) {
+		return runWorkers(relevant, func(s *storageShard) {
 			s.activeScanners.Add(-1)
 		})
 	} else {
 		t.shardModeMu.RUnlock()
 		relevant := collectRelevantShards(t.PDimensions, boundaries, t.PShards)
 		if len(relevant) == 0 {
-			return
+			return nil
 		}
 		if len(relevant) == 1 {
 			s := relevant[0]
 			release := s.GetRead()
 			callback(s, true)
 			release()
-			return
+			return nil
 		}
-		runWorkers(relevant, nil)
+		return runWorkers(relevant, nil)
 	}
 }
 

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -17,7 +17,6 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
-import "sync"
 import "time"
 import "runtime/debug"
 import "github.com/launix-de/memcp/scm"
@@ -127,37 +126,36 @@ func (t *table) scanWithBatch(conditionCols []string, condition scm.Scmer, callb
 	execStart := time.Now()
 	var outCount int64
 	var inputCount int64
-	results := make([]scanResult, 0, 8)
-	var resultsMu sync.Mutex
-	t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
+	values := make(chan scanResult, 4)
+	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
 		// Kill check at shard-scheduling point: ss is a closure variable, no GLS lookup needed.
 		// This keeps the worker pool draining quickly on tables with many shards.
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}
-		msg := scanResult{}
 		defer func() {
 			if r := recover(); r != nil {
-				msg = scanResult{err: scanError{r, string(debug.Stack())}}
+				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
-			if solo {
-				results = append(results, msg)
-				return
-			}
-			resultsMu.Lock()
-			results = append(results, msg)
-			resultsMu.Unlock()
 		}()
 		res, cnt := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata)
-		msg = scanResult{res: res, outCount: cnt, inputCount: int64(s.Count())}
+		values <- scanResult{res: res, outCount: cnt, inputCount: int64(s.Count())}
 	})
+	if done == nil {
+		close(values)
+	} else {
+		go func() {
+			<-done
+			close(values)
+		}()
+	}
 
 	akkumulator := neutral
 	hadValue := false
 	var scanErr scanError
 	if !aggregate2.IsNil() {
 		fn := scm.OptimizeProcToSerialFunction(aggregate2)
-		for _, msg := range results {
+		for msg := range values {
 			if msg.err.r != nil {
 				if scanErr.r == nil {
 					scanErr = msg.err
@@ -180,7 +178,7 @@ func (t *table) scanWithBatch(conditionCols []string, condition scm.Scmer, callb
 		}
 	} else if !aggregate.IsNil() {
 		fn := scm.OptimizeProcToSerialFunction(aggregate)
-		for _, msg := range results {
+		for msg := range values {
 			if msg.err.r != nil {
 				if scanErr.r == nil {
 					scanErr = msg.err
@@ -202,7 +200,7 @@ func (t *table) scanWithBatch(conditionCols []string, condition scm.Scmer, callb
 			akkumulator = fn(akkumulator, scm.Apply(callback, nullRow...)) // outer join: push one NULL row
 		}
 	} else {
-		for _, msg := range results {
+		for msg := range values {
 			if msg.err.r != nil {
 				if scanErr.r == nil {
 					scanErr = msg.err

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -21,7 +21,6 @@ import "sort"
 import "github.com/carli2/hybridsort"
 import "time"
 import "strings"
-import "sync"
 import "runtime/debug"
 import "container/heap"
 import "github.com/launix-de/memcp/scm"
@@ -400,33 +399,32 @@ func (t *table) scan_order(conditionCols []string, condition scm.Scmer, sortcols
 	// Measure execution time of the ordered scan
 	execStart := time.Now()
 	var q globalqueue
-	results := make([]scanOrderResult, 0, 8)
-	var resultsMu sync.Mutex
+	q_ := make(chan scanOrderResult, 1)
 	var inputCount int64
-	t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
+	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
 		// Kill check at shard-scheduling point using closure-captured ss (no GLS lookup).
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}
-		msg := scanOrderResult{}
 		defer func() {
 			if r := recover(); r != nil {
-				msg = scanOrderResult{err: scanError{r, string(debug.Stack())}}
+				q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 			}
-			if solo {
-				results = append(results, msg)
-				return
-			}
-			resultsMu.Lock()
-			results = append(results, msg)
-			resultsMu.Unlock()
 		}()
 		res := s.scan_order(boundaries, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, total_limit, callbackCols)
-		msg = scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
+		q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
 	})
+	if done == nil {
+		close(q_)
+	} else {
+		go func() {
+			<-done
+			close(q_)
+		}()
+	}
 
 	var scanErr scanError
-	for _, msg := range results {
+	for msg := range q_ {
 		if msg.err.r != nil {
 			if scanErr.r == nil {
 				scanErr = msg.err

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -57,10 +57,13 @@ func TestIterateShardsParallelMarksFreeSingleShardSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
+	done := tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
 		calls++
 		sawSolo = solo
 	})
+	if done != nil {
+		t.Fatal("iterateShardsParallel free single shard unexpectedly returned async done channel")
+	}
 
 	if calls != 1 {
 		t.Fatalf("iterateShardsParallel free single shard calls = %d, want 1", calls)
@@ -82,7 +85,7 @@ func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	tbl.iterateShardsParallel([]columnboundaries{{
+	done := tbl.iterateShardsParallel([]columnboundaries{{
 		col:            "id",
 		matcher:        EqualMatcher,
 		lower:          scm.NewInt(15),
@@ -93,6 +96,9 @@ func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 		calls++
 		sawSolo = solo
 	})
+	if done != nil {
+		t.Fatal("iterateShardsParallel partition single shard unexpectedly returned async done channel")
+	}
 
 	if calls != 1 {
 		t.Fatalf("iterateShardsParallel partition single shard calls = %d, want 1", calls)
@@ -114,10 +120,14 @@ func TestIterateShardsParallelMarksPartitionMultiShardNonSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
+	done := tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
 		calls++
 		sawSolo = sawSolo || solo
 	})
+	if done == nil {
+		t.Fatal("iterateShardsParallel partition multi shard did not return async done channel")
+	}
+	<-done
 
 	if calls != 2 {
 		t.Fatalf("iterateShardsParallel partition multi shard calls = %d, want 2", calls)

--- a/tests/92_unique_main_delta.yaml
+++ b/tests/92_unique_main_delta.yaml
@@ -8,6 +8,7 @@
 metadata:
   version: "1.0"
   description: "Unique constraint: main vs delta storage corner cases"
+  isolated: true
 
 test_cases:
   # ==============================================================


### PR DESCRIPTION
## Summary
- restore the channel-based shard result drain path for scan and scan_order while keeping the single-shard synchronous fast path
- keep iterateShardsParallel worker fanout bounded by min(relevant shards, NumCPU) and return an async done channel only for real multi-shard execution
- mark the flaky shared-run unique-constraint suite isolated so pre-commit stays deterministic

## Testing
- go test ./storage -run 'TestIterateShardsParallel|TestScanErrorIncludesStack|Test(ManualRepartitionForwardsConcurrentInserts|ShardRebuildForwardsConcurrentInsertsViaNext)' -count=1
- python3 run_sql_tests.py tests/54_transactions.yaml tests/55_scan_shard_coverage.yaml tests/56_multishard.yaml tests/71_repartition_concurrent.yaml tests/84_incremental_invalidation.yaml tests/85_suffix_recompute.yaml --jobs 4
- make test
