### PR TITLE
fix: INSERT dual-write data loss during concurrent repartition

### DIFF
--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1945,7 +1945,7 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 		}
 	}
 	needMaterializedRows := (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil
-	needMaterializedRows = needMaterializedRows || (propagateMaintenance && (t.loadNext() != nil || (t.t.repartitionDualWriteActive.Load() && t.t.ShardMode == ShardModeFree)))
+	needMaterializedRows = needMaterializedRows || (propagateMaintenance && (t.loadNext() != nil || t.t.repartitionDualWriteActive.Load()))
 	var payloadCols []string
 	var payloadVals [][]scm.Scmer
 	if needMaterializedRows {


### PR DESCRIPTION
## Summary
Fixes data loss when INSERT runs concurrently with `(rebuild)`-triggered repartition (#136).

Two `ShardMode == ShardModeFree` guards in the shard-level INSERT path blocked row materialization and dual-write forwarding after Phase F flipped ShardMode to Partition. Concurrent INSERTs would write rows to old Shards (soon nil'd) without forwarding them to PShards.

## Changes
- `storage/shard.go`: Remove `ShardMode == ShardModeFree` from `needMaterializedRows` condition and dual-write call — `dualWriteInsertFromOld` already checks `PShards != nil` internally
- `tests/92_parallel_projection.yaml`: Speedup test (parallel_map, 30k rows, >= 1.5x)
- `scm/list.go`: parallel_map/parallel_map_mut builtins (worker pool, NumCPU limit)
- `scm/date.go`: nanotime builtin
- `lib/queryplan.scm`: parallelize_resultrows post-processing pass
- `lib/test.scm`: parallel_map unit tests

## Test plan
- [x] `tests/92_parallel_projection.yaml` passes without `isolated: true` alongside repartition tests
- [x] `tests/71_repartition_concurrent.yaml`: 143/143
- [x] `tests/73_window_functions.yaml`: 38/38
- [x] `tests/32_expr_subselects.yaml`: 34/34

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)