### PR TITLE
fix: parse prefix NOT below comparison predicates

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -193,6 +193,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 
 	(define psql_expression2 (parser (or
+		/* SQL prefix NOT binds below comparison predicates and above AND/OR. */
+		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
+		(parser '((atom "NOT" true) (define expr psql_expression2)) '('sql_not expr))
 		/* IN (SELECT ...) and NOT IN (SELECT ...) -> pseudo operator, planner will lower or reject */
 		(parser '((define a psql_expression3) (atom "IN" true) "(" (define sub psql_select) ")") '('inner_select_in a sub))
 		(parser '((define a psql_expression3) (atom "NOT" true) (atom "IN" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_in) a sub)))
@@ -252,8 +255,6 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 
 	(define psql_expression5 (parser (or
-		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub psql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
-		(parser '((atom "NOT" true) (define expr psql_expression6)) '('sql_not expr))
 		/* unary minus: -(expr) */
 		(parser '("-" (define expr psql_expression6)) '((quote -) 0 expr))
 		(parser '((define expr psql_expression6) (atom "IS" true) (atom "NULL" true)) '('nil? expr))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -638,6 +638,12 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 
 	(define sql_expression2 (parser (or
+		/* Prefix NOT binds less tightly than comparison predicates but more tightly
+		than AND/OR. Parsing its operand at this level makes `NOT value LIKE ...`
+		mean `NOT (value LIKE ...)`, as required by MySQL, while retaining the
+		dedicated correlated-subquery marker for NOT EXISTS. */
+		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub sql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
+		(parser '((atom "NOT" true) (define expr sql_expression2)) '('sql_not expr))
 		(parser '((atom "MATCH" true) "(" (define cols (+ sql_expression ",")) ")" (atom "AGAINST" true) "(" (define needle sql_expression) (? (atom "IN" true) (atom "NATURAL" true) (atom "LANGUAGE" true) (atom "MODE" true)) ")")
 			(begin
 				(define terms (map cols (lambda (col) '('strlike col '('concat "%" needle "%") "utf8mb4_general_ci"))))
@@ -702,9 +708,6 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 
 	(define sql_expression5 (parser (or
-		(parser '((atom "NOT" true) (atom "EXISTS" true) "(" (define sub sql_select) ")") (list (quote not) (list (quote inner_select_exists) sub)))
-		/* NOT has lower precedence than IS NULL: NOT expr IS NULL == NOT (expr IS NULL) */
-		(parser '((atom "NOT" true) (define expr sql_expression5)) '('sql_not expr))
 		/* unary minus: -(expr) */
 		(parser '("-" (define expr sql_expression6)) '((quote -) 0 expr))
 		(parser '((define expr sql_expression6) (atom "IS" true) (atom "NULL" true)) '('nil? expr))

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -25066,7 +25066,9 @@ func init_alu() {
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{{Kind: "any", ParamName: "value", ParamDesc: "SQL predicate value"}},
-			Return: &TypeDescriptor{Kind: "bool"},
+			// SQL NOT is nullable: UNKNOWN remains UNKNOWN. Advertising a concrete
+			// bool lets expression optimization replace it with two-valued `not`.
+			Return: &TypeDescriptor{Kind: "bool|nil"},
 			Const:  true,
 
 			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {

--- a/tests/sql/compatibility/psql-parser.yaml
+++ b/tests/sql/compatibility/psql-parser.yaml
@@ -129,6 +129,13 @@ test_cases:
       data:
         - id: 2
 
+  - name: "Prefix NOT applies after LIKE"
+    sql: "SELECT id FROM psql_data WHERE NOT name LIKE '%li%' ORDER BY id"
+    expect:
+      rows: 1
+      data:
+        - id: 2
+
   - name: "NOT ILIKE is case-insensitive"
     sql: "SELECT id FROM psql_data WHERE name NOT ILIKE '%ALICE%' ORDER BY id"
     expect:
@@ -136,6 +143,31 @@ test_cases:
       data:
         - id: 2
         - id: 3
+
+  - name: "Prefix NOT applies after ILIKE"
+    sql: "SELECT id FROM psql_data WHERE NOT name ILIKE '%ALICE%' ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - id: 2
+        - id: 3
+
+  - name: "Prefix NOT follows PostgreSQL predicate precedence"
+    sql: |
+      SELECT
+        NOT 2 = 1 AS comparison_result,
+        NOT 4 BETWEEN 1 AND 3 AS between_result,
+        NOT 4 IN (1, 2, 3) AS in_result,
+        NOT FALSE AND FALSE AS and_result,
+        NOT FALSE OR FALSE AS or_result
+    expect:
+      rows: 1
+      data:
+        - comparison_result: true
+          between_result: true
+          in_result: true
+          and_result: false
+          or_result: true
 
   # === Derived-table column alias lists ===
   - name: "Derived table exposes explicit column aliases"

--- a/tests/sql/expressions/strings-like.yaml
+++ b/tests/sql/expressions/strings-like.yaml
@@ -1,3 +1,10 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
 # LIKE operator and patterns
 
 metadata:
@@ -118,6 +125,45 @@ test_cases:
         - id: 3
         - id: 5
         - id: 7
+
+  - name: "Prefix NOT applies after qualified collated LIKE"
+    sql: |
+      SELECT id
+      FROM notlike_test AS item
+      WHERE NOT (item.name) COLLATE utf8mb4_unicode_ci LIKE 'Brand%'
+      ORDER BY id
+    expect:
+      rows: 3
+      data:
+        - id: 3
+        - id: 5
+        - id: 7
+
+  - name: "Prefix NOT LIKE preserves UNKNOWN"
+    sql: |
+      SELECT NOT (value) COLLATE utf8mb4_unicode_ci LIKE 'Brand%' AS matches
+      FROM (SELECT NULL AS value) AS nullable_value
+    expect:
+      rows: 1
+      data:
+        - matches: null
+
+  - name: "Prefix NOT binds below predicates and above boolean operators"
+    sql: |
+      SELECT
+        NOT 2 = 1 AS comparison_result,
+        NOT 4 BETWEEN 1 AND 3 AS between_result,
+        NOT 4 IN (1, 2, 3) AS in_result,
+        NOT 0 AND 0 AS and_result,
+        NOT 0 OR 0 AS or_result
+    expect:
+      rows: 1
+      data:
+        - comparison_result: true
+          between_result: true
+          in_result: true
+          and_result: false
+          or_result: true
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS like_qualified"

--- a/tests/sql/expressions/strings-like.yaml
+++ b/tests/sql/expressions/strings-like.yaml
@@ -106,7 +106,7 @@ test_cases:
       INSERT INTO notlike_test (id, name) VALUES
         (1, 'Brand#23'), (2, 'Brand#45'), (3, 'Generic'),
         (4, 'Brand#12'), (5, 'NoName'), (6, 'Brand#99'),
-        (7, 'Special'), (8, 'Brand#23')
+        (7, 'Special'), (8, 'Brand#23'), (9, NULL)
 
   - name: "NOT LIKE basic"
     sql: "SELECT id FROM notlike_test WHERE name NOT LIKE 'Brand%' ORDER BY id"


### PR DESCRIPTION
## What

Fix prefix `NOT` precedence in both SQL parser families.

`NOT value LIKE pattern` was parsed as `(NOT value) LIKE pattern` instead of `NOT (value LIKE pattern)`. The same grammar position also affected comparison, `BETWEEN`, and `IN` predicates.

The parser now handles prefix `NOT` between predicate expressions and `AND`/`OR`, while retaining the dedicated `NOT EXISTS` correlated-subquery marker.

## Correctness proof

Tests were added first and confirmed red before the parser change.

- exact qualified + collated `NOT ... LIKE` shape
- PostgreSQL `LIKE` and `ILIKE`
- comparison, `BETWEEN`, and `IN` precedence
- `AND`/`OR` precedence
- SQL UNKNOWN/NULL preservation
- existing `NOT EXISTS` coverage

A production-shaped live query changed from an incorrect empty result to the expected 84 rows.

## Local validation

- `go build -o memcp .`
- Scheme formatter check for both changed parser files
- `strings-like.yaml`: 19/19
- `psql-parser.yaml`: 59/59
- `nulls.yaml`: 37/37
- `exists-subquery.yaml`: 35/35

The full SQL suite is left to CI as requested.

## Current-master follow-up

After merging the latest master, an existing NULL authorization regression test exposed an optimizer interaction: `sql_not` can return UNKNOWN/`nil`, but its runtime descriptor incorrectly advertised a strict `bool`. That allowed optimization to substitute two-valued `not`. The descriptor is now `bool|nil`, and the LIKE fixture includes a NULL row that must remain excluded by the negated predicate.

Repeated targeted validation on the merged code:

- `nulls.yaml`: 37/37 (twice)
- `strings-like.yaml`: 19/19
- `psql-parser.yaml`: 59/59
- `exists-subquery.yaml`: 35/35
- `go test ./scm`
