### PR TITLE
Fix ordered scalar session domain lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7059,8 +7059,9 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define mapcols (merge_unique (list group_key_cols_for_scan valuecols)))
 		(define key_expr (runtime_cons_list_expr (map keys (lambda (expr) (lower_column_expr_for_alias src expr)))))
 		(define payload_expr (runtime_cons_list_expr (map value_exprs (lambda (expr) (lower_column_expr_for_alias src expr)))))
-		(define key_sortcols (map keys (lambda (expr) (order_column_for_alias src expr))))
-		(define key_dirs (map keys (lambda (_key) (quote <))))
+		(define physical_keys (filter keys (lambda (expr) (not (query_session_read? expr)))))
+		(define key_sortcols (map physical_keys (lambda (expr) (order_column_for_alias src expr))))
+		(define key_dirs (map physical_keys (lambda (_key) (quote <))))
 		(define keep_first (list (quote lambda) (list (quote old) (quote new)) (quote old)))
 		(list
 			(list (quote lambda) (list (quote grouped))
@@ -8882,7 +8883,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 					(build_union_group_aggregates_insert_plan prepared_src grouptbl keys key_names ags)
 					(build_query_group_aggregates_insert_plan_using prepared_src grouptbl keys key_names lowering_ags ags))))
 			(if scalar_order_base_stage
-				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names aggregate_condition ags))
+				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names condition ags))
 				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names aggregate_condition ag))))))
 		(define empty_aggregate_seed_plans (if (and query_input_carrier
 			(and initializer_owner

--- a/tests/performance/session-group-cache.yaml
+++ b/tests/performance/session-group-cache.yaml
@@ -12,6 +12,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS sgc_data"
   - sql: "DROP TABLE IF EXISTS sgc_acl"
   - sql: "DROP TABLE IF EXISTS sgc_range_data"
+  - sql: "DROP TABLE IF EXISTS sgc_scalar_entity"
+  - sql: "DROP TABLE IF EXISTS sgc_scalar_history"
   - sql: |
       CREATE TABLE sgc_data (
         id INT PRIMARY KEY AUTO_INCREMENT,
@@ -26,6 +28,8 @@ setup:
         category INT
       )
   - sql: "CREATE TABLE sgc_range_data (id INT PRIMARY KEY, category INT, val INT)"
+  - sql: "CREATE TABLE sgc_scalar_entity (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE sgc_scalar_history (parent_id INT, valid_at INT, value_a INT, value_b INT)"
   - sql: |
       INSERT INTO sgc_data (category, owner, val) VALUES
         (2, 2, 7), (3, 3, 14), (4, 1, 21), (5, 2, 28), (1, 3, 35),
@@ -38,11 +42,15 @@ setup:
         (2, 1), (2, 4),
         (3, 2), (3, 5)
   - sql: "INSERT INTO sgc_range_data VALUES (1, 1, 60), (2, 1, 90)"
+  - sql: "INSERT INTO sgc_scalar_entity VALUES (1)"
+  - sql: "INSERT INTO sgc_scalar_history VALUES (1, 10, 11, 12), (1, 20, 21, 22)"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS sgc_data"
   - sql: "DROP TABLE IF EXISTS sgc_acl"
   - sql: "DROP TABLE IF EXISTS sgc_range_data"
+  - sql: "DROP TABLE IF EXISTS sgc_scalar_entity"
+  - sql: "DROP TABLE IF EXISTS sgc_scalar_history"
 
 test_cases:
   - name: "set session user"
@@ -311,6 +319,76 @@ test_cases:
       rows: 1
       data:
         - total: 1
+
+  - name: "set ordered scalar cutoff"
+    session_id: "sgc_scalar"
+    sql: "SET @scalar_cutoff = 20"
+    expect:
+      rows_affected: 0
+
+  - name: "merged ordered scalar projections use session domain"
+    session_id: "sgc_scalar"
+    max_time: 1.0
+    sql: |
+      SELECT id,
+        COALESCE((SELECT value_a FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1), 0) AS value_a,
+        COALESCE((SELECT value_b FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1), 0) AS value_b
+      FROM sgc_scalar_entity e
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          value_a: 21
+          value_b: 22
+
+  - name: "ordered scalar stage retains session lookup domain"
+    session_id: "sgc_scalar"
+    sql: |
+      EXPLAIN IR SELECT id,
+        (SELECT value_a FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1) AS value_a,
+        (SELECT value_b FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1) AS value_b
+      FROM sgc_scalar_entity e
+      WHERE id = 1
+    expect:
+      result_contains:
+        - "btw2025_domain"
+        - "btw2025_lookup_keys"
+        - "scalar_cutoff"
+
+  - name: "change ordered scalar cutoff"
+    session_id: "sgc_scalar"
+    sql: "SET @scalar_cutoff = 10"
+    expect:
+      rows_affected: 0
+
+  - name: "merged ordered scalar projections isolate changed session domain"
+    session_id: "sgc_scalar"
+    max_time: 1.0
+    sql: |
+      SELECT id,
+        COALESCE((SELECT value_a FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1), 0) AS value_a,
+        COALESCE((SELECT value_b FROM sgc_scalar_history h
+          WHERE h.parent_id = e.id AND h.valid_at <= @scalar_cutoff
+          ORDER BY h.valid_at DESC LIMIT 1), 0) AS value_b
+      FROM sgc_scalar_entity e
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          value_a: 11
+          value_b: 12
 
   - name: "set first aggregate factor"
     session_id: "sgc_factor_a"


### PR DESCRIPTION
## Summary

- keep session reads in ordered scalar cache keys without treating them as physical sort columns
- evaluate the combined one-pass initializer condition in its own session scope
- add anonymous regression coverage for two merged ordered scalar projections and a changed session cutoff

## Root cause

Session-sensitive group domains added session reads to the logical key list. The combined ordered-scalar initializer reused that complete list as physical scan ordering, although a session read is constant for the scan and has no source column. Compilation therefore failed while lowering the sort columns.

The same initializer was also receiving the condition rewritten for a per-carrier callback. That form references an outer materialized session key, which is not in scope in the combined one-pass scan.

The logical cache key remains unchanged. Only physical ordering excludes session constants, and only the combined initializer retains the direct session condition.

## Test-first evidence

On current master, the new anonymous execution cases both fail with HTTP 500:

```
build_queryplan: ORDER BY expression lowering needs a computed sort column
```

With this branch:

- `tests/performance/session-group-cache.yaml`: 37/37 passed
- initial cutoff returns both values from the latest eligible row
- changed cutoff returns both values from the earlier row
- `EXPLAIN IR` still contains the session-sensitive BTW2025 domain and lookup keys
- both execution cases have a 1 s wall-clock ceiling

## A/B downstream validation

| Revision | First-user stage | Progress |
| --- | ---: | --- |
| master `9a5cf23cc` | failed after 120 s with compiler HTTP 500 | stopped at first-user stage |
| this branch | 15.1 s, passed | continued through the next two stages and reached the larger parallel phase |

The later parallel-phase UI failures did not record SQL compiler/runtime errors and are separate follow-up work.

## Validation

- Scheme startup tests: 855/855 passed
- targeted session cache suite: 37/37 passed
- transaction suite rerun: 171/171 passed
- full `make test` traversed all suites; one transaction flake passed on rerun
- the existing multi-shard `ORDER BY ... OFFSET` performance suite still exceeds its 5 s host threshold while returning correct rows (unrelated code path; no threshold changed)
