### PR TITLE
fix: join reorder deadlock + sort builtins + statistics fixes

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -660,22 +660,18 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 			}
 
 			// Update per-column statistics from rebuilt shards.
-			// Use newShardList first (freshly compressed columns have accurate stats).
-			// Fall back to origShardList for shards whose columns are already loaded.
+			// The new shards have freshly compressed columns with accurate stats.
 			rowEst := uint64(t.CountEstimate())
 			for ci := range t.Columns {
 				var distinctSum uint64
 				colName := t.Columns[ci].Name
-				for i, shard := range newShardList {
+				for _, shard := range newShardList {
 					if shard == nil {
 						continue
 					}
+					// columns are populated during rebuild — access directly
 					if cs, ok := shard.columns[colName]; ok && cs != nil {
 						distinctSum += uint64(cs.DistinctCount())
-					} else if i < len(origShardList) && origShardList[i] != nil {
-						if cs2, ok2 := origShardList[i].columns[colName]; ok2 && cs2 != nil {
-							distinctSum += uint64(cs2.DistinctCount())
-						}
 					}
 				}
 				atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)

--- a/storage/table.go
+++ b/storage/table.go
@@ -847,29 +847,11 @@ func (c *column) Show(keyType string, t *table) scm.Scmer {
 	})
 }
 
-// distinctEstimateFor returns the sum of per-shard DistinctCount for this column.
-// Reads from cached DistinctEstimate if available, otherwise computes on-demand.
+// distinctEstimateFor returns the cached DistinctEstimate for this column.
+// Returns 0 if no statistics are available yet (populated at rebuild time).
+// Never acquires shard locks — safe to call during query compilation.
 func (c *column) distinctEstimateFor(t *table) uint {
-	cached := atomic.LoadUint64(&c.DistinctEstimate)
-	if cached > 0 {
-		return uint(cached)
-	}
-	// On-demand: iterate active shards and sum DistinctCount
-	var sum uint64
-	for _, shard := range t.ActiveShards() {
-		if shard == nil {
-			continue
-		}
-		unlock := shard.GetRead()
-		if cs, ok := shard.columns[c.Name]; ok && cs != nil {
-			sum += uint64(cs.DistinctCount())
-		}
-		unlock()
-	}
-	if sum > 0 {
-		atomic.StoreUint64(&c.DistinctEstimate, sum)
-	}
-	return uint(sum)
+	return uint(atomic.LoadUint64(&c.DistinctEstimate))
 }
 
 func (c *column) UpdateSanitizer() {

--- a/storage/table.go
+++ b/storage/table.go
@@ -802,12 +802,12 @@ func (t *table) ShowColumns() scm.Scmer {
 				}
 			}
 		}
-		result[i] = v.Show(keyType)
+		result[i] = v.Show(keyType, t)
 	}
 	return scm.NewSlice(result)
 }
 
-func (c *column) Show(keyType string) scm.Scmer {
+func (c *column) Show(keyType string, t *table) scm.Scmer {
 	dims := make([]scm.Scmer, len(c.Typdimensions))
 	for i, v := range c.Typdimensions {
 		dims[i] = scm.NewInt(int64(v))
@@ -842,9 +842,34 @@ func (c *column) Show(keyType string) scm.Scmer {
 		scm.NewString("Extra"), scm.NewString(extra),
 		scm.NewString("Privileges"), scm.NewString("select,insert,update,references"),
 		scm.NewString("Comment"), scm.NewString(c.Comment),
-		scm.NewString("DistinctEstimate"), scm.NewInt(int64(atomic.LoadUint64(&c.DistinctEstimate))),
-		scm.NewString("RowEstimate"), scm.NewInt(int64(atomic.LoadUint64(&c.RowEstimate))),
+		scm.NewString("DistinctEstimate"), scm.NewInt(int64(c.distinctEstimateFor(t))),
+		scm.NewString("RowEstimate"), scm.NewInt(int64(t.CountEstimate())),
 	})
+}
+
+// distinctEstimateFor returns the sum of per-shard DistinctCount for this column.
+// Reads from cached DistinctEstimate if available, otherwise computes on-demand.
+func (c *column) distinctEstimateFor(t *table) uint {
+	cached := atomic.LoadUint64(&c.DistinctEstimate)
+	if cached > 0 {
+		return uint(cached)
+	}
+	// On-demand: iterate active shards and sum DistinctCount
+	var sum uint64
+	for _, shard := range t.ActiveShards() {
+		if shard == nil {
+			continue
+		}
+		unlock := shard.GetRead()
+		if cs, ok := shard.columns[c.Name]; ok && cs != nil {
+			sum += uint64(cs.DistinctCount())
+		}
+		unlock()
+	}
+	if sum > 0 {
+		atomic.StoreUint64(&c.DistinctEstimate, sum)
+	}
+	return uint(sum)
 }
 
 func (c *column) UpdateSanitizer() {


### PR DESCRIPTION
Follow-up fixes for merged PR #187:
- Fix deadlock in distinctEstimateFor (shard locks during query compilation)
- Add sort/sort_mut builtins (hybridsort)
- Fix begin-wrap in map lambda for correct return value
- Predicate-count tiebreaker when statistics unavailable
- On-demand DistinctEstimate without shard locks

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>