### PR TITLE
[codex] Preserve grouped derived-table correlation boundaries

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -221,11 +221,15 @@ keytables/prejoins may not exist at compile time (runtime-only creation). */
 		nil
 	)
 ))
-(define register_materialized_subquery_metadata (lambda (mat_source fields_assoc)
+(define register_materialized_subquery_metadata (lambda (mat_source fields_assoc preserve_visible_boundary)
 	(begin
-		(define schema_def (extract_assoc fields_assoc (lambda (k v)
+		(define planned_schema_def (extract_assoc fields_assoc (lambda (k v)
 			(list "Field" k "Type" "any" "Expr" v))))
-		(planned_materialized_fields mat_source schema_def)
+		(define visible_schema_def (if preserve_visible_boundary
+			(extract_assoc fields_assoc (lambda (k v)
+				(list "Field" k "Type" "any")))
+			planned_schema_def))
+		(planned_materialized_fields mat_source planned_schema_def)
 		(prejoin_canonical_sources mat_source
 			(merge (extract_assoc fields_assoc (lambda (k v)
 				(list
@@ -234,7 +238,7 @@ keytables/prejoins may not exist at compile time (runtime-only creation). */
 		(materialized_source_expr_lookup mat_source
 			(merge (extract_assoc fields_assoc (lambda (k v)
 				(map (materialized_source_expr_keys v) (lambda (key) (list key k)))))))
-		schema_def
+		visible_schema_def
 	)
 ))
 /* Some rewrite paths carry alias provenance as (visible_alias canonical_source).
@@ -3980,6 +3984,7 @@ seeing the correctly prefixed outer alias. */
 						(reduce_assoc pruned_fields2 (lambda (acc _k v)
 							(or acc (expr_contains_materialized_helper v)))
 							false))
+					(define groups2_present (and (not (nil? groups2)) (not (equal? groups2 '()))))
 					(define aggregate_refs_subquery_alias (lambda (expr)
 						(reduce (extract_aggregates expr) (lambda (acc ag)
 							(or acc (match ag
@@ -3987,21 +3992,35 @@ seeing the correctly prefixed outer alias. */
 								(reduce (extract_tblvars agg_expr) (lambda (found tv) (or found (equal?? tv id))) false)
 								false)))
 							false)))
+					(define correlated_inner_select_refs_subquery_alias (lambda (expr)
+						(and
+							(_contains_inner_select_marker expr)
+							(reduce (extract_tblvars expr) (lambda (found tv)
+								(or found (equal?? tv id)))
+								false))))
+					(define grouped_or_helper_boundary
+						(or groups2_present flatten_has_helper_backed_projection))
 					(define outer_uses_subquery_group_boundary (or
-						(reduce_assoc fields (lambda (acc _k v) (or acc (aggregate_refs_subquery_alias v))) false)
+						(reduce_assoc fields (lambda (acc _k v) (or acc
+							(aggregate_refs_subquery_alias v)
+							(and grouped_or_helper_boundary (correlated_inner_select_refs_subquery_alias v)))) false)
+						(and grouped_or_helper_boundary (correlated_inner_select_refs_subquery_alias (coalesceNil condition true)))
 						(reduce (coalesceNil group '()) (lambda (acc gexpr)
 							(or acc (reduce (extract_tblvars gexpr) (lambda (found tv) (or found (equal?? tv id))) false)))
 							false)
 						(reduce (coalesceNil order '()) (lambda (acc o) (or acc (match o
-							'(col _dir) (aggregate_refs_subquery_alias col)
+							'(col _dir) (or
+								(aggregate_refs_subquery_alias col)
+								(and grouped_or_helper_boundary (correlated_inner_select_refs_subquery_alias col)))
 							false)))
 							false)
-						(aggregate_refs_subquery_alias (coalesceNil having true))))
+						(or
+							(aggregate_refs_subquery_alias (coalesceNil having true))
+							(and grouped_or_helper_boundary (correlated_inner_select_refs_subquery_alias (coalesceNil having true))))))
 					/* window functions in subquery require materialization (cannot flatten because window needs its own ordering) */
 					(define subquery_has_window (not (equal? (merge (extract_assoc fields2 (lambda (k v) (extract_window_funcs v)))) '())))
 					/* TODO: group+order+limit+offset -> ordered scan list with aggregation layers (to avoid materialization) */
 					/* Note: flat defines avoid nested begin scopes — (set) only updates the innermost Nodefine=false env */
-					(define groups2_present (and (not (nil? groups2)) (not (equal? groups2 '()))))
 					(define flatten_groups2 (if groups2_present
 						(filter groups2 (lambda (stage)
 							(or
@@ -4085,7 +4104,8 @@ seeing the correctly prefixed outer alias. */
 							(define mat_init (nth materialized_binding 1))
 							(sq_cache "init" (merge (coalesceNil (sq_cache "init") '())
 								(list mat_init)))
-							(define mat_schema_def (register_materialized_subquery_metadata mat_source fields2))
+							(define mat_schema_def
+								(register_materialized_subquery_metadata mat_source fields2 outer_uses_subquery_group_boundary))
 							(list
 								(list (list id schemax mat_source isOuter joinexpr))
 								'()
@@ -6585,20 +6605,20 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 					(map prejoin_source_tables (lambda (t) (match t '(_ tschema ttbl _ _) (concat tschema "." ttbl)))
 					) ":" prejoin_col_names "|" prejoin_condition_name))
 				/* capture outer schema and table name for trigger code generation */
-					(define prejoin_schema schema)
-					(define pj_schema schema) /* needed in quoted runtime code below */
-					(define prejoin_table_name prejointbl)
-					(define temp_source_table? materialized-source?)
-					(register_prejoin_materialized_metadata
-						canonicalize_prejoin_source_expr
-						prejointbl
-						prejoin_columns
-						prejoin_alias_map
-						prejoin_source_tables
-						prejoin_schema_def)
-					/* prejoin table creation deferred to runtime (guard at plan assembly below) */
-					(define covered_partition_stages (filter partition_stages (lambda (ps)
-						(reduce (coalesceNil (stage_partition_aliases ps) '()) (lambda (acc a)
+				(define prejoin_schema schema)
+				(define pj_schema schema) /* needed in quoted runtime code below */
+				(define prejoin_table_name prejointbl)
+				(define temp_source_table? materialized-source?)
+				(register_prejoin_materialized_metadata
+					canonicalize_prejoin_source_expr
+					prejointbl
+					prejoin_columns
+					prejoin_alias_map
+					prejoin_source_tables
+					prejoin_schema_def)
+				/* prejoin table creation deferred to runtime (guard at plan assembly below) */
+				(define covered_partition_stages (filter partition_stages (lambda (ps)
+					(reduce (coalesceNil (stage_partition_aliases ps) '()) (lambda (acc a)
 						(or acc (has? known_table_aliases a))) false))))
 				(define prejoin_materialize_plan
 					(build_legacy_prejoin_materialize_plan

--- a/tests/66_correlated_group_domain.yaml
+++ b/tests/66_correlated_group_domain.yaml
@@ -1,0 +1,93 @@
+# Correlated scalar subqueries over grouped derived tables with an outer grouped
+# domain. This exercises Neumann-style domain extension across multiple group
+# stages without relying on app-specific table names.
+
+metadata:
+  version: "1.0"
+  description: "Correlated scalar subquery across nested group domains"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS cgd_state"
+  - sql: "CREATE TABLE cgd_state (ID INT PRIMARY KEY, parent INT, grp INT)"
+  - sql: "INSERT INTO cgd_state VALUES (1, NULL, 10), (2, 1, 10), (3, NULL, 20), (4, 1, 20), (5, 3, 20)"
+
+test_cases:
+
+  - name: "scalar subquery over grouped inner derived table"
+    sql: |
+      SELECT t.grp, COUNT(*) AS cnt, SUM(t.child_groups) AS child_groups
+      FROM (
+        SELECT s1.ID, s1.grp,
+          COALESCE((SELECT COUNT(*)
+            FROM (
+              SELECT s2.parent, s2.grp, COUNT(*) AS cnt
+              FROM cgd_state s2
+              GROUP BY s2.parent, s2.grp
+            ) g
+            WHERE g.parent = s1.ID AND g.grp = s1.grp
+          ), 0) AS child_groups
+        FROM cgd_state s1
+      ) t
+      GROUP BY t.grp
+      ORDER BY t.grp
+    expect:
+      rows: 2
+      data:
+        - grp: 10
+          cnt: 2
+          child_groups: 1
+        - grp: 20
+          cnt: 3
+          child_groups: 1
+
+  - name: "outer grouped domain feeds correlated grouped scalar subquery"
+    sql: |
+      SELECT o.grp,
+        COALESCE((SELECT SUM(i.cnt)
+          FROM (
+            SELECT s2.parent, s2.grp, COUNT(*) AS cnt
+            FROM cgd_state s2
+            GROUP BY s2.parent, s2.grp
+          ) i
+          WHERE i.parent = o.sample_id AND i.grp = o.grp
+        ), 0) AS score
+      FROM (
+        SELECT grp, MIN(ID) AS sample_id
+        FROM cgd_state
+        GROUP BY grp
+      ) o
+      ORDER BY o.grp
+    expect:
+      rows: 2
+      data:
+        - grp: 10
+          score: 1
+        - grp: 20
+          score: 1
+
+  - name: "outer grouped domain stays logical in EXPLAIN IR"
+    sql: |
+      EXPLAIN IR SELECT o.grp,
+        COALESCE((SELECT SUM(i.cnt)
+          FROM (
+            SELECT s2.parent, s2.grp, COUNT(*) AS cnt
+            FROM cgd_state s2
+            GROUP BY s2.parent, s2.grp
+          ) i
+          WHERE i.parent = o.sample_id AND i.grp = o.grp
+        ), 0) AS score
+      FROM (
+        SELECT grp, MIN(ID) AS sample_id
+        FROM cgd_state
+        GROUP BY grp
+      ) o
+      ORDER BY o.grp
+    expect:
+      contains:
+        - "\"_unn_"
+      not_contains:
+        - "__mat:o:"
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS cgd_state"


### PR DESCRIPTION
## What changed
- preserve the visible alias boundary for materialized derived tables when an outer correlated scalar query depends on a grouped/helper-backed derived-table domain
- add a regression suite for correlated scalar subqueries over nested grouped domains

## Why
Current `master` still collapses grouped outer-domain references like `o.grp` back to the base-table expression during derived-table materialization. That breaks the FAQ requirement that grouped domains stay logical across correlation boundaries, and it produced wrong results for grouped correlated scalar subqueries.

## Root cause
The derived-table boundary check only looked at aggregate use from the outer query, but missed correlated inner-select references that make the visible derived-table aliases part of the logical domain. In the materialized path, those aliases were then exported with inline `Expr` metadata, allowing later rewrites to substitute `o.grp` back to the base-table column.

## Validation
- `python3 run_sql_tests.py tests/66_correlated_group_domain.yaml 43125 --connect-only`
- `python3 run_sql_tests.py tests/66_scalar_subselect_groupby.yaml 43125 --connect-only`
- `python3 run_sql_tests.py tests/66_prejoin_unnest_trigger.yaml 43125 --connect-only`
- `python3 run_sql_tests.py tests/66_prejoin_scalar_subselect.yaml 43125 --connect-only`
- `python3 run_sql_tests.py tests/66_scalar_window_derived.yaml 43125 --connect-only`
- `python3 run_sql_tests.py tests/28_mysql_fk_acceptance.yaml`
- `make test` up to known restart/persistence failures; `tests/34_collation_columns.yaml` is already failing on current `master`

## Impact
This is a planner-only fix plus regression coverage. It is intended to improve FAQ compliance for grouped-domain correlation without changing unrelated scalar/prejoin/window wrapper behavior.