### PR TITLE
Propagate Scheme helper return ownership

### DIFF
--- a/scm/declare.go
+++ b/scm/declare.go
@@ -140,6 +140,7 @@ func (ti TypeInfo) Length() int {
 func (ti TypeInfo) WithTransfer() TypeInfo    { ti.flags |= FlagTransfer; return ti }
 func (ti TypeInfo) WithoutTransfer() TypeInfo { ti.flags &^= FlagTransfer; return ti }
 func (ti TypeInfo) WithConst() TypeInfo       { ti.flags |= FlagConst; return ti }
+func (ti TypeInfo) WithoutConst() TypeInfo    { ti.flags &^= FlagConst; return ti }
 func (ti TypeInfo) WithKind(k uint8) TypeInfo { ti.kind = k; return ti }
 func (ti TypeInfo) WithLength(n int) TypeInfo {
 	if n <= 0 {
@@ -217,7 +218,35 @@ func (ti TypeInfo) ToTypeDescriptor() *TypeDescriptor {
 		td.NoEscape = !ti.Escape()
 		td.Length = ti.Length()
 	}
+	if td.Kind == "" {
+		td.Kind = ti.kindName()
+	}
 	return td
+}
+
+func (ti TypeInfo) kindName() string {
+	switch ti.kind {
+	case KindString:
+		return "string"
+	case KindInt:
+		return "int"
+	case KindFloat:
+		return "number"
+	case KindBool:
+		return "bool"
+	case KindNil:
+		return "nil"
+	case KindSymbol:
+		return "symbol"
+	case KindFunc:
+		return "func"
+	case KindList:
+		return "list"
+	case KindAssoc:
+		return "assoc"
+	default:
+		return ""
+	}
 }
 
 // NoEscape is a reusable TypeDescriptor annotation for parameters that
@@ -227,11 +256,6 @@ var NoEscape = &TypeDescriptor{Kind: "any", NoEscape: true, Length: UnknownLengt
 var declaration_titles []string
 var declarations map[string]*Declaration = make(map[string]*Declaration)
 var declarations_hash map[string]*Declaration = make(map[string]*Declaration)
-
-// globalFuncTypeInfo stores optimizer type info for Scheme-defined functions.
-// Persists across import boundaries so cross-file ownership propagation works.
-// Not used for arity checks or documentation — only for optimizer type inference.
-var globalFuncTypeInfo = make(map[Symbol]TypeInfo)
 
 func DeclareTitle(title string) {
 	declaration_titles = append(declaration_titles, "#"+title)

--- a/scm/list.go
+++ b/scm/list.go
@@ -406,7 +406,11 @@ func exprMayHaveSideEffects(expr Scmer) bool {
 
 func optimizeListCall(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	result, td := oc.ApplyDefaultOptimization(v, useResult)
-	return result, descriptorWithLength(td, len(v)-1)
+	td = descriptorWithLength(td, len(v)-1)
+	if !td.Const {
+		td.Transfer = true
+	}
+	return result, td
 }
 
 func optimizeCount(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -244,6 +244,8 @@ type optimizerMetainfo struct {
 	ownedVars            map[Symbol]bool // variables known to hold exclusively owned values (e.g. reduce accumulators)
 	pendingCallbackOwned []bool          // when set, the next lambda's params at these indices are owned
 	loopDepth            int             // >0 inside scan/reduce callbacks; prevents hoisted defines from being inlined back into loops
+	lambdaDepth          int             // >0 while optimizing a lambda body; keeps local definitions out of Env hints
+	beginDepth           int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
 }
 
 func newOptimizerMetainfo() (result optimizerMetainfo) {
@@ -267,6 +269,8 @@ func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	}
 	result.setBlacklist = ome.setBlacklist
 	result.loopDepth = ome.loopDepth
+	result.lambdaDepth = ome.lambdaDepth
+	result.beginDepth = ome.beginDepth
 	// nextSlot is NOT propagated across lambda boundaries (each lambda has its own)
 	return
 }
@@ -287,6 +291,8 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.nextSlot = ome.nextSlot   // shared scope shares VarsNumbered
 	result.ownedVars = ome.ownedVars // shared scope inherits ownership info
 	result.loopDepth = ome.loopDepth
+	result.lambdaDepth = ome.lambdaDepth
+	result.beginDepth = ome.beginDepth
 	return
 }
 
@@ -664,6 +670,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 		}
 		ome2 := ome.CopySharedScope()
+		ome2.beginDepth++
 		slotLimit := -1
 		if headSym == Symbol("begin_mut") {
 			slotIndex := 0
@@ -791,6 +798,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		// current lexical scope and cannot see NthLocalVar-only parameters.
 		if expressionContainsEvalCall(v[2]) {
 			ome2 := ome.Copy()
+			ome2.lambdaDepth++
 			if list, ok := scmerSlice(params); ok {
 				for _, param := range list {
 					if sym, ok := scmerSymbol(param); ok {
@@ -800,8 +808,8 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			} else if sym, ok := scmerSymbol(params); ok {
 				delete(ome2.variableReplacement, sym)
 			}
-			v[2], transferOwnership, _ = optimizeExCompat(v[2], env, &ome2, true)
-			return NewSlice(v), MakeTypeInfo(transferOwnership, false)
+			v[2], _, _ = optimizeExCompat(v[2], env, &ome2, true)
+			return NewSlice(v), tiZero
 		}
 		/* Lambdas with explicit NumVars still execute in numbered-call frames at
 		runtime. Some generated plans keep symbolic parameter references in the
@@ -810,6 +818,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		Otherwise callbacks like $update remain unbound at runtime. */
 		if len(v) > 3 {
 			ome2 := ome.Copy()
+			ome2.lambdaDepth++
 			numVars := int(ToInt(v[3]))
 			if list, ok := scmerSlice(params); ok {
 				for i, param := range list {
@@ -823,11 +832,13 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			} else if sym, ok := scmerSymbol(params); ok {
 				ome2.variableReplacement[sym] = NewNthLocalVar(0)
 			}
-			v[2], transferOwnership, _ = optimizeExCompat(v[2], env, &ome2, true)
-			return NewSlice(v), MakeTypeInfo(transferOwnership, false)
+			var bodyType TypeInfo
+			v[2], bodyType = OptimizeEx(v[2], env, &ome2, true)
+			return NewSlice(v), bodyType.WithoutConst()
 		}
 		// Auto-number parameters
 		ome2 := ome.Copy()
+		ome2.lambdaDepth++
 		slotIndex := 0
 		if list, ok := scmerSlice(params); ok {
 			for _, param := range list {
@@ -859,17 +870,21 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 			ome.pendingCallbackOwned = nil // consumed
 		}
-		v[2], transferOwnership, _ = optimizeExCompat(v[2], env, &ome2, true)
+		var bodyType TypeInfo
+		v[2], bodyType = OptimizeEx(v[2], env, &ome2, true)
 		// Set NumVars (may have grown due to !list allocations)
 		if slotIndex > 0 {
 			v = append(v[:len(v):len(v)], NewInt(int64(slotIndex)))
 		}
-		return NewSlice(v), MakeTypeInfo(transferOwnership, false)
+		return NewSlice(v), bodyType.WithoutConst()
 	}
 
 	switch {
 	case headOk && (headSym == Symbol("set") || headSym == Symbol("define")) && len(v) == 3:
+		var definedSym Symbol
+		var hasDefinedSym bool
 		if sym, ok := scmerSymbol(v[1]); ok {
+			definedSym, hasDefinedSym = sym, true
 			for _, black := range ome.setBlacklist {
 				if black == sym {
 					if useResult {
@@ -881,11 +896,25 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			if repl, ok := ome.variableReplacement[sym]; ok && repl.IsNthLocalVar() {
 				v[1] = repl
 			}
+			if ome.lambdaDepth == 0 && ome.beginDepth == 0 {
+				env.deleteOptimizerHint(sym)
+			}
 		}
 		if v[1].IsNthLocalVar() {
 			v[0] = NewSymbol("setN")
 		}
-		v[2], transferOwnership, _ = optimizeExCompat(v[2], env, ome, true)
+		var returnType TypeInfo
+		v[2], returnType = OptimizeEx(v[2], env, ome, true)
+		transferOwnership = returnType.Transfer()
+		if hasDefinedSym && ome.lambdaDepth == 0 && ome.beginDepth == 0 {
+			rhs := v[2]
+			if stripped, ok := scmerStripSourceInfo(rhs); ok {
+				rhs = stripped
+			}
+			if items, ok := scmerSlice(rhs); ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda") && returnType.Kind() != KindAny {
+				env.setOptimizerHint(definedSym, returnType.WithoutConst())
+			}
+		}
 	case headOk && (headSym == Symbol("match") || headSym == Symbol("match_mut")):
 		value, valueTransfer, _ := optimizeExCompat(v[1], env, ome, true)
 		v[1] = value
@@ -968,6 +997,7 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 
 	allConstArgs := true
 	var transferOwnership bool
+	var firstArgType TypeInfo
 
 	// Look up declaration for callback ownership propagation
 	var callDecl *Declaration
@@ -1002,6 +1032,9 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 		}
 		var ti TypeInfo
 		v[i], ti = OptimizeEx(v[i], env, ome, true)
+		if i == 1 {
+			firstArgType = ti
+		}
 		transferOwnership = ti.Transfer()
 		if i > 0 && !ti.Const() {
 			allConstArgs = false
@@ -1013,22 +1046,25 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 	if mutName != "" {
 		firstArgFresh := false
 		if len(v) >= 2 {
+			firstArgFresh = firstArgType.Transfer() && !firstArgType.Const() && (firstArgType.Kind() == KindList || firstArgType.Kind() == KindAssoc)
 			arg1 := v[1]
 			if si, ok := arg1.Any().(SourceInfo); ok {
 				arg1 = si.value
 			}
-			if inner, ok := scmerSlice(arg1); ok && len(inner) > 0 {
-				if d := DeclarationForValue(inner[0]); d != nil {
-					if d.Type != nil && d.Type.Return != nil && d.Type.Return.Transfer {
-						firstArgFresh = true
-					}
-				}
-			} else if arg1.IsNthLocalVar() {
-				for sym, owned := range ome.ownedVars {
-					if owned {
-						if repl, ok := ome.variableReplacement[sym]; ok && repl.IsNthLocalVar() && repl.NthLocalVar() == arg1.NthLocalVar() {
+			if !firstArgFresh {
+				if inner, ok := scmerSlice(arg1); ok && len(inner) > 0 {
+					if d := DeclarationForValue(inner[0]); d != nil {
+						if d.Type != nil && d.Type.Return != nil && d.Type.Return.Transfer {
 							firstArgFresh = true
-							break
+						}
+					}
+				} else if arg1.IsNthLocalVar() {
+					for sym, owned := range ome.ownedVars {
+						if owned {
+							if repl, ok := ome.variableReplacement[sym]; ok && repl.IsNthLocalVar() && repl.NthLocalVar() == arg1.NthLocalVar() {
+								firstArgFresh = true
+								break
+							}
 						}
 					}
 				}
@@ -1095,6 +1131,8 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 
 	// Look up declaration return type for propagation
 	var retTD *TypeDescriptor
+	var procReturn TypeInfo
+	hasProcReturn := false
 	if d := DeclarationForValue(v[0]); d != nil {
 		if d.IsFoldable() && allConstArgs && d.Fn != nil {
 			for i := range v {
@@ -1114,9 +1152,26 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 			retTD = d.Type.Return
 		}
 	}
+	if retTD == nil {
+		if sym, ok := scmerSymbol(v[0]); ok {
+			if ti, exists := env.optimizerProcHint(sym); exists {
+				procReturn = ti
+				hasProcReturn = true
+			}
+		}
+	}
 
 	td := &TypeDescriptor{Transfer: transferOwnership}
-	if retTD != nil {
+	if hasProcReturn {
+		td.Transfer = procReturn.Transfer()
+		td.Kind = procReturn.kindName()
+		td.Length = procReturn.Length()
+		if procReturn.Extra != nil {
+			td.Params = procReturn.Extra.Params
+			td.Return = procReturn.Extra.Return
+			td.HasSideEffects = procReturn.Extra.HasSideEffects
+		}
+	} else if retTD != nil {
 		td.Kind = retTD.Kind
 		td.Length = retTD.Length
 		td.Params = retTD.Params

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func newOptimizerTestEnv() *Env {
+	return &Env{Vars: make(Vars), Outer: &Globalenv}
+}
+
+func optimizeTestSource(t testing.TB, env *Env, source string) Scmer {
+	t.Helper()
+	return Optimize(Read("optimizer return test", source), env)
+}
+
+func serializedTestExpr(t testing.TB, env *Env, expr Scmer) string {
+	t.Helper()
+	var out bytes.Buffer
+	Serialize(&out, expr, env)
+	return out.String()
+}
+
+func TestSchemeHelperFreshReturnEnablesMutRewrite(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define fresh_pair (lambda (a b) (list a b)))`, env)
+
+	optimized := optimizeTestSource(t, env, `(append (fresh_pair 1 2) 3)`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "append_mut") {
+		t.Fatalf("fresh Scheme helper did not enable append_mut: %s", serialized)
+	}
+	if got := Eval(optimized, env); !Equal(got, NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})) {
+		t.Fatalf("optimized helper call returned %s", String(got))
+	}
+}
+
+func TestSchemeHelperReturnLengthPropagates(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define fresh_pair_len (lambda (a b) (list a b)))`, env)
+
+	optimized := optimizeTestSource(t, env, `(count (fresh_pair_len 1 2))`)
+	if !optimized.IsInt() || optimized.Int() != 2 {
+		t.Fatalf("expected exact helper return length to fold count, got %s", serializedTestExpr(t, env, optimized))
+	}
+}
+
+func TestSchemeHelperReturnHintFollowsEnvironmentChain(t *testing.T) {
+	parent := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define inherited_pair (lambda (a b) (list a b)))`, parent)
+	child := &Env{Vars: make(Vars), Outer: parent}
+
+	optimized := optimizeTestSource(t, child, `(append (inherited_pair 1 2) 3)`)
+	if serialized := serializedTestExpr(t, child, optimized); !strings.Contains(serialized, "append_mut") {
+		t.Fatalf("inherited helper hint did not enable append_mut: %s", serialized)
+	}
+}
+
+func TestSchemeHelperLocalBeginDoesNotReplaceOuterHint(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define outer_pair (lambda (a b) (list a b)))`, env)
+	optimizeTestSource(t, env, `(begin (define outer_pair (lambda (value) value)) (outer_pair 1))`)
+
+	optimized := optimizeTestSource(t, env, `(append (outer_pair 1 2) 3)`)
+	if serialized := serializedTestExpr(t, env, optimized); !strings.Contains(serialized, "append_mut") {
+		t.Fatalf("local begin replaced outer helper hint: %s", serialized)
+	}
+}
+
+func TestSchemeHelperSharedReturnStaysImmutable(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define shared_pair (list 1 2))`, env)
+	EvalAll("optimizer return test", `(define return_shared_pair (lambda () shared_pair))`, env)
+
+	optimized := optimizeTestSource(t, env, `(append (return_shared_pair) 3)`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "append_mut") {
+		t.Fatalf("shared Scheme helper return enabled append_mut: %s", serialized)
+	}
+	Eval(optimized, env)
+	if got := env.FindRead("shared_pair").Vars["shared_pair"]; len(got.Slice()) != 2 {
+		t.Fatalf("shared helper result was mutated: %s", String(got))
+	}
+}
+
+func TestSchemeHelperRecursiveReturnStaysConservative(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define recursive_pair (lambda (n) (if (= n 0) (list n) (recursive_pair (- n 1)))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(append (recursive_pair 2) 3)`)
+	if serialized := serializedTestExpr(t, env, optimized); strings.Contains(serialized, "append_mut") {
+		t.Fatalf("recursive Scheme helper enabled append_mut: %s", serialized)
+	}
+}
+
+func TestSchemeHelperEvalReturnStaysConservative(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define evaluated_pair (lambda () (eval '(list 1 2))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(append (evaluated_pair) 3)`)
+	if serialized := serializedTestExpr(t, env, optimized); strings.Contains(serialized, "append_mut") {
+		t.Fatalf("eval-using Scheme helper enabled append_mut: %s", serialized)
+	}
+}
+
+func TestSchemeHelperDynamicRebindInvalidatesReturnInfo(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define rebound_pair (lambda () (list 1 2)))`, env)
+	EvalAll("optimizer return test", `(define rebound_pair (lambda (value) value))`, env)
+
+	optimized := optimizeTestSource(t, env, `(append (rebound_pair (list 1 2)) 3)`)
+	if serialized := serializedTestExpr(t, env, optimized); strings.Contains(serialized, "append_mut") {
+		t.Fatalf("dynamically rebound Scheme helper kept stale ownership: %s", serialized)
+	}
+}
+
+func TestSchemeReturnHintsPreserveNestedMutRewrite(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := optimizeTestSource(t, env, `(set_assoc (filter (list) (lambda (x) true)) "k" "v")`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "set_assoc_mut") {
+		t.Fatalf("nested fresh result did not enable set_assoc_mut: %s", serialized)
+	}
+}
+
+func BenchmarkOptimizeSchemeHelperFreshReturn(b *testing.B) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return benchmark", `(define benchmark_fresh_pair (lambda (a b) (list a b)))`, env)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		expr := NewSlice([]Scmer{
+			NewSymbol("append"),
+			NewSlice([]Scmer{NewSymbol("benchmark_fresh_pair"), NewInt(1), NewInt(2)}),
+			NewInt(3),
+		})
+		Optimize(expr, env)
+	}
+}
+
+func BenchmarkSchemeHelperOwnedReturnAppend(b *testing.B) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return benchmark", `(define benchmark_filtered (lambda (a b c d) (filter (list a b c d) (lambda (x) (> x 1)))))`, env)
+	optimized := optimizeTestSource(b, env, `(lambda (a b c d e) (append (benchmark_filtered a b c d) e))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	args := []Scmer{NewInt(0), NewInt(2), NewInt(3), NewInt(4), NewInt(5)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := fn(args...)
+		if len(result.Slice()) != 4 {
+			b.Fatal("unexpected result length")
+		}
+	}
+}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -757,10 +757,49 @@ type NthLocalVar uint8 // equals to (var i)
 
 type Vars map[Symbol]Scmer
 type Env struct {
-	Vars         Vars
-	VarsNumbered []Scmer // <- for the optimizer
-	Outer        *Env
-	Nodefine     bool // define will write to Outer
+	Vars           Vars
+	VarsNumbered   []Scmer // <- for the optimizer
+	Outer          *Env
+	Nodefine       bool // define will write to Outer
+	optimizerHints map[Symbol]TypeInfo
+}
+
+func (e *Env) definitionTarget() *Env {
+	for e != nil && e.Nodefine {
+		e = e.Outer
+	}
+	if e == nil {
+		return &Globalenv
+	}
+	return e
+}
+
+func (e *Env) optimizerProcHint(s Symbol) (TypeInfo, bool) {
+	binding := e.FindRead(s)
+	if binding == nil || binding.optimizerHints == nil {
+		return tiZero, false
+	}
+	bound, exists := binding.Vars[s]
+	if !exists || bound.GetTag() != tagProc {
+		return tiZero, false
+	}
+	ti, ok := binding.optimizerHints[s]
+	return ti, ok
+}
+
+func (e *Env) setOptimizerHint(s Symbol, ti TypeInfo) {
+	target := e.definitionTarget()
+	if target.optimizerHints == nil {
+		target.optimizerHints = make(map[Symbol]TypeInfo)
+	}
+	target.optimizerHints[s] = ti
+}
+
+func (e *Env) deleteOptimizerHint(s Symbol) {
+	target := e.definitionTarget()
+	if target.optimizerHints != nil {
+		delete(target.optimizerHints, s)
+	}
 }
 
 func (e *Env) FindRead(s Symbol) *Env {
@@ -817,6 +856,7 @@ func init() {
 		nil,
 		nil,
 		false,
+		nil,
 	}
 
 	// system


### PR DESCRIPTION
## Summary

- propagate the existing `OptimizeEx` return `TypeInfo` from Scheme lambda bodies into the defining `Env`
- resolve return hints through the inherited environment chain and invalidate them conservatively on rebinding, recursion, `eval`, or shared results
- allow `_mut` rewrites only for proven fresh, non-constant list/assoc helper returns

This keeps code optimization and return-type inference in the same optimizer traversal. It does not introduce a second inference pass or a separate `inferOptimizedReturnType` API. The practical benefit is that callers can reuse freshly allocated helper results instead of copying them before an internal mutation.

## A/B measurements

Both variants were built from master `518aa1bd7`; the branch adds only this commit. The database copies came from the same imported production fixture. Query text and schema identifiers are intentionally omitted.

### Full compile cascade

`EXPLAIN COMPILE`, one warm-up plus four measured interleaved samples per build; values are median total compile time.

| Prefix | master | PR | delta |
|---|---:|---:|---:|
| C | 2148.347 ms | 2121.120 ms | -1.27% |
| Ca | 2162.487 ms | 2142.327 ms | -0.93% |
| Car | 2000.675 ms | 1935.332 ms | -3.27% |
| Carg | 1989.120 ms | 1949.933 ms | -1.97% |
| Cargl | 2210.801 ms | 2171.033 ms | -1.80% |
| Cargla | 2080.409 ms | 2047.988 ms | -1.56% |
| Carglas | 2027.900 ms | 2022.829 ms | -0.25% |
| Carglass | 2051.329 ms | 1985.757 ms | -3.20% |
| CarglassXXX | 2030.600 ms | 2005.339 ms | -1.24% |

Compiled plan sizes were identical for every pair.

### Full runtime cascade

One warm-up plus five measured samples per build; values are median response time. Both variants returned the same empty response body and SHA-256 hash for every prefix.

| Prefix | master | PR | delta |
|---|---:|---:|---:|
| C | 0.427424 s | 0.429261 s | +0.43% |
| Ca | 0.431661 s | 0.429559 s | -0.49% |
| Car | 0.425132 s | 0.428864 s | +0.88% |
| Carg | 0.426950 s | 0.427041 s | +0.02% |
| Cargl | 0.440601 s | 0.428713 s | -2.70% |
| Cargla | 0.431819 s | 0.436066 s | +0.98% |
| Carglas | 0.439379 s | 0.436479 s | -0.66% |
| Carglass | 0.428800 s | 0.433676 s | +1.14% |
| CarglassXXX | 0.425898 s | 0.425483 s | -0.10% |

The runtime deltas are noise-sized; the final prefix is effectively unchanged.

### Optimizer microbenchmarks

Ten samples per build, medians:

| Benchmark | master | PR | allocation change |
|---|---:|---:|---:|
| optimize fresh helper call | 764.65 ns | 779.50 ns (+1.94%) | 744 B / 10 -> 856 B / 10 |
| append fresh helper result | 2003 ns | 1960 ns (-2.15%) | 1632 B / 53 -> 1464 B / 52 |

The additional compile-time metadata pays for itself only on paths where the fresh result is consumed mutably; the full compile cascade above guards against a workload-level regression.

## Validation

- `go test ./scm -count=1`
- full serial pre-commit suite passed on the preceding master base
- after merging current master: `tests/41_in_subquery.yaml` passed 52/52 and the focused Go suite passed
- full compile and runtime cascade A/B measurements above
