### PR TITLE
Extend planner statistics contract

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4454,45 +4454,85 @@ and barrier ownership come from the pre-normalization query block. */
 			(list (symbol "get_column") tblvar tbl_ignorecase col col_ignorecase))
 		_ nil)))
 
-(define join_optimizer_column_selectivity (lambda (column_ref)
-	(if (nil? column_ref)
-		0.1
-		(begin
-			(define distinct (planner_column_distinct_estimate (car column_ref) (cadr column_ref)))
-			(if (or (nil? distinct) (<= distinct 0)) 0.1 (/ 1 (max 1 distinct)))))))
+(define planner_estimate (lambda (value confidence source known)
+	(list
+		(list (quote value) value)
+		(list (quote confidence) confidence)
+		(list (quote source) source)
+		(list (quote known) known))))
 
-(define join_optimizer_equality_selectivity (lambda (sources default_alias left right)
+(define planner_estimate_planning_value (lambda (estimate fallback)
+	(coalesceNil (qassoc_get estimate (quote value) nil) fallback)))
+
+(define planner_unknown_selectivity_estimate (lambda ()
+	(planner_estimate nil 0 (quote unknown) false)))
+
+(define join_optimizer_column_selectivity_estimate (lambda (column_ref)
+	(if (nil? column_ref)
+		(planner_unknown_selectivity_estimate)
+		(begin
+			(define stats (planner_column_statistics (car column_ref) (cadr column_ref)))
+			(define distinct (qassoc_get stats (quote distinct) nil))
+			(if (or (nil? distinct) (<= distinct 0))
+				(planner_unknown_selectivity_estimate)
+				(planner_estimate (/ 1 (max 1 distinct))
+					(qassoc_get stats (quote confidence) 0)
+					(qassoc_get stats (quote source) (quote unknown)) true))))))
+
+(define join_optimizer_column_selectivity (lambda (column_ref)
+	(planner_estimate_planning_value
+		(join_optimizer_column_selectivity_estimate column_ref) 0.1)))
+
+(define join_optimizer_equality_selectivity_estimate (lambda (sources default_alias left right)
 	(begin
 		(define left_ref (join_optimizer_column_ref sources default_alias left))
 		(define right_ref (join_optimizer_column_ref sources default_alias right))
 		(if (and (not (nil? left_ref)) (not (nil? right_ref)))
 			(begin
-				(define left_distinct (planner_column_distinct_estimate (car left_ref) (cadr left_ref)))
-				(define right_distinct (planner_column_distinct_estimate (car right_ref) (cadr right_ref)))
+				(define left_stats (planner_column_statistics (car left_ref) (cadr left_ref)))
+				(define right_stats (planner_column_statistics (car right_ref) (cadr right_ref)))
+				(define left_distinct (qassoc_get left_stats (quote distinct) nil))
+				(define right_distinct (qassoc_get right_stats (quote distinct) nil))
 				(if (or (nil? left_distinct) (nil? right_distinct))
-					0.1
-					(/ 1 (max 1 (max left_distinct right_distinct)))))
+					(planner_unknown_selectivity_estimate)
+					(planner_estimate (/ 1 (max 1 (max left_distinct right_distinct)))
+						(min (qassoc_get left_stats (quote confidence) 0)
+							(qassoc_get right_stats (quote confidence) 0))
+						(quote distinct_join) true)))
 			(if (not (nil? left_ref))
-				(join_optimizer_column_selectivity left_ref)
-				(if (not (nil? right_ref)) (join_optimizer_column_selectivity right_ref) 0.1))))))
+				(join_optimizer_column_selectivity_estimate left_ref)
+				(if (not (nil? right_ref))
+					(join_optimizer_column_selectivity_estimate right_ref)
+					(planner_unknown_selectivity_estimate)))))))
+
+(define join_optimizer_equality_selectivity (lambda (sources default_alias left right)
+	(planner_estimate_planning_value
+		(join_optimizer_equality_selectivity_estimate sources default_alias left right) 0.1)))
+
+(define join_optimizer_expr_selectivity_estimate (lambda (sources default_alias expr)
+	(match expr
+		((symbol equal?) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
+		((quote equal?) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal?") left right))
+		((symbol equal??) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
+		((quote equal??) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "equal??") left right))
+		((symbol =) left right) (join_optimizer_equality_selectivity_estimate sources default_alias left right)
+		((quote =) left right) (join_optimizer_expr_selectivity_estimate sources default_alias (list (symbol "=") left right))
+		((symbol <) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((quote <) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((symbol <=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((quote <=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((symbol >) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((quote >) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((symbol >=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((quote >=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		_ (planner_unknown_selectivity_estimate))))
 
 (define join_optimizer_expr_selectivity (lambda (sources default_alias expr)
-	(match expr
-		((symbol equal?) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((quote equal?) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((symbol equal??) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((quote equal??) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((symbol =) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((quote =) left right) (join_optimizer_equality_selectivity sources default_alias left right)
-		((symbol <) _left _right) 0.3333333333333333
-		((quote <) _left _right) 0.3333333333333333
-		((symbol <=) _left _right) 0.3333333333333333
-		((quote <=) _left _right) 0.3333333333333333
-		((symbol >) _left _right) 0.3333333333333333
-		((quote >) _left _right) 0.3333333333333333
-		((symbol >=) _left _right) 0.3333333333333333
-		((quote >=) _left _right) 0.3333333333333333
-		_ 0.1)))
+	(begin
+		(define estimate (join_optimizer_expr_selectivity_estimate sources default_alias expr))
+		(planner_estimate_planning_value estimate
+			(if (equal? (qassoc_get estimate (quote source) nil) (quote range_unknown))
+				0.3333333333333333 0.1)))))
 
 (define join_optimizer_product (lambda (values)
 	(reduce (coalesceNil values '()) (lambda (product value) (* product value)) 1)))
@@ -4516,7 +4556,8 @@ and barrier ownership come from the pre-normalization query block. */
 
 (define join_optimizer_source_rows (lambda (stages sources default_alias graph src)
 	(begin
-		(define base_rows (coalesceNil (planner_source_row_count_using_stages stages src) 1000000))
+		(define base_rows (planner_estimate_planning_value
+			(planner_source_row_estimate_using_stages stages src) 1000000))
 		(define local_selectivity (join_optimizer_product
 			(map (join_optimizer_local_predicates graph (source_alias src)) (lambda (entry)
 				(join_optimizer_expr_selectivity sources default_alias
@@ -6029,17 +6070,52 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(planner_table_row_count (source_schema src) (source_relation src))
 		nil)))
 
-(define planner_column_distinct_estimate (lambda (src column)
+(define planner_source_row_estimate (lambda (src)
+	(begin
+		(define rows (planner_source_row_count src))
+		(if (nil? rows)
+			(planner_estimate nil 0 (quote unknown) false)
+			(planner_estimate rows 0.9 (quote live_or_rebuild_row_count) true)))))
+
+(define planner_source_row_estimate_using_stages (lambda (stages src)
+	(if (join_optimizer_guaranteed_singleton_stage_source? stages src)
+		(planner_estimate 1 1 (quote semantic_singleton) true)
+		(planner_source_row_estimate src))))
+
+(define planner_column_statistics (lambda (src column)
 	(if (or (not (source_is_base_table? src)) (nil? column))
-		nil
+		(list
+			(list (quote known) false)
+			(list (quote confidence) 0)
+			(list (quote source) (quote unknown))
+			(list (quote distinct) nil)
+			(list (quote null_fraction) nil)
+			(list (quote min) nil)
+			(list (quote max) nil))
 		(try
 			(lambda ()
 				(reduce (get_schema (source_schema src) (source_relation src)) (lambda (found row)
 					(if (not (nil? found))
 						found
-						(if (equal?? (row "Field") column) (row "DistinctEstimate") nil)))
+						(if (equal?? (row "Field") column)
+							(list
+								(list (quote known) (row "StatisticsKnown"))
+								(list (quote confidence) (row "StatisticsConfidence"))
+								(list (quote source) (symbol (row "StatisticsSource")))
+								(list (quote distinct) (if (row "StatisticsKnown") (row "DistinctEstimate") nil))
+								(list (quote null_fraction) (row "NullFraction"))
+								(list (quote min) (row "MinEstimate"))
+								(list (quote max) (row "MaxEstimate")))
+							nil)))
 					nil))
-			(lambda (_e) nil)))))
+			(lambda (_e) (list
+				(list (quote known) false)
+				(list (quote confidence) 0)
+				(list (quote source) (quote unknown))
+				(list (quote distinct) nil)))))))
+
+(define planner_column_distinct_estimate (lambda (src column)
+	(qassoc_get (planner_column_statistics src column) (quote distinct) nil)))
 
 (define planner_group_distinct_estimate (lambda (src keys row_count)
 	(reduce keys (lambda (estimate key)
@@ -6073,12 +6149,15 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(not (or (nil? join_expr) (equal? join_expr true))))))
 
 (define source_reorder_estimate (lambda (src)
-	(list
-		(source_alias src)
-		(list (quote relation) (source_relation src))
-		(list (quote row_count) (planner_source_row_count src))
-		(list (quote outer_join) (source_outer? src))
-		(list (quote join_filter) (source_join_present? src)))))
+	(begin
+		(define row_estimate (planner_source_row_estimate src))
+		(list
+			(source_alias src)
+			(list (quote relation) (source_relation src))
+			(list (quote row_count) (qassoc_get row_estimate (quote value) nil))
+			(list (quote row_estimate) row_estimate)
+			(list (quote outer_join) (source_outer? src))
+			(list (quote join_filter) (source_join_present? src))))))
 
 /* Identify the leading inner-join cloud that the logical optimizer may
 reorder. Outer and stage-backed sources remain barriers and are appended to the
@@ -6109,12 +6188,42 @@ resulting tree in semantic order. */
 				(list (quote null_extension_barrier) true)
 				(list (quote reuse) 1))))))
 
+(define query_block_selectivity_estimates (lambda (block)
+	(begin
+		(define sources (qb_sources block))
+		(define default_alias (qassoc_get (qb_facts block) (quote default_alias)
+			(if (empty_list? sources) nil (source_alias (car sources)))))
+		(define predicates (merge (list
+			(split_and_terms (coalesceNil (qb_where block) true))
+			(merge (map sources (lambda (src)
+				(split_and_terms (coalesceNil (source_join_expr src) true))))))))
+		(map (filter predicates (lambda (predicate) (not (equal? predicate true))))
+			(lambda (predicate)
+				(begin
+					(define estimate (join_optimizer_expr_selectivity_estimate
+						sources default_alias predicate))
+					(list
+						(list (quote predicate) predicate)
+						(list (quote estimate) estimate)
+						(list (quote planning_value)
+							(planner_estimate_planning_value estimate
+								(if (equal? (qassoc_get estimate (quote source) nil) (quote range_unknown))
+									0.3333333333333333 0.1))))))))))
+
+(define explain_reorder_selectivities? (lambda ()
+	(try
+		(lambda () (coalesceNil ((context "session") "__memcp_explain_reorder_selectivities") false))
+		(lambda (_e) false))))
+
 (define query_block_reorder_telemetry (lambda (block)
-	(list
-		(list (quote source_estimates) (map (qb_sources block) source_reorder_estimate))
-		(list (quote left_join_requirements) (filter
+	(merge (list
+		(list (list (quote source_estimates) (map (qb_sources block) source_reorder_estimate)))
+		(if (explain_reorder_selectivities?)
+			(list (list (quote selectivity_estimates) (query_block_selectivity_estimates block)))
+			'())
+		(list (list (quote left_join_requirements) (filter
 			(map (qb_sources block) left_join_requirement)
-			(lambda (item) (not (nil? item))))))))
+			(lambda (item) (not (nil? item))))))))))
 
 (define query_block_needs_reorder_facts? (lambda (block)
 	(or (not (empty_list? (qb_stages block)))
@@ -15862,12 +15971,15 @@ build_queryplan contract. */
 					(explain_union_ir_metadata ir)))))))
 
 (define explain_queryplan_reorder (lambda (query)
-	(list (quote resultrow)
-		(list (quote list)
-			"reorder"
-			(pretty_print
-				(join_reorder (untangle_query_term query nil))
-				(settings "ExplainWidth"))))))
+	(begin
+		(define planning_session (context "session"))
+		(planning_session "__memcp_explain_reorder_selectivities" true)
+		(define reordered (join_reorder (untangle_query_term query nil)))
+		(planning_session "__memcp_explain_reorder_selectivities" nil)
+		(list (quote resultrow)
+			(list (quote list)
+				"reorder"
+				(pretty_print reordered (settings "ExplainWidth")))))))
 
 (define explain_queryplan_compile (lambda (query parse_started_ns sql_bytes)
 	(begin

--- a/storage/database.go
+++ b/storage/database.go
@@ -786,6 +786,15 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				}
 				atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)
 				atomic.StoreUint64(&t.Columns[ci].RowEstimate, rowEst)
+				// Planner statistics are properties of persisted base columns. Reading
+				// hidden/cache or computed storages can initialize maintenance state and
+				// must never be part of a statistics-only rebuild pass.
+				if !strings.HasPrefix(t.Name, ".") && !t.Columns[ci].IsTemp && t.Columns[ci].Computor.IsNil() && len(t.Columns[ci].OrcSortCols) == 0 {
+					t.Columns[ci].PlannerStats.Store(
+						collectRebuiltColumnPlannerStatistics(newShardList, colName))
+				} else {
+					t.Columns[ci].PlannerStats.Store(nil)
+				}
 			}
 			t.publishShowColumnsSnapshot()
 			t.collectStatisticsFromShards(newShardList)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3598,19 +3598,112 @@ func showEngineStr(t *table) string {
 	}
 }
 
-// showBuildMeta builds the meta assoc for a table: Name, Engine, Collation, Charset, Comment, Unique, Partitions.
+func showStringSlice(values []string) scm.Scmer {
+	items := make([]scm.Scmer, len(values))
+	for i, value := range values {
+		items[i] = scm.NewString(value)
+	}
+	return scm.NewSlice(items)
+}
+
+func plannerDistinctForColumns(t *table, columns []string) (float64, float64, string) {
+	rows := float64(t.CountEstimate())
+	if len(columns) == 0 {
+		return 0, 0, "unknown"
+	}
+	estimate := 1.0
+	confidence := 1.0
+	for _, columnName := range columns {
+		var descriptor *column
+		for _, candidate := range t.Columns {
+			if candidate.Name == columnName {
+				descriptor = candidate
+				break
+			}
+		}
+		if descriptor == nil || descriptor.PlannerStats.Load() == nil {
+			return 0, 0, "unknown"
+		}
+		distinct := float64(atomic.LoadUint64(&descriptor.DistinctEstimate))
+		if distinct <= 0 {
+			return 0, 0, "unknown"
+		}
+		estimate *= distinct
+		confidence *= descriptor.PlannerStats.Load().Confidence
+	}
+	if estimate > rows {
+		estimate = rows
+	}
+	return estimate, confidence, "rebuild_independence"
+}
+
+// showBuildMeta builds table metadata including key, relationship, and
+// multi-column planner statistics. All statistics are immutable snapshots.
 func showBuildMeta(db *database, t *table) scm.Scmer {
 	engine := showEngineStr(t)
 	uniques := make([]scm.Scmer, len(t.Unique))
 	for i, uk := range t.Unique {
-		cols := make([]scm.Scmer, len(uk.Cols))
-		for j, c := range uk.Cols {
-			cols[j] = scm.NewString(c)
-		}
 		uniques[i] = scm.NewSlice([]scm.Scmer{
 			scm.NewString("Id"), scm.NewString(uk.Id),
-			scm.NewString("Cols"), scm.NewSlice(cols),
+			scm.NewString("Cols"), showStringSlice(uk.Cols),
 		})
+	}
+	multiColumnDistinct := make([]scm.Scmer, 0, len(t.Unique))
+	for _, uk := range t.Unique {
+		if len(uk.Cols) < 2 {
+			continue
+		}
+		confidence := 0.8
+		source := "unique_constraint_upper_bound"
+		if uk.Id == "PRIMARY" {
+			confidence = 1
+			source = "primary_key"
+		}
+		multiColumnDistinct = append(multiColumnDistinct, scm.NewSlice([]scm.Scmer{
+			scm.NewString("Columns"), showStringSlice(uk.Cols),
+			scm.NewString("Estimate"), scm.NewInt(int64(t.CountEstimate())),
+			scm.NewString("Confidence"), scm.NewFloat(confidence),
+			scm.NewString("Source"), scm.NewString(source),
+		}))
+	}
+	foreignKeys := make([]scm.Scmer, 0, len(t.Foreign))
+	fanouts := make([]scm.Scmer, 0, len(t.Foreign))
+	for _, fk := range t.Foreign {
+		role := "referenced"
+		localColumns := fk.Cols2
+		otherTable := fk.Tbl1
+		otherColumns := fk.Cols1
+		if fk.Tbl1 == t.Name {
+			role = "referencing"
+			localColumns = fk.Cols1
+			otherTable = fk.Tbl2
+			otherColumns = fk.Cols2
+		}
+		foreignKeys = append(foreignKeys, scm.NewSlice([]scm.Scmer{
+			scm.NewString("Id"), scm.NewString(fk.Id),
+			scm.NewString("Role"), scm.NewString(role),
+			scm.NewString("LocalColumns"), showStringSlice(localColumns),
+			scm.NewString("OtherTable"), scm.NewString(otherTable),
+			scm.NewString("OtherColumns"), showStringSlice(otherColumns),
+		}))
+		fanoutEstimate := scm.NewNil()
+		confidenceValue := 0.0
+		sourceValue := "unknown"
+		if role == "referencing" {
+			distinct, confidence, source := plannerDistinctForColumns(t, localColumns)
+			if distinct > 0 {
+				fanoutEstimate = scm.NewFloat(float64(t.CountEstimate()) / distinct)
+				confidenceValue = confidence
+				sourceValue = source
+			}
+		}
+		fanouts = append(fanouts, scm.NewSlice([]scm.Scmer{
+			scm.NewString("Id"), scm.NewString(fk.Id),
+			scm.NewString("Role"), scm.NewString(role),
+			scm.NewString("EstimatedFanout"), fanoutEstimate,
+			scm.NewString("Confidence"), scm.NewFloat(confidenceValue),
+			scm.NewString("Source"), scm.NewString(sourceValue),
+		}))
 	}
 	partitions := make([]scm.Scmer, 0)
 	if t.ShardMode == ShardModePartition {
@@ -3629,6 +3722,9 @@ func showBuildMeta(db *database, t *table) scm.Scmer {
 		scm.NewString("Charset"), scm.NewString(t.Charset),
 		scm.NewString("Comment"), scm.NewString(t.Comment),
 		scm.NewString("Unique"), scm.NewSlice(uniques),
+		scm.NewString("ForeignKeys"), scm.NewSlice(foreignKeys),
+		scm.NewString("Fanout"), scm.NewSlice(fanouts),
+		scm.NewString("MultiColumnDistinct"), scm.NewSlice(multiColumnDistinct),
 		scm.NewString("Partitions"), scm.NewSlice(partitions),
 	})
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -53,6 +53,18 @@ func (t *table) String() string {
 }
 
 type dataset []scm.Scmer
+
+// columnPlannerStatistics is an immutable rebuild-generation snapshot. The
+// pointer is published atomically so query compilation never needs shard locks.
+type columnPlannerStatistics struct {
+	Confidence   float64
+	Source       string
+	NullCount    uint64
+	NullFraction float64
+	MinEstimate  scm.Scmer
+	MaxEstimate  scm.Scmer
+}
+
 type column struct {
 	Name              string
 	Typ               string
@@ -80,8 +92,9 @@ type column struct {
 	// Statistics — updated at rebuild time, O(1) access for query planning.
 	// DistinctEstimate is the sum of per-shard DistinctCount() (upper bound).
 	// RowEstimate is the table-wide CountEstimate() at last rebuild.
-	DistinctEstimate uint64 `json:"-"`
-	RowEstimate      uint64 `json:"-"`
+	DistinctEstimate uint64                                  `json:"-"`
+	RowEstimate      uint64                                  `json:"-"`
+	PlannerStats     atomic.Pointer[columnPlannerStatistics] `json:"-"`
 
 	// ORC fields — non-empty OrcSortCols signals this is an ordered-reduce computed column.
 	// The column value is produced by a scan_order pass rather than per-row computation.
@@ -494,6 +507,56 @@ func (t *table) collectStatisticsFromShards(shards []*storageShard) {
 	}
 }
 
+// collectRebuiltColumnPlannerStatistics reads only freshly rebuilt, unpublished
+// shard generations while the caller owns the table rebuild critical section.
+// It must not be used for live shards because it intentionally takes no shard
+// locks. Cached readers keep this maintenance pass sequential and allocation
+// free per value.
+func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName string) *columnPlannerStatistics {
+	stats := &columnPlannerStatistics{
+		Confidence:  1,
+		Source:      "rebuild",
+		MinEstimate: scm.NewNil(),
+		MaxEstimate: scm.NewNil(),
+	}
+	var rowCount uint64
+	var hasValue bool
+	for _, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		columnStorage := shard.columns[columnName]
+		if columnStorage == nil {
+			continue
+		}
+		reader := columnStorage.GetCachedReader()
+		for recid := uint32(0); recid < shard.main_count; recid++ {
+			rowCount++
+			value := reader.GetValue(recid)
+			if value.IsNil() {
+				stats.NullCount++
+				continue
+			}
+			if !hasValue {
+				stats.MinEstimate = value
+				stats.MaxEstimate = value
+				hasValue = true
+				continue
+			}
+			if scm.Less(value, stats.MinEstimate) {
+				stats.MinEstimate = value
+			}
+			if scm.Less(stats.MaxEstimate, value) {
+				stats.MaxEstimate = value
+			}
+		}
+	}
+	if rowCount > 0 {
+		stats.NullFraction = float64(stats.NullCount) / float64(rowCount)
+	}
+	return stats
+}
+
 func (t *table) statistics() tableStatisticsSnapshot {
 	if snapshot := t.showColumnsSnapshot.Load(); snapshot != nil {
 		if snapshot.statistics != nil {
@@ -893,6 +956,7 @@ type tableShowColumnsSnapshot struct {
 	value             scm.Scmer
 	rowEstimate       uint
 	distinctEstimates []uint64
+	plannerStatistics []*columnPlannerStatistics
 	columnNames       *tableColumnNamesSnapshot
 	statistics        *tableStatisticsSnapshot
 }
@@ -923,7 +987,7 @@ func foldIdentifier(name string) string {
 }
 
 func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, rowEstimate uint) bool {
-	if snapshot == nil || snapshot.rowEstimate != rowEstimate || len(snapshot.distinctEstimates) != len(t.Columns) {
+	if snapshot == nil || snapshot.rowEstimate != rowEstimate || len(snapshot.distinctEstimates) != len(t.Columns) || len(snapshot.plannerStatistics) != len(t.Columns) {
 		return false
 	}
 	for i, c := range t.Columns {
@@ -934,6 +998,9 @@ func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, r
 		if snapshot.distinctEstimates[i] != distinctEstimate {
 			return false
 		}
+		if snapshot.plannerStatistics[i] != c.PlannerStats.Load() {
+			return false
+		}
 	}
 	return true
 }
@@ -941,6 +1008,7 @@ func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, r
 func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnapshot {
 	result := make([]scm.Scmer, len(t.Columns))
 	distinctEstimates := make([]uint64, len(t.Columns))
+	plannerStatistics := make([]*columnPlannerStatistics, len(t.Columns))
 	columnNames := t.buildColumnNamesSnapshot()
 	for i, c := range t.Columns {
 		keyType := ""
@@ -960,12 +1028,14 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 			distinctEstimate = uint64(rowEstimate)
 		}
 		distinctEstimates[i] = distinctEstimate
-		result[i] = c.show(keyType, distinctEstimate, rowEstimate)
+		plannerStatistics[i] = c.PlannerStats.Load()
+		result[i] = c.show(keyType, distinctEstimate, rowEstimate, plannerStatistics[i])
 	}
 	snapshot := &tableShowColumnsSnapshot{
 		value:             scm.NewSlice(result),
 		rowEstimate:       rowEstimate,
 		distinctEstimates: distinctEstimates,
+		plannerStatistics: plannerStatistics,
 		columnNames:       columnNames,
 	}
 	if current := t.showColumnsSnapshot.Load(); current != nil {
@@ -1037,10 +1107,10 @@ func (t *table) ShowColumns() scm.Scmer {
 }
 
 func (c *column) Show(keyType string, t *table) scm.Scmer {
-	return c.show(keyType, uint64(c.distinctEstimateFor(t)), t.CountEstimate())
+	return c.show(keyType, uint64(c.distinctEstimateFor(t)), t.CountEstimate(), c.PlannerStats.Load())
 }
 
-func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint) scm.Scmer {
+func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint, plannerStats *columnPlannerStatistics) scm.Scmer {
 	dims := make([]scm.Scmer, len(c.Typdimensions))
 	for i, v := range c.Typdimensions {
 		dims[i] = scm.NewInt(int64(v))
@@ -1063,6 +1133,19 @@ func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint)
 	if c.AutoIncrement {
 		extra = "auto_increment"
 	}
+	statisticsKnown := plannerStats != nil
+	statisticsConfidence := 0.0
+	statisticsSource := "unknown"
+	nullFraction := scm.NewNil()
+	minEstimate := scm.NewNil()
+	maxEstimate := scm.NewNil()
+	if statisticsKnown {
+		statisticsConfidence = plannerStats.Confidence
+		statisticsSource = plannerStats.Source
+		nullFraction = scm.NewFloat(plannerStats.NullFraction)
+		minEstimate = plannerStats.MinEstimate
+		maxEstimate = plannerStats.MaxEstimate
+	}
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewString("Field"), scm.NewString(c.Name),
 		scm.NewString("Type"), scm.NewString(typ),
@@ -1077,6 +1160,18 @@ func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint)
 		scm.NewString("Comment"), scm.NewString(c.Comment),
 		scm.NewString("DistinctEstimate"), scm.NewInt(int64(distinctEstimate)),
 		scm.NewString("RowEstimate"), scm.NewInt(int64(rowEstimate)),
+		scm.NewString("StatisticsKnown"), scm.NewBool(statisticsKnown),
+		scm.NewString("StatisticsConfidence"), scm.NewFloat(statisticsConfidence),
+		scm.NewString("StatisticsSource"), scm.NewString(statisticsSource),
+		scm.NewString("DistinctEstimateSource"), scm.NewString(func() string {
+			if statisticsKnown {
+				return "rebuild"
+			}
+			return "fallback_row_count"
+		}()),
+		scm.NewString("NullFraction"), nullFraction,
+		scm.NewString("MinEstimate"), minEstimate,
+		scm.NewString("MaxEstimate"), maxEstimate,
 	})
 }
 

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -20,6 +20,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"
+  - sql: "DROP TABLE IF EXISTS stats_contract_child"
+  - sql: "DROP TABLE IF EXISTS stats_contract_parent"
 
 test_cases:
 
@@ -41,6 +43,29 @@ test_cases:
             (+ 1.0 (* i 0.5))))))
         (insert (table "memcp-tests" "rs_data") '("id" "val" "category" "price") rows)
         200)
+
+  - name: "Unrebuilt column statistics remain explicitly unknown"
+    scm: |
+      (begin
+        (define idcol (car (get_schema "memcp-tests" "rs_data")))
+        (and
+          (equal? (idcol "StatisticsKnown") false)
+          (equal? (idcol "StatisticsConfidence") 0)
+          (equal? (idcol "StatisticsSource") "unknown")
+          (equal? (idcol "DistinctEstimateSource") "fallback_row_count")
+          (nil? (idcol "NullFraction"))))
+    expect:
+      data: [true]
+
+  - name: "EXPLAIN keeps unknown selectivity separate from its planning fallback"
+    sql: "EXPLAIN REORDER SELECT a.id FROM rs_data a JOIN rs_data b ON b.id = a.id WHERE a.val > 10"
+    expect:
+      rows: 1
+      result_contains:
+        - "selectivity_estimates"
+        - "range_unknown"
+        - "(known false)"
+        - "planning_value"
 
   - name: "Clear range scan statistics"
     setup:
@@ -647,6 +672,64 @@ test_cases:
     expect:
       rows: 1
 
+  - name: "Rebuild publishes confidence null fraction and min max"
+    scm: |
+      (begin
+        (define idcol (car (get_schema "memcp-tests" "rs_data")))
+        (and
+          (idcol "StatisticsKnown")
+          (equal? (idcol "StatisticsConfidence") 1)
+          (equal? (idcol "StatisticsSource") "rebuild")
+          (equal? (idcol "DistinctEstimateSource") "rebuild")
+          (equal? (idcol "NullFraction") 0)
+          (equal? (idcol "MinEstimate") 0)
+          (equal? (idcol "MaxEstimate") 199)))
+    expect:
+      data: [true]
+
+  - name: "Create planner statistics relationship tables"
+    sql: "CREATE TABLE stats_contract_parent (tenant_id INT, id INT, PRIMARY KEY(tenant_id, id))"
+
+  - name: "Create planner statistics child table"
+    sql: "CREATE TABLE stats_contract_child (id INT PRIMARY KEY, tenant_id INT, parent_id INT, nullable_value INT, FOREIGN KEY stats_contract_fk (tenant_id, parent_id) REFERENCES stats_contract_parent(tenant_id, id))"
+
+  - name: "Insert planner statistics parent rows"
+    sql: "INSERT INTO stats_contract_parent VALUES (1,10),(1,20),(2,10)"
+
+  - name: "Insert planner statistics child rows"
+    sql: "INSERT INTO stats_contract_child VALUES (1,1,10,NULL),(2,1,10,5),(3,1,20,9)"
+
+  - name: "Rebuild planner statistics relationship tables"
+    sql: "SHUTDOWN"
+
+  - name: "Planner statistics expose nullable distribution"
+    scm: |
+      (begin
+        (define nullablecol (nth (get_schema "memcp-tests" "stats_contract_child") 3))
+        (and
+          (nullablecol "StatisticsKnown")
+          (> (nullablecol "NullFraction") 0.33)
+          (< (nullablecol "NullFraction") 0.34)
+          (equal? (nullablecol "MinEstimate") 5)
+          (equal? (nullablecol "MaxEstimate") 9)))
+    expect:
+      data: [true]
+
+  - name: "Planner metadata exposes composite distinct and FK fanout contracts"
+    scm: |
+      (begin
+        (define parentmeta ((show "memcp-tests" "stats_contract_parent" true) "meta"))
+        (define childmeta ((show "memcp-tests" "stats_contract_child" true) "meta"))
+        (and
+          (equal? (count (parentmeta "MultiColumnDistinct")) 1)
+          (equal? ((car (parentmeta "MultiColumnDistinct")) "Estimate") 3)
+          (equal? (count (childmeta "ForeignKeys")) 1)
+          (equal? ((car (childmeta "ForeignKeys")) "Role") "referencing")
+          (equal? (count (childmeta "Fanout")) 1)
+          (> ((car (childmeta "Fanout")) "EstimatedFanout") 0)))
+    expect:
+      data: [true]
+
   # ========================================================================
   # 8. Multi-column range + index (exercises multi-column boundary code)
   # ========================================================================
@@ -812,3 +895,5 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"
+  - sql: "DROP TABLE IF EXISTS stats_contract_child"
+  - sql: "DROP TABLE IF EXISTS stats_contract_parent"


### PR DESCRIPTION
## Summary
- publish explicit confidence, provenance, NULL fraction, min/max, FK/PK fanout, and multi-column distinct planner facts
- keep unknown estimates explicit while exposing separately labelled planning fallbacks
- include source and selectivity estimates in EXPLAIN REORDER

## Verification
- full `./git-pre-commit` passed before push
- `tests/execution/operators/range-scan-coverage.yaml`: 98/98 passed after rebase
- `tests/storage/persistence/crash-recovery.yaml`: 88/88 passed
- Scheme formatter and Go build passed

## Storage safety
- no serialization format or persistence deletion path changed
- rebuilt statistics are immutable snapshots and exclude hidden, temporary, computed, and ORC storage artifacts