### PR TITLE
fix: re-enable scan_batch rewrite after catalog merge (+67% equi-join)

### DIFF
--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -26,34 +26,19 @@ const batchCapacityRows = 128
 // a buffer, and the inner scan becomes scan_batch consuming the buffer via #N
 // pseudo-columns. Returns the rewritten AST or nil if the pattern doesn't match.
 // tryScanOrderBatchRewrite attempts batch rewrite for scan_order's mapfn.
-// scan_order: [fn, tx, schema, tbl, filtercols, filterfn, sortcols, sortdirs,
-//              partcols, offset, limit, mapcols, mapfn, reduce, neutral, isOuter]
-// mapfn is at index 12, reduce at 13, isOuter at 15.
+// DISABLED pending separate review — scan_order batch semantics need the
+// ordered-result-preservation path and are different from plain scan. Leave
+// scan_order unbatched for now.
 func tryScanOrderBatchRewrite(v []scm.Scmer) scm.Scmer {
-	// scan_order: [fn, tx, schema, tbl, filtercols, filterfn, sortcols, sortdirs,
-	//              partcols, offset, limit, mapcols, mapfn, reduce, neutral, isOuter]
-	if len(v) < 13 {
-		return scm.NewNil()
-	}
-	if !v[3].IsString() {
-		return scm.NewNil()
-	}
-	if len(v) > 15 && scm.ToBool(v[15]) {
-		return scm.NewNil()
-	}
-	if len(v) > 13 && !v[13].IsNil() {
-		return scm.NewNil()
-	}
-	// scan_order tail after mapfn: reduce, neutral, isOuter (no reduce2)
-	return tryScanBatchRewriteMapfn(v, 11, 12, false)
+	return scm.NewNil()
 }
 
 func tryScanBatchRewrite(v []scm.Scmer) scm.Scmer {
 	// scan: [fn, tx, tbl, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
+	// v[2] (tbl) is always a table reference — shape-agnostic (TagTable at
+	// runtime, (table schema tbl) list or tbl:schema:name symbol at optimize
+	// time). We trust that and just pass it through unchanged.
 	if len(v) < 7 {
-		return scm.NewNil()
-	}
-	if !v[2].IsCustom(TagTable) {
 		return scm.NewNil()
 	}
 	if len(v) > 10 && scm.ToBool(v[10]) {
@@ -98,8 +83,9 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 		return scm.NewNil()
 	}
 
-	// Inner scan must also be a real table (not list) and not outer
-	if len(innerScanSlice) < 7 || !innerScanSlice[2].IsCustom(TagTable) {
+	// Inner scan — v[2] is always a table reference (see tryScanBatchRewrite);
+	// we only check arity and that it's not an outer scan.
+	if len(innerScanSlice) < 7 {
 		return scm.NewNil()
 	}
 	if len(innerScanSlice) > 10 && scm.ToBool(innerScanSlice[10]) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -508,12 +508,16 @@ func Init(en scm.Env) {
 			stride := int(scm.ToInt(a[layout.strideIdx]))
 			batchdata := mustScmerSlice(a[layout.batchDataIdx], "batchdata")
 			tableArg := a[layout.tableIdx]
-			isOuter := len(a) > layout.outerIdx+1 && scm.ToBool(a[layout.outerIdx+1])
+			// scan_batch inserts stride+batchdata (2 slots) between mapfn and
+			// reduce, so reduce/neutral/reduce2/isOuter sit at scanLayout's
+			// reduceIdx/neutralIdx/reduce2Idx/outerIdx + 2.
+			const sbShift = 2
+			isOuter := len(a) > layout.outerIdx+sbShift && scm.ToBool(a[layout.outerIdx+sbShift])
 
 			if list, ok := scmerSlice(tableArg); ok {
 				neutral := scm.NewNil()
-				if len(a) > layout.neutralIdx+1 {
-					neutral = a[layout.neutralIdx+1]
+				if len(a) > layout.neutralIdx+sbShift {
+					neutral = a[layout.neutralIdx+sbShift]
 				}
 				result := neutral
 				filterfn := scm.OptimizeProcToSerialFunction(a[layout.filterFnIdx])
@@ -521,8 +525,8 @@ func Init(en scm.Env) {
 				mapfn := scm.OptimizeProcToSerialFunction(a[layout.mapFnIdx])
 				mapparams := make([]scm.Scmer, len(mapcols))
 				reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
-				if len(a) > layout.reduceIdx+1 {
-					reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx+1])
+				if len(a) > layout.reduceIdx+sbShift {
+					reducefn = scm.OptimizeProcToSerialFunction(a[layout.reduceIdx+sbShift])
 				}
 				hadValue := false
 				batchCount := 0
@@ -560,11 +564,11 @@ func Init(en scm.Env) {
 					}
 					result = reducefn(result, mapfn(mapparams...))
 				}
-				if len(a) > layout.reduce2Idx+1 && !a[layout.reduce2Idx+1].IsNil() {
-					reduce2fn := scm.OptimizeProcToSerialFunction(a[layout.reduce2Idx+1])
+				if len(a) > layout.reduce2Idx+sbShift && !a[layout.reduce2Idx+sbShift].IsNil() {
+					reduce2fn := scm.OptimizeProcToSerialFunction(a[layout.reduce2Idx+sbShift])
 					base := neutral
-					if len(a) > layout.neutralIdx+1 {
-						base = a[layout.neutralIdx+1]
+					if len(a) > layout.neutralIdx+sbShift {
+						base = a[layout.neutralIdx+sbShift]
 					}
 					result = reduce2fn(base, result)
 				}
@@ -574,16 +578,16 @@ func Init(en scm.Env) {
 			t := TableFromScmer(a[layout.tableIdx])
 
 			aggregate := scm.NewNil()
-			if len(a) > layout.reduceIdx+1 {
-				aggregate = a[layout.reduceIdx+1]
+			if len(a) > layout.reduceIdx+sbShift {
+				aggregate = a[layout.reduceIdx+sbShift]
 			}
 			neutral := scm.NewNil()
-			if len(a) > layout.neutralIdx+1 {
-				neutral = a[layout.neutralIdx+1]
+			if len(a) > layout.neutralIdx+sbShift {
+				neutral = a[layout.neutralIdx+sbShift]
 			}
 			reduce2 := scm.NewNil()
-			if len(a) > layout.reduce2Idx+1 {
-				reduce2 = a[layout.reduce2Idx+1]
+			if len(a) > layout.reduce2Idx+sbShift {
+				reduce2 = a[layout.reduce2Idx+sbShift]
 			}
 			return t.scanWithBatch(layout.tx, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter, stride, batchdata)
 		},


### PR DESCRIPTION
Resubmission of #192 on a clean branch rebased onto master.

## Summary

- The catalog merge (#191) silently disabled the nested-loop → batch-nested-loop rewrite for `scan`; every equi-join fell back to plain nested loop.
- Root cause: `tryScanBatchRewrite` guards on `v[2].IsCustom(TagTable)`, but at optimizer time `v[2]` is a symbol `tbl:schema:name` (pre-resolved reference) or a `(table schema tbl)` codegen list — never the runtime TagTable value. Guard never matched → rewrite never fired.
- Secondary latent bug in `scan_batch`'s runtime `Fn` handler: reduce/neutral/reduce2/isOuter were read from `layout.*Idx+1`, but stride+batchdata insertion shifts those args by 2 positions, not 1. Invisible so far because the rewrite never produced scan_batch calls.

## Measurement

A/B with median-of-5 at 3 250 rows (pre-catalog `e4702619a` vs post-catalog `7e6a334ad` vs this PR):

| Test       | Baseline | Catalog (unfixed) | Catalog + fix | Δ vs baseline |
|------------|---------:|------------------:|--------------:|--------------:|
| COUNT      |  1.6 ms  |  1.5 ms           |  1.4 ms       |  -13% |
| SUM        |  1.3 ms  |  1.3 ms           |  1.3 ms       |   0%  |
| ORDER+LIMIT|  4.7 ms  |  5.4 ms           |  4.3 ms       |  -9%  |
| SCAN+FILTER|  1.3 ms  |  1.3 ms           |  1.3 ms       |   0%  |
| GROUP BY   | 46.6 ms  | 47.9 ms           | 47.7 ms       |  +2%  |
| **EQUI JOIN**| **22.0 ms** | **36.7 ms** ⚠️ | **22.0 ms** ✅ | 0% |
| RANGE JOIN | 24.6 ms  | 16.1 ms           | 23.4 ms       |  -5%  |
| **DELTA JOIN**| **26.8 ms** | **40.6 ms** ⚠️ | **26.7 ms** ✅ | 0% |

## Changes

- `storage/scan_batch_rewrite.go`: drop the `TagTable` guard on both outer and inner scan. v[2] is always a table reference of some shape; pass it through and let runtime resolve. Keep `tryScanOrderBatchRewrite` disabled pending separate review (same latent index-drift + different ordered-result semantics).
- `storage/storage.go`: fix scan_batch Fn handler offsets — introduce a `sbShift = 2` constant and apply it consistently to reduce/neutral/reduce2/isOuter reads.

## Test plan

- [x] `tests/90_perf_basic.yaml` EQUI/RANGE/DELTA JOIN pass post-fix with times matching pre-catalog
- [x] Full pre-commit test suite (all `[0-9][0-9]_*.yaml`) passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)