### PR TITLE
fix: retire shard generations without blocking readers

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -84,8 +84,46 @@ type rebuildDatabaseResult struct {
 	// replaced remains reachable until the caller has committed schema.json.
 	// On any build or publication error these shards must stay on disk because
 	// the last committed schema may still reference them.
-	replaced []*storageShard
+	replaced []replacedShardGeneration
 	errors   []string
+}
+
+type replacedShardGeneration struct {
+	shard   *storageShard
+	drained <-chan struct{}
+}
+
+func cleanupReplacedShardGenerations(replaced []replacedShardGeneration, context string) []string {
+	cleanup := func() []string {
+		var errors []string
+		for _, generation := range replaced {
+			<-generation.drained
+			if err := func() (err error) {
+				defer func() {
+					err = recoverAsError("cleanup failed for " + context + " shard " + generation.shard.uuid.String())
+				}()
+				generation.shard.RemoveFromDisk()
+				return nil
+			}(); err != nil {
+				errors = append(errors, err.Error())
+			}
+		}
+		return errors
+	}
+
+	for _, generation := range replaced {
+		select {
+		case <-generation.drained:
+		default:
+			go func() {
+				for _, err := range cleanup() {
+					fmt.Println("error:", err)
+				}
+			}()
+			return nil
+		}
+	}
+	return cleanup()
 }
 
 type schemaWriteOptions interface {
@@ -195,17 +233,7 @@ func RebuildTable(tbl *table, all bool, repartition bool) string {
 	if len(errs) == 0 {
 		// tbl.schema.save() committed all replacement UUIDs. Only this success
 		// path may remove files belonging to the previous generation.
-		for _, s := range result.replaced {
-			if err := func() (err error) {
-				defer func() {
-					err = recoverAsError("cleanup failed for table " + tbl.schema.Name + "." + tbl.Name + " shard " + s.uuid.String())
-				}()
-				s.RemoveFromDisk()
-				return nil
-			}(); err != nil {
-				errs = append(errs, err.Error())
-			}
-		}
+		errs = append(errs, cleanupReplacedShardGenerations(result.replaced, "table "+tbl.schema.Name+"."+tbl.Name)...)
 	}
 
 	duration := fmt.Sprint(time.Since(start))
@@ -236,15 +264,7 @@ func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string 
 			}
 			// db.save() committed all replacement UUIDs. A save failure returns
 			// above and deliberately retains every old generation.
-			for _, s := range result.replaced {
-				if err := func() (err error) {
-					defer func() { err = recoverAsError("cleanup failed for database " + db.Name + " shard " + s.uuid.String()) }()
-					s.RemoveFromDisk()
-					return nil
-				}(); err != nil {
-					errs = append(errs, err.Error())
-				}
-			}
+			errs = append(errs, cleanupReplacedShardGenerations(result.replaced, "database "+db.Name)...)
 		}(db)
 	}
 	duration := fmt.Sprint(time.Since(start))
@@ -612,7 +632,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 	// ALL table rebuilds finish to avoid deadlocks with concurrent .blobs
 	// repartition holding shard read-locks.
 	var replacedMu sync.Mutex
-	var allReplaced []*storageShard
+	var allReplaced []replacedShardGeneration
 	var errMu sync.Mutex
 	var rebuildErrors []string
 	dbs := db.tables.GetAll()
@@ -687,7 +707,8 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 			// expensive shard rebuild runs. Writers must not be blocked on
 			// the whole sdone.Wait() phase.
 			targetIsP := t.ShardMode == ShardModePartition
-			origShardList := append([]*storageShard(nil), t.ActiveShards()...)
+			origTopology := t.activeTopology()
+			origShardList := append([]*storageShard(nil), origTopology.shards...)
 			t.mu.Unlock()
 			tableLocked = false
 			newShardList := make([]*storageShard, len(origShardList))
@@ -904,7 +925,12 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 			// Collect replaced shards for deferred cleanup (see comment above).
 			if len(replaced) > 0 {
 				replacedMu.Lock()
-				allReplaced = append(allReplaced, replaced...)
+				for _, shard := range replaced {
+					allReplaced = append(allReplaced, replacedShardGeneration{
+						shard:   shard,
+						drained: origTopology.drained,
+					})
+				}
 				replacedMu.Unlock()
 			}
 
@@ -953,19 +979,14 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 
 			t.mu.Unlock()
 			tableLocked = false
-			for _, shard := range origShardList {
-				if shard == nil {
-					continue
-				}
-				for shard.activeScanners.Load() > 0 {
-					runtime.Gosched()
-				}
-			}
-			t.mutationMu.Lock()
-			t.mutationMu.Unlock()
+			// Publication retired origTopology. Wait without polling until every
+			// scan/write task that selected it has left; the authoritative topology
+			// and its writers are already live while this cleanup barrier drains.
+			<-origTopology.operationsDrained
 
 			if doRepart {
-				// maintenanceMu stays locked; repartition Phase G will unlock it
+				// maintenanceMu stays locked; repartition generation retirement
+				// releases it after the last old-topology user.
 				rebuildClaimed = false
 				t.repartitionDDLReadLocked(shardCandidates)
 			} else {

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -147,12 +147,11 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 		}
 	}
 
-	runWorkers := func(shards []*storageShard, onDone func(*storageShard)) <-chan struct{} {
+	runWorkers := func(shards []*storageShard, topology *tableShardTopology) <-chan struct{} {
 		return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
 			s := shards[i]
-			if onDone != nil {
-				defer onDone(s)
-			}
+			defer topology.releaseOperation()
+			defer s.activeScanners.Add(-1)
 			release := s.GetRead()
 			defer release()
 			callback(s, synchronous)
@@ -161,54 +160,51 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 
 	for {
 		topology := t.activeTopology()
-		if topology.mode != ShardModeFree {
-			relevant := collectRelevantShards(topology.dimensions, boundaries, topology.shards)
-			if len(relevant) == 0 {
-				return nil
+		var relevant []*storageShard
+		if topology.mode == ShardModeFree {
+			relevant = make([]*storageShard, 0, len(topology.shards))
+			for _, s := range topology.shards {
+				if s != nil {
+					relevant = append(relevant, s)
+				}
 			}
-			if len(relevant) == 1 {
-				s := relevant[0]
-				release := s.GetRead()
-				defer release()
-				callback(s, true)
-				return nil
-			}
-			return runWorkers(relevant, nil)
+		} else {
+			relevant = collectRelevantShards(topology.dimensions, boundaries, topology.shards)
+		}
+		if len(relevant) == 0 {
+			return nil
 		}
 
-		// Register against the loaded generation, then verify it is still
-		// authoritative. A concurrent publisher can drain the old generation
-		// without a reader lock: late registrations notice the changed pointer
-		// before touching a shard and retry on the new topology.
-		shards := topology.shards
-		relevant := make([]*storageShard, 0, len(shards))
-		for _, s := range shards {
-			if s != nil {
-				s.activeScanners.Add(1)
-				relevant = append(relevant, s)
+		// Pin every shard task to the loaded immutable generation, then verify
+		// that it is still authoritative. A publisher never waits for this
+		// registration; late readers simply release it and retry on the new
+		// generation before touching shard state.
+		registered := 0
+		for _, s := range relevant {
+			if !topology.acquireOperation() {
+				break
 			}
+			s.activeScanners.Add(1)
+			registered++
 		}
-		if t.topology.Load() != topology {
-			for _, s := range relevant {
+		if registered != len(relevant) || t.topology.Load() != topology {
+			for _, s := range relevant[:registered] {
 				s.activeScanners.Add(-1)
+				topology.releaseOperation()
 			}
 			continue
 		}
 
-		if len(relevant) == 0 {
-			return nil
-		}
 		if len(relevant) == 1 {
 			s := relevant[0]
+			defer topology.releaseOperation()
 			defer s.activeScanners.Add(-1)
 			release := s.GetRead()
 			defer release()
 			callback(s, true)
 			return nil
 		}
-		return runWorkers(relevant, func(s *storageShard) {
-			s.activeScanners.Add(-1)
-		})
+		return runWorkers(relevant, topology)
 	}
 }
 
@@ -496,8 +492,8 @@ func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimen
 //	C. Build main storage (no locks held — long phase)
 //	C½. Build translation map for DELETE dual-write
 //	D. Install main storage + Delta shift (brief Lock per new shard)
-//	F. Flip ShardMode + Drain
-//	G. Cleanup
+//	F. Durably publish the new topology
+//	G. Retire the old generation after its users drain
 //
 // This function is called WITHOUT t.mu held (t.mu is released by the caller
 // before invoking repartition). It manages its own shard-level locking.
@@ -964,25 +960,13 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 		fmt.Println("repartition: applied", totalPending, "pending deletions after Phase D")
 	}
 
-	// ── Phase F: Durable publication + topology flip + drain ──
+	// ── Phase F: Durable publication + topology flip ──
 	// Keep the old immutable topology authoritative while schema.json is being
 	// committed. Source writes remain synchronous old→new forwards. Locking the
 	// old shards only for this short commit boundary prevents a writer from
 	// completing between the final catch-up and durable metadata publication.
 	for {
-		for {
-			active := false
-			for _, shard := range oldshards {
-				if shard.activeTransactions.Load() > 0 {
-					active = true
-					break
-				}
-			}
-			if !active {
-				break
-			}
-			runtime.Gosched()
-		}
+		t.waitForTransactions(oldshards)
 		for _, shard := range oldshards {
 			shard.mu.Lock()
 		}
@@ -1038,74 +1022,66 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	for i := len(oldshards) - 1; i >= 0; i-- {
 		oldshards[i].mu.Unlock()
 	}
-	// Wait for all in-flight scans on old shards to complete.
-	// During this drain, maintenanceKind == 2 is still true, so dual-write
-	// continues forwarding writes from old shards to PShards.
-	for _, s := range oldshards {
-		for s.activeScanners.Load() > 0 {
-			runtime.Gosched()
+
+	finishRetirement := func() {
+		// Every scan, insert, and transaction that selected the old immutable
+		// topology has now left it. No writer was stalled by that drain: old
+		// mutation pipelines kept forwarding into the published generation.
+		t.resolvePendingRepartitionSourceDeletes()
+		t.repartitionPendingMu.Lock()
+		unresolvedFinal := len(t.repartitionPendingSourceDels)
+		t.repartitionPendingMu.Unlock()
+		if unresolvedFinal != 0 {
+			panic(fmt.Sprintf("repartition published %s with %d unresolved source deletes; old generation retained", t.Name, unresolvedFinal))
 		}
-	}
-	// Step 4: Drain any in-flight mutating scan pipelines (UPDATE / DELETE) that
-	// still operate on the old shard set. They hold mutationMu for the whole
-	// scan+callback lifetime.
-	t.mutationMu.Lock()
-	t.mutationMu.Unlock()
-	// Step 5: Drain any in-flight partition-path dual-writes that write to old
-	// Shards (Partition→Shards direction). These hold t.mu briefly.
-	t.mu.Lock()
-	t.mu.Unlock()
-
-	// Final drain of pending deletions. After Phase F drain, all in-flight
-	// DELETE scans have completed and their dual-write callbacks have finished.
-	// Any remaining pending entries are now final.
-	t.resolvePendingRepartitionSourceDeletes()
-	t.repartitionPendingMu.Lock()
-	unresolvedFinal := len(t.repartitionPendingSourceDels)
-	t.repartitionPendingMu.Unlock()
-	if unresolvedFinal != 0 {
-		panic(fmt.Sprintf("repartition published %s with %d unresolved source deletes; old generation retained", t.Name, unresolvedFinal))
-	}
-	finalPending := applyPendingDeletes()
-	if finalPending > 0 {
-		fmt.Println("repartition: applied", finalPending, "final pending deletions after Phase F drain")
-	}
-
-	// Verify transformation result
-	total_count2 := uint64(0)
-	for _, s := range newshards {
-		total_count2 += uint64(s.Count())
-	}
-	if total_count2 < total_count {
-		diff := total_count - total_count2
-		if diff > total_count/10 {
-			fmt.Println("warning: repartition count mismatch for", t.Name, ": before", total_count, "after", total_count2, "(", diff, "rows missing)")
+		finalPending := applyPendingDeletes()
+		if finalPending > 0 {
+			fmt.Println("repartition: applied", finalPending, "final pending deletions after generation retirement")
 		}
-	}
-	fmt.Println("activated new partitioning schema for", t.Name, "after", time.Since(start))
 
-	// ── Phase G: Retire the old generation ──
-	t.mu.Lock()
-	t.maintenanceKind = 0
-	t.repartitionDualWriteActive.Store(false)
-	t.repartitionSources.Store(nil)
-	t.mu.Unlock()
-	t.clearRepartitionTranslation()
-	t.maintenanceMu.Unlock()
-
-	for _, s := range oldshards {
-		// Deliberately after successful schema publication. Persistent cleanup
-		// must never move into a defer, finalizer, or failure path.
-		GlobalCache.Remove(s)
-		s.RemoveFromDisk()
-	}
-
-	// Register new PShards with CacheManager
-	if t.PersistencyMode != Memory && !strings.HasPrefix(t.Name, ".") {
+		total_count2 := uint64(0)
 		for _, s := range newshards {
-			atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
-			GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+			total_count2 += uint64(s.Count())
 		}
+		if total_count2 < total_count {
+			diff := total_count - total_count2
+			if diff > total_count/10 {
+				fmt.Println("warning: repartition count mismatch for", t.Name, ": before", total_count, "after", total_count2, "(", diff, "rows missing)")
+			}
+		}
+		fmt.Println("activated new partitioning schema for", t.Name, "after", time.Since(start))
+
+		t.mu.Lock()
+		t.maintenanceKind = 0
+		t.repartitionDualWriteActive.Store(false)
+		t.repartitionSources.Store(nil)
+		t.mu.Unlock()
+		t.clearRepartitionTranslation()
+		t.maintenanceMu.Unlock()
+
+		for _, s := range oldshards {
+			// Deliberately after successful schema publication and after the last
+			// generation user. Persistent cleanup must never run on an active shard.
+			GlobalCache.Remove(s)
+			s.RemoveFromDisk()
+		}
+
+		if t.PersistencyMode != Memory && !strings.HasPrefix(t.Name, ".") {
+			for _, s := range newshards {
+				atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
+				GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
+			}
+		}
+	}
+
+	select {
+	case <-oldTopology.drained:
+		finishRetirement()
+	default:
+		go func() {
+			<-oldTopology.drained
+			finishRetirement()
+		}()
 	}
 }
 

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -164,6 +164,7 @@ func TestIterateShardsParallelMarksFreeSingleShardSolo(t *testing.T) {
 func TestIterateShardsParallelReleasesFreeShardRegistrationOnPanic(t *testing.T) {
 	tbl := setupScanParallelTestTable(t, "tscanparpanic")
 	shard := tbl.Shards[0]
+	topology := tbl.activeTopology()
 
 	func() {
 		defer func() {
@@ -178,6 +179,98 @@ func TestIterateShardsParallelReleasesFreeShardRegistrationOnPanic(t *testing.T)
 
 	if got := shard.activeScanners.Load(); got != 0 {
 		t.Fatalf("active scanner registrations after panic = %d, want 0", got)
+	}
+	if got := topology.operations.Load(); got != 0 {
+		t.Fatalf("topology user registrations after panic = %d, want 0", got)
+	}
+}
+
+func TestRepartitionPublishesWhileOldGenerationReaderRuns(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanparrepartitionreader")
+	rows := make([][]scm.Scmer, 128)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i))}
+	}
+	tbl.Insert([]string{"id"}, rows, nil, scm.NewNil(), false, nil)
+	dimensions := []shardDimension{tbl.NewShardDimension("id", 2)}
+	oldTopology := tbl.activeTopology()
+
+	readerEntered := make(chan struct{})
+	releaseReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		tbl.iterateShardsParallel(nil, nil, func(*storageShard, bool) {
+			close(readerEntered)
+			<-releaseReader
+		})
+	}()
+	<-readerEntered
+	t.Cleanup(func() {
+		select {
+		case <-releaseReader:
+		default:
+			close(releaseReader)
+		}
+		<-readerDone
+	})
+
+	if !tbl.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	repartitionDone := make(chan struct{})
+	go func() {
+		tbl.repartition(dimensions)
+		close(repartitionDone)
+	}()
+
+	select {
+	case <-repartitionDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repartition waited for a reader pinned to the old generation")
+	}
+	if topology := tbl.activeTopology(); topology == oldTopology || topology.mode != ShardModePartition {
+		t.Fatal("repartition did not publish the new partition generation")
+	}
+	select {
+	case <-oldTopology.drained:
+		t.Fatal("old generation drained before its reader returned")
+	default:
+	}
+
+	insertDone := make(chan struct{})
+	go func() {
+		tbl.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1000)}}, nil, scm.NewNil(), false, nil)
+		close(insertDone)
+	}()
+	select {
+	case <-insertDone:
+	case <-time.After(time.Second):
+		t.Fatal("writer on the published generation was blocked by an old reader")
+	}
+
+	close(releaseReader)
+	<-readerDone
+	select {
+	case <-oldTopology.drained:
+	case <-time.After(time.Second):
+		t.Fatal("old generation did not drain after its last reader returned")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		tbl.mu.Lock()
+		idle := tbl.maintenanceKind == 0
+		tbl.mu.Unlock()
+		if idle {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("repartition retirement did not release maintenance ownership")
+		}
+		runtime.Gosched()
+	}
+	if got := tbl.Count(); got != uint(len(rows)+1) {
+		t.Fatalf("row count after asynchronous generation retirement = %d, want %d", got, len(rows)+1)
 	}
 }
 

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -80,12 +80,25 @@ type storageShard struct {
 	srState      SharedState
 	lastAccessed uint64 // UnixNano, atomic; updated on GetRead/GetExclusive for LRU eviction
 
-	// repartition drain tracking: counts in-flight scans on this shard
+	// Repartition generation tracking. Counters are atomic; generation points to
+	// the immutable topology owning this shard and changes only on publication.
 	activeScanners     atomic.Int32
 	activeTransactions atomic.Int32
+	generation         atomic.Pointer[tableShardTopology]
 
 	// guards RemoveFromDisk against double execution (finalizer + explicit cleanup)
 	cleanupOnce sync.Once
+}
+
+func (s *storageShard) beginTransactionUse() {
+	s.activeTransactions.Add(1)
+}
+
+func (s *storageShard) endTransactionUse() {
+	if s.activeTransactions.Add(-1) != 0 {
+		return
+	}
+	s.t.signalTransactionDrain()
 }
 
 func (s *storageShard) loadNext() *storageShard {

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -1680,6 +1680,61 @@ func TestFailedRebuildSchemaPublicationKeepsLaterWritesRecoverable(t *testing.T)
 	}
 }
 
+func TestRebuildInsideActiveTransactionDoesNotWaitForItself(t *testing.T) {
+	tbl, _ := createDurabilityTestTable(t, "trebuildselftransaction", 1)
+	oldTopology := tbl.activeTopology()
+	tx := NewTxContext(TxCursorStability)
+	tx.Session = scm.NewSession()
+	scm.Apply(tx.Session, scm.NewString("__memcp_tx"), scm.NewAny(tx))
+	resultCh := make(chan string, 1)
+	panicCh := make(chan any, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		withTxSession(tx, func() scm.Scmer {
+			tbl.Insert([]string{"id", "payload"}, [][]scm.Scmer{{scm.NewInt(2), scm.NewString("same-request")}}, nil, scm.NewNil(), false, nil)
+			resultCh <- RebuildTable(tbl, true, false)
+			return scm.NewNil()
+		})
+	}()
+
+	select {
+	case r := <-panicCh:
+		t.Fatalf("rebuild in active transaction panicked: %v", r)
+	case result := <-resultCh:
+		if strings.Contains(result, "errors:") {
+			t.Fatalf("rebuild in active transaction returned %q", result)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("rebuild waited for the transaction owned by its own request")
+	}
+	select {
+	case <-oldTopology.operationsDrained:
+	case <-time.After(time.Second):
+		t.Fatal("retired rebuild generation still has active operations")
+	}
+	select {
+	case <-oldTopology.drained:
+		t.Fatal("retired rebuild generation drained before its transaction completed")
+	default:
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-oldTopology.drained:
+	case <-time.After(time.Second):
+		t.Fatal("retired rebuild generation did not drain after transaction commit")
+	}
+	if got := tbl.Count(); got != 2 {
+		t.Fatalf("row count after transactional rebuild = %d, want 2", got)
+	}
+}
+
 func TestOverflowRebuildSchemaFailureKeepsWritesRecoverable(t *testing.T) {
 	oldShardSize := Settings.ShardSize
 	Settings.ShardSize = 2

--- a/storage/table.go
+++ b/storage/table.go
@@ -221,6 +221,58 @@ type tableShardTopology struct {
 	mode       ShardMode
 	shards     []*storageShard
 	dimensions []shardDimension
+
+	// Operations and transactions drain independently. A rebuild request may be
+	// running inside the transaction that touched the retiring generation, so it
+	// can wait for operations but must defer physical cleanup until transactions
+	// finish after the request returns.
+	operations         atomic.Int64
+	transactions       atomic.Int64
+	retired            atomic.Bool
+	operationsDrained  chan struct{}
+	drained            chan struct{}
+	operationDrainOnce sync.Once
+	drainOnce          sync.Once
+}
+
+func (topology *tableShardTopology) acquireOperation() bool {
+	topology.operations.Add(1)
+	if topology.retired.Load() {
+		topology.releaseOperation()
+		return false
+	}
+	return true
+}
+
+func (topology *tableShardTopology) pinTransaction() {
+	topology.transactions.Add(1)
+}
+
+func (topology *tableShardTopology) releaseOperation() {
+	if topology.operations.Add(-1) == 0 && topology.retired.Load() {
+		topology.closeDrains()
+	}
+}
+
+func (topology *tableShardTopology) releaseTransaction() {
+	if topology.transactions.Add(-1) == 0 && topology.retired.Load() {
+		topology.closeDrains()
+	}
+}
+
+func (topology *tableShardTopology) closeDrains() {
+	if topology.operations.Load() == 0 {
+		topology.operationDrainOnce.Do(func() { close(topology.operationsDrained) })
+		if topology.transactions.Load() == 0 {
+			topology.drainOnce.Do(func() { close(topology.drained) })
+		}
+	}
+}
+
+func (topology *tableShardTopology) retire() <-chan struct{} {
+	topology.retired.Store(true)
+	topology.closeDrains()
+	return topology.drained
 }
 
 type repartitionSourceSet struct {
@@ -415,6 +467,14 @@ type table struct {
 	overflowRebuilds           atomic.Int32 // background workers; observed without joining the write path
 	repartitionDualWriteActive atomic.Bool  // true after Phase B snapshot; dual-write only when true
 	repartitionSources         atomic.Pointer[repartitionSourceSet]
+	// transactionDrainMu/transactionDrain coordinate the rare repartition
+	// publication wait. Transaction start/end stays lock-free unless a waiter is
+	// present; transactionDrainWaiters is atomic and the condition is guarded by
+	// transactionDrainMu.
+	transactionDrainMu      sync.Mutex
+	transactionDrain        *sync.Cond
+	transactionDrainOnce    sync.Once
+	transactionDrainWaiters atomic.Int32
 
 	// repartitionTranslation maps old-shard rows to their new PShard locations.
 	// Snapshot rows are published after Phase B. Post-snapshot dual-written rows
@@ -429,6 +489,43 @@ type table struct {
 	repartitionPendingMu         sync.Mutex
 	repartitionPendingDels       []translatedRecid
 	repartitionPendingSourceDels []pendingSourceDelete
+}
+
+func (t *table) signalTransactionDrain() {
+	if t.transactionDrainWaiters.Load() == 0 {
+		return
+	}
+	t.transactionDrainMu.Lock()
+	if t.transactionDrain != nil {
+		t.transactionDrain.Broadcast()
+	}
+	t.transactionDrainMu.Unlock()
+}
+
+func (t *table) waitForTransactions(shards []*storageShard) {
+	hasActive := func() bool {
+		for _, shard := range shards {
+			if shard != nil && shard.activeTransactions.Load() != 0 {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasActive() {
+		return
+	}
+	t.transactionDrainOnce.Do(func() {
+		t.transactionDrainMu.Lock()
+		t.transactionDrain = sync.NewCond(&t.transactionDrainMu)
+		t.transactionDrainMu.Unlock()
+	})
+	t.transactionDrainMu.Lock()
+	t.transactionDrainWaiters.Add(1)
+	for hasActive() {
+		t.transactionDrain.Wait()
+	}
+	t.transactionDrainWaiters.Add(-1)
+	t.transactionDrainMu.Unlock()
 }
 
 // awaitCreationInitialization is the idempotent createtable barrier for an
@@ -532,12 +629,34 @@ func (t *table) publishTopologyLocked() *tableShardTopology {
 		shards = t.PShards
 	}
 	topology := &tableShardTopology{
-		mode:       mode,
-		shards:     append([]*storageShard(nil), shards...),
-		dimensions: append([]shardDimension(nil), t.PDimensions...),
+		mode:              mode,
+		shards:            append([]*storageShard(nil), shards...),
+		dimensions:        append([]shardDimension(nil), t.PDimensions...),
+		operationsDrained: make(chan struct{}),
+		drained:           make(chan struct{}),
 	}
-	t.topology.Store(topology)
+	for _, shard := range topology.shards {
+		if shard != nil {
+			shard.generation.Store(topology)
+		}
+	}
+	previous := t.topology.Swap(topology)
+	if previous != nil {
+		previous.retire()
+	}
 	return topology
+}
+
+func (t *table) pinActiveTopology() *tableShardTopology {
+	for {
+		topology := t.activeTopology()
+		if topology.acquireOperation() {
+			if t.topology.Load() == topology {
+				return topology
+			}
+			topology.releaseOperation()
+		}
+	}
 }
 
 func (t *table) activeTopology() *tableShardTopology {
@@ -1844,7 +1963,19 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 		return 0
 	}
 
-	topology := t.activeTopology()
+	topology := t.pinActiveTopology()
+	defer func() { topology.releaseOperation() }()
+	switchTopology := func(next *tableShardTopology) {
+		topology.releaseOperation()
+		if next != nil && next.acquireOperation() {
+			if t.topology.Load() == next {
+				topology = next
+				return
+			}
+			next.releaseOperation()
+		}
+		topology = t.pinActiveTopology()
+	}
 	if topology.mode == ShardModeFree { // unpartitioned sharding
 		// Helper to get or create a shard with capacity for n rows
 		getShardWithCapacity := func(n uint) *storageShard {
@@ -1852,8 +1983,8 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				t.mu.Lock()
 				active := t.activeTopology()
 				if active != topology {
-					topology = active
 					t.mu.Unlock()
+					switchTopology(active)
 					if topology.mode != ShardModeFree {
 						return nil
 					}
@@ -1872,7 +2003,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				t.mu.Unlock()
 				published, appended := t.appendFreeShardDurably(topology, shard, n)
 				if published != nil {
-					topology = published
+					switchTopology(published)
 				}
 				if appended != nil {
 					return appended
@@ -1896,7 +2027,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				// generation. Reload the published partition topology before routing
 				// the remaining rows; the old free generation may already have
 				// finished its forwarding drain.
-				topology = t.activeTopology()
+				switchTopology(nil)
 				values = values[start:]
 				repartitioned = true
 				break

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -70,6 +70,7 @@ type storageShardTransaction struct {
 	DeletedRecids  []uint32
 	DeleteRecids   []uint32
 	UndeleteRecids []uint32
+	generation     *tableShardTopology
 
 	mu sync.Mutex
 }
@@ -220,8 +221,12 @@ func (tx *TxContext) getOrCreateShardTxLocked(shard *storageShard) *storageShard
 	st := tx.shards[shard]
 	if st == nil {
 		st = new(storageShardTransaction)
+		st.generation = shard.generation.Load()
+		if st.generation != nil {
+			st.generation.pinTransaction()
+		}
 		tx.shards[shard] = st
-		shard.activeTransactions.Add(1)
+		shard.beginTransactionUse()
 	}
 	return st
 }
@@ -249,8 +254,11 @@ func (tx *TxContext) finishRepartitionActions(commit bool) {
 }
 
 func (tx *TxContext) releaseActiveTransactionsLocked() {
-	for shard := range tx.shards {
-		shard.activeTransactions.Add(-1)
+	for shard, st := range tx.shards {
+		shard.endTransactionUse()
+		if st.generation != nil {
+			st.generation.releaseTransaction()
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- publish immutable shard topology generations atomically and pin scans/inserts to the generation they selected
- track operation and transaction retirement separately, so old readers never block new-generation writers
- replace transaction polling/timeouts with a condition-based drain only at the short durable publication boundary
- defer old shard/WAL cleanup until the retired generation has no remaining transactions
- allow rebuilds initiated inside their own request transaction to return without waiting on that transaction
- add regression coverage for long-lived old-generation readers and rebuild-inside-transaction

## Root cause

PR #510 tried to avoid the deadlock with lock acquisition retries and timeouts. That still coupled publication progress to unrelated readers and converted a lifecycle problem into timing-dependent failure behavior. The storage engine already has the right separation—immutable main generations plus deltas/forwarding—so the missing piece was explicit generation ownership and retirement.

This change makes publication a pointer swap. Existing operations finish against the retired generation; new operations immediately use the published generation. Physical cleanup happens only after the retired generation drains.

Supersedes #510.

## Validation

- `make test` — full hook-equivalent SQL/Scheme suite, passed
- `go test -race ./storage -run 'TestRebuildInsideActiveTransactionDoesNotWaitForItself|TestRepartitionPublishesWhileOldGenerationReaderRuns|TestIterateShardsParallelReleasesFreeShardRegistrationOnPanic|TestManualRepartitionForwardsConcurrentInserts|TestManualRepartitionInsertDeleteUsesTranslationMap|TestRepartition|TestFailedRebuildSchemaPublicationKeepsLaterWritesRecoverable' -count=1` — passed
- `tests/execution/concurrency/repartition-concurrent.yaml` — 143/143 passed
- scan fixed-cost benchmark compared against master; no measurable regression
