### PR TITLE
Resolve grouped join columns across sources

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3345,26 +3345,37 @@ PostgreSQL parsers should both lower to the same combined operators.
 								(define joined_expr_ctx (make_uctx child_ctx (list
 									(list (quote outer-sources) joined_expr_outer_sources)
 									(list (quote local-sources) (merge_unique (list untangled_sources source_join_stage_sources))))))
+								(define local_resolution_sources (merge_unique (list untangled_sources source_join_stage_sources)))
+								(define qualify_join_expr (lambda (expr)
+									(if (single_source? local_resolution_sources)
+										expr
+										(qualify_unqualified_column_for_sources local_resolution_sources expr))))
 								(define rewritten_where (qualify_unqualified_column_for_sources
-									(merge_unique (list untangled_sources source_join_stage_sources))
+									local_resolution_sources
 									(combine_where_terms source_where_terms (rewrite_derived_ref_chain rewrites (qb_where block)))))
 								(if (expr_contains_window? rewritten_where)
 									(neumann_fail "untangle_query" "window function is not allowed in WHERE")
 									true)
 								(define where_result (untangle_where_with_stages rewritten_where joined_expr_outer_sources joined_expr_ctx))
-								(define field_result (untangle_fields_with_stages (rewrite_derived_fields_chain rewrites (qb_fields block)) joined_expr_outer_sources joined_expr_ctx))
-								(define having_result (untangle_expr_with_stages (rewrite_derived_ref_chain rewrites (qb_having block)) joined_expr_outer_sources joined_expr_ctx))
+								(define field_result (untangle_fields_with_stages
+									(qualify_join_expr (rewrite_derived_fields_chain rewrites (qb_fields block)))
+									joined_expr_outer_sources joined_expr_ctx))
+								(define having_result (untangle_expr_with_stages
+									(qualify_join_expr (rewrite_derived_ref_chain rewrites (qb_having block)))
+									joined_expr_outer_sources joined_expr_ctx))
 								(define stage_sources (merge_unique (list (nth where_result 2) (nth field_result 2) (nth having_result 2))))
 								(define group_result (untangle_expr_list_with_stages
-									(qualify_unqualified_column_for_sources (merge_unique (list untangled_sources source_join_stage_sources))
+									(qualify_unqualified_column_for_sources local_resolution_sources
 										(map (coalesceNil (qb_group block) '()) (lambda (item) (rewrite_derived_ref_chain rewrites item))))
 									joined_expr_outer_sources
 									joined_expr_ctx))
 								(define order_result (untangle_order_with_stages
-									(rewrite_derived_order_chain rewrites (qb_order block))
+									(qualify_join_expr (rewrite_derived_order_chain rewrites (qb_order block)))
 									joined_expr_outer_sources
 									joined_expr_ctx))
-								(define hidden_result (untangle_fields_with_stages (rewrite_derived_fields_chain rewrites (qb_hidden block)) joined_expr_outer_sources joined_expr_ctx))
+								(define hidden_result (untangle_fields_with_stages
+									(qualify_join_expr (rewrite_derived_fields_chain rewrites (qb_hidden block)))
+									joined_expr_outer_sources joined_expr_ctx))
 								(define delayed_block (make_query_block
 									(qb_schema block)
 									(merge_unique (list untangled_sources source_join_stage_sources stage_sources (nth group_result 2) (nth order_result 2) (nth hidden_result 2)))

--- a/tests/09_joins.yaml
+++ b/tests/09_joins.yaml
@@ -57,6 +57,31 @@ test_cases:
         - { name: "another", matching_rows: 1 }
         - { name: "test", matching_rows: 1 }
 
+  - name: "Unqualified GROUP BY keys resolve to their non-driver sources"
+    sql: |
+      SELECT simple_test_id, name, SUM(r.id) AS id_sum
+      FROM simple_test_09 s
+      JOIN related_data_09 r ON s.id = r.simple_test_id
+      GROUP BY simple_test_id, name
+      ORDER BY simple_test_id
+    expect:
+      rows: 2
+      data:
+        - { simple_test_id: 1, name: "test", id_sum: 101 }
+        - { simple_test_id: 2, name: "another", id_sum: 102 }
+
+  - name: "Unqualified non-driver GROUP BY key remains available to HAVING"
+    sql: |
+      SELECT simple_test_id, COUNT(*) AS matching_rows
+      FROM simple_test_09 s
+      JOIN related_data_09 r ON s.id = r.simple_test_id
+      GROUP BY simple_test_id
+      HAVING simple_test_id >= 2
+      ORDER BY simple_test_id
+    expect:
+      rows: 1
+      data:
+        - { simple_test_id: 2, matching_rows: 1 }
 
 #  - name: "Complex SELECT JOIN test with filtering"
 #    sql: "SELECT s.name, r.description FROM simple_test s JOIN related_data r ON s.id = r.simple_test_id WHERE s.id IN (1, 2) AND r.description LIKE '%description%'"

--- a/tests/72_psql_parser.yaml
+++ b/tests/72_psql_parser.yaml
@@ -14,6 +14,8 @@ metadata:
 
 setup:
   - sql: "DROP VIEW IF EXISTS psql_data_view"
+  - sql: "DROP TABLE IF EXISTS psql_group_item"
+  - sql: "DROP TABLE IF EXISTS psql_group_owner"
   - sql: "DROP TABLE IF EXISTS psql_data"
   - sql: "DROP TABLE IF EXISTS psql_decimal_range"
   - sql: |
@@ -25,6 +27,10 @@ setup:
   - sql: |
       INSERT INTO psql_data (id, name, val) VALUES
       (1, 'Alice', 10), (2, 'Bob', 30), (3, 'Charlie', 50), (4, 'Alice', 20)
+  - sql: "CREATE TABLE psql_group_owner (id INT PRIMARY KEY, owner_name VARCHAR(50))"
+  - sql: "CREATE TABLE psql_group_item (id INT PRIMARY KEY, owner_id INT, amount INT)"
+  - sql: "INSERT INTO psql_group_owner VALUES (1, 'Alice'), (2, 'Bob')"
+  - sql: "INSERT INTO psql_group_item VALUES (10, 1, 4), (11, 1, 6), (12, 2, 7)"
   - sql: |
       CREATE TABLE psql_decimal_range (
         id INT, extended_price DECIMAL(15,2), discount DECIMAL(15,2),
@@ -431,6 +437,19 @@ test_cases:
         - id: 2
           name: "Bob"
 
+  - name: "PostgreSQL grouped join resolves unqualified keys from every source"
+    sql: |
+      SELECT owner_id, owner_name, SUM(amount) AS total
+      FROM psql_group_owner o
+      JOIN psql_group_item i ON o.id = i.owner_id
+      GROUP BY owner_id, owner_name
+      ORDER BY owner_id
+    expect:
+      rows: 2
+      data:
+        - { owner_id: 1, owner_name: "Alice", total: 10 }
+        - { owner_id: 2, owner_name: "Bob", total: 7 }
+
   - name: "PostgreSQL CREATE VIEW stores and expands parser IR"
     sql: |
       CREATE VIEW psql_data_view (view_id, view_name)
@@ -453,5 +472,7 @@ test_cases:
 
 cleanup:
   - sql: "DROP VIEW IF EXISTS psql_data_view"
+  - sql: "DROP TABLE IF EXISTS psql_group_item"
+  - sql: "DROP TABLE IF EXISTS psql_group_owner"
   - sql: "DROP TABLE IF EXISTS psql_decimal_range"
   - sql: "DROP TABLE IF EXISTS psql_data"


### PR DESCRIPTION
## What changed

- Resolve unqualified projection, `HAVING`, `ORDER BY`, and hidden expressions against every local join source during logical untangling.
- Keep the single-source path unchanged to avoid adding work or larger qualified expressions where source resolution is unambiguous.
- Add MySQL and PostgreSQL integration coverage for GROUP BY keys owned by non-driver join sources, including HAVING.

## Root cause

Only `WHERE` and `GROUP BY` expressions were source-qualified consistently. Unqualified grouped columns in projections and HAVING could therefore survive into physical lowering, where they were incorrectly attached to the first FROM source.

## Impact

The local TPC-H compile matrix improves from 11/22 to 19/22 queries. The remaining independent blockers are interval precision parsing (Q1), leading-dot decimal parsing (Q6), and grouped IN decorrelation (Q18).

No TPC-H queries, data, or helper scripts are included in this branch.

## Validation

- Full repository pre-commit suite passed with the current hook; no tests were skipped or disabled.
- `tests/09_joins.yaml`: 6/6
- `tests/66_campaign_state_group_regression.yaml`: 2/2
- `tests/72_psql_parser.yaml`: 48/48
- Scheme startup unit tests: 845/845
- Scheme formatter completed; only its known pre-existing parenthesis-depth warnings remain.