### PR TITLE
Keep scalar ORDER LIMIT inside scan pipelines

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -93,6 +93,19 @@ reordering. The same logical helper may lower to a group cache, direct scan,
 `scan_exists`, RecSet, ORC, `scan_order_multi`, or temp table depending on
 costs and semantics.
 
+## LIMIT Is A Scan Boundary
+
+Every physical operator that owns a SQL `LIMIT` must lower to `scan_order` or
+`scan_order_multi` with that limit. This also applies without an explicit
+`ORDER BY`, using an empty sort specification. A limited relational result must
+never be copied into a Scheme list or association structure for a later
+`sort`/`slice` step.
+
+Decorrelated helpers remain nested scans or independently prepared relational
+carriers. They must not replace the limited root scan with a complete lookup
+table. Projection-only helpers belong in the limited scan's map callback so
+rows rejected by filtering, ordering, offset, or limit never invoke them.
+
 ## No Subquery Fallback
 
 Every supported correlated subquery shape must be lowered through relational

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5437,6 +5437,65 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(merge (map direct_stages (lambda (nested_stage)
 			(get_assoc closure_index (logical_stage_key nested_stage))))))))))
 
+(define lower_scalar_query_point_probe (lambda (input value_expr keys lookup_keys)
+	(begin
+		(define sources (qb_sources input))
+		(if (not (and (single_source? sources) (source_is_base_table? (car sources))))
+			nil
+			(begin
+				(define src (car sources))
+				(define condition (combine_where (source_join_expr src) (coalesceNil (qb_where input) true)))
+				(define keycols (map keys (lambda (key) (direct_column_name_for_alias src key))))
+				(define valuecol (direct_column_name_for_alias src value_expr))
+				(define direct_keys (reduce keycols (lambda (ok col) (and ok (not (nil? col)))) true))
+				(if (and (equal? condition true)
+					(and direct_keys
+						(and (not (nil? valuecol))
+							(and (not (empty_list? keycols)) (equal? (count keycols) (count lookup_keys))))))
+					(list (quote scan_order_point)
+						'(session "__memcp_tx")
+						(source_table_expr src)
+						(quoted_runtime_list keycols)
+						(cons (quote list) lookup_keys)
+						valuecol)
+					nil))))))
+
+(define lower_direct_scalar_query_probe (lambda (input value_expr)
+	(begin
+		(define sources (qb_sources input))
+		(if (and (single_source? sources)
+			(and (source_is_base_table? (car sources))
+				(and (empty_list? (qb_stages input))
+					(and (empty_list? (qb_group input))
+						(and (nil? (qb_having input))
+							(and (empty_list? (qb_order input))
+								(and (nil? (qb_limit input)) (nil? (qb_offset input)))))))))
+			(begin
+				(define src (car sources))
+				(define condition (combine_where (source_join_expr src) (coalesceNil (qb_where input) true)))
+				(define filtercols (extract_columns_for_alias src condition))
+				(define mapcols (extract_columns_for_alias src value_expr))
+				(list (quote scan_order)
+					'(session "__memcp_tx")
+					(source_table_expr src)
+					(cons (quote list) filtercols)
+					(list (quote lambda)
+						(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
+						(list (quote optimize) (lower_column_expr_for_alias src condition)))
+					(quoted_runtime_list '())
+					(quoted_runtime_list '())
+					0
+					0
+					1
+					(cons (quote list) mapcols)
+					(list (quote lambda)
+						(map mapcols (lambda (col) (symbol (concat (source_alias src) "." col))))
+						(lower_column_expr_for_alias src value_expr))
+					(scalar_once_reduce_first)
+					nil
+					false))
+			nil))))
+
 (define lower_scalar_first_query_probe_expr_using (lambda (stage value_expr keys lookup_keys nested_stages prepare_stages)
 	(begin
 		(define input (gs_input stage))
@@ -5464,18 +5523,28 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(define prepared_input (if (empty_list? prepare_stages)
 			(query_block_with_stage_catalog raw_prepared_input '())
 			raw_prepared_input))
-		(define rows_plan (lower_query_block_as_dataset_rows prepared_input (list "__value" value_expr)))
-		(define probe_expr (list (quote scan)
-			'(session "__memcp_tx")
-			rows_plan
-			(quoted_runtime_list '())
-			(list (quote lambda) '() true)
-			(quoted_runtime_list '("__value"))
-			(list (quote lambda) (list (quote __value)) (quote __value))
-			(scalar_once_reduce_first)
-			nil
-			nil
-			false))
+		(define point_probe (lower_scalar_query_point_probe input value_expr keys lookup_keys))
+		(define direct_probe (if (not (nil? point_probe))
+			point_probe
+			(if (empty_list? prepare_stages)
+				(lower_direct_scalar_query_probe prepared_input value_expr)
+				nil)))
+		(define rows_plan (if (nil? direct_probe)
+			(lower_query_block_as_dataset_rows prepared_input (list "__value" value_expr))
+			nil))
+		(define probe_expr (if (nil? direct_probe)
+			(list (quote scan)
+				'(session "__memcp_tx")
+				rows_plan
+				(quoted_runtime_list '())
+				(list (quote lambda) '() true)
+				(quoted_runtime_list '("__value"))
+				(list (quote lambda) (list (quote __value)) (quote __value))
+				(scalar_once_reduce_first)
+				nil
+				nil
+				false)
+			direct_probe))
 		(if (or (not (empty_list? (qb_order input)))
 			(or (not (nil? (qb_limit input))) (not (nil? (qb_offset input)))))
 			(neumann_fail "build_queryplan" "scalar-first query probe cannot preserve nested ORDER/LIMIT yet")
@@ -5744,35 +5813,51 @@ dependency preparation does not emit free outer-row symbols. */
 				(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key))))
 			(begin
 				(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+				(define point_keycols (map keys (lambda (key) (direct_column_name_for_alias src key))))
+				(define point_valuecol (direct_column_name_for_alias src value_expr))
+				(define point_keys_direct (reduce point_keycols (lambda (ok col) (and ok (not (nil? col)))) true))
+				(define point_probe (and (equal? condition true)
+					(and (empty_list? order_exprs)
+						(and (equal? offset_value 0)
+							(and point_keys_direct
+								(and (not (nil? point_valuecol)) (not (empty_list? point_keycols))))))))
 				(define condition_cols (extract_columns_for_alias src condition))
 				(define key_cols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
 				(define order_cols (merge_unique (map order_exprs (lambda (expr) (extract_columns_for_alias src expr)))))
 				(define value_cols (extract_columns_for_alias src value_expr))
 				(define filtercols (merge_unique (list condition_cols key_cols order_cols)))
 				(define mapcols (merge_unique (list value_cols)))
-				(list (quote scan_order)
-					'(session "__memcp_tx")
-					(source_table_expr src)
-					(cons (quote list) filtercols)
-					(list (quote lambda)
-						(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
-						(list (quote optimize)
-							(cons (quote and)
-								(cons
-									(lower_column_expr_for_alias src condition)
-									(scalar_first_probe_key_terms sources default_alias src keys lookup_keys)))))
-					(cons (quote list) order_cols)
-					(cons (quote list) dirs)
-					0
-					(coalesceNil offset_value 0)
-					1
-					(cons (quote list) mapcols)
-					(list (quote lambda)
-						(map mapcols (lambda (col) (symbol (concat (source_alias src) "." col))))
-						(lower_column_expr_for_alias src value_expr))
-					(scalar_once_reduce_first)
-					nil
-					false)))))
+				(if point_probe
+					(list (quote scan_order_point)
+						'(session "__memcp_tx")
+						(source_table_expr src)
+						(quoted_runtime_list point_keycols)
+						(cons (quote list) (map lookup_keys (lambda (key)
+							(lower_column_expr_for_join sources default_alias key))))
+						point_valuecol)
+					(list (quote scan_order)
+						'(session "__memcp_tx")
+						(source_table_expr src)
+						(cons (quote list) filtercols)
+						(list (quote lambda)
+							(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
+							(list (quote optimize)
+								(cons (quote and)
+									(cons
+										(lower_column_expr_for_alias src condition)
+										(scalar_first_probe_key_terms sources default_alias src keys lookup_keys)))))
+						(cons (quote list) order_cols)
+						(cons (quote list) dirs)
+						0
+						(coalesceNil offset_value 0)
+						1
+						(cons (quote list) mapcols)
+						(list (quote lambda)
+							(map mapcols (lambda (col) (symbol (concat (source_alias src) "." col))))
+							(lower_column_expr_for_alias src value_expr))
+						(scalar_once_reduce_first)
+						nil
+						false))))))
 )
 
 (define lower_scalar_aggregate_probe_expr (lambda (sources default_alias stage requested_col)
@@ -5951,8 +6036,50 @@ dependency preparation does not emit free outer-row symbols. */
 	(scan_order_sort_callback_symbols driver_cols '()
 		(lower_column_expr_for_alias src expr))))
 
+(define scalar_point_sort_descriptor (lambda (driver_src stage requested_col)
+	(begin
+		(define ag (scalar_first_probe_aggregate stage requested_col))
+		(define parts (if (nil? ag) nil (scalar_first_probe_parts ag)))
+		(define inner_src (gs_input stage))
+		(define keys (gs_keys stage))
+		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(define condition (qassoc_get (gs_facts stage) (quote condition) true))
+		(if (or (nil? parts) (not (source_is_base_table? inner_src)))
+			nil
+			(begin
+				(define inner_cols (map keys (lambda (key) (direct_column_name_for_alias inner_src key))))
+				(define outer_cols (map lookup_keys (lambda (key) (direct_column_name_for_alias driver_src key))))
+				(define value_col (direct_column_name_for_alias inner_src (nth parts 0)))
+				(define direct (reduce (merge (list inner_cols outer_cols (list value_col)))
+					(lambda (ok col) (and ok (not (nil? col)))) true))
+				(if (and direct
+					(and (equal? condition true)
+						(and (empty_list? (nth parts 1))
+							(and (equal? (nth parts 3) 0)
+								(and (not (empty_list? keys)) (equal? (count keys) (count lookup_keys)))))))
+					(list (quote list)
+						(list (quote quote) (quote scan_order_point))
+						(source_table_expr inner_src)
+						(quoted_runtime_list inner_cols)
+						(quoted_runtime_list outer_cols)
+						value_col)
+					nil))))))
+
 (define scan_order_sort_column_for_alias (lambda (src expr)
 	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(coalesceNil (scalar_point_sort_descriptor src stage requested_col)
+			(begin
+				(define cols (extract_columns_for_alias src expr))
+				(list (quote lambda)
+					(map cols (lambda (col) (symbol col)))
+					(lower_scan_order_sort_expr_for_alias src cols expr))))
+		((symbol scalar_first_probe) stage requested_col _stages)
+		(scan_order_sort_column_for_alias src (list (quote scalar_first_probe) stage requested_col))
+		((quote scalar_first_probe) stage requested_col)
+		(scan_order_sort_column_for_alias src (list (quote scalar_first_probe) stage requested_col))
+		((quote scalar_first_probe) stage requested_col _stages)
+		(scan_order_sort_column_for_alias src (list (quote scalar_first_probe) stage requested_col))
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
 			(resolve_physical_column_name src col col_ignorecase)
 			(neumann_fail "build_queryplan" "ORDER BY references a different source"))
@@ -8550,8 +8677,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(source_alias (nth order_lookup 0))))
 		(define probe_sources (if (nil? retained_order_alias)
 			probe_candidates
-			(filter probe_candidates (lambda (src)
-				(not (equal? retained_order_alias (source_alias src)))))))
+			(merge_unique (list probe_candidates (list (nth order_lookup 0))))))
 		(define probe_index (probe_stage_alias_index stages probe_sources))
 		(define rewritten_sources (rewrite_scalar_first_probe_sources_using_index stages sources probe_index default_alias))
 		(make_query_block
@@ -10714,11 +10840,6 @@ source remain residual so they observe the null-extended row. */
 					_ nil)))
 			'()))))
 
-(define scalar_order_lookup_key_expr (lambda (key_exprs)
-	(if (equal? (count key_exprs) 1)
-		(car key_exprs)
-		(cons (quote list) key_exprs))))
-
 (define scalar_order_lookup_stage? (lambda (stage requested_col)
 	(if (or (nil? requested_col)
 		(or (not (group_stage? stage))
@@ -10778,63 +10899,6 @@ source remain residual so they observe the null-extended row. */
 			source_lookup
 			(scalar_order_lookup_marker (order_exprs order_items) nil)))))
 
-(define rewrite_scalar_order_lookup_expr (lambda (sources default_alias lookup_alias lookup_expr requested_col expr)
-	(match expr
-		((symbol scalar_first_probe) _stage col)
-		(if (equal?? col requested_col) lookup_expr expr)
-		((quote scalar_first_probe) _stage col)
-		(if (equal?? col requested_col) lookup_expr expr)
-		((symbol scalar_first_probe) _stage col _stages)
-		(if (equal?? col requested_col) lookup_expr expr)
-		((quote scalar_first_probe) _stage col _stages)
-		(if (equal?? col requested_col) lookup_expr expr)
-		((symbol get_column) tblvar tbl_ignorecase col _col_ignorecase)
-		(if (and (equal?? (resolve_column_alias tblvar default_alias) lookup_alias)
-			(equal?? col requested_col))
-			lookup_expr
-			expr)
-		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
-		(rewrite_scalar_order_lookup_expr sources default_alias lookup_alias lookup_expr requested_col
-			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
-		(cons head tail) (cons head (map tail (lambda (item)
-			(rewrite_scalar_order_lookup_expr sources default_alias lookup_alias lookup_expr requested_col item))))
-		_ expr)))
-
-(define scalar_order_lookup_plan (lambda (stage requested_col)
-	(begin
-		(define input_src (gs_input stage))
-		(define keys (scalar_order_lookup_input_keys stage))
-		(define ag (scalar_first_probe_aggregate stage requested_col))
-		(define value_expr (nth (scalar_first_probe_parts ag) 0))
-		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-		(define keycols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias input_src expr)))))
-		(define valuecols (extract_columns_for_alias input_src value_expr))
-		(define filtercols (merge_unique (list keycols (extract_columns_for_alias input_src condition))))
-		(define mapcols (merge_unique (list keycols valuecols)))
-		(list (quote scan)
-			'(session "__memcp_tx")
-			(source_table_expr input_src)
-			(cons (quote list) filtercols)
-			(list (quote lambda)
-				(map filtercols (lambda (col) (symbol (concat (source_alias input_src) "." col))))
-				(list (quote optimize) (lower_column_expr_for_alias input_src condition)))
-			(cons (quote list) mapcols)
-			(list (quote lambda)
-				(map mapcols (lambda (col) (symbol (concat (source_alias input_src) "." col))))
-				(list (quote list)
-					(scalar_order_lookup_key_expr
-						(map keys (lambda (expr) (lower_column_expr_for_alias input_src expr))))
-					(lower_column_expr_for_alias input_src value_expr)))
-			(list (quote lambda) (list (quote acc) (quote rowvals))
-				(list (quote set_assoc)
-					(quote acc)
-					(list (quote car) (quote rowvals))
-					(list (quote cadr) (quote rowvals))))
-			(quoted_runtime_list '())
-			(list (quote lambda) (list (quote acc) (quote grouped))
-				(list (quote merge_assoc_mut) (quote acc) (quote grouped)))
-			false))))
-
 (define lower_multi_source_query_block (lambda (block)
 	(begin
 		(define fields (expand_query_block_fields (qb_sources block) (qb_fields block)))
@@ -10854,38 +10918,8 @@ source remain residual so they observe the null-extended row. */
 					sources))
 				(define final_condition (if push_first_where true where_expr))
 				(define stage_catalog (query_block_stage_catalog block))
-				(define stage_lookup (query_block_stage_lookup block))
-				(define raw_order_items (coalesceNil (qb_order block) '()))
-				(define order_lookup (scalar_order_lookup_source stage_lookup raw_scan_sources first_alias raw_order_items))
-				(define order_lookup_src (if (nil? order_lookup) nil (nth order_lookup 0)))
-				(define order_lookup_stage (if (nil? order_lookup) nil (nth order_lookup 1)))
-				(define order_lookup_col (if (nil? order_lookup) nil (nth order_lookup 2)))
-				(define order_lookup_var (symbol "__scalar_order_lookup"))
-				(define order_lookup_key_exprs (if (nil? order_lookup)
-					'()
-					(qassoc_get (gs_facts order_lookup_stage) (quote lookup-keys) '())))
-				(define order_lookup_key (if (nil? order_lookup)
-					nil
-					(scalar_order_lookup_key_expr (map
-						order_lookup_key_exprs
-						(lambda (key) (lower_column_expr_for_join raw_scan_sources first_alias key))))))
-				(define order_lookup_expr (if (nil? order_lookup)
-					nil
-					(list (quote get_assoc) order_lookup_var order_lookup_key)))
-				(define scan_sources (if (or (nil? order_lookup) (nil? order_lookup_src))
-					raw_scan_sources
-					(filter raw_scan_sources (lambda (src)
-						(not (equal? (source_alias src) (source_alias order_lookup_src)))))))
-				(define order_items (if (nil? order_lookup)
-					raw_order_items
-					(map raw_order_items (lambda (item)
-						(match item
-							'(expr dir) (list
-								(rewrite_scalar_order_lookup_expr raw_scan_sources first_alias
-									(if (nil? order_lookup_src) nil (source_alias order_lookup_src))
-									order_lookup_expr order_lookup_col expr)
-								dir)
-							_ item)))))
+				(define scan_sources raw_scan_sources)
+				(define order_items (coalesceNil (qb_order block) '()))
 				(define direct_order (and (equal? first_alias (source_alias (car scan_sources)))
 					(order_items_belong_to_source? (car scan_sources) order_items)))
 				(define direct_order_safe (and direct_order
@@ -10896,7 +10930,6 @@ source remain residual so they observe the null-extended row. */
 					(extract_assoc fields (lambda (_title expr) expr))
 					(list final_condition)
 					(order_exprs order_items)
-					order_lookup_key_exprs
 					(source_join_exprs scan_sources))))
 				(define prelimit_sources
 					(prelimit_sources_for scan_sources first_alias final_condition order_items))
@@ -10911,14 +10944,12 @@ source remain residual so they observe the null-extended row. */
 						(define project_needed_exprs (merge (list
 							(extract_assoc fields (lambda (_title expr) expr))
 							(order_exprs order_items)
-							order_lookup_key_exprs
 							(source_join_exprs scan_sources))))
 						(define project_column_recipe (join_column_recipe scan_sources first_alias project_needed_exprs))
 						(define driver_cols (qassoc_get project_column_recipe first_alias '()))
 						(define driver_needed_exprs (merge (list
 							(list final_condition)
 							(order_exprs order_items)
-							order_lookup_key_exprs
 							(map driver_cols (lambda (col)
 								(list (quote get_column) first_alias false col false))))))
 						(define project_dependency_graph (stage_dependency_graph stage_catalog))
@@ -10999,11 +11030,7 @@ source remain residual so they observe the null-extended row. */
 								order_items
 								(qb_offset block)
 								(qb_limit block))))))
-				(if (nil? order_lookup)
-					lowered_plan
-					(list
-						(list (quote lambda) (list order_lookup_var) lowered_plan)
-						(scalar_order_lookup_plan order_lookup_stage order_lookup_col)))
+				lowered_plan
 )))))
 
 (define lower_zero_source_query_block (lambda (block)

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1025,6 +1025,14 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 
 func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
 	result := &shardqueue{shard: t}
+	defer func() {
+		if r := recover(); r != nil {
+			for _, release := range result.releases {
+				release()
+			}
+			panic(r)
+		}
+	}()
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -1038,6 +1046,31 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 
 	result.scols = make([]func(uint32) scm.Scmer, len(sortcols))
 	for i, scol := range sortcols {
+		if descriptor, ok := scmerSlice(scol); ok && len(descriptor) == 5 && scanSymbolIs(descriptor[0], "scan_order_point") {
+			innerTable := TableFromScmer(descriptor[1])
+			keyCols := scmerSliceToStrings(mustScmerSlice(descriptor[2], "scan_order_point key columns"))
+			outerCols := scmerSliceToStrings(mustScmerSlice(descriptor[3], "scan_order_point outer columns"))
+			valueCol := scm.String(descriptor[4])
+			outerReaders := make([]func(uint32) scm.Scmer, len(outerCols))
+			for j, col := range outerCols {
+				outerReaders[j] = t.ColumnReaderTx(currentTx, col)
+			}
+			pointReader, release, prepared := innerTable.preparePointValueReader(keyCols, valueCol, currentTx)
+			if prepared {
+				result.releases = append(result.releases, release)
+			}
+			result.scols[i] = func(idx uint32) scm.Scmer {
+				values := make([]scm.Scmer, len(outerReaders))
+				for j, reader := range outerReaders {
+					values[j] = reader(idx)
+				}
+				if prepared {
+					return pointReader.Lookup(values)
+				}
+				return innerTable.scanOrderPointValue(currentTx, keyCols, values, valueCol)
+			}
+			continue
+		}
 		if scol.IsString() {
 			result.scols[i] = t.ColumnReaderTx(currentTx, scol.String())
 			continue

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -634,6 +634,11 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 }
 
 func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool, recsetFilter *recSet) bool {
+	_, found := t.scanFirstRecord(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, stop, recsetFilter)
+	return found
+}
+
+func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool, recsetFilter *recSet) (uint32, bool) {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -646,7 +651,7 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	if recsetFilter != nil {
 		recsetPart = recsetFilter.shardEntry(t)
 		if recsetPart == nil || recsetPart.count == 0 {
-			return false
+			return 0, false
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
@@ -697,6 +702,7 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	maxInsertIndex := len(t.inserts)
 	visibleUpper := mainCount + uint32(maxInsertIndex)
 	found := false
+	var foundID uint32
 
 	var buf [8]uint32
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
@@ -742,13 +748,14 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 			}
 			if scm.ToBool(conditionFn(cdataset...)) {
 				found = true
+				foundID = idx
 				return false
 			}
 		}
 		return true
 	})
 
-	return found
+	return foundID, found
 }
 
 func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (scm.Scmer, int64, int64) {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -123,6 +123,132 @@ type shardqueue struct {
 	callbackCols   []string  // per-table map columns (for multi-table merge)
 	callback       scm.Scmer // per-table map function (for multi-table merge)
 	tableIdx       int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
+	releases       []func()
+}
+
+type preparedPointValueReader struct {
+	shard       *storageShard
+	keyCols     []string
+	keyStorages []ColumnStorage
+	valueCol    string
+	valueReader ColumnReader
+	currentTx   *TxContext
+}
+
+func (t *table) preparePointValueReader(keyCols []string, valueCol string, currentTx *TxContext) (*preparedPointValueReader, func(), bool) {
+	t.shardModeMu.RLock()
+	if t.ShardMode != ShardModeFree {
+		t.shardModeMu.RUnlock()
+		return nil, nil, false
+	}
+	var shard *storageShard
+	for _, candidate := range t.Shards {
+		if candidate == nil {
+			continue
+		}
+		if shard != nil {
+			t.shardModeMu.RUnlock()
+			return nil, nil, false
+		}
+		shard = candidate
+	}
+	if shard == nil {
+		t.shardModeMu.RUnlock()
+		return nil, nil, false
+	}
+	shard.activeScanners.Add(1)
+	t.shardModeMu.RUnlock()
+	releaseRead := shard.GetRead()
+	release := func() {
+		releaseRead()
+		shard.activeScanners.Add(-1)
+	}
+	prepared := false
+	defer func() {
+		if !prepared {
+			release()
+		}
+	}()
+
+	shard.ensureMainCount(false)
+	keyStorages := make([]ColumnStorage, len(keyCols))
+	for i, col := range keyCols {
+		keyStorages[i] = shard.getColumnStorageOrPanic(col)
+	}
+	valueStorage := shard.getColumnStorageOrPanic(valueCol)
+	reader := &preparedPointValueReader{
+		shard:       shard,
+		keyCols:     keyCols,
+		keyStorages: keyStorages,
+		valueCol:    valueCol,
+		valueReader: newCachedColumnReaderTx(valueStorage, currentTx),
+		currentTx:   currentTx,
+	}
+	prepared = true
+	return reader, release, true
+}
+
+func (r *preparedPointValueReader) Lookup(values []scm.Scmer) scm.Scmer {
+	if len(values) != len(r.keyCols) {
+		return scm.NewNil()
+	}
+	bounds := make(boundaries, len(r.keyCols))
+	for i, col := range r.keyCols {
+		bounds[i] = columnboundaries{col: col, matcher: EqualMatcher, lower: values[i], lowerInclusive: true, upper: values[i], upperInclusive: true}
+	}
+	lower, upperLast := indexFromBoundaries(bounds)
+
+	r.shard.mu.RLock()
+	defer r.shard.mu.RUnlock()
+	mainCount := r.shard.main_count
+	maxInsertIndex := len(r.shard.inserts)
+	visibleUpper := mainCount + uint32(maxInsertIndex)
+	acidMode := r.currentTx != nil && r.currentTx.Mode == TxACID
+	var result scm.Scmer
+	found := false
+	var buf [8]uint32
+	r.shard.iterateIndex(r.currentTx, bounds, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		for _, recid := range batch {
+			if recid >= visibleUpper {
+				continue
+			}
+			if acidMode {
+				if !r.currentTx.IsVisible(r.shard, recid) {
+					continue
+				}
+			} else if r.shard.deletions.Get(uint(recid)) {
+				continue
+			}
+			matched := true
+			for i, expected := range values {
+				var actual scm.Scmer
+				if recid < mainCount {
+					actual = r.keyStorages[i].GetValue(recid)
+				} else {
+					actual = r.shard.getDelta(int(recid-mainCount), r.keyCols[i])
+				}
+				if !scm.Equal(actual, expected) {
+					matched = false
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			if recid < mainCount {
+				result = r.valueReader.GetValue(recid)
+			} else {
+				result = r.shard.getDelta(int(recid-mainCount), r.valueCol)
+			}
+			found = true
+			return false
+		}
+		return true
+	})
+	if !found {
+		return scm.NewNil()
+	}
+	return result
 }
 
 // scanOrderResult bundles per-shard outputs for ordered scans.
@@ -638,6 +764,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 	// Collect shard results into globalqueue
 	var scanErr scanError
+	var scanQueues []*shardqueue
 	for msg := range q_ {
 		if msg.err.r != nil {
 			if scanErr.r == nil {
@@ -648,8 +775,11 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		if scanErr.r != nil {
 			continue
 		}
-		if msg.res != nil && len(msg.res.items) > 0 {
-			heap.Push(&q, msg.res)
+		if msg.res != nil {
+			scanQueues = append(scanQueues, msg.res)
+			if len(msg.res.items) > 0 {
+				heap.Push(&q, msg.res)
+			}
 		}
 		if msg.res != nil && msg.res.tableIdx >= 0 && msg.res.tableIdx < len(stats) {
 			tableStats := &stats[msg.res.tableIdx]
@@ -658,6 +788,13 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			tableStats.outputCount += msg.outputCount
 		}
 	}
+	defer func() {
+		for _, queue := range scanQueues {
+			for _, release := range queue.releases {
+				release()
+			}
+		}
+	}()
 	if scanErr.r != nil {
 		panic(scanErr)
 	}
@@ -852,6 +989,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 // scan_order delegates to scanOrderMulti with a single-element table spec.
 func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+	if len(sortcols) == 0 && limitPartitionCols == 0 && offset == 0 && limit == 1 && !aggregate.IsNil() && !isOuter {
+		return t.scanOrderFirst(currentTx, conditionCols, condition, callbackCols, callback, aggregate, neutral)
+	}
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
 		table:          t,
 		conditionCols:  conditionCols,
@@ -862,6 +1002,109 @@ func (t *table) scan_order(currentTx *TxContext, conditionCols []string, conditi
 		perTableOffset: -1,
 		perTableLimit:  -1,
 	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter)
+}
+
+// scanOrderFirst is the no-order LIMIT 1 specialization of scan_order. It
+// preserves the scan operator contract while avoiding the queues, channels,
+// and global merge needed by the general ordered multi-shard implementation.
+func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer) scm.Scmer {
+	ss := SessionStateFromTx(currentTx)
+	querySeq := scm.CurrentQuerySeq()
+	bounds := extractBoundaries(conditionCols, condition)
+	bounds, recsetFilter := splitRecSetBoundary(bounds, t)
+	reorderByFrequency(bounds, t)
+	lower, upperLast := indexFromBoundaries(bounds)
+
+	var mu sync.Mutex
+	var foundShard *storageShard
+	var foundID uint32
+	var firstErr scanError
+	done := t.iterateShardsParallel(bounds, func(shard *storageShard, _ bool) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				mu.Lock()
+				if firstErr.r == nil {
+					firstErr = scanError{recovered, string(debug.Stack())}
+				}
+				mu.Unlock()
+			}
+		}()
+		mu.Lock()
+		finished := foundShard != nil || firstErr.r != nil
+		mu.Unlock()
+		if finished {
+			return
+		}
+		if ss != nil && ss.IsKilledSeq(querySeq) {
+			panic("query killed")
+		}
+		recid, present := shard.scanFirstRecord(bounds, lower, upperLast, conditionCols, condition, currentTx, ss, nil, recsetFilter)
+		if !present {
+			return
+		}
+		mu.Lock()
+		if foundShard == nil {
+			foundShard = shard
+			foundID = recid
+		}
+		mu.Unlock()
+	})
+	if done != nil {
+		<-done
+	}
+	if firstErr.r != nil {
+		panic(firstErr)
+	}
+	if foundShard == nil {
+		return neutral
+	}
+	mapper := foundShard.OpenMapReducer(callbackCols, callback, aggregate, false, 0, nil, currentTx)
+	result := mapper.Stream(neutral, []uint32{foundID}, nil)
+	mapper.FlushSideEffects()
+	return result
+}
+
+func (t *table) scanOrderPointValue(currentTx *TxContext, keyCols []string, keyValues []scm.Scmer, valueCol string) scm.Scmer {
+	if len(keyCols) == 0 || len(keyCols) != len(keyValues) {
+		return scm.NewNil()
+	}
+	bounds := make(boundaries, len(keyCols))
+	for i, col := range keyCols {
+		bounds[i] = columnboundaries{col: col, matcher: EqualMatcher, lower: keyValues[i], lowerInclusive: true, upper: keyValues[i], upperInclusive: true}
+	}
+
+	var mu sync.Mutex
+	var value scm.Scmer
+	found := false
+	done := t.iterateShardsParallel(bounds, func(shard *storageShard, _ bool) {
+		mu.Lock()
+		finished := found
+		mu.Unlock()
+		if finished {
+			return
+		}
+		recid, present := shard.GetRecordidForUnique(keyCols, keyValues, currentTx)
+		if !present {
+			return
+		}
+		reader := shard.ColumnReaderTx(currentTx, valueCol)
+		shard.mu.RLock()
+		candidate := reader(recid)
+		shard.mu.RUnlock()
+		mu.Lock()
+		if !found {
+			value = candidate
+			found = true
+		}
+		mu.Unlock()
+	})
+	if done != nil {
+		<-done
+	}
+	if !found {
+		return scm.NewNil()
+	}
+	return value
 }
 
 func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
@@ -901,6 +1144,14 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, orderedEarlyLimit bool, recsetFilter *recSet) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
+	defer func() {
+		if r := recover(); r != nil {
+			for _, release := range result.releases {
+				release()
+			}
+			panic(r)
+		}
+	}()
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -931,6 +1182,31 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	// prepare sort criteria so they can be queried easily
 	result.scols = make([]func(uint32) scm.Scmer, len(sortcols))
 	for i, scol := range sortcols {
+		if descriptor, ok := scmerSlice(scol); ok && len(descriptor) == 5 && scanSymbolIs(descriptor[0], "scan_order_point") {
+			innerTable := TableFromScmer(descriptor[1])
+			keyCols := scmerSliceToStrings(mustScmerSlice(descriptor[2], "scan_order_point key columns"))
+			outerCols := scmerSliceToStrings(mustScmerSlice(descriptor[3], "scan_order_point outer columns"))
+			valueCol := scm.String(descriptor[4])
+			outerReaders := make([]func(uint32) scm.Scmer, len(outerCols))
+			for j, col := range outerCols {
+				outerReaders[j] = t.ColumnReaderTx(currentTx, col)
+			}
+			pointReader, release, prepared := innerTable.preparePointValueReader(keyCols, valueCol, currentTx)
+			if prepared {
+				result.releases = append(result.releases, release)
+			}
+			result.scols[i] = func(idx uint32) scm.Scmer {
+				values := make([]scm.Scmer, len(outerReaders))
+				for j, reader := range outerReaders {
+					values[j] = reader(idx)
+				}
+				if prepared {
+					return pointReader.Lookup(values)
+				}
+				return innerTable.scanOrderPointValue(currentTx, keyCols, values, valueCol)
+			}
+			continue
+		}
 		if scol.IsString() {
 			colname := scol.String()
 			result.scols[i] = t.ColumnReaderTx(currentTx, colname)
@@ -1175,6 +1451,21 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	itemPos := make(map[uint32]int, len(result.items))
 	for i, idx := range result.items {
 		itemPos[idx] = i
+	}
+	// Computed sort callbacks may contain nested point scans. Evaluate each key
+	// once per candidate instead of repeating the callback for every comparison.
+	// The cache is local to this physical scan and is released with its queue.
+	for c, sortcol := range sortcols {
+		if sortcol.IsString() {
+			continue
+		}
+		values := make([]scm.Scmer, len(result.items))
+		for i, idx := range result.items {
+			values[i] = result.scols[c](idx)
+		}
+		result.scols[c] = func(idx uint32) scm.Scmer {
+			return values[itemPos[idx]]
+		}
 	}
 	lessByID := func(a, b uint32) bool {
 		cmpCount := len(result.scols)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -853,6 +853,27 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "scan_order_point",
+		Desc: "specialized scan_order LIMIT 1 equality probe returning one column",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			currentTx := scmerToTxContext(a[0])
+			t := TableFromScmer(a[1])
+			keyCols := scmerSliceToStrings(mustScmerSlice(a[2], "keyColumns"))
+			keyValues := mustScmerSlice(a[3], "keyValues")
+			return t.scanOrderPointValue(currentTx, keyCols, keyValues, scm.String(a[4]))
+		},
+		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", ParamName: "tx"},
+				{Kind: "table", ParamName: "table"},
+				{Kind: "list", ParamName: "keyColumns"},
+				{Kind: "list", ParamName: "keyValues"},
+				{Kind: "string", ParamName: "valueColumn"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "any"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_order",
 		Desc: "does an ordered parallel filter and serial map-reduce pass on a single table and returns the reduced result",
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/tests/performance/unselective-scalar-order-limit.yaml
+++ b/tests/performance/unselective-scalar-order-limit.yaml
@@ -33,7 +33,7 @@ setup:
   - sql: "CREATE TABLE usol_file_multi (bucket INT, id INT, uploaded_at INT)"
   - sql: "INSERT INTO usol_parent VALUES (1, 7, 10), (2, 8, 20)"
   - sql: "INSERT INTO usol_assignment VALUES (1, 10, 7), (2, 20, 8)"
-  - sql: "INSERT INTO usol_item_multi VALUES (1, 1, 1), (2, 2, 1), (3, 1, 2), (4, 2, 2)"
+  - sql: "INSERT INTO usol_item_multi VALUES (1, 1, 1), (2, 2, 1), (3, 1, 2), (4, 2, 2), (5, 3, 1)"
   - scm: |
       (begin
         (insert (table "memcp-tests" "usol_item") '("id" "parent_id" "file_id")
@@ -50,6 +50,28 @@ setup:
         20000)
 
 test_cases:
+  - name: "Scalar ORDER LIMIT stays inside ordered scan pipelines"
+    sql: |
+      EXPLAIN
+      SELECT projected.id
+      FROM (
+        SELECT item.id, item.file_id
+        FROM usol_item item
+      ) projected
+      ORDER BY (
+        SELECT file.uploaded_at FROM usol_file file
+        WHERE file.id = projected.file_id LIMIT 1
+      ) DESC, projected.id DESC
+      LIMIT 3
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "scan_order_point"
+      result_not_contains:
+        - "__scalar_order_lookup"
+        - "(sort rows"
+
   - name: "Unselective scalar ORDER LIMIT defers nested access projections"
     max_time: 1.5
     max_plan_size: 100000
@@ -140,6 +162,32 @@ test_cases:
       data:
         - id: 4
         - id: 3
+
+  - name: "Scalar ORDER keeps ties stable and missing LEFT values last"
+    setup:
+      - "UPDATE usol_file_multi SET uploaded_at = 25 WHERE bucket = 1 AND id = 2"
+    cleanup:
+      - "UPDATE usol_file_multi SET uploaded_at = 20 WHERE bucket = 1 AND id = 2"
+    sql: |
+      SELECT projected.id
+      FROM (
+        SELECT item.id, item.bucket, item.file_id
+        FROM usol_item_multi item
+      ) projected
+      ORDER BY (
+        SELECT file.uploaded_at FROM usol_file_multi file
+        WHERE file.bucket = projected.bucket AND file.id = projected.file_id
+        LIMIT 1
+      ) DESC, projected.id DESC
+      LIMIT 5
+    expect:
+      rows: 5
+      data:
+        - id: 4
+        - id: 3
+        - id: 2
+        - id: 1
+        - id: 5
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS usol_item"


### PR DESCRIPTION
## Root cause

A decorrelated scalar used by `ORDER BY ... LIMIT` was lowered into a complete Scheme association lookup before the root scan. The root then probed that materialized result for every candidate. This ignored the LIMIT as the physical scan boundary and made an unselective list query pay for the complete inner result.

## Changes

- consume the decorrelated ORDER carrier in the root ordered scan instead of emitting `__scalar_order_lookup`
- lower simple equality scalar keys to a `scan_order_point` sort descriptor
- bind the inner shard/column readers once and cache each computed sort value once per candidate
- keep LIMIT 1 probes in the `scan_order` operator family, including the no-ORDER specialization
- support the same descriptor for table and RecSet ordered scans
- document the invariant that limited relational results may not be materialized into Scheme lists/associations
- add physical-plan and result regressions for composite keys, ties, and missing LEFT-side values

## A/B against current master

Same generated 20k-row payload, same query, one warmup plus 9 measured warm runs per binary:

| revision | median | min | max | EXPLAIN bytes | plan marker |
|---|---:|---:|---:|---:|---|
| master `eff27268f` | 623.599 ms | 602.972 ms | 641.186 ms | 6212 | `__scalar_order_lookup` |
| PR `5f0b312c2` | 64.672 ms | 57.660 ms | 70.010 ms | 686 | `scan_order_point` |

Median speedup: **9.64x**. The PR plan has no `__scalar_order_lookup` and no Scheme `(sort rows ...)`.

## Validation

- full `./git-pre-commit`: all critical tests passed
- focused scalar ORDER LIMIT suite: 4/4
- session-keyed traced late-projection suite: 11/11
- derived scalar LIMIT suite: 24/24
- composed scalar aggregate suite: 19/19
- ordinary non-coverage 200k multi-shard ORDER suite: 19/19, 1.84 s total on both master and PR

`make test` with Go coverage instrumentation completed all functional tests twice; its unrelated existing 5 s multi-shard ORDER performance gate measured 5.065 s and 5.007 s. The identical uninstrumented hook-equivalent run passed without changing that gate.