### PR TITLE
scm: panic on malformed reduce_assoc dictionaries

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -1670,6 +1670,9 @@ func init_list() {
 			result := a[2]
 			reduce := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "reduce_assoc"); fd == nil {
+				if len(slice)%2 != 0 {
+					panic(fmt.Sprintf("reduce_assoc received odd-length dict (%d): %s", len(slice), SerializeToString(a[0], &Globalenv)))
+				}
 				for i := 0; i < len(slice); i += 2 {
 					result = reduce(result, slice[i], slice[i+1])
 				}


### PR DESCRIPTION
Defensive runtime check in \`reduce_assoc\`: when the dictionary
argument is malformed (not a flat assoc list with stride-2 layout),
panic loudly instead of silently iterating past the end and producing
wrong results.

Surfaces planner-emitted bugs that would otherwise be silent — e.g.
wrong-shape dicts that read past the array bound and return arbitrary
values from neighbouring memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)