### PR TITLE
planner: stage IR carrier for anti-pass outer-sources

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1647,10 +1647,35 @@ post-group predicate under this name. On current master it is the HAVING expr. *
 				(cons (quote cache-query) _) false
 				true))))))
 )
+/* stage_outer_sources: list of correlation tuples carried by scalar/partition
+stages so the post-reorder anti-pass fixup can null-extend outer rows whose
+correlation key has no match in the inner helper (per FAQ point 34 /
+once-limit-rework.md). Each entry is (outer_tblvar outer_colname inner_expr).
+Present only on stages where Path B/C extracted us_domain_cols; nil elsewhere.
+Design: assoc-style add-on; make_stage signature stays stable. Rebuilders must
+preserve via stage_preserve_cache_meta. No consumer reads this field yet —
+inject_anti_passes (next PR) will annotate stages when join_reorder places the
+helper alias above its correlation source, and build_queryplan will emit the
+companion anti-pass scan. */
+(define stage_outer_sources (lambda (stage) (reduce stage (lambda (acc item)
+	(if (nil? acc) (match item
+		(cons (quote outer-sources) rest) (if (nil? rest) nil (car rest))
+		_ nil
+	) acc)
+) nil)))
+(define stage_with_outer_sources (lambda (stage sources)
+	(if (or (nil? sources) (equal? sources '())) stage
+		(cons (list (quote outer-sources) sources)
+			(filter stage (lambda (item) (match item
+				(cons (quote outer-sources) _) false
+				true))))))
+)
 (define stage_preserve_cache_meta (lambda (old_stage new_stage)
-	(stage_with_cache_query
-		(stage_with_cache_policy new_stage (stage_cache_policy old_stage))
-		(stage_cache_query old_stage)
+	(stage_with_outer_sources
+		(stage_with_cache_query
+			(stage_with_cache_policy new_stage (stage_cache_policy old_stage))
+			(stage_cache_query old_stage))
+		(stage_outer_sources old_stage)
 	)
 ))
 (define stage_has_group_boundary (lambda (stage) (begin


### PR DESCRIPTION
## Summary

- Add optional `outer-sources` carrier to the stage IR (list of `(outer_tblvar outer_colname inner_expr)` tuples), following the existing `cache-policy` / `cache-query` pattern
- Extend `stage_preserve_cache_meta` to propagate `outer-sources` across stage rebuilds
- `make_stage` signature is untouched — assoc-style add-on, readable on any stage via `stage_outer_sources`

## Why

Per FAQ point 34 (`todos/faq-unnesting.md`) and `todos/once-limit-rework.md`: when a partition-staged scalar helper drives LEFT JOIN semantics, an outer row whose correlation key has no match in the inner helper must still emit a NULL-extended row. `scan_order` only synthesizes a single global `isOuter` NULL row, so partitioned correlated helpers need a per-domain anti-pass over the outer table when `join_reorder` places the helper above its correlation source.

To emit that anti-pass cleanly, the stage IR needs to carry the correlation metadata local to the stage. This PR introduces the carrier only — no producer or consumer reads it yet.

## Follow-up PRs

1. `unnest_subselect` writes `outer-sources` from `us_domain_cols` at partition-stage construction
2. `join_reorder` calls `inject_anti_passes` to attach an anti-pass-needed marker when helper position < outer position in the reordered table list
3. `build_queryplan` consumes markers to emit the companion anti-pass scan keyed by the same domain columns, matched with NULL-safe semantics

## Scope

Pure plumbing. Full SQL suite green via pre-commit hook.

## Test plan
- [x] `go build -o memcp` succeeds
- [x] `git-pre-commit` full SQL suite (~203 test files) passes
- [x] No behavioral change: carrier is nil on every stage built by current producers