### PR TITLE
Merge compatible scalar latest stages

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5249,6 +5249,38 @@ PostgreSQL parsers should both lower to the same combined operators.
 		'(expr (quote +) 0) true
 		_ false)))
 
+(define scalar_order_aggregate_parts (lambda (ag)
+	(match ag
+		'(((symbol scalar_order_value) value_expr order_exprs dirs offset_value) agg_reduce agg_neutral)
+		(list value_expr order_exprs dirs (coalesceNil offset_value 0) agg_reduce agg_neutral)
+		'(((quote scalar_order_value) value_expr order_exprs dirs offset_value) agg_reduce agg_neutral)
+		(list value_expr order_exprs dirs (coalesceNil offset_value 0) agg_reduce agg_neutral)
+		'(((symbol scalar_order_value) value_expr order_expr dir) agg_reduce agg_neutral)
+		(list value_expr (list order_expr) (list dir) 0 agg_reduce agg_neutral)
+		'(((quote scalar_order_value) value_expr order_expr dir) agg_reduce agg_neutral)
+		(list value_expr (list order_expr) (list dir) 0 agg_reduce agg_neutral)
+		_ nil)))
+
+(define scalar_order_signature (lambda (parts)
+	(list (nth parts 1) (nth parts 2) (nth parts 3) (nth parts 4) (nth parts 5))))
+
+(define compatible_scalar_order_aggregates? (lambda (ags)
+	(if (< (count ags) 2)
+		false
+		(begin
+			(define first_parts (scalar_order_aggregate_parts (car ags)))
+			(if (nil? first_parts)
+				false
+				(begin
+					(define signature (scalar_order_signature first_parts))
+					(reduce ags (lambda (ok ag)
+						(and ok
+							(begin
+								(define parts (scalar_order_aggregate_parts ag))
+								(and (not (nil? parts))
+									(equal? (scalar_order_signature parts) signature)))))
+						true)))))))
+
 (define group_aggregate_read_expr (lambda (grouptbl ag)
 	(begin
 		(define col (aggregate_col_name ag))
@@ -5504,6 +5536,55 @@ PostgreSQL parsers should both lower to the same combined operators.
 					agg_reduce
 					agg_neutral
 					false))))))
+
+(define build_group_ordered_scalar_columns_insert_plan (lambda (schema tbl alias grouptbl keys key_names condition ags)
+	(begin
+		(define src (list alias schema tbl false nil))
+		(define parts (map ags scalar_order_aggregate_parts))
+		(define first_parts (car parts))
+		(define value_exprs (map parts (lambda (part) (nth part 0))))
+		(define order_exprs (nth first_parts 1))
+		(define dirs (nth first_parts 2))
+		(define offset_value (nth first_parts 3))
+		(define agg_cols (map ags aggregate_col_name))
+		(define group_key_cols_for_scan (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
+		(define condition_cols (extract_columns_for_alias src condition))
+		(define order_cols (map order_exprs (lambda (order_expr) (order_column_for_alias src order_expr))))
+		(define valuecols (merge_unique (map value_exprs (lambda (expr) (extract_columns_for_alias src expr)))))
+		(define filtercols (merge_unique (list group_key_cols_for_scan condition_cols order_cols)))
+		(define mapcols (merge_unique (list group_key_cols_for_scan valuecols)))
+		(define key_expr (runtime_cons_list_expr (map keys (lambda (expr) (lower_column_expr_for_alias src expr)))))
+		(define payload_expr (runtime_cons_list_expr (map value_exprs (lambda (expr) (lower_column_expr_for_alias src expr)))))
+		(define key_sortcols (map keys (lambda (expr) (order_column_for_alias src expr))))
+		(define key_dirs (map keys (lambda (_key) (quote <))))
+		(define keep_first (list (quote lambda) (list (quote old) (quote new)) (quote old)))
+		(list
+			(list (quote lambda) (list (quote grouped))
+				(group_insert_finish_expr schema grouptbl key_names agg_cols))
+			(list (quote scan_order)
+				'(session "__memcp_tx")
+				(list (quote table) schema tbl)
+				(cons (quote list) filtercols)
+				(list (quote lambda)
+					(map filtercols (lambda (col) (symbol (concat alias "." col))))
+					(list (quote optimize) (lower_column_expr_for_alias src condition)))
+				(cons (quote list) (merge (list key_sortcols order_cols)))
+				(cons (quote list) (merge (list key_dirs dirs)))
+				0
+				(coalesceNil offset_value 0)
+				-1
+				(cons (quote list) mapcols)
+				(list (quote lambda)
+					(map mapcols (lambda (col) (symbol (concat alias "." col))))
+					(runtime_cons_list_expr (list key_expr payload_expr)))
+				(list (quote lambda) (list (quote acc) (quote rowvals))
+					(list (quote set_assoc)
+						(quote acc)
+						(list (quote car) (quote rowvals))
+						(list (quote cadr) (quote rowvals))
+						keep_first))
+				(quoted_runtime_list '())
+				false)))))
 
 (define build_group_aggregate_column (lambda (schema tbl alias grouptbl keys key_names condition ag)
 	(match ag
@@ -6556,6 +6637,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define scalar_query_stage (and (query_block? src)
 			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
 				(equal? (count ags) 2))))
+		(define scalar_order_base_stage (and (not query_input_carrier)
+			(compatible_scalar_order_aggregates? ags)))
 		(define prepared_src (if (query_block? rewritten_src)
 			(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src)
 			rewritten_src))
@@ -6571,7 +6654,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			nil
 			(cons (quote !begin) (merge (list nested_prepare nested_materialize)))))
 		(define key_columns (map key_names (lambda (col) (list (quote list) "column" col "any" (quoted_runtime_list '()) (quoted_runtime_list '())))))
-		(define agg_columns (if query_input_carrier
+		(define agg_columns (if (or query_input_carrier scalar_order_base_stage)
 			(map ags (lambda (ag) (list (quote list) "column" (aggregate_col_name ag) "any" (quoted_runtime_list '()) (quoted_runtime_list '()))))
 			'()))
 		(define create_cols (cons (quote list)
@@ -6600,7 +6683,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(list (if (union_block? src)
 					(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names ags)
 					(build_query_group_aggregates_insert_plan_using prepared_src grouptbl keys key_names lowering_ags ags))))
-			(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names condition ag)))))
+			(if scalar_order_base_stage
+				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names condition ags))
+				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names condition ag))))))
 		(define computed_order_exprs (merge_unique (map (coalesceNil (gs_order stage) '()) (lambda (item)
 			(match item '(expr _dir) (begin
 				(define replaced_order_expr (replace_group_order_expr alias grouptbl keys key_names ags expr))
@@ -6624,18 +6709,23 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(if (empty_list? ags) (list collect_plan) '())
 						agg_plans
 						computed_order_plans)))
-				(list (quote !begin)
-					nested_prepare_expr
-					(if (nil? cleanup_plan)
-						(list (quote !begin)
-							keytable_init
-							collect_plan)
-						(list (quote if) keytable_init
+				(if scalar_order_base_stage
+					(list (quote !begin)
+						nested_prepare_expr
+						keytable_init
+						aggregate_prepare_expr)
+					(list (quote !begin)
+						nested_prepare_expr
+						(if (nil? cleanup_plan)
 							(list (quote !begin)
-								collect_plan
-								cleanup_plan)
-							nil))
-					aggregate_prepare_expr))))))
+								keytable_init
+								collect_plan)
+							(list (quote if) keytable_init
+								(list (quote !begin)
+									collect_plan
+									cleanup_plan)
+								nil))
+						aggregate_prepare_expr)))))))
 
 (define lower_orc_stage_prepare (lambda (stage)
 	(begin

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3831,10 +3831,282 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define normalize_stage_dependencies (lambda (ir)
 	(begin
 		(define root_result (normalize_stage_dependencies_node (ir_root ir)))
-		(make_ir
+		(merge_compatible_stage_output_left_joins_ir (make_ir
 			(ir_kind ir)
 			(nth root_result 0)
 			(if (query_block? (nth root_result 0)) (qb_stages (nth root_result 0)) (nth root_result 1))
+			(ir_context_of ir)
+			(ir_return ir))))))
+
+(define stage_output_left_join_stage_key (lambda (stage)
+	(if (not (and (group_stage? stage)
+			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
+				(and (source_is_base_table? (gs_input stage))
+					(equal? (count (gs_aggregates stage)) 1)))))
+		nil
+		(match (car (gs_aggregates stage))
+			'(((symbol scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
+			(concat "scalar-once-merge:" (fnv_hash (serialize (list
+				(gs_input stage)
+				(gs_domain stage)
+				(gs_keys stage)
+				(qassoc_get (gs_facts stage) (quote condition) true)
+				order_exprs
+				dirs
+				offset_value
+				reduce
+				neutral
+				(gs_having stage)
+				(gs_output stage)
+				(gs_order stage)
+				(gs_limit stage)
+				(gs_offset stage)))))
+			'(((quote scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
+			(concat "scalar-once-merge:" (fnv_hash (serialize (list
+				(gs_input stage)
+				(gs_domain stage)
+				(gs_keys stage)
+				(qassoc_get (gs_facts stage) (quote condition) true)
+				order_exprs
+				dirs
+				offset_value
+				reduce
+				neutral
+				(gs_having stage)
+				(gs_output stage)
+				(gs_order stage)
+				(gs_limit stage)
+				(gs_offset stage)))))
+			_ nil))))
+
+(define normalize_stage_output_left_join_expr (lambda (alias expr)
+	(match expr
+		((symbol get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(if (equal? tblvar alias) "__stage_output_join__" tblvar)
+			ignorecase
+			col
+			col_ignorecase)
+		((quote get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(if (equal? tblvar alias) "__stage_output_join__" tblvar)
+			ignorecase
+			col
+			col_ignorecase)
+		(cons head tail) (cons (normalize_stage_output_left_join_expr alias head)
+			(map tail (lambda (item) (normalize_stage_output_left_join_expr alias item))))
+		_ expr)))
+
+(define stage_output_left_join_key (lambda (stages src)
+	(begin
+		(define relation (source_relation src))
+		(if (not (and (source_outer? src) (stage_output_relation? relation)))
+			nil
+			(begin
+				(define stage (stage_by_id stages (stage_output_relation_id relation)))
+				(define stage_key (stage_output_left_join_stage_key stage))
+				(if (nil? stage_key)
+					nil
+					(concat "stage-output-left-join:" (fnv_hash (serialize (list
+						stage_key
+						(source_schema src)
+						(normalize_stage_output_left_join_expr (source_alias src) (source_join_expr src))))))))))))
+
+(define stage_output_left_join_stage_with_aggregates (lambda (stage ags)
+	(make_group_stage
+		(gs_id stage)
+		(gs_input stage)
+		(gs_domain stage)
+		(gs_keys stage)
+		(dedupe_aggregates_by_col ags)
+		(gs_having stage)
+		(gs_output stage)
+		(gs_order stage)
+		(gs_limit stage)
+		(gs_offset stage)
+		(gs_facts stage))))
+
+(define stage_output_left_join_entry_key (lambda (entry) (nth entry 0)))
+(define stage_output_left_join_entry_source (lambda (entry) (nth entry 1)))
+(define stage_output_left_join_entry_stage (lambda (entry) (nth entry 2)))
+(define stage_output_left_join_entry_ids (lambda (entry) (nth entry 3)))
+(define stage_output_left_join_entry_aliases (lambda (entry) (nth entry 4)))
+(define stage_output_left_join_entry_ags (lambda (entry) (nth entry 5)))
+
+(define stage_output_left_join_entry_for_source (lambda (key src stage)
+	(list key src stage (list (gs_id stage)) (list (source_alias src)) (gs_aggregates stage))))
+
+(define stage_output_left_join_entry_add_source (lambda (entry src stage)
+	(list
+		(stage_output_left_join_entry_key entry)
+		(stage_output_left_join_entry_source entry)
+		(stage_output_left_join_entry_stage entry)
+		(merge_unique (list (stage_output_left_join_entry_ids entry) (list (gs_id stage))))
+		(merge_unique (list (stage_output_left_join_entry_aliases entry) (list (source_alias src))))
+		(dedupe_aggregates_by_col (merge (list (stage_output_left_join_entry_ags entry) (gs_aggregates stage)))))))
+
+(define stage_output_left_join_upsert_entry (lambda (stages entries src)
+	(begin
+		(define key (stage_output_left_join_key stages src))
+		(if (nil? key)
+			entries
+			(begin
+				(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
+				(define matched (reduce entries (lambda (found entry)
+					(or found (equal? (stage_output_left_join_entry_key entry) key)))
+					false))
+				(if matched
+					(map entries (lambda (entry)
+						(if (equal? (stage_output_left_join_entry_key entry) key)
+							(stage_output_left_join_entry_add_source entry src stage)
+							entry)))
+					(merge entries (list (stage_output_left_join_entry_for_source key src stage)))))))))
+
+(define stage_output_left_join_entries (lambda (stages sources)
+	(reduce (coalesceNil sources '()) (lambda (entries src)
+		(stage_output_left_join_upsert_entry stages entries src))
+		'())))
+
+(define stage_output_left_join_entries_have_duplicates? (lambda (entries)
+	(reduce (coalesceNil entries '()) (lambda (found entry)
+		(or found (> (count (stage_output_left_join_entry_ids entry)) 1)))
+		false)))
+
+(define stage_output_left_join_id_map_for_entry (lambda (entry)
+	(begin
+		(define primary (gs_id (stage_output_left_join_entry_stage entry)))
+		(map (stage_output_left_join_entry_ids entry) (lambda (id) (list id primary))))))
+
+(define stage_output_left_join_alias_map_for_entry (lambda (entry)
+	(begin
+		(define primary (source_alias (stage_output_left_join_entry_source entry)))
+		(map (stage_output_left_join_entry_aliases entry) (lambda (alias) (list alias primary))))))
+
+(define stage_output_left_join_candidate_ids (lambda (entries)
+	(merge_unique (map (coalesceNil entries '()) stage_output_left_join_entry_ids))))
+
+(define stage_merge_lookup (lambda (mapping key default)
+	(if (empty_list? mapping)
+		default
+		(coalesceNil
+			(reduce mapping (lambda (found entry)
+				(if (not (nil? found))
+					found
+					(match entry
+						'(k v) (if (equal? k key) v nil)
+						_ nil)))
+				nil)
+			default))))
+
+(define rewrite_stage_output_left_join_expr (lambda (alias_map id_map expr)
+	(match expr
+		((symbol get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(stage_merge_lookup alias_map tblvar tblvar)
+			ignorecase
+			col
+			col_ignorecase)
+		((quote get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(stage_merge_lookup alias_map tblvar tblvar)
+			ignorecase
+			col
+			col_ignorecase)
+		((symbol stage-output) stage_id)
+		(list (quote stage-output) (stage_merge_lookup id_map stage_id stage_id))
+		((quote stage-output) stage_id)
+		(list (quote stage-output) (stage_merge_lookup id_map stage_id stage_id))
+		(cons head tail) (cons (rewrite_stage_output_left_join_expr alias_map id_map head)
+			(map tail (lambda (item) (rewrite_stage_output_left_join_expr alias_map id_map item))))
+		_ expr)))
+
+(define rewrite_stage_output_left_join_source (lambda (alias_map id_map src)
+	(match src
+		'(alias schema relation outer join)
+		(list
+			(stage_merge_lookup alias_map alias alias)
+			schema
+			(rewrite_stage_output_left_join_expr alias_map id_map relation)
+			outer
+			(rewrite_stage_output_left_join_expr alias_map id_map join))
+		_ src)))
+
+(define rewrite_stage_output_left_join_stage (lambda (alias_map id_map stage)
+	(if (not (group_stage? stage))
+		stage
+		(make_group_stage
+			(gs_id stage)
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_input stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_domain stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_keys stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_having stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_output stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_order stage))
+			(gs_limit stage)
+			(gs_offset stage)
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_facts stage))))))
+
+(define stage_id_in_list? (lambda (ids stage_id)
+	(reduce (coalesceNil ids '()) (lambda (found id)
+		(or found (equal? id stage_id)))
+		false)))
+
+(define stage_not_in_id_list? (lambda (ids stage)
+	(not (and (group_stage? stage) (stage_id_in_list? ids (gs_id stage))))))
+
+(define merge_compatible_stage_output_left_joins_block (lambda (block)
+	(if (or (empty_list? (qb_stages block)) (empty_list? (qb_sources block)))
+		block
+		(begin
+			(define entries (stage_output_left_join_entries (qb_stages block) (qb_sources block)))
+			(if (not (stage_output_left_join_entries_have_duplicates? entries))
+				block
+				(begin
+					(define id_map (merge (map entries stage_output_left_join_id_map_for_entry)))
+					(define alias_map (merge (map entries stage_output_left_join_alias_map_for_entry)))
+					(define candidate_ids (stage_output_left_join_candidate_ids entries))
+					(define untouched_stages (filter (qb_stages block) (lambda (stage)
+						(stage_not_in_id_list? candidate_ids stage))))
+					(define merged_stages (map entries (lambda (entry)
+						(rewrite_stage_output_left_join_stage alias_map id_map
+							(stage_output_left_join_stage_with_aggregates
+								(stage_output_left_join_entry_stage entry)
+								(stage_output_left_join_entry_ags entry))))))
+					(make_query_block
+						(qb_schema block)
+						(merge_unique (list (map (qb_sources block) (lambda (src) (rewrite_stage_output_left_join_source alias_map id_map src)))))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_fields block))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_where block))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_group block))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_having block))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_order block))
+						(qb_limit block)
+						(qb_offset block)
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_hidden block))
+						(merge_unique (list untouched_stages merged_stages))
+						(rewrite_stage_output_left_join_expr alias_map id_map (qb_facts block)))))))))
+
+(define merge_compatible_stage_output_left_joins_node (lambda (node)
+	(if (query_block? node)
+		(merge_compatible_stage_output_left_joins_block node)
+		(if (union_block? node)
+			(make_union_block
+				(union_mode node)
+				(map (union_branches node) merge_compatible_stage_output_left_joins_node)
+				(union_order node)
+				(union_limit node)
+				(union_offset node)
+				(union_facts node))
+			node))))
+
+(define merge_compatible_stage_output_left_joins_ir (lambda (ir)
+	(begin
+		(define root (merge_compatible_stage_output_left_joins_node (ir_root ir)))
+		(make_ir
+			(ir_kind ir)
+			root
+			(if (query_block? root) (qb_stages root) (ir_stages ir))
 			(ir_context_of ir)
 			(ir_return ir)))))
 

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1052,7 +1052,7 @@ class SQLTestRunner:
         if "Error" in response.text or response.status_code != 200:
             return False
 
-        if "result_contains" in expect or "result_not_contains" in expect:
+        if "result_contains" in expect or "result_not_contains" in expect or "result_occurrences" in expect:
             result_text = response.text
             if results is not None:
                 result_text += "\n" + json.dumps(results, sort_keys=True, ensure_ascii=False)
@@ -1065,6 +1065,11 @@ class SQLTestRunner:
                 needles = expect["result_not_contains"] if isinstance(expect["result_not_contains"], list) else [expect["result_not_contains"]]
                 for needle in needles:
                     if str(needle) in result_text:
+                        return False
+            if "result_occurrences" in expect:
+                for item in expect["result_occurrences"]:
+                    needle = str(item["text"])
+                    if response.text.count(needle) != item["count"]:
                         return False
 
         if "affected_rows" in expect:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1052,6 +1052,21 @@ class SQLTestRunner:
         if "Error" in response.text or response.status_code != 200:
             return False
 
+        if "result_contains" in expect or "result_not_contains" in expect:
+            result_text = response.text
+            if results is not None:
+                result_text += "\n" + json.dumps(results, sort_keys=True, ensure_ascii=False)
+            if "result_contains" in expect:
+                needles = expect["result_contains"] if isinstance(expect["result_contains"], list) else [expect["result_contains"]]
+                for needle in needles:
+                    if str(needle) not in result_text:
+                        return False
+            if "result_not_contains" in expect:
+                needles = expect["result_not_contains"] if isinstance(expect["result_not_contains"], list) else [expect["result_not_contains"]]
+                for needle in needles:
+                    if str(needle) in result_text:
+                        return False
+
         if "affected_rows" in expect:
             expected = expect["affected_rows"]
             if results and results and "affected_rows" in results[0]:

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -34,6 +34,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_folder"
   - sql: "DROP TABLE IF EXISTS trace_message"
   - sql: "DROP TABLE IF EXISTS trace_share"
+  - sql: "DROP TABLE IF EXISTS trace_profile"
+  - sql: "DROP TABLE IF EXISTS trace_metric"
   - sql: |
       CREATE TABLE trace_group (
         id INT PRIMARY KEY
@@ -74,6 +76,24 @@ setup:
         box_id INT,
         owner_id INT
       )
+  - sql: |
+      CREATE TABLE trace_profile (
+        id INT PRIMARY KEY
+      )
+  - sql: |
+      CREATE TABLE trace_metric (
+        id INT PRIMARY KEY,
+        profile_id INT,
+        valid_from INT,
+        value_a INT,
+        value_b INT,
+        value_c INT,
+        value_d INT,
+        value_e INT,
+        value_f INT,
+        value_g INT,
+        value_h INT
+      )
   - sql: "INSERT INTO trace_group (id) VALUES (10), (20)"
   - sql: "INSERT INTO trace_item (id, group_id, state) VALUES (1, 10, 1), (2, 20, NULL), (3, 30, 0)"
   - sql: "INSERT INTO trace_host (id, kind) VALUES (1, 1), (2, 2)"
@@ -81,6 +101,19 @@ setup:
   - sql: "INSERT INTO trace_folder (id, box_id, name) VALUES (1001, 100, 'inbox'), (1002, 100, 'archive'), (2001, 200, 'other')"
   - sql: "INSERT INTO trace_message (id, box_id, folder_id, seen) VALUES (1, 100, 1001, FALSE), (2, 100, 1002, TRUE), (3, 200, 2001, FALSE)"
   - sql: "INSERT INTO trace_share (id, box_id, owner_id) VALUES (1, 100, 7)"
+  - sql: "INSERT INTO trace_profile (id) VALUES (1)"
+  - sql: "INSERT INTO trace_metric (id, profile_id, valid_from, value_a, value_b, value_c, value_d, value_e, value_f, value_g, value_h) VALUES (1, 1, 1, 10, 20, 30, 40, 50, 60, 70, 80)"
+  - sql: "INSERT INTO trace_metric SELECT id + 1, profile_id, valid_from + 1, value_a + 1, value_b + 1, value_c + 1, value_d + 1, value_e + 1, value_f + 1, value_g + 1, value_h + 1 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 2, profile_id, valid_from + 2, value_a + 2, value_b + 2, value_c + 2, value_d + 2, value_e + 2, value_f + 2, value_g + 2, value_h + 2 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 4, profile_id, valid_from + 4, value_a + 4, value_b + 4, value_c + 4, value_d + 4, value_e + 4, value_f + 4, value_g + 4, value_h + 4 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 8, profile_id, valid_from + 8, value_a + 8, value_b + 8, value_c + 8, value_d + 8, value_e + 8, value_f + 8, value_g + 8, value_h + 8 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 16, profile_id, valid_from + 16, value_a + 16, value_b + 16, value_c + 16, value_d + 16, value_e + 16, value_f + 16, value_g + 16, value_h + 16 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 32, profile_id, valid_from + 32, value_a + 32, value_b + 32, value_c + 32, value_d + 32, value_e + 32, value_f + 32, value_g + 32, value_h + 32 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 64, profile_id, valid_from + 64, value_a + 64, value_b + 64, value_c + 64, value_d + 64, value_e + 64, value_f + 64, value_g + 64, value_h + 64 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 128, profile_id, valid_from + 128, value_a + 128, value_b + 128, value_c + 128, value_d + 128, value_e + 128, value_f + 128, value_g + 128, value_h + 128 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 256, profile_id, valid_from + 256, value_a + 256, value_b + 256, value_c + 256, value_d + 256, value_e + 256, value_f + 256, value_g + 256, value_h + 256 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 512, profile_id, valid_from + 512, value_a + 512, value_b + 512, value_c + 512, value_d + 512, value_e + 512, value_f + 512, value_g + 512, value_h + 512 FROM trace_metric"
+  - sql: "INSERT INTO trace_metric SELECT id + 1024, profile_id, valid_from + 1024, value_a + 1024, value_b + 1024, value_c + 1024, value_d + 1024, value_e + 1024, value_f + 1024, value_g + 1024, value_h + 1024 FROM trace_metric"
   - sql: |
       CREATE TABLE trace_config (
         id INT PRIMARY KEY,
@@ -309,6 +342,57 @@ test_cases:
           filename: "asset-2.dat"
           referenced: false
 
+  - name: "EXPLAIN IR merges repeated scalar latest projection stages"
+    sql: |
+      EXPLAIN IR
+      SELECT
+        p.id,
+        COALESCE((SELECT m.value_a FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_a,
+        COALESCE((SELECT m.value_b FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_b,
+        COALESCE((SELECT m.value_c FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_c,
+        COALESCE((SELECT m.value_d FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_d,
+        COALESCE((SELECT m.value_e FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_e,
+        COALESCE((SELECT m.value_f FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_f,
+        COALESCE((SELECT m.value_g FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_g,
+        COALESCE((SELECT m.value_h FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_h
+      FROM trace_profile p
+      WHERE p.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scalar-once"
+        - "value_h"
+      result_not_contains:
+        - "scalar-once:b1ecb2795b4bbb34"
+        - "__exists_2ff8679a7aafb8ea"
+
+  - name: "Repeated scalar latest projections reuse one key carrier"
+    sql: |
+      SELECT
+        p.id,
+        COALESCE((SELECT m.value_a FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_a,
+        COALESCE((SELECT m.value_b FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_b,
+        COALESCE((SELECT m.value_c FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_c,
+        COALESCE((SELECT m.value_d FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_d,
+        COALESCE((SELECT m.value_e FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_e,
+        COALESCE((SELECT m.value_f FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_f,
+        COALESCE((SELECT m.value_g FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_g,
+        COALESCE((SELECT m.value_h FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_h
+      FROM trace_profile p
+      WHERE p.id = 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          value_a: 2057
+          value_b: 2067
+          value_c: 2077
+          value_d: 2087
+          value_e: 2097
+          value_f: 2107
+          value_g: 2117
+          value_h: 2127
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_config"
   - sql: "DROP TABLE IF EXISTS trace_doc"
@@ -326,3 +410,5 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS trace_folder"
   - sql: "DROP TABLE IF EXISTS trace_message"
   - sql: "DROP TABLE IF EXISTS trace_share"
+  - sql: "DROP TABLE IF EXISTS trace_profile"
+  - sql: "DROP TABLE IF EXISTS trace_metric"

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -342,9 +342,9 @@ test_cases:
           filename: "asset-2.dat"
           referenced: false
 
-  - name: "EXPLAIN IR merges repeated scalar latest projection stages"
+  - name: "EXPLAIN uses one ordered scan for repeated scalar latest projections"
     sql: |
-      EXPLAIN IR
+      EXPLAIN
       SELECT
         p.id,
         COALESCE((SELECT m.value_a FROM trace_metric m WHERE m.profile_id = p.id AND m.valid_from <= 4096 ORDER BY m.valid_from DESC LIMIT 1), 0) AS value_a,
@@ -360,8 +360,11 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scalar-once"
         - "value_h"
+        - "scan_order"
+      result_occurrences:
+        - text: "scan_order"
+          count: 1
       result_not_contains:
         - "scalar-once:b1ecb2795b4bbb34"
         - "__exists_2ff8679a7aafb8ea"


### PR DESCRIPTION
## Summary
- add an anonymized regression for repeated scalar latest-value projections from the manual-build trace shape
- after Neumann decorrelation, deduplicate compatible `stage-output` LEFT JOIN sources and merge their carrier aggregates
- lower compatible repeated ordered-scalar carrier fills to one shared `scan_order` instead of one ordered probe per projected value
- add `result_occurrences` assertions so YAML tests can lock physical-plan operator counts

## Root cause
The traced query shape projects several latest values from the same helper relation with identical correlation keys, filter, ordering, and limit. Neumann decorrelation correctly turns those scalar subqueries into outer `stage-output` joins, but before this PR each projected value kept its own LEFT JOIN source and carrier stage.

The first half of this PR fixed that at the logical IR level. The remaining physical issue was that `build_queryplan` still lowered the combined carrier as separate ordered computed-column projections, so final `EXPLAIN` still contained one `scan_order` per value column.

## Fix
The merge pass runs after Neumann decorrelation, during stage-dependency normalization, and is driven by the decorrelated join IR:

- candidate sources must be outer joins to `(stage-output <id>)`
- the source join condition is normalized by replacing only the stage-output alias with a placeholder
- the backing carrier stage must be compatible: same base input, domain, keys, condition, order, limit, output shape, and scalar latest aggregation shape, excluding only the value expression
- matching sources are rewritten to the primary alias/stage id
- compatible aggregate payloads are combined into the primary carrier

For physical lowering, compatible base-table `scalar_order_value` aggregates with the same ORDER BY, directions, offset, reducer, and neutral value now get a single carrier-fill plan:

- the carrier table is created with all aggregate output columns up front
- one `scan_order` sorts by group keys plus the requested order columns
- the reducer keeps the first row per group key and stores a flat payload list
- the returned grouped dictionary is inserted/upserted into all carrier value columns in one step

This keeps the logical/physical boundary intact: join/source deduplication operates on logical `query-block` sources and stages; the shared `scan_order` is introduced only inside physical `build_queryplan` lowering.

## A/B measurements
Measured locally against `origin/master` (`49be9692a`) using the anonymized repeated latest-value query from `tests/118_manual_trace_sql_regressions.yaml`.

| Metric | master | branch |
| --- | ---: | ---: |
| final EXPLAIN `scan_order` occurrences | 8 | 1 |
| final EXPLAIN response size | 10,100 chars | 9,572 chars |
| cold query time, run 1 | 88.217 ms | 46.281 ms |
| warm query median, runs 2-5 | 23.677 ms | 22.265 ms |
| result row | correct | correct |

Earlier logical IR measurement from this branch remains: the repeated scalar-latest shape dropped from 24 `scalar-once` / 8 `stage-output` occurrences on master to 3 `scalar-once` / 1 `stage-output` on the branch.

## Test-first check
- master plus the new physical assertion fails because final `EXPLAIN` has 8 `scan_order` occurrences
- branch passes with exactly 1 `scan_order` and returns the expected data row

## Validation
- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml --log-times --fail-fast`
- `make test` passed with exit code 0
- `git diff --check`

Notes:
- `make test` reported one noncritical memory-pressure timing warning and expected `code=137` restarts in crash-recovery coverage, but finished with `All tests passed, commit allowed`.
- A redundant commit-hook rerun after the successful `make test` was interrupted after unrelated `No response` timeouts in old suites; the final commit used `--no-verify`, which is allowed by the repo policy after a successful full `make test`.
- `python3 tools/lint_scm.py --check` still reports existing repository-wide formatter/bracket-depth warnings; I did not reformat unrelated Scheme files in this PR.