### PR TITLE
sql: normalize DECIMAL aggregate output scale

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5852,6 +5852,84 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(cons head tail) (merge_unique (map tail extract_aggregates))
 		_ '())))
 
+/* DECIMAL is currently represented as float64 at runtime. Keep calculations
+unmodified, but normalize visible aggregate results to the declared scale of
+their DECIMAL inputs so binary floating-point residue does not leak through the
+SQL output boundary. This annotation is attached while base-column provenance
+is still available and remains an ordinary scalar expression through untangle. */
+(define decimal_column_scale (lambda (src col)
+	(if (or (not (string? (source_schema src))) (not (string? (source_relation src))))
+		nil
+		(begin
+			(define info (find (get_schema (source_schema src) (source_relation src))
+				(lambda (candidate) (equal?? (candidate "Field") col)) nil))
+			(define dimensions (if (nil? info) '() (coalesceNil (info "Dimensions") '())))
+			(if (and (not (nil? info))
+				(equal? (toLower (coalesceNil (info "RawType") "")) "decimal")
+				(> (count dimensions) 1))
+				(nth dimensions 1)
+				nil)))))
+
+(define decimal_column_scale_for_sources (lambda (sources tblvar col)
+	(reduce (coalesceNil sources '()) (lambda (best src)
+		(if (and (or (nil? tblvar) (equal?? tblvar (source_alias src)))
+			(not (stage_output_relation? (source_relation src))))
+			(begin
+				(define scale (decimal_column_scale src col))
+				(if (nil? scale) best (if (nil? best) scale (max best scale))))
+			best)) nil)))
+
+(define decimal_expr_scale (lambda (sources expr)
+	(match expr
+		((symbol get_column) tblvar _ignorecase col _col_ignorecase)
+		(decimal_column_scale_for_sources sources tblvar col)
+		((quote get_column) tblvar _ignorecase col _col_ignorecase)
+		(decimal_column_scale_for_sources sources tblvar col)
+		(cons _head tail) (reduce tail (lambda (best item)
+			(begin
+				(define scale (decimal_expr_scale sources item))
+				(if (nil? scale) best (if (nil? best) scale (max best scale))))) nil)
+		_ nil)))
+
+(define decimal_aggregate_output_scale (lambda (sources expr)
+	(reduce (extract_aggregates expr) (lambda (best aggregate_descriptor)
+		(begin
+			(define scale (decimal_expr_scale sources (nth aggregate_descriptor 0)))
+			(if (nil? scale) best (if (nil? best) scale (max best scale))))) nil)))
+
+(define sanitize_decimal_aggregate_fields (lambda (sources fields)
+	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
+		(begin
+			(define scale (decimal_aggregate_output_scale sources expr))
+			(if (nil? scale) expr (list (quote sql_decimal_output) expr scale)))))))
+
+(define sanitize_decimal_aggregate_outputs (lambda (query)
+	(begin
+		(define normalized (normalize_query_ast query))
+		(if (query_block? normalized)
+			(make_query_block
+				(qb_schema normalized)
+				(qb_sources normalized)
+				(sanitize_decimal_aggregate_fields (qb_sources normalized) (qb_fields normalized))
+				(qb_where normalized)
+				(qb_group normalized)
+				(qb_having normalized)
+				(qb_order normalized)
+				(qb_limit normalized)
+				(qb_offset normalized)
+				(qb_hidden normalized)
+				(qb_stages normalized)
+				(qb_facts normalized))
+			(if (union_block? normalized)
+				(make_union_block
+					(union_mode normalized)
+					(map (union_branches normalized) sanitize_decimal_aggregate_outputs)
+					(union_order normalized)
+					(union_limit normalized)
+					(union_offset normalized)
+					(union_facts normalized))
+				normalized)))))
+
 (define stage_aggregates_for_fields (lambda (fields)
 	(merge_unique (extract_assoc fields (lambda (_title expr) (extract_aggregates expr))))))
 
@@ -10490,7 +10568,7 @@ build_queryplan contract. */
 (define neumann_compile_pipeline (lambda (ast)
 	(build_queryplan
 		(join_reorder
-			(untangle_query_term ast nil)))))
+			(untangle_query_term (sanitize_decimal_aggregate_outputs ast) nil)))))
 
 (define neumann_compile_ir_pipeline (lambda (ir)
 	(build_queryplan

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -819,6 +819,19 @@ class SQLTestRunner:
                 step_sid = step.get("session_id")
                 step_timeout = int(step.get("timeout", 30))
                 step_expect = step.get("expect", {})
+                if step.get("wait_for_background"):
+                    for thread in bg_threads:
+                        thread.join(timeout=step_timeout)
+                    if any(thread.is_alive() for thread in bg_threads):
+                        return self._record_fail(
+                            name,
+                            "Background step did not finish before synchronization timeout",
+                            "wait_for_background",
+                            None,
+                            None,
+                            is_noncritical,
+                        )
+                    continue
                 if step.get("background"):
                     t = threading.Thread(target=run_bg_step, args=(step, bg_results), daemon=True)
                     t.start()

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -47,7 +47,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 			JITEmit: func(ctx *JITContext, args []Scmer, descs []JITValueDesc, result JITValueDesc) JITValueDesc {
 				d0 := descs[0]
 				r0 := ctx.AllocReg()
@@ -72,7 +72,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -109,8 +109,8 @@ func init_alu() {
 			Params: []*TypeDescriptor{
 				{Kind: "number", ParamName: "value...", ParamDesc: "values to add", Variadic: true},
 			},
-			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Return:   &TypeDescriptor{Kind: "number"},
+			Const:    true,
 			Optimize: optimizeAssociative,
 		},
 	})
@@ -153,7 +153,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -198,8 +198,8 @@ func init_alu() {
 			Params: []*TypeDescriptor{
 				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
 			},
-			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Return:   &TypeDescriptor{Kind: "number"},
+			Const:    true,
 			Optimize: optimizeAssociative,
 		},
 	})
@@ -224,7 +224,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -253,7 +253,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "b", ParamDesc: "divisor"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -268,7 +268,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -283,7 +283,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -298,7 +298,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -313,7 +313,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -328,7 +328,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -343,7 +343,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -373,7 +373,7 @@ func init_alu() {
 				{Kind: "string", ParamName: "collation", ParamDesc: "collation name"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -393,7 +393,7 @@ func init_alu() {
 				{Kind: "string", ParamName: "collation", ParamDesc: "collation name"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -407,7 +407,7 @@ func init_alu() {
 				{Kind: "bool", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -421,7 +421,7 @@ func init_alu() {
 				{Kind: "bool", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -435,7 +435,7 @@ func init_alu() {
 				{Kind: "any", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -457,7 +457,7 @@ func init_alu() {
 				{Kind: "number|string", ParamName: "value...", ParamDesc: "value", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number|string"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -479,7 +479,7 @@ func init_alu() {
 				{Kind: "number|string", ParamName: "value...", ParamDesc: "value", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number|string"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -493,7 +493,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -507,7 +507,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -521,7 +521,34 @@ func init_alu() {
 				{Kind: "number", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_decimal_output",
+		Desc: "normalizes a DECIMAL-derived result to its declared output scale",
+		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() {
+				return NewNil()
+			}
+			scale := ToInt(a[1])
+			if scale < 0 || scale > 15 {
+				return a[0]
+			}
+			factor := math.Pow10(int(scale))
+			value := a[0].Float()
+			if math.IsNaN(value) || math.IsInf(value, 0) {
+				return a[0]
+			}
+			return NewFloat(math.Round(value*factor) / factor)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "number|nil", ParamName: "value", ParamDesc: "DECIMAL-derived value"},
+				{Kind: "int", ParamName: "scale", ParamDesc: "declared decimal scale"},
+			},
+			Return: &TypeDescriptor{Kind: "number|nil"},
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -546,7 +573,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -567,7 +594,7 @@ func init_alu() {
 				{Kind: "number", ParamName: "value", ParamDesc: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -584,7 +611,7 @@ func init_alu() {
 		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 }

--- a/tests/59_float_decimal_coverage.yaml
+++ b/tests/59_float_decimal_coverage.yaml
@@ -10,6 +10,7 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS fdc_float"
   - sql: "DROP TABLE IF EXISTS fdc_decimal"
+  - sql: "DROP TABLE IF EXISTS fdc_decimal_expr"
   - sql: "DROP TABLE IF EXISTS fdc_mixed"
   - sql: "DROP TABLE IF EXISTS fdc_allnull"
   - sql: "DROP TABLE IF EXISTS fdc_empty"
@@ -127,6 +128,39 @@ test_cases:
     sql: "SELECT AVG(price) AS a FROM fdc_decimal"
     expect:
       rows: 1
+
+  - name: "Create decimal expression table"
+    sql: "CREATE TABLE fdc_decimal_expr (price DECIMAL(10,2), discount DECIMAL(5,2), tax DECIMAL(5,2), sample DOUBLE)"
+    expect:
+      rows: 0
+
+  - name: "Insert decimal expression data"
+    sql: "INSERT INTO fdc_decimal_expr VALUES (100.00, 0.07, 0.19, 1.2345), (12.34, 0.03, 0.07, 2.3456)"
+    expect:
+      affected_rows: 2
+
+  - name: "Decimal: aggregate expression is normalized to source scale"
+    sql: "SELECT SUM(price * (1 - discount) * (1 + tax)) AS total FROM fdc_decimal_expr"
+    expect:
+      rows: 1
+      result_contains: '"total": 123.48'
+      data:
+        - total: 123.48
+
+  - name: "Decimal: AVG is normalized to source scale"
+    sql: "SELECT AVG(price) AS average_price FROM fdc_decimal_expr"
+    expect:
+      rows: 1
+      data:
+        - average_price: 56.17
+
+  - name: "Float: aggregate output keeps its full precision"
+    sql: "SELECT SUM(sample) AS total FROM fdc_decimal_expr"
+    expect:
+      rows: 1
+      result_contains: '"total": 3.5801'
+      data:
+        - total: 3.5801
 
   - name: "Decimal: MIN"
     sql: "SELECT MIN(price) AS m FROM fdc_decimal"
@@ -349,6 +383,7 @@ test_cases:
 cleanup:
   - sql: "DROP TABLE IF EXISTS fdc_float"
   - sql: "DROP TABLE IF EXISTS fdc_decimal"
+  - sql: "DROP TABLE IF EXISTS fdc_decimal_expr"
   - sql: "DROP TABLE IF EXISTS fdc_mixed"
   - sql: "DROP TABLE IF EXISTS fdc_allnull"
   - sql: "DROP TABLE IF EXISTS fdc_empty"

--- a/tests/99_kill_lock.yaml
+++ b/tests/99_kill_lock.yaml
@@ -103,7 +103,7 @@ test_cases:
         sql: "SELECT 1"
       - session_id: "lock-conc-writer"
         sql: "UNLOCK TABLES"
-      # background thread joins here: SELECT must have completed with correct data
+      - wait_for_background: true
 
   # ── concurrent: WRITE lock blocks INSERT from another session ─────────────
 
@@ -123,7 +123,7 @@ test_cases:
         sql: "SELECT 1"
       - session_id: "lock-conc-w2"
         sql: "UNLOCK TABLES"
-      # after join: verify the INSERT committed
+      - wait_for_background: true
       - session_id: "lock-conc-w2"
         sql: "SELECT val FROM lock_test WHERE id = 50"
         expect:
@@ -147,7 +147,7 @@ test_cases:
         sql: "SELECT 1"
       - session_id: "lock-conc-r2"
         sql: "UNLOCK TABLES"
-      # after join: verify the INSERT committed
+      - wait_for_background: true
       - session_id: "lock-conc-r2"
         sql: "SELECT val FROM lock_test WHERE id = 51"
         expect:
@@ -264,6 +264,7 @@ test_cases:
         sql: "SELECT 1"
       - session_id: "lock-upd-writer"
         sql: "UNLOCK TABLES"
+      - wait_for_background: true
       - session_id: "lock-upd-writer"
         sql: "SELECT val FROM lock_test WHERE id = 88"
         expect:


### PR DESCRIPTION
## What changed

- preserve DECIMAL source scale as output metadata for visible aggregate expressions
- round only at the SQL output boundary, leaving internal float calculations and FLOAT/DOUBLE aggregates untouched
- add exact serialized-result regressions for DECIMAL `SUM`/`AVG` and FLOAT precision
- add an explicit `wait_for_background` test step so lock tests validate completed background writes deterministically

## Why

TPC-H Q1 performs chained arithmetic over DECIMAL columns. MemCP currently calculates those expressions as `float64`, so binary floating-point residue leaked into serialized aggregate results even when the declared DECIMAL scale was two places. The lock-suite synchronization was also discovered during full validation: its assertions ran before background requests were joined, making an unrelated master test scheduler-dependent.

## Impact

TPC-H Q1 now returns stable scale-correct aggregate values such as `119941.12` and `124828.14`. FLOAT/DOUBLE output keeps its existing full precision. No TPC-H queries, generated data, or helper scripts are included.

## Validation

- `python3 tools/lint_scm.py`
- `python3 tools/lint_scm.py --check`
- `go test ./scm/...`
- `python3 run_sql_tests.py tests/59_float_decimal_coverage.yaml` (53/53)
- `python3 run_sql_tests.py tests/99_kill_lock.yaml` (26/26)
- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (full suite green)
- local TPC-H Q1 smoke test against externally generated mini data; expected scale-correct output verified, with no benchmark assets committed