### PR TITLE
optimizer: hoist invariant scan filter branches

### DIFF
--- a/storage/scan.go
+++ b/storage/scan.go
@@ -69,6 +69,9 @@ func optimizeScanShared(v []scm.Scmer, oc *scm.OptimizerContext, mapEnd, reduceI
 }
 
 func optimizeScan(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
+		return oc.OptimizeSub(rewritten, useResult)
+	}
 	if rewritten := tryScanExistsRewrite(v); !rewritten.IsNil() {
 		return oc.OptimizeSub(rewritten, useResult)
 	}
@@ -76,6 +79,104 @@ func optimizeScan(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.
 		return oc.OptimizeSub(rewritten, useResult)
 	}
 	return optimizeScanShared(v, oc, 6, 7, 8, 9, 10)
+}
+
+// tryScanInvariantFilterRewrite selects a row-independent IF branch once per
+// scan invocation instead of evaluating it for every candidate row.
+func tryScanInvariantFilterRewrite(v []scm.Scmer) scm.Scmer {
+	// scan and scan_order share tx/table/filtercols/filterfn at indices 1..4.
+	if len(v) < 5 {
+		return scm.NewNil()
+	}
+	lambda, ok := scmerSlice(v[4])
+	if !ok || len(lambda) < 3 || !scanSymbolIs(lambda[0], "lambda") {
+		return scm.NewNil()
+	}
+	_, body, ok := scanLambdaParts(v[4])
+	if !ok {
+		return scm.NewNil()
+	}
+
+	wrappedOptimize := false
+	if bodyItems, bodyOK := scmerSlice(body); bodyOK && len(bodyItems) == 2 && scanSymbolIs(bodyItems[0], "optimize") {
+		wrappedOptimize = true
+		body = bodyItems[1]
+	}
+	conditional, ok := scmerSlice(body)
+	if !ok || len(conditional) != 4 || !scanSymbolIs(conditional[0], "if") {
+		return scm.NewNil()
+	}
+	condition := conditional[1]
+	if !scanExprSafeToHoist(condition, false) {
+		return scm.NewNil()
+	}
+
+	makeBranch := func(branch scm.Scmer) scm.Scmer {
+		if wrappedOptimize {
+			branch = scm.NewSlice([]scm.Scmer{scm.NewSymbol("optimize"), branch})
+		}
+		branchLambda := append([]scm.Scmer(nil), lambda...)
+		branchLambda[2] = branch
+		return scm.NewSlice(branchLambda)
+	}
+
+	rewritten := append([]scm.Scmer(nil), v...)
+	rewritten[4] = scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("if"),
+		scanLiftOutOfLambda(condition),
+		makeBranch(conditional[2]),
+		makeBranch(conditional[3]),
+	})
+	return scm.NewSlice(rewritten)
+}
+
+func scanExprSafeToHoist(expr scm.Scmer, belowOuter bool) bool {
+	if expr.IsNthLocalVar() {
+		return belowOuter
+	}
+	if _, ok := scanSymbolName(expr); ok {
+		return false
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 {
+		return true
+	}
+	if scanSymbolIs(items[0], "quote") {
+		return true
+	}
+	if scanSymbolIs(items[0], "outer") {
+		return len(items) == 2 && scanExprSafeToHoist(items[1], true)
+	}
+	name, named := scanSymbolName(items[0])
+	if !named {
+		return false
+	}
+	switch name {
+	case "session", "equal?", "equal??", "nil?", "not", "and", "or", "coalesceNil", "bool?", "int?", "float?", "string?", "<", "<=", ">", ">=":
+	default:
+		return false
+	}
+	for _, item := range items[1:] {
+		if !scanExprSafeToHoist(item, belowOuter) {
+			return false
+		}
+	}
+	return true
+}
+
+func scanLiftOutOfLambda(expr scm.Scmer) scm.Scmer {
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 || scanSymbolIs(items[0], "quote") {
+		return expr
+	}
+	if scanSymbolIs(items[0], "outer") && len(items) == 2 {
+		return items[1]
+	}
+	lifted := make([]scm.Scmer, len(items))
+	for i, item := range items {
+		lifted[i] = scanLiftOutOfLambda(item)
+	}
+	return scm.NewSlice(lifted)
 }
 
 func tryScanExistsRewrite(v []scm.Scmer) scm.Scmer {
@@ -245,6 +346,9 @@ func scanExprMayHaveSideEffects(v scm.Scmer) bool {
 }
 
 func optimizeScanBatch(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
+		return oc.OptimizeSub(rewritten, useResult)
+	}
 	return optimizeScanShared(v, oc, 8, 9, 10, 11, 12)
 }
 

--- a/storage/scan_invariant_filter_test.go
+++ b/storage/scan_invariant_filter_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func scanHoistTestCall(condition scm.Scmer) []scm.Scmer {
+	row := scm.NewNthLocalVar(0)
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("optimize"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("if"),
+			condition,
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol(">"), row, scm.NewInt(10)}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("<"), row, scm.NewInt(0)}),
+		}),
+	})
+	filter := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("lambda"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("row")}),
+		body,
+		scm.NewInt(1),
+	})
+	return []scm.Scmer{
+		scm.NewSymbol("scan"), scm.NewNil(), scm.NewSymbol("table_value"),
+		scm.NewSlice([]scm.Scmer{scm.NewString("value")}), filter,
+		scm.NewSlice([]scm.Scmer{scm.NewString("value")}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice([]scm.Scmer{scm.NewSymbol("row")}), row, scm.NewInt(1)}),
+		scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewBool(false),
+	}
+}
+
+func TestScanHoistsInvariantFilterCondition(t *testing.T) {
+	condition := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("outer"), scm.NewNthLocalVar(2)}),
+		scm.NewInt(1),
+	})
+	rewritten := tryScanInvariantFilterRewrite(scanHoistTestCall(condition))
+	if rewritten.IsNil() {
+		t.Fatal("invariant filter condition was not hoisted")
+	}
+	serialized := scm.SerializeToString(rewritten, &scm.Globalenv)
+	if !strings.Contains(serialized, "(if (equal?? (var 2) 1) (lambda") {
+		t.Fatalf("condition was not lifted out of the lambda frame: %s", serialized)
+	}
+	if strings.Contains(serialized, "(outer (var 2))") {
+		t.Fatalf("lifted condition retained the inner lambda's outer hop: %s", serialized)
+	}
+}
+
+func TestScanKeepsRowDependentFilterConditionInsideLambda(t *testing.T) {
+	condition := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"), scm.NewNthLocalVar(0), scm.NewInt(1),
+	})
+	if rewritten := tryScanInvariantFilterRewrite(scanHoistTestCall(condition)); !rewritten.IsNil() {
+		t.Fatalf("row-dependent condition was hoisted: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func TestScanKeepsEffectfulFilterConditionInsideLambda(t *testing.T) {
+	condition := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("scan_exists"), scm.NewNil(), scm.NewSymbol("other_table"),
+		scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(nil), scm.NewBool(true)}),
+	})
+	if rewritten := tryScanInvariantFilterRewrite(scanHoistTestCall(condition)); !rewritten.IsNil() {
+		t.Fatalf("table-reading condition was hoisted: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func TestScanKeepsPotentiallyFailingFilterConditionInsideLambda(t *testing.T) {
+	condition := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("/"), scm.NewInt(1), scm.NewInt(0),
+	})
+	if rewritten := tryScanInvariantFilterRewrite(scanHoistTestCall(condition)); !rewritten.IsNil() {
+		t.Fatalf("potentially failing condition was hoisted: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func TestScanKeepsUnknownBindingInsideLambda(t *testing.T) {
+	condition := scm.NewSymbol("unknown_binding")
+	if rewritten := tryScanInvariantFilterRewrite(scanHoistTestCall(condition)); !rewritten.IsNil() {
+		t.Fatalf("unknown binding was hoisted: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func BenchmarkScanInvariantFilterDispatch(b *testing.B) {
+	condition := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	trueBranch := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(args[0].Int() >= 500)
+	})
+	falseBranch := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(args[0].Int() < 500)
+	})
+	perRow := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		if scm.ToBool(scm.Apply(condition)) {
+			return scm.Apply(trueBranch, args...)
+		}
+		return scm.Apply(falseBranch, args...)
+	})
+	rows := make([]scm.Scmer, 1000)
+	for i := range rows {
+		rows[i] = scm.NewInt(int64(i))
+	}
+
+	b.Run("per_row_if", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, row := range rows {
+				scm.Apply(perRow, row)
+			}
+		}
+	})
+	b.Run("hoisted_if", func(b *testing.B) {
+		selected := falseBranch
+		if scm.ToBool(scm.Apply(condition)) {
+			selected = trueBranch
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, row := range rows {
+				scm.Apply(selected, row)
+			}
+		}
+	})
+}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -50,6 +50,9 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 }
 
 func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
+		return oc.OptimizeSub(rewritten, useResult)
+	}
 	// NOTE: scan_order has no reduce2, so batch-rewrite cannot flush the last
 	// partial batch. Disabled until scan_order gains reduce2 or an alternative
 	// flush mechanism is implemented.

--- a/tests/60_case_coalesce_nullif.yaml
+++ b/tests/60_case_coalesce_nullif.yaml
@@ -24,6 +24,51 @@ setup:
 
 test_cases:
 
+  - name: "Set invariant CASE filter to true branch"
+    session_id: "ccn_invariant_filter"
+    sql: "SET @ccn_filter_mode = 1"
+
+  - name: "CASE filter with invariant session condition uses true branch"
+    session_id: "ccn_invariant_filter"
+    sql: |
+      SELECT id FROM ccn_data
+      WHERE CASE WHEN @ccn_filter_mode = 1 THEN amount >= 200 ELSE amount >= 100 AND amount < 200 END
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 2
+        - id: 6
+
+  - name: "Switch invariant CASE filter to false branch"
+    session_id: "ccn_invariant_filter"
+    sql: "SET @ccn_filter_mode = 0"
+
+  - name: "CASE filter with invariant session condition uses false branch"
+    session_id: "ccn_invariant_filter"
+    sql: |
+      SELECT id FROM ccn_data
+      WHERE CASE WHEN @ccn_filter_mode = 1 THEN amount >= 200 ELSE amount >= 100 AND amount < 200 END
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+        - id: 7
+
+  - name: "EXPLAIN hoists invariant CASE dispatch outside scan filter"
+    session_id: "ccn_invariant_filter"
+    sql: |
+      EXPLAIN SELECT id FROM ccn_data
+      WHERE CASE WHEN @ccn_filter_mode = 1 THEN amount >= 200 ELSE amount >= 100 AND amount < 200 END
+      ORDER BY id
+    expect:
+      rows: 1
+      result_contains:
+        - '\n\t(if\n'
+      result_not_contains:
+        - '(optimize\n\t\t\t(if'
+
   # === Simple CASE WHEN ===
 
   - name: "CASE with literal comparison"


### PR DESCRIPTION
## Problem

Cached physical plans can contain scan filters whose top-level `if` depends only on session or outer values. The condition and branch dispatch then run once per candidate row even though the selected branch is invariant for the scan invocation.

## Change

Add a conservative physical optimizer rewrite for `scan`, `scan_batch`, and `scan_order`:

```scheme
(scan ... (lambda (row) (if invariant A(row) B(row))) ...)
```

becomes:

```scheme
(scan ... (if invariant (lambda (row) A(row)) (lambda (row) B(row))) ...)
```

Both branches remain in the cached plan. Session values are not folded into the plan, and the logical planner is unchanged. The rewrite only accepts a small allowlist of total, read-only conditions and rejects row-local dependencies, table reads, unknown calls/bindings, nested lambdas, and potentially failing arithmetic.

`scan_order_multi` is intentionally excluded because selecting combinations of multiple filter lambdas needs its own cost and code-size policy.

## Test first

The new SQL regression failed on unchanged master because EXPLAIN retained the invariant `if` inside the filter lambda. It passes on this branch and also executes both session-selected branches to verify cached-plan correctness.

Go-level negative tests cover row-dependent, effectful, potentially failing, and unknown-binding conditions.

## Performance

Base: `cd4c9c2c007f410f1e6a83ee93b7f658c4601504`

### Operator microbenchmark

Five runs, 1,000 candidate rows per operation, 2s benchtime:

| Plan | Median | Change |
|---|---:|---:|
| per-row condition and dispatch | 68.40 us | baseline |
| hoisted condition and dispatch | 52.46 us | -23.3% |

Allocations are unchanged at 16,000 B/op and 1,000 allocs/op; this patch removes repeated condition/branch dispatch rather than callback argument allocation.

### Anonymized real-world prefix-search cascade

Same persisted in-memory dataset and SQL for master and branch, one warmup plus two measured executions per term. Values are medians. The branch was measured first, so cache ordering slightly favors master.

| Search class | Master | Branch | Change |
|---|---:|---:|---:|
| broad 1-character prefix | 59.966s | 46.179s | -23.0% |
| 2-character prefix | 11.740s | 10.441s | -11.1% |
| 3-character prefix | 7.386s | 6.602s | -10.6% |
| 4-character prefix | 7.283s | 6.757s | -7.2% |
| 5-character prefix | 7.471s | 6.893s | -7.7% |
| 6-character prefix | 7.514s | 6.848s | -8.9% |
| 7-character prefix | 7.456s | 6.907s | -7.4% |
| 8-character prefix | 7.432s | 6.636s | -10.7% |
| highly selective exact-like term | 1.248s | 1.239s | -0.7% |

The result payload was identical between A/B runs. SQL-level result correctness is covered by the public regression; private benchmark data and literals are not included in this repository.

## Validation

- `go build ./...`
- focused storage rewriter tests
- `tests/60_case_coalesce_nullif.yaml`: 34/34
- `tests/87_scan_batch_optimizer.yaml`: 9/9
- targeted `git-pre-commit` for both SQL suites
- `git diff --check`

A full `go test ./storage -count=1` is currently blocked by the pre-existing `TestManualRepartitionForwardsConcurrentInserts` deadlock (and `TestBlobSharedAcrossTables` failure), both reproduced on unchanged master. This patch does not touch those paths.
