### PR TITLE
[codex] narrow compute invalidation triggers

### DIFF
--- a/storage/compute.go
+++ b/storage/compute.go
@@ -19,6 +19,7 @@ package storage
 import "sync"
 import "time"
 import "strings"
+import "strconv"
 import "runtime/debug"
 import "sync/atomic"
 import "github.com/jtolds/gls"
@@ -657,10 +658,32 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 	}
 }
 
+func stripSourceInfo(expr scm.Scmer) scm.Scmer {
+	return expr
+}
+
+func callHeadIs(head scm.Scmer, names ...string) bool {
+	head = stripSourceInfo(head)
+	for _, name := range names {
+		if head.SymbolEquals(name) {
+			return true
+		}
+	}
+	if d := scm.DeclarationForValue(head); d != nil {
+		for _, name := range names {
+			if d.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // registerORCTriggers installs AfterInsert/AfterUpdate/AfterDelete triggers on the
 // table itself so that any mutation invalidates the ORC column.
 // The triggers are idempotent (skipped if already registered).
 func (t *table) registerORCTriggers(name string) {
+	t.removeORCDependencyTriggers(name)
 	// Find the column to check for partition support
 	var col *column
 	for _, c := range t.Columns {
@@ -670,6 +693,10 @@ func (t *table) registerORCTriggers(name string) {
 		}
 	}
 	hasSortKey := col != nil && len(col.OrcSortCols) > 0
+	relevantCols := []string(nil)
+	if col != nil {
+		relevantCols = mergeUniqueStrings(col.OrcSortCols, col.OrcMapCols)
+	}
 
 	// Build composite sort key expression: (list (get_assoc dict "col1") (get_assoc dict "col2") ...)
 	buildSortKeyExpr := func(dictSym string) scm.Scmer {
@@ -726,6 +753,9 @@ func (t *table) registerORCTriggers(name string) {
 				scm.NewString(name),
 			})
 		}
+		if timing == AfterUpdate {
+			body = wrapUpdateBodyWithRelevantChangeGuard(body, relevantCols)
+		}
 		t.AddTrigger(TriggerDescription{
 			Name:     triggerName,
 			Timing:   timing,
@@ -734,6 +764,10 @@ func (t *table) registerORCTriggers(name string) {
 			Func:     buildFKProc(body),
 		})
 	}
+	if col != nil {
+		refs := append(extractScanJoinInfo(col.OrcMapFn), extractScanJoinInfo(col.OrcReduceFn)...)
+		t.registerORCDependencyTriggers(name, col, refs)
+	}
 }
 
 type tableRef struct{ schema, table string }
@@ -741,6 +775,7 @@ type tableRef struct{ schema, table string }
 // extractScannedTables walks a Scheme expression tree and returns all
 // (schema, table) pairs referenced by scan/scan_order/scalar_scan/scalar_scan_order.
 func extractScannedTables(expr scm.Scmer) []tableRef {
+	expr = stripSourceInfo(expr)
 	if expr.IsProc() {
 		return extractScannedTables(expr.Proc().Body)
 	}
@@ -748,15 +783,12 @@ func extractScannedTables(expr scm.Scmer) []tableRef {
 		return nil
 	}
 	items := expr.Slice()
-	if len(items) >= 3 && items[0].IsSymbol() {
-		sym := items[0].String()
-		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
-			result := []tableRef{{scm.String(items[1]), scm.String(items[2])}}
-			for _, item := range items[3:] {
-				result = append(result, extractScannedTables(item)...)
-			}
-			return result
+	if len(items) >= 3 && callHeadIs(items[0], "scan", "scan_order", "scalar_scan", "scalar_scan_order") {
+		result := []tableRef{{scm.String(items[1]), scm.String(items[2])}}
+		for _, item := range items[3:] {
+			result = append(result, extractScannedTables(item)...)
 		}
+		return result
 	}
 	var result []tableRef
 	for _, item := range items {
@@ -772,6 +804,8 @@ type scanJoinInfo struct {
 	table     string
 	srcCols   []string // source table columns in equality filter
 	inputCols []string // corresponding computor input column names
+	condCols  []string // source table columns read by the scan filter
+	mapCols   []string // source table columns read by the scan mapper
 }
 
 // extractScanJoinInfo walks a computor lambda and returns one scanJoinInfo per
@@ -786,55 +820,55 @@ func extractScanJoinInfo(computor scm.Scmer) []scanJoinInfo {
 }
 
 func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
+	expr = stripSourceInfo(expr)
 	if !expr.IsSlice() {
 		return nil
 	}
 	items := expr.Slice()
-	if len(items) >= 5 && items[0].IsSymbol() {
-		sym := items[0].String()
-		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
-			tableIdx := 2
-			condColsIdx, filterIdx := 3, 4
-			if len(items) <= filterIdx {
-				return nil
-			}
-			var info scanJoinInfo
-			if items[tableIdx].IsCustom(TagTable) {
-				t := TableFromScmer(items[tableIdx])
-				info.schema = t.schema.Name
-				info.table = t.Name
-			} else if items[tableIdx].IsSlice() {
-				// unfolded (table schema name) expression
-				sl := items[tableIdx].Slice()
-				if len(sl) == 3 && scm.String(sl[0]) == "table" {
-					info.schema = scm.String(sl[1])
-					info.table = scm.String(sl[2])
-				}
-			} else if items[tableIdx].IsSymbol() {
-				// pre-resolved tbl:schema:name symbol — extract schema and table from name
-				symStr := scm.String(items[tableIdx])
-				if strings.HasPrefix(symStr, "tbl:") {
-					parts := strings.SplitN(symStr[4:], ":", 2)
-					if len(parts) == 2 {
-						info.schema = parts[0]
-						info.table = parts[1]
-					}
-				}
-			} else {
-				info.schema = ""
-				info.table = scm.String(items[tableIdx])
-			}
-			// condCols = (list "col1" "col2" ...), filter = lambda
-			condCols := extractStringListFromAST(items[condColsIdx])
-			if len(condCols) > 0 {
-				info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols)
-			}
-			result := []scanJoinInfo{info}
-			for _, item := range items[filterIdx+1:] {
-				result = append(result, extractScanJoinInfoBody(item)...)
-			}
-			return result
+	if len(items) >= 5 && callHeadIs(items[0], "scan", "scan_order", "scalar_scan", "scalar_scan_order") {
+		tableIdx := 2
+		condColsIdx, filterIdx := 3, 4
+		if len(items) <= filterIdx {
+			return nil
 		}
+		var info scanJoinInfo
+		tableExpr := stripSourceInfo(items[tableIdx])
+		if tableExpr.IsCustom(TagTable) {
+			t := TableFromScmer(tableExpr)
+			info.schema = t.schema.Name
+			info.table = t.Name
+		} else if tableExpr.IsSlice() {
+			sl := tableExpr.Slice()
+			if len(sl) == 3 && callHeadIs(sl[0], "table") {
+				info.schema = scm.String(sl[1])
+				info.table = scm.String(sl[2])
+			}
+		} else if tableExpr.IsSymbol() {
+			symStr := scm.String(tableExpr)
+			if strings.HasPrefix(symStr, "tbl:") {
+				parts := strings.SplitN(symStr[4:], ":", 2)
+				if len(parts) == 2 {
+					info.schema = parts[0]
+					info.table = parts[1]
+				}
+			}
+		} else {
+			info.schema = ""
+			info.table = scm.String(tableExpr)
+		}
+		condCols := extractStringListFromAST(items[condColsIdx])
+		info.condCols = condCols
+		if len(items) > 5 {
+			info.mapCols = extractStringListFromAST(items[5])
+		}
+		if len(condCols) > 0 {
+			info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols)
+		}
+		result := []scanJoinInfo{info}
+		for _, item := range items[filterIdx+1:] {
+			result = append(result, extractScanJoinInfoBody(item)...)
+		}
+		return result
 	}
 	var result []scanJoinInfo
 	for _, item := range items {
@@ -856,11 +890,12 @@ func extractStringListFromAST(expr scm.Scmer) []string {
 	// Accept first element as either symbol "list" or resolved native function.
 	// Reject if it's a literal value (string/int/float/nil/bool).
 	first := items[0]
-	if first.IsSymbol() {
-		if first.String() != "list" {
-			return nil
-		}
+	first = stripSourceInfo(first)
+	if callHeadIs(first, "list") {
+		// ok
 	} else if first.IsString() || first.IsInt() || first.IsFloat() || first.IsNil() || first.IsBool() {
+		return nil
+	} else {
 		return nil
 	}
 	// first is symbol "list" or resolved function — extract string elements
@@ -878,9 +913,9 @@ func extractStringListFromAST(expr scm.Scmer) []string {
 // (equal? filterParam (outer inputCol)) and returns matched srcCol/inputCol pairs.
 // filterParam is matched by position against condCols.
 func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inputCols []string) {
-	// Unwrap lambda to get params and body
 	var params []scm.Scmer
 	var body scm.Scmer
+	filterExpr = stripSourceInfo(filterExpr)
 	if filterExpr.IsProc() {
 		proc := filterExpr.Proc()
 		if proc.Params.IsSlice() {
@@ -889,8 +924,7 @@ func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inp
 		body = proc.Body
 	} else if filterExpr.IsSlice() {
 		items := filterExpr.Slice()
-		// (lambda (params...) body)
-		if len(items) >= 3 && items[0].IsSymbol() && items[0].String() == "lambda" {
+		if len(items) >= 3 && callHeadIs(items[0], "lambda") {
 			if items[1].IsSlice() {
 				params = items[1].Slice()
 			}
@@ -900,19 +934,15 @@ func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inp
 	if len(params) == 0 || body.IsNil() {
 		return nil, nil
 	}
-
-	// Build param name → index map
 	paramIdx := make(map[string]int, len(params))
 	for i, p := range params {
+		p = stripSourceInfo(p)
 		if p.IsSymbol() {
 			paramIdx[p.String()] = i
 		}
 	}
-
-	// Collect equality comparisons from body
 	equalities := collectEqualities(body)
 	for _, eq := range equalities {
-		// Check pattern: (equal? paramRef (outer inputExpr)) or reversed
 		pIdx, iCol := matchJoinEquality(eq[0], eq[1], paramIdx, len(params), nil)
 		if pIdx < 0 {
 			pIdx, iCol = matchJoinEquality(eq[1], eq[0], paramIdx, len(params), nil)
@@ -928,18 +958,18 @@ func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inp
 // collectEqualities extracts pairs of expressions from (equal? A B) forms,
 // handling (and ...) wrapping.
 func collectEqualities(body scm.Scmer) [][2]scm.Scmer {
+	body = stripSourceInfo(body)
 	if !body.IsSlice() {
 		return nil
 	}
 	items := body.Slice()
-	if len(items) < 1 || !items[0].IsSymbol() {
+	if len(items) < 1 {
 		return nil
 	}
-	sym := items[0].String()
-	if sym == "equal?" && len(items) == 3 {
+	if callHeadIs(items[0], "equal?") && len(items) == 3 {
 		return [][2]scm.Scmer{{items[1], items[2]}}
 	}
-	if sym == "and" {
+	if callHeadIs(items[0], "and") {
 		var result [][2]scm.Scmer
 		for _, item := range items[1:] {
 			result = append(result, collectEqualities(item)...)
@@ -955,6 +985,8 @@ func collectEqualities(body scm.Scmer) [][2]scm.Scmer {
 // NthLocalVar (the optimizer may hoist the outer ref into a closure capture).
 // Returns the param index and input column name, or (-1, "") on mismatch.
 func matchJoinEquality(a, b scm.Scmer, paramIdx map[string]int, paramCount int, computorParams []scm.Scmer) (int, string) {
+	a = stripSourceInfo(a)
+	b = stripSourceInfo(b)
 	var idx int
 	if a.IsSymbol() {
 		var ok bool
@@ -970,34 +1002,27 @@ func matchJoinEquality(a, b scm.Scmer, paramIdx map[string]int, paramCount int, 
 	} else {
 		return -1, ""
 	}
-	// b must be (outer <expr>)
 	if b.IsSlice() {
 		bItems := b.Slice()
-		if len(bItems) == 2 && bItems[0].IsSymbol() && bItems[0].String() == "outer" {
-			inner := bItems[1]
+		if len(bItems) == 2 && callHeadIs(bItems[0], "outer") {
+			inner := stripSourceInfo(bItems[1])
 			if inner.IsSymbol() {
 				return idx, inner.String()
 			}
 			if inner.IsSlice() {
 				gcItems := inner.Slice()
-				if len(gcItems) >= 4 && gcItems[0].IsSymbol() && gcItems[0].String() == "get_column" {
+				if len(gcItems) >= 4 && callHeadIs(gcItems[0], "get_column") {
 					return idx, scm.String(gcItems[3])
 				}
 			}
 		}
 	}
-	// The optimizer may hoist (outer (get_column tblvar _ col _)) into a
-	// NthLocalVar referencing the computor's params. Detect by checking
-	// if b is an NthLocalVar whose index maps to a computor param whose name
-	// encodes the original column reference.
 	if b.IsNthLocalVar() && computorParams != nil {
 		bIdx := int(b.NthLocalVar())
-		// Filter params come first, computor params follow after paramCount
 		cIdx := bIdx - paramCount
 		if cIdx >= 0 && cIdx < len(computorParams) {
-			p := computorParams[cIdx]
+			p := stripSourceInfo(computorParams[cIdx])
 			if p.IsSymbol() {
-				// Computor param name is "tblvar.col" or the stringified expression
 				return idx, p.String()
 			}
 		}
@@ -1008,6 +1033,7 @@ func matchJoinEquality(a, b scm.Scmer, paramIdx map[string]int, paramCount int, 
 // findScanNode walks a computor expression and returns the scan AST node
 // (as a []Scmer slice) for the given source schema+table. Returns nil if not found.
 func findScanNode(expr scm.Scmer, schema, table string) []scm.Scmer {
+	expr = stripSourceInfo(expr)
 	if expr.IsProc() {
 		return findScanNode(expr.Proc().Body, schema, table)
 	}
@@ -1015,10 +1041,9 @@ func findScanNode(expr scm.Scmer, schema, table string) []scm.Scmer {
 		return nil
 	}
 	items := expr.Slice()
-	if len(items) >= 4 && items[0].IsSymbol() {
-		sym := items[0].String()
+	if len(items) >= 4 {
 		tableIdx := 2
-		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
+		if callHeadIs(items[0], "scan", "scan_order", "scalar_scan", "scalar_scan_order") {
 			var tSchema, tName string
 			if len(items) > tableIdx && items[tableIdx].IsCustom(TagTable) {
 				t := TableFromScmer(items[tableIdx])
@@ -1114,6 +1139,7 @@ func isConstantOneAggregate(mapFn scm.Scmer) bool {
 
 // containsScan returns true if the expression contains a scan/scan_order/etc. call.
 func containsScan(expr scm.Scmer) bool {
+	expr = stripSourceInfo(expr)
 	if expr.IsProc() {
 		return containsScan(expr.Proc().Body)
 	}
@@ -1121,11 +1147,8 @@ func containsScan(expr scm.Scmer) bool {
 		return false
 	}
 	items := expr.Slice()
-	if len(items) >= 1 && items[0].IsSymbol() {
-		sym := items[0].String()
-		if sym == "scan" || sym == "scan_order" || sym == "scalar_scan" || sym == "scalar_scan_order" {
-			return true
-		}
+	if len(items) >= 1 && callHeadIs(items[0], "scan", "scan_order", "scalar_scan", "scalar_scan_order") {
+		return true
 	}
 	for _, item := range items {
 		if containsScan(item) {
@@ -1301,6 +1324,67 @@ func buildIncrementScan(targetSchema, targetTable, colName string, srcCols, inpu
 	})
 }
 
+func mergeUniqueStrings(parts ...[]string) []string {
+	if len(parts) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	result := make([]string, 0)
+	for _, part := range parts {
+		for _, item := range part {
+			if item == "" {
+				continue
+			}
+			if _, ok := seen[item]; ok {
+				continue
+			}
+			seen[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func scanRelevantSourceCols(ref scanJoinInfo) []string {
+	return mergeUniqueStrings(ref.condCols, ref.mapCols)
+}
+
+func buildColsChangedExpr(cols []string) scm.Scmer {
+	if len(cols) == 0 {
+		return scm.NewBool(true)
+	}
+	checks := make([]scm.Scmer, len(cols))
+	for i, col := range cols {
+		checks[i] = scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("not"),
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("equal?"),
+				fkGetAssocExpr("OLD", col),
+				fkGetAssocExpr("NEW", col),
+			}),
+		})
+	}
+	if len(checks) == 1 {
+		return checks[0]
+	}
+	parts := make([]scm.Scmer, 1+len(checks))
+	parts[0] = scm.NewSymbol("or")
+	copy(parts[1:], checks)
+	return scm.NewSlice(parts)
+}
+
+func wrapUpdateBodyWithRelevantChangeGuard(body scm.Scmer, cols []string) scm.Scmer {
+	if len(cols) == 0 {
+		return body
+	}
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("if"),
+		buildColsChangedExpr(cols),
+		body,
+		scm.NewBool(true),
+	})
+}
+
 // buildIncrementalBody constructs the trigger body for incremental aggregate
 // updates. For AfterInsert it adds the delta, for AfterUpdate it subtracts
 // OLD and adds NEW. For AfterDelete it falls back to selective invalidation
@@ -1446,6 +1530,63 @@ func buildSelectiveInvalidationBody(targetSchema, targetTable, colName string, s
 	}
 }
 
+func buildInvalidateORCScan(targetSchema, targetTable, colName string, sortCols, srcCols, inputCols []string, dictSym string) scm.Scmer {
+	filterColElems, filterParams, filterBody := buildKeytableScanFilter(targetTable, srcCols, inputCols, dictSym)
+	resultCols := make([]scm.Scmer, 1+len(sortCols))
+	resultCols[0] = scm.NewSymbol("list")
+	mapParams := make([]scm.Scmer, len(sortCols))
+	for i, col := range sortCols {
+		resultCols[1+i] = scm.NewString(col)
+		mapParams[i] = scm.NewSymbol(targetTable + "." + col)
+	}
+	var sortKeyExpr scm.Scmer
+	if len(sortCols) == 1 {
+		sortKeyExpr = mapParams[0]
+	} else {
+		parts := make([]scm.Scmer, 1+len(mapParams))
+		parts[0] = scm.NewSymbol("list")
+		copy(parts[1:], mapParams)
+		sortKeyExpr = scm.NewSlice(parts)
+	}
+	tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)})
+	mapBody := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("begin"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("invalidateorc"), tblExpr, scm.NewString(colName), sortKeyExpr}),
+		scm.NewInt(0),
+	})
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("scan"),
+		scm.NewSymbol("session"),
+		tblExpr,
+		scm.NewSlice(filterColElems),
+		scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(filterParams)}, filterBody)),
+		scm.NewSlice(resultCols),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(mapParams), mapBody}),
+		scm.NewSymbol("+"), scm.NewInt(0), scm.NewNil(), scm.NewBool(false),
+	})
+}
+
+func buildSelectiveORCInvalidationBody(targetSchema, targetTable, colName string, sortCols, srcCols, inputCols []string, timing TriggerTiming) scm.Scmer {
+	switch timing {
+	case AfterInsert:
+		return buildInvalidateORCScan(targetSchema, targetTable, colName, sortCols, srcCols, inputCols, "NEW")
+	case AfterDelete:
+		return buildInvalidateORCScan(targetSchema, targetTable, colName, sortCols, srcCols, inputCols, "OLD")
+	case AfterUpdate:
+		return scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("begin"),
+			buildInvalidateORCScan(targetSchema, targetTable, colName, sortCols, srcCols, inputCols, "OLD"),
+			buildInvalidateORCScan(targetSchema, targetTable, colName, sortCols, srcCols, inputCols, "NEW"),
+		})
+	default:
+		return scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("invalidatecolumn"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(targetTable)}),
+			scm.NewString(colName),
+		})
+	}
+}
+
 // registerComputeTriggers installs AfterInsert/AfterUpdate/AfterDelete triggers
 // on source tables so that changes automatically invalidate the computed column.
 // Also installs AfterDropTable so that dropping a source table cascades to the target.
@@ -1455,7 +1596,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 	// Collect trigger names placed on source tables for self-cleanup
 	type triggerRef struct{ schema, name string }
 	var registeredNames []triggerRef
-	for _, ref := range refs {
+	for refIdx, ref := range refs {
 		srcDB := GetDatabase(ref.schema)
 		if srcDB == nil {
 			continue
@@ -1471,6 +1612,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 
 		// Determine trigger bodies: selective if join pairs are available
 		selective := len(ref.srcCols) > 0 && len(ref.srcCols) == len(ref.inputCols)
+		relevantCols := scanRelevantSourceCols(ref)
 
 		// Check if this scan is an additive aggregate eligible for incremental update.
 		var scanNode []scm.Scmer
@@ -1483,7 +1625,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 		}
 
 		for _, timing := range []TriggerTiming{AfterInsert, AfterUpdate, AfterDelete} {
-			triggerName := ".cache:" + t.Name + ":" + name + "|" + srcTable.Name + "|" + timing.String()
+			triggerName := ".cache:" + t.Name + ":" + name + "|scan" + strconv.Itoa(refIdx) + "|" + srcTable.Name + "|" + timing.String()
 			// idempotency: skip if trigger already exists
 			exists := false
 			for _, tr := range srcTable.Triggers {
@@ -1515,6 +1657,9 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 						tblExpr,
 						scm.NewString(name),
 					})
+				}
+				if timing == AfterUpdate {
+					body = wrapUpdateBodyWithRelevantChangeGuard(body, relevantCols)
 				}
 				srcTable.AddTrigger(TriggerDescription{
 					Name:     triggerName,
@@ -1583,6 +1728,123 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 				Func:     buildFKProc(scm.NewSlice(calls)),
 			})
 		}
+	}
+}
+
+func (t *table) registerORCDependencyTriggers(name string, col *column, refs []scanJoinInfo) {
+	if len(refs) == 0 {
+		return
+	}
+	targetSchema := t.schema.Name
+	type triggerRef struct{ schema, name string }
+	var registeredNames []triggerRef
+	for refIdx, ref := range refs {
+		srcDB := GetDatabase(ref.schema)
+		if srcDB == nil {
+			continue
+		}
+		srcTable := srcDB.GetTable(ref.table)
+		if srcTable == nil {
+			continue
+		}
+		selective := len(ref.srcCols) > 0 && len(ref.srcCols) == len(ref.inputCols)
+		relevantCols := scanRelevantSourceCols(ref)
+		for _, timing := range []TriggerTiming{AfterInsert, AfterUpdate, AfterDelete} {
+			triggerName := ".orcdep:" + t.Name + ":" + name + "|scan" + strconv.Itoa(refIdx) + "|" + srcTable.Name + "|" + timing.String()
+			exists := false
+			for _, tr := range srcTable.Triggers {
+				if tr.Name == triggerName {
+					exists = true
+					break
+				}
+			}
+			if exists {
+				continue
+			}
+			tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
+			body := scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("invalidatecolumn"),
+				tblExpr,
+				scm.NewString(name),
+			})
+			if selective {
+				body = buildSelectiveORCInvalidationBody(targetSchema, t.Name, name, col.OrcSortCols, ref.srcCols, ref.inputCols, timing)
+			}
+			if timing == AfterUpdate {
+				body = wrapUpdateBodyWithRelevantChangeGuard(body, relevantCols)
+			}
+			srcTable.AddTrigger(TriggerDescription{
+				Name:     triggerName,
+				Timing:   timing,
+				IsSystem: true,
+				Priority: 100,
+				Func:     buildFKProc(body),
+			})
+			if srcTable != t {
+				registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
+			}
+		}
+	}
+	if len(registeredNames) == 0 {
+		return
+	}
+	selfCleanupName := ".orcdep_cleanup:" + t.Name + ":" + name
+	exists := false
+	for _, tr := range t.Triggers {
+		if tr.Name == selfCleanupName {
+			exists = true
+			break
+		}
+	}
+	if exists {
+		return
+	}
+	calls := []scm.Scmer{scm.NewSymbol("begin")}
+	for _, rn := range registeredNames {
+		calls = append(calls, scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("droptrigger"),
+			scm.NewString(rn.schema),
+			scm.NewString(rn.name),
+			scm.NewBool(true),
+		}))
+	}
+	t.AddTrigger(TriggerDescription{
+		Name:     selfCleanupName,
+		Timing:   AfterDropTable,
+		IsSystem: true,
+		Priority: 50,
+		Func:     buildFKProc(scm.NewSlice(calls)),
+	})
+}
+
+func (t *table) removeORCDependencyTriggers(name string) {
+	prefix := ".orcdep:" + t.Name + ":" + name + "|"
+	for _, srcTable := range t.schema.tables.GetAll() {
+		changed := false
+		newTriggers := make([]TriggerDescription, 0, len(srcTable.Triggers))
+		for _, tr := range srcTable.Triggers {
+			if strings.HasPrefix(tr.Name, prefix) {
+				changed = true
+				continue
+			}
+			newTriggers = append(newTriggers, tr)
+		}
+		if changed {
+			srcTable.Triggers = newTriggers
+		}
+	}
+	cleanupName := ".orcdep_cleanup:" + t.Name + ":" + name
+	changed := false
+	newTriggers := make([]TriggerDescription, 0, len(t.Triggers))
+	for _, tr := range t.Triggers {
+		if tr.Name == cleanupName {
+			changed = true
+			continue
+		}
+		newTriggers = append(newTriggers, tr)
+	}
+	if changed {
+		t.Triggers = newTriggers
 	}
 }
 

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func serializeScmerForTest(v scm.Scmer) string {
+	var b bytes.Buffer
+	scm.Serialize(&b, v, &scm.Globalenv)
+	return b.String()
+}
+
+func triggerPlanStringForTest(tr TriggerDescription) string {
+	if tr.Func.IsProc() {
+		return serializeScmerForTest(tr.Func.Proc().Body)
+	}
+	return serializeScmerForTest(tr.Func)
+}
+
+func findTriggerByPrefixAndTiming(triggers []TriggerDescription, prefix string, timing TriggerTiming) (TriggerDescription, bool) {
+	for _, tr := range triggers {
+		if strings.HasPrefix(tr.Name, prefix) && tr.Timing == timing {
+			return tr, true
+		}
+	}
+	return TriggerDescription{}, false
+}
+
+func listAst(items ...scm.Scmer) scm.Scmer {
+	result := make([]scm.Scmer, 1+len(items))
+	result[0] = scm.NewSymbol("list")
+	copy(result[1:], items)
+	return scm.NewSlice(result)
+}
+
+func lambdaAst(params []string, body scm.Scmer) scm.Scmer {
+	paramItems := make([]scm.Scmer, len(params))
+	for i, p := range params {
+		paramItems[i] = scm.NewSymbol(p)
+	}
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("lambda"),
+		scm.NewSlice(paramItems),
+		body,
+	})
+}
+
+func nestedScanAst(schema, table, outerParam string) scm.Scmer {
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("scan"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("session"), scm.NewString("__memcp_tx")}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(schema), scm.NewString(table)}),
+		listAst(scm.NewString("ref_id")),
+		lambdaAst([]string{"src.ref_id"}, scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal?"),
+			scm.NewSymbol("src.ref_id"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("outer"), scm.NewSymbol(outerParam)}),
+		})),
+		listAst(scm.NewString("val")),
+		lambdaAst([]string{"val"}, scm.NewSymbol("val")),
+		scm.NewSymbol("+"),
+		scm.NewInt(0),
+	})
+}
+
+func TestComputeTriggersGuardRelevantSourceColumns(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-compute-trigger-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tcomputetrigger")
+
+	CreateDatabase("tcomputetrigger", false)
+	base, _ := CreateTable("tcomputetrigger", "base", Safe, false)
+	src, _ := CreateTable("tcomputetrigger", "src", Safe, false)
+
+	base.CreateColumn("id", "INT", nil, nil)
+	base.CreateColumn("ref_id", "INT", nil, nil)
+	base.CreateColumn("cached", "INT", nil, nil)
+	src.CreateColumn("ref_id", "INT", nil, nil)
+	src.CreateColumn("val", "INT", nil, nil)
+	src.CreateColumn("note", "TEXT", nil, nil)
+
+	computor := lambdaAst([]string{"ref_id"}, nestedScanAst("tcomputetrigger", "src", "ref_id"))
+	refs := extractScanJoinInfo(computor)
+	base.registerComputeTriggers("cached", computor)
+
+	prefix := ".cache:base:cached|scan0|src|"
+	var triggerCount int
+	for _, tr := range src.Triggers {
+		if strings.HasPrefix(tr.Name, prefix) {
+			triggerCount++
+		}
+	}
+	if triggerCount != 3 {
+		t.Fatalf("compute dependency trigger count = %d, want 3 (refs=%#v body=%s)", triggerCount, refs, serializeScmerForTest(computor))
+	}
+
+	tr, ok := findTriggerByPrefixAndTiming(src.Triggers, prefix, AfterUpdate)
+	if !ok {
+		t.Fatal("missing AfterUpdate compute dependency trigger")
+	}
+	plan := triggerPlanStringForTest(tr)
+	for _, want := range []string{`(get_assoc OLD "ref_id")`, `(get_assoc NEW "ref_id")`, `(get_assoc OLD "val")`, `(get_assoc NEW "val")`} {
+		if !strings.Contains(plan, want) {
+			t.Fatalf("compute trigger plan missing %s:\n%s", want, plan)
+		}
+	}
+	if strings.Contains(plan, `"note"`) {
+		t.Fatalf("compute trigger plan should ignore unrelated note column:\n%s", plan)
+	}
+}
+
+func TestORCDependencyTriggersUseRelevantColumnsAndInvalidateSuffix(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-orc-trigger-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("torctrigger")
+
+	CreateDatabase("torctrigger", false)
+	base, _ := CreateTable("torctrigger", "base", Safe, false)
+	src, _ := CreateTable("torctrigger", "src", Safe, false)
+
+	base.CreateColumn("id", "INT", nil, nil)
+	base.CreateColumn("sortk", "INT", nil, nil)
+	base.CreateColumn("ref_id", "INT", nil, nil)
+	base.CreateColumn("running", "INT", nil, nil)
+	src.CreateColumn("ref_id", "INT", nil, nil)
+	src.CreateColumn("val", "INT", nil, nil)
+	src.CreateColumn("note", "TEXT", nil, nil)
+
+	mapFn := lambdaAst([]string{"$set", "ref_id"}, scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("list"),
+		scm.NewSymbol("$set"),
+		nestedScanAst("torctrigger", "src", "ref_id"),
+	}))
+	reduceFn := lambdaAst([]string{"acc", "mapped"}, scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("begin"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("define"),
+			scm.NewSymbol("new_acc"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("+"), scm.NewSymbol("acc"), scm.NewSlice([]scm.Scmer{scm.NewSymbol("cadr"), scm.NewSymbol("mapped")})}),
+		}),
+		scm.NewSlice([]scm.Scmer{scm.NewSlice([]scm.Scmer{scm.NewSymbol("car"), scm.NewSymbol("mapped")}), scm.NewSymbol("new_acc")}),
+		scm.NewSymbol("new_acc"),
+	}))
+	for i, col := range base.Columns {
+		if col.Name == "running" {
+			base.Columns[i].OrcSortCols = []string{"sortk"}
+			base.Columns[i].OrcSortDirs = []bool{false}
+			base.Columns[i].OrcMapCols = []string{"ref_id"}
+			base.Columns[i].OrcMapFn = mapFn
+			base.Columns[i].OrcReduceFn = reduceFn
+			base.Columns[i].OrcReduceInit = scm.NewInt(0)
+			break
+		}
+	}
+	refs := append(extractScanJoinInfo(mapFn), extractScanJoinInfo(reduceFn)...)
+	base.registerORCTriggers("running")
+
+	prefix := ".orcdep:base:running|scan0|src|"
+	var triggerCount int
+	for _, tr := range src.Triggers {
+		if strings.HasPrefix(tr.Name, prefix) {
+			triggerCount++
+		}
+	}
+	if triggerCount != 3 {
+		t.Fatalf("ORC dependency trigger count = %d, want 3 (refs=%#v map=%s)", triggerCount, refs, serializeScmerForTest(mapFn))
+	}
+
+	tr, ok := findTriggerByPrefixAndTiming(src.Triggers, prefix, AfterUpdate)
+	if !ok {
+		t.Fatal("missing AfterUpdate ORC dependency trigger")
+	}
+	plan := triggerPlanStringForTest(tr)
+	for _, want := range []string{`(get_assoc OLD "ref_id")`, `(get_assoc NEW "ref_id")`, `(get_assoc OLD "val")`, `(get_assoc NEW "val")`, `invalidateorc`, `"sortk"`} {
+		if !strings.Contains(plan, want) {
+			t.Fatalf("ORC trigger plan missing %s:\n%s", want, plan)
+		}
+	}
+	if strings.Contains(plan, `"note"`) {
+		t.Fatalf("ORC trigger plan should ignore unrelated note column:\n%s", plan)
+	}
+}

--- a/tests/107_orc_trigger_dependencies.yaml
+++ b/tests/107_orc_trigger_dependencies.yaml
@@ -1,0 +1,168 @@
+metadata:
+  version: "1.0"
+  description: "ORC trigger dependencies: nested scans register precise source triggers"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS orc_dep_base"
+  - sql: "DROP TABLE IF EXISTS orc_dep_src"
+  - sql: "DROP TABLE IF EXISTS orc_dep_fb_base"
+  - sql: "DROP TABLE IF EXISTS orc_dep_fb_src"
+
+
+test_cases:
+  - name: "Create ORC dependency base table"
+    sql: |
+      CREATE TABLE orc_dep_base (
+        id INT PRIMARY KEY,
+        sortk INT,
+        ref_id INT,
+        running INT
+      )
+
+  - name: "Create ORC dependency source table"
+    sql: |
+      CREATE TABLE orc_dep_src (
+        ref_id INT PRIMARY KEY,
+        val INT,
+        note TEXT
+      )
+
+  - name: "Insert ORC dependency base rows"
+    sql: |
+      INSERT INTO orc_dep_base (id, sortk, ref_id) VALUES
+      (1, 10, 1),
+      (2, 20, 2),
+      (3, 30, 1)
+
+  - name: "Insert ORC dependency source rows"
+    sql: |
+      INSERT INTO orc_dep_src (ref_id, val, note) VALUES
+      (1, 100, 'match-a'),
+      (2, 200, 'match-b'),
+      (99, 999, 'other')
+
+  - name: "Create ORC column with nested source scan"
+    scm: |
+      (createcolumn (table "memcp-tests" "orc_dep_base") "running" "INT" '()
+        (list
+          "sortcols"  '("sortk")
+          "sortdirs"  (list false)
+          "partitioncount" 0
+          "mapcols"   '("ref_id")
+          "mapfn"     (lambda ($set ref_id)
+                        (list $set
+                          (scan (session "__memcp_tx") (table "memcp-tests" "orc_dep_src")
+                            '("ref_id")
+                            (lambda (src.ref_id) (equal? src.ref_id (outer ref_id)))
+                            '("val")
+                            (lambda (val) val)
+                            + 0)))
+          "reducefn"  (lambda (acc mapped)
+                        (begin
+                          (define new_acc (+ acc (cadr mapped)))
+                          ((car mapped) new_acc)
+                          new_acc))
+          "reduceinit" 0))
+
+  - name: "Initial nested-scan ORC result"
+    sql: "SELECT id, running FROM orc_dep_base ORDER BY sortk"
+    expect:
+      rows: 3
+      data:
+        - {id: 1, running: 100}
+        - {id: 2, running: 300}
+        - {id: 3, running: 400}
+
+  - name: "Source table gets three system triggers for analyzable nested ORC dependency"
+    scm: |
+      (begin
+        (define info (show "memcp-tests" "orc_dep_src" true))
+        (count (filter (get_assoc info "triggers") (lambda (tr) (get_assoc tr "system")))))
+    expect:
+      data: [3]
+
+  - name: "Irrelevant source-column update"
+    sql: "UPDATE orc_dep_src SET note = 'changed-only-note' WHERE ref_id = 1"
+
+  - name: "Irrelevant source-column update keeps ORC value"
+    sql: "SELECT running FROM orc_dep_base WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - {running: 100}
+
+  - name: "Unrelated-key source update"
+    sql: "UPDATE orc_dep_src SET val = 1001 WHERE ref_id = 99"
+
+  - name: "Unrelated-key source update keeps ORC value"
+    sql: "SELECT running FROM orc_dep_base WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - {running: 100}
+
+  - name: "Create fallback ORC base table"
+    sql: |
+      CREATE TABLE orc_dep_fb_base (
+        id INT PRIMARY KEY,
+        sortk INT,
+        ref_id INT,
+        running INT
+      )
+
+  - name: "Create fallback ORC source table"
+    sql: |
+      CREATE TABLE orc_dep_fb_src (
+        ref_id INT PRIMARY KEY,
+        val INT
+      )
+
+  - name: "Insert fallback ORC base rows"
+    sql: |
+      INSERT INTO orc_dep_fb_base (id, sortk, ref_id) VALUES
+      (1, 10, 1),
+      (2, 20, 2)
+
+  - name: "Insert fallback ORC source rows"
+    sql: |
+      INSERT INTO orc_dep_fb_src (ref_id, val) VALUES
+      (1, 11),
+      (2, 22)
+
+  - name: "Create ORC column with non-analyzable nested scan filter"
+    scm: |
+      (createcolumn (table "memcp-tests" "orc_dep_fb_base") "running" "INT" '()
+        (list
+          "sortcols"  '("sortk")
+          "sortdirs"  (list false)
+          "partitioncount" 0
+          "mapcols"   '("ref_id")
+          "mapfn"     (lambda ($set ref_id)
+                        (list $set
+                          (scan (session "__memcp_tx") (table "memcp-tests" "orc_dep_fb_src")
+                            '("ref_id")
+                            (lambda (src.ref_id) (equal? (+ src.ref_id 0) (outer ref_id)))
+                            '("val")
+                            (lambda (val) val)
+                            + 0)))
+          "reducefn"  (lambda (acc mapped)
+                        (begin
+                          (define new_acc (+ acc (cadr mapped)))
+                          ((car mapped) new_acc)
+                          new_acc))
+          "reduceinit" 0))
+
+  - name: "Fallback source table still gets three system triggers"
+    scm: |
+      (begin
+        (define info (show "memcp-tests" "orc_dep_fb_src" true))
+        (count (filter (get_assoc info "triggers") (lambda (tr) (get_assoc tr "system")))))
+    expect:
+      data: [3]
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS orc_dep_base"
+  - sql: "DROP TABLE IF EXISTS orc_dep_src"
+  - sql: "DROP TABLE IF EXISTS orc_dep_fb_base"
+  - sql: "DROP TABLE IF EXISTS orc_dep_fb_src"


### PR DESCRIPTION
## What changed
- narrow compute-column invalidation triggers to the source columns that are actually read by a nested scan
- add ORC-specific dependency triggers that invalidate by sort-key suffix when the nested scan join can be analyzed
- keep the conservative fallback for non-analyzable nested scan filters and cover both paths with tests

## Why
Nested computor / ORC lambdas that scan another table were deploying coarse invalidation triggers. That widened the blast radius on updates and did not carry ORC-specific invalidation metadata into the source-table triggers.

## Validation
- `go build -o memcp`
- `go test ./storage -run 'TestComputeTriggersGuardRelevantSourceColumns|TestORCDependencyTriggersUseRelevantColumnsAndInvalidateSuffix' -v`
- `python3 run_sql_tests.py tests/107_orc_trigger_dependencies.yaml 54424 --connect-only` against a manually started `./memcp --no-repl` instance

## Notes
- I also tried the hook-equivalent `make test`, but in this local environment the runner still aborts early with `MemCP did not become SQL-ready` even though the server is already listening. This is the same local startup-handshake issue seen in earlier runs, not a suite failure after SQL execution starts.
