### PR TITLE
Remove flatmap optimizer helper

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -721,31 +721,6 @@ func init_list() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
-		Name: "flatmap",
-		Desc: "applies fn to each element and flattens the results into a single list (map+merge in one pass, no intermediate allocation)",
-		Fn: func(a ...Scmer) Scmer {
-			list := asSlice(a[0], "flatmap")
-			fn := OptimizeProcToSerialFunction(a[1])
-			result := make([]Scmer, 0, len(list))
-			for _, v := range list {
-				mapped := fn(v)
-				if mapped.IsNil() {
-					continue
-				}
-				result = append(result, asSlice(mapped, "flatmap result")...)
-			}
-			return NewSlice(result)
-		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to map and flatten", NoEscape: true},
-				{Kind: "func", ParamName: "fn", ParamDesc: "func(item)->list that returns a list per element", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "list"}},
-			},
-			Return: FreshAlloc,
-			Const:  true,
-		},
-	})
-	Declare(&Globalenv, &Declaration{
 		Name: "reduce",
 		Desc: "returns a list that contains the result of a map function",
 		Fn: func(a ...Scmer) Scmer {
@@ -1791,27 +1766,9 @@ func init_list() {
 	})
 }
 
-// optimizeMerge rewrites merge calls to avoid intermediate allocations:
-//
-//	(merge (map list fn)) → (flatmap list fn)           — single-arg merge over map
-//	(merge (extract_assoc dict fn)) → (flatmap_assoc...) — not yet, but same idea
-//	(merge a b (map list fn)) → flatten map result inline
+// optimizeMerge currently only runs the standard optimization pipeline.
 func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
-	// First: apply default optimization to all args
-	result, td := oc.ApplyDefaultOptimization(v, useResult)
-	if rSlice, ok := scmerSlice(result); ok && len(rSlice) == 2 {
-		// (merge X) where X is a single argument
-		arg := rSlice[1]
-		if inner, ok2 := scmerSlice(arg); ok2 && len(inner) == 3 {
-			// Check if arg is (map list fn) or (map_mut list fn)
-			if scmerIsSymbol(inner[0], "map") || scmerIsSymbol(inner[0], "map_mut") {
-				// Rewrite to (flatmap list fn) — flatmap does map+flatten in one pass
-				flatmapCall := []Scmer{NewSymbol("flatmap"), inner[1], inner[2]}
-				return NewSlice(flatmapCall), FreshAlloc
-			}
-		}
-	}
-	return result, td
+	return oc.ApplyDefaultOptimization(v, useResult)
 }
 
 // optimizeCons rewrites cons when the tail is a freshly allocated list:


### PR DESCRIPTION
## Summary
- remove the unused flatmap builtin
- drop the merge optimizer rewrite that lowered to flatmap
- keep merge on the normal default optimization path

## Testing
- go build -o memcp
- make test was started but aborted on request before completion