### PR TITLE
fix: tighten dashboard processlist lifecycle

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -712,7 +712,7 @@ document.addEventListener("DOMContentLoaded",function(){
 var sel=document.getElementById("errors-db-filter");
 if(sel)sel.addEventListener("change",function(){_errorsDbFilter=this.value;_errorsPage=0;renderErrorsTable();});
 var arcb=document.getElementById("errors-autorefresh");
-if(arcb)arcb.addEventListener("change",function(){if(this.checked)startErrorsAutoRefresh();else stopErrorsAutoRefresh();});
+if(arcb)arcb.addEventListener("change",function(){syncDashboardPolling();});
 var btn=document.getElementById("btn-clear-errors");
 if(btn)btn.addEventListener("click",function(){
 if(!confirm("Clear all error log entries?"))return;
@@ -776,7 +776,7 @@ if(_logsAutoRefreshTimer){clearInterval(_logsAutoRefreshTimer);_logsAutoRefreshT
 
 document.addEventListener("DOMContentLoaded",function(){
 var cb=document.getElementById("logs-autorefresh");
-if(cb)cb.addEventListener("change",function(){if(this.checked)startLogsAutoRefresh();else stopLogsAutoRefresh();});
+if(cb)cb.addEventListener("change",function(){syncDashboardPolling();});
 var btn=document.getElementById("btn-clear-logs");
 if(btn)btn.addEventListener("click",function(){
 if(!confirm("Clear all log entries?"))return;
@@ -820,14 +820,15 @@ fetch(base+"/dashboard/api/whoami",{credentials:"same-origin"}).then(function(r)
 isAdmin=!!d.admin;
 defaultPassword=!!d.default_password;
 applyAdminState();
-if(isAdmin)connect();
 route();
 }).catch(function(){route();});
 
 /* WebSocket for gauges (admin only) */
 var statusEl=document.getElementById("status");
-var ws,retry=0;
+var ws,retry=0,wsWanted=false;
 function connect(){
+if(!wsWanted)return;
+if(ws&&(ws.readyState===WebSocket.OPEN||ws.readyState===WebSocket.CONNECTING))return;
 var proto=location.protocol==="https:"?"wss:":"ws:";
 ws=new WebSocket(proto+"//"+location.host+base+"/ws/dashboard");
 ws.onopen=function(){
@@ -861,6 +862,12 @@ var epsMax=Math.max(1,Math.pow(10,Math.ceil(Math.log10(Math.max(eps,1)))));
 setGauge("g-eps",eps/epsMax,eps+" err/s",eps===0?"no errors":"scale: 0-"+epsMax);
 };
 ws.onclose=function(){
+ws=null;
+if(!wsWanted){
+statusEl.textContent="Disconnected";
+statusEl.className="status-bar disconnected";
+return;
+}
 statusEl.textContent="Disconnected - reconnecting...";
 statusEl.className="status-bar disconnected";
 retry++;
@@ -869,9 +876,59 @@ setTimeout(connect,Math.min(1000*Math.pow(2,retry),30000));
 ws.onerror=function(){ws.close()};
 }
 
+function disconnectDashboardSocket(){
+wsWanted=false;
+retry=0;
+if(ws){
+var cur=ws;
+ws=null;
+cur.onclose=null;
+try{cur.close()}catch(_){}
+}
+statusEl.textContent="Disconnected";
+statusEl.className="status-bar disconnected";
+}
+
 /* SPA hash routing */
-var views=document.querySelectorAll("#view-gauges,#view-users,#view-settings,#view-databases,#view-tables,#view-detail,#view-shard");
+var views=document.querySelectorAll(".view");
 var _sidebarViewIds=["view-databases","view-tables","view-detail","view-shard"];
+
+function isViewActive(id){
+var el=document.getElementById(id);
+return !!(el&&el.classList.contains("active"));
+}
+
+function syncDashboardSocket(){
+var shouldRun=isAdmin&&!document.hidden&&isViewActive("view-gauges");
+if(shouldRun){
+wsWanted=true;
+connect();
+} else {
+disconnectDashboardSocket();
+}
+}
+
+function syncDashboardPolling(){
+var pageVisible=!document.hidden;
+var errorsActive=pageVisible&&isViewActive("view-databases")&&_dbsTab==="errors";
+var logsActive=pageVisible&&isViewActive("view-databases")&&_dbsTab==="logs";
+var processlistActive=pageVisible&&isViewActive("view-processlist");
+var errorsCb=document.getElementById("errors-autorefresh");
+var logsCb=document.getElementById("logs-autorefresh");
+var plCb=document.getElementById("pl-auto-refresh");
+if(errorsActive&&errorsCb&&errorsCb.checked)startErrorsAutoRefresh();else stopErrorsAutoRefresh();
+if(logsActive&&logsCb&&logsCb.checked)startLogsAutoRefresh();else stopLogsAutoRefresh();
+if(processlistActive&&plCb&&plCb.checked)startPlAutoRefresh();else stopPlAutoRefresh();
+syncDashboardSocket();
+}
+
+function refreshActiveDashboardView(){
+if(document.hidden)return;
+if(isViewActive("view-processlist"))loadProcesslist();
+if(isViewActive("view-databases")&&_dbsTab==="errors")loadErrors();
+if(isViewActive("view-databases")&&_dbsTab==="logs")loadLogs();
+syncDashboardPolling();
+}
 
 function showView(id){
 for(var i=0;i<views.length;i++)views[i].classList.remove("active");
@@ -879,6 +936,7 @@ var sw=document.getElementById("sidebar-wrap");
 sw.style.display=_sidebarViewIds.indexOf(id)>=0?"flex":"none";
 var el=document.getElementById(id);
 if(el)el.classList.add("active");
+syncDashboardPolling();
 }
 
 function setBreadcrumb(parts){
@@ -1013,6 +1071,7 @@ consoleTa.value=defaultQueries[defSyn]||"";
 loadConsoleDatabases(function(){consoleTa.focus();});
 renderHistory();
 }
+syncDashboardPolling();
 }
 function _switchDbsTabQuiet(tab){
 _dbsTab=tab;
@@ -1023,6 +1082,7 @@ var b=document.getElementById("tabbtn-dbs-"+tabs[i]);
 if(p)p.classList.toggle("active",tabs[i]===tab);
 if(b)b.classList.toggle("active",tabs[i]===tab);
 }
+syncDashboardPolling();
 }
 
 var _dbTab="tables";
@@ -1313,7 +1373,6 @@ _sidebarActiveDb=null;_sidebarActiveTbl=null;
 setBreadcrumb([]);
 _switchDbsTabQuiet("errors");
 loadErrors();
-startErrorsAutoRefresh();
 fetchSettings(function(data){
 var cb=document.getElementById("el-setting-enable");
 var inp=document.getElementById("el-setting-max");
@@ -1330,7 +1389,6 @@ _sidebarActiveDb=null;_sidebarActiveTbl=null;
 setBreadcrumb([]);
 _switchDbsTabQuiet("logs");
 loadLogs();
-startLogsAutoRefresh();
 fetchSettings(function(data){
 var cb=document.getElementById("pl-setting-enable");
 var inp=document.getElementById("pl-setting-max");
@@ -1344,7 +1402,6 @@ if(hash==="processlist"){
 if(!isAdmin){location.hash="databases";return}
 showView("view-processlist");
 loadProcesslist();
-startPlAutoRefresh();
 return;
 }
 if(hash==="settings"){
@@ -2277,6 +2334,9 @@ window.stopErrorsAutoRefresh=stopErrorsAutoRefresh;
 
 /* ── Processlist ── */
 var _plTimer=null;
+function isProcesslistVisible(){
+return isViewActive("view-processlist");
+}
 function loadProcesslist(){
 sqlFetch("SHOW FULL PROCESSLIST",function(rows){
 var tb=document.querySelector("#tbl-processlist tbody");
@@ -2288,7 +2348,7 @@ var p=rows[i];
 var info=p.Info||"";
 if(info.length>120) info=info.substring(0,120)+"\u2026";
 h+='<tr><td>'+esc(""+p.Id)+'</td><td>'+esc(p.User||"")+'</td><td>'+esc(p.Host||"")+'</td><td>'+esc(p.db||"")+'</td><td>'+esc(p.Command||"")+'</td><td>'+esc(""+p.Time)+'</td><td>'+esc(p.State||"")+'</td><td style="max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:.8rem" title="'+esc(p.Info||"")+'">'+esc(info)+'</td>';
-h+='<td style="white-space:nowrap"><button class="btn-warn" style="padding:2px 10px;font-size:.75rem;margin-right:4px" onclick="killQuery('+p.Id+')">Kill</button><button class="btn-warn" style="padding:2px 10px;font-size:.75rem;background:#16213e" onclick="copyQuery(this)">Copy</button></td></tr>';
+h+='<td style="white-space:nowrap"><button class="btn-warn" style="padding:2px 10px;font-size:.75rem;background:#16213e;margin-right:4px" onclick="copyQuery(this)">Copy</button><button class="btn-warn" style="padding:2px 10px;font-size:.75rem" onclick="killQuery('+p.Id+')">Kill</button></td></tr>';
 }
 tb.innerHTML=h;
 });
@@ -2303,11 +2363,21 @@ var cb=document.getElementById("pl-auto-refresh");
 if(cb&&cb.checked){_plTimer=setInterval(loadProcesslist,2000);}
 }
 function stopPlAutoRefresh(){if(_plTimer){clearInterval(_plTimer);_plTimer=null;}}
-function togglePlAutoRefresh(){
+function maybeRefreshProcesslist(){
 var cb=document.getElementById("pl-auto-refresh");
-if(cb&&cb.checked){startPlAutoRefresh();}else{stopPlAutoRefresh();}
+if(!cb||!cb.checked||!isProcesslistVisible())return;
+loadProcesslist();
+syncDashboardPolling();
+}
+function togglePlAutoRefresh(){
+syncDashboardPolling();
 }
 function copyQuery(btn){var td=btn.parentNode.previousElementSibling;var txt=td.getAttribute("title")||td.textContent;navigator.clipboard.writeText(txt).then(function(){btn.textContent="\u2713";setTimeout(function(){btn.textContent="Copy";},1000);});}
+window.addEventListener("focus",refreshActiveDashboardView);
+document.addEventListener("visibilitychange",function(){
+if(document.hidden)syncDashboardPolling();
+else refreshActiveDashboardView();
+});
 window.killQuery=killQuery;
 window.copyQuery=copyQuery;
 window.loadProcesslist=loadProcesslist;

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -119,6 +119,16 @@ var mysqlsessions sync.Map
 // mysqlStates maps driver session ID -> *SessionState for SHOW PROCESSLIST
 var mysqlStates sync.Map
 
+func refreshMySQLSessionProcesslistMeta(session *driver.Session) {
+	if v, ok := mysqlStates.Load(session.ID()); ok {
+		ss := v.(*SessionState)
+		if user := session.User(); user != "" {
+			ss.User = user
+		}
+		ss.SetDB(session.Schema())
+	}
+}
+
 func (m *MySQLWrapper) ServerVersion() string {
 	return "MemCP"
 }
@@ -129,6 +139,7 @@ func (m *MySQLWrapper) NewSession(session *driver.Session) {
 	mysqlsessions.Store(session.ID(), NewSession().Func())
 	ss := RegisterSession(session.User(), session.Addr(), session.Schema())
 	mysqlStates.Store(session.ID(), ss)
+	refreshMySQLSessionProcesslistMeta(session)
 }
 func (m *MySQLWrapper) SessionInc(session *driver.Session) {
 	// I think we can skip session counting
@@ -161,12 +172,7 @@ func (m *MySQLWrapper) AuthCheck(session *driver.Session) error {
 	if !session.TestPassword([]byte(password.String())) {
 		return sqldb.NewSQLError(sqldb.ER_ACCESS_DENIED_ERROR, session.User(), session.Addr(), "YES")
 	}
-	// Update the processlist User field now that auth is complete.
-	// NewSession runs before the auth handshake is parsed, so session.User()
-	// was empty at registration time.
-	if v, ok := mysqlStates.Load(session.ID()); ok {
-		v.(*SessionState).User = session.User()
-	}
+	refreshMySQLSessionProcesslistMeta(session)
 	return nil
 }
 func (m *MySQLWrapper) ComInitDB(session *driver.Session, database string) error {
@@ -176,6 +182,7 @@ func (m *MySQLWrapper) ComInitDB(session *driver.Session, database string) error
 		return sqldb.NewSQLErrorf(sqldb.ER_ACCESS_DENIED_ERROR, "access denied for database %s", database)
 	}
 	session.SetSchema(database)
+	refreshMySQLSessionProcesslistMeta(session)
 	return nil
 }
 func MySQLToScmer(v sqltypes.Value) Scmer {
@@ -301,10 +308,10 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	defer close(queryDone)
 	if v, ok := mysqlStates.Load(session.ID()); ok {
 		ss = v.(*SessionState)
+		refreshMySQLSessionProcesslistMeta(session)
 		ss.Touch()
 		querySeq = ss.BeginQuery("Query", query)
 		ss.SetCancel(querySeq, queryCancel)
-		ss.SetDB(session.Schema())
 	}
 	if doneSession, ok := any(session).(mysqlSessionDone); ok {
 		go func() {

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -18,6 +18,7 @@ package scm
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -174,6 +175,21 @@ func (s *SessionState) IsKilled() bool {
 	return s.killed != nil && s.killed[seq]
 }
 
+func formatKillLog(s *SessionState, action string) string {
+	info := strPtr(&s.Info)
+	if len(info) > 160 {
+		info = info[:160] + "..."
+	}
+	if info == "" {
+		return fmt.Sprintf("kill %s id=%d user=%s host=%s db=%s", action, s.ID, s.User, s.Host, strPtr(&s.DB))
+	}
+	return fmt.Sprintf("kill %s id=%d user=%s host=%s db=%s sql=%s", action, s.ID, s.User, s.Host, strPtr(&s.DB), info)
+}
+
+func logKill(s *SessionState, action string) {
+	TracePrintFunc(formatKillLog(s, action))
+}
+
 // Kill marks the session as killed and fires the cancel function if set.
 // Returns true if at least one running query was cancelled.
 func (s *SessionState) Kill() bool {
@@ -196,6 +212,7 @@ func (s *SessionState) Kill() bool {
 	for _, fn := range fns {
 		fn()
 	}
+	logKill(s, "session")
 	return true
 }
 
@@ -219,6 +236,7 @@ func (s *SessionState) KillQuery(seq uint64) bool {
 	if fn != nil {
 		fn()
 	}
+	logKill(s, fmt.Sprintf("query seq=%d", seq))
 	return true
 }
 

--- a/scm/processlist_test.go
+++ b/scm/processlist_test.go
@@ -19,6 +19,7 @@ package scm
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -82,4 +83,32 @@ func TestKillQueryMarksOnlyCurrentGeneration(t *testing.T) {
 	})
 	ss.EndQuery(seq1, "Sleep", "")
 	ss.EndQuery(seq2, "Sleep", "")
+}
+
+func TestKillSessionLogsKilledQuery(t *testing.T) {
+	ss := RegisterSession("u", "h", "db")
+	defer UnregisterSession(ss.ID)
+
+	seq := ss.BeginQuery("Query", "SELECT 42")
+	defer ss.EndQuery(seq, "Sleep", "")
+
+	var msgs []string
+	oldTracePrint := TracePrintFunc
+	TracePrintFunc = func(msg string) {
+		msgs = append(msgs, msg)
+	}
+	defer func() {
+		TracePrintFunc = oldTracePrint
+	}()
+
+	ss.SetCancel(seq, func() {})
+	if !KillSession(ss.ID) {
+		t.Fatalf("expected session kill to succeed")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected one kill log message, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "kill session") || !strings.Contains(msgs[0], "SELECT 42") {
+		t.Fatalf("unexpected kill log: %q", msgs[0])
+	}
 }


### PR DESCRIPTION
## What
- log successful query kills through the existing TracePrint/PrintLog path so they show up in the print log when enabled
- keep MySQL processlist metadata refreshed so the `User` column is populated reliably
- fix the dashboard processlist view leaking into other menus by treating all `.view` panels uniformly
- only keep the gauges websocket alive while the gauges view is visible
- only keep processlist/log/error auto-refresh timers alive while their view/tab is active and visible
- refresh the active dashboard view when the browser tab/window becomes visible again
- render processlist actions as `Copy` then `Kill`

## Verification
- `gofmt -w scm/processlist.go scm/processlist_test.go scm/mysql.go`
- `go test ./scm github.com/launix-de/go-mysqlstack/driver -run 'Test(SessionStateTouchUpdatesLastUsed|EvictHTTPSessionReleasesLocksAndKillsQuery|KillQueryMarksOnlyCurrentGeneration|KillSessionLogsKilledQuery|AppendMySQLResultRowDuplicateAliasUsesLastValueType|SessionDoneClosesOnClose)$' -count=1`
- `go build -o memcp`

## Note
- `make test` was run, but the full harness hit failures in `tests/84_information_schema.yaml` and `tests/92_parallel_projection.yaml`, both outside this change area. The dashboard/session lifecycle changes themselves are covered by the targeted tests above.
