### PR TITLE
[codex] Centralize scalar subselect strategy entrypoint

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2523,7 +2523,7 @@ seeing the correctly prefixed outer alias. */
 		replace_find_column_subselect
 	)))
 
-	(define build_scalar_subselect_with_strategy (lambda (subquery outer_schemas) (begin
+	(define build_scalar_subselect_inline_with_strategy (lambda (subquery outer_schemas) (begin
 		(define union_parts (query_union_all_parts subquery))
 		(if (not (nil? union_parts))
 			(error "scalar subselect UNION ALL is not supported yet")
@@ -2856,15 +2856,15 @@ seeing the correctly prefixed outer alias. */
 	)
 	)
 	)
-	(define build_scalar_subselect (lambda (subquery outer_schemas) (begin
-		(match (build_scalar_subselect_with_strategy subquery outer_schemas)
+	(define build_scalar_subselect_inline (lambda (subquery outer_schemas) (begin
+		(match (build_scalar_subselect_inline_with_strategy subquery outer_schemas)
 			'(_ lowered_expr) lowered_expr
 			nil)
 	)))
 	(define build_exists_subselect (lambda (subquery outer_schemas) (match subquery
 		'(schema2 tables2 fields2 condition2 group2 having2 order2 limit2 offset2)
 		(list (quote coalesceNil)
-			(build_scalar_subselect
+			(build_scalar_subselect_inline
 				(list schema2 tables2
 					(list "__exists" true)
 					condition2 group2 having2 order2 (coalesceNil limit2 1) offset2)
@@ -3469,14 +3469,19 @@ seeing the correctly prefixed outer alias. */
 				subst)
 			nil)
 	)))
-	(define lower_scalar_subselect (lambda (subquery outer_schemas) (begin
+	(define build_scalar_subselect_with_strategy (lambda (subquery outer_schemas) (begin
 		(if (scalar_subselect_unnest_applicable subquery outer_schemas)
 			(begin
 				(define lowered_expr (_unnest_scalar_subselect subquery outer_schemas))
 				(if (nil? lowered_expr)
-					(build_scalar_subselect_with_strategy subquery outer_schemas)
+					(build_scalar_subselect_inline_with_strategy subquery outer_schemas)
 					(list (quote unnest) lowered_expr)))
-			(build_scalar_subselect_with_strategy subquery outer_schemas))
+			(build_scalar_subselect_inline_with_strategy subquery outer_schemas))
+	)))
+	(define build_scalar_subselect (lambda (subquery outer_schemas) (begin
+		(match (build_scalar_subselect_with_strategy subquery outer_schemas)
+			'(_ lowered_expr) lowered_expr
+			nil)
 	)))
 	(define _unnest_count_subselect (lambda (subquery outer_schemas target_expr comparison) (begin
 		(define _resolve_outer (lambda (expr) (match expr
@@ -3690,7 +3695,7 @@ seeing the correctly prefixed outer alias. */
 			(if (nil? not_expr)
 				(match kind
 					(quote inner_select) (match args
-						(cons subquery '()) (match (lower_scalar_subselect subquery outer_schemas)
+						(cons subquery '()) (match (build_scalar_subselect_with_strategy subquery outer_schemas)
 							'(_ lowered_expr) lowered_expr
 							nil)
 						_ (cons sym (map args (lambda (arg) (replace_inner_selects arg outer_schemas)))))


### PR DESCRIPTION
## What changed
This refactor makes the scalar-subselect strategy entrypoint explicit and singular.

The patch:
- renames the old inline-only helper to `build_scalar_subselect_inline_with_strategy`
- introduces `build_scalar_subselect_with_strategy` as the single full strategy dispatcher
- keeps `build_scalar_subselect_inline` for callers like `build_exists_subselect` that must stay on the inline scalar path
- updates the `inner_select` call site to use the centralized strategy dispatcher directly

## Why
The previous refactor exposed the 3-way scalar dispatch (`unnest`, `direct-agg-scan`, `legacy-fallback`), but the strategy model was still split across two layers:
- one helper that only knew inline strategies
- a second wrapper that added unnesting on top

That still left the architecture harder to read than it should be. This patch makes one function the authoritative entrypoint for scalar lowering, while preserving the separate inline-only path needed by `EXISTS` helpers.

## Impact
There is no intended behavior change.

The practical gain is that the Neumann-relevant decision now has a single home: when a scalar `inner_select` is lowered, the planner reaches one dispatcher that can choose JOIN-style unnesting first and only then fall back to inline execution strategies.

## Root cause
Scalar strategy selection was visible, but not yet centralized: the code still distinguished between “full strategy dispatch” and “inline strategy dispatch” only implicitly through wrapper layering.

## Validation
- `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- `go build -o memcp`
- `python3 run_sql_tests.py tests/69_subquery_complex.yaml`
- `python3 run_sql_tests.py tests/96_scalar_subselect_patterns.yaml`
- `python3 run_sql_tests.py tests/102_nested_correlated_subquery.yaml`
- `python3 run_sql_tests.py tests/66_prejoin_scalar_subselect.yaml`
- `python3 run_sql_tests.py tests/66_derived_table_limit_scalar.yaml`
- `python3 run_sql_tests.py tests/66_left_join_correlated_on.yaml`
- `python3 run_sql_tests.py tests/66_count_sum_derived_table.yaml`