### PR TITLE
JIT match patterns with type-aware pruning

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -2002,6 +2002,60 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (jit? _jit_map_dynamic_callback) (jit-enabled?) "jit: map with runtime callback compiles natively when enabled")
 	(assert (equal? (_jit_map_dynamic_callback '(2 3 4) (lambda (value) (* value 3))) '(6 9 12)) true "jit: map runtime callback trampoline")
 
+	/* JIT match: compile-time pattern pruning and direct list destructuring */
+	(define _jit_match_source (jit (lambda (src)
+		(match src
+			'((symbol alias) schema relation outer join) (list schema relation outer join)
+			_ nil))))
+	(assert (jit? _jit_match_source) (jit-enabled?) "jit: fixed-list match compiles natively when enabled")
+	(assert (equal? (_jit_match_source (list (symbol "alias") "sales" "orders" false nil)) '("sales" "orders" false nil)) true "jit: fixed-list match binds fields")
+	(assert (nil? (_jit_match_source (list (symbol "other") "sales" "orders" false nil))) true "jit: fixed-list literal mismatch falls through")
+	(assert (nil? (_jit_match_source (list (symbol "alias") "sales" "orders"))) true "jit: fixed-list length mismatch falls through")
+
+	(define _jit_match_cons (jit (lambda (values)
+		(match values
+			(cons head tail) (list head tail)
+			_ nil))))
+	(assert (jit? _jit_match_cons) (jit-enabled?) "jit: cons match compiles natively when enabled")
+	(assert (equal? (_jit_match_cons '(1 2 3)) (list 1 (list 2 3))) true "jit: cons match binds head and tail")
+	(assert (nil? (_jit_match_cons '())) true "jit: empty list rejects cons pattern")
+	(assert (nth (_jit_match_cons fd2) 0) "k0" "jit: cons match normalizes FastDict head")
+	(assert (count (nth (_jit_match_cons fd2) 1)) 19 "jit: cons match normalizes FastDict tail")
+
+	(define _jit_match_typed (jit (lambda (value)
+		(match value
+			(number? number) (+ number 1)
+			(string? text) text
+			_ nil))))
+	(assert (jit? _jit_match_typed) (jit-enabled?) "jit: typed alternatives compile natively when enabled")
+	(assert (_jit_match_typed 41) 42 "jit: number pattern selects numeric branch")
+	(assert (_jit_match_typed "text") "text" "jit: string pattern selects string branch")
+	(assert (nil? (_jit_match_typed false)) true "jit: typed patterns retain fallback")
+
+	(define _jit_match_list_type (jit (lambda (value)
+		(match value
+			(list? items) items
+			_ nil))))
+	(assert (jit? _jit_match_list_type) (jit-enabled?) "jit: list? pattern compiles natively when enabled")
+	(assert (count (_jit_match_list_type fd2)) 20 "jit: list? pattern normalizes FastDict")
+	(assert (nil? (_jit_match_list_type "not a list")) true "jit: list? pattern rejects scalar")
+
+	(define _jit_match_eval (jit (lambda (value expected)
+		(match value
+			(eval expected) true
+			_ false))))
+	(assert (jit? _jit_match_eval) (jit-enabled?) "jit: eval pattern compiles natively when enabled")
+	(assert (_jit_match_eval "same" "same") true "jit: eval pattern accepts runtime equality")
+	(assert (_jit_match_eval "left" "right") false "jit: eval pattern rejects runtime inequality")
+
+	(define _jit_match_known_list (jit (lambda (value)
+		(match (list 'alias value)
+			'((symbol alias) result) result
+			'((symbol other) impossible) impossible
+			nil))))
+	(assert (jit? _jit_match_known_list) (jit-enabled?) "jit: known-list match compiles natively when enabled")
+	(assert (_jit_match_known_list 17) 17 "jit: known list type and length are matched without fallback")
+
 	/* alu.go: sql_abs */
 	(print "testing sql_abs ...")
 	(assert (equal? (sql_abs -5) 5) true "sql_abs of -5 = 5")

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -174,27 +174,30 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 	// even when the optimizer did not rewrite body symbols to NthLocalVar.
 	if proc != nil {
 		var vars map[Symbol]JITValueDesc
-		putVar := func(sym Symbol, off int32) {
+		putVar := func(sym Symbol, index int) {
 			if vars == nil {
-				vars = make(map[Symbol]JITValueDesc, numVars)
+				vars = make(map[Symbol]JITValueDesc, inputArgCount)
 			}
-			vars[sym] = JITValueDesc{
-				Loc:      LocStackPair,
-				Type:     JITTypeUnknown,
-				StackOff: off,
+			desc := JITValueDesc{
+				Loc: LocInputPair, Type: JITTypeUnknown, StackOff: int32(index),
 			}
+			if !useInputFrame && index < numVars {
+				desc.Loc = LocStackPair
+				desc.StackOff = int32(index * 16)
+			}
+			vars[sym] = desc
 		}
 		switch proc.Params.GetTag() {
 		case tagSlice:
 			params := proc.Params.Slice()
-			for i := 0; i < len(params) && i < numVars; i++ {
+			for i := 0; i < len(params) && (inputArgCount < 0 || i < inputArgCount); i++ {
 				if params[i].GetTag() != tagSymbol {
 					continue
 				}
-				putVar(params[i].Symbol(), int32(i*16))
+				putVar(params[i].Symbol(), i)
 			}
 		case tagSymbol:
-			if numVars > 0 {
+			if inputArgCount > 0 {
 				putVar(proc.Params.Symbol(), 0)
 			}
 		}
@@ -448,6 +451,654 @@ func jitReturnHasNoHeapPointer(td *TypeDescriptor) bool {
 	default:
 		return false
 	}
+}
+
+var jitMatchEmptyListStorage [1]Scmer
+
+func jitMatchAsGoSlice(value Scmer) []Scmer {
+	list, ok := scmerAsSlice(value)
+	if !ok {
+		return nil
+	}
+	// A non-nil pointer distinguishes a successfully normalized empty list from
+	// a non-list without adding a fourth ABI result word to the emitted call.
+	if len(list) == 0 && unsafe.SliceData(list) == nil {
+		return jitMatchEmptyListStorage[:0]
+	}
+	return list
+}
+
+func jitMatchSymbolLiteralWords(valuePtr *byte, valueAux uint64, expectedPtr *byte, expectedAux uint64) bool {
+	value := Scmer{ptr: valuePtr, aux: valueAux}
+	expected := Scmer{ptr: expectedPtr, aux: expectedAux}
+	actualName, actualOK := scmerSymbolName(value)
+	expectedName, expectedOK := scmerSymbolName(expected)
+	return actualOK && expectedOK && actualName == expectedName
+}
+
+func jitMatchEqualWords(valuePtr *byte, valueAux uint64, expectedPtr *byte, expectedAux uint64) bool {
+	return Equal(Scmer{ptr: valuePtr, aux: valueAux}, Scmer{ptr: expectedPtr, aux: expectedAux})
+}
+
+func jitMatchIsString(value Scmer) bool {
+	_, ok := scmerAsString(value)
+	return ok
+}
+
+type jitMatchOutcome struct {
+	possible bool
+	always   bool
+}
+
+func jitMatchBranchEnv(outer *JITEnv) *JITEnv {
+	env := &JITEnv{Outer: outer}
+	if outer != nil && len(outer.Numbered) > 0 {
+		env.Numbered = append([]JITValueDesc(nil), outer.Numbered...)
+	}
+	return env
+}
+
+func jitMatchStableValue(ctx *JITContext, value JITValueDesc) JITValueDesc {
+	if value.Loc == LocImm || value.Loc == LocStackPair || value.Loc == LocInputPair || value.Loc == LocVirtualSlice {
+		return value
+	}
+	src := value
+	ctx.EnsureDesc(&src)
+	if src.Loc == LocReg {
+		ptrReg := ctx.AllocRegExcept(src.Reg)
+		target := JITValueDesc{Loc: LocRegPair, Type: src.Type, Reg: ptrReg, Reg2: ctx.AllocRegExcept(src.Reg, ptrReg)}
+		src = jitPlaceIntoPair(ctx, &src, target)
+	}
+	if src.Loc != LocRegPair {
+		panic("jit: match value is not a Scmer pair")
+	}
+	off := ctx.AllocStack(16)
+	ctx.EmitStoreScmerToStack(src, off)
+	ctx.FreeDesc(&src)
+	return JITValueDesc{
+		Loc: LocStackPair, Type: value.Type, StackOff: off,
+		KnownSliceLen: value.KnownSliceLen, KnownSliceCap: value.KnownSliceCap,
+		SliceSizeKnown: value.SliceSizeKnown, NoHeapPointer: value.NoHeapPointer,
+	}
+}
+
+func jitMatchBindValue(ctx *JITContext, env *JITEnv, pattern Scmer, value JITValueDesc) {
+	if pattern.IsSymbol() && pattern.SymbolEquals("_") {
+		return
+	}
+	bound := value
+	if value.Loc != LocImm {
+		bound = jitMatchStableValue(ctx, value)
+	}
+	if pattern.IsNthLocalVar() {
+		idx := int(pattern.NthLocalVar())
+		if idx >= len(env.Numbered) {
+			numbered := make([]JITValueDesc, idx+1)
+			copy(numbered, env.Numbered)
+			env.Numbered = numbered
+		}
+		env.Numbered[idx] = bound
+		return
+	}
+	if !pattern.IsSymbol() {
+		panic("jit: invalid match binding")
+	}
+	if env.Vars == nil {
+		env.Vars = make(map[Symbol]JITValueDesc)
+	}
+	env.Vars[pattern.Symbol()] = bound
+}
+
+func jitMatchMaterializeImm(ctx *JITContext, value Scmer) JITValueDesc {
+	ptrReg := ctx.AllocReg()
+	auxReg := ctx.AllocRegExcept(ptrReg)
+	target := JITValueDesc{Loc: LocRegPair, Type: value.GetTag(), Reg: ptrReg, Reg2: auxReg}
+	source := JITValueDesc{Loc: LocImm, Type: value.GetTag(), Imm: value}
+	return jitPlaceIntoPair(ctx, &source, target)
+}
+
+func jitEmitMatchBool(ctx *JITContext, condition JITValueDesc, failLabel uint8) jitMatchOutcome {
+	if condition.Loc == LocImm {
+		return jitMatchOutcome{possible: condition.Imm.Bool(), always: condition.Imm.Bool()}
+	}
+	ctx.EnsureDesc(&condition)
+	if condition.Loc != LocReg {
+		panic("jit: match condition is not scalar")
+	}
+	// Go's internal ABI only defines the low byte of a bool result. Clear stale
+	// upper bits before using it as a branch condition.
+	ctx.EmitAndRegImm32(condition.Reg, 1)
+	ctx.EmitCmpRegImm32(condition.Reg, 0)
+	ctx.EmitJcc(CcE, failLabel)
+	ctx.FreeDesc(&condition)
+	return jitMatchOutcome{possible: true, always: false}
+}
+
+func jitEmitMatchTag(ctx *JITContext, value *JITValueDesc, tag uint8, failLabel uint8) jitMatchOutcome {
+	condition := ctx.EmitTagEqualsBorrowed(value, tag, JITValueDesc{Loc: LocAny})
+	return jitEmitMatchBool(ctx, condition, failLabel)
+}
+
+func jitMatchLoadElement(ctx *JITContext, slice *JITValueDesc, index int) JITValueDesc {
+	ctx.EnsureDesc(slice)
+	if slice.Loc != LocRegTriple {
+		panic("jit: match list requires a Go slice header")
+	}
+	ctx.ProtectReg(slice.Reg)
+	ctx.ProtectReg(slice.Reg2)
+	ctx.ProtectReg(slice.Reg3)
+	ptrReg := ctx.AllocRegExcept(slice.Reg, slice.Reg2, slice.Reg3)
+	auxReg := ctx.AllocRegExcept(slice.Reg, slice.Reg2, slice.Reg3, ptrReg)
+	ctx.UnprotectReg(slice.Reg3)
+	ctx.UnprotectReg(slice.Reg2)
+	ctx.UnprotectReg(slice.Reg)
+	ctx.EmitMovRegMem(ptrReg, slice.Reg, int32(index*16))
+	ctx.EmitMovRegMem(auxReg, slice.Reg, int32(index*16+8))
+	result := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ptrReg, Reg2: auxReg}
+	ctx.BindReg(ptrReg, &result)
+	ctx.BindReg(auxReg, &result)
+	return result
+}
+
+func jitMatchSliceTail(ctx *JITContext, slice *JITValueDesc) JITValueDesc {
+	ctx.EnsureDesc(slice)
+	if slice.Loc != LocRegTriple {
+		panic("jit: match cons requires a Go slice header")
+	}
+	ctx.ProtectReg(slice.Reg)
+	ctx.ProtectReg(slice.Reg2)
+	ctx.ProtectReg(slice.Reg3)
+	ptrReg := ctx.AllocRegExcept(slice.Reg, slice.Reg2, slice.Reg3)
+	auxReg := ctx.AllocRegExcept(slice.Reg, slice.Reg2, slice.Reg3, ptrReg)
+	tmpReg := ctx.AllocRegExcept(slice.Reg, slice.Reg2, slice.Reg3, ptrReg, auxReg)
+	ctx.UnprotectReg(slice.Reg3)
+	ctx.UnprotectReg(slice.Reg2)
+	ctx.UnprotectReg(slice.Reg)
+	ctx.EmitMovRegReg(ptrReg, slice.Reg)
+	ctx.EmitAddRegImm32(ptrReg, 16)
+	ctx.EmitMovRegReg(auxReg, slice.Reg2)
+	ctx.EmitSubRegImm32(auxReg, 1)
+	ctx.EmitShlRegImm8(auxReg, sliceCapBits)
+	ctx.EmitMovRegReg(tmpReg, slice.Reg3)
+	ctx.EmitSubRegImm32(tmpReg, 1)
+	ctx.EmitOrInt64(auxReg, tmpReg)
+	ctx.EmitShlRegImm8(auxReg, 8)
+	ctx.EmitOrRegImm32(auxReg, int32(tagSlice))
+	ctx.FreeReg(tmpReg)
+	result := JITValueDesc{Loc: LocRegPair, Type: tagSlice, Reg: ptrReg, Reg2: auxReg}
+	if slice.SliceSizeKnown {
+		result.KnownSliceLen = slice.KnownSliceLen - 1
+		result.KnownSliceCap = slice.KnownSliceCap - 1
+		result.SliceSizeKnown = true
+	}
+	ctx.BindReg(ptrReg, &result)
+	ctx.BindReg(auxReg, &result)
+	return result
+}
+
+func jitMatchListValue(ctx *JITContext, value JITValueDesc, failLabel uint8) (JITValueDesc, JITValueDesc, jitMatchOutcome) {
+	if value.Loc == LocImm {
+		list, ok := scmerAsSlice(value.Imm)
+		if !ok {
+			return JITValueDesc{}, JITValueDesc{}, jitMatchOutcome{}
+		}
+		normalized := JITValueDesc{
+			Loc: LocImm, Type: tagSlice, Imm: NewSlice(list),
+			KnownSliceLen: int32(len(list)), KnownSliceCap: int32(cap(list)), SliceSizeKnown: true,
+		}
+		return normalized, JITValueDesc{}, jitMatchOutcome{possible: true, always: true}
+	}
+	if value.Type != JITTypeUnknown && value.Type != tagSlice && value.Type != tagFastDict && value.Type != tagSourceInfo {
+		return JITValueDesc{}, JITValueDesc{}, jitMatchOutcome{}
+	}
+
+	normalized := value
+	typeKnown := value.Type == tagSlice
+	if !typeKnown {
+		header := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchAsGoSlice), []JITValueDesc{value}, 3)
+		ctx.BindReg(header.Reg, &header)
+		ctx.BindReg(header.Reg2, &header)
+		ctx.BindReg(header.Reg3, &header)
+		ctx.EmitCmpRegImm32(header.Reg, 0)
+		ctx.EmitJcc(CcE, failLabel)
+		normalized = ctx.EmitNewSliceFromGoSlice(&header)
+	}
+	normalized.KnownSliceLen = value.KnownSliceLen
+	normalized.KnownSliceCap = value.KnownSliceCap
+	normalized.SliceSizeKnown = value.SliceSizeKnown
+	normalized = jitMatchStableValue(ctx, normalized)
+	sliceValue := normalized
+	header := jitKnownSliceHeader(ctx, &sliceValue)
+	ctx.FreeDesc(&sliceValue)
+	header.KnownSliceLen = value.KnownSliceLen
+	header.KnownSliceCap = value.KnownSliceCap
+	header.SliceSizeKnown = value.SliceSizeKnown
+	return normalized, header, jitMatchOutcome{possible: true, always: typeKnown}
+}
+
+func jitMatchLiteral(ctx *JITContext, value JITValueDesc, pattern Scmer, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm {
+		matched := Equal(value.Imm, pattern)
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	expected := jitMatchMaterializeImm(ctx, pattern)
+	condition := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchEqualWords), []JITValueDesc{value, expected}, 1)
+	ctx.FreeDesc(&expected)
+	return jitEmitMatchBool(ctx, condition, failLabel)
+}
+
+func jitMatchDynamicValue(ctx *JITContext, value, expected JITValueDesc, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm && expected.Loc == LocImm {
+		matched := Equal(value.Imm, expected.Imm)
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	materialize := func(desc JITValueDesc) JITValueDesc {
+		if desc.Loc == LocImm {
+			return jitMatchMaterializeImm(ctx, desc.Imm)
+		}
+		if desc.Loc == LocReg {
+			ptrReg := ctx.AllocRegExcept(desc.Reg)
+			target := JITValueDesc{Loc: LocRegPair, Type: desc.Type, Reg: ptrReg, Reg2: ctx.AllocRegExcept(desc.Reg, ptrReg)}
+			return jitPlaceIntoPair(ctx, &desc, target)
+		}
+		return desc
+	}
+	actualArg := materialize(value)
+	expectedArg := materialize(expected)
+	condition := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchEqualWords), []JITValueDesc{actualArg, expectedArg}, 1)
+	if actualArg.Loc == LocRegPair && value.Loc != LocRegPair {
+		ctx.FreeDesc(&actualArg)
+	}
+	if expectedArg.Loc == LocRegPair && expected.Loc != LocRegPair {
+		ctx.FreeDesc(&expectedArg)
+	}
+	return jitEmitMatchBool(ctx, condition, failLabel)
+}
+
+func jitMatchBoolLiteral(ctx *JITContext, value JITValueDesc, expected bool, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm {
+		matched := value.Imm.IsBool() && value.Imm.Bool() == expected
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	if value.Type != JITTypeUnknown && value.Type != tagBool {
+		return jitMatchOutcome{}
+	}
+	typeAlways := value.Type == tagBool
+	if !typeAlways {
+		jitEmitMatchTag(ctx, &value, tagBool, failLabel)
+	}
+	pair := value
+	ctx.EnsureDesc(&pair)
+	if pair.Loc != LocRegPair {
+		panic("jit: bool match requires a Scmer pair")
+	}
+	expectedAux := makeAux(tagBool, 0)
+	if expected {
+		expectedAux = makeAux(tagBool, 1)
+	}
+	ctx.EmitCmpRegImm32(pair.Reg2, int32(expectedAux))
+	ctx.EmitJcc(CcNE, failLabel)
+	ctx.FreeDesc(&pair)
+	return jitMatchOutcome{possible: true, always: false}
+}
+
+func jitMatchSymbol(ctx *JITContext, value JITValueDesc, expected Scmer, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm {
+		matched := func() bool {
+			actualName, actualOK := scmerSymbolName(value.Imm)
+			expectedName, expectedOK := scmerSymbolName(expected)
+			return actualOK && expectedOK && actualName == expectedName
+		}()
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	if value.Type != JITTypeUnknown && value.Type != tagSymbol && value.Type != tagSourceInfo {
+		return jitMatchOutcome{}
+	}
+	expectedValue := jitMatchMaterializeImm(ctx, expected)
+	condition := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchSymbolLiteralWords), []JITValueDesc{value, expectedValue}, 1)
+	ctx.FreeDesc(&expectedValue)
+	return jitEmitMatchBool(ctx, condition, failLabel)
+}
+
+func jitMatchNumber(ctx *JITContext, value JITValueDesc, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm {
+		matched := value.Imm.IsInt() || value.Imm.IsFloat()
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	if value.Type != JITTypeUnknown {
+		matched := value.Type == tagInt || value.Type == tagFloat
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	tmp := value
+	ctx.EnsureDesc(&tmp)
+	if tmp.Loc != LocRegPair {
+		panic("jit: number match requires a Scmer pair")
+	}
+	tagReg := ctx.AllocRegExcept(tmp.Reg, tmp.Reg2)
+	ctx.emitGetTagRegs(tagReg, tmp.Reg, tmp.Reg2)
+	accepted := ctx.ReserveLabel()
+	ctx.EmitCmpRegImm8(tagReg, tagInt)
+	ctx.EmitJcc(CcE, accepted)
+	ctx.EmitCmpRegImm8(tagReg, tagFloat)
+	ctx.EmitJcc(CcNE, failLabel)
+	ctx.MarkLabel(accepted)
+	ctx.FreeReg(tagReg)
+	ctx.FreeDesc(&tmp)
+	return jitMatchOutcome{possible: true, always: false}
+}
+
+func jitMatchString(ctx *JITContext, value JITValueDesc, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocImm {
+		_, matched := scmerAsString(value.Imm)
+		return jitMatchOutcome{possible: matched, always: matched}
+	}
+	if value.Type == tagString {
+		return jitMatchOutcome{possible: true, always: true}
+	}
+	if value.Type != JITTypeUnknown && value.Type != tagAny && value.Type != tagSourceInfo {
+		return jitMatchOutcome{}
+	}
+	condition := ctx.EmitGoCallScalar(GoFuncAddr(jitMatchIsString), []JITValueDesc{value}, 1)
+	return jitEmitMatchBool(ctx, condition, failLabel)
+}
+
+func jitMatchFixedList(ctx *JITContext, value JITValueDesc, patterns []Scmer, env *JITEnv, failLabel uint8) jitMatchOutcome {
+	if value.Loc == LocVirtualSlice {
+		if len(value.Virtual) != len(patterns) {
+			return jitMatchOutcome{}
+		}
+		allAlways := true
+		for i, pattern := range patterns {
+			outcome := jitCompileMatchPattern(ctx, value.Virtual[i], pattern, env, failLabel)
+			if !outcome.possible {
+				return jitMatchOutcome{}
+			}
+			allAlways = allAlways && outcome.always
+		}
+		return jitMatchOutcome{possible: true, always: allAlways}
+	}
+	normalized, header, listOutcome := jitMatchListValue(ctx, value, failLabel)
+	if !listOutcome.possible {
+		return jitMatchOutcome{}
+	}
+	if normalized.Loc == LocImm {
+		list := normalized.Imm.Slice()
+		if len(list) != len(patterns) {
+			return jitMatchOutcome{}
+		}
+		for i, pattern := range patterns {
+			outcome := jitCompileMatchPattern(ctx, JITValueDesc{Loc: LocImm, Type: list[i].GetTag(), Imm: list[i]}, pattern, env, failLabel)
+			if !outcome.possible {
+				return jitMatchOutcome{}
+			}
+		}
+		return jitMatchOutcome{possible: true, always: true}
+	}
+	if header.SliceSizeKnown {
+		if int(header.KnownSliceLen) != len(patterns) {
+			ctx.FreeDesc(&header)
+			ctx.FreeDesc(&normalized)
+			return jitMatchOutcome{}
+		}
+	} else {
+		ctx.EmitCmpRegImm32(header.Reg2, int32(len(patterns)))
+		ctx.EmitJcc(CcNE, failLabel)
+		listOutcome.always = false
+	}
+	ctx.FreeDesc(&header)
+	allAlways := listOutcome.always
+	for i, pattern := range patterns {
+		sliceValue := normalized
+		header = jitKnownSliceHeader(ctx, &sliceValue)
+		ctx.FreeDesc(&sliceValue)
+		element := jitMatchLoadElement(ctx, &header, i)
+		ctx.FreeDesc(&header)
+		outcome := jitCompileMatchPattern(ctx, element, pattern, env, failLabel)
+		ctx.FreeDesc(&element)
+		if !outcome.possible {
+			ctx.FreeDesc(&normalized)
+			return jitMatchOutcome{}
+		}
+		allAlways = allAlways && outcome.always
+	}
+	ctx.FreeDesc(&normalized)
+	return jitMatchOutcome{possible: true, always: allAlways}
+}
+
+func jitMatchCons(ctx *JITContext, value JITValueDesc, patterns []Scmer, env *JITEnv, failLabel uint8) jitMatchOutcome {
+	if len(patterns) != 2 {
+		panic("jit: cons match expects head and tail patterns")
+	}
+	if value.Loc == LocVirtualSlice {
+		if len(value.Virtual) == 0 {
+			return jitMatchOutcome{}
+		}
+		tail := JITValueDesc{
+			Loc: LocVirtualSlice, Type: tagSlice, Virtual: value.Virtual[1:],
+			KnownSliceLen: int32(len(value.Virtual) - 1), KnownSliceCap: int32(len(value.Virtual) - 1), SliceSizeKnown: true,
+		}
+		first := jitCompileMatchPattern(ctx, value.Virtual[0], patterns[0], env, failLabel)
+		second := jitCompileMatchPattern(ctx, tail, patterns[1], env, failLabel)
+		return jitMatchOutcome{possible: first.possible && second.possible, always: first.always && second.always}
+	}
+	normalized, header, listOutcome := jitMatchListValue(ctx, value, failLabel)
+	if !listOutcome.possible {
+		return jitMatchOutcome{}
+	}
+	if normalized.Loc == LocImm {
+		list := normalized.Imm.Slice()
+		if len(list) == 0 {
+			return jitMatchOutcome{}
+		}
+		head := JITValueDesc{Loc: LocImm, Type: list[0].GetTag(), Imm: list[0]}
+		tailValue := NewSlice(list[1:])
+		tail := JITValueDesc{Loc: LocImm, Type: tagSlice, Imm: tailValue, KnownSliceLen: int32(len(list) - 1), KnownSliceCap: int32(cap(list) - 1), SliceSizeKnown: true}
+		first := jitCompileMatchPattern(ctx, head, patterns[0], env, failLabel)
+		second := jitCompileMatchPattern(ctx, tail, patterns[1], env, failLabel)
+		return jitMatchOutcome{possible: first.possible && second.possible, always: first.always && second.always}
+	}
+	if header.SliceSizeKnown {
+		if header.KnownSliceLen == 0 {
+			ctx.FreeDesc(&header)
+			ctx.FreeDesc(&normalized)
+			return jitMatchOutcome{}
+		}
+	} else {
+		ctx.EmitCmpRegImm32(header.Reg2, 0)
+		ctx.EmitJcc(CcE, failLabel)
+		listOutcome.always = false
+	}
+	head := jitMatchLoadElement(ctx, &header, 0)
+	tail := jitMatchSliceTail(ctx, &header)
+	first := jitCompileMatchPattern(ctx, head, patterns[0], env, failLabel)
+	second := jitCompileMatchPattern(ctx, tail, patterns[1], env, failLabel)
+	ctx.FreeDesc(&head)
+	ctx.FreeDesc(&tail)
+	ctx.FreeDesc(&header)
+	ctx.FreeDesc(&normalized)
+	return jitMatchOutcome{
+		possible: first.possible && second.possible,
+		always:   listOutcome.always && first.always && second.always,
+	}
+}
+
+func jitCompileMatchPattern(ctx *JITContext, value JITValueDesc, pattern Scmer, env *JITEnv, failLabel uint8) jitMatchOutcome {
+	for pattern.IsSourceInfo() {
+		pattern = pattern.SourceInfo().value
+	}
+	switch pattern.GetTag() {
+	case tagInt, tagFloat, tagString:
+		return jitMatchLiteral(ctx, value, pattern, failLabel)
+	case tagNthLocalVar:
+		if int(pattern.NthLocalVar()) >= len(env.Numbered) {
+			return jitMatchLiteral(ctx, value, pattern, failLabel)
+		}
+		jitMatchBindValue(ctx, env, pattern, value)
+		return jitMatchOutcome{possible: true, always: true}
+	case tagSymbol:
+		switch pattern.String() {
+		case "nil":
+			if value.Loc == LocImm {
+				matched := value.Imm.IsNil()
+				return jitMatchOutcome{possible: matched, always: matched}
+			}
+			if value.Type != JITTypeUnknown {
+				matched := value.Type == tagNil
+				return jitMatchOutcome{possible: matched, always: matched}
+			}
+			return jitEmitMatchTag(ctx, &value, tagNil, failLabel)
+		case "true":
+			return jitMatchBoolLiteral(ctx, value, true, failLabel)
+		case "false":
+			return jitMatchBoolLiteral(ctx, value, false, failLabel)
+		default:
+			jitMatchBindValue(ctx, env, pattern, value)
+			return jitMatchOutcome{possible: true, always: true}
+		}
+	case tagSlice:
+		p := pattern.Slice()
+		if len(p) == 0 {
+			panic("jit: empty match pattern")
+		}
+		if _, direct := scmerSymbolName(p[0]); !direct {
+			if nested, ok := scmerAsSlice(p[0]); ok && len(nested) > 0 {
+				if head, ok := scmerSymbolName(nested[0]); ok && (head == "symbol" || head == "quote") {
+					return jitMatchFixedList(ctx, value, p, env, failLabel)
+				}
+			}
+			panic("jit: unsupported nested match pattern")
+		}
+		name, _ := scmerSymbolName(p[0])
+		switch name {
+		case "eval":
+			if len(p) != 2 {
+				panic("jit: malformed eval match pattern")
+			}
+			outerEnv := ctx.Env
+			ctx.Env = env
+			expected := jitCompileExpr(ctx, p[1], ctx.SliceBase, JITValueDesc{Loc: LocAny})
+			ctx.Env = outerEnv
+			return jitMatchDynamicValue(ctx, value, expected, failLabel)
+		case "var":
+			if len(p) != 2 || !p[1].IsInt() {
+				panic("jit: malformed var match pattern")
+			}
+			jitMatchBindValue(ctx, env, NewNthLocalVar(NthLocalVar(p[1].Int())), value)
+			return jitMatchOutcome{possible: true, always: true}
+		case "list":
+			return jitMatchFixedList(ctx, value, p[1:], env, failLabel)
+		case "quote", "symbol":
+			if len(p) != 2 {
+				panic("jit: malformed symbol match pattern")
+			}
+			return jitMatchSymbol(ctx, value, p[1], failLabel)
+		case "string?":
+			if len(p) != 2 {
+				panic("jit: malformed string match pattern")
+			}
+			outcome := jitMatchString(ctx, value, failLabel)
+			if !outcome.possible {
+				return outcome
+			}
+			inner := jitCompileMatchPattern(ctx, value, p[1], env, failLabel)
+			return jitMatchOutcome{possible: inner.possible, always: outcome.always && inner.always}
+		case "number?":
+			if len(p) != 2 {
+				panic("jit: malformed number match pattern")
+			}
+			outcome := jitMatchNumber(ctx, value, failLabel)
+			if !outcome.possible {
+				return outcome
+			}
+			inner := jitCompileMatchPattern(ctx, value, p[1], env, failLabel)
+			return jitMatchOutcome{possible: inner.possible, always: outcome.always && inner.always}
+		case "list?":
+			if len(p) != 2 {
+				panic("jit: malformed list match pattern")
+			}
+			normalized, header, outcome := jitMatchListValue(ctx, value, failLabel)
+			if !outcome.possible {
+				return outcome
+			}
+			ctx.FreeDesc(&header)
+			inner := jitCompileMatchPattern(ctx, normalized, p[1], env, failLabel)
+			ctx.FreeDesc(&normalized)
+			return jitMatchOutcome{possible: inner.possible, always: outcome.always && inner.always}
+		case "cons":
+			return jitMatchCons(ctx, value, p[1:], env, failLabel)
+		default:
+			panic("jit: unsupported match pattern " + name)
+		}
+	default:
+		panic("jit: unsupported match pattern type")
+	}
+}
+
+func jitCompileMatch(ctx *JITContext, list []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	if len(list) < 2 {
+		panic("jit: match expects a value")
+	}
+	valueExpr := list[1]
+	for valueExpr.IsSourceInfo() {
+		valueExpr = valueExpr.SourceInfo().value
+	}
+	var value JITValueDesc
+	if items, ok := scmerAsSlice(valueExpr); ok && len(items) > 0 && items[0].SymbolEquals("list") {
+		values := make([]JITValueDesc, len(items)-1)
+		for i := 1; i < len(items); i++ {
+			item := jitCompileExpr(ctx, items[i], sliceBase, JITValueDesc{Loc: LocAny})
+			values[i-1] = jitMatchStableValue(ctx, item)
+		}
+		value = JITValueDesc{
+			Loc: LocVirtualSlice, Type: tagSlice, Virtual: values,
+			KnownSliceLen: int32(len(values)), KnownSliceCap: int32(len(values)), SliceSizeKnown: true,
+		}
+	} else {
+		value = jitCompileExpr(ctx, valueExpr, sliceBase, JITValueDesc{Loc: LocAny})
+	}
+	value = jitMatchStableValue(ctx, value)
+	target := jitEnsureResultPair(ctx, result)
+	endLabel := ctx.ReserveLabel()
+	hasBranch := false
+	terminated := false
+	baseEnv := ctx.Env
+	i := 2
+	for i+1 < len(list) {
+		nextLabel := ctx.ReserveLabel()
+		branchEnv := jitMatchBranchEnv(baseEnv)
+		outcome := jitCompileMatchPattern(ctx, value, list[i], branchEnv, nextLabel)
+		if outcome.possible {
+			ctx.Env = branchEnv
+			branchValue := jitCompileExpr(ctx, list[i+1], sliceBase, target)
+			ctx.Env = baseEnv
+			_ = jitPlaceIntoPair(ctx, &branchValue, target)
+			ctx.EmitJmp(endLabel)
+			hasBranch = true
+		}
+		ctx.MarkLabel(nextLabel)
+		i += 2
+		if outcome.always {
+			terminated = true
+			break
+		}
+	}
+	ctx.Env = baseEnv
+	if !terminated {
+		var fallback JITValueDesc
+		if i < len(list) {
+			fallback = jitCompileExpr(ctx, list[i], sliceBase, target)
+		} else {
+			fallback = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
+		}
+		_ = jitPlaceIntoPair(ctx, &fallback, target)
+	}
+	if hasBranch {
+		ctx.MarkLabel(endLabel)
+	}
+	ctx.FreeDesc(&value)
+	ctx.BindReg(target.Reg, &target)
+	ctx.BindReg(target.Reg2, &target)
+	return target
 }
 
 // EmitNewSliceFromGoSlice retags a Go []Scmer header as a Scheme list without
@@ -1053,6 +1704,8 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			return JITValueDesc{Loc: LocImm, Type: q.GetTag(), Imm: q}
 		case "!list":
 			return jitCompileStackList(ctx, list, sliceBase, result)
+		case "match", "match_mut":
+			return jitCompileMatch(ctx, list, sliceBase, result)
 		case "if":
 			if len(list) < 3 {
 				imm := NewNil()


### PR DESCRIPTION
## Summary

- lower `match` and `match_mut` as native control flow in the x86 JIT emitter
- propagate pattern bindings through branch-local `JITValueDesc` environments
- prune impossible alternatives from known type and slice-shape facts, including fully virtual `(list ...)` values
- destructure list, cons, symbol/quote, scalar, `string?`, `number?`, `list?`, and `eval` patterns without calling the Scheme evaluator
- normalize Slice, FastDict, and SourceInfo list representations while preserving empty-list semantics
- make named parameters available from the original input frame when optimizer barriers such as `(eval ...)` prevent numbered-local rewriting

This builds on the map/reduce callback emitter merged in #486. Unsupported pattern families such as `concat`, `merge`, `ignorecase`, and `regex` still reject JIT compilation and retain the existing interpreter fallback.

## Why

`match` is one of the dominant special forms in `lib/queryplan.scm`. Previously any procedure containing it stopped JIT compilation with `callable has no JIT emitter: match`. The emitter now turns patterns into direct branches and only emits checks that remain possible under the current `JITValueDesc` facts.

For example, matching a compiler-known two-element `(list 'alias value)` against an alias pattern proves the type, length, and literal head at compile time. The later impossible alternative is not emitted. The resulting function is 54 bytes and contains only frame/input/result moves; there are no pattern checks, evaluator calls, or match trampolines.

## Performance

A local A/B benchmark ran a query-planner-shaped five-element alias pattern 1,000,000 times. It includes the surrounding Scheme loop and checksum work:

| Version | Median | Native match |
| --- | ---: | --- |
| parent (`9b3bba6e`) | 1.783 s | no |
| this branch | 1.267 s | yes |

That is about 29% lower end-to-end time, or 1.41x throughput, despite the shared loop/checksum overhead.

## Validation

- patched compiler: `GOEXPERIMENT=jit /home/carli/projekte/go-jit/goroot/bin/go build -o memcp .`
- patched JIT runtime: `./memcp lib/test.scm` — 1188/1188 passed
- vanilla compiler: `go build -o memcp .`
- vanilla runtime: `./memcp lib/test.scm` — 1188/1188 passed
- regression coverage includes branch fallthrough, list length/literal rejection, cons head/tail, FastDict normalization, typed alternatives, `list?`, runtime `eval` equality, and compile-time removal of an unreachable invalid branch
- disassembled the known-shape case: 54 bytes, no calls and no residual pattern checks

Per the requested JIT workflow, no Go tests, SQL suites, or pre-commit hook were run.
