### PR TITLE
Fix derived LEFT JOIN values lost during lowering

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1086,6 +1086,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			'('lambda '('acc 'x) '('match 'acc '('cons 'h 't) '(+ 'h 'x) 'x))
 			'(list))))))
 	(assert (match opt_reduce_ser (regex "match_mut" _) true false) true "optimizer: match on owned reduce accumulator becomes match_mut")
+	/* cdr is a borrowed slice view; mutating its result must not corrupt the source list. */
+	(define filter_cdr_without_aliasing (eval (optimize '('lambda '('xs)
+		'('list 'xs '('filter '('cdr 'xs) '('lambda '('x) '(> 'x 2))))))))
+	(assert
+		(filter_cdr_without_aliasing (list 1 2 3 4))
+		(list (list 1 2 3 4) (list 3 4))
+		"optimizer: filter after cdr preserves the source list")
 
 	/* REGEXP_REPLACE precompilation: constant pattern gets precompiled */
 	(assert ((eval (optimize '('lambda '('s) '(regexp_replace 's "[^0-9]" "")))) "abc123def") "123" "regexp_replace precompilation works")

--- a/scm/list.go
+++ b/scm/list.go
@@ -880,7 +880,8 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", ParamName: "list", ParamDesc: "list", NoEscape: true},
 			},
-			Return:   FreshAlloc,
+			// cdr shares the input slice's backing array; its result is borrowed.
+			Return:   &TypeDescriptor{Kind: "list"},
 			Const:    true,
 			Optimize: optimizeCdr,
 		},

--- a/tests/41_in_subquery.yaml
+++ b/tests/41_in_subquery.yaml
@@ -1756,6 +1756,86 @@ test_cases:
       not_contains:
         - "unknown stage"
 
+  - name: "Derived LEFT JOIN keeps projected values beside nested permission probes"
+    fail_comment: "compiled plans must execute derived LEFT JOIN matches, not only resolve their stages"
+    setup:
+      - sql: "DROP TABLE IF EXISTS derived_label_acl"
+      - sql: "DROP TABLE IF EXISTS derived_label_item"
+      - sql: "DROP TABLE IF EXISTS derived_label_tenant"
+      - sql: "CREATE TABLE derived_label_acl (ID INT PRIMARY KEY, actor INT, derived_label_tenant INT)"
+      - sql: "CREATE TABLE derived_label_item (ID INT PRIMARY KEY, derived_label_tenant INT, title VARCHAR(64))"
+      - sql: "CREATE TABLE derived_label_tenant (ID INT PRIMARY KEY, name VARCHAR(64))"
+      - sql: "INSERT INTO derived_label_tenant (ID, name) VALUES (7, 'Tenant Seven'), (8, 'Tenant Eight')"
+      - sql: "INSERT INTO derived_label_item (ID, derived_label_tenant, title) VALUES (101, 7, 'matched'), (102, 8, 'matched too'), (103, 99, 'missing')"
+      - sql: "INSERT INTO derived_label_acl (ID, actor, derived_label_tenant) VALUES (1, 42, NULL), (2, 42, 7)"
+    sql: |
+      SELECT t.*
+      FROM (
+        SELECT derived_label_item.ID,
+          derived_label_item.derived_label_tenant,
+          `ref:tenant`.`tenant:description` AS `tenant:description`,
+          `ref:tenant`.`tenant:canView` AS `tenant:canView`
+        FROM derived_label_item derived_label_item
+        LEFT JOIN (
+          SELECT derived_label_tenant.ID AS `tenant:ID`,
+            derived_label_tenant.name AS `tenant:description`,
+            ((FALSE OR EXISTS (
+              SELECT TRUE FROM derived_label_acl global_allow
+              WHERE global_allow.actor = 42 AND global_allow.derived_label_tenant IS NULL
+              LIMIT 1
+            )) OR (NOT EXISTS (
+              SELECT TRUE FROM derived_label_acl global_deny
+              WHERE global_deny.actor = 42 AND global_deny.derived_label_tenant IS NULL
+              LIMIT 1
+            ))) AND CASE WHEN EXISTS (
+              SELECT TRUE FROM derived_label_acl global_check
+              WHERE global_check.actor = 42 AND global_check.derived_label_tenant IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM derived_label_acl tenant_acl
+              WHERE tenant_acl.derived_label_tenant = derived_label_tenant.ID
+                AND tenant_acl.actor = 42
+              LIMIT 1
+            ) END AS `tenant:canView`
+          FROM derived_label_tenant
+        ) `ref:tenant`
+          ON `ref:tenant`.`tenant:ID` = derived_label_tenant
+        WHERE EXISTS (
+          SELECT TRUE FROM derived_label_acl global_allow
+          WHERE global_allow.actor = 42 AND global_allow.derived_label_tenant IS NULL
+          LIMIT 1
+        ) AND COALESCE((
+          SELECT CASE WHEN EXISTS (
+            SELECT TRUE FROM derived_label_acl global_allow
+            WHERE global_allow.actor = 42 AND global_allow.derived_label_tenant IS NULL
+            LIMIT 1
+          ) THEN TRUE ELSE EXISTS (
+            SELECT TRUE FROM derived_label_acl row_filter
+            WHERE row_filter.derived_label_tenant = tenant_probe.ID
+              AND row_filter.actor = 42
+            LIMIT 1
+          ) END
+          FROM derived_label_tenant tenant_probe
+          WHERE tenant_probe.ID = derived_label_item.derived_label_tenant
+          LIMIT 1
+        ), FALSE)
+      ) t
+      LEFT JOIN derived_label_tenant sorter_tenant
+        ON t.derived_label_tenant = sorter_tenant.ID
+      ORDER BY t.ID
+      LIMIT 10
+    expect:
+      rows: 2
+      data:
+        - ID: 101
+          derived_label_tenant: 7
+          "tenant:description": "Tenant Seven"
+          "tenant:canView": true
+        - ID: 102
+          derived_label_tenant: 8
+          "tenant:description": "Tenant Eight"
+          "tenant:canView": true
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS assignment_x"
   - sql: "DROP TABLE IF EXISTS item_x"
@@ -1777,3 +1857,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS in_nullable_rhs"
   - sql: "DROP TABLE IF EXISTS in_renderjob"
   - sql: "DROP TABLE IF EXISTS in_fop_files"
+  - sql: "DROP TABLE IF EXISTS derived_label_acl"
+  - sql: "DROP TABLE IF EXISTS derived_label_item"
+  - sql: "DROP TABLE IF EXISTS derived_label_tenant"


### PR DESCRIPTION
## Summary
- mark `cdr` results as borrowed because they share the input slice backing array
- prevent the optimizer from selecting destructive `_mut` operations for a borrowed list tail
- cover both generic list aliasing and the executed derived LEFT JOIN/scalar-probe planner shape

## Root cause
`cdr` returned a slice view but advertised `FreshAlloc`. During physical lowering, the optimizer therefore rewrote `filter (cdr scan_sources)` to `filter_mut`. The mutation overwrote the original source catalog and could remove a derived LEFT JOIN source while later expressions still referenced its columns. Matching rows were consequently null-extended.

## Regression evidence
Before the fix, the new SQL test returned both expected outer rows but the two projected LEFT JOIN values were `NULL`. The generic optimizer test also showed that filtering a `cdr` result changed the source list. Both pass after correcting the ownership descriptor.

## Verification
- `go test ./scm/...`
- `python3 run_sql_tests.py tests/41_in_subquery.yaml` (61/61)
- `MEMCP_FAIL_FAST=0 MEMCP_TEST_JOBS=2 ./git-pre-commit` (all tests passed)
- `python3 tools/lint_scm.py --check` (exit 0; reports existing bracket-depth warnings in untouched planner/parser files)
