### PR TITLE
fix: preserve OR range index correctness

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -340,6 +340,20 @@ func widenBounds(a, b boundaries) boundaries {
 			} else if boundaryValueEqual(a[i].upper, cb.upper) {
 				a[i].upperInclusive = a[i].upperInclusive || cb.upperInclusive
 			}
+			// The union of distinct equality points is a range. Keeping the
+			// EqualMatcher here would let adaptive index ordering place this
+			// widened column before real equality columns and make the B-tree
+			// scan treat only the lower point as an exact prefix.
+			if matcherKindEqual(a[i].matcher, EqualMatcher) {
+				samePoint := a[i].lowerBatch && a[i].upperBatch &&
+					a[i].lowerBatchSubidx == a[i].upperBatchSubidx
+				if !a[i].lowerBatch && !a[i].upperBatch {
+					samePoint = boundaryValueEqual(a[i].lower, a[i].upper)
+				}
+				if !samePoint {
+					a[i].matcher = RangeMatcher
+				}
+			}
 			break
 		}
 		if found {

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -75,6 +75,30 @@ func TestBoundaryRange(t *testing.T) {
 	}
 }
 
+func TestWidenDistinctEqualityPointsProducesRange(t *testing.T) {
+	left := boundaries{{
+		col: "actor_id", matcher: EqualMatcher,
+		lower: scm.NewInt(7), lowerInclusive: true,
+		upper: scm.NewInt(7), upperInclusive: true,
+	}}
+	right := boundaries{{
+		col: "actor_id", matcher: EqualMatcher,
+		lower: scm.NewInt(8), lowerInclusive: true,
+		upper: scm.NewInt(8), upperInclusive: true,
+	}}
+
+	got := widenBounds(left, right)
+	if len(got) != 1 {
+		t.Fatalf("expected one widened boundary, got %d", len(got))
+	}
+	if got[0].matcher.Kind() != "range" {
+		t.Fatalf("widened matcher = %q, want range", got[0].matcher.Kind())
+	}
+	if got[0].lower.String() != "7" || got[0].upper.String() != "8" {
+		t.Fatalf("widened bounds = [%v..%v], want [7..8]", got[0].lower, got[0].upper)
+	}
+}
+
 func TestEffectiveBoundaryInclusivenessUsesIndexedRange(t *testing.T) {
 	bounds := boundaries{
 		{col: "discount", matcher: RangeMatcher, lowerInclusive: true, upperInclusive: true},

--- a/tests/66_complex_query_shapes.yaml
+++ b/tests/66_complex_query_shapes.yaml
@@ -1063,8 +1063,6 @@ test_cases:
         - weighted_score: 24
 
   - name: "TPC-H Q7 shape: bidirectional OR join alternatives"
-    noncritical: true
-    fail_comment: "join lowering retains the first bidirectional OR arm but drops the second matching arm"
     sql: |
       SELECT p.owner_id, a.actor_id, COUNT(*) AS pair_count
       FROM cq_parent p
@@ -1074,6 +1072,17 @@ test_cases:
          OR (p.owner_id = 20 AND a.actor_id = 8))
       GROUP BY p.owner_id, a.actor_id
       ORDER BY p.owner_id
+    on_fail:
+      sql: |
+        EXPLAIN IR
+        SELECT p.owner_id, a.actor_id, COUNT(*) AS pair_count
+        FROM cq_parent p
+        JOIN cq_assignment a
+          ON a.tenant_id = p.tenant_id
+         AND ((p.owner_id = 10 AND a.actor_id = 7)
+           OR (p.owner_id = 20 AND a.actor_id = 8))
+        GROUP BY p.owner_id, a.actor_id
+        ORDER BY p.owner_id
     expect:
       rows: 2
       data:

--- a/tests/66_complex_query_shapes.yaml
+++ b/tests/66_complex_query_shapes.yaml
@@ -938,6 +938,446 @@ test_cases:
           empty_sum: null
           display_count: 0
 
+  # These cases use independent synthetic SQL to cover the relational shapes
+  # exercised by TPC-H Q1 through Q22. No benchmark query text or data is
+  # redistributed here.
+  - name: "TPC-H Q1 shape: grouped multi-aggregate projection"
+    sql: |
+      SELECT COALESCE(state, -1) AS state_key,
+        COUNT(*) AS row_count,
+        SUM(score) AS total_score,
+        MIN(score) AS min_score,
+        MAX(score) AS max_score,
+        AVG(score) > 6 AS average_above_six
+      FROM cq_item
+      GROUP BY COALESCE(state, -1)
+      ORDER BY state_key
+    expect:
+      rows: 3
+      data:
+        - state_key: -1
+          row_count: 1
+          total_score: 9
+          min_score: 9
+          max_score: 9
+          average_above_six: true
+        - state_key: 0
+          row_count: 1
+          total_score: 3
+          min_score: 3
+          max_score: 3
+          average_above_six: false
+        - state_key: 1
+          row_count: 3
+          total_score: 20
+          min_score: 5
+          max_score: 8
+          average_above_six: true
+
+  - name: "TPC-H Q2 shape: correlated minimum across a joined domain"
+    sql: |
+      SELECT i.id, r.label
+      FROM cq_item i
+      JOIN cq_ref r ON r.id = i.ref_id
+      WHERE i.score = (
+        SELECT MIN(i2.score)
+        FROM cq_item i2
+        JOIN cq_ref r2 ON r2.id = i2.ref_id
+        WHERE r2.group_id = r.group_id
+      )
+      ORDER BY r.label DESC, i.id
+      LIMIT 3
+    expect:
+      rows: 2
+      data:
+        - id: 21
+          label: "gamma"
+        - id: 11
+          label: "alpha"
+
+  - name: "TPC-H Q3 shape: joined revenue groups with top-k ordering"
+    sql: |
+      SELECT p.id, SUM(i.score) AS revenue
+      FROM cq_parent p
+      JOIN cq_item i ON i.parent_id = p.id
+      WHERE p.tenant_id IS NOT NULL
+      GROUP BY p.id
+      ORDER BY revenue DESC, p.id
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          revenue: 14
+        - id: 4
+          revenue: 8
+
+  - name: "TPC-H Q4 shape: correlated EXISTS followed by grouping"
+    sql: |
+      SELECT p.tenant_id, COUNT(*) AS parent_count
+      FROM cq_parent p
+      WHERE p.tenant_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM cq_item i
+          JOIN cq_event e ON e.item_id = i.id
+          WHERE i.parent_id = p.id
+        )
+      GROUP BY p.tenant_id
+      ORDER BY p.tenant_id
+    expect:
+      rows: 2
+      data:
+        - tenant_id: 100
+          parent_count: 1
+        - tenant_id: 200
+          parent_count: 1
+
+  - name: "TPC-H Q5 shape: wide join grouped by a dimension"
+    sql: |
+      SELECT r.group_id, SUM(i.score) AS total_score
+      FROM cq_parent p
+      JOIN cq_item i ON i.parent_id = p.id
+      JOIN cq_ref r ON r.id = i.ref_id
+      JOIN cq_assignment a
+        ON a.tenant_id = p.tenant_id AND a.allowed = TRUE
+      GROUP BY r.group_id
+      ORDER BY r.group_id
+    expect:
+      rows: 2
+      data:
+        - group_id: 1
+          total_score: 14
+        - group_id: 2
+          total_score: 7
+
+  - name: "TPC-H Q6 shape: filtered scalar aggregate"
+    sql: |
+      SELECT SUM(score * 2) AS weighted_score
+      FROM cq_item
+      WHERE score BETWEEN 5 AND 7
+        AND state = 1
+    expect:
+      rows: 1
+      data:
+        - weighted_score: 24
+
+  - name: "TPC-H Q7 shape: bidirectional OR join alternatives"
+    noncritical: true
+    fail_comment: "join lowering retains the first bidirectional OR arm but drops the second matching arm"
+    sql: |
+      SELECT p.owner_id, a.actor_id, COUNT(*) AS pair_count
+      FROM cq_parent p
+      JOIN cq_assignment a
+        ON a.tenant_id = p.tenant_id
+       AND ((p.owner_id = 10 AND a.actor_id = 7)
+         OR (p.owner_id = 20 AND a.actor_id = 8))
+      GROUP BY p.owner_id, a.actor_id
+      ORDER BY p.owner_id
+    expect:
+      rows: 2
+      data:
+        - owner_id: 10
+          actor_id: 7
+          pair_count: 2
+        - owner_id: 20
+          actor_id: 8
+          pair_count: 1
+
+  - name: "TPC-H Q8 shape: conditional aggregate share inputs"
+    sql: |
+      SELECT r.group_id,
+        SUM(CASE WHEN i.state = 1 THEN i.score ELSE 0 END) AS selected_score,
+        SUM(i.score) AS total_score
+      FROM cq_item i
+      JOIN cq_ref r ON r.id = i.ref_id
+      WHERE r.group_id IS NOT NULL
+      GROUP BY r.group_id
+      ORDER BY r.group_id
+    expect:
+      rows: 2
+      data:
+        - group_id: 1
+          selected_score: 5
+          total_score: 14
+        - group_id: 2
+          selected_score: 7
+          total_score: 7
+
+  - name: "TPC-H Q9 shape: multi-join profit grouped by two keys"
+    sql: |
+      SELECT r.label, e.sequence_no,
+        SUM(i.score - e.sequence_no) AS profit
+      FROM cq_item i
+      JOIN cq_ref r ON r.id = i.ref_id
+      JOIN cq_event e ON e.item_id = i.id
+      GROUP BY r.label, e.sequence_no
+      ORDER BY r.label, e.sequence_no DESC
+    expect:
+      rows: 5
+      data:
+        - label: "alpha"
+          sequence_no: 2
+          profit: 3
+        - label: "alpha"
+          sequence_no: 1
+          profit: 4
+        - label: "beta"
+          sequence_no: 1
+          profit: 8
+        - label: "delta"
+          sequence_no: 1
+          profit: 2
+        - label: "gamma"
+          sequence_no: 1
+          profit: 6
+
+  - name: "TPC-H Q10 shape: joined detail grouped and ranked by aggregate"
+    sql: |
+      SELECT p.id, p.owner_id, SUM(i.score) AS open_score
+      FROM cq_parent p
+      JOIN cq_item i ON i.parent_id = p.id
+      JOIN cq_event e ON e.item_id = i.id
+      WHERE e.status = 'open'
+      GROUP BY p.id, p.owner_id
+      ORDER BY open_score DESC, p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          owner_id: 10
+          open_score: 14
+        - id: 3
+          owner_id: 30
+          open_score: 3
+
+  - name: "TPC-H Q11 shape: scalar aggregate threshold in HAVING"
+    sql: |
+      SELECT a.tenant_id,
+        SUM(CASE WHEN a.allowed = TRUE THEN 1 ELSE 0 END) AS allowed_count
+      FROM cq_assignment a
+      WHERE a.tenant_id IS NOT NULL
+      GROUP BY a.tenant_id
+      HAVING SUM(CASE WHEN a.allowed = TRUE THEN 1 ELSE 0 END) > (
+        SELECT MIN(i.state)
+        FROM cq_item i
+        WHERE i.state IS NOT NULL
+      )
+      ORDER BY a.tenant_id
+    expect:
+      rows: 2
+      data:
+        - tenant_id: 100
+          allowed_count: 1
+        - tenant_id: 200
+          allowed_count: 1
+
+  - name: "TPC-H Q12 shape: multiple conditional counts in one group"
+    sql: |
+      SELECT i.parent_id,
+        SUM(CASE WHEN e.status = 'open' THEN 1 ELSE 0 END) AS open_count,
+        SUM(CASE WHEN e.status = 'closed' THEN 1 ELSE 0 END) AS closed_count
+      FROM cq_item i
+      JOIN cq_event e ON e.item_id = i.id
+      GROUP BY i.parent_id
+      ORDER BY i.parent_id
+    expect:
+      rows: 3
+      data:
+        - parent_id: 1
+          open_count: 2
+          closed_count: 1
+        - parent_id: 2
+          open_count: 0
+          closed_count: 1
+        - parent_id: 3
+          open_count: 1
+          closed_count: 0
+
+  - name: "TPC-H Q13 shape: distribution over a LEFT JOIN aggregate"
+    sql: |
+      SELECT grouped.child_count, COUNT(*) AS parent_count
+      FROM (
+        SELECT p.id, COUNT(i.id) AS child_count
+        FROM cq_parent p
+        LEFT JOIN cq_item i ON i.parent_id = p.id
+        GROUP BY p.id
+      ) grouped
+      GROUP BY grouped.child_count
+      ORDER BY grouped.child_count
+    expect:
+      rows: 3
+      data:
+        - child_count: 0
+          parent_count: 1
+        - child_count: 1
+          parent_count: 3
+        - child_count: 2
+          parent_count: 1
+
+  - name: "TPC-H Q14 shape: conditional and total aggregates share a scan"
+    sql: |
+      SELECT
+        SUM(CASE WHEN r.label LIKE 'a%' THEN i.score ELSE 0 END) AS selected_score,
+        SUM(i.score) AS total_score
+      FROM cq_item i
+      JOIN cq_ref r ON r.id = i.ref_id
+    expect:
+      rows: 1
+      data:
+        - selected_score: 5
+          total_score: 24
+
+  - name: "TPC-H Q15 shape: maximum over a derived grouped aggregate"
+    sql: |
+      SELECT totals.parent_id, totals.total_score
+      FROM (
+        SELECT i.parent_id, SUM(i.score) AS total_score
+        FROM cq_item i
+        GROUP BY i.parent_id
+      ) totals
+      WHERE totals.total_score = (
+        SELECT MAX(other.total_score)
+        FROM (
+          SELECT i2.parent_id, SUM(i2.score) AS total_score
+          FROM cq_item i2
+          GROUP BY i2.parent_id
+        ) other
+      )
+      ORDER BY totals.parent_id
+    expect:
+      rows: 1
+      data:
+        - parent_id: 1
+          total_score: 14
+
+  - name: "TPC-H Q16 shape: anti-membership with COUNT DISTINCT"
+    sql: |
+      SELECT i.state, COUNT(DISTINCT i.ref_id) AS distinct_refs
+      FROM cq_item i
+      WHERE i.ref_id IS NOT NULL
+        AND i.ref_id NOT IN (
+          SELECT a.ref_id
+          FROM cq_assignment a
+          WHERE a.allowed = FALSE
+        )
+      GROUP BY i.state
+      ORDER BY i.state
+    expect:
+      rows: 2
+      data:
+        - state: 0
+          distinct_refs: 1
+        - state: 1
+          distinct_refs: 2
+
+  - name: "TPC-H Q17 shape: correlated AVG filters an outer aggregate"
+    sql: |
+      SELECT SUM(i.score) AS below_average_score
+      FROM cq_item i
+      WHERE i.score < (
+        SELECT AVG(i2.score)
+        FROM cq_item i2
+        WHERE i2.parent_id = i.parent_id
+      )
+    expect:
+      rows: 1
+      data:
+        - below_average_score: 5
+
+  - name: "TPC-H Q18 shape: grouped IN subquery feeds an outer group"
+    sql: |
+      SELECT p.id, SUM(i.score) AS total_score
+      FROM cq_parent p
+      JOIN cq_item i ON i.parent_id = p.id
+      WHERE p.id IN (
+        SELECT i2.parent_id
+        FROM cq_item i2
+        GROUP BY i2.parent_id
+        HAVING SUM(i2.score) > 10
+      )
+      GROUP BY p.id
+      ORDER BY p.id
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          total_score: 14
+
+  - name: "TPC-H Q19 shape: disjoint OR branches contribute once"
+    sql: |
+      SELECT SUM(score) AS selected_score
+      FROM cq_item
+      WHERE (state = 1 AND score BETWEEN 5 AND 6)
+         OR (state = 0 AND score BETWEEN 3 AND 4)
+         OR (state IS NULL AND score BETWEEN 9 AND 10)
+    expect:
+      rows: 1
+      data:
+        - selected_score: 17
+
+  - name: "TPC-H Q20 shape: grouped IN candidates plus correlated EXISTS"
+    sql: |
+      SELECT r.id, r.label
+      FROM cq_ref r
+      WHERE r.id IN (
+        SELECT i.ref_id
+        FROM cq_item i
+        WHERE i.ref_id IS NOT NULL
+        GROUP BY i.ref_id
+        HAVING SUM(i.score) >= 7
+      )
+        AND EXISTS (
+          SELECT 1
+          FROM cq_assignment a
+          WHERE a.ref_id = r.id
+        )
+      ORDER BY r.id
+    expect:
+      rows: 2
+      data:
+        - id: 1001
+          label: "beta"
+        - id: 2000
+          label: "gamma"
+
+  - name: "TPC-H Q21 shape: EXISTS and NOT EXISTS share a child domain"
+    sql: |
+      SELECT i.id
+      FROM cq_item i
+      WHERE EXISTS (
+        SELECT 1 FROM cq_event e
+        WHERE e.item_id = i.id AND e.status = 'closed'
+      )
+        AND NOT EXISTS (
+          SELECT 1 FROM cq_event e
+          WHERE e.item_id = i.id AND e.status = 'open'
+        )
+      ORDER BY i.id
+    expect:
+      rows: 1
+      data:
+        - id: 21
+
+  - name: "TPC-H Q22 shape: string prefix group with scalar AVG and anti-join"
+    sql: |
+      SELECT SUBSTRING(r.label, 1, 1) AS label_prefix,
+        COUNT(*) AS ref_count
+      FROM cq_ref r
+      WHERE LENGTH(r.label) > (
+        SELECT AVG(LENGTH(r2.label)) FROM cq_ref r2
+      )
+        AND NOT EXISTS (
+          SELECT 1 FROM cq_assignment a WHERE a.ref_id = r.id
+        )
+      GROUP BY SUBSTRING(r.label, 1, 1)
+      ORDER BY label_prefix
+    expect:
+      rows: 1
+      data:
+        - label_prefix: "d"
+          ref_count: 1
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS cq_event"
   - sql: "DROP TABLE IF EXISTS cq_assignment"

--- a/tests/66_complex_query_shapes.yaml
+++ b/tests/66_complex_query_shapes.yaml
@@ -1,0 +1,946 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Correctness matrix for deeply composed query shapes"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS cq_event"
+  - sql: "DROP TABLE IF EXISTS cq_assignment"
+  - sql: "DROP TABLE IF EXISTS cq_item"
+  - sql: "DROP TABLE IF EXISTS cq_parent"
+  - sql: "DROP TABLE IF EXISTS cq_ref"
+  - sql: |
+      CREATE TABLE cq_parent (
+        id INT PRIMARY KEY,
+        owner_id INT,
+        tenant_id INT,
+        ref_id INT
+      )
+  - sql: |
+      CREATE TABLE cq_item (
+        id INT PRIMARY KEY,
+        parent_id INT,
+        ref_id INT,
+        score INT,
+        state INT
+      )
+  - sql: |
+      CREATE TABLE cq_ref (
+        id INT PRIMARY KEY,
+        group_id INT,
+        label VARCHAR(32)
+      )
+  - sql: |
+      CREATE TABLE cq_assignment (
+        id INT PRIMARY KEY,
+        actor_id INT,
+        tenant_id INT,
+        ref_id INT,
+        allowed BOOL
+      )
+  - sql: |
+      CREATE TABLE cq_event (
+        id INT PRIMARY KEY,
+        item_id INT,
+        status VARCHAR(16),
+        sequence_no INT
+      )
+  - sql: |
+      INSERT INTO cq_parent (id, owner_id, tenant_id, ref_id) VALUES
+        (1, 10, 100, 1000),
+        (2, 20, 200, 2000),
+        (3, 30, NULL, 3000),
+        (4, 40, 100, NULL),
+        (5, 50, 300, 5000)
+  - sql: |
+      INSERT INTO cq_item (id, parent_id, ref_id, score, state) VALUES
+        (11, 1, 1000, 5, 1),
+        (12, 1, 1001, 9, NULL),
+        (21, 2, 2000, 7, 1),
+        (31, 3, 3000, 3, 0),
+        (41, 4, NULL, 8, 1)
+  - sql: |
+      INSERT INTO cq_ref (id, group_id, label) VALUES
+        (1000, 1, 'alpha'),
+        (1001, 1, 'beta'),
+        (2000, 2, 'gamma'),
+        (3000, NULL, 'delta')
+  - sql: |
+      INSERT INTO cq_assignment (id, actor_id, tenant_id, ref_id, allowed) VALUES
+        (1, 7, 100, 1000, TRUE),
+        (2, 7, 100, 1001, FALSE),
+        (3, 8, 200, 2000, TRUE),
+        (4, 7, NULL, NULL, TRUE),
+        (5, 9, 300, NULL, NULL)
+  - sql: |
+      INSERT INTO cq_event (id, item_id, status, sequence_no) VALUES
+        (1, 11, 'open', 1),
+        (2, 11, 'closed', 2),
+        (3, 12, 'open', 1),
+        (4, 21, 'closed', 1),
+        (5, 31, 'open', 1)
+
+test_cases:
+  - name: "Correlated ACL alternatives combine owner and assignment EXISTS"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE p.owner_id = 10
+         OR EXISTS (
+           SELECT 1 FROM cq_assignment a
+           WHERE a.actor_id = 7
+             AND a.tenant_id = p.tenant_id
+             AND a.allowed = TRUE
+         )
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+        - id: 4
+
+  - name: "Repeated correlated EXISTS agrees in WHERE and projection"
+    noncritical: true
+    fail_comment: "the projected use is rebound to a false/stale stage output although the identical WHERE use matched"
+    sql: |
+      SELECT p.id,
+        EXISTS (
+          SELECT 1 FROM cq_assignment a
+          WHERE a.actor_id = 7
+            AND a.tenant_id = p.tenant_id
+            AND a.allowed = TRUE
+        ) AS visible
+      FROM cq_parent p
+      WHERE EXISTS (
+        SELECT 1 FROM cq_assignment a
+        WHERE a.actor_id = 7
+          AND a.tenant_id = p.tenant_id
+          AND a.allowed = TRUE
+      )
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          visible: true
+        - id: 4
+          visible: true
+
+  - name: "Global EXISTS is combined with correlated EXISTS"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE EXISTS (
+        SELECT 1 FROM cq_assignment a
+        WHERE a.actor_id = 7 AND a.tenant_id IS NULL
+      )
+        AND EXISTS (
+          SELECT 1 FROM cq_item i
+          WHERE i.parent_id = p.id AND i.score >= 8
+        )
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+        - id: 4
+
+  - name: "Depth three scalar EXISTS references outermost scope"
+    noncritical: true
+    fail_comment: "skip-level correlation loses the outer domain while lowering nested scalar stages"
+    sql: |
+      SELECT p.id,
+        (SELECT
+          (SELECT EXISTS (
+             SELECT 1 FROM cq_assignment a
+             WHERE a.actor_id = 7
+               AND a.tenant_id = p.tenant_id
+               AND a.ref_id = i.ref_id
+               AND a.allowed = TRUE
+           )
+           FROM cq_ref r
+           WHERE r.id = i.ref_id
+           LIMIT 1)
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.score DESC
+         LIMIT 1) AS permitted
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          permitted: false
+        - id: 2
+          permitted: false
+        - id: 3
+          permitted: false
+        - id: 4
+          permitted: null
+        - id: 5
+          permitted: null
+
+  - name: "Depth four nested EXISTS filters a scalar chain"
+    sql: |
+      SELECT p.id,
+        (SELECT
+          (SELECT
+            (SELECT r.label
+             FROM cq_ref r
+             WHERE r.id = i.ref_id
+               AND EXISTS (
+                 SELECT 1 FROM cq_assignment a
+                 WHERE a.actor_id = 7
+                   AND a.ref_id = r.id
+                   AND a.allowed = TRUE
+               )
+             LIMIT 1)
+           FROM cq_event e
+           WHERE e.item_id = i.id
+           LIMIT 1)
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.id
+         LIMIT 1) AS permitted_label
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          permitted_label: "alpha"
+        - id: 2
+          permitted_label: null
+        - id: 3
+          permitted_label: null
+        - id: 4
+          permitted_label: null
+        - id: 5
+          permitted_label: null
+
+  - name: "Projected EXISTS returns false for an empty correlated domain"
+    sql: |
+      SELECT p.id,
+        EXISTS (
+          SELECT 1 FROM cq_item i
+          WHERE i.parent_id = p.id AND i.score > 100
+        ) AS has_large_item
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          has_large_item: false
+        - id: 2
+          has_large_item: false
+        - id: 3
+          has_large_item: false
+        - id: 4
+          has_large_item: false
+        - id: 5
+          has_large_item: false
+
+  - name: "Projected EXISTS keeps false through two scalar levels"
+    noncritical: true
+    fail_comment: "the presence result is lost while it crosses two scalar stage boundaries"
+    sql: |
+      SELECT p.id,
+        (SELECT
+          (SELECT EXISTS (
+             SELECT 1 FROM cq_event e
+             WHERE e.item_id = i.id AND e.status = 'missing'
+           )
+           FROM cq_ref r
+           WHERE r.id = i.ref_id
+           LIMIT 1)
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.id
+         LIMIT 1) AS has_missing_event
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          has_missing_event: false
+        - id: 2
+          has_missing_event: false
+        - id: 3
+          has_missing_event: false
+        - id: 4
+          has_missing_event: null
+        - id: 5
+          has_missing_event: null
+
+  - name: "Nested NOT EXISTS keeps outer correlation"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE EXISTS (
+        SELECT 1 FROM cq_item i
+        WHERE i.parent_id = p.id
+          AND NOT EXISTS (
+            SELECT 1 FROM cq_event e
+            WHERE e.item_id = i.id AND e.status = 'open'
+          )
+      )
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 2
+        - id: 4
+
+  - name: "IN over UNION combines two candidate branches"
+    noncritical: true
+    fail_comment: "membership lowering rejects a UNION branch that already contains a decorrelated EXISTS stage"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE p.id IN (
+        SELECT i.parent_id FROM cq_item i WHERE i.score >= 8
+        UNION
+        SELECT i.parent_id FROM cq_item i
+        WHERE EXISTS (
+          SELECT 1 FROM cq_event e
+          WHERE e.item_id = i.id AND e.status = 'closed'
+        )
+      )
+      ORDER BY p.id
+    expect:
+      rows: 3
+      data:
+        - id: 1
+        - id: 2
+        - id: 4
+
+  - name: "Correlated IN over UNION references the outer row in both branches"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE p.ref_id IN (
+        SELECT i.ref_id FROM cq_item i
+        WHERE i.parent_id = p.id AND i.state = 1
+        UNION
+        SELECT a.ref_id FROM cq_assignment a
+        WHERE a.tenant_id = p.tenant_id AND a.allowed = TRUE
+      )
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+        - id: 2
+
+  - name: "NOT IN with an empty correlated input is true"
+    noncritical: true
+    fail_comment: "a NULL probe against an empty subquery is TRUE, but the outer row is currently discarded"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE p.ref_id NOT IN (
+        SELECT i.ref_id FROM cq_item i
+        WHERE i.parent_id = p.id AND i.score > 100
+      )
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+        - id: 2
+        - id: 3
+        - id: 4
+        - id: 5
+
+  - name: "NOT IN with a NULL candidate remains unknown"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE p.ref_id NOT IN (
+        SELECT i.ref_id FROM cq_item i
+        WHERE i.parent_id = 4
+      )
+      ORDER BY p.id
+    expect:
+      rows: 0
+
+  - name: "Deep NOT IN skips scopes and preserves NULL semantics"
+    noncritical: true
+    fail_comment: "deep anti-membership loses its outer correlation and returns NULL for every scalar domain"
+    sql: |
+      SELECT p.id,
+        (SELECT
+          (SELECT r.label
+           FROM cq_ref r
+           WHERE r.id = i.ref_id
+             AND r.id NOT IN (
+               SELECT a.ref_id FROM cq_assignment a
+               WHERE a.actor_id = p.owner_id
+             )
+           LIMIT 1)
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.id
+         LIMIT 1) AS unassigned_label
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          unassigned_label: "alpha"
+        - id: 2
+          unassigned_label: "gamma"
+        - id: 3
+          unassigned_label: "delta"
+        - id: 4
+          unassigned_label: null
+        - id: 5
+          unassigned_label: null
+
+  - name: "Correlated scalar ORDER BY LIMIT chooses the top item"
+    sql: |
+      SELECT p.id,
+        (SELECT i.id
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.score DESC, i.id ASC
+         LIMIT 1) AS top_item
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          top_item: 12
+        - id: 2
+          top_item: 21
+        - id: 3
+          top_item: 31
+        - id: 4
+          top_item: 41
+        - id: 5
+          top_item: null
+
+  - name: "Correlated scalar OFFSET chooses the second item"
+    sql: |
+      SELECT p.id,
+        (SELECT i.id
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.score DESC, i.id ASC
+         LIMIT 1 OFFSET 1) AS second_item
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          second_item: 11
+        - id: 2
+          second_item: null
+        - id: 3
+          second_item: null
+        - id: 4
+          second_item: null
+        - id: 5
+          second_item: null
+
+  - name: "Correlated COUNT returns zero for a missing domain"
+    sql: |
+      SELECT p.id,
+        (SELECT COUNT(*) FROM cq_item i WHERE i.parent_id = p.id) AS item_count
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          item_count: 2
+        - id: 2
+          item_count: 1
+        - id: 3
+          item_count: 1
+        - id: 4
+          item_count: 1
+        - id: 5
+          item_count: 0
+
+  - name: "Correlated SUM returns NULL for a missing domain"
+    sql: |
+      SELECT p.id,
+        (SELECT SUM(i.score) FROM cq_item i WHERE i.parent_id = p.id) AS total_score
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          total_score: 14
+        - id: 2
+          total_score: 7
+        - id: 3
+          total_score: 3
+        - id: 4
+          total_score: 8
+        - id: 5
+          total_score: null
+
+  - name: "Equivalent correlated aggregates remain distinct projections"
+    sql: |
+      SELECT p.id,
+        (SELECT COUNT(*) FROM cq_item i WHERE i.parent_id = p.id) AS all_items,
+        (SELECT COUNT(*) FROM cq_item i WHERE i.parent_id = p.id AND i.state = 1) AS active_items,
+        (SELECT MAX(i.score) FROM cq_item i WHERE i.parent_id = p.id) AS max_score
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          all_items: 2
+          active_items: 1
+          max_score: 9
+        - id: 2
+          all_items: 1
+          active_items: 1
+          max_score: 7
+        - id: 3
+          all_items: 1
+          active_items: 0
+          max_score: 3
+        - id: 4
+          all_items: 1
+          active_items: 1
+          max_score: 8
+        - id: 5
+          all_items: 0
+          active_items: 0
+          max_score: null
+
+  - name: "Derived wrapper preserves scalar projections and LEFT JOIN misses"
+    sql: |
+      SELECT d.id, d.ref_label, d.open_events
+      FROM (
+        SELECT p.id,
+          r.label AS ref_label,
+          (SELECT COUNT(*)
+           FROM cq_event e
+           WHERE e.item_id IN (
+             SELECT i.id FROM cq_item i WHERE i.parent_id = p.id
+           ) AND e.status = 'open') AS open_events
+        FROM cq_parent p
+        LEFT JOIN cq_ref r ON r.id = p.ref_id
+      ) d
+      WHERE d.open_events > 0 OR d.ref_label IS NULL
+      ORDER BY d.id
+    expect:
+      rows: 4
+      data:
+        - id: 1
+          ref_label: "alpha"
+          open_events: 2
+        - id: 3
+          ref_label: "delta"
+          open_events: 1
+        - id: 4
+          ref_label: null
+          open_events: 0
+        - id: 5
+          ref_label: null
+          open_events: 0
+
+  - name: "Correlated aggregate HAVING is used as an EXISTS input"
+    noncritical: true
+    fail_comment: "EXISTS decorrelation rejects grouped inner query blocks instead of preserving their HAVING stage"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE EXISTS (
+        SELECT i.parent_id
+        FROM cq_item i
+        WHERE i.parent_id = p.id
+        GROUP BY i.parent_id
+        HAVING COUNT(*) >= 2
+      )
+      ORDER BY p.id
+    expect:
+      rows: 1
+      data:
+        - id: 1
+
+  - name: "LEFT JOIN ON with correlated EXISTS preserves unmatched rows"
+    sql: |
+      SELECT p.id, r.label
+      FROM cq_parent p
+      LEFT JOIN cq_ref r
+        ON r.id = p.ref_id
+       AND EXISTS (
+         SELECT 1 FROM cq_item i
+         WHERE i.parent_id = p.id AND i.ref_id = r.id
+       )
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          label: "alpha"
+        - id: 2
+          label: "gamma"
+        - id: 3
+          label: "delta"
+        - id: 4
+          label: null
+        - id: 5
+          label: null
+
+  - name: "Nested derived aggregate retains outer correlation"
+    sql: |
+      SELECT p.id,
+        (SELECT MAX(x.score)
+         FROM (
+           SELECT i.score, i.parent_id
+           FROM cq_item i
+           WHERE EXISTS (
+             SELECT 1 FROM cq_event e
+             WHERE e.item_id = i.id
+           )
+         ) x
+         WHERE x.parent_id = p.id) AS event_score
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          event_score: 9
+        - id: 2
+          event_score: 7
+        - id: 3
+          event_score: 3
+        - id: 4
+          event_score: null
+        - id: 5
+          event_score: null
+
+  - name: "CASE selects between global and correlated EXISTS"
+    sql: |
+      SELECT p.id,
+        CASE
+          WHEN p.tenant_id IS NULL THEN EXISTS (
+            SELECT 1 FROM cq_assignment a WHERE a.tenant_id IS NULL
+          )
+          ELSE EXISTS (
+            SELECT 1 FROM cq_assignment a
+            WHERE a.tenant_id = p.tenant_id AND a.allowed = TRUE
+          )
+        END AS permitted
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          permitted: true
+        - id: 2
+          permitted: true
+        - id: 3
+          permitted: true
+        - id: 4
+          permitted: true
+        - id: 5
+          permitted: false
+
+  - name: "COALESCE wraps nested scalar aggregate without losing zero"
+    sql: |
+      SELECT p.id,
+        COALESCE((
+          SELECT SUM((
+            SELECT COUNT(*) FROM cq_event e
+            WHERE e.item_id = i.id AND e.status = 'open'
+          ))
+          FROM cq_item i
+          WHERE i.parent_id = p.id
+        ), 0) AS open_count
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          open_count: 2
+        - id: 2
+          open_count: 0
+        - id: 3
+          open_count: 1
+        - id: 4
+          open_count: 0
+        - id: 5
+          open_count: 0
+
+  - name: "Two-column correlation keeps duplicate domains separate"
+    noncritical: true
+    fail_comment: "the aggregate carrier loses nonconstant two-column domain keys"
+    sql: |
+      SELECT p.id,
+        (SELECT COUNT(*)
+         FROM cq_assignment a
+         WHERE a.tenant_id = p.tenant_id
+           AND (a.ref_id = p.ref_id OR a.ref_id IS NULL)) AS grants
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          grants: 1
+        - id: 2
+          grants: 1
+        - id: 3
+          grants: 0
+        - id: 4
+          grants: 0
+        - id: 5
+          grants: 1
+
+  - name: "Outer NULL key does not equal an inner NULL key"
+    sql: |
+      SELECT p.id,
+        EXISTS (
+          SELECT 1 FROM cq_item i WHERE i.ref_id = p.ref_id
+        ) AS has_equal_ref
+      FROM cq_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          has_equal_ref: true
+        - id: 2
+          has_equal_ref: true
+        - id: 3
+          has_equal_ref: true
+        - id: 4
+          has_equal_ref: false
+        - id: 5
+          has_equal_ref: false
+
+  - name: "Nested OR keeps NOT EXISTS and nullable scalar predicates"
+    sql: |
+      SELECT p.id
+      FROM cq_parent p
+      WHERE (
+        NOT EXISTS (
+          SELECT 1 FROM cq_item i WHERE i.parent_id = p.id
+        )
+        OR COALESCE((
+          SELECT MAX(i.state) FROM cq_item i WHERE i.parent_id = p.id
+        ), 0) = 0
+      )
+        AND NOT (p.owner_id = 40)
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 3
+        - id: 5
+
+  - name: "Detail projection combines latest child and nested access checks"
+    sql: |
+      SELECT p.id,
+        r.label AS ref_label,
+        (SELECT i.id
+         FROM cq_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.score DESC, i.id
+         LIMIT 1) AS leading_item,
+        (SELECT e.status
+         FROM cq_event e
+         WHERE e.item_id = (
+           SELECT i.id
+           FROM cq_item i
+           WHERE i.parent_id = p.id
+           ORDER BY i.score DESC, i.id
+           LIMIT 1
+         )
+         ORDER BY e.sequence_no DESC
+         LIMIT 1) AS latest_status,
+        COALESCE((
+          SELECT CASE
+            WHEN source.owner_id = 10 THEN TRUE
+            ELSE EXISTS (
+              SELECT 1
+              FROM cq_assignment a
+              WHERE a.actor_id = 7
+                AND a.tenant_id = source.tenant_id
+                AND a.allowed = TRUE
+            )
+          END
+          FROM cq_parent source
+          WHERE source.id = p.id
+          LIMIT 1
+        ), FALSE) AS can_edit,
+        CASE
+          WHEN EXISTS (
+            SELECT 1
+            FROM cq_assignment a
+            WHERE a.actor_id = 7
+              AND a.tenant_id = p.tenant_id
+              AND a.allowed = TRUE
+          ) THEN 'assigned'
+          ELSE 'none'
+        END AS access_source
+      FROM cq_parent p
+      LEFT JOIN cq_ref r ON r.id = p.ref_id
+      WHERE p.id IN (1, 2)
+      ORDER BY p.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          ref_label: "alpha"
+          leading_item: 12
+          latest_status: "open"
+          can_edit: true
+          access_source: "assigned"
+        - id: 2
+          ref_label: "gamma"
+          leading_item: 21
+          latest_status: "closed"
+          can_edit: false
+          access_source: "none"
+
+  - name: "Data view preserves projected filters through sorter joins and pagination"
+    sql: |
+      SELECT view_rows.id, view_rows.ref_label, view_rows.top_score
+      FROM (
+        SELECT p.id,
+          p.ref_id,
+          r.label AS ref_label,
+          (SELECT MAX(i.score)
+           FROM cq_item i
+           WHERE i.parent_id = p.id) AS top_score,
+          EXISTS (
+            SELECT 1
+            FROM cq_item i
+            WHERE i.parent_id = p.id
+              AND EXISTS (
+                SELECT 1
+                FROM cq_event e
+                WHERE e.item_id = i.id
+                  AND e.status = 'open'
+              )
+          ) AS has_open_event
+        FROM cq_parent p
+        LEFT JOIN cq_ref r ON r.id = p.ref_id
+      ) view_rows
+      LEFT JOIN cq_ref sort_ref ON sort_ref.id = view_rows.ref_id
+      WHERE view_rows.has_open_event = TRUE
+        AND view_rows.top_score IS NOT NULL
+      ORDER BY sort_ref.label ASC, view_rows.top_score DESC, view_rows.id
+      LIMIT 1 OFFSET 1
+    expect:
+      rows: 1
+      data:
+        - id: 3
+          ref_label: "delta"
+          top_score: 3
+
+  - name: "Badge fanout combines independent nested aggregate domains"
+    sql: |
+      SELECT 1 AS marker,
+        (SELECT COUNT(1)
+         FROM cq_parent p
+         WHERE p.owner_id = 10
+            OR EXISTS (
+              SELECT 1
+              FROM cq_assignment a
+              WHERE a.actor_id = 7
+                AND a.tenant_id = p.tenant_id
+                AND a.allowed = TRUE
+            )) AS visible_parents,
+        (SELECT SUM(i.score)
+         FROM cq_item i
+         WHERE i.parent_id IN (
+           SELECT p.id
+           FROM cq_parent p
+           WHERE EXISTS (
+             SELECT 1
+             FROM cq_assignment a
+             WHERE a.actor_id = 7
+               AND a.tenant_id = p.tenant_id
+               AND a.allowed = TRUE
+           )
+         )) AS visible_score,
+        (SELECT COUNT(1)
+         FROM cq_event e
+         WHERE e.item_id IN (
+           SELECT i.id
+           FROM cq_item i
+           WHERE i.parent_id IN (
+             SELECT p.id
+             FROM cq_parent p
+             WHERE EXISTS (
+               SELECT 1
+               FROM cq_assignment a
+               WHERE a.actor_id = 7
+                 AND a.tenant_id = p.tenant_id
+                 AND a.allowed = TRUE
+             )
+           )
+         )) AS visible_events
+    expect:
+      rows: 1
+      data:
+        - marker: 1
+          visible_parents: 2
+          visible_score: 22
+          visible_events: 3
+
+  - name: "Badge count and sum keep distinct empty-domain identities"
+    noncritical: true
+    fail_comment: "the empty SUM carrier currently uses the COUNT identity 0 instead of SQL NULL"
+    sql: |
+      SELECT
+        (SELECT COUNT(1)
+         FROM cq_event e
+         WHERE e.status = 'missing') AS empty_count,
+        (SELECT SUM(1)
+         FROM cq_event e
+         WHERE e.status = 'missing') AS empty_sum,
+        COALESCE((
+          SELECT SUM(1)
+          FROM cq_event e
+          WHERE e.status = 'missing'
+        ), 0) AS display_count
+    expect:
+      rows: 1
+      data:
+        - empty_count: 0
+          empty_sum: null
+          display_count: 0
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS cq_event"
+  - sql: "DROP TABLE IF EXISTS cq_assignment"
+  - sql: "DROP TABLE IF EXISTS cq_item"
+  - sql: "DROP TABLE IF EXISTS cq_parent"
+  - sql: "DROP TABLE IF EXISTS cq_ref"


### PR DESCRIPTION
## Summary
- demote unions of distinct equality boundaries to a range matcher
- keep adaptive composite-index ordering from treating widened OR bounds as exact prefixes
- make the TPC-H Q7-shaped OR join regression critical and add direct analyzer coverage

## Root cause
After an earlier query warmed column-frequency statistics, the Q7-shaped join could order the widened `actor_id = 7 OR actor_id = 8` boundary before the true `tenant_id` equality boundary. The widened boundary still carried an equality matcher, so the composite B-tree scan treated only the lower point as an exact prefix and omitted the actor 8 branch.

## Validation
- `go test ./storage -run 'TestWidenDistinctEqualityPointsProducesRange|TestBoundary|TestEffectiveBoundary'`\n- `python3 run_sql_tests.py tests/66_complex_query_shapes.yaml`\n- reproducer sequence Q5-shaped warm-up -> raw Q7 join -> grouped Q7 join: 3/3 passed\n- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all tests passed\n- coverage `make test`: all correctness suites passed; one unrelated hard timing check in `tests/14_order_limit.yaml` measured 5.94s/5s under coverage, then passed 19/19 without coverage in 2.01s\n\n## Stack\nThis branch is intentionally based on regression PR #369, while this PR targets `master` as requested. Merge #369 first so this PR reduces to the Q7 fix commit.