### PR TITLE
Fix scalar aggregate LIMIT guard

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -868,7 +868,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(and (query_block? inner)
 		(and (not (empty_list? (qb_sources inner)))
 			(and (empty_list? (qb_order inner))
-				(and (or (nil? (qb_limit inner)) (equal? (qb_limit inner) 1))
+				(and (or (nil? (qb_limit inner))
+					(or (equal? (qb_limit inner) 1)
+						(and (empty_list? (qb_group inner))
+							(query_block_has_aggregates? inner))))
 					(nil? (qb_offset inner))))))))
 
 (define scalar_single_supported? (lambda (inner)

--- a/tests/96_scalar_subselect_patterns.yaml
+++ b/tests/96_scalar_subselect_patterns.yaml
@@ -409,6 +409,22 @@ test_cases:
         - badgeDoc: 2
           revCount: 3
 
+  - name: "GROUP_CONCAT scalar aggregate with nested scalar and nonrestrictive LIMIT"
+    sql: |
+      SELECT
+        sq_doc.ID,
+        (SELECT GROUP_CONCAT(CONCAT((SELECT sq_ptype.type FROM sq_ptype WHERE sq_ptype.ID = sq_prop.type LIMIT 1), ':', sq_prop.ID) SEPARATOR ';')
+         FROM sq_prop
+         WHERE sq_prop.doc = sq_doc.ID AND sq_prop.ID = 1
+         LIMIT 21) AS labels
+      FROM sq_doc
+      WHERE sq_doc.ID = 1
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          labels: "date:1"
+
   # Pattern 6: Nested COALESCE with scalar subselect fallback
   - name: "Nested COALESCE permission check pattern"
     sql: |


### PR DESCRIPTION
## Summary
- add an anonymized regression for a scalar `GROUP_CONCAT` aggregate whose argument contains a nested scalar subquery and whose subquery has `LIMIT > 1`
- allow scalar aggregate subqueries without `GROUP BY` to pass the aggregate lowering guard even when the SQL contains a nonrestrictive limit greater than one

## Root Cause
The scalar aggregate lowering guard accepted no limit or `LIMIT 1` only. For aggregate subqueries without `GROUP BY`, the aggregate already produces one row, so a larger limit does not affect cardinality. That rejected valid queries before the group-stage lowering could run.

## Validation
- fail-first on `origin/master` with only the test patch: `python3 run_sql_tests.py tests/96_scalar_subselect_patterns.yaml --fail-fast --port 46128` failed with `untangle_query: scalar aggregate group-stage(D) currently supports one plain inner query-block`
- fixed branch: `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- fixed branch: `go build -o memcp`
- fixed branch: `python3 run_sql_tests.py tests/96_scalar_subselect_patterns.yaml tests/69_subquery_complex.yaml --fail-fast --port 46127`

## Full Suite
- attempted `make test`; it was interrupted after existing parallel-suite timeouts in `tests/63_count_where_keytable.yaml` and `tests/64_colon_column_names.yaml` had already failed with no-response symptoms. The new regression and adjacent subquery suites passed separately.