### PR TITLE
fix: stabilize optimizer reducer ownership

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -561,19 +561,14 @@ func optimizedMergeSegments(v Scmer) (Scmer, bool) {
 	return NewSlice(segments), true
 }
 
-// mergeValidationSafeArgument reports whether evaluating an argument before
-// merge's list validation is unobservable. Fused calls evaluate their ordinary
-// arguments before reduce_segments validates the segment catalog, whereas the
-// unfused spelling validates during evaluation of reduce's first argument.
-func mergeValidationSafeArgument(v Scmer, allowLambda bool) bool {
+// mergeValidationSafeDeferredArgument reports whether evaluating a reduce
+// argument before merge's list validation is unobservable. Fused calls evaluate
+// their reducer and neutral value before validating the segment catalog, whereas
+// the unfused spelling finishes evaluating merge first. Dynamic lookups are not
+// safe here even when they have already been numbered by the optimizer.
+func mergeValidationSafeDeferredArgument(v Scmer, allowLambda bool) bool {
 	if stripped, ok := scmerStripSourceInfo(v); ok {
 		v = stripped
-	}
-	if v.IsNthLocalVar() {
-		return true
-	}
-	if v.IsSymbol() {
-		return true
 	}
 	inner, ok := scmerSlice(v)
 	if !ok {
@@ -581,9 +576,6 @@ func mergeValidationSafeArgument(v Scmer, allowLambda bool) bool {
 	}
 	if len(inner) == 0 {
 		return true
-	}
-	if scmerIsSymbol(inner[0], "var") {
-		return len(inner) == 2 && inner[1].IsInt()
 	}
 	return scmerIsSymbol(inner[0], "quote") || (allowLambda && scmerIsSymbol(inner[0], "lambda"))
 }
@@ -646,7 +638,8 @@ func optimizeReduce(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Ty
 		}
 	}
 	if inner, ok := scmerSlice(rv[1]); ok && len(inner) == 3 && scmerIsSymbol(inner[0], "merge") {
-		if !mergeValidationSafeArgument(inner[1], true) || !mergeValidationSafeArgument(inner[2], false) ||
+		if !mergeValidationSafeDeferredArgument(rv[2], true) ||
+			(len(rv) == 4 && !mergeValidationSafeDeferredArgument(rv[3], false)) ||
 			exprMayHaveSideEffects(rv[2]) || (len(rv) == 4 && exprMayHaveSideEffects(rv[3])) {
 			return result, td
 		}
@@ -657,7 +650,8 @@ func optimizeReduce(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Ty
 		return NewSlice(fused), td
 	}
 	segments, ok := optimizedMergeSegments(rv[1])
-	if !ok || !mergeValidationSafeArgument(rv[2], true) || (len(rv) == 4 && !mergeValidationSafeArgument(rv[3], false)) {
+	if !ok || !mergeValidationSafeDeferredArgument(rv[2], true) ||
+		(len(rv) == 4 && !mergeValidationSafeDeferredArgument(rv[3], false)) {
 		return result, td
 	}
 	fused := make([]Scmer, 0, len(rv))
@@ -9545,29 +9539,12 @@ func optimizedSingletonListItem(expr Scmer) (Scmer, bool) {
 	return NewNil(), false
 }
 
-// optimizeMergeUnique keeps merge_unique on the standard variadic path, but
-// additionally treats a direct (list ...) first argument as fresh so the
-// optimizer can swap to merge_unique_mut without changing the global list
-// return contract.
+// optimizeMergeUnique keeps merge_unique on the standard variadic path and
+// reuses an exclusively owned first argument. The common mutating-operator
+// pipeline also keeps that transferred argument heap-backed so the returned
+// list cannot alias a numbered lambda frame.
 func optimizeMergeUnique(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
-	result, td := oc.ApplyDefaultOptimization(v, useResult)
-	rv, ok := scmerSlice(result)
-	if !ok || len(rv) < 2 || !scmerIsSymbol(rv[0], "merge_unique") {
-		return result, td
-	}
-	if rv[1].IsSlice() {
-		inner := rv[1].Slice()
-		if len(inner) > 0 && scmerIsSymbol(inner[0], "list") {
-			rv[0] = NewSymbol("merge_unique_mut")
-			if td == nil {
-				td = &TypeDescriptor{}
-			}
-			td.Transfer = true
-			return NewSlice(rv), td
-		}
-	}
-
-	return result, td
+	return oc.applyDefaultOptimization(v, useResult, "merge_unique_mut")
 }
 
 func flattenConsList(v []Scmer) ([]Scmer, bool) {

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -182,12 +182,12 @@ func TestOptimizeFusesReduceOverMapThenFilter(t *testing.T) {
 	}
 }
 
-func TestOptimizeFusesMergeUniqueOverMap(t *testing.T) {
+func TestOptimizeKeepsMergeUniqueOverMapOfLists(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
-		(merge_unique (map values (lambda (value) (+ value 1)))))`)
+		(merge_unique (map values (lambda (value) (list (+ value 1))))))`)
 	serialized := serializedTestExpr(t, env, optimized)
-	if !strings.Contains(serialized, "merge_unique_map") {
-		t.Fatalf("merge_unique/map pipeline was not fused: %s", serialized)
+	if strings.Contains(serialized, "merge_unique_map") {
+		t.Fatalf("merge_unique/map-of-lists pipeline was unsafely fused: %s", serialized)
 	}
 
 	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
@@ -198,18 +198,73 @@ func TestOptimizeFusesMergeUniqueOverMap(t *testing.T) {
 	}
 }
 
-func TestOptimizeFusesMergeUniqueOverFilterMap(t *testing.T) {
+func TestOptimizeKeepsMergeUniqueOverFilterMapOfLists(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
-		(merge_unique (map (filter values (lambda (value) (> value 1))) (lambda (value) (* value 2)))))`)
+		(merge_unique (map (filter values (lambda (value) (> value 1))) (lambda (value) (list (* value 2))))))`)
 	serialized := serializedTestExpr(t, env, optimized)
-	if !strings.Contains(serialized, "merge_unique_map_filter") {
-		t.Fatalf("merge_unique/map/filter pipeline was not fused: %s", serialized)
+	if strings.Contains(serialized, "merge_unique_map_filter") {
+		t.Fatalf("merge_unique/map/filter-of-lists pipeline was unsafely fused: %s", serialized)
 	}
 
 	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
 	got := fn(NewSlice([]Scmer{NewInt(0), NewInt(1), NewInt(2), NewInt(2), NewInt(3)}))
 	want := NewSlice([]Scmer{NewInt(4), NewInt(6)})
 	if !Equal(got, want) {
-		t.Fatalf("fused merge_unique/map/filter returned %s, want %s", String(got), String(want))
+		t.Fatalf("merge_unique/map/filter returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeMergeUniqueMutatesFreshList(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (a b c)
+		(merge_unique (list (list a b) (list b c))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "merge_unique_mut") {
+		t.Fatalf("fresh list did not select merge_unique_mut: %s", serialized)
+	}
+	if strings.Contains(serialized, "!list") {
+		t.Fatalf("transferred merge_unique input was lowered to a frame-local list: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewInt(1), NewInt(2), NewInt(3))
+	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
+	if !Equal(got, want) {
+		t.Fatalf("merge_unique_mut returned %s, want %s", String(got), String(want))
+	}
+	second := fn(NewInt(4), NewInt(5), NewInt(6))
+	if !Equal(got, want) {
+		t.Fatalf("later call mutated escaped result to %s, want %s", String(got), String(want))
+	}
+	secondWant := NewSlice([]Scmer{NewInt(4), NewInt(5), NewInt(6)})
+	if !Equal(second, secondWant) {
+		t.Fatalf("second merge_unique_mut returned %s, want %s", String(second), String(secondWant))
+	}
+}
+
+func TestOptimizeKeepsDynamicReducerAfterMergeValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		fused  string
+	}{
+		{
+			name:   "segment catalog",
+			source: `(lambda (parts reducer) (reduce (merge parts) reducer 0))`,
+			fused:  "reduce_segments",
+		},
+		{
+			name:   "two lists",
+			source: `(lambda (left right reducer) (reduce (merge left right) reducer 0))`,
+			fused:  "reduce_merge2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if strings.Contains(serialized, tc.fused) {
+				t.Fatalf("dynamic reducer moved ahead of merge validation: %s", serialized)
+			}
+		})
 	}
 }

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1935,20 +1935,31 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 
 	// _mut swap: when mutName is set and first arg is exclusively owned,
 	// swap to the in-place variant
+	firstArgTransferred := false
 	if mutName != "" {
 		firstArgFresh := false
 		if len(v) >= 2 {
 			arg1 := v[1]
-			if si, ok := arg1.Any().(SourceInfo); ok {
-				arg1 = si.value
+			if stripped, ok := scmerStripSourceInfo(arg1); ok {
+				arg1 = stripped
 			}
 			if td := optimizerExpressionDescriptor(arg1, env, ome); td != nil {
 				firstArgFresh = td.Transfer && !td.Const
+			}
+			// merge_unique accepts either a segment catalog or variadic lists, so
+			// its public return contract cannot expose first-argument ownership.
+			// A direct catalog constructor is nevertheless fresh. Decide this
+			// before NoEscape lowering can turn it into !list.
+			if items, ok := scmerSlice(arg1); ok && mutName == "merge_unique_mut" {
+				if _, directList := listConstructorElements(items); directList {
+					firstArgFresh = true
+				}
 			}
 		}
 		if firstArgFresh && len(v) >= 2 {
 			v[0] = NewSymbol(mutName)
 			transferOwnership = true
+			firstArgTransferred = true
 		}
 	}
 
@@ -1971,6 +1982,12 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 	if !allConstArgs && ome.nextSlot != nil {
 		if decl := callDecl; decl != nil && decl.Type != nil && len(decl.Type.Params) > 0 {
 			for i := 1; i < len(v); i++ {
+				// A mutating variant returns the first argument's backing storage.
+				// Rewriting that argument to a frame-local !list would let the
+				// returned value escape after the frame has been reused.
+				if i == 1 && firstArgTransferred {
+					continue
+				}
 				paramIdx := i - 1
 				if paramIdx >= len(decl.Type.Params) {
 					paramIdx = len(decl.Type.Params) - 1 // variadic: use last param


### PR DESCRIPTION
Fixes #537

## Summary
- keep dynamic reducer and neutral lookups after merge input validation
- select merge_unique_mut for fresh catalogs without letting frame-local list storage escape
- add regression coverage for fresh-list ownership and dynamic reducer ordering

## Validation
- startup Scheme self-tests: 1230/1230 passed
- targeted optimizer regressions: 10 repeated runs passed
- full git-pre-commit suite: all suites passed except one OOM-affected crash-recovery case; that case passed independently (18/18)
- go test ./scm passed