### PR TITLE
fix dashboard client api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,16 @@ MemCP is designed to run alongside other services on the same machine without bl
 
 **Automatic compression** — MemCP stores each column in the most compact format that fits the data: small integers get bit-packed, repeated strings become dictionary-encoded, sequential IDs are stored as ranges. A table that takes 10 GB in MySQL often fits in 1–3 GB in MemCP.
 
-**Configurable memory budget** — by default MemCP uses at most 50% of your server's RAM. You can set an exact limit via the dashboard or the settings API:
+**Configurable memory budget** — by default MemCP uses at most 50% of your server's RAM. You can set an exact limit via the dashboard or the Scheme API:
 
 ```bash
 # Limit to 4 GB total
-curl -u root:admin -X POST http://localhost:4321/dashboard/api/settings \
-  -d '{"key":"MaxRamBytes","value":4294967296}'
+curl -u root:admin -X POST http://localhost:4321/scm \
+  -d '(settings "MaxRamBytes" 4294967296)'
 
 # Or as a percentage of total RAM (default: 50)
-curl -u root:admin -X POST http://localhost:4321/dashboard/api/settings \
-  -d '{"key":"MaxRamPercent","value":40}'
+curl -u root:admin -X POST http://localhost:4321/scm \
+  -d '(settings "MaxRamPercent" 40)'
 ```
 
 **Automatic eviction** — when MemCP approaches its memory limit, it automatically unloads the least recently used data from RAM. That data stays safe on disk and is transparently reloaded the next time a query needs it. Frequently accessed hot data stays in memory; cold data steps aside.

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -1216,7 +1216,7 @@ return r.json();
 }
 
 var SCM_SERVICES='(if (nil? service_registry) "[]" (dashboard_json_array (map (service_registry) (lambda (name) (begin (set v (service_registry name)) (json_encode_assoc (list "name" name "port" (car v) "route" (car (cdr v)) "protocols" (car (cdr (cdr v))))))))))';
-var SCM_USERS='(begin (set j (scan nil "system" "user" \'() (lambda () true) \'("username" "admin") (lambda (u adm) (begin (set dbs_str (scan nil "system" "access" \'("username") (lambda (au) (equal?? au u)) \'("database") (lambda (db) (json_encode db)) (lambda (a b) (if (equal? a "") b (concat a "," b))) "")) (concat "{\\"username\\":" (json_encode u) ",\\"admin\\":" (if (equal? adm 0) "false" "true") ",\\"databases\\":[" dbs_str "]}")) ) (lambda (acc item) (if (or (nil? item) (equal? item "")) acc (if (equal? acc "") item (concat acc "," item)))) "")) (concat "[" j "]"))';
+var SCM_USERS='(begin (set j (scan nil (table "system" "user") (list) (lambda () true) (list "username" "admin") (lambda (u adm) (begin (set dbs_str (scan nil (table "system" "access") (list "username") (lambda (au) (equal?? au u)) (list "database") (lambda (db) (json_encode db)) (lambda (a b) (if (equal? a "") b (concat a "," b))) "")) (concat "{\\"username\\":" (json_encode u) ",\\"admin\\":" (if (equal? adm 0) "false" "true") ",\\"databases\\":[" dbs_str "]}")) ) (lambda (acc item) (if (or (nil? item) (equal? item "")) acc (if (equal? acc "") item (concat acc "," item)))) "")) (concat "[" j "]"))';
 
 function scmFetch(expr,cb){
 fetch(base+"/scm",{method:"POST",credentials:"same-origin",body:expr})
@@ -1621,7 +1621,7 @@ var eng=this.value;
 var engSpec=engines.filter(function(e){return e.v===eng})[0];
 var engSql=engSpec?engSpec.sql:eng.toUpperCase();
 var sel=this;
-fetch(base+"/dashboard/api/sql",{method:"POST",credentials:"same-origin",headers:{"Content-Type":"application/json"},body:JSON.stringify({database:dbname,sql:"ALTER TABLE `"+tblname+"` ENGINE="+engSql})}).then(function(r){
+fetch(base+"/sql/"+encodeURIComponent(dbname),{method:"POST",credentials:"same-origin",body:"ALTER TABLE `"+tblname+"` ENGINE="+engSql}).then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t)});
 return r.text();
 }).then(function(){origEngine=eng}).catch(function(e){window.alert("Error: "+e.message);sel.value=origEngine});
@@ -2270,7 +2270,7 @@ var nowTs=Math.floor(Date.now()/1000);
 var whereClause=since>0?"WHERE time >= '"+(nowTs-since)+"' OR time >= '"+fmtDateTime(nowTs-since)+"'":"";
 /* query perf_metrics sorted oldest-first */
 var sql="SELECT time,rps,eps,cpu,connections,mem_available FROM perf_metrics ORDER BY time ASC LIMIT 2000";
-fetch(base+"/dashboard/api/query",{method:"POST",credentials:"same-origin",headers:{"Content-Type":"application/json"},body:JSON.stringify({database:"system_statistic",sql:sql})})
+fetch(base+"/sql/system_statistic",{method:"POST",credentials:"same-origin",body:sql})
 .then(function(r){if(!r.ok)throw new Error(r.status);return r.text()})
 .then(function(text){
 /* NDJSON: one JSON object per line */


### PR DESCRIPTION
## What changed

- Updated the dashboard client to use the current SQL and SCM endpoints instead of removed compatibility routes.
- Updated the dashboard user-list SCM expression to use the new `(table "schema" "name")` scan API and explicit `(list ...)` column arguments.
- Updated README settings examples to use `/scm` instead of the removed dashboard settings endpoint.

## Why

The dashboard SPA was still partly on an older API shape while the server-side dashboard settings/query compatibility endpoints had already been removed. The broken user-list SCM expression caused 500 errors such as `filterColumns: expected list, got user`, which also prevented the database list from rendering for admins because `renderDatabases()` waits on `fetchUsers()`.

## Validation

- `git diff --check`
- Extracted dashboard script and ran `node --check`
- Verified `/dashboard/api/databases` returns data on a local patched instance.
- Verified the patched user-list SCM expression returns HTTP 200 on the local patched instance.
- Pre-commit hook completed successfully, including the full SQL test suite.
