### PR TITLE
planner: probe EXISTS stages from point drivers

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -12363,7 +12363,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 					(probe_context_small_enough? sources)
 					true))))))
 
-(define probeable_stage_output_source_for_block? (lambda (stages sources default_alias limit_value src)
+(define probeable_stage_output_source_for_block? (lambda (stages sources default_alias limit_value driver_condition src)
 	(if (scalar_first_stage_output_source? stages src)
 		(or
 			(probe_limit_small_enough? limit_value)
@@ -12375,8 +12375,18 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			(begin
 				(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 				(define probe_sources (filter sources (lambda (candidate) (not (equal? (source_alias candidate) (source_alias src))))))
+				/* A sibling presence output contributes at most one row for the same
+				lookup domain. It can supply predicates, but it does not multiply the
+				base driver cardinality used for a point-probe decision. */
+				(define cardinality_sources (filter probe_sources (lambda (candidate)
+					(not (presence_stage_output_source? stages candidate)))))
 				(and
-					(stage_probe_allowed_in_context? stage probe_sources)
+					/* A complete UNIQUE-key equality bounds the whole consumer to one
+					probe. Building the dependent relation's full presence keytable
+					cannot amortize in that context, regardless of base table size. */
+					(or
+						(stage_probe_allowed_in_context? stage probe_sources)
+						(probe_context_unique_point? cardinality_sources default_alias driver_condition))
 					(or
 						(stage_has_residual_outer_refs? stage)
 						(or
@@ -12433,7 +12443,7 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 (define probe_output_sources_for_block (lambda (stages sources default_alias limit_value driver_condition consumers)
 	(filter (coalesceNil sources '()) (lambda (src)
 		(or
-			(probeable_stage_output_source_for_block? stages sources default_alias limit_value src)
+			(probeable_stage_output_source_for_block? stages sources default_alias limit_value driver_condition src)
 			(or
 				(scalar_aggregate_probe_output_source_for_block? stages sources default_alias limit_value src)
 				(or
@@ -12889,7 +12899,9 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		(define rewritten_sources (rewrite_scalar_first_probe_sources_using stages sources probe_sources default_alias))
 		(make_query_block
 			(qb_schema block)
-			(sources_without_presence_probe_outputs stages rewritten_sources default_alias)
+			/* probe_sources is the caller's already costed and semantics-checked
+			selection. Do not rerun the unbounded cache heuristic while removing it. */
+			(sources_without_probe_outputs rewritten_sources probe_sources)
 			(rewrite_scalar_first_probe_fields stages probe_sources default_alias (qb_fields block))
 			(rewrite_scalar_first_probe_expr stages probe_sources default_alias (qb_where block))
 			(qb_group block)
@@ -13924,14 +13936,15 @@ key-fill recipe per carrier. */
 				false))
 		_ false)))
 
-(define stage_consumed_by_probe_source? (lambda (stage stages sources default_alias limit_value)
+(define stage_consumed_by_probe_source? (lambda (stage stages sources default_alias limit_value driver_condition)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(or found
 			(and (stage_output_relation? (source_relation src))
 				(and (equal? (stage_output_relation_id (source_relation src)) (gs_id stage))
 					(and
 						(probeable_stage_output_source? stages src)
-						(probeable_stage_output_source_for_block? stages sources default_alias limit_value src))))))
+						(probeable_stage_output_source_for_block?
+							stages sources default_alias limit_value driver_condition src))))))
 		false)))
 
 (define scalar_first_inline_only_stage? (lambda (stage)
@@ -14003,7 +14016,8 @@ key-fill recipe per carrier. */
 		(not (or
 			(row_number_stage_consumed_by_join? stage sources)
 			(stage_consumed_by_membership_source? stage (qb_stages block) sources (qb_facts block))
-			(stage_consumed_by_probe_source? stage (qb_stages block) sources default_alias (qb_limit block)))))))
+			(stage_consumed_by_probe_source?
+				stage (qb_stages block) sources default_alias (qb_limit block) (qb_where block)))))))
 
 (define stage_direct_prepare_semantic_candidate? (lambda (consumed_probe_ids consumed_source_probe_ids stage_output_ids stage)
 	(and

--- a/tests/planner/subqueries/exists-subquery.yaml
+++ b/tests/planner/subqueries/exists-subquery.yaml
@@ -21,6 +21,9 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS exists_point_acl"
+  - sql: "DROP TABLE IF EXISTS exists_point_child"
+  - sql: "DROP TABLE IF EXISTS exists_point_parent"
   - sql: "DROP TABLE IF EXISTS exists_shipments"
   - sql: "DROP TABLE IF EXISTS exists_doc_shares"
   - sql: "DROP TABLE IF EXISTS exists_docs"
@@ -77,6 +80,90 @@ setup:
       (5, 3, 1, TRUE)
 
 test_cases:
+  - name: "Set up large point-probe EXISTS relations"
+    setup:
+      - sql: "CREATE TABLE exists_point_parent (ID INT PRIMARY KEY, payload INT)"
+      - sql: "CREATE TABLE exists_point_child (ID INT PRIMARY KEY, parent_id INT)"
+      - sql: "CREATE TABLE exists_point_acl (ID INT PRIMARY KEY, child_id INT, principal_id INT)"
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "exists_point_parent") (list "ID" "payload")
+              (map (produceN 2000) (lambda (i) (list (+ i 1) i))))
+            (insert (table "memcp-tests" "exists_point_child") (list "ID" "parent_id")
+              (map (produceN 2000) (lambda (i) (list (+ i 1) (+ i 1)))))
+            (insert (table "memcp-tests" "exists_point_acl") (list "ID" "child_id" "principal_id")
+              (map (produceN 2000) (lambda (i) (list (+ i 1) (+ i 1) 7)))))
+      - scm: "(rebuild)"
+    sql: "SELECT COUNT(*) AS cnt FROM exists_point_parent"
+    expect:
+      rows: 1
+      data:
+        - cnt: 2000
+
+  - name: "Point-selected parent evaluates correlated EXISTS directly"
+    sql: |
+      SELECT p.ID,
+        EXISTS (
+          SELECT TRUE
+          FROM exists_point_child c
+          WHERE c.parent_id = p.ID
+            AND EXISTS (
+              SELECT TRUE
+              FROM exists_point_acl acl
+              WHERE acl.child_id = c.ID
+                AND acl.principal_id = 7
+              LIMIT 1
+            )
+          LIMIT 1
+        ) AS has_child,
+        EXISTS (
+          SELECT TRUE
+          FROM exists_point_child alternate
+          WHERE alternate.parent_id = p.ID
+            AND alternate.ID > 0
+          LIMIT 1
+        ) AS has_alternate
+      FROM exists_point_parent p
+      WHERE p.ID = 1500
+    expect:
+      rows: 1
+      data:
+        - {ID: 1500, has_child: true, has_alternate: true}
+
+  - name: "Point-selected parent avoids full correlated EXISTS keytable"
+    sql: |
+      EXPLAIN SELECT p.ID,
+        EXISTS (
+          SELECT TRUE
+          FROM exists_point_child c
+          WHERE c.parent_id = p.ID
+            AND EXISTS (
+              SELECT TRUE
+              FROM exists_point_acl acl
+              WHERE acl.child_id = c.ID
+                AND acl.principal_id = 7
+              LIMIT 1
+            )
+          LIMIT 1
+        ) AS has_child,
+        EXISTS (
+          SELECT TRUE
+          FROM exists_point_child alternate
+          WHERE alternate.parent_id = p.ID
+            AND alternate.ID > 0
+          LIMIT 1
+        ) AS has_alternate
+      FROM exists_point_parent p
+      WHERE p.ID = 1500
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+      result_not_contains:
+        - "touch_keytable"
+        - ".grp:query:"
+        - ".grp:exists_point_acl:"
+
   - name: "EXISTS with correlated subquery - customers with orders"
     sql: |
       SELECT ID, name FROM exists_customers c
@@ -654,6 +741,9 @@ test_cases:
           count: 2
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS exists_point_acl"
+  - sql: "DROP TABLE IF EXISTS exists_point_child"
+  - sql: "DROP TABLE IF EXISTS exists_point_parent"
   - sql: "DROP TABLE IF EXISTS exists_shipments"
   - sql: "DROP TABLE IF EXISTS exists_doc_shares"
   - sql: "DROP TABLE IF EXISTS exists_docs"


### PR DESCRIPTION
## What changed

- treat a complete UNIQUE-key equality on the outer driver as a bounded context for correlated presence stages
- exclude sibling presence outputs from the driver-cardinality proof because they contribute at most one row per lookup domain
- preserve the caller's already costed direct-probe decision while removing rewritten presence sources instead of rerunning the unbounded cache heuristic
- add a 2,000-row SQL regression covering two sibling `EXISTS` projections and a nested ACL-style `EXISTS`

## Root cause

The physical probe selector ignored an exact point predicate when sibling decorrelated presence outputs were present. It therefore selected full reusable group carriers based on raw relation cardinality. A second unbounded eligibility check then contradicted an already selected direct probe, producing a mixed plan with both the nested scan and a full group-cache source.

For an outer UNIQUE point lookup this cache cannot amortize: the complete query can issue at most one correlated probe per selected presence stage.

## A/B measurements

Same current-master data snapshot, same SQL payload and binary build flags. The payload selects one row by primary key and projects a UNION-based presence check with nested access predicates.

| Variant | Result |
| --- | --- |
| master `2130cccc2` | no response after 30.0 s; timed out with 0 bytes |
| PR cold/warm runs | 2.538-2.641 s across 5 runs |

All five PR runs returned 52,717 bytes with identical SHA-256 `f439a428351941959c90371aaf9222daae5ba3c9bb2c9829f3240c4f8316c9c0`.

The PR plan no longer references the document-wide group carrier. Its physical plan contains 13 scans and 15 ordered scans; direct presence checks remain nested under the point-selected driver.

The anonymized 2,000-row regression is red on master because EXPLAIN contains the inner ACL presence keytable, and green on this branch without `touch_keytable`, query group carriers, or the ACL presence carrier.

## Validation

- `make test`: passed all critical suites; only pre-existing explicitly noncritical cases remain
- `exists-subquery.yaml`: 30/30
- `deep-nested-in-exists.yaml`: 22/22
- `exists-nested-scalar.yaml`: 4/4
- `nested-correlated-subquery.yaml`: 10/10
- `subquery-complex.yaml`: 41/41
- `traced-union-scalar-probes.yaml`: 7/7
- `order-limit.yaml`: 47/47
- `composed-scalar-aggregate-shapes.yaml`: 23/23
