### PR TITLE
Reuse warm aggregate carriers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -8126,13 +8126,11 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(merge (list
 				(list
 					(list (quote if)
-						(list (quote createtable) schema grouptbl create_cols (quoted_runtime_list '("engine" "sloppy")) true)
+						(list (quote createtable) schema grouptbl create_cols (quoted_runtime_list '("engine" "memory")) true)
 						nil
 						nil)
 					(list (quote touch_keytable) (list (quote table) schema grouptbl)))
-				(list (list (quote or)
-					(list (quote not) (list (quote has?) (list (quote show) schema) grouptbl))
-					(list (quote table_empty?) (list (quote table) schema grouptbl))))))))
+				(list (list (quote table_empty?) (list (quote table) schema grouptbl)))))))
 		(define collect_plan (if query_input_carrier
 			(if (union_block? src)
 				(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names (list aggregate_count_descriptor))
@@ -8314,7 +8312,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 				(if (query_block? src) (query_block_stage_catalog src) '())))))
 		(list (quote begin)
 			(lower_group_stage_prepare_using stage_catalog stage_catalog stage)
-			(lower_query_block_core_with_lazy_prepares stage_catalog
+			(lower_query_block_core
 				(group_stage_final_block stage (group_stage_final_extra_sources_using stage_catalog stage)))))))
 
 (define row_number_get_column? (lambda (col expr)

--- a/tests/83_group_cache_invalidation.yaml
+++ b/tests/83_group_cache_invalidation.yaml
@@ -79,6 +79,18 @@ test_cases:
         - "createcolumn"
         - ".grp:sc_base:"
 
+  - name: "GROUP BY lowering prepares each canonical carrier once"
+    sql: "EXPLAIN SELECT dept, COUNT(*) AS c, SUM(salary) AS s FROM sc_base GROUP BY dept ORDER BY dept"
+    expect:
+      rows: 1
+      result_occurrences:
+        - text: "touch_keytable"
+          count: 1
+      result_not_contains:
+        - "(show"
+      result_contains:
+        - "memory"
+
   # === INSERT new rows into base table ===
   - name: "Insert new Engineering employee"
     sql: "INSERT INTO sc_base (id, dept, salary, active) VALUES (6, 'Engineering', 300, true)"


### PR DESCRIPTION
## Summary

- prepare each canonical group carrier once in the physical plan
- reuse an existing non-empty group keytable instead of recollecting all source keys
- keep derived keytables in `ENGINE=MEMORY`, so crash/WAL recovery starts from an empty cache instead of reusing stale derived rows

## Root cause

Group-stage lowering prepared the same carrier explicitly and again through lazy query-block preparation. Its runtime guard also checked the internal relation through `show`, which intentionally hides internal tables. The check therefore evaluated true on every execution and rescanned the full source even when the keytable and aggregate columns were valid.

Simply removing that check exposed a recovery invariant: a persisted sloppy keytable can be older than WAL-replayed source rows. Group keytables are derived cache state, so this patch retains their schema but makes their rows restart-local through the existing memory-table lifecycle.

## A/B benchmark

Base: `178380a6bb3db593e4501bc12b0d81d215be9a65`

Synthetic workload: 10,010 source rows, 100 groups, `COUNT(*)` and `SUM(value)`, 20 warm HTTP executions after one cold execution.

| Metric | Master | Branch | Change |
| --- | ---: | ---: | ---: |
| Warm median | 19.916 ms | 1.465 ms | 13.6x faster |
| Physical plan size | 11,676 bytes | 5,126 bytes | -56.1% |
| `touch_keytable` calls | 2 | 1 | -50% |
| Base-table scans per warm execution | 1 | 0 | eliminated |

Cold execution remains effectively unchanged at about 155 ms because the carrier must be built once.

Manual integration workload, three complete runs per engine with four workers and tracing disabled:

| Engine | Runs | Median |
| --- | --- | ---: |
| Master | 69.64 / 69.49 / 70.35 s | 69.64 s |
| Branch | 69.46 / 66.95 / 67.10 s | 67.10 s |
| MySQL | 58.86 / 63.61 / 56.99 s | 58.86 s |

The branch improves the complete workload by 3.6%. The median gap to MySQL decreases from 18.3% to 14.0%.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`
- `tests/83_group_cache_invalidation.yaml`: 96/96
- `tests/95_crash_recovery.yaml`: 88/88
- `tests/40_exists_subquery.yaml`: 22/22
- `tests/54_transactions.yaml`: 171/171
- `tests/66_count_sum_derived_table.yaml`: 5/5
- `tests/112_session_group_empty_keytable.yaml`: 4/4
- `tests/116_campaign_agg_empty_keytable.yaml`: 3/3
- insert, group-key update, and delete checks on the benchmark dataset

The new plan regression requires one carrier preparation, no public-schema `show` lookup for the internal relation, and memory-backed derived keytables.
