### PR TITLE
planner: preserve unique lookup proofs in derived views

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -612,13 +612,36 @@ work before decorrelation has even started. */
 		(map (filter (get_schema (source_schema src) (source_relation src)) (lambda (col)
 			(equal?? (col "Key") "PRI"))) (lambda (col) (col "Field"))))))
 
+(define source_unique_key_sets (lambda (src)
+	(if (not (source_is_base_table? src))
+		'()
+		(try
+			(lambda ()
+				(begin
+					(define info (show (source_schema src) (source_relation src) true))
+					(map ((info "meta") "Unique") (lambda (unique_key)
+						(unique_key "Cols")))))
+			(lambda (_e) '())))))
+
+(define unique_lookup_column_name (lambda (src expr)
+	(match expr
+		((symbol if) ((symbol nil?) probe) fallback value)
+		(if (and (nil? fallback) (equal? probe value))
+			(direct_column_name_for_alias src probe)
+			nil)
+		((quote if) ((quote nil?) probe) fallback value)
+		(if (and (nil? fallback) (equal? probe value))
+			(direct_column_name_for_alias src probe)
+			nil)
+		_ (direct_column_name_for_alias src expr))))
+
 (define unique_left_join_key_term? (lambda (default_alias src key_col term)
 	(match term
 		'(op left right) (if (or (equal? op (quote equal?)) (equal? op (quote equal??)))
 			(or
-				(and (equal? (direct_column_name_for_alias src left) key_col)
+				(and (equal? (unique_lookup_column_name src left) key_col)
 					(not (expr_refs_alias? default_alias (source_alias src) right)))
-				(and (equal? (direct_column_name_for_alias src right) key_col)
+				(and (equal? (unique_lookup_column_name src right) key_col)
 					(not (expr_refs_alias? default_alias (source_alias src) left))))
 			false)
 		_ false)))
@@ -6120,12 +6143,6 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(join_optimizer_metadata_costed_predicates
 					all_sources default_alias graph aliases))))))
 
-(define join_optimizer_primary_key_columns (lambda (src)
-	(if (source_is_base_table? src)
-		(map (filter (get_schema (source_schema src) (source_relation src)) (lambda (col)
-			(equal?? (col "Key") "PRI"))) (lambda (col) (col "Field")))
-		'())))
-
 (define join_optimizer_ref_matches? (lambda (ref src col)
 	(and (not (nil? ref))
 		(and (equal? (source_alias (car ref)) (source_alias src))
@@ -6155,12 +6172,15 @@ source catalog. join_plan remains the single owner of physical join order. */
 
 (define join_optimizer_unique_lookup_from_driver? (lambda (sources default_alias graph driver lookup)
 	(begin
-		(define key_cols (join_optimizer_primary_key_columns lookup))
-		(and (not (empty_list? key_cols))
-			(reduce key_cols (lambda (unique key_col)
-				(and unique (join_optimizer_key_bound_to_driver?
-					sources default_alias graph driver lookup key_col)))
-				true)))))
+		(define key_sets (source_unique_key_sets lookup))
+		(reduce key_sets (lambda (unique key_cols)
+			(or unique
+				(and (not (empty_list? key_cols))
+					(reduce key_cols (lambda (complete key_col)
+						(and complete (join_optimizer_key_bound_to_driver?
+							sources default_alias graph driver lookup key_col)))
+						true))))
+			false))))
 
 (define join_optimizer_order_expr_available_from_driver? (lambda (sources default_alias graph driver expr)
 	(begin
@@ -9250,17 +9270,17 @@ until lowering without creating a depth-proportional binary OR chain. */
 (define unique_lookup_join_term? (lambda (default_alias src key_col term)
 	(unique_left_join_key_term? default_alias src key_col term)))
 
-(define unique_lookup_key_columns (lambda (src stages)
+(define unique_lookup_key_sets (lambda (src stages)
 	(begin
 		(define group_cache_stage (stage_for_group_cache_source stages src))
 		(if (group_stage? group_cache_stage)
-			(group_key_cols (gs_keys group_cache_stage))
+			(list (group_key_cols (gs_keys group_cache_stage)))
 			(if (source_is_base_table? src)
-				(prejoin_primary_key_columns src)
+				(source_unique_key_sets src)
 				(if (stage_output_relation? (source_relation src))
 					(begin
 						(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
-						(if (group_stage? stage) (group_key_cols (gs_keys stage)) '()))
+						(if (group_stage? stage) (list (group_key_cols (gs_keys stage))) '()))
 					'()))))))
 
 (define lookup_probe_term_from_sources? (lambda (sources default_alias bound_sources lookup term)
@@ -9286,17 +9306,20 @@ until lowering without creating a depth-proportional binary OR chain. */
 		(define stage (coalesceNil
 			(source_stage_output_stage stages src)
 			(stage_for_group_cache_source stages src)))
-		(define key_cols (unique_lookup_key_columns src stages))
+		(define key_sets (unique_lookup_key_sets src stages))
 		(define lookup_condition (lookup_probe_condition_from_sources
 			sources default_alias bound_sources src condition))
 		(or
 			(and (scalar_aggregate_probe_stage? stage)
 				(empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
-			(and (not (empty_list? key_cols))
-				(reduce key_cols (lambda (unique key_col)
-					(and unique (reduce (split_and_terms lookup_condition)
-						(lambda (found term) (or found (unique_lookup_join_term? default_alias src key_col term))) false)))
-					true))))))
+			(reduce key_sets (lambda (unique key_cols)
+				(or unique
+					(and (not (empty_list? key_cols))
+						(reduce key_cols (lambda (complete key_col)
+							(and complete (reduce (split_and_terms lookup_condition)
+								(lambda (found term) (or found (unique_lookup_join_term? default_alias src key_col term))) false)))
+							true))))
+				false)))))
 
 (define source_is_unique_lookup? (lambda (sources default_alias driver src stages condition)
 	(source_is_unique_lookup_from_sources?
@@ -12268,18 +12291,12 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 (define source_unique_point_condition? (lambda (src condition)
 	(if (not (source_is_base_table? src))
 		false
-		(try
-			(lambda ()
-				(begin
-					(define info (show (source_schema src) (source_relation src) true))
-					(define uniques ((info "meta") "Unique"))
-					(reduce uniques (lambda (found unique_key)
-						(or found
-							(reduce (unique_key "Cols") (lambda (complete col)
-								(and complete (source_column_bound_by_equality? src col condition)))
-								true)))
-						false)))
-			(lambda (_e) false)))))
+		(reduce (source_unique_key_sets src) (lambda (found key_cols)
+			(or found
+				(reduce key_cols (lambda (complete col)
+					(and complete (source_column_bound_by_equality? src col condition)))
+					true)))
+			false))))
 
 (define probe_context_unique_point? (lambda (sources default_alias condition)
 	(if (not (single_source? sources))

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -27,6 +27,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS ord_member_doc"
   - sql: "DROP TABLE IF EXISTS ord_member_file"
   - sql: "DROP TABLE IF EXISTS ord_member_label"
+  - sql: "DROP TABLE IF EXISTS ord_member_permission"
   - sql: "DROP TABLE IF EXISTS ord_derived_item"
   - sql: "DROP TABLE IF EXISTS ord_derived_parent"
   - sql: "DROP TABLE IF EXISTS ord_tree_a"
@@ -39,6 +40,7 @@ setup:
   - sql: "CREATE TABLE ord_member_doc (id INT PRIMARY KEY, file_id INT, label_id INT, rank_value INT)"
   - sql: "CREATE TABLE ord_member_file (id INT PRIMARY KEY, filename TEXT)"
   - sql: "CREATE TABLE ord_member_label (id INT PRIMARY KEY, name TEXT, visible INT)"
+  - sql: "CREATE TABLE ord_member_permission (id INT PRIMARY KEY, principal_id INT, label_id INT)"
   - sql: "CREATE TABLE ord_derived_parent (id INT PRIMARY KEY, label TEXT)"
   - sql: "CREATE TABLE ord_derived_item (id INT PRIMARY KEY, parent_id INT, created INT)"
   - sql: "CREATE TABLE ord_tree_a (id INT PRIMARY KEY, pair_key INT)"
@@ -53,6 +55,7 @@ setup:
   - sql: "INSERT INTO ord_member_doc VALUES (1,1,10,40),(2,2,20,30),(3,3,10,20),(4,4,30,10)"
   - sql: "INSERT INTO ord_member_file VALUES (1,'other'),(2,'needle one'),(3,'needle two'),(4,'other')"
   - sql: "INSERT INTO ord_member_label VALUES (10,'alpha',1),(20,'beta',0)"
+  - sql: "INSERT INTO ord_member_permission VALUES (1,7,10)"
   - sql: "INSERT INTO ord_derived_parent VALUES (1,'one'),(2,'two')"
   - sql: "INSERT INTO ord_derived_item VALUES (10,1,100),(20,2,200)"
   - sql: "INSERT INTO ord_tree_a VALUES (1,10),(2,20),(3,30)"
@@ -588,6 +591,184 @@ test_cases:
         - "(sort (var 0)"
         - "(slice (var 0)"
 
+  - name: "Bounded derived read model preserves nested permission semantics"
+    sql: |
+      SELECT d.id, d.file_id, d.label_name
+      FROM (
+        SELECT m.id, m.file_id, m.label_id, m.rank_value,
+          projected_label.name AS label_name
+        FROM ord_member_doc m
+        LEFT JOIN (
+          SELECT l.id, l.name
+          FROM ord_member_label l
+        ) projected_label ON projected_label.id = m.label_id
+        WHERE COALESCE((
+          SELECT EXISTS (
+            SELECT TRUE FROM ord_member_permission permission_entry
+            WHERE permission_entry.principal_id = 7
+              AND permission_entry.label_id = permission_label.id
+            LIMIT 1
+          )
+          FROM ord_member_label permission_label
+          WHERE permission_label.id = m.label_id
+          LIMIT 1
+        ), FALSE)
+      ) d
+      WHERE d.file_id IN (
+        SELECT id FROM ord_member_file WHERE filename LIKE '%needle%'
+        UNION
+        SELECT id FROM ord_member_file WHERE filename LIKE '%two%'
+      )
+      ORDER BY d.rank_value DESC, d.label_id ASC
+      LIMIT 2
+    expect:
+      rows: 1
+      data:
+        - {id: 3, file_id: 3, label_name: "alpha"}
+
+  - name: "Set up scalable bounded derived read model"
+    setup:
+      - sql: "DROP TABLE IF EXISTS ord_read_doc"
+      - sql: "DROP TABLE IF EXISTS ord_read_file"
+      - sql: "DROP TABLE IF EXISTS ord_read_label"
+      - sql: "DROP TABLE IF EXISTS ord_read_permission"
+      - sql: "CREATE TABLE ord_read_doc (id INT PRIMARY KEY, file_id INT, label_id INT, rank_value INT)"
+      - sql: "CREATE TABLE ord_read_file (id INT PRIMARY KEY, filename TEXT)"
+      - sql: "CREATE TABLE ord_read_label (id INT UNIQUE, name TEXT)"
+      - sql: "CREATE TABLE ord_read_permission (id INT PRIMARY KEY, principal_id INT, label_id INT)"
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "ord_read_doc") (list "id" "file_id" "label_id" "rank_value")
+              (map (produceN 20000) (lambda (i)
+                (list (+ i 1) (+ i 1) (+ (mod i 100) 1) (- 20000 i)))))
+            (insert (table "memcp-tests" "ord_read_file") (list "id" "filename")
+              (map (produceN 20000) (lambda (i)
+                (list (+ i 1) (if (equal? (mod i 3) 0) "needle" "other")))))
+            (insert (table "memcp-tests" "ord_read_label") (list "id" "name")
+              (map (produceN 100) (lambda (i) (list (+ i 1) (concat "label_" (+ i 1))))))
+            (insert (table "memcp-tests" "ord_read_permission") (list "id" "principal_id" "label_id")
+              (map (produceN 50) (lambda (i) (list (+ i 1) 7 (+ i 1))))))
+      - scm: "(rebuild)"
+    sql: "SELECT COUNT(*) AS cnt FROM ord_read_doc"
+    expect:
+      rows: 1
+      data:
+        - cnt: 20000
+
+  - name: "Scalable bounded derived read model applies nested permission before native limit"
+    max_time: 3
+    sql: |
+      SELECT d.*
+      FROM (
+        SELECT m.id, m.file_id, m.label_id, m.rank_value,
+          projected_label.name AS label_name,
+          projected_label.allowed AS label_allowed
+        FROM ord_read_doc m
+        LEFT JOIN (
+          SELECT l.id, l.name,
+            l.name IS NOT NULL AS allowed
+          FROM ord_read_label l
+        ) projected_label ON projected_label.id = m.label_id
+        WHERE COALESCE((
+          SELECT EXISTS (
+            SELECT TRUE FROM ord_read_permission permission_entry
+            WHERE permission_entry.principal_id = 7
+              AND permission_entry.label_id = permission_label.id
+            LIMIT 1
+          )
+          FROM ord_read_label permission_label
+          WHERE permission_label.id = m.label_id
+          LIMIT 1
+        ), FALSE)
+      ) d
+      LEFT JOIN ord_read_label unused_sorter
+        ON unused_sorter.id = d.label_id
+      WHERE d.file_id IN (
+        SELECT id FROM ord_read_file WHERE filename LIKE '%needle%'
+        UNION
+        SELECT id FROM ord_read_file WHERE filename LIKE '%alternate%'
+      )
+      ORDER BY d.rank_value DESC, d.label_id ASC
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - {id: 1, file_id: 1, label_id: 1, rank_value: 20000, label_name: "label_1", label_allowed: true}
+        - {id: 4, file_id: 4, label_id: 4, rank_value: 19997, label_name: "label_4", label_allowed: true}
+
+  - name: "Bounded nested permission and membership stay on the ordered base driver"
+    sql: |
+      EXPLAIN SELECT d.*
+      FROM (
+        SELECT m.id, m.file_id, m.label_id, m.rank_value,
+          projected_label.name AS label_name,
+          projected_label.allowed AS label_allowed
+        FROM ord_read_doc m
+        LEFT JOIN (
+          SELECT l.id, l.name,
+            l.name IS NOT NULL AS allowed
+          FROM ord_read_label l
+        ) projected_label ON projected_label.id = m.label_id
+        WHERE COALESCE((
+          SELECT EXISTS (
+            SELECT TRUE FROM ord_read_permission permission_entry
+            WHERE permission_entry.principal_id = 7
+              AND permission_entry.label_id = permission_label.id
+            LIMIT 1
+          )
+          FROM ord_read_label permission_label
+          WHERE permission_label.id = m.label_id
+          LIMIT 1
+        ), FALSE)
+      ) d
+      LEFT JOIN ord_read_label unused_sorter
+        ON unused_sorter.id = d.label_id
+      WHERE d.file_id IN (
+        SELECT id FROM ord_read_file WHERE filename LIKE '%needle%'
+        UNION
+        SELECT id FROM ord_read_file WHERE filename LIKE '%alternate%'
+      )
+      ORDER BY d.rank_value DESC, d.label_id ASC
+      LIMIT 2
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "recset"
+      result_not_contains:
+        - "__join_order_intermediate"
+        - '"$recset_contains"'
+        - "(lambda (rows)"
+        - "(sort (var 0)"
+        - "(slice (var 0)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS ord_read_doc"
+      - sql: "DROP TABLE IF EXISTS ord_read_file"
+      - sql: "DROP TABLE IF EXISTS ord_read_label"
+      - sql: "DROP TABLE IF EXISTS ord_read_permission"
+
+  - name: "Partial composite unique lookup retains its storage carrier"
+    setup:
+      - sql: "DROP TABLE IF EXISTS ord_composite_lookup"
+      - sql: "CREATE TABLE ord_composite_lookup (lookup_id INT, variant INT, name TEXT, UNIQUE KEY lookup_variant (lookup_id, variant))"
+      - sql: "INSERT INTO ord_composite_lookup VALUES (10,1,'first'),(10,2,'second'),(20,1,'third')"
+    sql: |
+      EXPLAIN SELECT d.id
+      FROM ord_member_doc d
+      JOIN ord_composite_lookup c ON c.lookup_id = d.label_id
+      ORDER BY d.rank_value DESC
+      LIMIT 2
+    expect:
+      rows: 1
+      result_contains:
+        - "__join_order_intermediate"
+      result_not_contains:
+        - "(lambda (rows)"
+        - "(sort (var 0)"
+        - "(slice (var 0)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS ord_composite_lookup"
+
   - name: "ORDER BY DESC OFFSET beyond rows returns empty"
     sql: "SELECT a FROM ord_t ORDER BY a DESC LIMIT 2 OFFSET 10"
     expect:
@@ -695,6 +876,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS ord_member_doc"
   - sql: "DROP TABLE IF EXISTS ord_member_file"
   - sql: "DROP TABLE IF EXISTS ord_member_label"
+  - sql: "DROP TABLE IF EXISTS ord_member_permission"
   - sql: "DROP TABLE IF EXISTS ord_derived_item"
   - sql: "DROP TABLE IF EXISTS ord_derived_parent"
   - sql: "DROP TABLE IF EXISTS ord_tree_a"


### PR DESCRIPTION
## Summary

- preserve exact UNIQUE-key lookup proofs through null-preserving derived-table projections
- use complete catalog UNIQUE key sets, including composite keys, in logical reorder and physical lowering
- keep ordered base scans as the driver instead of building broad join-order intermediate carriers before LIMIT

## Regression coverage

YAML-only coverage adds separate tests for:

- nested permission correctness on a small derived read model
- a dedicated 20,000-row bounded read-model performance case (`max_time: 3`)
- structural EXPLAIN guards requiring ordered scan/RecSet lowering and forbidding join-order intermediate carriers and Scheme list sort/slice collectors
- the negative partial-composite-UNIQUE case, which must retain a storage carrier

The new performance test fails on the base at about 5.27 s and runs at 1.35-2.15 s on this branch.

## Production-size A/B

Same imported production-size data, same traced SQL payloads, warm server, identical result checksums:

| Filter shape | Base | PR | Result |
|---|---:|---:|---|
| broad numeric pattern | 21.648 s | 5.867 s | 6 rows, identical SHA-256 |
| narrower pattern A | 22.908 s | 13.042 s | 4 rows, identical SHA-256 |
| narrower pattern B | 27.054 s | 14.565 s | 6 rows, identical SHA-256 |

The broad plan drops `__join_order_intermediate` carriers from 6 to 0. The remaining 13-15 s narrow-pattern cost is in pattern-specific LIKE/MATCH RecSet construction and is intentionally left for a separate operator/cost-model package.

Compile time increases on the full traced shape from about 1.16 s to 2.22 s because the emitted nested-scan plan is larger, while end-to-end execution improves by 8-16 s. This trade-off is explicit rather than hidden.

## Verification

- `python3 run_sql_tests.py tests/planner/order-window/order-limit.yaml --jobs 1 --fail-fast`: 47/47
- targeted range, grouped-stage, nested-scalar, subselect, and window suites: green
- normal commit hook / full test suite on current master: green
- `git diff --check`: clean
- Scheme formatter run; remaining lint warnings are inherited negative-depth sites
