### PR TITLE
Fix numeric-prefix SQL coercion

### DIFF
--- a/scm/compare.go
+++ b/scm/compare.go
@@ -446,26 +446,26 @@ func EqualSQL(a, b Scmer) Scmer {
 		if tb == tagFloat {
 			return NewBool(float64(a.Int()) == b.Float())
 		}
-		if tb == tagString || tb == tagSymbol {
-			return NewBool(a.Int() == b.Int())
+		if tb == tagString || tb == tagSymbol || tb == tagCString || tb == tagBString {
+			return NewBool(numericStringEqualsInt(b.String(), a.Int()))
 		}
 		return NewBool(a.Int() == b.Int())
 	case tagFloat:
 		if tb == tagInt {
 			return NewBool(a.Float() == float64(b.Int()))
 		}
-		if tb == tagString || tb == tagSymbol {
+		if tb == tagString || tb == tagSymbol || tb == tagCString || tb == tagBString {
 			return NewBool(a.Float() == b.Float())
 		}
 		return NewBool(a.Float() == b.Float())
-	case tagString, tagSymbol:
+	case tagString, tagSymbol, tagCString:
 		if tb == tagDate {
 			if ts, ok := ParseDateString(a.String()); ok {
 				return NewBool(ts == b.Int())
 			}
 		}
 		if tb == tagInt {
-			return NewBool(a.Int() == b.Int())
+			return NewBool(numericStringEqualsInt(a.String(), b.Int()))
 		}
 		if tb == tagFloat {
 			return NewBool(a.Float() == b.Float())
@@ -474,9 +474,16 @@ func EqualSQL(a, b Scmer) Scmer {
 			return NewBool(a.Bool() == b.Bool())
 		}
 		return NewBool(strings.EqualFold(a.String(), b.String()))
-	case tagCString:
-		return NewBool(strings.EqualFold(a.String(), b.String()))
 	case tagBString:
+		if tb == tagInt {
+			return NewBool(numericStringEqualsInt(a.String(), b.Int()))
+		}
+		if tb == tagFloat {
+			return NewBool(a.Float() == b.Float())
+		}
+		if tb == tagBool {
+			return NewBool(a.Bool() == b.Bool())
+		}
 		if tb == tagBString {
 			aLen := int(auxVal(a.aux) & ((1 << 47) - 1))
 			bLen := int(auxVal(b.aux) & ((1 << 47) - 1))

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -565,6 +565,80 @@ func (s Scmer) Bool() bool {
 	}
 }
 
+// numericPrefix returns the leading numeric token used by SQL coercions. MySQL
+// accepts trailing non-numeric bytes but only accepts an exponent when it has
+// at least one digit.
+func numericPrefix(value string) string {
+	value = strings.TrimLeft(value, " \t\n\r\f\v")
+	if value == "" {
+		return ""
+	}
+
+	i := 0
+	if value[i] == '+' || value[i] == '-' {
+		i++
+	}
+	digits := 0
+	for i < len(value) && value[i] >= '0' && value[i] <= '9' {
+		i++
+		digits++
+	}
+	if i < len(value) && value[i] == '.' {
+		i++
+		for i < len(value) && value[i] >= '0' && value[i] <= '9' {
+			i++
+			digits++
+		}
+	}
+	if digits == 0 {
+		return ""
+	}
+	if i < len(value) && (value[i] == 'e' || value[i] == 'E') {
+		exponent := i
+		i++
+		if i < len(value) && (value[i] == '+' || value[i] == '-') {
+			i++
+		}
+		exponentDigits := i
+		for i < len(value) && value[i] >= '0' && value[i] <= '9' {
+			i++
+		}
+		if i == exponentDigits {
+			i = exponent
+		}
+	}
+
+	return value[:i]
+}
+
+func numericPrefixFloat(value string) float64 {
+	n, err := strconv.ParseFloat(numericPrefix(value), 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func numericPrefixInt(value string) int64 {
+	token := numericPrefix(value)
+	if strings.ContainsAny(token, ".eE") {
+		return int64(numericPrefixFloat(token))
+	}
+	n, err := strconv.ParseInt(token, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func numericStringEqualsInt(value string, integer int64) bool {
+	token := numericPrefix(value)
+	if strings.ContainsAny(token, ".eE") {
+		return numericPrefixFloat(token) == float64(integer)
+	}
+	return numericPrefixInt(token) == integer
+}
+
 func (s Scmer) Int() int64 {
 	switch s.GetTag() {
 	case tagNil:
@@ -573,12 +647,8 @@ func (s Scmer) Int() int64 {
 		return int64(s.aux)
 	case tagFloat:
 		return int64(math.Float64frombits(s.aux))
-	case tagString, tagSymbol:
-		v, err := strconv.ParseInt(s.String(), 10, 64)
-		if err != nil {
-			return 0
-		}
-		return v
+	case tagString, tagSymbol, tagCString, tagBString:
+		return numericPrefixInt(s.String())
 	case tagDate:
 		return TagDateDecodeUnix(auxVal(s.aux))
 	case tagBool:
@@ -602,12 +672,8 @@ func (s Scmer) Float() float64 {
 		return math.Float64frombits(s.aux)
 	case tagInt:
 		return float64(int64(s.aux))
-	case tagString, tagSymbol:
-		v, err := strconv.ParseFloat(s.String(), 64)
-		if err != nil {
-			return 0.0
-		}
-		return v
+	case tagString, tagSymbol, tagCString, tagBString:
+		return numericPrefixFloat(s.String())
 	case tagDate:
 		return float64(TagDateDecodeUnix(auxVal(s.aux)))
 	case tagBool:

--- a/tests/sql/compatibility/mysql-basic-compat.yaml
+++ b/tests/sql/compatibility/mysql-basic-compat.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
 # MySQL Compatibility v1 — Basics
 
 metadata:
@@ -42,6 +44,29 @@ test_cases:
       rows: 1
       data:
         - eq: true
+
+  - name: "Implicit numeric cast accepts a leading numeric prefix"
+    sql: |
+      SELECT
+        15 = '15,16' AS integer_prefix,
+        15.5 = '15.5 trailing' AS decimal_prefix,
+        150 = '1.5e2 trailing' AS exponent_prefix,
+        9007199254740993 = '9007199254740993 trailing' AS large_integer_prefix
+    expect:
+      rows: 1
+      data:
+        - integer_prefix: true
+          decimal_prefix: true
+          exponent_prefix: true
+          large_integer_prefix: true
+
+  - name: "Numeric-prefix coercion applies to indexed integer columns"
+    sql: |
+      SELECT `id` FROM `compat_users` WHERE `id` = '1,2'
+    expect:
+      rows: 1
+      data:
+        - id: 1
 
   - name: "Implicit boolean truthiness"
     sql: |


### PR DESCRIPTION
## What changed

- Parse the leading numeric token when SQL coerces strings to numbers.
- Apply the same coercion to compact, buffered, and ordinary string representations.
- Preserve exact 64-bit integer comparison when the token is integral.
- Add anonymized constant and indexed-column regression cases.

## Root cause

Numeric conversion required the complete string to be valid. MySQL instead accepts a valid leading numeric token and ignores trailing non-numeric bytes in numeric contexts. A generated scalar identifier comparison therefore evaluated differently before later aggregate permission predicates were reached.

## Validation

- `go test ./scm/`
- `python3 run_sql_tests.py tests/sql/compatibility/mysql-basic-compat.yaml` (13/13)
- External document-action manual suite: the previously failing merge action now passes and the run advances to a later, unrelated data-view timeout.

The full local `make test` run progressed through the affected SQL, planner, index, transaction, and expression suites, but did not complete: `tests/execution/concurrency/rebuild-concurrent.yaml` lost responses while another worktree was running the same rebuild stress suite. The isolated retry reproduced that pre-existing rebuild stall.
