### PR TITLE
Reduce FastDict index allocations

### DIFF
--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -184,10 +184,6 @@ func (d *FastDict) Set(key, value Scmer, merge func(oldV, newV Scmer) Scmer) {
 		d.index = make(map[uint64]int)
 	}
 	h := HashKey(key)
-	d.setHashed(key, value, merge, h)
-}
-
-func (d *FastDict) setHashed(key, value Scmer, merge func(oldV, newV Scmer) Scmer, h uint64) {
 	if pos, ok := d.findPos(key, h); ok {
 		if merge != nil {
 			d.Pairs[pos+1] = merge(d.Pairs[pos+1], value)

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -35,15 +35,16 @@ func init() {
 // Implementation uses a flat pairs array plus a lightweight hash index
 // to avoid O(N^2) behavior as it grows.
 type FastDict struct {
-	Pairs []Scmer          // [k0, v0, k1, v1, ...]
-	index map[uint64][]int // hash -> positions (indices into Pairs, even only)
+	Pairs      []Scmer          // [k0, v0, k1, v1, ...]
+	index      map[uint64]int   // hash -> first position in Pairs
+	collisions map[uint64][]int // additional positions, allocated only on hash collision
 }
 
 func NewFastDictValue(capacityPairs int) *FastDict {
 	if capacityPairs < 0 {
 		capacityPairs = 0
 	}
-	return &FastDict{Pairs: make([]Scmer, 0, capacityPairs*2), index: make(map[uint64][]int)}
+	return &FastDict{Pairs: make([]Scmer, 0, capacityPairs*2), index: make(map[uint64]int)}
 }
 
 func (d *FastDict) Iterate(fn func(k, v Scmer) bool) {
@@ -156,10 +157,13 @@ func (d *FastDict) findPos(key Scmer, h uint64) (int, bool) {
 	if d.index == nil {
 		return -1, false
 	}
-	if bucket, ok := d.index[h]; ok {
-		for _, pos := range bucket {
-			if Equal(d.Pairs[pos], key) {
-				return pos, true
+	if pos, ok := d.index[h]; ok {
+		if Equal(d.Pairs[pos], key) {
+			return pos, true
+		}
+		for _, collisionPos := range d.collisions[h] {
+			if Equal(d.Pairs[collisionPos], key) {
+				return collisionPos, true
 			}
 		}
 	}
@@ -177,9 +181,13 @@ func (d *FastDict) Get(key Scmer) (Scmer, bool) {
 // Set sets or merges a value for key. If merge is nil, it overwrites.
 func (d *FastDict) Set(key, value Scmer, merge func(oldV, newV Scmer) Scmer) {
 	if d.index == nil {
-		d.index = make(map[uint64][]int)
+		d.index = make(map[uint64]int)
 	}
 	h := HashKey(key)
+	d.setHashed(key, value, merge, h)
+}
+
+func (d *FastDict) setHashed(key, value Scmer, merge func(oldV, newV Scmer) Scmer, h uint64) {
 	if pos, ok := d.findPos(key, h); ok {
 		if merge != nil {
 			d.Pairs[pos+1] = merge(d.Pairs[pos+1], value)
@@ -188,23 +196,36 @@ func (d *FastDict) Set(key, value Scmer, merge func(oldV, newV Scmer) Scmer) {
 		}
 		return
 	}
-	// append new
 	pos := len(d.Pairs)
 	d.Pairs = append(d.Pairs, key, value)
-	d.index[h] = append(d.index[h], pos)
+	if _, exists := d.index[h]; exists {
+		if d.collisions == nil {
+			d.collisions = make(map[uint64][]int)
+		}
+		d.collisions[h] = append(d.collisions[h], pos)
+	} else {
+		d.index[h] = pos
+	}
 }
 
 // Copy returns a deep copy of the FastDict (pairs and index).
 func (d *FastDict) Copy() *FastDict {
 	pairs := make([]Scmer, len(d.Pairs))
 	copy(pairs, d.Pairs)
-	idx := make(map[uint64][]int, len(d.index))
-	for h, bucket := range d.index {
-		b := make([]int, len(bucket))
-		copy(b, bucket)
-		idx[h] = b
+	idx := make(map[uint64]int, len(d.index))
+	for h, pos := range d.index {
+		idx[h] = pos
 	}
-	return &FastDict{Pairs: pairs, index: idx}
+	var collisions map[uint64][]int
+	if len(d.collisions) > 0 {
+		collisions = make(map[uint64][]int, len(d.collisions))
+		for h, positions := range d.collisions {
+			copied := make([]int, len(positions))
+			copy(copied, positions)
+			collisions[h] = copied
+		}
+	}
+	return &FastDict{Pairs: pairs, index: idx, collisions: collisions}
 }
 
 func (d *FastDict) ToList() []Scmer { return d.Pairs }

--- a/scm/assoc_fast_test.go
+++ b/scm/assoc_fast_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var assocBenchmarkSink Scmer
+
+func benchmarkAssocPairs(size int) []Scmer {
+	pairs := make([]Scmer, 0, size*2)
+	for i := 0; i < size; i++ {
+		pairs = append(pairs, NewString(fmt.Sprintf("key-%d", i)), NewInt(int64(i)))
+	}
+	return pairs
+}
+
+func benchmarkFastDict(size int) Scmer {
+	dict := NewFastDictValue(size)
+	pairs := benchmarkAssocPairs(size)
+	for i := 0; i < len(pairs); i += 2 {
+		dict.Set(pairs[i], pairs[i+1], nil)
+	}
+	return NewFastDict(dict)
+}
+
+func TestFastDictHashCollisionFallback(t *testing.T) {
+	dict := NewFastDictValue(3)
+	forcedHash := uint64(42)
+	dict.setHashed(NewString("first"), NewInt(1), nil, forcedHash)
+	dict.setHashed(NewString("second"), NewInt(2), nil, forcedHash)
+	dict.setHashed(NewString("third"), NewInt(3), nil, forcedHash)
+	dict.setHashed(NewString("second"), NewInt(20), nil, forcedHash)
+
+	for key, want := range map[string]int64{"first": 1, "second": 20, "third": 3} {
+		got, ok := dict.findPos(NewString(key), forcedHash)
+		if !ok || dict.Pairs[got+1].Int() != want {
+			t.Fatalf("collision lookup for %q returned position %d, found=%v", key, got, ok)
+		}
+	}
+	if len(dict.collisions[forcedHash]) != 2 {
+		t.Fatalf("expected two secondary collision positions, got %v", dict.collisions[forcedHash])
+	}
+}
+
+func BenchmarkAssocLookup(b *testing.B) {
+	for _, size := range []int{1, 2, 4, 5, 8, 12, 64} {
+		key := NewString(fmt.Sprintf("key-%d", size-1))
+		b.Run(fmt.Sprintf("list/%d", size), func(b *testing.B) {
+			dict := NewSlice(benchmarkAssocPairs(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				assocBenchmarkSink = Apply(dict, key)
+			}
+		})
+		b.Run(fmt.Sprintf("fastdict/%d", size), func(b *testing.B) {
+			dict := benchmarkFastDict(size)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				assocBenchmarkSink = Apply(dict, key)
+			}
+		})
+	}
+}
+
+func BenchmarkFastDictBuild(b *testing.B) {
+	for _, size := range []int{1, 2, 4, 5, 8, 12, 64} {
+		pairs := benchmarkAssocPairs(size)
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				dict := NewFastDictValue(size)
+				for pos := 0; pos < len(pairs); pos += 2 {
+					dict.Set(pairs[pos], pairs[pos+1], nil)
+				}
+				assocBenchmarkSink = NewFastDict(dict)
+			}
+		})
+	}
+}
+
+func TestFunctionalAssocBuilderUsesOwnedAccumulator(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := optimizeTestSource(t, env, `(lambda (items)
+		(reduce items (lambda (index item)
+			(set_assoc index item item)) '()))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "set_assoc_mut") {
+		t.Fatalf("functional assoc builder did not use owned accumulator: %s", serialized)
+	}
+}
+
+func BenchmarkFunctionalAssocBuild(b *testing.B) {
+	env := newOptimizerTestEnv()
+	optimized := optimizeTestSource(b, env, `(lambda (items)
+		(reduce items (lambda (index item)
+			(set_assoc index item item)) '()))`)
+	build := OptimizeProcToSerialFunction(Eval(optimized, env))
+	for _, size := range []int{1, 2, 4, 5, 8, 12, 64} {
+		items := make([]Scmer, size)
+		for i := range items {
+			items[i] = NewString(fmt.Sprintf("key-%d", i))
+		}
+		input := NewSlice(items)
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				assocBenchmarkSink = build(input)
+			}
+		})
+	}
+}

--- a/scm/assoc_fast_test.go
+++ b/scm/assoc_fast_test.go
@@ -42,12 +42,15 @@ func benchmarkFastDict(size int) Scmer {
 }
 
 func TestFastDictHashCollisionFallback(t *testing.T) {
-	dict := NewFastDictValue(3)
+	first := NewString("first")
+	second := NewString("second")
+	third := NewString("third")
 	forcedHash := uint64(42)
-	dict.setHashed(NewString("first"), NewInt(1), nil, forcedHash)
-	dict.setHashed(NewString("second"), NewInt(2), nil, forcedHash)
-	dict.setHashed(NewString("third"), NewInt(3), nil, forcedHash)
-	dict.setHashed(NewString("second"), NewInt(20), nil, forcedHash)
+	dict := &FastDict{
+		Pairs:      []Scmer{first, NewInt(1), second, NewInt(20), third, NewInt(3)},
+		index:      map[uint64]int{forcedHash: 0},
+		collisions: map[uint64][]int{forcedHash: {2, 4}},
+	}
 
 	for key, want := range map[string]int64{"first": 1, "second": 20, "third": 3} {
 		got, ok := dict.findPos(NewString(key), forcedHash)

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1575,11 +1575,13 @@ func fastDictPayloadSize(fd *FastDict) uint {
 	}
 	if len(fd.index) > 0 {
 		sz += goAllocOverhead + uint(len(fd.index))*16
-		for _, bucket := range fd.index {
-			if len(bucket) == 0 {
-				continue
+	}
+	if len(fd.collisions) > 0 {
+		sz += goAllocOverhead + uint(len(fd.collisions))*32
+		for _, positions := range fd.collisions {
+			if len(positions) > 0 {
+				sz += goAllocOverhead + uint(len(positions))*8
 			}
-			sz += goAllocOverhead + uint(len(bucket))*8
 		}
 	}
 	return sz


### PR DESCRIPTION
## What changed

FastDict now stores the first position for a hash directly in `map[uint64]int`. A secondary position slice is allocated only for a real hash collision. Ordered pairs, structural equality, collision handling, copy semantics, and memory accounting remain intact.

The existing list-to-FastDict transition stays at five pairs. The Scheme `reduce` builder still optimizes `set_assoc` to the owned `set_assoc_mut` accumulator path.

### Measurement-driven correction

The first revision introduced a `setHashed` method solely to inject collisions in a test. Go cannot inline either `Set` or that helper, so this added a function call to every real FastDict insertion/update. It has been removed: the production `Set` path is direct again, and the collision test constructs the internal collision shape without adding a production abstraction.

No list/FastDict threshold, `_mut` rewrite, ownership hint, or Scheme data structure was replaced.

## Stabilized microbenchmarks

Current master vs corrected branch, same pinned CPU, `GOMAXPROCS=1`, ABBA binary order, 10 samples per case at 300 ms:

| FastDict pairs | time | bytes | allocs |
|---:|---:|---:|---:|
| 1 | 142.1 ns -> 115.1 ns (-19.0%) | 408 -> 272 (-33.3%) | 5 -> 4 (-20.0%) |
| 2 | 185.4 ns -> 147.0 ns (-20.7%) | 448 -> 304 (-32.1%) | 6 -> 4 (-33.3%) |
| 4 | 275.2 ns -> 211.9 ns (-23.0%) | 528 -> 368 (-30.3%) | 8 -> 4 (-50.0%) |
| 5 | 318.3 ns -> 248.0 ns (-22.1%) | 568 -> 400 (-29.6%) | 9 -> 4 (-55.6%) |
| 8 | 457.7 ns -> 355.7 ns (-22.3%) | 688 -> 496 (-27.9%) | 12 -> 4 (-66.7%) |
| 12 | 910.7 ns -> 714.1 ns (-21.6%) | 1464 -> 952 (-35.0%) | 19 -> 7 (-63.2%) |
| 64 | 6.196 us -> 4.828 us (-22.1%) | 11.93 KiB -> 6.84 KiB (-42.7%) | 77 -> 13 (-83.1%) |

The functional `set_assoc`/`set_assoc_mut` builder improves by 3.7-9.2% from 2 through 64 pairs; the 1-pair case is neutral. The 64-pair case improves from 19.74 us to 17.93 us (-9.2%), with -21.4% bytes and -11.8% allocations.

## Stabilized full-cascade A/B

The production-derived full prefix cascade was repeated with:

- both servers pinned to the same four-CPU set with `GOMAXPROCS=4`
- two warmup rounds and 15 measured rounds per prefix
- randomized prefix and master/branch order per round
- paired deltas and bootstrapped 95% confidence intervals
- identical fixture shape and identical plan bytes at every prefix

| prefix | master median | branch median | paired median | paired median 95% CI | plan bytes |
|---|---:|---:|---:|---:|---:|
| C | 1934.012 ms | 1896.987 ms | -2.14% | [-4.30%, -1.06%] | 103989 |
| Ca | 1932.667 ms | 1901.596 ms | -1.71% | [-2.17%, -0.20%] | 104031 |
| Car | 1926.907 ms | 1887.157 ms | -1.79% | [-3.28%, -1.51%] | 104033 |
| Carg | 1915.583 ms | 1894.267 ms | -0.71% | [-2.58%, -0.00%] | 104035 |
| Cargl | 1939.972 ms | 1879.151 ms | -2.75% | [-4.06%, -2.29%] | 104037 |
| Cargla | 1948.479 ms | 1882.492 ms | -2.66% | [-3.82%, -1.78%] | 104039 |
| Carglas | 1944.178 ms | 1891.496 ms | -2.84% | [-4.32%, -2.28%] | 104041 |
| Carglass | 1935.880 ms | 1909.359 ms | -1.49% | [-2.23%, -0.88%] | 104043 |
| CarglassXXX | 1934.380 ms | 1913.913 ms | -1.13% | [-4.26%, +0.36%] | 104049 |

Across all 135 paired samples, compile time improves by 2.07% at the median and 2.09% at the mean. Recipe emission improves by 2.02% at the median. Eight of nine per-prefix confidence intervals are wholly non-positive; the longest prefix is directionally faster but not independently significant.

The earlier five-sample planner table is intentionally superseded because separate medians and uncontrolled scheduling were too noisy for a roughly 2% effect.

## Validation

- `go test ./scm -count=1`
- normal binary: `tests/14_order_limit.yaml`, 19/19 passed in 1.70 s
- hook-equivalent coverage run: all functional assertions passed; the existing 5 s ORDER BY/OFFSET performance gate exceeded its limit under coverage
- previous CI revision: both `test` and `sql-time-limit-guard` passed; the corrected revision reruns CI

The PR remains a draft for the merge decision.