### PR TITLE
Fix ordered correlated join lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -13687,6 +13687,81 @@ ownership remain available until the physical scans are emitted. */
 		schema sources sources default_alias needed_exprs final_condition sink_expr
 		'() 0 -1 false nil stages)))
 
+/* A total order that cannot be factored along the logical join tree needs a
+storage-backed intermediate relation.  Materializing joined rows in a Scheme
+list would violate the relation-materialization invariant and scale with heap
+objects.  This last-resort intermediate relation stays in the storage engine, where
+scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
+(define join_order_intermediate_names (lambda (prefix amount)
+	(map (produceN amount) (lambda (idx) (concat prefix idx)))))
+
+(define join_order_intermediate_columns (lambda (names)
+	(cons (quote list) (map names (lambda (name)
+		(list (quote list) "column" name "any" (quoted_runtime_list '()) (quoted_runtime_list '())))))))
+
+(define join_order_intermediate_insert (lambda (table_expr names values)
+	(list (quote insert)
+		table_expr
+		(cons (quote list) names)
+		(list (quote list) (cons (quote list) values))
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		true)))
+
+(define join_order_intermediate_result_fields (lambda (fields value_names)
+	(match fields
+		(cons title (cons _expr rest))
+		(cons title (cons (symbol (car value_names))
+			(join_order_intermediate_result_fields rest (cdr value_names))))
+		_ '())))
+
+(define join_order_intermediate_scan (lambda (table_expr fields value_names order_names order_items offset_value limit_value)
+	(list (quote scan_order)
+		'(session "__memcp_tx")
+		table_expr
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		(cons (quote list) order_names)
+		(cons (quote list) (order_dirs order_items))
+		0
+		(coalesceNil offset_value 0)
+		(coalesceNil limit_value -1)
+		(cons (quote list) value_names)
+		(list (quote lambda) (map value_names symbol)
+			(list (quote resultrow)
+				(cons (quote list) (join_order_intermediate_result_fields fields value_names))))
+		nil nil false)))
+
+(define lower_join_order_through_intermediate (lambda (block fields scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog)
+	(begin
+		(define value_exprs (extract_assoc fields (lambda (_title expr) expr)))
+		(define order_values (order_exprs order_items))
+		(define value_names (join_order_intermediate_names "v" (count value_exprs)))
+		(define order_names (join_order_intermediate_names "o" (count order_values)))
+		(define column_names (merge (list value_names order_names)))
+		(define lowered_values (map (merge (list value_exprs order_values)) (lambda (expr)
+			(lower_column_expr_for_join scan_sources default_alias expr))))
+		(define table_key (concat "__join_order_intermediate:" (uuid)))
+		(define table_name (list (quote session) table_key))
+		(define table_expr (list (quote table) (qb_schema block) table_name))
+		(define fill_plan (build_join_scan_pipeline_using_recipe
+			(qb_schema block) scan_sources scan_plan default_alias needed_exprs final_condition
+			(join_order_intermediate_insert table_expr column_names lowered_values)
+			'() 0 -1 false nil stage_catalog))
+		(define scan_plan_expr (join_order_intermediate_scan table_expr fields value_names order_names order_items
+			(qb_offset block) (qb_limit block)))
+		(define drop_plan (list (quote droptable) (qb_schema block) table_name true))
+		(list (quote !begin)
+			(list (quote session) table_key (list (quote concat) ".join-order:" (list (quote uuid))))
+			(list (quote createtable) (qb_schema block) table_name
+				(join_order_intermediate_columns column_names)
+				(quoted_runtime_list '("engine" "memory")) true)
+			(list (quote try)
+				(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
+				(list (quote lambda) (list (quote __intermediate_error))
+					(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error)))))
+			drop_plan))))
+
 /* ------------------------------------------------------------------------- */
 /* Canonical physical prejoin relations                                      */
 
@@ -14206,7 +14281,9 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 							final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
 						(if (physical_prejoin_supported? block)
 							(lower_query_block_through_prejoin block)
-							(neumann_fail "build_queryplan" "ORDER BY requires a storage carrier")))
+							(lower_join_order_through_intermediate
+								block fields scan_sources scan_plan first_alias needed_exprs
+								final_condition order_items stage_catalog)))
 ))))))
 
 (define lower_zero_source_query_block (lambda (block)

--- a/tests/planner/subqueries/subquery-complex.yaml
+++ b/tests/planner/subqueries/subquery-complex.yaml
@@ -26,6 +26,11 @@ setup:
   - sql: "DROP TABLE IF EXISTS sq_large_emp"
   - sql: "DROP TABLE IF EXISTS sq_dept"
   - sql: "DROP TABLE IF EXISTS sq_emp"
+  - sql: "DROP TABLE IF EXISTS sq_order_product"
+  - sql: "DROP TABLE IF EXISTS sq_order_vendor"
+  - sql: "DROP TABLE IF EXISTS sq_order_offer"
+  - sql: "DROP TABLE IF EXISTS sq_order_country"
+  - sql: "DROP TABLE IF EXISTS sq_order_region"
   - sql: |
       CREATE TABLE sq_dept (did INT, dname VARCHAR(30))
   - sql: |
@@ -45,11 +50,96 @@ setup:
         (8, 'Henry', NULL, 50000)
   - sql: "CREATE TABLE sq_large_dept (did INT)"
   - sql: "CREATE TABLE sq_large_emp (did INT, salary INT)"
+  - sql: "CREATE TABLE sq_order_product (id INT PRIMARY KEY, size INT, kind TEXT)"
+  - sql: "CREATE TABLE sq_order_vendor (id INT PRIMARY KEY, country_id INT, name TEXT, balance INT)"
+  - sql: "CREATE TABLE sq_order_offer (product_id INT, vendor_id INT, cost INT)"
+  - sql: "CREATE TABLE sq_order_country (id INT PRIMARY KEY, region_id INT, name TEXT)"
+  - sql: "CREATE TABLE sq_order_region (id INT PRIMARY KEY, name TEXT)"
+  - sql: "INSERT INTO sq_order_product VALUES (1,15,'small alloy'),(2,15,'small alloy')"
+  - sql: "INSERT INTO sq_order_vendor VALUES (10,100,'vendor a',200),(20,100,'vendor b',200),(30,200,'vendor c',400)"
+  - sql: "INSERT INTO sq_order_offer VALUES (1,10,50),(1,20,40),(2,10,30),(2,30,20)"
+  - sql: "INSERT INTO sq_order_country VALUES (100,1000,'country a'),(200,2000,'country b')"
+  - sql: "INSERT INTO sq_order_region VALUES (1000,'north'),(2000,'south')"
   - scm: |
       (insert (table "memcp-tests" "sq_large_dept") '("did")
         (map (produceN 1001) (lambda (i) (list i))))
 
 test_cases:
+
+  - name: "Ordered multi-join with correlated aggregate filter"
+    sql: |
+      SELECT v.balance, c.name AS country_name, v.name AS vendor_name, p.id
+      FROM sq_order_product p, sq_order_vendor v, sq_order_offer o,
+           sq_order_country c, sq_order_region r
+      WHERE p.id = o.product_id
+        AND v.id = o.vendor_id
+        AND v.country_id = c.id
+        AND c.region_id = r.id
+        AND p.size = 15
+        AND p.kind LIKE '%alloy'
+        AND r.name = 'north'
+        AND o.cost = (
+          SELECT MIN(o2.cost)
+          FROM sq_order_offer o2, sq_order_vendor v2,
+               sq_order_country c2, sq_order_region r2
+          WHERE p.id = o2.product_id
+            AND v2.id = o2.vendor_id
+            AND v2.country_id = c2.id
+            AND c2.region_id = r2.id
+            AND r2.name = 'north'
+        )
+      ORDER BY v.balance DESC, c.name, v.name, p.id
+      LIMIT 100
+    expect:
+      rows: 2
+      data:
+        - balance: 200
+          country_name: "country a"
+          vendor_name: "vendor a"
+          id: 2
+        - balance: 200
+          country_name: "country a"
+          vendor_name: "vendor b"
+          id: 1
+
+  - name: "Ordered correlated join uses a storage-backed intermediate relation"
+    sql: |
+      EXPLAIN SELECT v.balance, c.name AS country_name, v.name AS vendor_name, p.id
+      FROM sq_order_product p, sq_order_vendor v, sq_order_offer o,
+           sq_order_country c, sq_order_region r
+      WHERE p.id = o.product_id
+        AND v.id = o.vendor_id
+        AND v.country_id = c.id
+        AND c.region_id = r.id
+        AND p.size = 15
+        AND p.kind LIKE '%alloy'
+        AND r.name = 'north'
+        AND o.cost = (
+          SELECT MIN(o2.cost)
+          FROM sq_order_offer o2, sq_order_vendor v2,
+               sq_order_country c2, sq_order_region r2
+          WHERE p.id = o2.product_id
+            AND v2.id = o2.vendor_id
+            AND v2.country_id = c2.id
+            AND c2.region_id = r2.id
+            AND r2.name = 'north'
+        )
+      ORDER BY v.balance DESC, c.name, v.name, p.id
+      LIMIT 100
+    expect:
+      rows: 1
+      result_contains:
+        - ".join-order:"
+        - "scan_order"
+        - "droptable"
+      result_not_contains:
+        - "(sort rows"
+
+  - name: "Ordered join intermediate relation is query-local"
+    sql: "SHOW TABLES"
+    expect:
+      result_not_contains:
+        - ".join-order:"
 
   # === Scalar subquery in SELECT ===
 


### PR DESCRIPTION
## Problem

A total ORDER BY over a decorrelated multi-join could reach physical lowering without a legal ordered scan path. Since the non-scalable Scheme-list fallback was removed, that shape failed during compilation with `ORDER BY requires a storage carrier`; TPC-H Q2 was one affected query.

## Solution

- Keep the logical join tree as the producer.
- For the last-resort case only, stream projected and ordering expressions into a query-local memory-engine intermediate relation.
- Let `scan_order` and auto-indexing apply total ordering, OFFSET, and LIMIT.
- Drop the intermediate relation after consumption and from the error handler.
- Leave direct, hierarchical, and existing physical-prejoin ordered paths unchanged.

This preserves the planner phase boundary and the relational-materialization invariant: joined rows are never collected in a Scheme list. The new helpers intentionally use the architectural term “intermediate relation”, not the overloaded historical “carrier”.

## Regression coverage

The existing complex-subquery suite now includes a generic five-table query shape with a correlated MIN, four-key ORDER BY, and LIMIT. It verifies exact results, verifies the storage-backed lowering in EXPLAIN, and checks that no intermediate table remains catalog-visible. No TPC-H query text, data, or redistribution artifact is committed.

## Validation and A/B

- `./git-pre-commit`: green
- `python3 run_sql_tests.py tests/planner/subqueries/subquery-complex.yaml`: 41/41
- `python3 run_sql_tests.py tests/execution/concurrency/transactions.yaml`: 171/171
- `python3 run_sql_tests.py tests/planner/order-window/order-limit.yaml`: 34/34
- TPC-H Q2 at SF 0.01 against PostgreSQL: current master aborts during compilation; this branch returns the exact reference rows in about 314 ms. This patch restores correctness; optimizing the last-resort materialization is deliberately a later planner task.

A coverage-enabled full run also exposed two unrelated existing flakes: one transaction rollback case and an ORDER BY timing check at 5.049 s versus its unchanged 5 s limit. Both passed immediately in isolated normal-priority reruns; no guard, time limit, or test data was changed.