### PR TITLE
Optimize reductions over merged segments

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1343,6 +1343,52 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				(list 'list 'b 'c))))))
 	(assert (match opt_merge_unique_ser (regex "merge_unique_mut" _) true false) true "_mut merge_unique on fresh first arg")
 
+	/* merge consumers keep the segment catalog and avoid a flattened temporary. */
+	(print "testing optimizer merge consumer fusion ...")
+	(define opt_reduce_segments (optimize
+		(list 'lambda (list 'parts)
+			(list 'reduce (list 'merge 'parts)
+				(list 'lambda (list 'acc 'item) (list '+ 'acc 'item)) 0))))
+	(assert
+		(match (serialize opt_reduce_segments) (regex "reduce_segments" _) true false)
+		true
+		"optimizer: reduce consumes merge segments directly")
+	(define reduce_segments_fn (eval opt_reduce_segments))
+	(assert (reduce_segments_fn (list (list 1 2) (list) (list 3 4))) 10 "reduce_segments preserves order and empty segments")
+
+	(define opt_reduce_segments_without_neutral (optimize
+		(list 'lambda (list 'parts)
+			(list 'reduce (list 'merge 'parts)
+				(list 'lambda (list 'acc 'item) (list '+ 'acc 'item))))))
+	(define reduce_segments_without_neutral_fn (eval opt_reduce_segments_without_neutral))
+	(assert (reduce_segments_without_neutral_fn (list (list) (list 1 2) (list 3))) 6 "reduce_segments preserves implicit first accumulator")
+	(assert (reduce_segments_without_neutral_fn (list (list) (list))) nil "reduce_segments preserves empty reduction result")
+	(define opt_segment_validation_order (optimize
+		(list 'lambda (list 'parts)
+			(list 'reduce (list 'merge 'parts)
+				(list 'lambda (list 'acc 'item) (list 'panic "callback ran")) 0))))
+	(define segment_validation_order_fn (eval opt_segment_validation_order))
+	(define segment_validation_error (try
+		(lambda () (segment_validation_order_fn (list (list 1) 2)))
+		(lambda (e) e)))
+	(assert (strlike segment_validation_error "%reduce_segments item%") true "reduce_segments validates every segment before invoking reducer")
+	(define opt_dynamic_segment_reducer (optimize
+		(list 'lambda (list 'parts 'reducer)
+			(list 'reduce (list 'merge 'parts) 'reducer 0))))
+	(assert
+		(match (serialize opt_dynamic_segment_reducer) (regex "reduce_segments" _) true false)
+		false
+		"optimizer: dynamic reducer keeps merge validation before reducer lookup")
+	(define opt_computed_segment_neutral (optimize
+		(list 'lambda (list 'parts 'neutral)
+			(list 'reduce (list 'merge 'parts)
+				(list 'lambda (list 'acc 'item) (list '+ 'acc 'item))
+				(list '+ 'neutral 1)))))
+	(assert
+		(match (serialize opt_computed_segment_neutral) (regex "reduce_segments" _) true false)
+		false
+		"optimizer: computed neutral keeps merge validation order")
+
 	/* match / match_mut correctness */
 	(print "testing match/match_mut correctness ...")
 	/* match: literal patterns */

--- a/scm/list.go
+++ b/scm/list.go
@@ -521,6 +521,61 @@ func optimizeZip(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeD
 	return result, setOptimizedCallLength(td, minLen)
 }
 
+// optimizedMergeSegments returns the list-of-lists input of an optimized merge
+// call without materializing its flattened result. Variadic merge calls need a
+// small segment catalog; unary calls already carry that catalog as their sole
+// argument.
+func optimizedMergeSegments(v Scmer) (Scmer, bool) {
+	rv, ok := scmerSlice(v)
+	if !ok || len(rv) < 2 || !scmerIsSymbol(rv[0], "merge") {
+		return NewNil(), false
+	}
+	if len(rv) == 2 {
+		return rv[1], true
+	}
+	segments := make([]Scmer, 1, len(rv))
+	segments[0] = NewSymbol("list")
+	segments = append(segments, rv[1:]...)
+	return NewSlice(segments), true
+}
+
+// mergeValidationSafeArgument reports whether evaluating an argument before
+// merge's list validation is unobservable. Fused calls evaluate their ordinary
+// arguments before reduce_segments validates the segment catalog, whereas the
+// unfused spelling validates during evaluation of reduce's first argument.
+func mergeValidationSafeArgument(v Scmer, allowLambda bool) bool {
+	if stripped, ok := scmerStripSourceInfo(v); ok {
+		v = stripped
+	}
+	inner, ok := scmerSlice(v)
+	if !ok {
+		return v.IsNil() || v.IsBool() || v.IsInt() || v.IsFloat() || v.IsString()
+	}
+	if len(inner) == 0 {
+		return true
+	}
+	return scmerIsSymbol(inner[0], "quote") || (allowLambda && scmerIsSymbol(inner[0], "lambda"))
+}
+
+// optimizeReduce keeps merge as a segmented producer when its flattened value
+// is consumed exactly once by reduce. reduce_segments validates all segments
+// before invoking the callback, matching merge's existing error order.
+func optimizeReduce(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	result, td := oc.ApplyDefaultOptimization(v, useResult)
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) < 3 || len(rv) > 4 || !scmerIsSymbol(rv[0], "reduce") {
+		return result, td
+	}
+	segments, ok := optimizedMergeSegments(rv[1])
+	if !ok || !mergeValidationSafeArgument(rv[2], true) || (len(rv) == 4 && !mergeValidationSafeArgument(rv[3], false)) {
+		return result, td
+	}
+	fused := make([]Scmer, 0, len(rv))
+	fused = append(fused, NewSymbol("reduce_segments"), segments)
+	fused = append(fused, rv[2:]...)
+	return NewSlice(fused), td
+}
+
 // optimizeMap is the optimizer hook for `map`. It applies default optimization
 // (including FirstParameterMutable swap to map_mut), then fuses
 // (map (produceN N) fn) → (produceN N fn) to eliminate the intermediate list.
@@ -3943,8 +3998,9 @@ func init_list() {
 				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is a list item", Return: &TypeDescriptor{Kind: "any"}},
 				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
-			Return: &TypeDescriptor{Kind: "any"},
-			Const:  true,
+			Return:   &TypeDescriptor{Kind: "any"},
+			Const:    true,
+			Optimize: optimizeReduce,
 
 			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
 				var d3 JITValueDesc
@@ -6811,6 +6867,45 @@ func init_list() {
 	})
 
 	// Fused physical operators: optimizer-only, forbidden from .scm code.
+	Declare(&Globalenv, &Declaration{
+		Name: "reduce_segments",
+		Desc: "reduces ordered list segments without flattening them (optimizer-only)",
+		Fn: func(a ...Scmer) Scmer {
+			segments := asSlice(a[0], "reduce_segments")
+			for _, segment := range segments {
+				asSlice(segment, "reduce_segments item")
+			}
+			fn := OptimizeProcToSerialFunction(a[1])
+			result := NewNil()
+			hasResult := len(a) > 2
+			if hasResult {
+				result = a[2]
+			}
+			for _, segment := range segments {
+				for _, item := range asSlice(segment, "reduce_segments item") {
+					if !hasResult {
+						result = item
+						hasResult = true
+						continue
+					}
+					result = fn(result, item)
+				}
+			}
+			return result
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{
+				{Kind: "list", ParamName: "segments", NoEscape: true},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", ParamName: "neutral", Optional: true},
+			},
+			Return:    &TypeDescriptor{Kind: "any"},
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_map",
 		Desc: "fused serial map and filter (optimizer-only)",


### PR DESCRIPTION
## What changed

- Teach the recursive optimizer to rewrite `reduce(merge(segments), reducer, neutral)` to an optimizer-only segmented reducer.
- Preserve SQL/Scheme evaluation semantics by validating every segment before invoking the reducer.
- Keep dynamic reducers and computed neutral expressions on the original path when moving their evaluation could change panic/error order.
- Add Scheme regression coverage for optimized shape, ordering, empty segments, implicit neutral semantics, validation order, and conservative fallbacks.

## Why

The planner frequently builds a flat temporary only to consume it once. The segmented end form traverses the existing segment catalog directly and avoids allocating and copying the flattened list.

## Measurements

Microbenchmark, 32 segments × 32 elements, five 1-second samples; minima are compared because the host has competing load:

| metric | master after #492 | this branch | delta |
|---|---:|---:|---:|
| time | 37.935 µs | 33.492 µs | -11.7% |
| allocated bytes | 51,481 | 32,969 | -36.0% |
| allocations | 1,037 | 1,033 | -4 |

Private-application manual build, valid minima:

| backend | minimum |
|---|---:|
| master after #492 | 70.56 s |
| this branch | 74.16 s |
| MariaDB | 74.92 s |

The end-to-end minimum currently regresses by 5.1% versus master, despite the clear micro/allocation win. The difference is spread across browser phases rather than one observed SQL hotspot. A generated JIT emitter was also tested and discarded: it added 5,421 generated lines and produced no end-to-end improvement. This PR is therefore intentionally a draft and is not proposed for merge until the whole-application minimum is at least neutral.

## Validation

- `go build -o memcp`
- `go test ./scm`
- `python3 tools/lint_scm.py`
- complete hook-equivalent SQL suite split by taxonomy to stay below the local process limit: planner; execution/integration/performance; RDF/SQL; storage
- after rebasing onto #492: Scheme runtime suite and complete planner hook, including 42/42 ORDER/LIMIT tests

The Scheme runtime suite has the same two pre-existing master failures (`list with variable arg: count still works`, `!list count`); all newly added tests pass.
