### PR TITLE
fix: DistinctEstimate falls back to CountEstimate before first rebuild

### DIFF
--- a/storage/table.go
+++ b/storage/table.go
@@ -847,11 +847,19 @@ func (c *column) Show(keyType string, t *table) scm.Scmer {
 	})
 }
 
-// distinctEstimateFor returns the cached DistinctEstimate for this column.
-// Returns 0 if no statistics are available yet (populated at rebuild time).
+// distinctEstimateFor returns the DistinctEstimate for this column.
+// Uses cached value from rebuild if available. Falls back to CountEstimate
+// (conservative upper bound) when no rebuild statistics exist yet.
 // Never acquires shard locks — safe to call during query compilation.
 func (c *column) distinctEstimateFor(t *table) uint {
-	return uint(atomic.LoadUint64(&c.DistinctEstimate))
+	cached := atomic.LoadUint64(&c.DistinctEstimate)
+	if cached > 0 {
+		return uint(cached)
+	}
+	// No rebuild statistics yet — use row count as conservative upper bound.
+	// This ensures join_reorder can still compare table sizes even before
+	// the first rebuild runs.
+	return uint(t.CountEstimate())
 }
 
 func (c *column) UpdateSanitizer() {


### PR DESCRIPTION
Before rebuild, all DistinctEstimate values are 0, making join_reorder fall back to 1M for all tables (no useful ordering). Now falls back to CountEstimate (row count) as conservative upper bound. This lets join_reorder compare table sizes immediately — a 1-row userconfig table vs a 100-row doc table will be correctly ordered even without rebuild statistics.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>