### PR TITLE
fix: re-enable scan_batch rewrite after catalog merge (+67% equi-join)

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -366,7 +366,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* Metrics tracing: periodically insert rows into system_statistic.perf_metrics */
 (if (not (has? (show "system_statistic") "perf_metrics")) (begin
 	(print "creating table system_statistic.perf_metrics")
-	(eval (parse_sql "system_statistic" "CREATE TABLE perf_metrics(time text, cpu float, mem_available bigint, mem_total bigint, shard_memory bigint, shard_budget bigint, connections int, max_connections int, rps float, eps float) ENGINE=SLOPPY" (lambda (schema table write) true)))
+	(eval (parse_sql "system_statistic" "CREATE TABLE perf_metrics(time text, cpu float, mem_available bigint, mem_total bigint, shard_memory bigint, shard_budget bigint, connections int, max_connections int, rps float, eps float) ENGINE=SLOPPY" (lambda (schema tblname write) true)))
 ))
 
 /* self-scheduling tracing loop via setTimeout */

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -19,13 +19,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* check admin credentials against system.user table */
 (define dashboard_check_admin (lambda (req) (begin
-	(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
+	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
 	(and pw (equal? (car pw) (password (req "password"))) (car (cdr pw)))
 )))
 
 /* check any authenticated user (returns admin flag or false) */
 (define dashboard_check_user (lambda (req) (begin
-	(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
+	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
 	(if (and pw (equal? (car pw) (password (req "password")))) (equal? (car (cdr pw)) 1) nil)
 )))
 
@@ -42,7 +42,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(if is_admin (show)
 		(begin
 			/* build list of db names the user has access to; nil neutral avoids pre-call quirk */
-			(define allowed (scan nil "system" "access"
+			(define allowed (scan nil (table "system" "access")
 				'("username" "database") (lambda (u db) (equal?? u username))
 				'("database") (lambda (db) db)
 				(lambda (acc db) (if (nil? db) acc (cons db (if (nil? acc) (list) acc))))
@@ -90,7 +90,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* check if user has access to a specific database */
 (define dashboard_has_db_access (lambda (username is_admin dbname)
 	(if is_admin true
-		(> (scan nil "system" "access"
+		(> (scan nil (table "system" "access")
 			'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db dbname)))
 			'() (lambda () 1)
 			+ 0) 0)
@@ -127,10 +127,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* helper: build JSON for a single user entry (takes username string) */
 (define dashboard_build_user_json (lambda (uname) (begin
-	(set is_adm (scan nil "system" "user" '("username") (lambda (u) (equal? u uname)) '("admin") (lambda (a) a) (lambda (a b) b) false))
+	(set is_adm (scan nil (table "system" "user") '("username") (lambda (u) (equal? u uname)) '("admin") (lambda (a) a) (lambda (a b) b) false))
 	/* get database access for non-admins */
 	(set dbs_csv (if is_adm ""
-		(scan nil "system" "access" '("username") (lambda (u) (equal?? u uname))
+		(scan nil (table "system" "access") '("username") (lambda (u) (equal?? u uname))
 			'("database") (lambda (db) (json_encode db))
 			(lambda (acc db) (if (equal? acc "") db (concat acc "," db))) "")))
 	(concat "{\"username\":" (json_encode uname)
@@ -297,7 +297,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			/* API: print log — list latest entries (admin only) */
 			"/dashboard/api/logs" (begin
 				(if (dashboard_check_admin req) (begin
-					(define items (scan_order (session "__memcp_tx") "system_statistic" "logs"
+					(define items (scan_order (session "__memcp_tx") (table "system_statistic" "logs")
 						'() (lambda () true)
 						'("datetime") '(>) 0 0 100
 						'("datetime" "message")
@@ -310,7 +310,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			/* API: error query log — list entries (admin only) */
 			"/dashboard/api/errors" (begin
 				(if (dashboard_check_admin req) (begin
-					(define items (scan (session "__memcp_tx") "system_statistic" "errors"
+					(define items (scan (session "__memcp_tx") (table "system_statistic" "errors")
 						'() (lambda () true)
 						'("datetime" "database" "user" "query" "error")
 						(lambda (dt db usr qry err) (json_encode_assoc (list "datetime" dt "database" db "user" usr "query" qry "error" err)))
@@ -326,7 +326,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(dashboard_send_401 res)
 					(begin
 						(define default_pw (if is_admin
-							(scan nil "system" "user" '("username") (lambda (username) (equal? username "root")) '("password") (lambda (pw) (equal? pw (password "admin"))) (lambda (a b) b) false)
+							(scan nil (table "system" "user") '("username") (lambda (username) (equal? username "root")) '("password") (lambda (pw) (equal? pw (password "admin"))) (lambda (a b) b) false)
 							false))
 						(dashboard_send_json res (concat
 							"{\"admin\":" (if is_admin "true" "false")
@@ -373,7 +373,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (define metrics_trace_tick (lambda () (begin
 	(if (settings "MetricsTracing") (begin
 		(define s (stat))
-		(insert "system_statistic" "perf_metrics"
+		(insert (table "system_statistic" "perf_metrics")
 			'("time" "cpu" "mem_available" "mem_total" "shard_memory" "shard_budget" "connections" "max_connections" "rps" "eps")
 			(list (list
 				(now)
@@ -404,9 +404,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define max_print (settings "MaxPrintLog"))
 	(if (> max_print 0) (begin
 		(try (lambda () (begin
-			(define cnt (scan (session "__memcp_tx") "system_statistic" "logs" '() (lambda () true) '() (lambda () 1) + 0))
+			(define cnt (scan (session "__memcp_tx") (table "system_statistic" "logs") '() (lambda () true) '() (lambda () 1) + 0))
 			(if (> cnt max_print)
-				(scan_order (session "__memcp_tx") "system_statistic" "logs" '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_print) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
+				(scan_order (session "__memcp_tx") (table "system_statistic" "logs") '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_print) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
 			)
 		)) (lambda (e) true))
 	))
@@ -414,9 +414,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define max_err (settings "MaxErrorQueryLog"))
 	(if (> max_err 0) (begin
 		(try (lambda () (begin
-			(define cnt (scan (session "__memcp_tx") "system_statistic" "errors" '() (lambda () true) '() (lambda () 1) + 0))
+			(define cnt (scan (session "__memcp_tx") (table "system_statistic" "errors") '() (lambda () true) '() (lambda () 1) + 0))
 			(if (> cnt max_err)
-				(scan_order (session "__memcp_tx") "system_statistic" "errors" '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_err) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
+				(scan_order (session "__memcp_tx") (table "system_statistic" "errors") '() (lambda () true) '("datetime") '(<) 0 0 (- cnt max_err) '("$update") (lambda ($update) ($update)) (lambda (a b) b) nil)
 			)
 		)) (lambda (e) true))
 	))

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -275,7 +275,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser '((atom "VALUES" true) "(" (define e psql_identifier_unquoted) ")") '('get_column "VALUES" true e true)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
 		(parser '((atom "VALUES" true) "(" (define e psql_identifier_quoted) ")") '('get_column "VALUES" true e false)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
 		(parser '((atom "pg_catalog" true) "." (atom "set_config" true) "(" psql_expression "," psql_expression "," psql_expression ")") nil) /* ignore */
-		(parser '((atom "pg_catalog" true) "." (atom "setval" true) "(" "'" psql_identifier "." (define key psql_identifier) "'" "," (define val psql_expression) "," psql_expression ")") (match key (regex "(.*)_(.*?)_seq" _ tbl col) '('altercolumn schema tbl col "auto_increment" val) (error "unknown pg_catalog key: " key)))
+		(parser '((atom "pg_catalog" true) "." (atom "setval" true) "(" "'" psql_identifier "." (define key psql_identifier) "'" "," (define val psql_expression) "," psql_expression ")") (match key (regex "(.*)_(.*?)_seq" _ tbl col) '('altercolumn '('table schema tbl) col "auto_increment" val) (error "unknown pg_catalog key: " key)))
 
 		(parser (atom "NULL" true) 'nil)
 		(parser (atom "TRUE" true) true)
@@ -569,7 +569,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(set updaterows2 (if (nil? updaterows3) nil (merge updaterows3)))
 			(set updatecols (if (nil? updaterows3) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
-			'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
+			'('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
 				(if (or do_nothing (and ignoreexists (nil? updaterows3)))
 					'((quote lambda) '() 0)
 					(if ignoreexists '('lambda '() true) (if (nil? updaterows3) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
@@ -608,7 +608,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			'('begin
-				'('set 'resultrow '('lambda '('item) '('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols) (if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))) false '('lambda '('id) '('session "last_insert_id" 'id)))))
+				'('set 'resultrow '('lambda '('item) '('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols) (if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))) false '('lambda '('id) '('session "last_insert_id" 'id)))))
 				(build_queryplan_term inner)
 			)
 	)))
@@ -679,8 +679,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(define id (or (parser '(psql_identifier "." (define id psql_identifier)) id) psql_identifier))
 		(define alters (+ (or
 			/* TODO */
-			(parser '((atom "ADD" true) (atom "CONSTRAINT" true) (define id psql_identifier) (atom "PRIMARY" true) (atom "KEY" true) "(" (define cols (+ psql_identifier ",")) ")") (lambda (tbl) '('createkey schema tbl id true (cons (quote list) cols))))
-			(parser '((atom "ADD" true) (atom "CONSTRAINT" true) (define id psql_identifier) (atom "FOREIGN" true) (atom "KEY" true) "(" (define cols1 (+ psql_identifier ",")) ")" (atom "REFERENCES" true) (define tbl2 (or (parser '(psql_identifier "." (define id psql_identifier)) id) psql_identifier)) "(" (define cols2 (+ psql_identifier ",")) ")" (? (atom "ON" true) (atom "UPDATE" true) (define updatemode psql_foreign_key_mode)) (? (atom "ON" true) (atom "DELETE" true) (define deletemode psql_foreign_key_mode))) (lambda (tbl) '('createforeignkey schema id tbl (cons (quote list) cols1) tbl2 (cons (quote list) cols2) updatemode deletemode)))
+			(parser '((atom "ADD" true) (atom "CONSTRAINT" true) (define id psql_identifier) (atom "PRIMARY" true) (atom "KEY" true) "(" (define cols (+ psql_identifier ",")) ")") (lambda (tbl) '('createkey '('table schema tbl) id true (cons (quote list) cols))))
+			(parser '((atom "ADD" true) (atom "CONSTRAINT" true) (define id psql_identifier) (atom "FOREIGN" true) (atom "KEY" true) "(" (define cols1 (+ psql_identifier ",")) ")" (atom "REFERENCES" true) (define tbl2 (or (parser '(psql_identifier "." (define id psql_identifier)) id) psql_identifier)) "(" (define cols2 (+ psql_identifier ",")) ")" (? (atom "ON" true) (atom "UPDATE" true) (define updatemode psql_foreign_key_mode)) (? (atom "ON" true) (atom "DELETE" true) (define deletemode psql_foreign_key_mode))) (lambda (tbl) '('createforeignkey '('table schema tbl) id (cons (quote list) cols1) '('table schema tbl2) (cons (quote list) cols2) updatemode deletemode)))
 			/*
 			(parser '((atom "ADD" true) (atom "UNIQUE" true) (atom "KEY" true) (define id psql_identifier) "(" (define cols (+ psql_identifier ",")) ")" (? (atom "USING" true) (atom "BTREE" true))) '((quote list) "unique" id (cons (quote list) cols)))
 			(parser '((atom "ADD" true) (atom "KEY" true) psql_identifier "(" (+ psql_identifier ",") ")" (? (atom "USING" true) (atom "BTREE" true))) nil) /* ignore index definitions */
@@ -693,19 +693,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(parser empty '((quote list)))
 				))
 				(define typeparams psql_column_attributes)
-			) (lambda (id) '((quote createcolumn) schema id col type dimensions (cons 'list typeparams))))
-			(parser '((atom "OWNER" true) (atom "TO" true) (define owner psql_identifier)) (lambda (id) '((quote altertable) schema id "owner" owner)))
+			) (lambda (id) '((quote createcolumn) '('table schema id) col type dimensions (cons 'list typeparams))))
+			(parser '((atom "OWNER" true) (atom "TO" true) (define owner psql_identifier)) (lambda (id) '((quote altertable) '('table schema id) "owner" owner)))
 			(parser '((atom "DROP" true) (atom "CONSTRAINT" true) (define cname psql_identifier)) (lambda (id) true))
-			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (define col psql_identifier)) (lambda (id) '((quote altertable) schema id "drop" col)))
-			(parser '((atom "ENGINE" true) "=" (atom "MEMORY" true)) (lambda (id) '((quote altertable) schema id "engine" "memory")))
-			(parser '((atom "ENGINE" true) "=" (atom "CACHE" true)) (lambda (id) '((quote altertable) schema id "engine" "cache")))
-			(parser '((atom "ENGINE" true) "=" (atom "SLOPPY" true)) (lambda (id) '((quote altertable) schema id "engine" "sloppy")))
-			(parser '((atom "ENGINE" true) "=" (atom "LOGGING" true)) (lambda (id) '((quote altertable) schema id "engine" "logged")))
-			(parser '((atom "ENGINE" true) "=" (atom "SAFE" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "MyISAM" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "InnoDB" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "COLLATE" true) "=" (define collation (regex "[a-zA-Z0-9_]+"))) (lambda (id) '((quote altertable) schema id "collation" collation)))
-			(parser '((atom "AUTO_INCREMENT" true) "=" (define ai (regex "[0-9]+"))) (lambda (id) '((quote altertable) schema id "auto_increment" ai)))
+			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (define col psql_identifier)) (lambda (id) '((quote altertable) '('table schema id) "drop" col)))
+			(parser '((atom "ENGINE" true) "=" (atom "MEMORY" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "memory")))
+			(parser '((atom "ENGINE" true) "=" (atom "CACHE" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "cache")))
+			(parser '((atom "ENGINE" true) "=" (atom "SLOPPY" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "sloppy")))
+			(parser '((atom "ENGINE" true) "=" (atom "LOGGING" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "logged")))
+			(parser '((atom "ENGINE" true) "=" (atom "SAFE" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "MyISAM" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "InnoDB" true)) (lambda (id) '((quote altertable) '('table schema id) "engine" "safe")))
+			(parser '((atom "COLLATE" true) "=" (define collation (regex "[a-zA-Z0-9_]+"))) (lambda (id) '((quote altertable) '('table schema id) "collation" collation)))
+			(parser '((atom "AUTO_INCREMENT" true) "=" (define ai (regex "[0-9]+"))) (lambda (id) '((quote altertable) '('table schema id) "auto_increment" ai)))
 			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col psql_identifier) (define body (or /* ALTER COLUMN */
 				(parser '((atom "ADD" true) (atom "GENERATED" true) (or '((atom "BY" true) (atom "DEFAULT" true)) (atom "ALWAYS" true)) (atom "AS" true) (atom "IDENTITY") "("
 					(atom "SEQUENCE" true) (atom "NAME" true) psql_identifier "." psql_identifier
@@ -714,12 +714,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(? (atom "NO" true) (atom "MINVALUE" true))
 					(? (atom "NO" true) (atom "MAXVALUE" true))
 					(? (atom "CACHE" true) psql_expression)
-					")") (lambda (col) (lambda (id) '((quote altercolumn) schema id col "auto_increment" true))))
+					")") (lambda (col) (lambda (id) '((quote altercolumn) '('table schema id) col "auto_increment" true))))
 				/* Type and default changes */
-				(parser '((atom "TYPE" true) (define type psql_identifier) (define dimensions (or (parser '("(" (define a psql_int) "," (define b psql_int) ")") '((quote list) a b)) (parser '("(" (define a psql_int) ")") '((quote list) a)) (parser empty '((quote list))))) ) (lambda (col) (lambda (id) '('!begin '((quote altercolumn) schema id col "type" type) '((quote altercolumn) schema id col "dimensions" dimensions)))))
-				(parser '((atom "SET" true) (atom "DEFAULT" true) (define def psql_expression)) (lambda (col) (lambda (id) '((quote altercolumn) schema id col "default" def))))
-				(parser '((atom "DROP" true) (atom "DEFAULT" true)) (lambda (col) (lambda (id) '((quote altercolumn) schema id col "default" nil))))
-				(parser '((atom "COLLATE" true) (define coll psql_identifier)) (lambda (col) (lambda (id) '((quote altercolumn) schema id col "collation" coll))))
+				(parser '((atom "TYPE" true) (define type psql_identifier) (define dimensions (or (parser '("(" (define a psql_int) "," (define b psql_int) ")") '((quote list) a b)) (parser '("(" (define a psql_int) ")") '((quote list) a)) (parser empty '((quote list))))) ) (lambda (col) (lambda (id) '('!begin '((quote altercolumn) '('table schema id) col "type" type) '((quote altercolumn) '('table schema id) col "dimensions" dimensions)))))
+				(parser '((atom "SET" true) (atom "DEFAULT" true) (define def psql_expression)) (lambda (col) (lambda (id) '((quote altercolumn) '('table schema id) col "default" def))))
+				(parser '((atom "DROP" true) (atom "DEFAULT" true)) (lambda (col) (lambda (id) '((quote altercolumn) '('table schema id) col "default" nil))))
+				(parser '((atom "COLLATE" true) (define coll psql_identifier)) (lambda (col) (lambda (id) '((quote altercolumn) '('table schema id) col "collation" coll))))
 			))) (body col))
 		) ","))
 	) (cons '!begin (map alters (lambda (alter) (alter id))))))
@@ -747,41 +747,41 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'((? (atom "WITH" true)) (? (or (atom "SUPERUSER" true) (atom "LOGIN" true))) (atom "PASSWORD" true) (define password psql_expression))
 		)))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "user" '(list "username" "password" "admin") '(list '(list username '('password password) false)) '(list) '((quote lambda) '() '((quote error) "user already exists")))
+				'('insert '('table "system" "user") '(list "username" "password" "admin") '(list '(list username '('password password) false)) '(list) '((quote lambda) '() '((quote error) "user already exists")))
 		))
 		/* ALTER USER password: MySQL (IDENTIFIED BY) and PostgreSQL (WITH PASSWORD / PASSWORD) */
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username psql_identifier)
 			(? (atom "WITH" true))
 			(atom "PASSWORD" true) (define password psql_expression))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
 		))
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username psql_identifier)
 			(atom "IDENTIFIED" true) (atom "BY" true) (define password psql_expression))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
 		))
 		/* ALTER USER SUPERUSER / NOSUPERUSER — PostgreSQL admin grant */
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username psql_identifier) (atom "SUPERUSER" true))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
 		))
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username psql_identifier) (atom "NOSUPERUSER" true))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
 		))
 		/* DROP USER/ROLE [IF EXISTS] — cascade-deletes access entries then the user row */
 		(parser '((atom "DROP" true) (or (atom "USER" true) (atom "ROLE" true)) (? (atom "IF" true) (atom "EXISTS" true)) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
 				(cons '!begin (list
-					'((quote scan) '(session "__memcp_tx") "system" "access"
+					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
 						'(list "$update")
 						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
 						(quote +)
 						0)
-					'((quote scan) '(session "__memcp_tx") "system" "user"
+					'((quote scan) '(session "__memcp_tx") '('table "system" "user")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
 						'(list "$update")
@@ -795,28 +795,28 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		/* GRANT ALL [PRIVILEGES] ON *.* TO user -> set admin true */
 		(parser '((atom "GRANT" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
 		))
 		/* REVOKE ALL [PRIVILEGES] ON *.* FROM user -> set admin false */
 		(parser '((atom "REVOKE" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "FROM" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
 		))
 		/* GRANT <any> ON DATABASE db TO user (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "DATABASE" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
+				'('insert '('table "system" "access") '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 		/* GRANT <any> ON SCHEMA db TO user (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "SCHEMA" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
+				'('insert '('table "system" "access") '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 		/* GRANT ALL PRIVILEGES ON ALL DATABASES is non-standard; ignore */
 		/* Treat GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA db TO user as db-level access (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "ALL" true) (atom "TABLES" true) (atom "IN" true) (atom "SCHEMA" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
+				'('insert '('table "system" "access") '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 
 		/* REVOKE syntax (PostgreSQL-style) -> mirror GRANT behavior */
@@ -825,8 +825,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan)
 					'(session "__memcp_tx")
-					"system"
-					"access"
+					'('table "system" "access")
 					'(list "username" "database")
 					'((quote lambda) '('username 'database) '((quote and) '((quote equal??) (quote username) username) '((quote equal??) (quote database) db)))
 					'(list "$update")
@@ -839,8 +838,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan)
 					'(session "__memcp_tx")
-					"system"
-					"access"
+					'('table "system" "access")
 					'(list "username" "database")
 					'((quote lambda) '('username 'database) '((quote and) '((quote equal??) (quote username) username) '((quote equal??) (quote database) db)))
 					'(list "$update")
@@ -853,8 +851,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan)
 					'(session "__memcp_tx")
-					"system"
-					"access"
+					'('table "system" "access")
 					'(list "username" "database")
 					'((quote lambda) '('username 'database) '((quote and) '((quote equal?) (quote username) username) '((quote equal?) (quote database) db)))
 					'(list "$update")
@@ -863,7 +860,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					0
 		)))
 
-		(parser '((atom "CREATE" true) (define unique (? (atom "UNIQUE" true))) (atom "INDEX" true) (define id psql_identifier) (atom "ON" true) (define tbl (or (parser '(psql_identifier "." (define id psql_identifier)) id) psql_identifier)) (? (atom "USING" true) psql_identifier) "(" (define cols (+ psql_identifier ",")) ")") (if unique '('createkey schema tbl id unique (cons (quote list) cols)) true))
+		(parser '((atom "CREATE" true) (define unique (? (atom "UNIQUE" true))) (atom "INDEX" true) (define id psql_identifier) (atom "ON" true) (define tbl (or (parser '(psql_identifier "." (define id psql_identifier)) id) psql_identifier)) (? (atom "USING" true) psql_identifier) "(" (define cols (+ psql_identifier ",")) ")") (if unique '('createkey '('table schema tbl) id unique (cons (quote list) cols)) true))
 		(parser '((atom "DROP" true) (atom "INDEX" true) (define id psql_identifier)) true)
 
 		/* SHOW CREATE TABLE [schema.]table */
@@ -933,9 +930,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 		(parser '((atom "DROP" true) (atom "DATABASE" true) (define id psql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
-		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) schema oldname newname))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
+		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) '('table schema oldname) newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key psql_identifier) "=" (define value (or
 			(parser (atom "content" true) "content") /* quirks for SET xmloption = content */
 			(parser (atom "warning" true) "warning") /* quirks for SET client_min_messages = warning */
@@ -985,7 +982,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(state "line" (lambda (line) (begin
 						(match line
 							"\\.\n" /* end of input */ (state "line" psql_line)
-							(concat x "\n") (insert schema tbl columns '((split x "\t")))
+							(concat x "\n") (insert (table schema tbl) columns '((split x "\t")))
 						)
 					)))
 				))

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -932,7 +932,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser '((atom "DROP" true) (atom "DATABASE" true) (define id psql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
-		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) '('table schema oldname) newname))
+		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key psql_identifier) "=" (define value (or
 			(parser (atom "content" true) "content") /* quirks for SET xmloption = content */
 			(parser (atom "warning" true) "warning") /* quirks for SET client_min_messages = warning */

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -930,8 +930,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 		(parser '((atom "DROP" true) (atom "DATABASE" true) (define id psql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) '('table schema id) (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key psql_identifier) "=" (define value (or
 			(parser (atom "content" true) "content") /* quirks for SET xmloption = content */

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1473,7 +1473,7 @@ comes from show() on the existing parent table and fk_init_code creates the alia
 	(define fk_result (if (and physical_tbl (nil? condition_suffix) (equal? 1 (count keys)))
 		(match (car keys)
 			'('get_column (eval tblvar) false scol false) (begin
-				(define fk_info (get_fk_target schema tbl scol))
+				(define fk_info (get_fk_target (table schema tbl) scol))
 				(if (not (nil? fk_info))
 					(begin
 						(define alias_map (list (list tblvar (concat schema "." tbl))))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -658,13 +658,17 @@ while still recursing into deeper helper lineage when needed. */
 	'((quote materialized-subquery) key) ((context "session") key)
 	(table schema tbl)
 )))
-/* scan-codegen-table: generates a table expression for codegen (list context) */
+/* scan-codegen-table: generates a table reference for codegen — uses pre-resolved symbol */
 (define scan-codegen-table (lambda (schema tbl) (match tbl
 	'(materialized-subquery key) (list (list (quote context) "session") key)
 	'((symbol materialized-subquery) key) (list (list (quote context) "session") key)
 	'((quote materialized-subquery) key) (list (list (quote context) "session") key)
-	(list (quote table) schema tbl)
+	(symbol (concat "tbl:" schema ":" tbl))
 )))
+
+/* tbl-define-code: generates (define tbl:schema:name (table schema name)) for init blocks */
+(define tbl-define-code (lambda (schema tbl)
+	(list 'define (symbol (concat "tbl:" schema ":" tbl)) (list 'table schema tbl))))
 
 /* scan_batch peephole optimization has been moved to the Go optimizer hook
 in storage/scan_batch_rewrite.go (optimizeScan → tryScanBatchRewrite). */
@@ -1541,11 +1545,13 @@ comes from show() on the existing parent table and fk_init_code creates the alia
 			createtable returns true on first creation — caller wraps collect + trigger deploy
 			in this guard. On subsequent calls createtable returns false (table already exists,
 			incrementally maintained by triggers). partitiontable and touch_keytable are idempotent. */
-			(define init_code (list 'begin
+			(define init_code (list '!begin
 				(list 'if (list 'createtable schema keytable_name kt_cols_code query_temp_table_options_code true)
 					(list 'partitiontable (list 'table schema keytable_name) kt_partition_code)
 					nil)
 				(list 'touch_keytable (list 'table schema keytable_name))
+				/* pre-resolve keytable pointer for inner loops */
+				(tbl-define-code schema keytable_name)
 				/* returns true when collect + trigger deploy is needed:
 				   createtable=true (new) OR table_empty (restart recovery) */
 				(list 'or
@@ -4546,8 +4552,7 @@ Key helpers:
 */
 /* update_target: nil for SELECT, or (tblalias (col1 expr1 col2 expr2 ...)) for multi-table UPDATE.
 When set, the scan on tblalias includes $update in mapcols and the mapfn applies the SET expressions. */
-(define build_queryplan (lambda (schema tables fields condition groups schemas replace_find_column update_target) (begin
-	/*(print "build queryplan " '(schema tables fields condition groups schemas))*/
+(define _build_queryplan_inner (lambda (schema tables fields condition groups schemas replace_find_column update_target) (begin
 
 	/* TODO: order tables: outer joins behind */
 	(set groups (coalesceNil groups '()))
@@ -7398,3 +7403,12 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 	)))
 )))
 )
+/* build_queryplan: wraps _build_queryplan_inner with table-pointer pre-resolution */
+(define build_queryplan (lambda (schema tables fields condition groups schemas replace_find_column update_target) (begin
+	(define _tbl_defines (filter (map tables (lambda (td) (match td
+		'(_ tschema tname _ _) (if (string? tname) (tbl-define-code tschema tname) nil)
+		nil))) (lambda (d) (not (nil? d)))))
+	(define _plan (_build_queryplan_inner schema tables fields condition groups schemas replace_find_column update_target))
+	(if (equal? _tbl_defines '()) _plan
+		(cons '!begin (merge _tbl_defines (list _plan))))
+)))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -53,12 +53,12 @@ Uses code-generator pattern: values baked into quoted lambda body at register ti
 so no closure capture — the trigger body serializes cleanly as a self-contained expression. */
 (define register_prejoin_invalidation (lambda (src_schema src_table pj_schema pj_table) (begin
 	(define prefix (concat ".prejoin:" pj_table "|" src_table "|"))
-	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable pj_schema pj_table true))))
-	(createtrigger src_schema src_table (concat prefix "after_insert")     "after_insert"     "" drop_body false)
-	(createtrigger src_schema src_table (concat prefix "after_update")     "after_update"     "" drop_body false)
-	(createtrigger src_schema src_table (concat prefix "after_delete")     "after_delete"     "" drop_body false)
-	(createtrigger src_schema src_table (concat prefix "after_drop_table") "after_drop_table" "" drop_body false)
-	(createtrigger src_schema src_table (concat prefix "after_drop_column") "after_drop_column" "" drop_body false)
+	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable (list 'table pj_schema pj_table) true))))
+	(createtrigger (table src_schema src_table) (concat prefix "after_insert")     "after_insert"     "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_update")     "after_update"     "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_delete")     "after_delete"     "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_drop_table") "after_drop_table" "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_drop_column") "after_drop_column" "" drop_body false)
 	true)))
 
 /* Registers incremental maintenance triggers on src_table to keep pj_table in sync.
@@ -67,12 +67,12 @@ Lifecycle triggers use code-generator pattern for the drop body as well.
 update_fn embeds delete_fn/insert_fn as proc literals in its body (no closure capture). */
 (define register_prejoin_incremental (lambda (src_schema src_table pj_schema pj_table delete_fn insert_fn update_fn) (begin
 	(define prefix (concat ".pj_incr:" pj_table "|" src_table "|"))
-	(createtrigger src_schema src_table (concat prefix "after_delete") "after_delete" "" delete_fn false)
-	(createtrigger src_schema src_table (concat prefix "after_insert") "after_insert" "" insert_fn false)
-	(createtrigger src_schema src_table (concat prefix "after_update") "after_update" "" update_fn false)
-	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable pj_schema pj_table true))))
-	(createtrigger src_schema src_table (concat prefix "after_drop_table") "after_drop_table" "" drop_body false)
-	(createtrigger src_schema src_table (concat prefix "after_drop_column") "after_drop_column" "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_delete") "after_delete" "" delete_fn false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_insert") "after_insert" "" insert_fn false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_update") "after_update" "" update_fn false)
+	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable (list 'table pj_schema pj_table) true))))
+	(createtrigger (table src_schema src_table) (concat prefix "after_drop_table") "after_drop_table" "" drop_body false)
+	(createtrigger (table src_schema src_table) (concat prefix "after_drop_column") "after_drop_column" "" drop_body false)
 	true)))
 
 /* prejoin_canonical_sources maps a materialized prejoin table name to an assoc
@@ -1488,11 +1488,11 @@ comes from show() on the existing parent table and fk_init_code creates the alia
 						(define parent_schema (show schema parent_tbl))
 						/* FK-reuse createcolumn on parent: safe at compile time (parent is a physical table) */
 						(if (not (equal? key_name parent_col))
-							(createcolumn schema parent_tbl key_name "any" '() '("temp" true)
+							(createcolumn (table schema parent_tbl) key_name "any" '() '("temp" true)
 								(list parent_col)
 								(eval (list 'lambda (list (symbol parent_col)) (symbol parent_col)))))
 						(define fk_init (if (equal? key_name parent_col) nil
-							(list 'createcolumn schema parent_tbl key_name "any"
+							(list 'createcolumn (list 'table schema parent_tbl) key_name "any"
 								(list 'quote '())
 								(list 'quote '("temp" true))
 								(list 'quote (list parent_col))
@@ -1526,7 +1526,7 @@ comes from show() on the existing parent table and fk_init_code creates the alia
 			(define kt_partition_code (cons 'list (if physical_tbl
 				(merge (map (produceN (count keys)) (lambda (i)
 					(match (key_at i)
-						'('get_column (eval tblvar) false scol false) (list (list 'list (key_name_at i) (list 'shardcolumn schema tbl scol)))
+						'('get_column (eval tblvar) false scol false) (list (list 'list (key_name_at i) (list 'shardcolumn (list 'table schema tbl) scol)))
 						'()))))
 				'())))
 			/* init_code: idempotent runtime keytable creation.
@@ -1535,14 +1535,14 @@ comes from show() on the existing parent table and fk_init_code creates the alia
 			incrementally maintained by triggers). partitiontable and touch_keytable are idempotent. */
 			(define init_code (list 'begin
 				(list 'if (list 'createtable schema keytable_name kt_cols_code query_temp_table_options_code true)
-					(list 'partitiontable schema keytable_name kt_partition_code)
+					(list 'partitiontable (list 'table schema keytable_name) kt_partition_code)
 					nil)
-				(list 'touch_keytable schema keytable_name)
+				(list 'touch_keytable (list 'table schema keytable_name))
 				/* returns true when collect + trigger deploy is needed:
 				   createtable=true (new) OR table_empty (restart recovery) */
 				(list 'or
 					(list 'not (list 'has? (list 'show schema) keytable_name))
-					(list 'table_empty? schema keytable_name))))
+					(list 'table_empty? (list 'table schema keytable_name)))))
 			(define kt_schema_def (map key_names (lambda (colname) (list "Field" colname "Type" "any"))))
 			(list keytable_name kt_schema_def init_code nil)))
 )))
@@ -1629,7 +1629,7 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 			'()))
 		/* collect plan */
 		(define collect_plan (if (equal? group_keys '(1))
-			'('insert schema grouptbl '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
+			'('insert '('table schema grouptbl) '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
 			(begin
 				(define keycols (merge_unique (map group_keys (lambda (expr) (extract_columns_for_tblvar tblvar expr)))))
 				(scan_wrapper 'scan schema tbl
@@ -1639,7 +1639,7 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 					'('lambda (map keycols (lambda (col) (symbol (concat tblvar "." col)))) (cons 'list (map group_keys (lambda (expr) (replace_columns_from_expr expr)))))
 					'('lambda '('acc 'rowvals) '('set_assoc 'acc 'rowvals true))
 					'(list)
-					'('lambda '('acc 'sharddict) '('insert schema grouptbl (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
+					'('lambda '('acc 'sharddict) '('insert '('table schema grouptbl) (cons 'list (map group_keys expr_name)) '('extract_assoc 'sharddict '('lambda '('k 'v) 'k)) '(list) '('lambda '() true) true))
 					isOuter))))
 		/* aggregate descriptors */
 		(define agg_col_name (make_aggregate_cache_col_name expr_name condition window_runtime_suffix))
@@ -1655,7 +1655,7 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 		(define agg_plans (map ags (lambda (ag) (match ag '(expr reduce neutral) (begin
 			(define runtime_expr (lower_window_runtime_expr expr))
 			(define cols (extract_columns_for_tblvar tblvar runtime_expr))
-			'('createcolumn schema grouptbl (agg_col_name ag) "any" '(list) '(list "temp" true)
+			'('createcolumn '('table schema grouptbl) (agg_col_name ag) "any" '(list) '(list "temp" true)
 				(cons list (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
 				'('lambda (map group_keys (lambda (col) (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))
 					(scan_wrapper 'scan schema tbl
@@ -1679,7 +1679,7 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 					(define kt_key_names (map group_keys (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
 					/* outer refs need raw column names (tblvar.col), not canonical expr_name */
 					(define raw_col_names (map group_keys (lambda (col) (match col '('get_column _ _ c _) c (expr_name col)))))
-					(list 'scan '(session "__memcp_tx") schema grouptbl
+					(list 'scan '(session "__memcp_tx") (list 'table schema grouptbl)
 						(cons 'list kt_key_names)
 						/* filter: (equal? grouptbl.kt_key (outer tblvar.raw_col)) — zip kt_key_names with raw_col_names */
 						(list 'lambda
@@ -1689,7 +1689,7 @@ Result query runs on the BASE table; window_func expressions are replaced with s
 						(list 'list ag_col)
 						'('lambda '('__v) '__v)
 						'('lambda '('__a '__b) '__b) nil nil false))
-					(list 'scan '(session "__memcp_tx") schema grouptbl '(list) '('lambda '() true)
+					(list 'scan '(session "__memcp_tx") (list 'table schema grouptbl) '(list) '('lambda '() true)
 						(list 'list ag_col)
 						'('lambda '('__v) '__v)
 						'('lambda '('__a '__b) '__b) nil nil false)))
@@ -1809,7 +1809,7 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW session) ...) and
 					(set filtercols (merge_unique (list
 						(extract_columns_for_tblvar tblvar now_condition)
 						(extract_outer_columns_for_tblvar tblvar now_condition))))
-					(list 'scan '(session "__memcp_tx") schema tbl
+					(list 'scan '(session "__memcp_tx") (list 'table schema tbl)
 						(cons 'list filtercols)
 						/* filter lambda: (lambda (tv.col ...) compiled_condition) */
 						(list 'lambda (map filtercols (lambda (c) (symbol (concat tblvar "." c))))
@@ -1824,7 +1824,7 @@ Returns an S-expression that, when wrapped in (lambda (OLD NEW session) ...) and
 						/* reduce2: outermost inserts into pjtbl, inner levels merge */
 						(if is_outermost
 							(list 'lambda (list 'acc 'shard_rows)
-								(list 'insert pj_schema pjtbl (cons 'list mat_col_names) 'shard_rows (list) (list 'lambda (list) true) true))
+								(list 'insert (list 'table pj_schema pjtbl) (cons 'list mat_col_names) 'shard_rows (list) (list 'lambda (list) true) true))
 							(list 'lambda (list 'acc 'shard_rows) (list 'merge 'acc 'shard_rows)))
 						isOuter)
 				))
@@ -2634,7 +2634,7 @@ seeing the correctly prefixed outer alias. */
 									(list (quote createtable) schema2_us "(1)"
 										(list (list "unique" "group" (list "1")) (list "column" "1" "any" '() '()))
 										(list "engine" "sloppy") true)
-									(list (quote insert) schema2_us "(1)" (list "1") (list (list 1)) '() (list (quote lambda) '() true) true)))
+									(list (quote insert) (list (quote table) schema2_us "(1)") (list "1") (list (list 1)) '() (list (quote lambda) '() true) true)))
 								(if (or (nil? tables2_us) (equal? tables2_us '()))
 									(begin
 										(set tables2_us (list (list "(1)" schema2_us "(1)" false nil)))
@@ -3429,8 +3429,8 @@ seeing the correctly prefixed outer alias. */
 				(createtable schema ".(1)"
 					(list (list "unique" "group" (list "1")) (list "column" "1" "any" (list) (list)))
 					(list "engine" "sloppy") true)
-				(if (table_empty? schema ".(1)")
-					(insert schema ".(1)" (list "1") (list (list 1)) (list) (lambda () true) true)
+				(if (table_empty? (table schema ".(1)"))
+					(insert (table schema ".(1)") (list "1") (list (list 1)) (list) (lambda () true) true)
 					nil))
 			(list (list ".(1)" schema ".(1)" false nil)))
 		tables))
@@ -5341,7 +5341,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					'('time '('begin
 						/* If grouping is global (group='(1)), avoid base scan and insert one key row */
 						(if (equal? resolved_stage_group '(1))
-							'('insert schema grouptbl '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
+							'('insert '('table schema grouptbl) '(list "1") '(list '(list 1)) '(list) '('lambda '() true) true)
 							(begin
 								/* key columns */
 								(set keycols (merge_unique (map resolved_stage_group (lambda (expr) (extract_columns_for_tblvar tblvar expr)))))
@@ -5794,7 +5794,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 								(list (expr_name expr) (expr_name expr))
 						))))
 						(define cleanup_plan (if (or is_fk_reuse (equal? resolved_stage_group '(1))) nil
-							(list 'register_keytable_cleanup schema tbl schema grouptbl tblvar
+							(list 'register_keytable_cleanup (list 'table schema tbl) (list 'table schema grouptbl) tblvar
 								(cons 'list (map key_pairs (lambda (p) (list 'list (car p) (cadr p))))))))
 						/* collect + trigger deploy on first keytable creation only.
 						createtable inside init_code returns true on first creation.
@@ -6272,7 +6272,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 									'(list)
 									/* reduce2: outermost inserts into prejoin, inner levels merge */
 									(if is_outermost
-										'('lambda '('acc 'shard_rows) '('insert prejoin_schema prejointbl (cons 'list prejoin_column_names) 'shard_rows '(list) '('lambda '() true) true))
+										'('lambda '('acc 'shard_rows) '('insert '('table prejoin_schema prejointbl) (cons 'list prejoin_column_names) 'shard_rows '(list) '('lambda '() true) true))
 										'('lambda '('acc 'shard_rows) '('merge 'acc 'shard_rows)))
 									isOuter
 								)
@@ -6303,7 +6303,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 						(list 'set _pj_prev_rr (symbol "resultrow"))
 						(list 'set (symbol "resultrow")
 							(list 'lambda (list _pj_row_sym)
-								(list 'insert prejoin_schema prejointbl
+								(list 'insert (list 'table prejoin_schema prejointbl)
 									(cons 'list prejoin_column_names)
 									(list 'list
 										(cons 'list (map prejoin_column_names (lambda (col)
@@ -6697,7 +6697,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 												(build_pj_insert_scan tables condition trigger_tv true prejoin_schema prejoin_table_name prejoin_columns prejoin_column_names))))
 										(define insert_fn
 											(eval (list 'lambda (list 'OLD 'NEW 'session)
-												(list 'if (list 'table_empty? prejoin_schema prejoin_table_name)
+												(list 'if (list 'table_empty? (list 'table prejoin_schema prejoin_table_name))
 													true
 													(list raw_insert_fn 'OLD 'NEW 'session)))))
 										/* UPDATE trigger: delete old prejoin rows + insert new for any row change.
@@ -6708,7 +6708,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										(define raw_update_fn (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'begin (list delete_fn 'OLD 'NEW 'session) (list raw_insert_fn 'OLD 'NEW 'session)))))
 										(define update_fn
 											(eval (list 'lambda (list 'OLD 'NEW 'session)
-												(list 'if (list 'table_empty? prejoin_schema prejoin_table_name)
+												(list 'if (list 'table_empty? (list 'table prejoin_schema prejoin_table_name))
 													true
 													(list raw_update_fn 'OLD 'NEW 'session)))))
 										/* emit the register call as an S-expression to be executed at query time */
@@ -6723,7 +6723,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							(list 'createtable pj_schema prejointbl
 								(cons 'list (map prejoin_column_names (lambda (col) (list 'list "column" col "any" '(list) '(list)))))
 								query_temp_table_options_code true)
-							(list 'table_empty? pj_schema prejointbl))
+							(list 'table_empty? (list 'table pj_schema prejointbl)))
 							(cons 'begin (cons (list 'time prejoin_materialize_plan "materialize") pj_trigger_registrations))
 							nil))
 					(list grouped_result)))
@@ -6923,7 +6923,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 								orc_sort_dirs_vals))
 							/* partitioncount is auto-detected from reduceinit shape: (list init nil) → 1 partition key */
 							(define orc_setup (lambda ()
-								(createcolumn schema tbl orc_col_name "any" '()
+								(createcolumn (table schema tbl) orc_col_name "any" '()
 									(list "sortcols" full_sort_cols "sortdirs" full_sort_dirs
 										"mapcols" extra_mapcols
 										"mapfn" orc_mapfn "reducefn" orc_reducefn

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4363,8 +4363,7 @@ second table carries strictly more local WHERE predicates than the first. */
 					/* Emit scan_order_multi call */
 					(merge (list (symbol "scan_order_multi") '(session "__memcp_tx"))
 						(list
-							(cons (symbol "list") (map scan_specs (lambda (s) (nth s 0))))
-							(cons (symbol "list") (map scan_specs (lambda (s) (nth s 1))))
+							(cons (symbol "list") (map scan_specs (lambda (s) (list (symbol "table") (nth s 0) (nth s 1)))))
 							(cons (symbol "list") (map scan_specs (lambda (s) (cons (symbol "list") (nth s 2)))))
 							(cons (symbol "list") (map scan_specs (lambda (s) (nth s 3))))
 							(cons (symbol "list") (map scan_specs (lambda (s) (cons (symbol "list") (nth s 4)))))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -53,7 +53,7 @@ Uses code-generator pattern: values baked into quoted lambda body at register ti
 so no closure capture — the trigger body serializes cleanly as a self-contained expression. */
 (define register_prejoin_invalidation (lambda (src_schema src_table pj_schema pj_table) (begin
 	(define prefix (concat ".prejoin:" pj_table "|" src_table "|"))
-	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable (list 'table pj_schema pj_table) true))))
+	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable pj_schema pj_table true))))
 	(createtrigger (table src_schema src_table) (concat prefix "after_insert")     "after_insert"     "" drop_body false)
 	(createtrigger (table src_schema src_table) (concat prefix "after_update")     "after_update"     "" drop_body false)
 	(createtrigger (table src_schema src_table) (concat prefix "after_delete")     "after_delete"     "" drop_body false)
@@ -70,7 +70,7 @@ update_fn embeds delete_fn/insert_fn as proc literals in its body (no closure ca
 	(createtrigger (table src_schema src_table) (concat prefix "after_delete") "after_delete" "" delete_fn false)
 	(createtrigger (table src_schema src_table) (concat prefix "after_insert") "after_insert" "" insert_fn false)
 	(createtrigger (table src_schema src_table) (concat prefix "after_update") "after_update" "" update_fn false)
-	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable (list 'table pj_schema pj_table) true))))
+	(define drop_body (eval (list 'lambda (list 'OLD 'NEW 'session) (list 'droptable pj_schema pj_table true))))
 	(createtrigger (table src_schema src_table) (concat prefix "after_drop_table") "after_drop_table" "" drop_body false)
 	(createtrigger (table src_schema src_table) (concat prefix "after_drop_column") "after_drop_column" "" drop_body false)
 	true)))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -644,18 +644,26 @@ while still recursing into deeper helper lineage when needed. */
 
 /* scalar subselect helper wrappers */
 (define scalar_scan (lambda (schema tbl filtercols filterfn mapcols mapfn reduce neutral reduce2) (begin
-	(define result (scan (session "__memcp_tx") schema (scan-runtime-source tbl) filtercols filterfn mapcols mapfn reduce neutral reduce2))
+	(define result (scan (session "__memcp_tx") (scan-runtime-table schema tbl) filtercols filterfn mapcols mapfn reduce neutral reduce2))
 	(if (equal? result neutral) nil result)
 )))
 (define scalar_scan_order (lambda (schema tbl filtercols filterfn sortcols sortdirs offset limit mapcols mapfn reduce neutral) (begin
-	(define result (scan_order (session "__memcp_tx") schema (scan-runtime-source tbl) filtercols filterfn sortcols sortdirs 0 offset limit mapcols mapfn reduce neutral))
+	(define result (scan_order (session "__memcp_tx") (scan-runtime-table schema tbl) filtercols filterfn sortcols sortdirs 0 offset limit mapcols mapfn reduce neutral))
 	(if (equal? result neutral) nil result)
 )))
-(define scan-runtime-source (lambda (table-source) (match table-source
+/* scan-runtime-table: resolves a table source at runtime (direct call context) */
+(define scan-runtime-table (lambda (schema tbl) (match tbl
+	'(materialized-subquery key) ((context "session") key)
+	'((symbol materialized-subquery) key) ((context "session") key)
+	'((quote materialized-subquery) key) ((context "session") key)
+	(table schema tbl)
+)))
+/* scan-codegen-table: generates a table expression for codegen (list context) */
+(define scan-codegen-table (lambda (schema tbl) (match tbl
 	'(materialized-subquery key) (list (list (quote context) "session") key)
 	'((symbol materialized-subquery) key) (list (list (quote context) "session") key)
 	'((quote materialized-subquery) key) (list (list (quote context) "session") key)
-	table-source
+	(list (quote table) schema tbl)
 )))
 
 /* scan_batch peephole optimization has been moved to the Go optimizer hook
@@ -2527,8 +2535,7 @@ seeing the correctly prefixed outer alias. */
 													(if use_ordered_scalar
 														(list (quote scan_order)
 															(list (quote session) "__memcp_tx")
-															schema3
-															(scan-runtime-source tbl3)
+															(scan-codegen-table schema3 tbl3)
 															(cons list filtercols)
 															(list (quote lambda) filterparams filterbody)
 															(cons list ordercols)
@@ -2544,8 +2551,7 @@ seeing the correctly prefixed outer alias. */
 															false)
 														(list (quote scan)
 															(list (quote session) "__memcp_tx")
-															schema3
-															(scan-runtime-source tbl3)
+															(scan-codegen-table schema3 tbl3)
 															(cons list filtercols)
 															(list (quote lambda) filterparams filterbody)
 															(cons list mapcols)
@@ -5089,7 +5095,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					(define lowered_expr (group_value_local_key_expr expr))
 					(define col_name (group_value_local_col_name expr))
 					(define cols (extract_columns_for_tblvar tblvar lowered_expr))
-					(list (quote createcolumn) schema tbl col_name "any" '(list) '(list "temp" true)
+					(list (quote createcolumn) (list (quote table) schema tbl) col_name "any" '(list) '(list "temp" true)
 						(cons (quote list) cols)
 						(list (quote lambda) (map cols (lambda (col) (symbol (concat tblvar "." col))))
 							(replace_columns_from_expr lowered_expr))))))
@@ -5358,7 +5364,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 									'(list) /* empty dict */
 									'((quote lambda) '('acc 'sharddict)
 										'('insert
-											schema grouptbl
+											'('table schema grouptbl)
 											(cons 'list (map resolved_stage_group expr_name))
 											'('assoc_keys_as_dataset_rows 'sharddict (count resolved_stage_group)) /* turn keys from assoc into dataset rows */
 											'(list) '('lambda '() true) true)
@@ -5736,7 +5742,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 							)))
 							/* COUNT column itself must not filter by itself (circular); all others filter by COUNT>0 */
 							(define this_options (if (and needs_count (equal? (agg_col_name ag) count_col_name)) '(list "temp" true) createcol_options))
-							'((quote createcolumn) schema grouptbl (agg_col_name ag) "any" '(list) this_options
+							'((quote createcolumn) '('table schema grouptbl) (agg_col_name ag) "any" '(list) this_options
 								(cons list (map resolved_stage_group (lambda (col) (if is_fk_reuse fk_pk_col (expr_name col)))))
 								'((quote lambda) (map resolved_stage_group (lambda (col) (symbol (if is_fk_reuse fk_pk_col (expr_name col)))))
 									(scan_wrapper 'scan schema tbl
@@ -5880,8 +5886,7 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 												(list (quote set) (symbol pn)
 													(list (quote scan)
 														'(session "__memcp_tx")
-														schema
-														(scan-runtime-source grouptbl)
+														(scan-codegen-table schema grouptbl)
 														(list (quote list) acn)
 														(list (quote lambda) (list (symbol acn)) true)
 														(list (quote list) acn)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2541,7 +2541,7 @@ seeing the correctly prefixed outer alias. */
 													(if use_ordered_scalar
 														(list (quote scan_order)
 															(list (quote session) "__memcp_tx")
-															(scan-codegen-table schema3 tbl3)
+															(list (quote table) schema3 tbl3)
 															(cons list filtercols)
 															(list (quote lambda) filterparams filterbody)
 															(cons list ordercols)
@@ -2557,7 +2557,7 @@ seeing the correctly prefixed outer alias. */
 															false)
 														(list (quote scan)
 															(list (quote session) "__memcp_tx")
-															(scan-codegen-table schema3 tbl3)
+															(list (quote table) schema3 tbl3)
 															(cons list filtercols)
 															(list (quote lambda) filterparams filterbody)
 															(cons list mapcols)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -658,12 +658,12 @@ while still recursing into deeper helper lineage when needed. */
 	'((quote materialized-subquery) key) ((context "session") key)
 	(table schema tbl)
 )))
-/* scan-codegen-table: generates a table reference for codegen — uses pre-resolved symbol */
+/* scan-codegen-table: generates a table expression for codegen */
 (define scan-codegen-table (lambda (schema tbl) (match tbl
 	'(materialized-subquery key) (list (list (quote context) "session") key)
 	'((symbol materialized-subquery) key) (list (list (quote context) "session") key)
 	'((quote materialized-subquery) key) (list (list (quote context) "session") key)
-	(symbol (concat "tbl:" schema ":" tbl))
+	(list (quote table) schema tbl)
 )))
 
 /* tbl-define-code: generates (define tbl:schema:name (table schema name)) for init blocks */
@@ -7403,12 +7403,30 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 	)))
 )))
 )
+/* _replace_table_with_sym: replaces (table schema name) AST nodes with tbl:schema:name symbols
+   for tables that have pre-resolved defines. tbl_map is an assoc list of (schema.name . symbol). */
+(define _replace_table_with_sym (lambda (expr tbl_map)
+	(if (not (list? expr)) expr
+		(if (and (equal? (count expr) 3) (equal? (car expr) 'table) (string? (nth expr 1)) (string? (nth expr 2)))
+			(begin
+				(define key (concat (nth expr 1) ":" (nth expr 2)))
+				(define sym (get_assoc tbl_map key))
+				(if (nil? sym) expr sym))
+			(map expr (lambda (e) (_replace_table_with_sym e tbl_map)))))))
+
 /* build_queryplan: wraps _build_queryplan_inner with table-pointer pre-resolution */
 (define build_queryplan (lambda (schema tables fields condition groups schemas replace_find_column update_target) (begin
-	(define _tbl_defines (filter (map tables (lambda (td) (match td
-		'(_ tschema tname _ _) (if (string? tname) (tbl-define-code tschema tname) nil)
+	/* Collect base tables that can be pre-resolved */
+	(define _tbl_entries (filter (map tables (lambda (td) (match td
+		'(_ tschema tname _ _) (if (string? tname) (list tschema tname) nil)
 		nil))) (lambda (d) (not (nil? d)))))
+	(define _tbl_defines (map _tbl_entries (lambda (e) (tbl-define-code (car e) (car (cdr e))))))
+	(define _tbl_map (merge (map _tbl_entries (lambda (e)
+		(list (concat (car e) ":" (car (cdr e))) (symbol (concat "tbl:" (car e) ":" (car (cdr e)))))))))
 	(define _plan (_build_queryplan_inner schema tables fields condition groups schemas replace_find_column update_target))
 	(if (equal? _tbl_defines '()) _plan
-		(cons '!begin (merge _tbl_defines (list _plan))))
+		(begin
+			/* Replace (table schema name) calls with pre-resolved symbols in the plan */
+			(define _opt_plan (_replace_table_with_sym _plan _tbl_map))
+			(cons '!begin (merge _tbl_defines (list _opt_plan)))))
 )))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -661,7 +661,7 @@ consumer stage. */
 	(seen)
 )))
 (define rdf_ensure_table (lambda (schema)
-	(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema table write) true)))
+	(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema tblname write) true)))
 ))
 (define rdf_insert_triples (lambda (schema triples)
 	(if (equal? triples '())

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -641,7 +641,7 @@ consumer stage. */
 ))
 (define rdf_relation_targets (lambda (schema subj pred) (begin
 	(define out (newsession))
-	(scan (session "__memcp_tx") schema "rdf" '("s" "p") (lambda (s p) (and (equal? s subj) (equal? p pred))) '("o") (lambda (o) (out o true)))
+	(scan (session "__memcp_tx") (table schema "rdf") '("s" "p") (lambda (s p) (and (equal? s subj) (equal? p pred))) '("o") (lambda (o) (out o true)))
 	(out)
 )))
 (define rdf_path_targets (lambda (schema start pred include_self) (begin
@@ -666,12 +666,12 @@ consumer stage. */
 (define rdf_insert_triples (lambda (schema triples)
 	(if (equal? triples '())
 		nil
-		(insert schema "rdf" '("s" "p" "o") triples '() (lambda () true))
+		(insert (table schema "rdf") '("s" "p" "o") triples '() (lambda () true))
 	)
 ))
 (define rdf_delete_triples (lambda (schema triples) (begin
 	(map triples (lambda (triple) (match triple '(subj pred obj)
-		(scan (session "__memcp_tx") schema "rdf" '("s" "p" "o") (lambda (s p o) (and (equal? s subj) (equal? p pred) (equal? o obj))) '("$update") (lambda ($update) ($update)))
+		(scan (session "__memcp_tx") (table schema "rdf") '("s" "p" "o") (lambda (s p o) (and (equal? s subj) (equal? p pred) (equal? o obj))) '("$update") (lambda ($update) ($update)))
 	)))
 	nil
 )))
@@ -831,11 +831,11 @@ consumer stage. */
 									(set map_fn (list (quote lambda) (extract_assoc vars (lambda (k v) (symbol v))) (build_scan tail (if order_head order_rest order) inner_ctx resultfunc2)))
 									(match order_head
 										'(col dir)
-										(list (quote scan_order) (list (quote session) "__memcp_tx") schema "rdf"
+										(list (quote scan_order) (list (quote session) "__memcp_tx") (list (quote table) schema "rdf")
 											filter_cols filter_fn
 											(list (quote list) col) (list (quote list) (match dir "DESC" > <)) 0 0 -1
 											map_cols map_fn (quote cons) nil)
-										(list (quote scan) (list (quote session) "__memcp_tx") schema "rdf" filter_cols filter_fn map_cols map_fn)
+										(list (quote scan) (list (quote session) "__memcp_tx") (list (quote table) schema "rdf") filter_cols filter_fn map_cols map_fn)
 									)
 							)))
 					))
@@ -1009,7 +1009,7 @@ consumer stage. */
 (define delete_ttl (lambda (schema s) (begin
 	(set triples (parse_ttl_triples schema s))
 	(map triples (lambda (triple) (match triple '(subj pred obj)
-		(scan (session "__memcp_tx") schema "rdf" '("s" "p" "o") (lambda (s p o) (and (equal? s subj) (equal? p pred) (equal? o obj))) '("$update") (lambda ($update) ($update)))
+		(scan (session "__memcp_tx") (table schema "rdf") '("s" "p" "o") (lambda (s p o) (and (equal? s subj) (equal? p pred) (equal? o obj))) '("$update") (lambda ($update) ($update)))
 	)))
 )))
 
@@ -1063,7 +1063,7 @@ consumer stage. */
 		) '("facts" facts "rest" rest) "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|#[^\r\n]*[\r\n]|#[^\r\n]*$|[\r\n\t ]+)+"))
 		(set load (lambda (facts) (begin
 			/* resolve blank nodes to UUIDs and insert */
-			(insert schema "rdf" '("s" "p" "o") (map facts (lambda (triple) (list (resolve_blank (car triple)) (resolve_blank (car (cdr triple))) (resolve_blank (car (cdr (cdr triple))))))) '() (lambda () true))
+			(insert (table schema "rdf") '("s" "p" "o") (map facts (lambda (triple) (list (resolve_blank (car triple)) (resolve_blank (car (cdr triple))) (resolve_blank (car (cdr (cdr triple))))))) '() (lambda () true))
 		)))
 		(define process_fact (lambda (rest) (match (ttl_fact rest)
 			'("facts" facts "rest" (regex "^[ \\n\\r\\t]*$" _)) (load facts)

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -38,7 +38,7 @@ this is how rdf works:
 	(set old_handler (coalesce http_handler handler_404))
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
+		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
 		(if (and pw (equal? pw (password (req "password")))) (time (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)
@@ -59,7 +59,7 @@ this is how rdf works:
 	)))
 	(define handle_ttl_load (lambda (req res schema ttl_data) (begin
 		/* check for password */
-		(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
+		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
 		(if (and pw (equal? pw (password (req "password")))) (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -65,7 +65,7 @@ this is how rdf works:
 			((res "status") 200)
 			/*(print "Loading TTL data into: " schema)*/
 			/* ensure rdf table exists */
-			(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema table write) true)))
+			(eval (parse_sql schema "CREATE TABLE IF NOT EXISTS rdf (s TEXT, p TEXT, o TEXT)" (lambda (schema tblname write) true)))
 			/* load the TTL data */
 			(load_ttl schema ttl_data)
 			((res "println") "TTL data loaded successfully")

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -210,6 +210,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				table_source)))
 		(define tbl_resolved (scan-table-source tbl))
 		/* materialized subqueries produce list expressions — pass as-is; real tables get (table schema name) */
-		(define tbl_arg (if (string? tbl_resolved) (symbol (concat "tbl:" schema ":" tbl_resolved)) tbl_resolved))
+		(define tbl_arg (if (string? tbl_resolved) (list 'table schema tbl_resolved) tbl_resolved))
 		(merge (list scanfn '(session "__memcp_tx") tbl_arg) rest))
 ))))

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -172,7 +172,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 )))
 (define scan_wrapper (lambda args (match args (merge '(scanfn schema tbl) rest) (match '(schema tbl)
 	'((ignorecase "information_schema") (ignorecase "schemata"))
-	(merge '(scanfn '(session "__memcp_tx") schema 
+	(merge '(scanfn '(session "__memcp_tx")
 		'('map '('show) '('lambda '('schema) '('list "catalog_name" "def" "schema_name" 'schema "default_character_set_name" "utf8mb4" "default_collation_name" "utf8mb3_general_ci" "sql_path" NULL "schema_comment" "")))
 	) rest)
 	'((ignorecase "information_schema") (ignorecase "tables"))
@@ -181,21 +181,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		info_schema_table_row's (show schema tbl true) calls do not execute inside
 		a scan callback where locks are held (which deadlocks). */
 		'('define '__info_tables_data '('merge '('map '('show) '('lambda '('s) '('map '('show 's) '('lambda '('t) '('info_schema_table_row 's 't)))))))
-		(merge '(scanfn '(session "__memcp_tx") schema '__info_tables_data) rest))
+		(merge '(scanfn '(session "__memcp_tx") '__info_tables_data) rest))
 	'((ignorecase "information_schema") (ignorecase "columns"))
-	(merge '(scanfn '(session "__memcp_tx") schema 
+	(merge '(scanfn '(session "__memcp_tx")
 		'((quote merge) '((quote map) '((quote show)) '((quote lambda) '((quote schema)) '((quote merge) '((quote map) '((quote show) (quote schema)) '((quote lambda) '((quote tbl)) '((quote map) '((quote show) (quote schema) (quote tbl)) '((quote lambda) '((quote col)) '((quote list) "table_catalog" "def" "table_schema" (quote schema) "table_name" (quote tbl) "column_name" '((quote col) "Field") "data_type" '((quote col) "RawType") "column_type" '((quote concat) '((quote col) "Type") '((quote col) "Dimensions")))))))))))
 	) rest)
 	'((ignorecase "information_schema") (ignorecase "key_column_usage"))
-	(merge '(scanfn '(session "__memcp_tx") schema '(list)) rest) /* TODO: list constraints */
+	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* TODO: list constraints */
 	'((ignorecase "information_schema") (ignorecase "referential_constraints"))
-	(merge '(scanfn '(session "__memcp_tx") schema '(list)) rest) /* TODO: list constraints */
+	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* TODO: list constraints */
 	'((ignorecase "information_schema") (ignorecase "statistics"))
-	(merge '(scanfn '(session "__memcp_tx") schema '('merge '('map '('show) '('lambda '('schema) '('merge '('map '('show 'schema) '('lambda '('tbl) '('show 'schema 'tbl "statistics")))))))) rest)
+	(merge '(scanfn '(session "__memcp_tx") '('merge '('map '('show) '('lambda '('schema) '('merge '('map '('show 'schema) '('lambda '('tbl) '('show 'schema 'tbl "statistics")))))))) rest)
 	'((ignorecase "information_schema") (ignorecase "files"))
-	(merge '(scanfn '(session "__memcp_tx") schema '(list)) rest) /* empty: MemCP has no tablespaces/undo logs */
+	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* empty: MemCP has no tablespaces/undo logs */
 	'((ignorecase "information_schema") (ignorecase "partitions"))
-	(merge '(scanfn '(session "__memcp_tx") schema '(list)) rest) /* empty: no MySQL partitions */
+	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* empty: no MySQL partitions */
 		'(schema tbl) /* normal case */
 		(begin
 			/* scan helpers receive a runtime source as their table argument.
@@ -208,5 +208,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'((symbol materialized-subquery) key) (list (list (quote context) "session") key)
 				'((quote materialized-subquery) key) (list (list (quote context) "session") key)
 				table_source)))
-		(merge (list scanfn '(session "__memcp_tx") schema (scan-table-source tbl)) rest))
+		(define tbl_resolved (scan-table-source tbl))
+		/* materialized subqueries produce list expressions — pass as-is; real tables get (table schema name) */
+		(define tbl_arg (if (string? tbl_resolved) (list 'table schema tbl_resolved) tbl_resolved))
+		(merge (list scanfn '(session "__memcp_tx") tbl_arg) rest))
 ))))

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -209,7 +209,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'((quote materialized-subquery) key) (list (list (quote context) "session") key)
 				table_source)))
 		(define tbl_resolved (scan-table-source tbl))
-		/* materialized subqueries produce list expressions — pass as-is; real tables use pre-resolved symbol */
-		(define tbl_arg (if (string? tbl_resolved) (symbol (concat "__tbl:" schema "." tbl_resolved)) tbl_resolved))
+		/* materialized subqueries produce list expressions — pass as-is; real tables get (table schema name) */
+		(define tbl_arg (if (string? tbl_resolved) (list 'table schema tbl_resolved) tbl_resolved))
 		(merge (list scanfn '(session "__memcp_tx") tbl_arg) rest))
 ))))

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -210,6 +210,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				table_source)))
 		(define tbl_resolved (scan-table-source tbl))
 		/* materialized subqueries produce list expressions — pass as-is; real tables get (table schema name) */
-		(define tbl_arg (if (string? tbl_resolved) (list 'table schema tbl_resolved) tbl_resolved))
+		(define tbl_arg (if (string? tbl_resolved) (symbol (concat "tbl:" schema ":" tbl_resolved)) tbl_resolved))
 		(merge (list scanfn '(session "__memcp_tx") tbl_arg) rest))
 ))))

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -209,7 +209,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'((quote materialized-subquery) key) (list (list (quote context) "session") key)
 				table_source)))
 		(define tbl_resolved (scan-table-source tbl))
-		/* materialized subqueries produce list expressions — pass as-is; real tables get (table schema name) */
-		(define tbl_arg (if (string? tbl_resolved) (list 'table schema tbl_resolved) tbl_resolved))
+		/* materialized subqueries produce list expressions — pass as-is; real tables use pre-resolved symbol */
+		(define tbl_arg (if (string? tbl_resolved) (symbol (concat "__tbl:" schema "." tbl_resolved)) tbl_resolved))
 		(merge (list scanfn '(session "__memcp_tx") tbl_arg) rest))
 ))))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -769,7 +769,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "VALUES" true) "(" (define e sql_identifier_unquoted) ")") '('get_column "VALUES" true e true)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
 		(parser '((atom "VALUES" true) "(" (define e sql_identifier_quoted) ")") '('get_column "VALUES" true e false)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
 		(parser '((atom "pg_catalog" true) "." (atom "set_config" true) "(" sql_expression "," sql_expression "," sql_expression ")") nil) /* ignore */
-		(parser '((atom "pg_catalog" true) "." (atom "setval" true) "(" "'" sql_identifier "." (define key sql_identifier) "'" "," (define val sql_expression) "," sql_expression ")") (match key (regex "(.*)_(.*?)_seq" _ tbl col) '('altercolumn schema tbl col "auto_increment" val) (error "unknown pg_catalog key: " key)))
+		(parser '((atom "pg_catalog" true) "." (atom "setval" true) "(" "'" sql_identifier "." (define key sql_identifier) "'" "," (define val sql_expression) "," sql_expression ")") (match key (regex "(.*)_(.*?)_seq" _ tbl col) '('altercolumn '('table schema tbl) col "auto_increment" val) (error "unknown pg_catalog key: " key)))
 
 		(parser (atom "NULL" true) (sql_null_literal))
 		(parser (atom "TRUE" true) true)
@@ -919,7 +919,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	))
 	(define sql_insert_select_plan (lambda (schema2 tbl coldesc inner ignoreexists updaterows updaterows2 updatecols) (begin
 		'('begin
-			'('set 'resultrow '('lambda '('item) '('insert schema2 tbl (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols)
+			'('set 'resultrow '('lambda '('item) '('insert '('table schema2 tbl) (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols)
 				(if (and ignoreexists (nil? updaterows))
 					'((quote lambda) '() 0)
 					(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
@@ -1191,7 +1191,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 				(begin
 					(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
 					(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols))
-				'('insert (coalesce schema2 schema) tbl (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
+				'('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
 					(if (and ignoreexists (nil? updaterows))
 						'((quote lambda) '() 0)
 						(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
@@ -1273,7 +1273,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(define coldesc (map assignments (lambda (a) (match a '(col _) col))))
 			(define dataset (map assignments (lambda (a) (match a '(_ value) value))))
-			'('insert (coalesce schema2 schema) tbl (cons list coldesc) '(list (cons list dataset)) '(list)
+			'('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) '(list (cons list dataset)) '(list)
 				(if ignoreexists '('lambda '() true) nil)
 				false '('lambda '('id) '('session "last_insert_id" 'id))))))
 
@@ -1325,7 +1325,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(parser '((atom "COLLATE" true) (define collation (regex "[a-zA-Z0-9_]+"))) '("collation" collation))
 			(parser '((atom "AUTO_INCREMENT" true) "=" (define collation (regex "[0-9]+"))) '("auto_increment" collation))
 		)))
-	) '((quote createtable) (coalesce schema2 schema) id (cons (quote list) cols) (cons (quote list) (merge options)) ifnotexists)))
+	) '((quote createtable) (list (quote table) (coalesce schema2 schema) id) (cons (quote list) cols) (cons (quote list) (merge options)) ifnotexists)))
 
 	(define sql_alter_table (parser '(
 		(atom "ALTER" true)
@@ -1352,7 +1352,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					(parser empty '((quote list)))
 				))
 				(define typeparams sql_column_attributes)
-			) (lambda (id) '((quote createcolumn) schema id col type dimensions (cons 'list typeparams))))
+			) (lambda (id) '((quote createcolumn) '((quote table) schema id) col type dimensions (cons 'list typeparams))))
 			(parser '((atom "MODIFY" true) (?(atom "COLUMN" true))
 				(define col sql_identifier)
 				(define type sql_column_type)
@@ -1362,7 +1362,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					(parser empty '((quote list)))
 				))
 				(define typeparams sql_column_attributes)
-			) (lambda (id) '('!begin '((quote altercolumn) schema id col "type" type) '((quote altercolumn) schema id col "dimensions" dimensions) 1)))
+			) (lambda (id) '('!begin '((quote altercolumn) '((quote table) schema id) col "type" type) '((quote altercolumn) '((quote table) schema id) col "dimensions" dimensions) 1)))
 			(parser '((atom "CHANGE" true)
 				(define oldcol sql_identifier)
 				(define col sql_identifier)
@@ -1373,31 +1373,31 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					(parser empty '((quote list)))
 				))
 				(define typeparams sql_column_attributes)
-			) (lambda (id) '('!begin '((quote altercolumn) schema id col "type" type) '((quote altercolumn) schema id col "dimensions" dimensions) 1)))
+			) (lambda (id) '('!begin '((quote altercolumn) '((quote table) schema id) col "type" type) '((quote altercolumn) '((quote table) schema id) col "dimensions" dimensions) 1)))
 			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "TYPE" true) (define type sql_column_type) (define dimensions (or
 				(parser '("(" (define a sql_int) "," (define b sql_int) ")") '((quote list) a b))
 				(parser '("(" (define a sql_int) ")") '((quote list) a))
 				(parser empty '((quote list)))
-			))) (lambda (id) '('!begin '((quote altercolumn) schema id col "type" type) '((quote altercolumn) schema id col "dimensions" dimensions) 1)))
+			))) (lambda (id) '('!begin '((quote altercolumn) '((quote table) schema id) col "type" type) '((quote altercolumn) '((quote table) schema id) col "dimensions" dimensions) 1)))
 			(parser '((atom "CONVERT" true) (atom "TO" true) (atom "CHARACTER" true) (atom "SET" true) (define charset sql_identifier) (? (atom "COLLATE" true) (define coll sql_identifier))) (lambda (id) true))
-			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (atom "IF" true) (atom "EXISTS" true) (define col sql_identifier)) (lambda (id) '((quote altertable) schema id "drop_if_exists" col)))
-			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (define col sql_identifier)) (lambda (id) '((quote altertable) schema id "drop" col)))
-			(parser '((atom "ENGINE" true) "=" (atom "MEMORY" true)) (lambda (id) '((quote altertable) schema id "engine" "memory")))
-			(parser '((atom "ENGINE" true) "=" (atom "SLOPPY" true)) (lambda (id) '((quote altertable) schema id "engine" "sloppy")))
-			(parser '((atom "ENGINE" true) "=" (atom "CACHE" true)) (lambda (id) '((quote altertable) schema id "engine" "cache")))
-			(parser '((atom "ENGINE" true) "=" (atom "LOGGING" true)) (lambda (id) '((quote altertable) schema id "engine" "logged")))
-			(parser '((atom "ENGINE" true) "=" (atom "LOGGED" true)) (lambda (id) '((quote altertable) schema id "engine" "logged")))
-			(parser '((atom "ENGINE" true) "=" (atom "CSV" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "SAFE" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "MyISAM" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "InnoDB" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "ENGINE" true) "=" (atom "CSV" true)) (lambda (id) '((quote altertable) schema id "engine" "safe")))
-			(parser '((atom "COLLATE" true) "=" (define collation (regex "[a-zA-Z0-9_]+"))) (lambda (id) '((quote altertable) schema id "collation" collation)))
-			(parser '((atom "AUTO_INCREMENT" true) "=" (define ai (regex "[0-9]+"))) (lambda (id) '((quote altertable) schema id "auto_increment" ai)))
+			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (atom "IF" true) (atom "EXISTS" true) (define col sql_identifier)) (lambda (id) '((quote altertable) '((quote table) schema id) "drop_if_exists" col)))
+			(parser '((atom "DROP" true) (? (atom "COLUMN" true)) (define col sql_identifier)) (lambda (id) '((quote altertable) '((quote table) schema id) "drop" col)))
+			(parser '((atom "ENGINE" true) "=" (atom "MEMORY" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "memory")))
+			(parser '((atom "ENGINE" true) "=" (atom "SLOPPY" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "sloppy")))
+			(parser '((atom "ENGINE" true) "=" (atom "CACHE" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "cache")))
+			(parser '((atom "ENGINE" true) "=" (atom "LOGGING" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "logged")))
+			(parser '((atom "ENGINE" true) "=" (atom "LOGGED" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "logged")))
+			(parser '((atom "ENGINE" true) "=" (atom "CSV" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "SAFE" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "MyISAM" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "InnoDB" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "safe")))
+			(parser '((atom "ENGINE" true) "=" (atom "CSV" true)) (lambda (id) '((quote altertable) '((quote table) schema id) "engine" "safe")))
+			(parser '((atom "COLLATE" true) "=" (define collation (regex "[a-zA-Z0-9_]+"))) (lambda (id) '((quote altertable) '((quote table) schema id) "collation" collation)))
+			(parser '((atom "AUTO_INCREMENT" true) "=" (define ai (regex "[0-9]+"))) (lambda (id) '((quote altertable) '((quote table) schema id) "auto_increment" ai)))
 			/* ALTER COLUMN operations for defaults */
-			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "SET" true) (atom "DEFAULT" true) (define def sql_expression)) (lambda (id) '((quote altercolumn) schema id col "default" def)))
-			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "DROP" true) (atom "DEFAULT" true)) (lambda (id) '((quote altercolumn) schema id col "default" nil)))
-			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "COLLATE" true) (define coll sql_identifier)) (lambda (id) '((quote altercolumn) schema id col "collation" coll)))
+			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "SET" true) (atom "DEFAULT" true) (define def sql_expression)) (lambda (id) '((quote altercolumn) '((quote table) schema id) col "default" def)))
+			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "DROP" true) (atom "DEFAULT" true)) (lambda (id) '((quote altercolumn) '((quote table) schema id) col "default" nil)))
+			(parser '((atom "ALTER" true) (atom "COLUMN" true) (define col sql_identifier) (atom "COLLATE" true) (define coll sql_identifier)) (lambda (id) '((quote altercolumn) '((quote table) schema id) col "collation" coll)))
 		) ","))
 	) (cons '!begin (map alters (lambda (alter) (alter id))))))
 
@@ -1429,14 +1429,14 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "DROP" true) (atom "USER" true) (? (atom "IF" true) (atom "EXISTS" true)) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
 				(cons '!begin (list
-					'((quote scan) '(session "__memcp_tx") "system" "access"
+					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
 						'(list "$update")
 						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
 						(quote +)
 						0)
-					'((quote scan) '(session "__memcp_tx") "system" "user"
+					'((quote scan) '(session "__memcp_tx") '('table "system" "user")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
 						'(list "$update")
@@ -1448,12 +1448,12 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "CREATE" true) (atom "USER" true) (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true)) (define username sql_user_ident)
 			(? '((atom "IDENTIFIED" true) (atom "BY" true) (define password sql_expression))))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "user" '(list "username" "password" "admin") '(list '(list username '('password password) false)) '(list) '((quote lambda) '() '((quote error) "user already exists")))
+				'('insert '('table "system" "user") '(list "username" "password" "admin") '(list '(list username '('password password) false)) '(list) '((quote lambda) '() '((quote error) "user already exists")))
 		))
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username sql_user_ident)
 			(? '((atom "IDENTIFIED" true) (atom "BY" true) (define password sql_expression))))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "password" '('password password)))))
 		))
 
 		/* FLUSH PRIVILEGES / FLUSH TABLES / FLUSH ... — no-op in memcp */
@@ -1463,32 +1463,31 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		/* GRANT ALL [PRIVILEGES] ON *.* TO user -> set admin true */
 		(parser '((atom "GRANT" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "TO" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" true))))
 		))
 		/* GRANT <anything> ON db.* TO user -> insert access (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) (or (atom "*" true) sql_identifier) (atom "TO" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
+				'('insert '('table "system" "access") '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 		/* GRANT <anything> ON db.table TO user -> also insert access at db level (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) sql_identifier (atom "TO" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'('insert "system" "access" '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
+				'('insert '('table "system" "access") '('list "username" "database") '('list '('list username db)) '(list) '((quote lambda) '() false))
 		))
 
 		/* REVOKE syntax (MySQL-style) -> mirror GRANT behavior */
 		/* REVOKE ALL [PRIVILEGES] ON *.* FROM user -> set admin false */
 		(parser '((atom "REVOKE" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "FROM" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") "system" "user" '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
 		))
 		/* REVOKE <anything> ON db.* FROM user -> delete access entry */
 		(parser '((atom "REVOKE" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) (or (atom "*" true) sql_identifier) (atom "FROM" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan)
 					'(session "__memcp_tx")
-					"system"
-					"access"
+					'('table "system" "access")
 					'(list "username" "database")
 					'((quote lambda) '('username 'database) '((quote and) '((quote equal??) (quote username) username) '((quote equal??) (quote database) db)))
 					'(list "$update")
@@ -1501,8 +1500,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(begin (if policy (policy "system" true true) true)
 				'((quote scan)
 					'(session "__memcp_tx")
-					"system"
-					"access"
+					'('table "system" "access")
 					'(list "username" "database")
 					'((quote lambda) '('username 'database) '((quote and) '((quote equal??) (quote username) username) '((quote equal??) (quote database) db)))
 					'(list "$update")
@@ -1609,7 +1607,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((atom "DROP" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier))
 			(begin (if policy (policy "system" true true) true)
 				(cons '!begin (list
-					'((quote scan) '(session "__memcp_tx") "system" "access"
+					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
 						'('list "database")
 						'((quote lambda) '('database) '((quote equal??) (quote database) id))
 						'(list "$update")
@@ -1619,8 +1617,8 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					'((quote dropdatabase) id (if if_exists true false))
 				))
 		))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) (list (quote table) schema id) (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) (list (quote table) schema id) (if if_exists true false)))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname sql_identifier) (atom "TO" true) (define newname sql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key sql_identifier) "=" (define value sql_expression)) (list (list (quote context) "session") key value)) ","))) (cons '!begin vars))
 
@@ -1640,7 +1638,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			))
 			"(" (define cols (+ sql_index_column ",")) ")"
 			(? (atom "USING" true) (atom "BTREE" true))
-		) (match tbl '(schema2 t) '('createkey (coalesce schema2 schema) t idx true (cons (quote list) cols))))
+		) (match tbl '(schema2 t) '('createkey '('table (coalesce schema2 schema) t) idx true (cons (quote list) cols))))
 		(parser '((atom "CREATE" true)
 			(atom "INDEX" true)
 			(define idx sql_identifier)
@@ -1662,7 +1660,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			))
 			(atom "USING" true) (atom "BTREE" true)
 			"(" (define cols (+ sql_index_column ",")) ")"
-		) (match tbl '(schema2 t) '('createkey (coalesce schema2 schema) t idx true (cons (quote list) cols))))
+		) (match tbl '(schema2 t) '('createkey '('table (coalesce schema2 schema) t) idx true (cons (quote list) cols))))
 		(parser '((atom "DROP" true) (atom "INDEX" true) (define idx sql_identifier) (? (atom "ON" true) (define tbl sql_identifier))) "ignore")
 
 		/* CREATE TRIGGER syntax */
@@ -1685,7 +1683,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(define body sql_trigger_body)
 		) (begin
 				(define compiled (compile_trigger_body schema timing (car (cdr body))))
-				(list 'createtrigger schema tbl name timing (car body) (list 'quote (list 'deferred_trigger compiled)) true)
+				(list 'createtrigger (list 'table schema tbl) name timing (car body) (list 'quote (list 'deferred_trigger compiled)) true)
 		))
 		/* DROP TRIGGER syntax */
 		(parser '((atom "DROP" true) (atom "TRIGGER" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define name sql_identifier))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1617,8 +1617,8 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					'((quote dropdatabase) id (if if_exists true false))
 				))
 		))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) (list (quote table) schema id) (if if_exists true false)))
-		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) (list (quote table) schema id) (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname sql_identifier) (atom "TO" true) (define newname sql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key sql_identifier) "=" (define value sql_expression)) (list (list (quote context) "session") key value)) ","))) (cons '!begin vars))
 

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1325,7 +1325,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 			(parser '((atom "COLLATE" true) (define collation (regex "[a-zA-Z0-9_]+"))) '("collation" collation))
 			(parser '((atom "AUTO_INCREMENT" true) "=" (define collation (regex "[0-9]+"))) '("auto_increment" collation))
 		)))
-	) '((quote createtable) (list (quote table) (coalesce schema2 schema) id) (cons (quote list) cols) (cons (quote list) (merge options)) ifnotexists)))
+	) '((quote createtable) (coalesce schema2 schema) id (cons (quote list) cols) (cons (quote list) (merge options)) ifnotexists)))
 
 	(define sql_alter_table (parser '(
 		(atom "ALTER" true)

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -284,7 +284,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 									(define cols (car (cdr (cdr stmt))))
 									(define vals (car (cdr (cdr (cdr stmt)))))
 									(define ignore (car (cdr (cdr (cdr (cdr stmt))))))
-									(list (list (symbol "insert") schema tbl
+									(list (list (symbol "insert") (list (symbol "table") schema tbl)
 										(cons (symbol "list") cols)
 										(cons (symbol "list") (map vals (lambda (row) (cons (symbol "list") (map row transform_trigger_expr)))))
 										(list (symbol "list")) (if ignore (list (symbol "lambda") '() 0) nil) false nil)))
@@ -320,7 +320,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 										(list (list (symbol "begin")
 											(list (symbol "set") (symbol "resultrow")
 												(list (symbol "lambda") (list (symbol "item"))
-													(list (symbol "insert") schema tbl
+													(list (symbol "insert") (list (symbol "table") schema tbl)
 														(cons (symbol "list") cols)
 														(list (symbol "list")
 															(cons (symbol "list")

--- a/lib/sql-test.scm
+++ b/lib/sql-test.scm
@@ -54,7 +54,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (count result2) 1) true "SELECT COUNT(*) should return 1 row")
 
 	/* Basic parsing tests - just verify the SQL parses correctly without executing */
-	(define allow (lambda (schema table write) true))
+	(define allow (lambda (schema tblname write) true))
 	(assert (list? (parse_sql "system" "SELECT 1" allow)) true "Simple SELECT should parse")
 	(assert (list? (parse_sql "system" "SELECT * FROM user" allow)) true "SELECT * should parse")
 	(assert (list? (parse_sql "system" "INSERT INTO user VALUES (1, 'test', 'pass')" allow)) true "INSERT should parse")

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -56,9 +56,9 @@ if the user is not allowed to access this property, the function will throw an e
 			'("admin") (lambda (a) a)
 			(lambda (a b) (or a b))
 			false))
-		(if is_admin (lambda (schema table write) true) /* admin -> allow all */
+		(if is_admin (lambda (schema tblname write) true) /* admin -> allow all */
 			/* else: complicated policy */
-			(lambda (schema table write)
+			(lambda (schema tblname write)
 				(begin
 					/* Allow virtual INFORMATION_SCHEMA for all users */
 					(if (equal?? schema "information_schema") true (begin
@@ -82,7 +82,7 @@ if the user is not allowed to access this property, the function will throw an e
 ))
 (if (has? (show "system") "user") true (begin
 	(print "creating table system.user")
-	(eval (parse_sql "system" "CREATE TABLE `user`(username text, password text, admin boolean DEFAULT FALSE) ENGINE=SAFE" (lambda (schema table write) true)))
+	(eval (parse_sql "system" "CREATE TABLE `user`(username text, password text, admin boolean DEFAULT FALSE) ENGINE=SAFE" (lambda (schema tblname write) true)))
 	(insert (table "system" "user") '("username" "password" "admin") '('("root" (password (arg "root-password" "admin")) true)))
 ))
 
@@ -125,7 +125,7 @@ if the user is not allowed to access this property, the function will throw an e
 /* error query log table */
 (if (not (has? (show "system_statistic") "errors")) (begin
 	(print "creating table system_statistic.errors")
-	(eval (parse_sql "system_statistic" "CREATE TABLE errors(datetime text, database text, user text, query text, error text) ENGINE=SLOPPY" (lambda (schema table write) true)))
+	(eval (parse_sql "system_statistic" "CREATE TABLE errors(datetime text, database text, user text, query text, error text) ENGINE=SLOPPY" (lambda (schema tblname write) true)))
 ))
 
 /* global counter incremented on each logged error — used by dashboard WebSocket to trigger refresh */
@@ -155,13 +155,13 @@ qry    — query text (pass "" when unknown) */
 /* print log table */
 (if (not (has? (show "system_statistic") "logs")) (begin
 	(print "creating table system_statistic.logs")
-	(eval (parse_sql "system_statistic" "CREATE TABLE logs(datetime text, message text) ENGINE=SLOPPY" (lambda (schema table write) true)))
+	(eval (parse_sql "system_statistic" "CREATE TABLE logs(datetime text, message text) ENGINE=SLOPPY" (lambda (schema tblname write) true)))
 ))
 
 /* access control: which user can access which database */
 (if (has? (show "system") "access") true (begin
 	(print "creating table system.access")
-	(eval (parse_sql "system" "CREATE TABLE `access`(username text, database text) ENGINE=SAFE" (lambda (schema table write) true)))
+	(eval (parse_sql "system" "CREATE TABLE `access`(username text, database text) ENGINE=SAFE" (lambda (schema tblname write) true)))
 ))
 
 /* migration: ensure unique (username, database) constraint on system.access */

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -51,7 +51,7 @@ if the user is not allowed to access this property, the function will throw an e
 */
 (define sql_policy (lambda (username)
 	(begin
-		(define is_admin (scan nil "system" "user"
+		(define is_admin (scan nil (table "system" "user")
 			'("username") (lambda (u) (equal?? u username))
 			'("admin") (lambda (a) a)
 			(lambda (a b) (or a b))
@@ -63,7 +63,7 @@ if the user is not allowed to access this property, the function will throw an e
 					/* Allow virtual INFORMATION_SCHEMA for all users */
 					(if (equal?? schema "information_schema") true (begin
 						/* Database-level check via system.access */
-						(define access_count (scan nil "system" "access"
+						(define access_count (scan nil (table "system" "access")
 							'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db schema)))
 							'() (lambda () 1)
 							+ 0))
@@ -83,7 +83,7 @@ if the user is not allowed to access this property, the function will throw an e
 (if (has? (show "system") "user") true (begin
 	(print "creating table system.user")
 	(eval (parse_sql "system" "CREATE TABLE `user`(username text, password text, admin boolean DEFAULT FALSE) ENGINE=SAFE" (lambda (schema table write) true)))
-	(insert "system" "user" '("username" "password" "admin") '('("root" (password (arg "root-password" "admin")) true)))
+	(insert (table "system" "user") '("username" "password" "admin") '('("root" (password (arg "root-password" "admin")) true)))
 ))
 
 /* migration: older instances may miss the admin column; add it and mark all existing users as admin */
@@ -92,8 +92,8 @@ if the user is not allowed to access this property, the function will throw an e
 		(if (has? (map (show "system" "user") (lambda (col) (get_assoc col "Field"))) "admin")
 			true
 			(begin
-				(createcolumn "system" "user" "admin" "boolean" '() '())
-				(scan nil "system" "user" '() (lambda () true) '("$update") (lambda ($update) ($update '("admin" true))))
+				(createcolumn (table "system" "user") "admin" "boolean" '() '())
+				(scan nil (table "system" "user") '() (lambda () true) '("$update") (lambda ($update) ($update '("admin" true))))
 			)
 		)
 	) true)
@@ -103,7 +103,7 @@ if the user is not allowed to access this property, the function will throw an e
 (try (lambda () (begin
 	(if (has? (show "system") "user") (begin
 		(if (has? (map (show "system" "user") (lambda (col) (get_assoc col "Field"))) "id")
-			(dropcolumn "system" "user" "id")
+			(dropcolumn (table "system" "user") "id")
 			true)
 	) true)
 )) (lambda (e) true))
@@ -111,14 +111,14 @@ if the user is not allowed to access this property, the function will throw an e
 /* migration: ensure root always has admin=true */
 (try (lambda () (begin
 	(if (has? (show "system") "user")
-		(scan nil "system" "user" '("username") (lambda (username) (equal? username "root")) '("$update") (lambda ($update) ($update '("admin" true))))
+		(scan nil (table "system" "user") '("username") (lambda (username) (equal? username "root")) '("$update") (lambda ($update) ($update '("admin" true))))
 		true)
 )) (lambda (e) true))
 
 /* ensure unique username constraint to avoid duplicates */
 (try (lambda () (begin
 	(if (has? (show "system") "user")
-		(createkey "system" "user" "uniq_username" true '("username"))
+		(createkey (table "system" "user") "uniq_username" true '("username"))
 		true)
 )) (lambda (e) true))
 
@@ -144,7 +144,7 @@ qry    — query text (pass "" when unknown) */
 	(error_log_counter "count" (+ (error_log_counter "count") 1))
 	(if (settings "ErrorQueryLog") (begin
 		(try (lambda () (begin
-			(insert "system_statistic" "errors"
+			(insert (table "system_statistic" "errors")
 				'("datetime" "database" "user" "query" "error")
 				(list (list (now) db usr qry (concat errmsg))))
 			/* trimming moved to 15-minute cron in dashboard.scm */
@@ -167,7 +167,7 @@ qry    — query text (pass "" when unknown) */
 /* migration: ensure unique (username, database) constraint on system.access */
 (try (lambda () (begin
 	(if (has? (show "system") "access")
-		(createkey "system" "access" "uniq_user_db" true '("username" "database"))
+		(createkey (table "system" "access") "uniq_user_db" true '("username" "database"))
 		true)
 )) (lambda (e) true))
 
@@ -192,7 +192,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	(set old_handler http_handler)
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
+		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -245,7 +245,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	)))
 	(define handle_query_postgres (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
+		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (password) password) (lambda (a b) b) nil))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -303,7 +303,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	/* handler for raw Scheme code execution (global, no schema) */
 	(define handle_scm (lambda (req res code) (begin
 		/* check for password - must be admin */
-		(set pw (scan nil "system" "user" '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
+		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
 		(if (and pw (equal? (car pw) (password (req "password"))) (car (cdr pw)))
 			(begin
 				(try (lambda () (begin
@@ -372,7 +372,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 (service_registry "SCM Frontend" (list (arg "api-port" (env "PORT" "4321")) "/scm" "POST, JSON"))
 
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
-(set mysql_auth (lambda (username_) (scan nil "system" "user" '("username") (lambda (username) (equal? username username_)) '("password") (lambda (password) password) (lambda (a b) b) nil)))
+(set mysql_auth (lambda (username_) (scan nil (table "system" "user") '("username") (lambda (username) (equal? username username_)) '("password") (lambda (password) password) (lambda (a b) b) nil)))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
 (set mysql_handler (lambda (schema sql resultrow_sql session) (begin
 	(session "schema" schema)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -745,7 +745,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	/* _mut on append with fresh list arg */
 	(assert ((eval (optimize '('lambda '('a 'b) '(append '(list 'a) 'b)))) 10 20) '(10 20) "_mut append on fresh list")
 	/* scan callback ownership: reduce accumulator enables _mut inside reduce body */
-	(assert (serialize (optimize '('scan nil "db" "tbl" '("x") '('lambda '('x) true) '("x") '('lambda '('x) 'x) '('lambda '('acc 'row) '(set_assoc 'acc 'row true)) '(list) nil false))) "(scan nil \"db\" \"tbl\" (\"x\") (lambda (x) true 1) (\"x\") (lambda (x) (var 0) 1) (lambda (acc row) (set_assoc_mut (var 0) (var 1) true) 2) '() nil false)" "scan hook: reduce acc enables set_assoc_mut")
+	(assert (serialize (optimize '('scan nil '('table "db" "tbl") '("x") '('lambda '('x) true) '("x") '('lambda '('x) 'x) '('lambda '('acc 'row) '(set_assoc 'acc 'row true)) '(list) nil false))) "(scan nil (table \"db\" \"tbl\") (\"x\") (lambda (x) true 1) (\"x\") (lambda (x) (var 0) 1) (lambda (acc row) (set_assoc_mut (var 0) (var 1) true) 2) '() nil false)" "scan hook: reduce acc enables set_assoc_mut")
 
 	/* match / match_mut correctness */
 	(print "testing match/match_mut correctness ...")

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -119,7 +119,7 @@ PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_ROWS = 5_000_000  # cap at 5M rows to prevent OOM
 PERF_MAX_RAM_FRACTION = 0.15  # max 15% of AVAILABLE RAM for table data
 
-def get_max_rows_for_ram(bytes_per_row: int = 100) -> int:
+def get_max_rows_for_ram(bytes_per_row: int = 256) -> int:
     """Calculate max rows based on available RAM (uses MemAvailable, not MemTotal)."""
     try:
         with open('/proc/meminfo', 'r') as f:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -116,21 +116,21 @@ PERF_TARGET_MIN_MS = 10000  # target minimum query time (10s)
 PERF_TARGET_MAX_MS = 20000  # target maximum query time (20s)
 PERF_SCALE_FACTOR = 1.3  # scale up/down by 30%
 PERF_DEFAULT_ROWS = 10000  # default starting row count
-PERF_MAX_ROWS = 10_000_000  # allow large datasets for proper calibration
-PERF_MAX_RAM_FRACTION = 0.3  # max 30% of RAM for table data
+PERF_MAX_ROWS = 5_000_000  # cap at 5M rows to prevent OOM
+PERF_MAX_RAM_FRACTION = 0.15  # max 15% of AVAILABLE RAM for table data
 
 def get_max_rows_for_ram(bytes_per_row: int = 100) -> int:
-    """Calculate max rows based on available RAM (30% limit)."""
+    """Calculate max rows based on available RAM (uses MemAvailable, not MemTotal)."""
     try:
         with open('/proc/meminfo', 'r') as f:
             for line in f:
-                if line.startswith('MemTotal:'):
-                    total_kb = int(line.split()[1])
-                    max_bytes = int(total_kb * 1024 * PERF_MAX_RAM_FRACTION)
+                if line.startswith('MemAvailable:'):
+                    avail_kb = int(line.split()[1])
+                    max_bytes = int(avail_kb * 1024 * PERF_MAX_RAM_FRACTION)
                     return max_bytes // bytes_per_row
     except:
         pass
-    return 10_000_000  # fallback: 10M rows
+    return 1_000_000  # fallback: 1M rows (conservative)
 
 class SQLTestRunner:
     def __init__(self, base_url="http://localhost:4321", username="root", password="admin", default_database="memcp-tests", log_times=False):

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -242,18 +242,30 @@ type optimizerMetainfo struct {
 	nextSlot             *int            // pointer to lambda's slot counter; nil outside lambda
 	ownedVars            map[Symbol]bool // variables known to hold exclusively owned values (e.g. reduce accumulators)
 	pendingCallbackOwned []bool          // when set, the next lambda's params at these indices are owned
+	loopDepth            int             // >0 inside scan/reduce callbacks; prevents hoisted defines from being inlined back into loops
 }
 
 func newOptimizerMetainfo() (result optimizerMetainfo) {
 	result.variableReplacement = make(map[Symbol]Scmer)
 	return
 }
+
+// IncrLoopDepth increments the loop nesting depth. Called by scan optimizer hooks
+// before optimizing callback lambdas (filter/map/reduce).
+func (ome *optimizerMetainfo) IncrLoopDepth() { ome.loopDepth++ }
+
+// DecrLoopDepth decrements the loop nesting depth.
+func (ome *optimizerMetainfo) DecrLoopDepth() { ome.loopDepth-- }
+
+// LoopDepth returns the current loop nesting depth.
+func (ome *optimizerMetainfo) LoopDepth() int { return ome.loopDepth }
 func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	result.variableReplacement = make(map[Symbol]Scmer)
 	for k, v := range ome.variableReplacement {
 		result.variableReplacement[k] = NewSlice([]Scmer{NewSymbol("outer"), v})
 	}
 	result.setBlacklist = ome.setBlacklist
+	result.loopDepth = ome.loopDepth
 	// nextSlot is NOT propagated across lambda boundaries (each lambda has its own)
 	return
 }
@@ -273,6 +285,7 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.setBlacklist = ome.setBlacklist
 	result.nextSlot = ome.nextSlot   // shared scope shares VarsNumbered
 	result.ownedVars = ome.ownedVars // shared scope inherits ownership info
+	result.loopDepth = ome.loopDepth
 	return
 }
 
@@ -398,6 +411,11 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 				if s2, ok := scmerSymbol(slice[1]); ok && s2 == sym {
 					return val, tiTransfer
 				}
+			}
+			// Do not inline function calls into loops — the define was hoisted
+			// out of the loop intentionally (e.g. table pointer pre-resolution).
+			if ome.loopDepth > 0 && replacement.IsSlice() {
+				return val, tiTransfer
 			}
 			return OptimizeEx(replacement, env, ome, useResult)
 		}

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -22,6 +22,7 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 package scm
 
 import "regexp"
+import "strings"
 
 var SettingsHaveGoodBacktraces bool
 
@@ -412,11 +413,6 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 					return val, tiTransfer
 				}
 			}
-			// Do not inline function calls into loops — the define was hoisted
-			// out of the loop intentionally (e.g. table pointer pre-resolution).
-			if ome.loopDepth > 0 && replacement.IsSlice() {
-				return val, tiTransfer
-			}
 			return OptimizeEx(replacement, env, ome, useResult)
 		}
 		return val, tiTransfer
@@ -679,6 +675,11 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 			// Bring back old criterion: inline if used < 2 OR RHS is not a list
 			shouldReplace := usedVariables[sym] < 2 || !normalized.IsSlice()
+			// Convention: symbols starting with "tbl:" are pre-resolved table
+			// pointers that must not be inlined back into inner loops.
+			if strings.HasPrefix(string(sym), "tbl:") {
+				shouldReplace = false
+			}
 			// Never inline aliases to symbols; this preserves outer/old-handler semantics
 			if normalized.IsSymbol() {
 				shouldReplace = false

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -514,6 +514,10 @@ restart:
 			panic("Unknown function: " + list[0].String())
 		}
 	default:
+		if expression.GetTag() >= 100 {
+			// custom tags (e.g. TagTable) are opaque literals
+			return expression
+		}
 		panic("Unknown expression type - EVAL " + expression.String())
 	}
 	return

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -88,13 +88,16 @@ const (
 	TagDate    = tagDate
 	TagCString = tagCString
 	TagBString = tagBString
-	TagTable   = 101 // custom tag for *table pointers
 )
 
 // CStringDecompress is set by the storage package to materialize a compressed string.
 // ptr points into the StorageString dictionary; val is the 48-bit aux value carrying
 // format (bits 47-44), nibbleOffset (bit 43), and charLen (bits 42-0).
 var CStringDecompress func(ptr *byte, val uint64) string
+
+// CustomStringer maps custom tags to their serialization functions.
+// Registered by the storage package at init time. Key = tag ID.
+var CustomStringer [256]func(ptr unsafe.Pointer) string
 
 // NewCString creates a lazy compressed-string Scmer.
 // ptr points into the StorageString dictionary (must stay alive as long as the Scmer).
@@ -699,11 +702,13 @@ func (s Scmer) AppendString(dst []byte) (string, []byte) {
 		return s.SourceInfo().value.AppendString(dst)
 	case tagJIT:
 		return "[jit lambda]", dst
-	case TagTable:
-		return "<table>", dst
 	default:
 		if s.GetTag() == tagAny {
 			return fmt.Sprintf("%v", *(*any)(unsafe.Pointer(s.ptr))), dst
+		}
+		tag := s.GetTag()
+		if int(tag) < len(CustomStringer) && CustomStringer[tag] != nil {
+			return CustomStringer[tag](unsafe.Pointer(s.ptr)), dst
 		}
 		return fmt.Sprintf("<custom %d>", s.GetTag()), dst
 	}

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -88,6 +88,7 @@ const (
 	TagDate    = tagDate
 	TagCString = tagCString
 	TagBString = tagBString
+	TagTable   = 101 // custom tag for *table pointers
 )
 
 // CStringDecompress is set by the storage package to materialize a compressed string.
@@ -698,6 +699,8 @@ func (s Scmer) AppendString(dst []byte) (string, []byte) {
 		return s.SourceInfo().value.AppendString(dst)
 	case tagJIT:
 		return "[jit lambda]", dst
+	case TagTable:
+		return "<table>", dst
 	default:
 		if s.GetTag() == tagAny {
 			return fmt.Sprintf("%v", *(*any)(unsafe.Pointer(s.ptr))), dst

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -901,6 +901,9 @@ func (s Scmer) Any() any {
 	case tagAny:
 		return *(*any)(unsafe.Pointer(s.ptr))
 	default:
+		if s.GetTag() >= 100 {
+			return unsafe.Pointer(s.ptr) // custom tags return raw pointer
+		}
 		panic(fmt.Sprintf("unknown tag %d in Any", s.GetTag()))
 	}
 }

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -420,7 +420,7 @@ func (s Scmer) IsCustom(tag uint16) bool {
 
 func (s Scmer) Custom(tag uint16) unsafe.Pointer {
 	if s.GetTag() != tag {
-		panic("wrong custom tag")
+		panic(fmt.Sprintf("wrong custom tag: expected %d, got %d (value: %s)", tag, s.GetTag(), s.String()))
 	}
 	return unsafe.Pointer(s.ptr)
 }

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -810,6 +810,16 @@ func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
 					info.schema = scm.String(sl[1])
 					info.table = scm.String(sl[2])
 				}
+			} else if items[tableIdx].IsSymbol() {
+				// pre-resolved tbl:schema:name symbol — extract schema and table from name
+				symStr := scm.String(items[tableIdx])
+				if strings.HasPrefix(symStr, "tbl:") {
+					parts := strings.SplitN(symStr[4:], ":", 2)
+					if len(parts) == 2 {
+						info.schema = parts[0]
+						info.table = parts[1]
+					}
+				}
 			} else {
 				info.schema = ""
 				info.table = scm.String(items[tableIdx])
@@ -1017,6 +1027,14 @@ func findScanNode(expr scm.Scmer, schema, table string) []scm.Scmer {
 				sl := items[tableIdx].Slice()
 				if len(sl) == 3 && scm.String(sl[0]) == "table" {
 					tSchema, tName = scm.String(sl[1]), scm.String(sl[2])
+				}
+			} else if len(items) > tableIdx && items[tableIdx].IsSymbol() {
+				symStr := scm.String(items[tableIdx])
+				if strings.HasPrefix(symStr, "tbl:") {
+					parts := strings.SplitN(symStr[4:], ":", 2)
+					if len(parts) == 2 {
+						tSchema, tName = parts[0], parts[1]
+					}
 				}
 			}
 			if tSchema == schema && tName == table {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -790,18 +790,19 @@ func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
 	if len(items) >= 5 && items[0].IsSymbol() {
 		sym := items[0].String()
 		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
-			schemaIdx, tableIdx := 1, 2
+			tableIdx := 2
 			condColsIdx, filterIdx := 3, 4
-			if len(items) > 1 && !items[1].IsString() {
-				schemaIdx, tableIdx = 2, 3
-				condColsIdx, filterIdx = 4, 5
-			}
 			if len(items) <= filterIdx {
 				return nil
 			}
-			info := scanJoinInfo{
-				schema: scm.String(items[schemaIdx]),
-				table:  scm.String(items[tableIdx]),
+			var info scanJoinInfo
+			if items[tableIdx].IsCustom(TagTable) {
+				t := TableFromScmer(items[tableIdx])
+				info.schema = t.schema.Name
+				info.table = t.Name
+			} else {
+				info.schema = ""
+				info.table = scm.String(items[tableIdx])
 			}
 			// condCols = (list "col1" "col2" ...), filter = lambda
 			condCols := extractStringListFromAST(items[condColsIdx])
@@ -994,16 +995,15 @@ func findScanNode(expr scm.Scmer, schema, table string) []scm.Scmer {
 		return nil
 	}
 	items := expr.Slice()
-	if len(items) >= 5 && items[0].IsSymbol() {
+	if len(items) >= 4 && items[0].IsSymbol() {
 		sym := items[0].String()
-		schemaIdx, tableIdx := 1, 2
-		if len(items) > 1 && !items[1].IsString() {
-			schemaIdx, tableIdx = 2, 3
-		}
+		tableIdx := 2
 		if (sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order") &&
-			len(items) > tableIdx &&
-			scm.String(items[schemaIdx]) == schema && scm.String(items[tableIdx]) == table {
-			return items
+			len(items) > tableIdx && items[tableIdx].IsCustom(TagTable) {
+			t := TableFromScmer(items[tableIdx])
+			if t.schema.Name == schema && t.Name == table {
+				return items
+			}
 		}
 	}
 	for _, item := range items {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -703,23 +703,26 @@ func (t *table) registerORCTriggers(name string) {
 			// Invalidate from composite sort key onwards via validMask scan
 			switch timing {
 			case AfterInsert:
-				body = scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), scm.NewString(t.schema.Name), scm.NewString(t.Name), scm.NewString(name), buildSortKeyExpr("NEW")})
+				tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(t.schema.Name), scm.NewString(t.Name)})
+				body = scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), tblExpr, scm.NewString(name), buildSortKeyExpr("NEW")})
 			case AfterDelete:
-				body = scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), scm.NewString(t.schema.Name), scm.NewString(t.Name), scm.NewString(name), buildSortKeyExpr("OLD")})
+				tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(t.schema.Name), scm.NewString(t.Name)})
+				body = scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), tblExpr, scm.NewString(name), buildSortKeyExpr("OLD")})
 			case AfterUpdate:
 				// For UPDATE: invalidate from both OLD and NEW positions
+				tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(t.schema.Name), scm.NewString(t.Name)})
 				body = scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("begin"),
-					scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), scm.NewString(t.schema.Name), scm.NewString(t.Name), scm.NewString(name), buildSortKeyExpr("OLD")}),
-					scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), scm.NewString(t.schema.Name), scm.NewString(t.Name), scm.NewString(name), buildSortKeyExpr("NEW")}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), tblExpr, scm.NewString(name), buildSortKeyExpr("OLD")}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), tblExpr, scm.NewString(name), buildSortKeyExpr("NEW")}),
 				})
 			}
 		} else {
 			// No sort key: full column invalidation
+			tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(t.schema.Name), scm.NewString(t.Name)})
 			body = scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("invalidatecolumn"),
-				scm.NewString(t.schema.Name),
-				scm.NewString(t.Name),
+				tblExpr,
 				scm.NewString(name),
 			})
 		}
@@ -1267,10 +1270,11 @@ func buildIncrementScan(targetSchema, targetTable, colName string, srcCols, inpu
 		scm.NewSlice([]scm.Scmer{scm.NewSymbol("$incr"), valueExpr}),
 	})
 
+	tableExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)})
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("scan"),
 		scm.NewSymbol("session"),
-		scm.NewString(targetSchema), scm.NewString(targetTable),
+		tableExpr,
 		scm.NewSlice(filterColElems),
 		scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(filterParams)}, filterBody)),
 		resultCols,
@@ -1302,8 +1306,7 @@ func buildIncrementalBody(targetSchema, targetTable, colName string, srcCols, in
 		})
 		invalidateBody := scm.NewSlice([]scm.Scmer{
 			scm.NewSymbol("invalidatecolumn"),
-			scm.NewString(targetSchema),
-			scm.NewString(targetTable),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)}),
 			scm.NewString(colName),
 		})
 		// Build (and (equal? (get_assoc "OLD" "srcCol1") (get_assoc "NEW" "srcCol1")) ...)
@@ -1341,8 +1344,7 @@ func buildIncrementalBody(targetSchema, targetTable, colName string, srcCols, in
 		// Fallback: full invalidation.
 		return scm.NewSlice([]scm.Scmer{
 			scm.NewSymbol("invalidatecolumn"),
-			scm.NewString(targetSchema),
-			scm.NewString(targetTable),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)}),
 			scm.NewString(colName),
 		})
 	}
@@ -1387,10 +1389,11 @@ func buildInvalidateScan(targetSchema, targetTable, colName string, srcCols, inp
 	// Build result col list: '("$invalidate:colName")
 	invColName := "$invalidate:" + colName
 
+	tableExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)})
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("scan"),
 		scm.NewSymbol("session"),
-		scm.NewString(targetSchema), scm.NewString(targetTable),
+		tableExpr,
 		scm.NewSlice(filterColElems),
 		scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(filterParams)}, filterBody)),
 		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString(invColName)}),
@@ -1419,8 +1422,7 @@ func buildSelectiveInvalidationBody(targetSchema, targetTable, colName string, s
 		// Fallback: full invalidation
 		return scm.NewSlice([]scm.Scmer{
 			scm.NewSymbol("invalidatecolumn"),
-			scm.NewString(targetSchema),
-			scm.NewString(targetTable),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)}),
 			scm.NewString(colName),
 		})
 	}
@@ -1477,11 +1479,11 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 				if incremental && timing != AfterInvalidate {
 					// scan layout: [fn, tx, table, filterCols, filter, mapCols, map, ...]
 					mapColsIdx, mapFnIdx := 5, 6
+					tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
 					if isConstantOneAggregate(scanNode[mapFnIdx]) {
 						body = scm.NewSlice([]scm.Scmer{
 							scm.NewSymbol("invalidatecolumn"),
-							scm.NewString(targetSchema),
-							scm.NewString(t.Name),
+							tblExpr,
 							scm.NewString(name),
 						})
 					} else {
@@ -1489,10 +1491,10 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 					}
 				} else {
 					// Full invalidation: for non-additive aggregates and AfterInvalidate propagation.
+					tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
 					body = scm.NewSlice([]scm.Scmer{
 						scm.NewSymbol("invalidatecolumn"),
-						scm.NewString(targetSchema),
-						scm.NewString(t.Name),
+						tblExpr,
 						scm.NewString(name),
 					})
 				}

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -800,6 +800,13 @@ func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
 				t := TableFromScmer(items[tableIdx])
 				info.schema = t.schema.Name
 				info.table = t.Name
+			} else if items[tableIdx].IsSlice() {
+				// unfolded (table schema name) expression
+				sl := items[tableIdx].Slice()
+				if len(sl) == 3 && scm.String(sl[0]) == "table" {
+					info.schema = scm.String(sl[1])
+					info.table = scm.String(sl[2])
+				}
 			} else {
 				info.schema = ""
 				info.table = scm.String(items[tableIdx])
@@ -998,10 +1005,18 @@ func findScanNode(expr scm.Scmer, schema, table string) []scm.Scmer {
 	if len(items) >= 4 && items[0].IsSymbol() {
 		sym := items[0].String()
 		tableIdx := 2
-		if (sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order") &&
-			len(items) > tableIdx && items[tableIdx].IsCustom(TagTable) {
-			t := TableFromScmer(items[tableIdx])
-			if t.schema.Name == schema && t.Name == table {
+		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
+			var tSchema, tName string
+			if len(items) > tableIdx && items[tableIdx].IsCustom(TagTable) {
+				t := TableFromScmer(items[tableIdx])
+				tSchema, tName = t.schema.Name, t.Name
+			} else if len(items) > tableIdx && items[tableIdx].IsSlice() {
+				sl := items[tableIdx].Slice()
+				if len(sl) == 3 && scm.String(sl[0]) == "table" {
+					tSchema, tName = scm.String(sl[1]), scm.String(sl[2])
+				}
+			}
+			if tSchema == schema && tName == table {
 				return items
 			}
 		}
@@ -1034,13 +1049,11 @@ func isAdditiveReduce(reduce scm.Scmer) bool {
 // isAdditiveAggregate checks whether a scan node represents an additive aggregate
 // (reduce=+, neutral=0) whose mapFn contains no inner scans.
 func isAdditiveAggregate(scanNode []scm.Scmer) bool {
-	if len(scanNode) < 9 {
+	if len(scanNode) < 8 {
 		return false
 	}
+	// scan layout: [fn, tx, table, filterCols, filter, mapCols, map, reduce, neutral, ...]
 	mapFnIdx, reduceIdx, neutralIdx := 6, 7, 8
-	if len(scanNode) > 1 && !scanNode[1].IsString() {
-		mapFnIdx, reduceIdx, neutralIdx = 7, 8, 9
-	}
 	if len(scanNode) <= neutralIdx {
 		return false
 	}
@@ -1462,10 +1475,8 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 			if !exists {
 				var body scm.Scmer
 				if incremental && timing != AfterInvalidate {
+					// scan layout: [fn, tx, table, filterCols, filter, mapCols, map, ...]
 					mapColsIdx, mapFnIdx := 5, 6
-					if len(scanNode) > 1 && !scanNode[1].IsString() {
-						mapColsIdx, mapFnIdx = 6, 7
-					}
 					if isConstantOneAggregate(scanNode[mapFnIdx]) {
 						body = scm.NewSlice([]scm.Scmer{
 							scm.NewSymbol("invalidatecolumn"),

--- a/storage/database.go
+++ b/storage/database.go
@@ -428,10 +428,10 @@ func loadPersistedTriggerPlan(schemaName, tableName string, trigger *TriggerDesc
 		panic("persisted trigger parse did not return an AST")
 	}
 	items := plan.Slice()
-	if len(items) < 7 {
+	if len(items) < 6 {
 		panic("persisted trigger AST is incomplete")
 	}
-	trigger.Func, trigger.FuncPlan = unwrapDeferredTriggerBody(items[6])
+	trigger.Func, trigger.FuncPlan = unwrapDeferredTriggerBody(items[5])
 }
 
 // SharedResource impl for database

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -65,11 +65,11 @@ func optimizeScan(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.
 	if rewritten := tryScanBatchRewrite(v); !rewritten.IsNil() {
 		return oc.OptimizeSub(rewritten, useResult)
 	}
-	return optimizeScanShared(v, oc, 7, 8, 9, 10, 11)
+	return optimizeScanShared(v, oc, 6, 7, 8, 9, 10)
 }
 
 func optimizeScanBatch(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
-	return optimizeScanShared(v, oc, 9, 10, 11, 12, 13)
+	return optimizeScanShared(v, oc, 8, 9, 10, 11, 12)
 }
 
 // scanResult bundles per-shard outputs to minimize allocations and type assertions.

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -41,11 +41,15 @@ func buildOuterNullCallbackRow(callbackCols []string) []scm.Scmer {
 // ensuring the accumulator parameter is marked as owned (enabling _mut swaps
 // like set_assoc → set_assoc_mut inside the reduce body).
 func optimizeScanShared(v []scm.Scmer, oc *scm.OptimizerContext, mapEnd, reduceIdx, neutralIdx, reduce2Idx, outerIdx int) (scm.Scmer, *scm.TypeDescriptor) {
+	// Non-callback args (tx, table, filtercols, mapcols, etc.) at loop depth 0
 	for i := 1; i <= mapEnd && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
+	// Callback lambdas execute per-row → increment loop depth so the optimizer
+	// does not inline hoisted defines (like table pointers) back into the loop.
+	oc.Ome.IncrLoopDepth()
 	if len(v) > reduceIdx && !v[reduceIdx].IsNil() {
-		oc.SetCallbackOwned([]bool{true, false}) // acc is owned
+		oc.SetCallbackOwned([]bool{true, false})
 		v[reduceIdx], _ = oc.OptimizeSub(v[reduceIdx], true)
 	}
 	if len(v) > neutralIdx {
@@ -58,6 +62,7 @@ func optimizeScanShared(v []scm.Scmer, oc *scm.OptimizerContext, mapEnd, reduceI
 	if len(v) > outerIdx {
 		v[outerIdx], _ = oc.OptimizeSub(v[outerIdx], true)
 	}
+	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
 }
 

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -49,21 +49,21 @@ func tryScanOrderBatchRewrite(v []scm.Scmer) scm.Scmer {
 }
 
 func tryScanBatchRewrite(v []scm.Scmer) scm.Scmer {
-	// scan: [fn, tx, schema, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
-	if len(v) < 8 {
+	// scan: [fn, tx, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
+	if len(v) < 7 {
 		return scm.NewNil()
 	}
-	if !v[3].IsString() {
+	if !v[2].IsCustom(TagTable) {
 		return scm.NewNil()
 	}
-	if len(v) > 11 && scm.ToBool(v[11]) {
+	if len(v) > 10 && scm.ToBool(v[10]) {
 		return scm.NewNil()
 	}
-	if len(v) > 8 && !v[8].IsNil() {
+	if len(v) > 7 && !v[7].IsNil() {
 		return scm.NewNil()
 	}
 	// scan tail after mapfn: reduce, neutral, reduce2, isOuter
-	return tryScanBatchRewriteMapfn(v, 6, 7, true)
+	return tryScanBatchRewriteMapfn(v, 5, 6, true)
 }
 
 // tryScanBatchRewriteMapfn is the shared implementation for scan and scan_order batch rewrite.
@@ -99,10 +99,10 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	}
 
 	// Inner scan must also be a real table (not list) and not outer
-	if len(innerScanSlice) < 8 || !innerScanSlice[3].IsString() {
+	if len(innerScanSlice) < 7 || !innerScanSlice[2].IsCustom(TagTable) {
 		return scm.NewNil()
 	}
-	if len(innerScanSlice) > 11 && scm.ToBool(innerScanSlice[11]) {
+	if len(innerScanSlice) > 10 && scm.ToBool(innerScanSlice[10]) {
 		return scm.NewNil()
 	}
 
@@ -115,11 +115,11 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	}
 	hasOuterRef := false
 	// Check inner filterfn and mapfn bodies for outer param references
-	if len(innerScanSlice) > 5 {
-		hasOuterRef = hasOuterRef || astContainsSymbol(innerScanSlice[5], outerParamSet)
+	if len(innerScanSlice) > 4 {
+		hasOuterRef = hasOuterRef || astContainsSymbol(innerScanSlice[4], outerParamSet)
 	}
-	if len(innerScanSlice) > 7 {
-		hasOuterRef = hasOuterRef || astContainsSymbol(innerScanSlice[7], outerParamSet)
+	if len(innerScanSlice) > 6 {
+		hasOuterRef = hasOuterRef || astContainsSymbol(innerScanSlice[6], outerParamSet)
 	}
 	if !hasOuterRef {
 		return scm.NewNil()
@@ -371,27 +371,27 @@ func astContainsSymbol(expr scm.Scmer, symbols map[string]bool) bool {
 // 4. Replacing outer param symbols in filter/map bodies with #N symbols
 // 5. Inserting stride and __batchbuf after mapfn
 func rewriteInnerScanToBatch(inner []scm.Scmer, pseudocols, pseudoparams []scm.Scmer, replaceMap map[string]string, stride int) []scm.Scmer {
-	// inner = [scan, tx, schema, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
+	// inner = [scan, tx, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
 	result := make([]scm.Scmer, 0, len(inner)+2)
 
 	// [0] scan_batch
 	result = append(result, scm.NewSymbol("scan_batch"))
-	// [1..3] tx, schema, tbl
-	result = append(result, inner[1], inner[2], inner[3])
-	// [4] filtercols: append #N
-	result = append(result, appendToScmerList(inner[4], pseudocols))
-	// [5] filterfn: extend params + replace body symbols
-	result = append(result, extendAndRewriteLambda(inner[5], pseudoparams, replaceMap))
-	// [6] mapcols: append #N
-	result = append(result, appendToScmerList(inner[6], pseudocols))
-	// [7] mapfn: extend params + replace body symbols
-	result = append(result, extendAndRewriteLambda(inner[7], pseudoparams, replaceMap))
-	// [8] stride
+	// [1..2] tx, tbl
+	result = append(result, inner[1], inner[2])
+	// [3] filtercols: append #N
+	result = append(result, appendToScmerList(inner[3], pseudocols))
+	// [4] filterfn: extend params + replace body symbols
+	result = append(result, extendAndRewriteLambda(inner[4], pseudoparams, replaceMap))
+	// [5] mapcols: append #N
+	result = append(result, appendToScmerList(inner[5], pseudocols))
+	// [6] mapfn: extend params + replace body symbols
+	result = append(result, extendAndRewriteLambda(inner[6], pseudoparams, replaceMap))
+	// [7] stride
 	result = append(result, scm.NewInt(int64(stride)))
-	// [9] batchdata (symbol __batchbuf from the flush lambda)
+	// [8] batchdata (symbol __batchbuf from the flush lambda)
 	result = append(result, scm.NewSymbol("__batchbuf"))
-	// [10..] reduce, neutral, reduce2, isOuter from original
-	for i := 8; i < len(inner); i++ {
+	// [9..] reduce, neutral, reduce2, isOuter from original
+	for i := 7; i < len(inner); i++ {
 		result = append(result, inner[i])
 	}
 	return result

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -26,34 +26,19 @@ const batchCapacityRows = 128
 // a buffer, and the inner scan becomes scan_batch consuming the buffer via #N
 // pseudo-columns. Returns the rewritten AST or nil if the pattern doesn't match.
 // tryScanOrderBatchRewrite attempts batch rewrite for scan_order's mapfn.
-// scan_order: [fn, tx, schema, tbl, filtercols, filterfn, sortcols, sortdirs,
-//              partcols, offset, limit, mapcols, mapfn, reduce, neutral, isOuter]
-// mapfn is at index 12, reduce at 13, isOuter at 15.
+// DISABLED pending separate review — scan_order batch semantics need the
+// ordered-result-preservation path and are different from plain scan. Leave
+// scan_order unbatched for now.
 func tryScanOrderBatchRewrite(v []scm.Scmer) scm.Scmer {
-	// scan_order: [fn, tx, schema, tbl, filtercols, filterfn, sortcols, sortdirs,
-	//              partcols, offset, limit, mapcols, mapfn, reduce, neutral, isOuter]
-	if len(v) < 13 {
-		return scm.NewNil()
-	}
-	if !v[3].IsString() {
-		return scm.NewNil()
-	}
-	if len(v) > 15 && scm.ToBool(v[15]) {
-		return scm.NewNil()
-	}
-	if len(v) > 13 && !v[13].IsNil() {
-		return scm.NewNil()
-	}
-	// scan_order tail after mapfn: reduce, neutral, isOuter (no reduce2)
-	return tryScanBatchRewriteMapfn(v, 11, 12, false)
+	return scm.NewNil()
 }
 
 func tryScanBatchRewrite(v []scm.Scmer) scm.Scmer {
 	// scan: [fn, tx, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
+	// v[2] (tbl) is always a table reference — shape-agnostic (TagTable at
+	// runtime, (table schema tbl) list or tbl:schema:name symbol at optimize
+	// time). We trust that and just pass it through unchanged.
 	if len(v) < 7 {
-		return scm.NewNil()
-	}
-	if !v[2].IsCustom(TagTable) {
 		return scm.NewNil()
 	}
 	if len(v) > 10 && scm.ToBool(v[10]) {
@@ -98,8 +83,9 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 		return scm.NewNil()
 	}
 
-	// Inner scan must also be a real table (not list) and not outer
-	if len(innerScanSlice) < 7 || !innerScanSlice[2].IsCustom(TagTable) {
+	// Inner scan — v[2] is always a table reference (see tryScanBatchRewrite);
+	// we only check arity and that it's not an outer scan.
+	if len(innerScanSlice) < 7 {
 		return scm.NewNil()
 	}
 	if len(innerScanSlice) > 10 && scm.ToBool(innerScanSlice[10]) {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -33,6 +33,7 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 	for i := 1; i <= 11 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
+	oc.Ome.IncrLoopDepth()
 	if len(v) > 12 && !v[12].IsNil() {
 		oc.SetCallbackOwned([]bool{true, false})
 		v[12], _ = oc.OptimizeSub(v[12], true)
@@ -43,6 +44,7 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 	if len(v) > 14 {
 		v[14], _ = oc.OptimizeSub(v[14], true)
 	}
+	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
 }
 
@@ -57,6 +59,7 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	for i := 1; i <= mapEnd && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
+	oc.Ome.IncrLoopDepth()
 	if len(v) > reduceIdx && !v[reduceIdx].IsNil() {
 		oc.SetCallbackOwned([]bool{true, false})
 		v[reduceIdx], _ = oc.OptimizeSub(v[reduceIdx], true)
@@ -67,6 +70,7 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	if len(v) > outerIdx {
 		v[outerIdx], _ = oc.OptimizeSub(v[outerIdx], true)
 	}
+	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
 }
 

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -27,21 +27,21 @@ import "container/heap"
 import "github.com/launix-de/memcp/scm"
 
 func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
-	// scan_order_multi args: 0=fn, 1=tx, 2=schemas, 3=tables, 4=filterCols, 5=filterFns,
-	// 6=sortcols, 7=sortdirs, 8=partCols, 9=offset, 10=limit, 11=mapCols, 12=mapFns,
-	// 13=reduce, 14=neutral, 15=isOuter
-	for i := 1; i <= 12 && i < len(v); i++ {
+	// scan_order_multi args: 0=fn, 1=tx, 2=tables, 3=filterCols, 4=filterFns,
+	// 5=sortcols, 6=sortdirs, 7=partCols, 8=offset, 9=limit, 10=mapCols, 11=mapFns,
+	// 12=reduce, 13=neutral, 14=isOuter
+	for i := 1; i <= 11 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
-	if len(v) > 13 && !v[13].IsNil() {
+	if len(v) > 12 && !v[12].IsNil() {
 		oc.SetCallbackOwned([]bool{true, false})
+		v[12], _ = oc.OptimizeSub(v[12], true)
+	}
+	if len(v) > 13 {
 		v[13], _ = oc.OptimizeSub(v[13], true)
 	}
 	if len(v) > 14 {
 		v[14], _ = oc.OptimizeSub(v[14], true)
-	}
-	if len(v) > 15 {
-		v[15], _ = oc.OptimizeSub(v[15], true)
 	}
 	return scm.NewSlice(v), nil
 }
@@ -53,7 +53,7 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	// if rewritten := tryScanOrderBatchRewrite(v); !rewritten.IsNil() {
 	// 	return oc.OptimizeSub(rewritten, useResult)
 	// }
-	mapEnd, reduceIdx, neutralIdx, outerIdx := 12, 13, 14, 15
+	mapEnd, reduceIdx, neutralIdx, outerIdx := 11, 12, 13, 14
 	for i := 1; i <= mapEnd && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -350,15 +350,13 @@ func Init(en scm.Env) {
 		Name: "table",
 		Desc: "resolves a schema+table name pair into a table handle",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			schema := scm.String(a[0])
-			db := GetDatabase(schema)
+			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
-				panic("database " + schema + " does not exist")
+				return scm.NewNil()
 			}
-			tableName := scm.String(a[1])
-			t := db.GetTable(tableName)
+			t := db.GetTable(scm.String(a[1]))
 			if t == nil {
-				panic("table " + schema + "." + tableName + " does not exist")
+				return scm.NewNil()
 			}
 			return NewTableScmer(t)
 		},
@@ -370,19 +368,11 @@ func Init(en scm.Env) {
 			},
 			Return: &scm.TypeDescriptor{Kind: "table"},
 			Optimize: func(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
-				// optimize args first
+				// optimize args only — do NOT fold to a constant pointer because
+				// DDL (DROP/CREATE TABLE) can invalidate the pointer and cached
+				// query plans would then reference a stale/deleted table.
 				for i := 1; i < len(v); i++ {
 					v[i], _ = oc.OptimizeSub(v[i], true)
-				}
-				// fold at compile time if both args are constant strings
-				if len(v) == 3 && v[1].GetTag() == scm.TagString && v[2].GetTag() == scm.TagString {
-					db := GetDatabase(scm.String(v[1]))
-					if db != nil {
-						t := db.GetTable(scm.String(v[2]))
-						if t != nil {
-							return NewTableScmer(t), nil
-						}
-					}
 				}
 				return scm.NewSlice(v), nil
 			},
@@ -1450,8 +1440,14 @@ func Init(en scm.Env) {
 		Name: "droptable",
 		Desc: "removes a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			t := TableFromScmer(a[0])
 			ifexists := len(a) > 1 && scm.ToBool(a[1])
+			if a[0].IsNil() {
+				if ifexists {
+					return scm.NewBool(false)
+				}
+				panic("droptable: table does not exist")
+			}
+			t := TableFromScmer(a[0])
 			DropTable(t.schema.Name, t.Name, ifexists)
 			return scm.NewBool(true)
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -508,12 +508,16 @@ func Init(en scm.Env) {
 			stride := int(scm.ToInt(a[layout.strideIdx]))
 			batchdata := mustScmerSlice(a[layout.batchDataIdx], "batchdata")
 			tableArg := a[layout.tableIdx]
-			isOuter := len(a) > layout.outerIdx+1 && scm.ToBool(a[layout.outerIdx+1])
+			// scan_batch inserts stride+batchdata (2 slots) between mapfn and
+			// reduce, so reduce/neutral/reduce2/isOuter sit at scanLayout's
+			// reduceIdx/neutralIdx/reduce2Idx/outerIdx + 2.
+			const sbShift = 2
+			isOuter := len(a) > layout.outerIdx+sbShift && scm.ToBool(a[layout.outerIdx+sbShift])
 
 			if list, ok := scmerSlice(tableArg); ok {
 				neutral := scm.NewNil()
-				if len(a) > layout.neutralIdx+1 {
-					neutral = a[layout.neutralIdx+1]
+				if len(a) > layout.neutralIdx+sbShift {
+					neutral = a[layout.neutralIdx+sbShift]
 				}
 				result := neutral
 				filterfn := scm.OptimizeProcToSerialFunction(a[layout.filterFnIdx])
@@ -521,8 +525,8 @@ func Init(en scm.Env) {
 				mapfn := scm.OptimizeProcToSerialFunction(a[layout.mapFnIdx])
 				mapparams := make([]scm.Scmer, len(mapcols))
 				reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-				if len(a) > layout.reduceIdx+1 {
-					reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx+1])
+				if len(a) > layout.reduceIdx+sbShift {
+					reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx+sbShift])
 				}
 				hadValue := false
 				batchCount := 0
@@ -560,11 +564,11 @@ func Init(en scm.Env) {
 					}
 					result = reducefn(result, mapfn(mapparams...))
 				}
-				if len(a) > layout.reduce2Idx+1 && !a[layout.reduce2Idx+1].IsNil() {
-					reduce2fn := scm.OptimizeProcToSerialFunction(a[layout.reduce2Idx+1])
+				if len(a) > layout.reduce2Idx+sbShift && !a[layout.reduce2Idx+sbShift].IsNil() {
+					reduce2fn := scm.OptimizeProcToSerialFunction(a[layout.reduce2Idx+sbShift])
 					base := neutral
-					if len(a) > layout.neutralIdx+1 {
-						base = a[layout.neutralIdx+1]
+					if len(a) > layout.neutralIdx+sbShift {
+						base = a[layout.neutralIdx+sbShift]
 					}
 					result = reduce2fn(base, result)
 				}
@@ -574,16 +578,16 @@ func Init(en scm.Env) {
 			t := TableFromScmer(a[layout.tableIdx])
 
 			aggregate := scm.NewNil()
-			if len(a) > layout.reduceIdx+1 {
-				aggregate = a[layout.reduceIdx+1]
+			if len(a) > layout.reduceIdx+sbShift {
+				aggregate = a[layout.reduceIdx+sbShift]
 			}
 			neutral := scm.NewNil()
-			if len(a) > layout.neutralIdx+1 {
-				neutral = a[layout.neutralIdx+1]
+			if len(a) > layout.neutralIdx+sbShift {
+				neutral = a[layout.neutralIdx+sbShift]
 			}
 			reduce2 := scm.NewNil()
-			if len(a) > layout.reduce2Idx+1 {
-				reduce2 = a[layout.reduce2Idx+1]
+			if len(a) > layout.reduce2Idx+sbShift {
+				reduce2 = a[layout.reduce2Idx+sbShift]
 			}
 			return t.scanWithBatch(layout.tx, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter, stride, batchdata)
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1712,7 +1712,7 @@ func Init(en scm.Env) {
 			// table recreation with the same name and cause cross-suite flakes.
 			dropBody := scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("droptable"),
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(ktSchema), scm.NewString(ktName)}),
+				NewTableScmer(ktTable),
 				scm.NewBool(true),
 			})
 			for _, timing := range []TriggerTiming{AfterDropTable, AfterDropColumn} {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "io"
+import "unsafe"
 import "github.com/carli2/hybridsort"
 import "sync"
 import "sync/atomic"
@@ -58,7 +59,6 @@ func scmerToTxContext(v scm.Scmer) *TxContext {
 
 type scanArgLayout struct {
 	tx            *TxContext
-	schemaIdx     int
 	tableIdx      int
 	filterColsIdx int
 	filterFnIdx   int
@@ -80,28 +80,23 @@ type scanArgLayout struct {
 func scanLayout(a []scm.Scmer) scanArgLayout {
 	return scanArgLayout{
 		tx:            scmerToTxContext(a[0]),
-		schemaIdx:     1,
-		tableIdx:      2,
-		filterColsIdx: 3,
-		filterFnIdx:   4,
-		mapColsIdx:    5,
-		mapFnIdx:      6,
-		reduceIdx:     7,
-		neutralIdx:    8,
-		reduce2Idx:    9,
-		outerIdx:      10,
-		sortColsIdx:   5,
-		sortDirsIdx:   6,
-		partColsIdx:   7,
-		offsetIdx:     8,
-		limitIdx:      9,
-		strideIdx:     7,
-		batchDataIdx:  8,
+		tableIdx:      1,
+		filterColsIdx: 2,
+		filterFnIdx:   3,
+		mapColsIdx:    4,
+		mapFnIdx:      5,
+		reduceIdx:     6,
+		neutralIdx:    7,
+		reduce2Idx:    8,
+		outerIdx:      9,
+		sortColsIdx:   4,
+		sortDirsIdx:   5,
+		partColsIdx:   6,
+		offsetIdx:     7,
+		limitIdx:      8,
+		strideIdx:     6,
+		batchDataIdx:  7,
 	}
-}
-
-func normalizeScanTableArg(tx *TxContext, tableArg scm.Scmer) scm.Scmer {
-	return tableArg
 }
 
 func showColumnsForRows(rows []scm.Scmer) scm.Scmer {
@@ -346,26 +341,64 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 func Init(en scm.Env) {
 	scm.DeclareTitle("Storage")
 
+	// Register TagTable serializer for the printer.
+	scm.CustomStringer[TagTable] = func(ptr unsafe.Pointer) string {
+		return (*table)(ptr).String()
+	}
+
+	scm.Declare(&en, &scm.Declaration{
+		Name: "table",
+		Desc: "resolves a schema+table name pair into a table handle",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			schema := scm.String(a[0])
+			db := GetDatabase(schema)
+			if db == nil {
+				panic("database " + schema + " does not exist")
+			}
+			tableName := scm.String(a[1])
+			t := db.GetTable(tableName)
+			if t == nil {
+				panic("table " + schema + "." + tableName + " does not exist")
+			}
+			return NewTableScmer(t)
+		},
+		Type: &scm.TypeDescriptor{
+			Kind: "func",
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", ParamName: "schema"},
+				{Kind: "string", ParamName: "table"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "table"},
+			Optimize: func(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+				// optimize args first
+				for i := 1; i < len(v); i++ {
+					v[i], _ = oc.OptimizeSub(v[i], true)
+				}
+				// fold at compile time if both args are constant strings
+				if len(v) == 3 && v[1].GetTag() == scm.TagString && v[2].GetTag() == scm.TagString {
+					db := GetDatabase(scm.String(v[1]))
+					if db != nil {
+						t := db.GetTable(scm.String(v[2]))
+						if t != nil {
+							return NewTableScmer(t), nil
+						}
+					}
+				}
+				return scm.NewSlice(v), nil
+			},
+		},
+	})
+
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_estimate",
 		Desc: "estimate output row count for a table scan",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			schema := scm.String(a[0])
-			table := scm.String(a[1])
-			db := GetDatabase(schema)
-			if db == nil {
-				return scm.NewInt(0)
-			}
-			t := db.GetTable(table)
-			if t == nil {
-				return scm.NewInt(0)
-			}
+			t := TableFromScmer(a[0])
 			return scm.NewInt(int64(t.CountEstimate()))
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database where the table is located"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
@@ -374,22 +407,12 @@ func Init(en scm.Env) {
 		Name: "table_empty?",
 		Desc: "returns true if a table currently has no rows",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			schema := scm.String(a[0])
-			table := scm.String(a[1])
-			db := GetDatabase(schema)
-			if db == nil {
-				panic("database " + schema + " does not exist")
-			}
-			t := db.GetTable(table)
-			if t == nil {
-				panic("table " + schema + "." + table + " does not exist")
-			}
+			t := TableFromScmer(a[0])
 			return scm.NewBool(t.CountEstimate() == 0)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database where the table is located"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -402,7 +425,7 @@ func Init(en scm.Env) {
 			layout := scanLayout(a)
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[layout.filterColsIdx], "filterColumns"))
 			mapcols := scmerSliceToStrings(mustScmerSlice(a[layout.mapColsIdx], "mapColumns"))
-			tableArg := normalizeScanTableArg(layout.tx, a[layout.tableIdx])
+			tableArg := a[layout.tableIdx]
 			isOuter := len(a) > layout.outerIdx && scm.ToBool(a[layout.outerIdx])
 
 			if list, ok := scmerSlice(tableArg); ok {
@@ -452,37 +475,7 @@ func Init(en scm.Env) {
 				return result
 			}
 
-			db := GetDatabase(scm.String(a[layout.schemaIdx]))
-			if db == nil {
-				// Virtual schemas like information_schema are handled in the
-				// Scheme layer (scan_wrapper in sql-metadata.scm) which
-				// replaces the table name with an in-memory list before the
-				// scan reaches Go.  However, when the query planner emits a
-				// batched nested-loop join the outer scan bypasses
-				// scan_wrapper and arrives here with the raw table name
-				// string.  Since there is no physical database backing these
-				// virtual schemas, we return an empty result (or a single
-				// NULL row for outer joins) instead of panicking.  The inner
-				// scan will still go through scan_wrapper correctly.
-				neutral := scm.NewNil()
-				if len(a) > layout.neutralIdx {
-					neutral = a[layout.neutralIdx]
-				}
-				if isOuter {
-					mapfn := scm.OptimizeProcToSerialFunction(a[layout.mapFnIdx])
-					mapparams := make([]scm.Scmer, len(mapcols))
-					reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-					if len(a) > layout.reduceIdx {
-						reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx])
-					}
-					return reducefn(neutral, mapfn(mapparams...))
-				}
-				return neutral
-			}
-			t := db.GetTable(scm.String(tableArg))
-			if t == nil {
-				panic("table " + scm.String(a[layout.schemaIdx]) + "." + scm.String(tableArg) + " does not exist")
-			}
+			t := TableFromScmer(a[layout.tableIdx])
 
 			aggregate := scm.NewNil()
 			if len(a) > layout.reduceIdx {
@@ -501,8 +494,7 @@ func Init(en scm.Env) {
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "string|nil", ParamName: "schema", ParamDesc: "database where the table is located"},
-				{Kind: "string|list", ParamName: "table", ParamDesc: "name of the table to scan (or a list if you have temporary data)"},
+				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map"},
@@ -525,7 +517,7 @@ func Init(en scm.Env) {
 			mapcols := scmerSliceToStrings(mustScmerSlice(a[layout.mapColsIdx], "mapColumns"))
 			stride := int(scm.ToInt(a[layout.strideIdx]))
 			batchdata := mustScmerSlice(a[layout.batchDataIdx], "batchdata")
-			tableArg := normalizeScanTableArg(layout.tx, a[layout.tableIdx])
+			tableArg := a[layout.tableIdx]
 			isOuter := len(a) > layout.outerIdx+1 && scm.ToBool(a[layout.outerIdx+1])
 
 			if list, ok := scmerSlice(tableArg); ok {
@@ -589,34 +581,7 @@ func Init(en scm.Env) {
 				return result
 			}
 
-			db := GetDatabase(scm.String(a[layout.schemaIdx]))
-			if db == nil {
-				// Same virtual-schema guard as in scan() above.
-				// scan_batch is emitted by batchify_first_scan which
-				// rewrites scan→scan_batch after scan_wrapper has already
-				// run.  When the outer table of a batched join is virtual,
-				// scan_wrapper was bypassed by build_batched_regular_scan
-				// (queryplan.scm) so the raw table name arrives here.
-				// Return empty results to match the list-path semantics.
-				neutral := scm.NewNil()
-				if len(a) > layout.neutralIdx+1 {
-					neutral = a[layout.neutralIdx+1]
-				}
-				if isOuter {
-					mapfn := scm.OptimizeProcToSerialFunction(a[layout.mapFnIdx])
-					mapparams := make([]scm.Scmer, len(mapcols))
-					reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-					if len(a) > layout.reduceIdx+1 {
-						reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx+1])
-					}
-					return reducefn(neutral, mapfn(mapparams...))
-				}
-				return neutral
-			}
-			t := db.GetTable(scm.String(tableArg))
-			if t == nil {
-				panic("table " + scm.String(a[layout.schemaIdx]) + "." + scm.String(tableArg) + " does not exist")
-			}
+			t := TableFromScmer(a[layout.tableIdx])
 
 			aggregate := scm.NewNil()
 			if len(a) > layout.reduceIdx+1 {
@@ -635,8 +600,7 @@ func Init(en scm.Env) {
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "string|nil", ParamName: "schema", ParamDesc: "database where the table is located"},
-				{Kind: "string|list", ParamName: "table", ParamDesc: "name of the table to scan (or a list if you have temporary data)"},
+				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter; #0, #1, ... address batchdata slots"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map; #0, #1, ... address batchdata slots"},
@@ -662,7 +626,7 @@ func Init(en scm.Env) {
 			sortdirsVals := mustScmerSlice(a[layout.sortDirsIdx], "sortdirs")
 			limitPartitionCols := scm.ToInt(a[layout.partColsIdx])
 			mapcols := scmerSliceToStrings(mustScmerSlice(a[layout.limitIdx+1], "mapColumns"))
-			tableArg := normalizeScanTableArg(layout.tx, a[layout.tableIdx])
+			tableArg := a[layout.tableIdx]
 
 			aggregate := scm.NewNil()
 			if len(a) > layout.limitIdx+3 {
@@ -769,32 +733,14 @@ func Init(en scm.Env) {
 				return result
 			}
 
-			db := GetDatabase(scm.String(a[layout.schemaIdx]))
-			if db == nil {
-				// Same virtual-schema guard as in scan() — see comment there.
-				if isOuter {
-					mapfn := scm.OptimizeProcToSerialFunction(a[layout.limitIdx+2])
-					mapparams := make([]scm.Scmer, len(mapcols))
-					reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-					if !aggregate.IsNil() {
-						reducefn = scm.OptimizeProcToSerialFunction(aggregate)
-					}
-					return reducefn(neutral, mapfn(mapparams...))
-				}
-				return neutral
-			}
-			t := db.GetTable(scm.String(tableArg))
-			if t == nil {
-				panic("table " + scm.String(a[layout.schemaIdx]) + "." + scm.String(tableArg) + " does not exist")
-			}
+			t := TableFromScmer(a[layout.tableIdx])
 
 			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "string", ParamName: "schema", ParamDesc: "database where the table is located"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table to scan"},
+				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of columns to sort. Each column is either a string to point to an existing column or a func(cols...)->any to compute a sortable value"},
@@ -818,45 +764,43 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// Parameters:
 			// 0: tx
-			// 1: schemas list
-			// 2: tables list
-			// 3: filterColumns per table (list of lists)
-			// 4: filterFns per table (list of lambdas)
-			// 5: sortcols per table (list of lists)
-			// 6: sortdirs (shared list)
-			// 7: limitPartitionCols
-			// 8: offset
-			// 9: limit
-			// 10: mapColumns per table (list of lists)
-			// 11: mapFns per table (list of lambdas)
-			// 12: reduce (optional)
-			// 13: neutral (optional)
-			// 14: isOuter (optional)
+			// 1: tables list (table handles)
+			// 2: filterColumns per table (list of lists)
+			// 3: filterFns per table (list of lambdas)
+			// 4: sortcols per table (list of lists)
+			// 5: sortdirs (shared list)
+			// 6: limitPartitionCols
+			// 7: offset
+			// 8: limit
+			// 9: mapColumns per table (list of lists)
+			// 10: mapFns per table (list of lambdas)
+			// 11: reduce (optional)
+			// 12: neutral (optional)
+			// 13: isOuter (optional)
 			currentTx := scmerToTxContext(a[0])
-			schemas := mustScmerSlice(a[1], "schemas")
-			tables := mustScmerSlice(a[2], "tables")
-			filterColsArr := mustScmerSlice(a[3], "filterColumns")
-			filterFnArr := mustScmerSlice(a[4], "filterFns")
-			sortcolsArr := mustScmerSlice(a[5], "sortcols")
-			sortdirsVals := mustScmerSlice(a[6], "sortdirs")
-			limitPartitionCols := scm.ToInt(a[7])
-			offset := scm.ToInt(a[8])
-			limit := scm.ToInt(a[9])
-			mapColsArr := mustScmerSlice(a[10], "mapColumns")
-			mapFnArr := mustScmerSlice(a[11], "mapFns")
+			tables := mustScmerSlice(a[1], "tables")
+			filterColsArr := mustScmerSlice(a[2], "filterColumns")
+			filterFnArr := mustScmerSlice(a[3], "filterFns")
+			sortcolsArr := mustScmerSlice(a[4], "sortcols")
+			sortdirsVals := mustScmerSlice(a[5], "sortdirs")
+			limitPartitionCols := scm.ToInt(a[6])
+			offset := scm.ToInt(a[7])
+			limit := scm.ToInt(a[8])
+			mapColsArr := mustScmerSlice(a[9], "mapColumns")
+			mapFnArr := mustScmerSlice(a[10], "mapFns")
 
 			aggregate := scm.NewNil()
-			if len(a) > 12 {
-				aggregate = a[12]
+			if len(a) > 11 {
+				aggregate = a[11]
 			}
 			neutral := scm.NewNil()
-			if len(a) > 13 {
-				neutral = a[13]
+			if len(a) > 12 {
+				neutral = a[12]
 			}
-			isOuter := len(a) > 14 && scm.ToBool(a[14])
+			isOuter := len(a) > 13 && scm.ToBool(a[13])
 
-			n := len(schemas)
-			if len(tables) != n || len(filterColsArr) != n || len(filterFnArr) != n || len(sortcolsArr) != n || len(mapColsArr) != n || len(mapFnArr) != n {
+			n := len(tables)
+			if len(filterColsArr) != n || len(filterFnArr) != n || len(sortcolsArr) != n || len(mapColsArr) != n || len(mapFnArr) != n {
 				panic("scan_order_multi: all per-table arrays must have the same length")
 			}
 
@@ -867,24 +811,7 @@ func Init(en scm.Env) {
 
 			specs := make([]scanOrderTableSpec, n)
 			for i := 0; i < n; i++ {
-				db := GetDatabase(scm.String(schemas[i]))
-				if db == nil {
-					if isOuter && i == 0 {
-						mapfn := scm.OptimizeProcToSerialFunction(mapFnArr[0])
-						mCols := scmerSliceToStrings(mustScmerSlice(mapColsArr[0], "mapColumns[0]"))
-						mapparams := make([]scm.Scmer, len(mCols))
-						reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-						if !aggregate.IsNil() {
-							reducefn = scm.OptimizeProcToSerialFunction(aggregate)
-						}
-						return reducefn(neutral, mapfn(mapparams...))
-					}
-					panic("database " + scm.String(schemas[i]) + " does not exist")
-				}
-				t := db.GetTable(scm.String(tables[i]))
-				if t == nil {
-					panic("table " + scm.String(schemas[i]) + "." + scm.String(tables[i]) + " does not exist")
-				}
+				t := TableFromScmer(tables[i])
 				specs[i] = scanOrderTableSpec{
 					table:         t,
 					conditionCols: scmerSliceToStrings(mustScmerSlice(filterColsArr[i], "filterColumns[i]")),
@@ -900,8 +827,7 @@ func Init(en scm.Env) {
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context"},
-				{Kind: "list", ParamName: "schemas", ParamDesc: "list of database names, one per table"},
-				{Kind: "list", ParamName: "tables", ParamDesc: "list of table names"},
+				{Kind: "list", ParamName: "tables", ParamDesc: "list of table handles"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of filter column lists, one per table"},
 				{Kind: "list", ParamName: "filterFns", ParamDesc: "list of filter lambdas, one per table"},
 				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of sort column lists, one per table"},
@@ -1123,25 +1049,17 @@ func Init(en scm.Env) {
 		Name: "createcolumn",
 		Desc: "creates a new column in table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// get tbl
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("createcolumn: table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
 
 			// normal column
-			colname := scm.String(a[2])
-			typename := scm.String(a[3])
-			dimensionsVals := mustScmerSlice(a[4], "dimensions")
+			colname := scm.String(a[1])
+			typename := scm.String(a[2])
+			dimensionsVals := mustScmerSlice(a[3], "dimensions")
 			dimensions := make([]int, len(dimensionsVals))
 			for i, d := range dimensionsVals {
 				dimensions[i] = scm.ToInt(d)
 			}
-			typeparams := mustScmerSlice(a[5], "typeparams")
+			typeparams := mustScmerSlice(a[4], "typeparams")
 
 			// ORC column: sortcols in options signals ordered-reduce computed column.
 			// Extract ORC params from the options assoc list.
@@ -1196,8 +1114,8 @@ func Init(en scm.Env) {
 			}
 
 			// Regular per-row computed column.
-			if len(a) > 7 && !a[7].IsNil() {
-				paramNames := scmerSliceToStrings(mustScmerSlice(a[6], "computor param names"))
+			if len(a) > 6 && !a[6].IsNil() {
+				paramNames := scmerSliceToStrings(mustScmerSlice(a[5], "computor param names"))
 				// extract filter from options
 				var filterCols []string
 				var filter scm.Scmer
@@ -1209,7 +1127,7 @@ func Init(en scm.Env) {
 						filter = typeparams[i+1]
 					}
 				}
-				t.computeColumnDDLLocked(colname, paramNames, a[7], filterCols, filter)
+				t.computeColumnDDLLocked(colname, paramNames, a[6], filterCols, filter)
 				return scm.NewBool(true)
 			}
 
@@ -1217,8 +1135,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the new table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "colname", ParamDesc: "name of the new column"},
 				{Kind: "string", ParamName: "type", ParamDesc: "name of the basetype"},
 				{Kind: "list", ParamName: "dimensions", ParamDesc: "dimensions of the type (e.g. for decimal)"},
@@ -1233,39 +1150,31 @@ func Init(en scm.Env) {
 		Name: "createkey",
 		Desc: "creates a new key on a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
 
-			if !scm.ToBool(a[3]) {
+			if !scm.ToBool(a[2]) {
 				return scm.NewBool(true)
 			}
 
-			cols := scmerSliceToStrings(mustScmerSlice(a[4], "unique columns"))
-			name := scm.String(a[2])
+			cols := scmerSliceToStrings(mustScmerSlice(a[3], "unique columns"))
+			name := scm.String(a[1])
 
-			db.schemalock.Lock()
+			t.schema.schemalock.Lock()
 			for _, u := range t.Unique {
 				if u.Id == name {
-					db.schemalock.Unlock()
+					t.schema.schemalock.Unlock()
 					return scm.NewBool(false)
 				}
 			}
 
 			t.Unique = append(t.Unique, uniqueKey{name, cols})
-			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+			t.schema.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the new table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "keyname", ParamDesc: "name of the new key"},
 				{Kind: "bool", ParamName: "unique", ParamDesc: "whether the key is unique"},
 				{Kind: "list", ParamName: "columns", ParamDesc: "list of columns to include"},
@@ -1277,23 +1186,13 @@ func Init(en scm.Env) {
 		Name: "createforeignkey",
 		Desc: "creates a new foreign key on a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
+			t1 := TableFromScmer(a[0])
 			id := scm.String(a[1])
-			t1 := db.GetTable(scm.String(a[2]))
-			if t1 == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[2]) + " does not exist")
-			}
-			t2 := db.GetTable(scm.String(a[4]))
-			if t2 == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[4]) + " does not exist")
-			}
+			cols1 := scmerSliceToStrings(mustScmerSlice(a[2], "foreign cols1"))
+			t2 := TableFromScmer(a[3])
+			cols2 := scmerSliceToStrings(mustScmerSlice(a[4], "foreign cols2"))
 
-			cols1 := scmerSliceToStrings(mustScmerSlice(a[3], "foreign cols1"))
-			cols2 := scmerSliceToStrings(mustScmerSlice(a[5], "foreign cols2"))
-
+			db := t1.schema
 			db.schemalock.Lock()
 			for _, u := range t1.Foreign {
 				if u.Id == id {
@@ -1302,7 +1201,7 @@ func Init(en scm.Env) {
 				}
 			}
 
-			k := foreignKey{id, t1.Name, cols1, t2.Name, cols2, getForeignKeyMode(a[6]), getForeignKeyMode(a[7])}
+			k := foreignKey{id, t1.Name, cols1, t2.Name, cols2, getForeignKeyMode(a[5]), getForeignKeyMode(a[6])}
 			t1.Foreign = append(t1.Foreign, k)
 			t2.Foreign = append(t2.Foreign, k)
 
@@ -1315,11 +1214,10 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
+				{Kind: "table", ParamName: "table1"},
 				{Kind: "string", ParamName: "keyname", ParamDesc: "name of the new key"},
-				{Kind: "string", ParamName: "table1", ParamDesc: "name of the first table"},
 				{Kind: "list", ParamName: "columns1", ParamDesc: "list of columns to include"},
-				{Kind: "string", ParamName: "table2", ParamDesc: "name of the second table"},
+				{Kind: "table", ParamName: "table2"},
 				{Kind: "list", ParamName: "columns2", ParamDesc: "list of columns to include"},
 				{Kind: "string", ParamName: "updatemode", ParamDesc: "restrict|cascade|set null"},
 				{Kind: "string", ParamName: "deletemode", ParamDesc: "restrict|cascade|set null"},
@@ -1331,24 +1229,16 @@ func Init(en scm.Env) {
 		Name: "shardcolumn",
 		Desc: "tells us how it would partition a column according to their values. Returns a list of pivot elements.",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// get tbl
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
 			numPartitions := 0
-			if len(a) > 3 {
-				numPartitions = scm.ToInt(a[3])
+			if len(a) > 2 {
+				numPartitions = scm.ToInt(a[2])
 			}
 			if numPartitions == 0 {
 				// check if that paritition dimension already exists
 				if t.ShardMode == ShardModePartition {
 					for _, sd := range t.PDimensions {
-						if sd.Column == scm.String(a[2]) {
+						if sd.Column == scm.String(a[1]) {
 							return scm.NewSlice(sd.Pivots) // found the column in partition schema: return exactly the same pivots as we found already
 						}
 					}
@@ -1358,13 +1248,12 @@ func Init(en scm.Env) {
 				numPartitions = int(1 + ((2 * t.Count()) / Settings.ShardSize))
 			}
 			// calculate them anew
-			return scm.NewSlice(t.NewShardDimension(scm.String(a[2]), numPartitions).Pivots)
+			return scm.NewSlice(t.NewShardDimension(scm.String(a[1]), numPartitions).Pivots)
 
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the new table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "colname", ParamDesc: "name of the column"},
 				{Kind: "number", ParamName: "numpartitions", ParamDesc: "number of partitions; optional. leave 0 if you want to detect the partiton number automatically or copy the partition schema of the table", Optional: true},
 			},
@@ -1375,16 +1264,8 @@ func Init(en scm.Env) {
 		Name: "partitiontable",
 		Desc: "suggests a partition scheme for a table. If the table has no partition scheme yet, it will immediately apply that scheme and return true. If the table already has a partition scheme, it will alter the partitioning score such that the partitioning scheme is considered in the next repartitioning and return false.",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// get tbl
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
-			cols := normalizePartitionDataset(a[2])
+			t := TableFromScmer(a[0])
+			cols := normalizePartitionDataset(a[1])
 			// Contract: an empty partition schema carries no physical partitioning
 			// information. Keep the table in free-shard mode instead of forcing a
 			// degenerate "partitioned with one shard" rebuild for scratch/key tables.
@@ -1449,8 +1330,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the new table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "list", ParamName: "columns", ParamDesc: "associative list of string -> list representing column name -> pivots. You can compute pivots by (shardcolumn ...)"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -1460,23 +1340,16 @@ func Init(en scm.Env) {
 		Name: "altertable",
 		Desc: "alters a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// get tbl
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
+			db := t.schema
 
-			switch scm.String(a[2]) {
+			switch scm.String(a[1]) {
 			case "drop":
-				return scm.NewBool(t.DropColumn(scm.String(a[3])))
+				return scm.NewBool(t.DropColumn(scm.String(a[2])))
 			case "drop_if_exists":
-				return scm.NewBool(t.DropColumnIfExists(scm.String(a[3])))
+				return scm.NewBool(t.DropColumnIfExists(scm.String(a[2])))
 			case "engine":
-				newMode := parsePersistencyMode(scm.String(a[3]))
+				newMode := parsePersistencyMode(scm.String(a[2]))
 				oldMode := t.PersistencyMode
 				if oldMode == newMode {
 					return scm.NewBool(true) // no-op
@@ -1519,13 +1392,12 @@ func Init(en scm.Env) {
 			case "owner":
 				return scm.NewBool(false) // ignore
 			default:
-				panic("unimplemented alter table operation: " + scm.String(a[2]))
+				panic("unimplemented alter table operation: " + scm.String(a[1]))
 			}
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "operation", ParamDesc: "one of owner|drop|engine|collation"},
 				{Kind: "any", ParamName: "parameter", ParamDesc: "name of the column to drop or value of the parameter"},
 			},
@@ -1536,47 +1408,37 @@ func Init(en scm.Env) {
 		Name: "altercolumn",
 		Desc: "alters a column",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// get tbl
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
+			db := t.schema
 			for i, c := range t.Columns {
-				if c.Name == scm.String(a[2]) {
-					switch scm.String(a[3]) {
+				if c.Name == scm.String(a[1]) {
+					switch scm.String(a[2]) {
 					case "drop":
-						ok := t.DropColumn(scm.String(a[2]))
+						ok := t.DropColumn(scm.String(a[1]))
 						db.save()
 						return scm.NewBool(ok)
 					case "auto_increment":
-						ai := scm.ToInt(a[4])
+						ai := scm.ToInt(a[3])
 						if ai > 1 {
-							// set ai value
 							t.Auto_increment = uint64(ai)
 							db.save()
 							return scm.NewBool(true)
 						}
-						// set ai flag for column
-						t.Columns[i].AutoIncrement = scm.ToBool(a[4])
+						t.Columns[i].AutoIncrement = scm.ToBool(a[3])
 						db.save()
 						return scm.NewBool(true)
 					default:
-						ok := t.Columns[i].Alter(scm.String(a[3]), a[4])
+						ok := t.Columns[i].Alter(scm.String(a[2]), a[3])
 						db.save()
 						return scm.NewBool(scm.ToBool(ok))
 					}
 				}
 			}
-			panic("column " + scm.String(a[0]) + "." + scm.String(a[1]) + "." + scm.String(a[2]) + " does not exist")
+			panic("column " + t.schema.Name + "." + t.Name + "." + scm.String(a[1]) + " does not exist")
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "name of the column"},
 				{Kind: "string", ParamName: "operation", ParamDesc: "one of drop|type|collation|auto_increment|comment"},
 				{Kind: "any", ParamName: "parameter", ParamDesc: "name of the column to drop or value of the parameter"},
@@ -1588,17 +1450,14 @@ func Init(en scm.Env) {
 		Name: "droptable",
 		Desc: "removes a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			if len(a) > 2 {
-				DropTable(scm.String(a[0]), scm.String(a[1]), scm.ToBool(a[2]))
-			} else {
-				DropTable(scm.String(a[0]), scm.String(a[1]), false)
-			}
+			t := TableFromScmer(a[0])
+			ifexists := len(a) > 1 && scm.ToBool(a[1])
+			DropTable(t.schema.Name, t.Name, ifexists)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "bool", ParamName: "ifexists", ParamDesc: "if true, don't throw an error if it already exists", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -1608,20 +1467,12 @@ func Init(en scm.Env) {
 		Name: "dropcolumn",
 		Desc: "drops a column from a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
-			return scm.NewBool(t.DropColumn(scm.String(a[2])))
+			t := TableFromScmer(a[0])
+			return scm.NewBool(t.DropColumn(scm.String(a[1])))
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "name of the column to drop"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -1631,15 +1482,8 @@ func Init(en scm.Env) {
 		Name: "invalidatecolumn",
 		Desc: "marks all values of a computed column as stale",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				return scm.NewBool(false)
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				return scm.NewBool(false)
-			}
-			colName := scm.String(a[2])
+			t := TableFromScmer(a[0])
+			colName := scm.String(a[1])
 			for _, s := range t.maintenanceShards() {
 				s.mu.RLock()
 				col := s.columns[colName]
@@ -1652,8 +1496,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "name of the computed column"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -1663,28 +1506,20 @@ func Init(en scm.Env) {
 		Name: "invalidateorc",
 		Desc: "invalidates ORC column rows from a sort key onwards via validMask scan",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				return scm.NewBool(false)
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				return scm.NewBool(false)
-			}
+			t := TableFromScmer(a[0])
 			// Accept both a single value and a list of sort key values
 			var sortKeys []scm.Scmer
-			if a[3].IsSlice() {
-				sortKeys = a[3].Slice()
+			if a[2].IsSlice() {
+				sortKeys = a[2].Slice()
 			} else {
-				sortKeys = []scm.Scmer{a[3]}
+				sortKeys = []scm.Scmer{a[2]}
 			}
-			t.invalidateORCFromSortKey(scm.String(a[2]), sortKeys)
+			t.invalidateORCFromSortKey(scm.String(a[1]), sortKeys)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "name of the ORC column"},
 				{Kind: "list", ParamName: "sortkeys", ParamDesc: "composite sort key values from which to invalidate"},
 			},
@@ -1695,18 +1530,12 @@ func Init(en scm.Env) {
 		Name: "register_keytable_cleanup",
 		Desc: "registers triggers on a base table to maintain keytable entries (insert/delete group keys)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			baseDB := GetDatabase(scm.String(a[0]))
-			if baseDB == nil {
-				return scm.NewBool(false)
-			}
-			baseTable := baseDB.GetTable(scm.String(a[1]))
-			if baseTable == nil {
-				return scm.NewBool(false)
-			}
-			ktSchema := scm.String(a[2])
-			ktName := scm.String(a[3])
-			tblvar := scm.String(a[4])
-			pairs := a[5].Slice()
+			baseTable := TableFromScmer(a[0])
+			ktTable := TableFromScmer(a[1])
+			ktSchema := ktTable.schema.Name
+			ktName := ktTable.Name
+			tblvar := scm.String(a[2])
+			pairs := a[3].Slice()
 
 			// Extract column name pairs
 			var baseCols, ktCols []string
@@ -1716,7 +1545,7 @@ func Init(en scm.Env) {
 				ktCols = append(ktCols, scm.String(pp[1]))
 			}
 
-			baseSchema := scm.String(a[0])
+			baseSchema := baseTable.schema.Name
 
 			// Helper: build (and (equal? x1 y1) (equal? x2 y2) ...) or just (equal? x y) for single key
 			buildAndEquals := func(xs, ys []scm.Scmer) scm.Scmer {
@@ -1884,8 +1713,7 @@ func Init(en scm.Env) {
 			// table recreation with the same name and cause cross-suite flakes.
 			dropBody := scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("droptable"),
-				scm.NewString(ktSchema),
-				scm.NewString(ktName),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(ktSchema), scm.NewString(ktName)}),
 				scm.NewBool(true),
 			})
 			for _, timing := range []TriggerTiming{AfterDropTable, AfterDropColumn} {
@@ -1912,10 +1740,8 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "base_schema", ParamDesc: "database of the base table"},
-				{Kind: "string", ParamName: "base_table", ParamDesc: "name of the base table"},
-				{Kind: "string", ParamName: "kt_schema", ParamDesc: "database of the keytable"},
-				{Kind: "string", ParamName: "kt_name", ParamDesc: "name of the keytable"},
+				{Kind: "table", ParamName: "base_table"},
+				{Kind: "table", ParamName: "kt_table"},
 				{Kind: "string", ParamName: "tblvar", ParamDesc: "table alias used in scan column prefixes"},
 				{Kind: "list", ParamName: "key_pairs", ParamDesc: "list of (base_col kt_col) pairs"},
 			},
@@ -1926,14 +1752,7 @@ func Init(en scm.Env) {
 		Name: "touch_keytable",
 		Desc: "extends the lease on a keytable so CacheManager defers eviction",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				return scm.NewBool(false)
-			}
-			tbl := db.GetTable(scm.String(a[1]))
-			if tbl == nil {
-				return scm.NewBool(false)
-			}
+			tbl := TableFromScmer(a[0])
 			now := time.Now()
 			nowNs := uint64(now.UnixNano())
 			atomic.StoreUint64(&tbl.lastAccessed, nowNs)
@@ -1946,8 +1765,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "table", ParamDesc: "keytable name"},
+				{Kind: "table", ParamName: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -1993,15 +1811,8 @@ func Init(en scm.Env) {
 		Name: "get_fk_target",
 		Desc: "returns (ref_table ref_column) if a single-column FK exists for the given column, nil otherwise",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				return scm.NewNil()
-			}
-			tbl := db.GetTable(scm.String(a[1]))
-			if tbl == nil {
-				return scm.NewNil()
-			}
-			col := scm.String(a[2])
+			tbl := TableFromScmer(a[0])
+			col := scm.String(a[1])
 			for _, fk := range tbl.Foreign {
 				if fk.Tbl1 == tbl.Name && len(fk.Cols1) == 1 && fk.Cols1[0] == col {
 					return scm.NewSlice([]scm.Scmer{scm.NewString(fk.Tbl2), scm.NewString(fk.Cols2[0])})
@@ -2011,8 +1822,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "table", ParamDesc: "table name"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "column name"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
@@ -2038,52 +1848,43 @@ func Init(en scm.Env) {
 		Name: "insert",
 		Desc: "inserts a new dataset into table and returns the number of successful items",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
 			var onCollisionCols []string
 			onCollision := scm.NewNil()
-			if len(a) > 5 {
-				onCollisionColsVals := mustScmerSlice(a[4], "onCollision columns")
+			if len(a) > 4 {
+				onCollisionColsVals := mustScmerSlice(a[3], "onCollision columns")
 				onCollisionCols = make([]string, len(onCollisionColsVals))
 				for i, c := range onCollisionColsVals {
 					onCollisionCols[i] = scm.String(c)
 				}
-				onCollision = a[5]
+				onCollision = a[4]
 			}
-			mergeNull := len(a) > 6 && scm.ToBool(a[6])
+			mergeNull := len(a) > 5 && scm.ToBool(a[5])
 			// optional onInsertid callback
 			var onFirst func(int64)
-			if len(a) > 7 && !a[7].IsNil() {
-				cb := a[7]
+			if len(a) > 6 && !a[6].IsNil() {
+				cb := a[6]
 				var once sync.Once
 				onFirst = func(id int64) {
 					once.Do(func() { scm.Apply(cb, scm.NewInt(id)) })
 				}
 			}
-			colsVals := mustScmerSlice(a[2], "column names")
+			colsVals := mustScmerSlice(a[1], "column names")
 			cols := make([]string, len(colsVals))
 			for i, col := range colsVals {
 				cols[i] = scm.String(col)
 			}
-			rowVals := mustScmerSlice(a[3], "dataset rows")
+			rowVals := mustScmerSlice(a[2], "dataset rows")
 			rows := make([][]scm.Scmer, len(rowVals))
 			for i, row := range rowVals {
 				rows[i] = mustScmerSlice(row, "insert row")
-			}
-			// perform insert
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
 			}
 			inserted := t.Insert(cols, rows, onCollisionCols, onCollision, mergeNull, onFirst)
 			return scm.NewInt(int64(inserted))
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "list", ParamName: "columns", ParamDesc: "list of column names, e.g. '(\"ID\", \"value\")"},
 				{Kind: "list", ParamName: "datasets", ParamDesc: "list of list of column values, e.g. '('(1 10) '(2 15))"},
 				{Kind: "list", ParamName: "onCollisionCols", ParamDesc: "list of columns of the old dataset that have to be passed to onCollision. Can also request $update.", Optional: true},
@@ -2115,6 +1916,8 @@ func Init(en scm.Env) {
 				})
 			} else if len(a) == 1 {
 				return scm.NewString(GetDatabase(scm.String(a[0])).PrintMemUsage())
+			} else if len(a) == 1 && a[0].IsCustom(TagTable) {
+				return scm.NewString(TableFromScmer(a[0]).PrintMemUsage())
 			} else if len(a) == 2 {
 				return scm.NewString(GetDatabase(scm.String(a[0])).GetTable(scm.String(a[1])).PrintMemUsage())
 			}
@@ -2143,6 +1946,22 @@ func Init(en scm.Env) {
 		Name: "show",
 		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
+			// table-based overloads: (show table) → columns, (show table "statistics") → index stats, etc.
+			if len(a) >= 1 && a[0].IsCustom(TagTable) {
+				t := TableFromScmer(a[0])
+				if len(a) == 1 {
+					return t.ShowColumns()
+				}
+				if len(a) == 2 {
+					if a[1].IsString() && scm.String(a[1]) == "statistics" {
+						return showBuildMeta(t.schema, t) // reuse existing statistics builder
+					}
+					if a[1].IsBool() && a[1].Bool() {
+						return showBuildMeta(t.schema, t)
+					}
+				}
+				return t.ShowColumns()
+			}
 			if len(a) == 0 {
 				// list databases
 				dbs := databases.GetAll()
@@ -2196,7 +2015,7 @@ func Init(en scm.Env) {
 					return scm.NewSlice(rows)
 				}
 				// (show schema tbl) → column defs
-				tableArg := normalizeScanTableArg(CurrentTx(), a[1])
+				tableArg := a[1]
 				if rows, ok := scmerSlice(tableArg); ok {
 					return showColumnsForRows(rows)
 				}
@@ -2543,17 +2362,11 @@ func Init(en scm.Env) {
 		Name: "createtrigger",
 		Desc: "creates a new trigger on a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			db := GetDatabase(scm.String(a[0]))
-			if db == nil {
-				panic("database " + scm.String(a[0]) + " does not exist")
-			}
-			t := db.GetTable(scm.String(a[1]))
-			if t == nil {
-				panic("table " + scm.String(a[0]) + "." + scm.String(a[1]) + " does not exist")
-			}
+			t := TableFromScmer(a[0])
+			db := t.schema
 
-			name := scm.String(a[2])
-			timingStr := scm.String(a[3])
+			name := scm.String(a[1])
+			timingStr := scm.String(a[2])
 			var timing TriggerTiming
 			switch timingStr {
 			case "before_insert":
@@ -2578,9 +2391,9 @@ func Init(en scm.Env) {
 				panic("invalid trigger timing: " + timingStr)
 			}
 
-			sourceSQL := scm.String(a[4])
-			body, deferredPlan := unwrapDeferredTriggerBody(a[5])
-			visible := scm.ToBool(a[6])
+			sourceSQL := scm.String(a[3])
+			body, deferredPlan := unwrapDeferredTriggerBody(a[4])
+			visible := scm.ToBool(a[5])
 
 			trigger := TriggerDescription{
 				Name:      name,
@@ -2602,8 +2415,7 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
+				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "name", ParamDesc: "name of the trigger"},
 				{Kind: "string", ParamName: "timing", ParamDesc: "one of: before_insert, after_insert, before_update, after_update, before_delete, after_delete"},
 				{Kind: "string", ParamName: "source_sql", ParamDesc: "original SQL body text (for SHOW TRIGGERS)"},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -368,11 +368,18 @@ func Init(en scm.Env) {
 			},
 			Return: &scm.TypeDescriptor{Kind: "table"},
 			Optimize: func(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
-				// optimize args only — do NOT fold to a constant pointer because
-				// DDL (DROP/CREATE TABLE) can invalidate the pointer and cached
-				// query plans would then reference a stale/deleted table.
 				for i := 1; i < len(v); i++ {
 					v[i], _ = oc.OptimizeSub(v[i], true)
+				}
+				// fold at compile time if both args are constant strings
+				if len(v) == 3 && v[1].GetTag() == scm.TagString && v[2].GetTag() == scm.TagString {
+					db := GetDatabase(scm.String(v[1]))
+					if db != nil {
+						t := db.GetTable(scm.String(v[2]))
+						if t != nil {
+							return NewTableScmer(t), nil
+						}
+					}
 				}
 				return scm.NewSlice(v), nil
 			},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -361,8 +361,7 @@ func Init(en scm.Env) {
 			return NewTableScmer(t)
 		},
 		Type: &scm.TypeDescriptor{
-			Kind:           "func",
-			HasSideEffects: true, // prevent optimizer from inlining (define tbl:x (table ...)) back into loops
+			Kind: "func",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", ParamName: "schema"},
 				{Kind: "string", ParamName: "table"},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1526,6 +1526,9 @@ func Init(en scm.Env) {
 		Name: "register_keytable_cleanup",
 		Desc: "registers triggers on a base table to maintain keytable entries (insert/delete group keys)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if a[0].IsNil() {
+				return scm.NewBool(false)
+			}
 			baseTable := TableFromScmer(a[0])
 			ktTable := TableFromScmer(a[1])
 			ktSchema := ktTable.schema.Name

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1601,7 +1601,7 @@ func Init(en scm.Env) {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),
 					scm.NewSymbol("session"),
-					scm.NewString(baseSchema), scm.NewString(baseTable.Name),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(baseSchema), scm.NewString(baseTable.Name)}),
 					scanFilterCols(baseCols),
 					scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scanFilterParams(tblvar, baseCols)},
 						buildAndEquals(scanParamSyms(tblvar, baseCols), getAssocs(dictSym, baseCols)))),
@@ -1616,7 +1616,7 @@ func Init(en scm.Env) {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),
 					scm.NewSymbol("session"),
-					scm.NewString(ktSchema), scm.NewString(ktName),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(ktSchema), scm.NewString(ktName)}),
 					scanFilterCols(ktCols),
 					scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scanFilterParams(ktName, ktCols)},
 						buildAndEquals(scanParamSyms(ktName, ktCols), getAssocs(dictSym, baseCols)))),
@@ -1631,7 +1631,7 @@ func Init(en scm.Env) {
 			buildInsert := func(dictSym string) scm.Scmer {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("insert"),
-					scm.NewString(ktSchema), scm.NewString(ktName),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(ktSchema), scm.NewString(ktName)}),
 					scanFilterCols(ktCols),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"),
 						fkValListExpr(dictSym, baseCols)}),

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -368,18 +368,11 @@ func Init(en scm.Env) {
 			},
 			Return: &scm.TypeDescriptor{Kind: "table"},
 			Optimize: func(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+				// Do NOT fold to a constant pointer — DDL (DROP/CREATE TABLE)
+				// invalidates the pointer and cached query plans would reference
+				// a stale table. Runtime evaluation via GetTable is lock-free.
 				for i := 1; i < len(v); i++ {
 					v[i], _ = oc.OptimizeSub(v[i], true)
-				}
-				// fold at compile time if both args are constant strings
-				if len(v) == 3 && v[1].GetTag() == scm.TagString && v[2].GetTag() == scm.TagString {
-					db := GetDatabase(scm.String(v[1]))
-					if db != nil {
-						t := db.GetTable(scm.String(v[2]))
-						if t != nil {
-							return NewTableScmer(t), nil
-						}
-					}
 				}
 				return scm.NewSlice(v), nil
 			},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1440,20 +1440,14 @@ func Init(en scm.Env) {
 		Name: "droptable",
 		Desc: "removes a table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			ifexists := len(a) > 1 && scm.ToBool(a[1])
-			if a[0].IsNil() {
-				if ifexists {
-					return scm.NewBool(false)
-				}
-				panic("droptable: table does not exist")
-			}
-			t := TableFromScmer(a[0])
-			DropTable(t.schema.Name, t.Name, ifexists)
+			ifexists := len(a) > 2 && scm.ToBool(a[2])
+			DropTable(scm.String(a[0]), scm.String(a[1]), ifexists)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
+				{Kind: "string", ParamName: "schema"},
+				{Kind: "string", ParamName: "table"},
 				{Kind: "bool", ParamName: "ifexists", ParamDesc: "if true, don't throw an error if it already exists", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -1712,7 +1706,8 @@ func Init(en scm.Env) {
 			// table recreation with the same name and cause cross-suite flakes.
 			dropBody := scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("droptable"),
-				NewTableScmer(ktTable),
+				scm.NewString(ktSchema),
+				scm.NewString(ktName),
 				scm.NewBool(true),
 			})
 			for _, timing := range []TriggerTiming{AfterDropTable, AfterDropColumn} {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -361,7 +361,8 @@ func Init(en scm.Env) {
 			return NewTableScmer(t)
 		},
 		Type: &scm.TypeDescriptor{
-			Kind: "func",
+			Kind:           "func",
+			HasSideEffects: true, // prevent optimizer from inlining (define tbl:x (table ...)) back into loops
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", ParamName: "schema"},
 				{Kind: "string", ParamName: "table"},

--- a/storage/table.go
+++ b/storage/table.go
@@ -29,14 +29,22 @@ import "unsafe"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/go-mysqlstack/sqldb"
 
+// TagTable is the custom Scmer tag for *table pointers.
+const TagTable = 101
+
 // NewTableScmer wraps a *table into a Scmer with TagTable.
 func NewTableScmer(t *table) scm.Scmer {
-	return scm.NewCustom(scm.TagTable, unsafe.Pointer(t))
+	return scm.NewCustom(TagTable, unsafe.Pointer(t))
 }
 
 // TableFromScmer extracts a *table from a TagTable Scmer.
 func TableFromScmer(s scm.Scmer) *table {
-	return (*table)(s.Custom(scm.TagTable))
+	return (*table)(s.Custom(TagTable))
+}
+
+// String implements serialization for table pointers: (table "schema" "name")
+func (t *table) String() string {
+	return "(table \"" + t.schema.Name + "\" \"" + t.Name + "\")"
 }
 
 type dataset []scm.Scmer

--- a/storage/table.go
+++ b/storage/table.go
@@ -25,8 +25,19 @@ import "errors"
 import "strings"
 import "strconv"
 import "encoding/json"
+import "unsafe"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/go-mysqlstack/sqldb"
+
+// NewTableScmer wraps a *table into a Scmer with TagTable.
+func NewTableScmer(t *table) scm.Scmer {
+	return scm.NewCustom(scm.TagTable, unsafe.Pointer(t))
+}
+
+// TableFromScmer extracts a *table from a TagTable Scmer.
+func TableFromScmer(s scm.Scmer) *table {
+	return (*table)(s.Custom(scm.TagTable))
+}
 
 type dataset []scm.Scmer
 type column struct {

--- a/tests/103_scan_order_partition.yaml
+++ b/tests/103_scan_order_partition.yaml
@@ -32,7 +32,7 @@ test_cases:
       (begin
         (set s (newsession))
         (s "cnt" 0)
-        (scan_order (session "__memcp_tx") "memcp-tests" "part_test"
+        (scan_order (session "__memcp_tx") (table "memcp-tests" "part_test")
           '() (lambda () true)
           '("dept" "salary") '(< >)
           1 0 1
@@ -46,7 +46,7 @@ test_cases:
       (begin
         (set s (newsession))
         (s "cnt" 0)
-        (scan_order (session "__memcp_tx") "memcp-tests" "part_test"
+        (scan_order (session "__memcp_tx") (table "memcp-tests" "part_test")
           '() (lambda () true)
           '("dept" "salary") '(< >)
           1 0 2
@@ -60,7 +60,7 @@ test_cases:
       (begin
         (set s (newsession))
         (s "cnt" 0)
-        (scan_order (session "__memcp_tx") "memcp-tests" "part_test"
+        (scan_order (session "__memcp_tx") (table "memcp-tests" "part_test")
           '() (lambda () true)
           '("dept" "salary") '(< >)
           1 1 1
@@ -74,7 +74,7 @@ test_cases:
       (begin
         (set s (newsession))
         (s "cnt" 0)
-        (scan_order (session "__memcp_tx") "memcp-tests" "part_test"
+        (scan_order (session "__memcp_tx") (table "memcp-tests" "part_test")
           '() (lambda () true)
           '("salary") '(>)
           0 0 2
@@ -88,7 +88,7 @@ test_cases:
       (begin
         (set s (newsession))
         (s "cnt" 0)
-        (scan_order (session "__memcp_tx") "memcp-tests" "part_test"
+        (scan_order (session "__memcp_tx") (table "memcp-tests" "part_test")
           '() (lambda () true)
           '("dept" "salary") '(< >)
           1 0 1

--- a/tests/110_mysql_auth_tx_nil.yaml
+++ b/tests/110_mysql_auth_tx_nil.yaml
@@ -13,7 +13,7 @@ test_cases:
     scm: |
       (if
         (equal?
-          (scan nil "system" "user"
+          (scan nil (table "system" "user")
             '("username")
             (lambda (username) (equal? username "auth_scan_nil_repro"))
             '("password")

--- a/tests/14_order_limit.yaml
+++ b/tests/14_order_limit.yaml
@@ -167,7 +167,7 @@ test_cases:
           (begin
             (set rows (map (produceN 200000) (lambda (i)
               (list i (* 7 (- (* i 31337) (* (floor (/ (* i 31337) 200000)) 200000))) (floor (/ i 40000))))))
-            (insert "memcp-tests" "ord_stress" (list "id" "val" "grp") rows))
+            (insert (table "memcp-tests" "ord_stress") (list "id" "val" "grp") rows))
       - scm: "(rebuild)"
     sql: "SELECT COUNT(*) AS cnt FROM ord_stress"
     expect:

--- a/tests/56_multishard.yaml
+++ b/tests/56_multishard.yaml
@@ -25,21 +25,21 @@ test_cases:
     scm: |
       (begin
         (set b (map (produceN 20000) (lambda (i) (list i i (concat "n" i)))))
-        (insert "memcp-tests" "ms_data" '("id" "val" "name") b)
+        (insert (table "memcp-tests" "ms_data") '("id" "val" "name") b)
         20000)
 
   - name: "Insert batch 2 (rows 20000-39999)"
     scm: |
       (begin
         (set b (map (produceN 20000) (lambda (i) (list (+ i 20000) (+ i 20000) (concat "n" (+ i 20000))))))
-        (insert "memcp-tests" "ms_data" '("id" "val" "name") b)
+        (insert (table "memcp-tests" "ms_data") '("id" "val" "name") b)
         20000)
 
   - name: "Insert batch 3 (rows 40000-60999)"
     scm: |
       (begin
         (set b (map (produceN 21000) (lambda (i) (list (+ i 40000) (+ i 40000) (concat "n" (+ i 40000))))))
-        (insert "memcp-tests" "ms_data" '("id" "val" "name") b)
+        (insert (table "memcp-tests" "ms_data") '("id" "val" "name") b)
         21000)
 
   - name: "Rebuild to trigger repartition into multiple shards"

--- a/tests/57_storage_enum.yaml
+++ b/tests/57_storage_enum.yaml
@@ -168,7 +168,7 @@ test_cases:
       (begin
         (set b (map (produceN 10000) (lambda (i)
           (if (equal? 99 (- i (* 100 (floor (/ i 100))))) (list i 1) (list i 0)))))
-        (insert "memcp-tests" "se_bulk" '("id" "category") b)
+        (insert (table "memcp-tests" "se_bulk") '("id" "category") b)
         10000)
 
   - name: "Bulk: verify cell id=0 (should be 0)"
@@ -577,7 +577,7 @@ test_cases:
     scm: |
       (begin
         (set b (map (produceN 30) (lambda (i) (list i 42))))
-        (insert "memcp-tests" "se_single" '("id" "val") b)
+        (insert (table "memcp-tests" "se_single") '("id" "val") b)
         30)
 
   - name: "Single: verify cell id=0"
@@ -627,7 +627,7 @@ test_cases:
                       (if (< i 196)
                         (list i "pink")
                         (list i "black")))))))))))
-        (insert "memcp-tests" "se_max8" '("id" "color") b)
+        (insert (table "memcp-tests" "se_max8") '("id" "color") b)
         200)
 
   - name: "Max8: verify red"

--- a/tests/58_storage_formats.yaml
+++ b/tests/58_storage_formats.yaml
@@ -33,7 +33,7 @@ test_cases:
       (begin
         (set b (map (produceN 30) (lambda (i)
           (list i (/ (* (+ i 1) 3.14159265) (+ i 2.71828))))))
-        (insert "memcp-tests" "sf_float" '("id" "val") b)
+        (insert (table "memcp-tests" "sf_float") '("id" "val") b)
         30)
 
   - name: "Float: verify cell id=0"
@@ -81,7 +81,7 @@ test_cases:
         (define cities '("Berlin" "Munich" "Hamburg" "Cologne" "Frankfurt"))
         (set b (map (produceN 200) (lambda (i)
           (list i (nth cities (- i (* 5 (floor (/ i 5)))))))))
-        (insert "memcp-tests" "sf_string_dict" '("id" "city") b)
+        (insert (table "memcp-tests" "sf_string_dict") '("id" "city") b)
         200)
 
   - name: "Dict: verify id=0 Berlin"
@@ -137,7 +137,7 @@ test_cases:
       (begin
         (set b (map (produceN 150) (lambda (i)
           (list i (concat "item_" i "_description_unique_" (* i 7))))))
-        (insert "memcp-tests" "sf_string_nodict" '("id" "description") b)
+        (insert (table "memcp-tests" "sf_string_nodict") '("id" "description") b)
         150)
 
   - name: "Nodict: verify id=0"
@@ -193,7 +193,7 @@ test_cases:
       (begin
         (set b (map (produceN 10) (lambda (i)
           (list (* i 20) (* i 200)))))
-        (insert "memcp-tests" "sf_sparse" '("id" "rare_val") b)
+        (insert (table "memcp-tests" "sf_sparse") '("id" "rare_val") b)
         10)
 
   - name: "Insert sparse NULL rows batch 1 (id 1-19)"
@@ -343,7 +343,7 @@ test_cases:
       (begin
         (set b (map (produceN 100) (lambda (i)
           (list i (+ 100 (* i 2))))))
-        (insert "memcp-tests" "sf_seq" '("id" "seq_val") b)
+        (insert (table "memcp-tests" "sf_seq") '("id" "seq_val") b)
         100)
 
   - name: "Seq: verify id=0 (start=100)"
@@ -380,7 +380,7 @@ test_cases:
       (begin
         (set b (map (produceN 50) (lambda (i)
           (list (+ i 100) (+ 500 (* i 3))))))
-        (insert "memcp-tests" "sf_seq" '("id" "seq_val") b)
+        (insert (table "memcp-tests" "sf_seq") '("id" "seq_val") b)
         50)
 
   - name: "Seq: verify second run id=100 (500)"

--- a/tests/71_repartition_concurrent.yaml
+++ b/tests/71_repartition_concurrent.yaml
@@ -21,7 +21,7 @@ test_cases:
     scm: |
       (begin
         (set b (map (produceN 61000) (lambda (i) (list i i (concat "t" i)))))
-        (insert "memcp-tests" "rc_data" (list "id" "val" "tag") b)
+        (insert (table "memcp-tests" "rc_data") (list "id" "val" "tag") b)
         61000)
 
   - name: "RC: verify initial count"
@@ -41,7 +41,7 @@ test_cases:
     scm: |
       (begin
         (set b (map (produceN 200) (lambda (i) (list (+ i 100000) (+ i 100000) (concat "new" i)))))
-        (insert "memcp-tests" "rc_data" (list "id" "val" "tag") b)
+        (insert (table "memcp-tests" "rc_data") (list "id" "val" "tag") b)
         200)
 
   - name: "RC: concurrent DELETE 50 rows"
@@ -165,7 +165,7 @@ test_cases:
         scm: |
           (begin
             (set b (map (produceN 61000) (lambda (i) (list i i (concat "t" i)))))
-            (insert "memcp-tests" "rc_data" (list "id" "val" "tag") b)
+            (insert (table "memcp-tests" "rc_data") (list "id" "val" "tag") b)
             61000)
       - name: "RC-del: rebuild"
         parallel: repart_del
@@ -207,7 +207,7 @@ test_cases:
         scm: |
           (begin
             (set b (map (produceN 61000) (lambda (i) (list i i (concat "t" i)))))
-            (insert "memcp-tests" "rc_data" (list "id" "val" "tag") b)
+            (insert (table "memcp-tests" "rc_data") (list "id" "val" "tag") b)
             61000)
       - name: "RC-repeat: rebuild"
         parallel: repart_repeat
@@ -227,7 +227,7 @@ test_cases:
         scm: |
           (begin
             (set b (map (produceN 200) (lambda (i) (list (+ i 100000) (+ i 100000) (concat "new" i)))))
-            (insert "memcp-tests" "rc_data" (list "id" "val" "tag") b)
+            (insert (table "memcp-tests" "rc_data") (list "id" "val" "tag") b)
             200)
       - name: "RC-repeat: count after ops"
         sql: "SELECT COUNT(*) AS cnt FROM rc_data"

--- a/tests/75_serializer_coverage.yaml
+++ b/tests/75_serializer_coverage.yaml
@@ -37,7 +37,7 @@ test_cases:
   - name: "Decode JSON from table via scm"
     scm: |
       (begin
-        (set rows (scan (session "__memcp_tx") "memcp-tests" "ser_test" '("id") (lambda (id) (equal? id 2)) '("data") (lambda (data) data) (lambda (a b) b) nil))
+        (set rows (scan (session "__memcp_tx") (table "memcp-tests" "ser_test") '("id") (lambda (id) (equal? id 2)) '("data") (lambda (data) data) (lambda (a b) b) nil))
         (set decoded (json_decode rows))
         (get_assoc decoded "key"))
     expect:

--- a/tests/75_serializer_coverage.yaml
+++ b/tests/75_serializer_coverage.yaml
@@ -20,7 +20,7 @@ test_cases:
   - name: "Insert JSON-encoded data into table"
     scm: |
       (begin
-        (insert "memcp-tests" "ser_test" '("id" "data")
+        (insert (table "memcp-tests" "ser_test") '("id" "data")
           (list
             (list 1 (json_encode '("a" "b" "c")))
             (list 2 (json_encode_assoc '("key" "value" "num" 42)))

--- a/tests/76_range_scan_coverage.yaml
+++ b/tests/76_range_scan_coverage.yaml
@@ -34,7 +34,7 @@ test_cases:
             (* i 3)
             (nth '("alpha" "beta" "gamma" "delta") (- i (* 4 (floor (/ i 4)))))
             (+ 1.0 (* i 0.5))))))
-        (insert "memcp-tests" "rs_data" '("id" "val" "category" "price") rows)
+        (insert (table "memcp-tests" "rs_data") '("id" "val" "category" "price") rows)
         200)
 
   # ========================================================================
@@ -395,7 +395,7 @@ test_cases:
       (begin
         (set rows (map (produceN 100) (lambda (i)
           (list (floor (/ i 10)) (- i (* 10 (floor (/ i 10)))) (* i i)))))
-        (insert "memcp-tests" "rs_multi" '("a" "b" "c") rows)
+        (insert (table "memcp-tests" "rs_multi") '("a" "b" "c") rows)
         100)
 
   - name: "Multi-col: range on first key"

--- a/tests/76_range_scan_coverage.yaml
+++ b/tests/76_range_scan_coverage.yaml
@@ -229,7 +229,7 @@ test_cases:
           value: false
         - stage: "plan"
           kind: "root"
-          value: "scan_order"
+          value: "!begin"
 
   - name: "EXPLAIN REORDER exposes table order"
     sql: "EXPLAIN REORDER SELECT a.id, b.id FROM rs_data a, rs_data b WHERE a.id = b.id"

--- a/tests/80_memory_pressure.yaml
+++ b/tests/80_memory_pressure.yaml
@@ -23,7 +23,7 @@ test_cases:
               (sha256 (concat "s6:" i))
               (sha256 (concat "s7:" i))
               (sha256 (concat "s8:" i)))))
-        (insert "memcp-tests" "mp_pressure" '("id" "a" "b" "c" "d" "e" "f")
+        (insert (table "memcp-tests" "mp_pressure") '("id" "a" "b" "c" "d" "e" "f")
           (parallelN 4001 (lambda (i) (list i
             (imod (* i 54321) 999983)
             (imod (* i 12347) 999979)
@@ -158,7 +158,7 @@ test_cases:
   - name: "MP: create temp computed column"
     scm: |
       (begin
-        (createcolumn "memcp-tests" "mp_pressure" "tmp_sum" "any" '() '("temp" true)
+        (createcolumn (table "memcp-tests" "mp_pressure") "tmp_sum" "any" '() '("temp" true)
           '("a" "b") (lambda (a b) (+ a b)))
         "ok")
     expect: {}

--- a/tests/82_ordered_computed_column.yaml
+++ b/tests/82_ordered_computed_column.yaml
@@ -39,7 +39,7 @@ test_cases:
 
   - name: "Materialize rank column via createcolumn ORC"
     scm: |
-      (createcolumn "memcp-tests" "orc_rank" "rank" "INT" '()
+      (createcolumn (table "memcp-tests" "orc_rank") "rank" "INT" '()
         (list
           "sortcols"  '("score")
           "sortdirs"  (list false)
@@ -93,7 +93,7 @@ test_cases:
 
   - name: "Materialize running_total column via createcolumn ORC"
     scm: |
-      (createcolumn "memcp-tests" "orc_sales" "running_total" "INT" '()
+      (createcolumn (table "memcp-tests" "orc_sales") "running_total" "INT" '()
         (list
           "sortcols"  '("day")
           "sortdirs"  (list false)

--- a/tests/84_incremental_invalidation.yaml
+++ b/tests/84_incremental_invalidation.yaml
@@ -77,7 +77,7 @@ test_cases:
 
   - name: "Create partitioned ORC column"
     scm: |
-      (createcolumn "memcp-tests" "inv_part" "rn" "INT" '()
+      (createcolumn (table "memcp-tests" "inv_part") "rn" "INT" '()
         (list
           "sortcols"  '("grp" "val")
           "sortdirs"  (list false false)
@@ -150,7 +150,7 @@ test_cases:
     scm: |
       (begin
         (define rows (produceN 100 (lambda (i) (list (+ i 1) (mod (+ i 1) 10) (* (+ i 1) 7)))))
-        (insert "memcp-tests" "inv_conc" '("id" "grp" "val") rows '() (lambda () true) false))
+        (insert (table "memcp-tests" "inv_conc") '("id" "grp" "val") rows '() (lambda () true) false))
 
   - name: "Create large cross-join table for slow queries"
     sql: |
@@ -160,7 +160,7 @@ test_cases:
     scm: |
       (begin
         (define rows (produceN 200 (lambda (i) (list (+ i 1) (+ i 1)))))
-        (insert "memcp-tests" "inv_big" '("id" "v") rows '() (lambda () true) false))
+        (insert (table "memcp-tests" "inv_big") '("id" "v") rows '() (lambda () true) false))
 
   - name: "Warm up aggregate cache"
     sql: "SELECT grp, SUM(val) AS total FROM inv_conc GROUP BY grp ORDER BY grp"
@@ -220,7 +220,7 @@ test_cases:
     scm: |
       (begin
         (define rows (produceN 10000 (lambda (i) (list (+ i 1) (mod (* (+ i 1) 37) 9973)))))
-        (insert "memcp-tests" "inv_orc_big" '("id" "val") rows '() (lambda () true) false))
+        (insert (table "memcp-tests" "inv_orc_big") '("id" "val") rows '() (lambda () true) false))
 
   - name: "Concurrent: INSERT during ORC scan_order"
     steps:

--- a/tests/84_serialize_round_trip.yaml
+++ b/tests/84_serialize_round_trip.yaml
@@ -177,4 +177,4 @@ test_cases:
   - name: "Cleanup sr_data"
     sql: "DROP TABLE IF EXISTS sr_data"
   - name: "Cleanup hidden sloppy table"
-    scm: '(droptable (table "memcp-tests" ".sr_hidden") true)'
+    scm: '(droptable "memcp-tests" ".sr_hidden" true)'

--- a/tests/84_serialize_round_trip.yaml
+++ b/tests/84_serialize_round_trip.yaml
@@ -177,4 +177,4 @@ test_cases:
   - name: "Cleanup sr_data"
     sql: "DROP TABLE IF EXISTS sr_data"
   - name: "Cleanup hidden sloppy table"
-    scm: '(droptable "memcp-tests" ".sr_hidden" true)'
+    scm: '(droptable (table "memcp-tests" ".sr_hidden") true)'

--- a/tests/85_index_prefix_dedup.yaml
+++ b/tests/85_index_prefix_dedup.yaml
@@ -25,7 +25,7 @@ test_cases:
     setup:
       - scm: |
           (begin
-            (insert "memcp-tests" "idx_nopfx" '("a" "b" "c")
+            (insert (table "memcp-tests" "idx_nopfx") '("a" "b" "c")
               (map (produceN 200) (lambda (i) (list i (* i 2) (* i 5)))))
             (rebuild))
     sql: "SELECT COUNT(*) AS cnt FROM idx_nopfx"
@@ -161,7 +161,7 @@ test_cases:
     setup:
       - scm: |
           (begin
-            (insert "memcp-tests" "idx_rev" '("p" "q" "r")
+            (insert (table "memcp-tests" "idx_rev") '("p" "q" "r")
               (map (produceN 200) (lambda (i) (list i (* i 4) (* i 9)))))
             (rebuild))
     sql: "SELECT COUNT(*) AS cnt FROM idx_rev"
@@ -275,7 +275,7 @@ test_cases:
     setup:
       - scm: |
           (begin
-            (insert "memcp-tests" "idx_nonoverlap" '("x" "y" "z")
+            (insert (table "memcp-tests" "idx_nonoverlap") '("x" "y" "z")
               (map (produceN 200) (lambda (i) (list i (* i 3) (* i 7)))))
             (rebuild))
     sql: "SELECT COUNT(*) AS cnt FROM idx_nonoverlap"

--- a/tests/85_suffix_recompute.yaml
+++ b/tests/85_suffix_recompute.yaml
@@ -24,7 +24,7 @@ test_cases:
 
   - name: "Create running SUM ORC column"
     scm: |
-      (createcolumn "memcp-tests" "suf_sum" "running" "INT" '()
+      (createcolumn (table "memcp-tests" "suf_sum") "running" "INT" '()
         (list
           "sortcols"  '("day")
           "sortdirs"  (list false)

--- a/tests/86_reversed_comparisons.yaml
+++ b/tests/86_reversed_comparisons.yaml
@@ -19,7 +19,7 @@ test_cases:
       - scm: "(rebuild)"
       - scm: |
           (begin
-            (insert "memcp-tests" "rev_cmp" '("id" "val" "name")
+            (insert (table "memcp-tests" "rev_cmp") '("id" "val" "name")
               (map (produceN 200) (lambda (i)
                 (if (equal? i 150) (list i (* i 3) nil)
                   (list i (* i 3) (concat "item" i))))))

--- a/tests/87_in_list_like_prefix.yaml
+++ b/tests/87_in_list_like_prefix.yaml
@@ -17,7 +17,7 @@ test_cases:
       - sql: "CREATE TABLE inlike (id INT, name VARCHAR(100), val INT)"
       - scm: |
           (begin
-            (insert "memcp-tests" "inlike" '("id" "name" "val")
+            (insert (table "memcp-tests" "inlike") '("id" "name" "val")
               (map (produceN 200) (lambda (i)
                 (list i (concat "item" i) (* i 5)))))
             (rebuild))

--- a/tests/88_exclusive_bounds.yaml
+++ b/tests/88_exclusive_bounds.yaml
@@ -17,7 +17,7 @@ test_cases:
       - sql: "CREATE TABLE exbound (id INT, val INT)"
       - scm: |
           (begin
-            (insert "memcp-tests" "exbound" '("id" "val")
+            (insert (table "memcp-tests" "exbound") '("id" "val")
               (map (produceN 100) (lambda (i) (list i (* i 10)))))
             (rebuild))
     sql: "SELECT COUNT(*) AS cnt FROM exbound"

--- a/tests/89_native_index.yaml
+++ b/tests/89_native_index.yaml
@@ -18,7 +18,7 @@ test_cases:
       - sql: "CREATE TABLE native_idx (id INT, val INT, name VARCHAR(50))"
       - scm: |
           (begin
-            (insert "memcp-tests" "native_idx" '("id" "val" "name")
+            (insert (table "memcp-tests" "native_idx") '("id" "val" "name")
               (map (produceN 200) (lambda (i)
                 (list i (* i 7) (concat "row" i)))))
             (rebuild))

--- a/tests/90_eager_index_rebuild.yaml
+++ b/tests/90_eager_index_rebuild.yaml
@@ -18,7 +18,7 @@ test_cases:
       - sql: "CREATE TABLE eager_idx (id INT, val INT, name VARCHAR(50))"
       - scm: |
           (begin
-            (insert "memcp-tests" "eager_idx" '("id" "val" "name")
+            (insert (table "memcp-tests" "eager_idx") '("id" "val" "name")
               (map (produceN 100) (lambda (i)
                 (list i (* i 3) (concat "row" i)))))
             (rebuild))

--- a/tests/90_perf_basic.yaml
+++ b/tests/90_perf_basic.yaml
@@ -21,7 +21,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 54) (* i 71) (concat "str_" i)))))
-            (set cnt (insert "{database}" "perf_main" '("id" "category" "value" "name") rows))
+            (set cnt (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows))
             (rebuild)
             (set mem (memstats))
             (list cnt (mem "heap_alloc")))
@@ -39,7 +39,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 54) (* i 71) (concat "str_" i)))))
-            (set cnt (insert "{database}" "perf_main" '("id" "category" "value" "name") rows))
+            (set cnt (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows))
             (rebuild)
             (set mem (memstats))
             (list cnt (mem "heap_alloc")))
@@ -57,7 +57,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 54) (* i 71) (concat "str_" i)))))
-            (set cnt (insert "{database}" "perf_main" '("id" "category" "value" "name") rows))
+            (set cnt (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows))
             (rebuild)
             (set mem (memstats))
             (list cnt (mem "heap_alloc")))
@@ -75,7 +75,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 54) (* i 71) (concat "str_" i)))))
-            (set cnt (insert "{database}" "perf_main" '("id" "category" "value" "name") rows))
+            (set cnt (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows))
             (rebuild)
             (set mem (memstats))
             (list cnt (mem "heap_alloc")))
@@ -93,7 +93,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 54) (* i 71) (concat "str_" i)))))
-            (set cnt (insert "{database}" "perf_main" '("id" "category" "value" "name") rows))
+            (set cnt (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows))
             (rebuild)
             (set mem (memstats))
             (list cnt (mem "heap_alloc")))
@@ -114,9 +114,9 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (- i (* 100 (floor (/ i 100)))) (* i 71) (concat "str_" i)))))
-            (insert "{database}" "perf_main" '("id" "category" "value" "name") rows)
+            (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows)
             (set dims (map (produceN 100) (lambda (i) (list i (concat "cat_" i)))))
-            (insert "{database}" "perf_dim" '("cat_id" "label") dims)
+            (insert (table "{database}" "perf_dim") '("cat_id" "label") dims)
             (rebuild)
             "ok")
     sql: "SELECT d.label, m.id FROM perf_dim d JOIN perf_main m ON m.category = d.cat_id"
@@ -134,9 +134,9 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (- i (* 100 (floor (/ i 100)))) (* i 71) (concat "str_" i)))))
-            (insert "{database}" "perf_main" '("id" "category" "value" "name") rows)
+            (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows)
             (set ranges (map (produceN 20) (lambda (i) (list i (* i (/ (* {rows} 71) 20)) (* (+ i 1) (/ (* {rows} 71) 20))))))
-            (insert "{database}" "perf_ranges" '("range_id" "low_val" "high_val") ranges)
+            (insert (table "{database}" "perf_ranges") '("range_id" "low_val" "high_val") ranges)
             (rebuild)
             "ok")
     sql: "SELECT r.range_id, m.id FROM perf_ranges r JOIN perf_main m ON m.value >= r.low_val AND m.value < r.high_val"
@@ -158,9 +158,9 @@ test_cases:
             (set dim {rows})
             (set n (* dim dim))
             (set a (map (produceN n) (lambda (i) (list (floor (/ i dim)) (- i (* dim (floor (/ i dim)))) (+ 1 i)))))
-            (insert "{database}" "perf_mat_a" '("r" "c" "v") a)
+            (insert (table "{database}" "perf_mat_a") '("r" "c" "v") a)
             (set b (map (produceN n) (lambda (i) (list (floor (/ i dim)) (- i (* dim (floor (/ i dim)))) (+ 1 (* 3 i))))))
-            (insert "{database}" "perf_mat_b" '("r" "c" "v") b)
+            (insert (table "{database}" "perf_mat_b") '("r" "c" "v") b)
             (rebuild)
             "ok")
     sql: "SELECT a.r, b.c, a.v * b.v AS v FROM perf_mat_a a JOIN perf_mat_b b ON a.c = b.r"
@@ -178,13 +178,13 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (- i (* 100 (floor (/ i 100)))) (* i 71) (concat "str_" i)))))
-            (insert "{database}" "perf_main" '("id" "category" "value" "name") rows)
+            (insert (table "{database}" "perf_main") '("id" "category" "value" "name") rows)
             (set dims (map (produceN 100) (lambda (i) (list i (concat "cat_" i)))))
-            (insert "{database}" "perf_dim" '("cat_id" "label") dims)
+            (insert (table "{database}" "perf_dim") '("cat_id" "label") dims)
             (rebuild)
             (set delta_n (floor (/ {rows} 10)))
             (set delta (map (produceN delta_n) (lambda (i) (list (+ i {rows}) (- i (* 100 (floor (/ i 100)))) (* (+ i {rows}) 71) (concat "delta_" i)))))
-            (insert "{database}" "perf_main" '("id" "category" "value" "name") delta)
+            (insert (table "{database}" "perf_main") '("id" "category" "value" "name") delta)
             "ok")
     sql: "SELECT d.label, m.id FROM perf_dim d JOIN perf_main m ON m.category = d.cat_id"
     threshold_ms: 30000

--- a/tests/91_fulltext_like_index.yaml
+++ b/tests/91_fulltext_like_index.yaml
@@ -50,7 +50,7 @@ test_cases:
               (list 18 "Herbert" "Krause" "1976-11-13")
               (list 19 "Ute" "Schulze" "1989-09-21")
               (list 20 "Dieter" "Huber" "1972-02-08")))
-            (insert "memcp-tests" "ft_customers" '("id" "vorname" "nachname" "birthdate") rows))
+            (insert (table "memcp-tests" "ft_customers") '("id" "vorname" "nachname" "birthdate") rows))
       - scm: "(rebuild)"
     sql: "SELECT COUNT(*) AS cnt FROM ft_customers"
     expect:
@@ -138,7 +138,7 @@ test_cases:
                   22777 "Hans Klausner"
                   29999 "Klausmüller Gerd"
                   _ (concat "Person_" i))))))
-            (insert "memcp-tests" "ft_large" '("id" "name") rows))
+            (insert (table "memcp-tests" "ft_large") '("id" "name") rows))
       - scm: "(rebuild)"
     sql: "SELECT COUNT(*) AS cnt FROM ft_large"
     expect:
@@ -421,7 +421,7 @@ test_cases:
                 0 "Animal"
                 1 "Person"
                 _ "Object")))))
-            (insert "memcp-tests" "ft_alternating" '("id" "name") rows))
+            (insert (table "memcp-tests" "ft_alternating") '("id" "name") rows))
       - scm: "(rebuild)"
     sql: "SELECT COUNT(*) AS cnt FROM ft_alternating"
     expect:

--- a/tests/91_perf_derived_count_pruning.yaml
+++ b/tests/91_perf_derived_count_pruning.yaml
@@ -33,14 +33,14 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i (* i 3)))))
-            (insert "{database}" "perf_main" '("id" "payload") rows)
+            (insert (table "{database}" "perf_main") '("id" "payload") rows)
             (set detail_n (* {rows} 2))
             (set details (map (produceN detail_n) (lambda (i)
               (list
                 i
                 (floor (/ i 2))
                 (+ 1 (* i 5))))))
-            (insert "{database}" "perf_detail" '("id" "parent" "val") details)
+            (insert (table "{database}" "perf_detail") '("id" "parent" "val") details)
             (rebuild)
             "ok")
     sql: |

--- a/tests/91_perf_unique_insert.yaml
+++ b/tests/91_perf_unique_insert.yaml
@@ -21,7 +21,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i i (concat "name_" i)))))
-            (insert "{database}" "perf_source" '("id" "val" "name") rows)
+            (insert (table "{database}" "perf_source") '("id" "val" "name") rows)
             (rebuild))
     sql: "INSERT IGNORE INTO perf_unique (id, val, name) SELECT id, val, name FROM perf_source"
     warmup: false
@@ -38,10 +38,10 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i i (concat "name_" i)))))
-            (insert "{database}" "perf_unique" '("id" "val" "name") rows)
+            (insert (table "{database}" "perf_unique") '("id" "val" "name") rows)
             (rebuild)
             (set rows2 (map (produceN {rows}) (lambda (i) (list (+ i {rows}) (+ i {rows}) (concat "new_" i)))))
-            (insert "{database}" "perf_source" '("id" "val" "name") rows2)
+            (insert (table "{database}" "perf_source") '("id" "val" "name") rows2)
             (rebuild))
     sql: "INSERT IGNORE INTO perf_unique (id, val, name) SELECT id, val, name FROM perf_source"
     warmup: false
@@ -56,7 +56,7 @@ test_cases:
       - scm: |
           (begin
             (set rows (map (produceN {rows}) (lambda (i) (list i i (concat "name_" i)))))
-            (insert "{database}" "perf_unique" '("id" "val" "name") rows)
+            (insert (table "{database}" "perf_unique") '("id" "val" "name") rows)
             (rebuild))
     sql: "INSERT IGNORE INTO perf_unique (id, val, name) SELECT id + {rows}, val, CONCAT('dup_', name) FROM perf_unique"
     threshold_ms: 30000

--- a/tests/92_parallel_projection.yaml
+++ b/tests/92_parallel_projection.yaml
@@ -24,7 +24,7 @@ test_cases:
       (begin
         (define tables '("pp_data_1" "pp_data_2" "pp_data_3" "pp_data_4"))
         (map tables (lambda (tbl)
-          (insert "memcp-tests" tbl '("id" "score")
+          (insert (table "memcp-tests" tbl) '("id" "score")
             (map (produceN 30000) (lambda (i) (list i (* i 7)))))))
         (* 4 30000))
 

--- a/tests/93_index_delta_merge.yaml
+++ b/tests/93_index_delta_merge.yaml
@@ -27,7 +27,7 @@ test_cases:
     setup:
       - scm: |
           (begin
-            (insert "memcp-tests" "idx_merge" '("id" "cat" "val")
+            (insert (table "memcp-tests" "idx_merge") '("id" "cat" "val")
               (map (produceN 200) (lambda (i) (list i (- i (* 10 (floor (/ i 10)))) (* i 7)))))
             (rebuild))
     sql: "SELECT COUNT(*) AS cnt FROM idx_merge"

--- a/tests/95_crash_recovery.yaml
+++ b/tests/95_crash_recovery.yaml
@@ -47,7 +47,7 @@ test_cases:
   - name: "Seed crash_safe with 100 rows"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_safe" '("val" "name")
+          (insert (table "memcp-tests" "crash_safe") '("val" "name")
             (map (produceN 100) (lambda (i)
               (list i (concat "row" i)))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_safe"
@@ -70,7 +70,7 @@ test_cases:
   - name: "Insert 50 delta rows then crash"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_safe" '("val" "name")
+          (insert (table "memcp-tests" "crash_safe") '("val" "name")
             (map (produceN 50) (lambda (i)
               (list (+ 100 i) (concat "delta" i)))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_safe"
@@ -115,7 +115,7 @@ test_cases:
   - name: "Seed crash_insert with 20 known rows"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_insert" '("val")
+          (insert (table "memcp-tests" "crash_insert") '("val")
             (map (produceN 20) (lambda (i) (list i))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_insert"
     expect:
@@ -141,7 +141,7 @@ test_cases:
   - name: "Large insert interrupted by crash"
     parallel: crash_insert
     scm: |
-      (insert "memcp-tests" "crash_insert" '("val")
+      (insert (table "memcp-tests" "crash_insert") '("val")
         (map (produceN 100000) (lambda (i) (list (+ 20 i)))))
     expect:
       interrupted_ok: true
@@ -169,7 +169,7 @@ test_cases:
   - name: "Seed crash_update with 1000 rows"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_update" '("id" "val" "status")
+          (insert (table "memcp-tests" "crash_update") '("id" "val" "status")
             (map (produceN 1000) (lambda (i)
               (list i i "original"))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_update WHERE status = 'original'"
@@ -212,7 +212,7 @@ test_cases:
   - name: "Seed crash_count with 30 categorized rows"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_count" '("category" "amount")
+          (insert (table "memcp-tests" "crash_count") '("category" "amount")
             (map (produceN 30) (lambda (i)
               (list (concat "cat" (mod i 3)) (* i 10)))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_count"
@@ -230,7 +230,7 @@ test_cases:
   - name: "Insert 30 more rows then crash"
     scm: |
       (begin
-        (insert "memcp-tests" "crash_count" '("category" "amount")
+        (insert (table "memcp-tests" "crash_count") '("category" "amount")
           (map (produceN 30) (lambda (i)
             (list (concat "cat" (mod (+ i 30) 3)) (* (+ i 30) 10)))))
         (crash))
@@ -264,7 +264,7 @@ test_cases:
   - name: "Seed crash_clean with data"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_clean" '("data")
+          (insert (table "memcp-tests" "crash_clean") '("data")
             (map (produceN 40) (lambda (i)
               (list (concat "item" i)))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_clean"
@@ -286,7 +286,7 @@ test_cases:
   - name: "Insert more then crash"
     scm: |
       (begin
-        (insert "memcp-tests" "crash_clean" '("data")
+        (insert (table "memcp-tests" "crash_clean") '("data")
           (map (produceN 20) (lambda (i)
             (list (concat "item" (+ i 40))))))
         (crash))
@@ -685,7 +685,7 @@ test_cases:
   - name: "Seed crash_rebuild with data for rebuild"
     setup:
       - scm: |
-          (insert "memcp-tests" "crash_rebuild" '("val")
+          (insert (table "memcp-tests" "crash_rebuild") '("val")
             (map (produceN 200) (lambda (i) (list i))))
     sql: "SELECT COUNT(*) AS cnt FROM crash_rebuild"
     expect:
@@ -702,7 +702,7 @@ test_cases:
     scm: |
       (begin
         (rebuild)
-        (insert "memcp-tests" "crash_rebuild" '("val")
+        (insert (table "memcp-tests" "crash_rebuild") '("val")
           (map (produceN 100) (lambda (i) (list (+ 200 i)))))
         "ok")
     expect:

--- a/tests/96_rebuild_concurrent.yaml
+++ b/tests/96_rebuild_concurrent.yaml
@@ -15,7 +15,7 @@ setup:
         (set rows (map (produceN 20000) (lambda (i)
           (list (+ i 1) (concat "v" (+ i 1)))))
         )
-        (insert "memcp-tests" "rc_data" '("id" "val") rows)
+        (insert (table "memcp-tests" "rc_data") '("id" "val") rows)
         20000)
 
 test_cases:


### PR DESCRIPTION
## Summary

- The catalog merge (096b897ce) silently disabled the nested-loop → batch-nested-loop rewrite for `scan`; every equi-join fell back to plain nested loop.
- Root cause: `tryScanBatchRewrite` guards on `v[2].IsCustom(TagTable)`, but at optimizer time `v[2]` is a symbol `tbl:schema:name` (pre-resolved reference) or a `(table schema tbl)` codegen list — never the runtime TagTable value. Guard never matched → rewrite never fired.
- Secondary latent bug in `scan_batch`'s runtime `Fn` handler: reduce/neutral/reduce2/isOuter were read from `layout.*Idx+1`, but the stride+batchdata insertion shifts those args by 2 positions, not 1. Invisible so far because the rewrite never produced scan_batch calls.

## Measurement

A/B with median-of-5 at 3 250 rows (pre-catalog commit `e4702619a` vs post-catalog `7e6a334ad` vs this PR):

| Test       | Baseline | Catalog (unfixed) | Catalog + fix | Δ vs baseline |
|------------|---------:|------------------:|--------------:|--------------:|
| COUNT      |  1.6 ms  |  1.5 ms           |  1.4 ms       |  -13% |
| SUM        |  1.3 ms  |  1.3 ms           |  1.3 ms       |   0%  |
| ORDER+LIMIT|  4.7 ms  |  5.4 ms           |  4.3 ms       |  -9%  |
| SCAN+FILTER|  1.3 ms  |  1.3 ms           |  1.3 ms       |   0%  |
| GROUP BY   | 46.6 ms  | 47.9 ms           | 47.7 ms       |  +2%  |
| **EQUI JOIN**| **22.0 ms** | **36.7 ms** ⚠️ | **22.0 ms** ✅ | 0% |
| RANGE JOIN | 24.6 ms  | 16.1 ms           | 23.4 ms       |  -5%  |
| **DELTA JOIN**| **26.8 ms** | **40.6 ms** ⚠️ | **26.7 ms** ✅ | 0% |

## Changes

- `storage/scan_batch_rewrite.go`: drop the `TagTable` guard on both outer and inner scan. v[2] is always a table reference of some shape; pass it through and let runtime resolve. Keep `tryScanOrderBatchRewrite` disabled pending separate review (has same latent index-drift + different ordered-result semantics).
- `storage/storage.go`: fix scan_batch Fn handler offsets — `+1` → `+2` for reduce/neutral/reduce2/isOuter, introduced a `sbShift` constant so the intent is visible.

## Test plan

- [x] `tests/90_perf_basic.yaml` EQUI/RANGE/DELTA JOIN pass post-fix with times matching pre-catalog
- [x] Full pre-commit test suite (all `[0-9][0-9]_*.yaml`) passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)