### PR TITLE
Add logical SQL views

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -650,7 +650,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			'('begin
 				'('set 'resultrow '('lambda '('item) '('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols) (if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))) false '('lambda '('id) '('session "last_insert_id" 'id)))))
-				(build_queryplan_term inner)
+				(build_queryplan_term (sql_expand_views inner policy))
 			)
 	)))
 
@@ -659,6 +659,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser (atom "CASCADE" true) "cascade")
 		(parser (atom "SET NULL" true) "set null")
 	)))
+
+	(define psql_create_view (parser '(
+		(atom "CREATE" true)
+		(define replace (? (atom "OR" true) (atom "REPLACE" true)))
+		(atom "VIEW" true)
+		(define ifnotexists (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true)))
+		(define target (or
+			(parser '((define schema2 psql_identifier) "." (define id psql_identifier)) '(schema2 id))
+			(parser (define id psql_identifier) '(nil id))))
+		(define aliases (? (parser '("(" (define columns (+ psql_identifier ",")) ")") columns)))
+		(atom "AS" true)
+		(define captured (capture psql_select))
+	) (match target '(schema2 id) (begin
+			(define view_schema (coalesce schema2 schema))
+			(if policy (policy view_schema id true) true)
+			(define query (sql_apply_view_column_aliases (nth captured 1) aliases))
+			(list (quote create_sql_view)
+				(list (quote session) "__memcp_tx")
+				view_schema id "psql" (nth captured 0) (list (quote quote) query)
+				(if replace "replace" (if ifnotexists "ignore" "error")))))))
 
 	(define psql_create_table (parser '(
 		(atom "CREATE" true)
@@ -764,13 +784,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(alter auto_increment), not be wrapped as a SELECT projection. */
 		(parser '((atom "SELECT" true) (atom "pg_catalog" true) "." (atom "setval" true) "(" (define seq_name psql_string) "," (define val psql_expression) "," (define is_called psql_expression) ")")
 			(psql_setval_command seq_name val is_called))
-		(parser (define query psql_select) (build_queryplan_term query))
-		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query psql_select)) (explain_queryplan_ir query))
-		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query psql_select)) (explain_queryplan_reorder query))
-		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query psql_select)) (explain_queryplan_compile query parse_started_ns (strlen s)))
-		(parser '((atom "EXPLAIN" true) (define query psql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
+		(parser (define query psql_select) (build_queryplan_term (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query psql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query psql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query psql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (define query psql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term (sql_expand_views query policy)) (settings "ExplainWidth")))))
 		psql_insert_into
 		psql_insert_select
+		psql_create_view
 		psql_create_table
 		(parser '((atom "ALTER" true) (atom "TABLE" true) (? (atom "ONLY" true))
 			(define target (or
@@ -1011,6 +1032,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser '((atom "DROP" true) (atom "DATABASE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id (if if_exists true false))))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "VIEW" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true)))
+			(define target (or
+				(parser '((define schema2 psql_identifier) "." (define id psql_identifier)) '(schema2 id))
+				(parser (define id psql_identifier) '(nil id)))))
+			(match target '(schema2 id) (begin
+				(define view_schema (coalesce schema2 schema))
+				(if policy (policy view_schema id true) true)
+				(list (quote drop_sql_view) (list (quote session) "__memcp_tx") view_schema id (if if_exists true false)))))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname psql_identifier) (atom "TO" true) (define newname psql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key psql_identifier) (or "=" (atom ":=" true)) (define value (or
 			(parser (atom "content" true) "content") /* quirks for SET xmloption = content */

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -204,7 +204,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 						(list (symbol "lambda") (list (symbol "row"))
 							(list _psym "once" (list (symbol "nth") (symbol "row") 1) "scalar subselect returned more than one row")))
 					(list (symbol "set") (symbol "resultrow") _rrsym)
-					(build_queryplan_term transformed_subquery)
+					(build_queryplan_term (sql_expand_views transformed_subquery policy))
 					(list _psym "value")))
 				expr)
 			(if (or (equal?? head "inner_select_in") (equal?? head (quote inner_select_in))
@@ -336,7 +336,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 															(list (symbol "list"))
 															(if ignore (list (symbol "lambda") '() 0) nil)
 															false nil)))
-												(build_queryplan_term inner_t)))))
+												(build_queryplan_term (sql_expand_views inner_t policy))))))
 									(if (equal? tag '!update)
 										/* UPDATE table SET ... WHERE ... - stmt is (!update tbl assignments where) */
 										(begin
@@ -956,7 +956,7 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 					'((quote lambda) '() 0)
 					(if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))))
 				'('lambda '('id) '('session "last_insert_id" 'id)))))
-			(build_queryplan_term inner)
+			(build_queryplan_term (sql_expand_views inner policy))
 		)
 	)))
 	(define sql_select_core (parser '(
@@ -1320,6 +1320,26 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser (atom "SET NULL" true) "set null")
 	)))
 
+	(define sql_create_view (parser '(
+		(atom "CREATE" true)
+		(define replace (? (atom "OR" true) (atom "REPLACE" true)))
+		(atom "VIEW" true)
+		(define ifnotexists (? (atom "IF" true) (atom "NOT" true) (atom "EXISTS" true)))
+		(define target (or
+			(parser '((define schema2 sql_identifier) "." (define id sql_identifier)) '(schema2 id))
+			(parser (define id sql_identifier) '(nil id))))
+		(define aliases (? (parser '("(" (define columns (+ sql_identifier ",")) ")") columns)))
+		(atom "AS" true)
+		(define captured (capture sql_select))
+	) (match target '(schema2 id) (begin
+			(define view_schema (coalesce schema2 schema))
+			(if policy (policy view_schema id true) true)
+			(define query (sql_apply_view_column_aliases (nth captured 1) aliases))
+			(list (quote create_sql_view)
+				(list (quote session) "__memcp_tx")
+				view_schema id "sql" (nth captured 0) (list (quote quote) query)
+				(if replace "replace" (if ifnotexists "ignore" "error")))))))
+
 	(define sql_create_table (parser '(
 		(atom "CREATE" true)
 		(atom "TABLE" true)
@@ -1441,15 +1461,16 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	/* TODO: ignore comments wherever they occur --> Lexer */
 	(define p (parser (or
 		(parser (atom "SHUTDOWN" true) (begin (if policy (policy "system" true true) true) '(shutdown)))
-		(parser (define query sql_select) (build_queryplan_term query))
-		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query sql_select)) (explain_queryplan_ir query))
-		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query sql_select)) (explain_queryplan_reorder query))
-		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query sql_select)) (explain_queryplan_compile query parse_started_ns (strlen s)))
-		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term query) (settings "ExplainWidth")))))
+		(parser (define query sql_select) (build_queryplan_term (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query sql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query sql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query sql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (build_queryplan_term (sql_expand_views query policy)) (settings "ExplainWidth")))))
 		sql_insert_set
 		sql_insert_values_select
 		sql_insert_into
 		sql_insert_select
+		sql_create_view
 		sql_create_table
 		sql_alter_table
 		sql_update
@@ -1657,6 +1678,14 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
+		(parser '((atom "DROP" true) (atom "VIEW" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true)))
+			(define target (or
+				(parser '((define schema2 sql_identifier) "." (define id sql_identifier)) '(schema2 id))
+				(parser (define id sql_identifier) '(nil id)))))
+			(match target '(schema2 id) (begin
+				(define view_schema (coalesce schema2 schema))
+				(if policy (policy view_schema id true) true)
+				(list (quote drop_sql_view) (list (quote session) "__memcp_tx") view_schema id (if if_exists true false)))))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname sql_identifier) (atom "TO" true) (define newname sql_identifier)) '((quote renametable) schema oldname newname))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (define vars (* (parser '((? "@") (define key sql_identifier) (or "=" (atom ":=" true)) (define value sql_expression)) (list (list (quote context) "session") key value)) ","))) (cons '!begin vars))
 

--- a/lib/sql-views.scm
+++ b/lib/sql-views.scm
@@ -1,0 +1,168 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Views remain logical query sources. Their parser IR is expanded into a
+derived SELECT before untangle_query sees the complete query. */
+
+(set sql_view_catalog_state (coalesce sql_view_catalog_state (newsession)))
+(if (nil? (sql_view_catalog_state "version"))
+	(sql_view_catalog_state "version" 0)
+	true)
+(if (nil? (sql_view_catalog_state "count"))
+	(sql_view_catalog_state "count" 0)
+	true)
+
+(define sql_view_query_generation (lambda (query)
+	(if (> (sql_view_catalog_state "count") 0)
+		(begin
+			(define normalized_query (toLower query))
+			(define references_view (scan nil (table "system" "views")
+				'("name")
+				(lambda (name) (> (count (split normalized_query (toLower name))) 1))
+				'() (lambda () true) (lambda (a b) (or a b)) false))
+			(if references_view (sql_view_catalog_state "version") 0))
+		0)))
+
+(define sql_view_catalog_set_count (lambda (count)
+	(sql_view_catalog_state "count" count)))
+
+(define sql_view_catalog_changed (lambda ()
+	(sql_view_catalog_state "version" (+ (sql_view_catalog_state "version") 1))))
+
+(define sql_apply_view_column_aliases (lambda (query aliases)
+	(if (nil? aliases)
+		query
+		(match query
+			((symbol query-block) query_schema tables fields condition group having order limit offset hidden stages facts)
+			(if (equal? (* 2 (count aliases)) (count fields))
+				(list (quote query-block) query_schema tables
+					(merge (map (produceN (count aliases)) (lambda (i)
+						(list (nth aliases i) (nth fields (+ (* i 2) 1))))))
+					condition group having order limit offset hidden stages facts)
+				(error "view column alias count does not match its output columns"))
+			_ (error "view column aliases currently require one query block")))))
+
+(define sql_find_view (lambda (schema name)
+	(scan nil (table "system" "views")
+		'("database" "name")
+		(lambda (view_schema view_name)
+			(and (equal?? view_schema schema) (equal?? view_name name)))
+		'("dialect" "sql" "ir")
+		(lambda (dialect sql ir) (list dialect sql ir))
+		(lambda (a b) b)
+		nil)))
+
+(define sql_expand_views (lambda (query policy) (begin
+	(define expand_node (lambda (node stack)
+		(match node
+			((symbol query-block) query_schema sources fields condition group having order limit offset hidden stages facts)
+			(list (quote query-block)
+				query_schema
+				(map sources (lambda (source)
+					(match source
+						'(alias source_schema relation outer join_condition)
+						(begin
+							(define expanded_relation
+								(if (string? relation)
+									(begin
+										(if policy (policy source_schema relation false) true)
+										(if (has? (show source_schema) relation)
+											relation
+											(begin
+												(define view (sql_find_view source_schema relation))
+												(if (nil? view)
+													relation
+													(begin
+														(define key (concat source_schema "." relation))
+														(if (contains? stack key)
+															(error (concat "circular view reference: " key))
+															true)
+														(define stored_ir (nth view 2))
+														(if (nil? stored_ir)
+															(error (concat "view " key " has no parsed IR"))
+															(expand_node (json_decode_scmer stored_ir) (cons key stack))))))))
+									(expand_node relation stack)))
+							(list alias source_schema expanded_relation outer (expand_node join_condition stack)))
+						_ (error "invalid query source while expanding views"))))
+				(expand_node fields stack)
+				(expand_node condition stack)
+				(expand_node group stack)
+				(expand_node having stack)
+				(expand_node order stack)
+				limit offset
+				(expand_node hidden stack)
+				(expand_node stages stack)
+				(expand_node facts stack))
+			((symbol union-block) mode branches order limit offset facts)
+			(list (quote union-block) mode
+				(map branches (lambda (branch) (expand_node branch stack)))
+				(expand_node order stack) limit offset (expand_node facts stack))
+			(cons head tail)
+			(cons (expand_node head stack)
+				(map tail (lambda (item) (expand_node item stack))))
+			_ node)))
+	(if (> (sql_view_catalog_state "count") 0)
+		(expand_node query '())
+		query))))
+
+(define create_sql_view (lambda (tx schema name dialect sql ir mode) (begin
+	(define serialized_ir (json_encode ir))
+	(define existing (scan tx (table "system" "views")
+		'("database" "name")
+		(lambda (view_schema view_name)
+			(and (equal?? view_schema schema) (equal?? view_name name)))
+		'() (lambda () 1) + 0))
+	(define result
+		(if (> existing 0)
+			(match mode
+				"replace"
+				(scan tx (table "system" "views")
+					'("database" "name")
+					(lambda (view_schema view_name)
+						(and (equal?? view_schema schema) (equal?? view_name name)))
+					'("$update")
+					(lambda ($update)
+						($update (list "dialect" dialect "sql" sql "ir" serialized_ir)))
+					+ 0)
+				"ignore" 0
+				_ (error (concat "view " schema "." name " already exists")))
+			(insert (table "system" "views")
+				'("database" "name" "dialect" "sql" "ir")
+				(list (list schema name dialect sql serialized_ir)))))
+	(if (or (equal? existing 0) (equal? mode "replace"))
+		(begin
+			(if (equal? existing 0)
+				(sql_view_catalog_set_count (+ (sql_view_catalog_state "count") 1))
+				true)
+			(sql_view_catalog_changed))
+		true)
+	result)))
+
+(define drop_sql_view (lambda (tx schema name if_exists) (begin
+	(define removed (scan tx (table "system" "views")
+		'("database" "name")
+		(lambda (view_schema view_name)
+			(and (equal?? view_schema schema) (equal?? view_name name)))
+		'("$update")
+		(lambda ($update) ($update))
+		+ 0))
+	(if (> removed 0)
+		(begin
+			(sql_view_catalog_set_count (max 0 (- (sql_view_catalog_state "count") removed)))
+			(sql_view_catalog_changed)
+			removed)
+		(if if_exists 0 (error (concat "view " schema "." name " does not exist")))))))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (import "sql-builtins.scm")
 (import "sql-metadata.scm")
 (import "queryplan.scm")
+(import "sql-views.scm")
 
 /* query plan caches: separate cachemap per parser dialect */
 (set sql_queryplan_cache (newcachemap))
@@ -97,7 +98,7 @@ On parse error the result is not cached (e.g. table does not exist yet). */
 			(define cache_payload (if (not (equal? bindings '()))
 				(serialize (list parse_query bindings))
 				parse_query))
-			(define cache_key (concat username ":" schema ":" (fnv_hash cache_payload)))
+			(define cache_key (concat username ":" schema ":" (sql_view_query_generation parse_query) ":" (fnv_hash cache_payload)))
 			(define compile_diagnostic (match (toUpper parse_query)
 				(regex "^\\s*EXPLAIN\\s+COMPILE\\b" _) true
 				_ false))
@@ -231,6 +232,22 @@ qry    — query text (pass "" when unknown) */
 	(print "creating table system.access")
 	(eval (parse_sql "system" "CREATE TABLE `access`(username text, database text) ENGINE=SAFE" (lambda (schema tblname write) true)))
 ))
+
+/* Logical SQL views. Both the original SELECT and neutral parser IR are kept;
+the latter is expanded before logical planning and never materialized. */
+(if (has? (show "system") "views") true (begin
+	(print "creating table system.views")
+	(eval (parse_sql "system" "CREATE TABLE `views`(`database` text, `name` text, `dialect` text, `sql` text, `ir` text) ENGINE=SAFE" (lambda (schema tblname write) true)))
+))
+
+(try (lambda () (begin
+	(if (has? (show "system") "views")
+		(createkey (table "system" "views") "uniq_database_name" true '("database" "name"))
+		true)
+)) (lambda (e) true))
+
+(sql_view_catalog_set_count
+	(scan nil (table "system" "views") '() (lambda () true) '() (lambda () 1) + 0))
 
 /* migration: ensure unique (username, database) constraint on system.access */
 (try (lambda () (begin

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1507,6 +1507,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (> (strlen (serialize (_i ser_opt_lam))) 5) true "serialize optimized lambda with NumVars")
 	/* serialize roundtrip: eval serialized code */
 	(assert (equal? (eval (scheme (serialize '(+ 1 2)) "ser-test.scm")) 3) true "serialize roundtrip eval")
+	(define scmer_json_roundtrip '('query-block "db" '(list) nil))
+	(assert (equal? (json_decode_scmer (json_encode scmer_json_roundtrip)) scmer_json_roundtrip) true "Scmer JSON roundtrip preserves symbols and lists")
 
 	/* String() coverage (printer.go:String) */
 	(assert (equal? (string '()) "()") true "string of empty list")

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -756,6 +756,23 @@ func init_strings() {
 			Const:  true,
 		},
 	})
+	Declare(&Globalenv, &Declaration{
+		Name: "json_decode_scmer",
+		Desc: "parses JSON produced by json_encode and preserves Scheme symbols and lists",
+		Fn: func(a ...Scmer) Scmer {
+			var result Scmer
+			err := json.Unmarshal([]byte(String(a[0])), &result)
+			if err != nil {
+				panic(err)
+			}
+			return result
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "Scmer JSON to decode"}},
+			Return: &TypeDescriptor{Kind: "any"},
+			Const:  true,
+		},
+	})
 
 	Declare(&Globalenv, &Declaration{
 		Name: "base64_encode",

--- a/tests/03_ddl_operations.yaml
+++ b/tests/03_ddl_operations.yaml
@@ -9,6 +9,18 @@ setup:
   # Ensure user rows don't pre-exist from earlier runs
   - sql: "DELETE FROM system.user WHERE username = 'testuser'"
   - sql: "DELETE FROM system.user WHERE username = 'testuser2'"
+  - sql: "DROP VIEW IF EXISTS ddl_view_nested"
+  - sql: "DROP VIEW IF EXISTS ddl_view_totals"
+  - sql: "DROP VIEW IF EXISTS ddl_view_base"
+  - sql: "DROP VIEW IF EXISTS ddl_view_cycle_a"
+  - sql: "DROP VIEW IF EXISTS ddl_view_cycle_b"
+  - sql: "DROP VIEW IF EXISTS ddl_view_shadow"
+  - sql: "DROP TABLE IF EXISTS ddl_view_shadow"
+  - sql: "DROP TABLE IF EXISTS ddl_view_copy"
+  - sql: "DROP TABLE IF EXISTS ddl_view_source"
+  - sql: "CREATE TABLE ddl_view_source (id INT, category VARCHAR(20), amount INT)"
+  - sql: "CREATE TABLE ddl_view_copy (id INT, amount INT)"
+  - sql: "INSERT INTO ddl_view_source (id, category, amount) VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30)"
 
 test_cases:
 
@@ -223,6 +235,152 @@ test_cases:
     expect:
       affected_rows: 1
 
+  # === LOGICAL VIEW OPERATIONS ===
+  - name: "CREATE VIEW stores and expands a logical SELECT"
+    sql: |
+      CREATE VIEW ddl_view_base (key_id, category, doubled)
+      AS SELECT id, category, amount * 2
+      FROM ddl_view_source
+      WHERE amount >= 20
+    expect:
+      affected_rows: 1
+
+  - name: "SELECT reads an expanded view without materialization"
+    sql: "SELECT key_id, category, doubled FROM ddl_view_base ORDER BY key_id"
+    expect:
+      rows: 2
+      data:
+        - { key_id: 2, category: "a", doubled: 40 }
+        - { key_id: 3, category: "b", doubled: 60 }
+
+  - name: "system.views keeps raw SQL and parsed IR"
+    sql: |
+      SELECT dialect, sql LIKE 'SELECT%' AS has_sql, ir IS NOT NULL AS has_ir
+      FROM system.views
+      WHERE database = 'memcp-tests' AND name = 'ddl_view_base'
+    expect:
+      rows: 1
+      data:
+        - { dialect: "sql", has_sql: true, has_ir: true }
+
+  - name: "Nested views are recursively expanded"
+    sql: "CREATE VIEW ddl_view_nested AS SELECT key_id, doubled + 1 AS result FROM ddl_view_base"
+    expect:
+      affected_rows: 1
+
+  - name: "Nested view query sees the complete logical query"
+    sql: "SELECT key_id, result FROM ddl_view_nested ORDER BY key_id"
+    expect:
+      rows: 2
+      data:
+        - { key_id: 2, result: 41 }
+        - { key_id: 3, result: 61 }
+
+  - name: "Duplicate CREATE VIEW fails"
+    sql: "CREATE VIEW ddl_view_base AS SELECT id FROM ddl_view_source"
+    expect:
+      error: true
+
+  - name: "CREATE VIEW IF NOT EXISTS preserves the definition"
+    sql: "CREATE VIEW IF NOT EXISTS ddl_view_base AS SELECT id FROM ddl_view_source"
+    expect:
+      affected_rows: 0
+
+  - name: "CREATE OR REPLACE VIEW invalidates cached plans"
+    sql: |
+      CREATE OR REPLACE VIEW ddl_view_base (key_id, category, doubled)
+      AS SELECT id, category, amount * 3 FROM ddl_view_source
+    expect:
+      affected_rows: 1
+
+  - name: "Repeated SELECT uses the replaced view definition"
+    sql: "SELECT key_id, category, doubled FROM ddl_view_base ORDER BY key_id"
+    expect:
+      rows: 3
+      data:
+        - { key_id: 1, category: "a", doubled: 30 }
+        - { key_id: 2, category: "a", doubled: 60 }
+        - { key_id: 3, category: "b", doubled: 90 }
+
+  - name: "Aggregate view supports the TPC-H Q15 query shape"
+    sql: |
+      CREATE VIEW ddl_view_totals (supplier_no, total_revenue)
+      AS SELECT id, SUM(amount)
+      FROM ddl_view_source
+      GROUP BY id
+    expect:
+      affected_rows: 1
+
+  - name: "Aggregate view can be referenced by an aggregate subquery"
+    sql: |
+      SELECT supplier_no, total_revenue
+      FROM ddl_view_totals
+      WHERE total_revenue = (SELECT MAX(total_revenue) FROM ddl_view_totals)
+    expect:
+      rows: 1
+      data:
+        - { supplier_no: 3, total_revenue: 30 }
+
+  - name: "INSERT SELECT compiles views as logical sources"
+    sql: "INSERT INTO ddl_view_copy (id, amount) SELECT key_id, doubled FROM ddl_view_base"
+    expect:
+      affected_rows: 3
+
+  - name: "INSERT SELECT copied the expanded view rows"
+    sql: "SELECT id, amount FROM ddl_view_copy ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - { id: 1, amount: 30 }
+        - { id: 2, amount: 60 }
+        - { id: 3, amount: 90 }
+
+  - name: "View output alias count must match"
+    sql: "CREATE VIEW ddl_bad_view (only_one) AS SELECT id, amount FROM ddl_view_source"
+    expect:
+      error: true
+
+  - name: "Circular view definitions can be recorded"
+    sql: "CREATE VIEW ddl_view_cycle_a AS SELECT * FROM ddl_view_cycle_b"
+    expect:
+      affected_rows: 1
+
+  - name: "Second half of circular view can be recorded"
+    sql: "CREATE VIEW ddl_view_cycle_b AS SELECT * FROM ddl_view_cycle_a"
+    expect:
+      affected_rows: 1
+
+  - name: "Circular view expansion fails explicitly"
+    sql: "SELECT * FROM ddl_view_cycle_a"
+    expect:
+      error: true
+
+  - name: "Physical table shadows a view with the same name"
+    setup:
+      - sql: "CREATE VIEW ddl_view_shadow AS SELECT amount FROM ddl_view_source WHERE id = 1"
+      - sql: "CREATE TABLE ddl_view_shadow (amount INT)"
+      - sql: "INSERT INTO ddl_view_shadow (amount) VALUES (99)"
+    sql: "SELECT amount FROM ddl_view_shadow"
+    expect:
+      rows: 1
+      data:
+        - { amount: 99 }
+
+  - name: "DROP VIEW removes the catalog entry"
+    sql: "DROP VIEW ddl_view_nested"
+    expect:
+      affected_rows: 1
+
+  - name: "DROP missing VIEW fails"
+    sql: "DROP VIEW ddl_view_nested"
+    expect:
+      error: true
+
+  - name: "DROP VIEW IF EXISTS accepts a missing view"
+    sql: "DROP VIEW IF EXISTS ddl_view_nested"
+    expect:
+      affected_rows: 0
+
   # TODO: ALTER USER operations
   # - name: "ALTER USER password"
   #   sql: "ALTER USER testuser IDENTIFIED BY 'newpassword'"
@@ -233,3 +391,11 @@ cleanup:
   # Clean up created users to keep suite idempotent
   - sql: "DELETE FROM system.user WHERE username = 'testuser'"
   - sql: "DELETE FROM system.user WHERE username = 'testuser2'"
+  - sql: "DROP TABLE IF EXISTS ddl_view_shadow"
+  - sql: "DROP VIEW IF EXISTS ddl_view_shadow"
+  - sql: "DROP VIEW IF EXISTS ddl_view_cycle_b"
+  - sql: "DROP VIEW IF EXISTS ddl_view_cycle_a"
+  - sql: "DROP VIEW IF EXISTS ddl_view_totals"
+  - sql: "DROP VIEW IF EXISTS ddl_view_base"
+  - sql: "DROP TABLE IF EXISTS ddl_view_copy"
+  - sql: "DROP TABLE IF EXISTS ddl_view_source"

--- a/tests/72_psql_parser.yaml
+++ b/tests/72_psql_parser.yaml
@@ -13,6 +13,7 @@ metadata:
   syntax: postgresql
 
 setup:
+  - sql: "DROP VIEW IF EXISTS psql_data_view"
   - sql: "DROP TABLE IF EXISTS psql_data"
   - sql: "DROP TABLE IF EXISTS psql_decimal_range"
   - sql: |
@@ -363,6 +364,27 @@ test_cases:
         - id: 2
           name: "Bob"
 
+  - name: "PostgreSQL CREATE VIEW stores and expands parser IR"
+    sql: |
+      CREATE VIEW psql_data_view (view_id, view_name)
+      AS SELECT id, name FROM psql_data WHERE val >= 30
+    expect:
+      affected_rows: 1
+
+  - name: "PostgreSQL SELECT reads a logical view"
+    sql: "SELECT view_id, view_name FROM psql_data_view ORDER BY view_id"
+    expect:
+      rows: 2
+      data:
+        - { view_id: 2, view_name: "Bob" }
+        - { view_id: 3, view_name: "Charlie" }
+
+  - name: "PostgreSQL DROP VIEW removes the definition"
+    sql: "DROP VIEW psql_data_view"
+    expect:
+      affected_rows: 1
+
 cleanup:
+  - sql: "DROP VIEW IF EXISTS psql_data_view"
   - sql: "DROP TABLE IF EXISTS psql_decimal_range"
   - sql: "DROP TABLE IF EXISTS psql_data"

--- a/tests/90_trigger_persistence.yaml
+++ b/tests/90_trigger_persistence.yaml
@@ -10,6 +10,8 @@ metadata:
   isolated: true
 
 cleanup:
+  - action: "Drop persisted view"
+    sql: "DROP VIEW IF EXISTS tp_order_totals"
   - action: "Drop test tables"
     sql: "DROP TABLE IF EXISTS tp_orders"
   - action: "Drop test tables"
@@ -90,6 +92,21 @@ test_cases:
       # Only the user-visible tp_add100 trigger should appear; hidden prejoin triggers must not
       rows: 1
 
+  - name: "Create logical view before restart"
+    sql: "CREATE VIEW tp_order_totals AS SELECT customer_id, SUM(amount) AS total FROM tp_orders GROUP BY customer_id"
+    expect:
+      affected_rows: 1
+
+  - name: "Logical view works before restart"
+    sql: "SELECT customer_id, total FROM tp_order_totals ORDER BY customer_id"
+    expect:
+      rows: 2
+      data:
+        - customer_id: 1
+          total: 300
+        - customer_id: 2
+          total: 150
+
   # ----------------------------------------------------------------
   # SHUTDOWN — server will restart; subsequent tests run against fresh instance
   # ----------------------------------------------------------------
@@ -113,6 +130,16 @@ test_cases:
     expect:
       data:
         - val: 107
+
+  - name: "After restart: serialized logical view IR is restored"
+    sql: "SELECT customer_id, total FROM tp_order_totals ORDER BY customer_id"
+    expect:
+      rows: 2
+      data:
+        - customer_id: 1
+          total: 300
+        - customer_id: 2
+          total: 150
 
   # ----------------------------------------------------------------
   # After restart: internal prejoin trigger must still fire
@@ -152,6 +179,9 @@ test_cases:
   # ----------------------------------------------------------------
   # Cleanup
   # ----------------------------------------------------------------
+
+  - name: "Cleanup tp_order_totals"
+    sql: "DROP VIEW tp_order_totals"
 
   - name: "Cleanup tp_orders"
     sql: "DROP TABLE tp_orders"


### PR DESCRIPTION
## Summary

- add `CREATE [OR REPLACE] VIEW`, `CREATE VIEW IF NOT EXISTS`, and `DROP VIEW [IF EXISTS]` to both SQL dialects
- persist raw SELECT text plus type-preserving parsed IR in `system.views`
- expand missing physical sources into derived query blocks before logical planning, including nested views, cycle detection, column aliases, and physical-table shadowing
- invalidate cached plans only for queries that can reference cataloged views
- cover MySQL/PostgreSQL parsing, nested and aggregate/TPC-H Q15-shaped views, INSERT SELECT, cache invalidation, failure cases, and restart persistence

No TPC-H query text or redistribution-restricted helper data is included.

## Validation

- full current pre-commit hook, all suites green (serial suite scheduling on explicit free ports)
- `tests/03_ddl_operations.yaml`: 54/54
- `tests/72_psql_parser.yaml`: 41/41
- `tests/90_trigger_persistence.yaml`: 25/25
- full coverage run completed all correctness suites and 100% Scheme source coverage; only pre-existing 5s ORDER BY timing gates exceeded under coverage instrumentation/system contention