### PR TITLE
test: cover session corner cases

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -263,6 +263,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define prepared_lowering_catalog (make_lowering_catalog indexed_catalog_stages))
 	(assert (lowering_catalog? prepared_lowering_catalog) true
 		"physical preparation indexes stage catalogs above the measured crossover")
+	(assert (lowering_catalog? (make_lowering_catalog (cdr indexed_catalog_stages))) false
+		"physical preparation keeps exactly 24 stages on the list path")
 	(assert (equal? (gs_id (stage_for_output_relation prepared_lowering_catalog
 		(make_stage_output_relation "nested-catalog-stage"))) "nested-catalog-stage")
 		true "indexed physical catalog resolves stage-output relations")
@@ -287,8 +289,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"child lowering catalog resolves local stages")
 	(assert (equal? (gs_id (stage_by_id child_lowering_catalog "nested-catalog-stage")) "nested-catalog-stage") true
 		"child lowering catalog inherits root stage lookup")
+	(assert (equal? (gs_id (stage_for_carrier_source child_lowering_catalog outer_catalog_carrier_source))
+		"outer-catalog-stage") true
+		"child lowering catalog inherits root carrier lookup")
 	(assert (count (lowering_catalog_stages child_lowering_catalog)) (+ (count indexed_catalog_stages) 1)
 		"child lowering catalog exposes local and inherited stages without changing the root")
+	(define extended_list_catalog
+		(lowering_catalog_with_local_stages prepared_stage_lookup (list local_catalog_stage)))
+	(assert (lowering_catalog? extended_list_catalog) false
+		"local physical stages keep a small lowering catalog on the list path")
+	(assert (equal? (gs_id (stage_by_id extended_list_catalog "local-catalog-stage")) "local-catalog-stage") true
+		"extended list catalog resolves its local stage")
 	(assert (equal?
 		(stage_dependency_graph indexed_catalog_stages)
 		(stage_dependency_graph prepared_lowering_catalog))

--- a/scm/slice_alloc_test.go
+++ b/scm/slice_alloc_test.go
@@ -116,6 +116,29 @@ func TestOptimizeGeneratedConsChainToList(t *testing.T) {
 	}
 }
 
+func TestOptimizeGeneratedConsChainWithListTail(t *testing.T) {
+	expr := Read("generated cons chain with list tail", `(lambda (a b c) (cons a (cons b (list c 4))))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if strings.Contains(serialized, "cons") {
+		t.Fatalf("generated cons chain with list tail was not flattened: %s", serialized)
+	}
+
+	result := Apply(Eval(optimized, &Globalenv), NewInt(1), NewInt(2), NewInt(3))
+	expected := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3), NewInt(4)})
+	if !Equal(result, expected) {
+		t.Fatalf("unexpected result: got %s, want %s", String(result), String(expected))
+	}
+}
+
+func TestOptimizePreservesSetInNumberedLambda(t *testing.T) {
+	expr := Read("numbered set", `((lambda (counter) (!begin (set counter (+ counter 1)) counter) 1) 0)`)
+	got := Eval(Optimize(expr, &Globalenv), &Globalenv)
+	if ToInt(got) != 1 {
+		t.Fatalf("optimized numbered lambda returned %s, want 1", got.String())
+	}
+}
+
 func TestOptimizeImproperConsStaysCons(t *testing.T) {
 	expr := Read("improper cons", `(lambda (tail) (cons 1 tail))`)
 	optimized := Optimize(expr, &Globalenv)

--- a/tests/123_recset.yaml
+++ b/tests/123_recset.yaml
@@ -84,6 +84,34 @@ test_cases:
           "ok"
           (error "recset scan returned wrong row set")))
 
+  - name: "recset boundary statistics count candidates before residual filtering"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'recset_items'"
+      - scm: |
+          (begin
+            (define tbl (table "memcp-tests" "recset_items"))
+            (define rs (scan_recset nil tbl
+              '("tenant")
+              (lambda (tenant) (equal? tenant 1))))
+            (scan nil tbl
+              '("$recset_contains" "active")
+              (lambda (in_recset active) (and (in_recset rs) (equal? active 1)))
+              '("id")
+              (lambda (id) id)
+              (lambda (acc id) (+ acc id))
+              0))
+      - scm: '(sleep 0.1)'
+    sql: "SELECT inputCount, candidateCount, outputCount FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'recset_items' AND ordered = FALSE AND outputCount = 2 ORDER BY timestamp DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - inputCount: 5
+          candidateCount: 5
+          outputCount: 2
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
   - name: "$recset_contains probes current table row without exposing recid"
     scm: |
       (begin
@@ -166,6 +194,37 @@ test_cases:
         (if (equal? ordered (list (list 1) (list 5)))
           "ok"
           (error "scan_order $recset_contains returned wrong order")))
+
+  - name: "ordered recset scan statistics use recset cardinality"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'recset_items'"
+      - scm: |
+          (begin
+            (define tbl (table "memcp-tests" "recset_items"))
+            (define rs (scan_recset nil tbl
+              '("tenant")
+              (lambda (tenant) (equal? tenant 1))))
+            (scan_order nil rs
+              '("active")
+              (lambda (active) (equal? active 1))
+              '("id") '(<)
+              0 0 10
+              '("id")
+              (lambda (id) (list id))
+              (lambda (acc row) (append acc row))
+              '()
+              false))
+      - scm: '(sleep 0.1)'
+    sql: "SELECT inputCount, candidateCount, outputCount FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'recset_items' AND ordered = TRUE ORDER BY timestamp DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - inputCount: 3
+          candidateCount: 3
+          outputCount: 2
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
 
   - name: "scan_order keeps repeated $recset_contains calls exact"
     scm: |

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
 # IN with subquery tests
 
 metadata:
@@ -1307,6 +1309,57 @@ test_cases:
         - "inner_select"
         - "dependent-subquery"
         - ".grp:"
+
+  - name: "Grouped IN rejects an aggregate membership value"
+    sql: |
+      SELECT ID FROM in_fop_files
+      WHERE ID IN (
+        SELECT SUM(ID) FROM in_nullable_rhs
+        GROUP BY grp
+      )
+    expect:
+      error: true
+
+  - name: "Grouped IN rejects a correlated RHS"
+    sql: |
+      SELECT ID FROM in_fop_files f
+      WHERE ID IN (
+        SELECT grp FROM in_nullable_rhs r
+        WHERE r.ID >= f.ID
+        GROUP BY grp
+      )
+    expect:
+      error: true
+
+  - name: "Grouped IN rejects ordered limited membership"
+    sql: |
+      SELECT ID FROM in_fop_files
+      WHERE ID IN (
+        SELECT grp FROM in_nullable_rhs
+        GROUP BY grp
+        ORDER BY grp
+        LIMIT 1
+      )
+    expect:
+      error: true
+
+  - name: "Grouped NOT IN remains explicitly unsupported"
+    sql: |
+      SELECT ID FROM in_fop_files
+      WHERE ID NOT IN (
+        SELECT grp FROM in_nullable_rhs
+        GROUP BY grp
+      )
+    expect:
+      error: true
+
+  - name: "Projected grouped IN remains explicitly unsupported"
+    sql: |
+      SELECT ID,
+        ID IN (SELECT grp FROM in_nullable_rhs GROUP BY grp) AS grouped_match
+      FROM in_fop_files
+    expect:
+      error: true
 
   - name: "NOT IN subquery with RHS NULL projects UNKNOWN"
     sql: |

--- a/tests/76_range_scan_coverage.yaml
+++ b/tests/76_range_scan_coverage.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
 # Coverage tests for range scans, scan statistics logging, EXPLAIN (printer.go),
 # ordered scans with OFFSET/LIMIT, and aggregates with filters.
 # Exercises: storage/scan.go, storage/scan_order.go, storage/scan_helper.go,
@@ -68,6 +70,22 @@ test_cases:
         - inputCount: 200
           candidateCount: 1
           outputCount: 1
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
+  - name: "Unordered range scan distinguishes candidates from output rows"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data'"
+      - sql: "SELECT id FROM rs_data WHERE id BETWEEN 40 AND 49 AND MOD(id, 4) = 0"
+      - scm: '(sleep 0.1)'
+    sql: "SELECT inputCount, candidateCount, outputCount FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'rs_data' AND ordered = FALSE ORDER BY timestamp DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - inputCount: 200
+          candidateCount: 200
+          outputCount: 3
     cleanup:
       - scm: '(settings "ScanDebugging" false)'
 


### PR DESCRIPTION
## Was geändert wurde

- ergänzt explizite Must-fail-Regressionen für die neuen GROUP-IN-Grenzen
- deckt Listen-/Catalog-Grenzfälle bei 24/25 Lowering-Stages und geerbte Carrier-Lookups ab
- prüft Optimizer-Cons-Flattening mit List-Tail sowie veränderliche Bindings in nummerierten Lambdas
- prüft ungeordnete, geordnete und RecSet-basierte Scan-Statistiken mit getrennten Input-, Candidate- und Output-Zahlen

## Warum

Der Audit der in dieser TPC-H-Session gemergten Änderungen fand mehrere implementierte Corner Cases, die nur indirekt oder gar nicht als Regression festgehalten waren. Dieser PR ergänzt ausschließlich Tests; produktiver Code und TPC-H-Artefakte bleiben unberührt.

Die Raw-SQL-only-View-Fallback-Frage ist bewusst nicht enthalten, weil die aktuelle Speicherung die separate Spaltenaliasliste von `CREATE VIEW v(alias, ...)` nicht im Roh-SQL erhält und dafür zuerst die Repräsentationsentscheidung abgestimmt werden muss.

## Validierung

- vollständiger standardmäßiger Pre-commit-Hook, seriell: grün
- `tests/41_in_subquery.yaml`: 60/60
- `tests/76_range_scan_coverage.yaml`: 69/69
- `tests/123_recset.yaml`: 21/21
- fokussierte Go-Optimizer-Tests: grün
- Scheme-Formatter-Check: keine neuen Warnungen

Ein zusätzlicher Coverage-Vollhook lief funktional durch; drei bestehende 5-Sekunden-Grenzen wurden unter gleichzeitiger Fremdlast überschritten. Dieselben Dateien liefen anschließend unverändert isoliert mit 19/19 und 29/29 grün.