### PR TITLE
Fix scalar probes in computed sort keys

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5438,15 +5438,31 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			'(expr _dir) (order_column_for_alias src expr)
 			_ (neumann_fail "build_queryplan" "malformed ORDER BY item"))))))
 
-(define lower_scan_order_sort_expr_for_alias (lambda (src expr)
+(define scan_order_sort_callback_symbols (lambda (driver_cols bound_symbols expr)
 	(match expr
-		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
-			(symbol (resolve_physical_column_name src col col_ignorecase))
-			(neumann_fail "build_queryplan" "ORDER BY references a different source"))
-		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(lower_scan_order_sort_expr_for_alias src (list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
-		(cons head tail) (cons head (map tail (lambda (item) (lower_scan_order_sort_expr_for_alias src item))))
-		_ expr)))
+		((symbol quote) _value) expr
+		((symbol lambda) params body) (list (quote lambda) params
+			(scan_order_sort_callback_symbols driver_cols (merge_unique (list bound_symbols params)) body))
+		((symbol lambda) params body numvars) (list (quote lambda) params
+			(scan_order_sort_callback_symbols driver_cols (merge_unique (list bound_symbols params)) body)
+			numvars)
+		(cons head tail) (cons
+			(scan_order_sort_callback_symbols driver_cols bound_symbols head)
+			(map tail (lambda (item) (scan_order_sort_callback_symbols driver_cols bound_symbols item))))
+		_ (if (or (string? expr) (contains? bound_symbols expr))
+			expr
+			(begin
+				(define text (string expr))
+				(define col (find driver_cols (lambda (candidate)
+					(begin
+						(define suffix (concat "." candidate))
+						(and (> (strlen text) (strlen suffix))
+							(equal? (substr text (- (strlen text) (strlen suffix)) (strlen suffix)) suffix)))) nil))
+				(if (nil? col) expr (symbol col)))))))
+
+(define lower_scan_order_sort_expr_for_alias (lambda (src driver_cols expr)
+	(scan_order_sort_callback_symbols driver_cols '()
+		(lower_column_expr_for_alias src expr))))
 
 (define scan_order_sort_column_for_alias (lambda (src expr)
 	(match expr
@@ -5459,7 +5475,7 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(define cols (extract_columns_for_alias src expr))
 			(list (quote lambda)
 				(map cols (lambda (col) (symbol col)))
-				(lower_scan_order_sort_expr_for_alias src expr))))))
+				(lower_scan_order_sort_expr_for_alias src cols expr))))))
 
 (define scan_order_sort_columns_for_alias (lambda (src order_items)
 	(map (coalesceNil order_items '()) (lambda (item)

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -96,6 +96,61 @@ test_cases:
           latest_val: 300
           latest_ts: 3000
 
+  - name: "outer ORDER BY lowers correlated scalar probe"
+    sql: |
+      SELECT t.ID
+      FROM (
+        SELECT m.ID AS ID, m.category AS category
+        FROM dtl_main m
+      ) t
+      ORDER BY (
+        SELECT r.ID FROM dtl_ref r
+        WHERE r.ID = t.category LIMIT 1
+      ) DESC, t.ID ASC
+      LIMIT 72 OFFSET 0
+    expect:
+      rows: 2
+      data:
+        - ID: 2
+        - ID: 1
+
+  - name: "cached outer ORDER BY keeps scalar probe lowered"
+    sql: |
+      SELECT t.ID
+      FROM (
+        SELECT m.ID AS ID, m.category AS category
+        FROM dtl_main m
+      ) t
+      ORDER BY (
+        SELECT r.ID FROM dtl_ref r
+        WHERE r.ID = t.category LIMIT 1
+      ) DESC, t.ID ASC
+      LIMIT 72 OFFSET 0
+    expect:
+      rows: 2
+      data:
+        - ID: 2
+        - ID: 1
+
+  - name: "physical outer ORDER BY contains no scalar probe IR"
+    sql: |
+      EXPLAIN
+      SELECT t.ID
+      FROM (
+        SELECT m.ID AS ID, m.category AS category
+        FROM dtl_main m
+      ) t
+      ORDER BY (
+        SELECT r.ID FROM dtl_ref r
+        WHERE r.ID = t.category LIMIT 1
+      ) DESC, t.ID ASC
+      LIMIT 72 OFFSET 0
+    expect:
+      contains:
+        - "scan_order"
+      not_contains:
+        - "scalar_first_probe"
+
   - name: "COUNT over derived table with scalar subselects"
     sql: |
       SELECT COUNT(*) AS cnt, SUM(t.latest_val) AS total FROM (


### PR DESCRIPTION
## What changed

- lower planner-internal scalar probes before emitting computed `scan_order` sort callbacks
- rebind outer driver columns to callback-local symbols while preserving bindings inside nested scan lambdas
- cover the derived-table + correlated scalar `ORDER BY ... LIMIT 1` shape at runtime, on a plan-cache hit, and in physical `EXPLAIN` output

## Root cause

Computed sort expressions only rewrote `get_column` nodes. After scalar decorrelation, an internal `scalar_first_probe` could therefore survive physical lowering and be emitted as if it were a runtime function. The query-plan cache could reuse that malformed formula, but it did not create the bug and no plans persist across process restarts.

## Impact

Correlated scalar subqueries used directly as computed sort keys now execute and sort correctly. Physical plans no longer expose `scalar_first_probe` for this shape.

## Validation

- `python3 run_sql_tests.py tests/66_derived_table_limit_scalar.yaml` (8/8)
- repeated identical query validates the cached-plan path
- physical `EXPLAIN` assertion rejects leaked `scalar_first_probe`
- `python3 run_sql_tests.py tests/99_kill_lock.yaml` (26/26 after merging current master)
- full `make test` exercised the new test and all planner/scalar suites successfully; the overloaded shared host separately exceeded the unchanged 5 s multi-shard ORDER stress budget and hit the pre-#355 lock timing race
