### PR TITLE
Cache immutable SHOW column metadata

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -385,6 +385,7 @@ func (db *database) ensureLoaded() {
 		} else {
 			t.ShardMode = ShardModeFree
 		}
+		t.publishShowColumnsSnapshot()
 	}
 	// FK enforcement triggers are serializable Procs and persist with the table JSON.
 	// No re-installation needed on load.
@@ -679,6 +680,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 				atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)
 				atomic.StoreUint64(&t.Columns[ci].RowEstimate, rowEst)
 			}
+			t.publishShowColumnsSnapshot()
 
 			// Collect replaced shards for deferred cleanup (see comment above).
 			if len(replaced) > 0 {
@@ -1000,6 +1002,7 @@ func (db *database) createTableLocked(name string, pm PersistencyMode, ifnotexis
 	t.Shards = make([]*storageShard, 1)
 	t.Shards[0] = NewShard(t)
 	t.Auto_increment = 1
+	t.publishShowColumnsSnapshot()
 	if existing := db.tables.Set(t); existing != nil {
 		panic("Table " + name + " already exists")
 	}

--- a/storage/mysql_import.go
+++ b/storage/mysql_import.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2023, 2024  Carl-Philip Hänsch
+Copyright (C) 2023-2026  Carl-Philip Hänsch
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -421,6 +421,7 @@ existingLoop:
 		}
 		t.Unique = append(t.Unique, uniqueKey{k.name, colNames})
 	}
+	t.publishShowColumnsSnapshot()
 	t.schema.save()
 	return nil
 }

--- a/storage/psql_import.go
+++ b/storage/psql_import.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2023, 2024, 2025  Carl-Philip Hänsch
+Copyright (C) 2023-2026  Carl-Philip Hänsch
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -491,6 +491,7 @@ existingLoop:
 		}
 		t.Unique = append(t.Unique, uniqueKey{k.name, colNames})
 	}
+	t.publishShowColumnsSnapshot()
 	t.schema.save()
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1242,6 +1242,7 @@ func Init(en scm.Env) {
 					panic("unknown column definition: " + head)
 				}
 			}
+			newTable.publishShowColumnsSnapshot()
 
 			db.schemalock.Lock()
 			existing := db.tables.Get(tblName)
@@ -1423,6 +1424,7 @@ func Init(en scm.Env) {
 			}
 
 			t.Unique = append(t.Unique, uniqueKey{name, cols})
+			t.publishShowColumnsSnapshot()
 			t.schema.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 
 			return scm.NewBool(true)
@@ -1680,10 +1682,12 @@ func Init(en scm.Env) {
 							return scm.NewBool(true)
 						}
 						t.Columns[i].AutoIncrement = scm.ToBool(a[3])
+						t.publishShowColumnsSnapshot()
 						db.save()
 						return scm.NewBool(true)
 					default:
 						ok := t.Columns[i].Alter(scm.String(a[2]), a[3])
+						t.publishShowColumnsSnapshot()
 						db.save()
 						return scm.NewBool(scm.ToBool(ok))
 					}
@@ -2456,7 +2460,7 @@ func Init(en scm.Env) {
 				{Kind: "int|bool", ParamName: "property", ParamDesc: "(optional) shard index (int), true for full table info, or \"statistics\"", Optional: true},
 				{Kind: "bool", ParamName: "full", ParamDesc: "(optional) true to include columns and indexes in shard detail", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "any"},
+			Return: &scm.TypeDescriptor{Kind: "any", Transfer: false},
 		},
 	})
 	// show_triggers(schema, table): returns a list of triggers for a table (non-system triggers only)

--- a/storage/table.go
+++ b/storage/table.go
@@ -327,6 +327,10 @@ type table struct {
 	// unrelated tables behind the database-global schemalock.
 	ddlMu sync.RWMutex
 
+	// showColumnsSnapshot is immutable after publication. SHOW/compiler reads
+	// load it without locking; metadata writers replace the complete snapshot.
+	showColumnsSnapshot atomic.Pointer[tableShowColumnsSnapshot]
+
 	// storage: ShardMode controls which shard set is the read/write target
 	ShardMode   ShardMode
 	shardModeMu sync.RWMutex    // protects ShardMode reads in iterateShards vs Phase F flip
@@ -803,17 +807,36 @@ func getForeignKeyMode(val scm.Scmer) foreignKeyMode {
 	}
 }
 
-func (t *table) ShowColumns() scm.Scmer {
-	if t == nil {
-		return scm.NewNil()
+type tableShowColumnsSnapshot struct {
+	value             scm.Scmer
+	rowEstimate       uint
+	distinctEstimates []uint64
+}
+
+func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, rowEstimate uint) bool {
+	if snapshot == nil || snapshot.rowEstimate != rowEstimate || len(snapshot.distinctEstimates) != len(t.Columns) {
+		return false
 	}
+	for i, c := range t.Columns {
+		distinctEstimate := atomic.LoadUint64(&c.DistinctEstimate)
+		if distinctEstimate == 0 {
+			distinctEstimate = uint64(rowEstimate)
+		}
+		if snapshot.distinctEstimates[i] != distinctEstimate {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnapshot {
 	result := make([]scm.Scmer, len(t.Columns))
-	for i, v := range t.Columns {
-		// Determine Key type for this column
+	distinctEstimates := make([]uint64, len(t.Columns))
+	for i, c := range t.Columns {
 		keyType := ""
 		for _, uk := range t.Unique {
 			for _, col := range uk.Cols {
-				if col == v.Name {
+				if col == c.Name {
 					if uk.Id == "PRIMARY" {
 						keyType = "PRI"
 					} else if keyType == "" {
@@ -822,12 +845,47 @@ func (t *table) ShowColumns() scm.Scmer {
 				}
 			}
 		}
-		result[i] = v.Show(keyType, t)
+		distinctEstimate := atomic.LoadUint64(&c.DistinctEstimate)
+		if distinctEstimate == 0 {
+			distinctEstimate = uint64(rowEstimate)
+		}
+		distinctEstimates[i] = distinctEstimate
+		result[i] = c.show(keyType, distinctEstimate, rowEstimate)
 	}
-	return scm.NewSlice(result)
+	return &tableShowColumnsSnapshot{
+		value:             scm.NewSlice(result),
+		rowEstimate:       rowEstimate,
+		distinctEstimates: distinctEstimates,
+	}
+}
+
+func (t *table) publishShowColumnsSnapshot() scm.Scmer {
+	snapshot := t.buildShowColumnsSnapshot(t.CountEstimate())
+	t.showColumnsSnapshot.Store(snapshot)
+	return snapshot.value
+}
+
+func (t *table) invalidateShowColumnsSnapshot() {
+	t.showColumnsSnapshot.Store(nil)
+}
+
+func (t *table) ShowColumns() scm.Scmer {
+	if t == nil {
+		return scm.NewNil()
+	}
+	rowEstimate := t.CountEstimate()
+	snapshot := t.showColumnsSnapshot.Load()
+	if t.showColumnsSnapshotMatches(snapshot, rowEstimate) {
+		return snapshot.value
+	}
+	return t.publishShowColumnsSnapshot()
 }
 
 func (c *column) Show(keyType string, t *table) scm.Scmer {
+	return c.show(keyType, uint64(c.distinctEstimateFor(t)), t.CountEstimate())
+}
+
+func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint) scm.Scmer {
 	dims := make([]scm.Scmer, len(c.Typdimensions))
 	for i, v := range c.Typdimensions {
 		dims[i] = scm.NewInt(int64(v))
@@ -862,8 +920,8 @@ func (c *column) Show(keyType string, t *table) scm.Scmer {
 		scm.NewString("Extra"), scm.NewString(extra),
 		scm.NewString("Privileges"), scm.NewString("select,insert,update,references"),
 		scm.NewString("Comment"), scm.NewString(c.Comment),
-		scm.NewString("DistinctEstimate"), scm.NewInt(int64(c.distinctEstimateFor(t))),
-		scm.NewString("RowEstimate"), scm.NewInt(int64(t.CountEstimate())),
+		scm.NewString("DistinctEstimate"), scm.NewInt(int64(distinctEstimate)),
+		scm.NewString("RowEstimate"), scm.NewInt(int64(rowEstimate)),
 	})
 }
 
@@ -1159,6 +1217,7 @@ func (t *table) registerTempColumn(cp *column) {
 					delete(s.columns, colName)
 					s.mu.Unlock()
 				}
+				tbl.invalidateShowColumnsSnapshot()
 				tbl.schema.schemalock.Unlock()
 				return true
 			}
@@ -1181,6 +1240,11 @@ func (t *table) createColumnDDLLocked(name string, typ string, typdimensions []i
 	if !ok {
 		t.schema.schemalock.Unlock()
 		return false
+	}
+	if cp.IsTemp {
+		t.invalidateShowColumnsSnapshot()
+	} else {
+		t.publishShowColumnsSnapshot()
 	}
 	t.finishSchemaMutationLocked()
 	if cp.IsTemp {
@@ -1216,6 +1280,11 @@ func (t *table) dropColumnDDLLocked(name string) bool {
 			// remove cache invalidation triggers from source tables
 			t.removeComputeTriggers(name)
 
+			if c.IsTemp {
+				t.invalidateShowColumnsSnapshot()
+			} else {
+				t.publishShowColumnsSnapshot()
+			}
 			t.finishSchemaMutationLocked()
 			// Fire lifecycle hooks after unlock so dependents (e.g. prejoin caches)
 			// can invalidate without lock-ordering cycles.

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func showColumnsTestTable(columnCount int) *table {
+	columns := make([]*column, columnCount)
+	for i := range columns {
+		columns[i] = &column{
+			Name:          fmt.Sprintf("column_%d", i),
+			Typ:           "VARCHAR",
+			AllowNull:     true,
+			Collation:     "utf8mb4_general_ci",
+			Comment:       "original",
+			Typdimensions: []int{255},
+		}
+	}
+	return &table{
+		Columns: columns,
+		Unique:  []uniqueKey{{Id: "PRIMARY", Cols: []string{"column_0"}}},
+	}
+}
+
+func showColumnProperty(row scm.Scmer, name string) scm.Scmer {
+	values := row.Slice()
+	for i := 0; i+1 < len(values); i += 2 {
+		if scm.String(values[i]) == name {
+			return values[i+1]
+		}
+	}
+	return scm.NewNil()
+}
+
+func TestShowColumnsReusesImmutableSnapshot(t *testing.T) {
+	tbl := showColumnsTestTable(3)
+	first := tbl.ShowColumns()
+	second := tbl.ShowColumns()
+
+	firstRows := first.Slice()
+	secondRows := second.Slice()
+	if &firstRows[0] != &secondRows[0] {
+		t.Fatal("ShowColumns rebuilt the outer metadata list")
+	}
+	if &firstRows[0].Slice()[0] != &secondRows[0].Slice()[0] {
+		t.Fatal("ShowColumns rebuilt a column metadata row")
+	}
+}
+
+func TestShowColumnsPublishesReplacementSnapshot(t *testing.T) {
+	tbl := showColumnsTestTable(1)
+	before := tbl.ShowColumns()
+	tbl.Columns[0].Comment = "updated"
+	tbl.publishShowColumnsSnapshot()
+	after := tbl.ShowColumns()
+
+	if &before.Slice()[0] == &after.Slice()[0] {
+		t.Fatal("metadata update retained the old snapshot")
+	}
+	if got := scm.String(showColumnProperty(after.Slice()[0], "Comment")); got != "updated" {
+		t.Fatalf("updated comment = %q, want updated", got)
+	}
+}
+
+func TestShowColumnsRefreshesChangedStatistics(t *testing.T) {
+	tbl := showColumnsTestTable(1)
+	before := tbl.ShowColumns()
+	atomic.StoreUint64(&tbl.Columns[0].DistinctEstimate, 17)
+	after := tbl.ShowColumns()
+
+	if &before.Slice()[0] == &after.Slice()[0] {
+		t.Fatal("statistics update retained the old snapshot")
+	}
+	if got := showColumnProperty(after.Slice()[0], "DistinctEstimate").Int(); got != 17 {
+		t.Fatalf("distinct estimate = %d, want 17", got)
+	}
+}
+
+func BenchmarkShowColumnsCached(b *testing.B) {
+	tbl := showColumnsTestTable(64)
+	_ = tbl.ShowColumns()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = tbl.ShowColumns()
+	}
+}


### PR DESCRIPTION
## Summary
- cache each table's immutable `SHOW` column metadata behind one atomic snapshot pointer
- publish replacement snapshots at persistent DDL, import, load, and rebuild boundaries
- invalidate lazily for short-lived computed columns so query compilation does not perform eager table estimates
- mark the `show` builtin result as `transfer:false`, allowing the optimizer to retain the immutable value
- preserve dynamic row/distinct estimates by validating the snapshot signature before reuse

## A/B measurement
`BenchmarkShowColumnsCached`, 64 columns, five runs, same host, based on `origin/master` at `518aa1bd7`:

| Revision | Median | Memory | Allocations |
|---|---:|---:|---:|
| master | ~16.0 us/op | 30,848 B/op | 321 allocs/op |
| PR | 57.57 ns/op | 0 B/op | 0 allocs/op |

The cached path is roughly 278x faster by median and allocation-free. Individual PR runs measured 34.80-62.52 ns/op.

A normal-build integration comparison for the 200k-row ORDER BY suite was also neutral-to-positive: master 3.73 s, PR 2.88 s, both 19/19 passing. This guards against eager cache publication leaking into temporary-column query compilation.

## Validation
- regression tests cover snapshot reuse, replacement after metadata changes, and refresh after statistics changes
- `go test -race ./storage -run '^TestShowColumns'`
- full serial pre-commit suite without instrumentation: passed
- full serial coverage suite: all functional assertions passed; one existing 5 s ORDER BY timing gate took 8.23 s under coverage instrumentation, while the same suite passed in 2.88 s with the normal PR binary

No storage persistence format or disk-deletion paths are changed.
