### PR TITLE
[codex] Refactor unnest subselect rewrite helpers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -576,10 +576,10 @@ layout. */
 (define planner_debug_get_scalar_events (lambda ()
 	(coalesceNil (planner_debug_scalar_events "rows") '())))
 (define explain_plan_root_with_scalar_debug (lambda (plan) (begin
-		(define scalar_events (planner_debug_get_scalar_events))
-		(if (equal? scalar_events '())
-			(explain_plan_root plan)
-			(concat (explain_plan_root plan) " scalar-events=" (serialize scalar_events))))))
+	(define scalar_events (planner_debug_get_scalar_events))
+	(if (equal? scalar_events '())
+		(explain_plan_root plan)
+		(concat (explain_plan_root plan) " scalar-events=" (serialize scalar_events))))))
 (define scalar_subselect_inline_reason (lambda (_agg_args direct_agg_stages_simple raw_contains_skip_level_nested_outer_ref scalar_uses_session_state stage2_post_group_condition stage2_group tables2 scalar_has_outer_ref)
 	(if (nil? _agg_args)
 		(quote legacy-fallback-non-aggregate)
@@ -1897,6 +1897,67 @@ carrier until session domains are modeled explicitly. */
 		nil)))
 		(lambda (src) (not (nil? src))))
 ))
+(define unnest_expr_outer_refs (lambda (expr inner_aliases) (match expr
+	(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
+		(match args
+			(cons sym_arg '()) (list (string sym_arg))
+			'())
+		(if (or (equal? sym (quote get_column)) (equal? sym '(quote get_column)) (equal? sym '(symbol get_column)))
+			(match args
+				'(alias_ _ col _) (if (and (not (nil? alias_))
+					(not (reduce inner_aliases (lambda (a ia) (or a (equal?? ia alias_))) false)))
+					(list (concat alias_ "." col))
+					'())
+				'())
+			(if (_is_opaque_scope_sym sym)
+				'()
+				(merge_unique (map args (lambda (arg) (unnest_expr_outer_refs arg inner_aliases)))))))
+	'())))
+(define unnest_expr_has_outer_ref (lambda (expr inner_aliases) (match expr
+	(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
+		true
+		(if (or (equal? sym (quote get_column)) (equal? sym '(quote get_column)) (equal? sym '(symbol get_column)))
+			(match args
+				'(alias_ _ _ _) (and (not (nil? alias_))
+					(not (reduce inner_aliases (lambda (a ia) (or a (equal?? ia alias_))) false)))
+				false)
+			(if (_is_opaque_scope_sym sym)
+				false
+				(reduce args (lambda (a b) (or a (unnest_expr_has_outer_ref b inner_aliases))) false))))
+	false)))
+(define unnest_runtime_outer_ref_expr (lambda (expr) (match expr
+	(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
+		(match args
+			(cons sym_arg '()) (begin
+				(define ps (split (string sym_arg) "."))
+				(match ps
+					(list tbl col) (list (quote get_column) tbl false col false)
+					_ expr))
+			_ expr)
+		(cons (unnest_runtime_outer_ref_expr sym) (map args unnest_runtime_outer_ref_expr)))
+	expr)))
+(define unnest_rewrite_inner_aliases (lambda (expr alias_lookup) (match expr
+	'((symbol get_column) alias_ ti col ci) (begin
+		(define na (alias_lookup alias_))
+		(if (nil? na) expr (list (quote get_column) na false col false)))
+	'((quote get_column) alias_ ti col ci) (begin
+		(define na (alias_lookup alias_))
+		(if (nil? na) expr (list (quote get_column) na false col false)))
+	(cons sym args) (cons (unnest_rewrite_inner_aliases sym alias_lookup) (map args (lambda (arg)
+		(unnest_rewrite_inner_aliases arg alias_lookup))))
+	expr)))
+(define unnest_correlated_domain_col (lambda (part has_outer_ref resolve_outer_ref) (match part
+	'((symbol equal??) a b) (if (has_outer_ref a)
+		(if (not (has_outer_ref b)) (list b (resolve_outer_ref a)) nil)
+		(if (has_outer_ref b) (list a (resolve_outer_ref b)) nil))
+	'((quote equal??) a b) (if (has_outer_ref a)
+		(if (not (has_outer_ref b)) (list b (resolve_outer_ref a)) nil)
+		(if (has_outer_ref b) (list a (resolve_outer_ref b)) nil))
+	nil)))
+(define unnest_correlated_residual_part? (lambda (part has_outer_ref) (match part
+	'((symbol equal??) a b) (if (has_outer_ref a) (has_outer_ref b) (not (has_outer_ref b)))
+	'((quote equal??) a b) (if (has_outer_ref a) (has_outer_ref b) (not (has_outer_ref b)))
+	true)))
 (define stage_has_group_boundary (lambda (stage) (begin
 	(define sg (coalesceNil (stage_group_cols stage) '()))
 	(or
@@ -3340,24 +3401,10 @@ seeing the correctly prefixed outer alias. */
 									e)))
 								(set fields2_us (map_assoc fields2_us (lambda (k v) (_us_wrap v))))
 								(set condition2_us (_us_wrap condition2_us))
-								/* extract all outer references from fields and condition.
-								Detects both explicit (outer tbl.col) AND bare (get_column tbl false col false)
-								where tbl is NOT in the inner table set (from nested unnesting).
-								Skip opaque scopes (!begin, scan, etc.). */
 								(define us_inner_aliases (map tables2_us (lambda (td) (match td '(a _ _ _ _) a ""))))
-								(define _us_eor (lambda (expr) (match expr
-									(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
-										(match args (cons sym_arg '()) (list (string sym_arg)) '())
-										(if (or (equal? sym (quote get_column)) (equal? sym '(quote get_column)) (equal? sym '(symbol get_column)))
-											(match args '(alias_ _ col _) (if (and (not (nil? alias_)) (not (reduce us_inner_aliases (lambda (a ia) (or a (equal?? ia alias_))) false)))
-												(list (concat alias_ "." col)) '())
-												'())
-											(if (_is_opaque_scope_sym sym) '()
-												(merge_unique (map args _us_eor)))))
-									'())))
 								(define us_outer_refs (merge_unique
-									(merge (extract_assoc fields2_us (lambda (k v) (_us_eor v))))
-									(_us_eor condition2_us)))
+									(merge (extract_assoc fields2_us (lambda (k v) (unnest_expr_outer_refs v us_inner_aliases))))
+									(unnest_expr_outer_refs condition2_us us_inner_aliases)))
 								/* feasibility checks */
 								(define us_has_outer (not (equal? us_outer_refs '())))
 								/* separate own stages from inner scoped stages (from nested decorrelation) —
@@ -3409,7 +3456,7 @@ seeing the correctly prefixed outer alias. */
 								/* check for outer refs in fields (not just condition) — these need
 								more complex handling, fall back for now */
 								(define us_outer_in_fields (not (equal?
-									(merge (extract_assoc fields2_us (lambda (k v) (_us_eor v)))) '())))
+									(merge (extract_assoc fields2_us (lambda (k v) (unnest_expr_outer_refs v us_inner_aliases)))) '())))
 								(if us_outer_in_fields nil /* outer refs in fields: not handled yet */
 									(begin
 										/* === Neumann unnesting: nD domain, single or multi-table === */
@@ -3429,61 +3476,17 @@ seeing the correctly prefixed outer alias. */
 										(define us_value_expr (car (extract_assoc fields2_us (lambda (k v) v))))
 										(define us_value_src (match us_value_expr '((symbol get_column) a _ _ _) a '((quote get_column) a _ _ _) a nil))
 										(define us_value_new (if (nil? us_value_src) us_sq_prefix (coalesceNil (_us_lookup us_value_src) us_sq_prefix)))
-										/* helper: does expr contain outer refs? Detects both (outer ...) and
-										bare get_column refs to non-inner tables. Skip opaque scopes. */
-										(define _us_hor (lambda (expr) (match expr
-											(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
-												true
-												(if (or (equal? sym (quote get_column)) (equal? sym '(quote get_column)) (equal? sym '(symbol get_column)))
-													(match args '(alias_ _ _ _) (and (not (nil? alias_)) (not (reduce us_inner_aliases (lambda (a ia) (or a (equal?? ia alias_))) false))) false)
-													(if (_is_opaque_scope_sym sym) false
-														(reduce args (lambda (a b) (or a (_us_hor b))) false))))
-											false)))
-										/* split condition into AND-parts */
-										(define _us_fap (lambda (expr) (match expr
-											(cons sym parts) (if (or (equal? sym (quote and)) (equal? sym '(quote and)) (equal? sym 'and))
-												(merge (map parts _us_fap))
-												(list expr))
-											(list expr))))
-										(define us_cond_parts (_us_fap condition2_us))
+										(define _us_hor (lambda (expr) (unnest_expr_has_outer_ref expr us_inner_aliases)))
+										(define us_cond_parts (flatten_and_terms condition2_us))
 										(define us_inner_parts (filter us_cond_parts (lambda (p) (not (_us_hor p)))))
 										(define us_outer_parts (filter us_cond_parts (lambda (p) (_us_hor p))))
-										/* resolve (outer tbl.col) -> (get_column tbl false col false).
-										Runtime resolves bare symbols via scope chain (multi-level lookup). */
-										(define _us_ror (lambda (expr) (match expr
-											(cons sym args) (if (or (equal? sym (quote outer)) (equal? sym '(quote outer)))
-												(match args
-													(cons sym_arg '()) (begin
-														(define ps (split (string sym_arg) "."))
-														(match ps
-															(list tbl col) (list (quote get_column) tbl false col false)
-															_ expr))
-													_ expr)
-												(cons (_us_ror sym) (map args _us_ror)))
-											expr)))
-										/* replace ANY inner alias with its renamed version */
-										(define _us_ria (lambda (expr) (match expr
-											'((symbol get_column) alias_ ti col ci) (begin
-												(define na (_us_lookup alias_))
-												(if (nil? na) expr (list (quote get_column) na false col false)))
-											'((quote get_column) alias_ ti col ci) (begin
-												(define na (_us_lookup alias_))
-												(if (nil? na) expr (list (quote get_column) na false col false)))
-											(cons sym args) (cons (_us_ria sym) (map args _us_ria))
-											expr)))
-										/* extract domain columns from correlated equalities:
-										(equal?? inner_expr outer_expr) → (inner_expr resolved_outer_expr).
-										Only top-level AND parts with the equality pattern produce domain
-										columns; all other outer-referencing predicates still need to stay
-										on the inner scan after outer refs are resolved. */
-										(define us_domain_cols (filter (map us_outer_parts (lambda (part) (match part
-											'((symbol equal??) a b) (if (_us_hor a) (if (not (_us_hor b)) (list b (_us_ror a)) nil) (if (_us_hor b) (list a (_us_ror b)) nil))
-											'((quote equal??) a b) (if (_us_hor a) (if (not (_us_hor b)) (list b (_us_ror a)) nil) (if (_us_hor b) (list a (_us_ror b)) nil))
-											nil))) (lambda (x) (not (nil? x)))))
-										(define us_extra_inner_parts (filter us_outer_parts (lambda (part) (match part
-											'((symbol equal??) a b) (if (_us_hor a) (_us_hor b) (not (_us_hor b)))
-											'((quote equal??) a b) (if (_us_hor a) (_us_hor b) (not (_us_hor b)))
-											true))))
+										(define _us_ror unnest_runtime_outer_ref_expr)
+										(define _us_ria (lambda (expr) (unnest_rewrite_inner_aliases expr _us_lookup)))
+										(define us_domain_cols (filter
+											(map us_outer_parts (lambda (part) (unnest_correlated_domain_col part _us_hor _us_ror)))
+											(lambda (x) (not (nil? x)))))
+										(define us_extra_inner_parts (filter us_outer_parts (lambda (part)
+											(unnest_correlated_residual_part? part _us_hor))))
 										(define us_extra_inner_resolved (map us_extra_inner_parts _us_ror))
 										/* inner condition (non-correlated) - kept with original aliases for
 										aggregate path; renamed for non-aggregate path */

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -215,6 +215,30 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (scalar_subselect_lowering_reason_from_facts true false true false false 1 true false false)
 		'prefer-unnest) true "scalar_subselect_lowering_reason_from_facts keeps prefer-unnest explicit")
 	(define iap_outer_source_expr (list 'get_column "helper_t" false "owner" false))
+	(define unnest_outer_expr (list 'and
+		(list 'outer 'outer_t.id)
+		(list 'get_column "inner_t" false "v" false)
+		(list 'get_column "sibling_t" false "x" false)))
+	(assert (equal? (unnest_expr_outer_refs unnest_outer_expr '("inner_t"))
+		'("outer_t.id" "sibling_t.x")) true "unnest_expr_outer_refs collects wrapped and free outer references")
+	(assert (equal? (unnest_expr_has_outer_ref unnest_outer_expr '("inner_t")) true) true "unnest_expr_has_outer_ref detects correlated references")
+	(assert (equal? (unnest_runtime_outer_ref_expr (list 'outer 'outer_t.id))
+		(list 'get_column "outer_t" false "id" false)) true "unnest_runtime_outer_ref_expr lowers outer markers to runtime columns")
+	(assert (equal? (unnest_rewrite_inner_aliases
+		(list 'and (list 'get_column "inner_t" false "v" false) (list 'get_column "other_t" false "z" false))
+		(lambda (alias_) (match alias_
+			"inner_t" "inner_t_flat"
+			nil)))
+		(list 'and (list 'get_column "inner_t_flat" false "v" false) (list 'get_column "other_t" false "z" false))) true "unnest_rewrite_inner_aliases only rewrites mapped inner aliases")
+	(assert (equal? (unnest_correlated_domain_col
+		(list 'equal?? (list 'get_column "inner_t" false "id" false) (list 'outer 'outer_t.id))
+		(lambda (expr) (unnest_expr_has_outer_ref expr '("inner_t")))
+		unnest_runtime_outer_ref_expr)
+		(list (list 'get_column "inner_t" false "id" false) (list 'get_column "outer_t" false "id" false))) true "unnest_correlated_domain_col keeps domain equalities explicit")
+	(assert (equal? (unnest_correlated_residual_part?
+		(list '<= (list 'get_column "inner_t" false "id" false) (list 'outer 'outer_t.id))
+		(lambda (expr) (unnest_expr_has_outer_ref expr '("inner_t"))))
+		true) true "unnest_correlated_residual_part? keeps non-equality correlated predicates on the inner side")
 	(define iap_domain_cols (list
 		(list iap_outer_source_expr (list 'get_column "outer_t" false "id" false))
 		(list (list 'get_column "helper_t" false "grp" false) (list 'session "v1"))))


### PR DESCRIPTION
## What changed
This is a pure structure PR against `unnest_subselect` in `lib/queryplan.scm`.

It extracts the repeated correlated-rewrite pieces into named helpers:
- outer-reference extraction
- outer-reference detection
- `(outer tbl.col)` to runtime `get_column` lowering
- inner-alias rewrite
- correlated equality-domain extraction
- correlated residual predicate classification

`unnest_subselect` now reuses those helpers instead of carrying the same ad-hoc local walkers inline.

## Why
The current master has accumulated too many shape-local scalar unnesting branches. Before wiring more Neumann semantics, the rewrite logic needs to be expressed as reusable tree rewrites instead of one large `us_*` block.

This is the first small straighten-out step toward the paper-aligned algorithm:
- less duplicated local traversal code
- clearer separation between logical correlation rewrite and later lowering
- better basis for splitting `unnest_subselect` by operator shape in follow-up PRs

## Impact
No intended planner behavior change.

This PR is intentionally limited to refactoring plus unit coverage for the extracted helpers.

## Validation
Passed:
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml`
- `python3 run_sql_tests.py tests/66_correlated_group_domain.yaml`

Also exercised:
- `make test` was started and ran through the full planner/storage suites up to the late restart-heavy crash-recovery block.
- The run did not surface regressions in the touched scalar/group planner suites.
- The final `tests/95_crash_recovery.yaml` segment ended up in the existing restart-heavy harness path, so I am leaving this as a draft until that last block is rechecked cleanly.