### PR TITLE
Reduce Scheme planner allocation overhead

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -541,6 +541,26 @@ func optimizeMap(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeD
 	return result, td
 }
 
+// optimizeFilter fuses a serial map followed by a filter into one physical
+// traversal. The Scheme expression remains declarative; the fused operator is
+// optimizer-only and does not expose a separate surface-language primitive.
+func optimizeFilter(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.applyDefaultOptimization(v, useResult, "filter_mut")
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) != 3 || (!scmerIsSymbol(rv[0], "filter") && !scmerIsSymbol(rv[0], "filter_mut")) {
+		return result, td
+	}
+	inner, ok := scmerSlice(rv[1])
+	if !ok || len(inner) != 3 || (!scmerIsSymbol(inner[0], "map") && !scmerIsSymbol(inner[0], "map_mut")) {
+		return result, td
+	}
+	if exprMayHaveSideEffects(inner[2]) || exprMayHaveSideEffects(rv[2]) {
+		return result, td
+	}
+	fused := NewSlice([]Scmer{NewSymbol("filter_map"), inner[1], inner[2], rv[2]})
+	return fused, descriptorWithLength(FreshAlloc, UnknownLength)
+}
+
 // optimizeProduceN rewrites (produceN ...) to (produceN_mut ... nil) when the
 // result is unused, so runtime can avoid result allocation.
 func optimizeProduceN(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
@@ -1026,7 +1046,7 @@ func init_list() {
 			},
 			Return:   FreshAlloc,
 			Const:    true,
-			Optimize: FirstParameterMutable("filter_mut"),
+			Optimize: optimizeFilter,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1872,6 +1892,58 @@ func init_list() {
 		},
 	})
 
+	// Fused physical operators: optimizer-only, forbidden from .scm code.
+	Declare(&Globalenv, &Declaration{
+		Name: "filter_map",
+		Desc: "fused serial map and filter (optimizer-only)",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "filter_map")
+			mapper := OptimizeProcToSerialFunction(a[1])
+			predicate := OptimizeProcToSerialFunction(a[2])
+			result := make([]Scmer, 0, len(input))
+			for _, item := range input {
+				mapped := mapper(item)
+				if predicate(mapped).Bool() {
+					result = append(result, mapped)
+				}
+			}
+			return NewSlice(result)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "list", NoEscape: true},
+				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", ParamName: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+			},
+			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "flat_map",
+		Desc: "fused fixed-width serial map and flatten (optimizer-only)",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "flat_map")
+			mapper := OptimizeProcToSerialFunction(a[1])
+			width := int(ToInt(a[2]))
+			result := make([]Scmer, 0, len(input)*width)
+			for _, item := range input {
+				result = append(result, asSlice(mapper(item), "flat_map result")...)
+			}
+			return NewSlice(result)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "list", NoEscape: true},
+				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "list"}},
+				{Kind: "int", ParamName: "width"},
+			},
+			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+		},
+	})
 	// _mut variants: optimizer-only, forbidden from .scm code
 	// Tier 1: same-length, zero-copy
 
@@ -2365,6 +2437,24 @@ func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Typ
 		return result, td
 	}
 	if len(rv) == 2 {
+		if producer, ok := scmerSlice(rv[1]); ok && len(producer) == 3 {
+			if exprMayHaveSideEffects(producer[2]) {
+				return result, td
+			}
+			itemLength := exactCallbackListLength(producer[2], oc)
+			if itemLength >= 0 {
+				switch {
+				case scmerIsSymbol(producer[0], "map"), scmerIsSymbol(producer[0], "map_mut"):
+					inputLength := optimizedExactListLength(producer[1], oc)
+					resultLength := UnknownLength
+					if inputLength >= 0 {
+						resultLength = inputLength * itemLength
+					}
+					fused := NewSlice([]Scmer{NewSymbol("flat_map"), producer[1], producer[2], NewInt(int64(itemLength))})
+					return fused, descriptorWithLength(FreshAlloc, resultLength)
+				}
+			}
+		}
 		if outer, ok := scmerSlice(rv[1]); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
 			merged := make([]Scmer, 0, len(outer)+1)
 			merged = append(merged, NewSymbol("list"))

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+	"testing"
+)
+
+func optimizeListPipeline(t testing.TB, source string) (Scmer, *Env) {
+	t.Helper()
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read("list pipeline optimizer test", source), env)
+	return optimized, env
+}
+
+func TestOptimizeFusesFilterOverMap(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(filter (map values (lambda (value) (+ value 1)))
+			(lambda (value) (> value 2))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "filter_map") {
+		t.Fatalf("filter/map pipeline was not fused: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(0), NewInt(2), NewInt(3)}))
+	want := NewSlice([]Scmer{NewInt(3), NewInt(4)})
+	if !Equal(got, want) {
+		t.Fatalf("fused filter/map returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeFusesFixedWidthMergeOverMap(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(merge (map values (lambda (value) (list value (+ value 10))))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "flat_map") {
+		t.Fatalf("fixed-width merge/map pipeline was not fused: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(1), NewInt(2)}))
+	want := NewSlice([]Scmer{NewInt(1), NewInt(11), NewInt(2), NewInt(12)})
+	if !Equal(got, want) {
+		t.Fatalf("fused merge/map returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeKeepsDynamicWidthMergeOverMap(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(merge (map values (lambda (value) value))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "flat_map") {
+		t.Fatalf("dynamic-width merge/map pipeline was unsafely fused: %s", serialized)
+	}
+}
+
+func TestOptimizeFusesFixedWidthMergeOverProduceN(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda ()
+		(merge (map (produceN 3) (lambda (value) (list value (+ value 10))))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "flat_map") {
+		t.Fatalf("fixed-width merge/produceN pipeline was not fused: %s", serialized)
+	}
+
+	got := OptimizeProcToSerialFunction(Eval(optimized, env))()
+	want := NewSlice([]Scmer{NewInt(0), NewInt(10), NewInt(1), NewInt(11), NewInt(2), NewInt(12)})
+	if !Equal(got, want) {
+		t.Fatalf("fused merge/produceN returned %s, want %s", String(got), String(want))
+	}
+}

--- a/scm/match.go
+++ b/scm/match.go
@@ -24,6 +24,13 @@ import (
 	"strings"
 )
 
+func bindMatchVar(en *Env, sym Symbol, value Scmer) {
+	if en.Vars == nil {
+		en.Vars = make(Vars)
+	}
+	en.Vars[sym] = value
+}
+
 func scmerSymbolName(s Scmer) (string, bool) {
 	// Unwrap SourceInfo and direct symbols
 	if name, ok := symbolName(s); ok {
@@ -150,7 +157,7 @@ func match(val Scmer, pattern Scmer, en *Env, mutable bool) bool {
 		case "false":
 			return val.IsBool() && !val.Bool()
 		default:
-			en.Vars[Symbol(pattern.String())] = val
+			bindMatchVar(en, Symbol(pattern.String()), val)
 			return true
 		}
 	case tagNthLocalVar:
@@ -322,7 +329,7 @@ func match(val Scmer, pattern Scmer, en *Env, mutable bool) bool {
 							continue
 						}
 						if sym, ok := symbolName(p[i+2]); ok {
-							en.Vars[Symbol(sym)] = NewString(match[i])
+							bindMatchVar(en, Symbol(sym), NewString(match[i]))
 							continue
 						}
 						panic("regex variable invalid: " + SerializeToString(p[i+2], en))
@@ -361,7 +368,7 @@ func matchConcat(val Scmer, p []Scmer, en *Env) bool {
 			return true
 		}
 		if name, ok := symbolName(target); ok {
-			en.Vars[Symbol(name)] = NewString(str)
+			bindMatchVar(en, Symbol(name), NewString(str))
 			return true
 		}
 		return false
@@ -388,7 +395,7 @@ func matchConcat(val Scmer, p []Scmer, en *Env) bool {
 					return true
 				}
 				if name, ok := symbolName(first); ok {
-					en.Vars[Symbol(name)] = NewString(base)
+					bindMatchVar(en, Symbol(name), NewString(base))
 					return true
 				}
 			}
@@ -412,7 +419,7 @@ func matchConcat(val Scmer, p []Scmer, en *Env) bool {
 				}
 				en.VarsNumbered[id] = NewString(prefix)
 			} else if name, ok := symbolName(first); ok {
-				en.Vars[Symbol(name)] = NewString(prefix)
+				bindMatchVar(en, Symbol(name), NewString(prefix))
 			} else {
 				return false
 			}

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -52,6 +52,29 @@ func procBodyUsesNamedParam(body Scmer, named map[Symbol]struct{}) bool {
 	return false
 }
 
+func procCanUseNumberedOnly(params, body Scmer, numVars int) bool {
+	if numVars == 0 {
+		return false
+	}
+	if stripped, ok := scmerStripSourceInfo(params); ok {
+		params = stripped
+	}
+	named := make(map[Symbol]struct{})
+	if params.IsSlice() {
+		for _, param := range params.Slice() {
+			if stripped, ok := scmerStripSourceInfo(param); ok {
+				param = stripped
+			}
+			if param.IsSymbol() && !param.SymbolEquals("_") {
+				named[mustSymbol(param)] = struct{}{}
+			}
+		}
+	} else if params.IsSymbol() && !params.SymbolEquals("_") {
+		named[mustSymbol(params)] = struct{}{}
+	}
+	return !procBodyUsesNamedParam(body, named)
+}
+
 // to optimize lambdas serially; the resulting function MUST NEVER run on multiple threads simultanously since state is reduced to save mallocs
 func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	/* API contract:
@@ -246,6 +269,8 @@ type optimizerMetainfo struct {
 	loopDepth            int             // >0 inside scan/reduce callbacks; prevents hoisted defines from being inlined back into loops
 	lambdaDepth          int             // >0 while optimizing a lambda body; keeps local definitions out of Env hints
 	beginDepth           int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
+	inlineDepth          int
+	inlineStack          map[Symbol]bool
 }
 
 func newOptimizerMetainfo() (result optimizerMetainfo) {
@@ -271,6 +296,8 @@ func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	result.loopDepth = ome.loopDepth
 	result.lambdaDepth = ome.lambdaDepth
 	result.beginDepth = ome.beginDepth
+	result.inlineDepth = ome.inlineDepth
+	result.inlineStack = ome.inlineStack
 	// nextSlot is NOT propagated across lambda boundaries (each lambda has its own)
 	return
 }
@@ -293,7 +320,150 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.loopDepth = ome.loopDepth
 	result.lambdaDepth = ome.lambdaDepth
 	result.beginDepth = ome.beginDepth
+	result.inlineDepth = ome.inlineDepth
+	result.inlineStack = ome.inlineStack
 	return
+}
+
+const maxLeafInlineNodes = 24
+const maxLeafInlineDepth = 8
+
+func analyzeLeafInlineBody(expr Scmer, callee Symbol, paramCount int, refs []int, nodes *int) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	*nodes++
+	if *nodes > maxLeafInlineNodes {
+		return false
+	}
+	if expr.IsNthLocalVar() {
+		idx := int(expr.NthLocalVar())
+		if idx < 0 || idx >= paramCount {
+			return false
+		}
+		refs[idx]++
+		return refs[idx] <= 1
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 {
+		return true
+	}
+	if scmerIsSymbol(items[0], "quote") {
+		return true
+	}
+	if head, ok := scmerSymbol(items[0]); ok {
+		switch head {
+		case callee, "lambda", "define", "set", "setN", "eval", "parser", "outer", "begin", "begin_mut", "!begin", "match", "match_mut":
+			return false
+		}
+	}
+	for _, item := range items {
+		if !analyzeLeafInlineBody(item, callee, paramCount, refs, nodes) {
+			return false
+		}
+	}
+	return true
+}
+
+func substituteLeafInlineParams(expr Scmer, args []Scmer) Scmer {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() {
+		return args[int(expr.NthLocalVar())]
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 || scmerIsSymbol(items[0], "quote") {
+		return expr
+	}
+	rewritten := make([]Scmer, len(items))
+	for i, item := range items {
+		rewritten[i] = substituteLeafInlineParams(item, args)
+	}
+	return NewSlice(rewritten)
+}
+
+func leafInlineBindingsStable(expr Scmer, source, target *Env) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() || !expr.IsSlice() && !expr.IsSymbol() {
+		return true
+	}
+	if expr.IsSymbol() {
+		sym := mustSymbol(expr)
+		sourceOwner := source.FindRead(sym)
+		targetOwner := target.FindRead(sym)
+		if sourceOwner == nil || targetOwner == nil {
+			return false
+		}
+		sourceValue, sourceOK := sourceOwner.Vars[sym]
+		targetValue, targetOK := targetOwner.Vars[sym]
+		return sourceOK && targetOK && sourceValue == targetValue
+	}
+	items := expr.Slice()
+	if len(items) == 0 || scmerIsSymbol(items[0], "quote") {
+		return true
+	}
+	for _, item := range items {
+		if !leafInlineBindingsStable(item, source, target) {
+			return false
+		}
+	}
+	return true
+}
+
+func tryInlineLeafProc(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo, bool) {
+	if len(v) < 1 || ome.inlineDepth >= maxLeafInlineDepth {
+		return NewNil(), tiZero, false
+	}
+	callee, ok := scmerSymbol(v[0])
+	if !ok || (ome.inlineStack != nil && ome.inlineStack[callee]) {
+		return NewNil(), tiZero, false
+	}
+	owner := env.FindRead(callee)
+	if owner == nil {
+		return NewNil(), tiZero, false
+	}
+	value, ok := owner.Vars[callee]
+	if !ok || !value.IsProc() {
+		return NewNil(), tiZero, false
+	}
+	proc := value.Proc()
+	if proc == nil || proc.En == nil {
+		return NewNil(), tiZero, false
+	}
+	params := proc.Params
+	if stripped, ok := scmerStripSourceInfo(params); ok {
+		params = stripped
+	}
+	paramItems, ok := scmerSlice(params)
+	if !ok || len(paramItems) != len(v)-1 || proc.NumVars != len(paramItems) {
+		return NewNil(), tiZero, false
+	}
+	refs := make([]int, len(paramItems))
+	nodes := 0
+	if !analyzeLeafInlineBody(proc.Body, callee, len(paramItems), refs, &nodes) {
+		return NewNil(), tiZero, false
+	}
+	if !leafInlineBindingsStable(proc.Body, proc.En, env) {
+		return NewNil(), tiZero, false
+	}
+	for _, count := range refs {
+		if count != 1 {
+			return NewNil(), tiZero, false
+		}
+	}
+	inlined := substituteLeafInlineParams(proc.Body, v[1:])
+	if ome.inlineStack == nil {
+		ome.inlineStack = make(map[Symbol]bool)
+	}
+	ome.inlineStack[callee] = true
+	ome.inlineDepth++
+	result, ti := OptimizeEx(inlined, env, ome, useResult)
+	ome.inlineDepth--
+	delete(ome.inlineStack, callee)
+	return result, ti, true
 }
 
 func scmerIsSymbol(v Scmer, name string) bool {
@@ -1114,6 +1284,11 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 		transferOwnership = ti.Transfer()
 		if i > 0 && !ti.Const() {
 			allConstArgs = false
+		}
+	}
+	if !allConstArgs {
+		if inlined, ti, ok := tryInlineLeafProc(v, env, ome, useResult); ok {
+			return inlined, ti.ToTypeDescriptor()
 		}
 	}
 

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -140,6 +140,56 @@ func TestSchemeReturnHintsPreserveNestedMutRewrite(t *testing.T) {
 	}
 }
 
+func TestOptimizeInlinesSingleUseLeafProc(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("leaf inline test", `(define leaf_second (lambda (values) (nth values 1)))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (values) (leaf_second values))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "leaf_second") {
+		t.Fatalf("single-use leaf proc was not inlined: %s", serialized)
+	}
+	got := Apply(Eval(optimized, env), NewSlice([]Scmer{NewInt(4), NewInt(9)}))
+	if ToInt(got) != 9 {
+		t.Fatalf("inlined leaf proc returned %s, want 9", String(got))
+	}
+}
+
+func TestOptimizeKeepsMultiUseLeafProcCall(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("leaf inline test", `(define leaf_twice (lambda (value) (+ value value)))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (value) (leaf_twice value))`)
+	if serialized := serializedTestExpr(t, env, optimized); !strings.Contains(serialized, "leaf_twice") {
+		t.Fatalf("multi-use leaf proc was inlined: %s", serialized)
+	}
+}
+
+func TestOptimizeKeepsRecursiveLeafProcCall(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("leaf inline test", `(define leaf_recurse (lambda (value)
+		(if (equal? value 0) 0 (leaf_recurse (- value 1)))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (value) (leaf_recurse value))`)
+	if serialized := serializedTestExpr(t, env, optimized); !strings.Contains(serialized, "leaf_recurse") {
+		t.Fatalf("recursive leaf proc was inlined: %s", serialized)
+	}
+}
+
+func TestOptimizeKeepsLeafProcWithDifferentCapturedBinding(t *testing.T) {
+	source := newOptimizerTestEnv()
+	EvalAll("leaf inline test", `(define captured_value 7)`, source)
+	proc := Eval(Optimize(Read("leaf inline test", `(lambda (value) (+ value captured_value))`), source), source)
+
+	target := newOptimizerTestEnv()
+	target.Vars[Symbol("captured_value")] = NewInt(9)
+	target.Vars[Symbol("captured_leaf")] = proc
+	optimized := optimizeTestSource(t, target, `(lambda (value) (captured_leaf value))`)
+	if serialized := serializedTestExpr(t, target, optimized); !strings.Contains(serialized, "captured_leaf") {
+		t.Fatalf("leaf proc with a different captured binding was inlined: %s", serialized)
+	}
+}
+
 func BenchmarkOptimizeSchemeHelperFreshReturn(b *testing.B) {
 	env := newOptimizerTestEnv()
 	EvalAll("optimizer return benchmark", `(define benchmark_fresh_pair (lambda (a b) (list a b)))`, env)

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+var schemeStringUnescaper = strings.NewReplacer("\\\"", "\"", "\\\\", "\\", "\\n", "\n", "\\r", "\r", "\\t", "\t", "\\0", "\x00")
+
 type SourceInfo struct {
 	source   string
 	line     int
@@ -154,7 +156,6 @@ func tokenize(source, s string) []Scmer {
 	line := 1
 	col := 0
 
-	stringreplacer := strings.NewReplacer("\\\"", "\"", "\\\\", "\\", "\\n", "\n", "\\r", "\r", "\\t", "\t", "\\0", "\x00")
 	state := 0
 	startToken := 0
 	result := make([]Scmer, 0)
@@ -194,7 +195,7 @@ func tokenize(source, s string) []Scmer {
 			state = 3 // continue with string
 		} else if state == 3 && ch == '"' {
 			// finish string
-			result = append(result, NewString(stringreplacer.Replace(string(s[startToken+1:i]))))
+			result = append(result, NewString(schemeStringUnescaper.Replace(string(s[startToken+1:i]))))
 			state = 0
 		} else {
 			// otherwise: state change!

--- a/scm/printer.go
+++ b/scm/printer.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2023  Carl-Philip Hänsch
+Copyright (C) 2023-2026  Carl-Philip Hänsch
 Copyright (C) 2013  Pieter Kelchtermans (originally licensed unter WTFPL 2.0)
 
     This program is free software: you can redistribute it and/or modify
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"strings"
 )
+
+var schemeStringEscaper = strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "\r", "\\r", "\n", "\\n")
 
 func String(v Scmer) string {
 	switch v.GetTag() {
@@ -141,7 +143,7 @@ func SerializeEx(b *bytes.Buffer, v Scmer, en *Env, glob *Env, p *Proc) {
 		b.WriteString(v.String())
 	case tagString, tagCString, tagBString:
 		b.WriteByte('"')
-		b.WriteString(strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "\r", "\\r", "\n", "\\n").Replace(v.String()))
+		b.WriteString(schemeStringEscaper.Replace(v.String()))
 		b.WriteByte('"')
 	case tagSymbol:
 		sym := v.String()
@@ -260,7 +262,7 @@ func SerializeEx(b *bytes.Buffer, v Scmer, en *Env, glob *Env, p *Proc) {
 		}
 		if s, ok := v.Any().(string); ok {
 			b.WriteByte('"')
-			b.WriteString(strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "\r", "\\r", "\n", "\\n").Replace(s))
+			b.WriteString(schemeStringEscaper.Replace(s))
 			b.WriteByte('"')
 			return
 		}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -228,7 +228,7 @@ restart:
 				val := Eval(list[1], en)
 				i := 2
 				mutable := headSym == Symbol("match_mut")
-				en2 := Env{Vars: make(Vars), VarsNumbered: en.VarsNumbered, Outer: en, Nodefine: true}
+				en2 := Env{VarsNumbered: en.VarsNumbered, Outer: en, Nodefine: true}
 				for i < len(list)-1 {
 					if match(val, list[i], &en2, mutable) {
 						en = &en2
@@ -282,7 +282,13 @@ restart:
 				if len(list) > 3 {
 					numVars = int(list[3].Int())
 				}
-				return NewProcStruct(Proc{Params: params, Body: list[2], En: en, NumVars: numVars})
+				return NewProcStruct(Proc{
+					Params:       params,
+					Body:         list[2],
+					En:           en,
+					NumVars:      numVars,
+					NumberedOnly: procCanUseNumberedOnly(params, list[2], numVars),
+				})
 			case "begin":
 				en2 := &Env{Vars: make(Vars), VarsNumbered: en.VarsNumbered, Outer: en, Nodefine: false}
 				for _, form := range list[1 : len(list)-1] {
@@ -537,13 +543,28 @@ restart:
 	return
 }
 
+type smallProcCallEnv struct {
+	env      Env
+	numbered [4]Scmer
+}
+
+func newProcCallEnv(proc Proc) *Env {
+	if proc.NumVars <= 4 {
+		frame := &smallProcCallEnv{}
+		frame.env.Outer = proc.En
+		frame.env.VarsNumbered = frame.numbered[:proc.NumVars]
+		return &frame.env
+	}
+	return &Env{VarsNumbered: make([]Scmer, proc.NumVars), Outer: proc.En}
+}
+
 func prepareProcCall(p *Proc, operands []Scmer, caller *Env) (*Env, Scmer) {
 	if p == nil {
 		panic("apply: nil procedure")
 	}
 	proc := *p
 	var vars Vars
-	env := &Env{Vars: vars, VarsNumbered: make([]Scmer, proc.NumVars), Outer: proc.En, Nodefine: false}
+	env := newProcCallEnv(proc)
 	switch proc.Params.GetTag() {
 	case tagSlice:
 		params := proc.Params.Slice()
@@ -551,16 +572,18 @@ func prepareProcCall(p *Proc, operands []Scmer, caller *Env) (*Env, Scmer) {
 			panic(fmt.Sprintf("Apply: function with %d parameters is supplied with %d arguments", len(params), len(operands)))
 		}
 		if proc.NumVars > 0 {
-			vars = make(Vars, len(params))
-			env.Vars = vars
+			if !proc.NumberedOnly {
+				vars = make(Vars, len(params))
+				env.Vars = vars
+			}
 			for i := range params {
 				if i < len(operands) && i < proc.NumVars {
 					val := Eval(operands[i], caller)
 					env.VarsNumbered[i] = val
-					if !params[i].SymbolEquals("_") {
+					if !proc.NumberedOnly && !params[i].SymbolEquals("_") {
 						env.Vars[mustSymbol(params[i])] = val
 					}
-				} else if !params[i].SymbolEquals("_") {
+				} else if !proc.NumberedOnly && !params[i].SymbolEquals("_") {
 					env.Vars[mustSymbol(params[i])] = NewNil()
 				}
 			}
@@ -585,9 +608,11 @@ func prepareProcCall(p *Proc, operands []Scmer, caller *Env) (*Env, Scmer) {
 		argsList := NewSlice(args)
 		if proc.NumVars > 0 {
 			env.VarsNumbered[0] = argsList
-			vars = make(Vars, 1)
-			env.Vars = vars
-			env.Vars[mustSymbol(proc.Params)] = argsList
+			if !proc.NumberedOnly {
+				vars = make(Vars, 1)
+				env.Vars = vars
+				env.Vars[mustSymbol(proc.Params)] = argsList
+			}
 		} else {
 			vars = make(Vars, 1)
 			env.Vars = vars
@@ -607,20 +632,22 @@ func prepareProcCallWithArgs(p *Proc, args []Scmer) (*Env, Scmer) {
 	}
 	proc := *p
 	var vars Vars
-	env := &Env{Vars: vars, VarsNumbered: make([]Scmer, proc.NumVars), Outer: proc.En, Nodefine: false}
+	env := newProcCallEnv(proc)
 	switch proc.Params.GetTag() {
 	case tagSlice:
 		params := proc.Params.Slice()
 		if proc.NumVars > 0 {
-			vars = make(Vars, len(params))
-			env.Vars = vars
+			if !proc.NumberedOnly {
+				vars = make(Vars, len(params))
+				env.Vars = vars
+			}
 			for i := range params {
 				if i < len(args) {
 					env.VarsNumbered[i] = args[i]
-					if !params[i].SymbolEquals("_") {
+					if !proc.NumberedOnly && !params[i].SymbolEquals("_") {
 						env.Vars[mustSymbol(params[i])] = args[i]
 					}
-				} else if !params[i].SymbolEquals("_") {
+				} else if !proc.NumberedOnly && !params[i].SymbolEquals("_") {
 					env.Vars[mustSymbol(params[i])] = NewNil()
 				}
 			}
@@ -641,9 +668,11 @@ func prepareProcCallWithArgs(p *Proc, args []Scmer) (*Env, Scmer) {
 		argsList := NewSlice(args)
 		if proc.NumVars > 0 {
 			env.VarsNumbered[0] = argsList
-			vars = make(Vars, 1)
-			env.Vars = vars
-			env.Vars[mustSymbol(proc.Params)] = argsList
+			if !proc.NumberedOnly {
+				vars = make(Vars, 1)
+				env.Vars = vars
+				env.Vars[mustSymbol(proc.Params)] = argsList
+			}
 		} else {
 			vars = make(Vars, 1)
 			env.Vars = vars
@@ -746,6 +775,7 @@ type Proc struct {
 	Params, Body Scmer
 	En           *Env
 	NumVars      int
+	NumberedOnly bool
 }
 
 // helper pseudo type to optimize parameter reading from indices


### PR DESCRIPTION
## Summary
- fuse declarative map/filter and fixed-width map/flatten pipelines into optimizer-only physical operators
- inline conservative single-use leaf procedures while preserving lexical binding identity
- reduce call-frame, match-binding, and parser/serializer allocations
- keep Scheme planner code declarative; all physical representation choices remain in the Go optimizer/runtime

## A/B measurement
Seven cold `EXPLAIN COMPILE` runs of an anonymized query with eight independent nested aggregate recipes, same host and fresh data directories. Values are medians against current master (`75f581aff`).

| metric | master | PR | delta |
|---|---:|---:|---:|
| planner total | 1,394.1 ms | 956.0 ms | -31.4% |
| recipe emission | 1,311.4 ms | 896.5 ms | -31.6% |
| serialization | 30.3 ms | 4.5 ms | -85.1% |
| plan nodes | 6,131 | 6,131 | unchanged |
| plan bytes | 72,171 | 72,171 | unchanged |

## Downstream manual workload
- reached the first full parallel functional phase; 9/19 scenarios passed before 10 UI/upload timeouts under 12 concurrent workers
- TracePrint: 20,710 statements, 0.923 ms median, 100.9 ms p95, 1.143 s p99, 241 statements >=1 s, 20.726 s maximum
- remaining hot shapes are wide data-view projections (about 20.5 s), file-metadata lookups (13-15 s), and independent scalar-aggregate dashboards (6.4-8.8 s)
- one correlated unqualified outer-column resolver error is independent of this optimizer patch and already has a separate anonymized fix branch

## Validation
- `go test ./scm -count=1`
- full serial pre-commit hook after rebasing onto current master: all YAML suites passed
- targeted trigger, nested scalar, derived-table, and window regressions passed
- full downstream manual run diagnosed with TracePrint; it advances into the parallel functional phase, with the remaining timeout/query-resolution work isolated above