### PR TITLE
Optimize scalar aggregate constant lookups

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -151,6 +151,29 @@ PostgreSQL parsers should both lower to the same combined operators.
 		'(_ stage_id) stage_id
 		_ nil)))
 
+(define logical_stage_key (lambda (stage)
+	(if (group_stage? stage)
+		(concat "group:" (gs_id stage))
+		(if (orc_stage? stage)
+			(concat "orc:" (nth stage 1))
+			(if (window_stage? stage)
+				(concat "window:" (nth stage 1))
+				nil)))))
+
+(define unique_stages_by_id_acc (lambda (stages seen)
+	(match (coalesceNil stages '())
+		(cons stage rest) (begin
+			(define key (logical_stage_key stage))
+			(if (and (not (nil? key)) (has_assoc? seen key))
+				(unique_stages_by_id_acc rest seen)
+				(cons stage
+					(unique_stages_by_id_acc rest
+						(if (nil? key) seen (set_assoc seen key true))))))
+		_ '())))
+
+(define unique_stages_by_id (lambda (stages)
+	(unique_stages_by_id_acc stages '())))
+
 (define qb_schema (lambda (node) (nth node 1)))
 (define qb_sources (lambda (node) (nth node 2)))
 (define qb_fields (lambda (node) (nth node 3)))
@@ -6194,7 +6217,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(begin
 				(define stage (stage_by_id stages (stage_output_relation_id relation)))
 				(if (nil? stage)
-					(neumann_fail "build_queryplan" "stage-output source references unknown stage")
+					(neumann_fail "build_queryplan" (concat "physicalize stage-output source references unknown stage " (stage_output_relation_id relation)))
 					true)
 				(source_with_schema_relation
 					src
@@ -6214,10 +6237,30 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(begin
 					(define stage (stage_by_id stages (stage_output_relation_id relation)))
 					(if (nil? stage)
-						(neumann_fail "build_queryplan" "stage-output source references unknown stage")
+						(neumann_fail "build_queryplan" (concat "dependency stage-output source references unknown stage " (stage_output_relation_id relation)))
 						stage)))
 			_ nil)))
 		(lambda (stage) (not (nil? stage))))))))
+
+(define source_stage_output_stage (lambda (stages src)
+	(if (not (stage_output_relation? (source_relation src)))
+		nil
+		(stage_by_id stages (stage_output_relation_id (source_relation src))))))
+
+(define constant_scalar_stage_output_source? (lambda (stages src)
+	(begin
+		(define stage (source_stage_output_stage stages src))
+			(and (group_stage? stage)
+				(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
+					(and (empty_list? (gs_domain stage))
+						(not (stage_has_residual_outer_refs? stage))))))))
+
+(define constant_scalar_stage_outputs_first (lambda (stages sources)
+	(merge (list
+		(filter (coalesceNil sources '()) (lambda (src)
+			(constant_scalar_stage_output_source? stages src)))
+		(filter (coalesceNil sources '()) (lambda (src)
+			(not (constant_scalar_stage_output_source? stages src))))))))
 
 (define scalar_first_stage_output_source? (lambda (stages src)
 	(and (stage_output_relation? (source_relation src))
@@ -6599,6 +6642,23 @@ PostgreSQL parsers should both lower to the same combined operators.
 		'()
 		(qb_facts block))))
 
+(define query_block_without_stages_after_eager_prepare_with_constant_scalars_first (lambda (stages block)
+	(begin
+		(define available_stages (unique_stages_by_id (merge (list stages (qb_stages block)))))
+		(make_query_block
+			(qb_schema block)
+			(physicalize_stage_output_sources available_stages (constant_scalar_stage_outputs_first available_stages (qb_sources block)))
+			(qb_fields block)
+			(qb_where block)
+			(qb_group block)
+			(qb_having block)
+			(qb_order block)
+			(qb_limit block)
+			(qb_offset block)
+			(qb_hidden block)
+			'()
+			(qb_facts block)))))
+
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(begin
 		(define scalar_rewritten (query_block_with_scalar_first_probes_using stages block))
@@ -6715,8 +6775,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(equal? (count ags) 2))))
 		(define scalar_order_base_stage (and (not query_input_carrier)
 			(compatible_scalar_order_aggregates? ags)))
+		(define scalar_aggregate_stage (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_aggregate)))
 		(define prepared_src (if (query_block? rewritten_src)
-			(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src)
+			(if scalar_aggregate_stage
+				(begin
+					(define constant_reorder_stages (unique_stages_by_id (merge (list all_stages (qb_stages rewritten_src)))))
+					(if (not (empty_list? (filter (qb_sources rewritten_src) (lambda (src)
+						(constant_scalar_stage_output_source? constant_reorder_stages src)))))
+						(query_block_without_stages_after_eager_prepare_with_constant_scalars_first constant_reorder_stages rewritten_src)
+						(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src)))
+				(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src))
 			rewritten_src))
 			(define nested_stages (if (query_block? rewritten_src)
 				(merge_unique (list

--- a/tests/119_badge_scalar_aggregates.yaml
+++ b/tests/119_badge_scalar_aggregates.yaml
@@ -1,0 +1,111 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Badge scalar aggregate regressions for constant scalar stage lookups"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS badge_config"
+  - sql: "DROP TABLE IF EXISTS badge_doc"
+  - sql: "DROP TABLE IF EXISTS badge_task"
+  - sql: "DROP TABLE IF EXISTS badge_message"
+  - sql: "DROP TABLE IF EXISTS badge_ticket"
+  - sql: "CREATE TABLE badge_config (id INT PRIMARY KEY, default_type INT, actor_id INT)"
+  - sql: "CREATE TABLE badge_doc (id INT PRIMARY KEY, type INT, archived BOOL, flag INT)"
+  - sql: "CREATE TABLE badge_task (id INT PRIMARY KEY, due_at INT, done BOOL, actor_id INT)"
+  - sql: "CREATE TABLE badge_message (id INT PRIMARY KEY, box_id INT, seen BOOL, owner_id INT)"
+  - sql: "CREATE TABLE badge_ticket (id INT PRIMARY KEY, state INT, assignee INT, creator INT, effort INT)"
+  - sql: "INSERT INTO badge_config (id, default_type, actor_id) VALUES (1, 10, 7)"
+  - sql: "INSERT INTO badge_doc (id, type, archived, flag) VALUES (1, 10, FALSE, 1)"
+  - sql: "INSERT INTO badge_task (id, due_at, done, actor_id) VALUES (1, 100, FALSE, 7)"
+  - sql: "INSERT INTO badge_message (id, box_id, seen, owner_id) VALUES (1, 1, FALSE, 7)"
+  - sql: "INSERT INTO badge_ticket (id, state, assignee, creator, effort) VALUES (1, 1, 7, 8, 5)"
+  - sql: "INSERT INTO badge_doc SELECT id + 1, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 2, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 4, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 8, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 16, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 32, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 64, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 128, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 256, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 512, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 1024, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_doc SELECT id + 2048, CASE WHEN id % 2 = 0 THEN 10 ELSE 20 END, FALSE, id % 3 FROM badge_doc"
+  - sql: "INSERT INTO badge_task SELECT id + 1, due_at + 1, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 2, due_at + 2, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 4, due_at + 4, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 8, due_at + 8, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 16, due_at + 16, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 32, due_at + 32, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 64, due_at + 64, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_task SELECT id + 128, due_at + 128, FALSE, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_task"
+  - sql: "INSERT INTO badge_message SELECT id + 1, box_id, id % 2 = 0, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_message"
+  - sql: "INSERT INTO badge_message SELECT id + 2, box_id, id % 2 = 0, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_message"
+  - sql: "INSERT INTO badge_message SELECT id + 4, box_id, id % 2 = 0, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_message"
+  - sql: "INSERT INTO badge_message SELECT id + 8, box_id, id % 2 = 0, CASE WHEN id % 2 = 0 THEN 7 ELSE 8 END FROM badge_message"
+
+test_cases:
+  - name: "Badge scalar aggregates hoist constant stage lookups"
+    max_time: 0.5
+    sql: |
+      SELECT
+        1 AS marker,
+        (
+          SELECT COUNT(1)
+          FROM badge_doc d
+          WHERE (
+              (((SELECT default_type FROM badge_config WHERE id = 1 LIMIT 1) IS NULL) AND d.type IS NULL)
+              OR d.type = (SELECT default_type FROM badge_config WHERE id = 1 LIMIT 1)
+            )
+            AND NOT d.archived
+          LIMIT 1
+        ) AS doc_badge,
+        (
+          SELECT SUM(1)
+          FROM badge_task t
+          WHERE NOT t.done
+            AND t.actor_id = (SELECT actor_id FROM badge_config WHERE id = 1 LIMIT 1)
+          LIMIT 1
+        ) AS task_badge,
+        (
+          SELECT SUM(1)
+          FROM badge_message m
+          WHERE NOT m.seen
+            AND m.owner_id = (SELECT actor_id FROM badge_config WHERE id = 1 LIMIT 1)
+          LIMIT 1
+        ) AS message_badge,
+        (
+          SELECT SUM(effort)
+          FROM badge_ticket k
+          WHERE k.assignee = (SELECT actor_id FROM badge_config WHERE id = 1 LIMIT 1)
+          LIMIT 1
+        ) AS ticket_effort
+    expect:
+      rows: 1
+      data:
+        - marker: 1
+          doc_badge: 2048
+          task_badge: 128
+          message_badge: 1
+          ticket_effort: 5
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS badge_config"
+  - sql: "DROP TABLE IF EXISTS badge_doc"
+  - sql: "DROP TABLE IF EXISTS badge_task"
+  - sql: "DROP TABLE IF EXISTS badge_message"
+  - sql: "DROP TABLE IF EXISTS badge_ticket"


### PR DESCRIPTION
## Summary

This PR adds a minimal, anonymized regression for a no-FROM dashboard-style query with several scalar aggregates and repeated constant scalar lookups.

The planner now detects constant `scalar_single` stage outputs while preparing `scalar_aggregate` input blocks and orders those constant sources before the larger aggregate scans. That keeps the constant lookup available before the base scans run, without changing the normal logical decorrelation path for unrelated query blocks.

## Root Cause

For this query shape, a constant scalar lookup stage could stay behind the aggregate scan source in the prepared query block. `build_queryplan` then executed the combined stage in an order that forced the larger aggregate side to run without the cheap constant result being available first.

## A/B Measurements

Measured locally with the HTTP YAML runner against current `master` (`e674f58b8`) and this branch. The test data is synthetic and anonymized.

- master: `python3 run_sql_tests.py /tmp/119_badge_scalar_aggregates.yaml --log-times`
  - `Badge scalar aggregates hoist constant stage lookups`: **1670.5 ms**, fails `max_time: 0.5`
- branch: `python3 run_sql_tests.py tests/119_badge_scalar_aggregates.yaml --log-times`
  - `Badge scalar aggregates hoist constant stage lookups`: **94.3 ms**, passes `max_time: 0.5`
- branch combined focused run: `tests/92_parallel_projection.yaml tests/96_scalar_subselect_patterns.yaml tests/119_badge_scalar_aggregates.yaml --log-times`
  - 26/26 tests passed; new regression measured **99.3 ms** in that run

That is about **17.7x faster** for the isolated regression query versus current master.

## Manual Build Trace

I reran the downstream manual build against this branch with MemCP on `localhost:4321` / MySQL `3307` and TracePrint enabled.

Progress:

- setup: passed
- initial data stage: passed
- first user stage: passed
- phase0: passed
- phase0 email-client subset: passed
- phase1: failed with UI navigation/wait timeouts

Trace top SQL after this patch shows a later blocker, not the isolated regression fixed here:

- two broad document-list queries with repeated latest-revision/file/permission scalar projections: about **56.4 s** and **52.7 s**
- a document-property list query with nested permission scalar projections: about **12.2 s**
- large aggregate badge/reminder queries still appear around **9.1 s** and **4.9 s**, so the next PR should extract a separate minimal regression for the remaining mixed aggregate/access-check pattern

## Validation

- `go build -o memcp`
- `python3 run_sql_tests.py tests/119_badge_scalar_aggregates.yaml --log-times`
- `python3 run_sql_tests.py tests/92_parallel_projection.yaml tests/96_scalar_subselect_patterns.yaml tests/119_badge_scalar_aggregates.yaml --log-times`
- `git diff --check`
- `python3 tools/lint_scm.py --check` still reports existing formatter/bracket-depth warnings in several Scheme files, including pre-existing warnings in `lib/queryplan.scm`
- `make test` was started but manually interrupted after it stopped producing output for several minutes in existing parallel suites; the focused regression coverage above completed successfully
