### PR TITLE
Bound DPHyp join reorder search

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4688,14 +4688,24 @@ logical trees consumed before physical scan lowering. */
 				(if (nil? plan) plans (set_assoc plans (join_order_set_key aliases) plan))
 				(if (nil? plan) entries (+ entries 1)))))))
 
-(define join_order_dphyp (lambda (nodes aliases predicates)
+(define join_order_dphyp_connected (lambda (nodes aliases predicates connected)
 	(begin
-		(define connected (join_order_sort_sets (car (join_order_enumerate_connected aliases predicates 0))))
+		(define sorted_connected (join_order_sort_sets connected))
 		(define connected_by_first (reduce connected (lambda (dict subset)
 			(begin
 				(define first (car subset))
 				(set_assoc dict first (append (get_assoc dict first '()) subset)))) '()))
-		(join_order_dphyp_fill nodes aliases predicates connected_by_first connected '() 0))))
+		(join_order_dphyp_fill nodes aliases predicates connected_by_first sorted_connected '() 0))))
+
+(define join_order_dphyp_budgeted (lambda (nodes aliases predicates budget)
+	(begin
+		(define connected (join_order_enumerate_connected aliases predicates budget))
+		(if (cadr connected)
+			(list nil 0)
+			(join_order_dphyp_connected nodes aliases predicates (car connected))))))
+
+(define join_order_dphyp (lambda (nodes aliases predicates)
+	(join_order_dphyp_budgeted nodes aliases predicates (join_order_dp_state_budget))))
 
 (define join_order_alias_position (lambda (aliases alias)
 	(reduce (produceN (count aliases)) (lambda (found i)
@@ -4948,7 +4958,8 @@ logical trees consumed before physical scan lowering. */
 				(list plan used)
 				(begin
 					(define optimized (if hypergraph
-						(join_order_dphyp nodes (join_order_plan_aliases target) predicates)
+						(join_order_dphyp_budgeted nodes (join_order_plan_aliases target)
+							predicates (join_order_dp_state_budget))
 						(join_order_linearized_dp nodes (join_order_plan_aliases target) predicates)))
 					(define replacement (car optimized))
 					(define entries (cadr optimized))
@@ -5016,8 +5027,7 @@ logical trees consumed before physical scan lowering. */
 		(list (quote dp_entries) entries))))
 
 (define join_order_choose_strategy (lambda (alias_count hypergraph connected_over_budget)
-	(if (or (< alias_count 14)
-		(and (<= alias_count 100) (not connected_over_budget)))
+	(if (and (<= alias_count 100) (not connected_over_budget))
 		(quote dphyp)
 		(if hypergraph
 			(quote goo-dphyp)
@@ -5047,26 +5057,31 @@ subsets without materializing them. */
 		(or proven (join_order_degree_exceeds_budget?
 			(count (join_order_regular_neighbors edges alias)) budget))) false)))
 
+/* Connected subsets are the dominant retained state of DPHyp. Keeping this
+budget below the measured compile-time cliff makes the exact search predictable;
+the fallback still evaluates the same execution-cost function. */
+(define join_order_dp_state_budget (lambda ()
+	(begin
+		(define configured (settings "JoinReorderDPBudget"))
+		(if (> configured 0) configured 256))))
+
 (define join_order_adaptive (lambda (nodes raw_predicates)
 	(begin
 		(define aliases (map nodes car))
 		(define hypergraph (join_order_hypergraph? raw_predicates))
 		(define predicates (join_order_prepare_predicates aliases raw_predicates))
 		(define regular_edges (join_order_regular_edges aliases predicates))
-		(define regular_edge_count (count regular_edges))
-		(define complete_regular_graph (equal? regular_edge_count
-			(/ (* (count aliases) (- (count aliases) 1)) 2)))
-		(define connected_count (if (and (>= (count aliases) 14) (<= (count aliases) 100))
-			(if (or complete_regular_graph
-				(join_order_degree_proves_budget_overflow? aliases regular_edges 10000))
+		(define state_budget (join_order_dp_state_budget))
+		(define connected_count (if (<= (count aliases) 100)
+			(if (join_order_degree_proves_budget_overflow? aliases regular_edges state_budget)
 				(list '() true)
-				(join_order_enumerate_connected aliases predicates 10000))
+				(join_order_enumerate_connected aliases predicates state_budget))
 			(list '() true)))
 		(define strategy (join_order_choose_strategy
 			(count aliases) hypergraph (cadr connected_count)))
 		(define exact (equal? strategy (quote dphyp)))
 		(define result (if exact
-			(join_order_dphyp nodes aliases predicates)
+			(join_order_dphyp_connected nodes aliases predicates (car connected_count))
 			(if (equal? strategy (quote linearized-dp))
 				(join_order_linearized_dp nodes aliases predicates)
 				(join_order_goo_dp nodes aliases predicates hypergraph))))
@@ -5446,8 +5461,8 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(quote order) ordered_aliases)
 				(quote strategy) (quote order-prefix))))))
 
-(define join_optimizer_reorder_result (lambda (tree strategy dp_entries)
-	(list tree strategy dp_entries)))
+(define join_optimizer_reorder_result (lambda (tree strategy dp_entries cost cardinality)
+	(list tree strategy dp_entries cost cardinality)))
 
 (define join_optimizer_reorder_sources (lambda (stage_catalog block graph)
 	(begin
@@ -5470,7 +5485,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 			(join_optimizer_reorder_result
 				(join_optimizer_left_deep_tree sources)
 				(if preserve_order_driver (quote preserve-order-limit) (quote fixed))
-				0)
+				0 nil nil)
 			(begin
 				(define cost_planned (join_optimizer_plan_segment
 					stage_catalog sources segment default_alias graph))
@@ -5482,7 +5497,9 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(join_optimizer_append_sources_tree
 						(qassoc_get planned (quote tree) nil) remaining)
 					(qassoc_get planned (quote strategy) (quote fixed))
-					(qassoc_get planned (quote dp_entries) 0)))))))
+					(qassoc_get planned (quote dp_entries) 0)
+					(qassoc_get planned (quote cost) nil)
+					(qassoc_get planned (quote cardinality) nil)))))))
 
 (define join_optimizer_drop_sources (lambda (sources amount)
 	(if (or (<= amount 0) (empty_list? sources))
@@ -5495,6 +5512,9 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(list (quote join_plan) (nth reordered 0))
 		(list (quote join_driver) (car (join_optimizer_tree_aliases (nth reordered 0))))
 		(list (quote join_dp_entries) (nth reordered 2))
+		(list (quote join_estimated_cost) (nth reordered 3))
+		(list (quote join_estimated_rows) (nth reordered 4))
+		(list (quote join_dp_state_budget) (join_order_dp_state_budget))
 		(list (quote join_graph_nodes) (count (qassoc_get graph (quote nodes) '())))
 		(list (quote join_graph_edges) (count (qassoc_get graph (quote edges) '())))
 		(list (quote join_graph_hyperedges) (count (qassoc_get graph (quote hyperedges) '())))

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -47,6 +47,7 @@ type SettingsT struct {
 	LogJIT                 bool  // when true, log JIT compilation (serialized proc + hexdump)
 	ScanDebugging          bool  // when true, log every scan/scan_order: db+table+boundaries+index; also overrides AnalyzeMinItems for scan statistics
 	ExplainWidth           int   // max chars before EXPLAIN pretty-prints a sub-expression on multiple lines (0 = default 20)
+	JoinReorderDPBudget    int   // maximum connected subsets retained by exact DPHyp (0 = default 256)
 	ErrorQueryLog          bool  // when true, log failed queries to system_statistic.errors
 	MaxErrorQueryLog       int   // max rows in error log (0 = unlimited)
 	PrintLog               bool  // when true, log (print) output to system_statistic.logs
@@ -77,7 +78,7 @@ func (r CreateTableTriggerRegistration) triggerDescription() TriggerDescription 
 	}
 }
 
-var Settings SettingsT = SettingsT{false, false, false, 10, "safe", 60000, 50, 5, 0, 0, 0, 0, false, 0, 0, false, false, 20, false, 0, false, 0, nil}
+var Settings SettingsT = SettingsT{false, false, false, 10, "safe", 60000, 50, 5, 0, 0, 0, 0, false, 0, 0, false, false, 20, 256, false, 0, false, 0, nil}
 var createTableTriggerMu sync.Mutex
 
 func registerCreateTableTrigger(reg CreateTableTriggerRegistration) {
@@ -148,6 +149,7 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			scm.NewString("LogJIT"), scm.NewBool(Settings.LogJIT),
 			scm.NewString("ScanDebugging"), scm.NewBool(Settings.ScanDebugging),
 			scm.NewString("ExplainWidth"), scm.NewInt(int64(Settings.ExplainWidth)),
+			scm.NewString("JoinReorderDPBudget"), scm.NewInt(int64(Settings.JoinReorderDPBudget)),
 			scm.NewString("ErrorQueryLog"), scm.NewBool(Settings.ErrorQueryLog),
 			scm.NewString("MaxErrorQueryLog"), scm.NewInt(int64(Settings.MaxErrorQueryLog)),
 			scm.NewString("PrintLog"), scm.NewBool(Settings.PrintLog),
@@ -191,6 +193,8 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			return scm.NewBool(Settings.ScanDebugging)
 		case "ExplainWidth":
 			return scm.NewInt(int64(Settings.ExplainWidth))
+		case "JoinReorderDPBudget":
+			return scm.NewInt(int64(Settings.JoinReorderDPBudget))
 		case "ErrorQueryLog":
 			return scm.NewBool(Settings.ErrorQueryLog)
 		case "MaxErrorQueryLog":
@@ -252,6 +256,8 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			Settings.ScanDebugging = scm.ToBool(a[1])
 		case "ExplainWidth":
 			Settings.ExplainWidth = scm.ToInt(a[1])
+		case "JoinReorderDPBudget":
+			Settings.JoinReorderDPBudget = scm.ToInt(a[1])
 		case "ErrorQueryLog":
 			Settings.ErrorQueryLog = scm.ToBool(a[1])
 		case "MaxErrorQueryLog":

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -459,6 +459,61 @@ test_cases:
         - 'dphyp'
         - 'join_plan'
 
+  - name: "EXPLAIN REORDER honors the configured DPHyp state budget"
+    setup:
+      - scm: '(settings "JoinReorderDPBudget" 16)'
+    sql: |
+      EXPLAIN REORDER
+      SELECT a.id
+      FROM perf_tiny a, perf_tiny b, perf_tiny c,
+           perf_tiny d, perf_tiny e, perf_tiny f
+      WHERE a.id = b.id AND a.id = c.id AND a.id = d.id
+        AND a.id = e.id AND a.id = f.id
+    expect:
+      rows: 1
+      result_contains:
+        - 'join_reorder_strategy'
+        - 'linearized-dp'
+    cleanup:
+      - scm: '(settings "JoinReorderDPBudget" 256)'
+
+  - name: "EXPLAIN REORDER budgets a twelve-way star before DPHyp"
+    timeout: 2
+    max_time: 0.2
+    sql: |
+      EXPLAIN REORDER
+      SELECT a.id
+      FROM perf_tiny a, perf_tiny b, perf_tiny c, perf_tiny d,
+           perf_tiny e, perf_tiny f, perf_tiny g, perf_tiny h,
+           perf_tiny i, perf_tiny j, perf_tiny k, perf_tiny l
+      WHERE a.id = b.id AND a.id = c.id AND a.id = d.id AND a.id = e.id
+        AND a.id = f.id AND a.id = g.id AND a.id = h.id AND a.id = i.id
+        AND a.id = j.id AND a.id = k.id AND a.id = l.id
+    expect:
+      rows: 1
+      result_contains:
+        - 'join_reorder_strategy'
+        - 'linearized-dp'
+        - 'join_plan'
+        - 'join_estimated_cost'
+        - 'join_estimated_rows'
+        - 'join_dp_state_budget'
+
+  - name: "Budgeted twelve-way star preserves execution results"
+    timeout: 2
+    sql: |
+      SELECT a.id
+      FROM perf_tiny a, perf_tiny b, perf_tiny c, perf_tiny d,
+           perf_tiny e, perf_tiny f, perf_tiny g, perf_tiny h,
+           perf_tiny i, perf_tiny j, perf_tiny k, perf_tiny l
+      WHERE a.id = b.id AND a.id = c.id AND a.id = d.id AND a.id = e.id
+        AND a.id = f.id AND a.id = g.id AND a.id = h.id AND a.id = i.id
+        AND a.id = j.id AND a.id = k.id AND a.id = l.id
+    expect:
+      rows: 1
+      data:
+        - id: 1
+
   - name: "EXPLAIN REORDER linearizes a star beyond the connected-subgraph budget"
     sql: |
       EXPLAIN REORDER


### PR DESCRIPTION
## What
- apply the connected-subset budget to every DPHyp candidate, including graphs below 14 relations
- reuse the budgeted subset enumeration for exact planning instead of enumerating a second time without a limit
- expose the configurable `JoinReorderDPBudget`, estimated cost/cardinality, and active budget in EXPLAIN REORDER facts
- add SQL regressions for configured fallback and the 12-relation star

## Why
The prior strategy unconditionally chose DPHyp below 14 relations. A 12-way star therefore spent seconds enumerating a plan whose estimated execution cost was identical to the linearized-DP fallback.

## Impact
The default exact-search budget is 256 connected subsets. Small chains remain on DPHyp; shapes that exceed the budget fall back to linearized DP or GOO-DP while using the same execution-cost comparison. Local EXPLAIN COMPILE measurements for the 12-way star show a 15.5 ms median reorder and about 33.9 ms median total compile, with estimated cost 11 and cardinality 1.

## Checks
- `python3 run_sql_tests.py tests/execution/operators/range-scan-coverage.yaml` (88/88)
- full `MEMCP_FAIL_FAST=0 ./git-pre-commit` (passed)
- `python3 tools/lint_scm.py --check` (only the pre-existing repository warnings)
- `go build -o memcp`
- coverage-enabled `make test` was also run; its planner suite passed, while existing unrelated transaction/index/order stress cases were flaky under coverage and passed in isolated normal-binary reruns
