### PR TITLE
refactor scalar ordered scan helpers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1028,6 +1028,33 @@ build_scan can lower scalar subselects without extra once-limit stages. */
 		(not (nil? (scan_tagged_table_offset tbl)))
 		(not (equal? (scan_tagged_table_partition_cols tbl) 0)))
 ))
+/* Ordered scalar scans currently lower physically via partitioned scan_order.
+The later logical ORDER/LIMIT normalization should keep targeting these small
+helpers instead of rebuilding alias/order logic inline inside untangle_query. */
+(define scalar_scan_domain_order (lambda (domain_cols rewrite_inner_expr sq_alias)
+	(filter
+		(map domain_cols (lambda (dc) (list (rewrite_inner_expr (nth dc 0)) '<)))
+		(lambda (oi) (match oi '(col _)
+			(match col
+				'((symbol get_column) a _ _ _) (equal? a sq_alias)
+				'((quote get_column) a _ _ _) (equal? a sq_alias)
+				false)
+			false))
+)))
+(define scalar_scan_rewrite_order (lambda (order_list rewrite_expr)
+	(map (coalesceNil order_list '()) (lambda (oi) (match oi
+		'(col dir) (list (rewrite_expr col) dir)
+		oi)))
+))
+(define scalar_scan_order_supported (lambda (order_list sq_alias)
+	(reduce order_list (lambda (acc oi) (and acc (match oi
+		'(col _dir) (match col
+			'((symbol get_column) a _ _ _) (equal? a sq_alias)
+			'((quote get_column) a _ _ _) (equal? a sq_alias)
+			false)
+		false)))
+		true)
+))
 (define make_once_limit_scan_contract (lambda (limit_value offset_value partition_cols once_limit tblvar condition joinexpr tbl) (begin
 	(define contract_once_limit (if (nil? once_limit)
 		(if (and (not (nil? limit_value)) (<= limit_value 1))
@@ -3651,19 +3678,9 @@ seeing the correctly prefixed outer alias. */
 														(begin
 															(if (not (equal? _us_inner_tbls_rewritten '()))
 																(sq_cache "tables" (merge _us_inner_tbls_rewritten (coalesceNil (sq_cache "tables") '()))))
-															(define us_dom_order (filter (map us_domain_cols (lambda (dc) (list (_us_ria (nth dc 0)) '<)))
-																(lambda (oi) (match oi '(col _) (match col
-																	'((symbol get_column) a _ _ _) (equal? a us_sq_prefix)
-																	'((quote get_column) a _ _ _) (equal? a us_sq_prefix)
-																	false) false))))
-															(define us_renamed_order (map (coalesceNil us_orig_order '()) (lambda (oi) (match oi '(col dir) (list (_us_ria col) dir) oi))))
-															(define us_order_supported (reduce us_renamed_order (lambda (acc oi) (and acc (match oi
-																'(col _dir) (match col
-																	'((symbol get_column) a _ _ _) (equal? a us_sq_prefix)
-																	'((quote get_column) a _ _ _) (equal? a us_sq_prefix)
-																	false)
-																false)))
-																true))
+															(define us_dom_order (scalar_scan_domain_order us_domain_cols _us_ria us_sq_prefix))
+															(define us_renamed_order (scalar_scan_rewrite_order us_orig_order _us_ria))
+															(define us_order_supported (scalar_scan_order_supported us_renamed_order us_sq_prefix))
 															(if (not us_order_supported)
 																nil
 																(begin


### PR DESCRIPTION
What changed
- extract ordered scalar scan domain-order building into `scalar_scan_domain_order`
- extract ordered scalar scan order rewriting into `scalar_scan_rewrite_order`
- extract ordered scalar order-shape validation into `scalar_scan_order_supported`
- rewire the scalar non-aggregate lowering path to call those helpers instead of carrying the logic inline

Why
- this is the alias and order seam the later logical `ORDER BY/LIMIT/OFFSET` normalization will need
- keeping it in dedicated helpers makes the next ordered-scalar normalization step smaller and keeps more of `unnest_subselect` out of inline shape-specific logic
- planner semantics stay unchanged in this PR

Validation
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml`
- `python3 run_sql_tests.py tests/66_correlated_group_domain.yaml`
- `python3 run_sql_tests.py tests/52_group_stage_corners.yaml`
- `python3 run_sql_tests.py tests/66_scalar_subselect_groupby.yaml`
- `make test`