### PR TITLE
Support TPC-H numeric and interval literals

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -79,7 +79,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ))) (merge sub)))
 
 (define psql_int (parser (define x (regex "-?[0-9]+")) (simplify x)))
-(define psql_number (parser (define x (regex "-?[0-9]+\.?[0-9]*(?:e-?[0-9]+)?" true)) (simplify x)))
+(define psql_number (parser (define x (regex "-?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
+(define psql_interval_unit (parser '((define unit psql_identifier_unquoted) (? "(" (regex "[0-9]+") ")")) unit))
 
 (define psql_string (parser (or
 	(parser '((atom "'" false) (define x (regex "(\\\\.|[^\\'])*" false false)) (atom "'" false false)) (sql_unescape x))
@@ -194,9 +195,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	(define psql_expression3 (parser (or
 		/* date + INTERVAL n UNIT */
-		(parser '((define a psql_expression4) "+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_identifier_unquoted)) '('date_add a n unit))
+		(parser '((define a psql_expression4) "+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_add a n unit))
 		/* date - INTERVAL n UNIT */
-		(parser '((define a psql_expression4) "-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_identifier_unquoted)) '('date_sub a n unit))
+		(parser '((define a psql_expression4) "-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_sub a n unit))
 		(parser '((define a psql_expression4) "+" (define b psql_expression3)) '((quote +) a b))
 		(parser '((define a psql_expression4) "-" (define b psql_expression3)) '((quote -) a b))
 		psql_expression4

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -91,7 +91,8 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 )))
 
 (define sql_int (parser (define x (regex "-?[0-9]+")) (simplify x)))
-(define sql_number (parser (define x (regex "-?[0-9]+\.?[0-9]*(?:e-?[0-9]+)?" true)) (simplify x)))
+(define sql_number (parser (define x (regex "-?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
+(define sql_interval_unit (parser '((define unit sql_identifier_unquoted) (? "(" (regex "[0-9]+") ")")) unit))
 
 (define sql_string (parser (or
 	(parser '((atom "'" false) (define x (regex "(\\\\.|[^\\'])*" false false)) (atom "'" false false)) (sql_unescape x))
@@ -639,9 +640,9 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 
 	(define sql_expression3 (parser (or
 		/* date + INTERVAL n UNIT */
-		(parser '((define a sql_expression4) "+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_identifier_unquoted)) '('date_add a n unit))
+		(parser '((define a sql_expression4) "+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_add a n unit))
 		/* date - INTERVAL n UNIT */
-		(parser '((define a sql_expression4) "-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_identifier_unquoted)) '('date_sub a n unit))
+		(parser '((define a sql_expression4) "-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_sub a n unit))
 		(parser '((define a sql_expression4) "+" (define b sql_expression3)) '((quote +) a b))
 		(parser '((define a sql_expression4) "-" (define b sql_expression3)) '((quote -) a b))
 		sql_expression4

--- a/tests/06_edge_cases.yaml
+++ b/tests/06_edge_cases.yaml
@@ -264,6 +264,25 @@ test_cases:
       data:
         - tiny_number: 0.000001
 
+  - name: "Leading-dot decimal literal"
+    sql: "SELECT .06 AS leading_dot"
+    expect:
+      rows: 1
+      data:
+        - leading_dot: 0.06
+
+  - name: "Negative leading-dot decimal literal"
+    sql: "SELECT -.25 AS leading_dot"
+    expect:
+      rows: 1
+      data:
+        - leading_dot: -0.25
+
+  - name: "Leading dot without fractional digits must fail"
+    sql: "SELECT . AS invalid_decimal"
+    expect:
+      error: true
+
   - name: "Negative zero"
     sql: "SELECT -0 AS negative_zero"
     expect:

--- a/tests/50_datefunctions.yaml
+++ b/tests/50_datefunctions.yaml
@@ -182,6 +182,18 @@ test_cases:
       data:
         - d: "1998-09-02 00:00:00"
 
+  - name: "Date minus interval with leading field precision"
+    sql: "SELECT DATE '1998-12-01' - INTERVAL '90' DAY (3) AS d"
+    expect:
+      rows: 1
+      data:
+        - d: "1998-09-02 00:00:00"
+
+  - name: "Interval precision requires digits"
+    sql: "SELECT DATE '1998-12-01' - INTERVAL '90' DAY () AS d"
+    expect:
+      error: true
+
   - name: "Date plus interval year"
     sql: "SELECT DATE '1995-03-15' + INTERVAL 1 YEAR AS d"
     expect:

--- a/tests/72_psql_parser.yaml
+++ b/tests/72_psql_parser.yaml
@@ -206,6 +206,16 @@ test_cases:
         - { discount: 0.06, rows_per_discount: 1000 }
         - { discount: 0.07, rows_per_discount: 1000 }
 
+  - name: "TPC-H Q6 accepts leading-dot decimal bounds"
+    sql: |
+      SELECT COUNT(*) AS matching_rows
+      FROM psql_decimal_range
+      WHERE discount BETWEEN .05 AND .07
+    expect:
+      rows: 1
+      data:
+        - { matching_rows: 3000 }
+
   - name: "TPC-H Q6 combined predicates retain every matching row"
     sql: |
       SELECT COUNT(*) AS matching_rows
@@ -397,6 +407,13 @@ test_cases:
     sql: "SELECT '2025-06-15' - INTERVAL 3 MONTH AS d"
     expect:
       rows: 1
+
+  - name: "TPC-H Q1 interval leading field precision"
+    sql: "SELECT DATE '1998-12-01' - INTERVAL '90' DAY (3) AS d"
+    expect:
+      rows: 1
+      data:
+        - d: "1998-09-02 00:00:00"
 
   # === CONVERT ===
   - name: "CONVERT to SIGNED"


### PR DESCRIPTION
## What changed

- Accept decimal literals without an integer part, including `.06` and `-.25`, in both SQL parsers.
- Accept the optional interval leading-field precision used by TPC-H Q1, for example `INTERVAL '90' DAY (3)`.
- Keep malformed forms such as a bare `.` or `DAY ()` invalid.
- Add MySQL and PostgreSQL integration coverage for positive, negative, and malformed forms plus Q1/Q6-shaped expressions.

## Semantics

The interval precision is a syntactic qualifier only. It does not introduce a new date type or alter MemCP's existing date arithmetic/type model.

## Impact

The local typed-schema TPC-H compile matrix improves from 19/22 to 21/22. Q1 and Q6 now compile; Q18 remains the only blocker and requires a separate grouped-IN decorrelation package.

No TPC-H queries, data, helper scripts, or toolkit files are included in this branch.

## Validation

- Full repository pre-commit suite passed twice; the commit used the current hook without bypassing or weakening tests.
- `tests/06_edge_cases.yaml`: 42/42
- `tests/50_datefunctions.yaml`: 65/65
- `tests/72_psql_parser.yaml`: 50/50
- Scheme startup unit tests: 845/845
- All 22 locally generated TPC-H queries were compile-probed against an empty typed schema: 21 passed, only Q18 failed.
- Scheme formatter completed; only its known pre-existing parenthesis-depth warnings remain.