### PR TITLE
Restore nested stage metadata during lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7187,7 +7187,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define lower_group_stage_prepare_using (lambda (all_stages stage)
 	(begin
 		(define src (gs_input stage))
-		(define stage_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
+		(define stage_catalog (stage_catalog_with_nested
+			(merge (list
+				all_stages
+				(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
 			true)
@@ -7956,7 +7959,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 							(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
 						(cons (quote !begin)
 							(merge (list
-									(lazy_stage_prepare_bindings lazy_catalog lazy_stages)
+									(lazy_stage_prepare_bindings stage_catalog lazy_stages)
 									(map eager_stages (lambda (stage)
 										(lower_stage_prepare_using
 											(stage_dependency_closure_using_graph dependency_graph stage)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -207,6 +207,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (expr_contains_subquery? (untangle_query_term scalar_no_from_ast nil)) false "untangle_query unnests zero-domain expression subqueries")
 	(assert (equal? (serialize (build_queryplan_term scalar_no_from_ast))
 		"(resultrow '(\"x\" 8 \"in_ok\" (if (nil? 8) nil (if (nil? 8) nil (equal?? 8 8))) \"exists_ok\" true))") true "build_queryplan_term lowers zero-domain expression subqueries")
+	(define nested_catalog_stage (make_group_stage
+		"nested-catalog-stage"
+		(list "n" "memcp-tests" "nested_source" false nil)
+		'() '(1) '() nil '() '() nil nil '()))
+	(define nested_catalog_input (make_query_block
+		"memcp-tests"
+		(list
+			(list "o" "memcp-tests" "outer_source" false nil)
+			(list "nested" "memcp-tests" (make_stage_output_relation "nested-catalog-stage") false true))
+		'() true '() nil '() nil nil '() '() '()))
+	(define outer_catalog_stage (make_group_stage
+		"outer-catalog-stage"
+		nested_catalog_input
+		'() '(1) '() nil '() '() nil nil
+		(list (list 'stage_catalog (list nested_catalog_stage)))))
+	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) outer_catalog_stage))
+		true "group-stage lowering keeps nested stage-output metadata from the full catalog")
 	(define btw_outer_sources (list (list "o" "memcp-tests" "outer_t" false nil)))
 	(define btw_inner_sources (list (list "i" "memcp-tests" "inner_t" false nil)))
 	(define btw_outer_id (list 'get_column "o" false "id" false))


### PR DESCRIPTION
## Summary

- restore the complete nested stage catalog when lowering a group stage
- build lazy dependency closures from the full catalog while keeping the lazy root selection narrow
- add a deterministic Scheme regression test for a nested stage-output reference omitted from the selected subset

## Root cause

The physical dependency optimization introduced in #317 reused the reduced lazy-stage subset as a metadata catalog. A lazy scalar stage may depend on nested stages that were already selected eagerly. Those stages were absent from the reduced catalog, so physicalization failed with an unknown stage-output error.

## A/B measurement

Measured on the imported production-derived fixture with the full prefix cascade. Master was rebuilt from `3873cdeb6`; every prefix failed during physical lowering with HTTP 500. The PR completed every query. Cold is the first request after startup; warm is the median of three requests after one warmup.

| Prefix | master | PR cold | PR warm median |
|---|---:|---:|---:|
| C | HTTP 500 | 2.624 s | 0.430 s |
| Ca | HTTP 500 | 2.593 s | 0.416 s |
| Car | HTTP 500 | 2.597 s | 0.426 s |
| Carg | HTTP 500 | 2.648 s | 0.463 s |
| Cargl | HTTP 500 | 2.610 s | 0.456 s |
| Cargla | HTTP 500 | 2.594 s | 0.417 s |
| Carglas | HTTP 500 | 2.525 s | 0.462 s |
| Carglass | HTTP 500 | 2.448 s | 0.445 s |
| CarglassXXX | HTTP 500 | 2.490 s | 0.421 s |

All successful responses matched the reference response hash.

## Validation

- Scheme self-tests: 826/826 passed
- new regression test verified red on #317 and green on this branch
- `tests/67_computed_columns_exprs.yaml`: 18/18 passed in isolation
- `tests/118_manual_trace_sql_regressions.yaml`: 15/16 passed; all functional assertions passed, while the existing 300 ms compile gate measured 353 ms under concurrent host profiling load
- full local `make test` was attempted, then stopped after unrelated shared-server HTTP timeouts; the first timed-out suite passed 18/18 immediately in isolation
- `git diff --check` passed
- Scheme formatter check still reports the existing master formatting/depth warnings in `lib/queryplan.scm` and parser files