### PR TITLE
Fix prepared TEXT and BLOB parameter decoding

### DIFF
--- a/tests/sql/compatibility/mysql-prepared-binary.yaml
+++ b/tests/sql/compatibility/mysql-prepared-binary.yaml
@@ -1,0 +1,34 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+metadata:
+  version: "1.0"
+  description: "MySQL prepared statements preserve binary parameters byte-for-byte"
+  requires_mysql: true
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS prepared_binary_values"
+  - sql: "CREATE TABLE prepared_binary_values (id INT PRIMARY KEY, label TEXT, payload LONGBLOB)"
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS prepared_binary_values"
+
+test_cases:
+  - name: "Prepared binary parameter preserves arbitrary bytes"
+    mysql:
+      statements:
+        - sql: "INSERT INTO prepared_binary_values (id, label, payload) VALUES (1, ?, ?)"
+          parameters:
+            - base64: "cHJlcGFyZWQgdGV4dA=="
+              mysql_type: "text"
+            - base64: "AP8BgD8="
+              mysql_type: "blob"
+          expect:
+            {}
+        - sql: "SELECT label, LENGTH(payload) AS byte_count, TO_BASE64(payload) AS encoded FROM prepared_binary_values WHERE id = 1"
+          expect:
+            rows: 1
+            data:
+              - byte_count: 5
+                label: "prepared text"
+                encoded: "AP8BgD8="

--- a/third_party/go-mysqlstack/proto/statement.go
+++ b/third_party/go-mysqlstack/proto/statement.go
@@ -3,6 +3,7 @@
  * xelabs.org
  *
  * Copyright (c) XeLabs
+ * Copyright (C) 2026 Carl-Philip Haensch
  * GPL License
  *
  */
@@ -209,10 +210,6 @@ func UnPackStatementExecute(data []byte, prepare *Statement, parseValueFn func(*
 
 		for i := uint16(0); i < prepare.ParamCount; i++ {
 			var val interface{}
-			if prepare.ParamsType[i] == int32(sqltypes.Text) || prepare.ParamsType[i] == int32(sqltypes.Blob) {
-				continue
-			}
-
 			if (bitMap[i/8] & (1 << uint(i%8))) > 0 {
 				val, err = parseValueFn(buf, sqltypes.Null)
 			} else {

--- a/tools/mysql_probe.go
+++ b/tools/mysql_probe.go
@@ -19,12 +19,16 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
+	mysqlstack "github.com/launix-de/go-mysqlstack/driver"
+	"github.com/launix-de/go-mysqlstack/sqlparser/depends/sqltypes"
 )
 
 type probe struct {
@@ -37,8 +41,14 @@ type probe struct {
 }
 
 type statement struct {
-	SQL    string      `json:"sql"`
-	Expect expectation `json:"expect"`
+	SQL        string      `json:"sql"`
+	Parameters []parameter `json:"parameters"`
+	Expect     expectation `json:"expect"`
+}
+
+type parameter struct {
+	Base64    string `json:"base64"`
+	MySQLType string `json:"mysql_type"`
 }
 
 type expectation struct {
@@ -74,15 +84,36 @@ func main() {
 	}
 	defer conn.Close()
 	for i, stmt := range cfg.Statements {
-		if err := runStatement(conn, stmt); err != nil {
+		if err := runStatement(conn, cfg, stmt); err != nil {
 			fail("statement %d failed: %v\nsql: %s", i+1, err, stmt.SQL)
 		}
 	}
 	fmt.Println("mysql probe passed")
 }
 
-func runStatement(conn *sql.Conn, stmt statement) error {
-	rows, err := conn.QueryContext(context.Background(), stmt.SQL)
+func runStatement(conn *sql.Conn, cfg probe, stmt statement) error {
+	args := make([]any, len(stmt.Parameters))
+	typed := false
+	for i, param := range stmt.Parameters {
+		value, err := base64.StdEncoding.DecodeString(param.Base64)
+		if err != nil {
+			return fmt.Errorf("decode parameter %d: %w", i+1, err)
+		}
+		args[i] = value
+		typed = typed || param.MySQLType != ""
+	}
+	if typed {
+		for i, param := range stmt.Parameters {
+			if param.MySQLType == "" {
+				return fmt.Errorf("parameter %d requires mysql_type when any parameter is typed", i+1)
+			}
+		}
+		if stmt.Expect.Error || stmt.Expect.Rows != nil || len(stmt.Expect.Data) != 0 {
+			return fmt.Errorf("typed parameters currently support statements without result expectations")
+		}
+		return runTypedStatement(cfg, stmt, args)
+	}
+	rows, err := conn.QueryContext(context.Background(), stmt.SQL, args...)
 	if stmt.Expect.Error {
 		if err == nil {
 			rows.Close()
@@ -123,6 +154,33 @@ func runStatement(conn *sql.Conn, stmt statement) error {
 		}
 	}
 	return nil
+}
+
+func runTypedStatement(cfg probe, stmt statement, args []any) error {
+	client, err := mysqlstack.NewConn(cfg.Username, cfg.Password,
+		net.JoinHostPort(cfg.Host, fmt.Sprint(cfg.Port)), cfg.Database, "utf8mb4")
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	prepared, err := client.ComStatementPrepare(stmt.SQL)
+	if err != nil {
+		return err
+	}
+	defer prepared.ComStatementClose()
+	values := make([]sqltypes.Value, len(args))
+	for i, arg := range args {
+		data := arg.([]byte)
+		switch strings.ToLower(stmt.Parameters[i].MySQLType) {
+		case "blob":
+			values[i] = sqltypes.MakeTrusted(sqltypes.Blob, data)
+		case "text":
+			values[i] = sqltypes.MakeTrusted(sqltypes.Text, data)
+		default:
+			return fmt.Errorf("unsupported mysql_type %q", stmt.Parameters[i].MySQLType)
+		}
+	}
+	return prepared.ComStatementExecute(values)
 }
 
 func collectRows(rows *sql.Rows) ([]map[string]any, error) {


### PR DESCRIPTION
## Summary

- decode inline MySQL `TEXT` and `BLOB` values in `COM_STMT_EXECUTE` instead of retaining the prepare-time `?` placeholder
- extend the MySQL protocol probe with explicitly typed binary parameters
- add an anonymized end-to-end regression for mixed `TEXT` and `BLOB` parameters, including NUL and non-UTF-8 bytes

## Root cause

`UnPackStatementExecute` skipped `TEXT` and `BLOB` parameters although `ParseMySQLValues` supports their length-encoded representation. The bind variable therefore remained the prepare-time placeholder and was written incorrectly.

## A/B validation

The protocol regression sends prepared text followed by binary bytes `00 ff 01 80 3f`. Master stored the one-byte placeholder; this change stores all five bytes exactly.

## Tests

- prepared binary protocol regression
- MySQL compatibility and error-recovery suites
- blob storage regression suite
- private downstream compatibility validation; names, files, paths, and results are intentionally not published