### PR TITLE
Use nested outer keys as scan boundaries

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -413,6 +413,42 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		}
 		return 0, false
 	}
+	resolveOuterReference := func(node scm.Scmer) (scm.Scmer, bool) {
+		depth := 0
+		for {
+			parts, ok := scmerSlice(node)
+			if !ok || len(parts) != 2 || !scanSymbolIs(parts[0], "outer") {
+				break
+			}
+			depth++
+			node = parts[1]
+		}
+		if depth == 0 {
+			return scm.NewNil(), false
+		}
+
+		env := p.En
+		for level := 1; level < depth && env != nil; level++ {
+			env = env.Outer
+		}
+		if env == nil {
+			return scm.NewNil(), false
+		}
+		if node.IsSymbol() {
+			sym := scm.Symbol(node.String())
+			if binding := env.FindRead(sym); binding != nil {
+				value, ok := binding.Vars[sym]
+				return value, ok
+			}
+		}
+		if node.IsNthLocalVar() {
+			idx := int(node.NthLocalVar())
+			if idx < len(env.VarsNumbered) {
+				return env.VarsNumbered[idx], true
+			}
+		}
+		return scm.NewNil(), false
+	}
 	// analyze condition for AND clauses, equal? < > <= >= BETWEEN
 	extractConstant := func(v scm.Scmer) (scm.Scmer, bool) {
 		if v.IsInt() || v.IsFloat() || v.IsString() || v.IsBool() || v.IsCustom(TagRecSet) {
@@ -425,26 +461,9 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				}
 			}
 		}
-		if v.IsSlice() {
-			val := v.Slice()
-			if len(val) > 0 && val[0].SymbolEquals("outer") {
-				if val[1].IsSymbol() {
-					sym := scm.Symbol(val[1].String())
-					if val2, ok := p.En.Vars[sym]; ok {
-						if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
-							return val2, true
-						}
-					}
-				} else if val[1].IsNthLocalVar() {
-					// (outer NthLocalVar(i)) — free variable from outer captured environment
-					idx := int(val[1].NthLocalVar())
-					if p.En.VarsNumbered != nil && idx < len(p.En.VarsNumbered) {
-						val2 := p.En.VarsNumbered[idx]
-						if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
-							return val2, true
-						}
-					}
-				}
+		if val2, ok := resolveOuterReference(v); ok {
+			if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
+				return val2, true
 			}
 		}
 		if isIndependent(params, v) {

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -58,6 +58,65 @@ func TestBoundaryEqual(t *testing.T) {
 	}
 }
 
+func TestBoundaryEqualResolvesNestedOuterNumberedVar(t *testing.T) {
+	root := &scm.Env{Vars: make(scm.Vars), VarsNumbered: []scm.Scmer{scm.NewInt(33)}}
+	middle := &scm.Env{Vars: make(scm.Vars), VarsNumbered: []scm.Scmer{scm.NewInt(22)}, Outer: root}
+	immediate := &scm.Env{Vars: make(scm.Vars), VarsNumbered: []scm.Scmer{scm.NewInt(11)}, Outer: middle}
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewNthLocalVar(0),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("outer"),
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("outer"),
+				scm.NewSlice([]scm.Scmer{
+					scm.NewSymbol("outer"),
+					scm.NewNthLocalVar(0),
+				}),
+			}),
+		}),
+	})
+	cond := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("key")}),
+		Body:   body,
+		En:     immediate,
+	})
+
+	bounds := extractBoundaries([]string{"k0"}, cond)
+	if len(bounds) != 1 {
+		t.Fatalf("expected nested outer key to produce one boundary, got %d", len(bounds))
+	}
+	if bounds[0].col != "k0" || bounds[0].matcher.Kind() != "equal" {
+		t.Fatalf("unexpected nested outer boundary: %#v", bounds[0])
+	}
+	if got := scm.ToInt(bounds[0].lower); got != 33 {
+		t.Fatalf("nested outer boundary = %d, want 33", got)
+	}
+}
+
+func TestBoundaryEqualMissingOuterFrameIsNotExtracted(t *testing.T) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewNthLocalVar(0),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("outer"),
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("outer"),
+				scm.NewNthLocalVar(0),
+			}),
+		}),
+	})
+	cond := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("key")}),
+		Body:   body,
+		En:     &scm.Env{Vars: make(scm.Vars)},
+	})
+
+	if bounds := extractBoundaries([]string{"k0"}, cond); len(bounds) != 0 {
+		t.Fatalf("missing outer frame produced boundaries: %#v", bounds)
+	}
+}
+
 // TestBoundaryRange verifies that < produces RangeMatcher.
 func TestBoundaryRange(t *testing.T) {
 	body := scm.NewSlice([]scm.Scmer{

--- a/tests/performance/unselective-scalar-order-limit.yaml
+++ b/tests/performance/unselective-scalar-order-limit.yaml
@@ -112,6 +112,9 @@ test_cases:
   - name: "Unselective scalar ORDER LIMIT defers nested access projections"
     max_time: 1.5
     max_plan_size: 100000
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` LIKE '.grp:query:%'"
     sql: |
       SELECT projected.id, projected.access_1, projected.access_2,
         projected.access_3, projected.access_4
@@ -179,6 +182,48 @@ test_cases:
           access_2: true
           access_3: true
           access_4: true
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
+  - name: "Nested direct outer correlation preserves scalar results"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` LIKE '.grp:usol_text_inner:%'"
+    sql: |
+      SELECT outer_row.id, (
+        SELECT (
+          SELECT inner_row.value
+          FROM usol_text_inner inner_row
+          WHERE inner_row.lookup_key = outer_row.lookup_key
+          LIMIT 1
+        )
+        FROM usol_parent middle_row
+        WHERE middle_row.id = outer_row.id
+        LIMIT 1
+      ) AS matched
+      FROM usol_text_outer outer_row
+      ORDER BY outer_row.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          matched: 30
+        - id: 2
+          matched: 20
+
+  - name: "Nested decorrelation carrier probes keep their key boundary"
+    sql: |
+      SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS indexed
+      FROM `system_statistic`.`scans`
+      WHERE `schema` = 'memcp-tests'
+        AND `table` LIKE '.grp:usol_text_inner:%'
+        AND index_cols = 'k0'
+    expect:
+      rows: 1
+      data:
+        - indexed: 1
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
 
   - name: "Composite scalar ORDER lookup preserves every key component"
     max_time: 1.5


### PR DESCRIPTION
## What changed

- resolve scan-boundary constants through arbitrarily nested `outer` environment references
- preserve conservative behavior when an expected parent environment is unavailable
- add Go coverage for nested numbered variables and missing parent frames
- add an anonymized SQL regression that is red on current master and verifies the decorrelated group carrier receives its `k0` point boundary

## Root cause

Physical scans only recognized a single `(outer ...)` wrapper while extracting index boundaries. Deeply decorrelated scalar subqueries can emit multiple wrappers that follow the runtime environment parent chain. Their predicates remained correct residual filters, but the group carrier was scanned without an index boundary for every outer row.

## A/B benchmark

Same large cloned data directory, same query and result, warm process, wall-clock end-to-end measurements:

| revision | runs | median |
| --- | ---: | ---: |
| master `67de9e651` | 49.844 s, 53.720 s | 51.782 s |
| this PR | 39.111 s, 40.570 s, 39.922 s | 39.922 s |

Median improvement: **22.9%**. Trace output confirms the affected carrier changes from an unbounded scan to `k0:[value..value]` point boundaries. Compile time remains about 1.2 s, so the improvement is in execution rather than planner timing.

## Validation

- current master: focused SQL suite fails `7/8` at the new boundary assertion
- this PR: focused SQL suite passes `8/8`
- `go test ./storage -run 'TestBoundary' -count=1`
- full `./git-pre-commit`: passed all Scheme and SQL suites

The coverage-instrumented `make test` path was also attempted twice. Under parallel load its shared server entered an existing global wait state; the two apparent terminal suites passed independently (`171/171` and `21/21`). No test, timeout, or parallelism setting was weakened in this PR.
