### PR TITLE
Avoid GLS ownership checks in SQL scans

### DIFF
--- a/storage/recset.go
+++ b/storage/recset.go
@@ -245,7 +245,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) recSetShard {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner()
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	var recsetPart *recSetShard
 	if recsetFilter != nil {
@@ -413,7 +413,7 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 
 func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []string, currentTx *TxContext, ss *scm.SessionState) [][]scm.Scmer {
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner()
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 
 	cols := make([]ColumnStorage, len(sourceKeyCols))
@@ -551,7 +551,7 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 
 func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols []string, keys [][]scm.Scmer, ss *scm.SessionState) recSetShard {
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner()
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	targetCols := make([]ColumnStorage, len(targetKeyCols))
 	targetReaders := make([]ColumnReader, len(targetKeyCols))
@@ -826,7 +826,7 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 
 func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner()
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 
 	ccols := make([]ColumnStorage, len(conditionCols))
@@ -910,7 +910,7 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner()
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 
 	ccols := make([]ColumnStorage, len(conditionCols))
@@ -1089,7 +1089,7 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	}
 
 	t.ensureLoaded()
-	skipShardReadLock := t.hasWriteOwner() || (currentTx != nil && currentTx.HasShardWrite(t))
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -676,10 +676,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 
 	t.ensureLoaded()
-	skipShardReadLock := currentTx != nil && currentTx.HasShardWrite(t)
-	if currentTx == nil {
-		skipShardReadLock = t.hasWriteOwner()
-	}
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	var recsetPart *recSetShard
 	if recsetFilter != nil {
@@ -817,7 +814,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	// shards have their column map populated by load(t) first.
 	// ensureMainCount then loads at least one column to initialize main_count.
 	t.ensureLoaded()
-	ownsWrite := t.hasWriteOwner()
+	ownsWrite := t.hasWriteOwnerForTx(currentTx)
 	lockMutationExclusively := hasMutationCallback && !ownsWrite
 	writeLocked := false
 	if lockMutationExclusively {
@@ -1074,7 +1071,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	}
 
 	t.ensureLoaded()
-	ownsWrite := t.hasWriteOwner()
+	ownsWrite := t.hasWriteOwnerForTx(currentTx)
 	lockMutationExclusively := hasMutationCallback && !ownsWrite
 	writeLocked := false
 	if lockMutationExclusively {

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -144,7 +144,7 @@ func BenchmarkScanFixedCosts_DeepStack(b *testing.B) {
 	}
 }
 
-func benchmarkUniquePointScan(b *testing.B, name string) {
+func benchmarkUniquePointScan(b *testing.B, name string, currentTx *TxContext) {
 	dbName := "bench_scan_point_" + name
 	databases.Remove(dbName)
 	CreateDatabase(dbName, true)
@@ -162,19 +162,25 @@ func benchmarkUniquePointScan(b *testing.B, name string) {
 	mapFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[0] })
 	nilFn := scm.NewNil()
 	// Warm the lazily built index before measuring regular probe overhead.
-	tbl.scan(nil, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
+	tbl.scan(currentTx, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		tbl.scan(nil, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
+		tbl.scan(currentTx, []string{"id"}, condition, []string{"label"}, mapFn, nilFn, scm.NewNil(), nilFn, false)
 	}
 }
 
 // BenchmarkScanUniquePoint measures the repeated dimension-table lookup used
 // by nested joins after logical decorrelation and join reordering.
 func BenchmarkScanUniquePoint(b *testing.B) {
-	benchmarkUniquePointScan(b, "read")
+	benchmarkUniquePointScan(b, "read", nil)
+}
+
+// BenchmarkScanUniquePointWithTx measures the normal SQL nested-probe path,
+// where the transaction already tracks shard write ownership explicitly.
+func BenchmarkScanUniquePointWithTx(b *testing.B) {
+	benchmarkUniquePointScan(b, "read_tx", NewTxContext(TxCursorStability))
 }
 
 func TestOpenMapReducerAllocatesMutationMetadataLazily(t *testing.T) {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -942,10 +942,7 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 	if foundShard == nil {
 		return notFoundValue
 	}
-	mapperAlreadyLocked := currentTx != nil && currentTx.HasShardWrite(foundShard)
-	if currentTx == nil {
-		mapperAlreadyLocked = foundShard.hasWriteOwner()
-	}
+	mapperAlreadyLocked := foundShard.hasWriteOwnerForTx(currentTx)
 	mapper := foundShard.OpenMapReducer(callbackCols, callback, aggregate, mapperAlreadyLocked, 0, nil, currentTx)
 	result := mapper.Stream(neutral, []uint32{foundID}, nil)
 	mapper.FlushSideEffects()
@@ -1129,7 +1126,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		adjustedSortdirs[i] = cmpFn
 	}
 
-	skipShardReadLock := t.hasWriteOwner() || (currentTx != nil && currentTx.HasShardWrite(t))
+	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	if t.t.tableLockOwner.Load() != nil {
 		t.t.waitTableLock(ss, false)
 	}

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -136,3 +136,21 @@ func TestIterateShardsParallelMarksPartitionMultiShardNonSolo(t *testing.T) {
 		t.Fatal("iterateShardsParallel partition multi shard incorrectly marked callback as solo")
 	}
 }
+
+func TestShardWriteOwnershipUsesExplicitTransactionState(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanpartxowner")
+	shard := tbl.Shards[0]
+	tx := NewTxContext(TxCursorStability)
+
+	if shard.hasWriteOwnerForTx(tx) {
+		t.Fatal("fresh transaction unexpectedly owns shard write lock")
+	}
+	tx.EnterShardWrite(shard)
+	if !shard.hasWriteOwnerForTx(tx) {
+		t.Fatal("transaction write ownership was not detected")
+	}
+	tx.ExitShardWrite(shard)
+	if shard.hasWriteOwnerForTx(tx) {
+		t.Fatal("released transaction write ownership remained visible")
+	}
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -722,6 +722,16 @@ func (t *storageShard) hasWriteOwner() bool {
 	return t.writeOwners[goid] > 0
 }
 
+// hasWriteOwnerForTx uses the explicit transaction lock state on SQL paths.
+// The goroutine owner fallback remains necessary for internal callers that do
+// not carry a transaction context.
+func (t *storageShard) hasWriteOwnerForTx(currentTx *TxContext) bool {
+	if currentTx != nil {
+		return currentTx.HasShardWrite(t)
+	}
+	return t.hasWriteOwner()
+}
+
 // rowValueByRecidLocked reads a column value for a recid. Caller must hold t.mu.
 func (t *storageShard) rowValueByRecidLocked(recid uint32, col string) scm.Scmer {
 	if recid < t.main_count {


### PR DESCRIPTION
## Root cause

Normal SQL scans already carry a `TxContext` that explicitly tracks shard write ownership. Nested scan, ordered-scan, and RecSet paths nevertheless called `hasWriteOwner()`, which obtains a goroutine ID through a runtime stack walk. A representative large document-list query performs thousands of nested probes, making that fixed per-probe cost visible in CPU profiles.

## Change

- use `TxContext.HasShardWrite` when a transaction context is available
- retain the goroutine-owner fallback for internal callers without a transaction context
- apply the same ownership lookup to scan, scanBatch, scan_order, and RecSet paths
- add a unit test for explicit transaction ownership
- add a point-probe benchmark for the normal transaction-carrying SQL path

This does not alter locking order, logical or physical plans, plan serialization, or scan results.

## A/B measurements

### Point probe microbenchmark

8 samples per revision, same host and benchmark harness:

| Revision | Median | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| master | 5.356 us | 2266 | 34 |
| PR | 3.171 us | 2009 | 32 |
| delta | **-40.8%** | -11.3% | -5.9% |

### Representative large document-list query

Same cloned data directory, identical query, three fresh process runs per revision:

| Revision | Samples | Median |
| --- | --- | ---: |
| master | 38.134 s, 39.839 s, 42.827 s | 39.839 s |
| PR | 28.834 s, 30.025 s, 29.366 s | 29.366 s |
| delta | | **-26.3%** |

All six responses were 72,360 bytes with identical SHA-256. Physical plan shape also remained identical at 14,889 nodes and 128,796 plan bytes. Compile time was about 1.1 s, so the observed improvement is in execution.

## Validation

- `go test ./storage -run 'TestShardWriteOwnership|TestIterateShardsParallel' -count=1`
- `python3 run_sql_tests.py tests/execution/concurrency/transactions.yaml` (171/171)
- `python3 run_sql_tests.py tests/sql/dml/update-exists-alias.yaml` (2/2)
- `python3 run_sql_tests.py tests/execution/concurrency/concurrent-update-contention.yaml` (126/126)
- full `./git-pre-commit`: all tests passed
