### PR TITLE
Preserve physical predicate order before scalar probes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -9431,8 +9431,8 @@ source remain residual so they observe the null-extended row. */
 			(physical_partition_condition_terms default_alias all_sources future_sources rest (cons term ready) pending)
 			(physical_partition_condition_terms default_alias all_sources future_sources rest ready (cons term pending)))
 		_ (list
-			(combine_where_terms ready true)
-			(combine_where_terms pending true)))))
+			(combine_where_terms (reverse ready) true)
+			(combine_where_terms (reverse pending) true)))))
 
 (define physical_partition_condition (lambda (default_alias all_sources future_sources condition)
 	(physical_partition_condition_terms

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -560,6 +560,94 @@ test_cases:
         - ID: 1
         - ID: 2
 
+  - name: "Selective driver predicate stays ahead of nested scalar permission probe"
+    sql: |
+      SELECT t.* FROM (
+        SELECT m.ID, m.first_ref, m.second_ref, ref.label
+        FROM dtl_join_main m
+        LEFT JOIN (
+          SELECT r.ID AS ref_id, r.label
+          FROM dtl_join_ref r
+        ) ref ON ref.ref_id = m.first_ref
+        WHERE m.second_ref = 20
+          AND EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          )
+          AND COALESCE((
+            SELECT CASE WHEN EXISTS (
+              SELECT TRUE FROM dtl_global_access global_access
+              WHERE global_access.account_id = 11
+                AND global_access.tenant_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM dtl_join_acl row_access
+              WHERE row_access.ref_id = probe.ID
+                AND row_access.allowed = TRUE
+              LIMIT 1
+            ) END
+            FROM dtl_join_ref probe
+            WHERE probe.ID = m.first_ref
+            LIMIT 1
+          ), FALSE)
+      ) t
+      LEFT JOIN dtl_join_ref sorter ON sorter.ID = t.first_ref
+      ORDER BY t.second_ref DESC, t.ID
+      LIMIT 72
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          first_ref: 10
+          second_ref: 20
+          label: "ten"
+
+  - name: "Physical driver filter precedes nested scalar permission recipe"
+    fail_comment: "physical predicate partitioning must not reverse a cheap local filter behind a scalar probe"
+    sql: |
+      EXPLAIN SELECT t.* FROM (
+        SELECT m.ID, m.first_ref, m.second_ref, ref.label
+        FROM dtl_join_main m
+        LEFT JOIN (
+          SELECT r.ID AS ref_id, r.label
+          FROM dtl_join_ref r
+        ) ref ON ref.ref_id = m.first_ref
+        WHERE m.second_ref = 20
+          AND EXISTS (
+            SELECT TRUE FROM dtl_global_access global_access
+            WHERE global_access.account_id = 11
+              AND global_access.tenant_id IS NULL
+            LIMIT 1
+          )
+          AND COALESCE((
+            SELECT CASE WHEN EXISTS (
+              SELECT TRUE FROM dtl_global_access global_access
+              WHERE global_access.account_id = 11
+                AND global_access.tenant_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM dtl_join_acl row_access
+              WHERE row_access.ref_id = probe.ID
+                AND row_access.allowed = TRUE
+              LIMIT 1
+            ) END
+            FROM dtl_join_ref probe
+            WHERE probe.ID = m.first_ref
+            LIMIT 1
+          ), FALSE)
+      ) t
+      LEFT JOIN dtl_join_ref sorter ON sorter.ID = t.first_ref
+      ORDER BY t.second_ref DESC, t.ID
+      LIMIT 72
+    expect:
+      result_contains:
+        - "__scalar_query_probe_"
+        - "(and (equal??"
+      result_not_contains:
+        - "(and (coalesceNil (__scalar_query_probe_"
+
   - name: "Remove stale physical carrier fixture"
     scm: '(droptable "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc" true)'
 


### PR DESCRIPTION
## Problem

Physical predicate partitioning prepended matching terms while walking a WHERE conjunction and emitted the accumulated lists without restoring source order. When a cheap selective driver predicate and a correlated scalar permission probe landed in the same physical partition, the probe could therefore run first for every driver row.

## Change

- restore stable predicate order after physical partitioning
- add an integration regression for the derived-table/LEFT JOIN/scalar-permission shape
- add an EXPLAIN guard proving the selective equality precedes the scalar probe in the physical plan

## A/B measurement

Measured with the same 27.8 KiB production-derived query and preserved data directory:

| Revision | Run | Wall time |
| --- | --- | ---: |
| master | live request 1 | >78 s, terminated |
| master | live request 2 | >60 s, terminated |
| earlier master trace | completed outlier | 17m41s |
| PR | cold, 13 matching rows | 4.32 s |
| PR | warm 1 | 3.39 s |
| PR | warm 2 | 3.38 s |
| PR | warm 3 | 3.35 s |

The driver relation contains 855,496 rows; the selective predicate leaves 13 rows. Before this patch the physical conjunction started with the scalar probe. After this patch the equality is evaluated first. Planner compile time is about 0.87 s for this query and was not the minutes-long bottleneck.

## Verification

- red/green regression confirmed against master and this branch
- `tests/66_derived_table_limit_scalar.yaml`: 20/20
- `tests/41_in_subquery.yaml`: 61/61
- `tests/66_left_join_correlated_on.yaml`: 5/5
- `tests/76_range_scan_coverage.yaml`: 75/75
- full parallel `git-pre-commit`: all tests passed
- `python3 tools/lint_scm.py`
- `git diff --check`