### PR TITLE
Define local resultrow during pgdump import eval

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -1168,6 +1168,7 @@ substring replace (which is the historical behaviour). */
 )))
 
 (define psql_eval_import_command (lambda (schema source_dir dump_schema command policy) (begin
+	(define resultrow (lambda (row) true))
 	(match command
 		(regex "^[\\r\\n\\t ]*COPY (.*) FROM '([^']+)'\\z" _ def path)
 		(begin

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -67,7 +67,7 @@ if the user is not allowed to access this property, the function will throw an e
 							'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db schema)))
 							'() (lambda () 1)
 							+ 0))
-							(if (> access_count 0) true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
+						(if (> access_count 0) true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
 					))
 			))
 		)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -933,7 +933,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 						(list 'list
 							(list 'map (list 'produceN 3) (list 'lambda (list 'i) 'i))
 							(list 'reverse (list 'list 'a 'b 'c))))))))
-		 10 20 30)
+			10 20 30)
 		3
 		"length hook: zip preserves exact producer length")
 	(assert

--- a/tests/78_postgres_dump_import.yaml
+++ b/tests/78_postgres_dump_import.yaml
@@ -9,6 +9,10 @@ setup:
   - sql: "DROP TABLE IF EXISTS pgdump_people"
 
 test_cases:
+  - name: "Import command eval has local resultrow callback"
+    scm: |
+      (psql_eval_import_command "memcp-tests" "" nil "SELECT 1" (sql_policy "root"))
+
   - name: "Import minimal pg_dump archive into target schema"
     scm: |
       (load_psql "memcp-tests" (concat __DIR__ "/../tests/fixtures/mini_pgdump.pg_dump.gz") (sql_policy "root"))


### PR DESCRIPTION
## What

Defines a local `resultrow` callback while evaluating pgdump import commands and adds a direct regression to cover import-command evaluation.

The Scheme formatter also adjusted two existing indentation-only lines in `lib/sql.scm` and `lib/test.scm`.

## Validation

- `make`
- `python3 tools/lint_scm.py` (existing historical warnings only)
- `python3 run_sql_tests.py tests/78_postgres_dump_import.yaml 45331`

I also attempted full `make test`, but started multiple full suites in parallel. That overloaded the machine and produced unrelated hard-timeout/OOM-style failures in existing heavy suites, so that run is not a valid merge signal. Please rerun full `make test` serially before merge.
