### PR TITLE
planner: defer nullable projection probes past limit

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -14918,6 +14918,37 @@ either bound a real row or supplied the synthetic NULL row. */
 			recset_contains_callback_symbol
 			expr))))
 
+(define acceptance_expr_source_aliases (lambda (sources default_alias expr)
+	(map
+		(filter (coalesceNil sources '()) (lambda (src)
+			(expr_refs_alias? default_alias (source_alias src) expr)))
+		source_alias)))
+
+(define acceptance_required_aliases_expand (lambda (sources default_alias required)
+	(merge_unique (list required
+		(merge (map (filter (coalesceNil sources '()) (lambda (src)
+			(contains? required (source_alias src)))) (lambda (src)
+				(acceptance_expr_source_aliases sources default_alias
+					(coalesceNil (source_join_expr src) true)))))))))
+
+(define acceptance_required_aliases_closure (lambda (sources default_alias required)
+	(begin
+		(define expanded (acceptance_required_aliases_expand sources default_alias required))
+		(if (equal? (count expanded) (count required))
+			expanded
+			(acceptance_required_aliases_closure sources default_alias expanded)))))
+
+(define acceptance_required_sources (lambda (sources default_alias condition)
+	(begin
+		(define seeds (map (filter (coalesceNil sources '()) (lambda (src)
+			(or
+				(not (source_outer? src))
+				(expr_refs_alias? default_alias (source_alias src) condition))))
+			source_alias))
+		(define required (acceptance_required_aliases_closure sources default_alias seeds))
+		(filter (coalesceNil sources '()) (lambda (src)
+			(contains? required (source_alias src)))))))
+
 /* A bounded ordered join may use the logical driver directly only when every
 remaining source is a proven unique lookup. The ordinary filter stays driver-local
 and indexable. The nested lookup acceptance runs in scan_order's globally ordered
@@ -14948,17 +14979,29 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 			(recset_project_join_expr_for_membership src membership)))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		/* Acceptance runs before OFFSET/LIMIT and therefore contains only joins
+		which can reject a driver row. Projection-only nullable lookups belong to
+		the map callback after the native window and must not be probed twice. */
+		(define acceptance_sources (acceptance_required_sources
+			remaining_sources default_alias remaining_condition))
+		(define acceptance_aliases (map acceptance_sources source_alias))
+		(define removed_acceptance_aliases (filter (map remaining_sources source_alias)
+			(lambda (candidate) (not (contains? acceptance_aliases candidate)))))
+		(define acceptance_plan (join_optimizer_tree_without_aliases
+			remaining_plan removed_acceptance_aliases))
 		(define acceptance_needed_exprs (merge (list
-			needed_exprs
 			(list remaining_condition)
-			(source_join_exprs remaining_sources))))
-		(define acceptance_probe (build_join_scan_reduce_using_recipe
-			schema all_sources remaining_plan default_alias acceptance_needed_exprs remaining_condition true
-			'() 0 1 true nil stages
-			(list (quote lambda) (list (quote _accepted) (quote _row)) true)
-			false
-			(list (quote lambda) (list (quote accepted) (quote shard_accepted))
-				(list (quote or) (quote accepted) (quote shard_accepted)))))
+			(source_join_exprs acceptance_sources))))
+		(define acceptance_probe (if (empty_list? acceptance_sources)
+			(list (quote optimize)
+				(lower_column_expr_for_join all_sources default_alias remaining_condition))
+			(build_join_scan_reduce_using_recipe
+				schema all_sources acceptance_plan default_alias acceptance_needed_exprs remaining_condition true
+				'() 0 1 true nil stages
+				(list (quote lambda) (list (quote _accepted) (quote _row)) true)
+				false
+				(list (quote lambda) (list (quote accepted) (quote shard_accepted))
+					(list (quote or) (quote accepted) (quote shard_accepted))))))
 		(define filtercols (join_cols_for_alias all_sources default_alias alias (list effective_condition)))
 		(define filter_expr (list (quote lambda)
 			(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))

--- a/tests/performance/unselective-scalar-order-limit.yaml
+++ b/tests/performance/unselective-scalar-order-limit.yaml
@@ -23,6 +23,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS usol_file"
   - sql: "DROP TABLE IF EXISTS usol_parent"
   - sql: "DROP TABLE IF EXISTS usol_assignment"
+  - sql: "DROP TABLE IF EXISTS usol_projection"
   - sql: "DROP TABLE IF EXISTS usol_item_multi"
   - sql: "DROP TABLE IF EXISTS usol_file_multi"
   - sql: "DROP TABLE IF EXISTS usol_text_outer"
@@ -31,6 +32,7 @@ setup:
   - sql: "CREATE TABLE usol_file (id INT, uploaded_at INT)"
   - sql: "CREATE TABLE usol_parent (id INT PRIMARY KEY, owner_id INT, team_id INT)"
   - sql: "CREATE TABLE usol_assignment (id INT PRIMARY KEY, team_id INT, member_id INT)"
+  - sql: "CREATE TABLE usol_projection (id INT PRIMARY KEY, uploaded_at INT)"
   - sql: "CREATE TABLE usol_item_multi (id INT PRIMARY KEY, bucket INT, file_id INT)"
   - sql: "CREATE TABLE usol_file_multi (bucket INT, id INT, uploaded_at INT)"
   - sql: "CREATE TABLE usol_text_outer (id INT PRIMARY KEY, lookup_key TEXT COLLATE utf8mb4_general_ci)"
@@ -45,6 +47,8 @@ setup:
         (insert (table "memcp-tests" "usol_item") '("id" "parent_id" "file_id")
           (map (produceN 10000) (lambda (i) (list (+ i 1) (+ (- i (* 2 (floor (/ i 2)))) 1) (+ i 1)))))
         (insert (table "memcp-tests" "usol_file") '("id" "uploaded_at")
+          (map (produceN 10000) (lambda (i) (list (+ i 1) (+ i 1)))))
+        (insert (table "memcp-tests" "usol_projection") '("id" "uploaded_at")
           (map (produceN 10000) (lambda (i) (list (+ i 1) (+ i 1)))))
         (insert (table "memcp-tests" "usol_file_multi") '("bucket" "id" "uploaded_at")
           (map (produceN 2000) (lambda (i)
@@ -185,6 +189,52 @@ test_cases:
     cleanup:
       - scm: '(settings "ScanDebugging" false)'
 
+  - name: "Ordered ACL preserves late projection results"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM `system_statistic`.`scans` WHERE `schema` = 'memcp-tests'"
+    sql: |
+      SELECT projected.id, projected.uploaded_at
+      FROM (
+        SELECT item.id, projection.uploaded_at,
+          COALESCE((
+            SELECT (parent.owner_id = 7 OR EXISTS (
+              SELECT TRUE FROM usol_assignment member
+              WHERE member.team_id = parent.team_id
+                AND member.member_id = 7 LIMIT 1
+            ))
+            FROM usol_parent parent
+            WHERE parent.id = item.parent_id LIMIT 1
+          ), FALSE) AS can_view
+        FROM usol_item item
+        LEFT JOIN usol_projection projection ON projection.id = item.file_id
+      ) projected
+      WHERE projected.can_view
+      ORDER BY projected.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - id: 9999
+          uploaded_at: 9999
+        - id: 9997
+          uploaded_at: 9997
+        - id: 9995
+          uploaded_at: 9995
+
+  - name: "Ordered ACL projection probes run only for the native window"
+    sql: |
+      SELECT COUNT(*) AS scans, SUM(outputCount) AS outputs
+      FROM `system_statistic`.`scans`
+      WHERE `schema` = 'memcp-tests' AND `table` = 'usol_projection'
+    expect:
+      rows: 1
+      data:
+        - scans: 3
+          outputs: 3
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'
+
   - name: "Nested direct outer correlation preserves scalar results"
     setup:
       - scm: '(settings "ScanDebugging" true)'
@@ -276,6 +326,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS usol_file"
   - sql: "DROP TABLE IF EXISTS usol_parent"
   - sql: "DROP TABLE IF EXISTS usol_assignment"
+  - sql: "DROP TABLE IF EXISTS usol_projection"
   - sql: "DROP TABLE IF EXISTS usol_item_multi"
   - sql: "DROP TABLE IF EXISTS usol_file_multi"
   - sql: "DROP TABLE IF EXISTS usol_text_outer"


### PR DESCRIPTION
## Summary
- restrict ordered native-limit acceptance to joins that can reject a driver row
- retain transitive ON dependencies and nullable sources referenced by WHERE
- execute projection-only nullable lookups only in the post-limit map
- add an execution-level regression guard based on actual scan telemetry

## Why
The ordered driver already received its ORDER BY and native LIMIT, but the acceptance callback traversed the complete remaining join tree. Projection-only LEFT JOIN lookups therefore ran once for every pre-limit candidate and again for result projection.

## A/B measurements

### Deterministic YAML fixture
Same 10k-row fixture and query on `28db3b1b4` versus this branch, with ScanDebugging enabled:

| Metric | master | PR |
|---|---:|---:|
| projection relation scans | 11 | 3 |
| projection outputs | 11 | 3 |
| result rows | 3 | 3 |

The new guard is reproducibly red on master (`11`, expected `3`) and green on the PR.

### Large production-derived read-model query
Same persistent data directory, process restart before each side, one cold plus two warm runs, TracePrint enabled:

| Run | master | PR |
|---|---:|---:|
| cold | 65.21 s | 63.66 s |
| warm 1 | 25.11 s | 22.39 s |
| warm 2 | 24.64 s | 22.85 s |
| warm median | 24.88 s | 22.62 s |

Warm speedup: 9.1%. Output SHA-256 is identical on both sides: `3b938dc5454629ac75ffcf9724ae18f58435ff9be63aec06adc2ce3ab43b5830`.

A synthetic fixture with trivial indexed projection lookups showed the expected work reduction but essentially flat overall latency (183.5 ms -> 179.4 ms), so the PR does not claim a general operator speedup.

## Verification
- `make test` (full hook-equivalent run): passed
- `tests/performance/unselective-scalar-order-limit.yaml`: 10/10
- `tests/planner/order-window/order-limit.yaml`: 47/47
- `tests/planner/joins/join-complex.yaml`: 10/10
- `tests/integration/query-shapes/traced-late-projection-read-models.yaml`: all critical tests passed
- `python3 tools/lint_scm.py --check`: only inherited formatter warnings

## Follow-up
The large query is still far above target. Its ACL predicate is represented as a boolean scalar stage rather than a direct presence stage, so the existing EXISTS RecSet selection does not recognize it. That should be addressed separately in logical normalization/costing rather than folded into this late-projection fix.