### PR TITLE
Preserve column case metadata in derived rewrites

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3314,11 +3314,11 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 
 (define rewrite_derived_ref (lambda (alias projection expr)
 	(match expr
-		((symbol get_column) tblvar ignorecase col _json_path) (if (or (equal? tblvar alias) (nil? tblvar))
-			(coalesceNil (field_expr_by_title projection col ignorecase) expr)
+		((symbol get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias) (nil? tblvar))
+			(coalesceNil (field_expr_by_title projection col col_ignorecase) expr)
 			expr)
-		((quote get_column) tblvar ignorecase col _json_path) (if (or (equal? tblvar alias) (nil? tblvar))
-			(coalesceNil (field_expr_by_title projection col ignorecase) expr)
+		((quote get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias) (nil? tblvar))
+			(coalesceNil (field_expr_by_title projection col col_ignorecase) expr)
 			expr)
 		(cons head tail) (cons head (map tail (lambda (item) (rewrite_derived_ref alias projection item))))
 		_ expr)))
@@ -3338,10 +3338,10 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 
 (define rewrite_order_output_alias (lambda (fields expr)
 	(match expr
-		((symbol get_column) nil ignorecase col _json_path)
-		(coalesceNil (field_expr_by_title fields col ignorecase) expr)
-		((quote get_column) nil ignorecase col _json_path)
-		(coalesceNil (field_expr_by_title fields col ignorecase) expr)
+		((symbol get_column) nil _tbl_ignorecase col col_ignorecase)
+		(coalesceNil (field_expr_by_title fields col col_ignorecase) expr)
+		((quote get_column) nil _tbl_ignorecase col col_ignorecase)
+		(coalesceNil (field_expr_by_title fields col col_ignorecase) expr)
 		_ expr)))
 
 (define rewrite_order_output_aliases (lambda (fields order_items)

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -94,10 +94,10 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 
 (define sql_column (parser (or
 	(parser '((define tbl sql_identifier_unquoted) "." (define col sql_identifier_unquoted)) '((quote get_column) tbl true col true))
-	(parser '((define tbl sql_identifier_unquoted) "." (define col sql_identifier_quoted)) '((quote get_column) tbl true col false))
+	(parser '((define tbl sql_identifier_unquoted) "." (define col sql_identifier_quoted)) '((quote get_column) tbl true col true))
 	(parser '((define tbl sql_identifier_quoted) "." (define col sql_identifier_unquoted)) '((quote get_column) tbl false col true))
-	(parser '((define tbl sql_identifier_quoted) "." (define col sql_identifier_quoted)) '((quote get_column) tbl false col false))
-	(parser (define col sql_identifier_quoted) '((quote get_column) nil true col false))
+	(parser '((define tbl sql_identifier_quoted) "." (define col sql_identifier_quoted)) '((quote get_column) tbl false col true))
+	(parser (define col sql_identifier_quoted) '((quote get_column) nil true col true))
 	(parser (define col sql_identifier_unquoted) '((quote get_column) nil true col true))
 )))
 
@@ -823,7 +823,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* MySQL IF(condition, true_expr, false_expr) with short-circuit semantics */
 		(parser '((atom "IF" true) "(" (define cond sql_expression) "," (define t sql_expression) "," (define f sql_expression) ")") '((quote if) cond t f))
 		(parser '((atom "VALUES" true) "(" (define e sql_identifier_unquoted) ")") '('get_column "VALUES" true e true)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
-		(parser '((atom "VALUES" true) "(" (define e sql_identifier_quoted) ")") '('get_column "VALUES" true e false)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
+		(parser '((atom "VALUES" true) "(" (define e sql_identifier_quoted) ")") '('get_column "VALUES" true e true)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
 		(parser '((atom "pg_catalog" true) "." (atom "set_config" true) "(" sql_expression "," sql_expression "," sql_expression ")") nil) /* ignore */
 		(parser '((atom "pg_catalog" true) "." (atom "setval" true) "(" "'" sql_identifier "." (define key sql_identifier) "'" "," (define val sql_expression) "," sql_expression ")") (match key (regex "(.*)_(.*?)_seq" _ tbl col) '('altercolumn '('table schema tbl) col "auto_increment" val) (error "unknown pg_catalog key: " key)))
 

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -27,12 +27,16 @@ setup:
   - sql: "DROP TABLE IF EXISTS ord_member_doc"
   - sql: "DROP TABLE IF EXISTS ord_member_file"
   - sql: "DROP TABLE IF EXISTS ord_member_label"
+  - sql: "DROP TABLE IF EXISTS ord_derived_item"
+  - sql: "DROP TABLE IF EXISTS ord_derived_parent"
   - sql: "CREATE TABLE ord_t (a INT, b INT)"
   - sql: "CREATE TABLE ord_join_left (id INT PRIMARY KEY, ref_id INT)"
   - sql: "CREATE TABLE ord_join_right (id INT PRIMARY KEY, rank_value INT)"
   - sql: "CREATE TABLE ord_member_doc (id INT PRIMARY KEY, file_id INT, label_id INT, rank_value INT)"
   - sql: "CREATE TABLE ord_member_file (id INT PRIMARY KEY, filename TEXT)"
   - sql: "CREATE TABLE ord_member_label (id INT PRIMARY KEY, name TEXT, visible INT)"
+  - sql: "CREATE TABLE ord_derived_parent (id INT PRIMARY KEY, label TEXT)"
+  - sql: "CREATE TABLE ord_derived_item (id INT PRIMARY KEY, parent_id INT, created INT)"
   - sql: |
       INSERT INTO ord_t (a,b) VALUES
       (1,2),(1,1),(2,2),(2,0),(3,1)
@@ -41,6 +45,8 @@ setup:
   - sql: "INSERT INTO ord_member_doc VALUES (1,1,10,40),(2,2,20,30),(3,3,10,20),(4,4,30,10)"
   - sql: "INSERT INTO ord_member_file VALUES (1,'other'),(2,'needle one'),(3,'needle two'),(4,'other')"
   - sql: "INSERT INTO ord_member_label VALUES (10,'alpha',1),(20,'beta',0)"
+  - sql: "INSERT INTO ord_derived_parent VALUES (1,'one'),(2,'two')"
+  - sql: "INSERT INTO ord_derived_item VALUES (10,1,100),(20,2,200)"
 
 test_cases:
   - name: "Top-1 by a DESC"
@@ -387,6 +393,49 @@ test_cases:
         - "(sort (var 0)"
         - "(slice (var 0)"
 
+  - name: "Quoted derived aliases resolve case-insensitively across joined order keys"
+    sql: |
+      SELECT d.*
+      FROM (
+        SELECT i.id AS `ID`, i.created AS `Created`, i.parent_id,
+          p.id AS `parent:ID`, p.label AS `parent:label`
+        FROM ord_derived_item i
+        LEFT JOIN (
+          SELECT id AS `parent:ID`, label AS `parent:label`
+          FROM ord_derived_parent
+        ) p ON p.`parent:ID` = i.parent_id
+      ) d
+      LEFT JOIN ord_derived_parent sorter ON sorter.id = d.parent_id
+      ORDER BY `d`.`Created` DESC, `d`.`id` DESC
+    expect:
+      rows: 2
+      data:
+        - { ID: 20, Created: 200, parent_id: 2, "parent:ID": 2, "parent:label": "two" }
+        - { ID: 10, Created: 100, parent_id: 1, "parent:ID": 1, "parent:label": "one" }
+
+  - name: "Joined derived alias order remains a physical ordered scan"
+    sql: |
+      EXPLAIN SELECT d.*
+      FROM (
+        SELECT i.id AS `ID`, i.created AS `Created`, i.parent_id,
+          p.id AS `parent:ID`, p.label AS `parent:label`
+        FROM ord_derived_item i
+        LEFT JOIN (
+          SELECT id AS `parent:ID`, label AS `parent:label`
+          FROM ord_derived_parent
+        ) p ON p.`parent:ID` = i.parent_id
+      ) d
+      LEFT JOIN ord_derived_parent sorter ON sorter.id = d.parent_id
+      ORDER BY `d`.`Created` DESC, `d`.`id` DESC
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "(lambda (rows)"
+        - "(sort (var 0)"
+        - "(slice (var 0)"
+
   - name: "ORDER BY DESC OFFSET beyond rows returns empty"
     sql: "SELECT a FROM ord_t ORDER BY a DESC LIMIT 2 OFFSET 10"
     expect:
@@ -494,3 +543,5 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS ord_member_doc"
   - sql: "DROP TABLE IF EXISTS ord_member_file"
   - sql: "DROP TABLE IF EXISTS ord_member_label"
+  - sql: "DROP TABLE IF EXISTS ord_derived_item"
+  - sql: "DROP TABLE IF EXISTS ord_derived_parent"


### PR DESCRIPTION
## Summary

- preserve MySQL column case-resolution metadata while flattening derived tables
- resolve quoted MySQL column references case-insensitively without changing PostgreSQL quoted identifiers
- keep joined derived-table ordering on the physical `scan_order` path

## Root cause

`get_column` carries independent case-resolution flags for its table qualifier and column name. The derived-reference and output-alias rewrites consumed the table flag when matching projected column titles. A quoted derived reference whose spelling differed from its projected alias therefore survived derived-table flattening and reached physical lowering with a relation alias that no longer existed.

## Test-first evidence

- Master: the two added regression cases failed with `build_queryplan: ORDER BY requires a storage carrier`.
- Branch: `tests/planner/order-window/order-limit.yaml` passes 34/34.
- The EXPLAIN regression requires `scan_order` and rejects Scheme row collectors, sort, and slice fallbacks.

## Validation

- Derived/subselect aliases: 43/43 passed.
- Scalar prejoin aliases: 5/5 passed.
- PostgreSQL parser compatibility: 56/56 passed; quoted PostgreSQL identifiers remain case-sensitive.
- MySQL upsert compatibility: 25/25 passed.
- Colon-qualified LEFT JOIN aliases: 4/4 passed.
- Transactions on a fresh instance: 171/171 passed.
- Scheme startup tests: 905/905 passed.
- Scheme formatter/check completed with only the repository pre-existing parenthesis-depth warnings.

## A/B and end-to-end measurement

- Master: the representative joined-derived query fails during compilation, so no execution time exists.
- Branch: the same real-world query compiles and executes in `763.797 µs` under TracePrint.
- The plan remains a physical ordered scan; no list materialization was introduced.
- A one-locale manual workflow progressed past this SQL blocker: setup, initialization, first-user, and 10/12 parallel feature tests passed. The remaining failures were browser navigation and missing application-row assertions, with no SQL compiler error for this shape.

The shared-server full test run was also attempted serially. It progressed through 122 suites without a failure attributable to this patch, then stalled in the existing rebuild/shutdown concurrency path; the relevant and adjacent suites above were rerun on fresh instances.
