### PR TITLE
JIT generated map and reduce callbacks

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1976,6 +1976,32 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define jit_panic_result (try (lambda () (jit_will_panic 42)) (lambda (e) "caught")))
 	(assert jit_panic_result "caught" "panic through JIT frame must be recoverable")
 
+	/* JIT list callbacks: constant code shape with runtime values/captures */
+	(define _jit_map_constant_callback (jit (lambda (values)
+		(map values (lambda (_) 7)))))
+	(assert (jit? _jit_map_constant_callback) (jit-enabled?) "jit: map constant callback compiles natively when enabled")
+	(assert (equal? (_jit_map_constant_callback '(1 2 3)) '(7 7 7)) true "jit: map constant callback result")
+
+	(define _jit_map_captured_callback (jit (lambda (values offset)
+		(map values (lambda (value) (+ value offset))))))
+	(assert (jit? _jit_map_captured_callback) (jit-enabled?) "jit: map callback with runtime capture compiles natively when enabled")
+	(assert (equal? (_jit_map_captured_callback '(1 2 3) 10) '(11 12 13)) true "jit: map callback reads runtime capture")
+
+	(define _jit_map_mut_callback (jit (lambda (values)
+		(map_mut values (lambda (value) (+ value 1))))))
+	(assert (jit? _jit_map_mut_callback) (jit-enabled?) "jit: map_mut callback compiles natively when enabled")
+	(assert (equal? (_jit_map_mut_callback (list 3 4 5)) '(4 5 6)) true "jit: map_mut callback result")
+
+	(define _jit_reduce_callback (jit (lambda (values neutral offset)
+		(reduce values (lambda (acc value) (+ acc (+ value offset))) neutral))))
+	(assert (jit? _jit_reduce_callback) (jit-enabled?) "jit: reduce callback with runtime capture compiles natively when enabled")
+	(assert (_jit_reduce_callback '(1 2 3) 0 10) 36 "jit: reduce callback reads accumulator and runtime capture")
+
+	(define _jit_map_dynamic_callback (jit (lambda (values callback)
+		(map values callback))))
+	(assert (jit? _jit_map_dynamic_callback) (jit-enabled?) "jit: map with runtime callback compiles natively when enabled")
+	(assert (equal? (_jit_map_dynamic_callback '(2 3 4) (lambda (value) (* value 3))) '(6 9 12)) true "jit: map runtime callback trampoline")
+
 	/* alu.go: sql_abs */
 	(print "testing sql_abs ...")
 	(assert (equal? (sql_abs -5) 5) true "sql_abs of -5 = 5")

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -140,6 +140,7 @@ type JITEntryPoint struct {
 	// argument array as an owned list. Call must make that array fresh because
 	// apply may otherwise pass caller-owned list backing directly.
 	TransferInputArgs bool
+	HiddenArgs        []JITHiddenArg
 	CodePtr           unsafe.Pointer   // start of code in arena
 	CodeLen           int              // bytes used
 	Arena             *jitArena        // owning arena (for free on GC)
@@ -159,11 +160,37 @@ func (jep *JITEntryPoint) Call(args ...Scmer) (result Scmer) {
 	if jep.TransferInputArgs {
 		args = append([]Scmer(nil), args...)
 	}
+	for _, spec := range jep.HiddenArgs {
+		if spec.SourceInput < 0 || spec.SourceInput >= len(args) {
+			panic("JIT: invalid hidden argument input")
+		}
+		switch spec.Kind {
+		case jitHiddenPreallocatedSlice:
+			length := len(asSlice(args[spec.SourceInput], "jit preallocation"))
+			args = append(args, NewSlice(make([]Scmer, length)))
+		case jitHiddenOptimizedCallback:
+			args = append(args, NewFunc(OptimizeProcToSerialFunction(args[spec.SourceInput])))
+		default:
+			panic("JIT: invalid hidden argument kind")
+		}
+	}
 	defer func() {
 		runtime.KeepAlive(args)
 		runtime.KeepAlive(jep)
 	}()
 	return callJIT(jep.Native, args...)
+}
+
+type jitHiddenArgKind uint8
+
+const (
+	jitHiddenPreallocatedSlice jitHiddenArgKind = iota
+	jitHiddenOptimizedCallback
+)
+
+type JITHiddenArg struct {
+	Kind        jitHiddenArgKind
+	SourceInput int
 }
 
 // JITValueDesc describes a value during JIT compilation: its type and
@@ -198,10 +225,24 @@ type JITValueDesc struct {
 	KnownSliceLen  int32
 	KnownSliceCap  int32
 	SliceSizeKnown bool
+	// NoHeapPointer proves that the Scmer ptr word is nil or points at immutable
+	// runtime storage rather than the Go heap. It is intentionally independent
+	// of Type so unions such as int|float|nil retain the fact without claiming an
+	// exact tag.
+	NoHeapPointer bool
 	// Virtual holds compiler-only aggregate elements. LocVirtualSlice never
 	// reaches generated machine code; consumers either operate on its elements
 	// directly or materialize it through a Go allocation trampoline.
 	Virtual []JITValueDesc
+	// Lambda carries compiler-only code shape for a known lambda. Runtime
+	// captures remain descriptors in Outer and are never materialized merely to
+	// cross a generated emitter boundary.
+	Lambda *JITLambdaTemplate
+}
+
+type JITLambdaTemplate struct {
+	Proc  Proc
+	Outer *JITEnv
 }
 
 // ---- merged from scm/jit_types.go ----
@@ -233,6 +274,7 @@ const (
 	LocStackTriple // Three-word value in the current invocation's frame (StackOff..StackOff+16)
 	LocVirtualSlice
 	LocInputPair // Compiler-only reference to one Scmer in the native call's original variadic slice
+	LocLambdaTemplate
 )
 
 // JITFixup records a forward reference that must be patched after all
@@ -311,6 +353,7 @@ type JITContext struct {
 	// TransferInputArgs is set when emission proves that the native result is
 	// exactly the complete variadic input array re-tagged as an owned list.
 	TransferInputArgs bool
+	HiddenArgs        []JITHiddenArg
 	RegOwners         [16]*JITValueDesc // register → owner descriptor (nil = untracked)
 
 	// Stack frame: emitter locals use [RSP + offset], while register spills use
@@ -333,6 +376,18 @@ type JITContext struct {
 	ConstRoots []unsafe.Pointer
 	rootSet    map[unsafe.Pointer]struct{}
 	Arena      *jitArena // owning arena for source map entries
+}
+
+func (ctx *JITContext) RequestPreallocatedSlice(lengthInput int) JITValueDesc {
+	hiddenIndex := ctx.InputArgCount + len(ctx.HiddenArgs)
+	ctx.HiddenArgs = append(ctx.HiddenArgs, JITHiddenArg{Kind: jitHiddenPreallocatedSlice, SourceInput: lengthInput})
+	return JITValueDesc{Loc: LocInputPair, Type: tagSlice, StackOff: int32(hiddenIndex)}
+}
+
+func (ctx *JITContext) RequestOptimizedCallback(sourceInput int) JITValueDesc {
+	hiddenIndex := ctx.InputArgCount + len(ctx.HiddenArgs)
+	ctx.HiddenArgs = append(ctx.HiddenArgs, JITHiddenArg{Kind: jitHiddenOptimizedCallback, SourceInput: sourceInput})
+	return JITValueDesc{Loc: LocInputPair, Type: tagFunc, StackOff: int32(hiddenIndex)}
 }
 
 // jitAllocStateSnapshot captures allocator/spill bookkeeping so emitter
@@ -540,6 +595,45 @@ func (ctx *JITContext) ReclaimUntrackedRegs() {
 	}
 }
 
+type jitNestedPreservation struct {
+	alloc jitAllocStateSnapshot
+	regs  []Reg
+	offs  []int32
+}
+
+// PreserveOuterRegs makes nested emission independent of registers whose
+// identities have already been embedded in outer control flow. The values are
+// saved in invocation-local spill slots, all allocator registers become
+// available to the nested emitter, and RestoreOuterRegs reloads the exact same
+// registers before outer code resumes.
+func (ctx *JITContext) PreserveOuterRegs() jitNestedPreservation {
+	p := jitNestedPreservation{alloc: ctx.SnapshotAllocState()}
+	ctx.ReclaimUntrackedRegs()
+	for r := Reg(0); r <= RegR15; r++ {
+		owner := ctx.RegOwners[r]
+		if owner == nil || (ctx.AllRegs&(1<<uint(r))) == 0 || (ctx.FreeRegs&(1<<uint(r))) != 0 {
+			continue
+		}
+		off := ctx.AllocSpill(8)
+		ctx.EmitStoreRegMem(r, RegRBP, off)
+		p.regs = append(p.regs, r)
+		p.offs = append(p.offs, off)
+		ctx.RegOwners[r] = nil
+		ctx.FreeRegs |= 1 << uint(r)
+	}
+	ctx.ProtectedRegs = 0
+	ctx.ProtectedRegCounts = [16]int{}
+	return p
+}
+
+func (ctx *JITContext) RestoreOuterRegs(p jitNestedPreservation) {
+	ctx.ReclaimUntrackedRegs()
+	for i, r := range p.regs {
+		ctx.EmitMovRegMem(r, RegRBP, p.offs[i])
+	}
+	ctx.RestoreAllocState(p.alloc)
+}
+
 // AllocReg picks a free register from the bitmap and marks it used.
 // If no registers are free, spills the highest-numbered in-use register
 // to a pre-allocated buffer and returns it.
@@ -743,6 +837,16 @@ func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
 		}
 	}
 	switch desc.Loc {
+	case LocInputPair:
+		r1 := ctx.AllocReg()
+		r2 := ctx.AllocRegExcept(r1)
+		ctx.EmitMovRegMem(r1, ctx.SliceBase, desc.StackOff*16)
+		ctx.EmitMovRegMem(r2, ctx.SliceBase, desc.StackOff*16+8)
+		desc.Loc = LocRegPair
+		desc.Reg = r1
+		desc.Reg2 = r2
+		ctx.BindReg(r1, desc)
+		ctx.BindReg(r2, desc)
 	case LocStack:
 		ctx.EnsureReg(desc)
 	case LocStackPair:
@@ -1999,7 +2103,7 @@ func jitCompile(a ...Scmer) Scmer {
 		for _, codeCap := range [...]int{16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024} {
 			ptr, arena := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena}
-			codeLen, roots, overflow, transferInputArgs := jitCompileProcToExec(proc, buf)
+			codeLen, roots, overflow, transferInputArgs, hiddenArgs := jitCompileProcToExec(proc, buf)
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
 				if JITLog {
@@ -2011,6 +2115,7 @@ func jitCompile(a ...Scmer) Scmer {
 				jep := &JITEntryPoint{
 					Native:            nativeFn,
 					TransferInputArgs: transferInputArgs,
+					HiddenArgs:        hiddenArgs,
 					CodePtr:           ptr,
 					CodeLen:           codeLen,
 					Arena:             arena,

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -333,6 +333,10 @@ func jitList6(a, b, c, d, e, f Scmer) Scmer       { return List(a, b, c, d, e, f
 func jitList7(a, b, c, d, e, f, g Scmer) Scmer    { return List(a, b, c, d, e, f, g) }
 func jitList8(a, b, c, d, e, f, g, h Scmer) Scmer { return List(a, b, c, d, e, f, g, h) }
 
+func jitMakeScmerSlice(length, capacity int) []Scmer {
+	return make([]Scmer, length, capacity)
+}
+
 // jitMaterializeVirtualSlice lowers the virtual variadic array produced from
 // List's Go SSA. A normal list always gets fresh backing storage, preserving
 // the optimizer's Transfer contract even when the JIT is invoked through

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -62,7 +62,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 	const defaultCodeBufSize = 16 * 1024
 	ptr, _ := globalJITPool.Alloc(defaultCodeBufSize)
 	buf := &execBuf{ptr: ptr, n: defaultCodeBufSize}
-	codeLen, roots, _, _ := jitCompileProcToExec(proc, buf)
+	codeLen, roots, _, _, _ := jitCompileProcToExec(proc, buf)
 	if codeLen == 0 {
 		return nil, nil
 	}
@@ -74,7 +74,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 // jitCompileProcToExec compiles a Proc body directly into writable executable memory.
 // Returns code length, GC roots, an overflow flag, and whether the call boundary
 // must provide a fresh variadic array that becomes the owned list result.
-func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool, bool) {
+func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg) {
 	body := proc.Body
 	if body.GetTag() == tagSourceInfo {
 		si := body.SourceInfo()
@@ -93,7 +93,7 @@ func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool
 
 // jitCompileExprBodyToExec compiles a Scheme expression body into a writable
 // executable buffer using Declaration.JITEmit callbacks.
-func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool) {
+func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg) {
 	defer func() {
 		if r := recover(); r != nil {
 			if r == jitCodeOverflowPanic {
@@ -105,6 +105,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 			codeLen = 0
 			roots = nil
 			transferInputArgs = false
+			hiddenArgs = nil
 		}
 	}()
 
@@ -218,7 +219,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 		case tagNil:
 			ctx.EmitMakeNil(result)
 		default:
-			return 0, nil, false, false
+			return 0, nil, false, false, nil
 		}
 		// fall through to epilog
 	} else {
@@ -241,10 +242,10 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 			case tagFloat:
 				ctx.EmitMakeFloat(ret, desc)
 			default:
-				return 0, nil, false, false
+				return 0, nil, false, false, nil
 			}
 		default:
-			return 0, nil, false, false
+			return 0, nil, false, false, nil
 		}
 	}
 	// Unified epilog: patch SUB RSP with max frame size, then leave; ret.
@@ -256,7 +257,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 
 	ctx.ResolveFixupsFinal()
 	codeLen = int(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs
+	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs
 }
 
 func jitEnsureResultPair(ctx *JITContext, result JITValueDesc) JITValueDesc {
@@ -270,6 +271,10 @@ func jitPlaceIntoPair(ctx *JITContext, src *JITValueDesc, target JITValueDesc) J
 	if target.Loc != LocRegPair {
 		panic("jit: jitPlaceIntoPair requires LocRegPair target")
 	}
+	// Placement changes representation, not the proven Scheme type. Keeping the
+	// fact lets downstream generated SSA eliminate checks and write barriers.
+	target.Type = src.Type
+	target.NoHeapPointer = src.NoHeapPointer
 	// Keep descriptor location in sync with spill metadata before we read Reg/Reg2.
 	if src.Loc != LocImm {
 		ctx.EnsureDesc(src)
@@ -335,6 +340,145 @@ func jitList8(a, b, c, d, e, f, g, h Scmer) Scmer { return List(a, b, c, d, e, f
 
 func jitMakeScmerSlice(length, capacity int) []Scmer {
 	return make([]Scmer, length, capacity)
+}
+
+func jitStoreScmerAt(address *Scmer, value Scmer) {
+	*address = value
+}
+
+func jitInvokeCallback1(callback, arg0 Scmer) Scmer {
+	return callback.Func()(arg0)
+}
+
+func jitInvokeCallback2(callback, arg0, arg1 Scmer) Scmer {
+	return callback.Func()(arg0, arg1)
+}
+
+func jitInvokeCallback3(callback, arg0, arg1, arg2 Scmer) Scmer {
+	return callback.Func()(arg0, arg1, arg2)
+}
+
+// EmitSliceElementAddress lowers the address part shared by SSA slice loads and
+// stores.
+func (ctx *JITContext) EmitSliceElementAddress(slice, index *JITValueDesc, elementSize int32) JITValueDesc {
+	ctx.EnsureDesc(slice)
+	if slice.Loc != LocRegTriple {
+		panic("jit: slice element address requires a Go slice header")
+	}
+	ctx.ProtectReg(slice.Reg)
+	ctx.ProtectReg(slice.Reg2)
+	ctx.ProtectReg(slice.Reg3)
+	ctx.EnsureDesc(index)
+	excluded := []Reg{slice.Reg, slice.Reg2, slice.Reg3}
+	if index.Loc == LocReg {
+		excluded = append(excluded, index.Reg)
+	}
+	address := ctx.AllocRegExcept(excluded...)
+	if index.Loc == LocImm {
+		ctx.EmitMovRegImm64(address, uint64(index.Imm.Int())*uint64(elementSize))
+	} else if index.Loc == LocReg {
+		ctx.EmitMovRegReg(address, index.Reg)
+		switch elementSize {
+		case 8:
+			ctx.EmitShlRegImm8(address, 3)
+		case 16:
+			ctx.EmitShlRegImm8(address, 4)
+		default:
+			factor := ctx.AllocRegExcept(append(excluded, address)...)
+			ctx.EmitMovRegImm64(factor, uint64(elementSize))
+			ctx.EmitImulInt64(address, factor)
+			ctx.FreeReg(factor)
+		}
+	} else {
+		panic("jit: slice element index requires an integer descriptor")
+	}
+	ctx.EmitAddInt64(address, slice.Reg)
+	ctx.UnprotectReg(slice.Reg)
+	ctx.UnprotectReg(slice.Reg2)
+	ctx.UnprotectReg(slice.Reg3)
+	result := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: address}
+	ctx.BindReg(address, &result)
+	return result
+}
+
+// EmitStoreScmerAt stores a Scmer through an address produced by
+// EmitSliceElementAddress. Values whose descriptor proves that their ptr word
+// is nil or a static runtime sentinel need no GC write barrier and are emitted
+// as two plain stores. All other values retain Go's authoritative write barrier
+// through the generic trampoline.
+func (ctx *JITContext) EmitStoreScmerAt(address, value *JITValueDesc) {
+	ctx.EnsureDesc(address)
+	if address.Loc != LocReg {
+		panic("jit: Scmer store requires an address register")
+	}
+
+	switch value.Type {
+	case tagNil, tagFloat, tagInt, tagBool, tagDate, tagNthLocalVar:
+		value.NoHeapPointer = true
+	}
+	if value.NoHeapPointer {
+		ctx.ProtectReg(address.Reg)
+		ctx.EnsureDesc(value)
+		ctx.UnprotectReg(address.Reg)
+		if value.Loc == LocImm {
+			ctx.EmitMovRegImm64(RegR11, uint64(uintptr(unsafe.Pointer(value.Imm.ptr))))
+			ctx.EmitStoreRegMem(RegR11, address.Reg, 0)
+			ctx.EmitMovRegImm64(RegR11, value.Imm.aux)
+			ctx.EmitStoreRegMem(RegR11, address.Reg, 8)
+			return
+		}
+		if value.Loc == LocRegPair {
+			ctx.EmitStoreRegMem(value.Reg, address.Reg, 0)
+			ctx.EmitStoreRegMem(value.Reg2, address.Reg, 8)
+			return
+		}
+	}
+
+	ctx.EnsureDesc(value)
+	ctx.EmitGoCallVoid(GoFuncAddr(jitStoreScmerAt), []JITValueDesc{*address, *value})
+}
+
+func jitReturnHasNoHeapPointer(td *TypeDescriptor) bool {
+	if td == nil {
+		return false
+	}
+	switch td.Kind {
+	case "bool", "date", "int", "int|nil", "nil", "number", "number|nil":
+		return true
+	default:
+		return false
+	}
+}
+
+// EmitNewSliceFromGoSlice retags a Go []Scmer header as a Scheme list without
+// allocating or copying its backing storage. Ownership of the data pointer is
+// transferred from slice to the returned descriptor.
+func (ctx *JITContext) EmitNewSliceFromGoSlice(slice *JITValueDesc) JITValueDesc {
+	ctx.EnsureDesc(slice)
+	if slice.Loc != LocRegTriple {
+		panic("jit: NewSlice requires a Go slice header")
+	}
+	ptrReg, lenReg, capReg := slice.Reg, slice.Reg2, slice.Reg3
+	auxReg := ctx.AllocRegExcept(ptrReg, lenReg, capReg)
+	ctx.EmitMovRegReg(auxReg, lenReg)
+	ctx.EmitShlRegImm8(auxReg, sliceCapBits)
+	ctx.EmitOrInt64(auxReg, capReg)
+	ctx.EmitShlRegImm8(auxReg, 8)
+	ctx.EmitOrRegImm32(auxReg, int32(tagSlice))
+	oldID := slice.ID
+	for _, r := range [...]Reg{ptrReg, lenReg, capReg} {
+		if owner := ctx.RegOwners[r]; owner != nil && (oldID == 0 || owner.ID == oldID) {
+			ctx.RegOwners[r] = nil
+		}
+	}
+	ctx.FreeRegs |= 1 << uint(lenReg)
+	ctx.FreeRegs |= 1 << uint(capReg)
+	ctx.FreeRegs &^= 1 << uint(ptrReg)
+	slice.Loc = LocNone
+	result := JITValueDesc{Loc: LocRegPair, Type: tagSlice, Reg: ptrReg, Reg2: auxReg}
+	ctx.BindReg(ptrReg, &result)
+	ctx.BindReg(auxReg, &result)
+	return result
 }
 
 // jitMaterializeVirtualSlice lowers the virtual variadic array produced from
@@ -482,10 +626,14 @@ func jitKnownSliceHeader(ctx *JITContext, value *JITValueDesc) JITValueDesc {
 		ctx.EmitShrRegImm8(capReg, 8)
 		ctx.EmitAndRegImm32(capReg, int32(sliceCapMask))
 	}
-	return JITValueDesc{
+	result := JITValueDesc{
 		Loc: LocRegTriple, Type: tagSlice, Reg: ptrReg, Reg2: lenReg, Reg3: capReg,
 		KnownSliceLen: value.KnownSliceLen, KnownSliceCap: value.KnownSliceCap, SliceSizeKnown: value.SliceSizeKnown,
 	}
+	ctx.BindReg(ptrReg, &result)
+	ctx.BindReg(lenReg, &result)
+	ctx.BindReg(capReg, &result)
+	return result
 }
 
 // jitCondToBoolBorrowed evaluates truthiness without consuming cond.
@@ -823,6 +971,12 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			case LocImm:
 				ctx.TrackImm(src.Imm)
 				return src // constants are always safe to alias
+			case LocInputPair, LocStack, LocStackPair, LocStackTriple:
+				// Preserve lazy locations across an inlined Proc boundary. The
+				// consumer decides whether it needs registers; eagerly loading here
+				// both loses the callback argument's real stack location and creates
+				// avoidable register pressure in nested expressions.
+				return src
 			case LocReg:
 				// Allocate a fresh register so each use is independently freeable.
 				r := ctx.AllocRegExcept(src.Reg)
@@ -877,6 +1031,14 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			imm := NewBool(jitEnabled)
 			ctx.TrackImm(imm)
 			return JITValueDesc{Loc: LocImm, Type: tagBool, Imm: imm}
+		case "outer":
+			if len(list) != 2 || ctx.Env == nil || ctx.Env.Outer == nil {
+				panic("jit: invalid outer reference")
+			}
+			current := ctx.Env
+			ctx.Env = current.Outer
+			defer func() { ctx.Env = current }()
+			return jitCompileExpr(ctx, list[1], sliceBase, result)
 		case "quote":
 			if len(list) < 2 {
 				imm := NewNil()
@@ -1255,26 +1417,36 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 						args[i-1] = jitCompileExpr(ctx, argExpr, sliceBase, JITValueDesc{Loc: LocAny})
 					}
 				}
-				return decl.Type.JITEmit(ctx, list[1:], args, result)
+				out := decl.Type.JITEmit(ctx, list[1:], args, result)
+				out.NoHeapPointer = jitReturnHasNoHeapPointer(decl.Type.Return)
+				return out
 			}
-			// Descriptor ownership across nested generated emitters is not yet a
-			// stable part of the experimental contract. Compile leaf operations;
-			// let the interpreter handle composed calls until that ownership model
-			// can be proven instead of accepting silent register aliasing.
-			for _, argExpr := range list[1:] {
+			// Generated declaration emitters still require a general nested-result
+			// preservation contract. Special forms such as (outer ...) have their
+			// own lowering and do not create another generated emitter.
+			for argIndex, argExpr := range list[1:] {
 				for argExpr.GetTag() == tagSourceInfo {
 					argExpr = argExpr.SourceInfo().value
 				}
 				if argExpr.GetTag() == tagSlice {
 					nested := argExpr.Slice()
 					isQuote := len(nested) > 0 && nested[0].IsSymbol() && nested[0].Symbol() == Symbol("quote")
+					param := jitDeclarationParam(decl, argIndex)
+					isLambdaTemplate := param != nil && param.Kind == "func" && len(nested) > 0 && nested[0].IsSymbol() && nested[0].SymbolEquals("lambda")
 					// !list's backing storage is the current JIT frame. Until the
 					// generated-emitter contract can express result aliasing, only
 					// nth may consume it: nth returns one Scmer value, never a view
 					// into the list backing array.
 					isStackListForNth := name == "nth" && len(nested) > 0 && nested[0].IsSymbol() && nested[0].Symbol() == Symbol("!list")
-					if !isQuote && !isStackListForNth {
-						panic("jit: nested generated emitters are not supported")
+					var nestedType *TypeDescriptor
+					if len(nested) > 0 && nested[0].IsSymbol() {
+						if nestedDecl, exists := declarations[string(nested[0].Symbol())]; exists {
+							nestedType = nestedDecl.Type
+						}
+					}
+					isSpecialForm := nestedType == nil
+					if !isQuote && !isStackListForNth && !isLambdaTemplate && !isSpecialForm {
+						panic("jit: nested generated emitter has pointer-bearing or unknown result: " + SerializeToString(argExpr, &Globalenv))
 					}
 				}
 			}
@@ -1291,7 +1463,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 			protectedRegs := make([]Reg, 0, len(list)*2)
 			for i := 1; i < len(list); i++ {
-				args[i-1] = jitCompileExpr(ctx, list[i], sliceBase, JITValueDesc{Loc: LocAny})
+				args[i-1] = jitCompileCallArgument(ctx, decl, i-1, list[i], sliceBase)
 				// Keep argument descriptors tracked while compiling later args and
 				// inside the callee JITEmit body. Without rebinding to args[] slots,
 				// register spills/reuse can leave stale copies in args and break
@@ -1316,6 +1488,11 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 					ctx.UnprotectReg(r)
 				}
 			}()
+			// Argument compilation may have rendered mutually exclusive type paths.
+			// Their path-local temporaries are intentionally unowned after merging;
+			// reclaim them before entering another generated emitter while retaining
+			// the explicitly bound and protected argument descriptors above.
+			ctx.ReclaimUntrackedRegs()
 			labelsBefore := ctx.LabelNext
 			out := decl.Type.JITEmit(ctx, list[1:], args, result)
 			// A generated emitter may render several runtime control-flow paths.
@@ -1325,6 +1502,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			if ctx.LabelNext != labelsBefore && out.Loc == LocRegPair {
 				out.Type = JITTypeUnknown
 			}
+			out.NoHeapPointer = jitReturnHasNoHeapPointer(decl.Type.Return)
 			if out.Loc == LocImm {
 				ctx.TrackImm(out.Imm)
 			}
@@ -1348,9 +1526,13 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 // NthLocalVar loads (in practice not reached when all params are in args).
 // Panics on any un-emittable sub-expression — callers should recover and fall back.
 func JITEmitProcInline(ctx *JITContext, proc *Proc, args []JITValueDesc, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	return JITEmitProcInlineWithOuter(ctx, proc, ctx.Env, args, sliceBase, result)
+}
+
+func JITEmitProcInlineWithOuter(ctx *JITContext, proc *Proc, outer *JITEnv, args []JITValueDesc, sliceBase Reg, result JITValueDesc) JITValueDesc {
 	innerEnv := &JITEnv{
 		Numbered: args,
-		Outer:    ctx.Env,
+		Outer:    outer,
 	}
 	oldEnv := ctx.Env
 	ctx.Env = innerEnv
@@ -1360,7 +1542,78 @@ func JITEmitProcInline(ctx *JITContext, proc *Proc, args []JITValueDesc, sliceBa
 	if body.GetTag() == tagSourceInfo {
 		body = body.SourceInfo().value
 	}
-	return jitCompileExpr(ctx, body, sliceBase, result)
+	out := jitCompileExpr(ctx, body, sliceBase, result)
+	if result.Loc == LocRegPair && (out.Loc != LocRegPair || out.Reg != result.Reg || out.Reg2 != result.Reg2) {
+		return jitPlaceIntoPair(ctx, &out, result)
+	}
+	return out
+}
+
+func jitLambdaTemplate(expr Scmer, outer *JITEnv) (*JITLambdaTemplate, bool) {
+	for expr.GetTag() == tagSourceInfo {
+		expr = expr.SourceInfo().value
+	}
+	if expr.GetTag() != tagSlice {
+		return nil, false
+	}
+	parts := expr.Slice()
+	if len(parts) < 3 || !parts[0].IsSymbol() || !parts[0].SymbolEquals("lambda") {
+		return nil, false
+	}
+	params := parts[1]
+	for params.GetTag() == tagSourceInfo {
+		params = params.SourceInfo().value
+	}
+	numVars := 0
+	if len(parts) > 3 {
+		numVars = int(ToInt(parts[3]))
+	}
+	return &JITLambdaTemplate{Proc: Proc{Params: params, Body: parts[2], NumVars: numVars, NumberedOnly: procCanUseNumberedOnly(params, parts[2], numVars)}, Outer: outer}, true
+}
+
+func jitDeclarationParam(decl *Declaration, index int) *TypeDescriptor {
+	if decl == nil || decl.Type == nil || len(decl.Type.Params) == 0 {
+		return nil
+	}
+	if index < len(decl.Type.Params) {
+		return decl.Type.Params[index]
+	}
+	last := decl.Type.Params[len(decl.Type.Params)-1]
+	if last.Variadic {
+		return last
+	}
+	return nil
+}
+
+func jitCompileCallArgument(ctx *JITContext, decl *Declaration, index int, expr Scmer, sliceBase Reg) JITValueDesc {
+	param := jitDeclarationParam(decl, index)
+	if param != nil && param.Kind == "func" {
+		if lambda, ok := jitLambdaTemplate(expr, ctx.Env); ok {
+			return JITValueDesc{Loc: LocLambdaTemplate, Type: tagProc, Lambda: lambda}
+		}
+	}
+	hasCallback := false
+	for _, candidate := range decl.Type.Params {
+		if candidate.Kind == "func" {
+			hasCallback = true
+			break
+		}
+	}
+	if hasCallback {
+		for expr.GetTag() == tagSourceInfo {
+			expr = expr.SourceInfo().value
+		}
+		if expr.IsNthLocalVar() {
+			idx := int(expr.NthLocalVar())
+			if ctx.Env != nil && idx < len(ctx.Env.Numbered) {
+				return ctx.Env.Numbered[idx]
+			}
+			if idx < ctx.InputArgCount {
+				return JITValueDesc{Loc: LocInputPair, Type: JITTypeUnknown, StackOff: int32(idx)}
+			}
+		}
+	}
+	return jitCompileExpr(ctx, expr, sliceBase, JITValueDesc{Loc: LocAny})
 }
 
 // There is deliberately no later peephole optimizer. This backend is the final

--- a/scm/list.go
+++ b/scm/list.go
@@ -3000,7 +3000,755 @@ func init_list() {
 			Const:    true,
 			Optimize: optimizeMap,
 
-			JITEmit: nil,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				var d2 JITValueDesc
+				_ = d2
+				var d3 JITValueDesc
+				_ = d3
+				var d4 JITValueDesc
+				_ = d4
+				var d5 JITValueDesc
+				_ = d5
+				var d6 JITValueDesc
+				_ = d6
+				var d7 JITValueDesc
+				_ = d7
+				var d8 JITValueDesc
+				_ = d8
+				var d9 JITValueDesc
+				_ = d9
+				var d11 JITValueDesc
+				_ = d11
+				var d12 JITValueDesc
+				_ = d12
+				var d13 JITValueDesc
+				_ = d13
+				var d14 JITValueDesc
+				_ = d14
+				var d15 JITValueDesc
+				_ = d15
+				var d18 JITValueDesc
+				_ = d18
+				var d37 JITValueDesc
+				_ = d37
+				var d39 JITValueDesc
+				_ = d39
+				var d40 JITValueDesc
+				_ = d40
+				var d43 JITValueDesc
+				_ = d43
+				var d44 JITValueDesc
+				_ = d44
+				var d46 JITValueDesc
+				_ = d46
+				var d47 JITValueDesc
+				_ = d47
+				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
+				phiBase0 := ctx.AllocStack(int32(16))
+				d1 := JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+				var bbs [4]BBDescriptor
+				bbs[1].PhiBase = int32(phiBase0) + int32(0)
+				bbs[1].PhiCount = uint16(1)
+				if result.Loc == LocAny {
+					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+					ctx.BindReg(result.Reg, &result)
+					ctx.BindReg(result.Reg2, &result)
+				}
+				lbl0 := ctx.ReserveLabel()
+				bbpos_0_0 := int32(-1)
+				_ = bbpos_0_0
+				lbl1 := ctx.ReserveLabel()
+				bbpos_0_1 := int32(-1)
+				_ = bbpos_0_1
+				lbl2 := ctx.ReserveLabel()
+				bbpos_0_2 := int32(-1)
+				_ = bbpos_0_2
+				lbl3 := ctx.ReserveLabel()
+				bbpos_0_3 := int32(-1)
+				_ = bbpos_0_3
+				lbl4 := ctx.ReserveLabel()
+				bbs[0].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[0].VisitCount >= 0 {
+							ps.General = true
+							return bbs[0].RenderPS(ps)
+						}
+					}
+					bbs[0].VisitCount++
+					if ps.General {
+						if bbs[0].Rendered {
+							ctx.EmitJmp(lbl1)
+							return result
+						}
+						bbs[0].Rendered = true
+						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_0 = bbs[0].Address
+						ctx.MarkLabel(lbl1)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d2 = args[0]
+					d2.ID = 0
+					var d3 JITValueDesc
+					if d2.Type == tagSlice {
+						d3 = jitKnownSliceHeader(ctx, &d2)
+					} else {
+						d3 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d2}, 3)
+					}
+					ctx.BindReg(d3.Reg, &d3)
+					ctx.BindReg(d3.Reg2, &d3)
+					ctx.BindReg(d3.Reg3, &d3)
+					ctx.FreeDesc(&d2)
+					var d4 JITValueDesc
+					if d3.SliceSizeKnown {
+						d4 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.KnownSliceLen))}
+					} else if d3.Loc == LocImm {
+						d4 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.StackOff))}
+					} else {
+						ctx.EnsureDesc(&d3)
+						if d3.Loc == LocRegPair || d3.Loc == LocRegTriple {
+							d4 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg2, ID: 0}
+						} else if d3.Loc == LocReg {
+							d4 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg, ID: 0}
+						} else {
+							panic("len on unsupported descriptor location")
+						}
+					}
+					ctx.EnsureDesc(&d4)
+					ctx.EnsureDesc(&d4)
+					d5 = ctx.RequestPreallocatedSlice(0)
+					d6 = jitKnownSliceHeader(ctx, &d5)
+					ctx.FreeDesc(&d4)
+					d7 = args[1]
+					d7.ID = 0
+					var d8 JITValueDesc
+					if d7.Loc == LocLambdaTemplate {
+						d8 = d7
+					} else {
+						d8 = ctx.RequestOptimizedCallback(1)
+					}
+					ctx.FreeDesc(&d7)
+					var d9 JITValueDesc
+					if d3.SliceSizeKnown {
+						d9 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.KnownSliceLen))}
+					} else if d3.Loc == LocImm {
+						d9 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.StackOff))}
+					} else {
+						ctx.EnsureDesc(&d3)
+						if d3.Loc == LocRegPair || d3.Loc == LocRegTriple {
+							d9 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg2, ID: 0}
+						} else if d3.Loc == LocReg {
+							d9 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg, ID: 0}
+						} else {
+							panic("len on unsupported descriptor location")
+						}
+					}
+					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[1].PhiBase)+int32(0))
+					ps10 := PhiState{General: ps.General}
+					ps10.OverlayValues = make([]JITValueDesc, 10)
+					ps10.OverlayValues[1] = d1
+					ps10.OverlayValues[2] = d2
+					ps10.OverlayValues[3] = d3
+					ps10.OverlayValues[4] = d4
+					ps10.OverlayValues[5] = d5
+					ps10.OverlayValues[6] = d6
+					ps10.OverlayValues[7] = d7
+					ps10.OverlayValues[8] = d8
+					ps10.OverlayValues[9] = d9
+					ps10.PhiValues = make([]JITValueDesc, 1)
+					d11 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}
+					ps10.PhiValues[0] = d11
+					if ps10.General && bbs[1].Rendered {
+						ctx.EmitJmp(lbl2)
+						return result
+					}
+					return bbs[1].RenderPS(ps10)
+					return result
+				}
+				bbs[1].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d12 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d12)
+							ctx.EmitStoreToStack(d12, int32(bbs[1].PhiBase)+int32(0))
+						}
+						if bbs[1].VisitCount >= 0 {
+							ps.General = true
+							return bbs[1].RenderPS(ps)
+						}
+					}
+					bbs[1].VisitCount++
+					if ps.General {
+						if bbs[1].Rendered {
+							ctx.EmitJmp(lbl2)
+							return result
+						}
+						bbs[1].Rendered = true
+						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_1 = bbs[1].Address
+						ctx.MarkLabel(lbl2)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+						d1 = ps.PhiValues[0]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d1)
+					ctx.EnsureDesc(&d1)
+					var d13 JITValueDesc
+					if d1.Loc == LocImm {
+						d13 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1.Imm.Int() + 1)}
+					} else {
+						scratch := ctx.AllocRegExcept(d1.Reg)
+						ctx.EmitMovRegReg(scratch, d1.Reg)
+						ctx.EmitAddRegImm32(scratch, int32(1))
+						d13 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d13)
+					}
+					if d13.Loc == LocReg && d1.Loc == LocReg && d13.Reg == d1.Reg {
+						ctx.TransferReg(d1.Reg)
+						d1.Loc = LocNone
+					}
+					ctx.FreeDesc(&d1)
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d9)
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d9)
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d9)
+					var d14 JITValueDesc
+					if d13.Loc == LocImm && d9.Loc == LocImm {
+						d14 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d13.Imm.Int() < d9.Imm.Int())}
+					} else if d9.Loc == LocImm {
+						r0 := ctx.AllocRegExcept(d13.Reg)
+						if d9.Imm.Int() >= -2147483648 && d9.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d13.Reg, int32(d9.Imm.Int()))
+						} else {
+							ctx.EmitMovRegImm64(RegR11, uint64(d9.Imm.Int()))
+							ctx.EmitCmpInt64(d13.Reg, RegR11)
+						}
+						ctx.EmitSetcc(r0, CcL)
+						d14 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
+						ctx.BindReg(r0, &d14)
+					} else if d13.Loc == LocImm {
+						r1 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d13.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d9.Reg)
+						ctx.EmitSetcc(r1, CcL)
+						d14 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
+						ctx.BindReg(r1, &d14)
+					} else {
+						r2 := ctx.AllocRegExcept(d13.Reg)
+						ctx.EmitCmpInt64(d13.Reg, d9.Reg)
+						ctx.EmitSetcc(r2, CcL)
+						d14 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r2}
+						ctx.BindReg(r2, &d14)
+					}
+					ctx.FreeDesc(&d9)
+					d15 = d14
+					ctx.EnsureDesc(&d15)
+					if d15.Loc != LocImm && d15.Loc != LocReg {
+						panic("jit: If condition is neither LocImm nor LocReg")
+					}
+					if d15.Loc == LocImm {
+						if d15.Imm.Bool() {
+							ps16 := PhiState{General: ps.General}
+							ps16.OverlayValues = make([]JITValueDesc, 16)
+							ps16.OverlayValues[1] = d1
+							ps16.OverlayValues[2] = d2
+							ps16.OverlayValues[3] = d3
+							ps16.OverlayValues[4] = d4
+							ps16.OverlayValues[5] = d5
+							ps16.OverlayValues[6] = d6
+							ps16.OverlayValues[7] = d7
+							ps16.OverlayValues[8] = d8
+							ps16.OverlayValues[9] = d9
+							ps16.OverlayValues[11] = d11
+							ps16.OverlayValues[12] = d12
+							ps16.OverlayValues[13] = d13
+							ps16.OverlayValues[14] = d14
+							ps16.OverlayValues[15] = d15
+							return bbs[2].RenderPS(ps16)
+						}
+						ps17 := PhiState{General: ps.General}
+						ps17.OverlayValues = make([]JITValueDesc, 16)
+						ps17.OverlayValues[1] = d1
+						ps17.OverlayValues[2] = d2
+						ps17.OverlayValues[3] = d3
+						ps17.OverlayValues[4] = d4
+						ps17.OverlayValues[5] = d5
+						ps17.OverlayValues[6] = d6
+						ps17.OverlayValues[7] = d7
+						ps17.OverlayValues[8] = d8
+						ps17.OverlayValues[9] = d9
+						ps17.OverlayValues[11] = d11
+						ps17.OverlayValues[12] = d12
+						ps17.OverlayValues[13] = d13
+						ps17.OverlayValues[14] = d14
+						ps17.OverlayValues[15] = d15
+						return bbs[3].RenderPS(ps17)
+					}
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d18 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d18)
+							ctx.EmitStoreToStack(d18, int32(bbs[1].PhiBase)+int32(0))
+						}
+						ps.General = true
+						return bbs[1].RenderPS(ps)
+					}
+					lbl5 := ctx.ReserveLabel()
+					lbl6 := ctx.ReserveLabel()
+					ctx.EmitCmpRegImm32(d15.Reg, 0)
+					ctx.EmitJcc(CcNE, lbl5)
+					ctx.EmitJmp(lbl6)
+					ctx.MarkLabel(lbl5)
+					ctx.EmitJmp(lbl3)
+					ctx.MarkLabel(lbl6)
+					ctx.EmitJmp(lbl4)
+					ps19 := PhiState{General: true}
+					ps19.OverlayValues = make([]JITValueDesc, 19)
+					ps19.OverlayValues[1] = d1
+					ps19.OverlayValues[2] = d2
+					ps19.OverlayValues[3] = d3
+					ps19.OverlayValues[4] = d4
+					ps19.OverlayValues[5] = d5
+					ps19.OverlayValues[6] = d6
+					ps19.OverlayValues[7] = d7
+					ps19.OverlayValues[8] = d8
+					ps19.OverlayValues[9] = d9
+					ps19.OverlayValues[11] = d11
+					ps19.OverlayValues[12] = d12
+					ps19.OverlayValues[13] = d13
+					ps19.OverlayValues[14] = d14
+					ps19.OverlayValues[15] = d15
+					ps19.OverlayValues[18] = d18
+					ps20 := PhiState{General: true}
+					ps20.OverlayValues = make([]JITValueDesc, 19)
+					ps20.OverlayValues[1] = d1
+					ps20.OverlayValues[2] = d2
+					ps20.OverlayValues[3] = d3
+					ps20.OverlayValues[4] = d4
+					ps20.OverlayValues[5] = d5
+					ps20.OverlayValues[6] = d6
+					ps20.OverlayValues[7] = d7
+					ps20.OverlayValues[8] = d8
+					ps20.OverlayValues[9] = d9
+					ps20.OverlayValues[11] = d11
+					ps20.OverlayValues[12] = d12
+					ps20.OverlayValues[13] = d13
+					ps20.OverlayValues[14] = d14
+					ps20.OverlayValues[15] = d15
+					ps20.OverlayValues[18] = d18
+					snap21 := d1
+					snap22 := d2
+					snap23 := d3
+					snap24 := d4
+					snap25 := d5
+					snap26 := d6
+					snap27 := d7
+					snap28 := d8
+					snap29 := d9
+					snap30 := d11
+					snap31 := d12
+					snap32 := d13
+					snap33 := d14
+					snap34 := d15
+					snap35 := d18
+					alloc36 := ctx.SnapshotAllocState()
+					if !bbs[3].Rendered {
+						bbs[3].RenderPS(ps20)
+					}
+					ctx.RestoreAllocState(alloc36)
+					d1 = snap21
+					d2 = snap22
+					d3 = snap23
+					d4 = snap24
+					d5 = snap25
+					d6 = snap26
+					d7 = snap27
+					d8 = snap28
+					d9 = snap29
+					d11 = snap30
+					d12 = snap31
+					d13 = snap32
+					d14 = snap33
+					d15 = snap34
+					d18 = snap35
+					if !bbs[2].Rendered {
+						return bbs[2].RenderPS(ps19)
+					}
+					return result
+					ctx.FreeDesc(&d14)
+					return result
+				}
+				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[2].VisitCount >= 0 {
+							ps.General = true
+							return bbs[2].RenderPS(ps)
+						}
+					}
+					bbs[2].VisitCount++
+					if ps.General {
+						if bbs[2].Rendered {
+							ctx.EmitJmp(lbl3)
+							return result
+						}
+						bbs[2].Rendered = true
+						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_2 = bbs[2].Address
+						ctx.MarkLabel(lbl3)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+						d13 = ps.OverlayValues[13]
+					}
+					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+						d14 = ps.OverlayValues[14]
+					}
+					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
+						d18 = ps.OverlayValues[18]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d13)
+					r3 := ctx.AllocReg()
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d3)
+					if d13.Loc == LocImm {
+						ctx.EmitMovRegImm64(r3, uint64(d13.Imm.Int())*16)
+					} else {
+						ctx.EmitMovRegReg(r3, d13.Reg)
+						ctx.EmitShlRegImm8(r3, 4)
+					}
+					if d3.Loc == LocImm {
+						ctx.EmitMovRegImm64(RegR11, uint64(d3.Imm.Int()))
+						ctx.EmitAddInt64(r3, RegR11)
+					} else {
+						ctx.EmitAddInt64(r3, d3.Reg)
+					}
+					r4 := ctx.AllocRegExcept(r3)
+					r5 := ctx.AllocRegExcept(r3, r4)
+					ctx.EmitMovRegMem(r4, r3, 0)
+					ctx.EmitMovRegMem(r5, r3, 8)
+					ctx.FreeReg(r3)
+					d37 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r4, Reg2: r5}
+					ctx.BindReg(r4, &d37)
+					ctx.BindReg(r5, &d37)
+					stackArray38 := ctx.AllocStack(int32(16))
+					ctx.EnsureDesc(&d37)
+					ctx.EnsureDesc(&d37)
+					ctx.EmitStoreScmerToStack(d37, int32(stackArray38)+int32(0))
+					ctx.FreeDesc(&d37)
+					r6 := ctx.AllocReg()
+					r7 := ctx.AllocRegExcept(r6)
+					r8 := ctx.AllocRegExcept(r6, r7)
+					ctx.EmitLeaRegMem(r6, RegRSP, int32(stackArray38))
+					ctx.EmitMovRegImm64(r7, uint64(1))
+					ctx.EmitMovRegImm64(r8, uint64(1))
+					d39 = JITValueDesc{Loc: LocRegTriple, Reg: r6, Reg2: r7, Reg3: r8, KnownSliceLen: int32(1), KnownSliceCap: int32(1), SliceSizeKnown: true}
+					ctx.BindReg(r6, &d39)
+					ctx.BindReg(r7, &d39)
+					ctx.BindReg(r8, &d39)
+					callbackArgs41 := make([]JITValueDesc, 1)
+					callbackArgs41[0] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(stackArray38) + 0}
+					var d40 JITValueDesc
+					ctx.FreeDesc(&d39)
+					if d8.Loc == LocLambdaTemplate && d8.Lambda != nil {
+						outerRegs42 := ctx.PreserveOuterRegs()
+						d40 = JITEmitProcInlineWithOuter(ctx, &d8.Lambda.Proc, d8.Lambda.Outer, callbackArgs41, ctx.SliceBase, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+						ctx.RestoreOuterRegs(outerRegs42)
+					} else {
+						callbackCallArgs := make([]JITValueDesc, 0, 2)
+						callbackCallArgs = append(callbackCallArgs, d8)
+						callbackCallArgs = append(callbackCallArgs, callbackArgs41...)
+						d40 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+					}
+					ctx.EnsureDesc(&d13)
+					ctx.EnsureDesc(&d40)
+					d43 = ctx.EmitSliceElementAddress(&d6, &d13, int32(16))
+					ctx.EmitStoreScmerAt(&d43, &d40)
+					ctx.FreeDesc(&d43)
+					ctx.FreeDesc(&d40)
+					ctx.EnsureDesc(&d13)
+					if d13.Loc == LocReg {
+						ctx.ProtectReg(d13.Reg)
+					} else if d13.Loc == LocRegPair {
+						ctx.ProtectReg(d13.Reg)
+						ctx.ProtectReg(d13.Reg2)
+					}
+					d44 = d13
+					if d44.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d44)
+					ctx.EmitStoreToStack(d44, int32(bbs[1].PhiBase)+int32(0))
+					if d13.Loc == LocReg {
+						ctx.UnprotectReg(d13.Reg)
+					} else if d13.Loc == LocRegPair {
+						ctx.UnprotectReg(d13.Reg)
+						ctx.UnprotectReg(d13.Reg2)
+					}
+					ps45 := PhiState{General: ps.General}
+					ps45.OverlayValues = make([]JITValueDesc, 45)
+					ps45.OverlayValues[1] = d1
+					ps45.OverlayValues[2] = d2
+					ps45.OverlayValues[3] = d3
+					ps45.OverlayValues[4] = d4
+					ps45.OverlayValues[5] = d5
+					ps45.OverlayValues[6] = d6
+					ps45.OverlayValues[7] = d7
+					ps45.OverlayValues[8] = d8
+					ps45.OverlayValues[9] = d9
+					ps45.OverlayValues[11] = d11
+					ps45.OverlayValues[12] = d12
+					ps45.OverlayValues[13] = d13
+					ps45.OverlayValues[14] = d14
+					ps45.OverlayValues[15] = d15
+					ps45.OverlayValues[18] = d18
+					ps45.OverlayValues[37] = d37
+					ps45.OverlayValues[39] = d39
+					ps45.OverlayValues[40] = d40
+					ps45.OverlayValues[43] = d43
+					ps45.OverlayValues[44] = d44
+					ps45.PhiValues = make([]JITValueDesc, 1)
+					d46 = d13
+					ps45.PhiValues[0] = d46
+					if ps45.General && bbs[1].Rendered {
+						ctx.EmitJmp(lbl2)
+						return result
+					}
+					return bbs[1].RenderPS(ps45)
+					return result
+				}
+				bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[3].VisitCount >= 0 {
+							ps.General = true
+							return bbs[3].RenderPS(ps)
+						}
+					}
+					bbs[3].VisitCount++
+					if ps.General {
+						if bbs[3].Rendered {
+							ctx.EmitJmp(lbl4)
+							return result
+						}
+						bbs[3].Rendered = true
+						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_3 = bbs[3].Address
+						ctx.MarkLabel(lbl4)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if len(ps.OverlayValues) > 13 && ps.OverlayValues[13].Loc != LocNone {
+						d13 = ps.OverlayValues[13]
+					}
+					if len(ps.OverlayValues) > 14 && ps.OverlayValues[14].Loc != LocNone {
+						d14 = ps.OverlayValues[14]
+					}
+					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 18 && ps.OverlayValues[18].Loc != LocNone {
+						d18 = ps.OverlayValues[18]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
+					}
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
+					}
+					if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != LocNone {
+						d43 = ps.OverlayValues[43]
+					}
+					if len(ps.OverlayValues) > 44 && ps.OverlayValues[44].Loc != LocNone {
+						d44 = ps.OverlayValues[44]
+					}
+					if len(ps.OverlayValues) > 46 && ps.OverlayValues[46].Loc != LocNone {
+						d46 = ps.OverlayValues[46]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d47 = ctx.EmitNewSliceFromGoSlice(&d6)
+					ctx.EnsureDesc(&d47)
+					if d47.Loc == LocRegPair {
+						ctx.EmitMovPairToResult(&d47, &result)
+						result.Type = d47.Type
+					} else {
+						switch d47.Type {
+						case tagBool:
+							ctx.EmitMakeBool(result, d47)
+							result.Type = tagBool
+						case tagInt:
+							ctx.EmitMakeInt(result, d47)
+							result.Type = tagInt
+						case tagFloat:
+							ctx.EmitMakeFloat(result, d47)
+							result.Type = tagFloat
+						case tagNil:
+							ctx.EmitMakeNil(result)
+							result.Type = tagNil
+						default:
+							ctx.EmitMovPairToResult(&d47, &result)
+							result.Type = d47.Type
+						}
+					}
+					ctx.EmitJmp(lbl0)
+					return result
+				}
+				argPinned48 := make([]Reg, 0, len(args)*3)
+				seenArgRegs := make(map[Reg]bool)
+				for _, ai := range args {
+					if ai.Loc == LocReg {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned48 = append(argPinned48, ai.Reg)
+						}
+					} else if ai.Loc == LocRegPair {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned48 = append(argPinned48, ai.Reg)
+						}
+						if !seenArgRegs[ai.Reg2] {
+							ctx.ProtectReg(ai.Reg2)
+							seenArgRegs[ai.Reg2] = true
+							argPinned48 = append(argPinned48, ai.Reg2)
+						}
+					} else if ai.Loc == LocRegTriple {
+						for _, r := range [...]Reg{ai.Reg, ai.Reg2, ai.Reg3} {
+							if !seenArgRegs[r] {
+								ctx.ProtectReg(r)
+								seenArgRegs[r] = true
+								argPinned48 = append(argPinned48, r)
+							}
+						}
+					}
+				}
+				defer func() {
+					for _, r := range argPinned48 {
+						ctx.UnprotectReg(r)
+					}
+				}()
+				ps49 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps49)
+				ctx.MarkLabel(lbl0)
+				ctx.ResolveFixups()
+				ctx.FreeStack(int32(16))
+				return result
+			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3180,7 +3928,1872 @@ func init_list() {
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 
-			JITEmit: nil,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				var d3 JITValueDesc
+				_ = d3
+				var d4 JITValueDesc
+				_ = d4
+				var d5 JITValueDesc
+				_ = d5
+				var d6 JITValueDesc
+				_ = d6
+				var d7 JITValueDesc
+				_ = d7
+				var d8 JITValueDesc
+				_ = d8
+				var d9 JITValueDesc
+				_ = d9
+				var d10 JITValueDesc
+				_ = d10
+				var d26 JITValueDesc
+				_ = d26
+				var d27 JITValueDesc
+				_ = d27
+				var d29 JITValueDesc
+				_ = d29
+				var d30 JITValueDesc
+				_ = d30
+				var d31 JITValueDesc
+				_ = d31
+				var d32 JITValueDesc
+				_ = d32
+				var d33 JITValueDesc
+				_ = d33
+				var d35 JITValueDesc
+				_ = d35
+				var d37 JITValueDesc
+				_ = d37
+				var d38 JITValueDesc
+				_ = d38
+				var d39 JITValueDesc
+				_ = d39
+				var d42 JITValueDesc
+				_ = d42
+				var d43 JITValueDesc
+				_ = d43
+				var d68 JITValueDesc
+				_ = d68
+				var d69 JITValueDesc
+				_ = d69
+				var d70 JITValueDesc
+				_ = d70
+				var d72 JITValueDesc
+				_ = d72
+				var d73 JITValueDesc
+				_ = d73
+				var d74 JITValueDesc
+				_ = d74
+				var d76 JITValueDesc
+				_ = d76
+				var d77 JITValueDesc
+				_ = d77
+				var d80 JITValueDesc
+				_ = d80
+				var d81 JITValueDesc
+				_ = d81
+				var d82 JITValueDesc
+				_ = d82
+				var d84 JITValueDesc
+				_ = d84
+				var d85 JITValueDesc
+				_ = d85
+				var d86 JITValueDesc
+				_ = d86
+				var d87 JITValueDesc
+				_ = d87
+				var d88 JITValueDesc
+				_ = d88
+				var d89 JITValueDesc
+				_ = d89
+				var d90 JITValueDesc
+				_ = d90
+				var d93 JITValueDesc
+				_ = d93
+				var d94 JITValueDesc
+				_ = d94
+				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
+				phiBase0 := ctx.AllocStack(int32(32))
+				d1 := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+				d2 := JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+				var bbs [7]BBDescriptor
+				bbs[6].PhiBase = int32(phiBase0) + int32(0)
+				bbs[6].PhiCount = uint16(2)
+				if result.Loc == LocAny {
+					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+					ctx.BindReg(result.Reg, &result)
+					ctx.BindReg(result.Reg2, &result)
+				}
+				lbl0 := ctx.ReserveLabel()
+				bbpos_0_0 := int32(-1)
+				_ = bbpos_0_0
+				lbl1 := ctx.ReserveLabel()
+				bbpos_0_1 := int32(-1)
+				_ = bbpos_0_1
+				lbl2 := ctx.ReserveLabel()
+				bbpos_0_2 := int32(-1)
+				_ = bbpos_0_2
+				lbl3 := ctx.ReserveLabel()
+				bbpos_0_3 := int32(-1)
+				_ = bbpos_0_3
+				lbl4 := ctx.ReserveLabel()
+				bbpos_0_4 := int32(-1)
+				_ = bbpos_0_4
+				lbl5 := ctx.ReserveLabel()
+				bbpos_0_5 := int32(-1)
+				_ = bbpos_0_5
+				lbl6 := ctx.ReserveLabel()
+				bbpos_0_6 := int32(-1)
+				_ = bbpos_0_6
+				lbl7 := ctx.ReserveLabel()
+				bbs[0].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[0].VisitCount >= 0 {
+							ps.General = true
+							return bbs[0].RenderPS(ps)
+						}
+					}
+					bbs[0].VisitCount++
+					if ps.General {
+						if bbs[0].Rendered {
+							ctx.EmitJmp(lbl1)
+							return result
+						}
+						bbs[0].Rendered = true
+						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_0 = bbs[0].Address
+						ctx.MarkLabel(lbl1)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d3 = args[0]
+					d3.ID = 0
+					var d4 JITValueDesc
+					if d3.Type == tagSlice {
+						d4 = jitKnownSliceHeader(ctx, &d3)
+					} else {
+						d4 = ctx.EmitGoCallScalar(GoFuncAddr(jitAsSlice), []JITValueDesc{d3}, 3)
+					}
+					ctx.BindReg(d4.Reg, &d4)
+					ctx.BindReg(d4.Reg2, &d4)
+					ctx.BindReg(d4.Reg3, &d4)
+					ctx.FreeDesc(&d3)
+					d5 = args[1]
+					d5.ID = 0
+					var d6 JITValueDesc
+					if d5.Loc == LocLambdaTemplate {
+						d6 = d5
+					} else {
+						d6 = ctx.RequestOptimizedCallback(1)
+					}
+					ctx.FreeDesc(&d5)
+					d7 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+					d8 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
+					ctx.EnsureDesc(&d8)
+					var d9 JITValueDesc
+					if d8.Loc == LocImm {
+						d9 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d8.Imm.Int() > 2)}
+					} else {
+						r0 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d8.Reg, 2)
+						ctx.EmitSetcc(r0, CcG)
+						d9 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
+						ctx.BindReg(r0, &d9)
+					}
+					ctx.FreeDesc(&d8)
+					d10 = d9
+					ctx.EnsureDesc(&d10)
+					if d10.Loc != LocImm && d10.Loc != LocReg {
+						panic("jit: If condition is neither LocImm nor LocReg")
+					}
+					if d10.Loc == LocImm {
+						if d10.Imm.Bool() {
+							ps11 := PhiState{General: ps.General}
+							ps11.OverlayValues = make([]JITValueDesc, 11)
+							ps11.OverlayValues[1] = d1
+							ps11.OverlayValues[2] = d2
+							ps11.OverlayValues[3] = d3
+							ps11.OverlayValues[4] = d4
+							ps11.OverlayValues[5] = d5
+							ps11.OverlayValues[6] = d6
+							ps11.OverlayValues[7] = d7
+							ps11.OverlayValues[8] = d8
+							ps11.OverlayValues[9] = d9
+							ps11.OverlayValues[10] = d10
+							return bbs[1].RenderPS(ps11)
+						}
+						ps12 := PhiState{General: ps.General}
+						ps12.OverlayValues = make([]JITValueDesc, 11)
+						ps12.OverlayValues[1] = d1
+						ps12.OverlayValues[2] = d2
+						ps12.OverlayValues[3] = d3
+						ps12.OverlayValues[4] = d4
+						ps12.OverlayValues[5] = d5
+						ps12.OverlayValues[6] = d6
+						ps12.OverlayValues[7] = d7
+						ps12.OverlayValues[8] = d8
+						ps12.OverlayValues[9] = d9
+						ps12.OverlayValues[10] = d10
+						return bbs[2].RenderPS(ps12)
+					}
+					if !ps.General {
+						ps.General = true
+						return bbs[0].RenderPS(ps)
+					}
+					lbl8 := ctx.ReserveLabel()
+					lbl9 := ctx.ReserveLabel()
+					ctx.EmitCmpRegImm32(d10.Reg, 0)
+					ctx.EmitJcc(CcNE, lbl8)
+					ctx.EmitJmp(lbl9)
+					ctx.MarkLabel(lbl8)
+					ctx.EmitJmp(lbl2)
+					ctx.MarkLabel(lbl9)
+					ctx.EmitJmp(lbl3)
+					ps13 := PhiState{General: true}
+					ps13.OverlayValues = make([]JITValueDesc, 11)
+					ps13.OverlayValues[1] = d1
+					ps13.OverlayValues[2] = d2
+					ps13.OverlayValues[3] = d3
+					ps13.OverlayValues[4] = d4
+					ps13.OverlayValues[5] = d5
+					ps13.OverlayValues[6] = d6
+					ps13.OverlayValues[7] = d7
+					ps13.OverlayValues[8] = d8
+					ps13.OverlayValues[9] = d9
+					ps13.OverlayValues[10] = d10
+					ps14 := PhiState{General: true}
+					ps14.OverlayValues = make([]JITValueDesc, 11)
+					ps14.OverlayValues[1] = d1
+					ps14.OverlayValues[2] = d2
+					ps14.OverlayValues[3] = d3
+					ps14.OverlayValues[4] = d4
+					ps14.OverlayValues[5] = d5
+					ps14.OverlayValues[6] = d6
+					ps14.OverlayValues[7] = d7
+					ps14.OverlayValues[8] = d8
+					ps14.OverlayValues[9] = d9
+					ps14.OverlayValues[10] = d10
+					snap15 := d1
+					snap16 := d2
+					snap17 := d3
+					snap18 := d4
+					snap19 := d5
+					snap20 := d6
+					snap21 := d7
+					snap22 := d8
+					snap23 := d9
+					snap24 := d10
+					alloc25 := ctx.SnapshotAllocState()
+					if !bbs[2].Rendered {
+						bbs[2].RenderPS(ps14)
+					}
+					ctx.RestoreAllocState(alloc25)
+					d1 = snap15
+					d2 = snap16
+					d3 = snap17
+					d4 = snap18
+					d5 = snap19
+					d6 = snap20
+					d7 = snap21
+					d8 = snap22
+					d9 = snap23
+					d10 = snap24
+					if !bbs[1].Rendered {
+						return bbs[1].RenderPS(ps13)
+					}
+					return result
+					ctx.FreeDesc(&d9)
+					return result
+				}
+				bbs[1].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[1].VisitCount >= 0 {
+							ps.General = true
+							return bbs[1].RenderPS(ps)
+						}
+					}
+					bbs[1].VisitCount++
+					if ps.General {
+						if bbs[1].Rendered {
+							ctx.EmitJmp(lbl2)
+							return result
+						}
+						bbs[1].Rendered = true
+						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_1 = bbs[1].Address
+						ctx.MarkLabel(lbl2)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d26 = args[2]
+					d26.ID = 0
+					ctx.EnsureDesc(&d26)
+					if d26.Loc == LocReg {
+						ctx.ProtectReg(d26.Reg)
+					} else if d26.Loc == LocRegPair {
+						ctx.ProtectReg(d26.Reg)
+						ctx.ProtectReg(d26.Reg2)
+					}
+					d27 = d26
+					if d27.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d27)
+					if d27.Loc == LocRegPair || d27.Loc == LocImm {
+						ctx.EmitStoreScmerToStack(d27, int32(bbs[6].PhiBase)+int32(0))
+					} else {
+						ctx.EmitStoreToStack(d27, int32(bbs[6].PhiBase)+int32(0))
+						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
+					}
+					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
+					if d26.Loc == LocReg {
+						ctx.UnprotectReg(d26.Reg)
+					} else if d26.Loc == LocRegPair {
+						ctx.UnprotectReg(d26.Reg)
+						ctx.UnprotectReg(d26.Reg2)
+					}
+					ps28 := PhiState{General: ps.General}
+					ps28.OverlayValues = make([]JITValueDesc, 28)
+					ps28.OverlayValues[1] = d1
+					ps28.OverlayValues[2] = d2
+					ps28.OverlayValues[3] = d3
+					ps28.OverlayValues[4] = d4
+					ps28.OverlayValues[5] = d5
+					ps28.OverlayValues[6] = d6
+					ps28.OverlayValues[7] = d7
+					ps28.OverlayValues[8] = d8
+					ps28.OverlayValues[9] = d9
+					ps28.OverlayValues[10] = d10
+					ps28.OverlayValues[26] = d26
+					ps28.OverlayValues[27] = d27
+					ps28.PhiValues = make([]JITValueDesc, 2)
+					d29 = d26
+					ps28.PhiValues[0] = d29
+					d30 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps28.PhiValues[1] = d30
+					if ps28.General && bbs[6].Rendered {
+						ctx.EmitJmp(lbl7)
+						return result
+					}
+					return bbs[6].RenderPS(ps28)
+					return result
+				}
+				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[2].VisitCount >= 0 {
+							ps.General = true
+							return bbs[2].RenderPS(ps)
+						}
+					}
+					bbs[2].VisitCount++
+					if ps.General {
+						if bbs[2].Rendered {
+							ctx.EmitJmp(lbl3)
+							return result
+						}
+						bbs[2].Rendered = true
+						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_2 = bbs[2].Address
+						ctx.MarkLabel(lbl3)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
+					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					ctx.ReclaimUntrackedRegs()
+					var d31 JITValueDesc
+					if d4.SliceSizeKnown {
+						d31 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.KnownSliceLen))}
+					} else if d4.Loc == LocImm {
+						d31 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.StackOff))}
+					} else {
+						ctx.EnsureDesc(&d4)
+						if d4.Loc == LocRegPair || d4.Loc == LocRegTriple {
+							d31 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg2, ID: 0}
+						} else if d4.Loc == LocReg {
+							d31 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg, ID: 0}
+						} else {
+							panic("len on unsupported descriptor location")
+						}
+					}
+					ctx.EnsureDesc(&d31)
+					var d32 JITValueDesc
+					if d31.Loc == LocImm {
+						d32 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d31.Imm.Int() > 0)}
+					} else {
+						r1 := ctx.AllocReg()
+						ctx.EmitCmpRegImm32(d31.Reg, 0)
+						ctx.EmitSetcc(r1, CcG)
+						d32 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
+						ctx.BindReg(r1, &d32)
+					}
+					ctx.FreeDesc(&d31)
+					d33 = d32
+					ctx.EnsureDesc(&d33)
+					if d33.Loc != LocImm && d33.Loc != LocReg {
+						panic("jit: If condition is neither LocImm nor LocReg")
+					}
+					if d33.Loc == LocImm {
+						if d33.Imm.Bool() {
+							ps34 := PhiState{General: ps.General}
+							ps34.OverlayValues = make([]JITValueDesc, 34)
+							ps34.OverlayValues[1] = d1
+							ps34.OverlayValues[2] = d2
+							ps34.OverlayValues[3] = d3
+							ps34.OverlayValues[4] = d4
+							ps34.OverlayValues[5] = d5
+							ps34.OverlayValues[6] = d6
+							ps34.OverlayValues[7] = d7
+							ps34.OverlayValues[8] = d8
+							ps34.OverlayValues[9] = d9
+							ps34.OverlayValues[10] = d10
+							ps34.OverlayValues[26] = d26
+							ps34.OverlayValues[27] = d27
+							ps34.OverlayValues[29] = d29
+							ps34.OverlayValues[30] = d30
+							ps34.OverlayValues[31] = d31
+							ps34.OverlayValues[32] = d32
+							ps34.OverlayValues[33] = d33
+							return bbs[3].RenderPS(ps34)
+						}
+						ctx.EnsureDesc(&d7)
+						if d7.Loc == LocReg {
+							ctx.ProtectReg(d7.Reg)
+						} else if d7.Loc == LocRegPair {
+							ctx.ProtectReg(d7.Reg)
+							ctx.ProtectReg(d7.Reg2)
+						}
+						d35 = d7
+						if d35.Loc == LocNone {
+							panic("jit: phi source has no location")
+						}
+						ctx.EnsureDesc(&d35)
+						if d35.Loc == LocRegPair || d35.Loc == LocImm {
+							ctx.EmitStoreScmerToStack(d35, int32(bbs[6].PhiBase)+int32(0))
+						} else {
+							ctx.EmitStoreToStack(d35, int32(bbs[6].PhiBase)+int32(0))
+							ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
+						}
+						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
+						if d7.Loc == LocReg {
+							ctx.UnprotectReg(d7.Reg)
+						} else if d7.Loc == LocRegPair {
+							ctx.UnprotectReg(d7.Reg)
+							ctx.UnprotectReg(d7.Reg2)
+						}
+						ps36 := PhiState{General: ps.General}
+						ps36.OverlayValues = make([]JITValueDesc, 36)
+						ps36.OverlayValues[1] = d1
+						ps36.OverlayValues[2] = d2
+						ps36.OverlayValues[3] = d3
+						ps36.OverlayValues[4] = d4
+						ps36.OverlayValues[5] = d5
+						ps36.OverlayValues[6] = d6
+						ps36.OverlayValues[7] = d7
+						ps36.OverlayValues[8] = d8
+						ps36.OverlayValues[9] = d9
+						ps36.OverlayValues[10] = d10
+						ps36.OverlayValues[26] = d26
+						ps36.OverlayValues[27] = d27
+						ps36.OverlayValues[29] = d29
+						ps36.OverlayValues[30] = d30
+						ps36.OverlayValues[31] = d31
+						ps36.OverlayValues[32] = d32
+						ps36.OverlayValues[33] = d33
+						ps36.OverlayValues[35] = d35
+						ps36.PhiValues = make([]JITValueDesc, 2)
+						d37 = d7
+						ps36.PhiValues[0] = d37
+						d38 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+						ps36.PhiValues[1] = d38
+						return bbs[6].RenderPS(ps36)
+					}
+					if !ps.General {
+						ps.General = true
+						return bbs[2].RenderPS(ps)
+					}
+					lbl10 := ctx.ReserveLabel()
+					lbl11 := ctx.ReserveLabel()
+					ctx.EmitCmpRegImm32(d33.Reg, 0)
+					ctx.EmitJcc(CcNE, lbl10)
+					ctx.EmitJmp(lbl11)
+					ctx.MarkLabel(lbl10)
+					ctx.EmitJmp(lbl4)
+					ctx.MarkLabel(lbl11)
+					ctx.EnsureDesc(&d7)
+					if d7.Loc == LocReg {
+						ctx.ProtectReg(d7.Reg)
+					} else if d7.Loc == LocRegPair {
+						ctx.ProtectReg(d7.Reg)
+						ctx.ProtectReg(d7.Reg2)
+					}
+					d39 = d7
+					if d39.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d39)
+					if d39.Loc == LocRegPair || d39.Loc == LocImm {
+						ctx.EmitStoreScmerToStack(d39, int32(bbs[6].PhiBase)+int32(0))
+					} else {
+						ctx.EmitStoreToStack(d39, int32(bbs[6].PhiBase)+int32(0))
+						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
+					}
+					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}, int32(bbs[6].PhiBase)+int32(16))
+					if d7.Loc == LocReg {
+						ctx.UnprotectReg(d7.Reg)
+					} else if d7.Loc == LocRegPair {
+						ctx.UnprotectReg(d7.Reg)
+						ctx.UnprotectReg(d7.Reg2)
+					}
+					ctx.EmitJmp(lbl7)
+					ps40 := PhiState{General: true}
+					ps40.OverlayValues = make([]JITValueDesc, 40)
+					ps40.OverlayValues[1] = d1
+					ps40.OverlayValues[2] = d2
+					ps40.OverlayValues[3] = d3
+					ps40.OverlayValues[4] = d4
+					ps40.OverlayValues[5] = d5
+					ps40.OverlayValues[6] = d6
+					ps40.OverlayValues[7] = d7
+					ps40.OverlayValues[8] = d8
+					ps40.OverlayValues[9] = d9
+					ps40.OverlayValues[10] = d10
+					ps40.OverlayValues[26] = d26
+					ps40.OverlayValues[27] = d27
+					ps40.OverlayValues[29] = d29
+					ps40.OverlayValues[30] = d30
+					ps40.OverlayValues[31] = d31
+					ps40.OverlayValues[32] = d32
+					ps40.OverlayValues[33] = d33
+					ps40.OverlayValues[35] = d35
+					ps40.OverlayValues[37] = d37
+					ps40.OverlayValues[38] = d38
+					ps40.OverlayValues[39] = d39
+					ps41 := PhiState{General: true}
+					ps41.OverlayValues = make([]JITValueDesc, 40)
+					ps41.OverlayValues[1] = d1
+					ps41.OverlayValues[2] = d2
+					ps41.OverlayValues[3] = d3
+					ps41.OverlayValues[4] = d4
+					ps41.OverlayValues[5] = d5
+					ps41.OverlayValues[6] = d6
+					ps41.OverlayValues[7] = d7
+					ps41.OverlayValues[8] = d8
+					ps41.OverlayValues[9] = d9
+					ps41.OverlayValues[10] = d10
+					ps41.OverlayValues[26] = d26
+					ps41.OverlayValues[27] = d27
+					ps41.OverlayValues[29] = d29
+					ps41.OverlayValues[30] = d30
+					ps41.OverlayValues[31] = d31
+					ps41.OverlayValues[32] = d32
+					ps41.OverlayValues[33] = d33
+					ps41.OverlayValues[35] = d35
+					ps41.OverlayValues[37] = d37
+					ps41.OverlayValues[38] = d38
+					ps41.OverlayValues[39] = d39
+					ps41.PhiValues = make([]JITValueDesc, 2)
+					d42 = d7
+					ps41.PhiValues[0] = d42
+					d43 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					ps41.PhiValues[1] = d43
+					snap44 := d1
+					snap45 := d2
+					snap46 := d3
+					snap47 := d4
+					snap48 := d5
+					snap49 := d6
+					snap50 := d7
+					snap51 := d8
+					snap52 := d9
+					snap53 := d10
+					snap54 := d26
+					snap55 := d27
+					snap56 := d29
+					snap57 := d30
+					snap58 := d31
+					snap59 := d32
+					snap60 := d33
+					snap61 := d35
+					snap62 := d37
+					snap63 := d38
+					snap64 := d39
+					snap65 := d42
+					snap66 := d43
+					alloc67 := ctx.SnapshotAllocState()
+					if !bbs[6].Rendered {
+						bbs[6].RenderPS(ps41)
+					}
+					ctx.RestoreAllocState(alloc67)
+					d1 = snap44
+					d2 = snap45
+					d3 = snap46
+					d4 = snap47
+					d5 = snap48
+					d6 = snap49
+					d7 = snap50
+					d8 = snap51
+					d9 = snap52
+					d10 = snap53
+					d26 = snap54
+					d27 = snap55
+					d29 = snap56
+					d30 = snap57
+					d31 = snap58
+					d32 = snap59
+					d33 = snap60
+					d35 = snap61
+					d37 = snap62
+					d38 = snap63
+					d39 = snap64
+					d42 = snap65
+					d43 = snap66
+					if !bbs[3].Rendered {
+						return bbs[3].RenderPS(ps40)
+					}
+					return result
+					ctx.FreeDesc(&d32)
+					return result
+				}
+				bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[3].VisitCount >= 0 {
+							ps.General = true
+							return bbs[3].RenderPS(ps)
+						}
+					}
+					bbs[3].VisitCount++
+					if ps.General {
+						if bbs[3].Rendered {
+							ctx.EmitJmp(lbl4)
+							return result
+						}
+						bbs[3].Rendered = true
+						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_3 = bbs[3].Address
+						ctx.MarkLabel(lbl4)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
+					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
+					}
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
+						d38 = ps.OverlayValues[38]
+					}
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
+					}
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != LocNone {
+						d43 = ps.OverlayValues[43]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d68 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
+					r2 := ctx.AllocReg()
+					ctx.EnsureDesc(&d68)
+					ctx.EnsureDesc(&d4)
+					if d68.Loc == LocImm {
+						ctx.EmitMovRegImm64(r2, uint64(d68.Imm.Int())*16)
+					} else {
+						ctx.EmitMovRegReg(r2, d68.Reg)
+						ctx.EmitShlRegImm8(r2, 4)
+					}
+					if d4.Loc == LocImm {
+						ctx.EmitMovRegImm64(RegR11, uint64(d4.Imm.Int()))
+						ctx.EmitAddInt64(r2, RegR11)
+					} else {
+						ctx.EmitAddInt64(r2, d4.Reg)
+					}
+					r3 := ctx.AllocRegExcept(r2)
+					r4 := ctx.AllocRegExcept(r2, r3)
+					ctx.EmitMovRegMem(r3, r2, 0)
+					ctx.EmitMovRegMem(r4, r2, 8)
+					ctx.FreeReg(r2)
+					d69 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r3, Reg2: r4}
+					ctx.BindReg(r3, &d69)
+					ctx.BindReg(r4, &d69)
+					ctx.EnsureDesc(&d69)
+					if d69.Loc == LocReg {
+						ctx.ProtectReg(d69.Reg)
+					} else if d69.Loc == LocRegPair {
+						ctx.ProtectReg(d69.Reg)
+						ctx.ProtectReg(d69.Reg2)
+					}
+					d70 = d69
+					if d70.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d70)
+					if d70.Loc == LocRegPair || d70.Loc == LocImm {
+						ctx.EmitStoreScmerToStack(d70, int32(bbs[6].PhiBase)+int32(0))
+					} else {
+						ctx.EmitStoreToStack(d70, int32(bbs[6].PhiBase)+int32(0))
+						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
+					}
+					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(1)}, int32(bbs[6].PhiBase)+int32(16))
+					if d69.Loc == LocReg {
+						ctx.UnprotectReg(d69.Reg)
+					} else if d69.Loc == LocRegPair {
+						ctx.UnprotectReg(d69.Reg)
+						ctx.UnprotectReg(d69.Reg2)
+					}
+					ps71 := PhiState{General: ps.General}
+					ps71.OverlayValues = make([]JITValueDesc, 71)
+					ps71.OverlayValues[1] = d1
+					ps71.OverlayValues[2] = d2
+					ps71.OverlayValues[3] = d3
+					ps71.OverlayValues[4] = d4
+					ps71.OverlayValues[5] = d5
+					ps71.OverlayValues[6] = d6
+					ps71.OverlayValues[7] = d7
+					ps71.OverlayValues[8] = d8
+					ps71.OverlayValues[9] = d9
+					ps71.OverlayValues[10] = d10
+					ps71.OverlayValues[26] = d26
+					ps71.OverlayValues[27] = d27
+					ps71.OverlayValues[29] = d29
+					ps71.OverlayValues[30] = d30
+					ps71.OverlayValues[31] = d31
+					ps71.OverlayValues[32] = d32
+					ps71.OverlayValues[33] = d33
+					ps71.OverlayValues[35] = d35
+					ps71.OverlayValues[37] = d37
+					ps71.OverlayValues[38] = d38
+					ps71.OverlayValues[39] = d39
+					ps71.OverlayValues[42] = d42
+					ps71.OverlayValues[43] = d43
+					ps71.OverlayValues[68] = d68
+					ps71.OverlayValues[69] = d69
+					ps71.OverlayValues[70] = d70
+					ps71.PhiValues = make([]JITValueDesc, 2)
+					d72 = d69
+					ps71.PhiValues[0] = d72
+					d73 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(1)}
+					ps71.PhiValues[1] = d73
+					if ps71.General && bbs[6].Rendered {
+						ctx.EmitJmp(lbl7)
+						return result
+					}
+					return bbs[6].RenderPS(ps71)
+					return result
+				}
+				bbs[4].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[4].VisitCount >= 0 {
+							ps.General = true
+							return bbs[4].RenderPS(ps)
+						}
+					}
+					bbs[4].VisitCount++
+					if ps.General {
+						if bbs[4].Rendered {
+							ctx.EmitJmp(lbl5)
+							return result
+						}
+						bbs[4].Rendered = true
+						bbs[4].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_4 = bbs[4].Address
+						ctx.MarkLabel(lbl5)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
+					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
+					}
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
+						d38 = ps.OverlayValues[38]
+					}
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
+					}
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != LocNone {
+						d43 = ps.OverlayValues[43]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
+					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d2)
+					r5 := ctx.AllocReg()
+					ctx.EnsureDesc(&d2)
+					ctx.EnsureDesc(&d4)
+					if d2.Loc == LocImm {
+						ctx.EmitMovRegImm64(r5, uint64(d2.Imm.Int())*16)
+					} else {
+						ctx.EmitMovRegReg(r5, d2.Reg)
+						ctx.EmitShlRegImm8(r5, 4)
+					}
+					if d4.Loc == LocImm {
+						ctx.EmitMovRegImm64(RegR11, uint64(d4.Imm.Int()))
+						ctx.EmitAddInt64(r5, RegR11)
+					} else {
+						ctx.EmitAddInt64(r5, d4.Reg)
+					}
+					r6 := ctx.AllocRegExcept(r5)
+					r7 := ctx.AllocRegExcept(r5, r6)
+					ctx.EmitMovRegMem(r6, r5, 0)
+					ctx.EmitMovRegMem(r7, r5, 8)
+					ctx.FreeReg(r5)
+					d74 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r6, Reg2: r7}
+					ctx.BindReg(r6, &d74)
+					ctx.BindReg(r7, &d74)
+					stackArray75 := ctx.AllocStack(int32(32))
+					ctx.EnsureDesc(&d1)
+					ctx.EnsureDesc(&d1)
+					ctx.EmitStoreScmerToStack(d1, int32(stackArray75)+int32(0))
+					ctx.EnsureDesc(&d74)
+					ctx.EnsureDesc(&d74)
+					ctx.EmitStoreScmerToStack(d74, int32(stackArray75)+int32(16))
+					ctx.FreeDesc(&d74)
+					r8 := ctx.AllocReg()
+					r9 := ctx.AllocRegExcept(r8)
+					r10 := ctx.AllocRegExcept(r8, r9)
+					ctx.EmitLeaRegMem(r8, RegRSP, int32(stackArray75))
+					ctx.EmitMovRegImm64(r9, uint64(2))
+					ctx.EmitMovRegImm64(r10, uint64(2))
+					d76 = JITValueDesc{Loc: LocRegTriple, Reg: r8, Reg2: r9, Reg3: r10, KnownSliceLen: int32(2), KnownSliceCap: int32(2), SliceSizeKnown: true}
+					ctx.BindReg(r8, &d76)
+					ctx.BindReg(r9, &d76)
+					ctx.BindReg(r10, &d76)
+					callbackArgs78 := make([]JITValueDesc, 2)
+					callbackArgs78[0] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(stackArray75) + 0}
+					callbackArgs78[1] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(stackArray75) + 16}
+					var d77 JITValueDesc
+					ctx.FreeDesc(&d76)
+					if d6.Loc == LocLambdaTemplate && d6.Lambda != nil {
+						outerRegs79 := ctx.PreserveOuterRegs()
+						d77 = JITEmitProcInlineWithOuter(ctx, &d6.Lambda.Proc, d6.Lambda.Outer, callbackArgs78, ctx.SliceBase, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+						ctx.RestoreOuterRegs(outerRegs79)
+					} else {
+						callbackCallArgs := make([]JITValueDesc, 0, 3)
+						callbackCallArgs = append(callbackCallArgs, d6)
+						callbackCallArgs = append(callbackCallArgs, callbackArgs78...)
+						d77 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+					}
+					ctx.EnsureDesc(&d2)
+					ctx.EnsureDesc(&d2)
+					var d80 JITValueDesc
+					if d2.Loc == LocImm {
+						d80 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2.Imm.Int() + 1)}
+					} else {
+						scratch := ctx.AllocRegExcept(d2.Reg)
+						ctx.EmitMovRegReg(scratch, d2.Reg)
+						ctx.EmitAddRegImm32(scratch, int32(1))
+						d80 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d80)
+					}
+					if d80.Loc == LocReg && d2.Loc == LocReg && d80.Reg == d2.Reg {
+						ctx.TransferReg(d2.Reg)
+						d2.Loc = LocNone
+					}
+					ctx.EnsureDesc(&d77)
+					if d77.Loc == LocReg {
+						ctx.ProtectReg(d77.Reg)
+					} else if d77.Loc == LocRegPair {
+						ctx.ProtectReg(d77.Reg)
+						ctx.ProtectReg(d77.Reg2)
+					}
+					ctx.EnsureDesc(&d80)
+					if d80.Loc == LocReg {
+						ctx.ProtectReg(d80.Reg)
+					} else if d80.Loc == LocRegPair {
+						ctx.ProtectReg(d80.Reg)
+						ctx.ProtectReg(d80.Reg2)
+					}
+					d81 = d77
+					if d81.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d81)
+					if d81.Loc == LocRegPair || d81.Loc == LocImm {
+						ctx.EmitStoreScmerToStack(d81, int32(bbs[6].PhiBase)+int32(0))
+					} else {
+						ctx.EmitStoreToStack(d81, int32(bbs[6].PhiBase)+int32(0))
+						ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Imm: NewInt(0)}, (int32(bbs[6].PhiBase)+int32(0))+8)
+					}
+					d82 = d80
+					if d82.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d82)
+					ctx.EmitStoreToStack(d82, int32(bbs[6].PhiBase)+int32(16))
+					if d77.Loc == LocReg {
+						ctx.UnprotectReg(d77.Reg)
+					} else if d77.Loc == LocRegPair {
+						ctx.UnprotectReg(d77.Reg)
+						ctx.UnprotectReg(d77.Reg2)
+					}
+					if d80.Loc == LocReg {
+						ctx.UnprotectReg(d80.Reg)
+					} else if d80.Loc == LocRegPair {
+						ctx.UnprotectReg(d80.Reg)
+						ctx.UnprotectReg(d80.Reg2)
+					}
+					ps83 := PhiState{General: ps.General}
+					ps83.OverlayValues = make([]JITValueDesc, 83)
+					ps83.OverlayValues[1] = d1
+					ps83.OverlayValues[2] = d2
+					ps83.OverlayValues[3] = d3
+					ps83.OverlayValues[4] = d4
+					ps83.OverlayValues[5] = d5
+					ps83.OverlayValues[6] = d6
+					ps83.OverlayValues[7] = d7
+					ps83.OverlayValues[8] = d8
+					ps83.OverlayValues[9] = d9
+					ps83.OverlayValues[10] = d10
+					ps83.OverlayValues[26] = d26
+					ps83.OverlayValues[27] = d27
+					ps83.OverlayValues[29] = d29
+					ps83.OverlayValues[30] = d30
+					ps83.OverlayValues[31] = d31
+					ps83.OverlayValues[32] = d32
+					ps83.OverlayValues[33] = d33
+					ps83.OverlayValues[35] = d35
+					ps83.OverlayValues[37] = d37
+					ps83.OverlayValues[38] = d38
+					ps83.OverlayValues[39] = d39
+					ps83.OverlayValues[42] = d42
+					ps83.OverlayValues[43] = d43
+					ps83.OverlayValues[68] = d68
+					ps83.OverlayValues[69] = d69
+					ps83.OverlayValues[70] = d70
+					ps83.OverlayValues[72] = d72
+					ps83.OverlayValues[73] = d73
+					ps83.OverlayValues[74] = d74
+					ps83.OverlayValues[76] = d76
+					ps83.OverlayValues[77] = d77
+					ps83.OverlayValues[80] = d80
+					ps83.OverlayValues[81] = d81
+					ps83.OverlayValues[82] = d82
+					ps83.PhiValues = make([]JITValueDesc, 2)
+					d84 = d77
+					ps83.PhiValues[0] = d84
+					d85 = d80
+					ps83.PhiValues[1] = d85
+					if ps83.General && bbs[6].Rendered {
+						ctx.EmitJmp(lbl7)
+						return result
+					}
+					return bbs[6].RenderPS(ps83)
+					return result
+				}
+				bbs[5].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[5].VisitCount >= 0 {
+							ps.General = true
+							return bbs[5].RenderPS(ps)
+						}
+					}
+					bbs[5].VisitCount++
+					if ps.General {
+						if bbs[5].Rendered {
+							ctx.EmitJmp(lbl6)
+							return result
+						}
+						bbs[5].Rendered = true
+						bbs[5].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_5 = bbs[5].Address
+						ctx.MarkLabel(lbl6)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
+					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
+					}
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
+						d38 = ps.OverlayValues[38]
+					}
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
+					}
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != LocNone {
+						d43 = ps.OverlayValues[43]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
+					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
+					}
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
+					}
+					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
+						d77 = ps.OverlayValues[77]
+					}
+					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
+						d80 = ps.OverlayValues[80]
+					}
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
+					}
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
+					}
+					if len(ps.OverlayValues) > 84 && ps.OverlayValues[84].Loc != LocNone {
+						d84 = ps.OverlayValues[84]
+					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d1)
+					if d1.Loc == LocRegPair {
+						ctx.EmitMovPairToResult(&d1, &result)
+						result.Type = d1.Type
+					} else {
+						switch d1.Type {
+						case tagBool:
+							ctx.EmitMakeBool(result, d1)
+							result.Type = tagBool
+						case tagInt:
+							ctx.EmitMakeInt(result, d1)
+							result.Type = tagInt
+						case tagFloat:
+							ctx.EmitMakeFloat(result, d1)
+							result.Type = tagFloat
+						case tagNil:
+							ctx.EmitMakeNil(result)
+							result.Type = tagNil
+						default:
+							ctx.EmitMovPairToResult(&d1, &result)
+							result.Type = d1.Type
+						}
+					}
+					ctx.EmitJmp(lbl0)
+					return result
+				}
+				bbs[6].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d86 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d86)
+							ctx.EmitStoreScmerToStack(d86, int32(bbs[6].PhiBase)+int32(0))
+						}
+						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
+							d87 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d87)
+							ctx.EmitStoreToStack(d87, int32(bbs[6].PhiBase)+int32(16))
+						}
+						if bbs[6].VisitCount >= 0 {
+							ps.General = true
+							return bbs[6].RenderPS(ps)
+						}
+					}
+					bbs[6].VisitCount++
+					if ps.General {
+						if bbs[6].Rendered {
+							ctx.EmitJmp(lbl7)
+							return result
+						}
+						bbs[6].Rendered = true
+						bbs[6].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_6 = bbs[6].Address
+						ctx.MarkLabel(lbl7)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(phiBase0) + int32(0)}
+					d2 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(16)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if !ps.General && len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 7 && ps.OverlayValues[7].Loc != LocNone {
+						d7 = ps.OverlayValues[7]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 26 && ps.OverlayValues[26].Loc != LocNone {
+						d26 = ps.OverlayValues[26]
+					}
+					if len(ps.OverlayValues) > 27 && ps.OverlayValues[27].Loc != LocNone {
+						d27 = ps.OverlayValues[27]
+					}
+					if len(ps.OverlayValues) > 29 && ps.OverlayValues[29].Loc != LocNone {
+						d29 = ps.OverlayValues[29]
+					}
+					if len(ps.OverlayValues) > 30 && ps.OverlayValues[30].Loc != LocNone {
+						d30 = ps.OverlayValues[30]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
+					if len(ps.OverlayValues) > 32 && ps.OverlayValues[32].Loc != LocNone {
+						d32 = ps.OverlayValues[32]
+					}
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					if len(ps.OverlayValues) > 35 && ps.OverlayValues[35].Loc != LocNone {
+						d35 = ps.OverlayValues[35]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
+						d38 = ps.OverlayValues[38]
+					}
+					if len(ps.OverlayValues) > 39 && ps.OverlayValues[39].Loc != LocNone {
+						d39 = ps.OverlayValues[39]
+					}
+					if len(ps.OverlayValues) > 42 && ps.OverlayValues[42].Loc != LocNone {
+						d42 = ps.OverlayValues[42]
+					}
+					if len(ps.OverlayValues) > 43 && ps.OverlayValues[43].Loc != LocNone {
+						d43 = ps.OverlayValues[43]
+					}
+					if len(ps.OverlayValues) > 68 && ps.OverlayValues[68].Loc != LocNone {
+						d68 = ps.OverlayValues[68]
+					}
+					if len(ps.OverlayValues) > 69 && ps.OverlayValues[69].Loc != LocNone {
+						d69 = ps.OverlayValues[69]
+					}
+					if len(ps.OverlayValues) > 70 && ps.OverlayValues[70].Loc != LocNone {
+						d70 = ps.OverlayValues[70]
+					}
+					if len(ps.OverlayValues) > 72 && ps.OverlayValues[72].Loc != LocNone {
+						d72 = ps.OverlayValues[72]
+					}
+					if len(ps.OverlayValues) > 73 && ps.OverlayValues[73].Loc != LocNone {
+						d73 = ps.OverlayValues[73]
+					}
+					if len(ps.OverlayValues) > 74 && ps.OverlayValues[74].Loc != LocNone {
+						d74 = ps.OverlayValues[74]
+					}
+					if len(ps.OverlayValues) > 76 && ps.OverlayValues[76].Loc != LocNone {
+						d76 = ps.OverlayValues[76]
+					}
+					if len(ps.OverlayValues) > 77 && ps.OverlayValues[77].Loc != LocNone {
+						d77 = ps.OverlayValues[77]
+					}
+					if len(ps.OverlayValues) > 80 && ps.OverlayValues[80].Loc != LocNone {
+						d80 = ps.OverlayValues[80]
+					}
+					if len(ps.OverlayValues) > 81 && ps.OverlayValues[81].Loc != LocNone {
+						d81 = ps.OverlayValues[81]
+					}
+					if len(ps.OverlayValues) > 82 && ps.OverlayValues[82].Loc != LocNone {
+						d82 = ps.OverlayValues[82]
+					}
+					if len(ps.OverlayValues) > 84 && ps.OverlayValues[84].Loc != LocNone {
+						d84 = ps.OverlayValues[84]
+					}
+					if len(ps.OverlayValues) > 85 && ps.OverlayValues[85].Loc != LocNone {
+						d85 = ps.OverlayValues[85]
+					}
+					if len(ps.OverlayValues) > 86 && ps.OverlayValues[86].Loc != LocNone {
+						d86 = ps.OverlayValues[86]
+					}
+					if len(ps.OverlayValues) > 87 && ps.OverlayValues[87].Loc != LocNone {
+						d87 = ps.OverlayValues[87]
+					}
+					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+						d1 = ps.PhiValues[0]
+					}
+					if !ps.General && len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
+						d2 = ps.PhiValues[1]
+					}
+					ctx.ReclaimUntrackedRegs()
+					var d88 JITValueDesc
+					if d4.SliceSizeKnown {
+						d88 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.KnownSliceLen))}
+					} else if d4.Loc == LocImm {
+						d88 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d4.StackOff))}
+					} else {
+						ctx.EnsureDesc(&d4)
+						if d4.Loc == LocRegPair || d4.Loc == LocRegTriple {
+							d88 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg2, ID: 0}
+						} else if d4.Loc == LocReg {
+							d88 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d4.Reg, ID: 0}
+						} else {
+							panic("len on unsupported descriptor location")
+						}
+					}
+					ctx.EnsureDesc(&d2)
+					ctx.EnsureDesc(&d88)
+					ctx.EnsureDesc(&d2)
+					ctx.EnsureDesc(&d88)
+					ctx.EnsureDesc(&d2)
+					ctx.EnsureDesc(&d88)
+					var d89 JITValueDesc
+					if d2.Loc == LocImm && d88.Loc == LocImm {
+						d89 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d2.Imm.Int() < d88.Imm.Int())}
+					} else if d88.Loc == LocImm {
+						r11 := ctx.AllocReg()
+						if d88.Imm.Int() >= -2147483648 && d88.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d2.Reg, int32(d88.Imm.Int()))
+						} else {
+							ctx.EmitMovRegImm64(RegR11, uint64(d88.Imm.Int()))
+							ctx.EmitCmpInt64(d2.Reg, RegR11)
+						}
+						ctx.EmitSetcc(r11, CcL)
+						d89 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r11}
+						ctx.BindReg(r11, &d89)
+					} else if d2.Loc == LocImm {
+						r12 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d2.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d88.Reg)
+						ctx.EmitSetcc(r12, CcL)
+						d89 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r12}
+						ctx.BindReg(r12, &d89)
+					} else {
+						r13 := ctx.AllocReg()
+						ctx.EmitCmpInt64(d2.Reg, d88.Reg)
+						ctx.EmitSetcc(r13, CcL)
+						d89 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r13}
+						ctx.BindReg(r13, &d89)
+					}
+					ctx.FreeDesc(&d2)
+					ctx.FreeDesc(&d88)
+					d90 = d89
+					ctx.EnsureDesc(&d90)
+					if d90.Loc != LocImm && d90.Loc != LocReg {
+						panic("jit: If condition is neither LocImm nor LocReg")
+					}
+					if d90.Loc == LocImm {
+						if d90.Imm.Bool() {
+							ps91 := PhiState{General: ps.General}
+							ps91.OverlayValues = make([]JITValueDesc, 91)
+							ps91.OverlayValues[1] = d1
+							ps91.OverlayValues[2] = d2
+							ps91.OverlayValues[3] = d3
+							ps91.OverlayValues[4] = d4
+							ps91.OverlayValues[5] = d5
+							ps91.OverlayValues[6] = d6
+							ps91.OverlayValues[7] = d7
+							ps91.OverlayValues[8] = d8
+							ps91.OverlayValues[9] = d9
+							ps91.OverlayValues[10] = d10
+							ps91.OverlayValues[26] = d26
+							ps91.OverlayValues[27] = d27
+							ps91.OverlayValues[29] = d29
+							ps91.OverlayValues[30] = d30
+							ps91.OverlayValues[31] = d31
+							ps91.OverlayValues[32] = d32
+							ps91.OverlayValues[33] = d33
+							ps91.OverlayValues[35] = d35
+							ps91.OverlayValues[37] = d37
+							ps91.OverlayValues[38] = d38
+							ps91.OverlayValues[39] = d39
+							ps91.OverlayValues[42] = d42
+							ps91.OverlayValues[43] = d43
+							ps91.OverlayValues[68] = d68
+							ps91.OverlayValues[69] = d69
+							ps91.OverlayValues[70] = d70
+							ps91.OverlayValues[72] = d72
+							ps91.OverlayValues[73] = d73
+							ps91.OverlayValues[74] = d74
+							ps91.OverlayValues[76] = d76
+							ps91.OverlayValues[77] = d77
+							ps91.OverlayValues[80] = d80
+							ps91.OverlayValues[81] = d81
+							ps91.OverlayValues[82] = d82
+							ps91.OverlayValues[84] = d84
+							ps91.OverlayValues[85] = d85
+							ps91.OverlayValues[86] = d86
+							ps91.OverlayValues[87] = d87
+							ps91.OverlayValues[88] = d88
+							ps91.OverlayValues[89] = d89
+							ps91.OverlayValues[90] = d90
+							return bbs[4].RenderPS(ps91)
+						}
+						ps92 := PhiState{General: ps.General}
+						ps92.OverlayValues = make([]JITValueDesc, 91)
+						ps92.OverlayValues[1] = d1
+						ps92.OverlayValues[2] = d2
+						ps92.OverlayValues[3] = d3
+						ps92.OverlayValues[4] = d4
+						ps92.OverlayValues[5] = d5
+						ps92.OverlayValues[6] = d6
+						ps92.OverlayValues[7] = d7
+						ps92.OverlayValues[8] = d8
+						ps92.OverlayValues[9] = d9
+						ps92.OverlayValues[10] = d10
+						ps92.OverlayValues[26] = d26
+						ps92.OverlayValues[27] = d27
+						ps92.OverlayValues[29] = d29
+						ps92.OverlayValues[30] = d30
+						ps92.OverlayValues[31] = d31
+						ps92.OverlayValues[32] = d32
+						ps92.OverlayValues[33] = d33
+						ps92.OverlayValues[35] = d35
+						ps92.OverlayValues[37] = d37
+						ps92.OverlayValues[38] = d38
+						ps92.OverlayValues[39] = d39
+						ps92.OverlayValues[42] = d42
+						ps92.OverlayValues[43] = d43
+						ps92.OverlayValues[68] = d68
+						ps92.OverlayValues[69] = d69
+						ps92.OverlayValues[70] = d70
+						ps92.OverlayValues[72] = d72
+						ps92.OverlayValues[73] = d73
+						ps92.OverlayValues[74] = d74
+						ps92.OverlayValues[76] = d76
+						ps92.OverlayValues[77] = d77
+						ps92.OverlayValues[80] = d80
+						ps92.OverlayValues[81] = d81
+						ps92.OverlayValues[82] = d82
+						ps92.OverlayValues[84] = d84
+						ps92.OverlayValues[85] = d85
+						ps92.OverlayValues[86] = d86
+						ps92.OverlayValues[87] = d87
+						ps92.OverlayValues[88] = d88
+						ps92.OverlayValues[89] = d89
+						ps92.OverlayValues[90] = d90
+						return bbs[5].RenderPS(ps92)
+					}
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d93 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d93)
+							ctx.EmitStoreScmerToStack(d93, int32(bbs[6].PhiBase)+int32(0))
+						}
+						if len(ps.PhiValues) > 1 && ps.PhiValues[1].Loc != LocNone {
+							d94 := ps.PhiValues[1]
+							ctx.EnsureDesc(&d94)
+							ctx.EmitStoreToStack(d94, int32(bbs[6].PhiBase)+int32(16))
+						}
+						ps.General = true
+						return bbs[6].RenderPS(ps)
+					}
+					lbl12 := ctx.ReserveLabel()
+					lbl13 := ctx.ReserveLabel()
+					ctx.EmitCmpRegImm32(d90.Reg, 0)
+					ctx.EmitJcc(CcNE, lbl12)
+					ctx.EmitJmp(lbl13)
+					ctx.MarkLabel(lbl12)
+					ctx.EmitJmp(lbl5)
+					ctx.MarkLabel(lbl13)
+					ctx.EmitJmp(lbl6)
+					ps95 := PhiState{General: true}
+					ps95.OverlayValues = make([]JITValueDesc, 95)
+					ps95.OverlayValues[1] = d1
+					ps95.OverlayValues[2] = d2
+					ps95.OverlayValues[3] = d3
+					ps95.OverlayValues[4] = d4
+					ps95.OverlayValues[5] = d5
+					ps95.OverlayValues[6] = d6
+					ps95.OverlayValues[7] = d7
+					ps95.OverlayValues[8] = d8
+					ps95.OverlayValues[9] = d9
+					ps95.OverlayValues[10] = d10
+					ps95.OverlayValues[26] = d26
+					ps95.OverlayValues[27] = d27
+					ps95.OverlayValues[29] = d29
+					ps95.OverlayValues[30] = d30
+					ps95.OverlayValues[31] = d31
+					ps95.OverlayValues[32] = d32
+					ps95.OverlayValues[33] = d33
+					ps95.OverlayValues[35] = d35
+					ps95.OverlayValues[37] = d37
+					ps95.OverlayValues[38] = d38
+					ps95.OverlayValues[39] = d39
+					ps95.OverlayValues[42] = d42
+					ps95.OverlayValues[43] = d43
+					ps95.OverlayValues[68] = d68
+					ps95.OverlayValues[69] = d69
+					ps95.OverlayValues[70] = d70
+					ps95.OverlayValues[72] = d72
+					ps95.OverlayValues[73] = d73
+					ps95.OverlayValues[74] = d74
+					ps95.OverlayValues[76] = d76
+					ps95.OverlayValues[77] = d77
+					ps95.OverlayValues[80] = d80
+					ps95.OverlayValues[81] = d81
+					ps95.OverlayValues[82] = d82
+					ps95.OverlayValues[84] = d84
+					ps95.OverlayValues[85] = d85
+					ps95.OverlayValues[86] = d86
+					ps95.OverlayValues[87] = d87
+					ps95.OverlayValues[88] = d88
+					ps95.OverlayValues[89] = d89
+					ps95.OverlayValues[90] = d90
+					ps95.OverlayValues[93] = d93
+					ps95.OverlayValues[94] = d94
+					ps96 := PhiState{General: true}
+					ps96.OverlayValues = make([]JITValueDesc, 95)
+					ps96.OverlayValues[1] = d1
+					ps96.OverlayValues[2] = d2
+					ps96.OverlayValues[3] = d3
+					ps96.OverlayValues[4] = d4
+					ps96.OverlayValues[5] = d5
+					ps96.OverlayValues[6] = d6
+					ps96.OverlayValues[7] = d7
+					ps96.OverlayValues[8] = d8
+					ps96.OverlayValues[9] = d9
+					ps96.OverlayValues[10] = d10
+					ps96.OverlayValues[26] = d26
+					ps96.OverlayValues[27] = d27
+					ps96.OverlayValues[29] = d29
+					ps96.OverlayValues[30] = d30
+					ps96.OverlayValues[31] = d31
+					ps96.OverlayValues[32] = d32
+					ps96.OverlayValues[33] = d33
+					ps96.OverlayValues[35] = d35
+					ps96.OverlayValues[37] = d37
+					ps96.OverlayValues[38] = d38
+					ps96.OverlayValues[39] = d39
+					ps96.OverlayValues[42] = d42
+					ps96.OverlayValues[43] = d43
+					ps96.OverlayValues[68] = d68
+					ps96.OverlayValues[69] = d69
+					ps96.OverlayValues[70] = d70
+					ps96.OverlayValues[72] = d72
+					ps96.OverlayValues[73] = d73
+					ps96.OverlayValues[74] = d74
+					ps96.OverlayValues[76] = d76
+					ps96.OverlayValues[77] = d77
+					ps96.OverlayValues[80] = d80
+					ps96.OverlayValues[81] = d81
+					ps96.OverlayValues[82] = d82
+					ps96.OverlayValues[84] = d84
+					ps96.OverlayValues[85] = d85
+					ps96.OverlayValues[86] = d86
+					ps96.OverlayValues[87] = d87
+					ps96.OverlayValues[88] = d88
+					ps96.OverlayValues[89] = d89
+					ps96.OverlayValues[90] = d90
+					ps96.OverlayValues[93] = d93
+					ps96.OverlayValues[94] = d94
+					snap97 := d1
+					snap98 := d2
+					snap99 := d3
+					snap100 := d4
+					snap101 := d5
+					snap102 := d6
+					snap103 := d7
+					snap104 := d8
+					snap105 := d9
+					snap106 := d10
+					snap107 := d26
+					snap108 := d27
+					snap109 := d29
+					snap110 := d30
+					snap111 := d31
+					snap112 := d32
+					snap113 := d33
+					snap114 := d35
+					snap115 := d37
+					snap116 := d38
+					snap117 := d39
+					snap118 := d42
+					snap119 := d43
+					snap120 := d68
+					snap121 := d69
+					snap122 := d70
+					snap123 := d72
+					snap124 := d73
+					snap125 := d74
+					snap126 := d76
+					snap127 := d77
+					snap128 := d80
+					snap129 := d81
+					snap130 := d82
+					snap131 := d84
+					snap132 := d85
+					snap133 := d86
+					snap134 := d87
+					snap135 := d88
+					snap136 := d89
+					snap137 := d90
+					snap138 := d93
+					snap139 := d94
+					alloc140 := ctx.SnapshotAllocState()
+					if !bbs[5].Rendered {
+						bbs[5].RenderPS(ps96)
+					}
+					ctx.RestoreAllocState(alloc140)
+					d1 = snap97
+					d2 = snap98
+					d3 = snap99
+					d4 = snap100
+					d5 = snap101
+					d6 = snap102
+					d7 = snap103
+					d8 = snap104
+					d9 = snap105
+					d10 = snap106
+					d26 = snap107
+					d27 = snap108
+					d29 = snap109
+					d30 = snap110
+					d31 = snap111
+					d32 = snap112
+					d33 = snap113
+					d35 = snap114
+					d37 = snap115
+					d38 = snap116
+					d39 = snap117
+					d42 = snap118
+					d43 = snap119
+					d68 = snap120
+					d69 = snap121
+					d70 = snap122
+					d72 = snap123
+					d73 = snap124
+					d74 = snap125
+					d76 = snap126
+					d77 = snap127
+					d80 = snap128
+					d81 = snap129
+					d82 = snap130
+					d84 = snap131
+					d85 = snap132
+					d86 = snap133
+					d87 = snap134
+					d88 = snap135
+					d89 = snap136
+					d90 = snap137
+					d93 = snap138
+					d94 = snap139
+					if !bbs[4].Rendered {
+						return bbs[4].RenderPS(ps95)
+					}
+					return result
+					ctx.FreeDesc(&d89)
+					return result
+				}
+				argPinned141 := make([]Reg, 0, len(args)*3)
+				seenArgRegs := make(map[Reg]bool)
+				for _, ai := range args {
+					if ai.Loc == LocReg {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned141 = append(argPinned141, ai.Reg)
+						}
+					} else if ai.Loc == LocRegPair {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned141 = append(argPinned141, ai.Reg)
+						}
+						if !seenArgRegs[ai.Reg2] {
+							ctx.ProtectReg(ai.Reg2)
+							seenArgRegs[ai.Reg2] = true
+							argPinned141 = append(argPinned141, ai.Reg2)
+						}
+					} else if ai.Loc == LocRegTriple {
+						for _, r := range [...]Reg{ai.Reg, ai.Reg2, ai.Reg3} {
+							if !seenArgRegs[r] {
+								ctx.ProtectReg(r)
+								seenArgRegs[r] = true
+								argPinned141 = append(argPinned141, r)
+							}
+						}
+					}
+				}
+				defer func() {
+					for _, r := range argPinned141 {
+						ctx.UnprotectReg(r)
+					}
+				}()
+				ps142 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps142)
+				ctx.MarkLabel(lbl0)
+				ctx.ResolveFixups()
+				ctx.FreeStack(int32(32))
+				return result
+			},
 		},
 	})
 
@@ -4258,7 +6871,670 @@ func init_list() {
 			Const:     true,
 			Forbidden: true,
 
-			JITEmit: nil,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				var d2 JITValueDesc
+				_ = d2
+				var d3 JITValueDesc
+				_ = d3
+				var d4 JITValueDesc
+				_ = d4
+				var d5 JITValueDesc
+				_ = d5
+				var d6 JITValueDesc
+				_ = d6
+				var d8 JITValueDesc
+				_ = d8
+				var d9 JITValueDesc
+				_ = d9
+				var d10 JITValueDesc
+				_ = d10
+				var d11 JITValueDesc
+				_ = d11
+				var d12 JITValueDesc
+				_ = d12
+				var d15 JITValueDesc
+				_ = d15
+				var d31 JITValueDesc
+				_ = d31
+				var d33 JITValueDesc
+				_ = d33
+				var d34 JITValueDesc
+				_ = d34
+				var d37 JITValueDesc
+				_ = d37
+				var d38 JITValueDesc
+				_ = d38
+				var d40 JITValueDesc
+				_ = d40
+				var d41 JITValueDesc
+				_ = d41
+				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
+				phiBase0 := ctx.AllocStack(int32(16))
+				d1 := JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+				var bbs [4]BBDescriptor
+				bbs[1].PhiBase = int32(phiBase0) + int32(0)
+				bbs[1].PhiCount = uint16(1)
+				if result.Loc == LocAny {
+					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+					ctx.BindReg(result.Reg, &result)
+					ctx.BindReg(result.Reg2, &result)
+				}
+				lbl0 := ctx.ReserveLabel()
+				bbpos_0_0 := int32(-1)
+				_ = bbpos_0_0
+				lbl1 := ctx.ReserveLabel()
+				bbpos_0_1 := int32(-1)
+				_ = bbpos_0_1
+				lbl2 := ctx.ReserveLabel()
+				bbpos_0_2 := int32(-1)
+				_ = bbpos_0_2
+				lbl3 := ctx.ReserveLabel()
+				bbpos_0_3 := int32(-1)
+				_ = bbpos_0_3
+				lbl4 := ctx.ReserveLabel()
+				bbs[0].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[0].VisitCount >= 0 {
+							ps.General = true
+							return bbs[0].RenderPS(ps)
+						}
+					}
+					bbs[0].VisitCount++
+					if ps.General {
+						if bbs[0].Rendered {
+							ctx.EmitJmp(lbl1)
+							return result
+						}
+						bbs[0].Rendered = true
+						bbs[0].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_0 = bbs[0].Address
+						ctx.MarkLabel(lbl1)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d2 = args[0]
+					d2.ID = 0
+					d3 = jitKnownSliceHeader(ctx, &d2)
+					ctx.FreeDesc(&d2)
+					d4 = args[1]
+					d4.ID = 0
+					var d5 JITValueDesc
+					if d4.Loc == LocLambdaTemplate {
+						d5 = d4
+					} else {
+						d5 = ctx.RequestOptimizedCallback(1)
+					}
+					ctx.FreeDesc(&d4)
+					var d6 JITValueDesc
+					if d3.SliceSizeKnown {
+						d6 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.KnownSliceLen))}
+					} else if d3.Loc == LocImm {
+						d6 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(d3.StackOff))}
+					} else {
+						ctx.EnsureDesc(&d3)
+						if d3.Loc == LocRegPair || d3.Loc == LocRegTriple {
+							d6 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg2, ID: 0}
+						} else if d3.Loc == LocReg {
+							d6 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d3.Reg, ID: 0}
+						} else {
+							panic("len on unsupported descriptor location")
+						}
+					}
+					ctx.EmitStoreToStack(JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}, int32(bbs[1].PhiBase)+int32(0))
+					ps7 := PhiState{General: ps.General}
+					ps7.OverlayValues = make([]JITValueDesc, 7)
+					ps7.OverlayValues[1] = d1
+					ps7.OverlayValues[2] = d2
+					ps7.OverlayValues[3] = d3
+					ps7.OverlayValues[4] = d4
+					ps7.OverlayValues[5] = d5
+					ps7.OverlayValues[6] = d6
+					ps7.PhiValues = make([]JITValueDesc, 1)
+					d8 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(-1)}
+					ps7.PhiValues[0] = d8
+					if ps7.General && bbs[1].Rendered {
+						ctx.EmitJmp(lbl2)
+						return result
+					}
+					return bbs[1].RenderPS(ps7)
+					return result
+				}
+				bbs[1].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d9 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d9)
+							ctx.EmitStoreToStack(d9, int32(bbs[1].PhiBase)+int32(0))
+						}
+						if bbs[1].VisitCount >= 0 {
+							ps.General = true
+							return bbs[1].RenderPS(ps)
+						}
+					}
+					bbs[1].VisitCount++
+					if ps.General {
+						if bbs[1].Rendered {
+							ctx.EmitJmp(lbl2)
+							return result
+						}
+						bbs[1].Rendered = true
+						bbs[1].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_1 = bbs[1].Address
+						ctx.MarkLabel(lbl2)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if !ps.General && len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+						d1 = ps.PhiValues[0]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d1)
+					ctx.EnsureDesc(&d1)
+					var d10 JITValueDesc
+					if d1.Loc == LocImm {
+						d10 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1.Imm.Int() + 1)}
+					} else {
+						scratch := ctx.AllocRegExcept(d1.Reg)
+						ctx.EmitMovRegReg(scratch, d1.Reg)
+						ctx.EmitAddRegImm32(scratch, int32(1))
+						d10 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
+						ctx.BindReg(scratch, &d10)
+					}
+					if d10.Loc == LocReg && d1.Loc == LocReg && d10.Reg == d1.Reg {
+						ctx.TransferReg(d1.Reg)
+						d1.Loc = LocNone
+					}
+					ctx.FreeDesc(&d1)
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d6)
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d6)
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d6)
+					var d11 JITValueDesc
+					if d10.Loc == LocImm && d6.Loc == LocImm {
+						d11 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d10.Imm.Int() < d6.Imm.Int())}
+					} else if d6.Loc == LocImm {
+						r0 := ctx.AllocRegExcept(d10.Reg)
+						if d6.Imm.Int() >= -2147483648 && d6.Imm.Int() <= 2147483647 {
+							ctx.EmitCmpRegImm32(d10.Reg, int32(d6.Imm.Int()))
+						} else {
+							ctx.EmitMovRegImm64(RegR11, uint64(d6.Imm.Int()))
+							ctx.EmitCmpInt64(d10.Reg, RegR11)
+						}
+						ctx.EmitSetcc(r0, CcL)
+						d11 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r0}
+						ctx.BindReg(r0, &d11)
+					} else if d10.Loc == LocImm {
+						r1 := ctx.AllocReg()
+						ctx.EmitMovRegImm64(RegR11, uint64(d10.Imm.Int()))
+						ctx.EmitCmpInt64(RegR11, d6.Reg)
+						ctx.EmitSetcc(r1, CcL)
+						d11 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r1}
+						ctx.BindReg(r1, &d11)
+					} else {
+						r2 := ctx.AllocRegExcept(d10.Reg)
+						ctx.EmitCmpInt64(d10.Reg, d6.Reg)
+						ctx.EmitSetcc(r2, CcL)
+						d11 = JITValueDesc{Loc: LocReg, Type: tagBool, Reg: r2}
+						ctx.BindReg(r2, &d11)
+					}
+					ctx.FreeDesc(&d6)
+					d12 = d11
+					ctx.EnsureDesc(&d12)
+					if d12.Loc != LocImm && d12.Loc != LocReg {
+						panic("jit: If condition is neither LocImm nor LocReg")
+					}
+					if d12.Loc == LocImm {
+						if d12.Imm.Bool() {
+							ps13 := PhiState{General: ps.General}
+							ps13.OverlayValues = make([]JITValueDesc, 13)
+							ps13.OverlayValues[1] = d1
+							ps13.OverlayValues[2] = d2
+							ps13.OverlayValues[3] = d3
+							ps13.OverlayValues[4] = d4
+							ps13.OverlayValues[5] = d5
+							ps13.OverlayValues[6] = d6
+							ps13.OverlayValues[8] = d8
+							ps13.OverlayValues[9] = d9
+							ps13.OverlayValues[10] = d10
+							ps13.OverlayValues[11] = d11
+							ps13.OverlayValues[12] = d12
+							return bbs[2].RenderPS(ps13)
+						}
+						ps14 := PhiState{General: ps.General}
+						ps14.OverlayValues = make([]JITValueDesc, 13)
+						ps14.OverlayValues[1] = d1
+						ps14.OverlayValues[2] = d2
+						ps14.OverlayValues[3] = d3
+						ps14.OverlayValues[4] = d4
+						ps14.OverlayValues[5] = d5
+						ps14.OverlayValues[6] = d6
+						ps14.OverlayValues[8] = d8
+						ps14.OverlayValues[9] = d9
+						ps14.OverlayValues[10] = d10
+						ps14.OverlayValues[11] = d11
+						ps14.OverlayValues[12] = d12
+						return bbs[3].RenderPS(ps14)
+					}
+					if !ps.General {
+						if len(ps.PhiValues) > 0 && ps.PhiValues[0].Loc != LocNone {
+							d15 := ps.PhiValues[0]
+							ctx.EnsureDesc(&d15)
+							ctx.EmitStoreToStack(d15, int32(bbs[1].PhiBase)+int32(0))
+						}
+						ps.General = true
+						return bbs[1].RenderPS(ps)
+					}
+					lbl5 := ctx.ReserveLabel()
+					lbl6 := ctx.ReserveLabel()
+					ctx.EmitCmpRegImm32(d12.Reg, 0)
+					ctx.EmitJcc(CcNE, lbl5)
+					ctx.EmitJmp(lbl6)
+					ctx.MarkLabel(lbl5)
+					ctx.EmitJmp(lbl3)
+					ctx.MarkLabel(lbl6)
+					ctx.EmitJmp(lbl4)
+					ps16 := PhiState{General: true}
+					ps16.OverlayValues = make([]JITValueDesc, 16)
+					ps16.OverlayValues[1] = d1
+					ps16.OverlayValues[2] = d2
+					ps16.OverlayValues[3] = d3
+					ps16.OverlayValues[4] = d4
+					ps16.OverlayValues[5] = d5
+					ps16.OverlayValues[6] = d6
+					ps16.OverlayValues[8] = d8
+					ps16.OverlayValues[9] = d9
+					ps16.OverlayValues[10] = d10
+					ps16.OverlayValues[11] = d11
+					ps16.OverlayValues[12] = d12
+					ps16.OverlayValues[15] = d15
+					ps17 := PhiState{General: true}
+					ps17.OverlayValues = make([]JITValueDesc, 16)
+					ps17.OverlayValues[1] = d1
+					ps17.OverlayValues[2] = d2
+					ps17.OverlayValues[3] = d3
+					ps17.OverlayValues[4] = d4
+					ps17.OverlayValues[5] = d5
+					ps17.OverlayValues[6] = d6
+					ps17.OverlayValues[8] = d8
+					ps17.OverlayValues[9] = d9
+					ps17.OverlayValues[10] = d10
+					ps17.OverlayValues[11] = d11
+					ps17.OverlayValues[12] = d12
+					ps17.OverlayValues[15] = d15
+					snap18 := d1
+					snap19 := d2
+					snap20 := d3
+					snap21 := d4
+					snap22 := d5
+					snap23 := d6
+					snap24 := d8
+					snap25 := d9
+					snap26 := d10
+					snap27 := d11
+					snap28 := d12
+					snap29 := d15
+					alloc30 := ctx.SnapshotAllocState()
+					if !bbs[3].Rendered {
+						bbs[3].RenderPS(ps17)
+					}
+					ctx.RestoreAllocState(alloc30)
+					d1 = snap18
+					d2 = snap19
+					d3 = snap20
+					d4 = snap21
+					d5 = snap22
+					d6 = snap23
+					d8 = snap24
+					d9 = snap25
+					d10 = snap26
+					d11 = snap27
+					d12 = snap28
+					d15 = snap29
+					if !bbs[2].Rendered {
+						return bbs[2].RenderPS(ps16)
+					}
+					return result
+					ctx.FreeDesc(&d11)
+					return result
+				}
+				bbs[2].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[2].VisitCount >= 0 {
+							ps.General = true
+							return bbs[2].RenderPS(ps)
+						}
+					}
+					bbs[2].VisitCount++
+					if ps.General {
+						if bbs[2].Rendered {
+							ctx.EmitJmp(lbl3)
+							return result
+						}
+						bbs[2].Rendered = true
+						bbs[2].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_2 = bbs[2].Address
+						ctx.MarkLabel(lbl3)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
+					ctx.ReclaimUntrackedRegs()
+					ctx.EnsureDesc(&d10)
+					r3 := ctx.AllocReg()
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d3)
+					if d10.Loc == LocImm {
+						ctx.EmitMovRegImm64(r3, uint64(d10.Imm.Int())*16)
+					} else {
+						ctx.EmitMovRegReg(r3, d10.Reg)
+						ctx.EmitShlRegImm8(r3, 4)
+					}
+					if d3.Loc == LocImm {
+						ctx.EmitMovRegImm64(RegR11, uint64(d3.Imm.Int()))
+						ctx.EmitAddInt64(r3, RegR11)
+					} else {
+						ctx.EmitAddInt64(r3, d3.Reg)
+					}
+					r4 := ctx.AllocRegExcept(r3)
+					r5 := ctx.AllocRegExcept(r3, r4)
+					ctx.EmitMovRegMem(r4, r3, 0)
+					ctx.EmitMovRegMem(r5, r3, 8)
+					ctx.FreeReg(r3)
+					d31 = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r4, Reg2: r5}
+					ctx.BindReg(r4, &d31)
+					ctx.BindReg(r5, &d31)
+					stackArray32 := ctx.AllocStack(int32(16))
+					ctx.EnsureDesc(&d31)
+					ctx.EnsureDesc(&d31)
+					ctx.EmitStoreScmerToStack(d31, int32(stackArray32)+int32(0))
+					ctx.FreeDesc(&d31)
+					r6 := ctx.AllocReg()
+					r7 := ctx.AllocRegExcept(r6)
+					r8 := ctx.AllocRegExcept(r6, r7)
+					ctx.EmitLeaRegMem(r6, RegRSP, int32(stackArray32))
+					ctx.EmitMovRegImm64(r7, uint64(1))
+					ctx.EmitMovRegImm64(r8, uint64(1))
+					d33 = JITValueDesc{Loc: LocRegTriple, Reg: r6, Reg2: r7, Reg3: r8, KnownSliceLen: int32(1), KnownSliceCap: int32(1), SliceSizeKnown: true}
+					ctx.BindReg(r6, &d33)
+					ctx.BindReg(r7, &d33)
+					ctx.BindReg(r8, &d33)
+					callbackArgs35 := make([]JITValueDesc, 1)
+					callbackArgs35[0] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(stackArray32) + 0}
+					var d34 JITValueDesc
+					ctx.FreeDesc(&d33)
+					if d5.Loc == LocLambdaTemplate && d5.Lambda != nil {
+						outerRegs36 := ctx.PreserveOuterRegs()
+						d34 = JITEmitProcInlineWithOuter(ctx, &d5.Lambda.Proc, d5.Lambda.Outer, callbackArgs35, ctx.SliceBase, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+						ctx.RestoreOuterRegs(outerRegs36)
+					} else {
+						callbackCallArgs := make([]JITValueDesc, 0, 2)
+						callbackCallArgs = append(callbackCallArgs, d5)
+						callbackCallArgs = append(callbackCallArgs, callbackArgs35...)
+						d34 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
+					}
+					ctx.EnsureDesc(&d10)
+					ctx.EnsureDesc(&d34)
+					d37 = ctx.EmitSliceElementAddress(&d3, &d10, int32(16))
+					ctx.EmitStoreScmerAt(&d37, &d34)
+					ctx.FreeDesc(&d37)
+					ctx.FreeDesc(&d34)
+					ctx.EnsureDesc(&d10)
+					if d10.Loc == LocReg {
+						ctx.ProtectReg(d10.Reg)
+					} else if d10.Loc == LocRegPair {
+						ctx.ProtectReg(d10.Reg)
+						ctx.ProtectReg(d10.Reg2)
+					}
+					d38 = d10
+					if d38.Loc == LocNone {
+						panic("jit: phi source has no location")
+					}
+					ctx.EnsureDesc(&d38)
+					ctx.EmitStoreToStack(d38, int32(bbs[1].PhiBase)+int32(0))
+					if d10.Loc == LocReg {
+						ctx.UnprotectReg(d10.Reg)
+					} else if d10.Loc == LocRegPair {
+						ctx.UnprotectReg(d10.Reg)
+						ctx.UnprotectReg(d10.Reg2)
+					}
+					ps39 := PhiState{General: ps.General}
+					ps39.OverlayValues = make([]JITValueDesc, 39)
+					ps39.OverlayValues[1] = d1
+					ps39.OverlayValues[2] = d2
+					ps39.OverlayValues[3] = d3
+					ps39.OverlayValues[4] = d4
+					ps39.OverlayValues[5] = d5
+					ps39.OverlayValues[6] = d6
+					ps39.OverlayValues[8] = d8
+					ps39.OverlayValues[9] = d9
+					ps39.OverlayValues[10] = d10
+					ps39.OverlayValues[11] = d11
+					ps39.OverlayValues[12] = d12
+					ps39.OverlayValues[15] = d15
+					ps39.OverlayValues[31] = d31
+					ps39.OverlayValues[33] = d33
+					ps39.OverlayValues[34] = d34
+					ps39.OverlayValues[37] = d37
+					ps39.OverlayValues[38] = d38
+					ps39.PhiValues = make([]JITValueDesc, 1)
+					d40 = d10
+					ps39.PhiValues[0] = d40
+					if ps39.General && bbs[1].Rendered {
+						ctx.EmitJmp(lbl2)
+						return result
+					}
+					return bbs[1].RenderPS(ps39)
+					return result
+				}
+				bbs[3].RenderPS = func(ps PhiState) JITValueDesc {
+					if !ps.General {
+						if bbs[3].VisitCount >= 0 {
+							ps.General = true
+							return bbs[3].RenderPS(ps)
+						}
+					}
+					bbs[3].VisitCount++
+					if ps.General {
+						if bbs[3].Rendered {
+							ctx.EmitJmp(lbl4)
+							return result
+						}
+						bbs[3].Rendered = true
+						bbs[3].Address = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
+						bbpos_0_3 = bbs[3].Address
+						ctx.MarkLabel(lbl4)
+						ctx.ResolveFixups()
+					}
+					d1 = JITValueDesc{Loc: LocStack, Type: tagInt, StackOff: int32(phiBase0) + int32(0)}
+					if !ps.General && len(ps.OverlayValues) > 1 && ps.OverlayValues[1].Loc != LocNone {
+						d1 = ps.OverlayValues[1]
+					}
+					if len(ps.OverlayValues) > 2 && ps.OverlayValues[2].Loc != LocNone {
+						d2 = ps.OverlayValues[2]
+					}
+					if len(ps.OverlayValues) > 3 && ps.OverlayValues[3].Loc != LocNone {
+						d3 = ps.OverlayValues[3]
+					}
+					if len(ps.OverlayValues) > 4 && ps.OverlayValues[4].Loc != LocNone {
+						d4 = ps.OverlayValues[4]
+					}
+					if len(ps.OverlayValues) > 5 && ps.OverlayValues[5].Loc != LocNone {
+						d5 = ps.OverlayValues[5]
+					}
+					if len(ps.OverlayValues) > 6 && ps.OverlayValues[6].Loc != LocNone {
+						d6 = ps.OverlayValues[6]
+					}
+					if len(ps.OverlayValues) > 8 && ps.OverlayValues[8].Loc != LocNone {
+						d8 = ps.OverlayValues[8]
+					}
+					if len(ps.OverlayValues) > 9 && ps.OverlayValues[9].Loc != LocNone {
+						d9 = ps.OverlayValues[9]
+					}
+					if len(ps.OverlayValues) > 10 && ps.OverlayValues[10].Loc != LocNone {
+						d10 = ps.OverlayValues[10]
+					}
+					if len(ps.OverlayValues) > 11 && ps.OverlayValues[11].Loc != LocNone {
+						d11 = ps.OverlayValues[11]
+					}
+					if len(ps.OverlayValues) > 12 && ps.OverlayValues[12].Loc != LocNone {
+						d12 = ps.OverlayValues[12]
+					}
+					if len(ps.OverlayValues) > 15 && ps.OverlayValues[15].Loc != LocNone {
+						d15 = ps.OverlayValues[15]
+					}
+					if len(ps.OverlayValues) > 31 && ps.OverlayValues[31].Loc != LocNone {
+						d31 = ps.OverlayValues[31]
+					}
+					if len(ps.OverlayValues) > 33 && ps.OverlayValues[33].Loc != LocNone {
+						d33 = ps.OverlayValues[33]
+					}
+					if len(ps.OverlayValues) > 34 && ps.OverlayValues[34].Loc != LocNone {
+						d34 = ps.OverlayValues[34]
+					}
+					if len(ps.OverlayValues) > 37 && ps.OverlayValues[37].Loc != LocNone {
+						d37 = ps.OverlayValues[37]
+					}
+					if len(ps.OverlayValues) > 38 && ps.OverlayValues[38].Loc != LocNone {
+						d38 = ps.OverlayValues[38]
+					}
+					if len(ps.OverlayValues) > 40 && ps.OverlayValues[40].Loc != LocNone {
+						d40 = ps.OverlayValues[40]
+					}
+					ctx.ReclaimUntrackedRegs()
+					d41 = ctx.EmitNewSliceFromGoSlice(&d3)
+					ctx.EnsureDesc(&d41)
+					if d41.Loc == LocRegPair {
+						ctx.EmitMovPairToResult(&d41, &result)
+						result.Type = d41.Type
+					} else {
+						switch d41.Type {
+						case tagBool:
+							ctx.EmitMakeBool(result, d41)
+							result.Type = tagBool
+						case tagInt:
+							ctx.EmitMakeInt(result, d41)
+							result.Type = tagInt
+						case tagFloat:
+							ctx.EmitMakeFloat(result, d41)
+							result.Type = tagFloat
+						case tagNil:
+							ctx.EmitMakeNil(result)
+							result.Type = tagNil
+						default:
+							ctx.EmitMovPairToResult(&d41, &result)
+							result.Type = d41.Type
+						}
+					}
+					ctx.EmitJmp(lbl0)
+					return result
+				}
+				argPinned42 := make([]Reg, 0, len(args)*3)
+				seenArgRegs := make(map[Reg]bool)
+				for _, ai := range args {
+					if ai.Loc == LocReg {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned42 = append(argPinned42, ai.Reg)
+						}
+					} else if ai.Loc == LocRegPair {
+						if !seenArgRegs[ai.Reg] {
+							ctx.ProtectReg(ai.Reg)
+							seenArgRegs[ai.Reg] = true
+							argPinned42 = append(argPinned42, ai.Reg)
+						}
+						if !seenArgRegs[ai.Reg2] {
+							ctx.ProtectReg(ai.Reg2)
+							seenArgRegs[ai.Reg2] = true
+							argPinned42 = append(argPinned42, ai.Reg2)
+						}
+					} else if ai.Loc == LocRegTriple {
+						for _, r := range [...]Reg{ai.Reg, ai.Reg2, ai.Reg3} {
+							if !seenArgRegs[r] {
+								ctx.ProtectReg(r)
+								seenArgRegs[r] = true
+								argPinned42 = append(argPinned42, r)
+							}
+						}
+					}
+				}
+				defer func() {
+					for _, r := range argPinned42 {
+						ctx.UnprotectReg(r)
+					}
+				}()
+				ps43 := PhiState{General: false}
+				_ = bbs[0].RenderPS(ps43)
+				ctx.MarkLabel(lbl0)
+				ctx.ResolveFixups()
+				ctx.FreeStack(int32(16))
+				return result
+			},
 		},
 	})
 

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -2870,7 +2870,28 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 		} else {
 			// IndexAddr on a local slice (e.g. from Slice() or FieldAddr)
 			src := g.vals[v.X.Name()]
-			if strings.HasPrefix(src.marker, "_fieldaddr:array:") {
+			if strings.HasPrefix(src.marker, "_stackarray:") {
+				parts := strings.Split(src.marker, ":")
+				if len(parts) != 3 {
+					panic(fmt.Sprintf("malformed stack array marker: %q", src.marker))
+				}
+				elemSize, err := strconv.ParseInt(parts[1], 10, 64)
+				if err != nil {
+					panic(fmt.Sprintf("malformed stack array element size: %q", src.marker))
+				}
+				idx, ok := v.Index.(*ssa.Const)
+				if !ok {
+					panic(fmt.Sprintf("dynamic IndexAddr on local stack array: %s", v))
+				}
+				idxValue, ok := constInt64Value(idx.Value)
+				if !ok {
+					panic(fmt.Sprintf("non-integer IndexAddr on local stack array: %s", v))
+				}
+				g.vals[name] = genVal{
+					marker:     fmt.Sprintf("_stackaddr:%d", elemSize),
+					offsetExpr: fmt.Sprintf("int32(%s)+int32(%d)", src.goVar, idxValue*elemSize),
+				}
+			} else if strings.HasPrefix(src.marker, "_fieldaddr:array:") {
 				// Direct indexing on receiver array field address, e.g. &s.thresholds[i].
 				idxVal := g.resolveValue(v.Index)
 				elemType := v.Type().Underlying().(*types.Pointer).Elem().Underlying()
@@ -4016,7 +4037,9 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.keepAliveForMarker(v.Call.Args[0])
 			g.vals[name] = genVal{goVar: src.goVar, marker: "_newfloat"}
 		case "NewNil":
-			g.vals[name] = genVal{goVar: "", marker: "_newnil"}
+			dv := g.allocDesc()
+			g.emit("%s := JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}", dv)
+			g.vals[name] = genVal{goVar: dv, isDesc: true}
 		case "NewString":
 			// NewString(s string) Scmer — arg is a Go string (2 words: ptr+len), result is Scmer (2 words)
 			arg := g.vals[v.Call.Args[0].Name()]
@@ -5423,13 +5446,32 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 		}
 
 	case *ssa.Alloc:
-		// Track allocation — no machine code emitted.
-		// The actual value will be set by Store and consumed by MakeClosure.
+		if ptr, ok := v.Type().Underlying().(*types.Pointer); ok {
+			if array, ok := ptr.Elem().Underlying().(*types.Array); ok {
+				elemSize := types.SizesFor("gc", "amd64").Sizeof(array.Elem())
+				stackBase := g.allocTemp("stackArray")
+				g.emit("%s := ctx.AllocStack(int32(%d))", stackBase, elemSize*array.Len())
+				g.vals[name] = genVal{
+					goVar:  stackBase,
+					marker: fmt.Sprintf("_stackarray:%d:%d", elemSize, array.Len()),
+				}
+				break
+			}
+		}
+		// Non-array allocations are currently closure cells. Their value is
+		// forwarded by Store and consumed by MakeClosure without runtime storage.
 		g.vals[name] = genVal{marker: "_alloc"}
 
 	case *ssa.Store:
 		dst := g.vals[v.Addr.Name()]
-		if dst.marker == "_alloc" {
+		if strings.HasPrefix(dst.marker, "_stackaddr:") {
+			src := g.resolveValue(v.Val)
+			if !isScmerType(v.Val.Type()) {
+				panic(fmt.Sprintf("unsupported non-Scmer stack array Store: %s", v))
+			}
+			g.emit("ctx.EnsureDesc(&%s)", src.goVar)
+			g.emit("ctx.EmitStoreScmerToStack(%s, %s)", src.goVar, dst.offsetExpr)
+		} else if dst.marker == "_alloc" {
 			// Storing to an allocation: just remember the stored value
 			src := g.vals[v.Val.Name()]
 			g.vals[v.Addr.Name()] = genVal{goVar: src.goVar, isDesc: src.isDesc, marker: "_alloc_stored"}
@@ -5574,6 +5616,32 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 		}
 		// Sub-slice: strings use ptr+len, Go slices use the complete ptr+len+cap ABI header.
 		x := g.vals[v.X.Name()]
+		if strings.HasPrefix(x.marker, "_stackarray:") {
+			if v.Low != nil || v.High != nil || v.Max != nil {
+				panic(fmt.Sprintf("partial Slice on local stack array: %s", v))
+			}
+			parts := strings.Split(x.marker, ":")
+			if len(parts) != 3 {
+				panic(fmt.Sprintf("malformed stack array marker: %q", x.marker))
+			}
+			arrayLen, err := strconv.ParseInt(parts[2], 10, 64)
+			if err != nil {
+				panic(fmt.Sprintf("malformed stack array length: %q", x.marker))
+			}
+			ptrReg := g.allocReg()
+			lenReg := g.allocReg()
+			capReg := g.allocReg()
+			dv := g.allocDesc()
+			g.emit("%s := ctx.AllocReg()", ptrReg)
+			g.emit("%s := ctx.AllocRegExcept(%s)", lenReg, ptrReg)
+			g.emit("%s := ctx.AllocRegExcept(%s, %s)", capReg, ptrReg, lenReg)
+			g.emit("ctx.EmitLeaRegMem(%s, RegRSP, int32(%s))", ptrReg, x.goVar)
+			g.emit("ctx.EmitMovRegImm64(%s, uint64(%d))", lenReg, arrayLen)
+			g.emit("ctx.EmitMovRegImm64(%s, uint64(%d))", capReg, arrayLen)
+			g.emit("%s := JITValueDesc{Loc: LocRegTriple, Reg: %s, Reg2: %s, Reg3: %s, KnownSliceLen: int32(%d), KnownSliceCap: int32(%d), SliceSizeKnown: true}", dv, ptrReg, lenReg, capReg, arrayLen, arrayLen)
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
+			break
+		}
 		if x.marker == "_alloc" {
 			ptr, ok := v.X.Type().Underlying().(*types.Pointer)
 			if !ok {
@@ -5741,6 +5809,24 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			marker = "_slice"
 		}
 		g.vals[name] = genVal{goVar: dv2, isDesc: true, marker: marker}
+
+	case *ssa.MakeSlice:
+		if !isScmerType(v.Type().Underlying().(*types.Slice).Elem()) {
+			panic(fmt.Sprintf("MakeSlice of unsupported element type: %s", v))
+		}
+		length := g.resolveValue(v.Len)
+		capacity := length
+		if v.Cap != nil {
+			capacity = g.resolveValue(v.Cap)
+		}
+		g.emit("ctx.EnsureDesc(&%s)", length.goVar)
+		g.emit("ctx.EnsureDesc(&%s)", capacity.goVar)
+		dv := g.allocDesc()
+		g.emit("%s := ctx.EmitGoCallScalar(GoFuncAddr(jitMakeScmerSlice), []JITValueDesc{%s, %s}, 3)", dv, length.goVar, capacity.goVar)
+		g.emit("ctx.BindReg(%s.Reg, &%s)", dv, dv)
+		g.emit("ctx.BindReg(%s.Reg2, &%s)", dv, dv)
+		g.emit("ctx.BindReg(%s.Reg3, &%s)", dv, dv)
+		g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
 
 	default:
 		panic(instrDesc(instr))

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -507,6 +507,14 @@ type genVal struct {
 	deferredIndexSSA string // SSA name of index operand (for deferred IndexAddr on slices)
 	deferredBaseSSA  string // SSA name of base operand for deferred local FieldAddr deref
 	offsetExpr       string // Go expression for byte offset from thisptr (for _fieldaddr/_fieldconst markers)
+	stackBase        string
+	stackLen         int
+	sourceInput      int
+	hasSourceInput   bool
+	sliceInput       int
+	hasSliceInput    bool
+	lengthInput      int
+	hasLengthInput   bool
 }
 
 // ssaValueRewriter can replace SSA values while traversing instructions.
@@ -3585,7 +3593,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				g.emit("%s := args[%d]", dv, src.argIdx)
 				// Borrowed descriptor from caller: never own/free caller placements.
 				g.emit("%s.ID = 0", dv)
-				g.vals[name] = genVal{goVar: dv, isDesc: true}
+				g.vals[name] = genVal{goVar: dv, isDesc: true, sourceInput: src.argIdx, hasSourceInput: true}
 			} else if src.argIdxVar != "" {
 				// Variable-index IndexAddr+Deref on emitter args.
 				// If the index is known at emit-time, reuse args[idx] directly.
@@ -3740,16 +3748,20 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 						g.emit("} else {")
 						g.emit("\tctx.EnsureDesc(&%s)", src.goVar)
 						g.emit("\tif %s.Loc == LocRegPair || %s.Loc == LocRegTriple {", src.goVar, src.goVar)
-						g.emit("\t\t%s = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: %s.Reg2}", dv, src.goVar)
-						g.emit("\t\tctx.BindReg(%s.Reg2, &%s)", src.goVar, dv)
+						g.emit("\t\t%s = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: %s.Reg2, ID: 0}", dv, src.goVar)
 						g.emit("\t} else if %s.Loc == LocReg {", src.goVar)
-						g.emit("\t\t%s = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: %s.Reg}", dv, src.goVar)
-						g.emit("\t\tctx.BindReg(%s.Reg, &%s)", src.goVar, dv)
+						g.emit("\t\t%s = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: %s.Reg, ID: 0}", dv, src.goVar)
 						g.emit("\t} else {")
 						g.emit("\t\tpanic(\"len on unsupported descriptor location\")")
 						g.emit("\t}")
 						g.emit("}")
 						g.vals[name] = genVal{goVar: dv, isDesc: true}
+						if src.hasSliceInput {
+							withProvenance := g.vals[name]
+							withProvenance.lengthInput = src.sliceInput
+							withProvenance.hasLengthInput = true
+							g.vals[name] = withProvenance
+						}
 					} else {
 						panic(fmt.Sprintf("len on non-parameter: %s", v))
 					}
@@ -3761,7 +3773,46 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 		}
 		callee := v.Call.StaticCallee()
 		if callee == nil {
-			panic(fmt.Sprintf("dynamic call: %s", v))
+			callable := g.vals[v.Call.Value.Name()]
+			if callable.marker != "_serial_callable" || len(v.Call.Args) != 1 {
+				panic(fmt.Sprintf("dynamic call: %s", v))
+			}
+			callArgs := g.vals[v.Call.Args[0].Name()]
+			if callArgs.stackBase == "" {
+				panic(fmt.Sprintf("dynamic call args are not a local Scmer array: %s", v))
+			}
+			dv := g.allocDesc()
+			argsVar := g.allocTemp("callbackArgs")
+			g.emit("%s := make([]JITValueDesc, %d)", argsVar, callArgs.stackLen)
+			for i := 0; i < callArgs.stackLen; i++ {
+				g.emit("%s[%d] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(%s)+%d}", argsVar, i, callArgs.stackBase, i*16)
+			}
+			g.emit("var %s JITValueDesc", dv)
+			g.emit("ctx.FreeDesc(&%s)", callArgs.goVar)
+			g.emit("if %s.Loc == LocLambdaTemplate && %s.Lambda != nil {", callable.goVar, callable.goVar)
+			preservedVar := g.allocTemp("outerRegs")
+			g.emit("\t%s := ctx.PreserveOuterRegs()", preservedVar)
+			g.emit("\t%s = JITEmitProcInlineWithOuter(ctx, &%s.Lambda.Proc, %s.Lambda.Outer, %s, ctx.SliceBase, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})", dv, callable.goVar, callable.goVar, argsVar)
+			g.emit("\tctx.RestoreOuterRegs(%s)", preservedVar)
+			g.emit("} else {")
+			callbackHelper := ""
+			switch callArgs.stackLen {
+			case 1:
+				callbackHelper = "jitInvokeCallback1"
+			case 2:
+				callbackHelper = "jitInvokeCallback2"
+			case 3:
+				callbackHelper = "jitInvokeCallback3"
+			default:
+				panic(fmt.Sprintf("dynamic callback with unsupported arity: %s", v))
+			}
+			g.emit("\tcallbackCallArgs := make([]JITValueDesc, 0, %d)", callArgs.stackLen+1)
+			g.emit("\tcallbackCallArgs = append(callbackCallArgs, %s)", callable.goVar)
+			g.emit("\tcallbackCallArgs = append(callbackCallArgs, %s...)", argsVar)
+			g.emit("\t%s = ctx.EmitGoCallScalarInto(GoFuncAddr(%s), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})", dv, callbackHelper)
+			g.emit("}")
+			g.vals[name] = genVal{goVar: dv, isDesc: true}
+			break
 		}
 		atomicPkg := callee.Pkg != nil && callee.Pkg.Pkg != nil && callee.Pkg.Pkg.Path() == "sync/atomic"
 		atomicLoad := callee.Name() == "LoadInt64" || (atomicPkg && callee.Name() == "Load")
@@ -3841,7 +3892,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.emit("ctx.BindReg(%s.Reg, &%s)", dv, dv)
 			g.emit("ctx.BindReg(%s.Reg2, &%s)", dv, dv)
 			g.emit("ctx.BindReg(%s.Reg3, &%s)", dv, dv)
-			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice", sliceInput: arg.sourceInput, hasSliceInput: arg.hasSourceInput}
 		case "GetTag":
 			arg := g.vals[v.Call.Args[0].Name()]
 			if !arg.isDesc {
@@ -4068,6 +4119,12 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.vals[name] = genVal{goVar: dv, isDesc: true}
 		case "NewSlice":
 			arg := g.vals[v.Call.Args[0].Name()]
+			if arg.marker == "_slice" {
+				dv := g.allocDesc()
+				g.emit("%s := ctx.EmitNewSliceFromGoSlice(&%s)", dv, arg.goVar)
+				g.vals[name] = genVal{goVar: dv, isDesc: true}
+				break
+			}
 			if arg.marker != "_variadic_args" {
 				panic(fmt.Sprintf("NewSlice on non-variadic parameter: %s", v))
 			}
@@ -4076,11 +4133,22 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_newargslice"}
 		case "OptimizeProcToSerialFunction":
 			// OptimizeProcToSerialFunction(Scmer) func(...Scmer) Scmer
-			// arg: Scmer (2 words), result: func value (1 word)
+			// Known lambda templates remain compile-time values and can be inlined by
+			// the generated caller. Dynamic callbacks are optimized once at the JIT
+			// entry point and passed in as a hidden, GC-rooted function Scmer. Do not
+			// emit the optimizer call into a hot loop.
 			arg := g.vals[v.Call.Args[0].Name()]
 			dv := g.allocDesc()
-			g.emit("%s := ctx.EmitGoCallScalar(GoFuncAddr(OptimizeProcToSerialFunction), []JITValueDesc{%s}, 1)", dv, arg.goVar)
-			g.vals[name] = genVal{goVar: dv, isDesc: true}
+			g.emit("var %s JITValueDesc", dv)
+			g.emit("if %s.Loc == LocLambdaTemplate {", arg.goVar)
+			g.emit("\t%s = %s", dv, arg.goVar)
+			g.emit("} else {")
+			if !arg.hasSourceInput {
+				panic(fmt.Sprintf("OptimizeProcToSerialFunction argument has no input provenance: %s", v))
+			}
+			g.emit("\t%s = ctx.RequestOptimizedCallback(%d)", dv, arg.sourceInput)
+			g.emit("}")
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_serial_callable"}
 		case "FastDict":
 			// (Scmer).FastDict() *FastDict — extract ptr field, free aux
 			arg := g.vals[v.Call.Args[0].Name()]
@@ -4226,30 +4294,11 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.emit("}")
 			g.vals[name] = genVal{goVar: dv, isDesc: true}
 		case "Slice":
-			// (Scmer).Slice() []Scmer — materialize the complete Go slice ABI
-			// header. Scmer stores ptr+len; a reconstructed slice has cap == len.
+			// (Scmer).Slice() []Scmer — decode the complete ptr/len/cap header.
 			arg := g.vals[v.Call.Args[0].Name()]
 			dv := g.allocDesc()
-			ptrReg := g.allocReg()
-			lenReg := g.allocReg()
-			capReg := g.allocReg()
-			g.emit("%s := ctx.AllocReg()", ptrReg)
-			g.emit("%s := ctx.AllocRegExcept(%s)", lenReg, ptrReg)
-			g.emit("%s := ctx.AllocRegExcept(%s, %s)", capReg, ptrReg, lenReg)
-			g.emit("if %s.Loc == LocImm {", arg.goVar)
-			g.emit("\tctx.TrackImm(%s.Imm)", arg.goVar)
-			g.emit("\tptrWord, _ := %s.Imm.RawWords()", arg.goVar)
-			g.emit("\tctx.EmitMovRegImm64(%s, uint64(ptrWord))", ptrReg)
-			g.emit("\tctx.EmitMovRegImm64(%s, uint64(len(%s.Imm.Slice())))", lenReg, arg.goVar)
-			g.emit("} else {")
-			g.emit("\tctx.EnsureDesc(&%s)", arg.goVar)
-			g.emit("\tctx.EmitMovRegReg(%s, %s.Reg)", ptrReg, arg.goVar)
-			g.emit("\tctx.EmitMovRegReg(%s, %s.Reg2)", lenReg, arg.goVar)
-			g.emit("\tctx.EmitShrRegImm8(%s, 8)", lenReg)
-			g.emit("}")
-			g.emit("ctx.EmitMovRegReg(%s, %s)", capReg, lenReg)
-			g.emit("%s := JITValueDesc{Loc: LocRegTriple, Reg: %s, Reg2: %s, Reg3: %s}", dv, ptrReg, lenReg, capReg)
-			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
+			g.emit("%s := jitKnownSliceHeader(ctx, &%s)", dv, arg.goVar)
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice", sliceInput: arg.sourceInput, hasSliceInput: arg.hasSourceInput}
 		case "JITBuildMergeClosure":
 			// JITBuildMergeClosure(func(...Scmer) Scmer) func(Scmer, Scmer) Scmer
 			// arg: 1 word, result: 1 word
@@ -5475,6 +5524,19 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			// Storing to an allocation: just remember the stored value
 			src := g.vals[v.Val.Name()]
 			g.vals[v.Addr.Name()] = genVal{goVar: src.goVar, isDesc: src.isDesc, marker: "_alloc_stored"}
+		} else if strings.HasPrefix(dst.marker, "_sliceaddr:") {
+			parts := strings.SplitN(dst.marker, ":", 3)
+			elemSize := parts[1]
+			sliceDescVar := g.overlayDescVar(parts[2], dst.deferredBaseSSA)
+			idxDescVar := g.overlayDescVar(dst.argIdxVar, dst.deferredIndexSSA)
+			src := g.resolveValue(v.Val)
+			address := g.allocDesc()
+			g.emit("%s := ctx.EmitSliceElementAddress(&%s, &%s, int32(%s))", address, sliceDescVar, idxDescVar, elemSize)
+			g.emit("ctx.EmitStoreScmerAt(&%s, &%s)", address, src.goVar)
+			g.emit("ctx.FreeDesc(&%s)", address)
+			if dst.deferredIndexSSA != "" {
+				g.useOperand(dst.deferredIndexSSA)
+			}
 		} else {
 			panic(fmt.Sprintf("unsupported Store: %s", v))
 		}
@@ -5639,7 +5701,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			g.emit("ctx.EmitMovRegImm64(%s, uint64(%d))", lenReg, arrayLen)
 			g.emit("ctx.EmitMovRegImm64(%s, uint64(%d))", capReg, arrayLen)
 			g.emit("%s := JITValueDesc{Loc: LocRegTriple, Reg: %s, Reg2: %s, Reg3: %s, KnownSliceLen: int32(%d), KnownSliceCap: int32(%d), SliceSizeKnown: true}", dv, ptrReg, lenReg, capReg, arrayLen, arrayLen)
-			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice", stackBase: x.goVar, stackLen: int(arrayLen)}
 			break
 		}
 		if x.marker == "_alloc" {
@@ -5818,6 +5880,14 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 		capacity := length
 		if v.Cap != nil {
 			capacity = g.resolveValue(v.Cap)
+		}
+		if length.hasLengthInput && capacity.hasLengthInput && length.lengthInput == capacity.lengthInput {
+			root := g.allocDesc()
+			dv := g.allocDesc()
+			g.emit("%s := ctx.RequestPreallocatedSlice(%d)", root, length.lengthInput)
+			g.emit("%s := jitKnownSliceHeader(ctx, &%s)", dv, root)
+			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_slice"}
+			break
 		}
 		g.emit("ctx.EnsureDesc(&%s)", length.goVar)
 		g.emit("ctx.EnsureDesc(&%s)", capacity.goVar)
@@ -6166,6 +6236,13 @@ func injectBindRegCalls(code string) string {
 	out := make([]string, 0, len(lines)+len(lines)/3)
 	for _, line := range lines {
 		out = append(out, line)
+		// ID 0 explicitly marks a borrowed register view. Its source descriptor
+		// remains the spill/liveness owner; rebinding the register here would make
+		// later consumers overwrite or free that source (for example a Go slice's
+		// len register in a loop).
+		if strings.Contains(line, "ID: 0") {
+			continue
+		}
 		if m := locRegTripleAssignRe.FindStringSubmatch(line); m != nil {
 			indent, descVar := m[1], m[2]
 			for _, expr := range m[3:6] {

--- a/tools/jitgen/ssa_per_instr_emit.go
+++ b/tools/jitgen/ssa_per_instr_emit.go
@@ -64,6 +64,8 @@ func (e perSSAInstrEmitter) Emit(instr ssa.Instruction) {
 		e.EmitPanic(v)
 	case *ssa.Slice:
 		e.EmitSlice(v)
+	case *ssa.MakeSlice:
+		e.EmitMakeSlice(v)
 	default:
 		panic(instrDesc(instr))
 	}
@@ -85,3 +87,4 @@ func (e perSSAInstrEmitter) EmitMakeClosure(v *ssa.MakeClosure)     { e.g.emitIn
 func (e perSSAInstrEmitter) EmitMakeInterface(v *ssa.MakeInterface) { e.g.emitInstrLegacy(v) }
 func (e perSSAInstrEmitter) EmitPanic(v *ssa.Panic)                 { e.g.emitInstrLegacy(v) }
 func (e perSSAInstrEmitter) EmitSlice(v *ssa.Slice)                 { e.g.emitInstrLegacy(v) }
+func (e perSSAInstrEmitter) EmitMakeSlice(v *ssa.MakeSlice)         { e.g.emitInstrLegacy(v) }


### PR DESCRIPTION
## Summary

- teach `jitgen` to lower the SSA used by `map`, `map_mut`, and `reduce`, including slice construction, indexed stores, loop CFGs, and callback calls
- carry known lambda bodies and runtime captures through `JITValueDesc`, then emit known callback bodies inline
- optimize unknown callbacks once at the JIT entry point and pass the resulting function as a hidden GC-rooted argument
- preallocate `map` results at the Go/JIT boundary so the generated machine code only consumes a valid Go-managed slice
- preserve outer emitter registers across nested generated emitters
- retain exact type and no-heap-pointer facts across result placement, allowing pointer-free map results to bypass the Go write-barrier trampoline safely

There are no handwritten `map`, `map_mut`, or `reduce` JIT implementations. Their `JITEmit` bodies are generated from the existing Go implementations by `jitgen`; the handwritten additions are generic SSA lowering and runtime/emitter primitives.

## Newly native cases

The regression cases in `lib/test.scm` verify native compilation and results for:

- `map` with a constant callback
- `map` with a known callback and a runtime capture
- `map_mut` with a known callback
- `reduce` with accumulator, value, and runtime capture
- `map` with a callback supplied only at runtime

## Performance

A/B setup: Linux/amd64, patched Go 1.26.1-X:jit compiler, one pinned CPU, `GOMAXPROCS=1`, seven interleaved process runs, median shown. Each process executes 4,000 operations over 256-element lists. Baseline is the immediate pre-implementation commit `895edcff9`; result checksums are identical.

| Case | Baseline | This branch | Change |
|---|---:|---:|---:|
| `map`, constant callback | 64.36 ms | 18.39 ms | 3.50x faster |
| `map`, captured numeric callback | 353.23 ms | 39.14 ms | 9.03x faster |
| `map_mut`, captured numeric callback | 289.37 ms | 29.72 ms | 9.74x faster |
| `reduce`, captured numeric callback | 285.64 ms | 28.56 ms | 10.00x faster |
| `map`, runtime callback | 298.78 ms | 303.35 ms | parity / 1.5% slower |

The runtime-callback case intentionally retains one callback trampoline per element. Callback optimization itself is absent from the hot loop and happens once per JIT invocation. Its 1.5% delta is within the process-level noise visible in the seven samples and does not indicate a complexity change.

## Machine-code validation

Raw JIT buffers were dumped and inspected with `objdump -D -b binary -m i386:x86-64`:

- constant `map` is 371 bytes; its loop contains the immediate result and two direct element stores, with no callback or write-barrier call
- captured numeric `map` is 1,247 bytes and `map_mut` is 1,135 bytes; their result stores are direct because the declared numeric result proves that no Go heap pointer is written
- runtime-callback `map` is 469 bytes; its loop calls `jitInvokeCallback1` and `jitStoreScmerAt`, preserving callback semantics and Go's write barrier
- no generated loop calls `OptimizeProcToSerialFunction`

## Validation

- patched compiler: `./memcp lib/test.scm` — 1167/1167 passed
- patched compiler with `GOGC=1`: `./memcp lib/test.scm` — 1167/1167 passed
- vanilla compiler/JIT stub: `./memcp lib/test.scm` — 1167/1167 passed
- repeated `jitgen -patch` for all three builtins produces a byte-identical diff
- `git diff --check`

Per request, the SQL suites, Go tests, and pre-commit hook were not run for this experimental JIT patch.
