### PR TITLE
Document computed-column materialization invariant

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -154,6 +154,32 @@ Use the existing scalable physical representations instead:
 Lists remain valid for bounded scalar tuples, operator arguments, parser data,
 and final API row values. Their size must be independent of relation cardinality.
 
+## Computed Columns Are Definitions, Not Prepared Subsets
+
+A computed column, including a `StorageComputeProxy`, defines one logical value
+for every live row in its table. Its physical cache may be complete, partial,
+invalidated, or absent without changing that logical domain.
+
+`filter` / `filterCols` arguments and `CompressFiltered` are preparation hints.
+They may select values to prewarm because a physical plan expects to read them
+soon, but they must never become part of the column definition. A row omitted
+from a preparation batch is not absent, `NULL`, or an error.
+
+An ordinary computed column may repair a missing or invalidated value by
+computing that row from its current inputs and caching the result. An ordered
+reduction column (ORC) has dependencies between rows and must instead repair a
+semantically sufficient ordered dependency range. That range may be a suffix
+or the whole column. It must not pretend that an order-dependent value can be
+computed pointwise, return stale data, or expose a transient invalid-cache
+sentinel as a SQL value.
+
+Invalidation marks physical cache entries as unusable; it does not remove their
+logical values. Invalidation and repair must cover the dependency closure of
+the changed inputs. Planner setup, DDL, rebuild, persistence, and session-local
+variants must preserve this definition/cache distinction. Eager preparation,
+selective prewarming, and lazy repair may change when work happens, never the
+query-visible result.
+
 ## LIMIT Is A Scan Boundary
 
 Every physical operator that owns a SQL `LIMIT` must lower to `scan_order` or

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -70,6 +70,10 @@ func runWithTxSession(tx *TxContext, fn func()) {
 }
 
 func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {
+	// Computed-column DDL installs one complete logical column. filter/filterCols
+	// only select the initial prewarm batch for values the caller expects to read;
+	// they never restrict the column's domain. Rows outside that batch stay lazy
+	// and StorageComputeProxy.GetValue materializes them individually on demand.
 	t.schema.schemalock.Lock()
 	metadataLocked := true
 	defer func() {
@@ -217,7 +221,9 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 		return true
 	}
 
-	// Create new proxy
+	// Publish the definition before preparing values. Readers may immediately use
+	// the proxy: prewarmed rows hit its cache, while every other row is computed
+	// pointwise by GetValue and then cached.
 	proxy := &StorageComputeProxy{
 		delta:       make(map[uint32]scm.Scmer),
 		computor:    computor,

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -70,10 +70,12 @@ func runWithTxSession(tx *TxContext, fn func()) {
 }
 
 func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {
-	// Computed-column DDL installs one complete logical column. filter/filterCols
-	// only select the initial prewarm batch for values the caller expects to read;
-	// they never restrict the column's domain. Rows outside that batch stay lazy
-	// and StorageComputeProxy.GetValue materializes them individually on demand.
+	// Ordinary computed-column DDL installs one complete logical column.
+	// filter/filterCols only select the initial prewarm batch for values the caller
+	// expects to read; they never restrict the column's domain. Rows outside that
+	// batch stay lazy and StorageComputeProxy.GetValue materializes them
+	// individually on demand. Ordered reduction columns use dependency-aware
+	// preparation and repair instead.
 	t.schema.schemalock.Lock()
 	metadataLocked := true
 	defer func() {

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -68,9 +68,25 @@ func applyWithTx(tx *TxContext, fn scm.Scmer, args ...scm.Scmer) scm.Scmer {
 	}))
 }
 
-// StorageComputeProxy wraps a main storage with lazy-evaluation support.
-// Values are computed on demand via a computor lambda and cached in a delta map
-// until Compress() materializes them into a compressed main storage.
+// StorageComputeProxy is a complete logical column with lazy physical values.
+// Creating the proxy installs the column definition first; it does not require
+// every row value to be materialized before the column can be read.
+//
+// Materialization contract:
+//   - Compress eagerly prepares every row when all values are expected to be
+//     consumed.
+//   - CompressFiltered only prewarms rows selected by its filter because the
+//     caller expects to consume those rows soon. The filter is a preparation
+//     hint, not part of the column definition or its value semantics.
+//   - GetValue must compute a missing or invalidated row just in time, cache the
+//     result, and return it. A row omitted by prewarming is neither NULL nor an
+//     error and must never require rebuilding the whole column.
+//   - Invalidation discards only affected cached values where possible; later
+//     reads repair those values pointwise through the same JIT path.
+//
+// Keep this distinction intact when changing planner setup, DDL, rebuild, or
+// scan code: selective preparation may change work scheduling, never which
+// values the StorageComputeProxy represents.
 type StorageComputeProxy struct {
 	main       ColumnStorage                       // after Compress() — typically StorageSCMER or compressed type
 	delta      map[uint32]scm.Scmer                // sparse overwrites (lazy-computed values before Compress)
@@ -369,7 +385,10 @@ func (p *StorageComputeProxy) ComputeSize() uint {
 	return sz
 }
 
-// GetValue returns the value at idx, computing on demand if necessary.
+// GetValue returns the logical value at idx. A cache miss or invalidated value
+// is the normal JIT path: compute only this row from the current input values,
+// cache it, and return it. Do not turn a miss into eager whole-column
+// materialization and do not treat an unprepared row as absent.
 func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	// ORC path: validity tracked per-row via validMask.
 	if p.isOrdered {
@@ -521,8 +540,11 @@ func (p *StorageComputeProxy) Compress() {
 	p.compressed = true
 }
 
-// CompressFiltered eagerly computes only rows matching the filter predicate.
-// Unmatched rows stay lazy and are computed on demand via GetValue.
+// CompressFiltered prewarms only rows matching filter because the caller has
+// signalled that those values will likely be read immediately. The filter does
+// not narrow the logical column and is not a read-time predicate: unmatched
+// rows remain valid lazy values and GetValue materializes each one pointwise on
+// first read. Invalidated rows follow the same JIT repair path.
 func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.Scmer) {
 	tx := CurrentTx()
 	if variant := p.currentVariant(tx, true); variant != nil {

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -82,7 +82,7 @@ func applyWithTx(tx *TxContext, fn scm.Scmer, args ...scm.Scmer) scm.Scmer {
 //     result, and return it. A row omitted by prewarming is neither NULL nor an
 //     error and must never require rebuilding the whole column.
 //   - Invalidation discards only affected cached values where possible; later
-//     reads repair those values pointwise through the same JIT path.
+//     reads repair those values through the same pointwise on-demand path.
 //
 // Keep this distinction intact when changing planner setup, DDL, rebuild, or
 // scan code: selective preparation may change work scheduling, never which
@@ -386,8 +386,8 @@ func (p *StorageComputeProxy) ComputeSize() uint {
 }
 
 // GetValue returns the logical value at idx. A cache miss or invalidated value
-// is the normal JIT path: compute only this row from the current input values,
-// cache it, and return it. Do not turn a miss into eager whole-column
+// is the normal on-demand path: compute only this row from the current input
+// values, cache it, and return it. Do not turn a miss into eager whole-column
 // materialization and do not treat an unprepared row as absent.
 func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	// ORC path: validity tracked per-row via validMask.
@@ -544,7 +544,7 @@ func (p *StorageComputeProxy) Compress() {
 // signalled that those values will likely be read immediately. The filter does
 // not narrow the logical column and is not a read-time predicate: unmatched
 // rows remain valid lazy values and GetValue materializes each one pointwise on
-// first read. Invalidated rows follow the same JIT repair path.
+// first read. Invalidated rows follow the same pointwise on-demand repair path.
 func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.Scmer) {
 	tx := CurrentTx()
 	if variant := p.currentVariant(tx, true); variant != nil {

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -85,11 +85,13 @@ func applyWithTx(tx *TxContext, fn scm.Scmer, args ...scm.Scmer) scm.Scmer {
 //   - CompressFiltered only prewarms rows selected by its filter because the
 //     caller expects to consume those rows soon. The filter is a preparation
 //     hint, not part of the column definition or its value semantics.
-//   - GetValue must compute a missing or invalidated row just in time, cache the
-//     result, and return it. A row omitted by prewarming is neither NULL nor an
-//     error and must never require rebuilding the whole column.
-//   - Invalidation discards only affected cached values where possible; later
-//     reads repair those values through the same pointwise on-demand path.
+//   - GetValue repairs an ordinary missing or invalidated value pointwise and
+//     caches it. A row omitted by prewarming is neither NULL nor an error.
+//   - An ordered reduction column cannot be repaired pointwise. Its GetValue
+//     path recomputes the ordered dependency range required for the requested
+//     value, which may include a suffix or the whole column.
+//   - Invalidation marks cached values unusable; later reads repair the affected
+//     dependency closure without changing the column's logical domain.
 //
 // Keep this distinction intact when changing planner setup, DDL, rebuild, or
 // scan code: selective preparation may change work scheduling, never which
@@ -433,10 +435,11 @@ func (p *StorageComputeProxy) ComputeSize() uint {
 	return sz
 }
 
-// GetValue returns the logical value at idx. A cache miss or invalidated value
-// is the normal on-demand path: compute only this row from the current input
-// values, cache it, and return it. Do not turn a miss into eager whole-column
-// materialization and do not treat an unprepared row as absent.
+// GetValue returns the logical value at idx. For an ordinary proxy, a cache miss
+// or invalidated value computes only this row from the current inputs and caches
+// it. For an ordered reduction column, the branch below repairs the required
+// ordered dependency range instead. Neither kind may treat an unprepared row as
+// absent or expose a transient invalid-cache sentinel as its logical value.
 func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	// ORC path: validity tracked per-row via validMask.
 	if p.isOrdered {
@@ -588,11 +591,12 @@ func (p *StorageComputeProxy) Compress() {
 	p.compressed = true
 }
 
-// CompressFiltered prewarms only rows matching filter because the caller has
-// signalled that those values will likely be read immediately. The filter does
-// not narrow the logical column and is not a read-time predicate: unmatched
-// rows remain valid lazy values and GetValue materializes each one pointwise on
-// first read. Invalidated rows follow the same pointwise on-demand repair path.
+// CompressFiltered prewarms an ordinary computed column only for rows matching
+// filter because the caller has signalled that those values will likely be read
+// immediately. The filter does not narrow the logical column and is not a
+// read-time predicate: unmatched rows remain valid lazy values and GetValue
+// materializes each one pointwise on first read. Ordered reduction columns have
+// dependency-aware preparation and repair paths instead.
 func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.Scmer) {
 	tx := CurrentTx()
 	if variant := p.currentVariant(tx, true); variant != nil {


### PR DESCRIPTION
## What
- define in `INVARIANTS.md` that a computed column represents every live row regardless of cache state
- specify that filtered preparation is a scheduling/prewarming hint, never part of the logical column definition
- distinguish pointwise repair for ordinary compute proxies from dependency-aware ordered repair for ORCs
- document the same contract at the DDL, proxy, `GetValue`, and `CompressFiltered` implementation boundaries

## Why
Planner and storage work must not mistake a selectively prepared physical cache for a partial logical column. That would make query results depend on preparation strategy. ORCs also cannot safely inherit the ordinary proxy assumption that every cache miss is repairable one row at a time.

## Validation
- `gofmt -w storage/compute.go storage/compute_proxy.go`
- `git diff --check`
- documentation/comment-only change; executable behavior unchanged