### PR TITLE
Deduplicate physical scalar probe recipes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5009,6 +5009,125 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 					(list (quote coalesceNil) raw_probe false)
 					raw_probe))))))
 
+/* Query-input scalar probes can occur in many projected fields after their
+logical stages have merged. Emit the physical probe recipe once per block and
+pass correlation keys to it instead of copying the complete recipe per field. */
+(define scalar_query_probe_recipe_key (lambda (stage requested_col)
+	(concat "__scalar_query_probe_" (fnv_hash (concat (gs_id stage) "\n" requested_col)))))
+
+(define scalar_query_probe_recipe_entry_add (lambda (state stage requested_col)
+	(if (not (query_block? (gs_input stage)))
+		state
+		(begin
+			(define key (scalar_query_probe_recipe_key stage requested_col))
+			(if (has_assoc? (nth state 1) key)
+				state
+				(list
+					(cons (list stage requested_col) (nth state 0))
+					(set_assoc (nth state 1) key true)))))))
+
+(define collect_scalar_query_probe_recipe_entries_acc (lambda (expr state)
+	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(scalar_query_probe_recipe_entry_add state stage requested_col)
+		((quote scalar_first_probe) stage requested_col)
+		(scalar_query_probe_recipe_entry_add state stage requested_col)
+		((symbol scalar_first_probe) stage requested_col _stages)
+		(scalar_query_probe_recipe_entry_add state stage requested_col)
+		((quote scalar_first_probe) stage requested_col _stages)
+		(scalar_query_probe_recipe_entry_add state stage requested_col)
+		(cons _head tail) (reduce tail (lambda (acc item)
+			(collect_scalar_query_probe_recipe_entries_acc item acc)) state)
+		_ state)))
+
+(define query_block_scalar_query_probe_recipe_entries (lambda (block)
+	(nth (collect_scalar_query_probe_recipe_entries_acc
+		(list
+			(qb_sources block)
+			(qb_fields block)
+			(qb_where block)
+			(qb_group block)
+			(qb_having block)
+			(qb_order block)
+			(qb_hidden block))
+		(list '() '())) 0)))
+
+(define scalar_query_probe_recipe_keys (lambda (entries)
+	(reduce entries (lambda (keys entry)
+		(match entry
+			'(stage requested_col) (set_assoc keys
+				(scalar_query_probe_recipe_key stage requested_col) true)
+			_ keys)) '())))
+
+(define rewrite_scalar_query_probe_recipe_expr (lambda (expr recipe_keys)
+	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(if (has_assoc? recipe_keys (scalar_query_probe_recipe_key stage requested_col))
+			(cons (symbol (scalar_query_probe_recipe_key stage requested_col))
+				(qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			expr)
+		((quote scalar_first_probe) stage requested_col)
+		(rewrite_scalar_query_probe_recipe_expr
+			(list (symbol "scalar_first_probe") stage requested_col) recipe_keys)
+		((symbol scalar_first_probe) stage requested_col _stages)
+		(rewrite_scalar_query_probe_recipe_expr
+			(list (symbol "scalar_first_probe") stage requested_col) recipe_keys)
+		((quote scalar_first_probe) stage requested_col _stages)
+		(rewrite_scalar_query_probe_recipe_expr
+			(list (symbol "scalar_first_probe") stage requested_col) recipe_keys)
+		(cons head tail) (cons head (map tail (lambda (item)
+			(rewrite_scalar_query_probe_recipe_expr item recipe_keys))))
+		_ expr)))
+
+(define rewrite_scalar_query_probe_recipe_source (lambda (src recipe_keys)
+	(source_with_join_expr src
+		(rewrite_scalar_query_probe_recipe_expr (source_join_expr src) recipe_keys))))
+
+(define query_block_with_scalar_query_probe_recipes (lambda (block entries)
+	(begin
+		(define recipe_keys (scalar_query_probe_recipe_keys entries))
+		(make_query_block
+			(qb_schema block)
+			(map (qb_sources block) (lambda (src)
+				(rewrite_scalar_query_probe_recipe_source src recipe_keys)))
+			(rewrite_scalar_query_probe_recipe_expr (qb_fields block) recipe_keys)
+			(rewrite_scalar_query_probe_recipe_expr (qb_where block) recipe_keys)
+			(rewrite_scalar_query_probe_recipe_expr (qb_group block) recipe_keys)
+			(rewrite_scalar_query_probe_recipe_expr (qb_having block) recipe_keys)
+			(rewrite_scalar_query_probe_recipe_expr (qb_order block) recipe_keys)
+			(qb_limit block)
+			(qb_offset block)
+			(rewrite_scalar_query_probe_recipe_expr (qb_hidden block) recipe_keys)
+			(qb_stages block)
+			(qb_facts block)))))
+
+(define scalar_query_probe_recipe_binding (lambda (all_stages entry)
+	(match entry
+		'(stage requested_col) (begin
+			(define raw_keys (gs_keys stage))
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define keys (if (empty_list? lookup_keys) '() raw_keys))
+			(if (not (equal? (count keys) (count lookup_keys)))
+				(neumann_fail "build_queryplan" "scalar query probe recipe key/domain mismatch")
+				true)
+			(define ag (scalar_first_probe_aggregate stage requested_col))
+			(if (nil? ag)
+				(neumann_fail "build_queryplan" "scalar query probe recipe references unknown aggregate column")
+				true)
+			(define value_expr (nth (scalar_first_probe_parts ag) 0))
+			(define params (map (produceN (count keys)) (lambda (i)
+				(symbol (concat "__probe_key_" i)))))
+			(list
+				(quote define)
+				(symbol (scalar_query_probe_recipe_key stage requested_col))
+				(list (quote lambda) params
+					(lower_scalar_first_query_probe_expr all_stages stage value_expr keys params))))
+		_ (neumann_fail "build_queryplan" "malformed scalar query probe recipe entry"))))
+
+(define scalar_query_probe_recipe_bindings (lambda (all_stages entries)
+	(map (coalesceNil entries '()) (lambda (entry)
+		(scalar_query_probe_recipe_binding all_stages entry)))))
+
 (define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages)
 	(begin
 		(if (not (scalar_or_presence_probe_stage? stage))
@@ -8561,31 +8680,48 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 	(query_block_stages_to_prepare_using (qb_stages block) block)))
 
 (define lower_query_block_with_cataloged_stages (lambda (block)
-	(if (empty_list? (qb_stages block))
-		(lower_query_block_core block)
-		(begin
-			(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
-				(lower_grouped_query_block_with_stages block)
-				(begin
-					(define fused_row_number (lower_fused_row_number_block block))
-					(if (not (nil? fused_row_number))
-						fused_row_number
-						(begin
-							(define stage_catalog (query_block_stage_catalog block))
-							(define stage_lookup (query_block_stage_lookup block))
-							(define eager_stages (query_block_stages_to_prepare_using stage_lookup block))
-							(define dependency_graph (stage_dependency_graph stage_lookup))
-							(define prepared_block (if (single_source? (qb_sources block))
-								(query_block_without_stages_after_prepare_using stage_lookup block)
-								(query_block_with_prepared_sources_using stage_lookup block)))
-							(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
-							(define core_block (query_block_with_stage_catalog prepared_block lazy_catalog))
-							(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
-							(cons (quote !begin)
-								(merge (list
-									(lazy_stage_prepare_bindings stage_catalog lazy_stages)
-									(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup eager_stages)
-									(list (lower_query_block_core core_block))))))))))))))
+	(begin
+		(define stage_lookup (query_block_stage_lookup block))
+		(if (empty_list? (qb_stages block))
+			(begin
+				(define probe_recipe_entries (query_block_scalar_query_probe_recipe_entries block))
+				(define recipe_block (query_block_with_scalar_query_probe_recipes block probe_recipe_entries))
+				(define probe_recipe_bindings
+					(scalar_query_probe_recipe_bindings stage_lookup probe_recipe_entries))
+				(if (empty_list? probe_recipe_bindings)
+					(lower_query_block_core recipe_block)
+					(cons (quote !begin) (merge (list
+						probe_recipe_bindings
+						(list (lower_query_block_core recipe_block)))))))
+			(begin
+				(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
+					(lower_grouped_query_block_with_stages block)
+					(begin
+						(define fused_row_number (lower_fused_row_number_block block))
+						(if (not (nil? fused_row_number))
+							fused_row_number
+							(begin
+								(define stage_catalog (query_block_stage_catalog block))
+								(define eager_stages (query_block_stages_to_prepare_using stage_lookup block))
+								(define dependency_graph (stage_dependency_graph stage_lookup))
+								(define raw_prepared_block (if (single_source? (qb_sources block))
+									(query_block_without_stages_after_prepare_using stage_lookup block)
+									(query_block_with_prepared_sources_using stage_lookup block)))
+								(define probe_recipe_entries
+									(query_block_scalar_query_probe_recipe_entries raw_prepared_block))
+								(define prepared_block
+									(query_block_with_scalar_query_probe_recipes raw_prepared_block probe_recipe_entries))
+								(define probe_recipe_bindings
+									(scalar_query_probe_recipe_bindings stage_lookup probe_recipe_entries))
+								(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
+								(define core_block (query_block_with_stage_catalog prepared_block lazy_catalog))
+								(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
+								(cons (quote !begin)
+									(merge (list
+										probe_recipe_bindings
+										(lazy_stage_prepare_bindings stage_catalog lazy_stages)
+										(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup eager_stages)
+										(list (lower_query_block_core core_block)))))))))))))))
 
 (define lower_query_block_with_stages (lambda (block)
 	(lower_query_block_with_cataloged_stages (query_block_with_full_stage_catalog block))))

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -658,6 +658,10 @@ class SQLTestRunner:
         if not isinstance(compile_phase_limits_ms, dict):
             return self._record_fail(name, "max_compile_phase_ms must be a mapping",
                                      query, None, None, is_noncritical)
+        compile_metric_limits = test_case.get("max_compile_metrics", {})
+        if not isinstance(compile_metric_limits, dict):
+            return self._record_fail(name, "max_compile_metrics must be a mapping",
+                                     query, None, None, is_noncritical)
         perf_rows = PERF_DEFAULT_ROWS  # default row count
         if is_perf_test:
             # Get baseline data if available
@@ -933,7 +937,7 @@ class SQLTestRunner:
 
             # Explicit cold planner budget. Unlike max_time, this reads the
             # compile-only phase metric before EXPLAIN warms the plan cache.
-            if ((planner_time_limit_ms > 0 or compile_phase_limits_ms)
+            if ((planner_time_limit_ms > 0 or compile_phase_limits_ms or compile_metric_limits)
                     and not is_perf_test and not is_sparql
                     and not test_case.get("expect", {}).get("error")):
                 qhead = query.lstrip().upper()
@@ -973,6 +977,23 @@ class SQLTestRunner:
                                 f"{phase_time_ms:.1f}ms > {limit_ms:.0f}ms",
                                 query, compile_resp, test_case.get("expect"), is_noncritical,
                                 phase_time_ms, limit_ms, diag,
+                            )
+                    for metric, limit_value in compile_metric_limits.items():
+                        if metric not in metrics:
+                            return self._record_fail(
+                                name, f"EXPLAIN COMPILE did not report metric {metric}",
+                                query, compile_resp, test_case.get("expect"), is_noncritical,
+                            )
+                        metric_value = float(metrics[metric])
+                        metric_limit = float(limit_value)
+                        if metric_value > metric_limit:
+                            diag = self._run_on_fail(test_case, database)
+                            return self._record_fail(
+                                name,
+                                f"Compile metric {metric} too large: "
+                                f"{metric_value:g} > {metric_limit:g}",
+                                query, compile_resp, test_case.get("expect"), is_noncritical,
+                                metric_value, metric_limit, diag,
                             )
 
             # Hard plan-size limit — the hardware-independent compile-time-blowup

--- a/tests/118_manual_trace_sql_regressions.yaml
+++ b/tests/118_manual_trace_sql_regressions.yaml
@@ -670,12 +670,18 @@ test_cases:
           archived: false
           can_view: true
 
-  - name: "Repeated correlated access projections compile within one second"
+  - name: "Repeated correlated access projections share physical recipes"
     max_time: 1.0
-    max_planner_time_ms: 500
-    max_plan_size: 240000
+    max_planner_time_ms: 800
+    max_compile_phase_ms:
+      recipe_emit_ns: 160
+    max_compile_metrics:
+      plan_nodes: 6000
+      scans: 64
+      group_carriers: 8
+    max_plan_size: 100000
     sql: |
-      EXPLAIN COMPILE SELECT projected.*
+      SELECT projected.*
       FROM (
         SELECT item.id, item.archived,
         COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_1 WHERE parent_1.id = item.parent_id LIMIT 1), FALSE) AS access_1,
@@ -717,10 +723,59 @@ test_cases:
       LIMIT 72
     expect:
       rows: 1
-      contains:
-        - "planner_total_ns"
-        - "logical_nodes"
-        - "group_stages"
+      data:
+        - id: 1
+          archived: false
+          access_1: true
+          access_2: true
+          access_3: true
+          access_4: true
+          access_5: true
+          access_6: true
+          access_7: true
+          access_8: true
+          access_9: true
+          access_10: true
+          access_11: true
+          access_12: true
+          access_13: true
+          access_14: true
+          access_15: true
+          access_16: true
+          access_17: true
+          access_18: true
+          access_19: true
+          access_20: true
+          access_21: true
+          access_22: true
+          access_23: true
+          access_24: true
+          access_25: true
+          access_26: true
+          access_27: true
+          access_28: true
+          access_29: true
+          access_30: true
+          access_31: true
+          access_32: true
+
+  - name: "Shared scalar probe recipes preserve correlation keys"
+    sql: |
+      SELECT item.id,
+        COALESCE((SELECT (parent_a.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_a WHERE member_a.team_id = parent_a.team_id AND member_a.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_a WHERE parent_a.id = item.parent_id LIMIT 1), FALSE) AS access_a,
+        COALESCE((SELECT (parent_b.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_b WHERE member_b.team_id = parent_b.team_id AND member_b.member_id = 7 LIMIT 1)) FROM trace_wide_parent parent_b WHERE parent_b.id = item.parent_id LIMIT 1), FALSE) AS access_b
+      FROM trace_wide_prop item
+      WHERE item.id IN (1, 2)
+      ORDER BY item.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          access_a: true
+          access_b: true
+        - id: 2
+          access_a: false
+          access_b: false
 
   - name: "Independent nested scalar aggregates compile within a linear budget"
     max_time: 5.0


### PR DESCRIPTION
## Summary

- emit each query-input scalar probe recipe once per physical query block
- pass correlation keys as recipe parameters instead of copying the complete scan and carrier subtree into every projected field
- add hardware-independent compile metric limits to YAML SQL tests
- verify that shared recipes preserve distinct outer correlation keys

## Root cause

Logical alpha-equivalent scalar stages were already merged, but physical lowering expanded every remaining `scalar_first_probe` marker independently. A wide projection therefore copied the same scan/carrier recipe once per output field. The logical plan stayed compact while recipe emission, serialization, and the executable plan grew with the projection width.

The new lowering step catalogs recipes by stable stage ID and requested output column after physical preparation. It emits one local parameterized function per recipe and rewrites probe sites to calls with their original lookup keys. It does not compare ASTs deeply and does not move this optimization across the logical/physical boundary.

## Test-first regression

On master, the anonymous 32-field correlated projection exceeded the new structural limits:

| Metric | Master |
|---|---:|
| plan nodes | 20,290 |
| plan bytes | 337,484 |
| scans | 224 |
| group carriers | 64 |

The test also validates all projected values and a separate two-row case verifies that shared recipes retain different correlation keys.

## A/B measurement

Five cold `EXPLAIN COMPILE` runs per revision, fresh processes and identical anonymous setup; values below are medians.

| Metric | Master | PR | Change |
|---|---:|---:|---:|
| recipe emission | 211.1 ms | 47.5 ms | -77.5% |
| planner total | 433.6 ms | 293.8 ms | -32.2% |
| measured total | 667.2 ms | 354.5 ms | -46.9% |
| plan nodes | 20,290 | 925 | -95.4% |
| plan bytes | 337,484 | 13,943 | -95.9% |
| scans | 224 | 7 | -96.9% |
| group carriers | 64 | 2 | -96.9% |

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all suites passed
- scalar-subselect pattern suite: 21/21 passed
- multi-table DML suite: 10/10 passed
- anonymous manual-trace regression suite: correctness and structural recipe limits passed
- Scheme formatter/check and Python bytecode validation passed

A concurrent large-application manual run reached phase 1, with 6/19 browser suites passing. Remaining failures were browser navigation, upload, popup, and one five-minute UI-worker timeout.

Trace grouping confirms that the remaining SQL delays are cold compilation, not cached execution:

| Anonymous query shape | Cold/contended | Warm | SQL size |
|---|---:|---:|---:|
| broad document-list projection | 26.286 s | 0.015 s | 72.6 KB |
| multi-branch file-reference check | 22.869 s | 0.538 s | 12.8 KB |

The complete manual is therefore not yet clean. These two distinct compile shapes remain follow-up work rather than being hidden by this PR.