### PR TITLE
feat: unnest uncorrelated scalar subselects (Neumann CROSS JOIN)

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3092,9 +3092,9 @@ seeing the correctly prefixed outer alias. */
 				(nil? h)
 				(or (nil? g) (equal? g '()))
 				(or (nil? o) (equal? o '()))
-				/* uncorrelated: LIMIT is fine (produces 1-row CROSS JOIN) */
-				(or (not _has_outer) (nil? l))
-				(or (not _has_outer) (nil? off)))
+				/* uncorrelated: only unnest if LIMIT is present (preserves multi-row error semantics) */
+				(or _has_outer (not (nil? l)))
+				(or _has_outer (nil? off)))
 				(match (unnest_subselect subquery outer_schemas)
 					'(subst tbls) (begin
 						/* Scalar subselect unnesting yields null-preserving LEFT JOIN helper

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3076,16 +3076,20 @@ seeing the correctly prefixed outer alias. */
 			(define _value_expr (match flds
 				(cons _ (cons v _)) v
 				nil))
-			(if (and (_subquery_has_outer_refs subquery outer_schemas)
-				(_subquery_outer_refs_are_direct_columns subquery outer_schemas)
+			(define _has_outer (_subquery_has_outer_refs subquery outer_schemas))
+			(if (and
+				/* correlated: outer refs must be direct columns */
+				(or (not _has_outer)
+					(_subquery_outer_refs_are_direct_columns subquery outer_schemas))
 				(not (_contains_inner_select_marker subquery))
 				(not (nil? _value_expr))
 				(equal? (extract_aggregates _value_expr) '())
 				(nil? h)
 				(or (nil? g) (equal? g '()))
 				(or (nil? o) (equal? o '()))
-				(nil? l)
-				(nil? off))
+				/* uncorrelated: LIMIT is fine (produces 1-row CROSS JOIN) */
+				(or (not _has_outer) (nil? l))
+				(or (not _has_outer) (nil? off)))
 				(match (unnest_subselect subquery outer_schemas)
 					'(subst tbls) (begin
 						/* Scalar subselect unnesting yields null-preserving LEFT JOIN helper

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3077,10 +3077,15 @@ seeing the correctly prefixed outer alias. */
 				(cons _ (cons v _)) v
 				nil))
 			(define _has_outer (_subquery_has_outer_refs subquery outer_schemas))
+			/* uncorrelated + outer GROUP BY: defer to group-barrier refactoring
+			(prejoin scoping bug when unnested table meets GROUP stage) */
+			(define _outer_has_group (or group having _cd_has))
 			(if (and
 				/* correlated: outer refs must be direct columns */
 				(or (not _has_outer)
 					(_subquery_outer_refs_are_direct_columns subquery outer_schemas))
+				/* uncorrelated + outer GROUP: not yet safe (needs group-barrier) */
+				(or _has_outer (not _outer_has_group))
 				(not (_contains_inner_select_marker subquery))
 				(not (nil? _value_expr))
 				(equal? (extract_aggregates _value_expr) '())

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3092,9 +3092,10 @@ seeing the correctly prefixed outer alias. */
 				(nil? h)
 				(or (nil? g) (equal? g '()))
 				(or (nil? o) (equal? o '()))
-				/* uncorrelated: only unnest if LIMIT is present (preserves multi-row error semantics) */
-				(or _has_outer (not (nil? l)))
-				(or _has_outer (nil? off)))
+				/* correlated: no LIMIT allowed (not yet supported in unnesting).
+				   uncorrelated: LIMIT required (preserves multi-row error semantics) */
+				(if _has_outer (nil? l) (not (nil? l)))
+				(if _has_outer (nil? off) (nil? off)))
 				(match (unnest_subselect subquery outer_schemas)
 					'(subst tbls) (begin
 						/* Scalar subselect unnesting yields null-preserving LEFT JOIN helper


### PR DESCRIPTION
## Summary
- Open the gate in `_try_unnest_scalar_subselect` for subqueries without outer references
- `unnest_subselect` already handles this correctly: empty domain → CROSS JOIN, LIMIT via partition-stage
- `join_reorder` (#179) places the 1-row result first → variable access instead of per-row scan

## Performance impact
Queries with uncorrelated scalar subselects like `(SELECT x FROM config WHERE ID=1 LIMIT 1)` in SELECT/WHERE go from O(N) inner scans to O(1).

## Test plan
- [x] 13_subselects (11/11), 24_scalar_subselect, 26_subquery, 27_exists all pass
- [x] 95_join_dedup (7/7), 51_distinct (14/14), 96_scalar_subselect_patterns all pass
- [x] EXPLAIN confirms unnested plan structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)