### PR TITLE
Bound nested shard fanout per transaction

### DIFF
--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -307,8 +307,8 @@ func structuralEqual(a, b Scmer) bool {
 		}
 		return true
 	}
-	if structuralScalarTag(a.GetTag()) || structuralScalarTag(b.GetTag()) {
-		return structuralScalarTag(a.GetTag()) && structuralScalarTag(b.GetTag()) &&
+	if structuralScalarTag(uint16(a.GetTag())) || structuralScalarTag(uint16(b.GetTag())) {
+		return structuralScalarTag(uint16(a.GetTag())) && structuralScalarTag(uint16(b.GetTag())) &&
 			hashStructuralScalar(a) == hashStructuralScalar(b) && Equal(a, b)
 	}
 	return Equal(a, b)

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -53,6 +53,90 @@ func computeShardIndex(schema []shardDimension, values []scm.Scmer) (result int)
 	return // schema[0] has the higest stride; schema[len(schema)-1] is the least significant bit
 }
 
+// runFanoutTasks executes a fanout without recursively multiplying worker
+// pools. Transactions reserve at most half of their remaining budget. When
+// only one worker is available, the caller performs the work directly without
+// goroutines, channels, wait groups, or GLS propagation.
+func runFanoutTasks(currentTx *TxContext, taskCount int, task func(int, bool)) <-chan struct{} {
+	if taskCount <= 0 {
+		return nil
+	}
+	// This check must stay ahead of claimFanoutWorkers: point/range pruning to
+	// one shard must not read, write, or invalidate the budget cache line.
+	if taskCount == 1 {
+		task(0, true)
+		return nil
+	}
+
+	workers := runtime.GOMAXPROCS(0) / 2
+	claimedWorkers := 0
+	if currentTx != nil {
+		claimedWorkers = currentTx.claimFanoutWorkers(taskCount)
+		workers = claimedWorkers
+	}
+	if workers > taskCount {
+		workers = taskCount
+	}
+	if workers < 2 {
+		for i := 0; i < taskCount; i++ {
+			task(i, true)
+		}
+		return nil
+	}
+
+	jobs := make(chan int, taskCount)
+	doneCh := make(chan struct{})
+	var remainingWorkers atomic.Int32
+	remainingWorkers.Store(int32(workers))
+	startWorker := gls.Go
+	if currentTx != nil {
+		startWorker = func(worker func()) {
+			go func() {
+				withTxSession(currentTx, func() scm.Scmer {
+					worker()
+					return scm.NewNil()
+				})
+			}()
+		}
+	}
+	for i := 0; i < workers; i++ {
+		startWorker(func() {
+			defer func() {
+				if remainingWorkers.Add(-1) == 0 {
+					if currentTx != nil {
+						currentTx.releaseFanoutWorkers(claimedWorkers)
+					}
+					close(doneCh)
+				}
+			}()
+			for taskIndex := range jobs {
+				task(taskIndex, false)
+			}
+		})
+	}
+	for i := 0; i < taskCount; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	return doneCh
+}
+
+// shardResultBufferSize bounds synchronous multi-shard result buffering. It
+// snapshots only shard topology and does not touch the transaction fanout
+// budget; callers reach it after boundary analysis has selected a table scan.
+func (t *table) shardResultBufferSize() int {
+	t.shardModeMu.RLock()
+	defer t.shardModeMu.RUnlock()
+	size := len(t.PShards)
+	if t.ShardMode == ShardModeFree {
+		size = len(t.Shards)
+	}
+	if size < 1 {
+		return 1
+	}
+	return size
+}
+
 func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
 	// Keep shard acquisition outside physical scan callbacks. In clustered mode
 	// this is the orchestration point that can choose a local SHARED copy or send
@@ -69,51 +153,15 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 	}
 
 	runWorkers := func(shards []*storageShard, onDone func(*storageShard)) <-chan struct{} {
-		workers := runtime.NumCPU()
-		if workers < 1 {
-			workers = 1
-		}
-		if workers > len(shards) {
-			workers = len(shards)
-		}
-
-		jobs := make(chan *storageShard, len(shards))
-		doneCh := make(chan struct{})
-		var done sync.WaitGroup
-		done.Add(len(shards))
-		startWorker := gls.Go
-		if currentTx != nil && currentTx.autoCommit {
-			startWorker = func(worker func()) {
-				go func() {
-					withTxSession(currentTx, func() scm.Scmer {
-						worker()
-						return scm.NewNil()
-					})
-				}()
+		return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
+			s := shards[i]
+			release := s.GetRead()
+			defer release()
+			callback(s, synchronous)
+			if onDone != nil {
+				onDone(s)
 			}
-		}
-		for i := 0; i < workers; i++ {
-			startWorker(func() {
-				for s := range jobs {
-					release := s.GetRead()
-					callback(s, false)
-					release()
-					if onDone != nil {
-						onDone(s)
-					}
-					done.Done()
-				}
-			})
-		}
-		for _, s := range shards {
-			jobs <- s
-		}
-		close(jobs)
-		go func() {
-			done.Wait()
-			close(doneCh)
-		}()
-		return doneCh
+		})
 	}
 
 	// Hold shardModeMu.RLock while reading ShardMode and capturing shard list.

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -209,19 +209,6 @@ type recSetKeyResult struct {
 	err  scanError
 }
 
-func (t *table) recSetShardResultBufferSize() int {
-	t.shardModeMu.RLock()
-	defer t.shardModeMu.RUnlock()
-	size := len(t.PShards)
-	if t.ShardMode == ShardModeFree {
-		size = len(t.Shards)
-	}
-	if size < 1 {
-		return 1
-	}
-	return size
-}
-
 func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, condition scm.Scmer) *recSet {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
@@ -231,7 +218,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	lower, upperLast := indexFromBoundaries(boundaries)
 	result := &recSet{tx: currentTx, table: t}
 
-	values := make(chan recSetBuildResult, t.recSetShardResultBufferSize())
+	values := make(chan recSetBuildResult, t.shardResultBufferSize())
 	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
 		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
@@ -250,14 +237,10 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 			return scm.NewNil()
 		})
 	})
-	if done == nil {
-		close(values)
-	} else {
-		go func() {
-			<-done
-			close(values)
-		}()
+	if done != nil {
+		<-done
 	}
+	close(values)
 
 	var buildErr scanError
 	for msg := range values {
@@ -519,35 +502,38 @@ func (r *recSet) collectProjectJoinKeys(currentTx *TxContext, sourceKeyCols []st
 	for i := range r.shards {
 		offsets[i+1] = offsets[i] + int(r.shards[i].count)*width
 	}
-	closeAfter := 0
+	activeParts := make([]int, 0, len(r.shards))
 	for i := range r.shards {
-		part := r.shards[i]
-		if part.count == 0 {
-			continue
+		if r.shards[i].count > 0 {
+			activeParts = append(activeParts, i)
 		}
-		closeAfter++
-		go func(partIndex int, part recSetShard) {
-			withTxSession(currentTx, func() scm.Scmer {
-				defer func() {
-					if rec := recover(); rec != nil {
-						values <- recSetKeyResult{part: partIndex, err: scanError{rec, string(debug.Stack())}}
-					}
-				}()
-				// Cancellation contract: check only at the scheduling boundary, before entering
-				// the shard. Once entered, a shard runs atomically without cancellation checks.
-				if ss != nil && ss.IsKilledSeq(querySeq) {
-					panic("query killed")
+	}
+	done := runFanoutTasks(currentTx, len(activeParts), func(taskIndex int, _ bool) {
+		partIndex := activeParts[taskIndex]
+		part := r.shards[partIndex]
+		withTxSession(currentTx, func() scm.Scmer {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- recSetKeyResult{part: partIndex, err: scanError{rec, string(debug.Stack())}}
 				}
-				dst := keys.values[offsets[partIndex]:offsets[partIndex+1]]
-				used := part.shard.collectProjectJoinKeys(&part, sourceKeyCols, currentTx, ss, dst)
-				values <- recSetKeyResult{part: partIndex, used: used}
-				return scm.NewNil()
-			})
-		}(i, part)
+			}()
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
+				panic("query killed")
+			}
+			dst := keys.values[offsets[partIndex]:offsets[partIndex+1]]
+			used := part.shard.collectProjectJoinKeys(&part, sourceKeyCols, currentTx, ss, dst)
+			values <- recSetKeyResult{part: partIndex, used: used}
+			return scm.NewNil()
+		})
+	})
+	if done != nil {
+		<-done
 	}
 	used := make([]int, len(r.shards))
 	var keyErr scanError
-	for i := 0; i < closeAfter; i++ {
+	for i := 0; i < len(activeParts); i++ {
 		msg := <-values
 		if msg.err.r != nil {
 			if keyErr.r == nil {
@@ -667,7 +653,7 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 		part recSetShard
 		err  scanError
 	}
-	values := make(chan targetPartResult, t.recSetShardResultBufferSize())
+	values := make(chan targetPartResult, t.shardResultBufferSize())
 	done := t.iterateShardsParallel(currentTx, nil, func(shard *storageShard, solo bool) {
 		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
@@ -685,14 +671,10 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 			return scm.NewNil()
 		})
 	})
-	if done == nil {
-		close(values)
-	} else {
-		go func() {
-			<-done
-			close(values)
-		}()
+	if done != nil {
+		<-done
 	}
+	close(values)
 	var joinErr scanError
 	for msg := range values {
 		if msg.err.r != nil {
@@ -878,35 +860,34 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
 	values := make(chan scanResult, len(r.shards))
+	activeParts := make([]int, 0, len(r.shards))
 	for i := range r.shards {
-		rsShard := r.shards[i]
-		if rsShard.count == 0 {
-			continue
+		if r.shards[i].count > 0 {
+			activeParts = append(activeParts, i)
 		}
-		go func(part recSetShard) {
-			withTxSession(currentTx, func() scm.Scmer {
-				defer func() {
-					if rec := recover(); rec != nil {
-						values <- scanResult{err: scanError{rec, string(debug.Stack())}}
-					}
-				}()
-				// Cancellation contract: check only at the scheduling boundary, before entering
-				// the shard. Once entered, a shard runs atomically without cancellation checks.
-				if ss != nil && ss.IsKilledSeq(querySeq) {
-					panic("query killed")
+	}
+	done := runFanoutTasks(currentTx, len(activeParts), func(taskIndex int, _ bool) {
+		part := r.shards[activeParts[taskIndex]]
+		withTxSession(currentTx, func() scm.Scmer {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- scanResult{err: scanError{rec, string(debug.Stack())}}
 				}
-				res, cnt := part.shard.scanRecSetPart(&part, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
-				values <- scanResult{res: res, outCount: cnt, inputCount: part.count}
-				return scm.NewNil()
-			})
-		}(rsShard)
+			}()
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
+				panic("query killed")
+			}
+			res, cnt := part.shard.scanRecSetPart(&part, conditionCols, condition, callbackCols, callback, aggregate, neutral, currentTx, ss)
+			values <- scanResult{res: res, outCount: cnt, inputCount: part.count}
+			return scm.NewNil()
+		})
+	})
+	if done != nil {
+		<-done
 	}
-	closeAfter := 0
-	for _, part := range r.shards {
-		if part.count > 0 {
-			closeAfter++
-		}
-	}
+	closeAfter := len(activeParts)
 	akkumulator := neutral
 	hadValue := false
 	var scanErr scanError
@@ -986,34 +967,37 @@ func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condit
 	}
 	values := make(chan existsResult, len(r.shards))
 	var stop atomic.Bool
-	closeAfter := 0
+	activeParts := make([]int, 0, len(r.shards))
 	for i := range r.shards {
-		part := &r.shards[i]
-		if part.count == 0 {
-			continue
+		if r.shards[i].count > 0 {
+			activeParts = append(activeParts, i)
 		}
-		closeAfter++
-		go func(part recSetShard) {
-			withTxSession(currentTx, func() scm.Scmer {
-				defer func() {
-					if rec := recover(); rec != nil {
-						values <- existsResult{err: scanError{rec, string(debug.Stack())}}
-					}
-				}()
-				// Cancellation contract: check only at the scheduling boundary, before entering
-				// the shard. Once entered, a shard runs atomically without cancellation checks.
-				if ss != nil && ss.IsKilledSeq(querySeq) {
-					panic("query killed")
-				}
-				found := part.shard.recSetPartExists(&part, conditionCols, conditionFn, currentTx, ss, &stop)
-				if found {
-					stop.Store(true)
-				}
-				values <- existsResult{found: found}
-				return scm.NewNil()
-			})
-		}(*part)
 	}
+	done := runFanoutTasks(currentTx, len(activeParts), func(taskIndex int, _ bool) {
+		part := r.shards[activeParts[taskIndex]]
+		withTxSession(currentTx, func() scm.Scmer {
+			defer func() {
+				if rec := recover(); rec != nil {
+					values <- existsResult{err: scanError{rec, string(debug.Stack())}}
+				}
+			}()
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
+				panic("query killed")
+			}
+			found := part.shard.recSetPartExists(&part, conditionCols, conditionFn, currentTx, ss, &stop)
+			if found {
+				stop.Store(true)
+			}
+			values <- existsResult{found: found}
+			return scm.NewNil()
+		})
+	})
+	if done != nil {
+		<-done
+	}
+	closeAfter := len(activeParts)
 	var existsErr scanError
 	found := false
 	for i := 0; i < closeAfter; i++ {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -456,7 +456,7 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 		t.AddPartitioningScore([]string{b.col})
 	}
 
-	values := make(chan scanResult, 4)
+	values := make(chan scanResult, t.shardResultBufferSize())
 	var found atomic.Bool
 	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		if found.Load() {
@@ -480,14 +480,10 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 		}
 		values <- scanResult{}
 	})
-	if done == nil {
-		close(values)
-	} else {
-		go func() {
-			<-done
-			close(values)
-		}()
+	if done != nil {
+		<-done
 	}
+	close(values)
 
 	var scanErr scanError
 	for msg := range values {
@@ -559,7 +555,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	var outCount int64
 	var inputCount int64
 	var candidateCount int64
-	values := make(chan scanResult, 4)
+	values := make(chan scanResult, t.shardResultBufferSize())
 	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -574,14 +570,10 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, recsetFilter)
 		values <- scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount}
 	})
-	if done == nil {
-		close(values)
-	} else {
-		go func() {
-			<-done
-			close(values)
-		}()
+	if done != nil {
+		<-done
 	}
+	close(values)
 
 	akkumulator := neutral
 	hadValue := false

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -528,8 +528,19 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	}
 
 	var q globalqueue
-	q_ := make(chan scanOrderResult, len(tables)*4)
-	var wg sync.WaitGroup
+	resultBufferSize := 0
+	for i := range tables {
+		if tables[i].recset != nil {
+			resultBufferSize += len(tables[i].recset.shards)
+		} else {
+			resultBufferSize += tables[i].backingTable().shardResultBufferSize()
+		}
+	}
+	if resultBufferSize < 1 {
+		resultBufferSize = 1
+	}
+	q_ := make(chan scanOrderResult, resultBufferSize)
+	doneChannels := make([]<-chan struct{}, 0, len(tables))
 	querySeq := querySeqFromTx(currentTx)
 	stats := make([]scanOrderStats, len(tables))
 
@@ -592,10 +603,12 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 		if spec.recset != nil {
 			if len(sortcols) > 0 {
-				wg.Add(1)
-				go func(parts []recSetShard) {
+				// Ordered RecSet parts intentionally form one sequential producer.
+				// The result channel is sized for every part, so a one-worker path
+				// can execute directly without a goroutine or waiter.
+				runFanoutTasks(currentTx, 1, func(_ int, _ bool) {
+					parts := spec.recset.shards
 					withTxSession(currentTx, func() scm.Scmer {
-						defer wg.Done()
 						defer func() {
 							if r := recover(); r != nil {
 								q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
@@ -625,35 +638,37 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 						}
 						return scm.NewNil()
 					})
-				}(spec.recset.shards)
+				})
 			} else {
+				activeParts := make([]int, 0, len(spec.recset.shards))
 				for i := range spec.recset.shards {
-					part := spec.recset.shards[i]
-					if part.count == 0 {
-						continue
+					if spec.recset.shards[i].count > 0 {
+						activeParts = append(activeParts, i)
 					}
-					wg.Add(1)
-					go func(part recSetShard) {
-						withTxSession(currentTx, func() scm.Scmer {
-							defer wg.Done()
-							defer func() {
-								if r := recover(); r != nil {
-									q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
-								}
-							}()
-							// Cancellation contract: check only at the scheduling boundary, before entering
-							// the shard. Once entered, a shard runs atomically without cancellation checks.
-							if ss != nil && ss.IsKilledSeq(querySeq) {
-								panic("query killed")
+				}
+				done := runFanoutTasks(currentTx, len(activeParts), func(taskIndex int, _ bool) {
+					part := spec.recset.shards[activeParts[taskIndex]]
+					withTxSession(currentTx, func() scm.Scmer {
+						defer func() {
+							if r := recover(); r != nil {
+								q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 							}
-							res := part.shard.scan_order_recset_part(&part, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
-							res.callbackCols = callbackCols
-							res.callback = callback
-							res.tableIdx = tableIdx
-							q_ <- scanOrderResult{res: res, inputCount: part.count, candidateCount: part.count, outputCount: int64(len(res.items))}
-							return scm.NewNil()
-						})
-					}(part)
+						}()
+						// Cancellation contract: check only at the scheduling boundary, before entering
+						// the shard. Once entered, a shard runs atomically without cancellation checks.
+						if ss != nil && ss.IsKilledSeq(querySeq) {
+							panic("query killed")
+						}
+						res := part.shard.scan_order_recset_part(&part, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+						res.callbackCols = callbackCols
+						res.callback = callback
+						res.tableIdx = tableIdx
+						q_ <- scanOrderResult{res: res, inputCount: part.count, candidateCount: part.count, outputCount: int64(len(res.items))}
+						return scm.NewNil()
+					})
+				})
+				if done != nil {
+					doneChannels = append(doneChannels, done)
 				}
 			}
 		} else {
@@ -675,21 +690,24 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				q_ <- scanOrderResult{res: res, inputCount: int64(s.Count()), candidateCount: res.candidateCount, outputCount: int64(len(res.items))}
 			})
 			if done != nil {
-				wg.Add(1)
-				go func(ch <-chan struct{}) {
-					<-ch
-					wg.Done()
-				}(done)
+				doneChannels = append(doneChannels, done)
 			}
 		}
 
 	}
 
-	// Close result channel when all tables' shard scans complete
-	go func() {
-		wg.Wait()
+	// Synchronous scans have already filled the bounded result channel. Only a
+	// real fanout needs a coordinator goroutine while this caller consumes.
+	if len(doneChannels) == 0 {
 		close(q_)
-	}()
+	} else {
+		go func() {
+			for _, done := range doneChannels {
+				<-done
+			}
+			close(q_)
+		}()
+	}
 
 	// Collect shard results into globalqueue
 	var scanErr scanError

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "github.com/carli2/hybridsort"
+import "runtime"
 import "sync"
 import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
@@ -109,6 +110,10 @@ type TxContext struct {
 	Session       scm.Scmer
 	SessionState  *scm.SessionState // cached to avoid GLS stack-walking
 	querySeq      atomic.Uint64     // autocommit statement generation for cancellation checks
+	// fanoutLimit/fanoutInUse bound only additional multi-shard workers. A
+	// single relevant shard never reads or writes this cache line.
+	fanoutLimit atomic.Int32
+	fanoutInUse atomic.Int32
 
 	// Per-shard state, nil until first write (zero-alloc for read-only transactions).
 	shards map[*storageShard]*storageShardTransaction
@@ -128,10 +133,41 @@ func NewTxContext(mode TxMode) *TxContext {
 		State: TxActive,
 		Mode:  mode,
 	}
+	tx.fanoutLimit.Store(int32(runtime.GOMAXPROCS(0)))
 	if mode == TxACID {
 		tx.SnapshotEpoch = atomic.LoadUint64(&GlobalCommitEpoch)
 	}
 	return tx
+}
+
+// claimFanoutWorkers reserves at most half of the transaction's remaining
+// fanout capacity. It never blocks: callers run synchronously when fewer than
+// two workers can be claimed, preventing nested scans from waiting on their
+// parents' reservations.
+func (tx *TxContext) claimFanoutWorkers(maxWorkers int) int {
+	if tx == nil || maxWorkers < 2 {
+		return 0
+	}
+	for {
+		limit := tx.fanoutLimit.Load()
+		used := tx.fanoutInUse.Load()
+		claim := (limit - used) / 2
+		if claim > int32(maxWorkers) {
+			claim = int32(maxWorkers)
+		}
+		if claim < 2 {
+			return 0
+		}
+		if tx.fanoutInUse.CompareAndSwap(used, used+claim) {
+			return int(claim)
+		}
+	}
+}
+
+func (tx *TxContext) releaseFanoutWorkers(workers int) {
+	if workers > 0 {
+		tx.fanoutInUse.Add(-int32(workers))
+	}
 }
 
 func (tx *TxContext) SessionValue(key string) scm.Scmer {

--- a/tests/execution/operators/scan-shard-coverage.yaml
+++ b/tests/execution/operators/scan-shard-coverage.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Scan & Shard Coverage Tests
 # Targeted tests to exercise uncovered code paths in scan.go, scan_order.go, shard.go
 
@@ -15,6 +30,8 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS cov_trig_log"
   - sql: "DROP TABLE IF EXISTS cov_collate"
   - sql: "DROP TABLE IF EXISTS cov_main_store"
+  - sql: "DROP TABLE IF EXISTS cov_fanout_outer"
+  - sql: "DROP TABLE IF EXISTS cov_fanout_lookup"
 
 setup:
   - sql: "CREATE TABLE cov_main (id INT, val INT, label VARCHAR(50))"
@@ -719,3 +736,37 @@ test_cases:
 
   - name: "Cleanup main storage table"
     sql: "DROP TABLE IF EXISTS cov_main_store"
+
+  - name: "Nested multi-shard probes preserve every result with bounded fanout"
+    setup:
+      - scm: '(settings "ShardSize" 8)'
+      - sql: "CREATE TABLE cov_fanout_outer (id INT PRIMARY KEY, lookup_id INT, bucket INT)"
+      - sql: "CREATE TABLE cov_fanout_lookup (id INT PRIMARY KEY, value INT, bucket INT)"
+      - scm: |
+          (begin
+            (define rows (produceN 256 (lambda (i) (list (+ i 1) (+ i 1) (mod i 32)))))
+            (insert (table "memcp-tests" "cov_fanout_outer") '("id" "lookup_id" "bucket") rows '() (lambda () true) false))
+      - scm: |
+          (begin
+            (define rows (produceN 256 (lambda (i) (list (+ i 1) (* (+ i 1) 3) (mod i 32)))))
+            (insert (table "memcp-tests" "cov_fanout_lookup") '("id" "value" "bucket") rows '() (lambda () true) false))
+      - sql: "SELECT COUNT(*) AS n FROM cov_fanout_outer WHERE bucket >= 0"
+      - sql: "SELECT COUNT(*) AS n FROM cov_fanout_lookup WHERE bucket >= 0"
+      - scm: '(rebuild (table "memcp-tests" "cov_fanout_outer") true true)'
+      - scm: '(rebuild (table "memcp-tests" "cov_fanout_lookup") true true)'
+    sql: |
+      SELECT SUM((
+        SELECT l.value
+        FROM cov_fanout_lookup l
+        WHERE l.id = o.lookup_id
+        LIMIT 1
+      )) AS total
+      FROM cov_fanout_outer o
+    max_time: 1.0
+    expect:
+      rows: 1
+      data:
+        - total: 98688
+
+  - name: "Restore default shard size after bounded fanout coverage"
+    scm: '(settings "ShardSize" 60000)'


### PR DESCRIPTION
## Summary

- add a transaction-scoped fanout budget initialized from `GOMAXPROCS`
- let each multi-shard scan claim at most half of the remaining transaction budget
- execute exhausted/one-worker fanout synchronously without goroutines, channels, wait groups, or GLS propagation
- keep one-shard point/range scans ahead of every budget load/CAS
- route table scans, ordered scans, RecSet scans/projections, and existence probes through the same bounded runner
- close parallel pools with one atomic operation per worker, not per shard/item
- fix the current master build mismatch between `Scmer.GetTag()` and structural scalar tag checks

## A/B measurements

Same non-coverage builds and anonymous fixtures, 7 timed samples after setup.

Nested 1024-row / 128-bucket scalar lookup, with both relations repartitioned and every outer row probing the inner relation:

| | master | PR |
|---|---:|---:|
| median | 55.12 ms | 29.65 ms |
| result | 1,574,400 | 1,574,400 |

This is a 1.86x speedup while preserving the checksum/result. A smaller 256-row fixture is covered permanently in the YAML suite.

Controls:

- single-shard aggregate: repeated 21-sample medians overlap (roughly 1.4-1.8 ms on both builds); the fast path does not touch the fanout atomics
- flat ordered 200k-row scan repartitioned to 48 shards: master uses 24 workers; the specified budget uses 12. Median-of-run medians was about 169.6 ms master vs 183.3 ms PR (~8% latency cost) in exchange for bounded nested fanout and per-query fairness. This trade-off is explicit rather than hidden.

## Validation

- `scan-shard-coverage.yaml`: 114/114
- `range-scan-coverage.yaml`: 99/99
- `recset.yaml`: 29/29
- `scan-batch-optimizer.yaml`: 11/11
- `order-limit.yaml`: 40/40 (normal build)
- full pre-commit YAML hook, all suites: green; internal parallel groups included

The permanent regression is YAML-only; no Go tests were added.