### PR TITLE
fix: cap rANS chunk size to prevent uint16 jumpL2 overflow in StorageEnum

### DIFF
--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -50,6 +50,14 @@ const enumBitMask = ^uint64(0) >> (64 - enumBitShift) // 0xFF
 const enumBitModulo = uint64(1) << enumBitShift       // 256
 const enumMaxSymbols = 8
 
+// enumMaxChunkElems bounds how many elements a single rANS chunk may hold.
+// jumpL2 cumulative counts are stored as uint16, so a chunk (or a jumpL1
+// group of chunks) must never account for more than 65535 elements. Highly
+// skewed columns (near-zero entropy) can otherwise pack far more than 65535
+// elements into one 64-bit buffer before it ever overflows on bit-width
+// alone, silently wrapping jumpL2 and corrupting random access.
+const enumMaxChunkElems = 65535
+
 type StorageEnum struct {
 	// rANS coded payload
 	data []uint64
@@ -260,7 +268,7 @@ func (s *StorageEnum) finish() {
 		inv := s.invWidths[symIdx]
 
 		bufferx, rest := enumFastDivMod(buffer, width, inv)
-		if bufferx > ^uint64(0)>>enumBitShift {
+		if bufferx > ^uint64(0)>>enumBitShift || bufferlen >= enumMaxChunkElems {
 			s.data = append(s.data, buffer)
 			chunkSizes = append(chunkSizes, bufferlen)
 			buffer = 0
@@ -445,6 +453,15 @@ func (s *StorageEnum) findChunk(idx int) int {
 		} else {
 			hi = mid
 		}
+	}
+	if lo >= len(s.jumpL2) && len(s.jumpL2) > 0 && idx < int(s.count) {
+		// jumpL2 cumulative counts are uint16 and can wrap for files written
+		// by the pre-enumMaxChunkElems encoder, which let one rANS chunk
+		// (typically for a near-constant, low-entropy column) hold more than
+		// 65535 elements. idx is still a genuinely valid row per the
+		// untruncated s.count, so the search "falling off the end" means the
+		// row lives in the last real chunk, not that it's out of range.
+		return len(s.jumpL2) - 1
 	}
 	return lo
 }

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -147,6 +147,22 @@ func (s *StorageEnum) jumpCum(j int) int {
 	return int(base) + int(s.jumpL2[j])
 }
 
+// chunkEnd returns the element count at which chunk j ends. This is normally
+// just jumpCum(j), but for the last chunk in a file written by the
+// pre-enumMaxChunkElems encoder, jumpCum can under-report due to uint16
+// wraparound (see enumMaxChunkElems and findChunk). The last chunk always
+// truly extends to s.count, so callers that cache a chunk boundary (e.g.
+// GetValueCached's sequential fast path) must use this instead of jumpCum
+// directly, or they silently fall back to the slow path for every remaining
+// element instead of just once.
+func (s *StorageEnum) chunkEnd(j int) int {
+	end := s.jumpCum(j)
+	if j == len(s.jumpL2)-1 && end < int(s.count) {
+		return int(s.count)
+	}
+	return end
+}
+
 func (s *StorageEnum) decodeOne(buffer uint64) (scm.Scmer, uint64) {
 	slice := buffer & enumBitMask
 	symIdx := s.decodeSymbol(slice)
@@ -382,7 +398,7 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 	idx := int(i)
 
 	if c.valid && c.fwdChunk < len(s.jumpL2) && c.fwdChunk < len(s.data) {
-		chunkEnd := s.jumpCum(c.fwdChunk)
+		chunkEnd := s.chunkEnd(c.fwdChunk)
 		// fast path: index is ahead of cache position in same chunk
 		if idx >= c.start+c.pos && idx < chunkEnd {
 			buffer := c.buf
@@ -398,7 +414,7 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 		// next chunk fast path
 		if idx >= chunkEnd {
 			nextFwd := c.fwdChunk + 1
-			if nextFwd < len(s.jumpL2) && nextFwd < len(s.data) && idx < s.jumpCum(nextFwd) {
+			if nextFwd < len(s.jumpL2) && nextFwd < len(s.data) && idx < s.chunkEnd(nextFwd) {
 				dataIdx := len(s.data) - 1 - nextFwd
 				buffer := s.data[dataIdx]
 				posInChunk := idx - chunkEnd

--- a/tests/storage/formats/storage-enum.yaml
+++ b/tests/storage/formats/storage-enum.yaml
@@ -938,6 +938,90 @@ test_cases:
       data:
         - cnt: 3
 
+  # === Skewed column exceeding 65535 elements in one rANS chunk ===
+  # Regression test: a column with extremely low entropy (almost every row
+  # shares one value, only a couple of rows differ) can pack far more than
+  # 65535 elements into a single rANS chunk before the bit-buffer overflows
+  # on bit-width alone. The jumpL2 random-access index is stored as uint16
+  # per chunk; without an explicit element-count cap in finish(), such a
+  # chunk silently wraps that index, and any row past the wrapped (too
+  # small) cumulative count panics with "index out of range [-1]".
+  - name: "Create overflow-chunk table"
+    sql: "CREATE TABLE se_overflow_chunk (id INT, note VARCHAR(20))"
+    expect:
+      rows: 0
+
+  - name: "Insert 70000 rows, 2 rare values among a near-constant majority"
+    scm: |
+      (begin
+        (set b (map (produceN 70000) (lambda (i)
+          (if (equal? i 1) (list i "x")
+            (if (equal? i 2) (list i "yz")
+              (list i ""))))))
+        (insert (table "memcp-tests" "se_overflow_chunk") '("id" "note") b)
+        70000)
+
+  - name: "Overflow: count total before compression"
+    sql: "SELECT COUNT(*) AS cnt FROM se_overflow_chunk"
+    expect:
+      rows: 1
+      data:
+        - cnt: 70000
+
+  - name: "Overflow: SHUTDOWN to trigger compression"
+    sql: "SHUTDOWN"
+    expect:
+      rows: 0
+
+  - name: "Overflow: count total after compression"
+    sql: "SELECT COUNT(*) AS cnt FROM se_overflow_chunk"
+    expect:
+      rows: 1
+      data:
+        - cnt: 70000
+
+  - name: "Overflow: COUNT(note) forces a full sequential scan past 65535"
+    sql: "SELECT COUNT(note) AS cnt FROM se_overflow_chunk"
+    expect:
+      rows: 1
+      data:
+        - cnt: 70000
+
+  - name: "Overflow: verify rare value at id=1"
+    sql: "SELECT note FROM se_overflow_chunk WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - note: "x"
+
+  - name: "Overflow: verify rare value at id=2"
+    sql: "SELECT note FROM se_overflow_chunk WHERE id = 2"
+    expect:
+      rows: 1
+      data:
+        - note: "yz"
+
+  - name: "Overflow: verify majority value near the wrapped uint16 boundary"
+    sql: "SELECT note FROM se_overflow_chunk WHERE id = 9960"
+    expect:
+      rows: 1
+      data:
+        - note: ""
+
+  - name: "Overflow: verify majority value well past the wrapped boundary"
+    sql: "SELECT note FROM se_overflow_chunk WHERE id = 69999"
+    expect:
+      rows: 1
+      data:
+        - note: ""
+
+  - name: "Overflow: ORDER BY + LIMIT scan past the wrapped boundary"
+    sql: "SELECT note FROM se_overflow_chunk ORDER BY id DESC LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - note: ""
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS se_bool"
   - sql: "DROP TABLE IF EXISTS se_status"
@@ -946,3 +1030,4 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS se_single"
   - sql: "DROP TABLE IF EXISTS se_max8"
   - sql: "DROP TABLE IF EXISTS se_constish"
+  - sql: "DROP TABLE IF EXISTS se_overflow_chunk"


### PR DESCRIPTION
## Summary
- Root-cause fix for a production crash: `runtime error: index out of range [-1]` on SELECT/COUNT/ORDER BY queries touching a low-cardinality, extremely skewed (near-zero-entropy) column — e.g. a VARCHAR column where ~all rows share one value and only a couple of rows differ.
- `StorageEnum.finish()` (rANS entropy coding, `storage/storage-enum.go`) only flushed a chunk on rANS bit-buffer overflow. For low-entropy columns, a single 64-bit chunk can hold far more than 65535 elements before that ever happens. The `jumpL2` random-access index stores each chunk's cumulative element count as `uint16`, so once a chunk exceeds 65535 elements, the cast silently wraps, under-reporting the chunk's true length.
- `findChunk()` then returns "not found" for any row index at/beyond the wrapped count, and `GetValue`/`GetValueCached` compute `dataIdx = len(s.data)-1-numChunks = -1`, panicking on the next slice access.

## Fix (two-sided)
1. `finish()` now also flushes a chunk once it reaches `enumMaxChunkElems` (65535), so future encodes can never produce an overflowing chunk.
2. `findChunk()` falls back to the last real chunk when the binary search runs off the end but `idx` is still within the untruncated (`uint64`) `s.count`. This lets *already-corrupted* files written by the old encoder be read correctly again — including by a subsequent rebuild, which is what actually re-encodes them within the new bound.

No on-disk format change: encoding into more, smaller chunks doesn't alter `Serialize`/`Deserialize`'s layout, which already sizes `data`/`jumpL1`/`jumpL2` dynamically from stored lengths.

## Test plan
- [x] Added `tests/storage/formats/storage-enum.yaml` regression case: 70000 rows, 2 rare values among a near-constant majority, forcing a single rANS chunk past 65535 elements. Verified this new case (and the full 140-case suite) **fails** with `index out of range [-1]` on the pre-fix code, and **passes** with the fix.
- [x] `go build` succeeds, `gofmt -l` clean.
- [x] Verified against the original production repro (real crashing queries: `COUNT(col)`, point lookup, `ORDER BY ... LIMIT`, and the full original application query) — all now succeed.
- [ ] CI full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)