### PR TITLE
fix: preserve complete order relations in auto indexes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -9417,6 +9417,47 @@ until lowering without creating a depth-proportional binary OR chain. */
 			'(_expr dir) dir
 			_ (neumann_fail "build_queryplan" "malformed ORDER BY item"))))))
 
+(define source_column_order_collation (lambda (src col)
+	(if (not (source_is_base_table? src))
+		"bin"
+		(begin
+			(define meta (find (get_schema (source_schema src) (source_relation src))
+				(lambda (candidate) (equal?? (candidate "Field") col)) nil))
+			(if (nil? meta)
+				"bin"
+				(begin
+					(define collation (meta "Collation"))
+					(if (or (nil? collation) (equal? collation "")) "bin" collation)))))))
+
+(define canonical_order_relation (lambda (dir collation)
+	(if (or (equal? dir <) (equal? dir >))
+		(collate collation (equal? dir >))
+		dir)))
+
+(define order_relations_default (lambda (order_items)
+	(map (coalesceNil order_items '()) (lambda (item)
+		(match item
+			'(_expr dir) (canonical_order_relation dir "bin")
+			_ (neumann_fail "build_queryplan" "malformed ORDER BY item"))))))
+
+/* Resolve implicit SQL directions to canonical callbacks while source metadata
+is still available. Explicit COLLATE and user callbacks pass through intact. */
+(define order_relations_for_source (lambda (src order_items)
+	(map (coalesceNil order_items '()) (lambda (item)
+		(match item
+			'(expr dir) (canonical_order_relation dir
+				(match expr
+					((symbol get_column) tblvar tbl_ignorecase _col _col_ignorecase)
+					(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+						(source_column_order_collation src (order_column_for_alias src expr))
+						"bin")
+					((quote get_column) tblvar tbl_ignorecase _col _col_ignorecase)
+					(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+						(source_column_order_collation src (order_column_for_alias src expr))
+						"bin")
+					_ "bin"))
+			_ (neumann_fail "build_queryplan" "malformed ORDER BY item"))))))
+
 (define order_expr_belongs_to_source? (lambda (src expr)
 	(match expr
 		((symbol scalar_first_probe) stage _requested_col)
@@ -9479,7 +9520,7 @@ until lowering without creating a depth-proportional binary OR chain. */
 				(map filtercols (lambda (col) (symbol (concat grouptbl "." col))))
 				(list (quote optimize) (lower_column_expr_for_alias group_src session_filter)))
 			(cons (quote list) ordercols)
-			(cons (quote list) (order_dirs replaced_order))
+			(cons (quote list) (order_relations_for_source group_src replaced_order))
 			0
 			0
 			1
@@ -14665,7 +14706,7 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 								(cons (quote list) filtercols)
 								filter_expr
 								(cons (quote list) ordercols)
-								(cons (quote list) (if (empty_list? order_items) '() (order_dirs order_items)))
+								(cons (quote list) (if (empty_list? order_items) '() (order_relations_for_source src order_items)))
 								0
 								(coalesceNil (qb_offset block) 0)
 								(coalesceNil (qb_limit block) -1)
@@ -14891,7 +14932,7 @@ either bound a real row or supplied the synthetic NULL row. */
 			filter_expr
 			(cons (quote list) (scan_order_sort_columns_for_join_driver
 				ordered_sources default_alias src driver_order_items stages final_condition))
-			(cons (quote list) (order_dirs driver_order_items))
+			(cons (quote list) (order_relations_for_source src driver_order_items))
 			0 0 -1
 			(cons (quote list) mapcols)
 			map_expr reduce_expr 0 false))
@@ -15139,7 +15180,7 @@ either bound a real row or supplied the synthetic NULL row. */
 						filter_expr
 						(cons (quote list) (if (empty_list? current_order_items) '()
 							(scan_order_sort_columns_for_join_driver ordered_sources default_alias src current_order_items stages final_condition)))
-						(cons (quote list) (if (empty_list? current_order_items) '() (order_dirs current_order_items)))
+						(cons (quote list) (if (empty_list? current_order_items) '() (order_relations_for_source src current_order_items)))
 						0
 						(coalesceNil offset_value 0)
 						(coalesceNil limit_value -1)
@@ -15270,7 +15311,7 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 		(quoted_runtime_list '())
 		(list (quote lambda) '() true)
 		(cons (quote list) order_names)
-		(cons (quote list) (order_dirs order_items))
+		(cons (quote list) (order_relations_default order_items))
 		0
 		(coalesceNil offset_value 0)
 		(coalesceNil limit_value -1)
@@ -15979,7 +16020,7 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 				(cons (quote list) filtercols)
 				filter_expr
 				(cons (quote list) ordercols)
-				(cons (quote list) (if (empty_list? order_items) '() (order_dirs order_items)))
+				(cons (quote list) (if (empty_list? order_items) '() (order_relations_for_source src order_items)))
 				0
 				(coalesceNil (qb_offset block) 0)
 				(coalesceNil (qb_limit block) -1)
@@ -16079,11 +16120,12 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 					pos))
 			_ (neumann_fail "build_queryplan" "malformed UNION ORDER BY item"))))))
 
-(define union_order_dirs (lambda (order_items)
-	(map (coalesceNil order_items '()) (lambda (item)
-		(match item
-			'(_expr dir) dir
-			_ (neumann_fail "build_queryplan" "malformed UNION ORDER BY item"))))))
+(define union_order_relations (lambda (order_items)
+	/* UNION branches share one merge relation. Until the logical UNION model
+	carries result-column collation metadata, use the canonical binary factory
+	relation rather than letting individual storage scans infer incompatible
+	per-branch callbacks. */
+	(order_relations_default order_items)))
 
 (define union_ordered_branch_supported? (lambda (branch)
 	(and (query_block? branch)
@@ -16353,7 +16395,7 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 					(cons (quote list) (map specs (lambda (spec) (cons (quote list) (nth spec 1)))))
 					(cons (quote list) (map specs (lambda (spec) (nth spec 2))))
 					(cons (quote list) (map specs (lambda (spec) (cons (quote list) (nth spec 3)))))
-					(cons (quote list) (union_order_dirs (union_order block)))
+					(cons (quote list) (union_order_relations (union_order block)))
 					nil
 					nil
 					0

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -21,8 +21,8 @@ import "fmt"
 import "html"
 import "sync"
 import "regexp"
+import "unsafe"
 import "net/url"
-import "reflect"
 import "strings"
 import crand "crypto/rand"
 import "crypto/sha1"
@@ -37,6 +37,27 @@ import "golang.org/x/text/language"
 // Collation metadata registry for stable serialization of comparator closures.
 // Keyed by function pointer.
 var collateRegistry sync.Map // map[uintptr]struct{Collation string; Reverse bool}
+
+// collateLessRegistry holds the allocation-free executor belonging to a
+// canonical collate callback. The callback remains the public identity and the
+// single source of ordering semantics.
+var collateLessRegistry sync.Map // map[uintptr]func(Scmer, Scmer) bool
+
+// FunctionIdentity returns the runtime identity of a function value, including
+// its closure context. reflect.Value.Pointer only returns the shared code entry
+// and therefore aliases distinct collation closures.
+func FunctionIdentity(fn func(...Scmer) Scmer) uintptr {
+	return *(*uintptr)(unsafe.Pointer(&fn))
+}
+
+type collateCacheKey struct {
+	Collation string
+	Reverse   bool
+}
+
+// collateCache canonicalizes order relations. Auto indexes compare callback
+// pointers, so equivalent plans must receive the same function instance.
+var collateCache sync.Map // map[collateCacheKey]Scmer
 
 func optimizeFNVHash(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 	if len(v) == 2 {
@@ -89,7 +110,7 @@ func LookupCollate(fn func(...Scmer) Scmer) (string, bool, bool) {
 	if fn == nil {
 		return "", false, false
 	}
-	if v, ok := collateRegistry.Load(reflect.ValueOf(fn).Pointer()); ok {
+	if v, ok := collateRegistry.Load(FunctionIdentity(fn)); ok {
 		m := v.(struct {
 			Collation string
 			Reverse   bool
@@ -97,6 +118,16 @@ func LookupCollate(fn func(...Scmer) Scmer) (string, bool, bool) {
 		return m.Collation, m.Reverse, true
 	}
 	return "", false, false
+}
+
+// OrderRelationLess resolves the bool executor of an order callback once. The
+// fallback preserves arbitrary user callbacks; factory callbacks avoid a
+// Scmer(bool) roundtrip in storage sort loops.
+func OrderRelationLess(fn func(...Scmer) Scmer) func(Scmer, Scmer) bool {
+	if fast, ok := collateLessRegistry.Load(FunctionIdentity(fn)); ok {
+		return fast.(func(Scmer, Scmer) bool)
+	}
+	return func(a, b Scmer) bool { return ToBool(fn(a, b)) }
 }
 
 /* SQL LIKE operator implementation on strings */
@@ -9777,10 +9808,46 @@ func init_strings() {
 	collation_re := regexp.MustCompile("^([^_]+_)?(.+?)$") // caracterset_language_case
 	Declare(&Globalenv, &Declaration{
 		Name: "collate",
-		Desc: "returns the `<` operator for a given collation. MemCP allows natural sorting of numeric literals.",
+		Desc: "returns a canonical order relation for a collation and direction. MemCP allows natural sorting of numeric literals.",
 		Fn: func(a ...Scmer) Scmer {
-			collation := String(a[0])
-			ci := false
+			collationName := String(a[0])
+			reverse := len(a) > 1 && ToBool(a[1])
+			key := collateCacheKey{Collation: collationName, Reverse: reverse}
+			if cached, ok := collateCache.Load(key); ok {
+				return cached.(Scmer)
+			}
+			// Binary and bare-charset relations are the dominant index case. Keep
+			// their canonical callback to one function dispatch: Less already owns
+			// the required ASC NULL-first semantics, and swapping its operands owns
+			// DESC NULL-last semantics. A closure per metadata key keeps callback
+			// identity distinct even when two names have identical byte ordering.
+			if collationName == "bin" || collationName == "binary" || collationName == "utf8" || collationName == "utf8mb4" {
+				less := func(left, right Scmer) bool {
+					if reverse {
+						return Less(right, left)
+					}
+					return Less(left, right)
+				}
+				fn := func(args ...Scmer) Scmer {
+					return NewBool(less(args[0], args[1]))
+				}
+				result := NewFunc(fn)
+				collateRegistry.Store(FunctionIdentity(fn), struct {
+					Collation string
+					Reverse   bool
+				}{Collation: collationName, Reverse: reverse})
+				collateLessRegistry.Store(FunctionIdentity(fn), less)
+				canonical, _ := collateCache.LoadOrStore(key, result)
+				return canonical.(Scmer)
+			}
+			raw := func() Scmer {
+				collation := String(a[0])
+				// Bare charset names carry no language/case ordering. SQL columns use
+				// them as their default metadata and historically sort bytewise.
+				if collation == "utf8" || collation == "utf8mb4" || collation == "binary" {
+					collation = "bin"
+				}
+				ci := false
 			if strings.HasSuffix(collation, "_ci") {
 				ci = true
 				collation = collation[:len(collation)-3]
@@ -9792,14 +9859,14 @@ func init_strings() {
 					// Return closures that compare raw UTF-8 byte order; register for serialization
 					if len(a) > 1 && ToBool(a[1]) {
 						f := func(a ...Scmer) Scmer { return GreaterScm(a...) }
-						collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+						collateRegistry.Store(FunctionIdentity(f), struct {
 							Collation string
 							Reverse   bool
 						}{Collation: String(a[0]), Reverse: true})
 						return NewFunc(f)
 					}
 					f := func(a ...Scmer) Scmer { return LessScm(a...) }
-					collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+					collateRegistry.Store(FunctionIdentity(f), struct {
 						Collation string
 						Reverse   bool
 					}{Collation: String(a[0]), Reverse: false})
@@ -9851,7 +9918,7 @@ func init_strings() {
 							}
 							return NewBool(res)
 						}
-						collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+						collateRegistry.Store(FunctionIdentity(f), struct {
 							Collation string
 							Reverse   bool
 						}{Collation: String(a[0]), Reverse: true})
@@ -9878,7 +9945,7 @@ func init_strings() {
 						}
 						return NewBool(res)
 					}
-					collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+					collateRegistry.Store(FunctionIdentity(f), struct {
 						Collation string
 						Reverse   bool
 					}{Collation: String(a[0]), Reverse: false})
@@ -9928,7 +9995,7 @@ func init_strings() {
 						}
 						return NewBool(res)
 					}
-					collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+					collateRegistry.Store(FunctionIdentity(f), struct {
 						Collation string
 						Reverse   bool
 					}{Collation: String(a[0]), Reverse: true})
@@ -9941,7 +10008,7 @@ func init_strings() {
 					}
 					return NewBool(c.CompareString(String(a[0]), String(a[1])) == -1)
 				}
-				collateRegistry.Store(reflect.ValueOf(f).Pointer(), struct {
+				collateRegistry.Store(FunctionIdentity(f), struct {
 					Collation string
 					Reverse   bool
 				}{Collation: String(a[0]), Reverse: false})
@@ -9952,6 +10019,33 @@ func init_strings() {
 				}
 				return NewFunc(LessScm)
 			}
+			}()
+			rawFn := raw.Func()
+			less := func(left, right Scmer) bool {
+				leftNil := left.IsNil()
+				rightNil := right.IsNil()
+				if leftNil || rightNil {
+					if leftNil && rightNil {
+						return false
+					}
+					if reverse {
+						return !leftNil && rightNil
+					}
+					return leftNil && !rightNil
+				}
+				return ToBool(rawFn(left, right))
+			}
+			fn := func(args ...Scmer) Scmer {
+				return NewBool(less(args[0], args[1]))
+			}
+			result := NewFunc(fn)
+			collateRegistry.Store(FunctionIdentity(fn), struct {
+				Collation string
+				Reverse   bool
+			}{Collation: collationName, Reverse: reverse})
+			collateLessRegistry.Store(FunctionIdentity(fn), less)
+			canonical, _ := collateCache.LoadOrStore(key, result)
+			return canonical.(Scmer)
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "collation", ParamDesc: "collation string of the form LANG or LANG_cs or LANG_ci where LANG is a BCP 47 code, for compatibility to MySQL, a CHARSET_ prefix is allowed and ignored as well as the aliases bin, danish, general, german1, german2, spanish and swedish are allowed for language codes"}, &TypeDescriptor{Kind: "bool", ParamName: "reverse", ParamDesc: "whether to reverse the order like in ORDER BY DESC", Optional: true}},

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -261,6 +261,11 @@ type columnboundaries struct {
 	upperBatch       bool
 	upperBatchSubidx int
 	collation        string // non-empty only for collation-sensitive matchers
+	// order is the complete strict relation for an ORDER BY suffix, including
+	// direction, collation, and NULL placement. Nil means the column is only a
+	// filter boundary and uses its schema's canonical ascending relation.
+	order     func(...scm.Scmer) scm.Scmer
+	orderMeta string
 	// for computed index columns (col starts with ".")
 	mapCols []string  // source columns needed to compute the value
 	mapFn   scm.Scmer // function: mapFn(mapCols values...) → index value
@@ -278,6 +283,10 @@ func boundaryValueEqual(a, b scm.Scmer) bool {
 // boundaryIsPoint delegates to the matcher's IsPointLike.
 func boundaryIsPoint(b columnboundaries) bool {
 	return b.matcher.IsPointLike()
+}
+
+func boundaryIsUnboundedOrder(b columnboundaries) bool {
+	return b.order != nil && b.lower.IsNil() && b.upper.IsNil()
 }
 
 // addConstraint merges a column boundary into an existing set, narrowing the
@@ -1239,7 +1248,8 @@ func indexFromBoundaries(cols boundaries) (lower []scm.Scmer, upperLast scm.Scme
 		//fmt.Println("conditions:", cols)
 		// build up lower and upper bounds of index
 		for {
-			if len(cols) >= 2 && !boundaryIsPoint(cols[len(cols)-2]) {
+			if len(cols) >= 2 && !boundaryIsPoint(cols[len(cols)-2]) &&
+				!(boundaryIsUnboundedOrder(cols[len(cols)-2]) && boundaryIsUnboundedOrder(cols[len(cols)-1])) {
 				// remove last col -> we cant have two ranged cols
 				cols = cols[:len(cols)-1]
 			} else {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -688,7 +688,7 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 			s.ensureMainCount(false)
 			var buf [1024]uint32
 			rowVals := make([]scm.Scmer, nCols)
-			s.iterateIndex(nil, bounds, lower, upperLast, len(s.inserts), buf[:], true, func(batch []uint32) bool {
+			s.iterateIndex(nil, bounds, lower, upperLast, len(s.inserts), buf[:], 1, nil, func(batch []uint32) bool {
 				for _, idx := range batch {
 					if s.deletions.Get(uint(idx)) {
 						continue

--- a/storage/index.go
+++ b/storage/index.go
@@ -17,13 +17,15 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 
 package storage
 
+import "fmt"
+import "sort"
 import "sync"
-import "sync/atomic"
 import "time"
 import "strings"
+import "sync/atomic"
 
-import "github.com/carli2/hybridsort"
 import "github.com/google/btree"
+import "github.com/carli2/hybridsort"
 import "github.com/launix-de/memcp/scm"
 
 type indexPair struct {
@@ -70,14 +72,107 @@ type StorageIndex struct {
 	ColMapCols  [][]string        // per-column source col names; nil entry means raw column
 	ColMapFn    []scm.Scmer       // per-column compute fn; IsNil() entry means raw column
 	ColMatchers []BoundaryMatcher // per-column matcher (singleton: EqualMatcher/RangeMatcher/LikeMatcher)
-	Savings     float64           // store the amount of time savings here -> add selectivity (outputted / size) on each
-	Native      bool              // true when data is physically sorted by this index (zero-cost)
-	t           *storageShard
-	lastHit     atomic.Uint32 // last search position for sorted access pattern optimization
-	mu          sync.Mutex
-	sessionKeys []string
-	baseState   storageIndexState
-	variants    map[string]*storageIndexState
+	// ColOrder is the immutable per-column strict relation used by build, delta
+	// merge, lookup, and ordered scans. Each callback owns collation, direction,
+	// and NULL placement; storage must not infer or wrap those semantics.
+	ColOrder []func(...scm.Scmer) scm.Scmer
+	// ColOrderMeta is diagnostic metadata only. Equality and reuse are decided
+	// by canonical callback identity, never by reparsing this string.
+	ColOrderMeta []string
+	// ColOrderFast is derived once from ColOrder by the callback factory. It
+	// removes Scmer(bool) traffic from comparison loops without becoming a
+	// second source of ordering semantics.
+	ColOrderFast []func(scm.Scmer, scm.Scmer) bool
+	Savings      float64 // store the amount of time savings here -> add selectivity (outputted / size) on each
+	Native       bool    // true when data is physically sorted by this index (zero-cost)
+	t            *storageShard
+	lastHit      atomic.Uint32 // last search position for sorted access pattern optimization
+	mu           sync.Mutex
+	sessionKeys  []string
+	baseState    storageIndexState
+	variants     map[string]*storageIndexState
+}
+
+func orderRelationMeta(order func(...scm.Scmer) scm.Scmer) string {
+	if collation, reverse, ok := scm.LookupCollate(order); ok {
+		if reverse {
+			return collation + ":desc"
+		}
+		return collation + ":asc"
+	}
+	if order == nil {
+		return ""
+	}
+	return fmt.Sprintf("callback:%x", scm.FunctionIdentity(order))
+}
+
+func sameOrderRelation(a, b func(...scm.Scmer) scm.Scmer) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return scm.FunctionIdentity(a) == scm.FunctionIdentity(b)
+}
+
+func canonicalColumnOrder(t *table, col string) (func(...scm.Scmer) scm.Scmer, string) {
+	collation := "bin"
+	for _, definition := range t.Columns {
+		if definition.Name == col {
+			if definition.Collation != "" {
+				collation = definition.Collation
+			}
+			break
+		}
+	}
+	value := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString(collation), scm.NewBool(false))
+	order := scm.OptimizeProcToSerialFunction(value)
+	return order, orderRelationMeta(order)
+}
+
+func boundaryOrder(t *table, boundary columnboundaries) (func(...scm.Scmer) scm.Scmer, string) {
+	if boundary.order != nil {
+		meta := boundary.orderMeta
+		if meta == "" {
+			meta = orderRelationMeta(boundary.order)
+		}
+		return boundary.order, meta
+	}
+	return canonicalColumnOrder(t, boundary.col)
+}
+
+func (s *StorageIndex) lessAt(col int, a, b scm.Scmer) bool {
+	if col < len(s.ColOrderFast) && s.ColOrderFast[col] != nil {
+		return s.ColOrderFast[col](a, b)
+	}
+	if col < len(s.ColOrder) && s.ColOrder[col] != nil {
+		return scm.ToBool(s.ColOrder[col](a, b))
+	}
+	return scm.Less(a, b)
+}
+
+func (s *StorageIndex) compareAt(col int, a, b scm.Scmer) int {
+	if s.lessAt(col, a, b) {
+		return -1
+	}
+	if s.lessAt(col, b, a) {
+		return 1
+	}
+	return 0
+}
+
+func (s *StorageIndex) usesNaturalAscendingOrder(col int) bool {
+	if col >= len(s.ColOrder) || s.ColOrder[col] == nil {
+		return true
+	}
+	collation, reverse, ok := scm.LookupCollate(s.ColOrder[col])
+	if !ok || reverse {
+		return false
+	}
+	switch collation {
+	case "bin", "binary", "utf8", "utf8mb4":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildGetters returns per-column value getters for this index, reading from the
@@ -284,33 +379,37 @@ func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []sc
 // rowWithinBounds checks sorted (equal/range) columns using lower/upper directly.
 // Non-sorted columns (LIKE etc.) are skipped — handled by block-level skipping
 // in iterate(); the scan layer applies the full condition afterwards.
-func (s *StorageIndex) rowWithinBounds(cmpCols int, lower []scm.Scmer, upperLast scm.Scmer, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
+func (s *StorageIndex) rowWithinBounds(bounds boundaries, cmpCols int, lower []scm.Scmer, upperLast scm.Scmer, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
 	for i := 0; i < cmpCols; i++ {
 		if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() {
 			continue // non-sorted: block-skip handles this, scan() filters exact
 		}
 		v := getter(i)
+		if i < len(bounds) && boundaryIsUnboundedOrder(bounds[i]) {
+			continue // unbounded ORDER BY suffix, not a SQL range predicate
+		}
 		if i == cmpCols-1 {
 			if !upperLast.IsNil() {
 				if upperInclusive {
-					if scm.Less(upperLast, v) {
+					if s.compareAt(i, upperLast, v) < 0 {
 						return false, true
 					}
-				} else if !scm.Less(v, upperLast) {
+				} else if s.compareAt(i, v, upperLast) >= 0 {
 					return false, true
 				}
 			}
 			if len(lower) > i && !lower[i].IsNil() {
-				if scm.Less(v, lower[i]) {
+				if s.compareAt(i, v, lower[i]) < 0 {
 					return false, false
 				}
 			}
 			continue
 		}
-		if scm.Equal(v, lower[i]) {
+		cmp := s.compareAt(i, v, lower[i])
+		if cmp == 0 {
 			continue
 		}
-		if scm.Less(v, lower[i]) {
+		if cmp < 0 {
 			return false, false
 		}
 		return false, true
@@ -328,10 +427,10 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 		if !state.precomputedDelta {
 			deltaVal = s.getDeltaColValue(delta.data, i)
 		}
-		if scm.Less(mainVal, deltaVal) {
+		if s.lessAt(i, mainVal, deltaVal) {
 			return -1
 		}
-		if scm.Less(deltaVal, mainVal) {
+		if s.lessAt(i, deltaVal, mainVal) {
 			return 1
 		}
 	}
@@ -349,16 +448,24 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 // The callback receives batches of record IDs and returns false to stop iteration.
 // Buffer size controls early-out granularity: use small buffers (e.g. [8]uint32)
 // for existence checks, large buffers (e.g. [1024]uint32) for full scans.
-func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, false, nil, callback)
+func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, selected, callback)
 }
 
 func (t *storageShard) iterateIndexForce(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, true, nil, callback)
+	usageWeight := 0.0
+	if countUsage {
+		usageWeight = 1.0
+	}
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, true, nil, nil, callback)
 }
 
 func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, exactMain *bool, callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, countUsage, false, exactMain, callback)
+	usageWeight := 0.0
+	if countUsage {
+		usageWeight = 1.0
+	}
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, exactMain, nil, callback)
 }
 
 func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, bool) {
@@ -369,7 +476,7 @@ func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, b
 	return last.lowerInclusive, last.upperInclusive
 }
 
-func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, exactMain *bool, callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 	if exactMain != nil {
 		*exactMain = false
 	}
@@ -398,9 +505,15 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 					if len(index.ColMatchers) > i && !matcherKindEqual(cols[i].matcher, index.ColMatchers[i]) {
 						goto skip_index // matcher kind mismatch
 					}
+					if cols[i].matcher.IsSorted() && !boundaryIsPoint(cols[i]) {
+						requiredOrder, _ := boundaryOrder(t.t, cols[i])
+						if len(index.ColOrder) <= i || !sameOrderRelation(requiredOrder, index.ColOrder[i]) {
+							goto skip_index
+						}
+					}
 				}
 				// this index fits!
-				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
+				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, selected, callback)
 				return
 			}
 		skip_index:
@@ -425,11 +538,18 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 						covered = false
 						break
 					}
+					if cols[i].matcher.IsSorted() && !boundaryIsPoint(cols[i]) {
+						requiredOrder, _ := boundaryOrder(t.t, cols[i])
+						if len(index.ColOrder) <= i || !sameOrderRelation(requiredOrder, index.ColOrder[i]) {
+							covered = false
+							break
+						}
+					}
 				}
 				if covered {
 					// longer index covers this query; use it instead of creating a shorter one
 					t.indexMutex.Unlock()
-					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
+					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, selected, callback)
 					return
 				}
 			}
@@ -474,11 +594,16 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		index.ColMapCols = make([][]string, len(lower))
 		index.ColMapFn = make([]scm.Scmer, len(lower))
 		index.ColMatchers = make([]BoundaryMatcher, len(lower))
+		index.ColOrder = make([]func(...scm.Scmer) scm.Scmer, len(lower))
+		index.ColOrderMeta = make([]string, len(lower))
+		index.ColOrderFast = make([]func(scm.Scmer, scm.Scmer) bool, len(lower))
 		for i := range lower {
 			index.Cols[i] = cols[i].col
 			index.ColMapCols[i] = cols[i].mapCols  // nil for raw columns
 			index.ColMapFn[i] = cols[i].mapFn      // IsNil() for raw columns
 			index.ColMatchers[i] = cols[i].matcher // nil for equal/range
+			index.ColOrder[i], index.ColOrderMeta[i] = boundaryOrder(t.t, cols[i])
+			index.ColOrderFast[i] = scm.OrderRelationLess(index.ColOrder[i])
 		}
 		index.Savings = 0.0            // count how many cost we wasted so we decide when to build the index
 		index.baseState.active = false // tell the engine that index has to be built first
@@ -492,11 +617,14 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		}
 		t.Indexes = append(t.Indexes, index)
 		t.indexMutex.Unlock()
-		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, countUsage, forceBuild, exactMain, callback)
+		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, selected, callback)
 		return
 	}
 
 	// otherwise: iterate over all items in batches
+	if selected != nil {
+		selected(nil, false)
+	}
 	bufN := 0
 	for i := uint32(0); i < t.main_count; i++ {
 		buf[bufN] = i
@@ -555,6 +683,9 @@ func snapshotIndexesForRebuild(indexes []*StorageIndex) []*StorageIndex {
 		clone.ColMapCols = idx.ColMapCols   // shallow copy OK (immutable per-col slices)
 		clone.ColMapFn = idx.ColMapFn       // shallow copy OK
 		clone.ColMatchers = idx.ColMatchers // shallow copy OK (singletons)
+		clone.ColOrder = append([]func(...scm.Scmer) scm.Scmer(nil), idx.ColOrder...)
+		clone.ColOrderMeta = append([]string(nil), idx.ColOrderMeta...)
+		clone.ColOrderFast = append([]func(scm.Scmer, scm.Scmer) bool(nil), idx.ColOrderFast...)
 		clone.Savings = idx.Savings * 0.9
 		clone.baseState.active = false
 		candidates = append(candidates, clone)
@@ -592,6 +723,11 @@ func rebuildIndexes(candidates []*StorageIndex, t2 *storageShard) {
 			isPrefix := true
 			for k := 0; k < len(shorter.Cols); k++ {
 				if shorter.Cols[k] != longer.Cols[k] {
+					isPrefix = false
+					break
+				}
+				if len(shorter.ColOrder) <= k || len(longer.ColOrder) <= k ||
+					!sameOrderRelation(shorter.ColOrder[k], longer.ColOrder[k]) {
 					isPrefix = false
 					break
 				}
@@ -669,6 +805,16 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 	if !s.Native {
 		// main storage: build sort-order index
 		tmp := make([]uint32, s.t.main_count)
+		relations := make([]func(scm.Scmer, scm.Scmer) bool, len(cols))
+		for i := range relations {
+			if i < len(s.ColOrderFast) && s.ColOrderFast[i] != nil {
+				relations[i] = s.ColOrderFast[i]
+			} else if i < len(s.ColOrder) && s.ColOrder[i] != nil {
+				relations[i] = scm.OrderRelationLess(s.ColOrder[i])
+			} else {
+				relations[i] = scm.Less
+			}
+		}
 		for i := uint32(0); i < s.t.main_count; i++ {
 			tmp[i] = i // fill with natural order
 		}
@@ -681,9 +827,9 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 				}
 				va := g.get(a)
 				vb := g.get(b)
-				if scm.Less(va, vb) {
+				if relations[colIdx](va, vb) {
 					return true // less
-				} else if !scm.Equal(va, vb) {
+				} else if relations[colIdx](vb, va) {
 					return false // greater
 				}
 				// otherwise: next iteration
@@ -741,9 +887,9 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 				av = s.getDeltaColValue(a.data, colIdx)
 				bv = s.getDeltaColValue(b.data, colIdx)
 			}
-			if scm.Less(av, bv) {
+			if s.lessAt(colIdx, av, bv) {
 				return true // less
-			} else if !scm.Equal(av, bv) {
+			} else if s.lessAt(colIdx, bv, av) {
 				return false // greater
 			}
 			// otherwise: next iteration
@@ -852,7 +998,7 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sy
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, countUsage bool, forceBuild bool, exactMain *bool, callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -863,14 +1009,17 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 	state := s.stateForTx(tx, true)
 	// no collation-specific helpers in the current implementation
 
-	savings_threshold := 2.0 // building an index costs 1x the time as traversing the list
-	if countUsage {
-		s.Savings = s.Savings + 1.0 // mark that a real query could save time
+	savingsThreshold := 2.0 // building an index costs 1x the time as traversing the list
+	if usageWeight > 0 {
+		s.Savings += usageWeight
 	}
 	if !state.active {
 		// index is not built yet
-		if s.Savings < savings_threshold && !forceBuild {
+		if s.Savings < savingsThreshold && !forceBuild {
 			// iterate over all items because we don't want to store the index
+			if selected != nil {
+				selected(s, false)
+			}
 			s.fullScan(maxInsertIndex, buf, callback)
 			return
 		} else {
@@ -879,6 +1028,9 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 			// Falling back to a single full scan keeps progress while another
 			// goroutine builds or updates this index.
 			if !s.mu.TryLock() {
+				if selected != nil {
+					selected(s, false)
+				}
 				s.fullScan(maxInsertIndex, buf, callback)
 				return
 			}
@@ -899,12 +1051,18 @@ start_scan:
 	// indexCleanup, which may set active=false / mainIndexes={} / deltaBtree=nil
 	// concurrently. The snapshot keeps the backing data alive via GC references.
 	if !s.mu.TryLock() {
+		if selected != nil {
+			selected(s, false)
+		}
 		s.fullScan(maxInsertIndex, buf, callback)
 		return
 	}
 	if !state.active {
 		// Index was evicted between our initial check and here.
 		s.mu.Unlock()
+		if selected != nil {
+			selected(s, false)
+		}
 		s.fullScan(maxInsertIndex, buf, callback)
 		return
 	}
@@ -916,6 +1074,9 @@ start_scan:
 	snapSkipLists := state.skipLists
 	isNative := s.Native
 	s.mu.Unlock()
+	if selected != nil {
+		selected(s, true)
+	}
 
 	// record-ID lookup: identity when data is physically sorted (Native), index dereference otherwise
 	getRecid := func(idx int) uint32 {
@@ -970,27 +1131,32 @@ start_scan:
 	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !lower[firstSorted].IsNil() {
 		hintVal := cols[firstSorted].get(getRecid(hint))
 		if !hintVal.IsNil() {
-			if scm.Less(hintVal, lower[firstSorted]) {
+			if s.compareAt(firstSorted, hintVal, lower[firstSorted]) < 0 {
 				searchLo = hint
 				searchN -= hint
-			} else if scm.Less(lower[firstSorted], hintVal) {
+			} else if s.compareAt(firstSorted, lower[firstSorted], hintVal) < 0 {
 				searchN = hint + 1
 			}
 		}
 	}
-	// Interpolation search: estimate position from first sorted column's
-	// min/max, then binary search for exact multi-column position.
-	var interpMin, interpMax scm.Scmer
-	if firstSorted >= 0 && len(state.minVals) > firstSorted && !lower[firstSorted].IsNil() {
-		interpMin = state.minVals[firstSorted]
-		interpMax = state.maxVals[firstSorted]
-	}
 	mainIdx := 0
-	if firstSorted >= 0 {
-		mainIdx = interpolationSearch(searchLo, searchN, lower[firstSorted], interpMin, interpMax,
-			func(idx int) scm.Scmer {
-				return cols[firstSorted].get(getRecid(idx))
+	if firstSorted >= 0 && !lower[firstSorted].IsNil() {
+		if s.usesNaturalAscendingOrder(firstSorted) {
+			var interpMin, interpMax scm.Scmer
+			if len(state.minVals) > firstSorted {
+				interpMin = state.minVals[firstSorted]
+				interpMax = state.maxVals[firstSorted]
+			}
+			mainIdx = interpolationSearch(searchLo, searchN, lower[firstSorted], interpMin, interpMax,
+				func(idx int) scm.Scmer {
+					return cols[firstSorted].get(getRecid(idx))
+				})
+		} else {
+			mainIdx = searchLo + sort.Search(searchN, func(idx int) bool {
+				value := cols[firstSorted].get(getRecid(searchLo + idx))
+				return s.compareAt(firstSorted, value, lower[firstSorted]) >= 0
 			})
+		}
 	}
 	s.lastHit.Store(uint32(mainIdx))
 	// skip past equal values when lower bound is exclusive (col > 5)
@@ -999,7 +1165,7 @@ start_scan:
 	if !lowerInclusive && !lastHasMatcher && cmpCols > 0 && !lower[cmpCols-1].IsNil() {
 		for uint32(mainIdx) < s.t.main_count {
 			recid := getRecid(mainIdx)
-			if !scm.Equal(cols[cmpCols-1].get(recid), lower[cmpCols-1]) {
+			if s.compareAt(cmpCols-1, cols[cmpCols-1].get(recid), lower[cmpCols-1]) != 0 {
 				break
 			}
 			mainIdx++
@@ -1052,7 +1218,7 @@ start_scan:
 			}
 			recid := getRecid(mainIdx)
 			mainIdx++
-			inRange, beyond := s.rowWithinBounds(cmpCols, lower, upperLast, upperInclusive, func(i int) scm.Scmer {
+			inRange, beyond := s.rowWithinBounds(bounds, cmpCols, lower, upperLast, upperInclusive, func(i int) scm.Scmer {
 				return cols[i].get(recid)
 			})
 			if inRange {
@@ -1104,7 +1270,7 @@ start_scan:
 			if recid < s.t.main_count || p.itemid-int(s.t.main_count) >= maxInsertIndex {
 				return true
 			}
-			inRange, beyond := s.rowWithinBounds(cmpCols, lower, upperLast, upperInclusive, func(i int) scm.Scmer {
+			inRange, beyond := s.rowWithinBounds(bounds, cmpCols, lower, upperLast, upperInclusive, func(i int) scm.Scmer {
 				if state.precomputedDelta {
 					return p.data[i]
 				}
@@ -1134,7 +1300,7 @@ start_scan:
 		// don't map to sort order), so scan all.
 		hasUnsearchableInBounds := state.precomputedDelta
 		for i := 0; i < cmpCols; i++ {
-			if (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (len(bounds) > i && !bounds[i].matcher.IsSorted()) {
+			if lower[i].IsNil() || (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (len(bounds) > i && !bounds[i].matcher.IsSorted()) {
 				hasUnsearchableInBounds = true
 				break
 			}

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -40,7 +40,7 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	lower, upperLast := indexFromBoundaries(bounds)
 	var buf [8]uint32
 	shard.mu.RLock()
-	shard.iterateIndex(nil, bounds, lower, upperLast, len(shard.inserts), buf[:], false, func(batch []uint32) bool {
+	shard.iterateIndex(nil, bounds, lower, upperLast, len(shard.inserts), buf[:], 0, nil, func(batch []uint32) bool {
 		return true
 	})
 	shard.mu.RUnlock()

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1226,12 +1226,6 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
-	defaultSortDir := func(args ...scm.Scmer) scm.Scmer {
-		if len(args) < 2 {
-			return scm.NewBool(false)
-		}
-		return scm.NewBool(scm.Less(args[0], args[1]))
-	}
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 
 	result.scols = make([]func(uint32) scm.Scmer, len(sortcols))
@@ -1278,12 +1272,16 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 		panic("unknown sort criteria: " + scm.String(scol))
 	}
 	result.sortdirs = make([]func(...scm.Scmer) scm.Scmer, len(sortcols))
+	result.sortless = make([]func(scm.Scmer, scm.Scmer) bool, len(sortcols))
+	defaultOrder := scm.OptimizeProcToSerialFunction(scm.Apply(
+		scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString("bin"), scm.NewBool(false)))
 	for i := range sortcols {
 		if i < len(sortdirs) && sortdirs[i] != nil {
-			result.sortdirs[i] = wrapScanOrderComparator(sortdirs[i])
+			result.sortdirs[i] = sortdirs[i]
 		} else {
-			result.sortdirs[i] = wrapScanOrderComparator(defaultSortDir)
+			result.sortdirs[i] = defaultOrder
 		}
+		result.sortless[i] = scm.OrderRelationLess(result.sortdirs[i])
 	}
 
 	t.ensureLoaded()

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -744,7 +744,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	var foundID uint32
 
 	var buf [8]uint32
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}
@@ -917,7 +917,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	buf := make([]uint32, t.t.scanBufferSize(boundaries))
 	hadValue := false
 
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, true, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		candidateCount += int64(len(batch))
 		// filter in-place: overwrite batch with passing IDs
 		outN := 0
@@ -1178,7 +1178,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 			activeLower, activeUpperLast = indexFromBoundaries(activeBoundaries)
 		}
 
-		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))
 			outN := 0
 			for _, idx := range batch {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
+import "math"
 import "sort"
 import "sync"
 import "github.com/carli2/hybridsort"
@@ -25,41 +26,6 @@ import "strings"
 import "runtime/debug"
 import "container/heap"
 import "github.com/launix-de/memcp/scm"
-
-// wrapScanOrderComparator adds SQL NULL positioning around the comparator
-// supplied to scan_order. The comparator itself only sees non-NULL values:
-// ascending order puts NULL first, descending order puts NULL last.
-func wrapScanOrderComparator(compare func(...scm.Scmer) scm.Scmer) func(...scm.Scmer) scm.Scmer {
-	descending := false
-	if decl := scm.DeclarationForValue(scm.NewFunc(compare)); decl != nil && (decl.Name == "<" || decl.Name == ">") {
-		descending = decl.Name == ">"
-	} else if _, reverse, ok := scm.LookupCollate(compare); ok {
-		descending = reverse
-	} else {
-		// User callbacks can be type-specific. Direction probing must not make a
-		// valid string/date comparator fail before it sees actual input values.
-		func() {
-			defer func() { _ = recover() }()
-			ascendingProbe := scm.ToBool(compare(scm.NewInt(1), scm.NewInt(2)))
-			descendingProbe := scm.ToBool(compare(scm.NewInt(2), scm.NewInt(1)))
-			descending = !ascendingProbe && descendingProbe
-		}()
-	}
-	return func(args ...scm.Scmer) scm.Scmer {
-		if len(args) < 2 {
-			return scm.NewBool(false)
-		}
-		leftNil := args[0].IsNil()
-		rightNil := args[1].IsNil()
-		if leftNil || rightNil {
-			if leftNil && rightNil {
-				return scm.NewBool(false)
-			}
-			return scm.NewBool(leftNil != descending)
-		}
-		return compare(args...)
-	}
-}
 
 func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
 	// scan_order_multi args: 0=fn, 1=tx, 2=tables, 3=filterCols, 4=filterFns,
@@ -176,6 +142,7 @@ type shardqueue struct {
 	err            scanError
 	scols          []func(uint32) scm.Scmer // sort criteria column reader
 	sortdirs       []func(...scm.Scmer) scm.Scmer
+	sortless       []func(scm.Scmer, scm.Scmer) bool
 	mapper         *ShardMapReducer
 	callbackCols   []string  // per-table map columns (for multi-table merge)
 	callback       scm.Scmer // per-table map function (for multi-table merge)
@@ -208,15 +175,15 @@ func (s *shardqueue) Less(i, j int) bool {
 		return i < j
 	}
 	cmpCount := len(s.scols)
-	if len(s.sortdirs) < cmpCount {
-		cmpCount = len(s.sortdirs)
+	if len(s.sortless) < cmpCount {
+		cmpCount = len(s.sortless)
 	}
 	for c := 0; c < cmpCount; c++ {
 		a := s.scols[c](s.items[i])
 		b := s.scols[c](s.items[j])
-		if scm.ToBool(s.sortdirs[c](a, b)) {
+		if s.sortless[c](a, b) {
 			return true
-		} else if scm.ToBool(s.sortdirs[c](b, a)) {
+		} else if s.sortless[c](b, a) {
 			return false
 		} // else: go to next level
 		// otherwise: move on to c++
@@ -278,18 +245,18 @@ func (s *globalqueue) Less(i, j int) bool {
 	if len(s.q[j].scols) < cmpCount {
 		cmpCount = len(s.q[j].scols)
 	}
-	if len(s.q[i].sortdirs) < cmpCount {
-		cmpCount = len(s.q[i].sortdirs)
+	if len(s.q[i].sortless) < cmpCount {
+		cmpCount = len(s.q[i].sortless)
 	}
-	if len(s.q[j].sortdirs) < cmpCount {
-		cmpCount = len(s.q[j].sortdirs)
+	if len(s.q[j].sortless) < cmpCount {
+		cmpCount = len(s.q[j].sortless)
 	}
 	for c := 0; c < cmpCount; c++ {
 		a := s.q[i].scols[c](s.q[i].items[0])
 		b := s.q[j].scols[c](s.q[j].items[0])
-		if scm.ToBool(s.q[i].sortdirs[c](a, b)) {
+		if s.q[i].sortless[c](a, b) {
 			return true
-		} else if scm.ToBool(s.q[i].sortdirs[c](b, a)) {
+		} else if s.q[i].sortless[c](b, a) {
 			return false
 		} // else: go to next level
 		// otherwise: move on to c++
@@ -366,10 +333,9 @@ func (s *scanOrderTableSpec) backingTable() *table {
 	return s.table
 }
 
-// extendBoundariesWithSortCols appends sort columns to the boundaries when all
-// existing filter boundaries are point lookups and the comparators are
-// index-order compatible (ASC). This lets the shard return rows already sorted
-// by ORDER BY, reducing the cross-shard merge to merging pre-sorted runs.
+// extendBoundariesWithSortCols appends sort columns and their order relations
+// when all existing filter boundaries are point lookups. The relation callback
+// is the complete ordering contract, including collation, direction and NULLs.
 func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) (boundaries, bool) {
 	original := b
 	allEq := true
@@ -379,33 +345,15 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 			break
 		}
 	}
-	canAppendSortPrefix := len(sortcols) > 0
-	for i := range sortcols {
-		if i >= len(sortdirs) || sortdirs[i] == nil {
-			continue // default ASC
-		}
-		asc := false
-		probeOK := true
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					probeOK = false
-				}
-			}()
-			if scm.ToBool(sortdirs[i](scm.NewInt(1), scm.NewInt(2))) &&
-				!scm.ToBool(sortdirs[i](scm.NewInt(2), scm.NewInt(1))) {
-				asc = true
-			}
-		}()
-		if !probeOK || !asc {
-			canAppendSortPrefix = false
-			break
-		}
-	}
+	canAppendSortPrefix := len(sortcols) > 0 && len(sortdirs) >= len(sortcols)
 	if !allEq || !canAppendSortPrefix {
 		return b, false
 	}
-	for _, scol := range sortcols {
+	for i, scol := range sortcols {
+		if sortdirs[i] == nil {
+			return original, false
+		}
+		orderMeta := orderRelationMeta(sortdirs[i])
 		if scol.IsString() {
 			col := scol.String()
 			already := false
@@ -416,7 +364,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 				}
 			}
 			if !already {
-				b = append(b, columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil()})
+				b = append(b, columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta})
 			}
 			continue
 		}
@@ -459,10 +407,48 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 			}
 		}
 		if !already {
-			b = append(b, columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), mapCols: mc, mapFn: mf})
+			b = append(b, columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta, mapCols: mc, mapFn: mf})
 		}
 	}
 	return b, len(sortcols) > 0
+}
+
+func indexCoversBoundaryOrder(index *StorageIndex, active bool, bounds boundaries, effectiveCols int) bool {
+	if !active || index == nil {
+		return false
+	}
+	orderCols := 0
+	for i, boundary := range bounds {
+		if boundary.order == nil || boundaryIsPoint(boundary) {
+			continue
+		}
+		orderCols++
+		if i >= effectiveCols || i >= len(index.Cols) || i >= len(index.ColOrder) {
+			return false
+		}
+		if index.Cols[i] != boundary.col || !sameOrderRelation(index.ColOrder[i], boundary.order) {
+			return false
+		}
+	}
+	return orderCols > 0
+}
+
+// orderedIndexUsageWeight estimates how much of one full scan an ordered
+// index would save. Building the permutation costs O(n log n), while an
+// unindexed Top-k scan costs O(n log k). Savings therefore accumulate slowly
+// for tiny windows and at the normal rate for large offsets or full scans.
+func orderedIndexUsageWeight(rows, kept int) float64 {
+	if rows <= 1 || kept < 0 || kept >= rows {
+		return 1
+	}
+	if kept < 1 {
+		kept = 1
+	}
+	weight := 2 * math.Max(1, math.Log2(float64(kept)+1)) / math.Log2(float64(rows)+1)
+	if weight > 1 {
+		return 1
+	}
+	return weight
 }
 
 func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
@@ -570,7 +556,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		bounds := extractBoundaries(spec.conditionCols, spec.condition)
 		bounds, recsetBoundary := splitRecSetBoundary(bounds, t)
 		reorderByFrequency(bounds, t)
-		bounds, indexCoversOrder := extendBoundariesWithSortCols(bounds, spec.sortcols, sortdirs)
+		bounds, _ = extendBoundariesWithSortCols(bounds, spec.sortcols, sortdirs)
 		lower, upperLast := indexFromBoundaries(bounds)
 
 		if Settings.ScanDebugging {
@@ -598,7 +584,6 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		tableBounds := bounds
 		tableIdx := ti
 		shardLimit := shardTotalLimit
-		orderedEarlyLimit := indexCoversOrder && shardLimit >= 0 && limitPartitionCols == 0
 		recsetFilter := recsetBoundary
 
 		if spec.recset != nil {
@@ -683,7 +668,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, orderedEarlyLimit, recsetFilter)
+				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss, recsetFilter)
 				res.callbackCols = callbackCols
 				res.callback = callback
 				res.tableIdx = tableIdx
@@ -1038,7 +1023,7 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, orderedEarlyLimit bool, recsetFilter *recSet) (result *shardqueue) {
+func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState, recsetFilter *recSet) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	if ss == nil {
@@ -1053,13 +1038,6 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
-	defaultSortDir := func(args ...scm.Scmer) scm.Scmer {
-		if len(args) < 2 {
-			return scm.NewBool(false)
-		}
-		return scm.NewBool(scm.Less(args[0], args[1]))
-	}
-
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 
 	// prepare filter function
@@ -1114,75 +1092,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		panic("unknown sort criteria: " + scm.String(scol))
 	}
 
-	// If a sort column has a column-level collation and sortdir is the default < or >,
-	// replace the comparator with the appropriate collator-based comparator to honor
-	// column collation without explicit ORDER BY COLLATE.
-	// Build an adjusted sortdirs slice for this scan.
-	adjustedSortdirs := make([]func(...scm.Scmer) scm.Scmer, len(sortcols))
-	for i := range sortcols {
-		dir := defaultSortDir
-		if i < len(sortdirs) && sortdirs[i] != nil {
-			dir = sortdirs[i]
-		}
-		adjustedSortdirs[i] = dir
-		colname := ""
-		if sortcols[i].IsString() {
-			colname = sortcols[i].String()
-		} else if sym, ok := sortcols[i].Any().(scm.Symbol); ok {
-			colname = string(sym)
-		} else {
-			continue
-		}
-		// find column definition
-		coll := ""
-		for _, c := range t.t.Columns {
-			if c.Name == colname {
-				coll = c.Collation
-				break
-			}
-		}
-		if coll == "" {
-			continue
-		}
-		// Only actionable collations: those with a language suffix or explicit 'bin'.
-		if !(strings.Contains(coll, "_") || strings.EqualFold(coll, "bin")) {
-			continue
-		}
-		// If sortdirs[i] already is a collate closure, respect it (explicit ORDER BY COLLATE)
-		if _, _, isCollate := scm.LookupCollate(sortdirs[i]); isCollate {
-			continue
-		}
-		// Derive reverse flag by probing comparator semantics (robust across pointer differences).
-		// Keep panic recovery strictly local to this probe: a function-wide defer-recover
-		// here would swallow unrelated panics from scan/filter/map and surface as empty
-		// result sets instead of proper SQL errors.
-		reverse := false // ASC by default
-		probeOK := true
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					probeOK = false
-				}
-			}()
-			// If dir(1,2) is true, comparator behaves like '<' (ASC) -> reverse=false
-			// Else if dir(2,1) is true, comparator behaves like '>' (DESC) -> reverse=true
-			if res := dir(scm.NewInt(1), scm.NewInt(2)); scm.ToBool(res) {
-				reverse = false
-			} else if res2 := dir(scm.NewInt(2), scm.NewInt(1)); scm.ToBool(res2) {
-				reverse = true
-			}
-		}()
-		if !probeOK {
-			continue
-		}
-		// Build comparator via (collate coll reverse?)
-		cmpScm := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString(coll), scm.NewBool(reverse))
-		cmpFn := scm.OptimizeProcToSerialFunction(cmpScm)
-		adjustedSortdirs[i] = cmpFn
-	}
-	for i := range adjustedSortdirs {
-		adjustedSortdirs[i] = wrapScanOrderComparator(adjustedSortdirs[i])
-	}
+	adjustedSortdirs := sortdirs
 
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	if t.t.hasTableLock() {
@@ -1217,6 +1127,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	// scan loop in read lock
 	var maxInsertIndex int
 	var visibleUpper uint32
+	resultAlreadySorted := false
 	func() {
 		shardLocked := false
 		if !skipShardReadLock {
@@ -1247,7 +1158,10 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		resultCap := 1024
 		result.items = make([]uint32, resultCap)
 		resultN := 0
-		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		usageWeight := orderedIndexUsageWeight(int(visibleUpper), limit)
+		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, func(index *StorageIndex, active bool) {
+			resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
+		}, func(batch []uint32) bool {
 			result.candidateCount += int64(len(batch))
 			// filter in-place: overwrite batch with passing IDs
 			outN := 0
@@ -1310,7 +1224,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			}
 			copy(result.items[resultN:], batch[:outN])
 			resultN += outN
-			if orderedEarlyLimit && resultN >= limit {
+			if resultAlreadySorted && limit >= 0 && limitPartitionCols == 0 && resultN >= limit {
 				return false
 			}
 			return true
@@ -1320,6 +1234,10 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 
 	// and now sort result!
 	result.sortdirs = adjustedSortdirs
+	result.sortless = make([]func(scm.Scmer, scm.Scmer) bool, len(adjustedSortdirs))
+	for i, relation := range adjustedSortdirs {
+		result.sortless[i] = scm.OrderRelationLess(relation)
+	}
 	itemPos := make(map[uint32]int, len(result.items))
 	for i, idx := range result.items {
 		itemPos[idx] = i
@@ -1341,16 +1259,16 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	}
 	lessByID := func(a, b uint32) bool {
 		cmpCount := len(result.scols)
-		if len(result.sortdirs) < cmpCount {
-			cmpCount = len(result.sortdirs)
+		if len(result.sortless) < cmpCount {
+			cmpCount = len(result.sortless)
 		}
 		for c := 0; c < cmpCount; c++ {
 			av := result.scols[c](a)
 			bv := result.scols[c](b)
-			if scm.ToBool(result.sortdirs[c](av, bv)) {
+			if result.sortless[c](av, bv) {
 				return true
 			}
-			if scm.ToBool(result.sortdirs[c](bv, av)) {
+			if result.sortless[c](bv, av) {
 				return false
 			}
 		}
@@ -1370,7 +1288,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	//    order matches ORDER BY and there are no deltas, the sort is free.
 	// When these conditions are met, the same knowledge could also be
 	// used to exit early during iterateIndex (stop after OFFSET+LIMIT).
-	if len(sortcols) > 0 {
+	if len(sortcols) > 0 && !resultAlreadySorted {
 		if limit >= 0 && limitPartitionCols == 0 {
 			// ORDER BY ... LIMIT only needs the best k rows from each shard.
 			// Keeping all matching rows and fully sorting them makes small-LIMIT

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2425,7 +2425,7 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	// Use iterateIndex for O(log n) lookup (builds index lazily if needed)
 	// Small buffer for existence check: stop early after first match
 	var buf [8]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], true, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 1, nil, func(batch []uint32) bool {
 		for _, idx := range batch {
 			// Verify all columns match (iterateIndex may return superset for range boundaries)
 			matched := true
@@ -2519,7 +2519,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var buf [256]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], false, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, nil, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if recsetPart != nil && !recsetPart.contains(idx) {
 				continue
@@ -2914,9 +2914,8 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 					sortPerm = append(sortPerm, mainCount+uint32(i))
 				}
 			}
-			idxCols := idx.Cols
 			hybridsort.HybridSort(sortPerm, func(idA, idB uint32) bool {
-				for _, colName := range idxCols {
+				for colIdx, colName := range idx.Cols {
 					var va, vb scm.Scmer
 					if idA < mainCount {
 						va = columnSnapshot[colName].GetValue(idA)
@@ -2928,10 +2927,10 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 					} else {
 						vb = getDelta(int(idB-mainCount), colName)
 					}
-					if scm.Less(va, vb) {
+					if idx.lessAt(colIdx, va, vb) {
 						return true
 					}
-					if scm.Less(vb, va) {
+					if idx.lessAt(colIdx, vb, va) {
 						return false
 					}
 				}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2724,8 +2724,13 @@ func Init(en scm.Env) {
 						colRows = scm.NewSlice(colSlice)
 						idxSlice := make([]scm.Scmer, 0, len(s.Indexes))
 						for _, ix := range s.Indexes {
+							orders := make([]scm.Scmer, len(ix.ColOrderMeta))
+							for i, order := range ix.ColOrderMeta {
+								orders[i] = scm.NewString(order)
+							}
 							idxSlice = append(idxSlice, scm.NewSlice([]scm.Scmer{
 								scm.NewString("cols"), scm.NewString(ix.String()),
+								scm.NewString("orders"), scm.NewSlice(orders),
 								scm.NewString("active"), scm.NewBool(ix.baseState.active),
 								scm.NewString("native"), scm.NewBool(ix.Native),
 								scm.NewString("savings"), scm.NewFloat(ix.Savings),

--- a/tests/planner/set-operations/union-all.yaml
+++ b/tests/planner/set-operations/union-all.yaml
@@ -24,6 +24,8 @@ metadata:
 setup:
   - sql: "DROP TABLE IF EXISTS renderjob"
   - sql: "DROP TABLE IF EXISTS ua_fop_files"
+  - sql: "DROP TABLE IF EXISTS ua_order_a"
+  - sql: "DROP TABLE IF EXISTS ua_order_b"
   - sql: |
       CREATE TABLE ua_fop_files (
         ID INT PRIMARY KEY,
@@ -41,6 +43,10 @@ setup:
   - sql: |
       INSERT INTO renderjob (ID, result) VALUES
       (101, 1), (102, 3), (103, 3)
+  - sql: "CREATE TABLE ua_order_a (value VARCHAR(20) COLLATE utf8mb4_unicode_ci)"
+  - sql: "CREATE TABLE ua_order_b (value VARCHAR(20) COLLATE utf8mb4_unicode_ci)"
+  - sql: "INSERT INTO ua_order_a VALUES (NULL), ('beta')"
+  - sql: "INSERT INTO ua_order_b VALUES ('alpha'), (NULL)"
 
 test_cases:
 
@@ -257,6 +263,32 @@ test_cases:
         - name: "image3.png"
         - name: "image4.png"
         - name: "image5.png"
+
+  - name: "UNION ALL shared ASC relation puts NULL first"
+    sql: |
+      SELECT value FROM ua_order_a
+      UNION ALL
+      SELECT value FROM ua_order_b
+      ORDER BY value ASC
+    expect:
+      data:
+        - value: null
+        - value: null
+        - value: "alpha"
+        - value: "beta"
+
+  - name: "UNION ALL shared DESC relation puts NULL last"
+    sql: |
+      SELECT value FROM ua_order_a
+      UNION ALL
+      SELECT value FROM ua_order_b
+      ORDER BY value DESC
+    expect:
+      data:
+        - value: "beta"
+        - value: "alpha"
+        - value: null
+        - value: null
 
   - name: "EXPLAIN UNION ALL ORDER BY uses scan_order_multi"
     sql: |
@@ -560,3 +592,5 @@ test_cases:
 cleanup:
   - sql: "DROP TABLE IF EXISTS renderjob"
   - sql: "DROP TABLE IF EXISTS ua_fop_files"
+  - sql: "DROP TABLE IF EXISTS ua_order_a"
+  - sql: "DROP TABLE IF EXISTS ua_order_b"

--- a/tests/storage/indexes/index-prefix-dedup.yaml
+++ b/tests/storage/indexes/index-prefix-dedup.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 # Tests for index prefix deduplication:
 # 1. iterateIndex() reuses existing longer indexes instead of creating shorter ones
 # 2. rebuildIndexes() transfers indexes across rebuild with savings decay
@@ -323,7 +326,198 @@ test_cases:
     expect:
       rows: 1
 
+  # ==============================================================
+  # Phase 5: Ordered auto indexes retain the complete sort relation
+  # ==============================================================
+
+  - name: "Setup ordered relation index table"
+    setup:
+      - sql: "DROP TABLE IF EXISTS idx_order_relation"
+      - scm: "(rebuild)"
+    sql: |
+      CREATE TABLE idx_order_relation (
+        id INT,
+        tenant INT,
+        label VARCHAR(40) COLLATE utf8mb4_unicode_ci
+      )
+
+  - name: "Insert deliberately unordered collated rows"
+    setup:
+      - sql: |
+          INSERT INTO idx_order_relation VALUES
+            (1, 1, 'Zulu'),
+            (2, 1, NULL),
+            (3, 1, 'apple'),
+            (4, 1, 'Banana'),
+            (5, 1, 'apricot'),
+            (6, 1, 'cherry'),
+            (7, 2, 'aardvark'),
+            (8, 2, NULL)
+      - scm: "(rebuild)"
+    sql: "SELECT COUNT(*) AS cnt FROM idx_order_relation"
+    expect:
+      data:
+        - cnt: 8
+
+  - name: "Cold collated ASC index preserves NULL order before LIMIT"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label ASC LIMIT 3"
+    expect:
+      rows: 3
+      data:
+        - id: 2
+          label: null
+        - id: 3
+          label: "apple"
+        - id: 5
+          label: "apricot"
+
+  - name: "Warm collated ASC index preserves NULL order before LIMIT"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label ASC LIMIT 3"
+    expect:
+      rows: 3
+      data:
+        - id: 2
+          label: null
+        - id: 3
+          label: "apple"
+        - id: 5
+          label: "apricot"
+
+  - name: "Collated DESC uses its own relation and puts NULL last"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label DESC LIMIT 3"
+    expect:
+      rows: 3
+      data:
+        - id: 1
+          label: "Zulu"
+        - id: 6
+          label: "cherry"
+        - id: 4
+          label: "Banana"
+
+  - name: "Warm collated DESC relation remains stable"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label DESC LIMIT 3"
+    expect:
+      rows: 3
+      data:
+        - id: 1
+          label: "Zulu"
+        - id: 6
+          label: "cherry"
+        - id: 4
+          label: "Banana"
+
+  - name: "Delta rows merge through the stored DESC relation"
+    setup:
+      - sql: |
+          INSERT INTO idx_order_relation VALUES
+            (10, 1, 'apple'),
+            (11, 1, NULL)
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label DESC LIMIT 3"
+    expect:
+      data:
+        - id: 1
+          label: "Zulu"
+        - id: 6
+          label: "cherry"
+        - id: 4
+          label: "Banana"
+
+  - name: "Cold mixed ASC DESC order keeps NULL ties deterministic"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label ASC, id DESC LIMIT 4"
+    expect:
+      data:
+        - id: 11
+          label: null
+        - id: 2
+          label: null
+        - id: 10
+          label: "apple"
+        - id: 3
+          label: "apple"
+
+  - name: "Warm mixed ASC DESC index keeps NULL ties deterministic"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label ASC, id DESC LIMIT 4"
+    expect:
+      data:
+        - id: 11
+          label: null
+        - id: 2
+          label: null
+        - id: 10
+          label: "apple"
+        - id: 3
+          label: "apple"
+
+  - name: "Unfiltered DESC uses NULL-last semantics"
+    sql: "SELECT id, label FROM idx_order_relation ORDER BY label DESC LIMIT 3"
+    expect:
+      data:
+        - id: 7
+          label: "aardvark"
+        - id: 1
+          label: "Zulu"
+        - id: 6
+          label: "cherry"
+
+  - name: "ASC and DESC auto indexes retain distinct order metadata"
+    scm: |
+      (begin
+        (define indexes ((show "memcp-tests" "idx_order_relation" 0 true) "indexes"))
+        (define asc_count (reduce indexes (lambda (n index)
+          (begin
+            (define orders (get_assoc index "orders"))
+            (if (and (>= (count orders) 2)
+                (equal? (nth orders 0) "utf8mb4:asc")
+                (equal? (nth orders 1) "utf8mb4_unicode_ci:asc")) (+ n 1) n))) 0))
+        (define desc_count (reduce indexes (lambda (n index)
+          (begin
+            (define orders (get_assoc index "orders"))
+            (if (and (>= (count orders) 2)
+                (equal? (nth orders 0) "utf8mb4:asc")
+                (equal? (nth orders 1) "utf8mb4_unicode_ci:desc")) (+ n 1) n))) 0))
+        (if (and (> asc_count 0) (> desc_count 0))
+          "ok"
+          (error (concat "expected separate ASC/DESC relation indexes, got " (serialize indexes)))))
+
+  - name: "Rebuild preserves ordered relation identity"
+    setup:
+      - sql: "INSERT INTO idx_order_relation VALUES (9, 1, 'blueberry')"
+      - scm: "(rebuild)"
+    scm: |
+      (begin
+        (define indexes ((show "memcp-tests" "idx_order_relation" 0 true) "indexes"))
+        (define asc_count (reduce indexes (lambda (n index)
+          (begin
+            (define orders (get_assoc index "orders"))
+            (if (and (>= (count orders) 2)
+                (equal? (nth orders 0) "utf8mb4:asc")
+                (equal? (nth orders 1) "utf8mb4_unicode_ci:asc")) (+ n 1) n))) 0))
+        (define desc_count (reduce indexes (lambda (n index)
+          (begin
+            (define orders (get_assoc index "orders"))
+            (if (and (>= (count orders) 2)
+                (equal? (nth orders 0) "utf8mb4:asc")
+                (equal? (nth orders 1) "utf8mb4_unicode_ci:desc")) (+ n 1) n))) 0))
+        (if (and (> asc_count 0) (> desc_count 0))
+          "ok"
+          (error (concat "ordered relation metadata lost on rebuild: " (serialize indexes)))))
+
+  - name: "Rebuilt mixed relation remains executable"
+    sql: "SELECT id, label FROM idx_order_relation WHERE tenant = 1 ORDER BY label ASC, id DESC LIMIT 4"
+    expect:
+      data:
+        - id: 11
+          label: null
+        - id: 2
+          label: null
+        - id: 10
+          label: "apple"
+        - id: 3
+          label: "apple"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS idx_nopfx"
   - sql: "DROP TABLE IF EXISTS idx_nonoverlap"
+  - sql: "DROP TABLE IF EXISTS idx_order_relation"
   - sql: "DROP TABLE IF EXISTS idx_rev"


### PR DESCRIPTION
## What changed

- make the collation factory the single owner of ASC/DESC and SQL NULL ordering semantics
- cache canonical relation callbacks by collation metadata and direction so callback identity is stable
- lower physical ORDER BY keys to relation callbacks before entering storage
- persist complete per-column relation metadata and callbacks in auto indexes across build, delta merge, and rebuild
- reuse or brake on an ordered index only when the selected active index covers the complete relation
- retain point-prefix plus multi-column ordering and expose stored relation metadata through `SHOW`
- remove runtime comparator probing from `scan_order` and RecSet ordering; derive the fast boolean executor once from the canonical callback
- weight auto-index telemetry by the expected Top-k sorting benefit so tiny limits do not eagerly build an expensive index

## Why

`scan_order` and `scan_order_multi` had diverged: direction was partly encoded outside the ordering relation, storage attempted to infer or wrap callbacks, and auto-index reuse could not reliably distinguish ASC from DESC or preserve collation and NULL semantics. This caused both correctness hazards and missed warm-index performance.

The physical contract is now one callback per sort key. String metadata is retained only so the same canonical callback can be reconstructed after rebuild; the callback remains the executable relation and identity key.

## Validation

- full pre-commit/hook-equivalent suite: passed
- ordered index relation suite: 58/58
- range scan coverage: 99/99
- ordered multishard LIMIT/OFFSET: 40/40
- RecSet: 29/29
- UNION ALL: 38/38
- Scheme formatter/check run; `git diff --check` clean

Added SQL coverage for cold/warm ASC and DESC, MySQL NULL positioning, collation-aware strings, delta merge, mixed-direction ties, unfiltered order, relation identity after rebuild, and ordered UNION branches.

## A/B benchmark

An anonymized 200,000-row, 64-tenant payload used `utf8mb4_unicode_ci`, NULL values, and `ORDER BY ... LIMIT 72`; two setup executions and seven warm samples were measured with identical builds and fresh data directories.

| Shape | master median | PR median | warm speedup |
|---|---:|---:|---:|
| ASC | 38.44 ms | 5.10 ms | 7.5x |
| DESC | 38.78 ms | 4.06 ms | 9.6x |

All benchmark responses contained the expected 20 rows. Building the correct ordered index once costs about 3.8 s for 200,000 rows. The new weighted usage telemetry deliberately pays that cost only when repeated Top-k work makes it beneficial; warm execution then uses the preserved relation directly.
