### PR TITLE
planner: keep COUNT rewrite for projection-only EXISTS session state

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3121,8 +3121,8 @@ seeing the correctly prefixed outer alias. */
 														(stage_with_cache_query
 															(stage_with_cache_policy
 																(make_group_stage us_new_group us_new_having us_new_order us_orig_limit_a us_orig_offset_a us_stage_aliases nil)
-																(count_subquery_cache_policy subquery))
-															(if (nil? (count_subquery_cache_policy subquery)) nil subquery)))
+																(count_subquery_cache_policy subquery target_expr))
+															(if (nil? (count_subquery_cache_policy subquery target_expr)) nil subquery)))
 													/* propagate inner scoped stages with prefix */
 													(define _us_prefixed_inner_stages (map _us_inner_stages (lambda (s) (begin
 														(define _psg (map (coalesceNil (stage_group_cols s) '()) _us_prefix_ria))
@@ -3337,14 +3337,24 @@ seeing the correctly prefixed outer alias. */
 			(_contains_inner_select_marker sym)
 			(reduce args (lambda (found arg) (or found (_contains_inner_select_marker arg))) false))
 		false)))
-	(define count_subquery_cache_policy (lambda (query)
+	(define exists_subquery_uses_session_state_for_row_existence (lambda (query)
+		(match query
+			'(schema2 tables2 _fields2 condition2 group2 having2 _order2 limit2 offset2)
+			(expr_uses_session_state
+				(list schema2 tables2 '() condition2 group2 having2 nil limit2 offset2))
+			(expr_uses_session_state query))))
+	(define count_subquery_cache_policy (lambda (query target_expr)
 		(match query
 			'(s t f c g h o l off) (begin
 				(define only_count (match f
 					'("__cnt" ((quote aggregate) 1 op 0)) (equal?? op (quote +))
 					'("__cnt" ((symbol aggregate) 1 op 0)) (equal?? op (quote +))
 					false))
-				(if (and only_count (equal? g '(1)) (expr_uses_session_state query))
+				(define session_sensitive_count
+					(if (nil? target_expr)
+						(exists_subquery_uses_session_state_for_row_existence query)
+						(expr_uses_session_state query)))
+				(if (and only_count (equal? g '(1)) session_sensitive_count)
 					(quote uncached-count)
 					nil))
 			nil)))
@@ -3658,7 +3668,7 @@ seeing the correctly prefixed outer alias. */
 										(cons subquery '())
 										(coalesce
 											(union_exists_expr subquery true)
-											(if (expr_uses_session_state subquery)
+											(if (exists_subquery_uses_session_state_for_row_existence subquery)
 												(list (quote not) (build_exists_subselect subquery outer_schemas))
 												(coalesce
 													(_unnest_count_subselect subquery outer_schemas nil (quote equal?))
@@ -3686,7 +3696,7 @@ seeing the correctly prefixed outer alias. */
 						(cons subquery '())
 						(coalesce
 							(union_exists_expr subquery false)
-							(if (expr_uses_session_state subquery)
+							(if (exists_subquery_uses_session_state_for_row_existence subquery)
 								(build_exists_subselect subquery outer_schemas)
 								(coalesce
 									(_unnest_count_subselect subquery outer_schemas nil (quote >))

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -117,6 +117,34 @@ test_cases:
         - ID: 3
           name: "Charlie"
 
+  - name: "EXISTS ignores session state in projection for row existence"
+    sql: |
+      SELECT ID, name FROM exists_customers
+      WHERE EXISTS (SELECT LAST_INSERT_ID() FROM exists_orders WHERE total > 50)
+      ORDER BY ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          name: "Alice"
+        - ID: 2
+          name: "Bob"
+        - ID: 3
+          name: "Charlie"
+
+  - name: "EXPLAIN EXISTS ignores session state in projection and keeps count cache rewrite"
+    sql: |
+      EXPLAIN SELECT ID, name FROM exists_customers
+      WHERE EXISTS (SELECT LAST_INSERT_ID() FROM exists_orders WHERE total > 50)
+      ORDER BY ID
+    expect:
+      rows: 1
+      contains:
+        - "createcolumn"
+        - "touch_keytable"
+        - ".exists_orders:(1)"
+        - "\"__cnt\""
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"


### PR DESCRIPTION
## Summary
- keep the COUNT/keytable EXISTS rewrite when session state appears only in the subquery projection
- restrict the EXISTS session-state fallback to row-existence-affecting parts of the subquery
- add regression coverage for projection-only session state plus EXPLAIN rewrite output

## Testing
- python3 run_sql_tests.py tests/40_exists_subquery.yaml
- make test