### PR TITLE
storage: scope ORC recompute sentinel to participating goroutines

### DIFF
--- a/scm/sync.go
+++ b/scm/sync.go
@@ -335,6 +335,16 @@ func SetValues(vals map[string]any, fn func()) {
 	mgr.SetValues(glsVals, fn)
 }
 
+// GetGLSValue returns the GLS value for a given key, or nil if no GLS context
+// is installed. Used by packages outside scm to read goroutine-local markers
+// that propagate across gls.Go-spawned worker goroutines.
+func GetGLSValue(key string) (any, bool) {
+	if mgr == nil {
+		return nil, false
+	}
+	return mgr.GetValue(key)
+}
+
 // WithSession executes fn with the given session installed in GLS,
 // so that GetCurrentTx() and other GLS-based lookups use this session.
 func WithSession(session Scmer, fn Scmer) Scmer {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -486,17 +486,42 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 		return newAcc
 	})
 
-	t.scan_order(
-		CurrentTx(),
-		condCols, condFn,
-		sortcolsScmer, sortdirsFns,
-		0, 0, -1,
-		scanCallbackCols,
-		scanMapFn,
-		scanReduceFn,
-		col.OrcReduceInit,
-		false,
-	)
+	// Install a GLS marker so worker goroutines spawned by scan_order can detect
+	// that they are participating in this table's recompute. Other goroutines
+	// reading the same ORC column concurrently must wait on orcMu instead of
+	// observing the transient nil-for-invalid-row sentinel that the reducer needs.
+	scm.SetValues(map[string]any{orcRecomputeMarkerKey: t}, func() {
+		t.scan_order(
+			CurrentTx(),
+			condCols, condFn,
+			sortcolsScmer, sortdirsFns,
+			0, 0, -1,
+			scanCallbackCols,
+			scanMapFn,
+			scanReduceFn,
+			col.OrcReduceInit,
+			false,
+		)
+	})
+}
+
+// orcRecomputeMarkerKey is the GLS key set by incrementalRecomputeORC so that
+// re-entrant GetValue calls (made by the reducer itself) can distinguish the
+// recompute scan from concurrent reader goroutines on the same table.
+const orcRecomputeMarkerKey = "orcRecomputingTable"
+
+// isCurrentORCRecompute reports whether the current goroutine is participating
+// in an in-progress ORC recompute for the given table.
+func isCurrentORCRecompute(t *table) bool {
+	v, ok := scm.GetGLSValue(orcRecomputeMarkerKey)
+	if !ok {
+		return false
+	}
+	other, ok := v.(*table)
+	if !ok {
+		return false
+	}
+	return other == t
 }
 
 // invalidateORCFromSortKey clears validMask bits for rows affected by a mutation.

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -375,9 +375,11 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	if p.isOrdered {
 		if !p.validMask.Get(uint(idx)) {
 			// During an active recompute (scan_order reading ORC values):
-			// Return nil for invalid rows (reducer uses nil to detect "needs compute").
-			// Return cached value for valid rows (enables Phase 1 skip + Phase 3 convergence).
-			if atomic.LoadInt32(&p.shard.t.orcRecomputing) > 0 {
+			// Only the goroutine(s) participating in this table's recompute may
+			// observe the transient nil-for-invalid-row sentinel that the reducer
+			// uses to detect "needs compute". Other concurrent readers must block
+			// on orcMu and re-read after the recompute publishes the values.
+			if atomic.LoadInt32(&p.shard.t.orcRecomputing) > 0 && isCurrentORCRecompute(p.shard.t) {
 				if p.validMask.Get(uint(idx)) {
 					// Valid row: return cached value for convergence check
 					p.mu.RLock()
@@ -390,9 +392,10 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 						return p.main.GetValue(idx)
 					}
 				}
-				return scm.NewNil() // invalid row
+				return scm.NewNil() // invalid row, observed from inside the recompute
 			}
-			// Invalid row → on-demand incremental recompute
+			// Invalid row → on-demand incremental recompute (or wait for the
+			// ongoing one to complete).
 			p.shard.t.orcMu.Lock()
 			if !p.validMask.Get(uint(idx)) {
 				p.shard.t.incrementalRecomputeORC(p.colName, p.shard, idx)


### PR DESCRIPTION
The \`orcRecomputing\` atomic flag was checked unconditionally in
\`StorageComputeProxy.GetValue\`, so any concurrent reader that hit an
invalid bit while another goroutine was inside \`incrementalRecomputeORC\`
received the nil "needs compute" sentinel instead of the real value.

Under parallel load this surfaced as the \`73_window_functions\` case 15b
RANK-NULL race: window functions returned NULL to unrelated parallel
readers during ORC recompute.

Fix: scope the sentinel via a GLS marker \`orcRecomputingTable\` so only
the participating goroutines see "needs compute"; everyone else reads
the current value normally.

Verified: \`tests/73_window_functions.yaml\` stays green under
\`MEMCP_TEST_JOBS=4\` parallel pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)