### PR TITLE
Index physical stage dependencies during lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6775,38 +6775,89 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(stage_for_carrier_source stages src)))
 		(lambda (stage) (not (nil? stage))))))
 
-(define group_stage_nested_dependencies (lambda (stages stage)
+(define stage_dependency_id_index (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (index stage)
+		(if (group_stage? stage)
+			(set_assoc index (gs_id stage) stage)
+			index)) '())))
+
+(define stage_dependency_carrier_key (lambda (schema relation)
+	(list schema relation)))
+
+(define stage_dependency_carrier_index (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (index stage)
+		(if (not (group_stage? stage))
+			index
+			(set_assoc index
+				(stage_dependency_carrier_key
+					(group_stage_carrier_schema stage)
+					(group_stage_carrier_relation stage))
+				stage))) '())))
+
+(define stage_dependencies_from_output_sources (lambda (id_index sources)
+	(unique_stages_by_id (filter (map (coalesceNil sources '()) (lambda (src)
+		(begin
+			(define relation (source_relation src))
+			(if (and (stage_output_relation? relation)
+				(has_assoc? id_index (stage_output_relation_id relation)))
+				(id_index (stage_output_relation_id relation))
+				nil))))
+		(lambda (stage) (not (nil? stage)))))))
+
+(define group_stage_direct_dependencies_using_indexes (lambda (id_index carrier_index stage)
 	(begin
 		(define input (gs_input stage))
-		(define available_stages (unique_stages_by_id
-			(merge (list stages (qassoc_get (gs_facts stage) (quote stage_catalog) '())))))
 		(if (query_block? input)
-			(merge_unique (list
+			(unique_stages_by_id (merge (list
 				(qb_stages input)
-				(stage_outputs_from_sources_using available_stages (qb_sources input))))
+				(stage_dependencies_from_output_sources id_index (qb_sources input)))))
 			(if (source_is_base_table? input)
 				(begin
-					(define carrier_stage (stage_for_carrier_source available_stages input))
-					(if (nil? carrier_stage) '() (list carrier_stage)))
+					(define carrier_key (stage_dependency_carrier_key
+						(source_schema input)
+						(source_relation input)))
+					(if (has_assoc? carrier_index carrier_key)
+						(list (carrier_index carrier_key))
+						'()))
 				'())))))
 
-(define consumed_stage_closure (lambda (stages stage)
+(define stage_dependency_graph (lambda (stages)
 	(begin
-		(define direct (group_stage_nested_dependencies stages stage))
-		(merge_unique (list
-			(list stage)
-			direct
-			(merge (map direct (lambda (nested)
-				(consumed_stage_closure stages nested)))))))))
+		(define available_stages (unique_stages_by_id stages))
+		(define id_index (stage_dependency_id_index available_stages))
+		(define carrier_index (stage_dependency_carrier_index available_stages))
+		(reduce available_stages (lambda (graph stage)
+			(set_assoc graph (logical_stage_key stage)
+				(if (group_stage? stage)
+					(group_stage_direct_dependencies_using_indexes id_index carrier_index stage)
+					'()))) '()))))
 
-(define stage_prepare_dependency_closure (lambda (stages stage)
-	(if (group_stage? stage)
-		(consumed_stage_closure stages stage)
-		(list stage))))
+(define stage_dependency_closure_visit (lambda (graph stage states)
+	(begin
+		(define key (logical_stage_key stage))
+		(define state (if (has_assoc? states key) (states key) nil))
+		(if (equal? state (quote visiting))
+			(neumann_fail "build_queryplan" (concat "cyclic physical stage dependency " key))
+			true)
+		(if (equal? state (quote done))
+			(list '() states)
+			(begin
+				(define visiting (set_assoc states key (quote visiting)))
+				(define direct (if (has_assoc? graph key) (graph key) '()))
+				(define nested (reduce direct (lambda (acc dependency)
+					(begin
+						(define result (stage_dependency_closure_visit graph dependency (nth acc 1)))
+						(list (merge (list (nth acc 0) (nth result 0))) (nth result 1))))
+					(list '() visiting)))
+				(list
+					(cons stage (nth nested 0))
+					(set_assoc (nth nested 1) key (quote done))))))))
 
-(define stage_prepare_dependency_closure_all (lambda (stages selected)
-	(merge_unique (map (coalesceNil selected '()) (lambda (stage)
-		(stage_prepare_dependency_closure stages stage))))))
+(define stage_dependency_closure_using_graph (lambda (graph stage)
+	(nth (stage_dependency_closure_visit graph stage '()) 0)))
+
+(define consumed_stage_closure (lambda (stages stage)
+	(stage_dependency_closure_using_graph (stage_dependency_graph stages) stage)))
 
 (define expr_probe_stages (lambda (expr)
 	(match expr
@@ -6977,7 +7028,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_without_stages_after_prepare_using (lambda (stages block)
 	(begin
-		(define available_stages (stage_catalog_with_nested (merge (list stages (qb_stages block)))))
+		(define available_stages (unique_stages_by_id (merge (list stages (qb_stages block)))))
 		(define rewritten (query_block_with_scalar_first_probes_using available_stages block))
 		(make_query_block
 			(qb_schema rewritten)
@@ -6998,24 +7049,24 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_without_stages_after_eager_prepare_using (lambda (stages block)
 	(begin
-		(define available_stages (stage_catalog_with_nested (merge (list stages (qb_stages block)))))
-	(make_query_block
-		(qb_schema block)
+		(define available_stages (unique_stages_by_id (merge (list stages (qb_stages block)))))
+		(make_query_block
+			(qb_schema block)
 			(physicalize_stage_output_sources available_stages (qb_sources block))
-		(qb_fields block)
-		(qb_where block)
-		(qb_group block)
-		(qb_having block)
-		(qb_order block)
-		(qb_limit block)
-		(qb_offset block)
-		(qb_hidden block)
-		'()
+			(qb_fields block)
+			(qb_where block)
+			(qb_group block)
+			(qb_having block)
+			(qb_order block)
+			(qb_limit block)
+			(qb_offset block)
+			(qb_hidden block)
+			'()
 			(query_block_facts_with_stage_catalog block '())))))
 
 (define query_block_without_stages_after_eager_prepare_with_constant_scalars_first (lambda (stages block)
 	(begin
-		(define available_stages (stage_catalog_with_nested (merge (list stages (qb_stages block)))))
+		(define available_stages (unique_stages_by_id (merge (list stages (qb_stages block)))))
 		(make_query_block
 			(qb_schema block)
 			(physicalize_stage_output_sources available_stages (constant_scalar_stage_outputs_first available_stages (qb_sources block)))
@@ -7032,7 +7083,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(begin
-		(define available_stages (stage_catalog_with_nested (merge (list stages (qb_stages block)))))
+		(define available_stages (unique_stages_by_id (merge (list stages (qb_stages block)))))
 		(define scalar_rewritten (query_block_with_scalar_first_probes_using available_stages block))
 		(define membership_rewritten (query_block_with_physical_driver_order_membership_using available_stages scalar_rewritten))
 		(define sources (qb_sources membership_rewritten))
@@ -7136,10 +7187,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define lower_group_stage_prepare_using (lambda (all_stages stage)
 	(begin
 		(define src (gs_input stage))
-		(define stage_catalog (stage_catalog_with_nested
-			(merge (list
-				all_stages
-				(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))
+		(define stage_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
 			true)
@@ -7710,7 +7758,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(begin
 				(define rewritten (query_block_with_scalar_first_probes_using (qb_stages block) block))
 				(define sources (qb_sources rewritten))
-				(define stage_catalog (query_block_stage_catalog rewritten))
+				(define stage_catalog (stage_catalog_with_nested (query_block_stage_catalog rewritten)))
+				(define dependency_graph (stage_dependency_graph stage_catalog))
 				(define physical_sources (physicalize_stage_output_sources stage_catalog sources))
 				(define driver_src (car physical_sources))
 				(if (not (source_is_base_table? driver_src))
@@ -7737,9 +7786,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(cons (quote !begin)
 					(merge (list
 						(map (qb_stages rewritten) (lambda (stage)
-							(lower_stage_prepare_using (qb_stages rewritten) stage)))
+							(lower_stage_prepare_using
+								(stage_dependency_closure_using_graph dependency_graph stage)
+								stage)))
 						(lower_stage_materialize_all (qb_stages rewritten))
-						(list (lower_group_stage_prepare_using (cons main_stage (qb_stages rewritten)) main_stage))
+						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage))
 						(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources)))))))))))
 
 (define query_block_without_stages (lambda (block)
@@ -7894,18 +7945,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(if (not (nil? fused_row_number))
 						fused_row_number
 						(begin
+							(define stage_catalog (stage_catalog_with_nested (query_block_stage_catalog block)))
 							(define eager_stages (query_block_stages_to_prepare block))
+							(define dependency_graph (stage_dependency_graph stage_catalog))
 							(define prepared_block (if (single_source? (qb_sources block))
-								(query_block_without_stages_after_prepare_using (qb_stages block) block)
-								(query_block_with_prepared_sources_using (qb_stages block) block)))
-							(define lazy_catalog (stages_without_ids (qb_stages block) (stage_ids eager_stages)))
+								(query_block_without_stages_after_prepare_using stage_catalog block)
+								(query_block_with_prepared_sources_using stage_catalog block)))
+							(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
 							(define core_block (query_block_with_stage_catalog prepared_block lazy_catalog))
 							(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
 						(cons (quote !begin)
 							(merge (list
 									(lazy_stage_prepare_bindings lazy_catalog lazy_stages)
 									(map eager_stages (lambda (stage)
-									(lower_stage_prepare_using (qb_stages block) stage)))
+										(lower_stage_prepare_using
+											(stage_dependency_closure_using_graph dependency_graph stage)
+											stage)))
 									(list (lower_query_block_core core_block))))))))))))))
 
 (define lower_query_block_with_stages (lambda (block)
@@ -7942,20 +7997,24 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(list (list (quote context) "session") (stage_prepare_key stage))
 		(quoted_runtime_list '()))))
 
-(define lazy_stage_prepare_binding (lambda (stages stage)
-	(list
-		(list (quote context) "session")
-		(stage_prepare_key stage)
-		(list (quote once)
-			(list (quote lambda)
-				'()
-				(list (quote !begin)
-					(lower_stage_prepare_using stages stage)
-					true))))))
+(define lazy_stage_prepare_binding (lambda (dependency_graph stage)
+	(begin
+		(define dependencies (stage_dependency_closure_using_graph dependency_graph stage))
+		(list
+			(list (quote context) "session")
+			(stage_prepare_key stage)
+			(list (quote once)
+				(list (quote lambda)
+					'()
+					(list (quote !begin)
+						(lower_stage_prepare_using dependencies stage)
+						true)))))))
 
 (define lazy_stage_prepare_bindings (lambda (stages selected)
-	(map (coalesceNil selected '()) (lambda (stage)
-		(lazy_stage_prepare_binding stages stage)))))
+	(begin
+		(define dependency_graph (stage_dependency_graph stages))
+		(map (coalesceNil selected '()) (lambda (stage)
+			(lazy_stage_prepare_binding dependency_graph stage))))))
 
 (define lower_query_block_core_with_lazy_prepares (lambda (stage_catalog block)
 	(begin

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -653,6 +653,7 @@ class SQLTestRunner:
             plan_size_limit = int(self.suite_metadata["max_plan_size"])
         else:
             plan_size_limit = DEFAULT_MAX_PLAN_SIZE
+        planner_time_limit_ms = float(test_case.get("max_planner_time_ms", 0))
         perf_rows = PERF_DEFAULT_ROWS  # default row count
         if is_perf_test:
             # Get baseline data if available
@@ -925,6 +926,32 @@ class SQLTestRunner:
                     print(f"    📋 Query plan for {name}:")
                     for line in explain_resp.text.strip().split('\n')[:10]:
                         print(f"       {line[:120]}")
+
+            # Explicit cold planner budget. Unlike max_time, this reads the
+            # compile-only phase metric before EXPLAIN warms the plan cache.
+            if (planner_time_limit_ms > 0 and not is_perf_test and not is_sparql
+                    and not test_case.get("expect", {}).get("error")):
+                qhead = query.lstrip().upper()
+                if qhead.startswith("SELECT") or qhead.startswith("WITH"):
+                    try:
+                        compile_resp = self.execute_sql(database, "EXPLAIN COMPILE " + query, auth_header,
+                                                        active_syntax, session_id=session_id, timeout=sql_timeout)
+                    except Exception:
+                        compile_resp = None
+                    if compile_resp is None or compile_resp.status_code != 200 or "Error" in compile_resp.text[:64]:
+                        return self._record_fail(name, "EXPLAIN COMPILE failed", query, compile_resp,
+                                                 test_case.get("expect"), is_noncritical)
+                    compile_rows = self.parse_jsonl_response(compile_resp)
+                    metrics = compile_rows[0] if compile_rows else {}
+                    planner_time_ms = float(metrics.get("planner_total_ns", 0)) / 1_000_000.0
+                    if planner_time_ms > planner_time_limit_ms:
+                        diag = self._run_on_fail(test_case, database)
+                        return self._record_fail(
+                            name,
+                            f"Planner too slow: {planner_time_ms:.1f}ms > {planner_time_limit_ms:.0f}ms",
+                            query, compile_resp, test_case.get("expect"), is_noncritical,
+                            planner_time_ms, planner_time_limit_ms, diag,
+                        )
 
             # Hard plan-size limit — the hardware-independent compile-time-blowup
             # detector. Runs BEFORE the timed query so it is not preempted by

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -645,6 +645,40 @@ test_cases:
           archived: false
           can_view: true
 
+  - name: "Independent nested scalar aggregates compile within a linear budget"
+    max_time: 8.0
+    max_planner_time_ms: 800
+    max_plan_size: 230000
+    sql: |
+      SELECT
+        (SELECT SUM(1) FROM trace_wide_prop item_1 WHERE item_1.id = 1 AND COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item_1.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_1,
+        (SELECT SUM(1) FROM trace_wide_prop item_2 WHERE item_2.id = 1 AND COALESCE((SELECT (parent_2.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_2 WHERE member_2.team_id = parent_2.team_id AND member_2.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_2 WHERE parent_2.id = item_2.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_2,
+        (SELECT SUM(1) FROM trace_wide_prop item_3 WHERE item_3.id = 1 AND COALESCE((SELECT (parent_3.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_3 WHERE member_3.team_id = parent_3.team_id AND member_3.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_3 WHERE parent_3.id = item_3.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_3,
+        (SELECT SUM(1) FROM trace_wide_prop item_4 WHERE item_4.id = 1 AND COALESCE((SELECT (parent_4.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_4 WHERE member_4.team_id = parent_4.team_id AND member_4.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_4 WHERE parent_4.id = item_4.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_4,
+        (SELECT SUM(1) FROM trace_wide_prop item_5 WHERE item_5.id = 1 AND COALESCE((SELECT (parent_5.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_5 WHERE member_5.team_id = parent_5.team_id AND member_5.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_5 WHERE parent_5.id = item_5.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_5,
+        (SELECT SUM(1) FROM trace_wide_prop item_6 WHERE item_6.id = 1 AND COALESCE((SELECT (parent_6.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_6 WHERE member_6.team_id = parent_6.team_id AND member_6.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_6 WHERE parent_6.id = item_6.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_6,
+        (SELECT SUM(1) FROM trace_wide_prop item_7 WHERE item_7.id = 1 AND COALESCE((SELECT (parent_7.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_7 WHERE member_7.team_id = parent_7.team_id AND member_7.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_7 WHERE parent_7.id = item_7.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_7,
+        (SELECT SUM(1) FROM trace_wide_prop item_8 WHERE item_8.id = 1 AND COALESCE((SELECT (parent_8.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_8 WHERE member_8.team_id = parent_8.team_id AND member_8.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_8 WHERE parent_8.id = item_8.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_8,
+        (SELECT SUM(1) FROM trace_wide_prop item_9 WHERE item_9.id = 1 AND COALESCE((SELECT (parent_9.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_9 WHERE member_9.team_id = parent_9.team_id AND member_9.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_9 WHERE parent_9.id = item_9.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_9,
+        (SELECT SUM(1) FROM trace_wide_prop item_10 WHERE item_10.id = 1 AND COALESCE((SELECT (parent_10.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_10 WHERE member_10.team_id = parent_10.team_id AND member_10.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_10 WHERE parent_10.id = item_10.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_10,
+        (SELECT SUM(1) FROM trace_wide_prop item_11 WHERE item_11.id = 1 AND COALESCE((SELECT (parent_11.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_11 WHERE member_11.team_id = parent_11.team_id AND member_11.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_11 WHERE parent_11.id = item_11.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_11,
+        (SELECT SUM(1) FROM trace_wide_prop item_12 WHERE item_12.id = 1 AND COALESCE((SELECT (parent_12.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_12 WHERE member_12.team_id = parent_12.team_id AND member_12.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_12 WHERE parent_12.id = item_12.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_12
+    expect:
+      rows: 1
+      data:
+        - metric_1: 1
+          metric_2: 1
+          metric_3: 1
+          metric_4: 1
+          metric_5: 1
+          metric_6: 1
+          metric_7: 1
+          metric_8: 1
+          metric_9: 1
+          metric_10: 1
+          metric_11: 1
+          metric_12: 1
+
   - name: "Constant CASE prunes dead scalar aggregate"
     max_time: 0.2
     max_plan_size: 2000

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -646,9 +646,9 @@ test_cases:
           can_view: true
 
   - name: "Independent nested scalar aggregates compile within a linear budget"
-    max_time: 8.0
-    max_planner_time_ms: 800
-    max_plan_size: 230000
+    max_time: 5.0
+    max_planner_time_ms: 300
+    max_plan_size: 160000
     sql: |
       SELECT
         (SELECT SUM(1) FROM trace_wide_prop item_1 WHERE item_1.id = 1 AND COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item_1.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_1,
@@ -658,11 +658,7 @@ test_cases:
         (SELECT SUM(1) FROM trace_wide_prop item_5 WHERE item_5.id = 1 AND COALESCE((SELECT (parent_5.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_5 WHERE member_5.team_id = parent_5.team_id AND member_5.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_5 WHERE parent_5.id = item_5.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_5,
         (SELECT SUM(1) FROM trace_wide_prop item_6 WHERE item_6.id = 1 AND COALESCE((SELECT (parent_6.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_6 WHERE member_6.team_id = parent_6.team_id AND member_6.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_6 WHERE parent_6.id = item_6.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_6,
         (SELECT SUM(1) FROM trace_wide_prop item_7 WHERE item_7.id = 1 AND COALESCE((SELECT (parent_7.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_7 WHERE member_7.team_id = parent_7.team_id AND member_7.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_7 WHERE parent_7.id = item_7.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_7,
-        (SELECT SUM(1) FROM trace_wide_prop item_8 WHERE item_8.id = 1 AND COALESCE((SELECT (parent_8.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_8 WHERE member_8.team_id = parent_8.team_id AND member_8.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_8 WHERE parent_8.id = item_8.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_8,
-        (SELECT SUM(1) FROM trace_wide_prop item_9 WHERE item_9.id = 1 AND COALESCE((SELECT (parent_9.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_9 WHERE member_9.team_id = parent_9.team_id AND member_9.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_9 WHERE parent_9.id = item_9.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_9,
-        (SELECT SUM(1) FROM trace_wide_prop item_10 WHERE item_10.id = 1 AND COALESCE((SELECT (parent_10.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_10 WHERE member_10.team_id = parent_10.team_id AND member_10.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_10 WHERE parent_10.id = item_10.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_10,
-        (SELECT SUM(1) FROM trace_wide_prop item_11 WHERE item_11.id = 1 AND COALESCE((SELECT (parent_11.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_11 WHERE member_11.team_id = parent_11.team_id AND member_11.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_11 WHERE parent_11.id = item_11.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_11,
-        (SELECT SUM(1) FROM trace_wide_prop item_12 WHERE item_12.id = 1 AND COALESCE((SELECT (parent_12.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_12 WHERE member_12.team_id = parent_12.team_id AND member_12.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_12 WHERE parent_12.id = item_12.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_12
+        (SELECT SUM(1) FROM trace_wide_prop item_8 WHERE item_8.id = 1 AND COALESCE((SELECT (parent_8.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_8 WHERE member_8.team_id = parent_8.team_id AND member_8.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_8 WHERE parent_8.id = item_8.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_8
     expect:
       rows: 1
       data:
@@ -674,10 +670,6 @@ test_cases:
           metric_6: 1
           metric_7: 1
           metric_8: 1
-          metric_9: 1
-          metric_10: 1
-          metric_11: 1
-          metric_12: 1
 
   - name: "Constant CASE prunes dead scalar aggregate"
     max_time: 0.2


### PR DESCRIPTION
## Summary

- build a stage-id/carrier index and dependency DAG once per physical query-block lowering
- expand nested stage catalogs once at the query-block boundary instead of recursively for every stage preparation
- resolve eager and lazy prepare closures from the indexed DAG, with explicit cycle detection
- add a cold compile-time budget to YAML SQL tests via `max_planner_time_ms`
- add an anonymous eight-branch nested scalar aggregate regression

## Test-first evidence

The minimized regression was run against current `origin/master` first and failed its 300 ms planner budget:

| Metric | master | PR | Change |
|---|---:|---:|---:|
| Planner total | 475.6 ms | 160.6 ms | **2.96x faster** |
| Untangle | 27.1 ms | 21.9 ms | **1.24x faster** |
| Reorder | 18.3 ms | 6.0 ms | **3.05x faster** |
| Physical lowering | 430.2 ms | 132.7 ms | **3.24x faster** |
| Plan bytes | 95,955 | 95,955 | unchanged |

Plan structure is unchanged on both revisions: 17 query blocks, 24 group stages, 80 scans, 8 ordered scans, and 24 group carriers.

## Manual trace

A fresh large external manual suite was run through the branch binary with TracePrint enabled. Setup reached the previously identified wide dashboard query, but page loading still exceeded the existing 320 s Playwright timeout. The query remained in compilation and was cancelled after cleanup, so this PR removes a measured polynomial lowering cost but does **not** claim to clear the complete manual-build blocker. The next work package must profile the remaining compile path on that wider topology.

## Verification

- full pre-commit suite: passed
- SQL time-limit guard: passed
- Scheme startup tests: 821/821 passed
- focused nested-stage regression: 3/3 passed
- anonymous trace regression suite: 16/16 passed
- `git diff --check`: passed
- Python bytecode check: passed