### PR TITLE
Reuse plans for nested SELECT pagination

### DIFF
--- a/scm/sql_literals.go
+++ b/scm/sql_literals.go
@@ -25,6 +25,13 @@ type sqlShapeBuilder struct {
 	hash uint64
 }
 
+type sqlSelectScope struct {
+	depth      int
+	clause     string
+	orderDepth int
+	unsafe     bool
+}
+
 func newSQLShapeBuilder(capacity int) *sqlShapeBuilder {
 	result := &sqlShapeBuilder{hash: fnv64Offset}
 	result.text.Grow(capacity)
@@ -72,11 +79,10 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 	bindings := make([]Scmer, 0, 8)
 	depth := 0
 	typeDepth := -1
-	orderDepth := -1
 	previousWord := ""
 	previousToken := ""
-	seenSelect := false
-	clause := ""
+	structuralQuery := false
+	selectScopes := make([]sqlSelectScope, 0, 4)
 
 	for i := 0; i < len(query); {
 		if isSQLSpace(query[i]) {
@@ -115,7 +121,15 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 		}
 		if query[i] == '\'' || query[i] == '"' {
 			end, ok := scanQuotedSQL(query, i, query[i])
-			if !ok || previousWord == "AS" || previousWord == "DATE" || !parameterizableLiteralClause(clause) {
+			clause := ""
+			scopeDepth := -1
+			if len(selectScopes) > 0 {
+				clause = selectScopes[len(selectScopes)-1].clause
+				scopeDepth = selectScopes[len(selectScopes)-1].depth
+			}
+			parameterizable := parameterizableLiteralAtScope(clause, scopeDepth) ||
+				(scopeDepth > 0 && (previousWord == "LIKE" || previousWord == "AGAINST"))
+			if !ok || previousWord == "AS" || previousWord == "DATE" || !parameterizable {
 				if !ok {
 					return query, nil, fnvHashString(query)
 				}
@@ -139,27 +153,42 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 				end++
 			}
 			word := strings.ToUpper(query[i:end])
+			if word == "OVER" {
+				structuralQuery = true
+			}
 			if word == "SELECT" {
-				if seenSelect {
-					return query, nil, fnvHashString(query)
+				if len(selectScopes) > 0 && selectScopes[len(selectScopes)-1].depth == depth {
+					selectScopes[len(selectScopes)-1].clause = "SELECT"
+					selectScopes[len(selectScopes)-1].orderDepth = -1
+				} else {
+					selectScopes = append(selectScopes, sqlSelectScope{
+						depth:      depth,
+						clause:     "SELECT",
+						orderDepth: -1,
+					})
 				}
-				seenSelect = true
-				clause = "SELECT"
 			}
-			if unsafeParameterizedSelectWord(word) {
-				return query, nil, fnvHashString(query)
-			}
-			if word == "BY" && previousWord == "ORDER" {
-				orderDepth = depth
-			} else if orderDepth >= 0 && depth == orderDepth && (word == "LIMIT" || word == "FOR") {
-				orderDepth = -1
-			}
-			if depth == 0 {
+			if len(selectScopes) > 0 && depth == selectScopes[len(selectScopes)-1].depth {
+				scope := &selectScopes[len(selectScopes)-1]
+				if scope.depth == 0 {
+					switch word {
+					case "GROUP", "HAVING", "UNION", "DISTINCT", "OVER",
+						"COUNT", "SUM", "AVG", "MIN", "MAX", "GROUP_CONCAT":
+						scope.unsafe = true
+					}
+				}
+				if word == "BY" && previousWord == "ORDER" {
+					scope.orderDepth = depth
+				} else if scope.orderDepth >= 0 && (word == "LIMIT" || word == "FOR") {
+					scope.orderDepth = -1
+				}
 				switch word {
-				case "FROM", "WHERE", "LIMIT", "OFFSET":
-					clause = word
+				case "FROM", "WHERE", "HAVING", "LIMIT", "OFFSET":
+					scope.clause = word
 				case "ON":
-					clause = "WHERE"
+					scope.clause = "WHERE"
+				case "GROUP", "ORDER", "UNION":
+					scope.clause = word
 				}
 			}
 			out.WriteString(query[i:end])
@@ -182,13 +211,24 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 			if depth == typeDepth {
 				typeDepth = -1
 			}
+			if len(selectScopes) > 1 && selectScopes[len(selectScopes)-1].depth == depth {
+				selectScopes = selectScopes[:len(selectScopes)-1]
+			}
 			depth--
 			out.WriteByte(query[i])
 			i++
 			previousToken = ")"
 			continue
 		}
-		if query[i] == '-' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' && unarySQLSign(previousToken) && parameterizableLiteralClause(clause) {
+		clause := ""
+		orderDepth := -1
+		scopeDepth := -1
+		if len(selectScopes) > 0 {
+			clause = selectScopes[len(selectScopes)-1].clause
+			orderDepth = selectScopes[len(selectScopes)-1].orderDepth
+			scopeDepth = selectScopes[len(selectScopes)-1].depth
+		}
+		if query[i] == '-' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' && unarySQLSign(previousToken) && parameterizableLiteralAtScope(clause, scopeDepth) {
 			end := scanSQLNumber(query, i+1)
 			if !isSQLIdentifierPartAt(query, end) {
 				out.WriteByte('?')
@@ -202,7 +242,7 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 			end := scanSQLNumber(query, i)
 			if end > i && !isSQLIdentifierPartAt(query, end) {
 				isOrderOrdinal := orderDepth == depth && (previousWord == "BY" || previousToken == ",")
-				if typeDepth >= 0 || isOrderOrdinal || !parameterizableLiteralClause(clause) {
+				if typeDepth >= 0 || isOrderOrdinal || !parameterizableLiteralAtScope(clause, scopeDepth) {
 					out.WriteString(query[i:end])
 				} else {
 					out.WriteByte('?')
@@ -220,6 +260,9 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 	}
 
 	if len(bindings) == 0 {
+		return query, nil, fnvHashString(query)
+	}
+	if structuralQuery || len(selectScopes) == 0 || selectScopes[0].unsafe {
 		return query, nil, fnvHashString(query)
 	}
 	normalized, shapeHash := out.Result()
@@ -349,16 +392,12 @@ func unarySQLSign(previousToken string) bool {
 	}
 }
 
-func parameterizableLiteralClause(clause string) bool {
-	return clause == "WHERE" || clause == "LIMIT" || clause == "OFFSET"
-}
-
-func unsafeParameterizedSelectWord(word string) bool {
-	switch word {
-	case "GROUP", "HAVING", "UNION", "OR", "DISTINCT", "OVER",
-		"COUNT", "SUM", "AVG", "MIN", "MAX", "GROUP_CONCAT":
-		return true
-	default:
+func parameterizableLiteralAtScope(clause string, scopeDepth int) bool {
+	if scopeDepth != 0 {
 		return false
 	}
+	if clause == "LIMIT" || clause == "OFFSET" {
+		return true
+	}
+	return clause == "WHERE" || clause == "HAVING"
 }

--- a/scm/sql_literals.go
+++ b/scm/sql_literals.go
@@ -30,6 +30,15 @@ type sqlSelectScope struct {
 	clause     string
 	orderDepth int
 	unsafe     bool
+	derived    bool
+}
+
+type sqlLiteralCandidate struct {
+	start int
+	end   int
+	value Scmer
+	scope *sqlSelectScope
+	force bool
 }
 
 func newSQLShapeBuilder(capacity int) *sqlShapeBuilder {
@@ -82,7 +91,8 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 	previousWord := ""
 	previousToken := ""
 	structuralQuery := false
-	selectScopes := make([]sqlSelectScope, 0, 4)
+	selectScopes := make([]*sqlSelectScope, 0, 4)
+	candidates := make([]sqlLiteralCandidate, 0, 8)
 
 	for i := 0; i < len(query); {
 		if isSQLSpace(query[i]) {
@@ -122,13 +132,13 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 		if query[i] == '\'' || query[i] == '"' {
 			end, ok := scanQuotedSQL(query, i, query[i])
 			clause := ""
-			scopeDepth := -1
+			var scope *sqlSelectScope
 			if len(selectScopes) > 0 {
-				clause = selectScopes[len(selectScopes)-1].clause
-				scopeDepth = selectScopes[len(selectScopes)-1].depth
+				scope = selectScopes[len(selectScopes)-1]
+				clause = scope.clause
 			}
-			parameterizable := parameterizableLiteralAtScope(clause, scopeDepth) ||
-				(scopeDepth > 0 && (previousWord == "LIKE" || previousWord == "AGAINST"))
+			forcedPattern := scope != nil && scope.depth > 0 && (previousWord == "LIKE" || previousWord == "AGAINST")
+			parameterizable := parameterizableLiteralAtScope(clause, scope) || forcedPattern
 			if !ok || previousWord == "AS" || previousWord == "DATE" || !parameterizable {
 				if !ok {
 					return query, nil, fnvHashString(query)
@@ -139,7 +149,9 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 				continue
 			}
 			out.WriteByte('?')
-			bindings = append(bindings, NewString(unescapeSQLLiteral(query[i+1:end-1])))
+			value := NewString(unescapeSQLLiteral(query[i+1 : end-1]))
+			bindings = append(bindings, value)
+			candidates = append(candidates, sqlLiteralCandidate{i, end, value, selectScopes[len(selectScopes)-1], forcedPattern})
 			i = end
 			previousToken = "literal"
 			continue
@@ -161,21 +173,20 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 					selectScopes[len(selectScopes)-1].clause = "SELECT"
 					selectScopes[len(selectScopes)-1].orderDepth = -1
 				} else {
-					selectScopes = append(selectScopes, sqlSelectScope{
+					selectScopes = append(selectScopes, &sqlSelectScope{
 						depth:      depth,
 						clause:     "SELECT",
 						orderDepth: -1,
+						derived:    depth == 0 || previousWord == "FROM" || previousWord == "JOIN",
 					})
 				}
 			}
 			if len(selectScopes) > 0 && depth == selectScopes[len(selectScopes)-1].depth {
-				scope := &selectScopes[len(selectScopes)-1]
-				if scope.depth == 0 {
-					switch word {
-					case "GROUP", "HAVING", "UNION", "DISTINCT", "OVER",
-						"COUNT", "SUM", "AVG", "MIN", "MAX", "GROUP_CONCAT":
-						scope.unsafe = true
-					}
+				scope := selectScopes[len(selectScopes)-1]
+				switch word {
+				case "GROUP", "HAVING", "UNION", "DISTINCT", "OVER",
+					"COUNT", "SUM", "AVG", "MIN", "MAX", "GROUP_CONCAT":
+					scope.unsafe = true
 				}
 				if word == "BY" && previousWord == "ORDER" {
 					scope.orderDepth = depth
@@ -222,17 +233,19 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 		}
 		clause := ""
 		orderDepth := -1
-		scopeDepth := -1
+		var scope *sqlSelectScope
 		if len(selectScopes) > 0 {
-			clause = selectScopes[len(selectScopes)-1].clause
-			orderDepth = selectScopes[len(selectScopes)-1].orderDepth
-			scopeDepth = selectScopes[len(selectScopes)-1].depth
+			scope = selectScopes[len(selectScopes)-1]
+			clause = scope.clause
+			orderDepth = scope.orderDepth
 		}
-		if query[i] == '-' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' && unarySQLSign(previousToken) && parameterizableLiteralAtScope(clause, scopeDepth) {
+		if query[i] == '-' && i+1 < len(query) && query[i+1] >= '0' && query[i+1] <= '9' && unarySQLSign(previousToken) && parameterizableLiteralAtScope(clause, scope) {
 			end := scanSQLNumber(query, i+1)
 			if !isSQLIdentifierPartAt(query, end) {
 				out.WriteByte('?')
-				bindings = append(bindings, Simplify(query[i:end]))
+				value := Simplify(query[i:end])
+				bindings = append(bindings, value)
+				candidates = append(candidates, sqlLiteralCandidate{i, end, value, selectScopes[len(selectScopes)-1], false})
 				i = end
 				previousToken = "literal"
 				continue
@@ -242,11 +255,13 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 			end := scanSQLNumber(query, i)
 			if end > i && !isSQLIdentifierPartAt(query, end) {
 				isOrderOrdinal := orderDepth == depth && (previousWord == "BY" || previousToken == ",")
-				if typeDepth >= 0 || isOrderOrdinal || !parameterizableLiteralAtScope(clause, scopeDepth) {
+				if typeDepth >= 0 || isOrderOrdinal || !parameterizableLiteralAtScope(clause, scope) {
 					out.WriteString(query[i:end])
 				} else {
 					out.WriteByte('?')
-					bindings = append(bindings, Simplify(query[i:end]))
+					value := Simplify(query[i:end])
+					bindings = append(bindings, value)
+					candidates = append(candidates, sqlLiteralCandidate{i, end, value, selectScopes[len(selectScopes)-1], false})
 				}
 				i = end
 				previousToken = "literal"
@@ -259,11 +274,32 @@ func parameterizeSQLSelectLiterals(query string) (string, []Scmer, string) {
 		i++
 	}
 
-	if len(bindings) == 0 {
+	if len(candidates) == 0 {
 		return query, nil, fnvHashString(query)
 	}
 	if structuralQuery || len(selectScopes) == 0 || selectScopes[0].unsafe {
 		return query, nil, fnvHashString(query)
+	}
+	accepted := make([]sqlLiteralCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.force || !candidate.scope.unsafe {
+			accepted = append(accepted, candidate)
+		}
+	}
+	if len(accepted) == 0 {
+		return query, nil, fnvHashString(query)
+	}
+	if len(accepted) != len(candidates) {
+		out = newSQLShapeBuilder(len(query))
+		bindings = make([]Scmer, 0, len(accepted))
+		position := 0
+		for _, candidate := range accepted {
+			out.WriteString(query[position:candidate.start])
+			out.WriteByte('?')
+			bindings = append(bindings, candidate.value)
+			position = candidate.end
+		}
+		out.WriteString(query[position:])
 	}
 	normalized, shapeHash := out.Result()
 	return normalized, bindings, shapeHash
@@ -392,12 +428,12 @@ func unarySQLSign(previousToken string) bool {
 	}
 }
 
-func parameterizableLiteralAtScope(clause string, scopeDepth int) bool {
-	if scopeDepth != 0 {
+func parameterizableLiteralAtScope(clause string, scope *sqlSelectScope) bool {
+	if scope == nil || (scope.depth > 0 && !scope.derived) {
 		return false
 	}
 	if clause == "LIMIT" || clause == "OFFSET" {
-		return true
+		return scope.depth == 0
 	}
 	return clause == "WHERE" || clause == "HAVING"
 }

--- a/scm/sql_literals_test.go
+++ b/scm/sql_literals_test.go
@@ -79,8 +79,6 @@ func TestParameterizeSQLSelectLiteralsKeepsUnsafeShapesExact(t *testing.T) {
 		"SELECT id FROM items WHERE id = ?",
 		"SELECT id FROM items WHERE created_at >= DATE '2026-01-01'",
 		"SELECT category, COUNT(*) FROM items WHERE state = 'open' GROUP BY category",
-		"SELECT id FROM items WHERE id IN (SELECT item_id FROM links WHERE kind = 2)",
-		"SELECT id FROM items WHERE state = 'open' OR score = 2",
 		"SELECT COUNT(*) FROM items WHERE state = 'open'",
 		"SELECT DISTINCT state FROM items WHERE score >= 2",
 		"SELECT id FROM items WHERE id = 1 UNION SELECT id FROM items WHERE id = 2",

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -159,7 +159,7 @@ test_cases:
     expect:
       data: ["ok"]
 
-  - name: "Complex LIKE UNION search normalizes nested conditions"
+  - name: "Complex LIKE UNION search normalizes only search literals"
     scm: |
       (match (sql_parameterize_select_literals
         "SELECT d.id FROM ps_guard_left d WHERE d.id = 7 OR d.rhs IN (SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE '%Ca%' UNION SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE '%Ca%')"

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -159,15 +159,15 @@ test_cases:
     expect:
       data: ["ok"]
 
-  - name: "Complex LIKE UNION search normalizes only search literals"
+  - name: "Complex LIKE UNION search normalizes nested conditions"
     scm: |
       (match (sql_parameterize_select_literals
         "SELECT d.id FROM ps_guard_left d WHERE d.id = 7 OR d.rhs IN (SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE '%Ca%' UNION SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE '%Ca%')"
         true)
         '(normalized bindings shape_hash)
         (if (and
-          (equal? normalized "SELECT d.id FROM ps_guard_left d WHERE d.id = 7 OR d.rhs IN (SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE ? UNION SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE ?)")
-          (equal? bindings '("%Ca%" "%Ca%"))
+          (equal? normalized "SELECT d.id FROM ps_guard_left d WHERE d.id = ? OR d.rhs IN (SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE ? UNION SELECT f.id FROM ps_guard_right f WHERE CAST(f.id AS CHAR) LIKE ?)")
+          (equal? bindings '(7 "%Ca%" "%Ca%"))
           (equal? shape_hash (fnv_hash normalized)))
           "ok"
           (error (concat "unexpected complex normalization: " normalized " / " bindings))))
@@ -222,6 +222,85 @@ test_cases:
           (equal? (sess "v3") 1))
           "ok"
           (error (concat "unexpected cache/bindings: " (count (cache)) " / " (sess "v1") "," (sess "v2") "," (sess "v3")))))
+    expect:
+      data: ["ok"]
+
+  - name: "Nested SELECT keeps inner conditions structural"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT id, (SELECT 7 FROM ps_test inner_row WHERE inner_row.id = 1 OR inner_row.score = 6 LIMIT 1) AS marker FROM ps_test outer_row WHERE outer_row.score >= 8 LIMIT 2 OFFSET 0"
+        true)
+        '(normalized bindings shape_hash)
+        (if (and
+          (equal? normalized "SELECT id, (SELECT 7 FROM ps_test inner_row WHERE inner_row.id = 1 OR inner_row.score = 6 LIMIT 1) AS marker FROM ps_test outer_row WHERE outer_row.score >= ? LIMIT ? OFFSET ?")
+          (equal? bindings '(8 2 0))
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok"
+          (error (concat "unexpected nested normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Non-aggregate OR uses runtime literals"
+    sql: "SELECT id FROM ps_test WHERE score >= 9 OR id = 2 ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - {id: 1}
+        - {id: 2}
+
+  - name: "Non-aggregate OR cache reuse keeps changed literals"
+    sql: "SELECT id FROM ps_test WHERE score >= 10 OR id = 99 ORDER BY id"
+    expect:
+      rows: 0
+
+  - name: "Root aggregate conditions remain structural"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT COUNT(*) AS cnt FROM ps_test WHERE score >= 8 OR id = 2 HAVING COUNT(*) >= 1"
+        true)
+        '(normalized bindings shape_hash)
+        (if (and
+          (equal? normalized "SELECT COUNT(*) AS cnt FROM ps_test WHERE score >= 8 OR id = 2 HAVING COUNT(*) >= 1")
+          (equal? bindings '())
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok"
+          (error (concat "unexpected aggregate normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Window rank conditions remain structural"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT parent_row.id FROM ps_test parent_row LEFT JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY score DESC) AS rank_no FROM ps_test) ranked ON ranked.id = parent_row.id AND ranked.rank_no = 1 LIMIT 2"
+        true)
+        '(normalized bindings shape_hash)
+        (if (and
+          (equal? normalized "SELECT parent_row.id FROM ps_test parent_row LEFT JOIN (SELECT id, ROW_NUMBER() OVER (ORDER BY score DESC) AS rank_no FROM ps_test) ranked ON ranked.id = parent_row.id AND ranked.rank_no = 1 LIMIT 2")
+          (equal? bindings '())
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok"
+          (error (concat "unexpected window normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Nested literal variants share one cached SELECT plan"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (cached_parse cache (lambda (_schema _query _policy) 7)
+          "memcp-tests" "SELECT id FROM ps_test outer_row WHERE outer_row.score >= 8 AND outer_row.id IN (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 6 LIMIT 1) LIMIT 2"
+          nil "root" sess true)
+        (cached_parse cache (lambda (_schema _query _policy) 7)
+          "memcp-tests" "SELECT id FROM ps_test outer_row WHERE outer_row.score >= 9 AND outer_row.id IN (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 6 LIMIT 1) LIMIT 4"
+          nil "root" sess true)
+        (if (and
+          (equal? (count (cache)) 1)
+          (equal? (sess "v1") 9)
+          (equal? (sess "v2") 4))
+          "ok"
+          (error (concat "unexpected nested cache/bindings: " (count (cache)) " / "
+            (sess "v1") "," (sess "v2")))))
     expect:
       data: ["ok"]
 

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -225,7 +225,7 @@ test_cases:
     expect:
       data: ["ok"]
 
-  - name: "Nested SELECT keeps inner conditions structural"
+  - name: "Scalar SELECT keeps inner conditions structural"
     scm: |
       (match (sql_parameterize_select_literals
         "SELECT id, (SELECT 7 FROM ps_test inner_row WHERE inner_row.id = 1 OR inner_row.score = 6 LIMIT 1) AS marker FROM ps_test outer_row WHERE outer_row.score >= 8 LIMIT 2 OFFSET 0"
@@ -268,6 +268,36 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "Nested aggregate conditions remain structural"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT id, (SELECT COUNT(*) FROM ps_test inner_row WHERE inner_row.score >= 6) AS matches FROM ps_test outer_row WHERE outer_row.score >= 8 LIMIT 2"
+        true)
+        '(normalized bindings shape_hash)
+        (if (and
+          (equal? normalized "SELECT id, (SELECT COUNT(*) FROM ps_test inner_row WHERE inner_row.score >= 6) AS matches FROM ps_test outer_row WHERE outer_row.score >= ? LIMIT ?")
+          (equal? bindings '(8 2))
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok"
+          (error (concat "unexpected nested aggregate normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
+  - name: "Deep correlated conditions remain structural"
+    scm: |
+      (match (sql_parameterize_select_literals
+        "SELECT wrapped.id FROM (SELECT outer_row.id, EXISTS (SELECT TRUE FROM ps_test inner_row WHERE inner_row.id = outer_row.id AND inner_row.score >= 6 LIMIT 1) AS visible FROM ps_test outer_row) wrapped WHERE wrapped.id = 1 LIMIT 2"
+        true)
+        '(normalized bindings shape_hash)
+        (if (and
+          (equal? normalized "SELECT wrapped.id FROM (SELECT outer_row.id, EXISTS (SELECT TRUE FROM ps_test inner_row WHERE inner_row.id = outer_row.id AND inner_row.score >= 6 LIMIT 1) AS visible FROM ps_test outer_row) wrapped WHERE wrapped.id = ? LIMIT ?")
+          (equal? bindings '(1 2))
+          (equal? shape_hash (fnv_hash normalized)))
+          "ok"
+          (error (concat "unexpected deep normalization: " normalized " / " bindings))))
+    expect:
+      data: ["ok"]
+
   - name: "Window rank conditions remain structural"
     scm: |
       (match (sql_parameterize_select_literals
@@ -289,18 +319,19 @@ test_cases:
         (define cache (newcachemap))
         (define sess (newsession))
         (cached_parse cache (lambda (_schema _query _policy) 7)
-          "memcp-tests" "SELECT id FROM ps_test outer_row WHERE outer_row.score >= 8 AND outer_row.id IN (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 6 LIMIT 1) LIMIT 2"
+          "memcp-tests" "SELECT wrapped.id FROM (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 6) wrapped WHERE wrapped.id >= 1 LIMIT 2"
           nil "root" sess true)
         (cached_parse cache (lambda (_schema _query _policy) 7)
-          "memcp-tests" "SELECT id FROM ps_test outer_row WHERE outer_row.score >= 9 AND outer_row.id IN (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 6 LIMIT 1) LIMIT 4"
+          "memcp-tests" "SELECT wrapped.id FROM (SELECT inner_row.id FROM ps_test inner_row WHERE inner_row.score >= 7) wrapped WHERE wrapped.id >= 2 LIMIT 4"
           nil "root" sess true)
         (if (and
           (equal? (count (cache)) 1)
-          (equal? (sess "v1") 9)
-          (equal? (sess "v2") 4))
+          (equal? (sess "v1") 7)
+          (equal? (sess "v2") 2)
+          (equal? (sess "v3") 4))
           "ok"
           (error (concat "unexpected nested cache/bindings: " (count (cache)) " / "
-            (sess "v1") "," (sess "v2")))))
+            (sess "v1") "," (sess "v2") "," (sess "v3")))))
     expect:
       data: ["ok"]
 


### PR DESCRIPTION
## Problem

The literal front cache treated a second `SELECT` as globally unsafe. Large read-model queries containing scalar or membership subqueries therefore kept an exact cache key even when only outer filters, `LIMIT`, or `OFFSET` changed. Every pagination variant repeated parsing and planning.

## Change

- Track clause state independently for each nested `SELECT` scope.
- Generalize safe literals from the outer query and directly derived `FROM`/`JOIN` blocks.
- Keep literals in scalar, `IN`, `EXISTS`, aggregate, and nested pagination scopes structural because they can determine correlated carriers or group-cache identities.
- Preserve the established nested `LIKE`/`MATCH` specialization.
- Keep root aggregate plans exact because their conditions participate in canonical group-cache identities.
- Keep queries containing window `OVER` exact because rank predicates such as `rank_no = 1` select the physical window plan.

This changes only cache-key construction. It does not move logical decisions into physical lowering or add a planner fallback.

## Test-first evidence

Before the implementation, the new anonymous nested-normalization and cache-reuse cases failed: the query stayed exact and two literal variants produced two cache entries. The final suite also covers:

- outer and directly derived runtime bindings with structural scalar/correlated subquery conditions;
- changed literals across a non-aggregate `OR` cache hit;
- aggregate conditions remaining exact;
- window rank conditions remaining exact;
- nested variants sharing one compiled plan.

`tests/sql/expressions/prepared-stmts.yaml`: 46/46 passed. Focused aggregate, name-resolution, late-projection, relational-shape, and window suites passed. The complete pre-commit suite passed for the first commit. After widening derived-block coverage, the only full-hook failure is an unchanged 80 KB `EXPLAIN COMPILE` timing guard under 87% host CPU load: master 1.242 s, patch 1.259 s (limits 1.165 s and 1.162 s respectively). CI remains the clean-load gate.

## A/B measurements

Same machine, current master and patch built from the same base. The application-derived input was anonymized in this description: a 72 KB nested read-model query; only its outer `LIMIT` changed between executions.

| Build | first LIMIT | second LIMIT | third LIMIT |
|---|---:|---:|---:|
| master | 3.89 s | 3.13 s | 3.12 s |
| patch | 4.43 s | 0.19 s | 0.19 s |

The cold compile is unchanged within run-to-run noise. Reused variants improve by about 94%, or 16x, because they execute the cached plan instead of compiling the 72 KB query again.

A second A/B uses three 72 KB queries which differ only in a filter literal inside the directly derived block:

| Build | first value | second value | third value |
|---|---:|---:|---:|
| master | 3.49 s | 3.39 s | 3.31 s |
| patch | 4.06 s | 0.02 s | 0.02 s |

All three patched queries produce the same normalized shape hash. Warm variants improve by more than 99%, about 165x. The cold value again includes the one required compile.

Scanner microbenchmark (`BenchmarkParameterizeSQLSelectLiterals`, median of five 1-second runs):

| Build | time | allocations |
|---|---:|---:|
| master | 1.554 us/op | 520 B/op, 13 allocs/op |
| patch | 1.861 us/op | 808 B/op, 15 allocs/op |

Scope classification adds 0.307 us (19.8%), 288 bytes, and two allocations to the microbenchmark. This overhead is paid once per incoming SQL string and is explicitly reported against the seconds saved on cache hits.

## Manual integration

The patched manual run completed setup and 16/19 phase-one browser manuals. Trace analysis found no query near the four-minute browser timeout. The three failures are UI-state/navigation waits: one save click remains on the edit URL without issuing the expected save request, one missing tab selector, and one list row not shown after navigation. These are not SQL result or MemCP timeout failures. The retained patched instance is available on dashboard port 4325 for inspection.
