### PR TITLE
Show HTTP SQL text in processlist

### DIFF
--- a/scm/network.go
+++ b/scm/network.go
@@ -95,6 +95,8 @@ type HttpServer struct {
 
 func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-Type", "text/plain")
+	var ss *SessionState
+	var querySeq uint64
 	query_scm := make([]Scmer, 0)
 	for k, v := range req.URL.Query() {
 		for _, v2 := range v {
@@ -128,7 +130,11 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			var b strings.Builder
 			io.Copy(&b, req.Body)
 			req.Body.Close()
-			return NewString(b.String())
+			body := b.String()
+			if req.Method == http.MethodPost && strings.HasPrefix(req.URL.Path, "/sql/") {
+				ss.SetQueryInfo(querySeq, body)
+			}
+			return NewString(body)
 		}),
 		NewString("bodyParts"), NewFunc(func(a ...Scmer) Scmer {
 			result := []Scmer{}
@@ -282,7 +288,6 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			})
 		}),
 	}
-	var ss *SessionState
 	if sid := req.Header.Get("X-Session-Id"); sid != "" {
 		// Persistent HTTP session: reuse or create a long-lived SessionState.
 		if v, ok := httpStates.Load(sid); ok {
@@ -300,7 +305,7 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		defer ss.ReleaseAllLocks() // non-persistent: release locks when request ends
 	}
 	ss.Touch()
-	querySeq := ss.BeginQuery("Query", req.Method+" "+req.URL.Path)
+	querySeq = ss.BeginQuery("Query", req.Method+" "+req.URL.Path)
 	ctx, cancel := context.WithCancel(req.Context())
 	ss.SetCancel(querySeq, cancel)
 	ss.SetQueryContext(querySeq, ctx)

--- a/scm/network_test.go
+++ b/scm/network_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPSQLBodyUpdatesProcesslistInfo(t *testing.T) {
+	const query = "SELECT SLEEP(1)"
+	observed := ""
+	server := &HttpServer{callback: NewFunc(func(a ...Scmer) Scmer {
+		bodyFn := Apply(a[0], NewString("body"))
+		if body := Apply(bodyFn).String(); body != query {
+			t.Fatalf("expected request body %q, got %q", query, body)
+		}
+		ss := GetCurrentSessionState()
+		if ss == nil {
+			t.Fatal("expected HTTP session state")
+		}
+		observed = strPtr(&ss.Info)
+		return NewNil()
+	})}
+	req := httptest.NewRequest("POST", "/sql/database", strings.NewReader(query))
+	res := httptest.NewRecorder()
+
+	server.ServeHTTP(res, req)
+
+	if observed != query {
+		t.Fatalf("expected processlist info %q, got %q", query, observed)
+	}
+}

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -112,6 +112,22 @@ func (s *SessionState) BeginQuery(cmd, info string) uint64 {
 	return seq
 }
 
+// SetQueryInfo updates the processlist text for an active query generation.
+// HTTP requests use this after lazily reading a SQL request body. A stale
+// request must not overwrite the text of a newer request sharing the session.
+func (s *SessionState) SetQueryInfo(seq uint64, info string) bool {
+	if seq == 0 || s.activeQuery.Load() != seq {
+		return false
+	}
+	s.cancelMu.Lock()
+	defer s.cancelMu.Unlock()
+	if !s.active[seq] || s.activeQuery.Load() != seq {
+		return false
+	}
+	s.Info.Store(&info)
+	return true
+}
+
 // EndQuery clears the active generation if it still matches seq and restores
 // the idle processlist state. Older requests finishing late must not overwrite
 // a newer active request on the same persistent HTTP session.

--- a/scm/processlist_test.go
+++ b/scm/processlist_test.go
@@ -112,3 +112,26 @@ func TestKillSessionLogsKilledQuery(t *testing.T) {
 		t.Fatalf("unexpected kill log: %q", msgs[0])
 	}
 }
+
+func TestSetQueryInfoRejectsStaleGeneration(t *testing.T) {
+	ss := RegisterSession("u", "h", "db")
+	defer UnregisterSession(ss.ID)
+
+	stale := ss.BeginQuery("Query", "POST /sql/db")
+	current := ss.BeginQuery("Query", "SELECT 2")
+	defer ss.EndQuery(stale, "Sleep", "")
+	defer ss.EndQuery(current, "Sleep", "")
+
+	if ss.SetQueryInfo(stale, "SELECT 1") {
+		t.Fatal("expected stale generation update to be rejected")
+	}
+	if info := strPtr(&ss.Info); info != "SELECT 2" {
+		t.Fatalf("expected current query info to remain unchanged, got %q", info)
+	}
+	if !ss.SetQueryInfo(current, "SELECT 2 FROM dual") {
+		t.Fatal("expected current generation update to succeed")
+	}
+	if info := strPtr(&ss.Info); info != "SELECT 2 FROM dual" {
+		t.Fatalf("expected updated query info, got %q", info)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the generic POST /sql path in processlist Info with the SQL request body once it is read
- guard updates by query generation so stale requests cannot overwrite newer session activity
- add HTTP-path and stale-generation regression tests

## Testing
- make test
- go test ./scm/ -run 'TestHTTPSQLBodyUpdatesProcesslistInfo|TestSetQueryInfoRejectsStaleGeneration'