### PR TITLE
Support TPC-H Q13 parser syntax

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -172,9 +172,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser '((define a psql_expression3) "<" (define b psql_expression2)) '((quote <) a b))
 		(parser '((define a psql_expression3) ">" (define b psql_expression2)) '((quote >) a b))
 		/* ILIKE is Postgres case-insensitive LIKE. */
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "ILIKE" true) (define b psql_expression2)) '('not '('strlike a b "utf8mb4_general_ci")))
 		(parser '((define a psql_expression3) (atom "ILIKE" true) (define b psql_expression2)) '('strlike a b "utf8mb4_general_ci"))
 		(parser '((define a psql_expression3) (atom "COLLATE" true) (define collation psql_identifier) (atom "LIKE" true) (define b psql_expression2)) '('strlike_cs a b collation))
 		/* Postgres LIKE is case-sensitive by default. */
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "LIKE" true) (define b psql_expression2)) '('not '('strlike_cs a b)))
 		(parser '((define a psql_expression3) (atom "LIKE" true) (define b psql_expression2)) '('strlike_cs a b))
 		/* REGEXP/RLIKE/~ operator: expr ~ 'pattern' -> regexp_test(expr, pattern) */
 		(parser '((define a psql_expression3) "~" (define b psql_expression2)) '('regexp_test a b))
@@ -332,6 +334,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		psql_expression7
 	)))
 
+	/* A derived-table column alias list renames the visible output columns from
+	left to right. PostgreSQL permits a prefix list; specifying more aliases than
+	the query exposes is an error. Keep this transform in the parser so the
+	planner receives the usual neutral query-block/union-block shapes. */
+	(define psql_rename_derived_fields (lambda (fields aliases) (match aliases
+		(cons alias remaining_aliases) (match fields
+			(cons _title (cons expr remaining_fields))
+			(cons alias (cons expr (psql_rename_derived_fields remaining_fields remaining_aliases)))
+			_ (error "derived table has more column aliases than columns"))
+		_ fields
+	)))
+	(define psql_apply_derived_column_aliases (lambda (query aliases) (match query
+		((symbol query-block) schema2 tables fields condition group having order limit offset hidden stages facts)
+		(list (quote query-block) schema2 tables
+			(psql_rename_derived_fields fields aliases)
+			condition group having order limit offset hidden stages facts)
+		((symbol union-block) mode branches order limit offset facts)
+		(list (quote union-block) mode
+			(map branches (lambda (branch) (psql_apply_derived_column_aliases branch aliases)))
+			order limit offset facts)
+		_ (error "derived table column aliases require a SELECT query")
+	)))
+
 	(define tabledefs (parser (or
 		/* TODO: left [outer] join, right [outer] join recursive buildup */
 		(parser '((define l tabledefs) (define x (or
@@ -343,6 +368,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser (define t tabledef) '(t))
 	)))
 	(define tabledef (parser (or
+		(parser '((atom "(" true) (define query psql_select) (atom ")" true) (atom "AS" true) (define id psql_identifier) "(" (define aliases (+ psql_identifier ",")) ")")
+			(list id schema (psql_apply_derived_column_aliases query aliases) false nil)) /* inner select with relation and column aliases */
+		(parser '((atom "(" true) (define query psql_select) (atom ")" true) (define id psql_identifier) "(" (define aliases (+ psql_identifier ",")) ")")
+			(list id schema (psql_apply_derived_column_aliases query aliases) false nil)) /* AS is optional */
 		(parser '((atom "(" true) (define query psql_select) (atom ")" true) (atom "AS" true) (define id psql_identifier)) '(id schema query false nil)) /* inner select as from */
 		(parser '((atom "(" true) (define query psql_select) (atom ")" true) (define id psql_identifier)) '(id schema query false nil)) /* inner select as from */
 		/* TODO: case insensititive table search */

--- a/tests/72_psql_parser.yaml
+++ b/tests/72_psql_parser.yaml
@@ -82,6 +82,73 @@ test_cases:
         - id: 3
           val: 50
 
+  - name: "NOT LIKE is case-sensitive"
+    sql: "SELECT id FROM psql_data WHERE name NOT LIKE '%li%' ORDER BY id"
+    expect:
+      rows: 1
+      data:
+        - id: 2
+
+  - name: "NOT ILIKE is case-insensitive"
+    sql: "SELECT id FROM psql_data WHERE name NOT ILIKE '%ALICE%' ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - id: 2
+        - id: 3
+
+  # === Derived-table column alias lists ===
+  - name: "Derived table exposes explicit column aliases"
+    sql: |
+      SELECT derived.renamed_id, derived.renamed_value
+      FROM (SELECT id, val FROM psql_data) AS derived(renamed_id, renamed_value)
+      ORDER BY derived.renamed_id
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - renamed_id: 1
+          renamed_value: 10
+        - renamed_id: 2
+          renamed_value: 30
+
+  - name: "Derived table accepts a prefix column alias list"
+    sql: |
+      SELECT derived.renamed_id, derived.val
+      FROM (SELECT id, val FROM psql_data) derived(renamed_id)
+      ORDER BY derived.renamed_id
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - renamed_id: 1
+          val: 10
+
+  - name: "TPC-H Q13-shaped derived aggregate column aliases"
+    sql: |
+      SELECT c_count, COUNT(*) AS custdist
+      FROM (
+        SELECT customer.name, COUNT(orders.id)
+        FROM psql_data customer
+        LEFT OUTER JOIN psql_data orders ON customer.name = orders.name
+          AND orders.name NOT LIKE '%special%packages%'
+        GROUP BY customer.name
+      ) AS c_orders(customer_name, c_count)
+      GROUP BY c_count
+      ORDER BY c_count
+    expect:
+      rows: 2
+      data:
+        - c_count: 1
+          custdist: 2
+        - c_count: 4
+          custdist: 1
+
+  - name: "Derived table rejects excess column aliases"
+    sql: "SELECT * FROM (SELECT id FROM psql_data) AS derived(one, two)"
+    expect:
+      error: true
+
   - name: "TPC-H Q6 decimal range semantics across scan batches"
     sql: |
       SELECT SUM(extended_price * discount) AS revenue


### PR DESCRIPTION
## What changed

- add PostgreSQL `NOT LIKE` and `NOT ILIKE`
- support derived-table output column alias lists, with and without `AS`
- preserve PostgreSQL prefix-alias semantics and reject excess aliases explicitly
- add parser and execution regressions, including a small independently authored Q13-shaped query

## Why

TPC-H Q13 previously stopped in the PostgreSQL parser because it uses both `NOT LIKE` and a derived-table column alias list. The parser now produces the existing neutral logical AST for those constructs, so the complete locally generated official Q13 reaches query compilation.

This remains inside the parser/neutral-AST boundary and introduces no physical planner artifacts or fallback paths.

## Validation

- `tests/72_psql_parser.yaml`: 44/44 passed
- exact locally generated official Q13: EXPLAIN/compilation succeeds
- full current repository pre-commit suite: passed
- commit created through the current full hook; no test bypass

No TPC-H query text, data, generator, or helper scripts are included in this PR.