### PR TITLE
queryplan: fold boolean tautologies/contradictions in normalized IR

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -4405,6 +4405,11 @@ source alias is the stable identity consumed by all later planner phases. */
 		true true
 		_ false)))
 
+(define literal_false? (lambda (expr)
+	(match expr
+		false true
+		_ false)))
+
 (define build_and_terms (lambda (terms)
 	(begin
 		(define filtered (filter (coalesceNil terms '()) (lambda (term) (not (literal_true? (coalesceNil term true))))))
@@ -7908,16 +7913,150 @@ created. Canonicalize that unambiguous interface before physical lowering. */
 					'() block_with_stages))
 				(make_ir (ir_kind ir) block stages (ir_context_of ir) (ir_return ir)))))))
 
+/* ------------------------------------------------------------------------- */
+/* Boolean constant-folding on the normalized IR (todos/boolean-tautology-folding.md).
+Runs on the already-decorrelated, already-merged IR (after
+merge_compatible_stage_output_left_joins_ir), so two occurrences of the same
+correlated EXISTS check are already the same stage-output alias and match
+structurally without any further alias-normalization here. Plain 2-valued
+boolean algebra is safe in this truth context: every predicate this pass
+folds already reached its final IR shape via coalesceNil/comparison
+encodings (e.g. EXISTS lowers to `(> (coalesceNil (get_column ...) 0) 0)`)
+that are never SQL-NULL by construction. */
+
+(define expr_head_and? (lambda (head) (or (equal? head (quote and)) (equal? head (symbol "and")))))
+(define expr_head_or? (lambda (head) (or (equal? head (quote or)) (equal? head (symbol "or")))))
+(define expr_head_not? (lambda (head) (or (equal? head (quote not)) (equal? head (symbol "not")))))
+(define expr_head_if? (lambda (head) (or (equal? head (quote if)) (equal? head (symbol "if")))))
+
+(define boolean_fold_not (lambda (folded_inner)
+	(if (literal_true? folded_inner)
+		false
+		(if (literal_false? folded_inner)
+			true
+			(match folded_inner
+				(cons head tail) (if (and (expr_head_not? head) (equal? (count tail) 1))
+					(car tail)
+					(list (quote not) folded_inner))
+				_ (list (quote not) folded_inner))))))
+
+/* True when some folded term's negation is also present among the folded
+terms -- the (A OR NOT A) / (A AND NOT A) shape. Both sides were normalized
+by this same fold pass, so a correlated EXISTS check appearing verbatim on
+both sides of the connective always matches here, even when one side is
+wrapped in an extra NOT. */
+(define terms_have_negation_pair? (lambda (folded_terms)
+	(reduce folded_terms (lambda (found term)
+		(or found (contains? folded_terms (boolean_fold_not term))))
+		false)))
+
+(define boolean_fold_and_terms (lambda (folded_terms)
+	(begin
+		(define has_false (reduce folded_terms (lambda (found term) (or found (literal_false? term))) false))
+		(if has_false
+			false
+			(begin
+				(define kept (reduce folded_terms (lambda (acc term)
+					(if (literal_true? term) acc (append_unique acc term)))
+					'()))
+				(if (terms_have_negation_pair? kept)
+					false
+					(match kept
+						'() true
+						(cons single '()) single
+						_ (cons (quote and) kept))))))))
+
+(define boolean_fold_or_terms (lambda (folded_terms)
+	(begin
+		(define has_true (reduce folded_terms (lambda (found term) (or found (literal_true? term))) false))
+		(if has_true
+			true
+			(begin
+				(define kept (reduce folded_terms (lambda (acc term)
+					(if (literal_false? term) acc (append_unique acc term)))
+					'()))
+				(if (terms_have_negation_pair? kept)
+					true
+					(match kept
+						'() false
+						(cons single '()) single
+						_ (cons (quote or) kept))))))))
+
+(define boolean_fold_if (lambda (folded_cond folded_then folded_else)
+	(if (and (literal_true? folded_then) (literal_false? folded_else))
+		folded_cond
+		(if (and (literal_false? folded_then) (literal_true? folded_else))
+			(boolean_fold_not folded_cond)
+			(list (quote if) folded_cond folded_then folded_else)))))
+
+(define boolean_fold_expr (lambda (expr)
+	(match expr
+		(cons head tail) (begin
+			(define folded_tail (map tail boolean_fold_expr))
+			(if (and (expr_head_and? head) (>= (count folded_tail) 1))
+				(boolean_fold_and_terms folded_tail)
+				(if (and (expr_head_or? head) (>= (count folded_tail) 1))
+					(boolean_fold_or_terms folded_tail)
+					(if (and (expr_head_not? head) (equal? (count folded_tail) 1))
+						(boolean_fold_not (car folded_tail))
+						(if (and (expr_head_if? head) (equal? (count folded_tail) 3))
+							(boolean_fold_if (nth folded_tail 0) (nth folded_tail 1) (nth folded_tail 2))
+							(cons (boolean_fold_expr head) folded_tail))))))
+		_ expr)))
+
+(define boolean_fold_maybe_expr (lambda (expr)
+	(if (nil? expr) nil (boolean_fold_expr expr))))
+
+(define fold_stage_facts_condition (lambda (facts)
+	(begin
+		(define existing (qassoc_get facts (quote condition) nil))
+		(if (nil? existing)
+			facts
+			(qassoc_set facts (quote condition) (boolean_fold_expr existing))))))
+
+(define fold_boolean_tautologies_stage (lambda (stage)
+	(if (group_stage? stage)
+		(make_group_stage
+			(gs_id stage)
+			(gs_input stage)
+			(gs_domain stage)
+			(gs_keys stage)
+			(gs_aggregates stage)
+			(boolean_fold_maybe_expr (gs_having stage))
+			(gs_output stage)
+			(gs_order stage)
+			(gs_limit stage)
+			(gs_offset stage)
+			(fold_stage_facts_condition (gs_facts stage)))
+		stage)))
+
+(define fold_boolean_tautologies_ir (lambda (ir)
+	(begin
+		(define root (ir_root ir))
+		(if (not (query_block? root))
+			ir
+			(begin
+				(define folded_stages (map (qb_stages root) fold_boolean_tautologies_stage))
+				(define folded_block (make_query_block
+					(qb_schema root) (qb_sources root) (qb_fields root)
+					(boolean_fold_maybe_expr (qb_where root))
+					(qb_group root)
+					(boolean_fold_maybe_expr (qb_having root))
+					(qb_order root) (qb_limit root) (qb_offset root) (qb_hidden root)
+					folded_stages (qb_facts root)))
+				(make_ir (ir_kind ir) folded_block folded_stages (ir_context_of ir) (ir_return ir)))))))
+
 (define normalize_stage_dependencies (lambda (ir)
 	(begin
 		(define root_result (normalize_stage_dependencies_node (ir_root ir)))
 		(canonicalize_stage_output_interfaces
-			(merge_compatible_stage_output_left_joins_ir (make_ir
-				(ir_kind ir)
-				(nth root_result 0)
-				(if (query_block? (nth root_result 0)) (qb_stages (nth root_result 0)) (nth root_result 1))
-				(ir_context_of ir)
-				(ir_return ir)))))))
+			(fold_boolean_tautologies_ir
+				(merge_compatible_stage_output_left_joins_ir (make_ir
+					(ir_kind ir)
+					(nth root_result 0)
+					(if (query_block? (nth root_result 0)) (qb_stages (nth root_result 0)) (nth root_result 1))
+					(ir_context_of ir)
+					(ir_return ir))))))))
 
 /* Scalar stages are merged after decorrelation. Build their signatures bottom-up
 so generated aliases and dependency IDs do not hide equivalent stage graphs. */

--- a/tests/planner/subqueries/boolean-tautology-folding.yaml
+++ b/tests/planner/subqueries/boolean-tautology-folding.yaml
@@ -1,0 +1,150 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+# Boolean constant-folding on the normalized IR (todos/boolean-tautology-folding.md).
+# A correlated EXISTS check combined with its own negation via OR/AND is a
+# boolean tautology/contradiction that never depends on the EXISTS result, but
+# without folding it still compiles into real physical probe work every time.
+
+metadata:
+  version: "1.0"
+  description: "Boolean tautology/contradiction folding for duplicated correlated EXISTS checks"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS taut_child"
+  - sql: "DROP TABLE IF EXISTS taut_parent"
+  - sql: |
+      CREATE TABLE taut_parent (
+        ID INT PRIMARY KEY,
+        val INT
+      )
+  - sql: |
+      CREATE TABLE taut_child (
+        ID INT PRIMARY KEY,
+        parent_id INT
+      )
+  - sql: |
+      INSERT INTO taut_parent (ID, val) VALUES
+      (1, 10), (2, 20), (3, -5)
+  - sql: |
+      INSERT INTO taut_child (ID, parent_id) VALUES
+      (1, 1)
+
+test_cases:
+  - name: "(A OR NOT A) tautology keeps correct rows regardless of EXISTS"
+    sql: |
+      SELECT ID FROM taut_parent p
+      WHERE p.val > 0
+        AND (
+          EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+          OR NOT EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+        )
+      ORDER BY ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1}
+        - {ID: 2}
+
+  - name: "(A AND NOT A) contradiction drops all rows regardless of EXISTS"
+    sql: |
+      SELECT ID FROM taut_parent p
+      WHERE p.val > 0
+        AND (
+          EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+          AND NOT EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+        )
+      ORDER BY ID
+    expect:
+      rows: 0
+
+  - name: "EXPLAIN for the (A OR NOT A) tautology has no physical EXISTS probe left"
+    sql: |
+      EXPLAIN SELECT ID FROM taut_parent p
+      WHERE p.val > 0
+        AND (
+          EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+          OR NOT EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+        )
+      ORDER BY ID
+    expect:
+      rows: 1
+      result_contains:
+        - "taut_parent"
+      result_not_contains:
+        - "taut_child"
+        - "touch_keytable"
+        - ".grp:"
+        - "recset_project_join"
+
+  - name: "EXPLAIN IR folds the tautological branch out of the WHERE clause"
+    sql: |
+      EXPLAIN IR SELECT ID FROM taut_parent p
+      WHERE p.val > 0
+        AND (
+          EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+          OR NOT EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+        )
+      ORDER BY ID
+    expect:
+      rows: 1
+      result_contains:
+        - "get_column"
+        - "val"
+      result_not_contains:
+        - "(or"
+        - "(not"
+
+  - name: "Non-tautological OR of two distinct correlated EXISTS checks is not folded"
+    sql: |
+      EXPLAIN SELECT ID FROM taut_parent p
+      WHERE p.val > 0
+        AND (
+          EXISTS (SELECT 1 FROM taut_child c WHERE c.parent_id = p.ID)
+          OR EXISTS (SELECT 1 FROM taut_child c2 WHERE c2.parent_id = p.ID AND c2.ID > 100)
+        )
+      ORDER BY ID
+    expect:
+      rows: 1
+      result_contains:
+        - "taut_child"
+        - "scan_order"
+
+  - name: "Direct fold rule check: and/or/not/if simplification via /scm"
+    scm: |
+      (begin
+        (define col (list (quote get_column) "a" false "x" false))
+        (define checks (list
+          (equal? (boolean_fold_expr (list (quote and) true col)) col)
+          (equal? (boolean_fold_expr (list (quote and) false col)) false)
+          (equal? (boolean_fold_expr (list (quote or) true col)) true)
+          (equal? (boolean_fold_expr (list (quote or) false col)) col)
+          (equal? (boolean_fold_expr (list (quote not) true)) false)
+          (equal? (boolean_fold_expr (list (quote not) false)) true)
+          (equal? (boolean_fold_expr (list (quote not) (list (quote not) col))) col)
+          (equal? (boolean_fold_expr (list (quote and) col col)) col)
+          (equal? (boolean_fold_expr (list (quote or) col col)) col)
+          (equal? (boolean_fold_expr (list (quote or) col (list (quote not) col))) true)
+          (equal? (boolean_fold_expr (list (quote and) col (list (quote not) col))) false)
+          (equal? (boolean_fold_expr (list (quote if) col true false)) col)
+          (equal? (boolean_fold_expr (list (quote if) col false true)) (list (quote not) col))))
+        (if (reduce checks (lambda (acc c) (and acc c)) true)
+          true
+          (error (concat "boolean_fold_expr rule mismatch: " (string checks)))))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS taut_child"
+  - sql: "DROP TABLE IF EXISTS taut_parent"


### PR DESCRIPTION
## Summary
- A correlated `EXISTS` check combined with its own negation via `OR`/`AND` (`A OR NOT A`, `A AND NOT A`) is a boolean tautology/contradiction that never affects which rows are selected, but without folding it still compiles into real physical probe work every time it's evaluated (see `todos/boolean-tautology-folding.md`, written up from the real omnestum `dokument` COUNT query).
- Adds a bottom-up boolean constant-folding pass (`boolean_fold_expr` and friends in `lib/queryplan.scm`) applied to `qb_where`, `qb_having`, `gs_having`, and each group-stage's `condition` fact inside `normalize_stage_dependencies`, implementing standard 2-valued boolean-algebra identities: `and`/`or` with `true`/`false`, double negation, idempotence, degenerate `CASE`, and structural `X`/`NOT X` cancellation (both connectives, n-ary).
- The pass runs after `merge_compatible_stage_output_left_joins_ir`, so two textually-identical correlated `EXISTS` checks are already the same stage-output alias and match structurally with plain `equal?` — no extra alias-normalization needed.
- Verified (via `EXPLAIN`/`EXPLAIN IR`) that once the tautology folds away, the now-unreferenced `EXISTS` group-stage's physical probe work (`scan_order`/keytable/RecSet join) disappears entirely from the compiled plan — physical lowering already only touches reachable sources, so no separate dead-stage pruning pass was needed.

## Design note vs. the original todo
`todos/boolean-tautology-folding.md` expected the orphaned `EXISTS` stage to also vanish from `EXPLAIN IR`'s `qb_stages`. Empirically it stays listed there (the *logical* IR is a superset), but the *physical* `EXPLAIN` plan — what actually executes — no longer references the child table, `scan_order`, `touch_keytable`, `.grp:`, or `recset_project_join` for it at all. The test asserts against physical `EXPLAIN`, which is the actually load-bearing signal.

## Test plan
- [x] New regression test `tests/planner/subqueries/boolean-tautology-folding.yaml`: confirmed to fail against master (`Unknown function: boolean_fold_expr`, and manually verified the pre-fix physical/IR plans still carry the full EXISTS probe + `or`/`not` noise) before this change.
- [x] `python3 run_sql_tests.py tests/planner/subqueries/boolean-tautology-folding.yaml <port>` — 6/6 pass.
- [x] `python3 run_sql_tests.py tests/planner/subqueries/*.yaml <port> --jobs 4` — 69+13 pre-existing tests pass (EXISTS/IN/UNION correctness untouched).
- [ ] Full suite / pre-commit hook run — left to CI per user instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)