### PR TITLE
Develop cost-based document search lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4528,7 +4528,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(or (not (nil? (qb_limit input))) (not (nil? (qb_offset input)))))
 			(neumann_fail "build_queryplan" "scalar-first query probe cannot preserve nested ORDER/LIMIT yet")
 			(begin
-				(define raw_probe (cons (quote !begin) (merge (list prepare_exprs (list probe_expr)))))
+				(define raw_probe (cons (quote !begin)
+					(merge (list
+						(lazy_stage_prepare_bindings nested_stages (filter nested_stages group_stage?))
+						prepare_exprs
+						(list probe_expr)))))
 				(if (presence_bool_stage_output_expr? value_expr)
 					(list (quote coalesceNil) raw_probe false)
 					raw_probe))))))
@@ -6250,7 +6254,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(list (quote +)
 					(list (quote cadr) (quote old))
 					(list (quote cadr) (quote new))))))
-		(list (quote scan)
+		(define stage_catalog (if (query_block? prepared_input) (query_block_stage_catalog prepared_input) '()))
+		(define scan_plan (list (quote scan)
 			'(session "__memcp_tx")
 			rows_plan
 			(quoted_runtime_list '())
@@ -6269,6 +6274,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(list (quote lambda) (list (quote acc) (quote grouped))
 				(group_insert_finish_expr schema grouptbl key_names (list value_col count_col)))
 			false))
+		(if (empty_list? stage_catalog)
+			scan_plan
+			(cons (quote !begin)
+				(merge (list
+					(lazy_stage_prepare_bindings stage_catalog (filter stage_catalog group_stage?))
+					(list scan_plan))))))
 		_ (neumann_fail "build_queryplan" "scalar-single stage expects aggregate descriptor"))))
 
 (define build_group_keytable_cleanup (lambda (schema tbl alias grouptbl keys key_names)
@@ -6714,6 +6725,28 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define query_block_facts_with_stage_catalog (lambda (block stages)
 	(qassoc_set (qb_facts block) (quote stage_catalog) stages)))
 
+(define query_block_with_stage_catalog (lambda (block stages)
+	(make_query_block
+		(qb_schema block)
+		(qb_sources block)
+		(qb_fields block)
+		(qb_where block)
+		(qb_group block)
+		(qb_having block)
+		(qb_order block)
+		(qb_limit block)
+		(qb_offset block)
+		(qb_hidden block)
+		(qb_stages block)
+		(query_block_facts_with_stage_catalog block stages))))
+
+(define stage_ids (lambda (stages)
+	(map (coalesceNil stages '()) gs_id)))
+
+(define stages_without_ids (lambda (stages ids)
+	(filter (coalesceNil stages '()) (lambda (stage)
+		(not (contains? ids (gs_id stage)))))))
+
 (define scalar_first_probe_consumed_stages (lambda (stages stage)
 	(if (not (scalar_or_presence_probe_stage? stage))
 		'()
@@ -6820,7 +6853,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(qb_offset block)
 		(qb_hidden block)
 		'()
-		(query_block_facts_with_stage_catalog block stages))))
+		(query_block_facts_with_stage_catalog block '()))))
 
 (define query_block_without_stages_after_eager_prepare_with_constant_scalars_first (lambda (stages block)
 	(begin
@@ -7664,15 +7697,19 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(if (not (nil? fused_row_number))
 						fused_row_number
 						(begin
+							(define eager_stages (query_block_stages_to_prepare block))
 							(define prepared_block (if (single_source? (qb_sources block))
 								(query_block_without_stages_after_prepare_using (qb_stages block) block)
 								(query_block_with_prepared_sources_using (qb_stages block) block)))
+							(define lazy_catalog (stages_without_ids (qb_stages block) (stage_ids eager_stages)))
+							(define core_block (query_block_with_stage_catalog prepared_block lazy_catalog))
+							(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
 							(cons (quote !begin)
 								(merge (list
-									(lazy_stage_prepare_bindings (qb_stages block) (filter (qb_stages block) group_stage?))
-									(map (query_block_stages_to_prepare block) (lambda (stage)
+									(lazy_stage_prepare_bindings lazy_catalog lazy_stages)
+									(map eager_stages (lambda (stage)
 										(lower_stage_prepare_using (qb_stages block) stage)))
-									(list (lower_query_block_core prepared_block))))))))))))))
+									(list (lower_query_block_core core_block))))))))))))))
 
 (define source_is_base_table? (lambda (src)
 	(string? (source_relation src))))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6708,6 +6708,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(expr_probe_stages (qb_order block))
 		(expr_probe_stages (qb_hidden block))))))
 
+(define query_block_stage_catalog (lambda (block)
+	(qassoc_get (qb_facts block) (quote stage_catalog) (qb_stages block))))
+
+(define query_block_facts_with_stage_catalog (lambda (block stages)
+	(qassoc_set (qb_facts block) (quote stage_catalog) stages)))
+
 (define scalar_first_probe_consumed_stages (lambda (stages stage)
 	(if (not (scalar_or_presence_probe_stage? stage))
 		'()
@@ -6796,7 +6802,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(qb_offset rewritten)
 			(qb_hidden rewritten)
 			'()
-			(qb_facts rewritten)))))
+			(query_block_facts_with_stage_catalog rewritten stages)))))
 
 (define query_block_without_stages_after_prepare (lambda (block)
 	(query_block_without_stages_after_prepare_using (qb_stages block) block)))
@@ -6814,7 +6820,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(qb_offset block)
 		(qb_hidden block)
 		'()
-		(qb_facts block))))
+		(query_block_facts_with_stage_catalog block stages))))
 
 (define query_block_without_stages_after_eager_prepare_with_constant_scalars_first (lambda (stages block)
 	(begin
@@ -6853,7 +6859,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(qb_offset rewritten)
 			(qb_hidden rewritten)
 			(stages_without_probe_sources (qb_stages rewritten) presence_probe_sources)
-			(qb_facts rewritten)))))
+			(query_block_facts_with_stage_catalog rewritten stages)))))
 
 (define query_block_with_prepared_sources (lambda (block)
 	(query_block_with_prepared_sources_using (qb_stages block) block)))
@@ -7167,7 +7173,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define key_names (group_key_cols keys))
 		(list (quote begin)
 			(lower_group_stage_prepare_using (list stage) stage)
-			(lower_query_block_core (group_stage_final_block stage (group_stage_final_extra_sources stage)))))))
+			(lower_query_block_core_with_lazy_prepares (list stage) (group_stage_final_block stage (group_stage_final_extra_sources stage)))))))
 
 (define row_number_get_column? (lambda (col expr)
 	(match expr
@@ -7629,13 +7635,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(and
 				(stage_direct_prepare_source_visible? block sources default_alias stage)
 				(stage_direct_prepare_semantic_candidate? consumed_probe_ids stage_output_ids stage)))))
-		(merge_unique (list
-			direct
-			(stage_prepare_dependency_closure_all all_stages
-				(merge_unique (list
-					(stage_outputs_from_sources_using all_stages sources)
-					(carrier_stages_from_sources all_stages sources)
-					(query_block_probe_expr_stages block)))))))))
+		direct)))
 
 (define query_block_stages_to_prepare_base (lambda (block)
 	(query_block_stages_to_prepare_base_using (qb_stages block) block)))
@@ -7663,13 +7663,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(define fused_row_number (lower_fused_row_number_block block))
 					(if (not (nil? fused_row_number))
 						fused_row_number
-						(cons (quote !begin)
-							(merge (list
-								(map (query_block_stages_to_prepare block) (lambda (stage)
-									(lower_stage_prepare_using (qb_stages block) stage)))
-								(list (lower_query_block_core (if (single_source? (qb_sources block))
-									(query_block_without_stages_after_prepare_using (qb_stages block) block)
-									(query_block_with_prepared_sources_using (qb_stages block) block))))))))))))))
+						(begin
+							(define prepared_block (if (single_source? (qb_sources block))
+								(query_block_without_stages_after_prepare_using (qb_stages block) block)
+								(query_block_with_prepared_sources_using (qb_stages block) block)))
+							(cons (quote !begin)
+								(merge (list
+									(lazy_stage_prepare_bindings (qb_stages block) (filter (qb_stages block) group_stage?))
+									(map (query_block_stages_to_prepare block) (lambda (stage)
+										(lower_stage_prepare_using (qb_stages block) stage)))
+									(list (lower_query_block_core prepared_block))))))))))))))
 
 (define source_is_base_table? (lambda (src)
 	(string? (source_relation src))))
@@ -7683,6 +7686,50 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(if (information_schema_source? (source_schema src) (source_relation src))
 		(list (quote information_schema_rows) (source_schema src) (source_relation src))
 		(list (quote table) (source_schema src) (source_relation src)))))
+
+(define source_table_expr_using (lambda (stages src)
+	(begin
+		(define table_expr (source_table_expr src))
+		(define carrier_stage (stage_for_carrier_source stages src))
+		(if (nil? carrier_stage)
+			table_expr
+			(list (quote !begin)
+				(stage_prepare_call_expr carrier_stage)
+				table_expr)))))
+
+(define stage_prepare_key (lambda (stage)
+	(concat "__prepare_stage_" (fnv_hash (gs_id stage)))))
+
+(define stage_prepare_call_expr (lambda (stage)
+	(list (quote apply)
+		(list (list (quote context) "session") (stage_prepare_key stage))
+		(quoted_runtime_list '()))))
+
+(define lazy_stage_prepare_binding (lambda (stages stage)
+	(list
+		(list (quote context) "session")
+		(stage_prepare_key stage)
+		(list (quote once)
+			(list (quote lambda)
+				'()
+				(list (quote !begin)
+					(lower_stage_prepare_using stages stage)
+					true))))))
+
+(define lazy_stage_prepare_bindings (lambda (stages selected)
+	(map (coalesceNil selected '()) (lambda (stage)
+		(lazy_stage_prepare_binding stages stage)))))
+
+(define lower_query_block_core_with_lazy_prepares (lambda (stage_catalog block)
+	(begin
+		(define lazy_stages (carrier_stages_from_sources stage_catalog (qb_sources block)))
+		(define core_plan (lower_query_block_core block))
+		(if (empty_list? lazy_stages)
+			core_plan
+			(cons (quote !begin)
+				(merge (list
+					(lazy_stage_prepare_bindings stage_catalog lazy_stages)
+					(list core_plan))))))))
 
 (define query_block_has_aggregates? (lambda (block)
 	(not (empty_list? (stage_aggregates_for_fields (qb_fields block))))))
@@ -7818,9 +7865,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(if (direct_base_group_stage_supported? block group_stage)
 					(lower_direct_base_group_stage group_stage fields (qb_order block) (qb_offset block) (qb_limit block))
 					(lower_group_stage group_stage)))
-			(begin
-				(define alias (source_alias src))
-				(define condition (combine_where (qb_where block) (source_join_expr src)))
+				(begin
+					(define alias (source_alias src))
+					(define condition (combine_where (qb_where block) (source_join_expr src)))
 				(define order_items (coalesceNil (qb_order block) '()))
 				(define scan_order_supported (order_items_belong_to_source? src order_items))
 				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
@@ -7831,12 +7878,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(define filtercols (extract_columns_for_alias src effective_condition))
 				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
-				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
-				(define mapcols (merge_unique (list filtercols fieldcols)))
-				(define table_expr (coalesceNil membership_table_expr (source_table_expr src)))
-				(define filter_expr (list (quote lambda)
-					(map filtercols (lambda (col) (symbol (concat alias "." col))))
-					(list (quote optimize) (lower_column_expr_for_alias src effective_condition))))
+					(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
+					(define mapcols (merge_unique (list filtercols fieldcols)))
+					(define table_expr (coalesceNil membership_table_expr (source_table_expr_using (query_block_stage_catalog block) src)))
+					(define filter_expr (list (quote lambda)
+						(map filtercols (lambda (col) (symbol (concat alias "." col))))
+						(list (quote optimize) (lower_column_expr_for_alias src effective_condition))))
 				(define map_expr (list (quote lambda)
 					(map mapcols (lambda (col) (symbol (concat alias "." col))))
 					(list (quote resultrow)
@@ -7886,7 +7933,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 								0
 								-1
 								true
-								'())
+									(query_block_stage_catalog block))
 							fields
 							order_items
 							(qb_offset block)
@@ -8304,13 +8351,13 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(join_filter_cols_for_alias all_sources default_alias alias stripped_condition))))
 				(define raw_mapcols (join_cols_for_alias all_sources default_alias alias needed_exprs))
 				(define scan_mapcols (merge_unique (list (without_col raw_mapcols col) mapcols)))
-				(define table_expr (source_table_expr src))
+				(define table_expr (source_table_expr_using stages src))
 				(define rewritten_row_expr (replace_lowered_row_number_symbol alias col row_expr))
-				(define filter_expr (list (quote lambda)
-					(map filtercols (lambda (filter_col) (scan_callback_symbol_for_alias alias filter_col)))
-					(list (quote optimize) (lower_column_expr_for_join all_sources default_alias filter_condition))))
-				(define continuation_expr (list (quote lambda) (list (quote __row_number))
-					(build_join_scan_rows_with_mapper schema all_sources (cdr sources) default_alias needed_exprs final_condition rewritten_row_expr '() 0 -1 true '())))
+					(define filter_expr (list (quote lambda)
+						(map filtercols (lambda (filter_col) (scan_callback_symbol_for_alias alias filter_col)))
+						(list (quote optimize) (lower_column_expr_for_join all_sources default_alias filter_condition))))
+					(define continuation_expr (list (quote lambda) (list (quote __row_number))
+						(build_join_scan_rows_with_mapper schema all_sources (cdr sources) default_alias needed_exprs final_condition rewritten_row_expr '() 0 -1 true stages)))
 				(define map_expr (list (quote lambda)
 					(map scan_mapcols (lambda (map_col) (symbol (concat alias "." map_col))))
 					(list (quote list)
@@ -8387,11 +8434,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(if membership_filter (list "$recset_contains") '())
 				(join_filter_cols_for_alias all_sources default_alias alias effective_condition))))
 			(define mapcols (join_cols_for_alias all_sources default_alias alias needed_exprs))
-			(define table_expr (if membership_driver membership_table_expr (source_table_expr src)))
-			(define lowered_filter_condition (mark_outer_join_symbols
-				all_sources
-				alias
-				(lower_column_expr_for_join all_sources default_alias filter_condition)))
+				(define table_expr (if membership_driver membership_table_expr (source_table_expr_using stages src)))
+				(define lowered_filter_condition (mark_outer_join_symbols
+					all_sources
+					alias
+					(lower_column_expr_for_join all_sources default_alias filter_condition)))
 			(define filter_expr (list (quote lambda)
 				(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 				(list (quote optimize) lowered_filter_condition)))
@@ -8492,8 +8539,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			'()
 			0
 			-1
-			true
-			(qb_stages block)))))
+				true
+				(query_block_stage_catalog block)))))
 
 (define lower_multi_source_query_block (lambda (block)
 	(begin
@@ -8514,91 +8561,92 @@ PostgreSQL parsers should both lower to the same combined operators.
 					sources))
 				(define final_condition (if push_first_where true where_expr))
 				(define order_items (coalesceNil (qb_order block) '()))
-					(define direct_order (and (equal? first_alias (source_alias (car scan_sources)))
-						(order_items_belong_to_source? (car scan_sources) order_items)))
-					(define direct_order_safe (and direct_order
-						(not (ordered_join_limit_requires_complete_rows? scan_sources first_alias final_condition (qb_offset block) (qb_limit block)))))
-						(define membership_candidate_sort_plan
-							(equal? (qassoc_get (qb_facts block) (quote membership_selectivity_class) nil) (quote selective)))
-					(define needed_exprs (merge (list
-						(extract_assoc fields (lambda (_title expr) expr))
-						(list final_condition)
-						(order_exprs order_items)
-						(source_join_exprs scan_sources))))
-					(define prelimit_sources (if (empty_list? scan_sources)
-						'()
-						(cons (car scan_sources)
-							(filter (cdr scan_sources) (lambda (src)
-								(expr_refs_alias? first_alias (source_alias src) final_condition))))))
-					(define late_projection_safe (late_projection_sources_preserve_rows? scan_sources prelimit_sources))
-					(if direct_order_safe
-							(build_join_scan_rows (qb_schema block) scan_sources first_alias needed_exprs final_condition fields order_items (qb_offset block) (qb_limit block) (qb_stages block))
-							(if direct_order
-								(if (and membership_candidate_sort_plan late_projection_safe)
-									(begin
-									(define project_needed_exprs (merge (list
-										(extract_assoc fields (lambda (_title expr) expr))
-										(order_exprs order_items)
-										(source_join_exprs scan_sources))))
-									(define driver_needed_exprs (merge (list
-										(list final_condition)
-										(order_exprs order_items)
-										(map project_needed_exprs (lambda (expr)
-											(extract_columns_for_join_alias scan_sources first_alias first_alias expr))))))
-									(define driver_cols (join_cols_for_alias scan_sources first_alias first_alias project_needed_exprs))
-									(define prelimit_stage_ids (stage_ids_for_sources_with_closure (qb_stages block) prelimit_sources))
-									(define project_stages (filter (query_block_stages_to_prepare_base block) (lambda (stage)
-										(not (stage_id_in? stage prelimit_stage_ids)))))
-									(define project_prepare_expr (cons (quote !begin)
-										(map project_stages (lambda (stage)
-											(lower_stage_prepare_using (qb_stages block) stage)))))
-									(define project_row_expr
-										(lower_join_result_row_assoc scan_sources first_alias fields order_items))
-									(define project_rows_expr (replace_lowered_driver_symbols_with_row first_alias driver_cols
-										(build_join_scan_rows_with_mapper
-											(qb_schema block)
-											scan_sources
-											(cdr scan_sources)
-											first_alias
-											project_needed_exprs
-											true
-											project_row_expr
-											'()
-											0
-											-1
-											true
-											(qb_stages block))))
-									(join_sorted_rows_late_projection_plan
-										(build_join_scan_rows_with_mapper
-											(qb_schema block)
-											scan_sources
-											prelimit_sources
-											first_alias
-											driver_needed_exprs
-											final_condition
-											(lower_join_driver_sort_row_assoc scan_sources first_alias (car scan_sources) driver_cols order_items)
-											'()
-											0
-											-1
-											true
-											(qb_stages block))
-										project_prepare_expr
-										project_rows_expr
-										fields
-										order_items
-										(qb_offset block)
-										(qb_limit block)))
-								(join_ordered_filtered_stream_plan
-									(qb_schema block)
-									scan_sources
-									first_alias
+				(define stage_catalog (query_block_stage_catalog block))
+				(define direct_order (and (equal? first_alias (source_alias (car scan_sources)))
+					(order_items_belong_to_source? (car scan_sources) order_items)))
+				(define direct_order_safe (and direct_order
+					(not (ordered_join_limit_requires_complete_rows? scan_sources first_alias final_condition (qb_offset block) (qb_limit block)))))
+				(define membership_candidate_sort_plan
+					(equal? (qassoc_get (qb_facts block) (quote membership_selectivity_class) nil) (quote selective)))
+				(define needed_exprs (merge (list
+					(extract_assoc fields (lambda (_title expr) expr))
+					(list final_condition)
+					(order_exprs order_items)
+					(source_join_exprs scan_sources))))
+				(define prelimit_sources (if (empty_list? scan_sources)
+					'()
+					(cons (car scan_sources)
+						(filter (cdr scan_sources) (lambda (src)
+							(expr_refs_alias? first_alias (source_alias src) final_condition))))))
+				(define late_projection_safe (late_projection_sources_preserve_rows? scan_sources prelimit_sources))
+				(if direct_order_safe
+					(build_join_scan_rows (qb_schema block) scan_sources first_alias needed_exprs final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
+					(if direct_order
+						(if (and membership_candidate_sort_plan late_projection_safe)
+							(begin
+								(define project_needed_exprs (merge (list
+									(extract_assoc fields (lambda (_title expr) expr))
+									(order_exprs order_items)
+									(source_join_exprs scan_sources))))
+								(define driver_needed_exprs (merge (list
+									(list final_condition)
+									(order_exprs order_items)
+									(map project_needed_exprs (lambda (expr)
+										(extract_columns_for_join_alias scan_sources first_alias first_alias expr))))))
+								(define driver_cols (join_cols_for_alias scan_sources first_alias first_alias project_needed_exprs))
+								(define prelimit_stage_ids (stage_ids_for_sources_with_closure stage_catalog prelimit_sources))
+								(define project_stages (filter (query_block_stages_to_prepare_base_using stage_catalog block) (lambda (stage)
+									(not (stage_id_in? stage prelimit_stage_ids)))))
+								(define project_prepare_expr (cons (quote !begin)
+									(map project_stages (lambda (stage)
+										(lower_stage_prepare_using stage_catalog stage)))))
+								(define project_row_expr
+									(lower_join_result_row_assoc scan_sources first_alias fields order_items))
+								(define project_rows_expr (replace_lowered_driver_symbols_with_row first_alias driver_cols
+									(build_join_scan_rows_with_mapper
+										(qb_schema block)
+										scan_sources
+										(cdr scan_sources)
+										first_alias
+										project_needed_exprs
+										true
+										project_row_expr
+										'()
+										0
+										-1
+										true
+										stage_catalog)))
+								(join_sorted_rows_late_projection_plan
+									(build_join_scan_rows_with_mapper
+										(qb_schema block)
+										scan_sources
+										prelimit_sources
+										first_alias
+										driver_needed_exprs
+										final_condition
+										(lower_join_driver_sort_row_assoc scan_sources first_alias (car scan_sources) driver_cols order_items)
+										'()
+										0
+										-1
+										true
+										stage_catalog)
+									project_prepare_expr
+									project_rows_expr
+									fields
+									order_items
+									(qb_offset block)
+									(qb_limit block)))
+							(join_ordered_filtered_stream_plan
+								(qb_schema block)
+								scan_sources
+								first_alias
 								needed_exprs
 								final_condition
 								fields
 								order_items
 								(qb_offset block)
 								(qb_limit block)
-								(qb_stages block)))
+								stage_catalog))
 						(join_sorted_rows_plan
 							(build_join_scan_rows_with_mapper
 								(qb_schema block)
@@ -8612,7 +8660,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 								0
 								-1
 								(not (ordered_join_limit_requires_complete_rows? scan_sources first_alias final_condition (qb_offset block) (qb_limit block)))
-								(qb_stages block))
+								stage_catalog)
 							fields
 							order_items
 							(qb_offset block)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6630,6 +6630,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(or found (equal? (source_alias src) (source_alias probe_src))))
 			false))))))
 
+(define stage_for_carrier_source (lambda (stages src)
+	(reduce (coalesceNil stages '()) (lambda (found stage)
+		(if (not (nil? found))
+			found
+			(if (and (group_stage? stage)
+				(and (equal? (group_stage_carrier_schema stage) (source_schema src))
+					(equal? (group_stage_carrier_relation stage) (source_relation src))))
+				stage
+				nil)))
+		nil)))
+
+(define carrier_stages_from_sources (lambda (stages sources)
+	(filter (map (coalesceNil sources '()) (lambda (src)
+		(stage_for_carrier_source stages src)))
+		(lambda (stage) (not (nil? stage))))))
+
 (define group_stage_nested_dependencies (lambda (stages stage)
 	(begin
 		(define input (gs_input stage))
@@ -6637,7 +6653,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(merge_unique (list
 				(qb_stages input)
 				(stage_outputs_from_sources_using stages (qb_sources input))))
-			'()))))
+			(if (source_is_base_table? input)
+				(begin
+					(define carrier_stage (stage_for_carrier_source stages input))
+					(if (nil? carrier_stage) '() (list carrier_stage)))
+				'())))))
 
 (define consumed_stage_closure (lambda (stages stage)
 	(begin
@@ -6647,6 +6667,46 @@ PostgreSQL parsers should both lower to the same combined operators.
 			direct
 			(merge (map direct (lambda (nested)
 				(consumed_stage_closure stages nested)))))))))
+
+(define stage_prepare_dependency_closure (lambda (stages stage)
+	(if (group_stage? stage)
+		(consumed_stage_closure stages stage)
+		(list stage))))
+
+(define stage_prepare_dependency_closure_all (lambda (stages selected)
+	(merge_unique (map (coalesceNil selected '()) (lambda (stage)
+		(stage_prepare_dependency_closure stages stage))))))
+
+(define expr_probe_stages (lambda (expr)
+	(match expr
+		((symbol scalar_first_probe) stage _requested_col)
+		(list stage)
+		((quote scalar_first_probe) stage _requested_col)
+		(list stage)
+		((symbol scalar_first_probe) stage _requested_col stages)
+		(merge_unique (list (list stage) stages))
+		((quote scalar_first_probe) stage _requested_col stages)
+		(merge_unique (list (list stage) stages))
+		((symbol scalar_aggregate_probe) stage _requested_col)
+		(list stage)
+		((quote scalar_aggregate_probe) stage _requested_col)
+		(list stage)
+		((symbol grouped_scalar_top) stage)
+		(list stage)
+		((quote grouped_scalar_top) stage)
+		(list stage)
+		(cons _head tail)
+		(merge_unique (map tail expr_probe_stages))
+		_ '())))
+
+(define query_block_probe_expr_stages (lambda (block)
+	(merge_unique (list
+		(expr_probe_stages (qb_sources block))
+		(expr_probe_stages (qb_fields block))
+		(expr_probe_stages (qb_where block))
+		(expr_probe_stages (qb_having block))
+		(expr_probe_stages (qb_order block))
+		(expr_probe_stages (qb_hidden block))))))
 
 (define scalar_first_probe_consumed_stages (lambda (stages stage)
 	(if (not (scalar_or_presence_probe_stage? stage))
@@ -6837,14 +6897,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(gs_offset stage)
 			'() '() '()))))
 
-(define group_stage_final_extra_sources_using (lambda (stages stage)
+(define group_stage_final_extra_source_refs (lambda (stage)
 	(begin
 		(define src (gs_input stage))
 		(if (query_block? src)
-			(physicalize_stage_output_sources stages
-				(filter (cdr (qb_sources src)) (lambda (extra)
-					(source_needed_after_group_stage? (group_stage_input_alias stage) stage extra))))
+			(filter (cdr (qb_sources src)) (lambda (extra)
+				(source_needed_after_group_stage? (group_stage_input_alias stage) stage extra)))
 			'()))))
+
+(define group_stage_final_extra_sources_using (lambda (stages stage)
+	(physicalize_stage_output_sources stages (group_stage_final_extra_source_refs stage))))
 
 (define group_stage_final_extra_sources (lambda (stage)
 	(group_stage_final_extra_sources_using (if (query_block? (gs_input stage)) (qb_stages (gs_input stage)) '()) stage)))
@@ -6925,11 +6987,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src)))
 				(query_block_without_stages_after_eager_prepare_using all_stages rewritten_src))
 			rewritten_src))
-			(define nested_stages (if (query_block? rewritten_src)
-				(merge_unique (list
-					(query_block_stages_to_prepare rewritten_src)
-					(stage_outputs_from_sources_using all_stages (qb_sources rewritten_src))))
-				'()))
+		(define direct_nested_stages (if (query_block? rewritten_src)
+			(merge_unique (list
+				(query_block_stages_to_prepare_using all_stages rewritten_src)
+				(stage_outputs_from_sources_using all_stages (qb_sources rewritten_src))
+				(stage_outputs_from_sources_using all_stages (group_stage_final_extra_source_refs stage))
+				(carrier_stages_from_sources all_stages (qb_sources rewritten_src))
+				(carrier_stages_from_sources all_stages (group_stage_final_extra_source_refs stage))
+				(query_block_probe_expr_stages rewritten_src)))
+			'()))
+		(define nested_stages direct_nested_stages)
 		(define nested_prepare (if (query_block? rewritten_src) (map nested_stages (lambda (nested_stage)
 			(lower_stage_prepare_using all_stages nested_stage))) '()))
 		(define nested_materialize (if (query_block? rewritten_src) (lower_stage_materialize_all nested_stages) '()))
@@ -7533,41 +7600,58 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(filter (cdr sources) (lambda (src)
 					(expr_refs_alias? first_alias (source_alias src) where_expr))))))))
 
-(define query_block_stages_to_prepare_base (lambda (block)
-		(begin
-			(define sources (qb_sources block))
-			(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
-			(define consumed_probe_ids (qassoc_get (qb_facts block) (quote consumed_presence_probe_stage_ids) '()))
-			(define stage_output_ids (stage_output_source_ids sources))
-			(filter
-				(if (single_source? sources)
-					(qb_stages block)
-				(filter (qb_stages block) (lambda (stage)
-					(not
-						(or
-							(row_number_stage_consumed_by_join? stage sources)
-							(stage_consumed_by_driver_order_membership_source? stage (qb_stages block) sources (qb_facts block))
-							(stage_consumed_by_probe_source? stage (qb_stages block) sources default_alias))))))
-				(lambda (stage)
-					(and
-						(not (contains? consumed_probe_ids (gs_id stage)))
-						(and
-							(not (scalar_first_inline_only_stage? stage))
-							(and
-								(not (scalar_first_probe_stage? stage))
-								(or
-									(not (scalar_aggregate_probe_stage? stage))
-									(contains? stage_output_ids (gs_id stage)))))))))))
+(define stage_direct_prepare_source_visible? (lambda (block sources default_alias stage)
+	(if (single_source? sources)
+		true
+		(not (or
+			(row_number_stage_consumed_by_join? stage sources)
+			(stage_consumed_by_driver_order_membership_source? stage (qb_stages block) sources (qb_facts block))
+			(stage_consumed_by_probe_source? stage (qb_stages block) sources default_alias))))))
 
-	(define query_block_stages_to_prepare (lambda (block)
-		(begin
-		(define prelimit_stage_ids (if (late_projection_candidate_block? block)
-			(stage_ids_for_sources_with_closure (qb_stages block) (query_block_prelimit_sources block))
-			nil))
-			(filter (query_block_stages_to_prepare_base block) (lambda (stage)
+(define stage_direct_prepare_semantic_candidate? (lambda (consumed_probe_ids stage_output_ids stage)
+	(and
+		(not (contains? consumed_probe_ids (gs_id stage)))
+		(and
+			(not (scalar_first_inline_only_stage? stage))
+			(and
+				(not (scalar_first_probe_stage? stage))
 				(or
-					(nil? prelimit_stage_ids)
-					(stage_id_in? stage prelimit_stage_ids)))))))
+					(not (scalar_aggregate_probe_stage? stage))
+					(contains? stage_output_ids (gs_id stage))))))))
+
+(define query_block_stages_to_prepare_base_using (lambda (all_stages block)
+	(begin
+		(define sources (qb_sources block))
+		(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
+		(define consumed_probe_ids (qassoc_get (qb_facts block) (quote consumed_presence_probe_stage_ids) '()))
+		(define stage_output_ids (stage_output_source_ids sources))
+		(define direct (filter (qb_stages block) (lambda (stage)
+			(and
+				(stage_direct_prepare_source_visible? block sources default_alias stage)
+				(stage_direct_prepare_semantic_candidate? consumed_probe_ids stage_output_ids stage)))))
+		(merge_unique (list
+			direct
+			(stage_prepare_dependency_closure_all all_stages
+				(merge_unique (list
+					(stage_outputs_from_sources_using all_stages sources)
+					(carrier_stages_from_sources all_stages sources)
+					(query_block_probe_expr_stages block)))))))))
+
+(define query_block_stages_to_prepare_base (lambda (block)
+	(query_block_stages_to_prepare_base_using (qb_stages block) block)))
+
+(define query_block_stages_to_prepare_using (lambda (all_stages block)
+	(begin
+		(define prelimit_stage_ids (if (late_projection_candidate_block? block)
+			(stage_ids_for_sources_with_closure all_stages (query_block_prelimit_sources block))
+			nil))
+		(filter (query_block_stages_to_prepare_base_using all_stages block) (lambda (stage)
+			(or
+				(nil? prelimit_stage_ids)
+				(stage_id_in? stage prelimit_stage_ids)))))))
+
+(define query_block_stages_to_prepare (lambda (block)
+	(query_block_stages_to_prepare_using (qb_stages block) block)))
 
 	(define lower_query_block_with_stages (lambda (block)
 	(if (empty_list? (qb_stages block))

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1380,6 +1380,91 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS in_ref_site"
   - sql: "DROP TABLE IF EXISTS in_ref_file"
   - sql: "DROP TABLE IF EXISTS in_ref_doc"
+
+  - name: "IN UNION with nested reference scalar prepares query carriers"
+    fail_comment: "nested stage-output carriers must be prepared before physical reads"
+    setup:
+      - sql: "DROP TABLE IF EXISTS in_stage_dep_doc"
+      - sql: "DROP TABLE IF EXISTS in_stage_dep_file"
+      - sql: "DROP TABLE IF EXISTS in_stage_dep_ref"
+      - sql: "DROP TABLE IF EXISTS in_stage_dep_tenant"
+      - sql: "DROP TABLE IF EXISTS in_stage_dep_acl"
+      - sql: |
+          CREATE TABLE in_stage_dep_file (
+            ID INT PRIMARY KEY,
+            filename VARCHAR(64),
+            search VARCHAR(64)
+          )
+      - sql: |
+          CREATE TABLE in_stage_dep_doc (
+            ID INT PRIMARY KEY,
+            file_id INT,
+            ref_id INT,
+            sort_key INT
+          )
+      - sql: |
+          CREATE TABLE in_stage_dep_ref (
+            ID INT PRIMARY KEY,
+            tenant INT,
+            label VARCHAR(64)
+          )
+      - sql: |
+          CREATE TABLE in_stage_dep_tenant (
+            ID INT PRIMARY KEY,
+            label VARCHAR(64)
+          )
+      - sql: |
+          CREATE TABLE in_stage_dep_acl (
+            ID INT PRIMARY KEY,
+            usr INT,
+            tenant INT
+          )
+      - sql: "INSERT INTO in_stage_dep_file (ID, filename, search) VALUES (10, 'hit-a', 'x'), (11, 'miss', 'needle-b'), (12, 'miss', 'x')"
+      - sql: "INSERT INTO in_stage_dep_doc (ID, file_id, ref_id, sort_key) VALUES (1, 10, 100, 2), (2, 11, 101, 1), (3, 12, 102, 3)"
+      - sql: "INSERT INTO in_stage_dep_ref (ID, tenant, label) VALUES (100, 7, 'a'), (101, 8, 'b'), (102, 9, 'c')"
+      - sql: "INSERT INTO in_stage_dep_tenant (ID, label) VALUES (7, 'tenant-a'), (8, 'tenant-b'), (9, 'tenant-c')"
+      - sql: "INSERT INTO in_stage_dep_acl (ID, usr, tenant) VALUES (1, 105, 7), (2, 105, 8)"
+    sql: |
+      SELECT t.ID, t.`ref:canView`
+      FROM (
+        SELECT d.ID, d.file_id, d.sort_key, `ref:r`.`ref:canView` AS `ref:canView`
+        FROM in_stage_dep_doc d
+        LEFT JOIN (
+          SELECT r.ID AS `ref:ID`,
+            COALESCE((
+              SELECT CASE WHEN EXISTS (
+                SELECT TRUE FROM in_stage_dep_acl a
+                WHERE a.usr = 999 AND a.tenant = m.ID
+                LIMIT 1
+              ) THEN TRUE ELSE FALSE END
+              FROM in_stage_dep_tenant m
+              WHERE m.ID = r.tenant
+              LIMIT 1
+            ), FALSE) AS `ref:canView`
+          FROM in_stage_dep_ref r
+        ) `ref:r` ON `ref:r`.`ref:ID` = d.ref_id
+      ) t
+      WHERE t.file_id IN (
+        SELECT f.ID FROM in_stage_dep_file f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.ID FROM in_stage_dep_file f WHERE f.search LIKE '%needle%'
+      )
+      ORDER BY t.sort_key
+      LIMIT 10
+    expect:
+      rows: 2
+      data:
+        - ID: 2
+          "ref:canView": false
+        - ID: 1
+          "ref:canView": false
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS in_stage_dep_acl"
+  - sql: "DROP TABLE IF EXISTS in_stage_dep_tenant"
+  - sql: "DROP TABLE IF EXISTS in_stage_dep_ref"
+  - sql: "DROP TABLE IF EXISTS in_stage_dep_file"
+  - sql: "DROP TABLE IF EXISTS in_stage_dep_doc"
   - sql: "DROP TABLE IF EXISTS in_nullable_rhs"
   - sql: "DROP TABLE IF EXISTS in_renderjob"
   - sql: "DROP TABLE IF EXISTS in_fop_files"


### PR DESCRIPTION
## Summary

This draft explored cost-based document-search lowering on top of the current operator/RecSet planner. After rebasing onto current `master` with the ordered IN-union RecSet lowering, the branch is **not mergeable**.

The remaining issue is not a minor performance variance: the production-derived document dataview query still fails in final `build_queryplan` on this branch with an unresolved logical stage-output reference during physicalization.

## Current validation

Local checks on the branch after the latest catalog investigation:

- `python3 tools/lint_scm.py --check --path lib/queryplan.scm`
- `make`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml` -> 44/44 passed
- `python3 run_sql_tests.py tests/32_expr_subselects.yaml` -> 43/43 passed
- `python3 run_sql_tests.py tests/119_badge_scalar_aggregates.yaml` -> passed in the earlier rebase validation
- `python3 run_sql_tests.py tests/123_recset.yaml` -> passed in the earlier rebase validation

These targeted tests are not sufficient for merge because the real dataview query still catches a nested stage-catalog/lowering bug that the synthetic tests do not cover.

## Benchmark status

Dataset: production-derived document dataview dataset, local only. PR text intentionally avoids customer/project names.

Current `master` already includes the ordered IN-union RecSet lowering from #293. That is the relevant baseline for this PR.

Local smoke control against current `master` / #293:

| query shape | status | runtime |
| --- | ---: | ---: |
| selective document-search term | 200 | 14.807s cold/single run |
| `EXPLAIN` same term | 200 | 15.08s |
| `EXPLAIN REORDER` same term | 200 | 11.41s |
| `EXPLAIN IR` same term | 200 | 0.77s |

Branch #305 after rebase and catalog fixes:

| query shape | status | runtime |
| --- | ---: | ---: |
| selective document-search term | 500 | fails after ~10.6s |
| `EXPLAIN` same term | 500 | fails after ~12.6s |
| `EXPLAIN REORDER` same term | 200 | ~11.2s |
| `EXPLAIN IR` same term | 200 | ~0.8s |

Failure:

```text
build_queryplan: physicalize stage-output source references unknown stage exists:c86b90081d3d9623 from source __exists_885192772e105435
```

This means the logical/reordered IR still contains the semantic information, but final physical lowering is using a shortened stage catalog in at least one nested grouped/scalar/reference path.

## Assessment

Do **not** merge this PR as a performance package.

Reasoning:

- It is not faster than current `master` / #293; it cannot execute the real benchmark query at all.
- The earlier runtime table in this PR body was stale and predates the #293 baseline.
- The branch demonstrates the right failure area: stage-output catalog lifetime across scalar/presence/grouped lowering. But the fix is incomplete and should not be mixed with performance claims.

Recommended next step: close or keep this PR as a draft investigation only, then start a smaller PR focused solely on the stage-catalog invariant: local `qb_stages` may be reduced for prepare selection, but physical source resolution must always have access to the full logical stage catalog. Add a synthetic regression that mirrors the nested reference/presence/scalar shape before trying cost-based performance changes again.
