### PR TITLE
Reduce allocation cost of point scans

### DIFF
--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -75,6 +75,32 @@ func TestBoundaryRange(t *testing.T) {
 	}
 }
 
+func TestScanBufferSizeUsesSmallBufferOnlyForBoundUniqueKey(t *testing.T) {
+	tbl := &table{Unique: []uniqueKey{{Id: "PRIMARY", Cols: []string{"tenant_id", "id"}}}}
+	point := func(col string, value scm.Scmer) columnboundaries {
+		return columnboundaries{
+			col: col, matcher: EqualMatcher,
+			lower: value, lowerInclusive: true,
+			upper: value, upperInclusive: true,
+		}
+	}
+
+	if got := tbl.scanBufferSize(boundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewInt(42))}); got != uniquePointScanBufferSize {
+		t.Fatalf("fully bound unique key buffer = %d, want %d", got, uniquePointScanBufferSize)
+	}
+	if got := tbl.scanBufferSize(boundaries{point("id", scm.NewInt(42))}); got != defaultScanBufferSize {
+		t.Fatalf("partially bound unique key buffer = %d, want %d", got, defaultScanBufferSize)
+	}
+	if got := tbl.scanBufferSize(boundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewNil())}); got != defaultScanBufferSize {
+		t.Fatalf("NULL unique key buffer = %d, want %d", got, defaultScanBufferSize)
+	}
+	rangeBoundary := point("id", scm.NewInt(42))
+	rangeBoundary.matcher = RangeMatcher
+	if got := tbl.scanBufferSize(boundaries{point("tenant_id", scm.NewInt(9)), rangeBoundary}); got != defaultScanBufferSize {
+		t.Fatalf("range-bound unique key buffer = %d, want %d", got, defaultScanBufferSize)
+	}
+}
+
 func TestWidenDistinctEqualityPointsProducesRange(t *testing.T) {
 	left := boundaries{{
 		col: "actor_id", matcher: EqualMatcher,

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -361,6 +361,42 @@ type scanResult struct {
 	err            scanError // err.r != nil indicates an error
 }
 
+const (
+	defaultScanBufferSize     = 1024
+	uniquePointScanBufferSize = 8
+)
+
+// scanBufferSize keeps full scans batched while avoiding a 4 KiB allocation
+// for the common join case where an exact unique key can yield at most one
+// currently visible row. A few slots remain for stale index entries left by
+// updates; iterateIndex still visits further batches when necessary.
+func (t *table) scanBufferSize(boundaries boundaries) int {
+	for _, unique := range t.Unique {
+		covered := true
+		for _, col := range unique.Cols {
+			matched := false
+			for _, boundary := range boundaries {
+				if boundary.col != col || !matcherKindEqual(boundary.matcher, EqualMatcher) ||
+					boundary.lowerBatch || boundary.upperBatch || boundary.lower.IsNil() || boundary.upper.IsNil() ||
+					!boundary.lowerInclusive || !boundary.upperInclusive ||
+					!boundaryValueEqual(boundary.lower, boundary.upper) {
+					continue
+				}
+				matched = true
+				break
+			}
+			if !matched {
+				covered = false
+				break
+			}
+		}
+		if covered && len(unique.Cols) > 0 {
+			return uniquePointScanBufferSize
+		}
+	}
+	return defaultScanBufferSize
+}
+
 func (t *table) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
@@ -837,11 +873,11 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		mutationSeen = make(map[uint32]struct{}, 128)
 	}
 
-	// filter phase: iterateIndex fills stack buffer, callback filters in-place and flushes to MapReducer
-	var buf [1024]uint32
+	// filter phase: iterateIndex fills the reusable buffer, callback filters in-place and flushes to MapReducer
+	buf := make([]uint32, t.t.scanBufferSize(boundaries))
 	hadValue := false
 
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, true, func(batch []uint32) bool {
 		candidateCount += int64(len(batch))
 		// filter in-place: overwrite batch with passing IDs
 		outN := 0

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -144,6 +144,62 @@ func BenchmarkScanFixedCosts_DeepStack(b *testing.B) {
 	}
 }
 
+func benchmarkUniquePointScan(b *testing.B, name string) {
+	dbName := "bench_scan_point_" + name
+	databases.Remove(dbName)
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("label", "VARCHAR", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl.Insert([]string{"id", "label"}, rows, nil, scm.NewNil(), false, nil)
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "PRIMARY", Cols: []string{"id"}})
+
+	condition := scanCondition("id", scm.NewInt(511))
+	mapFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[0] })
+	nilFn := scm.NewNil()
+	// Warm the lazily built index before measuring regular probe overhead.
+	tbl.scan(nil, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tbl.scan(nil, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
+	}
+}
+
+// BenchmarkScanUniquePoint measures the repeated dimension-table lookup used
+// by nested joins after logical decorrelation and join reordering.
+func BenchmarkScanUniquePoint(b *testing.B) {
+	benchmarkUniquePointScan(b, "read")
+}
+
+func TestOpenMapReducerAllocatesMutationMetadataLazily(t *testing.T) {
+	const dbName = "test_scan_mapper_metadata"
+	databases.Remove(dbName)
+	t.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	shard := tbl.Shards[0]
+	mapFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewNil() })
+
+	readMapper := shard.OpenMapReducer([]string{"id"}, mapFn, scm.NewNil(), false, 0, nil, nil)
+	defer readMapper.Close()
+	if readMapper.isUpdate != nil || readMapper.isIncrement != nil || readMapper.setClosureFn != nil {
+		t.Fatal("read mapper allocated mutation-only metadata")
+	}
+
+	mutationMapper := shard.OpenMapReducer([]string{"$update"}, mapFn, scm.NewNil(), false, 0, nil, nil)
+	defer mutationMapper.Close()
+	if len(mutationMapper.isUpdate) != 1 || !mutationMapper.isUpdate[0] || len(mutationMapper.setClosureFn) != 1 {
+		t.Fatal("mutation mapper did not initialize mutation metadata")
+	}
+}
+
 // BenchmarkGLSGetValue measures raw cost of a single GLS GetValue call.
 // Establishes per-call overhead for CurrentTx() GLS lookups inside shard goroutines.
 func BenchmarkGLSGetValue(b *testing.B) {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1355,17 +1355,6 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		deltaGetters:     make([]mapArgGetter, len(cols)),
 		mainCols:         make([]ColumnStorage, len(cols)),
 		colNames:         cols,
-		isUpdate:         make([]bool, len(cols)),
-		isInvalidate:     make([]bool, len(cols)),
-		invalidateProxy:  make([]*StorageComputeProxy, len(cols)),
-		isIncrement:      make([]bool, len(cols)),
-		incrementProxy:   make([]*StorageComputeProxy, len(cols)),
-		isSet:            make([]bool, len(cols)),
-		setProxy:         make([]*StorageComputeProxy, len(cols)),
-		isBreak:          make([]bool, len(cols)),
-		setClosureFn:     make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols)),
-		incrClosureFn:    make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols)),
-		invClosureFn:     make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols)),
 		args:             make([]scm.Scmer, len(cols)),
 		mapFn:            scm.OptimizeProcToSerialFunction(mapFn),
 		reduceFn:         scm.OptimizeProcToSerialFunction(reduceFn),
@@ -1373,6 +1362,29 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		reduceScmer:      reduceFn,
 		mainCount:        t.main_count,
 		shardWriteLocked: alreadyLocked,
+	}
+	needsMutationMetadata := false
+	for _, col := range cols {
+		if col == "$update" || col == "$break" || len(col) >= 4 && col[:4] == "NEW." ||
+			len(col) > 12 && col[:12] == "$invalidate:" ||
+			len(col) > 11 && col[:11] == "$increment:" ||
+			len(col) > 5 && col[:5] == "$set:" {
+			needsMutationMetadata = true
+			break
+		}
+	}
+	if needsMutationMetadata {
+		mr.isUpdate = make([]bool, len(cols))
+		mr.isInvalidate = make([]bool, len(cols))
+		mr.invalidateProxy = make([]*StorageComputeProxy, len(cols))
+		mr.isIncrement = make([]bool, len(cols))
+		mr.incrementProxy = make([]*StorageComputeProxy, len(cols))
+		mr.isSet = make([]bool, len(cols))
+		mr.setProxy = make([]*StorageComputeProxy, len(cols))
+		mr.isBreak = make([]bool, len(cols))
+		mr.setClosureFn = make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols))
+		mr.incrClosureFn = make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols))
+		mr.invClosureFn = make([]*func(uint32, ...scm.Scmer) scm.Scmer, len(cols))
 	}
 	hasDeleteTriggers := false
 	for _, tr := range t.t.Triggers {
@@ -1442,12 +1454,14 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 	// Pre-allocate tagClosure fn ptrs (hoisted, one per pseudo-col type per column).
 	// These are allocated once here so processMainBlock/processDeltaBlock can use
 	// NewClosure(ptr, effectiveID) per row without any heap allocation.
-	noopFn := func(id uint32, args ...scm.Scmer) scm.Scmer { return scm.NewBool(true) }
-	mr.noopClosureFn = &noopFn
-	breakFn := func(id uint32, args ...scm.Scmer) scm.Scmer { panic(breakSentinel{}) }
-	mr.breakClosureFn = &breakFn
+	if needsMutationMetadata {
+		noopFn := func(id uint32, args ...scm.Scmer) scm.Scmer { return scm.NewBool(true) }
+		mr.noopClosureFn = &noopFn
+		breakFn := func(id uint32, args ...scm.Scmer) scm.Scmer { panic(breakSentinel{}) }
+		mr.breakClosureFn = &breakFn
+	}
 	for i := range cols {
-		if mr.isSet[i] {
+		if needsMutationMetadata && mr.isSet[i] {
 			if proxy := mr.setProxy[i]; proxy != nil {
 				fn := func(id uint32, args ...scm.Scmer) scm.Scmer {
 					if len(args) > 0 {
@@ -1458,7 +1472,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 				mr.setClosureFn[i] = &fn
 			}
 		}
-		if mr.isIncrement[i] {
+		if needsMutationMetadata && mr.isIncrement[i] {
 			if proxy := mr.incrementProxy[i]; proxy != nil {
 				// Batch increments: aggregate per (proxy, recid) and flush after scan
 				if mr.incrementBatch == nil {
@@ -1488,7 +1502,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 				mr.incrClosureFn[i] = &fn
 			}
 		}
-		if mr.isInvalidate[i] {
+		if needsMutationMetadata && mr.isInvalidate[i] {
 			if proxy := mr.invalidateProxy[i]; proxy != nil {
 				// Batch invalidations: mark proxy for InvalidateAll after scan
 				if mr.invalidateBatch == nil {
@@ -1504,7 +1518,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		if mr.mainGetters[i] != nil {
 			continue
 		}
-		if mr.isInvalidate[i] {
+		if needsMutationMetadata && mr.isInvalidate[i] {
 			if fnptr := mr.invClosureFn[i]; fnptr != nil {
 				mr.mainGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
 					return scm.NewClosure(fnptr, id)
@@ -1519,7 +1533,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			}
 			continue
 		}
-		if mr.isIncrement[i] {
+		if needsMutationMetadata && mr.isIncrement[i] {
 			if fnptr := mr.incrClosureFn[i]; fnptr != nil {
 				mr.mainGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
 					return scm.NewClosure(fnptr, id)
@@ -1534,7 +1548,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			}
 			continue
 		}
-		if mr.isSet[i] {
+		if needsMutationMetadata && mr.isSet[i] {
 			if fnptr := mr.setClosureFn[i]; fnptr != nil {
 				getter := func(id uint32, batchid uint32) scm.Scmer {
 					return scm.NewClosure(fnptr, id)
@@ -1550,7 +1564,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			}
 			continue
 		}
-		if mr.isBreak[i] {
+		if needsMutationMetadata && mr.isBreak[i] {
 			getter := func(id uint32, batchid uint32) scm.Scmer {
 				return scm.NewClosure(mr.breakClosureFn, id)
 			}
@@ -1558,7 +1572,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			mr.deltaGetters[i] = getter
 			continue
 		}
-		if mr.isUpdate[i] {
+		if needsMutationMetadata && mr.isUpdate[i] {
 			getter := func(id uint32, batchid uint32) scm.Scmer {
 				return scm.NewFunc(mr.shard.UpdateFunctionBatch(id, true, mr.shardWriteLocked, mr.deleteBatch, mr.currentTx))
 			}


### PR DESCRIPTION
## Summary

- allocate mutation-only `ShardMapReducer` metadata only for mutation pseudo-columns
- size exact non-NULL unique-key scan buffers for point probes instead of reserving 1024 recids
- keep the existing index iterator, residual filter, visibility, reducer, outer-join, and parallel-shard semantics
- add focused unit coverage and a repeated unique-point-probe benchmark

This replaces the closed query-local memoization experiment (#380) with a stateless optimization in the regular scan path.

## A/B measurements

Storage A/B base: `3c8e291b7`; patch: `51709e9a9`. Same host and data directory, TracePrint enabled. The branch subsequently merged current master through `3210f4135`; those planner-only changes have no overlap with this storage patch, and the full suite was rerun after each merge.

### Unique point probe

| metric | master | PR | delta |
|---|---:|---:|---:|
| time | 5.836 us | 5.949 us | no significant change (`p=0.371`) |
| bytes/op | 6,271 | 2,266 | -63.9% |
| allocs/op | 46 | 34 | -26.1% |

### Production-shaped 28 KB detail query

First three directly comparable warm runs:

| metric | master | PR |
|---|---:|---:|
| median | 8.25 s | 7.94 s |
| response bytes | 13,861 | 13,861 |
| SHA-256 | `902ddbc188e63f32...` | `902ddbc188e63f32...` |

### Full search-prefix cascade

The complete PR cascade was measured in order from the one-character prefix through the most selective full prefix (one warmup, two samples):

| stage | PR median |
|---:|---:|
| 1 | 47.889 s |
| 2 | 17.047 s |
| 3 | 11.852 s |
| 4 | 12.177 s |
| 5 | 12.216 s |
| 6 | 12.099 s |
| 7 | 12.157 s |
| 8 | 11.011 s |
| 9 | 1.172 s |

Every stage returned the same zero-byte response/hash expected for the isolated HTTP session. Master was run twice with the identical stage order and a 300 s timeout. Stage 1 timed out both before and after an explicit selective-stage prewarm, so the master cascade could not proceed to stages 2-9. I am not presenting that timeout as a quantified speedup: the host was under substantial concurrent load, while the microbenchmark and non-empty detail-query comparison are the stable evidence for this PR.

## Verification

- `make test`
- `go test ./storage -count=1`
- `go test -race ./storage -run 'TestOpenMapReducerAllocatesMutationMetadataLazily|TestScanBufferSizeUsesSmallBufferOnlyForBoundUniqueKey' -count=1`
- identical non-empty detail-query bytes and SHA-256

A broader race invocation also exposed a pre-existing race in `TestIterateShardsParallelMarksPartitionMultiShardNonSolo`; this patch does not touch that test or path.
