### PR TITLE
planner: real probe_work_rows for unlimited dataset reduces

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6642,6 +6642,19 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(planner_table_row_count (source_schema src) (source_relation src))
 		nil)))
 
+/* A driving source's own row count, scaled by how selective the residual
+condition is against it. Used wherever a nested probe's call count needs a
+real estimate instead of an unconditional "unknown": an unbounded scan still
+has a knowable multiplicity (its source's row count), it just isn't capped
+by a LIMIT or a unique point lookup. Falls back to `fallback` only when the
+source itself has no known row count (not a base table). */
+(define planner_row_count_after_selectivity (lambda (src sources default_alias condition fallback)
+	(begin
+		(define source_rows (planner_source_row_count src))
+		(if (number? source_rows)
+			(max 1 (* source_rows (join_optimizer_expr_selectivity sources default_alias condition)))
+			fallback))))
+
 (define planner_source_row_estimate (lambda (src)
 	(begin
 		(define rows (planner_source_row_count src))
@@ -9246,12 +9259,9 @@ both names therefore bind to the same parameter. */
 			true)
 		(define key_expr (query_block_first_expr prepared))
 		(define condition (combine_where (qb_where prepared) (source_join_expr src)))
-		(define source_rows (planner_source_row_count src))
 		(define probe_term (list (quote equal??) key_expr probe))
-		(define probe_work_rows (if (number? source_rows)
-			(max 1 (* source_rows
-				(join_optimizer_expr_selectivity (list src) (source_alias src) probe_term)))
-			1))
+		(define probe_work_rows (planner_row_count_after_selectivity
+			src (list src) (source_alias src) probe_term 1))
 		(define filtercols (merge_unique (list
 			(extract_columns_for_alias src condition)
 			(extract_columns_for_alias src key_expr))))
@@ -16456,10 +16466,15 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 			(source_join_exprs scan_sources))))
 		/* Dataset fields are mapped only after the native window accepts a row.
 		Propagate that bound so nested scalar probes can compare direct work with
-		the cost of preparing their complete dependent carriers. */
+		the cost of preparing their complete dependent carriers. An unlimited
+		reduce (e.g. a bare COUNT(*)) has no LIMIT window and no unique point
+		lookup to bound it, but its call count is still knowable: the driving
+		source's own row count, scaled by the residual condition's selectivity. */
 		(define projection_probe_work_rows (if (query_limit_active? (qb_offset block) (qb_limit block))
 			(coalesceNil (probe_limit_work_rows (qb_limit block)) 0)
-			(if (probe_context_unique_point? scan_sources first_alias final_condition) 1 nil)))
+			(if (probe_context_unique_point? scan_sources first_alias final_condition) 1
+				(planner_row_count_after_selectivity
+					driver_source scan_sources first_alias final_condition nil))))
 		(if direct_order_safe
 			(begin
 				(define row_expr (cons row_mapper (map field_exprs (lambda (expr)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -589,6 +589,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(list "mk" "memcp-tests" "multi_row_key_source" false nil)
 		(list (list (quote get_column) "mk" false "a" false) (list (quote get_column) "mk" false "b" false)))) true
 		"keytable key index declines when more than one non-session key remains")
+	/* planner_row_count_after_selectivity: an unlimited dataset reduce (a bare
+	COUNT(*) with no LIMIT and no unique point lookup) still has a knowable
+	call count -- its driving source's own row count -- it just isn't bounded
+	by a window. Only fall back to the caller-supplied sentinel when the
+	source's row count genuinely cannot be determined (not a base table, or
+	an unverifiable/fabricated one), matching the same "unknown stays
+	unknown" discipline as the keytable cost check above. */
+	(define row_count_unknown_src (list "rc" "memcp-tests" "row_count_unknown_source" false nil))
+	(assert (equal? (planner_row_count_after_selectivity
+		row_count_unknown_src (list row_count_unknown_src) "rc" true nil) nil) true
+		"row count after selectivity falls back to the caller's sentinel for an unverifiable source")
+	(assert (equal? (planner_row_count_after_selectivity
+		row_count_unknown_src (list row_count_unknown_src) "rc" true 1) 1) true
+		"row count after selectivity preserves whatever fallback the caller passed in")
 	(define no_from_select_ast (list "memcp-tests" '() (list "result" 8) true nil nil nil nil nil))
 	(assert (equal? (serialize (build_queryplan_term no_from_select_ast))
 		"(resultrow '(\"result\" 8))") true "build_queryplan_term lowers no-FROM projection")


### PR DESCRIPTION
## Summary
- `lower_query_block_as_dataset_reduce` (a bare aggregate/reduce with no GROUP BY, e.g. `COUNT(*)`) fell back to `probe_work_rows = nil` whenever there was no `LIMIT` and no unique point lookup on the driving source.
- That starved every nested scalar-first probe's keytable-eligibility check (`stage_direct_probe_cost_preferred?`, added in #522) of a call-count estimate, so the keytable option always declined for these queries — even though an unbounded reduce's call count is not actually unknown, it's the driving source's own row count scaled by the residual condition's selectivity.
- Factored the row-count/selectivity composition already used by `lower_exists_union_probe_branch` into a shared `planner_row_count_after_selectivity` helper and reused it for the dataset-reduce case, with an explicit fallback per call site (`1` for the EXISTS branch, `nil` for dataset reduce — preserving prior "truly unknown" behavior when the driving source isn't a base table with a known row count).

## Measurement (in progress)
A/B benchmark against an isolated copy of production data, same query (ACL-filtered `COUNT(*)` list-view pagination query, 855,496-row driving table) on both binaries:
- Baseline (pre-fix, #522 HEAD): >180s, timed out (matches live production: same query observed running >1400s).
- Candidate (this fix): benchmark in progress — will update this description with the final number.

## Test plan
- [x] `python3 tools/lint_scm.py --path lib/queryplan.scm --check` / `lib/test.scm` — clean
- [x] New `lib/test.scm` assertions locking in the fallback-safety property (unverifiable source → caller's sentinel, not a wrong guess)
- [x] `make test` (full pre-commit suite) — all tests passed locally
- [ ] Final A/B timing number in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)