### PR TITLE
Avoid per-row scan allocations

### DIFF
--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1367,6 +1367,7 @@ type ShardMapReducer struct {
 	noopClosureFn  *func(uint32, ...scm.Scmer) scm.Scmer   // shared noop
 	breakClosureFn *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
 	args           []scm.Scmer                             // pre-allocated args buffer
+	reduceArgs     []scm.Scmer                             // pre-allocated binary reducer arguments
 	mapFn          func(...scm.Scmer) scm.Scmer
 	reduceFn       func(...scm.Scmer) scm.Scmer
 	mapScmer       scm.Scmer     // original Scmer for network serialization
@@ -1399,6 +1400,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		mainCols:         make([]ColumnStorage, len(cols)),
 		colNames:         cols,
 		args:             make([]scm.Scmer, len(cols)),
+		reduceArgs:       make([]scm.Scmer, 2),
 		mapFn:            scm.OptimizeProcToSerialFunction(mapFn),
 		reduceFn:         scm.OptimizeProcToSerialFunction(reduceFn),
 		mapScmer:         mapFn,
@@ -1689,6 +1691,14 @@ func (m *ShardMapReducer) Stream(acc scm.Scmer, recids []uint32, batchids []uint
 	return acc
 }
 
+func (m *ShardMapReducer) reduce(acc scm.Scmer, value scm.Scmer) scm.Scmer {
+	// A direct variadic call with two values allocates its temporary argument
+	// slice on every row because reduceFn may retain it.
+	m.reduceArgs[0] = acc
+	m.reduceArgs[1] = value
+	return m.reduceFn(m.reduceArgs...)
+}
+
 // processMainBlock is a tight loop over main-storage records – no branching
 // on main vs delta, direct ColumnStorage.GetValue calls. JIT candidate.
 func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
@@ -1733,7 +1743,7 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduceFn(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapFn(m.args...))
 		}()
 	}
 	return acc
@@ -1776,7 +1786,7 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduceFn(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapFn(m.args...))
 		}()
 	}
 	return acc
@@ -1820,7 +1830,7 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduceFn(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapFn(m.args...))
 		}()
 	}
 	return acc
@@ -1863,7 +1873,7 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduceFn(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapFn(m.args...))
 		}()
 	}
 	return acc


### PR DESCRIPTION
## What

- reuse a two-element reducer argument buffer for the lifetime of each shard mapper
- route main, delta, and batch scan reducers through the allocation-free buffer

## Why

Every scanned row called the variadic reducer as `reduceFn(acc, value)`. Because the callback may retain its arguments, Go moved the temporary two-element variadic slice to the heap. That produced one 32-byte allocation per row in otherwise allocation-stable scans.

The mapper already owns and reuses its map argument buffer. Applying the same lifetime to the reducer arguments changes the row-linear allocation into one fixed allocation per mapper without changing scan, lock, or mutation semantics.

## Impact

- removes the identified 1 allocation / 32 bytes per scanned row
- covers main storage, delta storage, and both batch variants
- adds one fixed two-`Scmer` buffer per mapper
- no parser, planner, persistence, or on-disk-format changes

## Checks

- `go build ./...`
- compiler escape analysis confirms the new reducer helper is inlined and no temporary variadic argument slice is created per row
- targeted SQL suites: basic reads, complex UPDATE/DELETE, proxy updates, computed columns, transactions, and ordered multi-shard scans
- full repository SQL pre-commit hook: passed
