### PR TITLE
Canonicalize shared keytable initialization

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4415,6 +4415,27 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(ir_context_of ir)
 			(ir_return ir)))))
 
+(define group_stage_carrier_owner_key (lambda (stage)
+	(if (group_stage? stage)
+		(concat (group_stage_carrier_schema stage) "\n" (group_stage_carrier_relation stage))
+		(concat "stage\n" (logical_stage_key stage)))))
+
+(define group_stage_with_initializer_owner (lambda (stage owner)
+	(if (not (group_stage? stage))
+		stage
+		(make_group_stage
+			(gs_id stage)
+			(gs_input stage)
+			(gs_domain stage)
+			(gs_keys stage)
+			(gs_aggregates stage)
+			(gs_having stage)
+			(gs_output stage)
+			(gs_order stage)
+			(gs_limit stage)
+			(gs_offset stage)
+			(qassoc_set (gs_facts stage) (quote keytable_initializer_owner) owner)))))
+
 (define node_contains_nested_stage_input? (lambda (node)
 	(if (query_block? node)
 		(reduce (qb_stages node) (lambda (found stage)
@@ -5386,8 +5407,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(merge acc (list ag)))))
 		'())))
 
-(define group_table_name (lambda (schema tbl alias keys condition ags)
-	(concat ".grp:" tbl ":" (fnv_hash (serialize (list "neumann-clean-groups-v2" schema tbl alias keys condition ags))))))
+(define group_table_name (lambda (schema tbl alias keys condition)
+	(concat ".grp:" tbl ":" (fnv_hash (serialize (list "neumann-clean-groups-v3" schema tbl alias keys condition))))))
 
 (define canonical_group_stage_alias "__grp")
 
@@ -5442,15 +5463,13 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define tbl (group_stage_input_name stage))
 		(define alias (group_stage_input_alias stage))
 		(define keys (if (empty_list? (gs_keys stage)) '(1) (gs_keys stage)))
-		(define ags (gs_aggregates stage))
 		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
 		(make_group_keytable_carrier schema (group_table_name
 			schema
 			tbl
 			canonical_group_stage_alias
 			(canonicalize_group_stage_local_exprs alias keys)
-			(canonicalize_group_stage_local_expr alias condition)
-			(canonicalize_group_stage_local_exprs alias ags))))))
+			(canonicalize_group_stage_local_expr alias condition))))))
 
 (define group_stage_carrier (lambda (stage)
 	(coalesceNil
@@ -7392,24 +7411,41 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(if (group_stage? stage)
 		(begin
 			(define carrier (group_stage_carrier stage))
-			(list (quote group) (group_carrier_schema carrier) (group_carrier_relation carrier)))
+			(list
+				(quote group)
+				(group_carrier_schema carrier)
+				(group_carrier_relation carrier)
+				(map (gs_aggregates stage) aggregate_col_name)
+				(map (gs_order stage) (lambda (item) (fnv_hash (serialize item))))
+				(if (source_is_base_table? (gs_input stage))
+					nil
+					(list
+						(qassoc_get (gs_facts stage) (quote purpose) nil)
+						(qassoc_get (gs_facts stage) (quote cardinality_mode) nil)))))
 		(logical_stage_key stage))))
 
-(define lower_unique_stage_prepares_acc (lambda (stages seen prepare)
+(define lower_unique_stage_prepares_acc (lambda (stages seen initialized_carriers prepare)
 	(match (coalesceNil stages '())
 		(cons stage rest) (begin
-			/* Lower every logical owner before deduplication so stage-output IDs are
-			still resolved and validated against their original dependency scope. */
-			(define plan (prepare stage))
+			(define shared_carrier (and (group_stage? stage) (source_is_base_table? (gs_input stage))))
+			(define carrier_key (if shared_carrier (group_stage_carrier_owner_key stage) nil))
+			(define initializer_owner (or (not shared_carrier) (not (has_assoc? initialized_carriers carrier_key))))
+			(define prepared_stage (if shared_carrier
+				(group_stage_with_initializer_owner stage initializer_owner)
+				stage))
+			(define plan (prepare prepared_stage))
 			(define identity (stage_prepare_identity stage))
+			(define next_carriers (if (and shared_carrier initializer_owner)
+				(set_assoc initialized_carriers carrier_key true)
+				initialized_carriers))
 			(if (has_assoc? seen identity)
-				(lower_unique_stage_prepares_acc rest seen prepare)
+				(lower_unique_stage_prepares_acc rest seen next_carriers prepare)
 				(cons plan
-					(lower_unique_stage_prepares_acc rest (set_assoc seen identity true) prepare))))
+					(lower_unique_stage_prepares_acc rest (set_assoc seen identity true) next_carriers prepare))))
 		_ '())))
 
 (define lower_unique_stage_prepares (lambda (stages prepare)
-	(lower_unique_stage_prepares_acc stages '() prepare)))
+	(lower_unique_stage_prepares_acc stages '() '() prepare)))
 
 (define lower_unique_stage_prepares_using (lambda (all_stages lookup_stages stages)
 	(lower_unique_stage_prepares stages (lambda (stage)
@@ -7472,6 +7508,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)))
 		(define key_names (group_key_cols keys))
 		(define grouptbl (group_carrier_relation carrier))
+		(define initializer_owner (qassoc_get (gs_facts stage) (quote keytable_initializer_owner) true))
 		(define scalar_query_stage (and (query_block? src)
 			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
 				(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote single_or_error))
@@ -7525,21 +7562,29 @@ PostgreSQL parsers should both lower to the same combined operators.
 			nil
 			(cons (quote !begin) (merge (list nested_prepare nested_materialize)))))
 		(define key_columns (map key_names (lambda (col) (list (quote list) "column" col "any" (quoted_runtime_list '()) (quoted_runtime_list '())))))
-		(define agg_columns (if (or query_input_carrier scalar_order_base_stage)
-			(map ags (lambda (ag) (list (quote list) "column" (aggregate_col_name ag) "any" (quoted_runtime_list '()) (quoted_runtime_list '()))))
-			'()))
 		(define create_cols (cons (quote list)
 			(cons (cons (quote list) (cons "unique" (cons "group" (list (cons (quote list) key_names)))))
-				(merge (list key_columns agg_columns)))))
-		(define keytable_init (list (quote !begin)
-			(list (quote if)
-				(list (quote createtable) schema grouptbl create_cols (quoted_runtime_list '("engine" "sloppy")) true)
-				nil
-				nil)
-			(list (quote touch_keytable) (list (quote table) schema grouptbl))
-			(list (quote or)
-				(list (quote not) (list (quote has?) (list (quote show) schema) grouptbl))
-				(list (quote table_empty?) (list (quote table) schema grouptbl)))))
+				key_columns)))
+		(define ensure_agg_columns (if (or query_input_carrier scalar_order_base_stage)
+			(map ags (lambda (ag)
+				(list (quote createcolumn)
+					(list (quote table) schema grouptbl)
+					(aggregate_col_name ag)
+					"any"
+					(quoted_runtime_list '())
+					(quoted_runtime_list '()))))
+			'()))
+		(define keytable_init (cons (quote !begin)
+			(merge (list
+				(list
+					(list (quote if)
+						(list (quote createtable) schema grouptbl create_cols (quoted_runtime_list '("engine" "sloppy")) true)
+						nil
+						nil)
+					(list (quote touch_keytable) (list (quote table) schema grouptbl)))
+				(list (list (quote or)
+					(list (quote not) (list (quote has?) (list (quote show) schema) grouptbl))
+					(list (quote table_empty?) (list (quote table) schema grouptbl))))))))
 		(define collect_plan (if query_input_carrier
 			(if (union_block? src)
 				(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names (list aggregate_count_descriptor))
@@ -7563,39 +7608,46 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(if (direct_group_order_expr? replaced_order_expr) '() (list replaced_order_expr))))))))
 		(define computed_order_plans (map computed_order_exprs (lambda (expr)
 			(build_group_computed_order_column schema grouptbl expr))))
+		(define ensure_agg_expr (if (empty_list? ensure_agg_columns)
+			nil
+			(cons (quote !begin) ensure_agg_columns)))
 		(define aggregate_prepare_expr (cons
 			(quote !begin)
-			(merge (list agg_plans computed_order_plans))))
+			(merge (list ensure_agg_columns agg_plans computed_order_plans))))
 		(if scalar_query_stage
 			(list (quote !begin)
 				nested_prepare_expr
-				keytable_init
+				(if initializer_owner keytable_init nil)
+				ensure_agg_expr
 				(build_scalar_single_query_stage_fill_plan prepared_src grouptbl keys key_names (car lowering_ags) (cadr lowering_ags)))
 			(if query_input_carrier
 				(cons (quote !begin)
 					(merge (list
 						nested_prepare
 						nested_materialize
-						(list keytable_init)
-						(if (empty_list? ags) (list collect_plan) '())
+						(if initializer_owner (list keytable_init) '())
+						ensure_agg_columns
+						(if (and initializer_owner (empty_list? ags)) (list collect_plan) '())
 						agg_plans
 						computed_order_plans)))
 				(if scalar_order_base_stage
 					(list (quote !begin)
 						nested_prepare_expr
-						keytable_init
+						(if initializer_owner keytable_init nil)
 						aggregate_prepare_expr)
 					(list (quote !begin)
 						nested_prepare_expr
-						(if (nil? cleanup_plan)
-							(list (quote !begin)
-								keytable_init
-								collect_plan)
-							(list (quote if) keytable_init
+						(if initializer_owner
+							(if (nil? cleanup_plan)
 								(list (quote !begin)
-									collect_plan
-									cleanup_plan)
-								nil))
+									keytable_init
+									collect_plan)
+								(list (quote if) keytable_init
+									(list (quote !begin)
+										collect_plan
+										cleanup_plan)
+									nil))
+							nil)
 						aggregate_prepare_expr)))))))
 
 (define lower_orc_stage_prepare (lambda (stage)
@@ -8196,15 +8248,40 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define query_block_stages_to_prepare_base (lambda (block)
 	(query_block_stages_to_prepare_base_using (qb_stages block) block)))
 
+(define selected_group_carrier_keys (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (keys stage)
+		(if (and (group_stage? stage) (source_is_base_table? (gs_input stage)))
+			(set_assoc keys (group_stage_carrier_owner_key stage) true)
+			keys))
+		'())))
+
+(define include_shared_group_carrier_stages (lambda (block_stages selected)
+	(begin
+		(define selected_carriers (selected_group_carrier_keys selected))
+		(define selected_ids (reduce (coalesceNil selected '()) (lambda (ids stage)
+			(set_assoc ids (gs_id stage) true)) '()))
+		(if (empty_list? selected_carriers)
+			selected
+			(filter (coalesceNil block_stages '()) (lambda (stage)
+				(or
+					(has_assoc? selected_ids (gs_id stage))
+					(and
+						(group_stage? stage)
+						(and
+							(source_is_base_table? (gs_input stage))
+							(has_assoc? selected_carriers (group_stage_carrier_owner_key stage)))))))))))
+
 (define query_block_stages_to_prepare_using (lambda (all_stages block)
 	(begin
 		(define prelimit_stage_ids (if (late_projection_candidate_block? block)
 			(stage_ids_for_sources_with_closure all_stages (query_block_prelimit_sources block))
 			nil))
-		(filter (query_block_stages_to_prepare_base_using all_stages block) (lambda (stage)
-			(or
-				(nil? prelimit_stage_ids)
-				(stage_id_in? stage prelimit_stage_ids)))))))
+		(include_shared_group_carrier_stages
+			(qb_stages block)
+			(filter (query_block_stages_to_prepare_base_using all_stages block) (lambda (stage)
+				(or
+					(nil? prelimit_stage_ids)
+					(stage_id_in? stage prelimit_stage_ids))))))))
 
 (define query_block_stages_to_prepare (lambda (block)
 	(query_block_stages_to_prepare_using (qb_stages block) block)))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -186,6 +186,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			"c"
 			(list (quote and) "d" (list (quote and) "e" "f")))
 		true)) '("a" "b" "c" "d" "e" "f")) true "combine_where_terms flattens nested AND terms")
+	(define canonical_group_sum (list (list (quote get_column) "g" false "amount" false) (quote +) 0))
+	(define canonical_group_count (list 1 (quote +) 0))
+	(define canonical_group_source (list "g" "memcp-tests" "group_values" false nil))
+	(define canonical_group_keys (list (list (quote get_column) "g" false "owner_id" false)))
+	(define canonical_group_sum_stage (make_group_stage "group-sum" canonical_group_source '()
+		canonical_group_keys (list canonical_group_sum) nil '() '() nil nil '()))
+	(define canonical_group_count_stage (make_group_stage "group-count" canonical_group_source '()
+		canonical_group_keys (list canonical_group_count) nil '() '() nil nil '()))
+	(assert (equal?
+		(group_stage_carrier_relation canonical_group_sum_stage)
+		(group_stage_carrier_relation canonical_group_count_stage))
+		true "group keytable identity excludes aggregate columns")
 	(define no_from_select_ast (list "memcp-tests" '() (list "result" 8) true nil nil nil nil nil))
 	(assert (equal? (serialize (build_queryplan_term no_from_select_ast))
 		"(resultrow '(\"result\" 8))") true "build_queryplan_term lowers no-FROM projection")

--- a/tests/69_subquery_complex.yaml
+++ b/tests/69_subquery_complex.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Complex subquery coverage
 # Targets scan.go subquery evaluation, compute.go expression paths,
 # and scan_helper.go various scan strategies.
@@ -300,6 +315,79 @@ test_cases:
         - "inner_select"
         - "dependent-subquery"
         - "scalar_aggregate_probe"
+
+  - name: "Correlated SUM initializes a condition keytable"
+    sql: |
+      SELECT d.did,
+        (SELECT SUM(e.salary) FROM sq_emp e
+         WHERE e.did = d.did AND e.salary >= 0) AS metric
+      FROM sq_dept d
+      ORDER BY d.did
+    expect:
+      rows: 4
+      data:
+        - did: 1
+          metric: 265000
+        - did: 2
+          metric: 145000
+        - did: 3
+          metric: 125000
+        - did: 4
+          metric: null
+
+  - name: "Correlated COUNT extends the same condition keytable"
+    sql: |
+      SELECT d.did,
+        (SELECT COUNT(e.salary) FROM sq_emp e
+         WHERE e.did = d.did AND e.salary >= 0) AS metric
+      FROM sq_dept d
+      ORDER BY d.did
+    expect:
+      rows: 4
+      data:
+        - did: 1
+          metric: 3
+        - did: 2
+          metric: 2
+        - did: 3
+          metric: 2
+        - did: 4
+          metric: 0
+
+  - name: "Nested aggregate scopes share one keytable initializer"
+    sql: |
+      EXPLAIN SELECT candidate.did, candidate.total_salary
+      FROM (
+        SELECT d.did,
+          (SELECT SUM(e.salary) FROM sq_emp e WHERE e.did = d.did) AS total_salary
+        FROM sq_dept d
+      ) candidate
+      WHERE (SELECT MAX(e.salary) FROM sq_emp e WHERE e.did = candidate.did) > 0
+    expect:
+      rows: 1
+      result_occurrences:
+        - text: "touch_keytable"
+          count: 1
+
+  - name: "Nested aggregate scopes retain every aggregate column"
+    sql: |
+      SELECT candidate.did, candidate.total_salary
+      FROM (
+        SELECT d.did,
+          (SELECT SUM(e.salary) FROM sq_emp e WHERE e.did = d.did) AS total_salary
+        FROM sq_dept d
+      ) candidate
+      WHERE (SELECT MAX(e.salary) FROM sq_emp e WHERE e.did = candidate.did) > 0
+      ORDER BY candidate.did
+    expect:
+      rows: 3
+      data:
+        - did: 1
+          total_salary: 265000
+        - did: 2
+          total_salary: 145000
+        - did: 3
+          total_salary: 125000
 
   - name: "Aggregate correlated subselect with no match returns 0"
     sql: |


### PR DESCRIPTION
## Summary

- derive group keytable identity from schema, base relation, canonical keys, and canonical condition
- keep aggregate descriptors out of the carrier name so each aggregate becomes a separate column on the same keytable
- schedule base-table stages sharing a carrier as one prepare group and emit structural initialization only once
- assign initializer ownership only during physical lowering; logical IR remains free of physical `.grp:` carrier names
- keep distinct aggregate and ordering preparation identities so no aggregate column or filter term is discarded

## Test-first regression

The anonymized regression covers:
- sequential `SUM` and `COUNT` queries with equal keys and conditions
- nested aggregate scopes sharing one structural initializer
- preservation of every aggregate column
- a mixed lazy/eager `ORDER BY LIMIT 1` scalar case that initially failed with a nil table lookup

The carrier-identity unit assertion failed before the implementation because aggregate descriptors produced different keytable names.

## A/B measurements

Baseline: `eb0d1ab3834c1e2b8573a055e3ab5ebc876a6c87`. Five fresh table pairs per side, 10,000 value rows, 1,000 keys. Each run executes `SUM` first and then `COUNT` with identical keys and condition.

| Measurement | Master median | PR median | Change |
| --- | ---: | ---: | ---: |
| Initial `SUM` | 1.641 s | 1.618 s | -1.4% |
| Following `COUNT` | 1.657 s | 1.211 s | **-26.9%** |

The plans confirm that master uses different carrier names for `SUM` and `COUNT`, while this PR uses one carrier name and adds the second aggregate column to that table.

For a nested two-aggregate compile-only query, planner median was 9.430 ms on master and 10.015 ms on the PR (+6.2%); recipe emission was 6.370 ms vs 5.396 ms (-15.3%). The higher total is the cost of scheduling the complete shared prepare group, while execution benefits from shared key initialization.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all tests passed
- `tests/40_exists_subquery.yaml`: 20/20
- `tests/41_in_subquery.yaml`: 52/52
- `tests/66_derived_table_limit_scalar.yaml`: 5/5
- `tests/69_subquery_complex.yaml`: 37/37
- `tests/118_manual_trace_sql_regressions.yaml`: 20/20
- `python3 tools/lint_scm.py --check`: exits successfully with the repository's pre-existing depth warnings
