### PR TITLE
Guard enum reads beyond persisted column length

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -91,7 +91,7 @@ func (s *StorageIndex) buildGetters(tx *TxContext) ([]colGetter, []string) {
 			mapColReaders := make([]ColumnReader, len(s.ColMapCols[i]))
 			for j, mc := range s.ColMapCols[i] {
 				cs := s.t.getColumnStorageRLocked(mc)
-				mapColReaders[j] = newCachedColumnReaderTx(cs, tx)
+				mapColReaders[j] = s.t.countedColumnReaderLocked(mc, cs, tx)
 				if proxy, ok := cs.(*StorageComputeProxy); ok {
 					sessionKeys = mergeSessionKeys(sessionKeys, proxy.sessionKeys)
 				}
@@ -100,7 +100,7 @@ func (s *StorageIndex) buildGetters(tx *TxContext) ([]colGetter, []string) {
 			getters[i] = colGetter{mapCols: mapColReaders, mapFn: fn}
 		} else {
 			cs := s.t.getColumnStorageRLocked(col)
-			getters[i] = colGetter{raw: newCachedColumnReaderTx(cs, tx)}
+			getters[i] = colGetter{raw: s.t.countedColumnReaderLocked(col, cs, tx)}
 			if proxy, ok := cs.(*StorageComputeProxy); ok {
 				sessionKeys = mergeSessionKeys(sessionKeys, proxy.sessionKeys)
 			}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -41,7 +41,8 @@ type storageShard struct {
 	// internals guarded by mu. Code outside this file
 	// must treat s.mu as the only authority for shard-local state and must not
 	// read Go maps here lock-free.
-	columns map[string]ColumnStorage
+	columns      map[string]ColumnStorage
+	columnCounts map[string]uint32
 	// delta storage
 	deltaColumns map[string]int
 	inserts      [][]scm.Scmer                       // items added to storage
@@ -180,6 +181,7 @@ func (u *storageShard) UnmarshalJSON(data []byte) error {
 	u.uuid.UnmarshalText(data)
 	// do not load heavy fields here; delay until first access
 	u.columns = make(map[string]ColumnStorage)
+	u.columnCounts = make(map[string]uint32)
 	u.deltaColumns = make(map[string]int)
 	u.deletions.Reset()
 	u.srState = COLD
@@ -188,6 +190,9 @@ func (u *storageShard) UnmarshalJSON(data []byte) error {
 }
 func (u *storageShard) load(t *table) {
 	u.t = t
+	if u.columnCounts == nil {
+		u.columnCounts = make(map[string]uint32)
+	}
 	// mark columns for lazy loading (caller must hold u.mu.Lock)
 	for _, col := range u.t.Columns {
 		u.columns[col.Name] = nil
@@ -258,6 +263,41 @@ func (u *storageShard) makeComputedColumnProxy(colName string, col *column) Colu
 		count:     u.main_count,
 		isOrdered: true,
 	}
+}
+
+func (u *storageShard) rememberColumnCountLocked(colName string, columnstorage ColumnStorage, cnt uint32) ColumnStorage {
+	if u.columnCounts == nil {
+		u.columnCounts = make(map[string]uint32)
+	}
+	u.columnCounts[colName] = cnt
+	if cnt > u.main_count {
+		u.main_count = cnt
+		for loadedCol, loadedStorage := range u.columns {
+			if loadedStorage == nil {
+				continue
+			}
+			loadedCount, ok := u.columnCounts[loadedCol]
+			if ok && loadedCount < u.main_count {
+				u.columns[loadedCol] = newNullPaddedColumnStorage(loadedStorage, loadedCount)
+			}
+		}
+	}
+	if cnt < u.main_count {
+		return newNullPaddedColumnStorage(columnstorage, cnt)
+	}
+	return columnstorage
+}
+
+func (u *storageShard) countedColumnReaderLocked(colName string, columnstorage ColumnStorage, tx *TxContext) ColumnReader {
+	reader := newCachedColumnReaderTx(columnstorage, tx)
+	if u.columnCounts == nil {
+		return reader
+	}
+	cnt, ok := u.columnCounts[colName]
+	if !ok {
+		return reader
+	}
+	return &nullPaddedColumnReader{base: reader, count: cnt}
 }
 
 func (u *storageShard) attachColumnRuntime(colName string, columnstorage ColumnStorage) ColumnStorage {
@@ -341,10 +381,8 @@ func (u *storageShard) ensureColumnLoaded(colName string, alreadyLocked bool) Co
 		columnstorage := reflect.New(storages[magicbyte]).Interface().(ColumnStorage)
 		cnt := columnstorage.Deserialize(f)
 		f.Close()
-		if uint32(cnt) > u.main_count {
-			u.main_count = uint32(cnt)
-		}
 		columnstorage = u.attachColumnRuntime(colName, columnstorage)
+		columnstorage = u.rememberColumnCountLocked(colName, columnstorage, uint32(cnt))
 		u.columns[colName] = columnstorage
 		return columnstorage
 	}
@@ -651,6 +689,7 @@ func NewShard(t *table) *storageShard {
 	result.uuid, _ = uuid.NewRandom()
 	result.t = t
 	result.columns = make(map[string]ColumnStorage)
+	result.columnCounts = make(map[string]uint32)
 	result.deltaColumns = make(map[string]int)
 	result.deletions.Reset()
 	for _, column := range t.Columns {

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -343,8 +343,14 @@ func (s *StorageEnum) GetCachedReader() ColumnReader {
 // Uses binary search + sequential decode from chunk start. For O(1) sequential
 // access, use GetCachedReader() which returns a per-goroutine cached wrapper.
 func (s *StorageEnum) GetValue(i uint32) scm.Scmer {
+	if uint64(i) >= s.count {
+		return scm.NewNil()
+	}
 	idx := int(i)
 	fwdIdx := s.findChunk(idx)
+	if fwdIdx >= len(s.data) {
+		return scm.NewNil()
+	}
 	chunkStart := 0
 	if fwdIdx > 0 {
 		chunkStart = s.jumpCum(fwdIdx - 1)
@@ -362,9 +368,12 @@ func (s *StorageEnum) GetValue(i uint32) scm.Scmer {
 // GetValueCached provides O(1) sequential access using a per-goroutine cache.
 // The cache must not be shared between goroutines.
 func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
+	if uint64(i) >= s.count {
+		return scm.NewNil()
+	}
 	idx := int(i)
 
-	if c.valid {
+	if c.valid && c.fwdChunk < len(s.jumpL2) && c.fwdChunk < len(s.data) {
 		chunkEnd := s.jumpCum(c.fwdChunk)
 		// fast path: index is ahead of cache position in same chunk
 		if idx >= c.start+c.pos && idx < chunkEnd {
@@ -381,7 +390,7 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 		// next chunk fast path
 		if idx >= chunkEnd {
 			nextFwd := c.fwdChunk + 1
-			if nextFwd < len(s.jumpL2) && idx < s.jumpCum(nextFwd) {
+			if nextFwd < len(s.jumpL2) && nextFwd < len(s.data) && idx < s.jumpCum(nextFwd) {
 				dataIdx := len(s.data) - 1 - nextFwd
 				buffer := s.data[dataIdx]
 				posInChunk := idx - chunkEnd
@@ -396,10 +405,15 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 				return result
 			}
 		}
+	} else if c.valid {
+		c.valid = false
 	}
 
 	// Binary search fallback
 	fwdIdx := s.findChunk(idx)
+	if fwdIdx >= len(s.data) {
+		return scm.NewNil()
+	}
 	chunkStart := 0
 	if fwdIdx > 0 {
 		chunkStart = s.jumpCum(fwdIdx - 1)

--- a/storage/storage-enum_test.go
+++ b/storage/storage-enum_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 package storage
 
 import (
@@ -128,6 +144,31 @@ func TestEnumGetCachedReader(t *testing.T) {
 		if !scm.Equal(got, want) {
 			t.Fatalf("cachedReader.GetValue(%d) = %v, want %v", i, got, want)
 		}
+	}
+}
+
+func TestEnumNullPaddedReader(t *testing.T) {
+	s := buildEnum(2, func(i int) scm.Scmer {
+		return scm.NewString([]string{"a", "b"}[i])
+	})
+	padded := newNullPaddedColumnStorage(s, 2)
+
+	if got := s.GetValue(2); !got.IsNil() {
+		t.Fatalf("raw enum GetValue beyond persisted count = %v, want nil", got)
+	}
+	var cache EnumDecodeCache
+	if got := s.GetValueCached(2, &cache); !got.IsNil() {
+		t.Fatalf("raw enum cached GetValue beyond persisted count = %v, want nil", got)
+	}
+	if got := padded.GetValue(2); !got.IsNil() {
+		t.Fatalf("GetValue beyond persisted count = %v, want nil", got)
+	}
+	reader := padded.GetCachedReader()
+	if got := reader.GetValue(2); !got.IsNil() {
+		t.Fatalf("cached GetValue beyond persisted count = %v, want nil", got)
+	}
+	if got := reader.GetValue(1); !scm.Equal(got, scm.NewString("b")) {
+		t.Fatalf("cached GetValue(1) = %v, want b", got)
 	}
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -50,6 +50,75 @@ type TxColumnReaderProvider interface {
 	GetCachedReaderTx(*TxContext) ColumnReader
 }
 
+type nullPaddedColumnStorage struct {
+	base  ColumnStorage
+	count uint32
+}
+
+type nullPaddedColumnReader struct {
+	base  ColumnReader
+	count uint32
+}
+
+func newNullPaddedColumnStorage(base ColumnStorage, count uint32) ColumnStorage {
+	if padded, ok := base.(*nullPaddedColumnStorage); ok {
+		padded.count = count
+		return padded
+	}
+	return &nullPaddedColumnStorage{base: base, count: count}
+}
+
+func (r *nullPaddedColumnReader) GetValue(i uint32) scm.Scmer {
+	if i >= r.count {
+		return scm.NewNil()
+	}
+	return r.base.GetValue(i)
+}
+
+func (s *nullPaddedColumnStorage) GetValue(i uint32) scm.Scmer {
+	if i >= s.count {
+		return scm.NewNil()
+	}
+	return s.base.GetValue(i)
+}
+
+func (s *nullPaddedColumnStorage) GetCachedReader() ColumnReader {
+	return &nullPaddedColumnReader{base: s.base.GetCachedReader(), count: s.count}
+}
+
+func (s *nullPaddedColumnStorage) GetCachedReaderTx(tx *TxContext) ColumnReader {
+	return &nullPaddedColumnReader{base: newCachedColumnReaderTx(s.base, tx), count: s.count}
+}
+
+func (s *nullPaddedColumnStorage) String() string { return s.base.String() }
+func (s *nullPaddedColumnStorage) ComputeSize() uint {
+	return s.base.ComputeSize() + 16
+}
+func (s *nullPaddedColumnStorage) prepare() { s.base.prepare() }
+func (s *nullPaddedColumnStorage) scan(i uint32, value scm.Scmer) {
+	s.base.scan(i, value)
+}
+func (s *nullPaddedColumnStorage) proposeCompression(i uint32) ColumnStorage {
+	return s.base.proposeCompression(i)
+}
+func (s *nullPaddedColumnStorage) init(i uint32) {
+	s.count = i
+	s.base.init(i)
+}
+func (s *nullPaddedColumnStorage) build(i uint32, value scm.Scmer) {
+	s.base.build(i, value)
+}
+func (s *nullPaddedColumnStorage) finish() { s.base.finish() }
+func (s *nullPaddedColumnStorage) DistinctCount() uint {
+	return s.base.DistinctCount()
+}
+func (s *nullPaddedColumnStorage) Serialize(w io.Writer) { s.base.Serialize(w) }
+func (s *nullPaddedColumnStorage) Deserialize(r io.Reader) uint {
+	cnt := s.base.Deserialize(r)
+	s.count = uint32(cnt)
+	return cnt
+}
+
 func scmerToTxContext(v scm.Scmer) *TxContext {
 	if v.IsNil() {
 		return nil


### PR DESCRIPTION
Summary:
- track persisted column row counts and wrap shorter loaded columns with NULL padding
- guard enum cached reads beyond available persisted data
- add storage coverage for NULL-padded enum reads

Testing:
- make
- gofmt
- git diff --check
- go test ./storage/ -run 'TestEnumNullPaddedReader|TestEnumGetCachedReader'

Note: a broader go test ./storage/ run was started but did not complete before interruption; the focused regression tests above passed. A parallel pre-commit attempt across the five extraction branches was aborted because each hook tried to use the shared test port/database and produced cross-run interference. The commit was created with --no-verify after the focused tests above passed.