### PR TITLE
Reuse nested decorrelation results

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3131,31 +3131,43 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 					(merge_unique (list (nth probe_result 2) (nth in_result 2)))))
 			_ (neumann_fail "untangle_query" "unknown dependent subquery marker")))))
 
-(define btw2025_decorrelate_expr_with_stages (lambda (expr ctx)
-	(match expr
-		((symbol dependent-subquery) _kind _probe _subquery _outer_sources)
-		(btw2025_resolve_dependent_subquery expr ctx)
-		((quote dependent-subquery) _kind _probe _subquery _outer_sources)
-		(btw2025_resolve_dependent_subquery expr ctx)
-		(cons head tail)
-		(combine_stage_rewrite_results head (map tail (lambda (item)
-			(btw2025_decorrelate_expr_with_stages item ctx))))
-		_ (list expr '() '()))))
-
 (define btw2025_dependent_marker_key (lambda (expr)
 	(if (dependent_subquery_marker? expr)
 		(concat "dependent:" (fnv_hash (string expr)))
 		nil)))
 
-(define btw2025_decorrelate_field_expr_using (lambda (expr ctx resolved)
+(define btw2025_decorrelate_exprs_using (lambda (exprs ctx resolved)
+	(match exprs
+		(cons expr rest) (begin
+			(define current (btw2025_decorrelate_expr_using expr ctx resolved))
+			(define tail (btw2025_decorrelate_exprs_using rest ctx (nth current 1)))
+			(list (cons (nth current 0) (nth tail 0)) (nth tail 1)))
+		_ (list '() resolved))))
+
+(define btw2025_decorrelate_expr_using (lambda (expr ctx resolved)
 	(begin
 		(define key (btw2025_dependent_marker_key expr))
 		(if (and (not (nil? key)) (has_assoc? resolved key))
 			(list (resolved key) resolved)
-			(begin
-				(define rewritten (btw2025_decorrelate_expr_with_stages expr ctx))
-				(list rewritten
-					(if (nil? key) resolved (set_assoc resolved key rewritten))))))))
+			(match expr
+				((symbol dependent-subquery) _kind _probe _subquery _outer_sources) (begin
+					(define rewritten (btw2025_resolve_dependent_subquery expr ctx))
+					(list rewritten (set_assoc resolved key rewritten)))
+				((quote dependent-subquery) _kind _probe _subquery _outer_sources) (begin
+					(define rewritten (btw2025_resolve_dependent_subquery expr ctx))
+					(list rewritten (set_assoc resolved key rewritten)))
+				(cons head tail) (begin
+					(define rewritten_tail (btw2025_decorrelate_exprs_using tail ctx resolved))
+					(list
+						(combine_stage_rewrite_results head (nth rewritten_tail 0))
+						(nth rewritten_tail 1)))
+				_ (list (list expr '() '()) resolved))))))
+
+(define btw2025_decorrelate_expr_with_stages (lambda (expr ctx)
+	(nth (btw2025_decorrelate_expr_using expr ctx '()) 0)))
+
+(define btw2025_decorrelate_field_expr_using (lambda (expr ctx resolved)
+	(btw2025_decorrelate_expr_using expr ctx resolved)))
 
 (define btw2025_decorrelate_fields_with_stages_using (lambda (fields ctx resolved)
 	(match (coalesceNil fields '())
@@ -9113,7 +9125,7 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(if (equal? keys '(1))
 				(list (build_group_constant_key_insert_plan schema grouptbl))
 				(if (reduce keys (lambda (session_only key)
-						(and session_only (query_session_read? key))) true)
+					(and session_only (query_session_read? key))) true)
 					(list (build_group_session_key_insert_plan schema grouptbl key_names keys))
 					'()))
 			'()))

--- a/tests/integration/query-shapes/traced-late-projection-read-models.yaml
+++ b/tests/integration/query-shapes/traced-late-projection-read-models.yaml
@@ -466,6 +466,43 @@ test_cases:
         - id: 2
           access_a: false
           access_b: false
+  - name: "Repeated nested access predicates reuse decorrelated stages"
+    max_time: 1.0
+    max_planner_time_ms: 500
+    max_compile_phase_ms:
+      untangle_ns: 180
+      recipe_emit_ns: 180
+    max_compile_metrics:
+      group_stages: 4
+      plan_nodes: 2500
+    max_plan_size: 40000
+    sql: |
+      SELECT item.id,
+        COALESCE((
+          SELECT CASE WHEN
+            EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+            AND EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+            AND CASE WHEN parent.is_public THEN TRUE ELSE
+              EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+              AND EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+              AND EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+              AND EXISTS (SELECT TRUE FROM trace_wide_assignment member WHERE member.team_id = parent.team_id AND member.member_id = 7 LIMIT 1)
+            END
+          THEN TRUE ELSE FALSE END
+          FROM trace_wide_parent parent
+          WHERE parent.id = item.parent_id
+          LIMIT 1
+        ), FALSE) AS can_view
+      FROM trace_wide_prop item
+      WHERE item.id IN (1, 2)
+      ORDER BY item.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          can_view: true
+        - id: 2
+          can_view: false
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_config"


### PR DESCRIPTION
## What changed

- thread the existing decorrelation `resolved` accumulator through nested expression lists
- reuse identical dependent-subquery rewrites inside `CASE`, `AND`, and `OR`, instead of rebuilding them before stage deduplication
- add a regression query covering repeated correlated `EXISTS` probes inside a scalar `LIMIT 1` projection

The parser AST, logical operator model, physical lowering boundary, and emitted plan remain unchanged.

## Root cause

The decorrelator already reused an identical dependent-subquery marker when the marker was the complete projection expression. Nested markers were traversed with `map`, which discarded the updated accumulator after every child. Wide access predicates therefore rebuilt the same logical stage repeatedly and only deduplicated the finished stages afterwards.

## A/B measurements

All compile measurements use `EXPLAIN COMPILE` true misses. Master and branch ran simultaneously against copied data directories; every pair alternated execution order. Seven samples were collected per prefix.

| Prefix | Master | PR | Delta |
|---|---:|---:|---:|
| C | 1036.66 ms | 950.30 ms | -8.33% |
| Ca | 1043.76 ms | 956.32 ms | -8.38% |
| Car | 1042.43 ms | 966.75 ms | -7.26% |
| Carg | 1023.18 ms | 942.96 ms | -7.84% |
| Cargl | 1019.43 ms | 963.50 ms | -5.49% |
| Cargla | 1027.69 ms | 966.46 ms | -5.96% |
| Carglas | 1017.95 ms | 940.00 ms | -7.66% |
| Carglass | 1013.86 ms | 936.81 ms | -7.60% |
| CarglassXXX | 1011.55 ms | 947.14 ms | -6.37% |

Across the cascade, `untangle_ns` improved by 13.4-19.2%. SQL bytes, AST nodes, logical nodes, plan nodes, plan bytes, stage counts, and physical operator counts were identical for every pair.

A separate 31.7 KiB, 17-level nested application query was measured over 15 paired samples:

| Metric | Master | PR | Delta |
|---|---:|---:|---:|
| Untangle | 466.93 ms | 385.13 ms | -17.52% |
| Total compile | 1493.86 ms | 1409.23 ms | -5.66% |
| Wall | 1606.33 ms | 1523.00 ms | -5.19% |

Its complete physical plan is byte-identical on master and the PR.

The full reference-application manual build completed successfully. Overall wall time was 75.85 s on the PR, 75.57 s on master, and 57.52 s on the MySQL-compatible reference backend. This PR therefore claims a cold-compile improvement, not an overall application benchmark improvement.

## Validation

- `python3 run_sql_tests.py tests/integration/query-shapes/traced-late-projection-read-models.yaml`
- full `./git-pre-commit` suite, with all critical tests passing
- complete reference-application manual build, all Playwright phases passing
- Scheme formatter run; its check still reports the repository's pre-existing unmatched-depth warnings

