### PR TITLE
perf: reuse owned list accumulators

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1389,6 +1389,41 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		false
 		"optimizer: computed neutral keeps merge validation order")
 
+	/* owned builder reducers append without copying the growing accumulator. */
+	(print "testing optimizer owned list builders ...")
+	(define opt_owned_append_builder (optimize
+		(list 'lambda (list 'items)
+			(list 'reduce 'items
+				(list 'lambda (list 'acc 'item)
+					(list 'merge 'acc (list 'list 'item)))
+				(list 'quote (list))))))
+	(assert
+		(match (serialize opt_owned_append_builder) (regex "append_mut" _) true false)
+		true
+		"optimizer: singleton merge appends to owned reducer accumulator")
+	(assert
+		((eval opt_owned_append_builder) (list 1 2 3 4))
+		(list 1 2 3 4)
+		"owned reducer append preserves item order")
+
+	(define opt_owned_unique_builder (optimize
+		(list 'lambda (list 'items)
+			(list 'reduce 'items
+				(list 'lambda (list 'acc 'item)
+					(list 'if
+						(list 'contains? 'acc 'item)
+						'acc
+						(list 'merge 'acc (list 'list 'item))))
+				(list 'quote (list))))))
+	(assert
+		(match (serialize opt_owned_unique_builder) (regex "append_unique_mut" _) true false)
+		true
+		"optimizer: contains plus owned append becomes one unique append")
+	(assert
+		((eval opt_owned_unique_builder) (list 1 2 1 3 2 4))
+		(list 1 2 3 4)
+		"owned unique builder preserves first occurrence order")
+
 	/* match / match_mut correctness */
 	(print "testing match/match_mut correctness ...")
 	/* match: literal patterns */

--- a/scm/list.go
+++ b/scm/list.go
@@ -8174,6 +8174,15 @@ func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Typ
 	if !ok || len(rv) < 2 {
 		return result, td
 	}
+	if len(rv) == 3 && optimizedArgumentType(argumentTypes, 1).Transfer() {
+		if singleton, ok := optimizedSingletonListItem(rv[2]); ok {
+			length := UnknownLength
+			if baseLength := exactOptimizedListArgumentLength(rv[1], optimizedArgumentType(argumentTypes, 1)); baseLength >= 0 {
+				length = baseLength + 1
+			}
+			return NewSlice([]Scmer{NewSymbol("append_mut"), rv[1], singleton}), descriptorWithLength(FreshAlloc, length)
+		}
+	}
 	if len(rv) == 2 {
 		if producer, ok := scmerSlice(rv[1]); ok && len(producer) == 3 {
 			if exprMayHaveSideEffects(producer[2]) {
@@ -8244,6 +8253,23 @@ func optimizeMerge(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Typ
 		return result, setOptimizedCallLength(td, totalLength)
 	}
 	return result, td
+}
+
+// optimizedSingletonListItem extracts the item from an already optimized
+// one-element list constructor. The !list form is the frame-local equivalent
+// emitted for a NoEscape merge argument.
+func optimizedSingletonListItem(expr Scmer) (Scmer, bool) {
+	items, ok := scmerSlice(expr)
+	if !ok {
+		return NewNil(), false
+	}
+	if len(items) == 2 && scmerIsSymbol(items[0], "list") {
+		return items[1], true
+	}
+	if len(items) == 4 && scmerIsSymbol(items[0], "!list") && items[2].IsInt() && items[2].Int() == 1 {
+		return items[3], true
+	}
+	return NewNil(), false
 }
 
 // optimizeMergeUnique keeps merge_unique on the standard variadic path, but

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2215,8 +2215,41 @@ func optimizeIf(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDe
 	} else {
 		mergeResultType(&TypeDescriptor{Transfer: true, Const: true, Kind: "nil", Length: UnknownLength})
 	}
+	if base, item, ok := optimizedUniqueAppendBranches(out); ok {
+		return NewSlice([]Scmer{NewSymbol("append_unique_mut"), base, item}), FreshAlloc
+	}
 	// Single condition left: keep as (if cond then else)
 	return NewSlice(out), resultType
+}
+
+func optimizedUniqueAppendBranches(expr []Scmer) (Scmer, Scmer, bool) {
+	if len(expr) != 4 {
+		return NewNil(), NewNil(), false
+	}
+	condition, conditionOK := scmerSlice(expr[1])
+	otherwise, otherwiseOK := scmerSlice(expr[3])
+	if !conditionOK || len(condition) != 3 || !scmerIsSymbol(condition[0], "contains?") ||
+		!otherwiseOK || len(otherwise) != 3 || !scmerIsSymbol(otherwise[0], "append_mut") {
+		return NewNil(), NewNil(), false
+	}
+	base := condition[1]
+	item := condition[2]
+	if !optimizerStableReference(base) || !optimizerStableReference(item) ||
+		!structuralEqual(expr[2], base) || !structuralEqual(otherwise[1], base) || !structuralEqual(otherwise[2], item) {
+		return NewNil(), NewNil(), false
+	}
+	return base, item, true
+}
+
+func optimizerStableReference(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() || expr.IsSymbol() {
+		return true
+	}
+	items, ok := scmerSlice(expr)
+	return ok && len(items) == 2 && scmerIsSymbol(items[0], "outer") && optimizerStableReference(items[1])
 }
 
 // optimizeAnd is the Optimize hook for the lazy (and ...) special form.


### PR DESCRIPTION
## What changed

- Reuse a transferred-ownership list accumulator for `(merge acc (list item))` by emitting `append_mut` instead of allocating and copying the growing accumulator.
- Fold the already optimized canonical unique-builder shape `(if (contains? acc item) acc (append_mut acc item))` into `append_unique_mut`.
- Restrict the fold to stable references and structurally identical operands so evaluation count and order cannot change.
- Add Scheme-level optimizer and result-order regression coverage.

This targets allocation-heavy list-building patterns in the optimized `lib/queryplan.scm` code executed at runtime; it is not an attempt to optimize the optimizer implementation in isolation.

## Evidence

Microbenchmark minima for the representative unique reducer:

| Input | Master | PR | Change |
| --- | ---: | ---: | ---: |
| 32 items, time | 23,105 ns | 11,121 ns | -51.9% |
| 32 items, bytes | 16,496 B | 5,488 B | -66.7% |
| 32 items, allocations | 429 | 208 | -51.5% |
| 128 items, time | 153,723 ns | 83,414 ns | -45.7% |
| 128 items, bytes | ~171,059 B | 21,232 B | -87.6% |
| 128 items, allocations | 1,677 | 786 | -53.1% |

Direct planner-import trace minima:

| Phase | Master | PR | Change |
| --- | ---: | ---: | ---: |
| parse | 548.48 ms | 501.58 ms | -8.6% |
| untangle | 225.15 ms | 205.00 ms | -8.9% |
| planner total | 271.10 ms | 252.35 ms | -6.9% |
| compile total | 831.90 ms | 763.30 ms | -8.2% |

Default Go coverage builds also improve rather than regress: cold compile 1,030.61 ms → 1,008.23 ms (-2.2%); minimum compile 896.12 ms → 884.20 ms (-1.3%).

Application manual build A/B/C, comparing the minimum of two complete green runs because the host has competing load:

| Backend | Minimum |
| --- | ---: |
| MariaDB | 111.17 s |
| MemCP master | 128.24 s |
| MemCP PR | 125.78 s |

The PR is 2.46 s / 1.92% faster than master. It remains 14.61 s / 13.14% behind MariaDB.

A larger fixed-width map+dedup fusion reached 122.78 s, but regressed cold covered compilation and breached the traced planner scaling gate. It is intentionally excluded from this PR.

## Validation

- `make test`: green, including 100% Scheme source-node coverage for `lib/`.
- Crash-recovery suite: 88/88 green on the final full run (and on an isolated confirmation run).
- Traced planner scaling under the default coverage build: 7/7 green.
- Both application manual-build runs for the PR completed successfully.
