### PR TITLE
Optimize merge_unique with owned list inputs

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -142,6 +142,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (zip (list (list 1 2) (list 3 4))) (list (list 1 3) (list 2 4))) true "zip list of lists")
 	(assert (equal? (merge (list (list 1 2) (list 3))) '(1 2 3)) true "merge flattens")
 	(assert (equal? (merge_unique (list (list 1 2) (list 2 3))) '(1 2 3)) true "merge_unique removes duplicates")
+	(assert (equal? (merge_unique_mut '(1 2) '(2 3)) '(1 2 3)) true "merge_unique_mut multi-arg semantics")
+	(assert (equal? (merge_unique_mut '(1 1 2) '(2 3)) '(1 2 3)) true "merge_unique_mut deduplicates first arg too")
+	(assert (equal? (merge_unique_mut (list (list 1 2) (list 2 3))) '(1 2 3)) true "merge_unique_mut single-arg list-of-lists semantics")
 
 	/* has? / filter / map / mapIndex / reduce */
 	(assert (has? '("a" "b" "c") "b") true "has? finds element")
@@ -858,6 +861,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert ((eval (optimize '('lambda '('a 'b) '(append '(list 'a) 'b)))) 10 20) '(10 20) "_mut append on fresh list")
 	/* scan callback ownership: reduce accumulator enables _mut inside reduce body */
 	(assert (serialize (optimize '('scan nil '('table "db" "tbl") '("x") '('lambda '('x) true) '("x") '('lambda '('x) 'x) '('lambda '('acc 'row) '(set_assoc 'acc 'row true)) '(list) nil false))) "(scan nil (table \"db\" \"tbl\") (\"x\") (lambda (x) true 1) (\"x\") (lambda (x) (var 0) 1) (lambda (acc row) (set_assoc_mut (var 0) (var 1) true) 2) '() nil false)" "scan hook: reduce acc enables set_assoc_mut")
+	(define opt_merge_unique_ser (serialize (optimize
+		(list 'lambda
+			(list 'a 'b 'c)
+			(list 'merge_unique
+				(list 'list 'a 'b)
+				(list 'list 'b 'c))))))
+	(assert (match opt_merge_unique_ser (regex "merge_unique_mut" _) true false) true "_mut merge_unique on fresh first arg")
 
 	/* match / match_mut correctness */
 	(print "testing match/match_mut correctness ...")

--- a/scm/list.go
+++ b/scm/list.go
@@ -481,8 +481,9 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", ParamName: "list", ParamDesc: "list of lists of items", NoEscape: true, Variadic: true},
 			},
-			Return: FreshAlloc,
-			Const:  true,
+			Return:   FreshAlloc,
+			Const:    true,
+			Optimize: optimizeMergeUnique,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1668,6 +1669,71 @@ func init_list() {
 	})
 
 	Declare(&Globalenv, &Declaration{
+		Name: "merge_unique_mut",
+		Desc: "in-place merge_unique (optimizer-only)",
+		Fn: func(a ...Scmer) Scmer {
+			if len(a) == 1 {
+				lists := asSlice(a[0], "merge_unique_mut")
+				inputs := append([]Scmer{}, lists...)
+				result := lists[:0]
+				for _, v := range inputs {
+					for _, el := range asSlice(v, "merge_unique_mut item") {
+						duplicate := false
+						for _, existing := range result {
+							if Equal(el, existing) {
+								duplicate = true
+								break
+							}
+						}
+						if !duplicate {
+							result = append(result, el)
+						}
+					}
+				}
+				return NewSlice(result)
+			}
+			base := asSlice(a[0], "merge_unique_mut")
+			inputs := append([]Scmer{}, base...)
+			result := base[:0]
+			for _, el := range inputs {
+				duplicate := false
+				for _, existing := range result {
+					if Equal(el, existing) {
+						duplicate = true
+						break
+					}
+				}
+				if !duplicate {
+					result = append(result, el)
+				}
+			}
+			for _, v := range a[1:] {
+				for _, el := range asSlice(v, "merge_unique_mut item") {
+					duplicate := false
+					for _, existing := range result {
+						if Equal(el, existing) {
+							duplicate = true
+							break
+						}
+					}
+					if !duplicate {
+						result = append(result, el)
+					}
+				}
+			}
+			return NewSlice(result)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "list", ParamDesc: "owned base list or owned list of lists", Variadic: true},
+			},
+			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+
+	Declare(&Globalenv, &Declaration{
 		Name: "reset_mut",
 		Desc: "resets an owned list to len=0 while preserving capacity",
 		Fn: func(a ...Scmer) Scmer {
@@ -1769,6 +1835,39 @@ func init_list() {
 // optimizeMerge currently only runs the standard optimization pipeline.
 func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	return oc.ApplyDefaultOptimization(v, useResult)
+}
+
+// optimizeMergeUnique keeps merge_unique on the standard variadic path, but
+// additionally treats a direct (list ...) first argument as fresh so the
+// optimizer can swap to merge_unique_mut without changing the global list
+// return contract.
+func optimizeMergeUnique(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	firstArgListLiteral := false
+	if len(v) > 2 {
+		arg1 := v[1]
+		if stripped, ok := scmerStripSourceInfo(arg1); ok {
+			arg1 = stripped
+		}
+		if inner, ok := scmerSlice(arg1); ok && len(inner) > 0 && scmerIsSymbol(inner[0], "list") {
+			firstArgListLiteral = true
+		}
+	}
+
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	if !firstArgListLiteral {
+		return result, td
+	}
+
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) < 2 || !scmerIsSymbol(rv[0], "merge_unique") {
+		return result, td
+	}
+	rv[0] = NewSymbol("merge_unique_mut")
+	if td == nil {
+		td = &TypeDescriptor{}
+	}
+	td.Transfer = true
+	return NewSlice(rv), td
 }
 
 // optimizeCons rewrites cons when the tail is a freshly allocated list:


### PR DESCRIPTION
## Summary
- add optimizer-only `merge_unique_mut` with full `merge_unique` semantics for both single-arg list-of-lists and variadic calls
- teach `merge_unique` to rewrite only the safe case of a direct fresh first `(list ...)` argument
- cover the new runtime and optimizer behavior in `lib/test.scm`

## Verification
- `go build -o memcp`
- `python3 tools/lint_scm.py --check --path lib/test.scm`
- `python3 run_sql_tests.py tests/19_subselect_order.yaml`
- `python3 run_sql_tests.py tests/29_mysql_upsert.yaml`
- `python3 run_sql_tests.py tests/43_dbcheck_ddl_compat.yaml`
- `make test`
