### PR TITLE
fix session-aware scan regressions after master merge

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2556,41 +2556,41 @@ seeing the correctly prefixed outer alias. */
 								(define agg_item (nth _agg_args 0))
 								(define agg_reduce (nth _agg_args 1))
 								(define agg_neutral (nth _agg_args 2))
-										(define build_scalar_agg_scan (lambda (scan_tables scan_condition)
-											(match scan_tables
-												(cons '(tblvar schema3 tbl3 isOuter3 joinexpr3) rest_tables) (begin
-													(define cur_cols (merge_unique (list
-														(extract_columns_for_tblvar tblvar scan_condition)
-														(extract_columns_for_tblvar tblvar agg_item)
-														(extract_outer_columns_for_tblvar tblvar scan_condition)
-														(extract_outer_columns_for_tblvar tblvar agg_item)
+								(define build_scalar_agg_scan (lambda (scan_tables scan_condition)
+									(match scan_tables
+										(cons '(tblvar schema3 tbl3 isOuter3 joinexpr3) rest_tables) (begin
+											(define cur_cols (merge_unique (list
+												(extract_columns_for_tblvar tblvar scan_condition)
+												(extract_columns_for_tblvar tblvar agg_item)
+												(extract_outer_columns_for_tblvar tblvar scan_condition)
+												(extract_outer_columns_for_tblvar tblvar agg_item)
 												(extract_later_joinexpr_columns_for_tblvar tblvar rest_tables)
 											)))
-													(match (split_scan_condition isOuter3 joinexpr3 scan_condition rest_tables) '(now_condition later_condition) (begin
-														(define filtercols (merge_unique (list
-															(extract_columns_for_tblvar tblvar now_condition)
-															(extract_outer_columns_for_tblvar tblvar now_condition)
-														)))
-														(define inner_body (build_scalar_agg_scan rest_tables later_condition))
-														(define filterbody (collapse_runtime_outer_refs (replace_columns_from_expr now_condition)))
-														(scan_wrapper 'scan schema3 tbl3
-															(cons list filtercols)
-															(list (quote lambda)
-																(map filtercols (lambda (col) (symbol (concat tblvar "." col))))
-																filterbody
-															)
-															(cons list cur_cols)
-															(list (quote lambda)
-																(map cur_cols (lambda (col) (symbol (concat tblvar "." col))))
-																inner_body
+											(match (split_scan_condition isOuter3 joinexpr3 scan_condition rest_tables) '(now_condition later_condition) (begin
+												(define filtercols (merge_unique (list
+													(extract_columns_for_tblvar tblvar now_condition)
+													(extract_outer_columns_for_tblvar tblvar now_condition)
+												)))
+												(define inner_body (build_scalar_agg_scan rest_tables later_condition))
+												(define filterbody (collapse_runtime_outer_refs (replace_columns_from_expr now_condition)))
+												(scan_wrapper 'scan schema3 tbl3
+													(cons list filtercols)
+													(list (quote lambda)
+														(map filtercols (lambda (col) (symbol (concat tblvar "." col))))
+														filterbody
+													)
+													(cons list cur_cols)
+													(list (quote lambda)
+														(map cur_cols (lambda (col) (symbol (concat tblvar "." col))))
+														inner_body
 													)
 													(eval agg_reduce) agg_neutral (eval agg_reduce) isOuter3
 												)
 											))
 										)
-												'() (collapse_runtime_outer_refs (replace_columns_from_expr agg_item))
-											)
-										))
+										'() (collapse_runtime_outer_refs (replace_columns_from_expr agg_item))
+									)
+								))
 								(define _init_stmts_agg (if (or (nil? _init2) (equal? _init2 '())) '() _init2))
 								(if (equal? _init_stmts_agg '())
 									(build_scalar_agg_scan tables2 condition2)
@@ -3748,13 +3748,13 @@ seeing the correctly prefixed outer alias. */
 							)
 						) false)
 						false))
-						/* Nested derived-table flattening must not descend into precomputed runtime blocks
-						from scalar subselects when they appear in JOIN conditions; those scopes carry lowered
-						scan structures that break under alias-renaming. */
-						(define subquery_has_runtime_joinexpr (reduce tables2 (lambda (acc tbl_desc) (or acc (match tbl_desc
-							'(_ _ _ _ inner_joinexpr) (if (nil? inner_joinexpr) false (expr_has_opaque_scope (replace_column_alias inner_joinexpr)))
-							_ false))) false))
-						(define use_materialize (or
+					/* Nested derived-table flattening must not descend into precomputed runtime blocks
+					from scalar subselects when they appear in JOIN conditions; those scopes carry lowered
+					scan structures that break under alias-renaming. */
+					(define subquery_has_runtime_joinexpr (reduce tables2 (lambda (acc tbl_desc) (or acc (match tbl_desc
+						'(_ _ _ _ inner_joinexpr) (if (nil? inner_joinexpr) false (expr_has_opaque_scope (replace_column_alias inner_joinexpr)))
+						_ false))) false))
+					(define use_materialize (or
 						subquery_has_window
 						unsupported_groups
 						flatten_has_dangling_output_ref
@@ -5268,7 +5268,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					(extract_columns_for_tblvar tblvar collect_condition)
 					(extract_outer_columns_for_tblvar tblvar collect_condition))))
 				(define session_sensitive_group_domain (expr_uses_session_state collect_condition))
-				/* Session-sensitive groups use a GLOBAL keytable domain (no condition suffix)
+			/* Session-sensitive groups use a GLOBAL keytable domain (no condition suffix)
 				so all group keys are present regardless of session. The per-session filtering
 				happens in createcolumn via StorageComputeProxy session variants. */
 				(define kt_result (make_keytable schema tbl resolved_stage_group tblvar
@@ -6356,9 +6356,24 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 				the raw stage expressions back onto their logical source lineage first.
 				build_scan stays the only place that finally substitutes onto the current
 				stage's physical scan symbols. */
+				(define lower_prejoin_group_expr (lambda (expr) (begin
+					(define lowered (lower_prejoin_lineage_expr expr))
+					(define projected_field
+						(reduce prejoin_columns (lambda (found mc)
+							(if (not (nil? found))
+								found
+								(if (equal? lowered (lower_prejoin_lineage_expr (cadr mc)))
+									(car mc)
+									nil)))
+							nil))
+					(if (not (nil? projected_field))
+						(list (quote get_column) prejoin_alias false projected_field false)
+						(match lowered
+							(cons sym args) (cons sym (map args lower_prejoin_group_expr))
+							lowered)))))
 				(define grouped_fields (map_assoc raw_fields (lambda (k v)
-					(lower_prejoin_lineage_expr v))))
-				(define grouped_keys (map (coalesce raw_stage_group '()) lower_prejoin_lineage_expr))
+					(lower_prejoin_group_expr v))))
+				(define grouped_keys (map (coalesce raw_stage_group '()) lower_prejoin_group_expr))
 				(define grouped_stage_alias_result (if (nil? grouped_keys)
 					nil
 					(make_keytable_schema schema prejointbl grouped_keys prejoin_alias)))
@@ -6416,10 +6431,10 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							nil
 							(rewrite_local_prejoin_count_term expr)))))
 				(define grouped_having
-					(rewrite_group_key_to_group_alias (lower_prejoin_lineage_expr raw_stage_post_group_condition)))
+					(rewrite_group_key_to_group_alias (lower_prejoin_group_expr raw_stage_post_group_condition)))
 				(define grouped_order (if (nil? raw_stage_order) nil
 					(map raw_stage_order (lambda (o) (match o '(col dir)
-						(list (lower_prejoin_lineage_expr col) dir))))))
+						(list (lower_prejoin_group_expr col) dir))))))
 				(define grouped_outer_tables (map _grp_ps_tables (lambda (td) (match td
 					'(tv tschema ttbl toisOuter je)
 					(list (if (nil? tv) ttbl tv) tschema ttbl toisOuter je)
@@ -6451,7 +6466,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 								(lambda (x) (and (not (nil? x)) (not (equal? x true)))))))
 						(if (or (nil? grouped_plan_condition_base_raw) (equal? grouped_plan_condition_base_raw true))
 							nil
-							(lower_prejoin_lineage_expr grouped_plan_condition_base_raw)))))
+							(lower_prejoin_group_expr grouped_plan_condition_base_raw)))))
 				(define recursive_replace_find_column (lambda (expr)
 					(match expr
 						'((symbol get_column) alias_ _ _ _) (begin

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -596,6 +596,11 @@ class SQLTestRunner:
                                 for needle in (step_expect["contains"] if isinstance(step_expect["contains"], list) else [step_expect["contains"]]):
                                     if str(needle) not in flat:
                                         return self._record_fail(name, f"Step '{step_sql[:60]}' missing '{needle}' in result", step_sql, resp, step_expect, is_noncritical)
+                            if "not_contains" in step_expect:
+                                flat = " ".join(str(r) for r in rows)
+                                for needle in (step_expect["not_contains"] if isinstance(step_expect["not_contains"], list) else [step_expect["not_contains"]]):
+                                    if str(needle) in flat:
+                                        return self._record_fail(name, f"Step '{step_sql[:60]}' unexpectedly contained '{needle}' in result", step_sql, resp, step_expect, is_noncritical)
 
             # Wait for background threads to finish
             for t in bg_threads:
@@ -626,6 +631,11 @@ class SQLTestRunner:
                             for needle in (step_expect["contains"] if isinstance(step_expect["contains"], list) else [step_expect["contains"]]):
                                 if str(needle) not in flat:
                                     return self._record_fail(name, f"Background step '{step_sql[:60]}' missing '{needle}' in result", step_sql, resp, step_expect, is_noncritical)
+                        if "not_contains" in step_expect:
+                            flat = " ".join(str(r) for r in rows)
+                            for needle in (step_expect["not_contains"] if isinstance(step_expect["not_contains"], list) else [step_expect["not_contains"]]):
+                                if str(needle) in flat:
+                                    return self._record_fail(name, f"Background step '{step_sql[:60]}' unexpectedly contained '{needle}' in result", step_sql, resp, step_expect, is_noncritical)
             self._record_success(name, is_noncritical)
             return True
 

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -109,6 +109,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	analyzeStart := time.Now()
 	/* analyze query */
 	boundaries := extractBoundaries(conditionCols, condition)
+	boundaries = dropSessionVariantBoundaries(t, boundaries)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
 	if Settings.ScanDebugging {
@@ -305,9 +306,13 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	// condition column readers
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
+	cNeedsTxReader := make([]bool, len(conditionCols))
 	for i, k := range conditionCols {
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			cNeedsTxReader[i] = true
+		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
@@ -523,6 +528,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
+	cNeedsTxReader := make([]bool, len(conditionCols))
 	conditionBatchSubidx := make([]int, len(conditionCols))
 	for i, k := range conditionCols {
 		if subidx, ok := parseBatchPseudoColName(k); ok {
@@ -531,6 +537,9 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			cNeedsTxReader[i] = true
+		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
@@ -617,6 +626,8 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 					for i, k := range ccols {
 						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
 							cdataset[i] = batchdata[batchid*stride+subidx]
+						} else if cNeedsTxReader[i] {
+							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 						} else {
 							cdataset[i] = k.GetValue(effectiveIdx)
 						}
@@ -625,8 +636,10 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 					for i, k := range conditionCols {
 						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
 							cdataset[i] = batchdata[batchid*stride+subidx]
-						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+						} else if cNeedsTxReader[i] {
 							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
+						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+							cdataset[i] = ccols[i].GetValue(effectiveIdx)
 						} else {
 							cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), k)
 						}

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -292,3 +292,56 @@ func touchTempColumns(t *table, colSets ...[]string) {
 		}
 	}
 }
+
+// dropSessionVariantBoundaries removes index/range pushdown on session-sensitive
+// computed columns. Their visible values depend on tx/session state, while the
+// physical keytable/index domain is global; using such columns for iterateIndex
+// would therefore visit a stale/shared row subset and miss rows that only match
+// in the current session variant.
+func dropSessionVariantBoundaries(t *table, in boundaries) boundaries {
+	if len(in) == 0 {
+		return in
+	}
+	t.shardModeMu.RLock()
+	shards := t.Shards
+	if len(shards) == 0 {
+		shards = t.PShards
+	}
+	t.shardModeMu.RUnlock()
+	if len(shards) == 0 {
+		return in
+	}
+
+	out := make(boundaries, 0, len(in))
+	for _, b := range in {
+		drop := false
+		for _, s := range shards {
+			if s == nil {
+				continue
+			}
+			if s.schemaColumn(b.col) == nil {
+				continue
+			}
+			func() {
+				defer func() {
+					if recover() != nil {
+						// Some computed/prejoin boundary columns exist only on specific
+						// runtime paths. Missing local storage means we cannot prove
+						// session-sensitive index unsafety here, so keep the boundary.
+					}
+				}()
+				cs := s.getColumnStorageOrPanicEx(b.col, false)
+				if proxy, ok := cs.(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+					drop = true
+				}
+			}()
+			if drop {
+				break
+			}
+		}
+		if !drop {
+			out = append(out, b)
+		}
+	}
+	return out
+}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -253,6 +253,7 @@ func (t *table) scan_order(currentTx *TxContext, conditionCols []string, conditi
 	*/
 	/* analyze condition query */
 	boundaries := extractBoundaries(conditionCols, condition)
+	boundaries = dropSessionVariantBoundaries(t, boundaries)
 	reorderByFrequency(boundaries, t)
 	// When all filter conditions are equality, appending sort columns to the
 	// boundaries lets the shard return rows already sorted by ORDER BY — the
@@ -743,8 +744,14 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 
 	// main storage — use skipShardReadLock to avoid redundant hasWriteOwner() per column
 	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	cNeedsTxReader := make([]bool, len(conditionCols))
 	for i, k := range conditionCols { // iterate over columns
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			cNeedsTxReader[i] = true
+		}
 	}
 	// initialize main_count lazily if needed
 	t.ensureMainCount(skipShardReadLock)
@@ -800,13 +807,19 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					// value from main storage
 					// check condition
 					for i, k := range ccols { // iterate over columns
-						cdataset[i] = k.GetValue(idx)
+						if cNeedsTxReader[i] {
+							cdataset[i] = cReaders[i].GetValue(idx)
+						} else {
+							cdataset[i] = k.GetValue(idx)
+						}
 					}
 				} else {
 					// value from delta storage
 					// prepare&call condition function
 					for i, k := range conditionCols { // iterate over columns
-						if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+						if cNeedsTxReader[i] {
+							cdataset[i] = cReaders[i].GetValue(idx)
+						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 							cdataset[i] = ccols[i].GetValue(idx)
 						} else {
 							cdataset[i] = t.getDelta(int(idx-t.main_count), k) // fill value

--- a/tests/66_count_sum_derived_table.yaml
+++ b/tests/66_count_sum_derived_table.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # COUNT(*) + SUM over a derived table with scalar subselects.
 # Triggers NthLocalVar index out of range when the inner derived table
 # contains correlated scalar subselects that are Neumann-decorrelated.
@@ -52,6 +67,23 @@ test_cases:
       data:
         - cnt: 3
           total: 60
+
+  - name: "EXPLAIN IR keeps non-window derived aggregates flattened"
+    sql: |
+      EXPLAIN IR
+      SELECT COUNT(*) AS cnt, SUM(t.total_val) AS grand_total FROM (
+        SELECT m.ID AS ID,
+          COALESCE((SELECT SUM(d.val) FROM csd_detail d WHERE d.parent = m.ID), 0) AS total_val
+        FROM csd_main m
+      ) t
+    expect:
+      rows: 8
+      contains:
+        - "\"t\\u0000m\" \"memcp-tests\" \"csd_main\" false nil"
+        - "(aggregate 1 + 0)"
+        - "(aggregate (coalesceNil (scan"
+      not_contains:
+        - "__mat:"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS csd_main"

--- a/tests/91_perf_derived_count_pruning.yaml
+++ b/tests/91_perf_derived_count_pruning.yaml
@@ -1,0 +1,67 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Performance self-check for COUNT(*) pruning over derived tables with
+# correlated scalar subselects. If untangle stops pruning unused projections,
+# this query degenerates into repeated correlated scans over perf_detail.
+
+metadata:
+  version: "1.0"
+  description: "Performance self-check for derived COUNT(*) pruning"
+  isolated: true
+
+test_cases:
+  - name: "Perf: derived COUNT prunes correlated subselect payload"
+    setup:
+      - sql: "DROP TABLE IF EXISTS `perf_main`"
+      - sql: "DROP TABLE IF EXISTS `perf_detail`"
+      - scm: "(rebuild)"
+      - sql: "CREATE TABLE `perf_main` (id INT PRIMARY KEY, payload INT)"
+      - sql: "CREATE TABLE `perf_detail` (id INT PRIMARY KEY, parent INT, val INT)"
+      - scm: |
+          (begin
+            (set rows (map (produceN {rows}) (lambda (i) (list i (* i 3)))))
+            (insert "{database}" "perf_main" '("id" "payload") rows)
+            (set detail_n (* {rows} 2))
+            (set details (map (produceN detail_n) (lambda (i)
+              (list
+                i
+                (floor (/ i 2))
+                (+ 1 (* i 5))))))
+            (insert "{database}" "perf_detail" '("id" "parent" "val") details)
+            (rebuild)
+            "ok")
+    sql: |
+      SELECT COUNT(*) AS cnt FROM (
+        SELECT m.id,
+          COALESCE((SELECT SUM(d.val) FROM perf_detail d WHERE d.parent = m.id), 0) AS total_val,
+          EXISTS (SELECT 1 FROM perf_detail d2 WHERE d2.parent = m.id AND d2.val > 0) AS has_detail
+        FROM perf_main m
+      ) t
+    threshold_ms: 30000
+    on_fail:
+      - sql: |
+          EXPLAIN IR SELECT COUNT(*) AS cnt FROM (
+            SELECT m.id,
+              COALESCE((SELECT SUM(d.val) FROM perf_detail d WHERE d.parent = m.id), 0) AS total_val,
+              EXISTS (SELECT 1 FROM perf_detail d2 WHERE d2.parent = m.id AND d2.val > 0) AS has_detail
+            FROM perf_main m
+          ) t
+    expect:
+      rows: 1
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS perf_main"
+  - sql: "DROP TABLE IF EXISTS perf_detail"


### PR DESCRIPTION
## Summary
- merge latest `master` into this line of work
- keep the session-sensitive group-cache fix, but restrict tx-bound condition readers to session-variant compute proxies only
- preserve the derived/prejoin group fixes from the local queryplan work

## Why
After merging `master`, the branch still needed two classes of fixes:
- session-sensitive group-cache correctness regressions (`tests/111_*`)
- prejoin/group alias identity regressions in derived/grouped plans (`tests/112_*`)

A broad switch to tx-bound readers fixed the session-sensitive cache bug, but it also made the prejoin cleanup / invalidation path much heavier under the concurrent invalidation coverage suite. This PR narrows that change to the actual invariant: only session-variant `StorageComputeProxy` columns need tx-bound condition readers.

## Validation
Passed locally on fresh temp data:
- `tests/111_session_group_cache_perf.yaml`
- `tests/112_session_group_empty_keytable.yaml`
- `tests/84_incremental_invalidation.yaml`
- `tests/66_count_sum_derived_table.yaml`
- `tests/66_scalar_window_derived.yaml`
- `tests/66_lead_window_derived.yaml`

Local note:
- the repo hook `make test` currently cannot be used unchanged in this worktree because `git-pre-commit` starts against shared `./data` and expects `root:admin`, but the current worktree `./data` returns HTTP `401` for that credential. The code repros above were therefore run on fresh temp data / connect-only servers instead.
