### PR TITLE
Fix index memory accounting

### DIFF
--- a/storage/cache.go
+++ b/storage/cache.go
@@ -544,6 +544,18 @@ func (cm *CacheManager) removeInternal(pointer any, freedByType *[numEvictableTy
 	delete(cm.itemMap, pointer)
 }
 
+// removeIndexChildrenInternal removes eviction records for soft sub-items owned
+// by an index. The parent index owns the actual references and is responsible
+// for clearing them; this only keeps CacheManager bookkeeping in sync when the
+// parent is evicted or deregistered.
+func (cm *CacheManager) removeIndexChildrenInternal(index *StorageIndex, freedByType *[numEvictableTypes]int64) {
+	for pointer := range cm.itemMap {
+		if entry, ok := pointer.(*skipListCacheEntry); ok && entry.index == index {
+			cm.removeInternal(pointer, freedByType)
+		}
+	}
+}
+
 // updateSizeInternal adjusts size and recomputes heap position.
 func (cm *CacheManager) updateSizeInternal(pointer any, delta int64) {
 	item, ok := cm.itemMap[pointer]
@@ -698,12 +710,10 @@ func (cs CacheStat) FormatStat() string {
 	if shardColsOnly < 0 {
 		shardColsOnly = 0
 	}
-	var totalEvictable int64
-	for i := range cs.SizeByType {
-		totalEvictable += cs.SizeByType[i]
-	}
-	// subtract index double-count for display
-	totalEvictable -= cs.SizeByType[TypeIndex]
+	// Index sub-items, such as LIKE skip lists, may be registered separately so
+	// eviction can assign them their own weight and age. Those registrations are
+	// eviction records, not additional raw RAM copies, so aggregate RAM displays
+	// must avoid reading them as a second live allocation.
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("TotalBudget = %s\tPersistedBudget = %s\tTracked = %s\tPersisted = %s\n",

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -651,7 +651,7 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 			s.ensureMainCount(false)
 			var buf [1024]uint32
 			rowVals := make([]scm.Scmer, nCols)
-			s.iterateIndex(nil, bounds, lower, upperLast, len(s.inserts), buf[:], func(batch []uint32) bool {
+			s.iterateIndex(nil, bounds, lower, upperLast, len(s.inserts), buf[:], true, func(batch []uint32) bool {
 				for _, idx := range batch {
 					if s.deletions.Get(uint(idx)) {
 						continue

--- a/storage/database.go
+++ b/storage/database.go
@@ -1112,12 +1112,14 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 	for _, s := range tbl.Shards {
 		GlobalCache.removeInternal(s, freedByType)
 		for _, idx := range s.Indexes {
+			GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 			GlobalCache.removeInternal(idx, freedByType)
 		}
 	}
 	for _, s := range tbl.PShards {
 		GlobalCache.removeInternal(s, freedByType)
 		for _, idx := range s.Indexes {
+			GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 			GlobalCache.removeInternal(idx, freedByType)
 		}
 	}

--- a/storage/index.go
+++ b/storage/index.go
@@ -190,8 +190,28 @@ func (idx *StorageIndex) ComputeSize() uint {
 				sz += sl.ComputeSize()
 			}
 		}
+		sz += idx.computeDeltaBtreeSize(state)
 	}
-	// TODO: deltaBtree
+	return sz
+}
+
+func (idx *StorageIndex) computeDeltaBtreeSize(state *storageIndexState) uint {
+	if state == nil || state.deltaBtree == nil {
+		return 0
+	}
+	// The B-tree owns nodes and indexPair values. For normal delta rows,
+	// indexPair.data points at shard inserts that are already counted by the
+	// shard; count only the slice header there. Session-sensitive indexes store
+	// precomputed values and own that slice payload as well.
+	var sz uint = 64 + uint(state.deltaBtree.Len())*64
+	state.deltaBtree.Ascend(func(item indexPair) bool {
+		if state.precomputedDelta {
+			sz += scm.ComputeSize(scm.NewAny(item.data))
+		} else {
+			sz += 24
+		}
+		return true
+	})
 	return sz
 }
 
@@ -324,7 +344,7 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 // The callback receives batches of record IDs and returns false to stop iteration.
 // Buffer size controls early-out granularity: use small buffers (e.g. [8]uint32)
 // for existence checks, large buffers (e.g. [1024]uint32) for full scans.
-func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, callback func([]uint32) bool) {
+func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
 	// cols is already sorted by 1st rank: equality before range; 2nd rank alphabet
 
 	// extract inclusiveness for the range column (last boundary)
@@ -353,7 +373,7 @@ func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.
 					}
 				}
 				// this index fits!
-				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, callback)
+				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, callback)
 				return
 			}
 		skip_index:
@@ -382,7 +402,7 @@ func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.
 				if covered {
 					// longer index covers this query; use it instead of creating a shorter one
 					t.indexMutex.Unlock()
-					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, callback)
+					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, callback)
 					return
 				}
 			}
@@ -438,7 +458,7 @@ func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.
 		index.t = t
 		t.Indexes = append(t.Indexes, index)
 		t.indexMutex.Unlock()
-		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, callback)
+		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, callback)
 		return
 	}
 
@@ -734,8 +754,10 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, colIdx int, 
 	}
 	state.skipLists[colIdx][pattern] = sl
 	s.mu.Unlock()
-	// Register skip list with CacheManager at 1/100 of the index priority,
-	// so rarely used patterns are evicted before the whole index.
+	// Register skip lists as soft sub-items of the parent index. Their bytes
+	// are already included in StorageIndex.ComputeSize for total live-RAM
+	// reporting; the separate CacheManager entry exists only so eviction can
+	// choose a cheaper sub-item before dropping the whole index.
 	if sl != nil {
 		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: pattern}
 		GlobalCache.AddItem(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore)
@@ -744,7 +766,7 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, colIdx int, 
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -755,8 +777,10 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 	state := s.stateForTx(tx, true)
 	// no collation-specific helpers in the current implementation
 
-	savings_threshold := 2.0    // building an index costs 1x the time as traversing the list
-	s.Savings = s.Savings + 1.0 // mark that we could save time
+	savings_threshold := 2.0 // building an index costs 1x the time as traversing the list
+	if countUsage {
+		s.Savings = s.Savings + 1.0 // mark that a real query could save time
+	}
 	if !state.active {
 		// index is not built yet
 		if s.Savings < savings_threshold {
@@ -1042,6 +1066,7 @@ func indexCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	if !idx.mu.TryLock() {
 		return false // index is in use, skip eviction
 	}
+	GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 	idx.baseState = storageIndexState{}
 	idx.variants = nil
 	idx.mu.Unlock()

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "testing"
+
+import "github.com/google/btree"
+import "github.com/launix-de/memcp/scm"
+
+func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
+	Init(scm.Globalenv)
+	dbname := "test_estimate_no_savings"
+	CreateDatabase(dbname, true)
+	defer databases.Remove(dbname)
+
+	tbl, _ := CreateTable(dbname, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	rows := make([][]scm.Scmer, 0, 16)
+	for i := 0; i < 16; i++ {
+		rows = append(rows, []scm.Scmer{scm.NewInt(int64(i))})
+	}
+	tbl.Insert([]string{"id"}, rows, nil, scm.NewNil(), false, nil)
+
+	shard := tbl.Shards[0]
+	bounds := boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), lowerInclusive: true, upper: scm.NewInt(5), upperInclusive: true}}
+	lower, upperLast := indexFromBoundaries(bounds)
+	var buf [8]uint32
+	shard.mu.RLock()
+	shard.iterateIndex(nil, bounds, lower, upperLast, len(shard.inserts), buf[:], false, func(batch []uint32) bool {
+		return true
+	})
+	shard.mu.RUnlock()
+	if len(shard.Indexes) != 1 {
+		t.Fatalf("metadata indexes = %d, want 1", len(shard.Indexes))
+	}
+	if shard.Indexes[0].Savings != 0 {
+		t.Fatalf("estimate must not count as index usage, savings = %v", shard.Indexes[0].Savings)
+	}
+	if shard.Indexes[0].baseState.active {
+		t.Fatal("estimate must not materialize a cold auto-index before real usage")
+	}
+}
+
+func TestStorageIndexComputeSizeCountsDeltaBtree(t *testing.T) {
+	idx := &StorageIndex{}
+	state := &idx.baseState
+	state.deltaBtree = btree.NewG[indexPair](8, func(a, b indexPair) bool {
+		return a.itemid < b.itemid
+	})
+	state.deltaBtree.ReplaceOrInsert(indexPair{itemid: 1, data: []scm.Scmer{scm.NewInt(1)}})
+	state.deltaBtree.ReplaceOrInsert(indexPair{itemid: 2, data: []scm.Scmer{scm.NewInt(2)}})
+
+	baseOnly := uint(24 * 8)
+	if got := idx.ComputeSize(); got <= baseOnly {
+		t.Fatalf("ComputeSize() = %d, want larger than base-only size %d", got, baseOnly)
+	}
+}
+
+func TestRemoveIndexChildrenInternalDropsSkipListRecords(t *testing.T) {
+	idx := &StorageIndex{}
+	other := &StorageIndex{}
+	entry := &skipListCacheEntry{index: idx, colIdx: 0, pattern: "%needle%"}
+	otherEntry := &skipListCacheEntry{index: other, colIdx: 0, pattern: "%needle%"}
+	cm := &CacheManager{
+		itemMap: map[any]*softItem{
+			entry:      {pointer: entry, size: 128, evictType: TypeIndex, heapIndex: -1},
+			otherEntry: {pointer: otherEntry, size: 64, evictType: TypeIndex, heapIndex: -1},
+		},
+		currentMemory: 192,
+		sizeByType:    [numEvictableTypes]int64{TypeIndex: 192},
+		countByType:   [numEvictableTypes]int64{TypeIndex: 2},
+	}
+
+	var freed [numEvictableTypes]int64
+	cm.removeIndexChildrenInternal(idx, &freed)
+	if _, ok := cm.itemMap[entry]; ok {
+		t.Fatal("skip list cache entry for removed index is still registered")
+	}
+	if _, ok := cm.itemMap[otherEntry]; !ok {
+		t.Fatal("skip list cache entry for other index was removed")
+	}
+	if freed[TypeIndex] != 128 {
+		t.Fatalf("freed index bytes = %d, want 128", freed[TypeIndex])
+	}
+	if cm.currentMemory != 64 {
+		t.Fatalf("currentMemory = %d, want 64", cm.currentMemory)
+	}
+}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -360,7 +360,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	var buf [1024]uint32
 	hadValue := false
 
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 		// filter in-place: overwrite batch with passing IDs
 		outN := 0
 		for _, idx := range batch {
@@ -597,7 +597,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 			activeLower, activeUpperLast = indexFromBoundaries(activeBoundaries)
 		}
 
-		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], func(batch []uint32) bool {
+		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 			if ss != nil && ss.IsKilled() {
 				panic("query killed")
 			}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -910,7 +910,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		resultCap := 1024
 		result.items = make([]uint32, resultCap)
 		resultN := 0
-		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], func(batch []uint32) bool {
+		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 			// filter in-place: overwrite batch with passing IDs
 			outN := 0
 			for _, idx := range batch {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -597,6 +597,7 @@ func shardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	}
 	// remove indexes from CacheManager (recursive free)
 	for _, idx := range s.Indexes {
+		GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 		GlobalCache.removeInternal(idx, freedByType)
 		idx.baseState = storageIndexState{}
 		idx.variants = nil
@@ -626,6 +627,7 @@ func cacheShardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	}
 	// remove indexes from CacheManager (recursive free)
 	for _, idx := range s.Indexes {
+		GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 		GlobalCache.removeInternal(idx, freedByType)
 		idx.baseState = storageIndexState{}
 		idx.variants = nil
@@ -2172,7 +2174,7 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	// Use iterateIndex for O(log n) lookup (builds index lazily if needed)
 	// Small buffer for existence check: stop early after first match
 	var buf [8]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], true, func(batch []uint32) bool {
 		for _, idx := range batch {
 			// Verify all columns match (iterateIndex may return superset for range boundaries)
 			matched := true
@@ -2237,7 +2239,7 @@ func (t *storageShard) ProbeExists(columns []string, values []scm.Scmer, current
 	found := false
 
 	var buf [8]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], true, func(batch []uint32) bool {
 		for _, idx := range batch {
 			matched := true
 			if idx < mainCount {
@@ -2304,7 +2306,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var buf [256]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], false, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if acidMode {
 				if !currentTx.IsVisible(t, idx) {


### PR DESCRIPTION
## What

Fix index/cache memory accounting after the selectivity-aware planner changes:

- keep planner/index probes from incrementing index `Savings` when they are only estimates
- include `deltaBtree` memory in `StorageIndex.ComputeSize()`
- remove registered skip-list child eviction records when the parent index is evicted/deregistered
- document the intended distinction between live RAM accounting and separate eviction records for index sub-items
- add storage-level regression tests for these paths

## Why

Planner estimates can probe candidate plans that are later discarded. Those probes may create auto-index metadata, but they should not make the index look hot or force materialization through fake usage. Also, delta indexes and skip-list sub-items must be reflected consistently in memory/evasion accounting.

## Validation

Passed:

- `go test ./storage/ -run 'TestPlannerIndexProbeDoesNotIncreaseIndexSavings|TestStorageIndexComputeSizeCountsDeltaBtree|TestRemoveIndexChildrenInternalDropsSkipListRecords'`
- `go test ./storage/ -run '^$'`
- `go build -o memcp`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml`
- `python3 run_sql_tests.py tests/80_memory_pressure.yaml`
- `python3 run_sql_tests.py tests/91_fulltext_like_index.yaml`
- `python3 run_sql_tests.py tests/93_index_delta_merge.yaml`
- isolated rerun after first hook issue: `python3 run_sql_tests.py tests/86_reversed_comparisons.yaml && python3 run_sql_tests.py tests/81_trigger_compat.yaml`

Attempted:

- `make test` twice. First run was interrupted after the shared parallel runner hung in `tests/81_trigger_compat.yaml`; `tests/86_reversed_comparisons.yaml` had reported transient `No response`, but both suites passed immediately when rerun isolated. Second run progressed through many suites but exited with `make: *** wait: No child processes` while parallel suites were still printing output. I did not treat this as a deterministic patch failure, but CI should verify the full hook path.
