### PR TITLE
[codex] Migrate scan callsites to tx/table interface

### DIFF
--- a/storage/compute.go
+++ b/storage/compute.go
@@ -1454,7 +1454,7 @@ func buildIncrementalBody(targetSchema, targetTable, colName string, srcCols, in
 
 // buildInvalidateScan builds a scan expression that walks the keytable, matches rows
 // by join key values from a trigger dict (OLD or NEW), and invokes $invalidate: closures.
-// Pattern: (scan targetSchema targetTable '("inputCol1" ...) (lambda (kt.col ...) (and (equal? kt.col (get_assoc dictSym "srcCol")) ...)) '("$invalidate:colName") (lambda ($inv) ($inv)) + 0 nil false)
+// Pattern: (scan nil (table targetSchema targetTable) '("inputCol1" ...) (lambda (kt.col ...) (and (equal? kt.col (get_assoc dictSym "srcCol")) ...)) '("$invalidate:colName") (lambda ($inv) ($inv)) + 0 nil false)
 func buildInvalidateScan(targetSchema, targetTable, colName string, srcCols, inputCols []string, dictSym string) scm.Scmer {
 	// Build filter column list: '("inputCol1" "inputCol2" ...)
 	filterColElems := make([]scm.Scmer, 1+len(inputCols))

--- a/storage/compute_concurrency_test.go
+++ b/storage/compute_concurrency_test.go
@@ -73,8 +73,8 @@ func countCollapsedComputor() scm.Scmer {
 		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("group")}),
 		Body: scm.NewSlice([]scm.Scmer{
 			scm.NewSymbol("scan"),
-			scm.NewString("compconc"),
-			scm.NewString("feature"),
+			scm.NewNil(),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString("compconc"), scm.NewString("feature")}),
 			scm.NewSlice([]scm.Scmer{
 				scm.NewSymbol("list"),
 				scm.NewString("uid"),

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1629,7 +1629,7 @@ func Init(en scm.Env) {
 				return result
 			}
 
-			// Build count-scan: (scan base_schema base_table (list base_cols...) (lambda (tblvar.col...) (and (equal? tblvar.col (get_assoc OLD "col")) ...)) () (lambda () 1) + 0 nil)
+			// Build count-scan: (scan (session) (table base_schema base_table) (list base_cols...) (lambda (tblvar.col...) (and (equal? tblvar.col (get_assoc OLD "col")) ...)) () (lambda () 1) + 0 nil)
 			buildCountScan := func(dictSym string) scm.Scmer {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),
@@ -1644,7 +1644,7 @@ func Init(en scm.Env) {
 				})
 			}
 
-			// Build delete-scan: (scan kt_schema kt_name (list kt_cols...) (lambda (kt.col...) (and (equal? kt.col (get_assoc OLD "base_col")) ...)) (list "$update") (lambda ($update) ($update)) + 0 nil)
+			// Build delete-scan: (scan (session) (table kt_schema kt_name) (list kt_cols...) (lambda (kt.col...) (and (equal? kt.col (get_assoc OLD "base_col")) ...)) (list "$update") (lambda ($update) ($update)) + 0 nil)
 			buildDeleteScan := func(dictSym string) scm.Scmer {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),

--- a/storage/trigger_vectorize.go
+++ b/storage/trigger_vectorize.go
@@ -24,7 +24,7 @@ import "github.com/launix-de/memcp/scm"
 //
 // Currently recognizes the prejoin DELETE pattern:
 //
-//	(lambda (OLD NEW) (scan schema tbl condCols
+//	(lambda (OLD NEW) (scan nil (table schema tbl) condCols
 //	    (lambda (cols...) (equal? col (get_assoc OLD key)))
 //	    (list "$update") (lambda ($update) ($update)) + 0 nil false))
 //
@@ -32,7 +32,7 @@ import "github.com/launix-de/memcp/scm"
 //
 //	(lambda (OLD_batch NEW_batch)
 //	    (define vals (map OLD_batch (lambda (OLD) (get_assoc OLD key))))
-//	    (scan schema tbl condCols
+//	    (scan nil (table schema tbl) condCols
 //	        (lambda (cols...) (has? vals col))
 //	        (list "$update") (lambda ($update) ($update)) + 0 nil false))
 func VectorizeTrigger(triggerFn scm.Scmer) scm.Scmer {
@@ -56,7 +56,7 @@ func VectorizeTrigger(triggerFn scm.Scmer) scm.Scmer {
 	if len(items) < 5 {
 		return scm.NewNil()
 	}
-	// Check for (scan schema tbl condCols filterFn ...)
+	// Check for (scan tx table condCols filterFn ...)
 	// Handle both symbol "scan" and resolved tagFunc references.
 	headName := ""
 	if items[0].IsSymbol() {

--- a/storage/trigger_vectorize_test.go
+++ b/storage/trigger_vectorize_test.go
@@ -25,7 +25,7 @@ import (
 // TestVectorizeTriggerDeletePattern tests that the DELETE trigger pattern is recognized.
 func TestVectorizeTriggerDeletePattern(t *testing.T) {
 	// Build a trigger body that matches the prejoin DELETE pattern:
-	// (lambda (OLD NEW) (scan schema tbl (list "grp") (lambda (_pj.grp) (equal? _pj.grp (get_assoc OLD "grp"))) (list "$update") (lambda ($update) ($update)) + 0 nil false))
+	// (lambda (OLD NEW) (scan nil (table schema tbl) (list "grp") (lambda (_pj.grp) (equal? _pj.grp (get_assoc OLD "grp"))) (list "$update") (lambda ($update) ($update)) + 0 nil false))
 	filterBody := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),
 		scm.NewSymbol("_pj.grp"),
@@ -43,8 +43,8 @@ func TestVectorizeTriggerDeletePattern(t *testing.T) {
 
 	scanBody := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("scan"),
-		scm.NewString("mydb"),
-		scm.NewString(".prejoin:mytable"),
+		scm.NewNil(),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString("mydb"), scm.NewString(".prejoin:mytable")}),
 		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString("grp")}),
 		filterFn,
 		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString("$update")}),


### PR DESCRIPTION
## What changed
- updated the remaining Go-side `scan` AST callsites to use the current `scan tx table ...` signature
- switched the affected tests from raw schema/table strings to `nil`/`(table ...)`
- aligned nearby comments in storage/trigger helpers with the new interface so the documented shape matches the emitted AST

## Why
The `scan` builtin now expects a transaction argument followed by a table handle. A few Go-generated test/build helper callsites still emitted the legacy schema/table string form, which left a partially migrated codebase.

## User and developer impact
- the stale callsites no longer panic when they exercise `scan`
- the concurrency/vectorization tests now cover the same interface shape as production code
- comments around generated `scan` expressions now match the runtime contract

## Root cause
The `scan` interface migration was incomplete: some Go-side AST builders were updated, but a small set of older builders/tests still constructed `(scan "schema" "table" ...)` expressions.

## Validation
- `go test ./storage -run 'TestGlobalAggregateComputeAndInsertDoNotDeadlock|TestComputeTriggersGuardRelevantSourceColumns|TestTriggerVectorization'`
- `make test`
