### PR TITLE
Preserve writes across shard generations

### DIFF
--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -202,6 +202,7 @@ func TestBoundaryLikePrefixIsRange(t *testing.T) {
 		scm.NewSymbol("strlike"),
 		scm.NewSymbol("x"),
 		scm.NewString("foo%"),
+		scm.NewString("utf8mb4_bin"),
 	})
 	cond := buildProc([]string{"x"}, body)
 	bounds := extractBoundaries([]string{"name"}, cond)
@@ -267,11 +268,11 @@ func TestRowWithinBoundsEqual(t *testing.T) {
 	idx := &StorageIndex{Cols: []string{"id"}, ColMatchers: []BoundaryMatcher{EqualMatcher}}
 	lower := []scm.Scmer{scm.NewInt(5)}
 
-	inRange, _ := idx.rowWithinBounds(1, lower, scm.NewInt(5), true, func(i int) scm.Scmer { return scm.NewInt(5) })
+	inRange, _ := idx.rowWithinBounds(boundaries{}, 1, lower, scm.NewInt(5), true, func(i int) scm.Scmer { return scm.NewInt(5) })
 	if !inRange {
 		t.Error("expected match for equal value")
 	}
-	inRange, beyond := idx.rowWithinBounds(1, lower, scm.NewInt(5), true, func(i int) scm.Scmer { return scm.NewInt(10) })
+	inRange, beyond := idx.rowWithinBounds(boundaries{}, 1, lower, scm.NewInt(5), true, func(i int) scm.Scmer { return scm.NewInt(10) })
 	if inRange {
 		t.Error("expected no match for different value")
 	}
@@ -286,7 +287,7 @@ func TestRowWithinBoundsLike(t *testing.T) {
 	lower := []scm.Scmer{scm.NewString("%Klaus%")}
 
 	// rowWithinBounds skips non-sorted columns entirely
-	inRange, _ := idx.rowWithinBounds(1, lower, scm.NewString("%Klaus%"), true, func(i int) scm.Scmer { return scm.NewString("anything") })
+	inRange, _ := idx.rowWithinBounds(boundaries{}, 1, lower, scm.NewString("%Klaus%"), true, func(i int) scm.Scmer { return scm.NewString("anything") })
 	if !inRange {
 		t.Error("expected inRange=true (LIKE skipped in rowWithinBounds)")
 	}

--- a/storage/database.go
+++ b/storage/database.go
@@ -501,6 +501,7 @@ func (db *database) ensureLoaded() {
 		} else {
 			t.ShardMode = ShardModeFree
 		}
+		t.publishTopologyLocked()
 		t.publishShowColumnsSnapshot()
 	}
 	// FK enforcement triggers are serializable Procs and persist with the table JSON.
@@ -807,6 +808,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				}
 				t.Shards = newShardList
 			}
+			t.publishTopologyLocked()
 
 			if !hasColdShard {
 				// Update per-column statistics only when every rebuilt shard has
@@ -1173,6 +1175,7 @@ func (db *database) newTable(name string, pm PersistencyMode) *table {
 	t.lastAccessed = uint64(time.Now().UnixNano())
 	t.Shards = make([]*storageShard, 1)
 	t.Shards[0] = NewShard(t)
+	t.publishTopologyLocked()
 	t.Auto_increment = 1
 	t.publishShowColumnsSnapshot()
 	return t

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -125,12 +125,7 @@ func runFanoutTasks(currentTx *TxContext, taskCount int, task func(int, bool)) <
 // snapshots only shard topology and does not touch the transaction fanout
 // budget; callers reach it after boundary analysis has selected a table scan.
 func (t *table) shardResultBufferSize() int {
-	t.shardModeMu.RLock()
-	defer t.shardModeMu.RUnlock()
-	size := len(t.PShards)
-	if t.ShardMode == ShardModeFree {
-		size = len(t.Shards)
-	}
+	size := len(t.activeTopology().shards)
 	if size < 1 {
 		return 1
 	}
@@ -155,25 +150,37 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 	runWorkers := func(shards []*storageShard, onDone func(*storageShard)) <-chan struct{} {
 		return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
 			s := shards[i]
+			if onDone != nil {
+				defer onDone(s)
+			}
 			release := s.GetRead()
 			defer release()
 			callback(s, synchronous)
-			if onDone != nil {
-				onDone(s)
-			}
 		})
 	}
 
-	// Hold shardModeMu.RLock while reading ShardMode and capturing shard list.
-	// Phase F's drain uses shardModeMu.Lock() to synchronize, ensuring all
-	// iterateShards calls that read FreeShard have incremented activeScanners
-	// before the drain check begins.
-	t.shardModeMu.RLock()
-	mode := t.ShardMode
-	if mode == ShardModeFree {
-		shards := t.Shards
-		// Increment activeScanners while holding shardModeMu.RLock so Phase F
-		// sees all in-flight scans after its shardModeMu.Lock()/Unlock().
+	for {
+		topology := t.activeTopology()
+		if topology.mode != ShardModeFree {
+			relevant := collectRelevantShards(topology.dimensions, boundaries, topology.shards)
+			if len(relevant) == 0 {
+				return nil
+			}
+			if len(relevant) == 1 {
+				s := relevant[0]
+				release := s.GetRead()
+				defer release()
+				callback(s, true)
+				return nil
+			}
+			return runWorkers(relevant, nil)
+		}
+
+		// Register against the loaded generation, then verify it is still
+		// authoritative. A concurrent publisher can drain the old generation
+		// without a reader lock: late registrations notice the changed pointer
+		// before touching a shard and retry on the new topology.
+		shards := topology.shards
 		relevant := make([]*storageShard, 0, len(shards))
 		for _, s := range shards {
 			if s != nil {
@@ -181,36 +188,27 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 				relevant = append(relevant, s)
 			}
 		}
-		t.shardModeMu.RUnlock()
+		if t.topology.Load() != topology {
+			for _, s := range relevant {
+				s.activeScanners.Add(-1)
+			}
+			continue
+		}
 
 		if len(relevant) == 0 {
 			return nil
 		}
 		if len(relevant) == 1 {
 			s := relevant[0]
+			defer s.activeScanners.Add(-1)
 			release := s.GetRead()
+			defer release()
 			callback(s, true)
-			release()
-			s.activeScanners.Add(-1)
 			return nil
 		}
 		return runWorkers(relevant, func(s *storageShard) {
 			s.activeScanners.Add(-1)
 		})
-	} else {
-		t.shardModeMu.RUnlock()
-		relevant := collectRelevantShards(t.PDimensions, boundaries, t.PShards)
-		if len(relevant) == 0 {
-			return nil
-		}
-		if len(relevant) == 1 {
-			s := relevant[0]
-			release := s.GetRead()
-			callback(s, true)
-			release()
-			return nil
-		}
-		return runWorkers(relevant, nil)
 	}
 }
 
@@ -577,8 +575,6 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 			newshards[i].logfile = t.schema.persistence.OpenLog(newshards[i].uuid.String())
 		}
 	}
-	t.PShards = newshards
-	t.PDimensions = shardCandidates
 	// maintenanceKind was already set to 2 by the caller (db.rebuild or
 	// beginManualRepartition) under maintenanceMu.
 	// From this point, all concurrent inserts/updates go to BOTH shard sets.
@@ -591,9 +587,19 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	datasetids := make([][][]uint32, totalShards) // newshard -> oldshard -> []rowIdx
 	total_count := uint64(0)
 	t.mu.Lock()
+	t.PShards = newshards
+	t.PDimensions = shardCandidates
 	for si, s := range oldshards {
 		snapshots[si] = s.snapshotPartitionState(shardCandidates)
 	}
+	sourceSet := &repartitionSourceSet{
+		shards: append([]*storageShard(nil), oldshards...),
+		set:    make(map[*storageShard]struct{}, len(oldshards)),
+	}
+	for _, shard := range oldshards {
+		sourceSet.set[shard] = struct{}{}
+	}
+	t.repartitionSources.Store(sourceSet)
 	t.setRepartitionTranslationMap(make(map[*storageShard]map[uint32]translatedRecid))
 	t.repartitionDualWriteActive.Store(true)
 	t.mu.Unlock()
@@ -881,17 +887,16 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	}
 
 	// ── Phase F: Flip ShardMode + Drain ──
-	// Step 1: Flip ShardMode so new scans/inserts use PShards.
+	// Publish the complete immutable topology as one generation. Readers that
+	// registered against the old generation either finish there or notice the
+	// pointer change and retry before touching its shards.
+	t.mu.Lock()
 	t.PShards = newshards
 	t.PDimensions = shardCandidates
 	t.ShardMode = ShardModePartition
-	// Step 2: Acquire/release shardModeMu to synchronize with iterateShards.
-	// After this, all iterateShards calls that captured FreeShard mode have
-	// incremented activeScanners on old shards. New iterateShards calls see
-	// ShardModePartition and use PShards.
-	t.shardModeMu.Lock()
-	t.shardModeMu.Unlock()
-	// Step 3: Wait for all in-flight scans on old shards to complete.
+	t.publishTopologyLocked()
+	t.mu.Unlock()
+	// Wait for all in-flight scans on old shards to complete.
 	// During this drain, maintenanceKind == 2 is still true, so dual-write
 	// continues forwarding writes from old shards to PShards.
 	for _, s := range oldshards {
@@ -957,8 +962,10 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	// so new inserts use PShards exclusively.
 	t.mu.Lock()
 	t.Shards = nil
+	t.publishTopologyLocked()
 	t.maintenanceKind = 0
 	t.repartitionDualWriteActive.Store(false)
+	t.repartitionSources.Store(nil)
 	t.mu.Unlock()
 	t.clearRepartitionTranslation()
 	t.maintenanceMu.Unlock()

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"os"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -160,6 +161,92 @@ func TestIterateShardsParallelMarksFreeSingleShardSolo(t *testing.T) {
 	}
 }
 
+func TestIterateShardsParallelReleasesFreeShardRegistrationOnPanic(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanparpanic")
+	shard := tbl.Shards[0]
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("iterateShardsParallel callback did not panic")
+			}
+		}()
+		tbl.iterateShardsParallel(nil, nil, func(*storageShard, bool) {
+			panic("forced scan failure")
+		})
+	}()
+
+	if got := shard.activeScanners.Load(); got != 0 {
+		t.Fatalf("active scanner registrations after panic = %d, want 0", got)
+	}
+}
+
+func TestOverflowRebuildPublishesShardTopologySafely(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanpartopology")
+	oldShardSize := Settings.ShardSize
+	Settings.ShardSize = 8
+	t.Cleanup(func() {
+		Settings.ShardSize = oldShardSize
+	})
+
+	rows := make([][]scm.Scmer, 8)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i))}
+	}
+	tbl.Insert([]string{"id"}, rows, nil, scm.NewNil(), false, nil)
+	oldShard := tbl.Shards[0]
+
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		close(started)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				shards := tbl.ActiveShards()
+				if len(shards) > 0 {
+					_ = shards[0]
+				}
+			}
+		}
+	}()
+	<-started
+
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(8)}}, nil, scm.NewNil(), false, nil)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for oldShard.loadNext() == nil {
+		if time.Now().After(deadline) {
+			close(stop)
+			readers.Wait()
+			t.Fatal("overflow rebuild did not publish a successor")
+		}
+		runtime.Gosched()
+	}
+	next := oldShard.loadNext()
+	next.mu.Lock()
+	next.mu.Unlock()
+	for tbl.overflowRebuilds.Load() != 0 {
+		if time.Now().After(deadline) {
+			close(stop)
+			readers.Wait()
+			t.Fatal("overflow rebuild did not finish")
+		}
+		runtime.Gosched()
+	}
+	close(stop)
+	readers.Wait()
+
+	if got := tbl.Count(); got != 9 {
+		t.Fatalf("row count after overflow rebuild = %d, want 9", got)
+	}
+}
+
 func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 	tbl := setupScanParallelTestTable(t, "tscanparpartsolo")
 	tbl.ShardMode = ShardModePartition
@@ -169,6 +256,7 @@ func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 		Pivots:        []scm.Scmer{scm.NewInt(10)},
 	}}
 	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
+	tbl.publishTopologyLocked()
 
 	calls := 0
 	sawSolo := false
@@ -204,6 +292,7 @@ func TestIterateShardsParallelMarksPartitionMultiShardNonSolo(t *testing.T) {
 		Pivots:        []scm.Scmer{scm.NewInt(10)},
 	}}
 	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
+	tbl.publishTopologyLocked()
 
 	var calls atomic.Int32
 	var sawSolo atomic.Bool
@@ -235,6 +324,7 @@ func TestIterateShardsParallelAutocommitUsesExplicitContext(t *testing.T) {
 		Pivots:        []scm.Scmer{scm.NewInt(10)},
 	}}
 	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
+	tbl.publishTopologyLocked()
 	tx := NewTxContext(TxCursorStability)
 	tx.autoCommit = true
 	tx.Session = scm.NewSession()

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2168,7 +2168,17 @@ func (t *storageShard) insertReplica(columns []string, values [][]scm.Scmer, alr
 	if !alreadyLocked {
 		t.mu.Lock()
 	}
+	firstNewInsertIdx := len(t.inserts)
 	firstNewRecid := t.insertPreparedLocked(columns, values, nil, false, false, currentTx)
+	if next := t.nextForMaintenanceLocked(nil); next != nil {
+		// A writer may still hold an older immutable table-topology snapshot
+		// after more than one rebuild generation has been published. Replica
+		// inserts therefore continue through completed successor generations,
+		// without re-running triggers, unique checks, or repartition routing.
+		payloadCols, payloadVals := t.materializedInsertedRowsLocked(firstNewInsertIdx)
+		firstNextRecid := next.insertReplica(payloadCols, payloadVals, false, currentTx)
+		t.recordNextInsertRange(firstNewRecid, firstNextRecid, len(payloadVals))
+	}
 	if !alreadyLocked {
 		t.mu.Unlock()
 	}
@@ -2231,7 +2241,7 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 			firstNextRecid := next.insertReplica(payloadCols, payloadVals, false, currentTx)
 			t.recordNextInsertRange(firstNewRecid, firstNextRecid, len(payloadVals))
 		}
-		if t.t.repartitionDualWriteActive.Load() {
+		if t.t.repartitionDualWriteActive.Load() && t.t.isRepartitionSource(t) {
 			t.t.dualWriteInsertFromOld(t, firstNewRecid, payloadCols, payloadVals)
 		}
 	}

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -240,6 +240,30 @@ func TestShardRebuildForwardsConcurrentInsertsViaNext(t *testing.T) {
 	}
 }
 
+func TestShardRebuildForwardsInsertAcrossSuccessorChain(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "trebuildchain")
+	source := tbl.Shards[0]
+	firstSuccessor := NewShard(tbl)
+	latestSuccessor := NewShard(tbl)
+
+	source.storeNext(firstSuccessor)
+	source.nextReady.Store(true)
+	firstSuccessor.storeNext(latestSuccessor)
+	firstSuccessor.nextReady.Store(true)
+
+	source.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(42)}}, false, nil, false)
+
+	if got := source.Count(); got != 1 {
+		t.Fatalf("source count = %d, want 1", got)
+	}
+	if got := firstSuccessor.Count(); got != 1 {
+		t.Fatalf("first successor count = %d, want 1", got)
+	}
+	if got := latestSuccessor.Count(); got != 1 {
+		t.Fatalf("latest successor count = %d, want 1", got)
+	}
+}
+
 func TestShardRebuildDeletePropagationUsesStableTranslation(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-shard-rebuild-delete-*")
 	if err != nil {

--- a/storage/storage-int_jit_bench_test.go
+++ b/storage/storage-int_jit_bench_test.go
@@ -331,7 +331,7 @@ func BenchmarkStorageIntSum(b *testing.B) {
 			NumVars: 2,
 		})
 
-		mr := shard.OpenMapReducer([]string{"x"}, mapProc, reduceProc)
+		mr := shard.OpenMapReducer([]string{"x"}, mapProc, reduceProc, false, 1, nil, nil)
 		defer mr.Close()
 
 		// build recid list [0..benchN-1]
@@ -341,14 +341,14 @@ func BenchmarkStorageIntSum(b *testing.B) {
 		}
 
 		// validate
-		got := mr.Stream(scm.NewInt(0), recids)
+		got := mr.Stream(scm.NewInt(0), recids, nil)
 		if got.Int() != expectedSum {
 			b.Fatalf("MapReducer sum mismatch: got %d, want %d", got.Int(), expectedSum)
 		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			mr.Stream(scm.NewInt(0), recids)
+			mr.Stream(scm.NewInt(0), recids, nil)
 		}
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1363,6 +1363,7 @@ func Init(en scm.Env) {
 			newTable.lastAccessed = uint64(time.Now().UnixNano())
 			newTable.Shards = make([]*storageShard, 1)
 			newTable.Shards[0] = NewShard(newTable)
+			newTable.publishTopologyLocked()
 			newTable.Auto_increment = 1
 			newTable.Collation = collation
 			newTable.Charset = charset

--- a/storage/table.go
+++ b/storage/table.go
@@ -214,6 +214,19 @@ const (
 	ShardModePartition ShardMode = 1 // use PShards (partitioned)
 )
 
+// tableShardTopology is immutable after publication. Readers load one pointer
+// and can inspect the complete authoritative topology without taking t.mu.
+type tableShardTopology struct {
+	mode       ShardMode
+	shards     []*storageShard
+	dimensions []shardDimension
+}
+
+type repartitionSourceSet struct {
+	shards []*storageShard
+	set    map[*storageShard]struct{}
+}
+
 type translatedRecid struct {
 	pshardIdx int
 	newRecid  uint32
@@ -387,18 +400,20 @@ type table struct {
 
 	// storage: ShardMode controls which shard set is the read/write target
 	ShardMode   ShardMode
-	shardModeMu sync.RWMutex    // protects ShardMode reads in iterateShards vs Phase F flip
 	Shards      []*storageShard // unordered shards (used when ShardMode == ShardModeFree)
 	PShards     []*storageShard // partitioned shards according to PDimensions (used when ShardMode == ShardModePartition)
 	PDimensions []shardDimension
+	topology    atomic.Pointer[tableShardTopology]
 
 	// maintenanceMu prevents concurrent rebuild and repartition on this table.
 	// Holders: db.rebuild() claims it for rebuild (maintenanceKind=1) and may
 	// transition to repartition (maintenanceKind=2) while still holding it.
 	// beginManualRepartition() also claims it for direct repartition requests.
 	maintenanceMu              sync.Mutex
-	maintenanceKind            int         // 0=idle, 1=rebuilding, 2=repartitioning
-	repartitionDualWriteActive atomic.Bool // true after Phase B snapshot; dual-write only when true
+	maintenanceKind            int          // 0=idle, 1=rebuilding, 2=repartitioning
+	overflowRebuilds           atomic.Int32 // background workers; observed without joining the write path
+	repartitionDualWriteActive atomic.Bool  // true after Phase B snapshot; dual-write only when true
+	repartitionSources         atomic.Pointer[repartitionSourceSet]
 
 	// repartitionTranslation maps old-shard rows to their new PShard locations.
 	// Snapshot rows are published after Phase B. Post-snapshot dual-written rows
@@ -507,12 +522,36 @@ func (t *table) getColFreq(col string) int64 {
 	return t.colFreq[col]
 }
 
-// ActiveShards returns the shard set that is currently authoritative for reads/writes.
-func (t *table) ActiveShards() []*storageShard {
-	if t.ShardMode == ShardModePartition {
-		return t.PShards
+// publishTopologyLocked publishes an immutable authoritative topology. The
+// caller holds t.mu or otherwise has exclusive ownership before publication.
+func (t *table) publishTopologyLocked() *tableShardTopology {
+	mode := t.ShardMode
+	shards := t.Shards
+	if mode == ShardModePartition {
+		shards = t.PShards
 	}
-	return t.Shards
+	topology := &tableShardTopology{
+		mode:       mode,
+		shards:     append([]*storageShard(nil), shards...),
+		dimensions: append([]shardDimension(nil), t.PDimensions...),
+	}
+	t.topology.Store(topology)
+	return topology
+}
+
+func (t *table) activeTopology() *tableShardTopology {
+	if topology := t.topology.Load(); topology != nil {
+		return topology
+	}
+	// Tables are unpublished while constructors populate their initial shard.
+	// Lazily publishing here also supports zero-value tables in storage tests.
+	return t.publishTopologyLocked()
+}
+
+// ActiveShards returns an immutable snapshot of the shard set that is currently
+// authoritative for reads and writes.
+func (t *table) ActiveShards() []*storageShard {
+	return t.activeTopology().shards
 }
 
 // collectStatistics gathers approximate table statistics without coupling
@@ -1673,7 +1712,8 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 		return 0
 	}
 
-	if t.ShardMode == ShardModeFree { // unpartitioned sharding
+	topology := t.activeTopology()
+	if topology.mode == ShardModeFree { // unpartitioned sharding
 		// Helper to get or create a shard with capacity for n rows
 		getShardWithCapacity := func(n uint) *storageShard {
 			t.mu.Lock()
@@ -1685,15 +1725,38 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 			shard := t.Shards[len(t.Shards)-1]
 			if uint(shard.Count())+n > Settings.ShardSize {
 				// Current shard would overflow, create new one
+				t.overflowRebuilds.Add(1)
 				go func(i int, s *storageShard) {
+					t.maintenanceMu.Lock()
+					claimed := false
 					defer func() {
+						if claimed {
+							t.mu.Lock()
+							if t.maintenanceKind == 1 {
+								t.maintenanceKind = 0
+							}
+							t.mu.Unlock()
+						}
+						t.maintenanceMu.Unlock()
+						t.overflowRebuilds.Add(-1)
 						if r := recover(); r != nil {
 							fmt.Println("error: shard rebuild failed for", t.schema.Name+".", t.Name, "shard", i, ":", r)
 						}
 					}()
+					t.mu.Lock()
+					if t.ShardMode != ShardModeFree || i >= len(t.Shards) || t.Shards[i] != s {
+						t.mu.Unlock()
+						return
+					}
+					t.maintenanceKind = 1
+					claimed = true
+					t.mu.Unlock()
 					rebuilt := s.rebuild(false)
 					t.mu.Lock()
-					t.Shards[i] = rebuilt
+					if t.ShardMode == ShardModeFree && i < len(t.Shards) && t.Shards[i] == s {
+						t.Shards[i] = rebuilt
+						t.publishTopologyLocked()
+					}
 					t.mu.Unlock()
 					t.collectStatistics()
 					t.schema.save()
@@ -1701,6 +1764,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				shard = NewShard(t)
 				fmt.Println("started new shard for table", t.Name)
 				t.Shards = append(t.Shards, shard)
+				t.publishTopologyLocked()
 				if t.PersistencyMode == Cache && !strings.HasPrefix(t.Name, ".") {
 					GlobalCache.AddItem(shard, 0, TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 				}
@@ -1721,7 +1785,11 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 
 			shard := getShardWithCapacity(uint(len(chunk)))
 			if shard == nil {
-				// Repartition completed: re-insert remaining values via partition path
+				// Repartition completed after this Insert loaded its starting
+				// generation. Reload the published partition topology before routing
+				// the remaining rows; the old free generation may already have
+				// finished its forwarding drain.
+				topology = t.activeTopology()
 				values = values[start:]
 				repartitioned = true
 				break
@@ -1773,7 +1841,8 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 	{
 		// partitions
 		// TODO: check which shards are involved; a sharding dimension column must be present in ALL unique keys, otherwise we cannot prune
-		dims := t.PDimensions
+		dims := topology.dimensions
+		partitionShards := topology.shards
 		shardcols := make([]scm.Scmer, len(dims))
 		translatable := make([]int, len(dims))
 		for i, cd := range dims {
@@ -1834,7 +1903,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 					shardcols[j] = scm.NewNil()
 				}
 			}
-			shard := t.PShards[computeShardIndex(dims, shardcols)]
+			shard := partitionShards[computeShardIndex(dims, shardcols)]
 			if i > 0 && shard != last_shard {
 				checkUniqueForShard(last_shard, values[last_i:i]) // shard has changed: bulk insert all items that belong to this shard
 				last_i = i
@@ -1847,13 +1916,11 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 	}
 
 insertDone:
-	// Dual-write: forward inserts to the secondary shard set during repartition.
-	// The secondary insert bypasses unique checks (already handled above),
-	// triggers, and auto-increment (already assigned in primary insert).
-	// Use repartitionDualWriteActive (set after Phase B snapshot) to avoid
-	// duplicating rows that are already captured in the snapshot.
-	if t.repartitionDualWriteActive.Load() {
-		t.dualWriteInsert(columns, values)
+	// Before the topology flip, storageShard.Insert forwards old→new and records
+	// recid translations. After the flip, new writes are mirrored new→old only
+	// until old scans drain. Replica insertion prevents recursive forwarding.
+	if topology.mode == ShardModePartition && t.repartitionDualWriteActive.Load() {
+		t.dualWriteInsertToOld(columns, values)
 	}
 
 	return result
@@ -1901,62 +1968,26 @@ func (t *table) sanitizeInsertRows(columns []string, values [][]scm.Scmer, isIgn
 	return values
 }
 
-// dualWriteInsert routes rows into the secondary shard set (the one not selected
-// by ShardMode) during an active repartition. Called only when
-// repartitionDualWriteActive is true. Rows are inserted without unique/trigger processing.
-func (t *table) dualWriteInsert(columns []string, values [][]scm.Scmer) {
-	if t.ShardMode == ShardModeFree {
-		// Primary is Shards, secondary is PShards
-		if t.PShards == nil {
-			return
-		}
-		dims := t.PDimensions
-		shardcols := make([]scm.Scmer, len(dims))
-		translatable := make([]int, len(dims))
-		for i, cd := range dims {
-			for j, col := range columns {
-				if cd.Column == col {
-					translatable[i] = j
-				}
-			}
-		}
-		last_i := 0
-		var last_shard *storageShard
-		for i := 0; i < len(values); i++ {
-			for j, colidx := range translatable {
-				if colidx < len(values[i]) {
-					shardcols[j] = values[i][colidx]
-				} else {
-					shardcols[j] = scm.NewNil()
-				}
-			}
-			shard := t.PShards[computeShardIndex(dims, shardcols)]
-			if i > 0 && shard != last_shard {
-				rel := last_shard.GetExclusive()
-				last_shard.Insert(columns, values[last_i:i], false, nil, false)
-				rel()
-				last_i = i
-			}
-			last_shard = shard
-		}
-		if last_i < len(values) && last_shard != nil {
-			rel := last_shard.GetExclusive()
-			last_shard.Insert(columns, values[last_i:], false, nil, false)
-			rel()
-		}
-	} else {
-		// Primary is PShards, secondary is Shards
-		if t.Shards == nil {
-			return
-		}
-		// Route to the last shard in the free shard list
-		t.mu.Lock()
-		shard := t.Shards[len(t.Shards)-1]
-		t.mu.Unlock()
-		rel := shard.GetExclusive()
-		shard.Insert(columns, values, false, nil, false)
-		rel()
+// dualWriteInsertToOld keeps pre-flip readers current while the old generation
+// drains. It is called only for statements that started on partition topology.
+func (t *table) dualWriteInsertToOld(columns []string, values [][]scm.Scmer) {
+	sources := t.repartitionSources.Load()
+	if sources == nil || len(sources.shards) == 0 {
+		return
 	}
+	shard := sources.shards[len(sources.shards)-1]
+	release := shard.GetExclusive()
+	defer release()
+	shard.insertReplica(columns, values, false, nil)
+}
+
+func (t *table) isRepartitionSource(shard *storageShard) bool {
+	sources := t.repartitionSources.Load()
+	if sources == nil {
+		return false
+	}
+	_, ok := sources.set[shard]
+	return ok
 }
 
 func (t *table) dualWriteInsertFromOld(oldShard *storageShard, firstOldRecid uint32, columns []string, values [][]scm.Scmer) {


### PR DESCRIPTION
## Problem

Shard topology was read and published through independently mutable fields. Concurrent overflow rebuilds therefore raced with readers. A panic in a free-shard scan also leaked its active-scanner registration.

A second correctness gap appeared once topology reads became immutable snapshots: a writer pinned to generation A could overlap two rebuilds A to B to C, while replica forwarding stopped after B. The current group-carrier generation then missed the inserted key even though the source table contained the row.

## Changes

- publish the authoritative shard mode, shard list, and dimensions as one immutable atomic topology generation
- register free-shard readers with load/register/recheck, without a topology mutex; panic-safe defers release scanner registrations and shard rights
- serialize background overflow rebuild publication without blocking foreground writers
- preserve directional forwarding during repartition: old to staging before the flip, new to old only while old readers drain
- forward replica inserts through every completed rebuild successor and retain recid translation per hop
- reload the published partition topology when an insert observes that its starting free generation has already retired
- refresh stale storage test call sites so the new regressions compile against the current APIs

## Regression evidence

Tests were written and run against unchanged production code before the fixes:

- scanner panic: active scanner registrations after panic = 1, want 0
- concurrent ActiveShards plus overflow rebuild: Go race detector reported the shard slice publication race
- chained successor forwarding: generation A = 1 row, B = 1 row, C = 0 rows
- existing incremental aggregate suite: group C disappeared after deleting and reinserting its last row; unchanged base commit passed 108/108

After the fixes:

- targeted rebuild, scanner, overflow, and manual repartition tests pass under go test -race
- incremental aggregates: 108/108
- session-sensitive group cache: 37/37
- group-cache invalidation: 128/128 in the full hook run
- concurrent repartition: 143/143
- full git-pre-commit: passed

The coverage-enabled make test exercised all storage correctness suites successfully, but the machine had repeated external OOM kills and unrelated compile-time budget misses. The subsequent normal full hook and the commit hook both completed successfully.

## Contract

Foreground reads use immutable topology snapshots and do not take a table topology lock. Foreground writes remain live throughout background rebuilds. Rebuild successors receive forwarded writes through the complete published generation chain. No persistence deletion paths or serialization formats are changed.