### PR TITLE
Fix cancellation of table-lock waits

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -117,6 +117,20 @@ func materializeCodeLiteral(expr Scmer) (Scmer, bool) {
 	return expr, false
 }
 
+// listExpressionCallName recognizes both source symbols and native procedure
+// heads produced by recursive optimization. Length analysis runs after child
+// optimization, so treating a native `list` head as list data adds the call
+// head itself to the inferred length.
+func listExpressionCallName(head Scmer) (string, bool) {
+	if sym, ok := scmerSymbol(head); ok {
+		return string(sym), true
+	}
+	if decl := DeclarationForValue(head); decl != nil {
+		return decl.Name, true
+	}
+	return "", false
+}
+
 func exactListLengthFromExpr(expr Scmer) int {
 	if stripped, ok := scmerStripSourceInfo(expr); ok {
 		expr = stripped
@@ -125,8 +139,8 @@ func exactListLengthFromExpr(expr Scmer) int {
 		if len(inner) == 0 {
 			return UnknownLength
 		}
-		if sym, ok := scmerSymbol(inner[0]); ok {
-			switch sym {
+		if callName, ok := listExpressionCallName(inner[0]); ok {
+			switch callName {
 			case "quote":
 				if len(inner) == 2 {
 					return exactListLengthFromExpr(inner[1])
@@ -181,7 +195,11 @@ func exactListLengthFromExpr(expr Scmer) int {
 			case "merge":
 				if len(inner) == 2 {
 					arg := inner[1]
-					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
+					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 {
+						outerCall, isCall := listExpressionCallName(outer[0])
+						if !isCall || outerCall != "list" {
+							return UnknownLength
+						}
 						total := 0
 						for _, item := range outer[1:] {
 							itemLen := exactListLengthFromExpr(item)
@@ -211,7 +229,11 @@ func exactListLengthFromExpr(expr Scmer) int {
 			case "zip":
 				if len(inner) == 2 {
 					arg := inner[1]
-					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 && scmerIsSymbol(outer[0], "list") {
+					if outer, ok := scmerSlice(arg); ok && len(outer) > 0 {
+						outerCall, isCall := listExpressionCallName(outer[0])
+						if !isCall || outerCall != "list" {
+							return UnknownLength
+						}
 						expected := UnknownLength
 						for _, item := range outer[1:] {
 							itemLen := exactListLengthFromExpr(item)
@@ -260,8 +282,8 @@ func exactAssocLengthFromExpr(expr Scmer) int {
 		if len(inner) == 0 {
 			return UnknownLength
 		}
-		if sym, ok := scmerSymbol(inner[0]); ok {
-			switch sym {
+		if callName, ok := listExpressionCallName(inner[0]); ok {
+			switch callName {
 			case "quote":
 				if len(inner) == 2 {
 					return exactAssocLengthFromExpr(inner[1])
@@ -355,8 +377,8 @@ func exactFlattenedMergeArgumentLength(expr Scmer, ti TypeInfo) int {
 	if !ok || len(inner) == 0 {
 		return UnknownLength
 	}
-	if sym, ok := scmerSymbol(inner[0]); ok {
-		switch sym {
+	if callName, ok := listExpressionCallName(inner[0]); ok {
+		switch callName {
 		case "quote":
 			if len(inner) == 2 {
 				return exactFlattenedMergeArgumentLength(inner[1], ti)

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -334,6 +334,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		ss.Touch()
 		querySeq = ss.BeginQuery("Query", query)
 		ss.SetCancel(querySeq, queryCancel)
+		ss.SetQueryContext(querySeq, queryCtx)
 	}
 	if doneSession, ok := any(session).(mysqlSessionDone); ok {
 		go func() {

--- a/scm/network.go
+++ b/scm/network.go
@@ -303,6 +303,7 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	querySeq := ss.BeginQuery("Query", req.Method+" "+req.URL.Path)
 	ctx, cancel := context.WithCancel(req.Context())
 	ss.SetCancel(querySeq, cancel)
+	ss.SetQueryContext(querySeq, ctx)
 	defer cancel()
 	defer ss.EndQuery(querySeq, "Sleep", "")
 	// Watch for HTTP client disconnect and propagate to session kill

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -46,6 +46,7 @@ type SessionState struct {
 	activeCount  atomic.Int64  // number of concurrently running requests/queries
 
 	cancelFns map[uint64]context.CancelFunc
+	queryCtxs map[uint64]context.Context
 	active    map[uint64]bool
 	killed    map[uint64]bool
 	cancelMu  sync.Mutex // protects active query bookkeeping
@@ -159,11 +160,36 @@ func (s *SessionState) SetCancel(seq uint64, fn context.CancelFunc) {
 	s.cancelMu.Unlock()
 }
 
+// SetQueryContext records the query-generation-specific cancellation signal.
+// Persistent HTTP sessions may execute overlapping generations, so table-lock
+// waiters must never infer this context from the session's latest query.
+func (s *SessionState) SetQueryContext(seq uint64, ctx context.Context) {
+	s.cancelMu.Lock()
+	if s.queryCtxs == nil {
+		s.queryCtxs = make(map[uint64]context.Context)
+	}
+	s.queryCtxs[seq] = ctx
+	s.cancelMu.Unlock()
+}
+
+// QueryContext returns the cancellation context owned by one query generation.
+func (s *SessionState) QueryContext(seq uint64) context.Context {
+	if seq == 0 {
+		return nil
+	}
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	return s.queryCtxs[seq]
+}
+
 // ClearCancel removes the cancel function if it still belongs to seq.
 func (s *SessionState) ClearCancel(seq uint64) {
 	s.cancelMu.Lock()
 	if s.cancelFns != nil {
 		delete(s.cancelFns, seq)
+	}
+	if s.queryCtxs != nil {
+		delete(s.queryCtxs, seq)
 	}
 	if s.active != nil {
 		delete(s.active, seq)

--- a/storage/table.go
+++ b/storage/table.go
@@ -16,6 +16,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
+import "context"
 import "fmt"
 import "math"
 import "sync"
@@ -867,6 +868,22 @@ func (t *table) getTableLockCond() *sync.Cond {
 	return t.tableLockCond
 }
 
+// tableLockQueryContext resolves the exact statement generation rather than
+// the session's latest query. Autocommit workers carry that generation in the
+// transaction, which keeps overlapping persistent HTTP requests independent.
+func tableLockQueryContext(ss *scm.SessionState) context.Context {
+	if ss == nil {
+		return nil
+	}
+	querySeq := scm.CurrentQuerySeq()
+	if tx := CurrentTx(); tx != nil {
+		if txSeq := querySeqFromTx(tx); txSeq != 0 {
+			querySeq = txSeq
+		}
+	}
+	return ss.QueryContext(querySeq)
+}
+
 // waitTableLock blocks until the table lock is compatible with the caller's intent.
 // isWrite=true means the caller wants to write (blocked by ANY lock from another session).
 // isWrite=false means the caller wants to read (blocked only by WRITE lock from another session).
@@ -877,6 +894,15 @@ func (t *table) getTableLockCond() *sync.Cond {
 // Panics if the owning session tries to write while holding a READ lock (MySQL semantics).
 func (t *table) waitTableLock(ss *scm.SessionState, isWrite bool) {
 	cond := t.getTableLockCond()
+	ctx := tableLockQueryContext(ss)
+	if ctx != nil {
+		stopWake := context.AfterFunc(ctx, func() {
+			t.tableLockMu.Lock()
+			cond.Broadcast()
+			t.tableLockMu.Unlock()
+		})
+		defer stopWake()
+	}
 	if ss != nil {
 		ss.BeginLockWait()
 		defer ss.EndLockWait()
@@ -885,6 +911,10 @@ func (t *table) waitTableLock(ss *scm.SessionState, isWrite bool) {
 	var errMsg string
 	t.tableLockMu.Lock()
 	for {
+		if ctx != nil && ctx.Err() != nil {
+			errMsg = "query killed"
+			break
+		}
 		owner := t.tableLockOwner.Load()
 		state := t.tableLockState.Load()
 		if !isWrite {

--- a/tests/execution/concurrency/kill-lock.yaml
+++ b/tests/execution/concurrency/kill-lock.yaml
@@ -326,6 +326,44 @@ test_cases:
       - session_id: "lock-state-writer"
         sql: "UNLOCK TABLES"
 
+  # ── KILL QUERY interrupts a table-lock wait ───────────────────────────────
+
+  - name: "KILL QUERY interrupts a table-lock waiter without releasing the owner"
+    setup:
+      - sql: "DROP TABLE IF EXISTS lock_kill_ctrl"
+      - sql: "CREATE TABLE lock_kill_ctrl (id BIGINT)"
+    steps:
+      - session_id: "lock-kill-victim"
+        sql: "INSERT INTO lock_kill_ctrl VALUES (CONNECTION_ID())"
+      - session_id: "lock-kill-owner"
+        sql: "LOCK TABLES lock_test WRITE"
+      - session_id: "lock-kill-victim"
+        sql: "SELECT id FROM lock_test WHERE id = 1"
+        background: true
+        timeout: 5
+        expect:
+          error: true
+      - session_id: "lock-kill-owner"
+        sql: "SELECT 1"
+      - session_id: "lock-kill-attacker"
+        sql: "SELECT KILL_QUERY(id) AS killed FROM lock_kill_ctrl LIMIT 1"
+        expect:
+          rows: 1
+          contains: "True"
+      - wait_for_background: true
+        timeout: 5
+      - session_id: "lock-kill-owner"
+        sql: "SELECT COUNT(*) AS n FROM lock_test"
+        expect:
+          rows: 1
+      - session_id: "lock-kill-owner"
+        sql: "UNLOCK TABLES"
+      - session_id: "lock-kill-victim"
+        sql: "SELECT id FROM lock_test WHERE id = 1"
+        expect:
+          rows: 1
+          contains: "1"
+
   # ── KILL QUERY stops a running slow query ─────────────────────────────────
 
   - name: "KILL QUERY stops a running slow query"

--- a/tests/execution/operators/scan-batch-optimizer.yaml
+++ b/tests/execution/operators/scan-batch-optimizer.yaml
@@ -176,6 +176,15 @@ test_cases:
     expect:
       data: [true]
 
+  - name: "Optimizer preserves count of variable list constructors"
+    scm: |
+      (begin
+        (define count_three ((eval (optimize '('lambda '('x) '(count '(list 'x 2 3))))) 42))
+        (define count_two ((eval (optimize '('lambda '('a 'b) '(count '(list 'a 'b))))) 10 20))
+        (if (and (equal? count_three 3) (equal? count_two 2))
+          true
+          (error "optimizer changed the length of a variable list")))
+
   - name: "Grouped LEFT JOIN carrier keeps outer key as dynamic lookup"
     sql: |
       SELECT c.cid, g.total


### PR DESCRIPTION
## Summary

- make normal queries blocked by an explicit table lock observe `KILL QUERY` immediately
- bind cancellation to the exact query generation, including overlapping requests on persistent HTTP sessions
- repair recursive optimizer length inference when a `list` call head has already become a native procedure
- add CI-effective YAML regressions for both failures

## Root causes

A blocked table scan waited exclusively on the table lock condition variable. Cancelling its query context did not wake that condition, so the process-list entry remained in `Waiting for table lock` until the lock owner explicitly unlocked.

Separately, recursive optimization can replace the symbolic `list` call head with its native procedure. Static length inference then mistook that call expression for list data and counted the call head as an element. Existing Scheme startup assertions detected this, but startup continued and therefore did not fail the YAML test run. The new YAML case raises an explicit error on a wrong result.

## Tests

- `python3 run_sql_tests.py tests/execution/concurrency/kill-lock.yaml --jobs 1 --fail-fast` (28/28)
- `python3 run_sql_tests.py tests/execution/operators/scan-batch-optimizer.yaml --jobs 1 --fail-fast` (12/12)
- Scheme startup tests: 1176/1176
- full `make test`: passed; all critical suites green

The lock regression verifies that cancellation terminates the waiter within five seconds, does not release the owning session's table lock, and leaves the killed session reusable.
