### PR TITLE
Replace ordered join callback breaks with native limits

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -14351,6 +14351,28 @@ key-fill recipe per carrier. */
 	(late_projection_sources_preserve_rows_acc
 		stages sources sources prelimit_sources default_alias final_condition '())))
 
+(define ordered_join_sources_are_unique_lookups_acc (lambda (sources default_alias stages condition bound_sources remaining_sources)
+	(match (coalesceNil remaining_sources '())
+		(cons src rest) (and
+			(source_is_unique_lookup_from_sources? sources default_alias bound_sources src stages condition)
+			(ordered_join_sources_are_unique_lookups_acc
+				sources default_alias stages condition (cons src bound_sources) rest))
+		_ true)))
+
+(define ordered_join_native_limit_supported? (lambda (sources plan default_alias order_items stages final_condition)
+	(begin
+		(define ordered_sources (join_optimizer_sources_for_order sources
+			(join_optimizer_tree_aliases plan)))
+		(define driver (car ordered_sources))
+		(define order_parts (split_order_items_for_join_driver
+			ordered_sources default_alias driver order_items stages final_condition '()))
+		(define proof_condition (combine_where final_condition
+			(join_optimizer_node_condition (join_optimizer_tree_predicates plan))))
+		(and
+			(empty_list? (nth order_parts 1))
+			(ordered_join_sources_are_unique_lookups_acc
+				sources default_alias stages proof_condition (list driver) (cdr ordered_sources))))))
+
 (define ordered_join_limit_requires_complete_rows? (lambda (sources default_alias final_condition offset_value limit_value)
 	(and
 		(query_limit_active? offset_value limit_value)
@@ -14831,7 +14853,7 @@ either bound a real row or supplied the synthetic NULL row. */
 (define recset_contains_callback_symbol (symbol "__recset_contains"))
 
 (define scan_callback_symbol_for_alias (lambda (alias col)
-	(if (or (equal? col "$break") (equal? col "$tx"))
+	(if (equal? col "$tx")
 		(symbol col)
 		(if (equal? col "$recset_contains")
 			recset_contains_callback_symbol
@@ -14853,7 +14875,11 @@ either bound a real row or supplied the synthetic NULL row. */
 			recset_contains_callback_symbol
 			expr))))
 
-(define join_ordered_stream_plan (lambda (schema all_sources plan default_alias needed_exprs final_condition fields order_items offset_value limit_value stages)
+/* A bounded ordered join may use the logical driver directly only when every
+remaining source is a proven unique lookup. The ordinary filter stays driver-local
+and indexable. The nested lookup acceptance runs in scan_order's globally ordered
+stream before its native OFFSET/LIMIT counters; projection only sees the window. */
+(define join_ordered_native_limit_plan (lambda (schema all_sources plan default_alias needed_exprs final_condition fields order_items offset_value limit_value stages)
 	(begin
 		(define ordered_aliases (join_optimizer_tree_aliases plan))
 		(define ordered_sources (join_optimizer_sources_for_order all_sources ordered_aliases))
@@ -14879,52 +14905,38 @@ either bound a real row or supplied the synthetic NULL row. */
 			(recset_project_join_expr_for_membership src membership)))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		(define acceptance_needed_exprs (merge (list
+			needed_exprs
+			(list remaining_condition)
+			(source_join_exprs remaining_sources))))
+		(define acceptance_probe (build_join_scan_reduce_using_recipe
+			schema all_sources remaining_plan default_alias acceptance_needed_exprs remaining_condition true
+			'() 0 1 true nil stages
+			(list (quote lambda) (list (quote _accepted) (quote _row)) true)
+			false
+			(list (quote lambda) (list (quote accepted) (quote shard_accepted))
+				(list (quote or) (quote accepted) (quote shard_accepted)))))
 		(define filtercols (join_cols_for_alias all_sources default_alias alias (list effective_condition)))
 		(define filter_expr (list (quote lambda)
 			(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
-			(list (quote optimize) (lower_column_expr_for_join all_sources default_alias effective_condition))))
-		(define row_expr (cons (quote list) (lower_join_result_fields all_sources default_alias fields)))
+			(list (quote optimize)
+				(lower_column_expr_for_join all_sources default_alias effective_condition))))
+		(define acceptance_cols (join_cols_for_alias all_sources default_alias alias acceptance_needed_exprs))
+		(define acceptance_expr (list (quote lambda)
+			(map acceptance_cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+			(list (quote optimize) acceptance_probe)))
+		(define row_expr (list (quote resultrow)
+			(cons (quote list) (lower_join_result_fields all_sources default_alias fields))))
 		(define offset (coalesceNil offset_value 0))
 		(define limit (coalesceNil limit_value -1))
-		(define finite_limit (not (equal? limit -1)))
-		(define mapcols (merge_unique (list
-			(join_cols_for_alias all_sources default_alias alias needed_exprs)
-			(if finite_limit (list "$break") '()))))
-		(define end (list (quote +) offset limit))
-		(define projection_reduce (list (quote lambda) (list (quote __matched) (quote __row))
-			(list (quote begin)
-				(list (quote define) (quote __position) (list (quote +) (quote __accepted) (quote __matched)))
-				(list (quote if)
-					(list (quote and)
-						(list (quote >=) (quote __position) offset)
-						(list (quote or)
-							(list (quote equal?) limit -1)
-							(list (quote <) (quote __position) end)))
-					(list (quote resultrow) (quote __row))
-					nil)
-				(list (quote +) (quote __matched) 1))))
-		(define projection (build_join_scan_reduce_using_recipe
+		(define mapcols (join_cols_for_alias all_sources default_alias alias needed_exprs))
+		(define projection (build_join_scan_pipeline_using_recipe
 			schema all_sources remaining_plan default_alias needed_exprs remaining_condition row_expr
 			remaining_order_items 0 -1 true nil stages
-			projection_reduce
-			0
-			(list (quote lambda) (list (quote count) (quote matched))
-				(list (quote +) (quote count) (quote matched)))))
+		))
 		(define map_expr (list (quote lambda)
 			(map mapcols (lambda (col) (scan_callback_symbol_for_alias alias col)))
-			(list (quote lambda) (list (quote __accepted))
-				(if finite_limit
-					(list (quote if)
-						(list (quote >=) (quote __accepted) (list (quote +) offset limit))
-						(list (symbol "$break"))
-						projection)
-					projection))))
-		(define reduce_expr (list (quote lambda)
-			(list (quote __accepted) (quote __continuation))
-			(list
-				(list (quote lambda) (list (quote __matched))
-					(list (quote +) (quote __accepted) (quote __matched)))
-				(list (quote __continuation) (quote __accepted)))))
+			projection))
 		(define scan_expr (list (quote scan_order)
 			'(session "__memcp_tx")
 			(coalesceNil membership_table_expr (source_table_expr_using stages src))
@@ -14933,12 +14945,12 @@ either bound a real row or supplied the synthetic NULL row. */
 			(cons (quote list) (scan_order_sort_columns_for_join_driver
 				ordered_sources default_alias src driver_order_items stages final_condition))
 			(cons (quote list) (order_relations_for_source src driver_order_items))
-			0 0 -1
+			0 offset limit
 			(cons (quote list) mapcols)
-			map_expr reduce_expr 0 false))
-		(list
-			(list (quote lambda) (list (quote __accepted)) nil)
-			scan_expr))))
+			map_expr nil nil false nil
+			(cons (quote list) acceptance_cols)
+			acceptance_expr))
+		scan_expr)))
 
 (define without_col (lambda (cols col)
 	(filter (coalesceNil cols '()) (lambda (item) (not (equal? item col))))))
@@ -15304,6 +15316,16 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 			(join_order_intermediate_result_fields rest (cdr value_names))))
 		_ '())))
 
+(define join_order_intermediate_has_union_membership? (lambda (sources final_condition)
+	(reduce sources (lambda (found src)
+		(if found
+			true
+			(begin
+				(define membership (driver_membership_for_source src
+					(combine_where (source_join_expr src) final_condition)))
+				(and (not (nil? membership))
+					(union_block? (gs_input (nth membership 0))))))) false)))
+
 (define join_order_intermediate_reduce_scan (lambda (table_expr value_names order_names order_items offset_value limit_value map_expr reduce_expr neutral_expr)
 	(list (quote scan_order)
 		'(session "__memcp_tx")
@@ -15330,10 +15352,15 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 		(define table_key (concat "__join_order_intermediate:" (uuid)))
 		(define table_name (list (quote session) table_key))
 		(define table_expr (list (quote table) (qb_schema block) table_name))
+		/* Keep a logically implied membership as the scan source while filling
+		the storage carrier. Other joins retain their established base-table scan
+		path; enabling RecSet carriers globally regresses scalar ORDER pipelines. */
+		(define allow_membership_carrier
+			(join_order_intermediate_has_union_membership? scan_sources final_condition))
 		(define fill_plan (build_join_scan_pipeline_using_recipe
 			(qb_schema block) scan_sources scan_plan default_alias needed_exprs final_condition
 			(join_order_intermediate_insert table_expr column_names lowered_values)
-			'() 0 -1 false nil stage_catalog))
+			'() 0 -1 allow_membership_carrier nil stage_catalog))
 		(define scan_plan_expr (scan_builder table_expr value_names order_names))
 		(define drop_plan (list (quote droptable) (qb_schema block) table_name true))
 		(list (quote !begin)
@@ -15884,9 +15911,14 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 						(qb_schema block) scan_sources scan_plan first_alias needed_exprs
 						final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
 					(if hierarchical_order
-						(join_ordered_stream_plan
-							(qb_schema block) scan_sources scan_plan first_alias needed_exprs
-							final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
+						(if (ordered_join_native_limit_supported?
+							scan_sources scan_plan first_alias order_items stage_catalog final_condition)
+							(join_ordered_native_limit_plan
+								(qb_schema block) scan_sources scan_plan first_alias needed_exprs
+								final_condition fields order_items (qb_offset block) (qb_limit block) stage_catalog)
+							(lower_join_order_through_intermediate
+								block fields scan_sources scan_plan first_alias needed_exprs
+								final_condition order_items stage_catalog))
 						(if (physical_prejoin_supported? block)
 							(lower_query_block_through_prejoin block)
 							(lower_join_order_through_intermediate

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -540,6 +540,8 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 			col.OrcReduceInit,
 			false,
 			col.OrcReduceInit,
+			nil,
+			scm.NewNil(),
 		)
 	})
 }

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -72,7 +72,7 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	// if rewritten := tryScanOrderBatchRewrite(v); !rewritten.IsNil() {
 	// 	return oc.OptimizeSub(rewritten, useResult)
 	// }
-	mapEnd, reduceIdx, neutralIdx, outerIdx, notFoundIdx := 11, 12, 13, 14, 15
+	mapEnd, reduceIdx, neutralIdx, outerIdx, notFoundIdx, postOrderColsIdx, postOrderFilterIdx := 11, 12, 13, 14, 15, 16, 17
 	rawReduce := scm.NewNil()
 	if len(v) > reduceIdx {
 		rawReduce = v[reduceIdx]
@@ -96,6 +96,12 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	}
 	if len(v) > notFoundIdx {
 		v[notFoundIdx], _ = oc.OptimizeSub(v[notFoundIdx], true)
+	}
+	if len(v) > postOrderColsIdx {
+		v[postOrderColsIdx], _ = oc.OptimizeSub(v[postOrderColsIdx], true)
+	}
+	if len(v) > postOrderFilterIdx {
+		v[postOrderFilterIdx], _ = oc.OptimizeSub(v[postOrderFilterIdx], true)
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
@@ -136,17 +142,18 @@ func skipPartition(q *globalqueue, qx *shardqueue, pk []scm.Scmer, n int) {
 }
 
 type shardqueue struct {
-	shard          *storageShard
-	items          []uint32 // TODO: refactor to chan, so we can block generating too much entries
-	candidateCount int64
-	err            scanError
-	scols          []func(uint32) scm.Scmer // sort criteria column reader
-	sortdirs       []func(...scm.Scmer) scm.Scmer
-	sortless       []func(scm.Scmer, scm.Scmer) bool
-	mapper         *ShardMapReducer
-	callbackCols   []string  // per-table map columns (for multi-table merge)
-	callback       scm.Scmer // per-table map function (for multi-table merge)
-	tableIdx       int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
+	shard           *storageShard
+	items           []uint32 // TODO: refactor to chan, so we can block generating too much entries
+	candidateCount  int64
+	err             scanError
+	scols           []func(uint32) scm.Scmer // sort criteria column reader
+	sortdirs        []func(...scm.Scmer) scm.Scmer
+	sortless        []func(scm.Scmer, scm.Scmer) bool
+	mapper          *ShardMapReducer
+	postOrderMapper *ShardMapReducer
+	callbackCols    []string  // per-table map columns (for multi-table merge)
+	callback        scm.Scmer // per-table map function (for multi-table merge)
+	tableIdx        int       // index into scanOrderMulti tables slice; 0 for single-table scan_order
 }
 
 // scanOrderResult bundles per-shard outputs for ordered scans.
@@ -310,13 +317,15 @@ func topKByOrder(items []uint32, keep int, less func(a, b uint32) bool) []uint32
 
 // scanOrderTableSpec holds per-table parameters for scanOrderMulti.
 type scanOrderTableSpec struct {
-	table         *table
-	recset        *recSet
-	conditionCols []string
-	condition     scm.Scmer
-	sortcols      []scm.Scmer
-	callbackCols  []string
-	callback      scm.Scmer
+	table           *table
+	recset          *recSet
+	conditionCols   []string
+	condition       scm.Scmer
+	sortcols        []scm.Scmer
+	callbackCols    []string
+	callback        scm.Scmer
+	postOrderCols   []string
+	postOrderFilter scm.Scmer
 	// perTableOffset / perTableLimit: -1 disables per-table limiting for this
 	// table; otherwise the first `perTableOffset` rows (in merge order) are
 	// skipped and at most `perTableLimit` rows are emitted from this table.
@@ -451,6 +460,20 @@ func orderedIndexUsageWeight(rows, kept int) float64 {
 	return weight
 }
 
+// orderedScanIndexUsageWeight distinguishes a selective access path from a
+// pure ORDER BY Top-k. A restrictive boundary can avoid the complete scan, so
+// it must train the autoindex at the normal rate even when the result window is
+// tiny. Unbounded order boundaries only accelerate Top-k and retain the lower
+// build weight above.
+func orderedScanIndexUsageWeight(bounds boundaries, rows, kept int) float64 {
+	for _, bound := range bounds {
+		if !boundaryIsUnboundedOrder(bound) {
+			return 1
+		}
+	}
+	return orderedIndexUsageWeight(rows, kept)
+}
+
 func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 	var p scm.Proc
 	if condition.IsProc() {
@@ -541,6 +564,11 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		// per-table sort order. This prunes work at the shard level before
 		// the merge enforces the per-table offset/limit globally.
 		shardTotalLimit := total_limit
+		// A post-order predicate can reject any prefix of the ordered stream.
+		// Shards therefore cannot truncate before the global merge has applied it.
+		if !spec.postOrderFilter.IsNil() {
+			shardTotalLimit = -1
+		}
 		if spec.perTableLimit >= 0 {
 			ptTotal := spec.perTableLimit
 			if spec.perTableOffset > 0 {
@@ -713,7 +741,9 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			tableStats := &stats[msg.res.tableIdx]
 			tableStats.inputCount += msg.inputCount
 			tableStats.candidateCount += msg.candidateCount
-			tableStats.outputCount += msg.outputCount
+			if tables[msg.res.tableIdx].postOrderFilter.IsNil() {
+				tableStats.outputCount += msg.outputCount
+			}
 		}
 	}
 	if scanErr.r != nil {
@@ -726,6 +756,15 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	// initialize MapReducers per shard (each shard uses its table's callbackCols/callback)
 	for _, sq := range q.q {
 		sq.mapper = sq.shard.OpenMapReducer(sq.callbackCols, sq.callback, aggregate, false, 0, nil, currentTx)
+		spec := &tables[sq.tableIdx]
+		if !spec.postOrderFilter.IsNil() {
+			sq.postOrderMapper = sq.shard.OpenMapReducer(
+				spec.postOrderCols,
+				spec.postOrderFilter,
+				scm.NewFunc(func(args ...scm.Scmer) scm.Scmer { return args[1] }),
+				false, 0, nil, currentTx,
+			)
+		}
 	}
 
 	var buf [1024]uint32 // stack-allocated batch buffer (4 KB, fits in L1)
@@ -756,26 +795,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			continue
 		}
 
-		// Per-table limit: discard remaining shardqueue items once the
-		// per-table quota is exhausted. Sibling shardqueues of the same
-		// tableIdx are dropped as they reach the heap top.
 		ti := qx.tableIdx
-		if ti < len(tablePartLimit) && tablePartLimit[ti] == 0 {
-			heap.Pop(&q)
-			continue
-		}
-		// Per-table offset skip: consume leading items without emitting.
-		if ti < len(tablePartOffset) && tablePartOffset[ti] > 0 {
-			tablePartOffset[ti]--
-			qx.items = qx.items[1:]
-			if len(qx.items) > 0 {
-				heap.Fix(&q, 0)
-			} else {
-				heap.Pop(&q)
-			}
-			continue
-		}
-
 		// Extract partition key from leading sort columns (empty slice when limitPartitionCols == 0)
 		peekItem := qx.items[0]
 		curPK := make([]scm.Scmer, limitPartitionCols)
@@ -796,6 +816,38 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 			partOffset = offset
 			partLimit = limit
 			prevPK = curPK
+		}
+
+		// This predicate intentionally runs after ordering, but before offsets and
+		// limits are counted. It supports expensive nested lookup acceptance without
+		// turning callback-controlled panics into an execution-control mechanism.
+		if qx.postOrderMapper != nil && !scm.ToBool(qx.postOrderMapper.MapOne(peekItem)) {
+			qx.items = qx.items[1:]
+			if len(qx.items) > 0 {
+				heap.Fix(&q, 0)
+			} else {
+				heap.Pop(&q)
+			}
+			continue
+		}
+		if qx.postOrderMapper != nil {
+			stats[ti].outputCount++
+		}
+
+		// Per-table offsets and limits count only post-order accepted records.
+		if ti < len(tablePartLimit) && tablePartLimit[ti] == 0 {
+			heap.Pop(&q)
+			continue
+		}
+		if ti < len(tablePartOffset) && tablePartOffset[ti] > 0 {
+			tablePartOffset[ti]--
+			qx.items = qx.items[1:]
+			if len(qx.items) > 0 {
+				heap.Fix(&q, 0)
+			} else {
+				heap.Pop(&q)
+			}
+			continue
 		}
 		// Per-partition offset skip
 		if partOffset > 0 {
@@ -912,19 +964,21 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 }
 
 // scan_order delegates to scanOrderMulti with a single-element table spec.
-func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
-	if len(sortcols) == 0 && limitPartitionCols == 0 && offset == 0 && limit == 1 && !aggregate.IsNil() && !isOuter {
+func (t *table) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer, postOrderCols []string, postOrderFilter scm.Scmer) scm.Scmer {
+	if postOrderFilter.IsNil() && len(sortcols) == 0 && limitPartitionCols == 0 && offset == 0 && limit == 1 && !aggregate.IsNil() && !isOuter {
 		return t.scanOrderFirst(currentTx, conditionCols, condition, callbackCols, callback, aggregate, neutral, notFoundValue)
 	}
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
-		table:          t,
-		conditionCols:  conditionCols,
-		condition:      condition,
-		sortcols:       sortcols,
-		callbackCols:   callbackCols,
-		callback:       callback,
-		perTableOffset: -1,
-		perTableLimit:  -1,
+		table:           t,
+		conditionCols:   conditionCols,
+		condition:       condition,
+		sortcols:        sortcols,
+		callbackCols:    callbackCols,
+		callback:        callback,
+		postOrderCols:   postOrderCols,
+		postOrderFilter: postOrderFilter,
+		perTableOffset:  -1,
+		perTableLimit:   -1,
 	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter, notFoundValue)
 }
 
@@ -989,19 +1043,21 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 	return result
 }
 
-func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
+func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer, postOrderCols []string, postOrderFilter scm.Scmer) scm.Scmer {
 	if currentTx == nil {
 		currentTx = r.tx
 	}
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
-		recset:         r,
-		conditionCols:  conditionCols,
-		condition:      condition,
-		sortcols:       sortcols,
-		callbackCols:   callbackCols,
-		callback:       callback,
-		perTableOffset: -1,
-		perTableLimit:  -1,
+		recset:          r,
+		conditionCols:   conditionCols,
+		condition:       condition,
+		sortcols:        sortcols,
+		callbackCols:    callbackCols,
+		callback:        callback,
+		postOrderCols:   postOrderCols,
+		postOrderFilter: postOrderFilter,
+		perTableOffset:  -1,
+		perTableLimit:   -1,
 	}}, sortdirs, limitPartitionCols, offset, limit, aggregate, neutral, isOuter, notFoundValue)
 }
 
@@ -1158,7 +1214,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		resultCap := 1024
 		result.items = make([]uint32, resultCap)
 		resultN := 0
-		usageWeight := orderedIndexUsageWeight(int(visibleUpper), limit)
+		usageWeight := orderedScanIndexUsageWeight(boundaries, int(visibleUpper), limit)
 		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, func(index *StorageIndex, active bool) {
 			resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
 		}, func(batch []uint32) bool {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1535,6 +1535,19 @@ type ShardMapReducer struct {
 	shardWriteLocked bool
 }
 
+// MapOne evaluates the mapper for one already-visible record. Ordered scans use
+// this outside shard locks for predicates that must run after global ordering.
+func (m *ShardMapReducer) MapOne(id uint32) scm.Scmer {
+	getters := m.mainGetters
+	if id >= m.mainCount {
+		getters = m.deltaGetters
+	}
+	for i, getter := range getters {
+		m.args[i] = getter(id, 0)
+	}
+	return m.mapFn(m.args...)
+}
+
 // OpenMapReducer creates a MapReducer for the given columns. Column readers and
 // main storage references are built once; the args buffer is pre-allocated.
 // mapFn and reduceFn are stored as Scmer for future network serialization;

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -475,6 +475,9 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 }
 
 func Init(en scm.Env) {
+	const scanFilterColumnsDesc = "physical columns passed to filter before map/reduce; $recset_contains supplies a row-bound RecSet membership closure"
+	const scanMapColumnsDesc = "physical columns passed to map after filtering; pseudo columns are $update (update/delete current row), $recset_contains (row-bound RecSet membership), $set:<column>, $increment:<column>, and $invalidate:<column> (computed-column maintenance), plus NEW.<column> in trigger plans"
+	const scanOrderMapColumnsDesc = scanMapColumnsDesc + "; $break is reserved for internal ORC convergence and must not implement SQL OFFSET/LIMIT, which belong in the native offset and limit arguments"
 	scm.DeclareTitle("Storage")
 
 	// Register TagTable serializer for the printer.
@@ -847,9 +850,9 @@ func Init(en scm.Env) {
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
 				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local recset, or a list for temporary data"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter"},
+				{Kind: "list", ParamName: "filterColumns", ParamDesc: scanFilterColumnsDesc},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map"},
+				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanMapColumnsDesc},
 				{Kind: "func", ParamName: "map", ParamDesc: "lambda function to extract data from the dataset. You can use any column of that table as lambda parameter. You can return a value you want to extract and pass to reduce, but you can also directly call insert, print or resultrow functions. If you declare a parameter named '$update', this variable will hold a function that you can use to delete or update a row. Call ($update) to delete the dataset, call ($update '(\"field1\" value1 \"field2\" value2)) to update certain columns.", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 				{Kind: "func", Params: []*scm.TypeDescriptor{{}, nil}, ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results. It takes two parameters (a b) where a is the accumulator and b the new value. The accumulator for the first reduce call is the neutral element. The return value will be the accumulator input for the next reduce call. There are two reduce phases: shard-local and shard-collect. In the shard-local phase, a starts with neutral and b is fed with the return values of each map call. In the shard-collect phase, a starts with neutral and b is fed with the result of each shard-local pass.", Optional: true},
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
@@ -1003,6 +1006,12 @@ func Init(en scm.Env) {
 			if len(a) > layout.limitIdx+6 {
 				notFoundValue = a[layout.limitIdx+6]
 			}
+			postOrderCols := []string(nil)
+			postOrderFilter := scm.NewNil()
+			if len(a) > layout.limitIdx+8 {
+				postOrderCols = scmerSliceToStrings(mustScmerSlice(a[layout.limitIdx+7], "postOrderFilterColumns"))
+				postOrderFilter = a[layout.limitIdx+8]
+			}
 
 			// TODO(planner-scalability): remove list-backed relational scans after
 			// metadata/RDF callers use physical scan sources. Query plans must never
@@ -1013,6 +1022,11 @@ func Init(en scm.Env) {
 				filterparams := make([]scm.Scmer, len(filtercols))
 				mapfn := scm.OptimizeProcToSerialFunction(a[layout.limitIdx+2])
 				mapparams := make([]scm.Scmer, len(mapcols))
+				var postOrderFn func(...scm.Scmer) scm.Scmer
+				postOrderParams := make([]scm.Scmer, len(postOrderCols))
+				if !postOrderFilter.IsNil() {
+					postOrderFn = scm.OptimizeProcToSerialFunction(postOrderFilter)
+				}
 				reducefn := func(args ...scm.Scmer) scm.Scmer { return args[1] }
 				if !aggregate.IsNil() {
 					reducefn = scm.OptimizeProcToSerialFunction(aggregate)
@@ -1071,15 +1085,25 @@ func Init(en scm.Env) {
 				limit := int(scm.ToInt(a[layout.limitIdx]))
 				hadValue := false
 				count := 0
-				for idx, val := range filtered {
-					if idx < offset {
+				accepted := 0
+				for _, val := range filtered {
+					row := mustScmerSlice(val, "scan_order row")
+					ds := dataset(row)
+					if postOrderFn != nil {
+						for i, col := range postOrderCols {
+							postOrderParams[i], _ = ds.GetI(col)
+						}
+						if !scm.ToBool(postOrderFn(postOrderParams...)) {
+							continue
+						}
+					}
+					if accepted < offset {
+						accepted++
 						continue
 					}
 					if limit >= 0 && count >= limit {
 						break
 					}
-					row := mustScmerSlice(val, "scan_order row")
-					ds := dataset(row)
 					for i, col := range mapcols {
 						mapparams[i], _ = ds.GetI(col)
 					}
@@ -1100,30 +1124,32 @@ func Init(en scm.Env) {
 			}
 
 			if tableArg.IsCustom(TagRecSet) {
-				return RecSetFromScmer(tableArg).scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue)
+				return RecSetFromScmer(tableArg).scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue, postOrderCols, postOrderFilter)
 			}
 
 			t := TableFromScmer(a[layout.tableIdx])
 
-			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue)
+			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue, postOrderCols, postOrderFilter)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list", ParamName: "table", ParamDesc: "table handle or a list for temporary data"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter"},
+				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local RecSet, or a list for temporary data"},
+				{Kind: "list", ParamName: "filterColumns", ParamDesc: scanFilterColumnsDesc},
 				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of columns to sort. Each column is either a string to point to an existing column or a func(cols...)->any to compute a sortable value"},
 				{Kind: "list", ParamName: "sortdirs", ParamDesc: "list of column directions to sort. Must be same length as sortcols. < means ascending, > means descending, (collate ...) will add collations"},
 				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "number of leading sort columns that form the partition key for per-partition offset/limit. 0 (default) means global offset/limit."},
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of items to skip before the first one is fed into map"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "max number of items to read"},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map"},
+				{Kind: "number", ParamName: "offset", ParamDesc: "number of globally ordered, filter-accepted items to skip before map; apply SQL OFFSET here rather than in map"},
+				{Kind: "number", ParamName: "limit", ParamDesc: "maximum globally ordered, filter-accepted items passed to map; -1 means unlimited; apply SQL LIMIT here so shard-local Top-K and the global merge can brake early"},
+				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanOrderMapColumnsDesc},
 				{Kind: "func", ParamName: "map", ParamDesc: "lambda function to extract data from the dataset. You can use any column of that table as lambda parameter. You can return a value you want to extract and pass to reduce, but you can also directly call insert, print or resultrow functions. If you declare a parameter named '$update', this variable will hold a function that you can use to delete or update a row. Call ($update) to delete the dataset, call ($update '(\"field1\" value1 \"field2\" value2)) to update certain columns.", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results. It takes two parameters (a b) where a is the accumulator and b the new value. The accumulator for the first reduce call is the neutral element. The return value will be the accumulator input for the next reduce call. There are two reduce phases: shard-local and shard-collect. In the shard-local phase, a starts with neutral and b is fed with the return values of each map call. In the shard-collect phase, a starts with neutral and b is fed with the result of each shard-local pass.", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "acc"}, {Kind: "any", ParamName: "val"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
 				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
 				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
+				{Kind: "list", ParamName: "postOrderFilterColumns", ParamDesc: "(optional) columns for a predicate evaluated in global order before OFFSET/LIMIT are counted; use for expensive acceptance checks that cannot participate in index boundaries", Optional: true},
+				{Kind: "func", ParamName: "postOrderFilter", ParamDesc: "(optional) late acceptance predicate. Rejected rows do not count toward OFFSET/LIMIT and never reach map. SQL plans use this instead of callback-driven $break control flow", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrder,

--- a/tests/execution/operators/scan-order-native-limit.yaml
+++ b/tests/execution/operators/scan-order-native-limit.yaml
@@ -1,12 +1,10 @@
-# Tests for $break pseudo-column early-exit semantics.
-# The $break pseudo-column injects a closure into mapFn args that, when called,
-# panics with a breakSentinel causing the ordered-scan merge loop to stop.
-# This enables ORC early-exit (LIMIT semantics inside ORC window materialization).
-# These tests verify LIMIT + ORDER BY correctness which exercises the break path.
+# Native scan_order OFFSET/LIMIT coverage.
+# SQL LIMIT must be passed to scan_order itself so filtering, shard-local Top-K,
+# the global ordered merge, and mapping retain their physical phase boundaries.
 
 metadata:
   version: "1.0"
-  description: "$break early-exit: ORDER BY + LIMIT correctness"
+  description: "native scan_order OFFSET/LIMIT correctness"
   isolated: true
 
 test_cases:
@@ -74,6 +72,15 @@ test_cases:
     sql: "SELECT id FROM break_test ORDER BY val LIMIT 0"
     expect:
       rows: 0
+
+  - name: "EXPLAIN ORDER LIMIT does not emit callback break"
+    sql: "EXPLAIN SELECT id FROM break_test ORDER BY val LIMIT 3 OFFSET 2"
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "$break"
 
   - name: "Cleanup"
     sql: "DROP TABLE IF EXISTS break_test"

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -471,6 +471,37 @@ test_cases:
     expect:
       rows: 0
 
+  - name: "Ordered LIMIT counts rows accepted by a unique lookup filter"
+    sql: |
+      SELECT d.id, l.name
+      FROM ord_member_doc d
+      LEFT JOIN ord_member_label l ON l.id = d.label_id
+      WHERE l.visible = 1
+      ORDER BY d.rank_value DESC
+      LIMIT 1 OFFSET 1
+    expect:
+      rows: 1
+      data:
+        - { id: 3, name: "alpha" }
+
+  - name: "Ordered unique lookup filter uses native scan limit"
+    sql: |
+      EXPLAIN SELECT d.id, l.name
+      FROM ord_member_doc d
+      LEFT JOIN ord_member_label l ON l.id = d.label_id
+      WHERE l.visible = 1
+      ORDER BY d.rank_value DESC
+      LIMIT 1 OFFSET 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "ord_member_label"
+      result_not_contains:
+        - "$break"
+        - ".join-order:"
+        - "joined_matches"
+
   - name: "Grouped nullable lookup WHERE stays at its null-extension boundary"
     sql: |
       SELECT t.id, t.score

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1167,8 +1167,8 @@ test_cases:
             - "in_dv_file"
             - "recset_project_join"
             - "recset_union"
-            - "$break"
           not_contains:
+            - "$break"
             - ".grp:in_dv_file"
             - "touch_keytable"
 


### PR DESCRIPTION
## Summary

- replace the ordered-join `$break` callback workaround introduced by `7cb6915d4` with native `scan_order` offset/limit semantics
- keep cheap driver-local predicates in the indexable scan filter and evaluate expensive nested acceptance after global ordering but before offset/limit accounting
- run projection lookups only for accepted rows inside the requested result window
- document all scan pseudo-columns and reserve `$break` for the internal ORC convergence scan

## Commit audit

`7cb6915d4` combined the callback-controlled early-exit workaround with independent fixes for membership-carrier selection and generated Scheme evaluation. This PR removes only the `$break`/`__seen` execution-control path and retains the independent planner behavior.

## A/B benchmark

Anonymized 200,000-row ordered driver joined to a lookup table, filtered by a lookup predicate, `LIMIT 72 OFFSET 100`. Both binaries used the same data, two warmups and seven measured runs.

| | master `f092210f7` | PR `185698188` |
|---|---:|---:|
| median | 1.471428 s | 0.770644 s |
| min | 1.418797 s | 0.764474 s |
| max | 1.561115 s | 0.782275 s |
| physical plan bytes | 3,073 | 2,651 |
| emitted `$break` | 2 | 0 |

The PR is about 1.91x faster. Both sides returned 2,448 identical bytes with SHA-256 `01583383bf937194b9815e87fdacb2aca7d94f8a09cb84c13e02204048097f45`.

Master lowers the root ordered scan with offset 0 / unlimited rows and stops from the callback. The PR passes offset 100 / limit 72 to `scan_order`; its post-order predicate decides which globally ordered candidates count toward that native window.

## Verification

- full hook-equivalent test suite: passed
- `order-limit.yaml`: 42/42
- `in-subquery.yaml`: 69/69
- `join-complex.yaml`: 10/10
- `range-scan-coverage.yaml`: 99/99
- `scan-order-native-limit.yaml`: 11/11
- scalar planner performance suite: 8/8, normal and coverage builds
- Scheme formatter/check run; only warnings already present on master remain
- no Go tests added
