### PR TITLE
Prevent cold shard data loss during rebuild

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -653,18 +653,8 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 			t.mu.Unlock()
 			tableLocked = false
 			newShardList := make([]*storageShard, len(origShardList))
-			// Track if any shard is still COLD to avoid triggering repartition logic
+			// These facts are derived from the completed shard generations below.
 			hasColdShard := false
-			// Count items using shard read locks to avoid races
-			getShardCount := func(s *storageShard) uint {
-				if s == nil {
-					return 0
-				}
-				s.mu.RLock()
-				c := uint(s.main_count) + uint(len(s.inserts)) - uint(s.deletions.Count())
-				s.mu.RUnlock()
-				return c
-			}
 			maincount := uint(0)
 			var sdone sync.WaitGroup
 			var shardErrMu sync.Mutex
@@ -681,10 +671,6 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 			}
 			if len(origShardList) <= workers {
 				for i, s := range origShardList {
-					if s != nil && s.GetState() == COLD {
-						hasColdShard = true
-					}
-					maincount += getShardCount(s)
 					go func(i int, s *storageShard) {
 						defer func() {
 							if r := recover(); r != nil {
@@ -726,10 +712,6 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 					}()
 				}
 				for i, s := range origShardList {
-					if s != nil && s.GetState() == COLD {
-						hasColdShard = true
-					}
-					maincount += getShardCount(s)
 					jobs <- job{i: i, s: s}
 				}
 				close(jobs)
@@ -745,6 +727,26 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				t.maintenanceMu.Unlock()
 				rebuildClaimed = false
 				return
+			}
+			// Recompute both facts after the workers finish. A forced rebuild can
+			// turn an initially cold shard into an authoritative warm generation;
+			// conversely, an unchanged shard can become cold after the snapshot.
+			// Repartitioning must use only the completed generations, never the
+			// pre-rebuild zero counters of cold shards.
+			hasColdShard = false
+			maincount = 0
+			for _, shard := range newShardList {
+				if shard == nil {
+					continue
+				}
+				shard.mu.RLock()
+				cold := shard.srState == COLD
+				count := uint(shard.main_count) + uint(len(shard.inserts)) - uint(shard.deletions.Count())
+				shard.mu.RUnlock()
+				maincount += count
+				if cold {
+					hasColdShard = true
+				}
 			}
 
 			t.mu.Lock()
@@ -769,35 +771,37 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				t.Shards = newShardList
 			}
 
-			// Update per-column statistics from rebuilt shards.
-			// The new shards have freshly compressed columns with accurate stats.
-			rowEst := uint64(t.CountEstimate())
-			for ci := range t.Columns {
-				var distinctSum uint64
-				colName := t.Columns[ci].Name
-				for _, shard := range newShardList {
-					if shard == nil {
-						continue
+			if !hasColdShard {
+				// Update per-column statistics only when every rebuilt shard has
+				// authoritative in-memory counters and column statistics.
+				rowEst := uint64(t.CountEstimate())
+				for ci := range t.Columns {
+					var distinctSum uint64
+					colName := t.Columns[ci].Name
+					for _, shard := range newShardList {
+						if shard == nil {
+							continue
+						}
+						// columns are populated during rebuild - access directly
+						if cs, ok := shard.columns[colName]; ok && cs != nil {
+							distinctSum += uint64(cs.DistinctCount())
+						}
 					}
-					// columns are populated during rebuild — access directly
-					if cs, ok := shard.columns[colName]; ok && cs != nil {
-						distinctSum += uint64(cs.DistinctCount())
+					atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)
+					atomic.StoreUint64(&t.Columns[ci].RowEstimate, rowEst)
+					// Planner statistics are properties of persisted base columns. Reading
+					// hidden/cache or computed storages can initialize maintenance state and
+					// must never be part of a statistics-only rebuild pass.
+					if !strings.HasPrefix(t.Name, ".") && !t.Columns[ci].IsTemp && t.Columns[ci].Computor.IsNil() && len(t.Columns[ci].OrcSortCols) == 0 {
+						t.Columns[ci].PlannerStats.Store(
+							collectRebuiltColumnPlannerStatistics(newShardList, colName))
+					} else {
+						t.Columns[ci].PlannerStats.Store(nil)
 					}
 				}
-				atomic.StoreUint64(&t.Columns[ci].DistinctEstimate, distinctSum)
-				atomic.StoreUint64(&t.Columns[ci].RowEstimate, rowEst)
-				// Planner statistics are properties of persisted base columns. Reading
-				// hidden/cache or computed storages can initialize maintenance state and
-				// must never be part of a statistics-only rebuild pass.
-				if !strings.HasPrefix(t.Name, ".") && !t.Columns[ci].IsTemp && t.Columns[ci].Computor.IsNil() && len(t.Columns[ci].OrcSortCols) == 0 {
-					t.Columns[ci].PlannerStats.Store(
-						collectRebuiltColumnPlannerStatistics(newShardList, colName))
-				} else {
-					t.Columns[ci].PlannerStats.Store(nil)
-				}
+				t.collectStatisticsFromShards(newShardList)
 			}
 			t.publishShowColumnsSnapshot()
-			t.collectStatisticsFromShards(newShardList)
 
 			// Collect replaced shards for deferred cleanup (see comment above).
 			if len(replaced) > 0 {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2570,9 +2570,24 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 
 // rebuild main storage from main+delta
 func (t *storageShard) rebuild(all bool) *storageShard {
+	// An unchanged cold shard already is a complete persistent generation:
+	// its UUID references both the column files and any unreplayed WAL. Keep it
+	// byte-for-byte instead of loading it merely for a periodic rebuild or
+	// shutdown. A forced rebuild must materialize it before continuing.
+	for {
+		t.mu.Lock()
+		if t.srState != COLD {
+			break
+		}
+		if !all {
+			t.mu.Unlock()
+			return t
+		}
+		t.mu.Unlock()
+		t.ensureLoaded()
+	}
 
 	// concurrency! when rebuild is run in background, inserts and deletions into and from old delta storage must be duplicated to the ongoing process
-	t.mu.Lock()
 	locked := true
 	removedFromCache := false
 	defer func() {

--- a/tests/storage/persistence/safe-shard-restart.yaml
+++ b/tests/storage/persistence/safe-shard-restart.yaml
@@ -7,7 +7,9 @@ setup:
   - scm: (settings "ShardSize" 3)
   - sql: "DROP TABLE IF EXISTS safe_rollover"
   - sql: "DROP TABLE IF EXISTS safe_copy_rollover"
+  - sql: "DROP TABLE IF EXISTS safe_cold_rebuild"
   - sql: "CREATE TABLE safe_rollover (id INT PRIMARY KEY, note TEXT) ENGINE=SAFE"
+  - sql: "CREATE TABLE safe_cold_rebuild (id INT PRIMARY KEY, note TEXT) ENGINE=SAFE"
 
 test_cases:
   - name: "Insert enough rows to create multiple free shards"
@@ -22,6 +24,20 @@ test_cases:
       rows: 1
       data:
         - cnt: 8
+
+  - name: "Seed a multi-shard table that stays cold after restart"
+    scm: |
+      (insert (table "memcp-tests" "safe_cold_rebuild") '("id" "note")
+        (map (produceN 8) (lambda (i)
+          (list (+ i 1) (concat "cold-" i)))))
+
+  - name: "Cold-rebuild source is complete before restart"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM safe_cold_rebuild"
+    expect:
+      rows: 1
+      data:
+        - cnt: 8
+          checksum: 36
 
   - name: "Import COPY stream across shard rollover"
     scm: |
@@ -79,9 +95,46 @@ test_cases:
       data:
         - note: "copy-7"
 
+  - name: "Incremental rebuild preserves cold persisted shards"
+    scm: '(rebuild (table "memcp-tests" "safe_cold_rebuild") false false)'
+
+  - name: "All cold-shard rows remain visible after rebuild"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM safe_cold_rebuild"
+    expect:
+      rows: 1
+      data:
+        - cnt: 8
+          checksum: 36
+
+  - name: "Publish the generation rebuilt from cold shards"
+    sql: "SHUTDOWN"
+
+  - name: "Forced rebuild loads cold shards before repartition"
+    scm: '(rebuild (table "memcp-tests" "safe_cold_rebuild") true true)'
+
+  - name: "Forced cold-shard repartition preserves every row"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM safe_cold_rebuild"
+    expect:
+      rows: 1
+      data:
+        - cnt: 8
+          checksum: 36
+
+  - name: "Publish the forced cold-shard repartition"
+    sql: "SHUTDOWN"
+
+  - name: "Forced cold-shard repartition survives restart"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM safe_cold_rebuild"
+    expect:
+      rows: 1
+      data:
+        - cnt: 8
+          checksum: 36
+
   - name: "Restore default shard size"
     scm: (settings "ShardSize" 60000)
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS safe_rollover"
   - sql: "DROP TABLE IF EXISTS safe_copy_rollover"
+  - sql: "DROP TABLE IF EXISTS safe_cold_rebuild"


### PR DESCRIPTION
## Root cause

Persisted shards start cold after restart and intentionally keep their in-memory `main_count` uninitialized until data is accessed. Incremental rebuild replaced an unchanged cold shard with a new in-memory wrapper whose count was zero. A later repartition therefore treated the complete persistent generation as empty; if one shard happened to be warm, publication retained only that shard.

## Fix

- carry an unchanged cold shard forward byte-for-byte with the same UUID, column files, and unreplayed WAL
- perform no column load merely for periodic rebuild or shutdown
- preserve existing table statistics while any carried shard remains cold
- for `all=true`, fully materialize cold shards before rebuilding
- recompute post-rebuild cardinality and cold state from the completed shard generation before deciding whether repartition is legal
- never repartition from uninitialized cold-shard counters

## Regression coverage

The YAML persistence suite creates a three-shard SAFE table and covers both paths after restart:

1. `all=false, repartition=false` carries the cold generation without loading it.
2. `all=true, repartition=true` loads the cold generation before repartition.

Both paths verify row count 8 and checksum 36, publish with `SHUTDOWN`, restart, and verify the same values again. Before the fix, the incremental reproducer retained only 3/8 rows with checksum 6.

## Validation

- `safe-shard-restart.yaml`: 19/19
- `rebuild-concurrent.yaml`: 16/16
- `repartition-concurrent.yaml`: 143/143
- `rebuild-kill-shutdown.yaml`: 18/18
- full hook-equivalent YAML/Scheme/Go suite: passed (`MEMCP_FAIL_FAST=0 ./git-pre-commit`)

No Go regression tests were added; shutdown, restart, cold carry-forward, forced rebuild, and repartition are covered through `tests/`.