### PR TITLE
Reduce point scan partition and context overhead

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "github.com/carli2/hybridsort"
+import "sort"
 import "sync"
 import "sync/atomic"
 import "time"
@@ -52,7 +53,7 @@ func computeShardIndex(schema []shardDimension, values []scm.Scmer) (result int)
 	return // schema[0] has the higest stride; schema[len(schema)-1] is the least significant bit
 }
 
-func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
+func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
 	callback := callback_old
 	if scm.Trace != nil {
 		// hook on tracing
@@ -76,8 +77,19 @@ func (t *table) iterateShardsParallel(boundaries []columnboundaries, callback_ol
 		doneCh := make(chan struct{})
 		var done sync.WaitGroup
 		done.Add(len(shards))
+		startWorker := gls.Go
+		if currentTx != nil && currentTx.autoCommit {
+			startWorker = func(worker func()) {
+				go func() {
+					withTxSession(currentTx, func() scm.Scmer {
+						worker()
+						return scm.NewNil()
+					})
+				}()
+			}
+		}
 		for i := 0; i < workers; i++ {
-			gls.Go(func() {
+			startWorker(func() {
 				for s := range jobs {
 					release := s.GetRead()
 					callback(s, false)
@@ -156,6 +168,18 @@ func collectRelevantShards(schema []shardDimension, boundaries []columnboundarie
 	return result
 }
 
+func partitionForValue(dimension shardDimension, value scm.Scmer) int {
+	return sort.Search(len(dimension.Pivots), func(i int) bool {
+		return !scm.Less(dimension.Pivots[i], value)
+	})
+}
+
+func valueEqualsPivot(dimension shardDimension, partition int, value scm.Scmer) bool {
+	return partition < len(dimension.Pivots) &&
+		!scm.Less(value, dimension.Pivots[partition]) &&
+		!scm.Less(dimension.Pivots[partition], value)
+}
+
 func collectRelevantShardsIndex(schema []shardDimension, boundaries []columnboundaries, shards []*storageShard, result *[]*storageShard) {
 	if len(schema) == 0 {
 		for _, s := range shards {
@@ -175,46 +199,15 @@ func collectRelevantShardsIndex(schema []shardDimension, boundaries []columnboun
 			// iterate this axis over boundaries
 			min := 0
 			if !b.lower.IsNil() {
-				// lower bound is given -> find lowest part
-				max := schema[0].NumPartitions - 1
-				for min < max {
-					pivot := (min + max - 1) / 2
-					if !b.lowerInclusive {
-						if scm.Less(b.lower, schema[0].Pivots[pivot]) {
-							max = pivot
-						} else {
-							min = pivot + 1
-						}
-					} else {
-						if !scm.Less(schema[0].Pivots[pivot], b.lower) {
-							max = pivot
-						} else {
-							min = pivot + 1
-						}
-					}
+				min = partitionForValue(schema[0], b.lower)
+				if !b.lowerInclusive && valueEqualsPivot(schema[0], min, b.lower) {
+					min++
 				}
 			}
 
 			max := schema[0].NumPartitions - 1 // smaller than max
 			if !b.upper.IsNil() {
-				// upper bound is given -> find highest part
-				umin := min
-				for umin < max {
-					pivot := (umin + max - 1) / 2
-					if !b.upperInclusive {
-						if scm.Less(b.upper, schema[0].Pivots[pivot]) {
-							umin = pivot + 1
-						} else {
-							max = pivot
-						}
-					} else {
-						if !scm.Less(schema[0].Pivots[pivot], b.upper) {
-							umin = pivot + 1
-						} else {
-							max = pivot
-						}
-					}
-				}
+				max = partitionForValue(schema[0], b.upper)
 			}
 
 			for i := min; i <= max; i++ {

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -195,7 +195,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	result := &recSet{tx: currentTx, table: t}
 
 	values := make(chan recSetBuildResult, t.recSetShardResultBufferSize())
-	done := t.iterateShardsParallel(boundaries, func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
 		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {
@@ -505,7 +505,7 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 		err  scanError
 	}
 	values := make(chan targetPartResult, t.recSetShardResultBufferSize())
-	done := t.iterateShardsParallel(nil, func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, nil, func(shard *storageShard, solo bool) {
 		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -442,7 +442,7 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 
 	values := make(chan scanResult, 4)
 	var found atomic.Bool
-	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		if found.Load() {
 			values <- scanResult{}
 			return
@@ -544,7 +544,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	var inputCount int64
 	var candidateCount int64
 	values := make(chan scanResult, 4)
-	done := t.iterateShardsParallel(boundaries, func(s *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		defer func() {
 			if r := recover(); r != nil {
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -620,7 +620,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				}
 			}
 		} else {
-			done := t.iterateShardsParallel(tableBounds, func(s *storageShard, solo bool) {
+			done := t.iterateShardsParallel(currentTx, tableBounds, func(s *storageShard, solo bool) {
 				defer func() {
 					if r := recover(); r != nil {
 						q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
@@ -903,7 +903,7 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 	var foundShard *storageShard
 	var foundID uint32
 	var firstErr scanError
-	done := t.iterateShardsParallel(bounds, func(shard *storageShard, _ bool) {
+	done := t.iterateShardsParallel(currentTx, bounds, func(shard *storageShard, _ bool) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				mu.Lock()

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -18,10 +18,94 @@ package storage
 
 import (
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
 )
+
+func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
+	shards := make([]*storageShard, 5)
+	for i := range shards {
+		shards[i] = &storageShard{}
+	}
+	schema := []shardDimension{{
+		Column:        "id",
+		NumPartitions: len(shards),
+		Pivots: []scm.Scmer{
+			scm.NewInt(10),
+			scm.NewInt(20),
+			scm.NewInt(30),
+			scm.NewInt(40),
+		},
+	}}
+
+	tests := []struct {
+		name       string
+		boundary   columnboundaries
+		wantShards []int
+	}{
+		{
+			name: "point between late pivots",
+			boundary: columnboundaries{
+				col: "id", matcher: EqualMatcher,
+				lower: scm.NewInt(35), lowerInclusive: true,
+				upper: scm.NewInt(35), upperInclusive: true,
+			},
+			wantShards: []int{3},
+		},
+		{
+			name: "point on pivot",
+			boundary: columnboundaries{
+				col: "id", matcher: EqualMatcher,
+				lower: scm.NewInt(20), lowerInclusive: true,
+				upper: scm.NewInt(20), upperInclusive: true,
+			},
+			wantShards: []int{1},
+		},
+		{
+			name: "closed range",
+			boundary: columnboundaries{
+				col: "id", matcher: RangeMatcher,
+				lower: scm.NewInt(15), lowerInclusive: true,
+				upper: scm.NewInt(35), upperInclusive: true,
+			},
+			wantShards: []int{1, 2, 3},
+		},
+		{
+			name: "exclusive lower pivot",
+			boundary: columnboundaries{
+				col: "id", matcher: RangeMatcher,
+				lower: scm.NewInt(20), lowerInclusive: false,
+				upper: scm.NewNil(), upperInclusive: false,
+			},
+			wantShards: []int{2, 3, 4},
+		},
+		{
+			name: "exclusive upper pivot remains conservative",
+			boundary: columnboundaries{
+				col: "id", matcher: RangeMatcher,
+				lower: scm.NewNil(), lowerInclusive: false,
+				upper: scm.NewInt(20), upperInclusive: false,
+			},
+			wantShards: []int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectRelevantShards(schema, []columnboundaries{tt.boundary}, shards)
+			if len(got) != len(tt.wantShards) {
+				t.Fatalf("collectRelevantShards returned %d shards, want %d", len(got), len(tt.wantShards))
+			}
+			for i, wantIndex := range tt.wantShards {
+				if got[i] != shards[wantIndex] {
+					t.Fatalf("collectRelevantShards shard %d = %p, want shard[%d] %p", i, got[i], wantIndex, shards[wantIndex])
+				}
+			}
+		})
+	}
+}
 
 func setupScanParallelTestTable(t *testing.T, dbName string) *table {
 	t.Helper()
@@ -57,7 +141,7 @@ func TestIterateShardsParallelMarksFreeSingleShardSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	done := tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
+	done := tbl.iterateShardsParallel(nil, nil, func(s *storageShard, solo bool) {
 		calls++
 		sawSolo = solo
 	})
@@ -85,7 +169,7 @@ func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	done := tbl.iterateShardsParallel([]columnboundaries{{
+	done := tbl.iterateShardsParallel(nil, []columnboundaries{{
 		col:            "id",
 		matcher:        EqualMatcher,
 		lower:          scm.NewInt(15),
@@ -118,22 +202,69 @@ func TestIterateShardsParallelMarksPartitionMultiShardNonSolo(t *testing.T) {
 	}}
 	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
 
-	calls := 0
-	sawSolo := false
-	done := tbl.iterateShardsParallel(nil, func(s *storageShard, solo bool) {
-		calls++
-		sawSolo = sawSolo || solo
+	var calls atomic.Int32
+	var sawSolo atomic.Bool
+	done := tbl.iterateShardsParallel(nil, nil, func(s *storageShard, solo bool) {
+		calls.Add(1)
+		if solo {
+			sawSolo.Store(true)
+		}
 	})
 	if done == nil {
 		t.Fatal("iterateShardsParallel partition multi shard did not return async done channel")
 	}
 	<-done
 
-	if calls != 2 {
-		t.Fatalf("iterateShardsParallel partition multi shard calls = %d, want 2", calls)
+	if calls.Load() != 2 {
+		t.Fatalf("iterateShardsParallel partition multi shard calls = %d, want 2", calls.Load())
 	}
-	if sawSolo {
+	if sawSolo.Load() {
 		t.Fatal("iterateShardsParallel partition multi shard incorrectly marked callback as solo")
+	}
+}
+
+func TestIterateShardsParallelAutocommitUsesExplicitContext(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanparexplicit")
+	tbl.ShardMode = ShardModePartition
+	tbl.PDimensions = []shardDimension{{
+		Column:        "id",
+		NumPartitions: 2,
+		Pivots:        []scm.Scmer{scm.NewInt(10)},
+	}}
+	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
+	tx := NewTxContext(TxCursorStability)
+	tx.autoCommit = true
+	tx.Session = scm.NewSession()
+	scm.Apply(tx.Session, scm.NewString("worker-session-test"), scm.NewBool(true))
+
+	var calls atomic.Int32
+	var inheritedContext atomic.Bool
+	var missingSession atomic.Bool
+	scm.SetValues(map[string]any{"scan-worker-test": true}, func() {
+		done := tbl.iterateShardsParallel(tx, nil, func(s *storageShard, solo bool) {
+			calls.Add(1)
+			if _, ok := scm.GetGLSValue("scan-worker-test"); ok {
+				inheritedContext.Store(true)
+			}
+			session := scm.Context(scm.NewString("session"))
+			if !scm.Apply(session, scm.NewString("worker-session-test")).Bool() {
+				missingSession.Store(true)
+			}
+		})
+		if done == nil {
+			t.Fatal("iterateShardsParallel autocommit multi-shard scan did not return done channel")
+		}
+		<-done
+	})
+
+	if calls.Load() != 2 {
+		t.Fatalf("iterateShardsParallel autocommit calls = %d, want 2", calls.Load())
+	}
+	if inheritedContext.Load() {
+		t.Fatal("autocommit shard worker inherited GLS despite explicit transaction context")
+	}
+	if missingSession.Load() {
+		t.Fatal("autocommit shard worker did not install the transaction session")
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the partition-bound binary search with pivot-consistent lower-bound selection
- pass the existing transaction context into shard scheduling
- avoid copying the complete parent GLS stack for autocommit workers while reinstalling the transaction session explicitly
- retain GLS propagation for explicit transactions, where cancellation remains statement-local

## Correctness

- add table-driven coverage for late point probes, pivot equality, closed ranges, and exclusive bounds
- verify parallel autocommit workers see the transaction session but do not inherit unrelated GLS state
- fix the pre-existing race in the multi-shard callback test
- physical plans and query result bytes remain unchanged

## A/B measurement

Representative 30 KiB point-detail query on the same cloned large data snapshot, three sequential runs per binary, current master `48ec801b0` versus this PR:

| Revision | Runs | Median |
| --- | --- | --- |
| master | 37.52 s / 40.60 s / 38.54 s | 38.54 s |
| PR | 19.63 s / 23.03 s / 20.78 s | 20.78 s |

Median reduction: **46.1%** (**1.85x speedup**).

All six result files have the same SHA-256: `d2f652f37523ccf6b395011e41c3be9191d0bfa7115aa6b6e7cd110780978c93`.

## Verification

- `go test -race ./storage -run 'TestCollectRelevantShardsUsesPartitionBounds|TestIterateShardsParallel' -count=1`
- `./git-pre-commit` (all critical tests passed; existing noncritical planner expectations remain reported)
- manual builds and full-query A/B runs for both current master and PR binaries