### PR TITLE
Planner: project broad IN/UNION membership before COUNT

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7808,6 +7808,53 @@ those stages remain excluded rather than crashing during preparation. */
 									(join_optimizer_facts_without_aliases
 										(qb_facts physical_block) (list (source_alias candidate)))))))))))))
 
+(define candidate_stage_has_broad_text_filter? (lambda (stage)
+	(and (group_stage? stage)
+		(and (union_block? (gs_input stage))
+			(reduce (union_branches (gs_input stage)) (lambda (found branch)
+				(or found (and (query_block? branch)
+					(expr_contains_broad_text_match? (qb_where branch))))) false)))))
+
+(define physical_group_cache_candidate_source (lambda (stages sources)
+	(reduce (coalesceNil sources '()) (lambda (found src)
+		(if (not (nil? found))
+			found
+			(begin
+				(define stage (stage_for_group_cache_source stages src))
+				(if (and (group_stage? stage)
+					(and (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_candidate))
+						(candidate_stage_has_broad_text_filter? stage)))
+					src
+					nil)))) nil)))
+
+(define query_block_with_physical_group_cache_membership_using (lambda (stages block)
+	(begin
+		(define physical_block (query_block_with_physical_requirement_choices block))
+		(define sources (qb_sources physical_block))
+		(define candidate (physical_group_cache_candidate_source stages sources))
+		(if (or (not (membership_strategy? (qb_facts physical_block))) (nil? candidate))
+			physical_block
+			(begin
+				(define stage (stage_for_group_cache_source stages candidate))
+				(if (not (candidate_stage_recset_supported? stage))
+					physical_block
+					(begin
+						(define probe (car (qassoc_get (gs_facts stage) (quote lookup-keys) '())))
+						(make_query_block
+							(qb_schema physical_block)
+							(without_source_alias sources (source_alias candidate))
+							(qb_fields physical_block)
+							(combine_where (qb_where physical_block) (driver_membership_probe_expr stage probe))
+							(qb_group physical_block)
+							(qb_having physical_block)
+							(qb_order physical_block)
+							(qb_limit physical_block)
+							(qb_offset physical_block)
+							(qb_hidden physical_block)
+							(candidate_stage_without_source (qb_stages physical_block) (gs_id stage))
+							(join_optimizer_facts_without_aliases
+								(qb_facts physical_block) (list (source_alias candidate)))))))))))
+
 (define negated_term? (lambda (term)
 	(match term
 		((symbol not) _expr) true
@@ -15306,12 +15353,23 @@ get_column refs to the source) are excluded automatically too. */
 		(define tbl (group_stage_input_name stage))
 		(define alias (group_stage_input_alias stage))
 		(define query_input (or (query_block? src) (union_block? src)))
-		(define rewritten_src (if (query_block? src)
-			(query_block_with_presence_probes_using stage_lookup src)
+		/* Aggregate stages own their input query block. Apply the physical
+		membership choice here too; otherwise the top-level preparation pass never
+		reaches this nested block and eagerly materializes the candidate cache. */
+		(define membership_requirement (if (query_block? src)
+			(qassoc_get (qb_facts src) (quote membership_requirement) nil)
+			nil))
+		(define membership_src (if (and (query_block? src)
+			(and (not (nil? membership_requirement))
+				(qassoc_get membership_requirement (quote membership_candidate_estimate_capped) false)))
+			(query_block_with_physical_group_cache_membership_using stage_lookup src)
 			src))
-		(define rewrite_sources (if (query_block? src) (qb_sources src) '()))
+		(define rewritten_src (if (query_block? membership_src)
+			(query_block_with_presence_probes_using stage_lookup membership_src)
+			membership_src))
+		(define rewrite_sources (if (query_block? membership_src) (qb_sources membership_src) '()))
 		(define rewrite_default_alias (if (query_block? src)
-			(qassoc_get (qb_facts src) (quote default_alias) (if (empty_list? rewrite_sources) nil (source_alias (car rewrite_sources))))
+			(qassoc_get (qb_facts membership_src) (quote default_alias) (if (empty_list? rewrite_sources) nil (source_alias (car rewrite_sources))))
 			nil))
 		(define presence_probe_sources_for_rewrite (if (query_block? src)
 			(presence_probe_output_sources stage_lookup rewrite_sources rewrite_default_alias)

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -10,6 +10,7 @@ metadata:
   isolated: true
 
 setup:
+  - sql: "DROP TABLE IF EXISTS bqm_file"
   - sql: "DROP TABLE IF EXISTS bqm_unused_lookup"
   - sql: "DROP TABLE IF EXISTS bqm_standort_assignment"
   - sql: "DROP TABLE IF EXISTS bqm_mandant_assignment"
@@ -23,7 +24,14 @@ setup:
   - sql: |
       CREATE TABLE bqm_document (
         id INT PRIMARY KEY,
-        standort_id INT
+        standort_id INT,
+        file_id INT
+      )
+  - sql: |
+      CREATE TABLE bqm_file (
+        id INT PRIMARY KEY,
+        filename TEXT,
+        search TEXT
       )
   - sql: |
       CREATE TABLE bqm_mandant_assignment (
@@ -51,10 +59,16 @@ setup:
   - sql: "SET @bqm_actor = 7"
   - scm: |
       (begin
-        (insert (table "memcp-tests" "bqm_document") (list "id" "standort_id")
+        (insert (table "memcp-tests" "bqm_file") (list "id" "filename" "search")
+          (map (produceN 2500) (lambda (i)
+            (list (+ i 1)
+              (if (equal? (mod (+ i 1) 2) 0) "C-file" "other")
+              (if (equal? (mod (+ i 1) 3) 0) "C-search" "other")))))
+        (insert (table "memcp-tests" "bqm_document") (list "id" "standort_id" "file_id")
           (map (produceN 5000) (lambda (i)
-            (list (+ i 1) (+ (mod i 4) 1)))))
+            (list (+ i 1) (+ (mod i 4) 1) (+ (mod i 2500) 1)))))
         (rebuild (table "memcp-tests" "bqm_document") true false)
+        (rebuild (table "memcp-tests" "bqm_file") true false)
         (rebuild (table "memcp-tests" "bqm_standort") true false)
         (rebuild (table "memcp-tests" "bqm_unused_lookup") true false)
         (rebuild (table "memcp-tests" "bqm_mandant_assignment") true false)
@@ -215,7 +229,79 @@ test_cases:
       not_contains:
         - "recset_key_index"
 
+  - name: "broad membership cardinality prevents lossy COUNT partitioning"
+    sql: |
+      EXPLAIN REORDER SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
+      FROM (
+        SELECT d.id, d.standort_id, d.file_id, 1 AS _count
+        FROM bqm_document d
+        WHERE COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = @bqm_actor
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = @bqm_actor
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+      ) counted
+      LEFT JOIN bqm_standort sorter_standort
+        ON sorter_standort.id = counted.standort_id
+      WHERE counted.file_id IN (
+        SELECT f.id FROM bqm_file f WHERE f.filename LIKE '%C%'
+        UNION
+        SELECT f.id FROM bqm_file f WHERE f.search LIKE '%C%'
+      )
+    expect:
+      result_not_contains:
+        - "aggregate_pushdown"
+
+  - name: "broad IN UNION COUNT projects both branches before aggregation"
+    sql: |
+      EXPLAIN SELECT COUNT(*) AS total
+      FROM bqm_document d
+      WHERE d.file_id IN (
+        SELECT f.id FROM bqm_file f WHERE f.filename LIKE '%C%'
+        UNION
+        SELECT f.id FROM bqm_file f WHERE f.search LIKE '%C%'
+      )
+    expect:
+      result_contains:
+        - "recset_union"
+        - "recset_project_join"
+      result_not_contains:
+        - ".grp:union"
+      result_occurrences:
+        - text: "recset_project_join"
+          count: 2
+
+  - name: "broad IN UNION COUNT keeps projected membership semantics"
+    max_time: 3
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM bqm_document d
+      WHERE d.file_id IN (
+        SELECT f.id FROM bqm_file f WHERE f.filename LIKE '%C%'
+        UNION
+        SELECT f.id FROM bqm_file f WHERE f.search LIKE '%C%'
+      )
+    expect:
+      rows: 1
+      data:
+        - {total: 3334}
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS bqm_file"
   - sql: "DROP TABLE IF EXISTS bqm_unused_lookup"
   - sql: "DROP TABLE IF EXISTS bqm_standort_assignment"
   - sql: "DROP TABLE IF EXISTS bqm_mandant_assignment"


### PR DESCRIPTION
## Summary

- recognize capped broad-text membership inside aggregate-owned query blocks even after the candidate UNION has already become a physical group-cache source
- lower the UNION branches to RecSets, project them onto the driver row IDs, and union those RecSets before the aggregate scan
- retain the existing group-cache path for selective/non-text membership and preserve the ACL/presence-probe semantics
- add plan-shape, correctness, and 3-second regression coverage

## Root cause

The cardinality threshold/deoptimizer is intact: production telemetry records `membership_candidate_estimate_capped=true`. Its decision was not applied to this COUNT shape, however. The candidate source had already been physicalized as `.grp:union` inside a group-stage-owned nested query block, which the normal top-level membership preparation pass never visits.

The resulting plan materialized the candidate cache and then scanned roughly 855k `dokument` rows while point-probing that cache. For the non-selective search term `c`, candidate input telemetry was about 1.63m rows across both UNION branches, so this was the wrong side from which to drive the query.

This patch acts on the capped estimate at aggregate-stage lowering and restores the intended driver-side RecSet plan.

## Production-derived benchmark

Tested against a 1.5 GB copy of the affected dataset with the equivalent `COUNT(*)` membership query:

- previous live trace: 158.5 s for COUNT; the page request took 3.14 min
- patched cold run: 0.76 s
- patched warm run: 0.49 s
- patched repeated warm run: 0.05 s
- result cardinality: 7,491
- plan: 2 `scan_recset`, 2 `recset_project_join`, 1 `recset_union`, no `.grp:union`

This is below the promised 3-second response target for the isolated COUNT bottleneck.

## Tests

Targeted suites are green: 77/77 cases across:

- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`
- `tests/planner/subqueries/in-subquery.yaml`

`make test` was also run to completion. The current PR 535 base still reports its existing 13 unrelated suite failures (derived/scalar aggregate aliases, parser/string/date/null compatibility, and relational benchmark shapes); the touched planner suite passes in that full run.

## Dependency

This is intentionally stacked on the current experimental work from #535, while the merge target remains `master`. Rebase/update after #535 lands; until then the PR includes that prerequisite commit chain and is kept as draft.
