### PR TITLE
Cache table handles during SQL compilation

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -682,7 +682,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(set updaterows3 (coalesce conflictupdates updaterows))
 			(set updaterows2 (if (nil? updaterows3) nil (merge updaterows3)))
 			(set updatecols (if (nil? updaterows3) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(define coldesc (coalesce coldesc (map (get_schema (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			'('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list (map datasets (lambda (dataset) (cons list dataset)))) (cons list updatecols)
 				(if (or do_nothing (and ignoreexists (nil? updaterows3)))
 					'((quote lambda) '() 0)
@@ -720,7 +720,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(define coldesc (coalesce coldesc (map (get_schema (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			'('begin
 				'('set 'resultrow '('lambda '('item) '('insert '('table (coalesce schema2 schema) tbl) (cons list coldesc) (cons list '((cons list (map (produceN (count coldesc)) (lambda (i) '('nth 'item (+ (* i 2) 1))))))) (cons list updatecols) (if ignoreexists '('lambda '() true) (if (nil? updaterows) nil '('lambda (map updatecols (lambda (c) (symbol c))) '('$update (cons 'list (map_assoc updaterows2 (lambda (k v) (replace_stupid v)))))))) false '('lambda '('id) '('session "last_insert_id" 'id)))))
 				(build_queryplan_term (sql_expand_views inner policy))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -71,7 +71,10 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 (define get_schema (lambda (schema tbl)
 	(try
-		(lambda () (show schema tbl))
+		(lambda ()
+			(begin
+				(define handle (table schema tbl))
+				(if handle (show handle) (show schema tbl))))
 		(lambda (_e) '()))))
 
 (define qassoc_get (lambda (xs key default)
@@ -3945,7 +3948,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 				nil))
 			(if (and (not (nil? live_count)) (> live_count 0))
 				live_count
-				(match (show schema relation)
+				(match (get_schema schema relation)
 					(cons col _rest) (col "RowEstimate")
 					_ live_count)))
 		(lambda (_e) nil))))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1297,7 +1297,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(define coldesc (coalesce coldesc (map (get_schema (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			(if (reduce datasets (lambda (a b) (or a (sql_dataset_contains_inner_select b))) false)
 				(begin
 					(define inner (sql_values_to_select_query (coalesce schema2 schema) coldesc datasets))
@@ -1333,7 +1333,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(define coldesc (coalesce coldesc (map (get_schema (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols)
 	)))
 
@@ -1367,7 +1367,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(set updaterows2 (if (nil? updaterows) nil (merge updaterows)))
 			(set updatecols (if (nil? updaterows) '() (cons "$update" (merge_unique (extract_assoc updaterows2 (lambda (k v) (extract_stupid v)))))))
-			(define coldesc (coalesce coldesc (map (show (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
+			(define coldesc (coalesce coldesc (map (get_schema (coalesce schema2 schema) tbl) (lambda (col) (col "Field")))))
 			(sql_insert_select_plan (coalesce schema2 schema) tbl coldesc inner ignoreexists updaterows updaterows2 updatecols)
 	)))
 

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -45,6 +45,28 @@ continue to occupy just their existing query-plan entry. */
 (define sql_parameterize_select_literals (lambda (query enabled)
 	(sql_parameterize_select_literals_cached sql_literal_shape_cache query enabled)))
 
+/* A parse can mention the same physical table through many aliases. Resolve
+and authorize each readable table once, then keep using show's immutable table
+snapshot through the stable handle for the rest of this compile only. */
+(define sql_compile_table_policy (lambda (policy)
+	(begin
+		(define catalog (newsession))
+		(lambda (schema tbl write)
+			(if write
+				(if policy (policy schema tbl true) true)
+				(begin
+					(define handle (table schema tbl))
+					(if (and handle (catalog handle))
+						true
+						(begin
+							(if policy (policy schema tbl false) true)
+							(if handle
+								(begin
+									(show handle)
+									(catalog handle true))
+								true)
+							true))))))))
+
 /* sql_parameterize_select_like_strings: query-plan-cache helper for ad-hoc
 fulltext-ish SELECTs. It replaces string literals directly following LIKE or
 inside MATCH...AGAINST(...) with ? placeholders and returns (normalized-query bindings). Other string
@@ -116,12 +138,17 @@ session. On parse error the result is not cached. */
 					(planning_session "schema" schema)
 					(planning_session "__memcp_tx" (session "__memcp_tx")))
 				nil)
+			(define compile_formula (lambda ()
+				(begin
+					(define compile_policy (sql_compile_table_policy policy))
+					(optimize (with_session planning_session (lambda ()
+						(parse_fn schema parse_query compile_policy)))))))
 			/* Compile diagnostics measure true misses and must not turn their own
 			previous result into a cache hit. The inspected query is never run. */
 			(define formula (if compile_diagnostic
-				(optimize (with_session planning_session (lambda () (parse_fn schema parse_query policy))))
+				(compile_formula)
 				(queryplan_cache "get_or_compute" cache_key
-					(lambda () (optimize (with_session planning_session (lambda () (parse_fn schema parse_query policy))))))))
+					compile_formula)))
 			(if (not (equal? bindings '()))
 				(reduce (produceN (count bindings)) (lambda (_ idx)
 					(session (concat "v" (string (+ idx 1))) (nth bindings idx))) nil)

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -194,8 +194,9 @@ func ApplyPromise(p Scmer, args []Scmer) Scmer {
 /* threadsafe session storage */
 
 type session struct {
-	Mu  sync.RWMutex
-	Map map[string]Scmer
+	Mu      sync.RWMutex
+	Map     map[string]Scmer
+	Handles map[Scmer]Scmer
 }
 
 // build this function into your SCM environment to offer http server capabilities
@@ -207,11 +208,24 @@ func NewSession(a ...Scmer) Scmer {
 		case 2:
 			sess.Mu.Lock()
 			defer sess.Mu.Unlock()
-			sess.Map[a[0].String()] = a[1]
+			if a[0].GetTag() >= 100 {
+				if sess.Handles == nil {
+					sess.Handles = make(map[Scmer]Scmer)
+				}
+				sess.Handles[a[0]] = a[1]
+			} else {
+				sess.Map[a[0].String()] = a[1]
+			}
 			return a[1]
 		case 1:
 			sess.Mu.RLock()
 			defer sess.Mu.RUnlock()
+			if a[0].GetTag() >= 100 {
+				if v, ok := sess.Handles[a[0]]; ok {
+					return v
+				}
+				return NewNil()
+			}
 			if v, ok := sess.Map[a[0].String()]; ok {
 				return v
 			}
@@ -219,9 +233,12 @@ func NewSession(a ...Scmer) Scmer {
 		case 0:
 			sess.Mu.RLock()
 			defer sess.Mu.RUnlock()
-			keys := make([]Scmer, 0, len(sess.Map))
+			keys := make([]Scmer, 0, len(sess.Map)+len(sess.Handles))
 			for k := range sess.Map {
 				keys = append(keys, NewString(k))
+			}
+			for k := range sess.Handles {
+				keys = append(keys, k)
 			}
 			return NewSlice(keys)
 		default:
@@ -363,7 +380,7 @@ func init_sync() {
 	Declare(&Globalenv, &Declaration{
 		Name: "newpromise",
 		Desc: "Creates a single-value promise cell (thread-safe via CAS spin-lock). Returns a tagPromise Scmer. (newpromise) allocates a [2]Scmer backing; (newpromise list) reuses an existing ≥2-element slice as backing with zero extra allocation. API: (p \"value\") reads current value (nil if pending), (p \"value\" v) resolves, (p \"once\" v) resolves once (panics if already fulfilled/failed), (p \"once\" v msg) resolves once with custom panic message, (p \"state\") returns state (nil/true/false), (p \"fail\") sets failed and clears the stored value, (p \"fail\" err) sets failed and stores err as payload.",
-		Fn: NewPromise,
+		Fn:   NewPromise,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "list", ParamDesc: "optional: ≥2-element slice to use as backing", Optional: true},
@@ -380,12 +397,12 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "newsession",
-		Desc: "Creates a new session which is a threadsafe key-value store represented as a function that can be either called as a getter (session key) or setter (session key value) or list all keys with (session)",
-		Fn: NewSession,
+		Desc: "Creates a new session which is a threadsafe key-value store represented as a function that can be either called as a getter (session key) or setter (session key value) or list all keys with (session). String-like keys use value semantics; custom handles use pointer identity without serialization.",
+		Fn:   NewSession,
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
 				Params: []*TypeDescriptor{
-					{Kind: "string", ParamName: "key", ParamDesc: "key to get or set", Optional: true},
+					{Kind: "any", ParamName: "key", ParamDesc: "key to get or set; custom handles retain identity", Optional: true},
 					{Kind: "any", ParamName: "value", ParamDesc: "value to store", Optional: true},
 				},
 				Return: &TypeDescriptor{Kind: "any"},
@@ -400,7 +417,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "session", ParamDesc: "the session to install", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", ParamName: "session", ParamDesc: "the session to install", Params: []*TypeDescriptor{{Kind: "any", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &TypeDescriptor{Kind: "any"}},
 				{Kind: "func", ParamName: "fn", ParamDesc: "the function to execute", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
@@ -409,7 +426,7 @@ func init_sync() {
 	Declare(&Globalenv, &Declaration{
 		Name: "context",
 		Desc: "Context helper function. Each context also contains a session. (context func args) creates a new context and runs func in that context, (context \"session\") reads the session variable, (context \"check\") will check the liveliness of the context and otherwise throw an error",
-		Fn: Context,
+		Fn:   Context,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "args...", ParamDesc: "depends on the usage", Variadic: true},
@@ -499,7 +516,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "number"},
-			Const: true,
+			Const:  true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -517,7 +534,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{
 			Return: &TypeDescriptor{Kind: "dict"},
-			Const: true,
+			Const:  true,
 		},
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2384,7 +2384,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "show",
-		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
+		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show table_handle) lists the memoized column defs\n(show table_handle true) returns table metadata\n(show table_handle \"statistics\") returns index statistics\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// table-based overloads: (show table) / (show recset) → columns,
 			// (show table "statistics") / (show recset "statistics") → index stats, etc.
@@ -2632,9 +2632,9 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "(optional) database name", Optional: true},
-				{Kind: "string|bool", ParamName: "table", ParamDesc: "(optional) table name, or true for full table listing", Optional: true},
-				{Kind: "int|bool", ParamName: "property", ParamDesc: "(optional) shard index (int), true for full table info, or \"statistics\"", Optional: true},
+				{Kind: "string|table|recset", ParamName: "schema_or_table", ParamDesc: "(optional) database name or resolved table/recset handle", Optional: true},
+				{Kind: "string|bool", ParamName: "table_or_property", ParamDesc: "(optional) table name, true for full info, or \"statistics\" for a handle", Optional: true},
+				{Kind: "int|bool|string", ParamName: "property", ParamDesc: "(optional) shard index (int), true for full table info, or \"statistics\"", Optional: true},
 				{Kind: "bool", ParamName: "full", ParamDesc: "(optional) true to include columns and indexes in shard detail", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any", Transfer: false},

--- a/tests/performance/traced-planner-scaling.yaml
+++ b/tests/performance/traced-planner-scaling.yaml
@@ -384,6 +384,33 @@ test_cases:
       data:
         - value: 7
 
+  - name: "Compile policy resolves repeated table aliases once"
+    scm: |
+      (begin
+        (define calls (newsession))
+        (calls "count" 0)
+        (define policy (lambda (_schema _table _write)
+          (begin
+            (calls "count" (+ (calls "count") 1))
+            true)))
+        (cached_parse (newcachemap) parse_sql "memcp-tests"
+          "SELECT root.id, (SELECT a.id FROM tps_parent a LIMIT 1), (SELECT b.id FROM tps_parent b LIMIT 1), (SELECT c.id FROM tps_parent c LIMIT 1), (SELECT d.id FROM tps_parent d LIMIT 1) FROM tps_prop root"
+          policy "root" (newsession) false)
+        (if (equal? (calls "count") 2)
+          "ok"
+          (error (concat "compile policy calls: " (calls "count")))))
+    expect:
+      data: ["ok"]
+
+  - name: "Compile catalog does not bypass denied table access"
+    scm: |
+      (cached_parse (newcachemap) parse_sql "memcp-tests"
+        "SELECT denied.id FROM tps_parent denied"
+        (lambda (_schema _table _write) (error "access denied"))
+        "root" (newsession) false)
+    expect:
+      error: true
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS tps_prop"
   - sql: "DROP TABLE IF EXISTS tps_parent"


### PR DESCRIPTION
## Summary

- resolve readable table names to stable table handles once per SQL compilation
- authorize each physical table once and reuse `show(table_handle)` metadata for repeated aliases
- preserve write-policy calls and denied-access behavior unchanged
- let sessions retain custom handles by identity without serializing them
- route parser and planner metadata reads through the common handle-aware schema helper

## Root cause

A query that referenced one physical table through several aliases repeated the policy callback and name-based metadata lookup for every alias. The existing `show` implementation already memoizes immutable metadata and accepts table handles, but parser/planner callers did not consistently preserve and reuse those handles during a cache miss.

The compile-local catalog is created only inside the plan-cache miss producer. Warm cache hits therefore still skip parsing and do not allocate the catalog.

## Test first

The new anonymous regression case references one table through four scalar aliases and a second root table.

- current master: fails with `compile policy calls: 5`
- this branch: passes with exactly 2 calls, one per physical table
- a separate denied-policy case verifies that caching cannot bypass authorization errors

The existing functional hard-limit suites remain unchanged. Larger relative performance workloads remain in `tests/performance/`, where they can intentionally use 10+ shards without inheriting the functional runtime boundary.

## A/B measurements

Built both revisions normally and ran them from their respective source directories. The cold benchmark used the real non-admin SQL policy, 5,001 synthetic ACL entries, 16 aliases of one table plus one root table, five forced cache misses per sample, and 12 alternating samples.

| Revision | Mean cold compile | Median cold compile |
| --- | ---: | ---: |
| `origin/master` (`48ec801b0`) | 40.783 ms | 40.743 ms |
| this branch (`c555f11b8`) | 32.465 ms | 32.299 ms |

Median improvement: **20.7%**, or **1.26x faster**.

Warm-cache control used 500 hits per sample over nine alternating samples:

| Revision | Median per cache hit |
| --- | ---: |
| `origin/master` | 7.63 us |
| this branch | 7.57 us |

The 0.8% difference is measurement noise; no warm-cache regression is visible.

## Validation

- focused planner, order/limit, prepared-statement, temporal, INSERT, and policy suites pass
- `MEMCP_TEST_JOBS=1 make test` passes completely
- SCM coverage: 44,824 / 44,824 nodes (100.0%)
- Go coverage: 70.7%