### PR TITLE
Consolidate stage graph rebinding

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2047,24 +2047,30 @@ PostgreSQL parsers should both lower to the same combined operators.
 						old_alias
 						(aggregate_col_name ag)
 						(aggregate_col_name
-							(rewrite_stage_output_left_join_expr base_alias_map id_map ag))))))))))
+							(rewrite_stage_graph_expr base_alias_map id_map ag))))))))))
 		(merge (list base_alias_map aggregate_col_map)))))
 
-(define derived_stage_rebind_stage (lambda (alias_map id_map stage)
+/* Derived clones rebind their root ID. Stage merges keep the surviving root ID,
+while both modes rebind every reference and nested stage descriptor below it. */
+(define rewrite_stage_graph_stage (lambda (alias_map id_map rebind_id stage)
 	(if (not (group_stage? stage))
 		stage
 		(make_group_stage
-			(stage_merge_lookup id_map (gs_id stage) (gs_id stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_input stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_domain stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_keys stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_having stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_output stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_order stage))
+			(if rebind_id (stage_merge_lookup id_map (gs_id stage) (gs_id stage)) (gs_id stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_input stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_domain stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_keys stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_aggregates stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_having stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_output stage))
+			(rewrite_stage_graph_expr alias_map id_map (gs_order stage))
 			(gs_limit stage)
 			(gs_offset stage)
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_facts stage))))))
+			(rewrite_stage_graph_expr alias_map id_map (gs_facts stage))))))
+
+(define rewrite_stage_graph_stages (lambda (alias_map id_map stages)
+	(map (coalesceNil stages '()) (lambda (stage)
+		(rewrite_stage_graph_stage alias_map id_map true stage)))))
 
 /* Independently flattened instances may start with identical generated stage
 IDs. Give each instance its own IDs and source aliases before their plans meet. */
@@ -2074,16 +2080,16 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(define alias_map (derived_stage_rebind_alias_map id_map stages))
 		(list
 			(map (coalesceNil stages '()) (lambda (stage)
-				(derived_stage_rebind_stage alias_map id_map stage)))
+				(rewrite_stage_graph_stage alias_map id_map true stage)))
 			alias_map
 			id_map))))
 
 (define rebind_derived_stage_expr (lambda (rebinding expr)
-	(rewrite_stage_output_left_join_expr (nth rebinding 1) (nth rebinding 2) expr)))
+	(rewrite_stage_graph_expr (nth rebinding 1) (nth rebinding 2) expr)))
 
 (define rebind_derived_stage_sources (lambda (rebinding sources)
 	(map (coalesceNil sources '()) (lambda (src)
-		(rewrite_stage_output_left_join_source (nth rebinding 1) (nth rebinding 2) src)))))
+		(rewrite_stage_graph_source (nth rebinding 1) (nth rebinding 2) src)))))
 
 (define make_scalar_single_stage_rewrite (lambda (inner args)
 	(begin
@@ -4500,7 +4506,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 			(list
 				(stage_output_relation_id (source_relation (nth source_sources i)))
 				(stage_output_relation_id (source_relation (nth target_sources i)))))))
-		(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage)))))
+		(rewrite_stage_graph_expr alias_map id_map (gs_aggregates stage)))))
 
 (define stage_output_left_join_entry_add_source (lambda (entry src stage)
 	(list
@@ -4658,49 +4664,42 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				nil)
 			default))))
 
-(define rewrite_stage_output_probe_column (lambda (alias_map id_map stage requested_col)
+(define rewrite_stage_graph_probe_column (lambda (alias_map id_map stage requested_col)
 	(begin
 		(define ag (scalar_first_probe_aggregate stage requested_col))
 		(if (nil? ag)
 			requested_col
 			(aggregate_col_name
-				(rewrite_stage_output_left_join_expr alias_map id_map ag))))))
+				(rewrite_stage_graph_expr alias_map id_map ag))))))
 
-(define rewrite_stage_output_probe_stage (lambda (alias_map id_map stage)
-	(derived_stage_rebind_stage alias_map id_map stage)))
-
-(define rewrite_stage_output_probe_stages (lambda (alias_map id_map stages)
-	(map (coalesceNil stages '()) (lambda (stage)
-		(rewrite_stage_output_probe_stage alias_map id_map stage)))))
-
-(define rewrite_stage_output_left_join_expr (lambda (alias_map id_map expr)
+(define rewrite_stage_graph_expr (lambda (alias_map id_map expr)
 	(match expr
 		((symbol scalar_first_probe) stage requested_col stages)
 		(list (quote scalar_first_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col)
-			(rewrite_stage_output_probe_stages alias_map id_map stages))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col)
+			(rewrite_stage_graph_stages alias_map id_map stages))
 		((quote scalar_first_probe) stage requested_col stages)
 		(list (quote scalar_first_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col)
-			(rewrite_stage_output_probe_stages alias_map id_map stages))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col)
+			(rewrite_stage_graph_stages alias_map id_map stages))
 		((symbol scalar_first_probe) stage requested_col)
 		(list (quote scalar_first_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col))
 		((quote scalar_first_probe) stage requested_col)
 		(list (quote scalar_first_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col))
 		((symbol scalar_aggregate_probe) stage requested_col)
 		(list (quote scalar_aggregate_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col))
 		((quote scalar_aggregate_probe) stage requested_col)
 		(list (quote scalar_aggregate_probe)
-			(rewrite_stage_output_probe_stage alias_map id_map stage)
-			(rewrite_stage_output_probe_column alias_map id_map stage requested_col))
+			(rewrite_stage_graph_stage alias_map id_map true stage)
+			(rewrite_stage_graph_probe_column alias_map id_map stage requested_col))
 		((symbol get_column) tblvar ignorecase col col_ignorecase)
 		(list (quote get_column)
 			(stage_merge_lookup alias_map tblvar tblvar)
@@ -4717,36 +4716,20 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(list (quote stage-output) (stage_merge_lookup id_map stage_id stage_id))
 		((quote stage-output) stage_id)
 		(list (quote stage-output) (stage_merge_lookup id_map stage_id stage_id))
-		(cons head tail) (cons (rewrite_stage_output_left_join_expr alias_map id_map head)
-			(map tail (lambda (item) (rewrite_stage_output_left_join_expr alias_map id_map item))))
+		(cons head tail) (cons (rewrite_stage_graph_expr alias_map id_map head)
+			(map tail (lambda (item) (rewrite_stage_graph_expr alias_map id_map item))))
 		_ expr)))
 
-(define rewrite_stage_output_left_join_source (lambda (alias_map id_map src)
+(define rewrite_stage_graph_source (lambda (alias_map id_map src)
 	(match src
 		'(alias schema relation outer join)
 		(list
 			(stage_merge_lookup alias_map alias alias)
 			schema
-			(rewrite_stage_output_left_join_expr alias_map id_map relation)
+			(rewrite_stage_graph_expr alias_map id_map relation)
 			outer
-			(rewrite_stage_output_left_join_expr alias_map id_map join))
+			(rewrite_stage_graph_expr alias_map id_map join))
 		_ src)))
-
-(define rewrite_stage_output_left_join_stage (lambda (alias_map id_map stage)
-	(if (not (group_stage? stage))
-		stage
-		(make_group_stage
-			(gs_id stage)
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_input stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_domain stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_keys stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_aggregates stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_having stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_output stage))
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_order stage))
-			(gs_limit stage)
-			(gs_offset stage)
-			(rewrite_stage_output_left_join_expr alias_map id_map (gs_facts stage))))))
 
 (define stage_id_in_list? (lambda (ids stage_id)
 	(reduce (coalesceNil ids '()) (lambda (found id)
@@ -4779,27 +4762,27 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 					(define untouched_stages (filter (qb_stages block) (lambda (stage)
 						(stage_not_in_id_list? candidate_ids stage))))
 					(define merged_stages (map entries (lambda (entry)
-						(rewrite_stage_output_left_join_stage alias_map id_map
+						(rewrite_stage_graph_stage alias_map id_map false
 							(stage_output_left_join_stage_with_aggregates
 								(stage_output_left_join_entry_stage entry)
 								(stage_output_left_join_entry_ags entry))))))
 					(make_query_block
 						(qb_schema block)
 						(merge_unique (list (map (qb_sources block) (lambda (src)
-							(rewrite_stage_output_left_join_source alias_map id_map
+							(rewrite_stage_graph_source alias_map id_map
 								(rewrite_stage_output_left_join_source_columns column_maps src))))))
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_fields block)))
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_where block)))
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_group block)))
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_having block)))
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_order block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_fields block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_where block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_group block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_having block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_order block)))
 						(qb_limit block)
 						(qb_offset block)
-						(rewrite_stage_output_left_join_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_hidden block)))
+						(rewrite_stage_graph_expr alias_map id_map (rewrite_stage_output_left_join_columns column_maps (qb_hidden block)))
 						(merge_unique (list
-							(map untouched_stages (lambda (stage) (rewrite_stage_output_left_join_stage '() id_map stage)))
+							(map untouched_stages (lambda (stage) (rewrite_stage_graph_stage '() id_map false stage)))
 							merged_stages))
-						(rewrite_stage_output_left_join_expr alias_map id_map (qb_facts block)))))))))
+						(rewrite_stage_graph_expr alias_map id_map (qb_facts block)))))))))
 
 (define merge_compatible_stage_output_left_joins_node (lambda (node)
 	(if (query_block? node)

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -504,6 +504,30 @@ test_cases:
           "ok"
           (error "derived aggregate rebinding kept a stale column handle")))
 
+  - name: "stage graph rewrite separates root identity from internal references"
+    scm: |
+      (begin
+        (define y66_graph_stage (make_group_stage
+          "root-old"
+          (list "probe" "memcp-tests" (make_stage_output_relation "dep-old") false nil)
+          '() '(1) '() nil '() '() nil nil '()))
+        (define y66_graph_id_map (list
+          (list "root-old" "root-new")
+          (list "dep-old" "dep-new")))
+        (define y66_graph_preserved
+          (rewrite_stage_graph_stage '() y66_graph_id_map false y66_graph_stage))
+        (define y66_graph_rebound
+          (rewrite_stage_graph_stage '() y66_graph_id_map true y66_graph_stage))
+        (if (and
+          (equal? (gs_id y66_graph_preserved) "root-old")
+          (equal? (stage_output_relation_id
+            (source_relation (gs_input y66_graph_preserved))) "dep-new")
+          (equal? (gs_id y66_graph_rebound) "root-new")
+          (equal? (stage_output_relation_id
+            (source_relation (gs_input y66_graph_rebound))) "dep-new"))
+          "ok"
+          (error "stage graph rewrite mixed root identity with reference rebinding")))
+
   - name: "Repeated global EXISTS in derived wrapper stays scalar"
     sql: |
       SELECT t.* FROM (


### PR DESCRIPTION
## Summary

- replace the derived-stage and LEFT-JOIN stage rewriters with one recursive stage-graph rewrite API
- make root-ID rebinding explicit through the `rebind_id` parameter
- always rebind nested stage descriptors, dependency catalogs, expressions, sources, aliases, aggregate handles, and stage-output references through the same walker
- remove the probe-only forwarding helpers and duplicated group-stage reconstruction
- add a direct regression for preserved merge roots versus rebound derived roots

## Why these fixes are independent

Each of the three preceding fixes was removed independently from current master while its regression remained:

| Removed fix | Result |
| --- | --- |
| #363 list ownership | Scheme optimizer 852/853; LEFT JOIN projection 60/61 and labels become NULL |
| #364 nested stage rebinding | derived/scalar suite 20/21; dependent aggregate handle remains stale |
| #365 physical predicate order | derived/scalar suite 20/21; scalar probe precedes the selective equality |

The three changes therefore protect separate invariants. This PR only consolidates the overlapping stage-rewrite implementation introduced around #364.

## A/B measurement

The same 28.5 KiB production-derived query and preserved data directory were used for current master and this branch.

| Metric | Master | PR |
| --- | ---: | ---: |
| cold request | 2.15 s | 2.09 s |
| warm minimum, 10 runs | 1.04 s | 1.04 s |
| warm median, 10 runs | 1.12 s | 1.11 s |
| warm mean, 10 runs | 1.116 s | 1.144 s |
| warm maximum, 10 runs | 1.22 s | 1.31 s |
| EXPLAIN response bytes | 211,363 | 211,363 |
| EXPLAIN SHA-256 | `e4cca1578a67de2889f6ec454c27abb74184d9776e9f30723c5a45596f153998` | identical |

The refactor is performance-neutral and produces byte-identical physical plans.

## Verification

- `tests/66_derived_table_limit_scalar.yaml`: 22/22
- `tests/41_in_subquery.yaml`: 61/61
- `tests/66_left_join_correlated_on.yaml`: 5/5
- `tests/76_range_scan_coverage.yaml`: 75/75
- full parallel `git-pre-commit`: all tests passed
- Scheme formatter and check run; only the existing negative-depth warnings remain
- `git diff --check`

The first full-hook attempt hit the existing cold compile-time gate in `tests/89_indexed_column_resolution.yaml` once at 35.4 ms versus 28 ms. Repeated isolated starts failed 3/5 on unchanged master and 1/5 on this branch. No threshold, timeout, or parallelism setting was changed; the complete hook was rerun unchanged and passed.