### PR TITLE
Keep empty SELECT results distinct

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -20,6 +20,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (import "sql-builtins.scm")
 (import "queryplan.scm")
 
+(define sql_statement_starts_with (lambda (query keyword) (begin
+	(define trimmed (toUpper (strltrim query)))
+	(define kw_len (strlen keyword))
+	(and
+		(>= (strlen trimmed) kw_len)
+		(equal? (substr trimmed 0 kw_len) keyword)
+		(or
+			(equal? (strlen trimmed) kw_len)
+			(equal? (substr trimmed kw_len 1) " ")
+			(equal? (substr trimmed kw_len 1) "\n")
+			(equal? (substr trimmed kw_len 1) "\t")
+			(equal? (substr trimmed kw_len 1) "\r"))))))
+(define sql_statement_returns_rows (lambda (query)
+	(or
+		(sql_statement_starts_with query "SELECT")
+		(sql_statement_starts_with query "WITH")
+		(sql_statement_starts_with query "EXPLAIN")
+		(sql_statement_starts_with query "SHOW")
+		(sql_statement_starts_with query "DESCRIBE"))))
+
 /* query plan caches: separate cachemap per parser dialect */
 (set sql_queryplan_cache (newcachemap))
 (set psql_queryplan_cache (newcachemap))
@@ -274,16 +294,19 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					before parse/build so session-sensitive planner rewrites see the right values. */
 					(extract_assoc (req "query") (lambda (k v) (session k v)))
 					(define formula (cached_parse sql_queryplan_cache parse_sql schema query (sql_policy (req "username")) (req "username") session true))
-					(set resultrow_called false)
+					(define resultrow_state (newsession))
+					(resultrow_state "called" false)
 					(set original_resultrow resultrow)
 					(define resultrow (lambda (row) (begin
-						(set resultrow_called true)
+						(resultrow_state "called" true)
 						(original_resultrow row))))
 					/* Execute inside auto-commit tx (or existing explicit tx) */
 					(set query_result (with_session session (lambda () (with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula)))))))
-					/* If no resultrow was called and we got a number, return it as affected_rows */
-					(if (and (not resultrow_called) (number? query_result)) (begin
-						(original_resultrow '("affected_rows" query_result))
+					/* If no resultrow was called and we got a number, return it as affected_rows
+					for write-like statements only. Empty SELECT-style result sets must stay empty. */
+					(if (and (not (resultrow_state "called")) (number? query_result)
+						(not (sql_statement_returns_rows query))) (begin
+							(original_resultrow '("affected_rows" query_result))
 					))
 				) query)) (lambda(e) (begin
 						(error_log (concat e) schema (req "username") query)
@@ -311,10 +334,11 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(define session (context "session"))
 					(session "username" (req "username"))
 					(session "schema" schema)
-					(set resultrow_called false)
+					(define resultrow_state (newsession))
+					(resultrow_state "called" false)
 					(set original_resultrow resultrow)
 					(define resultrow (lambda (row) (begin
-						(set resultrow_called true)
+						(resultrow_state "called" true)
 						(original_resultrow row))))
 					(define handled (match query
 						(regex "SELECT\\s+c\\.relname\\s+as\\s+tblname\\s+FROM\\s+pg_catalog\\.pg_class" _)
@@ -338,9 +362,11 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						(define formula (cached_parse psql_queryplan_cache parse_psql schema query (sql_policy (req "username")) (req "username") session false))
 						(with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula))))
 					)))
-					/* If no resultrow was called and we got a number, return it as affected_rows */
-					(if (and (not resultrow_called) (number? query_result)) (begin
-						(original_resultrow '("affected_rows" query_result))
+					/* If no resultrow was called and we got a number, return it as affected_rows
+					for write-like statements only. Empty SELECT-style result sets must stay empty. */
+					(if (and (not (resultrow_state "called")) (number? query_result)
+						(not (sql_statement_returns_rows query))) (begin
+							(original_resultrow '("affected_rows" query_result))
 					))
 				) query)) (lambda(e) (begin
 						(error_log (concat e) schema (req "username") query)

--- a/tests/24_mysql_basic_compat.yaml
+++ b/tests/24_mysql_basic_compat.yaml
@@ -64,6 +64,7 @@ test_cases:
       SELECT 1 WHERE 0
     expect:
       rows: 0
+      not_contains: "affected_rows"
 
   - name: "NULL truthiness (WHERE filters out)"
     # Avoids aggregate over derived table; checks filter semantics directly
@@ -71,6 +72,14 @@ test_cases:
       SELECT 1 WHERE NULL
     expect:
       rows: 0
+      not_contains: "affected_rows"
+
+  - name: "Empty table SELECT returns empty result, not affected_rows"
+    sql: |
+      SELECT id FROM compat_users WHERE id = 99
+    expect:
+      rows: 0
+      not_contains: "affected_rows"
 
   - name: "String escape single quote"
     sql: |


### PR DESCRIPTION
## Summary
- keep empty row-returning statements from being serialized as affected_rows=0
- track resultrow calls through a session-backed flag so callbacks inside lambdas update shared state
- add regressions for empty SELECT-style responses not containing affected_rows

## Tests
- python3 tools/lint_scm.py
- make
- python3 run_sql_tests.py tests/24_mysql_basic_compat.yaml
- ./git-pre-commit tests/24_mysql_basic_compat.yaml

Note: a later full pre-commit attempt was interrupted because I accidentally started full hooks in two worktrees at once; both used the fixed test port/data directory and interfered with each other. The targeted hook above completed successfully before the commit.