### PR TITLE
fix: remove illegal resultrow deduplication from REST API

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -219,12 +219,9 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(define formula (cached_parse sql_queryplan_cache parse_sql schema query (sql_policy (req "username")) (req "username") session))
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
-					(set last_row nil)
 					(define resultrow (lambda (row) (begin
 						(set resultrow_called true)
-						(if (equal? row last_row)
-							true
-							(begin (set last_row row) (original_resultrow row))))))
+						(original_resultrow row))))
 					/* Execute inside auto-commit tx (or existing explicit tx) */
 					(set query_result (with_session session (lambda () (with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula)))))))
 					/* If no resultrow was called and we got a number, return it as affected_rows */
@@ -259,12 +256,9 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(session "schema" schema)
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
-					(set last_row nil)
 					(define resultrow (lambda (row) (begin
 						(set resultrow_called true)
-						(if (equal? row last_row)
-							true
-							(begin (set last_row row) (original_resultrow row))))))
+						(original_resultrow row))))
 					(define handled (match query
 						(regex "SELECT\\s+c\\.relname\\s+as\\s+tblname\\s+FROM\\s+pg_catalog\\.pg_class" _)
 						(begin

--- a/tests/50_union_all_duplicates.yaml
+++ b/tests/50_union_all_duplicates.yaml
@@ -1,0 +1,58 @@
+metadata:
+  version: "1.0"
+  description: "UNION ALL must preserve duplicate rows"
+
+test_cases:
+  - name: "UNION ALL with identical literal rows"
+    sql: "SELECT 1 AS x UNION ALL SELECT 1 AS x"
+    expect:
+      rows: 2
+      data:
+        - x: 1
+        - x: 1
+
+  - name: "UNION ALL with three identical rows"
+    sql: "SELECT 1 AS x UNION ALL SELECT 1 AS x UNION ALL SELECT 1 AS x"
+    expect:
+      rows: 3
+      data:
+        - x: 1
+        - x: 1
+        - x: 1
+
+  - name: "UNION ALL mixed duplicates and unique"
+    sql: "SELECT 1 AS x UNION ALL SELECT 2 AS x UNION ALL SELECT 1 AS x"
+    expect:
+      rows: 3
+      data:
+        - x: 1
+        - x: 2
+        - x: 1
+
+  - name: "Create test table for UNION ALL"
+    sql: "CREATE TABLE union_dup_test (id INT PRIMARY KEY, val VARCHAR(20))"
+
+  - name: "Insert duplicate values"
+    sql: "INSERT INTO union_dup_test (id, val) VALUES (1, 'aaa'), (2, 'aaa'), (3, 'bbb')"
+
+  - name: "UNION ALL from table with duplicate values"
+    sql: "SELECT val FROM union_dup_test WHERE val = 'aaa' UNION ALL SELECT val FROM union_dup_test WHERE val = 'aaa'"
+    expect:
+      rows: 4
+      data:
+        - val: "aaa"
+        - val: "aaa"
+        - val: "aaa"
+        - val: "aaa"
+
+  - name: "SELECT without UNION returns consecutive duplicates"
+    sql: "SELECT val FROM union_dup_test ORDER BY val"
+    expect:
+      rows: 3
+      data:
+        - val: "aaa"
+        - val: "aaa"
+        - val: "bbb"
+
+  - name: "Cleanup"
+    sql: "DROP TABLE union_dup_test"


### PR DESCRIPTION
## Summary
- Remove consecutive-row deduplication from REST API handlers in `lib/sql.scm` that silently dropped identical adjacent result rows
- This broke SQL semantics: `SELECT 1 UNION ALL SELECT 1` would only return 1 row instead of 2
- The workaround was introduced in commit d72ee43e6 alongside the user access system and masked potential query planner issues rather than fixing them
- Add `tests/50_union_all_duplicates.yaml` to guard UNION ALL duplicate preservation

## Context
The dedup compared `(equal? row last_row)` and skipped the `resultrow` callback for consecutive identical rows. This is incorrect behavior — SQL guarantees that `UNION ALL` preserves all rows including duplicates, and any query producing legitimately identical consecutive rows must emit them all.

The MySQL wire protocol frontend (`scm/mysql.go`) never had this dedup, only the REST API handlers (both MySQL-compat and PostgreSQL-compat routes in `lib/sql.scm`).

## Test plan
- [x] New test `50_union_all_duplicates.yaml` passes (UNION ALL with identical rows)
- [x] All existing subquery tests (24, 26, 27) pass
- [x] DISTINCT tests (51) pass
- [x] Join dedup tests (95) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)