### PR TITLE
[codex] Refactor scalar subselect 3-way dispatch

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2523,7 +2523,7 @@ seeing the correctly prefixed outer alias. */
 		replace_find_column_subselect
 	)))
 
-	(define build_scalar_subselect (lambda (subquery outer_schemas) (begin
+	(define build_scalar_subselect_with_strategy (lambda (subquery outer_schemas) (begin
 		(define union_parts (query_union_all_parts subquery))
 		(if (not (nil? union_parts))
 			(error "scalar subselect UNION ALL is not supported yet")
@@ -2840,13 +2840,15 @@ seeing the correctly prefixed outer alias. */
 								(build_scalar_agg_scan tables2 condition2)
 								(cons (quote !begin) (merge init_stmts_agg (list (build_scalar_agg_scan tables2 condition2)))))
 						)))
-						(define scalar_subselect_lowering_strategy (lambda ()
+						(define scalar_subselect_inline_strategy (lambda ()
 							(if (scalar_direct_agg_scan_applicable)
 								(quote direct-agg-scan)
 								(quote legacy-fallback))))
-						(if (equal? (scalar_subselect_lowering_strategy) (quote direct-agg-scan))
-							(build_scalar_subselect_via_direct_agg_scan)
-							(build_scalar_subselect_via_legacy_fallback))
+						(define scalar_strategy (scalar_subselect_inline_strategy))
+						(list scalar_strategy
+							(if (equal? scalar_strategy (quote direct-agg-scan))
+								(build_scalar_subselect_via_direct_agg_scan)
+								(build_scalar_subselect_via_legacy_fallback)))
 					)
 				)
 			)
@@ -2854,6 +2856,11 @@ seeing the correctly prefixed outer alias. */
 	)
 	)
 	)
+	(define build_scalar_subselect (lambda (subquery outer_schemas) (begin
+		(match (build_scalar_subselect_with_strategy subquery outer_schemas)
+			'(_ lowered_expr) lowered_expr
+			nil)
+	)))
 	(define build_exists_subselect (lambda (subquery outer_schemas) (match subquery
 		'(schema2 tables2 fields2 condition2 group2 having2 order2 limit2 offset2)
 		(list (quote coalesceNil)
@@ -3426,7 +3433,7 @@ seeing the correctly prefixed outer alias. */
 		(reduce (_subquery_outer_refs query outer_schemas) (lambda (all_ok ref)
 			(and all_ok (_outer_ref_is_direct_column outer_schemas ref)))
 			true)))
-	(define _try_unnest_scalar_subselect (lambda (subquery outer_schemas) (match subquery
+	(define scalar_subselect_unnest_applicable (lambda (subquery outer_schemas) (match subquery
 		'(_ _ flds _ g h o l off) (begin
 			(define _value_expr (match flds
 				(cons _ (cons v _)) v
@@ -3448,17 +3455,29 @@ seeing the correctly prefixed outer alias. */
 				(nil? h)
 				(or (nil? g) (equal? g '()))
 				true)
-				(match (unnest_subselect subquery outer_schemas)
-					'(subst tbls) (begin
-						/* Scalar subselect unnesting yields null-preserving LEFT JOIN helper
-						tables for SELECT/expr projection. Keep them separate from COUNT/IN/EXISTS
-						helper tables so their joinexpr stays attached to the table entry and is
-						not re-applied globally as a filter later. */
-						(sq_cache "scalar_tables" (merge tbls (coalesceNil (sq_cache "scalar_tables") '())))
-						subst)
-					nil)
-				nil))
+				true
+				false))
 		nil)))
+	(define _unnest_scalar_subselect (lambda (subquery outer_schemas) (begin
+		(match (unnest_subselect subquery outer_schemas)
+			'(subst tbls) (begin
+				/* Scalar subselect unnesting yields null-preserving LEFT JOIN helper
+				tables for SELECT/expr projection. Keep them separate from COUNT/IN/EXISTS
+				helper tables so their joinexpr stays attached to the table entry and is
+				not re-applied globally as a filter later. */
+				(sq_cache "scalar_tables" (merge tbls (coalesceNil (sq_cache "scalar_tables") '())))
+				subst)
+			nil)
+	)))
+	(define lower_scalar_subselect (lambda (subquery outer_schemas) (begin
+		(if (scalar_subselect_unnest_applicable subquery outer_schemas)
+			(begin
+				(define lowered_expr (_unnest_scalar_subselect subquery outer_schemas))
+				(if (nil? lowered_expr)
+					(build_scalar_subselect_with_strategy subquery outer_schemas)
+					(list (quote unnest) lowered_expr)))
+			(build_scalar_subselect_with_strategy subquery outer_schemas))
+	)))
 	(define _unnest_count_subselect (lambda (subquery outer_schemas target_expr comparison) (begin
 		(define _resolve_outer (lambda (expr) (match expr
 			'((symbol get_column) nil ti col ci) (begin
@@ -3671,9 +3690,9 @@ seeing the correctly prefixed outer alias. */
 			(if (nil? not_expr)
 				(match kind
 					(quote inner_select) (match args
-						(cons subquery '()) (coalesce
-							(_try_unnest_scalar_subselect subquery outer_schemas)
-							(build_scalar_subselect subquery outer_schemas))
+						(cons subquery '()) (match (lower_scalar_subselect subquery outer_schemas)
+							'(_ lowered_expr) lowered_expr
+							nil)
 						_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))
 					(quote inner_select_in) (match args
 						(cons target_expr (cons subquery '()))


### PR DESCRIPTION
## What changed
This refactor makes scalar subselect lowering dispatch explicit at the inner-select call site.

The patch introduces:
- `build_scalar_subselect_with_strategy`, which returns both the chosen inline strategy and the lowered expression
- `scalar_subselect_unnest_applicable`, which isolates the current structural gate for scalar unnesting
- `lower_scalar_subselect`, which now dispatches explicitly between `unnest`, `direct-agg-scan`, and `legacy-fallback`

`build_scalar_subselect` remains as the existing expression-only wrapper for callers that just need the lowered AST.

## Why
After the previous refactor, direct aggregate scans and the legacy fallback were separated, but scalar unnesting still lived as a side path outside that strategy split.

That meant the planner still had two disconnected decision points for scalar lowering:
- one in `replace_inner_selects` for "try unnest first"
- one in `build_scalar_subselect` for "direct aggregate scan vs fallback"

This change makes the full 3-way dispatch visible and local, which is the next step toward reducing fallback scope safely.

## Impact
There is no intended behavior change.

The planner is easier to audit because every scalar `inner_select` now goes through one explicit strategy choice:
- `unnest`
- `direct-agg-scan`
- `legacy-fallback`

That is the precondition for later work that shrinks fallback usage and moves more scalar shapes toward the FAQ target architecture.

## Root cause
Scalar subselect lowering still mixed architectural policy across two separate control-flow regions, so the real lowering model was harder to see than the code suggested.

## Validation
- `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- `go build -o memcp`
- `python3 run_sql_tests.py tests/69_subquery_complex.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/96_scalar_subselect_patterns.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/102_nested_correlated_subquery.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/66_prejoin_scalar_subselect.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/66_derived_table_limit_scalar.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/66_left_join_correlated_on.yaml 4321 --connect-only`
- `python3 run_sql_tests.py tests/66_count_sum_derived_table.yaml 4321 --connect-only`