### PR TITLE
Prefer selective connected join drivers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4028,6 +4028,75 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(list (quote outer_join) (source_outer? src))
 		(list (quote join_filter) (source_join_present? src)))))
 
+/* Promote a small, locally filtered base relation within the leading inner
+join segment. This keeps outer/stage relations and explicit JOIN dependencies
+in place while giving comma joins a selective physical driver. */
+(define reorderable_inner_driver_source? (lambda (src)
+	(and (source_is_base_table? src)
+		(not (source_outer? src))
+		(or (nil? (source_join_expr src)) (equal? (source_join_expr src) true)))))
+
+(define multiple_reorderable_inner_sources? (lambda (sources)
+	(and (not (empty_list? sources))
+		(not (empty_list? (cdr sources)))
+		(reorderable_inner_driver_source? (car sources))
+		(reorderable_inner_driver_source? (car (cdr sources))))))
+
+(define leading_reorderable_inner_sources (lambda (sources)
+	(match (coalesceNil sources '())
+		(cons src rest) (if (reorderable_inner_driver_source? src)
+			(cons src (leading_reorderable_inner_sources rest))
+			'())
+		_ '())))
+
+(define source_has_local_filter? (lambda (src default_alias condition)
+	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
+		(or found
+			(and (expr_refs_alias? default_alias (source_alias src) term)
+				(expr_only_refs_alias? default_alias (source_alias src) term))))
+		false)))
+
+(define sources_share_condition? (lambda (left right default_alias condition)
+	(reduce (split_and_terms (coalesceNil condition true)) (lambda (found term)
+		(or found
+			(and (expr_refs_alias? default_alias (source_alias left) term)
+				(expr_refs_alias? default_alias (source_alias right) term))))
+		false)))
+
+(define prefer_smaller_filtered_source (lambda (current candidate)
+	(if (nil? current)
+		candidate
+		(begin
+			(define current_rows (planner_source_row_count current))
+			(define candidate_rows (planner_source_row_count candidate))
+			(if (and (not (nil? candidate_rows))
+				(or (nil? current_rows) (< candidate_rows current_rows)))
+				candidate
+				current)))))
+
+(define selective_inner_driver (lambda (sources default_alias condition)
+	(reduce (leading_reorderable_inner_sources sources) (lambda (selected src)
+		(if (source_has_local_filter? src default_alias condition)
+			(prefer_smaller_filtered_source selected src)
+			selected))
+		nil)))
+
+(define promote_source_to_front (lambda (sources selected)
+	(cons selected
+		(filter sources (lambda (src) (not (equal? (source_alias src) (source_alias selected))))))))
+
+(define reorder_selective_inner_sources (lambda (sources default_alias condition stages order_items limit_value preserve_order_driver)
+	(if (or (and preserve_order_driver (source_order_limit_driver? (car sources) order_items limit_value))
+		(source_row_number_limit_driver? stages (car sources)))
+		sources
+		(begin
+			(define driver (selective_inner_driver sources default_alias condition))
+			(if (or (nil? driver)
+				(equal? (source_alias driver) (source_alias (car sources)))
+				(not (sources_share_condition? driver (car sources) default_alias condition)))
+				sources
+				(promote_source_to_front sources driver))))))
+
 (define left_join_strategy_options (lambda (src)
 	(if (not (source_outer? src))
 		nil
@@ -4459,11 +4528,18 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 						(define default_alias (if (empty_list? sources) nil (source_alias (car sources))))
 						(define exists_src (first_exists_recset_source (qb_stages block) sources default_alias (qb_where block)))
 						(if (nil? exists_src)
-							(if (query_block_needs_reorder_facts? block)
-								(query_block_with_reorder_facts
+							(begin
+								(define reordered_sources (if (not (multiple_reorderable_inner_sources? sources))
+									sources
+									(reorder_selective_inner_sources
+										sources default_alias (qb_where block) (qb_stages block) (qb_order block) (qb_limit block)
+										(and (query_limit_active? (qb_offset block) (qb_limit block))
+											(empty_list? (qb_group block))
+											(not (query_block_has_aggregates? block))))))
+								(define reordered_block
 									(make_query_block
 										(qb_schema block)
-										(qb_sources block)
+										reordered_sources
 										(qb_fields block)
 										(qb_where block)
 										(qb_group block)
@@ -4473,9 +4549,12 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 										(qb_offset block)
 										(qb_hidden block)
 										(map (qb_stages block) join_reorder_stage)
-										(qb_facts block))
-									(query_block_reorder_telemetry block))
-								block)
+										(qb_facts block)))
+								(if (query_block_needs_reorder_facts? block)
+									(query_block_with_reorder_facts
+										reordered_block
+										(query_block_reorder_telemetry block))
+									reordered_block))
 							(begin
 								(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation exists_src))))
 								(define stage_id (gs_id stage))
@@ -4496,10 +4575,17 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 									stage
 									probe
 									(qb_where block)))
+								(define reordered_driver_sources (if (not (multiple_reorderable_inner_sources? driver_sources))
+									driver_sources
+									(reorder_selective_inner_sources
+										driver_sources default_alias base_where (qb_stages block) (qb_order block) (qb_limit block)
+										(and (query_limit_active? (qb_offset block) (qb_limit block))
+											(empty_list? (qb_group block))
+											(not (query_block_has_aggregates? block))))))
 								(query_block_with_reorder_facts
 									(make_query_block
 										(qb_schema block)
-										driver_sources
+										reordered_driver_sources
 										(rewrite_consumer (qb_fields block))
 										base_where
 										(rewrite_consumer (qb_group block))

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -17,6 +17,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS rs_right"
   - sql: "DROP TABLE IF EXISTS perf_main"
   - sql: "DROP TABLE IF EXISTS perf_dim"
+  - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"
 
@@ -342,6 +343,11 @@ test_cases:
     expect:
       rows: 0
 
+  - name: "Create disconnected tiny table for reorder"
+    sql: "CREATE TABLE perf_tiny (id INT PRIMARY KEY, flag INT)"
+    expect:
+      rows: 0
+
   - name: "Insert selective join dimension rows"
     sql: "INSERT INTO perf_dim VALUES (1, 'one'), (2, 'two')"
     expect:
@@ -351,6 +357,11 @@ test_cases:
     sql: "INSERT INTO perf_main VALUES (1,1,'a'),(2,1,'b'),(3,2,'c')"
     expect:
       affected_rows: 3
+
+  - name: "Insert disconnected tiny row"
+    sql: "INSERT INTO perf_tiny VALUES (1, 1)"
+    expect:
+      affected_rows: 1
 
   - name: "EXPLAIN IR swaps to selective driver"
     fail_comment: "query is not fully decorrelated anymore; logical IR must not contain subquery markers"
@@ -373,6 +384,52 @@ test_cases:
       not_contains:
         - "inner_select"
         - "dependent-subquery"
+
+  - name: "EXPLAIN REORDER promotes a selective comma-join dimension"
+    sql: "EXPLAIN REORDER SELECT d.label, m.id FROM perf_main m, perf_dim d WHERE m.category = d.cat_id AND d.label = 'one'"
+    expect:
+      rows: 1
+      result_contains:
+        - '((\"d\" \"memcp-tests\" \"perf_dim\" false nil)'
+      result_not_contains:
+        - '((\"m\" \"memcp-tests\" \"perf_main\" false nil)'
+
+  - name: "Selective comma-join dimension preserves results"
+    sql: "SELECT d.label, m.id FROM perf_main m, perf_dim d WHERE m.category = d.cat_id AND d.label = 'one' ORDER BY m.id"
+    expect:
+      rows: 2
+      data:
+        - label: "one"
+          id: 1
+        - label: "one"
+          id: 2
+
+  - name: "EXPLAIN REORDER preserves an ungrouped ordered-limit driver"
+    sql: "EXPLAIN REORDER SELECT m.id FROM perf_main m, perf_dim d WHERE m.category = d.cat_id AND d.label = 'one' ORDER BY m.id LIMIT 1"
+    expect:
+      rows: 1
+      result_contains:
+        - '((\"m\" \"memcp-tests\" \"perf_main\" false nil)'
+      result_not_contains:
+        - '((\"d\" \"memcp-tests\" \"perf_dim\" false nil)'
+
+  - name: "EXPLAIN REORDER promotes through grouped ORDER LIMIT"
+    sql: "EXPLAIN REORDER SELECT d.label, COUNT(*) AS matches FROM perf_main m, perf_dim d WHERE m.category = d.cat_id AND d.label = 'one' GROUP BY d.label ORDER BY matches DESC LIMIT 1"
+    expect:
+      rows: 1
+      result_contains:
+        - '((\"d\" \"memcp-tests\" \"perf_dim\" false nil)'
+      result_not_contains:
+        - '((\"m\" \"memcp-tests\" \"perf_main\" false nil)'
+
+  - name: "EXPLAIN REORDER avoids a disconnected selective driver"
+    sql: "EXPLAIN REORDER SELECT m.id FROM perf_main m, perf_dim d, perf_tiny x WHERE m.category = d.cat_id AND d.label = 'one' AND x.flag = 1"
+    expect:
+      rows: 1
+      result_contains:
+        - '((\"m\" \"memcp-tests\" \"perf_main\" false nil)'
+      result_not_contains:
+        - '((\"x\" \"memcp-tests\" \"perf_tiny\" false nil)'
 
   - name: "Create physical pushdown tables"
     sql: "CREATE TABLE pushdown_main (id INT PRIMARY KEY, lookup_id INT, payload VARCHAR(20))"
@@ -641,5 +698,8 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS rs_multi"
   - sql: "DROP TABLE IF EXISTS rs_left"
   - sql: "DROP TABLE IF EXISTS rs_right"
+  - sql: "DROP TABLE IF EXISTS perf_main"
+  - sql: "DROP TABLE IF EXISTS perf_dim"
+  - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"


### PR DESCRIPTION
## What changed

- promote a selective, connected base-table source to the front of ordinary inner comma joins
- keep explicit JOIN dependencies, stage/outer sources, and ungrouped ordered-limit drivers fixed
- avoid promoting disconnected filtered sources that would create a Cartesian prefix
- add plan-shape and result regressions for promotion, ordering, grouping, and connectivity

## Why

TPC-H Q21 retained textual source order, so the selective `nation.n_name = ...` relation was scanned last. That repeatedly rescanned large `lineitem` and `orders` inputs.

After this change the driver order becomes `nation -> supplier -> lineitem -> orders`. In the measured SF 0.01 run, Q21 improved from 17.6 s to 6.0 s (about 66%); lineitem scans dropped from 101 to 2 and orders scans from 2,124 to 22.

## Validation

- rebased onto master including #417
- `python3 run_sql_tests.py tests/execution/operators/range-scan-coverage.yaml`: 82/82 passed
- `MEMCP_TEST_JOBS=1 ./git-pre-commit`: all critical tests passed
- TPC-H Q1-Q22 SF 0.01: 22/22 PostgreSQL oracle matches
- no TPC-H data, queries, or helper artifacts are tracked