### PR TITLE
Publish table statistics without reader locks

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -732,6 +732,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 				atomic.StoreUint64(&t.Columns[ci].RowEstimate, rowEst)
 			}
 			t.publishShowColumnsSnapshot()
+			t.collectStatisticsFromShards(newShardList)
 
 			// Collect replaced shards for deferred cleanup (see comment above).
 			if len(replaced) > 0 {

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -18,8 +18,11 @@ package storage
 
 import (
 	"os"
+	"runtime"
 	"sync/atomic"
 	"testing"
+	"time"
+	"unsafe"
 
 	"github.com/launix-de/memcp/scm"
 )
@@ -283,5 +286,151 @@ func TestShardWriteOwnershipUsesExplicitTransactionState(t *testing.T) {
 	tx.ExitShardWrite(shard)
 	if shard.hasWriteOwnerForTx(tx) {
 		t.Fatal("released transaction write ownership remained visible")
+	}
+}
+
+func TestShowStatsLockedDoesNotReenterWithQueuedWriter(t *testing.T) {
+	shard := &storageShard{
+		main_count:  1,
+		columns:     map[string]ColumnStorage{"value": &StorageConst{value: scm.NewInt(7), count: 1}},
+		writeOwners: make(map[uint64]uint32),
+	}
+	readerReady := make(chan struct{})
+	readStats := make(chan shardStatsSnapshot, 1)
+	releaseReader := make(chan struct{})
+	go func() {
+		shard.mu.RLock()
+		defer shard.mu.RUnlock()
+		close(readerReady)
+		<-releaseReader
+		readStats <- shard.statsSnapshotRLocked()
+	}()
+	<-readerReady
+
+	writerDone := make(chan struct{})
+	go func() {
+		shard.mu.Lock()
+		defer shard.mu.Unlock()
+		close(writerDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for shard.mu.TryRLock() {
+		shard.mu.RUnlock()
+		if time.Now().After(deadline) {
+			close(releaseReader)
+			t.Fatal("writer did not queue for the shard lock")
+		}
+		runtime.Gosched()
+	}
+	close(releaseReader)
+
+	select {
+	case stats := <-readStats:
+		if stats.rowCount() != 1 || stats.size == 0 {
+			t.Fatalf("locked statistics = %v, want one row and a nonzero size", stats)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("locked SHOW statistics re-entered the shard read lock")
+	}
+	select {
+	case <-writerDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued writer did not acquire the released shard lock")
+	}
+}
+
+func TestTableStatisticsReadsPublishedSnapshotWithoutShardLock(t *testing.T) {
+	shard := &storageShard{
+		main_count:  1,
+		columns:     map[string]ColumnStorage{"value": &StorageConst{value: scm.NewInt(7), count: 1}},
+		writeOwners: make(map[uint64]uint32),
+		srState:     WRITE,
+	}
+	tbl := &table{schema: &database{Name: "table-statistics-test"}, Shards: []*storageShard{shard}}
+	shard.t = tbl
+	tbl.publishShowColumnsSnapshot()
+	if stats := tbl.statistics(); stats.rowCount != 1 || stats.sizeBytes != 0 {
+		t.Fatalf("startup statistics = %+v, want row estimate 1 before size collection", stats)
+	}
+	tbl.collectStatistics()
+
+	shard.mu.Lock()
+	shard.main_count = 2
+	readStats := make(chan tableStatisticsSnapshot, 1)
+	go func() {
+		readStats <- tbl.statistics()
+	}()
+
+	select {
+	case stats := <-readStats:
+		if stats.rowCount != 1 || stats.sizeBytes == 0 {
+			t.Fatalf("published statistics = %+v, want the previously collected one-row snapshot", stats)
+		}
+	case <-time.After(time.Second):
+		shard.mu.Unlock()
+		t.Fatal("reading published table statistics waited for the shard lock")
+	}
+	shard.mu.Unlock()
+
+	tbl.ShowColumns()
+	if stats := tbl.statistics(); stats.rowCount != 1 {
+		t.Fatalf("SHOW COLUMNS replaced collected row count with %d, want 1", stats.rowCount)
+	}
+
+	tbl.collectStatistics()
+	if stats := tbl.statistics(); stats.rowCount != 2 {
+		t.Fatalf("refreshed row count = %d, want 2", stats.rowCount)
+	}
+}
+
+var tableStatisticsBenchmarkSink tableStatisticsSnapshot
+
+func TestTableShowColumnsSnapshotFitsCacheLine(t *testing.T) {
+	if size := unsafe.Sizeof(tableShowColumnsSnapshot{}); size > 64 {
+		t.Fatalf("table metadata snapshot size = %d bytes, want at most one cache line", size)
+	}
+}
+
+func benchmarkStatisticsTable() *table {
+	tbl := &table{schema: &database{Name: "table-statistics-benchmark"}}
+	for i := 0; i < 8; i++ {
+		shard := &storageShard{
+			t:            tbl,
+			main_count:   1000,
+			columns:      make(map[string]ColumnStorage, 4),
+			writeOwners:  make(map[uint64]uint32),
+			srState:      WRITE,
+			deltaColumns: make(map[string]int),
+		}
+		for col := 0; col < 4; col++ {
+			shard.columns[string(rune('a'+col))] = &StorageConst{value: scm.NewInt(int64(col)), count: 1000}
+		}
+		tbl.Shards = append(tbl.Shards, shard)
+	}
+	tbl.collectStatistics()
+	return tbl
+}
+
+func BenchmarkTableStatisticsOnDemandShardScan(b *testing.B) {
+	tbl := benchmarkStatisticsTable()
+	b.ReportAllocs()
+	for b.Loop() {
+		stats := tableStatisticsSnapshot{}
+		for _, shard := range tbl.Shards {
+			shard.mu.RLock()
+			stats.rowCount += int64(shard.main_count) + int64(len(shard.inserts)) - int64(shard.deletions.Count())
+			stats.sizeBytes += int64(shard.ComputeSize())
+			shard.mu.RUnlock()
+		}
+		tableStatisticsBenchmarkSink = stats
+	}
+}
+
+func BenchmarkTableStatisticsPublishedRead(b *testing.B) {
+	tbl := benchmarkStatisticsTable()
+	b.ReportAllocs()
+	for b.Loop() {
+		tableStatisticsBenchmarkSink = tbl.statistics()
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -173,6 +173,37 @@ func (s *storageShard) ComputeSize() uint {
 	return result
 }
 
+type shardStatsSnapshot struct {
+	mainCount uint32
+	delta     int
+	deletions uint
+	state     SharedState
+	size      uint
+}
+
+// statsSnapshotRLocked reads one consistent shard-local statistics snapshot.
+// The caller must already hold s.mu.RLock().
+func (s *storageShard) statsSnapshotRLocked() shardStatsSnapshot {
+	return shardStatsSnapshot{
+		mainCount: s.main_count,
+		delta:     len(s.inserts),
+		deletions: s.deletions.Count(),
+		state:     s.srState,
+		size:      s.computeSizeLocked(),
+	}
+}
+
+func (s *storageShard) statsSnapshot() shardStatsSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	stats := s.statsSnapshotRLocked()
+	return stats
+}
+
+func (s shardStatsSnapshot) rowCount() int64 {
+	return int64(s.mainCount) + int64(s.delta) - int64(s.deletions)
+}
+
 func (u *storageShard) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.uuid.String())
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2438,25 +2438,12 @@ func Init(en scm.Env) {
 							continue
 						}
 						engine := showEngineStr(t)
-						var rowCount int64
-						var sizeBytes int64
-						for _, s := range t.ActiveShards() {
-							if s == nil {
-								continue
-							}
-							s.mu.RLock()
-							rowCount += int64(s.main_count) + int64(len(s.inserts)) - int64(s.deletions.Count())
-							sizeBytes += int64(s.ComputeSize())
-							s.mu.RUnlock()
-						}
-						if rowCount == 0 {
-							rowCount = int64(t.CountEstimate())
-						}
+						stats := t.statistics()
 						rows = append(rows, scm.NewSlice([]scm.Scmer{
 							scm.NewString("name"), scm.NewString(t.Name),
 							scm.NewString("engine"), scm.NewString(engine),
-							scm.NewString("row_count"), scm.NewInt(rowCount),
-							scm.NewString("size_bytes"), scm.NewInt(sizeBytes),
+							scm.NewString("row_count"), scm.NewInt(stats.rowCount),
+							scm.NewString("size_bytes"), scm.NewInt(stats.sizeBytes),
 							scm.NewString("collation"), scm.NewString(t.Collation),
 							scm.NewString("comment"), scm.NewString(t.Comment),
 						}))
@@ -3562,19 +3549,13 @@ func showBuildShardRow(t *table, i int, s *storageShard) scm.Scmer {
 			scm.NewString("size_bytes"), scm.NewInt(0),
 		})
 	}
-	s.mu.RLock()
-	mainCount := s.main_count
-	delta := len(s.inserts)
-	deletions := s.deletions.Count()
-	state := sharedStateStr(s.srState)
-	size := s.ComputeSize()
-	s.mu.RUnlock()
+	stats := s.statsSnapshot()
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewString("shard"), scm.NewInt(int64(i)),
-		scm.NewString("state"), scm.NewString(state),
-		scm.NewString("main_count"), scm.NewInt(int64(mainCount)),
-		scm.NewString("delta"), scm.NewInt(int64(delta)),
-		scm.NewString("deletions"), scm.NewInt(int64(deletions)),
-		scm.NewString("size_bytes"), scm.NewInt(int64(size)),
+		scm.NewString("state"), scm.NewString(sharedStateStr(stats.state)),
+		scm.NewString("main_count"), scm.NewInt(int64(stats.mainCount)),
+		scm.NewString("delta"), scm.NewInt(int64(stats.delta)),
+		scm.NewString("deletions"), scm.NewInt(int64(stats.deletions)),
+		scm.NewString("size_bytes"), scm.NewInt(int64(stats.size)),
 	})
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -202,6 +202,11 @@ type pendingSourceDelete struct {
 	oldRecid uint32
 }
 
+type tableStatisticsSnapshot struct {
+	rowCount  int64
+	sizeBytes int64
+}
+
 func (m *ShardMode) MarshalJSON() ([]byte, error) {
 	if *m == ShardModePartition {
 		return []byte("\"partition\""), nil
@@ -442,6 +447,54 @@ func (t *table) ActiveShards() []*storageShard {
 		return t.PShards
 	}
 	return t.Shards
+}
+
+// collectStatistics gathers approximate table statistics without coupling
+// shard mutations to table-wide counters. It is intended for maintenance jobs.
+func (t *table) collectStatistics() {
+	t.mu.Lock()
+	shards := append([]*storageShard(nil), t.ActiveShards()...)
+	t.mu.Unlock()
+	t.collectStatisticsFromShards(shards)
+}
+
+func (t *table) collectStatisticsFromShards(shards []*storageShard) {
+	stats := &tableStatisticsSnapshot{}
+	for _, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		shardStats := shard.statsSnapshot()
+		stats.rowCount += shardStats.rowCount()
+		stats.sizeBytes += int64(shardStats.size)
+	}
+	for {
+		current := t.showColumnsSnapshot.Load()
+		if current == nil {
+			replacement := t.buildShowColumnsSnapshot(uint(stats.rowCount))
+			replacement.statistics = stats
+			if t.showColumnsSnapshot.CompareAndSwap(nil, replacement) {
+				t.columnNamesSnapshot.Store(replacement.columnNames)
+				return
+			}
+			continue
+		}
+		replacement := *current
+		replacement.statistics = stats
+		if t.showColumnsSnapshot.CompareAndSwap(current, &replacement) {
+			return
+		}
+	}
+}
+
+func (t *table) statistics() tableStatisticsSnapshot {
+	if snapshot := t.showColumnsSnapshot.Load(); snapshot != nil {
+		if snapshot.statistics != nil {
+			return *snapshot.statistics
+		}
+		return tableStatisticsSnapshot{rowCount: int64(snapshot.rowEstimate)}
+	}
+	return tableStatisticsSnapshot{}
 }
 
 // maintenanceShards returns every shard set that must observe derived-column
@@ -830,6 +883,7 @@ type tableShowColumnsSnapshot struct {
 	rowEstimate       uint
 	distinctEstimates []uint64
 	columnNames       *tableColumnNamesSnapshot
+	statistics        *tableStatisticsSnapshot
 }
 
 type tableColumnNamesSnapshot struct {
@@ -897,12 +951,16 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 		distinctEstimates[i] = distinctEstimate
 		result[i] = c.show(keyType, distinctEstimate, rowEstimate)
 	}
-	return &tableShowColumnsSnapshot{
+	snapshot := &tableShowColumnsSnapshot{
 		value:             scm.NewSlice(result),
 		rowEstimate:       rowEstimate,
 		distinctEstimates: distinctEstimates,
 		columnNames:       columnNames,
 	}
+	if current := t.showColumnsSnapshot.Load(); current != nil {
+		snapshot.statistics = current.statistics
+	}
+	return snapshot
 }
 
 func (t *table) buildColumnNamesSnapshot() *tableColumnNamesSnapshot {
@@ -1474,6 +1532,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 					t.mu.Lock()
 					t.Shards[i] = rebuilt
 					t.mu.Unlock()
+					t.collectStatistics()
 					t.schema.save()
 				}(len(t.Shards)-1, shard)
 				shard = NewShard(t)


### PR DESCRIPTION
## Summary

- serve full table statistics from an immutable snapshot loaded atomically, without taking table or shard locks on the read path
- collect the snapshot only at maintenance boundaries: rebuild and completed free-shard rollover
- retain the persisted row estimate during database startup without eagerly loading shard data
- keep detailed per-shard reporting consistent under exactly one shard read lock and remove the nested-lock deadlock
- keep the table object layout unchanged; the added snapshot pointer fills the existing metadata snapshot to one 64-byte cache line

Per-row and per-batch mutations do not update table-wide counters. Statistics are deliberately approximate between maintenance collections.

## A/B measurements

### Table-statistics hot path

Ten benchmark samples, 8 shards with 4 columns each:

| Variant | time/op | bytes/op | allocs/op |
| --- | ---: | ---: | ---: |
| master-style on-demand shard scan | 790.1 ns | 192 B | 16 |
| PR published snapshot read | 1.118 ns | 0 B | 0 |

The lock-free read is about 707x faster and allocation-free.

### Queued-writer reproducer

- master: timed out after 250 ms in the nested read-lock acquisition
- PR: completed in about 4 ms
- race repetition: 20/20 passed

### Query-path control

An anonymized large read query was run three times per variant with a fresh data-directory copy for every run:

| Variant | Run 1 | Run 2 | Run 3 | Median |
| --- | ---: | ---: | ---: | ---: |
| master | 23.859 s | 23.452 s | 23.333 s | 23.452 s |
| PR | 23.270 s | 23.331 s | 23.049 s | 23.270 s |

The 0.8% median difference is measurement noise. All responses were byte-identical: 1,167 bytes, SHA-256 `e4c56e1cdb8332709a0c8890f031c27dd1ec6e87cf96a132f182beae25a6afcc`.

## Local validation

- targeted storage regressions: 100 repetitions passed
- targeted race run: 20 repetitions passed
- isolated range-scan planner suite: 82/82 passed
- isolated complex-subquery planner suite: 38/38 passed
- full suite: delegated to CI as requested