### PR TITLE
Preserve large file-backed WAL rows across restart

### DIFF
--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -22,6 +22,7 @@ import "fmt"
 import "bufio"
 import "bytes"
 import "strings"
+import "errors"
 import "path/filepath"
 import "crypto/sha256"
 import "encoding/json"
@@ -194,16 +195,25 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 	if fi.Size() > 0 {
 		go func() {
 			defer close(replay)
-			scanner := bufio.NewScanner(f)
-			for scanner.Scan() {
-				b := scanner.Bytes()
-				if string(b) == "" {
+			reader := bufio.NewReaderSize(f, 256*1024)
+			for {
+				b, err := reader.ReadBytes('\n')
+				if len(b) == 0 && errors.Is(err, io.EOF) {
+					break
+				}
+				if len(b) > 0 && b[len(b)-1] == '\n' {
+					b = b[:len(b)-1]
+				}
+				if len(b) > 0 && b[len(b)-1] == '\r' {
+					b = b[:len(b)-1]
+				}
+				if len(b) == 0 && err == nil {
 					// nop
-				} else if string(b[0:7]) == "delete " {
+				} else if len(b) >= 7 && string(b[0:7]) == "delete " {
 					var idx uint32
 					json.Unmarshal(b[7:], &idx)
 					replay <- LogEntryDelete{idx}
-				} else if string(b[0:7]) == "insert " {
+				} else if len(b) >= 7 && string(b[0:7]) == "insert " {
 					body := string(b[7:])
 					if pos := strings.Index(body, "]["); pos >= 0 {
 						// new format: columns ][ values
@@ -236,6 +246,12 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 					}
 				} else {
 					panic("unknown log sequence: " + string(b))
+				}
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					panic(err)
 				}
 			}
 		}()

--- a/tests/122_large_wal_line_restart.yaml
+++ b/tests/122_large_wal_line_restart.yaml
@@ -1,0 +1,40 @@
+metadata:
+  version: "1.0"
+  description: "Large file-backed WAL rows survive restart"
+  isolated: true
+
+setup:
+  - scm: (settings "ShardSize" 3)
+  - sql: "DROP TABLE IF EXISTS safe_large_log"
+  - sql: "CREATE TABLE safe_large_log (id INT PRIMARY KEY, note TEXT) ENGINE=SAFE"
+
+test_cases:
+  - name: "Insert row larger than scanner token"
+    scm: |
+      (begin
+        (define big (apply concat (map (produceN 70000) (lambda (i) "x"))))
+        (insert (table "memcp-tests" "safe_large_log") '("id" "note")
+          (list (list 1 big))))
+
+  - name: "Large row is visible before restart"
+    sql: "SELECT LENGTH(note) AS len FROM safe_large_log WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - len: 70000
+
+  - name: "Restart after large WAL row"
+    sql: "SHUTDOWN"
+
+  - name: "Large row survives restart"
+    sql: "SELECT LENGTH(note) AS len FROM safe_large_log WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - len: 70000
+
+  - name: "Restore default shard size"
+    scm: (settings "ShardSize" 60000)
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS safe_large_log"


### PR DESCRIPTION
## Summary

This replaces scanner-based file WAL replay with buffered line reading so large insert records survive restart.

## Why

`bufio.Scanner` has a token limit. Large text/blob-like row payloads could make replay fail or silently prevent restart recovery for file-backed SAFE shards.

## Validation

- `make`
- `python3 run_sql_tests.py tests/122_large_wal_line_restart.yaml`
