### PR TITLE
Reuse query-local scalar probe results

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5400,8 +5400,9 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 			(list
 				(quote define)
 				(symbol (scalar_query_probe_recipe_key stage requested_col))
-				(list (quote lambda) params
-					(lower_scalar_first_query_probe_expr_using stage value_expr keys params nested_stages prepare_stages))))
+				(list (quote memoize)
+					(list (quote lambda) params
+						(lower_scalar_first_query_probe_expr_using stage value_expr keys params nested_stages prepare_stages)))))
 		_ (neumann_fail "build_queryplan" "malformed scalar query probe recipe plan"))))
 
 (define scalar_query_probe_recipe_bindings (lambda (plans)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1201,6 +1201,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (once_fn 2) 3) true "once first call computes")
 	(assert (equal? (once_fn 99) 3) true "once second call returns cached")
 	(assert (equal? (once_calls "n") 1) true "once executes only once")
+	/* memoize */
+	(define memo_calls (newsession))
+	(memo_calls "n" 0)
+	(define memo_fn (memoize (lambda (x y) (begin
+		(memo_calls "n" (+ (memo_calls "n") 1))
+		(if (equal? x 0) nil (+ x y))))))
+	(assert (equal? (memo_fn 2 3) 5) true "memoize first key computes")
+	(assert (equal? (memo_fn 2 3) 5) true "memoize repeated key reuses value")
+	(assert (nil? (memo_fn 0 9)) true "memoize caches nil values")
+	(assert (nil? (memo_fn 0 9)) true "memoize reuses cached nil values")
+	(assert (equal? (memo_fn 3 3) 6) true "memoize distinguishes arguments")
+	(assert (equal? (memo_calls "n") 3) true "memoize computes once per argument tuple")
+	(define memo_recursive (memoize (lambda (x)
+		(if (equal? x 0) 0 (+ 1 (memo_recursive (- x 1)))))))
+	(assert (equal? (memo_recursive 4) 4) true "memoize permits recursive calls")
+	(assert (equal? (memo_recursive 4) 4) true "memoize reuses recursive results")
 	/* mutex */
 	(define mtx (mutex))
 	(assert (equal? (mtx (lambda () 42)) 42) true "mutex executes inner function")

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -198,6 +198,60 @@ type session struct {
 	Map map[string]Scmer
 }
 
+type memoizedFunction struct {
+	mu      sync.Mutex
+	entries []Scmer
+	dict    *FastDict
+}
+
+func (memo *memoizedFunction) find(args []Scmer) (Scmer, bool) {
+	key := NewSlice(args)
+	if memo.dict != nil {
+		return memo.dict.Get(key)
+	}
+	for i := 0; i < len(memo.entries); i += 2 {
+		if Equal(memo.entries[i], key) {
+			return memo.entries[i+1], true
+		}
+	}
+	return NewNil(), false
+}
+
+func (memo *memoizedFunction) store(args []Scmer, value Scmer) {
+	key := NewSlice(append([]Scmer(nil), args...))
+	if memo.dict != nil {
+		memo.dict.Set(key, value, nil)
+		return
+	}
+	memo.entries = append(memo.entries, key, value)
+	if len(memo.entries) >= 10 {
+		memo.dict = NewFastDictValue(len(memo.entries)/2 + 4)
+		for i := 0; i < len(memo.entries); i += 2 {
+			memo.dict.Set(memo.entries[i], memo.entries[i+1], nil)
+		}
+		memo.entries = nil
+	}
+}
+
+func (memo *memoizedFunction) apply(fn Scmer, args []Scmer) (result Scmer) {
+	memo.mu.Lock()
+	if cached, ok := memo.find(args); ok {
+		memo.mu.Unlock()
+		return cached
+	}
+	memo.mu.Unlock()
+
+	result = Apply(fn, args...)
+	memo.mu.Lock()
+	if cached, ok := memo.find(args); ok {
+		memo.mu.Unlock()
+		return cached
+	}
+	memo.store(args, result)
+	memo.mu.Unlock()
+	return result
+}
+
 // build this function into your SCM environment to offer http server capabilities
 func NewSession(a ...Scmer) Scmer {
 	sess := new(session)
@@ -363,7 +417,7 @@ func init_sync() {
 	Declare(&Globalenv, &Declaration{
 		Name: "newpromise",
 		Desc: "Creates a single-value promise cell (thread-safe via CAS spin-lock). Returns a tagPromise Scmer. (newpromise) allocates a [2]Scmer backing; (newpromise list) reuses an existing ≥2-element slice as backing with zero extra allocation. API: (p \"value\") reads current value (nil if pending), (p \"value\" v) resolves, (p \"once\" v) resolves once (panics if already fulfilled/failed), (p \"once\" v msg) resolves once with custom panic message, (p \"state\") returns state (nil/true/false), (p \"fail\") sets failed and clears the stored value, (p \"fail\" err) sets failed and stores err as payload.",
-		Fn: NewPromise,
+		Fn:   NewPromise,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "list", ParamDesc: "optional: ≥2-element slice to use as backing", Optional: true},
@@ -381,7 +435,7 @@ func init_sync() {
 	Declare(&Globalenv, &Declaration{
 		Name: "newsession",
 		Desc: "Creates a new session which is a threadsafe key-value store represented as a function that can be either called as a getter (session key) or setter (session key value) or list all keys with (session)",
-		Fn: NewSession,
+		Fn:   NewSession,
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
 				Params: []*TypeDescriptor{
@@ -409,7 +463,7 @@ func init_sync() {
 	Declare(&Globalenv, &Declaration{
 		Name: "context",
 		Desc: "Context helper function. Each context also contains a session. (context func args) creates a new context and runs func in that context, (context \"session\") reads the session variable, (context \"check\") will check the liveliness of the context and otherwise throw an error",
-		Fn: Context,
+		Fn:   Context,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "args...", ParamDesc: "depends on the usage", Variadic: true},
@@ -462,6 +516,27 @@ func init_sync() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "memoize",
+		Desc: "Creates a query-local function wrapper that caches completed results by structurally equal argument tuple. Small caches stay linear and promote to a FastDict at the standard assoc-array threshold. Misses compute without holding the cache lock so recursive calls cannot deadlock.",
+		Fn: func(a ...Scmer) Scmer {
+			memo := &memoizedFunction{}
+			return NewFunc(func(args ...Scmer) Scmer {
+				return memo.apply(a[0], args)
+			})
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "func", ParamName: "f", ParamDesc: "pure function whose results are cached by argument tuple"},
+			},
+			Return: &TypeDescriptor{Kind: "func",
+				Params: []*TypeDescriptor{
+					{Kind: "any", ParamName: "args", ParamDesc: "arguments forwarded to the wrapped function", Variadic: true},
+				},
+				Return: &TypeDescriptor{Kind: "any"},
+			},
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "mutex",
 		Desc: "Creates a mutex. The return value is a function that takes one parameter which is a parameterless function. The mutex is guaranteed that all calls to that mutex get serialized.",
 		Fn: func(a ...Scmer) Scmer {
@@ -499,7 +574,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -517,7 +592,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "dict"},
-			Const: true,
+			Const:  true,
 		},
 	})
 }

--- a/scm/sync_test.go
+++ b/scm/sync_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "sync"
+import "sync/atomic"
+import "testing"
+
+func TestMemoizedFunctionUsesStructuralArgumentKeys(t *testing.T) {
+	var calls atomic.Int64
+	fn := NewFunc(func(args ...Scmer) Scmer {
+		calls.Add(1)
+		return NewInt(42)
+	})
+	memo := &memoizedFunction{}
+
+	first := []Scmer{NewSlice([]Scmer{NewInt(1), NewString("x")})}
+	second := []Scmer{NewSlice([]Scmer{NewInt(1), NewString("x")})}
+	if got := memo.apply(fn, first); got.Int() != 42 {
+		t.Fatalf("first result = %v, want 42", got)
+	}
+	if got := memo.apply(fn, second); got.Int() != 42 {
+		t.Fatalf("cached result = %v, want 42", got)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("calls = %d, want 1", got)
+	}
+}
+
+func TestMemoizedFunctionDoesNotCachePanics(t *testing.T) {
+	var calls atomic.Int64
+	fn := NewFunc(func(args ...Scmer) Scmer {
+		if calls.Add(1) == 1 {
+			panic("first call fails")
+		}
+		return NewInt(7)
+	})
+	memo := &memoizedFunction{}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("first call did not panic")
+			}
+		}()
+		memo.apply(fn, []Scmer{NewInt(1)})
+	}()
+	if got := memo.apply(fn, []Scmer{NewInt(1)}); got.Int() != 7 {
+		t.Fatalf("retry result = %v, want 7", got)
+	}
+}
+
+func TestMemoizedFunctionAllowsConcurrentMisses(t *testing.T) {
+	fn := NewFunc(func(args ...Scmer) Scmer {
+		return NewInt(args[0].Int() + 1)
+	})
+	memo := &memoizedFunction{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if got := memo.apply(fn, []Scmer{NewInt(9)}); got.Int() != 10 {
+				t.Errorf("result = %v, want 10", got)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestMemoizedFunctionPromotesToFastDict(t *testing.T) {
+	fn := NewFunc(func(args ...Scmer) Scmer {
+		return NewInt(args[0].Int() * 2)
+	})
+	memo := &memoizedFunction{}
+
+	for i := int64(0); i < 8; i++ {
+		if got := memo.apply(fn, []Scmer{NewInt(i)}); got.Int() != i*2 {
+			t.Fatalf("result for %d = %v, want %d", i, got, i*2)
+		}
+	}
+	if memo.dict == nil {
+		t.Fatal("cache did not promote to FastDict")
+	}
+	if memo.entries != nil {
+		t.Fatalf("linear entries retained after promotion: %v", memo.entries)
+	}
+	if got := memo.apply(fn, []Scmer{NewInt(3)}); got.Int() != 6 {
+		t.Fatalf("promoted cache result = %v, want 6", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a thread-safe `memoize` runtime wrapper for pure functions, keyed by structurally equal argument tuples
- keep small caches as linear assoc pairs and promote at the existing five-entry assoc-array threshold to avoid eager map allocation
- wrap generated scalar query-probe recipes so repeated correlation keys reuse completed lookup results within one query execution
- preserve recursion and panic behavior: misses run outside the cache lock, and failed evaluations are not cached

## A/B measurements

Base: `03a3bdc2b` (current master at measurement time)  
PR: `9f293a0a3`  
Same production-derived data snapshot, same host, sequential processes, TracePrint enabled. Each prefix run used one warmup followed by three measured executions. Values are median wall time in seconds; lower is better. Prefix contents are intentionally anonymized.

| Prefix stage | Master | PR | Delta |
|---:|---:|---:|---:|
| 1 char | 25.140 | 22.827 | -9.2% |
| 2 chars | 5.935 | 5.572 | -6.1% |
| 3 chars | 4.035 | 3.745 | -7.2% |
| 4 chars | 3.871 | 3.678 | -5.0% |
| 5 chars | 3.847 | 3.744 | -2.7% |
| 6 chars | 3.751 | 3.663 | -2.3% |
| 7 chars | 3.860 | 3.637 | -5.8% |
| 8 chars | 3.893 | 3.736 | -4.0% |
| longest | 1.030 | 1.002 | -2.8% |

The first broad warmup had one branch outlier (`35.423 s` versus `25.390 s`). A separate fresh-process repeat did not reproduce it: master `26.495 s`, PR `26.216 s`. The three measured broad samples were stable: master `24.562..25.843 s`, PR `22.238..23.300 s`.

The production-derived wide detail query was also measured five times per fresh process through the MySQL frontend:

| Variant | Samples (s) | Median |
|---|---|---:|
| Master | 8.383, 8.033, 7.707, 7.701, 7.697 | 7.707 |
| PR | 7.578, 7.536, 7.405, 7.379, 7.279 | 7.405 (-3.9%) |

Both variants returned 72 rows, 13,272 bytes, with identical SHA-256 output.

## Verification

- `go test -race ./scm -run '^TestMemoizedFunction'`
- `go test ./scm`
- targeted correlated-probe and deeply nested correlation SQL suites
- full `make test` after merging current master
