### PR TITLE
Fix planner cache eviction lifecycle

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -10163,9 +10163,16 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared carrier. */
 			(merge (list ensure_agg_columns agg_plans computed_order_plans))))
 		(define base_group_fill (symbol "__group_base_fill"))
 		(define base_group_fill_call (list base_group_fill))
+		(define finalize_group_fill (list (quote rebuild) (list (quote table) schema grouptbl) true false))
 		(define initial_fill_expr (if (nil? base_group_into_plan)
 			nil
-			(cons (quote !begin) (filter (list aggregate_prepare_expr base_group_fill_call cleanup_plan) (lambda (expr) (not (nil? expr)))))))
+			(list (quote initialize_cache_table)
+				(list (quote table) schema grouptbl)
+				(list (quote list) (source_table_expr src))
+				(list (quote lambda) '()
+					(cons (quote !begin) (filter (list aggregate_prepare_expr cleanup_plan) (lambda (expr) (not (nil? expr))))))
+				base_group_fill
+				(list (quote lambda) '() finalize_group_fill))))
 		(define create_options (if (nil? initial_fill_expr)
 			(quoted_runtime_list '("engine" "memory"))
 			(list (quote list)

--- a/storage/cache_initializer.go
+++ b/storage/cache_initializer.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Haensch
 */
 package storage
 
+import "strings"
 import "github.com/launix-de/memcp/scm"
 
 type cacheInitializerRun struct {
@@ -27,7 +28,7 @@ type cacheInitializerRun struct {
 // planner cache. Concurrent callers share both completion and failure. A later
 // call retries after a failed run.
 func (t *table) initializeCache(initialize func()) (initialized bool) {
-	if !t.isEphemeralQueryTable() {
+	if !strings.HasPrefix(t.Name, ".") {
 		panic("cache initialization requires a dot-prefixed cache table")
 	}
 

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -1621,6 +1621,18 @@ func buildSelectiveORCInvalidationBody(targetSchema, targetTable, colName string
 func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 	refs := extractScanJoinInfo(computor)
 	targetSchema := t.schema.Name
+	var targetColumn *column
+	for _, col := range t.Columns {
+		if col.Name == name {
+			targetColumn = col
+			break
+		}
+	}
+	if targetColumn == nil {
+		panic("computed trigger target column does not exist: " + t.Name + "." + name)
+	}
+	acquireTarget := func() bool { return t.acquireColumnCacheUse(targetColumn) }
+	releaseTarget := func() { t.releaseColumnCacheUse(targetColumn) }
 	// Collect trigger names placed on source tables for self-cleanup
 	type triggerRef struct{ schema, name string }
 	var registeredNames []triggerRef
@@ -1695,7 +1707,11 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 					IsSystem: true,
 					Priority: 100,
 					Func:     buildFKProc(body),
+					Acquire:  acquireTarget,
+					Release:  releaseTarget,
 				})
+			} else {
+				srcTable.SetTriggerTarget(triggerName, acquireTarget, releaseTarget)
 			}
 			registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
 		}
@@ -1722,7 +1738,11 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 						scm.NewString(t.Name),
 						scm.NewBool(true),
 					})),
+					Acquire: acquireTarget,
+					Release: releaseTarget,
 				})
+			} else {
+				srcTable.SetTriggerTarget(dropTriggerName, acquireTarget, releaseTarget)
 			}
 			registeredNames = append(registeredNames, triggerRef{ref.schema, dropTriggerName})
 		}
@@ -1764,6 +1784,8 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 		return
 	}
 	targetSchema := t.schema.Name
+	acquireTarget := func() bool { return t.acquireColumnCacheUse(col) }
+	releaseTarget := func() { t.releaseColumnCacheUse(col) }
 	type triggerRef struct{ schema, name string }
 	var registeredNames []triggerRef
 	for refIdx, ref := range refs {
@@ -1787,6 +1809,7 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 				}
 			}
 			if exists {
+				srcTable.SetTriggerTarget(triggerName, acquireTarget, releaseTarget)
 				continue
 			}
 			tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
@@ -1807,6 +1830,8 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 				IsSystem: true,
 				Priority: 100,
 				Func:     buildFKProc(body),
+				Acquire:  acquireTarget,
+				Release:  releaseTarget,
 			})
 			if srcTable != t {
 				registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})

--- a/storage/database.go
+++ b/storage/database.go
@@ -1209,9 +1209,23 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 		if !db.schemalock.TryLock() {
 			return false // schemalock is held (e.g. by CreateTable); retry later
 		}
-		db.tables.Remove(tbl.Name) // no-op if already removed by DropTable
+		if db.tables.Get(tbl.Name) != tbl {
+			db.schemalock.Unlock()
+			return true
+		}
+		if !tbl.beginCacheEviction() {
+			db.schemalock.Unlock()
+			return false
+		}
+		db.tables.Remove(tbl.Name)
 		db.saveLockedWithDurabilityAndUnlock(tbl.PersistencyMode == Safe)
+	} else if !tbl.beginCacheEviction() {
+		return false
 	}
+	// The table's self-cleanup hooks remove exactly the source-table triggers
+	// installed for its computed columns. Trigger target pins above make this
+	// safe even when a writer snapshotted a trigger concurrently.
+	tbl.ExecuteTableLifecycleTriggers(AfterDropTable)
 	// remove all shard+index+temp column registrations for this table (recursive)
 	for _, c := range tbl.Columns {
 		if c.IsTemp {

--- a/storage/database.go
+++ b/storage/database.go
@@ -151,6 +151,47 @@ func Rebuild(all bool, repartition bool) string {
 	return rebuildDatabases(all, repartition, false)
 }
 
+// RebuildTable compacts only the table referenced by tbl. It uses the same
+// publication, schema-save and deferred old-shard cleanup path as a global
+// rebuild without touching unrelated tables or databases.
+func RebuildTable(tbl *table, all bool, repartition bool) string {
+	start := time.Now()
+	if tbl == nil || tbl.schema == nil || tbl.schema.tables.Get(tbl.Name) != tbl {
+		panic("cannot rebuild a stale table handle")
+	}
+
+	result := tbl.schema.rebuild(all, repartition, true, tbl)
+	errs := append([]string(nil), result.errors...)
+	if len(errs) == 0 {
+		if err := func() (err error) {
+			defer func() { err = recoverAsError("save failed for database " + tbl.schema.Name) }()
+			tbl.schema.save()
+			return nil
+		}(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) == 0 {
+		for _, s := range result.replaced {
+			if err := func() (err error) {
+				defer func() {
+					err = recoverAsError("cleanup failed for table " + tbl.schema.Name + "." + tbl.Name + " shard " + s.uuid.String())
+				}()
+				s.RemoveFromDisk()
+				return nil
+			}(); err != nil {
+				errs = append(errs, err.Error())
+			}
+		}
+	}
+
+	duration := fmt.Sprint(time.Since(start))
+	if len(errs) == 0 {
+		return duration
+	}
+	return duration + " errors: " + strings.Join(errs, " | ")
+}
+
 func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string {
 	start := time.Now()
 	dbs := databases.GetAll()
@@ -507,7 +548,7 @@ func (db *database) ShowTables() scm.Scmer {
 	return scm.NewSlice(result)
 }
 
-func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) rebuildDatabaseResult {
+func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, only ...*table) rebuildDatabaseResult {
 	if db.srState == COLD {
 		// do nothing for cold databases; avoid loading during rebuild
 		return rebuildDatabaseResult{}
@@ -525,6 +566,9 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool) r
 	var errMu sync.Mutex
 	var rebuildErrors []string
 	dbs := db.tables.GetAll()
+	if len(only) > 0 {
+		dbs = []*table{only[0]}
+	}
 	if !includeEphemeral {
 		onlineTables := make([]*table, 0, len(dbs))
 		for _, t := range dbs {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2063,6 +2063,7 @@ func Init(en scm.Env) {
 					}
 				}
 				if exists {
+					baseTable.SetTriggerTarget(triggerName, ktTable.acquireCacheUse, ktTable.releaseCacheUse)
 					continue
 				}
 				baseTable.AddTrigger(TriggerDescription{
@@ -2071,6 +2072,8 @@ func Init(en scm.Env) {
 					IsSystem: true,
 					Priority: 90, // run before invalidatecolumn (100) so keys are current when values recompute
 					Func:     buildFKProc(td.body),
+					Acquire:  ktTable.acquireCacheUse,
+					Release:  ktTable.releaseCacheUse,
 				})
 			}
 			// Lifecycle cleanup: when the base table is dropped/shape-changed, the keytable
@@ -2092,6 +2095,7 @@ func Init(en scm.Env) {
 					}
 				}
 				if exists {
+					baseTable.SetTriggerTarget(triggerName, ktTable.acquireCacheUse, ktTable.releaseCacheUse)
 					continue
 				}
 				baseTable.AddTrigger(TriggerDescription{
@@ -2100,6 +2104,8 @@ func Init(en scm.Env) {
 					IsSystem: true,
 					Priority: 90,
 					Func:     buildFKProc(dropBody),
+					Acquire:  ktTable.acquireCacheUse,
+					Release:  ktTable.releaseCacheUse,
 				})
 			}
 			return scm.NewBool(true)
@@ -2120,8 +2126,6 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			tbl := TableFromScmer(a[0])
 			initialized := tbl.initializeCache(func() {
-				scm.Apply(a[2])
-
 				sources := mustScmerSlice(a[1], "source tables")
 				sourceTables := make([]*table, len(sources))
 				for i, source := range sources {
@@ -2146,7 +2150,13 @@ func Init(en scm.Env) {
 				for _, source := range sourceTables {
 					unlocks = append(unlocks, acquireTableLock(source.schema.Name, source.Name, false, ss))
 				}
+				// Install maintenance while source writes are blocked. Once the
+				// locks are released, every later mutation observes the triggers.
+				scm.Apply(a[2])
 				scm.Apply(a[3])
+				if len(a) > 4 {
+					scm.Apply(a[4])
+				}
 			})
 			return scm.NewBool(initialized)
 		},
@@ -2156,6 +2166,7 @@ func Init(en scm.Env) {
 				{Kind: "list", ParamName: "source_tables"},
 				{Kind: "func", ParamName: "register_maintenance", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
 				{Kind: "func", ParamName: "initializer", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", ParamName: "finalizer", ParamDesc: "optional zero-argument finalizer run under the same source-table locks after initialization", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}, Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2699,8 +2699,19 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "rebuild",
-		Desc: "rebuilds all main storages and returns the amount of time it took",
+		Desc: "rebuilds main storages and returns the amount of time it took; with a table handle, rebuilds only that table",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if len(a) > 0 && a[0].IsCustom(TagTable) {
+				all := len(a) > 1 && scm.ToBool(a[1])
+				repartition := true
+				if len(a) > 2 {
+					repartition = scm.ToBool(a[2])
+				}
+				return scm.NewString(RebuildTable(TableFromScmer(a[0]), all, repartition))
+			}
+			if len(a) > 2 {
+				panic("global rebuild accepts at most all and repartition")
+			}
 			all := false
 			if len(a) > 0 && scm.ToBool(a[0]) {
 				all = true
@@ -2714,8 +2725,9 @@ func Init(en scm.Env) {
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
-				{Kind: "bool", ParamName: "all", ParamDesc: "if true, rebuild all shards, even if nothing has changed (default: false)", Optional: true},
-				{Kind: "bool", ParamName: "repartition", ParamDesc: "if true, also repartition (default: true)", Optional: true},
+				{Kind: "bool|table", ParamName: "table_or_all", ParamDesc: "table handle for a table-local rebuild; otherwise whether to rebuild unchanged shards globally (default: false)", Optional: true},
+				{Kind: "bool", ParamName: "all_or_repartition", ParamDesc: "with a table: whether to rebuild unchanged shards; globally: whether to repartition (default: true)", Optional: true},
+				{Kind: "bool", ParamName: "repartition", ParamDesc: "with a table handle, whether to repartition that table (default: true)", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},

--- a/storage/table.go
+++ b/storage/table.go
@@ -75,6 +75,7 @@ type column struct {
 	Comment            string
 	sanitizer          func(scm.Scmer) scm.Scmer
 	lastAccessed       int64 // atomic; UnixNano timestamp for CacheManager LRU (lock-free via sync/atomic)
+	cacheUsers         int64 // atomic; -1 while/after CacheManager eviction, otherwise active trigger users
 
 	// Statistics — updated at rebuild time, O(1) access for query planning.
 	// DistinctEstimate is the sum of per-shard DistinctCount() (upper bound).
@@ -275,6 +276,7 @@ type table struct {
 	Foreign         []foreignKey         // foreign keys
 	Triggers        []TriggerDescription // triggers on this table
 	PersistencyMode PersistencyMode      /* 0 = safe (default), 1 = sloppy, 2 = memory */
+	cacheUsers      int64                // atomic; -1 while/after CacheManager eviction, otherwise active trigger users
 	// LOCK ORDER CONTRACT:
 	//   1. db.schemalock
 	//   2. t.ddlMu
@@ -1368,6 +1370,14 @@ func (t *table) registerTempColumn(cp *column) {
 		}
 		for i, col := range tbl.Columns {
 			if col.Name == colName {
+				// A trigger that already snapshotted this column pins it without a
+				// mutex. Retry eviction instead of deleting its target underneath it.
+				if !col.beginCacheEviction() {
+					tbl.schema.schemalock.Unlock()
+					return false
+				}
+				tbl.removeComputeTriggers(colName)
+				tbl.removeORCDependencyTriggers(colName)
 				tbl.Columns = append(tbl.Columns[:i], tbl.Columns[i+1:]...)
 				for _, s := range tbl.Shards {
 					s.mu.Lock()

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "errors"
+import "sync/atomic"
 import "encoding/json"
 import "github.com/launix-de/memcp/scm"
 
@@ -147,6 +148,61 @@ type TriggerDescription struct {
 	Priority   int           `json:"priority,omitempty"`   // Execution order (lower = earlier)
 	Async      bool          `json:"async,omitempty"`      // Run trigger in background goroutine (fire-and-forget, no transaction context)
 	VectorFunc scm.Scmer     `json:"-"`                    // Vectorized trigger: (lambda (OLD_batch NEW_batch) ...) for batch execution
+	Acquire    func() bool   `json:"-"`                    // Optional lock-free pin for an ephemeral trigger target
+	Release    func()        `json:"-"`                    // Releases a successful Acquire
+}
+
+func acquireCacheUse(users *int64) bool {
+	for {
+		current := atomic.LoadInt64(users)
+		if current < 0 {
+			return false
+		}
+		if atomic.CompareAndSwapInt64(users, current, current+1) {
+			return true
+		}
+	}
+}
+
+func beginCacheEviction(users *int64) bool {
+	return atomic.CompareAndSwapInt64(users, 0, -1)
+}
+
+func (t *table) acquireCacheUse() bool { return acquireCacheUse(&t.cacheUsers) }
+func (t *table) releaseCacheUse()      { atomic.AddInt64(&t.cacheUsers, -1) }
+func (t *table) beginCacheEviction() bool {
+	return beginCacheEviction(&t.cacheUsers)
+}
+func (c *column) acquireCacheUse() bool { return acquireCacheUse(&c.cacheUsers) }
+func (c *column) releaseCacheUse()      { atomic.AddInt64(&c.cacheUsers, -1) }
+func (c *column) beginCacheEviction() bool {
+	return beginCacheEviction(&c.cacheUsers)
+}
+
+func (t *table) acquireColumnCacheUse(c *column) bool {
+	if !t.acquireCacheUse() {
+		return false
+	}
+	if !c.acquireCacheUse() {
+		t.releaseCacheUse()
+		return false
+	}
+	return true
+}
+
+func (t *table) releaseColumnCacheUse(c *column) {
+	c.releaseCacheUse()
+	t.releaseCacheUse()
+}
+
+func (tr TriggerDescription) acquireTarget() bool {
+	return tr.Acquire == nil || tr.Acquire()
+}
+
+func (tr TriggerDescription) releaseTarget() {
+	if tr.Release != nil {
+		tr.Release()
+	}
 }
 
 type persistedTriggerDescription struct {
@@ -325,6 +381,21 @@ func (t *table) RemoveTrigger(name string) bool {
 	return false
 }
 
+// SetTriggerTarget refreshes the runtime-only cache target pin on an
+// idempotently reused system trigger, including triggers restored from JSON.
+func (t *table) SetTriggerTarget(name string, acquire func() bool, release func()) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range t.Triggers {
+		if t.Triggers[i].Name == name {
+			t.Triggers[i].Acquire = acquire
+			t.Triggers[i].Release = release
+			return true
+		}
+	}
+	return false
+}
+
 // rowToDict converts a dataset to a dict with column names
 func (t *table) rowToDict(row dataset) scm.Scmer {
 	if row == nil {
@@ -428,12 +499,20 @@ func (t *table) ExecuteTriggers(timing TriggerTiming, oldRow, newRow dataset) {
 					_ = trName
 					_ = tName
 				}()
+				if !tr.acquireTarget() {
+					return
+				}
+				defer tr.releaseTarget()
 				scm.Apply(trFunc, oldDict, newDict, session)
 			}()
 			continue
 		}
+		if !tr.acquireTarget() {
+			continue
+		}
 		// Execute trigger with savepoint for proper rollback
 		func() {
+			defer tr.releaseTarget()
 			tx := CurrentTx()
 			var sp Savepoint
 			hasSavepoint := false
@@ -477,7 +556,8 @@ func (t *table) ExecuteTriggersBatch(timing TriggerTiming, rows []dataset, isOld
 			continue
 		}
 		if tr.Async {
-			// Async: fire per-row (no batching for fire-and-forget)
+			// Each queued invocation acquires its own target pin. Holding one only
+			// while launching goroutines would let eviction race their execution.
 			for _, row := range rows {
 				var oldDict, newDict scm.Scmer = scm.NewNil(), scm.NewNil()
 				if isOld {
@@ -485,78 +565,88 @@ func (t *table) ExecuteTriggersBatch(timing TriggerTiming, rows []dataset, isOld
 				} else {
 					newDict = t.rowToDict(row)
 				}
-				trFunc := tr.Func
+				tr := tr
 				go func() {
 					defer func() { recover() }()
-					scm.Apply(trFunc, oldDict, newDict, session)
+					if !tr.acquireTarget() {
+						return
+					}
+					defer tr.releaseTarget()
+					scm.Apply(tr.Func, oldDict, newDict, session)
 				}()
 			}
 			continue
 		}
-		// Check for vectorized trigger (VectorFunc set)
-		if !tr.VectorFunc.IsNil() {
-			// Build columnar dict-of-lists: {"col1": [v1,v2,...], "col2": [v1,v2,...]}
-			colBatch := t.rowsToColumnar(rows)
-			func() {
-				tx := CurrentTx()
-				var sp Savepoint
-				hasSavepoint := false
-				if tx != nil {
-					sp = tx.CreateSavepoint()
-					hasSavepoint = true
-				}
-				defer func() {
-					if r := recover(); r != nil {
-						if hasSavepoint {
-							tx.RollbackToSavepoint(sp)
-						}
-						// Vectorization failed: fall back to per-row
-						for _, row := range rows {
-							var oldDict, newDict scm.Scmer = scm.NewNil(), scm.NewNil()
-							if isOld {
-								oldDict = t.rowToDict(row)
-							} else {
-								newDict = t.rowToDict(row)
+		if !tr.acquireTarget() {
+			continue
+		}
+		func() {
+			defer tr.releaseTarget()
+			// Check for vectorized trigger (VectorFunc set)
+			if !tr.VectorFunc.IsNil() {
+				// Build columnar dict-of-lists: {"col1": [v1,v2,...], "col2": [v1,v2,...]}
+				colBatch := t.rowsToColumnar(rows)
+				func() {
+					tx := CurrentTx()
+					var sp Savepoint
+					hasSavepoint := false
+					if tx != nil {
+						sp = tx.CreateSavepoint()
+						hasSavepoint = true
+					}
+					defer func() {
+						if r := recover(); r != nil {
+							if hasSavepoint {
+								tx.RollbackToSavepoint(sp)
 							}
-							scm.Apply(tr.Func, oldDict, newDict, session)
+							// Vectorization failed: fall back to per-row
+							for _, row := range rows {
+								var oldDict, newDict scm.Scmer = scm.NewNil(), scm.NewNil()
+								if isOld {
+									oldDict = t.rowToDict(row)
+								} else {
+									newDict = t.rowToDict(row)
+								}
+								scm.Apply(tr.Func, oldDict, newDict, session)
+							}
 						}
+					}()
+					if isOld {
+						scm.Apply(tr.VectorFunc, colBatch, scm.NewNil(), session)
+					} else {
+						scm.Apply(tr.VectorFunc, scm.NewNil(), colBatch, session)
 					}
 				}()
-				if isOld {
-					scm.Apply(tr.VectorFunc, colBatch, scm.NewNil(), session)
-				} else {
-					scm.Apply(tr.VectorFunc, scm.NewNil(), colBatch, session)
-				}
-			}()
-			continue
-		}
-		// Fallback: per-row execution
-		for _, row := range rows {
-			var oldDict, newDict scm.Scmer = scm.NewNil(), scm.NewNil()
-			if isOld {
-				oldDict = t.rowToDict(row)
-			} else {
-				newDict = t.rowToDict(row)
+				return
 			}
-			func() {
-				tx := CurrentTx()
-				var sp Savepoint
-				hasSavepoint := false
-				if tx != nil {
-					sp = tx.CreateSavepoint()
-					hasSavepoint = true
+			// Fallback: per-row execution
+			for _, row := range rows {
+				var oldDict, newDict scm.Scmer = scm.NewNil(), scm.NewNil()
+				if isOld {
+					oldDict = t.rowToDict(row)
+				} else {
+					newDict = t.rowToDict(row)
 				}
-				defer func() {
-					if r := recover(); r != nil {
-						if hasSavepoint {
-							tx.RollbackToSavepoint(sp)
-						}
-						panic(fmt.Sprintf("trigger %s (%s) on %s failed: %v", tr.Name, timing, t.Name, r))
+				func() {
+					tx := CurrentTx()
+					var sp Savepoint
+					hasSavepoint := false
+					if tx != nil {
+						sp = tx.CreateSavepoint()
+						hasSavepoint = true
 					}
+					defer func() {
+						if r := recover(); r != nil {
+							if hasSavepoint {
+								tx.RollbackToSavepoint(sp)
+							}
+							panic(fmt.Sprintf("trigger %s (%s) on %s failed: %v", tr.Name, timing, t.Name, r))
+						}
+					}()
+					scm.Apply(tr.Func, oldDict, newDict, session)
 				}()
-				scm.Apply(tr.Func, oldDict, newDict, session)
-			}()
-		}
+			}
+		}()
 	}
 }
 

--- a/tests/performance/group-lookup-performance.yaml
+++ b/tests/performance/group-lookup-performance.yaml
@@ -97,7 +97,7 @@ setup:
         (insert (table "memcp-tests" "lookup_group_items") '("id" "code" "bucket" "label")
           (map (produceN 20000) (lambda (i)
             (list i (concat "c" i) (concat "b" (mod i 4)) (concat "label " i)))))
-        (rebuild true)
+        (rebuild (table "memcp-tests" "lookup_group_items") true false)
         20000)
 
 cleanup:
@@ -229,6 +229,32 @@ test_cases:
       GROUP BY bucket
     expect:
       rows: 4
+
+  - name: "warm maintained group cache averages below one millisecond"
+    scm: |
+      (begin
+        (define iterations 200)
+        (define session (newsession))
+        (session "username" "root")
+        (session "schema" "memcp-tests")
+        (define resultrow (lambda (_row) true))
+        (define formula
+          (cached_parse (newcachemap) parse_sql "memcp-tests"
+            "SELECT bucket AS value, COUNT(*) AS amount FROM lookup_group_items WHERE TRUE GROUP BY bucket"
+            (lambda (_schema _table _write) true) "root" session true))
+        (define elapsed
+          (with_session session (lambda ()
+            (with_autocommit session (lambda () (begin
+              (eval formula)
+              (define started (nanotime))
+              (reduce (produceN iterations)
+                (lambda (count _index) (begin (eval formula) (+ count 1))) 0)
+              (- (nanotime) started)))))))
+        (define average_ns (/ elapsed iterations))
+        (if (< average_ns 1000000)
+          "ok"
+          (error (concat "warm group cache average: " average_ns "ns"))))
+    expect: {}
 
   - name: "low-cardinality group keeps a reusable keytable"
     sql: |

--- a/tests/storage/formats/storage-const.yaml
+++ b/tests/storage/formats/storage-const.yaml
@@ -51,7 +51,7 @@ test_cases:
       data:
         - val: 42
 
-  - name: "Int-const: table-local rebuild to trigger StorageConst"
+  - name: "Int-const: rebuild to trigger StorageConst"
     scm: '(rebuild (table "memcp-tests" "sc_int") true false)'
 
   - name: "Int-const: verify val column is const[42] after rebuild"

--- a/tests/storage/formats/storage-const.yaml
+++ b/tests/storage/formats/storage-const.yaml
@@ -1,3 +1,4 @@
+# Copyright (C) 2023-2026  Carl-Philip Hänsch
 # StorageConst compression test suite
 # Verifies that columns with a single distinct value are compressed to StorageConst
 # after rebuild. Uses scm:(rebuild) and (show ... 0 true) to inspect storage type.
@@ -9,6 +10,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS sc_int"
+  - sql: "DROP TABLE IF EXISTS sc_untouched"
   - sql: "DROP TABLE IF EXISTS sc_str"
   - sql: "DROP TABLE IF EXISTS sc_null"
   - sql: "DROP TABLE IF EXISTS sc_mixed"
@@ -32,6 +34,16 @@ test_cases:
     expect:
       affected_rows: 50
 
+  - name: "Create table-local rebuild control table"
+    sql: "CREATE TABLE sc_untouched (id INT, val TINYINT)"
+    expect:
+      rows: 0
+
+  - name: "Insert delta rows into table-local rebuild control"
+    sql: "INSERT INTO sc_untouched VALUES (1,7),(2,7),(3,7)"
+    expect:
+      affected_rows: 3
+
   - name: "Int-const: verify value before rebuild"
     sql: "SELECT val FROM sc_int WHERE id = 25"
     expect:
@@ -39,8 +51,8 @@ test_cases:
       data:
         - val: 42
 
-  - name: "Int-const: rebuild to trigger StorageConst"
-    scm: "(rebuild)"
+  - name: "Int-const: table-local rebuild to trigger StorageConst"
+    scm: '(rebuild (table "memcp-tests" "sc_int") true false)'
 
   - name: "Int-const: verify val column is const[42] after rebuild"
     scm: |
@@ -51,6 +63,16 @@ test_cases:
         (set compr (get_assoc col "compression"))
         (if (equal? compr "const[42]") "ok"
           (error (concat "expected const[42], got " compr))))
+
+  - name: "Int-const: table-local rebuild leaves other table in delta storage"
+    scm: |
+      (begin
+        (set shard (show "memcp-tests" "sc_untouched" 0 true))
+        (set cols (get_assoc shard "columns"))
+        (set col (nth (filter cols (lambda (c) (equal? (get_assoc c "name") "val"))) 0))
+        (set compr (get_assoc col "compression"))
+        (if (not (equal? compr "const[7]")) "ok"
+          (error "table-local rebuild compacted an unrelated table")))
 
   - name: "Int-const: read first row after rebuild"
     sql: "SELECT val FROM sc_int WHERE id = 0"
@@ -270,6 +292,7 @@ test_cases:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS sc_int"
+  - sql: "DROP TABLE IF EXISTS sc_untouched"
   - sql: "DROP TABLE IF EXISTS sc_str"
   - sql: "DROP TABLE IF EXISTS sc_null"
   - sql: "DROP TABLE IF EXISTS sc_mixed"

--- a/tests/storage/persistence/memory-pressure.yaml
+++ b/tests/storage/persistence/memory-pressure.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2023-2026  Carl-Philip Hänsch
+
 metadata:
   version: "1.0"
   description: "Memory pressure management"
@@ -119,8 +121,12 @@ test_cases:
     scm: (stat)
     expect: {}
 
-  - name: "MP: set MaxRamBytes to 1MB (evict temp keytables + columns)"
-    scm: (settings "MaxRamBytes" 1048576)
+  - name: "MP: let planner cache entries become evictable"
+    scm: (sleep 1.1)
+    expect: {}
+
+  - name: "MP: force eviction of temp keytables and columns"
+    scm: (settings "MaxRamBytes" 1)
     expect: {}
 
   - name: "MP: stat after temp eviction"
@@ -130,6 +136,19 @@ test_cases:
   - name: "MP: reset MaxRamBytes to 0 (before recovery test)"
     scm: (settings "MaxRamBytes" 0)
     expect: {}
+
+  - name: "MP: base-table mutation ignores evicted aggregate dependencies"
+    sql: "UPDATE `memcp-tests`.mp_pressure SET b = b + 10 WHERE id = 1000"
+    expect:
+      affected_rows: 1
+
+  - name: "MP: aggregate is rebuilt correctly after eviction and mutation"
+    sql: "SELECT a, SUM(b) AS sb FROM `memcp-tests`.mp_pressure WHERE a = 321918 GROUP BY a"
+    expect:
+      rows: 1
+      data:
+        - a: 321918
+          sb: 347262
 
   - name: "MP: GROUP BY still works after temp keytable eviction"
     sql: "SELECT a, SUM(b) AS sb FROM `memcp-tests`.mp_pressure GROUP BY a ORDER BY a LIMIT 3"

--- a/tests/storage/persistence/memory-pressure.yaml
+++ b/tests/storage/persistence/memory-pressure.yaml
@@ -125,7 +125,7 @@ test_cases:
     scm: (sleep 1.1)
     expect: {}
 
-  - name: "MP: force eviction of temp keytables and columns"
+  - name: "MP: set MaxRamBytes to 1MB (evict temp keytables + columns)"
     scm: (settings "MaxRamBytes" 1)
     expect: {}
 


### PR DESCRIPTION
## Summary
- add table-local `rebuild` for canonical cache finalization without touching unrelated schemas or tables
- initialize low-cardinality group caches under source-table locks, install maintenance first, and perform the final local rebuild before publishing the cache
- retire computed-column and keytable dependencies atomically during eviction so snapshotted triggers cannot target deleted cache objects
- add anonymized YAML regressions for local rebuild isolation, eviction followed by source mutation, concurrent cold initialization, and sub-millisecond warm aggregate reads

## Root cause
Cache eviction removed planner-owned keytables and columns without removing their exact source-table triggers. A later mutation could therefore execute a stale trigger against a deleted target and lose the aggregate update. Group-cache initialization also finalized storage outside the source lock window, while the existing global `rebuild` form could compact unrelated tables.

## A/B against origin/master (87778b054)
| Scenario | master | PR |
|---|---:|---:|
| Evict group cache, mutate source, query aggregate | 30/32; stale trigger error and stale sum | 32/32 |
| Rebuild one table, verify unrelated delta table | 38/39; unrelated table compacted | 39/39 |
| Warm maintained group cache, 200 evaluations | 301.8 us/query | 311.4 us/query |

The warm-path difference is about 3% in a single short run and is within run-to-run noise; both builds remain well below the enforced 1 ms bound. Target pinning is lock-free and only applies while a maintenance trigger is executing.

## Validation
- `go build -o memcp`
- `go test ./storage -run 'TestDatabaseRebuild|TestCreateColumnWaitsForTableRebuildLock|Test.*Trigger' -count=1 -timeout=3m`
- `tests/execution/concurrency/group-carrier-initialization.yaml`: 16/16
- `tests/storage/persistence/memory-pressure.yaml`: 32/32
- `tests/storage/formats/storage-const.yaml`: 39/39
- `tests/performance/group-lookup-performance.yaml`: 15/15
- `tests/sql/triggers/trigger-compat.yaml`: 28/28
- GitHub Actions regression guard: pass in 15 s
- GitHub Actions full test: pass in 8m58s

A local coverage-instrumented `make test` exposed the current-master compile-time sensitivity: trigger suites took 3-4 minutes and the shared server temporarily stopped answering. The same trigger compatibility suite passes 28/28 in 0.52 s with the normal binary. Two unchanged ORDER/OFFSET performance gates similarly exceeded 5 s only under local coverage; the normal binary passes that suite 21/21 in 2.0 s. The clean GitHub runner completed the full coverage suite successfully.