### PR TITLE
Fix nested aggregate stage lowering

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -107,6 +107,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		'("date_add" value unit) '('date_add acc value unit)
 		'("date_sub" value unit) '('date_sub acc value unit))))
 
+(define psql_comparison_expr (lambda (op a b)
+	(match op
+		"eq" '((quote equal??) a b)
+		"ne" '((quote not) '((quote equal?) a b))
+		"le" '((quote <=) a b)
+		"ge" '((quote >=) a b)
+		"lt" '((quote <) a b)
+		"gt" '((quote >) a b))))
+
 (define psql_type (parser (or
 	(parser '((atom "character" true) (atom "varying" true)) "varying")
 	(parser '((atom "double" true) (atom "precision" true)) "double")
@@ -181,14 +190,16 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* IN (SELECT ...) and NOT IN (SELECT ...) -> pseudo operator, planner will lower or reject */
 		(parser '((define a psql_expression3) (atom "IN" true) "(" (define sub psql_select) ")") '('inner_select_in a sub))
 		(parser '((define a psql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_in) a sub)))
-		(parser '((define a psql_expression3) "==" (define b psql_expression2)) '((quote equal??) a b))
-		(parser '((define a psql_expression3) "=" (define b psql_expression2)) '((quote equal??) a b))
-		(parser '((define a psql_expression3) "<>" (define b psql_expression2)) '((quote not) '((quote equal?) a b)))
-		(parser '((define a psql_expression3) "!=" (define b psql_expression2)) '((quote not) '((quote equal?) a b)))
-		(parser '((define a psql_expression3) "<=" (define b psql_expression2)) '((quote <=) a b))
-		(parser '((define a psql_expression3) ">=" (define b psql_expression2)) '((quote >=) a b))
-		(parser '((define a psql_expression3) "<" (define b psql_expression2)) '((quote <) a b))
-		(parser '((define a psql_expression3) ">" (define b psql_expression2)) '((quote >) a b))
+		(parser '((define a psql_expression3) (define op (or
+			(parser "==" "eq")
+			(parser "=" "eq")
+			(parser "<>" "ne")
+			(parser "!=" "ne")
+			(parser "<=" "le")
+			(parser ">=" "ge")
+			(parser "<" "lt")
+			(parser ">" "gt")
+		)) (define b psql_expression2)) (psql_comparison_expr op a b))
 		/* ILIKE is Postgres case-insensitive LIKE. */
 		(parser '((define a psql_expression3) (atom "NOT" true) (atom "ILIKE" true) (define b psql_expression2)) '('not '('strlike a b "utf8mb4_general_ci")))
 		(parser '((define a psql_expression3) (atom "ILIKE" true) (define b psql_expression2)) '('strlike a b "utf8mb4_general_ci"))

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -100,6 +100,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(sql_sub_numeric_literals a b)
 	'((quote -) a b))))
 
+(define psql_fold_additive_term (lambda (acc term)
+	(match term
+		'("add" value) (psql_add_expr acc value)
+		'("sub" value) (psql_sub_expr acc value)
+		'("date_add" value unit) '('date_add acc value unit)
+		'("date_sub" value unit) '('date_sub acc value unit))))
+
 (define psql_type (parser (or
 	(parser '((atom "character" true) (atom "varying" true)) "varying")
 	(parser '((atom "double" true) (atom "precision" true)) "double")
@@ -203,15 +210,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		psql_expression3
 	)))
 
-	(define psql_expression3 (parser (or
-		/* date + INTERVAL n UNIT */
-		(parser '((define a psql_expression4) "+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_add a n unit))
-		/* date - INTERVAL n UNIT */
-		(parser '((define a psql_expression4) "-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '('date_sub a n unit))
-		(parser '((define a psql_expression4) "+" (define b psql_expression3)) (psql_add_expr a b))
-		(parser '((define a psql_expression4) "-" (define b psql_expression3)) (psql_sub_expr a b))
-		psql_expression4
-	)))
+	(define psql_expression3 (parser '(
+		(define a psql_expression4)
+		(define terms (* (or
+			(parser '("+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '("date_add" n unit))
+			(parser '("-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '("date_sub" n unit))
+			(parser '("+" (define b psql_expression4)) '("add" b))
+			(parser '("-" (define b psql_expression4)) '("sub" b))
+		)))
+	) (reduce terms psql_fold_additive_term a)))
 
 	(define psql_expression4 (parser (or
 		(parser '((define a psql_expression5) "*" (define b psql_expression4)) '((quote *) a b))

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -224,7 +224,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		) (match operand
 				'("interval" value unit) (list (concat "date_" op) value unit)
 				'("value" value) (list op value)
-		))))
+		)) empty true))
 	) (reduce terms psql_fold_additive_term a)))
 
 	(define psql_expression4 (parser (or

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -212,12 +212,19 @@ arithmetic; leave expressions containing columns or functions untouched. */
 
 	(define psql_expression3 (parser '(
 		(define a psql_expression4)
-		(define terms (* (or
-			(parser '("+" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '("date_add" n unit))
-			(parser '("-" (atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '("date_sub" n unit))
-			(parser '("+" (define b psql_expression4)) '("add" b))
-			(parser '("-" (define b psql_expression4)) '("sub" b))
-		)))
+		(define terms (* (parser '(
+			(define op (or
+				(parser "+" "add")
+				(parser "-" "sub")
+			))
+			(define operand (or
+				(parser '((atom "INTERVAL" true) (define n psql_expression4) (define unit psql_interval_unit)) '("interval" n unit))
+				(parser (define value psql_expression4) '("value" value))
+			))
+		) (match operand
+				'("interval" value unit) (list (concat "date_" op) value unit)
+				'("value" value) (list op value)
+		))))
 	) (reduce terms psql_fold_additive_term a)))
 
 	(define psql_expression4 (parser (or

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -9648,7 +9648,9 @@ is still available and remains an ordinary scalar expression through untangle. *
 								(define probe_recipe_prepares
 									(scalar_query_probe_recipe_prepare_exprs probe_recipe_plans))
 								(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
-								(define core_block (query_block_with_stage_catalog prepared_block lazy_catalog))
+								(define core_block (query_block_with_stage_catalog
+									(query_block_without_stages prepared_block)
+									lazy_catalog))
 								(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
 								(cons (quote !begin)
 									(merge (list

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -668,12 +668,19 @@ arithmetic; leave expressions containing columns or functions untouched. */
 
 	(define sql_expression3 (parser '(
 		(define a sql_expression4)
-		(define terms (* (or
-			(parser '("+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '("date_add" n unit))
-			(parser '("-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '("date_sub" n unit))
-			(parser '("+" (define b sql_expression4)) '("add" b))
-			(parser '("-" (define b sql_expression4)) '("sub" b))
-		)))
+		(define terms (* (parser '(
+			(define op (or
+				(parser "+" "add")
+				(parser "-" "sub")
+			))
+			(define operand (or
+				(parser '((atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '("interval" n unit))
+				(parser (define value sql_expression4) '("value" value))
+			))
+		) (match operand
+				'("interval" value unit) (list (concat "date_" op) value unit)
+				'("value" value) (list op value)
+		))))
 	) (reduce terms sql_fold_additive_term a)))
 
 	(define sql_expression4 (parser (or

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -680,7 +680,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		) (match operand
 				'("interval" value unit) (list (concat "date_" op) value unit)
 				'("value" value) (list op value)
-		))))
+		)) empty true))
 	) (reduce terms sql_fold_additive_term a)))
 
 	(define sql_expression4 (parser (or

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -136,6 +136,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		'("date_add" value unit) '('date_add acc value unit)
 		'("date_sub" value unit) '('date_sub acc value unit))))
 
+(define sql_comparison_expr (lambda (op a b)
+	(match op
+		"eq" '((quote equal??) a b)
+		"ne" '((quote not) '((quote equal??) a b))
+		"le" '((quote <=) a b)
+		"ge" '((quote >=) a b)
+		"lt" '((quote <) a b)
+		"gt" '((quote >) a b))))
+
 /* lightweight literal parser for top-level contexts (before sql_expression is defined) */
 (define sql_literal (parser (or
 	(parser (atom "NULL" true) (sql_null_literal))
@@ -641,14 +650,16 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((define a sql_expression3) (atom "COLLATE" true) (define collation sql_identifier) "==" (define b sql_expression2)) '('equal_collate a b collation))
 		(parser '((define a sql_expression3) (atom "COLLATE" true) (define collation sql_identifier) "<>" (define b sql_expression2)) '('notequal_collate a b collation))
 		(parser '((define a sql_expression3) (atom "COLLATE" true) (define collation sql_identifier) "!=" (define b sql_expression2)) '('notequal_collate a b collation))
-		(parser '((define a sql_expression3) "==" (define b sql_expression2)) '((quote equal??) a b))
-		(parser '((define a sql_expression3) "=" (define b sql_expression2)) '((quote equal??) a b))
-		(parser '((define a sql_expression3) "<>" (define b sql_expression2)) '((quote not) '((quote equal??) a b)))
-		(parser '((define a sql_expression3) "!=" (define b sql_expression2)) '((quote not) '((quote equal??) a b)))
-		(parser '((define a sql_expression3) "<=" (define b sql_expression2)) '((quote <=) a b))
-		(parser '((define a sql_expression3) ">=" (define b sql_expression2)) '((quote >=) a b))
-		(parser '((define a sql_expression3) "<" (define b sql_expression2)) '((quote <) a b))
-		(parser '((define a sql_expression3) ">" (define b sql_expression2)) '((quote >) a b))
+		(parser '((define a sql_expression3) (define op (or
+			(parser "==" "eq")
+			(parser "=" "eq")
+			(parser "<>" "ne")
+			(parser "!=" "ne")
+			(parser "<=" "le")
+			(parser ">=" "ge")
+			(parser "<" "lt")
+			(parser ">" "gt")
+		)) (define b sql_expression2)) (sql_comparison_expr op a b))
 		(parser '((define a sql_expression3) (atom "COLLATE" true) (define collation sql_identifier) (atom "LIKE" true) (define b sql_expression2)) '('strlike a b collation))
 		/* MySQL default collation is case-insensitive in this project (utf8mb4_general_ci). */
 		(parser '((define a sql_expression3) (atom "LIKE" true) (define b sql_expression2)) '('strlike a b "utf8mb4_general_ci"))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -129,6 +129,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(sql_sub_numeric_literals a b)
 	'((quote -) a b))))
 
+(define sql_fold_additive_term (lambda (acc term)
+	(match term
+		'("add" value) (sql_add_expr acc value)
+		'("sub" value) (sql_sub_expr acc value)
+		'("date_add" value unit) '('date_add acc value unit)
+		'("date_sub" value unit) '('date_sub acc value unit))))
+
 /* lightweight literal parser for top-level contexts (before sql_expression is defined) */
 (define sql_literal (parser (or
 	(parser (atom "NULL" true) (sql_null_literal))
@@ -659,15 +666,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		sql_expression3
 	)))
 
-	(define sql_expression3 (parser (or
-		/* date + INTERVAL n UNIT */
-		(parser '((define a sql_expression4) "+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_add a n unit))
-		/* date - INTERVAL n UNIT */
-		(parser '((define a sql_expression4) "-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '('date_sub a n unit))
-		(parser '((define a sql_expression4) "+" (define b sql_expression3)) (sql_add_expr a b))
-		(parser '((define a sql_expression4) "-" (define b sql_expression3)) (sql_sub_expr a b))
-		sql_expression4
-	)))
+	(define sql_expression3 (parser '(
+		(define a sql_expression4)
+		(define terms (* (or
+			(parser '("+" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '("date_add" n unit))
+			(parser '("-" (atom "INTERVAL" true) (define n sql_expression4) (define unit sql_interval_unit)) '("date_sub" n unit))
+			(parser '("+" (define b sql_expression4)) '("add" b))
+			(parser '("-" (define b sql_expression4)) '("sub" b))
+		)))
+	) (reduce terms sql_fold_additive_term a)))
 
 	(define sql_expression4 (parser (or
 		(parser '((define a sql_expression5) "*" (define b sql_expression4)) '((quote *) a b))

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2023-2024  Carl-Philip Hänsch
+Copyright (C) 2023-2026  Carl-Philip Hänsch
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -324,7 +324,11 @@ func parseSyntax(syntax Scmer, en *Env, ome *optimizerMetainfo, ignoreResult boo
 				} else {
 					sep = packrat.NewEmptyParser(&parserResult{value: NewNil(), env: nil})
 				}
-				return packrat.NewKleeneParser(merger, sub, sep)
+				result := packrat.NewKleeneParser(merger, sub, sep)
+				if len(list) > 3 {
+					result.NoMemo = list[3].Bool()
+				}
+				return result
 			case "+":
 				sub := parseSyntax(list[1], en, ome, ignoreResult)
 				if sub == nil {
@@ -421,7 +425,7 @@ func init_parser() {
 	(regex "asdf" caseinsensitive skipws) RegexParser
 	'(a b c) AndParser
 	(or a b c) OrParser
-	(* sub separator) KleeneParser
+	(* sub separator noMemo) KleeneParser
 	(+ sub separator) ManyParser
 	(? xyz) MaybeParser (if >1 AndParser)
 	(not mainparser parser1 parser2 parser3 ...) a parser that matches mainparser but not parser1...

--- a/scm/packrat_test.go
+++ b/scm/packrat_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestKleeneParserWithoutMemoization(t *testing.T) {
+	parserValue := Eval(Read("no-memo parser", `(parser '(
+		(define values (* (regex "[0-9]+" false false) "," true))
+		$
+	) values "")`), &Globalenv)
+	parser := parserValue.Parser()
+
+	if got := parser.Execute("1,2,3", &Globalenv); String(got) != `(1 2 3)` {
+		t.Fatalf("no-memo parser returned %s", String(got))
+	}
+	if got := parser.Execute("", &Globalenv); String(got) != `()` {
+		t.Fatalf("empty no-memo parser returned %s", String(got))
+	}
+}

--- a/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
+++ b/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
@@ -26,6 +26,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS csa_item"
   - sql: "DROP TABLE IF EXISTS csa_parent"
   - sql: "DROP TABLE IF EXISTS csa_ref"
+  - sql: "DROP TABLE IF EXISTS csa_interval"
+  - sql: "DROP TABLE IF EXISTS csa_break"
+  - sql: "DROP TABLE IF EXISTS csa_balance"
   - sql: |
       CREATE TABLE csa_parent (
         id INT PRIMARY KEY,
@@ -62,6 +65,9 @@ setup:
         status VARCHAR(16),
         sequence_no INT
       )
+  - sql: "CREATE TABLE csa_interval (id INT PRIMARY KEY, owner_id INT, started_at INT, ended_at INT)"
+  - sql: "CREATE TABLE csa_break (id INT PRIMARY KEY, interval_id INT, started_at INT, ended_at INT)"
+  - sql: "CREATE TABLE csa_balance (id INT PRIMARY KEY, owner_id INT, target_value INT, actual_value INT, valid_at INT)"
   - sql: "CREATE TABLE cq_digit (n INT PRIMARY KEY)"
   - sql: |
       CREATE TABLE cq_large_parent (
@@ -103,6 +109,9 @@ setup:
         (3, 12, 'open', 1),
         (4, 21, 'closed', 1),
         (5, 31, 'open', 1)
+  - sql: "INSERT INTO csa_interval VALUES (1, 1, 2, 10), (2, 1, 12, NULL)"
+  - sql: "INSERT INTO csa_break VALUES (1, 1, 4, 6), (2, 2, 14, 15)"
+  - sql: "INSERT INTO csa_balance VALUES (1, 1, 5, 2, 10), (2, 1, 4, 1, 25)"
   - sql: "INSERT INTO cq_digit (n) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9)"
   - sql: |
       INSERT INTO cq_large_parent (id, tenant_id, ref_id)
@@ -457,6 +466,84 @@ test_cases:
         - id: 5
           open_count: 0
 
+  - name: "Set nested aggregate cutoff"
+    session_id: "csa_nested_aggregate"
+    sql: "SET @csa_cutoff = 20"
+    expect:
+      rows_affected: 0
+
+  - name: "Nested scalar aggregate participates in parent aggregate expression"
+    session_id: "csa_nested_aggregate"
+    max_time: 1.0
+    sql: |
+      SELECT COALESCE(
+        (SELECT COALESCE(SUM(
+          LEAST(COALESCE(i.ended_at, @csa_cutoff), @csa_cutoff)
+          - i.started_at
+          - COALESCE((
+            SELECT SUM(
+              LEAST(COALESCE(b.ended_at, @csa_cutoff), @csa_cutoff)
+              - b.started_at
+            )
+            FROM csa_break b
+            WHERE b.interval_id = i.id
+              AND b.started_at <= @csa_cutoff
+          ), 0)
+        ), 0)
+        FROM csa_interval i
+        WHERE i.owner_id = 1
+          AND i.started_at <= @csa_cutoff)
+        -
+        (SELECT COALESCE(SUM(a.target_value - a.actual_value), 0)
+         FROM csa_balance a
+         WHERE a.owner_id = 1
+           AND a.valid_at <= @csa_cutoff),
+        0
+      ) AS remaining
+    expect:
+      rows: 1
+      data:
+        - remaining: 10
+
+  - name: "Change nested aggregate cutoff"
+    session_id: "csa_nested_aggregate"
+    sql: "SET @csa_cutoff = 14"
+    expect:
+      rows_affected: 0
+
+  - name: "Nested aggregate expression uses changed session cutoff"
+    session_id: "csa_nested_aggregate"
+    max_time: 1.0
+    sql: |
+      SELECT COALESCE(
+        (SELECT COALESCE(SUM(
+          LEAST(COALESCE(i.ended_at, @csa_cutoff), @csa_cutoff)
+          - i.started_at
+          - COALESCE((
+            SELECT SUM(
+              LEAST(COALESCE(b.ended_at, @csa_cutoff), @csa_cutoff)
+              - b.started_at
+            )
+            FROM csa_break b
+            WHERE b.interval_id = i.id
+              AND b.started_at <= @csa_cutoff
+          ), 0)
+        ), 0)
+        FROM csa_interval i
+        WHERE i.owner_id = 1
+          AND i.started_at <= @csa_cutoff)
+        -
+        (SELECT COALESCE(SUM(a.target_value - a.actual_value), 0)
+         FROM csa_balance a
+         WHERE a.owner_id = 1
+           AND a.valid_at <= @csa_cutoff),
+        0
+      ) AS remaining
+    expect:
+      rows: 1
+      data:
+        - remaining: 5
+
   - name: "Two-column correlation keeps duplicate domains separate"
     sql: |
       SELECT p.id,
@@ -561,3 +648,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS csa_item"
   - sql: "DROP TABLE IF EXISTS csa_parent"
   - sql: "DROP TABLE IF EXISTS csa_ref"
+  - sql: "DROP TABLE IF EXISTS csa_interval"
+  - sql: "DROP TABLE IF EXISTS csa_break"
+  - sql: "DROP TABLE IF EXISTS csa_balance"

--- a/tests/sql/expressions/basic-sql.yaml
+++ b/tests/sql/expressions/basic-sql.yaml
@@ -24,6 +24,14 @@ test_cases:
       data:
         - result: 6
 
+  - name: "Equal-precedence arithmetic is left associative"
+    sql: "SELECT 20 - 7 - 3 AS subtract_result, 20 - 7 + 3 AS mixed_result"
+    expect:
+      rows: 1
+      data:
+        - subtract_result: 10
+          mixed_result: 16
+
   - name: "Basic multiplication"
     sql: "SELECT 6 * 7 AS result"
     expect:


### PR DESCRIPTION
## Problem

A no-FROM projection composed from sibling scalar aggregates failed when one aggregate contained another correlated aggregate. Probe rewriting reduced the outer block to one physical source, but dependency stages remained attached to `qb_stages`; the single-source core therefore rejected the otherwise prepared plan.

The same minimal query exposed a second correctness issue: equal-precedence additive operators were parsed right-associatively, so `a - b - c` became `a - (b - c)`.

## Fix

- clear logical stages from the already prepared physical core block while retaining the lazy stage catalog used for carrier preparation
- parse additive operator chains once and fold them left-to-right in both SQL frontends
- add anonymous session-sensitive nested aggregate regressions with a 1 s runtime bound
- add a direct left-associativity regression for mixed `+` and `-`

## A/B measurements

| Measurement | origin/master | branch |
|---|---:|---:|
| Nested aggregate target suite | 21/23, 2 HTTP 500 | 23/23 |
| Target suite wall time | 1.467 s | 1.417 s |
| Downstream phase-1 manual checks | 7/19 pass | 12/19 pass |
| SQL compiler errors during manual checks | 61 | 0 |
| Unrelated ordered-pagination suite, release binary | 19/19, 1.820 s | 19/19, 1.813 s |

The remaining downstream failures are UI/form synchronization timeouts; the engine error table remained empty.

## Validation

- `tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml`: 23/23
- `tests/sql/expressions/basic-sql.yaml`: 27/27
- `tests/sql/compatibility/psql-parser.yaml`: 52/52
- `tests/sql/expressions/date-functions.yaml`: 65/65
- downstream manual setup/init checks and phase 1 completed, with 12/19 phase-1 checks passing

`make test` traversed the complete suite and failed only two 5 s ordered-pagination performance assertions while using the Go coverage binary (9.95 s and 5.61 s, both correct results). Rebuilding without coverage makes the suite pass 19/19 in 1.813 s; the equivalent master binary takes 1.820 s.
