### PR TITLE
Decorrelate grouped IN membership queries

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1483,7 +1483,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 				(list stage null_stage)
 				(list source null_source))))))
 
-(define make_in_stage_rewrite (lambda (probe inner args)
+(define make_plain_in_stage_rewrite (lambda (probe inner args)
 	(begin
 		(define outer_sources (nth args 0))
 		(define negate (if (>= (count args) 3) (nth args 2) false))
@@ -1604,6 +1604,62 @@ PostgreSQL parsers should both lower to the same combined operators.
 					(in_membership_expr probe stage_alias aggregate_count_descriptor null_stage_alias null_ag))
 				(list stage null_stage)
 				(list source null_source))))))
+
+(define grouped_membership_inner_supported? (lambda (inner outer_sources)
+	(and (query_block? inner)
+		(and (not (empty_list? (qb_sources inner)))
+			(and (not (empty_list? (qb_group inner)))
+				(and (empty_list? (qb_order inner))
+					(and (nil? (qb_limit inner))
+						(and (nil? (qb_offset inner))
+							(empty_list? (btw2025_query_block_accessing_aliases inner outer_sources))))))))))
+
+(define make_grouped_in_semijoin_rewrite (lambda (probe inner outer_sources)
+	(begin
+		(if (not (grouped_membership_inner_supported? inner outer_sources))
+			(neumann_fail "untangle_query" "grouped IN currently requires an uncorrelated unordered query-block")
+			true)
+		(if (not (equal? (count (qb_fields inner)) 2))
+			(neumann_fail "untangle_query" "IN subquery must expose exactly one column")
+			true)
+		(define stage (make_group_stage_for_query_block inner))
+		(define input_alias (group_stage_input_alias stage))
+		(define keys (gs_keys stage))
+		(define ags (gs_aggregates stage))
+		(define rhs_expr (canonical_column_expr_for_alias input_alias (query_block_first_expr inner)))
+		(define key_idx (group_key_index input_alias keys rhs_expr))
+		(if (nil? key_idx)
+			(neumann_fail "untangle_query" "grouped IN currently requires the selected value to be a GROUP BY key")
+			true)
+		(define stage_alias (exists_stage_alias (gs_id stage)))
+		(define key_names (group_key_cols keys))
+		(define having_expr (replace_group_expr
+			input_alias stage_alias keys key_names ags (coalesceNil (gs_having stage) true)))
+		(define join_condition (combine_where_terms
+			(list
+				(make_exists_stage_join_condition stage_alias (list (nth key_names key_idx)) (list probe))
+				(list (quote not) (list (quote nil?) probe))
+				having_expr)
+			true))
+		(define source (list
+			stage_alias
+			(group_stage_schema stage)
+			(make_stage_output_relation (gs_id stage))
+			false
+			join_condition))
+		(list true (list stage) (list source)))))
+
+(define make_in_stage_rewrite (lambda (probe inner args)
+	(begin
+		(define outer_sources (nth args 0))
+		(define negate (if (>= (count args) 3) (nth args 2) false))
+		(define semijoin_where (and (not negate) (if (>= (count args) 4) (nth args 3) false)))
+		(define membership_inner (normalize_membership_query_block inner))
+		(if (empty_list? (qb_group membership_inner))
+			(make_plain_in_stage_rewrite probe membership_inner args)
+			(if semijoin_where
+				(make_grouped_in_semijoin_rewrite probe membership_inner outer_sources)
+				(neumann_fail "untangle_query" "grouped IN is currently supported only as a positive WHERE predicate"))))))
 
 (define make_scalar_aggregate_stage_rewrite (lambda (inner args)
 	(begin

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1257,6 +1257,57 @@ test_cases:
       data:
         - ID: 2
 
+  - name: "IN subquery consumes grouped keys after HAVING"
+    sql: |
+      SELECT ID FROM in_fop_files
+      WHERE ID IN (
+        SELECT grp FROM in_nullable_rhs
+        GROUP BY grp
+        HAVING SUM(ID) > 2
+      )
+      ORDER BY ID
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+        - ID: 2
+
+  - name: "Grouped outer query consumes grouped IN keys"
+    sql: |
+      SELECT f.ID, COUNT(*) AS job_count
+      FROM in_fop_files f
+      JOIN in_renderjob j ON j.result = f.ID
+      WHERE f.ID IN (
+        SELECT grp FROM in_nullable_rhs
+        GROUP BY grp
+        HAVING SUM(ID) > 2
+      )
+      GROUP BY f.ID
+      ORDER BY f.ID
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          job_count: 1
+
+  - name: "Grouped IN lowers to group stages without a subquery marker"
+    sql: |
+      EXPLAIN IR
+      SELECT ID FROM in_fop_files
+      WHERE ID IN (
+        SELECT grp FROM in_nullable_rhs
+        GROUP BY grp
+        HAVING SUM(ID) > 2
+      )
+    expect:
+      contains:
+        - "group-stage"
+        - "stage-output"
+      not_contains:
+        - "inner_select"
+        - "dependent-subquery"
+        - ".grp:"
+
   - name: "NOT IN subquery with RHS NULL projects UNKNOWN"
     sql: |
       SELECT ID, ID NOT IN (SELECT result FROM in_nullable_rhs) AS ok


### PR DESCRIPTION
## What changed

- lower positive `IN` predicates with a grouped RHS through the existing logical `group-stage` / `stage-output` model
- apply the RHS `HAVING` expression to the stage-output join
- require the selected membership value to be a `GROUP BY` key and fail explicitly for unsupported grouped membership shapes
- add SQL correctness coverage for grouped RHS keys, `HAVING`, a grouped outer query, and subquery-free logical IR

## Why

TPC-H Q18 was the final known compile blocker. Its membership subquery groups line items and filters those groups with `HAVING`; the previous membership rewrite rejected every grouped RHS query-block before physical lowering.

The rewrite composes existing logical operators and keeps the complete query visible to the planner. It does not add scalar/correlated fallback execution or an early materialization path.

## Validation

- full regular pre-commit suite: passed
- `tests/41_in_subquery.yaml`: 55/55 passed
- locally generated Q18 against an empty typed schema: compiled/executed without SQL error
- Scheme formatter/check run; only the repository's pre-existing negative-depth warnings remain

No TPC-H queries, data, or helper scripts are included in this branch.