### PR TITLE
Prefer exact point prefixes over LIKE matcher indexes

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -916,9 +916,10 @@ func materializeBatchBoundaries(template boundaries, stride int, batchdata []scm
 	return result
 }
 
-// reorderByFrequency re-sorts equality columns by query frequency (most-used first)
-// so that the most-queried columns appear first in the index key, maximizing prefix
-// overlap across queries. Also bumps the frequency counters for each boundary column.
+// reorderByFrequency keeps exact sorted points ahead of matcher-backed points.
+// A PK equality must be allowed to narrow a nested probe before an expensive LIKE
+// matcher is considered. Frequency only reorders boundaries with the same access
+// characteristics, preserving prefix reuse without overriding that cost property.
 func reorderByFrequency(bounds boundaries, t *table) {
 	for _, b := range bounds {
 		t.bumpColFreq(b.col)
@@ -928,6 +929,11 @@ func reorderByFrequency(bounds boundaries, t *table) {
 		jEq := boundaryIsPoint(bounds[j])
 		if iEq != jEq {
 			return iEq // equality first
+		}
+		iSortedPoint := iEq && bounds[i].matcher.IsSorted()
+		jSortedPoint := jEq && bounds[j].matcher.IsSorted()
+		if iSortedPoint != jSortedPoint {
+			return iSortedPoint
 		}
 		if iEq && jEq {
 			fi, fj := t.getColFreq(bounds[i].col), t.getColFreq(bounds[j].col)
@@ -1215,6 +1221,21 @@ func scmerStructEqual(a, b scm.Scmer) bool {
 
 func indexFromBoundaries(cols boundaries) (lower []scm.Scmer, upperLast scm.Scmer) {
 	if len(cols) > 0 {
+		// A non-sorted matcher after an exact sorted prefix is cheaper as a
+		// residual predicate: the prefix has already reduced the candidate set,
+		// while building a matcher skip list would scan the complete shard. Keep
+		// matcher-backed access for scans which have no exact sorted prefix.
+		hasExactPrefix := false
+		for i, col := range cols {
+			if col.matcher.IsSorted() && col.matcher.IsPointLike() {
+				hasExactPrefix = true
+				continue
+			}
+			if hasExactPrefix && !col.matcher.IsSorted() {
+				cols = cols[:i]
+				break
+			}
+		}
 		//fmt.Println("conditions:", cols)
 		// build up lower and upper bounds of index
 		for {

--- a/tests/storage/indexes/fulltext-like-index.yaml
+++ b/tests/storage/indexes/fulltext-like-index.yaml
@@ -99,6 +99,31 @@ test_cases:
         - vorname: "Nikolaus"
           nachname: "Meyer"
 
+  - name: "Exact point probes keep LIKE as a residual filter"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "ft_customers"))
+        (define probe (lambda (id)
+          (begin
+            (define condition (eval (list
+              'lambda (list 'row_id 'name)
+              (list 'and
+                (list 'equal?? 'row_id id)
+                (list 'strlike 'name "%laus%" "utf8mb4_general_ci")))))
+            (scan_exists nil tbl (list "id" "vorname") condition))))
+        (reduce (produceN 8) (lambda (ok i)
+          (begin (probe (+ 1 i)) ok)) true)
+        (define indexes ((show "memcp-tests" "ft_customers" 0 true) "indexes"))
+        (define bad (reduce indexes (lambda (found index)
+          (begin
+            (define cols (get_assoc index "cols"))
+            (or found (and
+              (strlike cols "%id(equal)%" "utf8mb4_bin")
+              (strlike cols "%vorname(like)%" "utf8mb4_bin"))))) false))
+        (if bad
+          (error "point lookup built a full-table LIKE matcher index")
+          true))
+
   # --- Incremental search pattern ---
   - name: "Incremental search step 1"
     sql: "SELECT COUNT(*) AS cnt FROM ft_customers WHERE vorname LIKE '%K%'"


### PR DESCRIPTION
## Summary

- keep exact sorted point boundaries ahead of matcher-backed equality predicates
- leave trailing LIKE predicates as residual filters after an exact point prefix
- retain matcher-backed access for scans without an exact sorted prefix
- add a YAML regression that rejects composite point+LIKE matcher indexes

## A/B measurement

Same persisted 100,000-row table, prewarmed `id` index, 64 distinct `id = ? AND payload LIKE ? LIMIT 1` probes in one connection:

| Revision | 64 probes | Resulting access index |
|---|---:|---|
| master `8e969bafb` | 124.832 ms | composite `id(equal) + payload(like)` |
| this PR | 31.387 ms | exact `id(equal)`; LIKE residual |

This is a 3.98x speedup for the point-probe workload. A cold run without prewarming the exact index measured 138.231 ms vs 91.473 ms (1.51x). Pure LIKE scans are unchanged.

## Verification

- new regression on master: fails with `point lookup built a full-table LIKE matcher index`
- `tests/storage/indexes/fulltext-like-index.yaml`: 71/71
- `tests/planner/order-window/order-limit.yaml`: 40/40 on branch, 40/40 on master
- two local coverage runs completed all functional suites, but the unchanged 200k ORDER/OFFSET suite exceeded its 5s wall limit under concurrent desktop load; no expectation or timing limit was changed