### PR TITLE
Bound selective scalar cardinality probes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1056,6 +1056,9 @@ instead of capturing whichever session populated the carrier first. */
 (define scalar_aggregate_probe_expr (lambda (stage col)
 	(list (quote scalar_aggregate_probe) stage col)))
 
+(define scalar_cardinality_probe_expr (lambda (stage col)
+	(list (quote scalar_cardinality_probe) stage col)))
+
 (define scalar_aggregate_probe_outer_exprs (lambda (stage)
 	(merge (list
 		(qassoc_get (gs_facts stage) (quote lookup-keys) '())
@@ -1292,6 +1295,22 @@ instead of capturing whichever session populated the carrier first. */
 								(not (stage_has_residual_outer_refs? stage))))
 							(and (equal? (coalesceNil (gs_having stage) true) true)
 								(source_is_base_table? (gs_input stage)))))))))))
+
+(define scalar_cardinality_probe_stage? (lambda (stage)
+	(if (not (group_stage? stage))
+		false
+		(begin
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define ags (gs_aggregates stage))
+			(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_single))
+				(and (equal? (qassoc_get (gs_facts stage) (quote cardinality_mode) nil) (quote single_or_error))
+					(and (not (empty_list? lookup_keys))
+						(and (equal? (count (gs_keys stage)) (count lookup_keys))
+							(and (empty_list? (qassoc_get (gs_facts stage) (quote btw2025_accessing_after_simple) '()))
+								(and (equal? (coalesceNil (gs_having stage) true) true)
+									(and (source_is_base_table? (gs_input stage))
+										(and (equal? (count ags) 2)
+											(equal? (nth ags 1) aggregate_count_descriptor)))))))))))))
 
 (define presence_probe_stage? (lambda (stage)
 	(and (group_stage? stage)
@@ -5334,6 +5353,11 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 			(extract_columns_for_alias src expr))))
 		((quote scalar_aggregate_probe) stage requested_col)
 		(extract_columns_for_alias src (list (quote scalar_aggregate_probe) stage requested_col))
+		((symbol scalar_cardinality_probe) stage _requested_col)
+		(merge_unique (map (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (key)
+			(extract_columns_for_alias src key))))
+		((quote scalar_cardinality_probe) stage requested_col)
+		(extract_columns_for_alias src (list (quote scalar_cardinality_probe) stage requested_col))
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase) (list (resolve_physical_column_name src col col_ignorecase)) '())
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase) (if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase) (list (resolve_physical_column_name src col col_ignorecase)) '())
 		(cons head tail) (merge_unique (map tail (lambda (item) (extract_columns_for_alias src item))))
@@ -5361,6 +5385,10 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(lower_scalar_aggregate_probe_expr (list src) (source_alias src) stage requested_col)
 		((quote scalar_aggregate_probe) stage requested_col)
 		(lower_scalar_aggregate_probe_expr (list src) (source_alias src) stage requested_col)
+		((symbol scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr (list src) (source_alias src) stage requested_col)
+		((quote scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr (list src) (source_alias src) stage requested_col)
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (symbol (concat (resolve_column_alias tblvar (source_alias src)) "." (resolve_physical_column_name src col col_ignorecase)))
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase) (symbol (concat (resolve_column_alias tblvar (source_alias src)) "." (resolve_physical_column_name src col col_ignorecase)))
 		(cons head tail) (cons head (map tail (lambda (item) (lower_column_expr_for_alias src item))))
@@ -5922,6 +5950,57 @@ dependency preparation does not emit free outer-row symbols. */
 			nil
 			false))))
 
+(define lower_scalar_cardinality_probe_expr (lambda (sources default_alias stage requested_col)
+	(begin
+		(if (not (scalar_cardinality_probe_stage? stage))
+			(neumann_fail "build_queryplan" "scalar cardinality probe requires scalar_single base stage")
+			true)
+		(define src (gs_input stage))
+		(define keys (gs_keys stage))
+		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(if (not (equal? (count keys) (count lookup_keys)))
+			(neumann_fail "build_queryplan" "scalar cardinality probe key/domain mismatch")
+			true)
+		(define ag (scalar_first_probe_aggregate stage requested_col))
+		(if (nil? ag)
+			(neumann_fail "build_queryplan" "scalar cardinality probe references unknown aggregate column")
+			true)
+		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+		(define value_expr (nth ag 0))
+		(define condition_cols (extract_columns_for_alias src condition))
+		(define key_cols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
+		(define value_cols (extract_columns_for_alias src value_expr))
+		(define filtercols (merge_unique (list condition_cols key_cols)))
+		(define unset (list (quote quote) (quote __scalar_cardinality_unset)))
+		(list (quote scan_order)
+			'(session "__memcp_tx")
+			(source_table_expr src)
+			(cons (quote list) filtercols)
+			(list (quote lambda)
+				(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
+				(list (quote optimize)
+					(cons (quote and)
+						(cons
+							(lower_column_expr_for_alias src condition)
+							(scalar_first_probe_key_terms sources default_alias src keys lookup_keys)))))
+			'(list)
+			'(list)
+			0
+			0
+			2
+			(cons (quote list) value_cols)
+			(list (quote lambda)
+				(map value_cols (lambda (col) (symbol (concat (source_alias src) "." col))))
+				(lower_column_expr_for_alias src value_expr))
+			(list (quote lambda) '((quote acc) (quote value))
+				(list (quote if)
+					(list (quote equal?) (quote acc) unset)
+					(quote value)
+					(list (quote error) "scalar subselect returned more than one row")))
+			unset
+			false
+			nil))))
+
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr
 		((symbol driver_membership_probe) _stage probe)
@@ -5947,6 +6026,11 @@ dependency preparation does not emit free outer-row symbols. */
 			(collect_join_columns_acc sources default_alias target_alias expr acc)) columns_by_alias)
 		((quote scalar_aggregate_probe) stage requested_col)
 		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_aggregate_probe) stage requested_col) columns_by_alias)
+		((symbol scalar_cardinality_probe) stage _requested_col)
+		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '()) (lambda (acc key)
+			(collect_join_columns_acc sources default_alias target_alias key acc)) columns_by_alias)
+		((quote scalar_cardinality_probe) stage requested_col)
+		(collect_join_columns_acc sources default_alias target_alias (list (quote scalar_cardinality_probe) stage requested_col) columns_by_alias)
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
 			(define src (if (nil? tblvar)
 				(source_for_unqualified_column sources default_alias col col_ignorecase)
@@ -5990,6 +6074,10 @@ dependency preparation does not emit free outer-row symbols. */
 		(lower_scalar_aggregate_probe_expr sources default_alias stage requested_col)
 		((quote scalar_aggregate_probe) stage requested_col)
 		(lower_scalar_aggregate_probe_expr sources default_alias stage requested_col)
+		((symbol scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr sources default_alias stage requested_col)
+		((quote scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr sources default_alias stage requested_col)
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (begin
 			(define src (if (nil? tblvar)
 				(source_for_unqualified_column sources default_alias col col_ignorecase)
@@ -6495,6 +6583,10 @@ dependency preparation does not emit free outer-row symbols. */
 		(lower_scalar_aggregate_probe_expr '() nil stage requested_col)
 		((quote scalar_aggregate_probe) stage requested_col)
 		(lower_scalar_aggregate_probe_expr '() nil stage requested_col)
+		((symbol scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr '() nil stage requested_col)
+		((quote scalar_cardinality_probe) stage requested_col)
+		(lower_scalar_cardinality_probe_expr '() nil stage requested_col)
 		((symbol union_count) block) (lower_union_count_expr block)
 		((quote union_count) block) (lower_union_count_expr block)
 		(cons head tail) (cons head (map tail lower_scalar_marker_expr))
@@ -8089,6 +8181,12 @@ is still available and remains an ordinary scalar expression through untangle. *
 			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 			(scalar_aggregate_probe_stage? stage)))))
 
+(define scalar_cardinality_probe_stage_output_source? (lambda (stages src)
+	(and (stage_output_relation? (source_relation src))
+		(begin
+			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
+			(scalar_cardinality_probe_stage? stage)))))
+
 /* A selective LEFT JOIN may evaluate a grouped base-table source as a keyed
 aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 (define direct_group_probe_input (lambda (stage)
@@ -8257,7 +8355,8 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 				(define direct (direct_group_probe_stage_for_block_source stages sources src consumers))
 				(define stage (coalesceNil direct original))
 				(if (or (scalar_or_presence_probe_stage? stage)
-					(scalar_aggregate_probe_stage? stage))
+					(or (scalar_aggregate_probe_stage? stage)
+						(scalar_cardinality_probe_stage? stage)))
 					(list src stage)
 					nil))))
 			(lambda (entry) (not (nil? entry)))))
@@ -8288,6 +8387,22 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 
 (define rewrite_scalar_first_probe_expr_using_index (lambda (stages index default_alias expr)
 	(match expr
+		((symbol if)
+			((symbol >) ((symbol coalesceNil) ((symbol get_column) count_alias count_tbl_ic count_col count_col_ic) 0) 1)
+			((symbol error) message)
+			((symbol get_column) value_alias value_tbl_ic value_col value_col_ic)) (begin
+			(define entry (probe_stage_entry_for_alias_using_index index default_alias count_alias count_tbl_ic))
+			(if (or (nil? entry)
+				(or (not (equal?? count_alias value_alias))
+					(or (not (equal? message "scalar subselect returned more than one row"))
+						(not (equal? count_col (aggregate_col_name aggregate_count_descriptor))))))
+				expr
+				(begin
+					(define stage (nth entry 0))
+					(if (and (scalar_cardinality_probe_stage? stage)
+						(not (nil? (scalar_first_probe_aggregate stage value_col))))
+						(scalar_cardinality_probe_expr stage value_col)
+						expr))))
 		((symbol get_column) tblvar tbl_ignorecase col _col_ignorecase) (begin
 			(define entry (probe_stage_entry_for_alias_using_index index default_alias tblvar tbl_ignorecase))
 			(if (nil? entry)
@@ -8558,6 +8673,18 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 								(probe_context_small_enough? probe_sources))))
 					(stage_lookup_keys_resolve_in_sources? stage probe_sources default_alias)))))))
 
+(define scalar_cardinality_probe_output_source_for_block? (lambda (stages sources default_alias limit_value driver_condition src)
+	(if (not (scalar_cardinality_probe_stage_output_source? stages src))
+		false
+		(begin
+			(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
+			(define probe_sources (filter sources (lambda (candidate)
+				(not (equal? (source_alias candidate) (source_alias src))))))
+			(and (stage_lookup_keys_resolve_in_sources? stage probe_sources default_alias)
+				(or (probe_limit_small_enough? limit_value)
+					(or (probe_context_small_enough? probe_sources)
+						(probe_context_unique_point? probe_sources default_alias driver_condition))))))))
+
 (define direct_group_probe_output_source_for_block? (lambda (stages sources default_alias limit_value driver_condition consumers src)
 	(begin
 		(define stage (direct_group_probe_stage_for_block_source stages sources src consumers))
@@ -8578,8 +8705,11 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 			(probeable_stage_output_source_for_block? stages sources default_alias limit_value src)
 			(or
 				(scalar_aggregate_probe_output_source_for_block? stages sources default_alias limit_value src)
-				(direct_group_probe_output_source_for_block?
-					stages sources default_alias limit_value driver_condition consumers src)))))))
+				(or
+					(scalar_cardinality_probe_output_source_for_block?
+						stages sources default_alias limit_value driver_condition src)
+					(direct_group_probe_output_source_for_block?
+						stages sources default_alias limit_value driver_condition consumers src))))))))
 
 (define sources_without_probe_outputs (lambda (sources probe_sources)
 	(begin
@@ -8768,6 +8898,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 		(list stage)
 		((quote scalar_aggregate_probe) stage _requested_col)
 		(list stage)
+		((symbol scalar_cardinality_probe) stage _requested_col)
+		(list stage)
+		((quote scalar_cardinality_probe) stage _requested_col)
+		(list stage)
 		((symbol grouped_scalar_top) stage)
 		(list stage)
 		((quote grouped_scalar_top) stage)
@@ -8877,7 +9011,8 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 
 (define scalar_probe_consumed_stages_many_using_graph (lambda (graph stages)
 	(unique_stages_by_id (merge (list
-		(filter (coalesceNil stages '()) scalar_aggregate_probe_stage?)
+		(filter (coalesceNil stages '()) (lambda (stage)
+			(or (scalar_aggregate_probe_stage? stage) (scalar_cardinality_probe_stage? stage))))
 		(stage_dependency_closure_many_using_graph graph
 			(filter (coalesceNil stages '()) scalar_or_presence_probe_stage?)))))))
 

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -503,6 +503,7 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 			scanReduceFn,
 			col.OrcReduceInit,
 			false,
+			col.OrcReduceInit,
 		)
 	})
 }

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -30,7 +30,7 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 	// scan_order_multi args: 0=fn, 1=tx, 2=tables, 3=filterCols, 4=filterFns,
 	// 5=sortcols, 6=sortdirs, 7=perTableOffset, 8=perTableLimit,
 	// 9=partCols, 10=offset, 11=limit, 12=mapCols, 13=mapFns,
-	// 14=reduce, 15=neutral, 16=isOuter
+	// 14=reduce, 15=neutral, 16=isOuter, 17=notFoundValue
 	for i := 1; i <= 13 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
@@ -44,6 +44,9 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 	}
 	if len(v) > 16 {
 		v[16], _ = oc.OptimizeSub(v[16], true)
+	}
+	if len(v) > 17 {
+		v[17], _ = oc.OptimizeSub(v[17], true)
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
@@ -59,7 +62,7 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	// if rewritten := tryScanOrderBatchRewrite(v); !rewritten.IsNil() {
 	// 	return oc.OptimizeSub(rewritten, useResult)
 	// }
-	mapEnd, reduceIdx, neutralIdx, outerIdx := 11, 12, 13, 14
+	mapEnd, reduceIdx, neutralIdx, outerIdx, notFoundIdx := 11, 12, 13, 14, 15
 	for i := 1; i <= mapEnd && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
@@ -73,6 +76,9 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	}
 	if len(v) > outerIdx {
 		v[outerIdx], _ = oc.OptimizeSub(v[outerIdx], true)
+	}
+	if len(v) > notFoundIdx {
+		v[notFoundIdx], _ = oc.OptimizeSub(v[notFoundIdx], true)
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
@@ -589,7 +595,7 @@ func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 // results from all tables' shards into a single globally sorted stream.
 // Each table has its own filter, sort columns and map function, but sort
 // directions, offset/limit, reduce and neutral are shared.
-func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
 	execStart := time.Now()
 	ss := SessionStateFromTx(currentTx)
 
@@ -951,6 +957,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		nullRow := buildOuterNullCallbackRow(cbCols)
 		akkumulator = aggregateFn(akkumulator, callbackFn(nullRow...))
 	}
+	if !hadValue && !isOuter {
+		akkumulator = notFoundValue
+	}
 	execNs := time.Since(execStart).Nanoseconds()
 	for i := range tables {
 		tableStats := stats[i]
@@ -988,9 +997,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 }
 
 // scan_order delegates to scanOrderMulti with a single-element table spec.
-func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
 	if len(sortcols) == 0 && limitPartitionCols == 0 && offset == 0 && limit == 1 && !aggregate.IsNil() && !isOuter {
-		return t.scanOrderFirst(currentTx, conditionCols, condition, callbackCols, callback, aggregate, neutral)
+		return t.scanOrderFirst(currentTx, conditionCols, condition, callbackCols, callback, aggregate, neutral, notFoundValue)
 	}
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
 		table:          t,
@@ -1001,13 +1010,13 @@ func (t *table) scan_order(currentTx *TxContext, conditionCols []string, conditi
 		callback:       callback,
 		perTableOffset: -1,
 		perTableLimit:  -1,
-	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter)
+	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter, notFoundValue)
 }
 
 // scanOrderFirst is the no-order LIMIT 1 specialization of scan_order. It
 // preserves the scan operator contract while avoiding the queues, channels,
 // and global merge needed by the general ordered multi-shard implementation.
-func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer) scm.Scmer {
+func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, notFoundValue scm.Scmer) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
 	bounds := extractBoundaries(conditionCols, condition)
@@ -1056,7 +1065,7 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 		panic(firstErr)
 	}
 	if foundShard == nil {
-		return neutral
+		return notFoundValue
 	}
 	mapper := foundShard.OpenMapReducer(callbackCols, callback, aggregate, false, 0, nil, currentTx)
 	result := mapper.Stream(neutral, []uint32{foundID}, nil)
@@ -1107,7 +1116,7 @@ func (t *table) scanOrderPointValue(currentTx *TxContext, keyCols []string, keyV
 	return value
 }
 
-func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool) scm.Scmer {
+func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
 	if currentTx == nil {
 		currentTx = r.tx
 	}
@@ -1120,7 +1129,7 @@ func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condit
 		callback:       callback,
 		perTableOffset: -1,
 		perTableLimit:  -1,
-	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter)
+	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter, notFoundValue)
 }
 
 // streamOrBreak calls mapper.Stream and catches a breakSentinel panic (from $break

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -900,6 +900,10 @@ func Init(en scm.Env) {
 			}
 
 			isOuter := len(a) > layout.limitIdx+5 && scm.ToBool(a[layout.limitIdx+5])
+			notFoundValue := neutral
+			if len(a) > layout.limitIdx+6 {
+				notFoundValue = a[layout.limitIdx+6]
+			}
 
 			if list, ok := scmerSlice(tableArg); ok {
 				result := neutral
@@ -987,16 +991,19 @@ func Init(en scm.Env) {
 					}
 					result = reducefn(result, mapfn(mapparams...))
 				}
+				if !hadValue && !isOuter {
+					result = notFoundValue
+				}
 				return result
 			}
 
 			if tableArg.IsCustom(TagRecSet) {
-				return RecSetFromScmer(tableArg).scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter)
+				return RecSetFromScmer(tableArg).scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue)
 			}
 
 			t := TableFromScmer(a[layout.tableIdx])
 
-			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter)
+			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
@@ -1014,6 +1021,7 @@ func Init(en scm.Env) {
 				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results. It takes two parameters (a b) where a is the accumulator and b the new value. The accumulator for the first reduce call is the neutral element. The return value will be the accumulator input for the next reduce call. There are two reduce phases: shard-local and shard-collect. In the shard-local phase, a starts with neutral and b is fed with the return values of each map call. In the shard-collect phase, a starts with neutral and b is fed with the result of each shard-local pass.", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "acc", Transfer: true}, {Kind: "any", ParamName: "val"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
 				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
+				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrder,
@@ -1040,6 +1048,7 @@ func Init(en scm.Env) {
 			// 13: reduce (optional)
 			// 14: neutral (optional)
 			// 15: isOuter (optional)
+			// 16: notFoundValue (optional)
 			currentTx := scmerToTxContext(a[0])
 			tables := mustScmerSlice(a[1], "tables")
 			filterColsArr := mustScmerSlice(a[2], "filterColumns")
@@ -1064,6 +1073,10 @@ func Init(en scm.Env) {
 				neutral = a[14]
 			}
 			isOuter := len(a) > 15 && scm.ToBool(a[15])
+			notFoundValue := neutral
+			if len(a) > 16 {
+				notFoundValue = a[16]
+			}
 
 			if len(filterColsArr) != n || len(filterFnArr) != n || len(sortcolsArr) != n || len(mapColsArr) != n || len(mapFnArr) != n {
 				panic("scan_order_multi: all per-table arrays must have the same length")
@@ -1092,7 +1105,7 @@ func Init(en scm.Env) {
 				}
 			}
 
-			return scanOrderMulti(currentTx, specs, sortdirs, int(limitPartitionCols), int(offset), int(limit), aggregate, neutral, isOuter)
+			return scanOrderMulti(currentTx, specs, sortdirs, int(limitPartitionCols), int(offset), int(limit), aggregate, neutral, isOuter, notFoundValue)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
@@ -1112,6 +1125,7 @@ func Init(en scm.Env) {
 				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) aggregation function", Optional: true},
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for reduce", Optional: true},
 				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, emit null row when no hits", Optional: true},
+				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrderMulti,

--- a/tests/planner/joins/join-dedup.yaml
+++ b/tests/planner/joins/join-dedup.yaml
@@ -1,3 +1,4 @@
+# Copyright (C) 2026 Carl-Philip Haensch
 # Scalar subquery deduplication (join-merge optimization)
 # When two or more scalar subqueries reference the same table with the same
 # condition and field, the inner scan should be performed only once per outer row.
@@ -18,7 +19,9 @@ setup:
   - sql: |
       CREATE TABLE jd_ref (id INT, label VARCHAR(40), score INT)
   - sql: |
-      INSERT INTO jd_ref (id, label, score) VALUES (10, 'Alpha', 100), (20, 'Beta', 200)
+      INSERT INTO jd_ref (id, label, score) VALUES
+        (10, 'Alpha', 100), (20, 'Beta', 200), (30, NULL, 300),
+        (40, NULL, 400), (40, 'duplicate', 401)
 
 test_cases:
 
@@ -160,8 +163,8 @@ test_cases:
       rows: 1
       data:
         - id: 1
-          total1: 2
-          total2: 2
+          total1: 5
+          total2: 5
 
   # Error: multiple rows for identical subquery still errors (semantics preserved)
   - name: "Multiple rows still errors even for deduplicated subquery"
@@ -171,6 +174,55 @@ test_cases:
         (SELECT id FROM jd_item WHERE jd_item.ref_id = 10) AS c2
     expect:
       error: true
+      contains:
+        - "scalar subselect returned more than one row"
+
+  - name: "Scalar cardinality check physically reads at most two rows per key"
+    sql: |
+      EXPLAIN
+      SELECT id,
+        (SELECT label FROM jd_ref WHERE jd_ref.id = jd_item.ref_id) AS label
+      FROM jd_item
+      WHERE jd_item.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "jd_ref"
+        - '\n\t\t\t\t\t\t0\n\t\t\t\t\t\t2\n'
+      result_not_contains:
+        - "scan_order_point"
+        - ".grp:jd_ref"
+
+  - name: "Scalar probe distinguishes no row from its internal initializer"
+    sql: |
+      SELECT (SELECT label FROM jd_ref WHERE jd_ref.id = jd_item.id + 998) AS label
+      FROM jd_item
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - label: null
+
+  - name: "Scalar probe preserves a matching NULL value"
+    sql: |
+      SELECT (SELECT label FROM jd_ref WHERE jd_ref.id = jd_item.id + 29) AS label
+      FROM jd_item
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - label: null
+
+  - name: "Scalar probe detects a second row after a NULL value"
+    sql: |
+      SELECT (SELECT label FROM jd_ref WHERE jd_ref.id = jd_item.id + 39) AS label
+      FROM jd_item
+      WHERE id = 1
+    expect:
+      error: true
+      contains:
+        - "scalar subselect returned more than one row"
 
   # NULL outer ref: both identical subqueries return NULL
   - name: "NULL outer ref produces NULL in all identical subqueries"


### PR DESCRIPTION
## What changed

- Keep decorrelated `scalar_single` LEFT JOINs in the logical join cloud, but lower selective base-table probes inside the chosen driver map.
- Replace the value-plus-COUNT carrier lookup with one `scan_order` using no required order and `LIMIT 2`.
- Add an optional `notFoundValue` to ordered scans so an aggregate initializer is distinct from both no match and a matching SQL NULL.
- Preserve the existing broad-query carrier path; the new probe is selected only by the existing small-limit, small-context, or unique-driver gates.
- Cover zero rows, one row, a matching NULL, and more than one row including NULL as the first value.

## Root cause

Neumann decorrelation correctly produced a logical LEFT JOIN and cardinality metadata. For a selective outer driver, physical lowering still retained the grouped stage output because the scalar result depended on both a value aggregate and a COUNT aggregate. That caused the full inner key carrier to be built before one demanded key was read.

The physical probe now obtains enough information from at most two matching rows: zero yields `notFoundValue`, one yields the mapped value (including NULL), and the second raises the scalar cardinality error. No result rows are copied into Scheme lists and no new reordering decision is made during lowering.

## A/B measurements

Current master `37d632c7c` vs this branch, same binaries/settings and an anonymized fixture with one selective outer row and 81,920 persisted lookup rows.

| Metric | Master | PR |
|---|---:|---:|
| Cold selective lookup, one matching row | 46.857 s | 0.055 s |
| Warm runs 2-7 | 0.041-0.044 s | 0.041-0.044 s |
| Planner total | 6.509 ms | 5.777 ms |
| Compile total | 8.643 ms | 7.704 ms |
| Physical plan bytes | 4,339 | 1,200 |
| Physical scans | 5 | 1 |
| Ordered scans | 0 | 1 |

The master plan referenced the generated `.grp` carrier eight times. The PR plan contains one nested `scan_order` and no `.grp` relation or `scan_order_point`.

Duplicate-key cardinality case on 81,920 persisted rows:

| Metric | Master | PR |
|---|---:|---:|
| Cold execution to the correct >1 error | 0.306 s | 0.045 s |
| Result | cardinality error | same cardinality error |

## Validation

- `./git-pre-commit` (complete parallel SQL suite): passed
- `python3 run_sql_tests.py tests/planner/joins/join-dedup.yaml 47821 --connect-only`: 13/13 passed
- Adjacent scalar/decorrelation/LEFT JOIN/application suites: 98/98 passed
- `go test ./storage -run '^$'`: passed
- Scheme formatter and `git diff --check`: passed
