### PR TITLE
Track exact list lengths through optimizer

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -859,6 +859,79 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (serialize (optimize '('set_assoc '('filter '('list) '('lambda '('x) true)) "k" "v"))) "(set_assoc_mut (filter '() (lambda (x) true 1)) \"k\" \"v\")" "_mut hook: set_assoc -> set_assoc_mut")
 	/* _mut on append with fresh list arg */
 	(assert ((eval (optimize '('lambda '('a 'b) '(append '(list 'a) 'b)))) 10 20) '(10 20) "_mut append on fresh list")
+	(assert ((eval (optimize '('lambda '() '(count '(list))))) ) 0 "length hook: count folds empty list")
+	(assert ((eval (optimize (list 'lambda '()
+		(list 'count (list 'append (list 'list) 1 2 3)))))) 3 "length hook: append preserves empty-base exact length")
+	(assert ((eval (optimize (list 'lambda (list 'a 'b 'c)
+		(list 'count (list 'append (list 'list 'a) 'b 'c))))) 10 20 30) 3 "length hook: count folds exact append length")
+	(assert ((eval (optimize (list 'lambda '()
+		(list 'count (list 'map (list 'produceN 4) (list 'lambda (list 'i) 'i))))))) 4 "length hook: count folds propagated map length")
+	(assert ((eval (optimize (list 'lambda '()
+		(list 'count (list 'mapIndex (list 'produceN 5) (list 'lambda (list 'i 'v) 'i))))))) 5 "length hook: count folds mapIndex over produceN")
+	(assert ((eval (optimize (list 'lambda '()
+		(list 'count (list 'parallel_map (list 'produceN 3) (list 'lambda (list 'v) 'v))))))) 3 "length hook: count folds parallel_map over produceN")
+	(assert ((eval (optimize (list 'lambda '('a 'b 'c)
+		(list 'count (list 'cdr (list 'list 'a 'b 'c)))))) 10 20 30) 2 "length hook: cdr preserves exact tail length")
+	(assert ((eval (optimize (list 'lambda '('a 'b 'c)
+		(list 'count (list 'reverse (list 'list 'a 'b 'c)))))) 10 20 30) 3 "length hook: reverse preserves exact length")
+	(assert ((eval (optimize (list 'lambda '()
+		(list 'count (list 'extract_assoc (list 'list "a" 1 "b" 2) (list 'lambda (list 'k 'v) 'k))))))) 2 "length hook: extract_assoc preserves exact pair count")
+	(assert
+		((eval (optimize
+			(list 'lambda '()
+				(list 'count
+					(list 'merge
+						(list 'map
+							(list 'produceN 3)
+							(list 'lambda (list 'i) (list 'list 'i (list '+ 'i 10))))))))))
+		6
+		"length hook: merge folds map callback list width")
+	(assert
+		((eval (optimize
+			(list 'lambda '()
+				(list 'count
+					(list 'merge
+						(list 'extract_assoc
+							(list 'list "a" 1 "b" 2)
+							(list 'lambda (list 'k 'v) (list 'list 'k 'v)))))))))
+		4
+		"length hook: merge folds extract_assoc callback list width")
+	(assert
+		((eval (optimize
+			(list 'lambda '()
+				(list 'count
+					(list 'merge
+						(list 'produceN 4
+							(list 'lambda (list 'i) (list 'list 'i (list '* 'i 2))))))))))
+		8
+		"length hook: merge folds produceN callback list width")
+	(assert
+		((eval (optimize
+			(list 'lambda '()
+				(list 'count
+					(list 'merge
+						(list 'list
+							(list 'map (list 'produceN 2) (list 'lambda (list 'i) 'i))
+							(list 'extract_assoc (list 'list "a" 1 "b" 2) (list 'lambda (list 'k 'v) 'k)))))))))
+		4
+		"length hook: merge composes exact producer lengths")
+	(assert
+		((eval (optimize
+			(list 'lambda '('a 'b 'c)
+				(list 'count
+					(list 'zip
+						(list 'list
+							(list 'map (list 'produceN 3) (list 'lambda (list 'i) 'i))
+							(list 'reverse (list 'list 'a 'b 'c))))))))
+		 10 20 30)
+		3
+		"length hook: zip preserves exact producer length")
+	(assert
+		((eval (optimize
+			(list 'lambda '()
+				(list 'count (list 'parallelN 4 (list 'lambda (list 'i) 'i)))))))
+		4
+		"length hook: count folds parallelN length")
 	/* scan callback ownership: reduce accumulator enables _mut inside reduce body */
 	(assert (serialize (optimize '('scan nil '('table "db" "tbl") '("x") '('lambda '('x) true) '("x") '('lambda '('x) 'x) '('lambda '('acc 'row) '(set_assoc 'acc 'row true)) '(list) nil false))) "(scan nil (table \"db\" \"tbl\") (\"x\") (lambda (x) true 1) (\"x\") (lambda (x) (var 0) 1) (lambda (acc row) (set_assoc_mut (var 0) (var 1) true) 2) '() nil false)" "scan hook: reduce acc enables set_assoc_mut")
 	(define opt_merge_unique_ser (serialize (optimize

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -59,30 +59,31 @@ func (d *Declaration) MaxParams() int {
 // TypeDescriptor describes the type of any Scmer value at arbitrary depth.
 // Uses pointers throughout — nil means "unknown / don't care" (conservative).
 type TypeDescriptor struct {
-	Kind      string                     // "any"|"string"|"number"|"int"|"bool"|"nil"|"symbol"|"func"|"list"|"assoc"
-	NoEscape  bool                       // true = value will NOT outlive its scope (safe for stack alloc); default false = may escape (conservative)
-	Transfer  bool                       // callee receives ownership, can mutate
-	Const     bool                       // value is a compile-time constant; for func: safe to constant-fold
-	Optional  bool                       // for func params: parameter is optional
-	Variadic  bool                       // for func params: last param accepts 0+ values
-	Forbidden      bool                  // for func: optimizer-only, hidden from help
-	HasSideEffects bool                  // for func: true = call has side effects, cannot be eliminated even if result unused
-	ParamName string                     // for func params: documentation name
-	ParamDesc string                     // for func params: documentation description
-	Params    []*TypeDescriptor          // for Kind="func": parameter types
-	Return    *TypeDescriptor            // for Kind="func": return type
-	Keys      map[string]*TypeDescriptor // for Kind="assoc": per-key type info
-	Element   *TypeDescriptor            // for Kind="list": element type
+	Kind           string                     // "any"|"string"|"number"|"int"|"bool"|"nil"|"symbol"|"func"|"list"|"assoc"
+	NoEscape       bool                       // true = value will NOT outlive its scope (safe for stack alloc); default false = may escape (conservative)
+	Transfer       bool                       // callee receives ownership, can mutate
+	Const          bool                       // value is a compile-time constant; for func: safe to constant-fold
+	Length         int                        // exact positive list/assoc length; -1 = unknown
+	Optional       bool                       // for func params: parameter is optional
+	Variadic       bool                       // for func params: last param accepts 0+ values
+	Forbidden      bool                       // for func: optimizer-only, hidden from help
+	HasSideEffects bool                       // for func: true = call has side effects, cannot be eliminated even if result unused
+	ParamName      string                     // for func params: documentation name
+	ParamDesc      string                     // for func params: documentation description
+	Params         []*TypeDescriptor          // for Kind="func": parameter types
+	Return         *TypeDescriptor            // for Kind="func": return type
+	Keys           map[string]*TypeDescriptor // for Kind="assoc": per-key type info
+	Element        *TypeDescriptor            // for Kind="list": element type
 	// Custom optimizer hook for function types. When set, the optimizer calls this
 	// INSTEAD of the default arg optimization + post-processing.
-	Optimize  func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor)
+	Optimize func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor)
 	// Optional JIT emitter for native code generation.
-	JITEmit   func(ctx *JITContext, args []Scmer, descs []JITValueDesc, result JITValueDesc) JITValueDesc
+	JITEmit func(ctx *JITContext, args []Scmer, descs []JITValueDesc, result JITValueDesc) JITValueDesc
 	// Specialized variants keyed by param-ownership bitmask.
 	// Built on-demand by the optimizer when a call site provides owned args.
 	// TODO: deoptimization — if the global function is redefined, all callsites
 	// referencing cached variants must be invalidated (reset to the original code).
-	Variants  map[uint64]Scmer
+	Variants map[uint64]Scmer
 }
 
 // OptimizerContext is an exported wrapper so packages like storage can use
@@ -96,9 +97,10 @@ type OptimizerContext struct {
 // No heap allocation for the common case (Kind + Flags). Extra info (sub-structure
 // types, function signatures) is stored in an optional *TypeDescriptor pointer.
 type TypeInfo struct {
-	kind  uint8
-	flags uint8
-	Extra *TypeDescriptor // nil in common case; only allocated for sub-structure info
+	kind   uint8
+	flags  uint8
+	length int
+	Extra  *TypeDescriptor // nil in common case; only allocated for sub-structure info
 }
 
 // Kind constants for TypeInfo
@@ -122,20 +124,36 @@ const (
 	FlagEscape                     // value may outlive scope
 )
 
+const UnknownLength = -1
+
 func (ti TypeInfo) Transfer() bool { return ti.flags&FlagTransfer != 0 }
 func (ti TypeInfo) Const() bool    { return ti.flags&FlagConst != 0 }
 func (ti TypeInfo) Escape() bool   { return ti.flags&FlagEscape != 0 }
 func (ti TypeInfo) Kind() uint8    { return ti.kind }
+func (ti TypeInfo) Length() int {
+	if ti.length <= 0 {
+		return UnknownLength
+	}
+	return ti.length
+}
 
-func (ti TypeInfo) WithTransfer() TypeInfo   { ti.flags |= FlagTransfer; return ti }
+func (ti TypeInfo) WithTransfer() TypeInfo    { ti.flags |= FlagTransfer; return ti }
 func (ti TypeInfo) WithoutTransfer() TypeInfo { ti.flags &^= FlagTransfer; return ti }
-func (ti TypeInfo) WithConst() TypeInfo      { ti.flags |= FlagConst; return ti }
+func (ti TypeInfo) WithConst() TypeInfo       { ti.flags |= FlagConst; return ti }
 func (ti TypeInfo) WithKind(k uint8) TypeInfo { ti.kind = k; return ti }
+func (ti TypeInfo) WithLength(n int) TypeInfo {
+	if n <= 0 {
+		ti.length = UnknownLength
+	} else {
+		ti.length = n
+	}
+	return ti
+}
 func (ti TypeInfo) WithExtra(td *TypeDescriptor) TypeInfo { ti.Extra = td; return ti }
 
 // MakeTypeInfo builds a TypeInfo from transfer/const bools (no heap allocation).
 func MakeTypeInfo(transfer, constant bool) TypeInfo {
-	var ti TypeInfo
+	ti := TypeInfo{length: UnknownLength}
 	if transfer {
 		ti.flags |= FlagTransfer
 	}
@@ -148,9 +166,9 @@ func MakeTypeInfo(transfer, constant bool) TypeInfo {
 // TypeInfoFromTD converts a *TypeDescriptor to a stack-allocated TypeInfo.
 func TypeInfoFromTD(td *TypeDescriptor) TypeInfo {
 	if td == nil {
-		return TypeInfo{}
+		return TypeInfo{length: UnknownLength}
 	}
-	var ti TypeInfo
+	ti := TypeInfo{length: UnknownLength}
 	if td.Transfer {
 		ti.flags |= FlagTransfer
 	}
@@ -177,7 +195,10 @@ func TypeInfoFromTD(td *TypeDescriptor) TypeInfo {
 	case "assoc":
 		ti.kind = KindAssoc
 	}
-	if len(td.Params) > 0 || td.Return != nil || len(td.Keys) > 0 || td.Element != nil {
+	if td.Length > 0 {
+		ti.length = td.Length
+	}
+	if td.Length > 0 || len(td.Params) > 0 || td.Return != nil || len(td.Keys) > 0 || td.Element != nil {
 		ti.Extra = td
 	}
 	return ti
@@ -185,22 +206,23 @@ func TypeInfoFromTD(td *TypeDescriptor) TypeInfo {
 
 // ToTypeDescriptor converts to a heap-allocated TypeDescriptor (for APIs that need it).
 func (ti TypeInfo) ToTypeDescriptor() *TypeDescriptor {
-	if ti.kind == KindAny && ti.flags == 0 && ti.Extra == nil {
+	if ti.kind == KindAny && ti.flags == 0 && ti.Extra == nil && ti.Length() == UnknownLength {
 		return nil
 	}
-	td := &TypeDescriptor{Transfer: ti.Transfer(), Const: ti.Const(), NoEscape: !ti.Escape()}
+	td := &TypeDescriptor{Transfer: ti.Transfer(), Const: ti.Const(), NoEscape: !ti.Escape(), Length: ti.Length()}
 	if ti.Extra != nil {
 		*td = *ti.Extra
 		td.Transfer = ti.Transfer()
 		td.Const = ti.Const()
 		td.NoEscape = !ti.Escape()
+		td.Length = ti.Length()
 	}
 	return td
 }
 
 // NoEscape is a reusable TypeDescriptor annotation for parameters that
 // the callee reads but never stores — safe to back with stack-allocated !list.
-var NoEscape = &TypeDescriptor{Kind: "any", NoEscape: true}
+var NoEscape = &TypeDescriptor{Kind: "any", NoEscape: true, Length: UnknownLength}
 
 var declaration_titles []string
 var declarations map[string]*Declaration = make(map[string]*Declaration)
@@ -217,7 +239,7 @@ func DeclareTitle(title string) {
 
 // FreshAlloc is a reusable TypeDescriptor for functions whose return value
 // is always a fresh allocation — safe for _mut swap by the optimizer.
-var FreshAlloc = &TypeDescriptor{Kind: "list", Transfer: true}
+var FreshAlloc = &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
 
 func (d *Declaration) IsForbidden() bool {
 	return d.Type != nil && d.Type.Forbidden
@@ -574,14 +596,14 @@ func Validate(val Scmer, require string) string {
 					def = def2
 				}
 			}
-				if def != nil {
-					if len(slice)-1 < def.MinParams() {
-						panic(source_info.String() + ": function " + def.Name + " expects at least " + fmt.Sprintf("%d", def.MinParams()) + " parameters")
-					}
-					if len(slice)-1 > def.MaxParams() {
-						panic(source_info.String() + ": function " + def.Name + " expects at most " + fmt.Sprintf("%d", def.MaxParams()) + " parameters")
-					}
+			if def != nil {
+				if len(slice)-1 < def.MinParams() {
+					panic(source_info.String() + ": function " + def.Name + " expects at least " + fmt.Sprintf("%d", def.MinParams()) + " parameters")
 				}
+				if len(slice)-1 > def.MaxParams() {
+					panic(source_info.String() + ": function " + def.Name + " expects at most " + fmt.Sprintf("%d", def.MaxParams()) + " parameters")
+				}
+			}
 			skipFirst := slice[0].IsSymbol() && (slice[0].SymbolEquals("lambda") || slice[0].SymbolEquals("parser"))
 			returntype := ""
 			for i := 1; i < len(slice); i++ {

--- a/scm/list.go
+++ b/scm/list.go
@@ -32,6 +32,478 @@ import "sync/atomic"
 import "github.com/carli2/hybridsort"
 import "github.com/jtolds/gls"
 
+func descriptorWithLength(td *TypeDescriptor, length int) *TypeDescriptor {
+	if td == nil {
+		td = &TypeDescriptor{}
+	}
+	out := *td
+	if length > 0 {
+		out.Length = length
+	} else {
+		out.Length = UnknownLength
+	}
+	return &out
+}
+
+func materializeCodeLiteral(expr Scmer) (Scmer, bool) {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if inner, ok := scmerSlice(expr); ok {
+		if len(inner) == 2 && scmerIsSymbol(inner[0], "quote") {
+			materialized, _ := materializeCodeLiteral(inner[1])
+			return materialized, true
+		}
+		if len(inner) == 2 && scmerIsSymbol(inner[0], "symbol") {
+			if sym, ok := scmerSymbol(inner[1]); ok {
+				return NewSymbol(string(sym)), true
+			}
+			if inner[1].IsString() {
+				return NewSymbol(inner[1].String()), true
+			}
+		}
+		out := make([]Scmer, len(inner))
+		changed := false
+		for i, item := range inner {
+			materialized, itemChanged := materializeCodeLiteral(item)
+			out[i] = materialized
+			changed = changed || itemChanged
+		}
+		if changed {
+			return NewSlice(out), true
+		}
+	}
+	return expr, false
+}
+
+func exactListLengthFromExpr(expr Scmer) int {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if inner, ok := scmerSlice(expr); ok {
+		if len(inner) == 0 {
+			return UnknownLength
+		}
+		if sym, ok := scmerSymbol(inner[0]); ok {
+			switch sym {
+			case "quote":
+				if len(inner) == 2 {
+					return exactListLengthFromExpr(inner[1])
+				}
+				return UnknownLength
+			case "!list":
+				if len(inner) >= 3 {
+					if count := int(ToInt(inner[2])); count >= 0 {
+						return count
+					}
+				}
+				return UnknownLength
+			case "list":
+				return len(inner) - 1
+			case "append", "append_mut":
+				if len(inner) < 2 {
+					return UnknownLength
+				}
+				baseLength := exactListLengthFromExpr(inner[1])
+				if baseLength >= 0 {
+					return baseLength + len(inner) - 2
+				}
+				return UnknownLength
+			case "cons":
+				if len(inner) == 3 {
+					tailLength := exactListLengthFromExpr(inner[2])
+					if tailLength >= 0 {
+						return tailLength + 1
+					}
+				}
+				return UnknownLength
+			case "map", "map_mut", "parallel_map", "parallel_map_mut", "mapIndex", "mapIndex_mut", "reverse", "reverse_mut":
+				if len(inner) >= 2 {
+					return exactListLengthFromExpr(inner[1])
+				}
+				return UnknownLength
+			case "cdr":
+				if len(inner) == 2 {
+					sourceLen := exactListLengthFromExpr(inner[1])
+					if sourceLen >= 0 {
+						return sourceLen - 1
+					}
+				}
+				return UnknownLength
+			case "produceN", "produceN_mut", "parallelN", "parallelN_mut":
+				if len(inner) >= 2 {
+					if count := int(ToInt(inner[1])); count >= 0 {
+						return count
+					}
+				}
+				return UnknownLength
+			case "merge":
+				if len(inner) == 2 {
+					arg := inner[1]
+					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
+						total := 0
+						for _, item := range outer[1:] {
+							itemLen := exactListLengthFromExpr(item)
+							if itemLen < 0 {
+								return UnknownLength
+							}
+							total += itemLen
+						}
+						return total
+					}
+					return UnknownLength
+				}
+				total := 0
+				for _, arg := range inner[1:] {
+					itemLen := exactListLengthFromExpr(arg)
+					if itemLen < 0 {
+						return UnknownLength
+					}
+					total += itemLen
+				}
+				return total
+			case "extract_assoc", "extract_assoc_mut":
+				if len(inner) >= 2 {
+					return exactAssocLengthFromExpr(inner[1])
+				}
+				return UnknownLength
+			case "zip":
+				if len(inner) == 2 {
+					arg := inner[1]
+					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
+						expected := UnknownLength
+						for _, item := range outer[1:] {
+							itemLen := exactListLengthFromExpr(item)
+							if itemLen < 0 {
+								return UnknownLength
+							}
+							if expected == UnknownLength {
+								expected = itemLen
+								continue
+							}
+							if itemLen != expected {
+								return UnknownLength
+							}
+						}
+						return expected
+					}
+					return UnknownLength
+				}
+				minLen := UnknownLength
+				for _, arg := range inner[1:] {
+					itemLen := exactListLengthFromExpr(arg)
+					if itemLen < 0 {
+						return UnknownLength
+					}
+					if minLen == UnknownLength || itemLen < minLen {
+						minLen = itemLen
+					}
+				}
+				return minLen
+			}
+			if decl := DeclarationForValue(inner[0]); decl != nil && decl.Type != nil && decl.Type.Return != nil && decl.Type.Return.Length > 0 {
+				return decl.Type.Return.Length
+			}
+			return UnknownLength
+		}
+		return len(inner)
+	}
+	return UnknownLength
+}
+
+func exactAssocLengthFromExpr(expr Scmer) int {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if inner, ok := scmerSlice(expr); ok {
+		if len(inner) == 0 {
+			return UnknownLength
+		}
+		if sym, ok := scmerSymbol(inner[0]); ok {
+			switch sym {
+			case "quote":
+				if len(inner) == 2 {
+					return exactAssocLengthFromExpr(inner[1])
+				}
+				return UnknownLength
+			case "!list":
+				if len(inner) >= 3 {
+					if count := int(ToInt(inner[2])); count >= 0 && count%2 == 0 {
+						return count / 2
+					}
+				}
+				return UnknownLength
+			case "list":
+				if (len(inner)-1)%2 == 0 {
+					return (len(inner) - 1) / 2
+				}
+				return UnknownLength
+			case "map_assoc", "map_assoc_mut":
+				if len(inner) >= 2 {
+					return exactAssocLengthFromExpr(inner[1])
+				}
+				return UnknownLength
+			case "set_assoc", "set_assoc_mut":
+				if len(inner) >= 4 {
+					sourceLen := exactAssocLengthFromExpr(inner[1])
+					_ = sourceLen
+				}
+				return UnknownLength
+			}
+			if decl := DeclarationForValue(inner[0]); decl != nil && decl.Type != nil && decl.Type.Return != nil && decl.Type.Return.Length > 0 {
+				return decl.Type.Return.Length
+			}
+		}
+	}
+	return UnknownLength
+}
+
+func optimizedExactListLength(expr Scmer, oc *OptimizerContext) int {
+	optimized, ti := OptimizeEx(expr, oc.Env, oc.Ome, true)
+	if length := ti.Length(); length > 0 {
+		return length
+	}
+	if length := exactListLengthFromExpr(optimized); length >= 0 {
+		return length
+	}
+	if materialized, changed := materializeCodeLiteral(expr); changed {
+		materializedOptimized, _ := OptimizeEx(materialized, oc.Env, oc.Ome, true)
+		if length := exactListLengthFromExpr(materializedOptimized); length >= 0 {
+			return length
+		}
+		return exactListLengthFromExpr(materialized)
+	}
+	return exactListLengthFromExpr(expr)
+}
+
+func optimizedExactAssocLength(expr Scmer, oc *OptimizerContext) int {
+	optimized, ti := OptimizeEx(expr, oc.Env, oc.Ome, true)
+	if length := ti.Length(); length > 0 {
+		return length
+	}
+	if length := exactAssocLengthFromExpr(optimized); length >= 0 {
+		return length
+	}
+	if materialized, changed := materializeCodeLiteral(expr); changed {
+		materializedOptimized, _ := OptimizeEx(materialized, oc.Env, oc.Ome, true)
+		if length := exactAssocLengthFromExpr(materializedOptimized); length >= 0 {
+			return length
+		}
+		return exactAssocLengthFromExpr(materialized)
+	}
+	return exactAssocLengthFromExpr(expr)
+}
+
+func lambdaBodyResultExpr(expr Scmer) (Scmer, bool) {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	inner, ok := scmerSlice(expr)
+	if !ok || len(inner) < 3 || !scmerIsSymbol(inner[0], "lambda") {
+		return NewNil(), false
+	}
+	body := inner[2]
+	if stripped, ok := scmerStripSourceInfo(body); ok {
+		body = stripped
+	}
+	if bodySlice, ok := scmerSlice(body); ok && len(bodySlice) > 0 && (scmerIsSymbol(bodySlice[0], "begin") || scmerIsSymbol(bodySlice[0], "!begin")) {
+		if len(bodySlice) == 1 {
+			return NewNil(), true
+		}
+		return bodySlice[len(bodySlice)-1], true
+	}
+	return body, true
+}
+
+func exactCallbackListLength(expr Scmer, oc *OptimizerContext) int {
+	if body, ok := lambdaBodyResultExpr(expr); ok {
+		return optimizedExactListLength(body, oc)
+	}
+	if decl := DeclarationForValue(expr); decl != nil && decl.Type != nil && decl.Type.Return != nil && decl.Type.Return.Length > 0 {
+		return decl.Type.Return.Length
+	}
+	return UnknownLength
+}
+
+func exactFlattenedMergeLength(expr Scmer, oc *OptimizerContext) int {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	inner, ok := scmerSlice(expr)
+	if !ok || len(inner) == 0 {
+		return UnknownLength
+	}
+	if sym, ok := scmerSymbol(inner[0]); ok {
+		switch sym {
+		case "quote":
+			if len(inner) == 2 {
+				return exactFlattenedMergeLength(inner[1], oc)
+			}
+			return UnknownLength
+		case "list":
+			total := 0
+			for _, item := range inner[1:] {
+				itemLen := optimizedExactListLength(item, oc)
+				if itemLen < 0 {
+					return UnknownLength
+				}
+				total += itemLen
+			}
+			return total
+		case "map", "map_mut", "parallel_map", "parallel_map_mut", "mapIndex", "mapIndex_mut":
+			if len(inner) >= 3 {
+				inputLen := optimizedExactListLength(inner[1], oc)
+				itemLen := exactCallbackListLength(inner[2], oc)
+				if inputLen >= 0 && itemLen >= 0 {
+					return inputLen * itemLen
+				}
+			}
+			return UnknownLength
+		case "extract_assoc", "extract_assoc_mut":
+			if len(inner) >= 3 {
+				inputLen := optimizedExactAssocLength(inner[1], oc)
+				itemLen := exactCallbackListLength(inner[2], oc)
+				if inputLen >= 0 && itemLen >= 0 {
+					return inputLen * itemLen
+				}
+			}
+			return UnknownLength
+		case "produceN", "produceN_mut", "parallelN", "parallelN_mut":
+			if len(inner) >= 3 {
+				if count := int(ToInt(inner[1])); count >= 0 {
+					itemLen := exactCallbackListLength(inner[2], oc)
+					if itemLen >= 0 {
+						return count * itemLen
+					}
+				}
+			}
+			return UnknownLength
+		case "merge":
+			return optimizedExactListLength(expr, oc)
+		}
+	}
+	return UnknownLength
+}
+
+func exprMayHaveSideEffects(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	inner, ok := scmerSlice(expr)
+	if !ok || len(inner) == 0 {
+		return false
+	}
+	if decl := DeclarationForValue(inner[0]); decl != nil && decl.Type != nil && decl.Type.HasSideEffects {
+		return true
+	}
+	for _, part := range inner[1:] {
+		if exprMayHaveSideEffects(part) {
+			return true
+		}
+	}
+	return false
+}
+
+func optimizeListCall(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	return result, descriptorWithLength(td, len(v)-1)
+}
+
+func optimizeCount(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	if len(v) == 2 && !exprMayHaveSideEffects(v[1]) {
+		if length := optimizedExactListLength(v[1], oc); length >= 0 {
+			return NewInt(int64(length)), &TypeDescriptor{Kind: "int", Transfer: true, Const: true, Length: UnknownLength}
+		}
+	}
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	if rv, ok := scmerSlice(result); ok && len(rv) == 2 {
+		if length := optimizedExactListLength(rv[1], oc); length >= 0 && !exprMayHaveSideEffects(rv[1]) {
+			return NewInt(int64(length)), &TypeDescriptor{Kind: "int", Transfer: true, Const: true, Length: UnknownLength}
+		}
+	}
+	return result, td
+}
+
+func optimizeFixedLengthInput(mutName string) func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	return func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+		result, td := oc.applyDefaultOptimization(v, useResult, mutName)
+		if rv, ok := scmerSlice(result); ok && len(rv) >= 2 {
+			return result, descriptorWithLength(td, optimizedExactListLength(rv[1], oc))
+		}
+		return result, td
+	}
+}
+
+func optimizeAssocFixedLengthInput(mutName string) func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	return func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+		result, td := oc.applyDefaultOptimization(v, useResult, mutName)
+		if rv, ok := scmerSlice(result); ok && len(rv) >= 2 {
+			return result, descriptorWithLength(td, optimizedExactAssocLength(rv[1], oc))
+		}
+		return result, td
+	}
+}
+
+func optimizeExtractAssoc(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.applyDefaultOptimization(v, useResult, "extract_assoc_mut")
+	if rv, ok := scmerSlice(result); ok && len(rv) >= 2 {
+		return result, descriptorWithLength(td, optimizedExactAssocLength(rv[1], oc))
+	}
+	return result, td
+}
+
+func optimizeCdr(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	if rv, ok := scmerSlice(result); ok && len(rv) == 2 {
+		if length := optimizedExactListLength(rv[1], oc); length >= 0 {
+			return result, descriptorWithLength(td, length-1)
+		}
+	}
+	return result, td
+}
+
+func optimizeZip(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) < 2 {
+		return result, td
+	}
+	if len(rv) == 2 {
+		argExpr := rv[1]
+		if argList, ok := scmerSlice(argExpr); ok && len(argList) > 0 {
+			expected := UnknownLength
+			for _, item := range argList[1:] {
+				itemLen := optimizedExactListLength(item, oc)
+				if itemLen < 0 {
+					return result, td
+				}
+				if expected == UnknownLength {
+					expected = itemLen
+					continue
+				}
+				if itemLen != expected {
+					return result, td
+				}
+			}
+			if expected > 0 {
+				return result, descriptorWithLength(td, expected)
+			}
+		}
+		return result, td
+	}
+	minLen := UnknownLength
+	for _, arg := range rv[1:] {
+		length := optimizedExactListLength(arg, oc)
+		if length < 0 {
+			return result, td
+		}
+		if minLen == UnknownLength || length < minLen {
+			minLen = length
+		}
+	}
+	return result, descriptorWithLength(td, minLen)
+}
+
 // optimizeMap is the optimizer hook for `map`. It applies default optimization
 // (including FirstParameterMutable swap to map_mut), then fuses
 // (map (produceN N) fn) → (produceN N fn) to eliminate the intermediate list.
@@ -49,12 +521,18 @@ func optimizeMap(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeD
 					if len(inner) == 2 {
 						if isym, ok := scmerSymbol(inner[0]); ok && isym == "produceN" {
 							// Fuse: (map (produceN N) fn) → (produceN N fn)
+							if count := int(ToInt(inner[1])); count > 0 {
+								return NewSlice([]Scmer{inner[0], inner[1], rv[2]}), descriptorWithLength(td, count)
+							}
 							return NewSlice([]Scmer{inner[0], inner[1], rv[2]}), td
 						}
 					}
 				}
 			}
 		}
+	}
+	if rv, ok := scmerSlice(result); ok && len(rv) == 3 {
+		return result, descriptorWithLength(td, optimizedExactListLength(rv[1], oc))
 	}
 	return result, td
 }
@@ -63,15 +541,21 @@ func optimizeMap(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeD
 // result is unused, so runtime can avoid result allocation.
 func optimizeProduceN(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	length := UnknownLength
+	if len(v) >= 2 {
+		if count := int(ToInt(v[1])); count > 0 {
+			length = count
+		}
+	}
 	if useResult || !result.IsSlice() {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	rv := result.Slice()
 	if len(rv) < 2 {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	if sym, ok := scmerSymbol(rv[0]); !ok || sym != "produceN" {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	out := make([]Scmer, 0, len(rv)+1)
 	out = append(out, NewSymbol("produceN_mut"))
@@ -79,22 +563,28 @@ func optimizeProduceN(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *
 	if len(rv) == 2 {
 		out = append(out, NewNil())
 	}
-	return NewSlice(out), &TypeDescriptor{}
+	return NewSlice(out), descriptorWithLength(&TypeDescriptor{}, length)
 }
 
 // optimizeParallelN rewrites (parallelN ...) to (parallelN_mut ... nil) when
 // the result is unused, so runtime can avoid result allocation.
 func optimizeParallelN(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	length := UnknownLength
+	if len(v) >= 2 {
+		if count := int(ToInt(v[1])); count > 0 {
+			length = count
+		}
+	}
 	if useResult || !result.IsSlice() {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	rv := result.Slice()
 	if len(rv) < 3 {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	if sym, ok := scmerSymbol(rv[0]); !ok || sym != "parallelN" {
-		return result, td
+		return result, descriptorWithLength(td, length)
 	}
 	out := make([]Scmer, 0, len(rv)+1)
 	out = append(out, NewSymbol("parallelN_mut"))
@@ -102,7 +592,7 @@ func optimizeParallelN(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, 
 	if len(rv) == 3 {
 		out = append(out, NewNil())
 	}
-	return NewSlice(out), &TypeDescriptor{}
+	return NewSlice(out), descriptorWithLength(&TypeDescriptor{}, length)
 }
 
 func asSlice(v Scmer, ctx string) []Scmer {
@@ -144,8 +634,9 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "items", ParamDesc: "items to put into the list", Variadic: true},
 			},
-			Return: &TypeDescriptor{Kind: "list"},
-			Const:  true,
+			Return:   &TypeDescriptor{Kind: "list", Length: UnknownLength},
+			Const:    true,
+			Optimize: optimizeListCall,
 		},
 	})
 
@@ -169,8 +660,9 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", ParamName: "list", ParamDesc: "base list", NoEscape: true},
 			},
-			Return: &TypeDescriptor{Kind: "int"},
-			Const:  true,
+			Return:   &TypeDescriptor{Kind: "int"},
+			Const:    true,
+			Optimize: optimizeCount,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -264,7 +756,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("reverse_mut"),
+			Optimize: optimizeFixedLengthInput("reverse_mut"),
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -282,7 +774,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("append_mut"),
+			Optimize: optimizeAppend,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -364,8 +856,9 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", ParamName: "list", ParamDesc: "list", NoEscape: true},
 			},
-			Return: FreshAlloc,
-			Const:  true,
+			Return:   FreshAlloc,
+			Const:    true,
+			Optimize: optimizeCdr,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -417,8 +910,9 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "list", ParamDesc: "list of lists of items", NoEscape: true, Variadic: true},
 			},
-			Return: FreshAlloc,
-			Const:  true,
+			Return:   FreshAlloc,
+			Const:    true,
+			Optimize: optimizeZip,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -637,7 +1131,7 @@ func init_list() {
 				{Kind: "func", ParamName: "fn", ParamDesc: "function applied to each element", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
-			Optimize: FirstParameterMutable("parallel_map_mut"),
+			Optimize: optimizeFixedLengthInput("parallel_map_mut"),
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -718,7 +1212,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("mapIndex_mut"),
+			Optimize: optimizeFixedLengthInput("mapIndex_mut"),
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1166,7 +1660,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("map_assoc_mut"),
+			Optimize: optimizeAssocFixedLengthInput("map_assoc_mut"),
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1283,7 +1777,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("extract_assoc_mut"),
+			Optimize: optimizeExtractAssoc,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1832,9 +2326,86 @@ func init_list() {
 	})
 }
 
-// optimizeMerge currently only runs the standard optimization pipeline.
+func optimizeAppend(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.applyDefaultOptimization(v, useResult, "append_mut")
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) < 2 {
+		return result, td
+	}
+	baseLength := optimizedExactListLength(rv[1], oc)
+	if baseLength >= 0 {
+		td = descriptorWithLength(td, baseLength+len(rv)-2)
+	}
+	if len(rv) > 2 {
+		if base, ok := scmerSlice(rv[1]); ok && len(base) > 0 && scmerIsSymbol(base[0], "list") {
+			merged := make([]Scmer, 0, len(base)+len(rv)-2)
+			merged = append(merged, NewSymbol("list"))
+			merged = append(merged, base[1:]...)
+			merged = append(merged, rv[2:]...)
+			return NewSlice(merged), descriptorWithLength(FreshAlloc, len(merged)-1)
+		}
+	}
+	return result, td
+}
+
+// optimizeMerge keeps the standard optimization pipeline, then uses exact
+// positive list lengths to annotate the flattened result and collapse direct
+// list-of-items merges into a single list constructor.
 func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
-	return oc.ApplyDefaultOptimization(v, useResult)
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) < 2 {
+		return result, td
+	}
+	if len(rv) == 2 {
+		if outer, ok := scmerSlice(rv[1]); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
+			merged := make([]Scmer, 0, len(outer)+1)
+			merged = append(merged, NewSymbol("list"))
+			allDirectListItems := true
+			for _, item := range outer[1:] {
+				itemSlice, ok := scmerSlice(item)
+				if !ok || len(itemSlice) == 0 || !scmerIsSymbol(itemSlice[0], "list") {
+					allDirectListItems = false
+					break
+				}
+				merged = append(merged, itemSlice[1:]...)
+			}
+			if allDirectListItems {
+				return NewSlice(merged), descriptorWithLength(FreshAlloc, len(merged)-1)
+			}
+		}
+		if totalLength := exactFlattenedMergeLength(rv[1], oc); totalLength > 0 {
+			return result, descriptorWithLength(td, totalLength)
+		}
+		return result, td
+	}
+	totalLength := 0
+	allExact := len(rv) > 2
+	allDirectListArgs := len(rv) > 2
+	for _, arg := range rv[1:] {
+		length := optimizedExactListLength(arg, oc)
+		if length >= 0 {
+			totalLength += length
+		} else {
+			allExact = false
+		}
+		inner, ok := scmerSlice(arg)
+		if !ok || len(inner) == 0 || !scmerIsSymbol(inner[0], "list") {
+			allDirectListArgs = false
+		}
+	}
+	if allDirectListArgs {
+		merged := make([]Scmer, 0, totalLength+1)
+		merged = append(merged, NewSymbol("list"))
+		for _, arg := range rv[1:] {
+			merged = append(merged, arg.Slice()[1:]...)
+		}
+		return NewSlice(merged), descriptorWithLength(FreshAlloc, len(merged)-1)
+	}
+	if allExact {
+		return result, descriptorWithLength(td, totalLength)
+	}
+	return result, td
 }
 
 // optimizeMergeUnique keeps merge_unique on the standard variadic path, but
@@ -1885,8 +2456,11 @@ func optimizeCons(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Type
 				merged = append(merged, NewSymbol("list"))
 				merged = append(merged, rSlice[1])    // head
 				merged = append(merged, inner[1:]...) // tail items
-				return NewSlice(merged), FreshAlloc
+				return NewSlice(merged), descriptorWithLength(FreshAlloc, len(merged)-1)
 			}
+		}
+		if tailLength := optimizedExactListLength(tail, oc); tailLength >= 0 {
+			return result, descriptorWithLength(td, tailLength+1)
 		}
 	}
 	return result, td

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -393,15 +393,15 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 
 	switch val.GetTag() {
 	case tagNil:
-		return val, TypeInfo{kind: KindNil, flags: FlagTransfer | FlagConst}
+		return val, TypeInfo{kind: KindNil, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagBool:
-		return val, TypeInfo{kind: KindBool, flags: FlagTransfer | FlagConst}
+		return val, TypeInfo{kind: KindBool, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagInt:
-		return val, TypeInfo{kind: KindInt, flags: FlagTransfer | FlagConst}
+		return val, TypeInfo{kind: KindInt, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagFloat:
-		return val, TypeInfo{kind: KindFloat, flags: FlagTransfer | FlagConst}
+		return val, TypeInfo{kind: KindFloat, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagString:
-		return val, TypeInfo{kind: KindString, flags: FlagTransfer | FlagConst}
+		return val, TypeInfo{kind: KindString, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagSymbol:
 		sym := mustSymbol(val)
 		if replacement, ok := ome.variableReplacement[sym]; ok {
@@ -460,9 +460,9 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 
 // Common TypeInfo values (stack-allocated, no heap)
 var (
-	tiConstTransfer = TypeInfo{flags: FlagTransfer | FlagConst}
-	tiTransfer      = TypeInfo{flags: FlagTransfer}
-	tiZero          = TypeInfo{}
+	tiConstTransfer = TypeInfo{flags: FlagTransfer | FlagConst, length: UnknownLength}
+	tiTransfer      = TypeInfo{flags: FlagTransfer, length: UnknownLength}
+	tiZero          = TypeInfo{length: UnknownLength}
 )
 
 // optimizeExCompat is a temporary bridge: calls OptimizeEx and unpacks TypeInfo
@@ -1097,11 +1097,11 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 			}
 			result := d.Fn(v[1:]...)
 			result = wrapConstListForCode(result)
-			td := &TypeDescriptor{Transfer: true, Const: true}
+			td := &TypeDescriptor{Transfer: true, Const: true, Length: UnknownLength}
 			if d.Type != nil && d.Type.Return != nil {
 				td = &TypeDescriptor{Transfer: true, Const: true, Kind: d.Type.Return.Kind,
 					Params: d.Type.Return.Params, Return: d.Type.Return.Return,
-					HasSideEffects: d.Type.Return.HasSideEffects}
+					HasSideEffects: d.Type.Return.HasSideEffects, Length: d.Type.Return.Length}
 			}
 			return result, td
 		}
@@ -1113,9 +1113,12 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 	td := &TypeDescriptor{Transfer: transferOwnership}
 	if retTD != nil {
 		td.Kind = retTD.Kind
+		td.Length = retTD.Length
 		td.Params = retTD.Params
 		td.Return = retTD.Return
 		td.HasSideEffects = retTD.HasSideEffects
+	} else {
+		td.Length = UnknownLength
 	}
 	return NewSlice(v), td
 }


### PR DESCRIPTION
## Summary
- add exact list/assoc length metadata to optimizer type descriptors
- propagate exact lengths through the hot list producers used by queryplan
- use the new length facts to fold `count` and improve `merge`/`append`/`cdr`/`zip` planning

## Details
This keeps the work focused on patterns that actually show up in `lib/queryplan.scm`: `append`, `merge`, `map`, `produceN`, `parallelN`, `extract_assoc`, and `zip`.

The branch adds exact-length propagation for those producers, plus targeted flatten-length inference for `merge` over fixed-width callbacks. It also extends the unit coverage in `lib/test.scm` with the new exact-length cases.

## Verification
- `python3 tools/lint_scm.py --check --path lib/test.scm`
- `go build -o memcp`
- `timeout 90 ./memcp --no-repl lib/main.scm`
- `python3 run_sql_tests.py tests/01_basic_sql.yaml`
- `make test`
