### PR TITLE
Use PostgreSQL names for unaliased aggregate columns

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -139,6 +139,12 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(define extract_title (lambda (expr) (match expr
 		'((symbol get_column) nil _ col _) col
 		'((symbol get_column) tblvar _ col _) col /* x.y -> (concat tblvar "." col) */
+		'((symbol count_distinct) _) "count"
+		'((symbol sql_avg_divide) _ _) "avg"
+		'((symbol aggregate) _ (symbol sql_sum_reduce) _) "sum"
+		'((symbol aggregate) _ (symbol +) 0) "count"
+		'((symbol aggregate) _ (symbol min) _) "min"
+		'((symbol aggregate) _ (symbol max) _) "max"
 		(cons sym args) /* function call */ (concat (cons sym (map args extract_title)))
 		(concat expr)
 	)))

--- a/tests/sql/compatibility/psql-parser.yaml
+++ b/tests/sql/compatibility/psql-parser.yaml
@@ -46,6 +46,27 @@ setup:
         5000)
 
 test_cases:
+  - name: "Unaliased aggregates use PostgreSQL result column names"
+    sql: "SELECT COUNT(val), SUM(val), AVG(val), MIN(val), MAX(val) FROM psql_data"
+    expect:
+      rows: 1
+      data:
+        - { count: 4, sum: 110, avg: 27.5, min: 10, max: 50 }
+
+  - name: "Unaliased COUNT DISTINCT uses PostgreSQL result column name"
+    sql: "SELECT COUNT(DISTINCT name) FROM psql_data"
+    expect:
+      rows: 1
+      data:
+        - { count: 3 }
+
+  - name: "Explicit aggregate alias overrides PostgreSQL default name"
+    sql: "SELECT SUM(val) AS explicit_total FROM psql_data"
+    expect:
+      rows: 1
+      data:
+        - { explicit_total: 110 }
+
   - name: "Empty SUM and AVG use NULL rather than the COUNT identity"
     sql: "SELECT COUNT(val) AS row_count, SUM(val) AS total, AVG(val) AS average FROM psql_data WHERE id < 0"
     expect:


### PR DESCRIPTION
## What changed

- map unaliased PostgreSQL aggregate expressions to their standard result column names
- cover COUNT, COUNT DISTINCT, SUM, AVG, MIN, and MAX
- preserve explicit aliases unchanged

## Root cause

The PostgreSQL parser generated default result labels by serializing the internal expression AST. TPC-H Q18 therefore exposed `(aggregate l_quantity sql_sum_reduce nil)` instead of PostgreSQL's `sum` column name.

This is parser metadata only. Logical IR, decorrelation, physical lowering, and execution remain unchanged.

## Validation

- full pre-commit hook: all critical suites passed
- PostgreSQL compatibility suite: 55/55
- TPC-H Q18 SF0.01: result column vector now matches local PostgreSQL
- explicit aggregate aliases remain unchanged

Q18 still differs in DATE display formatting and takes about 46 seconds at SF0.01; those are separate architecture/performance work packages.