### PR TITLE
Canonicalize membership and cost physical strategies

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -96,21 +96,76 @@ output and is not a physical RecSet or scan. Canonicalization may flatten
 `CASE`, projection, or another value-producing context; those retain the full
 match/RHS-NULL representation required for three-valued logic.
 
-For physical optimization, the following positive-truth equivalence may be
-used in either direction:
+### RecSet algebra as an optimization proof system
+
+RecSets provide a general way to discover and justify physical formula
+rewrites. For a fixed base relation `R`, define `T_R(p)` as the exact set of
+record IDs for which predicate `p` is SQL `TRUE`. In a truth-filtering context:
 
 ```
-RecSet(IN(UNION branches))
-  == union(RecSet(branch) ...)
-  == RecSet(OR(EXISTS branches))
+T_R(false)   = empty
+T_R(true)    = all visible records of R
+T_R(p OR q)  = T_R(p) union T_R(q)
+T_R(p AND q) = T_R(p) intersect T_R(q)
+p implies q  => T_R(p) is a subset of T_R(q)
 ```
 
-This is an optimization axiom, not permission to special-case the original SQL
-shape in physical lowering. New syntactic corner cases should normalize to the
-existing membership primitive; the common lowerer then chooses indexed
-existence probes, projected RecSets, driver order, and braking from statistics.
-The equivalence does not apply unchanged to `NOT IN` or value-producing SQL-3VL
-contexts.
+Ordinary set identities such as associativity, commutativity, distributivity,
+absorption, and factoring may therefore be used to generate equivalent
+candidate plans. For example,
+`(A intersect B) union (A intersect C) = A intersect (B union C)` can expose one
+shared selective scan instead of two. The optimizer should enumerate useful
+equivalent RecSet formulas, cost them, and lower the cheapest supported one.
+This is a general optimization method, not a rule tied to one SQL spelling.
+
+A physical candidate RecSet need not always be exact. If `C_R(p)` is only a
+proven superset of `T_R(p)`, it is a safe scan boundary only while the original
+predicate `p` remains as a residual filter. This permits cheap projections or
+partially extracted branches to reduce the search space without claiming a
+stronger equivalence than was proved. Union/intersection operands must refer to
+the same base relation and visibility snapshot.
+
+Containment proofs compose monotonically:
+
+```
+C_R(p) contains T_R(p), C_R(q) contains T_R(q)
+  => C_R(p) union C_R(q) contains T_R(p OR q)
+  => C_R(p) intersect C_R(q) contains T_R(p AND q)
+```
+
+Every RecSet rewrite must therefore record or establish whether its result is
+exact or merely a candidate, identify its base relation and snapshot, and keep
+the residual predicate unless exactness has been proved. Formula equality is
+not by itself permission to change result multiplicity, ordering, NULL
+extension, or LIMIT boundaries; RecSets prove which base records may be scanned,
+not how often or in which semantic order result rows are produced.
+
+Semijoins extend the same algebra across relations. If `S` is an exact or safe
+candidate RecSet on a source relation, projecting `S` through join keys to `R`
+produces the corresponding exact or candidate target RecSet. Duplicate source
+keys do not matter because RecSets contain record IDs, not result multiplicity.
+This is why membership, EXISTS, joins, and boolean filter clouds can share
+physical RecSet optimization even when their parser ASTs differ.
+
+As one instance of the general rules, for probe expression `x` and UNION
+branches `Q_i`, positive membership permits:
+
+```
+T_R(x IN (Q_1 UNION ... UNION Q_n))
+  = union(T_R(x IN Q_i) for each i)
+  = T_R(EXISTS(Q_1 matching x) OR ... OR EXISTS(Q_n matching x))
+```
+
+That example is not the axiom itself. New syntactic corner cases should
+normalize to semantic primitives; RecSet algebra then supplies transformations
+and proof obligations, and the common lowerer chooses indexed probes, projected
+RecSets, driver order, and braking from statistics.
+
+Complement and difference require extra care under SQL three-valued logic:
+`T_R(NOT p)` is not generally the complement of `T_R(p)` because `UNKNOWN` is
+in neither truth set. Such rewrites require a proven two-valued predicate or an
+explicit representation of FALSE and UNKNOWN. Consequently these identities
+do not apply unchanged to `NOT IN`, `NOT`, or value-producing SQL-3VL contexts.
 
 `build_queryplan` chooses the physical implementation after decorrelation and
 reordering. The same logical helper may lower to a group cache, direct scan,

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -111,12 +111,14 @@ p implies q  => T_R(p) is a subset of T_R(q)
 ```
 
 Ordinary set identities such as associativity, commutativity, distributivity,
-absorption, and factoring may therefore be used to generate equivalent
-candidate plans. For example,
+absorption, and factoring may therefore be used by planner developers to find
+and prove useful normalizations. For example,
 `(A intersect B) union (A intersect C) = A intersect (B union C)` can expose one
-shared selective scan instead of two. The optimizer should enumerate useful
-equivalent RecSet formulas, cost them, and lower the cheapest supported one.
-This is a general optimization method, not a rule tied to one SQL spelling.
+shared selective scan instead of two. Once such a transformation is proved, it
+belongs as a recognized pattern in a normalization pass over semantic
+primitives. The optimizer is not required to search arbitrary set formulas at
+query-compilation time. This is a general method for extending the optimizer,
+not a rule tied to one SQL spelling and not a mandate to execute a RecSet.
 
 A physical candidate RecSet need not always be exact. If `C_R(p)` is only a
 proven superset of `T_R(p)`, it is a safe scan boundary only while the original
@@ -157,9 +159,11 @@ T_R(x IN (Q_1 UNION ... UNION Q_n))
 ```
 
 That example is not the axiom itself. New syntactic corner cases should
-normalize to semantic primitives; RecSet algebra then supplies transformations
-and proof obligations, and the common lowerer chooses indexed probes, projected
-RecSets, driver order, and braking from statistics.
+normalize to semantic primitives. Developers may use RecSet algebra to derive
+and prove further normalization patterns; the common lowerer must still choose
+between ordinary scans with indexed probes, projected RecSets, driver order,
+and braking from statistics. A normalization justified using truth sets must
+never preselect RecSet execution.
 
 Complement and difference require extra care under SQL three-valued logic:
 `T_R(NOT p)` is not generally the complement of `T_R(p)` because `UNKNOWN` is

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -88,6 +88,30 @@ possible later, for example:
 - `preserve_empty_domain`
 - order/window/group facts
 
+Positive membership in a WHERE truth context may use the semantic
+`membership_truth` expression primitive. It references a logical group-stage
+output and is not a physical RecSet or scan. Canonicalization may flatten
+`IN (… UNION …)` to a n-ary OR of these primitives because SQL `UNKNOWN` and
+`FALSE` both reject the row in that context. This rewrite must not cross `NOT`,
+`CASE`, projection, or another value-producing context; those retain the full
+match/RHS-NULL representation required for three-valued logic.
+
+For physical optimization, the following positive-truth equivalence may be
+used in either direction:
+
+```
+RecSet(IN(UNION branches))
+  == union(RecSet(branch) ...)
+  == RecSet(OR(EXISTS branches))
+```
+
+This is an optimization axiom, not permission to special-case the original SQL
+shape in physical lowering. New syntactic corner cases should normalize to the
+existing membership primitive; the common lowerer then chooses indexed
+existence probes, projected RecSets, driver order, and braking from statistics.
+The equivalence does not apply unchanged to `NOT IN` or value-producing SQL-3VL
+contexts.
+
 `build_queryplan` chooses the physical implementation after decorrelation and
 reordering. The same logical helper may lower to a group cache, direct scan,
 `scan_exists`, RecSet, ORC, `scan_order_multi`, or temp table depending on

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7245,7 +7245,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(cons head tail) (merge_unique (map tail (lambda (item) (extract_columns_for_alias src item))))
 		_ '())))
 
-(define lower_column_expr_for_alias (lambda (src expr)
+(define lower_column_expr_for_alias_in_context (lambda (src expr probe_work_rows)
 	(match expr
 		((symbol driver_membership_probe) stage probe)
 		(lower_driver_membership_probe_expr (list src) (source_alias src) stage probe)
@@ -7256,13 +7256,13 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		((quote dml_driver_membership_probe) fallback_schema stage probe)
 		(lower_dml_driver_membership_probe_expr (list src) (source_alias src) fallback_schema stage probe)
 		((symbol scalar_first_probe) stage requested_col)
-		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col (list stage))
+		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col (list stage) probe_work_rows)
 		((symbol scalar_first_probe) stage requested_col stages)
-		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col stages)
+		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col stages probe_work_rows)
 		((quote scalar_first_probe) stage requested_col)
-		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col (list stage))
+		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col (list stage) probe_work_rows)
 		((quote scalar_first_probe) stage requested_col stages)
-		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col stages)
+		(lower_scalar_first_probe_expr (list src) (source_alias src) stage requested_col stages probe_work_rows)
 		((symbol scalar_aggregate_probe) stage requested_col)
 		(lower_scalar_aggregate_probe_expr (list src) (source_alias src) stage requested_col)
 		((quote scalar_aggregate_probe) stage requested_col)
@@ -7273,8 +7273,12 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 		(lower_scalar_cardinality_probe_expr (list src) (source_alias src) stage requested_col)
 		((symbol get_column) tblvar tbl_ignorecase col col_ignorecase) (symbol (concat (resolve_column_alias tblvar (source_alias src)) "." (resolve_physical_column_name src col col_ignorecase)))
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase) (symbol (concat (resolve_column_alias tblvar (source_alias src)) "." (resolve_physical_column_name src col col_ignorecase)))
-		(cons head tail) (cons head (map tail (lambda (item) (lower_column_expr_for_alias src item))))
+		(cons head tail) (cons head (map tail (lambda (item)
+			(lower_column_expr_for_alias_in_context src item probe_work_rows))))
 		_ expr)))
+
+(define lower_column_expr_for_alias (lambda (src expr)
+	(lower_column_expr_for_alias_in_context src expr nil)))
 
 (define scalar_first_probe_parts (lambda (ag)
 	(match ag
@@ -7483,21 +7487,47 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 					(list (quote coalesceNil) raw_probe false)
 					raw_probe))))))
 
-(define lower_scalar_first_query_probe_expr (lambda (all_stages stage value_expr keys lookup_keys)
+(define bounded_scalar_query_probe_inline_presence_stages (lambda (direct_stages probe_work_rows)
+	(if (not (equal? (count direct_stages) 1))
+		'()
+		(filter direct_stages (lambda (nested_stage)
+			(if (not (group_stage? nested_stage))
+				false
+				(begin
+					(define stage_rows (planner_stage_input_rows (gs_input nested_stage)))
+					(define cache_preferred (and (number? stage_rows)
+						(and (number? probe_work_rows)
+							(< (+ 16 stage_rows) (* probe_work_rows 4)))))
+					(and (not cache_preferred)
+						(and (equal? (qassoc_get (gs_facts nested_stage) (quote purpose) nil) (quote exists))
+							(and (equal? (qassoc_get (gs_facts nested_stage) (quote presence_only) false) true)
+								(and (source_is_base_table? (gs_input nested_stage))
+									(not (stage_has_residual_outer_refs? nested_stage)))))))))))))
+
+(define lower_scalar_first_query_probe_expr (lambda (all_stages stage value_expr keys lookup_keys probe_work_rows)
 	(begin
 		(define direct_stages (scalar_first_query_probe_direct_nested_stages all_stages stage))
 		(define dependency_graph (stage_dependency_graph all_stages))
 		(define closure_index (stage_dependency_closure_index_using_graph dependency_graph direct_stages))
 		(define nested_stages
 			(scalar_first_query_probe_nested_stages_using_index direct_stages closure_index))
+		/* A bounded parent probe evaluates this subtree only for rows that survived
+		root braking. Compare those expected probe calls with the dependent stage's
+		input size; retain the group cache when repeated probes amortize its build. */
+		(define inline_presence_stages (if (number? probe_work_rows)
+			(bounded_scalar_query_probe_inline_presence_stages direct_stages probe_work_rows)
+			'()))
+		(define inline_ids (stage_id_set inline_presence_stages))
+		(define prepare_stages (filter nested_stages (lambda (nested_stage)
+			(not (has_assoc? inline_ids (gs_id nested_stage))))))
 		(lower_scalar_first_query_probe_expr_using
 			stage
 			value_expr
 			keys
 			lookup_keys
 			nested_stages
-			nested_stages
-			'()))))
+			prepare_stages
+			inline_presence_stages))))
 
 /* Query-input scalar probes can occur in many projected fields after their
 logical stages have merged. Emit the physical probe recipe once per block and
@@ -7743,9 +7773,10 @@ dependency preparation does not emit free outer-row symbols. */
 			(lower_unique_stage_prepares_using stages stages stages)
 			(lower_stage_materialize_all stages))))))
 
-(define lower_exists_union_probe_branch (lambda (sources default_alias branch probe all_stages)
+(define lower_exists_union_probe_branch (lambda (sources default_alias branch probe all_stages dependency_graph)
 	(begin
-		(define prepared (query_block_with_prepared_sources_using all_stages branch))
+		(define prepared
+			(query_block_with_prepared_sources_using_graph all_stages dependency_graph branch))
 		(if (not (and (query_block? prepared) (single_source? (qb_sources prepared))))
 			(neumann_fail "build_queryplan" "EXISTS UNION point probe requires one prepared branch source")
 			true)
@@ -7755,6 +7786,12 @@ dependency preparation does not emit free outer-row symbols. */
 			true)
 		(define key_expr (query_block_first_expr prepared))
 		(define condition (combine_where (qb_where prepared) (source_join_expr src)))
+		(define source_rows (planner_source_row_count src))
+		(define probe_term (list (quote equal??) key_expr probe))
+		(define probe_work_rows (if (number? source_rows)
+			(max 1 (* source_rows
+				(join_optimizer_expr_selectivity (list src) (source_alias src) probe_term)))
+			1))
 		(define filtercols (merge_unique (list
 			(extract_columns_for_alias src condition)
 			(extract_columns_for_alias src key_expr))))
@@ -7766,7 +7803,7 @@ dependency preparation does not emit free outer-row symbols. */
 				(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
 				(list (quote optimize)
 					(list (quote and)
-						(lower_column_expr_for_alias src condition)
+						(lower_column_expr_for_alias_in_context src condition probe_work_rows)
 						(list (quote equal??)
 							(lower_column_expr_for_alias src key_expr)
 							(lower_column_expr_for_join sources default_alias probe)))))))))
@@ -7775,11 +7812,21 @@ dependency preparation does not emit free outer-row symbols. */
 one n-ary physical OR of bounded probes. This preserves the logical union tree
 until lowering without creating a depth-proportional binary OR chain. */
 (define lower_exists_union_probe_expr (lambda (sources default_alias branches probe all_stages)
-	(cons (quote or)
-		(map (coalesceNil branches '()) (lambda (branch)
-			(lower_exists_union_probe_branch sources default_alias branch probe all_stages))))))
+	(begin
+		/* All branches resolve against the same immutable decorrelation catalog.
+		Build its indexes once instead of rediscovering the complete stage set for
+		every arm of a wide UNION. */
+		(define branch_stages (merge (map (coalesceNil branches '()) (lambda (branch)
+			(if (query_block? branch) (qb_stages branch) '())))))
+		(define stage_lookup
+			(make_lowering_catalog (unique_stages_by_id (merge (list all_stages branch_stages)))))
+		(define dependency_graph (stage_dependency_graph stage_lookup))
+		(cons (quote or)
+			(map (coalesceNil branches '()) (lambda (branch)
+				(lower_exists_union_probe_branch
+					sources default_alias branch probe stage_lookup dependency_graph)))))))
 
-(define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages)
+(define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages probe_work_rows)
 	(begin
 		(if (not (scalar_or_presence_probe_stage? stage))
 			(neumann_fail "build_queryplan" "stage probe requires scalar_single first or presence stage")
@@ -7813,7 +7860,8 @@ until lowering without creating a depth-proportional binary OR chain. */
 					stage
 					value_expr
 					keys
-					(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key))))
+					(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key)))
+					probe_work_rows)
 				(begin
 					(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
 					(define condition_cols (extract_columns_for_alias src condition))
@@ -8002,13 +8050,13 @@ until lowering without creating a depth-proportional binary OR chain. */
 		((quote dml_driver_membership_probe) fallback_schema stage probe)
 		(lower_dml_driver_membership_probe_expr sources default_alias fallback_schema stage probe)
 		((symbol scalar_first_probe) stage requested_col)
-		(lower_scalar_first_probe_expr sources default_alias stage requested_col (list stage))
+		(lower_scalar_first_probe_expr sources default_alias stage requested_col (list stage) nil)
 		((symbol scalar_first_probe) stage requested_col stages)
-		(lower_scalar_first_probe_expr sources default_alias stage requested_col stages)
+		(lower_scalar_first_probe_expr sources default_alias stage requested_col stages nil)
 		((quote scalar_first_probe) stage requested_col)
-		(lower_scalar_first_probe_expr sources default_alias stage requested_col (list stage))
+		(lower_scalar_first_probe_expr sources default_alias stage requested_col (list stage) nil)
 		((quote scalar_first_probe) stage requested_col stages)
-		(lower_scalar_first_probe_expr sources default_alias stage requested_col stages)
+		(lower_scalar_first_probe_expr sources default_alias stage requested_col stages nil)
 		((symbol scalar_aggregate_probe) stage requested_col)
 		(lower_scalar_aggregate_probe_expr sources default_alias stage requested_col)
 		((quote scalar_aggregate_probe) stage requested_col)
@@ -10705,7 +10753,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(if insensitive (quote insensitive) (quote exact))
 		(if (and insensitive (string? alias)) (toLower alias) alias))))
 
-(define probe_stage_alias_index (lambda (stages sources consumers)
+(define probe_stage_alias_index_using_graph (lambda (stages dependency_graph sources consumers)
 	(begin
 		(define entries (filter (map (coalesceNil sources '()) (lambda (src)
 			(begin
@@ -10719,8 +10767,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 					nil))))
 			(lambda (entry) (not (nil? entry)))))
 		(define probe_stages (unique_stages_by_id (map entries (lambda (entry) (nth entry 1)))))
-		(define closures (stage_dependency_closure_index_using_graph
-			(stage_dependency_graph stages) probe_stages))
+		(define closures (stage_dependency_closure_index_using_graph dependency_graph probe_stages))
 		(reduce entries (lambda (index entry)
 			(begin
 				(define src (nth entry 0))
@@ -10738,6 +10785,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 					(if (has_assoc? with_exact insensitive_key)
 						with_exact
 						(set_assoc with_exact insensitive_key index_entry))))) '()))))
+
+(define probe_stage_alias_index (lambda (stages sources consumers)
+	(probe_stage_alias_index_using_graph
+		stages (stage_dependency_graph stages) sources consumers)))
 
 (define probe_stage_entry_for_alias_using_index (lambda (index default_alias tblvar tbl_ignorecase)
 	(get_assoc index
@@ -11389,14 +11440,17 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 	(stages_without_consumed_probes_using_graph
 		(stage_dependency_graph stages) stages stages)))
 
-(define stages_without_probe_sources (lambda (stages probe_sources)
+(define stages_without_probe_sources_using_graph (lambda (dependency_graph stage_lookup stages probe_sources)
 	(begin
-		(define graph (stage_dependency_graph stages))
-		(define consumed (stages_without_consumed_probes_using_graph graph stages
-			(stage_outputs_from_sources_using stages probe_sources)))
+		(define consumed (stages_without_consumed_probes_using_graph dependency_graph stages
+			(stage_outputs_from_sources_using stage_lookup probe_sources)))
 		(define direct_ids (stage_output_source_ids (filter probe_sources (lambda (src)
-			(not (nil? (direct_group_probe_stage_for_source stages src (list true))))))))
+			(not (nil? (direct_group_probe_stage_for_source stage_lookup src (list true))))))))
 		(stages_without_ids consumed direct_ids))))
+
+(define stages_without_probe_sources (lambda (stages probe_sources)
+	(stages_without_probe_sources_using_graph
+		(stage_dependency_graph stages) stages stages probe_sources)))
 
 (define query_block_probe_consumers (lambda (block)
 	(list
@@ -11407,7 +11461,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(qb_order block)
 		(qb_hidden block))))
 
-(define query_block_with_scalar_first_probes_using (lambda (stages block)
+(define query_block_with_scalar_first_probes_using_graph (lambda (stages dependency_graph block)
 	(begin
 		(define stage_list (lowering_catalog_stages stages))
 		(define sources (qb_sources block))
@@ -11434,7 +11488,8 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(define probe_sources (if (nil? retained_order_alias)
 			probe_candidates
 			(merge_unique (list probe_candidates (list (nth order_lookup 0))))))
-		(define probe_index (probe_stage_alias_index stages probe_sources consumers))
+		(define probe_index
+			(probe_stage_alias_index_using_graph stages dependency_graph probe_sources consumers))
 		(define rewritten_sources (rewrite_scalar_first_probe_sources_using_index stages sources probe_index default_alias))
 		(make_query_block
 			(qb_schema block)
@@ -11447,10 +11502,15 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(qb_limit block)
 			(qb_offset block)
 			(rewrite_scalar_first_probe_fields_using_index stages probe_index default_alias (qb_hidden block))
-			(stages_without_probe_sources (qb_stages block) probe_sources)
+			(stages_without_probe_sources_using_graph
+				dependency_graph stages (qb_stages block) probe_sources)
 			(join_optimizer_facts_without_aliases
 				(query_block_facts_with_stage_catalog block stage_list)
 				(map probe_sources source_alias))))))
+
+(define query_block_with_scalar_first_probes_using (lambda (stages block)
+	(query_block_with_scalar_first_probes_using_graph
+		stages (stage_dependency_graph stages) block)))
 
 (define query_block_with_presence_probe_sources_using (lambda (stages probe_sources block)
 	(begin
@@ -11551,13 +11611,14 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			'()
 			(qb_facts block)))))
 
-(define query_block_with_prepared_sources_using (lambda (stages block)
+(define query_block_with_prepared_sources_using_graph (lambda (stages dependency_graph block)
 	(begin
 		(define available_stages (if (lowering_catalog? stages)
 			(lowering_catalog_stages stages)
 			(unique_stages_by_id (merge (list stages (qb_stages block))))))
 		(define stage_lookup (if (lowering_catalog? stages) stages available_stages))
-		(define scalar_rewritten (query_block_with_scalar_first_probes_using stage_lookup block))
+		(define scalar_rewritten
+			(query_block_with_scalar_first_probes_using_graph stage_lookup dependency_graph block))
 		(define membership_rewritten (query_block_with_physical_membership_using stage_lookup scalar_rewritten))
 		(define sources (qb_sources membership_rewritten))
 		(define default_alias (qassoc_get (qb_facts membership_rewritten) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
@@ -11574,8 +11635,13 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(qb_limit rewritten)
 			(qb_offset rewritten)
 			(qb_hidden rewritten)
-			(stages_without_probe_sources (qb_stages rewritten) presence_probe_sources)
+			(stages_without_probe_sources_using_graph
+				dependency_graph stage_lookup (qb_stages rewritten) presence_probe_sources)
 			(query_block_facts_with_stage_catalog rewritten available_stages)))))
+
+(define query_block_with_prepared_sources_using (lambda (stages block)
+	(query_block_with_prepared_sources_using_graph
+		stages (stage_dependency_graph stages) block)))
 
 (define query_block_with_prepared_sources (lambda (block)
 	(query_block_with_prepared_sources_using (qb_stages block) block)))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1749,16 +1749,19 @@ physical membership probe. */
 
 /* Canonicalization is the only layer that should know IN was written over a
 UNION. In positive WHERE truth context, each branch becomes one membership
-alternative and the result is a flat n-ary OR. This deliberately gives naive
-lowering the short-circuit behavior of OR(EXISTS ...), while preserving the
-optimization axiom
+alternative and the result is a flat n-ary OR. This gives naive lowering the
+short-circuit behavior of OR(EXISTS ...) while exposing one application of the
+general RecSet algebra documented in INVARIANTS.md:
 
-RecSet(IN(UNION branches)) == union(RecSet(branch) ...)
-== RecSet(OR(EXISTS branches)).
+T_R(p OR q) = T_R(p) union T_R(q).
 
-Thus a later lowerer may fuse the alternatives back into RecSets without
-depending on the original SQL spelling. NOT IN and scalar/CASE consumers stay
-on the 3VL path and must not use this positive-truth equivalence. */
+The useful invariant is the general algebra and its proof obligations, not an
+IN/UNION special-case identity. A later optimizer may associate, distribute,
+factor, project, or fuse RecSet formulas and cost the equivalent plans without
+recovering the original SQL spelling. This particular canonicalizer merely
+makes the membership branches visible to that common machinery. NOT IN and
+scalar/CASE consumers stay on the 3VL path and cannot use complement laws
+without separately proving two-valued semantics. */
 (define combine_in_union_results (lambda (results negate)
 	(begin
 		(define items (coalesceNil results '()))
@@ -12823,11 +12826,14 @@ scan boundary only when the complete predicate implies it. */
 						(list (quote recset_union)
 							(cons (quote list) (map branch_bindings (lambda (binding) (nth binding 1))))))))))))
 
-/* When every OR alternative has a target-table candidate RecSet, their union
-is a safe scan boundary. Membership alternatives contribute projected supersets
-and ordinary alternatives contribute filtered base RecSets; the unchanged full
-predicate still runs on that much smaller union and enforces branch-local
-guards. This is the physical form of the RecSet membership equivalence. */
+/* When every OR alternative has a target-table candidate RecSet, the general
+truth-set law T_R(p OR q) = T_R(p) union T_R(q) provides a safe scan boundary.
+Membership alternatives contribute projected supersets and ordinary
+alternatives contribute filtered base RecSets. Because some inputs may be
+candidate supersets rather than exact truth sets, the unchanged full predicate
+still runs on the union and enforces branch-local guards. Keep this code phrased
+in terms of boolean RecSet formulas: future optimizers can add intersection,
+factoring, or other proven set transformations without adding SQL-shape cases. */
 (define membership_or_candidate_recset (lambda (src source_table condition bindings)
 	(begin
 		(define or_expr (membership_guard_or_expr condition))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1586,16 +1586,133 @@ instead of capturing whichever session populated the cache first. */
 		(make_grouped_exists_stage_rewrite inner args))))
 
 (define combine_exists_union_results (lambda (results)
-	(match (coalesceNil results '())
-		(cons item rest) (begin
-			(define tail (combine_exists_union_results rest))
+	(begin
+		(define items (coalesceNil results '()))
+		(if (empty_list? items)
+			(list false '() '())
 			(list
-				(if (empty_list? rest)
-					(nth item 0)
-					(list (quote or) (nth item 0) (nth tail 0)))
-				(merge (list (nth item 1) (nth tail 1)))
-				(merge (list (nth item 2) (nth tail 2)))))
-		_ (list false '() '()))))
+				(cons (quote or) (map items (lambda (item) (nth item 0))))
+				(merge (map items (lambda (item) (nth item 1))))
+				(merge (map items (lambda (item) (nth item 2)))))))))
+
+(define exists_union_branch_stage (lambda (result)
+	(match (nth result 1)
+		'(stage) (if (and (group_stage? stage)
+			(equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists)))
+			stage
+			nil)
+		_ nil)))
+
+(define exists_union_stage_contract (lambda (stage)
+	(if (nil? stage)
+		nil
+		(begin
+			(define keys (gs_keys stage))
+			(define input (gs_input stage))
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(if (or (not (equal? (count keys) 1))
+				(or (not (equal? (count lookup_keys) 1))
+					(or (not (if (query_block? input)
+						(scalar_source_shape_supported? (qb_sources input))
+						(source_is_base_table? input)))
+						(or (stage_has_residual_outer_refs? stage)
+							(not (stage_keys_are_input_local? stage))))))
+				nil
+				(list
+					1
+					(gs_domain stage)
+					lookup_keys
+					(qassoc_get (gs_facts stage) (quote null_semantics) nil)
+					(qassoc_get (gs_facts stage) (quote cardinality_mode) nil)))))))
+
+(define exists_union_results_compatible? (lambda (results)
+	(match (coalesceNil results '())
+		(cons first rest) (begin
+			(define first_contract (exists_union_stage_contract (exists_union_branch_stage first)))
+			(and (not (nil? first_contract))
+				(reduce rest (lambda (compatible result)
+					(and compatible
+						(equal? first_contract
+							(exists_union_stage_contract (exists_union_branch_stage result)))))
+					true)))
+		_ false)))
+
+(define exists_union_candidate_fields (lambda (keys)
+	(merge (mapIndex keys (lambda (i key)
+		(list (concat "k" (string i)) key))))))
+
+(define exists_union_candidate_branch (lambda (stage)
+	(begin
+		(define input (gs_input stage))
+		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+		(define fields (exists_union_candidate_fields (gs_keys stage)))
+		(if (query_block? input)
+			(make_query_block
+				(qb_schema input)
+				(qb_sources input)
+				fields
+				(combine_where (qb_where input) condition)
+				'() nil '() nil nil '()
+				(qb_stages input)
+				(qb_facts input))
+			(make_query_block
+				(source_schema input)
+				(list input)
+				fields
+				condition
+				'() nil '() nil nil '() '() '())))))
+
+(define make_combined_exists_union_stage_rewrite (lambda (inner results args)
+	(begin
+		(define first_stage (exists_union_branch_stage (car results)))
+		(define outer_sources (nth args 0))
+		(define lookup_keys (qassoc_get (gs_facts first_stage) (quote lookup-keys) '()))
+		(define outer_domain (gs_domain first_stage))
+		(define candidate_alias (concat "__exists_union_" (fnv_hash (serialize inner))))
+		(define union_input (make_union_block
+			(union_mode inner)
+			(map results (lambda (result)
+				(exists_union_candidate_branch (exists_union_branch_stage result))))
+			'() nil nil
+			(list
+				(list (quote purpose) (quote exists_candidate_union))
+				(list (quote alias) candidate_alias))))
+		(define keys (mapIndex (gs_keys first_stage) (lambda (i _key)
+			(list (quote get_column) candidate_alias false (concat "k" (string i)) false))))
+		(define stage_id (concat "exists-union:" (fnv_hash (serialize (list inner outer_domain lookup_keys)))))
+		(define stage (make_group_stage
+			stage_id
+			union_input
+			outer_domain
+			keys
+			(list aggregate_count_descriptor)
+			nil '() '() nil nil
+			(list
+				(list (quote condition) true)
+				(list (quote purpose) (quote exists))
+				(list (quote presence_only) true)
+				(list (quote max_needed_per_domain) 1)
+				(list (quote domain) outer_domain)
+				(list (quote lookup-keys) lookup_keys)
+				(list (quote preserve_empty_domain) (not (empty_list? outer_domain)))
+				(list (quote null_semantics) (quote exists))
+				(list (quote cardinality_mode) (quote many)))))
+		(define stage_alias (exists_stage_alias stage_id))
+		(define source (list
+			stage_alias
+			(group_stage_schema stage)
+			(make_stage_output_relation stage_id)
+			(stage_source_outer? outer_sources)
+			(make_exists_stage_join_condition stage_alias (group_key_cols keys) lookup_keys)))
+		(list
+			(list (quote >)
+				(list (quote coalesceNil)
+					(list (quote get_column) stage_alias false
+						(aggregate_col_name aggregate_count_descriptor) false)
+					0)
+				0)
+			(list stage)
+			(list source)))))
 
 (define make_exists_union_stage_rewrite (lambda (inner args)
 	(if (not (union_block? inner))
@@ -1603,12 +1720,16 @@ instead of capturing whichever session populated the cache first. */
 		(if (or (not (empty_list? (union_order inner)))
 			(or (not (nil? (union_limit inner))) (not (nil? (union_offset inner)))))
 			(neumann_fail "untangle_query" "EXISTS over UNION currently supports plain unordered branches")
-			(combine_exists_union_results
-				(map (union_branches inner) (lambda (branch)
+			(begin
+				(define results (map (union_branches inner) (lambda (branch)
 					(make_exists_stage_rewrite branch (list
 						(nth args 0)
 						branch
-						(if (>= (count args) 3) (nth args 2) nil))))))))))
+						(if (>= (count args) 3) (nth args 2) nil))))))
+				(if (and (equal? (union_mode inner) (quote all))
+					(exists_union_results_compatible? results))
+					(make_combined_exists_union_stage_rewrite inner results args)
+					(combine_exists_union_results results)))))))
 
 (define combine_in_union_results (lambda (results negate)
 	(match (coalesceNil results '())
@@ -5655,12 +5776,17 @@ resulting tree in semantic order. */
 		false
 		(begin
 			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define input (gs_input stage))
 			(and
 				(equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote exists))
 				(equal? (qassoc_get (gs_facts stage) (quote presence_only) false) true)
 				(not (empty_list? lookup_keys))
 				(equal? (count lookup_keys) (count (gs_keys stage)))
-				(source_is_base_table? (gs_input stage)))))))
+				(or (source_is_base_table? input)
+					(and (union_block? input)
+						(reduce (union_branches input) (lambda (supported branch)
+							(and supported (candidate_recset_branch_supported? branch)))
+							true))))))))
 
 (define exists_recset_stage_output_source? (lambda (stages src)
 	(and (stage_output_relation? (source_relation src))
@@ -7285,6 +7411,42 @@ dependency preparation does not emit free outer-row symbols. */
 			(lower_unique_stage_prepares_using stages stages stages)
 			(lower_stage_materialize_all stages))))))
 
+(define lower_exists_union_probe_branch (lambda (sources default_alias branch probe all_stages)
+	(begin
+		(define prepared (query_block_with_prepared_sources_using all_stages branch))
+		(if (not (and (query_block? prepared) (single_source? (qb_sources prepared))))
+			(neumann_fail "build_queryplan" "EXISTS UNION point probe requires one prepared branch source")
+			true)
+		(define src (car (qb_sources prepared)))
+		(if (not (source_is_base_table? src))
+			(neumann_fail "build_queryplan" "EXISTS UNION point probe requires base-table branches")
+			true)
+		(define key_expr (query_block_first_expr prepared))
+		(define condition (combine_where (qb_where prepared) (source_join_expr src)))
+		(define filtercols (merge_unique (list
+			(extract_columns_for_alias src condition)
+			(extract_columns_for_alias src key_expr))))
+		(list (quote scan_exists)
+			'(session "__memcp_tx")
+			(source_table_expr src)
+			(cons (quote list) filtercols)
+			(list (quote lambda)
+				(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
+				(list (quote optimize)
+					(list (quote and)
+						(lower_column_expr_for_alias src condition)
+						(list (quote equal??)
+							(lower_column_expr_for_alias src key_expr)
+							(lower_column_expr_for_join sources default_alias probe)))))))))
+
+/* EXISTS is short-circuiting, so selective independent UNION branches remain
+one n-ary physical OR of bounded probes. This preserves the logical union tree
+until lowering without creating a depth-proportional binary OR chain. */
+(define lower_exists_union_probe_expr (lambda (sources default_alias branches probe all_stages)
+	(cons (quote or)
+		(map (coalesceNil branches '()) (lambda (branch)
+			(lower_exists_union_probe_branch sources default_alias branch probe all_stages))))))
+
 (define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages)
 	(begin
 		(if (not (scalar_or_presence_probe_stage? stage))
@@ -7306,44 +7468,51 @@ dependency preparation does not emit free outer-row symbols. */
 		(define order_exprs (nth parts 1))
 		(define dirs (nth parts 2))
 		(define offset_value (nth parts 3))
-		(if (query_block? src)
-			(lower_scalar_first_query_probe_expr
-				all_stages
-				stage
-				value_expr
-				keys
-				(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key))))
-			(begin
-				(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-				(define condition_cols (extract_columns_for_alias src condition))
-				(define key_cols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
-				(define order_cols (merge_unique (map order_exprs (lambda (expr) (extract_columns_for_alias src expr)))))
-				(define value_cols (extract_columns_for_alias src value_expr))
-				(define filtercols (merge_unique (list condition_cols key_cols order_cols)))
-				(define mapcols (merge_unique (list value_cols)))
-				(list (quote scan_order)
-					'(session "__memcp_tx")
-					(source_table_expr src)
-					(cons (quote list) filtercols)
-					(list (quote lambda)
-						(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
-						(list (quote optimize)
-							(cons (quote and)
-								(cons
-									(lower_column_expr_for_alias src condition)
-									(scalar_first_probe_key_terms sources default_alias src keys lookup_keys)))))
-					(cons (quote list) order_cols)
-					(cons (quote list) dirs)
-					0
-					(coalesceNil offset_value 0)
-					1
-					(cons (quote list) mapcols)
-					(list (quote lambda)
-						(map mapcols (lambda (col) (symbol (concat (source_alias src) "." col))))
-						(lower_column_expr_for_alias src value_expr))
-					(scalar_once_reduce_first)
-					nil
-					false)))))
+		(if (union_block? src)
+			(list (quote if)
+				(lower_exists_union_probe_expr
+					sources default_alias (union_branches src)
+					(car lookup_keys) all_stages)
+				1
+				nil)
+			(if (query_block? src)
+				(lower_scalar_first_query_probe_expr
+					all_stages
+					stage
+					value_expr
+					keys
+					(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key))))
+				(begin
+					(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+					(define condition_cols (extract_columns_for_alias src condition))
+					(define key_cols (merge_unique (map keys (lambda (expr) (extract_columns_for_alias src expr)))))
+					(define order_cols (merge_unique (map order_exprs (lambda (expr) (extract_columns_for_alias src expr)))))
+					(define value_cols (extract_columns_for_alias src value_expr))
+					(define filtercols (merge_unique (list condition_cols key_cols order_cols)))
+					(define mapcols (merge_unique (list value_cols)))
+					(list (quote scan_order)
+						'(session "__memcp_tx")
+						(source_table_expr src)
+						(cons (quote list) filtercols)
+						(list (quote lambda)
+							(map filtercols (lambda (col) (symbol (concat (source_alias src) "." col))))
+							(list (quote optimize)
+								(cons (quote and)
+									(cons
+										(lower_column_expr_for_alias src condition)
+										(scalar_first_probe_key_terms sources default_alias src keys lookup_keys)))))
+						(cons (quote list) order_cols)
+						(cons (quote list) dirs)
+						0
+						(coalesceNil offset_value 0)
+						1
+						(cons (quote list) mapcols)
+						(list (quote lambda)
+							(map mapcols (lambda (col) (symbol (concat (source_alias src) "." col))))
+							(lower_column_expr_for_alias src value_expr))
+						(scalar_once_reduce_first)
+						nil
+						false))))))
 )
 
 (define lower_scalar_aggregate_probe_expr (lambda (sources default_alias stage requested_col)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1684,7 +1684,12 @@ physical membership probe. */
 		(define outer_sources (nth args 0))
 		(define lookup_keys (qassoc_get (gs_facts first_stage) (quote lookup-keys) '()))
 		(define outer_domain (gs_domain first_stage))
-		(define candidate_alias (concat "__exists_union_" (fnv_hash (serialize inner))))
+		/* The UNION subtree can contain many already-decorrelated stages. Hash its
+		serialization once and reuse the compact identity below; serializing that
+		large immutable tree twice made canonicalization scale with an avoidable
+		second full traversal. */
+		(define inner_hash (fnv_hash (serialize inner)))
+		(define candidate_alias (concat "__exists_union_" inner_hash))
 		(define union_input (make_union_block
 			(union_mode inner)
 			(map results (lambda (result)
@@ -1695,7 +1700,8 @@ physical membership probe. */
 				(list (quote alias) candidate_alias))))
 		(define keys (mapIndex (gs_keys first_stage) (lambda (i _key)
 			(list (quote get_column) candidate_alias false (concat "k" (string i)) false))))
-		(define stage_id (concat "exists-union:" (fnv_hash (serialize (list inner outer_domain lookup_keys)))))
+		(define stage_id (concat "exists-union:"
+			(fnv_hash (serialize (list inner_hash outer_domain lookup_keys)))))
 		(define stage (make_group_stage
 			stage_id
 			union_input
@@ -5797,10 +5803,7 @@ resulting tree in semantic order. */
 			(list (quote membership_candidate_estimate_capped) estimate_capped)
 			(list (quote membership_candidate_estimate_input) estimate_input)
 			(list (quote membership_order_limit) (qb_limit block))
-			(list (quote membership_order_limit_driver) ordered_driver)
-			(list (quote membership_cost_reason) (if (and (equal? class (quote broad)) ordered_driver)
-				(quote broad_membership_preserve_driver_order_limit)
-				(quote selective_membership_build_candidate_keyset)))))))
+			(list (quote membership_order_limit_driver) ordered_driver)))))
 
 (define stage_reorder_strategy (lambda (stage)
 	(match (qassoc_get (gs_facts stage) (quote purpose) nil)
@@ -5839,13 +5842,21 @@ resulting tree in semantic order. */
 		(gs_offset stage)
 		(merge (list (stage_reorder_telemetry stage) (gs_facts stage))))))
 
-(define candidate_reorder_strategy (lambda (telemetry single_source_driver)
-	(if (and
-		(or single_source_driver
-			(equal? (qassoc_get telemetry (quote membership_selectivity_class) nil) (quote broad)))
-		(qassoc_get telemetry (quote membership_order_limit_driver) false))
-		(quote driver_order_membership_probe)
-		(quote candidate_keyset))))
+(define candidate_reorder_strategy (lambda (telemetry)
+	(begin
+		(define estimated_rows (qassoc_get telemetry (quote membership_candidate_estimated_rows) nil))
+		(define candidate_rows (if (qassoc_get telemetry (quote membership_candidate_estimate_capped) false)
+			(qassoc_get telemetry (quote membership_candidate_estimate_input) nil)
+			estimated_rows))
+		(define driver_rows (qassoc_get telemetry (quote membership_driver_rows) nil))
+		/* UNION membership is already in a canonical semantic form here. Cost
+		the two supported implementations for every query shape: project the
+		candidate keys to a driver RecSet, or retain the driver scan and let its
+		per-row membership probes use autoindex. ORDER/LIMIT is an input to future
+		braking refinements, not permission for syntax to force either plan. */
+		(if (membership_projection_cost_preferred? candidate_rows driver_rows)
+			(quote candidate_keyset)
+			(quote driver_order_membership_probe)))))
 
 (define query_block_with_reorder_facts (lambda (block facts)
 	(make_query_block
@@ -5895,7 +5906,42 @@ in the canonicalization functions above. */
 				(or found (expr_contains_membership_truth? item))) false)
 			_ false))))
 
-(define membership_truth_projection_preferred? (lambda (block stage guarded_alternative)
+(define query_block_has_membership_truth_stage? (lambda (block)
+	(reduce (qb_stages block) (lambda (found stage)
+		(or found
+			(and (group_stage? stage)
+				(equal? (qassoc_get (gs_facts stage) (quote purpose) nil)
+					(quote in_membership)))))
+		false)))
+
+(define membership_estimated_work_rows (lambda (estimate fallback)
+	(if (nil? estimate)
+		fallback
+		(if (qassoc_get estimate (quote capped) false)
+			(coalesceNil (qassoc_get estimate (quote input) nil) fallback)
+			(coalesceNil (qassoc_get estimate (quote rows) nil) fallback)))))
+
+(define membership_driver_filter (lambda (condition)
+	/* Only top-level conjuncts which do not contain membership are guaranteed
+	to restrict every evaluation of the membership formula. Predicates inside
+	an OR branch cannot reduce the driver cost: a sibling may still admit the
+	row. Keeping this estimate conservative is preferable to choosing a RecSet
+	from an invalid branch-local selectivity assumption. */
+	(combine_where_terms
+		(filter (split_and_terms (coalesceNil condition true)) (lambda (term)
+			(not (expr_contains_membership_truth? term))))
+		true)))
+
+(define membership_projection_cost_preferred? (lambda (candidate_rows driver_rows)
+	(if (or (nil? candidate_rows) (nil? driver_rows))
+		false
+		/* Projection has fixed setup and per-key projection costs. Driver probing
+		uses the ordinary scan/autoindex path. These units are deliberately
+		simple and shared by every canonical membership shape; syntax recognition
+		must never select the physical representation. */
+		(< (+ 16 (* candidate_rows 4)) driver_rows))))
+
+(define membership_truth_projection_preferred? (lambda (block stage _guarded_alternative)
 	(begin
 		(define input (gs_input stage))
 		/* Projection from the canonical group cache currently guarantees a
@@ -5906,36 +5952,20 @@ in the canonicalization functions above. */
 		(if (or (not (source_is_base_table? input)) (not (single_source? base_sources)))
 			false
 			(begin
-				/* A branch-local membership below OR cannot become a mandatory
-				stage join or driver boundary: another branch may accept the row.
-				Project it and keep recset_contains exactly inside its original
-				boolean branch. This is a semantic feasibility rule before cost. */
-				(if guarded_alternative
-					true
-					(begin
-						/* Statistics are needed only when both plans are semantically
-						possible. Avoid sampling for guarded alternatives: their boolean
-						position has already made the decision. */
-						(define estimate (if (source_is_base_table? input)
-							(planner_source_filter_estimate input
-								(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
-								512)
-							(planner_stage_filter_estimate input 512)))
-						(define estimated_rows (qassoc_get estimate (quote rows) nil))
-						(define input_rows (qassoc_get estimate (quote input) nil))
-						(define estimate_capped (qassoc_get estimate (quote capped) false))
-						(define candidate_rows (if estimate_capped input_rows estimated_rows))
-						(define driver (reduce (qb_sources block) (lambda (found src)
-							(if (not (nil? found)) found (if (source_is_base_table? src) src nil))) nil))
-						(define driver_rows (if (nil? driver) nil (planner_source_row_count driver)))
-						/* Projection pays once per RHS key; probing pays while walking the
-						driver. A capped sample represents at least the sampled rows, so use the
-						RHS input as the conservative projection cost. Unknown estimates prefer
-						the structurally safe projected plan; later adaptive costing can replace
-						this static comparison without changing the canonical primitive. */
-						(if (or (nil? candidate_rows) (nil? driver_rows))
-							true
-							(<= (* candidate_rows 4) driver_rows)))))))))
+				(define candidate_estimate (planner_source_filter_estimate input
+					(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+					512))
+				(define candidate_rows (membership_estimated_work_rows candidate_estimate
+					(planner_source_row_count input)))
+				(define driver (reduce (qb_sources block) (lambda (found src)
+					(if (not (nil? found)) found (if (source_is_base_table? src) src nil))) nil))
+				(define driver_total_rows (if (nil? driver) nil (planner_source_row_count driver)))
+				(define driver_estimate (if (nil? driver)
+					nil
+					(planner_source_filter_estimate driver
+						(membership_driver_filter (qb_where block)) 512)))
+				(define driver_rows (membership_estimated_work_rows driver_estimate driver_total_rows))
+				(membership_projection_cost_preferred? candidate_rows driver_rows)))))))
 
 (define choose_membership_truth_items (lambda (block items guarded_alternative)
 	(match items
@@ -5972,10 +6002,12 @@ in the canonicalization functions above. */
 	(choose_membership_truth_expr_using block expr false)))
 
 (define query_block_with_physical_membership_choices (lambda (block)
-	(if (not (expr_contains_membership_truth? (qb_where block)))
+	(if (or (not (query_block_has_membership_truth_stage? block))
+		(not (expr_contains_membership_truth? (qb_where block))))
 		/* Keep unrelated query blocks byte-for-byte unchanged. Besides making
-		this phase boundary explicit, that prevents future membership planner
-		extensions from perturbing EXISTS/scalar stage preparation. */
+		this phase boundary explicit, the stage-purpose check avoids recursively
+		walking large EXISTS/scalar expressions which cannot contain the
+		canonical membership primitive. */
 		block
 		(begin
 			(define chosen (choose_membership_truth_expr block (qb_where block)))
@@ -6301,13 +6333,17 @@ in the canonicalization functions above. */
 					(begin
 						(define stage (stage_by_id (qb_stages block) (stage_output_relation_id (source_relation candidate))))
 						(define candidate_telemetry (candidate_reorder_telemetry stage sources block))
-						(define strategy (candidate_reorder_strategy candidate_telemetry
-							(single_source? (without_source_alias sources (source_alias candidate)))))
+						(define strategy (candidate_reorder_strategy candidate_telemetry))
+						(define costed_telemetry (qassoc_set candidate_telemetry
+							(quote membership_cost_reason)
+							(if (equal? strategy (quote candidate_keyset))
+								(quote projected_membership_cost)
+								(quote indexed_driver_probe_cost))))
 						(define facts (merge (list
 							(query_block_reorder_telemetry block)
 							(cons
 								(list (quote membership_plan_strategy) strategy)
-								candidate_telemetry))))
+								costed_telemetry))))
 						(query_block_with_reorder_facts
 							(make_query_block
 								(qb_schema block)

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1023,6 +1023,22 @@ instead of capturing whichever session populated the cache first. */
 		(list (quote get_column) stage_alias false (aggregate_col_name ag) false)
 		0)))
 
+/* Canonical positive-WHERE membership primitive. Its stage-output source
+provides the lookup relation; UNKNOWN and FALSE are intentionally equivalent in
+this truth context. Reordering may later replace this semantic primitive with a
+physical membership probe. */
+(define in_membership_truth_expr (lambda (probe stage_alias match_ag)
+	(list (quote membership_truth) probe stage_alias (aggregate_col_name match_ag))))
+
+(define expand_in_membership_truth_expr (lambda (probe stage_alias count_col)
+	(list (quote and)
+		(list (quote not) (list (quote nil?) probe))
+		(list (quote >)
+			(list (quote coalesceNil)
+				(list (quote get_column) stage_alias false count_col false)
+				0)
+			0))))
+
 (define in_membership_expr (lambda (probe match_alias match_ag null_alias rhs_state_ag)
 	(begin
 		(define match_count (membership_count_expr match_alias match_ag))
@@ -1731,17 +1747,30 @@ instead of capturing whichever session populated the cache first. */
 					(make_combined_exists_union_stage_rewrite inner results args)
 					(combine_exists_union_results results)))))))
 
+/* Canonicalization is the only layer that should know IN was written over a
+UNION. In positive WHERE truth context, each branch becomes one membership
+alternative and the result is a flat n-ary OR. This deliberately gives naive
+lowering the short-circuit behavior of OR(EXISTS ...), while preserving the
+optimization axiom
+
+RecSet(IN(UNION branches)) == union(RecSet(branch) ...)
+== RecSet(OR(EXISTS branches)).
+
+Thus a later lowerer may fuse the alternatives back into RecSets without
+depending on the original SQL spelling. NOT IN and scalar/CASE consumers stay
+on the 3VL path and must not use this positive-truth equivalence. */
 (define combine_in_union_results (lambda (results negate)
-	(match (coalesceNil results '())
-		(cons item rest) (begin
-			(define tail (combine_in_union_results rest negate))
+	(begin
+		(define items (coalesceNil results '()))
+		(if (empty_list? items)
+			(list false '() '())
 			(list
-				(if (empty_list? rest)
-					(nth item 0)
-					(list (if negate (quote and) (quote or)) (nth item 0) (nth tail 0)))
-				(merge (list (nth item 1) (nth tail 1)))
-				(merge (list (nth item 2) (nth tail 2)))))
-		_ (list false '() '()))))
+				(if (single_source? items)
+					(nth (car items) 0)
+					(cons (if negate (quote and) (quote or))
+						(map items (lambda (item) (nth item 0)))))
+				(merge_unique (map items (lambda (item) (nth item 1))))
+				(merge_unique (map items (lambda (item) (nth item 2)))))))))
 
 (define make_in_union_stage_rewrite (lambda (probe inner args)
 	(if (not (union_block? inner))
@@ -1751,13 +1780,28 @@ instead of capturing whichever session populated the cache first. */
 			(neumann_fail "untangle_query" "IN over UNION currently supports plain unordered branches")
 			(if (not (in_union_single_column? inner))
 				(neumann_fail "untangle_query" "IN UNION subquery branches must expose exactly one column")
-				(if (and (not (if (>= (count args) 3) (nth args 2) false))
-					(in_union_candidate_supported? inner (nth args 0)))
-					(make_in_union_candidate_stage_rewrite probe inner args)
-					(combine_in_union_results
-						(map (union_branches inner) (lambda (branch)
-							(make_in_stage_rewrite probe branch args)))
-						(if (>= (count args) 3) (nth args 2) false))))))))
+				(begin
+					(define truth_mode (string? (if (>= (count args) 4) (nth args 3) false)))
+					(define candidate_supported (in_union_candidate_supported? inner (nth args 0)))
+					(define canonical_supported (in_union_truth_canonical_supported? inner (nth args 0)))
+					(if (and (not (if (>= (count args) 3) (nth args 2) false))
+						(and candidate_supported (or (not truth_mode) (not canonical_supported))))
+						(make_in_union_candidate_stage_rewrite probe inner
+							(if truth_mode
+								(list (nth args 0) (nth args 1) false true
+									(if (>= (count args) 5) (nth args 4) nil))
+								args))
+						(begin
+							/* Unsupported complex branches keep their semantic barrier.
+							Only simple membership relations become the OR cloud. */
+							(define branch_args (if (and truth_mode (not canonical_supported))
+								(list (nth args 0) (nth args 1) false true
+									(if (>= (count args) 5) (nth args 4) nil))
+								args))
+							(combine_in_union_results
+								(map (union_branches inner) (lambda (branch)
+									(make_in_stage_rewrite probe branch branch_args)))
+								(if (>= (count args) 3) (nth args 2) false))))))))))
 
 (define in_union_single_column? (lambda (inner)
 	(reduce (union_branches inner) (lambda (ok branch)
@@ -1776,6 +1820,15 @@ instead of capturing whichever session populated the cache first. */
 				(and (exists_inner_supported? branch)
 					(and (equal? (count (qb_fields branch)) 2)
 						(empty_list? (btw2025_query_block_accessing_aliases branch outer_sources))))))
+			true))))
+
+(define in_union_truth_canonical_supported? (lambda (inner outer_sources)
+	(and (in_union_candidate_supported? inner outer_sources)
+		(reduce (union_branches inner) (lambda (ok branch)
+			(and ok
+				(and (single_source? (qb_sources branch))
+					(and (source_is_base_table? (car (qb_sources branch)))
+						(empty_list? (qb_stages branch))))))
 			true))))
 
 (define make_in_union_candidate_branch (lambda (branch)
@@ -1875,7 +1928,9 @@ instead of capturing whichever session populated the cache first. */
 	(begin
 		(define outer_sources (nth args 0))
 		(define negate (if (>= (count args) 3) (nth args 2) false))
-		(define semijoin_where (and (not negate) (if (>= (count args) 4) (nth args 3) false)))
+		(define where_mode (if (>= (count args) 4) (nth args 3) false))
+		(define truth_membership (and (not negate) (string? where_mode)))
+		(define semijoin_where (and (not negate) (and (not (string? where_mode)) where_mode)))
 		(define pending_info (if (>= (count args) 5) (nth args 4) nil))
 		(define membership_inner (normalize_membership_query_block inner))
 		(if (not (membership_inner_supported? membership_inner))
@@ -1975,7 +2030,7 @@ instead of capturing whichever session populated the cache first. */
 			stage_alias
 			(group_stage_schema stage)
 			(make_stage_output_relation stage_id)
-			(not semijoin_where)
+			(or truth_membership (not semijoin_where))
 			(if semijoin_where
 				(make_positive_in_join_condition stage_alias key_names lookup_keys probe aggregate_count_descriptor)
 				(make_exists_stage_join_condition stage_alias key_names lookup_keys))))
@@ -1988,12 +2043,17 @@ instead of capturing whichever session populated the cache first. */
 		(define count_col (aggregate_col_name aggregate_count_descriptor))
 		(if semijoin_where
 			(list true (list stage) (list source))
-			(list
-				(if negate
-					(not_in_membership_expr probe stage_alias aggregate_count_descriptor null_stage_alias null_ag)
-					(in_membership_expr probe stage_alias aggregate_count_descriptor null_stage_alias null_ag))
-				(list stage null_stage)
-				(list source null_source))))))
+			(if truth_membership
+				(list
+					(in_membership_truth_expr probe stage_alias aggregate_count_descriptor)
+					(list stage)
+					(list source))
+				(list
+					(if negate
+						(not_in_membership_expr probe stage_alias aggregate_count_descriptor null_stage_alias null_ag)
+						(in_membership_expr probe stage_alias aggregate_count_descriptor null_stage_alias null_ag))
+					(list stage null_stage)
+					(list source null_source)))))))
 
 (define grouped_membership_inner_supported? (lambda (inner outer_sources)
 	(and (query_block? inner)
@@ -3072,32 +3132,77 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(list (make_dependent_subquery_marker (quote not-in) probe subquery outer_sources) '() '())
 		(resolve_not_in_subquery_with_stages probe subquery outer_sources ctx))))
 
-(define direct_positive_in_term_rewrite (lambda (expr outer_sources ctx)
+(define direct_positive_in_term_rewrite_using (lambda (expr outer_sources ctx mode)
 	(match expr
 		((symbol inner_select_in) probe subquery)
 		(if (uctx_get ctx (quote defer-subquery-rewrites) false)
-			(list (make_dependent_subquery_marker (quote in-where) probe subquery outer_sources) '() '())
+			(list (make_dependent_subquery_marker
+				(if (string? mode) (quote in-where-truth) (quote in-where))
+				probe subquery outer_sources) '() '())
 			(begin
 				(define rewritten_probe (nth (untangle_expr_with_stages probe outer_sources ctx) 0))
-				(resolve_in_subquery_with_stages rewritten_probe subquery outer_sources ctx true)))
+				(resolve_in_subquery_with_stages rewritten_probe subquery outer_sources ctx mode)))
 		((quote inner_select_in) probe subquery)
 		(if (uctx_get ctx (quote defer-subquery-rewrites) false)
-			(list (make_dependent_subquery_marker (quote in-where) probe subquery outer_sources) '() '())
+			(list (make_dependent_subquery_marker
+				(if (string? mode) (quote in-where-truth) (quote in-where))
+				probe subquery outer_sources) '() '())
 			(begin
 				(define rewritten_probe (nth (untangle_expr_with_stages probe outer_sources ctx) 0))
-				(resolve_in_subquery_with_stages rewritten_probe subquery outer_sources ctx true)))
+				(resolve_in_subquery_with_stages rewritten_probe subquery outer_sources ctx mode)))
 		_ nil)))
+
+(define direct_positive_in_term_rewrite (lambda (expr outer_sources ctx)
+	(direct_positive_in_term_rewrite_using expr outer_sources ctx true)))
 
 (define where_conjunct_with_stages (lambda (expr outer_sources ctx)
 	(begin
 		(define direct_in (direct_positive_in_term_rewrite expr outer_sources ctx))
 		(if (nil? direct_in)
-			(untangle_expr_with_stages expr outer_sources ctx)
+			(if (and (list? expr)
+				(or (equal? (car expr) (quote or)) (equal? (car expr) (symbol "or"))))
+				(positive_where_expr_with_stages expr outer_sources ctx)
+				(untangle_expr_with_stages expr outer_sources ctx))
 			direct_in))))
+
+/* AND and OR preserve positive WHERE truth context: SQL UNKNOWN rejects a row
+just like FALSE. Descending only through this boolean cloud ensures NOT, CASE,
+projection, and arbitrary scalar functions retain full IN/NOT IN null
+semantics. New syntactic membership shapes should canonicalize here and reuse
+membership_truth rather than adding another physical lowering path. */
+(define positive_where_items_with_stages (lambda (items outer_sources ctx)
+	(match items
+		(cons item rest) (begin
+			(define rewritten (positive_where_expr_with_stages item outer_sources ctx))
+			(define tail (positive_where_items_with_stages rest outer_sources ctx))
+			(list
+				(cons (nth rewritten 0) (nth tail 0))
+				(merge_unique (list (nth rewritten 1) (nth tail 1)))
+				(merge_unique (list (nth rewritten 2) (nth tail 2)))))
+		_ (list '() '() '()))))
+
+(define positive_where_expr_with_stages (lambda (expr outer_sources ctx)
+	(begin
+		(define direct_in (direct_positive_in_term_rewrite_using
+			expr outer_sources ctx "truth"))
+		(if (not (nil? direct_in))
+			direct_in
+			(if (and (list? expr)
+				(or
+					(or (equal? (car expr) (quote and)) (equal? (car expr) (symbol "and")))
+					(or (equal? (car expr) (quote or)) (equal? (car expr) (symbol "or")))))
+				(begin
+					(define rewritten (positive_where_items_with_stages (cdr expr) outer_sources ctx))
+					(list
+						(cons (car expr) (nth rewritten 0))
+						(nth rewritten 1)
+						(nth rewritten 2)))
+				(untangle_expr_with_stages expr outer_sources ctx))))))
 
 (define untangle_where_with_stages (lambda (expr outer_sources ctx)
 	(begin
-		(define terms (split_and_terms (coalesceNil expr true)))
+		(define condition (coalesceNil expr true))
+		(define terms (split_and_terms condition))
 		(define rewritten_terms (map terms (lambda (term)
 			(where_conjunct_with_stages term outer_sources ctx))))
 		(list
@@ -3281,6 +3386,14 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(begin
 				(define probe_result (btw2025_decorrelate_expr_with_stages probe ctx))
 				(define in_result (resolve_in_subquery_with_stages (nth probe_result 0) subquery outer_sources resolve_ctx true))
+				(list
+					(nth in_result 0)
+					(unique_stages_by_id (merge (list (nth probe_result 1) (nth in_result 1))))
+					(merge_unique (list (nth probe_result 2) (nth in_result 2)))))
+			(symbol in-where-truth)
+			(begin
+				(define probe_result (btw2025_decorrelate_expr_with_stages probe ctx))
+				(define in_result (resolve_in_subquery_with_stages (nth probe_result 0) subquery outer_sources resolve_ctx "truth"))
 				(list
 					(nth in_result 0)
 					(unique_stages_by_id (merge (list (nth probe_result 1) (nth in_result 1))))
@@ -5750,6 +5863,133 @@ resulting tree in semantic order. */
 	(list (quote and)
 		(list (quote not) (list (quote nil?) probe))
 		(list (quote driver_membership_probe) stage probe))))
+
+(define membership_truth_parts (lambda (expr)
+	(match expr
+		((symbol membership_truth) probe stage_alias count_col)
+		(list probe stage_alias count_col)
+		((quote membership_truth) probe stage_alias count_col)
+		(list probe stage_alias count_col)
+		_ nil)))
+
+/* Physical membership selection operates only on the canonical primitive. It
+must not inspect parser expressions or table names. Extend its capability and
+cost inputs when a new physical strategy is added; keep SQL-shape recognition
+in the canonicalization functions above. */
+
+(define membership_truth_stage (lambda (stages sources stage_alias)
+	(begin
+		(define src (source_for_alias sources nil stage_alias false))
+		(if (or (nil? src) (not (stage_output_relation? (source_relation src))))
+			nil
+			(stage_by_id stages (stage_output_relation_id (source_relation src)))))))
+
+(define expr_contains_membership_truth? (lambda (expr)
+	(if (not (nil? (membership_truth_parts expr)))
+		true
+		(match expr
+			(cons _head tail) (reduce tail (lambda (found item)
+				(or found (expr_contains_membership_truth? item))) false)
+			_ false))))
+
+(define membership_truth_projection_preferred? (lambda (block stage guarded_alternative)
+	(begin
+		(define input (gs_input stage))
+		/* Projection from the canonical group cache currently guarantees a
+		direct key map only for base-table membership stages. Derived inputs keep
+		the same primitive and use indexed existence probing until their cache-key
+		lineage is represented explicitly; do not add a shape-specific fallback. */
+		(define base_sources (filter (qb_sources block) source_is_base_table?))
+		(if (or (not (source_is_base_table? input)) (not (single_source? base_sources)))
+			false
+			(begin
+				/* A branch-local membership below OR cannot become a mandatory
+				stage join or driver boundary: another branch may accept the row.
+				Project it and keep recset_contains exactly inside its original
+				boolean branch. This is a semantic feasibility rule before cost. */
+				(if guarded_alternative
+					true
+					(begin
+						/* Statistics are needed only when both plans are semantically
+						possible. Avoid sampling for guarded alternatives: their boolean
+						position has already made the decision. */
+						(define estimate (if (source_is_base_table? input)
+							(planner_source_filter_estimate input
+								(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+								512)
+							(planner_stage_filter_estimate input 512)))
+						(define estimated_rows (qassoc_get estimate (quote rows) nil))
+						(define input_rows (qassoc_get estimate (quote input) nil))
+						(define estimate_capped (qassoc_get estimate (quote capped) false))
+						(define candidate_rows (if estimate_capped input_rows estimated_rows))
+						(define driver (reduce (qb_sources block) (lambda (found src)
+							(if (not (nil? found)) found (if (source_is_base_table? src) src nil))) nil))
+						(define driver_rows (if (nil? driver) nil (planner_source_row_count driver)))
+						/* Projection pays once per RHS key; probing pays while walking the
+						driver. A capped sample represents at least the sampled rows, so use the
+						RHS input as the conservative projection cost. Unknown estimates prefer
+						the structurally safe projected plan; later adaptive costing can replace
+						this static comparison without changing the canonical primitive. */
+						(if (or (nil? candidate_rows) (nil? driver_rows))
+							true
+							(<= (* candidate_rows 4) driver_rows)))))))))
+
+(define choose_membership_truth_items (lambda (block items guarded_alternative)
+	(match items
+		(cons item rest) (begin
+			(define chosen (choose_membership_truth_expr_using block item guarded_alternative))
+			(define tail (choose_membership_truth_items block rest guarded_alternative))
+			(list
+				(cons (nth chosen 0) (nth tail 0))
+				(merge_unique (list (nth chosen 1) (nth tail 1)))))
+		_ (list '() '()))))
+
+(define choose_membership_truth_expr_using (lambda (block expr guarded_alternative)
+	(begin
+		(define parts (membership_truth_parts expr))
+		(if (not (nil? parts))
+			(begin
+				(define stage (membership_truth_stage (qb_stages block) (qb_sources block) (nth parts 1)))
+				(if (and (not (nil? stage))
+					(membership_truth_projection_preferred? block stage guarded_alternative))
+					(list (driver_membership_probe_expr stage (nth parts 0)) (list (nth parts 1)))
+					(list (expand_in_membership_truth_expr (nth parts 0) (nth parts 1) (nth parts 2)) '())))
+			(if (and (list? expr)
+				(or
+					(or (equal? (car expr) (quote and)) (equal? (car expr) (symbol "and")))
+					(or (equal? (car expr) (quote or)) (equal? (car expr) (symbol "or")))))
+				(begin
+					(define below_or (or guarded_alternative
+						(or (equal? (car expr) (quote or)) (equal? (car expr) (symbol "or")))))
+					(define chosen (choose_membership_truth_items block (cdr expr) below_or))
+					(list (cons (car expr) (nth chosen 0)) (nth chosen 1)))
+				(list expr '()))))))
+
+(define choose_membership_truth_expr (lambda (block expr)
+	(choose_membership_truth_expr_using block expr false)))
+
+(define query_block_with_physical_membership_choices (lambda (block)
+	(if (not (expr_contains_membership_truth? (qb_where block)))
+		/* Keep unrelated query blocks byte-for-byte unchanged. Besides making
+		this phase boundary explicit, that prevents future membership planner
+		extensions from perturbing EXISTS/scalar stage preparation. */
+		block
+		(begin
+			(define chosen (choose_membership_truth_expr block (qb_where block)))
+			(define removed_aliases (nth chosen 1))
+			(if (empty_list? removed_aliases)
+				(make_query_block
+					(qb_schema block) (qb_sources block) (qb_fields block) (nth chosen 0)
+					(qb_group block) (qb_having block) (qb_order block) (qb_limit block)
+					(qb_offset block) (qb_hidden block) (qb_stages block) (qb_facts block))
+				(make_query_block
+					(qb_schema block)
+					(filter (qb_sources block) (lambda (src) (not (contains? removed_aliases (source_alias src)))))
+					(qb_fields block) (nth chosen 0) (qb_group block) (qb_having block)
+					(qb_order block) (qb_limit block) (qb_offset block) (qb_hidden block)
+					(qb_stages block)
+					(qassoc_set (qb_facts block) (quote membership_plan_strategy)
+						(quote projected_membership_alternatives))))))))
 
 (define dml_preserve_driver_membership_probe (lambda (fallback_schema expr)
 	(match expr
@@ -8309,6 +8549,26 @@ until lowering without creating a depth-proportional binary OR chain. */
 					(source_table_expr target_src)
 					(quoted_runtime_list (nth parts 1))))))))
 
+/* The canonical membership stage has already computed arbitrary RHS key
+expressions into cache column k0. Project that compact key set to the driver;
+the auto-index chooses the concrete access path on both tables. */
+(define membership_cache_recset_project_join_expr (lambda (target_src stage target_col)
+	(if (or (not (equal? (count (gs_keys stage)) 1))
+		(not (equal? (count (qassoc_get (gs_facts stage) (quote lookup-keys) '())) 1)))
+		nil
+		(begin
+			(define cache (group_stage_cache stage))
+			(list (quote recset_project_join)
+				'(session "__memcp_tx")
+				(list (quote scan_recset)
+					'(session "__memcp_tx")
+					(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
+					(list (quote list))
+					(list (quote lambda) '() true))
+				(quoted_runtime_list (list "k0"))
+				(source_table_expr target_src)
+				(quoted_runtime_list (list target_col)))))))
+
 (define recset_project_join_expr_for_membership (lambda (src membership)
 	(begin
 		(define stage (nth membership 0))
@@ -8323,30 +8583,32 @@ until lowering without creating a depth-proportional binary OR chain. */
 					(if (single_source? projected)
 						(car projected)
 						(list (quote recset_union) (cons (quote list) projected)))))
-			(if (exists_recset_stage? stage)
-				(if (> (count (gs_keys stage)) 1)
-					(exists_recset_project_join_expr src stage)
-					(begin
-						(define source_col (direct_column_name_for_alias input (car (gs_keys stage))))
-						(if (nil? source_col)
-							nil
-							(begin
-								(define alias (source_alias input))
-								(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
-								(define filtercols (extract_columns_for_alias input condition))
-								(list (quote recset_project_join)
-									'(session "__memcp_tx")
-									(list (quote scan_recset)
+			(if (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_membership))
+				(membership_cache_recset_project_join_expr src stage target_col)
+				(if (exists_recset_stage? stage)
+					(if (> (count (gs_keys stage)) 1)
+						(exists_recset_project_join_expr src stage)
+						(begin
+							(define source_col (direct_column_name_for_alias input (car (gs_keys stage))))
+							(if (nil? source_col)
+								nil
+								(begin
+									(define alias (source_alias input))
+									(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+									(define filtercols (extract_columns_for_alias input condition))
+									(list (quote recset_project_join)
 										'(session "__memcp_tx")
-										(source_table_expr input)
-										(cons (quote list) filtercols)
-										(list (quote lambda)
-											(map filtercols (lambda (col) (symbol (concat alias "." col))))
-											(list (quote optimize) (lower_column_expr_for_alias input condition))))
-									(quoted_runtime_list (list source_col))
-									(source_table_expr src)
-									(quoted_runtime_list (list target_col)))))))
-				nil)))))
+										(list (quote scan_recset)
+											'(session "__memcp_tx")
+											(source_table_expr input)
+											(cons (quote list) filtercols)
+											(list (quote lambda)
+												(map filtercols (lambda (col) (symbol (concat alias "." col))))
+												(list (quote optimize) (lower_column_expr_for_alias input condition))))
+										(quoted_runtime_list (list source_col))
+										(source_table_expr src)
+										(quoted_runtime_list (list target_col)))))))
+					nil))))))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -12167,7 +12429,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 (define query_block_stages_to_prepare (lambda (block)
 	(query_block_stages_to_prepare_using (qb_stages block) block)))
 
-(define prepare_simple_query_block_physical_core (lambda (block)
+(define prepare_simple_query_block_physical_core_chosen (lambda (block)
 	(begin
 		(define stage_lookup (query_block_stage_lookup block))
 		(if (empty_list? (qb_stages block))
@@ -12214,6 +12476,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 						(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup eager_stages)
 						(lower_stage_materialize_all eager_stages)))
 					core_block))))))
+
+(define prepare_simple_query_block_physical_core (lambda (block)
+	(prepare_simple_query_block_physical_core_chosen
+		(query_block_with_physical_membership_choices block))))
 
 (define lower_simple_query_block_with_cataloged_stages (lambda (block)
 	(begin
@@ -12431,6 +12697,150 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(and (not (empty_list? (cdr sources)))
 			(not (downstream_sources_preserve_driver_rows? sources default_alias final_condition))))))
 
+(define driver_memberships_for_source (lambda (src expr)
+	(begin
+		(define marker (driver_membership_probe_term expr))
+		(if (not (nil? marker))
+			(begin
+				(define probe_col (direct_column_name_for_alias src (nth marker 1)))
+				(if (nil? probe_col)
+					'()
+					(list (list (nth marker 0) (nth marker 1) probe_col expr))))
+			(match expr
+				(cons _head tail) (merge_unique (map tail (lambda (item)
+					(driver_memberships_for_source src item))))
+				_ '())))))
+
+/* A scan may contain several branch-local membership predicates. Each RecSet is
+bound once, but every marker remains at its original AND/OR position and calls
+the shared $recset_contains row callback with its own RecSet argument. Do not
+collapse guarded alternatives into one driver RecSet: that would discard rows
+accepted by non-membership branches. The storage analyzer may use a RecSet as a
+scan boundary only when the complete predicate implies it. */
+
+(define membership_recset_var (lambda (membership)
+	(symbol (concat "__membership_recset_" (fnv_hash (gs_id (nth membership 0)))))))
+
+(define replace_driver_membership_markers (lambda (expr memberships)
+	(begin
+		/* Match the marker structurally, but never recurse into its embedded
+		group-stage. A stage is IR data containing booleans and expressions of its
+		own; treating that payload as part of the surrounding predicate would
+		corrupt stage facts while replacing a row-level membership marker. */
+		(define marker (driver_membership_probe_term expr))
+		(define membership (if (nil? marker)
+			nil
+			(reduce memberships (lambda (found item)
+				(if (not (nil? found))
+					found
+					(if (and (equal? (gs_id (nth marker 0)) (gs_id (nth item 0)))
+						(equal? (nth marker 1) (nth item 1)))
+						item
+						nil))) nil)))
+		(if (not (nil? membership))
+			(recset_contains_call_expr (membership_recset_var membership))
+			(if (not (nil? marker))
+				expr
+				(match expr
+					(cons head tail) (cons head (map tail (lambda (item)
+						(replace_driver_membership_markers item memberships))))
+					_ expr))))))
+
+(define membership_recset_bindings (lambda (src memberships)
+	(filter (map memberships (lambda (membership)
+		(begin
+			(define expr (recset_project_join_expr_for_membership src membership))
+			(if (nil? expr) nil (list membership (membership_recset_var membership) expr)))))
+		(lambda (binding) (not (nil? binding))))))
+
+(define wrap_membership_recset_bindings (lambda (bindings body)
+	(if (empty_list? bindings)
+		body
+		/* The projections are independent. Bind them in one application instead
+		of emitting a depth-proportional lambda tower; this keeps compilation and
+		generated-plan size linear with a small constant for large OR clouds. */
+		(cons
+			(list (quote lambda)
+				(map bindings (lambda (binding) (nth binding 1)))
+				body)
+			(map bindings (lambda (binding) (nth binding 2)))))))
+
+(define expr_contains_driver_membership? (lambda (expr)
+	(if (not (nil? (driver_membership_probe_term expr)))
+		true
+		(match expr
+			(cons _head tail) (reduce tail (lambda (found item)
+				(or found (expr_contains_driver_membership? item))) false)
+			_ false))))
+
+(define membership_guard_or_expr (lambda (expr)
+	(if (not (nil? (driver_membership_probe_term expr)))
+		nil
+		(match expr
+			(cons head tail)
+			(if (or (equal? head (quote or)) (equal? head (symbol "or")))
+				(if (reduce tail (lambda (found item)
+					(or found (expr_contains_driver_membership? item))) false)
+					expr
+					(reduce tail (lambda (found item)
+						(if (not (nil? found)) found (membership_guard_or_expr item))) nil))
+				(reduce tail (lambda (found item)
+					(if (not (nil? found)) found (membership_guard_or_expr item))) nil))
+			_ nil))))
+
+(define membership_binding_for_marker (lambda (bindings marker)
+	(reduce bindings (lambda (found binding)
+		(if (not (nil? found))
+			found
+			(begin
+				(define membership (nth binding 0))
+				(if (and (equal? (gs_id (nth marker 0)) (gs_id (nth membership 0)))
+					(equal? (nth marker 1) (nth membership 1)))
+					binding
+					nil)))) nil)))
+
+(define membership_branch_candidate_recset (lambda (src source_table branch bindings)
+	(begin
+		(define markers (driver_memberships_for_source src branch))
+		(if (empty_list? markers)
+			(begin
+				(define cols (extract_columns_for_alias src branch))
+				(list (quote scan_recset)
+					'(session "__memcp_tx")
+					source_table
+					(cons (quote list) cols)
+					(list (quote lambda)
+						(map cols (lambda (col) (scan_callback_symbol_for_alias (source_alias src) col)))
+						(list (quote optimize) (lower_column_expr_for_alias src branch)))))
+			(begin
+				(define branch_bindings (filter (map markers (lambda (marker)
+					(membership_binding_for_marker bindings marker)))
+					(lambda (binding) (not (nil? binding)))))
+				(if (not (equal? (count branch_bindings) (count markers)))
+					nil
+					(if (single_source? branch_bindings)
+						(nth (car branch_bindings) 1)
+						(list (quote recset_union)
+							(cons (quote list) (map branch_bindings (lambda (binding) (nth binding 1))))))))))))
+
+/* When every OR alternative has a target-table candidate RecSet, their union
+is a safe scan boundary. Membership alternatives contribute projected supersets
+and ordinary alternatives contribute filtered base RecSets; the unchanged full
+predicate still runs on that much smaller union and enforces branch-local
+guards. This is the physical form of the RecSet membership equivalence. */
+(define membership_or_candidate_recset (lambda (src source_table condition bindings)
+	(begin
+		(define or_expr (membership_guard_or_expr condition))
+		(if (nil? or_expr)
+			nil
+			(begin
+				(define candidates (map (cdr or_expr) (lambda (branch)
+					(membership_branch_candidate_recset src source_table branch bindings))))
+				(if (reduce candidates (lambda (missing candidate)
+					(or missing (nil? candidate))) false)
+					nil
+					(list (quote recset_union) (cons (quote list) candidates))))))))
+
 (define lower_single_source_query_block (lambda (block)
 	(begin
 		(define src (car (qb_sources block)))
@@ -12453,31 +12863,44 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				(define order_items (coalesceNil (qb_order block) '()))
 				(define scan_order_supported (order_items_belong_to_source? src order_items))
 				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
-				(define membership (driver_membership_for_source src condition))
-				(define membership_table_expr (if (nil? membership) nil (recset_project_join_expr_for_membership src membership)))
+				(define memberships (driver_memberships_for_source src condition))
+				(define membership_bindings (membership_recset_bindings src memberships))
+				(define bound_memberships (map membership_bindings (lambda (binding) (nth binding 0))))
+				/* A membership predicate which is implied by the whole WHERE clause is
+				eligible to become the scan driver. A branch-local predicate below OR is
+				not: its RecSet must remain a probe or rows accepted by sibling branches
+				would disappear. This distinction also preserves the established fast
+				single-IN path while allowing several guarded RecSets in one scan. */
+				(define direct_membership (driver_membership_for_source src condition))
+				(define prefer_membership_filter (and scan_order_supported
+					(and bounded
+						(broad_driver_order_membership_probe? (qb_facts block)))))
+				(define membership_driver (and
+					(not (nil? direct_membership))
+					(and (not prefer_membership_filter)
+						(and (not (empty_list? membership_bindings))
+							(and (empty_list? (cdr membership_bindings))
+								(equal? direct_membership (car bound_memberships)))))))
 				(define membership_filter (and
-					(not (nil? membership_table_expr))
-					(and scan_order_supported
-						(and bounded
-							(broad_driver_order_membership_probe? (qb_facts block))))))
-				(define effective_membership (if (nil? membership_table_expr) nil membership))
-				(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
-				(define membership_var (symbol "__membership_recset"))
-				(define membership_filter_expr (if membership_filter
-					(recset_contains_call_expr membership_var)
-					true))
-				(define filter_condition (combine_where membership_filter_expr effective_condition))
+					(not membership_driver)
+					(not (empty_list? membership_bindings))))
+				(define filter_condition (if membership_driver
+					(strip_driver_membership_for_source src condition direct_membership)
+					(replace_driver_membership_markers condition bound_memberships)))
 				(define filtercols (merge_unique (list
 					(if membership_filter (list "$recset_contains") '())
-					(extract_columns_for_alias src effective_condition))))
+					(extract_columns_for_alias src filter_condition))))
 				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
 				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
 				(define mapcols fieldcols)
 				(define source_table (source_table_expr_using (query_block_stage_catalog block) src))
-				(define table_expr (if membership_filter
-					source_table
-					(coalesceNil membership_table_expr source_table)))
+				(define membership_candidates (if membership_filter
+					(membership_or_candidate_recset src source_table condition membership_bindings)
+					nil))
+				(define table_expr (if membership_driver
+					(nth (car membership_bindings) 2)
+					(coalesceNil membership_candidates source_table)))
 				(define filter_expr (list (quote lambda)
 					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 					(list (quote optimize) (lower_column_expr_for_alias src filter_condition))))
@@ -12486,7 +12909,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 					(list (quote resultrow)
 						(cons (quote list) (map_assoc fields (lambda (title expr)
 							(lower_column_expr_for_alias src expr)))))))
-				(if (and (empty_list? order_items) (not bounded))
+				(define scan_plan (if (and (empty_list? order_items) (not bounded))
 					(list (quote scan)
 						'(session "__memcp_tx")
 						table_expr
@@ -12515,12 +12938,11 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 								nil
 								nil
 								(source_outer? src)))
-							(if membership_filter
-								(list
-									(list (quote lambda) (list membership_var) scan_expr)
-									membership_table_expr)
-								scan_expr))
-						(neumann_fail "build_queryplan" "single-source ORDER BY requires a storage carrier"))))))))
+							scan_expr)
+						(neumann_fail "build_queryplan" "single-source ORDER BY requires a storage carrier"))))
+				(if membership_filter
+					(wrap_membership_recset_bindings membership_bindings scan_plan)
+					scan_plan))))))
 
 (define order_exprs (lambda (order_items)
 	(map (coalesceNil order_items '()) (lambda (item)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -196,6 +196,32 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			"c"
 			(list (quote and) "d" (list (quote and) "e" "f")))
 		true)) '("a" "b" "c" "d" "e" "f")) true "combine_where_terms flattens nested AND terms")
+	(define test_exists_union_outer_source
+		(list "outer_asset" "memcp-tests" "trace_asset" false nil))
+	(define test_exists_union_probe
+		(list (quote get_column) "outer_asset" false "id" false))
+	(define test_exists_union_branch (lambda (alias relation)
+		(begin
+			(define src (list alias "memcp-tests" relation false nil))
+			(make_query_block "memcp-tests" (list src)
+				(list "id" (list (quote get_column) alias false "asset_id" false))
+				true '() nil '() nil nil '() '() '()))))
+	(define test_exists_union_probe_plan (lower_exists_union_probe_expr
+		(list test_exists_union_outer_source)
+		"outer_asset"
+		(list
+			(test_exists_union_branch "ref_a" "trace_ref_a")
+			(test_exists_union_branch "ref_b" "trace_ref_b")
+			(test_exists_union_branch "ref_c" "trace_ref_c"))
+		test_exists_union_probe
+		'()))
+	(assert (equal? (car test_exists_union_probe_plan) 'or) true
+		"EXISTS UNION selective lowering emits one n-ary OR root")
+	(assert (equal? (count test_exists_union_probe_plan) 4) true
+		"EXISTS UNION selective lowering does not build a binary OR chain")
+	(assert (reduce (cdr test_exists_union_probe_plan) (lambda (valid branch)
+		(and valid (equal? (car branch) 'scan_exists))) true) true
+		"EXISTS UNION selective lowering emits one bounded probe per branch")
 	(define graph_col (lambda (alias column)
 		(list (quote get_column) alias false column false)))
 	(define graph_sources (list

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -72,8 +72,6 @@ setup:
 
 test_cases:
   - name: "Selective IN branches under OR use projected membership recsets"
-    noncritical: true
-    fail_comment: "multiple selective IN branches under OR still lower to per-driver group-cache probes"
     sql: |
       EXPLAIN
       SELECT ID
@@ -94,6 +92,8 @@ test_cases:
     expect:
       result_contains:
         - "recset_project_join"
+        - "recset_union"
+        - "scan_recset"
         - "$recset_contains"
         - "scan_order"
 
@@ -139,8 +139,6 @@ test_cases:
         - ID: 9981
 
   - name: "Selective IN branches under OR meet the projected membership budget"
-    noncritical: true
-    fail_comment: "the projected RecSet plan measures in low milliseconds; per-driver group-cache probes exceed this budget"
     max_time: 0.02
     sql: |
       SELECT ID
@@ -178,6 +176,50 @@ test_cases:
         - "scan_order"
       result_not_contains:
         - "recset_project_join"
+
+  - name: "Nested OR membership keeps its projected probe below an outer AND"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE event_time >= 9990
+        AND (entity_kind = 'root' OR entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC
+    expect:
+      result_contains:
+        - "recset_project_join"
+        - "$recset_contains"
+        - "scan_order"
+
+  - name: "Nested OR membership preserves sibling alternatives"
+    sql: |
+      SELECT ID
+      FROM membership_event
+      WHERE event_time >= 9990
+        AND (entity_kind = 'root' OR entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC
+    expect:
+      rows: 11
+      data:
+        - ID: 10000
+        - ID: 9999
+        - ID: 9998
+        - ID: 9997
+        - ID: 9996
+        - ID: 9995
+        - ID: 9994
+        - ID: 9993
+        - ID: 9992
+        - ID: 9991
+        - ID: 9990
 
   - name: "IN subquery - files with render results"
     sql: |

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -738,7 +738,7 @@ test_cases:
             - "__union_distinct_rows"
             - "__union_distinct_seen"
 
-  - name: "IN UNION joined order limit costs keyset against driver probing"
+  - name: "IN UNION joined order limit uses guarded keyset fallback"
     fail_comment: "query is not fully decorrelated anymore; logical IR must not contain subquery markers"
     setup:
       - sql: "DROP TABLE IF EXISTS in_dv_doc"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -33,8 +33,152 @@ setup:
   - sql: "CREATE TABLE membership_assignment (ID INT PRIMARY KEY, result INT)"
   - sql: "INSERT INTO membership_item (ID, name) VALUES (1, 'item-1'), (2, 'item-2'), (3, 'item-3'), (4, 'item-4'), (5, 'item-5')"
   - sql: "INSERT INTO membership_assignment (ID, result) VALUES (101, 1), (102, 3), (103, 3)"
+  - sql: "DROP TABLE IF EXISTS membership_event"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_a"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_b"
+  - sql: "DROP TABLE IF EXISTS membership_broad_key"
+  - sql: |
+      CREATE TABLE membership_event (
+        ID INT PRIMARY KEY,
+        entity_kind VARCHAR(32),
+        entity_key VARCHAR(64),
+        event_time INT
+      )
+  - sql: "CREATE TABLE membership_narrow_key_a (ID INT PRIMARY KEY, enabled INT)"
+  - sql: "CREATE TABLE membership_narrow_key_b (ID INT PRIMARY KEY, enabled INT)"
+  - sql: "CREATE TABLE membership_broad_key (ID INT PRIMARY KEY, enabled INT)"
+  - scm: |
+      (begin
+        (define events (map (produceN 10000) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (if (>= id 9992)
+              (list id "root" "root:1" id)
+              (if (>= id 9983)
+                (list id "narrow_a" "narrow_a:1" id)
+                (if (>= id 9974)
+                  (list id "narrow_b" "narrow_b:1" id)
+                  (list id "noise" (concat "noise:" id) id))))))))
+        (insert (table "memcp-tests" "membership_event")
+          '("ID" "entity_kind" "entity_key" "event_time") events)
+        (insert (table "memcp-tests" "membership_narrow_key_a")
+          '("ID" "enabled") (list (list 1 1) (list 2 0)))
+        (insert (table "memcp-tests" "membership_narrow_key_b")
+          '("ID" "enabled") (list (list 1 1) (list 2 0)))
+        (insert (table "memcp-tests" "membership_broad_key")
+          '("ID" "enabled")
+          (map (produceN 8000) (lambda (i) (list (+ i 1) 1))))
+        true)
 
 test_cases:
+  - name: "Selective IN branches under OR use projected membership recsets"
+    noncritical: true
+    fail_comment: "multiple selective IN branches under OR still lower to per-driver group-cache probes"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC
+      LIMIT 20
+    expect:
+      result_contains:
+        - "recset_project_join"
+        - "$recset_contains"
+        - "scan_order"
+
+  - name: "Selective IN branches under OR preserve ordered results"
+    sql: |
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC, ID DESC
+      LIMIT 20
+    expect:
+      rows: 20
+      data:
+        - ID: 10000
+        - ID: 9999
+        - ID: 9998
+        - ID: 9997
+        - ID: 9996
+        - ID: 9995
+        - ID: 9994
+        - ID: 9993
+        - ID: 9992
+        - ID: 9991
+        - ID: 9990
+        - ID: 9989
+        - ID: 9988
+        - ID: 9987
+        - ID: 9986
+        - ID: 9985
+        - ID: 9984
+        - ID: 9983
+        - ID: 9982
+        - ID: 9981
+
+  - name: "Selective IN branches under OR meet the projected membership budget"
+    noncritical: true
+    fail_comment: "the projected RecSet plan measures in low milliseconds; per-driver group-cache probes exceed this budget"
+    max_time: 0.02
+    sql: |
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC, ID DESC
+      LIMIT 20
+    expect:
+      rows: 20
+
+  - name: "Broad IN branches retain driver probing"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE entity_kind = 'noise' AND entity_key IN (
+        SELECT CONCAT('noise:', ID)
+        FROM membership_broad_key
+        WHERE enabled = 1
+      )
+      ORDER BY event_time DESC
+      LIMIT 5
+    expect:
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "recset_project_join"
+
   - name: "IN subquery - files with render results"
     sql: |
       SELECT ID, name FROM in_fop_files
@@ -1837,6 +1981,10 @@ test_cases:
           "tenant:canView": true
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS membership_broad_key"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_b"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_a"
+  - sql: "DROP TABLE IF EXISTS membership_event"
   - sql: "DROP TABLE IF EXISTS assignment_x"
   - sql: "DROP TABLE IF EXISTS item_x"
   - sql: "DROP TABLE IF EXISTS tenant_x"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -177,7 +177,26 @@ test_cases:
       result_not_contains:
         - "recset_project_join"
 
-  - name: "Nested OR membership keeps its projected probe below an outer AND"
+  - name: "Broad membership below OR retains driver probing"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE entity_kind = 'root'
+        OR entity_key IN (
+          SELECT CONCAT('noise:', ID)
+          FROM membership_broad_key
+          WHERE enabled = 1
+        )
+      ORDER BY event_time DESC
+      LIMIT 5
+    expect:
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "recset_project_join"
+
+  - name: "Nested OR membership uses driver probing after a selective outer AND"
     sql: |
       EXPLAIN
       SELECT ID
@@ -191,9 +210,9 @@ test_cases:
       ORDER BY event_time DESC
     expect:
       result_contains:
-        - "recset_project_join"
-        - "$recset_contains"
         - "scan_order"
+      result_not_contains:
+        - "recset_project_join"
 
   - name: "Nested OR membership preserves sibling alternatives"
     sql: |
@@ -719,7 +738,7 @@ test_cases:
             - "__union_distinct_rows"
             - "__union_distinct_seen"
 
-  - name: "IN UNION joined order limit uses guarded keyset fallback"
+  - name: "IN UNION joined order limit costs keyset against driver probing"
     fail_comment: "query is not fully decorrelated anymore; logical IR must not contain subquery markers"
     setup:
       - sql: "DROP TABLE IF EXISTS in_dv_doc"
@@ -837,12 +856,13 @@ test_cases:
             - "in_candidate"
             - "candidate"
             - "membership_plan_strategy"
-            - "candidate_keyset"
+            - "driver_order_membership_probe"
             - "membership_selectivity_class"
             - "selective"
             - "membership_driver_rows"
             - "membership_candidate_input_rows"
             - "membership_cost_reason"
+            - "indexed_driver_probe_cost"
             - "source_estimates"
             - "group_stage_strategy"
             - "group_plan_options"
@@ -853,7 +873,6 @@ test_cases:
             - "in_membership"
             - ".grp:"
             - "touch_keytable"
-            - "driver_order_membership_probe"
       - sql: |
           EXPLAIN
           SELECT d.ID
@@ -986,11 +1005,11 @@ test_cases:
             - "membership_candidate_estimated_rows"
             - "membership_candidate_estimate_input"
             - "membership_cost_reason"
-            - "broad_membership_preserve_driver_order_limit"
+            - "indexed_driver_probe_cost"
           not_contains:
             - "inner_select"
             - "dependent-subquery"
-            - "selective_membership_build_candidate_keyset"
+            - "projected_membership_cost"
       - sql: |
           EXPLAIN REORDER
           SELECT t.ID
@@ -1015,14 +1034,14 @@ test_cases:
             - "membership_driver_rows"
             - "membership_candidate_input_rows"
             - "membership_cost_reason"
-            - "broad_membership_preserve_driver_order_limit"
+            - "indexed_driver_probe_cost"
             - "source_estimates"
             - "group_stage_strategy"
             - "group_plan_options"
           not_contains:
             - "inner_select"
             - "dependent-subquery"
-            - "selective_membership_build_candidate_keyset"
+            - "projected_membership_cost"
             - "driver_membership_probe"
             - ".grp:"
             - "touch_keytable"

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -24,6 +24,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_ref_b"
   - sql: "DROP TABLE IF EXISTS trace_ref_c"
   - sql: "DROP TABLE IF EXISTS trace_ref_d"
+  - sql: "DROP TABLE IF EXISTS trace_ref_dense"
   - sql: "DROP TABLE IF EXISTS trace_box"
   - sql: "DROP TABLE IF EXISTS trace_host"
   - sql: "DROP TABLE IF EXISTS trace_folder"
@@ -95,6 +96,12 @@ setup:
         asset_id INT,
         enabled BOOL
       )
+  - sql: |
+      CREATE TABLE trace_ref_dense (
+        id INT PRIMARY KEY,
+        asset_id INT,
+        enabled BOOL
+      )
   - sql: "INSERT INTO trace_asset (id, filename, kind, payload) VALUES (1, 'asset-1.dat', 1, 'p1')"
   - sql: "INSERT INTO trace_asset SELECT id + 1, CONCAT('asset-', CAST(id + 1 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 1 AS VARCHAR)) FROM trace_asset"
   - sql: "INSERT INTO trace_asset SELECT id + 2, CONCAT('asset-', CAST(id + 2 AS VARCHAR), '.dat'), CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, CONCAT('p', CAST(id + 2 AS VARCHAR)) FROM trace_asset"
@@ -111,6 +118,13 @@ setup:
   - sql: "INSERT INTO trace_ref_b SELECT id, id, TRUE FROM trace_asset WHERE id IN (1, 17, 257)"
   - sql: "INSERT INTO trace_ref_c SELECT id, id, FALSE FROM trace_asset WHERE id % 257 = 0"
   - sql: "INSERT INTO trace_ref_d SELECT id, id, TRUE FROM trace_asset WHERE id % 509 = 0"
+  - sql: "INSERT INTO trace_ref_dense (id, asset_id, enabled) VALUES (1, 1, TRUE)"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 1, asset_id, enabled FROM trace_ref_dense"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 2, asset_id, enabled FROM trace_ref_dense"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 4, asset_id, enabled FROM trace_ref_dense"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 8, asset_id, enabled FROM trace_ref_dense"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 16, asset_id, enabled FROM trace_ref_dense"
+  - sql: "INSERT INTO trace_ref_dense SELECT id + 32, asset_id, enabled FROM trace_ref_dense"
 
 test_cases:
   - name: "ordered UNION scalar probes use the multi-scan carrier"
@@ -268,7 +282,7 @@ test_cases:
     max_compile_metrics:
       group_stages: 49
       union_blocks: 1
-      group_caches: 24
+      group_caches: 1
     sql: |
       SELECT
         a.id,
@@ -329,12 +343,42 @@ test_cases:
         - "touch_keytable"
         - ".grp:"
 
+  - name: "Repeated bounded probes retain the cheaper shared group cache"
+    sql: |
+      EXPLAIN
+      SELECT a.id
+      FROM trace_asset a
+      WHERE a.id = 1
+        AND EXISTS (
+          SELECT r.id
+          FROM trace_ref_dense r
+          WHERE r.enabled
+            AND r.asset_id = a.id
+            AND COALESCE((
+              SELECT (b.owner_id = 7 OR EXISTS (
+                SELECT TRUE
+                FROM trace_share s
+                WHERE s.box_id = b.id AND s.owner_id = 7
+                LIMIT 1
+              ))
+              FROM trace_box b
+              WHERE b.id = r.asset_id * 100
+              LIMIT 1
+            ), FALSE)
+          UNION ALL
+          SELECT r.id FROM trace_ref_b r WHERE r.enabled AND r.asset_id = a.id
+        )
+    expect:
+      contains:
+        - "touch_keytable"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_asset"
   - sql: "DROP TABLE IF EXISTS trace_ref_a"
   - sql: "DROP TABLE IF EXISTS trace_ref_b"
   - sql: "DROP TABLE IF EXISTS trace_ref_c"
   - sql: "DROP TABLE IF EXISTS trace_ref_d"
+  - sql: "DROP TABLE IF EXISTS trace_ref_dense"
   - sql: "DROP TABLE IF EXISTS trace_box"
   - sql: "DROP TABLE IF EXISTS trace_host"
   - sql: "DROP TABLE IF EXISTS trace_folder"

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -234,6 +234,101 @@ test_cases:
           filename: "asset-2.dat"
           referenced: false
 
+  - name: "Selective UNION EXISTS keeps one logical union and bounded branch probes"
+    sql: |
+      EXPLAIN
+      SELECT
+        a.id,
+        EXISTS (
+          SELECT r.id FROM trace_ref_a r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_b r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_c r WHERE r.enabled AND r.asset_id = a.id
+          UNION ALL
+          SELECT r.id FROM trace_ref_d r WHERE r.enabled AND r.asset_id = a.id
+        ) AS referenced
+      FROM trace_asset a
+      WHERE a.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_exists"
+      result_occurrences:
+        - text: "scan_exists"
+          count: 4
+      result_not_contains:
+        - "touch_keytable"
+        - ".grp:"
+
+  - name: "Selective nested UNION EXISTS keeps bounded physical probes"
+    max_time: 1.0
+    max_planner_time_ms: 500
+    max_plan_size: 350000
+    max_compile_metrics:
+      group_stages: 49
+      union_blocks: 1
+      group_caches: 24
+    sql: |
+      SELECT
+        a.id,
+        EXISTS (
+          SELECT r01.id FROM trace_ref_a r01 WHERE r01.enabled AND r01.asset_id = a.id AND COALESCE((SELECT (b01.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s01 WHERE s01.box_id = b01.id AND s01.owner_id = 7 LIMIT 1)) FROM trace_box b01 WHERE b01.id = r01.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r02.id FROM trace_ref_b r02 WHERE r02.enabled AND r02.asset_id = a.id AND COALESCE((SELECT (b02.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s02 WHERE s02.box_id = b02.id AND s02.owner_id = 7 LIMIT 1)) FROM trace_box b02 WHERE b02.id = r02.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r03.id FROM trace_ref_c r03 WHERE r03.enabled AND r03.asset_id = a.id AND COALESCE((SELECT (b03.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s03 WHERE s03.box_id = b03.id AND s03.owner_id = 7 LIMIT 1)) FROM trace_box b03 WHERE b03.id = r03.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r04.id FROM trace_ref_d r04 WHERE r04.enabled AND r04.asset_id = a.id AND COALESCE((SELECT (b04.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s04 WHERE s04.box_id = b04.id AND s04.owner_id = 7 LIMIT 1)) FROM trace_box b04 WHERE b04.id = r04.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r05.id FROM trace_ref_a r05 WHERE r05.enabled AND r05.asset_id = a.id AND COALESCE((SELECT (b05.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s05 WHERE s05.box_id = b05.id AND s05.owner_id = 7 LIMIT 1)) FROM trace_box b05 WHERE b05.id = r05.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r06.id FROM trace_ref_b r06 WHERE r06.enabled AND r06.asset_id = a.id AND COALESCE((SELECT (b06.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s06 WHERE s06.box_id = b06.id AND s06.owner_id = 7 LIMIT 1)) FROM trace_box b06 WHERE b06.id = r06.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r07.id FROM trace_ref_c r07 WHERE r07.enabled AND r07.asset_id = a.id AND COALESCE((SELECT (b07.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s07 WHERE s07.box_id = b07.id AND s07.owner_id = 7 LIMIT 1)) FROM trace_box b07 WHERE b07.id = r07.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r08.id FROM trace_ref_d r08 WHERE r08.enabled AND r08.asset_id = a.id AND COALESCE((SELECT (b08.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s08 WHERE s08.box_id = b08.id AND s08.owner_id = 7 LIMIT 1)) FROM trace_box b08 WHERE b08.id = r08.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r09.id FROM trace_ref_a r09 WHERE r09.enabled AND r09.asset_id = a.id AND COALESCE((SELECT (b09.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s09 WHERE s09.box_id = b09.id AND s09.owner_id = 7 LIMIT 1)) FROM trace_box b09 WHERE b09.id = r09.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r10.id FROM trace_ref_b r10 WHERE r10.enabled AND r10.asset_id = a.id AND COALESCE((SELECT (b10.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s10 WHERE s10.box_id = b10.id AND s10.owner_id = 7 LIMIT 1)) FROM trace_box b10 WHERE b10.id = r10.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r11.id FROM trace_ref_c r11 WHERE r11.enabled AND r11.asset_id = a.id AND COALESCE((SELECT (b11.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s11 WHERE s11.box_id = b11.id AND s11.owner_id = 7 LIMIT 1)) FROM trace_box b11 WHERE b11.id = r11.asset_id * 100 LIMIT 1), FALSE)
+          UNION ALL
+          SELECT r12.id FROM trace_ref_d r12 WHERE r12.enabled AND r12.asset_id = a.id AND COALESCE((SELECT (b12.owner_id = 7 OR EXISTS (SELECT TRUE FROM trace_share s12 WHERE s12.box_id = b12.id AND s12.owner_id = 7 LIMIT 1)) FROM trace_box b12 WHERE b12.id = r12.asset_id * 100 LIMIT 1), FALSE)
+        ) AS referenced
+      FROM trace_asset a
+      WHERE a.id = 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          referenced: true
+
+  - name: "Broad UNION EXISTS uses a RecSet semijoin without group caches"
+    sql: |
+      EXPLAIN
+      SELECT a.id
+      FROM trace_asset a
+      WHERE EXISTS (
+        SELECT r.id FROM trace_ref_a r WHERE r.enabled AND r.asset_id = a.id
+        UNION ALL
+        SELECT r.id FROM trace_ref_b r WHERE r.enabled AND r.asset_id = a.id
+        UNION ALL
+        SELECT r.id FROM trace_ref_c r WHERE r.enabled AND r.asset_id = a.id
+        UNION ALL
+        SELECT r.id FROM trace_ref_d r WHERE r.enabled AND r.asset_id = a.id
+      )
+      ORDER BY a.id
+    expect:
+      rows: 1
+      result_contains:
+        - "recset_union"
+        - "recset_project_join"
+      result_not_contains:
+        - "touch_keytable"
+        - ".grp:"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_asset"
   - sql: "DROP TABLE IF EXISTS trace_ref_a"


### PR DESCRIPTION
## Outcome

This PR combines the correlated `EXISTS (... UNION ...)` groundwork from #441 with the independent OR-membership workload from #442. It separates three concerns which must not select each other implicitly:

1. SQL shapes are canonicalized to semantic membership and boolean primitives.
2. RecSet truth-set algebra is a method for developers to discover and prove additional normalization patterns.
3. Physical lowering costs ordinary driver scans with autoindex probes against projected RecSets, RecSet scan boundaries, and reusable group caches.

A normalization proved with RecSet algebra does **not** require RecSet execution. Cardinality and selectivity may make an ordinary scan/probe plan cheaper, including for membership below `OR` and nested presence checks.

## Architecture

### Canonicalization

- Positive `IN` in a WHERE truth context becomes the semantic `membership_truth` primitive.
- `IN (... UNION ...)` becomes a flat n-ary OR of membership alternatives where SQL three-valued semantics permit it.
- The rewrite does not cross `NOT`, `CASE`, projection, or another value-producing context.
- Correlated `EXISTS (... UNION ...)` retains one logical `union-block` instead of being expanded into unrelated physical helpers.
- Syntax recognition ends here; it does not choose `scan`, RecSet, group-cache, or autoindex execution.

### RecSet algebra is a proof method

For a fixed base relation `R`, let `T_R(p)` be the visible record IDs for which `p` is SQL `TRUE`:

```text
T_R(false)   = empty
T_R(true)    = all visible records of R
T_R(p OR q)  = T_R(p) union T_R(q)
T_R(p AND q) = T_R(p) intersect T_R(q)
p implies q  => T_R(p) is a subset of T_R(q)
```

Developers can use these laws to derive and prove useful transformations such as factoring or `IN(UNION)` to membership alternatives. Once proved, a transformation belongs as a recognized pattern in a normalization pass over semantic primitives. The compiler is not expected to enumerate arbitrary set formulas, and the proof notation is not a mandate to materialize a RecSet.

Candidate supersets remain valid only with the original predicate as a residual filter. Every rewrite must preserve base relation, visibility snapshot, multiplicity, ordering, NULL extension, and LIMIT boundaries. Complement laws remain unavailable for SQL `UNKNOWN` unless two-valued semantics are proved.

### Costed physical choice

The common membership chooser evaluates physical alternatives independently of SQL spelling:

- retain the driver and use ordinary scans plus autoindex-backed membership probes;
- project selective RHS keys to a driver RecSet;
- combine safe branch candidates with `recset_union` and use that as a scan boundary;
- retain a reusable group cache when repeated nested probes amortize its build cost.

The inputs include filtered driver cardinality, filtered RHS cardinality, capped-estimate conservatism, setup cost, per-key work, ordered-driver facts, expected bounded branch rows, and dependent-stage input size. Only top-level membership-free conjuncts reduce the driver estimate; a predicate local to one OR branch cannot incorrectly discount rows admitted by a sibling.

Unknown membership estimates default to the ordinary scan/probe plan. A bounded nested presence probe is inlined only when its estimated probe work is cheaper than constructing the shared dependent cache. Autoindex remains responsible for the concrete hash/range access path inside every scan.

## Regressions and compile-time fix

- Selective OR membership over a 10,000-row driver chooses projected RecSets and keeps its unchanged 20 ms budget.
- The same narrow RHS switches back to driver probing when a preceding conjunct reduces the driver to 11 rows.
- A broad 8,000-key RHS below OR retains the driver.
- The nested 12-branch EXISTS/UNION regression now lowers simple dependent presence checks after root braking instead of generating 24 persistent group caches.
- A counterexample with 64 expected repeated probes verifies that the cost model retains the cheaper shared group cache.
- All plan-shape cases have result-correctness assertions.

The formerly red CI check was `Selective nested UNION EXISTS keeps bounded physical probes`: latest CI measured 631.3 ms against its unchanged 500 ms planner limit. The revised lowering also constructs the immutable branch stage catalog and dependency graph once and reuses them across all UNION arms.

No guard, input size, planner limit, wall-time limit, plan-size limit, or criticality marker was weakened.

## A/B measurements

Membership runtime fixture:

| Measurement | `origin/master` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Cold selective OR-membership query | 47.1 ms | 8.7 ms | 5.4x faster |
| Required runtime budget | failed 20 ms | passed 20 ms | critical regression fixed |

Nested 12-branch compile fixture, same local process and SQL:

| Metric | Before nested lowering fix | After | Delta |
| --- | ---: | ---: | ---: |
| Planner total | ~352 ms | 249–260 ms | ~1.4x faster |
| Recipe emission | ~205 ms | 105–113 ms | ~1.9x faster |
| Physical plan nodes | 16,360 | 1,948 | 88% fewer |
| Physical plan bytes | 181,562 | 34,082 | 81% fewer |
| Group caches | 24 | 0 | eliminated for selective case |

The hand-written #442 reference plan measured 1.96 ms versus 1.420 s on its larger preserved production-like fixture (~724x). That motivates the available RecSet plan, but the cost model may reject it for broad RHS inputs or already-small drivers.

## Validation

- Full normal pre-commit hook: passed without bypass; all SQL suites green.
- SQL regression guard: passed unchanged.
- `tests/planner/subqueries/in-subquery.yaml`: 68/68.
- `tests/planner/subqueries/traced-union-scalar-probes.yaml`: 7/7.
- Scheme startup unit tests: 917/917.
- Formatter and build: passed.

## Future extensions

Additional proven boolean/set transformations should extend the normalization infrastructure, while new physical implementations extend the common capability and cost model. Runtime adaptive crossover, reuse-aware distinct-key estimates, projection fanout, and more precise ORDER/LIMIT braking remain physical-cost improvements—not new SQL-shape-specific lowerers.