### PR TITLE
fix: bind inherited scalar probe correlations

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5381,6 +5381,29 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 		(stage_dependency_graph all_stages)
 		entries)))
 
+(define scalar_query_probe_param_index (lambda (lookup_keys params)
+	(reduce (produceN (count lookup_keys)) (lambda (index i)
+		(match (nth lookup_keys i)
+			((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+			(set_assoc index (nth lookup_keys i) (nth params i))
+			((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+			(set_assoc index (nth lookup_keys i) (nth params i))
+			_ index)) '())))
+
+/* A query-probe lambda evaluates its outer lookup keys before entering nested
+stages. Replace inherited direct column references with those parameters so
+dependency preparation does not emit free outer-row symbols. */
+(define rewrite_scalar_query_probe_params (lambda (index expr)
+	(match expr
+		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+		(coalesceNil (get_assoc index expr) expr)
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(rewrite_scalar_query_probe_params index
+			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		(cons head tail) (cons (rewrite_scalar_query_probe_params index head) (map tail (lambda (item)
+			(rewrite_scalar_query_probe_params index item))))
+		_ expr)))
+
 (define scalar_query_probe_recipe_binding (lambda (plan)
 	(match plan
 		'(stage requested_col nested_stages _hoisted_stages prepare_stages) (begin
@@ -5397,11 +5420,18 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(define value_expr (nth (scalar_first_probe_parts ag) 0))
 			(define params (map (produceN (count keys)) (lambda (i)
 				(symbol (concat "__probe_key_" i)))))
+			(define param_index (scalar_query_probe_param_index lookup_keys params))
+			(define bound_stage (rewrite_scalar_query_probe_params param_index stage))
+			(define bound_value_expr (rewrite_scalar_query_probe_params param_index value_expr))
+			(define bound_nested_stages (map nested_stages (lambda (nested_stage)
+				(rewrite_scalar_query_probe_params param_index nested_stage))))
+			(define bound_prepare_stages (map prepare_stages (lambda (prepare_stage)
+				(rewrite_scalar_query_probe_params param_index prepare_stage))))
 			(list
 				(quote define)
 				(symbol (scalar_query_probe_recipe_key stage requested_col))
 				(list (quote lambda) params
-					(lower_scalar_first_query_probe_expr_using stage value_expr keys params nested_stages prepare_stages))))
+					(lower_scalar_first_query_probe_expr_using bound_stage bound_value_expr keys params bound_nested_stages bound_prepare_stages))))
 		_ (neumann_fail "build_queryplan" "malformed scalar query probe recipe plan"))))
 
 (define scalar_query_probe_recipe_bindings (lambda (plans)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -186,6 +186,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			"c"
 			(list (quote and) "d" (list (quote and) "e" "f")))
 		true)) '("a" "b" "c" "d" "e" "f")) true "combine_where_terms flattens nested AND terms")
+	(define probe_outer_column (list (quote get_column) "outer_row" true "id" true))
+	(define probe_param (symbol "__probe_key_0"))
+	(define probe_param_index (scalar_query_probe_param_index (list probe_outer_column) (list probe_param)))
+	(assert (equal?
+		(rewrite_scalar_query_probe_params probe_param_index probe_outer_column)
+		probe_param) true "scalar query probe binds a direct inherited column")
+	(assert (equal?
+		(rewrite_scalar_query_probe_params probe_param_index (list (quote stage-fixture) (list probe_outer_column)))
+		(list (quote stage-fixture) (list probe_param))) true "scalar query probe binds inherited columns throughout stage data")
 	(define canonical_group_sum (list (list (quote get_column) "g" false "amount" false) (quote +) 0))
 	(define canonical_group_count (list 1 (quote +) 0))
 	(define canonical_group_source (list "g" "memcp-tests" "group_values" false nil))

--- a/tests/planner/subqueries/deep-nested-in-exists.yaml
+++ b/tests/planner/subqueries/deep-nested-in-exists.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Deep nested IN / EXISTS / NOT IN at arbitrary depths
 # Reuses the dn_* chain tables from 104 plus adds a tags table for set membership.
 # Tests that IN/EXISTS/NOT IN rewrite candidates (→ COUNT-based Neumann unnesting)
@@ -200,8 +215,6 @@ test_cases:
         - "touch_keytable"
 
   - name: "Depth 3: EXISTS references outermost table (skip 2 levels)"
-    noncritical: true
-    fail_comment: "skip-level EXISTS loses its outermost domain key"
     sql: |
       SELECT a.id,
         (SELECT
@@ -424,8 +437,6 @@ test_cases:
           matched_d: 30
 
   - name: "Mixed depth 3: IN at level 2, scalar at level 3"
-    noncritical: true
-    fail_comment: "mixed IN and scalar stages currently produce an invalid physical value tag"
     sql: |
       SELECT a.id,
         (SELECT
@@ -470,8 +481,6 @@ test_cases:
           non_gamma_label: null
 
   - name: "Mixed depth 4: NOT IN skipping 2 levels to outermost"
-    noncritical: true
-    fail_comment: "skip-level NOT IN currently produces an invalid physical value tag"
     sql: |
       SELECT a.id,
         (SELECT
@@ -537,8 +546,6 @@ test_cases:
         - "exists_probe"
 
   - name: "Depth 3: EXISTS result propagated through 2 scalar levels"
-    noncritical: true
-    fail_comment: "projected EXISTS currently fails across two scalar stage boundaries"
     sql: |
       SELECT a.id,
         (SELECT
@@ -558,8 +565,6 @@ test_cases:
           is_urgent: false
 
   - name: "Depth 4: projected EXISTS propagates false through 3 scalar levels"
-    noncritical: true
-    fail_comment: "projected EXISTS currently fails across three scalar stage boundaries"
     sql: |
       SELECT a.id,
         (SELECT


### PR DESCRIPTION
## Root cause

Scalar query-probe recipes evaluate their outer lookup keys before entering the generated probe lambda. Nested stage closures still retained the original outer `get_column` expressions, however. Physical preparation therefore emitted free outer-row symbols instead of the existing `__probe_key_N` parameters. After the affected carriers had been materialized in the normal suite sequence, skip-level `EXISTS`, `IN`, and `NOT IN` lookups missed their domains and returned `NULL` or invalid results.

## Change

- Build a direct-column-to-probe-parameter index once per scalar query-probe recipe.
- Rewrite the root stage, projected value, nested dependency closure, and prepare stages with that index before physical lowering.
- Traverse each AST once and only hash fixed-size `get_column` nodes; this does not introduce deep pairwise AST comparisons.
- Add Scheme-level coverage for direct and nested stage-data substitution.
- Promote five anonymized depth-three/depth-four SQL shapes from noncritical to hard regressions.

The logical IR and stage topology are unchanged. This is a physical code-generation binding fix.

## A/B against master `b24b1352a`

Correctness uses a fresh server and the complete suite sequence, because isolated queries can pass before the conflicting carriers are reused:

| Suite | master | branch |
|---|---:|---:|
| `deep-nested-in-exists.yaml` | 17/22 | 22/22 |

The five repaired shapes cover skip-level `EXISTS`, mixed nested `IN`, skip-level `NOT IN`, and projected `EXISTS` crossing two and three scalar stages.

Timing used identical fresh in-memory data, alternating master/branch order, 20 `EXPLAIN COMPILE` samples and 200 warm executions per side. Several full hooks were running concurrently on the host, so relative values are more useful than absolute milliseconds.

| Shape | Metric | master p50 / p95 | branch p50 / p95 |
|---|---|---:|---:|
| depth 3 | compile | 24.323 / 28.899 ms | 24.119 / 34.500 ms |
| depth 3 | HTTP compile wall | 48.785 / 58.851 ms | 44.060 / 54.004 ms |
| depth 3 | warm execution | 21.774 / 25.357 ms | 22.336 / 25.369 ms |
| depth 4 | compile | 43.527 / 52.464 ms | 41.602 / 47.118 ms |
| depth 4 | HTTP compile wall | 87.541 / 98.973 ms | 82.720 / 89.582 ms |
| depth 4 | warm execution | 53.023 / 58.106 ms | 53.549 / 58.658 ms |

Plan size is unchanged: depth 3 remains 21,970 bytes / 1,476 nodes; depth 4 remains 47,002 bytes / 3,061 nodes. Warm execution is effectively neutral; compile medians are neutral to modestly faster, with the noisy depth-three p95 called out above.

## Validation

- `python3 run_sql_tests.py tests/planner/subqueries/deep-nested-in-exists.yaml`
- `python3 run_sql_tests.py tests/planner/subqueries/deep-correlation-membership.yaml`
- `python3 tools/lint_scm.py --check` (only pre-existing negative-depth warnings)
- `MEMCP_TEST_JOBS=1 make test`
- `git diff --check`

The complete hook passed with exit code 0.
