### PR TITLE
Track temporal SQL types through query planning

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -301,7 +301,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "DATE_ADD" true) "(" (define e psql_expression) "," (atom "INTERVAL" true) (define n psql_expression) (define unit psql_identifier_unquoted) ")") '('date_add e n unit))
 		(parser '((atom "DATE_SUB" true) "(" (define e psql_expression) "," (atom "INTERVAL" true) (define n psql_expression) (define unit psql_identifier_unquoted) ")") '('date_sub e n unit))
 		/* DATE('str') - parse date string; DATE(expr) - truncate to day */
-		(parser '((atom "DATE" true) (define s psql_string)) '('parse_date s))
+		(parser '((atom "DATE" true) (define s psql_string)) '('date_trunc_day '('parse_date s)))
 		(parser '((atom "DATE" true) "(" (define e psql_expression) ")") '('date_trunc_day e))
 		/* SUBSTRING(expr FROM start FOR len) - SQL standard syntax */
 		(parser '((atom "SUBSTRING" true) "(" (define s psql_expression) (atom "FROM" true) (define start psql_expression) (atom "FOR" true) (define len psql_expression) ")") '((quote sql_substr) s start len))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6747,6 +6747,126 @@ is still available and remains an ordinary scalar expression through untangle. *
 					(union_facts normalized))
 				normalized)))))
 
+/* Scmer and the storage engine intentionally keep temporal values generic.
+The SQL compiler retains the declared DATE/DATETIME/TIMESTAMP provenance and
+formats only visible result fields, after all relational operations have kept
+working on the original values. */
+(define temporal_column_type (lambda (src col)
+	(if (or (not (string? (source_schema src))) (not (string? (source_relation src))))
+		nil
+		(begin
+			(define info (find (get_schema (source_schema src) (source_relation src))
+				(lambda (candidate) (equal?? (candidate "Field") col)) nil))
+			(define raw_type (toLower (if (nil? info) "" (coalesceNil (info "RawType") ""))))
+			(match raw_type
+				"date" "DATE"
+				"datetime" "DATETIME"
+				"timestamp" "TIMESTAMP"
+				_ nil)))))
+
+(define temporal_derived_column_type (lambda (relation col)
+	(begin
+		(define normalized (normalize_query_ast relation))
+		(if (query_block? normalized)
+			(reduce_assoc (qb_fields normalized) (lambda (best title expr)
+				(if (and (nil? best) (string? title) (string? col)
+					(equal? (toLower title) (toLower col)))
+					(temporal_expr_type (qb_sources normalized) expr)
+					best)) nil)
+			nil))))
+
+(define temporal_source_column_type (lambda (src col)
+	(begin
+		(define derived_type (temporal_derived_column_type (source_relation src) col))
+		(if (nil? derived_type) (temporal_column_type src col) derived_type))))
+
+(define temporal_column_type_for_sources (lambda (sources tblvar col)
+	(reduce (coalesceNil sources '()) (lambda (best src)
+		(if (and (nil? best)
+			(or (nil? tblvar) (equal?? tblvar (source_alias src)))
+			(not (stage_output_relation? (source_relation src))))
+			(temporal_source_column_type src col)
+			best)) nil)))
+
+(define temporal_date_arithmetic_type (lambda (sources value unit)
+	(begin
+		(define value_type (temporal_expr_type sources value))
+		(if (and (equal? value_type "DATE") (string? unit))
+			(match (toLower unit)
+				"hour" "DATETIME"
+				"minute" "DATETIME"
+				"second" "DATETIME"
+				"microsecond" "DATETIME"
+				_ "DATE")
+			value_type))))
+
+(define temporal_expr_type (lambda (sources expr)
+	(match expr
+		((symbol get_column) tblvar _ignorecase col _col_ignorecase)
+		(temporal_column_type_for_sources sources tblvar col)
+		((quote get_column) tblvar _ignorecase col _col_ignorecase)
+		(temporal_column_type_for_sources sources tblvar col)
+		((symbol date_trunc_day) _value) "DATE"
+		((quote date_trunc_day) _value) "DATE"
+		((symbol current_date)) "DATE"
+		((quote current_date)) "DATE"
+		((symbol date_add) value _amount unit) (temporal_date_arithmetic_type sources value unit)
+		((quote date_add) value _amount unit) (temporal_date_arithmetic_type sources value unit)
+		((symbol date_sub) value _amount unit) (temporal_date_arithmetic_type sources value unit)
+		((quote date_sub) value _amount unit) (temporal_date_arithmetic_type sources value unit)
+		((symbol aggregate) value reducer _neutral)
+		(if (or (equal? reducer min) (equal? reducer max)
+			(equal? reducer (quote min)) (equal? reducer (quote max)))
+			(temporal_expr_type sources value)
+			nil)
+		((quote aggregate) value reducer _neutral)
+		(if (or (equal? reducer min) (equal? reducer max)
+			(equal? reducer (quote min)) (equal? reducer (quote max)))
+			(temporal_expr_type sources value)
+			nil)
+		((symbol now)) "TIMESTAMP"
+		((quote now)) "TIMESTAMP"
+		((symbol utc_timestamp)) "TIMESTAMP"
+		((quote utc_timestamp)) "TIMESTAMP"
+		((symbol from_unixtime) _value) "DATETIME"
+		((quote from_unixtime) _value) "DATETIME"
+		((symbol sql_temporal_output) _value sql_type) sql_type
+		((quote sql_temporal_output) _value sql_type) sql_type
+		_ nil)))
+
+(define sanitize_temporal_output_fields (lambda (sources fields)
+	(map_assoc (coalesceNil fields '()) (lambda (_title expr)
+		(begin
+			(define sql_type (temporal_expr_type sources expr))
+			(if (nil? sql_type) expr (list (quote sql_temporal_output) expr sql_type)))))))
+
+(define sanitize_temporal_outputs (lambda (query)
+	(begin
+		(define normalized (normalize_query_ast query))
+		(if (query_block? normalized)
+			(make_query_block
+				(qb_schema normalized)
+				(qb_sources normalized)
+				(sanitize_temporal_output_fields (qb_sources normalized) (qb_fields normalized))
+				(qb_where normalized)
+				(qb_group normalized)
+				(qb_having normalized)
+				(qb_order normalized)
+				(qb_limit normalized)
+				(qb_offset normalized)
+				(qb_hidden normalized)
+				(qb_stages normalized)
+				(qb_facts normalized))
+			(if (union_block? normalized)
+				(make_union_block
+					(union_mode normalized)
+					(map (union_branches normalized) sanitize_temporal_outputs)
+					(union_order normalized)
+					(union_limit normalized)
+					(union_offset normalized)
+					(union_facts normalized))
+				normalized)))))
+
 (define stage_aggregates_for_fields (lambda (fields)
 	(merge_unique (extract_assoc fields (lambda (_title expr) (extract_aggregates expr))))))
 
@@ -12388,7 +12508,7 @@ build_queryplan contract. */
 (define neumann_compile_pipeline (lambda (ast)
 	(build_queryplan
 		(join_reorder
-			(untangle_query_term (sanitize_decimal_aggregate_outputs ast) nil)))))
+			(untangle_query_term (sanitize_temporal_outputs (sanitize_decimal_aggregate_outputs ast)) nil)))))
 
 (define neumann_compile_ir_pipeline (lambda (ir)
 	(build_queryplan

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -771,7 +771,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "UNIX_TIMESTAMP" true) "(" (define p sql_expression) ")") '('unix_timestamp p))
 
 		/* DATE literal: DATE 'yyyy-mm-dd' */
-		(parser '((atom "DATE" true) (define s sql_string)) '('parse_date s))
+		(parser '((atom "DATE" true) (define s sql_string)) '('date_trunc_day '('parse_date s)))
 
 		/* CURRENT_DATE / CURRENT_DATE() */
 		(parser '((atom "CURRENT_DATE" true) "(" ")") '('current_date))

--- a/scm/date.go
+++ b/scm/date.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2024  Carl-Philip Hänsch
+Copyright (C) 2024-2026  Carl-Philip Hänsch
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -65,9 +65,46 @@ func toTime(v Scmer) (time.Time, bool) {
 	}
 }
 
+func sqlTemporalOutput(value Scmer, sqlType string) Scmer {
+	if value.IsNil() {
+		return NewNil()
+	}
+	t, ok := toTime(value)
+	if !ok {
+		return value
+	}
+	switch strings.ToUpper(sqlType) {
+	case "DATE":
+		return NewString(t.UTC().Format("2006-01-02"))
+	case "DATETIME", "TIMESTAMP":
+		if value.GetTag() == tagDate {
+			return NewString(DateToDisplay(value, GetCurrentSessionLocation()))
+		}
+		return NewString(t.In(GetCurrentSessionLocation()).Format("2006-01-02 15:04:05"))
+	default:
+		return value
+	}
+}
+
 func init_date() {
 	// string functions
 	DeclareTitle("Date")
+
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_temporal_output",
+		Desc: "formats a temporal SQL result according to its compiler-tracked declared type",
+		Fn: func(a ...Scmer) Scmer {
+			return sqlTemporalOutput(a[0], a[1].String())
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "any", ParamName: "value", ParamDesc: "type-flexible temporal value"},
+				{Kind: "string", ParamName: "sql_type", ParamDesc: "declared SQL temporal type"},
+			},
+			Return: &TypeDescriptor{Kind: "any"},
+			Const:  true,
+		},
+	})
 
 	Declare(&Globalenv, &Declaration{
 		Name: "now",

--- a/scm/date_output_test.go
+++ b/scm/date_output_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestSQLTemporalOutputDateFromGenericRepresentations(t *testing.T) {
+	const unix = int64(1718451045)
+	for _, value := range []Scmer{NewDate(unix), NewInt(unix), NewFloat(float64(unix)), NewString("2024-06-15 10:30:45")} {
+		if got := sqlTemporalOutput(value, "DATE").String(); got != "2024-06-15" {
+			t.Fatalf("DATE output = %q, want 2024-06-15", got)
+		}
+	}
+}
+
+func TestSQLTemporalOutputPreservesNilAndUnknownType(t *testing.T) {
+	if got := sqlTemporalOutput(NewNil(), "DATE"); !got.IsNil() {
+		t.Fatalf("DATE NULL output = %v, want nil", got)
+	}
+	value := NewInt(42)
+	if got := sqlTemporalOutput(value, "VARCHAR"); got != value {
+		t.Fatalf("unknown temporal type changed value: got %v, want %v", got, value)
+	}
+}

--- a/tests/sql/compatibility/psql-parser.yaml
+++ b/tests/sql/compatibility/psql-parser.yaml
@@ -429,6 +429,15 @@ test_cases:
     sql: "SELECT DATE('2025-06-15 12:30:00') AS d"
     expect:
       rows: 1
+      data:
+        - d: "2025-06-15"
+
+  - name: "PostgreSQL DATE column uses date-only output"
+    sql: "SELECT ship_date FROM psql_decimal_range LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - ship_date: "1994-06-15"
 
   # === DATE_ADD / DATE_SUB ===
   - name: "DATE_ADD"
@@ -457,7 +466,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "1998-09-02 00:00:00"
+        - d: "1998-09-02"
 
   # === CONVERT ===
   - name: "CONVERT to SIGNED"

--- a/tests/sql/expressions/date-functions.yaml
+++ b/tests/sql/expressions/date-functions.yaml
@@ -1,3 +1,12 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Date type and date function regression tests.
+
 metadata:
   version: "1.0"
   description: "Date type and date functions: tagDate, DATE column, DATE literal, INTERVAL, EXTRACT, DATE_ADD, DATE_SUB, CURRENT_DATE"
@@ -16,7 +25,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - dt: "2024-06-15 10:30:00"
+        - dt: "2024-06-15"
           ts: "2024-06-15 10:30:00"
 
   # --- INSERT unix timestamp integer ---
@@ -28,7 +37,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - dt: "2024-01-01 00:00:00"
+        - dt: "2024-01-01"
 
   # --- INSERT date-only string ---
   - name: "Insert date-only string"
@@ -39,7 +48,30 @@ test_cases:
     expect:
       rows: 1
       data:
-        - dt: "2024-12-25 00:00:00"
+        - dt: "2024-12-25"
+
+  - name: "DATE provenance survives a derived table"
+    sql: "SELECT d.dt FROM (SELECT dt FROM date_test WHERE id = 3) AS d"
+    expect:
+      rows: 1
+      data:
+        - dt: "2024-12-25"
+
+  - name: "Grouped DATE column keeps DATE output type"
+    sql: "SELECT dt, COUNT(*) AS n FROM date_test WHERE id = 3 GROUP BY dt"
+    expect:
+      rows: 1
+      data:
+        - dt: "2024-12-25"
+          n: 1
+
+  - name: "DATE aggregate keeps DATE output type"
+    sql: "SELECT MIN(dt) AS first_date, MAX(dt) AS last_date FROM date_test WHERE id IN (2, 3)"
+    expect:
+      rows: 1
+      data:
+        - first_date: "2024-01-01"
+          last_date: "2024-12-25"
 
   # --- NULL in DATE column ---
   - name: "Insert NULL date"
@@ -104,7 +136,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-03-15 00:00:00"
+        - d: "2024-03-15"
 
   # --- DATE literal in comparison ---
   - name: "DATE literal comparison"
@@ -143,21 +175,21 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-01-11 00:00:00"
+        - d: "2024-01-11"
 
   - name: "DATE_ADD months"
     sql: "SELECT DATE_ADD(DATE '2024-01-15', INTERVAL 3 MONTH) AS d"
     expect:
       rows: 1
       data:
-        - d: "2024-04-15 00:00:00"
+        - d: "2024-04-15"
 
   - name: "DATE_ADD years"
     sql: "SELECT DATE_ADD(DATE '2024-03-15', INTERVAL 1 YEAR) AS d"
     expect:
       rows: 1
       data:
-        - d: "2025-03-15 00:00:00"
+        - d: "2025-03-15"
 
   # --- DATE_SUB ---
   - name: "DATE_SUB days"
@@ -165,7 +197,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-05-31 00:00:00"
+        - d: "2024-05-31"
 
   # --- INTERVAL arithmetic: date + interval ---
   - name: "Date plus interval"
@@ -173,21 +205,21 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-03-31 00:00:00"
+        - d: "2024-03-31"
 
   - name: "Date minus interval"
     sql: "SELECT DATE '1998-12-01' - INTERVAL 90 DAY AS d"
     expect:
       rows: 1
       data:
-        - d: "1998-09-02 00:00:00"
+        - d: "1998-09-02"
 
   - name: "Date minus interval with leading field precision"
     sql: "SELECT DATE '1998-12-01' - INTERVAL '90' DAY (3) AS d"
     expect:
       rows: 1
       data:
-        - d: "1998-09-02 00:00:00"
+        - d: "1998-09-02"
 
   - name: "Interval precision requires digits"
     sql: "SELECT DATE '1998-12-01' - INTERVAL '90' DAY () AS d"
@@ -199,7 +231,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "1996-03-15 00:00:00"
+        - d: "1996-03-15"
 
   # --- CURRENT_DATE ---
   - name: "CURRENT_DATE is not null"
@@ -215,7 +247,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-06-15 00:00:00"
+        - d: "2024-06-15"
 
   # --- DATEDIFF ---
   - name: "DATEDIFF positive"
@@ -267,14 +299,14 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-04-15 00:00:00"
+        - d: "2024-04-15"
 
   - name: "DATE_SUB years"
     sql: "SELECT DATE_SUB(DATE '2024-06-15', INTERVAL 1 YEAR) AS d"
     expect:
       rows: 1
       data:
-        - d: "2023-06-15 00:00:00"
+        - d: "2023-06-15"
 
   - name: "DATE_SUB hours"
     sql: "SELECT DATE_SUB('2024-06-15 14:30:00', INTERVAL 2 HOUR) AS d"
@@ -302,7 +334,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-06-08 00:00:00"
+        - d: "2024-06-08"
 
   # --- DATE_ADD additional units ---
   - name: "DATE_ADD hours"
@@ -311,6 +343,13 @@ test_cases:
       rows: 1
       data:
         - d: "2024-06-15 13:00:00"
+
+  - name: "DATE plus sub-day interval returns DATETIME"
+    sql: "SELECT DATE_ADD(DATE '2024-06-15', INTERVAL 3 HOUR) AS d"
+    expect:
+      rows: 1
+      data:
+        - d: "2024-06-15 03:00:00"
 
   - name: "DATE_ADD minutes"
     sql: "SELECT DATE_ADD('2024-06-15 10:00:00', INTERVAL 45 MINUTE) AS d"
@@ -331,7 +370,7 @@ test_cases:
     expect:
       rows: 1
       data:
-        - d: "2024-06-29 00:00:00"
+        - d: "2024-06-29"
 
   # --- EXTRACT additional fields ---
   - name: "EXTRACT HOUR"


### PR DESCRIPTION
## What changed

- track declared `DATE`, `DATETIME`, and `TIMESTAMP` provenance while the logical query still has schema/source information
- format temporal values only at the visible SQL result boundary, keeping Scmer and storage representations generic and type-flexible
- distinguish date-only literals and preserve DATE through derived tables, grouping, `MIN`/`MAX`, and date arithmetic
- add MySQL- and PostgreSQL-dialect regression coverage plus unit tests for generic Scmer representations

## Why

TPC-H Q3 and Q18 returned PostgreSQL `DATE` columns as `YYYY-MM-DD 00:00:00`. Runtime storage representations may also be optimized into generic numeric forms, so correctness cannot depend on a dedicated Scmer storage tag. The compiler now carries the SQL type and applies presentation semantics only when emitting result fields.

No TPC-H toolkit, query text, generated data, or helper scripts are included.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`
- `python3 run_sql_tests.py tests/sql/expressions/date-functions.yaml` (69/69)
- `python3 run_sql_tests.py tests/sql/compatibility/psql-parser.yaml` (56/56)
- local untracked SF 0.01 comparison against PostgreSQL: Q3 PASS, Q18 PASS