### PR TITLE
Avoid duplicate nested group stage preparation

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -10086,6 +10086,8 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 				(define sources (qb_sources probe_rewritten))
 				(define stage_catalog (query_block_stage_catalog rewritten))
 				(define dependency_graph (stage_dependency_graph stage_lookup))
+				(define outer_prepare_stages (filter (qb_stages rewritten) (lambda (stage)
+					(not (group_stage? stage)))))
 				(define physical_sources (physicalize_stage_output_sources stage_lookup sources))
 				(define driver_src (car physical_sources))
 				(if (not (source_is_base_table? driver_src))
@@ -10119,8 +10121,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 					(lower_query_block_core grouped_input_block)
 					(cons (quote !begin)
 						(merge (list
-							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages rewritten))
-							(lower_stage_materialize_all (qb_stages rewritten))
+							/* The main group prepare owns nested group stages used by its input.
+							Window and ORC stages still require their explicit materialization. */
+							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup outer_prepare_stages)
+							(lower_stage_materialize_all outer_prepare_stages)
 							(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage))
 							(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources))))))))))))
 

--- a/tests/planner/aggregates/group-stage-corners.yaml
+++ b/tests/planner/aggregates/group-stage-corners.yaml
@@ -28,6 +28,9 @@ test_cases:
   - name: "Create customers table"
     sql: "CREATE TABLE gs_customers (id INT PRIMARY KEY, name VARCHAR(50))"
 
+  - name: "Create grouped membership candidate table"
+    sql: "CREATE TABLE gs_candidates (id INT PRIMARY KEY, order_id INT, qty INT)"
+
   - name: "Insert orders"
     sql: |
       INSERT INTO gs_orders (id, customer, amount, priority) VALUES
@@ -58,6 +61,11 @@ test_cases:
         (2, 'Bob'),
         (3, 'Charlie'),
         (4, 'Dana')
+
+  - name: "Insert grouped membership candidates"
+    sql: |
+      INSERT INTO gs_candidates (id, order_id, qty) VALUES
+        (1, 1, 1), (2, 1, 2), (3, 3, 1), (4, 6, 4)
 
   - name: "Create unordered group lookup tables"
     sql: "CREATE TABLE gs_parts (id INT, category VARCHAR(20))"
@@ -427,10 +435,47 @@ test_cases:
       data:
         - total: 0
 
+  # =================================================================
+  # 16. Nested stages are prepared once by their consuming main group
+  # =================================================================
+  - name: "Grouped membership feeding an outer group prepares once"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests' AND `table` = 'gs_candidates'"
+    sql: |
+      SELECT o.customer, SUM(i.qty) AS total_qty
+      FROM gs_orders o
+      JOIN gs_items i ON i.order_id = o.id
+      WHERE o.id IN (
+        SELECT c.order_id
+        FROM gs_candidates c
+        GROUP BY c.order_id
+        HAVING SUM(c.qty) > 2
+      )
+      GROUP BY o.customer
+    expect:
+      rows: 1
+      data:
+        - customer: "Alice"
+          total_qty: 8
+
+  - name: "Nested grouped membership scanned its input once"
+    sql: |
+      SELECT COUNT(*) AS scans
+      FROM `system_statistic`.`scans`
+      WHERE `schema` = 'memcp-tests' AND `table` = 'gs_candidates'
+    expect:
+      rows: 1
+      data:
+        - scans: 1
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS gs_blocked_sources"
   - sql: "DROP TABLE IF EXISTS gs_sources"
   - sql: "DROP TABLE IF EXISTS gs_parts"
   - sql: "DROP TABLE IF EXISTS gs_customers"
+  - sql: "DROP TABLE IF EXISTS gs_candidates"
   - sql: "DROP TABLE IF EXISTS gs_items"
   - sql: "DROP TABLE IF EXISTS gs_orders"


### PR DESCRIPTION
## What changed

- let the consuming main group own preparation of its nested group stages
- retain explicit preparation/materialization for Window and ORC stages
- add a scan-logging regression proving a grouped membership input is scanned exactly once

## Root cause

Grouped outer queries prepared every pre-existing stage explicitly and then prepared the generated main group. The main group's lowering already prepares nested group-stage dependencies, so grouped membership carriers were built twice. Window and ORC stages have a different materialization contract and remain explicitly prepared.

## Impact

On the local untracked SF 0.01 engineering dataset, all generated Q1-Q22 results still match PostgreSQL. Q18 improved from a roughly 41.7 s baseline median to 24.0 s median (about 42%). Q11, Q13, Q14, and Q17 also improved in the full matrix.

No TPC-H queries, data, toolkit files, answer files, or helper scripts are included.

## Validation

- `MEMCP_TEST_JOBS=1 ./git-pre-commit`
- `python3 run_sql_tests.py tests/planner/aggregates/group-stage-corners.yaml` (36/36)
- `python3 run_sql_tests.py tests/planner/subqueries/derived-table-count-regressions-minimal.yaml` (7/7)
- local untracked Q1-Q22 PostgreSQL comparison: 22/22 PASS
- baseline regression check: candidate input scanned twice on master, once on this branch