### PR TITLE
Fix SQL three-valued predicate semantics

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -110,7 +110,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 (define psql_comparison_expr (lambda (op a b)
 	(match op
 		"eq" '((quote equal??) a b)
-		"ne" '((quote not) '((quote equal?) a b))
+		"ne" '((quote sql_not) '((quote equal??) a b))
 		"le" '((quote <=) a b)
 		"ge" '((quote >=) a b)
 		"lt" '((quote <) a b)
@@ -207,23 +207,23 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(parser ">" "gt")
 		)) (define b psql_expression2)) (psql_comparison_expr op a b))
 		/* ILIKE is Postgres case-insensitive LIKE. */
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "ILIKE" true) (define b psql_expression2)) '('not '('strlike a b "utf8mb4_general_ci")))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "ILIKE" true) (define b psql_expression2)) '('sql_not '('strlike a b "utf8mb4_general_ci")))
 		(parser '((define a psql_expression3) (atom "ILIKE" true) (define b psql_expression2)) '('strlike a b "utf8mb4_general_ci"))
 		(parser '((define a psql_expression3) (atom "COLLATE" true) (define collation psql_identifier) (atom "LIKE" true) (define b psql_expression2)) '('strlike_cs a b collation))
 		/* Postgres LIKE is case-sensitive by default. */
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "LIKE" true) (define b psql_expression2)) '('not '('strlike_cs a b)))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "LIKE" true) (define b psql_expression2)) '('sql_not '('strlike_cs a b)))
 		(parser '((define a psql_expression3) (atom "LIKE" true) (define b psql_expression2)) '('strlike_cs a b))
 		/* REGEXP/RLIKE/~ operator: expr ~ 'pattern' -> regexp_test(expr, pattern) */
 		(parser '((define a psql_expression3) "~" (define b psql_expression2)) '('regexp_test a b))
 		(parser '((define a psql_expression3) (atom "REGEXP" true) (define b psql_expression2)) '('regexp_test a b))
 		(parser '((define a psql_expression3) (atom "RLIKE" true) (define b psql_expression2)) '('regexp_test a b))
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "REGEXP" true) (define b psql_expression2)) '('not '('regexp_test a b)))
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "RLIKE" true) (define b psql_expression2)) '('not '('regexp_test a b)))
-		(parser '((define a psql_expression3) (atom "IN" true) "(" (define b (+ psql_expression ",")) ")") '('contains? (cons list b) a))
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define b (+ psql_expression ",")) ")") '('not (contains? (cons list b) a)))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "REGEXP" true) (define b psql_expression2)) '('sql_not '('regexp_test a b)))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "RLIKE" true) (define b psql_expression2)) '('sql_not '('regexp_test a b)))
+		(parser '((define a psql_expression3) (atom "IN" true) "(" (define b (+ psql_expression ",")) ")") '('sql_in (cons list b) a))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define b (+ psql_expression ",")) ")") '('sql_not '('sql_in (cons list b) a)))
 		/* BETWEEN operator: expr BETWEEN low AND high -> a >= low AND a <= high */
 		(parser '((define a psql_expression3) (atom "BETWEEN" true) (define low psql_expression3) (atom "AND" true) (define high psql_expression3)) (list (quote and) (list (quote >=) a low) (list (quote <=) a high)))
-		(parser '((define a psql_expression3) (atom "NOT" true) (atom "BETWEEN" true) (define low psql_expression3) (atom "AND" true) (define high psql_expression3)) (list (quote not) (list (quote and) (list (quote >=) a low) (list (quote <=) a high))))
+		(parser '((define a psql_expression3) (atom "NOT" true) (atom "BETWEEN" true) (define low psql_expression3) (atom "AND" true) (define high psql_expression3)) (list (quote sql_not) (list (quote and) (list (quote >=) a low) (list (quote <=) a high))))
 		psql_expression3
 	)))
 
@@ -253,7 +253,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 
 	(define psql_expression5 (parser (or
 		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
-		(parser '((atom "NOT" true) (define expr psql_expression6)) '('not expr))
+		(parser '((atom "NOT" true) (define expr psql_expression6)) '('sql_not expr))
 		/* unary minus: -(expr) */
 		(parser '("-" (define expr psql_expression6)) '((quote -) 0 expr))
 		(parser '((define expr psql_expression6) (atom "IS" true) (atom "NULL" true)) '('nil? expr))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1784,10 +1784,11 @@ instead of capturing whichever session populated the cache first. */
 		(define domain_lookup_keys (correlation_lookup_keys lookup_pairs))
 		(define lookup_keys (cons probe domain_lookup_keys))
 		(define condition (combine_where_terms local_terms true))
-		(define stage_input (if (and (source_is_base_table? inner_src)
-			(and (empty_list? (qb_stages membership_inner))
-				(and (empty_list? (qb_order membership_inner))
-					(nil? (qb_limit membership_inner)))))
+		(define stage_input (if (and (equal? (count inner_sources) 1)
+			(and (source_is_base_table? inner_src)
+				(and (empty_list? (qb_stages membership_inner))
+					(and (empty_list? (qb_order membership_inner))
+						(nil? (qb_limit membership_inner))))))
 			inner_src
 			(make_query_block
 				(qb_schema membership_inner)

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -139,7 +139,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 (define sql_comparison_expr (lambda (op a b)
 	(match op
 		"eq" '((quote equal??) a b)
-		"ne" '((quote not) '((quote equal??) a b))
+		"ne" '((quote sql_not) '((quote equal??) a b))
 		"le" '((quote <=) a b)
 		"ge" '((quote >=) a b)
 		"lt" '((quote <) a b)
@@ -663,17 +663,17 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((define a sql_expression3) (atom "COLLATE" true) (define collation sql_identifier) (atom "LIKE" true) (define b sql_expression2)) '('strlike a b collation))
 		/* MySQL default collation is case-insensitive in this project (utf8mb4_general_ci). */
 		(parser '((define a sql_expression3) (atom "LIKE" true) (define b sql_expression2)) '('strlike a b "utf8mb4_general_ci"))
-		(parser '((define a sql_expression3) (atom "NOT" true) (atom "LIKE" true) (define b sql_expression2)) '('not '('strlike a b "utf8mb4_general_ci")))
+		(parser '((define a sql_expression3) (atom "NOT" true) (atom "LIKE" true) (define b sql_expression2)) '('sql_not '('strlike a b "utf8mb4_general_ci")))
 		/* REGEXP/RLIKE operator: expr REGEXP 'pattern' -> regexp_test(expr, pattern) */
 		(parser '((define a sql_expression3) (atom "REGEXP" true) (define b sql_expression2)) '('regexp_test a b))
 		(parser '((define a sql_expression3) (atom "RLIKE" true) (define b sql_expression2)) '('regexp_test a b))
-		(parser '((define a sql_expression3) (atom "NOT" true) (atom "REGEXP" true) (define b sql_expression2)) '('not '('regexp_test a b)))
-		(parser '((define a sql_expression3) (atom "NOT" true) (atom "RLIKE" true) (define b sql_expression2)) '('not '('regexp_test a b)))
-		(parser '((define a sql_expression3) (atom "IN" true) "(" (define b (+ sql_expression ",")) ")") '('contains? (cons list b) a))
-		(parser '((define a sql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define b (+ sql_expression ",")) ")") (list (quote not) (cons (quote contains?) (cons (cons (quote list) b) (list a)))))
+		(parser '((define a sql_expression3) (atom "NOT" true) (atom "REGEXP" true) (define b sql_expression2)) '('sql_not '('regexp_test a b)))
+		(parser '((define a sql_expression3) (atom "NOT" true) (atom "RLIKE" true) (define b sql_expression2)) '('sql_not '('regexp_test a b)))
+		(parser '((define a sql_expression3) (atom "IN" true) "(" (define b (+ sql_expression ",")) ")") '('sql_in (cons list b) a))
+		(parser '((define a sql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define b (+ sql_expression ",")) ")") (list (quote sql_not) (cons (quote sql_in) (cons (cons (quote list) b) (list a)))))
 		/* BETWEEN operator: expr BETWEEN low AND high -> a >= low AND a <= high */
 		(parser '((define a sql_expression3) (atom "BETWEEN" true) (define low sql_expression3) (atom "AND" true) (define high sql_expression3)) (list (quote and) (list (quote >=) a low) (list (quote <=) a high)))
-		(parser '((define a sql_expression3) (atom "NOT" true) (atom "BETWEEN" true) (define low sql_expression3) (atom "AND" true) (define high sql_expression3)) (list (quote not) (list (quote and) (list (quote >=) a low) (list (quote <=) a high))))
+		(parser '((define a sql_expression3) (atom "NOT" true) (atom "BETWEEN" true) (define low sql_expression3) (atom "AND" true) (define high sql_expression3)) (list (quote sql_not) (list (quote and) (list (quote >=) a low) (list (quote <=) a high))))
 		sql_expression3
 	)))
 
@@ -704,7 +704,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(define sql_expression5 (parser (or
 		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub sql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
 		/* NOT has lower precedence than IS NULL: NOT expr IS NULL == NOT (expr IS NULL) */
-		(parser '((atom "NOT" true) (define expr sql_expression5)) '('not expr))
+		(parser '((atom "NOT" true) (define expr sql_expression5)) '('sql_not expr))
 		/* unary minus: -(expr) */
 		(parser '("-" (define expr sql_expression6)) '((quote -) 0 expr))
 		(parser '((define expr sql_expression6) (atom "IS" true) (atom "NULL" true)) '('nil? expr))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -98,10 +98,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal?? false (count '(1))) false "equal?? bool cross-type falsy")
 	(assert (equal?? '() false) true "equal?? empty list vs false")
 	(assert (equal?? + (count '(1))) false "equal?? func vs non-func")
-	/* Less cross-type coverage (compare.go:Less) */
-	(assert (< nil nil) false "less nil nil")
-	(assert (< nil 5) true "less nil vs value")
-	(assert (< 5 nil) false "less value vs nil")
+	/* Public comparisons preserve SQL UNKNOWN. Internal storage ordering calls
+	Less directly and retains a total order including nil. */
+	(assert (nil? (< nil nil)) true "less nil nil is unknown")
+	(assert (nil? (< nil 5)) true "less nil vs value is unknown")
+	(assert (nil? (< 5 nil)) true "less value vs nil is unknown")
 	(assert (< 1.5 2.5) true "less float vs float")
 	(assert (< 2.5 1.5) false "less float vs float reverse")
 	(assert (< "apple" "banana") true "less string vs string")

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -366,8 +366,11 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "<=",
-		Desc: "compares two numbers or strings",
+		Desc: "compares two numbers or strings; returns nil if either value is nil",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			return NewBool(!Less(a[1], a[0]))
 		},
 		Type: &TypeDescriptor{
@@ -381,8 +384,11 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "<",
-		Desc: "compares two numbers or strings",
+		Desc: "compares two numbers or strings; returns nil if either value is nil",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			return NewBool(Less(a[0], a[1]))
 		},
 		Type: &TypeDescriptor{
@@ -396,8 +402,11 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: ">",
-		Desc: "compares two numbers or strings",
+		Desc: "compares two numbers or strings; returns nil if either value is nil",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			return NewBool(Less(a[1], a[0]))
 		},
 		Type: &TypeDescriptor{
@@ -411,8 +420,11 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: ">=",
-		Desc: "compares two numbers or strings",
+		Desc: "compares two numbers or strings; returns nil if either value is nil",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			return NewBool(!Less(a[0], a[1]))
 		},
 		Type: &TypeDescriptor{
@@ -450,6 +462,21 @@ func init_alu() {
 				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
 				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
 			},
+			Return: &TypeDescriptor{Kind: "bool"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_not",
+		Desc: "negates a SQL predicate while preserving nil as UNKNOWN",
+		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() {
+				return NewNil()
+			}
+			return NewBool(!a[0].Bool())
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{{Kind: "any", ParamName: "value", ParamDesc: "SQL predicate value"}},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 		},

--- a/scm/list.go
+++ b/scm/list.go
@@ -1575,6 +1575,34 @@ func init_list() {
 			Const:  true,
 		},
 	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sql_in",
+		Desc: "tests SQL IN-list membership and returns nil when NULL makes the result UNKNOWN",
+		Fn: func(a ...Scmer) Scmer {
+			values := asSlice(a[0], "sql_in")
+			if a[1].IsNil() {
+				return NewNil()
+			}
+			unknown := false
+			for _, value := range values {
+				equal := EqualSQL(value, a[1])
+				if equal.IsNil() {
+					unknown = true
+				} else if equal.Bool() {
+					return NewBool(true)
+				}
+			}
+			if unknown {
+				return NewNil()
+			}
+			return NewBool(false)
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{{Kind: "list", ParamName: "values", ParamDesc: "SQL IN-list values", NoEscape: true}, {Kind: "any", ParamName: "value", ParamDesc: "value to find"}},
+			Return: &TypeDescriptor{Kind: "bool"},
+			Const:  true,
+		},
+	})
 
 	// dictionary functions
 	DeclareTitle("Associative Lists / Dictionaries")

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2013,62 +2013,99 @@ func optimizeIf(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDe
 	return NewSlice(out), nil
 }
 
-// optimizeAnd is the Optimize hook for the (and ...) special form.
-// It short-circuits on constant-false and removes constant-true arguments.
-func appendFlattenedAndArgs(out []Scmer, arg Scmer) ([]Scmer, bool) {
+// optimizeAnd is the Optimize hook for the lazy (and ...) special form.
+// Nil is SQL UNKNOWN, so it cannot short-circuit: a later false still wins.
+func appendFlattenedLazyArgs(out []Scmer, arg Scmer, operator string) ([]Scmer, bool) {
 	inner, ok := scmerSlice(arg)
-	if !ok || len(inner) <= 1 || !scmerIsSymbol(inner[0], "and") {
+	if !ok || len(inner) <= 1 || !scmerIsSymbol(inner[0], operator) {
 		return append(out, arg), false
 	}
 	changed := true
 	for i := 1; i < len(inner); i++ {
 		var nested bool
-		out, nested = appendFlattenedAndArgs(out, inner[i])
+		out, nested = appendFlattenedLazyArgs(out, inner[i], operator)
 		changed = changed || nested
 	}
 	return out, changed
 }
 
 func optimizeAnd(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
-	// Optimize all args
+	// Optimize left-to-right. Do not touch operands after a known false: doing
+	// so would violate the special form's lazy evaluation contract. Flatten
+	// each optimized result so child rewrites cannot reintroduce nested ANDs.
+	out := make([]Scmer, 1, len(v))
+	out[0] = v[0]
+	var onlyType *TypeDescriptor
 	for i := 1; i < len(v); i++ {
-		v[i], _ = oc.OptimizeSub(v[i], true)
-	}
-	// Flatten nested AND calls so downstream pattern matchers can inspect one
-	// top-level list of conjunctive terms.
-	flattened := make([]Scmer, 0, len(v))
-	flattened = append(flattened, v[0])
-	changed := false
-	for i := 1; i < len(v); i++ {
-		var argChanged bool
-		flattened, argChanged = appendFlattenedAndArgs(flattened, v[i])
-		changed = changed || argChanged
-	}
-	if changed {
-		v = flattened
-	}
-	// Single arg: unwrap
-	if len(v) == 2 {
-		return oc.OptimizeSub(v[1], useResult)
-	}
-	// Short-circuit: remove constant-true, early-exit on constant-false
-	for i := 1; i < len(v); i++ {
-		switch v[i].GetTag() {
-		case tagNil, tagBool, tagInt, tagFloat, tagString:
-			if !ToBool(v[i]) {
-				return NewBool(false), &TypeDescriptor{Transfer: true, Const: true}
+		arg, td := oc.OptimizeSub(v[i], true)
+		flattened, _ := appendFlattenedLazyArgs(nil, arg, "and")
+		before := len(out)
+		for _, item := range flattened {
+			switch item.GetTag() {
+			case tagBool, tagInt, tagFloat, tagString:
+				if ToBool(item) {
+					continue
+				}
+				if len(out) == 1 {
+					return NewBool(false), &TypeDescriptor{Transfer: true, Const: true}
+				}
+				return NewSlice(append(out, NewBool(false))), nil
+			default:
+				out = append(out, item)
 			}
-			v = append(v[:i], v[i+1:]...)
-			i--
+		}
+		if len(out) == before+1 && len(flattened) == 1 {
+			onlyType = td
+		} else if len(out) > before {
+			onlyType = nil
 		}
 	}
-	if len(v) == 1 {
+	if len(out) == 1 {
 		return NewBool(true), &TypeDescriptor{Transfer: true, Const: true}
 	}
-	if len(v) == 2 {
-		return oc.OptimizeSub(v[1], useResult)
+	if len(out) == 2 {
+		return out[1], onlyType
 	}
-	return NewSlice(v), nil
+	return NewSlice(out), nil
+}
+
+// optimizeOr mirrors the lazy SQL three-valued OR evaluator. Nil must remain
+// until runtime because a later true wins over UNKNOWN.
+func optimizeOr(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	out := make([]Scmer, 1, len(v))
+	out[0] = v[0]
+	var onlyType *TypeDescriptor
+	for i := 1; i < len(v); i++ {
+		arg, td := oc.OptimizeSub(v[i], true)
+		flattened, _ := appendFlattenedLazyArgs(nil, arg, "or")
+		before := len(out)
+		for _, item := range flattened {
+			switch item.GetTag() {
+			case tagBool, tagInt, tagFloat, tagString:
+				if !ToBool(item) {
+					continue
+				}
+				if len(out) == 1 {
+					return NewBool(true), &TypeDescriptor{Transfer: true, Const: true}
+				}
+				return NewSlice(append(out, NewBool(true))), nil
+			default:
+				out = append(out, item)
+			}
+		}
+		if len(out) == before+1 && len(flattened) == 1 {
+			onlyType = td
+		} else if len(out) > before {
+			onlyType = nil
+		}
+	}
+	if len(out) == 1 {
+		return NewBool(false), &TypeDescriptor{Transfer: true, Const: true}
+	}
+	if len(out) == 2 {
+		return out[1], onlyType
+	}
+	return NewSlice(out), nil
 }
 
 // optimizeAssociative is the Optimize hook for associative operators (+ and *).

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -195,17 +195,35 @@ restart:
 				}
 				return NewNil()
 			case "and":
+				unknown := false
 				for idx, x := range list {
-					if idx > 0 && !Eval(x, en).Bool() {
-						return NewBool(false)
+					if idx > 0 {
+						value := Eval(x, en)
+						if value.IsNil() {
+							unknown = true
+						} else if !value.Bool() {
+							return NewBool(false)
+						}
 					}
+				}
+				if unknown {
+					return NewNil()
 				}
 				return NewBool(true)
 			case "or":
+				unknown := false
 				for idx, x := range list {
-					if idx > 0 && Eval(x, en).Bool() {
-						return NewBool(true)
+					if idx > 0 {
+						value := Eval(x, en)
+						if value.IsNil() {
+							unknown = true
+						} else if value.Bool() {
+							return NewBool(true)
+						}
 					}
+				}
+				if unknown {
+					return NewNil()
 				}
 				return NewBool(false)
 			case "coalesce":
@@ -971,7 +989,7 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "and",
-		Desc: "returns true if all conditions evaluate to true",
+		Desc: "lazily combines conditions using SQL three-valued logic; returns false on the first false value, nil for UNKNOWN, otherwise true",
 		Fn:   nil,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
@@ -984,14 +1002,15 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "or",
-		Desc: "returns true if at least one condition evaluates to true",
+		Desc: "lazily combines conditions using SQL three-valued logic; returns true on the first true value, nil for UNKNOWN, otherwise false",
 		Fn:   nil,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
 				{Kind: "any", ParamName: "condition", ParamDesc: "condition to evaluate", Variadic: true},
 			},
-			Return: &TypeDescriptor{Kind: "bool"},
-			Const:  true,
+			Return:   &TypeDescriptor{Kind: "bool"},
+			Const:    true,
+			Optimize: optimizeOr,
 		},
 	})
 	Declare(&Globalenv, &Declaration{

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -256,8 +256,11 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strlike",
-		Desc: "matches the string against a wildcard pattern (SQL compliant)",
+		Desc: "matches the string against a wildcard pattern using SQL NULL semantics",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			value := String(a[0])
 			pattern := String(a[1])
 			collation := "utf8mb4_general_ci"
@@ -278,8 +281,11 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strlike_cs",
-		Desc: "matches the string against a wildcard pattern (case-sensitive)",
+		Desc: "matches the string against a wildcard pattern case-sensitively using SQL NULL semantics",
 		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
 			return NewBool(StrLike(String(a[0]), String(a[1])))
 		},
 		Type: &TypeDescriptor{

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1082,9 +1082,9 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	result.sortdirs = make([]func(...scm.Scmer) scm.Scmer, len(sortcols))
 	for i := range sortcols {
 		if i < len(sortdirs) && sortdirs[i] != nil {
-			result.sortdirs[i] = sortdirs[i]
+			result.sortdirs[i] = wrapScanOrderComparator(sortdirs[i])
 		} else {
-			result.sortdirs[i] = defaultSortDir
+			result.sortdirs[i] = wrapScanOrderComparator(defaultSortDir)
 		}
 	}
 

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -180,7 +180,7 @@ func scanExprSafeToHoist(expr scm.Scmer, belowOuter bool) bool {
 		return false
 	}
 	switch name {
-	case "session", "equal?", "equal??", "nil?", "not", "and", "or", "coalesceNil", "bool?", "int?", "float?", "string?", "<", "<=", ">", ">=":
+	case "session", "equal?", "equal??", "nil?", "not", "sql_not", "and", "or", "coalesceNil", "bool?", "int?", "float?", "string?", "<", "<=", ">", ">=":
 	default:
 		return false
 	}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -26,6 +26,41 @@ import "runtime/debug"
 import "container/heap"
 import "github.com/launix-de/memcp/scm"
 
+// wrapScanOrderComparator adds SQL NULL positioning around the comparator
+// supplied to scan_order. The comparator itself only sees non-NULL values:
+// ascending order puts NULL first, descending order puts NULL last.
+func wrapScanOrderComparator(compare func(...scm.Scmer) scm.Scmer) func(...scm.Scmer) scm.Scmer {
+	descending := false
+	if decl := scm.DeclarationForValue(scm.NewFunc(compare)); decl != nil && (decl.Name == "<" || decl.Name == ">") {
+		descending = decl.Name == ">"
+	} else if _, reverse, ok := scm.LookupCollate(compare); ok {
+		descending = reverse
+	} else {
+		// User callbacks can be type-specific. Direction probing must not make a
+		// valid string/date comparator fail before it sees actual input values.
+		func() {
+			defer func() { _ = recover() }()
+			ascendingProbe := scm.ToBool(compare(scm.NewInt(1), scm.NewInt(2)))
+			descendingProbe := scm.ToBool(compare(scm.NewInt(2), scm.NewInt(1)))
+			descending = !ascendingProbe && descendingProbe
+		}()
+	}
+	return func(args ...scm.Scmer) scm.Scmer {
+		if len(args) < 2 {
+			return scm.NewBool(false)
+		}
+		leftNil := args[0].IsNil()
+		rightNil := args[1].IsNil()
+		if leftNil || rightNil {
+			if leftNil && rightNil {
+				return scm.NewBool(false)
+			}
+			return scm.NewBool(leftNil != descending)
+		}
+		return compare(args...)
+	}
+}
+
 func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	// scan_order_multi args: 0=fn, 1=tx, 2=tables, 3=filterCols, 4=filterFns,
 	// 5=sortcols, 6=sortdirs, 7=perTableOffset, 8=perTableLimit,
@@ -1122,6 +1157,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		cmpScm := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString(coll), scm.NewBool(reverse))
 		cmpFn := scm.OptimizeProcToSerialFunction(cmpScm)
 		adjustedSortdirs[i] = cmpFn
+	}
+	for i := range adjustedSortdirs {
+		adjustedSortdirs[i] = wrapScanOrderComparator(adjustedSortdirs[i])
 	}
 
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)

--- a/tests/planner/order-window/order-by-complex.yaml
+++ b/tests/planner/order-window/order-by-complex.yaml
@@ -61,11 +61,60 @@ test_cases:
     sql: "SELECT id, name FROM obc_data ORDER BY name ASC LIMIT 10"
     expect:
       rows: 10
+      data:
+        - id: 9
+          name: null
+        - id: 1
+          name: "alice"
+        - id: 2
+          name: "bob"
+        - id: 3
+          name: "carol"
+        - id: 4
+          name: "dave"
+        - id: 5
+          name: "eve"
+        - id: 6
+          name: "frank"
+        - id: 7
+          name: "grace"
+        - id: 8
+          name: "henry"
+        - id: 10
+          name: "ivy"
 
   - name: "ORDER BY with NULLs (DESC puts NULL last)"
     sql: "SELECT id, name FROM obc_data ORDER BY name DESC LIMIT 10"
     expect:
       rows: 10
+      data:
+        - id: 10
+          name: "ivy"
+        - id: 8
+          name: "henry"
+        - id: 7
+          name: "grace"
+        - id: 6
+          name: "frank"
+        - id: 5
+          name: "eve"
+        - id: 4
+          name: "dave"
+        - id: 3
+          name: "carol"
+        - id: 2
+          name: "bob"
+        - id: 1
+          name: "alice"
+        - id: 9
+          name: null
+
+  - name: "ORDER BY NULL positioning is applied before LIMIT"
+    sql: "SELECT id FROM obc_data ORDER BY name ASC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - id: 9
 
   # === LIMIT / OFFSET ===
 

--- a/tests/planner/subqueries/in-subselect-multitable.yaml
+++ b/tests/planner/subqueries/in-subselect-multitable.yaml
@@ -10,16 +10,17 @@ setup:
   - sql: "CREATE TABLE insub_author (id INT, name VARCHAR(100))"
   - sql: "CREATE TABLE insub_post (id INT, author_id INT, title VARCHAR(200))"
   - sql: "INSERT INTO insub_author (id, name) VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Carol')"
-  - sql: "INSERT INTO insub_post (id, author_id, title) VALUES (1, 1, 'Hello'), (2, 1, 'World'), (3, 2, 'Foo')"
+  - sql: "INSERT INTO insub_post (id, author_id, title) VALUES (1, 1, 'Hello'), (2, 1, 'World'), (3, 2, 'Foo'), (4, 3, 'Excluded')"
 
 test_cases:
   - name: "IN subselect single table (baseline)"
     sql: "SELECT name FROM insub_author WHERE id IN (SELECT author_id FROM insub_post)"
     expect:
-      rows: 2
+      rows: 3
       data:
         - name: Alice
         - name: Bob
+        - name: Carol
 
   - name: "IN subselect multi-table inner join"
     sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id WHERE a.name <> 'Carol')"
@@ -32,22 +33,22 @@ test_cases:
   - name: "IN subselect multi-table LEFT JOIN"
     sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p LEFT JOIN insub_author a ON p.author_id = a.id)"
     expect:
-      rows: 2
+      rows: 3
       data:
         - name: Alice
         - name: Bob
+        - name: Carol
 
   - name: "IN subselect multi-table join no match"
-    sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id WHERE a.name = 'Carol')"
+    sql: "SELECT name FROM insub_author WHERE id IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id WHERE a.name = 'Missing')"
     expect:
       rows: 0
 
   - name: "NOT IN subselect multi-table join"
     sql: "SELECT name FROM insub_author WHERE id NOT IN (SELECT p.author_id FROM insub_post p JOIN insub_author a ON p.author_id = a.id)"
     expect:
-      rows: 1
-      data:
-        - name: Carol
+      rows: 0
+      data: []
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS insub_post"

--- a/tests/sql/expressions/nulls.yaml
+++ b/tests/sql/expressions/nulls.yaml
@@ -153,5 +153,126 @@ test_cases:
     expect:
       rows: 2
 
+  # SQL predicates use three-valued logic. UNKNOWN must remain NULL while a
+  # predicate is composed or projected; only the final WHERE boundary drops it.
+  - name: "NOT preserves UNKNOWN"
+    sql: "SELECT NOT NULL AS value"
+    expect:
+      rows: 1
+      data:
+        - value: null
+
+  - name: "AND follows SQL three-valued logic"
+    sql: "SELECT NULL AND 0 AS false_value, NULL AND 1 AS unknown_value"
+    expect:
+      rows: 1
+      data:
+        - false_value: false
+          unknown_value: null
+
+  - name: "OR follows SQL three-valued logic"
+    sql: "SELECT NULL OR 1 AS true_value, NULL OR 0 AS unknown_value"
+    expect:
+      rows: 1
+      data:
+        - true_value: true
+          unknown_value: null
+
+  - name: "AND does not evaluate an unreachable operand"
+    sql: "SELECT 0 AND ('value' REGEXP '[') AS value"
+    expect:
+      rows: 1
+      data:
+        - value: false
+
+  - name: "OR does not evaluate an unreachable operand"
+    sql: "SELECT 1 OR ('value' REGEXP '[') AS value"
+    expect:
+      rows: 1
+      data:
+        - value: true
+
+  - name: "Nested AND keeps lazy evaluation after optimization"
+    sql: "SELECT 1 AND (0 AND ('value' REGEXP '[')) AS value"
+    expect:
+      rows: 1
+      data:
+        - value: false
+
+  - name: "Nested OR keeps lazy evaluation after optimization"
+    sql: "SELECT 0 OR (1 OR ('value' REGEXP '[')) AS value"
+    expect:
+      rows: 1
+      data:
+        - value: true
+
+  - name: "Nested AND terminal stops the outer optimizer"
+    sql: "SELECT id FROM null_test WHERE id = 1 AND (id = 1 AND 0) AND ('value' REGEXP '[')"
+    expect:
+      rows: 0
+
+  - name: "Nested OR terminal stops the outer optimizer"
+    sql: "SELECT id FROM null_test WHERE id = 99 OR (id = 1 OR 1) OR ('value' REGEXP '[') ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - id: 1
+        - id: 2
+        - id: 3
+
+  - name: "AND evaluates operands before a later false"
+    sql: "SELECT ('value' REGEXP '[') AND 0 AS value"
+    expect:
+      error: true
+
+  - name: "OR evaluates operands before a later true"
+    sql: "SELECT ('value' REGEXP '[') OR 1 AS value"
+    expect:
+      error: true
+
+  - name: "Comparisons preserve UNKNOWN"
+    sql: "SELECT NULL <> 0 AS ne_value, NULL < 0 AS lt_value, NULL >= 0 AS ge_value"
+    expect:
+      rows: 1
+      data:
+        - ne_value: null
+          lt_value: null
+          ge_value: null
+
+  - name: "Pattern and range predicates preserve UNKNOWN"
+    sql: "SELECT NULL LIKE '%' AS like_value, NULL BETWEEN 0 AND 1 AS between_value"
+    expect:
+      rows: 1
+      data:
+        - like_value: null
+          between_value: null
+
+  - name: "IN list preserves UNKNOWN"
+    sql: "SELECT NULL IN (0, 1) AS null_lhs, 0 IN (NULL, 1) AS null_rhs, 0 NOT IN (NULL, 1) AS negated"
+    expect:
+      rows: 1
+      data:
+        - null_lhs: null
+          null_rhs: null
+          negated: null
+
+  - name: "UNKNOWN cannot become an authorization grant through NOT"
+    sql: "SELECT id FROM null_test WHERE NOT (name = 'blocked') ORDER BY id"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+
+  - name: "Scalar subquery COALESCE distinguishes zero from no row"
+    sql: |
+      SELECT
+        COALESCE((SELECT 0 FROM null_test WHERE id = 1), 9) AS zero_value,
+        COALESCE((SELECT 0 FROM null_test WHERE id = 99), 9) AS empty_value
+    expect:
+      rows: 1
+      data:
+        - zero_value: 0
+          empty_value: 9
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS null_test"


### PR DESCRIPTION
## Summary

- implement SQL three-valued semantics for lazy `AND`/`OR`, `NOT`, comparisons, `LIKE`, `BETWEEN`, and literal `IN`
- keep generic Scheme `not` unchanged and route SQL negation through `sql_not`
- wrap physical ordered-scan comparators so NULL positioning remains an ordering concern rather than part of the public comparison collation
- prevent the single-source `IN` rewrite from discarding additional inner join sources

## Optimizer review

The lazy boolean optimizer needed two corrections discovered while extending the SQL regression suite:

- flatten nested same-operator expressions after optimizing their children, because child rewrites can create new nested `and`/`or` forms
- propagate nested terminal `false`/`true` values to the outer pass without optimizing unreachable operands, preserving left-to-right lazy evaluation and error behavior

When neutral constants leave one operand, its original type and ownership descriptor is retained. The rewrite preserves operand order and does not distribute or reorder predicates.

## A/B behavior

| Query shape | master | this PR |
| --- | --- | --- |
| `NOT NULL` | `true` | `NULL` |
| `NULL <> 0` | `true` | `NULL` |
| `NULL AND false` / `NULL OR true` | boolean coercion | `false` / `true` |
| nullable predicate behind `NOT` in `WHERE` | NULL row can be admitted | UNKNOWN is filtered |
| multi-table `IN` with an excluding joined row | joined filter can be discarded | joined filter is retained |

The ordered `ORDER BY ... LIMIT` performance suite passed in 2.372 s under its 5 s gate during the full pre-commit run.

## Validation

- full hook-equivalent test run: all critical suites passed
- SQL NULL regression suite: 37/37
- multi-table `IN` regression suite: 5/5
- complex ordering regression suite: 16/16
- derived scalar/limit regression suite: 38/38
- Scheme formatter and diff whitespace checks passed

Known `noncritical` decorrelation TODOs from current master remain unchanged.
