### PR TITLE
Fix correlated scalar representative binding

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -956,6 +956,29 @@ instead of capturing whichever session populated the cache first. */
 (define correlation_domain (lambda (pairs)
 	(merge_unique (list (correlation_lookup_keys pairs)))))
 
+/* Equality decorrelation makes each outer lookup expression equivalent to its
+inner key. Rewrite later scalar expressions to that local representative before
+they enter a group-stage, so physical lowering never receives a free outer
+binding. The structural index hashes the complete root once; each AST node is
+then matched without repeated deep comparisons. */
+(define decorrelate_expr_with_pairs (lambda (inner_default pairs expr)
+	(begin
+		(define pair_list (coalesceNil pairs '()))
+		(if (empty_list? pair_list)
+			expr
+			(begin
+				(define replacements (correlation_inner_keys inner_default pair_list))
+				(define index (make_structural_index (correlation_lookup_keys pair_list) (list expr)))
+				(define rewrite (lambda (node)
+					(begin
+						(define idx (index node))
+						(if (nil? idx)
+							(match node
+								(cons head tail) (cons head (map tail rewrite))
+								_ node)
+							(nth replacements idx)))))
+				(rewrite expr))))))
+
 (define btw2025_cclasses_for_pairs (lambda (pairs)
 	(map (coalesceNil pairs '()) (lambda (pair)
 		(list (nth pair 0) (nth pair 1))))))
@@ -2229,10 +2252,6 @@ without separately proving two-valued semantics. */
 			(neumann_fail "untangle_query" "scalar aggregate group-stage(D) currently supports one plain inner query-block")
 			true)
 		(define value_expr (query_block_first_expr inner))
-		(define ags (dedupe_aggregates_by_col (merge (list (extract_aggregates value_expr) (list aggregate_count_descriptor)))))
-		(if (empty_list? ags)
-			(neumann_fail "untangle_query" "table-backed scalar subquery without aggregate needs cardinality_mode single_or_error lowering")
-			true)
 		(define inner_src (car (qb_sources inner)))
 		(define inner_sources (qb_sources inner))
 		(define inner_default (source_alias inner_src))
@@ -2251,13 +2270,19 @@ without separately proving two-valued semantics. */
 		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
 		(define all_corr_pairs (domain_correlation_pairs (merge (list
 			corr_pairs having_corr_pairs source_corr_pairs (session_domain_pairs inner)))))
+		(define local_value_expr (decorrelate_expr_with_pairs inner_default all_corr_pairs value_expr))
+		(define ags (dedupe_aggregates_by_col (merge (list (extract_aggregates local_value_expr) (list aggregate_count_descriptor)))))
+		(if (empty_list? ags)
+			(neumann_fail "untangle_query" "table-backed scalar subquery without aggregate needs cardinality_mode single_or_error lowering")
+			true)
 		(define explicit_group_keys (map (coalesceNil (qb_group inner) '()) (lambda (expr)
 			(canonical_column_expr_for_alias inner_default expr))))
 		(define keys (group_keys_for_correlations inner_default all_corr_pairs explicit_group_keys))
 		(define outer_domain (correlation_domain all_corr_pairs))
 		(define lookup_keys (correlation_lookup_keys all_corr_pairs))
 		(define condition (combine_where_terms local_terms true))
-		(define local_having (combine_where_terms local_having_terms true))
+		(define local_having (decorrelate_expr_with_pairs inner_default all_corr_pairs
+			(combine_where_terms local_having_terms true)))
 		(define stage_input (if (and (single_source? (qb_sources inner)) (empty_list? (qb_stages inner)))
 			inner_src
 			(make_query_block
@@ -2301,7 +2326,7 @@ without separately proving two-valued semantics. */
 			(or (stage_source_outer? outer_sources) (not (equal? local_having true)))
 			(make_stage_lookup_condition stage_alias key_names lookup_keys post_condition)))
 		(define presence_expr (list (quote get_column) stage_alias false (aggregate_col_name aggregate_count_descriptor) false))
-		(define scalar_value_expr (replace_group_expr stage_input inner_default stage_alias keys key_names ags value_expr))
+		(define scalar_value_expr (replace_group_expr stage_input inner_default stage_alias keys key_names ags local_value_expr))
 		(list
 			(if (equal? local_having true)
 				scalar_value_expr
@@ -2339,9 +2364,11 @@ without separately proving two-valued semantics. */
 		(define outer_domain (correlation_domain lookup_pairs))
 		(define lookup_keys (correlation_lookup_keys lookup_pairs))
 		(define condition (combine_where_terms local_terms true))
-		(define value_for_inner (canonical_column_expr_for_alias inner_default value_expr))
+		(define value_for_inner (canonical_column_expr_for_alias inner_default
+			(decorrelate_expr_with_pairs inner_default lookup_pairs value_expr)))
 		(define order_for_inner (map (coalesceNil (qb_order inner) '()) (lambda (item)
-			(match item '(expr dir) (list (canonical_column_expr_for_alias inner_default expr) dir)))))
+			(match item '(expr dir) (list (canonical_column_expr_for_alias inner_default
+				(decorrelate_expr_with_pairs inner_default lookup_pairs expr)) dir)))))
 		(define ag (scalar_once_descriptor value_for_inner order_for_inner (qb_offset inner)))
 		(define ags (list ag))
 		(define stage_input (if (empty_list? (qb_stages inner))
@@ -2698,7 +2725,8 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(define outer_domain (correlation_domain lookup_pairs))
 		(define lookup_keys (correlation_lookup_keys lookup_pairs))
 		(define condition (combine_where_terms local_terms true))
-		(define value_for_inner (canonical_column_expr_for_alias inner_default value_expr))
+		(define value_for_inner (canonical_column_expr_for_alias inner_default
+			(decorrelate_expr_with_pairs inner_default lookup_pairs value_expr)))
 		(define ags (scalar_single_aggregates value_for_inner))
 		(define value_ag (car ags))
 		(define count_ag (cadr ags))

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -307,8 +307,8 @@ func structuralEqual(a, b Scmer) bool {
 		}
 		return true
 	}
-	if structuralScalarTag(uint16(a.GetTag())) || structuralScalarTag(uint16(b.GetTag())) {
-		return structuralScalarTag(uint16(a.GetTag())) && structuralScalarTag(uint16(b.GetTag())) &&
+	if structuralScalarTag(a.GetTag()) || structuralScalarTag(b.GetTag()) {
+		return structuralScalarTag(a.GetTag()) && structuralScalarTag(b.GetTag()) &&
 			hashStructuralScalar(a) == hashStructuralScalar(b) && Equal(a, b)
 	}
 	return Equal(a, b)

--- a/tests/planner/core/name-resolution-scopes.yaml
+++ b/tests/planner/core/name-resolution-scopes.yaml
@@ -359,6 +359,119 @@ test_cases:
     expect:
       error: true
 
+  - name: "Parallel sibling scalar scopes keep their repeated local alias"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT wrapped.*
+      FROM (
+        SELECT o.ID,
+          COALESCE((
+            SELECT probe.ID = o.file_id
+            FROM nr_inner probe
+            WHERE probe.ID = o.file_id
+            LIMIT 1
+          ), FALSE) AS first_match,
+          COALESCE((
+            SELECT probe.ID = o.file_id
+            FROM nr_inner probe
+            WHERE probe.ID = o.file_id
+            LIMIT 1
+          ), FALSE) AS second_match
+        FROM nr_outer o
+      ) wrapped
+      ORDER BY wrapped.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1, first_match: true, second_match: true}
+        - {ID: 2, first_match: true, second_match: true}
+
+  - name: "Correlated scalar values bind equality representatives locally"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT o.ID,
+        (
+          SELECT probe.ID = o.file_id
+          FROM nr_inner probe
+          WHERE probe.ID = o.file_id
+        ) AS exact_match,
+        (
+          SELECT SUM(CASE WHEN probe.ID = o.file_id THEN 1 ELSE 0 END)
+          FROM nr_inner probe
+          WHERE probe.ID = o.file_id
+        ) AS matching_rows
+      FROM nr_outer o
+      ORDER BY o.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1, exact_match: true, matching_rows: 1}
+        - {ID: 2, exact_match: true, matching_rows: 1}
+
+  - name: "Parallel quoted numeric alias remains local in a lazy branch"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT wrapped.*
+      FROM (
+        SELECT o.ID,
+          CASE WHEN TRUE THEN TRUE ELSE NOT ((
+            SELECT `26local`.ID = o.file_id
+            FROM nr_inner `26local`
+            WHERE `26local`.ID = o.file_id
+            LIMIT 1
+          )) END AS allowed
+        FROM nr_outer o
+      ) wrapped
+      ORDER BY wrapped.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1, allowed: true}
+        - {ID: 2, allowed: true}
+
+  - name: "Parallel unqualified ID remains a column beside nested probes"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT CONCAT('row-', o.ID) AS description,
+        COALESCE((
+          SELECT probe.label
+          FROM nr_inner probe
+          WHERE probe.ID = o.file_id
+          LIMIT 1
+        ), '') AS label
+      FROM nr_outer o
+      WHERE ID = 1
+    expect:
+      rows: 1
+      data:
+        - {description: "row-1", label: "ten"}
+
+  - name: "Parallel nested EXISTS keeps table names separate from aliases"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT wrapped.*
+      FROM (
+        SELECT o.ID, EXISTS (
+          SELECT TRUE
+          FROM nr_inner member_row
+          WHERE member_row.ID = o.file_id
+            AND EXISTS (
+              SELECT TRUE
+              FROM nr_leaf marker
+              WHERE marker.leaf_id = o.ID
+              LIMIT 1
+            )
+          LIMIT 1
+        ) AS visible
+        FROM nr_outer o
+      ) wrapped
+      ORDER BY wrapped.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1, visible: true}
+        - {ID: 2, visible: false}
+
   - name: "JOIN ON cannot reference a later source"
     sql: |
       SELECT o.ID


### PR DESCRIPTION
## What changed

- rewrite correlated equality representatives into scalar value, ordering, aggregate, and HAVING expressions during logical decorrelation
- use one structural index and one AST walk instead of repeated deep equality searches
- add anonymous parallel scope regressions for repeated aliases, quoted digit-leading aliases, unqualified columns, nested `EXISTS`, scalar cardinality, and scalar aggregates
- repair the `uint8` structural-tag call sites left inconsistent by the recent merge of #477 and #479

## Root cause

The binder and equality extraction correctly converted `inner.key = outer.key` into a Domain-D lookup pair. Scalar SELECT expressions could still retain the original outer expression, though. Physical group-cache initialization is a closed recipe, so that free outer binding produced false values even though the matching inner row existed.

The fix stays on the logical side of the planner boundary: equality decorrelation substitutes the local representative before constructing the `group-stage`. `build_queryplan` therefore receives a closed logical stage and needs no correlation-specific physical fallback.

## Validation

- `python3 run_sql_tests.py tests/planner/core/name-resolution-scopes.yaml`: 37/37 passed
- `go test ./scm`: passed
- full `make test`: the new suite and related scalar/decorrelation suites passed; the long shared-instance run later suffered repeated OOM restarts and failed three unrelated performance checks
- fresh isolation after the full run:
  - `group-cache-invalidation.yaml`: 117/117 passed
  - `traced-union-scalar-probes.yaml`: 7/7 passed
  - `order-limit.yaml`: existing large OFFSET performance guard remains over budget at 6.75 s versus 5.18 s, with correct output

The PR is left draft until CI confirms the clean-run result.
