### PR TITLE
Expose uppercase information_schema statistics columns

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2107,6 +2107,22 @@ func Init(en scm.Env) {
 					for _, uk := range t.Unique {
 						for seq, col := range uk.Cols {
 							result = append(result, scm.NewSlice([]scm.Scmer{
+								scm.NewString("TABLE_CATALOG"), scm.NewString("def"),
+								scm.NewString("TABLE_SCHEMA"), scm.NewString(db.Name),
+								scm.NewString("TABLE_NAME"), scm.NewString(t.Name),
+								scm.NewString("NON_UNIQUE"), scm.NewInt(0),
+								scm.NewString("INDEX_SCHEMA"), scm.NewString(db.Name),
+								scm.NewString("INDEX_NAME"), scm.NewString(uk.Id),
+								scm.NewString("SEQ_IN_INDEX"), scm.NewInt(int64(seq + 1)),
+								scm.NewString("COLUMN_NAME"), scm.NewString(col),
+								scm.NewString("COLLATION"), scm.NewString("A"),
+								scm.NewString("CARDINALITY"), scm.NewNil(),
+								scm.NewString("SUB_PART"), scm.NewNil(),
+								scm.NewString("PACKED"), scm.NewNil(),
+								scm.NewString("NULLABLE"), scm.NewString(""),
+								scm.NewString("INDEX_TYPE"), scm.NewString("BTREE"),
+								scm.NewString("COMMENT"), scm.NewString(""),
+								scm.NewString("INDEX_COMMENT"), scm.NewString(""),
 								scm.NewString("table_catalog"), scm.NewString("def"),
 								scm.NewString("table_schema"), scm.NewString(db.Name),
 								scm.NewString("table_name"), scm.NewString(t.Name),

--- a/tests/84_information_schema.yaml
+++ b/tests/84_information_schema.yaml
@@ -87,6 +87,11 @@ test_cases:
     expect:
       min_rows: 0
 
+  - name: "STATISTICS: uppercase index columns used by dbcheck migrations"
+    sql: "SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = 'memcp-tests' AND TABLE_NAME = 'is_test_tbl' ORDER BY INDEX_NAME, COLUMN_NAME LIMIT 5"
+    expect:
+      min_rows: 1
+
   # --- KEY_COLUMN_USAGE ---
 
   - name: "KEY_COLUMN_USAGE: query returns without error"


### PR DESCRIPTION
## Summary
- expose MySQL-compatible uppercase aliases for INFORMATION_SCHEMA.STATISTICS index metadata
- keep the existing lowercase column names for compatibility
- add a dbcheck-style regression that selects INDEX_NAME, COLUMN_NAME, and NON_UNIQUE

## Tests
- make
- python3 run_sql_tests.py tests/84_information_schema.yaml
- ./git-pre-commit tests/84_information_schema.yaml

Note: a later full pre-commit attempt was interrupted because I accidentally started full hooks in two worktrees at once; both used the fixed test port/data directory and interfered with each other. The targeted hook above completed successfully before the commit.