### PR TITLE
Optimize adaptive LIKE match sets

### DIFF
--- a/scm/strings.go
+++ b/scm/strings.go
@@ -58,6 +58,23 @@ func LookupCollate(fn func(...Scmer) Scmer) (string, bool, bool) {
 
 /* SQL LIKE operator implementation on strings */
 func StrLike(str, pattern string) bool {
+	if !strings.ContainsAny(pattern, "%_") {
+		return str == pattern
+	}
+	if !strings.Contains(pattern, "_") {
+		wildcards := strings.Count(pattern, "%")
+		if wildcards == 1 {
+			if pattern[0] == '%' {
+				return strings.HasSuffix(str, pattern[1:])
+			}
+			if pattern[len(pattern)-1] == '%' {
+				return strings.HasPrefix(str, pattern[:len(pattern)-1])
+			}
+		}
+		if wildcards == 2 && pattern[0] == '%' && pattern[len(pattern)-1] == '%' {
+			return strings.Contains(str, pattern[1:len(pattern)-1])
+		}
+	}
 	for {
 		// boundary check
 		if len(pattern) == 0 {
@@ -96,6 +113,23 @@ func StrLike(str, pattern string) bool {
 			}
 		}
 	}
+}
+
+// StrLikeFold retains the established Unicode lower-case behavior. StrLike's
+// fast paths then dispatch exact, prefix, suffix and contains patterns to Go's
+// optimized string primitives.
+func StrLikeFold(str, pattern string) bool {
+	return StrLike(strings.ToLower(str), strings.ToLower(pattern))
+}
+
+// StrLikeCollation is the canonical LIKE implementation shared by the Scheme
+// builtin and storage match indexes. Keeping both paths here guarantees that an
+// exact cached match set has the same case semantics as residual evaluation.
+func StrLikeCollation(str, pattern, collation string) bool {
+	if strings.Contains(strings.ToLower(collation), "_ci") {
+		return StrLikeFold(str, pattern)
+	}
+	return StrLike(str, pattern)
 }
 
 func TransformFromJSON(a_ any) Scmer {
@@ -267,11 +301,7 @@ func init_strings() {
 			if len(a) > 2 {
 				collation = strings.ToLower(String(a[2]))
 			}
-			if strings.Contains(collation, "_ci") {
-				value = strings.ToLower(value)
-				pattern = strings.ToLower(pattern)
-			}
-			return NewBool(StrLike(value, pattern))
+			return NewBool(StrLikeCollation(value, pattern, collation))
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "pattern", ParamDesc: "pattern with % and _ in them"}, &TypeDescriptor{Kind: "string", ParamName: "collation", ParamDesc: "collation in which to compare them", Optional: true}},

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "github.com/carli2/hybridsort"
+import "math/bits"
 import "strings"
 import "github.com/launix-de/memcp/scm"
 
@@ -55,47 +56,93 @@ type BoundaryMatcher interface {
 	// For sorted matchers this is a no-op. The pattern is the search value
 	// (e.g. the LIKE pattern). The result is stored on the StorageIndex.
 	// colStorage is the column's ColumnStorage for reading values.
-	BuildSkipList(pattern string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage) *SkipList
+	BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage, candidate *SkipList) *SkipList
 }
 
-// SkipList holds precomputed interval data for block-level skipping.
-// Built once during index construction, stored on StorageIndex, used by iterate().
+// SkipList holds an exact adaptive set of matching index positions.
 type SkipList struct {
-	starts StorageInt // interval start positions (index order), bit-packed
-	lens   StorageInt // interval lengths, bit-packed
-	count  uint32     // number of intervals
+	matches recSetShard
 }
 
-// NextBlock returns the next block of potentially matching records at or after pos.
-// Returns (0, 0, false) when no more blocks exist.
-func (s *SkipList) NextBlock(pos uint32) (start uint32, length uint32, ok bool) {
-	if s == nil || s.count == 0 {
+type skipListCursor struct {
+	skip    *SkipList
+	listPos int
+}
+
+func (s *SkipList) cursor() skipListCursor {
+	return skipListCursor{skip: s}
+}
+
+func (c *skipListCursor) NextBlock(pos uint32) (uint32, uint32, bool) {
+	if c.skip == nil {
 		return 0, 0, false
 	}
-	lo, hi := uint32(0), s.count
-	for lo < hi {
-		mid := (lo + hi) / 2
-		st := uint32(int64(s.starts.GetValueUInt(mid)) + s.starts.offset)
-		ln := uint32(int64(s.lens.GetValueUInt(mid)) + s.lens.offset)
-		if st+ln <= pos {
-			lo = mid + 1
-		} else {
-			hi = mid
+	set := &c.skip.matches
+	if pos >= set.universe || set.kind == recSetEmpty {
+		return 0, 0, false
+	}
+	switch set.kind {
+	case recSetFull:
+		return pos, set.universe - pos, true
+	case recSetPositive:
+		values := set.listedValues()
+		for c.listPos < len(values) && values[c.listPos] < pos {
+			c.listPos++
 		}
-	}
-	if lo >= s.count {
+		if c.listPos == len(values) {
+			return 0, 0, false
+		}
+		start := values[c.listPos]
+		end := start + 1
+		c.listPos++
+		for c.listPos < len(values) && values[c.listPos] == end {
+			end++
+			c.listPos++
+		}
+		return start, end - start, true
+	case recSetNegative:
+		excluded := set.listedValues()
+		for c.listPos < len(excluded) && excluded[c.listPos] < pos {
+			c.listPos++
+		}
+		for c.listPos < len(excluded) && excluded[c.listPos] == pos {
+			pos++
+			c.listPos++
+		}
+		if pos >= set.universe {
+			return 0, 0, false
+		}
+		end := set.universe
+		if c.listPos < len(excluded) {
+			end = excluded[c.listPos]
+		}
+		return pos, end - pos, true
+	case recSetBitmap:
+		wordIndex := pos >> 5
+		word := set.data[wordIndex] & (^uint32(0) << (pos & 31))
+		for word == 0 {
+			wordIndex++
+			if int(wordIndex) >= len(set.data) {
+				return 0, 0, false
+			}
+			word = set.data[wordIndex]
+		}
+		start := (wordIndex << 5) + uint32(bits.TrailingZeros32(word))
+		end := start + 1
+		for end < set.universe && set.contains(end) {
+			end++
+		}
+		return start, end - start, true
+	default:
 		return 0, 0, false
 	}
-	st := uint32(int64(s.starts.GetValueUInt(lo)) + s.starts.offset)
-	ln := uint32(int64(s.lens.GetValueUInt(lo)) + s.lens.offset)
-	return st, ln, true
 }
 
 func (s *SkipList) ComputeSize() uint {
 	if s == nil {
 		return 0
 	}
-	return s.starts.ComputeSize() + s.lens.ComputeSize() + 16
+	return uint(len(s.matches.data))*4 + 32
 }
 
 // Built-in matcher singletons. Every columnboundaries.matcher points to one of these.
@@ -123,7 +170,7 @@ type equalMatcher struct{}
 func (m *equalMatcher) Kind() string      { return "equal" }
 func (m *equalMatcher) IsSorted() bool    { return true }
 func (m *equalMatcher) IsPointLike() bool { return true }
-func (m *equalMatcher) BuildSkipList(_ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
+func (m *equalMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
 	return nil // sorted: no skip list needed
 }
 
@@ -134,7 +181,7 @@ type rangeMatcher struct{}
 func (m *rangeMatcher) Kind() string      { return "range" }
 func (m *rangeMatcher) IsSorted() bool    { return true }
 func (m *rangeMatcher) IsPointLike() bool { return false }
-func (m *rangeMatcher) BuildSkipList(_ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
+func (m *rangeMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
 	return nil // sorted: no skip list needed
 }
 
@@ -145,73 +192,49 @@ type likeMatcher struct{}
 func (m *likeMatcher) Kind() string      { return "like" }
 func (m *likeMatcher) IsSorted() bool    { return false }
 func (m *likeMatcher) IsPointLike() bool { return true }
-func (m *likeMatcher) BuildSkipList(pattern string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage) *SkipList {
+func (m *likeMatcher) BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage, candidate *SkipList) *SkipList {
 	if count == 0 || colStorage == nil {
 		return nil
 	}
 
-	// Scan to find intervals with 3-miss tolerance
-	type interval struct{ start, len uint32 }
-	var intervals []interval
-	inInterval := false
-	var intervalStart uint32
-	var intervalLen uint32
-	missCount := 0
-	const maxMiss = 3
-
-	patternCI := strings.ToLower(pattern)
-	for pos := uint32(0); pos < count; pos++ {
+	builder := newRecSetShardBuilder(nil, count, candidate == nil)
+	replayUntil := uint32(0)
+	matches := func(pos uint32) bool {
 		recid := getRecid(pos)
 		v := colStorage.GetValue(recid)
-		hit := false
-		if v.IsString() {
-			value := v.String()
-			hit = scm.StrLike(value, pattern) || scm.StrLike(strings.ToLower(value), patternCI)
+		return v.IsString() && scm.StrLikeCollation(v.String(), pattern, collation)
+	}
+	add := func(pos uint32) bool {
+		wasBitmap := builder.bitmap
+		builder.add(pos, matches(pos))
+		if !wasBitmap && builder.bitmap {
+			replayUntil = pos + 1
 		}
-
-		if hit {
-			if !inInterval {
-				intervalStart = pos
-				intervalLen = 1
-				inInterval = true
-			} else {
-				intervalLen = pos - intervalStart + 1
-			}
-			missCount = 0
-		} else if inInterval {
-			missCount++
-			if missCount > maxMiss {
-				intervals = append(intervals, interval{intervalStart, intervalLen})
-				inInterval = false
-				missCount = 0
-			}
+		return true
+	}
+	if candidate != nil {
+		candidate.matches.forEachID(add)
+	} else {
+		for pos := uint32(0); pos < count; pos++ {
+			add(pos)
 		}
 	}
-	if inInterval {
-		intervals = append(intervals, interval{intervalStart, intervalLen})
+	if replayUntil > 0 {
+		if candidate != nil {
+			candidate.matches.forEachID(func(pos uint32) bool {
+				if pos >= replayUntil {
+					return false
+				}
+				builder.addBitmap(pos, matches(pos))
+				return true
+			})
+		} else {
+			for pos := uint32(0); pos < replayUntil; pos++ {
+				builder.addBitmap(pos, matches(pos))
+			}
+		}
 	}
-
-	if len(intervals) == 0 {
-		return nil
-	}
-
-	// Pack into two StorageInt (compact bit-packed representation)
-	n := uint32(len(intervals))
-	sl := &SkipList{count: n}
-	sl.starts.prepare()
-	sl.lens.prepare()
-	for i, iv := range intervals {
-		sl.starts.scan(uint32(i), scm.NewInt(int64(iv.start)))
-		sl.lens.scan(uint32(i), scm.NewInt(int64(iv.len)))
-	}
-	sl.starts.init(n)
-	sl.lens.init(n)
-	for i, iv := range intervals {
-		sl.starts.build(uint32(i), scm.NewInt(int64(iv.start)))
-		sl.lens.build(uint32(i), scm.NewInt(int64(iv.len)))
-	}
-	sl.starts.finish()
-	sl.lens.finish()
+	sl := &SkipList{matches: builder.finish()}
 	return sl
 }
 
@@ -222,7 +245,7 @@ type recSetMatcher struct{}
 func (m *recSetMatcher) Kind() string      { return "recset" }
 func (m *recSetMatcher) IsSorted() bool    { return false }
 func (m *recSetMatcher) IsPointLike() bool { return true }
-func (m *recSetMatcher) BuildSkipList(_ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
+func (m *recSetMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
 	return nil
 }
 
@@ -237,6 +260,7 @@ type columnboundaries struct {
 	lowerBatchSubidx int
 	upperBatch       bool
 	upperBatchSubidx int
+	collation        string // non-empty only for collation-sensitive matchers
 	// for computed index columns (col starts with ".")
 	mapCols []string  // source columns needed to compute the value
 	mapFn   scm.Scmer // function: mapFn(mapCols values...) → index value
@@ -692,9 +716,17 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 			// LIKE: (strlike col "pattern" collation)
 			if col, ok := resolveColVar(v[1]); ok {
 				if pat, ok := extractConstant(v[2]); ok && pat.IsString() {
+					collation := "utf8mb4_general_ci"
+					if len(v) >= 4 {
+						coll, constant := extractConstant(v[3])
+						if !constant || !coll.IsString() {
+							return nil
+						}
+						collation = strings.ToLower(coll.String())
+					}
 					pattern := pat.String()
 					idx := strings.IndexAny(pattern, "%_")
-					if idx > 0 {
+					if idx > 0 && !strings.Contains(collation, "_ci") {
 						// prefix-anchored LIKE "foo%" → range boundary
 						prefix := pattern[:idx]
 						upperBytes := []byte(prefix)
@@ -702,7 +734,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewString(prefix), lowerInclusive: true, upper: scm.NewString(string(upperBytes)), upperInclusive: false}}
 					}
 					// non-prefix LIKE "%foo%" → matcher boundary
-					return boundaries{columnboundaries{col: col, matcher: LikeMatcher, lower: pat, upper: pat}}
+					return boundaries{columnboundaries{col: col, matcher: LikeMatcher, lower: pat, upper: pat, collation: collation}}
 				}
 			}
 			return nil
@@ -790,6 +822,60 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	}
 
 	return cols
+}
+
+// singleLikeBoundaryCoversCondition proves that the condition consists solely
+// of the LIKE call represented by bound. An exact main-row match set may bypass
+// residual evaluation only under this structural proof; deltas are never
+// covered because they are not part of the immutable set.
+func singleLikeBoundaryCoversCondition(conditionCols []string, condition scm.Scmer, bound columnboundaries) bool {
+	if bound.matcher != LikeMatcher {
+		return false
+	}
+	var p scm.Proc
+	if condition.IsProc() {
+		p = *condition.Proc()
+	} else if legacy, ok := condition.Any().(scm.Proc); ok {
+		p = legacy
+	} else {
+		return false
+	}
+	if !p.Params.IsSlice() {
+		return false
+	}
+	params := p.Params.Slice()
+	body := p.Body
+	for {
+		items, ok := scmerSlice(body)
+		if !ok || len(items) != 2 {
+			break
+		}
+		declaration := scm.DeclarationForValue(items[0])
+		if !items[0].SymbolEquals("optimize") && (declaration == nil || declaration.Name != "optimize") {
+			break
+		}
+		body = items[1]
+	}
+	items, ok := scmerSlice(body)
+	if !ok || len(items) < 3 {
+		return false
+	}
+	declaration := scm.DeclarationForValue(items[0])
+	if !items[0].SymbolEquals("strlike") && (declaration == nil || declaration.Name != "strlike") {
+		return false
+	}
+	if items[1].IsNthLocalVar() {
+		idx := int(items[1].NthLocalVar())
+		return idx < len(conditionCols) && conditionCols[idx] == bound.col
+	}
+	if items[1].IsSymbol() {
+		for i, param := range params {
+			if i < len(conditionCols) && param.IsSymbol() && param.String() == items[1].String() {
+				return conditionCols[i] == bound.col
+			}
+		}
+	}
+	return false
 }
 
 func splitRecSetBoundary(b boundaries, backingTable *table) (boundaries, *recSet) {

--- a/storage/index.go
+++ b/storage/index.go
@@ -37,7 +37,7 @@ type storageIndexState struct {
 	active           bool
 	minVals          []scm.Scmer
 	maxVals          []scm.Scmer
-	skipLists        []map[string]*SkipList
+	skipLists        []*sync.Map // map[skipListKey]*SkipList; immutable values, lock-free reads
 	precomputedDelta bool
 }
 
@@ -185,9 +185,14 @@ func (idx *StorageIndex) ComputeSize() uint {
 		}
 		for _, colCache := range state.skipLists {
 			sz += 8
-			for k, sl := range colCache {
-				sz += uint(len(k)) + 24
-				sz += sl.ComputeSize()
+			if colCache != nil {
+				colCache.Range(func(key, value any) bool {
+					k := key.(skipListKey)
+					sl := value.(*SkipList)
+					sz += uint(len(k.pattern)+len(k.collation)) + 24
+					sz += sl.ComputeSize()
+					return true
+				})
 			}
 		}
 		sz += idx.computeDeltaBtreeSize(state)
@@ -345,11 +350,15 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 // Buffer size controls early-out granularity: use small buffers (e.g. [8]uint32)
 // for existence checks, large buffers (e.g. [1024]uint32) for full scans.
 func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, false, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, false, nil, callback)
 }
 
 func (t *storageShard) iterateIndexForce(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, true, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, true, nil, callback)
+}
+
+func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, exactMain *bool, callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, false, exactMain, callback)
 }
 
 func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, bool) {
@@ -360,7 +369,10 @@ func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, b
 	return last.lowerInclusive, last.upperInclusive
 }
 
-func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, exactMain *bool, callback func([]uint32) bool) {
+	if exactMain != nil {
+		*exactMain = false
+	}
 	// cols is already sorted by 1st rank: equality before range; 2nd rank alphabet
 
 	// indexFromBoundaries may shorten lower when more than one range column is
@@ -388,7 +400,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 					}
 				}
 				// this index fits!
-				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, callback)
+				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
 				return
 			}
 		skip_index:
@@ -417,7 +429,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 				if covered {
 					// longer index covers this query; use it instead of creating a shorter one
 					t.indexMutex.Unlock()
-					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, callback)
+					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
 					return
 				}
 			}
@@ -471,9 +483,16 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		index.Savings = 0.0            // count how many cost we wasted so we decide when to build the index
 		index.baseState.active = false // tell the engine that index has to be built first
 		index.t = t
+		index.Native = true
+		for _, matcher := range index.ColMatchers {
+			if matcher.IsSorted() {
+				index.Native = false
+				break
+			}
+		}
 		t.Indexes = append(t.Indexes, index)
 		t.indexMutex.Unlock()
-		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, callback)
+		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
 		return
 	}
 
@@ -630,6 +649,12 @@ func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, callback func(
 // cols must contain value getters for each index column in order.
 // The caller must hold s.mu.Lock() or have exclusive access.
 func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx *TxContext) {
+	if state.skipLists == nil {
+		state.skipLists = make([]*sync.Map, len(s.Cols))
+		for i := range state.skipLists {
+			state.skipLists[i] = new(sync.Map)
+		}
+	}
 	if !s.Native {
 		// main storage: build sort-order index
 		tmp := make([]uint32, s.t.main_count)
@@ -734,13 +759,33 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 	state.active = true // mark as ready
 }
 
-// getOrBuildSkipList returns the cached skip list for a non-sorted column,
+type skipListKey struct {
+	pattern   string
+	collation string
+}
+
+func simpleContainsLiteral(pattern, collation string) (string, bool) {
+	if len(pattern) < 2 || pattern[0] != '%' || pattern[len(pattern)-1] != '%' {
+		return "", false
+	}
+	literal := pattern[1 : len(pattern)-1]
+	if strings.ContainsAny(literal, "%_") {
+		return "", false
+	}
+	if strings.Contains(collation, "_ci") {
+		literal = strings.ToLower(literal)
+	}
+	return literal, true
+}
+
+// getOrBuildSkipList returns the cached exact match set for a non-sorted column,
 // building it on first access. The caller must hold s.t.mu.RLock for column access.
-func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, colIdx int, pattern string) *SkipList {
+func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sync.Map, colIdx int, bound columnboundaries) *SkipList {
+	key := skipListKey{pattern: bound.lower.String(), collation: strings.ToLower(bound.collation)}
 	// Fast path: check cache
-	if len(state.skipLists) > colIdx && state.skipLists[colIdx] != nil {
-		if sl, ok := state.skipLists[colIdx][pattern]; ok {
-			return sl
+	if len(caches) > colIdx && caches[colIdx] != nil {
+		if cached, ok := caches[colIdx].Load(key); ok {
+			return cached.(*SkipList)
 		}
 	}
 	// Slow path: build and cache
@@ -760,30 +805,43 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, colIdx int, 
 		}
 		return uint32(int64(state.mainIndexes.GetValueUInt(pos)) + state.mainIndexes.offset)
 	}
-	sl := s.ColMatchers[colIdx].BuildSkipList(pattern, s.t.main_count, getRecid, colStorage)
-	// Cache the result (TODO: replace with NonLockingReadMap)
-	s.mu.Lock()
-	if state.skipLists == nil {
-		state.skipLists = make([]map[string]*SkipList, len(s.Cols))
+	var candidate *SkipList
+	if literal, ok := simpleContainsLiteral(key.pattern, key.collation); ok && len(caches) > colIdx && caches[colIdx] != nil {
+		bestLength := -1
+		caches[colIdx].Range(func(candidateKey, candidateValue any) bool {
+			cachedKey := candidateKey.(skipListKey)
+			if cachedKey.collation != key.collation {
+				return true
+			}
+			cachedLiteral, simple := simpleContainsLiteral(cachedKey.pattern, cachedKey.collation)
+			if simple && len(cachedLiteral) > bestLength && strings.Contains(literal, cachedLiteral) {
+				candidate = candidateValue.(*SkipList)
+				bestLength = len(cachedLiteral)
+			}
+			return true
+		})
 	}
-	if state.skipLists[colIdx] == nil {
-		state.skipLists[colIdx] = make(map[string]*SkipList)
+	sl := s.ColMatchers[colIdx].BuildSkipList(key.pattern, key.collation, s.t.main_count, getRecid, colStorage, candidate)
+	// Cache immutable match sets. sync.Map keeps the read path non-blocking and
+	// LoadOrStore prevents concurrent first users from publishing duplicates.
+	cache := caches[colIdx]
+	actual, loaded := cache.LoadOrStore(key, sl)
+	if loaded {
+		return actual.(*SkipList)
 	}
-	state.skipLists[colIdx][pattern] = sl
-	s.mu.Unlock()
 	// Register skip lists as soft sub-items of the parent index. Their bytes
 	// are already included in StorageIndex.ComputeSize for total live-RAM
 	// reporting; the separate CacheManager entry exists only so eviction can
 	// choose a cheaper sub-item before dropping the whole index.
 	if sl != nil {
-		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: pattern}
+		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: key.pattern, collation: key.collation, cache: cache}
 		GlobalCache.AddItem(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore)
 	}
 	return sl
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, exactMain *bool, callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -844,6 +902,7 @@ start_scan:
 	// inserts from modifying deltaBtree. The index mutex protects against
 	// eviction only; the btree data is stable under RLock.
 	snapDeltaBtree := state.deltaBtree
+	snapSkipLists := state.skipLists
 	isNative := s.Native
 	s.mu.Unlock()
 
@@ -862,27 +921,48 @@ start_scan:
 	// Look up or build skip lists for non-sorted columns.
 	// Stack-allocated array, zero heap allocation on cache hit.
 	var skipListPtrs [8]*SkipList
+	var skipCursors [8]skipListCursor
 	skipCount := 0
 	for i := 0; i < cmpCols && i < len(bounds) && skipCount < 8; i++ {
 		if !bounds[i].matcher.IsSorted() {
-			skipListPtrs[skipCount] = s.getOrBuildSkipList(state, i, bounds[i].lower.String())
+			skipListPtrs[skipCount] = s.getOrBuildSkipList(state, snapSkipLists, i, bounds[i])
+			skipCursors[skipCount] = skipListPtrs[skipCount].cursor()
 			skipCount++
 		}
 	}
+	if exactMain != nil && skipCount > 0 {
+		*exactMain = true
+		for i := 0; i < skipCount; i++ {
+			if skipListPtrs[i] == nil {
+				*exactMain = false
+				break
+			}
+		}
+	}
+	// Find the leading physical sort key. Non-sorted matchers such as LIKE are
+	// deliberately present in the logical boundary list but do not participate
+	// in buildIndex ordering and must never be used for binary search.
+	firstSorted := -1
+	for i := 0; i < cmpCols && i < len(bounds); i++ {
+		if bounds[i].matcher.IsSorted() {
+			firstSorted = i
+			break
+		}
+	}
+
 	// Use last-hit hint to narrow binary search range (helps sorted outer loops).
 	// The hint is advisory: if stale or from a concurrent goroutine, we safely
 	// fall through to an unnarrowed search. No correctness dependency on the hint.
 	// LIKE columns cannot participate in binary search (pattern doesn't map to sort order).
 	searchLo := 0
 	searchN := int(s.t.main_count)
-	firstSearchable := len(bounds) == 0 || bounds[0].matcher.IsSorted()
-	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && cmpCols > 0 && firstSearchable && !lower[0].IsNil() {
-		hintVal := cols[0].get(getRecid(hint))
+	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !lower[firstSorted].IsNil() {
+		hintVal := cols[firstSorted].get(getRecid(hint))
 		if !hintVal.IsNil() {
-			if scm.Less(hintVal, lower[0]) {
+			if scm.Less(hintVal, lower[firstSorted]) {
 				searchLo = hint
 				searchN -= hint
-			} else if scm.Less(lower[0], hintVal) {
+			} else if scm.Less(lower[firstSorted], hintVal) {
 				searchN = hint + 1
 			}
 		}
@@ -890,14 +970,17 @@ start_scan:
 	// Interpolation search: estimate position from first sorted column's
 	// min/max, then binary search for exact multi-column position.
 	var interpMin, interpMax scm.Scmer
-	if cmpCols > 0 && firstSearchable && len(state.minVals) > 0 && !lower[0].IsNil() {
-		interpMin = state.minVals[0]
-		interpMax = state.maxVals[0]
+	if firstSorted >= 0 && len(state.minVals) > firstSorted && !lower[firstSorted].IsNil() {
+		interpMin = state.minVals[firstSorted]
+		interpMax = state.maxVals[firstSorted]
 	}
-	mainIdx := interpolationSearch(searchLo, searchN, lower[0], interpMin, interpMax,
-		func(idx int) scm.Scmer {
-			return cols[0].get(getRecid(idx))
-		})
+	mainIdx := 0
+	if firstSorted >= 0 {
+		mainIdx = interpolationSearch(searchLo, searchN, lower[firstSorted], interpMin, interpMax,
+			func(idx int) scm.Scmer {
+				return cols[firstSorted].get(getRecid(idx))
+			})
+	}
 	s.lastHit.Store(uint32(mainIdx))
 	// skip past equal values when lower bound is exclusive (col > 5)
 	// LIKE columns don't have lower/upper semantics, so skip this optimization.
@@ -931,8 +1014,7 @@ start_scan:
 				if pos < blockEnds[si] {
 					continue // still inside current block
 				}
-				sl := skipListPtrs[si]
-				start, length, ok := sl.NextBlock(pos)
+				start, length, ok := skipCursors[si].NextBlock(pos)
 				if !ok {
 					return false // no more blocks
 				}
@@ -1101,9 +1183,11 @@ func indexGetScore(ptr any) float64 {
 
 // skipListCacheEntry wraps a single skip list for CacheManager eviction.
 type skipListCacheEntry struct {
-	index   *StorageIndex
-	colIdx  int
-	pattern string
+	index     *StorageIndex
+	colIdx    int
+	pattern   string
+	collation string
+	cache     *sync.Map
 }
 
 func skipListCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
@@ -1111,8 +1195,8 @@ func skipListCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	if !e.index.mu.TryLock() {
 		return false
 	}
-	if len(e.index.baseState.skipLists) > e.colIdx && e.index.baseState.skipLists[e.colIdx] != nil {
-		delete(e.index.baseState.skipLists[e.colIdx], e.pattern)
+	if e.cache != nil {
+		e.cache.Delete(skipListKey{pattern: e.pattern, collation: e.collation})
 	}
 	e.index.mu.Unlock()
 	return true

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -339,6 +339,8 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	visibleUpper := t.main_count + uint32(maxInsertIndex)
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	completeTraversal := len(boundaries) == 0 && recsetFilter == nil
+	singleExactLike := len(boundaries) == 1 && singleLikeBoundaryCoversCondition(conditionCols, condition, boundaries[0])
+	exactLikeMain := false
 	builder := newRecSetShardBuilder(t, visibleUpper, completeTraversal)
 	replayCandidates := 0
 	evaluate := func(idx uint32) bool {
@@ -354,6 +356,9 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 			}
 		} else if t.deletions.Get(uint(idx)) {
 			return false
+		}
+		if idx < t.main_count && exactLikeMain && singleExactLike {
+			return true
 		}
 		if idx < t.main_count {
 			for i, c := range cReaders {
@@ -382,7 +387,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	}
 	var buf [1024]uint32
 	processedCandidates := 0
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+	t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, &exactLikeMain, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if idx >= visibleUpper {
 				continue
@@ -398,7 +403,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 	})
 	if replayCandidates > 0 {
 		replayed := 0
-		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], false, func(batch []uint32) bool {
+		t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], false, &exactLikeMain, func(batch []uint32) bool {
 			for _, idx := range batch {
 				if idx < visibleUpper {
 					builder.addBitmap(idx, evaluate(idx))

--- a/tests/storage/indexes/fulltext-like-index.yaml
+++ b/tests/storage/indexes/fulltext-like-index.yaml
@@ -27,6 +27,7 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS `ft_customers`"
   - sql: "DROP TABLE IF EXISTS `ft_large`"
+  - sql: "DROP TABLE IF EXISTS `ft_matchset`"
 
 test_cases:
   # --- Small table: correctness tests ---
@@ -442,10 +443,9 @@ test_cases:
         (SELECT COUNT(*) FROM ft_large) AS total
     expect: { rows: 1 }
 
-  # --- Interval merge stress: alternating matches (Animal/Person/Animal/...) ---
-  # A naive implementation would create one interval per match, producing a
-  # skip list larger than the data. The 3-block merge tolerance must collapse
-  # adjacent intervals to keep the list small.
+  # --- Adaptive representation stress: alternating matches ---
+  # Alternating membership exceeds the compact positive/negative-list capacity
+  # and must switch in place to a bitmap without changing the result.
   - name: "Create alternating table"
     sql: |
       CREATE TABLE IF NOT EXISTS `ft_alternating` (
@@ -502,7 +502,92 @@ test_cases:
         - like_cnt: 3333
           total: 10000
 
+  # --- Direct storage boundary regression ---
+  # Keep matching values below the lexical position of the LIKE pattern. A
+  # binary search on a non-sorted matcher used to start after these records,
+  # so only warm scans lost rows while SQL-level aggregate tests stayed green.
+  - name: "Create exact match-set table"
+    sql: |
+      CREATE TABLE `ft_matchset` (
+        id INT PRIMARY KEY,
+        name TEXT,
+        tag TEXT
+      )
+    expect: { rows: 0 }
+
+  - name: "Insert exact match-set data"
+    scm: |
+      (begin
+        (set rows (map (produceN 30000) (lambda (i)
+          (list i
+            (if (< i 100)
+              (concat "!Klaus-" i)
+              (if (< i 105) (concat "Klaus-" i) (concat "Person-" i)))
+            (concat "!zzzz-" i)))))
+        (insert (table "memcp-tests" "ft_matchset") (list "id" "name" "tag") rows)
+        (rebuild)
+        30000)
+
+  - name: "Exact match-set fixture is visible through SQL"
+    sql: "SELECT COUNT(*) AS cnt FROM ft_matchset WHERE tag LIKE '%zzzz%'"
+    expect: { rows: 1, data: [{ cnt: 30000 }] }
+
+  - name: "LIKE match set remains exact through warmup"
+    scm: |
+      (begin
+        (set tbl (table "memcp-tests" "ft_matchset"))
+        (set condition (eval (list
+          'lambda (list 'search)
+          (list 'strlike 'search "%zzzz%" "utf8mb4_general_ci"))))
+        (set count-matches (lambda ()
+          (recset_count (scan_recset nil tbl (list "tag") condition))))
+        (set first (count-matches))
+        (set built (count-matches))
+        (set warm (count-matches))
+        (if (and (equal? first 30000) (equal? built 30000) (equal? warm 30000))
+          true
+          (error (concat "LIKE match-set counts: " first ", " built ", " warm))))
+
+  - name: "LIKE match sets keep collation semantics separate"
+    scm: |
+      (begin
+        (set tbl (table "memcp-tests" "ft_matchset"))
+        (set binary-condition (eval (list
+          'lambda (list 'name)
+          (list 'strlike 'name "%klaus%" "utf8mb4_bin"))))
+        (set ci-condition (eval (list
+          'lambda (list 'name)
+          (list 'strlike 'name "%klaus%" "utf8mb4_general_ci"))))
+        (set binary-count (recset_count (scan_recset nil tbl (list "name") binary-condition)))
+        (set ci-count (recset_count (scan_recset nil tbl (list "name") ci-condition)))
+        (if (and (equal? binary-count 0) (equal? ci-count 105))
+          true
+          (error (concat "LIKE collation counts: " binary-count ", " ci-count))))
+
+  - name: "Cached LIKE match sets still evaluate delta rows"
+    setup:
+      - sql: "INSERT INTO ft_matchset (id, name, tag) VALUES (30000, 'klaus-delta', 'delta')"
+    scm: |
+      (begin
+        (set tbl (table "memcp-tests" "ft_matchset"))
+        (set binary-condition (eval (list
+          'lambda (list 'name)
+          (list 'strlike 'name "%klaus%" "utf8mb4_bin"))))
+        (set ci-condition (eval (list
+          'lambda (list 'name)
+          (list 'strlike 'name "%klaus%" "utf8mb4_general_ci"))))
+        (set binary-count (recset_count (scan_recset nil tbl (list "name") binary-condition)))
+        (set ci-count (recset_count (scan_recset nil tbl (list "name") ci-condition)))
+        (if (and (equal? binary-count 1) (equal? ci-count 106))
+          true
+          (error (concat "LIKE delta counts: " binary-count ", " ci-count))))
+
+  - name: "Case-insensitive prefix LIKE does not use binary range semantics"
+    sql: "SELECT COUNT(*) AS cnt FROM ft_matchset WHERE name LIKE 'klaus%'"
+    expect: { rows: 1, data: [{ cnt: 6 }] }
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS `ft_customers`"
   - sql: "DROP TABLE IF EXISTS `ft_large`"
   - sql: "DROP TABLE IF EXISTS `ft_alternating`"
+  - sql: "DROP TABLE IF EXISTS `ft_matchset`"


### PR DESCRIPTION
## Summary

- Replace tolerant LIKE skip intervals with exact adaptive match sets using the existing RecSet empty/full/positive/negative/bitmap representations.
- Reuse the longest cached contains-pattern superset for incremental search, then refine only its candidates.
- Remove the generic RecID permutation for pure matcher indexes, use lock-free reads of immutable match sets, and skip duplicate residual LIKE evaluation only when structurally proven safe.
- Add optimized exact/prefix/suffix/contains LIKE paths and share one collation-aware matcher between residual evaluation and index construction.
- Fix two correctness bugs found by the benchmark: LIKE boundaries must not drive binary search, and case-insensitive prefix LIKE must not use binary range semantics.

## Correctness coverage

- Extended `tests/storage/indexes/fulltext-like-index.yaml`: 70/70 passing.
- Covers cold/build/warm exactness, alternating bitmap conversion, binary vs case-insensitive cache separation, delta rows after cache construction, and case-insensitive prefix matching.
- The production-size cascade returns identical counts on every stage. Current master loses one broad-search row on its second pass; this branch remains stable.

## A/B: production-size full-text cascade

Same 785,594-row anonymized snapshot, identical non-coverage builds, two consecutive passes. The physical cascade includes filename LIKE, large text LIKE, RecSet UNION, file-to-document RecSet projection, three document LIKE scans, union, and ordered top-72. Terms: `C`, `Ca`, `Car`, `Carg`, `Cargl`, `Cargla`, `Carglas`, `Carglass`, `Carglass3`, `Carglass38`, `Carglass389`.

| pass | master total | PR total | speedup | reduction |
|---|---:|---:|---:|---:|
| cold incremental cascade | 161.393 s | 37.819 s | 4.27x | 76.6% |
| warm incremental cascade | 37.908 s | 12.754 s | 2.97x | 66.4% |

Selected per-term totals:

| term | master cold | PR cold | speedup | master warm | PR warm | speedup |
|---|---:|---:|---:|---:|---:|---:|
| `C` | 36.057 s | 12.380 s | 2.91x | 20.993 s | 11.709 s | 1.79x |
| `Ca` | 14.168 s | 12.465 s | 1.14x | 3.430 s | 185 ms | 18.50x |
| `Car` | 13.201 s | 2.786 s | 4.74x | 2.266 s | 145 ms | 15.66x |
| `Carg` | 12.924 s | 1.736 s | 7.45x | 2.237 s | 134 ms | 16.69x |
| `Carglass` | 12.898 s | 1.714 s | 7.53x | 2.234 s | 141 ms | 15.79x |
| `Carglass38` | 10.983 s | 5.6 ms | 1951x | 5.4 ms | 5.5 ms | ~1x |
| `Carglass389` | 11.010 s | 6.4 ms | 1719x | 3.8 ms | 4.8 ms | ~1x |

The broad `C` stage remains the dominant cost (10.2 s matcher time warm), so this does not yet meet the <3 s end-to-end target. It removes repeated work for incremental terms; broad-pattern scanning still needs a separate strategy.

## Memory

- Resident searched column across 14 shards: ~28.97 MB.
- Master 11-term cache: ~770 KB interval data + ~1.57 MB generic RecID permutation = ~2.34 MB persistent, plus ~3.14 MB transient permutation during construction.
- PR 11-term adaptive exact sets: ~791 KB total; no generic permutation for pure LIKE indexes.
- Persistent matcher-index memory drops by about 66%; one dense shard bitmap is bounded at roughly 98.6 KB for this cardinality.

## Validation

- `go build -o memcp`
- Target LIKE suite: 70/70.
- Non-coverage pre-commit full run: all suites passed except two transient ACID assertions in the shared final rerun; the complete transaction suite then passed 171/171 three consecutive isolated runs.
- Coverage full run exposed only pre-existing hard performance gates under instrumentation (large OFFSET and planner/group timing); no correctness mismatch in changed paths.
- `git diff --check` clean.