### PR TITLE
Fix computed reads inside shard scans

### DIFF
--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -54,6 +54,13 @@ type computeVariantReader struct {
 	tx      *TxContext
 }
 
+type computeProxyReader struct {
+	proxy   *StorageComputeProxy
+	readers []ColumnReader
+	tx      *TxContext
+	values  []scm.Scmer
+}
+
 func applyWithTx(tx *TxContext, fn scm.Scmer, args ...scm.Scmer) scm.Scmer {
 	if fn.IsProc() {
 		proc := *fn.Proc()
@@ -231,14 +238,55 @@ func (r *computeVariantReader) GetValue(idx uint32) scm.Scmer {
 	return val
 }
 
+func (r *computeProxyReader) GetValue(idx uint32) scm.Scmer {
+	p := r.proxy
+
+	p.mu.RLock()
+	if val, ok := p.delta[idx]; ok {
+		p.mu.RUnlock()
+		return val
+	}
+	p.mu.RUnlock()
+
+	if p.compressed && idx < p.count && p.main != nil {
+		return p.main.GetValue(idx)
+	}
+	if p.validMask.Get(uint(idx)) && idx < p.count && p.main != nil {
+		return p.main.GetValue(idx)
+	}
+
+	for i := range r.readers {
+		r.values[i] = r.readers[i].GetValue(idx)
+	}
+	val := applyWithTx(r.tx, p.computor, r.values...)
+
+	p.mu.Lock()
+	p.delta[idx] = val
+	p.mu.Unlock()
+	p.validMask.Set(uint(idx), true)
+	return val
+}
+
 func (p *StorageComputeProxy) GetCachedReaderTx(tx *TxContext) ColumnReader {
-	if !p.hasSessionVariants() {
+	if p.isOrdered {
 		return p
 	}
-	variant := p.currentVariant(tx, true)
+	// Bind input readers before the physical scan acquires the shard read lock.
+	// A cache miss may compute a value, but it must stay within the already
+	// acquired shard capability instead of re-entering GetRead/ColumnReaderTx.
+	// This also keeps the reader executable on a future remote shard owner.
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
 		readers[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+	}
+	variant := p.currentVariant(tx, true)
+	if variant == nil {
+		return &computeProxyReader{
+			proxy:   p,
+			readers: readers,
+			tx:      tx,
+			values:  make([]scm.Scmer, len(readers)),
+		}
 	}
 	return &computeVariantReader{
 		proxy:   p,

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -54,6 +54,10 @@ func computeShardIndex(schema []shardDimension, values []scm.Scmer) (result int)
 }
 
 func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
+	// Keep shard acquisition outside physical scan callbacks. In clustered mode
+	// this is the orchestration point that can choose a local SHARED copy or send
+	// the whole shard-local scan pipeline to a remote holder; row readers must not
+	// perform another resource acquisition from inside the callback.
 	callback := callback_old
 	if scm.Trace != nil {
 		// hook on tracing

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -258,7 +258,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsTxReader := make([]bool, len(conditionCols))
+	cNeedsCachedReader := make([]bool, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
 		if k == "$recset_contains" {
@@ -274,8 +274,8 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-			cNeedsTxReader[i] = true
+		if _, ok := ccols[i].(*StorageComputeProxy); ok {
+			cNeedsCachedReader[i] = true
 		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
@@ -322,7 +322,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 				for i, c := range cReaders {
 					if getter := conditionGetters[i]; getter != nil {
 						cdataset[i] = getter(idx, 0)
-					} else if cNeedsTxReader[i] {
+					} else if cNeedsCachedReader[i] {
 						cdataset[i] = c.GetValue(idx)
 					} else {
 						cdataset[i] = ccols[i].GetValue(idx)
@@ -332,7 +332,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 				for i, col := range conditionCols {
 					if getter := conditionGetters[i]; getter != nil {
 						cdataset[i] = getter(idx, 0)
-					} else if cNeedsTxReader[i] {
+					} else if cNeedsCachedReader[i] {
 						cdataset[i] = cReaders[i].GetValue(idx)
 					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 						cdataset[i] = ccols[i].GetValue(idx)

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -689,7 +689,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsTxReader := make([]bool, len(conditionCols))
+	cNeedsCachedReader := make([]bool, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
 		if k == "$recset_contains" {
@@ -704,8 +704,8 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-			cNeedsTxReader[i] = true
+		if _, ok := ccols[i].(*StorageComputeProxy); ok {
+			cNeedsCachedReader[i] = true
 		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
@@ -758,7 +758,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 				for i, c := range cReaders {
 					if getter := conditionGetters[i]; getter != nil {
 						cdataset[i] = getter(idx, 0)
-					} else if cNeedsTxReader[i] {
+					} else if cNeedsCachedReader[i] {
 						cdataset[i] = c.GetValue(idx)
 					} else {
 						cdataset[i] = ccols[i].GetValue(idx)
@@ -768,7 +768,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 				for i, col := range conditionCols {
 					if getter := conditionGetters[i]; getter != nil {
 						cdataset[i] = getter(idx, 0)
-					} else if cNeedsTxReader[i] {
+					} else if cNeedsCachedReader[i] {
 						cdataset[i] = cReaders[i].GetValue(idx)
 					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 						cdataset[i] = ccols[i].GetValue(idx)
@@ -856,7 +856,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	// condition column readers
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsTxReader := make([]bool, len(conditionCols))
+	cNeedsCachedReader := make([]bool, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
 		if k == "$recset_contains" {
@@ -872,8 +872,8 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-			cNeedsTxReader[i] = true
+		if _, ok := ccols[i].(*StorageComputeProxy); ok {
+			cNeedsCachedReader[i] = true
 		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
@@ -1109,7 +1109,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsTxReader := make([]bool, len(conditionCols))
+	cNeedsCachedReader := make([]bool, len(conditionCols))
 	conditionBatchSubidx := make([]int, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols {
@@ -1129,8 +1129,8 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-			cNeedsTxReader[i] = true
+		if _, ok := ccols[i].(*StorageComputeProxy); ok {
+			cNeedsCachedReader[i] = true
 		}
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
@@ -1218,7 +1218,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 							cdataset[i] = batchdata[batchid*stride+subidx]
 						} else if getter := conditionGetters[i]; getter != nil {
 							cdataset[i] = getter(effectiveIdx, uint32(batchid))
-						} else if cNeedsTxReader[i] {
+						} else if cNeedsCachedReader[i] {
 							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 						} else {
 							cdataset[i] = k.GetValue(effectiveIdx)
@@ -1230,7 +1230,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 							cdataset[i] = batchdata[batchid*stride+subidx]
 						} else if getter := conditionGetters[i]; getter != nil {
 							cdataset[i] = getter(effectiveIdx, uint32(batchid))
-						} else if cNeedsTxReader[i] {
+						} else if cNeedsCachedReader[i] {
 							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
 						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 							cdataset[i] = ccols[i].GetValue(effectiveIdx)

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -240,9 +240,12 @@ func ensureSystemStatistic() {
 // TODO: measurements are temporary; remove later (nanoseconds)
 func safeLogScan(schema, table string, ordered bool, filter, order, indexCols string, inputCount, candidateCount, outputCount, analyzeNs, execNs int64) {
 	defer func() { _ = recover() }()
-	// The telemetry sink must not observe itself: querying scan statistics would
-	// otherwise append more scan rows while that same relation is being read.
-	if schema == "system_statistic" && table == "scans" {
+	// The telemetry sink and its physical cache relations must not observe
+	// themselves. Group-cache reads are still reads of the scan sink; logging
+	// them would recursively schedule incremental writes while the cache shard is
+	// held for reading and would leave telemetry work in flight at shutdown.
+	if schema == "system_statistic" &&
+		(table == "scans" || strings.HasPrefix(table, ".")) {
 		return
 	}
 	db := GetDatabase("system_statistic")

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1134,7 +1134,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	// main storage — use skipShardReadLock to avoid redundant hasWriteOwner() per column
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsTxReader := make([]bool, len(conditionCols))
+	cNeedsCachedReader := make([]bool, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
 	for i, k := range conditionCols { // iterate over columns
 		if k == "$recset_contains" {
@@ -1150,8 +1150,8 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		}
 		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if proxy, ok := ccols[i].(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-			cNeedsTxReader[i] = true
+		if _, ok := ccols[i].(*StorageComputeProxy); ok {
+			cNeedsCachedReader[i] = true
 		}
 	}
 	// initialize main_count lazily if needed
@@ -1214,7 +1214,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					for i, k := range ccols { // iterate over columns
 						if conditionGetters[i] != nil {
 							cdataset[i] = conditionGetters[i](idx, 0)
-						} else if cNeedsTxReader[i] {
+						} else if cNeedsCachedReader[i] {
 							cdataset[i] = cReaders[i].GetValue(idx)
 						} else {
 							cdataset[i] = k.GetValue(idx)
@@ -1226,7 +1226,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					for i, k := range conditionCols { // iterate over columns
 						if conditionGetters[i] != nil {
 							cdataset[i] = conditionGetters[i](idx, 0)
-						} else if cNeedsTxReader[i] {
+						} else if cNeedsCachedReader[i] {
 							cdataset[i] = cReaders[i].GetValue(idx)
 						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
 							cdataset[i] = ccols[i].GetValue(idx)

--- a/storage/shared_resource.go
+++ b/storage/shared_resource.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2025  Carl-Philip Hänsch
+Copyright (C) 2025-2026  Carl-Philip Hänsch
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -26,10 +26,12 @@ const (
 	WRITE  SharedState = 2
 )
 
-// SharedResource marks a lazily loaded resource controllable by a process monitor.
-// In the current single-process implementation, these methods primarily coordinate
-// lazy load/unload. The returned release() functions are placeholders and can
-// evolve into reference counting once a multi-node monitor is added.
+// SharedResource is the access boundary for a lazily loaded local or clustered
+// resource. GetRead/GetExclusive must not be bypassed by callers that happen to
+// know today's in-process representation: a cluster implementation may satisfy a
+// read by loading a local SHARED copy or by routing work to a current shard owner.
+// The returned release function delimits that acquired capability and can evolve
+// from the current local lifetime tracking into a cluster reference release.
 type SharedResource interface {
 	GetState() SharedState
 	GetRead() func()      // acquire read access; returns release()

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -531,6 +531,7 @@ test_cases:
   - name: "Nested point selection schedules filters before maps"
     setup:
       - scm: '(sleep 0.5)'
+    timeout: 2
     sql: |
       SELECT `table`, SUM(candidateCount) AS candidates, SUM(outputCount) AS outputs
       FROM `system_statistic`.`scans`


### PR DESCRIPTION
## Summary

- bind normal computed-column input readers before entering a physical shard scan
- make all scan, ordered-scan, batch-scan, and RecSet condition paths use the bound reader for computed columns
- stop scan telemetry from observing its own hidden physical relations
- document `SharedResource.GetRead` and shard iteration as the future local/remote cluster acquisition boundary
- add a 2 s regression bound to the existing scan-statistics query

## Root cause

A scan over a canonical statistics group cache held the shard read lock. A missing `StorageComputeProxy` value called `ColumnReaderTx` again from inside that scan. If asynchronous scan telemetry had queued a writer, Go's writer-preferring `RWMutex` blocked the nested read while the outer read could not finish.

The fix keeps `GetRead`: it is the shared-resource and future cluster-routing boundary. Per-goroutine computed readers bind their input columns before the physical scan enters the shard, so pointwise on-demand materialization stays within the already acquired local capability. A future remote scan can construct the same reader on the owner node.

## Validation

- Test-first: unchanged master repeatedly timed out on `Nested point selection schedules filters before maps`; the existing test now has an explicit 2 s limit.
- Branch: `tests/execution/operators/range-scan-coverage.yaml` passed 85/85 three consecutive times, including shutdown/restart: 43.121 s, 42.730 s, 42.928 s.
- Adjacent suites passed:
  - compute proxy rebuild/repartition: 15/15
  - incremental invalidation/concurrency: 33/33
  - cold group-cache initialization: 16/16
  - transactions: 171/171
  - grouped window regression: 2/2
- Fresh rebuild concurrency A/B:
  - branch: 16/16, suite 1.470 s
  - master: timed out in concurrent UPDATE and stable prefix read
- `go vet ./storage/...` reports only pre-existing noCopy warnings in atomic container values.

A full shared-server `make test` was attempted both parallel and serial. It progressed through the planner, SQL, trigger, storage, and concurrency suites, but the long-lived server accumulated stale KILL/rebuild requests and table-lock waiters before `rebuild-concurrent.yaml`. That suite passes immediately on a fresh branch server and can hang on fresh master as noted above; this separate runner/server lifecycle issue is not hidden by this PR.
