### PR TITLE
Define measured JIT and SIMD scan architecture

### DIFF
--- a/todos/vectorization.md
+++ b/todos/vectorization.md
@@ -1,0 +1,479 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+
+# Shard-wide Vectorized Query Execution
+
+## Status and decision
+
+This document proposes vectorized, SIMD-accelerated execution for physical
+query plans. It does not change the logical planner model.
+
+The recommended design combines both proposed entry points:
+
+- **A: physical lowering** may deliberately select a vectorized scan pipeline.
+- **B: the `scan` / `scan_order` optimizer hooks** may recognize a safe scalar
+  callback pipeline and specialize it to the same vector backend.
+
+There must be only one vector IR, one capability checker, and one executor.
+Variant A is the authoritative cost-based SQL path. Variant B is an
+opportunistic specialization and a fallback for plans produced outside the SQL
+planner. It must not become a second physical planner.
+
+The first implementation should use precompiled scalar/AVX kernels. Query JIT
+may fuse the same vector IR later, but vectorization must not depend on JIT.
+
+## Goals
+
+- Eliminate per-row `Scmer` construction and callback dispatch from supported
+  scan, filter, projection, and aggregate pipelines.
+- Execute directly on column storage and its compressed representations where
+  practical.
+- Keep intermediate relational results in storage operators, RecSets, indexes,
+  shard masks, or final result buffers; never materialize whole relations as
+  Scheme lists.
+- Preserve SQL NULL, decimal, overflow, visibility, ordering, outer-join, and
+  transaction semantics exactly.
+- Use one shard as the logical scheduling and vectorization unit.
+- Provide a scalar implementation of every vector operation as the correctness
+  oracle and fallback on non-amd64 platforms or unsupported storage types.
+- Make physical choice and measured benefit visible in `EXPLAIN` and telemetry.
+
+## Non-goals
+
+- No vector artifacts in `untangle_query` or logical join reorder.
+- No fixed 2,048-row execution chunks and no new chunk-based relational layer.
+- No mandatory full-column decompression before execution.
+- No attempt to vectorize arbitrary Scheme, side effects, mutation callbacks,
+  correlated scans, or user functions in the first version.
+- No AVX-only correctness path.
+
+## Terminology
+
+Three different sizes must not be conflated:
+
+- **Shard vector:** the logical row domain of one storage shard, normally up to
+  `Settings.ShardSize` rows (currently 60,000). Masks and vector expressions use
+  shard-relative row IDs.
+- **Storage span:** a contiguous or encoded region exposed by one column
+  storage. A shard vector may consist of several spans without changing its
+  identity.
+- **SIMD lane group:** the 128/256/512-bit register-sized portion processed by
+  one kernel iteration. This is an implementation detail, not a materialized
+  execution batch.
+
+A shard-wide vector therefore does not mean allocating 60,000 decoded values
+for every expression. It means evaluating one pipeline over the shard while
+keeping only borrowed column views, a selection representation, small reusable
+kernel scratch space where unavoidable, and shard-local aggregate state.
+
+## Phase boundary
+
+The existing planner pipeline remains:
+
+```text
+parser AST
+  -> untangle_query
+  -> join_reorder / optimize
+  -> build_queryplan
+  -> scalar or vector physical execution
+```
+
+Logical planning may carry properties needed for the decision:
+
+- estimated input and output cardinality
+- selectivity and confidence
+- required and available ordering
+- LIMIT and braking opportunities
+- expression types and NULLability
+- expected reuse
+- dense scan, range scan, sparse RecSet, or point-probe character
+
+It must not contain `vec_scan`, vector masks, AVX instructions, storage spans,
+or kernel names. These are physical artifacts chosen in `build_queryplan` or by
+the generic operator optimizer.
+
+## One backend, two entry points
+
+### A. Cost-based physical lowering
+
+`build_queryplan` may emit a vector-capable physical scan when all semantics are
+known and the common cost domain predicts a benefit. Conceptually:
+
+```scheme
+(scan_vec tx table
+	filter-columns filter-lambda
+	map-columns map-lambda
+	reduce-lambda neutral reduce2-lambda
+	outer? scalar-fallback)
+```
+
+The exact syntax is deliberately not fixed here. It may instead be an optional
+physical program argument to `scan`. The important contract is:
+
+- the ordinary scalar plan remains available as an exact fallback;
+- the vector program is produced only during physical lowering;
+- plan selection considers compile cost, density, storage encoding, startup,
+  output materialization, and estimated rows;
+- join order, predicate ownership, outer barriers, ordering, and LIMIT remain
+  unchanged.
+
+This path can make choices that a local hook cannot infer reliably, such as
+whether a sparse RecSet probe is cheaper than scanning a shard-wide mask, or
+whether an ordered LIMIT should remain an index-driven scalar probe.
+
+### B. `scan` and `scan_order` optimizer specialization
+
+The existing optimizer hooks already inspect filter, map, reduce, and neutral
+callbacks. They should additionally call the shared vector compiler after
+ordinary callback optimization and type propagation.
+
+The hook may specialize only when it can prove:
+
+- every referenced operation has vector semantics registered in its
+  declaration;
+- callbacks are pure and deterministic for the duration of the scan;
+- captured values are immutable scalar parameters or supported vector inputs;
+- reducer associativity and shard merge semantics are declared and valid;
+- NULL and overflow behavior has an exact vector implementation;
+- no update/increment pseudo-column or other side effect is present;
+- fallback preserves the original optimized scalar callbacks.
+
+This path is useful for hand-written Scheme, RDF plans, computed-column
+preparation, and older SQL lowering that still emits an ordinary scan. It must
+not choose another join order, materialize a new relation, or override an
+ordering decision made by the physical planner.
+
+### Combined rule
+
+Both paths call a single operation:
+
+```text
+CompileVectorPipeline(typed callbacks, scan properties)
+  -> unsupported(reason)
+  -> VecProgram + scalar fallback + capability requirements
+```
+
+An explicitly emitted vector candidate and an automatically recognized scalar
+scan must produce the same `VecProgram` fingerprint. Compilation is cached by
+callback structure, concrete input types, storage capabilities, CPU feature
+level, and SQL-semantics version.
+
+## Typed vector IR
+
+The vector IR should be small, typed, and independent of AVX instruction names.
+It describes a fused pipeline, not a generic list-processing language.
+
+Initial expression operations:
+
+- load column, constant, captured scalar, and row visibility
+- integer/date/decimal add, subtract, multiply, and comparison
+- float arithmetic and comparison with explicit NaN behavior
+- SQL equality, NULL tests, three-valued AND/OR/NOT
+- dictionary-code equality and membership
+- selection mask AND/OR/AND-NOT
+- projection into final rows or another physical storage sink
+- COUNT, SUM, MIN, MAX, and AVG partial state
+
+Later operations may add string prefix/range predicates, hash calculation,
+group lookup/update, join probing, and top-k comparison.
+
+Each value carries at least:
+
+```text
+physical type
+SQL logical type
+nullable / validity source
+storage encoding
+borrowed or owned lifetime
+scalar, shard-vector, selection, or aggregate-state shape
+```
+
+SQL three-valued logic must be represented by validity/truth masks, not by
+calling scalar truth conversion for each row. Decimal scale and intermediate
+width are part of the opcode. An unsupported combination rejects compilation;
+it must never silently use approximate float arithmetic.
+
+## Shard-wide execution model
+
+One worker owns one shard execution at a time:
+
+```text
+index/RecSet candidate source
+  -> visibility mask
+  -> fused predicate masks
+  -> projection or aggregate kernels
+  -> shard-local result
+  -> existing reduce2 / ordered merge
+```
+
+### Selection representation
+
+Use two interchangeable shard-relative representations:
+
+- dense bitmap: one bit per row; about 7.5 KiB for a 60,000-row shard;
+- sparse sorted `[]uint32` record IDs, preferably borrowed from index/RecSet
+  iteration or a worker-owned reusable buffer.
+
+The executor chooses the representation from candidate density and may switch
+once when measured density crosses a calibrated threshold. Repeated conversion
+between bitmap and ID list is forbidden. Visibility, deletion, RecSet, and
+predicate masks should be combined in place when ownership permits.
+
+### Column access
+
+`ColumnStorage.GetValue` is the scalar compatibility API and cannot be the hot
+vector path. Add an optional capability interface rather than widening every
+storage implementation immediately. Conceptually:
+
+```go
+type VectorColumn interface {
+	VectorSpans(snapshot VectorSnapshot) []VectorSpan
+}
+```
+
+`VectorSpan` describes borrowed encoded/native data, row range, validity, and
+the supported kernels. It must not expose mutable shard internals after the
+shard lock is released. The concrete API must follow the existing rights and
+locking contract: acquire read rights, load stable column storages, take the
+shard read lock for the visibility snapshot, and release everything with
+panic-safe defers.
+
+Useful first storage paths:
+
+- `StorageInt` and date: operate on native or bit-packed integer data;
+- decimal: operate on scaled integers without converting to `Scmer`;
+- const/enum/dictionary: compare codes or one constant directly;
+- float: contiguous numeric spans;
+- SCMER/sparse/compute proxy/delta: scalar fallback until they expose a safe
+  vector view.
+
+The delta tail and transactional overlays may be evaluated with a separate
+scalar or vector path. The main compressed column must not be decoded merely
+because a small delta exists.
+
+### No avoidable materialization
+
+- Filters produce or refine a selection, not an array of booleans.
+- Aggregates consume selected storage values directly into registers and one
+  shard-local state.
+- Projection converts to `Scmer` only at the API/result edge or when feeding an
+  unsupported scalar downstream operator.
+- Join probes consume selected keys directly; they do not first construct a
+  Scheme list of keys.
+- A reusable intermediate relation is written once into the selected storage
+  carrier, never duplicated into a vector-owned relation.
+- Scratch buffers are worker-owned and reused. Their size is a kernel detail;
+  they do not introduce a second 2,048-row execution domain.
+
+## AVX implementation
+
+### Dispatch
+
+Provide architecture-specific kernel tables selected once at startup:
+
+```text
+scalar reference
+amd64 AVX2
+amd64 AVX-512 where available and measurably beneficial
+arm64 NEON later
+```
+
+Use build tags for architecture code and runtime CPU feature detection for the
+amd64 level. Plans and cached programs name semantic operations and required
+capabilities, never concrete register numbers.
+
+### Kernel strategy
+
+Start with precompiled kernels, preferably assembly for loops the Go compiler
+does not vectorize reliably:
+
+- bit-packed/native integer comparison -> mask
+- integer/decimal SUM and COUNT over mask
+- dictionary-code equality/IN -> mask
+- bitmap combination and population count
+- numeric projection/copy into a physical sink
+- hash generation and batched hash probe later
+
+Each kernel processes the complete storage span by advancing SIMD registers.
+Scalar prefix/tail handling is part of the kernel. AVX-512 masked loads may be
+used when profitable; AVX2 uses explicit bitmap/ID iteration. Do not use gather
+for dense data when sequential loads are possible. For sparse candidates,
+benchmark scalar ID iteration against AVX gather rather than assuming gather is
+faster.
+
+The existing scalar JIT and `Declaration.JITEmit` can later gain a vector
+equivalent, for example `VectorEmit`. That second stage may fuse several IR
+operations into one query-specific loop. It must share the typed IR, validity
+rules, feature dispatch, fingerprinting, compile budget, and scalar fallback
+with the precompiled backend.
+
+## `scan_order`, indexes, LIMIT, and braking
+
+Vectorization must not destroy ordering to obtain a dense scan.
+
+- An ordered index remains the owner of row order.
+- OFFSET/LIMIT and partition limits remain scan boundaries.
+- Early braking wins over vectorization when only a few ordered rows are
+  required.
+- Vector predicates may filter an ordered candidate ID stream, but results are
+  emitted in the original stream order.
+- Dense monotonic index ranges may be exposed as spans and vectorized.
+- Irregular ordered IDs use sparse evaluation or scalar fallback.
+- Sorting/top-k is a separate physical operator and should consume typed column
+  values without first materializing Scheme rows.
+
+`scan_order` therefore needs the same vector compiler, but its cost threshold
+will usually be higher than for a full `scan`. The currently disabled batch
+rewrite is not enabled merely by adding vectors; reduce2, final partial-batch,
+outer-row, ordering, and LIMIT semantics must first be represented explicitly.
+
+## Joins and grouping
+
+The first milestone vectorizes leaf scans and scalar aggregates. It already
+removes substantial callback and boxing cost without redesigning joins.
+
+Next milestones extend the same pipeline:
+
+- vector hash build from selected key spans;
+- batched hash/index probes with a result mask or match-ID vector;
+- dictionary-code joins when dictionary identity or translation is proven;
+- vector group-key hashing and shard-local aggregate tables;
+- RecSet projection directly from match masks;
+- merge of shard-local aggregate states through the existing reduce2 ownership
+  contract.
+
+The logical join tree remains authoritative. Vector execution changes how one
+physical node consumes its children, never which aliases are joined or where an
+outer-join barrier sits.
+
+## Cost model and plan choice
+
+Vectorization is not unconditionally faster. Add measured physical facts:
+
+```text
+vector_startup_ns
+kernel_ns_per_row by operation/type/encoding/CPU level
+selection_bitmap_ns_per_word
+sparse_probe_ns_per_id
+decode_ns_per_row
+scalar_fallback_ns_per_row
+result_box_ns_per_row
+vector_compile_ns
+scratch_bytes
+```
+
+The cost calculation must include expected candidate density, output rows,
+LIMIT braking, ordering, storage encoding, cold/warm state, reuse, and the
+number of unsupported scalar islands. A pipeline with a scalar call per passing
+row may still win when the filter is vectorized and highly selective. A
+pipeline with a scalar call per input row normally should not be selected.
+
+`EXPLAIN` should show:
+
+- scalar or vector execution;
+- selected CPU kernel level;
+- supported fused operations and scalar islands;
+- dense bitmap or sparse-ID strategy;
+- estimated rows/density and scalar/vector cost;
+- fallback reason when vector compilation was rejected.
+
+## Correctness and fallback contract
+
+Every `VecProgram` contains or references the original optimized scalar plan.
+Fallback may happen at compile time for unsupported IR or at execution startup
+for an incompatible storage/CPU capability. Mid-shard fallback is allowed only
+before externally visible output or side effects and must restart that shard
+from a clean accumulator.
+
+Differential tests execute scalar and vector paths on identical snapshots and
+compare:
+
+- values, order, multiplicity, and NULLs;
+- empty input and outer-row behavior;
+- decimal scales, overflow, NaN, and signed zero;
+- main column plus inserts/deletions and each transaction mode;
+- dense scan, range, RecSet, unique point, and ordered LIMIT;
+- shard boundary sizes including 0, 1, SIMD width +/- 1, and shard size +/- 1;
+- scalar fallback islands and unsupported storage encodings.
+
+No vector optimization is accepted merely because TPC-H output matches once.
+Repeated execution and plan-cache variants must be included to prevent a repeat
+of cached aggregate ownership/correctness failures.
+
+## Delivery packages
+
+### 1. Baseline and vector IR
+
+- Record scalar CPU/allocation profiles for Q1, Q6, Q12, and representative ERP
+  point/range/report queries.
+- Define typed vector IR, fingerprints, capability errors, and scalar IR
+  interpreter.
+- Add declaration metadata for pure/vectorizable operations and reducers.
+
+Acceptance: scalar IR is bit-for-bit equivalent to existing callbacks; compile
+time and IR size are bounded and reported.
+
+### 2. Shard selection and raw numeric views
+
+- Add worker-owned shard bitmap/sparse-ID abstractions.
+- Add safe vector spans for integer, date, decimal, const, enum/dictionary, and
+  float storages.
+- Keep delta/compute-proxy fallback explicit.
+
+Acceptance: selection construction has no allocation per input row and obeys
+all shard locking/visibility rules.
+
+### 3. Precompiled vector scan kernels
+
+- Implement scalar, AVX2, and optional AVX-512 dispatch.
+- Fuse numeric/dictionary filters with COUNT/SUM/MIN/MAX/AVG.
+- Convert to `Scmer` only for final output.
+
+Acceptance: supported aggregate scans have zero allocations per input row,
+match scalar results in differential tests, and show a measured speedup over
+the scalar path on SF0.1 and SF1.
+
+### 4. Physical lowering (A)
+
+- Add vector candidates to `build_queryplan` only.
+- Connect candidates to the common physical cost domain and guarded plan cache.
+- Add `EXPLAIN` components and scalar fallback reasons.
+
+Acceptance: no vector artifact appears before physical lowering; cost guards
+select scalar plans for point lookups/early LIMIT where they are faster.
+
+### 5. Generic scan specialization (B)
+
+- Extend `scan` and then `scan_order` optimizer hooks to compile the same IR.
+- Reuse optimizer rewrite budgets, fingerprints, type/ownership facts, and
+  precondition reporting.
+
+Acceptance: hand-written and legacy scans obtain the same vector program as an
+equivalent physical SQL candidate, without recursive hook loops or AST growth.
+
+### 6. Vector joins, grouping, and sinks
+
+- Add batched hash/index probes, vector group updates, typed top-k/sort input,
+  and direct storage-carrier writes.
+- Add optional vector JIT only after stable precompiled kernels establish the
+  semantics and cost baseline.
+
+Acceptance: targeted TPC-H problem shapes and generic ERP reports improve
+without regressing point/range scans, compile time, transactional correctness,
+or memory bounds.
+
+## Recommended implementation order
+
+Implement **A+B on one backend**, but land the backend and A first:
+
+1. typed IR plus scalar reference;
+2. shard masks and borrowed storage spans;
+3. AVX numeric filter/aggregate kernels;
+4. cost-based physical SQL lowering;
+5. generic `scan` hook recognition;
+6. ordered scans, joins, grouping, strings, and optional vector JIT.
+
+This preserves planner ownership, gives SQL plans an intentional cost-based
+choice, and still lets generic Scheme/storage plans benefit. It also avoids the
+two failure modes of the isolated variants: A alone would leave many existing
+scan callbacks scalar, while B alone would hide a major physical strategy from
+the planner and its cost model.

--- a/todos/vectorization.md
+++ b/todos/vectorization.md
@@ -1,479 +1,628 @@
 # Copyright (C) 2026  Carl-Philip Haensch
 
-# Shard-wide Vectorized Query Execution
+# JIT, SIMD Bulk Operations, and Hybrid Scan Execution
 
-## Status and decision
+## Status: the backend decision is deliberately open
 
-This document proposes vectorized, SIMD-accelerated execution for physical
-query plans. It does not change the logical planner model.
+This document does not select a vector interpreter or a query-specific JIT as
+the universally best execution model. That decision has not been measured for
+MemCP yet.
 
-The recommended design combines both proposed entry points:
+The design space contains three physical execution candidates:
 
-- **A: physical lowering** may deliberately select a vectorized scan pipeline.
-- **B: the `scan` / `scan_order` optimizer hooks** may recognize a safe scalar
-  callback pipeline and specialize it to the same vector backend.
+1. **Fine-grained JIT:** the approach in `todos/jit.md`. Generate one
+   shard-specialized native loop from column decoders and the small Scheme
+   operations in filter, map, and reduce. Values remain scalar machine values;
+   there is no vector-operator dispatch and no intermediate selection vector
+   unless the expression needs one.
+2. **Precompiled SIMD bulk operators:** a MonetDB/DuckDB-style interpreter of
+   typed column operations. The executor dispatches to already compiled AVX2,
+   AVX-512, or scalar kernels. Operators exchange a shard-relative selection
+   bitmap or sparse record-ID vector. Startup is cheap, but every operator
+   boundary may require another pass or a materialized mask.
+3. **SIMD JIT:** generate a query- and storage-specific fused SIMD loop. This
+   can remove bulk-dispatch and intermediate-mask costs, but needs a materially
+   more expensive compiler, vector register allocation, and more code-cache
+   space than the fine-grained scalar JIT.
 
-There must be only one vector IR, one capability checker, and one executor.
-Variant A is the authoritative cost-based SQL path. Variant B is an
-opportunistic specialization and a fallback for plans produced outside the SQL
-planner. It must not become a second physical planner.
+All three may be useful. OLTP point/range queries, short ERP reports, and large
+TPC-H scans have very different break-even points. The physical planner should
+eventually compare measured candidates; this document first defines how to
+build and measure them without baking the answer into planner semantics.
 
-The first implementation should use precompiled scalar/AVX kernels. Query JIT
-may fuse the same vector IR later, but vectorization must not depend on JIT.
+The previous version of this document incorrectly selected precompiled kernels
+first and relegated JIT to a later optimization. There was no MemCP-specific
+measurement supporting that choice.
 
-## Goals
+## Relation to `todos/jit.md`
 
-- Eliminate per-row `Scmer` construction and callback dispatch from supported
-  scan, filter, projection, and aggregate pipelines.
-- Execute directly on column storage and its compressed representations where
-  practical.
-- Keep intermediate relational results in storage operators, RecSets, indexes,
-  shard masks, or final result buffers; never materialize whole relations as
-  Scheme lists.
-- Preserve SQL NULL, decimal, overflow, visibility, ordering, outer-join, and
-  transaction semantics exactly.
-- Use one shard as the logical scheduling and vectorization unit.
-- Provide a scalar implementation of every vector operation as the correctness
-  oracle and fallback on non-amd64 platforms or unsupported storage types.
-- Make physical choice and measured benefit visible in `EXPLAIN` and telemetry.
+`todos/jit.md` remains the source of truth for the fine-grained JIT:
 
-## Non-goals
+- a main-storage loop specialized per shard;
+- a separate, normally interpreted delta loop;
+- direct decoding through storage-specific emitters;
+- `Declaration.JITEmit` for small Scheme operations;
+- `JITValueDesc` propagation instead of `Scmer` in the hot loop;
+- storage fields such as data pointer, bit width, offset, NULL code, and row
+  count embedded as immediates;
+- shard-local executable pages and bounded code lifetime.
 
-- No vector artifacts in `untangle_query` or logical join reorder.
-- No fixed 2,048-row execution chunks and no new chunk-based relational layer.
-- No mandatory full-column decompression before execution.
-- No attempt to vectorize arbitrary Scheme, side effects, mutation callbacks,
-  correlated scans, or user functions in the first version.
-- No AVX-only correctness path.
+The vectorization work is not a replacement for that design. It adds two
+questions that `jit.md` leaves open:
 
-## Terminology
+- Can precompiled SIMD bulk kernels amortize their dispatch and mask traffic
+  well enough to beat the fine-grained JIT, especially when JIT compilation is
+  included?
+- If not, or only for some shapes, does a SIMD-emitting extension of that JIT
+  pay for its larger compiler?
 
-Three different sizes must not be conflated:
+The existing repository currently implements only part of `jit.md`:
+`JITValueDesc`, the amd64 writer/compiler scaffolding, and a small number of
+`Declaration.JITEmit` registrations exist. The storage-specific scan-loop JIT,
+generated `Storage.JIT` methods, shard JIT pools, and SIMD emitters described in
+the TODO are not complete. Benchmarks must therefore compare implemented
+vertical slices, not extrapolate from the TODO's cycle estimates.
 
-- **Shard vector:** the logical row domain of one storage shard, normally up to
-  `Settings.ShardSize` rows (currently 60,000). Masks and vector expressions use
-  shard-relative row IDs.
-- **Storage span:** a contiguous or encoded region exposed by one column
-  storage. A shard vector may consist of several spans without changing its
-  identity.
-- **SIMD lane group:** the 128/256/512-bit register-sized portion processed by
-  one kernel iteration. This is an implementation detail, not a materialized
-  execution batch.
+## Orthogonal choices: entry point and backend
 
-A shard-wide vector therefore does not mean allocating 60,000 decoded values
-for every expression. It means evaluating one pipeline over the shard while
-keeping only borrowed column views, a selection representation, small reusable
-kernel scratch space where unavoidable, and shard-local aggregate state.
+The two entry variants from the original request do not imply a backend:
 
-## Phase boundary
+### A. Physical planner lowering
 
-The existing planner pipeline remains:
+`build_queryplan` knows SQL-level physical facts: estimated cardinality and
+selectivity, required ordering, LIMIT/braking, join shape, expected reuse, and
+whether a scan feeds an aggregate or materialized result. It can produce a
+typed scan specification and a scalar fallback.
+
+It must not choose AVX instructions or assume one concrete storage encoding.
+Those differ per shard and may change after rebuild. The physical operator may
+carry a ranked set of backend families and defer the final per-shard dispatch
+until the concrete storages are locked and known.
+
+### B. `scan` / `scan_order` optimizer-hook recognition
+
+The storage optimizer hooks can recognize an existing filter/map/reduce
+callback pipeline and derive the same typed scan specification. This is needed
+for non-SQL Scheme callers and for physical plans that still lower to ordinary
+`scan` calls.
+
+The hook may prove purity, types, NULL behavior, reducer ownership, and
+associativity. It must not redo join ordering, predicate ownership, outer-join
+barriers, ordering, or LIMIT decisions.
+
+### Backends after A or B
+
+Both entry points end at a semantic `ScanSpec`, not at a mandatory vector IR:
+
+```text
+SQL physical lowering (A) ----+
+                              +--> typed ScanSpec + scalar fallback
+scan hook recognition (B) ----+              |
+                                             +--> fine-grained JIT
+                                             +--> SIMD bulk program
+                                             +--> SIMD JIT
+                                             +--> existing interpreter
+```
+
+The shared contract should include normalized expressions, physical/logical
+types, decimal scale, NULL semantics, referenced columns, candidate source,
+ordering, reducer semantics, and a stable fingerprint. Backend-specific IRs
+are allowed and expected:
+
+- the fine-grained JIT can continue compiling expressions directly through
+  `JITValueDesc` and `Declaration.JITEmit`;
+- the bulk backend needs a short program of typed kernel calls and explicit
+  selection carriers;
+- the SIMD JIT needs vector descriptors, masks, and vector registers.
+
+Forcing all three through an interpreted vector bytecode would add overhead to
+the JIT path without evidence. Duplicating SQL semantics in three compilers
+would be equally wrong. The common layer ends at proven semantics and typed
+operations; machine-level lowering remains backend-owned.
+
+## Planner boundary
+
+The existing phase boundary remains:
 
 ```text
 parser AST
   -> untangle_query
-  -> join_reorder / optimize
+  -> join_reorder / logical optimize
   -> build_queryplan
-  -> scalar or vector physical execution
+  -> physical ScanSpec
+  -> per-shard backend selection and execution
 ```
 
-Logical planning may carry properties needed for the decision:
+Logical planning may carry cardinality, selectivity, confidence, predicate
+dependencies, NULL-extension barriers, required order, LIMIT, and reuse. These
+are logical or abstract physical requirements and are relevant to reorder.
 
-- estimated input and output cardinality
-- selectivity and confidence
-- required and available ordering
-- LIMIT and braking opportunities
-- expression types and NULLability
-- expected reuse
-- dense scan, range scan, sparse RecSet, or point-probe character
+It must not contain `scan`, bulk kernel names, SIMD masks, `StorageInt` bit
+widths, RecSets, ORC columns, or JIT entry points. A/B and JIT/bulk selection
+start only in physical lowering or generic operator optimization.
 
-It must not contain `vec_scan`, vector masks, AVX instructions, storage spans,
-or kernel names. These are physical artifacts chosen in `build_queryplan` or by
-the generic operator optimizer.
+## Exact MemCP scan integration
 
-## One backend, two entry points
+Today `storageShard.scan` obtains condition column readers, iterates candidate
+record IDs through `iterateIndex`, checks visibility/deletions, calls
+`ColumnStorage.GetValue` per referenced row and column, invokes the scalar
+condition, and feeds passing IDs to `mapper.Stream`. The default index transport
+buffer is 1,024 IDs; that buffer is not a useful vectorization domain.
 
-### A. Cost-based physical lowering
-
-`build_queryplan` may emit a vector-capable physical scan when all semantics are
-known and the common cost domain predicts a benefit. Conceptually:
-
-```scheme
-(scan_vec tx table
-	filter-columns filter-lambda
-	map-columns map-lambda
-	reduce-lambda neutral reduce2-lambda
-	outer? scalar-fallback)
-```
-
-The exact syntax is deliberately not fixed here. It may instead be an optional
-physical program argument to `scan`. The important contract is:
-
-- the ordinary scalar plan remains available as an exact fallback;
-- the vector program is produced only during physical lowering;
-- plan selection considers compile cost, density, storage encoding, startup,
-  output materialization, and estimated rows;
-- join order, predicate ownership, outer barriers, ordering, and LIMIT remain
-  unchanged.
-
-This path can make choices that a local hook cannot infer reliably, such as
-whether a sparse RecSet probe is cheaper than scanning a shard-wide mask, or
-whether an ordered LIMIT should remain an index-driven scalar probe.
-
-### B. `scan` and `scan_order` optimizer specialization
-
-The existing optimizer hooks already inspect filter, map, reduce, and neutral
-callbacks. They should additionally call the shared vector compiler after
-ordinary callback optimization and type propagation.
-
-The hook may specialize only when it can prove:
-
-- every referenced operation has vector semantics registered in its
-  declaration;
-- callbacks are pure and deterministic for the duration of the scan;
-- captured values are immutable scalar parameters or supported vector inputs;
-- reducer associativity and shard merge semantics are declared and valid;
-- NULL and overflow behavior has an exact vector implementation;
-- no update/increment pseudo-column or other side effect is present;
-- fallback preserves the original optimized scalar callbacks.
-
-This path is useful for hand-written Scheme, RDF plans, computed-column
-preparation, and older SQL lowering that still emits an ordinary scan. It must
-not choose another join order, materialize a new relation, or override an
-ordering decision made by the physical planner.
-
-### Combined rule
-
-Both paths call a single operation:
-
-```text
-CompileVectorPipeline(typed callbacks, scan properties)
-  -> unsupported(reason)
-  -> VecProgram + scalar fallback + capability requirements
-```
-
-An explicitly emitted vector candidate and an automatically recognized scalar
-scan must produce the same `VecProgram` fingerprint. Compilation is cached by
-callback structure, concrete input types, storage capabilities, CPU feature
-level, and SQL-semantics version.
-
-## Typed vector IR
-
-The vector IR should be small, typed, and independent of AVX instruction names.
-It describes a fused pipeline, not a generic list-processing language.
-
-Initial expression operations:
-
-- load column, constant, captured scalar, and row visibility
-- integer/date/decimal add, subtract, multiply, and comparison
-- float arithmetic and comparison with explicit NaN behavior
-- SQL equality, NULL tests, three-valued AND/OR/NOT
-- dictionary-code equality and membership
-- selection mask AND/OR/AND-NOT
-- projection into final rows or another physical storage sink
-- COUNT, SUM, MIN, MAX, and AVG partial state
-
-Later operations may add string prefix/range predicates, hash calculation,
-group lookup/update, join probing, and top-k comparison.
-
-Each value carries at least:
-
-```text
-physical type
-SQL logical type
-nullable / validity source
-storage encoding
-borrowed or owned lifetime
-scalar, shard-vector, selection, or aggregate-state shape
-```
-
-SQL three-valued logic must be represented by validity/truth masks, not by
-calling scalar truth conversion for each row. Decimal scale and intermediate
-width are part of the opcode. An unsupported combination rejects compilation;
-it must never silently use approximate float arithmetic.
-
-## Shard-wide execution model
-
-One worker owns one shard execution at a time:
-
-```text
-index/RecSet candidate source
-  -> visibility mask
-  -> fused predicate masks
-  -> projection or aggregate kernels
-  -> shard-local result
-  -> existing reduce2 / ordered merge
-```
-
-### Selection representation
-
-Use two interchangeable shard-relative representations:
-
-- dense bitmap: one bit per row; about 7.5 KiB for a 60,000-row shard;
-- sparse sorted `[]uint32` record IDs, preferably borrowed from index/RecSet
-  iteration or a worker-owned reusable buffer.
-
-The executor chooses the representation from candidate density and may switch
-once when measured density crosses a calibrated threshold. Repeated conversion
-between bitmap and ID list is forbidden. Visibility, deletion, RecSet, and
-predicate masks should be combined in place when ownership permits.
-
-### Column access
-
-`ColumnStorage.GetValue` is the scalar compatibility API and cannot be the hot
-vector path. Add an optional capability interface rather than widening every
-storage implementation immediately. Conceptually:
+The new path should sit immediately after candidate boundaries and referenced
+storages have been resolved, before the per-record `GetValue` loop:
 
 ```go
-type VectorColumn interface {
-	VectorSpans(snapshot VectorSnapshot) []VectorSpan
+type ScanSpec struct {
+	// normalized typed filter/map/reduce descriptions
+	// reducer merge and ownership contract
+	// order, limit and candidate-source properties
+	// original optimized callbacks as exact fallback
 }
+
+func (t *storageShard) runSpecializedMainScan(
+	spec *ScanSpec,
+	boundaries scanBoundaries,
+	storages []ColumnStorage,
+) (partial scm.Scmer, matched uint, ok bool)
 ```
 
-`VectorSpan` describes borrowed encoded/native data, row range, validity, and
-the supported kernels. It must not expose mutable shard internals after the
-shard lock is released. The concrete API must follow the existing rights and
-locking contract: acquire read rights, load stable column storages, take the
-shard read lock for the visibility snapshot, and release everything with
-panic-safe defers.
+Names and exact signatures are not fixed, but the control flow is:
 
-Useful first storage paths:
+1. acquire shard read rights and load storages through existing helpers;
+2. take the required shard read lock and snapshot visibility/candidate state;
+3. classify the main-storage candidate domain as dense range, monotonic sparse
+   IDs, irregular ordered IDs, or unsupported;
+4. inspect the concrete storage types and their encoding parameters;
+5. select and run interpreter, fine JIT, bulk SIMD, or SIMD JIT;
+6. evaluate the small delta through the current scalar path unless measurement
+   justifies a delta backend;
+7. merge main and delta partials with the existing `reduce2` and ownership
+   contract.
 
-- `StorageInt` and date: operate on native or bit-packed integer data;
-- decimal: operate on scaled integers without converting to `Scmer`;
-- const/enum/dictionary: compare codes or one constant directly;
-- float: contiguous numeric spans;
-- SCMER/sparse/compute proxy/delta: scalar fallback until they expose a safe
-  vector view.
+There must be no function call, interface dispatch, allocation, lock operation,
+or `Scmer` construction per main-storage row on a supported specialized path.
 
-The delta tail and transactional overlays may be evaluated with a separate
-scalar or vector path. The main compressed column must not be decoded merely
-because a small delta exists.
+### Lifetime and rebuild safety
 
-### No avoidable materialization
+`jit.md` proposes embedding storage and deletion-bitmap pointers as immediates.
+That is only safe while those exact objects remain alive and immutable. A shard
+rebuild, lazy load/eviction, or storage replacement can invalidate such code.
 
-- Filters produce or refine a selection, not an array of booleans.
-- Aggregates consume selected storage values directly into registers and one
-  shard-local state.
-- Projection converts to `Scmer` only at the API/result edge or when feeding an
-  unsupported scalar downstream operator.
-- Join probes consume selected keys directly; they do not first construct a
-  Scheme list of keys.
-- A reusable intermediate relation is written once into the selected storage
-  carrier, never duplicated into a vector-owned relation.
-- Scratch buffers are worker-owned and reused. Their size is a kernel detail;
-  they do not introduce a second 2,048-row execution domain.
+Therefore either:
 
-## AVX implementation
+- compile and execute under one acquired read capability with strong references
+  to all storages, and discard the code before releasing it; or
+- cache code only with a shard storage-generation key, retain the referenced
+  storages, and reject execution when the generation differs.
 
-### Dispatch
+A persistent query-plan cache must never own raw storage pointers. Bulk kernels
+have the same lifetime rule for borrowed slices, even though their code itself
+is reusable.
 
-Provide architecture-specific kernel tables selected once at startup:
+## The shard is the relational vector, not an allocated value matrix
+
+`Settings.ShardSize` is currently 60,000. One shard is the scheduling,
+visibility, and selection domain. It does not mean allocating decoded arrays of
+60,000 values for each expression.
+
+- SIMD instructions still consume register-width lane groups.
+- A dense selection is one shard-sized bitmap (about 7.5 KiB at 60,000 rows).
+- A sparse selection is a monotonic `[]uint32` candidate stream when already
+  provided by an index or RecSet.
+- Fine JIT can avoid a selection entirely for a fused filter/aggregate.
+- Bulk execution may materialize a bitmap between kernels; its cost must be
+  counted.
+- SIMD JIT may keep masks in vector registers inside a fused loop and only
+  materialize them when another operator consumes the selection.
+
+Full and contiguous range scans should iterate `[lo, hi)` directly rather than
+round-trip through the 1,024-record index buffer. Unique probes and short
+ordered LIMIT paths normally remain scalar. Sparse gather is a measured choice,
+not a default: cache-cold AVX2 gathers can lose to a scalar monotonic loop.
+
+## Concrete column-storage lowering
+
+The backend selector must specialize on MemCP's actual `ColumnStorage` formats.
+`ColumnStorage.GetValue` remains the compatibility fallback, not the fast-path
+API. A new generic `VectorColumn` interface returning decoded spans would hide
+the format information needed by the JIT and could force materialization. Use
+a type switch once per column and shard, then call format-specific compiler or
+kernel builders.
+
+### `StorageInt`
+
+`StorageInt` stores packed unsigned codes in `chunk []uint64`, with `bitsize`,
+`offset`, optional `hasNull`, and a raw `null` code. `GetValueUInt` computes
+`bitpos = row * bitsize`, combines two words when the value crosses a word
+boundary, and right-aligns the result.
+
+- Fine JIT embeds chunk pointer, bit width, offset, NULL code, and count and
+  emits the exact packed decoder into the row loop as described in `jit.md`.
+- Bulk SIMD needs precompiled unpack/compare/reduce kernels. Widths
+  1/2/4/8/16/32/64 deserve direct kernels; arbitrary widths need either a
+  generated/unrolled decoder, a kernel table, or a scalar packed decoder.
+- SIMD JIT can generate the arbitrary-width extraction with immediate shifts
+  and fuse comparisons before decoded values leave registers.
+- Predicate constants should be converted to raw code space once. For SUM,
+  accumulate raw non-NULL values and add `count * offset`; do not create decoded
+  `int64` arrays.
+
+Odd bit widths are an important comparison case: the smaller memory footprint
+may beat easy SIMD on wider decoded values because cache lines dominate.
+
+### `StorageDecimal`
+
+`StorageDecimal` wraps an embedded `StorageInt` plus `scaleExp`. Keep scaled
+integers and scale metadata through filter and aggregate. Q6-style
+`extendedprice * discount` needs a widened exact integer product and combined
+scale; converting every value to float is not an acceptable shortcut. Overflow
+or an unsupported scale combination must reject the fast path before output.
+
+### `StorageFloat`
+
+`StorageFloat` is contiguous `[]float64`; NaN represents SQL NULL. It is the
+cleanest bulk-SIMD baseline: direct loads, unordered comparisons for validity,
+and masked aggregates. It is also the case most favorable to SIMD JIT fusion,
+so results from it must not be generalized to packed integer columns.
+
+### `StorageConst`
+
+Fold the predicate/projection once per shard. COUNT/SUM can use the selected row
+count and one constant. No backend should loop over a constant column merely to
+present a uniform API.
+
+### `StorageSeq`
+
+`StorageSeq` represents runs through packed record ID, start, and stride
+columns. Per-row `GetValue` searches for the owning run. A dense scan should
+walk runs once. Filters can solve ranges within a run, and SUM can use the
+arithmetic-series formula. A monotonic sparse candidate stream should advance
+one run cursor rather than binary-search for every record ID.
+
+### `StorageEnum`
+
+`StorageEnum` stores up to eight values and an rANS-coded symbol stream with L1
+and L2 jumps. Comparisons, IN, grouping, and hashing should operate on symbol
+IDs and translate to `Scmer` values only at the result edge. A single rANS state
+has a serial dependency; SIMD requires decoding several independent chunks or
+states in parallel. That constraint must be benchmarked rather than described
+as an ordinary packed integer load.
+
+### `StorageString`
+
+`StorageString` uses packed dictionary IDs or packed start/length columns over
+a byte dictionary/buffer, with raw, nibble, UUID, and Base64 encodings. Its
+dictionary may be LZ4-compressed and lazily expanded.
+
+- Resolve equality/IN constants to dictionary IDs once and compare packed IDs.
+- Use dictionary IDs for shard-local grouping; cross-shard grouping needs a
+  proven common dictionary or translation during merge.
+- For non-dictionary strings, filter length first and use AVX byte comparison,
+  prefix, or LIKE kernels directly on the encoded representation where valid.
+- UUID/nibble/Base64 comparisons should avoid expanding to Go strings.
+- Call `ensureDict` before entering native code when expansion is required;
+  never take its lock or decompress inside the hot loop.
+- Construct `CString`/`BString` only for selected output rows.
+
+### `StoragePrefix`
+
+`StoragePrefix` combines a packed prefix ID with suffix `StorageString` data.
+Equality and prefix predicates should resolve prefix and suffix constraints
+without concatenating a string per row. Unsupported lexical operations fall
+back before the scan begins.
+
+### `StorageSparse`
+
+`StorageSparse` has packed record IDs and dynamic `[]scm.Scmer` values. Dense
+execution should merge the candidate stream with one monotonic sparse-record
+cursor; the complement provides the NULL mask. `IS NULL`, `IS NOT NULL`, and
+selection can be bulk operations. Arithmetic on the dynamic values remains
+scalar until the value payload itself has a typed columnar representation.
+
+### `StorageSCMER`
+
+`StorageSCMER` is the dynamic/uncompressed representation and compression
+source. It is not a SIMD numeric source. A fine JIT may specialize stable tags,
+but otherwise it uses the scalar fallback. Large persistent main columns should
+normally have been converted by `proposeCompression` to const, sparse, enum,
+string, sequence, integer, decimal, or float storage.
+
+### `StorageComputeProxy`
+
+If all requested rows are valid and the proxy is compressed, delegate to its
+underlying typed storage. Otherwise split valid and invalid rows before native
+execution. Invalid values may be computed by the current scalar callback and
+then consumed; no native loop should jump into lazy recomputation per row.
+Ordered computed columns must finish their required range preparation before a
+borrowed fast path begins.
+
+### `OverlayBlob`
+
+Hash references may trigger external blob lookup and decompression. A native
+path can use the base/hash only for operations whose semantics are valid on
+that representation. Value comparison or output is a residual scalar fetch.
+Blob I/O must never occur inside an AVX or generated scan loop.
+
+### Main storage and delta
+
+All three specialized candidates target compressed immutable main storage.
+Delta rows remain dynamic and small; the default is the current scalar
+interpreter followed by `reduce2`. This preserves transaction visibility and
+avoids compiling for a handful of rows. Delta vectorization becomes a separate
+proposal only if measurements show it matters.
+
+## Three backend implementations
+
+### Fine-grained scalar JIT
+
+Implement the scan-loop portion already designed in `jit.md`. The generated
+loop decodes one row's referenced columns, evaluates the filter, map, and
+reducer with typed machine values, and advances. It is fused and has no
+operator-level materialization. Its decisive questions are actual compile time,
+instruction-cache footprint, branch behavior, and whether arbitrary packed
+decoders can be emitted cheaply enough per shard.
+
+The implementation should extend the existing files rather than create a
+second JIT framework:
+
+- storage-specific emission beside the corresponding storage type;
+- scalar expression emission through `scm.JITContext`, `JITValueDesc`, and
+  `Declaration.JITEmit`;
+- scan-loop construction in storage with code lifetime tied to shard rights.
+
+### Precompiled SIMD bulk interpreter
+
+This backend compiles no machine code per query. A typed bulk program might be:
 
 ```text
-scalar reference
-amd64 AVX2
-amd64 AVX-512 where available and measurably beneficial
-arm64 NEON later
+int.compare_range(shipdate, raw_lo, raw_hi) -> mask0
+decimal.compare_range(discount, raw_lo, raw_hi, mask0) -> mask0
+decimal.compare_lt(quantity, raw_limit, mask0) -> mask0
+decimal.mul_sum(extendedprice, discount, mask0) -> partial
 ```
 
-Use build tags for architecture code and runtime CPU feature detection for the
-amd64 level. Plans and cached programs name semantic operations and required
-capabilities, never concrete register numbers.
+The program is interpreted once per bulk operator, not once per row. Kernel
+dispatch happens outside lane loops. Inputs remain encoded wherever the kernel
+supports that encoding. The main costs are dispatch, repeated column passes,
+selection bitmap writes/reads, and loss of fusion. The advantages are almost
+zero query compile cost, small reusable code, mature hand-tuned kernels, and
+predictable code-cache behavior under many short distinct queries.
 
-### Kernel strategy
+Kernel tables should dispatch once on CPU level, storage encoding, bit width,
+NULL mode, predicate, and selection representation. Scalar reference kernels
+are mandatory; amd64 AVX2 is the first optimized target, AVX-512 only when
+measured. ARM64 NEON can use the same semantic kernel program later.
 
-Start with precompiled kernels, preferably assembly for loops the Go compiler
-does not vectorize reliably:
+### SIMD JIT
 
-- bit-packed/native integer comparison -> mask
-- integer/decimal SUM and COUNT over mask
-- dictionary-code equality/IN -> mask
-- bitmap combination and population count
-- numeric projection/copy into a physical sink
-- hash generation and batched hash probe later
+This backend extends the `jit.md` emitter with vector registers and mask/value
+descriptors. It generates a fused loop which loads/decodes several rows,
+evaluates all supported predicates, and updates the aggregate without writing
+intermediate masks.
 
-Each kernel processes the complete storage span by advancing SIMD registers.
-Scalar prefix/tail handling is part of the kernel. AVX-512 masked loads may be
-used when profitable; AVX2 uses explicit bitmap/ID iteration. Do not use gather
-for dense data when sequential loads are possible. For sparse candidates,
-benchmark scalar ID iteration against AVX gather rather than assuming gather is
-faster.
+It should reuse semantic operation registration, storage-specialized constants,
+W^X pages, fixups, safe points, and fallback rules from the scalar JIT. It needs
+its own vector register allocator and amd64 VEX/EVEX emitters; pretending scalar
+`JITValueDesc` is already a vector IR will make NULL masks and register pressure
+implicit and unsafe.
 
-The existing scalar JIT and `Declaration.JITEmit` can later gain a vector
-equivalent, for example `VectorEmit`. That second stage may fuse several IR
-operations into one query-specific loop. It must share the typed IR, validity
-rules, feature dispatch, fingerprinting, compile budget, and scalar fallback
-with the precompiled backend.
+SIMD JIT is not automatically the final stage. If compile time or code-cache
+pressure loses on ERP query diversity, the bulk backend may remain preferable
+even for large scans. Conversely, fine-grained scalar JIT may beat both on
+packed odd-width data or short ranges.
 
-## `scan_order`, indexes, LIMIT, and braking
+## First decisive experiment: one vertical Q6 pipeline
 
-Vectorization must not destroy ordering to obtain a dense scan.
+Before designing joins or general vector bytecode, implement the same supported
+Q6-shaped pipeline in all feasible backends:
 
-- An ordered index remains the owner of row order.
-- OFFSET/LIMIT and partition limits remain scan boundaries.
-- Early braking wins over vectorization when only a few ordered rows are
-  required.
-- Vector predicates may filter an ordered candidate ID stream, but results are
-  emitted in the original stream order.
-- Dense monotonic index ranges may be exposed as spans and vectorized.
-- Irregular ordered IDs use sparse evaluation or scalar fallback.
-- Sorting/top-k is a separate physical operator and should consume typed column
-  values without first materializing Scheme rows.
+```sql
+SUM(extendedprice * discount)
+WHERE shipdate >= ? AND shipdate < ?
+  AND discount BETWEEN ? AND ?
+  AND quantity < ?
+```
 
-`scan_order` therefore needs the same vector compiler, but its cost threshold
-will usually be higher than for a full `scan`. The currently disabled batch
-rewrite is not enabled merely by adding vectors; reduce2, final partial-batch,
-outer-row, ordering, and LIMIT semantics must first be represented explicitly.
+Use the real MemCP encodings selected for these TPC-H columns, especially
+`StorageInt`/`StorageDecimal`; do not benchmark only decoded `[]int64` or
+`[]float64` arrays.
 
-## Joins and grouping
+The candidates are:
 
-The first milestone vectorizes leaf scans and scalar aggregates. It already
-removes substantial callback and boxing cost without redesigning joins.
+- current callback interpreter;
+- fine-grained scalar JIT, one fused row loop;
+- precompiled SIMD bulk kernels, including actual mask traffic;
+- SIMD JIT, only after the first two provide a justified target.
 
-Next milestones extend the same pipeline:
+Measure separately:
 
-- vector hash build from selected key spans;
-- batched hash/index probes with a result mask or match-ID vector;
-- dictionary-code joins when dictionary identity or translation is proven;
-- vector group-key hashing and shard-local aggregate tables;
-- RecSet projection directly from match masks;
-- merge of shard-local aggregate states through the existing reduce2 ownership
-  contract.
+- ScanSpec recognition/lowering;
+- per-shard compile time and bytes of generated code;
+- cold execution, warm execution, and repeated execution;
+- cycles, instructions, branches/misses, LLC misses, and allocations;
+- time per input row and per selected row;
+- selection bitmap/scratch bytes;
+- total query latency including main/delta merge and result conversion.
 
-The logical join tree remains authoritative. Vector execution changes how one
-physical node consumes its children, never which aliases are joined or where an
-outer-join barrier sits.
+Run at row counts 0, 1, 8, 32, 128, 1K, 10K, and a full 60K shard, with
+selectivities near 0%, 1%, 10%, 50%, and 100%. Repeat for contiguous range and
+sparse candidate IDs. Include at least packed widths 3/5/7, 8/16/32/64,
+nullable/non-nullable, and a delta tail.
 
-## Cost model and plan choice
-
-Vectorization is not unconditionally faster. Add measured physical facts:
+The experiment must answer crossovers, not only throughput at one scale:
 
 ```text
-vector_startup_ns
-kernel_ns_per_row by operation/type/encoding/CPU level
-selection_bitmap_ns_per_word
+T_interpreter = startup_i + N * row_i
+T_fine_jit    = compile_j(expr, encoding) + N * fused_scalar_j
+T_bulk        = startup_b + sum(kernel_dispatch + rows_touched * kernel_cost
+                                + masks_written/read)
+T_simd_jit    = compile_v(expr, encoding) + N * fused_simd_v
+```
+
+Fit and publish the measured constants with confidence ranges. Do not import
+the speculative 25-row break-even from `jit.md` as a planner threshold.
+
+## Planner cost and adaptive choice
+
+The physical cost domain needs independent dimensions for:
+
+```text
+compile_ns
+code_bytes
+startup_ns
+decode_ns_per_row by storage encoding
+operation_ns_per_row
+bulk_dispatch_ns
+selection_write/read_ns_per_word
 sparse_probe_ns_per_id
-decode_ns_per_row
-scalar_fallback_ns_per_row
-result_box_ns_per_row
-vector_compile_ns
+result_box_ns_per_selected_row
 scratch_bytes
+estimated input/output rows and confidence
+expected executions/reuse
 ```
 
-The cost calculation must include expected candidate density, output rows,
-LIMIT braking, ordering, storage encoding, cold/warm state, reuse, and the
-number of unsupported scalar islands. A pipeline with a scalar call per passing
-row may still win when the filter is vectorized and highly selective. A
-pipeline with a scalar call per input row normally should not be selected.
+The planner can rank backend families using estimates, but concrete per-shard
+encodings are runtime facts. A practical split is:
 
-`EXPLAIN` should show:
+1. `build_queryplan` decides whether a scan is eligible for specialization and
+   records estimated rows, reuse, order/LIMIT constraints, and allowed backend
+   families;
+2. after storage acquisition, the scan executor obtains concrete calibrated
+   costs for that encoding and selects a backend per shard;
+3. repeated executions feed telemetry into the existing cost facts without
+   changing SQL semantics;
+4. a cached compiled candidate is reused only when its expression fingerprint,
+   CPU level, storage descriptors/generation, and semantic version match.
 
-- scalar or vector execution;
-- selected CPU kernel level;
-- supported fused operations and scalar islands;
-- dense bitmap or sparse-ID strategy;
-- estimated rows/density and scalar/vector cost;
-- fallback reason when vector compilation was rejected.
+Expected behavior, subject to measurement:
 
-## Correctness and fallback contract
+- unique probes and early ordered LIMIT: interpreter or fine JIT only if cached;
+- short ranges and high query diversity: bulk or interpreter may avoid compile
+  cost;
+- long scans with simple operations: precompiled SIMD bulk may win;
+- long fused predicates/aggregates with mask traffic: SIMD JIT may win;
+- odd-width packed integers: fine scalar JIT or encoding-specific SIMD,
+  depending on cache and decode measurements;
+- repeated prepared reports: amortized JIT compile cost may change the choice.
 
-Every `VecProgram` contains or references the original optimized scalar plan.
-Fallback may happen at compile time for unsupported IR or at execution startup
-for an incompatible storage/CPU capability. Mid-shard fallback is allowed only
-before externally visible output or side effects and must restart that shard
-from a clean accumulator.
+`EXPLAIN` should report candidate backend, estimated compile and execution cost,
+storage assumptions, reuse assumption, selected fallback, and measured reason
+when runtime dispatch changes the backend.
 
-Differential tests execute scalar and vector paths on identical snapshots and
-compare:
+## `scan_order`, LIMIT, joins, and grouping
 
-- values, order, multiplicity, and NULLs;
-- empty input and outer-row behavior;
-- decimal scales, overflow, NaN, and signed zero;
-- main column plus inserts/deletions and each transaction mode;
-- dense scan, range, RecSet, unique point, and ordered LIMIT;
-- shard boundary sizes including 0, 1, SIMD width +/- 1, and shard size +/- 1;
-- scalar fallback islands and unsupported storage encodings.
+Ordered index traversal remains the owner of row order. Vectorization must not
+turn it into an unordered dense scan. OFFSET/LIMIT and partition limits remain
+hard boundaries; early braking normally beats bulk startup when only a few rows
+are needed. Dense monotonic ranges can use any backend, while irregular ordered
+IDs use sparse kernels or scalar execution and preserve input order.
 
-No vector optimization is accepted merely because TPC-H output matches once.
-Repeated execution and plan-cache variants must be included to prevent a repeat
-of cached aggregate ownership/correctness failures.
+The currently disabled `scan_order` batch rewrite must not be enabled until
+final partial-batch, `reduce2`, outer-row, ordering, and LIMIT semantics have an
+explicit contract.
 
-## Delivery packages
+Join probing, grouping, top-k, and typed sinks are later candidates. They reuse
+the same backend comparison rather than assuming vector interpretation:
 
-### 1. Baseline and vector IR
+- a bulk backend may batch hash/index probes and group updates;
+- a fine JIT may fuse key extraction with a specialized probe helper;
+- SIMD JIT may inline hashing/probing where code size permits;
+- dictionary IDs can stay encoded only with proven dictionary identity or
+  translation;
+- the logical join tree, predicate provenance, and outer barriers are never
+  changed by backend selection.
 
-- Record scalar CPU/allocation profiles for Q1, Q6, Q12, and representative ERP
-  point/range/report queries.
-- Define typed vector IR, fingerprints, capability errors, and scalar IR
-  interpreter.
-- Add declaration metadata for pure/vectorizable operations and reducers.
+## Correctness and fallback
 
-Acceptance: scalar IR is bit-for-bit equivalent to existing callbacks; compile
-time and IR size are bounded and reported.
+Every specialized candidate retains the original optimized scalar callbacks.
+Unsupported type, encoding, CPU feature, ownership proof, or storage generation
+rejects the candidate before externally visible output. Mid-shard fallback may
+only restart from a clean accumulator; it must not double-apply a partial
+reducer.
 
-### 2. Shard selection and raw numeric views
+Differential tests compare interpreter, fine JIT, bulk, and SIMD JIT where
+implemented:
 
-- Add worker-owned shard bitmap/sparse-ID abstractions.
-- Add safe vector spans for integer, date, decimal, const, enum/dictionary, and
-  float storages.
-- Keep delta/compute-proxy fallback explicit.
+- values, order, multiplicity, and SQL NULLs;
+- decimal scales, exact products, overflow, NaN, and signed zero;
+- empty input, neutral ownership, outer rows, and `reduce2` merge;
+- main storage plus inserts/deletions under every transaction mode;
+- dense full/range, sparse RecSet/index, unique point, and ordered LIMIT;
+- all concrete storage formats and their fallback paths;
+- row counts around SIMD width, packed-word crossings, and shard boundaries;
+- cold/cached code and storage rebuild between executions.
 
-Acceptance: selection construction has no allocation per input row and obeys
-all shard locking/visibility rules.
+TPC-H correctness is necessary but not sufficient. Existing SQL suites in
+`tests/` remain authoritative, and performance assertions should detect changes
+in asymptotic behavior rather than depend on a narrow absolute timing window.
 
-### 3. Precompiled vector scan kernels
+## Work packages and decision gates
 
-- Implement scalar, AVX2, and optional AVX-512 dispatch.
-- Fuse numeric/dictionary filters with COUNT/SUM/MIN/MAX/AVG.
-- Convert to `Scmer` only for final output.
+### 1. Shared semantic ScanSpec and baseline
 
-Acceptance: supported aggregate scans have zero allocations per input row,
-match scalar results in differential tests, and show a measured speedup over
-the scalar path on SF0.1 and SF1.
+- Normalize typed filter/map/reduce semantics from A and B without a backend IR.
+- Preserve original callbacks and reducer ownership/merge rules.
+- Benchmark the current interpreter on Q6 and representative ERP point, range,
+  ordered-LIMIT, and report shapes.
 
-### 4. Physical lowering (A)
+Acceptance: A and B produce the same fingerprint for equivalent scans; no
+physical artifact leaks into logical planning; fixed/row/selection costs are
+reported separately.
 
-- Add vector candidates to `build_queryplan` only.
-- Connect candidates to the common physical cost domain and guarded plan cache.
-- Add `EXPLAIN` components and scalar fallback reasons.
+### 2. Fine-grained JIT vertical slice
 
-Acceptance: no vector artifact appears before physical lowering; cost guards
-select scalar plans for point lookups/early LIMIT where they are faster.
+- Complete only the `StorageInt`/`StorageDecimal` scan-loop pieces needed by Q6.
+- Reuse the current JIT descriptors and small-operation emitters.
+- Bind generated code lifetime to stable shard storages.
 
-### 5. Generic scan specialization (B)
+Acceptance: exact Q6 result, no per-row allocation or `Scmer`, compile/code-size
+measurements, and clean scalar fallback for main/delta edge cases.
 
-- Extend `scan` and then `scan_order` optimizer hooks to compile the same IR.
-- Reuse optimizer rewrite budgets, fingerprints, type/ownership facts, and
-  precondition reporting.
+### 3. Precompiled SIMD bulk vertical slice
 
-Acceptance: hand-written and legacy scans obtain the same vector program as an
-equivalent physical SQL candidate, without recursive hook loops or AST growth.
+- Implement scalar reference and AVX2 packed numeric compare/masked-multiply-sum
+  kernels for the same Q6 encodings.
+- Account for every dispatch and selection bitmap pass.
 
-### 6. Vector joins, grouping, and sinks
+Acceptance: exact differential results and crossover curves against interpreter
+and fine JIT, including cold one-shot and repeated queries.
 
-- Add batched hash/index probes, vector group updates, typed top-k/sort input,
-  and direct storage-carrier writes.
-- Add optional vector JIT only after stable precompiled kernels establish the
-  semantics and cost baseline.
+### 4. Backend decision and physical cost integration
 
-Acceptance: targeted TPC-H problem shapes and generic ERP reports improve
-without regressing point/range scans, compile time, transactional correctness,
-or memory bounds.
+- Decide from measurements whether both vertical slices remain production
+  candidates.
+- Add calibrated backend facts and per-shard encoding dispatch.
+- Expose estimates and runtime choice in `EXPLAIN`/telemetry.
 
-## Recommended implementation order
+Acceptance: the choice predicts the measured winner within a defined tolerance
+on held-out row counts, selectivities, encodings, and reuse counts; point/range
+OLTP latency does not regress.
 
-Implement **A+B on one backend**, but land the backend and A first:
+### 5. SIMD JIT decision gate
 
-1. typed IR plus scalar reference;
-2. shard masks and borrowed storage spans;
-3. AVX numeric filter/aggregate kernels;
-4. cost-based physical SQL lowering;
-5. generic `scan` hook recognition;
-6. ordered scans, joins, grouping, strings, and optional vector JIT.
+Implement vector emission only if bulk mask/dispatch overhead is material and
+the estimated additional compiler/code-cache cost has a realistic crossover.
+Prototype the same Q6 loop before generalizing vector descriptors.
 
-This preserves planner ownership, gives SQL plans an intentional cost-based
-choice, and still lets generic Scheme/storage plans benefit. It also avoids the
-two failure modes of the isolated variants: A alone would leave many existing
-scan callbacks scalar, while B alone would hide a major physical strategy from
-the planner and its cost model.
+Acceptance: total latency, including compilation, beats the selected scalar JIT
+or bulk backend in a documented region large enough to justify maintenance.
+
+### 6. Broader storage and operator coverage
+
+Add formats and operations in measured benefit order: float, const/sequence,
+enum/dictionary strings, ordered ranges, grouping, joins, and sinks. Sparse,
+compute-proxy, dynamic SCMER, and blobs retain explicit residual paths.
+
+Acceptance: each added path has encoding-specific differential tests, a
+reproducible benchmark, zero allocations per supported main-storage row, and no
+regression in compile time, code size, OLTP point/range latency, or transactional
+correctness.
+
+## Decision criteria
+
+No backend is selected because it is fashionable or because one architecture
+document mentioned it last. A backend remains only when it owns a measured
+region of the workload space or provides a necessary portability/correctness
+fallback. If both JIT and bulk survive, the query planner and per-shard executor
+choose between them using the same measured physical cost domain.


### PR DESCRIPTION
## What changed

- keeps the backend choice open between fine-grained shard JIT, precompiled SIMD bulk operators, and SIMD JIT
- separates the A/B entry choice (physical lowering versus scan-hook recognition) from backend selection
- grounds lowering in MemCP storage formats, including packed integers/decimals, rANS enums, dictionary strings, sequences, sparse columns, compute proxies, and main/delta handling
- defines shard-lock, rebuild, generated-code lifetime, ordering, LIMIT, and fallback constraints
- proposes an identical Q6 vertical slice and crossover benchmark before selecting a backend
- breaks implementation into six decision-gated work packages

## Why

The earlier draft selected precompiled vector kernels without measurements and forced all paths through one vector IR. That was premature: MemCP deliberately explores a fine-grained JIT for OLTP-friendly fused execution, while established column databases use precompiled bulk operators. The revised design treats both approaches, plus a possible SIMD JIT, as measurable physical candidates instead of choosing by assumption.

## Impact

Documentation only. No runtime behavior changes. The document now provides a concrete MemCP integration and experiment plan; it does not authorize implementation or select a winning backend.

## Validation

- `git diff --cached --check`
- checked against `INVARIANTS.md`, `todos/jit.md`, the current scan path, and concrete column-storage layouts
- full test suite not run because the change is documentation-only

## Review note

This remains a draft and must not be merged without review.