### PR TITLE
fix: move storage.Clean() after init to prevent concurrent map crash

### DIFF
--- a/main.go
+++ b/main.go
@@ -673,7 +673,6 @@ func main() {
 	gls.Go(func() {
 		defer close(initDone)
 		storage.LoadDatabases()
-		go storage.Clean() // remove crash-orphaned blobs and shard files in background
 		// scripts initialization
 		if len(imports) == 0 {
 			// search for lib/main.scm in well-known locations
@@ -726,6 +725,7 @@ func main() {
 		}
 	})
 	<-initDone
+	go storage.Clean() // remove crash-orphaned blobs/shard files after init completes
 
 	// install exit handler
 	cancelChan := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary
- Move `go storage.Clean()` from inside the init goroutine (before Scheme file loading) to after `<-initDone`
- Prevents fatal "concurrent map read and map write" when Clean's background scans read `Globalenv.Vars` while `define`/`set` from `.scm` loading writes to it
- Reproduces on systems with large data directories where Clean overlaps with init

## Test plan
- [ ] Start memcp with a large data directory (many tables/shards) and verify no crash
- [ ] Verify orphaned blob/shard cleanup still runs after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)