### PR TITLE
Poll cancellation only at shard scheduling boundaries

### DIFF
--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -175,6 +175,10 @@ func (s *SessionState) ClearCancel(seq uint64) {
 }
 
 // IsKilled returns true if this session has been killed.
+//
+// Storage execution contract: callers may check cancellation while scheduling
+// shard jobs, but never after entering a shard. Shard execution is atomic and
+// must not contain cancellation checks in index, batch, or row loops.
 func (s *SessionState) IsKilled() bool {
 	return s.IsKilledSeq(CurrentQuerySeq())
 }
@@ -198,6 +202,10 @@ func CurrentQuerySeq() uint64 {
 }
 
 // IsKilledSeq returns true if the given query generation has been killed.
+//
+// Storage execution contract: callers may check cancellation while scheduling
+// shard jobs, but never after entering a shard. Shard execution is atomic and
+// must not contain cancellation checks in index, batch, or row loops.
 func (s *SessionState) IsKilledSeq(seq uint64) bool {
 	if seq == 0 {
 		return false

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -187,6 +187,7 @@ func (t *table) recSetShardResultBufferSize() int {
 
 func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
 	ss := SessionStateFromTx(currentTx)
+	querySeq := scm.CurrentQuerySeq()
 	boundaries := extractBoundaries(conditionCols, condition)
 	boundaries, recsetFilter := splitRecSetBoundary(boundaries, t)
 	reorderByFrequency(boundaries, t)
@@ -201,7 +202,9 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 					values <- recSetBuildResult{err: scanError{rec, string(debug.Stack())}}
 				}
 			}()
-			if ss != nil && ss.IsKilled() {
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
 				panic("query killed")
 			}
 			values <- recSetBuildResult{
@@ -364,6 +367,7 @@ func (r *recSet) projectJoin(currentTx *TxContext, sourceKeyCols []string, targe
 }
 
 func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []string, ss *scm.SessionState) [][]scm.Scmer {
+	querySeq := scm.CurrentQuerySeq()
 	values := make(chan recSetKeyResult, len(r.shards))
 	closeAfter := 0
 	for i := range r.shards {
@@ -379,6 +383,11 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 						values <- recSetKeyResult{err: scanError{rec, string(debug.Stack())}}
 					}
 				}()
+				// Cancellation contract: check only at the scheduling boundary, before entering
+				// the shard. Once entered, a shard runs atomically without cancellation checks.
+				if ss != nil && ss.IsKilledSeq(querySeq) {
+					panic("query killed")
+				}
 				values <- recSetKeyResult{keys: part.shard.collectProjectJoinKeys(part.recids, sourceKeyCols, currentTx, ss)}
 				return scm.NewNil()
 			})
@@ -441,9 +450,6 @@ func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []s
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	keys := make([][]scm.Scmer, 0, len(recids))
 	for _, idx := range recids {
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
-		}
 		if idx >= visibleUpper {
 			continue
 		}
@@ -493,6 +499,7 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 	if len(keys) == 0 {
 		return result
 	}
+	querySeq := scm.CurrentQuerySeq()
 	type targetPartResult struct {
 		part recSetShard
 		err  scanError
@@ -505,6 +512,11 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 					values <- targetPartResult{err: scanError{rec, string(debug.Stack())}}
 				}
 			}()
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
+				panic("query killed")
+			}
 			values <- targetPartResult{part: shard.projectJoinKeysPart(currentTx, targetKeyCols, keys, ss)}
 			return scm.NewNil()
 		})
@@ -577,9 +589,6 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 	recids := make([]uint32, 0, 64)
 	var buf [1024]uint32
 	for _, key := range keys {
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
-		}
 		bounds := make(boundaries, len(targetKeyCols))
 		for i, col := range targetKeyCols {
 			bounds[i] = columnboundaries{
@@ -657,6 +666,7 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 		currentTx = r.tx
 	}
 	ss := SessionStateFromTx(currentTx)
+	querySeq := scm.CurrentQuerySeq()
 	values := make(chan scanResult, len(r.shards))
 	for i := range r.shards {
 		rsShard := r.shards[i]
@@ -670,6 +680,11 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 						values <- scanResult{err: scanError{rec, string(debug.Stack())}}
 					}
 				}()
+				// Cancellation contract: check only at the scheduling boundary, before entering
+				// the shard. Once entered, a shard runs atomically without cancellation checks.
+				if ss != nil && ss.IsKilledSeq(querySeq) {
+					panic("query killed")
+				}
 				res, cnt := part.shard.scanRecSetPart(part.recids, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
 				values <- scanResult{res: res, outCount: cnt, inputCount: part.count}
 				return scm.NewNil()
@@ -753,6 +768,7 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 		currentTx = r.tx
 	}
 	ss := SessionStateFromTx(currentTx)
+	querySeq := scm.CurrentQuerySeq()
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	type existsResult struct {
 		found bool
@@ -774,6 +790,11 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 						values <- existsResult{err: scanError{rec, string(debug.Stack())}}
 					}
 				}()
+				// Cancellation contract: check only at the scheduling boundary, before entering
+				// the shard. Once entered, a shard runs atomically without cancellation checks.
+				if ss != nil && ss.IsKilledSeq(querySeq) {
+					panic("query killed")
+				}
 				found := part.shard.recSetPartExists(part.recids, conditionCols, conditionFn, currentTx, ss, &stop)
 				if found {
 					stop.Store(true)
@@ -784,6 +805,7 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 		}(*part)
 	}
 	var existsErr scanError
+	found := false
 	for i := 0; i < closeAfter; i++ {
 		msg := <-values
 		if msg.err.r != nil {
@@ -793,13 +815,13 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 			continue
 		}
 		if msg.found {
-			return true
+			found = true
 		}
 	}
 	if existsErr.r != nil {
 		panic(existsErr)
 	}
-	return false
+	return found
 }
 
 func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
@@ -848,9 +870,6 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 	for _, idx := range recids {
 		if stop != nil && stop.Load() {
 			return false
-		}
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
 		}
 		if idx >= visibleUpper {
 			continue
@@ -939,9 +958,6 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	var buf [1024]uint32
 	pending := buf[:0]
 	for _, idx := range recids {
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
-		}
 		if idx >= visibleUpper {
 			continue
 		}
@@ -1007,7 +1023,7 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	return akkumulator, outCount
 }
 
-func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, querySeq uint64) *shardqueue {
+func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
 	result := &shardqueue{shard: t}
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
@@ -1110,9 +1126,6 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	result.items = make([]uint32, 0, len(recids))
 	for _, idx := range recids {
-		if ss != nil && ss.IsKilledSeq(querySeq) {
-			panic("query killed")
-		}
 		if idx >= visibleUpper {
 			continue
 		}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -363,9 +363,7 @@ type scanResult struct {
 
 func (t *table) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
 	ss := SessionStateFromTx(currentTx)
-	if ss != nil && ss.IsKilled() {
-		panic("query killed")
-	}
+	querySeq := scm.CurrentQuerySeq()
 	touchTempColumns(t, conditionCols, nil)
 	boundaries := extractBoundaries(conditionCols, condition)
 	boundaries, recsetFilter := splitRecSetBoundary(boundaries, t)
@@ -387,6 +385,11 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
 		}()
+		// Cancellation contract: check only at the scheduling boundary, before entering
+		// the shard. Once entered, a shard runs atomically without cancellation checks.
+		if ss != nil && ss.IsKilledSeq(querySeq) {
+			panic("query killed")
+		}
 		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found, recsetFilter) {
 			found.Store(true)
 			values <- scanResult{outCount: 1}
@@ -428,9 +431,7 @@ func (t *table) scan(currentTx *TxContext, conditionCols []string, condition scm
 
 func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
-	if ss != nil && ss.IsKilled() {
-		panic("query killed")
-	}
+	querySeq := scm.CurrentQuerySeq()
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -482,9 +483,9 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
 		}()
-		// Kill check at shard-scheduling point: ss is a closure variable, no GLS lookup needed.
-		// This keeps the worker pool draining quickly on tables with many shards.
-		if ss != nil && ss.IsKilled() {
+		// Cancellation contract: check only at the scheduling boundary, before entering
+		// the shard. Once entered, a shard runs atomically without cancellation checks.
+		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
 		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
@@ -665,9 +666,6 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
-		}
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
 		}
 		for _, idx := range batch {
 			if recsetPart != nil && !recsetPart.contains(idx) {
@@ -1099,9 +1097,6 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	batchBoundaries := hasBatchBoundaries(boundaries)
 
 	for batchid := 0; batchid < batchCount; batchid++ {
-		if ss != nil && ss.IsKilled() {
-			panic("query killed")
-		}
 		activeBoundaries := boundaries
 		activeLower := lower
 		activeUpperLast := upperLast
@@ -1112,9 +1107,6 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 
 		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))
-			if ss != nil && ss.IsKilled() {
-				panic("query killed")
-			}
 			outN := 0
 			for _, idx := range batch {
 				effectiveIdx := idx

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -466,9 +466,6 @@ func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
 	execStart := time.Now()
 	ss := SessionStateFromTx(currentTx)
-	if ss != nil && ss.IsKilled() {
-		panic("query killed")
-	}
 
 	total_limit := -1
 	if limitPartitionCols == 0 && limit >= 0 {
@@ -553,6 +550,8 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 							if part.count == 0 {
 								continue
 							}
+							// Cancellation contract: check only at the scheduling boundary, before entering
+							// the shard. Once entered, a shard runs atomically without cancellation checks.
 							if ss != nil && ss.IsKilledSeq(querySeq) {
 								panic("query killed")
 							}
@@ -562,7 +561,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 										q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 									}
 								}()
-								res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, querySeq)
+								res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 								res.callbackCols = callbackCols
 								res.callback = callback
 								res.tableIdx = tableIdx
@@ -582,15 +581,17 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 					go func(part recSetShard) {
 						withTxSession(currentTx, func() scm.Scmer {
 							defer wg.Done()
-							if ss != nil && ss.IsKilledSeq(querySeq) {
-								panic("query killed")
-							}
 							defer func() {
 								if r := recover(); r != nil {
 									q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 								}
 							}()
-							res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, querySeq)
+							// Cancellation contract: check only at the scheduling boundary, before entering
+							// the shard. Once entered, a shard runs atomically without cancellation checks.
+							if ss != nil && ss.IsKilledSeq(querySeq) {
+								panic("query killed")
+							}
+							res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 							res.callbackCols = callbackCols
 							res.callback = callback
 							res.tableIdx = tableIdx
@@ -602,14 +603,16 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			}
 		} else {
 			done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {
-				if ss != nil && ss.IsKilled() {
-					panic("query killed")
-				}
 				defer func() {
 					if r := recover(); r != nil {
 						q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 					}
 				}()
+				// Cancellation contract: check only at the scheduling boundary, before entering
+				// the shard. Once entered, a shard runs atomically without cancellation checks.
+				if ss != nil && ss.IsKilledSeq(querySeq) {
+					panic("query killed")
+				}
 				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, orderedEarlyLimit, recsetFilter)
 				res.callbackCols = callbackCols
 				res.callback = callback

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1301,7 +1301,6 @@ type mapArgGetter func(uint32, uint32) scm.Scmer
 // For remote shards, Stream() will be backed by an RPC returning the accumulator per batch.
 type ShardMapReducer struct {
 	shard           *storageShard
-	sessionState    *scm.SessionState
 	currentTx       *TxContext
 	acidMode        bool
 	mainGetters     []mapArgGetter
@@ -1350,7 +1349,6 @@ type ShardMapReducer struct {
 func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool, stride int, batchdata []scm.Scmer, currentTx *TxContext) *ShardMapReducer {
 	mr := &ShardMapReducer{
 		shard:            t,
-		sessionState:     SessionStateFromTx(currentTx),
 		currentTx:        currentTx,
 		acidMode:         currentTx != nil && currentTx.Mode == TxACID,
 		mainGetters:      make([]mapArgGetter, len(cols)),
@@ -1593,12 +1591,6 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 	return mr
 }
 
-func (m *ShardMapReducer) checkKilled() {
-	if m.sessionState != nil && m.sessionState.IsKilled() {
-		panic("query killed")
-	}
-}
-
 func withTxSession(currentTx *TxContext, fn func() scm.Scmer) scm.Scmer {
 	if currentTx == nil || currentTx.Session.IsNil() {
 		return fn()
@@ -1612,7 +1604,6 @@ func withTxSession(currentTx *TxContext, fn func() scm.Scmer) scm.Scmer {
 // partitioned order-preserving into runs of main-storage IDs and delta IDs.
 // batchids is optional and, when present, must align 1:1 with recids.
 func (m *ShardMapReducer) Stream(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
-	m.checkKilled()
 	i := 0
 	n := len(recids)
 	for i < n {
@@ -1648,10 +1639,7 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 	// not for the whole batch. This allows nested read scans (e.g. EXISTS
 	// inside UPDATE on the same table) to acquire RLock between rows.
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
-	for rowidx, id := range recids {
-		if rowidx&63 == 0 {
-			m.checkKilled()
-		}
+	for _, id := range recids {
 		func() {
 			effectiveID := id
 			// Acquire write lock per-row for mutation scans
@@ -1692,9 +1680,6 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	for rowidx, id := range recids {
-		if rowidx&63 == 0 {
-			m.checkKilled()
-		}
 		func() {
 			effectiveID := id
 			batchid := batchids[rowidx]
@@ -1734,10 +1719,7 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
 	// Same hoisting as processMainBlock (see comment there).
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
-	for rowidx, id := range recids {
-		if rowidx&63 == 0 {
-			m.checkKilled()
-		}
+	for _, id := range recids {
 		func() {
 			effectiveID := id
 			if needsPerRowLock {
@@ -1775,9 +1757,6 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	for rowidx, id := range recids {
-		if rowidx&63 == 0 {
-			m.checkKilled()
-		}
 		func() {
 			effectiveID := id
 			batchid := batchids[rowidx]

--- a/tests/99_kill_lock.yaml
+++ b/tests/99_kill_lock.yaml
@@ -377,12 +377,14 @@ test_cases:
       # kill the running INSERT SELECT
       - session_id: "rb-kill-attacker2"
         sql: "SELECT KILL_QUERY(id) FROM kill_ctrl2 LIMIT 1"
-      # two more sync steps: rollback completes before the background
-      # HTTP response is sent, so by the time we check, state is stable
+      # unrelated requests remain responsive while entered shards drain
       - session_id: "rb-kill-attacker2"
         sql: "SELECT 1"
       - session_id: "rb-kill-attacker2"
         sql: "SELECT 1"
+      # A running shard is atomic: KILL prevents further shard scheduling but
+      # rollback starts only after every already-entered shard has drained.
+      - wait_for_background: true
       # after rollback: target must be empty (all partial inserts undone)
       - session_id: "rb-kill-check"
         sql: "SELECT COUNT(*) AS n FROM kill_dst"


### PR DESCRIPTION
## Root cause

Storage scans polled query cancellation inside hot index, batch, RecSet, and map/reduce loops. The poll performs session-generation bookkeeping under a mutex and, in several paths, a GLS lookup. A primitive scan therefore paid cancellation overhead at `Stream`, once per index batch, and every 64 mapped rows even though cancellation is exceptional.

## Change

- Check cancellation only immediately before a scheduled shard operator starts.
- Capture the query generation once and use it for shard-boundary checks.
- Let entered shards run without cancellation polling in index, batch, RecSet, and row loops.
- Drain every started RecSet EXISTS shard before propagating errors or returning a result.
- Document the scheduling-only contract at every storage call site and on the processlist API.
- Make the KILL rollback regression wait for the background statement to drain before asserting that rollback removed every partial write.

A panic raised at a scheduling boundary is caught by the shard job, delivered to the parent scan, and re-raised only after all entered shard jobs have drained. Autocommit then rolls the statement back.

## A/B performance

Baseline: `34af3ecef` (current master when branched). Same machine and data for both variants.

### Primitive parallel SUM scan

Local benchmark over 100,000 integer rows with an active query generation, eight 2-second samples. This deliberately measures the physical primitive affected by the patch.

| Variant | Median | Mean | Bytes/op | Allocs/op |
|---|---:|---:|---:|---:|
| master | 6.365 ms | 6.442 ms | 3,640,395 | 103,438 |
| branch | 3.311 ms | 3.391 ms | 3,214,144 | 100,108 |

Median latency improves by **48.0%**, allocated bytes by about **11.7%**, and allocation count by about **3.2%**. The benchmark harness was local and is not committed.

### End-to-end manual application build

Tracing disabled, four test workers, three interleaved successful runs per engine. Public measurements intentionally omit application-specific identifiers and data.

| Engine | Runs | Median |
|---|---|---:|
| MySQL | 56.83 s, 56.75 s, 64.29 s | 56.83 s |
| MemCP master | 70.78 s, 70.59 s, 70.21 s | 70.59 s |
| MemCP branch | 68.50 s, 68.58 s, 69.31 s | 68.58 s |

The branch improves MemCP end-to-end latency by **2.85%** versus master. It remains **20.7%** slower than the MySQL median, so this closes part of the gap but does not claim parity.

## Validation

- `go build -o memcp`
- processlist query-generation tests, 10 repetitions
- `tests/41_in_subquery.yaml`: 60/60
- `tests/98_processlist.yaml`: 8/8
- `tests/99_kill_lock.yaml`: 26/26, including five repeated runs before full validation
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all suites passed
- `git diff --check`

All nine end-to-end A/B runs completed successfully.