### PR TITLE
Fix stage bindings in flattened derived joins

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2031,6 +2031,49 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(map (coalesceNil stages '()) (lambda (stage)
 		(requalify_stage_for_derived old_alias new_alias stage)))))
 
+(define derived_stage_rebind_id_map (lambda (alias stages)
+	(map (coalesceNil stages '()) (lambda (stage)
+		(list (gs_id stage) (concat (gs_id stage) ":derived:" (fnv_hash (string alias))))))))
+
+(define derived_stage_rebind_alias_map (lambda (id_map)
+	(map (coalesceNil id_map '()) (lambda (entry)
+		(list (exists_stage_alias (nth entry 0)) (exists_stage_alias (nth entry 1)))))))
+
+(define derived_stage_rebind_stage (lambda (alias_map id_map stage)
+	(if (not (group_stage? stage))
+		stage
+		(make_group_stage
+			(stage_merge_lookup id_map (gs_id stage) (gs_id stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_input stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_domain stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_keys stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_having stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_output stage))
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_order stage))
+			(gs_limit stage)
+			(gs_offset stage)
+			(rewrite_stage_output_left_join_expr alias_map id_map (gs_facts stage))))))
+
+/* Independently flattened instances may start with identical generated stage
+IDs. Give each instance its own IDs and source aliases before their plans meet. */
+(define rebind_derived_stages (lambda (alias stages)
+	(begin
+		(define id_map (derived_stage_rebind_id_map alias stages))
+		(define alias_map (derived_stage_rebind_alias_map id_map))
+		(list
+			(map (coalesceNil stages '()) (lambda (stage)
+				(derived_stage_rebind_stage alias_map id_map stage)))
+			alias_map
+			id_map))))
+
+(define rebind_derived_stage_expr (lambda (rebinding expr)
+	(rewrite_stage_output_left_join_expr (nth rebinding 1) (nth rebinding 2) expr)))
+
+(define rebind_derived_stage_sources (lambda (rebinding sources)
+	(map (coalesceNil sources '()) (lambda (src)
+		(rewrite_stage_output_left_join_source (nth rebinding 1) (nth rebinding 2) src)))))
+
 (define make_scalar_single_stage_rewrite (lambda (inner args)
 	(begin
 		(define outer_sources (nth args 0))
@@ -3147,7 +3190,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 										(begin
 											(define only_inner (car inner_sources))
 											(define inner_alias (source_alias only_inner))
-											(define projection (requalify_single_source_fields inner_alias alias (qb_fields inner)))
+											(define requalified_inner_stages (requalify_stages_for_derived inner_alias alias (qb_stages inner)))
+											(define stage_rebinding (rebind_derived_stages alias requalified_inner_stages))
+											(define projection (rebind_derived_stage_expr stage_rebinding
+												(requalify_single_source_fields inner_alias alias (qb_fields inner))))
 											(define effective_projection (if (source_outer? src)
 												(null_extend_projection_fields projection)
 												projection))
@@ -3168,13 +3214,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 													(rewrite_sources_join_for_derived alias effective_projection tail_sources))
 												(cons (list alias effective_projection) tail_rewrites)
 												(if (nil? parent_condition) tail_wheres (cons parent_condition tail_wheres))
-												(merge (list (qb_stages inner) tail_stages))))
+												(merge (list (nth stage_rebinding 0) tail_stages))))
 										(if (or (source_outer? src) (not (nil? (source_join_expr src))))
 											(if (scalar_source_shape_supported? inner_sources)
 												(begin
 													(define only_inner (car inner_sources))
 													(define inner_alias (source_alias only_inner))
-													(define projection (requalify_single_source_fields inner_alias alias (qb_fields inner)))
+													(define requalified_inner_stages (requalify_stages_for_derived inner_alias alias (qb_stages inner)))
+													(define stage_rebinding (rebind_derived_stages alias requalified_inner_stages))
+													(define projection (rebind_derived_stage_expr stage_rebinding
+														(requalify_single_source_fields inner_alias alias (qb_fields inner))))
 													(define effective_projection (if (source_outer? src)
 														(null_extend_projection_fields projection)
 														projection))
@@ -3187,7 +3236,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 														(source_relation only_inner)
 														(source_outer? src)
 														joined_condition))
-													(define derived_stage_sources (requalify_source_join_exprs inner_alias alias (cdr inner_sources)))
+													(define derived_stage_sources (rebind_derived_stage_sources stage_rebinding
+														(requalify_source_join_exprs inner_alias alias (cdr inner_sources))))
 													(list
 														(merge (list
 															(list derived_base_source)
@@ -3195,7 +3245,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 															(rewrite_sources_join_for_derived alias effective_projection tail_sources)))
 														(cons (list alias effective_projection) tail_rewrites)
 														tail_wheres
-														(merge (list (qb_stages inner) tail_stages))))
+														(merge (list (nth stage_rebinding 0) tail_stages))))
 												(neumann_fail "untangle_query" "multi-source derived JOIN needs relation-unit lowering"))
 											(list
 												(merge (list inner_sources (rewrite_sources_join_for_derived alias (qb_fields inner) tail_sources)))

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -29,12 +29,21 @@ setup:
   - sql: "DROP TABLE IF EXISTS dtl_main"
   - sql: "DROP TABLE IF EXISTS dtl_hist"
   - sql: "DROP TABLE IF EXISTS dtl_ref"
+  - sql: "DROP TABLE IF EXISTS dtl_join_main"
+  - sql: "DROP TABLE IF EXISTS dtl_join_ref"
+  - sql: "DROP TABLE IF EXISTS dtl_join_acl"
   - sql: "CREATE TABLE dtl_main (ID INT PRIMARY KEY, name TEXT, category INT)"
   - sql: "CREATE TABLE dtl_hist (ID INT PRIMARY KEY, parent INT, val INT, ts INT)"
   - sql: "CREATE TABLE dtl_ref (ID INT PRIMARY KEY, label TEXT)"
   - sql: "INSERT INTO dtl_main VALUES (1, 'Alice', 10), (2, 'Bob', 20)"
   - sql: "INSERT INTO dtl_hist VALUES (1, 1, 100, 1000), (2, 1, 200, 2000), (3, 2, 300, 3000)"
   - sql: "INSERT INTO dtl_ref VALUES (10, 'Cat A'), (20, 'Cat B')"
+  - sql: "CREATE TABLE dtl_join_main (ID INT PRIMARY KEY, first_ref INT, second_ref INT)"
+  - sql: "CREATE TABLE dtl_join_ref (ID INT PRIMARY KEY, label TEXT)"
+  - sql: "CREATE TABLE dtl_join_acl (ID INT PRIMARY KEY, ref_id INT, allowed BOOL)"
+  - sql: "INSERT INTO dtl_join_main VALUES (1, 10, 20), (2, 20, 30), (3, 99, 10)"
+  - sql: "INSERT INTO dtl_join_ref VALUES (10, 'ten'), (20, 'twenty'), (30, 'thirty'), (40, 'forty')"
+  - sql: "INSERT INTO dtl_join_acl VALUES (1, 10, TRUE), (2, 20, FALSE), (3, 40, TRUE)"
 
 test_cases:
 
@@ -189,8 +198,171 @@ test_cases:
         - "dependent-subquery"
         - '__mat:'
 
+  - name: "Flattened LEFT JOIN cascade keeps every ON predicate"
+    sql: |
+      SELECT t.ID, t.first_label, t.second_label
+      FROM (
+        SELECT m.ID, m.first_ref,
+          first_lookup.label AS first_label,
+          second_lookup.label AS second_label
+        FROM dtl_join_main m
+        LEFT JOIN (
+          SELECT ID, label FROM dtl_join_ref
+        ) first_lookup ON first_lookup.ID = m.first_ref
+        LEFT JOIN (
+          SELECT ID, label FROM dtl_join_ref
+        ) second_lookup ON second_lookup.ID = m.second_ref
+      ) t
+      ORDER BY t.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          first_label: "ten"
+          second_label: "twenty"
+        - ID: 2
+          first_label: "twenty"
+          second_label: "thirty"
+        - ID: 3
+          first_label: null
+          second_label: "ten"
+
+  - name: "Outer sorter JOIN keeps its ON predicate after flattened cascade"
+    sql: |
+      SELECT t.ID, t.first_label, sorter.label AS sorted_label
+      FROM (
+        SELECT m.ID, m.first_ref,
+          first_lookup.label AS first_label
+        FROM dtl_join_main m
+        LEFT JOIN (
+          SELECT ID, label FROM dtl_join_ref
+        ) first_lookup ON first_lookup.ID = m.first_ref
+      ) t
+      LEFT JOIN dtl_join_ref sorter ON sorter.ID = t.first_ref
+      ORDER BY sorter.label, t.ID
+      LIMIT 72 OFFSET 0
+    expect:
+      rows: 3
+      data:
+        - ID: 3
+          first_label: null
+          sorted_label: null
+        - ID: 1
+          first_label: "ten"
+          sorted_label: "ten"
+        - ID: 2
+          first_label: "twenty"
+          sorted_label: "twenty"
+
+  - name: "LEFT JOIN with correlated EXISTS projection keeps its ON predicate"
+    sql: |
+      SELECT m.ID, lookup_ref.label, lookup_ref.can_view
+      FROM dtl_join_main m
+      LEFT JOIN (
+        SELECT r.ID, r.label,
+          EXISTS (
+            SELECT 1 FROM dtl_join_acl acl
+            WHERE acl.ref_id = r.ID AND acl.allowed = TRUE
+          ) AS can_view
+        FROM dtl_join_ref r
+      ) lookup_ref ON lookup_ref.ID = m.first_ref
+      ORDER BY m.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          label: "ten"
+          can_view: true
+        - ID: 2
+          label: "twenty"
+          can_view: false
+        - ID: 3
+          label: null
+          can_view: null
+
+  - name: "LEFT JOIN with constant and correlated stages keeps its ON predicate"
+    sql: |
+      SELECT m.ID, lookup_ref.label, lookup_ref.can_view
+      FROM dtl_join_main m
+      LEFT JOIN (
+        SELECT r.ID, r.label,
+          (EXISTS (
+            SELECT 1 FROM dtl_join_acl global_acl
+            WHERE global_acl.allowed = TRUE
+          )) AND (CASE WHEN EXISTS (
+            SELECT 1 FROM dtl_join_acl global_acl
+            WHERE global_acl.allowed = FALSE
+          ) THEN TRUE ELSE EXISTS (
+            SELECT 1 FROM dtl_join_acl correlated_acl
+            WHERE correlated_acl.ref_id = r.ID
+              AND correlated_acl.allowed = TRUE
+          ) END) AS can_view
+        FROM dtl_join_ref r
+      ) lookup_ref ON lookup_ref.ID = m.first_ref
+      ORDER BY m.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          label: "ten"
+          can_view: true
+        - ID: 2
+          label: "twenty"
+          can_view: true
+        - ID: 3
+          label: null
+          can_view: null
+
+  - name: "Cascaded stage-producing LEFT JOINs keep every ON predicate"
+    sql: |
+      SELECT m.ID,
+        first_lookup.label AS first_label,
+        first_lookup.can_view AS first_can_view,
+        second_lookup.label AS second_label,
+        second_lookup.can_view AS second_can_view
+      FROM dtl_join_main m
+      LEFT JOIN (
+        SELECT r.ID, r.label,
+          EXISTS (
+            SELECT 1 FROM dtl_join_acl acl
+            WHERE acl.ref_id = r.ID AND acl.allowed = TRUE
+          ) AS can_view
+        FROM dtl_join_ref r
+      ) first_lookup ON first_lookup.ID = m.first_ref
+      LEFT JOIN (
+        SELECT r.ID, r.label,
+          EXISTS (
+            SELECT 1 FROM dtl_join_acl acl
+            WHERE acl.ref_id = r.ID AND acl.allowed = TRUE
+          ) AS can_view
+        FROM dtl_join_ref r
+      ) second_lookup ON second_lookup.ID = m.second_ref
+      ORDER BY m.ID
+      LIMIT 72 OFFSET 0
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          first_label: "ten"
+          first_can_view: true
+          second_label: "twenty"
+          second_can_view: false
+        - ID: 2
+          first_label: "twenty"
+          first_can_view: false
+          second_label: "thirty"
+          second_can_view: false
+        - ID: 3
+          first_label: null
+          first_can_view: null
+          second_label: "ten"
+          second_can_view: true
+
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS dtl_main"
   - sql: "DROP TABLE IF EXISTS dtl_hist"
   - sql: "DROP TABLE IF EXISTS dtl_ref"
+  - sql: "DROP TABLE IF EXISTS dtl_join_main"
+  - sql: "DROP TABLE IF EXISTS dtl_join_ref"
+  - sql: "DROP TABLE IF EXISTS dtl_join_acl"


### PR DESCRIPTION
## Problem

Flattening multiple structurally identical derived `LEFT JOIN`s could leave their correlated group stages in the inner alias namespace. The instances then shared generated stage IDs and `__exists_*` source aliases even though they belonged to different outer join aliases. Later normalization could bind one projection to the other instance's stage, producing incorrect join-dependent values and potentially broadening downstream predicates.

The existing physical selection-pushdown coverage used one flat `INNER JOIN`, so it could not exercise this collision.

## Fix

- Requalify derived stages together with their flattened base source and projection.
- Rebind generated stage IDs and stage-output aliases deterministically per derived instance before instances are merged into the parent query block.
- Rewrite stage dependencies, projections, and stage-output sources with the same mappings.
- Keep logical operators and physical plan choices unchanged.

## Regression coverage

Adds coverage for:

- cascaded flattened `LEFT JOIN`s retaining every `ON` predicate;
- an outer sorter join after derived flattening;
- correlated `EXISTS` values inside a derived lookup;
- mixed constant/correlated stages;
- two structurally identical stage-producing lookups with different foreign keys, including a missing lookup and `ORDER BY ... LIMIT 72 OFFSET 0`.

## A/B

Same test file and data on both revisions:

| Revision | Result | Incorrect row on collision case |
|---|---:|---|
| `origin/master` (`34af3ecef`) | 12/13 passed | `ID=1 first_can_view=false` (expected `true`) |
| this PR (`82fcdc5dd`) | 13/13 passed | none |

Command:

```bash
python3 run_sql_tests.py tests/66_derived_table_limit_scalar.yaml
```

The four suites that timed out during an initially CPU-contended full run were rerun individually and all passed. The full hook was then restarted and had no failures before being interrupted to publish this urgent correctness PR; CI runs the complete hook again.
