### PR TITLE
fix: correct RecSet scalar-probe once/apply misuse causing silent wrong results

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -9622,23 +9622,37 @@ membership set. */
 		(define cache_schema (group_cache_schema cache))
 		(define cache_relation (group_cache_relation cache))
 		(define lookup_key (recset_scalar_first_probe_lookup_key stage))
+		(define session_read (list (list (quote context) "session") lookup_key))
+		(define session_setter (list
+			(list (quote context) "session")
+			lookup_key
+			(list (quote once) (list (quote lambda) '()
+				(list (quote recset_key_index)
+					(list (quote session) "__memcp_tx")
+					(list (quote scan_recset)
+						(list (quote session) "__memcp_tx")
+						(list (quote table) cache_schema cache_relation)
+						(quoted_runtime_list (list requested_col))
+						(list (quote lambda) (list (symbol requested_col))
+							(list (quote equal??) (symbol requested_col) true)))
+					(quoted_runtime_list (list "k0")))))))
 		(list (quote begin)
 			(lower_group_stage_prepare_using stage_catalog stage_catalog stage)
-			(list
-				(list (quote context) "session")
-				lookup_key
-				(list (quote once) (list (quote lambda) '()
-					(list (quote recset_key_index)
-						(list (quote session) "__memcp_tx")
-						(list (quote scan_recset)
-							(list (quote session) "__memcp_tx")
-							(list (quote table) cache_schema cache_relation)
-							(quoted_runtime_list (list requested_col))
-							(list (quote lambda) (list (symbol requested_col))
-								(list (quote equal??) (symbol requested_col) true)))
-						(quoted_runtime_list (list "k0"))))))
+			/* session_setter builds a ZERO-ARG once-wrapped lookup-closure builder; without this guard
+			   every driving row would re-run this setter, constructing a fresh once-wrapper each time
+			   and discarding the previous memoization (defeating the point of `once`). */
+			(list (quote if)
+				(list (quote nil?) session_read)
+				session_setter
+				true)
+			/* session_read stores a zero-arg builder (not the lookup closure itself), so retrieving the
+			   actual boolean requires TWO applies: one zero-arg apply to run/fetch the memoized builder
+			   and obtain the recset_key_index closure, then a second apply of that closure to the real key.
+			   Single-applying session_read directly to resolved_lookup_key would instead pass the key as
+			   an ignored extra argument to the zero-arg builder, which just returns the closure itself
+			   (a non-nil/truthy value) rather than ever checking membership. */
 			(list (quote apply)
-				(list (list (quote context) "session") lookup_key)
+				(list (quote apply) session_read (quoted_runtime_list '()))
 				(list (quote list) resolved_lookup_key))))))
 
 (define lower_scalar_first_probe_expr (lambda (sources default_alias stage requested_col all_stages probe_work_rows)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1758,6 +1758,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (once_fn 2) 3) true "once first call computes")
 	(assert (equal? (once_fn 99) 3) true "once second call returns cached")
 	(assert (equal? (once_calls "n") 1) true "once executes only once")
+	/* a zero-arg once-wrapped builder returns a closure, not the closure's result;
+	   single-applying it to an argument just ignores that argument as noise */
+	(define once_builder (once (lambda () (lambda (x) (equal? x 1)))))
+	(assert (nil? (apply once_builder (list 1))) false
+		"single-applying a zero-arg once-wrapper still returns a closure (non-nil/truthy), not the intended boolean result")
+	(assert (equal? (apply (apply once_builder (list)) (list 1)) true) true
+		"double-applying a zero-arg once-wrapper runs the memoized builder first, then calls the built closure with the real argument")
+	(assert (equal? (apply (apply once_builder (list)) (list 2)) false) true
+		"the closure retrieved via the zero-arg call behaves correctly for a non-matching argument too")
 	/* mutex */
 	(define mtx (mutex))
 	(assert (equal? (mtx (lambda () 42)) 42) true "mutex executes inner function")


### PR DESCRIPTION
## Summary

- `lower_recset_scalar_first_probe_expr` stores a zero-arg `once`-wrapped
  lookup-closure builder in a session variable, then reads it back by
  single-applying that session variable directly to the per-row lookup key.
  Since `once` ignores extra arguments after its first call, this ran the
  builder (returning the `recset_key_index` closure itself, a non-nil/truthy
  value) instead of ever invoking that closure with the key — so every row's
  membership filter silently evaluated true regardless of actual membership.
  This is a **correctness bug**: any query where the planner selects the
  RecSet carrier for a scalar-first probe would silently return wrong rows,
  with no error or crash.
- Fixed by reading in two steps: a zero-arg apply to fetch the memoized
  lookup closure, then applying that closure to the real key.
- Also guards the setter with `(if (nil? session_read) session_setter true)`
  so it only runs once per query execution — previously it was embedded
  inside the per-row filter body and re-built a fresh `once`-wrapper (and
  recomputed the whole RecSet scan) on every driving row, discarding prior
  memoization.
- Added a `lib/test.scm` unit test that pins down the exact `once`/`apply`
  semantics responsible for the bug (single- vs. double-applying a zero-arg
  `once`-wrapped builder), independent of the query planner's cost model
  that decides whether the RecSet carrier is ever selected for a given
  query shape.

This bug pre-dates this branch — found while investigating an unrelated
perf/reachability issue, confirmed via direct diff against `origin/master`
to be untouched by that other work, and is being submitted here on its own
as a minimal, focused fix.

## Test plan

- [x] `go build -o memcp .`
- [x] `python3 tools/lint_scm.py --path lib/queryplan.scm --check`
- [x] `python3 tools/lint_scm.py --path lib/test.scm --check`
- [x] Full in-process unit test suite (`lib/test.scm`, runs at server startup):
      1231/1233 passing — the 2 remaining failures are pre-existing and
      unrelated (`_mut merge_unique on fresh first arg`,
      `optimizer: dynamic reducer keeps merge validation before reducer
      lookup`).
- [x] Targeted SQL regression suites against a running dev server:
      `tests/planner/subqueries/*.yaml`, `tests/execution/operators/recset.yaml`
      — all pass (only pre-existing/known-flaky noncritical cases observed).
- [x] Local pre-commit hook (full `make test`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)