### PR TITLE
Prune constant CASE stages

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2514,6 +2514,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(and (uctx_get ctx (quote defer-subquery-rewrites) false)
 		(not (empty_list? (btw2025_subquery_accessing_aliases subquery outer_sources))))))
 
+(define untangle_if_expr_with_stages (lambda (head args outer_sources ctx)
+	(match args
+		(cons condition (cons branch rest))
+		(if (equal? condition true)
+			(untangle_expr_with_stages branch outer_sources ctx)
+			(if (or (equal? condition false) (nil? condition))
+				(match rest
+					(cons fallback '()) (untangle_expr_with_stages fallback outer_sources ctx)
+					_ (untangle_if_expr_with_stages head rest outer_sources ctx))
+				(combine_stage_rewrite_results head
+					(map args (lambda (item) (untangle_expr_with_stages item outer_sources ctx))))))
+		_ (combine_stage_rewrite_results head
+			(map args (lambda (item) (untangle_expr_with_stages item outer_sources ctx)))))))
+
 (define untangle_expr_with_stages (lambda (expr outer_sources ctx)
 	(match expr
 		((symbol inner_select) subquery)
@@ -2566,7 +2580,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(if (or (equal? fn "RANK") (equal? fn "DENSE_RANK"))
 						(make_window_rank_orc_stage_rewrite fn args over window_sources ctx)
 						(make_window_aggregate_stage_rewrite fn args over window_sources ctx)))))
-		(cons head tail) (combine_stage_rewrite_results head (map tail (lambda (item) (untangle_expr_with_stages item outer_sources ctx))))
+		(cons head tail) (if (equal? head (quote if))
+			(untangle_if_expr_with_stages head tail outer_sources ctx)
+			(combine_stage_rewrite_results head (map tail (lambda (item) (untangle_expr_with_stages item outer_sources ctx)))))
 		_ (list expr '() '()))))
 
 (define untangle_expr (lambda (expr ctx)

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -571,6 +571,19 @@ test_cases:
           archived: false
           can_view: true
 
+  - name: "Constant CASE prunes dead scalar aggregate"
+    max_time: 0.2
+    max_plan_size: 2000
+    sql: |
+      SELECT CASE
+        WHEN TRUE THEN 7
+        ELSE (SELECT SUM(1) FROM trace_wide_parent dead_parent WHERE dead_parent.id = 1)
+      END AS value
+    expect:
+      rows: 1
+      data:
+        - value: 7
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_config"
   - sql: "DROP TABLE IF EXISTS trace_doc"


### PR DESCRIPTION
## What changed

- Prune statically selected `CASE` branches before scalar-subquery stage extraction.
- Keep normal stage collection for data-dependent `CASE` expressions.
- Add a minimal anonymous SQL regression with runtime and plan-size bounds.

## Root cause

The generic expression walker visited every `CASE` branch before the constant condition was applied. Scalar subqueries in unreachable branches were therefore decorrelated, lowered, and prepared even though they could never execute.

## A/B measurements

Measured from clean binaries built from `origin/master` (`60a02c568`) and this branch, using the regression query and `EXPLAIN COMPILE`:

| Metric | master | PR | Change |
|---|---:|---:|---:|
| Planner time | 3.055 ms | 0.348 ms | 8.8x faster |
| Plan bytes | 2,050 | 26 | -98.7% |
| Group stages | 1 | 0 | removed |
| Scans | 2 | 0 | removed |

The test's `max_plan_size: 2000` fails on master at 2,050 bytes and passes on this branch at 26 bytes.

## Validation

- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml`: 13/13 passed.
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all suites passed.
- Scheme formatter was run. Its check still reports the pre-existing repository-wide reformat and parenthesis-depth warnings.

## End-to-end status

The external one-locale manual build was rerun with `TracePrint`. This patch removes the dead constant branches but does not yet clear the current blocker: the same 25,451-byte query with 156 `SELECT` nodes still exceeds the 320-second browser setup timeout. CPU profiling points to generated-plan evaluation and GC, so the next work item is deduplicating nested stage preparation across the physical prepare DAG rather than adding another SQL special case.
