### PR TITLE
Fix multi-source derived LIMIT lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -958,6 +958,15 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(and (or (nil? (qb_offset inner)) (not (empty_list? (qb_order inner))))
 						(equal? (qb_limit inner) 1))))))))
 
+(define single_row_derived_supported? (lambda (inner)
+	(and (query_block? inner)
+		(and (not (empty_list? (qb_sources inner)))
+			(and (empty_list? (qb_group inner))
+				(and (nil? (qb_having inner))
+					(and (not (query_block_has_aggregates? inner))
+						(and (or (nil? (qb_offset inner)) (not (empty_list? (qb_order inner))))
+							(equal? (qb_limit inner) 1)))))))))
+
 (define scalar_aggregate_supported? (lambda (inner)
 	(and (query_block? inner)
 		(and (not (empty_list? (qb_sources inner)))
@@ -1710,37 +1719,46 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define make_limited_derived_stage_source (lambda (alias inner original_relation)
 	(begin
-		(if (not (scalar_once_supported? inner))
-			(neumann_fail "untangle_query" "derived relation stage currently supports ORDER/LIMIT scalar shape only")
+		(if (not (single_row_derived_supported? inner))
+			(neumann_fail "untangle_query" "derived relation stage currently supports a non-grouped LIMIT 1 relation")
 			true)
-		(if (not (equal? (count (qb_fields inner)) 2))
-			(neumann_fail "untangle_query" "derived relation stage currently supports one projected column")
-			true)
-		(define value_expr (query_block_first_expr inner))
 		(define inner_src (car (qb_sources inner)))
 		(if (not (source_is_base_table? inner_src))
 			(neumann_fail "untangle_query" "derived relation stage requires a base inner source")
 			true)
 		(define inner_default (source_alias inner_src))
 		(define keys '(1))
-		(define condition (coalesceNil (qb_where inner) true))
-		(define value_for_inner (canonical_column_expr_for_alias inner_default value_expr))
-		(define order_for_inner (map (coalesceNil (qb_order inner) '()) (lambda (item)
-			(match item '(expr dir) (list (canonical_column_expr_for_alias inner_default expr) dir)))))
-		(define ag (scalar_once_descriptor value_for_inner order_for_inner (qb_offset inner)))
-		(define stage_id (concat "derived-once:" (fnv_hash (string (list original_relation alias condition ag)))))
+		(define ags (dedupe_aggregates_by_col
+			(merge_unique (extract_assoc (qb_fields inner) (lambda (_title expr)
+				(list (list
+					(canonical_column_expr_for_alias inner_default expr)
+					(scalar_once_reduce_first)
+					nil)))))))
+		(define stage_input (make_query_block
+			(qb_schema inner)
+			(qb_sources inner)
+			'()
+			(coalesceNil (qb_where inner) true)
+			'() nil
+			(qb_order inner)
+			(qb_limit inner)
+			(qb_offset inner)
+			'()
+			(qb_stages inner)
+			(qb_facts inner)))
+		(define stage_id (concat "derived-once:" (fnv_hash (string (list original_relation alias ags)))))
 		(define stage (make_group_stage
 			stage_id
-			inner_src
+			stage_input
 			'()
 			keys
-			(list ag)
+			ags
 			nil
 			'()
 			'()
 			nil nil
 			(list
-				(list (quote condition) condition)
+				(list (quote condition) true)
 				(list (quote purpose) (quote scalar_single))
 				(list (quote domain) '())
 				(list (quote lookup-keys) '())
@@ -1750,9 +1768,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(list (quote partition_by) '())
 				(list (quote physical_max_rows) 1)
 				(list (quote on_overflow) (quote ignore)))))
-		(define projection (match (qb_fields inner)
-			'(title _expr) (list title (scalar_once_value_expr alias ag))
-			_ (neumann_fail "untangle_query" "malformed derived relation projection")))
+		(define projection (map_assoc (qb_fields inner) (lambda (_title expr)
+			(begin
+				(define value_expr (canonical_column_expr_for_alias inner_default expr))
+				(define ag (list value_expr (scalar_once_reduce_first) nil))
+				(scalar_once_value_expr alias ag)))))
 		(list
 			(list alias (group_stage_schema stage) (make_stage_output_relation stage_id) false nil)
 			projection
@@ -7107,7 +7127,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define grouptbl (group_carrier_relation carrier))
 		(define scalar_query_stage (and (query_block? src)
 			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
-				(equal? (count ags) 2))))
+				(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote single_or_error))
+					(and (equal? (count ags) 2)
+						(equal? (cadr ags) aggregate_count_descriptor))))))
 		(define scalar_order_base_stage (and (not query_input_carrier)
 			(compatible_scalar_order_aggregates? ags)))
 		(define scalar_aggregate_stage (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_aggregate)))
@@ -8296,7 +8318,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(sorted_row_result_assoc_expr rest)))
 		_ (list (quote list)))))
 
-	(define join_sorted_rows_plan (lambda (rows_plan fields order_items offset_value limit_value)
+(define join_sorted_rows_plan_with_mapper (lambda (rows_plan order_items offset_value limit_value mapper)
 		(begin
 			(define offset_expr (coalesceNil offset_value 0))
 			(define limit_expr (coalesceNil limit_value -1))
@@ -8310,13 +8332,23 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(list (quote lambda) (list (quote sorted))
 						(list (quote map)
 							(list (quote slice) (quote sorted) offset_expr end_expr)
-							(list (quote lambda) (list (quote row))
-								(list (quote resultrow)
-									(sorted_row_result_assoc_expr fields)))))
+							mapper))
 					(list (quote sort) (quote rows)
 							(list (quote lambda) (list (quote a) (quote b))
 								(join_order_compare_expr order_items 0)))))
 				rows_plan))))
+
+(define join_sorted_rows_plan (lambda (rows_plan fields order_items offset_value limit_value)
+	(join_sorted_rows_plan_with_mapper
+		rows_plan order_items offset_value limit_value
+		(list (quote lambda) (list (quote row))
+			(list (quote resultrow) (sorted_row_result_assoc_expr fields))))))
+
+(define join_sorted_dataset_rows_plan (lambda (rows_plan fields order_items offset_value limit_value)
+	(join_sorted_rows_plan_with_mapper
+		rows_plan order_items offset_value limit_value
+		(list (quote lambda) (list (quote row))
+			(sorted_row_result_assoc_expr fields)))))
 
 	(define join_sorted_rows_late_projection_plan (lambda (rows_plan project_prepare_expr project_rows_expr fields order_items offset_value limit_value)
 		(begin
@@ -8697,9 +8729,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
 			(neumann_fail "build_queryplan" "dataset query-block lowering cannot consume grouped input")
 			true)
-		(if (or (not (empty_list? (qb_order block))) (or (not (nil? (qb_limit block))) (not (nil? (qb_offset block)))))
-			(neumann_fail "build_queryplan" "dataset query-block lowering cannot preserve ORDER/LIMIT yet")
-			true)
 		(define sources (qb_sources block))
 		(define first_alias (source_alias (car sources)))
 		(define where_expr (coalesceNil (qb_where block) true))
@@ -8711,23 +8740,48 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons (source_with_join_expr (car sources) (combine_where (source_join_expr (car sources)) where_expr)) (cdr sources))
 			sources))
 		(define final_condition (if push_first_where true where_expr))
+		(define order_items (coalesceNil (qb_order block) '()))
+		(define direct_order (order_items_belong_to_source? (car scan_sources) order_items))
+		(define direct_order_safe (and direct_order
+			(not (ordered_join_limit_requires_complete_rows?
+				scan_sources first_alias final_condition (qb_offset block) (qb_limit block)))))
 		(define needed_exprs (merge (list
 			(extract_assoc fields (lambda (_title expr) expr))
 			(list final_condition)
+			(order_exprs order_items)
 			(source_join_exprs scan_sources))))
-		(build_join_scan_rows_with_mapper
-			(qb_schema block)
-			scan_sources
-			scan_sources
-			first_alias
-			needed_exprs
-			final_condition
-			(lower_dataset_row_assoc scan_sources first_alias fields)
-			'()
-			0
-			-1
-			true
-			(query_block_stage_catalog block)))))
+		(if direct_order_safe
+			(build_join_scan_rows_with_mapper
+				(qb_schema block)
+				scan_sources
+				scan_sources
+				first_alias
+				needed_exprs
+				final_condition
+				(lower_dataset_row_assoc scan_sources first_alias fields)
+				order_items
+				(coalesceNil (qb_offset block) 0)
+				(coalesceNil (qb_limit block) -1)
+				true
+				(query_block_stage_catalog block))
+			(join_sorted_dataset_rows_plan
+				(build_join_scan_rows_with_mapper
+					(qb_schema block)
+					scan_sources
+					scan_sources
+					first_alias
+					needed_exprs
+					final_condition
+					(lower_join_result_row_assoc scan_sources first_alias fields order_items)
+					'()
+					0
+					-1
+					true
+					(query_block_stage_catalog block))
+				fields
+				order_items
+				(qb_offset block)
+				(qb_limit block))))))
 
 (define lower_multi_source_query_block (lambda (block)
 	(begin

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -39,6 +39,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_wide_prop"
   - sql: "DROP TABLE IF EXISTS trace_wide_parent"
   - sql: "DROP TABLE IF EXISTS trace_wide_assignment"
+  - sql: "DROP TABLE IF EXISTS trace_limit_output"
+  - sql: "DROP TABLE IF EXISTS trace_limit_parent"
+  - sql: "DROP TABLE IF EXISTS trace_limit_label"
   - sql: |
       CREATE TABLE trace_group (
         id INT PRIMARY KEY
@@ -116,6 +119,21 @@ setup:
         parent_id INT,
         archived BOOL
       )
+  - sql: |
+      CREATE TABLE trace_limit_parent (
+        id INT PRIMARY KEY,
+        label_id INT
+      )
+  - sql: |
+      CREATE TABLE trace_limit_label (
+        id INT PRIMARY KEY,
+        label VARCHAR(64)
+      )
+  - sql: |
+      CREATE TABLE trace_limit_output (
+        id INT PRIMARY KEY,
+        label VARCHAR(64)
+      )
   - sql: "INSERT INTO trace_group (id) VALUES (10), (20)"
   - sql: "INSERT INTO trace_item (id, group_id, state) VALUES (1, 10, 1), (2, 20, NULL), (3, 30, 0)"
   - sql: "INSERT INTO trace_host (id, kind) VALUES (1, 1), (2, 2)"
@@ -139,6 +157,8 @@ setup:
   - sql: "INSERT INTO trace_wide_parent (id, owner_id, is_public, team_id) VALUES (1, 7, FALSE, 10), (2, 8, TRUE, 20)"
   - sql: "INSERT INTO trace_wide_assignment (id, team_id, member_id) VALUES (1, 10, 7), (2, 20, 9)"
   - sql: "INSERT INTO trace_wide_prop (id, parent_id, archived) VALUES (1, 1, FALSE)"
+  - sql: "INSERT INTO trace_limit_parent (id, label_id) VALUES (1, 10), (2, 20)"
+  - sql: "INSERT INTO trace_limit_label (id, label) VALUES (10, 'zeta'), (20, 'alpha')"
   - sql: "INSERT INTO trace_wide_prop SELECT id + 1, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
   - sql: "INSERT INTO trace_wide_prop SELECT id + 2, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
   - sql: "INSERT INTO trace_wide_prop SELECT id + 4, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM trace_wide_prop"
@@ -237,6 +257,86 @@ setup:
   - sql: "INSERT INTO trace_ref_d SELECT id, id, TRUE FROM trace_asset WHERE id % 509 = 0"
 
 test_cases:
+  - name: "INSERT SELECT preserves a multi-source derived ORDER LIMIT relation"
+    max_time: 1.0
+    max_plan_size: 20000
+    sql: |
+      INSERT INTO trace_limit_output (id, label)
+      SELECT candidate.id, candidate.label
+      FROM (
+        SELECT parent.id, label.label
+        FROM trace_limit_parent parent
+        LEFT JOIN trace_limit_label label ON label.id = parent.label_id
+        ORDER BY label.label DESC
+        LIMIT 1
+      ) candidate
+      WHERE NOT EXISTS (
+        SELECT TRUE
+        FROM trace_limit_output present
+        WHERE present.id = candidate.id
+      )
+    expect:
+      affected_rows: 1
+
+  - name: "INSERT SELECT derived ORDER LIMIT stores the selected joined row"
+    sql: "SELECT id, label FROM trace_limit_output"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          label: "zeta"
+
+  - name: "Multi-source derived ORDER LIMIT preserves OFFSET"
+    sql: |
+      SELECT candidate.id, candidate.label
+      FROM (
+        SELECT parent.id, label.label
+        FROM trace_limit_parent parent
+        LEFT JOIN trace_limit_label label ON label.id = parent.label_id
+        ORDER BY label.label ASC
+        LIMIT 1 OFFSET 1
+      ) candidate
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          label: "zeta"
+
+  - name: "Empty multi-source derived LIMIT returns no row"
+    sql: |
+      SELECT candidate.id, candidate.label
+      FROM (
+        SELECT parent.id, label.label
+        FROM trace_limit_parent parent
+        LEFT JOIN trace_limit_label label ON label.id = parent.label_id
+        WHERE parent.id > 100
+        ORDER BY label.label DESC
+        LIMIT 1
+      ) candidate
+    expect:
+      rows: 0
+
+  - name: "Multi-source derived LIMIT stays a logical one-row carrier"
+    sql: |
+      EXPLAIN IR
+      SELECT candidate.id, candidate.label
+      FROM (
+        SELECT parent.id, label.label
+        FROM trace_limit_parent parent
+        LEFT JOIN trace_limit_label label ON label.id = parent.label_id
+        ORDER BY label.label DESC
+        LIMIT 1
+      ) candidate
+    expect:
+      contains:
+        - "group-stage"
+        - "cardinality_mode first"
+        - "physical_max_rows 1"
+      not_contains:
+        - "legacy_materialized"
+        - "inner_select"
+        - "__mat:"
+
   - name: "ORDER BY RAND supports filtered table scan with IN subquery"
     sql: |
       SELECT id
@@ -493,3 +593,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS trace_wide_prop"
   - sql: "DROP TABLE IF EXISTS trace_wide_parent"
   - sql: "DROP TABLE IF EXISTS trace_wide_assignment"
+  - sql: "DROP TABLE IF EXISTS trace_limit_output"
+  - sql: "DROP TABLE IF EXISTS trace_limit_parent"
+  - sql: "DROP TABLE IF EXISTS trace_limit_label"


### PR DESCRIPTION
## Root cause

An `INSERT ... SELECT` whose source was a multi-source derived relation with `ORDER BY ... LIMIT 1` failed during logical planning. The derived-relation path only accepted a single-base-source scalar shape, even though the query is a valid one-row relation. The surrounding transaction consequently rolled back.

The physical query-input scalar classification also assumed that every two-aggregate `scalar_single` stage was the value-plus-count cardinality form. A normal two-column one-row carrier could therefore lower its second projection as a count.

## Planner change

- Represent a non-grouped `LIMIT 1` derived relation as a logical one-row `group-stage` while retaining its complete source list, join predicates, filters, order, offset, stages, and facts.
- Preserve every projected column with first-value aggregation over that one-row input.
- Select physical lowering in `build_queryplan`: use an ordered driver scan where early limiting is safe; otherwise reuse the existing complete-join sort path and return dataset rows after slicing.
- Restrict the value-plus-count carrier path to stages that actually have `cardinality_mode=single_or_error` and a count descriptor.

The logical IR does not contain physical temp tables or legacy scalar fallbacks. Empty input still produces no derived row.

## Regression coverage

`tests/118_manual_trace_sql_regressions.yaml` now covers an anonymized `INSERT ... SELECT` with:

- a two-source derived relation,
- ordering by the joined source,
- `LIMIT 1` and `OFFSET`,
- an outer `NOT EXISTS`,
- empty input,
- result-column correctness,
- IR gates against `legacy_materialized`, `inner_select`, and `__mat:`.

Against unchanged master, the reproducer fails with HTTP 500 and `untangle_query: derived relation stage currently supports ORDER/LIMIT scalar shape only`; the verification table remains empty. This branch passes all cases.

## A/B measurements

Baseline: `682208143d6e96a0d447bc62c50e1dea32aa894d`. Each side used a fresh data directory, identical SQL, and 1,024 driver plus 1,024 joined rows.

| Query | master | branch |
| --- | ---: | ---: |
| Existing valid joined `ORDER BY ... LIMIT 1` control, median of 5 | 284.0 ms | 273.7 ms |
| Repaired `INSERT ... SELECT`, master | compiler failure, median failure response 11.5 ms | n/a |
| Repaired `INSERT ... SELECT`, branch, median of 5 | n/a | 367.0 ms |

The repaired primitive is a correctness A/B, not a speedup claim. Its branch result is correct and its SELECT-equivalent physical plan is 9,318 bytes. The valid control shows no performance regression in this run.

## Downstream integration progress

With master, the manual integration run completed setup but stopped in the first account workflow because this statement failed and its transaction rolled back. With this branch and a fresh database, that workflow passed, the following three worker suites passed, and the run advanced through menu coverage into the search UI phase. It then stopped on a browser-side JavaScript `ReferenceError` caused by a handler that receives `event` but reads an undefined `e` variable.

A second fresh-database diagnostic run skipped only that confirmed browser-only suite. All later integration phases, including file-open, archive-download, and manual HTML generation, then passed. The unmodified complete manual run is therefore not claimed green, but no later MemCP correctness blocker was found.

The first remaining SQL performance signal is a complex derived `COUNT` with repeated ACL/scalar stages at 6.21 s on small integration data (4.53 s in the first run). Complex list projections ranged up to 4.38 s. That count/projection plan class is the next separate planner task.

## Validation

- `go build -o memcp`
- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml` (12/12)
- `python3 run_sql_tests.py tests/66_derived_table_limit_scalar.yaml` (5/5)
- `python3 run_sql_tests.py tests/40_exists_subquery.yaml` (20/20)
- relevant DML and trigger suites (all green)
- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (`All tests passed, commit allowed`)
- `git diff --check`

`python3 tools/lint_scm.py --check` reports the same existing formatter/depth warning categories on unchanged master; this patch introduces no new category.
