### PR TITLE
storage: recSetRanges encoding for recset, remove Full/Negative, bulk-wire recset scans

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -78,12 +78,28 @@ func (c *skipListCursor) NextBlock(pos uint32) (uint32, uint32, bool) {
 		return 0, 0, false
 	}
 	set := &c.skip.matches
-	if pos >= set.universe || set.kind == recSetEmpty {
+	if pos >= set.universe || set.count == 0 {
 		return 0, 0, false
 	}
 	switch set.kind {
-	case recSetFull:
-		return pos, set.universe - pos, true
+	case recSetRanges:
+		// A "full" set (everything matches) is just one pair covering
+		// [0,universe) here — no separate case needed; if pos lands inside
+		// that pair, it's trimmed to start at pos below, same as it would
+		// for any other range.
+		ranges := set.listedRanges()
+		for c.listPos < len(ranges) && ranges[c.listPos]+ranges[c.listPos+1] <= pos {
+			c.listPos += 2
+		}
+		if c.listPos >= len(ranges) {
+			return 0, 0, false
+		}
+		base, count := ranges[c.listPos], ranges[c.listPos+1]
+		if base < pos {
+			count -= pos - base
+			base = pos
+		}
+		return base, count, true
 	case recSetPositive:
 		values := set.listedValues()
 		for c.listPos < len(values) && values[c.listPos] < pos {
@@ -100,23 +116,6 @@ func (c *skipListCursor) NextBlock(pos uint32) (uint32, uint32, bool) {
 			c.listPos++
 		}
 		return start, end - start, true
-	case recSetNegative:
-		excluded := set.listedValues()
-		for c.listPos < len(excluded) && excluded[c.listPos] < pos {
-			c.listPos++
-		}
-		for c.listPos < len(excluded) && excluded[c.listPos] == pos {
-			pos++
-			c.listPos++
-		}
-		if pos >= set.universe {
-			return 0, 0, false
-		}
-		end := set.universe
-		if c.listPos < len(excluded) {
-			end = excluded[c.listPos]
-		}
-		return pos, end - pos, true
 	case recSetBitmap:
 		wordIndex := pos >> 5
 		word := set.data[wordIndex] & (^uint32(0) << (pos & 31))

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -42,17 +42,69 @@ func (s *recSetShard) contains(recid uint32) bool {
 		return false
 	}
 	switch s.kind {
-	case recSetFull:
-		return true
+	case recSetRanges:
+		return s.rangesContains(recid)
 	case recSetPositive:
 		return sortedUint32Contains(s.listedValues(), recid)
-	case recSetNegative:
-		return !sortedUint32Contains(s.listedValues(), recid)
 	case recSetBitmap:
 		return s.data[recid>>5]&(uint32(1)<<(recid&31)) != 0
 	default:
 		return false
 	}
+}
+
+// forEachVisibleRun walks part via forEachRange, splitting each range into
+// maximal runs of currently-visible rows (below visibleUpper, and neither
+// deleted nor tx-invisible), and calls onRun(base, count) once per such
+// run — the natural granularity for a bulk column read (GetValueRange)
+// instead of one GetValue call per row. Visibility is still checked one row
+// at a time (that was never avoidable — it's a property check, not a column
+// read, and doesn't get any cheaper by batching); what this saves is the
+// column reads inside onRun, which can cover however many consecutive rows
+// happen to be visible in a row, often the whole run for a recSetRanges
+// shard with no deletions in flight.
+func (t *storageShard) forEachVisibleRun(part *recSetShard, visibleUpper uint32, acidMode bool, currentTx *TxContext, onRun func(base, count uint32) bool) {
+	cont := true
+	part.forEachRange(func(base, count uint32) bool {
+		end := base + count
+		if base >= visibleUpper {
+			return true
+		}
+		if end > visibleUpper {
+			end = visibleUpper
+		}
+		var runStart uint32
+		haveRun := false
+		for idx := base; idx < end; idx++ {
+			visible := true
+			if acidMode {
+				visible = currentTx.IsVisible(t, idx)
+			} else if t.deletions.Get(uint(idx)) {
+				visible = false
+			}
+			if visible {
+				if !haveRun {
+					runStart = idx
+					haveRun = true
+				}
+				continue
+			}
+			if haveRun {
+				if !onRun(runStart, idx-runStart) {
+					cont = false
+					return false
+				}
+				haveRun = false
+			}
+		}
+		if haveRun {
+			if !onRun(runStart, end-runStart) {
+				cont = false
+				return false
+			}
+		}
+		return cont
+	})
 }
 
 // recSet is a query-local, non-persistent subset of one table represented by
@@ -598,30 +650,54 @@ func (t *storageShard) collectProjectJoinKeys(part *recSetShard, sourceKeyCols [
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	write := 0
-	part.forEachID(func(idx uint32) bool {
-		if idx >= visibleUpper {
-			return true
+	colBufs := make([][]scm.Scmer, len(sourceKeyCols))
+	t.forEachVisibleRun(part, visibleUpper, acidMode, currentTx, func(base, count uint32) bool {
+		end := base + count
+		mainEnd := end
+		if mainEnd > mainCount {
+			mainEnd = mainCount
 		}
-		if acidMode {
-			if !currentTx.IsVisible(t, idx) {
-				return true
-			}
-		} else if t.deletions.Get(uint(idx)) {
-			return true
+		if mainEnd < base {
+			// Run lies entirely in the delta region (base >= mainCount):
+			// without this, the delta loop below would incorrectly start
+			// at mainCount instead of base, reprocessing indices
+			// [mainCount,base) that aren't part of this run at all.
+			mainEnd = base
 		}
-		skip := false
-		if idx < mainCount {
-			for i, col := range cols {
+		if base < mainEnd {
+			// Main-storage sub-run: bulk-fetch every column for the whole
+			// run in one GetValueRange call each, instead of one GetValue
+			// call per row per column.
+			runLen := mainEnd - base
+			for i := range sourceKeyCols {
+				if cap(colBufs[i]) < int(runLen) {
+					colBufs[i] = make([]scm.Scmer, runLen)
+				}
+				colBufs[i] = colBufs[i][:runLen]
 				if needsTxReader[i] {
-					dst[write+i] = readers[i].GetValue(idx)
+					readers[i].GetValueRange(base, runLen, colBufs[i], 1)
 				} else {
-					dst[write+i] = col.GetValue(idx)
-				}
-				if dst[write+i].IsNil() {
-					skip = true
+					cols[i].GetValueRange(base, runLen, colBufs[i], 1)
 				}
 			}
-		} else {
+			for row := uint32(0); row < runLen; row++ {
+				skip := false
+				for i := range sourceKeyCols {
+					v := colBufs[i][row]
+					dst[write+i] = v
+					if v.IsNil() {
+						skip = true
+					}
+				}
+				if !skip {
+					write += len(sourceKeyCols)
+				}
+			}
+		}
+		// Delta sub-run (idx >= mainCount): getDelta is a plain map lookup,
+		// not a ColumnStorage read, so there's nothing to batch here.
+		for idx := mainEnd; idx < end; idx++ {
+			skip := false
 			for i, col := range sourceKeyCols {
 				if needsTxReader[i] {
 					dst[write+i] = readers[i].GetValue(idx)
@@ -634,9 +710,9 @@ func (t *storageShard) collectProjectJoinKeys(part *recSetShard, sourceKeyCols [
 					skip = true
 				}
 			}
-		}
-		if !skip {
-			write += len(sourceKeyCols)
+			if !skip {
+				write += len(sourceKeyCols)
+			}
 		}
 		return true
 	})
@@ -1154,26 +1230,71 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 	var outCount int64
 	var buf [1024]uint32
 	pending := buf[:0]
-	part.forEachID(func(idx uint32) bool {
-		if idx >= visibleUpper {
-			return true
+	flush := func() {
+		if len(pending) == 0 {
+			return
 		}
-		if acidMode {
-			if !currentTx.IsVisible(t, idx) {
-				return true
+		if locked {
+			t.mu.RUnlock()
+			locked = false
+		}
+		akkumulator = mapper.Stream(akkumulator, pending, nil)
+		pending = buf[:0]
+		if !skipShardReadLock {
+			t.mu.RLock()
+			locked = true
+		}
+	}
+	colBufs := make([][]scm.Scmer, len(conditionCols))
+	t.forEachVisibleRun(part, visibleUpper, acidMode, currentTx, func(base, count uint32) bool {
+		end := base + count
+		mainEnd := end
+		if mainEnd > mainCount {
+			mainEnd = mainCount
+		}
+		if mainEnd < base {
+			// Run lies entirely in the delta region (base >= mainCount):
+			// without this, the delta loop below would incorrectly start
+			// at mainCount instead of base, reprocessing indices
+			// [mainCount,base) that aren't part of this run at all.
+			mainEnd = base
+		}
+		if base < mainEnd {
+			// Main-storage sub-run: bulk-fetch every non-getter condition
+			// column for the whole run in one GetValueRange call each.
+			runLen := mainEnd - base
+			for i := range conditionCols {
+				if conditionGetters[i] != nil {
+					continue
+				}
+				if cap(colBufs[i]) < int(runLen) {
+					colBufs[i] = make([]scm.Scmer, runLen)
+				}
+				colBufs[i] = colBufs[i][:runLen]
+				cReaders[i].GetValueRange(base, runLen, colBufs[i], 1)
 			}
-		} else if t.deletions.Get(uint(idx)) {
-			return true
-		}
-		if idx < mainCount {
-			for i, c := range cReaders {
-				if getter := conditionGetters[i]; getter != nil {
-					cdataset[i] = getter(idx, 0)
-				} else {
-					cdataset[i] = c.GetValue(idx)
+			for row := uint32(0); row < runLen; row++ {
+				idx := base + row
+				for i := range conditionCols {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else {
+						cdataset[i] = colBufs[i][row]
+					}
+				}
+				if !scm.ToBool(conditionFn(cdataset...)) {
+					continue
+				}
+				pending = append(pending, idx)
+				outCount++
+				if len(pending) == cap(buf) {
+					flush()
 				}
 			}
-		} else {
+		}
+		// Delta sub-run: unchanged, per-row (getDelta is a map lookup, not a
+		// ColumnStorage read).
+		for idx := mainEnd; idx < end; idx++ {
 			for i, col := range conditionCols {
 				if getter := conditionGetters[i]; getter != nil {
 					cdataset[i] = getter(idx, 0)
@@ -1183,33 +1304,18 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 					cdataset[i] = t.getDelta(int(idx-mainCount), col)
 				}
 			}
-		}
-		if !scm.ToBool(conditionFn(cdataset...)) {
-			return true
-		}
-		pending = append(pending, idx)
-		outCount++
-		if len(pending) == cap(buf) {
-			if locked {
-				t.mu.RUnlock()
-				locked = false
+			if !scm.ToBool(conditionFn(cdataset...)) {
+				continue
 			}
-			akkumulator = mapper.Stream(akkumulator, pending, nil)
-			pending = buf[:0]
-			if !skipShardReadLock {
-				t.mu.RLock()
-				locked = true
+			pending = append(pending, idx)
+			outCount++
+			if len(pending) == cap(buf) {
+				flush()
 			}
 		}
 		return true
 	})
-	if len(pending) > 0 {
-		if locked {
-			t.mu.RUnlock()
-			locked = false
-		}
-		akkumulator = mapper.Stream(akkumulator, pending, nil)
-	}
+	flush()
 	if locked {
 		t.mu.RUnlock()
 		locked = false
@@ -1326,26 +1432,51 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
 	result.items = make([]uint32, 0, part.count)
-	part.forEachID(func(idx uint32) bool {
-		if idx >= visibleUpper {
-			return true
+	colBufs := make([][]scm.Scmer, len(conditionCols))
+	t.forEachVisibleRun(part, visibleUpper, acidMode, currentTx, func(base, count uint32) bool {
+		end := base + count
+		mainEnd := end
+		if mainEnd > mainCount {
+			mainEnd = mainCount
 		}
-		if acidMode {
-			if !currentTx.IsVisible(t, idx) {
-				return true
+		if mainEnd < base {
+			// Run lies entirely in the delta region (base >= mainCount):
+			// without this, the delta loop below would incorrectly start
+			// at mainCount instead of base, reprocessing indices
+			// [mainCount,base) that aren't part of this run at all.
+			mainEnd = base
+		}
+		if base < mainEnd {
+			// Main-storage sub-run: bulk-fetch every non-getter condition
+			// column for the whole run in one GetValueRange call each.
+			runLen := mainEnd - base
+			for i := range conditionCols {
+				if conditionGetters[i] != nil {
+					continue
+				}
+				if cap(colBufs[i]) < int(runLen) {
+					colBufs[i] = make([]scm.Scmer, runLen)
+				}
+				colBufs[i] = colBufs[i][:runLen]
+				cReaders[i].GetValueRange(base, runLen, colBufs[i], 1)
 			}
-		} else if t.deletions.Get(uint(idx)) {
-			return true
-		}
-		if idx < mainCount {
-			for i, c := range cReaders {
-				if getter := conditionGetters[i]; getter != nil {
-					cdataset[i] = getter(idx, 0)
-				} else {
-					cdataset[i] = c.GetValue(idx)
+			for row := uint32(0); row < runLen; row++ {
+				idx := base + row
+				for i := range conditionCols {
+					if getter := conditionGetters[i]; getter != nil {
+						cdataset[i] = getter(idx, 0)
+					} else {
+						cdataset[i] = colBufs[i][row]
+					}
+				}
+				if scm.ToBool(conditionFn(cdataset...)) {
+					result.items = append(result.items, idx)
 				}
 			}
-		} else {
+		}
+		// Delta sub-run: unchanged, per-row (getDelta is a map lookup, not a
+		// ColumnStorage read).
+		for idx := mainEnd; idx < end; idx++ {
 			for i, col := range conditionCols {
 				if getter := conditionGetters[i]; getter != nil {
 					cdataset[i] = getter(idx, 0)
@@ -1355,9 +1486,9 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 					cdataset[i] = t.getDelta(int(idx-mainCount), col)
 				}
 			}
-		}
-		if scm.ToBool(conditionFn(cdataset...)) {
-			result.items = append(result.items, idx)
+			if scm.ToBool(conditionFn(cdataset...)) {
+				result.items = append(result.items, idx)
+			}
 		}
 		return true
 	})

--- a/storage/recset_representation.go
+++ b/storage/recset_representation.go
@@ -21,27 +21,103 @@ import "sort"
 
 type recSetRepresentation uint8
 
+// Three kinds. There is deliberately no "full" or "empty" tag: a shard that
+// matches everything is recSetRanges with one pair covering [0,universe), and
+// a shard that matches nothing is recSetRanges with zero pairs — both fall
+// out of the general ranges logic with no special-casing, and (unlike the
+// former recSetFull) can never accidentally read past universe or absorb
+// rows a caller forgot to bound-check.
+//
+// There is also deliberately no "negative" (exclusion-list) tag anymore.
+// recSetRanges already represents "everything except a few scattered holes"
+// compactly — each hole just ends one run and starts the next, so a handful
+// of exceptions costs a handful of range pairs, not a bitmap. A negative tag
+// would only additionally help "everything except MANY scattered individual
+// exceptions", which is rare in practice, and its bulk/iteration form is the
+// *complement* of what's stored — derived, stateful, and a real source of
+// off-by-one bugs at shard/universe boundaries. That pattern now falls
+// through to recSetBitmap once ranges fragments past budget, which is
+// simpler and always correct.
 const (
-	recSetEmpty recSetRepresentation = iota
-	recSetFull
+	recSetRanges recSetRepresentation = iota
 	recSetPositive
-	recSetNegative
 	recSetBitmap
 )
 
-// recSetShardBuilder allocates exactly the eventual bitmap footprint. Until
-// deviations from the first result fill that storage, the same words hold a
-// positive or negative recid list. Overflow converts the words in place.
+// recSetShardBuilder builds a recSetShard incrementally in ascending recid
+// order (see the add() callers in recset.go / analyzer.go — all drive it via
+// a single forward scan).
+//
+// DESIGN INVARIANT (build phase): exactly one allocation while add() is
+// being called. newRecSetShardBuilder allocates the eventual bitmap
+// footprint ((universe+31)/32 words) once; every phase (ranges, positive,
+// bitmap) reuses that same backing array — ranges as (base,count) pairs,
+// positive as a flat hit-id list, bitmap as literal bits — and escalating
+// from one phase to a less compact one is a plain clear() of that same
+// array, never a new allocation. This is why escalation historically
+// discarded whatever the abandoned phase had recorded and relied on the
+// caller replaying: see the `wasBitmap`-watching code in recset.go's
+// collectRecSet/projectJoinKeysPart and analyzer.go's BuildSkipList,
+// unchanged by this rewrite. For that contract to be safe, every escalation
+// must happen synchronously inside an add() call the caller can see — never
+// deferred to finish(), which runs after the caller's add() loop has
+// already ended with no replay window left. The ranges phase's escalation
+// is therefore triggered the moment a new run *starts* (reserving its pair
+// slot immediately, in addRange), not when it closes — closeRun() only ever
+// fills in an already-reserved slot, so it can run safely from finish()
+// without ever needing to escalate itself.
+//
+// finish() itself adds exactly one more allocation for ranges/positive
+// results (not bitmap): it copies the logically-used prefix of the backing
+// array down to a right-sized slice before returning. Without that, a
+// recSetShard would keep the entire (universe+31)/32-word worst-case buffer
+// alive for its whole lifetime regardless of how compact its actual
+// content is — for the case ranges exists to compress (one big range
+// spanning a huge universe, down to 2 words), that would silently defeat
+// the entire memory point of the representation. This copy is bounded by
+// the logical size actually recorded (2×rangePairs or hits words), not by
+// universe, and paid exactly once — it is not part of the build-phase
+// invariant above, which is specifically about not re-allocating or
+// growing anything *while* add() is still being called.
+//
+// The one deliberate exception is the tryConvertToPositive path
+// (ranges→positive, triggered by too many isolated singleton runs, plus its
+// own overflow-to-bitmap fallback if positive wouldn't fit either):
+// flattening (base,count) pairs into individual ids is not a pure
+// clear+rebuild, and a naive in-place left-to-right expansion is unsafe —
+// any range with count>1 writes ahead of where a not-yet-read later pair
+// lives, corrupting it before it's read (a range with count=1000 at the
+// front, for instance, overwrites the read position of a pair many slots
+// further in before that pair has been read). Making this transition
+// correct needs a temporary buffer sized to the flattened hit count —
+// bounded by the same budget as everything else here, allocated at most
+// once per shard build, and only on the (by design, rare) path where ranges
+// already gave up on clustering.
 type recSetShardBuilder struct {
 	shard       *storageShard
 	universe    uint32
 	data        []uint32
-	deviations  uint32
 	matched     uint32
-	defaultHit  bool
 	initialized bool
-	bitmap      bool
+
+	bitmap   bool // once true, add() operates in bitmap mode
+	positive bool // once true (and !bitmap), add() operates in flat hit-list mode
+
+	// ranges-phase state
+	rangePairs    uint32
+	singletonRuns uint32
+	runStart      uint32
+	runLen        uint32
+	haveRun       bool
+
+	// positive-phase state
+	hits uint32
 }
+
+// maxSingletonRuns is how many isolated (count==1) hit-ranges the ranges
+// phase tolerates before concluding the data isn't clustering and switching
+// to a flat hit list instead.
+const maxSingletonRuns = 3
 
 func newRecSetShardBuilder(shard *storageShard, universe uint32, allowFull bool) *recSetShardBuilder {
 	builder := &recSetShardBuilder{
@@ -56,10 +132,7 @@ func newRecSetShardBuilder(shard *storageShard, universe uint32, allowFull bool)
 }
 
 func (b *recSetShardBuilder) add(recid uint32, hit bool) {
-	if !b.initialized {
-		b.initialized = true
-		b.defaultHit = hit
-	}
+	b.initialized = true
 	if hit {
 		b.matched++
 	}
@@ -67,17 +140,11 @@ func (b *recSetShardBuilder) add(recid uint32, hit bool) {
 		b.addBitmap(recid, hit)
 		return
 	}
-	if hit == b.defaultHit {
+	if b.positive {
+		b.addPositive(recid, hit)
 		return
 	}
-	if b.deviations < uint32(len(b.data)) {
-		b.data[b.deviations] = recid
-		b.deviations++
-		return
-	}
-	clear(b.data)
-	b.bitmap = true
-	b.addBitmap(recid, hit)
+	b.addRange(recid, hit)
 }
 
 func (b *recSetShardBuilder) addBitmap(recid uint32, hit bool) {
@@ -86,69 +153,232 @@ func (b *recSetShardBuilder) addBitmap(recid uint32, hit bool) {
 	}
 }
 
+// addPositive appends a hit recid to the flat list. Overflowing the shared
+// backing array's budget escalates to bitmap the zero-allocation way: clear
+// and rely on the caller's replay (see the type doc). This is always safe
+// here because addPositive's budget check fires on every single hit, not on
+// some deferred flush — there is no closeRun()-style batching that could
+// let the last hit of a shard slip past the caller's add() loop unseen.
+func (b *recSetShardBuilder) addPositive(recid uint32, hit bool) {
+	if !hit {
+		return
+	}
+	if b.hits >= uint32(len(b.data)) {
+		clear(b.data)
+		b.bitmap = true
+		b.addBitmap(recid, true)
+		return
+	}
+	b.data[b.hits] = recid
+	b.hits++
+}
+
+func (b *recSetShardBuilder) addRange(recid uint32, hit bool) {
+	if hit {
+		if b.haveRun && recid == b.runStart+b.runLen {
+			b.runLen++
+			return
+		}
+		if b.haveRun {
+			b.closeRun()
+		}
+		if b.bitmap {
+			b.addBitmap(recid, true)
+			return
+		}
+		if b.positive {
+			b.addPositive(recid, true)
+			return
+		}
+		// Reserve this new run's pair slot right now, while still inside a
+		// real add() call — never deferred to closeRun()/finish() — so
+		// this is the one and only place ranges→bitmap escalation can
+		// trigger, guaranteeing the caller always has a replay window.
+		if (b.rangePairs+1)*2 > uint32(len(b.data)) {
+			clear(b.data)
+			b.bitmap = true
+			b.addBitmap(recid, true)
+			return
+		}
+		b.rangePairs++
+		b.runStart = recid
+		b.runLen = 1
+		b.haveRun = true
+		return
+	}
+	if b.haveRun {
+		b.closeRun()
+	}
+}
+
+// closeRun flushes the currently open hit-run into its already-reserved
+// pair slot (reserved by addRange when the run started — see there) and
+// checks the one escalation closeRun can still trigger: too many isolated
+// singleton runs, meaning the data isn't clustering, so switch to a flat
+// hit list instead (tryConvertToPositive). Safe to run from finish() (i.e.
+// with no caller replay window left) purely because tryConvertToPositive
+// itself is lossless — it doesn't clear anything here.
+func (b *recSetShardBuilder) closeRun() {
+	if !b.haveRun {
+		return
+	}
+	base, count := b.runStart, b.runLen
+	b.haveRun = false
+
+	b.data[(b.rangePairs-1)*2] = base
+	b.data[(b.rangePairs-1)*2+1] = count
+	if count == 1 {
+		b.singletonRuns++
+		if b.singletonRuns > maxSingletonRuns {
+			b.tryConvertToPositive()
+		}
+	}
+}
+
+// tryConvertToPositive flattens the ranges accumulated so far into a flat
+// hit-id list, using a small temporary buffer sized exactly to the total hit
+// count — see the type doc for why this one transition can't be a plain
+// clear()+replay or a naive in-place expansion.
+//
+// If the total hit count doesn't fit the shared backing array's budget
+// either, this falls back to bitmap — but NOT via the zero-allocation
+// clear()+replay pattern addRange/addPositive use above. closeRun() (this
+// function's only caller) can run from finish(), flushing the very last run
+// of a shard with no caller add() loop left to replay from; a bare clear()
+// here would silently drop every range pair recorded before this one,
+// exactly the bug this design is built around avoiding (see the type doc).
+// escalateRangesToBitmap keeps this transition self-contained the same way
+// the flatten above is: convert what's already in `data` before touching
+// it. This — like the flatten itself — is a second, disclosed exception to
+// the one-allocation invariant, reached only via the same rare ">3
+// singleton runs" path, bounded by the same budget, at most once per shard
+// build.
+func (b *recSetShardBuilder) tryConvertToPositive() {
+	var total uint32
+	for i := uint32(0); i < b.rangePairs; i++ {
+		total += b.data[i*2+1]
+	}
+	if total > uint32(len(b.data)) {
+		b.escalateRangesToBitmap()
+		return
+	}
+	flat := make([]uint32, total)
+	var write uint32
+	for i := uint32(0); i < b.rangePairs; i++ {
+		base, count := b.data[i*2], b.data[i*2+1]
+		for k := uint32(0); k < count; k++ {
+			flat[write] = base + k
+			write++
+		}
+	}
+	copy(b.data, flat)
+	b.hits = write
+	b.positive = true
+	b.rangePairs = 0
+	b.singletonRuns = 0
+}
+
+// escalateRangesToBitmap converts the range pairs already recorded into
+// bitmap bits before clearing the backing array, so nothing is lost even
+// when there's no caller replay window left to fall back on (see
+// tryConvertToPositive, its only caller).
+func (b *recSetShardBuilder) escalateRangesToBitmap() {
+	oldRanges := append([]uint32(nil), b.data[:b.rangePairs*2]...)
+	clear(b.data)
+	b.bitmap = true
+	for i := 0; i < len(oldRanges); i += 2 {
+		base, count := oldRanges[i], oldRanges[i+1]
+		for id := base; id < base+count; id++ {
+			b.addBitmap(id, true)
+		}
+	}
+}
+
+// finish returns the built recSetShard. For bitmap, the full backing array
+// is genuinely all in use — returned as-is, no copy. For ranges/positive,
+// the whole point of staying in those phases is that the logical content is
+// (for the intended clustered/sparse cases) far smaller than the
+// (universe+31)/32-word backing array reserved for the bitmap worst case —
+// a single big range is 2 words no matter how large universe is. Returning
+// `b.data` directly there would silently keep that whole worst-case buffer
+// alive for the shard's entire (query-local, but potentially
+// large-universe) lifetime, defeating the memory point of having a compact
+// representation at all. So finish() copies down to a right-sized array
+// here — one more allocation, but bounded by the logical size actually
+// recorded (2*rangePairs or hits words), not by universe, and paid exactly
+// once, after the fact, never repeated or proportional to escalation
+// attempts the way the mid-build allocations discussed above are.
 func (b *recSetShardBuilder) finish() recSetShard {
+	if !b.bitmap && !b.positive {
+		b.closeRun()
+	}
 	part := recSetShard{shard: b.shard, universe: b.universe, count: int64(b.matched)}
 	if b.matched == 0 {
-		part.kind = recSetEmpty
+		part.kind = recSetRanges
 		return part
 	}
-	if b.matched == b.universe {
-		part.kind = recSetFull
+	if b.bitmap {
+		part.data = b.data
+		part.kind = recSetBitmap
 		return part
 	}
-	part.data = b.data
-	if !b.bitmap {
-		sort.Slice(part.data[:b.deviations], func(i, j int) bool {
-			return part.data[i] < part.data[j]
-		})
-		part.used = b.deviations
-		if b.defaultHit {
-			part.kind = recSetNegative
-		} else {
-			part.kind = recSetPositive
-		}
+	if b.positive {
+		part.used = b.hits
+		part.kind = recSetPositive
+		part.data = append([]uint32(nil), b.data[:part.used]...)
+		sort.Slice(part.data, func(i, j int) bool { return part.data[i] < part.data[j] })
 		return part
 	}
-	part.kind = recSetBitmap
+	part.used = b.rangePairs
+	part.kind = recSetRanges
+	part.data = append([]uint32(nil), b.data[:2*part.used]...)
 	return part
 }
 
+// newRecSetShardFromSortedIDs builds a recSetShard from an already-sorted,
+// deduplicated recid list (used by project-join, where ids are collected via
+// index probes rather than a single ascending scan). It picks whichever of
+// ranges/positive/bitmap ends up smallest, coalescing adjacent/consecutive
+// ids into ranges first since that's virtually free given the input is
+// already sorted.
 func newRecSetShardFromSortedIDs(shard *storageShard, universe uint32, ids []uint32) recSetShard {
 	part := recSetShard{shard: shard, universe: universe, count: int64(len(ids))}
 	if len(ids) == 0 {
-		part.kind = recSetEmpty
+		part.kind = recSetRanges
 		return part
 	}
-	if len(ids) == int(universe) {
-		part.kind = recSetFull
-		return part
-	}
-	part.data = make([]uint32, (universe+31)/32)
-	if len(ids) <= len(part.data) {
-		part.kind = recSetPositive
-		part.used = uint32(len(ids))
-		copy(part.data, ids)
-		return part
-	}
-	missing := int(universe) - len(ids)
-	if missing <= len(part.data) {
-		part.kind = recSetNegative
-		part.used = uint32(missing)
-		write, present := 0, 0
-		for id := uint32(0); id < universe; id++ {
-			if present < len(ids) && ids[present] == id {
-				present++
-				continue
-			}
-			part.data[write] = id
-			write++
+	budgetWords := (universe + 31) / 32
+
+	// Try ranges: coalesce consecutive ids into pairs.
+	rangePairs := make([]uint32, 0, 2*len(ids))
+	i := 0
+	for i < len(ids) {
+		base := ids[i]
+		j := i + 1
+		for j < len(ids) && ids[j] == ids[j-1]+1 {
+			j++
 		}
+		rangePairs = append(rangePairs, base, ids[j-1]-base+1)
+		i = j
+	}
+	if uint32(len(rangePairs)) <= budgetWords {
+		part.data = rangePairs
+		part.used = uint32(len(rangePairs)) / 2
+		part.kind = recSetRanges
 		return part
 	}
-	part.kind = recSetBitmap
-	for _, id := range ids {
-		part.data[id>>5] |= uint32(1) << (id & 31)
+	if uint32(len(ids)) <= budgetWords {
+		part.data = append([]uint32(nil), ids...)
+		part.used = uint32(len(ids))
+		part.kind = recSetPositive
+		return part
 	}
+	data := make([]uint32, budgetWords)
+	for _, id := range ids {
+		data[id>>5] |= uint32(1) << (id & 31)
+	}
+	part.data = data
+	part.kind = recSetBitmap
 	return part
 }
 
@@ -157,8 +387,36 @@ func sortedUint32Contains(values []uint32, value uint32) bool {
 	return pos < len(values) && values[pos] == value
 }
 
+// listedValues returns the flat hit-id list (recSetPositive only).
 func (s *recSetShard) listedValues() []uint32 {
 	return s.data[:s.used]
+}
+
+// listedRanges returns the flat [base0,count0,base1,count1,...] pair array
+// (recSetRanges only).
+func (s *recSetShard) listedRanges() []uint32 {
+	return s.data[:2*s.used]
+}
+
+// rangesContains does a binary search over the sorted, non-overlapping range
+// pairs for the one that might contain recid.
+func (s *recSetShard) rangesContains(recid uint32) bool {
+	ranges := s.listedRanges()
+	n := len(ranges) / 2
+	lo, hi := 0, n
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if ranges[mid*2] <= recid {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo == 0 {
+		return false
+	}
+	base, count := ranges[(lo-1)*2], ranges[(lo-1)*2+1]
+	return recid < base+count
 }
 
 func unionRecSetShards(shard *storageShard, parts []*recSetShard) recSetShard {
@@ -169,87 +427,108 @@ func unionRecSetShards(shard *storageShard, parts []*recSetShard) recSetShard {
 		}
 	}
 	compact := parts[:0]
-	hasBitmap := false
 	mixedUniverse := false
+	allRanges := true
+	allPositive := true
 	for _, part := range parts {
-		if part == nil || part.kind == recSetEmpty {
+		if part == nil || part.count == 0 {
 			continue
 		}
-		if part.kind == recSetFull && part.universe == universe {
-			return recSetShard{shard: shard, kind: recSetFull, universe: universe, count: int64(universe)}
+		if part.count == int64(part.universe) && part.universe == universe {
+			return recSetShardFromSingleFullRange(shard, universe)
 		}
-		hasBitmap = hasBitmap || part.kind == recSetBitmap
 		mixedUniverse = mixedUniverse || part.universe != universe
+		allRanges = allRanges && part.kind == recSetRanges
+		allPositive = allPositive && part.kind == recSetPositive
 		compact = append(compact, part)
 	}
 	parts = compact
 	if len(parts) == 0 {
-		return recSetShard{shard: shard, kind: recSetEmpty, universe: universe}
+		return recSetShard{shard: shard, kind: recSetRanges, universe: universe}
+	}
+	if len(parts) == 1 {
+		return cloneRecSetShardTo(shard, parts[0])
 	}
 	data := make([]uint32, (universe+31)/32)
 	if mixedUniverse {
 		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
 	}
-	if candidate := shortestRecSetList(parts, recSetNegative); candidate != nil {
-		used := filterRecSetCandidates(data, candidate.listedValues(), parts, false)
-		return recSetShardFromList(shard, universe, data, used, recSetNegative)
+	if allRanges {
+		lists := recSetRangeLists(parts)
+		used, overflow := unionSortedRanges(data, lists)
+		if !overflow {
+			return recSetShardFromRangePairs(shard, universe, data, used)
+		}
+	} else if allPositive {
+		positiveLists := recSetLists(parts, recSetPositive)
+		used, overflow := unionSortedLists(data, positiveLists)
+		if !overflow {
+			return recSetShardFromList(shard, universe, data, used)
+		}
 	}
-	if hasBitmap {
-		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
-	}
-	positiveLists := recSetLists(parts, recSetPositive)
-	used, overflow := unionSortedLists(data, positiveLists)
-	if overflow {
-		return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
-	}
-	return recSetShardFromList(shard, universe, data, used, recSetPositive)
+	// Mixed kinds (or a native-representation overflow): every part still
+	// answers .contains()/word() correctly regardless of its own kind, so
+	// this is always correct, just without the compact-representation
+	// shortcut above.
+	return combineRecSetBitmapsWithData(shard, universe, parts, true, data)
 }
 
 func intersectRecSetShards(shard *storageShard, parts []*recSetShard) recSetShard {
 	if len(parts) == 0 {
-		return recSetShard{shard: shard, kind: recSetEmpty}
+		return recSetShard{shard: shard, kind: recSetRanges}
 	}
 	var universe uint32
 	for _, part := range parts {
-		if part == nil || part.kind == recSetEmpty {
-			return recSetShard{shard: shard, kind: recSetEmpty, universe: universe}
+		if part == nil || part.count == 0 {
+			return recSetShard{shard: shard, kind: recSetRanges, universe: universe}
 		}
 		if part.universe > universe {
 			universe = part.universe
 		}
 	}
 	compact := parts[:0]
-	hasBitmap := false
 	mixedUniverse := false
+	allRanges := true
 	for _, part := range parts {
-		if part.kind == recSetFull && part.universe == universe {
+		if part.count == int64(part.universe) && part.universe == universe {
 			continue
 		}
-		hasBitmap = hasBitmap || part.kind == recSetBitmap
 		mixedUniverse = mixedUniverse || part.universe != universe
+		allRanges = allRanges && part.kind == recSetRanges
 		compact = append(compact, part)
 	}
 	parts = compact
 	if len(parts) == 0 {
-		return recSetShard{shard: shard, kind: recSetFull, universe: universe, count: int64(universe)}
+		return recSetShardFromSingleFullRange(shard, universe)
+	}
+	if len(parts) == 1 {
+		return cloneRecSetShardTo(shard, parts[0])
 	}
 	data := make([]uint32, (universe+31)/32)
 	if mixedUniverse {
 		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
 	}
-	if candidate := shortestRecSetList(parts, recSetPositive); candidate != nil {
-		used := filterRecSetCandidates(data, candidate.listedValues(), parts, true)
-		return recSetShardFromList(shard, universe, data, used, recSetPositive)
+	if allRanges {
+		lists := recSetRangeLists(parts)
+		used, overflow := intersectSortedRanges(data, lists)
+		if !overflow {
+			return recSetShardFromRangePairs(shard, universe, data, used)
+		}
 	}
-	if hasBitmap {
-		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
+	return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
+}
+
+func cloneRecSetShardTo(shard *storageShard, part *recSetShard) recSetShard {
+	clone := *part
+	clone.shard = shard
+	return clone
+}
+
+func recSetShardFromSingleFullRange(shard *storageShard, universe uint32) recSetShard {
+	if universe == 0 {
+		return recSetShard{shard: shard, kind: recSetRanges, universe: universe}
 	}
-	negativeLists := recSetLists(parts, recSetNegative)
-	used, overflow := unionSortedLists(data, negativeLists)
-	if overflow {
-		return combineRecSetBitmapsWithData(shard, universe, parts, false, data)
-	}
-	return recSetShardFromList(shard, universe, data, used, recSetNegative)
+	return recSetShard{shard: shard, kind: recSetRanges, universe: universe, data: []uint32{0, universe}, used: 1, count: int64(universe)}
 }
 
 func recSetLists(parts []*recSetShard, kind recSetRepresentation) [][]uint32 {
@@ -262,35 +541,12 @@ func recSetLists(parts []*recSetShard, kind recSetRepresentation) [][]uint32 {
 	return lists
 }
 
-func shortestRecSetList(parts []*recSetShard, kind recSetRepresentation) *recSetShard {
-	var shortest *recSetShard
-	for _, part := range parts {
-		if part.kind == kind && (shortest == nil || part.used < shortest.used) {
-			shortest = part
-		}
+func recSetRangeLists(parts []*recSetShard) [][]uint32 {
+	lists := make([][]uint32, len(parts))
+	for i, part := range parts {
+		lists[i] = part.listedRanges()
 	}
-	return shortest
-}
-
-// filterRecSetCandidates handles the sparse-result quadrants of the algebra
-// matrix. Intersections with a positive list can only contain its IDs; unions
-// with a negative list can only exclude its IDs.
-func filterRecSetCandidates(dst, candidates []uint32, parts []*recSetShard, wantPresent bool) uint32 {
-	used := 0
-	for _, id := range candidates {
-		matches := true
-		for _, part := range parts {
-			if part.contains(id) != wantPresent {
-				matches = false
-				break
-			}
-		}
-		if matches {
-			dst[used] = id
-			used++
-		}
-	}
-	return uint32(used)
+	return lists
 }
 
 // unionSortedLists merges sorted recid lists directly into the final backing.
@@ -324,6 +580,113 @@ func unionSortedLists(dst []uint32, lists [][]uint32) (uint32, bool) {
 	}
 }
 
+// unionSortedRanges merges multiple sorted, non-overlapping range-pair lists
+// into one sorted, maximally-coalesced list of non-overlapping ranges,
+// writing pairs into dst. Returns (pairs used, overflow).
+func unionSortedRanges(dst []uint32, lists [][]uint32) (uint32, bool) {
+	positions := make([]int, len(lists))
+	var used uint32
+	var curBase, curEnd uint32
+	haveCur := false
+	flush := func() bool {
+		if !haveCur {
+			return true
+		}
+		if (used+1)*2 > uint32(len(dst)) {
+			return false
+		}
+		dst[used*2] = curBase
+		dst[used*2+1] = curEnd - curBase
+		used++
+		return true
+	}
+	for {
+		var nextBase, nextEnd uint32
+		found := false
+		srcIdx := -1
+		for i, ranges := range lists {
+			if positions[i] < len(ranges) {
+				base := ranges[positions[i]]
+				if !found || base < nextBase {
+					nextBase = base
+					nextEnd = base + ranges[positions[i]+1]
+					found = true
+					srcIdx = i
+				}
+			}
+		}
+		if !found {
+			break
+		}
+		positions[srcIdx] += 2
+		if haveCur && nextBase <= curEnd {
+			if nextEnd > curEnd {
+				curEnd = nextEnd
+			}
+			continue
+		}
+		if !flush() {
+			return used, true
+		}
+		curBase, curEnd = nextBase, nextEnd
+		haveCur = true
+	}
+	if !flush() {
+		return used, true
+	}
+	return used, false
+}
+
+// intersectSortedRanges computes the N-way intersection of sorted,
+// non-overlapping range-pair lists via a sweep: at each step the candidate
+// interval is [max(current starts), min(current ends)); every list whose
+// current interval ends there is advanced.
+func intersectSortedRanges(dst []uint32, lists [][]uint32) (uint32, bool) {
+	positions := make([]int, len(lists))
+	var used uint32
+	for {
+		var maxStart, minEnd uint32
+		first := true
+		for i, ranges := range lists {
+			if positions[i] >= len(ranges) {
+				return used, false
+			}
+			base := ranges[positions[i]]
+			end := base + ranges[positions[i]+1]
+			if first {
+				maxStart, minEnd = base, end
+				first = false
+				continue
+			}
+			if base > maxStart {
+				maxStart = base
+			}
+			if end < minEnd {
+				minEnd = end
+			}
+		}
+		if maxStart < minEnd {
+			if (used+1)*2 > uint32(len(dst)) {
+				return used, true
+			}
+			dst[used*2] = maxStart
+			dst[used*2+1] = minEnd - maxStart
+			used++
+		}
+		advanced := false
+		for i, ranges := range lists {
+			end := ranges[positions[i]] + ranges[positions[i]+1]
+			if end == minEnd {
+				positions[i] += 2
+				advanced = true
+			}
+		}
+		if !advanced {
+			return used, false
+		}
+	}
+}
+
 type recSetWordCursor struct {
 	part *recSetShard
 	pos  int
@@ -339,14 +702,12 @@ func (c *recSetWordCursor) word(wordIndex uint32) uint32 {
 		tailMask = (uint32(1) << remaining) - 1
 	}
 	switch c.part.kind {
-	case recSetFull:
-		return tailMask
 	case recSetBitmap:
 		if int(wordIndex) < len(c.part.data) {
 			return c.part.data[wordIndex] & tailMask
 		}
 		return 0
-	case recSetPositive, recSetNegative:
+	case recSetPositive:
 		values := c.part.listedValues()
 		for c.pos < len(values) && values[c.pos]>>5 < wordIndex {
 			c.pos++
@@ -356,10 +717,28 @@ func (c *recSetWordCursor) word(wordIndex uint32) uint32 {
 			mask |= uint32(1) << (values[c.pos] & 31)
 			c.pos++
 		}
-		if c.part.kind == recSetNegative {
-			return ^mask & tailMask
-		}
 		return mask
+	case recSetRanges:
+		wordEnd := wordStart + 32
+		ranges := c.part.listedRanges()
+		for c.pos < len(ranges) && ranges[c.pos]+ranges[c.pos+1] <= wordStart {
+			c.pos += 2
+		}
+		mask := uint32(0)
+		for p := c.pos; p < len(ranges) && ranges[p] < wordEnd; p += 2 {
+			base, count := ranges[p], ranges[p+1]
+			lo, hi := base, base+count
+			if lo < wordStart {
+				lo = wordStart
+			}
+			if hi > wordEnd {
+				hi = wordEnd
+			}
+			for id := lo; id < hi; id++ {
+				mask |= uint32(1) << (id - wordStart)
+			}
+		}
+		return mask & tailMask
 	default:
 		return 0
 	}
@@ -388,18 +767,32 @@ func combineRecSetBitmapsWithData(shard *storageShard, universe uint32, parts []
 	return recSetShardFromBitmap(shard, universe, data)
 }
 
-func recSetShardFromList(shard *storageShard, universe uint32, data []uint32, used uint32, kind recSetRepresentation) recSetShard {
-	count := used
-	if kind == recSetNegative {
-		count = universe - used
+// recSetShardFromRangePairs and recSetShardFromList both receive `data`
+// as the full (universe+31)/32-word buffer the union/intersect caller
+// allocated for its bitmap-fallback path, of which only the first
+// 2*used/used words ended up holding the actual native-fast-path result —
+// same situation as recSetShardBuilder.finish() (see its doc comment), same
+// fix: copy down to a right-sized array rather than silently keeping the
+// whole worst-case buffer alive for a result that's supposed to be compact.
+
+func recSetShardFromRangePairs(shard *storageShard, universe uint32, data []uint32, used uint32) recSetShard {
+	var count int64
+	for i := uint32(0); i < used; i++ {
+		count += int64(data[i*2+1])
 	}
-	part := recSetShard{shard: shard, kind: kind, universe: universe, data: data, used: used, count: int64(count)}
-	if count == 0 {
-		part.kind = recSetEmpty
-		part.data = nil
-	} else if count == universe {
-		part.kind = recSetFull
-		part.data = nil
+	part := recSetShard{shard: shard, kind: recSetRanges, universe: universe, used: used, count: count}
+	if count > 0 {
+		part.data = append([]uint32(nil), data[:2*used]...)
+	}
+	return part
+}
+
+func recSetShardFromList(shard *storageShard, universe uint32, data []uint32, used uint32) recSetShard {
+	part := recSetShard{shard: shard, kind: recSetPositive, universe: universe, used: used, count: int64(used)}
+	if used == 0 {
+		part.kind = recSetRanges
+	} else {
+		part.data = append([]uint32(nil), data[:used]...)
 	}
 	return part
 }
@@ -414,52 +807,82 @@ func recSetShardFromBitmap(shard *storageShard, universe uint32, data []uint32) 
 	}
 	part := recSetShard{shard: shard, universe: universe, data: data, count: int64(count)}
 	if count == 0 {
-		part.kind = recSetEmpty
-	} else if count == universe {
-		part.kind = recSetFull
+		part.kind = recSetRanges
+		part.data = nil
 	} else {
 		part.kind = recSetBitmap
 	}
 	return part
 }
 
+// forEachID visits every matching recid in ascending order. Built on top of
+// forEachRange so the run-based iteration logic exists exactly once.
 func (s *recSetShard) forEachID(callback func(uint32) bool) {
+	s.forEachRange(func(base, count uint32) bool {
+		for id := base; id < base+count; id++ {
+			if !callback(id) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// forEachRange visits every maximal run of matching recids in ascending
+// order as (base, count) — the natural granularity for a bulk column read
+// (GetValueRange(base, count, ...)) instead of one GetValue call per row.
+// recSetRanges yields its stored pairs directly (zero conversion — this is
+// the case the whole representation exists for); recSetPositive yields each
+// hit as its own (id,1) range (they're scattered by construction, so there's
+// nothing to coalesce); recSetBitmap scans bit-by-bit coalescing consecutive
+// set bits into runs as it goes (not the fastest possible bitmap-run scan —
+// a bit-trick version could skip whole words via TrailingZeros/leading-run
+// masks — but bitmap is already the fallback tier where compression failed,
+// and correctness matters more than shaving that further here).
+func (s *recSetShard) forEachRange(callback func(base, count uint32) bool) {
 	switch s.kind {
-	case recSetEmpty:
-		return
+	case recSetRanges:
+		ranges := s.listedRanges()
+		for i := 0; i < len(ranges); i += 2 {
+			if !callback(ranges[i], ranges[i+1]) {
+				return
+			}
+		}
 	case recSetPositive:
 		for _, id := range s.listedValues() {
-			if !callback(id) {
-				return
-			}
-		}
-	case recSetFull:
-		for id := uint32(0); id < s.universe; id++ {
-			if !callback(id) {
-				return
-			}
-		}
-	case recSetNegative:
-		excluded := s.listedValues()
-		pos := 0
-		for id := uint32(0); id < s.universe; id++ {
-			if pos < len(excluded) && excluded[pos] == id {
-				pos++
-				continue
-			}
-			if !callback(id) {
+			if !callback(id, 1) {
 				return
 			}
 		}
 	case recSetBitmap:
+		var runStart uint32
+		haveRun := false
 		for wordIndex, word := range s.data {
-			for word != 0 {
-				bit := bits.TrailingZeros32(word)
-				id := uint32(wordIndex*32 + bit)
-				if id < s.universe && !callback(id) {
-					return
+			base := uint32(wordIndex) * 32
+			for bitPos := uint32(0); bitPos < 32; bitPos++ {
+				id := base + bitPos
+				if id >= s.universe {
+					word = 0
+					break
 				}
-				word &= word - 1
+				if word&(uint32(1)<<bitPos) != 0 {
+					if !haveRun {
+						runStart = id
+						haveRun = true
+					}
+					continue
+				}
+				if haveRun {
+					if !callback(runStart, id-runStart) {
+						return
+					}
+					haveRun = false
+				}
+			}
+		}
+		if haveRun {
+			if !callback(runStart, s.universe-runStart) {
+				return
 			}
 		}
 	}

--- a/storage/recset_representation_test.go
+++ b/storage/recset_representation_test.go
@@ -1,0 +1,581 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+// buildRecSetShard drives a recSetShardBuilder over want (a boolean mask
+// indexed by recid, len(want)==universe) exactly the way every real caller
+// (recset.go's collectRecSet/projectJoinKeysPart, analyzer.go's
+// BuildSkipList) does: one ascending add() call per recid, watching for the
+// (zero-allocation) transition into bitmap mode and replaying everything up
+// to that point via addBitmap once it happens — see recSetShardBuilder's
+// doc comment for exactly which transitions need this and which don't.
+func buildRecSetShard(want []bool) recSetShard {
+	universe := uint32(len(want))
+	b := newRecSetShardBuilder(nil, universe, true)
+	replayFrom := uint32(0)
+	for recid, hit := range want {
+		wasBitmap := b.bitmap
+		b.add(uint32(recid), hit)
+		if !wasBitmap && b.bitmap {
+			replayFrom = uint32(recid) + 1
+		}
+	}
+	for recid := uint32(0); recid < replayFrom; recid++ {
+		b.addBitmap(recid, want[recid])
+	}
+	return b.finish()
+}
+
+func wantFromRange(universe uint32, ranges [][2]uint32) []bool {
+	want := make([]bool, universe)
+	for _, r := range ranges {
+		for i := r[0]; i < r[0]+r[1]; i++ {
+			want[i] = true
+		}
+	}
+	return want
+}
+
+func verifyRecSetShard(t *testing.T, name string, part recSetShard, want []bool) {
+	t.Helper()
+	universe := uint32(len(want))
+
+	var wantCount int64
+	for _, v := range want {
+		if v {
+			wantCount++
+		}
+	}
+	if part.count != wantCount {
+		t.Errorf("%s: count = %d, want %d", name, part.count, wantCount)
+	}
+
+	// contains() must agree with want for every recid, plus recids beyond
+	// (and exactly at) the universe boundary must always be false — this is
+	// the correctness property the whole "no Full/Negative tag" redesign is
+	// about: nothing after the universe boundary can ever read as present.
+	for recid := uint32(0); recid < universe; recid++ {
+		if got := part.contains(recid); got != want[recid] {
+			t.Errorf("%s: contains(%d) = %v, want %v", name, recid, got, want[recid])
+		}
+	}
+	for _, recid := range []uint32{universe, universe + 1, universe + 1000} {
+		if part.contains(recid) {
+			t.Errorf("%s: contains(%d) beyond universe %d = true, want false", name, recid, universe)
+		}
+	}
+
+	// forEachID must visit exactly the matching recids, in ascending order.
+	var gotIDs []uint32
+	part.forEachID(func(id uint32) bool {
+		gotIDs = append(gotIDs, id)
+		return true
+	})
+	checkIDsMatchWant(t, name, gotIDs, want)
+
+	// forEachRange must be consistent with forEachID: same total ids (via
+	// expansion), ascending, non-overlapping, non-adjacent-when-coalescible
+	// ranges (adjacency isn't required to be coalesced across representations
+	// other than recSetRanges — bitmap coalesces greedily too — so just
+	// require expansion equality plus strictly-increasing, non-overlapping
+	// bases).
+	var expanded []uint32
+	var lastEnd uint32
+	first := true
+	part.forEachRange(func(base, count uint32) bool {
+		if count == 0 {
+			t.Errorf("%s: forEachRange yielded a zero-length range at base %d", name, base)
+		}
+		if !first && base < lastEnd {
+			t.Errorf("%s: forEachRange ranges overlap or go backwards: base=%d < lastEnd=%d", name, base, lastEnd)
+		}
+		first = false
+		lastEnd = base + count
+		for id := base; id < base+count; id++ {
+			expanded = append(expanded, id)
+		}
+		return true
+	})
+	checkIDsMatchWant(t, name, expanded, want)
+}
+
+func checkIDsMatchWant(t *testing.T, name string, ids []uint32, want []bool) {
+	t.Helper()
+	i := 0
+	for recid, hit := range want {
+		if !hit {
+			continue
+		}
+		if i >= len(ids) {
+			t.Fatalf("%s: id list too short, missing recid %d", name, recid)
+		}
+		if ids[i] != uint32(recid) {
+			t.Fatalf("%s: id list[%d] = %d, want %d", name, i, ids[i], recid)
+		}
+		i++
+	}
+	if i != len(ids) {
+		t.Fatalf("%s: id list has %d extra trailing entries (first extra: %d)", name, len(ids)-i, ids[i])
+	}
+}
+
+func TestRecSetShardBuilderPatterns(t *testing.T) {
+	cases := []struct {
+		name     string
+		universe uint32
+		ranges   [][2]uint32 // (base,count) hit runs
+	}{
+		{"Empty", 1000, nil},
+		{"Full", 1000, [][2]uint32{{0, 1000}}},
+		{"SingleBigRange", 100000, [][2]uint32{{12345, 54321}}},
+		{"SingleRangeAtStart", 1000, [][2]uint32{{0, 500}}},
+		{"SingleRangeAtEnd", 1000, [][2]uint32{{500, 500}}},
+		{"TwoBigRanges", 10000, [][2]uint32{{100, 3000}, {5000, 3000}}},
+		{"ThreeSingletons", 1000, [][2]uint32{{10, 1}, {500, 1}, {900, 1}}},
+		{"FourSingletons_TriggersPositive", 1000, [][2]uint32{{10, 1}, {300, 1}, {600, 1}, {900, 1}}},
+		{"MostlyFullFewHoles", 10000, [][2]uint32{{0, 100}, {101, 2000}, {2005, 7995}}}, // holes at 100, 2000-2005
+		{"ManySingletonsPastBudget", 2000, nil},                                         // filled below
+		{"AdjacentRuns", 1000, [][2]uint32{{0, 10}, {10, 10}, {20, 10}}},                // builder must coalesce contiguous add() calls
+		{"UniverseZero", 0, nil},
+		{"UniverseOne_Hit", 1, [][2]uint32{{0, 1}}},
+		{"UniverseOne_Miss", 1, nil},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			want := wantFromRange(tc.universe, tc.ranges)
+			if tc.name == "ManySingletonsPastBudget" {
+				rng := rand.New(rand.NewSource(1))
+				for i := range want {
+					want[i] = rng.Intn(3) == 0 // ~33% scattered hits, no clustering
+				}
+			}
+			part := buildRecSetShard(want)
+			verifyRecSetShard(t, tc.name, part, want)
+		})
+	}
+}
+
+// TestRecSetShardBuilderPhaseTransitions specifically checks the two
+// escalation boundaries (singleton-count threshold, and budget overflow) at
+// and around their exact trigger points, since off-by-one errors there are
+// the likeliest bug class in an online run-length builder.
+func TestRecSetShardBuilderPhaseTransitions(t *testing.T) {
+	universe := uint32(100000)
+	// Exactly maxSingletonRuns (3) isolated hits: must stay in ranges.
+	ranges3 := [][2]uint32{{10, 1}, {50000, 1}, {90000, 1}}
+	want3 := wantFromRange(universe, ranges3)
+	part3 := buildRecSetShard(want3)
+	if part3.kind != recSetRanges {
+		t.Errorf("3 singletons: kind = %v, want recSetRanges", part3.kind)
+	}
+	verifyRecSetShard(t, "3singletons", part3, want3)
+
+	// One more (4) must flip to positive.
+	ranges4 := [][2]uint32{{10, 1}, {30000, 1}, {50000, 1}, {90000, 1}}
+	want4 := wantFromRange(universe, ranges4)
+	part4 := buildRecSetShard(want4)
+	if part4.kind != recSetPositive {
+		t.Errorf("4 singletons: kind = %v, want recSetPositive", part4.kind)
+	}
+	verifyRecSetShard(t, "4singletons", part4, want4)
+
+	// A large number of scattered singletons that overflow even the flat
+	// positive-list budget must land in bitmap.
+	rng := rand.New(rand.NewSource(2))
+	wantDense := make([]bool, universe)
+	for i := range wantDense {
+		wantDense[i] = rng.Intn(2) == 0 // ~50% scattered — no clustering, way past any list budget
+	}
+	partDense := buildRecSetShard(wantDense)
+	if partDense.kind != recSetBitmap {
+		t.Errorf("dense random: kind = %v, want recSetBitmap", partDense.kind)
+	}
+	verifyRecSetShard(t, "dense-random", partDense, wantDense)
+}
+
+// TestRecSetShardUnionIntersect checks unionRecSetShards/intersectRecSetShards
+// across representative kind combinations (ranges/ranges, ranges/positive,
+// ranges/bitmap, positive/bitmap, mixed universes) against a reference
+// boolean-array computation.
+func TestRecSetShardUnionIntersect(t *testing.T) {
+	universe := uint32(10000)
+	rng := rand.New(rand.NewSource(3))
+
+	makeClustered := func(nRanges int, maxLen uint32) []bool {
+		want := make([]bool, universe)
+		for i := 0; i < nRanges; i++ {
+			base := uint32(rng.Intn(int(universe)))
+			length := uint32(rng.Intn(int(maxLen))) + 1
+			for j := base; j < base+length && j < universe; j++ {
+				want[j] = true
+			}
+		}
+		return want
+	}
+	makeScattered := func(density int) []bool {
+		want := make([]bool, universe)
+		for i := range want {
+			want[i] = rng.Intn(density) == 0
+		}
+		return want
+	}
+
+	scenarios := []struct {
+		name string
+		want []bool
+	}{
+		{"clustered_A", makeClustered(3, 2000)},
+		{"clustered_B", makeClustered(2, 500)},
+		{"scattered_A", makeScattered(50)}, // 2% density, no clustering -> positive
+		{"scattered_B", makeScattered(3)},  // 33% density, no clustering -> bitmap
+		{"empty", make([]bool, universe)},
+		{"full", func() []bool {
+			w := make([]bool, universe)
+			for i := range w {
+				w[i] = true
+			}
+			return w
+		}()},
+	}
+
+	for i := 0; i < len(scenarios); i++ {
+		for j := i + 1; j < len(scenarios); j++ {
+			a, b := scenarios[i], scenarios[j]
+			partA := buildRecSetShard(a.want)
+			partB := buildRecSetShard(b.want)
+
+			t.Run(a.name+"_union_"+b.name, func(t *testing.T) {
+				wantUnion := make([]bool, universe)
+				for k := range wantUnion {
+					wantUnion[k] = a.want[k] || b.want[k]
+				}
+				got := unionRecSetShards(nil, []*recSetShard{&partA, &partB})
+				verifyRecSetShard(t, "union", got, wantUnion)
+			})
+			t.Run(a.name+"_intersect_"+b.name, func(t *testing.T) {
+				wantIntersect := make([]bool, universe)
+				for k := range wantIntersect {
+					wantIntersect[k] = a.want[k] && b.want[k]
+				}
+				got := intersectRecSetShards(nil, []*recSetShard{&partA, &partB})
+				verifyRecSetShard(t, "intersect", got, wantIntersect)
+			})
+		}
+	}
+}
+
+// TestRecSetShardUnionIntersectThreeWay covers >2-way combination, since the
+// N-way interval sweep (intersectSortedRanges) and the min-of-N-lists loop
+// (unionSortedRanges) have different edge cases than a plain pairwise merge.
+func TestRecSetShardUnionIntersectThreeWay(t *testing.T) {
+	universe := uint32(5000)
+	wantA := wantFromRange(universe, [][2]uint32{{0, 3000}})
+	wantB := wantFromRange(universe, [][2]uint32{{1000, 3000}})
+	wantC := wantFromRange(universe, [][2]uint32{{2000, 2000}})
+	partA := buildRecSetShard(wantA)
+	partB := buildRecSetShard(wantB)
+	partC := buildRecSetShard(wantC)
+
+	wantUnion := make([]bool, universe)
+	wantIntersect := make([]bool, universe)
+	for i := range wantUnion {
+		wantUnion[i] = wantA[i] || wantB[i] || wantC[i]
+		wantIntersect[i] = wantA[i] && wantB[i] && wantC[i]
+	}
+	gotUnion := unionRecSetShards(nil, []*recSetShard{&partA, &partB, &partC})
+	verifyRecSetShard(t, "3way-union", gotUnion, wantUnion)
+	gotIntersect := intersectRecSetShards(nil, []*recSetShard{&partA, &partB, &partC})
+	verifyRecSetShard(t, "3way-intersect", gotIntersect, wantIntersect)
+}
+
+// TestNewRecSetShardFromSortedIDs checks the project-join builder path
+// (pre-sorted external id list, not an ascending add() scan).
+func TestNewRecSetShardFromSortedIDs(t *testing.T) {
+	universe := uint32(100000)
+	cases := []struct {
+		name string
+		ids  []uint32
+	}{
+		{"empty", nil},
+		{"contiguous", func() []uint32 {
+			ids := make([]uint32, 5000)
+			for i := range ids {
+				ids[i] = uint32(1000 + i)
+			}
+			return ids
+		}()},
+		{"scattered", func() []uint32 {
+			rng := rand.New(rand.NewSource(4))
+			seen := map[uint32]bool{}
+			var ids []uint32
+			for len(ids) < 200 {
+				id := uint32(rng.Intn(int(universe)))
+				if !seen[id] {
+					seen[id] = true
+					ids = append(ids, id)
+				}
+			}
+			sortUint32(ids)
+			return ids
+		}()},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			part := newRecSetShardFromSortedIDs(nil, universe, tc.ids)
+			want := make([]bool, universe)
+			for _, id := range tc.ids {
+				want[id] = true
+			}
+			verifyRecSetShard(t, tc.name, part, want)
+		})
+	}
+}
+
+// TestRecSetShardBuilderFuzz drives the builder over many random universe
+// sizes, densities, and clustering factors, including sizes chosen to land
+// exactly on/near the ranges/positive/bitmap budget boundaries, since
+// off-by-one errors in an online run-length builder concentrate there.
+func TestRecSetShardBuilderFuzz(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for iter := 0; iter < 500; iter++ {
+		universe := uint32(1 + rng.Intn(2000))
+		want := make([]bool, universe)
+		switch rng.Intn(4) {
+		case 0: // sparse scattered
+			density := 1 + rng.Intn(50)
+			for i := range want {
+				want[i] = rng.Intn(density) == 0
+			}
+		case 1: // clustered runs
+			nRuns := rng.Intn(20)
+			for r := 0; r < nRuns; r++ {
+				base := uint32(rng.Intn(int(universe)))
+				length := uint32(rng.Intn(int(universe)/4 + 1))
+				for i := base; i < base+length && i < universe; i++ {
+					want[i] = true
+				}
+			}
+		case 2: // dense with scattered holes
+			for i := range want {
+				want[i] = true
+			}
+			nHoles := rng.Intn(int(universe))
+			for h := 0; h < nHoles; h++ {
+				want[rng.Intn(int(universe))] = false
+			}
+		case 3: // all-or-nothing / boundary-ish
+			if rng.Intn(2) == 0 {
+				for i := range want {
+					want[i] = true
+				}
+			}
+		}
+		part := buildRecSetShard(want)
+		verifyRecSetShard(t, "fuzz", part, want)
+	}
+}
+
+// buildForEachVisibleRunShard constructs a minimal storageShard with the
+// given main row count, delta (insert) row count, and deletion set, for
+// testing forEachVisibleRun's run-splitting in isolation from the rest of
+// the scan machinery.
+func buildForEachVisibleRunShard(mainCount uint32, deltaCount int, deleted map[uint32]bool) *storageShard {
+	shard := &storageShard{
+		t:            &table{Columns: []*column{{Name: "x", Typ: "int"}}},
+		columns:      map[string]ColumnStorage{},
+		deltaColumns: make(map[string]int),
+		main_count:   mainCount,
+		inserts:      make([][]scm.Scmer, deltaCount),
+	}
+	shard.deletions.Reset()
+	for idx := range deleted {
+		shard.deletions.Set(uint(idx), true)
+	}
+	return shard
+}
+
+// TestForEachVisibleRun is the regression test for a real bug found while
+// wiring recset.go's scan/project sites to bulk column reads: when a
+// recSetRange run lands entirely in the delta region (base >= mainCount),
+// clamping mainEnd to mainCount (without also clamping it up to base) made
+// the delta loop start at mainCount instead of base, reprocessing indices
+// that were never part of the run — one specific instance of which was
+// caught by tests/execution/operators/recset.yaml returning double the
+// expected row count. This test exercises the run-splitting directly rather
+// than only through that one SQL scenario.
+func TestForEachVisibleRun(t *testing.T) {
+	cases := []struct {
+		name        string
+		mainCount   uint32
+		deltaCount  int
+		deleted     map[uint32]bool
+		rangeInput  [][2]uint32 // recSetRanges pairs to build part from
+		wantVisible []bool      // indexed 0..mainCount+deltaCount-1
+	}{
+		{
+			name:        "pure main run",
+			mainCount:   100,
+			deltaCount:  0,
+			rangeInput:  [][2]uint32{{10, 20}},
+			wantVisible: wantFromRange(100, [][2]uint32{{10, 20}}),
+		},
+		{
+			name:        "pure delta run",
+			mainCount:   50,
+			deltaCount:  50,
+			rangeInput:  [][2]uint32{{60, 10}},
+			wantVisible: wantFromRange(100, [][2]uint32{{60, 10}}),
+		},
+		{
+			name:        "run spanning the mainCount boundary",
+			mainCount:   50,
+			deltaCount:  50,
+			rangeInput:  [][2]uint32{{45, 10}}, // 45..54, straddles 50
+			wantVisible: wantFromRange(100, [][2]uint32{{45, 10}}),
+		},
+		{
+			name:       "delta run with a deletion hole",
+			mainCount:  50,
+			deltaCount: 50,
+			deleted:    map[uint32]bool{65: true},
+			rangeInput: [][2]uint32{{60, 20}}, // 60..79, minus 65
+			wantVisible: func() []bool {
+				w := wantFromRange(100, [][2]uint32{{60, 20}})
+				w[65] = false
+				return w
+			}(),
+		},
+		{
+			name:       "main run with a deletion hole right at the boundary",
+			mainCount:  50,
+			deltaCount: 50,
+			deleted:    map[uint32]bool{49: true},
+			rangeInput: [][2]uint32{{45, 10}}, // 45..54, minus 49
+			wantVisible: func() []bool {
+				w := wantFromRange(100, [][2]uint32{{45, 10}})
+				w[49] = false
+				return w
+			}(),
+		},
+		{
+			name:        "multiple ranges, one purely main, one purely delta",
+			mainCount:   50,
+			deltaCount:  50,
+			rangeInput:  [][2]uint32{{5, 5}, {70, 5}},
+			wantVisible: wantFromRange(100, [][2]uint32{{5, 5}, {70, 5}}),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			shard := buildForEachVisibleRunShard(tc.mainCount, tc.deltaCount, tc.deleted)
+			universe := tc.mainCount + uint32(tc.deltaCount)
+			part := recSetShardFromRangePairs(shard, universe, flattenPairs(tc.rangeInput), uint32(len(tc.rangeInput)))
+
+			var got []uint32
+			shard.forEachVisibleRun(&part, universe, false, nil, func(base, count uint32) bool {
+				for id := base; id < base+count; id++ {
+					got = append(got, id)
+				}
+				return true
+			})
+			checkIDsMatchWant(t, tc.name, got, tc.wantVisible)
+		})
+	}
+}
+
+func flattenPairs(ranges [][2]uint32) []uint32 {
+	flat := make([]uint32, 0, len(ranges)*2)
+	for _, r := range ranges {
+		flat = append(flat, r[0], r[1])
+	}
+	return flat
+}
+
+// TestRecSetShardResultIsRightSized guards against a real bug found while
+// benchmarking: finish() (and the union/intersect result builders) used to
+// return `part.data` as the full (universe+31)/32-word backing array they
+// build into, even when the logical content (ranges/positive) only used a
+// tiny prefix of it — silently keeping the entire bitmap-worst-case buffer
+// alive for the shard's whole lifetime regardless of how compact its
+// content actually was. For the case ranges exists to compress (one big
+// range spanning a huge universe), that defeated the entire memory point of
+// having a compact representation. This checks that a shard's data slice
+// length matches its logical content, not the universe-sized budget it was
+// built from.
+func TestRecSetShardResultIsRightSized(t *testing.T) {
+	universe := uint32(500000)
+	bitmapWords := int((universe + 31) / 32)
+
+	clustered := buildRecSetShard(wantFromRange(universe, [][2]uint32{{100000, 200000}}))
+	if clustered.kind != recSetRanges {
+		t.Fatalf("expected recSetRanges, got %v", clustered.kind)
+	}
+	if got, want := len(clustered.data), 2; got != want {
+		t.Errorf("single big range: len(data) = %d words, want %d (got a %dx bigger buffer than needed)", got, want, got/want)
+	}
+
+	scattered := buildRecSetShard(func() []bool {
+		w := make([]bool, universe)
+		for _, id := range []uint32{10, universe / 4, universe / 2, 3 * universe / 4, universe - 10} {
+			w[id] = true
+		}
+		return w
+	}())
+	if scattered.kind != recSetPositive {
+		t.Fatalf("expected recSetPositive, got %v", scattered.kind)
+	}
+	if got, want := len(scattered.data), 5; got != want {
+		t.Errorf("5 scattered hits: len(data) = %d words, want %d", got, want)
+	}
+
+	// Union/intersect result builders had the identical bug — check those
+	// too, not just the builder's own finish().
+	a := buildRecSetShard(wantFromRange(universe, [][2]uint32{{0, 100000}}))
+	b := buildRecSetShard(wantFromRange(universe, [][2]uint32{{50000, 100000}}))
+	union := unionRecSetShards(nil, []*recSetShard{&a, &b})
+	if got, want := len(union.data), 2; got != want {
+		t.Errorf("union of two overlapping ranges: len(data) = %d words, want %d", got, want)
+	}
+	intersect := intersectRecSetShards(nil, []*recSetShard{&a, &b})
+	if got, want := len(intersect.data), 2; got != want {
+		t.Errorf("intersect of two overlapping ranges: len(data) = %d words, want %d", got, want)
+	}
+
+	if bitmapWords < 1000 {
+		t.Fatalf("test setup: universe too small to make the point (bitmap budget = %d words)", bitmapWords)
+	}
+}
+
+func sortUint32(ids []uint32) {
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {
+			ids[j-1], ids[j] = ids[j], ids[j-1]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the ColumnStorage bulk-read work (#526, #528), this time targeting `recSetShard` — the query-local "which rows matched" set used by `scan_recset`/`recset_project_join`/`$recset_contains` and shared with `SkipList` (LIKE-pattern index skip lists, `analyzer.go`).

`recSetShard` previously had five kinds: empty, full, positive (sparse hit list), negative (sparse exclusion list), bitmap. This PR:

1. **Adds `recSetRanges`**: matches stored as sorted, non-overlapping `[base,count)` pairs — the natural shape for an index-driven boundary scan's result (a contiguous, or few-contiguous, block of matching recids). The builder starts in ranges mode; once more than `maxSingletonRuns` (3) isolated single-row hits have closed — meaning the data isn't clustering — it flattens to a flat hit list (`recSetPositive`); if the range-pair budget or the flattened list would overflow the shared backing array, it falls through to `recSetBitmap`.
2. **Removes `recSetFull` and `recSetNegative`** as separate kinds (not just folds them into ranges — genuinely removes them). "Full" and "empty" are now just `recSetRanges` with one pair covering `[0,universe)` or zero pairs — `contains()`/`forEachID()` need no special-casing for them at all, and unlike the old `recSetFull` (`return true` with only a `recid < universe` gate), every row's presence now traces back to an explicit stored pair. `recSetNegative` had the same class of risk, plus its bulk/iteration form would be the *complement* of what's stored — derived, stateful, exactly the kind of logic prone to off-by-one bugs at shard/universe boundaries. `recSetRanges` already covers negative's real use case (mostly-everything-matches, a handful of scattered holes) just as compactly, since each hole simply ends one run and starts the next; only "mostly matches, MANY scattered individual holes" loses a compact encoding now, falling through to bitmap instead — a deliberate, disclosed trade-off.
3. **Bulk-wires `GetValueRange`** into the three non-early-exit recset consumers (`collectProjectJoinKeys`, `scanRecSetPart`, `scan_order_recset_part`) via a new `forEachVisibleRun` helper: it walks a shard's `forEachRange` pairs, splits each into maximal runs of currently-visible rows, and hands each run to the caller as the natural granularity for one bulk column read instead of one `GetValue` call per row. `recSetPartExists` (an early-exit membership probe) is intentionally left per-row — bulk-prefetching a whole run would defeat an early exit that might hit on row 1, same reasoning as `scanFind` in #526.

## Two real bugs found and fixed along the way

**Off-by-one at the mainCount boundary.** All three bulk-wired sites had the identical bug on first pass: splitting a run at the mainCount boundary clamped `mainEnd` down to `mainCount` even when the run was entirely in the delta region (`base >= mainCount`), making the delta loop start at `mainCount` instead of `base` and reprocess indices that weren't part of the run at all. Caught by `tests/execution/operators/recset.yaml` returning double the expected row count; now covered directly by `TestForEachVisibleRun`.

**Backing array never shrunk (found while benchmarking).** `finish()` and the union/intersect result builders (`recSetShardFromRangePairs`/`recSetShardFromList`) originally returned `data` as the full `(universe+31)/32`-word backing array reserved for the bitmap worst case, even when the logical content — a `recSetRanges` or `recSetPositive` result — only used a tiny prefix of it. For the primary case ranges exists to compress (one big range over a huge table), that would have silently kept the entire bitmap-sized buffer alive for the shard's whole lifetime, defeating the entire memory point of the representation. Fixed by copying down to a right-sized slice before returning — one more bounded allocation, proportional to the logical result size, not universe. Now covered by `TestRecSetShardResultIsRightSized`.

## The one-allocation build invariant

The builder keeps a real, documented invariant: exactly one allocation *while `add()` is being called*. Escalating from one phase to a less compact one is a `clear()` of the same shared backing array, relying on the existing `wasBitmap`-watching replay code in `recset.go`/`analyzer.go` (unchanged by this PR) — safe only because every escalation is now guaranteed to happen synchronously inside an `add()` call, never deferred to `finish()`, which is itself a fix: the shard's last run only ever flushes from `finish()`, after the caller's `add()` loop has already ended with no replay window left, so an overflow there used to silently lose every earlier range. The ranges phase's budget check is therefore triggered the moment a new run *starts* (reserving its pair slot immediately), not when it closes.

The one necessary exception is the ranges→positive flatten: a naive in-place expansion has a genuine read-after-write hazard whenever an early range has `count>1` (it can overwrite a not-yet-read later pair before it's read), so that specific transition uses a small temporary buffer bounded by the flattened hit count. `finish()`'s right-sizing copy (see above) is a second, separate, disclosed exception — orthogonal to the build-phase invariant, paid once after `add()` is done, proportional to the logical result size.

## Testing

- `TestRecSetShardBuilderPatterns`/`PhaseTransitions`/`Fuzz` (storage/recset_representation_test.go): verify builder output against a reference boolean-array computation across empty/full/clustered/scattered/dense-random patterns, plus the exact `maxSingletonRuns` boundary (3 stays ranges, 4 flips to positive).
- `TestRecSetShardUnionIntersect(ThreeWay)`: pairwise and 3-way union/intersect across every kind combination (clustered/scattered/empty/full), verified against a reference computation.
- `TestForEachVisibleRun`: the mainCount-boundary regression test (pure main run, pure delta run, run spanning the boundary, deletion holes on both sides of the boundary).
- `TestRecSetShardResultIsRightSized`: the footprint regression test.
- `TestNewRecSetShardFromSortedIDs`: the project-join path (pre-sorted external id list, not an ascending `add()` scan).
- Full repo pre-commit hook (build + Scheme unit tests + `tests/**/*.yaml` SQL suite) passed clean, including `tests/execution/operators/recset.yaml`'s "adaptive recset algebra covers every representation pairing" test and `tests/storage/indexes/fulltext-like-index.yaml` (the shared `SkipList` consumer).

## Performance (A/B vs `origin/master`, 500,000-row table)

**Memory footprint** (the more meaningful number — the direct, table-size-independent effect of the encoding change) for the primary target case, one big contiguous range covering 200,000 of 500,000 rows:

| | words | bytes |
|---|---|---|
| master (bitmap, forced) | 15,625 | 62,500 |
| this branch (ranges) | 2 | 8 |

**7,812x smaller**, and this ratio only grows with table size — it's independent of how many rows matched, purely a function of how many contiguous runs the match forms.

**Wall-clock** (median of 5 runs, `scan_recset` build + a subsequent `scan` filtering on another column — exercises both the new encoding and the `GetValueRange` bulk-wiring):

| Scenario | master | branch | speedup |
|---|---|---|---|
| `scan_recset` build: clustered range (~200k contiguous rows) | 78ms | 75ms | 1.04x |
| `scan_recset` + `scan` filter: clustered range | 178ms | 164ms | 1.08x |
| `scan_recset` build: scattered (~0.1% match, no clustering — control) | 36ms | 37ms | 0.97x |
| `scan_recset` + `scan` filter: scattered (control) | 38ms | 38ms | 1.00x |

The scattered (control) scenario is at parity as expected — it never touches the new ranges path. The clustered scenario shows a modest but real wall-clock win (1.04–1.08x); at 500k rows, SQL/scm-interpreter overhead for evaluating the row condition dominates over the representation's own bookkeeping cost, which is why the wall-clock delta is much smaller than the memory delta — the bitmap iteration this replaces was already cheap in absolute terms at this scale. The memory number is the one that matters for the intended use case (large tables, selective contiguous filters); correctness was cross-checked to produce identical result values (4 and 9 respectively) on both binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)