### PR TITLE
fix: log original panic stack in WithAutocommit before re-panic

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -671,7 +671,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 				t.ddlMu.RUnlock()
 				if r := recover(); r != nil {
 					errmsg := fmt.Sprintf("rebuild failed for table %s.%s: %v", db.Name, t.Name, r)
-					fmt.Println("error:", errmsg)
+					scm.PrintError(errmsg)
 					errMu.Lock()
 					rebuildErrors = append(rebuildErrors, errmsg)
 					errMu.Unlock()

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -784,6 +784,10 @@ func WithAutocommit(sessionFn func(...scm.Scmer) scm.Scmer, fn scm.Scmer) scm.Sc
 		defer func() {
 			if r := recover(); r != nil {
 				panicVal = r
+				// the stack is lost once we re-panic panicVal below (it gets
+				// re-wrapped by the Scheme error layer), so log it here while
+				// we still have the original panic's stack trace.
+				scm.PrintError(r)
 			}
 		}()
 		result = scm.Apply(fn)


### PR DESCRIPTION
## Summary
- `WithAutocommit` recovers a panic, rolls back the transaction, and re-panics the raw value so the caller's error handler still fires — but `panic()` starts a fresh stack, so by the time the outer HTTP/MySQL handler logs it, the original crash site is gone and only generic handler frames survive.
- Logs the panic with `scm.PrintError` right at the `recover()` site in `storage/transaction.go`, while the original stack is still intact.

Found while investigating a one-off `index out of range [-1]` crash in production where the logged trace only showed generic HTTP handler frames, not the actual faulting code. This is purely additive logging — no behavior change to the panic/rollback/re-panic flow.

## Test plan
- [x] `go build` succeeds, `gofmt -l` clean
- [x] Local repro: triggered a panic (JSON marshal of `+Inf`) and confirmed the log now contains the full original stack, including the exact `storage.WithAutocommit` frame where the panic was caught, not just outer HTTP handler frames
- [x] Verified startup unit tests pass (1206/1206)
- [ ] CI full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)