### PR TITLE
Sanitize derived DECIMAL aggregate output

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6669,12 +6669,28 @@ is still available and remains an ordinary scalar expression through untangle. *
 				(nth dimensions 1)
 				nil)))))
 
+(define decimal_derived_column_scale (lambda (relation col)
+	(begin
+		(define normalized (normalize_query_ast relation))
+		(if (query_block? normalized)
+			(reduce_assoc (qb_fields normalized) (lambda (best title expr)
+				(if (and (string? title) (string? col)
+					(equal? (toLower title) (toLower col)))
+					(decimal_expr_scale (qb_sources normalized) expr)
+					best)) nil)
+			nil))))
+
+(define decimal_source_column_scale (lambda (src col)
+	(begin
+		(define derived_scale (decimal_derived_column_scale (source_relation src) col))
+		(if (nil? derived_scale) (decimal_column_scale src col) derived_scale))))
+
 (define decimal_column_scale_for_sources (lambda (sources tblvar col)
 	(reduce (coalesceNil sources '()) (lambda (best src)
 		(if (and (or (nil? tblvar) (equal?? tblvar (source_alias src)))
 			(not (stage_output_relation? (source_relation src))))
 			(begin
-				(define scale (decimal_column_scale src col))
+				(define scale (decimal_source_column_scale src col))
 				(if (nil? scale) best (if (nil? best) scale (max best scale))))
 			best)) nil)))
 
@@ -6708,7 +6724,9 @@ is still available and remains an ordinary scalar expression through untangle. *
 		(if (query_block? normalized)
 			(make_query_block
 				(qb_schema normalized)
-				(qb_sources normalized)
+				(map (qb_sources normalized) (lambda (src)
+					(source_with_relation src
+						(sanitize_decimal_aggregate_outputs (source_relation src)))))
 				(sanitize_decimal_aggregate_fields (qb_sources normalized) (qb_fields normalized))
 				(qb_where normalized)
 				(qb_group normalized)

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -52,6 +52,26 @@ func sqlLiteralArithmetic(a, b Scmer, subtract bool) Scmer {
 	return NewFloat(result)
 }
 
+func roundSQLDecimalOutput(value float64, scale int) float64 {
+	factor := math.Pow10(scale)
+	scaled := value * factor
+	if math.IsNaN(scaled) || math.IsInf(scaled, 0) {
+		return value
+	}
+
+	// Exact DECIMAL half values can land one binary ULP to either side after
+	// arithmetic. Snap only that representation error to the half boundary;
+	// values farther away retain normal half-away-from-zero rounding.
+	half := math.Round(scaled*2) / 2
+	ulpUp := math.Abs(math.Nextafter(scaled, math.Inf(1)) - scaled)
+	ulpDown := math.Abs(scaled - math.Nextafter(scaled, math.Inf(-1)))
+	tolerance := 2 * math.Max(ulpUp, ulpDown)
+	if math.Abs(scaled-half) <= tolerance {
+		scaled = half
+	}
+	return math.Round(scaled) / factor
+}
+
 func init_alu() {
 	// string functions
 	DeclareTitle("Arithmetic / Logic")
@@ -609,12 +629,11 @@ func init_alu() {
 			if scale < 0 || scale > 15 {
 				return a[0]
 			}
-			factor := math.Pow10(int(scale))
 			value := a[0].Float()
 			if math.IsNaN(value) || math.IsInf(value, 0) {
 				return a[0]
 			}
-			return NewFloat(math.Round(value*factor) / factor)
+			return NewFloat(roundSQLDecimalOutput(value, scale))
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{

--- a/scm/alu_decimal_output_test.go
+++ b/scm/alu_decimal_output_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestRoundSQLDecimalOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float64
+		scale int
+		want  float64
+	}{
+		{name: "addition residue", value: 0.30000000000000004, scale: 2, want: 0.3},
+		{name: "positive half below boundary", value: 62668.72499999999, scale: 2, want: 62668.73},
+		{name: "negative half above boundary", value: -1.0049999999999999, scale: 2, want: -1.01},
+		{name: "ordinary value below half", value: 1.004, scale: 2, want: 1.0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := roundSQLDecimalOutput(test.value, test.scale); got != test.want {
+				t.Fatalf("roundSQLDecimalOutput(%v, %d) = %v, want %v", test.value, test.scale, got, test.want)
+			}
+		})
+	}
+}

--- a/tests/storage/formats/decimal-sanitizer.yaml
+++ b/tests/storage/formats/decimal-sanitizer.yaml
@@ -17,6 +17,7 @@ setup:
   - sql: "CREATE TABLE char_strict (id INT, s CHAR(5) UNIQUE)"
   - sql: "CREATE TABLE mixed_col (id INT, x any)"
   - sql: "CREATE TABLE dec_scale0 (id INT, val DECIMAL(10,0))"
+  - sql: "CREATE TABLE dec_output_stage (amount DECIMAL(10,2), factor DECIMAL(10,2))"
 
 test_cases:
 
@@ -42,6 +43,40 @@ test_cases:
       rows: 1
       data:
         - { total: 113.06 }
+
+  - name: "Insert decimal output boundary values"
+    sql: "INSERT INTO dec_output_stage VALUES (0.10, 1.00), (0.20, 1.00)"
+    expect:
+      affected_rows: 2
+
+  - name: "Derived decimal aggregate hides binary float residue"
+    sql: "SELECT SUM(value) AS total FROM (SELECT amount * factor AS value FROM dec_output_stage) AS derived_values"
+    expect:
+      rows: 1
+      result_contains: '"total": 0.3'
+      result_not_contains: '0.30000000000000004'
+      data:
+        - { total: 0.3 }
+
+  - name: "Output boundary preserves deliberate DOUBLE precision"
+    sql: "SELECT 1.0000000000000002 AS precise_value"
+    expect:
+      rows: 1
+      result_contains: '"precise_value": 1.0000000000000002'
+
+  - name: "Create decimal aggregate view"
+    sql: "CREATE VIEW dec_output_view AS SELECT SUM(amount * factor) AS total FROM dec_output_stage"
+    expect:
+      affected_rows: 1
+
+  - name: "Decimal aggregate view hides binary float residue"
+    sql: "SELECT total FROM dec_output_view"
+    expect:
+      rows: 1
+      result_contains: '"total": 0.3'
+      result_not_contains: '0.30000000000000004'
+      data:
+        - { total: 0.3 }
 
   - name: "Insert negative DECIMAL"
     sql: "INSERT INTO dec_basic (id, price, qty) VALUES (4, -25.30, 10)"
@@ -594,6 +629,7 @@ test_cases:
         - { total: 5500 }
 
 cleanup:
+  - sql: "DROP VIEW IF EXISTS dec_output_view"
   - sql: "DROP TABLE IF EXISTS dec_basic"
   - sql: "DROP TABLE IF EXISTS dec_nn"
   - sql: "DROP TABLE IF EXISTS int_strict"
@@ -603,5 +639,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS char_strict"
   - sql: "DROP TABLE IF EXISTS mixed_col"
   - sql: "DROP TABLE IF EXISTS dec_scale0"
+  - sql: "DROP TABLE IF EXISTS dec_output_stage"
   - sql: "DROP TABLE IF EXISTS dec_rebuild"
   - sql: "DROP TABLE IF EXISTS dec_multiples"


### PR DESCRIPTION
## What changed

- propagate DECIMAL scale provenance through derived query blocks and expanded views
- sanitize derived aggregate output at the SQL boundary without changing DOUBLE output
- snap only binary representation error around exact half values before DECIMAL rounding
- add Go and SQL regressions for derived aggregates, view expansion, half-boundary rounding, and deliberate DOUBLE precision

## Why

TPC-H Q7, Q9, Q15, and Q22 produced visible binary floating-point residue even though their arithmetic originated from DECIMAL columns. Direct base-table aggregates were already sanitized, but derived relations and view-expanded query blocks lost the scale provenance.

The planner still retains the logical query-block model; no physical artifact or fallback path was introduced.

## Validation

- full pre-commit hook: all critical suites passed
- decimal sanitizer suite: 91/91
- TPC-H SF0.01 vs local PostgreSQL: Q7, Q9, Q15, Q22 match
- ORDER/LIMIT suite, normal binary: 21/21 (1.76 s)
- Go rounding unit tests pass

A coverage-instrumented full run exceeded two existing 5 s ORDER/LIMIT runtime guards, while the same suite passed normally on both master (1.99 s) and this branch (1.76 s). No guard, limit, or test set was changed.