### PR TITLE
lower scalar partition-topk via stages

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3709,28 +3709,20 @@ seeing the correctly prefixed outer alias. */
 																		(list us_part_stage)
 																		_us_inner_stages_rewritten
 																		(coalesceNil (sq_cache "groups") '())))
-																	(define us_join_lim (map us_outer_parts (lambda (p) (_us_ria (_us_ror p)))))
-																	(define us_inner_lim (_us_ria us_inner_cond_raw))
-																	(define us_full_lim (if (nil? us_inner_lim)
-																		(if (equal? (count us_join_lim) 0) true (if (equal? (count us_join_lim) 1) (car us_join_lim) (cons (quote and) us_join_lim)))
-																		(cons (quote and) (merge us_join_lim (list us_inner_lim)))))
-																	(define us_tagged_tbl (make_scan_tagged_table
-																		us_tbl_name
-																		us_part_order
-																		(once_limit_scan_contract_limit us_once_contract)
-																		(once_limit_scan_contract_offset us_once_contract)
-																		(once_limit_scan_contract_partition_cols us_once_contract)
-																		(once_limit_scan_contract_once_limit us_once_contract)))
-																	(define us_tagged_tbl (scan_tagged_table_with_outer_sources us_tagged_tbl us_outer_sources))
-																	(define _us_nested_direct_tbls_rewritten (map _us_nested_direct_tbls (lambda (td) (match td
-																		'(a s t io je) (list a s t io (if (nil? je) nil (_us_ria je)))
-																		td))))
-																	(define us_tbl_entries (merge _us_nested_direct_tbls_rewritten (list (list us_sq_prefix us_tbl_schema us_tagged_tbl true us_full_lim))))
-																	(define _us_inner_schema (schemas2_us us_tblvar))
-																	(define _us_passthrough_schemas (merge
-																		(if (not (nil? _us_inner_schema)) (list us_sq_prefix _us_inner_schema) '())
-																		(merge (map (merge _us_inner_tbls _us_nested_direct_tbls) (lambda (td) (match td
-																			'(a _ _ _ _) (begin
+															(define us_join_lim (map us_outer_parts (lambda (p) (_us_ria (_us_ror p)))))
+															(define us_inner_lim (_us_ria us_inner_cond_raw))
+															(define us_full_lim (if (nil? us_inner_lim)
+																(if (equal? (count us_join_lim) 0) true (if (equal? (count us_join_lim) 1) (car us_join_lim) (cons (quote and) us_join_lim)))
+																(cons (quote and) (merge us_join_lim (list us_inner_lim)))))
+															(define _us_nested_direct_tbls_rewritten (map _us_nested_direct_tbls (lambda (td) (match td
+																'(a s t io je) (list a s t io (if (nil? je) nil (_us_ria je)))
+																td))))
+															(define us_tbl_entries (merge _us_nested_direct_tbls_rewritten (list (list us_sq_prefix us_tbl_schema us_tbl_name true us_full_lim))))
+															(define _us_inner_schema (schemas2_us us_tblvar))
+															(define _us_passthrough_schemas (merge
+																(if (not (nil? _us_inner_schema)) (list us_sq_prefix _us_inner_schema) '())
+																(merge (map (merge _us_inner_tbls _us_nested_direct_tbls) (lambda (td) (match td
+																	'(a _ _ _ _) (begin
 																				(define _isch (schemas2_us a))
 																				(if (nil? _isch) '() (list a _isch)))
 																			'()))))))
@@ -8329,8 +8321,10 @@ When set, the scan on tblalias includes $update in mapcols and the mapfn applies
 										(extract_columns_for_tblvar tblvar effective_later_condition)
 										(extract_outer_columns_for_tblvar tblvar effective_later_condition))))
 									(set filtercols (merge_unique (list (extract_columns_for_tblvar tblvar now_condition) (extract_outer_columns_for_tblvar tblvar now_condition))))
-									/* check partition_stages for this table (non-first tables may have per-table partition limits) */
-									(define _ps_ord (if (or is_first (not (nil? tbl_once_limit))) nil
+									/* check partition_stages for this table. Tagged scans still override the
+									local stage config, but scoped partition stages must now also work when
+									this helper is the driver after join_reorder. */
+									(define _ps_ord (if (not (nil? tbl_once_limit)) nil
 										(reduce partition_stages (lambda (a s) (if (nil? a) (if (has? (coalesceNil (stage_partition_aliases s) '()) tblvar) s nil) a)) nil)))
 									(define _ps_once_limit (if (nil? _ps_ord) nil (stage_once_limit _ps_ord)))
 									/* tagged helper scans override the local scan config; otherwise use

--- a/tests/32_expr_subselects.yaml
+++ b/tests/32_expr_subselects.yaml
@@ -179,6 +179,7 @@ test_cases:
         - "prefer-unnest"
       not_contains:
         - "__scalar_promise_"
+        - "scan-tagged-table"
 
   - name: "Derived table with scalar aggregate subselect"
     sql: "SELECT t.* FROM (SELECT id, (SELECT COUNT(1) FROM t2 WHERE owner = t3.id LIMIT 1) AS cnt FROM t3) AS t ORDER BY id"


### PR DESCRIPTION
What changed
- stop emitting `scan-tagged-table` for the correlated non-aggregate scalar unnest path
- keep the helper as a normal table entry and carry its local `order/limit/offset/limit-partition-cols` semantics through the scoped partition stage instead
- let ordered `build_scan` honor scoped partition stages even when that helper becomes the driver after join reorder
- add an `EXPLAIN IR` regression to ensure this path no longer exposes `scan-tagged-table`

Why
- this is the first real shift from scalar-special helper metadata toward the normal logical partition-topk stage model
- `scan_order` already supports per-partition top-k physically; this PR moves one scalar path off the tagged-table special case and onto the existing stage pipeline
- `once_limit` remains as the current scalar-cardinality carrier for now, but the helper scan itself is no longer encoded as a separate table kind in this path

Scope
- correlated non-aggregate scalar path only
- single-table inner helper path
- no grouped/window rewrite in this PR

Validation
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml`
- `python3 run_sql_tests.py tests/66_correlated_group_domain.yaml`
- `python3 run_sql_tests.py tests/52_group_stage_corners.yaml`
- `python3 run_sql_tests.py tests/66_scalar_subselect_groupby.yaml`
- `make test`