### PR TITLE
Enable safe Proc JIT interoperability

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1595,17 +1595,46 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert ((jit (lambda (a b) a)) 3 4) 3 "jit: return 1st of 2 params native")
 	(assert ((jit (lambda (a b c) b)) 1 8 3) 8 "jit: return 2nd of 3 params native")
 	(define jit_id_desc (jit (lambda (x) x)))
-	(assert (jit? jit_id_desc) (jit-enabled?) "jit?: identity lambda matches build feature")
-	(assert (jit? (jit (lambda () 42))) (jit-enabled?) "jit?: constant lambda matches build feature")
+	(jit-warn-if-fallback jit_id_desc "jit: identity lambda")
+	(jit-warn-if-fallback (jit (lambda () 42)) "jit: constant lambda")
 	(assert ((jit (lambda () (jit-enabled?)))) (jit-enabled?) "jit-enabled? matches build feature inside jit")
 	(define jit_add_desc (jit (lambda (a b) (+ a b))))
 	(assert (strlike (serialize jit_add_desc) "(lambda %") true "jit descriptor serializes as lambda")
 	(assert (equal? (eval (list jit_add_desc 2 5)) 7) true "jit descriptor executable via eval")
 	(assert (equal? (apply jit_add_desc '(2 5)) 7) true "jit descriptor executable via apply")
 	(assert (jit? (lambda (a b) (+ a b))) false "jit?: plain lambda reports false")
-	(define jit_fallback_desc (jit (lambda () (now))))
-	(assert (jit? jit_fallback_desc) false "jit fallback returns plain lambda")
-	(assert (number? (jit_fallback_desc)) true "jit fallback lambda remains executable")
+	(define jit_now_desc (jit (lambda () (now))))
+	(jit-warn-if-fallback jit_now_desc "jit: now callback")
+	(assert (number? (jit_now_desc)) true "jit: Go callback result remains executable")
+
+	/* Proc identity and environment stay available across native compilation. */
+	(define jit_dynamic_value 40)
+	(define jit_dynamic_reader (jit (eval '('lambda '() 'jit_dynamic_value))))
+	(jit-warn-if-fallback jit_dynamic_reader "jit: dynamic environment read")
+	(assert (jit_dynamic_reader) 40 "jit: reads an unresolved symbol from its lexical environment")
+	(set jit_dynamic_value 41)
+	(assert (jit_dynamic_reader) 41 "jit: resolves a changed lexical binding at call time")
+	(define jit_scheme_callee (lambda (value) (+ value 1)))
+	(define jit_scheme_caller (jit (lambda (value) (jit_scheme_callee value))))
+	(jit-warn-if-fallback jit_scheme_caller "jit: call interpreted Scheme Proc")
+	(assert (jit_scheme_caller 6) 7 "jit: native Proc calls an interpreted Scheme Proc")
+	(set jit_scheme_callee (jit jit_scheme_callee))
+	(jit-warn-if-fallback jit_scheme_callee "jit: Scheme callee")
+	(assert (jit_scheme_caller 8) 9 "jit: native Proc follows rebinding to a native Scheme Proc")
+	(assert (jit_scheme_callee 10) 11 "jit: Scheme invokes a native Proc")
+	(define jit_scan_filter (jit (lambda (value) (> value 1))))
+	(define jit_scan_map (jit (lambda (value) value)))
+	(define jit_scan_reduce (jit (lambda (total value) (+ total value))))
+	(jit-warn-if-fallback jit_scan_filter "jit: scan filter callback")
+	(jit-warn-if-fallback jit_scan_map "jit: scan map callback")
+	(jit-warn-if-fallback jit_scan_reduce "jit: scan reduce callback")
+	(assert (scan nil (list (list "value" 1) (list "value" 2) (list "value" 3))
+		'("value") jit_scan_filter '("value") jit_scan_map jit_scan_reduce 0)
+		5 "jit: storage scan executes compiled filter/map/reduce callbacks")
+	(define jit_pointer_callee (lambda (value) (list value "rooted")))
+	(define jit_pointer_flow (jit (lambda (value) (list (jit_pointer_callee value) (now)))))
+	(jit-warn-if-fallback jit_pointer_flow "jit: rooted callback result")
+	(assert (nth (nth (jit_pointer_flow 12) 0) 0) 12 "jit: callback pointer result survives a later callback")
 
 	/* Borrowed Go-slice headers stay in the native pipeline as ptr/len/cap. */
 	(define jit_list_nth (jit (lambda (xs i) (nth xs i))))
@@ -1619,17 +1648,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define jit_list_reordered (jit (lambda (a b) (list b a))))
 	(define jit_list_subset (jit (lambda (a b) (list b))))
 	(define jit_list_stack_nth (jit (lambda (a b) (nth (list a b) 1))))
-	(assert (jit? jit_list_nth) (jit-enabled?) "jit: nth has a native slice emitter")
-	(assert (jit? jit_list_car) (jit-enabled?) "jit: car has a native slice emitter")
-	(assert (jit? jit_list_cdr) (jit-enabled?) "jit: cdr has a native slice emitter")
-	(assert (jit? jit_list_cadr) (jit-enabled?) "jit: cadr has a native slice emitter")
-	(assert (jit? jit_list_predicate) (jit-enabled?) "jit: list? remains native")
-	(assert (jit? jit_list_build2) (jit-enabled?) "jit: list constructor with two values is native")
-	(assert (jit? jit_list_build6) (jit-enabled?) "jit: list constructor with six values is native")
-	(assert (jit? jit_list_computed) (jit-enabled?) "jit: list constructor evaluates computed values natively")
-	(assert (jit? jit_list_reordered) (jit-enabled?) "jit: reordered list constructor remains native")
-	(assert (jit? jit_list_subset) (jit-enabled?) "jit: subset list constructor remains native")
-	(assert (jit? jit_list_stack_nth) (jit-enabled?) "jit: nth consumes an optimizer stack list natively")
+	(jit-warn-if-fallback jit_list_nth "jit: nth")
+	(jit-warn-if-fallback jit_list_car "jit: car")
+	(jit-warn-if-fallback jit_list_cdr "jit: cdr")
+	(jit-warn-if-fallback jit_list_cadr "jit: cadr")
+	(jit-warn-if-fallback jit_list_predicate "jit: list predicate")
+	(jit-warn-if-fallback jit_list_build2 "jit: two-element list constructor")
+	(jit-warn-if-fallback jit_list_build6 "jit: six-element list constructor")
+	(jit-warn-if-fallback jit_list_computed "jit: computed list constructor")
+	(jit-warn-if-fallback jit_list_reordered "jit: reordered list constructor")
+	(jit-warn-if-fallback jit_list_subset "jit: subset list constructor")
+	(jit-warn-if-fallback jit_list_stack_nth "jit: stack-list nth")
 	(assert (jit_list_nth '(10 20 30) 1) 20 "jit: nth reads a Go-slice element")
 	(assert (jit_list_car '(10 20 30)) 10 "jit: car reads the first Go-slice element")
 	(assert (jit_list_cdr '(10 20 30)) '(20 30) "jit: cdr returns a borrowed Go-slice view")
@@ -1972,34 +2001,34 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	/* JIT panic propagation: Go(try/recover) → JIT → Go(error) → panic */
 	(print "testing JIT panic propagation ...")
 	(define jit_will_panic (jit (lambda (x) (error "jit-boom"))))
-	(assert (jit? jit_will_panic) (jit-enabled?) "panic callback matches JIT build feature")
+	(jit-warn-if-fallback jit_will_panic "jit: panic callback")
 	(define jit_panic_result (try (lambda () (jit_will_panic 42)) (lambda (e) "caught")))
 	(assert jit_panic_result "caught" "panic through JIT frame must be recoverable")
 
 	/* JIT list callbacks: constant code shape with runtime values/captures */
 	(define _jit_map_constant_callback (jit (lambda (values)
 		(map values (lambda (_) 7)))))
-	(assert (jit? _jit_map_constant_callback) (jit-enabled?) "jit: map constant callback compiles natively when enabled")
+	(jit-warn-if-fallback _jit_map_constant_callback "jit: map constant callback")
 	(assert (equal? (_jit_map_constant_callback '(1 2 3)) '(7 7 7)) true "jit: map constant callback result")
 
 	(define _jit_map_captured_callback (jit (lambda (values offset)
 		(map values (lambda (value) (+ value offset))))))
-	(assert (jit? _jit_map_captured_callback) (jit-enabled?) "jit: map callback with runtime capture compiles natively when enabled")
+	(jit-warn-if-fallback _jit_map_captured_callback "jit: map captured callback")
 	(assert (equal? (_jit_map_captured_callback '(1 2 3) 10) '(11 12 13)) true "jit: map callback reads runtime capture")
 
 	(define _jit_map_mut_callback (jit (lambda (values)
 		(map_mut values (lambda (value) (+ value 1))))))
-	(assert (jit? _jit_map_mut_callback) (jit-enabled?) "jit: map_mut callback compiles natively when enabled")
+	(jit-warn-if-fallback _jit_map_mut_callback "jit: map_mut callback")
 	(assert (equal? (_jit_map_mut_callback (list 3 4 5)) '(4 5 6)) true "jit: map_mut callback result")
 
 	(define _jit_reduce_callback (jit (lambda (values neutral offset)
 		(reduce values (lambda (acc value) (+ acc (+ value offset))) neutral))))
-	(assert (jit? _jit_reduce_callback) (jit-enabled?) "jit: reduce callback with runtime capture compiles natively when enabled")
+	(jit-warn-if-fallback _jit_reduce_callback "jit: reduce callback")
 	(assert (_jit_reduce_callback '(1 2 3) 0 10) 36 "jit: reduce callback reads accumulator and runtime capture")
 
 	(define _jit_map_dynamic_callback (jit (lambda (values callback)
 		(map values callback))))
-	(assert (jit? _jit_map_dynamic_callback) (jit-enabled?) "jit: map with runtime callback compiles natively when enabled")
+	(jit-warn-if-fallback _jit_map_dynamic_callback "jit: map dynamic callback")
 	(assert (equal? (_jit_map_dynamic_callback '(2 3 4) (lambda (value) (* value 3))) '(6 9 12)) true "jit: map runtime callback trampoline")
 
 	/* JIT match: compile-time pattern pruning and direct list destructuring */
@@ -2007,7 +2036,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(match src
 			'((symbol alias) schema relation outer join) (list schema relation outer join)
 			_ nil))))
-	(assert (jit? _jit_match_source) (jit-enabled?) "jit: fixed-list match compiles natively when enabled")
+	(jit-warn-if-fallback _jit_match_source "jit: fixed-list match")
 	(assert (equal? (_jit_match_source (list (symbol "alias") "sales" "orders" false nil)) '("sales" "orders" false nil)) true "jit: fixed-list match binds fields")
 	(assert (nil? (_jit_match_source (list (symbol "other") "sales" "orders" false nil))) true "jit: fixed-list literal mismatch falls through")
 	(assert (nil? (_jit_match_source (list (symbol "alias") "sales" "orders"))) true "jit: fixed-list length mismatch falls through")
@@ -2016,7 +2045,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(match values
 			(cons head tail) (list head tail)
 			_ nil))))
-	(assert (jit? _jit_match_cons) (jit-enabled?) "jit: cons match compiles natively when enabled")
+	(jit-warn-if-fallback _jit_match_cons "jit: cons match")
 	(assert (equal? (_jit_match_cons '(1 2 3)) (list 1 (list 2 3))) true "jit: cons match binds head and tail")
 	(assert (nil? (_jit_match_cons '())) true "jit: empty list rejects cons pattern")
 	(assert (nth (_jit_match_cons fd2) 0) "k0" "jit: cons match normalizes FastDict head")
@@ -2027,7 +2056,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(number? number) (+ number 1)
 			(string? text) text
 			_ nil))))
-	(assert (jit? _jit_match_typed) (jit-enabled?) "jit: typed alternatives compile natively when enabled")
+	(jit-warn-if-fallback _jit_match_typed "jit: typed alternatives")
 	(assert (_jit_match_typed 41) 42 "jit: number pattern selects numeric branch")
 	(assert (_jit_match_typed "text") "text" "jit: string pattern selects string branch")
 	(assert (nil? (_jit_match_typed false)) true "jit: typed patterns retain fallback")
@@ -2036,7 +2065,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(match value
 			(list? items) items
 			_ nil))))
-	(assert (jit? _jit_match_list_type) (jit-enabled?) "jit: list? pattern compiles natively when enabled")
+	(jit-warn-if-fallback _jit_match_list_type "jit: list pattern")
 	(assert (count (_jit_match_list_type fd2)) 20 "jit: list? pattern normalizes FastDict")
 	(assert (nil? (_jit_match_list_type "not a list")) true "jit: list? pattern rejects scalar")
 
@@ -2044,7 +2073,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(match value
 			(eval expected) true
 			_ false))))
-	(assert (jit? _jit_match_eval) (jit-enabled?) "jit: eval pattern compiles natively when enabled")
+	(jit-warn-if-fallback _jit_match_eval "jit: eval pattern")
 	(assert (_jit_match_eval "same" "same") true "jit: eval pattern accepts runtime equality")
 	(assert (_jit_match_eval "left" "right") false "jit: eval pattern rejects runtime inequality")
 
@@ -2053,7 +2082,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			'((symbol alias) result) result
 			'((symbol other) impossible) impossible
 			nil))))
-	(assert (jit? _jit_match_known_list) (jit-enabled?) "jit: known-list match compiles natively when enabled")
+	(jit-warn-if-fallback _jit_match_known_list "jit: known-list match")
 	(assert (_jit_match_known_list 17) 17 "jit: known list type and length are matched without fallback")
 
 	/* alu.go: sql_abs */

--- a/main.go
+++ b/main.go
@@ -582,7 +582,7 @@ func getImport(path string) func(a ...scm.Scmer) scm.Scmer {
 		if err != nil {
 			panic(err)
 		}
-		return scm.EvalAll(filename, string(bytes), &otherPath)
+		return scm.EvalAllJIT(filename, string(bytes), &otherPath)
 	}
 }
 

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -146,6 +146,13 @@ type JITEntryPoint struct {
 	Arena             *jitArena        // owning arena (for free on GC)
 	ConstRoots        []unsafe.Pointer // GC roots for constants embedded into machine code
 	Proc              Proc             // original Proc for serialization
+	// NeedsStableArgs is set when emitted code crosses into Go and therefore may
+	// survive a goroutine stack move while retaining the variadic data pointer.
+	NeedsStableArgs bool
+	// AutoImportSafe is false for native bodies that still rely on an
+	// experimental pointer-producing path. Explicit (jit ...) may exercise such
+	// paths, but module import keeps the interpreter until they are proven safe.
+	AutoImportSafe bool
 }
 
 // Call keeps the entry point, embedded constant roots, and source arguments
@@ -157,22 +164,51 @@ func (jep *JITEntryPoint) Call(args ...Scmer) (result Scmer) {
 	if jep == nil || jep.Native == nil {
 		panic("JIT: nil entry point")
 	}
-	if jep.TransferInputArgs {
+	// Native code keeps the variadic data pointer in R12. Calls that append
+	// hidden callback/GC state or transfer that array as an owned list therefore
+	// need a fresh stable frame. Pure scalar JIT functions retain the original
+	// allocation-free call path.
+	stableArgs := jep.TransferInputArgs || jep.NeedsStableArgs || len(jep.HiddenArgs) != 0
+	if stableArgs {
 		args = append([]Scmer(nil), args...)
 	}
-	for _, spec := range jep.HiddenArgs {
-		if spec.SourceInput < 0 || spec.SourceInput >= len(args) {
-			panic("JIT: invalid hidden argument input")
+	if jep.Proc.Params.GetTag() == tagSlice {
+		paramCount := len(jep.Proc.Params.Slice())
+		if len(args) > paramCount {
+			panic(fmt.Sprintf("Apply: function with %d parameters is supplied with %d arguments", paramCount, len(args)))
 		}
+		if len(args) < paramCount {
+			padded := make([]Scmer, paramCount)
+			copy(padded, args)
+			for i := len(args); i < paramCount; i++ {
+				padded[i] = NewNil()
+			}
+			args = padded
+		}
+	}
+	for _, spec := range jep.HiddenArgs {
 		switch spec.Kind {
 		case jitHiddenPreallocatedSlice:
+			if spec.SourceInput < 0 || spec.SourceInput >= len(args) {
+				panic("JIT: invalid hidden argument input")
+			}
 			length := len(asSlice(args[spec.SourceInput], "jit preallocation"))
 			args = append(args, NewSlice(make([]Scmer, length)))
 		case jitHiddenOptimizedCallback:
+			if spec.SourceInput < 0 || spec.SourceInput >= len(args) {
+				panic("JIT: invalid hidden argument input")
+			}
 			args = append(args, NewFunc(OptimizeProcToSerialFunction(args[spec.SourceInput])))
+		case jitHiddenRootSlots:
+			args = append(args, NewSlice(make([]Scmer, spec.Count)))
 		default:
 			panic("JIT: invalid hidden argument kind")
 		}
+	}
+	var callPin runtime.Pinner
+	if stableArgs && len(args) > 0 {
+		callPin.Pin(&args[0])
+		defer callPin.Unpin()
 	}
 	defer func() {
 		runtime.KeepAlive(args)
@@ -186,11 +222,13 @@ type jitHiddenArgKind uint8
 const (
 	jitHiddenPreallocatedSlice jitHiddenArgKind = iota
 	jitHiddenOptimizedCallback
+	jitHiddenRootSlots
 )
 
 type JITHiddenArg struct {
 	Kind        jitHiddenArgKind
 	SourceInput int
+	Count       int
 }
 
 // JITValueDesc describes a value during JIT compilation: its type and
@@ -230,6 +268,9 @@ type JITValueDesc struct {
 	// of Type so unions such as int|float|nil retain the fact without claiming an
 	// exact tag.
 	NoHeapPointer bool
+	// Rooted means a pointer-bearing runtime value has been mirrored into the
+	// invocation's Go-heap root slice and may safely survive later callbacks.
+	Rooted bool
 	// Virtual holds compiler-only aggregate elements. LocVirtualSlice never
 	// reaches generated machine code; consumers either operate on its elements
 	// directly or materialize it through a Go allocation trampoline.
@@ -339,6 +380,11 @@ type JITContext struct {
 	FreeRegs  uint64
 	AllRegs   uint64 // original set of all allocatable registers (for spilling)
 	SliceBase Reg    // register holding the args slice pointer (for variable-index access)
+	// OriginalArgsOff stores the incoming variadic slice data pointer in the
+	// invocation-local frame.
+	// Optimized local frames may repurpose SliceBase, while hidden GC roots still
+	// live after the source-level arguments in the original Go-owned slice.
+	OriginalArgsOff int32
 	// SliceBaseTracksRSP indicates that SliceBase is a mirror of RSP and must be
 	// refreshed after helper calls (Go may grow/move the goroutine stack).
 	SliceBaseTracksRSP bool
@@ -354,6 +400,11 @@ type JITContext struct {
 	// exactly the complete variadic input array re-tagged as an owned list.
 	TransferInputArgs bool
 	HiddenArgs        []JITHiddenArg
+	RootHiddenArg     int
+	RootSlotCount     int
+	RuntimeEnv        Scmer
+	AutoImportSafe    bool
+	NeedsStableArgs   bool
 	RegOwners         [16]*JITValueDesc // register → owner descriptor (nil = untracked)
 
 	// Stack frame: emitter locals use [RSP + offset], while register spills use
@@ -388,6 +439,24 @@ func (ctx *JITContext) RequestOptimizedCallback(sourceInput int) JITValueDesc {
 	hiddenIndex := ctx.InputArgCount + len(ctx.HiddenArgs)
 	ctx.HiddenArgs = append(ctx.HiddenArgs, JITHiddenArg{Kind: jitHiddenOptimizedCallback, SourceInput: sourceInput})
 	return JITValueDesc{Loc: LocInputPair, Type: tagFunc, StackOff: int32(hiddenIndex)}
+}
+
+// RequestRootSlot reserves one Scmer slot in a Go-heap-backed hidden slice.
+// JIT values stored there remain visible to the garbage collector while a Go
+// callback is running, without a process-global shadow stack.
+func (ctx *JITContext) RequestRootSlot() (rootSlice JITValueDesc, slot int) {
+	if ctx.InputArgCount < 0 {
+		panic("jit: GC-root slots require fixed procedure parameters")
+	}
+	if ctx.RootHiddenArg < 0 {
+		ctx.RootHiddenArg = len(ctx.HiddenArgs)
+		ctx.HiddenArgs = append(ctx.HiddenArgs, JITHiddenArg{Kind: jitHiddenRootSlots})
+	}
+	slot = ctx.RootSlotCount
+	ctx.RootSlotCount++
+	ctx.HiddenArgs[ctx.RootHiddenArg].Count = ctx.RootSlotCount
+	hiddenIndex := ctx.InputArgCount + ctx.RootHiddenArg
+	return JITValueDesc{Loc: LocInputPair, Type: tagSlice, StackOff: int32(hiddenIndex)}, slot
 }
 
 // jitAllocStateSnapshot captures allocator/spill bookkeeping so emitter
@@ -840,8 +909,16 @@ func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
 	case LocInputPair:
 		r1 := ctx.AllocReg()
 		r2 := ctx.AllocRegExcept(r1)
-		ctx.EmitMovRegMem(r1, ctx.SliceBase, desc.StackOff*16)
-		ctx.EmitMovRegMem(r2, ctx.SliceBase, desc.StackOff*16+8)
+		base := ctx.SliceBase
+		if ctx.SliceBaseTracksRSP && int(desc.StackOff) >= ctx.InputArgCount {
+			base = ctx.AllocRegExcept(r1, r2)
+			ctx.EmitMovRegMem(base, RegRSP, ctx.OriginalArgsOff)
+		}
+		ctx.EmitMovRegMem(r1, base, desc.StackOff*16)
+		ctx.EmitMovRegMem(r2, base, desc.StackOff*16+8)
+		if base != ctx.SliceBase {
+			ctx.FreeReg(base)
+		}
 		desc.Loc = LocRegPair
 		desc.Reg = r1
 		desc.Reg2 = r2
@@ -1369,6 +1446,7 @@ func (ctx *JITContext) collectLiveRegsForCall(buf *[16]Reg) []Reg {
 // Returns a slice into resultsBuf holding the result registers.
 // All live JIT registers are saved/restored around the call.
 func (ctx *JITContext) EmitGoCall(funcAddr uint64, argWords []goCallArgWord, numResultWords int, resultsBuf *[16]Reg, resultTargets []Reg) []Reg {
+	ctx.NeedsStableArgs = true
 	if numResultWords > len(GoABIIntRegs) {
 		panic("jit: too many result words for Go ABI")
 	}
@@ -1937,7 +2015,7 @@ func init_jit() {
 		Name: "jit?",
 		Desc: "tells whether a value is a JIT-compiled function descriptor",
 		Fn: func(a ...Scmer) Scmer {
-			return NewBool(a[0].GetTag() == tagJIT)
+			return NewBool(a[0].GetTag() == tagJIT || (a[0].GetTag() == tagProc && a[0].Proc() != nil && a[0].Proc().Compiled != nil))
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
@@ -2004,6 +2082,30 @@ func init_jit() {
 				}
 				return result
 			},
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "jit-warn-if-fallback",
+		Desc: "prints a diagnostic warning when an enabled JIT build kept a procedure interpreted and returns the procedure unchanged",
+		Fn: func(a ...Scmer) Scmer {
+			value := a[0]
+			compiled := value.GetTag() == tagJIT || (value.GetTag() == tagProc && value.Proc() != nil && value.Proc().Compiled != nil)
+			if jitEnabled && !compiled {
+				label := SerializeToString(value, &Globalenv)
+				if len(a) > 1 {
+					label = String(a[1])
+				}
+				fmt.Printf("warning: JIT fallback: %s\n", label)
+			}
+			return value
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "any", ParamName: "procedure", ParamDesc: "procedure expected to be a native compilation candidate"},
+				{Kind: "string", ParamName: "label", ParamDesc: "optional diagnostic label", Optional: true},
+			},
+			Return:         &TypeDescriptor{Kind: "any"},
+			HasSideEffects: true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2099,11 +2201,14 @@ func jitCompile(a ...Scmer) Scmer {
 	case tagProc:
 		// Lambda/procedure — compile into a pool arena
 		proc := v.Proc()
+		if proc != nil && proc.Compiled != nil {
+			return v
+		}
 		// Try increasing buffer sizes for overflow retry
 		for _, codeCap := range [...]int{16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024} {
 			ptr, arena := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena}
-			codeLen, roots, overflow, transferInputArgs, hiddenArgs := jitCompileProcToExec(proc, buf)
+			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs := jitCompileProcToExec(proc, buf)
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
 				if JITLog {
@@ -2112,6 +2217,8 @@ func jitCompile(a ...Scmer) Scmer {
 				maybeDumpJITCode(ptr, code)
 				fn2 := unsafe.Pointer(&struct{ *byte }{&code[0]})
 				nativeFn := *(*func(...Scmer) Scmer)(unsafe.Pointer(&fn2))
+				sourceProc := *proc
+				sourceProc.Compiled = nil
 				jep := &JITEntryPoint{
 					Native:            nativeFn,
 					TransferInputArgs: transferInputArgs,
@@ -2120,14 +2227,18 @@ func jitCompile(a ...Scmer) Scmer {
 					CodeLen:           codeLen,
 					Arena:             arena,
 					ConstRoots:        roots,
-					Proc:              *proc,
+					Proc:              sourceProc,
+					AutoImportSafe:    autoImportSafe && jitAutoImportSyntaxSafe(sourceProc.Body),
+					NeedsStableArgs:   needsStableArgs,
 				}
 				runtime.SetFinalizer(jep, func(jep *JITEntryPoint) {
 					if jep.Arena != nil && jep.CodePtr != nil {
 						globalJITPool.Free(jep.CodePtr, jep.CodeLen)
 					}
 				})
-				return NewJIT(jep)
+				compiledProc := sourceProc
+				compiledProc.Compiled = jep
+				return NewProcStruct(compiledProc)
 			}
 			if !overflow {
 				break
@@ -2142,6 +2253,66 @@ func jitCompile(a ...Scmer) Scmer {
 	default:
 		panic(fmt.Sprintf("jit: cannot compile %v (tag %d)", v, tag))
 	}
+}
+
+// jitAutoImportSyntaxSafe is deliberately narrower than explicit (jit ...).
+// Module loading must never turn experimental emitter coverage into a semantic
+// regression. It enables leaf expressions, borrowed accessors, scalar
+// builtins, and rooted calls with at most two arguments; allocation-heavy
+// transforms remain interpreted until their callback/ABI paths are proven.
+func jitAutoImportSyntaxSafe(expr Scmer) bool {
+	for expr.IsSourceInfo() {
+		expr = expr.SourceInfo().value
+	}
+	if !expr.IsSlice() {
+		return true
+	}
+	items := expr.Slice()
+	if len(items) == 0 {
+		return true
+	}
+	if !items[0].IsSymbol() {
+		if len(items)-1 > 2 || !jitAutoImportSyntaxSafe(items[0]) {
+			return false
+		}
+		for _, item := range items[1:] {
+			if !jitAutoImportSyntaxSafe(item) {
+				return false
+			}
+		}
+		return true
+	}
+	name := items[0].String()
+	switch name {
+	case "quote":
+		return true
+	case "lambda", "begin", "begin_mut", "!begin", "set", "define", "setN", "!list", "!!list", "eval", "parallel":
+		return false
+	case "match", "match_mut":
+		return false
+	case "if", "and", "or", "coalesce", "coalesceNil":
+		return false
+	case "outer":
+		for _, item := range items[1:] {
+			if !jitAutoImportSyntaxSafe(item) {
+				return false
+			}
+		}
+		return true
+	}
+	if decl, ok := declarations[name]; ok && decl.Type != nil && decl.Type.JITEmit != nil {
+		if !jitAutoImportReturnSafe(name, decl.Type.Return) {
+			return false
+		}
+	} else {
+		return false
+	}
+	for _, item := range items[1:] {
+		if !jitAutoImportSyntaxSafe(item) {
+			return false
+		}
+	}
+	return true
 }
 
 // execBuf is a small wrapper for writable memory (arena-backed or standalone)

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -62,7 +62,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 	const defaultCodeBufSize = 16 * 1024
 	ptr, _ := globalJITPool.Alloc(defaultCodeBufSize)
 	buf := &execBuf{ptr: ptr, n: defaultCodeBufSize}
-	codeLen, roots, _, _, _ := jitCompileProcToExec(proc, buf)
+	codeLen, roots, _, _, _, _, _ := jitCompileProcToExec(proc, buf)
 	if codeLen == 0 {
 		return nil, nil
 	}
@@ -74,7 +74,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 // jitCompileProcToExec compiles a Proc body directly into writable executable memory.
 // Returns code length, GC roots, an overflow flag, and whether the call boundary
 // must provide a fresh variadic array that becomes the owned list result.
-func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg) {
+func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg, bool, bool) {
 	body := proc.Body
 	if body.GetTag() == tagSourceInfo {
 		si := body.SourceInfo()
@@ -93,7 +93,7 @@ func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool
 
 // jitCompileExprBodyToExec compiles a Scheme expression body into a writable
 // executable buffer using Declaration.JITEmit callbacks.
-func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg) {
+func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg, autoImportSafe bool, needsStableArgs bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			if r == jitCodeOverflowPanic {
@@ -106,6 +106,8 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 			roots = nil
 			transferInputArgs = false
 			hiddenArgs = nil
+			autoImportSafe = false
+			needsStableArgs = false
 		}
 	}()
 
@@ -128,8 +130,16 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 		SliceBase:      RegR12,
 		InputArgCount:  inputArgCount,
 		LocalSlotCount: numVars,
+		RootHiddenArg:  -1,
+		AutoImportSafe: true,
 		Arena:          buf.arena,
 	}
+	runtimeEnv := &Globalenv
+	if proc != nil && proc.En != nil {
+		runtimeEnv = proc.En
+	}
+	ctx.RuntimeEnv = NewAny(runtimeEnv)
+	ctx.TrackImm(ctx.RuntimeEnv)
 	ctx.W = ctx // self-reference for backward-compat ctx.W.Emit calls
 
 	// Unified frame: push rbp; mov rbp, rsp; sub rsp, <fixup>
@@ -166,6 +176,8 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 				ctx.EmitStoreRegMem(RegR11, RegRSP, dstOff+8)
 			}
 		}
+		ctx.OriginalArgsOff = ctx.AllocStack(8)
+		ctx.EmitStoreRegMem(RegR12, RegRSP, ctx.OriginalArgsOff)
 		ctx.emitMovRegReg(RegR12, RegRSP)
 		ctx.SliceBaseTracksRSP = true
 	}
@@ -222,7 +234,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 		case tagNil:
 			ctx.EmitMakeNil(result)
 		default:
-			return 0, nil, false, false, nil
+			return 0, nil, false, false, nil, false, false
 		}
 		// fall through to epilog
 	} else {
@@ -245,10 +257,10 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 			case tagFloat:
 				ctx.EmitMakeFloat(ret, desc)
 			default:
-				return 0, nil, false, false, nil
+				return 0, nil, false, false, nil, false, false
 			}
 		default:
-			return 0, nil, false, false, nil
+			return 0, nil, false, false, nil, false, false
 		}
 	}
 	// Unified epilog: patch SUB RSP with max frame size, then leave; ret.
@@ -260,7 +272,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 
 	ctx.ResolveFixupsFinal()
 	codeLen = int(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs
+	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs, ctx.AutoImportSafe, ctx.NeedsStableArgs
 }
 
 func jitEnsureResultPair(ctx *JITContext, result JITValueDesc) JITValueDesc {
@@ -278,6 +290,7 @@ func jitPlaceIntoPair(ctx *JITContext, src *JITValueDesc, target JITValueDesc) J
 	// fact lets downstream generated SSA eliminate checks and write barriers.
 	target.Type = src.Type
 	target.NoHeapPointer = src.NoHeapPointer
+	target.Rooted = src.Rooted
 	// Keep descriptor location in sync with spill metadata before we read Reg/Reg2.
 	if src.Loc != LocImm {
 		ctx.EnsureDesc(src)
@@ -347,6 +360,35 @@ func jitMakeScmerSlice(length, capacity int) []Scmer {
 
 func jitStoreScmerAt(address *Scmer, value Scmer) {
 	*address = value
+}
+
+func jitStoreRootScmer(rootSlice Scmer, slot int64, value Scmer) {
+	rootSlice.Slice()[slot] = value
+}
+
+func jitResolveRuntimeSymbol(envValue, symbol Scmer) Scmer {
+	env, ok := envValue.Any().(*Env)
+	if !ok || env == nil {
+		panic("jit: invalid runtime environment")
+	}
+	sym := mustSymbol(symbol)
+	binding := env.FindRead(sym)
+	if binding == nil {
+		panic("jit: unresolved symbol " + string(sym))
+	}
+	return binding.Vars[sym]
+}
+
+func jitApplyCallable0(callable, envValue Scmer) Scmer {
+	return ApplyEx(callable, nil, envValue.Any().(*Env))
+}
+
+func jitApplyCallable1(callable, envValue, arg0 Scmer) Scmer {
+	return ApplyEx(callable, []Scmer{arg0}, envValue.Any().(*Env))
+}
+
+func jitApplyCallable2(callable, envValue, arg0, arg1 Scmer) Scmer {
+	return ApplyEx(callable, []Scmer{arg0, arg1}, envValue.Any().(*Env))
 }
 
 func jitInvokeCallback1(callback, arg0 Scmer) Scmer {
@@ -441,12 +483,73 @@ func (ctx *JITContext) EmitStoreScmerAt(address, value *JITValueDesc) {
 	ctx.EmitGoCallVoid(GoFuncAddr(jitStoreScmerAt), []JITValueDesc{*address, *value})
 }
 
+// jitRootScmer mirrors a pointer-bearing intermediate into a hidden
+// Go-heap-backed slice. JITEntryPoint.Call keeps that slice live for the whole
+// invocation, so callbacks may trigger GC without relying on unscanned JIT
+// stack slots or a process-global shadow stack.
+func jitRootScmer(ctx *JITContext, value JITValueDesc) JITValueDesc {
+	if value.Rooted || value.NoHeapPointer || value.Loc == LocImm {
+		if value.Loc == LocImm {
+			ctx.TrackImm(value.Imm)
+		}
+		value.Rooted = true
+		return value
+	}
+	// RAX/RBX are the Go ABI result registers and are intentionally outside the
+	// allocator's saved-register set. Move such a result into managed registers
+	// before the write-barrier callback, otherwise that callback overwrites the
+	// value before the function epilogue can return it.
+	if value.Loc == LocRegPair && ((ctx.AllRegs&(1<<uint(value.Reg))) == 0 || (ctx.AllRegs&(1<<uint(value.Reg2))) == 0) {
+		managed := JITValueDesc{Loc: LocRegPair, Type: value.Type, Reg: ctx.AllocReg()}
+		managed.Reg2 = ctx.AllocRegExcept(managed.Reg)
+		ctx.EmitMovPairToResult(&value, &managed)
+		value = managed
+	}
+	// Own the live result registers through this local descriptor. The rooting
+	// callback may spill them; returning a stale copy that still names the
+	// pre-callback registers would lose pointer-bearing results.
+	if value.Loc == LocRegPair {
+		ctx.BindReg(value.Reg, &value)
+		ctx.BindReg(value.Reg2, &value)
+	}
+	// Release the result registers before loading the root-slice descriptor;
+	// small JIT frames deliberately expose only a compact allocator set.
+	valueOff := ctx.AllocStack(16)
+	valueType := value.Type
+	ctx.EmitStoreScmerToStack(value, valueOff)
+	ctx.FreeDesc(&value)
+	rootedValue := JITValueDesc{Loc: LocStackPair, Type: valueType, StackOff: valueOff}
+	rootSlice, slot := ctx.RequestRootSlot()
+	slotValue := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(slot)), NoHeapPointer: true}
+	ctx.EmitGoCallVoid(GoFuncAddr(jitStoreRootScmer), []JITValueDesc{rootSlice, slotValue, rootedValue})
+	ctx.EnsureDesc(&rootedValue)
+	rootedValue.Rooted = true
+	return rootedValue
+}
+
 func jitReturnHasNoHeapPointer(td *TypeDescriptor) bool {
 	if td == nil {
 		return false
 	}
 	switch td.Kind {
 	case "bool", "date", "int", "int|nil", "nil", "number", "number|nil":
+		return true
+	default:
+		return false
+	}
+}
+
+func jitAutoImportReturnSafe(name string, td *TypeDescriptor) bool {
+	if td == nil {
+		return false
+	}
+	if jitReturnHasNoHeapPointer(td) {
+		return true
+	}
+	// These accessors only borrow storage already rooted by an input value; they
+	// do not create a new pointer-bearing object behind the JIT boundary.
+	switch name {
+	case "nth", "car", "cadr", "cdr":
 		return true
 	default:
 		return false
@@ -1159,6 +1262,10 @@ func jitMaterializeVirtualSlice(ctx *JITContext, virtual JITValueDesc, result JI
 		ctx.EmitMovRegImm64(RegRBX, makeAux(tagSlice, makeSliceAux(ctx.InputArgCount, ctx.InputArgCount)))
 		return JITValueDesc{Loc: LocRegPair, Type: tagSlice, Reg: RegRAX, Reg2: RegRBX}
 	}
+	// Fresh list construction is explicitly JIT-testable, but automatic module
+	// activation remains conservative until all allocation/callback arities have
+	// complete GC and ABI coverage.
+	ctx.AutoImportSafe = false
 	pairs := make([]JITValueDesc, len(virtual.Virtual))
 	for i := range virtual.Virtual {
 		src := virtual.Virtual[i]
@@ -1171,6 +1278,27 @@ func jitMaterializeVirtualSlice(ctx *JITContext, virtual JITValueDesc, result JI
 		pairs[i] = jitPlaceIntoPair(ctx, &src, target)
 		ctx.BindReg(pairs[i].Reg, &pairs[i])
 		ctx.BindReg(pairs[i].Reg2, &pairs[i])
+	}
+	if len(pairs) > 4 {
+		length := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(pairs))), NoHeapPointer: true}
+		header := ctx.EmitGoCallScalar(GoFuncAddr(jitMakeScmerSlice), []JITValueDesc{length, length}, 3)
+		header.Type = tagSlice
+		ctx.BindReg(header.Reg, &header)
+		ctx.BindReg(header.Reg2, &header)
+		ctx.BindReg(header.Reg3, &header)
+		for i := range pairs {
+			index := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(i)), NoHeapPointer: true}
+			address := ctx.EmitSliceElementAddress(&header, &index, 16)
+			ctx.EmitStoreScmerAt(&address, &pairs[i])
+			ctx.FreeDesc(&address)
+			ctx.FreeDesc(&pairs[i])
+		}
+		materialized := ctx.EmitNewSliceFromGoSlice(&header)
+		materialized.Rooted = true
+		if result.Loc == LocRegPair {
+			return jitPlaceIntoPair(ctx, &materialized, result)
+		}
+		return materialized
 	}
 	var addr uint64
 	switch len(pairs) {
@@ -1458,6 +1586,80 @@ func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, ar
 	return out
 }
 
+func jitCompileRootedCallValue(ctx *JITContext, expr Scmer, sliceBase Reg) JITValueDesc {
+	off := ctx.AllocStack(16)
+	value := jitCompileExpr(ctx, expr, sliceBase, JITValueDesc{Loc: LocAny})
+	pair := value
+	if pair.Loc != LocRegPair {
+		pair = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+		pair = jitPlaceIntoPair(ctx, &value, pair)
+	}
+	pair = jitRootScmer(ctx, pair)
+	ctx.EmitStoreScmerToStack(pair, off)
+	ctx.FreeDesc(&pair)
+	return JITValueDesc{Loc: LocStackPair, Type: pair.Type, StackOff: off, NoHeapPointer: pair.NoHeapPointer, Rooted: pair.Rooted}
+}
+
+func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	if len(operands) > 2 {
+		panic("jit: dynamic calls with more than two arguments require Go stack-argument ABI support")
+	}
+	stackStart := ctx.BPOffset
+	callable := jitCompileRootedCallValue(ctx, callableExpr, sliceBase)
+	args := make([]JITValueDesc, 0, len(operands)+2)
+	args = append(args, callable)
+
+	envImm := JITValueDesc{Loc: LocImm, Type: tagAny, Imm: ctx.RuntimeEnv}
+	ctx.TrackImm(ctx.RuntimeEnv)
+	envOff := ctx.AllocStack(16)
+	envPair := JITValueDesc{Loc: LocRegPair, Type: tagAny, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+	envPair = jitPlaceIntoPair(ctx, &envImm, envPair)
+	ctx.EmitStoreScmerToStack(envPair, envOff)
+	ctx.FreeDesc(&envPair)
+	args = append(args, JITValueDesc{Loc: LocStackPair, Type: tagAny, StackOff: envOff})
+	for _, operand := range operands {
+		args = append(args, jitCompileRootedCallValue(ctx, operand, sliceBase))
+	}
+
+	target := jitEnsureResultPair(ctx, result)
+	var fn any
+	switch len(operands) {
+	case 0:
+		fn = jitApplyCallable0
+	case 1:
+		fn = jitApplyCallable1
+	case 2:
+		fn = jitApplyCallable2
+	}
+	out := ctx.EmitGoCallScalarInto(GoFuncAddr(fn), args, target)
+	out.Type = JITTypeUnknown
+	out = jitRootScmer(ctx, out)
+	ctx.FreeStack(ctx.BPOffset - stackStart)
+	ctx.BindReg(out.Reg, &out)
+	ctx.BindReg(out.Reg2, &out)
+	return out
+}
+
+func jitCompileRuntimeSymbol(ctx *JITContext, symbol Scmer, result JITValueDesc) JITValueDesc {
+	envImm := JITValueDesc{Loc: LocImm, Type: tagAny, Imm: ctx.RuntimeEnv}
+	symbolImm := JITValueDesc{Loc: LocImm, Type: tagSymbol, Imm: symbol}
+	ctx.TrackImm(ctx.RuntimeEnv)
+	ctx.TrackImm(symbol)
+	envPair := JITValueDesc{Loc: LocRegPair, Type: tagAny, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+	symbolPair := JITValueDesc{Loc: LocRegPair, Type: tagSymbol, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+	envPair = jitPlaceIntoPair(ctx, &envImm, envPair)
+	symbolPair = jitPlaceIntoPair(ctx, &symbolImm, symbolPair)
+	target := jitEnsureResultPair(ctx, result)
+	out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitResolveRuntimeSymbol), []JITValueDesc{envPair, symbolPair}, target)
+	out.Type = JITTypeUnknown
+	out = jitRootScmer(ctx, out)
+	ctx.FreeDesc(&envPair)
+	ctx.FreeDesc(&symbolPair)
+	ctx.BindReg(out.Reg, &out)
+	ctx.BindReg(out.Reg2, &out)
+	return out
+}
+
 // jitEmitCondJump emits branch code equivalent to Eval(...).Bool():
 // jumps to trueLbl when expr is truthy, otherwise to falseLbl.
 // It short-circuits nested (and ...)/(or ...)/(if ...) directly without
@@ -1584,10 +1786,16 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 		}
 		if v, ok := Globalenv.Vars[sym]; ok {
-			ctx.TrackImm(v)
-			return JITValueDesc{Loc: LocImm, Type: v.GetTag(), Imm: v}
+			switch v.GetTag() {
+			case tagFunc, tagFuncEnv, tagProc, tagJIT, tagClosure, tagPromise:
+				// Callable bindings stay late-bound so redefinition and future
+				// specialization invalidation retain Scheme semantics.
+			default:
+				ctx.TrackImm(v)
+				return JITValueDesc{Loc: LocImm, Type: v.GetTag(), Imm: v}
+			}
 		}
-		panic("jit: unresolved symbol " + string(sym))
+		return jitCompileRuntimeSymbol(ctx, expr, result)
 	case tagNthLocalVar:
 		// Load parameter: check inline env first (JITEmitProcInline places args here).
 		idx := int(expr.NthLocalVar())
@@ -1671,7 +1879,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		}
 		// Resolve operator
 		if !list[0].IsSymbol() {
-			panic("jit: non-symbol in call position")
+			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		name := string(list[0].Symbol())
 		switch name {
@@ -2038,7 +2246,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		}
 		decl, ok := declarations[name]
 		if !ok {
-			panic("jit: unknown callable " + name)
+			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		if name == "strlike" {
 			panic("jit: strlike emitter is not supported")
@@ -2047,9 +2255,12 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		// contract for Go callbacks. Keep them interpreted until that contract is
 		// implemented instead of exposing half-supported generated emitters.
 		if decl.Type != nil && decl.Type.Return != nil && decl.Type.Return.Kind == "string" {
-			panic("jit: pointer-bearing return is not supported: " + name)
+			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		if decl.Type != nil && decl.Type.JITEmit != nil {
+			if !jitAutoImportReturnSafe(name, decl.Type.Return) {
+				ctx.AutoImportSafe = false
+			}
 			if decl.Type.JITVirtualArgs {
 				args := make([]JITValueDesc, len(list)-1)
 				for i := 1; i < len(list); i++ {
@@ -2164,7 +2375,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		// Declarations without a dedicated emitter stay interpreted. The former
 		// generic variadic bridge built argument arrays below the fixed frame and
 		// also made every ordinary runtime function part of the experimental ABI.
-		panic("jit: callable has no JIT emitter: " + name)
+		return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 	default:
 		panic(fmt.Sprintf("jit: unsupported expression tag=%d expr=%s", expr.GetTag(), SerializeToString(expr, &Globalenv)))
 	}

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -110,6 +110,14 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 		return func(args ...Scmer) Scmer { return captured }
 	}
 	p := *proc
+	// A Proc keeps its source body even after native compilation. Execute the
+	// attached entry point now; future scan specialization may recompile the same
+	// filter/map/reduce body against concrete storage and column types first.
+	if p.Compiled != nil {
+		return func(args ...Scmer) Scmer {
+			return p.Compiled.Call(args...)
+		}
+	}
 
 	// constant body
 	switch p.Body.GetTag() {

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -51,14 +51,52 @@ func Read(source, s string) (expression Scmer) {
 }
 
 func EvalAll(source, s string, en *Env) (expression Scmer) {
+	return evalAll(source, s, en, false)
+}
+
+// EvalAllJIT evaluates a Scheme module and attaches native implementations to
+// every top-level procedure that the current emitter can compile. Unsupported
+// procedures stay ordinary Procs and retain the interpreter as a safe fallback.
+func EvalAllJIT(source, s string, en *Env) (expression Scmer) {
+	return evalAll(source, s, en, true)
+}
+
+func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scmer) {
 	tokens := tokenize(source, s)
 	for len(tokens) > 0 {
 		code := readFrom(&tokens)
 		Validate(code, "any")
 		code = Optimize(code, en, nil)
 		expression = Eval(code, en)
+		if compileProcedures && expression.GetTag() == tagProc {
+			compiled := jitCompile(expression)
+			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil && compiled.Proc().Compiled.AutoImportSafe {
+				expression = compiled
+				if sym, ok := topLevelDefinitionSymbol(code); ok {
+					target := en.definitionTarget()
+					if target.Vars == nil {
+						target.Vars = make(Vars)
+					}
+					target.Vars[sym] = compiled
+				}
+			}
+		}
 	}
 	return
+}
+
+func topLevelDefinitionSymbol(code Scmer) (Symbol, bool) {
+	for code.IsSourceInfo() {
+		code = code.SourceInfo().value
+	}
+	if !code.IsSlice() {
+		return "", false
+	}
+	items := code.Slice()
+	if len(items) < 3 || !items[0].IsSymbol() || (!items[0].SymbolEquals("define") && !items[0].SymbolEquals("set")) || !items[1].IsSymbol() {
+		return "", false
+	}
+	return items[1].Symbol(), true
 }
 
 // Syntactic Analysis

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -436,6 +436,13 @@ restart:
 			return fn(args...)
 		case tagProc:
 			// Lambdas (procs)
+			if proc := procedure.Proc(); proc != nil && proc.Compiled != nil {
+				args := make([]Scmer, len(operands))
+				for i, operand := range operands {
+					args[i] = Eval(operand, en)
+				}
+				return proc.Compiled.Call(args...)
+			}
 			en, expression = prepareProcCall(procedure.Proc(), operands, en)
 			goto restart
 		case tagFuncEnv:
@@ -747,6 +754,9 @@ func ApplyEx(procedure Scmer, args []Scmer, en *Env) (value Scmer) {
 		return fn(id, args...)
 	// Lambdas
 	case tagProc:
+		if proc := procedure.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call(args...)
+		}
 		env, body := prepareProcCallWithArgs(procedure.Proc(), args)
 		return Eval(body, env)
 	// Assoc list
@@ -794,6 +804,10 @@ type Proc struct {
 	En           *Env
 	NumVars      int
 	NumberedOnly bool
+	// Compiled is an optional native implementation of this procedure. The
+	// original body remains attached so storage scan callbacks can later be
+	// specialized and recompiled against concrete column/storage types.
+	Compiled *JITEntryPoint
 }
 
 // CloseProcedure snapshots explicit captures of a procedure without retaining
@@ -823,6 +837,7 @@ func CloseProcedure(value Scmer) Scmer {
 	collectProcedureBindings(proc.Body, bound)
 	proc.Body = closeProcedureCaptures(proc.Body, callFrame, bound)
 	proc.En = &Globalenv
+	proc.Compiled = nil
 	return NewProcStruct(proc)
 }
 
@@ -2510,11 +2525,17 @@ func ComputeSize(v Scmer) uint {
 		if p == nil {
 			return base
 		}
-		// Proc struct: Params(16) + Body(16) + En(8) + NumVars(8) = 48 bytes
+		// Proc struct: Params(16) + Body(16) + En(8) + NumVars(8) plus
+		// NumberedOnly padding and the optional compiled-entry pointer.
 		// Params and Body are inline Scmer fields — their slots are covered by
 		// the recursive ComputeSize base (same pattern as slice backing array).
-		// Only count the non-Scmer fields: *Env(8) + NumVars(8) = 16 bytes.
-		return base + goAllocOverhead + 16 + ComputeSize(p.Params) + ComputeSize(p.Body)
+		// Only count non-Scmer fields here; avoid recursively recounting the
+		// source Proc retained by the compiled entry point.
+		sz := base + goAllocOverhead + 24 + ComputeSize(p.Params) + ComputeSize(p.Body)
+		if p.Compiled != nil {
+			sz += goAllocOverhead + align8(uint(p.Compiled.CodeLen))
+		}
+		return sz
 	case tagString, tagSymbol:
 		ln := uint(auxVal(v.aux))
 		if ln == 0 {


### PR DESCRIPTION
## What changed

- Keep an optional native entry point on `Proc` instead of replacing procedures with an opaque JIT value. Parameters, body, lexical environment, and optimizer-visible source remain available for later specialization.
- Dispatch compiled procedures from normal Scheme evaluation, `apply`, and the serial callback adapter used by `scan`, `scan_batch`, and `scan_order` filter/map/reduce callbacks.
- Resolve unknown symbols against the procedure environment at runtime and trampoline calls between interpreted Scheme procedures and JIT procedures.
- Root pointer-bearing callback results in a per-invocation Go heap slice. There is no process-global shadow stack; Go write barriers remain authoritative.
- Keep scalar native calls allocation-free. A copied and pinned argument frame is used only for Go callbacks, hidden GC state, or ownership transfer.
- Run the JIT attempt after optimization during module imports. Automatic activation is conservative: supported safe bodies become native, while unsupported bodies remain ordinary interpreted procedures.
- Separate semantic assertions from native-coverage diagnostics through `jit-warn-if-fallback`.

## Concrete results

The following cases now compile and execute natively with the patched Go runtime:

- `(jit (lambda () (now)))`, including the pointer/ABI-safe Go trampoline result
- a runtime-constructed lambda that dynamically reads a lexical binding and observes a later rebinding
- JIT code calling an interpreted Scheme procedure
- Scheme code calling a JIT procedure
- a late-bound call whose callee is subsequently replaced by its JIT version
- `scan` filter, map, and reduce callbacks represented as compiled `Proc` values

Imports activate proven leaf functions incrementally. For example, `qb_sources` and `join_order_plan_cost` are native after importing `lib/main.scm`, while unsupported `build_queryplan` safely remains interpreted.

The retained `Proc.Body` is intentional infrastructure for the next execution-time step: storage scan callbacks can later be recompiled and fused against concrete column/storage types without reconstructing lost Scheme source.

## Safe fallback and current limits

- Dynamic calls with more than two Scheme arguments still fall back because their Go stack-argument ABI path is not yet proven.
- Allocation-heavy or structurally complex imported procedures remain interpreted until their generated callback and GC paths are validated.
- Fallback affects native coverage only, never correctness assertions.

## Validation

- Patched compiler: Go `1.26.1-X:jit` builds successfully; the new Proc/Env/callback/scan tests pass.
- Vanilla compiler: Go `1.24.0` builds and runs with JIT disabled and the same Scheme semantics.
- `./memcp lib/test.scm`: `1167/1169` on both builds. The two failures are unchanged current-master failures 480 and 489; all new tests pass. The patched build emits one expected fallback warning for an unsupported nested pointer/list shape.
- Module-import probe: `qb_sources=true`, `join_order_plan_cost=true`, `build_queryplan=false` under `jit?`.
- Full hook-equivalent run exercised all functional SQL, planner, storage, persistence, and concurrency suites successfully. Its parallel coverage run hit three existing wall-clock guards with correct results. An isolated A/B of the affected `order-limit.yaml` suite produced 41/42 on unchanged master (one hard-limit outlier) and 42/42 on this branch; no guard or expectation was changed.
- Scheme formatting/check completed; its existing warnings in untouched parser/planner files remain unchanged.
