### PR TITLE
fix: untangle session query lifecycle

### DIFF
--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -35,6 +35,10 @@ type mysqlCloser interface {
 	Close()
 }
 
+type mysqlSessionDone interface {
+	Done() <-chan struct{}
+}
+
 var mysqlListenersMu sync.Mutex
 var mysqlListeners []mysqlCloser
 
@@ -287,11 +291,26 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	var querySeq uint64
 	queryCtx, queryCancel := context.WithCancel(context.Background())
 	defer queryCancel()
+	queryDone := make(chan struct{})
+	defer close(queryDone)
 	if v, ok := mysqlStates.Load(session.ID()); ok {
 		ss = v.(*SessionState)
+		ss.Touch()
 		querySeq = ss.BeginQuery("Query", query)
 		ss.SetCancel(querySeq, queryCancel)
 		ss.SetDB(session.Schema())
+	}
+	if doneSession, ok := any(session).(mysqlSessionDone); ok {
+		go func() {
+			select {
+			case <-doneSession.Done():
+				queryCancel()
+				if ss != nil {
+					ss.KillQuery(querySeq)
+				}
+			case <-queryDone:
+			}
+		}()
 	}
 	defer func() {
 		if ss != nil {
@@ -384,6 +403,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		SetValues(map[string]any{
 			"session":         scmSessionScmer,
 			"sessionStatePtr": ss,
+			"querySeq":        querySeq,
 			"context":         queryCtx,
 		}, func() {
 			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, scmSessionScmer)

--- a/scm/network.go
+++ b/scm/network.go
@@ -295,6 +295,7 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		defer UnregisterSession(ss.ID)
 		defer ss.ReleaseAllLocks() // non-persistent: release locks when request ends
 	}
+	ss.Touch()
 	querySeq := ss.BeginQuery("Query", req.Method+" "+req.URL.Path)
 	ctx, cancel := context.WithCancel(req.Context())
 	ss.SetCancel(querySeq, cancel)
@@ -310,7 +311,7 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		case <-reqDone:
 		}
 	}(querySeq)
-	SetValues(map[string]any{"sessionStatePtr": ss}, func() {
+	SetValues(map[string]any{"sessionStatePtr": ss, "querySeq": querySeq}, func() {
 		contextFn := func() {
 			// catch panics and print out 500 Internal Server Error
 			defer func() {

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -37,21 +37,23 @@ type SessionState struct {
 	State   atomic.Pointer[string] // "Waiting for table lock", "" etc.
 
 	startedAt atomic.Int64 // unix nanos of last command start
-
-	killed atomic.Bool // set by Kill(); checked at scan entry points
+	lastUsed  atomic.Int64 // unix nanos of last observed access; used for cache eviction
 
 	nextQuerySeq atomic.Uint64 // monotonically increasing request/query generation
-	activeQuery  atomic.Uint64 // currently running generation; 0 when idle
+	activeQuery  atomic.Uint64 // latest running generation for processlist display
+	activeCount  atomic.Int64  // number of concurrently running requests/queries
 
-	cancel    context.CancelFunc // called by KILL QUERY; nil if not cancellable
-	cancelSeq uint64             // generation owning cancel
-	cancelMu  sync.Mutex         // protects cancel assignment
+	cancelFns map[uint64]context.CancelFunc
+	active    map[uint64]bool
+	killed    map[uint64]bool
+	cancelMu  sync.Mutex // protects active query bookkeeping
 
 	heldLocks   []func()   // unlock callbacks for LOCK TABLES
 	heldLocksMu sync.Mutex // protects heldLocks slice
 
 	scmSession     Scmer     // persistent Scheme session for HTTP connections
 	scmSessionOnce sync.Once // ensures scmSession is initialized exactly once
+
 }
 
 // GetOrCreateScmSession returns the persistent Scheme session for this SessionState,
@@ -72,11 +74,18 @@ func (s *SessionState) ElapsedSeconds() int64 {
 	return int64(time.Since(time.Unix(0, ns)).Seconds())
 }
 
+// Touch marks this session as recently used for cache eviction purposes.
+func (s *SessionState) Touch() {
+	s.lastUsed.Store(time.Now().UnixNano())
+}
+
 // SetCommand updates Command, Info, and resets the elapsed timer.
 func (s *SessionState) SetCommand(cmd, info string) {
 	s.Command.Store(&cmd)
 	s.Info.Store(&info)
-	s.startedAt.Store(time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	s.startedAt.Store(now)
+	s.lastUsed.Store(now)
 }
 
 // BeginQuery marks a new request/query generation as active on this session.
@@ -85,7 +94,16 @@ func (s *SessionState) SetCommand(cmd, info string) {
 func (s *SessionState) BeginQuery(cmd, info string) uint64 {
 	seq := s.nextQuerySeq.Add(1)
 	s.activeQuery.Store(seq)
-	s.killed.Store(false)
+	s.activeCount.Add(1)
+	s.cancelMu.Lock()
+	if s.active == nil {
+		s.active = make(map[uint64]bool)
+	}
+	s.active[seq] = true
+	if s.killed != nil {
+		delete(s.killed, seq)
+	}
+	s.cancelMu.Unlock()
 	s.SetState("")
 	s.SetCommand(cmd, info)
 	return seq
@@ -96,7 +114,8 @@ func (s *SessionState) BeginQuery(cmd, info string) uint64 {
 // a newer active request on the same persistent HTTP session.
 func (s *SessionState) EndQuery(seq uint64, idleCmd, idleInfo string) {
 	s.ClearCancel(seq)
-	if s.activeQuery.CompareAndSwap(seq, 0) {
+	if s.activeCount.Add(-1) == 0 {
+		s.activeQuery.Store(0)
 		s.SetState("")
 		s.SetCommand(idleCmd, idleInfo)
 	}
@@ -115,59 +134,90 @@ func (s *SessionState) SetDB(db string) {
 // SetCancel stores the cancel function for one specific active query generation.
 func (s *SessionState) SetCancel(seq uint64, fn context.CancelFunc) {
 	s.cancelMu.Lock()
-	if s.activeQuery.Load() == seq {
-		s.cancel = fn
-		s.cancelSeq = seq
+	if s.cancelFns == nil {
+		s.cancelFns = make(map[uint64]context.CancelFunc)
 	}
+	s.cancelFns[seq] = fn
 	s.cancelMu.Unlock()
 }
 
 // ClearCancel removes the cancel function if it still belongs to seq.
 func (s *SessionState) ClearCancel(seq uint64) {
 	s.cancelMu.Lock()
-	if s.cancelSeq == seq {
-		s.cancel = nil
-		s.cancelSeq = 0
+	if s.cancelFns != nil {
+		delete(s.cancelFns, seq)
+	}
+	if s.active != nil {
+		delete(s.active, seq)
+	}
+	if s.killed != nil {
+		delete(s.killed, seq)
 	}
 	s.cancelMu.Unlock()
 }
 
 // IsKilled returns true if this session has been killed.
 func (s *SessionState) IsKilled() bool {
-	return s.killed.Load()
-}
-
-// ResetKilled clears the killed flag, e.g. at the start of a new request on a reused session.
-func (s *SessionState) ResetKilled() {
-	s.killed.Store(false)
+	if mgr == nil {
+		return false
+	}
+	v, ok := mgr.GetValue("querySeq")
+	if !ok {
+		return false
+	}
+	seq, ok := v.(uint64)
+	if !ok || seq == 0 {
+		return false
+	}
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	return s.killed != nil && s.killed[seq]
 }
 
 // Kill marks the session as killed and fires the cancel function if set.
-// Returns true if a running query was cancelled.
+// Returns true if at least one running query was cancelled.
 func (s *SessionState) Kill() bool {
-	seq := s.activeQuery.Load()
-	if seq == 0 {
+	s.cancelMu.Lock()
+	if len(s.active) == 0 {
+		s.cancelMu.Unlock()
 		return false
 	}
-	return s.KillQuery(seq)
+	if s.killed == nil {
+		s.killed = make(map[uint64]bool, len(s.active))
+	}
+	fns := make([]context.CancelFunc, 0, len(s.cancelFns))
+	for seq := range s.active {
+		s.killed[seq] = true
+		if fn := s.cancelFns[seq]; fn != nil {
+			fns = append(fns, fn)
+		}
+	}
+	s.cancelMu.Unlock()
+	for _, fn := range fns {
+		fn()
+	}
+	return true
 }
 
 // KillQuery marks the given active query generation as killed.
 // Returns false if the session has already advanced to a different request.
 func (s *SessionState) KillQuery(seq uint64) bool {
-	if seq == 0 || s.activeQuery.Load() != seq {
+	if seq == 0 {
 		return false
 	}
-	s.killed.Store(true)
 	s.cancelMu.Lock()
-	var fn context.CancelFunc
-	if s.cancelSeq == seq {
-		fn = s.cancel
+	if s.active == nil || !s.active[seq] {
+		s.cancelMu.Unlock()
+		return false
 	}
+	fn := s.cancelFns[seq]
+	if s.killed == nil {
+		s.killed = make(map[uint64]bool)
+	}
+	s.killed[seq] = true
 	s.cancelMu.Unlock()
 	if fn != nil {
 		fn()
-		return true
 	}
 	return true
 }
@@ -223,12 +273,18 @@ func EvictHTTPSession(key string) bool {
 	if !ok {
 		return false
 	}
-	UnregisterSession(v.(*SessionState).ID)
+	ss := v.(*SessionState)
+	ss.Kill()
+	ss.ReleaseAllLocks()
+	UnregisterSession(ss.ID)
 	return true
 }
 
 // LastUsedNano returns the unix nanosecond timestamp of the last command start.
 func (s *SessionState) LastUsedNano() int64 {
+	if ts := s.lastUsed.Load(); ts != 0 {
+		return ts
+	}
 	return s.startedAt.Load()
 }
 
@@ -317,7 +373,9 @@ func RegisterSession(user, host, db string) *SessionState {
 	empty := ""
 	s.Info.Store(&empty)
 	s.State.Store(&empty)
-	s.startedAt.Store(time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	s.startedAt.Store(now)
+	s.lastUsed.Store(now)
 	processList.Store(s.ID, s)
 	return s
 }

--- a/scm/processlist_test.go
+++ b/scm/processlist_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2024-2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSessionStateTouchUpdatesLastUsed(t *testing.T) {
+	ss := RegisterSession("u", "h", "db")
+	defer UnregisterSession(ss.ID)
+
+	before := ss.LastUsedNano()
+	time.Sleep(time.Millisecond)
+	ss.Touch()
+	after := ss.LastUsedNano()
+	if after <= before {
+		t.Fatalf("expected LastUsedNano to advance, before=%d after=%d", before, after)
+	}
+}
+
+func TestEvictHTTPSessionReleasesLocksAndKillsQuery(t *testing.T) {
+	ss := RegisterSession("u", "h", "db")
+	key := "sid"
+	httpStates.Store(key, ss)
+
+	var unlocked int
+	var cancelled bool
+	ss.AddLock(func() { unlocked++ })
+	seq := ss.BeginQuery("Query", "SELECT 1")
+	ss.SetCancel(seq, func() { cancelled = true })
+
+	if !EvictHTTPSession(key) {
+		t.Fatalf("expected eviction to succeed")
+	}
+	if unlocked != 1 {
+		t.Fatalf("expected one lock release, got %d", unlocked)
+	}
+	if !cancelled {
+		t.Fatalf("expected active query to be cancelled")
+	}
+	if _, ok := processList.Load(ss.ID); ok {
+		t.Fatalf("expected evicted session to be removed from process list")
+	}
+}
+
+func TestKillQueryMarksOnlyCurrentGeneration(t *testing.T) {
+	ss := RegisterSession("u", "h", "db")
+	defer UnregisterSession(ss.ID)
+
+	seq1 := ss.BeginQuery("Query", "SELECT 1")
+	seq2 := ss.BeginQuery("Query", "SELECT 2")
+	if !ss.KillQuery(seq1) {
+		t.Fatalf("expected first query generation to be killable")
+	}
+	SetValues(map[string]any{"querySeq": seq1, "context": context.Background()}, func() {
+		if !ss.IsKilled() {
+			t.Fatalf("expected seq1 to be marked killed")
+		}
+	})
+	SetValues(map[string]any{"querySeq": seq2, "context": context.Background()}, func() {
+		if ss.IsKilled() {
+			t.Fatalf("expected seq2 to remain alive")
+		}
+	})
+	ss.EndQuery(seq1, "Sleep", "")
+	ss.EndQuery(seq2, "Sleep", "")
+}

--- a/third_party/go-mysqlstack/driver/session.go
+++ b/third_party/go-mysqlstack/driver/session.go
@@ -3,7 +3,7 @@
  * xelabs.org
  *
  * Copyright (c) 2021 XeLabs
- * Copyright (c) 2023 Carl-Philip Hänsch
+ * Copyright (c) 2023-2026 Carl-Philip Hänsch
  * GPL License
  *
  */
@@ -11,11 +11,12 @@
 package driver
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"net"
 	"sync"
+	"syscall"
 	"time"
-	"crypto/sha1"
 
 	"github.com/launix-de/go-mysqlstack/packet"
 	"github.com/launix-de/go-mysqlstack/proto"
@@ -39,10 +40,12 @@ type Session struct {
 	lastQueryTime time.Time
 	statementID   uint32                // used to identify different statements for the same session.
 	statements    map[uint32]*Statement // Save the metadata of the session related to the prepare operation.
+	done          chan struct{}
+	doneOnce      sync.Once
 }
 
 func newSession(log *xlog.Log, ID uint32, serverVersion string, conn net.Conn) *Session {
-	return &Session{
+	s := &Session{
 		id:            ID,
 		log:           log,
 		conn:          conn,
@@ -51,7 +54,10 @@ func newSession(log *xlog.Log, ID uint32, serverVersion string, conn net.Conn) *
 		packets:       packet.NewPackets(conn),
 		lastQueryTime: time.Now(),
 		statements:    make(map[uint32]*Statement),
+		done:          make(chan struct{}),
 	}
+	go s.watchDisconnect()
+	return s
 }
 
 func (s *Session) writeErrFromError(err error) error {
@@ -224,12 +230,70 @@ func (s *Session) writeStatementPrepareResult(stmt *Statement) error {
 
 // Close used to close the connection.
 func (s *Session) Close() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if s.conn != nil {
-		s.conn.Close()
-		s.conn = nil
+	s.mu.Lock()
+	conn := s.conn
+	s.conn = nil
+	s.mu.Unlock()
+	if conn != nil {
+		conn.Close()
 	}
+	s.doneOnce.Do(func() { close(s.done) })
+}
+
+// Done is closed once the client connection is gone.
+func (s *Session) Done() <-chan struct{} {
+	return s.done
+}
+
+func (s *Session) watchDisconnect() {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+		}
+		if s.connClosed() {
+			s.Close()
+			return
+		}
+	}
+}
+
+func (s *Session) connClosed() bool {
+	s.mu.RLock()
+	conn := s.conn
+	s.mu.RUnlock()
+	if conn == nil {
+		return true
+	}
+	sc, ok := conn.(syscall.Conn)
+	if !ok {
+		return false
+	}
+	raw, err := sc.SyscallConn()
+	if err != nil {
+		return false
+	}
+	closed := false
+	controlErr := raw.Read(func(fd uintptr) bool {
+		var buf [1]byte
+		n, _, recvErr := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+		switch {
+		case recvErr == nil:
+			closed = n == 0
+		case recvErr == syscall.EAGAIN || recvErr == syscall.EWOULDBLOCK:
+			closed = false
+		default:
+			closed = true
+		}
+		return true
+	})
+	if controlErr != nil {
+		return false
+	}
+	return closed
 }
 
 // ID returns the connection ID.
@@ -308,10 +372,10 @@ func (s *Session) updateLastQueryTime(time time.Time) {
 // helper functions for authentication
 // returns sha1(password) which you can store in your users table
 func CreatePassword(password string) []byte {
-        // stage1Hash = SHA1(password)
-        crypt := sha1.New()
-        crypt.Write([]byte(password))
-        stage1 := crypt.Sum(nil)
+	// stage1Hash = SHA1(password)
+	crypt := sha1.New()
+	crypt.Write([]byte(password))
+	stage1 := crypt.Sum(nil)
 	return stage1
 }
 
@@ -321,23 +385,23 @@ func (s *Session) TestPassword(sha1pw []byte) bool {
 	defer s.mu.RUnlock()
 
 	// sha1pw: SHA1(password)
-        crypt := sha1.New()
-        crypt.Write([]byte(sha1pw))
-        stage1SHA1 := crypt.Sum(nil)
+	crypt := sha1.New()
+	crypt.Write([]byte(sha1pw))
+	stage1SHA1 := crypt.Sum(nil)
 
-        // stage2Hash = SHA1(salt <concat> SHA1(SHA1(password)))
-        crypt.Reset()
-        crypt.Write(s.greeting.Salt)
-        crypt.Write(stage1SHA1)
-        stage2 := crypt.Sum(nil)
+	// stage2Hash = SHA1(salt <concat> SHA1(SHA1(password)))
+	crypt.Reset()
+	crypt.Write(s.greeting.Salt)
+	crypt.Write(stage1SHA1)
+	stage2 := crypt.Sum(nil)
 
 	// test: scrable ^ sha1pw = stage2
 	scramble := s.auth.AuthResponse()
-        for i := range stage2 {
-                if scramble[i] != sha1pw[i] ^ stage2[i] {
+	for i := range stage2 {
+		if scramble[i] != sha1pw[i]^stage2[i] {
 			return false
 		}
-        }
+	}
 	return true
 }
 

--- a/third_party/go-mysqlstack/driver/session_lifecycle_test.go
+++ b/third_party/go-mysqlstack/driver/session_lifecycle_test.go
@@ -1,0 +1,35 @@
+/*
+ * go-mysqlstack
+ * xelabs.org
+ *
+ * Copyright (c) 2021 XeLabs
+ * Copyright (c) 2023-2026 Carl-Philip Hänsch
+ * GPL License
+ *
+ */
+
+package driver
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/launix-de/go-mysqlstack/xlog"
+)
+
+func TestSessionDoneClosesOnClose(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+
+	s := newSession(xlog.NewStdLog(xlog.Level(xlog.ERROR)), 1, "MemCP", server)
+	defer s.Close()
+
+	s.Close()
+
+	select {
+	case <-s.Done():
+	case <-time.After(time.Second):
+		t.Fatalf("expected session Done channel to close")
+	}
+}


### PR DESCRIPTION
Fixes session-lifecycle bugs that left queries running after disconnects and made persistent HTTP sessions too coarse-grained.

What changed:
- cancel MySQL queries when the client connection disappears
- separate processlist timing from cache last-used lease
- make KILL/disconnect state query-local instead of session-global
- release locks and cancel active work when evicting persistent HTTP sessions
- allow multiple concurrent requests on one persistent session without serializing the whole session

Verified with:
- go test ./scm github.com/launix-de/go-mysqlstack/driver -run 'Test(SessionStateTouchUpdatesLastUsed|EvictHTTPSessionReleasesLocksAndKillsQuery|KillQueryMarksOnlyCurrentGeneration|SessionDoneClosesOnClose|AppendMySQLResultRowDuplicateAliasUsesLastValueType)$' -count=1\n- go build -o memcp