### PR TITLE
Fix trigger DDL lock ordering

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2965,41 +2965,9 @@ func Init(en scm.Env) {
 			}
 
 			name := scm.String(a[1])
-			if scm.ToBool(a[2]) {
-				db.schemalock.RLock()
-				found := false
-				for _, t := range db.tables.GetAll() {
-					t.mu.Lock()
-					for _, tr := range t.Triggers {
-						if tr.Name == name {
-							found = true
-							break
-						}
-					}
-					t.mu.Unlock()
-					if found {
-						break
-					}
-				}
-				db.schemalock.RUnlock()
-				if !found {
-					return scm.NewBool(false)
-				}
+			if db.dropTrigger(name) {
+				return scm.NewBool(true)
 			}
-
-			db.schemalock.Lock()
-			tables := db.tables.GetAll()
-			for _, t := range tables {
-				t.ddlMu.Lock()
-				if t.RemoveTrigger(name) {
-					db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
-					t.ddlMu.Unlock()
-					return scm.NewBool(true)
-				}
-				t.ddlMu.Unlock()
-			}
-			db.schemalock.Unlock()
-
 			if scm.ToBool(a[2]) {
 				return scm.NewBool(false)
 			}

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -381,6 +381,33 @@ func (t *table) RemoveTrigger(name string) bool {
 	return false
 }
 
+// dropTrigger follows the same table-DDL-before-schema lock order as trigger
+// creation. Tables may disappear between the catalog snapshot and locking, so
+// each candidate is revalidated under schemalock before it is modified.
+func (db *database) dropTrigger(name string) bool {
+	db.schemalock.RLock()
+	tables := db.tables.GetAll()
+	db.schemalock.RUnlock()
+
+	for _, t := range tables {
+		t.ddlMu.Lock()
+		db.schemalock.Lock()
+		if db.tables.Get(t.Name) != t {
+			db.schemalock.Unlock()
+			t.ddlMu.Unlock()
+			continue
+		}
+		if t.RemoveTrigger(name) {
+			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+			t.ddlMu.Unlock()
+			return true
+		}
+		db.schemalock.Unlock()
+		t.ddlMu.Unlock()
+	}
+	return false
+}
+
 // SetTriggerTarget refreshes the runtime-only cache target pin on an
 // idempotently reused system trigger, including triggers restored from JSON.
 func (t *table) SetTriggerTarget(name string, acquire func() bool, release func()) bool {

--- a/storage/trigger_lock_order_test.go
+++ b/storage/trigger_lock_order_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (C) 2023-2026 Launix GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launix-de/NonLockingReadMap"
+)
+
+func TestDropTriggerDoesNotHoldSchemaLockWhileWaitingForTableDDL(t *testing.T) {
+	db := &database{Name: "trigger-lock-order", srState: COLD}
+	db.tables = NonLockingReadMap.New[table, string]()
+	table := &table{Name: "items", schema: db}
+	table.Triggers = []TriggerDescription{{Name: "items_after_drop"}}
+	db.tables.Set(table)
+
+	table.ddlMu.Lock()
+	dropped := make(chan bool, 1)
+	go func() { dropped <- db.dropTrigger("items_after_drop") }()
+
+	// Give dropTrigger time to take its catalog snapshot and wait on ddlMu.
+	time.Sleep(20 * time.Millisecond)
+	schemaAvailable := make(chan struct{}, 1)
+	go func() {
+		db.schemalock.Lock()
+		db.schemalock.Unlock()
+		schemaAvailable <- struct{}{}
+	}()
+
+	select {
+	case <-schemaAvailable:
+	case <-time.After(2 * time.Second):
+		table.ddlMu.Unlock()
+		t.Fatal("dropTrigger held schemalock while waiting for table ddlMu")
+	}
+
+	table.ddlMu.Unlock()
+	select {
+	case ok := <-dropped:
+		if !ok {
+			t.Fatal("trigger was not removed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("dropTrigger did not finish after ddlMu was released")
+	}
+}


### PR DESCRIPTION
## Summary
- make `DROP TRIGGER` follow the existing table-DDL-before-schema lock order used by trigger creation
- revalidate catalog membership after acquiring the table DDL mutex
- add a deterministic concurrency regression proving the schema lock stays available while trigger removal waits for table DDL

## Root cause
Parallel SQL suites could deadlock the shared server when lifecycle-trigger cascades overlapped. `DROP TRIGGER` held `database.schemalock` while waiting for `table.ddlMu`; trigger creation and other table DDL acquire those locks in the opposite order. The goroutine dump on current master showed the cycle at `storage.go:2993` and `database.go:1150`.

This is independent of RecSet/query execution and is a prerequisite for reliable full planner testing.

## Verification
- `go test ./storage -run TestDropTriggerDoesNotHoldSchemaLockWhileWaitingForTableDDL -count=100`
- two complete `make test` executions passed every functional suite and reached the end without the former DDL deadlock
- isolated non-coverage `order-limit.yaml`: 21/21

Both coverage-mode full runs had one unrelated hard timing-gate miss on current master's 200k-row `ORDER BY ... OFFSET 99999` test (5.50s and 5.36s vs 5.00s) under concurrent host load. The test and timeout were not changed; the isolated normal build completes the whole suite in 1.95s. CI remains the clean-runner gate.
