### PR TITLE
Coalesce concurrent query plan cache misses

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -30,10 +30,10 @@ fulltext-ish SELECTs. It replaces string literals directly following LIKE or
 inside MATCH...AGAINST(...) with ? placeholders and returns (normalized-query bindings). Other string
 literals, DDL/DML and already-parameterized statements keep exact cache keys. */
 (define sql_parameterize_select_like_strings (lambda (query enabled) (begin
-		(define starts_like_select (lambda (q)
-			(or
-				(match q (regex "^\\s*SELECT\\b" _) true false)
-				(match q (regex "^\\s*EXPLAIN\\s+(?:(?:IR|REORDER)\\s+)?SELECT\\b" _) true false))))
+	(define starts_like_select (lambda (q)
+		(or
+			(match q (regex "^\\s*SELECT\\b" _) true false)
+			(match q (regex "^\\s*EXPLAIN\\s+(?:(?:IR|REORDER)\\s+)?SELECT\\b" _) true false))))
 	(define parameterized_rhs_literal? (lambda (q pos) (begin
 		(define prefix (toUpper (strrtrim (substr q 0 pos))))
 		(or
@@ -80,12 +80,12 @@ literals, DDL/DML and already-parameterized statements keep exact cache keys. */
 /* cached_parse: wraps a parser with cachemap-based caching.
 cache_key = username:schema:hash(query) — per-user isolation (policy checked at parse time).
 The query is hashed with FNV-1a (fnv_hash) so long SQL strings don't bloat the cache index.
-	LIKE/AGAINST strings may be parameterized into session variables, but their
-	bindings still participate in the key because the planner may choose different
-	physical strategies from their selectivity.
-	Session-sensitive plans must not be reused under a binding-blind key because
-	their lowered runtime helper names and cache domains may depend on current
-	session variables.
+LIKE/AGAINST strings may be parameterized into session variables, but their
+bindings still participate in the key because the planner may choose different
+physical strategies from their selectivity.
+Session-sensitive plans must not be reused under a binding-blind key because
+their lowered runtime helper names and cache domains may depend on current
+session variables.
 On parse error the result is not cached (e.g. table does not exist yet). */
 (define cached_parse (lambda (queryplan_cache parse_fn schema query policy username session parameterize_like_strings)
 	(begin
@@ -94,16 +94,12 @@ On parse error the result is not cached (e.g. table does not exist yet). */
 				(reduce (produceN (count bindings)) (lambda (_ idx)
 					(session (concat "v" (string (+ idx 1))) (nth bindings idx))) nil)
 				nil)
-				(define cache_payload (if (not (equal? bindings '()))
-					(serialize (list parse_query bindings))
-					parse_query))
-				(define cache_key (concat username ":" schema ":" (fnv_hash cache_payload)))
-			(define cached (queryplan_cache cache_key))
-			(if cached cached
-				(begin
-					(define formula (with_session session (lambda () (parse_fn schema parse_query policy))))
-					(queryplan_cache cache_key formula)
-					formula)))))))
+			(define cache_payload (if (not (equal? bindings '()))
+				(serialize (list parse_query bindings))
+				parse_query))
+			(define cache_key (concat username ":" schema ":" (fnv_hash cache_payload)))
+			(queryplan_cache "get_or_compute" cache_key
+				(lambda () (with_session session (lambda () (parse_fn schema parse_query policy))))))))))
 
 /* helper: build a policy function for table-level access checks
 usage: create a policy by (set policy (sql_policy "username")),

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1721,6 +1721,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (contains? cm_keys "k1") true "cachemap lists key k1")
 	(assert (contains? cm_keys "a") true "cachemap lists key a")
 	(assert (contains? cm_keys "b") true "cachemap lists key b")
+	/* concurrent misses run exactly one producer and share its value */
+	(define sf_cm (newcachemap))
+	(define sf_calls (newsession))
+	(define sf_values (parallelN 8 (lambda (i)
+		(sf_cm "get_or_compute" "shared" (lambda () (begin
+			(sf_calls (string i) true)
+			(sleep 0.02)
+			123))))))
+	(assert sf_values '(123 123 123 123 123 123 123 123) "cachemap singleflight shares producer value")
+	(assert (count (sf_calls)) 1 "cachemap singleflight runs one producer")
+	/* failed producers are not cached and a later caller can retry */
+	(assert (try
+		(lambda () (begin (sf_cm "get_or_compute" "retry" (lambda () (car (sf_calls "missing")))) false))
+		(lambda (e) true)) true "cachemap singleflight forwards producer panic")
+	(assert (sf_cm "get_or_compute" "retry" (lambda () 77)) 77 "cachemap singleflight retries after panic")
 
 	(print "finished unit tests")
 	(print "test result: " (teststat "success") "/" (teststat "count"))

--- a/storage/cachemap.go
+++ b/storage/cachemap.go
@@ -17,6 +17,7 @@ Copyright (C) 2025-2026  MemCP Contributors
 package storage
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -38,15 +39,27 @@ type cacheMapEntry struct {
 type cacheMap struct {
 	mu      sync.RWMutex
 	entries map[string]*cacheMapEntry
+	flights map[string]*cacheMapFlight
+}
+
+type cacheMapFlight struct {
+	done       chan struct{}
+	cancel     context.CancelFunc
+	value      scm.Scmer
+	panicValue any
+	failed     bool
+	waiters    int
 }
 
 // NewCacheMap creates a new cachemap and returns a Scheme function.
 // (cachemap key value) — set entry
 // (cachemap key) — get entry (or nil)
 // (cachemap) — list all keys
+// (cachemap "get_or_compute" key producer) — get or run producer once per key
 func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 	cm := &cacheMap{
 		entries: make(map[string]*cacheMapEntry),
+		flights: make(map[string]*cacheMapFlight),
 	}
 	return scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
 		switch len(a) {
@@ -74,47 +87,172 @@ func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 			// set
 			key := scm.String(a[0])
 			value := a[1]
-			valueSize := int64(scm.ComputeSize(value))
-			entrySize := valueSize + cacheMapEntryOverhead + int64(len(key))
-
-			entry := &cacheMapEntry{
-				cm:    cm,
-				key:   key,
-				value: value,
-				size:  entrySize,
-			}
-			entry.lastUsed.Store(time.Now().UnixNano())
-
-			// Remove old entry from CacheManager if it exists
-			cm.mu.Lock()
-			if old, ok := cm.entries[key]; ok {
-				GlobalCache.Remove(old)
-			}
-			cm.entries[key] = entry
-			cm.mu.Unlock()
-
-			// Register with CacheManager for LRU eviction
-			GlobalCache.AddItem(
-				entry,
-				entrySize,
-				TypeCacheEntry,
-				cacheMapCleanup,
-				cacheMapGetLastUsed,
-				nil,
-			)
-
+			cm.store(key, value)
 			return value
+		case 3:
+			if scm.String(a[0]) != "get_or_compute" {
+				panic("cachemap: unknown 3-argument operation")
+			}
+			return cm.getOrCompute(scm.String(a[1]), a[2])
 		default:
-			panic("cachemap: expected 0, 1, or 2 arguments")
+			panic("cachemap: expected 0, 1, 2, or 3 arguments")
 		}
 	})
+}
+
+func newCacheMapEntry(cm *cacheMap, key string, value scm.Scmer) *cacheMapEntry {
+	entry := &cacheMapEntry{
+		cm:    cm,
+		key:   key,
+		value: value,
+		size:  int64(scm.ComputeSize(value)) + cacheMapEntryOverhead + int64(len(key)),
+	}
+	entry.lastUsed.Store(time.Now().UnixNano())
+	return entry
+}
+
+func registerCacheMapEntry(entry *cacheMapEntry) {
+	GlobalCache.AddItem(
+		entry,
+		entry.size,
+		TypeCacheEntry,
+		cacheMapCleanup,
+		cacheMapGetLastUsed,
+		nil,
+	)
+}
+
+func (cm *cacheMap) store(key string, value scm.Scmer) {
+	entry := newCacheMapEntry(cm, key, value)
+	cm.mu.Lock()
+	old := cm.entries[key]
+	cm.entries[key] = entry
+	cm.mu.Unlock()
+	if old != nil {
+		GlobalCache.Remove(old)
+	}
+	registerCacheMapEntry(entry)
+}
+
+func currentCacheMapContext() context.Context {
+	if value, ok := scm.GetGLSValue("context"); ok {
+		if ctx, ok := value.(context.Context); ok {
+			return ctx
+		}
+	}
+	return context.Background()
+}
+
+func (cm *cacheMap) getOrCompute(key string, producer scm.Scmer) scm.Scmer {
+	cm.mu.RLock()
+	if entry := cm.entries[key]; entry != nil {
+		entry.lastUsed.Store(time.Now().UnixNano())
+		cm.mu.RUnlock()
+		return entry.value
+	}
+	cm.mu.RUnlock()
+
+	cm.mu.Lock()
+	if entry := cm.entries[key]; entry != nil {
+		entry.lastUsed.Store(time.Now().UnixNano())
+		cm.mu.Unlock()
+		return entry.value
+	}
+	flight := cm.flights[key]
+	if flight == nil {
+		compileCtx, cancel := context.WithCancel(context.Background())
+		flight = &cacheMapFlight{
+			done:    make(chan struct{}),
+			cancel:  cancel,
+			waiters: 1,
+		}
+		cm.flights[key] = flight
+		go cm.runProducer(compileCtx, key, producer, flight)
+	} else {
+		flight.waiters++
+	}
+	cm.mu.Unlock()
+
+	ctx := currentCacheMapContext()
+	select {
+	case <-flight.done:
+		if flight.failed {
+			panic(flight.panicValue)
+		}
+		return flight.value
+	case <-ctx.Done():
+		cm.cancelWaiter(key, flight)
+		panic(ctx.Err())
+	}
+}
+
+func (cm *cacheMap) cancelWaiter(key string, flight *cacheMapFlight) {
+	cm.mu.Lock()
+	if cm.flights[key] == flight {
+		flight.waiters--
+		if flight.waiters == 0 {
+			delete(cm.flights, key)
+			flight.cancel()
+		}
+	}
+	cm.mu.Unlock()
+}
+
+func (cm *cacheMap) runProducer(ctx context.Context, key string, producer scm.Scmer, flight *cacheMapFlight) {
+	value, panicValue, failed := runCacheMapProducer(ctx, producer)
+
+	var entry *cacheMapEntry
+	if !failed && ctx.Err() == nil {
+		entry = newCacheMapEntry(cm, key, value)
+	}
+
+	cm.mu.Lock()
+	if cm.flights[key] != flight {
+		cm.mu.Unlock()
+		close(flight.done)
+		return
+	}
+	delete(cm.flights, key)
+	flight.value = value
+	flight.panicValue = panicValue
+	flight.failed = failed || ctx.Err() != nil
+	var old *cacheMapEntry
+	if entry != nil {
+		old = cm.entries[key]
+		cm.entries[key] = entry
+	}
+	close(flight.done)
+	cm.mu.Unlock()
+
+	if old != nil {
+		GlobalCache.Remove(old)
+	}
+	if entry != nil {
+		registerCacheMapEntry(entry)
+	}
+}
+
+func runCacheMapProducer(ctx context.Context, producer scm.Scmer) (value scm.Scmer, panicValue any, failed bool) {
+	failed = true
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			panicValue = recovered
+		}
+	}()
+	scm.NewContext(ctx, func() {
+		value = scm.Apply(producer)
+	})
+	failed = false
+	return
 }
 
 // cacheMapCleanup is called by CacheManager on eviction.
 func cacheMapCleanup(pointer any, freedByType *[numEvictableTypes]int64) bool {
 	entry := pointer.(*cacheMapEntry)
 	entry.cm.mu.Lock()
-	delete(entry.cm.entries, entry.key)
+	if entry.cm.entries[entry.key] == entry {
+		delete(entry.cm.entries, entry.key)
+	}
 	entry.cm.mu.Unlock()
 	return true
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2830,7 +2830,7 @@ func Init(en scm.Env) {
 	initMetricsDeclarations(en)
 	scm.DeclareInSection("Sync", &en, &scm.Declaration{
 		Name: "newcachemap",
-		Desc: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys.",
+		Desc: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
 		Fn:   NewCacheMap,
 		Type: &scm.TypeDescriptor{
 			Return: &scm.TypeDescriptor{Kind: "func"},


### PR DESCRIPTION
## Root cause

The exact query-plan cache used a separate get, compile and set sequence. Concurrent requests with the same cold cache key therefore all compiled the same plan. The compiler is allocation/GC-heavy for wide decorrelated queries, so duplicate compilation also slowed unrelated workers through CPU and GC contention.

## Change

- Add a named `get_or_compute` cachemap operation.
- Coordinate only callers using the same exact cache key.
- Run the producer outside the cache lock; different keys retain full parallelism.
- Share the resulting `Scmer` directly without copying.
- Propagate producer failures to all waiters and allow a later retry.
- Let an individual waiter cancel independently; cancel shared compilation once no waiter remains.
- Use the operation in `cached_parse` without changing query-plan cache keys or literal/selectivity semantics.
- Make eviction cleanup conditional on entry identity so an old callback cannot remove a replacement entry.

## Tests

- Scheme regression: eight concurrent callers receive one producer result and the producer runs once.
- Scheme regression: producer panic reaches the caller and is not cached; a later call retries successfully.
- `python3 run_sql_tests.py tests/01_basic_sql.yaml`: 26/26.
- `python3 run_sql_tests.py tests/80_prepared_stmts.yaml`: 20/20.
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all repository SQL, persistence, crash and lock suites passed.
- Full manual/browser suite: passed.

The Go race binary cannot run the startup suite on either revision because the existing amd64 JIT fails under `-race`/checkptr at `scm/jit_amd64.go:33` before reaching the cachemap test.

## A/B performance

Baseline: `6c248a2d2cf58a331fb630460a27ecb6152b7837`.

Synthetic SQL shape: twelve independent correlated scalar aggregates over one parent/child relation. A warmed server received four concurrent requests. Every repetition used a new exact cache key; all four requests within a repetition used the same key.

| Four concurrent cold requests | master | branch | change |
|---|---:|---:|---:|
| run 1 | 348.9 ms | 276.7 ms | -20.7% |
| run 2 | 170.8 ms | 109.7 ms | -35.8% |
| run 3 | 174.6 ms | 106.0 ms | -39.3% |
| run 4 | 214.4 ms | 105.1 ms | -51.0% |
| run 5 | 166.1 ms | 109.0 ms | -34.3% |
| median | 174.6 ms | 109.0 ms | **-37.6%** |

Control with four different cold keys, proving that keys are not globally serialized:

| Four concurrent distinct keys | master | branch |
|---|---:|---:|
| wall time | 144.5 ms | 142.2 ms |

End-to-end manual/browser build with four test workers and identical configuration:

| master | branch | change |
|---:|---:|---:|
| 92.70 s | 85.70 s | **-7.00 s / -7.6%** |

This PR addresses compile stampedes, not single-query cold compile latency. Physical-lowering catalog/DAG work remains responsible for bringing one cold compile down to the millisecond target.
