### PR TITLE
Optimize scalar probe dependency reachability

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4968,7 +4968,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(and (expr_refs_stage_output_alias? (list (quote get_column) tblvar false col false)) true)
 		_ false)))
 
-(define lower_scalar_first_query_probe_expr (lambda (all_stages stage value_expr keys lookup_keys)
+(define lower_scalar_first_query_probe_expr (lambda (all_stages dependency_graph stage value_expr keys lookup_keys)
 	(begin
 		(define input (gs_input stage))
 		(define direct_nested_stages (merge_unique (list
@@ -4977,7 +4977,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(define nested_stages (merge_unique (list
 			direct_nested_stages
 			(merge (map direct_nested_stages (lambda (nested_stage)
-				(consumed_stage_closure all_stages nested_stage)))))))
+				(stage_dependency_closure_using_graph dependency_graph nested_stage)))))))
 		(define keyed_terms (map (produceN (count keys)) (lambda (i)
 			(list (query_key_term_alias (qb_sources input) (nth keys i))
 				(list (quote equal??) (nth keys i) (nth lookup_keys i))))))
@@ -5118,7 +5118,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(qb_stages block)
 			(qb_facts block)))))
 
-(define scalar_query_probe_recipe_binding (lambda (all_stages entry)
+(define scalar_query_probe_recipe_binding (lambda (all_stages dependency_graph entry)
 	(match entry
 		'(stage requested_col) (begin
 			(define raw_keys (gs_keys stage))
@@ -5138,12 +5138,14 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 				(quote define)
 				(symbol (scalar_query_probe_recipe_key stage requested_col))
 				(list (quote lambda) params
-					(lower_scalar_first_query_probe_expr all_stages stage value_expr keys params))))
+					(lower_scalar_first_query_probe_expr all_stages dependency_graph stage value_expr keys params))))
 		_ (neumann_fail "build_queryplan" "malformed scalar query probe recipe entry"))))
 
 (define scalar_query_probe_recipe_bindings (lambda (all_stages entries)
-	(map (coalesceNil entries '()) (lambda (entry)
-		(scalar_query_probe_recipe_binding all_stages entry)))))
+	(begin
+		(define dependency_graph (stage_dependency_graph all_stages))
+		(map (coalesceNil entries '()) (lambda (entry)
+			(scalar_query_probe_recipe_binding all_stages dependency_graph entry))))))
 
 (define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages)
 	(begin
@@ -5169,6 +5171,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(if (query_block? src)
 			(lower_scalar_first_query_probe_expr
 				all_stages
+				(stage_dependency_graph all_stages)
 				stage
 				value_expr
 				keys
@@ -7023,7 +7026,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(physicalize_stage_output_source stages src)))))
 
 (define stage_outputs_from_sources_using (lambda (stages sources)
-	(merge_unique (list (filter (map (coalesceNil sources '()) (lambda (src)
+	(unique_stages_by_id (filter (map (coalesceNil sources '()) (lambda (src)
 		(match src
 			'(_alias _schema relation _outer _join_expr)
 			(if (not (stage_output_relation? relation))
@@ -7035,7 +7038,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 						(neumann_fail "build_queryplan" (concat "dependency stage-output source references unknown stage " id))
 						stage)))
 			_ nil)))
-		(lambda (stage) (not (nil? stage))))))))
+		(lambda (stage) (not (nil? stage)))))))
 
 (define available_stage_outputs_from_sources_using (lambda (stages sources)
 	(filter (map (coalesceNil sources '()) (lambda (src)
@@ -7087,26 +7090,6 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(scalar_first_stage_output_source? stages src)
 		(presence_stage_output_source? stages src))))
 
-(define probeable_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
-	(reduce (coalesceNil sources '()) (lambda (found src)
-		(if (not (nil? found))
-			found
-			(if (and (probeable_stage_output_source? stages src)
-				(source_alias_matches? src default_alias tblvar tbl_ignorecase))
-				(stage_by_id stages (stage_output_relation_id (source_relation src)))
-				nil)))
-		nil)))
-
-(define scalar_aggregate_probe_stage_for_alias (lambda (stages sources default_alias tblvar tbl_ignorecase)
-	(reduce (coalesceNil sources '()) (lambda (found src)
-		(if (not (nil? found))
-			found
-			(if (and (scalar_aggregate_probe_stage_output_source? stages src)
-				(source_alias_matches? src default_alias tblvar tbl_ignorecase))
-				(stage_by_id stages (stage_output_relation_id (source_relation src)))
-				nil)))
-		nil)))
-
 (define list_index_of_from (lambda (items value offset)
 	(begin
 		(define rest (coalesceNil items '()))
@@ -7128,24 +7111,69 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(nth lookup_keys idx)
 			nil))))
 
-(define rewrite_scalar_first_probe_expr (lambda (stages sources default_alias expr)
+(define probe_stage_alias_key (lambda (alias insensitive)
+	(list
+		(if insensitive (quote insensitive) (quote exact))
+		(if (and insensitive (string? alias)) (toLower alias) alias))))
+
+(define probe_stage_alias_index (lambda (stages sources)
+	(begin
+		(define probe_stages (unique_stages_by_id (filter
+			(map (coalesceNil sources '()) (lambda (src)
+				(source_stage_output_stage stages src)))
+			(lambda (stage) (or (scalar_or_presence_probe_stage? stage)
+				(scalar_aggregate_probe_stage? stage))))))
+		(define closures (stage_dependency_closure_index_using_graph
+			(stage_dependency_graph stages) probe_stages))
+		(reduce (coalesceNil sources '()) (lambda (index src)
+			(begin
+				(define stage (source_stage_output_stage stages src))
+				(if (or (scalar_or_presence_probe_stage? stage)
+					(scalar_aggregate_probe_stage? stage))
+					(begin
+						(define entry (list stage (get_assoc closures (logical_stage_key stage))))
+						(define exact_key (probe_stage_alias_key (source_alias src) false))
+						(define insensitive_key (probe_stage_alias_key (source_alias src) true))
+						(define with_exact (if (has_assoc? index exact_key)
+							index
+							(set_assoc index exact_key entry)))
+						(if (has_assoc? with_exact insensitive_key)
+							with_exact
+							(set_assoc with_exact insensitive_key entry)))
+					index))) '()))))
+
+(define probe_stage_entry_for_alias_using_index (lambda (index default_alias tblvar tbl_ignorecase)
+	(get_assoc index
+		(probe_stage_alias_key (resolve_column_alias tblvar default_alias) tbl_ignorecase))))
+
+(define rewrite_scalar_first_probe_expr_using_index (lambda (stages index default_alias expr)
 	(match expr
-		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
-			(define stage (probeable_stage_for_alias stages sources default_alias tblvar tbl_ignorecase))
-			(if (nil? stage)
+		((symbol get_column) tblvar tbl_ignorecase col _col_ignorecase) (begin
+			(define entry (probe_stage_entry_for_alias_using_index index default_alias tblvar tbl_ignorecase))
+			(if (nil? entry)
+				expr
 				(begin
-					(define aggregate_stage (scalar_aggregate_probe_stage_for_alias stages sources default_alias tblvar tbl_ignorecase))
-					(if (nil? aggregate_stage)
-						expr
-						(scalar_aggregate_probe_expr aggregate_stage col)))
-				(coalesceNil
-					(scalar_first_stage_key_lookup_expr stage col)
-					(scalar_first_probe_expr stage col (lowering_catalog_stages stages)))))
+					(define stage (nth entry 0))
+					(define dependencies (nth entry 1))
+					(if (scalar_aggregate_probe_stage? stage)
+						(scalar_aggregate_probe_expr stage col)
+						(coalesceNil
+							(scalar_first_stage_key_lookup_expr stage col)
+							(scalar_first_probe_expr stage col dependencies))))))
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(rewrite_scalar_first_probe_expr stages sources default_alias (list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		(rewrite_scalar_first_probe_expr_using_index stages index default_alias
+			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
 		(cons head tail) (cons head (map tail (lambda (item)
-			(rewrite_scalar_first_probe_expr stages sources default_alias item))))
+			(rewrite_scalar_first_probe_expr_using_index stages index default_alias item))))
 		_ expr)))
+
+(define rewrite_scalar_first_probe_expr (lambda (stages sources default_alias expr)
+	(rewrite_scalar_first_probe_expr_using_index stages
+		(probe_stage_alias_index stages sources) default_alias expr)))
+
+(define rewrite_scalar_first_probe_fields_using_index (lambda (stages index default_alias fields)
+	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
+		(rewrite_scalar_first_probe_expr_using_index stages index default_alias expr)))))
 
 (define rewrite_scalar_first_probe_fields (lambda (stages sources default_alias fields)
 	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
@@ -7155,6 +7183,12 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 	(map (coalesceNil order_items '()) (lambda (item)
 		(match item
 			'(expr dir) (list (rewrite_scalar_first_probe_expr stages sources default_alias expr) dir)
+			_ item)))))
+
+(define rewrite_scalar_first_probe_order_using_index (lambda (stages index default_alias order_items)
+	(map (coalesceNil order_items '()) (lambda (item)
+		(match item
+			'(expr dir) (list (rewrite_scalar_first_probe_expr_using_index stages index default_alias expr) dir)
 			_ item)))))
 
 (define rewrite_scalar_first_probe_aggregate (lambda (stages sources default_alias ag)
@@ -7212,6 +7246,15 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(source_relation src)
 			(source_outer? src)
 			(rewrite_scalar_first_probe_expr stages rewrite_sources default_alias (source_join_expr src)))))))
+
+(define rewrite_scalar_first_probe_sources_using_index (lambda (stages sources index default_alias)
+	(map (coalesceNil sources '()) (lambda (src)
+		(list
+			(source_alias src)
+			(source_schema src)
+			(source_relation src)
+			(source_outer? src)
+			(rewrite_scalar_first_probe_expr_using_index stages index default_alias (source_join_expr src)))))))
 
 (define sources_without_scalar_first_outputs (lambda (stages sources)
 	(filter (coalesceNil sources '()) (lambda (src)
@@ -7320,10 +7363,11 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(scalar_aggregate_probe_output_source_for_block? stages sources default_alias limit_value src))))))
 
 (define sources_without_probe_outputs (lambda (sources probe_sources)
-	(filter (coalesceNil sources '()) (lambda (src)
-		(not (reduce probe_sources (lambda (found probe_src)
-			(or found (equal? (source_alias src) (source_alias probe_src))))
-			false))))))
+	(begin
+		(define probe_aliases (reduce (coalesceNil probe_sources '()) (lambda (aliases src)
+			(set_assoc aliases (source_alias src) true)) '()))
+		(filter (coalesceNil sources '()) (lambda (src)
+			(not (has_assoc? probe_aliases (source_alias src))))))))
 
 (define presence_probe_output_sources (lambda (stages sources default_alias)
 	(filter (coalesceNil sources '()) (lambda (src)
@@ -7449,32 +7493,47 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 					(group_stage_direct_dependencies_using_indexes id_index carrier_index stage)
 					'()))) '()))))
 
-(define stage_dependency_closure_visit (lambda (graph stage states)
+(define stage_dependency_closure_index_visit (lambda (graph stage states closures)
 	(begin
 		(define key (logical_stage_key stage))
 		(define state (if (has_assoc? states key) (states key) nil))
 		(if (equal? state (quote visiting))
 			(neumann_fail "build_queryplan" (concat "cyclic physical stage dependency " key))
 			true)
-		(if (equal? state (quote done))
-			(list '() states)
+		(if (has_assoc? closures key)
+			(list (closures key) states closures)
 			(begin
-				(define visiting (set_assoc states key (quote visiting)))
-				(define direct (if (has_assoc? graph key) (graph key) '()))
-				(define nested (reduce direct (lambda (acc dependency)
+				(define nested (reduce (if (has_assoc? graph key) (graph key) '()) (lambda (acc dependency)
 					(begin
-						(define result (stage_dependency_closure_visit graph dependency (nth acc 1)))
-						(list (merge (list (nth acc 0) (nth result 0))) (nth result 1))))
-					(list '() visiting)))
+						(define result (stage_dependency_closure_index_visit
+							graph dependency (nth acc 1) (nth acc 2)))
+						(list
+							(merge (list (nth acc 0) (nth result 0)))
+							(nth result 1)
+							(nth result 2))))
+					(list '() (set_assoc states key (quote visiting)) closures)))
+				(define closure (unique_stages_by_id (cons stage (nth nested 0))))
 				(list
-					(cons stage (nth nested 0))
-					(set_assoc (nth nested 1) key (quote done))))))))
+					closure
+					(set_assoc (nth nested 1) key (quote done))
+					(set_assoc (nth nested 2) key closure)))))))
+
+(define stage_dependency_closure_index_using_graph (lambda (graph stages)
+	(nth (reduce (coalesceNil stages '()) (lambda (acc stage)
+		(begin
+			(define result (stage_dependency_closure_index_visit graph stage (nth acc 0) (nth acc 1)))
+			(list (nth result 1) (nth result 2))))
+		(list '() '())) 1)))
 
 (define stage_dependency_closure_using_graph (lambda (graph stage)
-	(nth (stage_dependency_closure_visit graph stage '()) 0)))
+	(nth (stage_dependency_closure_index_visit graph stage '() '()) 0)))
 
-(define consumed_stage_closure (lambda (stages stage)
-	(stage_dependency_closure_using_graph (stage_dependency_graph stages) stage)))
+(define stage_dependency_closure_many_using_graph (lambda (graph stages)
+	(begin
+		(define roots (coalesceNil stages '()))
+		(define closures (stage_dependency_closure_index_using_graph graph roots))
+		(unique_stages_by_id (merge (map roots (lambda (stage)
+			(get_assoc closures (logical_stage_key stage)))))))))
 
 (define expr_probe_stages (lambda (expr)
 	(match expr
@@ -7597,33 +7656,32 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 	(filter (coalesceNil stages '()) (lambda (stage)
 		(not (contains? ids (gs_id stage)))))))
 
-(define scalar_first_probe_consumed_stages (lambda (stages stage)
-	(if (not (scalar_or_presence_probe_stage? stage))
-		'()
-		(consumed_stage_closure stages stage))))
+(define scalar_probe_consumed_stages_many_using_graph (lambda (graph stages)
+	(unique_stages_by_id (merge (list
+		(filter (coalesceNil stages '()) scalar_aggregate_probe_stage?)
+		(stage_dependency_closure_many_using_graph graph
+			(filter (coalesceNil stages '()) scalar_or_presence_probe_stage?)))))))
 
-(define scalar_probe_consumed_stages (lambda (stages stage)
-	(if (scalar_aggregate_probe_stage? stage)
-		(list stage)
-		(scalar_first_probe_consumed_stages stages stage))))
+(define stage_id_set (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (ids stage)
+		(set_assoc ids (gs_id stage) true)) '())))
+
+(define stages_without_consumed_probes_using_graph (lambda (graph stages probe_stages)
+	(begin
+		(define consumed_ids (stage_id_set
+			(scalar_probe_consumed_stages_many_using_graph graph probe_stages)))
+		(filter (coalesceNil stages '()) (lambda (stage)
+			(not (has_assoc? consumed_ids (gs_id stage))))))))
 
 (define stages_without_scalar_first_probes (lambda (stages)
-	(begin
-		(define consumed_ids (map
-			(merge_unique (map (coalesceNil stages '()) (lambda (stage)
-				(scalar_probe_consumed_stages stages stage))))
-			gs_id))
-		(filter (coalesceNil stages '()) (lambda (stage)
-			(not (contains? consumed_ids (gs_id stage))))))))
+	(stages_without_consumed_probes_using_graph
+		(stage_dependency_graph stages) stages stages)))
 
 (define stages_without_probe_sources (lambda (stages probe_sources)
 	(begin
-		(define consumed_ids (map
-			(merge_unique (map (stage_outputs_from_sources_using stages probe_sources) (lambda (stage)
-				(scalar_probe_consumed_stages stages stage))))
-			gs_id))
-		(filter (coalesceNil stages '()) (lambda (stage)
-			(not (contains? consumed_ids (gs_id stage))))))))
+		(define graph (stage_dependency_graph stages))
+		(stages_without_consumed_probes_using_graph graph stages
+			(stage_outputs_from_sources_using stages probe_sources)))))
 
 (define query_block_with_scalar_first_probes_using (lambda (stages block)
 	(begin
@@ -7631,18 +7689,19 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(define sources (qb_sources block))
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
 		(define probe_sources (probe_output_sources_for_block stages sources default_alias (qb_limit block)))
-		(define rewritten_sources (rewrite_scalar_first_probe_sources_using stages sources probe_sources default_alias))
+		(define probe_index (probe_stage_alias_index stages probe_sources))
+		(define rewritten_sources (rewrite_scalar_first_probe_sources_using_index stages sources probe_index default_alias))
 		(make_query_block
 			(qb_schema block)
 			(sources_without_probe_outputs rewritten_sources probe_sources)
-			(rewrite_scalar_first_probe_fields stages probe_sources default_alias (qb_fields block))
-			(rewrite_scalar_first_probe_expr stages probe_sources default_alias (qb_where block))
+			(rewrite_scalar_first_probe_fields_using_index stages probe_index default_alias (qb_fields block))
+			(rewrite_scalar_first_probe_expr_using_index stages probe_index default_alias (qb_where block))
 			(qb_group block)
-			(rewrite_scalar_first_probe_expr stages probe_sources default_alias (qb_having block))
-			(rewrite_scalar_first_probe_order stages probe_sources default_alias (qb_order block))
+			(rewrite_scalar_first_probe_expr_using_index stages probe_index default_alias (qb_having block))
+			(rewrite_scalar_first_probe_order_using_index stages probe_index default_alias (qb_order block))
 			(qb_limit block)
 			(qb_offset block)
-			(rewrite_scalar_first_probe_fields stages probe_sources default_alias (qb_hidden block))
+			(rewrite_scalar_first_probe_fields_using_index stages probe_index default_alias (qb_hidden block))
 			(stages_without_probe_sources (qb_stages block) probe_sources)
 			(query_block_facts_with_stage_catalog block stage_list)))))
 

--- a/tests/66_scalar_probe_compile_scaling.yaml
+++ b/tests/66_scalar_probe_compile_scaling.yaml
@@ -1,0 +1,99 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Scalar probe compile-time scaling"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS scale_host"
+  - sql: "DROP TABLE IF EXISTS scale_box"
+  - sql: |
+      CREATE TABLE scale_host (
+        id INT PRIMARY KEY,
+        kind INT
+      )
+  - sql: |
+      CREATE TABLE scale_box (
+        id INT PRIMARY KEY,
+        host_id INT
+      )
+  - sql: "INSERT INTO scale_host (id, kind) VALUES (1, 1)"
+  - sql: "INSERT INTO scale_box (id, host_id) VALUES (1, 1)"
+
+test_cases:
+  - name: "Distinct scalar probe stages compile within a linear budget"
+    max_time: 1.0
+    max_compile_phase_ms:
+      recipe_emit_ns: 700
+    sql: |
+      SELECT
+        (SELECT probe_1.kind FROM scale_host probe_1 WHERE probe_1.id = outer_row.host_id AND probe_1.kind = 1 LIMIT 1) AS value_1,
+        (SELECT probe_2.kind FROM scale_host probe_2 WHERE probe_2.id = outer_row.host_id AND probe_2.kind = 2 LIMIT 1) AS value_2,
+        (SELECT probe_3.kind FROM scale_host probe_3 WHERE probe_3.id = outer_row.host_id AND probe_3.kind = 3 LIMIT 1) AS value_3,
+        (SELECT probe_4.kind FROM scale_host probe_4 WHERE probe_4.id = outer_row.host_id AND probe_4.kind = 4 LIMIT 1) AS value_4,
+        (SELECT probe_5.kind FROM scale_host probe_5 WHERE probe_5.id = outer_row.host_id AND probe_5.kind = 5 LIMIT 1) AS value_5,
+        (SELECT probe_6.kind FROM scale_host probe_6 WHERE probe_6.id = outer_row.host_id AND probe_6.kind = 6 LIMIT 1) AS value_6,
+        (SELECT probe_7.kind FROM scale_host probe_7 WHERE probe_7.id = outer_row.host_id AND probe_7.kind = 7 LIMIT 1) AS value_7,
+        (SELECT probe_8.kind FROM scale_host probe_8 WHERE probe_8.id = outer_row.host_id AND probe_8.kind = 8 LIMIT 1) AS value_8,
+        (SELECT probe_9.kind FROM scale_host probe_9 WHERE probe_9.id = outer_row.host_id AND probe_9.kind = 9 LIMIT 1) AS value_9,
+        (SELECT probe_10.kind FROM scale_host probe_10 WHERE probe_10.id = outer_row.host_id AND probe_10.kind = 10 LIMIT 1) AS value_10,
+        (SELECT probe_11.kind FROM scale_host probe_11 WHERE probe_11.id = outer_row.host_id AND probe_11.kind = 11 LIMIT 1) AS value_11,
+        (SELECT probe_12.kind FROM scale_host probe_12 WHERE probe_12.id = outer_row.host_id AND probe_12.kind = 12 LIMIT 1) AS value_12,
+        (SELECT probe_13.kind FROM scale_host probe_13 WHERE probe_13.id = outer_row.host_id AND probe_13.kind = 13 LIMIT 1) AS value_13,
+        (SELECT probe_14.kind FROM scale_host probe_14 WHERE probe_14.id = outer_row.host_id AND probe_14.kind = 14 LIMIT 1) AS value_14,
+        (SELECT probe_15.kind FROM scale_host probe_15 WHERE probe_15.id = outer_row.host_id AND probe_15.kind = 15 LIMIT 1) AS value_15,
+        (SELECT probe_16.kind FROM scale_host probe_16 WHERE probe_16.id = outer_row.host_id AND probe_16.kind = 16 LIMIT 1) AS value_16,
+        (SELECT probe_17.kind FROM scale_host probe_17 WHERE probe_17.id = outer_row.host_id AND probe_17.kind = 17 LIMIT 1) AS value_17,
+        (SELECT probe_18.kind FROM scale_host probe_18 WHERE probe_18.id = outer_row.host_id AND probe_18.kind = 18 LIMIT 1) AS value_18,
+        (SELECT probe_19.kind FROM scale_host probe_19 WHERE probe_19.id = outer_row.host_id AND probe_19.kind = 19 LIMIT 1) AS value_19,
+        (SELECT probe_20.kind FROM scale_host probe_20 WHERE probe_20.id = outer_row.host_id AND probe_20.kind = 20 LIMIT 1) AS value_20,
+        (SELECT probe_21.kind FROM scale_host probe_21 WHERE probe_21.id = outer_row.host_id AND probe_21.kind = 21 LIMIT 1) AS value_21,
+        (SELECT probe_22.kind FROM scale_host probe_22 WHERE probe_22.id = outer_row.host_id AND probe_22.kind = 22 LIMIT 1) AS value_22,
+        (SELECT probe_23.kind FROM scale_host probe_23 WHERE probe_23.id = outer_row.host_id AND probe_23.kind = 23 LIMIT 1) AS value_23,
+        (SELECT probe_24.kind FROM scale_host probe_24 WHERE probe_24.id = outer_row.host_id AND probe_24.kind = 24 LIMIT 1) AS value_24,
+        (SELECT probe_25.kind FROM scale_host probe_25 WHERE probe_25.id = outer_row.host_id AND probe_25.kind = 25 LIMIT 1) AS value_25,
+        (SELECT probe_26.kind FROM scale_host probe_26 WHERE probe_26.id = outer_row.host_id AND probe_26.kind = 26 LIMIT 1) AS value_26,
+        (SELECT probe_27.kind FROM scale_host probe_27 WHERE probe_27.id = outer_row.host_id AND probe_27.kind = 27 LIMIT 1) AS value_27,
+        (SELECT probe_28.kind FROM scale_host probe_28 WHERE probe_28.id = outer_row.host_id AND probe_28.kind = 28 LIMIT 1) AS value_28,
+        (SELECT probe_29.kind FROM scale_host probe_29 WHERE probe_29.id = outer_row.host_id AND probe_29.kind = 29 LIMIT 1) AS value_29,
+        (SELECT probe_30.kind FROM scale_host probe_30 WHERE probe_30.id = outer_row.host_id AND probe_30.kind = 30 LIMIT 1) AS value_30,
+        (SELECT probe_31.kind FROM scale_host probe_31 WHERE probe_31.id = outer_row.host_id AND probe_31.kind = 31 LIMIT 1) AS value_31,
+        (SELECT probe_32.kind FROM scale_host probe_32 WHERE probe_32.id = outer_row.host_id AND probe_32.kind = 32 LIMIT 1) AS value_32,
+        (SELECT probe_33.kind FROM scale_host probe_33 WHERE probe_33.id = outer_row.host_id AND probe_33.kind = 33 LIMIT 1) AS value_33,
+        (SELECT probe_34.kind FROM scale_host probe_34 WHERE probe_34.id = outer_row.host_id AND probe_34.kind = 34 LIMIT 1) AS value_34,
+        (SELECT probe_35.kind FROM scale_host probe_35 WHERE probe_35.id = outer_row.host_id AND probe_35.kind = 35 LIMIT 1) AS value_35,
+        (SELECT probe_36.kind FROM scale_host probe_36 WHERE probe_36.id = outer_row.host_id AND probe_36.kind = 36 LIMIT 1) AS value_36,
+        (SELECT probe_37.kind FROM scale_host probe_37 WHERE probe_37.id = outer_row.host_id AND probe_37.kind = 37 LIMIT 1) AS value_37,
+        (SELECT probe_38.kind FROM scale_host probe_38 WHERE probe_38.id = outer_row.host_id AND probe_38.kind = 38 LIMIT 1) AS value_38,
+        (SELECT probe_39.kind FROM scale_host probe_39 WHERE probe_39.id = outer_row.host_id AND probe_39.kind = 39 LIMIT 1) AS value_39,
+        (SELECT probe_40.kind FROM scale_host probe_40 WHERE probe_40.id = outer_row.host_id AND probe_40.kind = 40 LIMIT 1) AS value_40,
+        (SELECT probe_41.kind FROM scale_host probe_41 WHERE probe_41.id = outer_row.host_id AND probe_41.kind = 41 LIMIT 1) AS value_41,
+        (SELECT probe_42.kind FROM scale_host probe_42 WHERE probe_42.id = outer_row.host_id AND probe_42.kind = 42 LIMIT 1) AS value_42,
+        (SELECT probe_43.kind FROM scale_host probe_43 WHERE probe_43.id = outer_row.host_id AND probe_43.kind = 43 LIMIT 1) AS value_43,
+        (SELECT probe_44.kind FROM scale_host probe_44 WHERE probe_44.id = outer_row.host_id AND probe_44.kind = 44 LIMIT 1) AS value_44,
+        (SELECT probe_45.kind FROM scale_host probe_45 WHERE probe_45.id = outer_row.host_id AND probe_45.kind = 45 LIMIT 1) AS value_45,
+        (SELECT probe_46.kind FROM scale_host probe_46 WHERE probe_46.id = outer_row.host_id AND probe_46.kind = 46 LIMIT 1) AS value_46,
+        (SELECT probe_47.kind FROM scale_host probe_47 WHERE probe_47.id = outer_row.host_id AND probe_47.kind = 47 LIMIT 1) AS value_47,
+        (SELECT probe_48.kind FROM scale_host probe_48 WHERE probe_48.id = outer_row.host_id AND probe_48.kind = 48 LIMIT 1) AS value_48
+      FROM scale_box outer_row
+      LIMIT 1
+    expect:
+      rows: 1
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS scale_box"
+  - sql: "DROP TABLE IF EXISTS scale_host"
+


### PR DESCRIPTION
## Summary

- index scalar/presence probe sources once per query block instead of rescanning them for every projected expression
- compute the stage dependency graph once per recipe batch and memoize transitive closures per probe stage
- carry only each probe's required stage closure through lowering instead of embedding the complete stage catalog in every marker
- replace deep stage/list deduplication and repeated consumed-stage scans with ID-keyed sets
- add an anonymous CI-active 48-probe regression with a 1 s total and 700 ms `recipe_emit` budget

## Root cause

Wide projections with many distinct correlated scalar probes repeated three costs for every field: linear alias lookup, dependency-graph reconstruction, and traversal of the complete lowering catalog embedded in the probe marker. The repeated catalog traversal dominated `recipe_emit` and produced polynomial compile-time growth.

The new alias index preserves first-match and case-insensitive lookup semantics. The memoized reachability visitor is shared by single-root, multi-root, and indexed closure consumers, including cycle detection.

## A/B measurements

Same base commit, fresh data directories, three cold `EXPLAIN COMPILE` samples per point; values are medians.

| Distinct probes | Master recipe emit | PR recipe emit | Speedup | Master planner | PR planner | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 32 | 1152.8 ms | 191.9 ms | 6.0x | 1290.3 ms | 299.7 ms | 4.3x |
| 48 | 2350.4 ms | 315.1 ms | 7.5x | 2579.6 ms | 512.2 ms | 5.0x |
| 64 | 3966.8 ms | 446.2 ms | 8.9x | 4248.7 ms | 716.0 ms | 5.9x |
| 128 | 15429.4 ms | 1319.5 ms | 11.7x | 16154.3 ms | 2021.6 ms | 8.0x |

Plan shape is unchanged at every point. For example, 128 probes produce 7,720 plan nodes and 77,112 plan bytes on both revisions.

An anonymized 72 KB trace query with 49 group stages was also measured with three cold samples:

| Revision | Recipe emit median | Planner median | Plan nodes | Plan bytes |
|---|---:|---:|---:|---:|
| Master | 5238.9 ms | 7156.9 ms | 19068 | 577152 |
| PR | 2851.6 ms | 4752.2 ms | 19068 | 577152 |

That is a 1.84x recipe-emission speedup and 1.51x planner speedup without changing the physical plan.

## Validation

- fail-first confirmed on master: the new active regression fails at `recipe_emit=2308 ms > 700 ms`
- PR passes the same 700 ms phase budget
- focused hook-equivalent coverage run: 113/113 SQL cases passed across scalar, nested, grouped, window, DML, and dependency-stage suites
- Scheme formatter run; `git diff --check` clean
- serial full `make test` completed but the heavily loaded host reported four unrelated suites: two ORDER runtime budgets, two post-restart `query killed` responses, and one lock timing race. The storage/restart and lock suites all passed when rerun independently; the ORDER budget remained CPU-load-bound. No thresholds were changed.