### PR TITLE
Deduplicate alpha-equivalent correlated scalar stages

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4154,46 +4154,150 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(ir_context_of ir)
 			(ir_return ir))))))
 
-(define stage_output_left_join_stage_key (lambda (stage)
+/* Scalar stages are merged after decorrelation. Build their signatures bottom-up
+so generated aliases and dependency IDs do not hide equivalent stage graphs. */
+(define stage_semantic_expr_aliases (lambda (expr)
+	(match expr
+		((symbol get_column) tblvar _ignorecase _col _col_ignorecase) (if (nil? tblvar) '() (list tblvar))
+		((quote get_column) tblvar _ignorecase _col _col_ignorecase) (if (nil? tblvar) '() (list tblvar))
+		(cons head tail) (merge_unique (list
+			(stage_semantic_expr_aliases head)
+			(map tail stage_semantic_expr_aliases)))
+		_ '())))
+
+(define stage_semantic_alias_entries (lambda (aliases prefix)
+	(map (produceN (count aliases)) (lambda (i)
+		(list (nth aliases i) (concat prefix i))))))
+
+(define stage_semantic_input_sources (lambda (input)
+	(if (query_block? input)
+		(qb_sources input)
+		(if (source_is_base_table? input) (list input) '()))))
+
+(define stage_semantic_alias_map (lambda (stage)
+	(begin
+		(define local_aliases (source_aliases (stage_semantic_input_sources (gs_input stage))))
+		(define referenced_aliases (merge_unique (list
+			(stage_semantic_expr_aliases (gs_input stage))
+			(stage_semantic_expr_aliases (gs_domain stage))
+			(stage_semantic_expr_aliases (gs_keys stage))
+			(stage_semantic_expr_aliases (gs_aggregates stage))
+			(stage_semantic_expr_aliases (qassoc_get (gs_facts stage) (quote condition) true)))))
+		(define outer_aliases (filter referenced_aliases (lambda (alias) (not (contains? local_aliases alias)))))
+		(merge (list
+			(stage_semantic_alias_entries local_aliases "__stage_local_")
+			(stage_semantic_alias_entries outer_aliases "__stage_outer_"))))))
+
+(define stage_semantic_rewrite_expr (lambda (alias_map signatures expr)
+	(match expr
+		((symbol get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(stage_merge_lookup alias_map tblvar tblvar)
+			ignorecase col col_ignorecase)
+		((quote get_column) tblvar ignorecase col col_ignorecase)
+		(list (quote get_column)
+			(stage_merge_lookup alias_map tblvar tblvar)
+			ignorecase col col_ignorecase)
+		((symbol stage-output) stage_id)
+		(list (quote stage-output) (coalesceNil (get_assoc signatures stage_id) stage_id))
+		((quote stage-output) stage_id)
+		(list (quote stage-output) (coalesceNil (get_assoc signatures stage_id) stage_id))
+		(cons head tail) (cons (stage_semantic_rewrite_expr alias_map signatures head)
+			(map tail (lambda (item) (stage_semantic_rewrite_expr alias_map signatures item))))
+		_ expr)))
+
+(define stage_semantic_rewrite_source (lambda (alias_map signatures src)
+	(match src
+		'(alias schema relation outer join)
+		(list
+			(stage_merge_lookup alias_map alias alias)
+			schema
+			(stage_semantic_rewrite_expr alias_map signatures relation)
+			outer
+			(stage_semantic_rewrite_expr alias_map signatures join))
+		_ src)))
+
+(define stage_semantic_canonical_node (lambda (alias_map signatures node)
+	(if (query_block? node)
+		(make_query_block
+			(qb_schema node)
+			(map (qb_sources node) (lambda (src) (stage_semantic_rewrite_source alias_map signatures src)))
+			(stage_semantic_rewrite_expr alias_map signatures (qb_fields node))
+			(stage_semantic_rewrite_expr alias_map signatures (qb_where node))
+			(stage_semantic_rewrite_expr alias_map signatures (qb_group node))
+			(stage_semantic_rewrite_expr alias_map signatures (qb_having node))
+			(stage_semantic_rewrite_expr alias_map signatures (qb_order node))
+			(qb_limit node)
+			(qb_offset node)
+			(stage_semantic_rewrite_expr alias_map signatures (qb_hidden node))
+			'()
+			'())
+		(if (union_block? node)
+			(make_union_block
+				(union_mode node)
+				(map (union_branches node) (lambda (branch) (stage_semantic_canonical_node alias_map signatures branch)))
+				(stage_semantic_rewrite_expr alias_map signatures (union_order node))
+				(union_limit node)
+				(union_offset node)
+				'())
+			(stage_semantic_rewrite_source alias_map signatures node)))))
+
+(define stage_semantic_aggregate_shape (lambda (alias_map signatures ag)
+	(match ag
+		'(((symbol scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
+		(list (quote scalar_order_value)
+			(stage_semantic_rewrite_expr alias_map signatures order_exprs)
+			dirs offset_value reduce neutral)
+		'(((quote scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
+		(list (quote scalar_order_value)
+			(stage_semantic_rewrite_expr alias_map signatures order_exprs)
+			dirs offset_value reduce neutral)
+		'(_value_expr reduce neutral) (list (quote aggregate) reduce neutral)
+		_ (stage_semantic_rewrite_expr alias_map signatures ag))))
+
+(define stage_semantic_facts (lambda (alias_map signatures facts)
+	(map (list
+		(quote purpose)
+		(quote presence_only)
+		(quote max_needed_per_domain)
+		(quote preserve_empty_domain)
+		(quote null_semantics)
+		(quote cardinality_mode)
+		(quote partition_by)
+		(quote physical_max_rows)
+		(quote on_overflow))
+		(lambda (key) (list key (stage_semantic_rewrite_expr alias_map signatures (qassoc_get facts key nil)))))))
+
+(define stage_semantic_signature (lambda (signatures stage)
+	(if (not (group_stage? stage))
+		(logical_stage_key stage)
+		(begin
+			(define alias_map (stage_semantic_alias_map stage))
+			(define payload (list
+				(stage_semantic_canonical_node alias_map signatures (gs_input stage))
+				(stage_semantic_rewrite_expr alias_map signatures (gs_domain stage))
+				(stage_semantic_rewrite_expr alias_map signatures (gs_keys stage))
+				(map (gs_aggregates stage) (lambda (ag) (stage_semantic_aggregate_shape alias_map signatures ag)))
+				(stage_semantic_rewrite_expr alias_map signatures (qassoc_get (gs_facts stage) (quote condition) true))
+				(stage_semantic_rewrite_expr alias_map signatures (gs_having stage))
+				(stage_semantic_rewrite_expr alias_map signatures (gs_output stage))
+				(stage_semantic_rewrite_expr alias_map signatures (gs_order stage))
+				(gs_limit stage)
+				(gs_offset stage)
+				(stage_semantic_facts alias_map signatures (gs_facts stage))))
+			(concat "stage-semantic:" (fnv_hash (serialize payload)))))))
+
+(define stage_semantic_signature_index (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (index stage)
+		(set_assoc index (gs_id stage) (stage_semantic_signature index stage)))
+		'())))
+
+(define stage_output_left_join_stage_key (lambda (signature_index stage)
 	(if (not (and (group_stage? stage)
 		(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
-			(and (source_is_base_table? (gs_input stage))
-				(equal? (count (gs_aggregates stage)) 1)))))
+			(equal? (count (gs_aggregates stage)) 1))))
 		nil
-		(match (car (gs_aggregates stage))
-			'(((symbol scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
-			(concat "scalar-once-merge:" (fnv_hash (serialize (list
-				(gs_input stage)
-				(gs_domain stage)
-				(gs_keys stage)
-				(qassoc_get (gs_facts stage) (quote condition) true)
-				order_exprs
-				dirs
-				offset_value
-				reduce
-				neutral
-				(gs_having stage)
-				(gs_output stage)
-				(gs_order stage)
-				(gs_limit stage)
-				(gs_offset stage)))))
-			'(((quote scalar_order_value) _value_expr order_exprs dirs offset_value) reduce neutral)
-			(concat "scalar-once-merge:" (fnv_hash (serialize (list
-				(gs_input stage)
-				(gs_domain stage)
-				(gs_keys stage)
-				(qassoc_get (gs_facts stage) (quote condition) true)
-				order_exprs
-				dirs
-				offset_value
-				reduce
-				neutral
-				(gs_having stage)
-				(gs_output stage)
-				(gs_order stage)
-				(gs_limit stage)
-				(gs_offset stage)))))
-			_ nil))))
+		(get_assoc signature_index (gs_id stage)))))
 
 (define normalize_stage_output_left_join_expr (lambda (alias expr)
 	(match expr
@@ -4213,14 +4317,14 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(map tail (lambda (item) (normalize_stage_output_left_join_expr alias item))))
 		_ expr)))
 
-(define stage_output_left_join_key (lambda (stages src)
+(define stage_output_left_join_key (lambda (stages signature_index src)
 	(begin
 		(define relation (source_relation src))
 		(if (not (and (source_outer? src) (stage_output_relation? relation)))
 			nil
 			(begin
 				(define stage (stage_by_id stages (stage_output_relation_id relation)))
-				(define stage_key (stage_output_left_join_stage_key stage))
+				(define stage_key (stage_output_left_join_stage_key signature_index stage))
 				(if (nil? stage_key)
 					nil
 					(concat "stage-output-left-join:" (fnv_hash (serialize (list
@@ -4252,6 +4356,18 @@ PostgreSQL parsers should both lower to the same combined operators.
 (define stage_output_left_join_entry_for_source (lambda (key src stage)
 	(list key src stage (list (gs_id stage)) (list (source_alias src)) (gs_aggregates stage))))
 
+(define stage_output_left_join_aligned_aggregates (lambda (target stage)
+	(begin
+		(define target_sources (stage_semantic_input_sources (gs_input target)))
+		(define source_sources (stage_semantic_input_sources (gs_input stage)))
+		(define alias_map (map (produceN (count source_sources)) (lambda (i)
+			(list (source_alias (nth source_sources i)) (source_alias (nth target_sources i))))))
+		(define id_map (map (produceN (count source_sources)) (lambda (i)
+			(list
+				(stage_output_relation_id (source_relation (nth source_sources i)))
+				(stage_output_relation_id (source_relation (nth target_sources i)))))))
+		(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage)))))
+
 (define stage_output_left_join_entry_add_source (lambda (entry src stage)
 	(list
 		(stage_output_left_join_entry_key entry)
@@ -4259,11 +4375,65 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(stage_output_left_join_entry_stage entry)
 		(merge_unique (list (stage_output_left_join_entry_ids entry) (list (gs_id stage))))
 		(merge_unique (list (stage_output_left_join_entry_aliases entry) (list (source_alias src))))
-		(dedupe_aggregates_by_col (merge (list (stage_output_left_join_entry_ags entry) (gs_aggregates stage)))))))
+		(dedupe_aggregates_by_col (merge (list
+			(stage_output_left_join_entry_ags entry)
+			(stage_output_left_join_aligned_aggregates (stage_output_left_join_entry_stage entry) stage)))))))
 
-(define stage_output_left_join_upsert_entry (lambda (stages entries src)
+(define stage_output_left_join_column_map_for_stage (lambda (target_alias target stage_alias stage)
 	(begin
-		(define key (stage_output_left_join_key stages src))
+		(define source_ags (gs_aggregates stage))
+		(define aligned_ags (stage_output_left_join_aligned_aggregates target stage))
+		(map (produceN (count source_ags)) (lambda (i)
+			(list
+				stage_alias
+				(aggregate_col_name (nth source_ags i))
+				target_alias
+				(aggregate_col_name (nth aligned_ags i))))))))
+
+(define stage_output_left_join_column_maps_for_entry (lambda (stages entry)
+	(begin
+		(define target (stage_output_left_join_entry_stage entry))
+		(define target_alias (source_alias (stage_output_left_join_entry_source entry)))
+		(define ids (stage_output_left_join_entry_ids entry))
+		(define aliases (stage_output_left_join_entry_aliases entry))
+		(merge (map (produceN (count ids)) (lambda (i)
+			(stage_output_left_join_column_map_for_stage
+				target_alias target (nth aliases i) (stage_by_id stages (nth ids i)))))))))
+
+(define stage_output_left_join_column_mapping (lambda (mappings alias col)
+	(reduce (coalesceNil mappings '()) (lambda (found mapping)
+		(if (not (nil? found))
+			found
+			(match mapping
+				'(old_alias old_col new_alias new_col)
+				(if (and (equal? alias old_alias) (equal? col old_col))
+					(list new_alias new_col)
+					nil)
+				_ nil)))
+		nil)))
+
+(define rewrite_stage_output_left_join_columns (lambda (mappings expr)
+	(match expr
+		((symbol get_column) tblvar ignorecase col col_ignorecase) (begin
+			(define mapped (stage_output_left_join_column_mapping mappings tblvar col))
+			(if (nil? mapped)
+				expr
+				(list (quote get_column) (nth mapped 0) ignorecase (nth mapped 1) col_ignorecase)))
+		((quote get_column) tblvar ignorecase col col_ignorecase) (begin
+			(define mapped (stage_output_left_join_column_mapping mappings tblvar col))
+			(if (nil? mapped)
+				expr
+				(list (quote get_column) (nth mapped 0) ignorecase (nth mapped 1) col_ignorecase)))
+		(cons head tail) (cons (rewrite_stage_output_left_join_columns mappings head)
+			(map tail (lambda (item) (rewrite_stage_output_left_join_columns mappings item))))
+		_ expr)))
+
+(define rewrite_stage_output_left_join_source_columns (lambda (mappings src)
+	(source_with_join_expr src (rewrite_stage_output_left_join_columns mappings (source_join_expr src)))))
+
+(define stage_output_left_join_upsert_entry (lambda (stages signature_index entries src)
+	(begin
+		(define key (stage_output_left_join_key stages signature_index src))
 		(if (nil? key)
 			entries
 			(begin
@@ -4278,9 +4448,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 							entry)))
 					(merge entries (list (stage_output_left_join_entry_for_source key src stage)))))))))
 
-(define stage_output_left_join_entries (lambda (stages sources)
+(define stage_output_left_join_entries (lambda (stages signature_index sources)
 	(reduce (coalesceNil sources '()) (lambda (entries src)
-		(stage_output_left_join_upsert_entry stages entries src))
+		(stage_output_left_join_upsert_entry stages signature_index entries src))
 		'())))
 
 (define stage_output_left_join_entries_have_duplicates? (lambda (entries)
@@ -4293,6 +4463,23 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define primary (gs_id (stage_output_left_join_entry_stage entry)))
 		(map (stage_output_left_join_entry_ids entry) (lambda (id) (list id primary))))))
 
+(define stage_output_left_join_dependency_id_map (lambda (target stage)
+	(begin
+		(define target_sources (stage_semantic_input_sources (gs_input target)))
+		(define source_sources (stage_semantic_input_sources (gs_input stage)))
+		(filter (map (produceN (count source_sources)) (lambda (i)
+			(begin
+				(define source_id (stage_output_relation_id (source_relation (nth source_sources i))))
+				(define target_id (stage_output_relation_id (source_relation (nth target_sources i))))
+				(if (or (nil? source_id) (nil? target_id)) nil (list source_id target_id)))))
+			(lambda (mapping) (not (nil? mapping)))))))
+
+(define stage_output_left_join_dependency_id_maps_for_entry (lambda (stages entry)
+	(begin
+		(define target (stage_output_left_join_entry_stage entry))
+		(merge (map (stage_output_left_join_entry_ids entry) (lambda (id)
+			(stage_output_left_join_dependency_id_map target (stage_by_id stages id))))))))
+
 (define stage_output_left_join_alias_map_for_entry (lambda (entry)
 	(begin
 		(define primary (source_alias (stage_output_left_join_entry_source entry)))
@@ -4300,6 +4487,13 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define stage_output_left_join_candidate_ids (lambda (entries)
 	(merge_unique (map (coalesceNil entries '()) stage_output_left_join_entry_ids))))
+
+(define stage_output_left_join_removed_dependency_ids (lambda (dependency_id_map)
+	(filter (map (coalesceNil dependency_id_map '()) (lambda (mapping)
+		(match mapping
+			'(old_id new_id) (if (equal? old_id new_id) nil old_id)
+			_ nil)))
+		(lambda (id) (not (nil? id))))))
 
 (define stage_merge_lookup (lambda (mapping key default)
 	(if (empty_list? mapping)
@@ -4375,13 +4569,22 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(if (or (empty_list? (qb_stages block)) (empty_list? (qb_sources block)))
 		block
 		(begin
-			(define entries (stage_output_left_join_entries (qb_stages block) (qb_sources block)))
+			(define signature_index (stage_semantic_signature_index (qb_stages block)))
+			(define entries (stage_output_left_join_entries (qb_stages block) signature_index (qb_sources block)))
 			(if (not (stage_output_left_join_entries_have_duplicates? entries))
 				block
 				(begin
-					(define id_map (merge (map entries stage_output_left_join_id_map_for_entry)))
+					(define dependency_id_map (merge (map entries (lambda (entry)
+						(stage_output_left_join_dependency_id_maps_for_entry (qb_stages block) entry)))))
+					(define id_map (merge (list
+						(merge (map entries stage_output_left_join_id_map_for_entry))
+						dependency_id_map)))
 					(define alias_map (merge (map entries stage_output_left_join_alias_map_for_entry)))
-					(define candidate_ids (stage_output_left_join_candidate_ids entries))
+					(define column_maps (merge (map entries (lambda (entry)
+						(stage_output_left_join_column_maps_for_entry (qb_stages block) entry)))))
+					(define candidate_ids (merge_unique (list
+						(stage_output_left_join_candidate_ids entries)
+						(stage_output_left_join_removed_dependency_ids dependency_id_map))))
 					(define untouched_stages (filter (qb_stages block) (lambda (stage)
 						(stage_not_in_id_list? candidate_ids stage))))
 					(define merged_stages (map entries (lambda (entry)
@@ -4391,16 +4594,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 								(stage_output_left_join_entry_ags entry))))))
 					(make_query_block
 						(qb_schema block)
-						(merge_unique (list (map (qb_sources block) (lambda (src) (rewrite_stage_output_left_join_source alias_map id_map src)))))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_fields block))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_where block))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_group block))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_having block))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_order block))
+						(merge_unique (list (map (qb_sources block) (lambda (src)
+							(rewrite_stage_output_left_join_source alias_map id_map
+								(rewrite_stage_output_left_join_source_columns column_maps src))))))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_fields block)))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_where block)))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_group block)))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_having block)))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_order block)))
 						(qb_limit block)
 						(qb_offset block)
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_hidden block))
-						(merge_unique (list untouched_stages merged_stages))
+						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_hidden block)))
+						(merge_unique (list
+							(map untouched_stages (lambda (stage) (rewrite_stage_output_left_join_stage '() id_map stage)))
+							merged_stages))
 						(rewrite_stage_output_left_join_expr alias_map id_map (qb_facts block)))))))))
 
 (define merge_compatible_stage_output_left_joins_node (lambda (node)

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -277,7 +277,6 @@ setup:
   - sql: "INSERT INTO trace_ref_b SELECT id, id, TRUE FROM trace_asset WHERE id IN (1, 17, 257)"
   - sql: "INSERT INTO trace_ref_c SELECT id, id, FALSE FROM trace_asset WHERE id % 257 = 0"
   - sql: "INSERT INTO trace_ref_d SELECT id, id, TRUE FROM trace_asset WHERE id % 509 = 0"
-
 test_cases:
   - name: "COUNT lowers a grouped derived stage with an outer presence stage"
     max_plan_size: 20000
@@ -670,6 +669,58 @@ test_cases:
         - id: 1
           archived: false
           can_view: true
+
+  - name: "Repeated correlated access projections compile within one second"
+    max_time: 1.0
+    max_planner_time_ms: 500
+    max_plan_size: 240000
+    sql: |
+      EXPLAIN COMPILE SELECT projected.*
+      FROM (
+        SELECT item.id, item.archived,
+        COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item.parent_id LIMIT 1), FALSE) AS access_1,
+        COALESCE((SELECT (parent_2.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_2 WHERE member_2.team_id = parent_2.team_id AND member_2.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_2 WHERE parent_2.id = item.parent_id LIMIT 1), FALSE) AS access_2,
+        COALESCE((SELECT (parent_3.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_3 WHERE member_3.team_id = parent_3.team_id AND member_3.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_3 WHERE parent_3.id = item.parent_id LIMIT 1), FALSE) AS access_3,
+        COALESCE((SELECT (parent_4.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_4 WHERE member_4.team_id = parent_4.team_id AND member_4.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_4 WHERE parent_4.id = item.parent_id LIMIT 1), FALSE) AS access_4,
+        COALESCE((SELECT (parent_5.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_5 WHERE member_5.team_id = parent_5.team_id AND member_5.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_5 WHERE parent_5.id = item.parent_id LIMIT 1), FALSE) AS access_5,
+        COALESCE((SELECT (parent_6.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_6 WHERE member_6.team_id = parent_6.team_id AND member_6.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_6 WHERE parent_6.id = item.parent_id LIMIT 1), FALSE) AS access_6,
+        COALESCE((SELECT (parent_7.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_7 WHERE member_7.team_id = parent_7.team_id AND member_7.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_7 WHERE parent_7.id = item.parent_id LIMIT 1), FALSE) AS access_7,
+        COALESCE((SELECT (parent_8.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_8 WHERE member_8.team_id = parent_8.team_id AND member_8.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_8 WHERE parent_8.id = item.parent_id LIMIT 1), FALSE) AS access_8,
+        COALESCE((SELECT (parent_9.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_9 WHERE member_9.team_id = parent_9.team_id AND member_9.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_9 WHERE parent_9.id = item.parent_id LIMIT 1), FALSE) AS access_9,
+        COALESCE((SELECT (parent_10.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_10 WHERE member_10.team_id = parent_10.team_id AND member_10.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_10 WHERE parent_10.id = item.parent_id LIMIT 1), FALSE) AS access_10,
+        COALESCE((SELECT (parent_11.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_11 WHERE member_11.team_id = parent_11.team_id AND member_11.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_11 WHERE parent_11.id = item.parent_id LIMIT 1), FALSE) AS access_11,
+        COALESCE((SELECT (parent_12.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_12 WHERE member_12.team_id = parent_12.team_id AND member_12.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_12 WHERE parent_12.id = item.parent_id LIMIT 1), FALSE) AS access_12,
+        COALESCE((SELECT (parent_13.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_13 WHERE member_13.team_id = parent_13.team_id AND member_13.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_13 WHERE parent_13.id = item.parent_id LIMIT 1), FALSE) AS access_13,
+        COALESCE((SELECT (parent_14.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_14 WHERE member_14.team_id = parent_14.team_id AND member_14.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_14 WHERE parent_14.id = item.parent_id LIMIT 1), FALSE) AS access_14,
+        COALESCE((SELECT (parent_15.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_15 WHERE member_15.team_id = parent_15.team_id AND member_15.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_15 WHERE parent_15.id = item.parent_id LIMIT 1), FALSE) AS access_15,
+        COALESCE((SELECT (parent_16.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_16 WHERE member_16.team_id = parent_16.team_id AND member_16.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_16 WHERE parent_16.id = item.parent_id LIMIT 1), FALSE) AS access_16,
+        COALESCE((SELECT (parent_17.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_17 WHERE member_17.team_id = parent_17.team_id AND member_17.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_17 WHERE parent_17.id = item.parent_id LIMIT 1), FALSE) AS access_17,
+        COALESCE((SELECT (parent_18.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_18 WHERE member_18.team_id = parent_18.team_id AND member_18.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_18 WHERE parent_18.id = item.parent_id LIMIT 1), FALSE) AS access_18,
+        COALESCE((SELECT (parent_19.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_19 WHERE member_19.team_id = parent_19.team_id AND member_19.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_19 WHERE parent_19.id = item.parent_id LIMIT 1), FALSE) AS access_19,
+        COALESCE((SELECT (parent_20.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_20 WHERE member_20.team_id = parent_20.team_id AND member_20.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_20 WHERE parent_20.id = item.parent_id LIMIT 1), FALSE) AS access_20,
+        COALESCE((SELECT (parent_21.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_21 WHERE member_21.team_id = parent_21.team_id AND member_21.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_21 WHERE parent_21.id = item.parent_id LIMIT 1), FALSE) AS access_21,
+        COALESCE((SELECT (parent_22.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_22 WHERE member_22.team_id = parent_22.team_id AND member_22.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_22 WHERE parent_22.id = item.parent_id LIMIT 1), FALSE) AS access_22,
+        COALESCE((SELECT (parent_23.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_23 WHERE member_23.team_id = parent_23.team_id AND member_23.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_23 WHERE parent_23.id = item.parent_id LIMIT 1), FALSE) AS access_23,
+        COALESCE((SELECT (parent_24.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_24 WHERE member_24.team_id = parent_24.team_id AND member_24.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_24 WHERE parent_24.id = item.parent_id LIMIT 1), FALSE) AS access_24,
+        COALESCE((SELECT (parent_25.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_25 WHERE member_25.team_id = parent_25.team_id AND member_25.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_25 WHERE parent_25.id = item.parent_id LIMIT 1), FALSE) AS access_25,
+        COALESCE((SELECT (parent_26.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_26 WHERE member_26.team_id = parent_26.team_id AND member_26.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_26 WHERE parent_26.id = item.parent_id LIMIT 1), FALSE) AS access_26,
+        COALESCE((SELECT (parent_27.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_27 WHERE member_27.team_id = parent_27.team_id AND member_27.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_27 WHERE parent_27.id = item.parent_id LIMIT 1), FALSE) AS access_27,
+        COALESCE((SELECT (parent_28.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_28 WHERE member_28.team_id = parent_28.team_id AND member_28.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_28 WHERE parent_28.id = item.parent_id LIMIT 1), FALSE) AS access_28,
+        COALESCE((SELECT (parent_29.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_29 WHERE member_29.team_id = parent_29.team_id AND member_29.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_29 WHERE parent_29.id = item.parent_id LIMIT 1), FALSE) AS access_29,
+        COALESCE((SELECT (parent_30.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_30 WHERE member_30.team_id = parent_30.team_id AND member_30.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_30 WHERE parent_30.id = item.parent_id LIMIT 1), FALSE) AS access_30,
+        COALESCE((SELECT (parent_31.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_31 WHERE member_31.team_id = parent_31.team_id AND member_31.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_31 WHERE parent_31.id = item.parent_id LIMIT 1), FALSE) AS access_31,
+        COALESCE((SELECT (parent_32.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_32 WHERE member_32.team_id = parent_32.team_id AND member_32.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_32 WHERE parent_32.id = item.parent_id LIMIT 1), FALSE) AS access_32
+        FROM trace_wide_prop item
+      ) projected
+      WHERE projected.id = 1
+        AND (projected.archived IS NULL OR projected.archived = FALSE)
+      LIMIT 72
+    expect:
+      rows: 1
+      contains:
+        - "planner_total_ns"
+        - "logical_nodes"
+        - "group_stages"
 
   - name: "Independent nested scalar aggregates compile within a linear budget"
     max_time: 5.0


### PR DESCRIPTION
## Summary
- deduplicate alpha-equivalent correlated scalar stages after decorrelation
- canonicalize generated local/outer aliases and nested stage dependencies before comparing stage semantics
- merge projected aggregate columns onto the representative stage without globally deduplicating dependencies
- add an anonymized 32-projection compile-time regression with a one-second wall limit and a 500 ms planner limit

## Root cause
Repeated correlated projections were decorrelated into structurally equivalent stage graphs whose generated aliases and dependency IDs differed. The existing stage key therefore treated every graph as distinct. Recipe emission expanded all 32 copies even though they had identical input, correlation keys, filter condition, cardinality semantics, ordering, and aggregate execution shape.

The merge remains post-decorrelation and scope-local. Signatures include the full stage semantics and use bottom-up child signatures, while projected values are aligned onto the representative stage. Distinct conditions, ordering, limits, null/cardinality behavior, or query scopes do not merge.

## A/B measurement
Cold runs of the anonymous regression, same host and fresh data directories, comparing `origin/master` at `a6a3469d0` with this branch:

| Metric | master | PR | Change |
| --- | ---: | ---: | ---: |
| Planner total | 1817.9 ms | 247.9 ms | 7.3x faster |
| Recipe emission | 1699.1 ms | 115.1 ms | 14.8x faster |
| Measured compile total | 1941.2 ms | 380.1 ms | 5.1x faster |
| Request wall time | 2100.4 ms | 512.6 ms | 4.1x faster |
| Logical nodes | 37,954 | 1,591 | -95.8% |
| Query blocks | 33 | 2 | -93.9% |
| Group stages | 64 | 2 | -96.9% |
| Physical plan nodes | 20,290 | 20,290 | unchanged |
| Scans | 224 | 224 | unchanged |

The unchanged physical node/scan counts make the scope explicit: this PR removes redundant logical stage construction and compile work. Deduplicating the remaining equivalent physical probe code is a separate follow-up.

## Manual trace validation
A traced application build now completes its setup and initialization suites and reaches the next stage. That stage still exceeds its 120-second suite limit; its broad reminder-style query takes about 9.86 seconds and is the next isolated work package.

## Validation
- `python3 run_sql_tests.py tests/118_manual_trace_sql_regressions.yaml`: 21/21
- `python3 run_sql_tests.py tests/66_multi_table_dml.yaml`: 10/10
- full `./git-pre-commit`: passed before the conflict-free rebase onto `a6a3469d0`
- post-rebase build and targeted suites: passed
- `python3 tools/lint_scm.py`: completed; existing repository bracket warnings remain unchanged
