### PR TITLE
Fix EXISTS UNION projection stage identity

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1260,7 +1260,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(neumann_fail "untangle_query" "EXISTS over UNION currently supports plain unordered branches")
 			(combine_exists_union_results
 				(map (union_branches inner) (lambda (branch)
-					(make_exists_stage_rewrite branch args))))))))
+					(make_exists_stage_rewrite branch (list (nth args 0) branch)))))))))
 
 (define combine_in_union_results (lambda (results negate)
 	(match (coalesceNil results '())

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -22,6 +22,11 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_doc"
   - sql: "DROP TABLE IF EXISTS trace_revision"
   - sql: "DROP TABLE IF EXISTS trace_file"
+  - sql: "DROP TABLE IF EXISTS trace_asset"
+  - sql: "DROP TABLE IF EXISTS trace_ref_a"
+  - sql: "DROP TABLE IF EXISTS trace_ref_b"
+  - sql: "DROP TABLE IF EXISTS trace_ref_c"
+  - sql: "DROP TABLE IF EXISTS trace_ref_d"
   - sql: "DROP TABLE IF EXISTS trace_item"
   - sql: "DROP TABLE IF EXISTS trace_group"
   - sql: "DROP TABLE IF EXISTS trace_box"
@@ -101,6 +106,37 @@ setup:
         filename VARCHAR(64),
         mime VARCHAR(64)
       )
+  - sql: |
+      CREATE TABLE trace_asset (
+        id INT PRIMARY KEY,
+        filename VARCHAR(64),
+        kind INT,
+        payload VARCHAR(64)
+      )
+  - sql: |
+      CREATE TABLE trace_ref_a (
+        id INT PRIMARY KEY,
+        asset_id INT,
+        enabled BOOL
+      )
+  - sql: |
+      CREATE TABLE trace_ref_b (
+        id INT PRIMARY KEY,
+        asset_id INT,
+        enabled BOOL
+      )
+  - sql: |
+      CREATE TABLE trace_ref_c (
+        id INT PRIMARY KEY,
+        asset_id INT,
+        enabled BOOL
+      )
+  - sql: |
+      CREATE TABLE trace_ref_d (
+        id INT PRIMARY KEY,
+        asset_id INT,
+        enabled BOOL
+      )
   - sql: "INSERT INTO trace_config (id, default_type) VALUES (1, 10)"
   - sql: "INSERT INTO trace_file (id, filename, mime) VALUES (1, 'one.txt', 'text/plain'), (2, 'two.pdf', 'application/pdf')"
   - sql: "INSERT INTO trace_doc (id, type, archived, parent) VALUES (1, 10, FALSE, NULL)"
@@ -115,6 +151,22 @@ setup:
   - sql: "INSERT INTO trace_doc SELECT id + 256, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, 1 FROM trace_doc"
   - sql: "INSERT INTO trace_doc SELECT id + 512, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, 1 FROM trace_doc"
   - sql: "INSERT INTO trace_revision SELECT id, id, CASE WHEN id % 2 = 0 THEN 2 ELSE 1 END, id FROM trace_doc"
+  - sql: "INSERT INTO trace_asset (id, filename, kind, payload) VALUES (1, 'asset-1.dat', 1, 'p1')"
+  - sql: "INSERT INTO trace_asset SELECT id + 1, CONCAT('asset-', CAST(id + 1 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 1 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 2, CONCAT('asset-', CAST(id + 2 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 2 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 4, CONCAT('asset-', CAST(id + 4 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 4 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 8, CONCAT('asset-', CAST(id + 8 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 8 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 16, CONCAT('asset-', CAST(id + 16 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 16 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 32, CONCAT('asset-', CAST(id + 32 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 32 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 64, CONCAT('asset-', CAST(id + 64 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 64 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 128, CONCAT('asset-', CAST(id + 128 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 128 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 256, CONCAT('asset-', CAST(id + 256 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 256 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 512, CONCAT('asset-', CAST(id + 512 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 512 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_asset SELECT id + 1024, CONCAT('asset-', CAST(id + 1024 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 1024 AS VARCHAR)) FROM trace_asset"
+  - sql: "INSERT INTO trace_ref_a SELECT id, id, TRUE FROM trace_asset WHERE id % 997 = 0"
+  - sql: "INSERT INTO trace_ref_b SELECT id, id, TRUE FROM trace_asset WHERE id IN (1, 17, 257)"
+  - sql: "INSERT INTO trace_ref_c SELECT id, id, FALSE FROM trace_asset WHERE id % 257 = 0"
+  - sql: "INSERT INTO trace_ref_d SELECT id, id, TRUE FROM trace_asset WHERE id % 509 = 0"
 
 test_cases:
   - name: "ORDER BY RAND supports filtered table scan with IN subquery"
@@ -228,11 +280,45 @@ test_cases:
           last_seen: 1
           has_pdf: false
 
+  - name: "UNION EXISTS projection probes only selected outer rows"
+    max_time: 0.4
+    max_plan_size: 60000
+    sql: |
+      SELECT
+        a.id,
+        a.filename,
+        EXISTS (
+          SELECT r.id FROM trace_ref_a r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_b r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_c r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_d r WHERE r.enabled AND r.asset_id = a.id
+        ) AS referenced
+      FROM trace_asset a
+      WHERE a.id IN (1, 2)
+      ORDER BY a.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          filename: "asset-1.dat"
+          referenced: true
+        - id: 2
+          filename: "asset-2.dat"
+          referenced: false
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_config"
   - sql: "DROP TABLE IF EXISTS trace_doc"
   - sql: "DROP TABLE IF EXISTS trace_revision"
   - sql: "DROP TABLE IF EXISTS trace_file"
+  - sql: "DROP TABLE IF EXISTS trace_asset"
+  - sql: "DROP TABLE IF EXISTS trace_ref_a"
+  - sql: "DROP TABLE IF EXISTS trace_ref_b"
+  - sql: "DROP TABLE IF EXISTS trace_ref_c"
+  - sql: "DROP TABLE IF EXISTS trace_ref_d"
   - sql: "DROP TABLE IF EXISTS trace_item"
   - sql: "DROP TABLE IF EXISTS trace_group"
   - sql: "DROP TABLE IF EXISTS trace_box"


### PR DESCRIPTION
## Summary
- fix per-branch stage identity for EXISTS projections over UNION branches
- add an anonymized regression test for the manual-trace query shape

## Root Cause
`make_exists_union_stage_rewrite` rewrote every UNION branch while keeping the original UNION expression in the EXISTS stage identity. Same-shaped branches over different tables could therefore collide on the same generated stage alias. In the reproduced case, an empty earlier branch caused a later matching branch to be ignored, so the projection returned `false` even though a later UNION branch matched.

The fix passes the concrete UNION branch into the stage identity while preserving the outer EXISTS expression, so each branch gets its own probe stage.

## Tests
- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml --log-times --fail-fast`
- `MEMCP_TEST_JOBS=1 MEMCP_LOG=/tmp/memcp-exists-union-maketest-after-rebase.log make test`

## A/B Measurement
Measured on current master `716d227ad` plus the new anonymized regression test versus this branch.

| Build | Result | Median for new test | Behavior |
| --- | --- | ---: | --- |
| master `716d227ad` | FAIL, suite 3/4 | 56.114 ms | returns `referenced=false` for `id=1` |
| branch `agent/exists-union-probe` | PASS, suite 4/4 | 64.904 ms | returns `id=1 => true`, `id=2 => false` |

This PR is primarily a correctness fix. The `max_time: 0.4` assertion on the regression keeps the manual-trace shape bounded against future gross runtime regressions; the A/B result shows same-order runtime while fixing the wrong result.