### PR TITLE
Fix durable shard generation publication

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -787,28 +787,87 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				}
 			}
 
-			t.mu.Lock()
-			tableLocked = true
-
 			// Collect pre-rebuild shards that were replaced so we can clean them up.
 			var replaced []*storageShard
-			// Publish the new shard list only after completion.
 			if targetIsP {
 				for i, oldShard := range origShardList {
 					if oldShard != nil && oldShard != newShardList[i] && oldShard.uuid != newShardList[i].uuid {
 						replaced = append(replaced, oldShard)
 					}
 				}
-				t.PShards = newShardList
 			} else {
 				for i, oldShard := range origShardList {
 					if oldShard != nil && oldShard != newShardList[i] && oldShard.uuid != newShardList[i].uuid {
 						replaced = append(replaced, oldShard)
 					}
 				}
+			}
+
+			// A persistent generation is named by schema.json. Keep the old
+			// topology authoritative and briefly drain its writers while the new
+			// UUID list is committed. Ephemeral tables have no schema commit
+			// boundary; waiting for their transaction here can self-deadlock cache
+			// initialization, which invokes RebuildTable inside that transaction.
+			durablePublication := len(replaced) > 0 && t.PersistencyMode != Memory && t.PersistencyMode != Cache
+			if durablePublication {
+				for _, shard := range origShardList {
+					if shard != nil {
+						shard.mu.Lock()
+					}
+				}
+			}
+
+			t.mu.Lock()
+			tableLocked = true
+			if targetIsP {
+				t.PShards = newShardList
+			} else {
 				t.Shards = newShardList
 			}
+			t.mu.Unlock()
+			tableLocked = false
+
+			var publicationPanic any
+			if durablePublication {
+				func() {
+					defer func() { publicationPanic = recover() }()
+					db.save()
+				}()
+			}
+			if publicationPanic != nil {
+				t.mu.Lock()
+				if targetIsP {
+					t.PShards = origShardList
+				} else {
+					t.Shards = origShardList
+				}
+				t.maintenanceKind = 0
+				t.mu.Unlock()
+				if durablePublication {
+					for i := len(origShardList) - 1; i >= 0; i-- {
+						if origShardList[i] != nil {
+							origShardList[i].mu.Unlock()
+						}
+					}
+				}
+				errMu.Lock()
+				rebuildErrors = append(rebuildErrors, fmt.Sprintf("schema publication failed for %s.%s: %v", db.Name, t.Name, publicationPanic))
+				errMu.Unlock()
+				t.maintenanceMu.Unlock()
+				rebuildClaimed = false
+				return
+			}
+
+			t.mu.Lock()
+			tableLocked = true
 			t.publishTopologyLocked()
+			if durablePublication {
+				for i := len(origShardList) - 1; i >= 0; i-- {
+					if origShardList[i] != nil {
+						origShardList[i].mu.Unlock()
+					}
+				}
+			}
 
 			if !hasColdShard {
 				// Update per-column statistics only when every rebuilt shard has
@@ -894,6 +953,16 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 
 			t.mu.Unlock()
 			tableLocked = false
+			for _, shard := range origShardList {
+				if shard == nil {
+					continue
+				}
+				for shard.activeScanners.Load() > 0 {
+					runtime.Gosched()
+				}
+			}
+			t.mutationMu.Lock()
+			t.mutationMu.Unlock()
 
 			if doRepart {
 				// maintenanceMu stays locked; repartition Phase G will unlock it

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -541,7 +541,14 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	fmt.Println("repartitioning", t.Name, "by", shardCandidates, "into", totalShards, "shards")
 	start := time.Now()
 
-	oldshards := t.ActiveShards()
+	t.mu.Lock()
+	oldTopology := t.activeTopology()
+	oldshards := append([]*storageShard(nil), oldTopology.shards...)
+	oldShardMode := t.ShardMode
+	oldFreeShards := append([]*storageShard(nil), t.Shards...)
+	oldPartitionShards := append([]*storageShard(nil), t.PShards...)
+	oldPartitionDimensions := append([]shardDimension(nil), t.PDimensions...)
+	t.mu.Unlock()
 
 	// Eagerly load all shard data before taking any locks for partitioning.
 	for _, s := range oldshards {
@@ -573,6 +580,26 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 		newshards[i].srState = WRITE // live shard, not cold
 		if t.PersistencyMode == Safe || t.PersistencyMode == Logged {
 			newshards[i].logfile = t.schema.persistence.OpenLog(newshards[i].uuid.String())
+		}
+	}
+	abortRepartition := func() {
+		t.mu.Lock()
+		t.ShardMode = oldShardMode
+		t.Shards = oldFreeShards
+		t.PShards = oldPartitionShards
+		t.PDimensions = oldPartitionDimensions
+		t.maintenanceKind = 0
+		t.repartitionDualWriteActive.Store(false)
+		t.repartitionSources.Store(nil)
+		t.mu.Unlock()
+		t.clearRepartitionTranslation()
+		t.repartitionPendingMu.Lock()
+		t.repartitionPendingDels = nil
+		t.repartitionPendingSourceDels = nil
+		t.repartitionPendingMu.Unlock()
+		t.maintenanceMu.Unlock()
+		for _, shard := range newshards {
+			discardUnpublishedShard(shard)
 		}
 	}
 	// maintenanceKind was already set to 2 by the caller (db.rebuild or
@@ -657,6 +684,8 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 
 	fmt.Println("moving data from", t.Name, len(oldshards), "into", totalShards, "shards")
 	var done sync.WaitGroup
+	var buildErrMu sync.Mutex
+	var buildErrors []any
 	done.Add(totalShards)
 	workers := runtime.NumCPU() / 2
 	if workers < 1 {
@@ -670,6 +699,9 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 					defer func() {
 						if r := recover(); r != nil {
 							fmt.Println("error: repartition shard build failed for", t.schema.Name+".", t.Name, "shard", si, ":", r)
+							buildErrMu.Lock()
+							buildErrors = append(buildErrors, r)
+							buildErrMu.Unlock()
 						}
 						done.Done()
 					}()
@@ -793,6 +825,11 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	}
 	close(progress) // signal workers to exit after processing all items
 	done.Wait()
+	if len(buildErrors) > 0 {
+		err := buildErrors[0]
+		abortRepartition()
+		panic(err)
+	}
 
 	// ── Phase D: Install main storage + Delta shift ──
 	// Under the shard lock, install the built columns and main_count, then
@@ -851,11 +888,58 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 				}
 			}
 		}
+		// Staging inserts were assigned recids while main_count was still zero.
+		// Rebuild their unpublished WAL after the main prefix is installed so a
+		// restart observes the same shifted recids as the live shard.
+		if t.PersistencyMode == Safe || t.PersistencyMode == Logged {
+			if s.logfile != nil {
+				s.logfile.Close()
+			}
+			t.schema.persistence.RemoveLog(s.uuid.String())
+			s.logfile = t.schema.persistence.OpenLog(s.uuid.String())
+			if len(s.inserts) > 0 {
+				columns, values := s.materializedInsertedRowsLocked(0)
+				s.logfile.Write(LogEntryInsert{columns, values})
+				for i := range s.inserts {
+					recid := s.main_count + uint32(i)
+					if s.deletions.Get(uint(recid)) {
+						s.logfile.Write(LogEntryDelete{recid})
+					}
+				}
+			}
+			if t.PersistencyMode == Safe {
+				s.logfile.Sync()
+			}
+		}
 		s.mu.Unlock()
 	}
 	mainCounts := make([]uint32, len(newshards))
 	for i, built := range builtData {
 		mainCounts[i] = built.mainCount
+	}
+	applyPendingDeletes := func() int {
+		t.repartitionPendingMu.Lock()
+		pending := t.repartitionPendingDels
+		t.repartitionPendingDels = nil
+		t.repartitionPendingMu.Unlock()
+		for _, tr := range pending {
+			ps := newshards[tr.pshardIdx]
+			recid := tr.newRecid
+			if tr.inDelta {
+				recid += mainCounts[tr.pshardIdx]
+			}
+			ps.mu.Lock()
+			wasDeleted := ps.deletions.Get(uint(recid))
+			ps.deletions.Set(uint(recid), true)
+			if !wasDeleted {
+				ps.logVisibilityChangeLocked(recid, true)
+			}
+			ps.mu.Unlock()
+			if !wasDeleted && t.PersistencyMode == Safe && ps.logfile != nil {
+				ps.logfile.Sync()
+			}
+		}
+		return len(pending)
 	}
 	t.shiftDeltaRepartitionTranslations(mainCounts)
 	t.resolvePendingRepartitionSourceDeletes()
@@ -871,31 +955,89 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 			break
 		}
 		totalPending += len(pending)
-		for _, tr := range pending {
-			ps := newshards[tr.pshardIdx]
-			recid := tr.newRecid
-			if tr.inDelta {
-				recid += mainCounts[tr.pshardIdx]
-			}
-			ps.mu.Lock()
-			ps.deletions.Set(uint(recid), true)
-			ps.mu.Unlock()
-		}
+		t.repartitionPendingMu.Lock()
+		t.repartitionPendingDels = append(t.repartitionPendingDels, pending...)
+		t.repartitionPendingMu.Unlock()
+		applyPendingDeletes()
 	}
 	if totalPending > 0 {
 		fmt.Println("repartition: applied", totalPending, "pending deletions after Phase D")
 	}
 
-	// ── Phase F: Flip ShardMode + Drain ──
-	// Publish the complete immutable topology as one generation. Readers that
-	// registered against the old generation either finish there or notice the
-	// pointer change and retry before touching its shards.
+	// ── Phase F: Durable publication + topology flip + drain ──
+	// Keep the old immutable topology authoritative while schema.json is being
+	// committed. Source writes remain synchronous old→new forwards. Locking the
+	// old shards only for this short commit boundary prevents a writer from
+	// completing between the final catch-up and durable metadata publication.
+	for {
+		for {
+			active := false
+			for _, shard := range oldshards {
+				if shard.activeTransactions.Load() > 0 {
+					active = true
+					break
+				}
+			}
+			if !active {
+				break
+			}
+			runtime.Gosched()
+		}
+		for _, shard := range oldshards {
+			shard.mu.Lock()
+		}
+		active := false
+		for _, shard := range oldshards {
+			if shard.activeTransactions.Load() > 0 {
+				active = true
+				break
+			}
+		}
+		if !active {
+			break
+		}
+		for i := len(oldshards) - 1; i >= 0; i-- {
+			oldshards[i].mu.Unlock()
+		}
+	}
+	// With source writers stopped, every completed pre-publication delete must
+	// now have a translation and be durable in the new generation.
+	t.resolvePendingRepartitionSourceDeletes()
+	t.repartitionPendingMu.Lock()
+	unresolvedBeforePublication := len(t.repartitionPendingSourceDels)
+	t.repartitionPendingMu.Unlock()
+	if unresolvedBeforePublication != 0 {
+		for i := len(oldshards) - 1; i >= 0; i-- {
+			oldshards[i].mu.Unlock()
+		}
+		abortRepartition()
+		panic(fmt.Sprintf("repartition cannot publish %s: %d source deletes have no target translation", t.Name, unresolvedBeforePublication))
+	}
+	applyPendingDeletes()
 	t.mu.Lock()
 	t.PShards = newshards
 	t.PDimensions = shardCandidates
 	t.ShardMode = ShardModePartition
+	t.Shards = nil
+	t.mu.Unlock()
+	var savePanic any
+	func() {
+		defer func() { savePanic = recover() }()
+		t.schema.save()
+	}()
+	if savePanic != nil {
+		for i := len(oldshards) - 1; i >= 0; i-- {
+			oldshards[i].mu.Unlock()
+		}
+		abortRepartition()
+		panic(savePanic)
+	}
+	t.mu.Lock()
 	t.publishTopologyLocked()
 	t.mu.Unlock()
+	for i := len(oldshards) - 1; i >= 0; i-- {
+		oldshards[i].mu.Unlock()
+	}
 	// Wait for all in-flight scans on old shards to complete.
 	// During this drain, maintenanceKind == 2 is still true, so dual-write
 	// continues forwarding writes from old shards to PShards.
@@ -919,22 +1061,14 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	// Any remaining pending entries are now final.
 	t.resolvePendingRepartitionSourceDeletes()
 	t.repartitionPendingMu.Lock()
-	finalPending := t.repartitionPendingDels
-	t.repartitionPendingDels = nil
-	t.repartitionPendingSourceDels = nil
+	unresolvedFinal := len(t.repartitionPendingSourceDels)
 	t.repartitionPendingMu.Unlock()
-	for _, tr := range finalPending {
-		ps := newshards[tr.pshardIdx]
-		recid := tr.newRecid
-		if tr.inDelta {
-			recid += mainCounts[tr.pshardIdx]
-		}
-		ps.mu.Lock()
-		ps.deletions.Set(uint(recid), true)
-		ps.mu.Unlock()
+	if unresolvedFinal != 0 {
+		panic(fmt.Sprintf("repartition published %s with %d unresolved source deletes; old generation retained", t.Name, unresolvedFinal))
 	}
-	if len(finalPending) > 0 {
-		fmt.Println("repartition: applied", len(finalPending), "final pending deletions after Phase F drain")
+	finalPending := applyPendingDeletes()
+	if finalPending > 0 {
+		fmt.Println("repartition: applied", finalPending, "final pending deletions after Phase F drain")
 	}
 
 	// Verify transformation result
@@ -950,19 +1084,8 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	}
 	fmt.Println("activated new partitioning schema for", t.Name, "after", time.Since(start))
 
-	// ── Phase G: Commit and cleanup ──
-	// New shard files are complete before this publication barrier. schema.json
-	// must atomically name the new PShards before any old shard file is released;
-	// a publication panic therefore leaves oldshards intact and recoverable.
-	t.schema.schemalock.Lock()
-	t.schema.saveLockedAndUnlock(t.schemaSaveMode())
-
-	// Nil out old shards after the schema is saved, so no FreeShard
-	// code path can reference them. At this point, ShardMode is Partition,
-	// so new inserts use PShards exclusively.
+	// ── Phase G: Retire the old generation ──
 	t.mu.Lock()
-	t.Shards = nil
-	t.publishTopologyLocked()
 	t.maintenanceKind = 0
 	t.repartitionDualWriteActive.Store(false)
 	t.repartitionSources.Store(nil)

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -506,8 +506,14 @@ func encodeLogEntry(e interface{}) []byte {
 	case LogEntryDelete:
 		tmp, _ := json.Marshal(encDelete{T: "delete", Idx: l.idx})
 		payload = tmp
+	case LogEntryUndelete:
+		tmp, _ := json.Marshal(encDelete{T: "undelete", Idx: l.idx})
+		payload = tmp
 	case LogEntryInsert:
 		tmp, _ := json.Marshal(encInsert{T: "insert", Cols: l.cols, Values: l.values})
+		payload = tmp
+	case LogEntryInsertHidden:
+		tmp, _ := json.Marshal(encInsert{T: "insert_hidden", Cols: l.cols, Values: l.values})
 		payload = tmp
 	default:
 		// ignore unknown
@@ -547,7 +553,12 @@ func decodeLogStream(data []byte, out chan interface{}) {
 			if json.Unmarshal(payload, &d) == nil {
 				out <- LogEntryDelete{idx: uint32(d.Idx)}
 			}
-		case "insert":
+		case "undelete":
+			var d encDelete
+			if json.Unmarshal(payload, &d) == nil {
+				out <- LogEntryUndelete{idx: uint32(d.Idx)}
+			}
+		case "insert", "insert_hidden":
 			var ins encInsert
 			if json.Unmarshal(payload, &ins) == nil {
 				// Transform values from JSON (same as FileStorage)
@@ -556,7 +567,11 @@ func decodeLogStream(data []byte, out chan interface{}) {
 						ins.Values[r][c] = scm.TransformFromJSON(ins.Values[r][c])
 					}
 				}
-				out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+				if head.T == "insert_hidden" {
+					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values}
+				} else {
+					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+				}
 			}
 		}
 	}

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -247,37 +247,16 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 					var idx uint32
 					json.Unmarshal(b[7:], &idx)
 					replay <- LogEntryDelete{idx}
+				} else if len(b) >= 9 && string(b[0:9]) == "undelete " {
+					var idx uint32
+					json.Unmarshal(b[9:], &idx)
+					replay <- LogEntryUndelete{idx}
+				} else if len(b) >= 14 && string(b[0:14]) == "insert-hidden " {
+					cols, values := decodeFileInsertLog(b[14:])
+					replay <- LogEntryInsertHidden{cols, values}
 				} else if len(b) >= 7 && string(b[0:7]) == "insert " {
-					body := string(b[7:])
-					if pos := strings.Index(body, "]["); pos >= 0 {
-						// new format: columns ][ values
-						var cols []string
-						var values [][]scm.Scmer
-						json.Unmarshal([]byte(body[:pos+1]), &cols)
-						json.Unmarshal([]byte(body[pos+1:]), &values)
-						for i := 0; i < len(values); i++ {
-							for j := 0; j < len(values[i]); j++ {
-								values[i][j] = scm.TransformFromJSON(values[i][j])
-							}
-						}
-						replay <- LogEntryInsert{cols, values}
-					} else {
-						// fallback/old format: flat array of alternating key/value pairs -> single row
-						var flat []interface{}
-						if err := json.Unmarshal([]byte(body), &flat); err != nil {
-							panic("unknown log sequence: " + string(b))
-						}
-						if len(flat)%2 != 0 {
-							panic("corrupt insert log (odd items): " + string(b))
-						}
-						cols := make([]string, 0, len(flat)/2)
-						row := make([]scm.Scmer, 0, len(flat)/2)
-						for i := 0; i < len(flat); i += 2 {
-							cols = append(cols, flat[i].(string))
-							row = append(row, scm.TransformFromJSON(flat[i+1]))
-						}
-						replay <- LogEntryInsert{cols, [][]scm.Scmer{row}}
-					}
+					cols, values := decodeFileInsertLog(b[7:])
+					replay <- LogEntryInsert{cols, values}
 				} else {
 					panic("unknown log sequence: " + string(b))
 				}
@@ -293,6 +272,39 @@ func (s *FileStorage) ReplayLog(shard string) (chan interface{}, PersistenceLogf
 		close(replay)
 	}
 	return replay, FileLogfile{f}
+}
+
+func decodeFileInsertLog(b []byte) ([]string, [][]scm.Scmer) {
+	body := string(b)
+	if pos := strings.Index(body, "]["); pos >= 0 {
+		// new format: columns ][ values
+		var cols []string
+		var values [][]scm.Scmer
+		json.Unmarshal([]byte(body[:pos+1]), &cols)
+		json.Unmarshal([]byte(body[pos+1:]), &values)
+		for i := 0; i < len(values); i++ {
+			for j := 0; j < len(values[i]); j++ {
+				values[i][j] = scm.TransformFromJSON(values[i][j])
+			}
+		}
+		return cols, values
+	} else {
+		// fallback/old format: flat array of alternating key/value pairs -> single row
+		var flat []interface{}
+		if err := json.Unmarshal([]byte(body), &flat); err != nil {
+			panic("unknown log sequence: " + string(b))
+		}
+		if len(flat)%2 != 0 {
+			panic("corrupt insert log (odd items): " + string(b))
+		}
+		cols := make([]string, 0, len(flat)/2)
+		row := make([]scm.Scmer, 0, len(flat)/2)
+		for i := 0; i < len(flat); i += 2 {
+			cols = append(cols, flat[i].(string))
+			row = append(row, scm.TransformFromJSON(flat[i+1]))
+		}
+		return cols, [][]scm.Scmer{row}
+	}
 }
 
 func (s *FileStorage) RemoveLog(shard string) {
@@ -312,16 +324,29 @@ func (w FileLogfile) Write(logentry interface{}) {
 		b.Write(tmp)
 		b.WriteString("\n")
 		w.w.Write(b.Bytes())
-	case LogEntryInsert:
+	case LogEntryUndelete:
 		var b bytes.Buffer
-		b.WriteString("insert ")
-		tmp, _ := json.Marshal(l.cols)
-		b.Write(tmp)
-		tmp, _ = json.Marshal(l.values)
+		b.WriteString("undelete ")
+		tmp, _ := json.Marshal(l.idx)
 		b.Write(tmp)
 		b.WriteString("\n")
 		w.w.Write(b.Bytes())
+	case LogEntryInsert:
+		w.writeInsert("insert ", l.cols, l.values)
+	case LogEntryInsertHidden:
+		w.writeInsert("insert-hidden ", l.cols, l.values)
 	}
+}
+
+func (w FileLogfile) writeInsert(prefix string, cols []string, values [][]scm.Scmer) {
+	var b bytes.Buffer
+	b.WriteString(prefix)
+	tmp, _ := json.Marshal(cols)
+	b.Write(tmp)
+	tmp, _ = json.Marshal(values)
+	b.Write(tmp)
+	b.WriteString("\n")
+	w.w.Write(b.Bytes())
 }
 func (w FileLogfile) Sync() {
 	w.w.Sync()

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -545,8 +545,14 @@ func encodeS3LogEntry(e interface{}) []byte {
 	case LogEntryDelete:
 		tmp, _ := json.Marshal(s3EncDelete{T: "delete", Idx: l.idx})
 		payload = tmp
+	case LogEntryUndelete:
+		tmp, _ := json.Marshal(s3EncDelete{T: "undelete", Idx: l.idx})
+		payload = tmp
 	case LogEntryInsert:
 		tmp, _ := json.Marshal(s3EncInsert{T: "insert", Cols: l.cols, Values: l.values})
+		payload = tmp
+	case LogEntryInsertHidden:
+		tmp, _ := json.Marshal(s3EncInsert{T: "insert_hidden", Cols: l.cols, Values: l.values})
 		payload = tmp
 	default:
 		return nil
@@ -584,7 +590,12 @@ func decodeS3LogStream(data []byte, out chan interface{}) {
 			if json.Unmarshal(payload, &d) == nil {
 				out <- LogEntryDelete{idx: uint32(d.Idx)}
 			}
-		case "insert":
+		case "undelete":
+			var d s3EncDelete
+			if json.Unmarshal(payload, &d) == nil {
+				out <- LogEntryUndelete{idx: uint32(d.Idx)}
+			}
+		case "insert", "insert_hidden":
 			var ins s3EncInsert
 			if json.Unmarshal(payload, &ins) == nil {
 				for r := 0; r < len(ins.Values); r++ {
@@ -592,7 +603,11 @@ func decodeS3LogStream(data []byte, out chan interface{}) {
 						ins.Values[r][c] = scm.TransformFromJSON(ins.Values[r][c])
 					}
 				}
-				out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+				if head.T == "insert_hidden" {
+					out <- LogEntryInsertHidden{cols: ins.Cols, values: ins.Values}
+				} else {
+					out <- LogEntryInsert{cols: ins.Cols, values: ins.Values}
+				}
 			}
 		}
 	}

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -97,7 +97,14 @@ func finishColumnWrite(w io.WriteCloser, durable bool) {
 type LogEntryDelete struct {
 	idx uint32
 }
+type LogEntryUndelete struct {
+	idx uint32
+}
 type LogEntryInsert struct {
+	cols   []string
+	values [][]scm.Scmer
+}
+type LogEntryInsertHidden struct {
 	cols   []string
 	values [][]scm.Scmer
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -81,7 +81,8 @@ type storageShard struct {
 	lastAccessed uint64 // UnixNano, atomic; updated on GetRead/GetExclusive for LRU eviction
 
 	// repartition drain tracking: counts in-flight scans on this shard
-	activeScanners atomic.Int32
+	activeScanners     atomic.Int32
+	activeTransactions atomic.Int32
 
 	// guards RemoveFromDisk against double execution (finalizer + explicit cleanup)
 	cleanupOnce sync.Once
@@ -162,9 +163,8 @@ func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map
 	}
 }
 
-// logVisibilityChangeLocked persists a visibility transition. WAL replay has
-// no undelete record, so restoring a tombstoned main row is represented by a
-// fresh insert of the same logical row. Caller must hold s.mu.Lock().
+// logVisibilityChangeLocked persists a visibility transition without changing
+// row identity. Caller must hold s.mu.Lock().
 func (s *storageShard) logVisibilityChangeLocked(recid uint32, deleted bool) {
 	if (s.t.PersistencyMode != Safe && s.t.PersistencyMode != Logged) || s.logfile == nil {
 		return
@@ -173,16 +173,7 @@ func (s *storageShard) logVisibilityChangeLocked(recid uint32, deleted bool) {
 		s.logfile.Write(LogEntryDelete{recid})
 		return
 	}
-	columns := make([]string, 0, len(s.t.Columns))
-	values := make([]scm.Scmer, 0, len(s.t.Columns))
-	for _, column := range s.t.Columns {
-		if isRuntimeComputedColumn(column) {
-			continue
-		}
-		columns = append(columns, column.Name)
-		values = append(values, s.rowValueByRecidLocked(recid, column.Name))
-	}
-	s.logfile.Write(LogEntryInsert{columns, [][]scm.Scmer{values}})
+	s.logfile.Write(LogEntryUndelete{recid})
 }
 
 // catchUpRebuildLocked replays only mutations that happened after the rebuild
@@ -368,8 +359,16 @@ func (u *storageShard) load(t *table) {
 			switch l := logentry.(type) {
 			case LogEntryDelete:
 				u.deletions.Set(uint(l.idx), true) // mark deletion
+			case LogEntryUndelete:
+				u.deletions.Set(uint(l.idx), false)
 			case LogEntryInsert:
 				u.insertDatasetFromLog(l.cols, l.values)
+			case LogEntryInsertHidden:
+				firstRecid := u.main_count + uint32(len(u.inserts))
+				u.insertDatasetFromLog(l.cols, l.values)
+				for i := range l.values {
+					u.deletions.Set(uint(firstRecid+uint32(i)), true)
+				}
 			default:
 				panic("unknown log sequence: " + fmt.Sprint(l))
 			}
@@ -1254,7 +1253,7 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 				// Capture for dual-write forwarding (cols/d2 are closure-local).
 				// Use repartitionDualWriteActive (set after Phase B snapshot)
 				// so rows already in the snapshot are not dual-written again.
-				if t.t.repartitionDualWriteActive.Load() {
+				if t.t.repartitionDualWriteActive.Load() && t.t.isRepartitionSource(t) {
 					dualWriteCols = payloadCols
 					dualWriteRow = [][]scm.Scmer{payloadRow}
 				}
@@ -1279,7 +1278,7 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 					currentTx.AddToUndeleteMask(t, newRecid)
 					// Only log the insert (delete applied at commit)
 					if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
-						t.logfile.Write(LogEntryInsert{payloadCols, [][]scm.Scmer{payloadRow}})
+						t.logfile.Write(LogEntryInsertHidden{payloadCols, [][]scm.Scmer{payloadRow}})
 					}
 				} else {
 					// Cursor-stability / no-tx: existing behavior
@@ -1295,7 +1294,7 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 			}()
 			// Dual-write: forward the new row to the secondary shard set
 			if result && dualWriteRow != nil {
-				t.t.dualWriteInsertFromOld(t, newRecid, dualWriteCols, dualWriteRow)
+				t.t.dualWriteInsertFromOld(t, newRecid, dualWriteCols, dualWriteRow, currentTx)
 			}
 			// transaction bookkeeping + deferred sync
 			// (shard is already registered via OpenMapReducer — no per-row RegisterTouchedShard)
@@ -1425,8 +1424,8 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 		}
 		if result {
 			// Dual-write: forward DELETE to PShards during repartition
-			if t.t.repartitionDualWriteActive.Load() {
-				t.t.dualWriteDelete(t, idx)
+			if t.t.repartitionDualWriteActive.Load() && t.t.isRepartitionSource(t) {
+				t.t.dualWriteDelete(t, idx, currentTx)
 			}
 			if maintenanceNext != nil {
 				// Propagate to the rebuild successor shard via the stable
@@ -2233,7 +2232,11 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 	if (t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged) && t.logfile != nil {
 		// Log the actual inserted rows (not the original columns/values) so that
 		// auto-incremented IDs and column defaults are preserved across restarts.
-		t.logfile.Write(LogEntryInsert{payloadCols, payloadVals})
+		if currentTx != nil && currentTx.Mode == TxACID {
+			t.logfile.Write(LogEntryInsertHidden{payloadCols, payloadVals})
+		} else {
+			t.logfile.Write(LogEntryInsert{payloadCols, payloadVals})
+		}
 	}
 	if propagateMaintenance {
 		if next := t.nextForMaintenanceLocked(nil); next != nil {
@@ -2242,7 +2245,7 @@ func (t *storageShard) insertPreparedLocked(columns []string, values [][]scm.Scm
 			t.recordNextInsertRange(firstNewRecid, firstNextRecid, len(payloadVals))
 		}
 		if t.t.repartitionDualWriteActive.Load() && t.t.isRepartitionSource(t) {
-			t.t.dualWriteInsertFromOld(t, firstNewRecid, payloadCols, payloadVals)
+			t.t.dualWriteInsertFromOld(t, firstNewRecid, payloadCols, payloadVals, currentTx)
 		}
 	}
 	// transaction bookkeeping
@@ -2639,6 +2642,27 @@ func (t *storageShard) RemoveFromDisk() {
 		}
 		t.t.schema.persistence.RemoveLog(t.uuid.String())
 	})
+}
+
+// discardUnpublishedShard removes files belonging to a generation that failed
+// before schema.json ever referenced it. It is deliberately separate from
+// RemoveFromDisk: published generations may only be retired by the explicit
+// lifecycle paths documented in the storage contract.
+func discardUnpublishedShard(s *storageShard) {
+	if s == nil || s.t == nil || s.t.schema == nil || s.t.schema.persistence == nil {
+		return
+	}
+	if s.logfile != nil {
+		s.logfile.Close()
+		s.logfile = nil
+	}
+	if s.uuid == uuid.Nil {
+		return
+	}
+	for _, col := range s.t.Columns {
+		s.t.schema.persistence.RemoveColumn(s.uuid.String(), col.Name)
+	}
+	s.t.schema.persistence.RemoveLog(s.uuid.String())
 }
 
 // removePersistence removes on-disk files (columns + logfile) for this shard

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -19,13 +19,129 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/launix-de/memcp/scm"
 )
+
+type failColumnWritePersistence struct {
+	PersistenceEngine
+	failNext atomic.Bool
+}
+
+func (p *failColumnWritePersistence) WriteColumn(shard string, column string) io.WriteCloser {
+	if p.failNext.CompareAndSwap(true, false) {
+		panic("injected repartition column write failure")
+	}
+	return p.PersistenceEngine.WriteColumn(shard, column)
+}
+
+type failSchemaWritePersistence struct {
+	PersistenceEngine
+	calls  atomic.Int32
+	failAt int32
+}
+
+func (p *failSchemaWritePersistence) WriteSchema(schema []byte) {
+	if p.calls.Add(1) == p.failAt {
+		panic("injected schema publication failure")
+	}
+	p.PersistenceEngine.WriteSchema(schema)
+}
+
+type blockingSchemaWritePersistence struct {
+	PersistenceEngine
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (p *blockingSchemaWritePersistence) WriteSchema(schema []byte) {
+	p.once.Do(func() {
+		close(p.entered)
+		<-p.release
+	})
+	p.PersistenceEngine.WriteSchema(schema)
+}
+
+type blockingColumnWritePersistence struct {
+	PersistenceEngine
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (p *blockingColumnWritePersistence) WriteColumn(shard string, column string) io.WriteCloser {
+	p.once.Do(func() {
+		close(p.entered)
+		<-p.release
+	})
+	return p.PersistenceEngine.WriteColumn(shard, column)
+}
+
+func reloadTableFromPersistence(t *testing.T, name string, persistence PersistenceEngine) *table {
+	t.Helper()
+	db := newDatabase()
+	db.Name = name
+	db.persistence = persistence
+	db.srState = COLD
+	db.ensureLoaded()
+	tbl := db.GetTable("items")
+	if tbl == nil {
+		t.Fatalf("reloaded database %s has no items table", name)
+	}
+	for _, shard := range tbl.ActiveShards() {
+		release := shard.GetRead()
+		release()
+	}
+	return tbl
+}
+
+func waitForRepartitionDualWrite(t *testing.T, tbl *table) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !tbl.repartitionDualWriteActive.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("repartition never enabled dual-write")
+		}
+		runtime.Gosched()
+	}
+}
+
+func createDurabilityTestTable(t *testing.T, databaseName string, rows int) (*table, PersistenceEngine) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "memcp-durability-regression-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBasepath := Basepath
+	Basepath = dir
+	t.Cleanup(func() {
+		databases.Remove(databaseName)
+		Basepath = oldBasepath
+		os.RemoveAll(dir)
+	})
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	CreateDatabase(databaseName, false)
+	tbl, _ := CreateTable(databaseName, "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("payload", "TEXT", nil, nil)
+	values := make([][]scm.Scmer, rows)
+	for i := range values {
+		values[i] = []scm.Scmer{scm.NewInt(int64(i + 1)), scm.NewString(fmt.Sprintf("row-%08d", i+1))}
+	}
+	tbl.Insert([]string{"id", "payload"}, values, nil, scm.NewNil(), false, nil)
+	return tbl, tbl.schema.persistence
+}
 
 func callBuiltin(t *testing.T, name string, args ...scm.Scmer) scm.Scmer {
 	t.Helper()
@@ -1370,5 +1486,267 @@ func TestInvalidateORCHitsShadowRebuildShards(t *testing.T) {
 	}
 	if shadowProxy.validMask.Get(0) || shadowProxy.validMask.Get(1) {
 		t.Fatal("shadow rebuild shard ORC proxy stayed valid after invalidateORC")
+	}
+}
+
+func TestRepartitionBuildFailureDoesNotPublishPartialGeneration(t *testing.T) {
+	tbl, persistence := createDurabilityTestTable(t, "trepartitionbuildfailure", 128)
+	failing := &failColumnWritePersistence{PersistenceEngine: persistence}
+	failing.failNext.Store(true)
+	tbl.schema.persistence = failing
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	var repartitionPanic any
+	func() {
+		defer func() { repartitionPanic = recover() }()
+		tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+	}()
+	if !strings.Contains(fmt.Sprint(repartitionPanic), "injected repartition column write failure") {
+		t.Fatalf("repartition panic %q does not report the build failure", repartitionPanic)
+	}
+
+	if topology := tbl.activeTopology(); topology.mode != ShardModeFree {
+		t.Fatalf("failed repartition published mode %v with %d shards; old free generation must remain authoritative", topology.mode, len(topology.shards))
+	}
+}
+
+func TestRepartitionConcurrentDeleteSurvivesReload(t *testing.T) {
+	const rows = 256
+	tbl, persistence := createDurabilityTestTable(t, "trepartitiondeletereload", rows)
+	blocking := &blockingColumnWritePersistence{
+		PersistenceEngine: persistence,
+		entered:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	tbl.schema.persistence = blocking
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	done := make(chan struct{})
+	go func() {
+		tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+		close(done)
+	}()
+	<-blocking.entered
+	waitForRepartitionDualWrite(t, tbl)
+
+	oldShard := tbl.repartitionSources.Load().shards[0]
+	if !scm.ToBool(oldShard.UpdateFunction(0, false, false, nil)()) {
+		t.Fatal("concurrent delete did not change the source row")
+	}
+	close(blocking.release)
+	<-done
+
+	if got := tbl.Count(); got != rows-1 {
+		t.Fatalf("live repartition count after delete = %d, want %d", got, rows-1)
+	}
+	reloaded := reloadTableFromPersistence(t, "trepartitiondeletereload", persistence)
+	if got := reloaded.Count(); got != rows-1 {
+		t.Fatalf("reloaded repartition count after delete = %d, want %d; forwarded delete was not durable", got, rows-1)
+	}
+}
+
+func TestRepartitionPublishedSchemaReloadsNewGeneration(t *testing.T) {
+	const rows = 32
+	tbl, persistence := createDurabilityTestTable(t, "trepartitionreload", rows)
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+	if got := tbl.Count(); got != rows {
+		t.Fatalf("live repartition count = %d, want %d", got, rows)
+	}
+
+	reloaded := reloadTableFromPersistence(t, "trepartitionreload", persistence)
+	if got := reloaded.Count(); got != rows {
+		t.Fatalf("reloaded repartition count = %d, want %d; schema references the retired generation", got, rows)
+	}
+}
+
+func TestRepartitionRolledBackACIDDeleteKeepsRow(t *testing.T) {
+	const rows = 256
+	tbl, persistence := createDurabilityTestTable(t, "trepartitionacidrollback", rows)
+	blocking := &blockingColumnWritePersistence{
+		PersistenceEngine: persistence,
+		entered:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	tbl.schema.persistence = blocking
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	done := make(chan struct{})
+	go func() {
+		tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+		close(done)
+	}()
+	<-blocking.entered
+	waitForRepartitionDualWrite(t, tbl)
+
+	oldShard := tbl.repartitionSources.Load().shards[0]
+	tx := NewTxContext(TxACID)
+	if !scm.ToBool(oldShard.UpdateFunction(0, false, false, tx)()) {
+		t.Fatal("transactional delete was not staged")
+	}
+	tx.Rollback()
+	close(blocking.release)
+	<-done
+
+	if got := tbl.Count(); got != rows {
+		t.Fatalf("repartition count after rolled-back ACID delete = %d, want %d", got, rows)
+	}
+}
+
+func TestRepartitionPostFlipUpdateDoesNotDuplicateRow(t *testing.T) {
+	const rows = 256
+	tbl, persistence := createDurabilityTestTable(t, "trepartitionpostflipupdate", rows)
+	blocking := &blockingSchemaWritePersistence{
+		PersistenceEngine: persistence,
+		entered:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	tbl.schema.persistence = blocking
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	done := make(chan struct{})
+	go func() {
+		tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+		close(done)
+	}()
+	defer func() {
+		select {
+		case <-blocking.release:
+		default:
+			close(blocking.release)
+		}
+	}()
+	<-blocking.entered
+
+	var target *storageShard
+	for _, shard := range tbl.ActiveShards() {
+		if shard.Count() > 0 {
+			target = shard
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("published partition topology has no rows")
+	}
+	updateDone := make(chan bool, 1)
+	go func() {
+		changes := scm.NewSlice([]scm.Scmer{scm.NewString("payload"), scm.NewString("updated-after-flip")})
+		updateDone <- scm.ToBool(target.UpdateFunction(0, false, false, nil)(changes))
+	}()
+	select {
+	case <-updateDone:
+		t.Fatal("update reached a generation before schema publication committed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(blocking.release)
+	<-done
+	if !<-updateDone {
+		t.Fatal("post-publication update did not change the row")
+	}
+
+	if got := tbl.Count(); got != rows {
+		t.Fatalf("repartition count after post-flip update = %d, want %d", got, rows)
+	}
+}
+
+func TestFailedRebuildSchemaPublicationKeepsLaterWritesRecoverable(t *testing.T) {
+	tbl, persistence := createDurabilityTestTable(t, "trebuildsavefailure", 1)
+	tbl.schema.ensureBlobTable()
+	failing := &failSchemaWritePersistence{PersistenceEngine: persistence, failAt: 1}
+	tbl.schema.persistence = failing
+
+	result := RebuildTable(tbl, true, false)
+	if !strings.Contains(result, "schema publication failure") {
+		t.Fatalf("rebuild result %q does not report injected schema failure", result)
+	}
+	tbl.Insert([]string{"id", "payload"}, [][]scm.Scmer{{scm.NewInt(2), scm.NewString("after-failed-save")}}, nil, scm.NewNil(), false, nil)
+	if got := tbl.Count(); got != 2 {
+		t.Fatalf("live count after failed schema save = %d, want 2", got)
+	}
+
+	reloaded := reloadTableFromPersistence(t, "trebuildsavefailure", persistence)
+	if got := reloaded.Count(); got != 2 {
+		t.Fatalf("reloaded count after failed rebuild schema save = %d, want 2; write reached only the unpublished generation", got)
+	}
+}
+
+func TestOverflowRebuildSchemaFailureKeepsWritesRecoverable(t *testing.T) {
+	oldShardSize := Settings.ShardSize
+	Settings.ShardSize = 2
+	t.Cleanup(func() { Settings.ShardSize = oldShardSize })
+	tbl, persistence := createDurabilityTestTable(t, "toverflowsavefailure", 2)
+	failing := &failSchemaWritePersistence{PersistenceEngine: persistence, failAt: 2}
+	tbl.schema.persistence = failing
+
+	tbl.Insert([]string{"id", "payload"}, [][]scm.Scmer{{scm.NewInt(3), scm.NewString("starts-overflow-rebuild")}}, nil, scm.NewNil(), false, nil)
+	deadline := time.Now().Add(5 * time.Second)
+	for tbl.overflowRebuilds.Load() > 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("overflow rebuild did not finish")
+		}
+		runtime.Gosched()
+	}
+	tbl.Insert([]string{"id", "payload"}, [][]scm.Scmer{{scm.NewInt(4), scm.NewString("after-failed-save")}}, nil, scm.NewNil(), false, nil)
+	if got := tbl.Count(); got != 4 {
+		t.Fatalf("live count after failed overflow schema save = %d, want 4", got)
+	}
+
+	reloaded := reloadTableFromPersistence(t, "toverflowsavefailure", persistence)
+	if got := reloaded.Count(); got != 4 {
+		t.Fatalf("reloaded count after failed overflow schema save = %d, want 4; writes reached only unpublished shards", got)
+	}
+}
+
+func TestACIDRolledBackInsertDoesNotReplayAfterRestart(t *testing.T) {
+	tbl, persistence := createDurabilityTestTable(t, "tacidrollbackreload", 0)
+	session := scm.NewSession()
+	tx := NewTxContext(TxACID)
+	tx.Session = session
+	scm.Apply(session, scm.NewString("__memcp_tx"), scm.NewAny(tx))
+	scm.SetValues(map[string]any{"session": session}, func() {
+		tbl.Insert([]string{"id", "payload"}, [][]scm.Scmer{{scm.NewInt(1), scm.NewString("rolled-back")}}, nil, scm.NewNil(), false, nil)
+	})
+	tx.Rollback()
+	if got := tbl.Count(); got != 0 {
+		t.Fatalf("live count after ACID rollback = %d, want 0", got)
+	}
+
+	reloaded := reloadTableFromPersistence(t, "tacidrollbackreload", persistence)
+	if got := reloaded.Count(); got != 0 {
+		t.Fatalf("reloaded count after ACID rollback = %d, want 0; uncommitted insert was replayed", got)
+	}
+}
+
+func TestCursorRollbackOfMainDeleteSurvivesRestart(t *testing.T) {
+	tbl, persistence := createDurabilityTestTable(t, "tcursorrollbackreload", 1)
+	if result := RebuildTable(tbl, true, false); strings.Contains(result, "errors:") {
+		t.Fatalf("preparing main storage failed: %s", result)
+	}
+	shard := tbl.ActiveShards()[0]
+	if shard.main_count != 1 {
+		t.Fatalf("rebuilt main count = %d, want 1", shard.main_count)
+	}
+	tx := NewTxContext(TxCursorStability)
+	if !scm.ToBool(shard.UpdateFunction(0, false, false, tx)()) {
+		t.Fatal("cursor-stability delete did not change the row")
+	}
+	tx.Rollback()
+	if got := tbl.Count(); got != 1 {
+		t.Fatalf("live count after cursor rollback = %d, want 1", got)
+	}
+
+	reloaded := reloadTableFromPersistence(t, "tcursorrollbackreload", persistence)
+	if got := reloaded.Count(); got != 1 {
+		t.Fatalf("reloaded count after cursor rollback = %d, want 1; rollback was not represented in WAL", got)
 	}
 }

--- a/storage/table.go
+++ b/storage/table.go
@@ -1682,6 +1682,108 @@ func (t *table) DropColumnIfExists(name string) bool {
 	return false
 }
 
+func (t *table) appendFreeShardDurably(topology *tableShardTopology, source *storageShard, incoming uint) (*tableShardTopology, *storageShard) {
+	t.maintenanceMu.Lock()
+	sourceCount := uint(source.Count())
+	t.mu.Lock()
+	active := t.activeTopology()
+	if active != topology || active.mode != ShardModeFree || len(active.shards) == 0 || active.shards[len(active.shards)-1] != source {
+		t.mu.Unlock()
+		t.maintenanceMu.Unlock()
+		return active, nil
+	}
+	if sourceCount+incoming <= Settings.ShardSize {
+		t.mu.Unlock()
+		t.maintenanceMu.Unlock()
+		return active, source
+	}
+
+	newShard := NewShard(t)
+	t.maintenanceKind = 1
+	t.Shards = append(t.Shards, newShard)
+	newIndex := len(t.Shards) - 1
+	sourceIndex := newIndex - 1
+	t.mu.Unlock()
+
+	var savePanic any
+	func() {
+		defer func() { savePanic = recover() }()
+		t.schema.save()
+	}()
+	if savePanic != nil {
+		t.mu.Lock()
+		if newIndex < len(t.Shards) && t.Shards[newIndex] == newShard {
+			t.Shards = t.Shards[:newIndex]
+		}
+		t.maintenanceKind = 0
+		t.mu.Unlock()
+		t.maintenanceMu.Unlock()
+		discardUnpublishedShard(newShard)
+		panic(savePanic)
+	}
+
+	t.mu.Lock()
+	published := t.publishTopologyLocked()
+	t.mu.Unlock()
+	if t.PersistencyMode == Cache && !strings.HasPrefix(t.Name, ".") {
+		GlobalCache.AddItem(newShard, 0, TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+	}
+	fmt.Println("started new shard for table", t.Name)
+	t.overflowRebuilds.Add(1)
+	go t.finishOverflowRebuild(sourceIndex, source)
+	return published, newShard
+}
+
+// finishOverflowRebuild owns maintenanceMu, which appendFreeShardDurably
+// acquired before publishing the appended shard. The replacement UUID becomes
+// authoritative only after schema.json durably names it.
+func (t *table) finishOverflowRebuild(index int, source *storageShard) {
+	defer func() {
+		t.mu.Lock()
+		if t.maintenanceKind == 1 {
+			t.maintenanceKind = 0
+		}
+		t.mu.Unlock()
+		t.maintenanceMu.Unlock()
+		t.overflowRebuilds.Add(-1)
+		if r := recover(); r != nil {
+			fmt.Println("error: shard rebuild failed for", t.schema.Name+".", t.Name, "shard", index, ":", r)
+		}
+	}()
+
+	rebuilt := source.rebuild(false)
+	source.mu.Lock()
+	t.mu.Lock()
+	if t.ShardMode != ShardModeFree || index >= len(t.Shards) || t.Shards[index] != source {
+		t.mu.Unlock()
+		source.mu.Unlock()
+		return
+	}
+	t.Shards[index] = rebuilt
+	t.mu.Unlock()
+
+	var savePanic any
+	func() {
+		defer func() { savePanic = recover() }()
+		t.schema.save()
+	}()
+	if savePanic != nil {
+		t.mu.Lock()
+		if index < len(t.Shards) && t.Shards[index] == rebuilt {
+			t.Shards[index] = source
+		}
+		t.mu.Unlock()
+		source.mu.Unlock()
+		panic(savePanic)
+	}
+
+	t.mu.Lock()
+	t.publishTopologyLocked()
+	t.mu.Unlock()
+	source.mu.Unlock()
+	t.collectStatistics()
+}
+
 func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols []string, onCollision scm.Scmer, mergeNull bool, onFirstInsertId func(int64)) int {
 	result := 0
 	isIgnore := !onCollision.IsNil() // INSERT IGNORE or ON DUPLICATE KEY UPDATE
@@ -1716,61 +1818,36 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 	if topology.mode == ShardModeFree { // unpartitioned sharding
 		// Helper to get or create a shard with capacity for n rows
 		getShardWithCapacity := func(n uint) *storageShard {
-			t.mu.Lock()
-			if t.Shards == nil {
-				// Repartition completed while we waited for the lock.
+			for {
+				t.mu.Lock()
+				active := t.activeTopology()
+				if active != topology {
+					topology = active
+					t.mu.Unlock()
+					if topology.mode != ShardModeFree {
+						return nil
+					}
+					continue
+				}
+				if len(topology.shards) == 0 {
+					t.mu.Unlock()
+					return nil
+				}
+				shard := topology.shards[len(topology.shards)-1]
+				if uint(shard.Count())+n <= Settings.ShardSize || t.maintenanceKind != 0 {
+					t.mu.Unlock()
+					return shard
+				}
+
 				t.mu.Unlock()
-				return nil
-			}
-			shard := t.Shards[len(t.Shards)-1]
-			if uint(shard.Count())+n > Settings.ShardSize {
-				// Current shard would overflow, create new one
-				t.overflowRebuilds.Add(1)
-				go func(i int, s *storageShard) {
-					t.maintenanceMu.Lock()
-					claimed := false
-					defer func() {
-						if claimed {
-							t.mu.Lock()
-							if t.maintenanceKind == 1 {
-								t.maintenanceKind = 0
-							}
-							t.mu.Unlock()
-						}
-						t.maintenanceMu.Unlock()
-						t.overflowRebuilds.Add(-1)
-						if r := recover(); r != nil {
-							fmt.Println("error: shard rebuild failed for", t.schema.Name+".", t.Name, "shard", i, ":", r)
-						}
-					}()
-					t.mu.Lock()
-					if t.ShardMode != ShardModeFree || i >= len(t.Shards) || t.Shards[i] != s {
-						t.mu.Unlock()
-						return
-					}
-					t.maintenanceKind = 1
-					claimed = true
-					t.mu.Unlock()
-					rebuilt := s.rebuild(false)
-					t.mu.Lock()
-					if t.ShardMode == ShardModeFree && i < len(t.Shards) && t.Shards[i] == s {
-						t.Shards[i] = rebuilt
-						t.publishTopologyLocked()
-					}
-					t.mu.Unlock()
-					t.collectStatistics()
-					t.schema.save()
-				}(len(t.Shards)-1, shard)
-				shard = NewShard(t)
-				fmt.Println("started new shard for table", t.Name)
-				t.Shards = append(t.Shards, shard)
-				t.publishTopologyLocked()
-				if t.PersistencyMode == Cache && !strings.HasPrefix(t.Name, ".") {
-					GlobalCache.AddItem(shard, 0, TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+				published, appended := t.appendFreeShardDurably(topology, shard, n)
+				if published != nil {
+					topology = published
+				}
+				if appended != nil {
+					return appended
 				}
 			}
-			t.mu.Unlock()
-			return shard
 		}
 
 		// For bulk inserts larger than ShardSize, split into chunks
@@ -1916,13 +1993,6 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 	}
 
 insertDone:
-	// Before the topology flip, storageShard.Insert forwards old→new and records
-	// recid translations. After the flip, new writes are mirrored new→old only
-	// until old scans drain. Replica insertion prevents recursive forwarding.
-	if topology.mode == ShardModePartition && t.repartitionDualWriteActive.Load() {
-		t.dualWriteInsertToOld(columns, values)
-	}
-
 	return result
 }
 
@@ -1968,19 +2038,6 @@ func (t *table) sanitizeInsertRows(columns []string, values [][]scm.Scmer, isIgn
 	return values
 }
 
-// dualWriteInsertToOld keeps pre-flip readers current while the old generation
-// drains. It is called only for statements that started on partition topology.
-func (t *table) dualWriteInsertToOld(columns []string, values [][]scm.Scmer) {
-	sources := t.repartitionSources.Load()
-	if sources == nil || len(sources.shards) == 0 {
-		return
-	}
-	shard := sources.shards[len(sources.shards)-1]
-	release := shard.GetExclusive()
-	defer release()
-	shard.insertReplica(columns, values, false, nil)
-}
-
 func (t *table) isRepartitionSource(shard *storageShard) bool {
 	sources := t.repartitionSources.Load()
 	if sources == nil {
@@ -1990,7 +2047,7 @@ func (t *table) isRepartitionSource(shard *storageShard) bool {
 	return ok
 }
 
-func (t *table) dualWriteInsertFromOld(oldShard *storageShard, firstOldRecid uint32, columns []string, values [][]scm.Scmer) {
+func (t *table) dualWriteInsertFromOld(oldShard *storageShard, firstOldRecid uint32, columns []string, values [][]scm.Scmer, currentTx *TxContext) {
 	if t.PShards == nil || len(values) == 0 {
 		return
 	}
@@ -2015,7 +2072,7 @@ func (t *table) dualWriteInsertFromOld(oldShard *storageShard, firstOldRecid uin
 			return
 		}
 		rel := lastShard.GetExclusive()
-		firstNewRecid := lastShard.insertReplica(columns, values[lastI:end], false, nil)
+		firstNewRecid := lastShard.insertReplica(columns, values[lastI:end], false, currentTx)
 		rel()
 		for i := lastI; i < end; i++ {
 			t.recordRepartitionTranslation(oldShard, firstOldRecid+uint32(i), translatedRecid{
@@ -2050,7 +2107,11 @@ func (t *table) dualWriteInsertFromOld(oldShard *storageShard, firstOldRecid uin
 // For rows in the Phase B snapshot (present in repartitionTranslation),
 // it uses the translation map to find the exact PShard recid. Post-snapshot
 // dual-written rows extend the same translation map as they are inserted.
-func (t *table) dualWriteDelete(oldShard *storageShard, oldRecid uint32) {
+func (t *table) dualWriteDelete(oldShard *storageShard, oldRecid uint32, currentTx *TxContext) {
+	if currentTx != nil {
+		currentTx.addRepartitionDelete(t, oldShard, oldRecid)
+		return
+	}
 	if tr, ok := t.lookupRepartitionTranslation(oldShard, oldRecid); ok {
 		t.appendPendingRepartitionDelete(tr)
 		return

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -85,8 +85,15 @@ type shardSavepoint struct {
 // Savepoint captures the state of a transaction at a point in time.
 // Used for nested transactions (trigger recovery, savepoints).
 type Savepoint struct {
-	shardLens map[*storageShard]shardSavepoint
-	Depth     uint32
+	shardLens            map[*storageShard]shardSavepoint
+	Depth                uint32
+	repartitionDeleteLen int
+}
+
+type repartitionDeleteAction struct {
+	table    *table
+	shard    *storageShard
+	oldRecid uint32
 }
 
 // global transaction ID counter
@@ -119,9 +126,10 @@ type TxContext struct {
 	shards map[*storageShard]*storageShardTransaction
 
 	// Deferred sync: shards with pending log writes that need fsync at commit.
-	touchedShards sync.Map // map[*storageShard]bool
-	autoCommit    bool
-	writeHeld     map[*storageShard]uint32 // reentrant write-lock depth per shard
+	touchedShards      sync.Map // map[*storageShard]bool
+	autoCommit         bool
+	writeHeld          map[*storageShard]uint32 // reentrant write-lock depth per shard
+	repartitionDeletes []repartitionDeleteAction
 
 	mu sync.Mutex
 }
@@ -213,8 +221,37 @@ func (tx *TxContext) getOrCreateShardTxLocked(shard *storageShard) *storageShard
 	if st == nil {
 		st = new(storageShardTransaction)
 		tx.shards[shard] = st
+		shard.activeTransactions.Add(1)
 	}
 	return st
+}
+
+func (tx *TxContext) addRepartitionDelete(table *table, shard *storageShard, oldRecid uint32) {
+	tx.mu.Lock()
+	tx.repartitionDeletes = append(tx.repartitionDeletes, repartitionDeleteAction{table: table, shard: shard, oldRecid: oldRecid})
+	tx.mu.Unlock()
+}
+
+// finishRepartitionActions must run before activeTransactions is decremented:
+// repartition publication waits for that counter and may otherwise pass its
+// final pending-delete drain before the committed action is visible.
+func (tx *TxContext) finishRepartitionActions(commit bool) {
+	tx.mu.Lock()
+	actions := tx.repartitionDeletes
+	tx.repartitionDeletes = nil
+	tx.mu.Unlock()
+	if !commit {
+		return
+	}
+	for _, action := range actions {
+		action.table.dualWriteDelete(action.shard, action.oldRecid, nil)
+	}
+}
+
+func (tx *TxContext) releaseActiveTransactionsLocked() {
+	for shard := range tx.shards {
+		shard.activeTransactions.Add(-1)
+	}
 }
 
 // getShardTx returns the storageShardTransaction for a shard, or nil if none exists.
@@ -377,6 +414,7 @@ func (tx *TxContext) CreateSavepoint() Savepoint {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 	sp := Savepoint{Depth: tx.Depth}
+	sp.repartitionDeleteLen = len(tx.repartitionDeletes)
 	tx.Depth++
 	if len(tx.shards) > 0 {
 		sp.shardLens = make(map[*storageShard]shardSavepoint, len(tx.shards))
@@ -409,6 +447,9 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 	tx.Depth = sp.Depth
+	if sp.repartitionDeleteLen < len(tx.repartitionDeletes) {
+		tx.repartitionDeletes = tx.repartitionDeletes[:sp.repartitionDeleteLen]
+	}
 	trackedShards := tx.trackedShardSetLocked()
 	for shard, st := range tx.shards {
 		lens := sp.shardLens[shard] // zero value (all zeros) if shard is new since savepoint
@@ -434,21 +475,7 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 				st.DeletedMask.Set(uint(recid), false)
 				shard.mu.Lock()
 				shard.deletions.Set(uint(recid), false)
-				if shard.logfile != nil && recid >= shard.main_count {
-					deltaIdx := int(recid - shard.main_count)
-					if deltaIdx < len(shard.inserts) {
-						row := shard.inserts[deltaIdx]
-						cols := make([]string, 0, len(shard.deltaColumns))
-						vals := make([]scm.Scmer, 0, len(shard.deltaColumns))
-						for name, idx := range shard.deltaColumns {
-							if idx < len(row) {
-								cols = append(cols, name)
-								vals = append(vals, row[idx])
-							}
-						}
-						shard.logfile.Write(LogEntryInsert{cols, [][]scm.Scmer{vals}})
-					}
-				}
+				shard.logVisibilityChangeLocked(recid, false)
 				shard.rollbackProtected.Set(uint(recid), false)
 				shard.syncNextVisibilityLocked(recid, trackedShards)
 				shard.mu.Unlock()
@@ -479,6 +506,9 @@ func (tx *TxContext) RollbackToSavepoint(sp Savepoint) {
 			st.UndeleteRecids = st.UndeleteRecids[:lens.UndeleteLen]
 		}
 		st.mu.Unlock()
+		if tx.Mode == TxCursorStability && shard.t.PersistencyMode == Safe && shard.logfile != nil {
+			shard.logfile.Sync()
+		}
 	}
 }
 
@@ -502,6 +532,10 @@ func (tx *TxContext) Commit() error {
 			shard.mu.Unlock()
 			st.mu.Unlock()
 		}
+		tx.mu.Unlock()
+		tx.finishRepartitionActions(true)
+		tx.mu.Lock()
+		tx.releaseActiveTransactionsLocked()
 		tx.State = TxCommitted
 		tx.shards = nil
 		tx.mu.Unlock()
@@ -546,8 +580,11 @@ func (tx *TxContext) commitACID() error {
 				for _, s := range shards {
 					s.mu.Unlock()
 				}
+				tx.finishRepartitionActions(false)
 				tx.mu.Lock()
+				tx.releaseActiveTransactionsLocked()
 				tx.State = TxAborted
+				tx.shards = nil
 				tx.mu.Unlock()
 				return fmt.Errorf("ACID commit conflict: row %d already deleted", recid)
 			}
@@ -577,6 +614,7 @@ func (tx *TxContext) commitACID() error {
 			}
 			shard.deletions.Set(uint(recid), false)
 			shard.rollbackProtected.Set(uint(recid), false)
+			shard.logVisibilityChangeLocked(recid, false)
 			shard.syncNextVisibilityLocked(recid, trackedShards)
 		}
 	}
@@ -587,7 +625,9 @@ func (tx *TxContext) commitACID() error {
 		s.mu.Unlock()
 	}
 
+	tx.finishRepartitionActions(true)
 	tx.mu.Lock()
+	tx.releaseActiveTransactionsLocked()
 	tx.State = TxCommitted
 	tx.shards = nil
 	tx.mu.Unlock()
@@ -613,7 +653,6 @@ func (tx *TxContext) Rollback() {
 // rollbackCursorStability replays undo masks in reverse to restore global state.
 func (tx *TxContext) rollbackCursorStability() {
 	tx.mu.Lock()
-	defer tx.mu.Unlock()
 	trackedShards := tx.trackedShardSetLocked()
 	for shard, st := range tx.shards {
 		st.mu.Lock()
@@ -633,30 +672,22 @@ func (tx *TxContext) rollbackCursorStability() {
 			recid := st.DeletedRecids[i]
 			shard.mu.Lock()
 			shard.deletions.Set(uint(recid), false)
-			if shard.logfile != nil && recid >= shard.main_count {
-				deltaIdx := int(recid - shard.main_count)
-				if deltaIdx < len(shard.inserts) {
-					row := shard.inserts[deltaIdx]
-					cols := make([]string, 0, len(shard.deltaColumns))
-					vals := make([]scm.Scmer, 0, len(shard.deltaColumns))
-					for name, idx := range shard.deltaColumns {
-						if idx < len(row) {
-							cols = append(cols, name)
-							vals = append(vals, row[idx])
-						}
-					}
-					shard.logfile.Write(LogEntryInsert{cols, [][]scm.Scmer{vals}})
-				}
-			}
+			shard.logVisibilityChangeLocked(recid, false)
 			shard.rollbackProtected.Set(uint(recid), false)
 			shard.syncNextVisibilityLocked(recid, trackedShards)
 			shard.mu.Unlock()
 		}
 		st.mu.Unlock()
+		if shard.t.PersistencyMode == Safe && shard.logfile != nil {
+			shard.logfile.Sync()
+		}
 	}
+	tx.repartitionDeletes = nil
+	tx.releaseActiveTransactionsLocked()
 	tx.State = TxAborted
 	tx.shards = nil
 	tx.touchedShards = sync.Map{}
+	tx.mu.Unlock()
 }
 
 // rollbackACID discards overlay masks. Staged rows that were globally hidden
@@ -674,6 +705,8 @@ func (tx *TxContext) rollbackACID() {
 		shard.mu.Unlock()
 		st.mu.Unlock()
 	}
+	tx.repartitionDeletes = nil
+	tx.releaseActiveTransactionsLocked()
 	tx.State = TxAborted
 	tx.shards = nil
 	tx.mu.Unlock()


### PR DESCRIPTION
## Summary

- make rebuild, repartition, and overflow generation publication commit schema metadata before switching the active topology
- preserve concurrent INSERT/UPDATE/DELETE forwarding across generation changes and retain the old generation on publication failure
- add explicit hidden-insert and undelete WAL records for transaction visibility recovery across filesystem, S3, and Ceph backends
- propagate transaction visibility and deferred repartition deletes through commit, rollback, and savepoint paths
- fail repartition builds and unresolved delete translations explicitly instead of publishing or discarding partial state

## Regression proof

The final regression tests were applied unchanged to master (`cd56cf3f4`) before the fix. Master failed with:

- swallowed repartition worker failure followed by partial publication
- reload selecting the retired generation (`0` rows instead of `32`)
- concurrent repartition delete disappearing after reload (`0` instead of `255`)
- rolled-back ACID delete removing a row (`255` instead of `256`)
- topology becoming writable before schema publication committed
- injected rebuild publication failure escaping without preserving later recoverable writes

The suite also covers overflow schema failure, rolled-back ACID insert replay, and cursor rollback of a main-storage delete.

## Validation

- `go test ./storage -run <nine durability regressions> -count=1 -timeout=3m`
- targeted `go test -race ./storage` across rebuild/repartition/overflow forwarding and all new regressions
- `./git-pre-commit --fail-fast`: all CI SQL suites passed; expected noncritical known-master test remained noncritical
- `transactions.yaml`: 204/204, including cursor-stability and ACID transactions across two successor rebuilds plus restart visibility
- `repartition-concurrent.yaml`: 143/143
- `rebuild-kill-shutdown.yaml`: 18/18
- `crash-recovery.yaml`: 88/88

## Durability contract

- no new `RemoveFromDisk` or `removePersistence` call sites were added
- old persistent generations are retired only after successful schema publication and forwarding drain
- unpublished shards use a separate cleanup helper and cannot delete a published generation
- WAL changes are additive; existing record encodings and readers remain supported

## Locking note

Persistent publication holds source shard locks only for the short schema commit boundary. Ephemeral CACHE/MEMORY rebuilds skip that durability barrier. Normal 1:1 rebuilds continue to rely on successor forwarding for transactions, avoiding a self-deadlock when `RebuildTable` runs inside a transaction; repartition retains the stricter transaction drain because it changes routing.