### PR TITLE
Fix ACL error message and grant persistence regression

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -67,7 +67,7 @@ if the user is not allowed to access this property, the function will throw an e
 							'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db schema)))
 							'() (lambda () 1)
 							+ 0))
-						(if (> access_count 0) true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." table)))
+							(if (> access_count 0) true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
 					))
 			))
 		)

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -984,7 +984,20 @@ class SQLTestRunner:
             return True
 
         if expect.get("error"):
-            return response.status_code != 200 or "Error" in response.text
+            has_error = response.status_code != 200 or "Error" in response.text
+            if not has_error:
+                return False
+            if "contains" in expect:
+                needles = expect["contains"] if isinstance(expect["contains"], list) else [expect["contains"]]
+                for needle in needles:
+                    if str(needle) not in response.text:
+                        return False
+            if "not_contains" in expect:
+                needles = expect["not_contains"] if isinstance(expect["not_contains"], list) else [expect["not_contains"]]
+                for needle in needles:
+                    if str(needle) in response.text:
+                        return False
+            return True
 
         if "Error" in response.text or response.status_code != 200:
             return False

--- a/tests/21_grant_revoke.yaml
+++ b/tests/21_grant_revoke.yaml
@@ -23,6 +23,10 @@ setup:
     expect: {}
   - sql: "DELETE FROM `system`.`user` WHERE username='hostalice'"
     expect: {}
+  - sql: "DELETE FROM `system`.`access` WHERE username='restartalice'"
+    expect: {}
+  - sql: "DELETE FROM `system`.`user` WHERE username='restartalice'"
+    expect: {}
 
 test_cases:
   - name: "CREATE USER alice"
@@ -111,6 +115,8 @@ test_cases:
     sql: "SELECT * FROM grant_t"
     expect:
       error: true
+      contains: "access denied: user 'alice' may not read memcp-tests.grant_t"
+      not_contains: "[native func]"
 
   - name: "grant db access to alice"
     sql: "GRANT SELECT ON `memcp-tests`.* TO alice"
@@ -124,6 +130,44 @@ test_cases:
       rows: 1
       data:
         - { id: 1, name: "x" }
+
+  - name: "create restart user"
+    sql: "CREATE USER restartalice IDENTIFIED BY 'pw'"
+    expect:
+      affected_rows: 1
+
+  - name: "grant db access to restart user"
+    sql: "GRANT SELECT ON `memcp-tests`.* TO restartalice"
+    expect: {}
+
+  - name: "restart user can read before restart"
+    username: "restartalice"
+    password: "pw"
+    sql: "SELECT COUNT(*) AS cnt FROM grant_t"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
+
+  - name: "restart server after grant"
+    action: restart
+    restart_timeout: 120
+
+  - name: "grant entry survives restart"
+    sql: "SELECT COUNT(*) AS cnt FROM system.access WHERE username='restartalice' AND database='memcp-tests'"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
+
+  - name: "restart user can read after restart"
+    username: "restartalice"
+    password: "pw"
+    sql: "SELECT COUNT(*) AS cnt FROM grant_t"
+    expect:
+      rows: 1
+      data:
+        - { cnt: 1 }
 
   - name: "revoke db access from alice"
     sql: "REVOKE SELECT ON `memcp-tests`.* FROM alice"
@@ -348,6 +392,7 @@ cleanup:
   - sql: "DROP USER IF EXISTS alice"
   - sql: "DROP USER IF EXISTS bob"
   - sql: "DROP USER IF EXISTS hostalice"
+  - sql: "DROP USER IF EXISTS restartalice"
   - sql: "DROP USER IF EXISTS psqlalice"
   - sql: "DROP USER IF EXISTS psqlrole"
   - sql: "DROP DATABASE IF EXISTS drop_test_db"


### PR DESCRIPTION
## Summary

Fixes a misleading ACL error message where denied table reads printed `schema.[native func]` instead of the actual table name.

The root cause was the policy error path using the Scheme native `table` binding in the formatted message instead of the `tblname` argument passed to the policy check.

## Tests

- Added SQL regression coverage for denied non-root reads asserting the real table name appears and `[native func]` does not.
- Added GRANT persistence coverage: create user, grant database access, verify read, restart MemCP, verify `system.access`, verify non-root read again.
- Extended YAML error expectations to optionally assert response text `contains` / `not_contains` for error cases.

## Validation

- `python3 tools/lint_scm.py --path lib/sql.scm --check`
- `python3 -m py_compile run_sql_tests.py`
- `./run_sql_tests.py tests/21_grant_revoke.yaml --fail-fast`
- `./run_sql_tests.py tests/23_policy_enforcement.yaml --fail-fast`
- `make test`
