### PR TITLE
storage: bulk GetValueMulti/GetValueRange for ColumnStorage

### DIFF
--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -256,6 +256,67 @@ func (r *computeVariantReader) GetValue(idx uint32) scm.Scmer {
 	return val
 }
 
+// GetValueRange and GetValueMulti mirror StorageComputeProxy's own bulk
+// fast path: delegate straight to v.main in one call when every row is
+// already valid and materialized there, otherwise fall back to this
+// reader's own GetValue per row (full delta/compute repair logic).
+func (r *computeVariantReader) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	v := r.variant
+	if v.compressed && v.main != nil && uint64(recid)+uint64(count) <= uint64(v.count) {
+		v.mu.RLock()
+		deltaEmpty := len(v.delta) == 0
+		v.mu.RUnlock()
+		if deltaEmpty {
+			v.main.GetValueRange(recid, count, target, stride)
+			return
+		}
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = r.GetValue(recid + k)
+		idx += stride
+	}
+}
+
+func (r *computeVariantReader) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if len(recids) == 0 {
+		return
+	}
+	v := r.variant
+	if v.compressed && v.main != nil {
+		allMain := true
+		for _, recid := range recids {
+			if recid >= v.count {
+				allMain = false
+				break
+			}
+		}
+		if allMain {
+			v.mu.RLock()
+			deltaEmpty := len(v.delta) == 0
+			v.mu.RUnlock()
+			if deltaEmpty {
+				v.main.GetValueMulti(recids, target, stride)
+				return
+			}
+		}
+	}
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = r.GetValue(recid)
+		idx += stride
+	}
+}
+
 func (r *computeProxyReader) GetValue(idx uint32) scm.Scmer {
 	p := r.proxy
 
@@ -283,6 +344,65 @@ func (r *computeProxyReader) GetValue(idx uint32) scm.Scmer {
 	p.mu.Unlock()
 	p.validMask.Set(uint(idx), true)
 	return val
+}
+
+// GetValueRange and GetValueMulti mirror computeVariantReader's bulk fast
+// path against p (the proxy) instead of a session variant.
+func (r *computeProxyReader) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	p := r.proxy
+	if p.compressed && p.main != nil && uint64(recid)+uint64(count) <= uint64(p.count) {
+		p.mu.RLock()
+		deltaEmpty := len(p.delta) == 0
+		p.mu.RUnlock()
+		if deltaEmpty {
+			p.main.GetValueRange(recid, count, target, stride)
+			return
+		}
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = r.GetValue(recid + k)
+		idx += stride
+	}
+}
+
+func (r *computeProxyReader) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if len(recids) == 0 {
+		return
+	}
+	p := r.proxy
+	if p.compressed && p.main != nil {
+		allMain := true
+		for _, recid := range recids {
+			if recid >= p.count {
+				allMain = false
+				break
+			}
+		}
+		if allMain {
+			p.mu.RLock()
+			deltaEmpty := len(p.delta) == 0
+			p.mu.RUnlock()
+			if deltaEmpty {
+				p.main.GetValueMulti(recids, target, stride)
+				return
+			}
+		}
+	}
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = r.GetValue(recid)
+		idx += stride
+	}
 }
 
 func (p *StorageComputeProxy) GetCachedReaderTx(tx *TxContext) ColumnReader {
@@ -519,6 +639,70 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	p.validMask.Set(uint(idx), true)
 
 	return val
+}
+
+// GetValueRange and GetValueMulti take the fast path — one bulk call
+// straight into p.main — only when every requested row is guaranteed to
+// come from main with no repair work: not an ORC column, no pending delta
+// overrides, and the proxy is fully compressed. That mirrors GetValue's own
+// "fast path 1" above. Any other case (ORC, live delta entries, rows beyond
+// the compressed main, or a row still needing on-demand compute) falls back
+// to the existing per-row GetValue, which already contains the full
+// invalidation/session/delta repair logic; duplicating that logic here for
+// the sake of batching would risk subtly diverging from it.
+func (p *StorageComputeProxy) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	if !p.isOrdered && p.compressed && p.main != nil && uint64(recid)+uint64(count) <= uint64(p.count) {
+		p.mu.RLock()
+		deltaEmpty := len(p.delta) == 0
+		p.mu.RUnlock()
+		if deltaEmpty {
+			p.main.GetValueRange(recid, count, target, stride)
+			return
+		}
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = p.GetValue(recid + k)
+		idx += stride
+	}
+}
+
+func (p *StorageComputeProxy) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if len(recids) == 0 {
+		return
+	}
+	if !p.isOrdered && p.compressed && p.main != nil {
+		allMain := true
+		for _, recid := range recids {
+			if recid >= p.count {
+				allMain = false
+				break
+			}
+		}
+		if allMain {
+			p.mu.RLock()
+			deltaEmpty := len(p.delta) == 0
+			p.mu.RUnlock()
+			if deltaEmpty {
+				p.main.GetValueMulti(recids, target, stride)
+				return
+			}
+		}
+	}
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = p.GetValue(recid)
+		idx += stride
+	}
 }
 
 func (p *StorageComputeProxy) GetCachedReader() ColumnReader {

--- a/storage/overlay-blob.go
+++ b/storage/overlay-blob.go
@@ -144,7 +144,41 @@ func gunzipValue(gzipped string) scm.Scmer {
 func (s *OverlayBlob) GetCachedReader() ColumnReader { return s }
 
 func (s *OverlayBlob) GetValue(i uint32) scm.Scmer {
-	v := s.Base.GetValue(i)
+	return s.resolveBlob(s.Base.GetValue(i))
+}
+
+// GetValueRange and GetValueMulti bulk-fetch the base storage (one call
+// instead of n GetValue calls) and then resolve the blob-escape encoding for
+// each result in place.
+func (s *OverlayBlob) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.Base.GetValueRange(recid, count, target, stride)
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = s.resolveBlob(target[idx])
+		idx += stride
+	}
+}
+
+func (s *OverlayBlob) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.Base.GetValueMulti(recids, target, stride)
+	idx := 0
+	for range recids {
+		target[idx] = s.resolveBlob(target[idx])
+		idx += stride
+	}
+}
+
+// resolveBlob turns a base-storage value into its logical value: a plain
+// value passes through unchanged; a "!"-prefixed string is either an
+// escaped literal ("!!...") or a blob reference that must be loaded from
+// persistence (or the in-memory build-time cache) and gunzipped.
+func (s *OverlayBlob) resolveBlob(v scm.Scmer) scm.Scmer {
 	if v.IsString() {
 		vs := v.String()
 		if vs != "" && vs[0] == '!' {

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -376,20 +376,41 @@ func (snap shardPartitionSnapshot) count() uint64 {
 	return uint64(snap.mainCount) + uint64(len(snap.inserts)) - uint64(snap.deletions.Count())
 }
 
-func (snap shardPartitionSnapshot) partition(schema []shardDimension) (result map[int][]uint32) {
-	result = make(map[int][]uint32)
-	values := make([]scm.Scmer, len(schema))
-
-	for idx := uint32(0); idx < snap.mainCount; idx++ {
-		if snap.deletions.Get(uint(idx)) {
-			continue
+// partitionMainRows assigns each surviving (non-deleted) row of main storage
+// in [0,mainCount) to a target shard. Deletion is a data-independent skip, so
+// it is checked once up front to build the surviving recid list; each
+// dimension column is then read for the whole batch via one GetValueMulti
+// call instead of one GetValue per row per column.
+func partitionMainRows(schema []shardDimension, mainCount uint32, deletions *NonLockingReadMap.NonBlockingBitMap, mainCols []ColumnStorage, result map[int][]uint32) {
+	surviving := make([]uint32, 0, mainCount)
+	for idx := uint32(0); idx < mainCount; idx++ {
+		if !deletions.Get(uint(idx)) {
+			surviving = append(surviving, idx)
 		}
-		for i, cs := range snap.mainCols {
-			values[i] = cs.GetValue(idx)
+	}
+	if len(surviving) == 0 {
+		return
+	}
+	colValues := make([][]scm.Scmer, len(schema))
+	for i, cs := range mainCols {
+		colValues[i] = make([]scm.Scmer, len(surviving))
+		cs.GetValueMulti(surviving, colValues[i], 1)
+	}
+	values := make([]scm.Scmer, len(schema))
+	for row, idx := range surviving {
+		for i := range schema {
+			values[i] = colValues[i][row]
 		}
 		shardnum := computeShardIndex(schema, values)
 		result[shardnum] = append(result[shardnum], idx)
 	}
+}
+
+func (snap shardPartitionSnapshot) partition(schema []shardDimension) (result map[int][]uint32) {
+	result = make(map[int][]uint32)
+	values := make([]scm.Scmer, len(schema))
+
+	partitionMainRows(schema, snap.mainCount, &snap.deletions, snap.mainCols, result)
 
 	for idx, row := range snap.inserts {
 		recid := snap.mainCount + uint32(idx)
@@ -1149,17 +1170,7 @@ func (s *storageShard) partition(schema []shardDimension) (result map[int][]uint
 	for i, sd := range schema {
 		maincols[i], _ = s.columns[sd.Column]
 	}
-	for idx := uint32(0); idx < s.main_count; idx++ {
-		if s.deletions.Get(uint(idx)) {
-			continue
-		}
-		for i, cs := range maincols {
-			values[i] = cs.GetValue(idx)
-		}
-		shardnum := computeShardIndex(schema, values)
-		oldlist, _ := result[shardnum]
-		result[shardnum] = append(oldlist, idx)
-	}
+	partitionMainRows(schema, s.main_count, &s.deletions, maincols, result)
 
 	/* collect delta storage */
 	deltacols := make([]int, len(schema))

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1215,12 +1215,20 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		result.items = make([]uint32, resultCap)
 		resultN := 0
 		usageWeight := orderedScanIndexUsageWeight(boundaries, int(visibleUpper), limit)
+		// Reused across batches: survived/mainIds scratch lists and one value
+		// buffer per non-getter condition column, so a batch's main-storage rows
+		// are fetched with one GetValueMulti call per column instead of one
+		// GetValue call per row per column.
+		var survivedBuf, mainIdsBuf []uint32
+		colBufs := make([][]scm.Scmer, len(conditionCols))
 		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, func(index *StorageIndex, active bool) {
 			resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
 		}, func(batch []uint32) bool {
 			result.candidateCount += int64(len(batch))
-			// filter in-place: overwrite batch with passing IDs
-			outN := 0
+
+			// pass 1: data-independent skip checks (recset/visibility/deletion),
+			// producing the ordered surviving-id list without touching column data.
+			survived := survivedBuf[:0]
 			for _, idx := range batch {
 				if recsetPart != nil && !recsetPart.contains(idx) {
 					continue
@@ -1235,22 +1243,53 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 				} else if t.deletions.Get(uint(idx)) {
 					continue // item is on delete list
 				}
+				survived = append(survived, idx)
+			}
+			survivedBuf = survived
 
+			// pass 2: bulk-fetch every non-getter condition column for the
+			// main-storage survivors of this batch, one call per column.
+			mainIds := mainIdsBuf[:0]
+			for _, idx := range survived {
 				if idx < t.main_count {
-					// value from main storage
-					// check condition
-					for i, k := range ccols { // iterate over columns
+					mainIds = append(mainIds, idx)
+				}
+			}
+			mainIdsBuf = mainIds
+			for i := range ccols {
+				if conditionGetters[i] != nil {
+					continue
+				}
+				if cap(colBufs[i]) < len(mainIds) {
+					colBufs[i] = make([]scm.Scmer, len(mainIds))
+				}
+				colBufs[i] = colBufs[i][:len(mainIds)]
+				if len(mainIds) == 0 {
+					continue
+				}
+				if cNeedsCachedReader[i] {
+					cReaders[i].GetValueMulti(mainIds, colBufs[i], 1)
+				} else {
+					ccols[i].GetValueMulti(mainIds, colBufs[i], 1)
+				}
+			}
+
+			// pass 3: evaluate the condition per row using the pre-fetched
+			// main-storage values; delta rows are still read one at a time.
+			outN := 0
+			mainBufIdx := 0
+			for _, idx := range survived {
+				if idx < t.main_count {
+					for i := range ccols {
 						if conditionGetters[i] != nil {
 							cdataset[i] = conditionGetters[i](idx, 0)
-						} else if cNeedsCachedReader[i] {
-							cdataset[i] = cReaders[i].GetValue(idx)
 						} else {
-							cdataset[i] = k.GetValue(idx)
+							cdataset[i] = colBufs[i][mainBufIdx]
 						}
 					}
+					mainBufIdx++
 				} else {
 					// value from delta storage
-					// prepare&call condition function
 					for i, k := range conditionCols { // iterate over columns
 						if conditionGetters[i] != nil {
 							cdataset[i] = conditionGetters[i](idx, 0)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2787,6 +2787,29 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 	}
 }
 
+// replayRebuiltRows replays one column's values in rebuiltRowIDs order for
+// shard rebuild's scan/build passes. mainRecids/mainMask (precomputed once
+// per shard, shared across every column) identify which slots of
+// rebuiltRowIDs are sourced from main storage; those are bulk-fetched from
+// reader in a single GetValueMulti call instead of one GetValue per row.
+// Delta-sourced slots still go through getDelta one row at a time, since
+// that reads a plain Go map rather than a ColumnStorage.
+func replayRebuiltRows(reader ColumnReader, mainRecids []uint32, mainMask []bool, rebuiltRowIDs []uint32, mainCount uint32, col string, getDelta func(int, string) scm.Scmer, emit func(uint32, scm.Scmer)) {
+	buf := make([]scm.Scmer, len(mainRecids))
+	if len(mainRecids) > 0 {
+		reader.GetValueMulti(mainRecids, buf, 1)
+	}
+	bufIdx := 0
+	for k, id := range rebuiltRowIDs {
+		if mainMask[k] {
+			emit(uint32(k), buf[bufIdx])
+			bufIdx++
+		} else {
+			emit(uint32(k), getDelta(int(id-mainCount), col))
+		}
+	}
+}
+
 // rebuild main storage from main+delta
 func (t *storageShard) rebuild(all bool) *storageShard {
 	// An unchanged cold shard already is a complete persistent generation:
@@ -3025,6 +3048,19 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				}
 			}
 		}
+		// mainRecids/mainMask precompute, once per rebuilt shard (not per column),
+		// which slots of rebuiltRowIDs are sourced from main storage vs delta so
+		// every column's scan/build replay can bulk-fetch its main-sourced values
+		// in one GetValueMulti call instead of one GetValue per row.
+		mainRecids := make([]uint32, 0, len(rebuiltRowIDs))
+		mainMask := make([]bool, len(rebuiltRowIDs))
+		for k, id := range rebuiltRowIDs {
+			if id < mainCount {
+				mainMask[k] = true
+				mainRecids = append(mainRecids, id)
+			}
+		}
+
 		nextTranslation := make(map[uint32]uint32, len(rebuiltRowIDs))
 		for newRecid, oldRecid := range rebuiltRowIDs {
 			nextTranslation[oldRecid] = uint32(newRecid)
@@ -3072,36 +3108,10 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 			var reader ColumnReader
 			for {
 				// scan phase
-				i = 0
 				reader = c.GetCachedReader() // must NOT use newCachedColumnReader: it strips OverlayBlob
 				newcol.prepare()
-				if sortPerm != nil {
-					for _, globalID := range sortPerm {
-						if globalID < mainCount {
-							newcol.scan(i, reader.GetValue(globalID))
-						} else {
-							newcol.scan(i, getDelta(int(globalID-mainCount), col))
-						}
-						i++
-					}
-				} else {
-					// scan main
-					for idx := uint32(0); idx < mainCount; idx++ {
-						if !keepRecid(idx) {
-							continue
-						}
-						newcol.scan(i, reader.GetValue(idx))
-						i++
-					}
-					// scan delta
-					for idx := 0; idx < maxInsertIndex; idx++ {
-						if !keepRecid(mainCount + uint32(idx)) {
-							continue
-						}
-						newcol.scan(i, getDelta(idx, col))
-						i++
-					}
-				}
+				replayRebuiltRows(reader, mainRecids, mainMask, rebuiltRowIDs, mainCount, col, getDelta, newcol.scan)
+				i = uint32(len(rebuiltRowIDs))
 				newcol2 := newcol.proposeCompression(i)
 				if newcol2 == nil {
 					break // we found the optimal storage format
@@ -3120,35 +3130,8 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				blob.schema = result.t.schema
 			}
 			newcol.init(i)
-			i = 0
 			reader = c.GetCachedReader() // must NOT use newCachedColumnReader: it strips OverlayBlob
-			if sortPerm != nil {
-				for _, globalID := range sortPerm {
-					if globalID < mainCount {
-						newcol.build(i, reader.GetValue(globalID))
-					} else {
-						newcol.build(i, getDelta(int(globalID-mainCount), col))
-					}
-					i++
-				}
-			} else {
-				// build main
-				for idx := uint32(0); idx < mainCount; idx++ {
-					if !keepRecid(idx) {
-						continue
-					}
-					newcol.build(i, reader.GetValue(idx))
-					i++
-				}
-				// build delta
-				for idx := 0; idx < maxInsertIndex; idx++ {
-					if !keepRecid(mainCount + uint32(idx)) {
-						continue
-					}
-					newcol.build(i, getDelta(idx, col))
-					i++
-				}
-			}
+			replayRebuiltRows(reader, mainRecids, mainMask, rebuiltRowIDs, mainCount, col, getDelta, newcol.build)
 			newcol.finish()
 
 			// LZ4 string dict compression: if the old column was a StorageString

--- a/storage/storage-const.go
+++ b/storage/storage-const.go
@@ -44,6 +44,30 @@ func (s *StorageConst) GetValue(i uint32) scm.Scmer {
 	return s.value
 }
 
+// GetValueRange and GetValueMulti fill target with the single constant
+// value directly; there is no per-row work to batch.
+func (s *StorageConst) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = s.value
+		idx += stride
+	}
+}
+
+func (s *StorageConst) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for range recids {
+		target[idx] = s.value
+		idx += stride
+	}
+}
+
 func (s *StorageConst) GetCachedReader() ColumnReader { return s }
 
 func (s *StorageConst) JITEmit(ctx *scm.JITContext, thisptr scm.JITValueDesc, idx scm.JITValueDesc, result scm.JITValueDesc) scm.JITValueDesc {

--- a/storage/storage-decimal.go
+++ b/storage/storage-decimal.go
@@ -120,6 +120,43 @@ func (s *StorageDecimal) GetValue(i uint32) scm.Scmer {
 	return scm.NewFloat(float64(v) * pow10f[int(s.scaleExp)+15])
 }
 
+// GetValueRange and GetValueMulti delegate the raw (offset-applied,
+// null-checked) integer decode to the wrapped StorageInt's own bulk method
+// — which is where the bit-unpacking cursor optimization lives — and then
+// rescale each non-nil result in place, avoiding a second per-element
+// GetValue dispatch.
+func (s *StorageDecimal) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.inner.GetValueRange(recid, count, target, stride)
+	s.rescaleInPlace(target, count, stride)
+}
+
+func (s *StorageDecimal) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.inner.GetValueMulti(recids, target, stride)
+	s.rescaleInPlace(target, uint32(len(recids)), stride)
+}
+
+func (s *StorageDecimal) rescaleInPlace(target []scm.Scmer, count uint32, stride int) {
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		v := target[idx]
+		if !v.IsNil() {
+			raw := v.Int()
+			if s.scaleExp > 0 {
+				target[idx] = scm.NewInt(raw * pow10i[s.scaleExp])
+			} else {
+				target[idx] = scm.NewFloat(float64(raw) * pow10f[int(s.scaleExp)+15])
+			}
+		}
+		idx += stride
+	}
+}
+
 // scaleValue converts a scm.Scmer to the scaled integer representation
 func (s *StorageDecimal) scaleValue(value scm.Scmer) scm.Scmer {
 	if value.IsNil() {

--- a/storage/storage-enum.go
+++ b/storage/storage-enum.go
@@ -359,6 +359,33 @@ func (r *cachedEnumReader) GetValue(i uint32) scm.Scmer {
 	return r.s.GetValueCached(i, &r.cache)
 }
 
+// GetValueRange and GetValueMulti reuse this reader's persistent decode
+// cache across the whole batch via GetValueCached, so a scan that gathers
+// many rows through one reader gets the O(1)-amortized sequential/jump
+// decode path GetValueCached already implements, instead of paying a fresh
+// binary search (or a shared-cache reset) per row.
+func (r *cachedEnumReader) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = r.s.GetValueCached(recid+k, &r.cache)
+		idx += stride
+	}
+}
+
+func (r *cachedEnumReader) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = r.s.GetValueCached(recid, &r.cache)
+		idx += stride
+	}
+}
+
 func (s *StorageEnum) GetCachedReader() ColumnReader {
 	return &cachedEnumReader{s: s}
 }
@@ -457,6 +484,35 @@ func (s *StorageEnum) GetValueCached(i uint32, c *EnumDecodeCache) scm.Scmer {
 	c.pos = posInChunk + 1
 	c.buf = buffer
 	return result
+}
+
+// GetValueRange and GetValueMulti decode a whole batch through a single
+// local (stack-allocated, not shared-atomic) EnumDecodeCache, so the rANS
+// chunk decode state — the expensive part of an enum read — is amortized
+// across the batch via GetValueCached's O(1) sequential/jump fast paths
+// instead of every element paying its own binary search from GetValue.
+func (s *StorageEnum) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	var cache EnumDecodeCache
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = s.GetValueCached(recid+k, &cache)
+		idx += stride
+	}
+}
+
+func (s *StorageEnum) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	var cache EnumDecodeCache
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = s.GetValueCached(recid, &cache)
+		idx += stride
+	}
 }
 
 // findChunk returns the chunk index containing element idx via binary search.

--- a/storage/storage-enum_test.go
+++ b/storage/storage-enum_test.go
@@ -373,6 +373,109 @@ func BenchmarkEnumRandomCached(b *testing.B) {
 	}
 }
 
+// TestEnumBulkMatchesGetValue checks GetValueRange/GetValueMulti (including
+// non-cached and the persistent cachedEnumReader path) against a plain
+// per-element GetValue loop, across sequential, ascending-gappy, and
+// shuffled-with-repeats recid patterns.
+func TestEnumBulkMatchesGetValue(t *testing.T) {
+	for _, cfg := range configs {
+		cfg := cfg
+		t.Run(cfg.name, func(t *testing.T) {
+			s := buildEnum(cfg.n, cfg.gen)
+			want := make([]scm.Scmer, cfg.n)
+			for i := 0; i < cfg.n; i++ {
+				want[i] = s.GetValue(uint32(i))
+			}
+
+			checkAgainstWant := func(label string, got []scm.Scmer, recids []int) {
+				for k, recid := range recids {
+					if !scm.Equal(got[k], want[recid]) {
+						t.Errorf("%s: %s[%d] (recid %d) = %v, want %v", cfg.name, label, k, recid, got[k], want[recid])
+					}
+				}
+			}
+
+			readers := []struct {
+				name       string
+				valueRange func(uint32, uint32, []scm.Scmer, int)
+				valueMulti func([]uint32, []scm.Scmer, int)
+			}{
+				{"storage", s.GetValueRange, s.GetValueMulti},
+				{"cachedReader", s.GetCachedReader().GetValueRange, s.GetCachedReader().GetValueMulti},
+			}
+
+			for _, r := range readers {
+				full := make([]scm.Scmer, cfg.n)
+				r.valueRange(0, uint32(cfg.n), full, 1)
+				fullRecids := make([]int, cfg.n)
+				for i := range fullRecids {
+					fullRecids[i] = i
+				}
+				checkAgainstWant(r.name+"/GetValueRange(full)", full, fullRecids)
+
+				var ascending []uint32
+				var ascendingInt []int
+				for i := 0; i < cfg.n; i += 2 {
+					ascending = append(ascending, uint32(i))
+					ascendingInt = append(ascendingInt, i)
+				}
+				gotAsc := make([]scm.Scmer, len(ascending))
+				r.valueMulti(ascending, gotAsc, 1)
+				checkAgainstWant(r.name+"/GetValueMulti(ascending)", gotAsc, ascendingInt)
+
+				rng := rand.New(rand.NewSource(7))
+				shuffled := make([]uint32, cfg.n)
+				shuffledInt := make([]int, cfg.n)
+				for i := range shuffled {
+					shuffled[i] = uint32(i)
+					shuffledInt[i] = i
+				}
+				rng.Shuffle(len(shuffled), func(i, j int) {
+					shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+					shuffledInt[i], shuffledInt[j] = shuffledInt[j], shuffledInt[i]
+				})
+				gotShuf := make([]scm.Scmer, len(shuffled))
+				r.valueMulti(shuffled, gotShuf, 1)
+				checkAgainstWant(r.name+"/GetValueMulti(shuffled)", gotShuf, shuffledInt)
+			}
+		})
+	}
+}
+
+// --- Bulk (GetValueRange/GetValueMulti) benchmarks, for comparison against
+// the per-element Sequential/Random benchmarks above ---
+
+func BenchmarkEnumSequentialBulk(b *testing.B) {
+	for _, cfg := range configs {
+		s := buildEnum(cfg.n, cfg.gen)
+		target := make([]scm.Scmer, cfg.n)
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				s.GetValueRange(0, uint32(cfg.n), target, 1)
+			}
+		})
+	}
+}
+
+func BenchmarkEnumRandomBulk(b *testing.B) {
+	for _, cfg := range configs {
+		s := buildEnum(cfg.n, cfg.gen)
+		rng := rand.New(rand.NewSource(42))
+		indices := make([]uint32, cfg.n)
+		for i := range indices {
+			indices[i] = uint32(rng.Intn(cfg.n))
+		}
+		target := make([]scm.Scmer, cfg.n)
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				s.GetValueMulti(indices, target, 1)
+			}
+		})
+	}
+}
+
 // --- Per-element benchmarks for ns/op comparison ---
 
 func BenchmarkEnumPerElem(b *testing.B) {

--- a/storage/storage-float.go
+++ b/storage/storage-float.go
@@ -416,6 +416,39 @@ func (s *StorageFloat) GetValue(i uint32) scm.Scmer {
 	return scm.NewFloat(s.values[i])
 }
 
+func (s *StorageFloat) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	values := s.values[recid : uint32(recid)+count]
+	idx := 0
+	for _, v := range values {
+		if math.IsNaN(v) {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewFloat(v)
+		}
+		idx += stride
+	}
+}
+
+func (s *StorageFloat) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	values := s.values
+	idx := 0
+	for _, recid := range recids {
+		v := values[recid]
+		if math.IsNaN(v) {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewFloat(v)
+		}
+		idx += stride
+	}
+}
+
 func (s *StorageFloat) scan(i uint32, value scm.Scmer) {
 }
 func (s *StorageFloat) prepare() {

--- a/storage/storage-int.go
+++ b/storage/storage-int.go
@@ -2099,6 +2099,97 @@ func (s *StorageInt) GetValueUInt(i uint32) uint64 {
 	return uint64(v) >> (64 - uint(s.bitsize)) // shift right without sign
 }
 
+// GetValueRange decodes count consecutive bit-packed values starting at
+// recid. Unlike calling GetValueUInt in a loop, it keeps a running
+// chunk/bit-offset cursor and advances it by bitsize each step instead of
+// recomputing bitpos/64 and bitpos%64 (a division+modulo) from scratch for
+// every element, since consecutive rows are exactly bitsize bits apart.
+func (s *StorageInt) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	bitsize := uint(s.bitsize)
+	hasNull := s.hasNull
+	null := s.null
+	offset := s.offset
+	chunk := s.chunk
+
+	bitpos := uint(recid) * bitsize
+	chunkIdx := bitpos / 64
+	bitOff := bitpos % 64
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		v := chunk[chunkIdx] << bitOff
+		if bitOff+bitsize > 64 {
+			v |= chunk[chunkIdx+1] >> (64 - bitOff)
+		}
+		raw := v >> (64 - bitsize)
+		if hasNull && raw == null {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewInt(int64(raw) + offset)
+		}
+		idx += stride
+		bitOff += bitsize
+		if bitOff >= 64 {
+			bitOff -= 64
+			chunkIdx++
+		}
+	}
+}
+
+// GetValueMulti gathers values at arbitrary recids. Consecutive recids that
+// happen to be adjacent (recids[k] == recids[k-1]+1, the common case for a
+// batch drawn from a contiguous index range) reuse the rolling cursor from
+// GetValueRange; any jump falls back to a direct bitpos computation for that
+// element only.
+func (s *StorageInt) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if len(recids) == 0 {
+		return
+	}
+	bitsize := uint(s.bitsize)
+	hasNull := s.hasNull
+	null := s.null
+	offset := s.offset
+	chunk := s.chunk
+
+	var chunkIdx, bitOff uint
+	havePos := false
+	var prevRecid uint32
+	idx := 0
+	for _, recid := range recids {
+		if !havePos || recid != prevRecid+1 {
+			bitpos := uint(recid) * bitsize
+			chunkIdx = bitpos / 64
+			bitOff = bitpos % 64
+		}
+		v := chunk[chunkIdx] << bitOff
+		if bitOff+bitsize > 64 {
+			v |= chunk[chunkIdx+1] >> (64 - bitOff)
+		}
+		raw := v >> (64 - bitsize)
+		if hasNull && raw == null {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewInt(int64(raw) + offset)
+		}
+		idx += stride
+		prevRecid = recid
+		havePos = true
+		bitOff += bitsize
+		if bitOff >= 64 {
+			bitOff -= 64
+			chunkIdx++
+		}
+	}
+}
+
 func (s *StorageInt) prepare() {
 	// set up scan
 	s.bitsize = 0

--- a/storage/storage-prefix.go
+++ b/storage/storage-prefix.go
@@ -52,6 +52,49 @@ func (s *StoragePrefix) GetValue(i uint32) scm.Scmer {
 	prefix := s.prefixdictionary[idx]
 	return scm.NewString(prefix + inner.String())
 }
+
+// GetValueRange and GetValueMulti bulk-fetch the suffix strings and the raw
+// prefix-dictionary indices via the two wrapped storages' own bulk methods
+// (one call each instead of 2*n GetValue calls) and then stitch prefix+suffix
+// together in a single post-process pass.
+func (s *StoragePrefix) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.values.GetValueRange(recid, count, target, stride)
+	idxbuf := make([]scm.Scmer, count)
+	s.prefixes.GetValueRange(recid, count, idxbuf, 1)
+	s.applyPrefixInPlace(target, idxbuf, count, stride)
+}
+
+func (s *StoragePrefix) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	s.values.GetValueMulti(recids, target, stride)
+	idxbuf := make([]scm.Scmer, len(recids))
+	s.prefixes.GetValueMulti(recids, idxbuf, 1)
+	s.applyPrefixInPlace(target, idxbuf, uint32(len(recids)), stride)
+}
+
+func (s *StoragePrefix) applyPrefixInPlace(target []scm.Scmer, idxbuf []scm.Scmer, count uint32, stride int) {
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		inner := target[idx]
+		if !inner.IsNil() {
+			if !inner.IsString() {
+				panic("invalid value in prefix storage")
+			}
+			pidx := idxbuf[k].Int()
+			if pidx < 0 || pidx >= int64(len(s.prefixdictionary)) {
+				panic("prefix index out of range")
+			}
+			target[idx] = scm.NewString(s.prefixdictionary[pidx] + inner.String())
+		}
+		idx += stride
+	}
+}
+
 func (s *StoragePrefix) JITEmit(ctx *scm.JITContext, thisptr scm.JITValueDesc, idx scm.JITValueDesc, result scm.JITValueDesc) scm.JITValueDesc {
 
 	/* TODO: RunDefers: rundefers */

--- a/storage/storage-scmer.go
+++ b/storage/storage-scmer.go
@@ -203,6 +203,34 @@ func (s *StorageSCMER) GetValue(i uint32) scm.Scmer {
 	return s.values[i]
 }
 
+func (s *StorageSCMER) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if stride == 1 {
+		copy(target[:count], s.values[recid:uint32(recid)+count])
+		return
+	}
+	values := s.values[recid : uint32(recid)+count]
+	idx := 0
+	for _, v := range values {
+		target[idx] = v
+		idx += stride
+	}
+}
+
+func (s *StorageSCMER) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	values := s.values
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = values[recid]
+		idx += stride
+	}
+}
+
 func (s *StorageSCMER) SetValue(i uint32, v scm.Scmer) {
 	s.values[i] = v
 }

--- a/storage/storage-seq.go
+++ b/storage/storage-seq.go
@@ -19333,6 +19333,141 @@ func (s *StorageSeq) GetValue(i uint32) scm.Scmer {
 
 }
 
+// findSegment does the same bisection as GetValue but as a plain local
+// search that never touches the shared s.lastValue atomic pivot cache.
+// GetValue's cache is a single field on the struct, so concurrent goroutines
+// doing bulk sequential reads over the same column would otherwise thrash
+// each other's cached pivot; the bulk paths below seed their own local walk
+// once and then advance it purely with local state.
+func (s *StorageSeq) findSegment(i uint32) uint32 {
+	var min, max uint32 = 0, s.seqCount - 1
+	for min < max {
+		pivot := (min + max + 1) / 2
+		recid := int64(s.recordId.GetValueUInt(pivot)) + s.recordId.offset
+		if uint32(recid) <= i {
+			min = pivot
+		} else {
+			max = pivot - 1
+		}
+	}
+	return min
+}
+
+// segmentAt reads the (recordId, isNil, start, stride) tuple for segment
+// seg. Called once per segment touched, not once per row.
+func (s *StorageSeq) segmentAt(seg uint32) (recordId int64, isNil bool, start int64, stride int64) {
+	recordId = int64(s.recordId.GetValueUInt(seg)) + s.recordId.offset
+	startRaw := s.start.GetValueUInt(seg)
+	if s.start.hasNull && startRaw == s.start.null {
+		isNil = true
+		return
+	}
+	start = int64(startRaw) + s.start.offset
+	stride = int64(s.stride.GetValueUInt(seg)) + s.stride.offset
+	return
+}
+
+func (s *StorageSeq) segmentEnd(seg uint32) int64 {
+	if seg+1 < s.seqCount {
+		return int64(s.recordId.GetValueUInt(seg+1)) + s.recordId.offset
+	}
+	return int64(s.count)
+}
+
+// GetValueRange reads count consecutive rows starting at recid. It seeds the
+// segment cursor with one local binary search and then walks forward: each
+// arithmetic-sequence segment is read as start+delta*stride incrementally
+// (a running add, no per-row multiply or search), and a nil segment fills
+// its whole span directly.
+func (s *StorageSeq) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	seg := s.findSegment(recid)
+	segRecordId, isNil, segStart, segStride := s.segmentAt(seg)
+	nextRecordId := s.segmentEnd(seg)
+	curVal := segStart + (int64(recid)-segRecordId)*segStride
+
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		i := int64(recid) + int64(k)
+		if i >= nextRecordId {
+			seg++
+			segRecordId, isNil, segStart, segStride = s.segmentAt(seg)
+			nextRecordId = s.segmentEnd(seg)
+			curVal = segStart + (i-segRecordId)*segStride
+		}
+		if isNil {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewFloat(float64(curVal))
+			curVal += segStride
+		}
+		idx += stride
+	}
+}
+
+// GetValueMulti gathers arbitrary recids. When the batch is ascending (the
+// common case for an index-probe or range-scan batch), it walks the segment
+// cursor forward exactly like GetValueRange, recomputing the value with one
+// multiply per row (deltas between requested recids aren't necessarily 1)
+// but still only touching each crossed segment's recordId/start/stride once.
+// A genuinely unordered batch falls back to a fresh local findSegment per
+// row — still O(log seqCount) per row like GetValue, but without the shared
+// atomic pivot-cache contention.
+func (s *StorageSeq) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	n := len(recids)
+	if n == 0 {
+		return
+	}
+	ascending := true
+	for k := 1; k < n; k++ {
+		if recids[k] < recids[k-1] {
+			ascending = false
+			break
+		}
+	}
+
+	idx := 0
+	if ascending {
+		seg := s.findSegment(recids[0])
+		segRecordId, isNil, segStart, segStride := s.segmentAt(seg)
+		nextRecordId := s.segmentEnd(seg)
+		for _, recid := range recids {
+			i := int64(recid)
+			for i >= nextRecordId {
+				seg++
+				segRecordId, isNil, segStart, segStride = s.segmentAt(seg)
+				nextRecordId = s.segmentEnd(seg)
+			}
+			if isNil {
+				target[idx] = scm.NewNil()
+			} else {
+				target[idx] = scm.NewFloat(float64(segStart + (i-segRecordId)*segStride))
+			}
+			idx += stride
+		}
+		return
+	}
+
+	for _, recid := range recids {
+		seg := s.findSegment(recid)
+		segRecordId, isNil, segStart, segStride := s.segmentAt(seg)
+		if isNil {
+			target[idx] = scm.NewNil()
+		} else {
+			target[idx] = scm.NewFloat(float64(segStart + (int64(recid)-segRecordId)*segStride))
+		}
+		idx += stride
+	}
+}
+
 func (s *StorageSeq) prepare() {
 	// set up scan
 	s.recordId.prepare()

--- a/storage/storage-sparse.go
+++ b/storage/storage-sparse.go
@@ -3700,6 +3700,119 @@ func (s *StorageSparse) GetValue(i uint32) scm.Scmer {
 	}
 }
 
+// sparseSeek returns the smallest pivot in [0,s.i) whose recid is >= want,
+// via binary search. Used once to seed the forward merge-scan below instead
+// of a fresh binary search per requested row.
+func (s *StorageSparse) sparseSeek(want uint32) uint32 {
+	var lower, upper uint32 = 0, uint32(s.i)
+	for lower < upper {
+		pivot := (lower + upper) / 2
+		recid := uint32(s.recids.GetValueUInt(pivot)) + uint32(s.recids.offset)
+		if recid < want {
+			lower = pivot + 1
+		} else {
+			upper = pivot
+		}
+	}
+	return lower
+}
+
+// GetValueRange and GetValueMulti (ascending case) do a single binary search
+// to seed a pointer into the sparse recids array, then merge-scan it forward
+// against the requested rows in one pass — O(touched sparse entries + n)
+// instead of a binary search per requested row.
+func (s *StorageSparse) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	n := uint32(s.i)
+	sp := s.sparseSeek(recid)
+	var curRecid uint32
+	haveCur := false
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		want := recid + k
+		for {
+			if !haveCur {
+				if sp >= n {
+					break
+				}
+				curRecid = uint32(s.recids.GetValueUInt(sp)) + uint32(s.recids.offset)
+				haveCur = true
+			}
+			if curRecid < want {
+				sp++
+				haveCur = false
+				continue
+			}
+			break
+		}
+		if haveCur && curRecid == want {
+			target[idx] = s.values[sp]
+		} else {
+			target[idx] = scm.NewNil()
+		}
+		idx += stride
+	}
+}
+
+func (s *StorageSparse) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	n := len(recids)
+	if n == 0 {
+		return
+	}
+	ascending := true
+	for k := 1; k < n; k++ {
+		if recids[k] < recids[k-1] {
+			ascending = false
+			break
+		}
+	}
+	if !ascending {
+		idx := 0
+		for _, want := range recids {
+			target[idx] = s.GetValue(want)
+			idx += stride
+		}
+		return
+	}
+
+	total := uint32(s.i)
+	sp := s.sparseSeek(recids[0])
+	var curRecid uint32
+	haveCur := false
+	idx := 0
+	for _, want := range recids {
+		for {
+			if !haveCur {
+				if sp >= total {
+					break
+				}
+				curRecid = uint32(s.recids.GetValueUInt(sp)) + uint32(s.recids.offset)
+				haveCur = true
+			}
+			if curRecid < want {
+				sp++
+				haveCur = false
+				continue
+			}
+			break
+		}
+		if haveCur && curRecid == want {
+			target[idx] = s.values[sp]
+		} else {
+			target[idx] = scm.NewNil()
+		}
+		idx += stride
+	}
+}
+
 func (s *StorageSparse) scan(i uint32, value scm.Scmer) {
 	if !value.IsNil() {
 		s.recids.scan(uint32(s.i), scm.NewInt(int64(i)))

--- a/storage/storage-string.go
+++ b/storage/storage-string.go
@@ -674,7 +674,53 @@ func (s *StorageString) GetCachedReader() ColumnReader { return s }
 
 func (s *StorageString) GetValue(i uint32) scm.Scmer {
 	atomic.AddUint64(&s.readCount, 1)
+	dict := s.ensureDict()
+	dictBase := unsafe.Pointer(unsafe.StringData(dict))
+	return s.decodeAt(i, dict, dictBase)
+}
 
+// GetValueRange and GetValueMulti hoist the two things that GetValue would
+// otherwise redo on every element — ensureDict()'s lock/branch and the dict
+// base pointer computation — out of the loop, and collapse the per-call
+// atomic readCount increment into a single batched add.
+func (s *StorageString) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if count == 0 {
+		return
+	}
+	atomic.AddUint64(&s.readCount, uint64(count))
+	dict := s.ensureDict()
+	dictBase := unsafe.Pointer(unsafe.StringData(dict))
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = s.decodeAt(recid+k, dict, dictBase)
+		idx += stride
+	}
+}
+
+func (s *StorageString) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	if len(recids) == 0 {
+		return
+	}
+	atomic.AddUint64(&s.readCount, uint64(len(recids)))
+	dict := s.ensureDict()
+	dictBase := unsafe.Pointer(unsafe.StringData(dict))
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = s.decodeAt(recid, dict, dictBase)
+		idx += stride
+	}
+}
+
+// decodeAt is the format-dispatch decode logic shared by GetValue and the
+// bulk readers. dict/dictBase are passed in so bulk callers materialize the
+// dictionary exactly once per batch instead of once per row.
+func (s *StorageString) decodeAt(i uint32, dict string, dictBase unsafe.Pointer) scm.Scmer {
 	var startVal, lensVal uint64
 	if s.nodict {
 		sv := uint64(int64(s.starts.GetValueUInt(i)) + s.starts.offset)
@@ -700,8 +746,6 @@ func (s *StorageString) GetValue(i uint32) scm.Scmer {
 	//   Base64: decoded byte count
 	//   UUID: unused (always 16 bytes / 36 chars)
 	//   Raw: byte count
-	dict := s.ensureDict()
-	dictBase := unsafe.Pointer(unsafe.StringData(dict))
 	switch s.format {
 	case FormatRaw:
 		byteStart := startVal

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -34,14 +34,57 @@ import "github.com/launix-de/go-mysqlstack/sqldb"
 
 // ColumnReader provides sequential-access-optimized reads. Returned by
 // ColumnStorage.GetCachedReader(). Must not be shared between goroutines.
+//
+// GetValueMulti and GetValueRange are bulk counterparts to GetValue that
+// amortize per-call overhead (interface dispatch, binary search, shared
+// decode state) across many rows in one call:
+//
+//   - GetValueMulti(recids, target, stride) gathers values at arbitrary,
+//     caller-supplied row ids (e.g. an index-probe batch or a sort
+//     permutation). Implementations should detect runs of ascending recids
+//     and take a sequential fast path where their underlying encoding
+//     benefits from it (rANS chunk decode, run-length sequences, sparse
+//     merge), falling back to per-element lookup only for genuine jumps.
+//   - GetValueRange(recid, count, target, stride) reads count consecutive
+//     rows starting at recid. Implementations should use this to skip
+//     repeated binary search / bit-position division entirely.
+//
+// Both write results into target starting at target[0], target[stride],
+// target[2*stride], ... so a caller building an interleaved multi-column
+// row buffer can pass stride=rowWidth and a per-column offset slice
+// (target[colOffset:]). stride<=0 is treated as 1.
 type ColumnReader interface {
 	GetValue(uint32) scm.Scmer
+	GetValueMulti(recids []uint32, target []scm.Scmer, stride int)
+	GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int)
 }
 
 type ColumnReaderFunc func(uint32) scm.Scmer
 
 func (f ColumnReaderFunc) GetValue(idx uint32) scm.Scmer {
 	return f(idx)
+}
+
+func (f ColumnReaderFunc) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for _, recid := range recids {
+		target[idx] = f(recid)
+		idx += stride
+	}
+}
+
+func (f ColumnReaderFunc) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	if stride <= 0 {
+		stride = 1
+	}
+	idx := 0
+	for k := uint32(0); k < count; k++ {
+		target[idx] = f(recid + k)
+		idx += stride
+	}
 }
 
 // TxColumnReaderProvider optionally exposes a transaction-bound reader.
@@ -159,7 +202,15 @@ func normalizePartitionDataset(arg scm.Scmer) dataset {
 // THE basic storage pattern
 type ColumnStorage interface {
 	// info
-	GetValue(uint32) scm.Scmer     // read function (concurrent-safe, no mutable state)
+	GetValue(uint32) scm.Scmer // read function (concurrent-safe, no mutable state)
+	// GetValueMulti and GetValueRange are the bulk counterparts of GetValue;
+	// see the ColumnReader doc comment for the exact contract. Every storage
+	// format must implement both with a real bulk strategy for its own
+	// encoding (sequential cursor, cached decode, merge-scan, ...) rather
+	// than a naive per-element loop through GetValue, wherever that
+	// encoding has state worth amortizing across a batch.
+	GetValueMulti(recids []uint32, target []scm.Scmer, stride int)
+	GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int)
 	GetCachedReader() ColumnReader // returns a per-goroutine cached reader for O(1) sequential access
 	String() string                // self-description
 	scm.Sizable

--- a/storage/storage_bulk_read_test.go
+++ b/storage/storage_bulk_read_test.go
@@ -1,0 +1,170 @@
+package storage
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+// bulkReadFixtures drives buildViaCompression with generators chosen to hit
+// each concrete ColumnStorage format's proposeCompression path, so the
+// generic checks below exercise every format's GetValueRange/GetValueMulti
+// implementation, not just one.
+func bulkReadFixtures() []struct {
+	name string
+	n    int
+	gen  func(int) scm.Scmer
+} {
+	return []struct {
+		name string
+		n    int
+		gen  func(int) scm.Scmer
+	}{
+		{"Const", 500, func(i int) scm.Scmer { return scm.NewInt(42) }},
+		{"IntRandom", 500, func(i int) scm.Scmer { return scm.NewInt(int64((i*2654435761)%9973) - 5000) }},
+		{"IntWithNulls", 500, func(i int) scm.Scmer {
+			if i%7 == 0 {
+				return scm.NewNil()
+			}
+			return scm.NewInt(int64(i % 100))
+		}},
+		{"Seq", 500, func(i int) scm.Scmer { return scm.NewInt(int64(i) * 3) }},
+		{"SeqWithNullRuns", 500, func(i int) scm.Scmer {
+			if (i/17)%5 == 0 {
+				return scm.NewNil()
+			}
+			return scm.NewInt(int64(i))
+		}},
+		{"Decimal", 500, func(i int) scm.Scmer { return scm.NewFloat(float64(i%1000) / 100.0) }},
+		{"Sparse", 500, func(i int) scm.Scmer {
+			if i%23 != 0 {
+				return scm.NewNil()
+			}
+			return scm.NewString("v")
+		}},
+		{"Enum", 500, func(i int) scm.Scmer {
+			switch i % 5 {
+			case 0:
+				return scm.NewString("alpha")
+			case 1:
+				return scm.NewString("beta")
+			case 2:
+				return scm.NewString("gamma")
+			case 3:
+				return scm.NewNil()
+			default:
+				return scm.NewString("delta")
+			}
+		}},
+		{"StringDict", 500, func(i int) scm.Scmer { return scm.NewString("str_" + scm.String(scm.NewInt(int64(i%37)))) }},
+		{"StringPrefix", 500, func(i int) scm.Scmer {
+			return scm.NewString("https://example.com/path/" + scm.String(scm.NewInt(int64(i))))
+		}},
+		{"Float", 500, func(i int) scm.Scmer { return scm.NewFloat(float64(i) * 1.0000001) }},
+	}
+}
+
+// bulkReadable is the minimal read surface shared by ColumnStorage and
+// ColumnReader, so the checks below run identically against either.
+type bulkReadable interface {
+	GetValue(uint32) scm.Scmer
+	GetValueMulti(recids []uint32, target []scm.Scmer, stride int)
+	GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int)
+}
+
+func verifyBulkAgainstGetValue(t *testing.T, name string, col bulkReadable, n int) {
+	t.Helper()
+
+	want := make([]scm.Scmer, n)
+	for i := 0; i < n; i++ {
+		want[i] = col.GetValue(uint32(i))
+	}
+
+	// GetValueRange over the full column, stride 1.
+	got := make([]scm.Scmer, n)
+	col.GetValueRange(0, uint32(n), got, 1)
+	for i := 0; i < n; i++ {
+		if !scm.Equal(got[i], want[i]) {
+			t.Errorf("%s: GetValueRange(0,%d)[%d] = %v, want %v", name, n, i, got[i], want[i])
+		}
+	}
+
+	// GetValueRange over a mid-column window.
+	base := uint32(n / 4)
+	count := uint32(n / 2)
+	got2 := make([]scm.Scmer, count)
+	col.GetValueRange(base, count, got2, 1)
+	for k := uint32(0); k < count; k++ {
+		if !scm.Equal(got2[k], want[base+k]) {
+			t.Errorf("%s: GetValueRange(%d,%d)[%d] = %v, want %v", name, base, count, k, got2[k], want[base+k])
+		}
+	}
+
+	// GetValueMulti with an ascending, gappy subset (the common index-scan shape).
+	var ascending []uint32
+	for i := 0; i < n; i += 3 {
+		ascending = append(ascending, uint32(i))
+	}
+	gotAsc := make([]scm.Scmer, len(ascending))
+	col.GetValueMulti(ascending, gotAsc, 1)
+	for k, recid := range ascending {
+		if !scm.Equal(gotAsc[k], want[recid]) {
+			t.Errorf("%s: GetValueMulti(ascending)[%d] (recid %d) = %v, want %v", name, k, recid, gotAsc[k], want[recid])
+		}
+	}
+
+	// GetValueMulti with a shuffled (non-monotonic) subset, including repeats.
+	rng := rand.New(rand.NewSource(1))
+	shuffled := make([]uint32, 0, n)
+	for i := 0; i < n; i++ {
+		shuffled = append(shuffled, uint32(i))
+	}
+	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	shuffled = append(shuffled, shuffled[:n/5]...) // duplicate a prefix to exercise repeats
+	gotShuf := make([]scm.Scmer, len(shuffled))
+	col.GetValueMulti(shuffled, gotShuf, 1)
+	for k, recid := range shuffled {
+		if !scm.Equal(gotShuf[k], want[recid]) {
+			t.Errorf("%s: GetValueMulti(shuffled)[%d] (recid %d) = %v, want %v", name, k, recid, gotShuf[k], want[recid])
+		}
+	}
+
+	// stride>1: writes must land at target[k*stride], leaving the gaps alone.
+	const stride = 3
+	target := make([]scm.Scmer, len(ascending)*stride)
+	for i := range target {
+		target[i] = scm.NewString("sentinel")
+	}
+	col.GetValueMulti(ascending, target, stride)
+	for k, recid := range ascending {
+		if !scm.Equal(target[k*stride], want[recid]) {
+			t.Errorf("%s: GetValueMulti stride=%d [%d] (recid %d) = %v, want %v", name, stride, k, recid, target[k*stride], want[recid])
+		}
+	}
+	for i := range ascending {
+		for g := 1; g < stride; g++ {
+			if !scm.Equal(target[i*stride+g], scm.NewString("sentinel")) {
+				t.Errorf("%s: GetValueMulti stride=%d clobbered gap slot %d", name, stride, i*stride+g)
+			}
+		}
+	}
+}
+
+// TestBulkReadMatchesGetValue checks GetValueRange/GetValueMulti against a
+// plain per-element GetValue loop across every ColumnStorage format
+// proposeCompression can produce, plus the reader returned by
+// GetCachedReader() for each.
+func TestBulkReadMatchesGetValue(t *testing.T) {
+	for _, fx := range bulkReadFixtures() {
+		fx := fx
+		t.Run(fx.name, func(t *testing.T) {
+			col := buildViaCompression(fx.n, fx.gen)
+			t.Logf("%s compressed to %s", fx.name, col.String())
+			verifyBulkAgainstGetValue(t, fx.name+"/storage", col, fx.n)
+
+			reader := col.GetCachedReader()
+			verifyBulkAgainstGetValue(t, fx.name+"/reader", reader, fx.n)
+		})
+	}
+}

--- a/storage/table.go
+++ b/storage/table.go
@@ -726,6 +726,7 @@ func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName st
 	}
 	var rowCount uint64
 	var hasValue bool
+	var buf []scm.Scmer
 	for _, shard := range shards {
 		if shard == nil {
 			continue
@@ -734,10 +735,14 @@ func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName st
 		if columnStorage == nil {
 			continue
 		}
+		if cap(buf) < int(shard.main_count) {
+			buf = make([]scm.Scmer, shard.main_count)
+		}
+		buf = buf[:shard.main_count]
 		reader := columnStorage.GetCachedReader()
-		for recid := uint32(0); recid < shard.main_count; recid++ {
+		reader.GetValueRange(0, shard.main_count, buf, 1)
+		for _, value := range buf {
 			rowCount++
-			value := reader.GetValue(recid)
 			if value.IsNil() {
 				stats.NullCount++
 				continue


### PR DESCRIPTION
## Summary

`ColumnStorage`/`ColumnReader` previously exposed only `GetValue(i uint32)`. Several hot loops across `scan.go`, `scan_order.go`, `recset.go`, `shard.go`, `partition.go`, and `table.go` call it once per row per column, which pays full interface dispatch plus each format's per-element decode cost (binary search, bit-position division, dictionary lookups, rANS chunk decode) on every single call.

This PR adds two mandatory bulk-read methods to the `ColumnStorage`/`ColumnReader` interface:

- `GetValueMulti(recids []uint32, target []scm.Scmer, stride int)` — gathers values at an arbitrary (often ascending) batch of row ids, e.g. an index-probe result or a sort permutation.
- `GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int)` — reads `count` consecutive rows starting at `recid`.

Both write results into `target` at `target[0], target[stride], target[2*stride], ...` so a caller building an interleaved multi-column row buffer (e.g. `recset` project) can pass `stride = rowWidth` and a per-column offset slice.

Every format implements **both** with a real bulk strategy — not a loop over `GetValue` — wherever its encoding has per-element overhead worth amortizing across a batch. `GetValueMulti` additionally detects ascending runs (the common case for a batch drawn from an index range scan) and takes the same fast path as `GetValueRange` for those; a genuinely unordered batch falls back to per-element decode with no regression.

## Per-format implementation notes

- **StorageInt**: keeps a rolling `(chunkIdx, bitOff)` cursor and advances it by `bitsize` per row instead of recomputing `bitpos/64` and `bitpos%64` (a division+modulo) for every element. `GetValueMulti` reuses the cursor across any run of `recids[k] == recids[k-1]+1`, falling back to a direct bitpos computation only on a jump.
- **StorageSeq** (arithmetic run-length sequences): does **one** local binary search to find the starting segment, then walks forward, reading each crossed segment's `(recordId, start, stride)` once and computing the rest by addition — O(segments touched + n) instead of O(n·log segments). This also sidesteps a real concurrency bug: `GetValue`'s binary search caches its pivot in a single `atomic.Int64` field shared on the struct, so concurrent goroutines doing sequential bulk reads over the same column were thrashing each other's cached pivot. The new bulk paths use purely local search state and never touch that atomic.
- **StorageSparse**: same idea — one binary search to seed a pointer into the sparse recid array, then a forward merge-scan against the (ascending) requested rows, touching each sparse entry once.
- **StorageEnum** (rANS entropy coding): `GetValueRange`/`GetValueMulti`, and the `cachedEnumReader` returned by `GetCachedReader()`, decode the whole batch through **one** local `EnumDecodeCache` via the existing `GetValueCached` — the same O(1)-amortized sequential/jump decode path already used for per-thread cached sequential scans, just applied across the batch instead of via `GetValue`'s always-binary-search path. See benchmark numbers below — this is the actual "decompression is expensive" case called out in review.
- **StorageString**: hoists `ensureDict()` (lock + branch) and the dictionary base pointer out of the loop, and batches the `readCount` atomic increment into one `AddUint64` per call instead of one per row. `GetValue` itself was refactored to share the same `decodeAt` helper (no logic duplication).
- **StorageConst / StorageSCMER / StorageFloat**: trivial O(1)-per-row fills/copies; no per-element state to amortize, but still real (non-`GetValue`) implementations as required by the interface.
- **StorageDecimal / StoragePrefix / OverlayBlob**: wrapper formats. Rather than duplicating their wrapped storage's decode logic, they delegate the bulk read to the wrapped storage's own `GetValueMulti`/`GetValueRange` (one call instead of N) and then do a cheap in-place post-process pass (rescale / prefix-concat / blob-resolve).
- **StorageComputeProxy** (+ its two reader wrappers): takes the bulk fast path — one call straight into `main` — only when every requested row is guaranteed already-materialized (compressed, no pending delta, not an ORC column); everything else falls back to the existing per-row `GetValue`, which contains the full invalidation/session/compute-repair logic. Duplicating that branchy stateful logic for the sake of batching was judged too risky relative to the benefit for a derived/computed column type.

## Callsites converted

Wired into every hot-loop site that already held a candidate id list **without** an early-exit consumer (so reading the whole batch upfront is strictly more work, not less):

- `table.go`: planner statistics collection (min/max/null-count scan) — was a plain per-row sequential loop, now one `GetValueRange` per shard.
- `shard.go`: rebuild's scan/build column replay. The old code had two near-duplicate branches (`sortPerm != nil` vs plain `mainCount` walk) each calling `GetValue` per row; both are unified into one `replayRebuiltRows` helper that bulk-fetches every main-sourced row in a single `GetValueMulti` call per column (precomputed once per shard, not per column) and interleaves delta-sourced rows from the existing `getDelta` map lookup.
- `partition.go`: both `partition()` implementations (the snapshot-based and the direct-shard-based one, previously near-duplicated) now share a `partitionMainRows` helper that separates the data-independent deletion-skip pass from a per-dimension bulk column read.
- `scan_order.go`: the main-storage condition-evaluation loop (WHERE-filter path feeding ORDER BY / indexed scans) now does a 3-pass batch transform — collect surviving ids (visibility/deletion/recset checks, no column reads), bulk-fetch every non-getter condition column for the main-storage survivors, then evaluate the condition per row from the pre-fetched buffers. Getter-backed columns (correlated closures) and delta rows are unchanged (per-row), since those aren't real bulk-storage reads.

**Deliberately left per-element**: `scanFind`'s small (≤8-row) early-exit batches in `scan.go` (bulk-prefetching would waste work once a match is found on row 1), `recset.go`'s `evaluate`/`forEachID`-driven paths (ids arrive one at a time via a push callback, not a pre-built slice — materializing one would be a separate iterator-API change), and `scan.go`'s mutation-dedup UPDATE/DELETE loop (the `resolveVisiblePrimaryRecidLocked` follow + `mutationSeen` dedup is interleaved with per-row column reads in a way that made a safe two-pass split for this PR's scope too risky to land untested against ACID/proxy interaction).

## Testing

- New `storage/storage_bulk_read_test.go`: `TestBulkReadMatchesGetValue` builds a `ColumnStorage` through the real `proposeCompression` pipeline for 11 generators (const, random/sequential/null-bearing ints, decimal, sparse, low-cardinality enum-ish, dict/prefix-compressible strings, float) and checks `GetValueRange` (full + windowed) and `GetValueMulti` (ascending-gappy, shuffled-with-repeats, stride>1 with gap-clobber check) against a plain `GetValue` loop, for both the storage itself and its `GetCachedReader()`.
- New `TestEnumBulkMatchesGetValue` in `storage/storage-enum_test.go`: same check specifically for `StorageEnum` and `cachedEnumReader` across all existing distribution configs (99/1 skew, 50/50, 4-way uniform, 8-way skewed).
- `go build ./...`, `go vet ./storage/...` (no new warnings beyond the pre-existing ones from generated `JITEmit` code and other pre-existing lock-copy findings), `gofmt` clean (the only diff needed was in the hand-written `storage-prefix.go` section; the 7 files that remain `gofmt`-dirty are unrelated generated `JITEmit` blocks, dirty on `master` too).
- Full `storage` package test suite and the full SQL regression suite (`tests/**/*.yaml`, ~5600 cases via `run_sql_tests.py`) via the repo's pre-commit hook: all pass. Two pre-existing *noncritical* deep-correlated-subselect failures (unrelated, tracked separately — see `CLAUDE.md`'s Neumann unnesting notes) reproduce identically on `master`. One test-restart timing flake and a `TestPartitionTable*`/`TestStorageIntJITEmit` panic class were investigated and confirmed to reproduce identically on unmodified `master` under the same (heavily loaded) host — not introduced by this change.

## Performance

Go micro-benchmark added to `storage/storage-enum_test.go` (`go test ./storage/ -bench 'BenchmarkEnum.*' -benchtime=200x`), 100K-row configs:

| Access pattern | per-element `GetValue` | existing cached reader | new bulk (`GetValueRange`/`Multi`) |
|---|---|---|---|
| Sequential, 99/1 skew | 76.2 ms | 543 µs | 654 µs (**~117x**) |
| Sequential, 50/50 | 8.66 ms | 532 µs | 691 µs (**~13x**) |
| Sequential, 4-way uniform | 6.67 ms | 575 µs | 678 µs (**~10x**) |
| Sequential, 8-way skewed | 8.70 ms | 573 µs | 683 µs (**~13x**) |
| Random (genuinely unordered) | 10.7–79.6 ms | 11–83 ms (no win) | 11–83 ms (**no regression**) |

The bulk path matches the existing per-thread cached-reader mechanism almost exactly (as expected, since it's built on the same `GetValueCached`), confirming it's reusing rather than reinventing that fast path — the win over plain `GetValue` comes from every *other* caller (`scan_order.go`'s WHERE-filter loop, `shard.go` rebuild, `partition.go`, `table.go` stats) no longer needing to thread a per-thread cache through manually to get it. Random/unordered access shows no regression, as expected — the ascending-run detection correctly declines to "sort" data that isn't sorted.

A live end-to-end SQL A/B benchmark (master vs. this branch, TPC-ish `ORDER BY`/`WHERE` queries through the converted `scan_order.go` path) was attempted but not obtained cleanly this session: the shared host this ran on had several other concurrent sessions and a game running (load average ~11.6), which made even plain `master` intermittently fail its own startup self-tests and hit a pre-existing DB-creation race — reproduced identically without this branch involved. Happy to re-run once the host is quieter if a live number is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)