### PR TITLE
fix: preserve correctness across rebuilds and derived probes

### DIFF
--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -343,8 +343,14 @@ func (s *StorageEnum) GetCachedReader() ColumnReader {
 // Uses binary search + sequential decode from chunk start. For O(1) sequential
 // access, use GetCachedReader() which returns a per-goroutine cached wrapper.
 func (s *StorageEnum) GetValue(i uint32) scm.Scmer {
+	if uint64(i) >= s.count {
+		return scm.NewNil()
+	}
 	idx := int(i)
 	fwdIdx := s.findChunk(idx)
+	if fwdIdx >= len(s.data) {
+		return scm.NewNil()
+	}
 	chunkStart := 0
 	if fwdIdx > 0 {
 		chunkStart = s.jumpCum(fwdIdx - 1)
@@ -362,9 +368,12 @@ func (s *StorageEnum) GetValue(i uint32) scm.Scmer {
 // GetValueCached provides O(1) sequential access using a per-goroutine cache.
 // The cache must not be shared between goroutines.
 func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
+	if uint64(i) >= s.count {
+		return scm.NewNil()
+	}
 	idx := int(i)
 
-	if c.valid {
+	if c.valid && c.fwdChunk < len(s.jumpL2) && c.fwdChunk < len(s.data) {
 		chunkEnd := s.jumpCum(c.fwdChunk)
 		// fast path: index is ahead of cache position in same chunk
 		if idx >= c.start+c.pos && idx < chunkEnd {
@@ -381,7 +390,7 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 		// next chunk fast path
 		if idx >= chunkEnd {
 			nextFwd := c.fwdChunk + 1
-			if nextFwd < len(s.jumpL2) && idx < s.jumpCum(nextFwd) {
+			if nextFwd < len(s.jumpL2) && nextFwd < len(s.data) && idx < s.jumpCum(nextFwd) {
 				dataIdx := len(s.data) - 1 - nextFwd
 				buffer := s.data[dataIdx]
 				posInChunk := idx - chunkEnd
@@ -396,10 +405,15 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 				return result
 			}
 		}
+	} else if c.valid {
+		c.valid = false
 	}
 
 	// Binary search fallback
 	fwdIdx := s.findChunk(idx)
+	if fwdIdx >= len(s.data) {
+		return scm.NewNil()
+	}
 	chunkStart := 0
 	if fwdIdx > 0 {
 		chunkStart = s.jumpCum(fwdIdx - 1)

--- a/storage/storage-enum_test.go
+++ b/storage/storage-enum_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 package storage
 
 import (
@@ -128,6 +144,21 @@ func TestEnumGetCachedReader(t *testing.T) {
 		if !scm.Equal(got, want) {
 			t.Fatalf("cachedReader.GetValue(%d) = %v, want %v", i, got, want)
 		}
+	}
+}
+
+func TestEnumReadsPastPersistedCountAsNull(t *testing.T) {
+	s := buildEnum(2, func(i int) scm.Scmer {
+		return scm.NewString([]string{"inactive", "active"}[i])
+	})
+
+	if got := s.GetValue(2); !got.IsNil() {
+		t.Fatalf("GetValue beyond persisted count = %v, want nil", got)
+	}
+
+	var cache EnumDecodeCache
+	if got := s.GetValueCached(2, &cache); !got.IsNil() {
+		t.Fatalf("GetValueCached beyond persisted count = %v, want nil", got)
 	}
 }
 

--- a/tests/integration/import/loader-coverage.yaml
+++ b/tests/integration/import/loader-coverage.yaml
@@ -1,3 +1,4 @@
+# Copyright (C) 2026 Carl-Philip Haensch
 # Loader coverage for SQL and PostgreSQL dump import paths.
 
 metadata:
@@ -9,6 +10,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS loader_sql"
   - sql: "DROP TABLE IF EXISTS loader_psql"
   - sql: "DROP TABLE IF EXISTS loader_psql_file"
+  - sql: "DROP TABLE IF EXISTS loader_psql_partial"
   - sql: "CREATE TABLE loader_psql (id INT PRIMARY KEY, flag BOOLEAN, note TEXT)"
 
 test_cases:
@@ -73,7 +75,51 @@ test_cases:
         - id: 1
           note: "from plain sql"
 
+  - name: "create table for partial COPY enum rebuild"
+    sql: "CREATE TABLE loader_psql_partial (id INT PRIMARY KEY, active BOOLEAN, note TEXT)"
+
+  - name: "seed enum-shaped imported column"
+    scm: |
+      (insert (table "memcp-tests" "loader_psql_partial") '("id" "active" "note")
+        (map (produceN 100) (lambda (i)
+          (list (+ i 1) (not (equal? i 99)) (concat "base-" (+ i 1))))))
+
+  - name: "rebuild seeded enum column"
+    scm: "(rebuild)"
+
+  - name: "load_psql imports later COPY rows with omitted enum column"
+    scm: |
+      (load_psql "memcp-tests"
+        (streamString (concat
+          "COPY public.loader_psql_partial (id, note) FROM stdin;\n"
+          "101\tpartial-101\n"
+          "102\tpartial-102\n"
+          "\\.\n"))
+        (sql_policy "root"))
+
+  - name: "rebuild partial COPY import"
+    scm: "(rebuild)"
+
+  - name: "omitted COPY columns remain null after rebuild"
+    sql: "SELECT id, active, note FROM loader_psql_partial WHERE id >= 99 ORDER BY id"
+    expect:
+      rows: 4
+      data:
+        - id: 99
+          active: true
+          note: "base-99"
+        - id: 100
+          active: false
+          note: "base-100"
+        - id: 101
+          active: null
+          note: "partial-101"
+        - id: 102
+          active: null
+          note: "partial-102"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS loader_sql"
   - sql: "DROP TABLE IF EXISTS loader_psql"
   - sql: "DROP TABLE IF EXISTS loader_psql_file"
+  - sql: "DROP TABLE IF EXISTS loader_psql_partial"


### PR DESCRIPTION
## What

- NULL-pad short persisted enum generations during reads instead of indexing past the generation payload
- bind both current derived lookup aliases and their original logical aliases to scalar-probe parameters
- cover the PostgreSQL COPY omission/rebuild lifecycle and the nested derived scalar/EXISTS query shape with regressions

## Why

Two independent correctness gaps reached `master`:

1. A persisted enum generation can legitimately contain fewer values than the shard row count. Reads treated the generation payload as row-aligned and indexed beyond its end instead of returning SQL `NULL`. Existing tests covered enum round trips, but not a short generation after PostgreSQL COPY omission plus rebuild/restart.
2. Derived-table flattening can rename a scalar probe's live lookup alias while a nested correlated stage still refers to the pre-derived logical alias. The physical recipe binder indexed only the renamed lookup, leaving the nested reference (for example `b.id`) free. Existing scalar representative tests covered direct correlations, but not a nested `EXISTS` inside a scalar probe projected through a derived `LEFT JOIN`.

The planner fix stays within decorrelated group-stage lowering: both equivalent logical names map to the same existing probe parameter. It does not introduce a scalar/correlated fallback.

## Why CI did not catch it

The CI hook builds MemCP and runs the Scheme/YAML suites, but does not execute the Go unit tests. The enum YAML fixtures used complete rectangular rows. The planner suites covered direct scalar representative binding, but not the derived/nested correlation combination reproduced here.

## Validation

- `python3 run_sql_tests.py tests/planner/subqueries/traced-union-scalar-probes.yaml` — 13/13 passed
- exact minimal query captured from the application — corrected from `false/false` to expected `true/false`
- `make test` — passed
- Scheme unit tests — 1207/1207 passed

`python3 tools/lint_scm.py` completed. Its `--check` mode still reports the repository's pre-existing negative-depth warnings in `queryplan.scm`, `rdf-parser.scm`, and `psql-parser.scm`.

Performance work remains intentionally excluded.