### PR TITLE
Fix canonical query aggregate column fills

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -78,13 +78,7 @@ PostgreSQL parsers should both lower to the same combined operators.
 		(lambda (_e) '()))))
 
 (define qassoc_get (lambda (xs key default)
-	(match (coalesceNil xs '())
-		(cons entry rest) (match entry
-			(cons k values) (if (equal? k key)
-				(if (equal? (count values) 1) (car values) values)
-				(qassoc_get rest key default))
-			_ (qassoc_get rest key default))
-		_ default)))
+	(get_assoc_pairlist (coalesceNil xs '()) key default)))
 
 (define qassoc_set (lambda (xs key value)
 	(cons (list key value)
@@ -12676,10 +12670,6 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(match item '(expr _dir) (canonical_column_expr_for_alias alias expr)))))
 		(define key_index (make_group_key_index keys prepare_resolved_order_exprs))
 		(define ags (gs_aggregates stage))
-		/* Aggregate column names belong to the immutable logical stage. Prepared
-		input and rewritten descriptors below affect execution only. */
-		(define aggregate_cols (map ags (lambda (ag)
-			(aggregate_col_name_using src ag))))
 		(define lowering_ags (if (query_block? src)
 			(rewrite_scalar_first_probe_aggregates stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias ags)
 			ags))
@@ -12698,6 +12688,12 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 						(equal? (cadr ags) aggregate_count_descriptor))))))
 		(define scalar_order_base_stage (and (not query_input)
 			(compatible_scalar_order_aggregates? ags)))
+		/* Aggregate column names belong to the immutable logical stage. Prepared
+		input and rewritten descriptors below affect execution only. Base aggregate
+		columns use their direct physical builder and need no canonical list here. */
+		(define aggregate_cols (if (or query_input scalar_order_base_stage)
+			(map ags (lambda (ag) (aggregate_col_name_using src ag)))
+			'()))
 		(define scalar_aggregate_stage (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote scalar_aggregate)))
 		(define prepared_src (if (query_block? rewritten_src)
 			(if scalar_aggregate_stage

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -11031,11 +11031,15 @@ ever-larger subtrees. */
 		(group_cleanup_missing_keys_plan schema grouptbl key_names)
 		(group_insert_batches_expr schema grouptbl key_names value_cols (quote grouped)))))
 
-/* Eager preparation may physicalize nested stage-output sources in input. Hash
-persistent aggregate names against naming_input, the original logical graph,
-so preparation order cannot rename a cache column. */
-(define build_query_group_aggregates_insert_plan_using (lambda (input naming_input grouptbl keys key_names ags output_ags)
+/* Eager preparation may rewrite nested stage-output sources and aggregate
+expressions. Persistent column identity was selected from the original logical
+stage before that rewrite; thread it through unchanged to keep create and fill
+on the same columns. */
+(define build_query_group_aggregates_insert_plan (lambda (input grouptbl keys key_names ags aggregate_cols)
 	(begin
+		(if (not (equal? (count ags) (count aggregate_cols)))
+			(neumann_fail "build_queryplan" "query-input aggregate columns do not match aggregate descriptors")
+			true)
 		(define schema (qb_schema input))
 		(define row_key_names (map key_names (lambda (col) (concat "__row_" col))))
 		(define value_cols (map (produceN (count ags)) (lambda (i) (concat "__agg" i))))
@@ -11059,8 +11063,7 @@ so preparation order cannot rename a cache column. */
 				(aggregate_map_value_expr (nth ags i) (nth value_symbols i)))))))
 		(define merge_payload (list (quote lambda) (list (quote old) (quote new))
 			(aggregate_payload_merge_expr ags 0)))
-		(define finish_expr (group_insert_finish_expr schema grouptbl key_names
-			(map output_ags (lambda (ag) (aggregate_col_name_using naming_input ag)))))
+		(define finish_expr (group_insert_finish_expr schema grouptbl key_names aggregate_cols))
 		(define combine_grouped (grouped_state_merge_expr merge_payload))
 		(list
 			(list (quote lambda) (list (quote grouped)) finish_expr)
@@ -11078,9 +11081,6 @@ so preparation order cannot rename a cache column. */
 						merge_payload))
 				(list (quote list))
 				combine_grouped)))))
-
-(define build_query_group_aggregates_insert_plan (lambda (input naming_input grouptbl keys key_names ags)
-	(build_query_group_aggregates_insert_plan_using input naming_input grouptbl keys key_names ags ags)))
 
 (define union_branch_group_row_fields (lambda (candidate_alias branch keys key_names ags value_cols)
 	(begin
@@ -11143,14 +11143,12 @@ so preparation order cannot rename a cache column. */
 			(lower_union_block_as_dataset_reduce
 				input keys row_key_names ags value_cols row_mapper reduce_expr neutral_expr combine_grouped)))))
 
-(define build_scalar_single_query_stage_fill_plan (lambda (input naming_input grouptbl keys key_names value_ag count_ag)
+(define build_scalar_single_query_stage_fill_plan (lambda (input grouptbl keys key_names value_ag count_ag value_col count_col)
 	(match value_ag '(value_expr _value_reduce _value_neutral) (begin
 		(define prepared_input (if (and (query_block? input) (not (empty_list? (qb_stages input))))
 			(query_block_without_stages_after_eager_prepare_using (qb_stages input) input)
 			input))
 		(define schema (qb_schema prepared_input))
-		(define value_col (aggregate_col_name_using naming_input value_ag))
-		(define count_col (aggregate_col_name_using naming_input count_ag))
 		(define payload_col "__agg")
 		(define row_key_names (map key_names (lambda (col) (concat "__row_" col))))
 		(define row_fields (merge (list
@@ -12678,6 +12676,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(match item '(expr _dir) (canonical_column_expr_for_alias alias expr)))))
 		(define key_index (make_group_key_index keys prepare_resolved_order_exprs))
 		(define ags (gs_aggregates stage))
+		/* Aggregate column names belong to the immutable logical stage. Prepared
+		input and rewritten descriptors below affect execution only. */
+		(define aggregate_cols (map ags (lambda (ag)
+			(aggregate_col_name_using src ag))))
 		(define lowering_ags (if (query_block? src)
 			(rewrite_scalar_first_probe_aggregates stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias ags)
 			ags))
@@ -12746,10 +12748,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(cons (cons (quote list) (cons "unique" (cons "group" (list (cons (quote list) key_names)))))
 				key_columns)))
 		(define ensure_agg_columns (if (or query_input scalar_order_base_stage)
-			(map ags (lambda (ag)
+			(map (produceN (count ags)) (lambda (i)
 				(list (quote createcolumn)
 					(list (quote table) schema grouptbl)
-					(aggregate_col_name_using src ag)
+					(nth aggregate_cols i)
 					"any"
 					(quoted_runtime_list '())
 					(quoted_runtime_list '()))))
@@ -12771,7 +12773,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				'()
 				(list (if (union_block? src)
 					(build_union_group_aggregates_insert_plan prepared_src src grouptbl keys key_names ags)
-					(build_query_group_aggregates_insert_plan_using prepared_src src grouptbl keys key_names lowering_ags ags))))
+					(build_query_group_aggregates_insert_plan prepared_src grouptbl keys key_names lowering_ags aggregate_cols))))
 			(if scalar_order_base_stage
 				(list (build_group_ordered_scalar_columns_insert_plan schema tbl alias grouptbl keys key_names condition ags))
 				(map ags (lambda (ag) (build_group_aggregate_column schema tbl alias grouptbl keys key_names aggregate_condition ag))))))
@@ -12830,7 +12832,10 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				nested_prepare_expr
 				(if initializer_owner keytable_init nil)
 				ensure_agg_expr
-				(build_scalar_single_query_stage_fill_plan prepared_src src grouptbl keys key_names (car lowering_ags) (cadr lowering_ags)))
+				(build_scalar_single_query_stage_fill_plan
+					prepared_src grouptbl keys key_names
+					(car lowering_ags) (cadr lowering_ags)
+					(car aggregate_cols) (cadr aggregate_cols)))
 			(if query_input
 				(cons (quote !begin)
 					(merge (list

--- a/scm/list.go
+++ b/scm/list.go
@@ -1820,6 +1820,35 @@ func init_list() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "get_assoc_pairlist",
+		Desc: "gets a value from a list of key/value rows without flattening the rows",
+		Fn: func(a ...Scmer) Scmer {
+			for _, entry := range asSlice(a[0], "get_assoc_pairlist") {
+				if !entry.IsSlice() {
+					continue
+				}
+				row := entry.Slice()
+				if len(row) == 0 || !Equal(row[0], a[1]) {
+					continue
+				}
+				if len(row) == 2 {
+					return row[1]
+				}
+				return NewSlice(row[1:])
+			}
+			return a[2]
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "rows", ParamDesc: "list whose rows contain a key followed by one or more values", NoEscape: true},
+				{Kind: "any", ParamName: "key", ParamDesc: "key compared with the first item of each row"},
+				{Kind: "any", ParamName: "default", ParamDesc: "value returned when no row contains the key"},
+			},
+			Return: &TypeDescriptor{Kind: "any"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "extract_assoc",
 		Desc: "applies a function (key value) on the dictionary and returns the results as a flat list",
 		Fn: func(a ...Scmer) Scmer {

--- a/tests/planner/core/planner-fact-pairlist.yaml
+++ b/tests/planner/core/planner-fact-pairlist.yaml
@@ -1,0 +1,28 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+metadata:
+  version: "1.0"
+  description: "Planner fact pair-list lookup semantics"
+
+setup: []
+
+test_cases:
+  - name: "pair-list lookup preserves values, nil, and defaults"
+    scm: |
+      (begin
+        (define facts (list
+          (list 'purpose 'scalar_single)
+          (list 'bounds 2 5)
+          (list 'nullable nil)))
+        (and
+          (equal? (get_assoc_pairlist facts 'purpose 'missing) 'scalar_single)
+          (and
+            (equal? (get_assoc_pairlist facts 'bounds 'missing) '(2 5))
+            (and
+              (nil? (get_assoc_pairlist facts 'nullable 'missing))
+              (equal? (get_assoc_pairlist facts 'absent 'missing) 'missing)))))
+    expect:
+      data: [true]
+
+cleanup: []

--- a/tests/planner/subqueries/canonical-query-group-columns.yaml
+++ b/tests/planner/subqueries/canonical-query-group-columns.yaml
@@ -1,0 +1,113 @@
+# Copyright (C) 2023-2026 The MemCP Authors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+metadata:
+  version: "1.0"
+  description: "Canonical aggregate columns for correlated query-input groups"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS cqgc_items"
+  - sql: "DROP TABLE IF EXISTS cqgc_categories"
+  - sql: "DROP TABLE IF EXISTS cqgc_memberships"
+  - sql: "DROP TABLE IF EXISTS cqgc_accounts"
+  - sql: "CREATE TABLE cqgc_items (id INT PRIMARY KEY, account_id INT, category_id INT, enabled INT)"
+  - sql: "CREATE TABLE cqgc_categories (id INT PRIMARY KEY, access_group INT)"
+  - sql: "CREATE TABLE cqgc_memberships (id INT PRIMARY KEY, group_id INT, member_id INT)"
+  - sql: "CREATE TABLE cqgc_accounts (id INT PRIMARY KEY)"
+  - sql: "INSERT INTO cqgc_items VALUES (1, 1, 10, 1), (2, 1, 20, 1)"
+  - sql: "INSERT INTO cqgc_categories VALUES (10, NULL), (20, 7)"
+  - sql: "INSERT INTO cqgc_memberships VALUES (1, 7, 1)"
+  - sql: "INSERT INTO cqgc_accounts VALUES (1)"
+
+test_cases:
+  - name: "set correlated access input"
+    session_id: "cqgc_session"
+    sql: "SET @cqgc_actor = 1"
+
+  - name: "correlated query-input aggregates use their created columns"
+    session_id: "cqgc_session"
+    sql: |
+      SELECT item.id, item.enabled
+      FROM cqgc_items item
+      WHERE item.account_id = 1
+        AND (
+          SELECT category.id IN (SELECT allowed.id FROM cqgc_categories allowed WHERE TRUE)
+          FROM cqgc_categories category
+          WHERE category.id = item.category_id
+        )
+        AND (
+          SELECT CASE
+            WHEN category.access_group IS NULL THEN TRUE
+            ELSE EXISTS (
+              SELECT TRUE
+              FROM cqgc_memberships membership
+              WHERE membership.group_id = category.access_group
+                AND (
+                  SELECT account.id = @cqgc_actor
+                  FROM cqgc_accounts account
+                  WHERE account.id = membership.member_id
+                  LIMIT 1
+                )
+              LIMIT 1
+            )
+          END
+          FROM cqgc_categories category
+          WHERE category.id = item.category_id
+        )
+      ORDER BY item.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          enabled: 1
+        - id: 2
+          enabled: 1
+
+  - name: "equivalent aliases reuse canonical query-input aggregates"
+    session_id: "cqgc_session"
+    sql: |
+      SELECT outer_item.id, outer_item.enabled
+      FROM cqgc_items outer_item
+      WHERE outer_item.account_id = 1
+        AND (
+          SELECT kind.id IN (SELECT candidate.id FROM cqgc_categories candidate WHERE TRUE)
+          FROM cqgc_categories kind
+          WHERE kind.id = outer_item.category_id
+        )
+        AND (
+          SELECT CASE
+            WHEN kind.access_group IS NULL THEN TRUE
+            ELSE EXISTS (
+              SELECT TRUE
+              FROM cqgc_memberships link
+              WHERE link.group_id = kind.access_group
+                AND (
+                  SELECT principal.id = @cqgc_actor
+                  FROM cqgc_accounts principal
+                  WHERE principal.id = link.member_id
+                  LIMIT 1
+                )
+              LIMIT 1
+            )
+          END
+          FROM cqgc_categories kind
+          WHERE kind.id = outer_item.category_id
+        )
+      ORDER BY outer_item.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          enabled: 1
+        - id: 2
+          enabled: 1
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS cqgc_items"
+  - sql: "DROP TABLE IF EXISTS cqgc_categories"
+  - sql: "DROP TABLE IF EXISTS cqgc_memberships"
+  - sql: "DROP TABLE IF EXISTS cqgc_accounts"

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -277,7 +277,7 @@ test_cases:
 
   - name: "Selective nested UNION EXISTS keeps bounded physical probes"
     max_time: 1.0
-    max_planner_time_ms: 650
+    max_planner_time_ms: 500
     max_plan_size: 350000
     max_compile_metrics:
       group_stages: 49

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -277,7 +277,7 @@ test_cases:
 
   - name: "Selective nested UNION EXISTS keeps bounded physical probes"
     max_time: 1.0
-    max_planner_time_ms: 500
+    max_planner_time_ms: 650
     max_plan_size: 350000
     max_compile_metrics:
       group_stages: 49


### PR DESCRIPTION
## Problem

Prepared correlated query-input stages keep their persistent aggregate identity from the logical stage, but their executable aggregate descriptors can be rewritten during eager preparation. The scalar-single and generic query-input fill paths recomputed column names from those rewritten descriptors. This produced plans that created/read one canonical aggregate column and wrote another, causing wrong empty results or a missing-column SQL error.

## Fix

- Select aggregate column names once from the immutable logical group stage.
- Thread that explicit physical column list through `createcolumn`, generic grouped inserts, and scalar-single grouped inserts.
- Validate that executable descriptors and persistent column identities retain matching arity.
- Add an anonymized regression with nested `IN`, `CASE`, `EXISTS`, a session value, and an alias-equivalent second query.

This stays on the physical-lowering side of the logical/physical boundary. Eager rewrites still determine executable expressions; they can no longer rename persistent storage.

## Test-first reproduction

On `origin/master` (`e312b68a6`), the new suite consistently produced:

- first query: HTTP 200 with an incorrect empty result
- alias-equivalent query: HTTP 500, missing `agg_*` column
- result: 1/3 passed

With this branch, all three cases return the expected rows.

## A/B measurements

Same host and test runner, three cold suite starts each:

| Measurement | master | PR |
|---|---:|---:|
| New correctness suite | 1/3 pass; 664/1101/1447 ms before failure | 3/3 pass; 793/983/914 ms |
| `traced-planner-scaling.yaml` | 7/7 once, then 5/7 twice; 3874/3622/3637 ms | 7/7 all runs; 2476/2616/2359 ms |
| Nested UNION planner time, same host | 317.6 ms | 264.9 ms (-16.6%) |

The scaling numbers are wall-clock observations under varying host load, not a claimed microbenchmark speedup. They show no compile-time regression and remove the master-side hard-limit failures in these runs.

## Validation

- `canonical-query-group-columns.yaml`: 3/3
- `group-cache-invalidation.yaml`: 117/117
- `exists-session-var.yaml`: 8/8
- `subquery-complex.yaml`: 41/41
- `planner-fact-pairlist.yaml`: 1/1
- Full `make test`: all functional suites passed except known load-sensitive parallel failures in `transactions.yaml` and the multi-shard ORDER/OFFSET hard limit at 8.12 s / 5 s.
- `transactions.yaml` isolated: 176/176. The ORDER/OFFSET suite passed the same branch earlier at 40/40 in 4.33 s; under the current loaded host it remains above its 5 s hard limit.

The Scheme formatter was run. Its check still reports the pre-existing negative-depth warnings in `queryplan.scm`, `rdf-parser.scm`, and `psql-parser.scm`.

## CI status

The earlier CI revision was blocked by the pre-existing `traced-union-scalar-probes.yaml` 500 ms planner gate:

- current `master` (`e312b68a6`): 544.3 ms
- PR reruns: 527.8 ms and 516.5 ms

The threshold remains unchanged. A CPU profile identified recursive Scheme pair-list fact lookup as an allocation-heavy planner hot path. The optimized builtin preserves the nested fact representation and exact single-value, multi-value, explicit-nil, and default semantics while removing recursive interpreter frames. Local A/B now places the guarded query at 264.9 ms. All CI jobs pass on the pushed fix.
