### PR TITLE
Optimize conditional zero-one aggregates

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -346,6 +346,53 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(make_query_block schema sources fields where group having order limit offset '() '() '())
 		_ query)))
 
+/* SUM(CASE WHEN predicate THEN 0 ELSE 1 END) is a conditional count, but
+SQL SUM still returns NULL for an empty input. Keep that distinction explicit
+in the logical expression and lower the per-row marker to a primitive IF only
+when aggregate input is emitted. In particular, FALSE and UNKNOWN both select
+the ELSE arm; rewriting this as (not predicate) would be NULL-incorrect. */
+(define sql_conditional_count_result (lambda (row_count true_count count_when_true)
+	(if (equal? row_count 0)
+		nil
+		(if count_when_true true_count (- row_count true_count)))))
+
+(define filtered_count (lambda (predicate)
+	(if predicate 1 0)))
+
+(define conditional_count_aggregate_rewrite (lambda (agg_expr agg_reduce agg_neutral)
+	(if (and (equal? agg_reduce (quote sql_sum_reduce)) (nil? agg_neutral))
+		(match agg_expr
+			((symbol if) predicate 0 1) (list predicate false)
+			((quote if) predicate 0 1) (list predicate false)
+			((symbol if) predicate 1 0) (list predicate true)
+			((quote if) predicate 1 0) (list predicate true)
+			_ nil)
+		nil)))
+
+(define normalize_conditional_count_aggregates (lambda (expr)
+	(match expr
+		((symbol aggregate) agg_expr agg_reduce agg_neutral)
+		(begin
+			(define parts (conditional_count_aggregate_rewrite agg_expr agg_reduce agg_neutral))
+			(if (nil? parts)
+				(list (quote aggregate)
+					(normalize_conditional_count_aggregates agg_expr)
+					agg_reduce
+					agg_neutral)
+				(list (quote sql_conditional_count_result)
+					(list (quote aggregate) 1 (quote +) 0)
+					(list (quote aggregate)
+						(list (quote filtered_count)
+							(normalize_conditional_count_aggregates (car parts)))
+						(quote +)
+						0)
+					(cadr parts))))
+		((quote aggregate) agg_expr agg_reduce agg_neutral)
+		(normalize_conditional_count_aggregates
+			(list (quote aggregate) agg_expr agg_reduce agg_neutral))
+		(cons head tail) (cons head (map tail normalize_conditional_count_aggregates))
+		_ expr)))
+
 (define query_block_no_from? (lambda (node)
 	(and (query_block? node)
 		(empty_list? (qb_sources node))
@@ -8189,7 +8236,16 @@ dependency preparation does not emit free outer-row symbols. */
 (define aggregate_map_value_expr (lambda (ag expr)
 	(if (count_distinct_descriptor? ag)
 		(list (quote cons) expr (list (quote list)))
-		expr)))
+		(match expr
+			((symbol filtered_count) predicate) (list (quote if) predicate 1 0)
+			((quote filtered_count) predicate) (list (quote if) predicate 1 0)
+			_ expr))))
+
+(define filtered_count_parts (lambda (expr)
+	(match expr
+		((symbol filtered_count) predicate) (list predicate)
+		((quote filtered_count) predicate) (list predicate)
+		_ nil)))
 
 (define extract_aggregates (lambda (expr)
 	(match expr
@@ -9091,10 +9147,14 @@ ever-larger subtrees. */
 		'(agg_expr agg_reduce agg_neutral) (begin
 			(define src (list alias schema tbl false nil))
 			(define agg_col (aggregate_col_name ag))
+			(define filtered_parts (filtered_count_parts agg_expr))
+			(define aggregate_condition (if (nil? filtered_parts)
+				condition
+				(list (quote and) condition (car filtered_parts))))
 			(define group_key_cols_for_scan (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
-			(define condition_cols (extract_columns_for_alias src condition))
+			(define condition_cols (extract_columns_for_alias src aggregate_condition))
 			(define filtercols (merge_unique (list group_key_cols_for_scan condition_cols)))
-			(define aggcols (extract_columns_for_alias src agg_expr))
+			(define aggcols (if (nil? filtered_parts) (extract_columns_for_alias src agg_expr) '()))
 			(list (quote createcolumn)
 				(list (quote table) schema grouptbl)
 				agg_col
@@ -9112,12 +9172,14 @@ ever-larger subtrees. */
 							(map filtercols (lambda (col) (symbol (concat alias "." col))))
 							(list (quote optimize)
 								(cons (quote and) (cons
-									(lower_column_expr_for_alias src condition)
+									(lower_column_expr_for_alias src aggregate_condition)
 									(group_key_equality_terms alias key_names keys)))))
 						(cons (quote list) aggcols)
 						(list (quote lambda)
 							(map aggcols (lambda (col) (symbol (concat alias "." col))))
-							(aggregate_map_value_expr ag (lower_column_expr_for_alias src agg_expr)))
+							(if (nil? filtered_parts)
+								(aggregate_map_value_expr ag (lower_column_expr_for_alias src agg_expr))
+								1))
 						agg_reduce
 						agg_neutral
 						(aggregate_shard_combine ag)
@@ -13988,7 +14050,11 @@ build_queryplan contract. */
 (define neumann_compile_pipeline (lambda (ast)
 	(build_queryplan
 		(join_reorder
-			(untangle_query_term (sanitize_temporal_outputs (sanitize_decimal_aggregate_outputs ast)) nil)))))
+			(untangle_query_term
+				(sanitize_temporal_outputs
+					(sanitize_decimal_aggregate_outputs
+						(normalize_conditional_count_aggregates ast)))
+				nil)))))
 
 (define neumann_compile_ir_pipeline (lambda (ir)
 	(build_queryplan

--- a/tests/planner/aggregates/incremental-aggregates.yaml
+++ b/tests/planner/aggregates/incremental-aggregates.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
 # Incremental aggregate tests.
 # Validates that GROUP BY aggregate caches produce correct results after
 # INSERT, UPDATE, and DELETE on the source table.
@@ -723,6 +725,85 @@ test_cases:
   # Cleanup filter test rows
   - name: "Cleanup filter test rows"
     sql: "DELETE FROM ia_data WHERE id IN (16, 17)"
+
+  # ============================================================
+  # Section 8b: conditional SUM lowered to filtered counts
+  # ============================================================
+  - name: "Conditional zero-one SUM preserves FALSE and UNKNOWN"
+    sql: |
+      SELECT grp,
+             SUM(CASE WHEN nullable_val = 10 THEN 0 ELSE 1 END) AS rejected
+      FROM ia_data
+      GROUP BY grp
+      ORDER BY grp
+    expect:
+      rows: 3
+      data:
+        - { grp: "A", rejected: 1 }
+        - { grp: "B", rejected: 2 }
+        - { grp: "C", rejected: 1 }
+
+  - name: "Conditional zero-one SUM preserves zero and empty identities"
+    sql: |
+      SELECT
+        SUM(CASE WHEN val > 0 THEN 0 ELSE 1 END) AS no_rejections,
+        (SELECT SUM(CASE WHEN val > 0 THEN 0 ELSE 1 END)
+         FROM ia_data
+         WHERE FALSE) AS empty_sum
+      FROM ia_data
+    expect:
+      rows: 1
+      data:
+        - no_rejections: 0
+          empty_sum: null
+
+  - name: "Conditional one-zero SUM counts only TRUE"
+    sql: |
+      SELECT grp,
+             SUM(CASE WHEN nullable_val = 10 THEN 1 ELSE 0 END) AS accepted
+      FROM ia_data
+      GROUP BY grp
+      ORDER BY grp
+    expect:
+      rows: 3
+      data:
+        - { grp: "A", accepted: 1 }
+        - { grp: "B", accepted: 0 }
+        - { grp: "C", accepted: 0 }
+
+  - name: "EXPLAIN conditional zero-one SUM uses a filtered count"
+    sql: |
+      EXPLAIN SELECT grp,
+        SUM(CASE WHEN nullable_val = 10 THEN 0 ELSE 1 END) AS rejected
+      FROM ia_data
+      GROUP BY grp
+    expect:
+      rows: 1
+      result_contains:
+        - "sql_conditional_count_result"
+        - "touch_keytable"
+      result_not_contains:
+        - "sql_sum_reduce"
+
+  - name: "Conditional zero-one SUM updates after predicate change"
+    sql: "UPDATE ia_data SET nullable_val = NULL WHERE id = 1"
+
+  - name: "Conditional zero-one SUM reuses updated aggregate cache"
+    sql: |
+      SELECT grp,
+             SUM(CASE WHEN nullable_val = 10 THEN 0 ELSE 1 END) AS rejected
+      FROM ia_data
+      GROUP BY grp
+      ORDER BY grp
+    expect:
+      rows: 3
+      data:
+        - { grp: "A", rejected: 2 }
+        - { grp: "B", rejected: 2 }
+        - { grp: "C", rejected: 1 }
+
+  - name: "Restore conditional aggregate source value"
+    sql: "UPDATE ia_data SET nullable_val = 10 WHERE id = 1"
 
   # ============================================================
   # Section 9: Rapid successive DML (burst invalidation)


### PR DESCRIPTION
## Summary

- normalize `SUM(CASE WHEN predicate THEN 0 ELSE 1 END)` and the inverse 1/0 form to a logical conditional count before unnesting
- preserve SQL three-valued and empty-input semantics by computing either `true_count` or `row_count - true_count`, returning `NULL` when `row_count = 0`
- lower cache-column materialization to the existing filtered `scan` with constant payload `1`; no new physical operator
- add anonymous YAML regressions for `FALSE`/`UNKNOWN`, empty scalar SUM, inverse 1/0 form, plan shape, and incremental invalidation

## Plan change

Master materializes the conditional aggregate column by scanning every row and reducing `CASE ... 0/1` through `sql_sum_reduce`. This branch keeps total count and true count in the same cold group initializer, uses primitive `+`, and materializes the conditional cache column through a predicate-filtered scan. The final 0/1 SUM identity is reconstructed from the two counts.

## A/B measurements

Same host, fresh MemCP processes and data directories, identical synthetic tables. Query shape: 500 groups over 50,000 rows, with 0.2% predicate selectivity. Three fresh table names avoid group-cache reuse between samples.

| phase | master | branch | delta |
|---|---:|---:|---:|
| cold query / group-cache creation, median | 488.7 ms | 611.2 ms | +25.1% |
| first conditional aggregate cache read, median | 166.9 ms | 3.0 ms | -98.2% / 55.6x faster |
| subsequent warm read, median | 2.63 ms | 2.71 ms | +3.0% (noise range) |

Raw samples in seconds:

- master cold: `0.499208`, `0.481435`, `0.488743`
- branch cold: `0.605851`, `0.626428`, `0.611164`
- master first conditional read: `0.168433`, `0.166868`, `0.163773`
- branch first conditional read: `0.003010`, `0.003354`, `0.003031`

The intentional trade-off is a roughly 25% slower first group-cache construction because the plan maintains total and true counts. It removes the later full-table CASE/SUM materialization and makes the first selective aggregate lookup roughly 50x faster. Repeated cache reads are unchanged within measurement noise.

## Validation

- `python3 tools/lint_scm.py --check` (passes with the repository's existing depth warnings)
- `python3 run_sql_tests.py tests/planner/aggregates/incremental-aggregates.yaml`: 115/115 passed
- `python3 run_sql_tests.py tests/execution/concurrency/rebuild-concurrent.yaml`: 16/16 passed in 1.1s
- full `make test` progressed through all displayed suites without a failure, then stalled in the shared-process run of `rebuild-concurrent.yaml` with old requests waiting on table locks; stopped after >8 minutes. The same suite passed immediately in isolation as noted above. CI should validate in its clean environment.
