### PR TITLE
Keep bounded ordered UNION branches in physical carriers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -2214,7 +2214,10 @@ instead of capturing whichever session populated the carrier first. */
 			(match item '(expr dir) (list (requalify_single_source_expr inner_alias alias expr) dir)))))
 		(define sortcols (order_cols_for_alias derived_src order_items))
 		(define sortdirs (window_order_dirs_for_orc order_items))
-		(define rn_col (concat "__derived_row_number_" (fnv_hash (serialize (list alias sortcols sortdirs (qb_limit inner) (qb_offset inner))))))
+		(define inner_where (requalify_single_source_expr inner_alias alias (qb_where inner)))
+		(define filtercols (extract_columns_for_alias derived_src inner_where))
+		(define rn_col (concat "__derived_row_number_" (fnv_hash (serialize (list
+			alias sortcols sortdirs inner_where (qb_limit inner) (qb_offset inner))))))
 		(define rn_stage (make_window_stage
 			(concat "window-row-number:" rn_col)
 			derived_src
@@ -2222,13 +2225,20 @@ instead of capturing whichever session populated the carrier first. */
 			sortcols
 			sortdirs
 			0
-			'()
-			(list (quote lambda) (list (quote $set))
-				(list (quote cons) (symbol "$set") (list (quote list))))
+			filtercols
+			(list (quote lambda)
+				(cons (quote $set) (map filtercols (lambda (col) (symbol (concat alias "." col)))))
+				(list (quote list)
+					(symbol "$set")
+					(list (quote optimize) (lower_column_expr_for_alias derived_src inner_where))))
 			(list (quote lambda) (list (quote acc) (quote mapped))
-				(list (quote begin)
-					(list (list (quote car) (quote mapped)) (list (quote +) (quote acc) 1))
-					(list (quote +) (quote acc) 1)))
+				(list (quote if) (list (quote cadr) (quote mapped))
+					(list (quote begin)
+						(list (list (quote car) (quote mapped)) (list (quote +) (quote acc) 1))
+						(list (quote +) (quote acc) 1))
+					(list (quote begin)
+						(list (list (quote car) (quote mapped)) 0)
+						(quote acc))))
 			0
 			(list (list (quote kind) (quote ordered-window)))))
 		(define rn_expr (list (quote get_column) alias false rn_col false))
@@ -2236,7 +2246,6 @@ instead of capturing whichever session populated the carrier first. */
 		(define upper_bound (+ offset_value (qb_limit inner)))
 		(define lower_filter (if (> offset_value 0) (list (quote >) rn_expr offset_value) true))
 		(define limit_filter (combine_where lower_filter (list (quote <=) rn_expr upper_bound)))
-		(define inner_where (requalify_single_source_expr inner_alias alias (qb_where inner)))
 		(define derived_filter (combine_where inner_where limit_filter))
 		(list
 			(cons (source_with_join_expr derived_src derived_filter) helper_sources)
@@ -12175,6 +12184,25 @@ source remain residual so they observe the null-extended row. */
 			nil
 			(list (cons prepare (nth stream 0)) (nth stream 1) (nth stream 2))))))
 
+(define row_number_union_branch_stream_plan (lambda (branch)
+	(begin
+		(define cataloged (query_block_with_full_stage_catalog branch))
+		(define stages (qb_stages cataloged))
+		(if (not (and (equal? (count stages) 1) (row_number_stage? (car stages))))
+			nil
+			(begin
+				(define stage_lookup (query_block_stage_lookup cataloged))
+				(define dependency_graph (stage_dependency_graph stage_lookup))
+				(define prepared (query_block_without_stages_after_prepare_using stage_lookup cataloged))
+				(if (union_ordered_branch_supported? prepared)
+					(list
+						(merge (list
+							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup stages)
+							(lower_stage_materialize_all stages)))
+						prepared
+						nil)
+					nil))))))
+
 (define union_ordered_branch_stream_plan (lambda (branch)
 	(if (not (query_block? branch))
 		nil
@@ -12188,10 +12216,7 @@ source remain residual so they observe the null-extended row. */
 						(prejoined_union_branch_stream_plan branch)
 						(if (grouped_union_branch? branch)
 							(grouped_union_branch_stream_plan branch)
-							nil))))))))
-
-(define union_ordered_branch_streamable? (lambda (branch)
-	(not (nil? (union_ordered_branch_stream_plan branch)))))
+							(row_number_union_branch_stream_plan branch)))))))))
 
 (define union_sort_column_for_alias (lambda (src expr)
 	(match expr
@@ -12269,64 +12294,6 @@ source remain residual so they observe the null-extended row. */
 					(cons (quote begin) (merge (list prepares (list scan_plan))))))
 			(neumann_fail "build_queryplan" "UNION ALL ORDER BY requires streamable branches")))))
 
-(define union_materialized_order_fields (lambda (branch order_positions)
-	(begin
-		(define exprs (projection_exprs (qb_fields branch)))
-		(merge (list
-			(qb_fields branch)
-			(merge (map (produceN (count order_positions)) (lambda (i)
-				(list (concat "__order_" i) (nth exprs (nth order_positions i)))))))))))
-
-(define query_block_with_fields (lambda (block fields)
-	(make_query_block
-		(qb_schema block)
-		(qb_sources block)
-		fields
-		(qb_where block)
-		(qb_group block)
-		(qb_having block)
-		(qb_order block)
-		(qb_limit block)
-		(qb_offset block)
-		(qb_hidden block)
-		(qb_stages block)
-		(qb_facts block))))
-
-(define lower_query_block_capture_rows (lambda (block)
-	/* TODO(planner-scalability): delete this UNION list collector; ordered UNION
-	branches belong in scan_order_multi, with canonical temp tables as barriers. */
-	(begin
-		(define state (symbol "__union_rows"))
-		(define emit (symbol "__union_emit"))
-		(define row (symbol "__union_row"))
-		(list
-			(list (quote lambda) (list state emit)
-				(list (quote begin)
-					(list state "rows" (list (quote list)))
-					(list (quote define) (quote resultrow)
-						(list (quote lambda) (list row)
-							(list state "rows"
-								(list (quote append) (list state "rows") (list (quote cons) row (list (quote list)))))))
-					(lower_query_block_with_stages block)
-					(list state "rows")))
-			(list (quote newsession))
-			(quote resultrow)))))
-
-(define lower_union_all_materialized_ordered (lambda (block titles width)
-	(begin
-		(define branches (union_branches block))
-		(define aligned (map branches (lambda (branch) (union_align_branch_fields branch titles width))))
-		(define order_positions (union_order_positions titles (union_order block)))
-		(define rows_plan (cons (quote merge) (map aligned (lambda (branch)
-			(lower_query_block_capture_rows
-				(query_block_with_fields branch (union_materialized_order_fields branch order_positions)))))))
-		(join_sorted_rows_plan
-			rows_plan
-			(qb_fields (car aligned))
-			(union_order block)
-			(union_offset block)
-			(union_limit block)))))
-
 (define union_direct_order_supported? (lambda (block)
 	(begin
 		(define branches (union_branches block))
@@ -12364,11 +12331,7 @@ source remain residual so they observe the null-extended row. */
 				(define titles (projection_titles (qb_fields first_branch)))
 				(define width (count (qb_fields first_branch)))
 				(if (not (empty_list? (union_order block)))
-					(if (reduce branches (lambda (ok branch)
-						(and ok (union_ordered_branch_streamable? (union_align_branch_fields branch titles width))))
-						true)
-						(lower_union_all_ordered block titles width)
-						(lower_union_all_materialized_ordered block titles width))
+					(lower_union_all_ordered block titles width)
 					(if (or (not (nil? (union_limit block))) (not (nil? (union_offset block))))
 						(lower_union_all_ordered block titles width)
 						(cons (quote begin)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -10231,7 +10231,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 (define query_block_stages_to_prepare (lambda (block)
 	(query_block_stages_to_prepare_using (qb_stages block) block)))
 
-(define lower_query_block_with_cataloged_stages (lambda (block)
+(define prepare_simple_query_block_physical_core (lambda (block)
 	(begin
 		(define stage_lookup (query_block_stage_lookup block))
 		(if (empty_list? (qb_stages block))
@@ -10244,48 +10244,60 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 					(scalar_query_probe_recipe_bindings probe_recipe_plans))
 				(define probe_recipe_prepares
 					(scalar_query_probe_recipe_prepare_exprs probe_recipe_plans))
-				(if (empty_list? probe_recipe_bindings)
-					(lower_query_block_core recipe_block)
-					(cons (quote !begin) (merge (list
+				(list
+					(merge (list probe_recipe_prepares probe_recipe_bindings))
+					recipe_block))
+			(begin
+				(define stage_catalog (query_block_stage_catalog block))
+				(define eager_stages (query_block_stages_to_prepare_using stage_lookup block))
+				(define dependency_graph (stage_dependency_graph stage_lookup))
+				(define raw_prepared_block (if (single_source? (qb_sources block))
+					(query_block_without_stages_after_prepare_using stage_lookup block)
+					(query_block_with_prepared_sources_using stage_lookup block)))
+				(define probe_recipe_entries
+					(query_block_scalar_query_probe_recipe_entries raw_prepared_block))
+				(define probe_recipe_plans
+					(scalar_query_probe_recipe_plans_using_graph
+						stage_lookup dependency_graph probe_recipe_entries))
+				(define prepared_block
+					(query_block_with_scalar_query_probe_recipes raw_prepared_block probe_recipe_entries))
+				(define probe_recipe_bindings
+					(scalar_query_probe_recipe_bindings probe_recipe_plans))
+				(define probe_recipe_prepares
+					(scalar_query_probe_recipe_prepare_exprs probe_recipe_plans))
+				(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
+				(define core_block (query_block_without_stages
+					(query_block_with_stage_catalog prepared_block lazy_catalog)))
+				(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
+				(list
+					(merge (list
 						probe_recipe_prepares
 						probe_recipe_bindings
-						(list (lower_query_block_core recipe_block)))))))
+						(lazy_stage_prepare_bindings stage_catalog lazy_stages)
+						(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup eager_stages)))
+					core_block))))))
+
+(define lower_simple_query_block_with_cataloged_stages (lambda (block)
+	(begin
+		(define prepared (prepare_simple_query_block_physical_core block))
+		(define prelude (nth prepared 0))
+		(define core_block (nth prepared 1))
+		(if (empty_list? prelude)
+			(lower_query_block_core core_block)
+			(cons (quote !begin) (merge (list
+				prelude
+				(list (lower_query_block_core core_block)))))))))
+
+(define lower_query_block_with_cataloged_stages (lambda (block)
+	(if (empty_list? (qb_stages block))
+		(lower_simple_query_block_with_cataloged_stages block)
+		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
+			(lower_grouped_query_block_with_stages block)
 			(begin
-				(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
-					(lower_grouped_query_block_with_stages block)
-					(begin
-						(define fused_row_number (lower_fused_row_number_block block))
-						(if (not (nil? fused_row_number))
-							fused_row_number
-							(begin
-								(define stage_catalog (query_block_stage_catalog block))
-								(define eager_stages (query_block_stages_to_prepare_using stage_lookup block))
-								(define dependency_graph (stage_dependency_graph stage_lookup))
-								(define raw_prepared_block (if (single_source? (qb_sources block))
-									(query_block_without_stages_after_prepare_using stage_lookup block)
-									(query_block_with_prepared_sources_using stage_lookup block)))
-								(define probe_recipe_entries
-									(query_block_scalar_query_probe_recipe_entries raw_prepared_block))
-								(define probe_recipe_plans
-									(scalar_query_probe_recipe_plans_using_graph
-										stage_lookup dependency_graph probe_recipe_entries))
-								(define prepared_block
-									(query_block_with_scalar_query_probe_recipes raw_prepared_block probe_recipe_entries))
-								(define probe_recipe_bindings
-									(scalar_query_probe_recipe_bindings probe_recipe_plans))
-								(define probe_recipe_prepares
-									(scalar_query_probe_recipe_prepare_exprs probe_recipe_plans))
-								(define lazy_catalog (stages_without_ids stage_catalog (stage_ids eager_stages)))
-								(define core_block (query_block_without_stages
-									(query_block_with_stage_catalog prepared_block lazy_catalog)))
-								(define lazy_stages (carrier_stages_from_sources lazy_catalog (qb_sources core_block)))
-								(cons (quote !begin)
-									(merge (list
-										probe_recipe_prepares
-										probe_recipe_bindings
-										(lazy_stage_prepare_bindings stage_catalog lazy_stages)
-										(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup eager_stages)
-										(list (lower_query_block_core core_block)))))))))))))))
+				(define fused_row_number (lower_fused_row_number_block block))
+				(if (not (nil? fused_row_number))
+					fused_row_number
+					(lower_simple_query_block_with_cataloged_stages block)))))))
 
 (define lower_query_block_with_stages (lambda (block)
 	(lower_query_block_with_cataloged_stages (query_block_with_full_stage_catalog block))))
@@ -12203,11 +12215,20 @@ source remain residual so they observe the null-extended row. */
 						nil)
 					nil))))))
 
+(define prepared_union_branch_stream_plan (lambda (branch)
+	(begin
+		(define prepared (prepare_simple_query_block_physical_core
+			(query_block_with_full_stage_catalog branch)))
+		(define core_block (nth prepared 1))
+		(if (union_ordered_branch_supported? core_block)
+			(list (nth prepared 0) core_block nil)
+			nil))))
+
 (define union_ordered_branch_stream_plan (lambda (branch)
 	(if (not (query_block? branch))
 		nil
 		(if (union_ordered_branch_supported? branch)
-			(list '() branch nil)
+			(prepared_union_branch_stream_plan branch)
 			(begin
 				(define semijoin (union_semijoin_branch_stream_plan branch))
 				(if (not (nil? semijoin))
@@ -12216,17 +12237,14 @@ source remain residual so they observe the null-extended row. */
 						(prejoined_union_branch_stream_plan branch)
 						(if (grouped_union_branch? branch)
 							(grouped_union_branch_stream_plan branch)
-							(row_number_union_branch_stream_plan branch)))))))))
+							(begin
+								(define row_number (row_number_union_branch_stream_plan branch))
+								(if (not (nil? row_number))
+									row_number
+									(prepared_union_branch_stream_plan branch)))))))))))
 
 (define union_sort_column_for_alias (lambda (src expr)
-	(match expr
-		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) (order_column_for_alias src expr)
-		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) (order_column_for_alias src expr)
-		_ (begin
-			(define cols (extract_columns_for_alias src expr))
-			(list (quote lambda)
-				(map cols (lambda (col) (symbol (concat (source_alias src) "." col))))
-				(lower_column_expr_for_alias src expr))))))
+	(scan_order_sort_column_for_alias src expr)))
 
 (define union_ordered_scan_spec (lambda (branch titles order_positions table_override)
 	(begin

--- a/storage/index.go
+++ b/storage/index.go
@@ -697,9 +697,11 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			if len(s.ColMatchers) > colIdx && !s.ColMatchers[colIdx].IsSorted() {
 				continue
 			}
-			av := a.data[colIdx]
-			bv := b.data[colIdx]
-			if !state.precomputedDelta {
+			var av, bv scm.Scmer
+			if state.precomputedDelta {
+				av = a.data[colIdx]
+				bv = b.data[colIdx]
+			} else {
 				av = s.getDeltaColValue(a.data, colIdx)
 				bv = s.getDeltaColValue(b.data, colIdx)
 			}

--- a/tests/performance/ordered-carriers.yaml
+++ b/tests/performance/ordered-carriers.yaml
@@ -51,6 +51,65 @@ test_cases:
         - result_id: 2
         - result_id: 1
 
+  - name: "filtered bounded union branches stay in physical carriers"
+    setup:
+      - sql: "DROP TABLE IF EXISTS ordered_source_a"
+      - sql: "DROP TABLE IF EXISTS ordered_source_b"
+      - sql: "CREATE TABLE ordered_source_a (id INT PRIMARY KEY, value INT)"
+      - sql: "CREATE TABLE ordered_source_b (id INT PRIMARY KEY, value INT)"
+      - sql: "INSERT INTO ordered_source_a (id, value) VALUES (1, 10), (2, 20), (3, 30), (4, 40), (5, 50)"
+      - sql: "INSERT INTO ordered_source_b (id, value) VALUES (10, 7), (11, 8)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS ordered_source_b"
+      - sql: "DROP TABLE IF EXISTS ordered_source_a"
+    steps:
+      - sql: |
+          EXPLAIN
+          SELECT id FROM (
+            SELECT id FROM ordered_source_a WHERE value <= 30 ORDER BY id DESC LIMIT 2
+          ) AS bounded_a
+          UNION ALL
+          SELECT id FROM (
+            SELECT value AS id FROM ordered_source_b ORDER BY value ASC LIMIT 1
+          ) AS bounded_b
+          ORDER BY id
+        expect:
+          contains:
+            - "scan_order_multi"
+          not_contains:
+            - "__union_rows"
+            - "(sort rows"
+      - sql: |
+          SELECT id FROM (
+            SELECT id FROM ordered_source_a WHERE value <= 30 ORDER BY id DESC LIMIT 2
+          ) AS bounded_a
+          UNION ALL
+          SELECT id FROM (
+            SELECT value AS id FROM ordered_source_b ORDER BY value ASC LIMIT 1
+          ) AS bounded_b
+          ORDER BY id
+        expect:
+          rows: 3
+          data:
+            - id: 2
+            - id: 3
+            - id: 7
+      - sql: |
+          SELECT id FROM (
+            SELECT id FROM ordered_source_a WHERE value <= 30 ORDER BY id DESC LIMIT 2
+          ) AS bounded_a
+          UNION ALL
+          SELECT id FROM (
+            SELECT value AS id FROM ordered_source_b ORDER BY value ASC LIMIT 1
+          ) AS bounded_b
+          ORDER BY id
+        expect:
+          rows: 3
+          data:
+            - id: 2
+            - id: 3
+            - id: 7
+
   # Warmups exercise the physical RecSet projection and ordered merge.
   - name: "Perf: ORDERED JOIN UNION LIMIT"
     setup:

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -113,6 +113,45 @@ setup:
   - sql: "INSERT INTO trace_ref_d SELECT id, id, TRUE FROM trace_asset WHERE id % 509 = 0"
 
 test_cases:
+  - name: "ordered UNION scalar probes use the multi-scan carrier"
+    sql: |
+      EXPLAIN
+      SELECT *
+      FROM (
+        SELECT
+          b.id AS box_id,
+          0 AS indent,
+          CAST(b.owner_id AS VARCHAR) AS label,
+          'box' AS kind,
+          (SELECT f.id FROM trace_folder f WHERE f.box_id = b.id LIMIT 1) AS item_id,
+          (SELECT COUNT(*) FROM trace_message m WHERE NOT m.seen AND m.box_id = b.id) AS unseen
+        FROM trace_box b
+        WHERE (SELECT h.kind FROM trace_host h WHERE h.id = b.host_id) = 1
+          AND (CASE WHEN FALSE THEN TRUE ELSE NOT ((b.owner_id <> 7) AND NOT EXISTS (SELECT TRUE FROM trace_share s WHERE s.box_id = b.id AND s.owner_id = 7 LIMIT 1)) END)
+        UNION ALL
+        SELECT
+          f.box_id AS box_id,
+          1 AS indent,
+          f.name AS label,
+          'folder' AS kind,
+          f.id AS item_id,
+          (SELECT COUNT(*) FROM trace_message m WHERE m.folder_id = f.id AND NOT m.seen AND m.box_id = f.box_id) AS unseen
+        FROM trace_folder f
+        WHERE COALESCE((
+          SELECT (CASE WHEN FALSE THEN TRUE ELSE NOT ((b.owner_id <> 7) AND NOT EXISTS (SELECT TRUE FROM trace_share s WHERE s.box_id = b.id AND s.owner_id = 7 LIMIT 1)) END)
+          FROM trace_box b
+          WHERE b.id = f.box_id
+          LIMIT 1
+        ), FALSE)
+      ) t
+      ORDER BY box_id ASC, indent ASC, label ASC
+    expect:
+      contains:
+        - "scan_order_multi"
+      not_contains:
+        - "__union_rows"
+        - "(sort rows"
+
   - name: "UNION ALL wrapper decorrelates scalar subqueries in branches"
     fail_comment: "query is not fully decorrelated anymore; logical IR must not contain subquery markers"
     sql: |


### PR DESCRIPTION
## Summary

- remove the final ordered-UNION Scheme row collector (`lower_query_block_capture_rows`)
- lower filtered, branch-local `ORDER BY`/`LIMIT` through canonical row-number ORCs and feed the prepared carriers to `scan_order_multi`
- preserve the complete pre-row-number predicate in the ORC definition and canonical column identity
- fix warm computed-column index reuse when delta search keys have no raw column slots

The two assoc-to-dataset helpers named in the work package were already removed by #403. This PR removes the remaining list-backed relational path. Unsupported branch shapes now fail explicitly instead of falling back to Scheme materialization.

## Root cause

Non-streamable ordered UNION branches replaced `resultrow` with a session callback that repeatedly appended complete rows to `__union_rows`. Global ordering then used Scheme `merge`, `sort`, and `slice`. Besides unbounded memory, repeated immutable `append` made the branch collector quadratic.

Bounded derived relations already carry a logical row-number stage. The physical lowering can prepare that existing ORC, materialize it before the parallel multi-scan, and retain the row-number predicate while globally merging the surviving base rows.

The new warm regression exposed an independent delta-index bug: the B-tree comparator indexed raw `indexPair.data` before checking whether values had to be resolved through `getDeltaColValue`. A computed-only boundary can legitimately have an empty raw search key, so the second query panicked. The comparator now keeps raw and precomputed representations separate.

## A/B measurements against master

Same host and data, 5,000 rows in each of two anonymous sources. Each branch filters and selects a local top 1,000; the UNION globally orders and returns 100 rows.

| measurement | master | PR | change |
|---|---:|---:|---:|
| cold execution | 6.411 s | 1.154 s | 5.6x faster |
| warm execution median | 6.357 s | 0.0159 s | about 400x faster |
| cold EXPLAIN median, 10 distinct shapes | 6.71 ms | 7.53 ms | +0.82 ms / +12% |

Raw execution samples:

- master: 6.411, 6.323, 6.390, 6.422, 6.220 s
- PR: 1.154, 0.0210, 0.0169, 0.0149, 0.0144 s

The compile-only regression is the cost of planning and preparing a reusable physical carrier instead of emitting the simpler list collector. Execution amortizes that cost immediately. In a larger top-5,000 stress case, master exceeded 120 seconds while the PR completed the cold run in 5.78 seconds.

## Validation

- red-first YAML regression confirmed `__union_rows`/Scheme sort on master
- `tests/performance/ordered-carriers.yaml`: 3/3, including identical warm execution
- `tests/planner/set-operations/union-all.yaml`: 36/36
- `tests/planner/order-window/ordered-computed-column.yaml`: 19/19
- `tests/storage/indexes/suffix-recompute.yaml`: 52/52
- focused Go index/compute-proxy tests: pass
- Scheme formatter executed; only the repository's pre-existing negative-depth warnings remain

`tests/execution/operators/range-scan-coverage.yaml` completed 74/75; the only failure was a timeout in the scan-statistics aggregation after the physical pushdown assertion. All actual range/index and post-compress cases passed. The full repository suite is delegated to CI as agreed.\n## Ordered scalar-probe UNION follow-up\n\nCI exposed a second ordered-UNION shape: globally ordered `UNION ALL` branches containing decorrelated scalar and `EXISTS` probes. The shared query-block preparation now returns the physical prelude plus a stage-free core block, so normal query lowering and `scan_order_multi` consume the same scalar recipe, eager/lazy stage, and carrier decisions. Computed UNION sort expressions also use the common `scan_order` callback lowering, keeping physical column names unqualified.\n\nThis does not change the separate `EXISTS`/`IN (... UNION ...)` membership strategy; its RecSet merge/probe regression remains green. Master rejects the ordered scalar-probe shape as non-streamable, while this PR emits `scan_order_multi` and returns the expected rows. Added validation: `traced-union-scalar-probes.yaml` 3/3 and `derived-table-limit-scalar.yaml` 38/38.\n