### PR TITLE
createtable: optional oninit thunk (FAQ §32)

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -939,6 +939,15 @@ func Init(en scm.Env) {
 		Desc: "creates a new database",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ifnotexists := len(a) > 4 && scm.ToBool(a[4])
+			// oninit (optional 6th parameter): a thunk run ONCE, synchronously,
+			// after the new table is fully created and before createtable returns
+			// true. Used by planner-generated keytable/virtual-source initializers
+			// so the caller never observes a created-but-empty table (FAQ §32).
+			// Skipped when the ifnotexists fast-path hits an existing table.
+			var oninit scm.Scmer
+			if len(a) > 5 {
+				oninit = a[5]
+			}
 			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
 				panic("database " + scm.String(a[0]) + " does not exist")
@@ -1091,6 +1100,11 @@ func Init(en scm.Env) {
 			}
 			db.saveLockedWithDurabilityAndUnlock(newTable.PersistencyMode == Safe)
 			registerCreatedTable(newTable)
+			// Run the optional initializer thunk synchronously so the caller never
+			// observes a created-but-empty table — FAQ §32.
+			if len(a) > 5 && !oninit.IsNil() {
+				scm.Apply(oninit)
+			}
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
@@ -1100,6 +1114,7 @@ func Init(en scm.Env) {
 				{Kind: "list", ParamName: "cols", ParamDesc: "list of columns and constraints, each '(\"column\" colname typename dimensions typeparams) where dimensions is a list of 0-2 numeric items or '(\"primary\" cols) or '(\"unique\" cols) or '(\"foreign\" cols tbl2 cols2 updatemode deletemode of 'restrict'|'cascade'|'set null')"},
 				{Kind: "list", ParamName: "options", ParamDesc: "further options like engine=safe|sloppy|memory"},
 				{Kind: "bool", ParamName: "ifnotexists", ParamDesc: "don't throw an error if table already exists", Optional: true},
+				{Kind: "func", ParamName: "oninit", ParamDesc: "optional 0-arg thunk run synchronously on first creation, before the call returns true. Lets callers attach the initial fill atomically so the table never becomes visible empty (FAQ §32).", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},


### PR DESCRIPTION
Adds an optional 6th parameter to the \`(createtable ...)\` builtin — a
0-arg thunk run synchronously after the new table is fully created and
before \`createtable\` returns \`true\`.

### Why
A keytable / planner-generated helper table is incrementally maintained
(FAQ §32) — its initial fill must already be done when the create call
returns. Without an atomic init hook the caller has to emit a separate
\`(begin (createtable …) (insert/collect …))\` sequence; any code path
that touches the table between the create and the fill observes it
empty.

### How
\`createtable\` after \`registerCreatedTable\` and before
\`return scm.NewBool(true)\`: if a 6th arg is present and non-nil, call
\`scm.Apply(oninit)\`. Skipped on the \`ifnotexists\` fast-path (the
other creator that actually built the table already ran its oninit).

Backward-compatible: existing 5-arg callers are unaffected (the
parameter is declared \`Optional: true\`).

### Why now as a standalone PR
The scheme-side use of this parameter (the \`.(1)\` one-row virtual
table and future keytable initializers) lives on the cleanup branch
\`codex/topdown-cleanup\` (#251) where it lands together with the
broader top-down unnesting work. Splitting the Go-side infrastructure
into its own small PR keeps the cleanup-branch's review surface
focused on the actual unnesting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)