### PR TITLE
Fix empty scalar aggregate domain preservation

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1237,12 +1237,20 @@ instead of capturing whichever session populated the carrier first. */
 										(not (scalar_once_ordered_payload? (car (gs_aggregates stage)))))))))))))))
 
 (define scalar_aggregate_probe_stage? (lambda (stage)
-	(and (group_stage? stage)
-		(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_aggregate))
-			(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote many))
-				(and (not (empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
-					(and (equal? (coalesceNil (gs_having stage) true) true)
-						(source_is_base_table? (gs_input stage)))))))))
+	(if (not (group_stage? stage))
+		false
+		(begin
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define keys (if (empty_list? lookup_keys) '() (gs_keys stage)))
+			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_aggregate))
+				(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote many))
+					(and (equal? (count keys) (count lookup_keys))
+						(and (or
+							(not (empty_list? lookup_keys))
+							(and (empty_list? (gs_domain stage))
+								(not (stage_has_residual_outer_refs? stage))))
+							(and (equal? (coalesceNil (gs_having stage) true) true)
+								(source_is_base_table? (gs_input stage)))))))))))
 
 (define presence_probe_stage? (lambda (stage)
 	(and (group_stage? stage)
@@ -5728,8 +5736,8 @@ dependency preparation does not emit free outer-row symbols. */
 			(neumann_fail "build_queryplan" "scalar aggregate probe requires scalar_aggregate base stage")
 			true)
 		(define src (gs_input stage))
-		(define keys (gs_keys stage))
 		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(define keys (if (empty_list? lookup_keys) '() (gs_keys stage)))
 		(if (not (equal? (count keys) (count lookup_keys)))
 			(neumann_fail "build_queryplan" "scalar aggregate probe key/domain mismatch")
 			true)
@@ -6287,6 +6295,10 @@ dependency preparation does not emit free outer-row symbols. */
 	(match expr
 		((symbol grouped_scalar_top) stage) (lower_grouped_scalar_top_expr stage)
 		((quote grouped_scalar_top) stage) (lower_grouped_scalar_top_expr stage)
+		((symbol scalar_aggregate_probe) stage requested_col)
+		(lower_scalar_aggregate_probe_expr '() nil stage requested_col)
+		((quote scalar_aggregate_probe) stage requested_col)
+		(lower_scalar_aggregate_probe_expr '() nil stage requested_col)
 		((symbol union_count) block) (lower_union_count_expr block)
 		((quote union_count) block) (lower_union_count_expr block)
 		(cons head tail) (cons head (map tail lower_scalar_marker_expr))
@@ -6935,6 +6947,15 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(list (quote table) schema grouptbl)
 		(quoted_runtime_list (list "k0"))
 		(list (quote list) (list (quote list) 1))
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		true)))
+
+(define build_group_session_key_insert_plan (lambda (schema grouptbl key_names keys)
+	(list (quote insert)
+		(list (quote table) schema grouptbl)
+		(cons (quote list) key_names)
+		(list (quote list) (cons (quote list) keys))
 		(quoted_runtime_list '())
 		(list (quote lambda) '() true)
 		true)))
@@ -8082,9 +8103,24 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(nil? (nth ag 2)))))
 
 (define scalar_aggregate_probe_stage_safe? (lambda (stage)
-	(reduce (gs_aggregates stage) (lambda (ok ag)
-		(and ok (scalar_aggregate_probe_aggregate_safe? ag)))
-		true)))
+	(and (empty_list? (expr_probe_stages (list
+		(qassoc_get (gs_facts stage) (quote condition) true)
+		(gs_aggregates stage))))
+		(reduce (gs_aggregates stage) (lambda (ok ag)
+			(and ok (scalar_aggregate_probe_aggregate_safe? ag)))
+			true))))
+
+(define constant_scalar_aggregate_probe_sources? (lambda (stages sources)
+	(and (not (empty_list? sources))
+		(reduce sources (lambda (constant_only src)
+			(if (not constant_only)
+				false
+				(begin
+					(define stage (source_stage_output_stage stages src))
+					(and (scalar_aggregate_probe_stage? stage)
+						(and (empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+							(scalar_aggregate_probe_stage_safe? stage))))))
+			true))))
 
 (define stage_input_small_enough? (lambda (stage)
 	(begin
@@ -8136,11 +8172,13 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(and
 				(scalar_aggregate_probe_stage_safe? stage)
 				(and
-					(or
-						(stage_has_residual_outer_refs? stage)
+					(if (empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+						(constant_scalar_aggregate_probe_sources? stages sources)
 						(or
-							(probe_limit_small_enough? limit_value)
-							(probe_context_small_enough? probe_sources)))
+							(stage_has_residual_outer_refs? stage)
+							(or
+								(probe_limit_small_enough? limit_value)
+								(probe_context_small_enough? probe_sources))))
 					(stage_lookup_keys_resolve_in_sources? stage probe_sources default_alias)))))))
 
 (define probe_output_sources_for_block (lambda (stages sources default_alias limit_value)
@@ -8888,8 +8926,13 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(define empty_aggregate_seed_plans (if (and query_input_carrier
 			(and initializer_owner
 				(and (not scalar_single_stage)
-					(and (not (empty_list? ags)) (equal? keys '(1))))))
-			(list (build_group_constant_key_insert_plan schema grouptbl))
+					(not (empty_list? ags)))))
+			(if (equal? keys '(1))
+				(list (build_group_constant_key_insert_plan schema grouptbl))
+				(if (reduce keys (lambda (session_only key)
+						(and session_only (query_session_read? key))) true)
+					(list (build_group_session_key_insert_plan schema grouptbl key_names keys))
+					'()))
 			'()))
 		(define computed_order_exprs (merge_unique (map (coalesceNil (gs_order stage) '()) (lambda (item)
 			(match item '(expr _dir) (begin

--- a/tests/planner/aggregates/nested-exists-not-aggregate.yaml
+++ b/tests/planner/aggregates/nested-exists-not-aggregate.yaml
@@ -89,6 +89,17 @@ test_cases:
     expect:
       rows_affected: 0
 
+  - name: "Empty scalar aggregates preserve the outer row"
+    sql: |
+      SELECT
+        (SELECT SUM(1) FROM nea_email e WHERE FALSE) AS empty_sum,
+        (SELECT COUNT(1) FROM nea_email e WHERE FALSE) AS empty_count
+    expect:
+      rows: 1
+      data:
+        - empty_sum: null
+          empty_count: 0
+
   - name: "SELECT 1 with scalar SUM subquery and correlated session owner check"
     session_id: "nea_sess"
     sql: |
@@ -132,8 +143,6 @@ test_cases:
           unseen: 2
 
   - name: "SUM with session var and nested CASE in correlated scalar subquery"
-    noncritical: true
-    fail_comment: "nested CASE correlation currently drops the scalar result row"
     session_id: "nea_sess"
     sql: |
       SELECT
@@ -160,11 +169,9 @@ test_cases:
     expect:
       rows: 1
       data:
-        - unseen: 1
+        - unseen: null
 
   - name: "SUM with session var, nested CASE, and nested EXISTS"
-    noncritical: true
-    fail_comment: "nested CASE plus EXISTS correlation currently drops the scalar result row"
     session_id: "nea_sess"
     sql: |
       SELECT
@@ -200,7 +207,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - unseen: 1
+        - unseen: null
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS nea_share"


### PR DESCRIPTION
## Root cause

A no-FROM projection whose scalar aggregate had no matching input could lose its synthetic outer row. Two physical gaps caused this:

- constant scalar aggregate stages were only probeable when they had outer lookup keys;
- query-backed group carriers seeded the constant `(1)` domain, but not a domain made exclusively from session bindings.

The latter left an empty carrier for deeply nested scalar chains even though the logical stage declared `preserve_empty_domain=true`.

## Change

- Allow stage-free, lookup-free scalar aggregates to lower to the existing direct aggregate scan when every source in the no-FROM block has that shape.
- Lower the resulting aggregate marker in the zero-source result path.
- Seed session-only empty aggregate domains in the existing group carrier, keyed by the current session values.
- Keep mixed or nested stage graphs on the existing prepared-carrier path.

No scalar fallback or physical artifact is added to logical IR.

## Regression

The anonymized aggregate suite now checks:

- empty `SUM` returns `NULL` while preserving one outer row;
- empty `COUNT` returns `0`;
- session-keyed nested scalar chains preserve the row through CASE/COALESCE;
- the same shape with nested EXISTS preserves the row.

The old expected value `1` for a predicate containing `AND ('0')` was corrected to `NULL`, matching MariaDB SQL truth semantics.

## A/B against master 48617c810

- master: target suite 7/9 critical behavior; both deep empty-domain cases return HTTP 200 with zero rows.
- branch: 10/10 in 0.62-0.66s; both cases return one row with the scalar `NULL` result.
- adjacent scalar/aggregate suites: 101/101 serially green.
- the existing mixed badge shape remains on its prepared-carrier plan and stays correct.

## Validation

- `python3 run_sql_tests.py` over seven adjacent scalar/aggregate suites with `--jobs 1`: green
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: green
- `git diff --check`: green
- Scheme formatter run on `lib/queryplan.scm`; check output contains only the repository's known historical negative-depth warnings.