### PR TITLE
fix: preserve projected EXISTS after RecSet lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4012,12 +4012,23 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(equal? tblvar alias)
 		_ false)))
 
+(define condition_requires_exists_recset_probe? (lambda (alias condition)
+	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
+		(or found (exists_recset_probe_term? alias term))) false)))
+
 (define condition_has_exists_recset_probe? (lambda (alias condition)
 	(match condition
 		(cons head tail) (or
 			(exists_recset_probe_term? alias condition)
 			(reduce tail (lambda (found item) (or found (condition_has_exists_recset_probe? alias item))) false))
 		_ false)))
+
+(define rewrite_required_exists_recset_probe_refs (lambda (alias expr)
+	(if (exists_recset_probe_term? alias expr)
+		true
+		(match expr
+			(cons head tail) (cons head (map tail (lambda (item) (rewrite_required_exists_recset_probe_refs alias item))))
+			_ expr))))
 
 (define rewrite_exists_recset_probe_refs (lambda (alias stage probe expr)
 	(if (exists_recset_probe_term? alias expr)
@@ -4118,6 +4129,16 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 								(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation exists_src))))
 								(define stage_id (gs_id stage))
 								(define probe (car (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
+								(define probe_sources (list exists_src))
+								(define probe_required (condition_requires_exists_recset_probe?
+									(source_alias exists_src) (qb_where block)))
+								(define rewritten_sources (rewrite_scalar_first_probe_sources_using
+									(qb_stages block) sources probe_sources default_alias))
+								(define rewrite_consumer (lambda (expr)
+									(if probe_required
+										(rewrite_required_exists_recset_probe_refs (source_alias exists_src) expr)
+										(rewrite_scalar_first_probe_expr
+											(qb_stages block) probe_sources default_alias expr))))
 								(define base_where (rewrite_exists_recset_probe_refs
 									(source_alias exists_src)
 									stage
@@ -4126,15 +4147,15 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 								(query_block_with_reorder_facts
 									(make_query_block
 										(qb_schema block)
-										(without_source_alias sources (source_alias exists_src))
-										(qb_fields block)
+										(without_source_alias rewritten_sources (source_alias exists_src))
+										(rewrite_consumer (qb_fields block))
 										base_where
-										(qb_group block)
-										(qb_having block)
-										(qb_order block)
+										(rewrite_consumer (qb_group block))
+										(rewrite_consumer (qb_having block))
+										(rewrite_consumer (qb_order block))
 										(qb_limit block)
 										(qb_offset block)
-										(qb_hidden block)
+										(rewrite_consumer (qb_hidden block))
 										(map (candidate_stage_without_source (qb_stages block) stage_id) join_reorder_stage)
 										(qb_facts block))
 									(merge (list

--- a/tests/planner/subqueries/deep-correlation-membership.yaml
+++ b/tests/planner/subqueries/deep-correlation-membership.yaml
@@ -116,8 +116,6 @@ test_cases:
         - id: 4
 
   - name: "Repeated correlated EXISTS agrees in WHERE and projection"
-    noncritical: true
-    fail_comment: "the projected use is rebound to a false/stale stage output although the identical WHERE use matched"
     sql: |
       SELECT p.id,
         EXISTS (
@@ -141,6 +139,60 @@ test_cases:
           visible: true
         - id: 4
           visible: true
+
+  - name: "Projected EXISTS remains false when another OR branch admits the row"
+    sql: |
+      SELECT p.id,
+        EXISTS (
+          SELECT 1 FROM cq_assignment a
+          WHERE a.actor_id = 7
+            AND a.tenant_id = p.tenant_id
+            AND a.allowed = TRUE
+        ) AS visible
+      FROM cq_parent p
+      WHERE p.owner_id = 20
+         OR EXISTS (
+           SELECT 1 FROM cq_assignment a
+           WHERE a.actor_id = 7
+             AND a.tenant_id = p.tenant_id
+             AND a.allowed = TRUE
+         )
+      ORDER BY p.id
+    expect:
+      rows: 3
+      data:
+        - id: 1
+          visible: true
+        - id: 2
+          visible: false
+        - id: 4
+          visible: true
+
+  - name: "Required projected EXISTS reuses its RecSet without a scalar rescan"
+    sql: |
+      EXPLAIN SELECT p.id,
+        EXISTS (
+          SELECT 1 FROM cq_assignment a
+          WHERE a.actor_id = 7
+            AND a.tenant_id = p.tenant_id
+            AND a.allowed = TRUE
+        ) AS visible
+      FROM cq_parent p
+      WHERE EXISTS (
+        SELECT 1 FROM cq_assignment a
+        WHERE a.actor_id = 7
+          AND a.tenant_id = p.tenant_id
+          AND a.allowed = TRUE
+      )
+    expect:
+      contains:
+        - "recset_project_join"
+        - "scan_recset"
+        - "visible"
+      not_contains:
+        - "scan_order"
+        - "scan_exists"
+        - "driver_membership_probe"
 
   - name: "Global EXISTS is combined with correlated EXISTS"
     sql: |


### PR DESCRIPTION
## Summary
- preserve every consumer of an EXISTS stage when RecSet lowering removes its stage-output source
- distinguish required positive top-level AND probes from optional OR/NOT probes
- reuse the RecSet truth directly for required probes, while optional consumers receive an explicit scalar presence probe
- promote the trace-derived repeated-EXISTS regression to a hard test and add OR plus physical-plan coverage

This PR is stacked on #372 so its diff contains only the planner fix. Retarget it to `master` after #372 merges.

## Root cause
Candidate reordering removed the decorrelated EXISTS stage and its stage-output source after rewriting the WHERE expression, but left SELECT/GROUP/HAVING/ORDER/hidden consumers bound to the removed alias. Those reads became NIL/FALSE. Treating every nested occurrence as a required RecSet filter would also be wrong: a row admitted by another OR branch can still have EXISTS=FALSE, and NOT EXISTS still needs its negated presence probe for DML lowering.

## Test-first evidence
Before the fix:
- repeated EXISTS in WHERE and SELECT returned FALSE for both matching rows
- the OR case returned FALSE for all three rows instead of TRUE/FALSE/TRUE

After the fix, both are hard passing tests. The EXPLAIN test also requires `recset_project_join` + `scan_recset` and forbids `scan_order`, `scan_exists`, and `driver_membership_probe` in the required-AND shape. The INSERT SELECT + NOT EXISTS DML regression remains green.

## A/B measurements
80 cold compile samples and 500 warm executions, alternated between binaries on identical fresh data. Times are p50; p95 is included where useful.

| Shape | Metric | master | PR |
|---|---:|---:|---:|
| required AND | plan chars | 903 | 810 |
| required AND | planner | 3.546 ms | 3.924 ms |
| required AND | warm execution | 0.995 ms | 1.001 ms |
| required AND | warm p95 | 1.340 ms | 1.433 ms |
| optional OR, raw broken master | planner | 3.757 ms | 5.540 ms |
| optional OR, raw broken master | warm execution | 1.779 ms | 2.722 ms |
| optional OR, correctness-equivalent master workaround | plan chars | 2022 | 1852 |
| optional OR, correctness-equivalent master workaround | planner | 8.863 ms | 5.552 ms |
| optional OR, correctness-equivalent master workaround | warm execution | 2.760 ms | 2.750 ms |

The raw optional-OR master timings are not a valid speed baseline because master returns the wrong constant FALSE. Against a semantically correct master workaround, the PR compiles 37% faster, produces an 8% smaller plan, and has unchanged warm latency.

## Validation
- Scheme formatter run; it reports only the repository's pre-existing negative-depth warnings
- focused subquery, EXISTS, read-model, and INSERT SELECT/NOT EXISTS suites
- `MEMCP_TEST_JOBS=1 make test`

Full coverage result: SCM 41792/41792 nodes (100.0%), Go statements 69.1%; all hard tests passed.