### PR TITLE
Canonicalize nested stage catalogs before lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6938,8 +6938,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_with_full_stage_catalog (lambda (block)
 	(begin
-		(define stages (query_block_stage_catalog block))
-		(define cataloged_stages (map stages (lambda (stage)
+		(define stages (stage_catalog_with_nested (query_block_stage_catalog block)))
+		(define cataloged_stages (map (qb_stages block) (lambda (stage)
 			(group_stage_with_stage_catalog stage stages))))
 		(make_query_block
 			(qb_schema block)
@@ -6953,7 +6953,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(qb_offset block)
 			(qb_hidden block)
 			cataloged_stages
-			(query_block_facts_with_stage_catalog block cataloged_stages)))))
+			(query_block_facts_with_stage_catalog block stages)))))
 
 (define stage_ids (lambda (stages)
 	(map (coalesceNil stages '()) gs_id)))
@@ -7197,7 +7197,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(begin
 		(define src (gs_input stage))
 		(define prepare_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
-		(define stage_catalog (stage_catalog_with_nested
+		(define stage_catalog (unique_stages_by_id
 			(merge (list
 				prepare_catalog
 				lookup_stages
@@ -7769,9 +7769,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(if (not (nil? fused_top_count))
 			fused_top_count
 			(begin
-				(define rewritten (query_block_with_scalar_first_probes_using (qb_stages block) block))
+				(define rewritten (query_block_with_scalar_first_probes_using (query_block_stage_catalog block) block))
 				(define sources (qb_sources rewritten))
-				(define stage_catalog (stage_catalog_with_nested (query_block_stage_catalog rewritten)))
+				(define stage_catalog (query_block_stage_catalog rewritten))
 				(define dependency_graph (stage_dependency_graph stage_catalog))
 				(define physical_sources (physicalize_stage_output_sources stage_catalog sources))
 				(define driver_src (car physical_sources))
@@ -7959,7 +7959,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(if (not (nil? fused_row_number))
 						fused_row_number
 						(begin
-							(define stage_catalog (stage_catalog_with_nested (query_block_stage_catalog block)))
+							(define stage_catalog (query_block_stage_catalog block))
 							(define eager_stages (query_block_stages_to_prepare block))
 							(define dependency_graph (stage_dependency_graph stage_catalog))
 							(define prepared_block (if (single_source? (qb_sources block))
@@ -9177,11 +9177,17 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define lower_dml_query_block_with_stages (lambda (block target_schema target_tbl)
 	(if (empty_list? (qb_stages block))
 		(lower_dml_query_block_core block target_schema target_tbl)
-		(cons (quote begin)
-			(merge (list
-				(map (qb_stages block) (lambda (stage)
-					(lower_stage_prepare_using (qb_stages block) (qb_stages block) stage)))
-				(list (lower_dml_query_block_core (query_block_without_stages_after_prepare_using (qb_stages block) block) target_schema target_tbl))))))))
+		(begin
+			(define stage_catalog (query_block_stage_catalog block))
+			(define dependency_graph (stage_dependency_graph stage_catalog))
+			(cons (quote begin)
+				(merge (list
+					(map (qb_stages block) (lambda (stage)
+						(lower_stage_prepare_using
+							(stage_dependency_closure_using_graph dependency_graph stage)
+							stage_catalog
+							stage)))
+					(list (lower_dml_query_block_core (query_block_without_stages_after_prepare_using stage_catalog block) target_schema target_tbl)))))))))
 
 (define lower_dml_union_block_with_stages (lambda (block target_schema target_tbl)
 	(cons (quote begin)
@@ -9518,22 +9524,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(wrap_plan_with_distinct_resultrow (lower_union_all_successive block)))
 			(neumann_fail "build_queryplan" "unknown UNION mode")))))
 
-/* Physical preparation attaches the canonical stage catalog without emitting
-runtime operators. Keeping this boundary explicit makes analysis and emission
-independently measurable while preserving the normal build_queryplan contract. */
+/* Physical preparation expands and attaches the canonical stage catalog once,
+without emitting runtime operators. Keeping this boundary explicit makes
+analysis and emission independently measurable while preserving the normal
+build_queryplan contract. */
 (define prepare_physical_queryplan (lambda (ir)
 	(begin
 		(require_unnested_node "build_queryplan input" (ir_root ir))
-		(match (ir_return ir)
-			(symbol rows) (match (logical_op (ir_root ir))
-				(symbol query-block) (make_ir
-					(ir_kind ir)
-					(query_block_with_full_stage_catalog (ir_root ir))
-					(ir_stages ir)
-					(ir_context_of ir)
-					(ir_return ir))
-				_ ir)
-			_ ir))))
+		(define root (ir_root ir))
+		(if (query_block? root)
+			(make_ir
+				(ir_kind ir)
+				(query_block_with_full_stage_catalog root)
+				(ir_stages ir)
+				(ir_context_of ir)
+				(ir_return ir))
+			ir))))
 
 (define emit_physical_queryplan (lambda (ir)
 	(begin

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -224,6 +224,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(list (list 'stage_catalog (list nested_catalog_stage)))))
 	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) (list outer_catalog_stage) outer_catalog_stage))
 		true "group-stage lowering keeps nested stage-output metadata from the full catalog")
+	(define catalog_root (make_query_block
+		"memcp-tests"
+		(list (list "o" "memcp-tests" "outer_source" false nil))
+		'() true '() nil '() nil nil '() (list outer_catalog_stage) '()))
+	(define prepared_catalog_root (ir_root (prepare_physical_queryplan
+		(make_ir (quote select) catalog_root '() nil (quote rows)))))
+	(assert (count (qb_stages prepared_catalog_root)) 1
+		"physical preparation keeps only direct stages on the query block")
+	(assert (count (query_block_stage_catalog prepared_catalog_root)) 2
+		"physical preparation expands the nested stage catalog once")
+	(assert (group_stage? (stage_by_id (query_block_stage_catalog prepared_catalog_root) "nested-catalog-stage"))
+		true "prepared physical catalog exposes nested stage metadata for emission")
+	(assert (count (qassoc_get (gs_facts (car (qb_stages prepared_catalog_root))) (quote stage_catalog) '())) 2
+		"direct physical stages share the complete prepared catalog")
 	(define btw_outer_sources (list (list "o" "memcp-tests" "outer_t" false nil)))
 	(define btw_inner_sources (list (list "i" "memcp-tests" "inner_t" false nil)))
 	(define btw_outer_id (list 'get_column "o" false "id" false))


### PR DESCRIPTION
## Root cause

Physical lowering recursively expanded the complete nested stage catalog from inside `lower_group_stage_prepare_using`. A query with many group stages therefore walked and deduplicated essentially the same nested catalog once per stage during recipe emission.

## Change

- expand the nested stage catalog once in `prepare_physical_queryplan`
- attach that canonical lookup catalog to the prepared query block
- keep direct stages separate from the complete lookup catalog introduced by #321
- let grouped, ordinary, and DML lowering consume the prepared catalog
- retain the narrow dependency closure used to decide which stages are prepared
- add a planner contract test for direct-stage and nested-catalog ownership

This keeps logical planning unchanged and moves repeated physical compiler work to the existing preparation boundary. It deliberately does not introduce the parent-linked/indexed catalog yet.

## Full cascade A/B

Current master `b6f94a7aa` and PR `69a86a95b` were built separately and run against identical copies of the same imported production-derived fixture. Query and schema text are intentionally omitted. Compile values are medians from five interleaved measurements after one warm-up.

| Prefix | master compile | PR compile | delta | master recipe emit | PR recipe emit | delta |
|---|---:|---:|---:|---:|---:|---:|
| C | 1958.288 ms | 1763.208 ms | -9.96% | 1594.551 ms | 1411.632 ms | -11.47% |
| Ca | 1920.004 ms | 1760.512 ms | -8.31% | 1578.330 ms | 1402.014 ms | -11.17% |
| Car | 1952.371 ms | 1766.040 ms | -9.54% | 1595.218 ms | 1401.944 ms | -12.12% |
| Carg | 1950.777 ms | 1793.769 ms | -8.05% | 1592.967 ms | 1419.174 ms | -10.91% |
| Cargl | 1942.405 ms | 1732.667 ms | -10.80% | 1591.758 ms | 1385.726 ms | -12.94% |
| Cargla | 1971.741 ms | 1766.456 ms | -10.41% | 1608.904 ms | 1391.724 ms | -13.50% |
| Carglas | 1935.007 ms | 1767.800 ms | -8.64% | 1584.100 ms | 1404.806 ms | -11.32% |
| Carglass | 1954.722 ms | 1751.072 ms | -10.42% | 1583.329 ms | 1389.211 ms | -12.26% |
| CarglassXXX | 1948.483 ms | 1771.713 ms | -9.07% | 1589.507 ms | 1404.102 ms | -11.66% |

The one-time physical preparation rises by roughly 1-2 ms, as intended. Serialized plan size is identical for every prefix (`103,989` through `104,049` bytes).

### Cached runtime

One warm-up plus five interleaved measurements. Runtime differences are noise-sized and show no systematic shift.

| Prefix | master | PR | delta |
|---|---:|---:|---:|
| C | 0.401594 s | 0.398811 s | -0.69% |
| Ca | 0.402631 s | 0.400614 s | -0.50% |
| Car | 0.395792 s | 0.403525 s | +1.95% |
| Carg | 0.396717 s | 0.409855 s | +3.31% |
| Cargl | 0.394435 s | 0.396845 s | +0.61% |
| Cargla | 0.400773 s | 0.403229 s | +0.61% |
| Carglas | 0.398209 s | 0.395975 s | -0.56% |
| Carglass | 0.396732 s | 0.397579 s | +0.21% |
| CarglassXXX | 0.392423 s | 0.403790 s | +2.90% |

For every prefix, master and PR produced byte-identical `EXPLAIN` output and identical result bytes/SHA-256.

## Scaling surrogate

An additional anonymized eight-scalar query used 3 warm-ups plus 30 unique cache-busted `EXPLAIN COMPILE` samples per build. This earlier isolated measurement compared the patch on the #321 base before #322 was merged:

| p50 metric | base | patch | change |
|---|---:|---:|---:|
| compile total | 277.2 ms | 186.9 ms | -32.6% |
| planner total | 263.6 ms | 174.1 ms | -34.0% |
| recipe emission | 228.1 ms | 137.8 ms | -39.6% |
| physical preparation | 2.6 ms | 4.6 ms | +2.0 ms |
| measured through serialization | 300.2 ms | 210.1 ms | -30.0% |
| HTTP wall time | 368.9 ms | 280.9 ms | -23.9% |

Plan shape remained identical: 8,043 physical nodes, 97,619 serialized bytes, 24 group stages, and 17 query blocks.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (full suite green, 830/830 Scheme tests)
- `tests/41_in_subquery.yaml` (52/52)
- full compile/runtime cascade above
- Scheme formatter executed; only the existing repository warning block remains
- `git diff --check`
