### PR TITLE
Deduplicate physical stage preparation

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4594,8 +4594,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define prepared_input (query_block_without_stages_after_eager_prepare_using nested_stages keyed_input))
 		(define rows_plan (lower_query_block_as_dataset_rows prepared_input (list "__value" value_expr)))
 		(define prepare_exprs (merge (list
-			(map nested_stages (lambda (nested_stage)
-				(lower_stage_prepare_using nested_stages nested_stages nested_stage)))
+			(lower_unique_stage_prepares_using nested_stages nested_stages nested_stages)
 			(lower_stage_materialize_all nested_stages))))
 		(define probe_expr (list (quote scan)
 			'(session "__memcp_tx")
@@ -7174,24 +7173,34 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(begin
 			(define carrier (group_stage_carrier stage))
 			(list (quote group) (group_carrier_schema carrier) (group_carrier_relation carrier)))
-		stage)))
+		(logical_stage_key stage))))
 
-(define stage_prepare_seen? (lambda (seen stage)
-	(begin
-		(define identity (stage_prepare_identity stage))
-		(reduce seen (lambda (found item)
-			(or found (equal? item identity)))
-			false))))
-
-(define dedupe_stages_for_prepare (lambda (stages)
-	(nth (reduce (coalesceNil stages '()) (lambda (acc stage)
-		(begin
-			(define kept (nth acc 0))
-			(define seen (nth acc 1))
+(define lower_unique_stage_prepares_acc (lambda (stages seen prepare)
+	(match (coalesceNil stages '())
+		(cons stage rest) (begin
+			/* Lower every logical owner before deduplication so stage-output IDs are
+			   still resolved and validated against their original dependency scope. */
+			(define plan (prepare stage))
 			(define identity (stage_prepare_identity stage))
-			(if (stage_prepare_seen? seen stage)
-				acc
-				(list (merge kept (list stage)) (merge seen (list identity)))))) (list '() '())) 0)))
+			(if (has_assoc? seen identity)
+				(lower_unique_stage_prepares_acc rest seen prepare)
+				(cons plan
+					(lower_unique_stage_prepares_acc rest (set_assoc seen identity true) prepare))))
+		_ '())))
+
+(define lower_unique_stage_prepares (lambda (stages prepare)
+	(lower_unique_stage_prepares_acc stages '() prepare)))
+
+(define lower_unique_stage_prepares_using (lambda (all_stages lookup_stages stages)
+	(lower_unique_stage_prepares stages (lambda (stage)
+		(lower_stage_prepare_using all_stages lookup_stages stage)))))
+
+(define lower_unique_stage_prepares_with_graph (lambda (dependency_graph stage_catalog stages)
+	(lower_unique_stage_prepares stages (lambda (stage)
+		(lower_stage_prepare_using
+			(stage_dependency_closure_using_graph dependency_graph stage)
+			stage_catalog
+			stage)))))
 
 (define lower_group_stage_prepare_using (lambda (all_stages lookup_stages stage)
 	(begin
@@ -7263,8 +7272,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(query_block_probe_expr_stages rewritten_src)))
 			'()))
 		(define nested_stages direct_nested_stages)
-		(define nested_prepare (if (query_block? rewritten_src) (map nested_stages (lambda (nested_stage)
-			(lower_stage_prepare_using prepare_catalog stage_catalog nested_stage))) '()))
+		(define nested_prepare (if (query_block? rewritten_src)
+			(lower_unique_stage_prepares_using prepare_catalog stage_catalog nested_stages)
+			'()))
 		(define nested_materialize (if (query_block? rewritten_src) (lower_stage_materialize_all nested_stages) '()))
 		(define nested_prepare_expr (if (empty_list? nested_prepare)
 			nil
@@ -7798,11 +7808,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(define main_stage (make_group_stage_for_query_block grouped_input_block))
 				(cons (quote !begin)
 					(merge (list
-						(map (qb_stages rewritten) (lambda (stage)
-							(lower_stage_prepare_using
-								(stage_dependency_closure_using_graph dependency_graph stage)
-								stage_catalog
-								stage)))
+						(lower_unique_stage_prepares_with_graph dependency_graph stage_catalog (qb_stages rewritten))
 						(lower_stage_materialize_all (qb_stages rewritten))
 						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) (cons main_stage stage_catalog) main_stage))
 						(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources)))))))))))
@@ -7971,11 +7977,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 						(cons (quote !begin)
 							(merge (list
 									(lazy_stage_prepare_bindings stage_catalog lazy_stages)
-									(map eager_stages (lambda (stage)
-										(lower_stage_prepare_using
-											(stage_dependency_closure_using_graph dependency_graph stage)
-											stage_catalog
-											stage)))
+									(lower_unique_stage_prepares_with_graph dependency_graph stage_catalog eager_stages)
 									(list (lower_query_block_core core_block))))))))))))))
 
 (define lower_query_block_with_stages (lambda (block)
@@ -8962,8 +8964,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 								(define project_stages (filter (query_block_stages_to_prepare_base_using stage_catalog block) (lambda (stage)
 										(not (stage_id_in? stage prelimit_stage_ids)))))
 									(define project_prepare_expr (cons (quote !begin)
-										(map project_stages (lambda (stage)
-										(lower_stage_prepare_using stage_catalog stage_catalog stage)))))
+										(lower_unique_stage_prepares_using stage_catalog stage_catalog project_stages)))
 									(define project_row_expr
 										(lower_join_result_row_assoc scan_sources first_alias fields order_items))
 									(define project_rows_expr (replace_lowered_driver_symbols_with_row first_alias driver_cols
@@ -9182,11 +9183,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(define dependency_graph (stage_dependency_graph stage_catalog))
 			(cons (quote begin)
 				(merge (list
-					(map (qb_stages block) (lambda (stage)
-						(lower_stage_prepare_using
-							(stage_dependency_closure_using_graph dependency_graph stage)
-							stage_catalog
-							stage)))
+					(lower_unique_stage_prepares_with_graph dependency_graph stage_catalog (qb_stages block))
 					(list (lower_dml_query_block_core (query_block_without_stages_after_prepare_using stage_catalog block) target_schema target_tbl)))))))))
 
 (define lower_dml_union_block_with_stages (lambda (block target_schema target_tbl)

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -671,6 +671,30 @@ test_cases:
           metric_7: 1
           metric_8: 1
 
+  - name: "Physical preparation owns each identical nested stage once per query scope"
+    sql: |
+      EXPLAIN SELECT
+        (SELECT SUM(1) FROM trace_wide_prop item_1 WHERE item_1.id = 1 AND COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item_1.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_1,
+        (SELECT SUM(1) FROM trace_wide_prop item_2 WHERE item_2.id = 1 AND COALESCE((SELECT (parent_2.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_2 WHERE member_2.team_id = parent_2.team_id AND member_2.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_2 WHERE parent_2.id = item_2.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_2
+    expect:
+      rows: 1
+      result_contains:
+        - "touch_keytable"
+      result_occurrences:
+        - text: "touch_keytable"
+          count: 5
+
+  - name: "Physical preparation keeps distinct nested filter formulas"
+    sql: |
+      EXPLAIN SELECT
+        (SELECT SUM(1) FROM trace_wide_prop item_1 WHERE item_1.id = 1 AND COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item_1.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_1,
+        (SELECT SUM(1) FROM trace_wide_prop item_2 WHERE item_2.id = 1 AND COALESCE((SELECT (parent_2.owner_id = 8 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_2 WHERE member_2.team_id = parent_2.team_id AND member_2.member_id = 8 LIMIT 1)) FROM trace_wide_parent parent_2 WHERE parent_2.id = item_2.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_2
+    expect:
+      rows: 1
+      result_occurrences:
+        - text: "touch_keytable"
+          count: 6
+
   - name: "Constant CASE prunes dead scalar aggregate"
     max_time: 0.2
     max_plan_size: 2000


### PR DESCRIPTION
## Root cause

Logical stages that resolve to the same canonical physical group carrier were lowered through multiple dependency paths. Runtime guards usually avoided rebuilding the carrier contents, but every duplicate preparation subtree still reached physical plan optimization, serialization, allocation, and execution.

Deduplicating logical stage lists is unsafe: distinct logical stage IDs still own source physicalization and validation. This change therefore lowers every logical owner in its original dependency scope, then emits only the first physical preparation for each canonical carrier identity.

## Changes

- add stable, assoc-backed physical preparation ownership
- apply ownership at eager, grouped, nested probe, late-projection, and DML lowering boundaries
- preserve original logical stage catalogs and dependency closures
- add an anonymized repeated-carrier EXPLAIN regression
- add a negative regression proving different filter formulas remain distinct

## A/B benchmark

Baseline: `9198b29ba56d465c44e91bf8544a63da624114cb`
Branch: `fa51143e8e9c892142cf4f8763f8165972ee3fe5`

Representative 28 KiB production-style dataview query, identical persisted data and session values. EXPLAIN COMPILE reports medians from 5 baseline and 7 branch runs:

| Metric | master | branch | change |
| --- | ---: | ---: | ---: |
| total compile | 3846.8 ms | 3719.3 ms | -3.3% |
| planner | 2522.2 ms | 2406.8 ms | -4.6% |
| recipe emission | 2139.4 ms | 2071.2 ms | -3.2% |
| plan nodes | 7,506 | 6,226 | -17.1% |
| plan bytes | 101,998 | 85,788 | -15.9% |
| carrier prepares | 26 | 18 | -30.8% |

Full SELECT wall time, five sequential runs on isolated copies of the same data:

- master: 17.53, 10.96, 25.56, 9.28, 9.12 s; median 10.96 s
- branch: 16.63, 11.11, 10.89, 10.87, 9.37 s; median 10.89 s

The warm execution difference (-0.6%) is below measurement noise. The supported performance claim is reduced physical plan size and compile work, not a material execution speedup.

The anonymized duplicate fixture reduces `touch_keytable` emission from 6 to 5. A companion query with distinct predicates remains at 6.

## Validation

- `go build -o memcp`
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all suites passed
- `tests/118_manual_trace_sql_regressions.yaml`: 18/18
- `tests/40_exists_subquery.yaml`: 20/20
- `tests/41_in_subquery.yaml`: 52/52
- `tests/69_subquery_complex.yaml`: 33/33
- `tests/70_union_all.yaml`: 35/35
- `tests/83_group_cache_invalidation.yaml`: 95/95
- `tests/37_triggers.yaml`: 316/316
- `git diff --check`

The existing global Scheme linter warnings remain unchanged.
