### PR TITLE
Hoist query-invariant presence probes

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -8625,6 +8625,173 @@ pass correlation keys to it instead of copying the complete recipe per field. */
 (define scalar_query_probe_recipe_key (lambda (stage requested_col)
 	(concat "__scalar_query_probe_" (fnv_hash (concat (gs_id stage) "\n" requested_col)))))
 
+(define expr_contains_column_ref? (lambda (expr)
+	(match expr
+		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) true
+		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) true
+		(cons head tail) (or
+			(expr_contains_column_ref? head)
+			(reduce tail (lambda (found item)
+				(or found (expr_contains_column_ref? item))) false))
+		_ false)))
+
+/* A base-table presence stage whose lookup domain contains only literals,
+parameters, or session values is invariant for one query execution. It may be
+bound once outside row callbacks; a column reference would make that unsafe. */
+(define query_invariant_presence_stage? (lambda (stage)
+	(and (presence_probe_stage? stage)
+		(and (source_is_base_table? (gs_input stage))
+			(and (not (stage_has_residual_outer_refs? stage))
+				(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '())
+					(lambda (invariant key)
+						(and invariant (not (expr_contains_column_ref? key))))
+					true))))))
+
+(define query_invariant_probe_requested_col (lambda (_stage)
+	(aggregate_col_name aggregate_count_descriptor)))
+
+(define query_invariant_probe_binding_key (lambda (stage requested_col)
+	(concat "__query_invariant_probe_" (fnv_hash (concat
+		(stage_prepare_backbone_signature stage) "\n" requested_col)))))
+
+(define query_invariant_probe_binding_for_col (lambda (stage requested_col)
+	(get_assoc
+		(qassoc_get (gs_facts stage) (quote query_invariant_probe_bindings) '())
+		requested_col)))
+
+(define group_stage_with_query_invariant_probe_binding (lambda (stage requested_col)
+	(group_stage_with_facts stage
+		(qassoc_set (gs_facts stage) (quote query_invariant_probe_bindings)
+			(set_assoc
+				(qassoc_get (gs_facts stage) (quote query_invariant_probe_bindings) '())
+				requested_col
+				(symbol (query_invariant_probe_binding_key stage requested_col)))))))
+
+(define query_invariant_probe_entries_for_stages (lambda (stages)
+	(nth (reduce (filter (lowering_catalog_stages stages) query_invariant_presence_stage?)
+		(lambda (state stage)
+			(begin
+				(define requested_col (query_invariant_probe_requested_col stage))
+				(define key (query_invariant_probe_binding_key stage requested_col))
+				(if (has_assoc? (nth state 1) key)
+					state
+					(list
+						(cons (list stage requested_col) (nth state 0))
+						(set_assoc (nth state 1) key true)))))
+		(list '() '())) 0)))
+
+(define query_invariant_probe_key_set (lambda (entries)
+	(reduce entries (lambda (keys entry)
+		(match entry
+			'(stage requested_col)
+			(set_assoc keys (query_invariant_probe_binding_key stage requested_col) true)
+			_ keys)) '())))
+
+(define stage_with_query_invariant_probe_binding_using (lambda (binding_keys stage)
+	(if (not (query_invariant_presence_stage? stage))
+		stage
+		(begin
+			(define requested_col (query_invariant_probe_requested_col stage))
+			(if (has_assoc? binding_keys (query_invariant_probe_binding_key stage requested_col))
+				(group_stage_with_query_invariant_probe_binding stage requested_col)
+				stage)))))
+
+(define stage_lookup_with_query_invariant_probe_bindings (lambda (stages entries)
+	(begin
+		(define binding_keys (query_invariant_probe_key_set entries))
+		(make_lowering_catalog
+			(map (lowering_catalog_stages stages) (lambda (stage)
+				(stage_with_query_invariant_probe_binding_using binding_keys stage)))))))
+
+(define query_invariant_probe_sources (lambda (stages sources)
+	(filter (coalesceNil sources '()) (lambda (src)
+		(begin
+			(define stage (coalesceNil
+				(source_stage_output_stage stages src)
+				(stage_for_group_cache_source stages src)))
+			(and (not (nil? stage)) (query_invariant_presence_stage? stage)))))))
+
+(define query_invariant_probe_binding (lambda (entry)
+	(match entry
+		'(stage requested_col)
+		(list
+			(quote define)
+			(symbol (query_invariant_probe_binding_key stage requested_col))
+			(lower_scalar_first_probe_expr '() nil stage requested_col (list stage) 1))
+		_ (neumann_fail "build_queryplan" "malformed query-invariant probe binding"))))
+
+(define query_invariant_probe_bindings (lambda (entries)
+	(map (reverse entries) query_invariant_probe_binding)))
+
+(define rewrite_query_invariant_probe_expr (lambda (expr)
+	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(if (query_invariant_presence_stage? stage)
+			(symbol (query_invariant_probe_binding_key stage requested_col))
+			expr)
+		((quote scalar_first_probe) stage requested_col)
+		(rewrite_query_invariant_probe_expr
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((symbol scalar_first_probe) stage requested_col _dependencies)
+		(if (query_invariant_presence_stage? stage)
+			(symbol (query_invariant_probe_binding_key stage requested_col))
+			expr)
+		((quote scalar_first_probe) stage requested_col dependencies)
+		(rewrite_query_invariant_probe_expr
+			(list (symbol "scalar_first_probe") stage requested_col dependencies))
+		(cons head tail) (cons head (map tail rewrite_query_invariant_probe_expr))
+		_ expr)))
+
+(define query_invariant_probe_symbol_index (lambda (stages sources)
+	(begin
+		(define stage_index (reduce (filter (lowering_catalog_stages stages)
+			query_invariant_presence_stage?) (lambda (index stage)
+				(begin
+					(define requested_col (query_invariant_probe_requested_col stage))
+					(set_assoc index
+						(concat (exists_stage_alias (gs_id stage)) "." requested_col)
+						(symbol (query_invariant_probe_binding_key stage requested_col))))) '()))
+		(reduce (query_invariant_probe_sources stages sources) (lambda (index src)
+			(begin
+				(define stage (coalesceNil
+					(source_stage_output_stage stages src)
+					(stage_for_group_cache_source stages src)))
+				(define requested_col (query_invariant_probe_requested_col stage))
+				(set_assoc index
+					(concat (source_alias src) "." requested_col)
+					(symbol (query_invariant_probe_binding_key stage requested_col)))))
+			stage_index))))
+
+(define rewrite_query_invariant_probe_symbols_using (lambda (index bound expr)
+	(if (symbol? expr)
+		(if (contains? bound expr)
+			expr
+			(coalesceNil (get_assoc index (string expr)) expr))
+		(match expr
+			((symbol get_column) alias _alias_ignorecase col _col_ignorecase)
+			(coalesceNil (get_assoc index (concat alias "." col)) expr)
+			((quote get_column) alias alias_ignorecase col col_ignorecase)
+			(rewrite_query_invariant_probe_symbols_using index bound
+				(list (symbol "get_column") alias alias_ignorecase col col_ignorecase))
+			((symbol lambda) params body) (list
+				(quote lambda)
+				params
+				(rewrite_query_invariant_probe_symbols_using index (merge (list bound params)) body))
+			((symbol lambda) params body arity) (list
+				(quote lambda)
+				params
+				(rewrite_query_invariant_probe_symbols_using index (merge (list bound params)) body)
+				arity)
+			((symbol quote) _value) expr
+			(cons head tail) (cons
+				(rewrite_query_invariant_probe_symbols_using index bound head)
+				(map tail (lambda (item)
+					(rewrite_query_invariant_probe_symbols_using index bound item))))
+			_ expr))))
+
+(define rewrite_query_invariant_probe_symbols (lambda (index expr)
+	(rewrite_query_invariant_probe_symbols_using index '() expr)))
+
 (define scalar_query_probe_recipe_entry_add (lambda (state stage requested_col)
 	(if (not (query_block? (gs_input stage)))
 		state
@@ -8829,21 +8996,48 @@ dependency preparation does not emit free outer-row symbols. */
 			(define params (map (produceN (count keys)) (lambda (i)
 				(symbol (concat "__probe_key_" i)))))
 			(define param_index (scalar_query_probe_param_index lookup_keys params))
-			(define bound_stage (rewrite_scalar_query_probe_params param_index stage))
+			(define invariant_entries (query_invariant_probe_entries_for_stages nested_stages))
+			(define annotated_nested_lookup
+				(stage_lookup_with_query_invariant_probe_bindings nested_stages invariant_entries))
+			(define annotated_nested_stages (lowering_catalog_stages annotated_nested_lookup))
+			(define input_sources (qb_sources (gs_input stage)))
+			(define input_default_alias (qassoc_get (qb_facts (gs_input stage)) (quote default_alias)
+				(if (empty_list? input_sources) nil (source_alias (car input_sources)))))
+			(define invariant_sources
+				(query_invariant_probe_sources annotated_nested_lookup input_sources))
+			(define invariant_symbol_index
+				(query_invariant_probe_symbol_index annotated_nested_lookup input_sources))
+			(define rewrite_invariants (lambda (expr)
+				(rewrite_query_invariant_probe_symbols invariant_symbol_index
+					(rewrite_query_invariant_probe_expr
+						(rewrite_scalar_first_probe_expr
+							annotated_nested_lookup invariant_sources input_default_alias expr)))))
+			(define rewrite_bound (lambda (expr)
+				(rewrite_invariants
+					(rewrite_scalar_query_probe_params param_index expr))))
+			/* Stage descriptors retain their aggregate columns. Only the scalar
+			recipe expression may replace a stage output with its query binding. */
+			(define rewrite_bound_stage (lambda (expr)
+				(rewrite_query_invariant_probe_expr
+					(rewrite_scalar_query_probe_params param_index expr))))
+			(define bound_stage (rewrite_bound_stage stage))
 			(define bound_keys (gs_keys bound_stage))
-			(define bound_value_expr (rewrite_scalar_query_probe_params param_index value_expr))
-			(define bound_nested_stages (map nested_stages (lambda (nested_stage)
-				(rewrite_scalar_query_probe_params param_index nested_stage))))
+			(define bound_value_expr (rewrite_bound value_expr))
+			(define bound_nested_stages (map annotated_nested_stages (lambda (nested_stage)
+				(rewrite_bound_stage nested_stage))))
 			(define bound_prepare_stages (map prepare_stages (lambda (prepare_stage)
-				(rewrite_scalar_query_probe_params param_index prepare_stage))))
+				(rewrite_bound_stage
+					(coalesceNil (stage_by_id annotated_nested_lookup (gs_id prepare_stage)) prepare_stage)))))
 			(define bound_inline_presence_stages (map inline_presence_stages (lambda (presence_stage)
-				(rewrite_scalar_query_probe_params param_index presence_stage))))
+				(rewrite_bound_stage
+					(coalesceNil (stage_by_id annotated_nested_lookup (gs_id presence_stage)) presence_stage)))))
 			(list
 				(quote define)
 				(symbol (scalar_query_probe_recipe_key stage requested_col))
 				(list (quote lambda) params
-					(lower_scalar_first_query_probe_expr_using bound_stage bound_value_expr bound_keys params
-						bound_nested_stages bound_prepare_stages bound_inline_presence_stages))))
+					(rewrite_query_invariant_probe_symbols invariant_symbol_index
+						(lower_scalar_first_query_probe_expr_using bound_stage bound_value_expr bound_keys params
+							bound_nested_stages bound_prepare_stages bound_inline_presence_stages)))))
 		_ (neumann_fail "build_queryplan" "malformed scalar query probe recipe plan"))))
 
 (define scalar_query_probe_recipe_bindings (lambda (plans)
@@ -12091,7 +12285,12 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 	(begin
 		(define entries (filter (map (coalesceNil sources '()) (lambda (src)
 			(begin
-				(define original (source_stage_output_stage stages src))
+				/* Eager preparation may already have replaced stage-output with the
+				canonical group-cache relation. Both names resolve to the same stage
+				handle and must therefore expose the same probe rewrite. */
+				(define original (coalesceNil
+					(source_stage_output_stage stages src)
+					(stage_for_group_cache_source stages src)))
 				(define direct (direct_group_probe_stage_for_block_source stages sources src consumers))
 				(define stage (coalesceNil direct original))
 				(if (or (scalar_or_presence_probe_stage? stage)
@@ -12153,13 +12352,16 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				(begin
 					(define stage (nth entry 0))
 					(define dependencies (nth entry 1))
-					(if (scalar_aggregate_probe_stage? stage)
-						(coalesceNil
-							(scalar_first_stage_key_lookup_expr stage col)
-							(scalar_aggregate_probe_expr stage col))
-						(coalesceNil
-							(scalar_first_stage_key_lookup_expr stage col)
-							(scalar_first_probe_expr stage col dependencies))))))
+					(define invariant_binding (query_invariant_probe_binding_for_col stage col))
+					(if (not (nil? invariant_binding))
+						invariant_binding
+						(if (scalar_aggregate_probe_stage? stage)
+							(coalesceNil
+								(scalar_first_stage_key_lookup_expr stage col)
+								(scalar_aggregate_probe_expr stage col))
+							(coalesceNil
+								(scalar_first_stage_key_lookup_expr stage col)
+								(scalar_first_probe_expr stage col dependencies)))))))
 		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
 		(rewrite_scalar_first_probe_expr_using_index stages index default_alias
 			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
@@ -14161,7 +14363,14 @@ key-fill recipe per carrier. */
 
 (define prepare_simple_query_block_physical_core_chosen (lambda (block)
 	(begin
-		(define stage_lookup (query_block_stage_lookup block))
+		(define raw_stage_lookup (query_block_stage_lookup block))
+		(define invariant_probe_entries
+			(query_invariant_probe_entries_for_stages raw_stage_lookup))
+		(define stage_lookup
+			(stage_lookup_with_query_invariant_probe_bindings
+				raw_stage_lookup invariant_probe_entries))
+		(define invariant_probe_bindings
+			(query_invariant_probe_bindings invariant_probe_entries))
 		(if (empty_list? (qb_stages block))
 			(begin
 				(define probe_recipe_entries (query_block_scalar_query_probe_recipe_entries block))
@@ -14175,7 +14384,7 @@ key-fill recipe per carrier. */
 				(define probe_recipe_prepares
 					(scalar_query_probe_recipe_prepare_exprs probe_recipe_plans))
 				(list
-					(merge (list probe_recipe_prepares probe_recipe_bindings))
+					(merge (list invariant_probe_bindings probe_recipe_prepares probe_recipe_bindings))
 					recipe_block))
 			(begin
 				(define stage_catalog (query_block_stage_catalog block))
@@ -14215,6 +14424,7 @@ key-fill recipe per carrier. */
 				(define lazy_stages (group_cache_stages_from_sources lazy_catalog (qb_sources core_block)))
 				(list
 					(merge (list
+						invariant_probe_bindings
 						probe_recipe_prepares
 						probe_recipe_bindings
 						(lazy_stage_prepare_bindings stage_catalog lazy_stages)

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -30,6 +30,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS trace_folder"
   - sql: "DROP TABLE IF EXISTS trace_message"
   - sql: "DROP TABLE IF EXISTS trace_share"
+  - sql: "DROP TABLE IF EXISTS trace_global_access"
   - sql: |
       CREATE TABLE trace_host (
         id INT PRIMARY KEY,
@@ -60,11 +61,18 @@ setup:
         box_id INT,
         owner_id INT
       )
+  - sql: |
+      CREATE TABLE trace_global_access (
+        id INT PRIMARY KEY,
+        actor_id INT,
+        scope_id INT
+      )
   - sql: "INSERT INTO trace_host (id, kind) VALUES (1, 1), (2, 2)"
   - sql: "INSERT INTO trace_box (id, host_id, owner_id) VALUES (100, 1, 7), (200, 2, 9)"
   - sql: "INSERT INTO trace_folder (id, box_id, name) VALUES (1001, 100, 'inbox'), (1002, 100, 'archive'), (2001, 200, 'other')"
   - sql: "INSERT INTO trace_message (id, box_id, folder_id, seen) VALUES (1, 100, 1001, FALSE), (2, 100, 1002, TRUE), (3, 200, 2001, FALSE)"
-  - sql: "INSERT INTO trace_share (id, box_id, owner_id) VALUES (1, 100, 7)"
+  - sql: "INSERT INTO trace_share (id, box_id, owner_id) VALUES (1, 100, 7), (2, 200, 8)"
+  - sql: "INSERT INTO trace_global_access (id, actor_id, scope_id) VALUES (1, 7, NULL), (2, 8, 10)"
   - sql: |
       CREATE TABLE trace_asset (
         id INT PRIMARY KEY,
@@ -372,6 +380,163 @@ test_cases:
       contains:
         - "touch_keytable"
 
+  - name: "Set actor for query-invariant nested presence probe"
+    session_id: "trace-invariant-probe"
+    sql: "SET @trace_actor = 7"
+    expect:
+      rows_affected: 0
+
+  - name: "Equivalent positive and negative invariant grants share nested semantics"
+    session_id: "trace-invariant-probe"
+    sql: |
+      SELECT
+        a.id,
+        COALESCE((
+          SELECT (
+            (
+              EXISTS (
+                SELECT TRUE FROM trace_global_access grant_positive
+                WHERE grant_positive.actor_id = @trace_actor
+                  AND grant_positive.scope_id IS NULL
+                LIMIT 1
+              )
+              OR NOT EXISTS (
+                SELECT TRUE FROM trace_global_access grant_negative
+                WHERE grant_negative.actor_id = @trace_actor
+                  AND grant_negative.scope_id IS NULL
+                LIMIT 1
+              )
+            )
+            AND CASE WHEN EXISTS (
+              SELECT TRUE FROM trace_global_access grant_branch
+              WHERE grant_branch.actor_id = @trace_actor
+                AND grant_branch.scope_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM trace_share local_access
+              WHERE local_access.box_id = box_row.id
+                AND local_access.owner_id = @trace_actor
+              LIMIT 1
+            ) END
+          )
+          FROM trace_box box_row
+          WHERE box_row.id = a.id * 100
+          LIMIT 1
+        ), FALSE) AS allowed
+      FROM trace_asset a
+      WHERE a.id IN (1, 2)
+      ORDER BY a.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          allowed: true
+        - id: 2
+          allowed: true
+
+  - name: "Nested session-only presence probe is bound once per query"
+    session_id: "trace-invariant-probe"
+    sql: |
+      EXPLAIN
+      SELECT
+        a.id,
+        COALESCE((
+          SELECT (
+            (
+              EXISTS (
+                SELECT TRUE FROM trace_global_access grant_positive
+                WHERE grant_positive.actor_id = @trace_actor
+                  AND grant_positive.scope_id IS NULL
+                LIMIT 1
+              )
+              OR NOT EXISTS (
+                SELECT TRUE FROM trace_global_access grant_negative
+                WHERE grant_negative.actor_id = @trace_actor
+                  AND grant_negative.scope_id IS NULL
+                LIMIT 1
+              )
+            )
+            AND CASE WHEN EXISTS (
+              SELECT TRUE FROM trace_global_access grant_branch
+              WHERE grant_branch.actor_id = @trace_actor
+                AND grant_branch.scope_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM trace_share local_access
+              WHERE local_access.box_id = box_row.id
+                AND local_access.owner_id = @trace_actor
+              LIMIT 1
+            ) END
+          )
+          FROM trace_box box_row
+          WHERE box_row.id = a.id * 100
+          LIMIT 1
+        ), FALSE) AS allowed
+      FROM trace_asset a
+      ORDER BY a.id
+      LIMIT 72
+    expect:
+      contains:
+        - "__query_invariant_probe_"
+        - "__scalar_query_probe_"
+      result_occurrences:
+        - text: "__query_invariant_probe_"
+          count: 4
+
+  - name: "Query-invariant presence binding observes the next session value"
+    session_id: "trace-invariant-probe"
+    sql: "SET @trace_actor = 8"
+    expect:
+      rows_affected: 0
+
+  - name: "Equivalent invariant grants preserve the false and fallback branches"
+    session_id: "trace-invariant-probe"
+    sql: |
+      SELECT
+        a.id,
+        COALESCE((
+          SELECT (
+            (
+              EXISTS (
+                SELECT TRUE FROM trace_global_access grant_positive
+                WHERE grant_positive.actor_id = @trace_actor
+                  AND grant_positive.scope_id IS NULL
+                LIMIT 1
+              )
+              OR NOT EXISTS (
+                SELECT TRUE FROM trace_global_access grant_negative
+                WHERE grant_negative.actor_id = @trace_actor
+                  AND grant_negative.scope_id IS NULL
+                LIMIT 1
+              )
+            )
+            AND CASE WHEN EXISTS (
+              SELECT TRUE FROM trace_global_access grant_branch
+              WHERE grant_branch.actor_id = @trace_actor
+                AND grant_branch.scope_id IS NULL
+              LIMIT 1
+            ) THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM trace_share local_access
+              WHERE local_access.box_id = box_row.id
+                AND local_access.owner_id = @trace_actor
+              LIMIT 1
+            ) END
+          )
+          FROM trace_box box_row
+          WHERE box_row.id = a.id * 100
+          LIMIT 1
+        ), FALSE) AS allowed
+      FROM trace_asset a
+      WHERE a.id IN (1, 2)
+      ORDER BY a.id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          allowed: false
+        - id: 2
+          allowed: true
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_asset"
   - sql: "DROP TABLE IF EXISTS trace_ref_a"
@@ -384,3 +549,4 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS trace_folder"
   - sql: "DROP TABLE IF EXISTS trace_message"
   - sql: "DROP TABLE IF EXISTS trace_share"
+  - sql: "DROP TABLE IF EXISTS trace_global_access"


### PR DESCRIPTION
## What changed

- identify uncorrelated presence stages whose lookup domain consists only of literals, parameters, or session values
- bind each canonical probe once in the generated query-execution prelude
- reuse that binding inside nested scalar projection recipes, including eager group-carrier aliases
- keep correlated probes row-local and leave persistent group caches unchanged
- add anonymized SQL coverage for positive, negative, fallback, session-change, and physical-plan reuse cases

This is execution-scoped code generation, not a query cache. Every execution evaluates the bindings again, so changed session values are observed without persistent state.

## Root cause

The document-list plan cloned equivalent global permission stages into several nested scalar recipes. Those recipes then re-ran the same uncorrelated presence scan for selected rows. Canonical stage interning existed, but physical recipe lowering did not carry that identity through eager group-carrier aliases and generated free stage symbols.

## A/B on a large production-shaped dataset

Same data directory, exact SQL, build settings, one cold run followed by five warm runs:

| | master `4cb1be872` | PR `c1983f0db` |
|---|---:|---:|
| cold | 79.50 s | 68.95 s |
| warm samples | 40.51 / 36.92 / 36.93 / 36.83 / 37.13 s | 23.57 / 22.69 / 21.11 / 20.97 / 21.04 s |
| warm median | 36.93 s | 21.11 s |
| generated plan | 233,819 B | 139,806 B |

Warm execution is **1.75x faster** (**42.8% less latency**) and the generated plan is **40.2% smaller**.

Row identities and ordering are unchanged. Permission projections differ where master returned false despite the underlying global grant probe returning true; the PR returns true. The anonymized regression covers both grant-present and grant-absent sessions plus the correlated fallback branch.

This is a substantial reduction, but not the final `<3 s` target. The remaining work is in correlated per-row projection/filter probes and the full-text cascade, not the global execution-invariant scans addressed here.

## Validation

- full `make test` hook-equivalent run passed all critical suites
- Scheme coverage: 55,984 / 55,984 source nodes (100%)
- `tests/planner/subqueries/traced-union-scalar-probes.yaml`: 12 / 12
- focused aggregate, correlated-domain, nested-scalar, session-cache, group-cache, and ordered-limit matrix passed
- `git diff --check` clean

Only pre-existing explicitly noncritical failures remained in the full run.
