### PR TITLE
Fix structural aggregate catalog equality

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -1424,8 +1424,10 @@ physical membership probe. */
 		(define inner_src (car (qb_sources inner)))
 		(define inner_default (source_alias inner_src))
 		(define visible_ags (stage_aggregates_for_fields (qb_fields inner)))
-		(define order_ags (merge_unique (map (order_item_exprs (qb_order inner)) extract_aggregates)))
-		(define ags (dedupe_aggregates_by_col (merge_unique (list visible_ags order_ags (list aggregate_count_descriptor)))))
+		(define order_ags (dedupe_aggregates_by_col
+			(merge (map (order_item_exprs (qb_order inner)) extract_aggregates))))
+		(define ags (dedupe_aggregates_by_col
+			(merge (list visible_ags order_ags (list aggregate_count_descriptor)))))
 		(define session_keys (query_expr_session_reads inner))
 		(define explicit_keys (map (coalesceNil (qb_group inner) '()) (lambda (expr)
 			(canonical_column_expr_for_alias inner_default expr))))
@@ -1572,7 +1574,7 @@ physical membership probe. */
 		(define outer_domain (correlation_domain lookup_pairs))
 		(define lookup_keys (correlation_lookup_keys lookup_pairs))
 		(define condition (combine_where_terms local_terms true))
-		(define ags (dedupe_aggregates_by_col (merge_unique
+		(define ags (dedupe_aggregates_by_col (merge
 			(list (extract_aggregates (coalesceNil (qb_having inner) true))
 				(list aggregate_count_descriptor)))))
 		(define stage_input (make_query_block
@@ -9774,16 +9776,16 @@ the auto-index chooses the concrete access path on both tables. */
 		((symbol scalar_aggregate_probe) stage requested_col)
 		(if (qassoc_get (gs_facts stage) (quote direct_group_probe) false)
 			'()
-			(merge_unique (map (list stage requested_col) extract_aggregates)))
+			(dedupe_aggregates_by_col (merge (map (list stage requested_col) extract_aggregates))))
 		((quote scalar_aggregate_probe) stage requested_col)
 		(if (qassoc_get (gs_facts stage) (quote direct_group_probe) false)
 			'()
-			(merge_unique (map (list stage requested_col) extract_aggregates)))
+			(dedupe_aggregates_by_col (merge (map (list stage requested_col) extract_aggregates))))
 		((symbol count_distinct) agg_expr) (list (count_distinct_descriptor agg_expr))
 		((quote count_distinct) agg_expr) (list (count_distinct_descriptor agg_expr))
 		((symbol aggregate) agg_expr agg_reduce agg_neutral) (list (list agg_expr agg_reduce agg_neutral))
 		((quote aggregate) agg_expr agg_reduce agg_neutral) (list (list agg_expr agg_reduce agg_neutral))
-		(cons head tail) (merge_unique (map tail extract_aggregates))
+		(cons head tail) (dedupe_aggregates_by_col (merge (map tail extract_aggregates)))
 		_ '())))
 
 /* DECIMAL is currently represented as float64 at runtime. Keep calculations
@@ -10003,7 +10005,8 @@ working on the original values. */
 				normalized)))))
 
 (define stage_aggregates_for_fields (lambda (fields)
-	(merge_unique (extract_assoc fields (lambda (_title expr) (extract_aggregates expr))))))
+	(dedupe_aggregates_by_col
+		(merge (extract_assoc fields (lambda (_title expr) (extract_aggregates expr)))))))
 
 (define expr_has_aggregates? (lambda (expr)
 	(not (empty_list? (extract_aggregates expr)))))
@@ -10389,8 +10392,8 @@ self-joins of the same base table still describe two distinct row roles. */
 		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
 		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
 		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
-			(merge_unique (list visible_ags having_ags))
-			(merge_unique (list visible_ags having_ags (list aggregate_count_descriptor))))))
+			(merge (list visible_ags having_ags))
+			(merge (list visible_ags having_ags (list aggregate_count_descriptor))))))
 		(define alias (source_alias src))
 		(define session_keys (query_expr_session_reads block))
 		(define explicit_keys (map (coalesceNil (qb_group block) '()) (lambda (expr)
@@ -10418,8 +10421,8 @@ self-joins of the same base table still describe two distinct row roles. */
 		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
 		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
 		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
-			(merge_unique (list visible_ags having_ags))
-			(merge_unique (list visible_ags having_ags (list aggregate_count_descriptor))))))
+			(merge (list visible_ags having_ags))
+			(merge (list visible_ags having_ags (list aggregate_count_descriptor))))))
 		(define alias (source_alias (car (qb_sources block))))
 		(define group_keys (map (coalesceNil (qb_group block) '()) (lambda (expr) (canonical_column_expr_for_alias alias expr))))
 		(define field_passthrough_keys (field_passthrough_keys_for_alias alias (qb_fields block)))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1901,6 +1901,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define structural_collision_frozen (structural_collision))
 	(assert (structural_collision_frozen "collision6") 6 "structural catalog resolves deliberate collisions with equality")
 	(assert (nil? (structural_collision_frozen "collision99")) true "structural collision bucket cannot create false identity")
+	(define structural_literal_ast (list (quote if) true))
+	(define structural_probe_ast (list (quote if) (list (quote probe))))
+	(define structural_ast_catalog (make_structural_catalog))
+	(structural_ast_catalog structural_literal_ast "literal")
+	(structural_ast_catalog structural_probe_ast "probe")
+	(define structural_ast_frozen (structural_ast_catalog))
+	(assert (structural_ast_frozen structural_literal_ast) "literal"
+		"structural catalog keeps literal truth separate from a truthy AST")
+	(assert (structural_ast_frozen structural_probe_ast) "probe"
+		"structural catalog keeps a truthy AST separate from literal truth")
+	(define structural_ast_index (make_structural_index
+		(list structural_literal_ast structural_probe_ast)
+		(list structural_literal_ast structural_probe_ast)))
+	(assert (structural_ast_index structural_literal_ast) 0
+		"structural index preserves the literal AST slot")
+	(assert (structural_ast_index structural_probe_ast) 1
+		"structural index preserves the probe AST slot")
 	(define structural_concurrent (make_structural_catalog))
 	(parallelN 64 (lambda (i) (structural_concurrent (list (quote concurrent) i) i)))
 	(define structural_concurrent_frozen (structural_concurrent))

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -262,6 +262,58 @@ func hashStructuralReadonly(key Scmer) uint64 {
 	}
 }
 
+func structuralScalarTag(tag uint16) bool {
+	switch tag {
+	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagSymbol, tagCString, tagBString:
+		return true
+	default:
+		return false
+	}
+}
+
+// structuralEqual compares planner data as trees. Equal implements Scheme/SQL
+// coercions such as TRUE == any non-empty list; those coercions must never
+// collapse distinct AST nodes in a structural catalog.
+func structuralEqual(a, b Scmer) bool {
+	if a.IsSourceInfo() {
+		return structuralEqual(a.SourceInfo().value, b)
+	}
+	if b.IsSourceInfo() {
+		return structuralEqual(a, b.SourceInfo().value)
+	}
+	if a.GetTag() == tagAny {
+		if source, ok := a.Any().(SourceInfo); ok {
+			return structuralEqual(source.value, b)
+		}
+	}
+	if b.GetTag() == tagAny {
+		if source, ok := b.Any().(SourceInfo); ok {
+			return structuralEqual(a, source.value)
+		}
+	}
+	if a.GetTag() == tagSlice || b.GetTag() == tagSlice {
+		if a.GetTag() != tagSlice || b.GetTag() != tagSlice {
+			return false
+		}
+		left := a.Slice()
+		right := b.Slice()
+		if len(left) != len(right) {
+			return false
+		}
+		for i := range left {
+			if !structuralEqual(left[i], right[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	if structuralScalarTag(a.GetTag()) || structuralScalarTag(b.GetTag()) {
+		return structuralScalarTag(a.GetTag()) && structuralScalarTag(b.GetTag()) &&
+			hashStructuralScalar(a) == hashStructuralScalar(b) && Equal(a, b)
+	}
+	return Equal(a, b)
+}
+
 const structuralCatalogFastThreshold = 5
 
 // structuralCatalog is mutable only during compile-local collection. Freeze
@@ -284,7 +336,7 @@ func (catalog *structuralCatalog) hash(key Scmer, memo map[Scmer]uint64) uint64 
 func (catalog *structuralCatalog) set(key, value Scmer) {
 	if catalog.buckets == nil {
 		for i := range catalog.entries {
-			if Equal(catalog.entries[i].key, key) {
+			if structuralEqual(catalog.entries[i].key, key) {
 				catalog.entries[i].value = value
 				return
 			}
@@ -306,7 +358,7 @@ func (catalog *structuralCatalog) set(key, value Scmer) {
 		hash = hashStructuralReadonly(key)
 	}
 	for _, i := range catalog.buckets[hash] {
-		if Equal(catalog.entries[i].key, key) {
+		if structuralEqual(catalog.entries[i].key, key) {
 			catalog.entries[i].value = value
 			return
 		}
@@ -327,7 +379,7 @@ func (catalog *structuralCatalog) get(key Scmer) Scmer {
 	defer catalog.mu.Unlock()
 	if catalog.buckets == nil {
 		for _, entry := range catalog.entries {
-			if Equal(entry.key, key) {
+			if structuralEqual(entry.key, key) {
 				return entry.value
 			}
 		}
@@ -338,7 +390,7 @@ func (catalog *structuralCatalog) get(key Scmer) Scmer {
 		hash = hashStructuralReadonly(key)
 	}
 	for _, index := range catalog.buckets[hash] {
-		if Equal(catalog.entries[index].key, key) {
+		if structuralEqual(catalog.entries[index].key, key) {
 			return catalog.entries[index].value
 		}
 	}
@@ -374,7 +426,7 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 		}
 		if buckets == nil {
 			for _, entry := range entries {
-				if Equal(entry.key, key) {
+				if structuralEqual(entry.key, key) {
 					return entry.value
 				}
 			}
@@ -389,7 +441,7 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 			}
 		}
 		for _, entry := range buckets[hash] {
-			if Equal(entry.key, key) {
+			if structuralEqual(entry.key, key) {
 				return entry.value
 			}
 		}
@@ -471,7 +523,7 @@ func NewStructuralIndex(a ...Scmer) Scmer {
 			hash = hashStructuralKey(expr, memo)
 		}
 		for _, entry := range entries[hash] {
-			if Equal(entry.key, expr) {
+			if structuralEqual(entry.key, expr) {
 				return entry.value
 			}
 		}

--- a/scm/assoc_fast_test.go
+++ b/scm/assoc_fast_test.go
@@ -112,6 +112,20 @@ func TestFunctionalAssocBuilderUsesOwnedAccumulator(t *testing.T) {
 	}
 }
 
+func TestStructuralCatalogDoesNotUseSQLTruthinessForASTs(t *testing.T) {
+	catalog := &structuralCatalog{}
+	catalog.set(NewSlice([]Scmer{NewSymbol("if"), NewBool(true)}), NewString("literal"))
+	catalog.set(NewSlice([]Scmer{NewSymbol("if"), NewSlice([]Scmer{NewSymbol("probe")})}), NewString("probe"))
+
+	if len(catalog.entries) != 2 {
+		t.Fatalf("structural catalog collapsed truthy AST nodes: %#v", catalog.entries)
+	}
+	got := catalog.get(NewSlice([]Scmer{NewSymbol("if"), NewSlice([]Scmer{NewSymbol("probe")})}))
+	if got.String() != "probe" {
+		t.Fatalf("probe-shaped AST lookup returned %s", SerializeToString(got, &Globalenv))
+	}
+}
+
 func BenchmarkFunctionalAssocBuild(b *testing.B) {
 	env := newOptimizerTestEnv()
 	optimized := optimizeTestSource(b, env, `(lambda (items)

--- a/tests/execution/concurrency/repartition-concurrent.yaml
+++ b/tests/execution/concurrency/repartition-concurrent.yaml
@@ -36,7 +36,7 @@ test_cases:
   # ---- Parallel group: rebuild + concurrent DML ----
   - name: "RC: rebuild (triggers repartition)"
     parallel: repart
-    scm: "(rebuild)"
+    scm: '(rebuild (table "memcp-tests" "rpc_data") false true)'
 
   - name: "RC: concurrent INSERT 200 rows"
     parallel: repart
@@ -134,7 +134,7 @@ test_cases:
 
   # ---- Second rebuild to verify stability ----
   - name: "RC: second rebuild"
-    scm: "(rebuild)"
+    scm: '(rebuild (table "memcp-tests" "rpc_data") false true)'
 
   - name: "RC: count after second rebuild"
     sql: "SELECT COUNT(*) AS cnt FROM rpc_data"
@@ -171,7 +171,7 @@ test_cases:
             61000)
       - name: "RC-del: rebuild"
         parallel: repart_del
-        scm: "(rebuild)"
+        scm: '(rebuild (table "memcp-tests" "rpc_data") false true)'
       - name: "RC-del: concurrent DELETE 50"
         parallel: repart_del
         sql: "DELETE FROM rpc_data WHERE id >= 60950 AND id < 61000"
@@ -213,7 +213,7 @@ test_cases:
             61000)
       - name: "RC-repeat: rebuild"
         parallel: repart_repeat
-        scm: "(rebuild)"
+        scm: '(rebuild (table "memcp-tests" "rpc_data") false true)'
       - name: "RC-repeat: concurrent UPDATE 50"
         parallel: repart_repeat
         sql: "UPDATE rpc_data SET val = -999, tag = 'updated' WHERE id >= 60900 AND id < 60950"

--- a/tests/planner/aggregates/correlated-group-domain.yaml
+++ b/tests/planner/aggregates/correlated-group-domain.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Correlated scalar subqueries over grouped derived tables with an outer grouped
 # domain. This exercises Neumann-style domain extension across multiple group
 # stages without relying on app-specific table names.
@@ -8,11 +23,77 @@ metadata:
   isolated: true
 
 setup:
+
+  - sql: "DROP TABLE IF EXISTS cgd_assignment"
+  - sql: "DROP TABLE IF EXISTS cgd_document"
+  - sql: "DROP TABLE IF EXISTS cgd_location"
   - sql: "DROP TABLE IF EXISTS cgd_state"
   - sql: "CREATE TABLE cgd_state (ID INT PRIMARY KEY, parent INT, grp INT)"
   - sql: "INSERT INTO cgd_state VALUES (1, NULL, 10), (2, 1, 10), (3, NULL, 20), (4, 1, 20), (5, 3, 20)"
+  - sql: "CREATE TABLE cgd_document (ID INT PRIMARY KEY, location_id INT)"
+  - sql: "CREATE TABLE cgd_location (ID INT PRIMARY KEY)"
+  - sql: "CREATE TABLE cgd_assignment (ID INT PRIMARY KEY, actor_id INT, location_id INT)"
+  - sql: "INSERT INTO cgd_location VALUES (1)"
+  - sql: "INSERT INTO cgd_document VALUES (5, 1), (6, 1), (7, 1)"
+  - sql: "INSERT INTO cgd_assignment VALUES (1, 42, 1)"
 
 test_cases:
+
+  - name: "set aggregate carrier session domain"
+    session_id: "cgd_carrier"
+    sql: "SET @actor_id = 42"
+    expect:
+      rows_affected: 0
+
+  - name: "sibling SUM producers survive correlated probe lowering"
+    session_id: "cgd_carrier"
+    sql: |
+      SELECT
+        SUM(CASE TRUE WHEN TRUE THEN 1 ELSE 0 END) AS all_documents,
+        SUM(CASE COALESCE((
+          SELECT EXISTS(
+            SELECT TRUE
+            FROM cgd_assignment a
+            WHERE a.actor_id = @actor_id
+              AND a.location_id = l.ID
+            LIMIT 1
+          )
+          FROM cgd_location l
+          WHERE l.ID = cgd_document.location_id
+          LIMIT 1
+        ), FALSE) WHEN TRUE THEN 1 ELSE 0 END) AS permitted_documents
+      FROM cgd_document
+      WHERE ID IN (5, 6, 7)
+    expect:
+      rows: 1
+      data:
+        - all_documents: 3
+          permitted_documents: 3
+
+  - name: "warm literal-specialized carrier keeps every aggregate producer"
+    session_id: "cgd_carrier"
+    sql: |
+      SELECT
+        SUM(CASE COALESCE((
+          SELECT EXISTS(
+            SELECT TRUE
+            FROM cgd_assignment a
+            WHERE a.actor_id = @actor_id
+              AND a.location_id = l.ID
+            LIMIT 1
+          )
+          FROM cgd_location l
+          WHERE l.ID = cgd_document.location_id
+          LIMIT 1
+        ), FALSE) WHEN TRUE THEN 1 ELSE 0 END) AS permitted_documents,
+        SUM(CASE TRUE WHEN TRUE THEN 1 ELSE 0 END) AS all_documents
+      FROM cgd_document
+      WHERE ID IN (5, 6)
+    expect:
+      rows: 1
+      data:
+        - permitted_documents: 2
+          all_documents: 2
 
   - name: "scalar subquery over grouped inner derived table"
     sql: |
@@ -91,4 +172,7 @@ test_cases:
         - "dependent-subquery"
         - "__mat:o:"
 cleanup:
+  - sql: "DROP TABLE IF EXISTS cgd_assignment"
+  - sql: "DROP TABLE IF EXISTS cgd_document"
+  - sql: "DROP TABLE IF EXISTS cgd_location"
   - sql: "DROP TABLE IF EXISTS cgd_state"


### PR DESCRIPTION
## Summary

- compare planner catalog keys as structural trees instead of using SQL truthiness coercions
- deduplicate aggregate descriptors only through the structural aggregate catalog
- cover cold and warm/literal-specialized plans with sibling aggregate producers around a decorrelated correlated probe

## Root cause

Generic `Equal` is SQL-oriented and can consider a literal `TRUE` equal to a non-empty AST list. Structural catalogs and generic aggregate merging could therefore collapse distinct aggregate expressions depending on projection order. The generated plan then referenced an aggregate carrier column that had never been prepared.

## Validation

- `go test ./scm -run TestStructuralCatalogDoesNotUseSQLTruthinessForASTs`
- `python3 run_sql_tests.py tests/planner/aggregates/correlated-group-domain.yaml` (6/6)
- `python3 run_sql_tests.py tests/performance/traced-planner-scaling.yaml` (7/7)
- `python3 run_sql_tests.py tests/planner/subqueries/traced-union-scalar-probes.yaml` (7/7)
- `python3 run_sql_tests.py tests/execution/concurrency/transactions.yaml` (176/176)
- `python3 run_sql_tests.py tests/planner/order-window/order-limit.yaml` (40/40)
- `python3 tools/lint_scm.py --check` (existing repository bracket-depth warnings only)

A full coverage-enabled `make test` traversed all relevant planner suites but ended non-green on four transient timeout/transaction cases while the host was repeatedly killing test servers with exit 137. Each reported suite passed when rerun individually with a normal build; the same comparison suites also pass on the exact base commit.