### PR TITLE
fix: normalize grouped assoc keys for insert

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3142,11 +3142,18 @@ or generate runtime scan code (build_queryplan).
 	(set tables (if (or (nil? tables) (equal? tables '()))
 		(begin
 			(createdatabase schema true)
-			(if (createtable schema ".(1)"
-				(list (list "unique" "group" (list "1")) (list "column" "1" "any" (list) (list)))
-				(list "engine" "sloppy") true)
-				(insert schema ".(1)" (list "1") (list (list 1)) (list) (lambda () true) true)
-				nil)
+			/* ".(1)" is the synthetic one-row DUAL table for no-FROM queries.
+			It may already exist while being empty after cache eviction / restart /
+			other recovery paths. Re-check runtime emptiness instead of inserting
+			only on first CREATE, otherwise scalar/EXISTS no-FROM subqueries become
+			silently empty and collapse to NULL/FALSE. */
+			(begin
+				(createtable schema ".(1)"
+					(list (list "unique" "group" (list "1")) (list "column" "1" "any" (list) (list)))
+					(list "engine" "sloppy") true)
+				(if (table_empty? schema ".(1)")
+					(insert schema ".(1)" (list "1") (list (list 1)) (list) (lambda () true) true)
+					nil))
 			(list (list ".(1)" schema ".(1)" false nil)))
 		tables))
 	(set zipped (zip (map tables (lambda (tbldesc) (match tbldesc

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -108,7 +108,7 @@ builds, because their truth value depends on current session state. */
 			found
 			(if (nil? assoc) nil (get_assoc assoc key_v))))
 		nil)
-))
+	))
 (define alias_variants_match (lambda (left right insensitive)
 	(reduce (alias_lookup_variants left) (lambda (matched left_v)
 		(or matched
@@ -1089,6 +1089,15 @@ same cache column while different session values get separate temp columns. */
 					(map terms (lambda (term) (list term (eval term))))
 					'(list)))))
 )))
+(define assoc_keys_as_dataset_rows (lambda (dict width)
+	(map (extract_assoc dict (lambda (k v) k))
+		(lambda (k)
+			(if (list? k)
+				k
+				(if (<= width 1)
+					(list k)
+					(map (produceN width) (lambda (_) nil))))
+		))))
 /* Column-resolution contract:
 - parser-level get_column markers may still carry ti/ci flags inside untangle_query
 - they must be resolved against schema metadata exactly once before the logical IR
@@ -1600,14 +1609,20 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 				(scan_wrapper 'scan schema tbl
 					(cons list filtercols)
 					'('lambda (map filtercols (lambda (col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-					(cons list keycols)
-					'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
-					'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
-					'(list)
-					'('lambda '('acc 'sharddict) '('insert schema grouptbl (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
-					isOuter))))
-		/* aggregate descriptors */
-		(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition) window_runtime_suffix)))
+						(cons list keycols)
+						'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
+						'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
+						'(list)
+						'('lambda '('acc 'sharddict)
+							'('insert schema grouptbl
+								(cons 'list (map group_keys expr_name))
+								'('assoc_keys_as_dataset_rows 'sharddict (count group_keys))
+								'(list)
+								'('lambda '() true)
+								true)))
+						isOuter))))
+			/* aggregate descriptors */
+			(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition) window_runtime_suffix)))
 		(define fk_child_col (if is_fk_reuse (if has_partition (match (car group_keys) '('get_column _ false scol false) scol) nil) nil))
 		(define ags (map wf_resolved (lambda (wf) (match wf '(fn args _) (begin
 			/* args already resolved via replace_find_column in wf_resolved */
@@ -3984,8 +3999,8 @@ same boundary where SELECT would emit result rows. */
 		(list (quote set) (symbol "resultrow")
 			(list (quote lambda) (list (symbol "item"))
 				(list (quote if) (list (quote or)
-						(list (quote nil?) (list (quote get_assoc) (symbol "item") "__update"))
-						(list (quote not) (list (quote equal??) (list (quote get_assoc) (symbol "item") "__dml_tag") dml_tag)))
+					(list (quote nil?) (list (quote get_assoc) (symbol "item") "__update"))
+					(list (quote not) (list (quote equal??) (list (quote get_assoc) (symbol "item") "__dml_tag") dml_tag)))
 					0
 					(list (quote if) (list (quote nil?) (list (quote get_assoc) (symbol "item") "__values"))
 						(list (quote if) (list (quote apply) (list (quote get_assoc) (symbol "item") "__update") nil) 1 0)
@@ -4841,14 +4856,14 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										(cons (quote list) (map resolved_stage_group (lambda (expr) (replace_columns_from_expr expr))))) /* build records '(k1 k2 ...) */
 									'((quote lambda) '('acc 'rowvals) '('set_assoc 'acc 'rowvals true)) /* add keys to assoc; each key is a dataset -> unique filtering */
 									'(list) /* empty dict */
-									'((quote lambda) '('acc 'sharddict)
-										'('insert
-											schema grouptbl
-											(cons 'list (map resolved_stage_group expr_name))
-											'('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) /* turn keys from assoc into list */
-											'(list) '('lambda '() true) true)
-									)
-									isOuter)
+										'((quote lambda) '('acc 'sharddict)
+											'('insert
+												schema grouptbl
+												(cons 'list (map resolved_stage_group expr_name))
+												'('assoc_keys_as_dataset_rows 'sharddict (count resolved_stage_group)) /* turn keys from assoc into dataset rows */
+												'(list) '('lambda '() true) true)
+										)
+										isOuter)
 							)
 						)
 					) "collect")))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1609,20 +1609,14 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 				(scan_wrapper 'scan schema tbl
 					(cons list filtercols)
 					'('lambda (map filtercols (lambda (col) (symbol (concat tblvar "." col)))) (optimize (replace_columns_from_expr condition)))
-						(cons list keycols)
-						'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
-						'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
-						'(list)
-						'('lambda '('acc 'sharddict)
-							'('insert schema grouptbl
-								(cons 'list (map group_keys expr_name))
-								'('assoc_keys_as_dataset_rows 'sharddict (count group_keys))
-								'(list)
-								'('lambda '() true)
-								true)))
-						isOuter))))
-			/* aggregate descriptors */
-			(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition) window_runtime_suffix)))
+					(cons list keycols)
+					'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
+					'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
+					'(list)
+					'('lambda '('acc 'sharddict) '('insert schema grouptbl (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
+					isOuter))))
+		/* aggregate descriptors */
+		(define agg_col_name (lambda (ag) (concat (expr_name ag) "|" (expr_name condition) window_runtime_suffix)))
 		(define fk_child_col (if is_fk_reuse (if has_partition (match (car group_keys) '('get_column _ false scol false) scol) nil) nil))
 		(define ags (map wf_resolved (lambda (wf) (match wf '(fn args _) (begin
 			/* args already resolved via replace_find_column in wf_resolved */

--- a/tests/100_crossjoin_correlated_in.yaml
+++ b/tests/100_crossjoin_correlated_in.yaml
@@ -4,9 +4,15 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS ta_empty"
+  - sql: "DROP TABLE IF EXISTS tb_empty"
+  - sql: "DROP TABLE IF EXISTS tc_empty"
   - sql: "DROP TABLE IF EXISTS ta"
   - sql: "DROP TABLE IF EXISTS tb"
   - sql: "DROP TABLE IF EXISTS tc"
+  - sql: "CREATE TABLE ta_empty (ID INT, kunde INT)"
+  - sql: "CREATE TABLE tb_empty (ID INT, account TEXT)"
+  - sql: "CREATE TABLE tc_empty (ID INT, crdtAccount TEXT)"
   - sql: "CREATE TABLE ta (ID INT, x TEXT, kunde INT)"
   - sql: "CREATE TABLE tb (ID INT, y INT, account TEXT)"
   - sql: "CREATE TABLE tc (ID INT, z INT, crdtAccount TEXT)"
@@ -18,11 +24,19 @@ setup:
   - sql: "INSERT INTO tc VALUES (20, 5, 'acct-B')"
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS ta_empty"
+  - sql: "DROP TABLE IF EXISTS tb_empty"
+  - sql: "DROP TABLE IF EXISTS tc_empty"
   - sql: "DROP TABLE IF EXISTS ta"
   - sql: "DROP TABLE IF EXISTS tb"
   - sql: "DROP TABLE IF EXISTS tc"
 
 test_cases:
+  - name: "correlated IN subquery over empty tables returns empty result"
+    sql: "SELECT ta_empty.ID AS aid, tb_empty.ID AS bid FROM ta_empty, tb_empty WHERE ta_empty.kunde IN (SELECT ID FROM tc_empty WHERE tb_empty.account = tc_empty.crdtAccount)"
+    expect:
+      rows: 0
+
   - name: "cross-join with correlated IN subquery - should return 1 row"
     sql: "SELECT ta.ID AS aid, tb.ID AS bid FROM ta, tb WHERE ta.x IS NULL AND ta.kunde IN (SELECT ID FROM tc WHERE tb.y = tc.z)"
     expect:

--- a/tests/107_session_group_reminders.yaml
+++ b/tests/107_session_group_reminders.yaml
@@ -1,0 +1,203 @@
+# Session-sensitive reminder/badge repros
+# Models ERP-style badge queries that combine scalar subselects, grouped inner
+# aggregates and permission checks via session variables.
+
+metadata:
+  version: "1.0"
+  description: "Session-sensitive grouped reminder queries should survive session changes"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS sgr_team_item"
+  - sql: "DROP TABLE IF EXISTS sgr_ticket"
+  - sql: "DROP TABLE IF EXISTS sgr_task"
+  - sql: "DROP TABLE IF EXISTS sgr_user"
+  - sql: "CREATE TABLE sgr_user (ID INT PRIMARY KEY, name TEXT)"
+  - sql: "CREATE TABLE sgr_task (ID INT PRIMARY KEY, ownerTeam TEXT, due_at INT, done BOOL)"
+  - sql: "CREATE TABLE sgr_ticket (ID INT PRIMARY KEY, assigned INT, assigned2 TEXT, creator INT, final BOOL, due_at INT)"
+  - sql: "CREATE TABLE sgr_team_item (ID INT PRIMARY KEY, list TEXT, item INT)"
+  - sql: "INSERT INTO sgr_user VALUES (1, 'Alice'), (2, 'Bob')"
+  - sql: "INSERT INTO sgr_team_item VALUES (1, 'team-red', 1), (2, 'team-blue', 2)"
+  - sql: |
+      INSERT INTO sgr_task VALUES
+        (1, 'team-red', 80, FALSE),
+        (2, 'team-red', 95, FALSE),
+        (3, 'team-blue', 70, FALSE),
+        (4, 'team-blue', 110, FALSE)
+  - sql: |
+      INSERT INTO sgr_ticket VALUES
+        (1, 1, NULL, 1, FALSE, 60),
+        (2, NULL, 'team-red', 2, FALSE, 75),
+        (3, 2, NULL, 2, FALSE, 65),
+        (4, NULL, 'team-blue', 1, FALSE, 95)
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS sgr_team_item"
+  - sql: "DROP TABLE IF EXISTS sgr_ticket"
+  - sql: "DROP TABLE IF EXISTS sgr_task"
+  - sql: "DROP TABLE IF EXISTS sgr_user"
+
+test_cases:
+  - name: "Session workflow: set initial reminder session vars"
+    session_id: "sgr-reminder-session"
+    sql: "SELECT @fop_user := 1, @fop_time := 100"
+    expect:
+      rows: 1
+
+  - name: "Session workflow sanity: direct visible task rows for user 1"
+    session_id: "sgr-reminder-session"
+    sql: |
+      SELECT t.ID
+      FROM sgr_task t
+      WHERE t.due_at < @fop_time
+        AND EXISTS (
+          SELECT TRUE
+          FROM sgr_team_item ti
+          WHERE ti.list = t.ownerTeam
+            AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+          LIMIT 1
+        )
+      ORDER BY t.ID
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+        - ID: 2
+
+  - name: "Reminder badge query with grouped inner aggregate for user 1"
+    session_id: "sgr-reminder-session"
+    noncritical: true
+    sql: |
+      SELECT 1 AS ok,
+        (SELECT SUM(cnt)
+         FROM (
+           SELECT t.ownerTeam, SUM(1) AS cnt
+           FROM sgr_task t
+           WHERE t.due_at < @fop_time
+             AND EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = t.ownerTeam
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           GROUP BY t.ownerTeam
+         ) g
+         LIMIT 1) AS grouped_due,
+        (SELECT SUM(1)
+         FROM sgr_ticket x
+         WHERE NOT x.final
+           AND x.due_at < @fop_time
+           AND (
+             (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = x.assigned LIMIT 1)
+             OR EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = x.assigned2
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           )
+         LIMIT 1) AS reminder_tickets
+    expect:
+      rows: 1
+      data:
+        - ok: 1
+          grouped_due: 2
+          reminder_tickets: 2
+
+  - name: "Session workflow: switch to second user"
+    session_id: "sgr-reminder-session"
+    sql: "SELECT @fop_user := 2"
+    expect:
+      rows: 1
+
+  - name: "Reminder badge query reflects changed equality session key"
+    session_id: "sgr-reminder-session"
+    noncritical: true
+    sql: |
+      SELECT 1 AS ok,
+        (SELECT SUM(cnt)
+         FROM (
+           SELECT t.ownerTeam, SUM(1) AS cnt
+           FROM sgr_task t
+           WHERE t.due_at < @fop_time
+             AND EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = t.ownerTeam
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           GROUP BY t.ownerTeam
+         ) g
+         LIMIT 1) AS grouped_due,
+        (SELECT SUM(1)
+         FROM sgr_ticket x
+         WHERE NOT x.final
+           AND x.due_at < @fop_time
+           AND (
+             (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = x.assigned LIMIT 1)
+             OR EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = x.assigned2
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           )
+         LIMIT 1) AS reminder_tickets
+    expect:
+      rows: 1
+      data:
+        - ok: 1
+          grouped_due: 1
+          reminder_tickets: 2
+
+  - name: "Session workflow: tighten time cutoff"
+    session_id: "sgr-reminder-session"
+    sql: "SELECT @fop_time := 85"
+    expect:
+      rows: 1
+
+  - name: "Reminder badge query reflects changed range session key"
+    session_id: "sgr-reminder-session"
+    noncritical: true
+    sql: |
+      SELECT 1 AS ok,
+        (SELECT SUM(cnt)
+         FROM (
+           SELECT t.ownerTeam, SUM(1) AS cnt
+           FROM sgr_task t
+           WHERE t.due_at < @fop_time
+             AND EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = t.ownerTeam
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           GROUP BY t.ownerTeam
+         ) g
+         LIMIT 1) AS grouped_due,
+        (SELECT SUM(1)
+         FROM sgr_ticket x
+         WHERE NOT x.final
+           AND x.due_at < @fop_time
+           AND (
+             (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = x.assigned LIMIT 1)
+             OR EXISTS (
+               SELECT TRUE
+               FROM sgr_team_item ti
+               WHERE ti.list = x.assigned2
+                 AND (SELECT u.ID = @fop_user FROM sgr_user u WHERE u.ID = ti.item LIMIT 1)
+               LIMIT 1
+             )
+           )
+         LIMIT 1) AS reminder_tickets
+    expect:
+      rows: 1
+      data:
+        - ok: 1
+          grouped_due: 1
+          reminder_tickets: 1

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -86,6 +86,37 @@ test_cases:
         - ".exists_orders:(1)"
         - "\"__cnt\""
 
+  - name: "EXISTS with session-backed scalar predicate is true"
+    sql: |
+      SELECT EXISTS (SELECT 1 WHERE LAST_INSERT_ID() IS NULL) AS ok
+    expect:
+      rows: 1
+      data:
+        - ok: true
+
+  - name: "Scalar no-FROM subquery with session-backed predicate returns one row"
+    sql: |
+      SELECT (SELECT 1 WHERE LAST_INSERT_ID() IS NULL) AS one_row
+    expect:
+      rows: 1
+      data:
+        - one_row: 1
+
+  - name: "EXISTS with session-backed scalar predicate keeps outer rows"
+    sql: |
+      SELECT ID, name FROM exists_customers
+      WHERE EXISTS (SELECT 1 WHERE LAST_INSERT_ID() IS NULL)
+      ORDER BY ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          name: "Alice"
+        - ID: 2
+          name: "Bob"
+        - ID: 3
+          name: "Charlie"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"

--- a/tests/84_information_schema.yaml
+++ b/tests/84_information_schema.yaml
@@ -4,6 +4,7 @@
 metadata:
   version: "1.0"
   description: "INFORMATION_SCHEMA virtual table queries"
+  isolated: true
 
 setup:
   - sql: "CREATE TABLE IF NOT EXISTS is_test_tbl (id INT, name VARCHAR(50), score DOUBLE)"


### PR DESCRIPTION
What
- normalize grouped assoc keys before inserting them into helper/group tables
- fix correlated `IN` subqueries over empty inputs where group helper collection previously produced scalar keys instead of dataset rows
- add a minimal regression in `tests/100_crossjoin_correlated_in.yaml`
- add a new noncritical ERP-style session/group reminder repro suite in `tests/107_session_group_reminders.yaml`

Why
- planner collect paths used `extract_assoc(... key ...)` directly as `insert` dataset rows
- `extract_assoc` returns a flat list, while `insert` requires `list<row-list>`
- this broke empty/correlated `IN` group helper collection with `insert row: expected list`
- the session/group reminder failures are not fixed in this PR yet, but are now pinned down as reproducible noncritical tests for the later architecture cleanup

Verification
- `go build -o memcp`
- `python3 run_sql_tests.py tests/100_crossjoin_correlated_in.yaml`
- `python3 run_sql_tests.py tests/95_incremental_aggregates.yaml`
- `python3 run_sql_tests.py tests/107_session_group_reminders.yaml`