### PR TITLE
Add scan_exists probe operator and optimizer rewrite

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -845,12 +845,15 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(and (equal? (gs_aggregates stage) (list aggregate_count_descriptor))
 				(and (nil? (gs_having stage))
 					(and (empty_list? (gs_order stage))
-						(and (nil? (gs_limit stage))
-							(and (not (equal? (direct_probe_key_columns (group_stage_input_alias stage) (gs_keys stage)) false))
-								(not (equal? (exists_probe_condition_bindings
-									(group_stage_input_alias stage)
-									(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-									false)))))))))))
+						(nil? (gs_limit stage)))))))))
+
+(define exists_probe_expr_supported? (lambda (stage)
+	(and (exists_probe_supported? stage)
+		(and (not (equal? (direct_probe_key_columns (group_stage_input_alias stage) (gs_keys stage)) false))
+			(not (equal? (exists_probe_condition_bindings
+				(group_stage_input_alias stage)
+				(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+				false))))))
 
 (define exists_probe_expr (lambda (stage lookup_keys)
 	(list (quote exists_probe) stage lookup_keys)))
@@ -1128,7 +1131,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(stage_source_outer? outer_sources)
 			(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
-		(if (exists_probe_supported? stage)
+		(if (exists_probe_expr_supported? stage)
 			(list
 				(exists_probe_expr stage lookup_keys)
 				'()
@@ -3734,23 +3737,26 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(begin
 		(define src (gs_input stage))
 		(define alias (group_stage_input_alias stage))
+		(define probe_sources (cons src sources))
 		(define keys (gs_keys stage))
-		(define key_cols (direct_probe_key_columns alias keys))
 		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-		(define condition_bindings (exists_probe_condition_bindings alias condition))
-		(if (or (equal? key_cols false) (equal? condition_bindings false))
-			(neumann_fail "build_queryplan" "EXISTS probe lowering expects direct equality/null bindings")
-			true)
-		(define condition_cols (map condition_bindings (lambda (binding) (nth binding 0))))
-		(define condition_values (map condition_bindings (lambda (binding) (nth binding 1))))
+		(define key_terms (if (equal? (count keys) (count lookup_keys))
+			(map (produceN (count keys)) (lambda (i)
+				(list (quote equal??)
+					(nth keys i)
+					(nth lookup_keys i))))
+			'()))
+		(define filter_expr (combine_where
+			condition
+			(combine_where_terms key_terms true)))
+		(define filtercols (extract_columns_for_alias src filter_expr))
 		(list (quote scan_exists)
 			'(session "__memcp_tx")
 			(source_table_expr src)
-			(quoted_runtime_list (merge (list key_cols condition_cols)))
-			(cons (quote list)
-				(merge (list
-					(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key)))
-					(map condition_values (lambda (value) (lower_column_expr_for_join sources default_alias value))))))))))
+			(cons (quote list) filtercols)
+			(list (quote lambda)
+				(map filtercols (lambda (col) (symbol (concat alias "." col))))
+				(list (quote optimize) (lower_column_expr_for_join probe_sources alias filter_expr)))))))
 
 (define scalar_first_probe_parts (lambda (ag)
 	(match ag
@@ -5015,6 +5021,53 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 			(scalar_first_probe_stage? stage)))))
 
+(define exists_probe_stage? (lambda (stage)
+	(and (group_stage? stage) (exists_probe_supported? stage))))
+
+(define exists_probe_stage_output_source? (lambda (stages src)
+	(and (stage_output_relation? (source_relation src))
+		(begin
+			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
+			(exists_probe_stage? stage)))))
+
+(define exists_probe_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
+	(reduce (coalesceNil sources '()) (lambda (found src)
+			(if (not (nil? found))
+				found
+				(if (and (exists_probe_stage_output_source? stages src)
+					(source_alias_matches? src default_alias tblvar tbl_ignorecase))
+					(stage_by_id stages (stage_output_relation_id (source_relation src)))
+					nil)))
+		nil)))
+
+(define exists_probe_count_ref_stage (lambda (stages sources default_alias expr)
+	(match expr
+		((symbol get_column) tblvar tbl_ignorecase col _col_ignorecase) (begin
+			(define stage (exists_probe_stage_for_alias stages sources default_alias tblvar tbl_ignorecase))
+			(if (and (not (nil? stage)) (equal? col (aggregate_col_name aggregate_count_descriptor)))
+				stage
+				nil))
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(exists_probe_count_ref_stage stages sources default_alias (list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		_ nil)))
+
+(define exists_probe_compare_expr (lambda (stages sources default_alias expr op value)
+	(begin
+		(define stage (exists_probe_count_ref_stage stages sources default_alias expr))
+		(if (and (not (nil? stage)) (and (equal? op (quote >)) (equal? value 0)))
+			(exists_probe_expr stage (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(list op
+				(rewrite_exists_probe_expr stages sources default_alias expr)
+				(rewrite_exists_probe_expr stages sources default_alias value))))))
+
+(define rewrite_exists_probe_expr (lambda (stages sources default_alias expr)
+	(match expr
+		((symbol >) left right) (exists_probe_compare_expr stages sources default_alias left (quote >) right)
+		((quote >) left right) (exists_probe_compare_expr stages sources default_alias left (quote >) right)
+		(cons head tail) (cons head (map tail (lambda (item)
+			(rewrite_exists_probe_expr stages sources default_alias item))))
+		_ expr)))
+
 (define scalar_first_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(if (not (nil? found))
@@ -5048,6 +5101,25 @@ PostgreSQL parsers should both lower to the same combined operators.
 			'(expr dir) (list (rewrite_scalar_first_probe_expr stages sources default_alias expr) dir)
 			_ item)))))
 
+(define rewrite_exists_probe_fields (lambda (stages sources default_alias fields)
+	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
+		(rewrite_exists_probe_expr stages sources default_alias expr)))))
+
+(define rewrite_exists_probe_order (lambda (stages sources default_alias order_items)
+	(map (coalesceNil order_items '()) (lambda (item)
+		(match item
+			'(expr dir) (list (rewrite_exists_probe_expr stages sources default_alias expr) dir)
+			_ item)))))
+
+(define rewrite_exists_probe_sources (lambda (stages sources default_alias)
+	(map (coalesceNil sources '()) (lambda (src)
+		(list
+			(source_alias src)
+			(source_schema src)
+			(source_relation src)
+			(source_outer? src)
+			(rewrite_exists_probe_expr stages sources default_alias (source_join_expr src)))))))
+
 (define rewrite_scalar_first_probe_sources (lambda (stages sources default_alias)
 	(map (coalesceNil sources '()) (lambda (src)
 		(list
@@ -5061,27 +5133,37 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(filter (coalesceNil sources '()) (lambda (src)
 		(not (scalar_first_stage_output_source? stages src))))))
 
+(define sources_without_exists_probe_outputs (lambda (stages sources)
+	(filter (coalesceNil sources '()) (lambda (src)
+		(not (exists_probe_stage_output_source? stages src))))))
+
 (define stages_without_scalar_first_probes (lambda (stages)
 	(filter (coalesceNil stages '()) (lambda (stage)
 		(not (scalar_first_probe_stage? stage))))))
+
+(define stages_without_exists_probe_stages (lambda (stages)
+	(filter (coalesceNil stages '()) (lambda (stage)
+		(not (exists_probe_stage? stage))))))
 
 (define query_block_with_scalar_first_probes_using (lambda (stages block)
 	(begin
 		(define sources (qb_sources block))
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
-		(define rewritten_sources (rewrite_scalar_first_probe_sources stages sources default_alias))
+		(define exists_rewritten_sources (rewrite_exists_probe_sources stages sources default_alias))
+		(define rewritten_sources (rewrite_scalar_first_probe_sources stages exists_rewritten_sources default_alias))
+		(define exists_rewritten_stages (stages_without_exists_probe_stages (qb_stages block)))
 		(make_query_block
 			(qb_schema block)
-			(sources_without_scalar_first_outputs stages rewritten_sources)
-			(rewrite_scalar_first_probe_fields stages sources default_alias (qb_fields block))
-			(rewrite_scalar_first_probe_expr stages sources default_alias (qb_where block))
+			(sources_without_exists_probe_outputs stages (sources_without_scalar_first_outputs stages rewritten_sources))
+			(rewrite_scalar_first_probe_fields stages sources default_alias (rewrite_exists_probe_fields stages sources default_alias (qb_fields block)))
+			(rewrite_scalar_first_probe_expr stages sources default_alias (rewrite_exists_probe_expr stages sources default_alias (qb_where block)))
 			(qb_group block)
-			(rewrite_scalar_first_probe_expr stages sources default_alias (qb_having block))
-			(rewrite_scalar_first_probe_order stages sources default_alias (qb_order block))
+			(rewrite_scalar_first_probe_expr stages sources default_alias (rewrite_exists_probe_expr stages sources default_alias (qb_having block)))
+			(rewrite_scalar_first_probe_order stages sources default_alias (rewrite_exists_probe_order stages sources default_alias (qb_order block)))
 			(qb_limit block)
 			(qb_offset block)
-			(rewrite_scalar_first_probe_fields stages sources default_alias (qb_hidden block))
-			(stages_without_scalar_first_probes (qb_stages block))
+			(rewrite_scalar_first_probe_fields stages sources default_alias (rewrite_exists_probe_fields stages sources default_alias (qb_hidden block)))
+			(stages_without_scalar_first_probes exists_rewritten_stages)
 			(qb_facts block)))))
 
 (define query_block_without_stages_after_prepare_using (lambda (stages block)
@@ -5745,7 +5827,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(filter (qb_stages block) (lambda (stage)
 				(not (row_number_stage_consumed_by_join? stage (qb_sources block))))))
 		(lambda (stage)
-			(not (scalar_first_probe_stage? stage))))))
+			(and (not (scalar_first_probe_stage? stage))
+				(not (exists_probe_stage? stage)))))))
 
 (define lower_query_block_with_stages (lambda (block)
 	(if (empty_list? (qb_stages block))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -807,16 +807,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(define acol (direct_probe_column alias a))
 			(define bcol (direct_probe_column alias b))
 			(if (and (not (nil? acol)) (nil? bcol))
-				(list acol b)
+				(list (list acol b))
 				(if (and (nil? acol) (not (nil? bcol)))
-					(list bcol a)
+					(list (list bcol a))
 					false)))
 		((quote equal??) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((symbol equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((quote equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((symbol nil?) expr) (begin
 			(define col (direct_probe_column alias expr))
-			(if (nil? col) false (list col nil)))
+			(if (nil? col) false (list (list col nil))))
 		((quote nil?) expr) (exists_probe_condition_binding alias (list (quote nil?) expr))
 		_ false)))
 
@@ -830,9 +830,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				false
 				(merge (list aa bb))))
 		((quote and) a b) (exists_probe_condition_bindings alias (list (quote and) a b))
-		_ (begin
-			(define binding (exists_probe_condition_binding alias condition))
-			(if (equal? binding false) false (list binding))))))
+		_ (exists_probe_condition_binding alias condition))))
 
 (define direct_probe_key_columns (lambda (alias keys)
 	(begin
@@ -3290,7 +3288,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define stage_reorder_strategy (lambda (stage)
 	(match (qassoc_get (gs_facts stage) (quote purpose) nil)
-		(symbol exists) (quote group_cache_read)
+		(symbol exists) (if (exists_probe_supported? stage)
+			(quote storage_index_probe)
+			(quote group_cache_read))
 		(symbol not_exists) (quote group_cache_read)
 		(symbol in_membership) (quote group_cache_read)
 		(symbol in_candidate) (quote candidate_keyset)
@@ -3743,7 +3743,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			true)
 		(define condition_cols (map condition_bindings (lambda (binding) (nth binding 0))))
 		(define condition_values (map condition_bindings (lambda (binding) (nth binding 1))))
-		(list (quote probe_exists)
+		(list (quote scan_exists)
 			'(session "__memcp_tx")
 			(source_table_expr src)
 			(quoted_runtime_list (merge (list key_cols condition_cols)))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -807,16 +807,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(define acol (direct_probe_column alias a))
 			(define bcol (direct_probe_column alias b))
 			(if (and (not (nil? acol)) (nil? bcol))
-				(list (list acol b))
+				(list acol b)
 				(if (and (nil? acol) (not (nil? bcol)))
-					(list (list bcol a))
+					(list bcol a)
 					false)))
 		((quote equal??) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((symbol equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((quote equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
 		((symbol nil?) expr) (begin
 			(define col (direct_probe_column alias expr))
-			(if (nil? col) false (list (list col nil))))
+			(if (nil? col) false (list col nil)))
 		((quote nil?) expr) (exists_probe_condition_binding alias (list (quote nil?) expr))
 		_ false)))
 
@@ -830,7 +830,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 				false
 				(merge (list aa bb))))
 		((quote and) a b) (exists_probe_condition_bindings alias (list (quote and) a b))
-		_ (exists_probe_condition_binding alias condition))))
+		_ (begin
+			(define binding (exists_probe_condition_binding alias condition))
+			(if (equal? binding false) false (list binding))))))
 
 (define direct_probe_key_columns (lambda (alias keys)
 	(begin
@@ -845,15 +847,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(and (equal? (gs_aggregates stage) (list aggregate_count_descriptor))
 				(and (nil? (gs_having stage))
 					(and (empty_list? (gs_order stage))
-						(nil? (gs_limit stage)))))))))
-
-(define exists_probe_expr_supported? (lambda (stage)
-	(and (exists_probe_supported? stage)
-		(and (not (equal? (direct_probe_key_columns (group_stage_input_alias stage) (gs_keys stage)) false))
-			(not (equal? (exists_probe_condition_bindings
-				(group_stage_input_alias stage)
-				(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-				false))))))
+						(and (nil? (gs_limit stage))
+							(and (not (equal? (direct_probe_key_columns (group_stage_input_alias stage) (gs_keys stage)) false))
+								(not (equal? (exists_probe_condition_bindings
+									(group_stage_input_alias stage)
+									(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+									false)))))))))))
 
 (define exists_probe_expr (lambda (stage lookup_keys)
 	(list (quote exists_probe) stage lookup_keys)))
@@ -1131,7 +1130,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(stage_source_outer? outer_sources)
 			(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
-		(if (exists_probe_expr_supported? stage)
+		(if (exists_probe_supported? stage)
 			(list
 				(exists_probe_expr stage lookup_keys)
 				'()
@@ -3291,9 +3290,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define stage_reorder_strategy (lambda (stage)
 	(match (qassoc_get (gs_facts stage) (quote purpose) nil)
-		(symbol exists) (if (exists_probe_supported? stage)
-			(quote storage_index_probe)
-			(quote group_cache_read))
+		(symbol exists) (quote group_cache_read)
 		(symbol not_exists) (quote group_cache_read)
 		(symbol in_membership) (quote group_cache_read)
 		(symbol in_candidate) (quote candidate_keyset)
@@ -3737,7 +3734,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(begin
 		(define src (gs_input stage))
 		(define alias (group_stage_input_alias stage))
-		(define probe_sources (cons src sources))
 		(define keys (gs_keys stage))
 		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
 		(define key_terms (if (equal? (count keys) (count lookup_keys))
@@ -3756,7 +3752,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons (quote list) filtercols)
 			(list (quote lambda)
 				(map filtercols (lambda (col) (symbol (concat alias "." col))))
-				(list (quote optimize) (lower_column_expr_for_join probe_sources alias filter_expr)))))))
+				(list (quote optimize) (lower_column_expr_for_join (cons src sources) alias filter_expr)))))))
 
 (define scalar_first_probe_parts (lambda (ag)
 	(match ag
@@ -5021,53 +5017,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 			(scalar_first_probe_stage? stage)))))
 
-(define exists_probe_stage? (lambda (stage)
-	(and (group_stage? stage) (exists_probe_supported? stage))))
-
-(define exists_probe_stage_output_source? (lambda (stages src)
-	(and (stage_output_relation? (source_relation src))
-		(begin
-			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
-			(exists_probe_stage? stage)))))
-
-(define exists_probe_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
-	(reduce (coalesceNil sources '()) (lambda (found src)
-			(if (not (nil? found))
-				found
-				(if (and (exists_probe_stage_output_source? stages src)
-					(source_alias_matches? src default_alias tblvar tbl_ignorecase))
-					(stage_by_id stages (stage_output_relation_id (source_relation src)))
-					nil)))
-		nil)))
-
-(define exists_probe_count_ref_stage (lambda (stages sources default_alias expr)
-	(match expr
-		((symbol get_column) tblvar tbl_ignorecase col _col_ignorecase) (begin
-			(define stage (exists_probe_stage_for_alias stages sources default_alias tblvar tbl_ignorecase))
-			(if (and (not (nil? stage)) (equal? col (aggregate_col_name aggregate_count_descriptor)))
-				stage
-				nil))
-		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(exists_probe_count_ref_stage stages sources default_alias (list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
-		_ nil)))
-
-(define exists_probe_compare_expr (lambda (stages sources default_alias expr op value)
-	(begin
-		(define stage (exists_probe_count_ref_stage stages sources default_alias expr))
-		(if (and (not (nil? stage)) (and (equal? op (quote >)) (equal? value 0)))
-			(exists_probe_expr stage (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
-			(list op
-				(rewrite_exists_probe_expr stages sources default_alias expr)
-				(rewrite_exists_probe_expr stages sources default_alias value))))))
-
-(define rewrite_exists_probe_expr (lambda (stages sources default_alias expr)
-	(match expr
-		((symbol >) left right) (exists_probe_compare_expr stages sources default_alias left (quote >) right)
-		((quote >) left right) (exists_probe_compare_expr stages sources default_alias left (quote >) right)
-		(cons head tail) (cons head (map tail (lambda (item)
-			(rewrite_exists_probe_expr stages sources default_alias item))))
-		_ expr)))
-
 (define scalar_first_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(if (not (nil? found))
@@ -5101,25 +5050,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 			'(expr dir) (list (rewrite_scalar_first_probe_expr stages sources default_alias expr) dir)
 			_ item)))))
 
-(define rewrite_exists_probe_fields (lambda (stages sources default_alias fields)
-	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
-		(rewrite_exists_probe_expr stages sources default_alias expr)))))
-
-(define rewrite_exists_probe_order (lambda (stages sources default_alias order_items)
-	(map (coalesceNil order_items '()) (lambda (item)
-		(match item
-			'(expr dir) (list (rewrite_exists_probe_expr stages sources default_alias expr) dir)
-			_ item)))))
-
-(define rewrite_exists_probe_sources (lambda (stages sources default_alias)
-	(map (coalesceNil sources '()) (lambda (src)
-		(list
-			(source_alias src)
-			(source_schema src)
-			(source_relation src)
-			(source_outer? src)
-			(rewrite_exists_probe_expr stages sources default_alias (source_join_expr src)))))))
-
 (define rewrite_scalar_first_probe_sources (lambda (stages sources default_alias)
 	(map (coalesceNil sources '()) (lambda (src)
 		(list
@@ -5133,37 +5063,27 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(filter (coalesceNil sources '()) (lambda (src)
 		(not (scalar_first_stage_output_source? stages src))))))
 
-(define sources_without_exists_probe_outputs (lambda (stages sources)
-	(filter (coalesceNil sources '()) (lambda (src)
-		(not (exists_probe_stage_output_source? stages src))))))
-
 (define stages_without_scalar_first_probes (lambda (stages)
 	(filter (coalesceNil stages '()) (lambda (stage)
 		(not (scalar_first_probe_stage? stage))))))
-
-(define stages_without_exists_probe_stages (lambda (stages)
-	(filter (coalesceNil stages '()) (lambda (stage)
-		(not (exists_probe_stage? stage))))))
 
 (define query_block_with_scalar_first_probes_using (lambda (stages block)
 	(begin
 		(define sources (qb_sources block))
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
-		(define exists_rewritten_sources (rewrite_exists_probe_sources stages sources default_alias))
-		(define rewritten_sources (rewrite_scalar_first_probe_sources stages exists_rewritten_sources default_alias))
-		(define exists_rewritten_stages (stages_without_exists_probe_stages (qb_stages block)))
+		(define rewritten_sources (rewrite_scalar_first_probe_sources stages sources default_alias))
 		(make_query_block
 			(qb_schema block)
-			(sources_without_exists_probe_outputs stages (sources_without_scalar_first_outputs stages rewritten_sources))
-			(rewrite_scalar_first_probe_fields stages sources default_alias (rewrite_exists_probe_fields stages sources default_alias (qb_fields block)))
-			(rewrite_scalar_first_probe_expr stages sources default_alias (rewrite_exists_probe_expr stages sources default_alias (qb_where block)))
+			(sources_without_scalar_first_outputs stages rewritten_sources)
+			(rewrite_scalar_first_probe_fields stages sources default_alias (qb_fields block))
+			(rewrite_scalar_first_probe_expr stages sources default_alias (qb_where block))
 			(qb_group block)
-			(rewrite_scalar_first_probe_expr stages sources default_alias (rewrite_exists_probe_expr stages sources default_alias (qb_having block)))
-			(rewrite_scalar_first_probe_order stages sources default_alias (rewrite_exists_probe_order stages sources default_alias (qb_order block)))
+			(rewrite_scalar_first_probe_expr stages sources default_alias (qb_having block))
+			(rewrite_scalar_first_probe_order stages sources default_alias (qb_order block))
 			(qb_limit block)
 			(qb_offset block)
-			(rewrite_scalar_first_probe_fields stages sources default_alias (rewrite_exists_probe_fields stages sources default_alias (qb_hidden block)))
-			(stages_without_scalar_first_probes exists_rewritten_stages)
+			(rewrite_scalar_first_probe_fields stages sources default_alias (qb_hidden block))
+			(stages_without_scalar_first_probes (qb_stages block))
 			(qb_facts block)))))
 
 (define query_block_without_stages_after_prepare_using (lambda (stages block)
@@ -5827,8 +5747,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(filter (qb_stages block) (lambda (stage)
 				(not (row_number_stage_consumed_by_join? stage (qb_sources block))))))
 		(lambda (stage)
-			(and (not (scalar_first_probe_stage? stage))
-				(not (exists_probe_stage? stage)))))))
+			(not (scalar_first_probe_stage? stage))))))
 
 (define lower_query_block_with_stages (lambda (block)
 	(if (empty_list? (qb_stages block))

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -19,6 +19,7 @@ package storage
 import "fmt"
 import "time"
 import "runtime/debug"
+import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
 
 type scanError struct {
@@ -83,6 +84,65 @@ type scanResult struct {
 	outCount   int64
 	inputCount int64
 	err        scanError // err.r != nil indicates an error
+}
+
+func (t *table) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
+	ss := SessionStateFromTx(currentTx)
+	if ss != nil && ss.IsKilled() {
+		panic("query killed")
+	}
+	touchTempColumns(t, conditionCols, nil)
+	boundaries := extractBoundaries(conditionCols, condition)
+	reorderByFrequency(boundaries, t)
+	lower, upperLast := indexFromBoundaries(boundaries)
+	for _, b := range boundaries {
+		t.AddPartitioningScore([]string{b.col})
+	}
+
+	values := make(chan scanResult, 4)
+	var found atomic.Bool
+	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
+		if found.Load() {
+			values <- scanResult{}
+			return
+		}
+		defer func() {
+			if r := recover(); r != nil {
+				values <- scanResult{err: scanError{r, string(debug.Stack())}}
+			}
+		}()
+		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found) {
+			found.Store(true)
+			values <- scanResult{outCount: 1}
+			return
+		}
+		values <- scanResult{}
+	})
+	if done == nil {
+		close(values)
+	} else {
+		go func() {
+			<-done
+			close(values)
+		}()
+	}
+
+	var scanErr scanError
+	for msg := range values {
+		if msg.err.r != nil {
+			if scanErr.r == nil {
+				scanErr = msg.err
+			}
+			continue
+		}
+		if msg.outCount > 0 {
+			found.Store(true)
+		}
+	}
+	if scanErr.r != nil {
+		panic(scanErr)
+	}
+	return found.Load()
 }
 
 // map reduce implementation based on scheme scripts
@@ -253,6 +313,101 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 		}(analyzeNs, execNs)
 	}
 	return akkumulator
+}
+
+func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
+	if ss == nil {
+		ss = SessionStateFromTx(currentTx)
+	}
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+
+	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	cNeedsTxReader := make([]bool, len(conditionCols))
+	for i, k := range conditionCols {
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			cNeedsTxReader[i] = true
+		}
+	}
+	cdataset := make([]scm.Scmer, len(conditionCols))
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	mainCount := t.main_count
+	maxInsertIndex := len(t.inserts)
+	visibleUpper := mainCount + uint32(maxInsertIndex)
+	found := false
+
+	var buf [8]uint32
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], func(batch []uint32) bool {
+		if stop != nil && stop.Load() {
+			return false
+		}
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		for _, idx := range batch {
+			if idx >= visibleUpper {
+				continue
+			}
+			if acidMode {
+				if !currentTx.IsVisible(t, idx) {
+					continue
+				}
+			} else if t.deletions.Get(uint(idx)) {
+				continue
+			}
+			if idx < mainCount {
+				for i, c := range cReaders {
+					if cNeedsTxReader[i] {
+						cdataset[i] = c.GetValue(idx)
+					} else {
+						cdataset[i] = ccols[i].GetValue(idx)
+					}
+				}
+			} else {
+				for i, col := range conditionCols {
+					if cNeedsTxReader[i] {
+						cdataset[i] = cReaders[i].GetValue(idx)
+					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+						cdataset[i] = ccols[i].GetValue(idx)
+					} else {
+						cdataset[i] = t.getDelta(int(idx-mainCount), col)
+					}
+				}
+			}
+			if scm.ToBool(conditionFn(cdataset...)) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+
+	return found
 }
 
 func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -19,6 +19,7 @@ package storage
 import "fmt"
 import "time"
 import "runtime/debug"
+import "strings"
 import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
 
@@ -68,10 +69,179 @@ func optimizeScanShared(v []scm.Scmer, oc *scm.OptimizerContext, mapEnd, reduceI
 }
 
 func optimizeScan(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+	if rewritten := tryScanExistsRewrite(v); !rewritten.IsNil() {
+		return oc.OptimizeSub(rewritten, useResult)
+	}
 	if rewritten := tryScanBatchRewrite(v); !rewritten.IsNil() {
 		return oc.OptimizeSub(rewritten, useResult)
 	}
 	return optimizeScanShared(v, oc, 6, 7, 8, 9, 10)
+}
+
+func tryScanExistsRewrite(v []scm.Scmer) scm.Scmer {
+	// scan: [fn, tx, table, filtercols, filterfn, mapcols, mapfn, reduce, neutral, reduce2, isOuter]
+	if len(v) < 9 {
+		return scm.NewNil()
+	}
+	if len(v) > 10 && scm.ToBool(v[10]) {
+		return scm.NewNil()
+	}
+	if len(v) > 9 && !v[9].IsNil() {
+		return scm.NewNil()
+	}
+	if !scanFalseNeutral(v[8]) || !scanExistsMap(v[6]) || !scanExistsOrReducer(v[7]) {
+		return scm.NewNil()
+	}
+	if scanMapColsHaveSideEffects(v[5]) || scanExprMayHaveSideEffects(v[4]) {
+		return scm.NewNil()
+	}
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("scan_exists"),
+		v[1],
+		v[2],
+		v[3],
+		v[4],
+	})
+}
+
+func scanFalseNeutral(v scm.Scmer) bool {
+	if v.IsBool() {
+		return !v.Bool()
+	}
+	return false
+}
+
+func scanExistsMap(v scm.Scmer) bool {
+	_, body, ok := scanLambdaParts(v)
+	return ok && scanExprIsTrue(body)
+}
+
+func scanExistsOrReducer(v scm.Scmer) bool {
+	params, body, ok := scanLambdaParts(v)
+	if !ok || len(params) != 2 {
+		return false
+	}
+	left, ok1 := scanSymbolName(params[0])
+	right, ok2 := scanSymbolName(params[1])
+	if !ok1 || !ok2 {
+		return false
+	}
+	return scanExprIsOrOf(body, left, right)
+}
+
+func scanLambdaParts(v scm.Scmer) ([]scm.Scmer, scm.Scmer, bool) {
+	if !v.IsSlice() {
+		return nil, scm.NewNil(), false
+	}
+	items := v.Slice()
+	if len(items) < 3 || !scanSymbolIs(items[0], "lambda") {
+		return nil, scm.NewNil(), false
+	}
+	paramsExpr := items[1]
+	if paramsExpr.IsNil() {
+		return []scm.Scmer{}, items[2], true
+	}
+	if !paramsExpr.IsSlice() {
+		return nil, scm.NewNil(), false
+	}
+	return paramsExpr.Slice(), items[2], true
+}
+
+func scanExprIsTrue(v scm.Scmer) bool {
+	return v.IsBool() && v.Bool()
+}
+
+func scanExprIsOrOf(v scm.Scmer, left, right string) bool {
+	if !v.IsSlice() {
+		return false
+	}
+	items := v.Slice()
+	if len(items) < 3 || !scanSymbolIs(items[0], "or") {
+		return false
+	}
+	seenLeft := false
+	seenRight := false
+	for _, item := range items[1:] {
+		if item.IsBool() && !item.Bool() {
+			continue
+		}
+		if scanExprIsLambdaParam(item, left, 0) {
+			seenLeft = true
+			continue
+		}
+		if scanExprIsLambdaParam(item, right, 1) {
+			seenRight = true
+			continue
+		}
+		return false
+	}
+	return seenLeft && seenRight
+}
+
+func scanExprIsLambdaParam(v scm.Scmer, name string, idx int) bool {
+	if v.IsNthLocalVar() {
+		return int(v.NthLocalVar()) == idx
+	}
+	s, ok := scanSymbolName(v)
+	return ok && s == name
+}
+
+func scanSymbolIs(v scm.Scmer, name string) bool {
+	s, ok := scanSymbolName(v)
+	return ok && s == name
+}
+
+func scanSymbolName(v scm.Scmer) (string, bool) {
+	if v.GetTag() == scm.TagSymbol {
+		return v.String(), true
+	}
+	if !v.IsSlice() {
+		return "", false
+	}
+	items := v.Slice()
+	if len(items) == 2 && items[0].GetTag() == scm.TagSymbol && items[0].String() == "quote" && items[1].GetTag() == scm.TagSymbol {
+		return items[1].String(), true
+	}
+	return "", false
+}
+
+func scanMapColsHaveSideEffects(v scm.Scmer) bool {
+	if v.IsNil() {
+		return false
+	}
+	if !v.IsSlice() {
+		return true
+	}
+	for _, item := range v.Slice() {
+		if !item.IsString() {
+			return true
+		}
+		col := item.String()
+		if strings.HasPrefix(col, "$") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanExprMayHaveSideEffects(v scm.Scmer) bool {
+	if name, ok := scanSymbolName(v); ok {
+		switch name {
+		case "set", "define", "insert", "update", "delete", "createcolumn", "dropcolumn", "createtable", "droptable", "createkey", "dropkey", "resultrow", "print", "error", "$update":
+			return true
+		default:
+			return false
+		}
+	}
+	if !v.IsSlice() {
+		return false
+	}
+	for _, item := range v.Slice() {
+		if scanExprMayHaveSideEffects(item) {
+			return true
+		}
+	}
+	return false
 }
 
 func optimizeScanBatch(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
@@ -362,7 +532,7 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	found := false
 
 	var buf [8]uint32
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2218,64 +2218,6 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	return
 }
 
-func (t *storageShard) ProbeExists(columns []string, values []scm.Scmer, currentTx *TxContext) bool {
-	t.ensureMainCount(false)
-	mcols := make([]ColumnStorage, len(columns))
-	for i, col := range columns {
-		mcols[i] = t.getColumnStorageOrPanic(col)
-	}
-
-	bounds := make(boundaries, len(columns))
-	for i, col := range columns {
-		bounds[i] = columnboundaries{col: col, matcher: EqualMatcher, lower: values[i], lowerInclusive: true, upper: values[i], upperInclusive: true}
-	}
-	lower, upperLast := indexFromBoundaries(bounds)
-
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	acidMode := currentTx != nil && currentTx.Mode == TxACID
-	mainCount := t.main_count
-	found := false
-
-	var buf [8]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], true, func(batch []uint32) bool {
-		for _, idx := range batch {
-			matched := true
-			if idx < mainCount {
-				for j, v := range values {
-					if !scm.Equal(mcols[j].GetValue(idx), v) {
-						matched = false
-						break
-					}
-				}
-			} else {
-				for j, v := range values {
-					if !scm.Equal(t.getDelta(int(idx-mainCount), columns[j]), v) {
-						matched = false
-						break
-					}
-				}
-			}
-			if !matched {
-				continue
-			}
-			if acidMode {
-				if currentTx.IsVisible(t, idx) {
-					found = true
-					return false
-				}
-			} else if !t.deletions.Get(uint(idx)) {
-				found = true
-				return false
-			}
-		}
-		return true
-	})
-
-	return found
-}
-
 func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition scm.Scmer, limit int, currentTx *TxContext) (int64, bool) {
 	if limit <= 0 {
 		limit = 1024

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -508,7 +508,7 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
-		Name: "probe_exists",
+		Name: "scan_exists",
 		Desc: "returns true if a table contains at least one visible row matching equality values for the given columns; uses storage indexes directly without scan lambda setup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
@@ -516,7 +516,7 @@ func Init(en scm.Env) {
 			columns := scmerSliceToStrings(mustScmerSlice(a[2], "columns"))
 			values := mustScmerSlice(a[3], "values")
 			if len(columns) != len(values) {
-				panic("probe_exists: columns and values must have the same length")
+				panic("scan_exists: columns and values must have the same length")
 			}
 			for _, shard := range t.ActiveShards() {
 				if shard != nil && shard.ProbeExists(columns, values, currentTx) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -509,28 +509,35 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_exists",
-		Desc: "returns true if a table contains at least one visible row matching equality values for the given columns; uses storage indexes directly without scan lambda setup",
+		Desc: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
-			t := TableFromScmer(a[1])
-			columns := scmerSliceToStrings(mustScmerSlice(a[2], "columns"))
-			values := mustScmerSlice(a[3], "values")
-			if len(columns) != len(values) {
-				panic("scan_exists: columns and values must have the same length")
-			}
-			for _, shard := range t.ActiveShards() {
-				if shard != nil && shard.ProbeExists(columns, values, currentTx) {
-					return scm.NewBool(true)
+			filtercols := scmerSliceToStrings(mustScmerSlice(a[2], "filterColumns"))
+			tableArg := a[1]
+			if list, ok := scmerSlice(tableArg); ok {
+				filterfn := scm.OptimizeProcToSerialFunction(a[3])
+				filterparams := make([]scm.Scmer, len(filtercols))
+				for _, val := range list {
+					row := mustScmerSlice(val, "scan_exists list row")
+					ds := dataset(row)
+					for i, col := range filtercols {
+						filterparams[i], _ = ds.GetI(col)
+					}
+					if scm.ToBool(filterfn(filterparams...)) {
+						return scm.NewBool(true)
+					}
 				}
+				return scm.NewBool(false)
 			}
-			return scm.NewBool(false)
+			t := TableFromScmer(tableArg)
+			return scm.NewBool(t.scanExists(currentTx, filtercols, a[3]))
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table", ParamName: "table"},
-				{Kind: "list", ParamName: "columns"},
-				{Kind: "list", ParamName: "values"},
+				{Kind: "table|list", ParamName: "table"},
+				{Kind: "list", ParamName: "filterColumns"},
+				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a row exists", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -6,9 +6,6 @@ metadata:
   isolated: true
 
 setup:
-  - sql: "DROP TABLE IF EXISTS dv_acl"
-  - sql: "DROP TABLE IF EXISTS dv_file"
-  - sql: "DROP TABLE IF EXISTS dv_doc"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"
   - sql: |
@@ -28,46 +25,6 @@ setup:
   - sql: |
       INSERT INTO exists_orders (ID, customer_id, total) VALUES
       (101, 1, 100.00), (102, 1, 200.00), (103, 2, 150.00)
-  - sql: |
-      CREATE TABLE dv_doc (
-        ID INT PRIMARY KEY,
-        file_id INT,
-        tenant_id INT,
-        location_id INT,
-        upload_ts INT,
-        title VARCHAR(64)
-      )
-  - sql: |
-      CREATE TABLE dv_file (
-        ID INT PRIMARY KEY,
-        filename VARCHAR(64),
-        search_text VARCHAR(64)
-      )
-  - sql: |
-      CREATE TABLE dv_acl (
-        ID INT PRIMARY KEY,
-        user_id INT,
-        tenant_id INT,
-        location_id INT
-      )
-  - sql: |
-      INSERT INTO dv_doc (ID, file_id, tenant_id, location_id, upload_ts, title) VALUES
-      (1, 10, 100, 501, 5001, 'alpha'),
-      (2, 11, 101, 502, 5002, 'beta'),
-      (3, 12, 102, 503, 5003, 'blocked'),
-      (4, 13, 103, 504, 5004, 'miss')
-  - sql: |
-      INSERT INTO dv_file (ID, filename, search_text) VALUES
-      (10, 'alpha-hit.pdf', 'plain text'),
-      (11, 'report.pdf', 'contains needle'),
-      (12, 'blocked-hit.pdf', 'plain text'),
-      (13, 'unmatched.pdf', 'plain text')
-  - sql: |
-      INSERT INTO dv_acl (ID, user_id, tenant_id, location_id) VALUES
-      (1, 8, 100, NULL),
-      (2, 8, NULL, 502),
-      (3, 9, 102, NULL),
-      (4, 7, NULL, NULL)
 
 test_cases:
   - name: "EXISTS with correlated subquery - customers with orders"
@@ -115,34 +72,20 @@ test_cases:
       not_contains:
         - "touch_keytable"
 
-  - name: "Correlated EXISTS probe supports scan-style range filters"
-    steps:
-      - sql: |
-          SELECT ID, name FROM exists_customers c
-          WHERE EXISTS (
-            SELECT 1 FROM exists_orders o
-            WHERE o.customer_id = c.ID
-              AND o.total > 150
-          )
-          ORDER BY ID
-        expect:
-          rows: 1
-          data:
-            - ID: 1
-              name: "Alice"
-      - sql: |
-          EXPLAIN SELECT ID, name FROM exists_customers c
-          WHERE EXISTS (
-            SELECT 1 FROM exists_orders o
-            WHERE o.customer_id = c.ID
-              AND o.total > 150
-          )
-          ORDER BY ID
-        expect:
-          contains:
-            - "scan_exists"
-          not_contains:
-            - "touch_keytable"
+  - name: "Correlated EXISTS with range filter keeps correct SQL result"
+    sql: |
+      SELECT ID, name FROM exists_customers c
+      WHERE EXISTS (
+        SELECT 1 FROM exists_orders o
+        WHERE o.customer_id = c.ID
+          AND o.total > 150
+      )
+      ORDER BY ID
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          name: "Alice"
 
   - name: "Optimizer rewrites generated EXISTS scan pattern to scan_exists"
     scm: |
@@ -334,162 +277,6 @@ test_cases:
             - "touch_keytable"
             - "\"__cnt\""
 
-  - name: "Dataview-shaped repeated ACL EXISTS use prepared storage probes"
-    steps:
-      - sql: "SET @acl_user := 8"
-        session_id: "dv-acl-probe"
-      - sql: |
-          SELECT
-            d.ID,
-            d.title,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.tenant_id = d.tenant_id
-            ) AS tenant_allowed,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.location_id = d.location_id
-            ) AS location_allowed
-          FROM dv_doc d
-          WHERE d.file_id IN (
-              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
-              UNION
-              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
-            )
-            AND (
-              EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id IS NULL
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id = d.tenant_id
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.location_id = d.location_id
-              )
-            )
-          ORDER BY d.upload_ts DESC
-          LIMIT 2
-        session_id: "dv-acl-probe"
-        expect:
-          rows: 2
-          data:
-            - ID: 2
-              title: "beta"
-              tenant_allowed: false
-              location_allowed: true
-            - ID: 1
-              title: "alpha"
-              tenant_allowed: true
-              location_allowed: false
-      - sql: |
-          EXPLAIN REORDER SELECT
-            d.ID,
-            d.title,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.tenant_id = d.tenant_id
-            ) AS tenant_allowed,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.location_id = d.location_id
-            ) AS location_allowed
-          FROM dv_doc d
-          WHERE d.file_id IN (
-              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
-              UNION
-              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
-            )
-            AND (
-              EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id IS NULL
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id = d.tenant_id
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.location_id = d.location_id
-              )
-            )
-          ORDER BY d.upload_ts DESC
-          LIMIT 2
-        session_id: "dv-acl-probe"
-        expect:
-          contains:
-            - "group_stage_strategy"
-            - "exists_probe"
-            - "in_candidate"
-          not_contains:
-            - "inner_select"
-            - "dependent-subquery"
-            - "legacy_materialized"
-      - sql: |
-          EXPLAIN SELECT
-            d.ID,
-            d.title,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.tenant_id = d.tenant_id
-            ) AS tenant_allowed,
-            EXISTS (
-              SELECT 1 FROM dv_acl a
-              WHERE a.user_id = @acl_user
-                AND a.location_id = d.location_id
-            ) AS location_allowed
-          FROM dv_doc d
-          WHERE d.file_id IN (
-              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
-              UNION
-              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
-            )
-            AND (
-              EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id IS NULL
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.tenant_id = d.tenant_id
-              )
-              OR EXISTS (
-                SELECT 1 FROM dv_acl a
-                WHERE a.user_id = @acl_user
-                  AND a.location_id = d.location_id
-              )
-            )
-          ORDER BY d.upload_ts DESC
-          LIMIT 2
-        session_id: "dv-acl-probe"
-        expect:
-          contains:
-            - "scan_exists"
-            - "dv_acl"
-          not_contains:
-            - "inner_select"
-            - "dependent-subquery"
-            - "legacy_materialized"
-
 cleanup:
-  - sql: "DROP TABLE IF EXISTS dv_acl"
-  - sql: "DROP TABLE IF EXISTS dv_file"
-  - sql: "DROP TABLE IF EXISTS dv_doc"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -64,14 +64,6 @@ test_cases:
             - "__mat:_uncorr_cnt_"
             - "touch_keytable"
 
-  - name: "EXPLAIN correlated EXISTS uses direct storage probe"
-    sql: "EXPLAIN SELECT ID, name FROM exists_customers c WHERE EXISTS (SELECT 1 FROM exists_orders o WHERE o.customer_id = c.ID) ORDER BY ID"
-    expect:
-      contains:
-        - "scan_exists"
-      not_contains:
-        - "touch_keytable"
-
   - name: "Correlated EXISTS with range filter keeps correct SQL result"
     sql: |
       SELECT ID, name FROM exists_customers c

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -144,6 +144,66 @@ test_cases:
           not_contains:
             - "touch_keytable"
 
+  - name: "Optimizer rewrites generated EXISTS scan pattern to scan_exists"
+    scm: |
+      (begin
+        (define plan (serialize (optimize
+          (list 'scan
+            nil
+            (list 'table "memcp-tests" "exists_orders")
+            (list "customer_id" "total")
+            (list 'lambda (list 'customer_id 'total)
+              (list 'and (list 'equal?? 'customer_id 1) (list '> 'total 150)))
+            (list)
+            (list 'lambda (list) true)
+            (list 'lambda (list 'acc 'row) (list 'or 'acc 'row))
+            false
+            nil
+            false))))
+        (if (not (match plan (regex "scan_exists" _) true false))
+          (error (concat "expected scan_exists rewrite, got " plan)))
+        (if (match plan (regex "^\\(scan " _) true false)
+          (error (concat "old scan survived EXISTS rewrite: " plan)))
+        true)
+
+  - name: "Optimizer rewrites generated EXISTS scan even with ignored map columns"
+    scm: |
+      (begin
+        (define plan (serialize (optimize
+          (list 'scan
+            nil
+            (list 'table "memcp-tests" "exists_orders")
+            (list "customer_id")
+            (list 'lambda (list 'customer_id) (list 'equal?? 'customer_id 1))
+            (list "ID")
+            (list 'lambda (list 'ID) true)
+            (list 'lambda (list 'a 'b) (list 'or 'b 'a))
+            false
+            nil
+            false))))
+        (if (not (match plan (regex "scan_exists" _) true false))
+          (error (concat "expected scan_exists rewrite with ignored map column, got " plan)))
+        true)
+
+  - name: "Optimizer keeps non-EXISTS scan with projected map value"
+    scm: |
+      (begin
+        (define plan (serialize (optimize
+          (list 'scan
+            nil
+            (list 'table "memcp-tests" "exists_orders")
+            (list "customer_id")
+            (list 'lambda (list 'customer_id) (list 'equal?? 'customer_id 1))
+            (list "ID")
+            (list 'lambda (list 'ID) 'ID)
+            (list 'lambda (list 'a 'b) (list 'or 'a 'b))
+            false
+            nil
+            false))))
+        (if (match plan (regex "scan_exists" _) true false)
+          (error (concat "projecting scan must not become scan_exists: " plan)))
+        true)
+
   - name: "NOT EXISTS - customers without orders"
     sql: |
       SELECT ID, name FROM exists_customers c

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -115,6 +115,35 @@ test_cases:
       not_contains:
         - "touch_keytable"
 
+  - name: "Correlated EXISTS probe supports scan-style range filters"
+    steps:
+      - sql: |
+          SELECT ID, name FROM exists_customers c
+          WHERE EXISTS (
+            SELECT 1 FROM exists_orders o
+            WHERE o.customer_id = c.ID
+              AND o.total > 150
+          )
+          ORDER BY ID
+        expect:
+          rows: 1
+          data:
+            - ID: 1
+              name: "Alice"
+      - sql: |
+          EXPLAIN SELECT ID, name FROM exists_customers c
+          WHERE EXISTS (
+            SELECT 1 FROM exists_orders o
+            WHERE o.customer_id = c.ID
+              AND o.total > 150
+          )
+          ORDER BY ID
+        expect:
+          contains:
+            - "scan_exists"
+          not_contains:
+            - "touch_keytable"
+
   - name: "NOT EXISTS - customers without orders"
     sql: |
       SELECT ID, name FROM exists_customers c

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -6,6 +6,9 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS dv_acl"
+  - sql: "DROP TABLE IF EXISTS dv_file"
+  - sql: "DROP TABLE IF EXISTS dv_doc"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"
   - sql: |
@@ -25,6 +28,46 @@ setup:
   - sql: |
       INSERT INTO exists_orders (ID, customer_id, total) VALUES
       (101, 1, 100.00), (102, 1, 200.00), (103, 2, 150.00)
+  - sql: |
+      CREATE TABLE dv_doc (
+        ID INT PRIMARY KEY,
+        file_id INT,
+        tenant_id INT,
+        location_id INT,
+        upload_ts INT,
+        title VARCHAR(64)
+      )
+  - sql: |
+      CREATE TABLE dv_file (
+        ID INT PRIMARY KEY,
+        filename VARCHAR(64),
+        search_text VARCHAR(64)
+      )
+  - sql: |
+      CREATE TABLE dv_acl (
+        ID INT PRIMARY KEY,
+        user_id INT,
+        tenant_id INT,
+        location_id INT
+      )
+  - sql: |
+      INSERT INTO dv_doc (ID, file_id, tenant_id, location_id, upload_ts, title) VALUES
+      (1, 10, 100, 501, 5001, 'alpha'),
+      (2, 11, 101, 502, 5002, 'beta'),
+      (3, 12, 102, 503, 5003, 'blocked'),
+      (4, 13, 103, 504, 5004, 'miss')
+  - sql: |
+      INSERT INTO dv_file (ID, filename, search_text) VALUES
+      (10, 'alpha-hit.pdf', 'plain text'),
+      (11, 'report.pdf', 'contains needle'),
+      (12, 'blocked-hit.pdf', 'plain text'),
+      (13, 'unmatched.pdf', 'plain text')
+  - sql: |
+      INSERT INTO dv_acl (ID, user_id, tenant_id, location_id) VALUES
+      (1, 8, 100, NULL),
+      (2, 8, NULL, 502),
+      (3, 9, 102, NULL),
+      (4, 7, NULL, NULL)
 
 test_cases:
   - name: "EXISTS with correlated subquery - customers with orders"
@@ -68,7 +111,7 @@ test_cases:
     sql: "EXPLAIN SELECT ID, name FROM exists_customers c WHERE EXISTS (SELECT 1 FROM exists_orders o WHERE o.customer_id = c.ID) ORDER BY ID"
     expect:
       contains:
-        - "probe_exists"
+        - "scan_exists"
       not_contains:
         - "touch_keytable"
 
@@ -202,6 +245,162 @@ test_cases:
             - "touch_keytable"
             - "\"__cnt\""
 
+  - name: "Dataview-shaped repeated ACL EXISTS use prepared storage probes"
+    steps:
+      - sql: "SET @acl_user := 8"
+        session_id: "dv-acl-probe"
+      - sql: |
+          SELECT
+            d.ID,
+            d.title,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.tenant_id = d.tenant_id
+            ) AS tenant_allowed,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.location_id = d.location_id
+            ) AS location_allowed
+          FROM dv_doc d
+          WHERE d.file_id IN (
+              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
+              UNION
+              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
+            )
+            AND (
+              EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id IS NULL
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id = d.tenant_id
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.location_id = d.location_id
+              )
+            )
+          ORDER BY d.upload_ts DESC
+          LIMIT 2
+        session_id: "dv-acl-probe"
+        expect:
+          rows: 2
+          data:
+            - ID: 2
+              title: "beta"
+              tenant_allowed: false
+              location_allowed: true
+            - ID: 1
+              title: "alpha"
+              tenant_allowed: true
+              location_allowed: false
+      - sql: |
+          EXPLAIN REORDER SELECT
+            d.ID,
+            d.title,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.tenant_id = d.tenant_id
+            ) AS tenant_allowed,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.location_id = d.location_id
+            ) AS location_allowed
+          FROM dv_doc d
+          WHERE d.file_id IN (
+              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
+              UNION
+              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
+            )
+            AND (
+              EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id IS NULL
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id = d.tenant_id
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.location_id = d.location_id
+              )
+            )
+          ORDER BY d.upload_ts DESC
+          LIMIT 2
+        session_id: "dv-acl-probe"
+        expect:
+          contains:
+            - "group_stage_strategy"
+            - "exists_probe"
+            - "in_candidate"
+          not_contains:
+            - "inner_select"
+            - "dependent-subquery"
+            - "legacy_materialized"
+      - sql: |
+          EXPLAIN SELECT
+            d.ID,
+            d.title,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.tenant_id = d.tenant_id
+            ) AS tenant_allowed,
+            EXISTS (
+              SELECT 1 FROM dv_acl a
+              WHERE a.user_id = @acl_user
+                AND a.location_id = d.location_id
+            ) AS location_allowed
+          FROM dv_doc d
+          WHERE d.file_id IN (
+              SELECT f.ID FROM dv_file f WHERE f.filename LIKE '%hit%'
+              UNION
+              SELECT f.ID FROM dv_file f WHERE f.search_text LIKE '%needle%'
+            )
+            AND (
+              EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id IS NULL
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.tenant_id = d.tenant_id
+              )
+              OR EXISTS (
+                SELECT 1 FROM dv_acl a
+                WHERE a.user_id = @acl_user
+                  AND a.location_id = d.location_id
+              )
+            )
+          ORDER BY d.upload_ts DESC
+          LIMIT 2
+        session_id: "dv-acl-probe"
+        expect:
+          contains:
+            - "scan_exists"
+            - "dv_acl"
+          not_contains:
+            - "inner_select"
+            - "dependent-subquery"
+            - "legacy_materialized"
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS dv_acl"
+  - sql: "DROP TABLE IF EXISTS dv_file"
+  - sql: "DROP TABLE IF EXISTS dv_doc"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"


### PR DESCRIPTION
## Summary

- expose `scan_exists` as the scan-style physical EXISTS operator: `tx + table/list + filtercols + filterfn -> bool`
- keep the existing logical EXISTS group-stage model, but lower the existing direct probe path to `scan_exists` instead of the old equality-only storage helper
- add a conservative Go optimizer rewrite from generated EXISTS-shaped `scan` plans to `scan_exists`
- cover SQL correctness plus generated physical scan patterns in `tests/40_exists_subquery.yaml`, including a negative projection case that must remain `scan`

## Scope after cleanup

This PR is intentionally small. It does **not** introduce the broader Stage-Output/Projection rewrite for ACL/dataview plans. That attempted path was cut back because it had alias-scope edge cases around derived-table LEFT JOIN projections and global EXISTS stages.

Remaining scope:

- physical operator: `scan_exists`
- direct existing logical EXISTS probe lowering to `scan_exists`
- Go optimizer rewrite for generated EXISTS-shaped scans
- YAML coverage for correctness and generated physical rewrite shape

Out of scope for this PR:

- no new stage-output removal logic
- no projection-field EXISTS rewrite
- no dataview-specific plan rewrite
- no customer/project-specific test data

## Optimizer rewrite shape

The rewrite only fires for scans that are semantically an EXISTS/ANY probe:

```scheme
(scan tx table filtercols filterfn mapcols (lambda (...) true) (lambda (a b) (or a b)) false nil false)
=>
(scan_exists tx table filtercols filterfn)
```

Safety gates:

- neutral element must be boolean `false`
- reduce2 must be absent
- outer-scan mode must be false
- map function must return constant `true`
- reducer must be boolean OR over its two lambda parameters, including optimizer-generated `(var 0)/(var 1)` bodies
- map columns with `$` pseudo-columns are rejected
- obvious side-effecting filter forms are rejected

## A/B performance validation

The strong speedup below is a physical operator benchmark, not an end-to-end SQL-query benchmark. It measures the case where a plan already chooses `scan_exists`.

Measured on the same host, CPU `AMD Ryzen 9 7900X3D 12-Core Processor`, 100k in-memory rows, 7 repeats per case:

```bash
go test ./storage -run "^$" -bench "BenchmarkExists" -benchtime=1s -count=7 -benchmem
```

Compared commits:

- master at measurement: `9dbd355f3`
- PR head at measurement: `5aff12799`

The current head `752f5d00` only cuts back Scheme planner scope and removes an unverified SQL plan assertion; it does not change the measured Go storage/operator path.

Median results:

| Case | master scan+OR | PR scan+OR | PR scan_exists | speedup vs master | allocs master -> scan_exists |
| --- | ---: | ---: | ---: | ---: | ---: |
| point hit | 1.002 ms/op | 1.020 ms/op | 83.4 us/op | 12.0x | 35 -> 24 |
| many hits | 1.056 ms/op | 0.949 ms/op | 5.85 us/op | 180.7x | 135 -> 20 |
| early range hit | 2.573 ms/op | 2.998 ms/op | 4.50 us/op | 572.3x | 100035 -> 19 |

Ranges over 7 repeats:

| Case | master scan+OR min..max | PR scan_exists min..max |
| --- | ---: | ---: |
| point hit | 0.979..1.025 ms/op | 81.98..84.91 us/op |
| many hits | 1.020..1.074 ms/op | 5.37..5.94 us/op |
| early range hit | 2.530..2.825 ms/op | 4.44..4.52 us/op |

Interpretation: the normal `scan` path itself is not the win. The win appears only when the physical EXISTS operator is selected, because unordered `scan` has no global EXISTS early-out and still opens the map/reduce path. `scan_exists` avoids map/reduce setup and stops shards via a shared found flag.

## SQL-query check

I checked whether simple real SQL queries from `tests/40_exists_subquery.yaml` already benefit end-to-end. They do not in the simple COUNT/LIMIT form I measured against current `origin/master` (`3bdb93657`) and PR head.

Synthetic SQL dataset: 2,000 outer rows, 1,000 matching inner rows.

| Query | master median | PR median | Plan marker |
| --- | ---: | ---: | --- |
| `COUNT(*) WHERE EXISTS (...)` | 883.5 ms | 896.9 ms | neither the old equality helper nor `scan_exists` |
| `SELECT ... WHERE EXISTS (...) ORDER BY ... LIMIT 20` | 107.0 ms | 107.0 ms | neither the old equality helper nor `scan_exists` |

So the current PR should not claim that ordinary SQL queries broadly speed up. It provides the physical operator and generated-plan rewrite; further planner work is needed to route more SQL shapes to it.

## Application plan inspection

I also inspected the physical plan of the saved fullsearch dataview query on the imported application dataset with `@fop_user = 342`.

Plan timings on PR head:

- `EXPLAIN`: 1.16s, 453 KB plan
- `EXPLAIN IR`: 0.76s, 199 KB IR
- `EXPLAIN REORDER`: 0.78s, 230 KB reorder IR

Plan markers:

| Marker | EXPLAIN | IR | REORDER |
| --- | ---: | ---: | ---: |
| `scan_exists` | 14 | 0 | 0 |
| `scan_batch` | 0 | 0 | 0 |
| `touch_keytable` | 60 | 0 | 0 |
| `.grp:` | 412 | 0 | 0 |
| `group-stage` | 0 | 60 | 60 |
| `group_cache_read` | 0 | 0 | 78 |
| `candidate_keyset` | 0 | 0 | 4 |
| `legacy_materialized` / `inner_select` / `.mat:` | 0 | 0 | 0 |

Interpretation: the real application query does use `scan_exists` for some direct ACL probes (`userMandant.user = @fop_user AND userMandant.mandant = outer.ID`), but the dominant physical plan is still group-keytable preparation and group-cache reads. This PR is therefore useful as a small operator building block, but it is not the main application-query speedup.

## Validation

Passed locally on current head `752f5d00`:

- `make`
- `timeout 8 ./memcp --api-port=26394 --disable-mysql` -> startup Scheme tests passed
- `python3 tools/lint_scm.py --check --path lib/queryplan.scm`
- `python3 run_sql_tests.py tests/40_exists_subquery.yaml --port 26417 --fail-fast` -> 15/15

Previously also passed on the same branch line after cleanup:

- `python3 run_sql_tests.py tests/66_circular_queryplan.yaml --port 26392 --fail-fast` -> 5/5
- `python3 run_sql_tests.py tests/41_in_subquery.yaml tests/87_scan_batch_optimizer.yaml --port 26393 --fail-fast` -> 41/41 and 7/7

Note: while reviewing this, I found that `expect.contains` is not enforced for successful non-error responses by the current YAML runner. This PR removed the misleading SQL `scan_exists` plan assertion instead of relying on that weak gate.

## Follow-up

The full application dataview speedup still needs planner work beyond this PR: selectivity, ACL domain extraction, if-hoisting, candidate-id streaming, and reducing repeated group-keytable preparation. This PR is only the small reusable physical operator and optimizer building block.

