### PR TITLE
Fix cache initialization in shard workers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -12558,6 +12558,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(define initial_fill_expr (if (nil? base_group_into_plan)
 			nil
 			(list (quote initialize_cache_table)
+				'(session "__memcp_tx")
 				(list (quote table) schema grouptbl)
 				(list (quote list) (source_table_expr src))
 				(list (quote lambda) '()
@@ -14842,6 +14843,7 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 			(list (quote createtable) (qb_schema block) table_name
 				(prejoin_create_columns sources) (quoted_runtime_list '("engine" "cache")) true)
 			(list (quote initialize_cache_table)
+				'(session "__memcp_tx")
 				table_expr
 				(cons (quote list) (map sources source_table_expr))
 				(list (quote lambda) '() (cons (quote !begin) (prejoin_trigger_registration_plans block table_name)))

--- a/storage/cache_initializer.go
+++ b/storage/cache_initializer.go
@@ -26,8 +26,9 @@ type cacheInitializerRun struct {
 
 // initializeCache runs initialize exactly once for the lifetime of a canonical
 // planner cache. Concurrent callers share both completion and failure. A later
-// call retries after a failed run.
-func (t *table) initializeCache(initialize func()) (initialized bool) {
+// call retries after a failed run. The caller must pass the owning query session
+// explicitly because initialization may begin inside a shard worker without GLS.
+func (t *table) initializeCache(ss *scm.SessionState, initialize func()) (initialized bool) {
 	if !strings.HasPrefix(t.Name, ".") {
 		panic("cache initialization requires a dot-prefixed cache table")
 	}
@@ -48,7 +49,7 @@ func (t *table) initializeCache(initialize func()) (initialized bool) {
 	run := &cacheInitializerRun{
 		done: make(chan struct{}),
 	}
-	if scm.GetCurrentSessionState() == nil {
+	if ss == nil {
 		t.cacheInitMu.Unlock()
 		panic("cache initialization requires a query session")
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2229,9 +2229,16 @@ func Init(en scm.Env) {
 		Name: "initialize_cache_table",
 		Desc: "registers maintenance, locks source tables for a consistent snapshot, and runs a canonical planner-cache initializer exactly once",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			tbl := TableFromScmer(a[0])
-			initialized := tbl.initializeCache(func() {
-				sources := mustScmerSlice(a[1], "source tables")
+			currentTx := scmerToTxContext(a[0])
+			tbl := TableFromScmer(a[1])
+			// Cache preparation can execute inside a shard worker. Like every scan
+			// operator, it receives transaction and session ownership explicitly.
+			var ss *scm.SessionState
+			if currentTx != nil {
+				ss = currentTx.SessionState
+			}
+			initialized := tbl.initializeCache(ss, func() {
+				sources := mustScmerSlice(a[2], "source tables")
 				sourceTables := make([]*table, len(sources))
 				for i, source := range sources {
 					sourceTables[i] = TableFromScmer(source)
@@ -2242,10 +2249,6 @@ func Init(en scm.Env) {
 					return left < right
 				})
 
-				ss := scm.GetCurrentSessionState()
-				if ss == nil {
-					panic("cache initialization requires a query session")
-				}
 				unlocks := make([]func(), 0, len(sourceTables))
 				defer func() {
 					for i := len(unlocks) - 1; i >= 0; i-- {
@@ -2257,16 +2260,17 @@ func Init(en scm.Env) {
 				}
 				// Install maintenance while source writes are blocked. Once the
 				// locks are released, every later mutation observes the triggers.
-				scm.Apply(a[2])
 				scm.Apply(a[3])
-				if len(a) > 4 {
-					scm.Apply(a[4])
+				scm.Apply(a[4])
+				if len(a) > 5 {
+					scm.Apply(a[5])
 				}
 			})
 			return scm.NewBool(initialized)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "any", ParamName: "transaction", ParamDesc: "explicit transaction context carrying query-session ownership"},
 				{Kind: "table", ParamName: "table"},
 				{Kind: "list", ParamName: "source_tables"},
 				{Kind: "func", ParamName: "register_maintenance", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1964,6 +1964,55 @@ test_cases:
       not_contains:
         - "unknown stage"
 
+  - name: "Nested ACL caches initialize inside a parallel physical lookup"
+    fail_comment: "lazy cache preparation in a shard worker must retain the owning query session"
+    setup:
+      - sql: "DROP TABLE IF EXISTS worker_acl"
+      - sql: "DROP TABLE IF EXISTS worker_item"
+      - sql: "DROP TABLE IF EXISTS worker_location"
+      - sql: "DROP TABLE IF EXISTS worker_file"
+      - sql: "CREATE TABLE worker_acl (ID INT PRIMARY KEY, actor INT, tenant_id INT, location_id INT)"
+      - sql: "CREATE TABLE worker_item (ID INT PRIMARY KEY, file_id INT, tenant_id INT, location_id INT)"
+      - sql: "CREATE TABLE worker_location (ID INT PRIMARY KEY, tenant_id INT)"
+      - sql: "CREATE TABLE worker_file (ID INT PRIMARY KEY, filename VARCHAR(64), search VARCHAR(64))"
+      - sql: "INSERT INTO worker_acl VALUES (1, 42, NULL, NULL), (2, 42, 7, 70)"
+      - sql: "INSERT INTO worker_location VALUES (70, 7), (80, 8)"
+      - sql: "INSERT INTO worker_file VALUES (10, 'x-one', ''), (20, '', 'x-two')"
+      - sql: "INSERT INTO worker_item VALUES (100, 10, 7, 70), (200, 20, 8, 80)"
+      - scm: |
+          (partitiontable (table "memcp-tests" "worker_item")
+            (list "ID" (list 150)))
+    sql: |
+      SELECT i.ID
+      FROM worker_item i
+      WHERE COALESCE((
+        SELECT CASE WHEN EXISTS (
+          SELECT TRUE FROM worker_acl global_acl
+          WHERE global_acl.actor = 42 AND global_acl.tenant_id IS NULL
+          LIMIT 1
+        ) THEN TRUE ELSE EXISTS (
+          SELECT TRUE FROM worker_acl location_acl
+          WHERE location_acl.actor = 42
+            AND COALESCE(location_acl.location_id, current_location.ID) = current_location.ID
+          LIMIT 1
+        ) END
+        FROM worker_location current_location
+        WHERE current_location.ID = i.location_id
+        LIMIT 1
+      ), FALSE)
+      AND i.file_id IN (
+        SELECT f.ID FROM worker_file f WHERE f.filename LIKE '%x%'
+        UNION
+        SELECT f.ID FROM worker_file f WHERE f.search LIKE '%x%'
+      )
+      ORDER BY i.ID
+      LIMIT 10
+    expect:
+      rows: 2
+      data:
+        - ID: 100
+        - ID: 200
+
   - name: "Derived LEFT JOIN keeps projected values beside nested permission probes"
     fail_comment: "compiled plans must execute derived LEFT JOIN matches, not only resolve their stages"
     setup:


### PR DESCRIPTION
## Summary

- pass the owning query session explicitly from the transaction context into canonical cache initialization
- avoid relying on goroutine-local session state when lazy cache preparation starts inside an autocommit shard worker
- turn the existing nested ACL lookup plan-only case into a two-shard execution regression

## Regression

Before the fix, the expanded YAML case fails with:

```
SQL Error: cache initialization requires a query session
```

After the fix, `tests/planner/subqueries/in-subquery.yaml` passes 68/68.

## Validation

- `go build -o memcp`
- `python3 run_sql_tests.py tests/planner/subqueries/in-subquery.yaml --jobs 1 --fail-fast` (68/68)
- related parallel matrix: group-cache invalidation 117/117, multishard 56/56, session-group reminders 13/13, session empty-keytable 4/4
- real-data MySQL reproduction no longer raises the cache-session error

`make test` was attempted repeatedly. The new regression and all related suites pass, but the shared parallel run exposed pre-existing, timing-dependent transaction/rebuild failures in `tests/execution/concurrency/transactions.yaml`; the same transaction suite passes 176/176 in isolation and 176/176 under a focused four-suite parallel load on unmodified master. CI is left authoritative for the clean runner.
