### PR TITLE
Optimize scans with RecSet boundaries

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7776,7 +7776,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
 				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
-				(define mapcols (merge_unique (list filtercols fieldcols)))
+				(define mapcols fieldcols)
 				(define table_expr (if membership_filter
 					(source_table_expr src)
 					(coalesceNil membership_table_expr (source_table_expr src))))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3598,6 +3598,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define driver_order_membership_strategy? (lambda (facts)
 	(equal? (qassoc_get facts (quote membership_plan_strategy) nil) (quote driver_order_membership_probe))))
 
+(define broad_driver_order_membership_probe? (lambda (facts)
+	(begin
+		(define estimated_rows (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
+		(define estimate_input (qassoc_get facts (quote membership_candidate_estimate_input) nil))
+		(define capped (qassoc_get facts (quote membership_candidate_estimate_capped) false))
+		(define broad_by_count (and
+			(and (not (nil? estimated_rows)) (and (not (nil? estimate_input)) (> estimate_input 0)))
+			(>= (* estimated_rows 4) estimate_input)))
+		(and
+			(driver_order_membership_strategy? facts)
+			(or
+				capped
+				(or
+					broad_by_count
+					(equal? (qassoc_get facts (quote membership_selectivity_class) nil) (quote broad))))))))
+
 (define stage_consumed_by_driver_order_membership_source? (lambda (stage stages sources facts)
 	(if (not (driver_order_membership_strategy? facts))
 		false
@@ -7742,17 +7758,31 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
 				(define membership (driver_membership_for_source src condition))
 				(define membership_table_expr (if (nil? membership) nil (recset_project_join_expr_for_membership src membership)))
+				(define membership_filter (and
+					(not (nil? membership_table_expr))
+					(and scan_order_supported
+						(and bounded
+							(broad_driver_order_membership_probe? (qb_facts block))))))
 				(define effective_membership (if (nil? membership_table_expr) nil membership))
 				(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
-				(define filtercols (extract_columns_for_alias src effective_condition))
+				(define membership_var (symbol "__membership_recset"))
+				(define membership_filter_expr (if membership_filter
+					(recset_contains_call_expr membership_var)
+					true))
+				(define filter_condition (combine_where membership_filter_expr effective_condition))
+				(define filtercols (merge_unique (list
+					(if membership_filter (list "$recset_contains") '())
+					(extract_columns_for_alias src effective_condition))))
 				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
 				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
 				(define mapcols (merge_unique (list filtercols fieldcols)))
-				(define table_expr (coalesceNil membership_table_expr (source_table_expr src)))
+				(define table_expr (if membership_filter
+					(source_table_expr src)
+					(coalesceNil membership_table_expr (source_table_expr src))))
 				(define filter_expr (list (quote lambda)
-					(map filtercols (lambda (col) (symbol (concat alias "." col))))
-					(list (quote optimize) (lower_column_expr_for_alias src effective_condition))))
+					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+					(list (quote optimize) (lower_column_expr_for_alias src filter_condition))))
 				(define map_expr (list (quote lambda)
 					(map mapcols (lambda (col) (symbol (concat alias "." col))))
 					(list (quote resultrow)
@@ -7771,21 +7801,27 @@ PostgreSQL parsers should both lower to the same combined operators.
 						nil
 						(source_outer? src))
 					(if scan_order_supported
-						(list (quote scan_order)
-							'(session "__memcp_tx")
-							table_expr
-							(cons (quote list) filtercols)
-							filter_expr
-							(cons (quote list) ordercols)
-							(cons (quote list) (if (empty_list? order_items) '() (order_dirs order_items)))
-							0
-							(coalesceNil (qb_offset block) 0)
-							(coalesceNil (qb_limit block) -1)
-							(cons (quote list) mapcols)
-							map_expr
-							nil
-							nil
-							(source_outer? src))
+						(begin
+							(define scan_expr (list (quote scan_order)
+								'(session "__memcp_tx")
+								table_expr
+								(cons (quote list) filtercols)
+								filter_expr
+								(cons (quote list) ordercols)
+								(cons (quote list) (if (empty_list? order_items) '() (order_dirs order_items)))
+								0
+								(coalesceNil (qb_offset block) 0)
+								(coalesceNil (qb_limit block) -1)
+								(cons (quote list) mapcols)
+								map_expr
+								nil
+								nil
+								(source_outer? src)))
+							(if membership_filter
+								(list
+									(list (quote lambda) (list membership_var) scan_expr)
+									membership_table_expr)
+								scan_expr))
 						(join_sorted_rows_plan
 							(build_join_scan_rows_with_mapper
 								(qb_schema block)

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -735,12 +735,18 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	}
 	cols := traverseCondition(p.Body)
 
-	// Sort columns: point-like (equal + like) first, then range, alphabetically within
-	// each group. LIKE columns are treated as point-like because the index sort treats
-	// them like any other column; the LIKE pattern is a query-level overlay that filters
-	// via rowWithinBounds, not via sort order. The binary search skips LIKE columns.
+	// Keep transient RecSet boundaries in a prefix so scans can remove them by
+	// slicing. Sort real columns point-like (equal + like) first, then range,
+	// alphabetically within each group. LIKE columns are treated as point-like because
+	// the index sort treats them like any other column; the LIKE pattern is a query-level
+	// overlay that filters via rowWithinBounds, not via sort order.
 	if len(cols) > 1 {
 		hybridsort.Slice(cols, func(i, j int) bool {
+			iRecSet := matcherKindEqual(cols[i].matcher, RecSetMatcher)
+			jRecSet := matcherKindEqual(cols[j].matcher, RecSetMatcher)
+			if iRecSet != jRecSet {
+				return iRecSet
+			}
 			iPoint := boundaryIsPoint(cols[i])
 			jPoint := boundaryIsPoint(cols[j])
 			if iPoint != jPoint {
@@ -751,6 +757,21 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	}
 
 	return cols
+}
+
+func splitRecSetBoundary(b boundaries, carrier *table) (boundaries, *recSet) {
+	var rs *recSet
+	prefixLen := 0
+	for prefixLen < len(b) && matcherKindEqual(b[prefixLen].matcher, RecSetMatcher) {
+		if rs == nil && b[prefixLen].lower.IsCustom(TagRecSet) {
+			candidate := RecSetFromScmer(b[prefixLen].lower)
+			if candidate != nil && candidate.table == carrier {
+				rs = candidate
+			}
+		}
+		prefixLen++
+	}
+	return b[prefixLen:], rs
 }
 
 func hasBatchBoundaries(bounds boundaries) bool {

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -107,13 +107,14 @@ func (s *SkipList) ComputeSize() uint {
 //   - VectorDistanceMatcher: IsSorted=false, ORDER BY vector_distance(col, query)
 //     (query varies per query → cluster-based SkipList, not sort-order based)
 var (
-	EqualMatcher BoundaryMatcher = &equalMatcher{}
-	RangeMatcher BoundaryMatcher = &rangeMatcher{}
-	LikeMatcher  BoundaryMatcher = &likeMatcher{}
+	EqualMatcher  BoundaryMatcher = &equalMatcher{}
+	RangeMatcher  BoundaryMatcher = &rangeMatcher{}
+	LikeMatcher   BoundaryMatcher = &likeMatcher{}
+	RecSetMatcher BoundaryMatcher = &recSetMatcher{}
 )
 
 // boundaryMatchers lists all known matcher types.
-var boundaryMatchers = []BoundaryMatcher{EqualMatcher, RangeMatcher, LikeMatcher}
+var boundaryMatchers = []BoundaryMatcher{EqualMatcher, RangeMatcher, LikeMatcher, RecSetMatcher}
 
 // --- Equal ---
 
@@ -214,6 +215,17 @@ func (m *likeMatcher) BuildSkipList(pattern string, count uint32, getRecid func(
 	return sl
 }
 
+// --- RecSet ---
+
+type recSetMatcher struct{}
+
+func (m *recSetMatcher) Kind() string      { return "recset" }
+func (m *recSetMatcher) IsSorted() bool    { return false }
+func (m *recSetMatcher) IsPointLike() bool { return true }
+func (m *recSetMatcher) BuildSkipList(_ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
+	return nil
+}
+
 type columnboundaries struct {
 	col              string
 	matcher          BoundaryMatcher // always set: EqualMatcher, RangeMatcher, LikeMatcher, ...
@@ -249,6 +261,9 @@ func boundaryIsPoint(b columnboundaries) bool {
 func addConstraint(in boundaries, b2 columnboundaries) boundaries {
 	for i, b := range in {
 		if b.col == b2.col {
+			if matcherKindEqual(b.matcher, RecSetMatcher) || matcherKindEqual(b2.matcher, RecSetMatcher) {
+				return in
+			}
 			// matcher promotion: more selective matcher wins (equal > like > range)
 			if b2.matcher.IsPointLike() && !b.matcher.IsPointLike() {
 				in[i].matcher = b2.matcher
@@ -386,12 +401,12 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	}
 	// analyze condition for AND clauses, equal? < > <= >= BETWEEN
 	extractConstant := func(v scm.Scmer) (scm.Scmer, bool) {
-		if v.IsInt() || v.IsFloat() || v.IsString() || v.IsBool() {
+		if v.IsInt() || v.IsFloat() || v.IsString() || v.IsBool() || v.IsCustom(TagRecSet) {
 			return v, true
 		}
 		if v.IsSymbol() {
 			if val2, ok := p.En.Vars[scm.Symbol(v.String())]; ok {
-				if val2.IsInt() || val2.IsFloat() || val2.IsString() {
+				if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
 					return val2, true
 				}
 			}
@@ -402,7 +417,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				if val[1].IsSymbol() {
 					sym := scm.Symbol(val[1].String())
 					if val2, ok := p.En.Vars[sym]; ok {
-						if val2.IsInt() || val2.IsFloat() || val2.IsString() {
+						if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
 							return val2, true
 						}
 					}
@@ -411,7 +426,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 					idx := int(val[1].NthLocalVar())
 					if p.En.VarsNumbered != nil && idx < len(p.En.VarsNumbered) {
 						val2 := p.En.VarsNumbered[idx]
-						if val2.IsInt() || val2.IsFloat() || val2.IsString() {
+						if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
 							return val2, true
 						}
 					}
@@ -420,7 +435,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		}
 		if isIndependent(params, v) {
 			if val2, ok := evalIndependentScmer(v, p.En); ok {
-				if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsBool() || val2.IsNil() {
+				if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsBool() || val2.IsNil() || val2.IsCustom(TagRecSet) {
 					return val2, true
 				}
 			}
@@ -450,6 +465,11 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		}
 		if funcIs(v[0], "optimize") && len(v) == 2 {
 			return traverseCondition(v[1])
+		}
+		if col, ok := resolveParamName(v[0]); ok && col == "$recset_contains" && len(v) == 2 {
+			if rs, ok := extractConstant(v[1]); ok && rs.IsCustom(TagRecSet) {
+				return boundaries{columnboundaries{col: col, matcher: RecSetMatcher, lower: rs, lowerInclusive: true, upper: rs, upperInclusive: true}}
+			}
 		}
 		if funcIs(v[0], "equal?") || funcIs(v[0], "equal??") {
 			if col, ok := resolveColVar(v[1]); ok {
@@ -690,6 +710,11 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				} else {
 					result = widenBounds(result, child)
 					if len(result) == 0 {
+						return nil
+					}
+				}
+				for _, cb := range result {
+					if matcherKindEqual(cb.matcher, RecSetMatcher) {
 						return nil
 					}
 				}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -155,6 +155,13 @@ func recSetContainsClosure(shard *storageShard) *func(uint32, ...scm.Scmer) scm.
 	return &fn
 }
 
+func recSetAlreadyMatchedClosure() *func(uint32, ...scm.Scmer) scm.Scmer {
+	fn := func(_ uint32, _ ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(true)
+	}
+	return &fn
+}
+
 type recSetBuildResult struct {
 	part recSetShard
 	err  scanError

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -188,6 +188,7 @@ func (t *table) recSetShardResultBufferSize() int {
 func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
 	ss := SessionStateFromTx(currentTx)
 	boundaries := extractBoundaries(conditionCols, condition)
+	boundaries, recsetFilter := splitRecSetBoundary(boundaries, t)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
 	result := &recSet{tx: currentTx, table: t}
@@ -204,7 +205,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 				panic("query killed")
 			}
 			values <- recSetBuildResult{
-				part: shard.collectRecSet(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss),
+				part: shard.collectRecSet(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, recsetFilter),
 			}
 			return scm.NewNil()
 		})
@@ -238,11 +239,19 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	return result
 }
 
-func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) recSetShard {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwner()
 	t.ensureMainCount(skipShardReadLock)
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			return recSetShard{shard: t}
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
@@ -251,6 +260,9 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	for i, k := range conditionCols {
 		if k == "$recset_contains" {
 			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
 			getter := func(id uint32, batchid uint32) scm.Scmer {
 				return scm.NewClosure(fnptr, id)
 			}
@@ -290,6 +302,9 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	var buf [1024]uint32
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 		for _, idx := range batch {
+			if recsetPart != nil && !recsetPart.contains(idx) {
+				continue
+			}
 			if idx >= visibleUpper {
 				continue
 			}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -263,6 +263,7 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 	}
 	touchTempColumns(t, conditionCols, nil)
 	boundaries := extractBoundaries(conditionCols, condition)
+	boundaries, recsetFilter := splitRecSetBoundary(boundaries, t)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
 	for _, b := range boundaries {
@@ -281,7 +282,7 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
 		}()
-		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found) {
+		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found, recsetFilter) {
 			found.Store(true)
 			values <- scanResult{outCount: 1}
 			return
@@ -347,6 +348,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	analyzeStart := time.Now()
 	/* analyze query */
 	boundaries := extractBoundaries(conditionCols, condition)
+	boundaries, recsetFilter := splitRecSetBoundary(boundaries, t)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
 	if Settings.ScanDebugging {
@@ -379,7 +381,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}
-		res, cnt := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss)
+		res, cnt := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
 		values <- scanResult{res: res, outCount: cnt, inputCount: int64(s.Count())}
 	})
 	if done == nil {
@@ -485,7 +487,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	return akkumulator
 }
 
-func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
+func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool, recsetFilter *recSet) bool {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -494,11 +496,30 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwner()
 	t.ensureMainCount(skipShardReadLock)
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			return false
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
 	cNeedsTxReader := make([]bool, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
+			conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			continue
+		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
@@ -540,6 +561,9 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 			panic("query killed")
 		}
 		for _, idx := range batch {
+			if recsetPart != nil && !recsetPart.contains(idx) {
+				continue
+			}
 			if idx >= visibleUpper {
 				continue
 			}
@@ -552,7 +576,9 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 			}
 			if idx < mainCount {
 				for i, c := range cReaders {
-					if cNeedsTxReader[i] {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
 						cdataset[i] = c.GetValue(idx)
 					} else {
 						cdataset[i] = ccols[i].GetValue(idx)
@@ -560,7 +586,9 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 				}
 			} else {
 				for i, col := range conditionCols {
-					if cNeedsTxReader[i] {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
 						cdataset[i] = cReaders[i].GetValue(idx)
 					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 						cdataset[i] = ccols[i].GetValue(idx)
@@ -580,9 +608,9 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	return found
 }
 
-func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
+func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64) {
 	if stride > 0 {
-		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss)
+		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
 	}
 	akkumulator := neutral
 	var outCount int64
@@ -634,6 +662,14 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
 	t.ensureMainCount(skipShardReadLock)
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			return neutral, 0
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 
 	// condition column readers
 	ccols := make([]ColumnStorage, len(conditionCols))
@@ -643,6 +679,9 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	for i, k := range conditionCols {
 		if k == "$recset_contains" {
 			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
 			getter := func(id uint32, batchid uint32) scm.Scmer {
 				return scm.NewClosure(fnptr, id)
 			}
@@ -699,6 +738,9 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		outN := 0
 		for _, idx := range batch {
 			effectiveIdx := idx
+			if recsetPart != nil && !recsetPart.contains(effectiveIdx) {
+				continue
+			}
 			if effectiveIdx >= visibleUpper {
 				continue
 			}
@@ -828,7 +870,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	return akkumulator, outCount
 }
 
-func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
+func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64) {
 	akkumulator := neutral
 	var outCount int64
 	if ss == nil {
@@ -872,12 +914,31 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
 	t.ensureMainCount(skipShardReadLock)
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			return neutral, 0
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
 	cNeedsTxReader := make([]bool, len(conditionCols))
 	conditionBatchSubidx := make([]int, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
+		if k == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
+			conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			continue
+		}
 		if subidx, ok := parseBatchPseudoColName(k); ok {
 			conditionBatchSubidx[i] = subidx + 1
 			continue
@@ -944,6 +1005,9 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 			outN := 0
 			for _, idx := range batch {
 				effectiveIdx := idx
+				if recsetPart != nil && !recsetPart.contains(effectiveIdx) {
+					continue
+				}
 				if effectiveIdx >= visibleUpper {
 					continue
 				}
@@ -973,6 +1037,8 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 					for i, k := range ccols {
 						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
 							cdataset[i] = batchdata[batchid*stride+subidx]
+						} else if getter := conditionGetters[i]; getter != nil {
+							cdataset[i] = getter(effectiveIdx, uint32(batchid))
 						} else if cNeedsTxReader[i] {
 							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 						} else {
@@ -983,6 +1049,8 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 					for i, k := range conditionCols {
 						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
 							cdataset[i] = batchdata[batchid*stride+subidx]
+						} else if getter := conditionGetters[i]; getter != nil {
+							cdataset[i] = getter(effectiveIdx, uint32(batchid))
 						} else if cNeedsTxReader[i] {
 							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -397,28 +397,6 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 	return b, addedSortCols > 0
 }
 
-func splitRecSetBoundary(b boundaries, carrier *table) (boundaries, *recSet) {
-	if len(b) == 0 {
-		return b, nil
-	}
-	write := 0
-	var rs *recSet
-	for i := range b {
-		if matcherKindEqual(b[i].matcher, RecSetMatcher) {
-			if rs == nil && b[i].lower.IsCustom(TagRecSet) {
-				candidate := RecSetFromScmer(b[i].lower)
-				if candidate != nil && candidate.table == carrier {
-					rs = candidate
-				}
-			}
-			continue
-		}
-		b[write] = b[i]
-		write++
-	}
-	return b[:write], rs
-}
-
 func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 	var p scm.Proc
 	if condition.IsProc() {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -300,10 +300,7 @@ func (s *scanOrderTableSpec) carrierTable() *table {
 // existing filter boundaries are point lookups and the comparators are
 // index-order compatible (ASC). This lets the shard return rows already sorted
 // by ORDER BY, reducing the cross-shard merge to merging pre-sorted runs.
-func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) boundaries {
-	if len(b) == 0 {
-		return b
-	}
+func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) (boundaries, bool) {
 	allEq := true
 	for _, bi := range b {
 		if !boundaryIsPoint(bi) {
@@ -335,8 +332,9 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 		}
 	}
 	if !allEq || !canAppendSortPrefix {
-		return b
+		return b, false
 	}
+	addedSortCols := 0
 	for _, scol := range sortcols {
 		if scol.IsString() {
 			col := scol.String()
@@ -349,6 +347,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 			}
 			if !already {
 				b = append(b, columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil()})
+				addedSortCols++
 			}
 			continue
 		}
@@ -392,9 +391,81 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 		}
 		if !already {
 			b = append(b, columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), mapCols: mc, mapFn: mf})
+			addedSortCols++
 		}
 	}
-	return b
+	return b, addedSortCols > 0
+}
+
+func splitRecSetBoundary(b boundaries, carrier *table) (boundaries, *recSet) {
+	if len(b) == 0 {
+		return b, nil
+	}
+	write := 0
+	var rs *recSet
+	for i := range b {
+		if matcherKindEqual(b[i].matcher, RecSetMatcher) {
+			if rs == nil && b[i].lower.IsCustom(TagRecSet) {
+				candidate := RecSetFromScmer(b[i].lower)
+				if candidate != nil && candidate.table == carrier {
+					rs = candidate
+				}
+			}
+			continue
+		}
+		b[write] = b[i]
+		write++
+	}
+	return b[:write], rs
+}
+
+func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
+	var p scm.Proc
+	if condition.IsProc() {
+		p = *condition.Proc()
+	} else if si, ok := condition.Any().(scm.Proc); ok {
+		p = si
+	} else {
+		return 0
+	}
+	var params []scm.Scmer
+	if p.Params.IsSlice() {
+		params = p.Params.Slice()
+	}
+	paramIsRecSetContains := func(node scm.Scmer) bool {
+		if node.IsSymbol() {
+			name := node.String()
+			for i, sym := range params {
+				if i < len(conditionCols) && sym.IsSymbol() && sym.String() == name {
+					return conditionCols[i] == "$recset_contains"
+				}
+			}
+		}
+		if node.IsNthLocalVar() {
+			idx := int(node.NthLocalVar())
+			return idx < len(conditionCols) && conditionCols[idx] == "$recset_contains"
+		}
+		return false
+	}
+	var walk func(scm.Scmer) int
+	walk = func(node scm.Scmer) int {
+		if !node.IsSlice() {
+			return 0
+		}
+		items := node.Slice()
+		if len(items) == 0 {
+			return 0
+		}
+		count := 0
+		if paramIsRecSetContains(items[0]) {
+			count++
+		}
+		for _, item := range items[1:] {
+			count += walk(item)
+		}
+		return count
+	}
+	return walk(p.Body)
 }
 
 // scanOrderMulti performs an ordered scan across one or more tables, merging
@@ -442,8 +513,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		// Boundary analysis per table
 		analyzeStart := time.Now()
 		bounds := extractBoundaries(spec.conditionCols, spec.condition)
+		bounds, recsetBoundary := splitRecSetBoundary(bounds, t)
 		reorderByFrequency(bounds, t)
-		bounds = extendBoundariesWithSortCols(bounds, spec.sortcols, sortdirs)
+		bounds, indexCoversOrder := extendBoundariesWithSortCols(bounds, spec.sortcols, sortdirs)
 		lower, upperLast := indexFromBoundaries(bounds)
 
 		if Settings.ScanDebugging {
@@ -469,6 +541,8 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		tableBounds := bounds
 		tableIdx := ti
 		shardLimit := shardTotalLimit
+		orderedEarlyLimit := indexCoversOrder && shardLimit >= 0 && limitPartitionCols == 0
+		recsetFilter := recsetBoundary
 
 		if spec.recset != nil {
 			if len(sortcols) > 0 {
@@ -542,7 +616,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 						q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 					}
 				}()
-				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, orderedEarlyLimit, recsetFilter)
 				res.callbackCols = callbackCols
 				res.callback = callback
 				res.tableIdx = tableIdx
@@ -820,12 +894,21 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
+func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, orderedEarlyLimit bool, recsetFilter *recSet) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			result.items = nil
+			return
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 	defaultSortDir := func(args ...scm.Scmer) scm.Scmer {
 		if len(args) < 2 {
 			return scm.NewBool(false)
@@ -962,6 +1045,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	for i, k := range conditionCols { // iterate over columns
 		if k == "$recset_contains" {
 			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
 			getter := func(id uint32, batchid uint32) scm.Scmer {
 				return scm.NewClosure(fnptr, id)
 			}
@@ -1013,6 +1099,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			// filter in-place: overwrite batch with passing IDs
 			outN := 0
 			for _, idx := range batch {
+				if recsetPart != nil && !recsetPart.contains(idx) {
+					continue
+				}
 				if idx >= visibleUpper {
 					continue
 				}
@@ -1068,6 +1157,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			}
 			copy(result.items[resultN:], batch[:outN])
 			resultN += outN
+			if orderedEarlyLimit && resultN >= limit {
+				return false
+			}
 			return true
 		})
 		result.items = result.items[:resultN]

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2244,7 +2244,28 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
 	cNeedsTxReader := make([]bool, len(conditionCols))
+	conditionGetters := make([]mapArgGetter, len(conditionCols))
+	bounds := extractBoundaries(conditionCols, condition)
+	bounds, recsetFilter := splitRecSetBoundary(bounds, t.t)
+	var recsetPart *recSetShard
+	if recsetFilter != nil {
+		recsetPart = recsetFilter.shardEntry(t)
+		if recsetPart == nil || recsetPart.count == 0 {
+			return 0, false
+		}
+	}
+	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
 	for i, col := range conditionCols {
+		if col == "$recset_contains" {
+			fnptr := recSetContainsClosure(t)
+			if recsetBoundaryCoversCondition {
+				fnptr = recSetAlreadyMatchedClosure()
+			}
+			conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
+				return scm.NewClosure(fnptr, id)
+			}
+			continue
+		}
 		ccols[i] = t.getColumnStorageOrPanic(col)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
@@ -2252,7 +2273,6 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		}
 	}
 
-	bounds := extractBoundaries(conditionCols, condition)
 	lower, upperLast := indexFromBoundaries(bounds)
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 
@@ -2268,6 +2288,9 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	var buf [256]uint32
 	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], false, func(batch []uint32) bool {
 		for _, idx := range batch {
+			if recsetPart != nil && !recsetPart.contains(idx) {
+				continue
+			}
 			if acidMode {
 				if !currentTx.IsVisible(t, idx) {
 					continue
@@ -2277,7 +2300,9 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 			}
 			if idx < mainCount {
 				for i, c := range ccols {
-					if cNeedsTxReader[i] {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
 						cdataset[i] = cReaders[i].GetValue(idx)
 					} else {
 						cdataset[i] = c.GetValue(idx)
@@ -2285,7 +2310,9 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 				}
 			} else {
 				for i, col := range conditionCols {
-					if cNeedsTxReader[i] {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else if cNeedsTxReader[i] {
 						cdataset[i] = cReaders[i].GetValue(idx)
 					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 						cdataset[i] = ccols[i].GetValue(idx)

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -234,6 +234,57 @@ test_cases:
           "ok"
           (error "scan_exists over recset returned wrong result")))
 
+  - name: "scan_exists uses recset membership on base table"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (if (and
+              (scan_exists nil tbl
+                '("$recset_contains" "id")
+                (lambda (in_recset id) (and (in_recset tenant1) (equal? id 5))))
+              (not (scan_exists nil tbl
+                '("$recset_contains" "id")
+                (lambda (in_recset id) (and (in_recset tenant1) (equal? id 3))))))
+          "ok"
+          (error "scan_exists recset membership returned wrong result")))
+
+  - name: "scan_recset intersects recset membership before reading columns"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define active_tenant1 (scan_recset nil tbl
+          '("$recset_contains" "active")
+          (lambda (in_recset active) (and (in_recset tenant1) (equal? active 1)))))
+        (if (equal? (recset_count active_tenant1) 2)
+          "ok"
+          (error "scan_recset membership intersection returned wrong cardinality")))
+
+  - name: "scan_batch applies recset membership to every lookup batch"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define sum_ids (scan_batch nil tbl
+          '("$recset_contains" "id" "#0")
+          (lambda (in_recset id wanted_id)
+            (and (in_recset tenant1) (equal? id wanted_id)))
+          '("id")
+          (lambda (id) id)
+          1 (list 1 3 5)
+          (lambda (acc id) (+ acc id))
+          0))
+        (if (equal? sum_ids 6)
+          "ok"
+          (error "scan_batch recset membership returned wrong rows")))
+
   - name: "scan_order accepts recset as table-like source"
     scm: |
       (begin

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -167,6 +167,56 @@ test_cases:
           "ok"
           (error "scan_order $recset_contains returned wrong order")))
 
+  - name: "scan_order keeps repeated $recset_contains calls exact"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define active (scan_recset nil tbl
+          '("active")
+          (lambda (active) (equal? active 1))))
+        (define ordered
+          (scan_order nil tbl
+            '("$recset_contains")
+            (lambda (in_recset) (and (in_recset tenant1) (in_recset active)))
+            '("id") '(<)
+            0 0 10
+            '("id")
+            (lambda (id) (list id))
+            (lambda (acc row) (append acc row))
+            '()
+            false))
+        (if (equal? ordered (list (list 1) (list 5)))
+          "ok"
+          (error "scan_order repeated $recset_contains calls lost a predicate")))
+
+  - name: "scan_order keeps $recset_contains OR semantics exact"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_items"))
+        (define tenant1 (scan_recset nil tbl
+          '("tenant")
+          (lambda (tenant) (equal? tenant 1))))
+        (define active (scan_recset nil tbl
+          '("active")
+          (lambda (active) (equal? active 1))))
+        (define ordered
+          (scan_order nil tbl
+            '("$recset_contains")
+            (lambda (in_recset) (or (in_recset tenant1) (in_recset active)))
+            '("id") '(<)
+            0 0 10
+            '("id")
+            (lambda (id) (list id))
+            (lambda (acc row) (append acc row))
+            '()
+            false))
+        (if (equal? ordered (list (list 1) (list 2) (list 3) (list 5)))
+          "ok"
+          (error "scan_order $recset_contains OR semantics changed")))
+
   - name: "scan_exists accepts recset as table-like source"
     scm: |
       (begin

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -545,6 +545,26 @@ test_cases:
             - "__union_distinct_seen"
       - sql: |
           EXPLAIN
+          SELECT d.ID
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+          ORDER BY d.sort_key
+          LIMIT 2
+        expect:
+          contains:
+            - "recset_project_join"
+            - "$recset_contains"
+            - "in_dv_doc"
+          not_contains:
+            - "touch_keytable"
+            - "__union_distinct_rows"
+            - "__union_distinct_seen"
+      - sql: |
+          EXPLAIN
           SELECT t.ID
           FROM (
             SELECT d.ID, d.file_id, d.tenant, d.sort_key


### PR DESCRIPTION
## Summary

This PR makes query-local RecSet membership a shared physical scan boundary and adds a cost-based lowering guard for broad ordered membership. Selective membership can use the RecSet as driver; broad `ORDER BY ... LIMIT` membership keeps the ordered driver and probes the once-built RecSet.

The change stays behind the logical/physical boundary from `INVARIANTS.md`: logical IR remains `query-block` / `group-stage` / `union-block`, and RecSets are selected only in `build_queryplan`.

## What changed

- Recognize `$recset_contains` as a transient boundary and sort these boundaries to the front.
- Remove the RecSet prefix by slicing, without allocation or copying.
- Apply the candidate filter shard-locally before reading row columns in `scan`, `scan_batch`, `scan_exists`, `scan_recset`, `scan_order`, and selectivity sampling.
- Preserve the callback as semantic fallback for repeated calls, OR expressions, and table mismatches.
- Avoid rereading filter-only columns in the map phase of single-source query blocks.
- Keep an ordered driver for broad membership estimates (sampling cap or estimated membership >=25% of driver rows).
- Cover normal, ordered, batched, existence, nested RecSet, repeated-call, OR, and table-mismatch behavior in YAML.

## A/B: physical operator

Same anonymized synthetic data, 200k driver rows, 200 RecSet hits, `ORDER BY ... LIMIT 25`, 15 samples after warmup. Values are only the ordered scan phase:

| Variant | Commit | Range | Result |
| --- | --- | ---: | --- |
| master | `a3dfd5b2b` | 10.8-22.0 ms | baseline |
| branch | `137347f6a` | 6.3-11.0 ms | about 2x faster |

Including one-off RecSet construction was slower in this isolated synthetic shape (304.9 ms master vs 345.8 ms branch), which is why the planner guard is necessary: the primitive pays off when a constant RecSet replaces repeated inner work, not when construction dominates a one-shot scan.

## A/B: synthetic SQL lowering

30k candidate rows, 120k driver rows, `IN (SELECT ... UNION SELECT ...)`, `ORDER BY ... LIMIT 25`, five warm executions:

| Shape | master `3117f850f` | branch `94a90b80a` | Result |
| --- | ---: | ---: | --- |
| broad membership | 486.6-522.2 ms | 447.3-523.9 ms | small/noisy improvement |
| selective membership | 40.4-47.1 ms | 39.5-46.3 ms | neutral |

## A/B: real Dataview full-text cascade

The unmodified private Dataview query and a private production-shaped snapshot were used locally; neither is part of this PR. Both binaries used the same snapshot source, session variables, result limit, and eleven successively longer search prefixes. Both returned the same empty result for the measured ACL context and completed without SQL errors.

First invocation on separate fresh snapshot copies, including plan compilation, storage loading, and index/cache warmup:

| Prefix length | master `3117f850f` | branch `372594a43` | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 29.47 s | 23.80 s | -19.3% |
| 2 | 24.53 s | 14.43 s | -41.2% |
| 3 | 6.68 s | 6.30 s | -5.8% |
| 4 | 6.61 s | 6.41 s | -3.0% |
| 5 | 6.72 s | 6.39 s | -4.9% |
| 6 | 6.68 s | 6.18 s | -7.4% |
| 7 | 6.75 s | 6.20 s | -8.1% |
| 8 | 8.71 s | 6.25 s | -28.2% |
| 9 | 5.46 s | 4.93 s | -9.7% |
| 10 | 5.41 s | 5.00 s | -7.6% |
| 11 | 5.34 s | 4.96 s | -7.1% |

Warm execution median from two complete process runs:

| Prefix length | master | branch | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 11.97 s | 12.04 s | +0.5% |
| 2 | 3.77 s | 3.77 s | -0.1% |
| 3 | 2.92 s | 2.96 s | +1.4% |
| 4 | 2.89 s | 2.88 s | -0.3% |
| 5 | 2.88 s | 2.87 s | -0.5% |
| 6 | 2.88 s | 2.86 s | -0.6% |
| 7 | 2.95 s | 2.90 s | -1.7% |
| 8 | 3.00 s | 2.87 s | -4.1% |
| 9 | 1.82 s | 1.69 s | -7.4% |
| 10 | 1.79 s | 1.66 s | -7.7% |
| 11 | 1.70 s | 1.65 s | -2.8% |

Interpretation: the branch materially reduces first-run work and improves selective warm searches. Broad and medium warm searches are neutral within run-to-run noise; this PR does not yet solve their remaining 3-12 s hot path. The next cost-model step is ordered index/RecSet intersection so the driver can skip RecID ranges instead of probing every ordered row.

`EXPLAIN REORDER` remained stable at roughly 0.75-0.98 s on both variants, so these changes affect physical execution rather than logical compile time.

## Validation

- `make`
- `tests/123_recset.yaml`: 19/19
- `tests/41_in_subquery.yaml`: 44/44
- `tests/87_scan_batch_optimizer.yaml`: 9/9
- `tests/54_transactions.yaml`: 171/171
- range scan and ORDER/LIMIT suites passed
- full hook-equivalent run processed all suites and shut down cleanly; two parallel runner processes remained asleep in the harness and were stopped
- isolated reruns: `tests/73_window_functions.yaml` 38/38, `tests/74_csv_json_import.yaml` 36/36
- `python3 tools/lint_scm.py --check` reports only the repository's existing formatter/depth warning block