### PR TITLE
Normalize NOT EXISTS decorrelation

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -207,6 +207,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	)))
 
 	(define psql_expression5 (parser (or
+		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
 		(parser '((atom "NOT" true) (define expr psql_expression6)) '('not expr))
 		/* unary minus: -(expr) */
 		(parser '("-" (define expr psql_expression6)) '((quote -) 0 expr))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -679,12 +679,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define terms (split_and_terms (coalesceNil (source_join_expr src) true)))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_aliases outer_aliases term)))))
-		(list
-			(source_alias src)
-			(source_schema src)
-			(source_relation src)
-			false
-			(combine_where_terms local_terms true)))))
+			(list
+				(source_alias src)
+				(source_schema src)
+				(source_relation src)
+				(source_outer? src)
+				(combine_where_terms local_terms true)))))
 
 (define sources_without_outer_join_terms (lambda (inner_default inner_aliases outer_aliases sources)
 	(map (coalesceNil sources '()) (lambda (src)
@@ -1061,14 +1061,18 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define stage_alias (exists_stage_alias stage_id))
 		(define key_names (group_key_cols keys))
 		(define source (list
-			stage_alias
-			(group_stage_schema stage)
-			(make_stage_output_relation stage_id)
-			(stage_source_outer? outer_sources)
-			(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
+				stage_alias
+				(group_stage_schema stage)
+				(make_stage_output_relation stage_id)
+				(stage_source_outer? outer_sources)
+				(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
 		(list
-			(list (quote >) (list (quote get_column) stage_alias false count_col false) 0)
+			(list (quote >)
+				(list (quote coalesceNil)
+					(list (quote get_column) stage_alias false count_col false)
+					0)
+				0)
 			(list stage)
 			(list source)))))
 
@@ -2175,9 +2179,17 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define inner (untangle_query normalized sub_ctx))
 		(if (union_block? inner)
 			(make_exists_union_stage_rewrite inner (list outer_sources subquery))
-			(if (query_block_no_from? inner)
-				(list (untangle_zero_domain_subquery (quote inner_select_exists) nil subquery ctx) '() '())
-				(make_exists_stage_rewrite inner (list outer_sources subquery)))))))
+				(if (query_block_no_from? inner)
+					(list (untangle_zero_domain_subquery (quote inner_select_exists) nil subquery ctx) '() '())
+					(make_exists_stage_rewrite inner (list outer_sources subquery)))))))
+
+(define untangle_not_exists_subquery_with_stages (lambda (subquery outer_sources ctx)
+	(begin
+		(define rewritten (untangle_exists_subquery_with_stages subquery outer_sources ctx))
+		(list
+			(list (quote not) (nth rewritten 0))
+			(nth rewritten 1)
+			(nth rewritten 2)))))
 
 (define untangle_in_subquery_with_stages (lambda (probe subquery outer_sources ctx)
 	(begin
@@ -2277,12 +2289,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(if (btw2025_defer_subquery_rewrite? subquery outer_sources ctx)
 			(list (make_dependent_subquery_marker (quote in) probe subquery outer_sources) '() '())
 			(untangle_in_subquery_with_stages probe subquery outer_sources ctx))
-		((quote inner_select_in) probe subquery)
-		(if (btw2025_defer_subquery_rewrite? subquery outer_sources ctx)
-			(list (make_dependent_subquery_marker (quote in) probe subquery outer_sources) '() '())
-			(untangle_in_subquery_with_stages probe subquery outer_sources ctx))
-		((symbol not) ((symbol inner_select_in) probe subquery))
-		(untangle_not_in_subquery_with_stages probe subquery outer_sources ctx)
+			((quote inner_select_in) probe subquery)
+			(if (btw2025_defer_subquery_rewrite? subquery outer_sources ctx)
+				(list (make_dependent_subquery_marker (quote in) probe subquery outer_sources) '() '())
+				(untangle_in_subquery_with_stages probe subquery outer_sources ctx))
+			((symbol not) ((symbol inner_select_exists) subquery))
+			(untangle_not_exists_subquery_with_stages subquery outer_sources ctx)
+			((quote not) ((quote inner_select_exists) subquery))
+			(untangle_not_exists_subquery_with_stages subquery outer_sources ctx)
+			((symbol not) ((quote inner_select_exists) subquery))
+			(untangle_not_exists_subquery_with_stages subquery outer_sources ctx)
+			((quote not) ((symbol inner_select_exists) subquery))
+			(untangle_not_exists_subquery_with_stages subquery outer_sources ctx)
+			((symbol not) ((symbol inner_select_in) probe subquery))
+			(untangle_not_in_subquery_with_stages probe subquery outer_sources ctx)
 		((quote not) ((quote inner_select_in) probe subquery))
 		(untangle_not_in_subquery_with_stages probe subquery outer_sources ctx)
 		((symbol not) ((quote inner_select_in) probe subquery))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -654,6 +654,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	)))
 
 	(define sql_expression5 (parser (or
+		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub sql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
 		/* NOT has lower precedence than IS NULL: NOT expr IS NULL == NOT (expr IS NULL) */
 		(parser '((atom "NOT" true) (define expr sql_expression5)) '('not expr))
 		/* unary minus: -(expr) */

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -194,6 +194,7 @@ test_cases:
           not_contains:
             - "neumann_exists"
             - "inner_select"
+            - "exists_probe"
             - ".grp:"
             - "__mat:_uncorr_cnt_"
             - "touch_keytable"
@@ -265,6 +266,7 @@ test_cases:
           not_contains:
             - "neumann_exists"
             - "inner_select"
+            - "exists_probe"
             - ".grp:"
             - "__mat:_uncorr_cnt_"
             - "touch_keytable"


### PR DESCRIPTION
## Summary

Normalize `NOT EXISTS` so both MySQL and PostgreSQL parser paths emit the same logical form as `NOT (inner_select_exists ...)`, then decorrelate that form through the existing EXISTS group-stage path.

This keeps EXISTS as a logical aggregate-style stage instead of reintroducing `exists_probe` as a logical marker. Physical choices such as `scan_exists`, RecSet, or group-cache lowering remain build-queryplan decisions.

## Changes

- Parse `NOT EXISTS (...)` explicitly before generic unary `NOT` in both SQL parsers.
- Add planner handling for `NOT (inner_select_exists ...)`.
- Preserve outer-join flags when stripping only correlated join terms from subquery sources.
- Coalesce missing EXISTS count output to `0` before comparing it to `> 0`, so anti-presence checks do not collapse to `NULL`.
- Extend existing EXISTS plan assertions to reject the old `exists_probe` marker.

## A/B measurements

Baseline: `origin/master` at `5d4fa1d8a`.
Branch: `321e0cb00`.

| Check | master | branch |
| --- | ---: | ---: |
| `tests/40_exists_subquery.yaml` | 15/15, suite 0.180s, wall 1.35s | 15/15, suite 0.173s, wall 1.34s |
| `tests/41_in_subquery.yaml` | 41/41, suite 1.475s, wall 2.67s | 41/41, suite 1.226s, wall 2.42s |
| `tests/66_exists_nested_scalar.yaml` | 4/4, suite 0.140s, wall 1.30s | 4/4, suite 0.137s, wall 1.31s |
| `tests/105_deep_nested_in_exists.yaml` diagnostic | 11/18, suite 1.165s, wall 2.34s | 15/18, suite 1.195s, wall 2.37s |

The PR is not making a broad runtime-speed claim; the targeted suites show no measurable regression, and the diagnostic deep-nesting suite improves the NOT EXISTS filter cases while leaving deeper scalar-domain semantics for follow-up work.

## Validation

- `make`
- `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- `python3 tools/lint_scm.py --path lib/sql-parser.scm --check`
- `python3 tools/lint_scm.py --path lib/psql-parser.scm --check`
- `python3 run_sql_tests.py tests/40_exists_subquery.yaml --port 45640`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml --port 45641`
- `python3 run_sql_tests.py tests/66_exists_nested_scalar.yaml --port 45642`
- `python3 run_sql_tests.py tests/66_neumann_domain_col.yaml --port 45666`
- `python3 run_sql_tests.py tests/66_prejoin_scalar_subselect.yaml --port 45667`
- `python3 run_sql_tests.py tests/66_multi_table_dml.yaml --port 45668`
- `python3 run_sql_tests.py tests/66_nested_subselect_column_as_table.yaml --port 45669`

Full pre-commit was attempted, but the shared parallel run timed out in `tests/66_neumann_domain_col.yaml`; that exact suite passed isolated in 0.140s, and the other concurrently active `66_*` suites also passed isolated. CI should provide the clean full-harness signal.

## Follow-up

`tests/105_deep_nested_in_exists.yaml` still has three failing diagnostic cases:

- one deep `NOT IN` case skipping two correlation levels
- two EXISTS-as-projected-scalar cases where missing inner rows still need explicit false-domain seeding

Those need a separate scalar-domain/anti-join follow-up rather than another EXISTS logical marker.
