### PR TITLE
Fix empty aggregates over joined inputs

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6930,15 +6930,18 @@ is still available and remains an ordinary scalar expression through untangle. *
 					(lower_column_expr_for_alias src (nth keys i))
 					(list (quote outer) (symbol (nth key_names i))))))))))
 
+(define build_group_constant_key_insert_plan (lambda (schema grouptbl)
+	(list (quote insert)
+		(list (quote table) schema grouptbl)
+		(quoted_runtime_list (list "k0"))
+		(list (quote list) (list (quote list) 1))
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		true)))
+
 (define build_group_collect_plan (lambda (schema tbl alias grouptbl keys key_names condition)
 	(if (equal? keys '(1))
-		(list (quote insert)
-			(list (quote table) schema grouptbl)
-			(quoted_runtime_list (list "k0"))
-			(list (quote list) (list (quote list) 1))
-			(quoted_runtime_list '())
-			(list (quote lambda) '() true)
-			true)
+		(build_group_constant_key_insert_plan schema grouptbl)
 		(begin
 			(define src (list alias schema tbl false nil))
 			(define keycols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
@@ -8789,8 +8792,9 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define aggregate_condition (replace_group_session_expr stage keys key_names condition))
 		(define grouptbl (group_carrier_relation carrier))
 		(define initializer_owner (qassoc_get (gs_facts stage) (quote keytable_initializer_owner) true))
+		(define scalar_single_stage (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single)))
 		(define scalar_query_stage (and (query_block? src)
-			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
+			(and scalar_single_stage
 				(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote single_or_error))
 					(and (equal? (count ags) 2)
 						(equal? (cadr ags) aggregate_count_descriptor))))))
@@ -8880,6 +8884,12 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(if scalar_order_base_stage
 				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names aggregate_condition ags))
 				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names aggregate_condition ag))))))
+		(define empty_aggregate_seed_plans (if (and query_input_carrier
+			(and initializer_owner
+				(and (not scalar_single_stage)
+					(and (not (empty_list? ags)) (equal? keys '(1))))))
+			(list (build_group_constant_key_insert_plan schema grouptbl))
+			'()))
 		(define computed_order_exprs (merge_unique (map (coalesceNil (gs_order stage) '()) (lambda (item)
 			(match item '(expr _dir) (begin
 				(define replaced_order_expr (replace_group_order_expr alias grouptbl keys key_names ags expr))
@@ -8907,7 +8917,8 @@ is still available and remains an ordinary scalar expression through untangle. *
 						ensure_agg_columns
 						computed_order_plans
 						(if (and initializer_owner (empty_list? ags)) (list collect_plan) '())
-						agg_plans)))
+						agg_plans
+						empty_aggregate_seed_plans)))
 				(if scalar_order_base_stage
 					(list (quote !begin)
 						nested_prepare_expr

--- a/tests/planner/aggregates/group-stage-corners.yaml
+++ b/tests/planner/aggregates/group-stage-corners.yaml
@@ -402,6 +402,31 @@ test_cases:
           amount: 250
           total_qty: 5
 
+  # =================================================================
+  # 15. Ungrouped aggregates over an empty join still return one row
+  # =================================================================
+  - name: "SUM over empty join returns NULL"
+    sql: |
+      SELECT SUM(i.qty) AS total
+      FROM gs_orders o
+      JOIN gs_items i ON i.order_id = o.id
+      WHERE o.id < 0
+    expect:
+      rows: 1
+      data:
+        - total: null
+
+  - name: "COUNT over empty join returns zero"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM gs_orders o
+      JOIN gs_items i ON i.order_id = o.id
+      WHERE o.id < 0
+    expect:
+      rows: 1
+      data:
+        - total: 0
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS gs_blocked_sources"
   - sql: "DROP TABLE IF EXISTS gs_sources"


### PR DESCRIPTION
## What changed

- seed the constant group key for ungrouped aggregate stages whose query input produces no rows
- keep `scalar_single` / `ORDER BY ... LIMIT 1` carriers empty when their input is empty
- add critical regressions for `SUM` and `COUNT` over an empty join

## Why

An ungrouped SQL aggregate must always produce exactly one row. Query-input group carriers only created their constant key from input rows, so an empty multi-table input returned no row instead of `NULL` for `SUM` or `0` for `COUNT`. This also caused TPC-H Q17 to return an empty result at SF 0.01 instead of its correct single NULL row.

## Validation

- `python3 run_sql_tests.py tests/planner/aggregates/group-stage-corners.yaml`
- `python3 run_sql_tests.py tests/sql/dml/traced-insert-select-pagination.yaml`
- full `./git-pre-commit` hook-equivalent suite: passed, commit allowed
- official TPC-H Q17 generated and run locally at SF 0.01: exact match with PostgreSQL reference (`avg_yearly = NULL`)

TPC-H query text, generated data, and helper scripts are not included in this branch.