### PR TITLE
Consolidate holistic query planner phases

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -29,20 +29,38 @@ The planner pipeline is:
 
 ```text
 parser AST
--> untangle_query
--> join_reorder / optimize
+-> normalize_sql_syntax
+-> decorrelate_logical_query / untangle_query
+-> logical predicate placement and join_reorder / optimize
 -> build_queryplan
 ```
 
 Each phase has a distinct job:
 
 - parser: preserve SQL syntax and produce neutral AST/query terms
-- `untangle_query`: build a decorrelated logical IR
-- `join_reorder` / optimize: choose logical order and record costing facts
-- `build_queryplan`: choose physical scan sources/operators and emit Scheme code
+- `normalize_sql_syntax`: remove parser-specific spelling and syntactic sugar;
+  normalization must be context-safe for SQL three-valued logic
+- `decorrelate_logical_query` / `untangle_query`: build a decorrelated logical
+  IR using Neumann domains, equivalence classes, and representatives
+- logical predicate placement and `join_reorder` / optimize: move selections
+  only across proven-safe logical boundaries, choose logical order, and record
+  costing facts after decorrelation has exposed the complete join graph
+- `build_queryplan`: choose physical scan sources/operators, bind conditions to
+  concrete scans, and emit Scheme code
 
 Do not move physical decisions into `untangle_query`. Do not leave logical
 decorrelation work for `build_queryplan`.
+
+Each transformation has exactly one owning phase. A later phase may consume
+facts established earlier, but it must not rediscover parser shapes or repeat a
+semantic rewrite. In particular:
+
+- syntax normalization must not choose RecSets, scans, keytables, or join order
+- join reorder must run after dependent joins have been eliminated
+- selection placement across query/group stages is logical; attaching a final
+  predicate callback or index bound to a scan is physical
+- physical lowering must consume canonical logical primitives instead of
+  matching the original SQL spelling again
 
 ## Logical IR Shape
 
@@ -87,6 +105,13 @@ possible later, for example:
 - `cardinality_mode`
 - `preserve_empty_domain`
 - order/window/group facts
+
+For Neumann decorrelation, `D` denotes the complete outer domain required by a
+dependent subtree. An equivalence-class representative from the nullable side
+of an outer join cannot replace `D`: missing matches would erase the very
+domain rows for which `EXISTS` must produce `FALSE` or a scalar aggregate must
+produce its empty-input result. Representative selection must preserve every
+outer domain row before later selection placement or join reordering.
 
 Positive membership in a WHERE truth context may use the semantic
 `membership_truth` expression primitive. It references a logical group-stage

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -21,7 +21,8 @@ Neumann compiler rebuild
 
 This file is the clean query compiler pipeline:
 
-parser AST -> untangle_query -> join_reorder -> build_queryplan
+parser AST -> normalize_sql_syntax -> decorrelate_logical_query
+-> optimize_logical_query -> build_queryplan
 
 The logical IR deliberately uses a small set of combined operators instead of
 textbook one-operation nodes:
@@ -844,43 +845,32 @@ instead of capturing whichever session populated the cache first. */
 					false))
 			_ false))))
 
-(define exists_correlation_pair (lambda (inner_default inner_sources outer_sources term)
-	(match term
-		((symbol equal??) a b) (begin
-			(define a_inner (expr_refs_sources? inner_default inner_sources a))
-			(define b_inner (expr_refs_sources? inner_default inner_sources b))
-			(define a_outer (and (not a_inner) (expr_refs_sources? nil outer_sources a)))
-			(define b_outer (and (not b_inner) (expr_refs_sources? nil outer_sources b)))
-			(if (and a_inner b_outer)
-				(list a b)
-				(if (and b_inner a_outer)
-					(list b a)
-					nil)))
-		((quote equal??) a b) (exists_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
-		((symbol equal?) a b) (exists_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
-		((quote equal?) a b) (exists_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
-		_ nil)))
-
-(define presence_correlation_pair (lambda (inner_default inner_sources outer_sources term)
+(define correlation_pair_using (lambda (inner_default inner_sources outer_sources term include_session)
 	(match term
 		((symbol equal??) a b) (begin
 			(define a_inner (expr_refs_sources? inner_default inner_sources a))
 			(define b_inner (expr_refs_sources? inner_default inner_sources b))
 			(define a_outer (and (not a_inner) (or
 				(expr_refs_sources? nil outer_sources a)
-				(session_dependency_expr? a))))
+				(and include_session (session_dependency_expr? a)))))
 			(define b_outer (and (not b_inner) (or
 				(expr_refs_sources? nil outer_sources b)
-				(session_dependency_expr? b))))
+				(and include_session (session_dependency_expr? b)))))
 			(if (and a_inner b_outer)
 				(list a b)
 				(if (and b_inner a_outer)
 					(list b a)
 					nil)))
-		((quote equal??) a b) (presence_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
-		((symbol equal?) a b) (presence_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
-		((quote equal?) a b) (presence_correlation_pair inner_default inner_sources outer_sources (list (quote equal??) a b))
+		((quote equal??) a b) (correlation_pair_using inner_default inner_sources outer_sources (list (quote equal??) a b) include_session)
+		((symbol equal?) a b) (correlation_pair_using inner_default inner_sources outer_sources (list (quote equal??) a b) include_session)
+		((quote equal?) a b) (correlation_pair_using inner_default inner_sources outer_sources (list (quote equal??) a b) include_session)
 		_ nil)))
+
+(define exists_correlation_pair (lambda (inner_default inner_sources outer_sources term)
+	(correlation_pair_using inner_default inner_sources outer_sources term false)))
+
+(define presence_correlation_pair (lambda (inner_default inner_sources outer_sources term)
+	(correlation_pair_using inner_default inner_sources outer_sources term true)))
 
 (define unique_correlation_pairs (lambda (pairs)
 	(reduce (coalesceNil pairs '()) (lambda (acc pair)
@@ -1051,6 +1041,40 @@ then matched without repeated deep comparisons. */
 (define sources_without_outer_join_terms (lambda (inner_default inner_sources outer_sources sources)
 	(map (coalesceNil sources '()) (lambda (src)
 		(source_without_outer_join_terms inner_default inner_sources outer_sources src)))))
+
+/* Compute the Neumann dependent-join inputs once. EXISTS, IN and scalar
+builders differ in result semantics, not in how they partition correlated and
+local predicates. Keeping this analysis central prevents the six builders from
+drifting on source-join pairs or residual outer references. */
+(define analyze_query_correlations (lambda (inner outer_sources pair_fn extra_pairs include_source_pairs)
+	(begin
+		(define inner_sources (qb_sources inner))
+		(define inner_src (if (empty_list? inner_sources) nil (car inner_sources)))
+		(define inner_default (if (nil? inner_src) nil (source_alias inner_src)))
+		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
+		(define term_pairs (filter (map terms (lambda (term)
+			(pair_fn inner_default inner_sources outer_sources term)))
+			(lambda (pair) (not (nil? pair)))))
+		(define source_pairs (if include_source_pairs
+			(source_join_correlation_pairs inner_default inner_sources outer_sources inner_sources)
+			'()))
+		(define lookup_pairs (domain_correlation_pairs
+			(merge (list term_pairs source_pairs (coalesceNil extra_pairs '())))))
+		(define local_terms (filter terms (lambda (term)
+			(nil? (pair_fn inner_default inner_sources outer_sources term)))))
+		(define local_sources
+			(sources_without_outer_join_terms inner_default inner_sources outer_sources inner_sources))
+		(define residual_outer_refs (merge_unique (list
+			(btw2025_terms_outer_column_refs local_terms inner_sources outer_sources)
+			(btw2025_sources_outer_column_refs local_sources inner_sources outer_sources))))
+		(list
+			(list (quote inner_src) inner_src)
+			(list (quote inner_sources) inner_sources)
+			(list (quote inner_default) inner_default)
+			(list (quote lookup_pairs) lookup_pairs)
+			(list (quote local_terms) local_terms)
+			(list (quote local_sources) local_sources)
+			(list (quote residual_outer_refs) residual_outer_refs)))))
 
 (define btw2025_local_where_terms_after_simple (lambda (inner_default inner_sources outer_sources block)
 	(filter
@@ -1553,23 +1577,14 @@ physical membership probe. */
 		(if (not (exists_inner_supported? inner))
 			(neumann_fail "untangle_query" "EXISTS group-stage(D) currently supports one plain inner query-block")
 			true)
-		(define inner_src (car (qb_sources inner)))
-		(define inner_sources (qb_sources inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(presence_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list
-			corr_pairs source_corr_pairs (presence_session_domain_pairs inner)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (presence_correlation_pair inner_default inner_sources outer_sources term)))))
-		(define local_sources
-			(sources_without_outer_join_terms inner_default inner_sources outer_sources inner_sources))
-		(define residual_outer_refs (merge_unique (list
-			(btw2025_terms_outer_column_refs local_terms inner_sources outer_sources)
-			(btw2025_sources_outer_column_refs local_sources inner_sources outer_sources))))
+		(define analysis (analyze_query_correlations inner outer_sources
+			presence_correlation_pair (presence_session_domain_pairs inner) true))
+		(define inner_src (qassoc_get analysis (quote inner_src) nil))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define lookup_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
+		(define residual_outer_refs (qassoc_get analysis (quote residual_outer_refs) '()))
 		(define keys (if (and (empty_list? lookup_pairs) (empty_list? residual_outer_refs))
 			'(1)
 			(merge_unique (list
@@ -1643,18 +1658,12 @@ physical membership probe. */
 		(if (not (grouped_exists_inner_supported? inner))
 			(neumann_fail "untangle_query" "grouped EXISTS requires an unordered, unlimited query-block")
 			true)
-		(define inner_src (car (qb_sources inner)))
-		(define inner_sources (qb_sources inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(presence_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list
-			corr_pairs source_corr_pairs (presence_session_domain_pairs inner)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (presence_correlation_pair inner_default inner_sources outer_sources term)))))
+		(define analysis (analyze_query_correlations inner outer_sources
+			presence_correlation_pair (presence_session_domain_pairs inner) true))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define lookup_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
 		(define explicit_keys (map (qb_group inner) (lambda (expr)
 			(canonical_column_expr_for_alias inner_default expr))))
 		(define keys (group_keys_for_correlations inner_default lookup_pairs explicit_keys))
@@ -1666,7 +1675,7 @@ physical membership probe. */
 				(list aggregate_count_descriptor)))))
 		(define stage_input (make_query_block
 			(qb_schema inner)
-			(sources_without_outer_join_terms inner_default inner_sources outer_sources (qb_sources inner))
+			local_sources
 			'()
 			condition
 			'() nil '() nil nil
@@ -2069,17 +2078,14 @@ without separately proving two-valued semantics. */
 		(if (not (equal? (count (qb_fields membership_inner)) 2))
 			(neumann_fail "untangle_query" "IN subquery must expose exactly one column")
 			true)
-		(define inner_src (car (qb_sources membership_inner)))
-		(define inner_sources (qb_sources membership_inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where membership_inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(exists_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define lookup_pairs (domain_correlation_pairs (merge (list
-			corr_pairs (session_domain_pairs membership_inner)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
+		(define analysis (analyze_query_correlations membership_inner outer_sources
+			exists_correlation_pair (session_domain_pairs membership_inner) false))
+		(define inner_src (qassoc_get analysis (quote inner_src) nil))
+		(define inner_sources (qassoc_get analysis (quote inner_sources) '()))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define lookup_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
 		(define rhs_expr (canonical_column_expr_for_alias inner_default (query_block_first_expr membership_inner)))
 		(define keys (cons rhs_expr
 			(correlation_inner_keys inner_default lookup_pairs)))
@@ -2098,7 +2104,7 @@ without separately proving two-valued semantics. */
 			inner_src
 			(make_query_block
 				(qb_schema membership_inner)
-				(sources_without_outer_join_terms inner_default inner_sources outer_sources (qb_sources membership_inner))
+				local_sources
 				'()
 				condition
 				'() nil
@@ -2252,24 +2258,22 @@ without separately proving two-valued semantics. */
 			(neumann_fail "untangle_query" "scalar aggregate group-stage(D) currently supports one plain inner query-block")
 			true)
 		(define value_expr (query_block_first_expr inner))
-		(define inner_src (car (qb_sources inner)))
-		(define inner_sources (qb_sources inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(exists_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
+		(define analysis (analyze_query_correlations inner outer_sources
+			exists_correlation_pair (session_domain_pairs inner) true))
+		(define inner_src (qassoc_get analysis (quote inner_src) nil))
+		(define inner_sources (qassoc_get analysis (quote inner_sources) '()))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define where_corr_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
 		(define having_terms (split_and_terms (coalesceNil (qb_having inner) true)))
 		(define having_corr_pairs (filter (map having_terms (lambda (term)
 			(exists_correlation_pair inner_default inner_sources outer_sources term)))
 			(lambda (pair) (not (nil? pair)))))
 		(define local_having_terms (filter having_terms (lambda (term)
 			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
-		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
 		(define all_corr_pairs (domain_correlation_pairs (merge (list
-			corr_pairs having_corr_pairs source_corr_pairs (session_domain_pairs inner)))))
+			where_corr_pairs having_corr_pairs))))
 		(define local_value_expr (decorrelate_expr_with_pairs inner_default all_corr_pairs value_expr))
 		(define ags (dedupe_aggregates_by_col (merge (list (extract_aggregates local_value_expr) (list aggregate_count_descriptor)))))
 		(if (empty_list? ags)
@@ -2287,7 +2291,7 @@ without separately proving two-valued semantics. */
 			inner_src
 			(make_query_block
 				(qb_schema inner)
-				(sources_without_outer_join_terms inner_default inner_sources outer_sources (qb_sources inner))
+				local_sources
 				'()
 				condition
 				'() nil '() nil nil
@@ -2343,21 +2347,16 @@ without separately proving two-valued semantics. */
 			(neumann_fail "untangle_query" "table-backed scalar subquery without explicit LIMIT 1 needs cardinality_mode single_or_error lowering")
 			true)
 		(define value_expr (query_block_first_expr inner))
-		(define inner_src (car (qb_sources inner)))
+		(define analysis (analyze_query_correlations inner outer_sources
+			exists_correlation_pair (session_domain_pairs inner) true))
+		(define inner_src (qassoc_get analysis (quote inner_src) nil))
 		(if (not (source_is_base_table? inner_src))
 			(neumann_fail "untangle_query" "scalar once_limit stage requires a base inner source after FROM flattening")
 			true)
-		(define inner_sources (qb_sources inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(exists_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list
-			corr_pairs source_corr_pairs (session_domain_pairs inner)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define lookup_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
 		(define keys (if (empty_list? lookup_pairs)
 			'(1)
 			(scalar_stage_inner_keys_for_correlations inner_default (qb_stages inner) (qb_sources inner) lookup_pairs)))
@@ -2375,7 +2374,7 @@ without separately proving two-valued semantics. */
 			inner_src
 			(make_query_block
 				(qb_schema inner)
-				(sources_without_outer_join_terms inner_default inner_sources outer_sources (qb_sources inner))
+				local_sources
 				'()
 				condition
 				'() nil '() nil nil
@@ -2707,18 +2706,13 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(neumann_fail "untangle_query" "table-backed scalar subquery without explicit LIMIT 1 needs cardinality_mode single_or_error lowering")
 			true)
 		(define value_expr (query_block_first_expr inner))
-		(define inner_src (car (qb_sources inner)))
-		(define inner_sources (qb_sources inner))
-		(define inner_default (source_alias inner_src))
-		(define terms (split_and_terms (coalesceNil (qb_where inner) true)))
-		(define corr_pairs (filter (map terms (lambda (term)
-			(exists_correlation_pair inner_default inner_sources outer_sources term)))
-			(lambda (pair) (not (nil? pair)))))
-		(define source_corr_pairs (source_join_correlation_pairs inner_default inner_sources outer_sources (qb_sources inner)))
-		(define lookup_pairs (domain_correlation_pairs (merge (list
-			corr_pairs source_corr_pairs (session_domain_pairs inner)))))
-		(define local_terms (filter terms (lambda (term)
-			(nil? (exists_correlation_pair inner_default inner_sources outer_sources term)))))
+		(define analysis (analyze_query_correlations inner outer_sources
+			exists_correlation_pair (session_domain_pairs inner) true))
+		(define inner_src (qassoc_get analysis (quote inner_src) nil))
+		(define inner_default (qassoc_get analysis (quote inner_default) nil))
+		(define lookup_pairs (qassoc_get analysis (quote lookup_pairs) '()))
+		(define local_terms (qassoc_get analysis (quote local_terms) '()))
+		(define local_sources (qassoc_get analysis (quote local_sources) '()))
 		(define keys (if (empty_list? lookup_pairs)
 			'(1)
 			(correlation_inner_keys inner_default lookup_pairs)))
@@ -2734,7 +2728,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			inner_src
 			(make_query_block
 				(qb_schema inner)
-				(sources_without_outer_join_terms inner_default inner_sources outer_sources (qb_sources inner))
+				local_sources
 				'()
 				condition
 				'() nil '() nil nil
@@ -16620,14 +16614,28 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 (define build_queryplan (lambda (ir)
 	(emit_physical_queryplan (prepare_physical_queryplan ir))))
 
+/* Keep phase ownership explicit. normalize_query_ast inside untangle_query
+removes parser-specific spelling before dependent joins are identified; this
+wrapper owns the output-shape normalizers which must precede binding.
+Decorrelation owns D and all subquery elimination; only then may logical join
+ordering run. Storage artifacts begin in build_queryplan. */
+(define normalize_sql_syntax (lambda (ast)
+	(sanitize_temporal_outputs (sanitize_decimal_aggregate_outputs ast))))
+
+(define decorrelate_logical_query (lambda (ast)
+	(untangle_query_term (normalize_sql_syntax ast) nil)))
+
+(define optimize_logical_query (lambda (ir)
+	(join_reorder ir)))
+
 (define neumann_compile_pipeline (lambda (ast)
 	(build_queryplan
-		(join_reorder
-			(untangle_query_term (sanitize_temporal_outputs (sanitize_decimal_aggregate_outputs ast)) nil)))))
+		(optimize_logical_query
+			(decorrelate_logical_query ast)))))
 
 (define neumann_compile_ir_pipeline (lambda (ir)
 	(build_queryplan
-		(join_reorder
+		(optimize_logical_query
 			(require_flat_stage_dependencies "compile_ir" (normalize_stage_dependencies ir))))))
 
 /* ------------------------------------------------------------------------- */
@@ -16638,7 +16646,7 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 
 (define build_queryplan_term_with_sink (lambda (query sink_mode)
 	(neumann_compile_ir_pipeline
-		(ir_with_return (untangle_query_term query nil) sink_mode))))
+		(ir_with_return (decorrelate_logical_query query) sink_mode))))
 
 (define build_queryplan_term_from_logical (lambda (logical_ir)
 	(neumann_compile_ir_pipeline logical_ir)))
@@ -16661,7 +16669,7 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 			'() '()
 			(list (list (quote dml) true))))
 		(neumann_compile_ir_pipeline
-			(ir_with_return (untangle_query_term query nil) (list (quote dml) schema tbl))))))
+			(ir_with_return (decorrelate_logical_query query) (list (quote dml) schema tbl))))))
 
 (define sql_truncate (lambda (schema tbl)
 	(build_dml_plan schema tbl nil
@@ -16677,7 +16685,7 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 
 (define explain_queryplan_ir (lambda (query)
 	(begin
-		(define ir (untangle_query_term query nil))
+		(define ir (decorrelate_logical_query query))
 		(list (quote resultrow)
 			(list (quote list)
 				"ir"
@@ -16689,7 +16697,7 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 	(begin
 		(define planning_session (context "session"))
 		(planning_session "__memcp_explain_reorder_selectivities" true)
-		(define reordered (join_reorder (untangle_query_term query nil)))
+		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
 		(planning_session "__memcp_explain_reorder_selectivities" nil)
 		(list (quote resultrow)
 			(list (quote list)
@@ -16726,9 +16734,9 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 						(+ total (tree_count item))) 0))
 				_ 1)))
 		(define started_ns (nanotime))
-		(define ir (untangle_query_term query nil))
+		(define ir (decorrelate_logical_query query))
 		(define untangled_ns (nanotime))
-		(define reordered (join_reorder ir))
+		(define reordered (optimize_logical_query ir))
 		(define reordered_ns (nanotime))
 		(define prepared (prepare_physical_queryplan reordered))
 		(define prepared_ns (nanotime))

--- a/tests/planner/subqueries/deep-correlation-membership.yaml
+++ b/tests/planner/subqueries/deep-correlation-membership.yaml
@@ -215,7 +215,7 @@ test_cases:
 
   - name: "Depth three scalar EXISTS references outermost scope"
     noncritical: true
-    fail_comment: "skip-level correlation loses the outer domain while lowering nested scalar stages"
+    fail_comment: "Neumann D is metadata-only here; the nested scalar cache loses empty outer domains"
     sql: |
       SELECT p.id,
         (SELECT
@@ -312,7 +312,7 @@ test_cases:
 
   - name: "Projected EXISTS keeps false through two scalar levels"
     noncritical: true
-    fail_comment: "the presence result is lost while it crosses two scalar stage boundaries"
+    fail_comment: "the nullable presence key replaces D and turns FALSE into an absent scalar row"
     sql: |
       SELECT p.id,
         (SELECT
@@ -494,7 +494,7 @@ test_cases:
 
   - name: "Deep NOT IN skips scopes and preserves NULL semantics"
     noncritical: true
-    fail_comment: "deep anti-membership loses its outer correlation and returns NULL for every scalar domain"
+    fail_comment: "skip-level anti-membership does not retain the complete outer D relation"
     sql: |
       SELECT p.id,
         (SELECT
@@ -525,6 +525,93 @@ test_cases:
           unassigned_label: null
         - id: 5
           unassigned_label: null
+
+  - name: "Skip-level IN UNION keeps every ancestor domain"
+    sql: |
+      SELECT p.id,
+        (SELECT
+          (SELECT r.label
+           FROM dcm_ref r
+           WHERE r.id = i.ref_id
+             AND r.id IN (
+               SELECT a.ref_id FROM dcm_assignment a
+               WHERE a.actor_id = p.owner_id
+               UNION ALL
+               SELECT a.ref_id FROM dcm_assignment a
+               WHERE a.actor_id = 7
+                 AND a.tenant_id = p.tenant_id
+             )
+           LIMIT 1)
+         FROM dcm_item i
+         WHERE i.parent_id = p.id
+         ORDER BY i.id
+         LIMIT 1) AS visible_label
+      FROM dcm_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          visible_label: "alpha"
+        - id: 2
+          visible_label: null
+        - id: 3
+          visible_label: null
+        - id: 4
+          visible_label: null
+        - id: 5
+          visible_label: null
+
+  - name: "Correlated aggregate preserves nested EXISTS and empty domains"
+    sql: |
+      SELECT p.id,
+        COALESCE((
+          SELECT SUM(i.score)
+          FROM dcm_item i
+          WHERE i.parent_id = p.id
+            AND EXISTS (
+              SELECT 1 FROM dcm_event e
+              WHERE e.item_id = i.id AND e.status = 'open'
+            )
+        ), 0) AS open_score
+      FROM dcm_parent p
+      ORDER BY p.id
+    expect:
+      rows: 5
+      data:
+        - id: 1
+          open_score: 14
+        - id: 2
+          open_score: 0
+        - id: 3
+          open_score: 3
+        - id: 4
+          open_score: 0
+        - id: 5
+          open_score: 0
+
+  - name: "Logical decorrelation stays free of physical scan artifacts"
+    sql: |
+      EXPLAIN IR SELECT p.id
+      FROM dcm_parent p
+      WHERE EXISTS (
+        SELECT 1 FROM dcm_item i
+        WHERE i.parent_id = p.id
+          AND EXISTS (
+            SELECT 1 FROM dcm_event e
+            WHERE e.item_id = i.id AND e.status = 'open'
+          )
+      )
+    expect:
+      contains:
+        - "group-stage"
+        - "purpose exists"
+        - "lookup-keys"
+      not_contains:
+        - "scan_order"
+        - "scan_recset"
+        - "touch_keytable"
+        - ".grp:"
 
 
 cleanup:


### PR DESCRIPTION
## Summary

- make the planner phase order explicit at every compile, explain, sink, and DML entry point
- centralize correlation classification shared by plain/grouped `EXISTS`, `IN`, scalar aggregate, scalar-once, and scalar-single decorrelation
- centralize the equality correlation matcher while retaining the deliberate session-domain distinction
- document the Neumann domain (`D`) constraint across nullable outer-join representatives
- add anonymous nested correlation, membership/union, aggregate empty-domain, and logical/physical boundary regressions

## Architecture

The pipeline is now named and enforced as:

```text
parser AST
-> normalize_sql_syntax
-> decorrelate_logical_query
-> optimize_logical_query
-> build_queryplan
```

This follows the Neumann/Kemper 2015 and Neumann 2025 ordering: dependent joins and their complete outer domain are resolved before join reordering sees the final logical graph. Logical predicate placement remains before physical lowering; concrete scan callbacks, bounds, RecSets, ORC columns, and keytables remain owned by `build_queryplan`.

The six subquery builders previously repeated correlation-pair extraction, local-term partitioning, source-join handling, session-domain handling, source cleanup, and residual outer-reference discovery. They now consume one `analyze_query_correlations` result while retaining their separate SQL result semantics.

The change removes 113 existing lines from `queryplan.scm`. Explicit phase wrappers, the shared analyzer, and architecture comments leave the file at net +8 lines; the duplicated semantic implementations are gone rather than hidden behind forwarding fallbacks.

### Planner line-count development

The following are reproducible `wc -l` snapshots of `lib/queryplan.scm` at representative merged planner milestones. Deltas compare adjacent sampled milestones; they are not an attribution of every intervening line to the named PR alone.

| snapshot | date | lines | delta |
|---|---:|---:|---:|
| #349 grouped derived aliases | 2026-08-07 | 10,479 | baseline |
| #376 grouped EXISTS decorrelation | 2026-08-08 | 11,316 | +837 / +8.0% |
| #409 canonical carrier initialization | 2026-08-11 | 12,508 | +1,192 / +10.5% |
| #426 SCM Neumann join reorder | 2026-08-12 | 13,924 | +1,416 / +11.3% |
| #441 canonical membership/costing | 2026-08-13 | 14,993 | +1,069 / +7.7% |
| #469 centralized name binding | 2026-08-14 | 16,405 | +1,412 / +9.4% |
| PR base (`3cdd6a27e`) | 2026-08-15 | 16,786 | +381 / +2.3% |
| this PR (`9d9b01bdb`) | 2026-08-15 | 16,794 | +8 / +0.05% |

From #349 to this PR the file grew by 6,315 lines, or 60.3%, in eight days. This is the reason the phase ownership and shared analysis matter: further feature patches should extend one canonical logical transformation or one physical strategy instead of adding another query-shape-specific route.

For this PR specifically, `queryplan.scm` changes by `+121/-113`. The net eight lines consist of the explicit pipeline wrappers and architecture comments; six copies of correlation/source/domain partitioning plus the duplicate equality matcher are replaced by one implementation. Tests and `INVARIANTS.md` account for the remainder of the repository-level `+241/-121` diff.

### Membership syntax

This PR does not apply a blanket textual `IN (... UNION ...) -> OR EXISTS` rewrite. That rewrite is not generally valid across `NOT IN`, nullable probes/RHS values, `UNION DISTINCT`, and semantically relevant branch `ORDER BY`/`LIMIT`. Existing positive-WHERE normalization already maps supported spellings to the logical `membership_truth`/group-stage model. Physical lowering then chooses RecSet union, bounded branch probes, or a reusable group cache without re-matching parser syntax.

## Regression coverage

The added anonymous cases cover:

- skip-level `IN` over `UNION ALL` with references to different ancestor scopes
- correlated aggregate plus nested `EXISTS`, including empty outer domains and `COALESCE`
- `EXPLAIN IR` remaining free of scans, RecSets, keytables, and `.grp:` names

Three older deep-domain defects remain visibly `noncritical`; their failure descriptions now identify the precise lost-`D` behavior. This refactor does not disguise them as passing behavior.

## A/B compile measurement

Ten fresh `EXPLAIN COMPILE` runs of the same anonymous four-relation nested correlated query were measured on the base commit and this branch:

| metric | master | PR | delta |
|---|---:|---:|---:|
| untangle | 17.942 ms | 17.935 ms | -0.04% |
| reorder | 13.023 ms | 13.909 ms | +6.8% (run noise; no reorder code changed) |
| planner total | 75.774 ms | 75.482 ms | -0.39% |
| compile total | 101.757 ms | 101.460 ms | -0.29% |

The intended result is compile-time neutrality. An earlier version accidentally normalized the AST twice and measured about 4.6% slower; the A/B gate caught it and that implementation was removed.

## Validation

- `MEMCP_FAIL_FAST=0 ./git-pre-commit` (all suites passed)
- focused `deep-correlation-membership.yaml`: 20/23, with exactly the three pre-existing declared noncritical failures
- focused `in-subquery.yaml`: 69/69
- focused `scalar-subselect-patterns.yaml`: 21/21
- focused `composed-scalar-aggregate-shapes.yaml`: 23/23
- normal-binary `order-limit.yaml`: 40/40 on both base and PR
- `git diff --check`

`tools/lint_scm.py --check` still reports the pre-existing global negative-depth warnings in `queryplan.scm`, `rdf-parser.scm`, and `psql-parser.scm`; this diff adds no new warning location.