### PR TITLE
Fix NULL membership over empty subqueries

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -971,41 +971,42 @@ instead of capturing whichever session populated the carrier first. */
 			(list (quote >) (membership_count_expr stage_alias match_ag) 0))
 		true)))
 
-(define in_null_count_descriptor (lambda (rhs_expr)
-	(list (list (quote if) (list (quote nil?) rhs_expr) 1 0) (quote +) 0)))
+/* One aggregate encodes empty=0, nonempty=1, and contains-NULL=2. */
+(define in_rhs_state_descriptor (lambda (rhs_expr)
+	(list (list (quote if) (list (quote nil?) rhs_expr) 2 1) (quote max) 0)))
 
 (define membership_count_expr (lambda (stage_alias ag)
 	(list (quote coalesceNil)
 		(list (quote get_column) stage_alias false (aggregate_col_name ag) false)
 		0)))
 
-(define in_membership_expr (lambda (probe match_alias match_ag null_alias null_ag)
+(define in_membership_expr (lambda (probe match_alias match_ag null_alias rhs_state_ag)
 	(begin
 		(define match_count (membership_count_expr match_alias match_ag))
-		(define null_count (membership_count_expr null_alias null_ag))
+		(define rhs_state (membership_count_expr null_alias rhs_state_ag))
 		(list (quote if)
 			(list (quote nil?) probe)
-			nil
+			(list (quote if) (list (quote >) rhs_state 0) nil false)
 			(list (quote if)
 				(list (quote >) match_count 0)
 				true
 				(list (quote if)
-					(list (quote >) null_count 0)
+					(list (quote equal??) rhs_state 2)
 					nil
 					false))))))
 
-(define not_in_membership_expr (lambda (probe match_alias match_ag null_alias null_ag)
+(define not_in_membership_expr (lambda (probe match_alias match_ag null_alias rhs_state_ag)
 	(begin
 		(define match_count (membership_count_expr match_alias match_ag))
-		(define null_count (membership_count_expr null_alias null_ag))
+		(define rhs_state (membership_count_expr null_alias rhs_state_ag))
 		(list (quote if)
 			(list (quote nil?) probe)
-			nil
+			(list (quote if) (list (quote >) rhs_state 0) nil true)
 			(list (quote if)
 				(list (quote >) match_count 0)
 				false
 				(list (quote if)
-					(list (quote >) null_count 0)
+					(list (quote equal??) rhs_state 2)
 					nil
 					true))))))
 
@@ -1594,7 +1595,7 @@ instead of capturing whichever session populated the carrier first. */
 		(define keys (list candidate_key))
 		(define stage_id (concat "in-candidate:" (fnv_hash (string (list probe inner)))))
 		(define null_stage_id (concat "in-candidate-null:" (fnv_hash (string inner))))
-		(define null_ag (in_null_count_descriptor candidate_key))
+		(define null_ag (in_rhs_state_descriptor candidate_key))
 		(define stage (make_group_stage
 			stage_id
 			union_input
@@ -1640,7 +1641,7 @@ instead of capturing whichever session populated the carrier first. */
 			stage_alias
 			(group_stage_schema stage)
 			(make_stage_output_relation stage_id)
-			false
+			(not semijoin_where)
 			(if semijoin_where
 				(make_positive_in_join_condition stage_alias key_names (list probe) probe aggregate_count_descriptor)
 				(make_exists_stage_join_condition stage_alias key_names (list probe)))))
@@ -1648,7 +1649,7 @@ instead of capturing whichever session populated the carrier first. */
 			null_stage_alias
 			(group_stage_schema null_stage)
 			(make_stage_output_relation null_stage_id)
-			false
+			true
 			true))
 		(if semijoin_where
 			(list true (list stage) (list source))
@@ -1710,7 +1711,7 @@ instead of capturing whichever session populated the carrier first. */
 				(qb_facts membership_inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
 		(define stage_id (concat "in:" (fnv_hash (string (list probe keys lookup_keys condition)))))
-		(define null_ag (in_null_count_descriptor rhs_expr))
+		(define null_ag (in_rhs_state_descriptor rhs_expr))
 		(define null_stage_id (concat "in-null:" (fnv_hash (string (list outer_domain condition rhs_expr)))))
 		(define stage (make_group_stage
 			stage_id
@@ -1760,7 +1761,7 @@ instead of capturing whichever session populated the carrier first. */
 			stage_alias
 			(group_stage_schema stage)
 			(make_stage_output_relation stage_id)
-			(if semijoin_where false (stage_source_outer? outer_sources))
+			(not semijoin_where)
 			(if semijoin_where
 				(make_positive_in_join_condition stage_alias key_names lookup_keys probe aggregate_count_descriptor)
 				(make_exists_stage_join_condition stage_alias key_names lookup_keys))))
@@ -1768,7 +1769,7 @@ instead of capturing whichever session populated the carrier first. */
 			null_stage_alias
 			(group_stage_schema null_stage)
 			(make_stage_output_relation null_stage_id)
-			(stage_source_outer? outer_sources)
+			true
 			(make_exists_stage_join_condition null_stage_alias null_key_names domain_lookup_keys)))
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
 		(if semijoin_where

--- a/tests/planner/subqueries/deep-correlation-membership.yaml
+++ b/tests/planner/subqueries/deep-correlation-membership.yaml
@@ -404,8 +404,6 @@ test_cases:
         - id: 2
 
   - name: "NOT IN with an empty correlated input is true"
-    noncritical: true
-    fail_comment: "a NULL probe against an empty subquery is TRUE, but the outer row is currently discarded"
     sql: |
       SELECT p.id
       FROM dcm_parent p
@@ -422,6 +420,65 @@ test_cases:
         - id: 3
         - id: 4
         - id: 5
+
+  - name: "NULL IN an empty correlated input is false"
+    sql: |
+      SELECT p.ref_id IN (
+        SELECT i.ref_id FROM dcm_item i
+        WHERE i.parent_id = p.id AND i.score > 100
+      ) AS matched
+      FROM dcm_parent p
+      WHERE p.id = 4
+    expect:
+      rows: 1
+      data:
+        - matched: false
+
+  - name: "NULL IN a nonempty correlated input is unknown"
+    sql: |
+      SELECT p.ref_id IN (
+        SELECT i.ref_id FROM dcm_item i
+        WHERE i.parent_id = 1
+      ) AS matched
+      FROM dcm_parent p
+      WHERE p.id = 4
+    expect:
+      rows: 1
+      data:
+        - matched: null
+
+  - name: "NULL IN an empty uncorrelated input is false"
+    sql: |
+      SELECT NULL IN (
+        SELECT i.ref_id FROM dcm_item i WHERE i.score > 100
+      ) AS matched
+    expect:
+      rows: 1
+      data:
+        - matched: false
+
+  - name: "NULL NOT IN an empty uncorrelated input is true"
+    sql: |
+      SELECT NULL NOT IN (
+        SELECT i.ref_id FROM dcm_item i WHERE i.score > 100
+      ) AS unmatched
+    expect:
+      rows: 1
+      data:
+        - unmatched: true
+
+  - name: "NULL NOT IN a nonempty correlated input is unknown"
+    sql: |
+      SELECT p.ref_id NOT IN (
+        SELECT i.ref_id FROM dcm_item i
+        WHERE i.parent_id = 1
+      ) AS unmatched
+      FROM dcm_parent p
+      WHERE p.id = 4
+    expect:
+      rows: 1
+      data:
+        - unmatched: null
 
   - name: "NOT IN with a NULL candidate remains unknown"
     sql: |


### PR DESCRIPTION
## Root cause

The membership stage only retained a count of RHS NULL values. For a NULL probe, that cannot distinguish an empty RHS from a nonempty RHS, so both `IN` and `NOT IN` returned UNKNOWN. Uncorrelated projected membership had a second issue: empty stage outputs were inner-joined and removed the scalar result row before three-valued logic was evaluated.

## Fix

- Encode the RHS state in the existing aggregate column: empty=0, nonempty=1, contains NULL=2.
- Keep projected membership stage sources row-preserving; positive WHERE semijoins remain inner.
- Preserve the existing logical group-stage / physical carrier boundary.
- Add critical correlated and uncorrelated SQL regressions for NULL probes over empty and nonempty RHS inputs.

The state uses one `MAX` aggregate and does not add a carrier column, another scan, or an additional aggregate pass.

## Correctness

Validated against base `48617c810`:

- `NULL IN empty` -> false
- `NULL NOT IN empty` -> true
- `NULL IN nonempty` -> NULL
- `NULL NOT IN nonempty` -> NULL
- existing match and RHS-NULL semantics remain unchanged

## A/B performance

Five paired runs of the unchanged 61-case `tests/planner/subqueries/in-subquery.yaml` suite on the same host:

| Run | master | branch |
|---:|---:|---:|
| 1 | 4.199s | 4.357s |
| 2 | 4.372s | 4.200s |
| 3 | 4.083s | 4.026s |
| 4 | 3.986s | 3.988s |
| 5 | 4.253s | 5.481s |
| Median | 4.199s | 4.200s |

Median delta is +0.001s (+0.02%), within measurement noise. The branch outlier is retained rather than discarded.

## Validation

- `python3 run_sql_tests.py tests/planner/subqueries/deep-correlation-membership.yaml`: 16/20 critical assertions pass; the remaining four failures are pre-existing and explicitly noncritical.
- `python3 run_sql_tests.py tests/planner/subqueries/in-subquery.yaml`: 61/61.
- `python3 run_sql_tests.py tests/planner/subqueries/not-in-operator.yaml`: 5/5.
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: green.
- `git diff --check`: green.
- Scheme lint reports only the pre-existing global parenthesis-depth warnings; no new formatter finding.