### PR TITLE
Index compiler column metadata lookups

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4388,22 +4388,11 @@ PostgreSQL parsers should both lower to the same combined operators.
 		col
 		(if (not (source_is_base_table? src))
 			nil
-			(begin
-				(define cols (get_schema (source_schema src) (source_relation src)))
-				(define exact (reduce cols (lambda (found row)
-					(if (not (nil? found))
-						found
-						(if (equal? (row "Field") col) (row "Field") nil)))
-					nil))
-				(if (not (nil? exact))
-					exact
-					(if col_ignorecase
-						(reduce cols (lambda (found row)
-							(if (not (nil? found))
-								found
-								(if (equal?? (row "Field") col) (row "Field") nil)))
-							nil)
-						nil)))))))
+			(resolve_column_name
+				(source_schema src)
+				(source_relation src)
+				col
+				col_ignorecase)))))
 
 (define source_has_column? (lambda (src col col_ignorecase)
 	(not (nil? (source_column_name src col col_ignorecase)))))

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -654,6 +654,10 @@ class SQLTestRunner:
         else:
             plan_size_limit = DEFAULT_MAX_PLAN_SIZE
         planner_time_limit_ms = float(test_case.get("max_planner_time_ms", 0))
+        compile_phase_limits_ms = test_case.get("max_compile_phase_ms", {})
+        if not isinstance(compile_phase_limits_ms, dict):
+            return self._record_fail(name, "max_compile_phase_ms must be a mapping",
+                                     query, None, None, is_noncritical)
         perf_rows = PERF_DEFAULT_ROWS  # default row count
         if is_perf_test:
             # Get baseline data if available
@@ -929,7 +933,8 @@ class SQLTestRunner:
 
             # Explicit cold planner budget. Unlike max_time, this reads the
             # compile-only phase metric before EXPLAIN warms the plan cache.
-            if (planner_time_limit_ms > 0 and not is_perf_test and not is_sparql
+            if ((planner_time_limit_ms > 0 or compile_phase_limits_ms)
+                    and not is_perf_test and not is_sparql
                     and not test_case.get("expect", {}).get("error")):
                 qhead = query.lstrip().upper()
                 if qhead.startswith("SELECT") or qhead.startswith("WITH"):
@@ -944,7 +949,7 @@ class SQLTestRunner:
                     compile_rows = self.parse_jsonl_response(compile_resp)
                     metrics = compile_rows[0] if compile_rows else {}
                     planner_time_ms = float(metrics.get("planner_total_ns", 0)) / 1_000_000.0
-                    if planner_time_ms > planner_time_limit_ms:
+                    if planner_time_limit_ms > 0 and planner_time_ms > planner_time_limit_ms:
                         diag = self._run_on_fail(test_case, database)
                         return self._record_fail(
                             name,
@@ -952,6 +957,23 @@ class SQLTestRunner:
                             query, compile_resp, test_case.get("expect"), is_noncritical,
                             planner_time_ms, planner_time_limit_ms, diag,
                         )
+                    for phase, limit_ms_value in compile_phase_limits_ms.items():
+                        if phase not in metrics:
+                            return self._record_fail(
+                                name, f"EXPLAIN COMPILE did not report phase {phase}",
+                                query, compile_resp, test_case.get("expect"), is_noncritical,
+                            )
+                        limit_ms = float(limit_ms_value)
+                        phase_time_ms = float(metrics[phase]) / 1_000_000.0
+                        if phase_time_ms > limit_ms:
+                            diag = self._run_on_fail(test_case, database)
+                            return self._record_fail(
+                                name,
+                                f"Compile phase {phase} too slow: "
+                                f"{phase_time_ms:.1f}ms > {limit_ms:.0f}ms",
+                                query, compile_resp, test_case.get("expect"), is_noncritical,
+                                phase_time_ms, limit_ms, diag,
+                            )
 
             # Hard plan-size limit — the hardware-independent compile-time-blowup
             # detector. Runs BEFORE the timed query so it is not preempted by

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2206,6 +2206,34 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "resolve_column_name",
+		Desc: "resolve a physical column name from immutable table metadata",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			db := GetDatabase(scm.String(a[0]))
+			if db == nil {
+				return scm.NewNil()
+			}
+			t := db.GetTable(scm.String(a[1]))
+			if t == nil {
+				return scm.NewNil()
+			}
+			name, ok := t.ResolveColumnName(scm.String(a[2]), scm.ToBool(a[3]))
+			if !ok {
+				return scm.NewNil()
+			}
+			return scm.NewString(name)
+		},
+		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
+				{Kind: "string", ParamName: "table", ParamDesc: "table name"},
+				{Kind: "string", ParamName: "column", ParamDesc: "column name"},
+				{Kind: "bool", ParamName: "ignorecase", ParamDesc: "whether identifier case is ignored"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "string|nil", Transfer: false},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "show",
 		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/storage/table.go
+++ b/storage/table.go
@@ -19,13 +19,15 @@ package storage
 import "fmt"
 import "math"
 import "sync"
-import "sync/atomic"
 import "time"
 import "errors"
-import "strings"
-import "strconv"
-import "encoding/json"
 import "unsafe"
+import "strconv"
+import "strings"
+import "unicode"
+import "sync/atomic"
+import "unicode/utf8"
+import "encoding/json"
 import "github.com/launix-de/memcp/scm"
 import "github.com/launix-de/go-mysqlstack/sqldb"
 
@@ -330,6 +332,7 @@ type table struct {
 	// showColumnsSnapshot is immutable after publication. SHOW/compiler reads
 	// load it without locking; metadata writers replace the complete snapshot.
 	showColumnsSnapshot atomic.Pointer[tableShowColumnsSnapshot]
+	columnNamesSnapshot atomic.Pointer[tableColumnNamesSnapshot]
 
 	// storage: ShardMode controls which shard set is the read/write target
 	ShardMode   ShardMode
@@ -811,6 +814,32 @@ type tableShowColumnsSnapshot struct {
 	value             scm.Scmer
 	rowEstimate       uint
 	distinctEstimates []uint64
+	columnNames       *tableColumnNamesSnapshot
+}
+
+type tableColumnNamesSnapshot struct {
+	exact  map[string]string
+	folded map[string]string
+}
+
+func foldIdentifier(name string) string {
+	for i := 0; i < len(name); i++ {
+		if name[i] >= utf8.RuneSelf {
+			var b strings.Builder
+			b.Grow(len(name))
+			for _, r := range name {
+				canonical := r
+				for folded := unicode.SimpleFold(r); folded != r; folded = unicode.SimpleFold(folded) {
+					if folded < canonical {
+						canonical = folded
+					}
+				}
+				b.WriteRune(canonical)
+			}
+			return b.String()
+		}
+	}
+	return strings.ToLower(name)
 }
 
 func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, rowEstimate uint) bool {
@@ -832,6 +861,7 @@ func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, r
 func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnapshot {
 	result := make([]scm.Scmer, len(t.Columns))
 	distinctEstimates := make([]uint64, len(t.Columns))
+	columnNames := t.buildColumnNamesSnapshot()
 	for i, c := range t.Columns {
 		keyType := ""
 		for _, uk := range t.Unique {
@@ -856,17 +886,58 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 		value:             scm.NewSlice(result),
 		rowEstimate:       rowEstimate,
 		distinctEstimates: distinctEstimates,
+		columnNames:       columnNames,
 	}
+}
+
+func (t *table) buildColumnNamesSnapshot() *tableColumnNamesSnapshot {
+	exact := make(map[string]string, len(t.Columns))
+	folded := make(map[string]string, len(t.Columns))
+	for _, c := range t.Columns {
+		exact[c.Name] = c.Name
+		foldedName := foldIdentifier(c.Name)
+		if _, exists := folded[foldedName]; !exists {
+			folded[foldedName] = c.Name
+		}
+	}
+	return &tableColumnNamesSnapshot{exact: exact, folded: folded}
+}
+
+func (t *table) publishColumnNamesSnapshot() *tableColumnNamesSnapshot {
+	snapshot := t.buildColumnNamesSnapshot()
+	t.columnNamesSnapshot.Store(snapshot)
+	return snapshot
 }
 
 func (t *table) publishShowColumnsSnapshot() scm.Scmer {
 	snapshot := t.buildShowColumnsSnapshot(t.CountEstimate())
+	t.columnNamesSnapshot.Store(snapshot.columnNames)
 	t.showColumnsSnapshot.Store(snapshot)
 	return snapshot.value
 }
 
 func (t *table) invalidateShowColumnsSnapshot() {
+	t.publishColumnNamesSnapshot()
 	t.showColumnsSnapshot.Store(nil)
+}
+
+// ResolveColumnName reads immutable DDL metadata without scanning SHOW rows.
+func (t *table) ResolveColumnName(name string, ignoreCase bool) (string, bool) {
+	if t == nil {
+		return "", false
+	}
+	snapshot := t.columnNamesSnapshot.Load()
+	if snapshot == nil {
+		snapshot = t.publishColumnNamesSnapshot()
+	}
+	if resolved, ok := snapshot.exact[name]; ok {
+		return resolved, true
+	}
+	if ignoreCase {
+		resolved, ok := snapshot.folded[foldIdentifier(name)]
+		return resolved, ok
+	}
+	return "", false
 }
 
 func (t *table) ShowColumns() scm.Scmer {

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -96,6 +96,38 @@ func TestShowColumnsRefreshesChangedStatistics(t *testing.T) {
 	}
 }
 
+func TestResolveColumnNameUsesSnapshotIndex(t *testing.T) {
+	tbl := showColumnsTestTable(3)
+	tbl.Columns[1].Name = "MixedCase"
+	tbl.Columns[2].Name = "Σ"
+	tbl.publishShowColumnsSnapshot()
+
+	if got, ok := tbl.ResolveColumnName("MixedCase", false); !ok || got != "MixedCase" {
+		t.Fatalf("exact lookup = %q, %t; want MixedCase, true", got, ok)
+	}
+	if _, ok := tbl.ResolveColumnName("mixedcase", false); ok {
+		t.Fatal("case-sensitive lookup accepted different case")
+	}
+	if got, ok := tbl.ResolveColumnName("mixedcase", true); !ok || got != "MixedCase" {
+		t.Fatalf("case-insensitive lookup = %q, %t; want MixedCase, true", got, ok)
+	}
+	if _, ok := tbl.ResolveColumnName("missing", true); ok {
+		t.Fatal("missing column resolved")
+	}
+	if got, ok := tbl.ResolveColumnName("ς", true); !ok || got != "Σ" {
+		t.Fatalf("Unicode fold lookup = %q, %t; want Σ, true", got, ok)
+	}
+
+	tbl.Columns[1].Name = "Renamed"
+	tbl.invalidateShowColumnsSnapshot()
+	if _, ok := tbl.ResolveColumnName("MixedCase", false); ok {
+		t.Fatal("invalidated column name remained visible")
+	}
+	if got, ok := tbl.ResolveColumnName("Renamed", false); !ok || got != "Renamed" {
+		t.Fatalf("replacement lookup = %q, %t; want Renamed, true", got, ok)
+	}
+}
+
 func BenchmarkShowColumnsCached(b *testing.B) {
 	tbl := showColumnsTestTable(64)
 	_ = tbl.ShowColumns()
@@ -103,5 +135,15 @@ func BenchmarkShowColumnsCached(b *testing.B) {
 	b.ResetTimer()
 	for range b.N {
 		_ = tbl.ShowColumns()
+	}
+}
+
+func BenchmarkResolveColumnNameCached(b *testing.B) {
+	tbl := showColumnsTestTable(256)
+	tbl.publishColumnNamesSnapshot()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, _ = tbl.ResolveColumnName("column_255", false)
 	}
 }

--- a/tests/89_indexed_column_resolution.yaml
+++ b/tests/89_indexed_column_resolution.yaml
@@ -1,0 +1,307 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Indexed column lookup for wide projections"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS resolver_values"
+  - sql: |
+      CREATE TABLE resolver_values (
+        id INT PRIMARY KEY,
+        column_1 INT,
+        column_2 INT,
+        column_3 INT,
+        column_4 INT,
+        column_5 INT,
+        column_6 INT,
+        column_7 INT,
+        column_8 INT,
+        column_9 INT,
+        column_10 INT,
+        column_11 INT,
+        column_12 INT,
+        column_13 INT,
+        column_14 INT,
+        column_15 INT,
+        column_16 INT,
+        column_17 INT,
+        column_18 INT,
+        column_19 INT,
+        column_20 INT,
+        column_21 INT,
+        column_22 INT,
+        column_23 INT,
+        column_24 INT,
+        column_25 INT,
+        column_26 INT,
+        column_27 INT,
+        column_28 INT,
+        column_29 INT,
+        column_30 INT,
+        column_31 INT,
+        column_32 INT,
+        column_33 INT,
+        column_34 INT,
+        column_35 INT,
+        column_36 INT,
+        column_37 INT,
+        column_38 INT,
+        column_39 INT,
+        column_40 INT,
+        column_41 INT,
+        column_42 INT,
+        column_43 INT,
+        column_44 INT,
+        column_45 INT,
+        column_46 INT,
+        column_47 INT,
+        column_48 INT,
+        column_49 INT,
+        column_50 INT,
+        column_51 INT,
+        column_52 INT,
+        column_53 INT,
+        column_54 INT,
+        column_55 INT,
+        column_56 INT,
+        column_57 INT,
+        column_58 INT,
+        column_59 INT,
+        column_60 INT,
+        column_61 INT,
+        column_62 INT,
+        column_63 INT,
+        column_64 INT,
+        column_65 INT,
+        column_66 INT,
+        column_67 INT,
+        column_68 INT,
+        column_69 INT,
+        column_70 INT,
+        column_71 INT,
+        column_72 INT,
+        column_73 INT,
+        column_74 INT,
+        column_75 INT,
+        column_76 INT,
+        column_77 INT,
+        column_78 INT,
+        column_79 INT,
+        column_80 INT,
+        column_81 INT,
+        column_82 INT,
+        column_83 INT,
+        column_84 INT,
+        column_85 INT,
+        column_86 INT,
+        column_87 INT,
+        column_88 INT,
+        column_89 INT,
+        column_90 INT,
+        column_91 INT,
+        column_92 INT,
+        column_93 INT,
+        column_94 INT,
+        column_95 INT,
+        column_96 INT,
+        column_97 INT,
+        column_98 INT,
+        column_99 INT,
+        column_100 INT,
+        column_101 INT,
+        column_102 INT,
+        column_103 INT,
+        column_104 INT,
+        column_105 INT,
+        column_106 INT,
+        column_107 INT,
+        column_108 INT,
+        column_109 INT,
+        column_110 INT,
+        column_111 INT,
+        column_112 INT,
+        column_113 INT,
+        column_114 INT,
+        column_115 INT,
+        column_116 INT,
+        column_117 INT,
+        column_118 INT,
+        column_119 INT,
+        column_120 INT,
+        column_121 INT,
+        column_122 INT,
+        column_123 INT,
+        column_124 INT,
+        column_125 INT,
+        column_126 INT,
+        column_127 INT,
+        column_128 INT
+      )
+  - scm: |
+      (begin
+        (define cols (map (produceN 128) (lambda (i) (concat "column_" (+ i 1)))))
+        (define vals (map (produceN 128) (lambda (i) (+ i 1))))
+        (insert (table "memcp-tests" "resolver_values")
+          (cons "id" cols)
+          (list (cons 1 vals))))
+
+test_cases:
+  - name: "Wide projection resolves columns within recipe budget"
+    max_time: 2
+    max_plan_size: 50000
+    max_compile_phase_ms:
+      recipe_emit_ns: 28
+    sql: |
+      SELECT
+        column_1 +
+        column_2 +
+        column_3 +
+        column_4 +
+        column_5 +
+        column_6 +
+        column_7 +
+        column_8 +
+        column_9 +
+        column_10 +
+        column_11 +
+        column_12 +
+        column_13 +
+        column_14 +
+        column_15 +
+        column_16 +
+        column_17 +
+        column_18 +
+        column_19 +
+        column_20 +
+        column_21 +
+        column_22 +
+        column_23 +
+        column_24 +
+        column_25 +
+        column_26 +
+        column_27 +
+        column_28 +
+        column_29 +
+        column_30 +
+        column_31 +
+        column_32 +
+        column_33 +
+        column_34 +
+        column_35 +
+        column_36 +
+        column_37 +
+        column_38 +
+        column_39 +
+        column_40 +
+        column_41 +
+        column_42 +
+        column_43 +
+        column_44 +
+        column_45 +
+        column_46 +
+        column_47 +
+        column_48 +
+        column_49 +
+        column_50 +
+        column_51 +
+        column_52 +
+        column_53 +
+        column_54 +
+        column_55 +
+        column_56 +
+        column_57 +
+        column_58 +
+        column_59 +
+        column_60 +
+        column_61 +
+        column_62 +
+        column_63 +
+        column_64 +
+        column_65 +
+        column_66 +
+        column_67 +
+        column_68 +
+        column_69 +
+        column_70 +
+        column_71 +
+        column_72 +
+        column_73 +
+        column_74 +
+        column_75 +
+        column_76 +
+        column_77 +
+        column_78 +
+        column_79 +
+        column_80 +
+        column_81 +
+        column_82 +
+        column_83 +
+        column_84 +
+        column_85 +
+        column_86 +
+        column_87 +
+        column_88 +
+        column_89 +
+        column_90 +
+        column_91 +
+        column_92 +
+        column_93 +
+        column_94 +
+        column_95 +
+        column_96 +
+        column_97 +
+        column_98 +
+        column_99 +
+        column_100 +
+        column_101 +
+        column_102 +
+        column_103 +
+        column_104 +
+        column_105 +
+        column_106 +
+        column_107 +
+        column_108 +
+        column_109 +
+        column_110 +
+        column_111 +
+        column_112 +
+        column_113 +
+        column_114 +
+        column_115 +
+        column_116 +
+        column_117 +
+        column_118 +
+        column_119 +
+        column_120 +
+        column_121 +
+        column_122 +
+        column_123 +
+        column_124 +
+        column_125 +
+        column_126 +
+        column_127 +
+        column_128 AS total
+      FROM resolver_values
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - total: 8256
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS resolver_values"


### PR DESCRIPTION
## Summary

- cache immutable exact and Unicode case-folded column-name indexes alongside table metadata
- expose a read-only `resolve_column_name` SCM primitive and use it during physical recipe emission instead of repeatedly scanning `SHOW` rows
- add phase-specific `EXPLAIN COMPILE` limits to the YAML runner and a minimal 128-column regression

## Root cause

Each unqualified base-table column reference rebuilt/scanned the full column metadata list during recipe emission. Wide expressions therefore multiplied reference count by table width. The logical plan was already correct; the repeated work lived in physical compiler metadata resolution.

## Test first

The new YAML regression failed on `origin/master` because `recipe_emit_ns` took 42.0 ms against a 28 ms ceiling. The initial Go test also failed to compile before `ResolveColumnName` existed.

## A/B against origin/master

Seven cold, cache-distinct compiles per width on the same host; values are median `recipe_emit_ns`.

| Column references | Master | Branch | Speedup | Plan bytes |
|---:|---:|---:|---:|---:|
| 32 | 7.188 ms | 1.363 ms | 5.27x | 3,895 |
| 64 | 17.331 ms | 3.066 ms | 5.65x | 9,559 |
| 128 | 40.908 ms | 9.935 ms | 4.12x | 27,118 |
| 256 | 117.093 ms | 43.487 ms | 2.69x | 87,022 |

Plan sizes are identical between revisions. Total planner time improves 2.71x at 128 references (49.578 to 18.319 ms) and 2.19x at 256 references (135.033 to 61.662 ms).

The direct cached exact-name lookup benchmark has a 15.23 ns/op median across five runs, with 0 B/op and 0 allocs/op.

## Validation

- full `MEMCP_FAIL_FAST=1 ./git-pre-commit`: passed
- targeted SQL regression: passed
- storage unit tests and race tests: passed
- Python syntax check and `git diff --check`: passed
- no logical IR or generated plan-size change
