### PR TITLE
Fix exact SQL literal arithmetic for TPC-H Q6

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -90,6 +90,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (define psql_mod_expr (lambda (a b) '('mod a b))
 ))
 
+/* SQL numeric literals are exact decimals. Fold literal addition and
+subtraction before the AST loses that distinction to binary float runtime
+arithmetic; leave expressions containing columns or functions untouched. */
+(define psql_add_expr (lambda (a b) (if (and (number? a) (number? b))
+	(sql_add_numeric_literals a b)
+	'((quote +) a b))))
+(define psql_sub_expr (lambda (a b) (if (and (number? a) (number? b))
+	(sql_sub_numeric_literals a b)
+	'((quote -) a b))))
+
 (define psql_type (parser (or
 	(parser '((atom "character" true) (atom "varying" true)) "varying")
 	(parser '((atom "double" true) (atom "precision" true)) "double")
@@ -198,8 +208,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(parser '((define a psql_expression4) "+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_add a n unit))
 		/* date - INTERVAL n UNIT */
 		(parser '((define a psql_expression4) "-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_sub a n unit))
-		(parser '((define a psql_expression4) "+" (define b psql_expression3)) '((quote +) a b))
-		(parser '((define a psql_expression4) "-" (define b psql_expression3)) '((quote -) a b))
+		(parser '((define a psql_expression4) "+" (define b psql_expression3)) (psql_add_expr a b))
+		(parser '((define a psql_expression4) "-" (define b psql_expression3)) (psql_sub_expr a b))
 		psql_expression4
 	)))
 

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -108,6 +108,16 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	)
 ))
 
+/* SQL numeric literals are exact decimals. Fold literal addition and
+subtraction before the AST loses that distinction to binary float runtime
+arithmetic; leave expressions containing columns or functions untouched. */
+(define sql_add_expr (lambda (a b) (if (and (number? a) (number? b))
+	(sql_add_numeric_literals a b)
+	'((quote +) a b))))
+(define sql_sub_expr (lambda (a b) (if (and (number? a) (number? b))
+	(sql_sub_numeric_literals a b)
+	'((quote -) a b))))
+
 /* lightweight literal parser for top-level contexts (before sql_expression is defined) */
 (define sql_literal (parser (or
 	(parser (atom "NULL" true) (sql_null_literal))
@@ -643,8 +653,8 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 		(parser '((define a sql_expression4) "+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_add a n unit))
 		/* date - INTERVAL n UNIT */
 		(parser '((define a sql_expression4) "-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_sub a n unit))
-		(parser '((define a sql_expression4) "+" (define b sql_expression3)) '((quote +) a b))
-		(parser '((define a sql_expression4) "-" (define b sql_expression3)) '((quote -) a b))
+		(parser '((define a sql_expression4) "+" (define b sql_expression3)) (sql_add_expr a b))
+		(parser '((define a sql_expression4) "-" (define b sql_expression3)) (sql_sub_expr a b))
 		sql_expression4
 	)))
 

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -29,8 +29,28 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"math"
+	"math/big"
+	"strconv"
 	"strings"
 )
+
+func sqlLiteralArithmetic(a, b Scmer, subtract bool) Scmer {
+	left, leftOK := new(big.Rat).SetString(strconv.FormatFloat(a.Float(), 'g', -1, 64))
+	right, rightOK := new(big.Rat).SetString(strconv.FormatFloat(b.Float(), 'g', -1, 64))
+	if !leftOK || !rightOK {
+		if subtract {
+			return NewFloat(a.Float() - b.Float())
+		}
+		return NewFloat(a.Float() + b.Float())
+	}
+	if subtract {
+		left.Sub(left, right)
+	} else {
+		left.Add(left, right)
+	}
+	result, _ := left.Float64()
+	return NewFloat(result)
+}
 
 func init_alu() {
 	// string functions
@@ -151,6 +171,36 @@ func init_alu() {
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
+			},
+			Return: &TypeDescriptor{Kind: "number"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_add_numeric_literals",
+		Desc: "adds two SQL numeric literals using their exact decimal spellings",
+		Fn: func(a ...Scmer) Scmer {
+			return sqlLiteralArithmetic(a[0], a[1], false)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "number", ParamName: "a", ParamDesc: "left literal"},
+				{Kind: "number", ParamName: "b", ParamDesc: "right literal"},
+			},
+			Return: &TypeDescriptor{Kind: "number"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_sub_numeric_literals",
+		Desc: "subtracts two SQL numeric literals using their exact decimal spellings",
+		Fn: func(a ...Scmer) Scmer {
+			return sqlLiteralArithmetic(a[0], a[1], true)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "number", ParamName: "a", ParamDesc: "left literal"},
+				{Kind: "number", ParamName: "b", ParamDesc: "right literal"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,

--- a/tests/sql/compatibility/psql-parser.yaml
+++ b/tests/sql/compatibility/psql-parser.yaml
@@ -216,6 +216,20 @@ test_cases:
       data:
         - { matching_rows: 3000 }
 
+  - name: "TPC-H Q6 computed decimal bounds include both endpoints"
+    sql: |
+      SELECT discount, COUNT(*) AS rows_per_discount
+      FROM psql_decimal_range
+      WHERE discount BETWEEN .06 - 0.01 AND .06 + 0.01
+      GROUP BY discount
+      ORDER BY discount
+    expect:
+      rows: 3
+      data:
+        - { discount: 0.05, rows_per_discount: 1000 }
+        - { discount: 0.06, rows_per_discount: 1000 }
+        - { discount: 0.07, rows_per_discount: 1000 }
+
   - name: "TPC-H Q6 combined predicates retain every matching row"
     sql: |
       SELECT COUNT(*) AS matching_rows

--- a/tests/sql/expressions/edge-cases.yaml
+++ b/tests/sql/expressions/edge-cases.yaml
@@ -278,6 +278,15 @@ test_cases:
       data:
         - leading_dot: -0.25
 
+  - name: "Decimal literal addition and subtraction are exact"
+    sql: "SELECT .06 + 0.01 AS upper_bound, .06 - 0.01 AS lower_bound, (.06 + 0.01) = 0.07 AS upper_matches"
+    expect:
+      rows: 1
+      data:
+        - upper_bound: 0.07
+          lower_bound: 0.05
+          upper_matches: true
+
   - name: "Leading dot without fractional digits must fail"
     sql: "SELECT . AS invalid_decimal"
     expect:


### PR DESCRIPTION
## What changed

- fold pure SQL numeric-literal addition and subtraction with exact decimal semantics in both SQL frontends
- leave expressions involving columns or functions on the existing runtime arithmetic path
- add critical MySQL and PostgreSQL regression coverage for computed decimal bounds

## Why

TPC-H Q6 computes its inclusive discount range as decimal literal expressions. Binary floating-point addition produced an upper bound just below 0.07, excluding every row at the upper endpoint and returning a wrong aggregate.

## Impact

TPC-H Q6 now returns 1193053.23 on the local SF 0.01 dataset, matching the PostgreSQL reference at MemCP's declared DECIMAL output scale. No TPC-H queries, data, expected results, or helper scripts are included in this PR.

## Validation

- PostgreSQL parser suite: 51/51 passed
- SQL edge-case suite: 43/43 passed
- real generated TPC-H Q6 on SF 0.01: 1193053.23
- complete pre-commit suite, serialized with MEMCP_TEST_JOBS=1: passed, commit allowed
- coverage-instrumented full suite executed separately; Scheme coverage 100%, Go coverage 69.2%. Its hard order-limit timing guard is not meaningful under atomic coverage instrumentation and reproduces on clean master; the normal master and branch binaries pass that suite.
