### PR TITLE
Reuse safe SELECT plans across literal variants

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -25,6 +25,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* query plan caches: separate cachemap per parser dialect */
 (set sql_queryplan_cache (newcachemap))
 (set psql_queryplan_cache (newcachemap))
+(set sql_literal_shape_cache (newcachemap))
+
+/* Keep exact SQL variants out of the parser while sharing their compiled plan.
+Only parameterized results enter the small front cache; exact-only statements
+continue to occupy just their existing query-plan entry. */
+(define sql_parameterize_select_literals_cached (lambda (cache query enabled)
+	(if (not enabled)
+		(list query '())
+		(begin
+			(define cached (cache query))
+			(if cached
+				cached
+				(match (parameterize_sql_select_literals query) '(normalized bindings)
+					(if (equal? bindings '())
+						(list normalized bindings)
+						(cache query (list normalized bindings)))))))))
+
+(define sql_parameterize_select_literals (lambda (query enabled)
+	(sql_parameterize_select_literals_cached sql_literal_shape_cache query enabled)))
 
 /* sql_parameterize_select_like_strings: query-plan-cache helper for ad-hoc
 fulltext-ish SELECTs. It replaces string literals directly following LIKE or
@@ -79,35 +98,35 @@ literals, DDL/DML and already-parameterized statements keep exact cache keys. */
 					(list normalized bindings))))))))
 
 /* cached_parse: wraps a parser with cachemap-based caching.
-cache_key = username:schema:hash(query) — per-user isolation (policy checked at parse time).
-The query is hashed with FNV-1a (fnv_hash) so long SQL strings don't bloat the cache index.
-LIKE/AGAINST strings may be parameterized into session variables, but their
-bindings still participate in the key because the planner may choose different
-physical strategies from their selectivity.
-Session-sensitive plans must not be reused under a binding-blind key because
-their lowered runtime helper names and cache domains may depend on current
-session variables.
-On parse error the result is not cached (e.g. table does not exist yet). */
-(define cached_parse (lambda (queryplan_cache parse_fn schema query policy username session parameterize_like_strings)
+cache_key = username:schema:view-generation:hash(query-shape), retaining policy
+isolation while sharing safe SELECT plans across literal variants. Runtime
+bindings are installed only after a shape miss has compiled in a value-neutral
+session. On parse error the result is not cached. */
+(define cached_parse (lambda (queryplan_cache parse_fn schema query policy username session parameterize_literals)
 	(begin
-		(match (sql_parameterize_select_like_strings query parameterize_like_strings) '(parse_query bindings) (begin
+		(match (sql_parameterize_select_literals query parameterize_literals) '(parse_query bindings) (begin
+			(define cache_key (concat username ":" schema ":" (sql_view_query_generation parse_query) ":" (fnv_hash parse_query)))
+			(define compile_diagnostic (match (toUpper parse_query)
+				(regex "^\\s*EXPLAIN\\s+COMPILE\\b" _) true
+				_ false))
+			(define planning_session (if (equal? bindings '()) session (newsession)))
+			(if (not (equal? bindings '()))
+				(begin
+					(planning_session "username" username)
+					(planning_session "schema" schema)
+					(planning_session "__memcp_tx" (session "__memcp_tx")))
+				nil)
+			/* Compile diagnostics measure true misses and must not turn their own
+			previous result into a cache hit. The inspected query is never run. */
+			(define formula (if compile_diagnostic
+				(optimize (with_session planning_session (lambda () (parse_fn schema parse_query policy))))
+				(queryplan_cache "get_or_compute" cache_key
+					(lambda () (optimize (with_session planning_session (lambda () (parse_fn schema parse_query policy))))))))
 			(if (not (equal? bindings '()))
 				(reduce (produceN (count bindings)) (lambda (_ idx)
 					(session (concat "v" (string (+ idx 1))) (nth bindings idx))) nil)
 				nil)
-			(define cache_payload (if (not (equal? bindings '()))
-				(serialize (list parse_query bindings))
-				parse_query))
-			(define cache_key (concat username ":" schema ":" (sql_view_query_generation parse_query) ":" (fnv_hash cache_payload)))
-			(define compile_diagnostic (match (toUpper parse_query)
-				(regex "^\\s*EXPLAIN\\s+COMPILE\\b" _) true
-				_ false))
-			/* Compile diagnostics measure true misses and must not turn their own
-			previous result into a cache hit. The inspected query is never run. */
-			(if compile_diagnostic
-				(optimize (with_session session (lambda () (parse_fn schema parse_query policy))))
-				(queryplan_cache "get_or_compute" cache_key
-					(lambda () (optimize (with_session session (lambda () (parse_fn schema parse_query policy))))))))))))
+			formula)))))
 
 /* helper: build a policy function for table-level access checks
 usage: create a policy by (set policy (sql_policy "username")),

--- a/scm/sql_literals.go
+++ b/scm/sql_literals.go
@@ -1,0 +1,337 @@
+/*
+Copyright (C) 2026  MemCP Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+)
+
+func declareSQLLiteralParameterizer() {
+	Declare(&Globalenv, &Declaration{
+		Name: "parameterize_sql_select_literals",
+		Desc: "replaces safe literals in a top-level MySQL SELECT with positional runtime bindings",
+		Fn: func(a ...Scmer) Scmer {
+			normalized, bindings := parameterizeSQLSelectLiterals(String(a[0]))
+			return NewSlice([]Scmer{NewString(normalized), NewSlice(bindings)})
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{{Kind: "string", ParamName: "query"}},
+			Return: &TypeDescriptor{Kind: "list"},
+			Const:  true,
+		},
+	})
+}
+
+func parameterizeSQLSelectLiterals(query string) (string, []Scmer) {
+	if !parameterizableSelectPrefix(query) {
+		return query, nil
+	}
+
+	var out strings.Builder
+	out.Grow(len(query))
+	bindings := make([]Scmer, 0, 8)
+	depth := 0
+	typeDepth := -1
+	orderDepth := -1
+	previousWord := ""
+	previousToken := ""
+	seenSelect := false
+	clause := ""
+
+	for i := 0; i < len(query); {
+		if isSQLSpace(query[i]) {
+			out.WriteByte(query[i])
+			i++
+			continue
+		}
+		if query[i] == '#' || (query[i] == '-' && i+1 < len(query) && query[i+1] == '-') {
+			end := i + 1
+			for end < len(query) && query[end] != '\n' {
+				end++
+			}
+			out.WriteString(query[i:end])
+			i = end
+			continue
+		}
+		if query[i] == '/' && i+1 < len(query) && query[i+1] == '*' {
+			end := strings.Index(query[i+2:], "*/")
+			if end < 0 {
+				return query, nil
+			}
+			end += i + 4
+			out.WriteString(query[i:end])
+			i = end
+			continue
+		}
+		if query[i] == '`' {
+			end, ok := scanQuotedSQL(query, i, '`')
+			if !ok {
+				return query, nil
+			}
+			out.WriteString(query[i:end])
+			i = end
+			previousToken = "identifier"
+			continue
+		}
+		if query[i] == '\'' || query[i] == '"' {
+			end, ok := scanQuotedSQL(query, i, query[i])
+			if !ok || previousWord == "AS" || previousWord == "DATE" || !parameterizableLiteralClause(clause) {
+				if !ok {
+					return query, nil
+				}
+				out.WriteString(query[i:end])
+				i = end
+				previousToken = "literal"
+				continue
+			}
+			out.WriteByte('?')
+			bindings = append(bindings, NewString(unescapeSQLLiteral(query[i+1:end-1])))
+			i = end
+			previousToken = "literal"
+			continue
+		}
+		if query[i] == '?' {
+			return query, nil
+		}
+		if isSQLIdentifierStart(query[i]) {
+			end := i + 1
+			for end < len(query) && isSQLIdentifierPart(query[end]) {
+				end++
+			}
+			word := strings.ToUpper(query[i:end])
+			if word == "SELECT" {
+				if seenSelect {
+					return query, nil
+				}
+				seenSelect = true
+				clause = "SELECT"
+			}
+			if unsafeParameterizedSelectWord(word) {
+				return query, nil
+			}
+			if word == "BY" && previousWord == "ORDER" {
+				orderDepth = depth
+			} else if orderDepth >= 0 && depth == orderDepth && (word == "LIMIT" || word == "FOR") {
+				orderDepth = -1
+			}
+			if depth == 0 {
+				switch word {
+				case "FROM", "WHERE", "LIMIT", "OFFSET":
+					clause = word
+				case "ON":
+					clause = "WHERE"
+				}
+			}
+			out.WriteString(query[i:end])
+			i = end
+			previousWord = word
+			previousToken = word
+			continue
+		}
+		if query[i] == '(' {
+			depth++
+			if previousWord == "DECIMAL" || previousWord == "VARCHAR" {
+				typeDepth = depth
+			}
+			out.WriteByte(query[i])
+			i++
+			previousToken = "("
+			continue
+		}
+		if query[i] == ')' {
+			if depth == typeDepth {
+				typeDepth = -1
+			}
+			depth--
+			out.WriteByte(query[i])
+			i++
+			previousToken = ")"
+			continue
+		}
+		if query[i] == '-' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' && unarySQLSign(previousToken) && parameterizableLiteralClause(clause) {
+			end := scanSQLNumber(query, i+1)
+			if !isSQLIdentifierPartAt(query, end) {
+				out.WriteByte('?')
+				bindings = append(bindings, Simplify(query[i:end]))
+				i = end
+				previousToken = "literal"
+				continue
+			}
+		}
+		if isSQLNumberStart(query, i) {
+			end := scanSQLNumber(query, i)
+			if end > i && !isSQLIdentifierPartAt(query, end) {
+				isOrderOrdinal := orderDepth == depth && (previousWord == "BY" || previousToken == ",")
+				if typeDepth >= 0 || isOrderOrdinal || !parameterizableLiteralClause(clause) {
+					out.WriteString(query[i:end])
+				} else {
+					out.WriteByte('?')
+					bindings = append(bindings, Simplify(query[i:end]))
+				}
+				i = end
+				previousToken = "literal"
+				continue
+			}
+		}
+
+		out.WriteByte(query[i])
+		previousToken = query[i : i+1]
+		i++
+	}
+
+	if len(bindings) == 0 {
+		return query, nil
+	}
+	return out.String(), bindings
+}
+
+func parameterizableSelectPrefix(query string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+	if strings.HasPrefix(upper, "SELECT ") || strings.HasPrefix(upper, "SELECT\n") || strings.HasPrefix(upper, "SELECT\t") {
+		return true
+	}
+	if !strings.HasPrefix(upper, "EXPLAIN ") {
+		return false
+	}
+	rest := strings.TrimSpace(upper[len("EXPLAIN "):])
+	if strings.HasPrefix(rest, "COMPILE ") {
+		return false
+	}
+	for _, modifier := range []string{"IR ", "REORDER "} {
+		if strings.HasPrefix(rest, modifier) {
+			rest = strings.TrimSpace(rest[len(modifier):])
+		}
+	}
+	return strings.HasPrefix(rest, "SELECT ") || rest == "SELECT"
+}
+
+func scanQuotedSQL(query string, start int, quote byte) (int, bool) {
+	for i := start + 1; i < len(query); i++ {
+		if query[i] == '\\' {
+			i++
+			continue
+		}
+		if query[i] == quote {
+			if quote == '`' && i+1 < len(query) && query[i+1] == '`' {
+				i++
+				continue
+			}
+			return i + 1, true
+		}
+	}
+	return len(query), false
+}
+
+func unescapeSQLLiteral(value string) string {
+	var out strings.Builder
+	out.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		if value[i] != '\\' || i+1 >= len(value) {
+			out.WriteByte(value[i])
+			continue
+		}
+		i++
+		switch value[i] {
+		case 'n':
+			out.WriteByte('\n')
+		case 'r':
+			out.WriteByte('\r')
+		case '0':
+			out.WriteByte(0)
+		case '\\', '\'', '"':
+			out.WriteByte(value[i])
+		default:
+			out.WriteByte('\\')
+			out.WriteByte(value[i])
+		}
+	}
+	return out.String()
+}
+
+func scanSQLNumber(query string, start int) int {
+	i := start
+	for i < len(query) && query[i] >= '0' && query[i] <= '9' {
+		i++
+	}
+	if i < len(query) && query[i] == '.' {
+		i++
+		for i < len(query) && query[i] >= '0' && query[i] <= '9' {
+			i++
+		}
+	}
+	if i < len(query) && (query[i] == 'e' || query[i] == 'E') {
+		exponent := i
+		i++
+		if i < len(query) && (query[i] == '+' || query[i] == '-') {
+			i++
+		}
+		digits := i
+		for i < len(query) && query[i] >= '0' && query[i] <= '9' {
+			i++
+		}
+		if i == digits {
+			return exponent
+		}
+	}
+	return i
+}
+
+func isSQLNumberStart(query string, i int) bool {
+	if i >= len(query) || (query[i] < '0' || query[i] > '9') {
+		return false
+	}
+	return i == 0 || !isSQLIdentifierPart(query[i-1])
+}
+
+func isSQLIdentifierStart(ch byte) bool {
+	return ch == '_' || ch == '$' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z'
+}
+
+func isSQLIdentifierPart(ch byte) bool {
+	return isSQLIdentifierStart(ch) || ch >= '0' && ch <= '9'
+}
+
+func isSQLIdentifierPartAt(query string, i int) bool {
+	return i < len(query) && isSQLIdentifierPart(query[i])
+}
+
+func isSQLSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+func unarySQLSign(previousToken string) bool {
+	switch previousToken {
+	case "", "(", ",", "=", ">", "<", ">=", "<=", "<>", "!=", "+", "-", "*", "/", "WHERE", "ON", "LIMIT", "OFFSET", "AND", "OR", "THEN", "ELSE":
+		return true
+	default:
+		return false
+	}
+}
+
+func parameterizableLiteralClause(clause string) bool {
+	return clause == "WHERE" || clause == "LIMIT" || clause == "OFFSET"
+}
+
+func unsafeParameterizedSelectWord(word string) bool {
+	switch word {
+	case "GROUP", "HAVING", "UNION", "OR", "DISTINCT", "OVER",
+		"COUNT", "SUM", "AVG", "MIN", "MAX", "GROUP_CONCAT":
+		return true
+	default:
+		return false
+	}
+}

--- a/scm/sql_literals_test.go
+++ b/scm/sql_literals_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2026  MemCP Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestParameterizeSQLSelectLiterals(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		normalized string
+		bindings   []Scmer
+	}{
+		{
+			name:       "conditions and bounds",
+			query:      "SELECT id FROM items WHERE id >= 12 AND label = 'open' ORDER BY id LIMIT 5 OFFSET 2",
+			normalized: "SELECT id FROM items WHERE id >= ? AND label = ? ORDER BY id LIMIT ? OFFSET ?",
+			bindings:   []Scmer{Simplify("12"), NewString("open"), Simplify("5"), Simplify("2")},
+		},
+		{
+			name:       "comments and quoted identifiers",
+			query:      "SELECT `value2` FROM `items7` /* 99 ? */ WHERE note = 'line\\nvalue' -- 42\nLIMIT 3",
+			normalized: "SELECT `value2` FROM `items7` /* 99 ? */ WHERE note = ? -- 42\nLIMIT ?",
+			bindings:   []Scmer{NewString("line\nvalue"), Simplify("3")},
+		},
+		{
+			name:       "order ordinal and cast width",
+			query:      "SELECT CAST(score AS DECIMAL(10,2)) AS 'amount' FROM items WHERE score > 4 ORDER BY 1 LIMIT 6",
+			normalized: "SELECT CAST(score AS DECIMAL(10,2)) AS 'amount' FROM items WHERE score > ? ORDER BY 1 LIMIT ?",
+			bindings:   []Scmer{Simplify("4"), Simplify("6")},
+		},
+		{
+			name:       "escaped string",
+			query:      "SELECT id FROM items WHERE note = 'it\\'s\\\\ok'",
+			normalized: "SELECT id FROM items WHERE note = ?",
+			bindings:   []Scmer{NewString("it's\\ok")},
+		},
+		{
+			name:       "projection metadata and negative condition",
+			query:      "SELECT 1, 'fixed' AS label, score - 2 AS adjusted FROM items WHERE score >= -4",
+			normalized: "SELECT 1, 'fixed' AS label, score - 2 AS adjusted FROM items WHERE score >= ?",
+			bindings:   []Scmer{Simplify("-4")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, bindings := parameterizeSQLSelectLiterals(tt.query)
+			if normalized != tt.normalized {
+				t.Fatalf("normalized = %q, want %q", normalized, tt.normalized)
+			}
+			if !Equal(NewSlice(bindings), NewSlice(tt.bindings)) {
+				t.Fatalf("bindings = %v, want %v", NewSlice(bindings), NewSlice(tt.bindings))
+			}
+		})
+	}
+}
+
+func TestParameterizeSQLSelectLiteralsKeepsUnsafeShapesExact(t *testing.T) {
+	queries := []string{
+		"UPDATE items SET score = 2 WHERE id = 1",
+		"SELECT id FROM items WHERE id = ?",
+		"SELECT id FROM items WHERE created_at >= DATE '2026-01-01'",
+		"SELECT category, COUNT(*) FROM items WHERE state = 'open' GROUP BY category",
+		"SELECT id FROM items WHERE id IN (SELECT item_id FROM links WHERE kind = 2)",
+		"SELECT id FROM items WHERE state = 'open' OR score = 2",
+		"SELECT COUNT(*) FROM items WHERE state = 'open'",
+		"SELECT DISTINCT state FROM items WHERE score >= 2",
+		"SELECT id FROM items WHERE id = 1 UNION SELECT id FROM items WHERE id = 2",
+		"EXPLAIN COMPILE SELECT id FROM items WHERE id = 1",
+	}
+	for _, query := range queries {
+		normalized, bindings := parameterizeSQLSelectLiterals(query)
+		if normalized != query || len(bindings) != 0 {
+			t.Errorf("unsafe query changed: %q -> %q, %v", query, normalized, bindings)
+		}
+	}
+}
+
+func BenchmarkParameterizeSQLSelectLiterals(b *testing.B) {
+	query := "SELECT id, label, score FROM items WHERE tenant_id = 481 AND state = 'open' AND score >= 12.5 ORDER BY created_at DESC LIMIT 50 OFFSET 100"
+	b.ReportAllocs()
+	b.SetBytes(int64(len(query)))
+	for b.Loop() {
+		parameterizeSQLSelectLiterals(query)
+	}
+}

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -126,6 +126,7 @@ func TransformFromJSON(a_ any) Scmer {
 }
 
 func init_strings() {
+	declareSQLLiteralParameterizer()
 	// string functions
 	DeclareTitle("Strings")
 

--- a/tests/80_prepared_stmts.yaml
+++ b/tests/80_prepared_stmts.yaml
@@ -121,6 +121,108 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "SELECT literals normalize into runtime bindings"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT id FROM ps_test WHERE id >= 1 AND name = 'alice' ORDER BY id LIMIT 2 OFFSET 0"
+        true)
+        '(normalized bindings)
+        (if (and
+          (equal? normalized "SELECT id FROM ps_test WHERE id >= ? AND name = ? ORDER BY id LIMIT ? OFFSET ?")
+          (equal? bindings '(1 "alice" 2 0)))
+          "ok"
+          (error (concat "unexpected normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Literal variants share one cached SELECT plan"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (cached_parse cache (lambda (_schema _query _policy) 7)
+          "memcp-tests" "SELECT id FROM ps_test WHERE id = 1 LIMIT 1 OFFSET 0"
+          nil "root" sess true)
+        (cached_parse cache (lambda (_schema _query _policy) 7)
+          "memcp-tests" "SELECT id FROM ps_test WHERE id = 2 LIMIT 2 OFFSET 1"
+          nil "root" sess true)
+        (if (and
+          (equal? (count (cache)) 1)
+          (equal? (sess "v1") 2)
+          (equal? (sess "v2") 2)
+          (equal? (sess "v3") 1))
+          "ok"
+          (error (concat "unexpected cache/bindings: " (count (cache)) " / " (sess "v1") "," (sess "v2") "," (sess "v3")))))
+    expect:
+      data: ["ok"]
+
+  - name: "Literal front cache stores only generalized SELECTs"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (sql_parameterize_select_literals_cached cache
+          "UPDATE ps_test SET score = 5 WHERE id = 1" true)
+        (sql_parameterize_select_literals_cached cache
+          "SELECT COUNT(*) FROM ps_test WHERE id = 1" true)
+        (sql_parameterize_select_literals_cached cache
+          "SELECT id FROM ps_test WHERE id = 1" true)
+        (sql_parameterize_select_literals_cached cache
+          "SELECT id FROM ps_test WHERE id = 1" true)
+        (if (equal? (count (cache)) 1)
+          "ok"
+          (error (concat "unexpected literal front-cache size: " (count (cache))))))
+    expect:
+      data: ["ok"]
+
+  - name: "Literal equality first execution"
+    sql: "SELECT id FROM ps_test WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - {id: 1}
+
+  - name: "Literal equality second execution"
+    sql: "SELECT id FROM ps_test WHERE id = 2"
+    expect:
+      rows: 1
+      data:
+        - {id: 2}
+
+  - name: "Projection literal keeps result metadata"
+    sql: "SELECT 1, 'fixed' AS label FROM ps_test LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - {"1": 1, label: "fixed"}
+
+  - name: "Literal normalization leaves DML exact"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "UPDATE ps_test SET score = 5 WHERE id = 1"
+        true)
+        '(normalized bindings)
+        (if (and
+          (equal? normalized "UPDATE ps_test SET score = 5 WHERE id = 1")
+          (equal? bindings '()))
+          "ok"
+          (error (concat "unexpected normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Literal LIMIT and OFFSET stay execution-local"
+    sql: "SELECT id FROM ps_test ORDER BY id LIMIT 1 OFFSET 0"
+    expect:
+      rows: 1
+      data:
+        - {id: 1}
+
+  - name: "Literal LIMIT and OFFSET second execution"
+    sql: "SELECT id FROM ps_test ORDER BY id LIMIT 1 OFFSET 1"
+    expect:
+      rows: 1
+      data:
+        - {id: 2}
+
   - name: "? placeholder: no match returns 0 rows"
     sql: "SELECT id FROM ps_test WHERE id = ?"
     params: [99]


### PR DESCRIPTION
## What

- parameterize literals from conservative top-level MySQL SELECT shapes into request-local session bindings
- cache and compile the normalized shape once in a value-neutral planning session
- retain a small exact-query front cache so repeated byte-identical eligible queries also skip the linear scanner
- keep DML, existing placeholders, nested SELECT, OR, aggregates, DISTINCT, GROUP/HAVING/UNION, window queries, typed DATE literals, projection literals, type widths, and ORDER BY ordinals exact
- add scanner unit coverage and SQL regressions for plan reuse, first-value independence, result metadata, LIMIT/OFFSET, exact-only statements, and front-cache admission

## Why

Ad-hoc queries that differ only in condition literals currently create one parsed and optimized plan per literal combination. Moving those values into session bindings lets the existing plan cache reuse one physical plan without changing the SQL-facing prepared-statement API.

Compilation deliberately happens without the first request's literal values. This prevents the first variant from specializing the shared physical plan.

## A/B measurements

Both binaries were built from `cd4c9c2c0` plus this patch for B. Each run used a fresh process and data directory on the same host.

### 500 cold literal variants

Query shape: a selective equality condition with `LIMIT 1 OFFSET 0`; 500 distinct literal values.

| Metric | master | PR | Change |
|---|---:|---:|---:|
| total | 1996.52 ms | 715.91 ms | 2.79x faster |
| median/request | 3.7977 ms | 1.3560 ms | 2.80x faster |
| p95/request | 5.4809 ms | 1.8431 ms | 2.97x faster |
| compiled plan entries after setup | 504 | 4 | 500 variants collapse to one plan |

The PR additionally held 500 lightweight scanner-result entries, keyed by exact text, so repeated identical requests do not rescan. This is still an unbounded cache and is the principal memory drawback; it replaces full compiled-plan duplication with normalized text and bindings rather than eliminating one entry per observed SQL text entirely.

### Identical warm eligible query

Five alternating rounds, 3000 requests each:

| Round | master total | PR total | master median | PR median |
|---|---:|---:|---:|---:|
| 1 | 4000.74 ms | 3994.80 ms | 1.2636 ms | 1.2704 ms |
| 2 | 4076.08 ms | 4001.47 ms | 1.2854 ms | 1.2679 ms |
| 3 | 4047.18 ms | 4133.45 ms | 1.2782 ms | 1.3005 ms |
| 4 | 3936.28 ms | 4159.22 ms | 1.2455 ms | 1.3089 ms |
| 5 | 3991.76 ms | 4018.98 ms | 1.2616 ms | 1.2766 ms |

Warm identical traffic ranges from 1.8% faster to 5.7% slower by total wall time. Median latency is mostly slightly slower (about 0.5-5.1%). The parser remains skipped: the residual cost is the extra front-cache lookup, binding installation, and host noise.

### Excluded warm aggregate

Three alternating rounds, 3000 requests each. These queries pay the scanner but deliberately keep their exact plan:

- master totals: 4503.86 / 4494.17 / 4581.34 ms
- PR totals: 4458.46 / 4539.38 / 4479.69 ms
- result: -2.2% to +1.0%, no stable end-to-end regression above noise

The isolated scanner benchmark is 1.16-1.23 us/op, 504 B/op, 12 allocs/op on an AMD Ryzen 9 7900X3D. This is the explicit cost for excluded SELECTs.

### Representative integration run

A non-controlled, browser-driven workload showed directional SQL trace improvement: traced SQL time 310.1 s -> 253.5 s (-18.2%) and calls >=1 s 74 -> 44 (-40.5%). Request counts and concurrent host load differed, so these numbers are not treated as a clean A/B result. Setup stages completed, but the parallel UI phase still failed predominantly on browser navigation/context timeouts, not a demonstrated SQL correctness failure.

## Drawbacks and limits

- Exact repeated eligible queries still avoid parsing, addressing the expected warm-latency concern, but have an extra cache lookup and per-request binding writes.
- Novel eligible SQL text always runs the linear scanner before a shape-cache lookup.
- Excluded SELECTs run the scanner on every request and gain no plan reuse.
- The exact-query scanner cache is unbounded, though each entry is much smaller than a compiled plan.
- Conservative exclusions leave optimization potential on the table until those planner paths are proven value-independent.
- A shared generic plan can be worse than a literal-specialized plan when cardinality-sensitive planning is introduced; MemCP does not currently have a cost model to select generic versus custom plans.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`
- `go test ./scm -run TestParameterizeSQLSelectLiterals -count=1`
- targeted SQL suites for prepared statements, dates, OR index scans, and aggregate keytables
- `go test ./scm -run '^$' -bench '^BenchmarkParameterizeSQLSelectLiterals$' -benchmem -count=10`
