### PR TITLE
Speed up structural GROUP expression lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7137,16 +7137,23 @@ working on the original values. */
 				(list (quote lookup-keys) session_keys)
 				(list (quote stage_catalog) (query_block_stage_catalog block)))))))
 
-(define group_key_index (lambda (alias keys expr)
-	(if (or (nil? expr) (or (equal? expr true) (equal? expr false)))
+/* Group rewriters walk original and canonical trees in lockstep. Prehash every
+canonical root once so descendant lookup does not rescan keys or recanonicalize
+ever-larger subtrees. */
+(define make_group_key_index (lambda (keys roots)
+	(make_structural_index keys roots)))
+
+(define lookup_group_key_index (lambda (index resolved)
+	(if (or (nil? resolved) (or (equal? resolved true) (equal? resolved false)))
 		nil
-		(begin
-			(define resolved (canonical_column_expr_for_alias alias expr))
-			(reduce (produceN (count keys)) (lambda (found i)
-				(if (not (nil? found))
-					found
-					(if (equal? resolved (nth keys i)) i nil)))
-				nil)))))
+		(index resolved))))
+
+(define group_key_index (lambda (alias keys expr)
+	(begin
+		(define resolved (canonical_column_expr_for_alias alias expr))
+		(lookup_group_key_index
+			(make_group_key_index keys (list resolved))
+			resolved))))
 
 (define aggregate_count_like? (lambda (ag)
 	(match ag
@@ -7208,7 +7215,7 @@ working on the original values. */
 			(list (quote count) read_expr)
 			(list (quote coalesceNil) read_expr 0)))))
 
-(define replace_group_probe_stage_lookup_keys (lambda (alias grouptbl keys key_names ags stage)
+(define replace_group_probe_stage_lookup_keys (lambda (alias grouptbl keys key_names ags key_index stage)
 	(if (not (group_stage? stage))
 		stage
 		(begin
@@ -7227,35 +7234,46 @@ working on the original values. */
 				(gs_offset stage)
 				(qassoc_set facts (quote lookup-keys)
 					(map lookup_keys (lambda (expr)
-						(replace_group_expr alias grouptbl keys key_names ags expr)))))))))
+						(begin
+							(define resolved (canonical_column_expr_for_alias alias expr))
+							(replace_group_expr_indexed alias grouptbl keys key_names ags
+								(make_group_key_index keys (list resolved)) expr resolved))))))))))
 
-(define replace_group_probe_stages_lookup_keys (lambda (alias grouptbl keys key_names ags stages)
+(define replace_group_probe_stages_lookup_keys (lambda (alias grouptbl keys key_names ags key_index stages)
 	(map (coalesceNil stages '()) (lambda (stage)
-		(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags stage)))))
+		(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags key_index stage)))))
 
-(define replace_group_expr (lambda (alias grouptbl keys key_names ags expr)
+(define replace_group_expr_tail_indexed (lambda (alias grouptbl keys key_names ags key_index items resolved_items)
+	(match items
+		(cons item rest)
+		(cons
+			(replace_group_expr_indexed alias grouptbl keys key_names ags key_index item (car resolved_items))
+			(replace_group_expr_tail_indexed alias grouptbl keys key_names ags key_index rest (cdr resolved_items)))
+		_ '())))
+
+(define replace_group_expr_indexed (lambda (alias grouptbl keys key_names ags key_index expr resolved)
 	(begin
-		(define key_idx (group_key_index alias keys expr))
+		(define key_idx (lookup_group_key_index key_index resolved))
 		(if (not (nil? key_idx))
 			(list (quote get_column) grouptbl false (nth key_names key_idx) false)
 			(match expr
 				((symbol scalar_first_probe) stage requested_col stages)
 				(list (quote scalar_first_probe)
-					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags stage)
+					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags key_index stage)
 					requested_col
-					(replace_group_probe_stages_lookup_keys alias grouptbl keys key_names ags stages))
+					(replace_group_probe_stages_lookup_keys alias grouptbl keys key_names ags key_index stages))
 				((quote scalar_first_probe) stage requested_col stages)
 				(list (quote scalar_first_probe)
-					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags stage)
+					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags key_index stage)
 					requested_col
-					(replace_group_probe_stages_lookup_keys alias grouptbl keys key_names ags stages))
+					(replace_group_probe_stages_lookup_keys alias grouptbl keys key_names ags key_index stages))
 				((symbol scalar_aggregate_probe) stage requested_col)
 				(list (quote scalar_aggregate_probe)
-					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags stage)
+					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags key_index stage)
 					requested_col)
 				((quote scalar_aggregate_probe) stage requested_col)
 				(list (quote scalar_aggregate_probe)
-					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags stage)
+					(replace_group_probe_stage_lookup_keys alias grouptbl keys key_names ags key_index stage)
 					requested_col)
 				((symbol count_distinct) agg_expr)
 				(count_distinct_read_expr grouptbl agg_expr)
@@ -7273,12 +7291,36 @@ working on the original values. */
 				(if (equal?? (resolve_column_alias _tblvar alias) alias)
 					(neumann_fail "build_queryplan" (concat "non-aggregate output must be a GROUP BY key: " (serialize expr)))
 					expr)
-				(cons head tail) (cons head (map tail (lambda (item) (replace_group_expr alias grouptbl keys key_names ags item))))
+				(cons head tail) (cons head
+					(replace_group_expr_tail_indexed alias grouptbl keys key_names ags key_index tail (cdr resolved)))
 				_ expr)))))
 
-(define replace_group_order_expr (lambda (alias grouptbl keys key_names ags expr)
+(define replace_group_expr (lambda (alias grouptbl keys key_names ags expr)
 	(begin
-		(define key_idx (group_key_index alias keys expr))
+		(define resolved (canonical_column_expr_for_alias alias expr))
+		(replace_group_expr_indexed
+			alias grouptbl keys key_names ags (make_group_key_index keys (list resolved))
+			expr resolved))))
+
+(define replace_group_fields_indexed (lambda (alias grouptbl keys key_names ags key_index fields resolved_fields)
+	(match fields
+		(cons title (cons expr rest))
+		(cons title (cons
+			(replace_group_expr_indexed alias grouptbl keys key_names ags key_index expr (cadr resolved_fields))
+			(replace_group_fields_indexed alias grouptbl keys key_names ags key_index rest (cdr (cdr resolved_fields)))))
+		_ '())))
+
+(define replace_group_order_expr_tail_indexed (lambda (alias grouptbl keys key_names ags key_index items resolved_items)
+	(match items
+		(cons item rest)
+		(cons
+			(replace_group_order_expr_indexed alias grouptbl keys key_names ags key_index item (car resolved_items))
+			(replace_group_order_expr_tail_indexed alias grouptbl keys key_names ags key_index rest (cdr resolved_items)))
+		_ '())))
+
+(define replace_group_order_expr_indexed (lambda (alias grouptbl keys key_names ags key_index expr resolved)
+	(begin
+		(define key_idx (lookup_group_key_index key_index resolved))
 		(if (not (nil? key_idx))
 			(list (quote get_column) grouptbl false (nth key_names key_idx) false)
 			(match expr
@@ -7290,8 +7332,16 @@ working on the original values. */
 				(group_aggregate_order_read_expr grouptbl (list agg_expr agg_reduce agg_neutral))
 				((quote aggregate) agg_expr agg_reduce agg_neutral)
 				(group_aggregate_order_read_expr grouptbl (list agg_expr agg_reduce agg_neutral))
-				(cons head tail) (cons head (map tail (lambda (item) (replace_group_order_expr alias grouptbl keys key_names ags item))))
+				(cons head tail) (cons head
+					(replace_group_order_expr_tail_indexed alias grouptbl keys key_names ags key_index tail (cdr resolved)))
 				_ expr)))))
+
+(define replace_group_order_expr (lambda (alias grouptbl keys key_names ags expr)
+	(begin
+		(define resolved (canonical_column_expr_for_alias alias expr))
+		(replace_group_order_expr_indexed
+			alias grouptbl keys key_names ags (make_group_key_index keys (list resolved))
+			expr resolved))))
 
 (define direct_group_order_expr? (lambda (expr)
 	(match expr
@@ -7615,9 +7665,17 @@ working on the original values. */
 			(list (quote coalesceNil) read_expr 0)
 			read_expr))))
 
-(define replace_direct_group_expr (lambda (alias keys key_names ags expr)
+(define replace_direct_group_expr_tail_indexed (lambda (alias keys key_names ags key_index items resolved_items)
+	(match items
+		(cons item rest)
+		(cons
+			(replace_direct_group_expr_indexed alias keys key_names ags key_index item (car resolved_items))
+			(replace_direct_group_expr_tail_indexed alias keys key_names ags key_index rest (cdr resolved_items)))
+		_ '())))
+
+(define replace_direct_group_expr_indexed (lambda (alias keys key_names ags key_index expr resolved)
 	(begin
-		(define key_idx (group_key_index alias keys expr))
+		(define key_idx (lookup_group_key_index key_index resolved))
 		(if (not (nil? key_idx))
 			(list (quote get_assoc) (quote rowassoc) (nth key_names key_idx))
 			(match expr
@@ -7637,18 +7695,36 @@ working on the original values. */
 				(if (equal?? (resolve_column_alias _tblvar alias) alias)
 					(neumann_fail "build_queryplan" (concat "non-aggregate output must be a GROUP BY key: " (serialize expr)))
 					expr)
-				(cons head tail) (cons head (map tail (lambda (item) (replace_direct_group_expr alias keys key_names ags item))))
+				(cons head tail) (cons head
+					(replace_direct_group_expr_tail_indexed alias keys key_names ags key_index tail (cdr resolved)))
 				_ expr))))))
 
-(define direct_group_result_assoc_expr (lambda (alias keys key_names ags fields)
+(define replace_direct_group_expr (lambda (alias keys key_names ags expr)
+	(begin
+		(define resolved (canonical_column_expr_for_alias alias expr))
+		(replace_direct_group_expr_indexed
+			alias keys key_names ags (make_group_key_index keys (list resolved))
+			expr resolved))))
+
+(define direct_group_result_assoc_expr_indexed (lambda (alias keys key_names ags key_index fields resolved_fields)
 	(match (coalesceNil fields '())
 		(cons title (cons expr rest))
 		(list (quote cons)
 			(string title)
 			(list (quote cons)
-				(replace_direct_group_expr alias keys key_names ags expr)
-				(direct_group_result_assoc_expr alias keys key_names ags rest)))
+				(replace_direct_group_expr_indexed alias keys key_names ags key_index expr (cadr resolved_fields))
+				(direct_group_result_assoc_expr_indexed alias keys key_names ags key_index rest
+					(cdr (cdr resolved_fields)))))
 		_ (list (quote list)))))
+
+(define direct_group_result_assoc_expr (lambda (alias keys key_names ags fields)
+	(begin
+		(define items (coalesceNil fields '()))
+		(define resolved_fields (map_assoc items (lambda (_title expr)
+			(canonical_column_expr_for_alias alias expr))))
+		(define key_index (make_group_key_index keys
+			(extract_assoc resolved_fields (lambda (_title expr) expr))))
+		(direct_group_result_assoc_expr_indexed alias keys key_names ags key_index items resolved_fields))))
 
 (define direct_group_agg_index (lambda (ags expr)
 	(reduce (produceN (count ags)) (lambda (found i)
@@ -7657,9 +7733,9 @@ working on the original values. */
 			(if (equal? expr (nth ags i)) i nil)))
 		nil)))
 
-(define direct_group_order_column (lambda (alias keys key_names ags expr)
+(define direct_group_order_column_indexed (lambda (alias keys key_names ags key_index expr resolved)
 	(begin
-		(define key_idx (group_key_index alias keys expr))
+		(define key_idx (lookup_group_key_index key_index resolved))
 		(if (not (nil? key_idx))
 			(nth key_names key_idx)
 			(match expr
@@ -7668,26 +7744,46 @@ working on the original values. */
 					(define agg_idx (direct_group_agg_index ags (list agg_expr agg_reduce agg_neutral)))
 					(if (nil? agg_idx) nil (aggregate_col_name (nth ags agg_idx))))
 				((quote aggregate) agg_expr agg_reduce agg_neutral)
-				(direct_group_order_column alias keys key_names ags (list (quote aggregate) agg_expr agg_reduce agg_neutral))
+				(begin
+					(define agg_idx (direct_group_agg_index ags (list agg_expr agg_reduce agg_neutral)))
+					(if (nil? agg_idx) nil (aggregate_col_name (nth ags agg_idx))))
 				_ nil)))))
 
+(define direct_group_order_column (lambda (alias keys key_names ags expr)
+	(begin
+		(define resolved (canonical_column_expr_for_alias alias expr))
+		(direct_group_order_column_indexed alias keys key_names ags
+			(make_group_key_index keys (list resolved)) expr resolved))))
+
 (define direct_group_order_columns (lambda (alias keys key_names ags order_items)
-	(map (coalesceNil order_items '()) (lambda (item)
-		(match item
-			'(expr _dir)
-			(begin
-				(define col (direct_group_order_column alias keys key_names ags expr))
-				(if (nil? col)
-					(neumann_fail "build_queryplan" (concat "direct GROUP BY cannot order by " (serialize expr)))
-					col))
-			_ (neumann_fail "build_queryplan" "malformed ORDER BY item"))))))
+	(begin
+		(define items (coalesceNil order_items '()))
+		(define resolved_items (map items (lambda (item)
+			(match item '(expr dir) (list (canonical_column_expr_for_alias alias expr) dir)))))
+		(define key_index (make_group_key_index keys (map resolved_items car)))
+		(map (produceN (count items)) (lambda (i)
+			(match (nth items i)
+				'(expr _dir)
+				(begin
+					(define col (direct_group_order_column_indexed alias keys key_names ags key_index expr
+						(car (nth resolved_items i))))
+					(if (nil? col)
+						(neumann_fail "build_queryplan" (concat "direct GROUP BY cannot order by " (serialize expr)))
+						col))
+				_ (neumann_fail "build_queryplan" "malformed ORDER BY item")))))))
 
 (define direct_group_order_supported? (lambda (alias keys key_names ags order_items)
-	(reduce (coalesceNil order_items '()) (lambda (ok item)
-		(and ok (match item
-			'(expr _dir) (not (nil? (direct_group_order_column alias keys key_names ags expr)))
-			_ false)))
-		true)))
+	(begin
+		(define items (coalesceNil order_items '()))
+		(define resolved_items (map items (lambda (item)
+			(match item '(expr dir) (list (canonical_column_expr_for_alias alias expr) dir)))))
+		(define key_index (make_group_key_index keys (map resolved_items car)))
+		(reduce (produceN (count items)) (lambda (ok i)
+			(and ok (match (nth items i)
+				'(expr _dir) (not (nil? (direct_group_order_column_indexed
+					alias keys key_names ags key_index expr (car (nth resolved_items i)))))
+				_ false)))
+			true))))
 
 (define build_base_group_scan_assoc_plan (lambda (schema tbl alias table_expr keys condition ags)
 	(begin
@@ -8121,25 +8217,43 @@ working on the original values. */
 				(cons (quote list) (map pairs (lambda (p) (cons (quote list) p)))))))))
 
 (define group_stage_keytable_block (lambda (stage grouptbl key_names ags having_expr)
-	(make_query_block
-		(group_stage_schema stage)
-		(list (list grouptbl (group_stage_schema stage) grouptbl false nil))
-		(gs_output stage)
-		having_expr
-		nil nil
-		(map (coalesceNil (gs_order stage) '()) (lambda (item)
-			(match item '(expr dir) (list (replace_group_expr (group_stage_input_alias stage) grouptbl (if (empty_list? (gs_keys stage)) '(1) (gs_keys stage)) key_names ags expr) dir))))
-		(gs_limit stage)
-		(gs_offset stage)
-		'() '() '())))
+	(begin
+		(define alias (group_stage_input_alias stage))
+		(define keys (if (empty_list? (gs_keys stage)) '(1) (gs_keys stage)))
+		(define order_items (coalesceNil (gs_order stage) '()))
+		(define resolved_order_exprs (map order_items (lambda (item)
+			(match item '(expr _dir) (canonical_column_expr_for_alias alias expr)))))
+		(define key_index (make_group_key_index keys resolved_order_exprs))
+		(make_query_block
+			(group_stage_schema stage)
+			(list (list grouptbl (group_stage_schema stage) grouptbl false nil))
+			(gs_output stage)
+			having_expr
+			nil nil
+			(map (produceN (count order_items)) (lambda (i)
+				(match (nth order_items i) '(expr dir) (list
+					(replace_group_expr_indexed alias grouptbl keys key_names ags key_index expr
+						(nth resolved_order_exprs i))
+					dir))))
+			(gs_limit stage)
+			(gs_offset stage)
+			'() '() '()))))
 
 (define rewrite_source_for_group_domain (lambda (alias grouptbl keys key_names ags src)
+	(begin
+		(define resolved (canonical_column_expr_for_alias alias (source_join_expr src)))
+		(rewrite_source_for_group_domain_indexed alias grouptbl keys key_names ags
+			(make_group_key_index keys (list resolved)) src resolved))))
+
+(define rewrite_source_for_group_domain_indexed (lambda (alias grouptbl keys key_names ags key_index src resolved_join)
 	(list
 		(source_alias src)
 		(source_schema src)
 		(source_relation src)
 		(source_outer? src)
-		(replace_group_expr alias grouptbl keys key_names ags (source_join_expr src)))))
+		(replace_group_expr_indexed alias grouptbl keys key_names ags key_index
+			(source_join_expr src)
+			resolved_join))))
 
 (define lowering_catalog? (lambda (catalog)
 	(match catalog
@@ -9339,9 +9453,26 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 		(define carrier (group_stage_carrier stage))
 		(define schema (group_carrier_schema carrier))
 		(define grouptbl (group_carrier_relation carrier))
-		(define output_fields (map_assoc (gs_output stage) (lambda (_title expr)
-			(replace_group_expr alias grouptbl keys key_names ags expr))))
-		(define replaced_having (replace_group_expr alias grouptbl keys key_names ags (coalesceNil (gs_having stage) true)))
+		(define original_output (gs_output stage))
+		(define resolved_output (map_assoc original_output (lambda (_title expr)
+			(canonical_column_expr_for_alias alias expr))))
+		(define original_having (coalesceNil (gs_having stage) true))
+		(define resolved_having (canonical_column_expr_for_alias alias original_having))
+		(define order_items (coalesceNil (gs_order stage) '()))
+		(define resolved_order_exprs (map order_items (lambda (item)
+			(match item '(expr _dir) (canonical_column_expr_for_alias alias expr)))))
+		(define extras (coalesceNil extra_sources '()))
+		(define resolved_extra_joins (map extras (lambda (extra)
+			(canonical_column_expr_for_alias alias (source_join_expr extra)))))
+		(define key_index (make_group_key_index keys (merge (list
+			(extract_assoc resolved_output (lambda (_title expr) expr))
+			(list resolved_having)
+			resolved_order_exprs
+			resolved_extra_joins))))
+		(define output_fields (replace_group_fields_indexed
+			alias grouptbl keys key_names ags key_index original_output resolved_output))
+		(define replaced_having (replace_group_expr_indexed alias grouptbl keys key_names ags key_index
+			original_having resolved_having))
 		(define count_col_name (aggregate_col_name aggregate_count_descriptor))
 		(define count_check (list (quote >) (list (quote get_column) grouptbl false count_col_name false) 0))
 		(define needs_count_filter (and (not (equal? keys '(1))) (not (equal? condition true))))
@@ -9356,14 +9487,17 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 			schema
 			(cons
 				(list grouptbl schema grouptbl false nil)
-				(map (coalesceNil extra_sources '()) (lambda (extra)
-					(rewrite_source_for_group_domain alias grouptbl keys key_names ags extra))))
+				(map (produceN (count extras)) (lambda (i)
+					(rewrite_source_for_group_domain_indexed alias grouptbl keys key_names ags key_index
+						(nth extras i) (nth resolved_extra_joins i)))))
 			output_fields
 			having_expr
 			nil nil
-			(map (coalesceNil (gs_order stage) '()) (lambda (item)
-				(match item '(expr dir) (begin
-					(define replaced_order_expr (replace_group_order_expr alias grouptbl keys key_names ags expr))
+			(map (produceN (count order_items)) (lambda (i)
+				(match (nth order_items i) '(expr dir) (begin
+					(define replaced_order_expr (replace_group_order_expr_indexed
+						alias grouptbl keys key_names ags key_index expr
+						(nth resolved_order_exprs i)))
 					(list (group_order_physical_expr grouptbl replaced_order_expr) dir)))))
 			(gs_limit stage)
 			(gs_offset stage)
@@ -9475,6 +9609,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 				(map (gs_keys stage) (lambda (key)
 					(rewrite_scalar_first_probe_expr stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias key)))
 				(gs_keys stage))))
+		(define prepare_order_items (coalesceNil (gs_order stage) '()))
+		(define prepare_resolved_order_exprs (map prepare_order_items (lambda (item)
+			(match item '(expr _dir) (canonical_column_expr_for_alias alias expr)))))
+		(define key_index (make_group_key_index keys prepare_resolved_order_exprs))
 		(define ags (gs_aggregates stage))
 		(define lowering_ags (if (query_block? src)
 			(rewrite_scalar_first_probe_aggregates stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias ags)
@@ -9584,9 +9722,11 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 					(list (build_group_session_key_insert_plan schema grouptbl key_names keys))
 					'()))
 			'()))
-		(define computed_order_exprs (merge_unique (map (coalesceNil (gs_order stage) '()) (lambda (item)
-			(match item '(expr _dir) (begin
-				(define replaced_order_expr (replace_group_order_expr alias grouptbl keys key_names ags expr))
+		(define computed_order_exprs (merge_unique (map (produceN (count prepare_order_items)) (lambda (i)
+			(match (nth prepare_order_items i) '(expr _dir) (begin
+				(define replaced_order_expr (replace_group_order_expr_indexed
+					alias grouptbl keys key_names ags key_index expr
+					(nth prepare_resolved_order_exprs i)))
 				(if (direct_group_order_expr? replaced_order_expr) '() (list replaced_order_expr))))))))
 		(define computed_order_plans (map computed_order_exprs (lambda (expr)
 			(build_group_computed_order_column schema grouptbl expr))))

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -153,6 +153,100 @@ func HashKey(k Scmer) uint64 {
 	return h.Sum64()
 }
 
+func combineStructuralHash(hash, value uint64) uint64 {
+	value += 0x9e3779b97f4a7c15
+	value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9
+	value = (value ^ (value >> 27)) * 0x94d049bb133111eb
+	value ^= value >> 31
+	return (hash ^ value) * 0x100000001b3
+}
+
+// hashStructuralKey computes every immutable list node bottom-up once. The
+// resulting memo is frozen before it is shared with lookup closures.
+func hashStructuralKey(key Scmer, memo map[Scmer]uint64) uint64 {
+	switch key.GetTag() {
+	case tagSourceInfo:
+		return hashStructuralKey(key.SourceInfo().value, memo)
+	case tagAny:
+		if source, ok := key.Any().(SourceInfo); ok {
+			return hashStructuralKey(source.value, memo)
+		}
+		return HashKey(key)
+	case tagSlice:
+		if hash, ok := memo[key]; ok {
+			return hash
+		}
+		items := key.Slice()
+		hash := combineStructuralHash(0x6a09e667f3bcc909, uint64(len(items)))
+		for _, item := range items {
+			hash = combineStructuralHash(hash, hashStructuralKey(item, memo))
+		}
+		memo[key] = hash
+		return hash
+	case tagFastDict:
+		panic("make_structural_index requires immutable list expressions")
+	case tagInt, tagDate:
+		// Equal accepts numerically equal int/float/date values across tags.
+		return HashKey(NewFloat(float64(key.Int())))
+	case tagString, tagSymbol:
+		// Symbols and strings with the same text compare equal.
+		return HashKey(NewString(key.String()))
+	default:
+		return HashKey(key)
+	}
+}
+
+type structuralIndexEntry struct {
+	key   Scmer
+	value Scmer
+}
+
+// NewStructuralIndex eagerly indexes keys and every node below roots. The
+// returned lookup closure performs read-only map access and is therefore safe
+// for parallel planner walkers without a mutex.
+func NewStructuralIndex(a ...Scmer) Scmer {
+	if len(a) != 2 {
+		panic("make_structural_index expects keys and roots")
+	}
+	keys := asSlice(a[0], "make_structural_index keys")
+	roots := asSlice(a[1], "make_structural_index roots")
+	memo := make(map[Scmer]uint64)
+	entries := make(map[uint64][]structuralIndexEntry, len(keys))
+	for i, key := range keys {
+		hash := hashStructuralKey(key, memo)
+		entries[hash] = append(entries[hash], structuralIndexEntry{key: key, value: NewInt(int64(i))})
+	}
+	for _, root := range roots {
+		hashStructuralKey(root, memo)
+	}
+	return NewFunc(func(args ...Scmer) Scmer {
+		if len(args) != 1 {
+			panic("structural index lookup expects one expression")
+		}
+		expr := args[0]
+		if expr.IsSourceInfo() {
+			expr = expr.SourceInfo().value
+		} else if expr.GetTag() == tagAny {
+			if source, ok := expr.Any().(SourceInfo); ok {
+				expr = source.value
+			}
+		}
+		hash, ok := memo[expr]
+		if !ok {
+			if expr.GetTag() == tagSlice || expr.GetTag() == tagFastDict {
+				panic("structural index lookup received an expression outside its roots")
+			}
+			hash = hashStructuralKey(expr, memo)
+		}
+		for _, entry := range entries[hash] {
+			if Equal(entry.key, expr) {
+				return entry.value
+			}
+		}
+		return NewNil()
+	})
+}
+
 func (d *FastDict) findPos(key Scmer, h uint64) (int, bool) {
 	if d.index == nil {
 		return -1, false

--- a/scm/list.go
+++ b/scm/list.go
@@ -1717,6 +1717,24 @@ func init_list() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "make_structural_index",
+		Desc: "Builds an immutable structural-expression index. It eagerly hashes every key and every node under roots, then returns a parallel-safe lookup function that maps an equal expression to its zero-based key position or nil.",
+		Fn:   NewStructuralIndex,
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "keys", ParamDesc: "immutable structural expressions to index"},
+				{Kind: "list", ParamName: "roots", ParamDesc: "immutable expression roots whose descendant hashes are precomputed"},
+			},
+			Return: &TypeDescriptor{
+				Kind: "func",
+				Params: []*TypeDescriptor{
+					{Kind: "any", ParamName: "expression", ParamDesc: "a key, root, descendant of a declared root, or scalar expression"},
+				},
+				Return: &TypeDescriptor{Kind: "int|nil"},
+			},
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "has_assoc?",
 		Desc: "checks if a dictionary has a key present",
 		Fn: func(a ...Scmer) Scmer {

--- a/tests/performance/group-lookup-performance.yaml
+++ b/tests/performance/group-lookup-performance.yaml
@@ -9,7 +9,82 @@ metadata:
   max_time: 5
 
 setup:
+  - sql: "DROP TABLE IF EXISTS group_expression_items"
   - sql: "DROP TABLE IF EXISTS lookup_group_items"
+  - sql: |
+      CREATE TABLE group_expression_items (
+        id INT PRIMARY KEY,
+        c1 INT,
+        c2 INT,
+        c3 INT,
+        c4 INT,
+        c5 INT,
+        c6 INT,
+        c7 INT,
+        c8 INT,
+        c9 INT,
+        c10 INT,
+        c11 INT,
+        c12 INT,
+        c13 INT,
+        c14 INT,
+        c15 INT,
+        c16 INT,
+        c17 INT,
+        c18 INT,
+        c19 INT,
+        c20 INT,
+        c21 INT,
+        c22 INT,
+        c23 INT,
+        c24 INT,
+        c25 INT,
+        c26 INT,
+        c27 INT,
+        c28 INT,
+        c29 INT,
+        c30 INT,
+        c31 INT,
+        c32 INT,
+        c33 INT,
+        c34 INT,
+        c35 INT,
+        c36 INT,
+        c37 INT,
+        c38 INT,
+        c39 INT,
+        c40 INT,
+        c41 INT,
+        c42 INT,
+        c43 INT,
+        c44 INT,
+        c45 INT,
+        c46 INT,
+        c47 INT,
+        c48 INT,
+        c49 INT,
+        c50 INT,
+        c51 INT,
+        c52 INT,
+        c53 INT,
+        c54 INT,
+        c55 INT,
+        c56 INT,
+        c57 INT,
+        c58 INT,
+        c59 INT,
+        c60 INT,
+        c61 INT,
+        c62 INT,
+        c63 INT,
+        c64 INT
+      )
+  - sql: |
+      INSERT INTO group_expression_items (
+        id, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52, c53, c54, c55, c56, c57, c58, c59, c60, c61, c62, c63, c64
+      ) VALUES (
+        1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
+      )
   - sql: |
       CREATE TABLE lookup_group_items (
         id INT PRIMARY KEY,
@@ -26,9 +101,70 @@ setup:
         20000)
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS group_expression_items"
   - sql: "DROP TABLE IF EXISTS lookup_group_items"
 
 test_cases:
+  - name: "nested projection preserves every grouped key"
+    sql: |
+      SELECT
+        (((((((COALESCE(c1, 0) + COALESCE(c2, 0)) + COALESCE(c3, 0)) + COALESCE(c4, 0)) + COALESCE(c5, 0)) + COALESCE(c6, 0)) + COALESCE(c7, 0)) + COALESCE(c8, 0)) AS combined,
+        SUM(id) AS total
+      FROM group_expression_items
+      GROUP BY c1, c2, c3, c4, c5, c6, c7, c8
+      ORDER BY (((((((COALESCE(c1, 0) + COALESCE(c2, 0)) + COALESCE(c3, 0)) + COALESCE(c4, 0)) + COALESCE(c5, 0)) + COALESCE(c6, 0)) + COALESCE(c7, 0)) + COALESCE(c8, 0))
+    expect:
+      rows: 1
+      data:
+        - combined: 36
+          total: 1
+
+  - name: "structural group expression compile scaling"
+    threshold_ms: 1000
+    warmup: false
+    timeout: 30
+    sql: |
+      EXPLAIN COMPILE SELECT
+        (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((COALESCE(k1, 0) + COALESCE(k2, 0)) + COALESCE(k3, 0)) + COALESCE(k4, 0)) + COALESCE(k5, 0)) + COALESCE(k6, 0)) + COALESCE(k7, 0)) + COALESCE(k8, 0)) + COALESCE(k9, 0)) + COALESCE(k10, 0)) + COALESCE(k11, 0)) + COALESCE(k12, 0)) + COALESCE(k13, 0)) + COALESCE(k14, 0)) + COALESCE(k15, 0)) + COALESCE(k16, 0)) + COALESCE(k17, 0)) + COALESCE(k18, 0)) + COALESCE(k19, 0)) + COALESCE(k20, 0)) + COALESCE(k21, 0)) + COALESCE(k22, 0)) + COALESCE(k23, 0)) + COALESCE(k24, 0)) + COALESCE(k25, 0)) + COALESCE(k26, 0)) + COALESCE(k27, 0)) + COALESCE(k28, 0)) + COALESCE(k29, 0)) + COALESCE(k30, 0)) + COALESCE(k31, 0)) + COALESCE(k32, 0)) + COALESCE(k33, 0)) + COALESCE(k34, 0)) + COALESCE(k35, 0)) + COALESCE(k36, 0)) + COALESCE(k37, 0)) + COALESCE(k38, 0)) + COALESCE(k39, 0)) + COALESCE(k40, 0)) + COALESCE(k41, 0)) + COALESCE(k42, 0)) + COALESCE(k43, 0)) + COALESCE(k44, 0)) + COALESCE(k45, 0)) + COALESCE(k46, 0)) + COALESCE(k47, 0)) + COALESCE(k48, 0)) + COALESCE(k49, 0)) + COALESCE(k50, 0)) + COALESCE(k51, 0)) + COALESCE(k52, 0)) + COALESCE(k53, 0)) + COALESCE(k54, 0)) + COALESCE(k55, 0)) + COALESCE(k56, 0)) + COALESCE(k57, 0)) + COALESCE(k58, 0)) + COALESCE(k59, 0)) + COALESCE(k60, 0)) + COALESCE(k61, 0)) + COALESCE(k62, 0)) + COALESCE(k63, 0)) + COALESCE(k64, 0)) + COALESCE(k65, 0)) + COALESCE(k66, 0)) + COALESCE(k67, 0)) + COALESCE(k68, 0)) + COALESCE(k69, 0)) + COALESCE(k70, 0)) + COALESCE(k71, 0)) + COALESCE(k72, 0)) + COALESCE(k73, 0)) + COALESCE(k74, 0)) + COALESCE(k75, 0)) + COALESCE(k76, 0)) + COALESCE(k77, 0)) + COALESCE(k78, 0)) + COALESCE(k79, 0)) + COALESCE(k80, 0)) + COALESCE(k81, 0)) + COALESCE(k82, 0)) + COALESCE(k83, 0)) + COALESCE(k84, 0)) + COALESCE(k85, 0)) + COALESCE(k86, 0)) + COALESCE(k87, 0)) + COALESCE(k88, 0)) + COALESCE(k89, 0)) + COALESCE(k90, 0)) + COALESCE(k91, 0)) + COALESCE(k92, 0)) + COALESCE(k93, 0)) + COALESCE(k94, 0)) + COALESCE(k95, 0)) + COALESCE(k96, 0)) + COALESCE(k97, 0)) + COALESCE(k98, 0)) + COALESCE(k99, 0)) + COALESCE(k100, 0)) + COALESCE(k101, 0)) + COALESCE(k102, 0)) + COALESCE(k103, 0)) + COALESCE(k104, 0)) + COALESCE(k105, 0)) + COALESCE(k106, 0)) + COALESCE(k107, 0)) + COALESCE(k108, 0)) + COALESCE(k109, 0)) + COALESCE(k110, 0)) + COALESCE(k111, 0)) + COALESCE(k112, 0)) + COALESCE(k113, 0)) + COALESCE(k114, 0)) + COALESCE(k115, 0)) + COALESCE(k116, 0)) + COALESCE(k117, 0)) + COALESCE(k118, 0)) + COALESCE(k119, 0)) + COALESCE(k120, 0)) + COALESCE(k121, 0)) + COALESCE(k122, 0)) + COALESCE(k123, 0)) + COALESCE(k124, 0)) + COALESCE(k125, 0)) + COALESCE(k126, 0)) + COALESCE(k127, 0)) + COALESCE(k128, 0)) + COALESCE(k129, 0)) + COALESCE(k130, 0)) + COALESCE(k131, 0)) + COALESCE(k132, 0)) + COALESCE(k133, 0)) + COALESCE(k134, 0)) + COALESCE(k135, 0)) + COALESCE(k136, 0)) + COALESCE(k137, 0)) + COALESCE(k138, 0)) + COALESCE(k139, 0)) + COALESCE(k140, 0)) + COALESCE(k141, 0)) + COALESCE(k142, 0)) + COALESCE(k143, 0)) + COALESCE(k144, 0)) + COALESCE(k145, 0)) + COALESCE(k146, 0)) + COALESCE(k147, 0)) + COALESCE(k148, 0)) + COALESCE(k149, 0)) + COALESCE(k150, 0)) + COALESCE(k151, 0)) + COALESCE(k152, 0)) + COALESCE(k153, 0)) + COALESCE(k154, 0)) + COALESCE(k155, 0)) + COALESCE(k156, 0)) + COALESCE(k157, 0)) + COALESCE(k158, 0)) + COALESCE(k159, 0)) + COALESCE(k160, 0)) AS combined,
+        SUM(id) AS total
+      FROM (
+        SELECT id,
+          c1 AS k1, c2 AS k2, c3 AS k3, c4 AS k4, c5 AS k5, c6 AS k6, c7 AS k7, c8 AS k8,
+          c9 AS k9, c10 AS k10, c11 AS k11, c12 AS k12, c13 AS k13, c14 AS k14, c15 AS k15, c16 AS k16,
+          c17 AS k17, c18 AS k18, c19 AS k19, c20 AS k20, c21 AS k21, c22 AS k22, c23 AS k23, c24 AS k24,
+          c25 AS k25, c26 AS k26, c27 AS k27, c28 AS k28, c29 AS k29, c30 AS k30, c31 AS k31, c32 AS k32,
+          c33 AS k33, c34 AS k34, c35 AS k35, c36 AS k36, c37 AS k37, c38 AS k38, c39 AS k39, c40 AS k40,
+          c41 AS k41, c42 AS k42, c43 AS k43, c44 AS k44, c45 AS k45, c46 AS k46, c47 AS k47, c48 AS k48,
+          c49 AS k49, c50 AS k50, c51 AS k51, c52 AS k52, c53 AS k53, c54 AS k54, c55 AS k55, c56 AS k56,
+          c57 AS k57, c58 AS k58, c59 AS k59, c60 AS k60, c61 AS k61, c62 AS k62, c63 AS k63, c64 AS k64,
+          c1 AS k65, c2 AS k66, c3 AS k67, c4 AS k68, c5 AS k69, c6 AS k70, c7 AS k71, c8 AS k72,
+          c9 AS k73, c10 AS k74, c11 AS k75, c12 AS k76, c13 AS k77, c14 AS k78, c15 AS k79, c16 AS k80,
+          c17 AS k81, c18 AS k82, c19 AS k83, c20 AS k84, c21 AS k85, c22 AS k86, c23 AS k87, c24 AS k88,
+          c25 AS k89, c26 AS k90, c27 AS k91, c28 AS k92, c29 AS k93, c30 AS k94, c31 AS k95, c32 AS k96,
+          c33 AS k97, c34 AS k98, c35 AS k99, c36 AS k100, c37 AS k101, c38 AS k102, c39 AS k103, c40 AS k104,
+          c41 AS k105, c42 AS k106, c43 AS k107, c44 AS k108, c45 AS k109, c46 AS k110, c47 AS k111, c48 AS k112,
+          c49 AS k113, c50 AS k114, c51 AS k115, c52 AS k116, c53 AS k117, c54 AS k118, c55 AS k119, c56 AS k120,
+          c57 AS k121, c58 AS k122, c59 AS k123, c60 AS k124, c61 AS k125, c62 AS k126, c63 AS k127, c64 AS k128,
+          c1 AS k129, c2 AS k130, c3 AS k131, c4 AS k132, c5 AS k133, c6 AS k134, c7 AS k135, c8 AS k136,
+          c9 AS k137, c10 AS k138, c11 AS k139, c12 AS k140, c13 AS k141, c14 AS k142, c15 AS k143, c16 AS k144,
+          c17 AS k145, c18 AS k146, c19 AS k147, c20 AS k148, c21 AS k149, c22 AS k150, c23 AS k151, c24 AS k152,
+          c25 AS k153, c26 AS k154, c27 AS k155, c28 AS k156, c29 AS k157, c30 AS k158, c31 AS k159, c32 AS k160
+        FROM group_expression_items
+      ) AS grouped_source
+      GROUP BY
+        k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14, k15, k16,
+        k17, k18, k19, k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k30, k31, k32,
+        k33, k34, k35, k36, k37, k38, k39, k40, k41, k42, k43, k44, k45, k46, k47, k48,
+        k49, k50, k51, k52, k53, k54, k55, k56, k57, k58, k59, k60, k61, k62, k63, k64,
+        k65, k66, k67, k68, k69, k70, k71, k72, k73, k74, k75, k76, k77, k78, k79, k80,
+        k81, k82, k83, k84, k85, k86, k87, k88, k89, k90, k91, k92, k93, k94, k95, k96,
+        k97, k98, k99, k100, k101, k102, k103, k104, k105, k106, k107, k108, k109, k110, k111, k112,
+        k113, k114, k115, k116, k117, k118, k119, k120, k121, k122, k123, k124, k125, k126, k127, k128,
+        k129, k130, k131, k132, k133, k134, k135, k136, k137, k138, k139, k140, k141, k142, k143, k144,
+        k145, k146, k147, k148, k149, k150, k151, k152, k153, k154, k155, k156, k157, k158, k159, k160
+      ORDER BY (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((COALESCE(k1, 0) + COALESCE(k2, 0)) + COALESCE(k3, 0)) + COALESCE(k4, 0)) + COALESCE(k5, 0)) + COALESCE(k6, 0)) + COALESCE(k7, 0)) + COALESCE(k8, 0)) + COALESCE(k9, 0)) + COALESCE(k10, 0)) + COALESCE(k11, 0)) + COALESCE(k12, 0)) + COALESCE(k13, 0)) + COALESCE(k14, 0)) + COALESCE(k15, 0)) + COALESCE(k16, 0)) + COALESCE(k17, 0)) + COALESCE(k18, 0)) + COALESCE(k19, 0)) + COALESCE(k20, 0)) + COALESCE(k21, 0)) + COALESCE(k22, 0)) + COALESCE(k23, 0)) + COALESCE(k24, 0)) + COALESCE(k25, 0)) + COALESCE(k26, 0)) + COALESCE(k27, 0)) + COALESCE(k28, 0)) + COALESCE(k29, 0)) + COALESCE(k30, 0)) + COALESCE(k31, 0)) + COALESCE(k32, 0)) + COALESCE(k33, 0)) + COALESCE(k34, 0)) + COALESCE(k35, 0)) + COALESCE(k36, 0)) + COALESCE(k37, 0)) + COALESCE(k38, 0)) + COALESCE(k39, 0)) + COALESCE(k40, 0)) + COALESCE(k41, 0)) + COALESCE(k42, 0)) + COALESCE(k43, 0)) + COALESCE(k44, 0)) + COALESCE(k45, 0)) + COALESCE(k46, 0)) + COALESCE(k47, 0)) + COALESCE(k48, 0)) + COALESCE(k49, 0)) + COALESCE(k50, 0)) + COALESCE(k51, 0)) + COALESCE(k52, 0)) + COALESCE(k53, 0)) + COALESCE(k54, 0)) + COALESCE(k55, 0)) + COALESCE(k56, 0)) + COALESCE(k57, 0)) + COALESCE(k58, 0)) + COALESCE(k59, 0)) + COALESCE(k60, 0)) + COALESCE(k61, 0)) + COALESCE(k62, 0)) + COALESCE(k63, 0)) + COALESCE(k64, 0)) + COALESCE(k65, 0)) + COALESCE(k66, 0)) + COALESCE(k67, 0)) + COALESCE(k68, 0)) + COALESCE(k69, 0)) + COALESCE(k70, 0)) + COALESCE(k71, 0)) + COALESCE(k72, 0)) + COALESCE(k73, 0)) + COALESCE(k74, 0)) + COALESCE(k75, 0)) + COALESCE(k76, 0)) + COALESCE(k77, 0)) + COALESCE(k78, 0)) + COALESCE(k79, 0)) + COALESCE(k80, 0)) + COALESCE(k81, 0)) + COALESCE(k82, 0)) + COALESCE(k83, 0)) + COALESCE(k84, 0)) + COALESCE(k85, 0)) + COALESCE(k86, 0)) + COALESCE(k87, 0)) + COALESCE(k88, 0)) + COALESCE(k89, 0)) + COALESCE(k90, 0)) + COALESCE(k91, 0)) + COALESCE(k92, 0)) + COALESCE(k93, 0)) + COALESCE(k94, 0)) + COALESCE(k95, 0)) + COALESCE(k96, 0)) + COALESCE(k97, 0)) + COALESCE(k98, 0)) + COALESCE(k99, 0)) + COALESCE(k100, 0)) + COALESCE(k101, 0)) + COALESCE(k102, 0)) + COALESCE(k103, 0)) + COALESCE(k104, 0)) + COALESCE(k105, 0)) + COALESCE(k106, 0)) + COALESCE(k107, 0)) + COALESCE(k108, 0)) + COALESCE(k109, 0)) + COALESCE(k110, 0)) + COALESCE(k111, 0)) + COALESCE(k112, 0)) + COALESCE(k113, 0)) + COALESCE(k114, 0)) + COALESCE(k115, 0)) + COALESCE(k116, 0)) + COALESCE(k117, 0)) + COALESCE(k118, 0)) + COALESCE(k119, 0)) + COALESCE(k120, 0)) + COALESCE(k121, 0)) + COALESCE(k122, 0)) + COALESCE(k123, 0)) + COALESCE(k124, 0)) + COALESCE(k125, 0)) + COALESCE(k126, 0)) + COALESCE(k127, 0)) + COALESCE(k128, 0)) + COALESCE(k129, 0)) + COALESCE(k130, 0)) + COALESCE(k131, 0)) + COALESCE(k132, 0)) + COALESCE(k133, 0)) + COALESCE(k134, 0)) + COALESCE(k135, 0)) + COALESCE(k136, 0)) + COALESCE(k137, 0)) + COALESCE(k138, 0)) + COALESCE(k139, 0)) + COALESCE(k140, 0)) + COALESCE(k141, 0)) + COALESCE(k142, 0)) + COALESCE(k143, 0)) + COALESCE(k144, 0)) + COALESCE(k145, 0)) + COALESCE(k146, 0)) + COALESCE(k147, 0)) + COALESCE(k148, 0)) + COALESCE(k149, 0)) + COALESCE(k150, 0)) + COALESCE(k151, 0)) + COALESCE(k152, 0)) + COALESCE(k153, 0)) + COALESCE(k154, 0)) + COALESCE(k155, 0)) + COALESCE(k156, 0)) + COALESCE(k157, 0)) + COALESCE(k158, 0)) + COALESCE(k159, 0)) + COALESCE(k160, 0))
+    expect:
+      rows: 1
   - name: "large lookup group by without order"
     timeout: 30
     max_time: 5
@@ -110,6 +246,20 @@ test_cases:
         - "scan_group_into"
         - "assoc_keys_as_dataset_rows"
         - "assoc_keys_values_as_dataset_rows"
+
+  - name: "structural expression index preserves deep key equality"
+    scm: |
+      (begin
+        (define keys (map (produceN 12) (lambda (i)
+          (list (quote node) i (list (quote leaf) (* i 2))))))
+        (define equal_probe (list (quote node) 7 (list (quote leaf) 14)))
+        (define missing_probe (list (quote node) 7 (list (quote leaf) 15)))
+        (define index (make_structural_index keys (list equal_probe missing_probe)))
+        (if (not (equal? (index equal_probe) 7))
+          (error "equal structural key was not found"))
+        (if (not (nil? (index missing_probe)))
+          (error "different structural key matched"))
+        true)
 
   - name: "scan optimizer mutates only an owned projected map value"
     scm: |


### PR DESCRIPTION
## What changed

- add an immutable structural-expression index for planner ASTs
- canonicalize GROUP output, HAVING, ORDER BY, join, and direct-group roots once
- walk original and canonical trees in lockstep instead of recanonicalizing every subtree
- replace linear deep-equality scans over all GROUP keys with hash-bucket lookup plus collision equality checks
- add anonymized correctness and compile-time regression coverage under `tests/`

The index is built eagerly and frozen before use. Planner walkers only perform concurrent map reads; no mutex or lazy mutation is involved. Mutable FastDict values are rejected as index inputs.

## Root cause

Each visited GROUP expression subtree was canonicalized again and compared deeply against every GROUP key. With many keys and nested projections this made lowering polynomial and dominated compile time.

## Test-first gate

The anonymized 160-key derived-table shape retains the existing hard 1 s limit:

- current master: 1,256.0 ms median over 3 runner repetitions, fails the gate
- this branch: 696.0 ms median over 7 repetitions, 625.7-741.8 ms, passes the gate

## A/B measurements

Both binaries were built from the same current master base. Requests used `EXPLAIN COMPILE` to force compilation and alternated master/branch order. Reported values are medians of batch means.

### 64 direct GROUP keys

9 alternating batches, 5 compiles per batch:

| metric | master | branch | change |
|---|---:|---:|---:|
| lowering | 142.055 ms | 46.707 ms | 3.04x, -67.1% |
| planner total | 179.204 ms | 75.352 ms | 2.38x, -58.0% |
| compile total | 252.226 ms | 152.591 ms | 1.65x, -39.5% |

Plan shape is unchanged: 8,449 nodes and 74,030 bytes on both revisions.

### 160 derived GROUP keys

5 alternating batches, 3 compiles per batch:

| metric | master | branch | change |
|---|---:|---:|---:|
| lowering | 703.539 ms | 134.490 ms | 5.23x, -80.9% |
| planner total | 851.112 ms | 253.284 ms | 3.36x, -70.2% |
| compile total | 1,041.424 ms | 478.771 ms | 2.18x, -54.0% |

Plan shape is unchanged: 17,761 nodes and 189,216 bytes on both revisions.

## Validation

- performance regression suite: 15/15, including 7 repeated hard-gate runs
- aggregate and window planner surface: 32/32 suites
- focused concurrency/rebuild rerun: 16/16
- Scheme formatter/check and `git diff --check`
- two full coverage-hook runs exercised all suites and reached 100% Scheme source-node coverage, but did not finish green under concurrent host load; failures moved between unrelated timeout/restart-heavy suites and passed when isolated. CI is the clean full-suite authority for this PR.
