### PR TITLE
Promote fixed planner regressions to critical

### DIFF
--- a/tests/integration/query-shapes/relational-benchmark-shapes.yaml
+++ b/tests/integration/query-shapes/relational-benchmark-shapes.yaml
@@ -219,8 +219,6 @@ test_cases:
         - weighted_score: 24
 
   - name: "TPC-H Q7 shape: bidirectional OR join alternatives"
-    noncritical: true
-    fail_comment: "join lowering retains the first bidirectional OR arm but drops the second matching arm"
     sql: |
       SELECT p.owner_id, a.actor_id, COUNT(*) AS pair_count
       FROM cq_parent p

--- a/tests/planner/aggregates/session-group-empty-keytable.yaml
+++ b/tests/planner/aggregates/session-group-empty-keytable.yaml
@@ -66,7 +66,6 @@ test_cases:
         - cnt: 2
 
   - name: "SUM over session-filtered derived table"
-    noncritical: true
     session_id: "sge_sess"
     sql: |
       SELECT COUNT(*) AS cnt, t.state_desc


### PR DESCRIPTION
## Change

Remove stale `noncritical` markers from two planner regressions that are now fixed:

- bidirectional OR join alternatives
- session-filtered grouped derived tables

The SQL and expected results are unchanged. Future regressions in either shape now fail CI instead of being reported as warnings.

## Validation

- focused suites: 26/26
- full `./git-pre-commit`: status 0
- `git diff --check`