### PR TITLE
planner: prune unused derived scalar payload

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -630,6 +630,19 @@ while still recursing into deeper helper lineage when needed. */
 	)
 ))
 
+/* true iff expr contains a direct tblvar.* wildcard reference.
+Used by derived-table flattening: an empty referenced-column set can mean either
+"outer query needs nothing from this wrapper" (good, prune all inner fields) or
+"outer query asked for tblvar.*" (must retain the full projected column set). */
+(define expr_has_tblvar_wildcard_ref (lambda (tblvar expr)
+	(match expr
+		'((symbol get_column) (eval tblvar) _ col _) (equal? col "*")
+		'((quote get_column) (eval tblvar) _ col _) (equal? col "*")
+		(cons sym args) (reduce args (lambda (found arg) (or found (expr_has_tblvar_wildcard_ref tblvar arg))) false)
+		false
+	)
+))
+
 /* changes (get_column tblvar ti col ci) into its symbol */
 (define replace_columns_from_expr (lambda (expr)
 	(match expr
@@ -3534,7 +3547,14 @@ seeing the correctly prefixed outer alias. */
 						(extract_columns_for_tblvar id (coalesceNil having true))
 						(merge (map (coalesceNil order '()) (lambda (o) (extract_columns_for_tblvar id o))))
 						(merge (map (coalesceNil group '()) (lambda (gexpr) (extract_columns_for_tblvar id gexpr)))))))
-					(define pruned_fields2 (if (equal? flatten_referenced_cols '()) fields2
+					(define flatten_uses_subquery_wildcard (or
+						(expr_has_tblvar_wildcard_ref id fields)
+						(expr_has_tblvar_wildcard_ref id condition)
+						(expr_has_tblvar_wildcard_ref id (coalesceNil having true))
+						(reduce (coalesceNil order '()) (lambda (acc o) (or acc (expr_has_tblvar_wildcard_ref id o))) false)
+						(reduce (coalesceNil group '()) (lambda (acc gexpr) (or acc (expr_has_tblvar_wildcard_ref id gexpr))) false)))
+					(define pruned_fields2 (if flatten_uses_subquery_wildcard
+						fields2
 						(filter_assoc fields2 (lambda (k v) (has? flatten_referenced_cols k)))))
 					(define expr_contains_materialized_helper (lambda (expr) (match expr
 						_ (if (materialized-source? expr)

--- a/tests/66_count_sum_derived_table.yaml
+++ b/tests/66_count_sum_derived_table.yaml
@@ -68,6 +68,24 @@ test_cases:
         - cnt: 3
           total: 60
 
+  - name: "EXPLAIN IR prunes unused scalar payload from COUNT(*) derived table"
+    sql: |
+      EXPLAIN IR
+      SELECT COUNT(*) AS cnt FROM (
+        SELECT m.ID AS ID,
+          COALESCE((SELECT SUM(d.val) FROM csd_detail d WHERE d.parent = m.ID), 0) AS total_val,
+          EXISTS (SELECT 1 FROM csd_detail d2 WHERE d2.parent = m.ID) AS has_detail
+        FROM csd_main m
+      ) t
+    expect:
+      contains:
+        - '"kind": "tables", "value": "((\"t\\u0000m\" \"memcp-tests\" \"csd_main\" false nil))"'
+        - '"kind": "fields", "value": "(\"cnt\" (aggregate 1 + 0))"'
+      not_contains:
+        - 'total_val'
+        - 'has_detail'
+        - 'csd_detail'
+
   - name: "EXPLAIN IR keeps non-window derived aggregates flattened"
     sql: |
       EXPLAIN IR


### PR DESCRIPTION
## What
- distinguish between empty outer references and explicit `t.*` wildcard use when flattening derived tables
- prune unused scalar/EXISTS payload from `COUNT(*) FROM (SELECT ...)` wrappers
- add an `EXPLAIN IR` regression test for the pruned shape

## Why
This is a small architecture-first step from `master`: keep derived-table flattening honest without adding new fallbacks or planner side paths. It removes unnecessary inner scalar work from count-only wrappers while preserving wildcard semantics.

## Validation
- `go build -o memcp`
- `python3 tools/lint_scm.py --check --path lib/queryplan.scm`
- `python3 run_sql_tests.py tests/66_count_sum_derived_table.yaml`
- `python3 run_sql_tests.py tests/66_derived_table_exists_flatten.yaml`
- `make test`