### PR TITLE
Bind nested query columns to local scope

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3680,16 +3680,99 @@ available while nested queries are decorrelated. */
 		((quote get_column) tblvar _ "*" _) (or (nil? tblvar) (equal? tblvar alias))
 		_ false)))
 
-(define rewrite_derived_ref (lambda (alias projection expr)
+/* A derived-relation rewrite may cross a subquery boundary only after names
+local to that subquery have been bound. Otherwise an unqualified local column
+which happens to share an outer projection title is captured by the outer
+rewrite. Names not provided by the local sources deliberately remain
+unqualified so correlated references can still bind to the derived projection. */
+(define qualify_query_local_scope (lambda (query)
+	(begin
+		(define normalized (normalize_query_ast query))
+		(if (query_block? normalized)
+			(begin
+				(define local_sources (qb_sources normalized))
+				(define resolution_sources (map local_sources (lambda (src)
+					(list
+						(source_alias src)
+						(coalesceNil (source_schema src) (qb_schema normalized))
+						(source_relation src)
+						(source_outer? src)
+						(source_join_expr src)))))
+				(define qualify (lambda (expr)
+					(qualify_unqualified_column_for_logical_scope resolution_sources '() expr)))
+				(define qualify_source (lambda (src)
+					(begin
+						(define relation (normalize_query_ast (source_relation src)))
+						(list
+							(source_alias src)
+							(source_schema src)
+							(if (or (query_block? relation) (union_block? relation))
+								(qualify_query_local_scope relation)
+								relation)
+							(source_outer? src)
+							(qualify (source_join_expr src))))))
+				(make_query_block
+					(qb_schema normalized)
+					(map local_sources qualify_source)
+					(map_assoc (qb_fields normalized) (lambda (_title expr) (qualify expr)))
+					(qualify (qb_where normalized))
+					(map (coalesceNil (qb_group normalized) '()) qualify)
+					(qualify (qb_having normalized))
+					(map (coalesceNil (qb_order normalized) '()) (lambda (item)
+						(match item
+							'(expr dir) (list (qualify expr) dir)
+							_ item)))
+					(qb_limit normalized)
+					(qb_offset normalized)
+					(map_assoc (qb_hidden normalized) (lambda (_title expr) (qualify expr)))
+					(qb_stages normalized)
+					(qb_facts normalized)))
+			(if (union_block? normalized)
+				(make_union_block
+					(union_mode normalized)
+					(map (union_branches normalized) qualify_query_local_scope)
+					(union_order normalized)
+					(union_limit normalized)
+					(union_offset normalized)
+					(union_facts normalized))
+				normalized)))))
+
+(define rewrite_derived_ref_for_scope (lambda (alias projection expr rewrite_unqualified)
 	(match expr
-		((symbol get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias) (nil? tblvar))
+		((symbol inner_select) subquery)
+		(list (quote inner_select) (rewrite_derived_ref_for_scope alias projection
+			(qualify_query_local_scope subquery) true))
+		((quote inner_select) subquery)
+		(list (quote inner_select) (rewrite_derived_ref_for_scope alias projection
+			(qualify_query_local_scope subquery) true))
+		((symbol inner_select_exists) subquery)
+		(list (quote inner_select_exists) (rewrite_derived_ref_for_scope alias projection
+			(qualify_query_local_scope subquery) true))
+		((quote inner_select_exists) subquery)
+		(list (quote inner_select_exists) (rewrite_derived_ref_for_scope alias projection
+			(qualify_query_local_scope subquery) true))
+		((symbol inner_select_in) probe subquery)
+		(list (quote inner_select_in)
+			(rewrite_derived_ref_for_scope alias projection probe rewrite_unqualified)
+			(rewrite_derived_ref_for_scope alias projection (qualify_query_local_scope subquery) true))
+		((quote inner_select_in) probe subquery)
+		(list (quote inner_select_in)
+			(rewrite_derived_ref_for_scope alias projection probe rewrite_unqualified)
+			(rewrite_derived_ref_for_scope alias projection (qualify_query_local_scope subquery) true))
+		((symbol get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias)
+			(and rewrite_unqualified (nil? tblvar)))
 			(coalesceNil (field_expr_by_title projection col col_ignorecase) expr)
 			expr)
-		((quote get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias) (nil? tblvar))
+		((quote get_column) tblvar _tbl_ignorecase col col_ignorecase) (if (or (equal? tblvar alias)
+			(and rewrite_unqualified (nil? tblvar)))
 			(coalesceNil (field_expr_by_title projection col col_ignorecase) expr)
 			expr)
-		(cons head tail) (cons head (map tail (lambda (item) (rewrite_derived_ref alias projection item))))
+		(cons head tail) (cons head (map tail (lambda (item)
+			(rewrite_derived_ref_for_scope alias projection item rewrite_unqualified))))
 		_ expr)))
+
+(define rewrite_derived_ref (lambda (alias projection expr)
+	(rewrite_derived_ref_for_scope alias projection expr true)))
 
 (define rewrite_derived_fields (lambda (alias projection fields)
 	(match (coalesceNil fields '())

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -817,6 +817,100 @@ test_cases:
             - ID: 2
             - ID: 1
       - sql: |
+          SELECT d.ID
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT ID FROM in_dv_file WHERE filename LIKE '%does-not-match%'
+            UNION
+            SELECT ID FROM in_dv_file WHERE search LIKE '%needle%'
+          )
+          ORDER BY d.ID
+        expect:
+          rows: 1
+          data:
+            - ID: 2
+      - sql: |
+          SELECT d.ID
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT ID FROM in_dv_file WHERE filename LIKE '%invoice-hit%'
+            UNION
+            SELECT ID FROM in_dv_file WHERE search LIKE '%does-not-match%'
+          )
+          ORDER BY d.ID
+        expect:
+          rows: 2
+          data:
+            - ID: 1
+            - ID: 4
+      - sql: |
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE t.file_id IN (
+            SELECT ID FROM in_dv_file WHERE filename LIKE '%does-not-match%'
+            UNION
+            SELECT ID FROM in_dv_file WHERE search LIKE '%needle%'
+          )
+          ORDER BY t.ID
+        expect:
+          rows: 1
+          data:
+            - ID: 2
+      - sql: |
+          EXPLAIN IR
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE t.file_id IN (
+            SELECT ID FROM in_dv_file WHERE filename LIKE '%does-not-match%'
+            UNION
+            SELECT ID FROM in_dv_file WHERE search LIKE '%needle%'
+          )
+          ORDER BY t.ID
+        expect:
+          contains:
+            - "in_candidate_union"
+            - '(get_column "in_dv_file" false "ID" false)'
+      - sql: |
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE EXISTS (
+            SELECT 1
+            FROM in_dv_file f
+            WHERE f.ID = t.file_id AND ID = 20
+          )
+          ORDER BY t.ID
+        expect:
+          rows: 1
+          data:
+            - ID: 2
+      - sql: |
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE EXISTS (
+            SELECT 1
+            FROM in_dv_file f1
+            JOIN in_dv_file f2 ON f2.ID = f1.ID
+            WHERE ID = t.file_id
+          )
+        expect:
+          error: true
+      - sql: |
           SELECT t.ID
           FROM (
             SELECT d.ID, d.file_id, d.tenant, d.sort_key


### PR DESCRIPTION
## What changed

- bind unqualified columns to the nearest nested query scope before rewriting derived-table references
- preserve unresolved names for genuine outer correlation
- reject locally ambiguous names instead of capturing a same-named outer projection
- cover both UNION branches, a derived ACL-shaped query, mixed local/correlated predicates, logical IR, and the ambiguous must-fail case

## Root cause

Derived-table flattening rewrote unqualified column references recursively. When a nested UNION branch selected an unqualified `ID`, the rewrite could bind it to the outer derived projection before SQL name resolution had considered the branch's own source. The membership stage then compared identifiers from the wrong relation and returned no rows.

The fix resolves names provided by each nested logical query block first. Only names that no local source provides remain unqualified and eligible for outer correlation. This stays in logical planning and introduces no physical scans, RecSets, helper tables, or fallback subquery execution.

## A/B

Same anonymized schema, fresh builds from current `master` and this branch:

| Case | master | PR |
| --- | ---: | ---: |
| Derived ACL + unqualified UNION membership | 0 rows | `ID=2` |
| Target suite | fails at new regression | 69/69 |

Thirty cache-busted `EXPLAIN COMPILE` samples show the cost of compiling the now-correct logical plan:

| Metric p50 | master (incorrect) | PR (correct) |
| --- | ---: | ---: |
| compile total | 9.835 ms | 20.037 ms |
| planner total | 7.200 ms | 15.875 ms |
| physical lower | 2.743 ms | 8.457 ms |
| plan nodes | 194 | 1326 |
| plan bytes | 1856 | 12042 |
| group carriers | 0 | 2 |

These are not presented as a speedup: master compiles a smaller but semantically wrong plan. The correct plan exposes the next physical-planning task: choose a costed driver probe or RecSet strategy for a simple UNION membership instead of eagerly preparing both group carriers.

## Validation

- `tests/planner/subqueries/in-subquery.yaml`: 69/69
- targeted parallel concurrency matrix: transactions 176/176, compute proxy rebuild 15/15, update contention 126/126, group-cache initialization 16/16
- `tests/execution/concurrency/kill-lock.yaml`: 27/27 isolated
- `tests/planner/order-window/order-limit.yaml`: 40/40 isolated
- `git diff --check`: clean
- Scheme lint warnings match the four pre-existing `queryplan.scm` negative-depth sites on master, shifted by the added definitions

The local full hook was run twice. Functional suites remained green; under concurrent host benchmark load, the isolated 200k-row ORDER/OFFSET performance gate exceeded its 5 s wall limit (9.9 s and 5.8 s) despite passing 40/40 in isolation. No timeout, parallelism, or test expectation was changed. CI is the independent full-run gate for this PR.
