### PR TITLE
[codex] Cherry-pick scan_order_multi per-table offset/limit

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4407,7 +4407,9 @@ second table carries strictly more local WHERE predicates than the first. */
 					(define limit_val (if (nil? limit) -1 limit))
 					(define offset_val (if (nil? offset) 0 offset))
 
-					/* Emit scan_order_multi call */
+					/* Emit scan_order_multi call. Per-table offset/limit are nil here
+					(no per-branch ORDER+LIMIT in this codepath); if a branch ever carries
+					its own order+limit, populate the nil lists with per-branch ints. */
 					(merge (list (symbol "scan_order_multi") '(session "__memcp_tx"))
 						(list
 							(cons (symbol "list") (map scan_specs (lambda (s) (list (symbol "table") (nth s 0) (nth s 1)))))
@@ -4415,6 +4417,8 @@ second table carries strictly more local WHERE predicates than the first. */
 							(cons (symbol "list") (map scan_specs (lambda (s) (nth s 3))))
 							(cons (symbol "list") (map scan_specs (lambda (s) (cons (symbol "list") (nth s 4)))))
 							(cons (symbol "list") sort_dirs)
+							nil
+							nil
 							0
 							offset_val
 							limit_val

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -28,21 +28,22 @@ import "github.com/launix-de/memcp/scm"
 
 func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	// scan_order_multi args: 0=fn, 1=tx, 2=tables, 3=filterCols, 4=filterFns,
-	// 5=sortcols, 6=sortdirs, 7=partCols, 8=offset, 9=limit, 10=mapCols, 11=mapFns,
-	// 12=reduce, 13=neutral, 14=isOuter
-	for i := 1; i <= 11 && i < len(v); i++ {
+	// 5=sortcols, 6=sortdirs, 7=perTableOffset, 8=perTableLimit,
+	// 9=partCols, 10=offset, 11=limit, 12=mapCols, 13=mapFns,
+	// 14=reduce, 15=neutral, 16=isOuter
+	for i := 1; i <= 13 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
 	oc.Ome.IncrLoopDepth()
-	if len(v) > 12 && !v[12].IsNil() {
+	if len(v) > 14 && !v[14].IsNil() {
 		oc.SetCallbackOwned([]bool{true, false})
-		v[12], _ = oc.OptimizeSub(v[12], true)
-	}
-	if len(v) > 13 {
-		v[13], _ = oc.OptimizeSub(v[13], true)
-	}
-	if len(v) > 14 {
 		v[14], _ = oc.OptimizeSub(v[14], true)
+	}
+	if len(v) > 15 {
+		v[15], _ = oc.OptimizeSub(v[15], true)
+	}
+	if len(v) > 16 {
+		v[16], _ = oc.OptimizeSub(v[16], true)
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
@@ -117,6 +118,7 @@ type shardqueue struct {
 	mapper       *ShardMapReducer
 	callbackCols []string  // per-table map columns (for multi-table merge)
 	callback     scm.Scmer // per-table map function (for multi-table merge)
+	tableIdx     int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
 }
 
 // scanOrderResult bundles per-shard outputs for ordered scans.
@@ -277,6 +279,13 @@ type scanOrderTableSpec struct {
 	sortcols      []scm.Scmer
 	callbackCols  []string
 	callback      scm.Scmer
+	// perTableOffset / perTableLimit: -1 disables per-table limiting for this
+	// table; otherwise the first `perTableOffset` rows (in merge order) are
+	// skipped and at most `perTableLimit` rows are emitted from this table.
+	// NOTE: only well-defined when per-table sort direction matches the global
+	// merge direction (shared sortdirs). Callers must enforce this.
+	perTableOffset int
+	perTableLimit  int
 }
 
 // extendBoundariesWithSortCols appends sort columns to the boundaries when all
@@ -406,6 +415,21 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		t := spec.table
 		touchTempColumns(t, spec.conditionCols, spec.callbackCols)
 
+		// Per-table top-K hint: when perTableLimit is set, each shard only
+		// needs to return the top (perTableOffset + perTableLimit) rows in
+		// per-table sort order. This prunes work at the shard level before
+		// the merge enforces the per-table offset/limit globally.
+		shardTotalLimit := total_limit
+		if spec.perTableLimit >= 0 {
+			ptTotal := spec.perTableLimit
+			if spec.perTableOffset > 0 {
+				ptTotal += spec.perTableOffset
+			}
+			if shardTotalLimit < 0 || ptTotal < shardTotalLimit {
+				shardTotalLimit = ptTotal
+			}
+		}
+
 		// Boundary analysis per table
 		analyzeStart := time.Now()
 		bounds := extractBoundaries(spec.conditionCols, spec.condition)
@@ -434,6 +458,8 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		condition := spec.condition
 		sortcols := spec.sortcols
 		tableBounds := bounds
+		tableIdx := ti
+		shardLimit := shardTotalLimit
 
 		done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {
 			if ss != nil && ss.IsKilled() {
@@ -444,9 +470,10 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 					q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 				}
 			}()
-			res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, total_limit, callbackCols, currentTx, ss)
+			res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 			res.callbackCols = callbackCols
 			res.callback = callback
+			res.tableIdx = tableIdx
 			q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
 		})
 		if done != nil {
@@ -536,11 +563,40 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	partOffset := offset
 	partLimit := limit
 
+	// Per-table offset/limit state. Applied BEFORE partition/global logic.
+	// -1 entries disable per-table limiting for that table.
+	tablePartOffset := make([]int, len(tables))
+	tablePartLimit := make([]int, len(tables))
+	for ti := range tables {
+		tablePartOffset[ti] = tables[ti].perTableOffset
+		tablePartLimit[ti] = tables[ti].perTableLimit
+	}
+
 	for !breakCaught && len(q.q) > 0 {
 		qx := q.q[0]
 
 		if len(qx.items) == 0 {
 			heap.Pop(&q)
+			continue
+		}
+
+		// Per-table limit: discard remaining shardqueue items once the
+		// per-table quota is exhausted. Sibling shardqueues of the same
+		// tableIdx are dropped as they reach the heap top.
+		ti := qx.tableIdx
+		if ti < len(tablePartLimit) && tablePartLimit[ti] == 0 {
+			heap.Pop(&q)
+			continue
+		}
+		// Per-table offset skip: consume leading items without emitting.
+		if ti < len(tablePartOffset) && tablePartOffset[ti] > 0 {
+			tablePartOffset[ti]--
+			qx.items = qx.items[1:]
+			if len(qx.items) > 0 {
+				heap.Fix(&q, 0)
+			} else {
+				heap.Pop(&q)
+			}
 			continue
 		}
 
@@ -587,6 +643,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			break
 		}
 		partLimit--
+		if ti < len(tablePartLimit) && tablePartLimit[ti] > 0 {
+			tablePartLimit[ti]--
+		}
 
 		// Pop one item from the global merge
 		item := qx.items[0]
@@ -643,12 +702,14 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 // scan_order delegates to scanOrderMulti with a single-element table spec.
 func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
-		table:         t,
-		conditionCols: conditionCols,
-		condition:     condition,
-		sortcols:      sortcols,
-		callbackCols:  callbackCols,
-		callback:      callback,
+		table:          t,
+		conditionCols:  conditionCols,
+		condition:      condition,
+		sortcols:       sortcols,
+		callbackCols:   callbackCols,
+		callback:       callback,
+		perTableOffset: -1,
+		perTableLimit:  -1,
 	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter)
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -267,6 +267,33 @@ func scmerSliceToStrings(list []scm.Scmer) []string {
 	return out
 }
 
+// decodePerTableInts accepts nil (= all -1), or a list of length n of ints.
+// Sentinel -1 disables per-table offset/limit for that entry.
+func decodePerTableInts(v scm.Scmer, n int, ctx string) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = -1
+	}
+	if v.IsNil() {
+		return out
+	}
+	slice, ok := scmerSlice(v)
+	if !ok {
+		panic(ctx + ": expected list or nil")
+	}
+	if len(slice) != n {
+		panic(fmt.Sprintf("%s: expected length %d, got %d", ctx, n, len(slice)))
+	}
+	for i, entry := range slice {
+		if entry.IsNil() {
+			out[i] = -1
+		} else {
+			out[i] = int(scm.ToInt(entry))
+		}
+	}
+	return out
+}
+
 func parseBatchPseudoColName(name string) (int, bool) {
 	if len(name) < 2 || name[0] != '#' {
 		return 0, false
@@ -757,43 +784,47 @@ func Init(en scm.Env) {
 		Desc: "does an ordered parallel filter and serial map-reduce pass across multiple tables simultaneously, merging results into a single sorted stream",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// Parameters:
-			// 0: tx
-			// 1: tables list (table handles)
-			// 2: filterColumns per table (list of lists)
-			// 3: filterFns per table (list of lambdas)
-			// 4: sortcols per table (list of lists)
-			// 5: sortdirs (shared list)
-			// 6: limitPartitionCols
-			// 7: offset
-			// 8: limit
-			// 9: mapColumns per table (list of lists)
-			// 10: mapFns per table (list of lambdas)
-			// 11: reduce (optional)
-			// 12: neutral (optional)
-			// 13: isOuter (optional)
+			// 0:  tx
+			// 1:  tables list (table handles)
+			// 2:  filterColumns per table (list of lists)
+			// 3:  filterFns per table (list of lambdas)
+			// 4:  sortcols per table (list of lists)
+			// 5:  sortdirs (shared list — used for both per-table top-K and outer merge)
+			// 6:  perTableOffset (list of int, or nil; -1 per entry = disable for that table)
+			// 7:  perTableLimit  (list of int, or nil; -1 per entry = disable for that table)
+			// 8:  limitPartitionCols (global Top-K-per-partition across merge)
+			// 9:  offset (global)
+			// 10: limit  (global; -1 = unlimited)
+			// 11: mapColumns per table (list of lists)
+			// 12: mapFns per table (list of lambdas)
+			// 13: reduce (optional)
+			// 14: neutral (optional)
+			// 15: isOuter (optional)
 			currentTx := scmerToTxContext(a[0])
 			tables := mustScmerSlice(a[1], "tables")
 			filterColsArr := mustScmerSlice(a[2], "filterColumns")
 			filterFnArr := mustScmerSlice(a[3], "filterFns")
 			sortcolsArr := mustScmerSlice(a[4], "sortcols")
 			sortdirsVals := mustScmerSlice(a[5], "sortdirs")
-			limitPartitionCols := scm.ToInt(a[6])
-			offset := scm.ToInt(a[7])
-			limit := scm.ToInt(a[8])
-			mapColsArr := mustScmerSlice(a[9], "mapColumns")
-			mapFnArr := mustScmerSlice(a[10], "mapFns")
+			n := len(tables)
+			perTableOffsets := decodePerTableInts(a[6], n, "perTableOffset")
+			perTableLimits := decodePerTableInts(a[7], n, "perTableLimit")
+			limitPartitionCols := scm.ToInt(a[8])
+			offset := scm.ToInt(a[9])
+			limit := scm.ToInt(a[10])
+			mapColsArr := mustScmerSlice(a[11], "mapColumns")
+			mapFnArr := mustScmerSlice(a[12], "mapFns")
 
 			aggregate := scm.NewNil()
-			if len(a) > 11 {
-				aggregate = a[11]
+			if len(a) > 13 {
+				aggregate = a[13]
 			}
 			neutral := scm.NewNil()
-			if len(a) > 12 {
-				neutral = a[12]
+			if len(a) > 14 {
+				neutral = a[14]
 			}
-			isOuter := len(a) > 13 && scm.ToBool(a[13])
+			isOuter := len(a) > 15 && scm.ToBool(a[15])
 
-			n := len(tables)
 			if len(filterColsArr) != n || len(filterFnArr) != n || len(sortcolsArr) != n || len(mapColsArr) != n || len(mapFnArr) != n {
 				panic("scan_order_multi: all per-table arrays must have the same length")
 			}
@@ -813,6 +844,8 @@ func Init(en scm.Env) {
 					sortcols:      mustScmerSlice(sortcolsArr[i], "sortcols[i]"),
 					callbackCols:  scmerSliceToStrings(mustScmerSlice(mapColsArr[i], "mapColumns[i]")),
 					callback:      mapFnArr[i],
+					perTableOffset: perTableOffsets[i],
+					perTableLimit:  perTableLimits[i],
 				}
 			}
 
@@ -826,9 +859,11 @@ func Init(en scm.Env) {
 				{Kind: "list", ParamName: "filterFns", ParamDesc: "list of filter lambdas, one per table"},
 				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of sort column lists, one per table"},
 				{Kind: "list", ParamName: "sortdirs", ParamDesc: "list of sort direction comparators (shared)"},
+				{Kind: "list", ParamName: "perTableOffset", ParamDesc: "per-table offset (list of int; -1 disables)"},
+				{Kind: "list", ParamName: "perTableLimit", ParamDesc: "per-table limit (list of int; -1 disables)"},
 				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "number of leading sort columns forming partition key"},
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of items to skip"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "max number of items to read"},
+				{Kind: "number", ParamName: "offset", ParamDesc: "number of items to skip (global)"},
+				{Kind: "number", ParamName: "limit", ParamDesc: "max number of items to read (global; -1 = unlimited)"},
 				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of map column lists, one per table"},
 				{Kind: "list", ParamName: "mapFns", ParamDesc: "list of map lambdas, one per table"},
 				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) aggregation function", Optional: true},


### PR DESCRIPTION
## What changed
- cherry-picks `1e276c7531a01f11282874a2da11f6db29bf292c` onto current `master`
- extends `scan_order_multi` with optional `perTableOffset` / `perTableLimit` argument lists
- threads the per-table settings through `storage/storage.go` and `storage/scan_order.go`
- keeps the existing `UNION ALL ... ORDER BY` planner path unchanged by passing `nil` for the new per-table lists in `lib/queryplan.scm`

## Why
- prepares `scan_order_multi` for future per-branch top-k behavior without changing the current UNION ALL planner semantics
- adapts the cherry-pick to the current `master` structure rather than taking the source branch layout blindly

## Validation
- `go build -o memcp`
- `go test ./... -run '^$'`
- `python3 run_sql_tests.py tests/70_union_all.yaml`

## Review notes
- reviewed the source commit before cherry-pick; no blocking correctness issue found for the currently wired call path
- the new per-table semantics are currently dormant at the planner layer because both new arguments are passed as `nil`
