### PR TITLE
fix: preserve daemon sessions and expose mysql session identity

### DIFF
--- a/lib/sql-builtins.scm
+++ b/lib/sql-builtins.scm
@@ -1,3 +1,20 @@
+/*
+Copyright (C) 2023 - 2026  Carl-Philip Hänsch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 (define sql_builtins (coalesce sql_builtins (newsession)))
 
 /* all upper case */
@@ -116,6 +133,19 @@
 (sql_builtins "VECTOR_DIM" json_encode)
 
 /* session / processlist */
+(sql_builtins "DATABASE" (lambda () (coalesceNil (session "schema") nil)))
+(sql_builtins "CURRENT_USER" (lambda () (match (session "username")
+	nil nil
+	username (concat username "@%")
+)))
+(sql_builtins "USER" (lambda () (match (session "username")
+	nil nil
+	username (concat username "@%")
+)))
+(sql_builtins "SESSION_USER" (lambda () (match (session "username")
+	nil nil
+	username (concat username "@%")
+)))
 (sql_builtins "CONNECTION_ID" connection_id)
 (sql_builtins "KILL_QUERY" kill_query)
 

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -213,6 +213,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						)
 						(context "session")
 					))
+					(session "username" (req "username"))
+					(session "schema" schema)
 					/* Bind URL query params (v1=, v2=, ...) as prepared-statement args into the session
 					before parse/build so session-sensitive planner rewrites see the right values. */
 					(extract_assoc (req "query") (lambda (k v) (session k v)))
@@ -255,6 +257,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					((res "header") "Content-Type" "text/plain")
 					(define resultrow (res "jsonl"))
 					(define session (context "session"))
+					(session "username" (req "username"))
+					(session "schema" schema)
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
 					(set last_row nil)
@@ -313,6 +317,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 				(try (lambda () (begin
 					((res "header") "Content-Type" "application/json")
 					(define session (context "session"))
+					(session "username" (req "username"))
+					(session "schema" "")
 					(set result (eval (scheme code)))
 					((res "print") (json_encode result))
 				)) (lambda(e) (begin
@@ -377,6 +383,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 (set mysql_auth (lambda (username_) (scan nil "system" "user" '("username") (lambda (username) (equal? username username_)) '("password") (lambda (password) password) (lambda (a b) b) nil)))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
 (set mysql_handler (lambda (schema sql resultrow_sql session) (begin
+	(session "schema" schema)
 	(define resultrow resultrow_sql)
 	(try (lambda () (begin
 		(if (equal? (session "syntax") "scheme") (begin

--- a/main.go
+++ b/main.go
@@ -758,6 +758,9 @@ func main() {
 
 	// REPL shell or wait for signal
 	if noRepl {
+		// In daemon mode, the parent shell may send SIGHUP when its job control
+		// session ends. Ignore it so backgrounded servers keep running.
+		signal.Ignore(syscall.SIGHUP)
 		signal.Stop(cancelChan) // stop duplicate handler; this goroutine handles the signal
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -366,6 +366,8 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	// result from scheme
 	sessionFunc := scmSessionAny.(func(...Scmer) Scmer)
 	scmSessionScmer := NewFunc(sessionFunc)
+	sessionFunc(NewString("username"), NewString(session.User()))
+	sessionFunc(NewString("schema"), NewString(session.Schema()))
 	// Populate bind variables (v1, v2, ...) from prepared-statement params into session
 	for name, bv := range bindVariables {
 		if bv == nil {

--- a/tests/02_functions.yaml
+++ b/tests/02_functions.yaml
@@ -103,6 +103,22 @@ test_cases:
         - upper_case: "HELLO"
           lower_case: "world"
 
+  - name: "DATABASE function"
+    sql: "SELECT DATABASE() AS db"
+    expect:
+      rows: 1
+      data:
+        - db: "memcp-tests"
+
+  - name: "CURRENT_USER function"
+    sql: "SELECT CURRENT_USER() AS current_user, USER() AS user_name, SESSION_USER() AS session_user"
+    expect:
+      rows: 1
+      data:
+        - current_user: "root@%"
+          user_name: "root@%"
+          session_user: "root@%"
+
   # === BASE64 FUNCTIONS ===
   - name: "TO_BASE64 encodes"
     sql: "SELECT TO_BASE64('foo') AS b64"

--- a/tests/21_grant_revoke.yaml
+++ b/tests/21_grant_revoke.yaml
@@ -5,6 +5,8 @@ metadata:
   description: "User privileges: GRANT and REVOKE"
 
 setup:
+  - sql: "DROP TABLE IF EXISTS grant_t"
+    expect: {}
   - sql: "DELETE FROM `system`.`access` WHERE username='alice'"
     expect: {}
   - sql: "DELETE FROM `system`.`user` WHERE username='alice'"
@@ -16,6 +18,10 @@ setup:
   - sql: "DELETE FROM `system`.`access` WHERE username='psqlrole'"
     expect: {}
   - sql: "DELETE FROM `system`.`user` WHERE username='psqlrole'"
+    expect: {}
+  - sql: "DELETE FROM `system`.`access` WHERE username='hostalice'"
+    expect: {}
+  - sql: "DELETE FROM `system`.`user` WHERE username='hostalice'"
     expect: {}
 
 test_cases:
@@ -52,6 +58,29 @@ test_cases:
 
   - name: "Verify access entry exists"
     sql: "SELECT database FROM system.access WHERE username='alice' AND database='memcp-tests'"
+    expect:
+      rows: 1
+      data:
+        - { database: "memcp-tests" }
+
+  - name: "CREATE USER with MySQL host syntax"
+    sql: "CREATE USER 'hostalice'@'%' IDENTIFIED BY 'pw'"
+    expect:
+      affected_rows: 1
+
+  - name: "host syntax stores stripped username"
+    sql: "SELECT username FROM system.user WHERE username='hostalice'"
+    expect:
+      rows: 1
+      data:
+        - { username: "hostalice" }
+
+  - name: "GRANT with MySQL host syntax creates access entry"
+    sql: "GRANT ALL PRIVILEGES ON `memcp-tests`.* TO 'hostalice'@'%'"
+    expect: {}
+
+  - name: "Verify host syntax access entry exists"
+    sql: "SELECT database FROM system.access WHERE username='hostalice' AND database='memcp-tests'"
     expect:
       rows: 1
       data:
@@ -315,8 +344,10 @@ test_cases:
         - { cnt: 0 }
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS grant_t"
   - sql: "DROP USER IF EXISTS alice"
   - sql: "DROP USER IF EXISTS bob"
+  - sql: "DROP USER IF EXISTS hostalice"
   - sql: "DROP USER IF EXISTS psqlalice"
   - sql: "DROP USER IF EXISTS psqlrole"
   - sql: "DROP DATABASE IF EXISTS drop_test_db"


### PR DESCRIPTION
Summary:
- ignore `SIGHUP` in `--no-repl` mode so backgrounded memcp processes keep running after the parent shell exits
- expose session identity (`username`, `schema`) to SQL builtins and add MySQL-compatible `CURRENT_USER()`, `USER()`, `SESSION_USER()`, and `DATABASE()`
- add regression coverage for host-qualified `CREATE USER`/`GRANT` syntax and the session identity builtins

Why:
- real application MySQL tests revealed two regressions in the debug/compatibility path: daemonized runs were fragile, and authenticated SQL sessions were missing the identity/schema context expected by MySQL-style helper functions

Validation:
- `python3 run_sql_tests.py tests/02_functions.yaml tests/21_grant_revoke.yaml`
- live MySQL wire check on `3307`: `CREATE USER ...`, `GRANT ...`, login, `SELECT DATABASE(), CURRENT_USER()`

Notes:
- the original worktree still contains an unrelated uncommitted formatting-only change in `lib/sql-metadata.scm`; it is not part of this PR