### PR TITLE
Fix session-sensitive group cache domains

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6580,11 +6580,18 @@ is still available and remains an ordinary scalar expression through untangle. *
 (define group_stage_session_key_pairs (lambda (stage keys key_names)
 	(map (group_stage_session_domain_keys stage) (lambda (expr)
 		(begin
-			(define idx (group_key_expr_index keys expr))
+			(define direct_idx (group_key_expr_index keys expr))
+			(define lookup_idx (group_key_expr_index
+				(coalesceNil (qassoc_get (gs_facts stage) (quote lookup-keys) '()) '())
+				expr))
+			(define idx (if (not (nil? direct_idx)) direct_idx lookup_idx))
 			(if (nil? idx)
 				(neumann_fail "build_queryplan" (concat "session domain expression is not a group key: "
 					(serialize expr) " in " (serialize keys)))
-				(list expr (nth key_names idx))))))))
+				(if (>= idx (count key_names))
+					(neumann_fail "build_queryplan" (concat "session lookup key has no matching group key: "
+						(serialize expr) " in " (serialize keys)))
+					(list expr (nth key_names idx)))))))))
 
 (define replace_group_session_expr (lambda (stage keys key_names expr)
 	(begin

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -560,6 +560,42 @@ PostgreSQL parsers should both lower to the same combined operators.
 	(merge_unique (map (coalesceNil terms '()) (lambda (term)
 		(btw2025_expr_accessing_aliases term outer_aliases))))))
 
+/* Session reads affect a dependent helper like outer-column reads do. Keep
+their expressions in Domain D so reusable carriers are keyed by the binding
+instead of capturing whichever session populated the carrier first. */
+(define query_expr_session_reads (lambda (expr)
+	(match expr
+		((symbol session) "__memcp_tx") '()
+		((quote session) "__memcp_tx") '()
+		((symbol session) key) (list (list (quote session) key))
+		((quote session) key) (list (list (quote session) key))
+		(cons head tail) (merge_unique (cons
+			(query_expr_session_reads head)
+			(map tail query_expr_session_reads)))
+		_ '())))
+
+(define query_session_read? (lambda (expr)
+	(match expr
+		((symbol session) "__memcp_tx") false
+		((quote session) "__memcp_tx") false
+		((symbol session) _key) true
+		((quote session) _key) true
+		_ false)))
+
+(define session_domain_pairs (lambda (node)
+	(map (query_expr_session_reads node) (lambda (expr) (list expr expr)))))
+
+(define presence_session_domain_pairs (lambda (block)
+	(session_domain_pairs (list
+		(qb_sources block)
+		(qb_where block)
+		(qb_group block)
+		(qb_having block)
+		(qb_order block)
+		(qb_limit block)
+		(qb_offset block)
+		(qb_stages block)))))
+
 (define btw2025_query_block_accessing_aliases (lambda (block outer_sources)
 	(if (not (query_block? block))
 		'()
@@ -1226,13 +1262,16 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define visible_ags (stage_aggregates_for_fields (qb_fields inner)))
 		(define order_ags (merge_unique (map (order_item_exprs (qb_order inner)) extract_aggregates)))
 		(define ags (dedupe_aggregates_by_col (merge_unique (list visible_ags order_ags (list aggregate_count_descriptor)))))
-		(define keys (map (coalesceNil (qb_group inner) '()) (lambda (expr)
+		(define session_keys (query_expr_session_reads inner))
+		(define explicit_keys (map (coalesceNil (qb_group inner) '()) (lambda (expr)
 			(canonical_column_expr_for_alias inner_default expr))))
+		(define keys (merge (list explicit_keys (filter session_keys (lambda (expr)
+			(not (contains? explicit_keys expr)))))))
 		(define stage_id (concat "scalar-group-top:" (fnv_hash (serialize (list subquery keys ags (qb_order inner))))))
 		(define stage (make_group_stage
 			stage_id
 			inner_src
-			'()
+			session_keys
 			keys
 			ags
 			nil
@@ -1243,8 +1282,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(list
 				(list (quote condition) (coalesceNil (qb_where inner) true))
 				(list (quote purpose) (quote scalar_aggregate))
-				(list (quote domain) '())
-				(list (quote lookup-keys) '())
+				(list (quote domain) session_keys)
+				(list (quote lookup-keys) session_keys)
 				(list (quote preserve_empty_domain) false)
 				(list (quote null_semantics) (quote scalar))
 				(list (quote cardinality_mode) (quote first)))))
@@ -1269,7 +1308,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list corr_pairs source_corr_pairs))))
+		(define lookup_pairs (domain_correlation_pairs (merge (list
+			corr_pairs source_corr_pairs (presence_session_domain_pairs inner)))))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define keys (if (empty_list? lookup_pairs)
@@ -1347,7 +1387,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list corr_pairs source_corr_pairs))))
+		(define lookup_pairs (domain_correlation_pairs (merge (list
+			corr_pairs source_corr_pairs (presence_session_domain_pairs inner)))))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define explicit_keys (map (qb_group inner) (lambda (expr)
@@ -1601,7 +1642,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define corr_pairs (filter (map terms (lambda (term)
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
-		(define lookup_pairs (unique_correlation_pairs corr_pairs))
+		(define lookup_pairs (domain_correlation_pairs (merge (list
+			corr_pairs (session_domain_pairs membership_inner)))))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define rhs_expr (canonical_column_expr_for_alias inner_default (query_block_first_expr membership_inner)))
@@ -1788,7 +1830,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(define local_having_terms (filter having_terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define all_corr_pairs (domain_correlation_pairs (merge (list corr_pairs having_corr_pairs source_corr_pairs))))
+		(define all_corr_pairs (domain_correlation_pairs (merge (list
+			corr_pairs having_corr_pairs source_corr_pairs (session_domain_pairs inner)))))
 		(define explicit_group_keys (map (coalesceNil (qb_group inner) '()) (lambda (expr)
 			(canonical_column_expr_for_alias inner_default expr))))
 		(define keys (group_keys_for_correlations inner_default all_corr_pairs explicit_group_keys))
@@ -1867,7 +1910,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list corr_pairs source_corr_pairs))))
+		(define lookup_pairs (domain_correlation_pairs (merge (list
+			corr_pairs source_corr_pairs (session_domain_pairs inner)))))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define keys (if (empty_list? lookup_pairs)
@@ -2206,7 +2250,8 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list corr_pairs source_corr_pairs))))
+		(define lookup_pairs (domain_correlation_pairs (merge (list
+			corr_pairs source_corr_pairs (session_domain_pairs inner)))))
 		(define local_terms (filter terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
 		(define keys (if (empty_list? lookup_pairs)
@@ -5864,13 +5909,17 @@ dependency preparation does not emit free outer-row symbols. */
 		(define value_expr (replace_group_expr alias grouptbl keys key_names ags (first_projection_expr (gs_output stage))))
 		(define replaced_order (map (coalesceNil (gs_order stage) '()) (lambda (item)
 			(match item '(expr dir) (list (replace_group_order_expr alias grouptbl keys key_names ags expr) dir)))))
+		(define session_filter (group_stage_session_filter_expr stage grouptbl keys key_names))
+		(define filtercols (extract_columns_for_alias group_src session_filter))
 		(define ordercols (order_cols_for_alias group_src replaced_order))
 		(define valuecols (extract_columns_for_alias group_src value_expr))
 		(list (quote scan_order)
 			'(session "__memcp_tx")
 			(list (quote table) schema grouptbl)
-			(quoted_runtime_list '())
-			(list (quote lambda) '() true)
+			(cons (quote list) filtercols)
+			(list (quote lambda)
+				(map filtercols (lambda (col) (symbol (concat grouptbl "." col))))
+				(list (quote optimize) (lower_column_expr_for_alias group_src session_filter)))
 			(cons (quote list) ordercols)
 			(cons (quote list) (order_dirs replaced_order))
 			0
@@ -6406,6 +6455,67 @@ is still available and remains an ordinary scalar expression through untangle. *
 (define group_key_cols (lambda (keys)
 	(map (produceN (count keys)) group_key_col_name)))
 
+(define group_stage_session_domain_keys (lambda (stage)
+	(query_expr_session_reads (gs_domain stage))))
+
+(define group_key_expr_index (lambda (keys expr)
+	(reduce (produceN (count keys)) (lambda (found i)
+		(if (not (nil? found)) found (if (equal? (nth keys i) expr) i nil)))
+		nil)))
+
+(define group_stage_session_key_pairs (lambda (stage keys key_names)
+	(map (group_stage_session_domain_keys stage) (lambda (expr)
+		(begin
+			(define idx (group_key_expr_index keys expr))
+			(if (nil? idx)
+				(neumann_fail "build_queryplan" (concat "session domain expression is not a group key: "
+					(serialize expr) " in " (serialize keys)))
+				(list expr (nth key_names idx))))))))
+
+(define replace_group_session_expr (lambda (stage keys key_names expr)
+	(begin
+		(define pair (reduce (group_stage_session_key_pairs stage keys key_names)
+			(lambda (found candidate)
+				(if (not (nil? found)) found (if (equal? expr (nth candidate 0)) candidate nil)))
+			nil))
+		(if (not (nil? pair))
+			(list (quote outer) (symbol (nth pair 1)))
+			(match expr
+				(cons head tail) (cons head (map tail (lambda (item)
+					(replace_group_session_expr stage keys key_names item))))
+				_ expr)))))
+
+(define group_stage_session_filter_expr (lambda (stage grouptbl keys key_names)
+	(begin
+		(define pairs (group_stage_session_key_pairs stage keys key_names))
+		(if (empty_list? pairs)
+			true
+			(combine_where_terms (map pairs (lambda (pair)
+				(list (quote equal??)
+					(list (quote get_column) grouptbl false (nth pair 1) false)
+					(nth pair 0))))
+				true)))))
+
+(define group_stage_session_binding_missing_expr (lambda (stage schema grouptbl keys key_names)
+	(begin
+		(define pairs (group_stage_session_key_pairs stage keys key_names))
+		(if (empty_list? pairs)
+			(list (quote table_empty?) (list (quote table) schema grouptbl))
+			(begin
+				(define cols (map pairs (lambda (pair) (nth pair 1))))
+				(define params (map cols (lambda (col) (symbol (concat grouptbl "." col)))))
+				(list (quote not)
+					(list (quote scan_exists)
+						'(session "__memcp_tx")
+						(list (quote table) schema grouptbl)
+						(cons (quote list) cols)
+						(list (quote lambda)
+							params
+							(list (quote optimize)
+								(combine_where_terms (map (produceN (count pairs)) (lambda (i)
+									(list (quote equal??) (nth params i) (nth (nth pairs i) 0))))
+									true))))))))))
+
 (define assoc_keys_as_dataset_rows (lambda (dict width)
 	(map (extract_assoc dict (lambda (k v) k))
 		(lambda (k)
@@ -6439,11 +6549,16 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(merge_unique (list visible_ags having_ags))
 			(merge_unique (list visible_ags having_ags (list aggregate_count_descriptor))))))
 		(define alias (source_alias src))
+		(define session_keys (query_expr_session_reads block))
+		(define explicit_keys (map (coalesceNil (qb_group block) '()) (lambda (expr)
+			(canonical_column_expr_for_alias alias expr))))
+		(define keys (merge (list explicit_keys (filter session_keys (lambda (expr)
+			(not (contains? explicit_keys expr)))))))
 		(make_group_stage
-			(concat "group:" (source_relation src) ":" (fnv_hash (string (list (qb_group block) ags))))
+			(concat "group:" (source_relation src) ":" (fnv_hash (string (list keys ags))))
 			src
-			'()
-			(map (coalesceNil (qb_group block) '()) (lambda (expr) (canonical_column_expr_for_alias alias expr)))
+			session_keys
+			keys
 			ags
 			(qb_having block)
 			(qb_fields block)
@@ -6451,7 +6566,9 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(qb_limit block)
 			(qb_offset block)
 			(list
-				(list (quote condition) (coalesceNil (qb_where block) true)))))))
+				(list (quote condition) (coalesceNil (qb_where block) true))
+				(list (quote domain) session_keys)
+				(list (quote lookup-keys) session_keys))))))
 
 (define make_group_stage_for_query_block (lambda (block)
 	(begin
@@ -6464,6 +6581,8 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define group_keys (map (coalesceNil (qb_group block) '()) (lambda (expr) (canonical_column_expr_for_alias alias expr))))
 		(define field_passthrough_keys (field_passthrough_keys_for_alias alias (qb_fields block)))
 		(define passthrough_keys (external_column_refs_for_alias alias (coalesceNil (qb_having block) true)))
+		(define session_keys (query_expr_session_reads block))
+		(define keys (merge_unique (list group_keys field_passthrough_keys passthrough_keys session_keys)))
 		(define input (make_query_block
 			(qb_schema block)
 			(qb_sources block)
@@ -6474,10 +6593,11 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(qb_stages block)
 			(qb_facts block)))
 		(make_group_stage
-			(concat "group:query:" (fnv_hash (serialize (list (qb_sources block) (qb_where block) (qb_group block) ags))))
+			(concat "group:query:" (fnv_hash (serialize (list
+				(qb_sources block) (qb_where block) keys ags))))
 			input
-			'()
-			(merge_unique (list group_keys field_passthrough_keys passthrough_keys))
+			session_keys
+			keys
 			ags
 			(qb_having block)
 			(qb_fields block)
@@ -6486,6 +6606,8 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(qb_offset block)
 			(list
 				(list (quote condition) true)
+				(list (quote domain) session_keys)
+				(list (quote lookup-keys) session_keys)
 				(list (quote stage_catalog) (query_block_stage_catalog block)))))))
 
 (define group_key_index (lambda (alias keys expr)
@@ -6681,9 +6803,11 @@ is still available and remains an ordinary scalar expression through untangle. *
 	(begin
 		(define src (list alias nil nil false nil))
 		(map (produceN (count keys)) (lambda (i)
-			(list (quote equal?)
-				(lower_column_expr_for_alias src (nth keys i))
-				(list (quote outer) (symbol (nth key_names i)))))))))
+			(if (query_session_read? (nth keys i))
+				true
+				(list (quote equal?)
+					(lower_column_expr_for_alias src (nth keys i))
+					(list (quote outer) (symbol (nth key_names i))))))))))
 
 (define build_group_collect_plan (lambda (schema tbl alias grouptbl keys key_names condition)
 	(if (equal? keys '(1))
@@ -8380,11 +8504,13 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define count_col_name (aggregate_col_name aggregate_count_descriptor))
 		(define count_check (list (quote >) (list (quote get_column) grouptbl false count_col_name false) 0))
 		(define needs_count_filter (and (not (equal? keys '(1))) (not (equal? condition true))))
-		(define having_expr (if (not needs_count_filter)
+		(define aggregate_having_expr (if (not needs_count_filter)
 			replaced_having
 			(if (or (nil? replaced_having) (equal? replaced_having true))
 				count_check
 				(list (quote and) replaced_having count_check))))
+		(define session_filter (group_stage_session_filter_expr stage grouptbl keys key_names))
+		(define having_expr (combine_where_terms (list aggregate_having_expr session_filter) true))
 		(make_query_block
 			schema
 			(cons
@@ -8516,6 +8642,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(rewrite_scalar_first_probe_expr stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
 			(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)))
 		(define key_names (group_key_cols keys))
+		(define aggregate_condition (replace_group_session_expr stage keys key_names condition))
 		(define grouptbl (group_carrier_relation carrier))
 		(define initializer_owner (qassoc_get (gs_facts stage) (quote keytable_initializer_owner) true))
 		(define scalar_query_stage (and (query_block? src)
@@ -8591,7 +8718,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 						nil
 						nil)
 					(list (quote touch_keytable) (list (quote table) schema grouptbl)))
-				(list (list (quote table_empty?) (list (quote table) schema grouptbl)))))))
+				(list (group_stage_session_binding_missing_expr stage schema grouptbl keys key_names))))))
 		(define collect_plan (if query_input_carrier
 			(if (union_block? src)
 				(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names (list aggregate_count_descriptor))
@@ -8607,8 +8734,8 @@ is still available and remains an ordinary scalar expression through untangle. *
 					(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names ags)
 					(build_query_group_aggregates_insert_plan_using prepared_src grouptbl keys key_names lowering_ags ags))))
 			(if scalar_order_base_stage
-				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names condition ags))
-				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names condition ag))))))
+				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names aggregate_condition ags))
+				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names aggregate_condition ag))))))
 		(define computed_order_exprs (merge_unique (map (coalesceNil (gs_order stage) '()) (lambda (item)
 			(match item '(expr _dir) (begin
 				(define replaced_order_expr (replace_group_order_expr alias grouptbl keys key_names ags expr))

--- a/tests/performance/session-group-cache.yaml
+++ b/tests/performance/session-group-cache.yaml
@@ -133,6 +133,30 @@ test_cases:
         - ".grp:"
         - "scan_exists"
 
+  - name: "projected session presence maps lookup domain to inner group key"
+    session_id: "sgc_sess"
+    sql: |
+      SELECT wrapped.id, wrapped.has_global_access
+      FROM (
+        SELECT id,
+          EXISTS (
+            SELECT TRUE
+            FROM sgc_acl access_rows
+            WHERE access_rows.usr = @actor_id
+              AND access_rows.category IS NULL
+            GROUP BY access_rows.usr
+            HAVING COUNT(*) > 0
+          ) AS has_global_access
+        FROM sgc_data
+      ) wrapped
+      ORDER BY wrapped.id
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          has_global_access: false
+
   - name: "session-filtered SUM GROUP BY (warm)"
     session_id: "sgc_sess"
     sql: |

--- a/tests/performance/session-group-cache.yaml
+++ b/tests/performance/session-group-cache.yaml
@@ -43,7 +43,7 @@ cleanup:
 test_cases:
   - name: "set session user"
     session_id: "sgc_sess"
-    sql: "SET @fop_user = 1"
+    sql: "SET @app_user = 1"
     expect:
       rows_affected: 0
 
@@ -54,7 +54,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @app_user
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -76,7 +76,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @app_user
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -98,7 +98,7 @@ test_cases:
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @app_user
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -108,20 +108,18 @@ test_cases:
 
   - name: "set session user 2"
     session_id: "sgc_sess2"
-    sql: "SET @fop_user = 2"
+    sql: "SET @app_user = 2"
     expect:
       rows_affected: 0
 
   - name: "different session sees different groups"
-    noncritical: true
-    fail_comment: "the reusable group carrier currently retains results from the previous session binding"
     session_id: "sgc_sess2"
     sql: |
       SELECT category, COUNT(*) AS cnt
       FROM sgc_data
       WHERE EXISTS (
         SELECT 1 FROM sgc_acl
-        WHERE sgc_acl.usr = @fop_user
+        WHERE sgc_acl.usr = @app_user
           AND sgc_acl.category = sgc_data.category
       )
       GROUP BY category
@@ -134,11 +132,205 @@ test_cases:
         - category: 4
           cnt: 4
 
+  - name: "first session reuses its own cached groups"
+    session_id: "sgc_sess"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @app_user
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 3
+      data:
+        - category: 1
+          cnt: 4
+        - category: 2
+          cnt: 4
+        - category: 3
+          cnt: 4
+
+  - name: "write from an unrelated session updates every populated domain"
+    session_id: "sgc_writer"
+    sql: "INSERT INTO sgc_data (category, owner, val) VALUES (4, 9, 200)"
+    expect:
+      affected_rows: 1
+
+  - name: "second session sees incremental changes for its cached domain"
+    session_id: "sgc_sess2"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @app_user
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 2
+      data:
+        - category: 1
+          cnt: 4
+        - category: 4
+          cnt: 5
+
+  - name: "first session stays isolated after an unrelated write"
+    session_id: "sgc_sess"
+    sql: |
+      SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @app_user
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 3
+      data:
+        - category: 1
+          cnt: 4
+        - category: 2
+          cnt: 4
+        - category: 3
+          cnt: 4
+
+  - name: "logical plan exposes the session binding as a domain key"
+    session_id: "sgc_sess"
+    sql: |
+      EXPLAIN IR SELECT category, COUNT(*) AS cnt
+      FROM sgc_data
+      WHERE EXISTS (
+        SELECT 1 FROM sgc_acl
+        WHERE sgc_acl.usr = @app_user
+          AND sgc_acl.category = sgc_data.category
+      )
+      GROUP BY category
+    expect:
+      contains:
+        - '(domain ((get_column "sgc_data" true "category" true) (session "app_user")))'
+        - '(lookup-keys ((get_column "sgc_data" true "category" true) (session "app_user")))'
+
   - name: "simple COUNT with session WHERE (warm, must be fast)"
     session_id: "sgc_sess"
     sql: |
       SELECT COUNT(*) AS cnt
       FROM sgc_data
-      WHERE owner = @fop_user
+      WHERE owner = @app_user
     expect:
       rows: 1
+
+  - name: "set first aggregate factor"
+    session_id: "sgc_factor_a"
+    sql: "SET @factor = 2"
+    expect:
+      rows_affected: 0
+
+  - name: "session value in aggregate expression uses first domain"
+    session_id: "sgc_factor_a"
+    sql: |
+      SELECT category, SUM(val * @factor) AS total
+      FROM sgc_data
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 5
+      data:
+        - category: 1
+          total: 700
+        - category: 2
+          total: 476
+        - category: 3
+          total: 532
+        - category: 4
+          total: 988
+        - category: 5
+          total: 644
+
+  - name: "set second aggregate factor"
+    session_id: "sgc_factor_b"
+    sql: "SET @factor = 3"
+    expect:
+      rows_affected: 0
+
+  - name: "session value in aggregate expression uses second domain"
+    session_id: "sgc_factor_b"
+    sql: |
+      SELECT category, SUM(val * @factor) AS total
+      FROM sgc_data
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 5
+      data:
+        - category: 1
+          total: 1050
+        - category: 2
+          total: 714
+        - category: 3
+          total: 798
+        - category: 4
+          total: 1482
+        - category: 5
+          total: 966
+
+  - name: "set unrelated aggregate session"
+    session_id: "sgc_factor_writer"
+    sql: "SET @factor = 9"
+    expect:
+      rows_affected: 0
+
+  - name: "write under unrelated aggregate session"
+    session_id: "sgc_factor_writer"
+    sql: "INSERT INTO sgc_data (category, owner, val) VALUES (1, 9, 5)"
+    expect:
+      affected_rows: 1
+
+  - name: "first aggregate domain remains correct after write"
+    session_id: "sgc_factor_a"
+    sql: |
+      SELECT category, SUM(val * @factor) AS total
+      FROM sgc_data
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 5
+      data:
+        - category: 1
+          total: 710
+        - category: 2
+          total: 476
+        - category: 3
+          total: 532
+        - category: 4
+          total: 988
+        - category: 5
+          total: 644
+
+  - name: "second aggregate domain remains correct after write"
+    session_id: "sgc_factor_b"
+    sql: |
+      SELECT category, SUM(val * @factor) AS total
+      FROM sgc_data
+      GROUP BY category
+      ORDER BY category
+    expect:
+      rows: 5
+      data:
+        - category: 1
+          total: 1065
+        - category: 2
+          total: 714
+        - category: 3
+          total: 798
+        - category: 4
+          total: 1482
+        - category: 5
+          total: 966

--- a/tests/planner/aggregates/session-group-reminders.yaml
+++ b/tests/planner/aggregates/session-group-reminders.yaml
@@ -66,7 +66,6 @@ test_cases:
 
   - name: "Reminder badge query with grouped inner aggregate for user 1"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -129,7 +128,6 @@ test_cases:
 
   - name: "Materialized grouped reminder source for user 1"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT *
       FROM (
@@ -179,7 +177,6 @@ test_cases:
           cnt: 1
   - name: "Reminder badge query reflects changed equality session key"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -274,7 +271,6 @@ test_cases:
           cnt: 2
   - name: "Reminder badge query reflects changed range session key"
     session_id: "sgr-reminder-session"
-    noncritical: true
     sql: |
       SELECT 1 AS ok,
         (SELECT SUM(cnt)
@@ -311,5 +307,5 @@ test_cases:
       rows: 1
       data:
         - ok: 1
-          grouped_due: 1
+          grouped_due: 2
           reminder_tickets: 1


### PR DESCRIPTION
## Root cause

Reusable group carriers keyed only by row correlations while session reads stayed inside their filter formulas. The first session that populated a carrier therefore fixed its visible domain for later sessions. A second binding could read missing or stale groups.

## Change

- Treat semantic session reads as Domain D dependencies, excluding the internal transaction handle.
- Add those values to logical group-stage domains, lookup keys, and physical carrier keys.
- Filter carrier reads to the active session binding and bind aggregate scans to the carrier key rather than the writer's current session.
- Preserve explicit `GROUP BY` key order and multiplicity while appending session keys.
- Promote the previously noncritical session-group scenarios to required regressions.

No application-specific names or data are included.

## A/B against master `3c8e291b7`

The anonymized session-group suite was run against the same test file and data:

| Variant | Result | Suite time |
| --- | ---: | ---: |
| master | 19/20; second session returned the first session's cached domain | 0.325 s |
| branch | 20/20 | 0.326 s |

The branch also preserves both populated bindings across alternating reads and verifies correctness after a write from a third session. Session values used directly inside aggregate expressions are covered as well.

On a 20,000-row query-input aggregate, master took 7.9-8.4 s to populate the first binding and then returned an incorrect empty result for the second binding in 0.58-0.64 s. The corrected branch computes each binding in roughly 3.8-4.2 s. This PR does **not** claim a warm-cache speedup for complex query-input carriers: those carriers still rebuild to preserve correctness after DML because they do not yet have dependency-aware invalidation. Adding that lifecycle is the next performance package; skipping the rebuild without it produced stale post-write aggregates and was rejected during development.

## Validation

- `go build -o memcp`
- focused session, aggregate, EXISTS, IN, and complex subquery suites
- `tests/storage/indexes/computed-index-cols.yaml` (30/30)
- `python3 tools/lint_scm.py --check` (only pre-existing repository warnings)
- `MEMCP_TEST_JOBS=1 ./git-pre-commit` (green; known noncritical cases remain noncritical)
- `git diff --check`

## Manual-build A/B after merging master `b4b0cfa04`

The complete German application manual suite was measured with tracing disabled,
four Playwright workers, a fresh database per run, and a fresh MemCP data directory
per MemCP run. Both engines completed every stage successfully.

| Engine | Run 1 | Run 2 | Mean |
| --- | ---: | ---: | ---: |
| MariaDB 10.11 | 55.30 s | 59.74 s | 57.52 s |
| MemCP `71232e285` | 74.35 s | 75.12 s | 74.74 s |

MemCP is currently 29.9% slower end to end. The stable database-heavy stage
medians show the same remaining gap: search 15.85 s vs. 10.65 s, document open
11.30 s vs. 8.40 s, and archive download 13.65 s vs. 7.55 s.

The first post-merge run was not counted as a performance sample: it exposed a
compiler error where a session Domain D expression was represented by its inner
correlation key. The follow-up fix resolves session bindings through generic
`lookup-keys -> keys` correspondence. Its anonymized grouped-EXISTS regression
failed before the fix and now passes; the full pre-commit suite is green.
