### PR TITLE
Reuse numbered-only lambda analysis in serial adapters

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -160,22 +160,25 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	if params.IsSlice() {
 		paramSlice := params.Slice()
 		if p.NumVars > 0 {
-			named := make(map[Symbol]struct{}, len(paramSlice))
-			for i, param := range paramSlice {
-				if i >= p.NumVars {
-					break
+			bindNamed := false
+			if !p.NumberedOnly {
+				named := make(map[Symbol]struct{}, len(paramSlice))
+				for i, param := range paramSlice {
+					if i >= p.NumVars {
+						break
+					}
+					if stripped, ok := scmerStripSourceInfo(param); ok {
+						param = stripped
+					}
+					if param.IsSymbol() && !param.SymbolEquals("_") {
+						named[mustSymbol(param)] = struct{}{}
+					}
 				}
-				if stripped, ok := scmerStripSourceInfo(param); ok {
-					param = stripped
+				bindNamed = procBodyUsesNamedParam(p.Body, named)
+				if bindNamed {
+					vars = make(Vars, len(named))
+					en.Vars = vars
 				}
-				if param.IsSymbol() && !param.SymbolEquals("_") {
-					named[mustSymbol(param)] = struct{}{}
-				}
-			}
-			bindNamed := procBodyUsesNamedParam(p.Body, named)
-			if bindNamed {
-				vars = make(Vars, len(named))
-				en.Vars = vars
 			}
 			return func(args ...Scmer) Scmer {
 				for i := 0; i < p.NumVars; i++ {
@@ -227,10 +230,13 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	if params.IsSymbol() {
 		sym := mustSymbol(params)
 		if p.NumVars > 0 {
-			bindNamed := procBodyUsesNamedParam(p.Body, map[Symbol]struct{}{sym: {}})
-			if bindNamed {
-				vars = make(Vars, 1)
-				en.Vars = vars
+			bindNamed := false
+			if !p.NumberedOnly {
+				bindNamed = procBodyUsesNamedParam(p.Body, map[Symbol]struct{}{sym: {}})
+				if bindNamed {
+					vars = make(Vars, 1)
+					en.Vars = vars
+				}
 			}
 			return func(args ...Scmer) Scmer {
 				argsList := NewSlice(args)

--- a/scm/optimizer_explicit_numvars_test.go
+++ b/scm/optimizer_explicit_numvars_test.go
@@ -18,6 +18,32 @@ package scm
 
 import "testing"
 
+func TestOptimizeProcToSerialFunctionUsesNumberedFixedParams(t *testing.T) {
+	lambda := Eval(Optimize(Read("test", "(lambda (value) (+ value value))"), &Globalenv), &Globalenv)
+	if !lambda.Proc().NumberedOnly {
+		t.Fatal("expected optimized lambda to use numbered bindings only")
+	}
+	got := OptimizeProcToSerialFunction(lambda)(NewInt(6))
+	if ToInt(got) != 12 {
+		t.Fatalf("expected numbered callback result 12, got %v", got)
+	}
+}
+
+func TestOptimizeProcToSerialFunctionUsesNumberedVariadicParam(t *testing.T) {
+	lambda := NewProcStruct(Proc{
+		Params:       NewSymbol("values"),
+		Body:         NewSlice([]Scmer{NewSymbol("list"), NewNthLocalVar(0)}),
+		En:           &Globalenv,
+		NumVars:      1,
+		NumberedOnly: true,
+	})
+	got := OptimizeProcToSerialFunction(lambda)(NewInt(3), NewInt(4))
+	want := NewSlice([]Scmer{NewSlice([]Scmer{NewInt(3), NewInt(4)})})
+	if !Equal(got, want) {
+		t.Fatalf("expected numbered variadic callback result %v, got %v", want, got)
+	}
+}
+
 func TestOptimizeProcToSerialFunctionExplicitNumVarsKeepsNamedParamBinding(t *testing.T) {
 	lambda := Eval(Read("test", "(lambda ($update) ($update) 1)"), &Globalenv)
 	called := false
@@ -31,5 +57,38 @@ func TestOptimizeProcToSerialFunctionExplicitNumVarsKeepsNamedParamBinding(t *te
 	}
 	if ToInt(got) != 7 {
 		t.Fatalf("expected callback result 7, got %v", got)
+	}
+}
+
+func TestOptimizeProcToSerialFunctionExplicitNumVarsKeepsNamedVariadicBinding(t *testing.T) {
+	lambda := NewProcStruct(Proc{
+		Params:  NewSymbol("values"),
+		Body:    NewSymbol("values"),
+		En:      &Globalenv,
+		NumVars: 1,
+	})
+	got := OptimizeProcToSerialFunction(lambda)(NewInt(3), NewInt(4))
+	want := NewSlice([]Scmer{NewInt(3), NewInt(4)})
+	if !Equal(got, want) {
+		t.Fatalf("expected named variadic callback result %v, got %v", want, got)
+	}
+}
+
+func BenchmarkOptimizeProcToSerialFunctionNumberedAdapter(b *testing.B) {
+	body := NewNthLocalVar(0)
+	for i := 0; i < 256; i++ {
+		body = NewSlice([]Scmer{NewSymbol("+"), body, NewInt(1)})
+	}
+	proc := NewProcStruct(Proc{
+		Params:       NewSlice([]Scmer{NewSymbol("value")}),
+		Body:         body,
+		En:           &Globalenv,
+		NumVars:      1,
+		NumberedOnly: true,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		OptimizeProcToSerialFunction(proc)
 	}
 }


### PR DESCRIPTION
## What changed

`Proc.NumberedOnly` is computed when an optimized lambda is created. Serial adapter creation now trusts that proven fact and skips rebuilding the named-parameter set and recursively scanning the lambda body a second time.

Procedures without that proof keep the existing conservative named-binding analysis. Tests cover fixed and variadic numbered procedures as well as both named-binding fallback shapes.

## Why

A CPU profile over 50 cache-busted compiles of a production-derived 27.9 KiB query attributed 4.73 s to `procBodyUsesNamedParam`; 2.98 s came directly from `OptimizeProcToSerialFunction`. This duplicated analysis already performed by `procCanUseNumberedOnly` during lambda construction.

## A/B measurements

Both binaries were built with the same Go toolchain. HTTP requests used randomized A/B order, warmups, and 15 paired samples per point. Physical `EXPLAIN` output SHA-256 hashes are identical for every measurement.

Full prefix cascade, median paired `compile_total_ns` delta (branch versus master):

| Prefix | Delta |
| --- | ---: |
| C | -4.35% |
| Ca | -0.60% |
| Car | -2.93% |
| Carg | -3.28% |
| Cargl | -2.42% |
| Cargla | -3.09% |
| Carglas | -2.98% |
| Carglass | -2.99% |
| CarglassXXX | -3.01% |

The final prefix initially exposed a large data-directory bias. A binary crossover showed that the offset followed the data replica rather than this patch. Repeating it with two byte-identical fresh data copies produced the `-3.01%` result above.

Independent-stage compile matrix, median paired delta:

| Stages | Delta |
| ---: | ---: |
| 1 | -10.08% |
| 2 | -2.94% |
| 4 | -1.43% |
| 8 | -1.23% |
| 12 | -4.29% |

Focused adapter construction benchmark (256-node body, 10 runs): approximately `6.96 us/op` to `0.107 us/op`, about 65x faster. Allocations remain `192 B/op`, `3 allocs/op` because the adapter environment and closure are unchanged.

## Validation

- `go test ./scm -count=1`
- focused semantic tests repeated 10 times
- full `./git-pre-commit`: green, all critical suites passed
- two coverage-instrumented `make test` attempts hit unrelated shared-server timeouts; each timed-out query passed in isolation, including 10/10 repetitions of the window-derived suite
- clean master coverage baseline also failed an unchanged hard performance gate at `5006.3 ms > 5000 ms`

No parser, logical planner, physical lowering, or emitted plan representation changes.
