### PR TITLE
Fix stale single-aggregate stage output columns

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4284,15 +4284,82 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 				(union_facts block))
 			(merge_unique (map branch_results (lambda (item) (nth item 1))))))))
 
+/* Aggregate column names are derived from their expressions. A decorrelation
+rewrite may therefore rename a single-column stage output after a consumer was
+created. Canonicalize that unambiguous interface before physical lowering. */
+(define stage_output_stage_index (lambda (stages)
+	(reduce (coalesceNil stages '()) (lambda (index stage)
+		(if (group_stage? stage) (set_assoc index (gs_id stage) stage) index)) '())))
+
+(define stage_output_single_aggregate_columns (lambda (stage_index sources)
+	(filter (map (coalesceNil sources '()) (lambda (src)
+		(begin
+			(define relation (source_relation src))
+			(define stage (if (stage_output_relation? relation)
+				(get_assoc stage_index (stage_output_relation_id relation))
+				nil))
+			(if (and (group_stage? stage) (equal? (count (gs_aggregates stage)) 1))
+				(list (source_alias src) (quote aggregate-column)
+					(aggregate_col_name (car (gs_aggregates stage))))
+				nil))))
+		(lambda (entry) (not (nil? entry))))))
+
+(define aggregate_column_name? (lambda (col)
+	(and (string? col) (and (>= (strlen col) 4) (equal? (substr col 0 4) "agg_")))))
+
+(define canonicalize_stage_output_stage (lambda (stage_index stage)
+	(if (not (group_stage? stage))
+		stage
+		(begin
+			(define input (gs_input stage))
+			(define sources (if (query_block? input) (qb_sources input) (list input)))
+			(rewrite_stage_graph_stage
+				(stage_output_single_aggregate_columns stage_index sources)
+				'() false stage)))))
+
+(define canonicalize_stage_output_stages_acc (lambda (remaining rewritten stage_index)
+	(match (coalesceNil remaining '())
+		(cons stage rest) (begin
+			(define canonical (canonicalize_stage_output_stage stage_index stage))
+			(canonicalize_stage_output_stages_acc rest
+				(merge rewritten (list canonical))
+				(if (group_stage? canonical)
+					(set_assoc stage_index (gs_id canonical) canonical)
+					stage_index)))
+		_ (list rewritten stage_index))))
+
+(define canonicalize_stage_output_stages (lambda (stages)
+	(nth (canonicalize_stage_output_stages_acc
+		stages '() (stage_output_stage_index stages)) 0)))
+
+(define canonicalize_stage_output_interfaces (lambda (ir)
+	(begin
+		(define root (ir_root ir))
+		(if (not (query_block? root))
+			ir
+			(begin
+				(define canonical (canonicalize_stage_output_stages_acc
+					(qb_stages root) '() (stage_output_stage_index (qb_stages root))))
+				(define stages (nth canonical 0))
+				(define block_with_stages (make_query_block
+					(qb_schema root) (qb_sources root) (qb_fields root) (qb_where root)
+					(qb_group root) (qb_having root) (qb_order root) (qb_limit root)
+					(qb_offset root) (qb_hidden root) stages (qb_facts root)))
+				(define block (rewrite_stage_graph_expr
+					(stage_output_single_aggregate_columns (nth canonical 1) (qb_sources root))
+					'() block_with_stages))
+				(make_ir (ir_kind ir) block stages (ir_context_of ir) (ir_return ir)))))))
+
 (define normalize_stage_dependencies (lambda (ir)
 	(begin
 		(define root_result (normalize_stage_dependencies_node (ir_root ir)))
-		(merge_compatible_stage_output_left_joins_ir (make_ir
+		(canonicalize_stage_output_interfaces
+			(merge_compatible_stage_output_left_joins_ir (make_ir
 			(ir_kind ir)
 			(nth root_result 0)
 			(if (query_block? (nth root_result 0)) (qb_stages (nth root_result 0)) (nth root_result 1))
 			(ir_context_of ir)
-			(ir_return ir))))))
+			(ir_return ir)))))))
 
 /* Scalar stages are merged after decorrelation. Build their signatures bottom-up
 so generated aliases and dependency IDs do not hide equivalent stage graphs. */
@@ -4656,6 +4723,10 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				(if (not (nil? found))
 					found
 					(match entry
+						'(entry_alias (symbol aggregate-column) replacement)
+						(if (and (equal? entry_alias alias) (aggregate_column_name? col))
+							replacement
+							nil)
 						'(entry_alias entry_col replacement)
 						(if (and (equal? entry_alias alias) (equal? entry_col col))
 							replacement

--- a/tests/66_derived_table_limit_scalar.yaml
+++ b/tests/66_derived_table_limit_scalar.yaml
@@ -528,6 +528,64 @@ test_cases:
           "ok"
           (error "stage graph rewrite mixed root identity with reference rebinding")))
 
+  - name: "Single aggregate stage output uses its canonical column"
+    scm: |
+      (begin
+        (define y66_interface_ag (list true (quote max) false))
+        (define y66_interface_target (make_group_stage
+          "interface-target"
+          (list "target-row" "memcp-tests" "dtl_join_ref" false nil)
+          '() '(1) (list y66_interface_ag) nil '() '() nil nil '()))
+        (define y66_interface_consumer_ag (list
+          (list (quote get_column) "target-output" false "agg_stale" false)
+          (quote max)
+          false))
+        (define y66_interface_consumer (make_group_stage
+          "interface-consumer"
+          (make_query_block
+            "memcp-tests"
+            (list (list "target-output" "memcp-tests"
+              (make_stage_output_relation "interface-target") true true))
+            '() true nil nil nil nil nil '() '() '())
+          '() '(1) (list y66_interface_consumer_ag) nil '() '() nil nil '()))
+        (define y66_interface_stages (canonicalize_stage_output_stages
+          (list y66_interface_target y66_interface_consumer)))
+        (define y66_interface_ref (car (car (gs_aggregates
+          (stage_by_id y66_interface_stages "interface-consumer")))))
+        (if (equal? (nth y66_interface_ref 3)
+          (aggregate_col_name y66_interface_ag))
+          "ok"
+          (error "single aggregate stage output kept a stale column")))
+
+  - name: "Multi aggregate stage output is not guessed"
+    scm: |
+      (begin
+        (define y66_ambiguous_first (list true (quote max) false))
+        (define y66_ambiguous_second (list false (quote min) true))
+        (define y66_ambiguous_target (make_group_stage
+          "ambiguous-target"
+          (list "target-row" "memcp-tests" "dtl_join_ref" false nil)
+          '() '(1) (list y66_ambiguous_first y66_ambiguous_second)
+          nil '() '() nil nil '()))
+        (define y66_ambiguous_consumer (make_group_stage
+          "ambiguous-consumer"
+          (make_query_block
+            "memcp-tests"
+            (list (list "target-output" "memcp-tests"
+              (make_stage_output_relation "ambiguous-target") true true))
+            '() true nil nil nil nil nil '() '() '())
+          '() '(1) (list (list
+            (list (quote get_column) "target-output" false "agg_unknown" false)
+            (quote max)
+            false)) nil '() '() nil nil '()))
+        (define y66_ambiguous_stages (canonicalize_stage_output_stages
+          (list y66_ambiguous_target y66_ambiguous_consumer)))
+        (define y66_ambiguous_ref (car (car (gs_aggregates
+          (stage_by_id y66_ambiguous_stages "ambiguous-consumer")))))
+        (if (equal? (nth y66_ambiguous_ref 3) "agg_unknown")
+          "ok"
+          (error "multi aggregate stage output guessed a column")))
+
   - name: "Repeated global EXISTS in derived wrapper stays scalar"
     sql: |
       SELECT t.* FROM (


### PR DESCRIPTION
## Root cause\n\nDecorrelation can rewrite the expression of a logical single-aggregate stage after a dependent stage-output source has already captured its generated aggregate column name. The physical carrier is then created with the canonical aggregate column while a dependent scan requests the stale name.\n\nThe latest master graph-rebinding refactor covers stage IDs, aliases, and explicit column mappings, but did not canonicalize this derived single-column interface. The same integration query fails on both b9786b9ff and its parent, so this is not introduced by the latest refactor.\n\n## Change\n\n- Build one indexed logical stage catalog after dependency normalization.\n- Express an unambiguous single-aggregate output as a wildcard aggregate-column mapping.\n- Reuse the existing stage graph expression and stage traversal to update dependent logical expressions.\n- Leave multi-aggregate outputs untouched rather than guessing.\n- Keep all canonicalization before physical lowering; no carrier or scan special case is added.\n\nThe pass is linear in stage and expression size: target stages are resolved through a prebuilt ID index.\n\n## Regression tests\n\nAdded anonymized YAML coverage for a dependent stage using a stale generated column from a single-aggregate output and for a multi-aggregate output that must not be rewritten ambiguously.\n\nBase b9786b9ffd9d4f1ba2fdccaa64e7381b498808b1: new invariant suite is red.\nPR branch: tests/66_derived_table_limit_scalar.yaml is 24/24 green.\n\n## Integration A/B\n\nIdentical imported dataset, session values, and complex derived/scalar query:\n\n| Revision | Result | Timing |\n|---|---|---|\n| master b9786b9ff | fails: dependent scan requests a missing aggregate carrier column | 1.08 s to error |\n| PR, cold | correct, 4 rows | 2.12 s |\n| PR, warm run 1 | correct, identical output | 1.14 s |\n| PR, warm run 2 | correct, identical output | 1.15 s |\n\nThe three successful outputs are byte-identical. This is a correctness fix, not a speedup claim.\n\n## Validation\n\n- go build -o memcp\n- tests/66_derived_table_limit_scalar.yaml: 24/24\n- tests/40_exists_subquery.yaml: 22/22\n- full MEMCP_TEST_JOBS=1 ./git-pre-commit: green (All tests passed, commit allowed)\n- git diff --check: clean\n\nNo private query text, schema names, data, logs, or generated artifacts are included.