### PR TITLE
Optimize adaptive RecSet operations

### DIFF
--- a/storage/recset.go
+++ b/storage/recset.go
@@ -29,17 +29,30 @@ import "github.com/launix-de/memcp/scm"
 const TagRecSet = 102
 
 type recSetShard struct {
-	shard  *storageShard
-	recids []uint32
-	count  int64
+	shard    *storageShard
+	kind     recSetRepresentation
+	universe uint32
+	data     []uint32
+	used     uint32
+	count    int64
 }
 
 func (s *recSetShard) contains(recid uint32) bool {
-	if s == nil {
+	if s == nil || recid >= s.universe {
 		return false
 	}
-	pos := sort.Search(len(s.recids), func(i int) bool { return s.recids[i] >= recid })
-	return pos < len(s.recids) && s.recids[pos] == recid
+	switch s.kind {
+	case recSetFull:
+		return true
+	case recSetPositive:
+		return sortedUint32Contains(s.listedValues(), recid)
+	case recSetNegative:
+		return !sortedUint32Contains(s.listedValues(), recid)
+	case recSetBitmap:
+		return s.data[recid>>5]&(uint32(1)<<(recid&31)) != 0
+	default:
+		return false
+	}
 }
 
 // recSet is a query-local, non-persistent subset of one table represented by
@@ -103,7 +116,7 @@ func recSetUnion(items []*recSet) *recSet {
 		return result
 	}
 
-	byShard := make(map[*storageShard][]uint32)
+	byShard := make(map[*storageShard][]*recSetShard)
 	for _, rs := range items {
 		if rs == nil || rs.table == nil {
 			continue
@@ -113,28 +126,51 @@ func recSetUnion(items []*recSet) *recSet {
 			if part.count == 0 {
 				continue
 			}
-			byShard[part.shard] = append(byShard[part.shard], part.recids...)
+			byShard[part.shard] = append(byShard[part.shard], &rs.shards[i])
 		}
 	}
-	for shard, recids := range byShard {
-		sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
-		write := 0
-		var last uint32
-		for i, recid := range recids {
-			if i > 0 && recid == last {
-				continue
-			}
-			recids[write] = recid
-			write++
-			last = recid
-		}
-		recids = recids[:write]
-		result.count += int64(len(recids))
-		result.shards = append(result.shards, recSetShard{shard: shard, recids: recids, count: int64(len(recids))})
+	for shard, parts := range byShard {
+		part := unionRecSetShards(shard, parts)
+		result.count += part.count
+		result.shards = append(result.shards, part)
 	}
 	sort.Slice(result.shards, func(i, j int) bool {
 		return result.shards[i].shard.uuid.String() < result.shards[j].shard.uuid.String()
 	})
+	return result
+}
+
+func recSetIntersect(items []*recSet) *recSet {
+	var base *table
+	var tx *TxContext
+	for _, rs := range items {
+		if rs == nil || rs.table == nil {
+			continue
+		}
+		if base == nil {
+			base = rs.table
+			tx = rs.tx
+		} else if base != rs.table {
+			panic("recset_intersect: all recsets must belong to the same table")
+		}
+	}
+	result := &recSet{tx: tx, table: base}
+	if base == nil || len(items) == 0 {
+		return result
+	}
+	for _, shard := range base.ActiveShards() {
+		parts := make([]*recSetShard, len(items))
+		for i, rs := range items {
+			if rs != nil {
+				parts[i] = rs.shardEntry(shard)
+			}
+		}
+		part := intersectRecSetShards(shard, parts)
+		if part.count > 0 {
+			result.count += part.count
+			result.shards = append(result.shards, part)
+		}
+	}
 	return result
 }
 
@@ -168,7 +204,8 @@ type recSetBuildResult struct {
 }
 
 type recSetKeyResult struct {
-	keys [][]scm.Scmer
+	part int
+	used int
 	err  scanError
 }
 
@@ -301,54 +338,80 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	maxInsertIndex := len(t.inserts)
 	visibleUpper := t.main_count + uint32(maxInsertIndex)
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
-	recids := make([]uint32, 0, 64)
+	completeTraversal := len(boundaries) == 0 && recsetFilter == nil
+	builder := newRecSetShardBuilder(t, visibleUpper, completeTraversal)
+	replayCandidates := 0
+	evaluate := func(idx uint32) bool {
+		if recsetPart != nil && !recsetPart.contains(idx) {
+			return false
+		}
+		if idx >= visibleUpper {
+			return false
+		}
+		if acidMode {
+			if !currentTx.IsVisible(t, idx) {
+				return false
+			}
+		} else if t.deletions.Get(uint(idx)) {
+			return false
+		}
+		if idx < t.main_count {
+			for i, c := range cReaders {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else if cNeedsCachedReader[i] {
+					cdataset[i] = c.GetValue(idx)
+				} else {
+					cdataset[i] = ccols[i].GetValue(idx)
+				}
+			}
+		} else {
+			for i, col := range conditionCols {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(idx, 0)
+				} else if cNeedsCachedReader[i] {
+					cdataset[i] = cReaders[i].GetValue(idx)
+				} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					cdataset[i] = ccols[i].GetValue(idx)
+				} else {
+					cdataset[i] = t.getDelta(int(idx-t.main_count), col)
+				}
+			}
+		}
+		return scm.ToBool(conditionFn(cdataset...))
+	}
 	var buf [1024]uint32
+	processedCandidates := 0
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 		for _, idx := range batch {
-			if recsetPart != nil && !recsetPart.contains(idx) {
-				continue
-			}
 			if idx >= visibleUpper {
 				continue
 			}
-			if acidMode {
-				if !currentTx.IsVisible(t, idx) {
-					continue
-				}
-			} else if t.deletions.Get(uint(idx)) {
-				continue
-			}
-			if idx < t.main_count {
-				for i, c := range cReaders {
-					if getter := conditionGetters[i]; getter != nil {
-						cdataset[i] = getter(idx, 0)
-					} else if cNeedsCachedReader[i] {
-						cdataset[i] = c.GetValue(idx)
-					} else {
-						cdataset[i] = ccols[i].GetValue(idx)
-					}
-				}
-			} else {
-				for i, col := range conditionCols {
-					if getter := conditionGetters[i]; getter != nil {
-						cdataset[i] = getter(idx, 0)
-					} else if cNeedsCachedReader[i] {
-						cdataset[i] = cReaders[i].GetValue(idx)
-					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
-						cdataset[i] = ccols[i].GetValue(idx)
-					} else {
-						cdataset[i] = t.getDelta(int(idx-t.main_count), col)
-					}
-				}
-			}
-			if scm.ToBool(conditionFn(cdataset...)) {
-				recids = append(recids, idx)
+			processedCandidates++
+			wasBitmap := builder.bitmap
+			builder.add(idx, evaluate(idx))
+			if !wasBitmap && builder.bitmap {
+				replayCandidates = processedCandidates
 			}
 		}
 		return true
 	})
-	sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
-	return recSetShard{shard: t, recids: recids, count: int64(len(recids))}
+	if replayCandidates > 0 {
+		replayed := 0
+		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], false, func(batch []uint32) bool {
+			for _, idx := range batch {
+				if idx < visibleUpper {
+					builder.addBitmap(idx, evaluate(idx))
+					replayed++
+					if replayed >= replayCandidates {
+						return false
+					}
+				}
+			}
+			return true
+		})
+	}
+	return builder.finish()
 }
 
 func (r *recSet) projectJoin(currentTx *TxContext, sourceKeyCols []string, target *table, targetKeyCols []string) *recSet {
@@ -366,9 +429,91 @@ func (r *recSet) projectJoin(currentTx *TxContext, sourceKeyCols []string, targe
 	return target.projectJoinKeysToRecSet(currentTx, targetKeyCols, keys, ss)
 }
 
-func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []string, ss *scm.SessionState) [][]scm.Scmer {
+type recSetProjectKeys struct {
+	width  int
+	values []scm.Scmer
+}
+
+func (k *recSetProjectKeys) count() int {
+	if k.width == 0 {
+		return 0
+	}
+	return len(k.values) / k.width
+}
+
+func (k *recSetProjectKeys) tuple(index int) []scm.Scmer {
+	start := index * k.width
+	return k.values[start : start+k.width]
+}
+
+func (k *recSetProjectKeys) contains(key []scm.Scmer) bool {
+	position := sort.Search(k.count(), func(i int) bool {
+		return compareProjectKey(k.tuple(i), key) >= 0
+	})
+	return position < k.count() && compareProjectKey(k.tuple(position), key) == 0
+}
+
+func compareProjectKey(left, right []scm.Scmer) int {
+	for i := range left {
+		if scm.Equal(left[i], right[i]) {
+			continue
+		}
+		if scm.Less(left[i], right[i]) {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func (k *recSetProjectKeys) sortAndDeduplicate() {
+	count := k.count()
+	if count < 2 {
+		return
+	}
+	sort.Sort(makeProjectKeyIndices(k))
+	write := 1
+	for read := 1; read < count; read++ {
+		if compareProjectKey(k.tuple(write-1), k.tuple(read)) == 0 {
+			continue
+		}
+		if write != read {
+			copy(k.tuple(write), k.tuple(read))
+		}
+		write++
+	}
+	k.values = k.values[:write*k.width]
+}
+
+type projectKeyIndices struct {
+	keys *recSetProjectKeys
+}
+
+func makeProjectKeyIndices(keys *recSetProjectKeys) *projectKeyIndices {
+	return &projectKeyIndices{keys: keys}
+}
+
+func (p *projectKeyIndices) Len() int { return p.keys.count() }
+func (p *projectKeyIndices) Less(i, j int) bool {
+	return compareProjectKey(p.keys.tuple(i), p.keys.tuple(j)) < 0
+}
+func (p *projectKeyIndices) Swap(i, j int) {
+	left := p.keys.tuple(i)
+	right := p.keys.tuple(j)
+	for col := range left {
+		left[col], right[col] = right[col], left[col]
+	}
+}
+
+func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []string, ss *scm.SessionState) recSetProjectKeys {
 	querySeq := scm.CurrentQuerySeq()
 	values := make(chan recSetKeyResult, len(r.shards))
+	width := len(sourceKeyCols)
+	keys := recSetProjectKeys{width: width, values: make([]scm.Scmer, int(r.count)*width)}
+	offsets := make([]int, len(r.shards)+1)
+	for i := range r.shards {
+		offsets[i+1] = offsets[i] + int(r.shards[i].count)*width
+	}
 	closeAfter := 0
 	for i := range r.shards {
 		part := r.shards[i]
@@ -376,11 +521,11 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 			continue
 		}
 		closeAfter++
-		go func(part recSetShard) {
+		go func(partIndex int, part recSetShard) {
 			withTxSession(currentTx, func() scm.Scmer {
 				defer func() {
 					if rec := recover(); rec != nil {
-						values <- recSetKeyResult{err: scanError{rec, string(debug.Stack())}}
+						values <- recSetKeyResult{part: partIndex, err: scanError{rec, string(debug.Stack())}}
 					}
 				}()
 				// Cancellation contract: check only at the scheduling boundary, before entering
@@ -388,12 +533,14 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				values <- recSetKeyResult{keys: part.shard.collectProjectJoinKeys(part.recids, sourceKeyCols, currentTx, ss)}
+				dst := keys.values[offsets[partIndex]:offsets[partIndex+1]]
+				used := part.shard.collectProjectJoinKeys(&part, sourceKeyCols, currentTx, ss, dst)
+				values <- recSetKeyResult{part: partIndex, used: used}
 				return scm.NewNil()
 			})
-		}(part)
+		}(i, part)
 	}
-	keys := make([][]scm.Scmer, 0, r.count)
+	used := make([]int, len(r.shards))
 	var keyErr scanError
 	for i := 0; i < closeAfter; i++ {
 		msg := <-values
@@ -403,15 +550,26 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 			}
 			continue
 		}
-		keys = append(keys, msg.keys...)
+		used[msg.part] = msg.used
 	}
 	if keyErr.r != nil {
 		panic(keyErr)
 	}
+	write := 0
+	for i := range r.shards {
+		if used[i] == 0 {
+			continue
+		}
+		start := offsets[i]
+		copy(keys.values[write:], keys.values[start:start+used[i]])
+		write += used[i]
+	}
+	keys.values = keys.values[:write]
+	keys.sortAndDeduplicate()
 	return keys
 }
 
-func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []string, currentTx *TxContext, ss *scm.SessionState) [][]scm.Scmer {
+func (t *storageShard) collectProjectJoinKeys(part *recSetShard, sourceKeyCols []string, currentTx *TxContext, ss *scm.SessionState, dst []scm.Scmer) int {
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -448,55 +606,55 @@ func (t *storageShard) collectProjectJoinKeys(recids []uint32, sourceKeyCols []s
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
-	keys := make([][]scm.Scmer, 0, len(recids))
-	for _, idx := range recids {
+	write := 0
+	part.forEachID(func(idx uint32) bool {
 		if idx >= visibleUpper {
-			continue
+			return true
 		}
 		if acidMode {
 			if !currentTx.IsVisible(t, idx) {
-				continue
+				return true
 			}
 		} else if t.deletions.Get(uint(idx)) {
-			continue
+			return true
 		}
-		key := make([]scm.Scmer, len(sourceKeyCols))
 		skip := false
 		if idx < mainCount {
 			for i, col := range cols {
 				if needsTxReader[i] {
-					key[i] = readers[i].GetValue(idx)
+					dst[write+i] = readers[i].GetValue(idx)
 				} else {
-					key[i] = col.GetValue(idx)
+					dst[write+i] = col.GetValue(idx)
 				}
-				if key[i].IsNil() {
+				if dst[write+i].IsNil() {
 					skip = true
 				}
 			}
 		} else {
 			for i, col := range sourceKeyCols {
 				if needsTxReader[i] {
-					key[i] = readers[i].GetValue(idx)
+					dst[write+i] = readers[i].GetValue(idx)
 				} else if _, isProxy := cols[i].(*StorageComputeProxy); isProxy {
-					key[i] = cols[i].GetValue(idx)
+					dst[write+i] = cols[i].GetValue(idx)
 				} else {
-					key[i] = t.getDelta(int(idx-mainCount), col)
+					dst[write+i] = t.getDelta(int(idx-mainCount), col)
 				}
-				if key[i].IsNil() {
+				if dst[write+i].IsNil() {
 					skip = true
 				}
 			}
 		}
 		if !skip {
-			keys = append(keys, key)
+			write += len(sourceKeyCols)
 		}
-	}
-	return keys
+		return true
+	})
+	return write
 }
 
-func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []string, keys [][]scm.Scmer, ss *scm.SessionState) *recSet {
+func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []string, keys recSetProjectKeys, ss *scm.SessionState) *recSet {
 	result := &recSet{tx: currentTx, table: t}
-	if len(keys) == 0 {
+	if keys.count() == 0 {
 		return result
 	}
 	querySeq := scm.CurrentQuerySeq()
@@ -517,7 +675,8 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 			if ss != nil && ss.IsKilledSeq(querySeq) {
 				panic("query killed")
 			}
-			values <- targetPartResult{part: shard.projectJoinKeysPart(currentTx, targetKeyCols, keys, ss)}
+			dense := uint(keys.count()*64) >= t.CountEstimate()
+			values <- targetPartResult{part: shard.projectJoinKeysPart(currentTx, targetKeyCols, keys, ss, dense)}
 			return scm.NewNil()
 		})
 	})
@@ -549,7 +708,7 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 	return result
 }
 
-func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols []string, keys [][]scm.Scmer, ss *scm.SessionState) recSetShard {
+func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols []string, keys recSetProjectKeys, ss *scm.SessionState, dense bool) recSetShard {
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -585,10 +744,56 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 	maxInsertIndex := len(t.inserts)
 	visibleUpper := t.main_count + uint32(maxInsertIndex)
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	if dense {
+		builder := newRecSetShardBuilder(t, visibleUpper, true)
+		actual := make([]scm.Scmer, len(targetKeyCols))
+		replayUntil := uint32(0)
+		evaluate := func(idx uint32) bool {
+			visible := true
+			if acidMode {
+				visible = currentTx.IsVisible(t, idx)
+			} else if t.deletions.Get(uint(idx)) {
+				visible = false
+			}
+			if !visible {
+				return false
+			}
+			for col := range targetKeyCols {
+				if idx < t.main_count {
+					if targetNeedsTxReader[col] {
+						actual[col] = targetReaders[col].GetValue(idx)
+					} else {
+						actual[col] = targetCols[col].GetValue(idx)
+					}
+				} else if targetNeedsTxReader[col] {
+					actual[col] = targetReaders[col].GetValue(idx)
+				} else if _, proxy := targetCols[col].(*StorageComputeProxy); proxy {
+					actual[col] = targetCols[col].GetValue(idx)
+				} else {
+					actual[col] = t.getDelta(int(idx-t.main_count), targetKeyCols[col])
+				}
+			}
+			return keys.contains(actual)
+		}
+		for idx := uint32(0); idx < visibleUpper; idx++ {
+			wasBitmap := builder.bitmap
+			builder.add(idx, evaluate(idx))
+			if !wasBitmap && builder.bitmap {
+				replayUntil = idx + 1
+			}
+		}
+		if replayUntil > 0 {
+			for idx := uint32(0); idx < replayUntil; idx++ {
+				builder.addBitmap(idx, evaluate(idx))
+			}
+		}
+		return builder.finish()
+	}
 	seen := make(map[uint32]struct{})
 	recids := make([]uint32, 0, 64)
 	var buf [1024]uint32
-	for _, key := range keys {
+	for keyIndex := 0; keyIndex < keys.count(); keyIndex++ {
+		key := keys.tuple(keyIndex)
 		bounds := make(boundaries, len(targetKeyCols))
 		for i, col := range targetKeyCols {
 			bounds[i] = columnboundaries{
@@ -627,7 +832,7 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 		})
 	}
 	sort.Slice(recids, func(i, j int) bool { return recids[i] < recids[j] })
-	return recSetShard{shard: t, recids: recids, count: int64(len(recids))}
+	return newRecSetShardFromSortedIDs(t, visibleUpper, recids)
 }
 
 func (t *storageShard) projectJoinTargetMatches(idx uint32, key []scm.Scmer, targetKeyCols []string, targetCols []ColumnStorage, targetReaders []ColumnReader, targetNeedsTxReader []bool, currentTx *TxContext) bool {
@@ -685,7 +890,7 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				res, cnt := part.shard.scanRecSetPart(part.recids, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
+				res, cnt := part.shard.scanRecSetPart(&part, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
 				values <- scanResult{res: res, outCount: cnt, inputCount: part.count}
 				return scm.NewNil()
 			})
@@ -795,7 +1000,7 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				found := part.shard.recSetPartExists(part.recids, conditionCols, conditionFn, currentTx, ss, &stop)
+				found := part.shard.recSetPartExists(&part, conditionCols, conditionFn, currentTx, ss, &stop)
 				if found {
 					stop.Store(true)
 				}
@@ -824,7 +1029,7 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 	return found
 }
 
-func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
+func (t *storageShard) recSetPartExists(part *recSetShard, conditionCols []string, conditionFn func(...scm.Scmer) scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -867,19 +1072,20 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
-	for _, idx := range recids {
+	found := false
+	part.forEachID(func(idx uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}
 		if idx >= visibleUpper {
-			continue
+			return true
 		}
 		if acidMode {
 			if !currentTx.IsVisible(t, idx) {
-				continue
+				return true
 			}
 		} else if t.deletions.Get(uint(idx)) {
-			continue
+			return true
 		}
 		if idx < mainCount {
 			for i, c := range cReaders {
@@ -901,13 +1107,15 @@ func (t *storageShard) recSetPartExists(recids []uint32, conditionCols []string,
 			}
 		}
 		if scm.ToBool(conditionFn(cdataset...)) {
-			return true
+			found = true
+			return false
 		}
-	}
-	return false
+		return true
+	})
+	return found
 }
 
-func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
+func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64) {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
@@ -957,16 +1165,16 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	var outCount int64
 	var buf [1024]uint32
 	pending := buf[:0]
-	for _, idx := range recids {
+	part.forEachID(func(idx uint32) bool {
 		if idx >= visibleUpper {
-			continue
+			return true
 		}
 		if acidMode {
 			if !currentTx.IsVisible(t, idx) {
-				continue
+				return true
 			}
 		} else if t.deletions.Get(uint(idx)) {
-			continue
+			return true
 		}
 		if idx < mainCount {
 			for i, c := range cReaders {
@@ -988,7 +1196,7 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 			}
 		}
 		if !scm.ToBool(conditionFn(cdataset...)) {
-			continue
+			return true
 		}
 		pending = append(pending, idx)
 		outCount++
@@ -1004,7 +1212,8 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 				locked = true
 			}
 		}
-	}
+		return true
+	})
 	if len(pending) > 0 {
 		if locked {
 			t.mu.RUnlock()
@@ -1023,7 +1232,7 @@ func (t *storageShard) scanRecSetPart(recids []uint32, conditionCols []string, c
 	return akkumulator, outCount
 }
 
-func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
+func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) *shardqueue {
 	result := &shardqueue{shard: t}
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
@@ -1129,17 +1338,17 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
-	result.items = make([]uint32, 0, len(recids))
-	for _, idx := range recids {
+	result.items = make([]uint32, 0, part.count)
+	part.forEachID(func(idx uint32) bool {
 		if idx >= visibleUpper {
-			continue
+			return true
 		}
 		if acidMode {
 			if !currentTx.IsVisible(t, idx) {
-				continue
+				return true
 			}
 		} else if t.deletions.Get(uint(idx)) {
-			continue
+			return true
 		}
 		if idx < mainCount {
 			for i, c := range cReaders {
@@ -1163,7 +1372,8 @@ func (t *storageShard) scan_order_recids(recids []uint32, conditionCols []string
 		if scm.ToBool(conditionFn(cdataset...)) {
 			result.items = append(result.items, idx)
 		}
-	}
+		return true
+	})
 
 	itemPos := make(map[uint32]int, len(result.items))
 	for i, idx := range result.items {

--- a/storage/recset_representation.go
+++ b/storage/recset_representation.go
@@ -1,0 +1,466 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "math/bits"
+import "sort"
+
+type recSetRepresentation uint8
+
+const (
+	recSetEmpty recSetRepresentation = iota
+	recSetFull
+	recSetPositive
+	recSetNegative
+	recSetBitmap
+)
+
+// recSetShardBuilder allocates exactly the eventual bitmap footprint. Until
+// deviations from the first result fill that storage, the same words hold a
+// positive or negative recid list. Overflow converts the words in place.
+type recSetShardBuilder struct {
+	shard       *storageShard
+	universe    uint32
+	data        []uint32
+	deviations  uint32
+	matched     uint32
+	defaultHit  bool
+	initialized bool
+	bitmap      bool
+}
+
+func newRecSetShardBuilder(shard *storageShard, universe uint32, allowFull bool) *recSetShardBuilder {
+	builder := &recSetShardBuilder{
+		shard:    shard,
+		universe: universe,
+		data:     make([]uint32, (universe+31)/32),
+	}
+	if !allowFull {
+		builder.initialized = true
+	}
+	return builder
+}
+
+func (b *recSetShardBuilder) add(recid uint32, hit bool) {
+	if !b.initialized {
+		b.initialized = true
+		b.defaultHit = hit
+	}
+	if hit {
+		b.matched++
+	}
+	if b.bitmap {
+		b.addBitmap(recid, hit)
+		return
+	}
+	if hit == b.defaultHit {
+		return
+	}
+	if b.deviations < uint32(len(b.data)) {
+		b.data[b.deviations] = recid
+		b.deviations++
+		return
+	}
+	clear(b.data)
+	b.bitmap = true
+	b.addBitmap(recid, hit)
+}
+
+func (b *recSetShardBuilder) addBitmap(recid uint32, hit bool) {
+	if hit {
+		b.data[recid>>5] |= uint32(1) << (recid & 31)
+	}
+}
+
+func (b *recSetShardBuilder) finish() recSetShard {
+	part := recSetShard{shard: b.shard, universe: b.universe, count: int64(b.matched)}
+	if b.matched == 0 {
+		part.kind = recSetEmpty
+		return part
+	}
+	if b.matched == b.universe {
+		part.kind = recSetFull
+		return part
+	}
+	part.data = b.data
+	if !b.bitmap {
+		sort.Slice(part.data[:b.deviations], func(i, j int) bool {
+			return part.data[i] < part.data[j]
+		})
+		part.used = b.deviations
+		if b.defaultHit {
+			part.kind = recSetNegative
+		} else {
+			part.kind = recSetPositive
+		}
+		return part
+	}
+	part.kind = recSetBitmap
+	return part
+}
+
+func newRecSetShardFromSortedIDs(shard *storageShard, universe uint32, ids []uint32) recSetShard {
+	part := recSetShard{shard: shard, universe: universe, count: int64(len(ids))}
+	if len(ids) == 0 {
+		part.kind = recSetEmpty
+		return part
+	}
+	if len(ids) == int(universe) {
+		part.kind = recSetFull
+		return part
+	}
+	part.data = make([]uint32, (universe+31)/32)
+	if len(ids) <= len(part.data) {
+		part.kind = recSetPositive
+		part.used = uint32(len(ids))
+		copy(part.data, ids)
+		return part
+	}
+	missing := int(universe) - len(ids)
+	if missing <= len(part.data) {
+		part.kind = recSetNegative
+		part.used = uint32(missing)
+		write, present := 0, 0
+		for id := uint32(0); id < universe; id++ {
+			if present < len(ids) && ids[present] == id {
+				present++
+				continue
+			}
+			part.data[write] = id
+			write++
+		}
+		return part
+	}
+	part.kind = recSetBitmap
+	for _, id := range ids {
+		part.data[id>>5] |= uint32(1) << (id & 31)
+	}
+	return part
+}
+
+func sortedUint32Contains(values []uint32, value uint32) bool {
+	pos := sort.Search(len(values), func(i int) bool { return values[i] >= value })
+	return pos < len(values) && values[pos] == value
+}
+
+func (s *recSetShard) listedValues() []uint32 {
+	return s.data[:s.used]
+}
+
+func unionRecSetShards(shard *storageShard, parts []*recSetShard) recSetShard {
+	var universe uint32
+	for _, part := range parts {
+		if part != nil && part.universe > universe {
+			universe = part.universe
+		}
+	}
+	compact := parts[:0]
+	hasBitmap := false
+	mixedUniverse := false
+	for _, part := range parts {
+		if part == nil || part.kind == recSetEmpty {
+			continue
+		}
+		if part.kind == recSetFull && part.universe == universe {
+			return recSetShard{shard: shard, kind: recSetFull, universe: universe, count: int64(universe)}
+		}
+		hasBitmap = hasBitmap || part.kind == recSetBitmap
+		mixedUniverse = mixedUniverse || part.universe != universe
+		compact = append(compact, part)
+	}
+	parts = compact
+	if len(parts) == 0 {
+		return recSetShard{shard: shard, kind: recSetEmpty, universe: universe}
+	}
+	data := make([]uint32, (universe+31)/32)
+	if mixedUniverse {
+		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
+	}
+	if candidate := shortestRecSetList(parts, recSetNegative); candidate != nil {
+		used := filterRecSetCandidates(data, candidate.listedValues(), parts, false)
+		return recSetShardFromList(shard, universe, data, used, recSetNegative)
+	}
+	if hasBitmap {
+		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
+	}
+	positiveLists := recSetLists(parts, recSetPositive)
+	used, overflow := unionSortedLists(data, positiveLists)
+	if overflow {
+		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
+	}
+	return recSetShardFromList(shard, universe, data, used, recSetPositive)
+}
+
+func intersectRecSetShards(shard *storageShard, parts []*recSetShard) recSetShard {
+	if len(parts) == 0 {
+		return recSetShard{shard: shard, kind: recSetEmpty}
+	}
+	var universe uint32
+	for _, part := range parts {
+		if part == nil || part.kind == recSetEmpty {
+			return recSetShard{shard: shard, kind: recSetEmpty, universe: universe}
+		}
+		if part.universe > universe {
+			universe = part.universe
+		}
+	}
+	compact := parts[:0]
+	hasBitmap := false
+	mixedUniverse := false
+	for _, part := range parts {
+		if part.kind == recSetFull && part.universe == universe {
+			continue
+		}
+		hasBitmap = hasBitmap || part.kind == recSetBitmap
+		mixedUniverse = mixedUniverse || part.universe != universe
+		compact = append(compact, part)
+	}
+	parts = compact
+	if len(parts) == 0 {
+		return recSetShard{shard: shard, kind: recSetFull, universe: universe, count: int64(universe)}
+	}
+	data := make([]uint32, (universe+31)/32)
+	if mixedUniverse {
+		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
+	}
+	if candidate := shortestRecSetList(parts, recSetPositive); candidate != nil {
+		used := filterRecSetCandidates(data, candidate.listedValues(), parts, true)
+		return recSetShardFromList(shard, universe, data, used, recSetPositive)
+	}
+	if hasBitmap {
+		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
+	}
+	negativeLists := recSetLists(parts, recSetNegative)
+	used, overflow := unionSortedLists(data, negativeLists)
+	if overflow {
+		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
+	}
+	return recSetShardFromList(shard, universe, data, used, recSetNegative)
+}
+
+func recSetLists(parts []*recSetShard, kind recSetRepresentation) [][]uint32 {
+	lists := make([][]uint32, 0, len(parts))
+	for _, part := range parts {
+		if part.kind == kind {
+			lists = append(lists, part.listedValues())
+		}
+	}
+	return lists
+}
+
+func shortestRecSetList(parts []*recSetShard, kind recSetRepresentation) *recSetShard {
+	var shortest *recSetShard
+	for _, part := range parts {
+		if part.kind == kind && (shortest == nil || part.used < shortest.used) {
+			shortest = part
+		}
+	}
+	return shortest
+}
+
+// filterRecSetCandidates handles the sparse-result quadrants of the algebra
+// matrix. Intersections with a positive list can only contain its IDs; unions
+// with a negative list can only exclude its IDs.
+func filterRecSetCandidates(dst, candidates []uint32, parts []*recSetShard, wantPresent bool) uint32 {
+	used := 0
+	for _, id := range candidates {
+		matches := true
+		for _, part := range parts {
+			if part.contains(id) != wantPresent {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			dst[used] = id
+			used++
+		}
+	}
+	return uint32(used)
+}
+
+// unionSortedLists merges sorted recid lists directly into the final backing.
+// False means the list representation overflowed and the caller must reuse the
+// same storage as a bitmap.
+func unionSortedLists(dst []uint32, lists [][]uint32) (uint32, bool) {
+	positions := make([]int, len(lists))
+	used := 0
+	for {
+		var next uint32
+		found := false
+		for i, values := range lists {
+			if positions[i] < len(values) && (!found || values[positions[i]] < next) {
+				next = values[positions[i]]
+				found = true
+			}
+		}
+		if !found {
+			return uint32(used), false
+		}
+		if used == len(dst) {
+			return uint32(used), true
+		}
+		dst[used] = next
+		used++
+		for i, values := range lists {
+			for positions[i] < len(values) && values[positions[i]] == next {
+				positions[i]++
+			}
+		}
+	}
+}
+
+type recSetWordCursor struct {
+	part *recSetShard
+	pos  int
+}
+
+func (c *recSetWordCursor) word(wordIndex uint32) uint32 {
+	wordStart := wordIndex << 5
+	if wordStart >= c.part.universe {
+		return 0
+	}
+	tailMask := ^uint32(0)
+	if remaining := c.part.universe - wordStart; remaining < 32 {
+		tailMask = (uint32(1) << remaining) - 1
+	}
+	switch c.part.kind {
+	case recSetFull:
+		return tailMask
+	case recSetBitmap:
+		if int(wordIndex) < len(c.part.data) {
+			return c.part.data[wordIndex] & tailMask
+		}
+		return 0
+	case recSetPositive, recSetNegative:
+		values := c.part.listedValues()
+		for c.pos < len(values) && values[c.pos]>>5 < wordIndex {
+			c.pos++
+		}
+		mask := uint32(0)
+		for c.pos < len(values) && values[c.pos]>>5 == wordIndex {
+			mask |= uint32(1) << (values[c.pos] & 31)
+			c.pos++
+		}
+		if c.part.kind == recSetNegative {
+			return ^mask & tailMask
+		}
+		return mask
+	default:
+		return 0
+	}
+}
+
+func combineRecSetBitmapsWithData(shard *storageShard, universe uint32, parts []*recSetShard, union bool, data []uint32) recSetShard {
+	clear(data)
+	cursors := make([]recSetWordCursor, len(parts))
+	for i, part := range parts {
+		cursors[i].part = part
+	}
+	for wordIndex := range data {
+		value := uint32(0)
+		if !union {
+			value = ^uint32(0)
+		}
+		for i := range cursors {
+			if union {
+				value |= cursors[i].word(uint32(wordIndex))
+			} else {
+				value &= cursors[i].word(uint32(wordIndex))
+			}
+		}
+		data[wordIndex] = value
+	}
+	return recSetShardFromBitmap(shard, universe, data)
+}
+
+func recSetShardFromList(shard *storageShard, universe uint32, data []uint32, used uint32, kind recSetRepresentation) recSetShard {
+	count := used
+	if kind == recSetNegative {
+		count = universe - used
+	}
+	part := recSetShard{shard: shard, kind: kind, universe: universe, data: data, used: used, count: int64(count)}
+	if count == 0 {
+		part.kind = recSetEmpty
+		part.data = nil
+	} else if count == universe {
+		part.kind = recSetFull
+		part.data = nil
+	}
+	return part
+}
+
+func recSetShardFromBitmap(shard *storageShard, universe uint32, data []uint32) recSetShard {
+	if tail := universe & 31; tail != 0 && len(data) > 0 {
+		data[len(data)-1] &= (uint32(1) << tail) - 1
+	}
+	count := uint32(0)
+	for _, word := range data {
+		count += uint32(bits.OnesCount32(word))
+	}
+	part := recSetShard{shard: shard, universe: universe, data: data, count: int64(count)}
+	if count == 0 {
+		part.kind = recSetEmpty
+	} else if count == universe {
+		part.kind = recSetFull
+	} else {
+		part.kind = recSetBitmap
+	}
+	return part
+}
+
+func (s *recSetShard) forEachID(callback func(uint32) bool) {
+	switch s.kind {
+	case recSetEmpty:
+		return
+	case recSetPositive:
+		for _, id := range s.listedValues() {
+			if !callback(id) {
+				return
+			}
+		}
+	case recSetFull:
+		for id := uint32(0); id < s.universe; id++ {
+			if !callback(id) {
+				return
+			}
+		}
+	case recSetNegative:
+		excluded := s.listedValues()
+		pos := 0
+		for id := uint32(0); id < s.universe; id++ {
+			if pos < len(excluded) && excluded[pos] == id {
+				pos++
+				continue
+			}
+			if !callback(id) {
+				return
+			}
+		}
+	case recSetBitmap:
+		for wordIndex, word := range s.data {
+			for word != 0 {
+				bit := bits.TrailingZeros32(word)
+				id := uint32(wordIndex*32 + bit)
+				if id < s.universe && !callback(id) {
+					return
+				}
+				word &= word - 1
+			}
+		}
+	}
+}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -612,7 +612,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 										q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 									}
 								}()
-								res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+								res := part.shard.scan_order_recset_part(&part, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 								res.callbackCols = callbackCols
 								res.callback = callback
 								res.tableIdx = tableIdx
@@ -642,7 +642,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 							if ss != nil && ss.IsKilledSeq(querySeq) {
 								panic("query killed")
 							}
-							res := part.shard.scan_order_recids(part.recids, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+							res := part.shard.scan_order_recset_part(&part, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 							res.callbackCols = callbackCols
 							res.callback = callback
 							res.tableIdx = tableIdx

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -662,6 +662,25 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "recset_intersect",
+		Desc: "intersects query-local recsets from the same table",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			values := mustScmerSlice(a[0], "recsets")
+			recsets := make([]*recSet, 0, len(values))
+			for _, value := range values {
+				recsets = append(recsets, RecSetFromScmer(value))
+			}
+			return NewRecSetScmer(recSetIntersect(recsets))
+		},
+		Type: &scm.TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "list", ParamName: "recsets"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "recset"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_exists",
 		Desc: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/tests/execution/operators/recset.yaml
+++ b/tests/execution/operators/recset.yaml
@@ -12,6 +12,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS recset_items"
   - sql: "DROP TABLE IF EXISTS recset_other"
   - sql: "DROP TABLE IF EXISTS recset_link"
+  - sql: "DROP TABLE IF EXISTS recset_adaptive"
+  - sql: "DROP TABLE IF EXISTS recset_project_source"
+  - sql: "DROP TABLE IF EXISTS recset_project_target"
   - sql: |
       CREATE TABLE recset_items (
         id INT PRIMARY KEY,
@@ -29,6 +32,9 @@ setup:
         item_id INT,
         tenant INT
       )
+  - sql: "CREATE TABLE recset_adaptive (id INT PRIMARY KEY, value INT)"
+  - sql: "CREATE TABLE recset_project_source (id INT PRIMARY KEY, k1 INT, k2 INT, selected INT)"
+  - sql: "CREATE TABLE recset_project_target (id INT PRIMARY KEY, k1 INT, k2 INT)"
   - sql: |
       INSERT INTO recset_items VALUES
         (1, 1, 1),
@@ -47,8 +53,24 @@ setup:
         (3, 1, 1),
         (4, 3, 2),
         (5, NULL, 1)
+  - scm: |
+      (begin
+        (define rows (produceN 4096 (lambda (i) (list (+ i 1) (mod i 8)))))
+        (insert (table "memcp-tests" "recset_adaptive") '("id" "value") rows '() (lambda () true) false))
+  - scm: |
+      (begin
+        (define rows (produceN 20000 (lambda (i)
+          (list (+ i 1) (if (equal? (mod i 997) 0) nil (mod i 10000)) (mod i 17) (if (< i 5000) 1 0)))))
+        (insert (table "memcp-tests" "recset_project_source") '("id" "k1" "k2" "selected") rows '() (lambda () true) false))
+  - scm: |
+      (begin
+        (define rows (produceN 40000 (lambda (i) (list (+ i 1) (mod i 10000) (mod i 17)))))
+        (insert (table "memcp-tests" "recset_project_target") '("id" "k1" "k2") rows '() (lambda () true) false))
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS recset_project_target"
+  - sql: "DROP TABLE IF EXISTS recset_project_source"
+  - sql: "DROP TABLE IF EXISTS recset_adaptive"
   - sql: "DROP TABLE IF EXISTS recset_link"
   - sql: "DROP TABLE IF EXISTS recset_other"
   - sql: "DROP TABLE IF EXISTS recset_items"
@@ -469,6 +491,87 @@ test_cases:
               (equal? sum_ids 11))
           "ok"
           (error "recset_union returned wrong row set")))
+
+  - name: "adaptive recset algebra covers every representation pairing"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "recset_adaptive"))
+        (define full (scan_recset nil tbl '() (lambda () true)))
+        (define empty (scan_recset nil tbl '() (lambda () false)))
+        (define positive (scan_recset nil tbl '("id") (lambda (id) (> id 4086))))
+        (define positive2 (scan_recset nil tbl '("id") (lambda (id) (and (>= id 4083) (<= id 4092)))))
+        (define negative (scan_recset nil tbl '("id") (lambda (id) (not (> (mod id 5000) 4086)))))
+        (define negative2 (scan_recset nil tbl '("id") (lambda (id)
+          (not (and (>= (mod id 5000) 6) (<= (mod id 5000) 15))))))
+        (define negative3 (scan_recset nil tbl '("id") (lambda (id) (not (> (mod id 5000) 4091)))))
+        (define even (scan_recset nil tbl '("id") (lambda (id) (equal? (mod id 2) 0))))
+        (define third (scan_recset nil tbl '("id") (lambda (id) (equal? (mod id 3) 0))))
+        (if (and
+              (equal? (recset_count full) 4096)
+              (equal? (recset_count empty) 0)
+              (equal? (recset_count positive) 10)
+              (equal? (recset_count negative) 4086)
+              (equal? (recset_count even) 2048)
+              (equal? (recset_count (recset_union (list positive positive2))) 14)
+              (equal? (recset_count (recset_intersect (list positive positive2))) 6)
+              (equal? (recset_count (recset_union (list negative negative2))) 4096)
+              (equal? (recset_count (recset_intersect (list negative negative2))) 4076)
+              (equal? (recset_count (recset_union (list negative negative3))) 4091)
+              (equal? (recset_count (recset_intersect (list negative negative3))) 4086)
+              (equal? (recset_count (recset_union (list positive2 negative))) 4092)
+              (equal? (recset_count (recset_intersect (list positive2 negative))) 4)
+              (equal? (recset_count (recset_union (list even third))) 2731)
+              (equal? (recset_count (recset_intersect (list even third))) 682)
+              (equal? (recset_count (recset_union (list positive even))) 2053)
+              (equal? (recset_count (recset_intersect (list positive even))) 5)
+              (equal? (recset_count (recset_union (list negative even))) 4091)
+              (equal? (recset_count (recset_intersect (list negative even))) 2043)
+              (equal? (recset_count (recset_union (list full positive))) 4096)
+              (equal? (recset_count (recset_intersect (list empty negative))) 0)
+              (equal? (recset_count (recset_union (list empty positive))) 10)
+              (equal? (recset_count (recset_intersect (list full negative))) 4086))
+          "ok"
+          (error "adaptive recset algebra returned wrong cardinality")))
+
+  - name: "recset_union rejects recsets from different tables"
+    scm: |
+      (begin
+        (define left (scan_recset nil (table "memcp-tests" "recset_items") '() (lambda () true)))
+        (define right (scan_recset nil (table "memcp-tests" "recset_other") '() (lambda () true)))
+        (recset_union (list left right)))
+    expect:
+      error: true
+
+  - name: "recset_intersect rejects recsets from different tables"
+    scm: |
+      (begin
+        (define left (scan_recset nil (table "memcp-tests" "recset_items") '() (lambda () true)))
+        (define right (scan_recset nil (table "memcp-tests" "recset_other") '() (lambda () true)))
+        (recset_intersect (list left right)))
+    expect:
+      error: true
+
+  - name: "large recset projection keeps one-column duplicates and nulls exact"
+    scm: |
+      (begin
+        (define source (table "memcp-tests" "recset_project_source"))
+        (define target (table "memcp-tests" "recset_project_target"))
+        (define selected (scan_recset nil source '("selected") (lambda (v) (equal? v 1))))
+        (define projected (recset_project_join nil selected '("k1") target '("k1")))
+        (if (equal? (recset_count projected) 19976)
+          "ok"
+          (error "large one-column recset projection returned wrong cardinality")))
+
+  - name: "large recset projection keeps composite keys exact"
+    scm: |
+      (begin
+        (define source (table "memcp-tests" "recset_project_source"))
+        (define target (table "memcp-tests" "recset_project_target"))
+        (define selected (scan_recset nil source '("selected") (lambda (v) (equal? v 1))))
+        (define projected (recset_project_join nil selected '("k1" "k2") target '("k1" "k2")))
+        (if (equal? (recset_count projected) 4994)
+          "ok"
+          (error "large composite recset projection returned wrong cardinality")))
 
   - name: "show forwards recset to base table metadata"
     scm: |


### PR DESCRIPTION
## What changed

- replace per-row `[][]Scmer` projection materialization with one flat tuple buffer, in-place tuple sorting/deduplication, and shard-parallel target projection
- add adaptive per-shard RecSet representations: empty, full, positive RecID list, negative RecID list, and bitmap
- allocate exactly `(row_count + 31) / 32` `uint32` words and reuse that single backing from RecID deviations to bitmap after overflow
- execute scans, ordered scans, membership probes, and projections directly from every representation
- add representation-aware Union and Intersection algorithms:
  - constant folding for empty/full
  - selective candidate iteration for positive-list intersections and negative-list unions
  - sorted list merging for sparse/dense list-only quadrants
  - sequential word cursors for bitmap combinations, including list+bitmap and negative-list+bitmap
- mask mixed-universe/tail words so RecSets remain exact across concurrent growth

## Why

The old projection collected one allocated Scheme slice per source row, merged those slices on one core, and materialized target RecIDs again. On production-scale membership sets this made the RecSet projection itself take seconds and generated substantial GC traffic.

The new representation keeps sparse sets compact, dense sets sequential, and performs no Scheme-row materialization. Algebra chooses the smallest provable candidate domain; only result shapes that can be dense traverse bitmap words.

## A/B measurement

Same current-master base, same imported production-scale data directory, warm direct physical operator pipeline, TracePrint disabled. Results and cardinalities were checked after every run.

| Membership payload | Master projection | PR projection | Output rows | Speedup |
|---|---:|---:|---:|---:|
| broad prefix | 16,392.7 ms | 360-374 ms | 847,219 | about 44x |
| selective prefix | 2,056-2,125 ms | 65.9-69.9 ms | 98,008 | about 30x |

For the selective payload, representation-aware Union itself measured 0.12-0.14 ms on the PR. The full cascade is still dominated by the physical case-insensitive string scan (roughly 6-8 seconds); this PR removes projection/materialization as the next multi-second component but does not claim the final `<3s` target.

## Validation

- `make test`: green, including all YAML suites, parallel concurrency suites, and restart/crash/persistence suites
- Scheme coverage: 48,675 / 48,675 source nodes (100%)
- Go statement coverage: 71.4%
- `tests/execution/operators/recset.yaml`: 26/26, including every positive/negative-list, bitmap, full, and empty Union/Intersection pairing plus large one- and two-column projections
- `tests/planner/subqueries/in-subquery.yaml`: 61/61

The first full run exposed a transient transaction-suite failure under parallel load; its isolated rerun was 171/171 and the complete repeated parallel `make test` run was green.
