### PR TITLE
Inherit indexed lowering catalogs

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -89,6 +89,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(cons k _) (not (equal? k key))
 			true))))))
 
+(define qassoc_set_without (lambda (xs key value removed_key)
+	(cons (list key value)
+		(filter (coalesceNil xs '()) (lambda (entry) (match entry
+			(cons k _) (and (not (equal? k key)) (not (equal? k removed_key)))
+			true))))))
+
 (define empty_list? (lambda (xs)
 	(or (nil? xs) (equal? xs '()))))
 
@@ -6494,32 +6500,64 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define lowering_catalog? (lambda (catalog)
 	(match catalog
-		((symbol lowering-catalog) _stages _id_index _carrier_index) true
-		((quote lowering-catalog) _stages _id_index _carrier_index) true
+		((symbol lowering-catalog) _stages _id_index _carrier_index _parent) true
+		((quote lowering-catalog) _stages _id_index _carrier_index _parent) true
 		_ false)))
 
 (define lowering_catalog_stages (lambda (catalog)
-	(if (lowering_catalog? catalog) (nth catalog 1) catalog)))
+	(if (not (lowering_catalog? catalog))
+		catalog
+		(begin
+			(define local_stages (nth catalog 1))
+			(define parent (nth catalog 4))
+			(if (lowering_catalog? parent)
+				(unique_stages_by_id (merge (list local_stages (lowering_catalog_stages parent))))
+				local_stages)))))
 
 (define lowering_catalog_id_index (lambda (catalog) (nth catalog 2)))
 (define lowering_catalog_carrier_index (lambda (catalog) (nth catalog 3)))
+(define lowering_catalog_parent (lambda (catalog) (nth catalog 4)))
+
+(define make_indexed_lowering_catalog (lambda (stages parent)
+	(list
+		(quote lowering-catalog)
+		stages
+		(stage_dependency_id_index stages)
+		(stage_dependency_carrier_index stages)
+		parent)))
 
 (define make_lowering_catalog (lambda (stages)
 	(begin
 		(define available_stages (coalesceNil stages '()))
 		/* Below this measured crossover, sequential list lookup costs less than
-		   building and hashing two immutable indexes. */
+		building and hashing two immutable indexes. */
 		(if (<= (count available_stages) 24)
 			available_stages
-			(list
-				(quote lowering-catalog)
-				available_stages
-				(stage_dependency_id_index available_stages)
-				(stage_dependency_carrier_index available_stages))))))
+			(make_indexed_lowering_catalog available_stages nil)))))
+
+(define lowering_catalog_with_local_stages (lambda (catalog stages)
+	(begin
+		(define local_stages (if (lowering_catalog? catalog)
+			(filter (coalesceNil stages '()) (lambda (stage)
+				(if (group_stage? stage)
+					(nil? (stage_by_id catalog (gs_id stage)))
+					true)))
+			(coalesceNil stages '())))
+		(if (empty_list? local_stages)
+			catalog
+			(if (lowering_catalog? catalog)
+				(make_indexed_lowering_catalog local_stages catalog)
+				(unique_stages_by_id (merge (list local_stages catalog))))))))
 
 (define stage_by_id (lambda (stages stage_id)
 	(if (lowering_catalog? stages)
-		(get_assoc (lowering_catalog_id_index stages) stage_id)
+		(begin
+			(define local (get_assoc (lowering_catalog_id_index stages) stage_id))
+			(if (not (nil? local))
+				local
+				(begin
+					(define parent (lowering_catalog_parent stages))
+					(if (lowering_catalog? parent) (stage_by_id parent stage_id) nil))))
 		(reduce (coalesceNil stages '()) (lambda (found stage)
 			(if (not (nil? found))
 				found
@@ -6894,7 +6932,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(begin
 			(define index (lowering_catalog_carrier_index stages))
 			(define key (stage_dependency_carrier_key (source_schema src) (source_relation src)))
-			(get_assoc index key))
+			(define local (get_assoc index key))
+			(if (not (nil? local))
+				local
+				(begin
+					(define parent (lowering_catalog_parent stages))
+					(if (lowering_catalog? parent) (stage_for_carrier_source parent src) nil))))
 		(reduce (coalesceNil stages '()) (lambda (found stage)
 			(if (not (nil? found))
 				found
@@ -6912,7 +6955,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define stage_dependency_id_index (lambda (stages)
 	(if (lowering_catalog? stages)
-		(lowering_catalog_id_index stages)
+		(if (lowering_catalog? (lowering_catalog_parent stages))
+			(stage_dependency_id_index (lowering_catalog_stages stages))
+			(lowering_catalog_id_index stages))
 		(reduce (coalesceNil stages '()) (lambda (index stage)
 			(if (group_stage? stage)
 				(set_assoc index (gs_id stage) stage)
@@ -6923,7 +6968,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define stage_dependency_carrier_index (lambda (stages)
 	(if (lowering_catalog? stages)
-		(lowering_catalog_carrier_index stages)
+		(if (lowering_catalog? (lowering_catalog_parent stages))
+			(stage_dependency_carrier_index (lowering_catalog_stages stages))
+			(lowering_catalog_carrier_index stages))
 		(reduce (coalesceNil stages '()) (lambda (index stage)
 			(if (not (group_stage? stage))
 				index
@@ -7064,28 +7111,40 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(qb_stages block)
 		(query_block_facts_with_stage_catalog block stages))))
 
-(define group_stage_with_stage_catalog (lambda (stage stages)
+(define group_stage_with_lowering_catalog (lambda (stage catalog)
 	(if (not (group_stage? stage))
 		stage
-		(make_group_stage
-			(gs_id stage)
-			(gs_input stage)
-			(gs_domain stage)
-			(gs_keys stage)
-			(gs_aggregates stage)
-			(gs_having stage)
-			(gs_output stage)
-			(gs_order stage)
-			(gs_limit stage)
-			(gs_offset stage)
-			(qassoc_set (gs_facts stage) (quote stage_catalog) stages)))))
+		(begin
+			(define facts (gs_facts stage))
+			(make_group_stage
+				(gs_id stage)
+				(gs_input stage)
+				(gs_domain stage)
+				(gs_keys stage)
+				(gs_aggregates stage)
+				(gs_having stage)
+				(gs_output stage)
+				(gs_order stage)
+				(gs_limit stage)
+				(gs_offset stage)
+				(if (lowering_catalog? catalog)
+					(qassoc_set_without facts (quote lowering_catalog) catalog (quote stage_catalog))
+					(qassoc_set facts (quote stage_catalog) catalog)))))))
+
+(define group_stage_lowering_catalog (lambda (stage)
+	(match (gs_facts stage)
+		(cons entry _rest) (match entry
+			((symbol lowering_catalog) catalog) catalog
+			((quote lowering_catalog) catalog) catalog
+			_ nil)
+		_ nil)))
 
 (define query_block_with_full_stage_catalog (lambda (block)
 	(begin
 		(define stages (stage_catalog_with_nested (query_block_stage_catalog block)))
 		(define catalog (make_lowering_catalog stages))
 		(define cataloged_stages (map (qb_stages block) (lambda (stage)
-			(group_stage_with_stage_catalog stage stages))))
+			(group_stage_with_lowering_catalog stage catalog))))
 		(make_query_block
 			(qb_schema block)
 			(qb_sources block)
@@ -7183,7 +7242,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_without_stages_after_prepare_using (lambda (stages block)
 	(begin
-		(define available_stages (unique_stages_by_id (merge (list (lowering_catalog_stages stages) (qb_stages block)))))
+		(define available_stages (if (lowering_catalog? stages)
+			(lowering_catalog_stages stages)
+			(unique_stages_by_id (merge (list stages (qb_stages block))))))
 		(define stage_lookup (if (lowering_catalog? stages) stages available_stages))
 		(define rewritten (query_block_with_scalar_first_probes_using stage_lookup block))
 		(make_query_block
@@ -7205,7 +7266,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_without_stages_after_eager_prepare_using (lambda (stages block)
 	(begin
-		(define available_stages (unique_stages_by_id (merge (list (lowering_catalog_stages stages) (qb_stages block)))))
+		(define available_stages (if (lowering_catalog? stages)
+			(lowering_catalog_stages stages)
+			(unique_stages_by_id (merge (list stages (qb_stages block))))))
 		(define stage_lookup (if (lowering_catalog? stages) stages available_stages))
 		(make_query_block
 			(qb_schema block)
@@ -7223,7 +7286,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_without_stages_after_eager_prepare_with_constant_scalars_first (lambda (stages block)
 	(begin
-		(define available_stages (unique_stages_by_id (merge (list (lowering_catalog_stages stages) (qb_stages block)))))
+		(define available_stages (if (lowering_catalog? stages)
+			(lowering_catalog_stages stages)
+			(unique_stages_by_id (merge (list stages (qb_stages block))))))
 		(define stage_lookup (if (lowering_catalog? stages) stages available_stages))
 		(make_query_block
 			(qb_schema block)
@@ -7241,7 +7306,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(begin
-		(define available_stages (unique_stages_by_id (merge (list (lowering_catalog_stages stages) (qb_stages block)))))
+		(define available_stages (if (lowering_catalog? stages)
+			(lowering_catalog_stages stages)
+			(unique_stages_by_id (merge (list stages (qb_stages block))))))
 		(define stage_lookup (if (lowering_catalog? stages) stages available_stages))
 		(define scalar_rewritten (query_block_with_scalar_first_probes_using stage_lookup block))
 		(define membership_rewritten (query_block_with_physical_driver_order_membership_using stage_lookup scalar_rewritten))
@@ -7357,12 +7424,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(begin
 		(define src (gs_input stage))
 		(define prepare_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
-		(define stage_catalog (unique_stages_by_id
-			(merge (list
-				prepare_catalog
-				(lowering_catalog_stages lookup_stages)
-				(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))
-		(define stage_lookup (if (lowering_catalog? lookup_stages) lookup_stages stage_catalog))
+		(define fact_lookup (group_stage_lowering_catalog stage))
+		(define stage_lookup (if (lowering_catalog? lookup_stages)
+			lookup_stages
+			(if (lowering_catalog? fact_lookup)
+				fact_lookup
+				(unique_stages_by_id
+					(merge (list
+						prepare_catalog
+						lookup_stages
+						(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
 			true)
@@ -7410,12 +7481,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define prepared_src (if (query_block? rewritten_src)
 			(if scalar_aggregate_stage
 				(begin
-					(define constant_reorder_stages (unique_stages_by_id (merge (list stage_catalog (qb_stages rewritten_src)))))
+					(define constant_reorder_stages (if (lowering_catalog? stage_lookup)
+						stage_lookup
+						(unique_stages_by_id (merge (list stage_lookup (qb_stages rewritten_src))))))
 					(if (not (empty_list? (filter (qb_sources rewritten_src) (lambda (src)
 						(constant_scalar_stage_output_source? constant_reorder_stages src)))))
 						(query_block_without_stages_after_eager_prepare_with_constant_scalars_first constant_reorder_stages rewritten_src)
-						(query_block_without_stages_after_eager_prepare_using stage_catalog rewritten_src)))
-				(query_block_without_stages_after_eager_prepare_using stage_catalog rewritten_src))
+						(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src)))
+				(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src))
 			rewritten_src))
 		(define direct_nested_stages (if (query_block? rewritten_src)
 			(merge_unique (list
@@ -7443,7 +7516,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 								(not (equal? candidate_handle owner_handle))
 								(not (contains? owner_ancestors candidate_handle))))))))))
 		(define nested_prepare (if (query_block? rewritten_src)
-			(lower_unique_stage_prepares_using prepare_catalog stage_catalog nested_stages)
+			(lower_unique_stage_prepares_using prepare_catalog stage_lookup nested_stages)
 			'()))
 		(define nested_materialize (if (query_block? rewritten_src) (lower_stage_materialize_all nested_stages) '()))
 		(define nested_prepare_expr (if (empty_list? nested_prepare)
@@ -7977,11 +8050,12 @@ PostgreSQL parsers should both lower to the same combined operators.
 					'()
 					(qb_facts rewritten)))
 				(define main_stage (make_group_stage_for_query_block grouped_input_block))
+				(define main_stage_lookup (lowering_catalog_with_local_stages stage_lookup (list main_stage)))
 				(cons (quote !begin)
 					(merge (list
 						(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages rewritten))
 						(lower_stage_materialize_all (qb_stages rewritten))
-						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) (cons main_stage stage_catalog) main_stage))
+						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage))
 						(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources)))))))))))
 
 (define query_block_without_stages (lambda (block)
@@ -8094,15 +8168,15 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(and
 		(nil? (qassoc_get (gs_facts stage) (quote btw2025_parent) nil))
 		(and
-		(not (contains? consumed_probe_ids (gs_id stage)))
-		(and (not (contains? consumed_source_probe_ids (gs_id stage)))
-			(and
-				(not (scalar_first_inline_only_stage? stage))
+			(not (contains? consumed_probe_ids (gs_id stage)))
+			(and (not (contains? consumed_source_probe_ids (gs_id stage)))
 				(and
-					(not (scalar_first_probe_stage? stage))
-					(or
-						(not (scalar_aggregate_probe_stage? stage))
-						(contains? stage_output_ids (gs_id stage))))))))))
+					(not (scalar_first_inline_only_stage? stage))
+					(and
+						(not (scalar_first_probe_stage? stage))
+						(or
+							(not (scalar_aggregate_probe_stage? stage))
+							(contains? stage_output_ids (gs_id stage))))))))))
 
 (define query_block_stages_to_prepare_base_using (lambda (all_stages block)
 	(begin

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -263,12 +263,31 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (gs_id (stage_for_carrier_source prepared_lowering_catalog outer_catalog_carrier_source))
 		"outer-catalog-stage")
 		true "indexed physical catalog resolves carrier sources")
+	(define local_catalog_stage (make_group_stage
+		"local-catalog-stage"
+		(list "local" "memcp-tests" "local_source" false nil)
+		'() '(1) '() nil '() '() nil nil '()))
+	(define child_lowering_catalog
+		(lowering_catalog_with_local_stages prepared_lowering_catalog (list local_catalog_stage)))
+	(assert (lowering_catalog? child_lowering_catalog) true
+		"local physical stages create a child lowering catalog")
+	(assert (equal? (gs_id (stage_by_id child_lowering_catalog "local-catalog-stage")) "local-catalog-stage") true
+		"child lowering catalog resolves local stages")
+	(assert (equal? (gs_id (stage_by_id child_lowering_catalog "nested-catalog-stage")) "nested-catalog-stage") true
+		"child lowering catalog inherits root stage lookup")
+	(assert (count (lowering_catalog_stages child_lowering_catalog)) (+ (count indexed_catalog_stages) 1)
+		"child lowering catalog exposes local and inherited stages without changing the root")
 	(assert (equal?
 		(stage_dependency_graph indexed_catalog_stages)
 		(stage_dependency_graph prepared_lowering_catalog))
 		true "indexed physical catalog preserves the dependency graph")
 	(assert (count (qassoc_get (gs_facts (car (qb_stages prepared_catalog_root))) (quote stage_catalog) '())) 2
-		"direct physical stages share the complete prepared catalog")
+		"small physical stages retain the cache-friendly catalog list")
+	(define indexed_catalog_stage (group_stage_with_lowering_catalog outer_catalog_stage prepared_lowering_catalog))
+	(assert (empty_list? (qassoc_get (gs_facts indexed_catalog_stage) (quote stage_catalog) '())) true
+		"indexed physical stages do not copy the complete prepared catalog into their facts")
+	(assert (lowering_catalog? (qassoc_get (gs_facts indexed_catalog_stage) (quote lowering_catalog) nil)) true
+		"indexed physical stages retain only the lowering catalog handle")
 	(define btw_outer_sources (list (list "o" "memcp-tests" "outer_t" false nil)))
 	(define btw_inner_sources (list (list "i" "memcp-tests" "inner_t" false nil)))
 	(define btw_outer_id (list 'get_column "o" false "id" false))


### PR DESCRIPTION
## Summary

- extend wide physical lowering catalogs with immutable parent links and small local stage deltas
- keep list catalogs as lists across the existing 24-stage crossover instead of promoting them after a local extension
- store one indexed root handle in physical stage facts instead of the complete sibling-stage list
- resolve stage IDs and carrier identities locally first, then through the parent without copying the root FastDict
- preserve the list representation and legacy metadata fallback for small catalogs
- avoid rebuilding and deduplicating the complete root list in repeated block rewrites and nested recipe emission

This is the stage/catalog portion of AP14b. Scoped source-alias child bindings and the remaining compatibility materializations stay separate because the measured overall gain here is modest.

## A/B method

- base: `57c2880c7` (`master` after #331)
- same production-derived, anonymized fixture copied for both binaries
- `GOMAXPROCS=4`; both servers pinned to the same four cores and the client pinned separately
- randomized paired A/B order
- width matrix: 3 warmups plus 15 samples for 1/2/4/8/12 independent stages
- depth matrix: 3 warmups plus 15 samples for 1/2/4/8/12/16/24/32 nested scalar stages
- full prefix cascade: 2 warmups plus 15 accepted paired samples for every prefix
- predeclared load filter: reject the complete pair if either compile exceeds 2.5 s; no pair was rejected in the final run
- percentage values are medians of paired deltas, not deltas between independent medians

## Independent-stage matrix

| Stages | Compile A | Compile B | Compile delta | Prepare | Emit | Lower | Plan bytes |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 24.78 ms | 23.45 ms | -0.47% | -2.66% | -3.34% | -2.95% | 9123 / 9123 |
| 2 | 41.76 ms | 42.73 ms | -0.68% | +0.83% | +3.14% | +4.33% | 18493 / 18493 |
| 4 | 87.98 ms | 89.67 ms | +1.88% | -1.17% | +6.73% | +0.04% | 37199 / 37199 |
| 8 | 214.14 ms | 220.29 ms | -1.36% | +5.82% | -2.30% | -2.01% | 75427 / 75427 |
| 12 | 362.78 ms | 329.15 ms | -8.99% | +5.41% | -10.94% | -10.64% | 114788 / 114788 |

Small cases remain around noise. The intended wide case removes about 9% total compile time and 11% recipe-emission/lowering time.

## Depth matrix

| Depth | Compile delta | Prepare | Emit | Lower | Plan bytes |
|---:|---:|---:|---:|---:|---:|
| 1 | -2.48% | -1.75% | -2.60% | -2.34% | 2143 / 2143 |
| 2 | -9.72% | -1.16% | -11.25% | -9.18% | 6024 / 6024 |
| 4 | +1.79% | -2.77% | -5.21% | -5.08% | 14461 / 14461 |
| 8 | +0.77% | -0.72% | +5.18% | +5.02% | 34035 / 34035 |
| 12 | -1.19% | -5.02% | +3.22% | +3.16% | 57217 / 57217 |
| 16 | -2.48% | -0.90% | +0.40% | +1.71% | 84003 / 84003 |
| 24 | -1.62% | -4.82% | -5.23% | -5.18% | 148375 / 148375 |
| 32 | -0.99% | +2.24% | -4.83% | -4.01% | 227147 / 227147 |

## Full prefix cascade

| Prefix | Compile A | Compile B | Paired delta (95% bootstrap CI) | Prepare A/B | Emit A/B | Lower A/B | Plan bytes |
|:---|---:|---:|---:|---:|---:|---:|---:|
| C | 1851.6 ms | 1807.4 ms | -1.03% [-4.04, +0.57] | 12.8 / 13.7 ms | 1289.1 / 1257.3 ms | 1309.6 / 1270.5 ms | 73953 / 73953 |
| Ca | 1834.4 ms | 1848.0 ms | +1.64% [-2.26, +2.49] | 13.4 / 13.3 ms | 1263.5 / 1266.5 ms | 1278.5 / 1279.5 ms | 73995 / 73995 |
| Car | 1831.8 ms | 1839.4 ms | +0.73% [-1.73, +2.91] | 13.0 / 13.3 ms | 1269.4 / 1257.4 ms | 1283.3 / 1270.7 ms | 73997 / 73997 |
| Carg | 1897.4 ms | 1841.4 ms | -1.47% [-5.03, +0.38] | 12.6 / 13.7 ms | 1316.4 / 1264.1 ms | 1329.0 / 1277.5 ms | 73999 / 73999 |
| Cargl | 1842.6 ms | 1821.2 ms | -1.57% [-4.96, -0.50] | 14.3 / 13.4 ms | 1282.5 / 1278.4 ms | 1296.4 / 1291.4 ms | 74001 / 74001 |
| Cargla | 1850.5 ms | 1817.1 ms | -2.07% [-4.33, +2.36] | 13.1 / 13.8 ms | 1276.8 / 1248.9 ms | 1294.6 / 1264.5 ms | 74003 / 74003 |
| Carglas | 1835.9 ms | 1802.8 ms | -0.03% [-2.29, +1.79] | 13.3 / 14.1 ms | 1271.1 / 1238.8 ms | 1284.8 / 1254.6 ms | 74005 / 74005 |
| Carglass | 1865.5 ms | 1800.8 ms | -1.40% [-3.54, +0.84] | 13.0 / 13.2 ms | 1294.0 / 1281.3 ms | 1309.6 / 1294.5 ms | 74007 / 74007 |
| CarglassXXX | 1826.8 ms | 1839.0 ms | +0.43% [-1.50, +1.68] | 12.6 / 14.7 ms | 1255.4 / 1289.0 ms | 1270.8 / 1303.3 ms | 74013 / 74013 |

The full cascade is neutral to modestly faster rather than a large overall win. All positive deltas have confidence intervals crossing zero. The value of this change is therefore the wide-query improvement plus removing copied catalog state before later DAG/emitter work, not a claimed step-change for the representative query by itself.

All nine byte-exact `EXPLAIN` responses match between A and B: 116737 response bytes, SHA-256 `6526a43205d13616da9f34b5b1c15a43a7cc58bde92722dfae01afcdb8966c6d`.

## Validation

- Scheme startup tests: 842/842
- `tests/66_derived_table_exists_flatten.yaml`: 3/3
- `tests/66_prejoin_scalar_subselect.yaml`: 5/5
- `tests/66_nested_subselect_column_as_table.yaml`: 8/8
- `tests/72_psql_parser.yaml`: 38/38
- `tests/73_window_functions.yaml`: 38/38 isolated
- `tests/74_csv_json_import.yaml`: 36/36 isolated
- normal-build `tests/14_order_limit.yaml`: 19/19 on both branch and master, 1.920 s vs 1.934 s suite time
- serial full `make test`: all functional assertions and 100% Scheme coverage passed; only the unchanged hard 5 s ORDER BY timing gate failed under the coverage-instrumented binary on the loaded host
- Scheme formatter executed; `--check` retains the pre-existing unmatched-depth warnings on current master
- `git diff --check`: clean

AP14c remains scoped source-alias child bindings and removal of compatibility materialization for list-valued ownership consumers. Given the small full-cascade delta here, AP15 dependency-DAG work may now be the higher-priority follow-up.
