### PR TITLE
Reject empty dashboard credentials safely

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -20,13 +20,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* check admin credentials against system.user table */
 (define dashboard_check_admin (lambda (req) (begin
 	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
-	(and pw (equal? (car pw) (password (req "password"))) (car (cdr pw)))
+	(if (nil? pw) false
+		(and (equal? (car pw) (password (req "password"))) (car (cdr pw))))
 )))
 
 /* check any authenticated user (returns admin flag or false) */
 (define dashboard_check_user (lambda (req) (begin
 	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
-	(if (and pw (equal? (car pw) (password (req "password")))) (equal? (car (cdr pw)) 1) nil)
+	(if (nil? pw) nil
+		(if (equal? (car pw) (password (req "password"))) (equal? (car (cdr pw)) 1) nil))
 )))
 
 /* send 401 with WWW-Authenticate header */

--- a/tests/sql/security/mysql-auth-tx-nil.yaml
+++ b/tests/sql/security/mysql-auth-tx-nil.yaml
@@ -38,5 +38,19 @@ test_cases:
         "ok"
         (error "mysql_auth should return nil for missing user"))
 
+  - name: "Dashboard user authentication rejects missing credentials without evaluating an empty row"
+    scm: |
+      (if
+        (nil? (dashboard_check_user (lambda (key) "")))
+        "ok"
+        (error "missing dashboard credentials should be rejected"))
+
+  - name: "Dashboard admin authentication rejects missing credentials without evaluating an empty row"
+    scm: |
+      (if
+        (not (dashboard_check_admin (lambda (key) "")))
+        "ok"
+        (error "missing dashboard admin credentials should be rejected"))
+
 cleanup:
   - sql: "DELETE FROM system.user WHERE username IN ('auth_scan_nil_repro', 'auth_scan_nil_other')"


### PR DESCRIPTION
## Summary

- reject a missing dashboard user row before reading its password/admin fields
- keep SCM/SQL three-valued `and` semantics unchanged
- cover both user and admin authentication guards in the existing security YAML suite

## Root cause

The dashboard guards used `(and row (car row) ...)`. Since SCM predicates gained SQL three-valued semantics, `nil` represents UNKNOWN and is no longer an immediate false terminal when a later operand could still determine the result. Missing or unauthenticated credentials therefore evaluated `car` on the empty scan result and returned HTTP 500.

The dashboard now branches explicitly on an empty authentication row. This restores the intended HTTP contract without weakening SQL NULL semantics.

## Validation

- regression reproduced first on master: both guards failed with `car on empty list`
- focused security suite: 5/5 passed
- anonymous `GET /dashboard`: HTTP 401 with `WWW-Authenticate`
- authenticated `GET /dashboard`: HTTP 200
- authenticated databases/logs/errors/whoami APIs: HTTP 200
- full `./git-pre-commit`: passed
