### PR TITLE
perf: prune unreferenced LEFT JOINed tables

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -825,6 +825,18 @@ planner starts splitting aggregate conditions apart. */
 	)
 ))
 
+/* extract_all_table_aliases: return a flat list of all table aliases referenced
+   via get_column nodes in an expression.  Used by LEFT JOIN pruning to detect
+   which tables are actually read. */
+(define extract_all_table_aliases (lambda (expr)
+	(match expr
+		'((symbol get_column) alias_ _ _ _) (if (nil? alias_) '() (list (string alias_)))
+		'((quote get_column) alias_ _ _ _) (if (nil? alias_) '() (list (string alias_)))
+		(cons sym args) (merge (map args extract_all_table_aliases))
+		'()
+	)
+))
+
 /* extract_scanned_tables: walk an expression AST and return all (schema table) pairs from scan/scan_order calls.
 Used to detect which tables a computor lambda reads from, so we can register invalidation triggers. */
 (define extract_scanned_tables (lambda (expr)
@@ -3645,6 +3657,20 @@ or generate runtime scan code (build_queryplan).
 	(set order (map order (lambda (o) (match o '(col dir) (list (finalize_visible_expr col) dir)))))
 
 	(set having (finalize_visible_expr having))
+
+	/* LEFT JOIN pruning: remove LEFT JOINed tables that are not referenced
+	   anywhere in the query (fields, condition, having, order, or sibling
+	   joinexprs). A LEFT JOIN that is never read contributes only NULL columns
+	   and cannot filter rows, so it is safe to drop entirely. */
+	(define _all_referenced_aliases (merge_unique (list
+		(extract_all_table_aliases fields)
+		(extract_all_table_aliases conditionAll)
+		(extract_all_table_aliases (coalesceNil having true))
+		(merge (map (coalesceNil order '()) (lambda (o) (extract_all_table_aliases o))))
+		(merge (map tables (lambda (td) (match td '(_ _ _ _ je) (if (nil? je) '() (extract_all_table_aliases je)) '())))))))
+	(set tables (filter tables (lambda (td) (match td
+		'(alias _ _ isOuter _) (or (not isOuter) (has? _all_referenced_aliases (string alias)))
+		true))))
 
 	(define groups (merge
 		(coalesceNil _sq_pstages '())


### PR DESCRIPTION
## Summary
After column pruning (#146) removes unused derived-table columns, some LEFT JOINed tables may no longer be referenced anywhere. These orphaned LEFT JOINs only contribute NULL columns and cannot filter rows — safe to remove entirely.

Example: `SELECT COUNT(*) FROM (SELECT t.*, p.permission FROM t LEFT JOIN permissions p ON ...) sub` — after column pruning removes `p.permission`, the LEFT JOIN on `permissions` has no remaining references and is dropped.

## Implementation
- `extract_all_table_aliases`: new helper that collects all table aliases from `get_column` nodes
- After `finalize_visible_expr` pass: filter out LEFT JOIN tables (`isOuter=true`) whose alias doesn't appear in fields, condition, having, order, or sibling joinexprs

## Test plan
- [x] 12_joins_outer: 3/3
- [x] 66_join_complex: 5/5
- [x] 66_left_join_correlated_on: 10/10
- [x] 32_expr_subselects: 34/34
- [x] 69_subquery_complex: 4/4
- [x] All other suites: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)