### PR TITLE
perf: refine LIKE skip-list cache lifecycle

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -16,9 +16,12 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
-import "github.com/carli2/hybridsort"
-import "math/bits"
+import "time"
+import "unsafe"
 import "strings"
+import "math/bits"
+import "sync/atomic"
+import "github.com/carli2/hybridsort"
 import "github.com/launix-de/memcp/scm"
 
 func mustSymbolValue(v scm.Scmer) scm.Symbol {
@@ -56,12 +59,40 @@ type BoundaryMatcher interface {
 	// For sorted matchers this is a no-op. The pattern is the search value
 	// (e.g. the LIKE pattern). The result is stored on the StorageIndex.
 	// colStorage is the column's ColumnStorage for reading values.
-	BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage, candidate *SkipList) *SkipList
+	BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage) *SkipList
 }
 
 // SkipList holds an exact adaptive set of matching index positions.
 type SkipList struct {
-	matches recSetShard
+	matches      recSetShard
+	lastUsedNano atomic.Int64
+	hitCount     atomic.Uint64
+}
+
+func (s *SkipList) recordUse() {
+	if s == nil {
+		return
+	}
+	s.lastUsedNano.Store(time.Now().UnixNano())
+	s.hitCount.Add(1)
+}
+
+func (s *SkipList) lastUsed() time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	return time.Unix(0, s.lastUsedNano.Load())
+}
+
+func (s *SkipList) cacheScore() float64 {
+	if s == nil {
+		return 0
+	}
+	hits := s.hitCount.Load()
+	if hits > 1024 {
+		hits = 1024
+	}
+	return float64(hits)
 }
 
 type skipListCursor struct {
@@ -141,7 +172,7 @@ func (s *SkipList) ComputeSize() uint {
 	if s == nil {
 		return 0
 	}
-	return uint(len(s.matches.data))*4 + 32
+	return uint(len(s.matches.data))*4 + uint(unsafe.Sizeof(*s))
 }
 
 // Built-in matcher singletons. Every columnboundaries.matcher points to one of these.
@@ -169,7 +200,7 @@ type equalMatcher struct{}
 func (m *equalMatcher) Kind() string      { return "equal" }
 func (m *equalMatcher) IsSorted() bool    { return true }
 func (m *equalMatcher) IsPointLike() bool { return true }
-func (m *equalMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
+func (m *equalMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
 	return nil // sorted: no skip list needed
 }
 
@@ -180,7 +211,7 @@ type rangeMatcher struct{}
 func (m *rangeMatcher) Kind() string      { return "range" }
 func (m *rangeMatcher) IsSorted() bool    { return true }
 func (m *rangeMatcher) IsPointLike() bool { return false }
-func (m *rangeMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
+func (m *rangeMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
 	return nil // sorted: no skip list needed
 }
 
@@ -191,12 +222,12 @@ type likeMatcher struct{}
 func (m *likeMatcher) Kind() string      { return "like" }
 func (m *likeMatcher) IsSorted() bool    { return false }
 func (m *likeMatcher) IsPointLike() bool { return true }
-func (m *likeMatcher) BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage, candidate *SkipList) *SkipList {
+func (m *likeMatcher) BuildSkipList(pattern, collation string, count uint32, getRecid func(uint32) uint32, colStorage ColumnStorage) *SkipList {
 	if count == 0 || colStorage == nil {
 		return nil
 	}
 
-	builder := newRecSetShardBuilder(nil, count, candidate == nil, 0)
+	builder := newRecSetShardBuilder(nil, count, true, 0)
 	matches := func(pos uint32) bool {
 		recid := getRecid(pos)
 		v := colStorage.GetValue(recid)
@@ -206,12 +237,8 @@ func (m *likeMatcher) BuildSkipList(pattern, collation string, count uint32, get
 		builder.add(pos, matches(pos))
 		return true
 	}
-	if candidate != nil {
-		candidate.matches.forEachID(add)
-	} else {
-		for pos := uint32(0); pos < count; pos++ {
-			add(pos)
-		}
+	for pos := uint32(0); pos < count; pos++ {
+		add(pos)
 	}
 	sl := &SkipList{matches: builder.finish()}
 	return sl
@@ -224,7 +251,7 @@ type recSetMatcher struct{}
 func (m *recSetMatcher) Kind() string      { return "recset" }
 func (m *recSetMatcher) IsSorted() bool    { return false }
 func (m *recSetMatcher) IsPointLike() bool { return true }
-func (m *recSetMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage, _ *SkipList) *SkipList {
+func (m *recSetMatcher) BuildSkipList(_, _ string, _ uint32, _ func(uint32) uint32, _ ColumnStorage) *SkipList {
 	return nil
 }
 

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -56,9 +56,8 @@ const (
 //
 // Phase 1 (heap) pulls candidates by evictionScore (max-heap).
 // Phase 2 sorts candidates by dynamicScore = age * evictionScore - telemetry*1000.
-// The minLifetime guarantee (default 1s) protects items from premature eviction
-// during query execution. Keytables use touch_keytable to refresh lastAccessed
-// before each use, ensuring they survive cache pressure during query runtime.
+// Callers that need a minimum lifetime set it explicitly. Query-local cache
+// consumers should instead retain a Go reference for the duration of their use.
 //
 //	TempCol Shard Index TempKT CacheEntry StringDict
 var evictableWeights = [numEvictableTypes]int64{20, 1, 20, 2, 20, 20}
@@ -264,6 +263,7 @@ func (cm *CacheManager) AddItem(
 		getLastUsed:   getLastUsed,
 		getScore:      getScore,
 		heapIndex:     -1,
+		minLifetime:   int64(time.Second),
 	}
 	done := make(chan struct{})
 	cm.opChan <- cacheOp{add: item, done: done}
@@ -271,7 +271,7 @@ func (cm *CacheManager) AddItem(
 }
 
 // AddItemEx is like AddItem but allows specifying per-item lifetimes.
-// minLifetime: minimum idle duration before this item is eligible for eviction (0 = default 1s).
+// minLifetime: minimum idle duration before this item is eligible for eviction (0 = none).
 // maxIdleTime: force-evict the item if it has been idle for longer than this (0 = no limit).
 func (cm *CacheManager) AddItemEx(
 	pointer any,
@@ -667,12 +667,8 @@ func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFi
 		if lu := c.getLastUsed(c.pointer).UnixNano(); lu > lastActive {
 			lastActive = lu
 		}
-		minLT := c.minLifetime
-		if minLT == 0 {
-			minLT = int64(time.Second)
-		}
 		idleNanos := now.UnixNano() - lastActive
-		if idleNanos < minLT {
+		if idleNanos < c.minLifetime {
 			heap.Push(&cm.h, c)
 			continue
 		}

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -482,9 +482,11 @@ func (cm *CacheManager) evictExpired() {
 		}
 		if item.cleanup(item.pointer, &freedByType) {
 			cm.removeInternal(item.pointer, &freedByType)
+		} else {
+			// Lock contention means the item is currently in use. Keep its expiry
+			// tracked so the next ticker can retry instead of leaking it forever.
+			heap.Push(&cm.expH, expiryEntry{nowNano + int64(time.Minute), entry.pointer})
 		}
-		// If cleanup failed (lock contention), we don't retry — item will linger
-		// until the next ticker tick, which is acceptable.
 	}
 }
 

--- a/storage/cache_test.go
+++ b/storage/cache_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2026  MemCP Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "time"
+import "testing"
+import "container/heap"
+
+func TestEvictExpiredRetriesFailedCleanup(t *testing.T) {
+	pointer := new(int)
+	attempts := 0
+	registeredAt := time.Now().Add(-time.Hour).UnixNano()
+	item := &softItem{
+		pointer:      pointer,
+		evictType:    TypeIndex,
+		heapIndex:    -1,
+		registeredAt: registeredAt,
+		maxIdleTime:  int64(time.Minute),
+		getLastUsed:  func(any) time.Time { return time.Unix(0, registeredAt) },
+		getScore:     func(any) float64 { return 0 },
+		cleanup: func(any, *[numEvictableTypes]int64) bool {
+			attempts++
+			return attempts > 1
+		},
+	}
+	cm := &CacheManager{
+		countByType: [numEvictableTypes]int64{TypeIndex: 1},
+		itemMap:     map[any]*softItem{pointer: item},
+	}
+	heap.Push(&cm.expH, expiryEntry{estimatedExpiry: registeredAt + item.maxIdleTime, pointer: pointer})
+
+	cm.evictExpired()
+	if _, ok := cm.itemMap[pointer]; !ok {
+		t.Fatal("item was removed after cleanup reported lock contention")
+	}
+	if cm.expH.Len() != 1 {
+		t.Fatalf("expiry retry entries = %d, want 1", cm.expH.Len())
+	}
+
+	cm.expH[0].estimatedExpiry = time.Now().Add(-time.Second).UnixNano()
+	cm.evictExpired()
+	if _, ok := cm.itemMap[pointer]; ok {
+		t.Fatal("item remained registered after successful cleanup retry")
+	}
+	if attempts != 2 {
+		t.Fatalf("cleanup attempts = %d, want 2", attempts)
+	}
+}

--- a/storage/cache_test.go
+++ b/storage/cache_test.go
@@ -60,3 +60,37 @@ func TestEvictExpiredRetriesFailedCleanup(t *testing.T) {
 		t.Fatalf("cleanup attempts = %d, want 2", attempts)
 	}
 }
+
+func TestEvictionHonorsOnlyExplicitMinimumLifetime(t *testing.T) {
+	newManager := func(minLifetime time.Duration) (*CacheManager, *int) {
+		pointer := new(int)
+		item := &softItem{
+			pointer:      pointer,
+			evictType:    TypeIndex,
+			heapIndex:    -1,
+			registeredAt: time.Now().UnixNano(),
+			minLifetime:  int64(minLifetime),
+			getLastUsed:  func(any) time.Time { return time.Time{} },
+			cleanup:      func(any, *[numEvictableTypes]int64) bool { return true },
+		}
+		cm := &CacheManager{
+			currentMemory: 1,
+			countByType:   [numEvictableTypes]int64{TypeIndex: 1},
+			itemMap:       map[any]*softItem{pointer: item},
+		}
+		heap.Push(&cm.h, item)
+		return cm, pointer
+	}
+
+	withoutMinimum, unpinned := newManager(0)
+	withoutMinimum.evict(1, 0, 0, nil)
+	if _, ok := withoutMinimum.itemMap[unpinned]; ok {
+		t.Fatal("zero minimum lifetime prevented immediate pressure eviction")
+	}
+
+	withMinimum, pinned := newManager(time.Minute)
+	withMinimum.evict(1, 0, 0, nil)
+	if _, ok := withMinimum.itemMap[pinned]; !ok {
+		t.Fatal("explicit minimum lifetime did not protect the item")
+	}
+}

--- a/storage/index.go
+++ b/storage/index.go
@@ -950,18 +950,17 @@ type skipListKey struct {
 	collation string
 }
 
-func simpleContainsLiteral(pattern, collation string) (string, bool) {
-	if len(pattern) < 2 || pattern[0] != '%' || pattern[len(pattern)-1] != '%' {
-		return "", false
+func loadCachedSkipList(cache *sync.Map, key skipListKey) (*SkipList, bool) {
+	if cache == nil {
+		return nil, false
 	}
-	literal := pattern[1 : len(pattern)-1]
-	if strings.ContainsAny(literal, "%_") {
-		return "", false
+	cached, ok := cache.Load(key)
+	if !ok {
+		return nil, false
 	}
-	if strings.Contains(collation, "_ci") {
-		literal = strings.ToLower(literal)
-	}
-	return literal, true
+	skipList := cached.(*SkipList)
+	skipList.recordUse()
+	return skipList, true
 }
 
 // getOrBuildSkipList returns the cached exact match set for a non-sorted column,
@@ -969,9 +968,9 @@ func simpleContainsLiteral(pattern, collation string) (string, bool) {
 func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sync.Map, colIdx int, bound columnboundaries) *SkipList {
 	key := skipListKey{pattern: bound.lower.String(), collation: strings.ToLower(bound.collation)}
 	// Fast path: check cache
-	if len(caches) > colIdx && caches[colIdx] != nil {
-		if cached, ok := caches[colIdx].Load(key); ok {
-			return cached.(*SkipList)
+	if len(caches) > colIdx {
+		if cached, ok := loadCachedSkipList(caches[colIdx], key); ok {
+			return cached
 		}
 	}
 	// Slow path: build and cache
@@ -991,37 +990,23 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sy
 		}
 		return uint32(int64(state.mainIndexes.GetValueUInt(pos)) + state.mainIndexes.offset)
 	}
-	var candidate *SkipList
-	if literal, ok := simpleContainsLiteral(key.pattern, key.collation); ok && len(caches) > colIdx && caches[colIdx] != nil {
-		bestLength := -1
-		caches[colIdx].Range(func(candidateKey, candidateValue any) bool {
-			cachedKey := candidateKey.(skipListKey)
-			if cachedKey.collation != key.collation {
-				return true
-			}
-			cachedLiteral, simple := simpleContainsLiteral(cachedKey.pattern, cachedKey.collation)
-			if simple && len(cachedLiteral) > bestLength && strings.Contains(literal, cachedLiteral) {
-				candidate = candidateValue.(*SkipList)
-				bestLength = len(cachedLiteral)
-			}
-			return true
-		})
-	}
-	sl := s.ColMatchers[colIdx].BuildSkipList(key.pattern, key.collation, s.t.main_count, getRecid, colStorage, candidate)
+	sl := s.ColMatchers[colIdx].BuildSkipList(key.pattern, key.collation, s.t.main_count, getRecid, colStorage)
 	// Cache immutable match sets. sync.Map keeps the read path non-blocking and
 	// LoadOrStore prevents concurrent first users from publishing duplicates.
 	cache := caches[colIdx]
 	actual, loaded := cache.LoadOrStore(key, sl)
+	sl = actual.(*SkipList)
+	sl.recordUse()
 	if loaded {
-		return actual.(*SkipList)
+		return sl
 	}
 	// Register skip lists as soft sub-items of the parent index. Their bytes
 	// are already included in StorageIndex.ComputeSize for total live-RAM
 	// reporting; the separate CacheManager entry exists only so eviction can
 	// choose a cheaper sub-item before dropping the whole index.
 	if sl != nil {
-		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: key.pattern, collation: key.collation, cache: cache}
-		GlobalCache.AddItem(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore)
+		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: key.pattern, collation: key.collation, cache: cache, skipList: sl}
+		GlobalCache.AddItemEx(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore, 0, likeSkipListMaxIdle)
 	}
 	return sl
 }
@@ -1387,6 +1372,10 @@ func indexGetScore(ptr any) float64 {
 	return ptr.(*StorageIndex).Savings
 }
 
+// Exact terms stay useful while a user pages through results, but one-off
+// searches should not retain their match sets for the lifetime of the shard.
+const likeSkipListMaxIdle = 30 * time.Minute
+
 // skipListCacheEntry wraps a single skip list for CacheManager eviction.
 type skipListCacheEntry struct {
 	index     *StorageIndex
@@ -1394,6 +1383,7 @@ type skipListCacheEntry struct {
 	pattern   string
 	collation string
 	cache     *sync.Map
+	skipList  *SkipList
 }
 
 func skipListCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
@@ -1401,18 +1391,17 @@ func skipListCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	if !e.index.mu.TryLock() {
 		return false
 	}
+	defer e.index.mu.Unlock()
 	if e.cache != nil {
-		e.cache.Delete(skipListKey{pattern: e.pattern, collation: e.collation})
+		e.cache.CompareAndDelete(skipListKey{pattern: e.pattern, collation: e.collation}, e.skipList)
 	}
-	e.index.mu.Unlock()
 	return true
 }
 
 func skipListLastUsed(ptr any) time.Time {
-	e := ptr.(*skipListCacheEntry)
-	return time.Unix(0, int64(atomic.LoadUint64(&e.index.t.lastAccessed)))
+	return ptr.(*skipListCacheEntry).skipList.lastUsed()
 }
 
 func skipListGetScore(ptr any) float64 {
-	return 1 // minimal telemetry protection; index has Savings (2+) so skip lists evicted first
+	return ptr.(*skipListCacheEntry).skipList.cacheScore()
 }

--- a/storage/index.go
+++ b/storage/index.go
@@ -1006,6 +1006,8 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sy
 	// choose a cheaper sub-item before dropping the whole index.
 	if sl != nil {
 		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: key.pattern, collation: key.collation, cache: cache, skipList: sl}
+		// The active query owns sl directly, so removing the cache recommendation
+		// cannot invalidate its cursor. Do not impose a wall-clock grace period.
 		GlobalCache.AddItemEx(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore, 0, likeSkipListMaxIdle)
 	}
 	return sl

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
+import "sync"
 import "testing"
 
 import "github.com/google/btree"
@@ -98,5 +99,63 @@ func TestRemoveIndexChildrenInternalDropsSkipListRecords(t *testing.T) {
 	}
 	if cm.currentMemory != 64 {
 		t.Fatalf("currentMemory = %d, want 64", cm.currentMemory)
+	}
+}
+
+func TestLoadCachedSkipListUsesExactTermAndTracksReuse(t *testing.T) {
+	cache := &sync.Map{}
+	shortKey := skipListKey{pattern: "%car%", collation: "utf8_bin"}
+	longKey := skipListKey{pattern: "%carglass%", collation: "utf8_bin"}
+	short := &SkipList{}
+	cache.Store(shortKey, short)
+
+	if _, ok := loadCachedSkipList(cache, longKey); ok {
+		t.Fatal("a cached substring must not be reused for a different LIKE term")
+	}
+	if got := short.hitCount.Load(); got != 0 {
+		t.Fatalf("substring lookup changed hit count to %d, want 0", got)
+	}
+
+	first, ok := loadCachedSkipList(cache, shortKey)
+	if !ok || first != short {
+		t.Fatal("exact LIKE term was not loaded from cache")
+	}
+	firstUsed := short.lastUsed()
+	if firstUsed.IsZero() || short.hitCount.Load() != 1 {
+		t.Fatal("exact cache hit did not update per-term lifecycle")
+	}
+	if got := skipListLastUsed(&skipListCacheEntry{skipList: short}); !got.Equal(firstUsed) {
+		t.Fatalf("cache entry last-used = %v, want term timestamp %v", got, firstUsed)
+	}
+
+	loadCachedSkipList(cache, shortKey)
+	if short.lastUsed().Before(firstUsed) {
+		t.Fatal("repeated cache hit moved last-used timestamp backwards")
+	}
+	if got := skipListGetScore(&skipListCacheEntry{skipList: short}); got != 2 {
+		t.Fatalf("cache score = %v, want 2 exact uses", got)
+	}
+}
+
+func TestSkipListCleanupDoesNotDeleteReplacement(t *testing.T) {
+	cache := &sync.Map{}
+	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
+	oldSkipList := &SkipList{}
+	replacement := &SkipList{}
+	cache.Store(key, replacement)
+	entry := &skipListCacheEntry{
+		index:     &StorageIndex{},
+		pattern:   key.pattern,
+		collation: key.collation,
+		cache:     cache,
+		skipList:  oldSkipList,
+	}
+
+	if !skipListCleanup(entry, new([numEvictableTypes]int64)) {
+		t.Fatal("skip-list cleanup unexpectedly failed")
+	}
+	got, ok := cache.Load(key)
+	if !ok || got != replacement {
+		t.Fatal("stale eviction removed a newer exact-term cache entry")
 	}
 }


### PR DESCRIPTION
## Summary

- track last use and exact-term hit counts per LIKE skip list, refreshing them on paginated reuse
- expire one-off LIKE terms after 30 minutes of inactivity
- make LIKE entries pressure-evictable immediately; the active query keeps its direct Go reference instead of relying on a wall-clock grace period
- remove the O(number of cached terms) substring-candidate scan and build new exact terms directly
- retry idle eviction after lock contention and avoid deleting a newer replacement entry
- account for the complete skip-list structure size

## Scalability note

The current global CacheManager remains heap-based. Its normal mutations are O(log n), pressure eviction is O(k log n + k log k), and recursive index-child removal currently contains global O(n) scans. A billion-entry design needs a separate follow-up based on bounded/sharded admission, an amortized-O(1) clock policy, a timing wheel for idle expiry, and intrusive parent/child ownership rather than global scans.

## Tests

- `make test`
- targeted cache lifecycle race tests
- `./git-pre-commit tests/storage/indexes/fulltext-like-index.yaml tests/storage/persistence/memory-pressure.yaml`