### PR TITLE
Fix nested scalar probe stage rebinding

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6105,7 +6105,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 		'())))
 
 (define group_table_name (lambda (schema tbl alias keys condition)
-	(concat ".grp:" tbl ":" (fnv_hash (serialize (list "neumann-clean-groups-v3" schema tbl alias keys condition))))))
+	(concat ".grp:" tbl ":" (fnv_hash (serialize (list "neumann-clean-groups-v4" schema tbl alias keys condition))))))
 
 (define canonical_group_stage_alias "__grp")
 

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2035,9 +2035,20 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(map (coalesceNil stages '()) (lambda (stage)
 		(list (gs_id stage) (concat (gs_id stage) ":derived:" (fnv_hash (string alias))))))))
 
-(define derived_stage_rebind_alias_map (lambda (id_map)
-	(map (coalesceNil id_map '()) (lambda (entry)
-		(list (exists_stage_alias (nth entry 0)) (exists_stage_alias (nth entry 1)))))))
+(define derived_stage_rebind_alias_map (lambda (id_map stages)
+	(begin
+		(define base_alias_map (map (coalesceNil id_map '()) (lambda (entry)
+			(list (exists_stage_alias (nth entry 0)) (exists_stage_alias (nth entry 1))))))
+		(define aggregate_col_map (merge (map (coalesceNil stages '()) (lambda (stage)
+			(begin
+				(define old_alias (exists_stage_alias (gs_id stage)))
+				(map (gs_aggregates stage) (lambda (ag)
+					(list
+						old_alias
+						(aggregate_col_name ag)
+						(aggregate_col_name
+							(rewrite_stage_output_left_join_expr base_alias_map id_map ag))))))))))
+		(merge (list base_alias_map aggregate_col_map)))))
 
 (define derived_stage_rebind_stage (lambda (alias_map id_map stage)
 	(if (not (group_stage? stage))
@@ -2060,7 +2071,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 (define rebind_derived_stages (lambda (alias stages)
 	(begin
 		(define id_map (derived_stage_rebind_id_map alias stages))
-		(define alias_map (derived_stage_rebind_alias_map id_map))
+		(define alias_map (derived_stage_rebind_alias_map id_map stages))
 		(list
 			(map (coalesceNil stages '()) (lambda (stage)
 				(derived_stage_rebind_stage alias_map id_map stage)))
@@ -4631,19 +4642,69 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				nil)
 			default))))
 
+(define stage_column_merge_lookup (lambda (mapping alias col default)
+	(if (empty_list? mapping)
+		default
+		(coalesceNil
+			(reduce mapping (lambda (found entry)
+				(if (not (nil? found))
+					found
+					(match entry
+						'(entry_alias entry_col replacement)
+						(if (and (equal? entry_alias alias) (equal? entry_col col))
+							replacement
+							nil)
+						_ nil)))
+				nil)
+			default))))
+
+(define rewrite_stage_output_probe_column (lambda (alias_map id_map stage requested_col)
+	(begin
+		(define ag (scalar_first_probe_aggregate stage requested_col))
+		(if (nil? ag)
+			requested_col
+			(aggregate_col_name
+				(rewrite_stage_output_left_join_expr alias_map id_map ag))))))
+
 (define rewrite_stage_output_left_join_expr (lambda (alias_map id_map expr)
 	(match expr
+		((symbol scalar_first_probe) stage requested_col stages)
+		(list (quote scalar_first_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col)
+			(rewrite_stage_output_left_join_expr alias_map id_map stages))
+		((quote scalar_first_probe) stage requested_col stages)
+		(list (quote scalar_first_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col)
+			(rewrite_stage_output_left_join_expr alias_map id_map stages))
+		((symbol scalar_first_probe) stage requested_col)
+		(list (quote scalar_first_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+		((quote scalar_first_probe) stage requested_col)
+		(list (quote scalar_first_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+		((symbol scalar_aggregate_probe) stage requested_col)
+		(list (quote scalar_aggregate_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+		((quote scalar_aggregate_probe) stage requested_col)
+		(list (quote scalar_aggregate_probe)
+			(rewrite_stage_output_left_join_expr alias_map id_map stage)
+			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
 		((symbol get_column) tblvar ignorecase col col_ignorecase)
 		(list (quote get_column)
 			(stage_merge_lookup alias_map tblvar tblvar)
 			ignorecase
-			col
+			(stage_column_merge_lookup alias_map tblvar col col)
 			col_ignorecase)
 		((quote get_column) tblvar ignorecase col col_ignorecase)
 		(list (quote get_column)
 			(stage_merge_lookup alias_map tblvar tblvar)
 			ignorecase
-			col
+			(stage_column_merge_lookup alias_map tblvar col col)
 			col_ignorecase)
 		((symbol stage-output) stage_id)
 		(list (quote stage-output) (stage_merge_lookup id_map stage_id stage_id))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -198,6 +198,42 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(group_stage_carrier_relation canonical_group_sum_stage)
 		(group_stage_carrier_relation canonical_group_count_stage))
 		true "group keytable identity excludes aggregate columns")
+	(define rebind_child_ag (list 1 (quote +) 0))
+	(define rebind_child_stage (make_group_stage
+		"rebind-child"
+		(list "child" "memcp-tests" "child_source" false nil)
+		'() '(1) (list rebind_child_ag) nil '() '() nil nil '()))
+	(define rebind_parent_ag (list
+		(list (quote scalar_first_probe)
+			rebind_child_stage
+			(aggregate_col_name rebind_child_ag)
+			(list rebind_child_stage))
+		(quote +)
+		0))
+	(define rebind_parent_stage (make_group_stage
+		"rebind-parent"
+		(list "parent" "memcp-tests" (make_stage_output_relation "rebind-child") false nil)
+		'() '(1) (list rebind_parent_ag) nil '() '() nil nil '()))
+	(define rebind_fixture (rebind_derived_stages
+		"lookup"
+		(list rebind_child_stage rebind_parent_stage)))
+	(define rebound_parent_stage (stage_by_id
+		(nth rebind_fixture 0)
+		(stage_merge_lookup (nth rebind_fixture 2) "rebind-parent" nil)))
+	(define rebound_parent_ref (rebind_derived_stage_expr rebind_fixture
+		(list (quote get_column)
+			(exists_stage_alias "rebind-parent")
+			false
+			(aggregate_col_name rebind_parent_ag)
+			false)))
+	(assert (not (equal?
+		(aggregate_col_name rebind_parent_ag)
+		(aggregate_col_name (car (gs_aggregates rebound_parent_stage)))))
+		true "derived stage rebinding changes dependent aggregate column hashes")
+	(assert (equal?
+		(nth rebound_parent_ref 3)
+		(aggregate_col_name (car (gs_aggregates rebound_parent_stage))))
+		true "derived stage rebinding updates aggregate column handles")
 	(define no_from_select_ast (list "memcp-tests" '() (list "result" 8) true nil nil nil nil nil))
 	(assert (equal? (serialize (build_queryplan_term no_from_select_ast))
 		"(resultrow '(\"result\" 8))") true "build_queryplan_term lowers no-FROM projection")

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -24,6 +24,7 @@
 metadata:
   version: "1.0"
   description: "Derived table with ORDER BY LIMIT scalar subselects"
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS dtl_main"
@@ -56,6 +57,29 @@ setup:
   - sql: "INSERT INTO dtl_access_link VALUES (1, 11, 100, 1000), (2, 11, 200, 2000), (3, 12, 100, 1000), (4, 11, NULL, NULL)"
   - sql: "CREATE TABLE dtl_global_access (ID INT PRIMARY KEY, account_id INT, tenant_id INT)"
   - sql: "INSERT INTO dtl_global_access VALUES (1, 11, NULL), (2, 11, NULL), (3, 11, NULL), (4, 11, NULL), (5, 12, NULL)"
+  # Simulate a v3 carrier retained across a planner upgrade. Its stale computed
+  # presence column makes all four carrier keys look like successful probes.
+  - scm: |
+      (begin
+        (droptable "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc" true)
+        (createtable "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc"
+          (list
+            (list "unique" "group" (list "k0"))
+            (list "column" "k0" "any" (list) (list)))
+          (list "engine" "memory")
+          true)
+        (insert
+          (table "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc")
+          (list "k0")
+          (list (list 1) (list 2) (list 3) (list 4)))
+        (createcolumn
+          (table "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc")
+          "agg_f0d39398d80eb9d2"
+          "any"
+          (list)
+          (list "temp" true)
+          (list "k0")
+          (lambda (k0) 1)))
 
 test_cases:
 
@@ -535,6 +559,9 @@ test_cases:
       data:
         - ID: 1
         - ID: 2
+
+  - name: "Remove stale physical carrier fixture"
+    scm: '(droptable "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc" true)'
 
 
 cleanup:

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -35,6 +35,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS dtl_access_link"
   - sql: "DROP TABLE IF EXISTS dtl_access_tenant"
   - sql: "DROP TABLE IF EXISTS dtl_access_location"
+  - sql: "DROP TABLE IF EXISTS dtl_global_access"
   - sql: "CREATE TABLE dtl_main (ID INT PRIMARY KEY, name TEXT, category INT)"
   - sql: "CREATE TABLE dtl_hist (ID INT PRIMARY KEY, parent INT, val INT, ts INT)"
   - sql: "CREATE TABLE dtl_ref (ID INT PRIMARY KEY, label TEXT)"
@@ -53,6 +54,8 @@ setup:
   - sql: "INSERT INTO dtl_access_tenant VALUES (100, 'tenant-a'), (200, 'tenant-b')"
   - sql: "INSERT INTO dtl_access_location VALUES (1000, 'location-a', 100), (2000, 'location-b', 200)"
   - sql: "INSERT INTO dtl_access_link VALUES (1, 11, 100, 1000), (2, 11, 200, 2000), (3, 12, 100, 1000), (4, 11, NULL, NULL)"
+  - sql: "CREATE TABLE dtl_global_access (ID INT PRIMARY KEY, account_id INT, tenant_id INT)"
+  - sql: "INSERT INTO dtl_global_access VALUES (1, 11, NULL), (2, 11, NULL), (3, 11, NULL), (4, 11, NULL), (5, 12, NULL)"
 
 test_cases:
 
@@ -436,6 +439,103 @@ test_cases:
       not_contains:
         - "scalar_first_probe"
 
+  - name: "Repeated global EXISTS in derived wrapper stays scalar"
+    sql: |
+      SELECT t.* FROM (
+        SELECT r.ID, r.label,
+          EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          ) AS can_delete,
+          (EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          )) AND (CASE WHEN EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          ) THEN TRUE ELSE r.ID = 10 END) AS can_edit
+        FROM dtl_join_ref r
+        WHERE EXISTS (
+          SELECT TRUE FROM dtl_global_access global_access
+          WHERE global_access.account_id = 11
+            AND global_access.tenant_id IS NULL
+          LIMIT 1
+        )
+      ) t
+      WHERE TRUE
+      ORDER BY t.ID
+      LIMIT 72 OFFSET 0
+    expect:
+      rows: 4
+      data:
+        - ID: 10
+          label: "ten"
+          can_delete: true
+          can_edit: true
+        - ID: 20
+          label: "twenty"
+          can_delete: true
+          can_edit: true
+        - ID: 30
+          label: "thirty"
+          can_delete: true
+          can_edit: true
+        - ID: 40
+          label: "forty"
+          can_delete: true
+          can_edit: true
+
+  - name: "Derived comma JOIN keeps equality predicate from WHERE"
+    sql: |
+      SELECT t.* FROM (
+        SELECT m.ID, r.label
+        FROM dtl_join_main m, dtl_join_ref r
+        WHERE r.ID = m.first_ref
+          AND EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          )
+      ) t
+      ORDER BY t.ID
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+          label: "ten"
+        - ID: 2
+          label: "twenty"
+
+  - name: "Derived correlated EXISTS keeps JOIN predicate from inner WHERE"
+    sql: |
+      SELECT t.* FROM (
+        SELECT m.ID
+        FROM dtl_join_main m
+        WHERE EXISTS (
+          SELECT TRUE FROM dtl_join_ref r
+          WHERE r.ID = m.first_ref
+          LIMIT 1
+        ) AND EXISTS (
+          SELECT TRUE FROM dtl_global_access global_access
+          WHERE global_access.account_id = 11
+            AND global_access.tenant_id IS NULL
+          LIMIT 1
+        )
+      ) t
+      ORDER BY t.ID
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+        - ID: 2
+
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS dtl_main"
@@ -447,3 +547,4 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS dtl_access_link"
   - sql: "DROP TABLE IF EXISTS dtl_access_tenant"
   - sql: "DROP TABLE IF EXISTS dtl_access_location"
+  - sql: "DROP TABLE IF EXISTS dtl_global_access"

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -32,6 +32,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS dtl_join_main"
   - sql: "DROP TABLE IF EXISTS dtl_join_ref"
   - sql: "DROP TABLE IF EXISTS dtl_join_acl"
+  - sql: "DROP TABLE IF EXISTS dtl_access_link"
+  - sql: "DROP TABLE IF EXISTS dtl_access_tenant"
+  - sql: "DROP TABLE IF EXISTS dtl_access_location"
   - sql: "CREATE TABLE dtl_main (ID INT PRIMARY KEY, name TEXT, category INT)"
   - sql: "CREATE TABLE dtl_hist (ID INT PRIMARY KEY, parent INT, val INT, ts INT)"
   - sql: "CREATE TABLE dtl_ref (ID INT PRIMARY KEY, label TEXT)"
@@ -44,6 +47,12 @@ setup:
   - sql: "INSERT INTO dtl_join_main VALUES (1, 10, 20), (2, 20, 30), (3, 99, 10)"
   - sql: "INSERT INTO dtl_join_ref VALUES (10, 'ten'), (20, 'twenty'), (30, 'thirty'), (40, 'forty')"
   - sql: "INSERT INTO dtl_join_acl VALUES (1, 10, TRUE), (2, 20, FALSE), (3, 40, TRUE)"
+  - sql: "CREATE TABLE dtl_access_link (ID INT PRIMARY KEY, account_id INT, tenant_id INT, location_id INT)"
+  - sql: "CREATE TABLE dtl_access_tenant (ID INT PRIMARY KEY, name TEXT)"
+  - sql: "CREATE TABLE dtl_access_location (ID INT PRIMARY KEY, name TEXT, tenant_id INT)"
+  - sql: "INSERT INTO dtl_access_tenant VALUES (100, 'tenant-a'), (200, 'tenant-b')"
+  - sql: "INSERT INTO dtl_access_location VALUES (1000, 'location-a', 100), (2000, 'location-b', 200)"
+  - sql: "INSERT INTO dtl_access_link VALUES (1, 11, 100, 1000), (2, 11, 200, 2000), (3, 12, 100, 1000), (4, 11, NULL, NULL)"
 
 test_cases:
 
@@ -358,6 +367,75 @@ test_cases:
           second_label: "ten"
           second_can_view: true
 
+  - name: "Derived access lookup retains nested scalar probe aggregates"
+    sql: |
+      EXPLAIN SELECT access_link.ID, location_lookup.description AS location_description,
+        location_lookup.can_view AS location_can_view
+      FROM dtl_access_link access_link
+        JOIN (
+          SELECT location.ID, location.name AS description,
+            ((EXISTS (
+              SELECT TRUE FROM dtl_access_link global_access
+              WHERE global_access.account_id = 11
+                AND global_access.tenant_id IS NULL
+              LIMIT 1
+            )) OR (NOT EXISTS (
+              SELECT TRUE FROM dtl_access_link denied_access
+              WHERE denied_access.account_id = 999
+                AND denied_access.tenant_id IS NULL
+              LIMIT 1
+            ))) AND (CASE WHEN EXISTS (
+              SELECT TRUE FROM dtl_access_link global_access
+              WHERE global_access.account_id = 11
+                AND global_access.tenant_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM dtl_access_link location_access
+              WHERE COALESCE(location_access.location_id, location.ID) = location.ID
+                AND location_access.account_id = 11
+              LIMIT 1
+            ) END) AND COALESCE((
+              SELECT ((EXISTS (
+                SELECT TRUE FROM dtl_access_link nested_global_access
+                WHERE nested_global_access.account_id = 11
+                  AND nested_global_access.tenant_id IS NULL
+                LIMIT 1
+              )) OR (NOT EXISTS (
+                SELECT TRUE FROM dtl_access_link nested_denied_access
+                WHERE nested_denied_access.account_id = 999
+                  AND nested_denied_access.tenant_id IS NULL
+                LIMIT 1
+              ))) AND (CASE WHEN EXISTS (
+                SELECT TRUE FROM dtl_access_link nested_global_access
+                WHERE nested_global_access.account_id = 11
+                  AND nested_global_access.tenant_id IS NULL
+                LIMIT 1
+              ) THEN TRUE ELSE EXISTS (
+                SELECT TRUE FROM dtl_access_link nested_tenant_access
+                WHERE nested_tenant_access.tenant_id = parent_tenant.ID
+                  AND nested_tenant_access.account_id = 11
+                LIMIT 1
+              ) END)
+              FROM dtl_access_tenant parent_tenant
+              WHERE parent_tenant.ID = location.tenant_id
+              LIMIT 1
+            ), FALSE) AS can_view
+          FROM dtl_access_location location
+        ) location_lookup ON location_lookup.ID = access_link.location_id
+      WHERE EXISTS (
+        SELECT TRUE FROM dtl_access_link global_filter
+        WHERE global_filter.account_id = 11
+          AND global_filter.tenant_id IS NULL
+        LIMIT 1
+      )
+      ORDER BY access_link.ID
+      LIMIT 72 OFFSET 0
+    expect:
+      contains:
+        - "scan"
+      not_contains:
+        - "scalar_first_probe"
+
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS dtl_main"
@@ -366,3 +444,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS dtl_join_main"
   - sql: "DROP TABLE IF EXISTS dtl_join_ref"
   - sql: "DROP TABLE IF EXISTS dtl_join_acl"
+  - sql: "DROP TABLE IF EXISTS dtl_access_link"
+  - sql: "DROP TABLE IF EXISTS dtl_access_tenant"
+  - sql: "DROP TABLE IF EXISTS dtl_access_location"


### PR DESCRIPTION
## Summary
- keep aggregate-column handles synchronized when independently flattened derived stages receive new IDs
- rewrite embedded scalar probe stages and requested aggregate columns as one operation
- invalidate stale physical group carriers by advancing the deterministic helper namespace
- cover repeated presence probes plus JOIN predicates originating in outer and nested WHERE clauses
- reproduce cross-version carrier reuse with a stale computed-column fixture

## Root cause
Aggregate column names are hashes of their aggregate descriptors. Rebinding a nested stage changes embedded stage IDs and therefore changes those hashes, while existing `get_column` and scalar-probe references still carried the old hash. Recipe emission then rejected the stale handle as an unknown aggregate column.

A second correctness issue appeared after deploying successive planner versions over an existing data directory: a decorrelated presence stage reused an incompatible helper relation created by an older physical plan. Its current logical and physical predicates were correct, but the stale carrier multiplied every outer row. Advancing the physical helper namespace preserves Neumann decorrelation while preventing cross-version carrier reuse.

## A/B correctness measurement
Same binary inputs, SQL payload, and preserved real-data directory:

| Revision | Returned rows | Unique primary IDs | Maximum rows per ID |
| --- | ---: | ---: | ---: |
| previous PR revision | 72 | 18 | 4 |
| this revision | 72 | 72 | 1 |

The automated regression fixture constructs the old deterministic carrier with four keys and a stale computed presence column:

| Planner namespace | Focused suite | Result |
| --- | ---: | --- |
| v3 | 15/18 | all three new WHERE/EXISTS cases reproduce fourfold rows |
| v4 | 18/18 | original cardinality preserved |

The current logical IR still contains the nested WHERE predicate in the group stage. The fix does not remove decorrelation or replace the outer join.

## Verification
- focused derived/scalar suite (`18/18`)
- explicit v3/v4 Red/Green run using the same stale-carrier fixture
- isolated self-referencing `UPDATE ... EXISTS` suites (`2/2`, `3/3`)
- isolated ORDER/LIMIT suite with a non-coverage binary (`19/19`)
- full hook-equivalent suite with parallel execution (`MEMCP_COVERAGE=0 MEMCP_FAIL_FAST=0 MEMCP_TEST_JOBS=2 ./git-pre-commit`)
- replayed the captured production-shaped payload against the preserved real-data instance: no compile failure and no duplicate primary IDs

## Scope
No parser change and no rollback of Neumann decorrelation, selection pushdown, or the outer-join model. The patch extends existing derived-stage rebinding and rotates only the deterministic namespace of physical group carriers.