### PR TITLE
feat: cost-based join reorder using shard statistics

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4220,11 +4220,11 @@ second table carries strictly more local WHERE predicates than the first. */
 							(< (car a) (car b))))))
 					(define all_join_terms (jqr_flatten_join_terms segment))
 					(define combined_je (combine_and_terms all_join_terms))
-					(map (produceN (count sorted)) (lambda (i)
+					(map (produceN (count sorted)) (lambda (i) (begin
 						(define td (nth (nth sorted i) 2))
 						(if (equal? i 0)
 							(jqr_td_with_joinexpr td true)
-							(jqr_td_with_joinexpr td combined_je)))))))))))
+							(jqr_td_with_joinexpr td combined_je))))))))))))
 
 (define jqr_reorder_segments (lambda (tables_ condition schemas) (begin
 	(match (reduce tables_

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4208,14 +4208,23 @@ second table carries strictly more local WHERE predicates than the first. */
 			(if (reduce segment (lambda (acc td) (or acc (jqr_td_outer td))) false)
 				segment
 				(begin
-					(define scored (map segment (lambda (td) (list (jqr_estimate_rows td condition schemas) td))))
-					(define sorted (sort scored (lambda (a b) (< (car a) (car b)))))
+					/* score each table: estimated rows (from statistics) with predicate count as tiebreaker */
+					(define condition_terms (flatten_and_terms (coalesceNil condition true)))
+					(define scored (map segment (lambda (td) (list
+						(jqr_estimate_rows td condition schemas)
+						(- 0 (jqr_local_term_count (jqr_td_alias td) condition_terms)) /* negate: more predicates = lower score = scanned first */
+						td))))
+					(define sorted (sort scored (lambda (a b)
+						(if (equal? (car a) (car b))
+							(< (cadr a) (cadr b))  /* tiebreaker: more local predicates first */
+							(< (car a) (car b))))))
 					(define all_join_terms (jqr_flatten_join_terms segment))
 					(define combined_je (combine_and_terms all_join_terms))
 					(map (produceN (count sorted)) (lambda (i)
+						(define td (nth (nth sorted i) 2))
 						(if (equal? i 0)
-							(jqr_td_with_joinexpr (cadr (nth sorted i)) true)
-							(jqr_td_with_joinexpr (cadr (nth sorted i)) combined_je)))))))))))
+							(jqr_td_with_joinexpr td true)
+							(jqr_td_with_joinexpr td combined_je)))))))))))
 
 (define jqr_reorder_segments (lambda (tables_ condition schemas) (begin
 	(match (reduce tables_

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4168,33 +4168,65 @@ second table carries strictly more local WHERE predicates than the first. */
 				(not (nil? (stage_limit_val stage)))
 				(not (nil? (stage_offset_val stage)))))
 		false)))
-(define jqr_reorder_inner_segment (lambda (segment condition) (begin
-	(if (not (equal? (count segment) 2))
+/* jqr_estimate_rows: estimate filtered row count using cached statistics */
+(define jqr_estimate_rows (lambda (td condition schemas) (begin
+	(define alias (jqr_td_alias td))
+	(define cols (if (has_assoc? schemas alias) (schemas alias) '()))
+	(define base_rows (reduce cols (lambda (acc coldef)
+		(if (> acc 0) acc
+			(begin (define re (coldef "RowEstimate"))
+				(if (and (not (nil? re)) (> re 0)) re 0)))) 0))
+	(if (equal? base_rows 0) 1000000
+		(begin
+			(define condition_terms (flatten_and_terms (coalesceNil condition true)))
+			(define selectivity (reduce condition_terms (lambda (sel term)
+				(match term
+					'((symbol equal??) left right) (begin
+						(define col_name (match left
+							'((symbol get_column) (eval alias) _ c _) c
+							'((quote get_column) (eval alias) _ c _) c
+							nil))
+						(define col_name (if (nil? col_name) (match right
+							'((symbol get_column) (eval alias) _ c _) c
+							'((quote get_column) (eval alias) _ c _) c
+							nil) col_name))
+						(if (nil? col_name) sel
+							(begin
+								(define distinct (reduce cols (lambda (acc coldef)
+									(if (> acc 0) acc
+										(if (equal?? (coldef "Field") col_name)
+											(begin (define de (coldef "DistinctEstimate"))
+												(if (and (not (nil? de)) (> de 0)) de 0))
+											0))) 0))
+								(if (> distinct 1) (* sel (/ 1.0 distinct)) sel))))
+					_ sel)) 1.0))
+			(max 1 (* base_rows selectivity)))))))
+(define jqr_reorder_inner_segment (lambda (segment condition schemas) (begin
+	(if (< (count segment) 2)
 		segment
 		(begin
-			(define td1 (nth segment 0))
-			(define td2 (nth segment 1))
-			(if (or (jqr_td_outer td1) (jqr_td_outer td2))
+			(if (reduce segment (lambda (acc td) (or acc (jqr_td_outer td))) false)
 				segment
 				(begin
-					(define condition_terms (flatten_and_terms (coalesceNil condition true)))
-					(define local1 (jqr_local_term_count (jqr_td_alias td1) condition_terms))
-					(define local2 (jqr_local_term_count (jqr_td_alias td2) condition_terms))
-					(if (> local2 local1)
-						(list
-							(jqr_td_with_joinexpr td2 true)
-							(jqr_td_with_joinexpr td1 (combine_and_terms (jqr_flatten_join_terms segment))))
-						segment))))))))
-(define jqr_reorder_segments (lambda (tables_ condition) (begin
+					(define scored (map segment (lambda (td) (list (jqr_estimate_rows td condition schemas) td))))
+					(define sorted (sort scored (lambda (a b) (< (car a) (car b)))))
+					(define all_join_terms (jqr_flatten_join_terms segment))
+					(define combined_je (combine_and_terms all_join_terms))
+					(map (produceN (count sorted)) (lambda (i)
+						(if (equal? i 0)
+							(jqr_td_with_joinexpr (cadr (nth sorted i)) true)
+							(jqr_td_with_joinexpr (cadr (nth sorted i)) combined_je)))))))))))
+
+(define jqr_reorder_segments (lambda (tables_ condition schemas) (begin
 	(match (reduce tables_
 		(lambda (state td) (match state
 			'(out seg)
 			(if (jqr_td_outer td)
-				(list (merge out (jqr_reorder_inner_segment seg condition) (list td)) '())
+				(list (merge out (jqr_reorder_inner_segment seg condition schemas) (list td)) '())
 				(list out (merge seg (list td))))
 			state))
 		(list '() '()))
-		'(out seg) (merge out (jqr_reorder_inner_segment seg condition))
+		'(out seg) (merge out (jqr_reorder_inner_segment seg condition schemas))
 		tables_))))
 (define join_reorder (lambda (schema tables fields condition groups schemas replace_find_column) (begin
 		(define jqr_constant_scalar_aliases (reduce (coalesceNil groups '()) (lambda (acc stage)
@@ -4216,7 +4248,7 @@ second table carries strictly more local WHERE predicates than the first. */
 				jqr_constant_scalar_tables
 				(if (jqr_has_order_sensitive_stage groups)
 					jqr_regular_tables
-					(jqr_reorder_segments jqr_regular_tables condition)))
+					(jqr_reorder_segments jqr_regular_tables condition schemas)))
 			fields condition groups schemas replace_find_column))))
 
 (define build_queryplan_term (lambda (query) (begin

--- a/scm/list.go
+++ b/scm/list.go
@@ -29,6 +29,7 @@ import "fmt"
 import "runtime"
 import "sync"
 import "sync/atomic"
+import "github.com/carli2/hybridsort"
 import "github.com/jtolds/gls"
 
 // optimizeMap is the optimizer hook for `map`. It applies default optimization
@@ -1743,6 +1744,49 @@ func init_list() {
 			Return:    FreshAlloc,
 			Const:     true,
 			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sort",
+		Desc: "returns a sorted copy of a list using a comparator (lambda (a b) truthy/falsy)",
+		Fn: func(a ...Scmer) Scmer {
+			src := a[0].Slice()
+			cmp := a[1]
+			dst := make([]Scmer, len(src))
+			copy(dst, src)
+			hybridsort.SliceStable(dst, func(i, j int) bool {
+				return ToBool(Apply(cmp, dst[i], dst[j]))
+			})
+			return NewSlice(dst)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "list", NoEscape: true},
+				{Kind: "func", ParamName: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+			},
+			Return:   FreshAlloc,
+			Const:    true,
+			Optimize: FirstParameterMutable("sort_mut"),
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sort_mut",
+		Desc: "sorts a list in-place using a comparator (lambda (a b) truthy/falsy)",
+		Fn: func(a ...Scmer) Scmer {
+			src := a[0].Slice()
+			cmp := a[1]
+			hybridsort.SliceStable(src, func(i, j int) bool {
+				return ToBool(Apply(cmp, src[i], src[j]))
+			})
+			return a[0]
+		},
+		Type: &TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "list"},
+				{Kind: "func", ParamName: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+			},
+			Return: &TypeDescriptor{Kind: "list"},
 		},
 	})
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -659,16 +659,23 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 				t.Shards = newShardList
 			}
 
-			// Update per-column statistics from rebuilt shards (O(1) per shard per column).
+			// Update per-column statistics from rebuilt shards.
+			// Use newShardList first (freshly compressed columns have accurate stats).
+			// Fall back to origShardList for shards whose columns are already loaded.
 			rowEst := uint64(t.CountEstimate())
 			for ci := range t.Columns {
 				var distinctSum uint64
-				for _, shard := range newShardList {
+				colName := t.Columns[ci].Name
+				for i, shard := range newShardList {
 					if shard == nil {
 						continue
 					}
-					if cs, ok := shard.columns[t.Columns[ci].Name]; ok {
+					if cs, ok := shard.columns[colName]; ok && cs != nil {
 						distinctSum += uint64(cs.DistinctCount())
+					} else if i < len(origShardList) && origShardList[i] != nil {
+						if cs2, ok2 := origShardList[i].columns[colName]; ok2 && cs2 != nil {
+							distinctSum += uint64(cs2.DistinctCount())
+						}
 					}
 				}
 				atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)


### PR DESCRIPTION
## Summary
Replace predicate-count heuristic with cost-based join reorder using `RowEstimate` and `DistinctEstimate` from cached shard statistics (PR #186).

- Smallest estimated table first in nested-loop join
- Equality selectivity: `rows / distinct_count` per filtered column
- N-way inner join support (not limited to 2-table segments)
- Falls back to 1M rows when statistics unavailable

## Depends on
- PR #186 (shard-statistics) for `DistinctEstimate`/`RowEstimate` in `show()`

## Test plan
- [x] 13_subselects (11/11), 51_distinct (14/14)
- [x] 95_join_dedup (7/7), 09_joins (3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)