### PR TITLE
Tune Eval dispatch order for optimized code paths

### DIFF
--- a/scm/scm.go
+++ b/scm/scm.go
@@ -496,6 +496,12 @@ restart:
 		default:
 			panic("Unknown function: " + list[0].String())
 		}
+	case tagFunc, tagFuncEnv, tagProc, tagJIT, tagClosure, tagPromise:
+		// Optimizer-resolved native callables.
+		return expression
+	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector, tagFastDict, tagParser, tagAny:
+		// Self-evaluating literals.
+		return expression
 	case tagNthLocalVar:
 		// Optimized lambda bodies resolve locals directly through numbered slots.
 		idx := int(expression.NthLocalVar())
@@ -505,9 +511,6 @@ restart:
 			panic(fmt.Sprintf("NthLocalVar(%d) out of range (len=%d)\n%s", idx, len(en.VarsNumbered), buf[:n]))
 		}
 		return en.VarsNumbered[idx]
-	case tagFunc, tagFuncEnv, tagProc, tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector, tagFastDict, tagParser, tagJIT, tagClosure, tagPromise, tagAny:
-		// Self-evaluating literals and optimizer-resolved native callables.
-		return expression
 	case tagSymbol:
 		// Fallback for names not folded to numbered vars/native funcs by the optimizer.
 		return en.FindRead(mustSymbol(expression)).Vars[mustSymbol(expression)]

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -101,25 +101,8 @@ func evalWithSourceInfo(si SourceInfo, en *Env) (value Scmer) {
 func Eval(expression Scmer, en *Env) (value Scmer) {
 restart:
 	switch expression.GetTag() {
-	case tagSourceInfo:
-		return evalWithSourceInfo(*expression.SourceInfo(), en)
-	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector, tagFastDict, tagParser, tagAny, tagFunc, tagFuncEnv, tagProc, tagJIT, tagClosure, tagPromise:
-		// literals
-		return expression
-	case tagSymbol:
-		// get named variable
-		return en.FindRead(mustSymbol(expression)).Vars[mustSymbol(expression)]
-	case tagNthLocalVar:
-		// get numbered variable
-		idx := int(expression.NthLocalVar())
-		if idx >= len(en.VarsNumbered) {
-			buf := make([]byte, 8192)
-			n := runtime.Stack(buf, false)
-			panic(fmt.Sprintf("NthLocalVar(%d) out of range (len=%d)\n%s", idx, len(en.VarsNumbered), buf[:n]))
-		}
-		return en.VarsNumbered[idx]
 	case tagSlice:
-		// slice -> function call
+		// Hot path: optimized queryplan/runtime code is dominated by call forms.
 		list := expression.Slice()
 		if len(list) == 0 {
 			return expression
@@ -416,6 +399,10 @@ restart:
 				args[i] = Eval(x, en)
 			}
 			return fn(args...)
+		case tagProc:
+			// Lambdas (procs)
+			en, expression = prepareProcCall(procedure.Proc(), operands, en)
+			goto restart
 		case tagFuncEnv:
 			// Native funcs with env
 			fn := procedure.FuncEnv()
@@ -431,10 +418,34 @@ restart:
 				args[i] = Eval(x, en)
 			}
 			return fn(en, args...)
-		case tagProc:
-			// Lambdas (procs)
-			en, expression = prepareProcCall(procedure.Proc(), operands, en)
-			goto restart
+		case tagClosure:
+			fn := *(*func(uint32, ...Scmer) Scmer)(unsafe.Pointer(procedure.ptr))
+			id := uint32(auxVal(procedure.aux))
+			if n := len(operands); n <= 4 {
+				var buf [4]Scmer
+				for i := 0; i < n; i++ {
+					buf[i] = Eval(operands[i], en)
+				}
+				return fn(id, buf[:n]...)
+			}
+			args := make([]Scmer, len(operands))
+			for i, x := range operands {
+				args[i] = Eval(x, en)
+			}
+			return fn(id, args...)
+		case tagPromise:
+			if n := len(operands); n <= 4 {
+				var buf [4]Scmer
+				for i := 0; i < n; i++ {
+					buf[i] = Eval(operands[i], en)
+				}
+				return ApplyPromise(procedure, buf[:n])
+			}
+			args := make([]Scmer, len(operands))
+			for i, x := range operands {
+				args[i] = Eval(x, en)
+			}
+			return ApplyPromise(procedure, args)
 		case tagSlice:
 			// Associative list
 			p := procedure.Slice()
@@ -482,37 +493,26 @@ restart:
 				args[i] = Eval(x, en)
 			}
 			return jep.Native(args...)
-		case tagClosure:
-			fn := *(*func(uint32, ...Scmer) Scmer)(unsafe.Pointer(procedure.ptr))
-			id := uint32(auxVal(procedure.aux))
-			if n := len(operands); n <= 4 {
-				var buf [4]Scmer
-				for i := 0; i < n; i++ {
-					buf[i] = Eval(operands[i], en)
-				}
-				return fn(id, buf[:n]...)
-			}
-			args := make([]Scmer, len(operands))
-			for i, x := range operands {
-				args[i] = Eval(x, en)
-			}
-			return fn(id, args...)
-		case tagPromise:
-			if n := len(operands); n <= 4 {
-				var buf [4]Scmer
-				for i := 0; i < n; i++ {
-					buf[i] = Eval(operands[i], en)
-				}
-				return ApplyPromise(procedure, buf[:n])
-			}
-			args := make([]Scmer, len(operands))
-			for i, x := range operands {
-				args[i] = Eval(x, en)
-			}
-			return ApplyPromise(procedure, args)
 		default:
 			panic("Unknown function: " + list[0].String())
 		}
+	case tagNthLocalVar:
+		// Optimized lambda bodies resolve locals directly through numbered slots.
+		idx := int(expression.NthLocalVar())
+		if idx >= len(en.VarsNumbered) {
+			buf := make([]byte, 8192)
+			n := runtime.Stack(buf, false)
+			panic(fmt.Sprintf("NthLocalVar(%d) out of range (len=%d)\n%s", idx, len(en.VarsNumbered), buf[:n]))
+		}
+		return en.VarsNumbered[idx]
+	case tagFunc, tagFuncEnv, tagProc, tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector, tagFastDict, tagParser, tagJIT, tagClosure, tagPromise, tagAny:
+		// Self-evaluating literals and optimizer-resolved native callables.
+		return expression
+	case tagSymbol:
+		// Fallback for names not folded to numbered vars/native funcs by the optimizer.
+		return en.FindRead(mustSymbol(expression)).Vars[mustSymbol(expression)]
+	case tagSourceInfo:
+		return evalWithSourceInfo(*expression.SourceInfo(), en)
 	default:
 		if expression.GetTag() >= 100 {
 			// custom tags (e.g. TagTable) are opaque literals


### PR DESCRIPTION
## What changed

This picks the benchmark-winning `Eval` dispatch order in `scm.Eval` for optimized query/runtime code:

`tagSlice -> native funcs -> constants -> tagNthLocalVar -> tagSymbol -> tagSourceInfo`

The important change from the earlier branch state is splitting native callables from constants and moving the callable tags in front of literal/self-evaluating tags. That matches the optimizer behavior in `lib/queryplan.scm`: known heads are folded to native callable tags, and local bindings are often lowered to `tagNthLocalVar`.

## Why

The earlier grouped order (`slice -> nth -> func+const -> symbol`) was not the winner on the representative SQL/queryplan workloads.

I compared four orders against `master` on selected suites:

- `func_const_nth`: `slice -> func -> const -> nth -> symbol`
- `func_nth_const`: `slice -> func -> nth -> const -> symbol`
- `nth_func_const`: `slice -> nth -> func -> const -> symbol`
- previous branch state: grouped `func+const`

Selected suite aggregate over repeated runs:

- `master`: mean `2.027s`
- `func_const_nth`: mean `1.502s`
- delta vs `master`: `-25.9%`

The grouped branch state was slightly worse than `master` overall on the same sample, so this PR now carries the actual benchmark winner.

## Query behavior

Representative queries kept the same `EXPLAIN`/`EXPLAIN IR` plan hashes across variants, so this change is affecting runtime dispatch cost rather than planner output.

Direct query medians vs `master`:

- scalar subquery pattern: `-1.5%`
- window `LEAD` pattern: `-6.0%`
- scan-batch join pattern: `+0.3%` (effectively flat)

That matches the intent here: prioritize execution-path wins over compile/planning time.

## Validation

- `go test ./scm`
- selected SQL suites used for A/B comparison:
  - `tests/13_subselects.yaml`
  - `tests/69_subquery_complex.yaml`
  - `tests/73_window_functions.yaml`
  - `tests/87_scan_batch_optimizer.yaml`
  - `tests/96_scalar_subselect_patterns.yaml`
- representative `EXPLAIN` comparisons on subquery/window/scan-batch queries
- `make test` was rerun and progressed cleanly through the suite until `tests/91_fulltext_like_index.yaml`; that suite's scan-stat query over accumulated `system_statistic.scans` stayed long-running, so I am not claiming a full green run from this session

## Impact

This keeps the optimizer-aligned hot tags in front of the generic fallback cases and improves execution time on the selected query-heavy workloads without changing the generated plans.