### PR TITLE
Protect recursive optimizer hook rewrites

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -24,6 +24,7 @@ package scm
 import "regexp"
 import "strconv"
 import "strings"
+import "time"
 
 var SettingsHaveGoodBacktraces bool
 
@@ -266,9 +267,52 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 
 // do preprocessing and optimization (Optimize is allowed to edit the value in-place)
 func Optimize(val Scmer, env *Env) Scmer {
+	result, _ := OptimizeWithStats(val, env)
+	return result
+}
+
+// OptimizerStats exposes compile work without coupling callers to optimizer
+// internals. All counters cover one top-level optimization.
+type OptimizerStats struct {
+	CompileNS        int64
+	InputNodes       int
+	OutputNodes      int
+	Rewrites         int
+	RejectedRewrites int
+	BudgetRemaining  int
+	CallbackAnalyses int
+	CallbackClones   int
+}
+
+type optimizerRewriteState struct {
+	remainingBudget  int
+	inputNodes       int
+	rewrites         int
+	rejected         int
+	callbackAnalyses int
+	callbackClones   int
+	active           map[string]bool
+	seen             map[uint64]bool
+}
+
+const defaultOptimizerRewriteBudget = 64
+
+// OptimizeWithStats returns both optimized code and bounded-work telemetry.
+func OptimizeWithStats(val Scmer, env *Env) (Scmer, OptimizerStats) {
+	started := time.Now()
 	ome := newOptimizerMetainfo()
+	ome.rewrite.inputNodes = optimizerNodeCount(val)
 	v, _ := OptimizeEx(val, env, &ome, true)
-	return v
+	return v, OptimizerStats{
+		CompileNS:        time.Since(started).Nanoseconds(),
+		InputNodes:       ome.rewrite.inputNodes,
+		OutputNodes:      optimizerNodeCount(v),
+		Rewrites:         ome.rewrite.rewrites,
+		RejectedRewrites: ome.rewrite.rejected,
+		BudgetRemaining:  ome.rewrite.remainingBudget,
+		CallbackAnalyses: ome.rewrite.callbackAnalyses,
+		CallbackClones:   ome.rewrite.callbackClones,
+	}
 }
 
 type optimizerMetainfo struct {
@@ -284,13 +328,34 @@ type optimizerMetainfo struct {
 	beginDepth            int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
 	inlineDepth           int
 	inlineStack           map[Symbol]bool
+	rewrite               *optimizerRewriteState
 }
 
 func newOptimizerMetainfo() (result optimizerMetainfo) {
 	result.variableReplacement = make(map[Symbol]Scmer)
 	result.variableTypes = make(map[Symbol]*TypeDescriptor)
 	result.numberedTypes = make(map[NthLocalVar]*TypeDescriptor)
+	result.rewrite = &optimizerRewriteState{
+		remainingBudget: defaultOptimizerRewriteBudget,
+		active:          make(map[string]bool),
+		seen:            make(map[uint64]bool),
+	}
 	return
+}
+
+func optimizerNodeCount(expr Scmer) int {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	items, ok := scmerSlice(expr)
+	if !ok {
+		return 1
+	}
+	count := 1
+	for _, item := range items {
+		count += optimizerNodeCount(item)
+	}
+	return count
 }
 
 func rewriteNoEscapeListReturn(expr Scmer, flow *TypeDescriptor, nextSlot *int) Scmer {
@@ -641,6 +706,7 @@ func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	result.beginDepth = ome.beginDepth
 	result.inlineDepth = ome.inlineDepth
 	result.inlineStack = ome.inlineStack
+	result.rewrite = ome.rewrite
 	// nextSlot is NOT propagated across lambda boundaries (each lambda has its own)
 	return
 }
@@ -666,6 +732,7 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.beginDepth = ome.beginDepth
 	result.inlineDepth = ome.inlineDepth
 	result.inlineStack = ome.inlineStack
+	result.rewrite = ome.rewrite
 	return
 }
 
@@ -1597,10 +1664,66 @@ func (oc *OptimizerContext) OptimizeSub(val Scmer, useResult bool) (Scmer, *Type
 	return result, ti.ToTypeDescriptor()
 }
 
+// OptimizerRewriteContract declares the safety proof and maximum AST growth
+// for one recursive hook rewrite.
+type OptimizerRewriteContract struct {
+	Name             string
+	PreconditionsMet bool
+	MaxGrowthNodes   int
+}
+
+// OptimizeRewrite is the only supported path for a hook to recursively
+// optimize rewritten code. It enforces reentrancy, fingerprint, work-budget,
+// and AST-growth guards. The boolean is false when the caller must continue
+// with its non-rewrite optimization path.
+func (oc *OptimizerContext) OptimizeRewrite(original, rewritten Scmer, useResult bool, contract OptimizerRewriteContract) (Scmer, *TypeDescriptor, bool) {
+	state := oc.Ome.rewrite
+	if state == nil {
+		state = newOptimizerMetainfo().rewrite
+		oc.Ome.rewrite = state
+	}
+	activeKey := contract.Name + ":" + strconv.FormatUint(HashKey(original), 16)
+	if contract.Name == "" || !contract.PreconditionsMet || state.remainingBudget <= 0 || state.active[activeKey] {
+		state.rejected++
+		return original, nil, false
+	}
+	originalNodes := optimizerNodeCount(original)
+	rewrittenNodes := optimizerNodeCount(rewritten)
+	if contract.MaxGrowthNodes >= 0 && rewrittenNodes-originalNodes > contract.MaxGrowthNodes {
+		state.rejected++
+		return original, nil, false
+	}
+	globalLimit := state.inputNodes*4 + 1024
+	if state.inputNodes > 0 && rewrittenNodes > globalLimit {
+		state.rejected++
+		return original, nil, false
+	}
+	fingerprint := HashKey(rewritten)
+	if state.seen[fingerprint] {
+		state.rejected++
+		return original, nil, false
+	}
+	state.seen[fingerprint] = true
+	state.remainingBudget--
+	state.rewrites++
+	state.active[activeKey] = true
+	defer func() {
+		delete(state.active, activeKey)
+		delete(state.seen, fingerprint)
+	}()
+	result, td := oc.OptimizeSub(rewritten, useResult)
+	return result, td, true
+}
+
 // AnalyzeCallback computes a callback result type without consuming pending
 // metadata or otherwise mutating the optimizer context used for emitted code.
 func (oc *OptimizerContext) AnalyzeCallback(callback Scmer, params []*TypeDescriptor) *TypeDescriptor {
+	if oc.Ome.rewrite != nil {
+		oc.Ome.rewrite.callbackAnalyses++
+		oc.Ome.rewrite.callbackClones++
+	}
 	analysisOme := newOptimizerMetainfo()
+	analysisOme.rewrite = oc.Ome.rewrite
 	analysisOme.loopDepth = oc.Ome.loopDepth
 	analysis := OptimizerContext{Env: oc.Env, Ome: &analysisOme}
 	analysis.SetCallbackParamTypes(params)
@@ -1622,7 +1745,7 @@ func (oc *OptimizerContext) OptimizeReducerCallback(callback Scmer, accumulator 
 		return optimized, normalizeOptimizerType(result)
 	}
 	loopType := accumulator
-	for {
+	for iteration := 0; iteration < 16; iteration++ {
 		params[0] = loopType
 		result := normalizeOptimizerType(oc.AnalyzeCallback(callback, params))
 		next, changed := mergeOptimizerTypes(loopType, result)
@@ -1634,6 +1757,12 @@ func (oc *OptimizerContext) OptimizeReducerCallback(callback Scmer, accumulator 
 		}
 		loopType = next
 	}
+	// The join is monotonic, but malformed custom descriptors must not make
+	// optimizer compilation unbounded.
+	params[0] = loopType
+	oc.SetCallbackParamTypes(params)
+	optimized, finalResult := oc.OptimizeSub(callback, true)
+	return optimized, normalizeOptimizerType(finalResult)
 }
 
 func normalizeOptimizerType(td *TypeDescriptor) *TypeDescriptor {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -961,6 +961,31 @@ func init() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "optimize_stats",
+		Desc: "optimize code and return bounded rewrite, AST growth, callback-analysis, and compile-time metrics",
+		Fn: func(a ...Scmer) Scmer {
+			result, stats := OptimizeWithStats(a[0], &Globalenv)
+			return NewSlice([]Scmer{
+				NewString("result"), result,
+				NewString("compile_ns"), NewInt(stats.CompileNS),
+				NewString("input_nodes"), NewInt(int64(stats.InputNodes)),
+				NewString("output_nodes"), NewInt(int64(stats.OutputNodes)),
+				NewString("rewrites"), NewInt(int64(stats.Rewrites)),
+				NewString("rejected_rewrites"), NewInt(int64(stats.RejectedRewrites)),
+				NewString("budget_remaining"), NewInt(int64(stats.BudgetRemaining)),
+				NewString("callback_analyses"), NewInt(int64(stats.CallbackAnalyses)),
+				NewString("callback_clones"), NewInt(int64(stats.CallbackClones)),
+			})
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "code", ParamDesc: "list with head and optional parameters"},
+			},
+			Return: &TypeDescriptor{Kind: "assoc"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "time",
 		Desc: "measures the time it takes to compute the first argument",
 		Fn:   nil,

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -98,13 +98,25 @@ func normalizeScanType(td *scm.TypeDescriptor) *scm.TypeDescriptor {
 
 func optimizeScan(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
-		return oc.OptimizeSub(rewritten, useResult)
+		if result, td, accepted := oc.OptimizeRewrite(scm.NewSlice(v), rewritten, useResult, scm.OptimizerRewriteContract{
+			Name: "scan-invariant-filter", PreconditionsMet: true, MaxGrowthNodes: 64,
+		}); accepted {
+			return result, td
+		}
 	}
 	if rewritten := tryScanExistsRewrite(v); !rewritten.IsNil() {
-		return oc.OptimizeSub(rewritten, useResult)
+		if result, td, accepted := oc.OptimizeRewrite(scm.NewSlice(v), rewritten, useResult, scm.OptimizerRewriteContract{
+			Name: "scan-exists", PreconditionsMet: true, MaxGrowthNodes: 64,
+		}); accepted {
+			return result, td
+		}
 	}
 	if rewritten := tryScanBatchRewrite(v); !rewritten.IsNil() {
-		return oc.OptimizeSub(rewritten, useResult)
+		if result, td, accepted := oc.OptimizeRewrite(scm.NewSlice(v), rewritten, useResult, scm.OptimizerRewriteContract{
+			Name: "scan-batch", PreconditionsMet: true, MaxGrowthNodes: 256,
+		}); accepted {
+			return result, td
+		}
 	}
 	return optimizeScanShared(v, oc, 6, 7, 8, 9, 10)
 }
@@ -378,7 +390,11 @@ func scanExprMayHaveSideEffects(v scm.Scmer) bool {
 
 func optimizeScanBatch(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
-		return oc.OptimizeSub(rewritten, useResult)
+		if result, td, accepted := oc.OptimizeRewrite(scm.NewSlice(v), rewritten, useResult, scm.OptimizerRewriteContract{
+			Name: "scan-batch-invariant-filter", PreconditionsMet: true, MaxGrowthNodes: 64,
+		}); accepted {
+			return result, td
+		}
 	}
 	return optimizeScanShared(v, oc, 8, 9, 10, 11, 12)
 }

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -94,7 +94,11 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 
 func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	if rewritten := tryScanInvariantFilterRewrite(v); !rewritten.IsNil() {
-		return oc.OptimizeSub(rewritten, useResult)
+		if result, td, accepted := oc.OptimizeRewrite(scm.NewSlice(v), rewritten, useResult, scm.OptimizerRewriteContract{
+			Name: "scan-order-invariant-filter", PreconditionsMet: true, MaxGrowthNodes: 64,
+		}); accepted {
+			return result, td
+		}
 	}
 	// NOTE: scan_order has no reduce2, so batch-rewrite cannot flush the last
 	// partial batch. Disabled until scan_order gains reduce2 or an alternative

--- a/tests/execution/operators/scan-batch-optimizer.yaml
+++ b/tests/execution/operators/scan-batch-optimizer.yaml
@@ -142,6 +142,34 @@ test_cases:
       data_not_contains:
         - code: "scan_batch"
 
+  - name: "Optimizer telemetry exposes compile and AST growth costs"
+    scm: |
+      (begin
+        (define stats (optimize_stats (scheme "(+ 1 2)")))
+        (and
+          (> (stats "compile_ns") 0)
+          (> (stats "input_nodes") 0)
+          (> (stats "output_nodes") 0)
+          (>= (stats "rewrites") 0)
+          (>= (stats "rejected_rewrites") 0)
+          (>= (stats "budget_remaining") 0)
+          (>= (stats "callback_analyses") 0)
+          (>= (stats "callback_clones") 0)))
+    expect:
+      data: [true]
+
+  - name: "Recursive scan rewrites consume the shared rewrite budget once"
+    scm: |
+      (begin
+        (define code (scheme "(scan nil nil (list) (lambda () (if (> 2 1) true false)) (list) (lambda () nil) nil nil nil false)"))
+        (define stats (optimize_stats code))
+        (and
+          (> (stats "rewrites") 0)
+          (< (stats "budget_remaining") 64)
+          (< (stats "output_nodes") (+ (* (stats "input_nodes") 4) 1025))))
+    expect:
+      data: [true]
+
   - name: "Grouped LEFT JOIN carrier keeps outer key as dynamic lookup"
     sql: |
       SELECT c.cid, g.total


### PR DESCRIPTION
## Summary
- add a shared recursive-rewrite budget, reentrancy guard, active fingerprint guard, and AST growth contracts to optimizer hooks
- route scan, scan_batch, scan_exists, and scan_order recursive rewrites through the bounded contract
- expose compile time, AST size, accepted/rejected rewrites, remaining budget, and callback analysis/clone counts through `optimize_stats`
- cap malformed reducer type fixpoints while preserving the existing monotonic analysis

## Verification
- full `./git-pre-commit` passed on final master base
- `tests/execution/operators/scan-batch-optimizer.yaml`: 11/11 passed
- `tests/planner/subqueries/traced-union-scalar-probes.yaml`: 7/7 passed
- Go build passed

No tests, guards, or time limits were weakened.