### PR TITLE
JIT nested planner lambdas without fallback

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1789,6 +1789,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(set jit_dynamic_many_callee (jit jit_dynamic_many_list_callee))
 	(assert (jit_dynamic_many_caller 6 7 8 9) '(6 7 8 9)
 		"jit: dynamic call follows rebinding to a native Scheme Proc")
+	(define jit_nested_maker (jit (lambda (offset)
+		(lambda (value) (+ value offset)))))
+	(define jit_nested_add7 (jit_nested_maker 7))
+	(assert (jit? jit_nested_add7) (jit-enabled?) "jit: captured nested lambda is compiled")
+	(assert (jit_nested_add7 5) 12 "jit: captured nested lambda reads its outer value")
 	(define jit_scan_filter (jit (lambda (value) (> value 1))))
 	(define jit_scan_map (jit (lambda (value) value)))
 	(define jit_scan_reduce (jit (lambda (total value) (+ total value))))
@@ -2903,6 +2908,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(lambda () (begin (sf_cm "get_or_compute" "retry" (lambda () (car (sf_calls "missing")))) false))
 		(lambda (e) true)) true "cachemap singleflight forwards producer panic")
 	(assert (sf_cm "get_or_compute" "retry" (lambda () 77)) 77 "cachemap singleflight retries after panic")
+
+	/* query_expr_alias_set is the planner JIT coverage target. Native compilation
+	is atomic, so a compiled descriptor means every expression in the function was
+	lowered without a whole-procedure fallback. Exercise representative match paths,
+	the nested reduce lambda, recursion, and both resolve_column_alias branches. */
+	(set resolve_column_alias (jit resolve_column_alias))
+	(set query_expr_alias_set (jit query_expr_alias_set))
+	(assert (jit? resolve_column_alias) (jit-enabled?) "jit coverage: resolve_column_alias is 100% native")
+	(assert (jit? query_expr_alias_set) (jit-enabled?) "jit coverage: query_expr_alias_set is 100% native")
+	(assert (query_expr_alias_set 'default (list 'get_column 'a 'x nil nil) '()) (list 'a true)
+		"jit coverage: symbol get_column match")
+	(assert (query_expr_alias_set 'default
+		(list '+ (list 'get_column 'a 'x nil nil) (list 'get_column nil 'y nil nil)) '())
+		(list 'a true 'default true)
+		"jit coverage: cons recursion and nested reduce lambda")
+	(assert (query_expr_alias_set 'default 42 (list 'existing true)) (list 'existing true)
+		"jit coverage: scalar fallback match")
 
 	(print "finished unit tests")
 	(print "test result: " (teststat "success") "/" (teststat "count"))

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -154,6 +154,9 @@ type JITEntryPoint struct {
 	// experimental pointer-producing path. Explicit (jit ...) may exercise such
 	// paths, but module import keeps the interpreter until they are proven safe.
 	AutoImportSafe bool
+	// RecursiveLambdas makes lambda values constructed by this native body
+	// compile their own body before they are returned or passed onward.
+	RecursiveLambdas bool
 }
 
 // Call keeps the entry point, embedded constant roots, and source arguments
@@ -423,6 +426,7 @@ type JITContext struct {
 	HiddenArgs        []JITHiddenArg
 	RuntimeEnv        Scmer
 	AutoImportSafe    bool
+	RecursiveLambdas  bool
 	NeedsStableArgs   bool
 	RegOwners         [16]*JITValueDesc // register → owner descriptor (nil = untracked)
 	// DynamicSP is the temporary distance below the static frame bottom. It
@@ -1375,6 +1379,10 @@ func jitBuildLambdaClosure(args ...Scmer) Scmer {
 	})
 }
 
+func jitBuildCompiledLambdaClosure(args ...Scmer) Scmer {
+	return jitCompile(jitBuildLambdaClosure(args...))
+}
+
 // GoFuncAddr returns the entry point address of a Go function value.
 func GoFuncAddr(fn interface{}) uint64 {
 	return uint64(reflect.ValueOf(fn).Pointer())
@@ -2269,6 +2277,14 @@ func init_jit() {
 // jitCompile compiles a Proc to a native function (tagFunc)
 // Already compiled functions (tagFunc, tagFuncEnv) are passed through unchanged
 func jitCompile(a ...Scmer) Scmer {
+	return jitCompileMode(true, a...)
+}
+
+func jitCompileForImport(value Scmer) Scmer {
+	return jitCompileMode(false, value)
+}
+
+func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 	if len(a) != 1 {
 		panic("jit: expects exactly 1 argument")
 	}
@@ -2309,7 +2325,7 @@ func jitCompile(a ...Scmer) Scmer {
 		for _, codeCap := range [...]int{16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024} {
 			ptr, arena, reservation := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena, reservation: reservation}
-			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs := jitCompileProcToExec(proc, buf)
+			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs := jitCompileProcToExec(proc, buf, recursiveLambdas)
 			arena.complete(reservation, buf.stackMaps)
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
@@ -2331,6 +2347,7 @@ func jitCompile(a ...Scmer) Scmer {
 					ConstRoots:        roots,
 					Proc:              sourceProc,
 					AutoImportSafe:    autoImportSafe && jitAutoImportSyntaxSafe(sourceProc.Body),
+					RecursiveLambdas:  recursiveLambdas,
 					NeedsStableArgs:   needsStableArgs,
 				}
 				runtime.SetFinalizer(jep, func(jep *JITEntryPoint) {

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -29,6 +29,23 @@ import (
 
 var jitCodeOverflowPanic = &struct{}{}
 
+func jitCapturedEnv(en *Env) *JITEnv {
+	if en == nil || en == &Globalenv {
+		return nil
+	}
+	out := &JITEnv{Outer: jitCapturedEnv(en.Outer)}
+	if len(en.VarsNumbered) != 0 {
+		out.Numbered = make([]JITValueDesc, len(en.VarsNumbered))
+		for i, value := range en.VarsNumbered {
+			out.Numbered[i] = JITValueDesc{Loc: LocImm, Type: value.GetTag(), Imm: value}
+		}
+	}
+	if len(out.Numbered) == 0 && out.Outer == nil {
+		return nil
+	}
+	return out
+}
+
 // Keep the unwind marker above the register-argument spill area used by Go
 // callees. MemCP's JIT call bridge supports at most nine ABI words (72 bytes).
 const jitGoSpillBytes = uintptr(128)
@@ -45,7 +62,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 	const defaultCodeBufSize = 16 * 1024
 	ptr, arena, reservation := globalJITPool.Alloc(defaultCodeBufSize)
 	buf := &execBuf{ptr: ptr, n: defaultCodeBufSize, arena: arena, reservation: reservation}
-	codeLen, roots, _, _, _, _, _ := jitCompileProcToExec(proc, buf)
+	codeLen, roots, _, _, _, _, _ := jitCompileProcToExec(proc, buf, true)
 	arena.complete(reservation, buf.stackMaps)
 	if codeLen == 0 {
 		return nil, nil
@@ -58,7 +75,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 // jitCompileProcToExec compiles a Proc body directly into writable executable memory.
 // Returns code length, GC roots, an overflow flag, and whether the call boundary
 // must provide a fresh variadic array that becomes the owned list result.
-func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg, bool, bool) {
+func jitCompileProcToExec(proc *Proc, buf *execBuf, recursiveLambdas bool) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg, bool, bool) {
 	body := proc.Body
 	if body.GetTag() == tagSourceInfo {
 		si := body.SourceInfo()
@@ -72,12 +89,12 @@ func jitCompileProcToExec(proc *Proc, buf *execBuf) (int, []unsafe.Pointer, bool
 		}
 		body = si.value
 	}
-	return jitCompileExprBodyToExec(proc, body, proc.NumVars, buf)
+	return jitCompileExprBodyToExec(proc, body, proc.NumVars, buf, recursiveLambdas)
 }
 
 // jitCompileExprBodyToExec compiles a Scheme expression body into a writable
 // executable buffer using Declaration.JITEmit callbacks.
-func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg, autoImportSafe bool, needsStableArgs bool) {
+func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf, recursiveLambdas bool) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg, autoImportSafe bool, needsStableArgs bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			if r == jitCodeOverflowPanic {
@@ -106,16 +123,17 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 		inputArgCount = len(proc.Params.Slice())
 	}
 	ctx := &JITContext{
-		Ptr:            buf.ptr,
-		Start:          buf.ptr,
-		End:            unsafe.Add(buf.ptr, buf.n),
-		FreeRegs:       freeRegs,
-		AllRegs:        freeRegs,
-		SliceBase:      RegR12,
-		InputArgCount:  inputArgCount,
-		LocalSlotCount: numVars,
-		AutoImportSafe: true,
-		Arena:          buf.arena,
+		Ptr:              buf.ptr,
+		Start:            buf.ptr,
+		End:              unsafe.Add(buf.ptr, buf.n),
+		FreeRegs:         freeRegs,
+		AllRegs:          freeRegs,
+		SliceBase:        RegR12,
+		InputArgCount:    inputArgCount,
+		LocalSlotCount:   numVars,
+		AutoImportSafe:   true,
+		RecursiveLambdas: recursiveLambdas,
+		Arena:            buf.arena,
 	}
 	runtimeEnv := &Globalenv
 	if proc != nil && proc.En != nil {
@@ -171,6 +189,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 	// Map lambda parameters to local stack slots so symbol lookup remains correct
 	// even when the optimizer did not rewrite body symbols to NthLocalVar.
 	if proc != nil {
+		captured := jitCapturedEnv(proc.En)
 		var vars map[Symbol]JITValueDesc
 		putVar := func(sym Symbol, index int) {
 			if vars == nil {
@@ -199,8 +218,8 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf)
 				putVar(proc.Params.Symbol(), 0)
 			}
 		}
-		if len(vars) > 0 {
-			ctx.Env = &JITEnv{Vars: vars}
+		if len(vars) > 0 || captured != nil {
+			ctx.Env = &JITEnv{Vars: vars, Outer: captured}
 		}
 	}
 
@@ -367,18 +386,38 @@ func jitResolveRuntimeSymbol(envValue, symbol Scmer) Scmer {
 }
 
 func jitApplyCallable0(callable, envValue Scmer) Scmer {
+	if callable.GetTag() == tagProc {
+		if proc := callable.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call()
+		}
+	}
 	return ApplyEx(callable, nil, envValue.Any().(*Env))
 }
 
 func jitApplyCallable1(callable, envValue, arg0 Scmer) Scmer {
+	if callable.GetTag() == tagProc {
+		if proc := callable.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call(arg0)
+		}
+	}
 	return ApplyEx(callable, []Scmer{arg0}, envValue.Any().(*Env))
 }
 
 func jitApplyCallable2(callable, envValue, arg0, arg1 Scmer) Scmer {
+	if callable.GetTag() == tagProc {
+		if proc := callable.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call(arg0, arg1)
+		}
+	}
 	return ApplyEx(callable, []Scmer{arg0, arg1}, envValue.Any().(*Env))
 }
 
 func jitApplyCallableSlice(callable, envValue Scmer, args []Scmer) Scmer {
+	if callable.GetTag() == tagProc {
+		if proc := callable.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call(args...)
+		}
+	}
 	return ApplyEx(callable, args, envValue.Any().(*Env))
 }
 
@@ -1031,7 +1070,7 @@ func jitCompileMatchPattern(ctx *JITContext, value JITValueDesc, pattern Scmer, 
 		if len(p) == 0 {
 			panic("jit: empty match pattern")
 		}
-		if _, direct := scmerSymbolName(p[0]); !direct {
+		if _, direct := symbolName(p[0]); !direct {
 			if nested, ok := scmerAsSlice(p[0]); ok && len(nested) > 0 {
 				if head, ok := scmerSymbolName(nested[0]); ok && (head == "symbol" || head == "quote") {
 					return jitMatchFixedList(ctx, value, p, env, failLabel)
@@ -1039,7 +1078,7 @@ func jitCompileMatchPattern(ctx *JITContext, value JITValueDesc, pattern Scmer, 
 			}
 			panic("jit: unsupported nested match pattern")
 		}
-		name, _ := scmerSymbolName(p[0])
+		name, _ := symbolName(p[0])
 		switch name {
 		case "eval":
 			if len(p) != 2 {
@@ -1130,11 +1169,13 @@ func jitCompileMatch(ctx *JITContext, list []Scmer, sliceBase Reg, result JITVal
 	value = jitMatchStableValue(ctx, value)
 	target := jitEnsureResultPair(ctx, result)
 	endLabel := ctx.ReserveLabel()
+	branchState := ctx.SnapshotAllocState()
 	hasBranch := false
 	terminated := false
 	baseEnv := ctx.Env
 	i := 2
 	for i+1 < len(list) {
+		ctx.RestoreAllocState(branchState)
 		nextLabel := ctx.ReserveLabel()
 		branchEnv := jitMatchBranchEnv(baseEnv)
 		outcome := jitCompileMatchPattern(ctx, value, list[i], branchEnv, nextLabel)
@@ -1147,6 +1188,7 @@ func jitCompileMatch(ctx *JITContext, list []Scmer, sliceBase Reg, result JITVal
 			hasBranch = true
 		}
 		ctx.MarkLabel(nextLabel)
+		ctx.RestoreAllocState(branchState)
 		i += 2
 		if outcome.always {
 			terminated = true
@@ -1155,6 +1197,7 @@ func jitCompileMatch(ctx *JITContext, list []Scmer, sliceBase Reg, result JITVal
 	}
 	ctx.Env = baseEnv
 	if !terminated {
+		ctx.RestoreAllocState(branchState)
 		var fallback JITValueDesc
 		if i < len(list) {
 			fallback = jitCompileExpr(ctx, list[i], sliceBase, target)
@@ -1505,12 +1548,7 @@ func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, ar
 			slot := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: slotOff}
 			v := jitCompileExpr(ctx, argExprs[i], sliceBase, slot)
 			if !(v.Loc == LocStackPair && v.MemPtr == 0 && v.StackOff == slotOff) {
-				tmp := JITValueDesc{
-					Loc:  LocRegPair,
-					Type: JITTypeUnknown,
-					Reg:  ctx.AllocReg(),
-					Reg2: ctx.AllocReg(),
-				}
+				tmp := jitAllocTrackedPair(ctx, JITTypeUnknown)
 				_ = jitPlaceIntoPair(ctx, &v, tmp)
 				ctx.EmitStoreRegMem(tmp.Reg, RegRSP, slotOff)
 				ctx.EmitStoreRegMem(tmp.Reg2, RegRSP, slotOff+8)
@@ -1520,27 +1558,13 @@ func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, ar
 			ctx.FreeDesc(&v)
 		}
 		// argslice: ptr + len (cap = len inside EmitGoCallVariadic).
-		argsSlice = JITValueDesc{
-			Loc:  LocRegPair,
-			Type: JITTypeUnknown,
-			Reg:  ctx.AllocReg(),
-			Reg2: ctx.AllocReg(),
-		}
+		argsSlice = jitAllocTrackedPair(ctx, JITTypeUnknown)
 		ctx.EmitMovRegReg(argsSlice.Reg, RegRSP)
 		ctx.EmitMovRegImm64(argsSlice.Reg2, uint64(argc))
-		ctx.BindReg(argsSlice.Reg, &argsSlice)
-		ctx.BindReg(argsSlice.Reg2, &argsSlice)
 	} else {
-		argsSlice = JITValueDesc{
-			Loc:  LocRegPair,
-			Type: JITTypeUnknown,
-			Reg:  ctx.AllocReg(),
-			Reg2: ctx.AllocReg(),
-		}
+		argsSlice = jitAllocTrackedPair(ctx, JITTypeUnknown)
 		ctx.EmitMovRegImm64(argsSlice.Reg, 0)
 		ctx.EmitMovRegImm64(argsSlice.Reg2, 0)
-		ctx.BindReg(argsSlice.Reg, &argsSlice)
-		ctx.BindReg(argsSlice.Reg2, &argsSlice)
 	}
 
 	out := ctx.EmitGoCallVariadic(fn, argsSlice, result)
@@ -2219,7 +2243,11 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 				argExprs = append(argExprs, key)
 			}
 
-			return jitEmitGoVariadicCallFromExprs(ctx, jitBuildLambdaClosure, argExprs, sliceBase, result)
+			builder := jitBuildLambdaClosure
+			if ctx.RecursiveLambdas {
+				builder = jitBuildCompiledLambdaClosure
+			}
+			return jitEmitGoVariadicCallFromExprs(ctx, builder, argExprs, sliceBase, result)
 		case "error":
 			// Keep one real Go callback in the experimental JIT so panic/recover is
 			// exercised across the registered JIT frame. More complex variadic

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -69,7 +69,7 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 		code = Optimize(code, en, nil)
 		expression = Eval(code, en)
 		if compileProcedures && expression.GetTag() == tagProc {
-			compiled := jitCompile(expression)
+			compiled := jitCompileForImport(expression)
 			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil && compiled.Proc().Compiled.AutoImportSafe {
 				expression = compiled
 				if sym, ok := topLevelDefinitionSymbol(code); ok {


### PR DESCRIPTION
## What changed

- recursively JIT-compile nested lambda closures created by an explicitly JIT-compiled procedure, including numbered outer captures
- dispatch dynamically resolved compiled Scheme procedures directly to their JIT entry point for zero, one, two, and variadic argument calls
- fix nested `match` pattern lowering and restore allocator state between match branches
- fix tracked-register lifetime in variadic closure construction
- add coverage tests around the selected planner function `query_expr_alias_set`

## Why

`query_expr_alias_set` combines recursive calls, nested `reduce` lambdas, fixed-list `match` patterns, and planner helper calls. Previously its `match` form fell back during compilation, nested closures remained interpreted, and dynamically resolved Proc calls always went through the generic Apply path.

The JIT remains conservative for automatic module imports. Explicit `(jit ...)` now recursively compiles nested closures, while import-time compilation does not silently activate experimental nested code in unrelated optimizer functions.

## Validation

- `make test` — passed; 56,134/56,134 Scheme source nodes covered
- patched Go compiler (`go1.26.6-X:jit`) build and Scheme startup tests
- `query_expr_alias_set` JIT A/B: master 0%, branch 100% atomic native coverage
- nested captured lambda returns a JIT procedure and preserves its outer value
- SQL `EXPLAIN COMPILE` A/B, 10 runs each, for:
  `SELECT id FROM jit_ab WHERE val BETWEEN 50 AND 150 ORDER BY id LIMIT 5`

The current master checkout has two pre-existing optimizer assertions (`merge_unique` ownership and dynamic reducer validation) that also reproduce unchanged at commit `d7452616a`; all tests added by this PR pass in both normal and patched-JIT builds.
