### PR TITLE
Preserve join trees in ordered lowering

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -5507,30 +5507,35 @@ the fallback still evaluates the same execution-cost function. */
 				(lambda (term) (not (contains? owned_exprs term))))
 			true))))
 
-(define join_optimizer_tree_without_aliases (lambda (tree removed_aliases)
+(define join_optimizer_tree_without_aliases_with_aliases (lambda (tree removed_aliases)
 	(match tree
-		((symbol join-leaf) alias) (if (contains? removed_aliases alias) nil tree)
-		((quote join-leaf) alias) (if (contains? removed_aliases alias) nil tree)
-		((symbol join-leaf) alias _predicates) (if (contains? removed_aliases alias) nil tree)
-		((quote join-leaf) alias _predicates) (if (contains? removed_aliases alias) nil tree)
+		((symbol join-leaf) alias) (if (contains? removed_aliases alias) (list nil '()) (list tree (list alias)))
+		((quote join-leaf) alias) (if (contains? removed_aliases alias) (list nil '()) (list tree (list alias)))
+		((symbol join-leaf) alias _predicates) (if (contains? removed_aliases alias) (list nil '()) (list tree (list alias)))
+		((quote join-leaf) alias _predicates) (if (contains? removed_aliases alias) (list nil '()) (list tree (list alias)))
 		((symbol join-node) kind left right predicates)
 		(begin
-			(define kept_left (join_optimizer_tree_without_aliases left removed_aliases))
-			(define kept_right (join_optimizer_tree_without_aliases right removed_aliases))
-			(if (nil? kept_left) kept_right
-				(if (nil? kept_right) kept_left
+			(define left_result (join_optimizer_tree_without_aliases_with_aliases left removed_aliases))
+			(define right_result (join_optimizer_tree_without_aliases_with_aliases right removed_aliases))
+			(define kept_left (car left_result))
+			(define kept_right (car right_result))
+			(if (nil? kept_left) right_result
+				(if (nil? kept_right) left_result
 					(begin
-						(define kept_aliases (merge (list
-							(join_optimizer_tree_aliases kept_left)
-							(join_optimizer_tree_aliases kept_right))))
-						(make_join_optimizer_node kind kept_left kept_right
-							(filter predicates (lambda (predicate)
-								(join_optimizer_alias_subset?
-									(join_order_pred_aliases predicate) kept_aliases))))))))
+						(define kept_aliases (merge (list (cadr left_result) (cadr right_result))))
+						(list
+							(make_join_optimizer_node kind kept_left kept_right
+								(filter predicates (lambda (predicate)
+									(join_optimizer_alias_subset?
+										(join_order_pred_aliases predicate) kept_aliases))))
+							kept_aliases)))))
 		((quote join-node) kind left right predicates)
-		(join_optimizer_tree_without_aliases
+		(join_optimizer_tree_without_aliases_with_aliases
 			(make_join_optimizer_node kind left right predicates) removed_aliases)
 		_ (neumann_fail "build_queryplan" "malformed logical join plan while removing consumed sources"))))
+
+(define join_optimizer_tree_without_aliases (lambda (tree removed_aliases)
+	(car (join_optimizer_tree_without_aliases_with_aliases tree removed_aliases))))
 
 (define join_optimizer_facts_without_aliases (lambda (facts removed_aliases)
 	(begin
@@ -14115,7 +14120,10 @@ either bound a real row or supplied the synthetic NULL row. */
 		(define ordered_sources (join_optimizer_sources_for_order all_sources ordered_aliases))
 		(define src (car ordered_sources))
 		(define remaining_sources (cdr ordered_sources))
-		(define remaining_plan (physical_join_plan_for_sources remaining_sources))
+		/* The ordered driver is consumed here. Preserve the optimizer's remaining
+		subtree instead of rebuilding a left-deep tree from the source catalog. */
+		(define remaining_plan (join_optimizer_tree_without_aliases
+			plan (list (source_alias src))))
 		(define alias (source_alias src))
 		(define condition_parts (physical_partition_condition default_alias src remaining_sources final_condition))
 		(define local_condition (nth condition_parts 0))

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -29,6 +29,10 @@ setup:
   - sql: "DROP TABLE IF EXISTS ord_member_label"
   - sql: "DROP TABLE IF EXISTS ord_derived_item"
   - sql: "DROP TABLE IF EXISTS ord_derived_parent"
+  - sql: "DROP TABLE IF EXISTS ord_tree_a"
+  - sql: "DROP TABLE IF EXISTS ord_tree_b"
+  - sql: "DROP TABLE IF EXISTS ord_tree_c"
+  - sql: "DROP TABLE IF EXISTS ord_tree_d"
   - sql: "CREATE TABLE ord_t (a INT, b INT)"
   - sql: "CREATE TABLE ord_join_left (id INT PRIMARY KEY, ref_id INT)"
   - sql: "CREATE TABLE ord_join_right (id INT PRIMARY KEY, rank_value INT)"
@@ -37,6 +41,10 @@ setup:
   - sql: "CREATE TABLE ord_member_label (id INT PRIMARY KEY, name TEXT, visible INT)"
   - sql: "CREATE TABLE ord_derived_parent (id INT PRIMARY KEY, label TEXT)"
   - sql: "CREATE TABLE ord_derived_item (id INT PRIMARY KEY, parent_id INT, created INT)"
+  - sql: "CREATE TABLE ord_tree_a (id INT PRIMARY KEY, pair_key INT)"
+  - sql: "CREATE TABLE ord_tree_b (id INT PRIMARY KEY, pair_key INT)"
+  - sql: "CREATE TABLE ord_tree_c (id INT PRIMARY KEY, pair_key INT)"
+  - sql: "CREATE TABLE ord_tree_d (id INT PRIMARY KEY, pair_key INT)"
   - sql: |
       INSERT INTO ord_t (a,b) VALUES
       (1,2),(1,1),(2,2),(2,0),(3,1)
@@ -47,6 +55,10 @@ setup:
   - sql: "INSERT INTO ord_member_label VALUES (10,'alpha',1),(20,'beta',0)"
   - sql: "INSERT INTO ord_derived_parent VALUES (1,'one'),(2,'two')"
   - sql: "INSERT INTO ord_derived_item VALUES (10,1,100),(20,2,200)"
+  - sql: "INSERT INTO ord_tree_a VALUES (1,10),(2,20),(3,30)"
+  - sql: "INSERT INTO ord_tree_b VALUES (10,10),(20,20),(30,30)"
+  - sql: "INSERT INTO ord_tree_c VALUES (1,100),(2,200),(3,300)"
+  - sql: "INSERT INTO ord_tree_d VALUES (100,100),(200,200)"
 
 test_cases:
   - name: "Top-1 by a DESC"
@@ -219,6 +231,115 @@ test_cases:
         - "initialize_cache_table"
         - "(sort rows"
         - "(slice sorted"
+
+  - name: "Ordered four-way join retains a bushy logical tree"
+    sql: |
+      EXPLAIN REORDER SELECT a.id
+      FROM ord_tree_a a
+      JOIN ord_tree_b b ON b.pair_key = a.pair_key
+      JOIN ord_tree_c c ON c.id = a.id
+      JOIN ord_tree_d d ON d.pair_key = c.pair_key
+      ORDER BY a.id, b.id, c.id, d.id
+      LIMIT 2
+    expect:
+      rows: 1
+      result_contains:
+        - "join_reorder_strategy"
+        - "dphyp"
+        - "ord_tree_a"
+        - "ord_tree_b"
+        - "ord_tree_c"
+        - "ord_tree_d"
+      result_occurrences:
+        - { text: "join-node", count: 3 }
+
+  - name: "Ordered driver removal retains a bushy independent subtree"
+    scm: |
+      (begin
+        (define tree (make_join_optimizer_node 'inner
+          (make_join_optimizer_node 'inner
+            (make_join_optimizer_leaf "a")
+            (make_join_optimizer_leaf "b") '())
+          (make_join_optimizer_node 'inner
+            (make_join_optimizer_leaf "c")
+            (make_join_optimizer_leaf "d") '()) '()))
+        (equal?
+          (join_optimizer_tree_without_aliases tree '("a"))
+          (make_join_optimizer_node 'inner
+            (make_join_optimizer_leaf "b")
+            (make_join_optimizer_node 'inner
+              (make_join_optimizer_leaf "c")
+              (make_join_optimizer_leaf "d") '()) '())))
+    expect:
+      data: [true]
+
+  - name: "Ordered driver removal retains an outer-join barrier"
+    scm: |
+      (begin
+        (define tree (make_join_optimizer_node 'left-outer
+          (make_join_optimizer_node 'inner
+            (make_join_optimizer_leaf "a")
+            (make_join_optimizer_leaf "b") '())
+          (make_join_optimizer_leaf "d") '()))
+        (equal?
+          (join_optimizer_tree_without_aliases tree '("a"))
+          (make_join_optimizer_node 'left-outer
+            (make_join_optimizer_leaf "b")
+            (make_join_optimizer_leaf "d") '())))
+    expect:
+      data: [true]
+
+  - name: "Bushy ordered join lowers without rebuilding its independent subtree"
+    sql: |
+      EXPLAIN SELECT a.id
+      FROM ord_tree_a a
+      JOIN ord_tree_b b ON b.pair_key = a.pair_key
+      JOIN ord_tree_c c ON c.id = a.id
+      JOIN ord_tree_d d ON d.pair_key = c.pair_key
+      ORDER BY a.id, b.id, c.id, d.id
+      LIMIT 2
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "ord_tree_a"
+        - "ord_tree_b"
+        - "ord_tree_c"
+        - "ord_tree_d"
+      result_not_contains:
+        - "(sort rows"
+        - "(slice sorted"
+
+  - name: "Bushy ordered join preserves results across independent subtrees"
+    sql: |
+      SELECT a.id
+      FROM ord_tree_a a
+      JOIN ord_tree_b b ON b.pair_key = a.pair_key
+      JOIN ord_tree_c c ON c.id = a.id
+      JOIN ord_tree_d d ON d.pair_key = c.pair_key
+      ORDER BY a.id, b.id, c.id, d.id
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - id: 1
+        - id: 2
+
+  - name: "Ordered lowering preserves the nullable outer-join barrier"
+    sql: |
+      SELECT a.id, d.id AS nullable_id
+      FROM ord_tree_a a
+      JOIN ord_tree_b b ON b.pair_key = a.pair_key
+      JOIN ord_tree_c c ON c.id = a.id
+      LEFT JOIN ord_tree_d d ON d.pair_key = c.pair_key
+      ORDER BY a.id, b.id, c.id, d.id
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - { id: 1, nullable_id: 100 }
+        - { id: 2, nullable_id: 200 }
+        - { id: 3, nullable_id: null }
 
   - name: "RecSet membership with lookup order never materializes Scheme rows"
     sql: |
@@ -545,3 +666,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS ord_member_label"
   - sql: "DROP TABLE IF EXISTS ord_derived_item"
   - sql: "DROP TABLE IF EXISTS ord_derived_parent"
+  - sql: "DROP TABLE IF EXISTS ord_tree_a"
+  - sql: "DROP TABLE IF EXISTS ord_tree_b"
+  - sql: "DROP TABLE IF EXISTS ord_tree_c"
+  - sql: "DROP TABLE IF EXISTS ord_tree_d"


### PR DESCRIPTION
## What
- remove the ordered driver from the optimizer join tree structurally
- retain the remaining bushy subtree and its join kinds/predicate ownership
- add coverage for independent subtrees and outer-join barriers

## Why
The ordered-stream special path flattened aliases and rebuilt a left-deep tree, discarding optimizer subtree boundaries and physical opportunities.

## Verification
- full `./git-pre-commit` suite passed before rebase
- focused `tests/planner/order-window/order-limit.yaml`: 40/40 after rebase
- Scheme formatter run; only repository-existing negative-depth warnings remain

## Impact
No parser or storage changes. Ordered lowering now consumes the same logical join tree as the general path.