### PR TITLE
Normalize stage post-group conditions

### DIFF
--- a/git-pre-commit
+++ b/git-pre-commit
@@ -1,5 +1,20 @@
 #!/bin/bash
 #
+# Copyright (C) 2023-2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # MemCP Pre-commit Hook
 # Runs SQL tests before allowing commits using a single MemCP instance
 #
@@ -71,9 +86,14 @@ echo ""
 
 test_port=4480
 memcp_test_datadir="/tmp/memcp-pre-commit-tests"
-rm -rf "$memcp_test_datadir" || true
 export MEMCP_TEST_DATADIR="$memcp_test_datadir"
 tmpdir=""
+supervisor_pid=""
+
+new_datadir() {
+  local suffix="${1:-shared}"
+  echo "/tmp/memcp-pre-commit-tests-${suffix}"
+}
 
 run_memcp_forever() {
   trap 'kill $memcp_pid 2>/dev/null; exit 0' TERM INT
@@ -93,6 +113,31 @@ run_memcp_forever() {
   done
 }
 
+start_supervisor() {
+  memcp_test_datadir="$1"
+  export MEMCP_TEST_DATADIR="$memcp_test_datadir"
+  rm -rf "$memcp_test_datadir" || true
+  echo -n > /tmp/memcp-test.log
+  run_memcp_forever &
+  supervisor_pid=$!
+
+  echo "⏳ Waiting for MemCP to be ready..."
+  if wait_for_sql_ready 60 1; then
+    echo "✅ MemCP is ready!"
+    return 0
+  fi
+  echo "❌ MemCP did not become SQL-ready"
+  return 1
+}
+
+stop_supervisor() {
+  if [ -n "${supervisor_pid:-}" ]; then
+    kill "$supervisor_pid" 2>/dev/null || true
+    supervisor_pid=""
+  fi
+  pkill -f "memcp.*--api-port=$test_port" 2>/dev/null || true
+}
+
 wait_for_sql_ready() {
   local retries="${1:-60}"
   local delay="${2:-1}"
@@ -109,15 +154,7 @@ wait_for_sql_ready() {
   return 1
 }
 
-echo -n > /tmp/memcp-test.log
-run_memcp_forever &
-supervisor_pid=$!
-
-echo "⏳ Waiting for MemCP to be ready..."
-if wait_for_sql_ready 60 1; then
-  echo "✅ MemCP is ready!"
-else
-  echo "❌ MemCP did not become SQL-ready"
+if ! start_supervisor "$(new_datadir shared)"; then
   exit 1
 fi
 
@@ -132,12 +169,12 @@ cleanup() {
   for pid in $(jobs -p 2>/dev/null); do
     kill "$pid" 2>/dev/null || true
   done
-  kill $supervisor_pid 2>/dev/null || true
-  pkill -f "memcp.*--api-port=$test_port" 2>/dev/null || true
+  stop_supervisor
   if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then
     rm -rf "$tmpdir" 2>/dev/null || true
   fi
   rm -rf "$memcp_test_datadir" 2>/dev/null || true
+  rm -rf /tmp/memcp-pre-commit-tests-* 2>/dev/null || true
   echo "✅ MemCP stopped"
 }
 trap cleanup EXIT
@@ -153,8 +190,30 @@ failed_files=""
 
 parallel_tests=()
 sequential_tests=()
+suite_mode() {
+  python3 - "$1" <<'PY'
+import sys, yaml
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    spec = yaml.safe_load(f) or {}
+metadata = spec.get("metadata", {}) if isinstance(spec, dict) else {}
+if metadata.get("isolated"):
+    print("isolated")
+    raise SystemExit(0)
+for test_case in spec.get("test_cases", []) if isinstance(spec, dict) else []:
+    if not isinstance(test_case, dict):
+        continue
+    if test_case.get("action") == "restart":
+        print("isolated")
+        raise SystemExit(0)
+    sql = test_case.get("sql")
+    if isinstance(sql, str) and sql.strip().upper() == "SHUTDOWN":
+        print("isolated")
+        raise SystemExit(0)
+print("shared")
+PY
+}
 for tf in "${test_files_arr[@]}"; do
-  if grep -Eqi "^[[:space:]]*isolated:[[:space:]]*true([[:space:]]|$)" "$tf"; then
+  if [ "$(suite_mode "$tf")" = "isolated" ]; then
     sequential_tests+=("$tf")
   else
     parallel_tests+=("$tf")
@@ -174,16 +233,21 @@ run_one() {
   local tf="$1"
   local out="$2"
   local statusf="$3"
-  if ! wait_for_sql_ready 60 1; then
-    echo "FAIL" > "$statusf"
-    {
-      flock -x 9
-      echo "❌ $tf: MemCP did not become SQL-ready before running this suite"
-      echo ""
-    } 9>>"$lockfile"
-    return
+  local mode="${4:-shared}"
+  if [ "$mode" = "isolated" ]; then
+    python3 -u run_sql_tests.py "$tf" > "$out" 2>&1
+  else
+    if ! wait_for_sql_ready 60 1; then
+      echo "FAIL" > "$statusf"
+      {
+        flock -x 9
+        echo "❌ $tf: MemCP did not become SQL-ready before running this suite"
+        echo ""
+      } 9>>"$lockfile"
+      return
+    fi
+    python3 -u run_sql_tests.py "$tf" $test_port --connect-only > "$out" 2>&1
   fi
-  python3 -u run_sql_tests.py "$tf" $test_port --connect-only > "$out" 2>&1
   rc=$?
   if [ $rc -eq 0 ]; then
     echo OK > "$statusf"
@@ -216,11 +280,15 @@ active_pids=()
 for tf in "${sequential_tests[@]}"; do
   out="$tmpdir/$(basename "$tf").out"
   statusf="$tmpdir/$(basename "$tf").status"
-  run_one "$tf" "$out" "$statusf"
+  stop_supervisor
+  run_one "$tf" "$out" "$statusf" isolated
+  if ! start_supervisor "$(new_datadir shared)"; then
+    echo "FAIL" > "$statusf"
+    break
+  fi
 done
 
-kill $supervisor_pid 2>/dev/null || true
-pkill -f "memcp.*--api-port=$test_port" 2>/dev/null || true
+stop_supervisor
 
 for tf in "${test_files_arr[@]}"; do
   statusf="$tmpdir/$(basename "$tf").status"

--- a/git-pre-commit
+++ b/git-pre-commit
@@ -235,21 +235,16 @@ run_one() {
   local tf="$1"
   local out="$2"
   local statusf="$3"
-  local mode="${4:-shared}"
-  if [ "$mode" = "isolated" ]; then
-    python3 -u run_sql_tests.py "$tf" > "$out" 2>&1
-  else
-    if ! wait_for_sql_ready 60 1; then
-      echo "FAIL" > "$statusf"
-      {
-        flock -x 9
-        echo "❌ $tf: MemCP did not become SQL-ready before running this suite"
-        echo ""
-      } 9>>"$lockfile"
-      return
-    fi
-    python3 -u run_sql_tests.py "$tf" $test_port --connect-only > "$out" 2>&1
+  if ! wait_for_sql_ready 60 1; then
+    echo "FAIL" > "$statusf"
+    {
+      flock -x 9
+      echo "❌ $tf: MemCP did not become SQL-ready before running this suite"
+      echo ""
+    } 9>>"$lockfile"
+    return
   fi
+  python3 -u run_sql_tests.py "$tf" $test_port --connect-only > "$out" 2>&1
   rc=$?
   if [ $rc -eq 0 ]; then
     echo OK > "$statusf"
@@ -282,12 +277,7 @@ active_pids=()
 for tf in "${sequential_tests[@]}"; do
   out="$tmpdir/$(basename "$tf").out"
   statusf="$tmpdir/$(basename "$tf").status"
-  stop_supervisor
-  run_one "$tf" "$out" "$statusf" isolated
-  if ! start_supervisor; then
-    echo "FAIL" > "$statusf"
-    break
-  fi
+  run_one "$tf" "$out" "$statusf"
 done
 
 stop_supervisor

--- a/git-pre-commit
+++ b/git-pre-commit
@@ -85,15 +85,16 @@ printf '%s\n' "${test_files_arr[@]}"
 echo ""
 
 test_port=4480
-memcp_test_datadir="/tmp/memcp-pre-commit-tests"
-export MEMCP_TEST_DATADIR="$memcp_test_datadir"
 tmpdir=""
 supervisor_pid=""
 
-new_datadir() {
-  local suffix="${1:-shared}"
-  echo "/tmp/memcp-pre-commit-tests-${suffix}"
-}
+# Runner contract:
+# - All suites use the repository-local ./data directory.
+# - ./data must never be deleted by this hook.
+# - "isolated" means serialized execution on the same shared database, not
+#   storage isolation.
+# - restart/SHUTDOWN suites may temporarily stop the shared supervisor, but
+#   they must come back on the same ./data afterwards.
 
 run_memcp_forever() {
   trap 'kill $memcp_pid 2>/dev/null; exit 0' TERM INT
@@ -102,7 +103,7 @@ run_memcp_forever() {
     pkill -f "memcp.*--api-port=$test_port" || true
     sleep 1
     memcp_log="${MEMCP_LOG:-/tmp/memcp-test.log}"
-    ./memcp --no-repl -data "$memcp_test_datadir" --api-port=$test_port --mysql-port=$((test_port + 1000)) --disable-mysql lib/main.scm >> "$memcp_log" 2>&1 &
+    ./memcp --no-repl -data ./data --api-port=$test_port --mysql-port=$((test_port + 1000)) --disable-mysql lib/main.scm >> "$memcp_log" 2>&1 &
     memcp_pid=$!
     wait $memcp_pid
     rc=$?
@@ -114,9 +115,6 @@ run_memcp_forever() {
 }
 
 start_supervisor() {
-  memcp_test_datadir="$1"
-  export MEMCP_TEST_DATADIR="$memcp_test_datadir"
-  rm -rf "$memcp_test_datadir" || true
   echo -n > /tmp/memcp-test.log
   run_memcp_forever &
   supervisor_pid=$!
@@ -154,7 +152,7 @@ wait_for_sql_ready() {
   return 1
 }
 
-if ! start_supervisor "$(new_datadir shared)"; then
+if ! start_supervisor; then
   exit 1
 fi
 
@@ -173,8 +171,6 @@ cleanup() {
   if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then
     rm -rf "$tmpdir" 2>/dev/null || true
   fi
-  rm -rf "$memcp_test_datadir" 2>/dev/null || true
-  rm -rf /tmp/memcp-pre-commit-tests-* 2>/dev/null || true
   echo "✅ MemCP stopped"
 }
 trap cleanup EXIT
@@ -212,6 +208,12 @@ for test_case in spec.get("test_cases", []) if isinstance(spec, dict) else []:
 print("shared")
 PY
 }
+
+# Scheduling contract:
+# - shared suites may run in parallel against the long-lived shared MemCP
+#   process
+# - isolated suites must run one after another, but still on the same ./data
+#   database state
 for tf in "${test_files_arr[@]}"; do
   if [ "$(suite_mode "$tf")" = "isolated" ]; then
     sequential_tests+=("$tf")
@@ -282,7 +284,7 @@ for tf in "${sequential_tests[@]}"; do
   statusf="$tmpdir/$(basename "$tf").status"
   stop_supervisor
   run_one "$tf" "$out" "$statusf" isolated
-  if ! start_supervisor "$(new_datadir shared)"; then
+  if ! start_supervisor; then
     echo "FAIL" > "$statusf"
     break
   fi

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -318,7 +318,7 @@ they must not guess/fix alias or column casing anymore. */
 ))
 /* Naming contract:
 - canonicalize_expr rewrites planner-local aliases into the stable canonical
-  source namespace, but only for already-canonical logical expressions
+source namespace, but only for already-canonical logical expressions
 - serialize_canonical_expr turns that canonical logical IR into a stable key
 Callers that need the canonical expression for more than one downstream use must
 keep it in a local define instead of rebuilding it from scratch. */
@@ -991,7 +991,7 @@ search order for unqualified refs (main tables before helper/unnested aliases). 
 - all alias/column lookups flow through these helpers
 - callers choose whether they want the first visible match or require uniqueness
 - the resolver itself is the only place that may interpret alias variants or
-  schema-driven column casing inside queryplan.scm */
+schema-driven column casing inside queryplan.scm */
 (define schema_alias_matches (lambda (query_alias schema_alias ti)
 	((if ti equal?? equal?) query_alias schema_alias)
 ))
@@ -1122,7 +1122,7 @@ get_column markers and may no longer run schema-based repair heuristics. */
 (define finalize_logical_stage_scoped (lambda (stage local_schemas visible_schemas rewrite_expr enforce_contract) (begin
 	(define fin (lambda (expr) (finalize_logical_expr_scoped expr local_schemas visible_schemas rewrite_expr enforce_contract)))
 	(define sg (coalesceNil (stage_group_cols stage) '()))
-	(define sh (stage_having_expr stage))
+	(define sh (stage_post_group_condition_expr stage))
 	(define so (coalesceNil (stage_order_list stage) '()))
 	(define sl (stage_limit_val stage))
 	(define soff (stage_offset_val stage))
@@ -1203,6 +1203,12 @@ All stages have init: nil = no init code, or code to run before the scan. */
 		_ nil
 	) acc)
 ) nil)))
+/* Transitional alias: the stage `having` slot carries the stage-local
+post-group condition until the stage IR is flattened further. Planner code
+should reason about this as post-group filtering on the stage's group domain,
+not as a separate SQL-level HAVING special case. */
+(define stage_post_group_condition_expr (lambda (stage)
+	(stage_having_expr stage)))
 (define stage_order_list (lambda (stage) (reduce stage (lambda (acc item)
 	(if (nil? acc) (match item
 		(cons (quote order) rest) (if (nil? rest) '() (car rest))
@@ -2019,7 +2025,7 @@ or generate runtime scan code (build_queryplan).
 						(define has_stage2 (and (not (nil? groups2)) (not (equal? groups2 '()))))
 						(define stage2 (if has_stage2 (car groups2) nil))
 						(define stage2_group (if stage2 (coalesceNil (stage_group_cols stage2) '()) '()))
-						(define stage2_having (if stage2 (stage_having_expr stage2) nil))
+						(define stage2_post_group_condition (if stage2 (stage_post_group_condition_expr stage2) nil))
 						(define contains_noncolumn_outer_ref (lambda (expr) (match expr
 							'((quote outer) outer_sym) (equal? 1 (count (split (string outer_sym) ".")))
 							'((symbol outer) outer_sym) (equal? 1 (count (split (string outer_sym) ".")))
@@ -2045,7 +2051,7 @@ or generate runtime scan code (build_queryplan).
 							(not (nil? _agg_args))
 							(equal? (count _agg_args) 3)
 							(not raw_contains_skip_level_nested_outer_ref)
-							(nil? stage2_having)
+							(nil? stage2_post_group_condition)
 							(or (nil? stage2_group) (equal? stage2_group '()) (equal? stage2_group '(1)))
 							(not (nil? tables2))
 							(not (equal? tables2 '()))
@@ -2057,7 +2063,7 @@ or generate runtime scan code (build_queryplan).
 							(not (contains_inner_select_marker condition2))
 							(not (contains_inner_select_marker value_expr))
 							(not has_noncolumn_outer_ref)
-							(nil? stage2_having)
+							(nil? stage2_post_group_condition)
 							(or (nil? stage2_group) (equal? stage2_group '()) (equal? stage2_group '(1)))
 							(and (list? tables2) (equal? (count tables2) 1))
 						))
@@ -2329,7 +2335,7 @@ or generate runtime scan code (build_queryplan).
 										(begin
 											(define g (stage_group_cols stage))
 											(or (and (not (nil? g)) (not (equal? g '())) (not (equal? g '(1))))
-												(not (nil? (stage_having_expr stage))))))) false)
+												(not (nil? (stage_post_group_condition_expr stage))))))) false)
 									false))
 								/* check for LIMIT/ORDER/OFFSET stages — deferred until 1-row constraint handling */
 								(define us_has_limit (if us_has_stages
@@ -2442,7 +2448,7 @@ or generate runtime scan code (build_queryplan).
 													(_us_prefix_ria (_us_ror us_inner_cond_raw))))
 												/* domain columns + original GROUP BY → scoped GROUP stage */
 												(define us_orig_group (if us_has_stages (coalesceNil (stage_group_cols (car _us_own_stages)) '()) '()))
-												(define us_orig_having (if us_has_stages (stage_having_expr (car _us_own_stages)) nil))
+												(define us_orig_having (if us_has_stages (stage_post_group_condition_expr (car _us_own_stages)) nil))
 												(define _us_dom_group_cols (map us_domain_cols (lambda (dc) (_us_prefix_ria (nth dc 0)))))
 												(define us_new_group (merge _us_dom_group_cols
 													(if (or (equal? us_orig_group '()) (equal? us_orig_group '(1)))
@@ -2468,7 +2474,7 @@ or generate runtime scan code (build_queryplan).
 												/* propagate inner scoped stages with prefix */
 												(define _us_prefixed_inner_stages (map _us_inner_stages (lambda (s) (begin
 													(define _psg (map (coalesceNil (stage_group_cols s) '()) _us_prefix_ria))
-													(define _psh (if (nil? (stage_having_expr s)) nil (_us_prefix_ria (stage_having_expr s))))
+													(define _psh (if (nil? (stage_post_group_condition_expr s)) nil (_us_prefix_ria (stage_post_group_condition_expr s))))
 													(define _pso (map (coalesceNil (stage_order_list s) '()) (lambda (o) (match o '(c d) (list (_us_prefix_ria c) d) o))))
 													(define _psa (map (coalesceNil (stage_partition_aliases s) '()) (lambda (a) (coalesceNil (_us_lookup a) a))))
 													(stage_preserve_cache_meta s
@@ -2593,7 +2599,7 @@ or generate runtime scan code (build_queryplan).
 															(sq_cache "groups" (merge
 																(map _us_inner_stages (lambda (s) (begin
 																	(define _psg (map (coalesceNil (stage_group_cols s) '()) _us_ria))
-																	(define _psh (if (nil? (stage_having_expr s)) nil (_us_ria (stage_having_expr s))))
+																	(define _psh (if (nil? (stage_post_group_condition_expr s)) nil (_us_ria (stage_post_group_condition_expr s))))
 																	(define _pso (map (coalesceNil (stage_order_list s) '()) (lambda (o) (match o '(c d) (list (_us_ria c) d) o))))
 																	(define _psa (map (coalesceNil (stage_partition_aliases s) '()) (lambda (a) (coalesceNil (_us_lookup a) a))))
 																	(stage_preserve_cache_meta s
@@ -3078,7 +3084,7 @@ or generate runtime scan code (build_queryplan).
 									(define g (stage_group_cols stage))
 									(and (not (nil? g)) (not (equal? g '())))
 								)
-								(not (nil? (stage_having_expr stage)))
+								(not (nil? (stage_post_group_condition_expr stage)))
 								(not (nil? (stage_limit_val stage)))
 								(not (nil? (stage_offset_val stage)))
 							)
@@ -3253,7 +3259,7 @@ or generate runtime scan code (build_queryplan).
 				resolved))
 		(cons sym args) /* function call */ (cons sym (map args replace_find_column))
 		expr
-)))
+	)))
 
 	/* pass full schema chain (current + ancestors) so nested subselects can resolve grandparent refs */
 	(define _ris_schemas (merge schemas outer_schemas_chain))
@@ -3426,7 +3432,7 @@ or generate runtime scan code (build_queryplan).
 		(merge (map _canon_groups (lambda (stage)
 			(merge_unique
 				(merge (map (coalesceNil (stage_group_cols stage) '()) extract_tblvars))
-				(extract_tblvars (coalesceNil (stage_having_expr stage) true))
+				(extract_tblvars (coalesceNil (stage_post_group_condition_expr stage) true))
 				(merge (map (coalesceNil (stage_order_list stage) '()) (lambda (o) (match o '(col dir) (extract_tblvars col) (extract_tblvars o)))))
 				(coalesceNil (stage_partition_aliases stage) '())))))))
 	/* prune unused LEFT JOINs and unreferenced .(1) DUAL tables.
@@ -3672,7 +3678,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 	(define require_canonical_stage (lambda (stage) (begin
 		(map (coalesceNil (stage_group_cols stage) '()) (lambda (expr)
 			(require_canonical_logical_expr "build_queryplan stage group" expr)))
-		(require_canonical_logical_expr "build_queryplan stage having" (coalesceNil (stage_having_expr stage) true))
+		(require_canonical_logical_expr "build_queryplan stage post-group condition" (coalesceNil (stage_post_group_condition_expr stage) true))
 		(map (coalesceNil (stage_order_list stage) '()) (lambda (o) (match o '(expr dir)
 			(require_canonical_logical_expr "build_queryplan stage order" expr)
 			true)))
@@ -3697,7 +3703,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 	(define rest_groups (if groups_present (cdr groups) nil))
 	(set rest_groups (coalesceNil rest_groups '()))
 	(define stage_group (if stage (stage_group_cols stage) nil))
-	(define stage_having (if stage (stage_having_expr stage) nil))
+	(define stage_post_group_condition (if stage (stage_post_group_condition_expr stage) nil))
 	(define stage_group_alias_name (if stage (stage_group_alias stage) nil))
 	(define stage_order (if stage (stage_order_list stage) nil))
 	(define stage_partcols (if stage (coalesceNil (stage_limit_partition_cols stage) 0) 0))
@@ -3811,11 +3817,11 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 		next stage's logical keys/fields and explode into nested "(get_column ...)"
 		temp names. */
 		(define raw_stage_group stage_group)
-		(define raw_stage_having stage_having)
+		(define raw_stage_post_group_condition stage_post_group_condition)
 		(define raw_stage_order stage_order)
 		(define raw_fields fields)
 		(set stage_group (map stage_group replace_find_column))
-		(set stage_having (replace_find_column stage_having))
+		(set stage_post_group_condition (replace_find_column stage_post_group_condition))
 		(set stage_order (map stage_order (lambda (o) (match o '(col dir) (list (replace_find_column col) dir)))))
 		(define is_dedup (stage_is_dedup stage))
 		(define _scoped_stage (not (nil? (stage_partition_aliases stage))))
@@ -3839,7 +3845,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 			(not _has_existing_later_group_stage)
 			(or
 				(reduce_assoc fields (lambda (acc _k expr) (or acc (_needs_outer_group_expr expr))) false)
-				(_needs_outer_group_expr (coalesce stage_having true))
+				(_needs_outer_group_expr (coalesce stage_post_group_condition true))
 				(reduce (coalesce stage_order '()) (lambda (acc o)
 					(or acc (match o '(col _dir) (_needs_outer_group_expr col) false))) false))))
 		(define _has_later_group_stage (or _has_existing_later_group_stage _needs_synthetic_outer_group))
@@ -3865,7 +3871,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 		(define ags_raw (if is_dedup '() (extract_assoc fields (lambda (key expr) (extract_stage_field_aggregates expr false)))))
 		(define ags (if is_dedup '() (merge_unique ags_raw))) /* aggregates in fields */
 		(define ags (if is_dedup ags (merge_unique ags (merge_unique (map (coalesce stage_order '()) (lambda (x) (match x '(col dir) (extract_aggregates col)))))))) /* aggregates in order */
-		(define ags (if is_dedup ags (merge_unique ags (extract_aggregates (coalesce stage_having true))))) /* aggregates in having */
+		(define ags (if is_dedup ags (merge_unique ags (extract_aggregates (coalesce stage_post_group_condition true))))) /* aggregates in stage-local post-group condition */
 		(define ags (if is_dedup ags (merge_unique ags (extract_aggregates (coalesce condition true))))) /* aggregates in condition (from Neumann EXISTS/IN rewrite) */
 
 		/* TODO: replace (get_column nil ti col ci) in group, having and order with (coalesce (fields col) '('get_column nil false col false)) */
@@ -3910,7 +3916,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 			(or
 				(reduce stage_group (lambda (acc expr) (or acc (_resolved_expr_refs_grp_ps_table expr))) false)
 				(reduce ags (lambda (acc ag) (or acc (_resolved_expr_refs_grp_ps_table ag))) false)
-				(_resolved_expr_refs_grp_ps_table (coalesce stage_having true))
+				(_resolved_expr_refs_grp_ps_table (coalesce stage_post_group_condition true))
 				(reduce (coalesce stage_order '()) (lambda (acc o) (or acc (match o '(col _dir) (_resolved_expr_refs_grp_ps_table col) false))) false))))
 		(define _grp_tables (if _must_prejoin_outer_group_tables
 			(merge _grp_tables_raw _grp_ps_tables_raw)
@@ -4498,7 +4504,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					(define transformed_rest_groups (map rest_groups (lambda (s)
 						(stage_preserve_cache_meta s (make_group_stage
 							(map (stage_group_cols s) _dedup_resolve)
-							(_dedup_resolve (stage_having_expr s))
+							(_dedup_resolve (stage_post_group_condition_expr s))
 							(map (coalesce (stage_order_list s) '()) (lambda (o) (match o '(col dir) (list (_dedup_resolve col) dir))))
 							(stage_limit_val s)
 							(stage_offset_val s)
@@ -4678,13 +4684,13 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						if the deferred post-group condition contains aggregate terms. Only the
 						COUNT>0 empty-group filter itself stays restricted to true global groups. */
 						(define _marker_in_fields (reduce_assoc fields (lambda (acc _k v) (or acc (_has_agg_expr v))) false))
-						(define _marker_in_having (if (nil? stage_having) false (_has_agg_expr stage_having)))
+						(define _marker_in_post_group_condition (if (nil? stage_post_group_condition) false (_has_agg_expr stage_post_group_condition)))
 						(define _marker_in_order (reduce (coalesce stage_order '()) (lambda (acc o) (or acc (match o '(col _dir) (_has_agg_expr col) false))) false))
 						(define needs_count (or
 							(not (equal? resolved_stage_group '(1)))
 							(not (equal? _cond_agg_parts '()))
 							_marker_in_fields
-							_marker_in_having
+							_marker_in_post_group_condition
 							_marker_in_order))
 						/* SQL GROUP BY semantics: unscoped non-global groups only exist for row
 						keys that survive the pre-group row domain. Keep the logical aggregate
@@ -4700,7 +4706,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 								(not (equal? resolved_stage_group '(1)))
 								(and
 									(not _marker_in_fields)
-									(not _marker_in_having)
+									(not _marker_in_post_group_condition)
 									(not _marker_in_order)))))
 						(define ags (if needs_count (merge_unique ags (list count_ag)) ags))
 						(define count_col_name (if needs_count (agg_col_name count_ag) nil))
@@ -4740,15 +4746,14 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							(cons sym args) (cons sym (map args rewrite_group_outer_refs))
 							expr)))
 						/* AND count>0 into HAVING so empty/non-matching groups are excluded */
-						(define effective_having_raw (if (and needs_count filter_empty_groups)
+						(define current_stage_post_group_condition_raw (if (and needs_count filter_empty_groups)
 							(begin
 								(define count_check '('> '('get_column grouptbl false count_col_name false) 0))
-								(define replaced_having (replace_group_key_or_fetch stage_having))
-								(if (or (nil? replaced_having) (equal? replaced_having true))
-									count_check
-									(list 'and replaced_having count_check)))
-							(replace_group_key_or_fetch stage_having)))
-						(define effective_having (rewrite_group_outer_refs effective_having_raw))
+								(combine_and_terms (list
+									(replace_group_key_or_fetch stage_post_group_condition)
+									count_check)))
+							(replace_group_key_or_fetch stage_post_group_condition)))
+						(define current_stage_post_group_condition (rewrite_group_outer_refs current_stage_post_group_condition_raw))
 
 						/* Phase 2: replace aggregates in the separated agg-condition parts,
 						then combine everything: HAVING + replaced agg-parts + ps-table conditions */
@@ -4757,7 +4762,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						The keytable LEFT JOIN must only use correlations against group/domain
 						keys, otherwise unrelated outer filters get attached to the wrong side. */
 						(define _gp_parts (filter (merge (map (merge
-							(if (or (nil? effective_having) (equal? effective_having true)) '() (list effective_having))
+							(flatten_and_terms current_stage_post_group_condition)
 							_replaced_agg_parts
 							(if (equal? _grp_ps_condition true) '() (list (replace_group_key_or_fetch _grp_ps_condition))))
 							_flatten_gp_part))
@@ -5239,7 +5244,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				(define all_referenced_columns (merge
 					(merge (map stage_group extract_all_get_columns))
 					(merge (extract_assoc resolved_fields (lambda (k v) (extract_all_get_columns v))))
-					(if (nil? stage_having) '() (extract_all_get_columns stage_having))
+					(if (nil? stage_post_group_condition) '() (extract_all_get_columns stage_post_group_condition))
 					(merge (map (coalesce stage_order '()) (lambda (o) (match o '(col dir) (extract_all_get_columns col)))))
 					(extract_all_get_columns (coalesceNil raw_condition true))
 					(extract_all_get_columns (coalesceNil raw_post_group_condition true))
@@ -5287,10 +5292,10 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				(define prejoin_col_names prejoin_column_names)
 				(define prejoin_schema_def (map prejoin_columns (lambda (mc)
 					(list "Field" (car mc) "Type" "any" "Expr" (cadr mc)))))
-					(define prejoin_condition_name (serialize_canonical_expr
-						(canonicalize_expr
-							(normalize_canonical_aliases (canonicalize_prejoin_source_expr raw_condition))
-							prejoin_alias_map)))
+				(define prejoin_condition_name (serialize_canonical_expr
+					(canonicalize_expr
+						(normalize_canonical_aliases (canonicalize_prejoin_source_expr raw_condition))
+						prejoin_alias_map)))
 				(define prejointbl (concat ".prejoin:"
 					(map prejoin_source_tables (lambda (t) (match t '(_ tschema ttbl _ _) (concat tschema "." ttbl)))
 					) ":" prejoin_col_names "|" prejoin_condition_name))
@@ -5343,10 +5348,10 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				(define prejoin_variant_names (lambda (expr)
 					(reduce (map (prejoin_variant_exprs expr) (lambda (variant_expr)
 						(sanitize_temp_name
-								(serialize_canonical_expr
-									(canonicalize_expr
-										(normalize_canonical_aliases (canonicalize_prejoin_source_expr variant_expr))
-										prejoin_alias_map)))))
+							(serialize_canonical_expr
+								(canonicalize_expr
+									(normalize_canonical_aliases (canonicalize_prejoin_source_expr variant_expr))
+									prejoin_alias_map)))))
 						(lambda (acc variant_name) (append_unique acc variant_name))
 						'())))
 				(prejoin_canonical_sources prejointbl
@@ -5541,7 +5546,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						(match expr
 							(cons sym args) (cons sym (map args rewrite_group_key_to_group_alias))
 							expr))))
-				(define grouped_having (rewrite_group_key_to_group_alias (lower_prejoin_lineage_expr raw_stage_having)))
+				(define grouped_having (rewrite_group_key_to_group_alias (lower_prejoin_lineage_expr raw_stage_post_group_condition)))
 				(define grouped_order (if (nil? raw_stage_order) nil
 					(map raw_stage_order (lambda (o) (match o '(col dir)
 						(list (lower_prejoin_lineage_expr col) dir))))))
@@ -5658,7 +5663,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 								(stage_preserve_cache_meta s
 									(make_group_stage
 										(map _sg recursive_replace_find_column)
-										(recursive_replace_find_column_condition (stage_having_expr s))
+										(recursive_replace_find_column_condition (stage_post_group_condition_expr s))
 										(map _so (lambda (o) (match o '(col dir) (list (recursive_replace_find_column col) dir))))
 										(stage_limit_val s)
 										(stage_offset_val s)
@@ -6344,32 +6349,32 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 															_ '()))))))
 														/* emit init code from partition stage if present */
 														(define _ps_init2 (stage_init_code _ps))
-															(define _ps_scan (scan_wrapper 'scan_order schema tbl
-																(cons list (merge_unique _ps_filtercols cols))
-																'((quote lambda) (map (merge_unique _ps_filtercols cols) (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
-																(cons list _ps_ordercols)
-																(cons list _ps_dirs)
+														(define _ps_scan (scan_wrapper 'scan_order schema tbl
+															(cons list (merge_unique _ps_filtercols cols))
+															'((quote lambda) (map (merge_unique _ps_filtercols cols) (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition)))
+															(cons list _ps_ordercols)
+															(cons list _ps_dirs)
 															_ps_partcols _ps_offset _ps_limit
 															scan_mapcols
 															(list (symbol "lambda") scan_mapfn_params (build_scan tables effective_later_condition (list schema tbl tblvar)))
-																nil nil isOuter))
-															(if (nil? _ps_init2) _ps_scan (list (quote begin) _ps_init2 _ps_scan)))
-														/* === regular scan === */
-														(begin
-															(define _direct_inner_scan (build_scan tables effective_later_condition (list schema tbl tblvar)))
-															(define _batch_stride (count batch_map_params))
-															(define _batch_capacity_rows 1024)
-															(define _batch_capacity (* _batch_stride _batch_capacity_rows))
-															(define _batch_pseudocols (map (produceN _batch_stride) (lambda (i) (concat "#" i))))
-															(define _batched_inner_scan (if (or (not (nil? update_target)) (equal? tables '()) (equal? _batch_stride 0))
-																nil
-																(batchify_first_scan _direct_inner_scan batch_map_params _batch_pseudocols _batch_stride (symbol "__batchbuf"))))
-															(define _outer_filter_lambda
-																'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition))))
-															(build_batched_regular_scan schema tbl filtercols _outer_filter_lambda scan_mapcols scan_mapfn_params batch_map_params _direct_inner_scan _batched_inner_scan _batch_stride _batch_capacity is_update_target isOuter)
-											))))
-										))
-									)
+															nil nil isOuter))
+														(if (nil? _ps_init2) _ps_scan (list (quote begin) _ps_init2 _ps_scan)))
+													/* === regular scan === */
+													(begin
+														(define _direct_inner_scan (build_scan tables effective_later_condition (list schema tbl tblvar)))
+														(define _batch_stride (count batch_map_params))
+														(define _batch_capacity_rows 1024)
+														(define _batch_capacity (* _batch_stride _batch_capacity_rows))
+														(define _batch_pseudocols (map (produceN _batch_stride) (lambda (i) (concat "#" i))))
+														(define _batched_inner_scan (if (or (not (nil? update_target)) (equal? tables '()) (equal? _batch_stride 0))
+															nil
+															(batchify_first_scan _direct_inner_scan batch_map_params _batch_pseudocols _batch_stride (symbol "__batchbuf"))))
+														(define _outer_filter_lambda
+															'((quote lambda) (map filtercols (lambda(col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr now_condition))))
+														(build_batched_regular_scan schema tbl filtercols _outer_filter_lambda scan_mapcols scan_mapfn_params batch_map_params _direct_inner_scan _batched_inner_scan _batch_stride _batch_capacity is_update_target isOuter)
+										))))
+									))
+								)
 								'() /* final inner (=scalar) */ (if (nil? update_target)
 									(begin
 										(define emit_fields (if (nil? last_scan_ctx) fields

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -659,7 +659,8 @@ class SQLTestRunner:
             else:
                 # Treat SHUTDOWN as successful regardless of response body, even if the connection closed.
                 if self._restart_handler is not None:
-                    self._restart_handler()
+                    if not self._restart_handler():
+                        return self._record_fail(name, "Restart failed after SHUTDOWN", query, None, None, is_noncritical)
                 else:
                     # No restart handler (--connect-only): wait until SQL endpoint is actually ready again.
                     restart_timeout = int(test_case.get("restart_timeout", 120))
@@ -979,7 +980,15 @@ _memcp_log_file: str = ""
 def start_memcp_process(port: int) -> subprocess.Popen | None:
     global _memcp_log_file
     try:
-        datadir = os.environ.get("MEMCP_TEST_DATADIR", f"/tmp/memcp-sql-tests-{port}")
+        # Test-runner contract:
+        # - Always use the repository-local ./data directory.
+        # - Never create port-specific or temp datadirs here.
+        # - Never delete ./data in the runner.
+        #
+        # The SQL suites intentionally share one database state across tables and
+        # restart/shutdown scenarios. "isolated" means serialized execution, not
+        # storage isolation.
+        datadir = "./data"
         _memcp_log_file = f"/tmp/memcp-test-{port}.log"
         env = os.environ.copy()
         memcp_bin = os.environ.get("MEMCP_BINARY", "./memcp")
@@ -1012,13 +1021,40 @@ def print_memcp_log(tail: int = 100) -> None:
     except Exception:
         pass
 
-def stop_memcp_process(proc: subprocess.Popen) -> None:
+def get_memcp_api_port(proc: subprocess.Popen) -> Optional[int]:
     try:
-        proc.stdin.close()
+        args = proc.args if isinstance(proc.args, list) else [proc.args]
+        for arg in args:
+            if isinstance(arg, str) and arg.startswith("--api-port="):
+                return int(arg.split("=", 1)[1])
+    except Exception:
+        pass
+    return None
+
+def stop_memcp_process(proc: subprocess.Popen) -> None:
+    port = get_memcp_api_port(proc)
+    try:
+        if proc.stdin is not None and not proc.stdin.closed:
+            proc.stdin.close()
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=10)
+        return
+    except Exception:
+        pass
+    if port is not None:
+        kill_memcp_by_port(port)
+    try:
+        proc.kill()
+    except Exception:
+        pass
+    try:
         proc.wait(timeout=10)
     except Exception:
         try:
-            proc.kill()
+            if port is not None:
+                kill_memcp_by_port(port)
         except Exception:
             pass
 
@@ -1107,6 +1143,13 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
     sequential_specs: List[Tuple[str, str]] = []
     for spec_file in spec_files:
         metadata = load_suite_metadata(spec_file)
+        # Scheduling contract:
+        # - restart/SHUTDOWN suites run sequentially with managed restarts
+        #   against the same shared ./data.
+        # - metadata.isolated also means sequential execution on that same
+        #   shared database, never a fresh datadir.
+        # - only non-isolated, non-restart suites may use the parallel
+        #   connect-only worker pool.
         if suite_requires_managed_restart(spec_file):
             sequential_specs.append(("direct", spec_file))
         elif metadata.get("isolated"):

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+#
+# Copyright (C) 2023-2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """
 MemCP SQL Test Runner (Optimized)
 
@@ -1062,8 +1078,10 @@ def normalize_jobs(jobs: Optional[int]) -> int:
     return jobs
 
 
-def run_spec_subprocess(spec_file: str, port: int, log_times: bool) -> Tuple[bool, str]:
-    cmd = [sys.executable, os.path.abspath(__file__), spec_file, str(port), "--connect-only"]
+def run_spec_subprocess(spec_file: str, port: Optional[int], log_times: bool, connect_only: bool) -> Tuple[bool, str]:
+    cmd = [sys.executable, os.path.abspath(__file__), spec_file]
+    if connect_only and port is not None:
+        cmd.extend([str(port), "--connect-only"])
     if log_times:
         cmd.append("--log-times")
     proc = subprocess.run(cmd, capture_output=True, text=True)
@@ -1103,7 +1121,7 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
 
     with ThreadPoolExecutor(max_workers=max_jobs) as executor:
         futures = {
-            executor.submit(run_spec_subprocess, spec_file, port, log_times): spec_file
+            executor.submit(run_spec_subprocess, spec_file, port, log_times, True): spec_file
             for spec_file in parallel_specs
         }
         for future in as_completed(futures):
@@ -1124,7 +1142,7 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
             ok = runner.run_test_spec(spec_file)
             suite_status[spec_file] = ok
         else:
-            ok, output = run_spec_subprocess(spec_file, port, log_times)
+            ok, output = run_spec_subprocess(spec_file, None, log_times, False)
             record_result(spec_file, ok, output)
 
     failed_files = [spec_file for spec_file in spec_files if not suite_status.get(spec_file, False)]

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1185,7 +1185,7 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
             ok = runner.run_test_spec(spec_file)
             suite_status[spec_file] = ok
         else:
-            ok, output = run_spec_subprocess(spec_file, None, log_times, False)
+            ok, output = run_spec_subprocess(spec_file, port, log_times, True)
             record_result(spec_file, ok, output)
 
     failed_files = [spec_file for spec_file in spec_files if not suite_status.get(spec_file, False)]

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 
 package scm
 
+import "context"
 import "os"
 import "fmt"
 import "net"
@@ -283,14 +284,18 @@ func isSelectQuery(query string) bool {
 func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (myerr error) {
 	atomic.AddInt64(&TotalHTTPRequests, 1)
 	var ss *SessionState
+	var querySeq uint64
+	queryCtx, queryCancel := context.WithCancel(context.Background())
+	defer queryCancel()
 	if v, ok := mysqlStates.Load(session.ID()); ok {
 		ss = v.(*SessionState)
-		ss.SetCommand("Query", query)
+		querySeq = ss.BeginQuery("Query", query)
+		ss.SetCancel(querySeq, queryCancel)
 		ss.SetDB(session.Schema())
 	}
 	defer func() {
 		if ss != nil {
-			ss.SetCommand("Sleep", "")
+			ss.EndQuery(querySeq, "Sleep", "")
 			ss.SetDB(session.Schema())
 		}
 	}()
@@ -379,6 +384,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		SetValues(map[string]any{
 			"session":         scmSessionScmer,
 			"sessionStatePtr": ss,
+			"context":         queryCtx,
 		}, func() {
 			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, scmSessionScmer)
 		})

--- a/scm/network.go
+++ b/scm/network.go
@@ -295,19 +295,21 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		defer UnregisterSession(ss.ID)
 		defer ss.ReleaseAllLocks() // non-persistent: release locks when request ends
 	}
-	// Reset killed flag in case this session was killed in a previous request
-	ss.ResetKilled()
-	ss.SetCommand("Query", req.Method+" "+req.URL.Path)
+	querySeq := ss.BeginQuery("Query", req.Method+" "+req.URL.Path)
+	ctx, cancel := context.WithCancel(req.Context())
+	ss.SetCancel(querySeq, cancel)
+	defer cancel()
+	defer ss.EndQuery(querySeq, "Sleep", "")
 	// Watch for HTTP client disconnect and propagate to session kill
 	reqDone := make(chan struct{})
 	defer close(reqDone)
-	go func() {
+	go func(seq uint64) {
 		select {
 		case <-req.Context().Done():
-			ss.Kill()
+			ss.KillQuery(seq)
 		case <-reqDone:
 		}
-	}()
+	}(querySeq)
 	SetValues(map[string]any{"sessionStatePtr": ss}, func() {
 		contextFn := func() {
 			// catch panics and print out 500 Internal Server Error
@@ -331,9 +333,9 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		// Persistent HTTP sessions reuse the same Scheme session so that
 		// @variables set in one request are visible in subsequent requests.
 		if req.Header.Get("X-Session-Id") != "" {
-			NewContextWithSession(req.Context(), ss.GetOrCreateScmSession(), contextFn)
+			NewContextWithSession(ctx, ss.GetOrCreateScmSession(), contextFn)
 		} else {
-			NewContext(req.Context(), contextFn)
+			NewContext(ctx, contextFn)
 		}
 	})
 }

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -40,8 +40,12 @@ type SessionState struct {
 
 	killed atomic.Bool // set by Kill(); checked at scan entry points
 
-	cancel   context.CancelFunc // called by KILL QUERY; nil if not cancellable
-	cancelMu sync.Mutex         // protects cancel assignment
+	nextQuerySeq atomic.Uint64 // monotonically increasing request/query generation
+	activeQuery  atomic.Uint64 // currently running generation; 0 when idle
+
+	cancel    context.CancelFunc // called by KILL QUERY; nil if not cancellable
+	cancelSeq uint64             // generation owning cancel
+	cancelMu  sync.Mutex         // protects cancel assignment
 
 	heldLocks   []func()   // unlock callbacks for LOCK TABLES
 	heldLocksMu sync.Mutex // protects heldLocks slice
@@ -75,6 +79,29 @@ func (s *SessionState) SetCommand(cmd, info string) {
 	s.startedAt.Store(time.Now().UnixNano())
 }
 
+// BeginQuery marks a new request/query generation as active on this session.
+// This prevents late disconnects from earlier HTTP requests from killing a
+// subsequent request reusing the same SessionState.
+func (s *SessionState) BeginQuery(cmd, info string) uint64 {
+	seq := s.nextQuerySeq.Add(1)
+	s.activeQuery.Store(seq)
+	s.killed.Store(false)
+	s.SetState("")
+	s.SetCommand(cmd, info)
+	return seq
+}
+
+// EndQuery clears the active generation if it still matches seq and restores
+// the idle processlist state. Older requests finishing late must not overwrite
+// a newer active request on the same persistent HTTP session.
+func (s *SessionState) EndQuery(seq uint64, idleCmd, idleInfo string) {
+	s.ClearCancel(seq)
+	if s.activeQuery.CompareAndSwap(seq, 0) {
+		s.SetState("")
+		s.SetCommand(idleCmd, idleInfo)
+	}
+}
+
 // SetState updates the State field (e.g. "Waiting for table lock").
 func (s *SessionState) SetState(state string) {
 	s.State.Store(&state)
@@ -85,17 +112,23 @@ func (s *SessionState) SetDB(db string) {
 	s.DB.Store(&db)
 }
 
-// SetCancel stores the cancel function for KILL QUERY support.
-func (s *SessionState) SetCancel(fn context.CancelFunc) {
+// SetCancel stores the cancel function for one specific active query generation.
+func (s *SessionState) SetCancel(seq uint64, fn context.CancelFunc) {
 	s.cancelMu.Lock()
-	s.cancel = fn
+	if s.activeQuery.Load() == seq {
+		s.cancel = fn
+		s.cancelSeq = seq
+	}
 	s.cancelMu.Unlock()
 }
 
-// ClearCancel removes the cancel function after query completion.
-func (s *SessionState) ClearCancel() {
+// ClearCancel removes the cancel function if it still belongs to seq.
+func (s *SessionState) ClearCancel(seq uint64) {
 	s.cancelMu.Lock()
-	s.cancel = nil
+	if s.cancelSeq == seq {
+		s.cancel = nil
+		s.cancelSeq = 0
+	}
 	s.cancelMu.Unlock()
 }
 
@@ -112,15 +145,31 @@ func (s *SessionState) ResetKilled() {
 // Kill marks the session as killed and fires the cancel function if set.
 // Returns true if a running query was cancelled.
 func (s *SessionState) Kill() bool {
+	seq := s.activeQuery.Load()
+	if seq == 0 {
+		return false
+	}
+	return s.KillQuery(seq)
+}
+
+// KillQuery marks the given active query generation as killed.
+// Returns false if the session has already advanced to a different request.
+func (s *SessionState) KillQuery(seq uint64) bool {
+	if seq == 0 || s.activeQuery.Load() != seq {
+		return false
+	}
 	s.killed.Store(true)
 	s.cancelMu.Lock()
-	fn := s.cancel
+	var fn context.CancelFunc
+	if s.cancelSeq == seq {
+		fn = s.cancel
+	}
 	s.cancelMu.Unlock()
 	if fn != nil {
 		fn()
 		return true
 	}
-	return false
+	return true
 }
 
 // AddLock registers an unlock callback for a LOCK TABLES lock.
@@ -199,55 +248,55 @@ func GetCurrentSessionState() *SessionState {
 
 func init_processlist() {
 	nextSessionID.Store(1)
-		Declare(&Globalenv, &Declaration{
+	Declare(&Globalenv, &Declaration{
 		Name: "show_processlist",
 		Desc: "returns a list of active sessions for SHOW [FULL] PROCESSLIST; pass true for full info",
 		Fn: func(a ...Scmer) Scmer {
-				full := len(a) > 0 && a[0].Bool()
-				sessions := Snapshot()
-				result := make([]Scmer, len(sessions))
-				for i, s := range sessions {
-					info := strPtr(&s.Info)
-					if !full && len(info) > 100 {
-						info = info[:100]
-					}
-					result[i] = NewSlice([]Scmer{
-						NewString("Id"), NewInt(int64(s.ID)),
-						NewString("User"), NewString(s.User),
-						NewString("Host"), NewString(s.Host),
-						NewString("db"), NewString(strPtr(&s.DB)),
-						NewString("Command"), NewString(strPtr(&s.Command)),
-						NewString("Time"), NewInt(s.ElapsedSeconds()),
-						NewString("State"), NewString(strPtr(&s.State)),
-						NewString("Info"), NewString(info),
-					})
+			full := len(a) > 0 && a[0].Bool()
+			sessions := Snapshot()
+			result := make([]Scmer, len(sessions))
+			for i, s := range sessions {
+				info := strPtr(&s.Info)
+				if !full && len(info) > 100 {
+					info = info[:100]
 				}
-				return NewSlice(result)
-			},
+				result[i] = NewSlice([]Scmer{
+					NewString("Id"), NewInt(int64(s.ID)),
+					NewString("User"), NewString(s.User),
+					NewString("Host"), NewString(s.Host),
+					NewString("db"), NewString(strPtr(&s.DB)),
+					NewString("Command"), NewString(strPtr(&s.Command)),
+					NewString("Time"), NewInt(s.ElapsedSeconds()),
+					NewString("State"), NewString(strPtr(&s.State)),
+					NewString("Info"), NewString(info),
+				})
+			}
+			return NewSlice(result)
+		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "bool", ParamName: "full", ParamDesc: "if true, include full Info text", Optional: true}},
 			Return: &TypeDescriptor{Kind: "list"},
 		},
 	})
-		Declare(&Globalenv, &Declaration{
+	Declare(&Globalenv, &Declaration{
 		Name: "connection_id",
 		Desc: "returns the process-list ID of the current session (MySQL CONNECTION_ID() equivalent)",
 		Fn: func(a ...Scmer) Scmer {
-				if ss := GetCurrentSessionState(); ss != nil {
-					return NewInt(int64(ss.ID))
-				}
-				return NewInt(0)
-			},
+			if ss := GetCurrentSessionState(); ss != nil {
+				return NewInt(int64(ss.ID))
+			}
+			return NewInt(0)
+		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "int"},
 		},
 	})
-		Declare(&Globalenv, &Declaration{
+	Declare(&Globalenv, &Declaration{
 		Name: "kill_query",
 		Desc: "cancel the running query in session id; returns true if a query was killed",
 		Fn: func(a ...Scmer) Scmer {
-				return NewBool(KillSession(uint64(a[0].Int())))
-			},
+			return NewBool(KillSession(uint64(a[0].Int())))
+		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "int", ParamName: "id", ParamDesc: "session ID from SHOW PROCESSLIST"}},
 			Return: &TypeDescriptor{Kind: "bool"},

--- a/tests/99_kill_lock.yaml
+++ b/tests/99_kill_lock.yaml
@@ -301,11 +301,13 @@ test_cases:
       - sql: "CREATE TABLE kill_ctrl (id BIGINT)"
       - sql: "CREATE TABLE kill_big (id INT)"
       - sql: "INSERT INTO kill_big VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99),(100),(101),(102),(103),(104),(105),(106),(107),(108),(109),(110),(111),(112),(113),(114),(115),(116),(117),(118),(119),(120),(121),(122),(123),(124),(125),(126),(127),(128),(129),(130),(131),(132),(133),(134),(135),(136),(137),(138),(139),(140),(141),(142),(143),(144),(145),(146),(147),(148),(149),(150),(151),(152),(153),(154),(155),(156),(157),(158),(159),(160),(161),(162),(163),(164),(165),(166),(167),(168),(169),(170),(171),(172),(173),(174),(175),(176),(177),(178),(179),(180),(181),(182),(183),(184),(185),(186),(187),(188),(189),(190),(191),(192),(193),(194),(195),(196),(197),(198),(199),(200)"
+      - sql: "INSERT INTO kill_big SELECT id + 200 FROM kill_big"
+      - sql: "INSERT INTO kill_big SELECT id + 1000 FROM kill_big"
     steps:
       # store victim session's connection ID in kill_ctrl
       - session_id: "kill-victim"
         sql: "INSERT INTO kill_ctrl VALUES (CONNECTION_ID())"
-      # start slow CROSS JOIN in background — 200×200 = 40 000 row combinations
+      # start slow CROSS JOIN in background — 400×400 = 160 000 row combinations
       - session_id: "kill-victim"
         sql: "SELECT COUNT(*) AS n FROM kill_big a, kill_big b"
         background: true
@@ -319,6 +321,16 @@ test_cases:
       # kill the victim's running query
       - session_id: "kill-attacker"
         sql: "SELECT KILL_QUERY(id) FROM kill_ctrl LIMIT 1"
+      # let the killed background request drain fully; then the same session
+      # must be reusable immediately without inheriting a stale killed flag
+      - session_id: "kill-attacker"
+        sql: "SELECT 1"
+      - session_id: "kill-attacker"
+        sql: "SELECT 1"
+      - session_id: "kill-victim"
+        sql: "SELECT CONNECTION_ID() AS id"
+        expect:
+          rows: 1
 
   # ── KILL mid-INSERT rollback: no partial state ────────────────────────────
   #
@@ -332,11 +344,11 @@ test_cases:
   #             → error response returned
   #
   # Invariant: after kill, kill_dst contains either 0 rows (kill fired
-  # before INSERT completed + rollback) or 40000 rows (INSERT completed
+  # before INSERT completed + rollback) or 160000 rows (INSERT completed
   # before kill arrived, no rollback needed).  Never a value in between.
   #
   # The check enforces 0 rows because the kill is sent well before the
-  # 200×200=40000-row INSERT SELECT finishes (~89 ms on typical hardware).
+  # 400×400-row INSERT SELECT finishes on typical hardware.
 
   - name: "KILL mid-INSERT leaves target table empty (rollback correctness)"
     setup:
@@ -348,7 +360,7 @@ test_cases:
       # record victim session ID so the attacker can retrieve it
       - session_id: "rb-kill-victim"
         sql: "INSERT INTO kill_ctrl2 VALUES (CONNECTION_ID())"
-      # slow INSERT SELECT: 200×200 = 40 000 row combinations (~89 ms)
+      # slow INSERT SELECT: 400×400 = 160 000 row combinations
       - session_id: "rb-kill-victim"
         sql: "INSERT INTO kill_dst SELECT a.id, b.id FROM kill_big a, kill_big b"
         background: true


### PR DESCRIPTION
## Summary
- treat the stage-local having slot as a post-group condition contract throughout the planner
- merge the current stage post-group predicate through one planner path before combining it with deferred aggregate conditions
- keep group_alias-based grouped key rewrites intact while reducing HAVING-specific naming and branching

## Testing
- python3 run_sql_tests.py tests/51_distinct.yaml
- python3 run_sql_tests.py tests/66_exists_session_var.yaml
- python3 run_sql_tests.py tests/106_subselect_in_clauses.yaml
- make test
