### PR TITLE
Add query-local RecSet carrier

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -352,7 +352,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(quote neumann_scalar)
 		(quote neumann_exists)
 		(quote neumann_in)
-		(quote dependent-subquery)) head)
+		(quote dependent-subquery)
+		(quote exists_probe)) head)
 		true
 		(match head
 			((quote quote) sym) (subquery_head? sym)
@@ -793,70 +794,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 					nil
 					true))))))
 
-(define direct_probe_column (lambda (alias expr)
-	(match expr
-		((symbol get_column) tblvar _tbl_ignorecase col _col_ignorecase)
-		(if (equal? (resolve_column_alias tblvar alias) alias) col nil)
-		((quote get_column) tblvar _tbl_ignorecase col _col_ignorecase)
-		(direct_probe_column alias (list (quote get_column) tblvar false col false))
-		_ nil)))
-
-(define exists_probe_condition_binding (lambda (alias term)
-	(match term
-		((symbol equal??) a b) (begin
-			(define acol (direct_probe_column alias a))
-			(define bcol (direct_probe_column alias b))
-			(if (and (not (nil? acol)) (nil? bcol))
-				(list acol b)
-				(if (and (nil? acol) (not (nil? bcol)))
-					(list bcol a)
-					false)))
-		((quote equal??) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
-		((symbol equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
-		((quote equal?) a b) (exists_probe_condition_binding alias (list (quote equal??) a b))
-		((symbol nil?) expr) (begin
-			(define col (direct_probe_column alias expr))
-			(if (nil? col) false (list col nil)))
-		((quote nil?) expr) (exists_probe_condition_binding alias (list (quote nil?) expr))
-		_ false)))
-
-(define exists_probe_condition_bindings (lambda (alias condition)
-	(match (coalesceNil condition true)
-		(symbol true) '()
-		((symbol and) a b) (begin
-			(define aa (exists_probe_condition_bindings alias a))
-			(define bb (exists_probe_condition_bindings alias b))
-			(if (or (equal? aa false) (equal? bb false))
-				false
-				(merge (list aa bb))))
-		((quote and) a b) (exists_probe_condition_bindings alias (list (quote and) a b))
-		_ (begin
-			(define binding (exists_probe_condition_binding alias condition))
-			(if (equal? binding false) false (list binding))))))
-
-(define direct_probe_key_columns (lambda (alias keys)
-	(begin
-		(define cols (map keys (lambda (key) (direct_probe_column alias key))))
-		(if (reduce cols (lambda (bad col) (or bad (nil? col))) false)
-			false
-			cols))))
-
-(define exists_probe_supported? (lambda (stage)
-	(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists))
-		(and (source_is_base_table? (gs_input stage))
-			(and (equal? (gs_aggregates stage) (list aggregate_count_descriptor))
-				(and (nil? (gs_having stage))
-					(and (empty_list? (gs_order stage))
-						(and (nil? (gs_limit stage))
-							(and (not (equal? (direct_probe_key_columns (group_stage_input_alias stage) (gs_keys stage)) false))
-								(not (equal? (exists_probe_condition_bindings
-									(group_stage_input_alias stage)
-									(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-									false)))))))))))
-
-(define exists_probe_expr (lambda (stage lookup_keys)
-	(list (quote exists_probe) stage lookup_keys)))
-
 (define scalar_first_probe_expr (lambda (stage col)
 	(list (quote scalar_first_probe) stage col)))
 
@@ -1130,15 +1067,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(stage_source_outer? outer_sources)
 			(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
-		(if (exists_probe_supported? stage)
-			(list
-				(exists_probe_expr stage lookup_keys)
-				'()
-				'())
-			(list
-				(list (quote >) (list (quote get_column) stage_alias false count_col false) 0)
-				(list stage)
-				(list source))))))
+		(list
+			(list (quote >) (list (quote get_column) stage_alias false count_col false) 0)
+			(list stage)
+			(list source)))))
 
 (define combine_exists_union_results (lambda (results)
 	(match (coalesceNil results '())
@@ -3691,10 +3623,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define extract_columns_for_alias (lambda (src expr)
 	(match expr
-		((symbol exists_probe) _stage lookup_keys)
-		(merge_unique (map lookup_keys (lambda (key) (extract_columns_for_alias src key))))
-		((quote exists_probe) _stage lookup_keys)
-		(extract_columns_for_alias src (list (quote exists_probe) _stage lookup_keys))
 		((symbol scalar_first_probe) stage _requested_col)
 		(merge_unique (map (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (key)
 			(extract_columns_for_alias src key))))
@@ -3707,10 +3635,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define lower_column_expr_for_alias (lambda (src expr)
 	(match expr
-		((symbol exists_probe) stage lookup_keys)
-		(lower_exists_probe_expr (list src) (source_alias src) stage lookup_keys)
-		((quote exists_probe) stage lookup_keys)
-		(lower_exists_probe_expr (list src) (source_alias src) stage lookup_keys)
 		((symbol scalar_first_probe) stage requested_col)
 		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col)
 		((quote scalar_first_probe) stage requested_col)
@@ -3719,30 +3643,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase) (symbol (concat (resolve_column_alias tblvar (source_alias src)) "." (resolve_physical_column_name src col col_ignorecase)))
 		(cons head tail) (cons head (map tail (lambda (item) (lower_column_expr_for_alias src item))))
 		_ expr)))
-
-(define lower_exists_probe_expr (lambda (sources default_alias stage lookup_keys)
-	(begin
-		(define src (gs_input stage))
-		(define alias (group_stage_input_alias stage))
-		(define keys (gs_keys stage))
-		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-		(define key_terms (if (equal? (count keys) (count lookup_keys))
-			(map (produceN (count keys)) (lambda (i)
-				(list (quote equal??)
-					(nth keys i)
-					(nth lookup_keys i))))
-			'()))
-		(define filter_expr (combine_where
-			condition
-			(combine_where_terms key_terms true)))
-		(define filtercols (extract_columns_for_alias src filter_expr))
-		(list (quote scan_exists)
-			'(session "__memcp_tx")
-			(source_table_expr src)
-			(cons (quote list) filtercols)
-			(list (quote lambda)
-				(map filtercols (lambda (col) (symbol (concat alias "." col))))
-				(list (quote optimize) (lower_column_expr_for_join (cons src sources) alias filter_expr)))))))
 
 (define scalar_first_probe_parts (lambda (ag)
 	(match ag
@@ -3826,10 +3726,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define extract_columns_for_join_alias (lambda (sources default_alias alias expr)
 	(match expr
-		((symbol exists_probe) _stage lookup_keys)
-		(merge_unique (map lookup_keys (lambda (key) (extract_columns_for_join_alias sources default_alias alias key))))
-		((quote exists_probe) _stage lookup_keys)
-		(extract_columns_for_join_alias sources default_alias alias (list (quote exists_probe) _stage lookup_keys))
 		((symbol driver_membership_probe) _stage probe)
 		(extract_columns_for_join_alias sources default_alias alias probe)
 		((quote driver_membership_probe) _stage probe)
@@ -3854,10 +3750,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define lower_column_expr_for_join (lambda (sources default_alias expr)
 	(match expr
-		((symbol exists_probe) stage lookup_keys)
-		(lower_exists_probe_expr sources default_alias stage lookup_keys)
-		((quote exists_probe) stage lookup_keys)
-		(lower_exists_probe_expr sources default_alias stage lookup_keys)
 		((symbol driver_membership_probe) stage probe)
 		(lower_driver_membership_probe_expr sources default_alias stage probe)
 		((quote driver_membership_probe) stage probe)

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -33,6 +33,14 @@ type recSetShard struct {
 	count  int64
 }
 
+func (s *recSetShard) contains(recid uint32) bool {
+	if s == nil {
+		return false
+	}
+	pos := sort.Search(len(s.recids), func(i int) bool { return s.recids[i] >= recid })
+	return pos < len(s.recids) && s.recids[pos] == recid
+}
+
 // recSet is a query-local, non-persistent subset of one table represented by
 // physical record IDs. It is intentionally table-shaped so the planner can swap
 // repeated scans over the same filtered base relation for a scan over this value.
@@ -58,29 +66,43 @@ func (r *recSet) String() string {
 	return fmt.Sprintf("(recset %q %q %d)", r.table.schema.Name, r.table.Name, r.count)
 }
 
-func (r *recSet) contains(shard *storageShard, recid uint32) bool {
+func (r *recSet) shardEntry(shard *storageShard) *recSetShard {
 	if r == nil || shard == nil || r.table != shard.t {
-		return false
+		return nil
 	}
 	for i := range r.shards {
 		rs := &r.shards[i]
-		if rs.shard != shard {
-			continue
+		if rs.shard == shard {
+			return rs
 		}
-		pos := sort.Search(len(rs.recids), func(i int) bool { return rs.recids[i] >= recid })
-		return pos < len(rs.recids) && rs.recids[pos] == recid
 	}
-	return false
+	return nil
+}
+
+func (r *recSet) contains(shard *storageShard, recid uint32) bool {
+	return r.shardEntry(shard).contains(recid)
 }
 
 func recSetContainsClosure(shard *storageShard) *func(uint32, ...scm.Scmer) scm.Scmer {
+	var cachedRecSet *recSet
+	var cachedShard *recSetShard
 	fn := func(recid uint32, args ...scm.Scmer) scm.Scmer {
 		if len(args) != 1 || !args[0].IsCustom(TagRecSet) {
 			return scm.NewBool(false)
 		}
-		return scm.NewBool(RecSetFromScmer(args[0]).contains(shard, recid))
+		rs := RecSetFromScmer(args[0])
+		if rs != cachedRecSet {
+			cachedRecSet = rs
+			cachedShard = rs.shardEntry(shard)
+		}
+		return scm.NewBool(cachedShard.contains(recid))
 	}
 	return &fn
+}
+
+type recSetBuildResult struct {
+	part recSetShard
+	err  scanError
 }
 
 func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
@@ -88,21 +110,53 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	boundaries := extractBoundaries(conditionCols, condition)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	result := &recSet{tx: currentTx, table: t}
 
-	for _, shard := range t.ActiveShards() {
+	values := make(chan recSetBuildResult, 4)
+	done := t.iterateShardsParallel(boundaries, func(shard *storageShard, solo bool) {
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}
-		rsShard := shard.collectRecSet(boundaries, lower, upperLast, conditionCols, conditionFn, currentTx, ss)
-		result.count += rsShard.count
-		result.shards = append(result.shards, rsShard)
+		defer func() {
+			if rec := recover(); rec != nil {
+				values <- recSetBuildResult{err: scanError{rec, string(debug.Stack())}}
+			}
+		}()
+		values <- recSetBuildResult{
+			part: shard.collectRecSet(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss),
+		}
+	})
+	if done == nil {
+		close(values)
+	} else {
+		go func() {
+			<-done
+			close(values)
+		}()
+	}
+
+	var buildErr scanError
+	for msg := range values {
+		if msg.err.r != nil {
+			if buildErr.r == nil {
+				buildErr = msg.err
+			}
+			continue
+		}
+		if buildErr.r != nil {
+			continue
+		}
+		result.count += msg.part.count
+		result.shards = append(result.shards, msg.part)
+	}
+	if buildErr.r != nil {
+		panic(buildErr)
 	}
 	return result
 }
 
-func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwner()
 	t.ensureMainCount(skipShardReadLock)

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -294,6 +294,110 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 	return akkumulator
 }
 
+func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
+	if r == nil {
+		return false
+	}
+	if currentTx == nil {
+		currentTx = r.tx
+	}
+	ss := SessionStateFromTx(currentTx)
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	for i := range r.shards {
+		part := &r.shards[i]
+		if part.count == 0 {
+			continue
+		}
+		if part.shard.recSetPartExists(part.recids, conditionCols, conditionFn, currentTx, ss) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState) bool {
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+
+	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
+	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			conditionGetters[i] = getter
+			continue
+		}
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+	}
+	cdataset := make([]scm.Scmer, len(conditionCols))
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	mainCount := t.main_count
+	visibleUpper := mainCount + uint32(len(t.inserts))
+	for _, idx := range recids {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		if idx >= visibleUpper {
+			continue
+		}
+		if acidMode {
+			if !currentTx.IsVisible(t, idx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(idx)) {
+			continue
+		}
+		if idx < mainCount {
+			for i, c := range cReaders {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else {
+					cdataset[i] = c.GetValue(idx)
+				}
+			}
+		} else {
+			for i, col := range conditionCols {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					cdataset[i] = cReaders[i].GetValue(idx)
+				} else {
+					cdataset[i] = t.getDelta(int(idx-mainCount), col)
+				}
+			}
+		}
+		if scm.ToBool(conditionFn(cdataset...)) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
@@ -411,4 +515,202 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 		return scm.NewNil(), 0
 	}
 	return akkumulator, outCount
+}
+
+func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
+	result := &shardqueue{shard: t}
+	if ss == nil {
+		ss = SessionStateFromTx(currentTx)
+	}
+	defaultSortDir := func(args ...scm.Scmer) scm.Scmer {
+		if len(args) < 2 {
+			return scm.NewBool(false)
+		}
+		return scm.NewBool(scm.Less(args[0], args[1]))
+	}
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+
+	result.scols = make([]func(uint32) scm.Scmer, len(sortcols))
+	for i, scol := range sortcols {
+		if scol.IsString() {
+			result.scols[i] = t.ColumnReaderTx(currentTx, scol.String())
+			continue
+		}
+		if scol.IsProc() {
+			proc := scol.Proc()
+			var params []scm.Scmer
+			if proc.Params.IsSlice() {
+				params = proc.Params.Slice()
+			} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
+				params = arr
+			}
+			largs := make([]func(uint32) scm.Scmer, len(params))
+			for j, param := range params {
+				name := ""
+				if param.IsSymbol() {
+					name = param.String()
+				} else if sym, ok := param.Any().(scm.Symbol); ok {
+					name = string(sym)
+				} else {
+					name = scm.String(param)
+				}
+				largs[j] = t.ColumnReaderTx(currentTx, name)
+			}
+			procFn := scm.OptimizeProcToSerialFunction(scol)
+			result.scols[i] = func(idx uint32) scm.Scmer {
+				vals := make([]scm.Scmer, len(largs))
+				for j, getter := range largs {
+					vals[j] = getter(idx)
+				}
+				return procFn(vals...)
+			}
+			continue
+		}
+		panic("unknown sort criteria: " + scm.String(scol))
+	}
+	result.sortdirs = make([]func(...scm.Scmer) scm.Scmer, len(sortcols))
+	for i := range sortcols {
+		if i < len(sortdirs) && sortdirs[i] != nil {
+			result.sortdirs[i] = sortdirs[i]
+		} else {
+			result.sortdirs[i] = defaultSortDir
+		}
+	}
+
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner() || (currentTx != nil && currentTx.HasShardWrite(t))
+	t.ensureMainCount(skipShardReadLock)
+	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
+	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			conditionGetters[i] = getter
+			continue
+		}
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+	}
+	cdataset := make([]scm.Scmer, len(conditionCols))
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	mainCount := t.main_count
+	visibleUpper := mainCount + uint32(len(t.inserts))
+	result.items = make([]uint32, 0, len(recids))
+	for _, idx := range recids {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		if idx >= visibleUpper {
+			continue
+		}
+		if acidMode {
+			if !currentTx.IsVisible(t, idx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(idx)) {
+			continue
+		}
+		if idx < mainCount {
+			for i, c := range cReaders {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else {
+					cdataset[i] = c.GetValue(idx)
+				}
+			}
+		} else {
+			for i, col := range conditionCols {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					cdataset[i] = cReaders[i].GetValue(idx)
+				} else {
+					cdataset[i] = t.getDelta(int(idx-mainCount), col)
+				}
+			}
+		}
+		if scm.ToBool(conditionFn(cdataset...)) {
+			result.items = append(result.items, idx)
+		}
+	}
+
+	itemPos := make(map[uint32]int, len(result.items))
+	for i, idx := range result.items {
+		itemPos[idx] = i
+	}
+	lessByID := func(a, b uint32) bool {
+		cmpCount := len(result.scols)
+		if len(result.sortdirs) < cmpCount {
+			cmpCount = len(result.sortdirs)
+		}
+		for c := 0; c < cmpCount; c++ {
+			av := result.scols[c](a)
+			bv := result.scols[c](b)
+			if scm.ToBool(result.sortdirs[c](av, bv)) {
+				return true
+			}
+			if scm.ToBool(result.sortdirs[c](bv, av)) {
+				return false
+			}
+		}
+		return itemPos[a] < itemPos[b]
+	}
+	if len(sortcols) > 0 {
+		if limit >= 0 && limitPartitionCols == 0 {
+			result.items = topKByOrder(result.items, offset+limit, lessByID)
+		} else {
+			sort.Slice(result.items, func(i, j int) bool {
+				return lessByID(result.items[i], result.items[j])
+			})
+		}
+	}
+	if limit >= 0 {
+		perPart := offset + limit
+		if perPart < 0 {
+			perPart = len(result.items)
+		}
+		var pruned []uint32
+		var prevPK []scm.Scmer
+		partCount := 0
+		for _, idx := range result.items {
+			curPK := make([]scm.Scmer, limitPartitionCols)
+			for c := 0; c < limitPartitionCols; c++ {
+				curPK[c] = result.scols[c](idx)
+			}
+			if prevPK == nil || !pkEqual(prevPK, curPK) {
+				partCount = 0
+				prevPK = curPK
+			}
+			if partCount < perPart {
+				pruned = append(pruned, idx)
+			}
+			partCount++
+		}
+		result.items = pruned
+	}
+	_ = callbackCols
+	return result
 }

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1,0 +1,414 @@
+/*
+Copyright (C) 2023-2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "runtime/debug"
+import "sort"
+import "unsafe"
+import "github.com/launix-de/memcp/scm"
+
+// TagRecSet is the custom Scmer tag for query-local RecSet handles.
+const TagRecSet = 102
+
+type recSetShard struct {
+	shard  *storageShard
+	recids []uint32
+	count  int64
+}
+
+// recSet is a query-local, non-persistent subset of one table represented by
+// physical record IDs. It is intentionally table-shaped so the planner can swap
+// repeated scans over the same filtered base relation for a scan over this value.
+type recSet struct {
+	tx     *TxContext
+	table  *table
+	shards []recSetShard
+	count  int64
+}
+
+func NewRecSetScmer(rs *recSet) scm.Scmer {
+	return scm.NewCustom(TagRecSet, unsafe.Pointer(rs))
+}
+
+func RecSetFromScmer(s scm.Scmer) *recSet {
+	return (*recSet)(s.Custom(TagRecSet))
+}
+
+func (r *recSet) String() string {
+	if r == nil || r.table == nil {
+		return "(recset nil)"
+	}
+	return fmt.Sprintf("(recset %q %q %d)", r.table.schema.Name, r.table.Name, r.count)
+}
+
+func (r *recSet) contains(shard *storageShard, recid uint32) bool {
+	if r == nil || shard == nil || r.table != shard.t {
+		return false
+	}
+	for i := range r.shards {
+		rs := &r.shards[i]
+		if rs.shard != shard {
+			continue
+		}
+		pos := sort.Search(len(rs.recids), func(i int) bool { return rs.recids[i] >= recid })
+		return pos < len(rs.recids) && rs.recids[pos] == recid
+	}
+	return false
+}
+
+func recSetContainsClosure(shard *storageShard) *func(uint32, ...scm.Scmer) scm.Scmer {
+	fn := func(recid uint32, args ...scm.Scmer) scm.Scmer {
+		if len(args) != 1 || !args[0].IsCustom(TagRecSet) {
+			return scm.NewBool(false)
+		}
+		return scm.NewBool(RecSetFromScmer(args[0]).contains(shard, recid))
+	}
+	return &fn
+}
+
+func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
+	ss := SessionStateFromTx(currentTx)
+	boundaries := extractBoundaries(conditionCols, condition)
+	reorderByFrequency(boundaries, t)
+	lower, upperLast := indexFromBoundaries(boundaries)
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	result := &recSet{tx: currentTx, table: t}
+
+	for _, shard := range t.ActiveShards() {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		rsShard := shard.collectRecSet(boundaries, lower, upperLast, conditionCols, conditionFn, currentTx, ss)
+		result.count += rsShard.count
+		result.shards = append(result.shards, rsShard)
+	}
+	return result
+}
+
+func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+
+	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	cNeedsTxReader := make([]bool, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
+	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			conditionGetters[i] = getter
+			continue
+		}
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			cNeedsTxReader[i] = true
+		}
+	}
+	cdataset := make([]scm.Scmer, len(conditionCols))
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	maxInsertIndex := len(t.inserts)
+	visibleUpper := t.main_count + uint32(maxInsertIndex)
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	recids := make([]uint32, 0, 64)
+	var buf [1024]uint32
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		for _, idx := range batch {
+			if idx >= visibleUpper {
+				continue
+			}
+			if acidMode {
+				if !currentTx.IsVisible(t, idx) {
+					continue
+				}
+			} else if t.deletions.Get(uint(idx)) {
+				continue
+			}
+			if idx < t.main_count {
+				for i, c := range cReaders {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
+						cdataset[i] = c.GetValue(idx)
+					} else {
+						cdataset[i] = ccols[i].GetValue(idx)
+					}
+				}
+			} else {
+				for i, col := range conditionCols {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
+						cdataset[i] = cReaders[i].GetValue(idx)
+					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+						cdataset[i] = ccols[i].GetValue(idx)
+					} else {
+						cdataset[i] = t.getDelta(int(idx-t.main_count), col)
+					}
+				}
+			}
+			if scm.ToBool(conditionFn(cdataset...)) {
+				recids = append(recids, idx)
+			}
+		}
+		return true
+	})
+	sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
+	return recSetShard{shard: t, recids: recids, count: int64(len(recids))}
+}
+
+func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool) scm.Scmer {
+	if r == nil {
+		return neutral
+	}
+	for _, c := range callbackCols {
+		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") || (len(c) > 5 && c[:5] == "$set:") || (len(c) > 12 && c[:12] == "$invalidate:") {
+			panic("recset scan mutation callbacks are not implemented")
+		}
+	}
+	if currentTx == nil {
+		currentTx = r.tx
+	}
+	ss := SessionStateFromTx(currentTx)
+	values := make(chan scanResult, len(r.shards))
+	for i := range r.shards {
+		rsShard := r.shards[i]
+		if rsShard.count == 0 {
+			continue
+		}
+		go func(part recSetShard) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- scanResult{err: scanError{rec, string(debug.Stack())}}
+				}
+			}()
+			res, cnt := part.shard.scanRecSetPart(part.recids, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
+			values <- scanResult{res: res, outCount: cnt, inputCount: part.count}
+		}(rsShard)
+	}
+	closeAfter := 0
+	for _, part := range r.shards {
+		if part.count > 0 {
+			closeAfter++
+		}
+	}
+	akkumulator := neutral
+	hadValue := false
+	var scanErr scanError
+	if !aggregate2.IsNil() {
+		fn := scm.OptimizeProcToSerialFunction(aggregate2)
+		for i := 0; i < closeAfter; i++ {
+			msg := <-values
+			if msg.err.r != nil {
+				if scanErr.r == nil {
+					scanErr = msg.err
+				}
+				continue
+			}
+			if msg.outCount > 0 {
+				akkumulator = fn(akkumulator, msg.res)
+				hadValue = true
+			}
+		}
+	} else if !aggregate.IsNil() {
+		fn := scm.OptimizeProcToSerialFunction(aggregate)
+		for i := 0; i < closeAfter; i++ {
+			msg := <-values
+			if msg.err.r != nil {
+				if scanErr.r == nil {
+					scanErr = msg.err
+				}
+				continue
+			}
+			if msg.outCount > 0 {
+				akkumulator = fn(akkumulator, msg.res)
+				hadValue = true
+			}
+		}
+	} else {
+		for i := 0; i < closeAfter; i++ {
+			msg := <-values
+			if msg.err.r != nil {
+				if scanErr.r == nil {
+					scanErr = msg.err
+				}
+				continue
+			}
+			hadValue = hadValue || msg.outCount > 0
+		}
+	}
+	if scanErr.r != nil {
+		panic(scanErr)
+	}
+	if !hadValue && isOuter {
+		nullRow := buildOuterNullCallbackRow(callbackCols)
+		if !aggregate2.IsNil() {
+			fn := scm.OptimizeProcToSerialFunction(aggregate2)
+			akkumulator = fn(akkumulator, scm.Apply(callback, nullRow...))
+		} else if !aggregate.IsNil() {
+			fn := scm.OptimizeProcToSerialFunction(aggregate)
+			akkumulator = fn(akkumulator, scm.Apply(callback, nullRow...))
+		} else {
+			scm.Apply(callback, nullRow...)
+		}
+	}
+	return akkumulator
+}
+
+func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
+	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+
+	ccols := make([]ColumnStorage, len(conditionCols))
+	cReaders := make([]ColumnReader, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
+	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			conditionGetters[i] = getter
+			continue
+		}
+		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
+		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+	}
+	cdataset := make([]scm.Scmer, len(conditionCols))
+	mapper := t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, 0, nil, currentTx)
+	defer mapper.Close()
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	mainCount := t.main_count
+	visibleUpper := mainCount + uint32(len(t.inserts))
+	akkumulator := neutral
+	var outCount int64
+	var buf [1024]uint32
+	pending := buf[:0]
+	for _, idx := range recids {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		if idx >= visibleUpper {
+			continue
+		}
+		if acidMode {
+			if !currentTx.IsVisible(t, idx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(idx)) {
+			continue
+		}
+		if idx < mainCount {
+			for i, c := range cReaders {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else {
+					cdataset[i] = c.GetValue(idx)
+				}
+			}
+		} else {
+			for i, col := range conditionCols {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					cdataset[i] = cReaders[i].GetValue(idx)
+				} else {
+					cdataset[i] = t.getDelta(int(idx-mainCount), col)
+				}
+			}
+		}
+		if !scm.ToBool(conditionFn(cdataset...)) {
+			continue
+		}
+		pending = append(pending, idx)
+		outCount++
+		if len(pending) == cap(buf) {
+			if locked {
+				t.mu.RUnlock()
+				locked = false
+			}
+			akkumulator = mapper.Stream(akkumulator, pending, nil)
+			pending = buf[:0]
+			if !skipShardReadLock {
+				t.mu.RLock()
+				locked = true
+			}
+		}
+	}
+	if len(pending) > 0 {
+		if locked {
+			t.mu.RUnlock()
+			locked = false
+		}
+		akkumulator = mapper.Stream(akkumulator, pending, nil)
+	}
+	if locked {
+		t.mu.RUnlock()
+		locked = false
+	}
+	mapper.FlushSideEffects()
+	if outCount == 0 {
+		return scm.NewNil(), 0
+	}
+	return akkumulator, outCount
+}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -639,7 +639,16 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
 	cNeedsTxReader := make([]bool, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			conditionGetters[i] = getter
+			continue
+		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
@@ -719,11 +728,17 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 			// condition check
 			if effectiveIdx < t.main_count {
 				for i, k := range cReaders {
-					cdataset[i] = k.GetValue(effectiveIdx)
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(effectiveIdx, 0)
+					} else {
+						cdataset[i] = k.GetValue(effectiveIdx)
+					}
 				}
 			} else {
 				for i, k := range conditionCols {
-					if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(effectiveIdx, 0)
+					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 						cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 					} else {
 						cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), k)

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -274,6 +274,7 @@ func topKByOrder(items []uint32, keep int, less func(a, b uint32) bool) []uint32
 // scanOrderTableSpec holds per-table parameters for scanOrderMulti.
 type scanOrderTableSpec struct {
 	table         *table
+	recset        *recSet
 	conditionCols []string
 	condition     scm.Scmer
 	sortcols      []scm.Scmer
@@ -286,6 +287,13 @@ type scanOrderTableSpec struct {
 	// merge direction (shared sortdirs). Callers must enforce this.
 	perTableOffset int
 	perTableLimit  int
+}
+
+func (s *scanOrderTableSpec) carrierTable() *table {
+	if s.recset != nil {
+		return s.recset.table
+	}
+	return s.table
 }
 
 // extendBoundariesWithSortCols appends sort columns to the boundaries when all
@@ -412,7 +420,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	// Launch shard-parallel scans for each table
 	for ti := range tables {
 		spec := &tables[ti]
-		t := spec.table
+		t := spec.carrierTable()
 		touchTempColumns(t, spec.conditionCols, spec.callbackCols)
 
 		// Per-table top-K hint: when perTableLimit is set, each shard only
@@ -461,27 +469,53 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		tableIdx := ti
 		shardLimit := shardTotalLimit
 
-		done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {
-			if ss != nil && ss.IsKilled() {
-				panic("query killed")
-			}
-			defer func() {
-				if r := recover(); r != nil {
-					q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
+		if spec.recset != nil {
+			for i := range spec.recset.shards {
+				part := spec.recset.shards[i]
+				if part.count == 0 {
+					continue
 				}
-			}()
-			res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
-			res.callbackCols = callbackCols
-			res.callback = callback
-			res.tableIdx = tableIdx
-			q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
-		})
-		if done != nil {
-			wg.Add(1)
-			go func(ch <-chan struct{}) {
-				<-ch
-				wg.Done()
-			}(done)
+				wg.Add(1)
+				go func(part recSetShard) {
+					defer wg.Done()
+					if ss != nil && ss.IsKilled() {
+						panic("query killed")
+					}
+					defer func() {
+						if r := recover(); r != nil {
+							q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
+						}
+					}()
+					res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+					res.callbackCols = callbackCols
+					res.callback = callback
+					res.tableIdx = tableIdx
+					q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
+				}(part)
+			}
+		} else {
+			done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {
+				if ss != nil && ss.IsKilled() {
+					panic("query killed")
+				}
+				defer func() {
+					if r := recover(); r != nil {
+						q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
+					}
+				}()
+				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+				res.callbackCols = callbackCols
+				res.callback = callback
+				res.tableIdx = tableIdx
+				q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
+			})
+			if done != nil {
+				wg.Add(1)
+				go func(ch <-chan struct{}) {
+					<-ch
+					wg.Done()
+				}(done)
+			}
 		}
 
 		// Per-table logging (best-effort, async) — inputCount is 0 here (set
@@ -703,6 +737,22 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
 		table:          t,
+		conditionCols:  conditionCols,
+		condition:      condition,
+		sortcols:       sortcols,
+		callbackCols:   callbackCols,
+		callback:       callback,
+		perTableOffset: -1,
+		perTableLimit:  -1,
+	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter)
+}
+
+func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+	if currentTx == nil {
+		currentTx = r.tx
+	}
+	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
+		recset:         r,
 		conditionCols:  conditionCols,
 		condition:      condition,
 		sortcols:       sortcols,

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1393,6 +1393,15 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			mr.deltaGetters[i] = getter
 			continue
 		}
+		if col == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			getter := func(id uint32, batchid uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			mr.mainGetters[i] = getter
+			mr.deltaGetters[i] = getter
+			continue
+		}
 		if col == "$update" {
 			mr.isUpdate[i] = true
 			mr.hasUpdateCol = true

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2155,9 +2155,15 @@ func Init(en scm.Env) {
 		Name: "show",
 		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			// table-based overloads: (show table) → columns, (show table "statistics") → index stats, etc.
-			if len(a) >= 1 && a[0].IsCustom(TagTable) {
-				t := TableFromScmer(a[0])
+			// table-based overloads: (show table) / (show recset) → columns,
+			// (show table "statistics") / (show recset "statistics") → index stats, etc.
+			if len(a) >= 1 && (a[0].IsCustom(TagTable) || a[0].IsCustom(TagRecSet)) {
+				t := (*table)(nil)
+				if a[0].IsCustom(TagRecSet) {
+					t = RecSetFromScmer(a[0]).table
+				} else {
+					t = TableFromScmer(a[0])
+				}
 				if len(a) == 1 {
 					return t.ShowColumns()
 				}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -565,13 +565,16 @@ func Init(en scm.Env) {
 				}
 				return scm.NewBool(false)
 			}
+			if tableArg.IsCustom(TagRecSet) {
+				return scm.NewBool(RecSetFromScmer(tableArg).scanExists(currentTx, filtercols, a[3]))
+			}
 			t := TableFromScmer(tableArg)
 			return scm.NewBool(t.scanExists(currentTx, filtercols, a[3]))
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list", ParamName: "table"},
+				{Kind: "table|list|recset", ParamName: "table"},
 				{Kind: "list", ParamName: "filterColumns"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a row exists", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 			},
@@ -783,7 +786,7 @@ func Init(en scm.Env) {
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
+				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local recset, or a list for temporary data"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter; #0, #1, ... address batchdata slots"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map; #0, #1, ... address batchdata slots"},
@@ -916,6 +919,10 @@ func Init(en scm.Env) {
 				return result
 			}
 
+			if tableArg.IsCustom(TagRecSet) {
+				return RecSetFromScmer(tableArg).scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter)
+			}
+
 			t := TableFromScmer(a[layout.tableIdx])
 
 			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter)
@@ -998,9 +1005,7 @@ func Init(en scm.Env) {
 
 			specs := make([]scanOrderTableSpec, n)
 			for i := 0; i < n; i++ {
-				t := TableFromScmer(tables[i])
 				specs[i] = scanOrderTableSpec{
-					table:          t,
 					conditionCols:  scmerSliceToStrings(mustScmerSlice(filterColsArr[i], "filterColumns[i]")),
 					condition:      filterFnArr[i],
 					sortcols:       mustScmerSlice(sortcolsArr[i], "sortcols[i]"),
@@ -1008,6 +1013,11 @@ func Init(en scm.Env) {
 					callback:       mapFnArr[i],
 					perTableOffset: perTableOffsets[i],
 					perTableLimit:  perTableLimits[i],
+				}
+				if tables[i].IsCustom(TagRecSet) {
+					specs[i].recset = RecSetFromScmer(tables[i])
+				} else {
+					specs[i].table = TableFromScmer(tables[i])
 				}
 			}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -402,6 +402,9 @@ func Init(en scm.Env) {
 	scm.CustomStringer[TagTable] = func(ptr unsafe.Pointer) string {
 		return (*table)(ptr).String()
 	}
+	scm.CustomStringer[TagRecSet] = func(ptr unsafe.Pointer) string {
+		return (*recSet)(ptr).String()
+	}
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "table",
@@ -508,6 +511,39 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "scan_recset",
+		Desc: "builds a query-local record-set handle from one table scan; the returned value is not persisted and can be scanned like a table",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			currentTx := scmerToTxContext(a[0])
+			t := TableFromScmer(a[1])
+			filtercols := scmerSliceToStrings(mustScmerSlice(a[2], "filterColumns"))
+			return NewRecSetScmer(t.scanRecSet(currentTx, filtercols, a[3]))
+		},
+		Type: &scm.TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table", ParamName: "table"},
+				{Kind: "list", ParamName: "filterColumns"},
+				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a row enters the recset", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+			},
+			Return: &scm.TypeDescriptor{Kind: "recset"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "recset_count",
+		Desc: "returns the number of currently stored recids in a query-local recset",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			return scm.NewInt(RecSetFromScmer(a[0]).count)
+		},
+		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "recset", ParamName: "recset"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "int"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_exists",
 		Desc: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
@@ -600,6 +636,23 @@ func Init(en scm.Env) {
 				return result
 			}
 
+			if tableArg.IsCustom(TagRecSet) {
+				rs := RecSetFromScmer(tableArg)
+				aggregate := scm.NewNil()
+				if len(a) > layout.reduceIdx {
+					aggregate = a[layout.reduceIdx]
+				}
+				neutral := scm.NewNil()
+				if len(a) > layout.neutralIdx {
+					neutral = a[layout.neutralIdx]
+				}
+				reduce2 := scm.NewNil()
+				if len(a) > layout.reduce2Idx {
+					reduce2 = a[layout.reduce2Idx]
+				}
+				return rs.scan(layout.tx, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter)
+			}
+
 			t := TableFromScmer(a[layout.tableIdx])
 
 			aggregate := scm.NewNil()
@@ -620,7 +673,7 @@ func Init(en scm.Env) {
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
+				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local recset, or a list for temporary data"},
 				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter"},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map"},

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -179,6 +179,20 @@ test_cases:
           "ok"
           (error "scan_order_multi over recsets returned wrong order")))
 
+  - name: "show forwards recset to base table metadata"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (if (and
+              (equal? (show rs) (show tbl))
+              (equal? (show rs true) (show tbl true))
+              (equal? (show rs "statistics") (show tbl "statistics")))
+          "ok"
+          (error "show did not forward recset to base table")))
+
   - name: "recset scan rejects mutation callbacks"
     scm: |
       (begin

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -88,6 +88,28 @@ test_cases:
           "ok"
           (error "$recset_contains returned wrong membership")))
 
+  - name: "$recset_contains handles multiple recsets in one scan"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define active (scan_recset nil tbl
+          '("active")
+          (lambda (active) (equal? active 1))))
+        (define sum_ids
+          (scan nil tbl
+            '("$recset_contains" "$recset_contains")
+            (lambda (in_tenant1 in_active) (and (in_tenant1 tenant1) (in_active active)))
+            '("id")
+            (lambda (id) id)
+            (lambda (acc id) (+ acc id))
+            0))
+        (if (equal? sum_ids 6)
+          "ok"
+          (error "$recset_contains did not switch between recset handles")))
+
   - name: "$recset_contains is table-scoped"
     scm: |
       (begin

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -108,6 +108,77 @@ test_cases:
           "ok"
           (error "$recset_contains matched a different table")))
 
+  - name: "scan_exists accepts recset as table-like source"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (if (and
+              (scan_exists nil rs
+                '("active")
+                (lambda (active) (equal? active 0)))
+              (not (scan_exists nil rs
+                '("id")
+                (lambda (id) (equal? id 3)))))
+          "ok"
+          (error "scan_exists over recset returned wrong result")))
+
+  - name: "scan_order accepts recset as table-like source"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define ordered
+          (scan_order nil rs
+            '("active")
+            (lambda (active) true)
+            '("id") '(<)
+            0 0 2
+            '("id")
+            (lambda (id) (list id))
+            (lambda (acc row) (append acc row))
+            '()
+            false))
+        (if (equal? ordered (list (list 1) (list 2)))
+          "ok"
+          (error "scan_order over recset returned wrong order")))
+
+  - name: "scan_order_multi accepts recset branches"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define rs2 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 2))))
+        (define ordered
+          (scan_order_multi nil
+            (list rs1 rs2)
+            (list (list "active") (list "active"))
+            (list
+              (lambda (active) (equal? active 1))
+              (lambda (active) (equal? active 1)))
+            (list (list "id") (list "id"))
+            '(<)
+            nil nil
+            0 0 10
+            (list (list "id") (list "id"))
+            (list
+              (lambda (id) (list id))
+              (lambda (id) (list id)))
+            (lambda (acc row) (append acc row))
+            '()
+            false))
+        (if (equal? ordered (list (list 1) (list 3) (list 5)))
+          "ok"
+          (error "scan_order_multi over recsets returned wrong order")))
+
   - name: "recset scan rejects mutation callbacks"
     scm: |
       (begin

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -1,0 +1,126 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Query-local RecSet storage primitive tests. RecSets are intentionally SCM
+# values only; the tests exercise public scans without exposing recids.
+
+metadata:
+  version: "1.0"
+  description: "Query-local RecSet scans and contains probes"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS recset_items"
+  - sql: "DROP TABLE IF EXISTS recset_other"
+  - sql: |
+      CREATE TABLE recset_items (
+        id INT PRIMARY KEY,
+        tenant INT,
+        active INT
+      )
+  - sql: |
+      CREATE TABLE recset_other (
+        id INT PRIMARY KEY,
+        tenant INT
+      )
+  - sql: |
+      INSERT INTO recset_items VALUES
+        (1, 1, 1),
+        (2, 1, 0),
+        (3, 2, 1),
+        (4, 2, 0),
+        (5, 1, 1)
+  - sql: |
+      INSERT INTO recset_other VALUES
+        (1, 1),
+        (2, 1)
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS recset_other"
+  - sql: "DROP TABLE IF EXISTS recset_items"
+
+test_cases:
+  - name: "scan_recset builds a query-local subset"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (if (equal? (recset_count rs) 3)
+          "ok"
+          (error "scan_recset returned wrong cardinality")))
+
+  - name: "scan accepts recset as table-like source"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define sum_active
+          (scan nil rs
+            '("active")
+            (lambda (active) (equal? active 1))
+            '("id")
+            (lambda (id) id)
+            (lambda (acc id) (+ acc id))
+            0))
+        (if (equal? sum_active 6)
+          "ok"
+          (error "recset scan returned wrong row set")))
+
+  - name: "$recset_contains probes current table row without exposing recid"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define sum_active
+          (scan nil tbl
+            '("$recset_contains" "active")
+            (lambda (in_recset active) (and (in_recset rs) (equal? active 1)))
+            '("id")
+            (lambda (id) id)
+            (lambda (acc id) (+ acc id))
+            0))
+        (if (equal? sum_active 6)
+          "ok"
+          (error "$recset_contains returned wrong membership")))
+
+  - name: "$recset_contains is table-scoped"
+    scm: |
+      (begin
+        (define source (table "memcp-tests" "recset_items"))
+        (define other (table "memcp-tests" "recset_other"))
+        (define rs (scan_recset nil source
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define matches
+          (scan nil other
+            '("$recset_contains")
+            (lambda (in_recset) (if (in_recset rs) true false))
+            '("id")
+            (lambda (id) 1)
+            (lambda (acc one) (+ acc one))
+            0))
+        (if (equal? matches 0)
+          "ok"
+          (error "$recset_contains matched a different table")))
+
+  - name: "recset scan rejects mutation callbacks"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define rs (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (scan nil rs
+          '()
+          (lambda () true)
+          '("$update")
+          (lambda (update) (update))
+          (lambda (acc ignored) acc)
+          nil))
+    expect:
+      error: true

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -59,6 +59,7 @@ test_cases:
             - "cardinality_mode"
           not_contains:
             - "neumann_exists"
+            - "exists_probe"
             - "inner_select"
             - ".grp:"
             - "__mat:_uncorr_cnt_"


### PR DESCRIPTION
## Summary
- add query-local RecSet SCM values built by `scan_recset`
- allow `scan`, `scan_exists`, `scan_order`, and `scan_order_multi` to consume RecSets as table-like read-only sources
- add `$recset_contains` as a scan-local closure probe without exposing shard pointers or recids to SCM
- forward `(show recset ...)` metadata calls to the underlying base table
- make `scan_recset` construction use the existing shard-parallel scan scheduler instead of building shards sequentially
- cache the current shard's RecSet entry inside scan-local `$recset_contains`, avoiding repeated shard-entry resolution for the same RecSet handle
- remove the logical `exists_probe` shortcut from `queryplan.scm`: correlated EXISTS now stays visible as `group-stage` + `stage-output` after `untangle_query`, so reorder can see the helper relation instead of a hidden nested probe
- keep `exists_probe` as a forbidden invariant marker only; EXPLAIN IR regression checks that it does not survive

## Scope boundary
This PR is a storage/SCM carrier slice plus one Neumann decorrelation cleanup. It deliberately does not add the final planner carrier decision that chooses between group cache, extra scan, or prepared RecSet for EXISTS helpers. That should be implemented at the stage-output/carrier boundary after the logical EXISTS/left-join work lands, not as expression-lowering shortcuts.

The RecSet carrier is now cheaper to build and safe to use as a physical option, but it is still not a blanket replacement for joins or search indexes. It should be selected only when build cost is amortized by reuse, set operations, join-order changes, or a smaller final ordered scan.

## Physical operator measurements
Head: `5d33f9e42`.
Method: local physical SCM measurements on the imported production-shaped dataview dataset, using `(time ...)` with `TracePrint`; medians over three warm timed runs. These are operator-level measurements, not end-to-end SQL planner claims.

RecSet preparation effect:

| operation | previous median | new median | result |
| --- | ---: | ---: | ---: |
| build filename RecSet, selective term | 24.7ms | 14.8ms | 3 rows |
| build text RecSet, selective term | 1.96s | 1.19s | 6,759 rows |
| build document RecSet, narrow tenant | 419ms | 218ms | 7 rows |
| build document RecSet, medium tenant | 406ms | 215ms | 7,618 rows |
| build document RecSet, direct text predicate | 293ms | 54.0ms | 116 rows |
| build one-row file RecSet | 22.4ms | 14.0ms | 1 row |
| scan-local contains over all documents, 7-row RecSet | 33.8ms | 35.9ms | 7 hits |
| scan-local contains over all documents, 7,618-row RecSet | 37.5ms | 35.7ms | 7,618 hits |
| scan-local contains over all documents, 116-row RecSet | 35.1ms | 37.3ms | 116 hits |
| `scan_exists` over one-row file RecSet per document | 2.44s | 2.51s | 1 hit |

Conclusion:
- shard-parallel RecSet construction materially improves build cost
- scan-local contains remains cheap and stable
- RecSet iteration after build remains cheap
- cross-table `scan_exists` over a RecSet per outer row remains the wrong physical plan; future planner work should lift/project or use key-hashed probes instead

Older end-to-end dataview SQL A/B, before the build/probe preparation, showed the PR slower than master because the planner does not yet select RecSets as a better carrier for the query. This PR therefore remains a carrier/preparation PR, not the final dataview optimization PR.

## Tests
- `make` started, but did not complete; see full-suite note
- `python3 run_sql_tests.py tests/123_recset.yaml`
- `go test ./storage/ -run 'TestIterateShardsParallel|TestScan' -count=1 -timeout=90s`
- `python3 run_sql_tests.py tests/66_multi_table_dml.yaml`
- `python3 run_sql_tests.py tests/66_lead_window_derived.yaml`
- `python3 run_sql_tests.py tests/66_exists_session_var.yaml`

## Full-suite note
`make test` was started locally and passed many YAML suites, but the parallel full-suite run later hit `No response` timeouts in unrelated 66_* suites and was interrupted. The first affected suites passed when rerun individually, including `tests/66_multi_table_dml.yaml`, `tests/66_lead_window_derived.yaml`, and `tests/66_exists_session_var.yaml`. Current GitHub CI is the authoritative full-run check for this draft.
