### PR TITLE
unnest correlated order-limit scalar path

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3948,11 +3948,17 @@ seeing the correctly prefixed outer alias. */
 	(define scalar_subselect_lowering_reason (lambda (subquery outer_schemas)
 		(match (scalar_subselect_shape_facts subquery outer_schemas)
 			'(_g h _o _l _off _value_expr _has_outer _outer_refs_are_direct_columns _contains_inner_select_marker _has_aggregate _uses_session_state _contains_skip_level_nested_outer_ref) (begin
-				(define _has_agg_or_stage (or
+				/* ORDER/LIMIT-only correlated scalars already lower through the
+				normal non-aggregate partition-topk path, but only for the direct
+				single-level shape. Nested inner-select markers still stay on the
+				old fallback path for now. */
+				(define _has_grouped_semantics (or
 					_has_aggregate
 					(not (nil? h))
 					(not (equal? (coalesceNil _g '()) '()))
-					(not (equal? (coalesceNil _o '()) '()))))
+					(and
+						(not (equal? (coalesceNil _o '()) '()))
+						_contains_inner_select_marker)))
 				(define _value_expr_is_direct_column (match _value_expr
 					'((symbol get_column) _ _ _ _) true
 					'((quote get_column) _ _ _ _) true
@@ -3967,7 +3973,7 @@ seeing the correctly prefixed outer alias. */
 						(_raw_subquery_has_non_equality_outer_condition subquery outer_schemas)))
 				(scalar_subselect_lowering_reason_from_facts
 					_has_outer
-					_has_agg_or_stage
+					_has_grouped_semantics
 					_outer_refs_are_direct_columns
 					_outer_has_group
 					_contains_inner_select_marker

--- a/tests/32_expr_subselects.yaml
+++ b/tests/32_expr_subselects.yaml
@@ -177,9 +177,12 @@ test_cases:
       contains:
         - "scalar-events"
         - "prefer-unnest"
+        - "limit-partition-cols 1"
+        - "partition-aliases (\"_unn_t2_0\")"
       not_contains:
         - "__scalar_promise_"
         - "scan-tagged-table"
+        - "inline-grouped-non-domain-correlation"
 
   - name: "Derived table with scalar aggregate subselect"
     sql: "SELECT t.* FROM (SELECT id, (SELECT COUNT(1) FROM t2 WHERE owner = t3.id LIMIT 1) AS cnt FROM t3) AS t ORDER BY id"


### PR DESCRIPTION
What changed
- let direct correlated non-aggregate scalar subqueries with `ORDER BY/LIMIT/OFFSET` take the existing unnest path instead of classifying them as grouped fallback shapes
- keep nested inner-select marker shapes on the old fallback path; this PR only opens the direct single-level case
- strengthen the `EXPLAIN IR` regression to assert the actual partition-topk stage shape (`limit-partition-cols`, scoped alias) and to reject the old grouped fallback reason

Why
- `scan_order` already implements the physical partition-topk semantics; the missing piece was the lowering policy gate that still treated ordered correlated scalars as grouped/fallback cases
- this is the next incremental step after `#232`: the same logical stage path now covers the explicit `ORDER/LIMIT/OFFSET` scalar shape too

Scope
- correlated non-aggregate scalar path only
- direct single-level shape only
- no grouped/window/multi-table expansion in this PR

Validation
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml`
- `python3 run_sql_tests.py tests/66_correlated_group_domain.yaml`
- `python3 run_sql_tests.py tests/52_group_stage_corners.yaml`
- `python3 run_sql_tests.py tests/66_scalar_subselect_groupby.yaml`
- `make test`