### PR TITLE
Estimate LIKE membership selectivity

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3105,16 +3105,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(expr_contains_broad_text_match? head))
 		_ false)))
 
-(define expr_contains_text_match? (lambda (expr)
-	(match expr
-		((symbol strlike) _value _pattern _collation) true
-		((quote strlike) _value _pattern _collation) true
-		(cons head tail)
-		(reduce tail (lambda (found item)
-			(or found (expr_contains_text_match? item)))
-			(expr_contains_text_match? head))
-		_ false)))
-
 (define stage_input_contains_broad_membership_filter? (lambda (input)
 	(if (union_block? input)
 		(reduce (union_branches input) (lambda (found branch)
@@ -3150,7 +3140,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(lambda (_e) nil))))
 
 (define planner_source_filter_estimate (lambda (src condition max_rows)
-	(if (or (not (source_is_base_table? src)) (expr_contains_text_match? condition))
+	(if (not (source_is_base_table? src))
 		nil
 		(try
 			(lambda ()
@@ -3266,7 +3256,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define driver (if (empty_list? sources) nil (car sources)))
 		(define driver_rows (if (nil? driver) nil (planner_source_row_count driver)))
 		(define candidate_rows (planner_stage_input_rows (gs_input stage)))
-		(define candidate_estimate (planner_stage_filter_estimate (gs_input stage) 2048))
+		(define candidate_estimate (planner_stage_filter_estimate (gs_input stage) 512))
 		(define estimate_rows (qassoc_get candidate_estimate (quote rows) nil))
 		(define estimate_capped (qassoc_get candidate_estimate (quote capped) false))
 		(define estimate_input (qassoc_get candidate_estimate (quote input) nil))
@@ -3328,7 +3318,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define candidate_reorder_strategy (lambda (stage sources block)
 	(begin
 		(define driver (if (empty_list? sources) nil (car sources)))
-		(define candidate_estimate (planner_stage_filter_estimate (gs_input stage) 2048))
+		(define candidate_estimate (planner_stage_filter_estimate (gs_input stage) 512))
 		(define estimate_rows (qassoc_get candidate_estimate (quote rows) nil))
 		(define estimate_input (qassoc_get candidate_estimate (quote input) nil))
 		(define estimate_ratio_broad (and
@@ -6533,8 +6523,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(and (nil? (qb_having branch))
 						(and (not (query_block_has_aggregates? branch))
 							(and (empty_list? (qb_order branch))
-									(and (nil? (qb_limit branch))
-										(nil? (qb_offset branch))))))))))))
+								(and (nil? (qb_limit branch))
+									(nil? (qb_offset branch))))))))))))
 
 (define grouped_union_branch? (lambda (branch)
 	(and (query_block? branch)

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -419,7 +419,14 @@ test_cases:
           INSERT INTO in_dv_file (ID, filename, search) VALUES
           (10, 'invoice-hit.pdf', 'other'),
           (20, 'other.pdf', 'needle token'),
-          (30, 'miss.pdf', 'other')
+          (30, 'miss.pdf', 'other'),
+          (40, 'cold-a.pdf', 'other'),
+          (50, 'cold-b.pdf', 'other'),
+          (60, 'cold-c.pdf', 'other'),
+          (70, 'cold-d.pdf', 'other'),
+          (80, 'cold-f.pdf', 'other'),
+          (90, 'cold-g.pdf', 'other'),
+          (100, 'cold-h.pdf', 'other')
       - sql: |
           INSERT INTO in_dv_doc (ID, file_id, tenant, sort_key) VALUES
           (1, 10, 1, 20),
@@ -532,6 +539,35 @@ test_cases:
             - "driver_membership_probe"
             - "__union_distinct_rows"
             - "__union_distinct_seen"
+      - sql: |
+          EXPLAIN REORDER
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE t.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%co%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%co%'
+          )
+          ORDER BY t.sort_key
+          LIMIT 10
+        expect:
+          contains:
+            - "membership_plan_strategy"
+            - "driver_order_membership_probe"
+            - "membership_selectivity_class"
+            - "broad"
+            - "membership_candidate_estimated_rows"
+            - "membership_candidate_estimate_input"
+            - "membership_cost_reason"
+            - "broad_membership_preserve_driver_order_limit"
+          not_contains:
+            - "inner_select"
+            - "dependent-subquery"
+            - "selective_membership_build_candidate_keyset"
       - sql: |
           EXPLAIN REORDER
           SELECT t.ID


### PR DESCRIPTION
## What
- Let membership filter planning use the existing storage boundary selectivity estimate for `strlike` conditions instead of treating every text match as unknown.
- Lower the membership estimate cap to 512 rows so broad text filters are detected without building a large candidate estimate.
- Extend the anonymized IN/UNION dataview-shaped YAML case so a multi-character LIKE term is estimated as broad and keeps the ordered driver path.

## Why
The parser already lowers MATCH/AGAINST to `strlike`, and storage already has BoundaryMatcher/LIKE skiplist support. The missing part was that the query planner explicitly skipped selectivity estimation for all `strlike` predicates, so medium text terms fell back to `candidate_keyset` even when the bounded estimate would show a broad candidate set.

## Validation
- `make`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml`
- `python3 run_sql_tests.py tests/91_fulltext_like_index.yaml`
- `python3 tools/lint_scm.py` exits 0; it still reports the known parser depth warnings in untouched parser files.

## Local A/B Measurement
Dataset: local imported production-shaped dataset, user/session variable `@fop_user = 342`, real dataview fulltext query. Customer data and raw SQL are not committed.

EXPLAIN REORDER plan signal:
- master: 1-char term uses `driver_order_membership_probe`; 2-char, 3-char, medium-heavy and selective-miss terms have `membership_candidate_estimated_rows nil` and choose `candidate_keyset`.
- this branch: 2-char, 3-char and medium-heavy terms estimate via boundaries, cap at 512, and choose `driver_order_membership_probe`; selective miss estimates 0 and stays `candidate_keyset`.

Warm SELECT timings, this branch:
- 1-char broad: 3.45s
- 2-char medium: 3.39s
- 3-char medium: 3.40s
- medium-heavy: 3.39s
- selective miss: 7.85s

Master comparison from same data/server setup:
- 1-char broad: 5.51s
- 2-char medium: timed out after 180s without result
- further master SELECT measurements were stopped after the timeout; cancelling a running master query triggered the existing parallel-scan kill panic, so I did not continue the sequence.

## Follow-up
This fixes the wrong planner choice for medium text membership. The remaining hot path is the selective/zero-hit candidate path plus repeated ACL/reference/group helper work; that should be addressed separately with earlier empty-candidate termination and late projection / helper reuse.