### PR TITLE
[codex] Revert fail-fast root-account invariant

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -115,22 +115,6 @@ if the user is not allowed to access this property, the function will throw an e
 		true)
 )) (lambda (e) true))
 
-/* Startup invariant: root is only bootstrapped when the user table itself is
-missing. If system.user exists but no root row is present, treat that as
-persistent corruption instead of silently recreating credentials. */
-(if (has? (show "system") "user") (begin
-	(define _root_count (scan nil (table "system" "user")
-		'("username")
-		(lambda (username) (equal? username "root"))
-		'()
-		(lambda () 1)
-		+
-		0))
-	(if (> _root_count 0)
-		true
-		(error "startup corruption: system.user exists but root account is missing; refusing automatic bootstrap")))
-	true)
-
 /* ensure unique username constraint to avoid duplicates */
 (try (lambda () (begin
 	(if (has? (show "system") "user")


### PR DESCRIPTION
## What changed
This reverts commit `dd7d1fa7d` (`Fail fast on missing root account`).

It removes the startup invariant that required an existing `system.user` table to still contain a user named `root`.

## Why
That invariant was too strict.

Existing setups may intentionally operate without a `root` user after initial bootstrap. Hard-failing startup just because `system.user` exists without a `root` row is therefore not a valid correctness check.

The original bootstrap behavior remains unchanged:
- if `system.user` does not exist yet, startup may still create the initial `root` account
- if `system.user` already exists, startup must not enforce the presence of `root`

## Validation
Ran locally:
- `python3 tools/lint_scm.py --path lib/sql.scm --check`