### PR TITLE
Fix concurrent blob refcount maintenance

### DIFF
--- a/storage/blob-refcount.go
+++ b/storage/blob-refcount.go
@@ -19,19 +19,78 @@ package storage
 import "fmt"
 import "github.com/launix-de/memcp/scm"
 
+func blobRefStripe(hash string) int {
+	value := byte(0)
+	for i := 0; i < len(hash) && i < 2; i++ {
+		value <<= 4
+		switch c := hash[i]; {
+		case c >= '0' && c <= '9':
+			value |= c - '0'
+		case c >= 'a' && c <= 'f':
+			value |= c - 'a' + 10
+		case c >= 'A' && c <= 'F':
+			value |= c - 'A' + 10
+		default:
+			value ^= c
+		}
+	}
+	return int(value) & 63
+}
+
+func (db *database) lockBlobRef(hash string) func() {
+	lock := &db.blobRefState().locks[blobRefStripe(hash)].mu
+	lock.Lock()
+	return lock.Unlock
+}
+
+func blobTableHasColumns(t *table) bool {
+	hash, refcount := false, false
+	for _, col := range t.Columns {
+		hash = hash || col.Name == "hash"
+		refcount = refcount || col.Name == "refcount"
+	}
+	return hash && refcount
+}
+
 // ensureBlobTable lazily creates the `.blobs` table inside this database.
 func (db *database) ensureBlobTable() *table {
-	t := db.GetTable(".blobs")
-	if t != nil {
+	state := db.blobRefState()
+	t := state.table.Load()
+	if t != nil && blobTableHasColumns(t) {
 		return t
 	}
-	fmt.Println("creating table", db.Name+".\".blobs\"")
-	t, _ = CreateTable(db.Name, ".blobs", Safe, true)
-	if t != nil {
+
+	state.tableMu.Lock()
+	defer state.tableMu.Unlock()
+	if t = state.table.Load(); t != nil && blobTableHasColumns(t) {
+		return t
+	}
+	db.ensureLoaded()
+	if t = db.tables.Get(".blobs"); t != nil {
+		// Repair schemas created by older versions that published the table
+		// before both columns had been added.
 		t.CreateColumn("hash", "TEXT", nil, nil)
 		t.CreateColumn("refcount", "INT", nil, nil)
-		db.save()
+		state.table.Store(t)
+		return t
 	}
+
+	fmt.Println("creating table", db.Name+".\".blobs\"")
+	db.schemalock.Lock()
+	if t = db.tables.Get(".blobs"); t != nil {
+		db.schemalock.Unlock()
+		t.CreateColumn("hash", "TEXT", nil, nil)
+		t.CreateColumn("refcount", "INT", nil, nil)
+		state.table.Store(t)
+		return t
+	}
+	t = db.newTable(".blobs", Safe)
+	t.createColumnLocked("hash", "TEXT", nil, nil)
+	t.createColumnLocked("refcount", "INT", nil, nil)
+	db.tables.Set(t)
+	db.saveLockedWithDurabilityAndUnlock(true)
+	state.table.Store(t)
+	registerCreatedTable(t)
 	return t
 }
 
@@ -58,12 +117,11 @@ func sumProc() scm.Scmer {
 
 // IncrBlobRefcount increments the reference count for a blob hash in db.`.blobs`.
 // If no row exists yet, it inserts one with refcount=1.
-// IncrBlobRefcount increments the reference count for a blob hash in db.`.blobs`.
-// If no row exists yet, it inserts one with refcount=1.
-// No global lock: the .blobs table's own shard-level locking via scan+$update
-// provides atomicity per hash.  Callers must call IncrBlobRefcount BEFORE
-// WriteBlob so that cleanBlobs never sees an orphaned file on disk.
+// Same-hash operations are serialized across the scan and insert/update;
+// independent hashes retain the concurrency of separate lock stripes.
 func (db *database) IncrBlobRefcount(hash string) {
+	defer db.lockBlobRef(hash)()
+	state := db.blobRefState()
 	t := db.ensureBlobTable()
 	if t == nil {
 		return
@@ -90,25 +148,41 @@ func (db *database) IncrBlobRefcount(hash string) {
 	})
 
 	aggr := sumProc()
-	result := t.scan(
-		CurrentTx(),
-		[]string{"hash"}, blobCondition(hashVal),
-		[]string{"refcount", "$update"}, callback,
-		aggr, scm.NewInt(0), aggr, false,
-	)
-
-	if scm.ToInt(result) == 0 {
-		t.Insert(
-			[]string{"hash", "refcount"},
-			[][]scm.Scmer{{hashVal, scm.NewInt(1)}},
-			nil, scm.NewNil(), false, nil,
+	incrementExisting := func() bool {
+		result := t.scan(
+			CurrentTx(),
+			[]string{"hash"}, blobCondition(hashVal),
+			[]string{"refcount", "$update"}, callback,
+			aggr, scm.NewInt(0), aggr, false,
 		)
+		return scm.ToInt(result) > 0
 	}
+	state.rows.RLock()
+	found := incrementExisting()
+	state.rows.RUnlock()
+	if found {
+		return
+	}
+
+	state.rows.Lock()
+	defer state.rows.Unlock()
+	if incrementExisting() {
+		return
+	}
+	t.Insert(
+		[]string{"hash", "refcount"},
+		[][]scm.Scmer{{hashVal, scm.NewInt(1)}},
+		nil, scm.NewNil(), false, nil,
+	)
 }
 
 // DecrBlobRefcount decrements the reference count for a blob hash in db.`.blobs`.
 // If the count reaches 0, the row is deleted and the blob file is removed.
 func (db *database) DecrBlobRefcount(hash string) {
+	defer db.lockBlobRef(hash)()
+	state := db.blobRefState()
+	state.rows.Lock()
+	defer state.rows.Unlock()
 	t := db.ensureBlobTable()
 	if t == nil {
 		return

--- a/storage/blob_refcount_test.go
+++ b/storage/blob_refcount_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
@@ -430,6 +431,53 @@ func TestBlobSharedAcrossTables(t *testing.T) {
 		t.Fatalf("after dropping both tables: expected 0 blob files, got %d", n)
 	}
 	fmt.Println("TestBlobSharedAcrossTables passed")
+}
+
+func TestConcurrentBlobRefcountUpdates(t *testing.T) {
+	dir := t.TempDir()
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tdb_concurrent")
+	oldAnalyzeMinItems := Settings.AnalyzeMinItems
+	Settings.AnalyzeMinItems = 1 << 30
+	defer func() { Settings.AnalyzeMinItems = oldAnalyzeMinItems }()
+
+	CreateDatabase("tdb_concurrent", false)
+	db := GetDatabase("tdb_concurrent")
+	hash := strings.Repeat("ab", 32)
+
+	const refs = 64
+	var wg sync.WaitGroup
+	wg.Add(refs)
+	for range refs {
+		go func() {
+			defer wg.Done()
+			db.IncrBlobRefcount(hash)
+		}()
+	}
+	wg.Wait()
+
+	values := queryBlobsTable(t, db)
+	if len(values) != 1 || values[hash] != refs {
+		t.Fatalf("concurrent increments: got %v, want one row with refcount %d", values, refs)
+	}
+
+	wg.Add(refs - 1)
+	for range refs - 1 {
+		go func() {
+			defer wg.Done()
+			db.DecrBlobRefcount(hash)
+		}()
+	}
+	wg.Wait()
+
+	values = queryBlobsTable(t, db)
+	if len(values) != 1 || values[hash] != 1 {
+		t.Fatalf("concurrent decrements: got %v, want one row with refcount 1", values)
+	}
 }
 
 // TestDoubleRebuildPreservesShardFiles is a regression test for a data-loss

--- a/storage/database.go
+++ b/storage/database.go
@@ -42,18 +42,41 @@ type database struct {
 	//     instead of forcing N full schema.json rewrites in sequence
 	//   - durable=true (Safe engine metadata) upgrades the coalesced write to
 	//     a fully synced commit; non-durable callers may piggyback on it
-	saveMu          sync.Mutex `json:"-"`
-	saveCondOnce    sync.Once  `json:"-"`
-	saveCond        *sync.Cond `json:"-"`
-	saveRequested   uint64     `json:"-"`
-	saveCompleted   uint64     `json:"-"`
-	saveInFlight    bool       `json:"-"`
-	savePending     []byte     `json:"-"`
-	savePendingSync bool       `json:"-"`
-	savePanic       any        `json:"-"`
+	saveMu          sync.Mutex    `json:"-"`
+	saveCondOnce    sync.Once     `json:"-"`
+	saveCond        *sync.Cond    `json:"-"`
+	saveRequested   uint64        `json:"-"`
+	saveCompleted   uint64        `json:"-"`
+	saveInFlight    bool          `json:"-"`
+	savePending     []byte        `json:"-"`
+	savePendingSync bool          `json:"-"`
+	savePanic       any           `json:"-"`
+	blobRefs        *blobRefState `json:"-"`
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
+}
+
+// blobRefLock occupies one cache line so unrelated hash stripes do not
+// invalidate each other's lock state under parallel blob rebuilds.
+type blobRefLock struct {
+	mu sync.Mutex
+	_  [56]byte
+}
+
+type blobRefState struct {
+	tableMu sync.Mutex
+	rows    sync.RWMutex
+	locks   [64]blobRefLock
+	table   atomic.Pointer[table]
+}
+
+func (db *database) blobRefState() *blobRefState {
+	return db.blobRefs
+}
+
+func newDatabase() *database {
+	return &database{blobRefs: new(blobRefState)}
 }
 
 type rebuildDatabaseResult struct {
@@ -207,7 +230,7 @@ func LoadDatabases() {
 	entries, _ := os.ReadDir(Basepath)
 	for _, entry := range entries {
 		if entry.IsDir() {
-			db := new(database)
+			db := newDatabase()
 			db.Name = entry.Name()
 			db.persistence = &FileStorage{path: Basepath + "/" + entry.Name() + "/"}
 			db.srState = COLD
@@ -227,7 +250,7 @@ func LoadDatabases() {
 				continue
 			}
 			fmt.Println("loading database", dbName, "from backend config", configPath)
-			db := new(database)
+			db := newDatabase()
 			db.Name = dbName
 			db.persistence = persistence
 			db.srState = COLD
@@ -360,6 +383,9 @@ func (db *database) ensureLoaded() {
 	// restore back-references; do not touch on-disk columns yet
 	for _, t := range db.tables.GetAll() {
 		t.schema = db
+		if t.Name == ".blobs" {
+			db.blobRefState().table.Store(t)
+		}
 		for _, col := range t.Columns {
 			col.UpdateSanitizer()
 		}
@@ -486,6 +512,9 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 		// do nothing for cold databases; avoid loading during rebuild
 		return rebuildDatabaseResult{}
 	}
+	// Blob-producing table rebuilds run in parallel. Publish their shared
+	// refcount table before workers start so no worker mutates the catalog.
+	db.ensureBlobTable()
 	var done sync.WaitGroup
 	// Collect pre-rebuild shards that were superseded. Their cleanup
 	// (RemoveFromDisk → ReleaseBlobs → DecrBlobRefcount) must run after
@@ -496,9 +525,31 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 	var errMu sync.Mutex
 	var rebuildErrors []string
 	dbs := db.tables.GetAll()
+	if !includeEphemeral {
+		onlineTables := make([]*table, 0, len(dbs))
+		for _, t := range dbs {
+			if t.Name != ".blobs" {
+				onlineTables = append(onlineTables, t)
+			}
+		}
+		dbs = onlineTables
+	}
+	var blobWriters sync.WaitGroup
+	for _, t := range dbs {
+		if t.Name != ".blobs" {
+			blobWriters.Add(1)
+		}
+	}
 	done.Add(len(dbs))
 	for _, t := range dbs {
 		go func(t *table) {
+			if t.Name == ".blobs" {
+				// Rebuilding other tables may update blob refcounts. Rebuild the
+				// shared catalog only after those writes have completed.
+				blobWriters.Wait()
+			} else {
+				defer blobWriters.Done()
+			}
 			tableLocked := false
 			rebuildClaimed := false
 			t.ddlMu.RLock()
@@ -770,7 +821,7 @@ func CreateDatabase(schema string, ignoreexists bool /*, persistence Persistence
 		panic("Database " + schema + " already exists")
 	}
 
-	db = new(database)
+	db = newDatabase()
 	db.Name = schema
 	persistence := FileFactory{Basepath} // TODO: remove this, use parameter instead
 	db.persistence = persistence.CreateDatabase(schema)
@@ -847,7 +898,7 @@ func CreateDatabaseWithBackend(schema string, ignoreexists bool, options map[str
 		panic("failed to create persistence engine for backend: " + backend)
 	}
 
-	db = new(database)
+	db = newDatabase()
 	db.Name = schema
 	db.persistence = persistence
 	db.tables = NonLockingReadMap.New[table, string]()
@@ -905,7 +956,7 @@ func CreateDatabaseFrom(schema string, ignoreexists bool, sourceDB string) bool 
 		panic("failed to create persistence engine from source config")
 	}
 
-	db = new(database)
+	db = newDatabase()
 	db.Name = schema
 	db.persistence = persistence
 	db.tables = NonLockingReadMap.New[table, string]()
@@ -993,7 +1044,17 @@ func (db *database) createTableLocked(name string, pm PersistencyMode, ifnotexis
 		}
 		panic("Table " + name + " already exists")
 	}
-	t = new(table)
+	t = db.newTable(name, pm)
+	if existing := db.tables.Set(t); existing != nil {
+		panic("Table " + name + " already exists")
+	}
+	return t, true
+}
+
+// newTable builds a complete table object without publishing it in db.tables.
+// Callers may add internal columns before publication while holding schemalock.
+func (db *database) newTable(name string, pm PersistencyMode) *table {
+	t := new(table)
 	t.schema = db
 	t.Name = name
 	t.PersistencyMode = pm
@@ -1003,10 +1064,7 @@ func (db *database) createTableLocked(name string, pm PersistencyMode, ifnotexis
 	t.Shards[0] = NewShard(t)
 	t.Auto_increment = 1
 	t.publishShowColumnsSnapshot()
-	if existing := db.tables.Set(t); existing != nil {
-		panic("Table " + name + " already exists")
-	}
-	return t, true
+	return t
 }
 
 func registerCreatedTable(t *table) {
@@ -1039,6 +1097,9 @@ func DropTable(schema, name string, ifexists bool) {
 		panic("Table " + schema + "." + name + " does not exist")
 	}
 	db.tables.Remove(name)
+	if name == ".blobs" {
+		db.blobRefState().table.Store(nil)
+	}
 	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
 	// fire AfterDropTable triggers after releasing schemalock (avoids deadlock on cascading drops)
 	t.ExecuteTableLifecycleTriggers(AfterDropTable)

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -33,9 +33,8 @@ func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
 }
 
 // cleanBlobs deletes blob files that are not referenced in the .blobs table.
-// No global lock needed: IncrBlobRefcount is always called BEFORE WriteBlob,
-// so any file on disk has (or will have) a refcount entry.  Only truly
-// orphaned files (from incomplete writes) are deleted.
+// IncrBlobRefcount is always called BEFORE WriteBlob, and the per-hash lock
+// prevents cleanup from racing a missing-row insert or final decrement.
 // Queries the .blobs table per blob file instead of building an in-memory map.
 func cleanBlobs(db *database) int {
 	bt := db.GetTable(".blobs")
@@ -47,6 +46,10 @@ func cleanBlobs(db *database) int {
 	// Walk disk blobs one by one; check refcount via scan on .blobs table.
 	deleted := 0
 	db.persistence.WalkBlobs(func(hash string) error {
+		defer db.lockBlobRef(hash)()
+		state := db.blobRefState()
+		state.rows.RLock()
+		defer state.rows.RUnlock()
 		hashVal := scm.NewString(hash)
 		// scan .blobs WHERE hash = <hash>, sum refcount
 		rc := bt.scan(

--- a/tests/42_blob_storage.yaml
+++ b/tests/42_blob_storage.yaml
@@ -304,6 +304,22 @@ test_cases:
     expect:
       affected_rows: 1
 
+  - name: "Shared blob: rebuild both tables concurrently"
+    sql: "SHUTDOWN"
+    expect:
+      rows: 0
+
+  - name: "Shared blob: both tables survive concurrent rebuild"
+    sql: |
+      SELECT
+        (SELECT payload = REPEAT('S', 1000) FROM blob_shared1 WHERE id = 1) AS first_ok,
+        (SELECT payload = REPEAT('S', 1000) FROM blob_shared2 WHERE id = 1) AS second_ok
+    expect:
+      rows: 1
+      data:
+        - first_ok: 1
+          second_ok: 1
+
   - name: "Shared blob: drop first table"
     sql: "DROP TABLE blob_shared1"
     expect:


### PR DESCRIPTION
## Summary

- publish the internal blob refcount table only after its schema is complete
- serialize same-hash refcount transitions while retaining striped concurrency across hashes
- protect structural `.blobs` row changes across distinct hashes
- order shutdown rebuilds so blob-producing tables finish before `.blobs` is rebuilt
- cover concurrent refcount changes and shared-blob persistence across restart

## Root cause

Parallel rebuilds of tables sharing a blob could observe a partially published `.blobs` table or both insert a missing row for the same hash. Duplicate refcount rows then allowed dropping one table to remove a blob still referenced by the other table. Distinct-hash inserts could also race structural changes in the same lazy shard.

## A/B measurements

Correctness baseline on current master:

- `TestBlobSharedAcrossTables`, separate-process repetition: **7/10 runs failed**

PR:

- `go test ./storage -run '^(TestBlobSharedAcrossTables|TestConcurrentBlobRefcountUpdates)$' -count=50 -timeout=5m`: **pass**
- `go test -race ./storage -run '^(TestBlobSharedAcrossTables|TestConcurrentBlobRefcountUpdates)$' -count=20 -timeout=3m`: **pass**, 26.6 s
- `tests/42_blob_storage.yaml`: **53/53 pass**, including two-table shared-blob shutdown/restart

Unrelated rebuild-path control, fresh store without coverage:

| Revision | `tests/71_repartition_concurrent.yaml` |
| --- | ---: |
| master | 47.424 s, 143/143 |
| PR | 48.502 s, 143/143 |

The 1.078 s difference (+2.3%) is within run-to-run host variance and shows no material general rebuild regression.

## Validation

- current repository pre-commit hook, full suite: **pass**
- unchanged parallel `make test` was also exercised; local coverage runs hit unrelated 100 s planner-query timeouts. A detached unmodified master control reproduced the same timeout (`SUM with DATEDIFF-like expression over LEAD derived table`, 1m41s), while the focused parallel A/B above stayed green. No test parallelism, test case, or timeout was changed.
