### PR TITLE
Avoid recursive stage catalog expansion

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7266,15 +7266,21 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define nested_stage_catalog (lambda (stage)
 	(begin
 		(define input (if (group_stage? stage) (gs_input stage) nil))
-		(define direct (if (query_block? input)
+		(define catalog (if (query_block? input)
 			(merge_unique (list
 				(qassoc_get (gs_facts stage) (quote stage_catalog) '())
-				(query_block_stage_catalog input)
+				(query_block_stage_catalog input)))
+			'()))
+		(define nested (if (query_block? input)
+			(merge_unique (list
 				(qb_stages input)
 				(query_block_probe_expr_stages input)))
 			'()))
 		(unique_stages_by_id
-			(cons stage (merge (map direct nested_stage_catalog)))))))
+			(merge (list
+				(list stage)
+				catalog
+				(merge (map nested nested_stage_catalog))))))))
 
 (define stage_catalog_with_nested (lambda (stages)
 	(unique_stages_by_id

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1376,6 +1376,7 @@ test_cases:
 
   - name: "IN UNION with nested reference scalar prepares query carriers"
     fail_comment: "nested stage-output carriers must be prepared before physical reads"
+    max_plan_size: 60000
     setup:
       - sql: "DROP TABLE IF EXISTS in_stage_dep_doc"
       - sql: "DROP TABLE IF EXISTS in_stage_dep_file"


### PR DESCRIPTION
## Summary

- treat an attached stage catalog as an already complete availability set
- recurse only through stages that are actually nested in an input query block or probe expression
- add a 60k physical-plan size guard to the anonymized nested carrier regression

The full catalog added for nested carrier resolution was being traversed recursively as if every catalog entry were a dependency. That repeated closure work across a wide query even though catalog membership only establishes name availability. This keeps dependency traversal separate from catalog availability and preserves the same deduplicated stage set.

## A/B benchmark

A production-derived PostgreSQL fixture was imported locally, validated after restart, and copied into two identical MemCP data directories. The comparison uses master `3cf9ed514` and this PR `77397555b`, with one server active at a time. Each binary ran one complete cold cascade followed by three measured warm cascades. Values are HTTP wall-clock time.

| Prefix | Master cold | PR cold | Cold delta | Master warm median | PR warm median | Warm delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| C | 3.042s | 2.492s | -18.1% | 0.482s | 0.473s | -2.0% |
| Ca | 2.974s | 2.446s | -17.8% | 0.479s | 0.476s | -0.8% |
| Car | 3.019s | 2.449s | -18.9% | 0.481s | 0.467s | -2.9% |
| Carg | 2.992s | 2.444s | -18.3% | 0.471s | 0.466s | -1.0% |
| Cargl | 3.100s | 2.464s | -20.5% | 0.481s | 0.465s | -3.3% |
| Cargla | 3.063s | 2.451s | -20.0% | 0.482s | 0.466s | -3.3% |
| Carglas | 3.017s | 2.431s | -19.4% | 0.478s | 0.467s | -2.2% |
| Carglass | 3.113s | 2.451s | -21.2% | 0.490s | 0.467s | -4.7% |
| CarglassXXX | 3.059s | 2.486s | -18.7% | 0.479s | 0.465s | -3.0% |

The complete cold cascade improves from **27.380s to 22.116s (-19.2%)**. Every cold prefix is below 2.50s. The sum of warm medians improves from **4.323s to 4.212s (-2.6%)**.

All benchmark responses matched by SHA-256 and byte size. This fixture/query combination returned zero rows for these terms, so the table measures planner and execution latency for the complete query shape. Row-producing correctness is covered by the anonymized SQL regression.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (all hook suites passed)
- focused suites: `41_in_subquery` (45/45), `66_derived_table_exists_flatten` (3/3), `73_window_functions` (38/38), `91_fulltext_like_index` (63/63)
- Scheme formatter and check completed with only the pre-existing repository warnings
- `118_nested_correlated_scalar_perf` currently emits 40,258 plan characters against its 40,000 limit on both master and this PR; this patch does not change that plan

