### PR TITLE
Fix mutation scan lock release on projection errors

### DIFF
--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1668,20 +1668,24 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 	for _, id := range recids {
 		func() {
 			effectiveID := id
+			rowLocked := false
 			// Acquire write lock per-row for mutation scans
 			if needsPerRowLock {
 				m.shard.mu.Lock()
 				m.shard.enterWriteOwner()
+				rowLocked = true
+				defer func() {
+					if rowLocked {
+						m.shard.exitWriteOwner()
+						m.shard.mu.Unlock()
+					}
+				}()
 			}
 			if m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol {
 				if !m.acidMode {
 					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
-							if needsPerRowLock {
-								m.shard.exitWriteOwner()
-								m.shard.mu.Unlock()
-							}
 							return
 						}
 						effectiveID = followedID
@@ -1696,6 +1700,7 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 			if needsPerRowLock {
 				m.shard.exitWriteOwner()
 				m.shard.mu.Unlock()
+				rowLocked = false
 			}
 			acc = m.reduceFn(acc, m.mapFn(m.args...))
 		}()
@@ -1709,19 +1714,23 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 		func() {
 			effectiveID := id
 			batchid := batchids[rowidx]
+			rowLocked := false
 			if needsPerRowLock {
 				m.shard.mu.Lock()
 				m.shard.enterWriteOwner()
+				rowLocked = true
+				defer func() {
+					if rowLocked {
+						m.shard.exitWriteOwner()
+						m.shard.mu.Unlock()
+					}
+				}()
 			}
 			if m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol {
 				if !m.acidMode {
 					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
-							if needsPerRowLock {
-								m.shard.exitWriteOwner()
-								m.shard.mu.Unlock()
-							}
 							return
 						}
 						effectiveID = followedID
@@ -1734,6 +1743,7 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 			if needsPerRowLock {
 				m.shard.exitWriteOwner()
 				m.shard.mu.Unlock()
+				rowLocked = false
 			}
 			acc = m.reduceFn(acc, m.mapFn(m.args...))
 		}()
@@ -1748,19 +1758,23 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 	for _, id := range recids {
 		func() {
 			effectiveID := id
+			rowLocked := false
 			if needsPerRowLock {
 				m.shard.mu.Lock()
 				m.shard.enterWriteOwner()
+				rowLocked = true
+				defer func() {
+					if rowLocked {
+						m.shard.exitWriteOwner()
+						m.shard.mu.Unlock()
+					}
+				}()
 			}
 			if m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol {
 				if !m.acidMode {
 					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
-							if needsPerRowLock {
-								m.shard.exitWriteOwner()
-								m.shard.mu.Unlock()
-							}
 							return
 						}
 						effectiveID = followedID
@@ -1773,6 +1787,7 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 			if needsPerRowLock {
 				m.shard.exitWriteOwner()
 				m.shard.mu.Unlock()
+				rowLocked = false
 			}
 			acc = m.reduceFn(acc, m.mapFn(m.args...))
 		}()
@@ -1786,19 +1801,23 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 		func() {
 			effectiveID := id
 			batchid := batchids[rowidx]
+			rowLocked := false
 			if needsPerRowLock {
 				m.shard.mu.Lock()
 				m.shard.enterWriteOwner()
+				rowLocked = true
+				defer func() {
+					if rowLocked {
+						m.shard.exitWriteOwner()
+						m.shard.mu.Unlock()
+					}
+				}()
 			}
 			if m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol {
 				if !m.acidMode {
 					if m.shard.deletions.Get(uint(effectiveID)) {
 						followedID, ok := m.shard.resolveVisiblePrimaryRecidLocked(effectiveID)
 						if !ok {
-							if needsPerRowLock {
-								m.shard.exitWriteOwner()
-								m.shard.mu.Unlock()
-							}
 							return
 						}
 						effectiveID = followedID
@@ -1811,6 +1830,7 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 			if needsPerRowLock {
 				m.shard.exitWriteOwner()
 				m.shard.mu.Unlock()
+				rowLocked = false
 			}
 			acc = m.reduceFn(acc, m.mapFn(m.args...))
 		}()

--- a/tests/execution/concurrency/mutation-lock-release.yaml
+++ b/tests/execution/concurrency/mutation-lock-release.yaml
@@ -1,0 +1,70 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Mutation scans release shard locks when row projection fails"
+  isolated: true
+
+test_cases:
+  - name: "MLR: create source table"
+    sql: |
+      CREATE TABLE mutation_lock_rows (
+        id INT PRIMARY KEY,
+        value INT
+      )
+
+  - name: "MLR: insert source row"
+    sql: "INSERT INTO mutation_lock_rows VALUES (1, 10)"
+
+  - name: "MLR: create failing computed projection"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "mutation_lock_rows")
+        "failing_value" "INT" '() '("temp" true)
+        '("value")
+        (lambda (value) (error "expected projection failure")))
+    expect:
+      error: true
+
+  - name: "MLR: projection failure aborts update"
+    sql: "UPDATE mutation_lock_rows SET value = failing_value WHERE id = 1"
+    expect:
+      error: true
+
+  - name: "MLR: shard remains readable after projection failure"
+    sql: "SELECT id, value FROM mutation_lock_rows WHERE id = 1"
+    timeout: 2
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          value: 10
+
+  - name: "MLR: rebuild completes after projection failure"
+    scm: "(rebuild)"
+    timeout: 2
+
+  - name: "MLR: rebuild preserves the source row"
+    sql: "SELECT id, value FROM mutation_lock_rows WHERE id = 1"
+    timeout: 2
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          value: 10
+
+  - name: "MLR: cleanup"
+    sql: "DROP TABLE IF EXISTS mutation_lock_rows"


### PR DESCRIPTION
## Summary

- make per-row mutation shard locks panic-safe in main, delta, scalar, and batch reducer paths
- preserve the existing explicit unlock before executing the map/reduce callback
- add an isolated SQL regression that injects a projection error, then verifies reads, rebuild progress, and row preservation

## Root cause

Mutation reducers acquired a shard write lock before resolving row getters. A panic from a computed getter bypassed the explicit unlock, permanently retaining the shard lock. Later reads and rebuilds then blocked on that shard, creating a data-integrity risk during maintenance.

The reducers now register cleanup immediately after acquiring ownership and disarm it after the normal explicit unlock.

## Measurements

Unpatched master:
- read after the injected projection error: no response within 2 s
- rebuild after the error: timed out after 2 s

Patched branch:
- complete 8-step regression suite: 45-203 ms across repeated runs
- unchanged read-only scan microbenchmark: 5127.5 ns/op master vs 5115.1 ns/op patched (-0.24%, noise)

## Validation

- `go test ./storage/...`
- `tests/execution/concurrency/mutation-lock-release.yaml`: 8/8
- `tests/execution/concurrency/rebuild-concurrent.yaml`: 16/16
- `tests/storage/persistence/incremental-invalidation.yaml`: 33/33
- concurrent update suite observed during the broader run: 126/126
- full suite delegated to CI
