### PR TITLE
Fix canonical group carrier initialization race

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -9411,15 +9411,6 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 					(quoted_runtime_list '())
 					(quoted_runtime_list '()))))
 			'()))
-		(define keytable_init (cons (quote !begin)
-			(merge (list
-				(list
-					(list (quote if)
-						(list (quote createtable) schema grouptbl create_cols (quoted_runtime_list '("engine" "memory")) true)
-						nil
-						nil)
-					(list (quote touch_keytable) (list (quote table) schema grouptbl)))
-				(list (group_stage_session_binding_missing_expr stage schema grouptbl keys key_names))))))
 		(define collect_plan (if (not query_input_carrier)
 			nil
 			(if (union_block? src)
@@ -9464,7 +9455,24 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 		(define aggregate_prepare_expr (cons
 			(quote !begin)
 			(merge (list ensure_agg_columns agg_plans computed_order_plans))))
-		(if scalar_query_stage
+		(define base_group_fill (symbol "__group_base_fill"))
+		(define base_group_fill_call (list base_group_fill))
+		(define initial_fill_expr (if (nil? base_group_into_plan)
+			nil
+			(cons (quote !begin) (filter (list aggregate_prepare_expr base_group_fill_call cleanup_plan) (lambda (expr) (not (nil? expr)))))))
+		(define create_options (if (nil? initial_fill_expr)
+			(quoted_runtime_list '("engine" "memory"))
+			(list (quote list)
+				"engine" "memory"
+				"oninit" (list (quote lambda) '() initial_fill_expr))))
+		(define carrier_created (symbol "__group_carrier_created"))
+		(define keytable_init (list
+			(list (quote lambda) (list carrier_created)
+				(list (quote !begin)
+					(list (quote touch_keytable) (list (quote table) schema grouptbl))
+					carrier_created))
+			(list (quote createtable) schema grouptbl create_cols create_options true)))
+		(define lowered_plan (if scalar_query_stage
 			(list (quote !begin)
 				nested_prepare_expr
 				(if initializer_owner keytable_init nil)
@@ -9489,13 +9497,22 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 					(list (quote !begin)
 						nested_prepare_expr
 						(if initializer_owner
-							(list (quote if) keytable_init
-								(list (quote !begin)
-									aggregate_prepare_expr
-									base_group_into_plan
-									cleanup_plan)
-								aggregate_prepare_expr)
-							aggregate_prepare_expr))))))))
+							(list
+								(list (quote lambda) (list carrier_created)
+									(list (quote if) carrier_created
+										nil
+										(list (quote if) (group_stage_session_binding_missing_expr stage schema grouptbl keys key_names)
+											(list (quote !begin)
+												aggregate_prepare_expr
+												base_group_fill_call)
+											aggregate_prepare_expr)))
+								keytable_init)
+							aggregate_prepare_expr))))))
+		(if (nil? base_group_into_plan)
+			lowered_plan
+			(list
+				(list (quote lambda) (list base_group_fill) lowered_plan)
+				(list (quote lambda) '() base_group_into_plan))))))
 
 (define lower_orc_stage_prepare (lambda (stage)
 	(begin

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1157,7 +1157,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createtable",
-		Desc: "creates a new database",
+		Desc: "creates a table, runs its oninit option and registered after-create-table lifecycle triggers synchronously, and returns only after initialization completes; concurrent if-not-exists callers wait for that same completion",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ifnotexists := len(a) > 4 && scm.ToBool(a[4])
 			db := GetDatabase(scm.String(a[0]))
@@ -1179,6 +1179,15 @@ func Init(en scm.Env) {
 			// result stays race-free under concurrent creators.
 			if ifnotexists {
 				if existing := db.tables.Get(tblName); existing != nil {
+					// A table is published before oninit so the initializer can access it.
+					// Do not let another creator return while that initializer is running.
+					if !existing.creationMu.TryLock() {
+						existing.creationMu.Lock()
+					}
+					existing.creationMu.Unlock()
+					if existing.creationPanic != nil {
+						panic(existing.creationPanic)
+					}
 					atomic.StoreUint64(&existing.lastAccessed, uint64(time.Now().UnixNano()))
 					return scm.NewBool(false)
 				}
@@ -1191,6 +1200,7 @@ func Init(en scm.Env) {
 			collation := ""
 			charset := ""
 			comment := ""
+			oninit := scm.NewNil()
 			for i := 0; i+1 < len(options); i += 2 {
 				key := scm.String(options[i])
 				val := options[i+1]
@@ -1205,6 +1215,8 @@ func Init(en scm.Env) {
 					comment = scm.String(val)
 				case "auto_increment":
 					autoIncrement, _ = strconv.ParseUint(scm.String(val), 0, 64)
+				case "oninit":
+					oninit = val
 				default:
 					panic("unknown option: " + key)
 				}
@@ -1276,20 +1288,32 @@ func Init(en scm.Env) {
 			db.schemalock.Lock()
 			existing := db.tables.Get(tblName)
 			if existing != nil {
-				if !ifnotexists {
-					db.schemalock.Unlock()
-					panic("Table " + tblName + " already exists")
-				}
 				// Keep the hot ifnotexists path free of schema saves. Planner-created
 				// helper tables deliberately re-issue createtable on every query; if
 				// the table already exists, "created=false" is the only signal the
 				// caller needs to skip collect/materialization work.
 				atomic.StoreUint64(&existing.lastAccessed, uint64(time.Now().UnixNano()))
 				db.schemalock.Unlock()
+				// The competing creator may have published the table after our
+				// optimistic probe. It owns creationMu until all initializers finish.
+				if !existing.creationMu.TryLock() {
+					existing.creationMu.Lock()
+				}
+				existing.creationMu.Unlock()
+				if existing.creationPanic != nil {
+					panic(existing.creationPanic)
+				}
+				if !ifnotexists {
+					panic("Table " + tblName + " already exists")
+				}
 				return scm.NewBool(false)
 			}
 
+			// Lock before publication. Every if-not-exists observer therefore waits
+			// until oninit and registered create-table triggers have both completed.
+			newTable.creationMu.Lock()
 			if prev := db.tables.Set(newTable); prev != nil {
+				newTable.creationMu.Unlock()
 				db.schemalock.Unlock()
 				panic("Table " + tblName + " already exists")
 			}
@@ -1313,18 +1337,31 @@ func Init(en scm.Env) {
 			}
 			db.saveLockedWithDurabilityAndUnlock(newTable.PersistencyMode == Safe)
 			registerCreatedTable(newTable)
-			executeRegisteredCreateTableTriggers(newTable)
+			func() {
+				defer func() {
+					// Publish the shared outcome before releasing concurrent creators.
+					newTable.creationPanic = recover()
+					newTable.creationMu.Unlock()
+				}()
+				if !oninit.IsNil() {
+					scm.Apply(oninit)
+				}
+				executeRegisteredCreateTableTriggers(newTable)
+			}()
+			if newTable.creationPanic != nil {
+				panic(newTable.creationPanic)
+			}
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the new table"},
-				{Kind: "list", ParamName: "cols", ParamDesc: "list of columns and constraints, each '(\"column\" colname typename dimensions typeparams) where dimensions is a list of 0-2 numeric items or '(\"primary\" cols) or '(\"unique\" cols) or '(\"foreign\" cols tbl2 cols2 updatemode deletemode of 'restrict'|'cascade'|'set null')"},
-				{Kind: "list", ParamName: "options", ParamDesc: "further options like engine=safe|sloppy|memory"},
-				{Kind: "bool", ParamName: "ifnotexists", ParamDesc: "don't throw an error if table already exists", Optional: true},
+				{Kind: "string", ParamName: "schema", ParamDesc: "name of the existing database that will contain the table"},
+				{Kind: "string", ParamName: "table", ParamDesc: "name of the table to create"},
+				{Kind: "list", ParamName: "cols", ParamDesc: "column and constraint definitions: (\"column\" name type dimensions typeparams), (\"unique\" name columns), or (\"foreign\" name local_columns referenced_table referenced_columns update_mode delete_mode). dimensions is a list of integer type dimensions. typeparams is an alternating key/value list supporting primary (bool), unique (bool), auto_increment (bool), null (bool), default (any), update (expression), comment (string), collate (string), temp (bool), filtercols (string list), filter (function), sortcols (string list), sortdirs (bool list), partitioncount (integer), mapcols (string list), mapfn (function), reducefn (function), and reduceinit (any). Column lists are string lists; foreign-key modes are restrict, cascade, or set null"},
+				{Kind: "list", ParamName: "options", ParamDesc: "alternating key/value list; supported keys are engine (safe, logged, sloppy, or memory), collation (string), charset (string), comment (string), auto_increment (non-negative integer), and oninit (zero-argument function run exactly once and synchronously after first creation; concurrent if-not-exists callers wait for it and do not run it again)"},
+				{Kind: "bool", ParamName: "ifnotexists", ParamDesc: "when true, return false instead of failing if the table exists; if another caller is still creating it, wait for that caller's after-create-table initialization before returning false", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "bool"},
+			Return: &scm.TypeDescriptor{Kind: "bool", ParamDesc: "true when this call created and initialized the table, false when ifnotexists reused an initialized table"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{

--- a/storage/table.go
+++ b/storage/table.go
@@ -325,6 +325,11 @@ type table struct {
 
 	lastAccessed uint64 // atomic; UnixNano timestamp for CacheManager LRU of TempKeytable
 
+	// creationMu is held while a newly published table runs its synchronous
+	// oninit hook. Concurrent if-not-exists calls wait on the same barrier.
+	creationMu    sync.Mutex
+	creationPanic any
+
 	// cacheInitMu guards the one-time initializer for canonical planner caches.
 	// The table object is removed on cache eviction, so initialization state has
 	// exactly the same lifetime as the cached relation itself.

--- a/tests/execution/concurrency/group-carrier-initialization.yaml
+++ b/tests/execution/concurrency/group-carrier-initialization.yaml
@@ -1,0 +1,136 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Concurrent callers wait for cold canonical group-carrier initialization"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS `.creation_barrier`"
+  - sql: "DROP TABLE IF EXISTS aggregate_source"
+  - sql: |
+      CREATE TABLE aggregate_source (
+        id INT PRIMARY KEY,
+        nullable_key INT,
+        value DECIMAL(12,2)
+      )
+
+test_cases:
+  - name: "Creator waits for existing table initialization 1/2"
+    parallel: existing_creation_barrier
+    scm: &create_with_initializer |
+      (begin
+        (createtable
+          "memcp-tests"
+          ".creation_barrier"
+          (list (list "column" "id" "int" (list) (list)))
+          (list "engine" "memory" "oninit"
+            (lambda ()
+              (begin
+                (sleep 0.2)
+                (insert
+                  (table "memcp-tests" ".creation_barrier")
+                  (list "id")
+                  (list (list 1))
+                  (list)
+                  (lambda () true)
+                  false))))
+          true)
+        (if (table_empty? (table "memcp-tests" ".creation_barrier"))
+          (error "createtable returned before oninit completed")
+          true))
+
+  - name: "Creator waits for existing table initialization 2/2"
+    parallel: existing_creation_barrier
+    scm: *create_with_initializer
+
+  - name: "Initializer ran exactly once"
+    sql: "SELECT COUNT(*) AS marker_count FROM `.creation_barrier`"
+    expect:
+      rows: 1
+      data:
+        - marker_count: 1
+
+  - name: "Cold aggregate caller 1/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: &empty_sum
+      rows: 1
+      data:
+        - total: null
+
+  - name: "Cold aggregate caller 2/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 3/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 4/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 5/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 6/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 7/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 8/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 9/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 10/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 11/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Cold aggregate caller 12/12"
+    parallel: cold_group_carrier
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+  - name: "Warm aggregate remains usable"
+    sql: "SELECT SUM(value) AS total FROM aggregate_source WHERE nullable_key = NULL"
+    expect: *empty_sum
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS `.creation_barrier`"
+  - sql: "DROP TABLE IF EXISTS aggregate_source"


### PR DESCRIPTION
## Summary

- add a synchronous `oninit` option to `createtable`
- make concurrent creators of the same table wait for the creator's initialization result
- move canonical group-carrier first fill and incremental-maintenance registration into the one-time initializer
- keep the session-domain fill recipe shared in generated code so the physical RecSet plan occurs only once
- document all `createtable` parameters and supported option/type-parameter keys

## Root cause

Canonical group carriers were published before their aggregate columns, initial rows, and maintenance triggers were ready. Concurrent cold queries could therefore reuse a partially initialized table and fail with an invalid aggregate column. Initialization also happened as follow-up planner commands, outside the creation contract.

The table-local creation barrier is locked before publication. `oninit` and registered after-create lifecycle hooks run synchronously for the actual creator only. Concurrent `ifnotexists` callers wait for completion and receive the same initialization panic when initialization failed. Unrelated tables remain fully parallel.

After the initial snapshot, normal base-table changes are handled by the existing incremental key and aggregate maintenance. A previously unseen session domain still invokes the shared base-fill recipe once because no prior DML event could have created that domain key.

## A/B measurements

Current `master` (`00b0a3769`) versus this branch, same machine and test:

| Measurement | master | branch |
|---|---:|---:|
| concurrent initialization regression | 7/16 pass | 16/16 pass |
| cold aggregate callers | 6/12 pass | 12/12 pass |
| initializer wait/exactly-once checks | unsupported (`oninit` rejected) | 3/3 pass |
| 100,000 warm `createtable ... ifnotexists` calls, median of 5 | 0.19 s | 0.19 s |

Master failures reproduced `UPDATE on invalid column: agg_41710798ed10202c` and an index-out-of-range error. The warm-path barrier overhead was below the measurement resolution. Individual warm samples were master 0.19/0.20/0.19/0.20/0.18 s and branch 0.20/0.19/0.18/0.19/0.19 s.

## Validation

- full `./git-pre-commit`: passed
- new concurrency suite: 16/16 passed
- all planner aggregate suites: passed
- `tests/performance/session-group-cache.yaml`: 37/37 passed, including the single-RecSet plan contract
- `tests/execution/operators/range-scan-coverage.yaml`: 75/75 passed
- Scheme formatter and `git diff --check`: passed

A separate `go test -race ./storage/...` run exposed existing races and a pre-existing repartition timeout in untouched storage paths; none of its reports or stacks involved the new creation barrier.