### PR TITLE
Match SQL truthiness for numeric strings

### DIFF
--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -544,7 +544,13 @@ func (s Scmer) Bool() bool {
 		return math.Float64frombits(s.aux) != 0.0
 	case tagString, tagSymbol, tagCString, tagBString:
 		str := s.String()
-		return str != "" && str != "false"
+		if str == "" || strings.EqualFold(str, "false") {
+			return false
+		}
+		if n, err := strconv.ParseFloat(strings.TrimSpace(str), 64); err == nil {
+			return n != 0.0
+		}
+		return true
 	case tagSlice:
 		return len(s.Slice()) > 0
 	case tagVector:

--- a/tests/24_mysql_basic_compat.yaml
+++ b/tests/24_mysql_basic_compat.yaml
@@ -51,6 +51,25 @@ test_cases:
       data:
         - v: "t"
 
+  - name: "String numerals follow SQL boolean truthiness"
+    sql: |
+      SELECT
+        IF('0', 't', 'f') AS zero_string,
+        IF(' 0 ', 't', 'f') AS spaced_zero_string,
+        IF('0.0', 't', 'f') AS decimal_zero_string,
+        IF('1', 't', 'f') AS one_string,
+        IF('0.1', 't', 'f') AS decimal_string,
+        IF('FALSE', 't', 'f') AS false_string
+    expect:
+      rows: 1
+      data:
+        - zero_string: "f"
+          spaced_zero_string: "f"
+          decimal_zero_string: "f"
+          one_string: "t"
+          decimal_string: "t"
+          false_string: "f"
+
   - name: "SELECT WHERE without FROM"
     # Avoids aggregate over derived table; checks filter semantics directly
     sql: |


### PR DESCRIPTION
## Summary

This makes string boolean truthiness match SQL/MySQL-style numeric conversion for strings such as `'0'`, `' 0 '`, and `'0.0'`.

## Why

MemCP previously treated every non-empty string except lowercase `false` as true. SQL boolean contexts convert numeric strings first, so `'0'` must be false while `'1'` and `'0.1'` remain true.

## Validation

- `make`
- `python3 run_sql_tests.py tests/24_mysql_basic_compat.yaml`
