### PR TITLE
sql: support grouped derived aliases

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2969,6 +2969,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 			'(expr dir) (list (rewrite_derived_ref alias projection expr) dir)
 			_ item)))))
 
+(define rewrite_order_output_alias (lambda (fields expr)
+	(match expr
+		((symbol get_column) nil ignorecase col _json_path)
+		(coalesceNil (field_expr_by_title fields col ignorecase) expr)
+		((quote get_column) nil ignorecase col _json_path)
+		(coalesceNil (field_expr_by_title fields col ignorecase) expr)
+		_ expr)))
+
+(define rewrite_order_output_aliases (lambda (fields order_items)
+	(map (coalesceNil order_items '()) (lambda (item)
+		(match item
+			'(expr dir) (list (rewrite_order_output_alias fields expr) dir)
+			_ item)))))
+
 (define rewrite_source_join_for_derived (lambda (alias projection src)
 	(list
 		(source_alias src)
@@ -3413,8 +3427,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 									(neumann_fail "untangle_query" "window function is not allowed in WHERE")
 									true)
 								(define where_result (untangle_where_with_stages rewritten_where joined_expr_outer_sources joined_expr_ctx))
+								(define rewritten_fields (rewrite_derived_fields_chain rewrites (qb_fields block)))
 								(define field_result (untangle_fields_with_stages
-									(qualify_join_expr (rewrite_derived_fields_chain rewrites (qb_fields block)))
+									(qualify_join_expr rewritten_fields)
 									joined_expr_outer_sources joined_expr_ctx))
 								(define having_result (untangle_expr_with_stages
 									(qualify_join_expr (rewrite_derived_ref_chain rewrites (qb_having block)))
@@ -3426,7 +3441,9 @@ PostgreSQL parsers should both lower to the same combined operators.
 									joined_expr_outer_sources
 									joined_expr_ctx))
 								(define order_result (untangle_order_with_stages
-									(qualify_join_expr (rewrite_derived_order_chain rewrites (qb_order block)))
+									(qualify_join_expr (rewrite_order_output_aliases
+										rewritten_fields
+										(rewrite_derived_order_chain rewrites (qb_order block))))
 									joined_expr_outer_sources
 									joined_expr_ctx))
 								(define hidden_result (untangle_fields_with_stages

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -813,6 +813,28 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		sql_column
 	)))
 
+	/* SQL-standard derived-table column alias lists rename visible output
+	columns from left to right. Keep this transform at the parser boundary so
+	the planner receives the same neutral query shape for every frontend. */
+	(define sql_rename_derived_fields (lambda (fields aliases) (match aliases
+		(cons alias remaining_aliases) (match fields
+			(cons _title (cons expr remaining_fields))
+			(cons alias (cons expr (sql_rename_derived_fields remaining_fields remaining_aliases)))
+			_ (error "derived table has more column aliases than columns"))
+		_ fields
+	)))
+	(define sql_apply_derived_column_aliases (lambda (query aliases) (match query
+		((symbol query-block) schema2 tables fields condition group having order limit offset hidden stages facts)
+		(list (quote query-block) schema2 tables
+			(sql_rename_derived_fields fields aliases)
+			condition group having order limit offset hidden stages facts)
+		((symbol union-block) mode branches order limit offset facts)
+		(list (quote union-block) mode
+			(map branches (lambda (branch) (sql_apply_derived_column_aliases branch aliases)))
+			order limit offset facts)
+		_ (error "derived table column aliases require a SELECT query")
+	)))
+
 	(define tabledefs (parser (or
 		/* TODO: left [outer] join, right [outer] join recursive buildup */
 		(parser '((define l tabledefs) (define x (or
@@ -829,6 +851,10 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser (define t tabledef) '(t))
 	)))
 	(define tabledef (parser (or
+		(parser '((atom "(" true) (define query sql_select) (atom ")" true) (atom "AS" true) (define id sql_identifier) "(" (define aliases (+ sql_identifier ",")) ")")
+			(list id schema (sql_apply_derived_column_aliases query aliases) false nil)) /* inner select with relation and column aliases */
+		(parser '((atom "(" true) (define query sql_select) (atom ")" true) (define id sql_identifier) "(" (define aliases (+ sql_identifier ",")) ")")
+			(list id schema (sql_apply_derived_column_aliases query aliases) false nil)) /* AS is optional */
 		(parser '((atom "(" true) (define query sql_select) (atom ")" true) (atom "AS" true) (define id sql_identifier)) '(id schema query false nil)) /* inner select as from */
 		(parser '((atom "(" true) (define query sql_select) (atom ")" true) (define id sql_identifier)) '(id schema query false nil)) /* inner select as from */
 		/* TODO: case insensititive table search */

--- a/tests/52_group_stage_corners.yaml
+++ b/tests/52_group_stage_corners.yaml
@@ -10,6 +10,9 @@ test_cases:
   - name: "Create items table"
     sql: "CREATE TABLE gs_items (id INT PRIMARY KEY, order_id INT, product VARCHAR(50), qty INT)"
 
+  - name: "Create customers table"
+    sql: "CREATE TABLE gs_customers (id INT PRIMARY KEY, name VARCHAR(50))"
+
   - name: "Insert orders"
     sql: |
       INSERT INTO gs_orders (id, customer, amount, priority) VALUES
@@ -32,6 +35,14 @@ test_cases:
         (7, 5, 'Gadget', 2),
         (8, 6, 'Doohickey', 4),
         (9, 6, 'Widget', 1)
+
+  - name: "Insert customers"
+    sql: |
+      INSERT INTO gs_customers (id, name) VALUES
+        (1, 'Alice'),
+        (2, 'Bob'),
+        (3, 'Charlie'),
+        (4, 'Dana')
 
   # =================================================================
   # 1. GROUP BY inside FROM subquery (derived table with aggregation)
@@ -112,6 +123,36 @@ test_cases:
           cnt: 3
         - customer: "Bob"
           cnt: 2
+
+  - name: "Outer GROUP BY on aggregate alias from left-joined derived table"
+    sql: |
+      SELECT order_count, COUNT(*) AS customer_count
+      FROM (
+        SELECT c.id, COUNT(o.id) AS order_count
+        FROM gs_customers c
+        LEFT OUTER JOIN gs_orders o
+          ON o.customer = c.name
+         AND o.customer NOT LIKE '%Nobody%'
+        GROUP BY c.id
+      ) customer_orders (customer_id, order_count)
+      GROUP BY order_count
+      ORDER BY customer_count DESC, order_count DESC
+    expect:
+      rows: 4
+      data:
+        - order_count: 3
+          customer_count: 1
+        - order_count: 2
+          customer_count: 1
+        - order_count: 1
+          customer_count: 1
+        - order_count: 0
+          customer_count: 1
+
+  - name: "Derived table rejects more column aliases than outputs"
+    sql: "SELECT renamed FROM (SELECT id FROM gs_customers) customer_ids (renamed, extra)"
+    expect:
+      error: true
 
   # =================================================================
   # 5. COUNT(DISTINCT) with JOIN
@@ -305,5 +346,6 @@ test_cases:
           total_qty: 5
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS gs_customers"
   - sql: "DROP TABLE IF EXISTS gs_items"
   - sql: "DROP TABLE IF EXISTS gs_orders"


### PR DESCRIPTION
## What changed

- add SQL-standard derived-table column alias lists to the regular SQL parser
- resolve unqualified `ORDER BY` output aliases during logical untangling
- cover the grouped derived-table + `LEFT JOIN` aggregate shape and excess-alias rejection with generic SQL regressions

## Why

A nested grouped query could parse through the PostgreSQL frontend but the regular SQL frontend did not preserve an explicit derived-column alias list. Its outer aggregate ordering also treated the SELECT alias as a physical group-table column. Together these blocked the remaining TPC-H compile shape.

## Validation

- final local generated-query compile census: 22/22
- focused group-stage suite: 23/23
- full hook with coverage: all tests passed (`MEMCP_TEST_JOBS=1`, CPU-affinity pinned for stable existing performance limits)
- Scheme coverage: 100% source nodes; Go coverage: 66.5%
- unchanged `origin/master` A/B reproduced the transient ORDER-BY performance failure seen under cross-CCD load

No TPC-H query text, data, answers, helper scripts, or other licensed material is included in this PR.