### PR TITLE
planner: hoist query-invariant presence probes in lower_group_stage_prepare_using

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -13837,7 +13837,7 @@ get_column refs to the source) are excluded automatically too. */
 		(define src (gs_input stage))
 		(define prepare_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
 		(define fact_lookup (group_stage_lowering_catalog stage))
-		(define stage_lookup (if (lowering_catalog? lookup_stages)
+		(define raw_stage_lookup (if (lowering_catalog? lookup_stages)
 			lookup_stages
 			(if (lowering_catalog? fact_lookup)
 				fact_lookup
@@ -13846,6 +13846,18 @@ get_column refs to the source) are excluded automatically too. */
 						prepare_catalog
 						lookup_stages
 						(qassoc_get (gs_facts stage) (quote stage_catalog) '())))))))
+		/* A presence/scalar-first-probe source whose lookup domain is invariant
+		for the whole query (only literals, parameters, or session values -- no
+		outer-row column) is evaluated exactly once regardless of how many rows
+		this stage's own input scan accepts. Bind it before rewriting so
+		rewrite_scalar_first_probe_expr_using_index (via query_invariant_probe_
+		binding_for_col) replaces every reference with that one bound value
+		instead of a fresh per-row probe. Mirrors
+		prepare_simple_query_block_physical_core_chosen. */
+		(define invariant_probe_entries (query_invariant_probe_entries_for_stages raw_stage_lookup))
+		(define stage_lookup (stage_lookup_with_query_invariant_probe_bindings
+			raw_stage_lookup invariant_probe_entries))
+		(define invariant_probe_bindings (query_invariant_probe_bindings invariant_probe_entries))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
 			true)
@@ -14032,7 +14044,7 @@ get_column refs to the source) are excluded automatically too. */
 					(list (quote touch_keytable) (list (quote table) schema grouptbl))
 					group_cache_created))
 			(list (quote createtable) schema grouptbl create_cols create_options true)))
-		(define lowered_plan (if scalar_query_stage
+		(define lowered_plan_core (if scalar_query_stage
 			(list (quote !begin)
 				nested_prepare_expr
 				(if initializer_owner keytable_init nil)
@@ -14071,6 +14083,13 @@ get_column refs to the source) are excluded automatically too. */
 											aggregate_prepare_expr)))
 								keytable_init)
 							aggregate_prepare_expr))))))
+		/* A query-invariant presence/scalar-first probe (see the comment at
+		raw_stage_lookup above) is bound exactly once here, ahead of whatever
+		this stage's own prepare plan does, so every rewritten reference below
+		reads that one binding instead of re-probing per row. */
+		(define lowered_plan (if (empty_list? invariant_probe_bindings)
+			lowered_plan_core
+			(cons (quote !begin) (merge (list invariant_probe_bindings (list lowered_plan_core))))))
 		(if (nil? base_group_into_plan)
 			lowered_plan
 			(list

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -603,6 +603,50 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (planner_row_count_after_selectivity
 		row_count_unknown_src (list row_count_unknown_src) "rc" true 1) 1) true
 		"row count after selectivity preserves whatever fallback the caller passed in")
+	/* query_invariant_presence_stage?/query_invariant_probe_entries_for_stages:
+	a presence probe whose lookup key is a session read (not a reference to
+	an outer row's column) is invariant for the whole query execution -- it
+	is the same building block lower_group_stage_prepare_using now uses to
+	bind such a stage once instead of re-probing it per row. */
+	(define invariant_probe_stage (make_group_stage
+		"invariant-probe-stage"
+		(list "ip" "memcp-tests" "invariant_probe_source" false nil)
+		(list (list (quote session) "probe_user"))
+		(list (list (quote get_column) "ip" false "user" false))
+		(list aggregate_count_descriptor)
+		nil '() '() nil nil
+		(list
+			(list (quote purpose) (quote exists))
+			(list (quote presence_only) true)
+			(list (quote max_needed_per_domain) 1)
+			(list (quote physical_max_rows) 1)
+			(list (quote on_overflow) (quote ignore))
+			(list (quote cardinality_mode) (quote many))
+			(list (quote lookup-keys) (list (list (quote session) "probe_user"))))))
+	(assert (query_invariant_presence_stage? invariant_probe_stage) true
+		"a base-table presence stage whose lookup key is only a session read is query-invariant")
+	(define invariant_entries (query_invariant_probe_entries_for_stages (list invariant_probe_stage)))
+	(assert (not (empty_list? invariant_entries)) true
+		"query_invariant_probe_entries_for_stages finds the eligible stage")
+	(assert (not (empty_list? (query_invariant_probe_bindings invariant_entries))) true
+		"a non-empty entry list produces a once-bound define lower_group_stage_prepare_using can emit")
+	(define correlated_probe_stage (make_group_stage
+		"correlated-probe-stage"
+		(list "cp2" "memcp-tests" "correlated_probe_source" false nil)
+		(list (list (quote get_column) "outer" false "standort" false))
+		(list (list (quote get_column) "cp2" false "user" false))
+		(list aggregate_count_descriptor)
+		nil '() '() nil nil
+		(list
+			(list (quote purpose) (quote exists))
+			(list (quote presence_only) true)
+			(list (quote max_needed_per_domain) 1)
+			(list (quote physical_max_rows) 1)
+			(list (quote on_overflow) (quote ignore))
+			(list (quote cardinality_mode) (quote many))
+			(list (quote lookup-keys) (list (list (quote get_column) "outer" false "standort" false))))))
+	(assert (query_invariant_presence_stage? correlated_probe_stage) false
+		"a presence stage whose lookup key references an outer column is not query-invariant -- it must keep using its per-row/keytable probe unchanged")
 	(define no_from_select_ast (list "memcp-tests" '() (list "result" 8) true nil nil nil nil nil))
 	(assert (equal? (serialize (build_queryplan_term no_from_select_ast))
 		"(resultrow '(\"result\" 8))") true "build_queryplan_term lowers no-FROM projection")


### PR DESCRIPTION
## Summary
- `lower_group_stage_prepare_using` (the whole-table-aggregate / bare `COUNT(*)`-with-`WHERE` lowering path) never wired in the query-invariant-probe binding machinery that shipped in #505 (`query_invariant_probe_entries_for_stages` / `stage_lookup_with_query_invariant_probe_bindings` / `query_invariant_probe_bindings`). Other lowering paths that can encounter a `presence_probe_stage?`/`query_invariant_presence_stage?`-eligible source already use it (`prepare_simple_query_block_physical_core_chosen`); this whole-table-aggregate path was the one remaining gap.
- A `WHERE`-clause `EXISTS` predicate whose lookup domain is a session value only (not an outer-row column — e.g. `WHERE EXISTS(SELECT ... WHERE user=@current_user)`) is provably constant for the whole query execution. It should be evaluated once, not re-probed per outer row.
- Fix: compute the annotated stage lookup + its once-bound `define`s at the top of the function (mirroring the existing template exactly, same functions, no new mechanism), thread it through as the existing `stage_lookup` variable so every downstream use picks it up automatically, and emit the resulting bindings ahead of whatever the stage's own prepare plan already does.

## Honest scope note (this does NOT fully close the underlying production report)
This investigation started from a production `dokument`-table `COUNT(*)` pagination query observed running from minutes to over an hour. This PR is a real, reproducible, root-cause-appropriate improvement, but **it is not the complete fix**:
- Measured effect on an isolated repro (single zero-correlation `EXISTS`, 855k-row driving table, isolated copy of production data): **~19.1s → ~14.6-15.1s** (reproducible across 3 separate builds/runs).
- `EXPLAIN` on the actual production predicate shape (several `EXISTS` branches combined via `AND`/`OR`/`COALESCE`/`CASE`) still shows a raw per-row `scan_order` surviving inside the driving scan's filter lambda — meaning at least one more wiring/invocation gap in the same pipeline remains, not yet identified. `lower_group_stage_prepare_using` is evidently invoked multiple times for different stages within one query compile, and the specific invocation whose output becomes the final row-filter lambda for the full production shape doesn't yet pick up this annotation.
- Already-correct behavior is unaffected: a genuinely row-correlated `EXISTS` (e.g. `WHERE EXISTS(... WHERE t.standort = outer.standort)`) still gets its existing keytable treatment unchanged (~1ms warm, verified before and after this change).

Follow-up work (separate PR) is needed to close the remaining gap and reach the ~1.6s (bare-scan) / sub-millisecond (fully warm, combined with existing correlated-probe caching) target for the real production query.

## Test plan
- [x] `python3 tools/lint_scm.py --path lib/queryplan.scm --check` / `lib/test.scm` — clean
- [x] New `lib/test.scm` assertions locking in the building-block behavior: a base-table presence stage whose lookup key is only a session read is `query_invariant_presence_stage?` and produces a binding via `query_invariant_probe_entries_for_stages`/`query_invariant_probe_bindings`; a presence stage whose lookup key references an outer column is correctly *not* query-invariant (regression guard for the already-working correlated-probe path)
- [x] `make test` (full pre-commit suite, local) — 100% SCM coverage, all suites passed, "commit allowed"
- [x] A/B timing against an isolated copy of production data, before/after this change (see above)
- [x] Regression check: the already-correct correlated-`EXISTS` case stays at ~1ms warm, unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)