### PR TITLE
test: cover cost-based OR membership lowering

### DIFF
--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -33,8 +33,152 @@ setup:
   - sql: "CREATE TABLE membership_assignment (ID INT PRIMARY KEY, result INT)"
   - sql: "INSERT INTO membership_item (ID, name) VALUES (1, 'item-1'), (2, 'item-2'), (3, 'item-3'), (4, 'item-4'), (5, 'item-5')"
   - sql: "INSERT INTO membership_assignment (ID, result) VALUES (101, 1), (102, 3), (103, 3)"
+  - sql: "DROP TABLE IF EXISTS membership_event"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_a"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_b"
+  - sql: "DROP TABLE IF EXISTS membership_broad_key"
+  - sql: |
+      CREATE TABLE membership_event (
+        ID INT PRIMARY KEY,
+        entity_kind VARCHAR(32),
+        entity_key VARCHAR(64),
+        event_time INT
+      )
+  - sql: "CREATE TABLE membership_narrow_key_a (ID INT PRIMARY KEY, enabled INT)"
+  - sql: "CREATE TABLE membership_narrow_key_b (ID INT PRIMARY KEY, enabled INT)"
+  - sql: "CREATE TABLE membership_broad_key (ID INT PRIMARY KEY, enabled INT)"
+  - scm: |
+      (begin
+        (define events (map (produceN 10000) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (if (>= id 9992)
+              (list id "root" "root:1" id)
+              (if (>= id 9983)
+                (list id "narrow_a" "narrow_a:1" id)
+                (if (>= id 9974)
+                  (list id "narrow_b" "narrow_b:1" id)
+                  (list id "noise" (concat "noise:" id) id))))))))
+        (insert (table "memcp-tests" "membership_event")
+          '("ID" "entity_kind" "entity_key" "event_time") events)
+        (insert (table "memcp-tests" "membership_narrow_key_a")
+          '("ID" "enabled") (list (list 1 1) (list 2 0)))
+        (insert (table "memcp-tests" "membership_narrow_key_b")
+          '("ID" "enabled") (list (list 1 1) (list 2 0)))
+        (insert (table "memcp-tests" "membership_broad_key")
+          '("ID" "enabled")
+          (map (produceN 8000) (lambda (i) (list (+ i 1) 1))))
+        true)
 
 test_cases:
+  - name: "Selective IN branches under OR use projected membership recsets"
+    noncritical: true
+    fail_comment: "multiple selective IN branches under OR still lower to per-driver group-cache probes"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC
+      LIMIT 20
+    expect:
+      result_contains:
+        - "recset_project_join"
+        - "$recset_contains"
+        - "scan_order"
+
+  - name: "Selective IN branches under OR preserve ordered results"
+    sql: |
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC, ID DESC
+      LIMIT 20
+    expect:
+      rows: 20
+      data:
+        - ID: 10000
+        - ID: 9999
+        - ID: 9998
+        - ID: 9997
+        - ID: 9996
+        - ID: 9995
+        - ID: 9994
+        - ID: 9993
+        - ID: 9992
+        - ID: 9991
+        - ID: 9990
+        - ID: 9989
+        - ID: 9988
+        - ID: 9987
+        - ID: 9986
+        - ID: 9985
+        - ID: 9984
+        - ID: 9983
+        - ID: 9982
+        - ID: 9981
+
+  - name: "Selective IN branches under OR meet the projected membership budget"
+    noncritical: true
+    fail_comment: "the projected RecSet plan measures in low milliseconds; per-driver group-cache probes exceed this budget"
+    max_time: 0.02
+    sql: |
+      SELECT ID
+      FROM membership_event
+      WHERE (entity_kind = 'root' AND entity_key = 'root:1')
+        OR (entity_kind = 'narrow_a' AND entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+        OR (entity_kind = 'narrow_b' AND entity_key IN (
+          SELECT CONCAT('narrow_b:', ID)
+          FROM membership_narrow_key_b
+          WHERE enabled = 1
+        ))
+      ORDER BY event_time DESC, ID DESC
+      LIMIT 20
+    expect:
+      rows: 20
+
+  - name: "Broad IN branches retain driver probing"
+    sql: |
+      EXPLAIN
+      SELECT ID
+      FROM membership_event
+      WHERE entity_kind = 'noise' AND entity_key IN (
+        SELECT CONCAT('noise:', ID)
+        FROM membership_broad_key
+        WHERE enabled = 1
+      )
+      ORDER BY event_time DESC
+      LIMIT 5
+    expect:
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "recset_project_join"
+
   - name: "IN subquery - files with render results"
     sql: |
       SELECT ID, name FROM in_fop_files
@@ -1837,6 +1981,10 @@ test_cases:
           "tenant:canView": true
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS membership_broad_key"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_b"
+  - sql: "DROP TABLE IF EXISTS membership_narrow_key_a"
+  - sql: "DROP TABLE IF EXISTS membership_event"
   - sql: "DROP TABLE IF EXISTS assignment_x"
   - sql: "DROP TABLE IF EXISTS item_x"
   - sql: "DROP TABLE IF EXISTS tenant_x"


### PR DESCRIPTION
## Purpose

This is a test-only companion for #441. It adds an anonymous second membership shape that should use the same physical cost decision as correlated `EXISTS (... UNION ALL ...)`: multiple independent positive `IN` predicates below one top-level `OR`, combined with local guards and `ORDER BY ... LIMIT`.

No planner implementation is included. The intent is to merge these regressions into #441 and keep one common membership lowerer instead of introducing a competing shape-specific path.

## Reproduced current plan

The current lowerer turns every positive `IN` into a match stage plus an RHS-NULL stage. Because `driver_membership_for_source` only discovers membership markers among top-level AND terms, memberships nested below OR are left as stage-backed sources.

The resulting ordered driver scan:

- receives physical limit `-1` and counts accepted rows in the callback;
- performs match and NULL group-cache scans for every visited driver row;
- prepares four caches for two positive `IN` branches;
- cannot compare row-wise probes with one-time target RecSet projection.

For an anonymous preserved workload with 1,104 driver rows, two selective RHS relations, and 18 output rows:

| Plan | Warm wall time |
| --- | ---: |
| current compiled plan | 1.420 s median |
| hand-written exact RecSet callback plan | 1.96 ms median |

The hand-written plan was roughly 724x faster and returned the same ordered IDs. Its main ordered scan measured about 1.12 ms.

## Desired physical plan

1. Prepare each reusable canonical match cache once.
2. Scan each cache keyset once.
3. Use `recset_project_join` to project RHS keys onto the driver key column.
4. Keep every branch-local guard in the original OR expression.
5. Feed the projected RecSets through separate `$recset_contains` callbacks to one `scan_order` that owns ORDER, OFFSET, and LIMIT.

This uses existing scalable primitives only. It does not materialize a UNION or a relation in an SCM list, and it needs no new physical operator.

Match projection by key alone is not semantically sufficient: target rows can share a key across branch categories. The local branch guards must remain in the final filter.

## Cost-model handoff for #441

Please centralize the choice used by both #441 and these tests. The relevant alternatives are:

- bounded row-wise `scan_exists` or group-cache probes;
- one-time match-cache or RHS-to-target RecSet projection;
- unioned branch RecSets when branches may overlap;
- `scan_order_multi` only when branches are provably disjoint and independently streamable;
- one ordered driver scan with multiple RecSet membership callbacks.

The choice should use available statistics rather than consumer shape alone:

- driver/base cardinality;
- driver selectivity after local predicates;
- expected driver demand after ORDER, OFFSET, and LIMIT;
- RHS input cardinality and branch-local selectivity;
- estimated distinct RHS key cardinality;
- estimated projected target cardinality;
- target key distinctness/index availability;
- branch count, overlap, and expected short-circuit hit position;
- reusable canonical cache availability;
- NULL/truth context;
- compile-time and generated-plan growth.

A useful comparison is:

```text
probe_cost =
  expected_driver_rows_visited
  * sum(expected_probe_cost_per_membership)

projection_cost =
  sum(filtered_rhs_rows + distinct_rhs_keys * target_index_probe_cost)
  + expected_driver_rows_visited * cheap_recset_contains_cost
```

For a broad RHS keyset close to the target cardinality, projection can be worse than preserving the ordered driver and probing only until a small LIMIT is satisfied. The critical broad-RHS regression therefore asserts that the lowerer does not blindly choose `recset_project_join`.

For a small selective RHS keyset and high driver demand, repeated group-cache scans are substantially more expensive than one projection. The selective plan and runtime regressions are `noncritical` until #441 implements the shared decision.

Positive `IN` can discard the separate RHS-NULL stage only when consumed directly as a WHERE truth filter. Projection, CASE, negation, and `NOT IN` still require complete SQL three-valued semantics.

## Tests

Added to `tests/planner/subqueries/in-subquery.yaml`:

- selective two-`IN` OR shape expects `recset_project_join`, `$recset_contains`, and `scan_order` (`noncritical`, currently fails);
- exact ordered-result regression (critical, passes);
- 10,000-row runtime budget of 20 ms (`noncritical`, currently fails);
- broad RHS guard against unconditional RecSet projection (critical, passes).

Targeted result on current master:

```text
63/65 passed
2 expected noncritical failures
```

The full test run was intentionally not completed at the requester’s direction; the targeted suite was run repeatedly and the final two failures are the explicitly documented TODO regressions.