### PR TITLE
Buffer reconstructible schema cache updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ MemCP supports several storage engines, selectable per table via `CREATE TABLE .
 | `safe` | Persisted to disk (default) | Yes | All writes are immediately durable; data is evicted from RAM when memory is tight and reloaded on demand. |
 | `logged` | Persisted to disk | Yes | Like `safe` but uses a write-ahead log for faster writes with the same durability guarantee. |
 | `sloppy` | Persisted to disk | Yes | Data is written to disk asynchronously; faster writes but brief data loss on crash. |
-| `memory` | RAM only | No | Data lives entirely in RAM and is never written to disk. Not registered with the memory manager — data is never evicted. Lost on restart. |
-| `cache` | Schema only (RAM data) | Yes | Like `memory`, data lives in RAM and is never written to disk. Unlike `memory`, the data **is** registered with the memory manager and will be automatically cleared when MemCP approaches its memory limit. The table schema is always persisted; after eviction the table is accessible but empty. Useful for derived or precomputed data that can be regenerated on demand. |
+| `memory` | RAM only | No | Data lives entirely in RAM and is never written to disk. Its schema and optional `oninit` callback are persisted; the callback can rebuild the empty data generation after restart. Not registered with the memory manager, so data is never evicted. |
+| `cache` | Reconstructible RAM data | Yes | Data lives in RAM and can be cleared under memory pressure. Hidden query-helper table and temporary-column creation buffer their schema update instead of writing the full catalog immediately; the next schema publication or rebuild includes the definition and closed `oninit` callback. The callback rebuilds an empty generation after restart. |
 
 ### **🔧 Developer-Friendly**
 - **Comprehensive test suite** with 2470+ SQL tests across 100+ test suites

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -12828,9 +12828,9 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				base_group_fill
 				(list (quote lambda) '() finalize_group_fill))))
 		(define create_options (if (nil? initial_fill_expr)
-			(quoted_runtime_list '("engine" "memory"))
+			(quoted_runtime_list '("engine" "cache"))
 			(list (quote list)
-				"engine" "memory"
+				"engine" "cache"
 				"oninit" (list (quote lambda) '() initial_fill_expr))))
 		(define group_cache_created (symbol "__group_cache_created"))
 		(define keytable_init (list

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -796,6 +796,96 @@ type Proc struct {
 	NumberedOnly bool
 }
 
+// CloseProcedure snapshots explicit captures of a procedure without retaining
+// its request-local environment. The optimizer represents a capture from the
+// procedure's creation frame as (outer expr). Resolve only those forms in the
+// current procedure body; nested lambdas keep their own outer references,
+// which bind to frames created when the closed procedure runs.
+func CloseProcedure(value Scmer) Scmer {
+	if value.GetTag() != tagProc {
+		return value
+	}
+	proc := *value.Proc()
+	if proc.En == nil || proc.En == &Globalenv {
+		return value
+	}
+	callFrame := &Env{Outer: proc.En}
+	bound := make(map[Symbol]struct{})
+	if proc.Params.IsSlice() {
+		for _, param := range proc.Params.Slice() {
+			if param.IsSymbol() {
+				bound[param.Symbol()] = struct{}{}
+			}
+		}
+	} else if proc.Params.IsSymbol() {
+		bound[proc.Params.Symbol()] = struct{}{}
+	}
+	collectProcedureBindings(proc.Body, bound)
+	proc.Body = closeProcedureCaptures(proc.Body, callFrame, bound)
+	proc.En = &Globalenv
+	return NewProcStruct(proc)
+}
+
+func collectProcedureBindings(expression Scmer, bound map[Symbol]struct{}) {
+	if expression.IsSourceInfo() {
+		collectProcedureBindings(expression.SourceInfo().value, bound)
+		return
+	}
+	if !expression.IsSlice() {
+		return
+	}
+	items := expression.Slice()
+	if len(items) > 0 && items[0].IsSymbol() {
+		switch items[0].String() {
+		case "lambda", "quote":
+			return
+		case "define", "set":
+			if len(items) > 1 && items[1].IsSymbol() {
+				bound[items[1].Symbol()] = struct{}{}
+			}
+		}
+	}
+	for _, item := range items {
+		collectProcedureBindings(item, bound)
+	}
+}
+
+func closeProcedureCaptures(expression Scmer, callFrame *Env, bound map[Symbol]struct{}) Scmer {
+	if expression.IsSourceInfo() {
+		source := *expression.SourceInfo()
+		source.value = closeProcedureCaptures(source.value, callFrame, bound)
+		return NewSourceInfo(source)
+	}
+	if expression.IsSymbol() {
+		symbol := expression.Symbol()
+		if _, local := bound[symbol]; !local {
+			if binding := callFrame.Outer.FindRead(symbol); binding != nil && binding != &Globalenv {
+				if captured, ok := binding.Vars[symbol]; ok {
+					return captured
+				}
+			}
+		}
+		return expression
+	}
+	if !expression.IsSlice() {
+		return expression
+	}
+	items := expression.Slice()
+	if len(items) > 0 && items[0].IsSymbol() {
+		switch items[0].String() {
+		case "outer":
+			return Eval(expression, callFrame)
+		case "lambda", "quote":
+			return expression
+		}
+	}
+	closed := make([]Scmer, len(items))
+	for i, item := range items {
+		closed[i] = closeProcedureCaptures(item, callFrame, bound)
+	}
+	return NewSlice(closed)
+}
+
 // helper pseudo type to optimize parameter reading from indices
 type NthLocalVar uint8 // equals to (var i)
 

--- a/storage/blob-refcount.go
+++ b/storage/blob-refcount.go
@@ -88,7 +88,7 @@ func (db *database) ensureBlobTable() *table {
 	t.createColumnLocked("hash", "TEXT", nil, nil)
 	t.createColumnLocked("refcount", "INT", nil, nil)
 	db.tables.Set(t)
-	db.saveLockedWithDurabilityAndUnlock(true)
+	db.saveLockedAndUnlock(schemaSaveFsync)
 	state.table.Store(t)
 	registerCreatedTable(t)
 	return t

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -146,7 +146,11 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 			if metadataChanged {
 				t.schema.schemalock.Lock()
 				metadataLocked = true
-				t.finishSchemaMutationLocked()
+				mode := t.schemaSaveMode()
+				if c.IsTemp {
+					mode = schemaSaveBuffered
+				}
+				t.finishSchemaMutationLocked(mode)
 				metadataLocked = false
 			}
 			return
@@ -267,6 +271,7 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
 	found := false
 	paramsChanged := false
+	isTemp := false
 	t.schema.schemalock.Lock()
 	for i, c := range t.Columns {
 		if c.Name == name {
@@ -282,6 +287,7 @@ func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, so
 			t.Columns[i].OrcMapFn = mapFn
 			t.Columns[i].OrcReduceFn = reduceFn
 			t.Columns[i].OrcReduceInit = reduceInit
+			isTemp = c.IsTemp
 			found = true
 			break
 		}
@@ -291,11 +297,15 @@ func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, so
 		panic("ComputeOrderedColumn: column " + t.Name + "." + name + " does not exist")
 	}
 
-	// Register triggers while the table-local DDL contract is held and persist
-	// the new ORC metadata atomically into schema.json before any rebuild can
-	// publish a stale shard snapshot of this table.
+	// Register triggers while the table-local DDL contract is held. Durable
+	// columns publish synchronously; reconstructible temp metadata joins the next
+	// complete schema snapshot.
 	t.registerORCTriggers(name)
-	t.finishSchemaMutationLocked()
+	mode := t.schemaSaveMode()
+	if isTemp {
+		mode = schemaSaveBuffered
+	}
+	t.finishSchemaMutationLocked(mode)
 
 	// Ensure every shard has an ORC proxy (lazy: no eager recompute).
 	//

--- a/storage/database.go
+++ b/storage/database.go
@@ -51,6 +51,7 @@ type database struct {
 	savePending     []byte        `json:"-"`
 	savePendingSync bool          `json:"-"`
 	savePanic       any           `json:"-"`
+	schemaDirty     atomic.Bool   `json:"-"`
 	blobRefs        *blobRefState `json:"-"`
 
 	// lazy-loading/shared-resource state (not serialized)
@@ -91,6 +92,21 @@ type schemaWriteOptions interface {
 	// This has the same atomic-generation contract as WriteSchema. durable also
 	// requires data and namespace metadata to be stable before returning.
 	WriteSchemaWithMode(schema []byte, durable bool)
+}
+
+type schemaSaveMode uint8
+
+const (
+	schemaSaveFsync schemaSaveMode = iota
+	schemaSaveNoFsync
+	schemaSaveBuffered
+)
+
+func schemaSaveModeForDurability(durable bool) schemaSaveMode {
+	if durable {
+		return schemaSaveFsync
+	}
+	return schemaSaveNoFsync
 }
 
 func normalizeTempLookupName(dbName string, name string) string {
@@ -394,26 +410,47 @@ func (db *database) save() {
 	}
 	db.schemalock.RLock()
 	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
+	// Buffered mutations after this snapshot must leave the catalog dirty.
+	// They need the exclusive schema lock and therefore cannot race this store.
+	db.schemaDirty.Store(false)
 	db.schemalock.RUnlock()
-	db.commitSchemaSnapshot(jsonbytes, true)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				db.schemaDirty.Store(true)
+				panic(r)
+			}
+		}()
+		db.commitSchemaSnapshot(jsonbytes, true)
+	}()
 	// shards are written while rebuild
 }
 
-// saveLockedAndUnlock snapshots the schema while schemalock is held, then
-// releases schemalock before performing the synchronous schema write.
-// Callers must already hold db.schemalock.Lock().
-func (db *database) saveLockedAndUnlock() {
-	db.saveLockedWithDurabilityAndUnlock(true)
-}
-
-func (db *database) saveLockedWithDurabilityAndUnlock(durable bool) {
+// saveLockedAndUnlock publishes according to mode and always releases
+// schemalock. Buffered temp metadata is immediately visible in memory; a later
+// synchronous schema save or rebuild includes it in its complete snapshot.
+func (db *database) saveLockedAndUnlock(mode schemaSaveMode) {
 	if db.srState == COLD {
 		db.schemalock.Unlock()
 		return
 	}
+	if mode == schemaSaveBuffered {
+		db.schemaDirty.Store(true)
+		db.schemalock.Unlock()
+		return
+	}
 	jsonbytes, _ := json.MarshalIndent(db, "", "  ")
+	// Clear while the snapshot is protected. A later buffered mutation takes
+	// schemalock exclusively and sets dirty again after this generation.
+	db.schemaDirty.Store(false)
 	db.schemalock.Unlock()
-	db.commitSchemaSnapshot(jsonbytes, durable)
+	defer func() {
+		if r := recover(); r != nil {
+			db.schemaDirty.Store(true)
+			panic(r)
+		}
+	}()
+	db.commitSchemaSnapshot(jsonbytes, mode == schemaSaveFsync)
 }
 
 // ensureLoaded loads schema.json into the database struct exactly once.
@@ -1098,7 +1135,11 @@ func CreateTable(schema, name string, pm PersistencyMode, ifnotexists bool) (*ta
 		db.schemalock.Unlock()
 		return t, false
 	}
-	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+	mode := t.schemaSaveMode()
+	if t.isEphemeralQueryTable() {
+		mode = schemaSaveBuffered
+	}
+	db.saveLockedAndUnlock(mode)
 	registerCreatedTable(t)
 	return t, true
 }
@@ -1170,7 +1211,7 @@ func DropTable(schema, name string, ifexists bool) {
 	if name == ".blobs" {
 		db.blobRefState().table.Store(nil)
 	}
-	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+	db.saveLockedAndUnlock(t.schemaSaveMode())
 	// fire AfterDropTable triggers after releasing schemalock (avoids deadlock on cascading drops)
 	t.ExecuteTableLifecycleTriggers(AfterDropTable)
 
@@ -1215,7 +1256,7 @@ func RenameTable(schema, oldname, newname string) {
 	db.tables.Remove(oldname)
 	t.Name = newname
 	db.tables.Set(t)
-	db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+	db.saveLockedAndUnlock(t.schemaSaveMode())
 }
 
 // keytableCleanup is called by the CacheManager when evicting a temp keytable.
@@ -1243,7 +1284,7 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 			return false
 		}
 		db.tables.Remove(tbl.Name)
-		db.saveLockedWithDurabilityAndUnlock(tbl.PersistencyMode == Safe)
+		db.saveLockedAndUnlock(tbl.schemaSaveMode())
 	} else if !tbl.beginCacheEviction() {
 		return false
 	}

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -902,7 +902,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	// must atomically name the new PShards before any old shard file is released;
 	// a publication panic therefore leaves oldshards intact and recoverable.
 	t.schema.schemalock.Lock()
-	t.schema.saveLockedWithDurabilityAndUnlock(t.schemaWriteDurable())
+	t.schema.saveLockedAndUnlock(t.schemaSaveMode())
 
 	// Nil out old shards after the schema is saved, so no FreeShard
 	// code path can reference them. At this point, ShardMode is Partition,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1284,17 +1284,15 @@ func Init(en scm.Env) {
 			// result stays race-free under concurrent creators.
 			if ifnotexists {
 				if existing := db.tables.Get(tblName); existing != nil {
-					// A table is published before oninit so the initializer can access it.
-					// Do not let another creator return while that initializer is running.
-					if !existing.creationMu.TryLock() {
-						existing.creationMu.Lock()
+					if existing.OnInit != nil || existing.onInitComplete {
+						// This also reruns persisted oninit for data-empty MEMORY/CACHE
+						// tables after restart. The local barrier affects no other table.
+						existing.awaitCreationInitialization()
+						atomic.StoreUint64(&existing.lastAccessed, uint64(time.Now().UnixNano()))
+						return scm.NewBool(false)
 					}
-					existing.creationMu.Unlock()
-					if existing.creationPanic != nil {
-						panic(existing.creationPanic)
-					}
-					atomic.StoreUint64(&existing.lastAccessed, uint64(time.Now().UnixNano()))
-					return scm.NewBool(false)
+					// Legacy CACHE/MEMORY schemas did not persist oninit. Parse this
+					// invocation so its current closed callback can repair the table.
 				}
 			}
 
@@ -1341,6 +1339,10 @@ func Init(en scm.Env) {
 			newTable.Charset = charset
 			newTable.Comment = comment
 			newTable.Auto_increment = autoIncrement
+			if !oninit.IsNil() {
+				closedOnInit := scm.CloseProcedure(oninit)
+				newTable.OnInit = &closedOnInit
+			}
 
 			for _, coldef := range mustScmerSlice(a[2], "columns") {
 				def := mustScmerSlice(coldef, "column definition")
@@ -1398,16 +1400,16 @@ func Init(en scm.Env) {
 				// the table already exists, "created=false" is the only signal the
 				// caller needs to skip collect/materialization work.
 				atomic.StoreUint64(&existing.lastAccessed, uint64(time.Now().UnixNano()))
-				db.schemalock.Unlock()
+				if existing.OnInit == nil && !oninit.IsNil() {
+					closedOnInit := scm.CloseProcedure(oninit)
+					existing.OnInit = &closedOnInit
+					db.saveLockedAndUnlock(schemaSaveBuffered)
+				} else {
+					db.schemalock.Unlock()
+				}
 				// The competing creator may have published the table after our
-				// optimistic probe. It owns creationMu until all initializers finish.
-				if !existing.creationMu.TryLock() {
-					existing.creationMu.Lock()
-				}
-				existing.creationMu.Unlock()
-				if existing.creationPanic != nil {
-					panic(existing.creationPanic)
-				}
+				// optimistic probe. Its table-local barrier includes oninit.
+				existing.awaitCreationInitialization()
 				if !ifnotexists {
 					panic("Table " + tblName + " already exists")
 				}
@@ -1440,7 +1442,11 @@ func Init(en scm.Env) {
 					}
 				}
 			}
-			db.saveLockedWithDurabilityAndUnlock(newTable.PersistencyMode == Safe)
+			mode := newTable.schemaSaveMode()
+			if newTable.isEphemeralQueryTable() {
+				mode = schemaSaveBuffered
+			}
+			db.saveLockedAndUnlock(mode)
 			registerCreatedTable(newTable)
 			func() {
 				defer func() {
@@ -1451,6 +1457,7 @@ func Init(en scm.Env) {
 				if !oninit.IsNil() {
 					scm.Apply(oninit)
 				}
+				newTable.onInitComplete = true
 				executeRegisteredCreateTableTriggers(newTable)
 			}()
 			if newTable.creationPanic != nil {
@@ -1463,7 +1470,7 @@ func Init(en scm.Env) {
 				{Kind: "string", ParamName: "schema", ParamDesc: "name of the existing database that will contain the table"},
 				{Kind: "string", ParamName: "table", ParamDesc: "name of the table to create"},
 				{Kind: "list", ParamName: "cols", ParamDesc: "column and constraint definitions: (\"column\" name type dimensions typeparams), (\"unique\" name columns), or (\"foreign\" name local_columns referenced_table referenced_columns update_mode delete_mode). dimensions is a list of integer type dimensions. typeparams is an alternating key/value list supporting primary (bool), unique (bool), auto_increment (bool), null (bool), default (any), update (expression), comment (string), collate (string), temp (bool), filtercols (string list), filter (function), sortcols (string list), sortdirs (bool list), partitioncount (integer), mapcols (string list), mapfn (function), reducefn (function), and reduceinit (any). Column lists are string lists; foreign-key modes are restrict, cascade, or set null"},
-				{Kind: "list", ParamName: "options", ParamDesc: "alternating key/value list; supported keys are engine (safe, logged, sloppy, or memory), collation (string), charset (string), comment (string), auto_increment (non-negative integer), and oninit (zero-argument function run exactly once and synchronously after first creation; concurrent if-not-exists callers wait for it and do not run it again)"},
+				{Kind: "list", ParamName: "options", ParamDesc: "alternating key/value list; supported keys are engine (safe, logged, sloppy, memory, or cache), collation (string), charset (string), comment (string), auto_increment (non-negative integer), and oninit (closed zero-argument function run synchronously once per data generation; concurrent if-not-exists callers wait for it, and memory/cache tables persist the callback so the first idempotent createtable after restart repopulates their empty data)"},
 				{Kind: "bool", ParamName: "ifnotexists", ParamDesc: "when true, return false instead of failing if the table exists; if another caller is still creating it, wait for that caller's after-create-table initialization before returning false", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool", ParamDesc: "true when this call created and initialized the table, false when ifnotexists reused an initialized table"},
@@ -1596,7 +1603,7 @@ func Init(en scm.Env) {
 
 			t.Unique = append(t.Unique, uniqueKey{name, cols})
 			t.publishShowColumnsSnapshot()
-			t.schema.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+			t.schema.saveLockedAndUnlock(t.schemaSaveMode())
 
 			return scm.NewBool(true)
 		},
@@ -1636,7 +1643,7 @@ func Init(en scm.Env) {
 			// auto-generate system triggers for FK enforcement
 			installFKTriggers(db, t1, t2, k)
 
-			db.saveLockedWithDurabilityAndUnlock(t1.PersistencyMode == Safe || t2.PersistencyMode == Safe)
+			db.saveLockedAndUnlock(schemaSaveModeForDurability(t1.PersistencyMode == Safe || t2.PersistencyMode == Safe))
 
 			return scm.NewBool(true)
 		},
@@ -3046,7 +3053,7 @@ func Init(en scm.Env) {
 			// Idempotent: replace any existing trigger with the same name
 			t.RemoveTrigger(name)
 			t.AddTrigger(trigger)
-			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+			db.saveLockedAndUnlock(t.schemaSaveMode())
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,

--- a/storage/table.go
+++ b/storage/table.go
@@ -147,10 +147,19 @@ func (c *column) OrcFirstSortDesc() bool {
 //
 //	Memory:
 //	  Non-persistent. ALL data is held in RAM only and is LOST on any
-//	  shutdown or restart. This is intentional and by design.
+//	  shutdown or restart. The schema is persisted synchronously. A closed
+//	  oninit callback is part of that schema and repopulates the empty data on
+//	  the first idempotent createtable guard after restart.
 //	  ⚠️  ALTER TABLE … ENGINE=memory on a persisted table PERMANENTLY
 //	  DELETES all on-disk files with no possibility of recovery.
 //	  Never use for production data that must survive a restart.
+//
+//	Cache:
+//	  Reconstructible RAM-only data managed by the global cache manager. Hidden
+//	  query-helper tables use buffered schema creation: creation returns without
+//	  schema I/O, and the table definition plus its closed oninit callback joins
+//	  the next complete schema save or rebuild. On restart, the first idempotent
+//	  createtable guard runs that callback before exposing the empty generation.
 //
 // ENGINE TRANSITION DATA SAFETY:
 //   - persisted (Safe/Logged/Sloppy) → Memory:  IRREVERSIBLE disk deletion.
@@ -289,6 +298,7 @@ type table struct {
 	Foreign         []foreignKey         // foreign keys
 	Triggers        []TriggerDescription // triggers on this table
 	PersistencyMode PersistencyMode      /* 0 = safe (default), 1 = sloppy, 2 = memory */
+	OnInit          *scm.Scmer           `json:"oninit,omitempty"` // closed callback that repopulates data-empty engines after restart
 	cacheUsers      int64                // atomic; -1 while/after CacheManager eviction, otherwise active trigger users
 	// LOCK ORDER CONTRACT:
 	//   1. db.schemalock
@@ -352,8 +362,9 @@ type table struct {
 
 	// creationMu is held while a newly published table runs its synchronous
 	// oninit hook. Concurrent if-not-exists calls wait on the same barrier.
-	creationMu    sync.Mutex
-	creationPanic any
+	creationMu     sync.Mutex
+	creationPanic  any
+	onInitComplete bool // guarded by creationMu; deliberately resets after restart
 
 	// cacheInitMu guards the one-time initializer for canonical planner caches.
 	// The table object is removed on cache eviction, so initialization state has
@@ -402,6 +413,41 @@ type table struct {
 	repartitionPendingMu         sync.Mutex
 	repartitionPendingDels       []translatedRecid
 	repartitionPendingSourceDels []pendingSourceDelete
+}
+
+// awaitCreationInitialization is the idempotent createtable barrier for an
+// already-published table. Persisted MEMORY/CACHE schemas deliberately reload
+// without data, so their closed oninit callback runs again on the first
+// createtable guard after every restart.
+func (t *table) awaitCreationInitialization() {
+	if !t.creationMu.TryLock() {
+		t.creationMu.Lock()
+	}
+	defer t.creationMu.Unlock()
+	if t.creationPanic != nil {
+		panic(t.creationPanic)
+	}
+	if t.PersistencyMode != Memory && t.PersistencyMode != Cache {
+		t.onInitComplete = true
+		return
+	}
+	if t.onInitComplete {
+		return
+	}
+	if t.OnInit == nil {
+		t.onInitComplete = true
+		return
+	}
+	func() {
+		defer func() {
+			t.creationPanic = recover()
+		}()
+		scm.Apply(*t.OnInit)
+		t.onInitComplete = true
+	}()
+	if t.creationPanic != nil {
+		panic(t.creationPanic)
+	}
 }
 
 func (t *table) enterMutationOwner() {
@@ -756,15 +802,14 @@ func (t *table) isEphemeralQueryTable() bool {
 	return strings.HasPrefix(t.Name, ".") && t.PersistencyMode == Cache
 }
 
-// schemaWriteDurable reports whether schema.json must be flushed with Sync for
-// DDL on this table. Safe tables keep the full durability contract; other
-// engines still write schema.json synchronously, but without fsync.
-func (t *table) schemaWriteDurable() bool {
-	return t.PersistencyMode == Safe
+// schemaSaveMode selects the synchronous persistence guarantee for ordinary
+// DDL. Callers explicitly override it for reconstructible temp metadata.
+func (t *table) schemaSaveMode() schemaSaveMode {
+	return schemaSaveModeForDurability(t.PersistencyMode == Safe)
 }
 
-func (t *table) finishSchemaMutationLocked() {
-	t.schema.saveLockedWithDurabilityAndUnlock(t.schemaWriteDurable())
+func (t *table) finishSchemaMutationLocked(mode schemaSaveMode) {
+	t.schema.saveLockedAndUnlock(mode)
 }
 
 // isHiddenFromShowTables implements the SQL metadata contract for internal
@@ -1522,7 +1567,11 @@ func (t *table) createColumnDDLLocked(name string, typ string, typdimensions []i
 	} else {
 		t.publishShowColumnsSnapshot()
 	}
-	t.finishSchemaMutationLocked()
+	mode := t.schemaSaveMode()
+	if cp.IsTemp {
+		mode = schemaSaveBuffered
+	}
+	t.finishSchemaMutationLocked(mode)
 	if cp.IsTemp {
 		t.registerTempColumn(cp)
 	}
@@ -1561,7 +1610,7 @@ func (t *table) dropColumnDDLLocked(name string) bool {
 			} else {
 				t.publishShowColumnsSnapshot()
 			}
-			t.finishSchemaMutationLocked()
+			t.finishSchemaMutationLocked(t.schemaSaveMode())
 			// Fire lifecycle hooks after unlock so dependents (e.g. prejoin caches)
 			// can invalidate without lock-ordering cycles.
 			t.ExecuteTableLifecycleTriggers(AfterDropColumn)

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -398,7 +398,7 @@ func (db *database) dropTrigger(name string) bool {
 			continue
 		}
 		if t.RemoveTrigger(name) {
-			db.saveLockedWithDurabilityAndUnlock(t.PersistencyMode == Safe)
+			db.saveLockedAndUnlock(t.schemaSaveMode())
 			t.ddlMu.Unlock()
 			return true
 		}

--- a/tests/planner/aggregates/group-cache-invalidation.yaml
+++ b/tests/planner/aggregates/group-cache-invalidation.yaml
@@ -104,7 +104,7 @@ test_cases:
       result_not_contains:
         - "(show"
       result_contains:
-        - "memory"
+        - "cache"
 
   - name: "Equivalent GROUP queries share carrier and aggregate column names"
     scm: |

--- a/tests/storage/persistence/buffered-temp-schema.yaml
+++ b/tests/storage/persistence/buffered-temp-schema.yaml
@@ -1,0 +1,198 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Buffered temporary schema changes remain live and join the next persisted schema snapshot"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS `.buffered_schema_cache`"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_memory"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_base"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_flush"
+  - sql: "CREATE TABLE buffered_schema_base (id INT PRIMARY KEY) ENGINE=SAFE"
+  - sql: "INSERT INTO buffered_schema_base (id) VALUES (1), (2)"
+
+test_cases:
+  - name: "Temporary column is published immediately"
+    scm: &create_computed_column |
+      (createcolumn
+        (table "memcp-tests" "buffered_schema_base")
+        "cached_value" "int" '() '("temp" true)
+        '("id") (lambda (id) (* id 2)))
+
+  - name: "Published temporary column is queryable"
+    sql: "SELECT id, cached_value FROM buffered_schema_base"
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          cached_value: 2
+        - id: 2
+          cached_value: 4
+
+  - name: "Temporary ordered column metadata is published immediately"
+    scm: &create_ordered_column |
+      (createcolumn
+        (table "memcp-tests" "buffered_schema_base")
+        "ordered_position" "int" '()
+        (list
+          "temp" true
+          "sortcols" '("id")
+          "sortdirs" (list false)
+          "partitioncount" 0
+          "mapcols" '()
+          "mapfn" (lambda ($set) (list $set))
+          "reducefn" (lambda (acc mapped)
+            (begin
+              ((car mapped) (+ acc 1))
+              (+ acc 1)))
+          "reduceinit" 0))
+
+  - name: "Published ordered column is queryable"
+    sql: "SELECT id, ordered_position FROM buffered_schema_base ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          ordered_position: 1
+        - id: 2
+          ordered_position: 2
+
+  - name: "Temporary table is published immediately"
+    scm: &create_temp_table |
+      ((lambda (seed)
+        (createtable
+          "memcp-tests"
+          ".buffered_schema_cache"
+          (list (list "column" "cache_key" "int" (list) (list)))
+          (list "engine" "cache" "oninit"
+            (lambda ()
+              (insert
+                (table "memcp-tests" ".buffered_schema_cache")
+                (list "cache_key")
+                (list (list seed))
+                (list)
+                (lambda () true)
+                false)))
+          true))
+        7)
+
+  - name: "Published temporary table is queryable"
+    sql: "SELECT COUNT(*) AS cnt FROM `.buffered_schema_cache`"
+    expect:
+      rows: 1
+      data:
+        - cnt: 1
+
+  - name: "Memory table stores a restart initializer"
+    scm: &create_memory_table |
+      ((lambda (seed)
+        (createtable
+          "memcp-tests"
+          "buffered_schema_memory"
+          (list (list "column" "value" "int" (list) (list)))
+          (list "engine" "memory" "oninit"
+            (lambda ()
+              (insert
+                (table "memcp-tests" "buffered_schema_memory")
+                (list "value")
+                (list (list seed))
+                (list)
+                (lambda () true)
+                false)))
+          true))
+        11)
+
+  - name: "Memory initializer populated the first process generation"
+    sql: "SELECT value FROM buffered_schema_memory"
+    expect:
+      rows: 1
+      data:
+        - value: 11
+
+  - name: "Durable DDL flushes the complete buffered schema"
+    sql: "CREATE TABLE buffered_schema_flush (id INT) ENGINE=SAFE"
+    expect:
+      rows: 0
+
+  - name: "Crash after the later durable schema publication"
+    scm: "(crash)"
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after buffered schema flush"
+    action: restart
+
+  - name: "Idempotent temp create reruns persisted initialization"
+    scm: *create_temp_table
+
+  - name: "Repeated temp guard does not rerun initialization in one generation"
+    scm: *create_temp_table
+
+  - name: "Reinitialized temp table is not left empty"
+    sql: "SELECT cache_key FROM `.buffered_schema_cache`"
+    expect:
+      rows: 1
+      data:
+        - cache_key: 7
+
+  - name: "Idempotent memory create reruns persisted initialization"
+    scm: *create_memory_table
+
+  - name: "Repeated memory guard does not rerun initialization in one generation"
+    scm: *create_memory_table
+
+  - name: "Reinitialized memory table is not left empty"
+    sql: "SELECT value FROM buffered_schema_memory"
+    expect:
+      rows: 1
+      data:
+        - value: 11
+
+  - name: "Temporary column joined the durable snapshot"
+    sql: "SHOW FULL COLUMNS FROM buffered_schema_base"
+    expect:
+      rows: 3
+
+  - name: "Canonical computed-column guard repairs the empty RAM generation"
+    scm: *create_computed_column
+
+  - name: "Canonical ordered-column guard repairs the empty RAM generation"
+    scm: *create_ordered_column
+
+  - name: "Reprepared temporary metadata remains executable after restart"
+    sql: "SELECT id, cached_value, ordered_position FROM buffered_schema_base ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          cached_value: 2
+          ordered_position: 1
+        - id: 2
+          cached_value: 4
+          ordered_position: 2
+
+  - name: "Temporary table joined the durable snapshot"
+    sql: "SHOW FULL COLUMNS FROM `.buffered_schema_cache`"
+    expect:
+      rows: 1
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS `.buffered_schema_cache`"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_memory"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_base"
+  - sql: "DROP TABLE IF EXISTS buffered_schema_flush"


### PR DESCRIPTION
## Summary

- introduce internal fsync, no-fsync, and buffered schema publication modes
- buffer hidden cache-table and temporary compute/ORC column creation while keeping ordinary DDL synchronous
- persist closed `oninit` callbacks and rerun them once for empty `memory`/`cache` generations after restart
- use the evictable `cache` engine for non-FK group carriers without enlarging generated plans

## Root cause

Every temporary helper-table or column creation serialized the complete database catalog. Large catalogs therefore paid synchronous JSON generation and schema I/O repeatedly while compiling cold aggregate plans. Switching helper tables to RAM-only engines alone would be incorrect after restart unless their initializer remained available to reconstruct the empty generation.

## Correctness

The new persistence suite covers immediate visibility, buffered metadata joining the next durable snapshot, hard-crash restart, captured callback values, exactly-once initialization per process generation, and repair of temporary compute and ordered columns. Existing group-cache restart, invalidation, and concurrent-initialization suites remain green.

## Measurements

Identical 4.2 MB, 343-table catalog; 20 cold hidden cache-table creates:

| Revision | Mean | Median | Min | Max |
| --- | ---: | ---: | ---: | ---: |
| master | 80.505 ms | 86.671 ms | 55.757 ms | 101.953 ms |
| this PR | 0.625 ms | 0.603 ms | 0.471 ms | 0.937 ms |

This is a 129x mean speedup (99.2% lower latency). The representative generated plan size stays flat: 11,735 bytes on master and 11,734 bytes here.

A manual application workload reached 17/19 scenarios. The remaining two failures were browser overlay/popup waits; at each timeout the process list contained no active database query. In the completed first phase, badge-like query maxima fell from 11.051 s to 4.921 s, while the broad data-view family remained approximately flat (5.908 s vs. 5.666 s maxima).

## Validation

- full `./git-pre-commit`: passed
- `go test ./...`: passed
- buffered persistence/restart: 22/22
- serialization round trip: 23/23
- concurrent cache initialization: 16/16
- group-cache invalidation: 117/117
- normal-binary ordered 200k-row suite: 40/40; 2.410 s master vs. 2.439 s PR

`make test` uses atomic Go coverage instrumentation locally. Its pre-existing 200k-row ORDER/OFFSET hard limit also fails on unmodified master under coverage; the same suite passes on both revisions with normal binaries and is unrelated to this patch.
