### PR TITLE
Handle ordered join dataset reductions

### DIFF
--- a/.github/workflows/sql-regression-policy.yml
+++ b/.github/workflows/sql-regression-policy.yml
@@ -1,0 +1,45 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: SQL Regression Policy
+
+on:
+  pull_request_target:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  protected-regression-policy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Policy code always comes from the trusted base revision.  Candidate
+      # files are parsed as data and are never imported or executed.
+      - name: Check out trusted policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          path: policy
+
+      - name: Check out candidate as data
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: candidate
+
+      - name: Install policy dependencies
+        run: pip install PyYAML
+
+      - name: Apply trusted regression policy
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git -C candidate fetch ../policy "$BASE_REF"
+          python3 policy/tools/check_sql_time_limit.py \
+            --root candidate \
+            --base-ref "$BASE_REF"

--- a/git-pre-commit
+++ b/git-pre-commit
@@ -77,6 +77,32 @@ if ! go build $build_flags -o memcp; then
     exit 1
 fi
 
+# Calibrate fixed, engine-independent CPU work before MemCP starts.  Every
+# suite process inherits this one machine factor, so a MemCP regression cannot
+# slow the calibrator and thereby enlarge its own wall-clock allowance.
+read -r performance_arch performance_scale performance_measured_ns performance_reference_ns < <(
+  python3 - <<'PY'
+from run_sql_tests import calibrate_performance_scale
+
+calibration = calibrate_performance_scale()
+print(
+    calibration["architecture"],
+    format(calibration["scale"], ".17g"),
+    calibration["measured_ns"],
+    calibration["reference_ns"],
+)
+PY
+)
+if [ -z "$performance_scale" ]; then
+  echo "❌ Performance calibration failed, commit aborted"
+  exit 1
+fi
+export MEMCP_TEST_PERFORMANCE_ARCH="$performance_arch"
+export MEMCP_TEST_PERFORMANCE_SCALE="$performance_scale"
+export MEMCP_TEST_PERFORMANCE_MEASURED_NS="$performance_measured_ns"
+export MEMCP_TEST_PERFORMANCE_REFERENCE_NS="$performance_reference_ns"
+echo "⚖️  Wall-clock calibration: ${performance_scale}x (${performance_arch})"
+
 resolve_test_selection() {
   local selected=""
   local pattern resolved

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -13715,7 +13715,7 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 			(join_order_intermediate_result_fields rest (cdr value_names))))
 		_ '())))
 
-(define join_order_intermediate_scan (lambda (table_expr fields value_names order_names order_items offset_value limit_value)
+(define join_order_intermediate_reduce_scan (lambda (table_expr value_names order_names order_items offset_value limit_value map_expr reduce_expr neutral_expr)
 	(list (quote scan_order)
 		'(session "__memcp_tx")
 		table_expr
@@ -13727,14 +13727,11 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 		(coalesceNil offset_value 0)
 		(coalesceNil limit_value -1)
 		(cons (quote list) value_names)
-		(list (quote lambda) (map value_names symbol)
-			(list (quote resultrow)
-				(cons (quote list) (join_order_intermediate_result_fields fields value_names))))
-		nil nil false)))
+		map_expr
+		reduce_expr neutral_expr false)))
 
-(define lower_join_order_through_intermediate (lambda (block fields scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog)
+(define lower_join_order_to_intermediate (lambda (block value_exprs scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog scan_builder)
 	(begin
-		(define value_exprs (extract_assoc fields (lambda (_title expr) expr)))
 		(define order_values (order_exprs order_items))
 		(define value_names (join_order_intermediate_names "v" (count value_exprs)))
 		(define order_names (join_order_intermediate_names "o" (count order_values)))
@@ -13748,19 +13745,33 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 			(qb_schema block) scan_sources scan_plan default_alias needed_exprs final_condition
 			(join_order_intermediate_insert table_expr column_names lowered_values)
 			'() 0 -1 false nil stage_catalog))
-		(define scan_plan_expr (join_order_intermediate_scan table_expr fields value_names order_names order_items
-			(qb_offset block) (qb_limit block)))
+		(define scan_plan_expr (scan_builder table_expr value_names order_names))
 		(define drop_plan (list (quote droptable) (qb_schema block) table_name true))
 		(list (quote !begin)
 			(list (quote session) table_key (list (quote concat) ".join-order:" (list (quote uuid))))
 			(list (quote createtable) (qb_schema block) table_name
 				(join_order_intermediate_columns column_names)
 				(quoted_runtime_list '("engine" "memory")) true)
-			(list (quote try)
-				(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
-				(list (quote lambda) (list (quote __intermediate_error))
-					(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error)))))
-			drop_plan))))
+			(list
+				(list (quote lambda) (list (quote __intermediate_result))
+					(list (quote !begin) drop_plan (quote __intermediate_result)))
+				(list (quote try)
+					(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
+					(list (quote lambda) (list (quote __intermediate_error))
+						(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error))))))))))
+
+(define lower_join_order_through_intermediate (lambda (block fields scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog)
+	(begin
+		(define value_exprs (extract_assoc fields (lambda (_title expr) expr)))
+		(lower_join_order_to_intermediate
+			block value_exprs scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog
+			(lambda (table_expr value_names order_names)
+				(join_order_intermediate_reduce_scan
+					table_expr value_names order_names order_items (qb_offset block) (qb_limit block)
+					(list (quote lambda) (map value_names symbol)
+						(list (quote resultrow)
+							(cons (quote list) (join_order_intermediate_result_fields fields value_names))))
+					nil nil))))))
 
 /* ------------------------------------------------------------------------- */
 /* Canonical physical prejoin relations                                      */
@@ -14145,30 +14156,38 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 		(define direct_order_safe (and direct_order
 			(not (ordered_join_limit_requires_complete_rows?
 				scan_sources first_alias final_condition (qb_offset block) (qb_limit block)))))
-		(if (not direct_order_safe)
-			(neumann_fail "build_queryplan" "dataset ORDER BY requires a storage carrier")
-			true)
 		(define field_exprs (extract_assoc fields (lambda (_title expr) expr)))
 		(define needed_exprs (merge (list
 			field_exprs
 			(list final_condition)
 			(order_exprs order_items)
 			(source_join_exprs scan_sources))))
-		(define row_expr (cons row_mapper (map field_exprs (lambda (expr)
-			(lower_column_expr_for_join scan_sources first_alias expr)))))
-		(build_join_scan_reduce_using_recipe
-			(qb_schema block)
-			scan_sources
-			scan_plan
-			first_alias
-			needed_exprs
-			final_condition
-			row_expr
-			order_items
-			(coalesceNil (qb_offset block) 0)
-			(coalesceNil (qb_limit block) -1)
-			true nil (query_block_stage_catalog block)
-			reduce_expr neutral_expr shard_reduce_expr))))
+		(if direct_order_safe
+			(begin
+				(define row_expr (cons row_mapper (map field_exprs (lambda (expr)
+					(lower_column_expr_for_join scan_sources first_alias expr)))))
+				(build_join_scan_reduce_using_recipe
+					(qb_schema block)
+					scan_sources
+					scan_plan
+					first_alias
+					needed_exprs
+					final_condition
+					row_expr
+					order_items
+					(coalesceNil (qb_offset block) 0)
+					(coalesceNil (qb_limit block) -1)
+					true nil (query_block_stage_catalog block)
+					reduce_expr neutral_expr shard_reduce_expr))
+			(lower_join_order_to_intermediate
+				block field_exprs scan_sources scan_plan first_alias needed_exprs final_condition order_items
+				(query_block_stage_catalog block)
+				(lambda (table_expr value_names order_names)
+					(join_order_intermediate_reduce_scan
+						table_expr value_names order_names order_items (qb_offset block) (qb_limit block)
+						(list (quote lambda) (map value_names symbol)
+							(cons row_mapper (map value_names symbol)))
+						reduce_expr neutral_expr)))))))
 
 (define scalar_order_lookup_input_keys (lambda (stage)
 	(begin

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -13687,6 +13687,81 @@ ownership remain available until the physical scans are emitted. */
 		schema sources sources default_alias needed_exprs final_condition sink_expr
 		'() 0 -1 false nil stages)))
 
+/* A total order that cannot be factored along the logical join tree needs a
+storage-backed intermediate relation.  Materializing joined rows in a Scheme
+list would violate the relation-materialization invariant and scale with heap
+objects.  This last-resort intermediate relation stays in the storage engine, where
+scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
+(define join_order_intermediate_names (lambda (prefix amount)
+	(map (produceN amount) (lambda (idx) (concat prefix idx)))))
+
+(define join_order_intermediate_columns (lambda (names)
+	(cons (quote list) (map names (lambda (name)
+		(list (quote list) "column" name "any" (quoted_runtime_list '()) (quoted_runtime_list '())))))))
+
+(define join_order_intermediate_insert (lambda (table_expr names values)
+	(list (quote insert)
+		table_expr
+		(cons (quote list) names)
+		(list (quote list) (cons (quote list) values))
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		true)))
+
+(define join_order_intermediate_result_fields (lambda (fields value_names)
+	(match fields
+		(cons title (cons _expr rest))
+		(cons title (cons (symbol (car value_names))
+			(join_order_intermediate_result_fields rest (cdr value_names))))
+		_ '())))
+
+(define join_order_intermediate_scan (lambda (table_expr fields value_names order_names order_items offset_value limit_value)
+	(list (quote scan_order)
+		'(session "__memcp_tx")
+		table_expr
+		(quoted_runtime_list '())
+		(list (quote lambda) '() true)
+		(cons (quote list) order_names)
+		(cons (quote list) (order_dirs order_items))
+		0
+		(coalesceNil offset_value 0)
+		(coalesceNil limit_value -1)
+		(cons (quote list) value_names)
+		(list (quote lambda) (map value_names symbol)
+			(list (quote resultrow)
+				(cons (quote list) (join_order_intermediate_result_fields fields value_names))))
+		nil nil false)))
+
+(define lower_join_order_through_intermediate (lambda (block fields scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog)
+	(begin
+		(define value_exprs (extract_assoc fields (lambda (_title expr) expr)))
+		(define order_values (order_exprs order_items))
+		(define value_names (join_order_intermediate_names "v" (count value_exprs)))
+		(define order_names (join_order_intermediate_names "o" (count order_values)))
+		(define column_names (merge (list value_names order_names)))
+		(define lowered_values (map (merge (list value_exprs order_values)) (lambda (expr)
+			(lower_column_expr_for_join scan_sources default_alias expr))))
+		(define table_key (concat "__join_order_intermediate:" (uuid)))
+		(define table_name (list (quote session) table_key))
+		(define table_expr (list (quote table) (qb_schema block) table_name))
+		(define fill_plan (build_join_scan_pipeline_using_recipe
+			(qb_schema block) scan_sources scan_plan default_alias needed_exprs final_condition
+			(join_order_intermediate_insert table_expr column_names lowered_values)
+			'() 0 -1 false nil stage_catalog))
+		(define scan_plan_expr (join_order_intermediate_scan table_expr fields value_names order_names order_items
+			(qb_offset block) (qb_limit block)))
+		(define drop_plan (list (quote droptable) (qb_schema block) table_name true))
+		(list (quote !begin)
+			(list (quote session) table_key (list (quote concat) ".join-order:" (list (quote uuid))))
+			(list (quote createtable) (qb_schema block) table_name
+				(join_order_intermediate_columns column_names)
+				(quoted_runtime_list '("engine" "memory")) true)
+			(list (quote try)
+				(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
+				(list (quote lambda) (list (quote __intermediate_error))
+					(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error)))))
+			drop_plan))))
+
 /* ------------------------------------------------------------------------- */
 /* Canonical physical prejoin relations                                      */
 
@@ -14206,7 +14281,9 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 							final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
 						(if (physical_prejoin_supported? block)
 							(lower_query_block_through_prejoin block)
-							(neumann_fail "build_queryplan" "ORDER BY requires a storage carrier")))
+							(lower_join_order_through_intermediate
+								block fields scan_sources scan_plan first_alias needed_exprs
+								final_condition order_items stage_catalog)))
 ))))))
 
 (define lower_zero_source_query_block (lambda (block)

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -50,7 +50,11 @@ except Exception as e:
     sys.exit(2)
 
 import json
+import hashlib
+import math
+import platform
 import socket
+import statistics
 import subprocess
 import time
 import multiprocessing
@@ -176,6 +180,24 @@ PERF_SCALE_FACTOR = 1.3  # scale up/down by 30%
 PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_RAM_FRACTION = 0.30  # abort when MemAvailable drops below (1 - fraction) of MemTotal
 PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))  # measured runs per test; median reported
+# Wall-clock budgets are expressed for a reference CPU.  A fixed SHA-256
+# workload, measured before MemCP starts in the full test hook, maps that budget
+# to the current machine.  The workload is deliberately independent of MemCP:
+# a query-engine regression must not make its own allowance larger.
+PERFORMANCE_REFERENCE_NS_PER_MIB = 450_000
+PERFORMANCE_CALIBRATION_SAMPLES = 5
+PERFORMANCE_SCALE_MIN = 1.0
+PERFORMANCE_SCALE_MAX = 16.0
+PERFORMANCE_CALIBRATION_ROUNDS = {
+    "x86_64": 32,
+    "aarch64": 16,
+    "armv7l": 8,
+    "other": 16,
+}
+PERFORMANCE_SCALE_ENV = "MEMCP_TEST_PERFORMANCE_SCALE"
+PERFORMANCE_ARCH_ENV = "MEMCP_TEST_PERFORMANCE_ARCH"
+PERFORMANCE_MEASURED_NS_ENV = "MEMCP_TEST_PERFORMANCE_MEASURED_NS"
+PERFORMANCE_REFERENCE_NS_ENV = "MEMCP_TEST_PERFORMANCE_REFERENCE_NS"
 # Hard wall-clock limit per query — a GENEROUS backstop, not a precise gate.
 # Wall-clock is hardware-dependent (a Raspberry Pi is ~10x slower), so this is
 # only meant to catch gross runaways. The default gives a fast query (<100ms
@@ -195,6 +217,93 @@ MEMCP_START_TIMEOUT = int(os.environ.get("MEMCP_START_TIMEOUT", "180"))
 RUNNER_CONFIG_LOCK_FILE = f"{PERF_BASELINE_FILE}.lock"
 RUNNER_META_KEY = "_runner"
 FAILURE_MAP_KEY = "failures"
+
+
+def performance_architecture(machine: Optional[str] = None) -> str:
+    """Return the stable calibration profile for the execution architecture."""
+    value = (machine or platform.machine()).strip().lower()
+    aliases = {"amd64": "x86_64", "arm64": "aarch64", "armv6l": "armv7l"}
+    value = aliases.get(value, value)
+    return value if value in PERFORMANCE_CALIBRATION_ROUNDS else "other"
+
+
+def performance_scale_from_samples(architecture: str, samples_ns: List[int]) -> Dict[str, Any]:
+    """Build a bounded machine scale from fixed-work calibration samples."""
+    profile = performance_architecture(architecture)
+    if not samples_ns or any(sample <= 0 for sample in samples_ns):
+        raise ValueError("performance calibration requires positive samples")
+    measured_ns = int(statistics.median(samples_ns))
+    reference_ns = PERFORMANCE_REFERENCE_NS_PER_MIB * PERFORMANCE_CALIBRATION_ROUNDS[profile]
+    raw_scale = measured_ns / reference_ns
+    if raw_scale > PERFORMANCE_SCALE_MAX:
+        raise ValueError(
+            f"performance calibration {raw_scale:.2f}x exceeds supported maximum "
+            f"{PERFORMANCE_SCALE_MAX:.0f}x"
+        )
+    return {
+        "architecture": profile,
+        "scale": max(PERFORMANCE_SCALE_MIN, raw_scale),
+        "measured_ns": measured_ns,
+        "reference_ns": reference_ns,
+    }
+
+
+def calibrate_performance_scale(machine: Optional[str] = None) -> Dict[str, Any]:
+    """Measure fixed CPU work without executing any MemCP or test code."""
+    profile = performance_architecture(machine)
+    rounds = PERFORMANCE_CALIBRATION_ROUNDS[profile]
+    payload = bytes(range(256)) * 4096  # exactly one MiB
+
+    # Warm caches and crypto dispatch before collecting the robust median.
+    hashlib.sha256(payload).digest()
+    samples_ns = []
+    for _sample in range(PERFORMANCE_CALIBRATION_SAMPLES):
+        started_ns = time.perf_counter_ns()
+        for _round in range(rounds):
+            hashlib.sha256(payload).digest()
+        samples_ns.append(time.perf_counter_ns() - started_ns)
+    return performance_scale_from_samples(profile, samples_ns)
+
+
+def load_performance_scale() -> Dict[str, Any]:
+    """Load the hook's pre-server calibration or measure one for direct runs."""
+    serialized = os.environ.get(PERFORMANCE_SCALE_ENV)
+    if serialized is None:
+        return calibrate_performance_scale()
+
+    profile = performance_architecture(os.environ.get(PERFORMANCE_ARCH_ENV, ""))
+    if profile != performance_architecture():
+        raise ValueError("performance calibration architecture does not match this machine")
+    scale = float(serialized)
+    measured_ns = int(os.environ[PERFORMANCE_MEASURED_NS_ENV])
+    reference_ns = int(os.environ[PERFORMANCE_REFERENCE_NS_ENV])
+    expected_reference = PERFORMANCE_REFERENCE_NS_PER_MIB * PERFORMANCE_CALIBRATION_ROUNDS[profile]
+    if reference_ns != expected_reference:
+        raise ValueError("performance calibration reference does not match the protected constant")
+    expected_scale = max(PERFORMANCE_SCALE_MIN, measured_ns / reference_ns)
+    if not (PERFORMANCE_SCALE_MIN <= scale <= PERFORMANCE_SCALE_MAX):
+        raise ValueError("performance calibration scale is outside protected bounds")
+    if not math.isclose(scale, expected_scale, rel_tol=1e-9, abs_tol=1e-12):
+        raise ValueError("performance calibration scale does not match its measurements")
+    return {
+        "architecture": profile,
+        "scale": scale,
+        "measured_ns": measured_ns,
+        "reference_ns": reference_ns,
+    }
+
+
+def publish_performance_scale(calibration: Dict[str, Any]) -> None:
+    """Pass one pre-server calibration unchanged to suite subprocesses."""
+    os.environ[PERFORMANCE_ARCH_ENV] = calibration["architecture"]
+    os.environ[PERFORMANCE_SCALE_ENV] = format(calibration["scale"], ".17g")
+    os.environ[PERFORMANCE_MEASURED_NS_ENV] = str(calibration["measured_ns"])
+    os.environ[PERFORMANCE_REFERENCE_NS_ENV] = str(calibration["reference_ns"])
+
+
+def scaled_wall_clock_limit_ms(seconds: float, calibration: Dict[str, Any]) -> float:
+    """Translate a reference-machine wall-clock budget to this machine."""
+    return seconds * 1000.0 * calibration["scale"]
 
 
 def is_error_response(response: Optional[requests.Response]) -> bool:
@@ -316,7 +425,7 @@ def start_ram_monitor():
     return t
 
 class SQLTestRunner:
-    def __init__(self, base_url="http://localhost:4321", username="root", password="admin", default_database="memcp-tests", log_times=False, fail_fast=False):
+    def __init__(self, base_url="http://localhost:4321", username="root", password="admin", default_database="memcp-tests", log_times=False, fail_fast=False, performance_calibration=None):
         self.base_url = base_url
         self.username = username
         self.password = password
@@ -342,6 +451,7 @@ class SQLTestRunner:
         self.fail_fast = fail_fast
         self.current_spec_file = None
         self._config_loaded = False
+        self.performance_calibration = performance_calibration or load_performance_scale()
 
     def set_restart_handler(self, fn):
         """Install a restart handler callable that restarts MemCP (returns True on success)."""
@@ -1161,7 +1271,12 @@ class SQLTestRunner:
         # DEFAULT_MAX_TIME_SEC; slower queries must declare a higher limit so the
         # time budget stays explicit and visible in the test spec.
         if not is_perf_test and response.status_code == 200:
-            hard_limit_ms = hard_limit_sec * 1000.0
+            # max_time is a reference-machine budget.  Only its wall-clock
+            # enforcement is machine-scaled; correctness, plan size, planner
+            # metrics, data volume, and test criticality remain unchanged.
+            hard_limit_ms = scaled_wall_clock_limit_ms(
+                hard_limit_sec, self.performance_calibration
+            )
             if elapsed_ms > hard_limit_ms:
                 diag = self._run_on_fail(test_case, database)
                 return self._record_fail(name, f"Too slow (hard limit): {elapsed_ms:.1f}ms > {hard_limit_ms:.0f}ms", query, response,
@@ -1376,6 +1491,13 @@ class SQLTestRunner:
 
         print(f"🎯 Running suite: {metadata.get('description', spec_file)}")
         print(f"💾 Database: {database}")
+        calibration = self.performance_calibration
+        print(
+            "⚖️  Wall-clock scale: "
+            f"{calibration['scale']:.2f}x ({calibration['architecture']}, "
+            f"reference {calibration['measured_ns'] / 1_000_000:.1f}/"
+            f"{calibration['reference_ns'] / 1_000_000:.1f}ms)"
+        )
 
         self.ensure_database(database)
 
@@ -1823,6 +1945,11 @@ def main():
         print_usage()
         sys.exit(1)
 
+    # Calibrate before a candidate MemCP process exists.  Publishing the
+    # validated result makes all later suite workers use exactly this factor.
+    performance_calibration = load_performance_scale()
+    publish_performance_scale(performance_calibration)
+
     spec_files, port, connect_only, log_times, jobs, fail_fast = parse_cli_args(sys.argv[1:])
 
     if not spec_files:
@@ -1854,7 +1981,12 @@ def main():
                 print("❌ Failed to start MemCP")
                 sys.exit(1)
 
-    runner = SQLTestRunner(base_url, log_times=log_times, fail_fast=fail_fast)
+    runner = SQLTestRunner(
+        base_url,
+        log_times=log_times,
+        fail_fast=fail_fast,
+        performance_calibration=performance_calibration,
+    )
     if not connect_only:
         def restart_handler() -> bool:
             nonlocal memcp_process

--- a/tests/planner/subqueries/subquery-complex.yaml
+++ b/tests/planner/subqueries/subquery-complex.yaml
@@ -26,6 +26,11 @@ setup:
   - sql: "DROP TABLE IF EXISTS sq_large_emp"
   - sql: "DROP TABLE IF EXISTS sq_dept"
   - sql: "DROP TABLE IF EXISTS sq_emp"
+  - sql: "DROP TABLE IF EXISTS sq_order_product"
+  - sql: "DROP TABLE IF EXISTS sq_order_vendor"
+  - sql: "DROP TABLE IF EXISTS sq_order_offer"
+  - sql: "DROP TABLE IF EXISTS sq_order_country"
+  - sql: "DROP TABLE IF EXISTS sq_order_region"
   - sql: |
       CREATE TABLE sq_dept (did INT, dname VARCHAR(30))
   - sql: |
@@ -45,11 +50,96 @@ setup:
         (8, 'Henry', NULL, 50000)
   - sql: "CREATE TABLE sq_large_dept (did INT)"
   - sql: "CREATE TABLE sq_large_emp (did INT, salary INT)"
+  - sql: "CREATE TABLE sq_order_product (id INT PRIMARY KEY, size INT, kind TEXT)"
+  - sql: "CREATE TABLE sq_order_vendor (id INT PRIMARY KEY, country_id INT, name TEXT, balance INT)"
+  - sql: "CREATE TABLE sq_order_offer (product_id INT, vendor_id INT, cost INT)"
+  - sql: "CREATE TABLE sq_order_country (id INT PRIMARY KEY, region_id INT, name TEXT)"
+  - sql: "CREATE TABLE sq_order_region (id INT PRIMARY KEY, name TEXT)"
+  - sql: "INSERT INTO sq_order_product VALUES (1,15,'small alloy'),(2,15,'small alloy')"
+  - sql: "INSERT INTO sq_order_vendor VALUES (10,100,'vendor a',200),(20,100,'vendor b',200),(30,200,'vendor c',400)"
+  - sql: "INSERT INTO sq_order_offer VALUES (1,10,50),(1,20,40),(2,10,30),(2,30,20)"
+  - sql: "INSERT INTO sq_order_country VALUES (100,1000,'country a'),(200,2000,'country b')"
+  - sql: "INSERT INTO sq_order_region VALUES (1000,'north'),(2000,'south')"
   - scm: |
       (insert (table "memcp-tests" "sq_large_dept") '("did")
         (map (produceN 1001) (lambda (i) (list i))))
 
 test_cases:
+
+  - name: "Ordered multi-join with correlated aggregate filter"
+    sql: |
+      SELECT v.balance, c.name AS country_name, v.name AS vendor_name, p.id
+      FROM sq_order_product p, sq_order_vendor v, sq_order_offer o,
+           sq_order_country c, sq_order_region r
+      WHERE p.id = o.product_id
+        AND v.id = o.vendor_id
+        AND v.country_id = c.id
+        AND c.region_id = r.id
+        AND p.size = 15
+        AND p.kind LIKE '%alloy'
+        AND r.name = 'north'
+        AND o.cost = (
+          SELECT MIN(o2.cost)
+          FROM sq_order_offer o2, sq_order_vendor v2,
+               sq_order_country c2, sq_order_region r2
+          WHERE p.id = o2.product_id
+            AND v2.id = o2.vendor_id
+            AND v2.country_id = c2.id
+            AND c2.region_id = r2.id
+            AND r2.name = 'north'
+        )
+      ORDER BY v.balance DESC, c.name, v.name, p.id
+      LIMIT 100
+    expect:
+      rows: 2
+      data:
+        - balance: 200
+          country_name: "country a"
+          vendor_name: "vendor a"
+          id: 2
+        - balance: 200
+          country_name: "country a"
+          vendor_name: "vendor b"
+          id: 1
+
+  - name: "Ordered correlated join uses a storage-backed intermediate relation"
+    sql: |
+      EXPLAIN SELECT v.balance, c.name AS country_name, v.name AS vendor_name, p.id
+      FROM sq_order_product p, sq_order_vendor v, sq_order_offer o,
+           sq_order_country c, sq_order_region r
+      WHERE p.id = o.product_id
+        AND v.id = o.vendor_id
+        AND v.country_id = c.id
+        AND c.region_id = r.id
+        AND p.size = 15
+        AND p.kind LIKE '%alloy'
+        AND r.name = 'north'
+        AND o.cost = (
+          SELECT MIN(o2.cost)
+          FROM sq_order_offer o2, sq_order_vendor v2,
+               sq_order_country c2, sq_order_region r2
+          WHERE p.id = o2.product_id
+            AND v2.id = o2.vendor_id
+            AND v2.country_id = c2.id
+            AND c2.region_id = r2.id
+            AND r2.name = 'north'
+        )
+      ORDER BY v.balance DESC, c.name, v.name, p.id
+      LIMIT 100
+    expect:
+      rows: 1
+      result_contains:
+        - ".join-order:"
+        - "scan_order"
+        - "droptable"
+      result_not_contains:
+        - "(sort rows"
+
+  - name: "Ordered join intermediate relation is query-local"
+    sql: "SHOW TABLES"
+    expect:
+      result_not_contains:
+        - ".join-order:"
 
   # === Scalar subquery in SELECT ===
 

--- a/tests/sql/dml/traced-insert-select-pagination.yaml
+++ b/tests/sql/dml/traced-insert-select-pagination.yaml
@@ -20,6 +20,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS trace_limit_output"
+  - sql: "DROP TABLE IF EXISTS trace_limit_file"
   - sql: "DROP TABLE IF EXISTS trace_limit_parent"
   - sql: "DROP TABLE IF EXISTS trace_limit_label"
   - sql: |
@@ -37,8 +38,14 @@ setup:
         id INT PRIMARY KEY,
         label VARCHAR(64)
       )
+  - sql: |
+      CREATE TABLE trace_limit_file (
+        id INT PRIMARY KEY,
+        uploaded_at INT
+      )
   - sql: "INSERT INTO trace_limit_parent (id, label_id) VALUES (1, 10), (2, 20)"
   - sql: "INSERT INTO trace_limit_label (id, label) VALUES (10, 'zeta'), (20, 'alpha')"
+  - sql: "INSERT INTO trace_limit_file (id, uploaded_at) VALUES (100, 500), (200, 900)"
 
 test_cases:
   - name: "INSERT SELECT preserves a multi-source derived ORDER LIMIT relation"
@@ -68,6 +75,40 @@ test_cases:
       data:
         - id: 1
           label: "zeta"
+  - name: "INSERT SELECT reduces an ordered join with a scalar lookup key"
+    max_time: 1.0
+    max_plan_size: 20000
+    setup:
+      - sql: "DELETE FROM trace_limit_output"
+    sql: |
+      INSERT INTO trace_limit_output (id, label)
+      SELECT candidate.id, candidate.label
+      FROM (
+        SELECT parent.id, label.label
+        FROM trace_limit_parent parent
+        LEFT JOIN trace_limit_label label ON label.id = parent.label_id
+        ORDER BY (
+          SELECT file.uploaded_at
+          FROM trace_limit_file file
+          WHERE file.id = parent.id * 100
+          LIMIT 1
+        ) DESC, label.label DESC, parent.id
+        LIMIT 1
+      ) candidate
+      WHERE NOT EXISTS (
+        SELECT TRUE
+        FROM trace_limit_output present
+        WHERE present.id = candidate.id
+      )
+    expect:
+      affected_rows: 1
+  - name: "INSERT SELECT scalar lookup ordering stores the selected joined row"
+    sql: "SELECT id, label FROM trace_limit_output"
+    expect:
+      rows: 1
+      data:
+        - id: 2
+          label: "alpha"
   - name: "Multi-source derived ORDER LIMIT preserves OFFSET"
     sql: |
       SELECT candidate.id, candidate.label
@@ -119,5 +160,6 @@ test_cases:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_limit_output"
+  - sql: "DROP TABLE IF EXISTS trace_limit_file"
   - sql: "DROP TABLE IF EXISTS trace_limit_parent"
   - sql: "DROP TABLE IF EXISTS trace_limit_label"

--- a/tools/check_sql_time_limit.py
+++ b/tools/check_sql_time_limit.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import math
 import re
 import subprocess
@@ -34,7 +35,22 @@ import yaml
 
 EXPECTED_DEFAULT_MAX_TIME_SEC = 5.0
 EXPECTED_DEFAULT_MAX_PLAN_SIZE = 200_000
+EXPECTED_PERFORMANCE_REFERENCE_NS_PER_MIB = 450_000
+EXPECTED_PERFORMANCE_CALIBRATION_SAMPLES = 5
+EXPECTED_PERFORMANCE_SCALE_MIN = 1.0
+EXPECTED_PERFORMANCE_SCALE_MAX = 16.0
+EXPECTED_PERFORMANCE_CALIBRATION_ROUNDS = {
+    "x86_64": 32,
+    "aarch64": 16,
+    "armv7l": 8,
+    "other": 16,
+}
+EXPECTED_CALIBRATION_AST_SHA256 = "2e3ab9d30e772472d35c44d9dc11e330a2755e68e65fb848c652dd1af5d08dd2"
 MAPPING_BUDGETS = ("max_compile_phase_ms", "max_compile_metrics")
+PROTECTED_POLICY_PATHS = (
+    ".github/workflows/sql-regression-policy.yml",
+    "tools/check_sql_time_limit.py",
+)
 PROTECTED_EXPECTATIONS = (
     "rows",
     "data",
@@ -81,8 +97,31 @@ def assigned_numeric_constant(tree: ast.AST, name: str) -> float:
     return value
 
 
+def assigned_literal(tree: ast.AST, name: str) -> Any:
+    values: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                values.append(node.value)
+    if len(values) != 1:
+        raise GuardFailure(f"run_sql_tests.py must define {name} exactly once")
+    try:
+        return ast.literal_eval(values[0])
+    except (ValueError, TypeError) as exc:
+        raise GuardFailure(f"{name} must be a literal") from exc
+
+
 def check_runner(root: Path) -> None:
     runner = root / "run_sql_tests.py"
+    required_paths = (
+        runner,
+        root / "git-pre-commit",
+        root / ".github/workflows/test.yml",
+    )
+    if any(path.is_symlink() for path in required_paths):
+        raise GuardFailure("runner, test hook, and required workflow must be regular files")
     source = runner.read_text(encoding="utf-8")
     for environment_override in ("MEMCP_MAX_TIME", "MEMCP_MAX_PLAN_SIZE"):
         if environment_override in source:
@@ -101,6 +140,120 @@ def check_runner(root: Path) -> None:
         raise GuardFailure(
             f"DEFAULT_MAX_PLAN_SIZE must remain the literal {EXPECTED_DEFAULT_MAX_PLAN_SIZE}"
         )
+    protected_constants = {
+        "PERFORMANCE_REFERENCE_NS_PER_MIB": EXPECTED_PERFORMANCE_REFERENCE_NS_PER_MIB,
+        "PERFORMANCE_CALIBRATION_SAMPLES": EXPECTED_PERFORMANCE_CALIBRATION_SAMPLES,
+        "PERFORMANCE_SCALE_MIN": EXPECTED_PERFORMANCE_SCALE_MIN,
+        "PERFORMANCE_SCALE_MAX": EXPECTED_PERFORMANCE_SCALE_MAX,
+    }
+    for name, expected in protected_constants.items():
+        actual = assigned_numeric_constant(tree, name)
+        if actual != expected:
+            raise GuardFailure(
+                f"{name} must remain the protected literal {expected}; "
+                "do not weaken regression budgets through calibration"
+            )
+    actual_rounds = assigned_literal(tree, "PERFORMANCE_CALIBRATION_ROUNDS")
+    if actual_rounds != EXPECTED_PERFORMANCE_CALIBRATION_ROUNDS:
+        raise GuardFailure(
+            "PERFORMANCE_CALIBRATION_ROUNDS must remain the protected architecture mapping"
+        )
+
+    calibration_names = {
+        "performance_architecture",
+        "performance_scale_from_samples",
+        "calibrate_performance_scale",
+        "load_performance_scale",
+        "publish_performance_scale",
+        "scaled_wall_clock_limit_ms",
+    }
+    calibration_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in calibration_names
+    ]
+    if {node.name for node in calibration_nodes} != calibration_names:
+        raise GuardFailure("run_sql_tests.py is missing protected calibration functions")
+    calibration_ast = "\n".join(
+        ast.dump(node, annotate_fields=True, include_attributes=False)
+        for node in calibration_nodes
+    )
+    calibration_digest = hashlib.sha256(calibration_ast.encode("utf-8")).hexdigest()
+    if calibration_digest != EXPECTED_CALIBRATION_AST_SHA256:
+        raise GuardFailure(
+            "performance calibration implementation changed; do not make a regression enlarge its own budget"
+        )
+
+    scale_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "scaled_wall_clock_limit_ms"
+    ]
+    scaled_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "hard_limit_ms"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "scaled_wall_clock_limit_ms"
+    ]
+    if len(scale_calls) != 1 or len(scaled_assignments) != 1:
+        raise GuardFailure(
+            "machine scaling must apply exactly once and only to the max_time wall-clock gate"
+        )
+    for unscaled_gate in (
+        "plan_size_limit",
+        "planner_time_limit_ms",
+        "compile_phase_limits_ms",
+        "compile_metric_limits",
+    ):
+        if re.search(rf"{unscaled_gate}[^\n]*performance_calibration", source):
+            raise GuardFailure(
+                f"{unscaled_gate} must remain independent of machine wall-clock calibration"
+            )
+
+    hook = (root / "git-pre-commit").read_text(encoding="utf-8")
+    export_line = 'export MEMCP_TEST_PERFORMANCE_SCALE="$performance_scale"'
+    if hook.count(export_line) != 1:
+        raise GuardFailure(
+            "git-pre-commit must publish exactly one pre-server performance calibration"
+        )
+    for variable in (
+        "MEMCP_TEST_PERFORMANCE_ARCH",
+        "MEMCP_TEST_PERFORMANCE_SCALE",
+        "MEMCP_TEST_PERFORMANCE_MEASURED_NS",
+        "MEMCP_TEST_PERFORMANCE_REFERENCE_NS",
+    ):
+        if hook.count(variable) != 1:
+            raise GuardFailure(
+                f"git-pre-commit must set {variable} exactly once from the protected calibration"
+            )
+    calibration_pos = hook.find("calibrate_performance_scale")
+    server_pos = hook.find("start_supervisor")
+    if calibration_pos < 0 or server_pos < 0 or calibration_pos > server_pos:
+        raise GuardFailure(
+            "git-pre-commit must calibrate before MemCP starts so regressions cannot enlarge their own allowance"
+        )
+
+    workflow_path = root / ".github/workflows/test.yml"
+    workflow = load_suite(workflow_path.read_text(encoding="utf-8"), str(workflow_path))
+    jobs = workflow.get("jobs", {})
+    test_job = jobs.get("test", {}) if isinstance(jobs, dict) else {}
+    steps = test_job.get("steps", []) if isinstance(test_job, dict) else []
+    hook_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("run") == "bash git-pre-commit"
+    ]
+    if len(hook_steps) != 1 or hook_steps[0].get("continue-on-error") is True:
+        raise GuardFailure("the required test workflow must execute git-pre-commit")
 
 
 def load_suite(text: str, label: str) -> dict[str, Any]:
@@ -412,6 +565,28 @@ def check_base_regressions(
             )
         compare_suites(old_suite, head_suites[new_path], new_path)
     check_added_planner_lines(added_planner_lines(root, base_ref))
+
+    # The pull_request_target policy runs this checker from the trusted base
+    # revision.  Once bootstrapped, a PR cannot rewrite either that workflow or
+    # the checker that defines the policy it is being judged by.
+    policy_path = PROTECTED_POLICY_PATHS[0]
+    policy_exists = subprocess.run(
+        ["git", "cat-file", "-e", f"{base_ref}:{policy_path}"],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    ).returncode == 0
+    if policy_exists:
+        for path in PROTECTED_POLICY_PATHS:
+            if (root / path).is_symlink():
+                raise GuardFailure(f"{path} must be a regular protected policy file")
+            base_content = git(root, "show", f"{base_ref}:{path}").stdout
+            head_content = (root / path).read_text(encoding="utf-8")
+            if head_content != base_content:
+                raise GuardFailure(
+                    f"{path} is protected policy code; obtain explicit maintainer approval "
+                    "and use the administrative policy-update procedure"
+                )
 
 
 def parse_args() -> argparse.Namespace:

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -19,6 +19,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 import sys
 import tempfile
 import threading
@@ -28,7 +29,91 @@ import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from run_sql_tests import SQLTestRunner, is_error_response, observe_atomic_json  # noqa: E402
+from run_sql_tests import (  # noqa: E402
+    PERFORMANCE_ARCH_ENV,
+    PERFORMANCE_CALIBRATION_ROUNDS,
+    PERFORMANCE_MEASURED_NS_ENV,
+    PERFORMANCE_REFERENCE_NS_ENV,
+    PERFORMANCE_REFERENCE_NS_PER_MIB,
+    PERFORMANCE_SCALE_ENV,
+    SQLTestRunner,
+    is_error_response,
+    load_performance_scale,
+    observe_atomic_json,
+    performance_architecture,
+    performance_scale_from_samples,
+    publish_performance_scale,
+    scaled_wall_clock_limit_ms,
+)
+
+
+class PerformanceScaleContractTest(unittest.TestCase):
+    def test_architecture_aliases_select_stable_profiles(self) -> None:
+        self.assertEqual(performance_architecture("AMD64"), "x86_64")
+        self.assertEqual(performance_architecture("arm64"), "aarch64")
+        self.assertEqual(performance_architecture("mips64"), "other")
+
+    def test_reference_machine_never_tightens_wall_clock_budget(self) -> None:
+        reference_ns = (
+            PERFORMANCE_REFERENCE_NS_PER_MIB
+            * PERFORMANCE_CALIBRATION_ROUNDS["x86_64"]
+        )
+        calibration = performance_scale_from_samples(
+            "x86_64", [reference_ns // 2, reference_ns // 2, reference_ns]
+        )
+        self.assertEqual(calibration["scale"], 1.0)
+        self.assertEqual(scaled_wall_clock_limit_ms(0.02, calibration), 20.0)
+
+    def test_slower_machine_scales_only_the_wall_clock_budget(self) -> None:
+        reference_ns = (
+            PERFORMANCE_REFERENCE_NS_PER_MIB
+            * PERFORMANCE_CALIBRATION_ROUNDS["aarch64"]
+        )
+        calibration = performance_scale_from_samples(
+            "aarch64", [reference_ns * 4] * 5
+        )
+        self.assertEqual(calibration["scale"], 4.0)
+        self.assertEqual(scaled_wall_clock_limit_ms(0.02, calibration), 80.0)
+
+    def test_unreasonably_slow_calibration_fails_instead_of_disabling_gates(self) -> None:
+        reference_ns = (
+            PERFORMANCE_REFERENCE_NS_PER_MIB
+            * PERFORMANCE_CALIBRATION_ROUNDS["armv7l"]
+        )
+        with self.assertRaisesRegex(ValueError, "exceeds supported maximum"):
+            performance_scale_from_samples("armv7l", [reference_ns * 17])
+
+    def test_inherited_scale_must_match_protected_measurements(self) -> None:
+        profile = performance_architecture()
+        reference_ns = (
+            PERFORMANCE_REFERENCE_NS_PER_MIB
+            * PERFORMANCE_CALIBRATION_ROUNDS[profile]
+        )
+        environment = {
+            PERFORMANCE_ARCH_ENV: profile,
+            PERFORMANCE_SCALE_ENV: "8",
+            PERFORMANCE_MEASURED_NS_ENV: str(reference_ns),
+            PERFORMANCE_REFERENCE_NS_ENV: str(reference_ns),
+        }
+        with mock.patch.dict("os.environ", environment, clear=False):
+            with self.assertRaisesRegex(ValueError, "does not match its measurements"):
+                load_performance_scale()
+
+    def test_published_calibration_round_trips_without_recalibration(self) -> None:
+        profile = performance_architecture()
+        reference_ns = (
+            PERFORMANCE_REFERENCE_NS_PER_MIB
+            * PERFORMANCE_CALIBRATION_ROUNDS[profile]
+        )
+        calibration = {
+            "architecture": profile,
+            "scale": 2.0,
+            "measured_ns": reference_ns * 2,
+            "reference_ns": reference_ns,
+        }
+        with mock.patch.dict("os.environ", {}, clear=True):
+            publish_performance_scale(calibration)
+            self.assertEqual(load_performance_scale(), calibration)
 
 
 class ErrorResponseContractTest(unittest.TestCase):

--- a/tools/test_sql_time_limit_guard.py
+++ b/tools/test_sql_time_limit_guard.py
@@ -19,10 +19,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import shutil
+import tempfile
 import unittest
 
 from check_sql_time_limit import GuardFailure
 from check_sql_time_limit import check_added_planner_lines
+from check_sql_time_limit import check_runner
 from check_sql_time_limit import compare_suites
 from check_sql_time_limit import load_suite
 from check_sql_time_limit import validate_suite
@@ -38,6 +42,68 @@ def suite(case: dict | None = None, metadata: dict | None = None) -> dict:
 
 
 class CurrentTreeValidationTest(unittest.TestCase):
+    def runner_fixture(self) -> tuple[tempfile.TemporaryDirectory, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name)
+        repository = Path(__file__).resolve().parents[1]
+        (root / "tools").mkdir()
+        (root / ".github" / "workflows").mkdir(parents=True)
+        for relative in (
+            "run_sql_tests.py",
+            "git-pre-commit",
+            ".github/workflows/test.yml",
+        ):
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(repository / relative, target)
+        return temporary, root
+
+    def test_current_runner_keeps_calibration_contract(self) -> None:
+        check_runner(Path(__file__).resolve().parents[1])
+
+    def test_runner_rejects_a_relaxed_machine_scale_cap(self) -> None:
+        temporary, root = self.runner_fixture()
+        with temporary:
+            runner = root / "run_sql_tests.py"
+            runner.write_text(
+                runner.read_text(encoding="utf-8").replace(
+                    "PERFORMANCE_SCALE_MAX = 16.0", "PERFORMANCE_SCALE_MAX = 160.0"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(GuardFailure, "protected literal"):
+                check_runner(root)
+
+    def test_runner_rejects_calibration_work_that_can_be_tampered_with(self) -> None:
+        temporary, root = self.runner_fixture()
+        with temporary:
+            runner = root / "run_sql_tests.py"
+            runner.write_text(
+                runner.read_text(encoding="utf-8").replace(
+                    "hashlib.sha256(payload).digest()",
+                    "time.sleep(0.1)",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(GuardFailure, "implementation changed"):
+                check_runner(root)
+
+    def test_runner_rejects_scaling_any_gate_other_than_max_time(self) -> None:
+        temporary, root = self.runner_fixture()
+        with temporary:
+            runner = root / "run_sql_tests.py"
+            runner.write_text(
+                runner.read_text(encoding="utf-8").replace(
+                    "plan_size_limit = int(test_case[\"max_plan_size\"])",
+                    "plan_size_limit = scaled_wall_clock_limit_ms(1, self.performance_calibration)",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(GuardFailure, "exactly once"):
+                check_runner(root)
+
     def test_structured_yaml_rejects_quoted_time_bypass(self) -> None:
         value = load_suite(
             "metadata: {}\ntest_cases:\n  - name: bypass\n    max_time: '6e0'\n    sql: SELECT 1\n",


### PR DESCRIPTION
## Regression

A real-world compatibility workload exposed a second ordered-join lowering gap after #446: an `INSERT ... SELECT` consumes an ordered derived join through a dataset reducer. The order starts with a decorrelated scalar lookup and therefore cannot be represented by the direct ordered driver. Master aborted with `build_queryplan: dataset ORDER BY requires a storage carrier` and rolled back the surrounding transaction.

## Fix

Generalize the storage-backed join-order intermediate relation from #446 so both result streaming and dataset reductions can consume it. The logical join tree still streams directly into the memory-engine relation; `scan_order` owns ordering, OFFSET, and LIMIT. Cleanup now preserves the reducer result while still dropping the intermediate relation on success and error. Existing direct ordered paths are unchanged.

## Regression coverage

Adds a generic trace-derived `INSERT ... SELECT` regression with:

- a LEFT JOIN inside a derived relation,
- a decorrelated scalar lookup as the leading ORDER BY key,
- additional joined ordering keys and LIMIT,
- an outer NOT EXISTS filter, and
- exact verification of the inserted row.

No proprietary application SQL, data, names, or local tooling is committed or referenced.

## Machine-normalized CI budgets

The CI failure exposed that a fixed wall-clock budget also measures runner speed. This PR now treats `max_time` as a reference-machine budget:

- a fixed SHA-256 workload is calibrated before MemCP starts;
- architecture-specific work sizes keep the measurement stable on x86-64, AArch64, and ARMv7;
- the median maps the reference budget to a bounded 1x–16x machine factor;
- the same pre-server factor is inherited by every suite worker;
- only the `max_time` wall-clock comparison is scaled.

Correctness expectations, test criticality, row counts, plan-size limits, planner metrics, and compile-phase limits remain absolute. The calibration does not execute MemCP or candidate queries, so a query-engine regression cannot enlarge its own allowance.

A new `pull_request_target` policy evaluates candidate files with the checker from the trusted base revision. After bootstrap, PRs cannot rewrite the policy workflow or checker they are being judged by. Guard tests reject a raised factor cap, altered calibration work, inconsistent inherited measurements, and attempts to apply scaling to another gate.

## Validation

- SQL regression guard against current master: green
- guard contract tests: 19/19
- runner contract tests: 14/14
- ordered INSERT SELECT regression suite: 7/7
- IN/NOT IN subquery suite, including the previously red reference budget: 68/68
- three repeated reproductions of the previously red suite: green
- complete GitHub Actions test suite: green in 10m 4s
- CI reference calibration: 1.47x on x86-64; the formerly failing reference budget passed without changing its YAML limit