### PR TITLE
Make rebuild publication atomic

### DIFF
--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -57,6 +57,9 @@ import multiprocessing
 import re
 import random
 import tempfile
+import ctypes
+import select
+import struct
 from pathlib import Path
 from base64 import b64encode
 from typing import Dict, List, Any, Optional, Tuple
@@ -106,6 +109,59 @@ def measure_cpu_load(pid: int, start_cpu: float, end_cpu: float, elapsed_sec: fl
 
 # Global flag for connect-only mode
 is_connect_only_mode = False
+
+
+def observe_atomic_json(path: Path, duration_seconds: float) -> Tuple[int, Optional[str]]:
+    """Read a live JSON file repeatedly and reject missing or partial generations."""
+    deadline = time.monotonic() + duration_seconds
+    reads = 0
+    inotify_fd = -1
+    libc = None
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.inotify_init1.argtypes = [ctypes.c_int]
+        libc.inotify_init1.restype = ctypes.c_int
+        libc.inotify_add_watch.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_uint32]
+        libc.inotify_add_watch.restype = ctypes.c_int
+        inotify_fd = libc.inotify_init1(os.O_NONBLOCK | os.O_CLOEXEC)
+        if inotify_fd >= 0:
+            watch_mask = 0x00000100 | 0x00000200 | 0x00000040 | 0x00000080
+            if libc.inotify_add_watch(inotify_fd, os.fsencode(path.parent), watch_mask) < 0:
+                os.close(inotify_fd)
+                inotify_fd = -1
+
+        while time.monotonic() < deadline:
+            try:
+                payload = path.read_bytes()
+            except FileNotFoundError:
+                if reads == 0:
+                    time.sleep(0.001)
+                    continue
+                return reads, "file disappeared after a complete generation was observed"
+            if not payload:
+                return reads, "observed an empty generation"
+            try:
+                json.loads(payload)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                return reads, f"observed a partial generation ({len(payload)} bytes): {exc}"
+            reads += 1
+
+            if inotify_fd >= 0 and select.select([inotify_fd], [], [], 0)[0]:
+                events = os.read(inotify_fd, 64 * 1024)
+                offset = 0
+                while offset + 16 <= len(events):
+                    _, mask, _, name_len = struct.unpack_from("iIII", events, offset)
+                    offset += 16
+                    name = events[offset:offset + name_len].split(b"\0", 1)[0]
+                    offset += name_len
+                    if name == os.fsencode(path.name) and mask & (0x00000100 | 0x00000200 | 0x00000040):
+                        return reads, f"schema target was removed before replacement (inotify mask 0x{mask:x})"
+    finally:
+        if inotify_fd >= 0:
+            os.close(inotify_fd)
+    if reads == 0:
+        return 0, "no schema generation was observed"
+    return reads, None
 
 # Performance test configuration
 PERF_TEST_ENABLED = os.environ.get("PERF_TEST", "0") == "1"
@@ -615,6 +671,10 @@ class SQLTestRunner:
         if is_noncritical:
             self.noncritical_count += 1
 
+        start_delay_ms = int(test_case.get("start_delay_ms", 0))
+        if start_delay_ms > 0:
+            time.sleep(start_delay_ms / 1000.0)
+
         # Special action test cases (restart, etc.)
         action = test_case.get("action")
         if action == "restart":
@@ -636,6 +696,20 @@ class SQLTestRunner:
                 else:
                     self._record_fail(name, "Server not reachable after crash", None, None, None, is_noncritical)
             return True
+        if action == "observe_atomic_schema":
+            try:
+                port = int(self.base_url.rsplit(':', 1)[1])
+            except (ValueError, IndexError):
+                port = 4321
+            data_dir = Path(os.environ.get("MEMCP_TEST_DATA_DIR", f"/tmp/memcp-sql-tests-{port}"))
+            duration = float(test_case.get("duration", 1.0))
+            reads, error = observe_atomic_json(data_dir / database / "schema.json", duration)
+            if error is None:
+                self._record_success(name, is_noncritical)
+            else:
+                self._record_fail(name, f"Atomic schema observation failed after {reads} reads: {error}",
+                                  None, None, None, is_noncritical)
+            return error is None
 
         # Performance test handling
         yaml_threshold_ms = test_case.get("threshold_ms")
@@ -1340,40 +1414,33 @@ class SQLTestRunner:
             else:
                 test_cases.append(tc)
 
-        if self.fail_fast:
-            for i, tc in enumerate(test_cases):
-                if '_delay_ms' in tc:
-                    time.sleep(tc['_delay_ms'] / 1000.0)
-                    continue
+        # Preserve declared concurrency in every mode. Fail-fast stops only
+        # after the complete parallel group containing the first failure.
+        i = 0
+        while i < len(test_cases):
+            tc = test_cases[i]
+            if '_delay_ms' in tc:
+                time.sleep(tc['_delay_ms'] / 1000.0)
+                i += 1
+                continue
+            group = tc.get('parallel')
+            if group:
+                group_tests = [tc]
+                j = i + 1
+                while j < len(test_cases) and test_cases[j].get('parallel') == group:
+                    group_tests.append(test_cases[j])
+                    j += 1
+                print(f"⚡ Running {len(group_tests)} tests in parallel group '{group}'")
+                self._run_parallel_group(group_tests, database)
+                i = j
+            else:
                 self.run_test_case(tc, database)
-                if self.failed_critical > 0:
-                    remaining_tests = sum(1 for pending in test_cases[i + 1:] if '_delay_ms' not in pending)
-                    if remaining_tests > 0:
-                        print(f"⏭️  Fail-fast skipped {remaining_tests} tests after the first failure")
-                    break
-        else:
-            # Group consecutive test cases by 'parallel' key and run groups concurrently
-            i = 0
-            while i < len(test_cases):
-                tc = test_cases[i]
-                if '_delay_ms' in tc:
-                    time.sleep(tc['_delay_ms'] / 1000.0)
-                    i += 1
-                    continue
-                group = tc.get('parallel')
-                if group:
-                    # Collect all consecutive tests with the same parallel group
-                    group_tests = [tc]
-                    j = i + 1
-                    while j < len(test_cases) and test_cases[j].get('parallel') == group:
-                        group_tests.append(test_cases[j])
-                        j += 1
-                    print(f"⚡ Running {len(group_tests)} tests in parallel group '{group}'")
-                    self._run_parallel_group(group_tests, database)
-                    i = j
-                else:
-                    self.run_test_case(tc, database)
-                    i += 1
+                i += 1
+            if self.fail_fast and self.failed_critical > 0:
+                remaining_tests = sum(1 for pending in test_cases[i:] if '_delay_ms' not in pending)
+                if remaining_tests > 0:
+                    print(f"⏭️  Fail-fast skipped {remaining_tests} tests after the first failure")
+                break
 
         if spec.get('cleanup'):
             self.run_cleanup(spec['cleanup'], database)
@@ -1544,7 +1611,7 @@ def suite_requires_managed_restart(spec_file: str) -> bool:
     for test_case in test_cases:
         if not isinstance(test_case, dict):
             continue
-        if test_case.get("action") == "restart":
+        if test_case.get("action") in ("restart", "observe_atomic_schema"):
             return True
         sql = test_case.get("sql")
         if isinstance(sql, str) and sql.strip().upper() == "SHUTDOWN":

--- a/storage/database.go
+++ b/storage/database.go
@@ -80,11 +80,16 @@ func newDatabase() *database {
 }
 
 type rebuildDatabaseResult struct {
+	// replaced remains reachable until the caller has committed schema.json.
+	// On any build or publication error these shards must stay on disk because
+	// the last committed schema may still reference them.
 	replaced []*storageShard
 	errors   []string
 }
 
 type schemaWriteOptions interface {
+	// This has the same atomic-generation contract as WriteSchema. durable also
+	// requires data and namespace metadata to be stable before returning.
 	WriteSchemaWithMode(schema []byte, durable bool)
 }
 
@@ -172,6 +177,8 @@ func RebuildTable(tbl *table, all bool, repartition bool) string {
 		}
 	}
 	if len(errs) == 0 {
+		// tbl.schema.save() committed all replacement UUIDs. Only this success
+		// path may remove files belonging to the previous generation.
 		for _, s := range result.replaced {
 			if err := func() (err error) {
 				defer func() {
@@ -211,6 +218,8 @@ func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string 
 				errs = append(errs, err.Error())
 				return
 			}
+			// db.save() committed all replacement UUIDs. A save failure returns
+			// above and deliberately retains every old generation.
 			for _, s := range result.replaced {
 				if err := func() (err error) {
 					defer func() { err = recoverAsError("cleanup failed for database " + db.Name + " shard " + s.uuid.String()) }()
@@ -319,6 +328,9 @@ func (db *database) getSaveCond() *sync.Cond {
 }
 
 func (db *database) commitSchemaSnapshot(jsonbytes []byte, durable bool) {
+	// Serialize publications without holding schemalock. Coalescing may skip an
+	// intermediate in-memory snapshot, but every backend call still publishes a
+	// complete generation and every waiter observes its success or panic.
 	db.saveMu.Lock()
 	cond := db.getSaveCond()
 	db.saveRequested++

--- a/storage/database.go
+++ b/storage/database.go
@@ -848,8 +848,8 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 	// on-disk files AFTER db.save() has written the new schema.json.
 	// Deleting old column files before saving the schema creates a window
 	// where a crash/kill leaves schema.json pointing at already-deleted UUIDs.
-	// The finalizer set in shard.rebuild() provides a safety net: if the
-	// caller never calls RemoveFromDisk (e.g. on panic), GC will clean up.
+	// Failed schema publication intentionally retains the old generation: it is
+	// still referenced by the last committed schema and must remain recoverable.
 	return rebuildDatabaseResult{replaced: allReplaced, errors: rebuildErrors}
 }
 

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -897,7 +897,10 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	}
 	fmt.Println("activated new partitioning schema for", t.Name, "after", time.Since(start))
 
-	// ── Phase G: Cleanup ──
+	// ── Phase G: Commit and cleanup ──
+	// New shard files are complete before this publication barrier. schema.json
+	// must atomically name the new PShards before any old shard file is released;
+	// a publication panic therefore leaves oldshards intact and recoverable.
 	t.schema.schemalock.Lock()
 	t.schema.saveLockedWithDurabilityAndUnlock(t.schemaWriteDurable())
 
@@ -913,6 +916,8 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	t.maintenanceMu.Unlock()
 
 	for _, s := range oldshards {
+		// Deliberately after successful schema publication. Persistent cleanup
+		// must never move into a defer, finalizer, or failure path.
 		GlobalCache.Remove(s)
 		s.RemoveFromDisk()
 	}

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -725,7 +725,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 							if s.t.PersistencyMode != Memory {
 								f := s.t.schema.persistence.WriteColumn(s.uuid.String(), col.Name)
 								newcol.Serialize(f)
-								f.Close()
+								finishColumnWrite(f, s.t.PersistencyMode == Safe)
 							}
 						}
 					}

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -156,7 +156,8 @@ func (s *CephStorage) ReadSchema() []byte {
 func (s *CephStorage) WriteSchema(schema []byte) {
 	s.ensureOpen()
 	obj := s.obj("schema.json")
-	// atomic overwrite
+	// RADOS full-object overwrite satisfies PersistenceEngine's atomic schema
+	// generation contract: readers see the old or complete new object.
 	if err := s.ioctx.WriteFull(obj, schema); err != nil {
 		panic(err)
 	}

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -63,6 +63,11 @@ func (s *FileStorage) WriteSchema(jsonbytes []byte) {
 	s.WriteSchemaWithMode(jsonbytes, true)
 }
 
+// WriteSchemaWithMode publishes filesystem schema generations atomically. The
+// live path is never renamed away or truncated: a complete same-directory
+// temporary file replaces it with one atomic rename. Durable writes sync the
+// file before rename and the directory afterwards. The backup is a hard link
+// to the previously committed generation and cannot create a live-path gap.
 func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
 	if err := os.MkdirAll(s.path, 0750); err != nil {
 		panic(err)
@@ -90,6 +95,8 @@ func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
 	current := s.path + "schema.json"
 	backup := s.path + "schema.json.old"
 	if stat, err := os.Stat(current); err == nil && stat.Size() > 0 {
+		// Publish the rescue link under a temporary name first. Failure to make
+		// a backup must not disturb the still-live current generation.
 		backupTmp := s.path + ".schema.json.old.tmp"
 		_ = os.Remove(backupTmp)
 		if err := os.Link(current, backupTmp); err == nil {

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -64,28 +64,55 @@ func (s *FileStorage) WriteSchema(jsonbytes []byte) {
 }
 
 func (s *FileStorage) WriteSchemaWithMode(jsonbytes []byte, durable bool) {
-	os.MkdirAll(s.path, 0750)
-	if stat, err := os.Stat(s.path + "schema.json"); err == nil && stat.Size() > 0 {
-		// rescue a copy of schema.json in case the schema is not serializable
-		os.Rename(s.path+"schema.json", s.path+"schema.json.old")
+	if err := os.MkdirAll(s.path, 0750); err != nil {
+		panic(err)
 	}
-	f, err := os.Create(s.path + "schema.json")
+	tmp, err := os.CreateTemp(s.path, ".schema.json.tmp-")
 	if err != nil {
 		panic(err)
 	}
-	defer f.Close()
-	if _, err := f.Write(jsonbytes); err != nil {
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(jsonbytes); err != nil {
+		tmp.Close()
 		panic(err)
 	}
 	if durable {
-		if err := f.Sync(); err != nil {
+		if err := tmp.Sync(); err != nil {
+			tmp.Close()
 			panic(err)
 		}
-		if dir, err := os.Open(s.path); err == nil {
-			defer dir.Close()
-			if err := dir.Sync(); err != nil {
+	}
+	if err := tmp.Close(); err != nil {
+		panic(err)
+	}
+
+	current := s.path + "schema.json"
+	backup := s.path + "schema.json.old"
+	if stat, err := os.Stat(current); err == nil && stat.Size() > 0 {
+		backupTmp := s.path + ".schema.json.old.tmp"
+		_ = os.Remove(backupTmp)
+		if err := os.Link(current, backupTmp); err == nil {
+			if err := os.Rename(backupTmp, backup); err != nil {
+				_ = os.Remove(backupTmp)
 				panic(err)
 			}
+		}
+	}
+	if err := os.Rename(tmpName, current); err != nil {
+		panic(err)
+	}
+	if durable {
+		dir, err := os.Open(s.path)
+		if err != nil {
+			panic(err)
+		}
+		if err := dir.Sync(); err != nil {
+			dir.Close()
+			panic(err)
+		}
+		if err := dir.Close(); err != nil {
+			panic(err)
 		}
 	}
 }

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -182,6 +182,8 @@ func (s *S3Storage) WriteSchema(schema []byte) {
 	s.ensureOpen()
 	key := s.key("schema.json")
 
+	// A completed single-object PUT atomically replaces the schema key; readers
+	// cannot observe the request body while it is still being uploaded.
 	_, err := s.client.PutObject(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String(s.factory.Bucket),
 		Key:    aws.String(key),

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -41,8 +41,14 @@ A storage interface must implement the following operations:
 
 type PersistenceEngine interface {
 	ReadSchema() []byte
+	// WriteSchema must publish one complete schema generation atomically. A
+	// reader may observe either the previous or the new generation, never a
+	// missing, empty, or partial schema. Failures must panic.
 	WriteSchema(schema []byte)
 	ReadColumn(shard string, column string) io.ReadCloser
+	// WriteColumn returns a generation-private writer. Close must either publish
+	// the complete column object or report an error; partial objects must never
+	// become readable as a successfully completed rebuild generation.
 	WriteColumn(shard string, column string) io.WriteCloser
 	RemoveColumn(shard string, column string)
 	ReadBlob(hash string) io.ReadCloser
@@ -71,6 +77,10 @@ type PersistenceLogfile interface {
 }
 
 func finishColumnWrite(w io.WriteCloser, durable bool) {
+	// Rebuild publication order is column data first, schema reference second.
+	// SAFE columns must reach stable storage before schema.json can name their
+	// shard generation. Close errors are publication failures too; callers must
+	// retain the previously committed shard generation on every panic here.
 	if durable {
 		if syncer, ok := w.(interface{ Sync() error }); ok {
 			if err := syncer.Sync(); err != nil {

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -69,6 +69,21 @@ type PersistenceLogfile interface {
 	Sync()
 	Close()
 }
+
+func finishColumnWrite(w io.WriteCloser, durable bool) {
+	if durable {
+		if syncer, ok := w.(interface{ Sync() error }); ok {
+			if err := syncer.Sync(); err != nil {
+				_ = w.Close()
+				panic(err)
+			}
+		}
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+}
+
 type LogEntryDelete struct {
 	idx uint32
 }

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -284,7 +284,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -431,7 +431,7 @@ func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []s
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -568,7 +568,7 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -850,7 +850,7 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -936,7 +936,7 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -1112,7 +1112,7 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -512,7 +512,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 		t.enterMutationOwner()
 		defer t.exitMutationOwner()
 	}
-	if t.tableLockOwner.Load() != nil {
+	if t.hasTableLock() {
 		t.waitTableLock(ss, hasMutationCallback)
 	}
 	// touch temp columns so CacheManager knows they're still in use
@@ -714,7 +714,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, false)
@@ -818,7 +818,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	lockMutationExclusively := hasMutationCallback && !ownsWrite
 	writeLocked := false
 	if lockMutationExclusively {
-		t.mu.Lock()
+		t.lockForMutation(ss)
 		writeLocked = true
 		defer func() {
 			if writeLocked {
@@ -834,12 +834,6 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		if currentTx != nil {
 			currentTx.EnterShardWrite(t)
 			defer currentTx.ExitShardWrite(t)
-		}
-		// Table lock check for mutation path: lockTable() stores owner while holding
-		// all shard write locks, so checking after our own t.mu.Lock() is TOCTOU-safe.
-		// waitTableLock only uses tableLockMu (not t.mu), so no deadlock.
-		if t.t.tableLockOwner.Load() != nil {
-			t.t.waitTableLock(ss, true)
 		}
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
@@ -887,10 +881,10 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		t.mu.RLock()
 		locked = true
 		// Table lock check must happen AFTER shard RLock to close the TOCTOU window:
-		// lockTable() sets tableLockOwner while holding shard write locks, so any
-		// scan that gets past RLock is guaranteed to see a non-nil owner if a
-		// LOCK TABLES was issued before this scan acquired the shard read lock.
-		if t.t.tableLockOwner.Load() != nil {
+		// lockTable() publishes tableLockState while holding shard write locks, so
+		// any scan that gets past RLock sees a lock issued before it acquired the
+		// shard read lock.
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, hasMutationCallback)
@@ -1075,7 +1069,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	lockMutationExclusively := hasMutationCallback && !ownsWrite
 	writeLocked := false
 	if lockMutationExclusively {
-		t.mu.Lock()
+		t.lockForMutation(ss)
 		writeLocked = true
 		defer func() {
 			if writeLocked {
@@ -1091,9 +1085,6 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		if currentTx != nil {
 			currentTx.EnterShardWrite(t)
 			defer currentTx.ExitShardWrite(t)
-		}
-		if t.t.tableLockOwner.Load() != nil {
-			t.t.waitTableLock(ss, true)
 		}
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
@@ -1142,7 +1133,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	if !skipShardReadLock {
 		t.mu.RLock()
 		locked = true
-		if t.t.tableLockOwner.Load() != nil {
+		if t.t.hasTableLock() {
 			t.mu.RUnlock()
 			locked = false
 			t.t.waitTableLock(ss, hasMutationCallback)

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1163,7 +1163,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	}
 
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
-	if t.t.tableLockOwner.Load() != nil {
+	if t.t.hasTableLock() {
 		t.t.waitTableLock(ss, false)
 	}
 
@@ -1202,7 +1202,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			shardLocked = true
 			// Table lock check must happen AFTER shard RLock — race-safe synchronization
 			// point (mirrors storageShard.scan logic for the TOCTOU fix).
-			if t.t.tableLockOwner.Load() != nil {
+			if t.t.hasTableLock() {
 				t.mu.RUnlock()
 				shardLocked = false
 				t.t.waitTableLock(ss, false)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1901,11 +1901,12 @@ func (m *ShardMapReducer) FlushSideEffects() {
 }
 
 func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLocked bool, onFirstInsertId func(int64), isIgnore bool) uint32 {
+	ss := scm.GetCurrentSessionState()
 	// Check table-level user lock (LOCK TABLES): writes block under any lock.
 	// Always call waitTableLock — it handles other-session blocking and
 	// owner-write-under-READ-lock error in one place.
-	if t.t.tableLockOwner.Load() != nil {
-		t.t.waitTableLock(scm.GetCurrentSessionState(), true)
+	if t.t.hasTableLock() {
+		t.t.waitTableLock(ss, true)
 	}
 	beforeInsertTriggers := t.t.GetTriggers(BeforeInsert)
 	currentTx := CurrentTx()
@@ -1928,7 +1929,7 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 			return 0
 		}
 		if !alreadyLocked {
-			t.mu.Lock()
+			t.lockForMutation(ss)
 			defer t.mu.Unlock()
 		}
 		firstNewRecid := uint32(0)
@@ -1952,11 +1953,31 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 	}
 
 	if !alreadyLocked {
-		t.mu.Lock()
+		t.lockForMutation(ss)
 		defer t.mu.Unlock()
 	}
 	firstNewRecid := t.insertPreparedLocked(columns, values, onFirstInsertId, true, true, currentTx)
 	return firstNewRecid
+}
+
+// lockForMutation follows the table-lock-before-shard-lock order without a
+// TOCTOU window. Table-lock acquisition publishes its owner while holding all
+// shard write locks, so a lock that raced our first check is visible after we
+// acquire t.mu. Never wait for that owner while retaining t.mu: a cache
+// initializer holding a READ table lock may need this shard to finish its
+// snapshot before it can release the table lock.
+func (t *storageShard) lockForMutation(ss *scm.SessionState) {
+	for {
+		if t.t.hasTableLock() {
+			t.t.waitTableLock(ss, true)
+		}
+		t.mu.Lock()
+		owner := t.t.tableLockOwner.Load()
+		if t.t.tableLockState.Load() == 0 || owner == ss {
+			return
+		}
+		t.mu.Unlock()
+	}
 }
 
 func (t *storageShard) insertReplica(columns []string, values [][]scm.Scmer, alreadyLocked bool) uint32 {
@@ -2060,7 +2081,7 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 	if fireTriggers && len(t.t.Triggers) > 0 {
 		func() {
 			t.mu.Unlock()
-			defer t.mu.Lock()
+			defer t.lockForMutation(scm.GetCurrentSessionState())
 			for _, row := range triggerInsertRows {
 				t.t.ExecuteTriggers(AfterInsert, nil, row)
 			}
@@ -2497,7 +2518,7 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 			}
 			f := s.t.schema.persistence.WriteColumn(s.uuid.String(), colName)
 			cs.Serialize(f)
-			f.Close()
+			finishColumnWrite(f, newMode == Safe)
 		}
 		// open logfile for Safe/Logged
 		if newMode == Safe || newMode == Logged {
@@ -2765,7 +2786,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				if t.t.PersistencyMode != Memory && t.t.PersistencyMode != Cache {
 					f := result.t.schema.persistence.WriteColumn(result.uuid.String(), col)
 					newProxy.Serialize(f)
-					f.Close()
+					finishColumnWrite(f, t.t.PersistencyMode == Safe)
 				}
 				continue
 			}
@@ -2877,7 +2898,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			if t.t.PersistencyMode != Memory && t.t.PersistencyMode != Cache {
 				f := result.t.schema.persistence.WriteColumn(result.uuid.String(), col)
 				newcol.Serialize(f) // col takes ownership of f, so they will defer f.Close() at the right time
-				f.Close()
+				finishColumnWrite(f, t.t.PersistencyMode == Safe)
 			}
 		}
 		b.WriteString(") -> ")
@@ -2929,10 +2950,9 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 		// publish can leave schema.json pointing at the old shard UUID after its
 		// WAL was already removed, losing rows that only existed in the old log.
 
-		// Only after a successful rebuild, schedule old shard files for deletion.
-		runtime.SetFinalizer(t, func(t *storageShard) {
-			t.RemoveFromDisk()
-		})
+		// The caller retains the old shard until the new schema generation is
+		// durably committed, then removes it explicitly. A finalizer must never
+		// delete files because the last committed schema may still reference them.
 	} else {
 		// otherwise: table stays the same
 		result.uuid = t.uuid // copy uuid in case nothing changes

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1961,9 +1961,9 @@ func (t *storageShard) Insert(columns []string, values [][]scm.Scmer, alreadyLoc
 }
 
 // lockForMutation follows the table-lock-before-shard-lock order without a
-// TOCTOU window. Table-lock acquisition publishes its owner while holding all
-// shard write locks, so a lock that raced our first check is visible after we
-// acquire t.mu. Never wait for that owner while retaining t.mu: a cache
+// TOCTOU window. Table-lock acquisition publishes tableLockState while holding
+// all shard write locks, so a lock that raced our first check is visible after
+// we acquire t.mu. Never wait for that owner while retaining t.mu: a cache
 // initializer holding a READ table lock may need this shard to finish its
 // snapshot before it can release the table lock.
 func (t *storageShard) lockForMutation(ss *scm.SessionState) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -347,9 +347,12 @@ func isScanPseudoColName(name string) bool {
 // lockTable acquires a user-level read or write lock on the named table.
 // The session's State is updated while waiting, and the unlock callback is
 // registered with the session so that ReleaseAllLocks() can free it later.
-// Acquiring any lock requires an exclusive wait (drain other owners), then
-// drains in-flight shard readers by briefly acquiring each shard's write lock.
+// A run of FIFO-adjacent READ requests shares the lock. The first reader, or an
+// exclusive writer, drains in-flight shard readers before publishing the lock.
 func acquireTableLock(schema, name string, write bool, ss *scm.SessionState) func() {
+	if ss == nil {
+		panic("LOCK TABLES requires a query session")
+	}
 	db := GetDatabase(schema)
 	if db == nil {
 		panic("LOCK TABLES: unknown database: " + schema)
@@ -358,31 +361,56 @@ func acquireTableLock(schema, name string, write bool, ss *scm.SessionState) fun
 	if t == nil {
 		panic("LOCK TABLES: unknown table: " + schema + "." + name)
 	}
-	// LOCK TABLES itself is serialized FIFO per table. This avoids a thundering
-	// herd when many sessions repeatedly lock the same hot table (e.g. cron).
 	cond := t.getTableLockCond()
-	if owner := t.tableLockOwner.Load(); owner != nil && owner == ss {
-		if write && !t.tableLockWrite.Load() {
+	ss.BeginLockWait()
+	defer ss.EndLockWait()
+	ss.SetState("Waiting for table lock")
+	t.tableLockMu.Lock()
+	if t.tableLockOwner.Load() == ss {
+		t.tableLockMu.Unlock()
+		return func() {}
+	}
+	if t.tableLockReadOwners[ss] != 0 {
+		t.tableLockMu.Unlock()
+		if write {
 			panic("LOCK TABLES: cannot upgrade an existing READ lock")
 		}
 		return func() {}
 	}
-	if ss != nil {
-		ss.BeginLockWait()
-		defer ss.EndLockWait()
-		ss.SetState("Waiting for table lock")
-	}
-	t.tableLockMu.Lock()
 	myTicket := t.tableLockNext
 	t.tableLockNext++
-	for myTicket != t.tableLockServe || t.tableLockOwner.Load() != nil {
+	for myTicket != t.tableLockServe || t.tableLockState.Load() < 0 || (write && t.tableLockState.Load() != 0) {
 		cond.Wait()
+	}
+	if !write && t.tableLockState.Load() > 0 {
+		if t.tableLockReadOwners == nil {
+			t.tableLockReadOwners = make(map[*scm.SessionState]uint32)
+		}
+		t.tableLockReadOwners[ss]++
+		t.tableLockState.Add(1)
+		t.tableLockServe++
+		cond.Broadcast()
+		t.tableLockMu.Unlock()
+		return func() {
+			t.tableLockMu.Lock()
+			if t.tableLockReadOwners[ss] == 1 {
+				delete(t.tableLockReadOwners, ss)
+			} else {
+				t.tableLockReadOwners[ss]--
+			}
+			if t.tableLockState.Add(-1) < 0 {
+				t.tableLockMu.Unlock()
+				panic("table READ lock count underflow")
+			}
+			cond.Broadcast()
+			t.tableLockMu.Unlock()
+		}
 	}
 	t.tableLockMu.Unlock()
 	// Drain in-flight shard readers by acquiring each shard's write lock.
-	// We MUST set tableLockOwner while still holding the last shard write lock
-	// so that any new scan that does RLock → tableLockOwner.Load() sees the
-	// owner set before it can proceed past its own RLock.
+	// We MUST publish the lock while still holding the last shard write lock
+	// so that any new scan that does RLock -> tableLockState.Load() sees the
+	// lock before it can proceed past its own RLock.
 	acquired := false
 	defer func() {
 		if acquired {
@@ -399,13 +427,41 @@ func acquireTableLock(schema, name string, write bool, ss *scm.SessionState) fun
 	for _, s := range shards {
 		s.mu.Lock()
 	}
-	t.tableLockWrite.Store(write)
-	t.tableLockOwner.Store(ss)
+	if write {
+		t.tableLockOwner.Store(ss)
+		t.tableLockState.Store(-1)
+	} else {
+		t.tableLockMu.Lock()
+		if t.tableLockReadOwners == nil {
+			t.tableLockReadOwners = make(map[*scm.SessionState]uint32)
+		}
+		t.tableLockReadOwners[ss]++
+		t.tableLockState.Add(1)
+		t.tableLockServe++
+		cond.Broadcast()
+		t.tableLockMu.Unlock()
+	}
 	for _, s := range shards {
 		s.mu.Unlock()
 	}
 	acquired = true
-	return t.unlockTable
+	if write {
+		return t.unlockTableWrite
+	}
+	return func() {
+		t.tableLockMu.Lock()
+		if t.tableLockReadOwners[ss] == 1 {
+			delete(t.tableLockReadOwners, ss)
+		} else {
+			t.tableLockReadOwners[ss]--
+		}
+		if t.tableLockState.Add(-1) < 0 {
+			t.tableLockMu.Unlock()
+			panic("table READ lock count underflow")
+		}
+		cond.Broadcast()
+		t.tableLockMu.Unlock()
+	}
 }
 
 func lockTable(schema, name string, write bool, ss *scm.SessionState) {

--- a/storage/table.go
+++ b/storage/table.go
@@ -300,6 +300,9 @@ type table struct {
 	//     so many concurrent waiters (e.g. cron workers) do not stampede on unlock.
 	//   - Regular scans/writes only consult waitTableLock; they never participate in
 	//     the FIFO queue and are released together once the owner unlocks.
+	//   - Mutations wait for tableLockState before taking a shard lock and recheck
+	//     after taking it. They never wait for a table lock while holding a shard
+	//     lock; cache snapshots hold their table READ lock while entering shards.
 	// tableLockState is read from every shard goroutine on
 	// every scan; isolate them on their own cache line to prevent false sharing
 	// with Auto_increment (written on every INSERT).

--- a/storage/table.go
+++ b/storage/table.go
@@ -294,26 +294,28 @@ type table struct {
 	// LOCK TABLES: variable-based lock that is cheap for scans to check but
 	// expensive to acquire (drains shard readers first via waitTableLock).
 	// Software contract:
-	//   - tableLockOwner/tableLockWrite describe the currently granted user lock.
+	//   - tableLockOwner describes the WRITE owner; tableLockState and
+	//     tableLockReadOwners describe concurrently granted READ locks.
 	//   - tableLockNext/tableLockServe serialize LOCK TABLES acquisition FIFO per table,
 	//     so many concurrent waiters (e.g. cron workers) do not stampede on unlock.
 	//   - Regular scans/writes only consult waitTableLock; they never participate in
 	//     the FIFO queue and are released together once the owner unlocks.
-	// tableLockOwner and tableLockWrite are read from every shard goroutine on
+	// tableLockState is read from every shard goroutine on
 	// every scan; isolate them on their own cache line to prevent false sharing
 	// with Auto_increment (written on every INSERT).
-	tableLockMu    sync.Mutex                       // guards cond waits + acquisition
-	tableLockOnce  sync.Once                        // lazy-inits tableLockCond
-	tableLockCond  *sync.Cond                       // broadcast on unlock
-	tableLockNext  uint64                           // next FIFO ticket for LOCK TABLES acquisition
-	tableLockServe uint64                           // currently served FIFO ticket
-	tableLockOwner atomic.Pointer[scm.SessionState] // nil = no lock; points to owning *SessionState
-	tableLockWrite atomic.Bool                      // true = WRITE lock, false = READ lock
-	_              [39]byte                         // pad to cache-line boundary
-	Auto_increment uint64                           // this dosen't scale over multiple cores, so assign auto_increment ranges to each shard
-	Collation      string
-	Charset        string
-	Comment        string
+	tableLockMu         sync.Mutex                       // guards cond waits + acquisition
+	tableLockOnce       sync.Once                        // lazy-inits tableLockCond
+	tableLockCond       *sync.Cond                       // broadcast on unlock
+	tableLockNext       uint64                           // next FIFO ticket for LOCK TABLES acquisition
+	tableLockServe      uint64                           // currently served FIFO ticket
+	tableLockOwner      atomic.Pointer[scm.SessionState] // non-nil for a WRITE lock
+	tableLockState      atomic.Int64                     // 0 = unlocked, -1 = WRITE, positive = READ count
+	tableLockReadOwners map[*scm.SessionState]uint32     // guarded by tableLockMu
+	_                   [32]byte                         // separate table locks from insert traffic
+	Auto_increment      uint64                           // this dosen't scale over multiple cores, so assign auto_increment ranges to each shard
+	Collation           string
+	Charset             string
+	Comment             string
 
 	// index column frequency: used to sort equality columns by frequency
 	// so that the most-queried columns come first, maximizing prefix overlap.
@@ -734,19 +736,18 @@ func (t *table) waitTableLock(ss *scm.SessionState, isWrite bool) {
 	t.tableLockMu.Lock()
 	for {
 		owner := t.tableLockOwner.Load()
-		if owner == nil {
-			break
-		}
-		if owner == ss {
-			if !isWrite || t.tableLockWrite.Load() {
-				break // owner can always read; owner can write under WRITE lock
+		state := t.tableLockState.Load()
+		if !isWrite {
+			if state >= 0 || owner == ss {
+				break
 			}
-			// Owner trying to write while holding a READ lock: MySQL returns an error.
+		} else if owner == ss {
+			break
+		} else if t.tableLockReadOwners[ss] != 0 {
 			errMsg = "Can't write to table '" + t.Name + "' while it has a READ lock"
 			break
-		}
-		if !isWrite && !t.tableLockWrite.Load() {
-			break // READ lock doesn't block reads from other sessions
+		} else if state == 0 {
+			break
 		}
 		cond.Wait()
 	}
@@ -756,9 +757,14 @@ func (t *table) waitTableLock(ss *scm.SessionState, isWrite bool) {
 	}
 }
 
-// unlockTable releases the table lock and wakes all waiters.
-func (t *table) unlockTable() {
+func (t *table) hasTableLock() bool {
+	return t.tableLockState.Load() != 0
+}
+
+// unlockTableWrite releases the exclusive table lock and wakes all waiters.
+func (t *table) unlockTableWrite() {
 	t.tableLockOwner.Store(nil)
+	t.tableLockState.Store(0)
 	cond := t.getTableLockCond()
 	t.tableLockMu.Lock()
 	t.tableLockServe++

--- a/tests/execution/concurrency/kill-lock.yaml
+++ b/tests/execution/concurrency/kill-lock.yaml
@@ -1,3 +1,4 @@
+# Copyright (C) 2026 Carl-Philip Haensch
 # KILL QUERY and LOCK TABLES functional tests
 
 metadata:
@@ -168,6 +169,36 @@ test_cases:
           rows: 1
       - session_id: "lock-conc-r3"
         sql: "UNLOCK TABLES"
+
+  - name: "concurrent READ locks share ownership while writers remain blocked"
+    steps:
+      - session_id: "lock-shared-r1"
+        sql: "LOCK TABLES lock_test READ"
+      - session_id: "lock-shared-r2"
+        sql: "LOCK TABLES lock_test READ"
+      - session_id: "lock-shared-writer"
+        sql: "INSERT INTO lock_test VALUES (52, 'after-readers')"
+        background: true
+        expect:
+          rows: 1
+      - session_id: "lock-shared-r1"
+        sql: "SELECT 1"
+      - session_id: "lock-shared-r1"
+        sql: "SELECT 1"
+      - session_id: "lock-shared-r1"
+        sql: "UNLOCK TABLES"
+      - session_id: "lock-shared-r1"
+        sql: "SHOW PROCESSLIST"
+        expect:
+          contains: "Waiting for table lock"
+      - session_id: "lock-shared-r2"
+        sql: "UNLOCK TABLES"
+      - wait_for_background: true
+      - session_id: "lock-shared-r1"
+        sql: "SELECT val FROM lock_test WHERE id = 52"
+        expect:
+          rows: 1
+          contains: "after-readers"
 
   # ── data integrity after concurrent lock cycle ────────────────────────────
 

--- a/tests/storage/persistence/rebuild-kill-shutdown.yaml
+++ b/tests/storage/persistence/rebuild-kill-shutdown.yaml
@@ -1,0 +1,163 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+
+metadata:
+  version: "1.0"
+  description: "Query cancellation, rebuild publication, and shutdown preserve one complete SAFE generation"
+  isolated: true
+
+setup:
+  - scm: (settings "ShardSize" 1000)
+  - sql: "DROP TABLE IF EXISTS rks_rows"
+  - sql: "DROP TABLE IF EXISTS rks_kill_ids"
+  - sql: "DROP TABLE IF EXISTS rks_scan"
+  - sql: "CREATE TABLE rks_rows (id INT PRIMARY KEY, payload TEXT) ENGINE=SAFE"
+  - sql: "CREATE TABLE rks_kill_ids (id BIGINT) ENGINE=MEMORY"
+  - sql: "CREATE TABLE rks_scan (id INT PRIMARY KEY) ENGINE=MEMORY"
+  - scm: |
+      (insert (table "memcp-tests" "rks_rows") '("id" "payload")
+        (map (produceN 20000) (lambda (i)
+          (list (+ i 1) (concat "payload-" (+ i 1))))))
+  - scm: |
+      (insert (table "memcp-tests" "rks_scan") '("id")
+        (map (produceN 800) (lambda (i) (list (+ i 1)))))
+
+test_cases:
+  - name: "Publish the initial SAFE generation"
+    sql: "SHUTDOWN"
+
+  - name: "Initial generation is exact after restart"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+    expect:
+      rows: 1
+      data:
+        - cnt: 20000
+          checksum: 200010000
+
+  - name: "Schema readers only observe complete generations"
+    parallel: rks_schema_publication
+    action: observe_atomic_schema
+    duration: 2.0
+
+  - name: "Publish repeated schema generations"
+    parallel: rks_schema_publication
+    start_delay_ms: 100
+    steps:
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_01 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_02 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_03 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_04 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_05 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_06 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_07 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_08 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_09 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_10 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_11 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_12 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_13 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_14 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_15 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_16 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_17 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_18 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_19 INT"
+      - sql: "ALTER TABLE rks_rows ADD COLUMN schema_probe_20 INT"
+
+  - name: "Add a WAL-backed delta generation"
+    scm: |
+      (insert (table "memcp-tests" "rks_rows") '("id" "payload")
+        (map (produceN 2000) (lambda (i)
+          (list (+ i 20001) (concat "delta-" (+ i 20001))))))
+
+  - name: "Killed scan releases all shard locks"
+    steps:
+      - session_id: "rks-victim"
+        sql: "INSERT INTO rks_kill_ids VALUES (CONNECTION_ID())"
+      - session_id: "rks-victim"
+        sql: "SELECT COUNT(*) FROM rks_scan a, rks_scan b, rks_scan c"
+        background: true
+        expect:
+          error: true
+      - session_id: "rks-killer"
+        sql: "SELECT 1"
+      - session_id: "rks-killer"
+        sql: "SELECT KILL_QUERY(id) FROM rks_kill_ids LIMIT 1"
+      - wait_for_background: true
+      - session_id: "rks-check"
+        sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+        expect:
+          rows: 1
+          data:
+            - cnt: 22000
+              checksum: 242011000
+
+  - name: "Rebuild immediately after query cancellation"
+    scm: '(rebuild (table "memcp-tests" "rks_rows") true false)'
+    timeout: 20
+
+  - name: "Rebuilt generation remains exact"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+    expect:
+      rows: 1
+      data:
+        - cnt: 22000
+          checksum: 242011000
+
+  - name: "Graceful shutdown after killed query and rebuild"
+    sql: "SHUTDOWN"
+    restart_timeout: 30
+
+  - name: "Graceful restart retains the complete generation"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+    expect:
+      rows: 1
+      data:
+        - cnt: 22000
+          checksum: 242011000
+
+  - name: "Rebuild interrupted by hard process crash"
+    parallel: rks_crash_rebuild
+    scm: '(rebuild (table "memcp-tests" "rks_rows") true false)'
+    expect:
+      interrupted_ok: true
+
+  - name: "Crash while rebuild publication is active"
+    parallel: rks_crash_rebuild
+    scm: "(begin (sleep 0.01) (crash))"
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after interrupted rebuild"
+    action: restart
+
+  - name: "Crash recovery selects one complete committed generation"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+    expect:
+      rows: 1
+      data:
+        - cnt: 22000
+          checksum: 242011000
+
+  - name: "Second rebuild succeeds after crash recovery"
+    scm: '(rebuild (table "memcp-tests" "rks_rows") true false)'
+    timeout: 20
+
+  - name: "Second graceful shutdown completes"
+    sql: "SHUTDOWN"
+    restart_timeout: 30
+
+  - name: "Final restart retains exact rows and checksum"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM rks_rows"
+    expect:
+      rows: 1
+      data:
+        - cnt: 22000
+          checksum: 242011000
+
+  - name: "Restore default shard size"
+    scm: (settings "ShardSize" 60000)
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS rks_rows"
+  - sql: "DROP TABLE IF EXISTS rks_kill_ids"
+  - sql: "DROP TABLE IF EXISTS rks_scan"

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -20,12 +20,15 @@
 from pathlib import Path
 from types import SimpleNamespace
 import sys
+import tempfile
+import threading
+import time
 import unittest
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from run_sql_tests import is_error_response  # noqa: E402
+from run_sql_tests import SQLTestRunner, is_error_response, observe_atomic_json  # noqa: E402
 
 
 class ErrorResponseContractTest(unittest.TestCase):
@@ -44,6 +47,90 @@ class ErrorResponseContractTest(unittest.TestCase):
         response = SimpleNamespace(status_code=200, text="Error: invalid query")
         self.assertTrue(is_error_response(response))
 
+
+class AtomicJSONObserverContractTest(unittest.TestCase):
+    def test_accepts_complete_atomic_replacements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schema.json"
+            path.write_text('{"generation": 0}', encoding="utf-8")
+
+            def replace() -> None:
+                for generation in range(1, 30):
+                    candidate = path.with_suffix(".tmp")
+                    candidate.write_text(f'{{"generation": {generation}}}', encoding="utf-8")
+                    candidate.replace(path)
+
+            writer = threading.Thread(target=replace)
+            writer.start()
+            reads, error = observe_atomic_json(path, 0.05)
+            writer.join()
+            self.assertGreater(reads, 0)
+            self.assertIsNone(error)
+
+    def test_rejects_partial_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schema.json"
+            path.write_text('{"generation": 0}', encoding="utf-8")
+
+            def truncate() -> None:
+                time.sleep(0.01)
+                path.write_text('{"generation":', encoding="utf-8")
+
+            writer = threading.Thread(target=truncate)
+            writer.start()
+            reads, error = observe_atomic_json(path, 0.1)
+            writer.join()
+            self.assertGreater(reads, 0)
+            self.assertIsNotNone(error)
+
+    def test_rejects_rename_away_before_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "schema.json"
+            backup = Path(tmp) / "schema.json.old"
+            path.write_text('{"generation": 0}', encoding="utf-8")
+
+            def replace_nonatomically() -> None:
+                time.sleep(0.01)
+                path.replace(backup)
+                path.write_text('{"generation": 1}', encoding="utf-8")
+
+            writer = threading.Thread(target=replace_nonatomically)
+            writer.start()
+            reads, error = observe_atomic_json(path, 0.1)
+            writer.join()
+            self.assertGreater(reads, 0)
+            self.assertIsNotNone(error)
+
+
+class FailFastParallelContractTest(unittest.TestCase):
+    def test_fail_fast_preserves_parallel_groups(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp) / "parallel.yaml"
+            spec.write_text(
+                "metadata:\n"
+                "  description: parallel contract\n"
+                "test_cases:\n"
+                "  - name: first\n"
+                "    parallel: together\n"
+                "  - name: second\n"
+                "    parallel: together\n",
+                encoding="utf-8",
+            )
+            runner = SQLTestRunner("http://localhost:1", fail_fast=True)
+            runner.ensure_database = lambda _database: None
+            barrier = threading.Barrier(2)
+            completed = []
+
+            def run_case(test_case, _database):
+                barrier.wait(timeout=1)
+                completed.append(test_case["name"])
+                runner.test_count += 1
+                runner.test_passed += 1
+                return True
+
+            runner.run_test_case = run_case
+            self.assertTrue(runner.run_test_spec(str(spec)))
+            self.assertCountEqual(completed, ["first", "second"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- publish `schema.json` by fsyncing a same-directory temporary file and atomically replacing the live generation
- retain replaced shard files until the new schema generation has been committed; remove the GC finalizer that could delete the last recoverable generation
- fsync SAFE column files before schema publication
- make source snapshot READ locks shareable and enforce table-lock-before-shard-lock ordering for scans and inserts
- keep the scan hot path to one atomic lock-state load
- make YAML `parallel:` groups remain concurrent under fail-fast and add an atomic-schema observer
- add YAML coverage for KILL QUERY, rebuild, crash, graceful shutdown/restart, exact row checksums, and concurrent READ locks

No Go tests were added or changed.

## Root cause

Schema persistence renamed the live schema away before creating its replacement. A crash could therefore leave no current schema, while a rebuild finalizer could remove files still referenced by the last committed schema. Separately, mutation paths could wait for a table lock while already holding a shard lock, creating a lock-order cycle with consistent cache snapshots. The test runner also serialized declared parallel groups in fail-fast mode, so the relevant concurrency was not exercised in CI.

## Validation

- new rebuild/kill/shutdown YAML suite: 18/18; exact 22,000 rows and checksum 242,011,000 after graceful and crash restarts
- lock/KILL YAML suite: 27/27
- concurrent rebuild suite: 16/16
- runner contract tests: 8/8
- SQL guards and table-name guard: green
- full hook-equivalent run completed all suites and coverage; all functional suites passed, with one existing `order-limit.yaml` 5 s performance gate at 5.188 s on the loaded host

## A/B

On unmodified current master, the atomic-schema observer failed deterministically after 2,086 successful reads with `IN_MOVED_FROM` on the live schema target. This branch completes the 18/18 lifecycle suite without any missing, empty, or partial schema generation.

With identical coverage builds, the existing 200k-row ORDER setup measured 9.621 s on master and 9.628 s on this branch under current host load, so the local 5 s gate failure is already present on master and the final single-atomic lock probe adds no measurable regression.