### PR TITLE
Stream query-root join results without Scheme materialization

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -10924,14 +10924,14 @@ source remain residual so they observe the null-extended row. */
 						(source_outer? src))))
 			_ (neumann_fail "build_queryplan" "malformed ROW_NUMBER stage")))))
 
-(define build_join_scan_rows_with_mapper_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier column_recipe stages)
+(define build_join_scan_with_mapper_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier column_recipe stages collect_rows)
 	(if (empty_list? sources)
 		(if (equal? (coalesceNil final_condition true) true)
-			(runtime_cons_list_expr (list row_expr))
+			(if collect_rows (runtime_cons_list_expr (list row_expr)) row_expr)
 			(list (quote if)
 				(list (quote optimize) (lower_column_expr_for_join all_sources default_alias final_condition))
-				(runtime_cons_list_expr (list row_expr))
-				(list (quote list))))
+				(if collect_rows (runtime_cons_list_expr (list row_expr)) row_expr)
+				(if collect_rows (list (quote list)) nil)))
 		(begin
 			(define src (car sources))
 			(if (not (source_is_base_table? src))
@@ -10974,12 +10974,17 @@ source remain residual so they observe the null-extended row. */
 				(list (quote optimize) lowered_filter_condition)))
 			(define map_expr (list (quote lambda)
 				(map mapcols (lambda (col) (symbol (concat alias "." col))))
-				(build_join_scan_rows_with_mapper_using_recipe schema all_sources (cdr sources) default_alias needed_exprs remaining_condition row_expr '() 0 -1 allow_membership_carrier column_recipe stages)))
-			(define reduce_expr (list (quote lambda) (list (quote acc) (quote subrows))
-				(list (quote if)
-					(list (quote nil?) (quote subrows))
-					(quote acc)
-					(list (quote merge) (quote acc) (quote subrows)))))
+				(build_join_scan_with_mapper_using_recipe schema all_sources (cdr sources) default_alias needed_exprs remaining_condition row_expr '() 0 -1 allow_membership_carrier column_recipe stages collect_rows)))
+			(define reduce_expr (if collect_rows
+				(list (quote lambda) (list (quote acc) (quote subrows))
+					(list (quote if)
+						(list (quote nil?) (quote subrows))
+						(quote acc)
+						(list (quote merge) (quote acc) (quote subrows))))
+				nil))
+			(if (and (not collect_rows) (not (nil? row_number_stage_filter)))
+				(neumann_fail "build_queryplan" "streaming join scan cannot consume a ROW_NUMBER stage")
+				true)
 			(define scan_expr
 				(if (not (nil? row_number_stage_filter))
 					(build_join_row_number_scan_rows schema all_sources sources default_alias needed_exprs remaining_condition row_expr row_number_stage_filter membership_var membership_filter column_recipe)
@@ -10992,7 +10997,7 @@ source remain residual so they observe the null-extended row. */
 							(cons (quote list) mapcols)
 							map_expr
 							reduce_expr
-							(list (quote list))
+							(if collect_rows (list (quote list)) nil)
 							nil
 							(source_outer? src))
 						(list (quote scan_order)
@@ -11008,7 +11013,7 @@ source remain residual so they observe the null-extended row. */
 							(cons (quote list) mapcols)
 							map_expr
 							reduce_expr
-							(list (quote list))
+							(if collect_rows (list (quote list)) nil)
 							(source_outer? src)))))
 			(if membership_filter
 				(list
@@ -11016,26 +11021,32 @@ source remain residual so they observe the null-extended row. */
 					membership_table_expr)
 				scan_expr)))))
 
+(define build_join_scan_rows_with_mapper_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier column_recipe stages)
+	(build_join_scan_with_mapper_using_recipe
+		schema all_sources sources default_alias needed_exprs final_condition row_expr
+		order_items offset_value limit_value allow_membership_carrier column_recipe stages true)))
+
+(define build_join_scan_pipeline_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier column_recipe stages)
+	(build_join_scan_with_mapper_using_recipe
+		schema all_sources sources default_alias needed_exprs final_condition row_expr
+		order_items offset_value limit_value allow_membership_carrier column_recipe stages false)))
+
 (define build_join_scan_rows_with_mapper (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier stages)
 	(build_join_scan_rows_with_mapper_using_recipe
 		schema all_sources sources default_alias needed_exprs final_condition row_expr
 		order_items offset_value limit_value allow_membership_carrier nil stages)))
 
 (define build_join_scan_rows (lambda (schema sources default_alias needed_exprs final_condition fields order_items offset_value limit_value stages)
-	(build_join_scan_rows_with_mapper
-		schema
-		sources
-		sources
-		default_alias
-		needed_exprs
-		final_condition
-		(list (quote resultrow)
-			(cons (quote list) (lower_join_result_fields sources default_alias fields)))
-		order_items
-		offset_value
-		limit_value
-		true
-		stages)))
+	(begin
+		(define row_expr (list (quote resultrow)
+			(cons (quote list) (lower_join_result_fields sources default_alias fields))))
+		(if (empty_list? (filter (lowering_catalog_stages stages) row_number_stage?))
+			(build_join_scan_pipeline_using_recipe
+				schema sources sources default_alias needed_exprs final_condition row_expr
+				order_items offset_value limit_value true nil stages)
+			(build_join_scan_rows_with_mapper
+				schema sources sources default_alias needed_exprs final_condition row_expr
+				order_items offset_value limit_value true stages)))))
 
 (define lower_query_block_as_dataset_rows (lambda (block fields)
 	(begin

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -91,6 +91,12 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	if len(innerScanSlice) > 10 && scm.ToBool(innerScanSlice[10]) {
 		return scm.NewNil()
 	}
+	// Delaying an effectful mapper until a batch flush changes observable
+	// behavior. In particular, query-root resultrow callbacks must stay in the
+	// nested scan pipeline instead of being buffered as Scheme values.
+	if scanExprMayHaveSideEffects(innerScanSlice[6]) {
+		return scm.NewNil()
+	}
 
 	// The inner scan must actually reference at least one outer param
 	// (otherwise it's a cross-join where batching adds overhead for no gain

--- a/storage/scan_batch_rewrite_test.go
+++ b/storage/scan_batch_rewrite_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func nestedScanBatchRewriteCall(innerMapBody scm.Scmer) []scm.Scmer {
+	outerID := scm.NewSymbol("outer_id")
+	innerScan := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("scan"), scm.NewNil(), scm.NewSymbol("inner_table"),
+		scm.NewSlice([]scm.Scmer{scm.NewString("ID")}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("lambda"), scm.NewSlice([]scm.Scmer{scm.NewSymbol("inner_id")}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("equal??"), scm.NewSymbol("inner_id"), outerID}),
+		}),
+		scm.NewSlice([]scm.Scmer{scm.NewString("ID")}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("lambda"), scm.NewSlice([]scm.Scmer{scm.NewSymbol("inner_id")}), innerMapBody,
+		}),
+		scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewBool(false),
+	})
+	return []scm.Scmer{
+		scm.NewSymbol("scan"), scm.NewNil(), scm.NewSymbol("outer_table"),
+		scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("lambda"), scm.NewSlice(nil), scm.NewBool(true)}),
+		scm.NewSlice([]scm.Scmer{scm.NewString("ID")}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("lambda"), scm.NewSlice([]scm.Scmer{outerID}), innerScan,
+		}),
+		scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewBool(false),
+	}
+}
+
+func TestScanBatchRewriteKeepsEffectfulInnerMapperStreaming(t *testing.T) {
+	resultrow := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("resultrow"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("inner_id")}),
+	})
+	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(resultrow)); !rewritten.IsNil() {
+		t.Fatalf("effectful nested scan was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func TestScanBatchRewriteStillBatchesPureInnerMapper(t *testing.T) {
+	rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(scm.NewSymbol("inner_id")))
+	if rewritten.IsNil() {
+		t.Fatal("pure nested scan was not batched")
+	}
+	if plan := scm.SerializeToString(rewritten, &scm.Globalenv); !strings.Contains(plan, "scan_batch") {
+		t.Fatalf("rewritten plan contains no scan_batch: %s", plan)
+	}
+}

--- a/tests/planner/subqueries/derived-table-limit-scalar.yaml
+++ b/tests/planner/subqueries/derived-table-limit-scalar.yaml
@@ -788,6 +788,120 @@ test_cases:
       result_not_contains:
         - "(and (coalesceNil (__scalar_query_probe_"
 
+  - name: "Ordered root LEFT JOIN streams nested scans"
+    sql: |
+      SELECT m.ID, ref.label
+      FROM dtl_join_main m
+      LEFT JOIN dtl_join_ref ref ON ref.ID = m.first_ref
+      WHERE m.second_ref = 20
+      ORDER BY m.ID
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          label: "ten"
+
+  - name: "Physical ordered root LEFT JOIN does not collect subrows"
+    sql: |
+      EXPLAIN
+      SELECT m.ID, ref.label
+      FROM dtl_join_main m
+      LEFT JOIN dtl_join_ref ref ON ref.ID = m.first_ref
+      WHERE m.second_ref = 20
+      ORDER BY m.ID
+      LIMIT 1
+    expect:
+      result_contains:
+        - "scan_order"
+        - "dtl_join_main"
+        - "dtl_join_ref"
+      result_not_contains:
+        - "(acc subrows)"
+
+  - name: "Streaming root LEFT JOIN preserves missing rows"
+    sql: |
+      SELECT m.ID, ref.label
+      FROM dtl_join_main m
+      LEFT JOIN dtl_join_ref ref ON ref.ID = m.first_ref
+      ORDER BY m.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          label: "ten"
+        - ID: 2
+          label: "twenty"
+        - ID: 3
+          label: null
+
+  - name: "Streaming root preserves cascaded LEFT JOIN bindings"
+    sql: |
+      SELECT m.ID, first_ref.label AS first_label, second_ref.label AS second_label
+      FROM dtl_join_main m
+      LEFT JOIN dtl_join_ref first_ref ON first_ref.ID = m.first_ref
+      LEFT JOIN dtl_join_ref second_ref ON second_ref.ID = m.second_ref
+      ORDER BY m.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          first_label: "ten"
+          second_label: "twenty"
+        - ID: 2
+          first_label: "twenty"
+          second_label: "thirty"
+        - ID: 3
+          first_label: null
+          second_label: "ten"
+
+  - name: "Streaming root INNER JOIN preserves multiple matches"
+    sql: |
+      SELECT m.ID, access.ID AS access_id
+      FROM dtl_join_main m
+      JOIN dtl_global_access access
+        ON access.account_id = 11 AND m.ID = 1
+      ORDER BY access.ID
+    expect:
+      rows: 4
+      data:
+        - ID: 1
+          access_id: 1
+        - ID: 1
+          access_id: 2
+        - ID: 1
+          access_id: 3
+        - ID: 1
+          access_id: 4
+
+  - name: "Unordered streaming INNER JOIN emits every matching row"
+    sql: |
+      SELECT m.ID, ref.label
+      FROM dtl_join_main m
+      JOIN dtl_join_ref ref ON ref.ID = m.first_ref
+    expect:
+      rows: 2
+      data:
+        - ID: 1
+          label: "ten"
+        - ID: 2
+          label: "twenty"
+
+  - name: "Physical unordered root join stays a direct scan pipeline"
+    sql: |
+      EXPLAIN
+      SELECT m.ID, ref.label
+      FROM dtl_join_main m
+      JOIN dtl_join_ref ref ON ref.ID = m.first_ref
+    expect:
+      result_contains:
+        - "scan"
+        - "resultrow"
+      result_not_contains:
+        - "scan_batch"
+        - "__batchbuf"
+        - "(acc subrows)"
+
   - name: "Remove stale physical carrier fixture"
     scm: '(droptable "memcp-tests" ".grp:dtl_global_access:c686880da9e520fc" true)'
 


### PR DESCRIPTION
## Summary

- emit query-root rows directly from the nested scan pipeline instead of wrapping every row in Scheme lists and merging those lists at every join level
- keep dataset-producing lowering unchanged and retain the existing specialized ROW_NUMBER path
- prevent the scan-batch optimizer from delaying effectful inner mappers such as `resultrow`
- cover ordered and unordered roots, INNER and LEFT joins, missing rows, cascaded joins, multiple matches, and the optimizer guard

## Root cause

Query-root lowering used the same list-producing helper as derived datasets. Each leaf executed `resultrow`, wrapped its return value in a singleton Scheme list, and every enclosing scan merged `subrows` into another accumulator.

Removing those reducers exposed a second correctness issue: `tryScanBatchRewrite` interpreted the reducer-free nested scan as a batch candidate. It moved the effectful `resultrow` mapper behind a Scheme-list batch flush, which could produce empty results. The optimizer now rejects batching when the inner mapper has observable effects; pure nested mappers remain eligible.

## A/B measurements

All measurements used the same machine, fresh data directories, two warmups, and anonymous synthetic schemas.

### Four PK LEFT JOIN probes, 1,000 root rows, 7 samples

| | Median | Min | Max |
|---|---:|---:|---:|
| master | 3,001.0 ms | 2,995.2 ms | 3,026.1 ms |
| PR | 3,068.8 ms | 3,011.4 ms | 3,123.4 ms |

The ranges overlap and the scan/probe cost dominates. This result does not establish a runtime speedup; the PR median is 2.3% slower in this run.

### Query-root scan, 50,000 rows, 51 samples

| | Median | Min | Max |
|---|---:|---:|---:|
| master | 65.784 ms | 61.420 ms | 74.381 ms |
| PR | 65.492 ms | 59.623 ms | 73.578 ms |

The isolated changed primitive is effectively neutral, with the PR median 0.4% faster.

### Physical plan

The four-join EXPLAIN shrinks from 5,233 to 4,010 bytes (-23.4%). Five `(acc subrows)` reducers on master become zero on the PR. Source order and scan operators remain planner-owned and unchanged.

## Validation

- `MEMCP_TEST_JOBS=2 make test`: all tests passed; Scheme coverage 100%, Go coverage 69.3%
- `go test ./storage/ -count=1`
- `derived-table-limit-scalar.yaml`: 38/38
- `join-complex.yaml`: 10/10

The default four-suite local run was also attempted repeatedly. Under concurrent unrelated host workloads it timed out in varying otherwise-fast suites; every reported suite passed in isolation. GitHub CI remains the standard four-worker gate.
