### PR TITLE
Fix bounded query-backed scalar probes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6548,7 +6548,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define rows (probe_context_row_count sources))
 		(or (nil? rows) (< rows 1000)))))
 
-(define scalar_aggregate_probe_limit_small_enough? (lambda (limit_value)
+(define probe_limit_small_enough? (lambda (limit_value)
 	(and (number? limit_value)
 		(and (> limit_value 0)
 			(<= limit_value 512)))))
@@ -6581,11 +6581,13 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(probe_context_small_enough? sources)
 					true))))))
 
-(define probeable_stage_output_source_for_block? (lambda (stages sources default_alias src)
+(define probeable_stage_output_source_for_block? (lambda (stages sources default_alias limit_value src)
 	(if (scalar_first_stage_output_source? stages src)
-		(stage_probe_allowed_in_context?
-			(stage_by_id stages (stage_output_relation_id (source_relation src)))
-			(filter sources (lambda (candidate) (not (equal? (source_alias candidate) (source_alias src))))))
+		(or
+			(probe_limit_small_enough? limit_value)
+			(stage_probe_allowed_in_context?
+				(stage_by_id stages (stage_output_relation_id (source_relation src)))
+				(filter sources (lambda (candidate) (not (equal? (source_alias candidate) (source_alias src)))))))
 		(if (not (presence_stage_output_source? stages src))
 			false
 			(begin
@@ -6612,14 +6614,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(scalar_aggregate_probe_stage_safe? stage)
 				(and
 					(or
-						(scalar_aggregate_probe_limit_small_enough? limit_value)
+						(probe_limit_small_enough? limit_value)
 						(probe_context_small_enough? probe_sources))
 					(stage_lookup_keys_resolve_in_sources? stage probe_sources default_alias)))))))
 
 (define probe_output_sources_for_block (lambda (stages sources default_alias limit_value)
 	(filter (coalesceNil sources '()) (lambda (src)
 		(or
-			(probeable_stage_output_source_for_block? stages sources default_alias src)
+			(probeable_stage_output_source_for_block? stages sources default_alias limit_value src)
 			(scalar_aggregate_probe_output_source_for_block? stages sources default_alias limit_value src))))))
 
 (define sources_without_probe_outputs (lambda (sources probe_sources)
@@ -7519,14 +7521,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 				false))
 		_ false)))
 
-(define stage_consumed_by_probe_source? (lambda (stage stages sources default_alias)
+(define stage_consumed_by_probe_source? (lambda (stage stages sources default_alias limit_value)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(or found
 			(and (stage_output_relation? (source_relation src))
 				(and (equal? (stage_output_relation_id (source_relation src)) (gs_id stage))
 					(and
 						(probeable_stage_output_source? stages src)
-						(probeable_stage_output_source_for_block? stages sources default_alias src))))))
+						(probeable_stage_output_source_for_block? stages sources default_alias limit_value src))))))
 		false)))
 
 (define scalar_first_inline_only_stage? (lambda (stage)
@@ -7579,7 +7581,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(or
 							(row_number_stage_consumed_by_join? stage sources)
 							(stage_consumed_by_driver_order_membership_source? stage (qb_stages block) sources (qb_facts block))
-							(stage_consumed_by_probe_source? stage (qb_stages block) sources default_alias))))))
+							(stage_consumed_by_probe_source? stage (qb_stages block) sources default_alias (qb_limit block)))))))
 				(lambda (stage)
 					(and
 						(not (contains? consumed_probe_ids (gs_id stage)))

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -36,6 +36,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_share"
   - sql: "DROP TABLE IF EXISTS trace_profile"
   - sql: "DROP TABLE IF EXISTS trace_metric"
+  - sql: "DROP TABLE IF EXISTS trace_wide_prop"
+  - sql: "DROP TABLE IF EXISTS trace_wide_parent"
+  - sql: "DROP TABLE IF EXISTS trace_wide_assignment"
   - sql: |
       CREATE TABLE trace_group (
         id INT PRIMARY KEY
@@ -94,6 +97,25 @@ setup:
         value_g INT,
         value_h INT
       )
+  - sql: |
+      CREATE TABLE trace_wide_parent (
+        id INT PRIMARY KEY,
+        owner_id INT,
+        is_public BOOL,
+        team_id INT
+      )
+  - sql: |
+      CREATE TABLE trace_wide_assignment (
+        id INT PRIMARY KEY,
+        team_id INT,
+        member_id INT
+      )
+  - sql: |
+      CREATE TABLE trace_wide_prop (
+        id INT PRIMARY KEY,
+        parent_id INT,
+        archived BOOL
+      )
   - sql: "INSERT INTO trace_group (id) VALUES (10), (20)"
   - sql: "INSERT INTO trace_item (id, group_id, state) VALUES (1, 10, 1), (2, 20, NULL), (3, 30, 0)"
   - sql: "INSERT INTO trace_host (id, kind) VALUES (1, 1), (2, 2)"
@@ -114,6 +136,19 @@ setup:
   - sql: "INSERT INTO trace_metric SELECT id + 256, profile_id, valid_from + 256, value_a + 256, value_b + 256, value_c + 256, value_d + 256, value_e + 256, value_f + 256, value_g + 256, value_h + 256 FROM trace_metric"
   - sql: "INSERT INTO trace_metric SELECT id + 512, profile_id, valid_from + 512, value_a + 512, value_b + 512, value_c + 512, value_d + 512, value_e + 512, value_f + 512, value_g + 512, value_h + 512 FROM trace_metric"
   - sql: "INSERT INTO trace_metric SELECT id + 1024, profile_id, valid_from + 1024, value_a + 1024, value_b + 1024, value_c + 1024, value_d + 1024, value_e + 1024, value_f + 1024, value_g + 1024, value_h + 1024 FROM trace_metric"
+  - sql: "INSERT INTO trace_wide_parent (id, owner_id, is_public, team_id) VALUES (1, 7, FALSE, 10), (2, 8, TRUE, 20)"
+  - sql: "INSERT INTO trace_wide_assignment (id, team_id, member_id) VALUES (1, 10, 7), (2, 20, 9)"
+  - sql: "INSERT INTO trace_wide_prop (id, parent_id, archived) VALUES (1, 1, FALSE)"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 1, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 2, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 4, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 8, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 16, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 32, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 64, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 128, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 256, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
+  - sql: "INSERT INTO trace_wide_prop SELECT id + 512, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
   - sql: |
       CREATE TABLE trace_config (
         id INT PRIMARY KEY,
@@ -396,6 +431,46 @@ test_cases:
           value_g: 2117
           value_h: 2127
 
+  - name: "Wide bounded scalar projection probes nested presence stage on cold cache"
+    max_time: 1.0
+    max_plan_size: 30000
+    sql: |
+      SELECT t.*
+      FROM (
+        SELECT
+          p.id,
+          p.archived,
+          COALESCE((
+            SELECT CASE
+              WHEN par.owner_id = 7 THEN TRUE
+              ELSE NOT (
+                (NOT par.is_public)
+                AND COALESCE(par.owner_id <> 7, TRUE)
+                AND NOT EXISTS (
+                  SELECT TRUE
+                  FROM trace_wide_assignment a
+                  WHERE a.team_id = par.team_id
+                    AND a.member_id = 7
+                  LIMIT 1
+                )
+              )
+            END
+            FROM trace_wide_parent par
+            WHERE par.id = p.parent_id
+            LIMIT 1
+          ), TRUE) AS can_view
+        FROM trace_wide_prop p
+      ) t
+      WHERE t.id IN (1)
+        AND (t.archived IS NULL OR t.archived IN (FALSE))
+      LIMIT 72
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          archived: false
+          can_view: true
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_config"
   - sql: "DROP TABLE IF EXISTS trace_doc"
@@ -415,3 +490,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS trace_share"
   - sql: "DROP TABLE IF EXISTS trace_profile"
   - sql: "DROP TABLE IF EXISTS trace_metric"
+  - sql: "DROP TABLE IF EXISTS trace_wide_prop"
+  - sql: "DROP TABLE IF EXISTS trace_wide_parent"
+  - sql: "DROP TABLE IF EXISTS trace_wide_assignment"


### PR DESCRIPTION
## Summary

- treat a bounded outer `LIMIT` as a valid cost bound for query-backed scalar-first projection probes
- share the existing `<= 512` probe-limit predicate between scalar-first and scalar-aggregate probes
- propagate the query-block limit into stage-consumption analysis so preparation and physical lowering make the same decision
- add a minimal anonymized cold-cache regression with a nested presence probe

## Root cause

A query-backed scalar-first stage was excluded from materialized preparation because it was expected to be consumed as an inline probe. Physical lowering then rejected that same probe when the estimated outer source contained at least 1000 rows, even though the outer query was bounded by `LIMIT 72`. The generated plan consequently scanned an uninitialized carrier and failed with an HTTP 500 on a cold cache.

The planner already accepts bounded scalar-aggregate probes when `LIMIT <= 512`. This change centralizes that rule and applies it consistently to scalar-first probes.

## A/B measurement

Exact same anonymized regression and fresh data directory:

| Revision | Result | Reported query time |
|---|---:|---:|
| `origin/master` (`3117f850f`) | HTTP 500, uninitialized custom carrier | 30.280 ms |
| this PR (`c4cb84cf8`) | correct row, 1/1 passed | 49.582 ms |

The timing is not presented as a speedup: the master path terminates incorrectly. The regression has a 1.0 s runtime ceiling and a 30,000-node plan-size ceiling.

## Manual-suite validation

The instrumented manual suite used the same runtime configuration and trace collection for both revisions.

- setup, initialization, first-use, phase 0, and the phase-0 follow-up all passed
- phase 0 completed in 29.1 s
- the previously blocking phase-1 scenario passed in 1.0 min; master timed out after 1.4 min
- the suite continued through the complete phase-1 run, but is not fully green yet
- the next trace-derived work package is wide derived-list projection: 9.765 s and 9.677 s
- other remaining classes are metadata/visibility projections at 9.545 s and 9.454 s, and a complex existence query at 8.511 s

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all tests passed
- `tests/118_manual_trace_sql_regressions.yaml`: 7/7 passed
- `tests/96_scalar_subselect_patterns.yaml`: 21/21 passed
- `tests/69_subquery_complex.yaml`: 33/33 passed
- `tests/66_exists_session_var.yaml`: 8/8 passed
- `git diff --check`: passed

`tools/lint_scm.py --check` still reports the pre-existing repository-wide formatting and parenthesis-depth warnings on unchanged regions.