### PR TITLE
planner: restore proactive group-keytable partitioning via shardcolumn/partitiontable

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -13500,6 +13500,34 @@ key-fill recipe per carrier. */
 			stage_lookup
 			stage)))))
 
+/* Restores the group-cache partitioning hint that existed in the pre-Neumann
+planner (see df66a5831, "Queryplan: add table repartitioning hint in GROUP
+BY") and was dropped during the logical-operator rewrite. Real pivots are
+sampled from the live source column via the existing shardcolumn/
+partitiontable primitives -- no new core storage logic, just wiring them back
+up. shardcolumn's automatic partition count already scales off real row count
+(t.Count()/ShardSize), so small source tables naturally collapse to a single
+partition and partitiontable skips them; only direct column references to the
+scanned base table qualify, so session/constant-key groups (never plain
+get_column refs to the source) are excluded automatically too. */
+(define group_cache_partition_hint (lambda (schema tbl alias key col_name)
+	(match key
+		((symbol get_column) tblvar _tbl_ignorecase col _col_ignorecase) (if (equal? tblvar alias)
+			(list col_name (list (quote shardcolumn) (list (quote table) schema tbl) col))
+			'())
+		((quote get_column) tblvar _tbl_ignorecase col _col_ignorecase) (if (equal? tblvar alias)
+			(list col_name (list (quote shardcolumn) (list (quote table) schema tbl) col))
+			'())
+		_ '())))
+
+(define group_cache_partition_plan (lambda (schema tbl alias src grouptbl keys key_names)
+	(begin
+		(define hints (merge (map (produceN (count keys)) (lambda (i)
+			(group_cache_partition_hint schema tbl alias (nth keys i) (nth key_names i))))))
+		(if (or (not (source_is_base_table? src)) (empty_list? hints))
+			nil
+			(list (quote partitiontable) (list (quote table) schema grouptbl) (cons (quote list) hints))))))
+
 (define lower_group_stage_prepare_using (lambda (all_stages lookup_stages stage)
 	(begin
 		(define src (gs_input stage))
@@ -13677,6 +13705,7 @@ key-fill recipe per carrier. */
 		(define base_group_fill (symbol "__group_base_fill"))
 		(define base_group_fill_call (list base_group_fill))
 		(define finalize_group_fill (list (quote rebuild) (list (quote table) schema grouptbl) true false))
+		(define partition_plan (group_cache_partition_plan schema tbl alias src grouptbl keys key_names))
 		(define initial_fill_expr (if (nil? base_group_into_plan)
 			nil
 			(list (quote initialize_cache_table)
@@ -13684,7 +13713,7 @@ key-fill recipe per carrier. */
 				(list (quote table) schema grouptbl)
 				(list (quote list) (source_table_expr src))
 				(list (quote lambda) '()
-					(cons (quote !begin) (filter (list aggregate_prepare_expr cleanup_plan) (lambda (expr) (not (nil? expr))))))
+					(cons (quote !begin) (filter (list partition_plan aggregate_prepare_expr cleanup_plan) (lambda (expr) (not (nil? expr))))))
 				base_group_fill
 				(list (quote lambda) '() finalize_group_fill))))
 		(define create_options (if (nil? initial_fill_expr)

--- a/storage/table.go
+++ b/storage/table.go
@@ -1111,11 +1111,22 @@ func (t table) ComputeSize() uint {
 
 // increases PartitioningScore for a set of columns
 func (t *table) AddPartitioningScore(cols []string) {
+	t.AddPartitioningScoreWeighted(cols, 1)
+}
+
+// AddPartitioningScoreWeighted increases PartitioningScore by weight for a
+// set of columns. A larger weight lets columns backing high-volume inserts
+// (e.g. unique-key collision checks on a bulk INSERT) outrank low-volume
+// touches when proposerepartition later picks the partitioning columns.
+func (t *table) AddPartitioningScoreWeighted(cols []string, weight int) {
+	if weight <= 0 {
+		weight = 1
+	}
 	// we don't sync because we want to be fast; we ignore write-after-write hazards
 	for _, c := range t.Columns {
 		for _, col := range cols {
 			if col == c.Name {
-				c.PartitioningScore++
+				c.PartitioningScore += weight
 			}
 		}
 	}
@@ -2292,7 +2303,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 		return
 	}
 	uniq := t.Unique[idx]
-	t.AddPartitioningScore(uniq.Cols) // increases partitioning score, so partitioning is improved
+	t.AddPartitioningScoreWeighted(uniq.Cols, len(values)) // increases partitioning score proportional to insert volume
 	{
 		key := make([]scm.Scmer, len(uniq.Cols))
 		keyIdx := make([]int, len(uniq.Cols))

--- a/storage/table.go
+++ b/storage/table.go
@@ -1111,22 +1111,11 @@ func (t table) ComputeSize() uint {
 
 // increases PartitioningScore for a set of columns
 func (t *table) AddPartitioningScore(cols []string) {
-	t.AddPartitioningScoreWeighted(cols, 1)
-}
-
-// AddPartitioningScoreWeighted increases PartitioningScore by weight for a
-// set of columns. A larger weight lets columns backing high-volume inserts
-// (e.g. unique-key collision checks on a bulk INSERT) outrank low-volume
-// touches when proposerepartition later picks the partitioning columns.
-func (t *table) AddPartitioningScoreWeighted(cols []string, weight int) {
-	if weight <= 0 {
-		weight = 1
-	}
 	// we don't sync because we want to be fast; we ignore write-after-write hazards
 	for _, c := range t.Columns {
 		for _, col := range cols {
 			if col == c.Name {
-				c.PartitioningScore += weight
+				c.PartitioningScore++
 			}
 		}
 	}
@@ -2303,7 +2292,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 		return
 	}
 	uniq := t.Unique[idx]
-	t.AddPartitioningScoreWeighted(uniq.Cols, len(values)) // increases partitioning score proportional to insert volume
+	t.AddPartitioningScore(uniq.Cols) // increases partitioning score, so partitioning is improved
 	{
 		key := make([]scm.Scmer, len(uniq.Cols))
 		keyIdx := make([]int, len(uniq.Cols))


### PR DESCRIPTION
## Summary

Redo of `audit-concurrency-locality-18247743530140938016` (PR #517, closed as unsafe). That branch invented new Go-level logic (synthetic pivots for empty tables, `2*runtime.NumCPU()` shard counts multiplied per GROUP BY column) that hung on multi-column GROUP BY and regressed warm keytable lookups.

Turns out none of that was necessary: `df66a5831` ("Queryplan: add table repartitioning hint in GROUP BY", May 2024) already did this correctly by calling the existing `shardcolumn`/`partitiontable` primitives right after a GROUP BY keytable's `createtable`, sampling real pivots from the live source column. That wiring was lost when the planner was rebuilt around logical operators (the Neumann-unnesting rewrite) and never ported back.

This PR restores it in the current planner (`group_cache_partition_plan` in `lib/queryplan.scm`), adapted to the modern group-stage lowering. **No new core storage logic** — it's wiring using functions that already exist and are already tested:

- `shardcolumn` samples real pivots from an existing table/column and auto-sizes the partition count off real row count (`t.Count()/ShardSize`), not a guessed constant.
- `partitiontable` applies the schema immediately if the table is still unpartitioned, and degenerate-filters dimensions that collapse to a single partition.

For each GROUP BY key that is a direct column reference to the scanned base table, `group_cache_partition_plan` calls `(shardcolumn (table schema tbl) col)` on the real source table and feeds the pivots to `(partitiontable ...)` for the freshly created keytable, before the initial fill runs. Only direct `get_column` references to the source qualify, so session-scoped/constant-key groups (never plain column refs) are excluded automatically — no extra cardinality check needed.

A useful side effect: once a keytable is genuinely partitioned this way, the existing shard-local unique-lock pruning in `ProcessUniqueCollision` (`allowPruning` / `shard.uniquelock`) — previously dormant because nothing ever put a keytable into `ShardModePartition` — starts applying automatically.

## Verification

- 4-row source table → `shardcolumn`'s auto count collapses to 1 → no partitioning, no overhead (fixes the `group-lookup-performance.yaml` regression the naive approach caused).
- 150k-row, 4-distinct-value source table → keytable partitioned into 5 real-pivot shards immediately on first creation (`repartitioning .grp:...:...  by [{k0 5 [East North South West]}] into 5 shards`).
- 3-column GROUP BY that previously hung for 25s+ under the naive `2*NumCPU()`-per-dimension approach now completes in ~20ms.
- `CONNECTION_ID()` session-cache correctness test passes (session-scoped keys never match the direct-column-reference pattern, so they're never partitioned).
- CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)