### PR TITLE
fix: bind nested probes across derived aliases

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -8956,18 +8956,30 @@ bound once outside row callbacks; a column reference would make that unsafe. */
 		entries
 		bounded_recipe_keys)))
 
-(define scalar_query_probe_param_index (lambda (lookup_keys params)
-	(reduce (produceN (count lookup_keys)) (lambda (index i)
-		(match (nth lookup_keys i)
-			((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
-			(set_assoc index (nth lookup_keys i) (nth params i))
-			((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
-			(set_assoc index (nth lookup_keys i) (nth params i))
-			_ index)) '())))
+(define scalar_query_probe_param_index_add (lambda (index key param)
+	(match key
+		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+		(set_assoc index key param)
+		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+		(set_assoc index key param)
+		_ index)))
+
+(define scalar_query_probe_param_index (lambda (lookup_keys logical_lookup_keys params)
+	(begin
+		(define logical_keys (if (equal? (count lookup_keys) (count logical_lookup_keys))
+			logical_lookup_keys
+			lookup_keys))
+		(reduce (produceN (count lookup_keys)) (lambda (index i)
+			(scalar_query_probe_param_index_add
+				(scalar_query_probe_param_index_add index (nth lookup_keys i) (nth params i))
+				(nth logical_keys i)
+				(nth params i))) '()))))
 
 /* A query-probe lambda evaluates its outer lookup keys before entering nested
 stages. Replace inherited direct column references with those parameters so
-dependency preparation does not emit free outer-row symbols. */
+dependency preparation does not emit free outer-row symbols. Derived flattening
+may rename the live lookup while nested stages retain its logical predecessor;
+both names therefore bind to the same parameter. */
 (define rewrite_scalar_query_probe_params (lambda (index expr)
 	(match expr
 		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
@@ -8984,6 +8996,8 @@ dependency preparation does not emit free outer-row symbols. */
 		'(stage requested_col nested_stages _hoisted_stages prepare_stages inline_presence_stages) (begin
 			(define raw_keys (gs_keys stage))
 			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define logical_lookup_keys
+				(qassoc_get (gs_facts stage) (quote btw2025_lookup_keys) lookup_keys))
 			(define keys (if (empty_list? lookup_keys) '() raw_keys))
 			(if (not (equal? (count keys) (count lookup_keys)))
 				(neumann_fail "build_queryplan" "scalar query probe recipe key/domain mismatch")
@@ -8995,7 +9009,7 @@ dependency preparation does not emit free outer-row symbols. */
 			(define value_expr (nth (scalar_first_probe_parts ag) 0))
 			(define params (map (produceN (count keys)) (lambda (i)
 				(symbol (concat "__probe_key_" i)))))
-			(define param_index (scalar_query_probe_param_index lookup_keys params))
+			(define param_index (scalar_query_probe_param_index lookup_keys logical_lookup_keys params))
 			(define invariant_entries (query_invariant_probe_entries_for_stages nested_stages))
 			(define annotated_nested_lookup
 				(stage_lookup_with_query_invariant_probe_bindings nested_stages invariant_entries))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -484,14 +484,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(lambda (_e) true)) true
 		"physical preparation rejects a join tree that does not cover its source catalog")
 	(define probe_outer_column (list (quote get_column) "outer_row" true "id" true))
+	(define probe_logical_column (list (quote get_column) "derived_row" false "id" false))
 	(define probe_param (symbol "__probe_key_0"))
-	(define probe_param_index (scalar_query_probe_param_index (list probe_outer_column) (list probe_param)))
+	(define probe_param_index (scalar_query_probe_param_index
+		(list probe_outer_column) (list probe_logical_column) (list probe_param)))
 	(assert (equal?
 		(rewrite_scalar_query_probe_params probe_param_index probe_outer_column)
 		probe_param) true "scalar query probe binds a direct inherited column")
 	(assert (equal?
 		(rewrite_scalar_query_probe_params probe_param_index (list (quote stage-fixture) (list probe_outer_column)))
 		(list (quote stage-fixture) (list probe_param))) true "scalar query probe binds inherited columns throughout stage data")
+	(assert (equal?
+		(rewrite_scalar_query_probe_params probe_param_index probe_logical_column)
+		probe_param) true "scalar query probe binds pre-derived logical aliases")
 	(define canonical_group_sum (list (list (quote get_column) "g" false "amount" false) (quote +) 0))
 	(define canonical_group_count (list 1 (quote +) 0))
 	(define canonical_group_source (list "g" "memcp-tests" "group_values" false nil))

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -537,6 +537,53 @@ test_cases:
         - id: 2
           allowed: true
 
+  - name: "Derived scalar probe requalifies nested correlation keys"
+    sql: |
+      SELECT t.id, t.allowed
+      FROM (
+        SELECT
+          a.id,
+          ref.allowed
+        FROM trace_asset a
+        LEFT JOIN (
+          SELECT
+            b.id,
+            COALESCE((
+              SELECT (
+                EXISTS (
+                  SELECT TRUE
+                  FROM trace_global_access global_access
+                  WHERE global_access.actor_id = 7
+                    AND global_access.scope_id IS NULL
+                  LIMIT 1
+                )
+                AND EXISTS (
+                  SELECT TRUE
+                  FROM trace_share local_access
+                  WHERE local_access.box_id = b.id
+                    AND local_access.owner_id = 7
+                  LIMIT 1
+                )
+              )
+              FROM trace_host h
+              WHERE h.id = b.host_id
+              LIMIT 1
+            ), FALSE) AS allowed
+          FROM trace_box b
+        ) ref ON ref.id = a.id * 100
+        WHERE a.id IN (1, 2)
+      ) t
+      LEFT JOIN trace_box sorter ON sorter.id = t.id * 100
+      ORDER BY t.id
+      LIMIT 72
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          allowed: true
+        - id: 2
+          allowed: false
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_asset"
   - sql: "DROP TABLE IF EXISTS trace_ref_a"


### PR DESCRIPTION
## What

- bind both the current derived lookup alias and its original logical alias to the same scalar-probe parameter
- add a Scheme unit assertion for equivalent probe aliases
- add a YAML regression for a nested `EXISTS` inside a scalar probe projected through a derived `LEFT JOIN`

## Root cause

Derived-table flattening renames the live lookup keys of a scalar probe (for example from `b.id` to `ref.id`). Nested correlated stages can still retain the pre-derived logical reference. The physical scalar recipe binder indexed only the renamed lookup expression, so the nested `b.id` survived as a free symbol in the generated scan predicate. The query returned a false permission result even though both `EXISTS` branches were true.

The fix uses the already-recorded `btw2025_lookup_keys` equivalence data and maps both names to the existing probe parameter. It stays inside normal decorrelated group-stage lowering and adds no correlated/scalar fallback.

## Why tests missed it

The existing scalar representative tests cover direct correlated values. They did not combine all of these properties:

- a scalar probe inside a derived relation
- a nested correlated `EXISTS` that adds another lookup key
- flattening the derived relation through a `LEFT JOIN`
- consuming the projected scalar result in an outer query

The new YAML case failed before the fix with `false/false`; the expected result is `true/false`.

## Validation

- focused suite: 13/13 passed
- Scheme unit tests: 1207/1207 passed
- captured minimal application query: corrected from `false/false` to `true/false`
- full `make test` after rebasing onto current `master`: passed

`python3 tools/lint_scm.py` completed. Its `--check` mode still reports the repository's pre-existing negative-depth warnings in `queryplan.scm`, `rdf-parser.scm`, and `psql-parser.scm`.

Performance work is intentionally excluded.
