### PR TITLE
Fix session-dependent grouped membership reuse

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -149,6 +149,35 @@ Session reads used inside dependent helpers are treated like outer dependencies
 when they affect semantics. Pull their values into the helper domain/key
 context and join back with null-safe equality when needed.
 
+The internal transaction session `__memcp_tx` identifies execution state, not
+SQL input, and must not become a semantic domain key. All other session reads
+that can change a helper result are external dependencies, including values
+used below grouped or derived query blocks.
+
+## Predicate and Rewrite Closure
+
+Planner rewrites must preserve the complete predicate. A rule may split a
+top-level AND into independently placeable terms, but selecting one useful term
+does not permit the remaining terms to be dropped. Terms that cannot move must
+remain as residual predicates at a semantically valid level.
+
+When a rewrite removes or replaces a stage-output source, it must rewrite every
+consumer of that source consistently: source joins, WHERE, projections, GROUP
+BY, HAVING, ORDER BY, and hidden fields. Driver/domain keys must be selected
+from the rewritten source set, after inherited scalar probes and correlation
+bindings have been resolved. Choosing a key from the pre-rewrite source set can
+leave free aliases in the physical plan.
+
+Carrier projection is valid only when all semantic inputs are represented:
+
+- every key has a matching projected driver column or an explicit external
+  binding
+- the full local filter remains attached to the carrier build or as a residual
+  predicate
+- session-dependent carriers are query-local and cannot be reused across
+  different session bindings
+- NULL and empty-domain behavior remains that of the logical stage
+
 ## Scalar Cardinality
 
 Scalar cardinality is semantic, not a physical operator.
@@ -323,3 +352,16 @@ It must also preserve architecture and performance:
 Do not weaken tests, mark critical tests noncritical, or replace performance
 guards with shape-only assertions unless the lost protection is restored
 elsewhere.
+
+## Planner Source Layout
+
+Source files should follow the planner phases rather than feature history. A
+future split of `lib/queryplan.scm` should keep one-way dependencies in pipeline
+order: shared logical IR, decorrelation and logical rewrites, reorder/cost facts,
+physical lowering, then parser-facing adapters. Logical modules must not import
+or call physical lowering modules.
+
+Do not combine a large mechanical file move with a semantic planner fix. Move
+stable phase ranges in a dedicated refactoring PR so review can distinguish
+behavior changes from relocation and A/B compile-time measurements remain
+meaningful.

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -657,13 +657,34 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(qualify_unqualified_column_for_sources sources item))))
 		_ expr)))
 
+(define session_dependency_expr? (lambda (expr)
+	(match expr
+		((symbol session) key) (not (equal? key "__memcp_tx"))
+		((quote session) key) (not (equal? key "__memcp_tx"))
+		_ false)))
+
+(define expr_contains_session_dependency? (lambda (expr)
+	(if (session_dependency_expr? expr)
+		true
+		(match expr
+			(cons head tail) (or
+				(expr_contains_session_dependency? head)
+				(reduce tail (lambda (found item)
+					(or found (expr_contains_session_dependency? item)))
+					false))
+			_ false))))
+
 (define exists_correlation_pair (lambda (inner_default inner_sources outer_sources term)
 	(match term
 		((symbol equal??) a b) (begin
 			(define a_inner (expr_refs_sources? inner_default inner_sources a))
 			(define b_inner (expr_refs_sources? inner_default inner_sources b))
-			(define a_outer (and (not a_inner) (expr_refs_sources? nil outer_sources a)))
-			(define b_outer (and (not b_inner) (expr_refs_sources? nil outer_sources b)))
+			(define a_outer (and (not a_inner) (or
+				(expr_refs_sources? nil outer_sources a)
+				(session_dependency_expr? a))))
+			(define b_outer (and (not b_inner) (or
+				(expr_refs_sources? nil outer_sources b)
+				(session_dependency_expr? b))))
 			(if (and a_inner b_outer)
 				(list a (qualify_unqualified_column_for_sources outer_sources b))
 				(if (and b_inner a_outer)
@@ -1126,9 +1147,6 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(or found (expr_refs_one_of_aliases? item aliases)))
 			false)
 		_ false)))
-
-(define source_is_stage_output? (lambda (src)
-	(stage_output_relation? (source_relation src))))
 
 (define query_block_base_aliases (lambda (block)
 	(map
@@ -3999,12 +4017,16 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 				(equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_candidate)))))))
 
 (define exists_recset_stage? (lambda (stage)
-	(and (group_stage? stage)
-		(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists))
-			(and (equal? (qassoc_get (gs_facts stage) (quote presence_only) false) true)
-				(and (single_source? (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
-					(and (single_source? (gs_keys stage))
-						(source_is_base_table? (gs_input stage)))))))))
+	(if (not (group_stage? stage))
+		false
+		(begin
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(and
+				(equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists))
+				(equal? (qassoc_get (gs_facts stage) (quote presence_only) false) true)
+				(not (empty_list? lookup_keys))
+				(equal? (count lookup_keys) (count (gs_keys stage)))
+				(source_is_base_table? (gs_input stage)))))))
 
 (define exists_recset_stage_output_source? (lambda (stages src)
 	(and (stage_output_relation? (source_relation src))
@@ -4149,12 +4171,26 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(cons head tail) (cons head (map tail (lambda (item) (rewrite_exists_recset_probe_refs alias stage probe item))))
 			_ expr))))
 
+(define first_driver_lookup_key (lambda (stage sources)
+	(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (found key)
+		(if (not (nil? found))
+			found
+			(reduce (coalesceNil sources '()) (lambda (resolved src)
+				(if (or (not (nil? resolved)) (nil? (direct_column_name_for_alias src key)))
+					resolved
+					key))
+				nil)))
+		nil)))
+
 (define first_exists_recset_source (lambda (stages sources default_alias condition)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(if (not (nil? found))
 			found
 			(if (and (exists_recset_stage_output_source? stages src)
-				(condition_has_exists_recset_probe? (source_alias src) condition))
+				(and (not (nil? (first_driver_lookup_key
+					(stage_by_id stages (stage_output_relation_id (source_relation src)))
+					(without_source_alias sources (source_alias src)))))
+					(condition_has_exists_recset_probe? (source_alias src) condition)))
 				src
 				nil)))
 		nil)))
@@ -4240,12 +4276,13 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 							(begin
 								(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation exists_src))))
 								(define stage_id (gs_id stage))
-								(define probe (car (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
 								(define probe_sources (list exists_src))
 								(define probe_required (condition_requires_exists_recset_probe?
 									(source_alias exists_src) (qb_where block)))
 								(define rewritten_sources (rewrite_scalar_first_probe_sources_using
 									(qb_stages block) sources probe_sources default_alias))
+								(define driver_sources (without_source_alias rewritten_sources (source_alias exists_src)))
+								(define probe (first_driver_lookup_key stage driver_sources))
 								(define rewrite_consumer (lambda (expr)
 									(if probe_required
 										(rewrite_required_exists_recset_probe_refs (source_alias exists_src) expr)
@@ -4259,7 +4296,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 								(query_block_with_reorder_facts
 									(make_query_block
 										(qb_schema block)
-										(without_source_alias rewritten_sources (source_alias exists_src))
+										driver_sources
 										(rewrite_consumer (qb_fields block))
 										base_where
 										(rewrite_consumer (qb_group block))
@@ -4272,7 +4309,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 										(qb_facts block))
 									(merge (list
 										(query_block_reorder_telemetry block)
-										(list (list (quote exists_plan_strategy) (quote recset_project_join)))))))))
+										(list (list (quote exists_reorder_strategy) (quote project_driver)))))))))
 					(begin
 						(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation candidate))))
 						(define candidate_telemetry (candidate_reorder_telemetry stage sources block))
@@ -6085,6 +6122,64 @@ dependency preparation does not emit free outer-row symbols. */
 			(source_table_expr target_src)
 			(quoted_runtime_list (list target_col))))))
 
+(define exists_recset_projection_parts_acc (lambda (input_src target_src keys lookup_keys source_cols target_cols constant_terms)
+	(match keys
+		(cons inner_expr inner_rest) (match lookup_keys
+			(cons lookup_expr lookup_rest) (begin
+				(define source_col (direct_column_name_for_alias input_src inner_expr))
+				(define target_col (direct_column_name_for_alias target_src lookup_expr))
+				(if (nil? source_col)
+					nil
+					(if (not (nil? target_col))
+						(exists_recset_projection_parts_acc input_src target_src inner_rest lookup_rest
+							(cons source_col source_cols)
+							(cons target_col target_cols)
+							constant_terms)
+						(if (expr_refs_sources? nil (list target_src) lookup_expr)
+							nil
+							(exists_recset_projection_parts_acc input_src target_src inner_rest lookup_rest
+								source_cols target_cols
+								(cons (list (quote equal??) inner_expr lookup_expr) constant_terms))))))
+			_ nil)
+		_ (if (empty_list? lookup_keys)
+			(list (reverse source_cols) (reverse target_cols) (reverse constant_terms))
+			nil))))
+
+(define exists_recset_projection_parts (lambda (stage target_src)
+	(exists_recset_projection_parts_acc
+		(gs_input stage)
+		target_src
+		(gs_keys stage)
+		(qassoc_get (gs_facts stage) (quote lookup-keys) '())
+		'() '() '())))
+
+(define exists_recset_project_join_expr (lambda (target_src stage)
+	(begin
+		(define input_src (gs_input stage))
+		(define parts (exists_recset_projection_parts stage target_src))
+		(if (or (nil? parts) (empty_list? (nth parts 0)))
+			nil
+			(begin
+				(define alias (source_alias input_src))
+				(define condition (combine_where_terms
+					(cons
+						(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+						(nth parts 2))
+					true))
+				(define filtercols (extract_columns_for_alias input_src condition))
+				(list (quote recset_project_join)
+					'(session "__memcp_tx")
+					(list (quote scan_recset)
+						'(session "__memcp_tx")
+						(source_table_expr input_src)
+						(cons (quote list) filtercols)
+						(list (quote lambda)
+							(map filtercols (lambda (col) (symbol (concat alias "." col))))
+							(list (quote optimize) (lower_column_expr_for_alias input_src condition))))
+					(quoted_runtime_list (nth parts 0))
+					(source_table_expr target_src)
+					(quoted_runtime_list (nth parts 1))))))))
+
 (define recset_project_join_expr_for_membership (lambda (src membership)
 	(begin
 		(define stage (nth membership 0))
@@ -6098,26 +6193,28 @@ dependency preparation does not emit free outer-row symbols. */
 					(car projected)
 					(list (quote recset_union) (cons (quote list) projected))))
 			(if (exists_recset_stage? stage)
-				(begin
-					(define source_col (direct_column_name_for_alias input (car (gs_keys stage))))
-					(if (nil? source_col)
-						nil
-						(begin
-							(define alias (source_alias input))
-							(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-							(define filtercols (extract_columns_for_alias input condition))
-							(list (quote recset_project_join)
-								'(session "__memcp_tx")
-								(list (quote scan_recset)
+				(if (> (count (gs_keys stage)) 1)
+					(exists_recset_project_join_expr src stage)
+					(begin
+						(define source_col (direct_column_name_for_alias input (car (gs_keys stage))))
+						(if (nil? source_col)
+							nil
+							(begin
+								(define alias (source_alias input))
+								(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+								(define filtercols (extract_columns_for_alias input condition))
+								(list (quote recset_project_join)
 									'(session "__memcp_tx")
-									(source_table_expr input)
-									(cons (quote list) filtercols)
-									(list (quote lambda)
-										(map filtercols (lambda (col) (symbol (concat alias "." col))))
-										(list (quote optimize) (lower_column_expr_for_alias input condition))))
-								(quoted_runtime_list (list source_col))
-								(source_table_expr src)
-								(quoted_runtime_list (list target_col))))))
+									(list (quote scan_recset)
+										'(session "__memcp_tx")
+										(source_table_expr input)
+										(cons (quote list) filtercols)
+										(list (quote lambda)
+											(map filtercols (lambda (col) (symbol (concat alias "." col))))
+											(list (quote optimize) (lower_column_expr_for_alias input condition))))
+									(quoted_runtime_list (list source_col))
+									(source_table_expr src)
+									(quoted_runtime_list (list target_col)))))))
 				nil)))))
 
 (define lower_scalar_marker_expr (lambda (expr)
@@ -7060,7 +7157,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 			_ false)))
 		true)))
 
-(define build_base_group_scan_assoc_plan (lambda (schema tbl alias keys condition ags)
+(define build_base_group_scan_assoc_plan (lambda (schema tbl alias table_expr keys condition ags)
 	(begin
 		(define src (list alias schema tbl false nil))
 		(define group_key_cols_for_scan (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
@@ -7088,7 +7185,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(list (quote merge_assoc_mut) (quote acc) (quote grouped) merge_payload)))
 		(list (quote scan)
 			'(session "__memcp_tx")
-			(list (quote table) schema tbl)
+			table_expr
 			(cons (quote list) filtercols)
 			(list (quote lambda)
 				(map filtercols (lambda (col) (symbol (concat alias "." col))))
@@ -7133,6 +7230,25 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define limit_expr (coalesceNil limit_value -1))
 		(define normalized_order (coalesceNil order_items '()))
 		(define raw_rows_expr (list (quote assoc_keys_values_as_dataset_rows) (quote grouped) (count key_names)))
+		(define candidate_membership (driver_membership_for_source src condition))
+		(define membership_stage (if (nil? candidate_membership) nil (nth candidate_membership 0)))
+		(define membership (if (and (list? membership_stage)
+			(and (group_stage? membership_stage) (reduce
+				(qassoc_get (gs_facts membership_stage) (quote lookup-keys) '())
+				(lambda (found key) (or found (expr_contains_session_dependency? key)))
+				false)))
+			candidate_membership
+			nil))
+		(define membership_table_expr (if (nil? membership)
+			nil
+			(recset_project_join_expr_for_membership src membership)))
+		(define effective_membership (if (nil? membership_table_expr) nil membership))
+		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		(define membership_var (symbol "__membership_recset"))
+		(define table_expr (if (nil? membership_table_expr)
+			(source_table_expr src)
+			membership_var))
+		(define grouped_scan (build_base_group_scan_assoc_plan schema tbl alias table_expr keys effective_condition ags))
 		(list
 			(list (quote lambda) (list (quote grouped))
 				(if (empty_list? normalized_order)
@@ -7177,7 +7293,11 @@ is still available and remains an ordinary scalar expression through untangle. *
 						nil
 						nil
 						false)))
-			(build_base_group_scan_assoc_plan schema tbl alias keys condition ags)))))
+			(if (nil? membership_table_expr)
+				grouped_scan
+				(list
+					(list (quote lambda) (list membership_var) grouped_scan)
+					membership_table_expr))))))
 
 (define aggregate_payload_merge_expr (lambda (ags idx)
 	(if (>= idx (count ags))
@@ -9085,7 +9205,10 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(begin
 				(define stage_lookup (query_block_stage_lookup block))
 				(define rewritten (query_block_with_scalar_first_probes_using stage_lookup block))
-				(define sources (qb_sources rewritten))
+				(define probe_rewritten (if (expr_contains_session_dependency? (qb_where rewritten))
+					(query_block_with_prepared_sources_using stage_lookup rewritten)
+					rewritten))
+				(define sources (qb_sources probe_rewritten))
 				(define stage_catalog (query_block_stage_catalog rewritten))
 				(define dependency_graph (stage_dependency_graph stage_lookup))
 				(define physical_sources (physicalize_stage_output_sources stage_lookup sources))
@@ -9094,30 +9217,37 @@ is still available and remains an ordinary scalar expression through untangle. *
 					(neumann_fail "build_queryplan" "group-stage source did not lower to a physical driver")
 					true)
 				(define stage_sources (cdr physical_sources))
+				(define direct_probe_group (and
+					(empty_list? stage_sources)
+					(empty_list? (qb_stages probe_rewritten))
+					(source_is_base_table? driver_src)
+					(expr_contains_driver_membership? (qb_where probe_rewritten))))
 				(define final_stage_sources (physicalize_stage_output_sources stage_lookup
 					(filter (cdr sources) (lambda (src)
-						(source_needed_after_group? (source_alias driver_src) rewritten src)))))
+						(source_needed_after_group? (source_alias driver_src) probe_rewritten src)))))
 				(define grouped_input_block (make_query_block
-					(qb_schema rewritten)
+					(qb_schema probe_rewritten)
 					(cons driver_src stage_sources)
-					(qb_fields rewritten)
-					(qb_where rewritten)
-					(qb_group rewritten)
-					(qb_having rewritten)
-					(qb_order rewritten)
-					(qb_limit rewritten)
-					(qb_offset rewritten)
-					(qb_hidden rewritten)
+					(qb_fields probe_rewritten)
+					(qb_where probe_rewritten)
+					(qb_group probe_rewritten)
+					(qb_having probe_rewritten)
+					(qb_order probe_rewritten)
+					(qb_limit probe_rewritten)
+					(qb_offset probe_rewritten)
+					(qb_hidden probe_rewritten)
 					'()
-					(qb_facts rewritten)))
+					(qb_facts probe_rewritten)))
 				(define main_stage (make_group_stage_for_query_block grouped_input_block))
 				(define main_stage_lookup (lowering_catalog_with_local_stages stage_lookup (list main_stage)))
-				(cons (quote !begin)
-					(merge (list
-						(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages rewritten))
-						(lower_stage_materialize_all (qb_stages rewritten))
-						(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage))
-						(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources)))))))))))
+				(if direct_probe_group
+					(lower_query_block_core grouped_input_block)
+					(cons (quote !begin)
+						(merge (list
+							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages rewritten))
+							(lower_stage_materialize_all (qb_stages rewritten))
+							(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage))
+							(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources))))))))))))
 
 (define query_block_without_stages (lambda (block)
 	(make_query_block
@@ -9440,10 +9570,13 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define key_names (group_key_cols keys))
 		(define ags (gs_aggregates stage))
 		(define order_items (coalesceNil (qb_order block) '()))
+		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
 		(and (not (empty_list? (qb_group block)))
 			(and (nil? (qb_having block))
 				(and (or (empty_list? order_items)
-					(and (query_limit_active? (qb_offset block) (qb_limit block))
+					(and (or
+						(query_limit_active? (qb_offset block) (qb_limit block))
+						(expr_contains_session_dependency? condition))
 						(direct_group_order_supported? alias keys key_names ags order_items)))
 					(and (query_block_has_aggregates? block)
 						(not (reduce ags

--- a/tests/performance/session-group-cache.yaml
+++ b/tests/performance/session-group-cache.yaml
@@ -11,6 +11,7 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS sgc_data"
   - sql: "DROP TABLE IF EXISTS sgc_acl"
+  - sql: "DROP TABLE IF EXISTS sgc_range_data"
   - sql: |
       CREATE TABLE sgc_data (
         id INT PRIMARY KEY AUTO_INCREMENT,
@@ -24,6 +25,7 @@ setup:
         usr INT,
         category INT
       )
+  - sql: "CREATE TABLE sgc_range_data (id INT PRIMARY KEY, category INT, val INT)"
   - sql: |
       INSERT INTO sgc_data (category, owner, val) VALUES
         (2, 2, 7), (3, 3, 14), (4, 1, 21), (5, 2, 28), (1, 3, 35),
@@ -35,15 +37,17 @@ setup:
         (1, 1), (1, 2), (1, 3),
         (2, 1), (2, 4),
         (3, 2), (3, 5)
+  - sql: "INSERT INTO sgc_range_data VALUES (1, 1, 60), (2, 1, 90)"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS sgc_data"
   - sql: "DROP TABLE IF EXISTS sgc_acl"
+  - sql: "DROP TABLE IF EXISTS sgc_range_data"
 
 test_cases:
   - name: "set session user"
     session_id: "sgc_sess"
-    sql: "SET @fop_user = 1"
+    sql: "SET @actor_id = 1"
     expect:
       rows_affected: 0
 
@@ -54,7 +58,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @actor_id
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -68,6 +72,24 @@ test_cases:
           cnt: 4
         - category: 3
           cnt: 4
+
+  - name: "session equality is a logical domain key"
+    session_id: "sgc_sess"
+    sql: |
+      EXPLAIN IR SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @actor_id
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      result_contains:
+        - "btw2025_domain"
+        - "btw2025_lookup_keys"
+        - "(condition true) (purpose exists)"
 
   - name: "session-filtered COUNT GROUP BY (warm, must be fast)"
     session_id: "sgc_sess"
@@ -76,7 +98,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @actor_id
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -91,6 +113,26 @@ test_cases:
         - category: 3
           cnt: 4
 
+  - name: "session-dependent grouping projects one membership recset"
+    session_id: "sgc_sess"
+    sql: |
+      EXPLAIN SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @actor_id
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      result_contains:
+        - "scan_recset"
+        - "recset_project_join"
+      result_not_contains:
+        - ".grp:"
+        - "scan_exists"
+
   - name: "session-filtered SUM GROUP BY (warm)"
     session_id: "sgc_sess"
     sql: |
@@ -98,7 +140,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @actor_id
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -108,20 +150,18 @@ test_cases:
 
   - name: "set session user 2"
     session_id: "sgc_sess2"
-    sql: "SET @fop_user = 2"
+    sql: "SET @actor_id = 2"
     expect:
       rows_affected: 0
 
   - name: "different session sees different groups"
-    noncritical: true
-    fail_comment: "the reusable group carrier currently retains results from the previous session binding"
     session_id: "sgc_sess2"
     sql: |
       SELECT category, COUNT(*) AS cnt
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @actor_id
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -134,11 +174,116 @@ test_cases:
         - category: 4
           cnt: 4
 
+  - name: "change the original session binding"
+    session_id: "sgc_sess"
+    sql: "SET @actor_id = 2"
+    expect:
+      rows_affected: 0
+
+  - name: "changed session binding uses its own domain key"
+    session_id: "sgc_sess"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE @actor_id = sgc_acl.usr
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 2
+      data:
+        - category: 1
+          cnt: 4
+        - category: 4
+          cnt: 4
+
+  - name: "restore the original session binding"
+    session_id: "sgc_sess"
+    sql: "SET @actor_id = 1"
+    expect:
+      rows_affected: 0
+
+  - name: "null session binding"
+    session_id: "sgc_sess2"
+    sql: "SET @actor_id = NULL"
+    expect:
+      rows_affected: 0
+
+  - name: "null session binding has no memberships"
+    session_id: "sgc_sess2"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @actor_id
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 0
+
+  - name: "restored session binding reuses the correct carrier slice"
+    session_id: "sgc_sess"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @actor_id
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 3
+      data:
+        - category: 1
+          cnt: 4
+        - category: 2
+          cnt: 4
+        - category: 3
+          cnt: 4
+
   - name: "simple COUNT with session WHERE (warm, must be fast)"
     session_id: "sgc_sess"
     sql: |
       SELECT COUNT(*) AS cnt
       FROM sgc_data
-      WHERE owner = @fop_user
+      WHERE owner = @actor_id
     expect:
       rows: 1
+
+  - name: "set initial range binding"
+    session_id: "sgc_range"
+    sql: "SET @cutoff = 100"
+    expect:
+      rows_affected: 0
+
+  - name: "nested grouped aggregate uses initial range binding"
+    session_id: "sgc_range"
+    sql: >-
+      SELECT (SELECT SUM(cnt) FROM (SELECT category, SUM(1) AS cnt FROM sgc_range_data WHERE val < @cutoff GROUP BY category) grouped_rows LIMIT 1) AS total
+    expect:
+      rows: 1
+      data:
+        - total: 2
+
+  - name: "tighten range binding"
+    session_id: "sgc_range"
+    sql: "SET @cutoff = 85"
+    expect:
+      rows_affected: 0
+
+  - name: "nested grouped aggregate uses changed range binding"
+    session_id: "sgc_range"
+    sql: >-
+      SELECT (SELECT SUM(cnt) FROM (SELECT category, SUM(1) AS cnt FROM sgc_range_data WHERE val < @cutoff GROUP BY category) grouped_rows LIMIT 1) AS total
+    expect:
+      rows: 1
+      data:
+        - total: 1

--- a/tests/planner/aggregates/session-group-reminders.yaml
+++ b/tests/planner/aggregates/session-group-reminders.yaml
@@ -66,7 +66,6 @@ test_cases:
 
   - name: "Reminder badge query with grouped inner aggregate for user 1"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -129,7 +128,6 @@ test_cases:
 
   - name: "Materialized grouped reminder source for user 1"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT *
       FROM (
@@ -179,7 +177,6 @@ test_cases:
           cnt: 1
   - name: "Reminder badge query reflects changed equality session key"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -274,7 +271,6 @@ test_cases:
           cnt: 2
   - name: "Reminder badge query reflects changed range session key"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -311,5 +307,5 @@ test_cases:
       rows: 1
       data:
         - ok: 1
-          grouped_due: 1
+          grouped_due: 2
           reminder_tickets: 1


### PR DESCRIPTION
## Root cause

Session values used by correlated grouped membership predicates were not part of the logical correlation domain. A reusable grouped carrier was keyed only by the driver group, so a warm result from one session binding could be reused under another.

## Change

- Treat every result-affecting session expression except internal `__memcp_tx` as an external logical dependency.
- Preserve those dependencies in stage domain and lookup keys.
- Select driver keys only after inherited scalar probes and sources have been rewritten.
- Rewrite all consumers when removing the decorrelated EXISTS stage.
- Lower multi-key session/driver membership to one query-local `scan_recset` plus `recset_project_join`.
- Keep every local filter term on the RecSet scan; mixed projected/constant lookup keys are supported.
- Aggregate the projected driver candidates directly instead of constructing a persistent `.grp:` carrier.
- Build projection lists linearly with `cons` plus one `reverse`, avoiding repeated immutable-list merges.
- Remove the duplicate `source_is_stage_output?` definition.
- Rename the reorder fact to logical `exists_reorder_strategy=project_driver`; physical carrier selection stays in lowering.

The branch is rebased onto current master and semantically incorporates the grouped-EXISTS and scalar-probe changes from #376 and #378.

## Regression coverage

`tests/performance/session-group-cache.yaml` contains 19 anonymized cases covering logical IR, physical RecSet lowering, reversed equality, changed/NULL session bindings, cross-session isolation, and changed range bindings.

The test-only contents of #373 are folded into this PR. Four grouped reminder cases are now critical, and the corrected final oracle accounts for the preceding visible insert.

## A/B against master 3c8e291b7

Fresh data directories and identically rebuilt non-coverage binaries; five suite executions per side. Warm medians exclude the first cold run.

| Measurement | Master | PR | Delta |
|---|---:|---:|---:|
| Session-group correctness | 16/19 | 19/19 | fixes 3 failures |
| Cold suite | 464 ms | 413 ms | -11% |
| Warm suite median | 273 ms | 179 ms | -35% |
| Unrelated 200k-row ORDER guard | 2.866 s | 2.915 s | +1.7% (noise) |

Master's warm result is also semantically wrong for the changed session. The PR is faster while returning the correct two groups.

## Invariants and planner review

`INVARIANTS.md` now specifies session dependency boundaries, complete-predicate preservation, rewrite closure across all consumers, and carrier projection requirements.

A complete structural pass over `queryplan.scm` found:

- current master: 11,316 lines / 900 top-level definitions; this PR: 11,449 / 905
- natural phase boundaries: shared/logical and decorrelation (~3.7k lines), reorder/cost (~1.4k), physical lowering and adapters (~6.2k)
- no duplicate top-level definitions remain after removing the duplicate helper
- `membership_plan_strategy` remains pre-existing architecture debt: reorder emits a physical strategy consumed by lowering

The file split should be a separate mechanical PR into logical, reorder/cost, and physical/adapters modules. Combining that relocation with this correctness patch would hide semantic changes and destroy useful blame/A/B comparison.

A proposed generic recursive AST predicate walker was measured and discarded: it increased the ORDER suite from about 2 seconds to about 33 seconds and violated hard limits. Specialized walkers remain until traversal can be centralized without higher-order recursion in hot compile paths.

## Validation

- Scheme startup tests: 855/855
- affected suites: session group 19/19, reminders 13/13, scalar aggregates 19/19, deep IN/EXISTS 22/22, IN subquery 61/61, ORDER 19/19
- full `make test`: all functional assertions passed; under concurrent host load, the coverage-instrumented 200k-row ORDER suite alone crossed two 5 s guards
- both failures pass isolated with normal binaries (master 2.866 s, PR 2.915 s)
- `git diff --check`
- Scheme lint reports only the same pre-existing queryplan/parser depth warnings as master
