### PR TITLE
Track scan candidates without logging indexed point probes

### DIFF
--- a/storage/scan.go
+++ b/storage/scan.go
@@ -250,10 +250,11 @@ func optimizeScanBatch(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 
 // scanResult bundles per-shard outputs to minimize allocations and type assertions.
 type scanResult struct {
-	res        scm.Scmer
-	outCount   int64
-	inputCount int64
-	err        scanError // err.r != nil indicates an error
+	res            scm.Scmer
+	outCount       int64
+	inputCount     int64
+	candidateCount int64
+	err            scanError // err.r != nil indicates an error
 }
 
 func (t *table) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
@@ -369,6 +370,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	execStart := time.Now()
 	var outCount int64
 	var inputCount int64
+	var candidateCount int64
 	values := make(chan scanResult, 4)
 	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
 		defer func() {
@@ -381,8 +383,8 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 		if ss != nil && ss.IsKilled() {
 			panic("query killed")
 		}
-		res, cnt := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
-		values <- scanResult{res: res, outCount: cnt, inputCount: int64(s.Count())}
+		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
+		values <- scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount}
 	})
 	if done == nil {
 		close(values)
@@ -409,6 +411,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				continue
 			}
 			inputCount += msg.inputCount
+			candidateCount += msg.candidateCount
 			outCount += msg.outCount
 			if msg.outCount > 0 {
 				akkumulator = fn(akkumulator, msg.res)
@@ -432,6 +435,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				continue
 			}
 			inputCount += msg.inputCount
+			candidateCount += msg.candidateCount
 			outCount += msg.outCount
 			if msg.outCount > 0 {
 				akkumulator = fn(akkumulator, msg.res)
@@ -454,6 +458,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				continue
 			}
 			inputCount += msg.inputCount
+			candidateCount += msg.candidateCount
 			outCount += msg.outCount
 			hadValue = hadValue || msg.outCount > 0
 		}
@@ -467,7 +472,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	}
 	// log statistics (best-effort, async so it doesn't add latency)
 	execNs := time.Since(execStart).Nanoseconds()
-	if Settings.ScanDebugging || inputCount > int64(Settings.AnalyzeMinItems) {
+	if Settings.ScanDebugging || candidateCount > int64(Settings.AnalyzeMinItems) {
 		go func(anNs, exNs int64) {
 			defer func() { _ = recover() }()
 			filterEnc := ""
@@ -481,7 +486,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
 			}
 			indexColsEnc := boundaryIndexCols(boundaries)
-			safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", indexColsEnc, inputCount, outCount, anNs, exNs)
+			safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", indexColsEnc, inputCount, candidateCount, outCount, anNs, exNs)
 		}(analyzeNs, execNs)
 	}
 	return akkumulator
@@ -608,12 +613,13 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	return found
 }
 
-func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64) {
+func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64, int64) {
 	if stride > 0 {
 		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
 	}
 	akkumulator := neutral
 	var outCount int64
+	var candidateCount int64
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -666,7 +672,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	if recsetFilter != nil {
 		recsetPart = recsetFilter.shardEntry(t)
 		if recsetPart == nil || recsetPart.count == 0 {
-			return neutral, 0
+			return neutral, 0, 0
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
@@ -734,6 +740,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	hadValue := false
 
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		candidateCount += int64(len(batch))
 		// filter in-place: overwrite batch with passing IDs
 		outN := 0
 		for _, idx := range batch {
@@ -833,7 +840,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 			locked = false
 		}
 		mapper.FlushSideEffects()
-		return scm.NewNil(), outCount
+		return scm.NewNil(), outCount, candidateCount
 	}
 	if hasMutationCallback && len(pendingRecids) > 0 {
 		// Release exclusive lock before map+reduce phase: mapFn may contain
@@ -867,12 +874,13 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		writeLocked = false
 	}
 	mapper.FlushSideEffects()
-	return akkumulator, outCount
+	return akkumulator, outCount, candidateCount
 }
 
-func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64) {
+func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64, int64) {
 	akkumulator := neutral
 	var outCount int64
+	var candidateCount int64
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -918,7 +926,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	if recsetFilter != nil {
 		recsetPart = recsetFilter.shardEntry(t)
 		if recsetPart == nil || recsetPart.count == 0 {
-			return neutral, 0
+			return neutral, 0, 0
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
@@ -999,6 +1007,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		}
 
 		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+			candidateCount += int64(len(batch))
 			if ss != nil && ss.IsKilled() {
 				panic("query killed")
 			}
@@ -1098,7 +1107,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	}
 	if !hadValue {
 		mapper.FlushSideEffects()
-		return scm.NewNil(), outCount
+		return scm.NewNil(), outCount, candidateCount
 	}
 	if hasMutationCallback && len(pendingRecids) > 0 {
 		if writeLocked {
@@ -1125,5 +1134,5 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		writeLocked = false
 	}
 	mapper.FlushSideEffects()
-	return akkumulator, outCount
+	return akkumulator, outCount, candidateCount
 }

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -215,6 +215,7 @@ func ensureSystemStatistic() {
 		{"order", "TEXT"},
 		{"index_cols", "TEXT"},
 		{"inputCount", "INT"},
+		{"candidateCount", "INT"},
 		{"outputCount", "INT"},
 		// TODO: measurements are temporary; remove later (store in nanoseconds)
 		{"analyze_ns", "INT"},
@@ -237,7 +238,7 @@ func ensureSystemStatistic() {
 
 // safeLogScan writes a single row into system_statistic.scans. Failures are ignored.
 // TODO: measurements are temporary; remove later (nanoseconds)
-func safeLogScan(schema, table string, ordered bool, filter, order, indexCols string, inputCount, outputCount, analyzeNs, execNs int64) {
+func safeLogScan(schema, table string, ordered bool, filter, order, indexCols string, inputCount, candidateCount, outputCount, analyzeNs, execNs int64) {
 	defer func() { _ = recover() }()
 	db := GetDatabase("system_statistic")
 	if db == nil {
@@ -248,7 +249,7 @@ func safeLogScan(schema, table string, ordered bool, filter, order, indexCols st
 		return
 	}
 
-	cols := []string{"schema", "table", "ordered", "filter", "order", "index_cols", "inputCount", "outputCount", "analyze_ns", "exec_ns", "timestamp"}
+	cols := []string{"schema", "table", "ordered", "filter", "order", "index_cols", "inputCount", "candidateCount", "outputCount", "analyze_ns", "exec_ns", "timestamp"}
 	row := []scm.Scmer{
 		scm.NewString(schema),
 		scm.NewString(table),
@@ -257,6 +258,7 @@ func safeLogScan(schema, table string, ordered bool, filter, order, indexCols st
 		scm.NewString(order),
 		scm.NewString(indexCols),
 		scm.NewInt(inputCount),
+		scm.NewInt(candidateCount),
 		scm.NewInt(outputCount),
 		scm.NewInt(analyzeNs),
 		scm.NewInt(execNs),

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -110,23 +110,33 @@ func skipPartition(q *globalqueue, qx *shardqueue, pk []scm.Scmer, n int) {
 }
 
 type shardqueue struct {
-	shard        *storageShard
-	items        []uint32 // TODO: refactor to chan, so we can block generating too much entries
-	err          scanError
-	scols        []func(uint32) scm.Scmer // sort criteria column reader
-	sortdirs     []func(...scm.Scmer) scm.Scmer
-	mapper       *ShardMapReducer
-	callbackCols []string  // per-table map columns (for multi-table merge)
-	callback     scm.Scmer // per-table map function (for multi-table merge)
-	tableIdx     int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
+	shard          *storageShard
+	items          []uint32 // TODO: refactor to chan, so we can block generating too much entries
+	candidateCount int64
+	err            scanError
+	scols          []func(uint32) scm.Scmer // sort criteria column reader
+	sortdirs       []func(...scm.Scmer) scm.Scmer
+	mapper         *ShardMapReducer
+	callbackCols   []string  // per-table map columns (for multi-table merge)
+	callback       scm.Scmer // per-table map function (for multi-table merge)
+	tableIdx       int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
 }
 
 // scanOrderResult bundles per-shard outputs for ordered scans.
 type scanOrderResult struct {
-	res        *shardqueue
-	err        scanError // err.r != nil indicates an error
-	inputCount int64
-	scanCount  int64
+	res            *shardqueue
+	err            scanError // err.r != nil indicates an error
+	inputCount     int64
+	candidateCount int64
+	outputCount    int64
+}
+
+type scanOrderStats struct {
+	boundaries     boundaries
+	inputCount     int64
+	candidateCount int64
+	outputCount    int64
+	analyzeNs      int64
 }
 
 // sort interface for shardqueue (local) (TODO: heap could be more efficient because early-out will be cheaper)
@@ -451,6 +461,7 @@ func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 // Each table has its own filter, sort columns and map function, but sort
 // directions, offset/limit, reduce and neutral are shared.
 func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+	execStart := time.Now()
 	ss := SessionStateFromTx(currentTx)
 	if ss != nil && ss.IsKilled() {
 		panic("query killed")
@@ -463,9 +474,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 	var q globalqueue
 	q_ := make(chan scanOrderResult, len(tables)*4)
-	var inputCount int64
 	var wg sync.WaitGroup
 	querySeq := scm.CurrentQuerySeq()
+	stats := make([]scanOrderStats, len(tables))
 
 	// Launch shard-parallel scans for each table
 	for ti := range tables {
@@ -509,6 +520,8 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			t.AddPartitioningScore([]string{b.col})
 		}
 		analyzeNs := time.Since(analyzeStart).Nanoseconds()
+		stats[ti].boundaries = bounds
+		stats[ti].analyzeNs = analyzeNs
 
 		// Capture closure variables
 		callbackCols := spec.callbackCols
@@ -550,7 +563,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 								res.callbackCols = callbackCols
 								res.callback = callback
 								res.tableIdx = tableIdx
-								q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
+								q_ <- scanOrderResult{res: res, inputCount: part.count, candidateCount: part.count, outputCount: int64(len(res.items))}
 							}(part)
 						}
 						return scm.NewNil()
@@ -578,7 +591,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 							res.callbackCols = callbackCols
 							res.callback = callback
 							res.tableIdx = tableIdx
-							q_ <- scanOrderResult{res: res, inputCount: part.count, scanCount: int64(len(res.items))}
+							q_ <- scanOrderResult{res: res, inputCount: part.count, candidateCount: part.count, outputCount: int64(len(res.items))}
 							return scm.NewNil()
 						})
 					}(part)
@@ -598,7 +611,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				res.callbackCols = callbackCols
 				res.callback = callback
 				res.tableIdx = tableIdx
-				q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), scanCount: int64(len(res.items))}
+				q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), candidateCount: res.candidateCount, outputCount: int64(len(res.items))}
 			})
 			if done != nil {
 				wg.Add(1)
@@ -609,37 +622,6 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			}
 		}
 
-		// Per-table logging (best-effort, async) — inputCount is 0 here (set
-		// after merge), so this fires only when ScanDebugging is enabled.
-		if Settings.ScanDebugging {
-			go func(tbl *table, cCols []string, cond scm.Scmer, scols []scm.Scmer, bnds boundaries, anNs int64) {
-				defer func() { _ = recover() }()
-				filterEnc := ""
-				if proc, ok := cond.Any().(scm.Proc); ok {
-					var params []scm.Scmer
-					if proc.Params.IsSlice() {
-						params = proc.Params.Slice()
-					} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
-						params = arr
-					}
-					filterEnc = encodeScmerToString(proc.Body, cCols, params)
-				}
-				var sb strings.Builder
-				for i, sc := range scols {
-					if i > 0 {
-						sb.WriteByte('|')
-					}
-					if sc.IsString() {
-						sb.WriteString(sc.String())
-					} else {
-						encodeScmer(sc, &sb, nil, nil)
-					}
-				}
-				orderEnc := sb.String()
-				indexColsEnc := boundaryIndexCols(bnds)
-				safeLogScan(tbl.schema.Name, tbl.Name, true, filterEnc, orderEnc, indexColsEnc, 0, 0, anNs, 0)
-			}(t, conditionCols, condition, sortcols, tableBounds, analyzeNs)
-		}
 	}
 
 	// Close result channel when all tables' shard scans complete
@@ -663,7 +645,12 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		if msg.res != nil && len(msg.res.items) > 0 {
 			heap.Push(&q, msg.res)
 		}
-		inputCount += msg.inputCount
+		if msg.res != nil && msg.res.tableIdx >= 0 && msg.res.tableIdx < len(stats) {
+			tableStats := &stats[msg.res.tableIdx]
+			tableStats.inputCount += msg.inputCount
+			tableStats.candidateCount += msg.candidateCount
+			tableStats.outputCount += msg.outputCount
+		}
 	}
 	if scanErr.r != nil {
 		panic(scanErr)
@@ -820,6 +807,39 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		aggregateFn := scm.OptimizeProcToSerialFunction(aggregate)
 		nullRow := buildOuterNullCallbackRow(cbCols)
 		akkumulator = aggregateFn(akkumulator, callbackFn(nullRow...))
+	}
+	execNs := time.Since(execStart).Nanoseconds()
+	for i := range tables {
+		tableStats := stats[i]
+		if !Settings.ScanDebugging && tableStats.candidateCount <= int64(Settings.AnalyzeMinItems) {
+			continue
+		}
+		spec := &tables[i]
+		tbl := spec.carrierTable()
+		filterEnc := ""
+		if proc, ok := spec.condition.Any().(scm.Proc); ok {
+			var params []scm.Scmer
+			if proc.Params.IsSlice() {
+				params = proc.Params.Slice()
+			} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
+				params = arr
+			}
+			filterEnc = encodeScmerToString(proc.Body, spec.conditionCols, params)
+		}
+		var sb strings.Builder
+		for j, sortcol := range spec.sortcols {
+			if j > 0 {
+				sb.WriteByte('|')
+			}
+			if sortcol.IsString() {
+				sb.WriteString(sortcol.String())
+			} else {
+				encodeScmer(sortcol, &sb, nil, nil)
+			}
+		}
+		orderEnc := sb.String()
+		indexColsEnc := boundaryIndexCols(tableStats.boundaries)
+		go safeLogScan(tbl.schema.Name, tbl.Name, true, filterEnc, orderEnc, indexColsEnc, tableStats.inputCount, tableStats.candidateCount, tableStats.outputCount, tableStats.analyzeNs, execNs)
 	}
 	return akkumulator
 }
@@ -1074,6 +1094,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		result.items = make([]uint32, resultCap)
 		resultN := 0
 		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+			result.candidateCount += int64(len(batch))
 			// filter in-place: overwrite batch with passing IDs
 			outN := 0
 			for _, idx := range batch {

--- a/tests/56_multishard.yaml
+++ b/tests/56_multishard.yaml
@@ -87,6 +87,15 @@ test_cases:
       data:
         - cnt: 10
 
+  - repeat: 20
+    tests:
+      - name: "Selective COUNT keeps nonempty shard result"
+        sql: "SELECT COUNT(*) AS cnt FROM ms_data WHERE val BETWEEN 30000 AND 30009"
+        expect:
+          rows: 1
+          data:
+            - cnt: 10
+
   - name: "MIN/MAX across shards"
     sql: "SELECT MIN(val) AS lo, MAX(val) AS hi FROM ms_data"
     expect:

--- a/tests/76_range_scan_coverage.yaml
+++ b/tests/76_range_scan_coverage.yaml
@@ -37,6 +37,54 @@ test_cases:
         (insert (table "memcp-tests" "rs_data") '("id" "val" "category" "price") rows)
         200)
 
+  - name: "Clear range scan statistics"
+    setup:
+      - scm: '(settings "ScanDebugging" false)'
+      - sql: "SELECT val FROM rs_data WHERE id = 42"
+      - scm: '(sleep 0.1)'
+    sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data'"
+    expect:
+      affected_rows: 1
+
+  - name: "Point scan stays below automatic logging threshold"
+    setup:
+      - sql: "SELECT val FROM rs_data WHERE id = 42"
+      - scm: '(sleep 0.1)'
+    sql: "SELECT COUNT(*) AS cnt FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data'"
+    expect:
+      rows: 1
+      data:
+        - cnt: 0
+
+  - name: "Scan debugging still records point probes"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "SELECT val FROM rs_data WHERE id = 42"
+      - scm: '(sleep 0.1)'
+    sql: "SELECT inputCount, candidateCount, outputCount FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data' AND index_cols = 'id' ORDER BY timestamp DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - inputCount: 200
+          candidateCount: 1
+          outputCount: 1
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
+  - name: "Ordered scan logs relation, candidate, and output counts"
+    setup:
+      - scm: '(settings "ScanDebugging" false)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data'"
+      - sql: "SELECT id FROM rs_data ORDER BY price LIMIT 5"
+      - scm: '(sleep 0.1)'
+    sql: "SELECT inputCount, candidateCount, outputCount FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data' AND ordered = TRUE ORDER BY timestamp DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - inputCount: 200
+          candidateCount: 200
+          outputCount: 5
+
   # ========================================================================
   # 2. Range scans with various operators (exercises index boundary code)
   # ========================================================================


### PR DESCRIPTION
## Summary
- preserve `inputCount` as the cardinality of the selected input relation
- add `candidateCount` for rows emitted by `iterateIndex`, before residual filtering
- retain `outputCount` for rows surviving the residual filter
- gate automatic statistics on `candidateCount`; explicit `ScanDebugging` still records every scan
- apply the same counters and automatic logging semantics to unordered, batched, RecSet, and ordered scans
- add selective multi-shard aggregation and scan-statistics regressions

No semantic PRIMARY/UNIQUE shortcut is used. A cold equality probe that examines a large relation remains visible so the analyzer can build an index; warmed point probes no longer generate automatic statistic rows.

## A/B measurement
Fresh 200-row table, warm runs, ScanDebugging disabled; five batches of 2,000 primary-key probes each:

| Revision | Mean batch time | Statistic rows per batch |
|---|---:|---:|
| master | 744.6 ms | 2,000 |
| PR | 736.2 ms | 0 |
| delta | -1.1% | -100% |

The latency delta is intentionally reported as small; the material improvement is removing one asynchronous statistic insert/rebuild chain per warmed point probe.

## Persisted multi-shard validation
The first revision exposed a shared-counter bug under a 48-shard persisted dataset. The counters are now shard-local and a selective multi-shard query is repeated 20 times in the regression suite. On a filesystem copy of the persisted dataset:

| Query | master | PR |
|---|---:|---:|
| large relation count | 855,496 | 855,496 |
| permission relation count | 342 | 342 |

## Validation
- `tests/56_multishard.yaml`: 56/56 passed
- `tests/76_range_scan_coverage.yaml`: 68/68 passed
- `tests/91_fulltext_like_index.yaml`: 63/63 passed
- serial full suite: all functional assertions passed; one unrelated ORDER BY timing gate exceeded 5 s under suite load
- isolated `tests/14_order_limit.yaml`: 19/19 passed in 2.17 s
- merged and revalidated against current master
