### PR TITLE
Preserve nested stage catalogs during physical lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4595,7 +4595,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define rows_plan (lower_query_block_as_dataset_rows prepared_input (list "__value" value_expr)))
 		(define prepare_exprs (merge (list
 			(map nested_stages (lambda (nested_stage)
-				(lower_stage_prepare_using nested_stages nested_stage)))
+				(lower_stage_prepare_using nested_stages nested_stages nested_stage)))
 			(lower_stage_materialize_all nested_stages))))
 		(define probe_expr (list (quote scan)
 			'(session "__memcp_tx")
@@ -6418,9 +6418,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(if (not (stage_output_relation? relation))
 			src
 			(begin
-				(define stage (stage_by_id stages (stage_output_relation_id relation)))
+				(define id (stage_output_relation_id relation))
+				(define stage (stage_by_id stages id))
 				(if (nil? stage)
-					(neumann_fail "build_queryplan" (concat "physicalize stage-output source references unknown stage " (stage_output_relation_id relation)))
+					(neumann_fail "build_queryplan" (concat "physicalize stage-output source references unknown stage " id))
 					true)
 				(source_with_schema_relation
 					src
@@ -6438,12 +6439,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(if (not (stage_output_relation? relation))
 				nil
 				(begin
-					(define stage (stage_by_id stages (stage_output_relation_id relation)))
+					(define id (stage_output_relation_id relation))
+					(define stage (stage_by_id stages id))
 					(if (nil? stage)
-						(neumann_fail "build_queryplan" (concat "dependency stage-output source references unknown stage " (stage_output_relation_id relation)))
+						(neumann_fail "build_queryplan" (concat "dependency stage-output source references unknown stage " id))
 						stage)))
 			_ nil)))
 		(lambda (stage) (not (nil? stage))))))))
+
+(define available_stage_outputs_from_sources_using (lambda (stages sources)
+	(filter (map (coalesceNil sources '()) (lambda (src)
+		(if (stage_output_relation? (source_relation src))
+			(stage_by_id stages (stage_output_relation_id (source_relation src)))
+			nil)))
+		(lambda (stage) (not (nil? stage))))))
 
 (define source_stage_output_stage (lambda (stages src)
 	(if (not (stage_output_relation? (source_relation src)))
@@ -7184,12 +7193,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 				acc
 				(list (merge kept (list stage)) (merge seen (list identity)))))) (list '() '())) 0)))
 
-(define lower_group_stage_prepare_using (lambda (all_stages stage)
+(define lower_group_stage_prepare_using (lambda (all_stages lookup_stages stage)
 	(begin
 		(define src (gs_input stage))
+		(define prepare_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
 		(define stage_catalog (stage_catalog_with_nested
 			(merge (list
-				all_stages
+				prepare_catalog
+				lookup_stages
 				(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
@@ -7244,16 +7255,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 			rewritten_src))
 		(define direct_nested_stages (if (query_block? rewritten_src)
 			(merge_unique (list
-				(query_block_stages_to_prepare_using stage_catalog rewritten_src)
-				(stage_outputs_from_sources_using stage_catalog (qb_sources rewritten_src))
-				(stage_outputs_from_sources_using stage_catalog (group_stage_final_extra_source_refs stage))
-				(carrier_stages_from_sources stage_catalog (qb_sources rewritten_src))
-				(carrier_stages_from_sources stage_catalog (group_stage_final_extra_source_refs stage))
+				(query_block_stages_to_prepare_using prepare_catalog rewritten_src)
+				(available_stage_outputs_from_sources_using prepare_catalog (qb_sources rewritten_src))
+				(available_stage_outputs_from_sources_using prepare_catalog (group_stage_final_extra_source_refs stage))
+				(carrier_stages_from_sources prepare_catalog (qb_sources rewritten_src))
+				(carrier_stages_from_sources prepare_catalog (group_stage_final_extra_source_refs stage))
 				(query_block_probe_expr_stages rewritten_src)))
 			'()))
 		(define nested_stages direct_nested_stages)
 		(define nested_prepare (if (query_block? rewritten_src) (map nested_stages (lambda (nested_stage)
-			(lower_stage_prepare_using stage_catalog nested_stage))) '()))
+			(lower_stage_prepare_using prepare_catalog stage_catalog nested_stage))) '()))
 		(define nested_materialize (if (query_block? rewritten_src) (lower_stage_materialize_all nested_stages) '()))
 		(define nested_prepare_expr (if (empty_list? nested_prepare)
 			nil
@@ -7390,17 +7401,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(filter (map (coalesceNil stages '()) lower_stage_materialize)
 		(lambda (plan) (not (nil? plan))))))
 
-(define lower_stage_prepare_using (lambda (all_stages stage)
+(define lower_stage_prepare_using (lambda (all_stages lookup_stages stage)
 	(if (group_stage? stage)
-		(lower_group_stage_prepare_using all_stages stage)
+		(lower_group_stage_prepare_using all_stages lookup_stages stage)
 		(if (orc_stage? stage)
 			(lower_orc_stage_prepare stage)
 			(if (window_stage? stage)
 				(lower_window_stage_prepare stage)
 				(neumann_fail "build_queryplan" "unknown logical stage"))))))
-
 (define lower_stage_prepare (lambda (stage)
-	(lower_stage_prepare_using (list stage) stage)))
+	(lower_stage_prepare_using (list stage) (list stage) stage)))
 
 (define nested_stage_catalog (lambda (stage)
 	(begin
@@ -7448,7 +7458,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(nested_stage_catalog stage)
 				(if (query_block? src) (query_block_stage_catalog src) '())))))
 		(list (quote begin)
-			(lower_group_stage_prepare_using stage_catalog stage)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog stage)
 			(lower_query_block_core_with_lazy_prepares stage_catalog
 				(group_stage_final_block stage (group_stage_final_extra_sources_using stage_catalog stage)))))))
 
@@ -7791,9 +7801,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(map (qb_stages rewritten) (lambda (stage)
 							(lower_stage_prepare_using
 								(stage_dependency_closure_using_graph dependency_graph stage)
+								stage_catalog
 								stage)))
 						(lower_stage_materialize_all (qb_stages rewritten))
-						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage))
+						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) (cons main_stage stage_catalog) main_stage))
 						(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources)))))))))))
 
 (define query_block_without_stages (lambda (block)
@@ -7963,6 +7974,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 									(map eager_stages (lambda (stage)
 										(lower_stage_prepare_using
 											(stage_dependency_closure_using_graph dependency_graph stage)
+											stage_catalog
 											stage)))
 									(list (lower_query_block_core core_block))))))))))))))
 
@@ -8000,7 +8012,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(list (list (quote context) "session") (stage_prepare_key stage))
 		(quoted_runtime_list '()))))
 
-(define lazy_stage_prepare_binding (lambda (dependency_graph stage)
+(define lazy_stage_prepare_binding (lambda (dependency_graph stage stage_catalog)
 	(begin
 		(define dependencies (stage_dependency_closure_using_graph dependency_graph stage))
 		(list
@@ -8010,14 +8022,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(list (quote lambda)
 					'()
 					(list (quote !begin)
-						(lower_stage_prepare_using dependencies stage)
+						(lower_stage_prepare_using dependencies stage_catalog stage)
 						true)))))))
 
 (define lazy_stage_prepare_bindings (lambda (stages selected)
 	(begin
 		(define dependency_graph (stage_dependency_graph stages))
 		(map (coalesceNil selected '()) (lambda (stage)
-			(lazy_stage_prepare_binding dependency_graph stage))))))
+			(lazy_stage_prepare_binding dependency_graph stage stages))))))
 
 (define lower_query_block_core_with_lazy_prepares (lambda (stage_catalog block)
 	(begin
@@ -8951,7 +8963,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 										(not (stage_id_in? stage prelimit_stage_ids)))))
 									(define project_prepare_expr (cons (quote !begin)
 										(map project_stages (lambda (stage)
-										(lower_stage_prepare_using stage_catalog stage)))))
+										(lower_stage_prepare_using stage_catalog stage_catalog stage)))))
 									(define project_row_expr
 										(lower_join_result_row_assoc scan_sources first_alias fields order_items))
 									(define project_rows_expr (replace_lowered_driver_symbols_with_row first_alias driver_cols
@@ -9168,7 +9180,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(cons (quote begin)
 			(merge (list
 				(map (qb_stages block) (lambda (stage)
-					(lower_stage_prepare_using (qb_stages block) stage)))
+					(lower_stage_prepare_using (qb_stages block) (qb_stages block) stage)))
 				(list (lower_dml_query_block_core (query_block_without_stages_after_prepare_using (qb_stages block) block) target_schema target_tbl))))))))
 
 (define lower_dml_union_block_with_stages (lambda (block target_schema target_tbl)
@@ -9281,7 +9293,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(define stage (make_group_stage_for_block branch src))
 				(define final_block (group_stage_final_block stage (group_stage_final_extra_sources stage)))
 				(if (union_ordered_branch_supported? final_block)
-					(list (list (lower_group_stage_prepare_using (list stage) stage)) final_block)
+					(list (list (lower_group_stage_prepare_using (list stage) (list stage) stage)) final_block)
 					nil))))))
 
 (define union_ordered_branch_stream_plan (lambda (branch)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -222,7 +222,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		nested_catalog_input
 		'() '(1) '() nil '() '() nil nil
 		(list (list 'stage_catalog (list nested_catalog_stage)))))
-	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) outer_catalog_stage))
+	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) (list outer_catalog_stage) outer_catalog_stage))
 		true "group-stage lowering keeps nested stage-output metadata from the full catalog")
 	(define btw_outer_sources (list (list "o" "memcp-tests" "outer_t" false nil)))
 	(define btw_inner_sources (list (list "i" "memcp-tests" "inner_t" false nil)))

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1624,7 +1624,39 @@ test_cases:
           "ref:canView": false
           global_can_view: false
 
+
+  - name: "Nested scalar physical lookup resolves attached presence stages"
+    fail_comment: "physical lookup must resolve attached catalogs without expanding the prepare closure"
+    max_plan_size: 100000
+    setup:
+      - sql: "DROP TABLE IF EXISTS assignment_x"
+      - sql: "DROP TABLE IF EXISTS item_x"
+      - sql: "DROP TABLE IF EXISTS tenant_x"
+      - sql: "DROP TABLE IF EXISTS location_x"
+      - sql: "DROP TABLE IF EXISTS file_x"
+      - sql: "CREATE TABLE assignment_x (ID INT PRIMARY KEY, actor INT, tenant_x INT, location_x INT)"
+      - sql: "CREATE TABLE item_x (ID INT PRIMARY KEY, file INT, tenant_x INT, location_x INT)"
+      - sql: "CREATE TABLE tenant_x (ID INT PRIMARY KEY, name VARCHAR(64))"
+      - sql: "CREATE TABLE location_x (ID INT PRIMARY KEY, tenant_x INT)"
+      - sql: "CREATE TABLE file_x (ID INT PRIMARY KEY, filename VARCHAR(64), search VARCHAR(64))"
+    sql: |
+      EXPLAIN SELECT `item_x`.`ID`, `ref:tenant`.`tenant:canView` FROM `item_x` `item_x`
+      LEFT JOIN (SELECT `ID` AS `tenant:ID`, `tenant_x`.`name` AS `tenant:description`, (((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND (CASE WHEN (('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ('1') THEN TRUE ELSE EXISTS (SELECT (TRUE) FROM `assignment_x` `tenant_acl` WHERE `tenant_acl`.`tenant_x` = `tenant_x`.`ID` AND ((`tenant_acl`.`actor`) = (999)) LIMIT 1) END)) AS `tenant:canView`, ((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND (CASE WHEN (('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ('1') THEN TRUE ELSE EXISTS (SELECT (TRUE) FROM `assignment_x` `tenant_acl` WHERE `tenant_acl`.`tenant_x` = `tenant_x`.`ID` AND ((`tenant_acl`.`actor`) = (999)) LIMIT 1) END) AS `tenant:tiar:tenant:view` FROM `tenant_x`) `ref:tenant` ON `ref:tenant`.`tenant:ID` = `tenant_x`
+      WHERE ((((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND ((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1)))) OR ('1')) AND ((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND (COALESCE((SELECT (((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1)))) OR ('1')) AND (CASE WHEN (('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ('1') THEN TRUE ELSE EXISTS (SELECT (TRUE) FROM `assignment_x` `location_acl` WHERE TRUE AND (((COALESCE(`location_acl`.`location_x`, `current_location`.`ID`)) = (`current_location`.`ID`)) AND ((`location_acl`.`actor`) = (999))) LIMIT 1) END) AND ((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND (COALESCE((SELECT (((('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ((NOT ('1')) AND (NOT ('0')) AND (NOT (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_deny` WHERE `global_deny`.`actor` = 999 AND ((`global_deny`.`tenant_x`) IS NULL) LIMIT 1))))) AND (CASE WHEN (('0') OR (EXISTS (SELECT (TRUE) FROM `assignment_x` `global_allow` WHERE `global_allow`.`actor` = 999 AND ((`global_allow`.`tenant_x`) IS NULL) LIMIT 1))) OR ('1') THEN TRUE ELSE EXISTS (SELECT (TRUE) FROM `assignment_x` `tenant_acl` WHERE `tenant_acl`.`tenant_x` = `parent_tenant`.`ID` AND ((`tenant_acl`.`actor`) = (999)) LIMIT 1) END)) FROM `tenant_x` `parent_tenant` WHERE `parent_tenant`.`ID` = `current_location`.`tenant_x` LIMIT 1), FALSE))) FROM `location_x` `current_location` WHERE `current_location`.`ID` = `item_x`.`location_x` LIMIT 1), FALSE))))
+       AND item_x.file IN (SELECT ID FROM file_x WHERE filename LIKE '%x%' UNION SELECT ID FROM file_x WHERE search LIKE '%x%') ORDER BY item_x.ID LIMIT 10
+    expect:
+      rows: 1
+      contains:
+        - "createtable"
+      not_contains:
+        - "unknown stage"
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS assignment_x"
+  - sql: "DROP TABLE IF EXISTS item_x"
+  - sql: "DROP TABLE IF EXISTS tenant_x"
+  - sql: "DROP TABLE IF EXISTS location_x"
+  - sql: "DROP TABLE IF EXISTS file_x"
   - sql: "DROP TABLE IF EXISTS membership_assignment"
   - sql: "DROP TABLE IF EXISTS membership_item"
   - sql: "DROP TABLE IF EXISTS in_ref_acl"


### PR DESCRIPTION
## Root cause and relationship to current master

The indexed physical dependency closure introduced in `296952da5` correctly limits which stages are prepared, but the same reduced list was originally also reused as the stage lookup catalog. Nested scalar/reference plans could therefore lose shared presence-stage metadata during physicalization.

Current master already contains two related follow-ups:

- `#319` adds compile-phase accounting only; it does not change planning decisions.
- `#320` restores recursively nested stage metadata and passes the full catalog to lazy preparation. Its group lowering, however, uses the expanded lookup catalog as its prepare catalog as well.

This PR combines the concepts semantically: recursive metadata coverage from `#320` remains available for expression rewriting and physical source resolution, while the dependency closure remains the only source of stages selected for preparation.

## Change

- Pass prepare stages and lookup stages as separate inputs through group-stage lowering.
- Build the lookup catalog recursively from the full stage metadata introduced by `#320`.
- Keep direct nested preparation restricted to the dependency closure.
- Preserve strict unknown-stage validation for normal dependency and physicalization paths.
- Use a deliberately tolerant local lookup only while selecting members already present in the narrow prepare closure.
- Do not add materialization or eagerly prepare unrelated stages.

## Regression

An anonymized SQL case in `tests/41_in_subquery.yaml` combines nested scalar references, repeated presence aggregates, a derived reference projection, and membership over a UNION.

- A, historical master `3873cdeb6286a6daeee39b2b725c4fafc3a99907`: 51/52, HTTP 500 (`unknown stage`)
- C, this PR: 52/52, query compiles successfully
- The Scheme regression added by `#320` remains enabled and uses the unified prepare/lookup API.
- Existing wide-plan budget remains green: `tests/118_manual_trace_sql_regressions.yaml` 16/16, including the 30 kB maximum plan-size gate.

## MemCP A/B/C performance

A is the historical result already documented on this PR. B and C were remeasured interleaved on identical private fixture copies.

Cold `EXPLAIN` compilation of the same anonymized eight-scalar query, 20 runs per revision:

| Revision | Commit | p50 | p95 | mean |
| --- | --- | ---: | ---: | ---: |
| A: historical master | `3873cdeb6` | 230.768 ms | 345.325 ms | 241.041 ms |
| B: current master | `4730cb8c2` | 349.779 ms | 364.732 ms | 350.073 ms |
| C: current PR | `a6bf2b7ca` | 293.348 ms | 314.369 ms | 293.288 ms |

A is retained as historical context and was measured in an earlier run. The directly comparable interleaved B/C result shows C reducing compile p50 by 16.1%.

Production-sized private fixture, full wide ordered/limited query with a nine-term short-to-selective prefix cascade:

| Revision | Result | Cold range | Mean |
| --- | --- | ---: | ---: |
| A: historical master | HTTP 500 during compilation | n/a | n/a |
| B: current master | HTTP 200 for all terms | 2.370-2.428 s | 2.403 s |
| C: current PR | HTTP 200 for all terms | 2.292-2.358 s | 2.329 s |

C is 3.1% faster than B on the complete query cascade. No private schema, data, names, or query text is included in this branch or PR.

## Manual A/B against MySQL

One complete German-language run per database, four Playwright workers, fresh test database/datadir. Both runs passed.

| A/B | Database/revision | Total wall time | Search stage | Open stage | Archive-download stage |
| --- | --- | ---: | ---: | ---: | ---: |
| A | MySQL-compatible reference | 57.28 s | 10.9 s | 8.5 s | 7.8 s |
| B | MemCP current PR | 80.49 s | 18.1 s | 11.3 s | 13.0 s |

MemCP is currently 23.21 s / 40.5% slower over the complete manual workflow. Current MemCP master was also measured as a control at 79.45 s total, with 18.2 s / 11.3 s / 13.0 s for the same SQL-heavy stages. The 1.04 s total difference between current master and this PR comes from setup/authentication stage variance; the SQL-heavy stages are equal or marginally faster on this PR. The broader MemCP-vs-MySQL gap remains follow-up work.

## Validation

- `go build -o memcp`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml` (52/52)
- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml` (16/16)
- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (all tests passed)
- full application manual: current master, this PR, and MySQL-compatible reference all passed
- `git diff --check`
- `python3 tools/lint_scm.py --check` (only pre-existing repository warnings)
