### PR TITLE
planner: calibrate physical membership costs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ulikunitz/xz v0.5.15
 	golang.org/x/text v0.21.0
 	golang.org/x/tools v0.42.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -861,6 +861,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query psql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query psql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query psql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (define query psql_select)) (explain_queryplan_physical_calibrate (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (define query psql_select)) (explain_queryplan_physical (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (define query psql_select)) '('resultrow '('list "code" (pretty_print (optimize (build_queryplan_term (sql_expand_views query policy))) (settings "ExplainWidth")))))
 		psql_insert_into

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6487,6 +6487,8 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(list (quote membership_candidate_estimate_input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
 					(list (quote membership_driver_rows) (qassoc_get facts (quote membership_driver_rows) nil))
 					(list (quote membership_selectivity_class) (qassoc_get facts (quote membership_selectivity_class) (quote unknown)))
+					(list (quote membership_driver_alternative) (qassoc_get facts (quote membership_driver_alternative) false))
+					(list (quote membership_order_limit_driver) (qassoc_get facts (quote membership_order_limit_driver) false))
 					(list (quote reuse) (qassoc_get facts (quote reuse) 1)))
 				(gs_facts stage)))))))
 
@@ -6516,13 +6518,18 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(begin
 			(define planned (apply_join_optimizer_plan node))
 			(define physical_planned (query_block_with_physical_requirement_choices planned))
+			(define physical_consumer (if (query_block_has_aggregates? physical_planned)
+				(quote aggregate)
+				(if (query_limit_active? (qb_offset physical_planned) (qb_limit physical_planned))
+					(quote order_limit)
+					(quote filter))))
+			(define local_driver_rows (if (equal? physical_consumer (quote order_limit))
+				(probe_limit_work_rows (qb_limit physical_planned)) nil))
 			(define physical_facts (merge (list
-				(list (list (quote membership_consumer)
-					(if (query_block_has_aggregates? physical_planned)
-						(quote aggregate)
-						(if (query_limit_active? (qb_offset physical_planned) (qb_limit physical_planned))
-							(quote order_limit)
-							(quote filter)))))
+				(list
+					(list (quote membership_consumer) physical_consumer)
+					(list (quote membership_driver_rows) (coalesceNil local_driver_rows
+						(qassoc_get (qb_facts physical_planned) (quote membership_driver_rows) nil))))
 				(qb_facts physical_planned))))
 			(make_query_block
 				(qb_schema physical_planned)
@@ -7426,25 +7433,28 @@ in the canonicalization functions above. */
 		false
 		(planner_cost_better?
 			(membership_projection_cost candidate_input_rows candidate_rows)
-			(membership_driver_probe_cost driver_rows)))))
+			(membership_driver_probe_cost candidate_input_rows candidate_rows driver_rows)))))
 
 (define membership_projection_cost (lambda (candidate_input_rows candidate_rows)
 	(planner_cost planner_membership_startup_ns
 		(* candidate_input_rows planner_membership_candidate_scan_row_ns)
-		0 0 0 (* candidate_rows planner_membership_candidate_match_row_ns)
+		0 0 0 (* candidate_rows planner_membership_recset_build_row_ns)
 		(* candidate_rows 8) 0 candidate_rows 0.5)))
 
-(define membership_driver_probe_cost (lambda (driver_rows)
-	(planner_cost planner_membership_startup_ns 0
-		(* driver_rows planner_membership_driver_probe_row_ns)
-		0 0 0 0 0 driver_rows 0.5)))
+(define membership_driver_probe_cost (lambda (candidate_input_rows candidate_rows driver_rows)
+	(planner_cost planner_membership_startup_ns
+		(* candidate_input_rows planner_membership_candidate_scan_row_ns)
+		(* driver_rows planner_membership_group_cache_probe_row_ns)
+		0 0 (* candidate_rows planner_membership_group_cache_build_row_ns)
+		(* candidate_rows 8) 0 (+ candidate_rows driver_rows) 0.5)))
 
 (define membership_cost_options (lambda (candidate_input_rows candidate_rows driver_rows)
 	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
 		'()
 		(list
 			(list (quote candidate_keyset) (membership_projection_cost candidate_input_rows candidate_rows))
-			(list (quote driver_order_membership_probe) (membership_driver_probe_cost driver_rows))))))
+			(list (quote driver_order_membership_probe)
+				(membership_driver_probe_cost candidate_input_rows candidate_rows driver_rows))))))
 
 (define membership_cost_options_for_telemetry (lambda (telemetry)
 	(begin
@@ -7509,28 +7519,49 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define candidate_estimate (planner_source_filter_estimate input
 					(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
 					512))
+				(define capped (if (nil? candidate_estimate) false
+					(qassoc_get candidate_estimate (quote capped) false)))
 				(define candidate_total_rows (planner_source_row_count input))
 				(define candidate_rows (membership_estimated_work_rows candidate_estimate candidate_total_rows))
 				(define driver (car base_sources))
 				(define driver_total_rows (planner_source_row_count driver))
 				(define driver_estimate (planner_source_filter_estimate driver
 					(membership_driver_filter (qb_where block)) 512))
-				(define driver_rows (membership_estimated_work_rows driver_estimate driver_total_rows))
+				(define local_driver_rows (if (and (query_limit_active? (qb_offset block) (qb_limit block))
+					(order_items_belong_to_source? driver (qb_order block)))
+					(probe_limit_work_rows (qb_limit block)) nil))
+				(define driver_rows (coalesceNil local_driver_rows
+					(membership_estimated_work_rows driver_estimate driver_total_rows)))
+				(define guarded_small_driver (and _guarded_alternative
+					(and (not (query_limit_active? (qb_offset block) (qb_limit block)))
+						(and (number? driver_rows) (<= driver_rows 512)))))
+				(define broad_text_driver (and _guarded_alternative
+					(membership_broad_driver_probe_preferred? block stage)))
 				(define broad_driver (if _guarded_alternative
-					(membership_broad_driver_probe_preferred? block stage)
+					(or guarded_small_driver
+						(or broad_text_driver
+							(and (query_limit_active? (qb_offset block) (qb_limit block))
+								(and (order_items_belong_to_source? driver (qb_order block))
+									(or capped
+										(and (and (number? candidate_total_rows) (> candidate_total_rows 512))
+											(and (number? candidate_rows)
+												(and (number? candidate_total_rows)
+													(>= (* candidate_rows 4) candidate_total_rows)))))))))
 					false))
-				(define normal_projection (if broad_driver
-					true
-					(membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows)))
-				(define decision_id (concat "membership_carrier:" (gs_id stage)))
-				(define projected_choice (if broad_driver
+				/* The rewrite target depends on the surrounding shape: below a
+				broad ordered OR it is the lazy driver marker used to build one
+				source-key index; otherwise it is the projected candidate RecSet. */
+				(define projected_choice (if broad_text_driver
 					"driver_order_membership_probe"
 					"candidate_keyset"))
+				(define decision_id (concat "membership_carrier:" (gs_id stage)))
 				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
-				(define normal_choice (if normal_projection projected_choice
-					(if (equal? projected_choice "candidate_keyset")
-						"driver_order_membership_probe"
-						"candidate_keyset")))
+				(define normal_choice (if broad_driver
+					"driver_order_membership_probe"
+					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows)
+						"candidate_keyset"
+						"driver_order_membership_probe")))
+				(define normal_projection (equal? normal_choice projected_choice))
 				(define chosen_choice (planner_physical_choice decision_id normal_choice alternatives))
 				(define chosen_projection (equal? chosen_choice projected_choice))
 				(define forced_choice (planner_physical_override decision_id))
@@ -7538,10 +7569,8 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 					(membership_projection_cost candidate_total_rows candidate_rows)
 					nil))
 				(define driver_cost (if (number? driver_rows)
-					(membership_driver_probe_cost driver_rows)
+					(membership_driver_probe_cost candidate_total_rows candidate_rows driver_rows)
 					nil))
-				(define capped (if (nil? candidate_estimate) false
-					(qassoc_get candidate_estimate (quote capped) false)))
 				(planner_record_physical_decision
 					(list
 						(list "decision_id" decision_id)
@@ -7549,10 +7578,12 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 						(list "stage" (gs_id stage))
 						(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
 						(list "chosen" chosen_choice)
-						(list "selection" (if (nil? forced_choice) "cost" "forced"))
+						(list "selection" (if (nil? forced_choice) (if broad_driver "constraint" "cost") "forced"))
 						(list "normally_chosen" normal_choice)
 						(list "reason" (if (not (nil? forced_choice)) "calibration_override"
-							(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))
+							(if guarded_small_driver "guarded_small_local_driver"
+								(if broad_driver "guarded_broad_order_limit_driver"
+									(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))))
 						(list "inputs" (list
 							(list "candidate_input_rows" candidate_total_rows)
 							(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
@@ -7597,7 +7628,13 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define stage (membership_truth_stage (qb_stages block) (qb_sources block) (nth parts 1)))
 				(if (and (not (nil? stage))
 					(membership_truth_projection_preferred? block stage guarded_alternative))
-					(list (driver_membership_probe_expr stage (nth parts 0)) (list (nth parts 1)))
+					(begin
+						(define guarded_stage (if (and guarded_alternative
+							(membership_broad_driver_probe_preferred? block stage))
+							(group_stage_with_facts stage
+								(qassoc_set (gs_facts stage) (quote guarded_broad_order_driver) true))
+							stage))
+						(list (driver_membership_probe_expr guarded_stage (nth parts 0)) (list (nth parts 1))))
 					(list (expand_in_membership_truth_expr (nth parts 0) (nth parts 1) (nth parts 2)) '())))
 			(if (and (list? expr)
 				(or
@@ -7809,7 +7846,7 @@ those stages remain excluded rather than crashing during preparation. */
 				(and supported (candidate_recset_branch_supported? branch)))
 				true)))))
 
-(define broad_driver_order_membership_probe? (lambda (facts)
+(define membership_estimate_broad? (lambda (facts)
 	(begin
 		(define estimated_rows (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
 		(define estimate_input (qassoc_get facts (quote membership_candidate_estimate_input) nil))
@@ -7817,13 +7854,16 @@ those stages remain excluded rather than crashing during preparation. */
 		(define broad_by_count (and
 			(and (not (nil? estimated_rows)) (and (not (nil? estimate_input)) (> estimate_input 0)))
 			(>= (* estimated_rows 4) estimate_input)))
-		(and
-			(driver_order_membership_strategy? facts)
+		(or
+			capped
 			(or
-				capped
-				(or
-					broad_by_count
-					(equal? (qassoc_get facts (quote membership_selectivity_class) nil) (quote broad))))))))
+				broad_by_count
+				(equal? (qassoc_get facts (quote membership_selectivity_class) nil) (quote broad)))))))
+
+(define broad_driver_order_membership_probe? (lambda (facts)
+	(and
+		(driver_order_membership_strategy? facts)
+		(membership_estimate_broad? facts))))
 
 (define broad_nested_driver_membership_probe? (lambda (facts)
 	(and
@@ -11821,7 +11861,7 @@ the auto-index chooses the concrete access path on both tables. */
 the marker in the filter, whose ordinary lowering emits the driver-side
 scan_exists/keytable path. Returning the expression emits the RecSet carrier.
 That makes the recorded and forced choice identical to the executable plan. */
-(define recset_project_join_expr_for_membership_using (lambda (src membership consumer ordered_filter)
+(define recset_project_join_expr_for_membership_using (lambda (src membership consumer ordered_filter driver_rows_override)
 	(begin
 		(define stage (nth membership 0))
 		(define facts (gs_facts stage))
@@ -11843,22 +11883,36 @@ That makes the recorded and forced choice identical to the executable plan. */
 				(define candidate_rows (if capped
 					(coalesceNil (qassoc_get facts (quote membership_candidate_estimate_input) nil) candidate_input_rows)
 					candidate_matching_rows))
-				(define driver_rows (coalesceNil
-					(qassoc_get facts (quote membership_driver_rows) nil)
-					(planner_source_row_count src)))
+				/* Ordered LIMIT consumes only its local window before downstream
+				operators. Cost this edge with that workload instead of a global
+				driver cardinality; it is the relevant side of the plan inequality. */
+				(define driver_rows (coalesceNil driver_rows_override
+					(coalesceNil
+						(qassoc_get facts (quote membership_driver_rows) nil)
+						(planner_source_row_count src))))
 				(define decision_id (concat "membership_carrier:" (gs_id stage)))
 				(define known (and (number? candidate_rows) (number? driver_rows)))
 				(define owns_requirement (qassoc_get facts (quote physical_membership_requirement) false))
-				(define normal_choice (if owns_requirement
-					(if (and known (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows))
-						"candidate_keyset"
-						"driver_order_membership_probe")
-					"candidate_keyset"))
+				/* A membership below OR cannot become the scan driver without
+				dropping sibling-accepted rows. For a broad ordered window retain
+				the lazy probe carrier; the ordinary cost inequality owns every
+				feasible carrier pair outside this semantic/Top-K constraint. */
+				(define guarded_broad_order_driver
+					(qassoc_get facts (quote guarded_broad_order_driver) false))
+				(define normal_choice (if guarded_broad_order_driver
+					"driver_order_membership_probe"
+					(if known
+						(if (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows)
+							"candidate_keyset"
+							"driver_order_membership_probe")
+						(if owns_requirement "driver_order_membership_probe" "candidate_keyset"))))
 				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
 				(define candidate_cost (if known (membership_projection_cost candidate_input_rows candidate_rows) nil))
-				(define driver_cost (if known (membership_driver_probe_cost driver_rows) nil))
+				(define driver_cost (if known
+					(membership_driver_probe_cost candidate_input_rows candidate_rows driver_rows)
+					nil))
 				(planner_record_physical_decision
 					(list
 						(list "decision_id" decision_id)
@@ -11867,13 +11921,13 @@ That makes the recorded and forced choice identical to the executable plan. */
 						(list "consumer" (string (coalesceNil consumer
 							(qassoc_get facts (quote membership_consumer) (quote filter)))))
 						(list "chosen" chosen)
-						(list "selection" (if (nil? forced) (if owns_requirement (if known "cost" "fallback") "upstream") "forced"))
+						(list "selection" (if (nil? forced) (if known "cost" "fallback") "forced"))
 						(list "normally_chosen" normal_choice)
 						(list "reason" (if (not (nil? forced)) "calibration_override"
-							(if owns_requirement
+							(if guarded_broad_order_driver "guarded_broad_order_limit_driver"
 								(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
-									"unknown_statistics_driver_fallback")
-								"upstream_projection_choice")))
+									(if owns_requirement "unknown_statistics_driver_fallback"
+										"unknown_statistics_projection_fallback")))))
 						(list "inputs" (list
 							(list "candidate_input_rows" candidate_input_rows)
 							(list "candidate_matching_rows" candidate_matching_rows)
@@ -11917,7 +11971,7 @@ That makes the recorded and forced choice identical to the executable plan. */
 				(if (equal? chosen "candidate_keyset") raw_expr nil))))))
 
 (define recset_project_join_expr_for_membership (lambda (src membership)
-	(recset_project_join_expr_for_membership_using src membership nil false)))
+	(recset_project_join_expr_for_membership_using src membership nil false nil)))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -14387,10 +14441,11 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
 
-(define planner_membership_startup_ns 1)
-(define planner_membership_candidate_scan_row_ns 1)
-(define planner_membership_candidate_match_row_ns 33217)
-(define planner_membership_driver_probe_row_ns 138828)
+(define planner_membership_startup_ns 0)
+(define planner_membership_candidate_scan_row_ns 2258)
+(define planner_membership_recset_build_row_ns 1)
+(define planner_membership_group_cache_build_row_ns 88430)
+(define planner_membership_group_cache_probe_row_ns 150302)
 /* END GENERATED COST CONSTANTS */
 
 (define planner_direct_presence_probe_preferred? (lambda (probe_rows input_rows)
@@ -16746,12 +16801,16 @@ scan boundary only when the complete predicate implies it. */
 						(replace_driver_membership_markers src item memberships))))
 					_ expr))))))
 
-(define membership_recset_bindings (lambda (src memberships)
+(define membership_recset_bindings_using (lambda (src memberships consumer ordered_filter driver_rows_override)
 	(filter (map memberships (lambda (membership)
 		(begin
-			(define expr (recset_project_join_expr_for_membership src membership))
+			(define expr (recset_project_join_expr_for_membership_using
+				src membership consumer ordered_filter driver_rows_override))
 			(if (nil? expr) nil (list membership (membership_recset_var src membership) expr)))))
 		(lambda (binding) (not (nil? binding))))))
+
+(define membership_recset_bindings (lambda (src memberships)
+	(membership_recset_bindings_using src memberships nil false nil)))
 
 (define wrap_membership_recset_bindings (lambda (bindings body)
 	(if (empty_list? bindings)
@@ -16978,9 +17037,22 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 					'()))
 				(define use_membership_keysets (and keyset_membership_probe
 					(equal? (count membership_keysets) (count memberships))))
-				(define membership_bindings (if keyset_membership_probe
+				(define forced_candidate_membership (reduce memberships (lambda (forced membership)
+					(or forced (equal?
+						(planner_physical_override (concat "membership_carrier:" (gs_id (nth membership 0))))
+						"candidate_keyset"))) false))
+				(define prefer_membership_filter (and scan_order_supported
+					(and bounded
+						(and (not forced_candidate_membership)
+							(and (qassoc_get (qb_facts block) (quote membership_driver_alternative) false)
+								(membership_estimate_broad? (qb_facts block)))))))
+				(define membership_bindings (if (or keyset_membership_probe prefer_membership_filter)
 					'()
-					(membership_recset_bindings src memberships)))
+					(membership_recset_bindings_using src memberships
+						(if bounded (quote order_limit) (quote filter))
+						(and scan_order_supported bounded)
+						(if (and scan_order_supported bounded)
+							(probe_limit_work_rows (qb_limit block)) nil))))
 				(define bound_memberships (map membership_bindings (lambda (binding) (nth binding 0))))
 				/* A membership predicate which is implied by the whole WHERE clause is
 				eligible to become the scan driver. A branch-local predicate below OR is
@@ -16988,8 +17060,6 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 				would disappear. This distinction also preserves the established fast
 				single-IN path while allowing several guarded RecSets in one scan. */
 				(define direct_membership (driver_membership_for_source src condition))
-				(define prefer_membership_filter (and scan_order_supported
-					(and bounded (broad_driver_order_membership_probe? (qb_facts block)))))
 				(define membership_driver (and
 					(not (nil? direct_membership))
 					(and (not prefer_membership_filter)
@@ -17255,7 +17325,9 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 			(recset_project_join_expr_for_membership_using src membership
 				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
 				(and (not (empty_list? driver_order_items))
-					(query_limit_active? offset_value limit_value)))))
+					(query_limit_active? offset_value limit_value))
+				(if (query_limit_active? offset_value limit_value)
+					(probe_limit_work_rows limit_value) nil))))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
 		/* A broad membership set cannot narrow an ordered driver. Keep the base

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -141,14 +141,40 @@ compared without reverse-engineering the generated Scheme plan. */
 		(if (nil? accumulator)
 			decision
 			(begin
-				(define count (coalesceNil (accumulator "count") 0))
-				(accumulator (concat "decision:" count) decision)
-				(accumulator "count" (+ count 1))
+				(define decision_id (qassoc_get decision "decision_id" nil))
+				(define seen_key (if (nil? decision_id) nil (concat "seen:" decision_id)))
+				(if (and (not (nil? seen_key)) (accumulator seen_key))
+					nil
+					(begin
+						(define count (coalesceNil (accumulator "count") 0))
+						(accumulator (concat "decision:" count) decision)
+						(accumulator "count" (+ count 1))
+						(if (nil? seen_key) nil (accumulator seen_key true))))
 				decision)))))
 
 (define planner_physical_explain_decisions (lambda (accumulator)
 	(map (produceN (coalesceNil (accumulator "count") 0)) (lambda (idx)
 		(accumulator (concat "decision:" idx))))))
+
+/* CALIBRATE compiles the same logical query repeatedly with one explicitly
+forced physical alternative. Overrides are compile-local and keyed by the
+stable logical stage identity, so nested decisions cannot accidentally consume
+an override intended for a sibling edge. */
+(define planner_physical_override (lambda (decision_id)
+	(begin
+		(define overrides (try
+			(lambda () ((context "session") "__memcp_physical_overrides"))
+			(lambda (_e) nil)))
+		(if (nil? overrides) nil (qassoc_get overrides decision_id nil)))))
+
+(define planner_physical_choice (lambda (decision_id normal_choice alternatives)
+	(begin
+		(define forced (planner_physical_override decision_id))
+		(if (nil? forced)
+			normal_choice
+			(if (contains? alternatives forced)
+				forced
+				(error (concat "Unknown physical alternative `" forced "` for " decision_id)))))))
 
 (define planner_cost_explain (lambda (cost)
 	(list
@@ -1791,26 +1817,26 @@ column type instead of borrowing a sibling dependency's shape. */
 			true
 			(match expr
 				(cons head tail)
-					(if (or (equal? head (quote and))
-						(or (equal? head (symbol "and"))
-							(or (equal? head (quote or)) (equal? head (symbol "or")))))
-						(reduce tail (lambda (shaped item)
-							(and shaped (boolean_typed_expr_shaped? graph stage item)))
-							true)
-						(if (or (equal? head (quote not))
-							(or (equal? head (symbol "not"))
-								(or (equal? head (quote sql_not)) (equal? head (symbol "sql_not")))))
-							(and (equal? (count tail) 1)
-								(boolean_typed_expr_shaped? graph stage (car tail)))
-							(if (or (equal? head (quote if)) (equal? head (symbol "if")))
-								(boolean_case_results_shaped? graph stage tail)
-								(if (or (equal? head (quote coalesceNil)) (equal? head (symbol "coalesceNil")))
-									(and (equal? (count tail) 2)
-										(and (or (equal?? (nth tail 1) false) (equal?? (nth tail 1) true))
-											(boolean_typed_expr_shaped? graph stage (car tail))))
-									(if (boolean_expr_comparison_head? head)
-										true
-										(boolean_stage_dependency_leaf? graph stage expr))))))
+				(if (or (equal? head (quote and))
+					(or (equal? head (symbol "and"))
+						(or (equal? head (quote or)) (equal? head (symbol "or")))))
+					(reduce tail (lambda (shaped item)
+						(and shaped (boolean_typed_expr_shaped? graph stage item)))
+						true)
+					(if (or (equal? head (quote not))
+						(or (equal? head (symbol "not"))
+							(or (equal? head (quote sql_not)) (equal? head (symbol "sql_not")))))
+						(and (equal? (count tail) 1)
+							(boolean_typed_expr_shaped? graph stage (car tail)))
+						(if (or (equal? head (quote if)) (equal? head (symbol "if")))
+							(boolean_case_results_shaped? graph stage tail)
+							(if (or (equal? head (quote coalesceNil)) (equal? head (symbol "coalesceNil")))
+								(and (equal? (count tail) 2)
+									(and (or (equal?? (nth tail 1) false) (equal?? (nth tail 1) true))
+										(boolean_typed_expr_shaped? graph stage (car tail))))
+								(if (boolean_expr_comparison_head? head)
+									true
+									(boolean_stage_dependency_leaf? graph stage expr))))))
 				_ false)))))
 
 /* Whether stage's own realized value is boolean-shaped, considering both the
@@ -1833,7 +1859,7 @@ validate the stage as a whole rather than a particular output column. */
 			(and (not (nil? ag))
 				(begin
 					(define value_expr (car (scalar_first_probe_parts ag)))
-				(boolean_typed_expr_shaped? graph stage value_expr)))))))
+					(boolean_typed_expr_shaped? graph stage value_expr)))))))
 
 (define driver_membership_boolean_passthrough? (lambda (graph stage expr)
 	(if (presence_bool_stage_output_expr? expr)
@@ -6444,39 +6470,74 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(neumann_fail "build_queryplan" "logical join plan does not cover the query-block sources exactly once"))
 				block)))))
 
-(define physicalize_membership_requirement_expr (lambda (expr)
+(define physical_membership_requirement_stage (lambda (stage facts)
+	(if (not (group_stage? stage))
+		stage
+		(make_group_stage
+			(gs_id stage) (gs_input stage) (gs_domain stage) (gs_keys stage)
+			(gs_aggregates stage) (gs_having stage) (gs_output stage) (gs_order stage)
+			(gs_limit stage) (gs_offset stage)
+			(merge (list
+				(list
+					(list (quote physical_membership_requirement) true)
+					(list (quote membership_consumer) (qassoc_get facts (quote membership_consumer) (quote filter)))
+					(list (quote membership_candidate_input_rows) (qassoc_get facts (quote membership_candidate_input_rows) nil))
+					(list (quote membership_candidate_estimated_rows) (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
+					(list (quote membership_candidate_estimate_capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
+					(list (quote membership_candidate_estimate_input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
+					(list (quote membership_driver_rows) (qassoc_get facts (quote membership_driver_rows) nil))
+					(list (quote membership_selectivity_class) (qassoc_get facts (quote membership_selectivity_class) (quote unknown)))
+					(list (quote reuse) (qassoc_get facts (quote reuse) 1)))
+				(gs_facts stage)))))))
+
+(define physicalize_membership_requirement_expr_using (lambda (expr facts)
 	(match expr
 		((symbol membership_requirement_probe) stage probe)
-		(list (quote driver_membership_probe) stage probe)
+		(list (quote driver_membership_probe)
+			(physical_membership_requirement_stage stage facts) probe)
 		((quote membership_requirement_probe) stage probe)
-		(list (quote driver_membership_probe) stage probe)
+		(list (quote driver_membership_probe)
+			(physical_membership_requirement_stage stage facts) probe)
 		(cons head tail) (cons
-			(physicalize_membership_requirement_expr head)
-			(map tail physicalize_membership_requirement_expr))
+			(physicalize_membership_requirement_expr_using head facts)
+			(map tail (lambda (item)
+				(physicalize_membership_requirement_expr_using item facts))))
 		_ expr)))
 
-(define physicalize_membership_requirement_source (lambda (src)
+(define physicalize_membership_requirement_expr (lambda (expr)
+	(physicalize_membership_requirement_expr_using expr '())))
+
+(define physicalize_membership_requirement_source_using (lambda (src facts)
 	(source_with_join_expr src
-		(physicalize_membership_requirement_expr (source_join_expr src)))))
+		(physicalize_membership_requirement_expr_using (source_join_expr src) facts))))
 
 (define apply_join_optimizer_plan_node (lambda (node)
 	(if (query_block? node)
 		(begin
 			(define planned (apply_join_optimizer_plan node))
 			(define physical_planned (query_block_with_physical_requirement_choices planned))
+			(define physical_facts (merge (list
+				(list (list (quote membership_consumer)
+					(if (query_block_has_aggregates? physical_planned)
+						(quote aggregate)
+						(if (query_limit_active? (qb_offset physical_planned) (qb_limit physical_planned))
+							(quote order_limit)
+							(quote filter)))))
+				(qb_facts physical_planned))))
 			(make_query_block
 				(qb_schema physical_planned)
-				(map (qb_sources physical_planned) physicalize_membership_requirement_source)
-				(physicalize_membership_requirement_expr (qb_fields physical_planned))
-				(physicalize_membership_requirement_expr (qb_where physical_planned))
-				(physicalize_membership_requirement_expr (qb_group physical_planned))
-				(physicalize_membership_requirement_expr (qb_having physical_planned))
-				(physicalize_membership_requirement_expr (qb_order physical_planned))
+				(map (qb_sources physical_planned) (lambda (src)
+					(physicalize_membership_requirement_source_using src physical_facts)))
+				(physicalize_membership_requirement_expr_using (qb_fields physical_planned) physical_facts)
+				(physicalize_membership_requirement_expr_using (qb_where physical_planned) physical_facts)
+				(physicalize_membership_requirement_expr_using (qb_group physical_planned) physical_facts)
+				(physicalize_membership_requirement_expr_using (qb_having physical_planned) physical_facts)
+				(physicalize_membership_requirement_expr_using (qb_order physical_planned) physical_facts)
 				(qb_limit physical_planned)
 				(qb_offset physical_planned)
-				(physicalize_membership_requirement_expr (qb_hidden physical_planned))
+				(physicalize_membership_requirement_expr_using (qb_hidden physical_planned) physical_facts)
 				(map (qb_stages physical_planned) apply_join_optimizer_plan_stage)
-				(physicalize_membership_requirement_expr (qb_facts physical_planned))))
+				(physicalize_membership_requirement_expr_using physical_facts physical_facts)))
 		(if (union_block? node)
 			(make_union_block
 				(union_mode node)
@@ -7360,27 +7421,29 @@ in the canonicalization functions above. */
 			(not (expr_contains_membership_truth? term))))
 		true)))
 
-(define membership_projection_cost_preferred? (lambda (candidate_rows driver_rows)
-	(if (or (nil? candidate_rows) (nil? driver_rows))
+(define membership_projection_cost_preferred? (lambda (candidate_input_rows candidate_rows driver_rows)
+	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
 		false
 		(planner_cost_better?
-			(membership_projection_cost candidate_rows)
+			(membership_projection_cost candidate_input_rows candidate_rows)
 			(membership_driver_probe_cost driver_rows)))))
 
-(define membership_projection_cost (lambda (candidate_rows)
-	/* Preserve the measured crossover of the prior 16+4*n model while making
-	each component explicit in nanoseconds. */
-	(planner_cost 864 (* candidate_rows 54) 0 0 0 (* candidate_rows 162)
+(define membership_projection_cost (lambda (candidate_input_rows candidate_rows)
+	(planner_cost planner_membership_startup_ns
+		(* candidate_input_rows planner_membership_candidate_scan_row_ns)
+		0 0 0 (* candidate_rows planner_membership_candidate_match_row_ns)
 		(* candidate_rows 8) 0 candidate_rows 0.5)))
 
 (define membership_driver_probe_cost (lambda (driver_rows)
-	(planner_cost 0 0 (* driver_rows 54) 0 0 0 0 0 driver_rows 0.5)))
+	(planner_cost planner_membership_startup_ns 0
+		(* driver_rows planner_membership_driver_probe_row_ns)
+		0 0 0 0 0 driver_rows 0.5)))
 
-(define membership_cost_options (lambda (candidate_rows driver_rows)
-	(if (or (nil? candidate_rows) (nil? driver_rows))
+(define membership_cost_options (lambda (candidate_input_rows candidate_rows driver_rows)
+	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
 		'()
 		(list
-			(list (quote candidate_keyset) (membership_projection_cost candidate_rows))
+			(list (quote candidate_keyset) (membership_projection_cost candidate_input_rows candidate_rows))
 			(list (quote driver_order_membership_probe) (membership_driver_probe_cost driver_rows))))))
 
 (define membership_cost_options_for_telemetry (lambda (telemetry)
@@ -7388,54 +7451,10 @@ in the canonicalization functions above. */
 		(define candidate_rows (if (qassoc_get telemetry (quote membership_candidate_estimate_capped) false)
 			(qassoc_get telemetry (quote membership_candidate_estimate_input) nil)
 			(qassoc_get telemetry (quote membership_candidate_estimated_rows) nil)))
-		(membership_cost_options candidate_rows
+		(membership_cost_options
+			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)
+			candidate_rows
 			(qassoc_get telemetry (quote membership_driver_rows) nil)))))
-
-(define record_membership_physical_choice (lambda (requirement strategy reason candidates)
-	(begin
-		(planner_record_physical_decision
-			(list
-				(list "decision" "membership_carrier")
-				(list "chosen" (string strategy))
-				(list "reason" (string reason))
-				(list "inputs" (list
-					(list "candidate_rows"
-						(if (qassoc_get requirement (quote membership_candidate_estimate_capped) false)
-							(qassoc_get requirement (quote membership_candidate_estimate_input) nil)
-							(qassoc_get requirement (quote membership_candidate_estimated_rows) nil)))
-					(list "candidate_input_rows" (qassoc_get requirement (quote membership_candidate_input_rows) nil))
-					(list "driver_rows" (qassoc_get requirement (quote membership_driver_rows) nil))
-					(list "selectivity_class" (string (qassoc_get requirement (quote membership_selectivity_class) nil)))
-					(list "estimate_capped" (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
-					(list "reuse" (qassoc_get requirement (quote reuse) 1))))
-				(list "alternatives" (map candidates (lambda (candidate)
-					(list
-						(list "plan" (string (car candidate)))
-						(list "status" (if (equal? (car candidate) strategy) "chosen" "rejected"))
-						(list "reason" (if (equal? (car candidate) strategy) "lowest_total_ns" "higher_total_ns_or_memory_tiebreak"))
-						(list "cost" (planner_cost_explain (cadr candidate)))))))))
-		(if (qassoc_get requirement (quote membership_order_limit_driver) false)
-			(begin
-				(define recset_source (equal? strategy (quote candidate_keyset)))
-				(planner_record_physical_decision
-					(list
-						(list "decision" "ordered_recset_iterator")
-						(list "chosen" (if recset_source "scan_order_recset_part" "recset_contains_probe"))
-						(list "reason" (if recset_source "projected_recset_scan_source" "base_table_scan_with_membership_filter"))
-						(list "inputs" (list
-							(list "limit" (qassoc_get requirement (quote membership_order_limit) nil))
-							(list "candidate_rows" (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
-							(list "driver_rows" (qassoc_get requirement (quote membership_driver_rows) nil))))
-						(list "alternatives" (list
-							(list
-								(list "plan" "scan_order_recset_part")
-								(list "status" (if recset_source "chosen" "rejected"))
-								(list "reason" (if recset_source "projected_recset_scan_source" "source_is_base_table")))
-							(list
-								(list "plan" "recset_contains_probe")
-								(list "status" (if recset_source "rejected" "chosen"))
-								(list "reason" (if recset_source "direct_intersection_available" "membership_is_filter"))))))))
-			nil))))
 
 /* The reorder phase carries only an abstract membership requirement. Concrete
 keyset/probe names enter the IR here, at the physical preparation boundary. */
@@ -7450,7 +7469,6 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define reason (if (equal? strategy (quote candidate_keyset))
 					(quote projected_membership_cost)
 					(quote indexed_driver_probe_cost)))
-				(record_membership_physical_choice requirement strategy reason candidates)
 				(define physical_facts (merge (list
 					(list
 						(list (quote membership_plan_strategy) strategy)
@@ -7483,25 +7501,79 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 		for the driver probe because each branch lowers independently against the
 		current lookup key; this does not project or materialize the UNION. */
 		(define base_sources (filter (qb_sources block) source_is_base_table?))
-		(if (if _guarded_alternative (membership_broad_driver_probe_preferred? block stage) false)
-			true
-			(if (or (not (source_is_base_table? input)) (not (single_source? base_sources)))
-				false
-				(begin
-					(define candidate_estimate (planner_source_filter_estimate input
-						(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
-						512))
-					(define candidate_rows (membership_estimated_work_rows candidate_estimate
-						(planner_source_row_count input)))
-					(define driver (reduce (qb_sources block) (lambda (found src)
-						(if (not (nil? found)) found (if (source_is_base_table? src) src nil))) nil))
-					(define driver_total_rows (if (nil? driver) nil (planner_source_row_count driver)))
-					(define driver_estimate (if (nil? driver)
-						nil
-						(planner_source_filter_estimate driver
-							(membership_driver_filter (qb_where block)) 512)))
-					(define driver_rows (membership_estimated_work_rows driver_estimate driver_total_rows))
-					(membership_projection_cost_preferred? candidate_rows driver_rows)))))))
+		(if (or
+			(or (not (source_is_base_table? input)) (not (single_source? base_sources)))
+			(not (empty_list? (group_stage_session_domain_keys stage))))
+			false
+			(begin
+				(define candidate_estimate (planner_source_filter_estimate input
+					(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+					512))
+				(define candidate_total_rows (planner_source_row_count input))
+				(define candidate_rows (membership_estimated_work_rows candidate_estimate candidate_total_rows))
+				(define driver (car base_sources))
+				(define driver_total_rows (planner_source_row_count driver))
+				(define driver_estimate (planner_source_filter_estimate driver
+					(membership_driver_filter (qb_where block)) 512))
+				(define driver_rows (membership_estimated_work_rows driver_estimate driver_total_rows))
+				(define broad_driver (if _guarded_alternative
+					(membership_broad_driver_probe_preferred? block stage)
+					false))
+				(define normal_projection (if broad_driver
+					true
+					(membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows)))
+				(define decision_id (concat "membership_carrier:" (gs_id stage)))
+				(define projected_choice (if broad_driver
+					"driver_order_membership_probe"
+					"candidate_keyset"))
+				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
+				(define normal_choice (if normal_projection projected_choice
+					(if (equal? projected_choice "candidate_keyset")
+						"driver_order_membership_probe"
+						"candidate_keyset")))
+				(define chosen_choice (planner_physical_choice decision_id normal_choice alternatives))
+				(define chosen_projection (equal? chosen_choice projected_choice))
+				(define forced_choice (planner_physical_override decision_id))
+				(define candidate_cost (if (number? candidate_rows)
+					(membership_projection_cost candidate_total_rows candidate_rows)
+					nil))
+				(define driver_cost (if (number? driver_rows)
+					(membership_driver_probe_cost driver_rows)
+					nil))
+				(define capped (if (nil? candidate_estimate) false
+					(qassoc_get candidate_estimate (quote capped) false)))
+				(planner_record_physical_decision
+					(list
+						(list "decision_id" decision_id)
+						(list "decision" "membership_carrier")
+						(list "stage" (gs_id stage))
+						(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
+						(list "chosen" chosen_choice)
+						(list "selection" (if (nil? forced_choice) "cost" "forced"))
+						(list "normally_chosen" normal_choice)
+						(list "reason" (if (not (nil? forced_choice)) "calibration_override"
+							(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))
+						(list "inputs" (list
+							(list "candidate_input_rows" candidate_total_rows)
+							(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
+							(list "candidate_rows" candidate_rows)
+							(list "driver_input_rows" driver_total_rows)
+							(list "driver_rows" driver_rows)
+							(list "estimate_capped" capped)
+							(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get (gs_facts stage) (quote selectivity_class) (quote unknown)))))
+							(list "reuse" (qassoc_get (gs_facts stage) (quote reuse) 1))))
+						(list "alternatives" (list
+							(list
+								(list "plan" "candidate_keyset")
+								(list "status" (if (equal? chosen_choice "candidate_keyset") "chosen" "rejected"))
+								(list "reason" (if (equal? chosen_choice "candidate_keyset") "selected" "higher_total_ns_or_forced_alternative"))
+								(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
+							(list
+								(list "plan" "driver_order_membership_probe")
+								(list "status" (if (equal? chosen_choice "driver_order_membership_probe") "chosen" "rejected"))
+								(list "reason" (if (equal? chosen_choice "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
+								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
+				chosen_projection)))))
 
 (define choose_membership_truth_items (lambda (block items guarded_alternative)
 	(match items
@@ -7902,8 +7974,8 @@ boolean probe, matched against the specific logical output alias. */
 					(begin
 						(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 						(and (not (nil? (first_driver_lookup_key
-								stage
-								(without_source_alias sources (source_alias src)))))
+							stage
+							(without_source_alias sources (source_alias src)))))
 							(condition_has_exists_recset_probe? (source_alias src) condition))))
 					src
 					nil)))
@@ -8649,13 +8721,13 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 						(cdr (split (gs_id stage) ":derived:"))
 						(qassoc_get (gs_facts stage) (quote btw2025_parent) nil))))
 					signature)
-			/* Alias-normalized interning is safe for base-table groups. Query-input
-			stages retain distinct correlation scopes until scope equivalence can
-			be proven independently of their canonical carrier name. */
-			(if (and (source_is_base_table? (gs_input stage))
-				(empty_list? (stage_semantic_outer_aliases stage)))
-				(stage_semantic_backbone_signature signature_index stage)
-				nil))))))
+				/* Alias-normalized interning is safe for base-table groups. Query-input
+				stages retain distinct correlation scopes until scope equivalence can
+				be proven independently of their canonical carrier name. */
+				(if (and (source_is_base_table? (gs_input stage))
+					(empty_list? (stage_semantic_outer_aliases stage)))
+					(stage_semantic_backbone_signature signature_index stage)
+					nil))))))
 
 (define normalize_stage_output_left_join_expr (lambda (alias expr)
 	(match expr
@@ -10379,8 +10451,8 @@ and RecSet carriers additionally verify its uniqueness below. */
 					(source_unique_key_sets src)
 					(if (empty_list? primary_key) '() (list primary_key)))))
 				(if (reduce unique_keys (lambda (found key_cols)
-						(or found (and (equal? (count key_cols) 1) (equal?? (car key_cols) col))))
-						false)
+					(or found (and (equal? (count key_cols) 1) (equal?? (car key_cols) col))))
+					false)
 					idx
 					nil))))))
 
@@ -10485,6 +10557,7 @@ membership set. */
 							(quote group_keytable))))
 					(planner_record_physical_decision
 						(list
+							(list "decision_id" (concat "scalar_presence_carrier:" (gs_id stage)))
 							(list "decision" "scalar_presence_carrier")
 							(list "stage" (gs_id stage))
 							(list "chosen" (string chosen))
@@ -10538,7 +10611,7 @@ membership set. */
 (define lower_recset_stage_prepare_once_expr (lambda (stage_catalog stage)
 	(list
 		(physical_query_session_symbol)
-			"get_or_compute_scoped"
+		"get_or_compute_scoped"
 		(physical_query_scope_symbol)
 		(stage_prepare_key stage)
 		(list (quote lambda) '()
@@ -10567,15 +10640,15 @@ membership set. */
 					(physical_query_scope_symbol)
 					lookup_key
 					(list (quote lambda) '()
-					(list (quote recset_key_index)
-						(list (quote session) "__memcp_tx")
-						(list (quote scan_recset)
+						(list (quote recset_key_index)
 							(list (quote session) "__memcp_tx")
-						(list (quote table) cache_schema cache_relation)
-						(quoted_runtime_list (list requested_col))
-						(list (quote lambda) (list (symbol requested_col))
-							(list (quote equal??) (symbol requested_col) true)))
-						(quoted_runtime_list (list "k0")))))
+							(list (quote scan_recset)
+								(list (quote session) "__memcp_tx")
+								(list (quote table) cache_schema cache_relation)
+								(quoted_runtime_list (list requested_col))
+								(list (quote lambda) (list (symbol requested_col))
+									(list (quote equal??) (symbol requested_col) true)))
+							(quoted_runtime_list (list "k0")))))
 				(list (quote list) resolved_lookup_key))))))
 
 /* Select one physical realization at the consumer which owns this probe.
@@ -10711,10 +10784,10 @@ choice table instead of adding another promotion path. */
 			(symbol recset) (begin
 				(define carrier_src (scalar_first_probe_carrier_source src))
 				(define key_index (scalar_first_probe_keytable_key_index stage carrier_src keys))
-			(lower_recset_scalar_first_probe_expr
-				probe_stages stage requested_col
-				(lower_column_expr_for_join sources default_alias
-					(nth lookup_keys key_index))))
+				(lower_recset_scalar_first_probe_expr
+					probe_stages stage requested_col
+					(lower_column_expr_for_join sources default_alias
+						(nth lookup_keys key_index))))
 			(symbol keytable) (begin
 				(define carrier_src (scalar_first_probe_carrier_source src))
 				(define key_index (scalar_first_probe_keytable_key_index stage carrier_src keys))
@@ -11724,7 +11797,7 @@ the auto-index chooses the concrete access path on both tables. */
 				(source_table_expr target_src)
 				(quoted_runtime_list (list target_col)))))))
 
-(define recset_project_join_expr_for_membership (lambda (src membership)
+(define recset_project_join_expr_for_membership_raw (lambda (src membership)
 	(begin
 		(define stage (nth membership 0))
 		(define target_col (nth membership 2))
@@ -11743,6 +11816,108 @@ the auto-index chooses the concrete access path on both tables. */
 				(if (recset_probe_stage_shape? stage)
 					(exists_recset_project_join_expr src stage)
 					nil))))))
+
+/* A membership requirement becomes physical only here. Returning nil keeps
+the marker in the filter, whose ordinary lowering emits the driver-side
+scan_exists/keytable path. Returning the expression emits the RecSet carrier.
+That makes the recorded and forced choice identical to the executable plan. */
+(define recset_project_join_expr_for_membership_using (lambda (src membership consumer ordered_filter)
+	(begin
+		(define stage (nth membership 0))
+		(define facts (gs_facts stage))
+		(define raw_expr (recset_project_join_expr_for_membership_raw src membership))
+		(if (or (nil? raw_expr)
+			(not (or
+				(equal? (qassoc_get facts (quote purpose) nil) (quote in_membership))
+				(equal? (qassoc_get facts (quote purpose) nil) (quote in_candidate)))))
+			raw_expr
+			(begin
+				(define capped (qassoc_get facts (quote membership_candidate_estimate_capped) false))
+				(define measured_estimate (planner_stage_filter_estimate (gs_input stage) 512))
+				(define candidate_input_rows (coalesceNil
+					(qassoc_get facts (quote membership_candidate_input_rows) nil)
+					(planner_stage_input_rows (gs_input stage))))
+				(define candidate_matching_rows (coalesceNil
+					(qassoc_get facts (quote membership_candidate_estimated_rows) nil)
+					(qassoc_get measured_estimate (quote rows) nil)))
+				(define candidate_rows (if capped
+					(coalesceNil (qassoc_get facts (quote membership_candidate_estimate_input) nil) candidate_input_rows)
+					candidate_matching_rows))
+				(define driver_rows (coalesceNil
+					(qassoc_get facts (quote membership_driver_rows) nil)
+					(planner_source_row_count src)))
+				(define decision_id (concat "membership_carrier:" (gs_id stage)))
+				(define known (and (number? candidate_rows) (number? driver_rows)))
+				(define owns_requirement (qassoc_get facts (quote physical_membership_requirement) false))
+				(define normal_choice (if owns_requirement
+					(if (and known (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows))
+						"candidate_keyset"
+						"driver_order_membership_probe")
+					"candidate_keyset"))
+				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
+				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
+				(define forced (planner_physical_override decision_id))
+				(define candidate_cost (if known (membership_projection_cost candidate_input_rows candidate_rows) nil))
+				(define driver_cost (if known (membership_driver_probe_cost driver_rows) nil))
+				(planner_record_physical_decision
+					(list
+						(list "decision_id" decision_id)
+						(list "decision" "membership_carrier")
+						(list "stage" (gs_id stage))
+						(list "consumer" (string (coalesceNil consumer
+							(qassoc_get facts (quote membership_consumer) (quote filter)))))
+						(list "chosen" chosen)
+						(list "selection" (if (nil? forced) (if owns_requirement (if known "cost" "fallback") "upstream") "forced"))
+						(list "normally_chosen" normal_choice)
+						(list "reason" (if (not (nil? forced)) "calibration_override"
+							(if owns_requirement
+								(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
+									"unknown_statistics_driver_fallback")
+								"upstream_projection_choice")))
+						(list "inputs" (list
+							(list "candidate_input_rows" candidate_input_rows)
+							(list "candidate_matching_rows" candidate_matching_rows)
+							(list "candidate_rows" candidate_rows)
+							(list "driver_input_rows" (planner_source_row_count src))
+							(list "driver_rows" driver_rows)
+							(list "probe_rows" driver_rows)
+							(list "estimate_capped" capped)
+							(list "selectivity_class" (string (qassoc_get facts (quote membership_selectivity_class) (quote unknown))))
+							(list "reuse" (qassoc_get facts (quote reuse) 1))))
+						(list "alternatives" (list
+							(list
+								(list "plan" "candidate_keyset")
+								(list "status" (if (equal? chosen "candidate_keyset") "chosen" "rejected"))
+								(list "reason" (if (equal? chosen "candidate_keyset") "selected" (if known "higher_total_ns_or_forced_alternative" "unknown_statistics_fallback")))
+								(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
+							(list
+								(list "plan" "driver_order_membership_probe")
+								(list "status" (if (equal? chosen "driver_order_membership_probe") "chosen" "rejected"))
+								(list "reason" (if (equal? chosen "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
+								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
+				(if (and (equal? chosen "candidate_keyset") ordered_filter)
+					(planner_record_physical_decision
+						(list
+							(list "decision" "ordered_recset_iterator")
+							(list "chosen" "recset_contains_probe")
+							(list "reason" "base_table_scan_with_membership_filter")
+							(list "inputs" (list
+								(list "candidate_rows" candidate_rows)
+								(list "driver_rows" driver_rows)))
+							(list "alternatives" (list
+								(list
+									(list "plan" "scan_order_recset_part")
+									(list "status" "rejected")
+									(list "reason" "source_is_base_table"))
+								(list
+									(list "plan" "recset_contains_probe")
+									(list "status" "chosen")
+									(list "reason" "base_table_scan_with_membership_filter"))))))
+					nil)
+				(if (equal? chosen "candidate_keyset") raw_expr nil))))))
+
+(define recset_project_join_expr_for_membership (lambda (src membership)
+	(recset_project_join_expr_for_membership_using src membership nil false)))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -14198,17 +14373,9 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 	(not (nil? (probe_limit_work_rows limit_value)))))
 
 /* BEGIN GENERATED COST CONSTANTS. DO NEVER MANUALLY EDIT THIS SECTION. RUN make costgen TO UPDATE.
-Calibrated by tools/costgen against a live storage engine (see that tool for the exact
-benchmark scenarios). Re-run make costgen whenever a storage-primitive perf change lands
-(e.g. an adaptive-index build fix) so these numbers keep tracking reality instead of
-silently drifting stale.
-
-domain_rows is the stage's own (usually small) input table -- what a carrier is built
-FROM. probe_rows is the driving table's row/evaluation count -- how many times the
-built carrier is actually READ. A keytable's dominant cost is per read (row_ns,
-scaled by probe_rows); a RecSet's dominant cost is its one-pass build over the driving
-side (build_ns, also scaled by probe_rows -- recset_project_join visits it once
-regardless of domain size, which is why domain_rows barely matters there). */
+Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
+metadata.physical_calibration. Each observation is an executed, forced
+EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
 	(planner_cost 0 0 (* probe_rows 48685) 0 0 0 0 0 probe_rows 0.75)))
 
@@ -14219,6 +14386,11 @@ regardless of domain size, which is why domain_rows barely matters there). */
 (define planner_recset_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
+
+(define planner_membership_startup_ns 1)
+(define planner_membership_candidate_scan_row_ns 1)
+(define planner_membership_candidate_match_row_ns 33217)
+(define planner_membership_driver_probe_row_ns 138828)
 /* END GENERATED COST CONSTANTS */
 
 (define planner_direct_presence_probe_preferred? (lambda (probe_rows input_rows)
@@ -15363,7 +15535,7 @@ get_column refs to the source) are excluded automatically too. */
 						(query_block_without_stages_after_eager_prepare_with_constant_scalars_first constant_reorder_stages rewritten_src)
 						(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src)))
 				(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src))
-				rewritten_src))
+			rewritten_src))
 		(define direct_nested_stages (if (query_block? rewritten_src)
 			(merge_unique (list
 				(query_block_stages_to_prepare_using prepare_catalog rewritten_src)
@@ -16151,16 +16323,16 @@ get_column refs to the source) are excluded automatically too. */
 
 (define query_block_bounded_scalar_probe_recipe_keys (lambda (block entries)
 	(if (not (query_block_bounded_scalar_probe_recipe_context? block))
-			'()
-			(begin
-				(define prelimit_keys (scalar_query_probe_recipe_keys
-					(query_block_prelimit_scalar_query_probe_recipe_entries block)))
-				(reduce entries (lambda (keys entry)
-					(match entry
-						'(stage requested_col) (begin
-							(define key (scalar_query_probe_recipe_key stage requested_col))
-							(if (has_assoc? prelimit_keys key) keys (set_assoc keys key true)))
-						_ keys)) '()))))))
+		'()
+		(begin
+			(define prelimit_keys (scalar_query_probe_recipe_keys
+				(query_block_prelimit_scalar_query_probe_recipe_entries block)))
+			(reduce entries (lambda (keys entry)
+				(match entry
+					'(stage requested_col) (begin
+						(define key (scalar_query_probe_recipe_key stage requested_col))
+						(if (has_assoc? prelimit_keys key) keys (set_assoc keys key true)))
+					_ keys)) '()))))))
 
 /* A filter probe must retain its marker until scan lowering knows the number
 of pre-limit rows it will evaluate. Turning it into a bounded direct recipe
@@ -17080,7 +17252,10 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 		(define remaining_order_items (nth order_parts 1))
 		(define membership (driver_membership_for_source src condition))
 		(define membership_table_expr (if (nil? membership) nil
-			(recset_project_join_expr_for_membership src membership)))
+			(recset_project_join_expr_for_membership_using src membership
+				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
+				(and (not (empty_list? driver_order_items))
+					(query_limit_active? offset_value limit_value)))))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
 		/* A broad membership set cannot narrow an ordered driver. Keep the base
@@ -19018,8 +19193,8 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 
 (define physical_plan_uses_query_scope? (lambda (expr)
 	(if (or (equal? expr (physical_query_session_symbol))
-			(or (equal? expr (physical_query_scope_symbol))
-				(equal? expr (physical_query_tx_symbol))))
+		(or (equal? expr (physical_query_scope_symbol))
+			(equal? expr (physical_query_tx_symbol))))
 		true
 		(match expr
 			((symbol quote) _value) false
@@ -19251,11 +19426,11 @@ ordering run. Storage artifacts begin in build_queryplan. */
 (define physical_recset_source_expr? (lambda (expr)
 	(match expr
 		(cons head tail) (or
-			(equal? (string head) "scan_recset")
-			(equal? (string head) "filter_recset")
-			(equal? (string head) "recset_project_join")
-			(equal? (string head) "recset_union")
-			(equal? (string head) "recset_intersect")
+			(equal? head (quote scan_recset))
+			(equal? head (quote filter_recset))
+			(equal? head (quote recset_project_join))
+			(equal? head (quote recset_union))
+			(equal? head (quote recset_intersect))
 			(reduce tail (lambda (found item) (or found (physical_recset_source_expr? item))) false))
 		_ false)))
 
@@ -19264,7 +19439,10 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		(cons head tail) (or
 			(physical_recset_contains_expr? head)
 			(reduce tail (lambda (found item) (or found (physical_recset_contains_expr? item))) false))
-		_ (equal? (string expr) "$recset_contains"))))
+		_ (or
+			(equal? (string expr) "$recset_contains")
+			(equal? (string expr) "__recset_contains")
+			(equal? (string expr) "recset_contains")))))
 
 (define physical_ordered_recset_decision (lambda (scan_expr)
 	(begin
@@ -19304,7 +19482,7 @@ ordering run. Storage artifacts begin in build_queryplan. */
 	(match expr
 		(cons head tail) (begin
 			(define own (if (and
-				(equal? (string head) "scan_order")
+				(equal? head (quote scan_order))
 				(> (count expr) 9))
 				(begin
 					(define decision (physical_ordered_recset_decision expr))
@@ -19314,20 +19492,173 @@ ordering run. Storage artifacts begin in build_queryplan. */
 				(merge (list decisions (physical_ordered_recset_decisions item)))) own))
 		_ '())))
 
-(define explain_queryplan_physical (lambda (query)
+(define physical_head_matches? (lambda (head target)
+	(or (equal? head target)
+		(try
+			(lambda () (equal? head (eval target)))
+			(lambda (_e) false)))))
+
+(define physical_expr_has_head? (lambda (expr target)
+	(match expr
+		(cons head tail) (or
+			(physical_head_matches? head target)
+			(reduce tail (lambda (found item)
+				(or found (physical_expr_has_head? item target))) false))
+		_ false)))
+
+(define physical_membership_operator_family (lambda (plan)
+	(if (physical_expr_has_head? plan (quote recset_project_join))
+		"candidate_keyset"
+		/* A forced membership variant reaches this function only after
+		require_physical_scan_relations has rejected every surviving logical
+		marker. Without a projected RecSet its emitted carrier is therefore the
+		driver-side probe family, independent of the concrete group-cache/index
+		primitive selected inside that family. */
+		"driver_order_membership_probe")))
+
+(define compile_physical_explain_variant (lambda (reordered overrides)
 	(begin
 		(define planning_session (context "session"))
 		(define accumulator (newsession))
 		(accumulator "count" 0)
 		(planning_session "__memcp_explain_physical" accumulator)
-		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
+		(planning_session "__memcp_physical_overrides" overrides)
 		(define prepared (prepare_physical_queryplan reordered))
 		(define plan (emit_physical_queryplan prepared))
+		(define operator_family (physical_membership_operator_family plan))
 		(define optimized_plan (optimize plan))
 		(define decisions (merge (list
 			(planner_physical_explain_decisions accumulator)
-			(physical_ordered_recset_decisions optimized_plan))))
+			(physical_ordered_recset_decisions plan))))
 		(planning_session "__memcp_explain_physical" nil)
+		(planning_session "__memcp_physical_overrides" nil)
+		(list optimized_plan decisions operator_family))))
+
+(define physical_decision_by_id (lambda (decisions decision_id)
+	(reduce decisions (lambda (found decision)
+		(if (not (nil? found))
+			found
+			(if (equal? (qassoc_get decision "decision_id" nil) decision_id)
+				decision
+				nil))) nil)))
+
+(define physical_decision_alternative (lambda (decision plan_name)
+	(reduce (qassoc_get decision "alternatives" '()) (lambda (found alternative)
+		(if (not (nil? found))
+			found
+			(if (equal? (qassoc_get alternative "plan" nil) plan_name)
+				alternative
+				nil))) nil)))
+
+(define physical_calibration_input (lambda (decision name)
+	(qassoc_get (qassoc_get decision "inputs" '()) name nil)))
+
+/* Execute one forced plan while shadowing resultrow with a bounded digest
+sink. The outer protocol callback receives only the calibration row, never the
+potentially large calibrated SELECT result. */
+(define physical_calibration_runtime_plan (lambda (plan decision variant estimated_ns operator_family suite_var)
+	(begin
+		(define decision_id (qassoc_get decision "decision_id" "unknown"))
+		(define expected_family (if (equal? (qassoc_get decision "decision" nil) "membership_carrier")
+			variant
+			operator_family))
+		(define consistent (or (not (equal? (qassoc_get decision "decision" nil) "membership_carrier"))
+			(equal? operator_family expected_family)))
+		(define baseline_hash_key (concat "hash:" decision_id))
+		(define baseline_count_key (concat "count:" decision_id))
+		(list
+			(list (quote lambda) (list (quote __calibration_emit))
+				(list (quote !begin)
+					(list (quote define) (quote __calibration_capture) (list (quote newsession)))
+					(list (quote __calibration_capture) "count" 0)
+					(list (quote __calibration_capture) "hash" "")
+					(list (quote define) (quote resultrow)
+						(list (quote lambda) (list (quote __calibration_row))
+							(list (quote !begin)
+								(list (quote __calibration_capture) "count"
+									(list (quote +) (list (quote __calibration_capture) "count") 1))
+								(list (quote __calibration_capture) "hash"
+									(list (quote sha256) (list (quote concat)
+										(list (quote __calibration_capture) "hash")
+										(list (quote serialize) (quote __calibration_row)))))
+								nil)))
+					(list (quote define) (quote __calibration_started_ns) (list (quote nanotime)))
+					plan
+					(list (quote define) (quote __calibration_actual_ns)
+						(list (quote -) (list (quote nanotime)) (quote __calibration_started_ns)))
+					(list (quote define) (quote __calibration_rows) (list (quote __calibration_capture) "count"))
+					(list (quote define) (quote __calibration_hash) (list (quote __calibration_capture) "hash"))
+					(list (quote define) (quote __calibration_first_hash) (list suite_var baseline_hash_key))
+					(list (quote define) (quote __calibration_equal)
+						(list (quote if) (list (quote nil?) (quote __calibration_first_hash))
+							(list (quote !begin)
+								(list suite_var baseline_hash_key (quote __calibration_hash))
+								(list suite_var baseline_count_key (quote __calibration_rows))
+								true)
+							(list (quote and)
+								(list (quote equal?) (quote __calibration_first_hash) (quote __calibration_hash))
+								(list (quote equal?) (list suite_var baseline_count_key) (quote __calibration_rows)))))
+					(list (quote __calibration_emit)
+						(list (quote list)
+							"decision_id" decision_id
+							"decision" (qassoc_get decision "decision" "unknown")
+							"consumer" (qassoc_get decision "consumer" "unknown")
+							"plan" variant
+							"operator_family" operator_family
+							"operator_consistent" consistent
+							"estimated_ns" estimated_ns
+							"actual_ns" (quote __calibration_actual_ns)
+							"candidate_input_rows" (physical_calibration_input decision "candidate_input_rows")
+							"candidate_rows" (physical_calibration_input decision "candidate_rows")
+							"driver_rows" (physical_calibration_input decision "driver_rows")
+							"rows" (quote __calibration_rows)
+							"result_hash" (quote __calibration_hash)
+							"result_equal" (quote __calibration_equal)))))
+			(quote resultrow)))))
+
+(define physical_calibration_variants_for_decision (lambda (reordered decision suite_var)
+	(begin
+		(define decision_id (qassoc_get decision "decision_id" nil))
+		(map (qassoc_get decision "alternatives" '()) (lambda (alternative)
+			(begin
+				(define variant (qassoc_get alternative "plan" nil))
+				(define compilation (compile_physical_explain_variant reordered
+					(list (list decision_id variant))))
+				(define variant_decision (physical_decision_by_id (nth compilation 1) decision_id))
+				(define variant_alternative (physical_decision_alternative variant_decision variant))
+				(define variant_cost (qassoc_get variant_alternative "cost" '()))
+				(physical_calibration_runtime_plan
+					(nth compilation 0)
+					variant_decision
+					variant
+					(qassoc_get variant_cost "total_ns" nil)
+					(nth compilation 2)
+					suite_var)))))))
+
+(define explain_queryplan_physical_calibrate (lambda (query)
+	(begin
+		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
+		(define default_compilation (compile_physical_explain_variant reordered nil))
+		(define decisions (filter (nth default_compilation 1) (lambda (decision)
+			(and (not (nil? (qassoc_get decision "decision_id" nil)))
+				(> (count (qassoc_get decision "alternatives" '())) 1)))))
+		(if (empty_list? decisions)
+			(list (quote resultrow) (list (quote list)
+				"error" "no calibratable physical decision"))
+			(begin
+				(define suite_var (quote __physical_calibration_suite))
+				(define variants (merge (map decisions (lambda (decision)
+					(physical_calibration_variants_for_decision reordered decision suite_var)))))
+				(cons (quote !begin) (cons
+					(list (quote define) suite_var (list (quote newsession)))
+					variants)))))))
+
+(define explain_queryplan_physical (lambda (query)
+	(begin
+		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
+		(define compilation (compile_physical_explain_variant reordered nil))
+		(define optimized_plan (nth compilation 0))
+		(define decisions (nth compilation 1))
 		(list (quote resultrow)
 			(list (quote list)
 				"physical"

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1539,6 +1539,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query sql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query sql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query sql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (define query sql_select)) (explain_queryplan_physical_calibrate (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (define query sql_select)) (explain_queryplan_physical (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (optimize (build_queryplan_term (sql_expand_views query policy))) (settings "ExplainWidth")))))
 		sql_insert_set

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -1,0 +1,82 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Input workload for `make costgen`. CI intentionally skips the repeated
+# measurements; ordinary EXPLAIN PHYSICAL CALIBRATE coverage lives in the
+# planner suites.
+
+metadata:
+  version: "1.0"
+  description: "Physical membership cost calibration workload"
+  isolated: true
+  ci: false
+  physical_calibration: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS pc_files_small"
+  - sql: "DROP TABLE IF EXISTS pc_docs_small"
+  - sql: "DROP TABLE IF EXISTS pc_files_large"
+  - sql: "DROP TABLE IF EXISTS pc_docs_large"
+  - sql: "CREATE TABLE pc_files_small (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32))"
+  - sql: "CREATE TABLE pc_docs_small (id INT PRIMARY KEY, file_id INT, sort_key INT)"
+  - sql: "CREATE TABLE pc_files_large (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32))"
+  - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT)"
+  - scm: |
+      (begin
+        (define make_files (lambda (n)
+          (map (produceN n) (lambda (i)
+            (list i
+              (if (equal? (mod i 10) 0) "filename-hit" "filename-other")
+              (if (equal? (mod i 7) 0) "search-hit" "search-other"))))))
+        (define make_docs (lambda (n file_count)
+          (map (produceN n) (lambda (i) (list i (mod i file_count) i)))))
+        (insert (table "memcp-tests" "pc_files_small") '("id" "filename" "search") (make_files 1000))
+        (insert (table "memcp-tests" "pc_docs_small") '("id" "file_id" "sort_key") (make_docs 4000 1000))
+        (insert (table "memcp-tests" "pc_files_large") '("id" "filename" "search") (make_files 5000))
+        (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key") (make_docs 20000 5000))
+        (rebuild))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS pc_files_small"
+  - sql: "DROP TABLE IF EXISTS pc_docs_small"
+  - sql: "DROP TABLE IF EXISTS pc_files_large"
+  - sql: "DROP TABLE IF EXISTS pc_docs_large"
+
+test_cases:
+  - name: "small broad UNION membership"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_small d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_small f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_small f WHERE f.search LIKE '%hit%'
+      )
+
+  - name: "large broad UNION membership"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+
+  - name: "large high-selectivity UNION membership"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%other%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%other%'
+      )

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -80,3 +80,44 @@ test_cases:
         UNION
         SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%other%'
       )
+
+  - name: "large candidates with small driver"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_small d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+
+  - name: "small candidates with large driver"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_small f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_small f WHERE f.search LIKE '%hit%'
+      )
+
+  - name: "selective membership below ordered limit one"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.sort_key
+      LIMIT 1

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -180,7 +180,7 @@ test_cases:
       result_not_contains:
         - "recset_project_join"
 
-  - name: "Broad membership below OR retains driver probing"
+  - name: "Broad membership below OR uses calibrated projected membership"
     sql: |
       EXPLAIN
       SELECT ID
@@ -196,10 +196,9 @@ test_cases:
     expect:
       result_contains:
         - "scan_order"
-      result_not_contains:
         - "recset_project_join"
 
-  - name: "Nested OR membership uses driver probing after a selective outer AND"
+  - name: "Nested OR membership uses calibrated projection after a selective outer AND"
     sql: |
       EXPLAIN
       SELECT ID
@@ -214,7 +213,6 @@ test_cases:
     expect:
       result_contains:
         - "scan_order"
-      result_not_contains:
         - "recset_project_join"
 
   - name: "Nested OR membership preserves sibling alternatives"
@@ -1025,11 +1023,11 @@ test_cases:
           LIMIT 2
         expect:
           contains:
-            - "ordered_recset_iterator"
-            - "recset_contains_probe"
-            - "scan_order_recset_part"
-            - "base_table_scan_with_membership_filter"
-            - "source_is_base_table"
+            - "membership_carrier"
+            - "candidate_keyset"
+            - "driver_order_membership_probe"
+            - "recset_project_join"
+            - "$recset_contains"
             - "chosen"
             - "rejected"
       - sql: |
@@ -1217,6 +1215,32 @@ test_cases:
             - "$break"
             - ".grp:in_dv_file"
             - "touch_keytable"
+      - sql: |
+          EXPLAIN PHYSICAL CALIBRATE
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.tenant, d.sort_key
+            FROM in_dv_doc d
+            JOIN in_dv_acl a ON a.tenant = d.tenant AND a.allowed = 1
+          ) t
+          WHERE t.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+          ORDER BY t.sort_key
+          LIMIT 10
+        expect:
+          rows: 2
+          contains:
+            - "candidate_keyset"
+            - "driver_order_membership_probe"
+            - "operator_consistent"
+            - "estimated_ns"
+            - "actual_ns"
+            - "candidate_rows"
+            - "driver_rows"
+            - "result_equal"
 
   - name: "IN UNION after derived ACL EXISTS keeps rows and lowers probes"
     fail_comment: "planner must not leak driver_membership_probe into final code or drop rows"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -180,7 +180,7 @@ test_cases:
       result_not_contains:
         - "recset_project_join"
 
-  - name: "Broad membership below OR uses calibrated projected membership"
+  - name: "Broad membership below OR retains driver probing"
     sql: |
       EXPLAIN
       SELECT ID
@@ -196,9 +196,10 @@ test_cases:
     expect:
       result_contains:
         - "scan_order"
+      result_not_contains:
         - "recset_project_join"
 
-  - name: "Nested OR membership uses calibrated projection after a selective outer AND"
+  - name: "Nested OR membership uses driver probing after a selective outer AND"
     sql: |
       EXPLAIN
       SELECT ID
@@ -213,6 +214,7 @@ test_cases:
     expect:
       result_contains:
         - "scan_order"
+      result_not_contains:
         - "recset_project_join"
 
   - name: "Nested OR membership preserves sibling alternatives"
@@ -1004,7 +1006,8 @@ test_cases:
         expect:
           contains:
             - "recset_project_join"
-            - "$recset_contains"
+            - "recset_union"
+            - "scan_order"
             - "in_dv_doc"
           not_contains:
             - "touch_keytable"
@@ -1027,7 +1030,8 @@ test_cases:
             - "candidate_keyset"
             - "driver_order_membership_probe"
             - "recset_project_join"
-            - "$recset_contains"
+            - "recset_union"
+            - "scan_order"
             - "chosen"
             - "rejected"
       - sql: |

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -15,45 +15,40 @@ Copyright (C) 2026  Carl-Philip Hänsch
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// costgen measures real storage-engine costs for the query planner's
-// physical-strategy cost model (the calibrated constants in
-// lib/queryplan.scm: planner_direct_presence_probe_cost,
-// planner_presence_carrier_cost, planner_recset_carrier_cost) and patches
-// them in place, the same way `make jitgen` regenerates JIT emitters from a
-// live analysis instead of hand-typed code.
-//
-// Why this exists: those three constants are calibrated, hand-typed magic
-// numbers with no way to tell whether they still reflect reality. A
-// storage-primitive perf change (e.g. the adaptive-index buildIndex fix in
-// PR #525) silently invalidates them. Re-run `make costgen` whenever a
-// storage-primitive perf change lands.
-//
-// Usage:
-//
-//	go run ./tools/costgen                # measure and print, don't modify
-//	go run ./tools/costgen -patch          # measure and patch lib/queryplan.scm
+// costgen discovers tagged YAML workloads, runs each forced physical
+// alternative, validates results/operators, solves a non-negative cost
+// equation system, and regenerates planner constants.
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
+	"io/fs"
+	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strconv"
+	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
-// syncBuffer is a bytes.Buffer safe for one writer goroutine (the child
-// process's stdout/stderr pump) and one reader goroutine (the readiness
-// poller) at the same time.
+const (
+	beginMarker = "/* BEGIN GENERATED COST CONSTANTS."
+	endMarker   = "/* END GENERATED COST CONSTANTS */"
+	database    = "memcp-tests"
+)
+
 type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -71,73 +66,105 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-func logStep(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, "costgen: "+format+"\n", a...)
+type metadata struct {
+	PhysicalCalibration bool `yaml:"physical_calibration"`
 }
 
-const beginMarker = "/* BEGIN GENERATED COST CONSTANTS."
-const endMarker = "/* END GENERATED COST CONSTANTS */"
+type step struct {
+	SQL string `yaml:"sql"`
+	SCM string `yaml:"scm"`
+}
 
-// probeIterations is how many repeated scan_exists / point-read calls each
-// scenario performs. High enough to average out first-call warmup noise for
-// the carrier scenarios, small enough that the direct-probe scenario (which
-// intentionally has no reusable structure) still finishes quickly.
-const probeIterations = 400
+type testCase struct {
+	Name                string `yaml:"name"`
+	SQL                 string `yaml:"sql"`
+	SCM                 string `yaml:"scm"`
+	PhysicalCalibration bool   `yaml:"physical_calibration"`
+	Warmup              int    `yaml:"warmup"`
+	Repetitions         int    `yaml:"repetitions"`
+	Setup               []step `yaml:"setup"`
+}
 
-// bigRows is the driving-table size for the recset-carrier scenario. Chosen
-// to land solidly in the "adaptive index actually gets built" regime
-// (Settings.IndexThreshold default 5) while keeping the tool's own runtime
-// reasonable.
-const bigRows = 200000
+type suite struct {
+	Path      string
+	Metadata  metadata   `yaml:"metadata"`
+	Setup     []step     `yaml:"setup"`
+	Cleanup   []step     `yaml:"cleanup"`
+	TestCases []testCase `yaml:"test_cases"`
+}
+
+type calibrationRow struct {
+	DecisionID         string   `json:"decision_id"`
+	Decision           string   `json:"decision"`
+	Consumer           string   `json:"consumer"`
+	Plan               string   `json:"plan"`
+	OperatorFamily     string   `json:"operator_family"`
+	OperatorConsistent bool     `json:"operator_consistent"`
+	EstimatedNS        *float64 `json:"estimated_ns"`
+	ActualNS           float64  `json:"actual_ns"`
+	CandidateInputRows *float64 `json:"candidate_input_rows"`
+	CandidateRows      *float64 `json:"candidate_rows"`
+	DriverRows         *float64 `json:"driver_rows"`
+	ResultEqual        bool     `json:"result_equal"`
+}
+
+type observation struct {
+	caseName string
+	plan     string
+	y        float64
+	x        []float64
+}
+
+type constants struct {
+	startupNS           int64
+	candidateScanRowNS  int64
+	candidateMatchRowNS int64
+	driverRowNS         int64
+}
 
 func main() {
-	patch := false
-	for _, arg := range os.Args[1:] {
-		if arg == "-patch" {
-			patch = true
+	patch := flag.Bool("patch", false, "rewrite lib/queryplan.scm")
+	jsonl := flag.String("jsonl", "", "write raw measurements as JSONL")
+	flag.Parse()
+
+	root, err := repoRoot()
+	if err != nil {
+		fatal(err)
+	}
+	suites, err := discoverSuites(root)
+	if err != nil {
+		fatal(err)
+	}
+	if len(suites) == 0 {
+		fatal(errors.New("no tests/**/*.yaml suite has metadata.physical_calibration: true"))
+	}
+	server, err := startServer(root)
+	if err != nil {
+		fatal(err)
+	}
+	defer server.stop()
+
+	observations, raw, err := runSuites(server, suites)
+	if err != nil {
+		fatal(err)
+	}
+	if *jsonl != "" {
+		if err := writeJSONL(*jsonl, raw); err != nil {
+			fatal(err)
 		}
 	}
-
-	repoRoot, err := findRepoRoot()
+	c, err := solve(observations)
 	if err != nil {
 		fatal(err)
 	}
-
-	binPath, err := buildMemcp(repoRoot)
-	if err != nil {
-		fatal(fmt.Errorf("building memcp: %w", err))
-	}
-	defer os.Remove(binPath)
-
-	dataDir, err := os.MkdirTemp("", "costgen-data-*")
-	if err != nil {
-		fatal(err)
-	}
-	defer os.RemoveAll(dataDir)
-
-	apiPort, err := freePort()
-	if err != nil {
-		fatal(err)
-	}
-	mysqlPort, err := freePort()
-	if err != nil {
-		fatal(err)
-	}
-
-	results, err := runBenchmark(binPath, dataDir, apiPort, mysqlPort)
-	if err != nil {
-		fatal(fmt.Errorf("running benchmark: %w", err))
-	}
-
-	c := computeConstants(results)
-	fmt.Println(c.describe())
-
-	if patch {
-		queryplanPath := filepath.Join(repoRoot, "lib", "queryplan.scm")
-		if err := patchQueryplan(queryplanPath, c); err != nil {
-			fatal(fmt.Errorf("patching %s: %w", queryplanPath, err))
+	fmt.Printf("membership startup: %d ns\ncandidate scan:    %d ns/input-row\ncandidate build:   %d ns/matching-row\ndriver probe:      %d ns/row\n",
+		c.startupNS, c.candidateScanRowNS, c.candidateMatchRowNS, c.driverRowNS)
+	if *patch {
+		path := filepath.Join(root, "lib", "queryplan.scm")
+		if err := patchQueryplan(path, c); err != nil {
+			fatal(err)
 		}
-		fmt.Println("patched", queryplanPath)
+		fmt.Println("patched", path)
 	}
 }
 
@@ -146,7 +173,11 @@ func fatal(err error) {
 	os.Exit(1)
 }
 
-func findRepoRoot() (string, error) {
+func logStep(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "costgen: "+format+"\n", args...)
+}
+
+func repoRoot() (string, error) {
 	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		return "", err
@@ -154,351 +185,394 @@ func findRepoRoot() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func buildMemcp(repoRoot string) (string, error) {
-	binPath := filepath.Join(os.TempDir(), fmt.Sprintf("costgen-memcp-%d", os.Getpid()))
-	cmd := exec.Command("go", "build", "-o", binPath, ".")
-	cmd.Dir = repoRoot
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("%w: %s", err, stderr.String())
-	}
-	return binPath, nil
-}
-
-func freePort() (int, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
-}
-
-// benchResults holds the raw nanosecond/count measurements parsed out of the
-// benchmark script's final printed assoc list.
-type benchResults struct {
-	directNs      int64
-	directCalls   int64
-	ktBuildNs     int64
-	ktReadNs      int64
-	ktReadCalls   int64
-	recsetBuildNs int64
-	recsetProjNs  int64
-	bigRows       int64
-}
-
-func runBenchmark(binPath, dataDir string, apiPort, mysqlPort int) (*benchResults, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, binPath, "-data", dataDir,
-		fmt.Sprintf("--api-port=%d", apiPort),
-		fmt.Sprintf("--mysql-port=%d", mysqlPort),
-		"lib/main.scm")
-	cmd.Dir = mustRepoRootFromBin()
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-	stdout := &syncBuffer{}
-	cmd.Stdout = stdout
-	cmd.Stderr = stdout
-
-	logStep("starting memcp (api=%d mysql=%d data=%s)", apiPort, mysqlPort, dataDir)
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	if err := waitForListening(stdout, apiPort, 20*time.Second); err != nil {
-		cmd.Process.Kill()
-		return nil, fmt.Errorf("server never became ready: %w\noutput so far:\n%s", err, stdout.String())
-	}
-	logStep("server ready, running SQL setup (%d big rows)", bigRows)
-
-	if err := setupData(mysqlPort); err != nil {
-		cmd.Process.Kill()
-		return nil, fmt.Errorf("SQL setup: %w", err)
-	}
-	logStep("SQL setup done, feeding benchmark script")
-
-	if _, err := io.WriteString(stdin, benchmarkScript()); err != nil {
-		cmd.Process.Kill()
-		return nil, err
-	}
-	stdin.Close()
-
-	logStep("waiting for the result line (not for a graceful shutdown, which can be slow)")
-	waitErrCh := make(chan error, 1)
-	go func() { waitErrCh <- cmd.Wait() }()
-
-	resultDeadline := time.Now().Add(60 * time.Second)
-	for time.Now().Before(resultDeadline) {
-		if resultLineFrom(stdout.String()) != "" {
-			break
+func discoverSuites(root string) ([]suite, error) {
+	var found []suite
+	err := filepath.WalkDir(filepath.Join(root, "tests"), func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-		select {
-		case err := <-waitErrCh:
-			// process exited (or was context-killed) before printing a result
-			if err != nil {
-				return nil, fmt.Errorf("%w\noutput:\n%s", err, stdout.String())
-			}
-			return parseResults(stdout.String())
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-	// Result line is in the buffer; stop waiting for shutdown/table-compression
-	// and kill the process outright.
-	cmd.Process.Kill()
-	<-waitErrCh
-	logStep("result line captured, process terminated")
-
-	return parseResults(stdout.String())
-}
-
-// mustRepoRootFromBin re-derives the repo root for the child process's
-// working directory (it needs to find lib/main.scm relative to cwd).
-func mustRepoRootFromBin() string {
-	root, err := findRepoRoot()
-	if err != nil {
-		fatal(err)
-	}
-	return root
-}
-
-func waitForListening(out *syncBuffer, apiPort int, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	needle := fmt.Sprintf(":%d", apiPort)
-	for time.Now().Before(deadline) {
-		if strings.Contains(out.String(), needle) {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
 			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var header struct {
+			Metadata metadata `yaml:"metadata"`
+		}
+		if err := yaml.Unmarshal(data, &header); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if !header.Metadata.PhysicalCalibration {
+			return nil
+		}
+		var parsed suite
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		parsed.Path = path
+		found = append(found, parsed)
+		return nil
+	})
+	sort.Slice(found, func(i, j int) bool { return found[i].Path < found[j].Path })
+	return found, err
+}
+
+type memcpServer struct {
+	baseURL string
+	binPath string
+	dataDir string
+	cmd     *exec.Cmd
+	out     *syncBuffer
+	cancel  context.CancelFunc
+}
+
+func startServer(root string) (*memcpServer, error) {
+	bin := filepath.Join(os.TempDir(), fmt.Sprintf("costgen-memcp-%d", os.Getpid()))
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = root
+	if output, err := build.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("build memcp: %w: %s", err, output)
+	}
+	dataDir, err := os.MkdirTemp("", "costgen-data-*")
+	if err != nil {
+		return nil, err
+	}
+	port, err := freePort()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin, "-data", dataDir,
+		fmt.Sprintf("--api-port=%d", port), "--disable-mysql", "--no-repl", "lib/main.scm")
+	cmd.Dir = root
+	out := &syncBuffer{}
+	cmd.Stdout, cmd.Stderr = out, out
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+	server := &memcpServer{
+		baseURL: fmt.Sprintf("http://127.0.0.1:%d", port),
+		binPath: bin,
+		dataDir: dataDir,
+		cmd:     cmd,
+		out:     out,
+		cancel:  cancel,
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), fmt.Sprintf(":%d", port)) {
+			if _, err := server.execute("/sql/system", "CREATE DATABASE IF NOT EXISTS `"+database+"`", 30*time.Second); err != nil {
+				server.stop()
+				return nil, fmt.Errorf("create calibration database: %w", err)
+			}
+			return server, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return fmt.Errorf("timed out waiting for %q in server output", needle)
+	server.stop()
+	return nil, fmt.Errorf("server did not become ready: %s", out.String())
 }
 
-func setupData(mysqlPort int) error {
-	var sb strings.Builder
-	sb.WriteString("DROP DATABASE IF EXISTS costgen;\n")
-	sb.WriteString("CREATE DATABASE costgen;\n")
-	sb.WriteString("USE costgen;\n")
-	sb.WriteString("CREATE TABLE side (id INT, flag INT);\n")
-	sb.WriteString("INSERT INTO side (id, flag) VALUES (1,1),(2,0),(3,1),(4,0),(5,1),(6,0),(7,1),(8,0),(9,1),(10,0);\n")
-	sb.WriteString("CREATE TABLE big (id INT, k INT);\n")
-	const batchSize = 2000
-	for start := 0; start < bigRows; start += batchSize {
-		end := start + batchSize
-		if end > bigRows {
-			end = bigRows
-		}
-		sb.WriteString("INSERT INTO big (id, k) VALUES ")
-		for i := start; i < end; i++ {
-			if i > start {
-				sb.WriteString(",")
-			}
-			fmt.Fprintf(&sb, "(%d,%d)", i, (i%10)+1)
-		}
-		sb.WriteString(";\n")
+func (s *memcpServer) stop() {
+	s.cancel()
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+		_, _ = s.cmd.Process.Wait()
 	}
+	_ = os.Remove(s.binPath)
+	_ = os.RemoveAll(s.dataDir)
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+func freePort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
+func (s *memcpServer) execute(endpoint, body string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "mysql", "-h127.0.0.1", fmt.Sprintf("-P%d", mysqlPort), "-uroot", "-padmin")
-	cmd.Stdin = strings.NewReader(sb.String())
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%w: %s", err, stderr.String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+endpoint, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth("root", "admin")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	var output bytes.Buffer
+	if _, err := output.ReadFrom(response.Body); err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", response.StatusCode, output.String())
+	}
+	return output.Bytes(), nil
+}
+
+func (s *memcpServer) runStep(current step) error {
+	if current.SQL != "" {
+		_, err := s.execute("/sql/"+database, current.SQL, 10*time.Minute)
+		return err
+	}
+	if current.SCM != "" {
+		_, err := s.execute("/scm", current.SCM, 10*time.Minute)
+		return err
 	}
 	return nil
 }
 
-func benchmarkScript() string {
-	return fmt.Sprintf(`
-(define sess (newsession))
-(with_autocommit sess (lambda ()
-  (begin
-    (define tx (sess "__memcp_tx"))
-    (define keys (list 1 2 3 4 5 6 7 8 9 10))
-    (define iterations (produceN %d))
-
-    (define probe_once (lambda (k)
-      (scan_exists tx (table "costgen" "side") (list "id" "flag")
-        (lambda (id flag) (and (equal?? id k) (equal?? flag 1))))))
-
-    (define direct_t0 (nanotime))
-    (define direct_hits (reduce iterations (lambda (acc i)
-      (+ acc (if (probe_once (+ 1 (mod i 10))) 1 0))) 0))
-    (define direct_t1 (nanotime))
-
-    (createtable "costgen" ".grp:costgen_bench" (list (list "column" "k0" "int" '() '())) (list "engine" "cache") true)
-    (createcolumn (table "costgen" ".grp:costgen_bench") "flagval" "any" '() '() (list "k0")
-      (lambda (k0) (probe_once k0)))
-    (define kt_build_t0 (nanotime))
-    (reduce keys (lambda (_ k) (insert (table "costgen" ".grp:costgen_bench") (list "k0") (list (list k)))) nil)
-    /* Real compiler-generated keytables get bulk-populated with precomputed
-    values during their build pass (group_insert_batches), not lazily on first
-    read. Re-issuing createcolumn on the now-populated table forces the same
-    eager Compress() a fresh, unfiltered createcolumn call does -- this keeps
-    the timed read window measuring genuinely warm point-reads instead of
-    accidentally re-triggering per-row materialization mid-scan (the scan
-    condition below touches both k0 and flagval per row, so an unwarmed
-    lazy column would recompute flagval while scanning toward a match). */
-    (createcolumn (table "costgen" ".grp:costgen_bench") "flagval" "any" '() '() (list "k0")
-      (lambda (k0) (probe_once k0)))
-    (define kt_build_t1 (nanotime))
-
-    (define kt_read_t0 (nanotime))
-    (define kt_hits (reduce iterations (lambda (acc i)
-      (+ acc (if (scan_exists tx (table "costgen" ".grp:costgen_bench") (list "k0" "flagval")
-                   (lambda (k0 fv) (and (equal?? k0 (+ 1 (mod i 10))) (equal?? fv true)))) 1 0))) 0))
-    (define kt_read_t1 (nanotime))
-
-    (define recset_t0 (nanotime))
-    (define rs (scan_recset tx (table "costgen" "side") (list "id") (lambda (id) (probe_once id))))
-    (define recset_build_t1 (nanotime))
-    (define proj (recset_project_join tx rs (list "id") (table "costgen" "big") (list "k")))
-    (define recset_t1 (nanotime))
-    (define big_rows (recset_count proj))
-
-    (list
-      "direct_ns" (- direct_t1 direct_t0) "direct_calls" (count iterations) "direct_hits" direct_hits
-      "kt_build_ns" (- kt_build_t1 kt_build_t0)
-      "kt_read_ns" (- kt_read_t1 kt_read_t0) "kt_read_calls" (count iterations) "kt_hits" kt_hits
-      "recset_build_ns" (- recset_build_t1 recset_t0)
-      "recset_proj_ns" (- recset_t1 recset_build_t1)
-      "big_rows" big_rows)))))
-`, probeIterations)
-}
-
-var resultLineRe = regexp.MustCompile(`^\s*=\s*\((.*)\)\s*$`)
-var kvRe = regexp.MustCompile(`"([a-z_]+)"\s+(-?[0-9]+)`)
-var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
-
-// resultLineFrom returns the last line in output that matches the
-// benchmark script's printed assoc list, or "" if none is present yet.
-func resultLineFrom(output string) string {
-	scanner := bufio.NewScanner(strings.NewReader(output))
-	scanner.Buffer(make([]byte, 1<<20), 1<<20)
-	var line string
-	for scanner.Scan() {
-		candidate := ansiRe.ReplaceAllString(scanner.Text(), "")
-		if resultLineRe.MatchString(candidate) {
-			line = candidate
+func runSuites(server *memcpServer, suites []suite) ([]observation, []calibrationRow, error) {
+	var observations []observation
+	var allRows []calibrationRow
+	for _, currentSuite := range suites {
+		logStep("suite %s", currentSuite.Path)
+		for _, setup := range currentSuite.Setup {
+			if err := server.runStep(setup); err != nil {
+				return nil, nil, fmt.Errorf("%s setup: %w", currentSuite.Path, err)
+			}
+		}
+		for _, test := range currentSuite.TestCases {
+			if !test.PhysicalCalibration {
+				continue
+			}
+			for _, setup := range test.Setup {
+				if err := server.runStep(setup); err != nil {
+					return nil, nil, fmt.Errorf("%s/%s setup: %w", currentSuite.Path, test.Name, err)
+				}
+			}
+			query := strings.TrimSpace(test.SQL)
+			if query == "" || test.SCM != "" {
+				return nil, nil, fmt.Errorf("%s/%s: calibration cases require SQL", currentSuite.Path, test.Name)
+			}
+			if !strings.HasPrefix(strings.ToUpper(query), "EXPLAIN PHYSICAL CALIBRATE") {
+				query = "EXPLAIN PHYSICAL CALIBRATE\n" + query
+			}
+			warmup, repetitions := test.Warmup, test.Repetitions
+			if repetitions <= 0 {
+				repetitions = 5
+			}
+			var runs [][]calibrationRow
+			for run := 0; run < warmup+repetitions; run++ {
+				payload, err := server.execute("/sql/"+database, query, 10*time.Minute)
+				if err != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+				}
+				rows, err := decodeRows(payload)
+				if err != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w; response=%s", currentSuite.Path, test.Name, err, payload)
+				}
+				if err := validateRows(rows); err != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+				}
+				if run >= warmup {
+					runs = append(runs, rows)
+					allRows = append(allRows, rows...)
+				}
+			}
+			medians, err := medianRows(runs)
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+			}
+			for _, row := range medians {
+				features, err := rowFeatures(row)
+				if err != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+				}
+				observations = append(observations, observation{caseName: test.Name, plan: row.Plan, y: row.ActualNS, x: features})
+			}
+		}
+		for _, cleanup := range currentSuite.Cleanup {
+			if err := server.runStep(cleanup); err != nil {
+				return nil, nil, fmt.Errorf("%s cleanup: %w", currentSuite.Path, err)
+			}
 		}
 	}
-	return line
+	return observations, allRows, nil
 }
 
-func parseResults(output string) (*benchResults, error) {
-	line := resultLineFrom(output)
-	if line == "" {
-		return nil, fmt.Errorf("no result line found in output:\n%s", output)
+func decodeRows(payload []byte) ([]calibrationRow, error) {
+	var rows []calibrationRow
+	if err := json.Unmarshal(payload, &rows); err == nil {
+		return rows, nil
 	}
-	values := map[string]int64{}
-	for _, m := range kvRe.FindAllStringSubmatch(line, -1) {
-		v, err := strconv.ParseInt(m[2], 10, 64)
-		if err != nil {
-			continue
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	for {
+		var row calibrationRow
+		if err := decoder.Decode(&row); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
 		}
-		values[m[1]] = v
+		rows = append(rows, row)
 	}
-	get := func(k string) int64 { return values[k] }
-	r := &benchResults{
-		directNs:      get("direct_ns"),
-		directCalls:   get("direct_calls"),
-		ktBuildNs:     get("kt_build_ns"),
-		ktReadNs:      get("kt_read_ns"),
-		ktReadCalls:   get("kt_read_calls"),
-		recsetBuildNs: get("recset_build_ns"),
-		recsetProjNs:  get("recset_proj_ns"),
-		bigRows:       get("big_rows"),
+	if len(rows) == 0 {
+		return nil, errors.New("empty calibration response")
 	}
-	if r.directCalls == 0 || r.ktReadCalls == 0 {
-		return nil, fmt.Errorf("incomplete result line: %s", line)
-	}
-	return r, nil
+	return rows, nil
 }
 
-// calibratedConstants mirrors the three planner_*_cost lambdas' numeric
-// literals in lib/queryplan.scm.
-type calibratedConstants struct {
-	directProbeNsPerRow int64
-	carrierStartupNs    int64
-	carrierBuildNsPerRow int64
-	recsetStartupNs     int64
-	recsetBuildNsPerRow int64
+func validateRows(rows []calibrationRow) error {
+	if len(rows) != 2 {
+		return fmt.Errorf("expected exactly two membership alternatives, got %d", len(rows))
+	}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		if row.Decision != "membership_carrier" || row.DecisionID == "" {
+			return fmt.Errorf("unexpected or anonymous decision: %+v", row)
+		}
+		if !row.OperatorConsistent || row.OperatorFamily != row.Plan {
+			return fmt.Errorf("chosen/emitted mismatch for %s: chosen=%s emitted=%s", row.DecisionID, row.Plan, row.OperatorFamily)
+		}
+		if !row.ResultEqual {
+			return fmt.Errorf("forced alternative %s changed the result", row.Plan)
+		}
+		if row.CandidateInputRows == nil || row.CandidateRows == nil || row.DriverRows == nil || row.EstimatedNS == nil {
+			return fmt.Errorf("known-statistics row contains nil inputs: %+v", row)
+		}
+		if row.ActualNS <= 0 {
+			return fmt.Errorf("invalid actual_ns for %s", row.Plan)
+		}
+		seen[row.Plan] = true
+	}
+	if !seen["candidate_keyset"] || !seen["driver_order_membership_probe"] {
+		return fmt.Errorf("alternatives incomplete: %v", seen)
+	}
+	return nil
 }
 
-func computeConstants(r *benchResults) *calibratedConstants {
-	directPerCall := r.directNs / r.directCalls
-	ktReadPerCall := r.ktReadNs / r.ktReadCalls
-	recsetPerRow := r.recsetProjNs / max64(r.bigRows, 1)
-	return &calibratedConstants{
-		directProbeNsPerRow: directPerCall,
-		carrierStartupNs:    r.ktBuildNs,
-		carrierBuildNsPerRow: ktReadPerCall,
-		recsetStartupNs:     r.recsetBuildNs,
-		recsetBuildNsPerRow: recsetPerRow,
+func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
+	byPlan := map[string][]calibrationRow{}
+	for _, run := range runs {
+		for _, row := range run {
+			byPlan[row.Plan] = append(byPlan[row.Plan], row)
+		}
+	}
+	var result []calibrationRow
+	for _, plan := range []string{"candidate_keyset", "driver_order_membership_probe"} {
+		rows := byPlan[plan]
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("no rows for %s", plan)
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].ActualNS < rows[j].ActualNS })
+		result = append(result, rows[len(rows)/2])
+	}
+	return result, nil
+}
+
+func rowFeatures(row calibrationRow) ([]float64, error) {
+	switch row.Plan {
+	case "candidate_keyset":
+		return []float64{1, *row.CandidateInputRows, *row.CandidateRows, 0}, nil
+	case "driver_order_membership_probe":
+		return []float64{1, 0, 0, *row.DriverRows}, nil
+	default:
+		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
 	}
 }
 
-func max64(a, b int64) int64 {
-	if a > b {
-		return a
+// solve fits: actual_ns = startup + candidate_input_rows*scan_ns +
+// candidate_rows*build_ns OR startup + driver_rows*driver_probe_ns.
+// Non-negative coordinate descent
+// prevents noisy samples from generating impossible negative costs.
+func solve(rows []observation) (constants, error) {
+	if len(rows) < 4 {
+		return constants{}, fmt.Errorf("need at least four observations, got %d", len(rows))
 	}
-	return b
+	beta := []float64{1, 1, 1, 1}
+	for iteration := 0; iteration < 10000; iteration++ {
+		largestChange := 0.0
+		for column := range beta {
+			numerator, denominator := 0.0, 0.0
+			for _, row := range rows {
+				residual := row.y
+				for other, value := range beta {
+					if other != column {
+						residual -= row.x[other] * value
+					}
+				}
+				numerator += row.x[column] * residual
+				denominator += row.x[column] * row.x[column]
+			}
+			if denominator == 0 {
+				return constants{}, fmt.Errorf("cost equation column %d is not covered", column)
+			}
+			next := numerator / denominator
+			if next < 1 {
+				next = 1
+			}
+			change := next - beta[column]
+			if change < 0 {
+				change = -change
+			}
+			if change > largestChange {
+				largestChange = change
+			}
+			beta[column] = next
+		}
+		if largestChange < 0.001 {
+			break
+		}
+	}
+	return constants{
+		startupNS:           int64(math.Round(beta[0])),
+		candidateScanRowNS:  int64(math.Round(beta[1])),
+		candidateMatchRowNS: int64(math.Round(beta[2])),
+		driverRowNS:         int64(math.Round(beta[3])),
+	}, nil
 }
 
-func (c *calibratedConstants) describe() string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "direct probe:    %6d ns/accepted-row (no reusable structure)\n", c.directProbeNsPerRow)
-	fmt.Fprintf(&sb, "keytable carrier: %6d ns startup + %6d ns/driving-row (point-read)\n", c.carrierStartupNs, c.carrierBuildNsPerRow)
-	fmt.Fprintf(&sb, "recset carrier:   %6d ns startup + %6d ns/driving-row (project-join)\n", c.recsetStartupNs, c.recsetBuildNsPerRow)
-	return sb.String()
+func writeJSONL(path string, rows []calibrationRow) error {
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	for _, row := range rows {
+		if err := encoder.Encode(row); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, output.Bytes(), 0o644)
 }
 
-func patchQueryplan(path string, c *calibratedConstants) error {
+func patchQueryplan(path string, c constants) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	content := string(data)
-	beginIdx := strings.Index(content, beginMarker)
-	endIdx := strings.Index(content, endMarker)
-	if beginIdx < 0 || endIdx < 0 || endIdx < beginIdx {
-		return fmt.Errorf("could not find generated-cost-constants block markers")
+	begin := strings.Index(content, beginMarker)
+	end := strings.Index(content, endMarker)
+	if begin < 0 || end < begin {
+		return errors.New("generated cost constants block not found")
 	}
-	endIdx += len(endMarker)
-
+	end += len(endMarker)
 	block := fmt.Sprintf(`/* BEGIN GENERATED COST CONSTANTS. DO NEVER MANUALLY EDIT THIS SECTION. RUN make costgen TO UPDATE.
-Calibrated by tools/costgen against a live storage engine (see that tool for the exact
-benchmark scenarios). Re-run make costgen whenever a storage-primitive perf change lands
-(e.g. an adaptive-index build fix) so these numbers keep tracking reality instead of
-silently drifting stale.
-
-domain_rows is the stage's own (usually small) input table -- what a carrier is built
-FROM. probe_rows is the driving table's row/evaluation count -- how many times the
-built carrier is actually READ. A keytable's dominant cost is per read (row_ns,
-scaled by probe_rows); a RecSet's dominant cost is its one-pass build over the driving
-side (build_ns, also scaled by probe_rows -- recset_project_join visits it once
-regardless of domain size, which is why domain_rows barely matters there). */
+Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
+metadata.physical_calibration. Each observation is an executed, forced
+EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
-	(planner_cost 0 0 (* probe_rows %d) 0 0 0 0 0 probe_rows 0.75)))
+	(planner_cost 0 0 (* probe_rows 48685) 0 0 0 0 0 probe_rows 0.75)))
 
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
-	(planner_cost %d (* probe_rows %d) 0 0 0 0
+	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
 		(* domain_rows 8) 0 domain_rows 0.65)))
 
 (define planner_recset_carrier_cost (lambda (domain_rows probe_rows)
-	(planner_cost %d 0 0 0 0 (* probe_rows %d)
+	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
-/* END GENERATED COST CONSTANTS */`,
-		c.directProbeNsPerRow,
-		c.carrierStartupNs, c.carrierBuildNsPerRow,
-		c.recsetStartupNs, c.recsetBuildNsPerRow)
 
-	newContent := content[:beginIdx] + block + content[endIdx:]
-	return os.WriteFile(path, []byte(newContent), 0644)
+(define planner_membership_startup_ns %d)
+(define planner_membership_candidate_scan_row_ns %d)
+(define planner_membership_candidate_match_row_ns %d)
+(define planner_membership_driver_probe_row_ns %d)
+/* END GENERATED COST CONSTANTS */`, c.startupNS, c.candidateScanRowNS, c.candidateMatchRowNS, c.driverRowNS)
+	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -116,10 +116,11 @@ type observation struct {
 }
 
 type constants struct {
-	startupNS           int64
-	candidateScanRowNS  int64
-	candidateMatchRowNS int64
-	driverRowNS         int64
+	startupNS             int64
+	candidateScanRowNS    int64
+	candidateRecsetRowNS  int64
+	driverCacheBuildRowNS int64
+	driverCacheProbeRowNS int64
 }
 
 func main() {
@@ -157,8 +158,13 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
-	fmt.Printf("membership startup: %d ns\ncandidate scan:    %d ns/input-row\ncandidate build:   %d ns/matching-row\ndriver probe:      %d ns/row\n",
-		c.startupNS, c.candidateScanRowNS, c.candidateMatchRowNS, c.driverRowNS)
+	if err := validateDecisionOrdering(observations, c); err != nil {
+		fatal(err)
+	}
+	fmt.Printf("membership startup:  %d ns\ncandidate scan:      %d ns/input-row\nrecset build:        %d ns/matching-row\ngroup-cache build:   %d ns/matching-row\ngroup-cache probe:   %d ns/driver-row\n",
+		c.startupNS, c.candidateScanRowNS, c.candidateRecsetRowNS,
+		c.driverCacheBuildRowNS, c.driverCacheProbeRowNS)
+	printDecisionOrdering(observations, c)
 	if *patch {
 		path := filepath.Join(root, "lib", "queryplan.scm")
 		if err := patchQueryplan(path, c); err != nil {
@@ -472,21 +478,29 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 func rowFeatures(row calibrationRow) ([]float64, error) {
 	switch row.Plan {
 	case "candidate_keyset":
-		return []float64{1, *row.CandidateInputRows, *row.CandidateRows, 0}, nil
+		return []float64{*row.CandidateInputRows, *row.CandidateRows, 0, 0}, nil
 	case "driver_order_membership_probe":
-		return []float64{1, 0, 0, *row.DriverRows}, nil
+		return []float64{*row.CandidateInputRows, 0, *row.CandidateRows, *row.DriverRows}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
 	}
 }
 
-// solve fits: actual_ns = startup + candidate_input_rows*scan_ns +
-// candidate_rows*build_ns OR startup + driver_rows*driver_probe_ns.
+// solve fits the physical work both alternatives actually perform:
+//
+//	candidate = candidate_input*scan + candidate_rows*recset_build
+//	driver    = candidate_input*scan + candidate_rows*cache_build + driver_rows*cache_probe
+//
+// Keeping candidate materialization in the driver equation prevents its cost
+// from being incorrectly absorbed into a workload-specific per-driver probe.
+// A shared startup is deliberately not fitted: it cancels from the plan
+// inequality and otherwise absorbs noise while making the row constants
+// underdetermined.
 // Non-negative coordinate descent
 // prevents noisy samples from generating impossible negative costs.
 func solve(rows []observation) (constants, error) {
-	if len(rows) < 4 {
-		return constants{}, fmt.Errorf("need at least four observations, got %d", len(rows))
+	if len(rows) < 5 {
+		return constants{}, fmt.Errorf("need at least five observations, got %d", len(rows))
 	}
 	beta := []float64{1, 1, 1, 1}
 	for iteration := 0; iteration < 10000; iteration++ {
@@ -524,11 +538,106 @@ func solve(rows []observation) (constants, error) {
 		}
 	}
 	return constants{
-		startupNS:           int64(math.Round(beta[0])),
-		candidateScanRowNS:  int64(math.Round(beta[1])),
-		candidateMatchRowNS: int64(math.Round(beta[2])),
-		driverRowNS:         int64(math.Round(beta[3])),
+		startupNS:             0,
+		candidateScanRowNS:    int64(math.Round(beta[0])),
+		candidateRecsetRowNS:  int64(math.Round(beta[1])),
+		driverCacheBuildRowNS: int64(math.Round(beta[2])),
+		driverCacheProbeRowNS: int64(math.Round(beta[3])),
 	}, nil
+}
+
+func estimatedNS(row observation, c constants) float64 {
+	beta := []float64{
+		float64(c.candidateScanRowNS),
+		float64(c.candidateRecsetRowNS),
+		float64(c.driverCacheBuildRowNS),
+		float64(c.driverCacheProbeRowNS),
+	}
+	total := 0.0
+	for i, value := range row.x {
+		total += value * beta[i]
+	}
+	return total
+}
+
+type decisionPair struct {
+	candidate observation
+	driver    observation
+}
+
+func decisionPairs(rows []observation) (map[string]decisionPair, error) {
+	pairs := make(map[string]decisionPair)
+	seen := make(map[string]map[string]bool)
+	for _, row := range rows {
+		pair := pairs[row.caseName]
+		if seen[row.caseName] == nil {
+			seen[row.caseName] = make(map[string]bool)
+		}
+		if seen[row.caseName][row.plan] {
+			return nil, fmt.Errorf("duplicate %s observation for %q", row.plan, row.caseName)
+		}
+		seen[row.caseName][row.plan] = true
+		switch row.plan {
+		case "candidate_keyset":
+			pair.candidate = row
+		case "driver_order_membership_probe":
+			pair.driver = row
+		default:
+			return nil, fmt.Errorf("unsupported plan %q", row.plan)
+		}
+		pairs[row.caseName] = pair
+	}
+	for name, plans := range seen {
+		if !plans["candidate_keyset"] || !plans["driver_order_membership_probe"] {
+			return nil, fmt.Errorf("incomplete alternative pair for %q", name)
+		}
+	}
+	return pairs, nil
+}
+
+func validateDecisionOrdering(rows []observation, c constants) error {
+	pairs, err := decisionPairs(rows)
+	if err != nil {
+		return err
+	}
+	for name, pair := range pairs {
+		actualCandidateWins := pair.candidate.y < pair.driver.y
+		estimatedCandidateWins := estimatedNS(pair.candidate, c) < estimatedNS(pair.driver, c)
+		if actualCandidateWins != estimatedCandidateWins {
+			return fmt.Errorf("calibrated inequality disagrees for %q: actual candidate=%0.fns driver=%0.fns, estimated candidate=%0.fns driver=%0.fns",
+				name, pair.candidate.y, pair.driver.y,
+				estimatedNS(pair.candidate, c), estimatedNS(pair.driver, c))
+		}
+	}
+	return nil
+}
+
+func printDecisionOrdering(rows []observation, c constants) {
+	pairs, err := decisionPairs(rows)
+	if err != nil {
+		return
+	}
+	names := make([]string, 0, len(pairs))
+	for name := range pairs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		pair := pairs[name]
+		estimatedCandidate := estimatedNS(pair.candidate, c)
+		estimatedDriver := estimatedNS(pair.driver, c)
+		actualWinner := pair.driver.plan
+		if pair.candidate.y < pair.driver.y {
+			actualWinner = pair.candidate.plan
+		}
+		estimatedWinner := pair.driver.plan
+		if estimatedCandidate < estimatedDriver {
+			estimatedWinner = pair.candidate.plan
+		}
+		fmt.Printf("decision %-40s actual=%-30s driver-candidate=%+.3fms estimated=%-30s driver-candidate=%+.3fms\n",
+			name, actualWinner, (pair.driver.y-pair.candidate.y)/1e6,
+			estimatedWinner, (estimatedDriver-estimatedCandidate)/1e6)
+	}
 }
 
 func writeJSONL(path string, rows []calibrationRow) error {
@@ -571,8 +680,10 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 
 (define planner_membership_startup_ns %d)
 (define planner_membership_candidate_scan_row_ns %d)
-(define planner_membership_candidate_match_row_ns %d)
-(define planner_membership_driver_probe_row_ns %d)
-/* END GENERATED COST CONSTANTS */`, c.startupNS, c.candidateScanRowNS, c.candidateMatchRowNS, c.driverRowNS)
+(define planner_membership_recset_build_row_ns %d)
+(define planner_membership_group_cache_build_row_ns %d)
+(define planner_membership_group_cache_probe_row_ns %d)
+/* END GENERATED COST CONSTANTS */`, c.startupNS, c.candidateScanRowNS,
+		c.candidateRecsetRowNS, c.driverCacheBuildRowNS, c.driverCacheProbeRowNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package main
+
+import "testing"
+
+func TestSolvePhysicalCostEquation(t *testing.T) {
+	want := constants{startupNS: 1000, candidateScanRowNS: 5, candidateMatchRowNS: 20, driverRowNS: 80}
+	rows := []observation{
+		{x: []float64{1, 100, 10, 0}, y: 1000 + 100*5 + 10*20},
+		{x: []float64{1, 1000, 100, 0}, y: 1000 + 1000*5 + 100*20},
+		{x: []float64{1, 1000, 800, 0}, y: 1000 + 1000*5 + 800*20},
+		{x: []float64{1, 0, 0, 100}, y: 1000 + 100*80},
+		{x: []float64{1, 0, 0, 1000}, y: 1000 + 1000*80},
+		{x: []float64{1, 0, 0, 4000}, y: 1000 + 4000*80},
+	}
+	got, err := solve(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("solve() = %+v, want %+v", got, want)
+	}
+}
+
+func TestValidateRowsRejectsDecisionPlanMismatch(t *testing.T) {
+	estimated, candidateInput, candidateRows, driverRows := 100.0, 1000.0, 100.0, 4000.0
+	rows := []calibrationRow{
+		{
+			DecisionID: "membership_carrier:1", Decision: "membership_carrier",
+			Plan: "candidate_keyset", OperatorFamily: "driver_order_membership_probe",
+			OperatorConsistent: false, EstimatedNS: &estimated, ActualNS: 200,
+			CandidateInputRows: &candidateInput, CandidateRows: &candidateRows,
+			DriverRows: &driverRows, ResultEqual: true,
+		},
+	}
+	if err := validateRows(rows); err == nil {
+		t.Fatal("validateRows accepted a chosen/emitted operator mismatch")
+	}
+}

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -12,14 +12,17 @@ package main
 import "testing"
 
 func TestSolvePhysicalCostEquation(t *testing.T) {
-	want := constants{startupNS: 1000, candidateScanRowNS: 5, candidateMatchRowNS: 20, driverRowNS: 80}
+	want := constants{
+		startupNS: 0, candidateScanRowNS: 5, candidateRecsetRowNS: 20,
+		driverCacheBuildRowNS: 30, driverCacheProbeRowNS: 80,
+	}
 	rows := []observation{
-		{x: []float64{1, 100, 10, 0}, y: 1000 + 100*5 + 10*20},
-		{x: []float64{1, 1000, 100, 0}, y: 1000 + 1000*5 + 100*20},
-		{x: []float64{1, 1000, 800, 0}, y: 1000 + 1000*5 + 800*20},
-		{x: []float64{1, 0, 0, 100}, y: 1000 + 100*80},
-		{x: []float64{1, 0, 0, 1000}, y: 1000 + 1000*80},
-		{x: []float64{1, 0, 0, 4000}, y: 1000 + 4000*80},
+		{caseName: "a", plan: "candidate_keyset", x: []float64{100, 10, 0, 0}, y: 100*5 + 10*20},
+		{caseName: "b", plan: "candidate_keyset", x: []float64{1000, 100, 0, 0}, y: 1000*5 + 100*20},
+		{caseName: "c", plan: "candidate_keyset", x: []float64{1000, 800, 0, 0}, y: 1000*5 + 800*20},
+		{caseName: "a", plan: "driver_order_membership_probe", x: []float64{100, 0, 10, 100}, y: 100*5 + 10*30 + 100*80},
+		{caseName: "b", plan: "driver_order_membership_probe", x: []float64{1000, 0, 100, 1000}, y: 1000*5 + 100*30 + 1000*80},
+		{caseName: "c", plan: "driver_order_membership_probe", x: []float64{1000, 0, 800, 4000}, y: 1000*5 + 800*30 + 4000*80},
 	}
 	got, err := solve(rows)
 	if err != nil {
@@ -27,6 +30,9 @@ func TestSolvePhysicalCostEquation(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("solve() = %+v, want %+v", got, want)
+	}
+	if err := validateDecisionOrdering(rows, got); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `EXPLAIN PHYSICAL CALIBRATE`, which forces every alternative of a physical membership decision, executes it, compares result digests, and reports estimated versus actual runtime
- make final membership lowering own one stable decision record with local cardinalities, complete alternatives, rejection reasons, and emitted-operator consistency
- make `costgen` one YAML-driven workflow that discovers tagged calibration workloads, validates measurements, solves a non-negative physical-work equation system, verifies every estimated cost inequality selects the measured winner, and rewrites the generated constants
- report the signed `driver - candidate` delta for actual and estimated costs so calibration is evaluated by plan ordering, not false nanosecond precision
- keep semantic OR/Top-K constraints separate from cost comparisons between feasible carrier alternatives
- recalibrate and commit the generated membership constants: candidate scan 2258 ns/input row, RecSet build 1 ns/matching row, group-cache build 88430 ns/matching row, and group-cache probe 150302 ns/driver row; shared startup is 0 because it cancels from the decision inequality
- add crossed-cardinality and ordered-LIMIT calibration workloads plus protected planner regressions

## Validation

- `make test` (all critical suites passed; 60678/60678 Scheme source nodes covered)
- `make costgen`
- `GOCACHE=/tmp/memcp-costgen-gocache go test ./tools/costgen`
- `python3 run_sql_tests.py tests/performance/physical-cost-calibration.yaml`
- `python3 run_sql_tests.py tests/planner/subqueries/in-subquery.yaml`
- `python3 run_sql_tests.py tests/sql/expressions/prepared-stmts.yaml`
- `python3 tools/check_sql_time_limit.py --base-ref origin/master`
- `python3 tools/lint_scm.py --check` (passes with existing baseline warnings)
- `git diff --check`
- GitHub CI: `test`, `protected-regression-policy`, and `sql-time-limit-guard` pass