### PR TITLE
Number safe Scheme local bindings

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -374,10 +374,9 @@ func scmerSlice(v Scmer) ([]Scmer, bool) {
 	return nil, false
 }
 
-// expressionContainsEvalCall conservatively detects runtime eval usage.
-// If a lambda body calls eval, parameter symbol bindings must remain name-based
-// so eval can resolve them from lexical scope.
-func expressionContainsEvalCall(v Scmer) bool {
+// expressionContainsDynamicSyntaxCall detects forms that interpret an AST in
+// their lexical environment. Symbols reachable by these forms must stay named.
+func expressionContainsDynamicSyntaxCall(v Scmer) bool {
 	if stripped, ok := scmerStripSourceInfo(v); ok {
 		v = stripped
 	}
@@ -386,7 +385,7 @@ func expressionContainsEvalCall(v Scmer) bool {
 		return false
 	}
 	if head, ok := scmerSymbol(list[0]); ok {
-		if head == Symbol("eval") {
+		if head == Symbol("eval") || head == Symbol("import") || head == Symbol("parser") {
 			return true
 		}
 		if head == Symbol("quote") {
@@ -394,32 +393,7 @@ func expressionContainsEvalCall(v Scmer) bool {
 		}
 	}
 	for _, item := range list {
-		if expressionContainsEvalCall(item) {
-			return true
-		}
-	}
-	return false
-}
-
-// expressionContainsEvalOrImportCall conservatively detects runtime eval/import usage.
-func expressionContainsEvalOrImportCall(v Scmer) bool {
-	if stripped, ok := scmerStripSourceInfo(v); ok {
-		v = stripped
-	}
-	list, ok := scmerSlice(v)
-	if !ok || len(list) == 0 {
-		return false
-	}
-	if head, ok := scmerSymbol(list[0]); ok {
-		if head == Symbol("eval") || head == Symbol("import") {
-			return true
-		}
-		if head == Symbol("quote") {
-			return false
-		}
-	}
-	for _, item := range list {
-		if expressionContainsEvalOrImportCall(item) {
+		if expressionContainsDynamicSyntaxCall(item) {
 			return true
 		}
 	}
@@ -543,6 +517,13 @@ func canEliminateFromBegin(val Scmer) bool {
 	return true // constant value, safe to eliminate
 }
 
+type localBindingFacts struct {
+	defineIdx int
+	firstUse  int
+	count     int
+	used      bool
+}
+
 func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {
 	var transferOwnership, isConstant bool
 	if len(v) == 0 {
@@ -590,9 +571,45 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		usedVariables := make(map[Symbol]int)
 		variableContent := make(map[Symbol]Scmer)
-		// Track top-level define positions and earliest top-level eval/import index
-		defineTopIdx := make(map[Symbol]int)
-		earliestEvalImport := -1
+		bindings := make(map[Symbol]localBindingFacts)
+		bindingOrder := make([]Symbol, 0)
+		earliestDynamicSyntax := -1
+		currentTopIdx := 0
+		for i := bodyStart; i < len(v); i++ {
+			expr := v[i]
+			if stripped, ok := scmerStripSourceInfo(expr); ok {
+				expr = stripped
+			}
+			if sub, ok := scmerSlice(expr); ok && len(sub) > 0 {
+				headExpr := sub[0]
+				if stripped, ok := scmerStripSourceInfo(headExpr); ok {
+					headExpr = stripped
+				}
+				if head, ok := scmerSymbol(headExpr); ok {
+					if (head == Symbol("define") || head == Symbol("set")) && len(sub) >= 3 {
+						if sym, ok := scmerSymbol(sub[1]); ok {
+							facts := bindings[sym]
+							if facts.count == 0 {
+								bindingOrder = append(bindingOrder, sym)
+							}
+							facts.defineIdx = i
+							facts.count++
+							bindings[sym] = facts
+						}
+					}
+					if head == Symbol("eval") || head == Symbol("import") {
+						if earliestDynamicSyntax == -1 || i < earliestDynamicSyntax {
+							earliestDynamicSyntax = i
+						}
+					}
+				}
+				if expressionContainsDynamicSyntaxCall(expr) {
+					if earliestDynamicSyntax == -1 || i < earliestDynamicSyntax {
+						earliestDynamicSyntax = i
+					}
+				}
+			}
+		}
 		var visitNode func(x Scmer, depth int, blacklist []Symbol)
 		visitNode = func(x Scmer, depth int, blacklist []Symbol) {
 			if stripped, ok := scmerStripSourceInfo(x); ok {
@@ -662,6 +679,11 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 					}
 				}
 				if !isBlacklisted {
+					if facts, tracked := bindings[sym]; tracked && !facts.used {
+						facts.firstUse = currentTopIdx
+						facts.used = true
+						bindings[sym] = facts
+					}
 					if depth > 0 {
 						usedVariables[sym] = 100
 					} else {
@@ -671,35 +693,8 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 		}
 		for i := bodyStart; i < len(v); i++ {
+			currentTopIdx = i
 			visitNode(v[i], 0, nil)
-			// Scan top-level statement order for define/set and eval/import safeguards
-			expr := v[i]
-			if stripped, ok := scmerStripSourceInfo(expr); ok {
-				expr = stripped
-			}
-			if sub, ok := scmerSlice(expr); ok && len(sub) > 0 {
-				headExpr := sub[0]
-				if stripped, ok := scmerStripSourceInfo(headExpr); ok {
-					headExpr = stripped
-				}
-				if head, ok := scmerSymbol(headExpr); ok {
-					if (head == Symbol("define") || head == Symbol("set")) && len(sub) >= 3 {
-						if sym, ok := scmerSymbol(sub[1]); ok {
-							defineTopIdx[sym] = i
-						}
-					}
-					if head == Symbol("eval") || head == Symbol("import") {
-						if earliestEvalImport == -1 || i < earliestEvalImport {
-							earliestEvalImport = i
-						}
-					}
-				}
-				if expressionContainsEvalOrImportCall(expr) {
-					if earliestEvalImport == -1 || i < earliestEvalImport {
-						earliestEvalImport = i
-					}
-				}
-			}
 		}
 		ome2 := ome.CopySharedScope()
 		ome2.beginDepth++
@@ -734,24 +729,45 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 					shouldReplace = false
 				}
 				// Safeguard: if RHS references a symbol that is defined at top-level in this begin, do not inline
-				if _, ok := defineTopIdx[mustSymbol(normalized)]; ok {
+				if _, ok := bindings[mustSymbol(normalized)]; ok {
 					shouldReplace = false
 				}
 			}
-			// Safeguard: if a top-level eval/import appears anywhere in this begin,
+			// Safeguard: if a dynamic syntax form appears anywhere in this begin,
 			// keep all bindings explicit. eval can resolve dynamically-built symbols
 			// against lexical scope, so partial inlining is unsafe.
-			if earliestEvalImport >= 0 {
+			if earliestDynamicSyntax >= 0 {
 				shouldReplace = false
 			}
 			if shouldReplace {
 				delete(variableContent, sym)
 				delete(usedVariables, sym)
+				delete(bindings, sym)
 				ome2.setBlacklist = append(ome2.setBlacklist, sym)
 				ome2.variableReplacement[sym] = content
 			}
 		}
-		if len(usedVariables) == 0 && len(defineTopIdx) == 0 {
+		var numberedLocals map[Symbol]Scmer
+		if earliestDynamicSyntax < 0 && ome2.nextSlot != nil {
+			for _, sym := range bindingOrder {
+				if _, retained := variableContent[sym]; !retained {
+					continue
+				}
+				facts := bindings[sym]
+				if facts.count != 1 || (facts.used && facts.firstUse <= facts.defineIdx) || *ome2.nextSlot >= 256 {
+					continue
+				}
+				if numberedLocals == nil {
+					numberedLocals = make(map[Symbol]Scmer)
+				}
+				slot := NewNthLocalVar(NthLocalVar(*ome2.nextSlot))
+				*ome2.nextSlot++
+				numberedLocals[sym] = slot
+				delete(usedVariables, sym)
+				delete(bindings, sym)
+			}
+		}
+		if len(usedVariables) == 0 && len(bindings) == 0 {
 			v[0] = NewSymbol("!begin")
 			for sym, content := range ome2.variableReplacement {
 				if slice, ok := scmerSlice(content); ok && len(slice) == 2 && scmerIsSymbol(slice[0], "outer") {
@@ -760,6 +776,17 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 		}
 		for i := bodyStart; i < len(v); i++ {
+			expr := v[i]
+			if stripped, ok := scmerStripSourceInfo(expr); ok {
+				expr = stripped
+			}
+			if items, ok := scmerSlice(expr); ok && len(items) == 3 && (scmerIsSymbol(items[0], "define") || scmerIsSymbol(items[0], "set")) {
+				if sym, ok := scmerSymbol(items[1]); ok {
+					if slot, numbered := numberedLocals[sym]; numbered {
+						ome2.variableReplacement[sym] = slot
+					}
+				}
+			}
 			var constant bool
 			v[i], transferOwnership, constant = optimizeExCompat(v[i], env, &ome2, i == len(v)-1 && useResult)
 			if constant {
@@ -827,9 +854,9 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		if stripped, ok := scmerStripSourceInfo(params); ok {
 			params = stripped
 		}
-		// Keep lambdas with eval conservative: eval relies on symbol lookup in
-		// current lexical scope and cannot see NthLocalVar-only parameters.
-		if expressionContainsEvalCall(v[2]) {
+		// Dynamic syntax forms rely on symbol lookup in the current lexical scope
+		// and cannot see NthLocalVar-only parameters.
+		if expressionContainsDynamicSyntaxCall(v[2]) {
 			ome2 := ome.Copy()
 			ome2.lambdaDepth++
 			for sym := range assigned {
@@ -859,6 +886,8 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				delete(ome2.variableReplacement, sym)
 			}
 			numVars := int(ToInt(v[3]))
+			slotIndex := numVars
+			ome2.nextSlot = &slotIndex
 			if list, ok := scmerSlice(params); ok {
 				for i, param := range list {
 					if i >= numVars {
@@ -873,6 +902,9 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 			var bodyType TypeInfo
 			v[2], bodyType = OptimizeEx(v[2], env, &ome2, true)
+			if slotIndex != numVars {
+				v[3] = NewInt(int64(slotIndex))
+			}
 			return NewSlice(v), bodyType.WithoutConst()
 		}
 		// Auto-number parameters

--- a/scm/slice_alloc_test.go
+++ b/scm/slice_alloc_test.go
@@ -135,6 +135,199 @@ func TestOptimizePreservesSetAndReadInNestedLambda(t *testing.T) {
 	}
 }
 
+func TestOptimizeNumbersRepeatedLocalBinding(t *testing.T) {
+	expr := Read("numbered local", `(lambda (value)
+		(begin
+			(define doubled (+ value value))
+			(+ doubled doubled)))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if strings.Contains(serialized, "define doubled") {
+		t.Fatalf("repeated local binding stayed symbolic: %s", serialized)
+	}
+	if !strings.Contains(serialized, "setN") {
+		t.Fatalf("repeated local binding did not get a numbered slot: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(3)); ToInt(got) != 12 {
+		t.Fatalf("optimized local binding returned %s, want 12", String(got))
+	}
+}
+
+func TestOptimizeNumbersLocalBindingsDeterministically(t *testing.T) {
+	source := `(lambda (value)
+		(begin
+			(define first (+ value 1))
+			(define second (+ value 2))
+			(+ first first second second)))`
+	want := serializeSliceAllocTestExpr(t, Optimize(Read("numbered local reference", source), &Globalenv))
+	for i := 0; i < 100; i++ {
+		got := serializeSliceAllocTestExpr(t, Optimize(Read("numbered local repeat", source), &Globalenv))
+		if got != want {
+			t.Fatalf("numbered local slots changed between runs:\nwant %s\n got %s", want, got)
+		}
+	}
+}
+
+func TestOptimizeExtendsExplicitNumVarsForLocalBinding(t *testing.T) {
+	expr := Read("numbered local explicit frame", `(lambda (value)
+		(begin
+			(define doubled (+ value value))
+			(+ doubled doubled))
+		1)`)
+	optimized := Optimize(expr, &Globalenv)
+	items := optimized.Slice()
+	if len(items) != 4 || ToInt(items[3]) != 2 {
+		t.Fatalf("explicit frame was not extended for local binding: %s", serializeSliceAllocTestExpr(t, optimized))
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(4)); ToInt(got) != 16 {
+		t.Fatalf("optimized explicit-frame binding returned %s, want 16", String(got))
+	}
+}
+
+func TestOptimizeKeepsEvalVisibleBindingNamed(t *testing.T) {
+	expr := Read("dynamic local", `(lambda (value)
+		(begin
+			(define dynamic_value (+ value value))
+			(+ dynamic_value (eval 'dynamic_value))))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "define dynamic_value") {
+		t.Fatalf("eval-visible local binding was numbered: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(5)); ToInt(got) != 20 {
+		t.Fatalf("optimized eval-visible binding returned %s, want 20", String(got))
+	}
+}
+
+func TestOptimizeKeepsParserVisibleBindingNamed(t *testing.T) {
+	expr := Read("dynamic parser local", `(lambda ()
+		(begin
+			(define parser_rule (parser (atom "FOO" true) "inner"))
+			(define parser_value (parser parser_rule "ok"))
+			(list parser_rule parser_value)))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "define parser_rule") {
+		t.Fatalf("parser-visible local binding was numbered: %s", serialized)
+	}
+	result := Apply(Eval(optimized, &Globalenv))
+	if len(result.Slice()) != 2 || !result.Slice()[1].IsParser() {
+		t.Fatalf("optimized parser-visible binding returned %s", String(result))
+	}
+}
+
+func TestOptimizeKeepsForwardReferencedBindingNamed(t *testing.T) {
+	expr := Read("forward local", `(lambda (value)
+		(begin
+			(define read_later (lambda () later))
+			(define later (+ value value))
+			(+ (read_later) later)))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "define later") {
+		t.Fatalf("forward-referenced local binding was numbered: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(6)); ToInt(got) != 24 {
+		t.Fatalf("optimized forward binding returned %s, want 24", String(got))
+	}
+}
+
+func TestOptimizeKeepsInitializerReferenceNamed(t *testing.T) {
+	expr := Read("initializer local", `(lambda (value)
+		(begin
+			(define current (+ current value))
+			current))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "define current") {
+		t.Fatalf("initializer-referenced local binding was numbered: %s", serialized)
+	}
+}
+
+func TestOptimizeKeepsMultiplyDefinedBindingNamed(t *testing.T) {
+	expr := Read("redefined local", `(lambda (value)
+		(begin
+			(define current (+ value 1))
+			(define before current)
+			(set current (+ value 2))
+			(+ before current)))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "define current") || !strings.Contains(serialized, "set current") {
+		t.Fatalf("multiply defined local binding was numbered: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(3)); ToInt(got) != 9 {
+		t.Fatalf("optimized redefined binding returned %s, want 9", String(got))
+	}
+}
+
+func TestOptimizeNumberedLocalSurvivesClosureCapture(t *testing.T) {
+	expr := Read("captured numbered local", `(lambda (value)
+		(begin
+			(define doubled (+ value value))
+			(define read_doubled (lambda () doubled))
+			(+ doubled (read_doubled))))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "setN") || !strings.Contains(serialized, "outer") {
+		t.Fatalf("captured local did not use a numbered outer slot: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(7)); ToInt(got) != 28 {
+		t.Fatalf("optimized captured binding returned %s, want 28", String(got))
+	}
+}
+
+func TestOptimizeNumbersLocalInsideBeginMutReserve(t *testing.T) {
+	expr := Read("begin mut local", `(lambda (value)
+		(begin_mut 1
+			(define doubled (+ value value))
+			(+ doubled doubled)))`)
+	optimized := Optimize(expr, &Globalenv)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "setN") {
+		t.Fatalf("begin_mut local binding was not numbered: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(8)); ToInt(got) != 32 {
+		t.Fatalf("optimized begin_mut binding returned %s, want 32", String(got))
+	}
+}
+
+func benchmarkRepeatedLocalBindings(b *testing.B, serial bool) {
+	expr := Read("numbered local benchmark", `(lambda (value)
+		(begin
+			(define v0 (+ value 1))
+			(define v1 (+ value 2))
+			(define v2 (+ value 3))
+			(define v3 (+ value 4))
+			(define v4 (+ value 5))
+			(define v5 (+ value 6))
+			(define v6 (+ value 7))
+			(define v7 (+ value 8))
+			(+ v0 v0 v1 v1 v2 v2 v3 v3 v4 v4 v5 v5 v6 v6 v7 v7)))`)
+	proc := Eval(Optimize(expr, &Globalenv), &Globalenv)
+	value := NewInt(3)
+	b.ReportAllocs()
+	b.ResetTimer()
+	if serial {
+		fn := OptimizeProcToSerialFunction(proc)
+		for i := 0; i < b.N; i++ {
+			fn(value)
+		}
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		Apply(proc, value)
+	}
+}
+
+func BenchmarkRepeatedLocalBindingsApply(b *testing.B) {
+	benchmarkRepeatedLocalBindings(b, false)
+}
+
+func BenchmarkRepeatedLocalBindingsSerial(b *testing.B) {
+	benchmarkRepeatedLocalBindings(b, true)
+}
+
 func benchmarkGeneratedConsChain(b *testing.B, width int) {
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
## Summary
- lower retained, single-assignment local Scheme bindings to numbered frame slots
- extend existing numbered lambda frames deterministically in source order
- preserve named lookup for dynamic syntax (`eval`, `import`, and `parser`), forward references, redefinitions, and unsupported frame sizes
- remove the per-call symbolic `Vars` map when a begin frame becomes fully numbered

## Root cause
Lambda parameters already use numbered frame slots, but repeated local `define`/`set` values remained name-based. Every invocation therefore allocated and populated a lexical name map and repeatedly resolved symbols even when the binding was statically scoped and assigned once.

The optimizer now gathers local-binding facts once, assigns safe slots in source order, and activates each replacement only at its definition. This keeps closure capture and statement ordering intact. Dynamic AST interpreters remain conservative because they resolve lexical symbols by name.

## Correctness gates
Numbering is skipped when a binding:
- has multiple definitions
- is referenced before its definition
- is reachable from dynamic syntax
- has no numbered frame or would exceed the 8-bit slot representation

The physical SQL plan remains unchanged: a 303,763-byte application plan was byte-identical between master and this branch.

## A/B performance
Baseline: `a712c61ef95c5de8d0254e871fb2c4b3f96db378`; AMD Ryzen 9 7900X3D; ten samples, medians.

| benchmark | master | branch | change | allocations |
|---|---:|---:|---:|---:|
| repeated locals, normal Apply | 2,872 ns/op | 2,466 ns/op | -14.1% | 75 -> 74 |
| repeated locals, serial call | 2,753 ns/op | 2,087 ns/op | -24.2% | 71 -> 70 |

Existing optimizer benchmarks showed no systematic regression (median changes ranged from +1.8% to -5.0%).

Large real-plan compile A/B, five samples:
- master compile median: 928.08 ms
- branch compile median: 926.82 ms (-0.1%, neutral)
- plan size: 177,980 bytes / 12,868 nodes on both

Application manual suite, three successful runs per MemCP variant:
- master: 73.76 / 73.76 / 80.30 s, median 73.76 s
- branch: 75.77 / 73.70 / 72.70 s, median 73.70 s (-0.1%, neutral)
- same-host MySQL reference from the preceding controlled suite: 56.76 / 65.99 / 66.03 s, median 65.99 s

The end-to-end suite does not spend enough time in this binding shape to expose the microbenchmark gain. This PR claims a targeted operator-runtime improvement, not a general manual-suite speedup.

A separate large aggregate query timed out at 120 s on both revisions. Its planner hotpath is unaffected by this change.

## Validation
- `go test ./scm`
- `go test -race ./scm`
- focused SQL suites for IN/subqueries, range plans, traced regressions, triggers, and trigger scope
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`
- `git diff --check`

All passed.