### PR TITLE
Use RecSets for positive EXISTS carrier

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3316,11 +3316,48 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(and (not (nil? stage))
 				(equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_candidate)))))))
 
+(define exists_recset_stage? (lambda (stage)
+	(and (group_stage? stage)
+		(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists))
+			(and (equal? (qassoc_get (gs_facts stage) (quote presence_only) false) true)
+				(and (single_source? (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+					(and (single_source? (gs_keys stage))
+						(source_is_base_table? (gs_input stage)))))))))
+
+(define exists_recset_stage_output_source? (lambda (stages src)
+	(and (stage_output_relation? (source_relation src))
+		(begin
+			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
+			(exists_recset_stage? stage)))))
+
 (define first_candidate_source (lambda (stages sources)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(if (not (nil? found))
 			found
 			(if (candidate_stage_output_source? stages src) src nil)))
+		nil)))
+
+(define negated_term? (lambda (term)
+	(match term
+		((symbol not) _expr) true
+		((quote not) _expr) true
+		_ false)))
+
+(define positive_condition_refs_source? (lambda (default_alias alias condition)
+	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
+		(or found
+			(and (not (negated_term? term))
+				(expr_refs_alias_after_group? default_alias alias term))))
+		false)))
+
+(define first_exists_recset_source (lambda (stages sources default_alias condition)
+	(reduce (coalesceNil sources '()) (lambda (found src)
+		(if (not (nil? found))
+			found
+			(if (and (exists_recset_stage_output_source? stages src)
+				(positive_condition_refs_source? default_alias (source_alias src) condition))
+				src
+				nil)))
 		nil)))
 
 (define without_source_alias (lambda (sources alias)
@@ -3334,6 +3371,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons (source_with_join_expr src (combine_where (source_join_expr src) condition)) rest)
 			(cons src (attach_candidate_join_condition default_alias candidate_alias condition rest)))
 		_ '())))
+
+(define strip_condition_for_source_alias (lambda (default_alias alias condition)
+	(combine_where_terms
+		(filter (split_and_terms (coalesceNil condition true)) (lambda (term)
+			(not (expr_refs_alias_after_group? default_alias alias term))))
+		true)))
 
 (define reorder_candidate_sources (lambda (stages sources)
 	(begin
@@ -3359,23 +3402,52 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define sources (qb_sources block))
 		(define candidate (first_candidate_source (qb_stages block) sources))
 		(if (nil? candidate)
-			(if (query_block_needs_reorder_facts? block)
-				(query_block_with_reorder_facts
-					(make_query_block
-						(qb_schema block)
-						(qb_sources block)
-						(qb_fields block)
-						(qb_where block)
-						(qb_group block)
-						(qb_having block)
-						(qb_order block)
-						(qb_limit block)
-						(qb_offset block)
-						(qb_hidden block)
-						(map (qb_stages block) join_reorder_stage)
-						(qb_facts block))
-					(query_block_reorder_telemetry block))
-				block)
+			(begin
+				(define default_alias (if (empty_list? sources) nil (source_alias (car sources))))
+				(define exists_src (first_exists_recset_source (qb_stages block) sources default_alias (qb_where block)))
+				(if (nil? exists_src)
+					(if (query_block_needs_reorder_facts? block)
+						(query_block_with_reorder_facts
+							(make_query_block
+								(qb_schema block)
+								(qb_sources block)
+								(qb_fields block)
+								(qb_where block)
+								(qb_group block)
+								(qb_having block)
+								(qb_order block)
+								(qb_limit block)
+								(qb_offset block)
+								(qb_hidden block)
+								(map (qb_stages block) join_reorder_stage)
+								(qb_facts block))
+							(query_block_reorder_telemetry block))
+						block)
+					(begin
+						(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation exists_src))))
+						(define stage_id (gs_id stage))
+						(define probe (car (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
+						(define base_where (strip_condition_for_source_alias
+							default_alias
+							(source_alias exists_src)
+							(qb_where block)))
+						(query_block_with_reorder_facts
+							(make_query_block
+								(qb_schema block)
+								(without_source_alias sources (source_alias exists_src))
+								(qb_fields block)
+								(combine_where base_where (driver_membership_probe_expr stage probe))
+								(qb_group block)
+								(qb_having block)
+								(qb_order block)
+								(qb_limit block)
+								(qb_offset block)
+								(qb_hidden block)
+								(map (candidate_stage_without_source (qb_stages block) stage_id) join_reorder_stage)
+								(qb_facts block))
+							(merge (list
+								(query_block_reorder_telemetry block)
+								(list (list (quote exists_plan_strategy) (quote recset_project_join)))))))))
 			(begin
 				(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation candidate))))
 				(define strategy (candidate_reorder_strategy stage sources block))
@@ -4063,14 +4135,35 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define stage (nth membership 0))
 		(define target_col (nth membership 2))
 		(define input (gs_input stage))
-		(if (not (union_block? input))
-			nil
+		(if (union_block? input)
 			(begin
 				(define projected (map (union_branches input) (lambda (branch)
 					(recset_project_join_branch_expr src branch target_col))))
 				(if (single_source? projected)
 					(car projected)
-					(list (quote recset_union) (cons (quote list) projected))))))))
+					(list (quote recset_union) (cons (quote list) projected))))
+			(if (exists_recset_stage? stage)
+				(begin
+					(define source_col (direct_column_name_for_alias input (car (gs_keys stage))))
+					(if (nil? source_col)
+						nil
+						(begin
+							(define alias (source_alias input))
+							(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+							(define filtercols (extract_columns_for_alias input condition))
+							(list (quote recset_project_join)
+								'(session "__memcp_tx")
+								(list (quote scan_recset)
+									'(session "__memcp_tx")
+									(source_table_expr input)
+									(cons (quote list) filtercols)
+									(list (quote lambda)
+										(map filtercols (lambda (col) (symbol (concat alias "." col))))
+										(list (quote optimize) (lower_column_expr_for_alias input condition))))
+								(quoted_runtime_list (list source_col))
+								(source_table_expr src)
+								(quoted_runtime_list (list target_col))))))
+				nil)))))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -5966,21 +6059,24 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(if (direct_base_group_stage_supported? block group_stage)
 					(lower_direct_base_group_stage group_stage fields (qb_offset block) (qb_limit block))
 					(lower_group_stage group_stage)))
-			(begin
-				(define alias (source_alias src))
-				(define condition (combine_where (qb_where block) (source_join_expr src)))
-				(define order_items (coalesceNil (qb_order block) '()))
-				(define scan_order_supported (order_items_belong_to_source? src order_items))
-				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
-				(define filtercols (extract_columns_for_alias src condition))
-				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
-					(extract_columns_for_alias src expr)))))
-				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
-				(define mapcols (merge_unique (list filtercols fieldcols)))
-				(define table_expr (source_table_expr src))
-				(define filter_expr (list (quote lambda)
-					(map filtercols (lambda (col) (symbol (concat alias "." col))))
-					(list (quote optimize) (lower_column_expr_for_alias src condition))))
+				(begin
+					(define alias (source_alias src))
+					(define condition (combine_where (qb_where block) (source_join_expr src)))
+					(define membership (driver_membership_for_source src condition))
+					(define membership_table_expr (if (nil? membership) nil (recset_project_join_expr_for_membership src membership)))
+					(define effective_condition (strip_driver_membership_for_source src condition membership))
+					(define order_items (coalesceNil (qb_order block) '()))
+					(define scan_order_supported (order_items_belong_to_source? src order_items))
+					(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
+					(define filtercols (extract_columns_for_alias src effective_condition))
+					(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
+						(extract_columns_for_alias src expr)))))
+					(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
+					(define mapcols (merge_unique (list filtercols fieldcols)))
+					(define table_expr (coalesceNil membership_table_expr (source_table_expr src)))
+					(define filter_expr (list (quote lambda)
+						(map filtercols (lambda (col) (symbol (concat alias "." col))))
+						(list (quote optimize) (lower_column_expr_for_alias src effective_condition))))
 				(define map_expr (list (quote lambda)
 					(map mapcols (lambda (col) (symbol (concat alias "." col))))
 					(list (quote resultrow)
@@ -6021,10 +6117,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 								(qb_sources block)
 								alias
 								(merge (list
-									(extract_assoc fields (lambda (_title expr) expr))
-									(list condition)
-									(order_exprs order_items)))
-								condition
+										(extract_assoc fields (lambda (_title expr) expr))
+										(list effective_condition)
+										(order_exprs order_items)))
+									effective_condition
 								(lower_join_result_row_assoc (qb_sources block) alias fields order_items)
 								'()
 								0

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3305,6 +3305,15 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(list (quote not) (list (quote nil?) probe))
 		(list (quote driver_membership_probe) stage probe))))
 
+(define dml_preserve_driver_membership_probe (lambda (fallback_schema expr)
+	(match expr
+		((symbol driver_membership_probe) stage probe)
+		(list (quote dml_driver_membership_probe) fallback_schema stage probe)
+		((quote driver_membership_probe) stage probe)
+		(list (quote dml_driver_membership_probe) fallback_schema stage probe)
+		(cons head tail) (cons head (map tail (lambda (item) (dml_preserve_driver_membership_probe fallback_schema item))))
+		_ expr)))
+
 (define candidate_stage_without_source (lambda (stages stage_id)
 	(filter (coalesceNil stages '()) (lambda (stage)
 		(not (and (group_stage? stage) (equal? (gs_id stage) stage_id)))))))
@@ -3399,6 +3408,21 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define reorder_query_block_with_candidate_strategy (lambda (block)
 	(begin
+		(if (equal? (qassoc_get (qb_facts block) (quote dml) false) true)
+			(make_query_block
+				(qb_schema block)
+				(qb_sources block)
+				(qb_fields block)
+				(qb_where block)
+				(qb_group block)
+				(qb_having block)
+				(qb_order block)
+				(qb_limit block)
+				(qb_offset block)
+				(qb_hidden block)
+				(map (qb_stages block) join_reorder_stage)
+				(qb_facts block))
+			(begin
 		(define sources (qb_sources block))
 		(define candidate (first_candidate_source (qb_stages block) sources))
 		(if (nil? candidate)
@@ -3487,7 +3511,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(qb_offset block)
 						(qb_hidden block)
 						(map (qb_stages block) join_reorder_stage)
-						(merge (list facts (qassoc_set (qb_facts block) (quote default_alias) (source_alias (car sources))))))))))))
+						(merge (list facts (qassoc_set (qb_facts block) (quote default_alias) (source_alias (car sources)))))))))))))))
 
 (define join_reorder_node (lambda (node)
 	(if (query_block? node)
@@ -3714,6 +3738,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define extract_columns_for_alias (lambda (src expr)
 	(match expr
+		((symbol dml_driver_membership_probe) _fallback_schema _stage probe)
+		(extract_columns_for_alias src probe)
+		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
+		(extract_columns_for_alias src probe)
 		((symbol scalar_first_probe) stage _requested_col)
 		(merge_unique (map (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (key)
 			(extract_columns_for_alias src key))))
@@ -3726,6 +3754,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define lower_column_expr_for_alias (lambda (src expr)
 	(match expr
+		((symbol dml_driver_membership_probe) fallback_schema stage probe)
+		(lower_dml_driver_membership_probe_expr (list src) (source_alias src) fallback_schema stage probe)
+		((quote dml_driver_membership_probe) fallback_schema stage probe)
+		(lower_dml_driver_membership_probe_expr (list src) (source_alias src) fallback_schema stage probe)
 		((symbol scalar_first_probe) stage requested_col)
 		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col)
 		((quote scalar_first_probe) stage requested_col)
@@ -3821,6 +3853,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(extract_columns_for_join_alias sources default_alias alias probe)
 		((quote driver_membership_probe) _stage probe)
 		(extract_columns_for_join_alias sources default_alias alias probe)
+		((symbol dml_driver_membership_probe) _fallback_schema _stage probe)
+		(extract_columns_for_join_alias sources default_alias alias probe)
+		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
+		(extract_columns_for_join_alias sources default_alias alias probe)
 		((symbol scalar_first_probe) stage _requested_col)
 		(merge_unique (map (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (key)
 			(extract_columns_for_join_alias sources default_alias alias key))))
@@ -3845,6 +3881,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(lower_driver_membership_probe_expr sources default_alias stage probe)
 		((quote driver_membership_probe) stage probe)
 		(lower_driver_membership_probe_expr sources default_alias stage probe)
+		((symbol dml_driver_membership_probe) fallback_schema stage probe)
+		(lower_dml_driver_membership_probe_expr sources default_alias fallback_schema stage probe)
+		((quote dml_driver_membership_probe) fallback_schema stage probe)
+		(lower_dml_driver_membership_probe_expr sources default_alias fallback_schema stage probe)
 		((symbol scalar_first_probe) stage requested_col)
 		(lower_scalar_first_probe_expr sources default_alias stage requested_col)
 		((quote scalar_first_probe) stage requested_col)
@@ -4051,6 +4091,28 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons (quote +) (map (union_branches input) (lambda (branch)
 				(driver_membership_probe_branch_expr sources default_alias branch probe))))
 			0))))
+
+(define lower_dml_driver_membership_probe_expr (lambda (sources default_alias fallback_schema stage _probe)
+	(begin
+		(define keys (gs_keys stage))
+		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(if (< (count keys) (count lookup_keys))
+			(neumann_fail "build_queryplan" "DML membership probe key/domain mismatch")
+			true)
+		(define key_names (group_key_cols keys))
+		(define filter_key_names (map (produceN (count lookup_keys)) (lambda (i) (nth key_names i))))
+		(define carrier_schema (coalesceNil (group_stage_carrier_schema stage) fallback_schema))
+		(define key_terms (map (produceN (count lookup_keys)) (lambda (i)
+			(list (quote equal??)
+				(symbol (nth key_names i))
+				(lower_column_expr_for_join sources default_alias (nth lookup_keys i))))))
+		(list (quote scan_exists)
+			'(session "__memcp_tx")
+			(list (quote table) carrier_schema (group_stage_carrier_relation stage))
+			(cons (quote list) filter_key_names)
+			(list (quote lambda)
+				(map filter_key_names symbol)
+				(list (quote optimize) (if (empty_list? key_terms) true (cons (quote and) key_terms))))))))
 
 (define direct_column_name_for_alias (lambda (src expr)
 	(match expr
@@ -4302,19 +4364,13 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(list (quote group-keytable) schema relation)))
 
 (define group_carrier_kind (lambda (carrier)
-	(match carrier
-		'(kind _schema _relation) kind
-		_ nil)))
+	(if (list? carrier) (nth carrier 0) nil)))
 
 (define group_carrier_schema (lambda (carrier)
-	(match carrier
-		'(_kind schema _relation) schema
-		_ nil)))
+	(if (list? carrier) (nth carrier 1) nil)))
 
 (define group_carrier_relation (lambda (carrier)
-	(match carrier
-		'(_kind _schema relation) relation
-		_ nil)))
+	(if (list? carrier) (nth carrier 2) nil)))
 
 (define group_stage_schema (lambda (stage)
 	(begin
@@ -6574,7 +6630,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define cols (qb_fields block))
 		(define delete_mode (empty_list? (coalesceNil cols '())))
 		(define update_ref (list (quote get_column) target_alias false "$update" false))
-		(define cond (coalesceNil (qb_where block) true))
+		(define cond (dml_preserve_driver_membership_probe target_schema (coalesceNil (qb_where block) true)))
 		(define needed_exprs (merge (list
 			(dml_assignment_exprs cols)
 			(list cond)
@@ -6619,7 +6675,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define alias (source_alias src))
 		(define cols (qb_fields block))
 		(define delete_mode (empty_list? (coalesceNil cols '())))
-		(define cond (coalesceNil (qb_where block) true))
+		(define cond (dml_preserve_driver_membership_probe target_schema (coalesceNil (qb_where block) true)))
 		(define order_items (coalesceNil (qb_order block) '()))
 		(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
 		(define filtercols (extract_columns_for_alias src cond))
@@ -7068,7 +7124,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(coalesceNil order '())
 			limit
 			offset
-			'() '() '()))
+			'() '()
+			(list (list (quote dml) true))))
 		(neumann_compile_ir_pipeline
 			(ir_with_return (untangle_query_term query nil) (list (quote dml) schema tbl))))))
 

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3261,8 +3261,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(or estimate_ratio_broad
 				(and (nil? candidate_estimate) (candidate_stage_broad? stage)))))
 		(if (and (not (nil? driver))
-			(and broad
-				(source_order_limit_driver? driver (qb_order block) (qb_limit block))))
+			(source_order_limit_driver? driver (qb_order block) (qb_limit block)))
 			(quote driver_order_membership_probe)
 			(quote candidate_keyset)))))
 
@@ -3960,6 +3959,98 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons (quote +) (map (union_branches input) (lambda (branch)
 				(driver_membership_probe_branch_expr sources default_alias branch probe))))
 			0))))
+
+(define direct_column_name_for_alias (lambda (src expr)
+	(match expr
+		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+			(resolve_physical_column_name src col col_ignorecase)
+			nil)
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase) (direct_column_name_for_alias src (list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		_ nil)))
+
+(define driver_membership_probe_term (lambda (expr)
+	(match expr
+		((symbol driver_membership_probe) stage probe) (list stage probe)
+		((quote driver_membership_probe) stage probe) (list stage probe)
+		_ nil)))
+
+(define driver_membership_nil_guard? (lambda (probe expr)
+	(match expr
+		((symbol not) ((symbol nil?) guarded)) (equal? guarded probe)
+		((quote not) ((quote nil?) guarded)) (equal? guarded probe)
+		((symbol not) ((quote nil?) guarded)) (equal? guarded probe)
+		((quote not) ((symbol nil?) guarded)) (equal? guarded probe)
+		_ false)))
+
+(define driver_membership_for_source (lambda (src condition)
+	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
+		(if (not (nil? found))
+			found
+			(begin
+				(define probe_term (driver_membership_probe_term term))
+				(if (nil? probe_term)
+					nil
+					(begin
+						(define probe_col (direct_column_name_for_alias src (nth probe_term 1)))
+						(if (nil? probe_col)
+							nil
+							(list (nth probe_term 0) (nth probe_term 1) probe_col term)))))))
+		nil)))
+
+(define strip_driver_membership_for_source (lambda (src condition membership)
+	(if (nil? membership)
+		condition
+		(begin
+			(define probe (nth membership 1))
+			(define marker_term (nth membership 3))
+			(combine_where_terms
+				(filter (split_and_terms (coalesceNil condition true)) (lambda (term)
+					(and (not (equal? term marker_term))
+						(not (driver_membership_nil_guard? probe term)))))
+				true)))))
+
+(define recset_project_join_branch_expr (lambda (target_src branch target_col)
+	(begin
+		(if (not (and (query_block? branch) (single_source? (qb_sources branch))))
+			(neumann_fail "build_queryplan" "recset project membership expects simple query-block branches")
+			true)
+		(define src (car (qb_sources branch)))
+		(if (not (source_is_base_table? src))
+			(neumann_fail "build_queryplan" "recset project membership expects base table branches")
+			true)
+		(define source_col (direct_column_name_for_alias src (query_block_first_expr branch)))
+		(if (nil? source_col)
+			(neumann_fail "build_queryplan" "recset project membership expects direct RHS column")
+			true)
+		(define alias (source_alias src))
+		(define condition (combine_where (qb_where branch) (source_join_expr src)))
+		(define filtercols (extract_columns_for_alias src condition))
+		(list (quote recset_project_join)
+			'(session "__memcp_tx")
+			(list (quote scan_recset)
+				'(session "__memcp_tx")
+				(source_table_expr src)
+				(cons (quote list) filtercols)
+				(list (quote lambda)
+					(map filtercols (lambda (col) (symbol (concat alias "." col))))
+					(list (quote optimize) (lower_column_expr_for_alias src condition))))
+			(quoted_runtime_list (list source_col))
+			(source_table_expr target_src)
+			(quoted_runtime_list (list target_col))))))
+
+(define recset_project_join_expr_for_membership (lambda (src membership)
+	(begin
+		(define stage (nth membership 0))
+		(define target_col (nth membership 2))
+		(define input (gs_input stage))
+		(if (not (union_block? input))
+			nil
+			(begin
+				(define projected (map (union_branches input) (lambda (branch)
+					(recset_project_join_branch_expr src branch target_col))))
+				(if (single_source? projected)
+					(car projected)
+					(list (quote recset_union) (cons (quote list) projected))))))))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -6184,23 +6275,26 @@ PostgreSQL parsers should both lower to the same combined operators.
 				true)
 			(define alias (source_alias src))
 			(define condition (coalesceNil (source_join_expr src) true))
+			(define membership (driver_membership_for_source src final_condition))
+			(define membership_table_expr (if (nil? membership) nil (recset_project_join_expr_for_membership src membership)))
+			(define effective_final_condition (strip_driver_membership_for_source src final_condition membership))
 			(define row_number_stage_filter (row_number_stage_for_source stages src condition))
 			(define filtercols (join_filter_cols_for_alias all_sources default_alias alias condition))
 			(define mapcols (join_cols_for_alias all_sources default_alias alias needed_exprs))
-			(define table_expr (source_table_expr src))
+			(define table_expr (coalesceNil membership_table_expr (source_table_expr src)))
 			(define filter_expr (list (quote lambda)
 				(map filtercols (lambda (col) (symbol (concat alias "." col))))
 				(list (quote optimize) (lower_column_expr_for_join all_sources default_alias condition))))
 			(define map_expr (list (quote lambda)
 				(map mapcols (lambda (col) (symbol (concat alias "." col))))
-				(build_join_scan_rows_with_mapper schema all_sources (cdr sources) default_alias needed_exprs final_condition row_expr '() 0 -1 stages)))
+				(build_join_scan_rows_with_mapper schema all_sources (cdr sources) default_alias needed_exprs effective_final_condition row_expr '() 0 -1 stages)))
 			(define reduce_expr (list (quote lambda) (list (quote acc) (quote subrows))
 				(list (quote if)
 					(list (quote nil?) (quote subrows))
 					(quote acc)
 					(list (quote merge) (quote acc) (quote subrows)))))
 			(if (not (nil? row_number_stage_filter))
-				(build_join_row_number_scan_rows schema all_sources sources default_alias needed_exprs final_condition row_expr row_number_stage_filter)
+				(build_join_row_number_scan_rows schema all_sources sources default_alias needed_exprs effective_final_condition row_expr row_number_stage_filter)
 				(if (and (empty_list? order_items) (not (query_limit_active? offset_value limit_value)))
 					(list (quote scan)
 						'(session "__memcp_tx")

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -176,15 +176,30 @@ func (s *SessionState) ClearCancel(seq uint64) {
 
 // IsKilled returns true if this session has been killed.
 func (s *SessionState) IsKilled() bool {
+	return s.IsKilledSeq(CurrentQuerySeq())
+}
+
+// CurrentQuerySeq returns the query generation installed in the current
+// execution context. Storage workers should capture this once in the parent
+// goroutine and use IsKilledSeq instead of reading GLS concurrently.
+func CurrentQuerySeq() uint64 {
 	if mgr == nil {
-		return false
+		return 0
 	}
 	v, ok := mgr.GetValue("querySeq")
 	if !ok {
-		return false
+		return 0
 	}
 	seq, ok := v.(uint64)
 	if !ok || seq == 0 {
+		return 0
+	}
+	return seq
+}
+
+// IsKilledSeq returns true if the given query generation has been killed.
+func (s *SessionState) IsKilledSeq(seq uint64) bool {
+	if seq == 0 {
 		return false
 	}
 	s.cancelMu.Lock()

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -21,6 +21,7 @@ package storage
 import "fmt"
 import "runtime/debug"
 import "sort"
+import "sync/atomic"
 import "unsafe"
 import "github.com/launix-de/memcp/scm"
 
@@ -83,6 +84,60 @@ func (r *recSet) contains(shard *storageShard, recid uint32) bool {
 	return r.shardEntry(shard).contains(recid)
 }
 
+func recSetUnion(items []*recSet) *recSet {
+	var base *table
+	var tx *TxContext
+	for _, rs := range items {
+		if rs == nil || rs.table == nil {
+			continue
+		}
+		if base == nil {
+			base = rs.table
+			tx = rs.tx
+		} else if base != rs.table {
+			panic("recset_union: all recsets must belong to the same table")
+		}
+	}
+	result := &recSet{tx: tx, table: base}
+	if base == nil {
+		return result
+	}
+
+	byShard := make(map[*storageShard][]uint32)
+	for _, rs := range items {
+		if rs == nil || rs.table == nil {
+			continue
+		}
+		for i := range rs.shards {
+			part := rs.shards[i]
+			if part.count == 0 {
+				continue
+			}
+			byShard[part.shard] = append(byShard[part.shard], part.recids...)
+		}
+	}
+	for shard, recids := range byShard {
+		sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
+		write := 0
+		var last uint32
+		for i, recid := range recids {
+			if i > 0 && recid == last {
+				continue
+			}
+			recids[write] = recid
+			write++
+			last = recid
+		}
+		recids = recids[:write]
+		result.count += int64(len(recids))
+		result.shards = append(result.shards, recSetShard{shard: shard, recids: recids, count: int64(len(recids))})
+	}
+	sort.Slice(result.shards, func(i, j int) bool {
+		return result.shards[i].shard.uuid.String() < result.shards[j].shard.uuid.String()
+	})
+	return result
+}
+
 func recSetContainsClosure(shard *storageShard) *func(uint32, ...scm.Scmer) scm.Scmer {
 	var cachedRecSet *recSet
 	var cachedShard *recSetShard
@@ -105,6 +160,24 @@ type recSetBuildResult struct {
 	err  scanError
 }
 
+type recSetKeyResult struct {
+	keys [][]scm.Scmer
+	err  scanError
+}
+
+func (t *table) recSetShardResultBufferSize() int {
+	t.shardModeMu.RLock()
+	defer t.shardModeMu.RUnlock()
+	size := len(t.PShards)
+	if t.ShardMode == ShardModeFree {
+		size = len(t.Shards)
+	}
+	if size < 1 {
+		return 1
+	}
+	return size
+}
+
 func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
 	ss := SessionStateFromTx(currentTx)
 	boundaries := extractBoundaries(conditionCols, condition)
@@ -112,7 +185,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	lower, upperLast := indexFromBoundaries(boundaries)
 	result := &recSet{tx: currentTx, table: t}
 
-	values := make(chan recSetBuildResult, 4)
+	values := make(chan recSetBuildResult, t.recSetShardResultBufferSize())
 	done := t.iterateShardsParallel(boundaries, func(shard *storageShard, solo bool) {
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
@@ -250,6 +323,296 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	return recSetShard{shard: t, recids: recids, count: int64(len(recids))}
 }
 
+func (r *recSet) projectJoin(currentTx *TxContext, sourceKeyCols []string, target *table, targetKeyCols []string) *recSet {
+	if r == nil || r.table == nil {
+		return &recSet{tx: currentTx, table: target}
+	}
+	if len(sourceKeyCols) == 0 || len(sourceKeyCols) != len(targetKeyCols) {
+		panic("recset_project_join: source and target key columns must have the same non-zero length")
+	}
+	if currentTx == nil {
+		currentTx = r.tx
+	}
+	ss := SessionStateFromTx(currentTx)
+	keys := r.collectProjectJoinKeys(currentTx, sourceKeyCols, ss)
+	return target.projectJoinKeysToRecSet(currentTx, targetKeyCols, keys, ss)
+}
+
+func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []string, ss *scm.SessionState) [][]scm.Scmer {
+	values := make(chan recSetKeyResult, len(r.shards))
+	closeAfter := 0
+	for i := range r.shards {
+		part := r.shards[i]
+		if part.count == 0 {
+			continue
+		}
+		closeAfter++
+		go func(part recSetShard) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- recSetKeyResult{err: scanError{rec, string(debug.Stack())}}
+				}
+			}()
+			values <- recSetKeyResult{keys: part.shard.collectProjectJoinKeys(part.recids, sourceKeyCols, currentTx, ss)}
+		}(part)
+	}
+	keys := make([][]scm.Scmer, 0, r.count)
+	var keyErr scanError
+	for i := 0; i < closeAfter; i++ {
+		msg := <-values
+		if msg.err.r != nil {
+			if keyErr.r == nil {
+				keyErr = msg.err
+			}
+			continue
+		}
+		keys = append(keys, msg.keys...)
+	}
+	if keyErr.r != nil {
+		panic(keyErr)
+	}
+	return keys
+}
+
+func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []string, currentTx *TxContext, ss *scm.SessionState) [][]scm.Scmer {
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+
+	cols := make([]ColumnStorage, len(sourceKeyCols))
+	readers := make([]ColumnReader, len(sourceKeyCols))
+	needsTxReader := make([]bool, len(sourceKeyCols))
+	for i, col := range sourceKeyCols {
+		cols[i] = t.getColumnStorageOrPanicEx(col, skipShardReadLock)
+		readers[i] = newCachedColumnReaderTx(cols[i], currentTx)
+		if proxy, ok := cols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			needsTxReader[i] = true
+		}
+	}
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	mainCount := t.main_count
+	visibleUpper := mainCount + uint32(len(t.inserts))
+	keys := make([][]scm.Scmer, 0, len(recids))
+	for _, idx := range recids {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		if idx >= visibleUpper {
+			continue
+		}
+		if acidMode {
+			if !currentTx.IsVisible(t, idx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(idx)) {
+			continue
+		}
+		key := make([]scm.Scmer, len(sourceKeyCols))
+		skip := false
+		if idx < mainCount {
+			for i, col := range cols {
+				if needsTxReader[i] {
+					key[i] = readers[i].GetValue(idx)
+				} else {
+					key[i] = col.GetValue(idx)
+				}
+				if key[i].IsNil() {
+					skip = true
+				}
+			}
+		} else {
+			for i, col := range sourceKeyCols {
+				if needsTxReader[i] {
+					key[i] = readers[i].GetValue(idx)
+				} else if _, isProxy := cols[i].(*StorageComputeProxy); isProxy {
+					key[i] = cols[i].GetValue(idx)
+				} else {
+					key[i] = t.getDelta(int(idx-mainCount), col)
+				}
+				if key[i].IsNil() {
+					skip = true
+				}
+			}
+		}
+		if !skip {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []string, keys [][]scm.Scmer, ss *scm.SessionState) *recSet {
+	result := &recSet{tx: currentTx, table: t}
+	if len(keys) == 0 {
+		return result
+	}
+	type targetPartResult struct {
+		part recSetShard
+		err  scanError
+	}
+	values := make(chan targetPartResult, t.recSetShardResultBufferSize())
+	done := t.iterateShardsParallel(nil, func(shard *storageShard, solo bool) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				values <- targetPartResult{err: scanError{rec, string(debug.Stack())}}
+			}
+		}()
+		values <- targetPartResult{part: shard.projectJoinKeysPart(currentTx, targetKeyCols, keys, ss)}
+	})
+	if done == nil {
+		close(values)
+	} else {
+		go func() {
+			<-done
+			close(values)
+		}()
+	}
+	var joinErr scanError
+	for msg := range values {
+		if msg.err.r != nil {
+			if joinErr.r == nil {
+				joinErr = msg.err
+			}
+			continue
+		}
+		if joinErr.r != nil {
+			continue
+		}
+		result.count += msg.part.count
+		result.shards = append(result.shards, msg.part)
+	}
+	if joinErr.r != nil {
+		panic(joinErr)
+	}
+	return result
+}
+
+func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols []string, keys [][]scm.Scmer, ss *scm.SessionState) recSetShard {
+	t.ensureLoaded()
+	skipShardReadLock := t.hasWriteOwner()
+	t.ensureMainCount(skipShardReadLock)
+	targetCols := make([]ColumnStorage, len(targetKeyCols))
+	targetReaders := make([]ColumnReader, len(targetKeyCols))
+	targetNeedsTxReader := make([]bool, len(targetKeyCols))
+	for i, col := range targetKeyCols {
+		targetCols[i] = t.getColumnStorageOrPanicEx(col, skipShardReadLock)
+		targetReaders[i] = newCachedColumnReaderTx(targetCols[i], currentTx)
+		if proxy, ok := targetCols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+			targetNeedsTxReader[i] = true
+		}
+	}
+
+	locked := false
+	if !skipShardReadLock {
+		t.mu.RLock()
+		locked = true
+		if t.t.tableLockOwner.Load() != nil {
+			t.mu.RUnlock()
+			locked = false
+			t.t.waitTableLock(ss, false)
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	defer func() {
+		if locked {
+			t.mu.RUnlock()
+		}
+	}()
+
+	maxInsertIndex := len(t.inserts)
+	visibleUpper := t.main_count + uint32(maxInsertIndex)
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	seen := make(map[uint32]struct{})
+	recids := make([]uint32, 0, 64)
+	var buf [1024]uint32
+	for _, key := range keys {
+		if ss != nil && ss.IsKilled() {
+			panic("query killed")
+		}
+		bounds := make(boundaries, len(targetKeyCols))
+		for i, col := range targetKeyCols {
+			bounds[i] = columnboundaries{
+				col:            col,
+				matcher:        EqualMatcher,
+				lower:          key[i],
+				lowerInclusive: true,
+				upper:          key[i],
+				upperInclusive: true,
+			}
+		}
+		reorderByFrequency(bounds, t.t)
+		lower, upperLast := indexFromBoundaries(bounds)
+		t.iterateIndex(currentTx, bounds, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+			for _, idx := range batch {
+				if idx >= visibleUpper {
+					continue
+				}
+				if acidMode {
+					if !currentTx.IsVisible(t, idx) {
+						continue
+					}
+				} else if t.deletions.Get(uint(idx)) {
+					continue
+				}
+				if _, ok := seen[idx]; ok {
+					continue
+				}
+				if !t.projectJoinTargetMatches(idx, key, targetKeyCols, targetCols, targetReaders, targetNeedsTxReader, currentTx) {
+					continue
+				}
+				seen[idx] = struct{}{}
+				recids = append(recids, idx)
+			}
+			return true
+		})
+	}
+	sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
+	return recSetShard{shard: t, recids: recids, count: int64(len(recids))}
+}
+
+func (t *storageShard) projectJoinTargetMatches(idx uint32, key []scm.Scmer, targetKeyCols []string, targetCols []ColumnStorage, targetReaders []ColumnReader, targetNeedsTxReader []bool, currentTx *TxContext) bool {
+	for i, expected := range key {
+		var actual scm.Scmer
+		if idx < t.main_count {
+			if targetNeedsTxReader[i] {
+				actual = targetReaders[i].GetValue(idx)
+			} else {
+				actual = targetCols[i].GetValue(idx)
+			}
+		} else if targetNeedsTxReader[i] {
+			actual = targetReaders[i].GetValue(idx)
+		} else if _, isProxy := targetCols[i].(*StorageComputeProxy); isProxy {
+			actual = targetCols[i].GetValue(idx)
+		} else {
+			actual = t.getDelta(int(idx-t.main_count), targetKeyCols[i])
+		}
+		if !scm.Equal(actual, expected) {
+			return false
+		}
+	}
+	return true
+}
+
 func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool) scm.Scmer {
 	if r == nil {
 		return neutral
@@ -357,19 +720,52 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 	}
 	ss := SessionStateFromTx(currentTx)
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	type existsResult struct {
+		found bool
+		err   scanError
+	}
+	values := make(chan existsResult, len(r.shards))
+	var stop atomic.Bool
+	closeAfter := 0
 	for i := range r.shards {
 		part := &r.shards[i]
 		if part.count == 0 {
 			continue
 		}
-		if part.shard.recSetPartExists(part.recids, conditionCols, conditionFn, currentTx, ss) {
+		closeAfter++
+		go func(part recSetShard) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- existsResult{err: scanError{rec, string(debug.Stack())}}
+				}
+			}()
+			found := part.shard.recSetPartExists(part.recids, conditionCols, conditionFn, currentTx, ss, &stop)
+			if found {
+				stop.Store(true)
+			}
+			values <- existsResult{found: found}
+		}(*part)
+	}
+	var existsErr scanError
+	for i := 0; i < closeAfter; i++ {
+		msg := <-values
+		if msg.err.r != nil {
+			if existsErr.r == nil {
+				existsErr = msg.err
+			}
+			continue
+		}
+		if msg.found {
 			return true
 		}
+	}
+	if existsErr.r != nil {
+		panic(existsErr)
 	}
 	return false
 }
 
-func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState) bool {
+func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwner()
 	t.ensureMainCount(skipShardReadLock)
@@ -413,6 +809,9 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	for _, idx := range recids {
+		if stop != nil && stop.Load() {
+			return false
+		}
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -970,7 +970,7 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	return akkumulator, outCount
 }
 
-func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
+func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, querySeq uint64) *shardqueue {
 	result := &shardqueue{shard: t}
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
@@ -1073,7 +1073,7 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	result.items = make([]uint32, 0, len(recids))
 	for _, idx := range recids {
-		if ss != nil && ss.IsKilled() {
+		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
 		if idx >= visibleUpper {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -416,6 +416,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	q_ := make(chan scanOrderResult, len(tables)*4)
 	var inputCount int64
 	var wg sync.WaitGroup
+	querySeq := scm.CurrentQuerySeq()
 
 	// Launch shard-parallel scans for each table
 	for ti := range tables {
@@ -470,28 +471,60 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		shardLimit := shardTotalLimit
 
 		if spec.recset != nil {
-			for i := range spec.recset.shards {
-				part := spec.recset.shards[i]
-				if part.count == 0 {
-					continue
-				}
+			if len(sortcols) > 0 {
 				wg.Add(1)
-				go func(part recSetShard) {
+				go func(parts []recSetShard) {
 					defer wg.Done()
-					if ss != nil && ss.IsKilled() {
-						panic("query killed")
-					}
 					defer func() {
 						if r := recover(); r != nil {
 							q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 						}
 					}()
-					res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
-					res.callbackCols = callbackCols
-					res.callback = callback
-					res.tableIdx = tableIdx
-					q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
-				}(part)
+					for _, part := range parts {
+						if part.count == 0 {
+							continue
+						}
+						if ss != nil && ss.IsKilledSeq(querySeq) {
+							panic("query killed")
+						}
+						func(part recSetShard) {
+							defer func() {
+								if r := recover(); r != nil {
+									q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
+								}
+							}()
+							res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, querySeq)
+							res.callbackCols = callbackCols
+							res.callback = callback
+							res.tableIdx = tableIdx
+							q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
+						}(part)
+					}
+				}(spec.recset.shards)
+			} else {
+				for i := range spec.recset.shards {
+					part := spec.recset.shards[i]
+					if part.count == 0 {
+						continue
+					}
+					wg.Add(1)
+					go func(part recSetShard) {
+						defer wg.Done()
+						if ss != nil && ss.IsKilledSeq(querySeq) {
+							panic("query killed")
+						}
+						defer func() {
+							if r := recover(); r != nil {
+								q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
+							}
+						}()
+						res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, querySeq)
+						res.callbackCols = callbackCols
+						res.callback = callback
+						res.tableIdx = tableIdx
+						q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
+					}(part)
+				}
 			}
 		} else {
 			done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -544,6 +544,48 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "recset_project_join",
+		Desc: "projects a source recset through key columns into a query-local target-table recset",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			currentTx := scmerToTxContext(a[0])
+			source := RecSetFromScmer(a[1])
+			sourceKeyCols := scmerSliceToStrings(mustScmerSlice(a[2], "sourceKeyColumns"))
+			target := TableFromScmer(a[3])
+			targetKeyCols := scmerSliceToStrings(mustScmerSlice(a[4], "targetKeyColumns"))
+			return NewRecSetScmer(source.projectJoin(currentTx, sourceKeyCols, target, targetKeyCols))
+		},
+		Type: &scm.TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "recset", ParamName: "source_recset"},
+				{Kind: "list", ParamName: "source_key_columns"},
+				{Kind: "table", ParamName: "target_table"},
+				{Kind: "list", ParamName: "target_key_columns"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "recset"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "recset_union",
+		Desc: "combines query-local recsets from the same table and removes duplicate record IDs",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			values := mustScmerSlice(a[0], "recsets")
+			recsets := make([]*recSet, 0, len(values))
+			for _, value := range values {
+				recsets = append(recsets, RecSetFromScmer(value))
+			}
+			return NewRecSetScmer(recSetUnion(recsets))
+		},
+		Type: &scm.TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "list", ParamName: "recsets"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "recset"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_exists",
 		Desc: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -11,6 +11,7 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS recset_items"
   - sql: "DROP TABLE IF EXISTS recset_other"
+  - sql: "DROP TABLE IF EXISTS recset_link"
   - sql: |
       CREATE TABLE recset_items (
         id INT PRIMARY KEY,
@@ -20,6 +21,12 @@ setup:
   - sql: |
       CREATE TABLE recset_other (
         id INT PRIMARY KEY,
+        tenant INT
+      )
+  - sql: |
+      CREATE TABLE recset_link (
+        id INT PRIMARY KEY,
+        item_id INT,
         tenant INT
       )
   - sql: |
@@ -33,8 +40,16 @@ setup:
       INSERT INTO recset_other VALUES
         (1, 1),
         (2, 1)
+  - sql: |
+      INSERT INTO recset_link VALUES
+        (1, 1, 1),
+        (2, 5, 1),
+        (3, 1, 1),
+        (4, 3, 2),
+        (5, NULL, 1)
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS recset_link"
   - sql: "DROP TABLE IF EXISTS recset_other"
   - sql: "DROP TABLE IF EXISTS recset_items"
 
@@ -200,6 +215,78 @@ test_cases:
         (if (equal? ordered (list (list 1) (list 3) (list 5)))
           "ok"
           (error "scan_order_multi over recsets returned wrong order")))
+
+  - name: "recset_project_join projects source keys to target recids"
+    scm: |
+      (begin
+        (define links (table "memcp-tests" "recset_link"))
+        (define items (table "memcp-tests" "recset_items"))
+        (define link_rs (scan_recset nil links
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define item_rs (recset_project_join nil link_rs '("item_id") items '("id")))
+        (define sum_ids
+          (scan nil item_rs
+            '()
+            (lambda () true)
+            '("id")
+            (lambda (id) id)
+            (lambda (acc id) (+ acc id))
+            0))
+        (if (and
+              (equal? (recset_count item_rs) 2)
+              (equal? sum_ids 6))
+          "ok"
+          (error "recset_project_join returned wrong target recset")))
+
+  - name: "recset_project_join output can be ordered"
+    scm: |
+      (begin
+        (define links (table "memcp-tests" "recset_link"))
+        (define items (table "memcp-tests" "recset_items"))
+        (define link_rs (scan_recset nil links
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define item_rs (recset_project_join nil link_rs '("item_id") items '("id")))
+        (define ordered
+          (scan_order nil item_rs
+            '()
+            (lambda () true)
+            '("id") '(<)
+            0 0 10
+            '("id" "active")
+            (lambda (id active) (list (list id active)))
+            (lambda (acc row) (append acc row))
+            '()
+            false))
+        (if (equal? ordered (list (list (list 1 1)) (list (list 5 1))))
+          "ok"
+          (error "recset_project_join output did not scan_order correctly")))
+
+  - name: "recset_union combines same-table recsets without duplicates"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define active (scan_recset nil tbl
+          '("active")
+          (lambda (active) (equal? active 1))))
+        (define combined (recset_union (list tenant1 active)))
+        (define sum_ids
+          (scan nil combined
+            '()
+            (lambda () true)
+            '("id")
+            (lambda (id) id)
+            (lambda (acc id) (+ acc id))
+            0))
+        (if (and
+              (equal? (recset_count combined) 4)
+              (equal? sum_ids 11))
+          "ok"
+          (error "recset_union returned wrong row set")))
 
   - name: "show forwards recset to base table metadata"
     scm: |

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -80,6 +80,24 @@ test_cases:
         - ID: 1
           name: "Alice"
 
+  - name: "EXPLAIN correlated EXISTS can use RecSet projection carrier"
+    sql: |
+      EXPLAIN SELECT ID, name FROM exists_customers c
+      WHERE EXISTS (
+        SELECT 1 FROM exists_orders o
+        WHERE o.customer_id = c.ID
+          AND o.total > 150
+      )
+      ORDER BY ID
+    expect:
+      contains:
+        - "recset_project_join"
+        - "scan_recset"
+      not_contains:
+        - "exists_probe"
+        - "driver_membership_probe"
+        - "touch_keytable"
+
   - name: "Optimizer rewrites generated EXISTS scan pattern to scan_exists"
     scm: |
       (begin

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -497,24 +497,20 @@ test_cases:
             - "in_candidate"
             - "candidate"
             - "membership_plan_strategy"
-            - "candidate_keyset"
+            - "driver_order_membership_probe"
             - "membership_selectivity_class"
             - "selective"
             - "membership_driver_rows"
             - "membership_candidate_input_rows"
             - "membership_cost_reason"
-            - "selective_membership_build_candidate_keyset"
             - "source_estimates"
             - "group_stage_strategy"
             - "group_plan_options"
-            - "stage-output"
             - "lookup-keys"
           not_contains:
             - "inner_select"
             - "dependent-subquery"
             - "in_membership"
-            - "driver_order_membership_probe"
-            - "driver_membership_probe"
             - ".grp:"
             - "touch_keytable"
       - sql: |
@@ -534,11 +530,13 @@ test_cases:
           LIMIT 10
         expect:
           contains:
-            - "scan"
+            - "recset_project_join"
+            - "scan_order"
           not_contains:
             - "driver_membership_probe"
             - "__union_distinct_rows"
             - "__union_distinct_seen"
+            - "touch_keytable"
       - sql: |
           EXPLAIN REORDER
           SELECT t.ID


### PR DESCRIPTION
## Summary

- Let reorder recognize simple positive decorrelated EXISTS stages that can be represented as a RecSet projection onto the driver table.
- Lower that shape through `scan_recset -> recset_project_join`, keeping unsupported EXISTS shapes on the existing group-stage carrier path.
- Keep NOT EXISTS out of this path for now; negated stage predicates continue to use the existing semantics.
- Add an EXPLAIN regression for the positive EXISTS RecSet carrier.
- Stabilize ordered scans over RecSets: sorted RecSet `scan_order` no longer evaluates shared Scheme order lambdas concurrently across shard workers.

## Scope boundary

This PR intentionally handles only positive EXISTS filters with:

- one direct lookup key on the driver side
- one direct inner key on the EXISTS input side
- a base-table EXISTS input
- presence-only semantics

It does not implement RecSet difference for NOT EXISTS and does not fix projected EXISTS false-domain seeding. Those remain separate semantic work.

## Real-query A/B measurements

Measured against the real production-size full-search dataview query on the imported production-size dataset. The PR text intentionally avoids customer/project names.

- Baseline: current `master` at `579e9a8c2`
- Branch: `agent/recset-exists-carrier` at `871925c1c`
- Session setup: `@fop_user := 105`, `@fop_time := UNIX_TIMESTAMP()` via the existing local measurement helper
- Method: one execution per term, no warmup, HTTP SQL endpoint, same data directory, fresh server process per branch

| Search term | master | branch | Notes |
| --- | ---: | ---: | --- |
| `C` | 99.082s | 19.433s | branch spot-check after ordered RecSet stability fix |
| `Ca` | 100.738s | 18.362s | branch before stability fix; same physical plan class |
| `Car` | 101.066s | 20.137s | branch before stability fix; same physical plan class |
| `Carg` | 101.321s | 19.648s | branch before stability fix; same physical plan class |
| `Cargl` | not measured; master series stopped after repeated ~100s runs | 19.717s | branch before stability fix; same physical plan class |
| `Cargla` | not measured; master series stopped after repeated ~100s runs | 19.738s | branch before stability fix; same physical plan class |
| `Carglas` | not measured; master series stopped after repeated ~100s runs | 19.660s | branch before stability fix; same physical plan class |
| `Carglass` | not measured; master series stopped after repeated ~100s runs | 19.723s | branch before stability fix; same physical plan class |
| `Carglass389` | not measured in the corrected master session series | 24.968s | branch spot-check after ordered RecSet stability fix |

Interpretation: this branch is materially faster than current `master` on the broad-prefix full-search query, but it is still not the target plan. The nearly flat 18-25s branch latency across very different term selectivities means the planner still pays large fixed costs instead of fully driving from the selective search/ACL sets.

EXPLAIN markers for the branch on the narrow term:

- `scan_recset`: 2
- `recset_project_join`: 2
- `scan_order_multi`: 0
- `touch_keytable`: 76
- `.grp:` occurrences: 537
- `assoc_keys_values_as_dataset_rows`: 16
- `inner_select`: 0

So the positive RecSet carrier exists, but the full query still materializes/prepares too many group carriers and does not yet collapse the remaining ACL/reference work into cheap reusable set operations.

## Physical operator measurements and runtime model

The targeted micro-measurements show where the time goes. Measured via `/scm` snippets against the same dataset.

| Operation | Search term | Time | Count / result |
| --- | --- | ---: | --- |
| build filename RecSet | `C` | 17-23ms | 239 files |
| build filename RecSet | `Carglass389` | 18-27ms | 1 file |
| build fulltext/search RecSet | `C` | 1.17-1.19s | 55,332 files |
| build fulltext/search RecSet | `Carglass389` | 1.21s | 0 files |
| union file RecSets | `C` | 3.8ms | 55,375 files |
| project files to documents | `C` | 1.60s | 60,308 documents |
| project files to documents | `Carglass389` | 0.7ms | 1 document |
| ordered top-k over projected document RecSet | `C` | 0.58s | 72 rows from 60,308 candidate documents |
| ordered top-k over projected document RecSet | `Carglass389` | 0.2ms | 1 row |

Cost model conclusion:

- RecSet projection has the desired effect. For a narrow set it is sub-millisecond; for a broad 60k-document set it is still only ~1.6s.
- Ordered top-k over a RecSet is not the dominant cost after the stability fix: ~0.58s for 60k candidate documents.
- The remaining 18-25s in the real dataview query is therefore mostly fixed query-shape overhead: reference/ACL projection, repeated group-carrier preparation, and post-candidate column computation before/around LIMIT.
- Combining filter formulas is preferable when filters hit the same base table and the result is consumed once. Set operations are most useful when they cross relation boundaries or avoid repeated inner scans.
- Lazy RecSets/streaming set expressions are promising for one-shot broad queries, but they should be introduced as physical carriers chosen by `build_queryplan`, not as new logical semantics.

Next optimizer work should therefore not be more eager RecSet materialization by default. The next useful step is late projection plus lazy/reusable group carriers: compute the candidate document keys and top-k first, then evaluate expensive ACL/reference/projection columns only for the final rows.

Additional `scan_exists` micro-measurement on 10k synthetic rows (`tenant = i mod 100`), using TracePrint + `(time ... "label")`, average over four runs:

| Operation | Probes / result | Avg time |
| --- | ---: | ---: |
| build `tenant = 7` RecSet | 100 rows | 2.8ms |
| base-table `scan_exists tenant = 7` | 50 hit probes | 7.1ms total |
| base-table `scan_exists tenant = impossible` | 50 miss probes | 2.16s total |
| RecSet `scan_exists ID = 7` | one hit probe over 100 candidates | 0.06ms |
| RecSet `scan_exists ID = -1` | one miss probe over 100 candidates | 0.11ms |

Lowering implication: direct `scan_exists` is good for a few early-hit/indexed probes, repeated misses over a broad base table must be reordered or carried by a domain/index, and RecSet-backed `scan_exists` is cheap only after RecSet build cost has already been justified. DML deliberately keeps the RecSet carrier rewrite disabled until RecSet scan mutation callbacks exist; it uses prepared group carriers plus `scan_exists` probes instead.

## Regression checks

Local comparison against the previous stacked base branch. Both sides were checked out into fresh detached worktrees and built with `GOFLAGS=-buildvcs=false make` before measuring.

| Suite | Previous avg | Branch avg | Delta | Result |
| --- | ---: | ---: | ---: | --- |
| `tests/40_exists_subquery.yaml` | 1.330s | 1.322s | -0.6% | previous 15/15, branch 16/16 |
| `tests/41_in_subquery.yaml` | 2.411s | 2.368s | -1.8% | 41/41 both |
| `tests/123_recset.yaml` | 1.218s | 1.215s | -0.3% | 13/13 both |

These YAML timings are only regression checks. They are not the performance claim for this PR.

## Validation

- `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- `make`
- `go test ./scm -run TestKillQueryMarksOnlyCurrentGeneration`
- `python3 run_sql_tests.py tests/97_prejoin_update_delete.yaml`
- `python3 run_sql_tests.py tests/123_recset.yaml`
- `python3 run_sql_tests.py tests/40_exists_subquery.yaml`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml`

Full `make test` was also started after the CI fix. It progressed through the long repartition and many SQL suites successfully, but the parallel runner became stuck in connect-only tests and was interrupted to avoid leaving background test servers. The failure being fixed here is covered by the targeted DML regression suite above.

Diagnostic note: `tests/105_deep_nested_in_exists.yaml` remains at the known #292 baseline, 15/18. The remaining failures are deep NOT IN and projected EXISTS domain-seeding semantics, not this positive EXISTS carrier path.

## Merge decision

This PR is now best treated as a mergeable RecSet-carrier and stability package, not as the final dataview-performance PR. It unlocks and hardens the positive EXISTS RecSet path and documents the next bottleneck. The next PR should target late projection / group-carrier laziness / selectivity-sensitive lowering for the remaining fixed 18-25s cost.

