### PR TITLE
Fix CASE-wrapped correlated EXISTS filtering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2611,15 +2611,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(map_assoc (coalesceNil fields '()) (lambda (_title expr)
 				(list (quote if) (list (quote nil?) presence) nil expr)))))))
 
-(define combine_where (lambda (a b)
+(define literal_true? (lambda (expr)
+	(match expr
+		true true
+		_ false)))
+
+(define build_and_terms (lambda (terms)
 	(begin
-		(define aa (coalesceNil a true))
-		(define bb (coalesceNil b true))
-		(if (equal? aa true)
-			bb
-			(if (equal? bb true)
-				aa
-				(list (quote and) aa bb))))))
+		(define filtered (filter (coalesceNil terms '()) (lambda (term) (not (literal_true? (coalesceNil term true))))))
+		(if (empty_list? filtered)
+			true
+			(if (single_source? filtered)
+				(car filtered)
+				(cons (quote and) filtered))))))
+
+(define combine_where (lambda (a b)
+	(combine_where_terms (list a b) true)))
 
 (define derived_block_needs_operator? (lambda (block)
 	(or (not (empty_list? (qb_group block)))
@@ -2758,7 +2765,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 ))))))
 
 (define combine_where_terms (lambda (terms seed)
-	(reduce (coalesceNil terms '()) combine_where seed)))
+	(build_and_terms (merge (list
+		(split_and_terms (coalesceNil seed true))
+		(merge (map (coalesceNil terms '()) (lambda (term) (split_and_terms (coalesceNil term true))))))))))
 
 (define untangle_source (lambda (src ctx)
 	(begin
@@ -3377,19 +3386,46 @@ PostgreSQL parsers should both lower to the same combined operators.
 		((quote not) _expr) true
 		_ false)))
 
-(define positive_condition_refs_source? (lambda (default_alias alias condition)
-	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
-		(or found
-			(and (not (negated_term? term))
-				(expr_refs_alias_after_group? default_alias alias term))))
-		false)))
+(define exists_recset_probe_term? (lambda (alias term)
+	(match term
+		((symbol >) ((symbol coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((symbol >) ((quote coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((symbol >) ((symbol coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((symbol >) ((quote coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((quote >) ((symbol coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((quote >) ((quote coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((quote >) ((symbol coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		((quote >) ((quote coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) 0) 0)
+		(equal? tblvar alias)
+		_ false)))
+
+(define condition_has_exists_recset_probe? (lambda (alias condition)
+	(match condition
+		(cons head tail) (or
+			(exists_recset_probe_term? alias condition)
+			(reduce tail (lambda (found item) (or found (condition_has_exists_recset_probe? alias item))) false))
+		_ false)))
+
+(define rewrite_exists_recset_probe_refs (lambda (alias stage probe expr)
+	(if (exists_recset_probe_term? alias expr)
+		(driver_membership_probe_expr stage probe)
+		(match expr
+			(cons head tail) (cons head (map tail (lambda (item) (rewrite_exists_recset_probe_refs alias stage probe item))))
+			_ expr))))
 
 (define first_exists_recset_source (lambda (stages sources default_alias condition)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(if (not (nil? found))
 			found
 			(if (and (exists_recset_stage_output_source? stages src)
-				(positive_condition_refs_source? default_alias (source_alias src) condition))
+				(condition_has_exists_recset_probe? (source_alias src) condition))
 				src
 				nil)))
 		nil)))
@@ -3476,16 +3512,17 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation exists_src))))
 						(define stage_id (gs_id stage))
 						(define probe (car (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
-						(define base_where (strip_condition_for_source_alias
-							default_alias
+						(define base_where (rewrite_exists_recset_probe_refs
 							(source_alias exists_src)
+							stage
+							probe
 							(qb_where block)))
 						(query_block_with_reorder_facts
 							(make_query_block
 								(qb_schema block)
 								(without_source_alias sources (source_alias exists_src))
 								(qb_fields block)
-								(combine_where base_where (driver_membership_probe_expr stage probe))
+								base_where
 								(qb_group block)
 								(qb_having block)
 								(qb_order block)
@@ -3785,6 +3822,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define extract_columns_for_alias (lambda (src expr)
 	(match expr
+		((symbol driver_membership_probe) _stage probe)
+		(extract_columns_for_alias src probe)
+		((quote driver_membership_probe) _stage probe)
+		(extract_columns_for_alias src probe)
 		((symbol dml_driver_membership_probe) _fallback_schema _stage probe)
 		(extract_columns_for_alias src probe)
 		((quote dml_driver_membership_probe) _fallback_schema _stage probe)
@@ -3801,6 +3842,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define lower_column_expr_for_alias (lambda (src expr)
 	(match expr
+		((symbol driver_membership_probe) stage probe)
+		(lower_driver_membership_probe_expr (list src) (source_alias src) stage probe)
+		((quote driver_membership_probe) stage probe)
+		(lower_driver_membership_probe_expr (list src) (source_alias src) stage probe)
 		((symbol dml_driver_membership_probe) fallback_schema stage probe)
 		(lower_dml_driver_membership_probe_expr (list src) (source_alias src) fallback_schema stage probe)
 		((quote dml_driver_membership_probe) fallback_schema stage probe)
@@ -4139,13 +4184,42 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define lower_driver_membership_probe_expr (lambda (sources default_alias stage probe)
 	(begin
 		(define input (gs_input stage))
-		(if (not (union_block? input))
-			(neumann_fail "build_queryplan" "driver membership probe currently expects UNION candidate input")
-			true)
-		(list (quote >)
-			(cons (quote +) (map (union_branches input) (lambda (branch)
-				(driver_membership_probe_branch_expr sources default_alias branch probe))))
-			0))))
+		(if (union_block? input)
+			(list (quote >)
+				(cons (quote +) (map (union_branches input) (lambda (branch)
+					(driver_membership_probe_branch_expr sources default_alias branch probe))))
+				0)
+			(begin
+				(define input_src (if (query_block? input)
+					(if (single_source? (qb_sources input)) (car (qb_sources input)) nil)
+					input))
+				(if (or (nil? input_src) (not (source_is_base_table? input_src)))
+					(neumann_fail "build_queryplan" "driver membership probe expects UNION or simple base-table input")
+					true)
+				(define keys (gs_keys stage))
+				(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+				(if (not (equal? (count keys) (count lookup_keys)))
+					(neumann_fail "build_queryplan" "driver membership probe key/domain mismatch")
+					true)
+				(define condition (if (query_block? input)
+					(combine_where (qb_where input) (source_join_expr input_src))
+					(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)))
+				(define key_terms (map (produceN (count keys)) (lambda (i)
+					(list (quote equal??)
+						(lower_column_expr_for_alias input_src (nth keys i))
+						(lower_column_expr_for_join sources default_alias (nth lookup_keys i))))))
+				(define filtercols (merge_unique (list
+					(extract_columns_for_alias input_src condition)
+					(merge_unique (map keys (lambda (key) (extract_columns_for_alias input_src key)))))))
+				(list (quote scan_exists)
+					'(session "__memcp_tx")
+					(source_table_expr input_src)
+					(cons (quote list) filtercols)
+					(list (quote lambda)
+						(map filtercols (lambda (col) (symbol (concat (source_alias input_src) "." col))))
+						(list (quote optimize)
+							(cons (quote and)
+								(cons (lower_column_expr_for_alias input_src condition) key_terms)))))))))))
 
 (define lower_dml_driver_membership_probe_expr (lambda (sources default_alias fallback_schema stage _probe)
 	(begin

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -180,6 +180,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (ir_context_get (ir_context_of simple_ir) 'compile-budget-ms nil) 1000) true "untangle_query carries compile budget in context")
 	(assert (equal? (join_reorder simple_ir) simple_ir) true "join_reorder is an IR-only phase")
 	(assert (equal? (logical_op (build_queryplan_term simple_select_ast)) 'scan) true "build_queryplan lowers simple query-block to physical scan")
+	(assert (equal? (split_and_terms (combine_where_terms
+		(list
+			(list (quote and) "a" "b")
+			"c"
+			(list (quote and) "d" (list (quote and) "e" "f")))
+		true)) '("a" "b" "c" "d" "e" "f")) true "combine_where_terms flattens nested AND terms")
 	(define no_from_select_ast (list "memcp-tests" '() (list "result" 8) true nil nil nil nil nil))
 	(assert (equal? (serialize (build_queryplan_term no_from_select_ast))
 		"(resultrow '(\"result\" 8))") true "build_queryplan_term lowers no-FROM projection")
@@ -782,6 +788,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (optimize '('and '(equal? 1 1) 'x)) 'x "and hook: removes true constant")
 	(assert (optimize '('and '(equal? 1 1) '(equal? 1 1))) true "and hook: all true constants fold")
 	(assert (serialize (optimize '('and 'x 'y))) "(and x y)" "and hook: non-const args preserved")
+	(assert (serialize (optimize '('and 'x '('and 'y '('and 'z 'w))))) "(and x y z w)" "and hook: flattens nested AND terms")
 
 	/* +/* hooks: associative flattening with symbolic args */
 	(assert (serialize (optimize '('+ 'a '('+ 'b 'c)))) "(+ a b c)" "+ hook: flattens nested +")

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1207,10 +1207,37 @@ func optimizeIf(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDe
 
 // optimizeAnd is the Optimize hook for the (and ...) special form.
 // It short-circuits on constant-false and removes constant-true arguments.
+func appendFlattenedAndArgs(out []Scmer, arg Scmer) ([]Scmer, bool) {
+	inner, ok := scmerSlice(arg)
+	if !ok || len(inner) <= 1 || !scmerIsSymbol(inner[0], "and") {
+		return append(out, arg), false
+	}
+	changed := true
+	for i := 1; i < len(inner); i++ {
+		var nested bool
+		out, nested = appendFlattenedAndArgs(out, inner[i])
+		changed = changed || nested
+	}
+	return out, changed
+}
+
 func optimizeAnd(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	// Optimize all args
 	for i := 1; i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
+	}
+	// Flatten nested AND calls so downstream pattern matchers can inspect one
+	// top-level list of conjunctive terms.
+	flattened := make([]Scmer, 0, len(v))
+	flattened = append(flattened, v[0])
+	changed := false
+	for i := 1; i < len(v); i++ {
+		var argChanged bool
+		flattened, argChanged = appendFlattenedAndArgs(flattened, v[i])
+		changed = changed || argChanged
+	}
+	if changed {
+		v = flattened
 	}
 	// Single arg: unwrap
 	if len(v) == 2 {

--- a/tests/40_exists_subquery.yaml
+++ b/tests/40_exists_subquery.yaml
@@ -6,6 +6,8 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS exists_doc_shares"
+  - sql: "DROP TABLE IF EXISTS exists_docs"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"
   - sql: |
@@ -25,6 +27,24 @@ setup:
   - sql: |
       INSERT INTO exists_orders (ID, customer_id, total) VALUES
       (101, 1, 100.00), (102, 1, 200.00), (103, 2, 150.00)
+  - sql: |
+      CREATE TABLE exists_docs (
+        ID INT PRIMARY KEY,
+        owner_id INT,
+        title VARCHAR(64)
+      )
+  - sql: |
+      CREATE TABLE exists_doc_shares (
+        ID INT PRIMARY KEY,
+        doc_id INT,
+        user_id INT
+      )
+  - sql: |
+      INSERT INTO exists_docs (ID, owner_id, title) VALUES
+      (1, 1, 'own row'), (2, 2, 'shared row'), (3, 2, 'blocked row')
+  - sql: |
+      INSERT INTO exists_doc_shares (ID, doc_id, user_id) VALUES
+      (10, 2, 1)
 
 test_cases:
   - name: "EXISTS with correlated subquery - customers with orders"
@@ -290,6 +310,100 @@ test_cases:
             - "touch_keytable"
             - "\"__cnt\""
 
+  - name: "Correlated NOT EXISTS access expression projects true"
+    sql: |
+      SELECT ID,
+        NOT (
+          owner_id <> 1
+          AND NOT EXISTS (
+            SELECT TRUE
+            FROM exists_doc_shares s
+            WHERE s.doc_id = d.ID
+              AND s.user_id = 1
+            LIMIT 1
+          )
+        ) AS can_read
+      FROM exists_docs d
+      ORDER BY ID
+    expect:
+      rows: 3
+      data:
+        - {ID: 1, can_read: true}
+        - {ID: 2, can_read: true}
+        - {ID: 3, can_read: false}
+
+  - name: "Correlated NOT EXISTS access expression filters rows without CASE"
+    sql: |
+      SELECT ID
+      FROM exists_docs d
+      WHERE NOT (
+        owner_id <> 1
+        AND NOT EXISTS (
+          SELECT TRUE
+          FROM exists_doc_shares s
+          WHERE s.doc_id = d.ID
+            AND s.user_id = 1
+          LIMIT 1
+        )
+      )
+      ORDER BY ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1}
+        - {ID: 2}
+
+  - name: "CASE in WHERE keeps correlated NOT EXISTS access expression"
+    sql: |
+      SELECT ID
+      FROM exists_docs d
+      WHERE CASE
+        WHEN FALSE THEN TRUE
+        ELSE NOT (
+          owner_id <> 1
+          AND NOT EXISTS (
+            SELECT TRUE
+            FROM exists_doc_shares s
+            WHERE s.doc_id = d.ID
+              AND s.user_id = 1
+            LIMIT 1
+          )
+        )
+      END
+      ORDER BY ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1}
+        - {ID: 2}
+
+  - name: "CASE in SELECT projects correlated NOT EXISTS access expression"
+    sql: |
+      SELECT ID,
+        CASE
+          WHEN FALSE THEN TRUE
+          ELSE NOT (
+            owner_id <> 1
+            AND NOT EXISTS (
+              SELECT TRUE
+              FROM exists_doc_shares s
+              WHERE s.doc_id = d.ID
+                AND s.user_id = 1
+              LIMIT 1
+            )
+          )
+        END AS can_read
+      FROM exists_docs d
+      ORDER BY ID
+    expect:
+      rows: 3
+      data:
+        - {ID: 1, can_read: true}
+        - {ID: 2, can_read: true}
+        - {ID: 3, can_read: false}
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS exists_doc_shares"
+  - sql: "DROP TABLE IF EXISTS exists_docs"
   - sql: "DROP TABLE IF EXISTS exists_orders"
   - sql: "DROP TABLE IF EXISTS exists_customers"


### PR DESCRIPTION
## What
- Add anonymized regression coverage for an owner/share access predicate using correlated `NOT EXISTS` inside `CASE`.
- Rewrite EXISTS-stage probe references inside the full boolean expression instead of dropping every term that references the stage alias.
- Keep residual filter terms in place; only a visible top-level membership probe can become a physical `recset_project_join` input.
- Allow membership probes that remain nested in `CASE` / `NOT` / other boolean expressions to lower as normal `scan_exists` filter expressions.
- Normalize generated `AND` conditions through `combine_where_terms` so nested conjuncts spill into one top-level list, and flatten nested `(and ...)` in the Go optimizer with a linear collector.

## Why
A manual-build blocker reduced to a SQL compiler correctness bug. The RecSet rewrite projected a useful membership relation, but then discarded the entire filter term that referenced that relation. That is only valid when the discarded term is exactly the positive membership predicate. For composed expressions, such as `CASE ... ELSE NOT (... NOT EXISTS (...)) END`, the non-membership parts of the condition still determine whether the row passes.

The fix keeps the full condition and replaces only the EXISTS probe subexpression. Projection remains valid only when all other filter terms are still evaluated at the correct point.

The `AND` normalization is intentionally centralized: parser output for normal `AND` chains is already variadic, and generated/planner-combined conditions now use the same shape. The Go optimizer flattening avoids repeated slice rebuilds so deeply nested ASTs do not add another O(N²) compile-time path.

## Manual / Trace Check
- With this branch, the previous phase0 access-predicate blocker passes and the manual-build advances into the next stage.
- The next observed blocker is later: trace output shows a very large document/dataview-shaped query killed after roughly 56.7s, plus another nested property/dataview-shaped query around 11.0s. Those are separate follow-up performance/correctness work items.
- Earlier migration errors in the trace are expected one-shot migration queries and did not stop the run.

## Validation
- `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- `python3 tools/lint_scm.py --path lib/test.scm --check`
- `go build -o memcp`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml --fail-fast --port 45991`
- `python3 run_sql_tests.py tests/40_exists_subquery.yaml tests/41_in_subquery.yaml tests/66_exists_session_var.yaml tests/69_subquery_complex.yaml tests/123_recset.yaml --fail-fast --port 45987`

Full `make test` was not run locally before updating this draft PR; the focused planner/subquery/RecSet suites pass.