### PR TITLE
perf: make cache eviction top-level aware

### DIFF
--- a/storage/cache.go
+++ b/storage/cache.go
@@ -65,36 +65,94 @@ var evictableWeights = [numEvictableTypes]int64{20, 1, 20, 2, 20, 20}
 var evictableNames = [numEvictableTypes]string{"TempColumn", "Shard", "Index", "TempKeytable", "CacheEntry", "StringDict"}
 
 type softItem struct {
-	pointer       any
-	size          int64
-	evictType     EvictableType
-	evictionScore int64 // = size * weight (static, max-heap key); higher = evicted sooner
-	cleanup       func(pointer any, freedByType *[numEvictableTypes]int64) bool
-	getLastUsed   func(pointer any) time.Time
-	getScore      func(pointer any) float64 // optional type-specific telemetry
-	heapIndex     int                       // position in heap (-1 if not in heap)
-	dynamicScore  float64                   // scratch field for Phase 2
-	registeredAt  int64                     // UnixNano; set once in addInternal as fallback for items whose lastAccessed starts at zero
-	minLifetime   int64                     // minimum idle nanos before eviction (0 = default 1s)
-	maxIdleTime   int64                     // force-evict if idle for this many nanos (0 = no limit)
+	pointer         any
+	size            int64
+	evictType       EvictableType
+	evictionScore   int64 // = size * weight (static, max-heap key); higher = evicted sooner
+	object          cacheObject
+	getLastUsed     func(pointer any) time.Time
+	getScore        func(pointer any) float64 // optional type-specific telemetry
+	heapIndex       int                       // position in heap (-1 if not in heap)
+	expiryIndex     int                       // position in expiryHeap (-1 if no expiry is registered)
+	estimatedExpiry int64                     // UnixNano; refreshed lazily when the deadline is reached
+	dynamicScore    float64                   // scratch field for Phase 2
+	registeredAt    int64                     // UnixNano; set once in addInternal as fallback for items whose lastAccessed starts at zero
+	minLifetime     int64                     // minimum idle nanos before eviction (0 = none)
+	maxIdleTime     int64                     // force-evict if idle for this many nanos (0 = no limit)
 }
 
-// expiryEntry is a lazy min-heap entry tracking when an item may expire.
-// Lazy: stale entries (where the item has been re-used or removed) are
-// discarded on pop rather than eagerly updated — O(log n) per expiry event.
-type expiryEntry struct {
-	estimatedExpiry int64 // unix nanos: when we expect this item to expire
-	pointer         any   // key into itemMap
+type evictionMode uint8
+
+const (
+	evictPartial evictionMode = iota
+	evictFull
+)
+
+// evictionOffer is a revalidated recommendation, not a promise. Concurrent
+// users may change an object between offer collection and execution.
+type evictionOffer struct {
+	partialBytes int64
+	fullBytes    int64
+}
+
+type evictionResult struct {
+	freedBytes   int64
+	fullyEvicted bool
+	success      bool
+}
+
+// cacheObject lets one top-level registration own and selectively shed its
+// internal caches. Implementations must never call public CacheManager methods:
+// eviction runs on the manager's single-owner goroutine.
+type cacheObject interface {
+	evictionOffer(currentSize int64) evictionOffer
+	evict(mode evictionMode, currentSize int64, freedByType *[numEvictableTypes]int64) evictionResult
+}
+
+// atomicCacheObject adapts existing all-or-nothing cleanup callbacks to the
+// same protocol. For atomic objects the partial and full alternatives coincide.
+type atomicCacheObject struct {
+	pointer any
+	cleanup func(pointer any, freedByType *[numEvictableTypes]int64) bool
+}
+
+func (o atomicCacheObject) evictionOffer(currentSize int64) evictionOffer {
+	return evictionOffer{partialBytes: currentSize, fullBytes: currentSize}
+}
+
+func (o atomicCacheObject) evict(_ evictionMode, currentSize int64, freedByType *[numEvictableTypes]int64) evictionResult {
+	if !o.cleanup(o.pointer, freedByType) {
+		return evictionResult{}
+	}
+	return evictionResult{freedBytes: currentSize, fullyEvicted: true, success: true}
 }
 
 // expiryHeap is a min-heap on estimatedExpiry (soonest expiry at top).
-type expiryHeap []expiryEntry
+// It stores the same softItem as the main heap so removal can eagerly unlink
+// expiry metadata and release the complete object graph immediately.
+type expiryHeap []*softItem
 
 func (h expiryHeap) Len() int           { return len(h) }
 func (h expiryHeap) Less(i, j int) bool { return h[i].estimatedExpiry < h[j].estimatedExpiry }
-func (h expiryHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h *expiryHeap) Push(x any)        { *h = append(*h, x.(expiryEntry)) }
-func (h *expiryHeap) Pop() any          { old := *h; n := len(old); x := old[n-1]; *h = old[:n-1]; return x }
+func (h expiryHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].expiryIndex = i
+	h[j].expiryIndex = j
+}
+func (h *expiryHeap) Push(x any) {
+	item := x.(*softItem)
+	item.expiryIndex = len(*h)
+	*h = append(*h, item)
+}
+func (h *expiryHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.expiryIndex = -1
+	*h = old[:n-1]
+	return item
+}
 
 // softItemHeap implements container/heap.Interface as a max-heap on evictionScore.
 type softItemHeap []*softItem
@@ -171,6 +229,8 @@ func systemMemInfo() (free, total int64) {
 // CacheManager manages memory-limited soft references with two-phase eviction.
 // Two budgets: persistedBudget (shards+indexes) and memoryBudget (total).
 type CacheManager struct {
+	// All metadata below is owned by run(). Query workers only publish lifecycle
+	// messages; cache-object children never become global registrations.
 	memoryBudget    int64 // total budget (default 50% of RAM)
 	persistedBudget int64 // budget for persisted shards+indexes (default 30% of RAM)
 	currentMemory   int64
@@ -185,6 +245,7 @@ type CacheManager struct {
 	itemMap map[any]*softItem
 
 	opChan  chan cacheOp
+	runDone chan struct{}
 	stopped atomic.Bool
 }
 
@@ -221,7 +282,9 @@ func (cm *CacheManager) Init(memoryBudget, persistedBudget int64) {
 	cm.persistedBudget = persistedBudget
 	cm.itemMap = make(map[any]*softItem)
 	cm.opChan = make(chan cacheOp, 1024)
+	cm.runDone = make(chan struct{})
 	heap.Init(&cm.h)
+	heap.Init(&cm.expH)
 	go cm.run()
 }
 
@@ -235,6 +298,27 @@ func (cm *CacheManager) Stop() {
 		return // already stopped
 	}
 	close(cm.opChan)
+	<-cm.runDone
+}
+
+func newSoftItem(pointer any, size int64, evictType EvictableType, cleanup func(any, *[numEvictableTypes]int64) bool, getLastUsed func(any) time.Time, getScore func(any) float64, minLifetime, maxIdleTime time.Duration) *softItem {
+	object := cacheObject(atomicCacheObject{pointer: pointer, cleanup: cleanup})
+	if topLevel, ok := pointer.(cacheObject); ok {
+		object = topLevel
+	}
+	return &softItem{
+		pointer:       pointer,
+		size:          size,
+		evictType:     evictType,
+		evictionScore: size * evictableWeights[evictType],
+		object:        object,
+		getLastUsed:   getLastUsed,
+		getScore:      getScore,
+		heapIndex:     -1,
+		expiryIndex:   -1,
+		minLifetime:   int64(minLifetime),
+		maxIdleTime:   int64(maxIdleTime),
+	}
 }
 
 // AddItem registers an evictable item. Triggers cleanup if over budget.
@@ -253,18 +337,7 @@ func (cm *CacheManager) AddItem(
 	if cm.stopped.Load() {
 		return
 	}
-	weight := evictableWeights[evictType]
-	item := &softItem{
-		pointer:       pointer,
-		size:          size,
-		evictType:     evictType,
-		evictionScore: size * weight,
-		cleanup:       cleanup,
-		getLastUsed:   getLastUsed,
-		getScore:      getScore,
-		heapIndex:     -1,
-		minLifetime:   int64(time.Second),
-	}
+	item := newSoftItem(pointer, size, evictType, cleanup, getLastUsed, getScore, time.Second, 0)
 	done := make(chan struct{})
 	cm.opChan <- cacheOp{add: item, done: done}
 	<-done
@@ -285,19 +358,7 @@ func (cm *CacheManager) AddItemEx(
 	if cm.opChan == nil || cm.stopped.Load() {
 		return
 	}
-	weight := evictableWeights[evictType]
-	item := &softItem{
-		pointer:       pointer,
-		size:          size,
-		evictType:     evictType,
-		evictionScore: size * weight,
-		cleanup:       cleanup,
-		getLastUsed:   getLastUsed,
-		getScore:      getScore,
-		heapIndex:     -1,
-		minLifetime:   int64(minLifetime),
-		maxIdleTime:   int64(maxIdleTime),
-	}
+	item := newSoftItem(pointer, size, evictType, cleanup, getLastUsed, getScore, minLifetime, maxIdleTime)
 	done := make(chan struct{})
 	cm.opChan <- cacheOp{add: item, done: done}
 	<-done
@@ -329,6 +390,17 @@ func (cm *CacheManager) UpdateSize(pointer any, delta int64) {
 	done := make(chan struct{})
 	cm.opChan <- cacheOp{updatePtr: pointer, updateDelta: delta, done: done}
 	<-done
+}
+
+// UpdateSizeAsync queues an ownership-local size change without waiting for
+// eviction. It is intended for callers that already hold storage locks. Such
+// objects serialize enqueue order with their own lock; the single manager then
+// applies the deltas in channel order and runs the normal pressure check.
+func (cm *CacheManager) UpdateSizeAsync(pointer any, delta int64) {
+	if delta == 0 || cm.opChan == nil || cm.stopped.Load() {
+		return
+	}
+	cm.opChan <- cacheOp{updatePtr: pointer, updateDelta: delta}
 }
 
 // UpdateBudget changes both memory budgets (e.g. when MaxRamPercent or MaxPersistPercent changes).
@@ -416,6 +488,7 @@ func (cm *CacheManager) runEvictionChecks(additionalSize int64) {
 
 // run is the single-threaded goroutine handling all operations.
 func (cm *CacheManager) run() {
+	defer close(cm.runDone)
 	expireTicker := time.NewTicker(time.Minute)
 	defer expireTicker.Stop()
 	for {
@@ -457,18 +530,14 @@ func (cm *CacheManager) run() {
 	}
 }
 
-// evictExpired removes items whose maxIdleTime has been exceeded.
-// Uses a lazy min-heap (expH): stale entries where the item has been re-used
-// or already removed are discarded on pop — O(k log n) total, no O(n) scan.
+// evictExpired removes items whose maxIdleTime has been exceeded. Cache hits
+// only update object-local timestamps; when a deadline is reached we either
+// evict or reinsert the item at its refreshed deadline.
 func (cm *CacheManager) evictExpired() {
 	nowNano := time.Now().UnixNano()
 	var freedByType [numEvictableTypes]int64
 	for cm.expH.Len() > 0 && cm.expH[0].estimatedExpiry <= nowNano {
-		entry := heap.Pop(&cm.expH).(expiryEntry)
-		item, ok := cm.itemMap[entry.pointer]
-		if !ok {
-			continue // lazily discard: item already removed
-		}
+		item := heap.Pop(&cm.expH).(*softItem)
 		// Recheck actual idle time — item may have been used since we estimated.
 		lastActive := item.registeredAt
 		if lu := item.getLastUsed(item.pointer).UnixNano(); lu > lastActive {
@@ -476,22 +545,25 @@ func (cm *CacheManager) evictExpired() {
 		}
 		actualExpiry := lastActive + item.maxIdleTime
 		if actualExpiry > nowNano {
-			// Item was used after our estimate; push back with the updated deadline.
-			heap.Push(&cm.expH, expiryEntry{actualExpiry, entry.pointer})
+			item.estimatedExpiry = actualExpiry
+			heap.Push(&cm.expH, item)
 			continue
 		}
-		if item.cleanup(item.pointer, &freedByType) {
+		result := item.object.evict(evictFull, item.size, &freedByType)
+		if result.success && result.fullyEvicted {
 			cm.removeInternal(item.pointer, &freedByType)
 		} else {
 			// Lock contention means the item is currently in use. Keep its expiry
 			// tracked so the next ticker can retry instead of leaking it forever.
-			heap.Push(&cm.expH, expiryEntry{nowNano + int64(time.Minute), entry.pointer})
+			item.estimatedExpiry = nowNano + int64(time.Minute)
+			heap.Push(&cm.expH, item)
 		}
 	}
 }
 
 // addInternal inserts a new softItem.
 func (cm *CacheManager) addInternal(item *softItem) {
+	item.registeredAt = time.Now().UnixNano()
 	if old, ok := cm.itemMap[item.pointer]; ok {
 		// re-registration: update in place
 		delta := item.size - old.size
@@ -501,16 +573,22 @@ func (cm *CacheManager) addInternal(item *softItem) {
 		cm.countByType[old.evictType]--
 		cm.sizeByType[item.evictType] += item.size
 		cm.countByType[item.evictType]++
-		// copy heap position
+		// Replace both heap nodes so neither heap retains the old registration.
 		item.heapIndex = old.heapIndex
 		if item.heapIndex >= 0 {
 			cm.h[item.heapIndex] = item
 			heap.Fix(&cm.h, item.heapIndex)
 		}
+		if old.expiryIndex >= 0 {
+			heap.Remove(&cm.expH, old.expiryIndex)
+		}
+		if item.maxIdleTime > 0 {
+			item.estimatedExpiry = time.Now().UnixNano() + item.maxIdleTime
+			heap.Push(&cm.expH, item)
+		}
 		cm.itemMap[item.pointer] = item
 		return
 	}
-	item.registeredAt = time.Now().UnixNano()
 	cm.itemMap[item.pointer] = item
 	cm.currentMemory += item.size
 	scm.AdjustMemStats(item.size)
@@ -518,7 +596,8 @@ func (cm *CacheManager) addInternal(item *softItem) {
 	cm.countByType[item.evictType]++
 	heap.Push(&cm.h, item)
 	if item.maxIdleTime > 0 {
-		heap.Push(&cm.expH, expiryEntry{item.registeredAt + item.maxIdleTime, item.pointer})
+		item.estimatedExpiry = item.registeredAt + item.maxIdleTime
+		heap.Push(&cm.expH, item)
 	}
 }
 
@@ -543,19 +622,10 @@ func (cm *CacheManager) removeInternal(pointer any, freedByType *[numEvictableTy
 	if item.heapIndex >= 0 {
 		heap.Remove(&cm.h, item.heapIndex)
 	}
-	delete(cm.itemMap, pointer)
-}
-
-// removeIndexChildrenInternal removes eviction records for soft sub-items owned
-// by an index. The parent index owns the actual references and is responsible
-// for clearing them; this only keeps CacheManager bookkeeping in sync when the
-// parent is evicted or deregistered.
-func (cm *CacheManager) removeIndexChildrenInternal(index *StorageIndex, freedByType *[numEvictableTypes]int64) {
-	for pointer := range cm.itemMap {
-		if entry, ok := pointer.(*skipListCacheEntry); ok && entry.index == index {
-			cm.removeInternal(pointer, freedByType)
-		}
+	if item.expiryIndex >= 0 {
+		heap.Remove(&cm.expH, item.expiryIndex)
 	}
+	delete(cm.itemMap, pointer)
 }
 
 // updateSizeInternal adjusts size and recomputes heap position.
@@ -563,6 +633,9 @@ func (cm *CacheManager) updateSizeInternal(pointer any, delta int64) {
 	item, ok := cm.itemMap[pointer]
 	if !ok {
 		return
+	}
+	if item.size+delta < 0 {
+		delta = -item.size
 	}
 	cm.currentMemory += delta
 	scm.AdjustMemStats(delta)
@@ -583,106 +656,147 @@ func (cm *CacheManager) updateSizeInternal(pointer any, delta int64) {
 // Telemetry is decayed by 0.9x at each rebuild, so it reflects recent usage rate.
 const telemetryWeight = 50.0
 
-// evict runs two-phase eviction to bring currentUsage below budget.
-// additionalSize accounts for an upcoming allocation that hasn't been tracked yet.
-// typeFilter restricts which types are eviction candidates (nil = all types).
+type evictionCandidate struct {
+	item  *softItem
+	offer evictionOffer
+}
+
+func (cm *CacheManager) usage(typeFilter func(EvictableType) bool) int64 {
+	if typeFilter == nil {
+		return cm.currentMemory
+	}
+	var result int64
+	for evictType, size := range cm.sizeByType {
+		if typeFilter(EvictableType(evictType)) {
+			result += size
+		}
+	}
+	return result
+}
+
+func (cm *CacheManager) applyEviction(candidate evictionCandidate, mode evictionMode, freedByType *[numEvictableTypes]int64) int64 {
+	item := candidate.item
+	if _, ok := cm.itemMap[item.pointer]; !ok {
+		return 0
+	}
+	before := cm.currentMemory
+	result := item.object.evict(mode, item.size, freedByType)
+	if !result.success {
+		return 0
+	}
+	if result.fullyEvicted {
+		cm.removeInternal(item.pointer, freedByType)
+		return before - cm.currentMemory
+	}
+	freed := result.freedBytes
+	if freed < 0 {
+		freed = 0
+	}
+	if freed > item.size {
+		freed = item.size
+	}
+	if freed == 0 {
+		return 0
+	}
+	cm.currentMemory -= freed
+	scm.AdjustMemStats(-freed)
+	cm.sizeByType[item.evictType] -= freed
+	freedByType[item.evictType] += freed
+	item.size -= freed
+	item.evictionScore = item.size * evictableWeights[item.evictType]
+	return before - cm.currentMemory
+}
+
+// evict uses bounded candidate batches. Each batch first collects immutable
+// offers, then applies partial alternatives greedily before full alternatives.
+// If actual reclamation is smaller than proposed, another top-k batch is read.
 func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFilter func(EvictableType) bool) {
 	if currentUsage+additionalSize <= budget {
 		return
 	}
-	needToFree := currentUsage + additionalSize - budget
-	freeTarget := needToFree + budget*25/100
-	candidateTarget := freeTarget * 2
-
-	// Phase 1: pull candidates from max-heap (largest evictionScore first)
-	var candidates []*softItem
+	targetBudget := budget - additionalSize
+	if targetBudget < 0 {
+		targetBudget = 0
+	}
+	var held []*softItem
 	var skipped []*softItem
-	var candidateSum int64
-	for candidateSum < candidateTarget && cm.h.Len() > 0 {
-		item := heap.Pop(&cm.h).(*softItem)
-		if typeFilter != nil && !typeFilter(item.evictType) {
-			skipped = append(skipped, item)
-			continue
-		}
-		candidates = append(candidates, item)
-		candidateSum += item.size
-	}
-	// push back items that didn't match the type filter
-	for _, s := range skipped {
-		heap.Push(&cm.h, s)
-	}
-
-	// Phase 2: remove candidates already freed by recursive side effects
-	alive := candidates[:0]
-	for _, c := range candidates {
-		if _, ok := cm.itemMap[c.pointer]; ok {
-			alive = append(alive, c)
-		}
-	}
-	candidates = alive
-
-	// Phase 2: dynamic scoring among candidates.
-	// dynamicScore = age * weight - telemetry * K
-	//   age: seconds since last access (higher = more stale)
-	//   weight: type-based eviction priority (higher = cheaper to rebuild)
-	//   telemetry: usage score, decayed at each rebuild (higher = more useful)
-	//   K: calibration constant balancing seconds vs usage score
-	// Size is NOT in Phase 2 — Phase 1 (heap) already selected by size*weight.
-	now := time.Now()
-	for _, c := range candidates {
-		age := now.Sub(c.getLastUsed(c.pointer)).Seconds()
-		telemetry := 0.0
-		if c.getScore != nil {
-			telemetry = c.getScore(c.pointer)
-		}
-		weight := float64(evictableWeights[c.evictType])
-		c.dynamicScore = age*weight - telemetry*telemetryWeight
-	}
-
-	// sort by dynamicScore (worst first)
-	hybridsort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].dynamicScore > candidates[j].dynamicScore
-	})
-
-	// evict all candidates, oldest first; stop once we are within budget
 	var freedByType [numEvictableTypes]int64
 	var totalFreed int64
-	for i := 0; i < len(candidates); i++ {
-		if cm.currentMemory <= budget {
-			// already within budget – push remaining survivors back
-			for ; i < len(candidates); i++ {
-				if _, ok := cm.itemMap[candidates[i].pointer]; ok {
-					heap.Push(&cm.h, candidates[i])
-				}
+
+	for cm.usage(typeFilter) > targetBudget && cm.h.Len() > 0 {
+		needToFree := cm.usage(typeFilter) - targetBudget
+		candidateTarget := needToFree * 2
+		if candidateTarget < 1 {
+			candidateTarget = 1
+		}
+		var candidates []evictionCandidate
+		var candidateSum int64
+		for candidateSum < candidateTarget && cm.h.Len() > 0 {
+			item := heap.Pop(&cm.h).(*softItem)
+			if typeFilter != nil && !typeFilter(item.evictType) {
+				skipped = append(skipped, item)
+				continue
 			}
+			candidates = append(candidates, evictionCandidate{item: item, offer: item.object.evictionOffer(item.size)})
+			candidateSum += item.size
+		}
+		if len(candidates) == 0 {
 			break
 		}
-		c := candidates[i]
-		// check again — previous cleanup in this loop may have freed this item recursively
-		if _, ok := cm.itemMap[c.pointer]; !ok {
-			continue
-		}
-		// guarantee minimum lifetime before eviction: use the later of registeredAt and getLastUsed
-		lastActive := c.registeredAt
-		if lu := c.getLastUsed(c.pointer).UnixNano(); lu > lastActive {
-			lastActive = lu
-		}
-		idleNanos := now.UnixNano() - lastActive
-		if idleNanos < c.minLifetime {
-			heap.Push(&cm.h, c)
-			continue
-		}
-		if !c.cleanup(c.pointer, &freedByType) {
-			// cleanup couldn't acquire lock; push back for later retry
-			heap.Push(&cm.h, c)
-			continue
-		}
-		// removeInternal handles bookkeeping + recursive accounting
-		cm.removeInternal(c.pointer, &freedByType)
-		totalFreed += c.size
-	}
 
-	// survivors already pushed back inside the loop above (early-exit branch)
+		now := time.Now()
+		for i := range candidates {
+			item := candidates[i].item
+			age := now.Sub(item.getLastUsed(item.pointer)).Seconds()
+			telemetry := 0.0
+			if item.getScore != nil {
+				telemetry = item.getScore(item.pointer)
+			}
+			item.dynamicScore = age*float64(evictableWeights[item.evictType]) - telemetry*telemetryWeight
+		}
+		hybridsort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].item.dynamicScore > candidates[j].item.dynamicScore
+		})
+
+		eligible := func(item *softItem) bool {
+			lastActive := item.registeredAt
+			if lu := item.getLastUsed(item.pointer).UnixNano(); lu > lastActive {
+				lastActive = lu
+			}
+			return now.UnixNano()-lastActive >= item.minLifetime
+		}
+		// Pass 1: prefer shedding object-owned caches while preserving parents.
+		for _, candidate := range candidates {
+			if cm.usage(typeFilter) <= targetBudget {
+				break
+			}
+			if candidate.offer.partialBytes <= 0 || !eligible(candidate.item) {
+				continue
+			}
+			totalFreed += cm.applyEviction(candidate, evictPartial, &freedByType)
+		}
+		// Pass 2: fully evict surviving parents if partial reclamation was insufficient.
+		for _, candidate := range candidates {
+			if cm.usage(typeFilter) <= targetBudget {
+				break
+			}
+			if candidate.offer.fullBytes <= 0 || !eligible(candidate.item) {
+				continue
+			}
+			totalFreed += cm.applyEviction(candidate, evictFull, &freedByType)
+		}
+		for _, candidate := range candidates {
+			if _, ok := cm.itemMap[candidate.item.pointer]; ok {
+				held = append(held, candidate.item)
+			}
+		}
+	}
+	for _, item := range held {
+		heap.Push(&cm.h, item)
+	}
+	for _, item := range skipped {
+		heap.Push(&cm.h, item)
+	}
 
 	// log summary
 	if totalFreed > 0 {
@@ -708,10 +822,8 @@ func (cs CacheStat) FormatStat() string {
 	if shardColsOnly < 0 {
 		shardColsOnly = 0
 	}
-	// Index sub-items, such as LIKE skip lists, may be registered separately so
-	// eviction can assign them their own weight and age. Those registrations are
-	// eviction records, not additional raw RAM copies, so aggregate RAM displays
-	// must avoid reading them as a second live allocation.
+	// Child caches are included in their top-level owner's size and count as one
+	// object. This keeps global cache metadata independent of child cardinality.
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("TotalBudget = %s\tPersistedBudget = %s\tTracked = %s\tPersisted = %s\n",

--- a/storage/cache_object_benchmark_test.go
+++ b/storage/cache_object_benchmark_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright (C) 2026  MemCP Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "strconv"
+import "sync"
+import "testing"
+import "time"
+
+func BenchmarkCacheManagerAsyncSizeUpdate(b *testing.B) {
+	manager := new(CacheManager)
+	manager.Init(0, 0)
+	pointer := new(int)
+	manager.AddItem(
+		pointer,
+		1<<30,
+		TypeIndex,
+		func(any, *[numEvictableTypes]int64) bool { return true },
+		func(any) time.Time { return time.Time{} },
+		nil,
+	)
+	b.Cleanup(manager.Stop)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		delta := int64(1)
+		for pb.Next() {
+			manager.UpdateSizeAsync(pointer, delta)
+			delta = -delta
+		}
+	})
+	manager.Stat()
+}
+
+func BenchmarkStorageIndexEvictionOffer(b *testing.B) {
+	idx := new(StorageIndex)
+	idx.skipListCacheBytes.Store(64 << 20)
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			offer := idx.evictionOffer(128 << 20)
+			if offer.partialBytes == 0 {
+				b.Fatal("missing partial offer")
+			}
+		}
+	})
+}
+
+func BenchmarkStorageIndexPartialEviction(b *testing.B) {
+	for _, childCount := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("children-%d", childCount), func(b *testing.B) {
+			idx := new(StorageIndex)
+			cache := new(sync.Map)
+			var size int64
+			for child := 0; child < childCount; child++ {
+				key := skipListKey{pattern: fmt.Sprintf("%%term-%d%%", child), collation: "utf8_bin"}
+				skipList := new(SkipList)
+				cache.Store(key, skipList)
+				size += skipListEntrySize(key, skipList)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iteration := 0; iteration < b.N; iteration++ {
+				idx.baseState.skipLists = []*sync.Map{cache}
+				idx.baseState.skipListBytes.Store(size)
+				idx.skipListCacheBytes.Store(size)
+				result := idx.evict(evictPartial, size+1024, new([numEvictableTypes]int64))
+				if !result.success || result.freedBytes != size {
+					b.Fatalf("partial result = %+v, want %d bytes", result, size)
+				}
+			}
+			b.ReportMetric(float64(childCount), "children/op")
+		})
+	}
+}
+
+func BenchmarkLikeSkipListExactHitParallel(b *testing.B) {
+	cache := new(sync.Map)
+	key := skipListKey{pattern: "%carglass%", collation: "utf8_bin"}
+	cache.Store(key, new(SkipList))
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, ok := loadCachedSkipList(cache, key); !ok {
+				b.Fatal("exact cache entry disappeared")
+			}
+		}
+	})
+}
+
+func BenchmarkLikeSkipListCacheAdmission(b *testing.B) {
+	keys := make([]skipListKey, b.N)
+	skipLists := make([]*SkipList, b.N)
+	for i := range keys {
+		keys[i] = skipListKey{pattern: "%term-" + strconv.Itoa(i) + "%", collation: "utf8_bin"}
+		skipLists[i] = new(SkipList)
+	}
+	cache := new(sync.Map)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range keys {
+		cache.Store(keys[i], skipLists[i])
+	}
+}

--- a/storage/cache_test.go
+++ b/storage/cache_test.go
@@ -20,28 +20,59 @@ import "time"
 import "testing"
 import "container/heap"
 
+type testPartialCacheObject struct {
+	partialBytes int64
+	modes        []evictionMode
+}
+
+type testRejectingCacheObject struct{}
+
+func (*testRejectingCacheObject) evictionOffer(currentSize int64) evictionOffer {
+	return evictionOffer{partialBytes: currentSize, fullBytes: currentSize}
+}
+
+func (*testRejectingCacheObject) evict(evictionMode, int64, *[numEvictableTypes]int64) evictionResult {
+	return evictionResult{}
+}
+
+func (o *testPartialCacheObject) evictionOffer(currentSize int64) evictionOffer {
+	return evictionOffer{partialBytes: o.partialBytes, fullBytes: currentSize}
+}
+
+func (o *testPartialCacheObject) evict(mode evictionMode, currentSize int64, _ *[numEvictableTypes]int64) evictionResult {
+	o.modes = append(o.modes, mode)
+	if mode == evictPartial {
+		freed := o.partialBytes
+		o.partialBytes = 0
+		return evictionResult{freedBytes: freed, success: freed > 0}
+	}
+	return evictionResult{freedBytes: currentSize, fullyEvicted: true, success: true}
+}
+
 func TestEvictExpiredRetriesFailedCleanup(t *testing.T) {
 	pointer := new(int)
 	attempts := 0
 	registeredAt := time.Now().Add(-time.Hour).UnixNano()
 	item := &softItem{
-		pointer:      pointer,
-		evictType:    TypeIndex,
-		heapIndex:    -1,
-		registeredAt: registeredAt,
-		maxIdleTime:  int64(time.Minute),
-		getLastUsed:  func(any) time.Time { return time.Unix(0, registeredAt) },
-		getScore:     func(any) float64 { return 0 },
-		cleanup: func(any, *[numEvictableTypes]int64) bool {
-			attempts++
-			return attempts > 1
-		},
+		pointer:         pointer,
+		evictType:       TypeIndex,
+		heapIndex:       -1,
+		expiryIndex:     -1,
+		registeredAt:    registeredAt,
+		maxIdleTime:     int64(time.Minute),
+		estimatedExpiry: registeredAt + int64(time.Minute),
+		getLastUsed:     func(any) time.Time { return time.Unix(0, registeredAt) },
+		getScore:        func(any) float64 { return 0 },
 	}
+	item.object = atomicCacheObject{pointer: pointer, cleanup: func(any, *[numEvictableTypes]int64) bool {
+		attempts++
+		return attempts > 1
+	}}
 	cm := &CacheManager{
 		countByType: [numEvictableTypes]int64{TypeIndex: 1},
 		itemMap:     map[any]*softItem{pointer: item},
 	}
-	heap.Push(&cm.expH, expiryEntry{estimatedExpiry: registeredAt + item.maxIdleTime, pointer: pointer})
+	heap.Push(&cm.expH, item)
 
 	cm.evictExpired()
 	if _, ok := cm.itemMap[pointer]; !ok {
@@ -65,16 +96,23 @@ func TestEvictionHonorsOnlyExplicitMinimumLifetime(t *testing.T) {
 	newManager := func(minLifetime time.Duration) (*CacheManager, *int) {
 		pointer := new(int)
 		item := &softItem{
-			pointer:      pointer,
-			evictType:    TypeIndex,
-			heapIndex:    -1,
-			registeredAt: time.Now().UnixNano(),
-			minLifetime:  int64(minLifetime),
-			getLastUsed:  func(any) time.Time { return time.Time{} },
-			cleanup:      func(any, *[numEvictableTypes]int64) bool { return true },
+			pointer:       pointer,
+			size:          1,
+			evictType:     TypeIndex,
+			evictionScore: evictableWeights[TypeIndex],
+			heapIndex:     -1,
+			expiryIndex:   -1,
+			registeredAt:  time.Now().UnixNano(),
+			minLifetime:   int64(minLifetime),
+			getLastUsed:   func(any) time.Time { return time.Time{} },
+			object: atomicCacheObject{
+				pointer: pointer,
+				cleanup: func(any, *[numEvictableTypes]int64) bool { return true },
+			},
 		}
 		cm := &CacheManager{
 			currentMemory: 1,
+			sizeByType:    [numEvictableTypes]int64{TypeIndex: 1},
 			countByType:   [numEvictableTypes]int64{TypeIndex: 1},
 			itemMap:       map[any]*softItem{pointer: item},
 		}
@@ -92,5 +130,133 @@ func TestEvictionHonorsOnlyExplicitMinimumLifetime(t *testing.T) {
 	withMinimum.evict(1, 0, 0, nil)
 	if _, ok := withMinimum.itemMap[pinned]; !ok {
 		t.Fatal("explicit minimum lifetime did not protect the item")
+	}
+}
+
+func TestEvictionUsesPartialOfferBeforeFullRemoval(t *testing.T) {
+	pointer := new(testPartialCacheObject)
+	pointer.partialBytes = 40
+	item := &softItem{
+		pointer:       pointer,
+		size:          100,
+		evictType:     TypeIndex,
+		evictionScore: 100 * evictableWeights[TypeIndex],
+		object:        pointer,
+		getLastUsed:   func(any) time.Time { return time.Time{} },
+		heapIndex:     -1,
+		expiryIndex:   -1,
+	}
+	cm := &CacheManager{
+		currentMemory: 100,
+		sizeByType:    [numEvictableTypes]int64{TypeIndex: 100},
+		countByType:   [numEvictableTypes]int64{TypeIndex: 1},
+		itemMap:       map[any]*softItem{pointer: item},
+	}
+	heap.Push(&cm.h, item)
+
+	cm.evict(100, 60, 0, nil)
+	if len(pointer.modes) != 1 || pointer.modes[0] != evictPartial {
+		t.Fatalf("eviction modes = %v, want one partial action", pointer.modes)
+	}
+	if _, ok := cm.itemMap[pointer]; !ok {
+		t.Fatal("partial eviction removed top-level object")
+	}
+	if item.size != 60 || cm.currentMemory != 60 {
+		t.Fatalf("sizes after partial eviction: item=%d manager=%d", item.size, cm.currentMemory)
+	}
+}
+
+func TestEvictionFallsBackToFullAfterPartialOffer(t *testing.T) {
+	pointer := new(testPartialCacheObject)
+	pointer.partialBytes = 20
+	item := &softItem{
+		pointer:       pointer,
+		size:          100,
+		evictType:     TypeIndex,
+		evictionScore: 100 * evictableWeights[TypeIndex],
+		object:        pointer,
+		getLastUsed:   func(any) time.Time { return time.Time{} },
+		heapIndex:     -1,
+		expiryIndex:   -1,
+	}
+	cm := &CacheManager{
+		currentMemory: 100,
+		sizeByType:    [numEvictableTypes]int64{TypeIndex: 100},
+		countByType:   [numEvictableTypes]int64{TypeIndex: 1},
+		itemMap:       map[any]*softItem{pointer: item},
+	}
+	heap.Push(&cm.h, item)
+
+	cm.evict(100, 10, 0, nil)
+	if len(pointer.modes) != 2 || pointer.modes[0] != evictPartial || pointer.modes[1] != evictFull {
+		t.Fatalf("eviction modes = %v, want partial then full", pointer.modes)
+	}
+	if _, ok := cm.itemMap[pointer]; ok {
+		t.Fatal("full fallback retained top-level object")
+	}
+}
+
+func TestRemoveEagerlyReleasesExpiryReference(t *testing.T) {
+	pointer := new(int)
+	item := newSoftItem(
+		pointer,
+		64,
+		TypeCacheEntry,
+		func(any, *[numEvictableTypes]int64) bool { return true },
+		func(any) time.Time { return time.Now() },
+		nil,
+		0,
+		time.Hour,
+	)
+	cm := &CacheManager{itemMap: make(map[any]*softItem)}
+	cm.addInternal(item)
+	if cm.expH.Len() != 1 {
+		t.Fatalf("expiry entries after add = %d, want 1", cm.expH.Len())
+	}
+	backing := cm.expH[:cap(cm.expH)]
+	cm.removeInternal(pointer, nil)
+	if cm.expH.Len() != 0 || item.expiryIndex != -1 {
+		t.Fatalf("expiry state after remove: len=%d index=%d", cm.expH.Len(), item.expiryIndex)
+	}
+	if backing[0] != nil {
+		t.Fatal("expiry heap backing array retained removed object")
+	}
+}
+
+func TestEvictionExpandsTopKAfterRejectedOffer(t *testing.T) {
+	rejected := new(testRejectingCacheObject)
+	accepted := new(int)
+	old := func(any) time.Time { return time.Time{} }
+	first := &softItem{
+		pointer: rejected, size: 200, evictType: TypeIndex,
+		evictionScore: 200 * evictableWeights[TypeIndex], object: rejected,
+		getLastUsed: old, heapIndex: -1, expiryIndex: -1,
+	}
+	second := &softItem{
+		pointer: accepted, size: 100, evictType: TypeIndex,
+		evictionScore: 100 * evictableWeights[TypeIndex],
+		object: atomicCacheObject{pointer: accepted, cleanup: func(any, *[numEvictableTypes]int64) bool {
+			return true
+		}},
+		getLastUsed: old, heapIndex: -1, expiryIndex: -1,
+	}
+	cm := &CacheManager{
+		currentMemory: 300,
+		sizeByType:    [numEvictableTypes]int64{TypeIndex: 300},
+		countByType:   [numEvictableTypes]int64{TypeIndex: 2},
+		itemMap: map[any]*softItem{
+			rejected: first,
+			accepted: second,
+		},
+	}
+	heap.Push(&cm.h, first)
+	heap.Push(&cm.h, second)
+
+	cm.evict(300, 200, 0, nil)
+	if _, ok := cm.itemMap[rejected]; !ok {
+		t.Fatal("rejected top-k object was removed")
+	}
+	if _, ok := cm.itemMap[accepted]; ok {
+		t.Fatal("manager did not expand top-k after rejected offer")
 	}
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -1405,15 +1405,15 @@ func keytableCleanup(tbl *table, schemaName string, freedByType *[numEvictableTy
 	for _, s := range tbl.Shards {
 		GlobalCache.removeInternal(s, freedByType)
 		for _, idx := range s.Indexes {
-			GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 			GlobalCache.removeInternal(idx, freedByType)
+			idx.evict(evictFull, 0, freedByType)
 		}
 	}
 	for _, s := range tbl.PShards {
 		GlobalCache.removeInternal(s, freedByType)
 		for _, idx := range s.Indexes {
-			GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 			GlobalCache.removeInternal(idx, freedByType)
+			idx.evict(evictFull, 0, freedByType)
 		}
 	}
 	for _, s := range tbl.Shards {

--- a/storage/index.go
+++ b/storage/index.go
@@ -21,6 +21,7 @@ import "fmt"
 import "sort"
 import "sync"
 import "time"
+import "unsafe"
 import "strings"
 import "sync/atomic"
 
@@ -39,7 +40,8 @@ type storageIndexState struct {
 	active           bool
 	minVals          []scm.Scmer
 	maxVals          []scm.Scmer
-	skipLists        []*sync.Map // map[skipListKey]*SkipList; immutable values, lock-free reads
+	skipLists        []*sync.Map  // map[skipListKey]*SkipList; immutable values, lock-free reads
+	skipListBytes    atomic.Int64 // exact bytes owned by skipLists
 	precomputedDelta bool
 }
 
@@ -87,10 +89,14 @@ type StorageIndex struct {
 	Native       bool    // true when data is physically sorted by this index (zero-cost)
 	t            *storageShard
 	lastHit      atomic.Uint32 // last search position for sorted access pattern optimization
-	mu           sync.Mutex
-	sessionKeys  []string
-	baseState    storageIndexState
-	variants     map[string]*storageIndexState
+	// skipListCacheBytes is the exact memory owned by LIKE child caches. The
+	// CacheManager sees only this StorageIndex; child admission updates the
+	// parent's registered size while eviction remains local to the index.
+	skipListCacheBytes atomic.Int64
+	mu                 sync.Mutex
+	sessionKeys        []string
+	baseState          storageIndexState
+	variants           map[string]*storageIndexState
 }
 
 func orderRelationMeta(order func(...scm.Scmer) scm.Scmer) string {
@@ -254,8 +260,9 @@ func (idx *StorageIndex) stateForTx(tx *TxContext, create bool) *storageIndexSta
 
 func (idx *StorageIndex) markVariantsDirty() {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
+	var freed int64
 	for _, state := range idx.variants {
+		freed += idx.clearSkipListsLocked(state)
 		state.active = false
 		state.mainIndexes = StorageInt{}
 		state.deltaBtree = nil
@@ -264,6 +271,11 @@ func (idx *StorageIndex) markVariantsDirty() {
 		state.maxVals = nil
 		state.precomputedDelta = false
 	}
+	if freed > 0 {
+		idx.skipListCacheBytes.Add(-freed)
+		GlobalCache.UpdateSizeAsync(idx, -freed)
+	}
+	idx.mu.Unlock()
 }
 
 func (idx *StorageIndex) ComputeSize() uint {
@@ -279,13 +291,12 @@ func (idx *StorageIndex) ComputeSize() uint {
 			sz += state.mainIndexes.ComputeSize()
 		}
 		for _, colCache := range state.skipLists {
-			sz += 8
+			sz += uint(unsafe.Sizeof(sync.Map{}))
 			if colCache != nil {
 				colCache.Range(func(key, value any) bool {
 					k := key.(skipListKey)
 					sl := value.(*SkipList)
-					sz += uint(len(k.pattern)+len(k.collation)) + 24
-					sz += sl.ComputeSize()
+					sz += uint(skipListEntrySize(k, sl))
 					return true
 				})
 			}
@@ -293,6 +304,89 @@ func (idx *StorageIndex) ComputeSize() uint {
 		sz += idx.computeDeltaBtreeSize(state)
 	}
 	return sz
+}
+
+// BenchmarkLikeSkipListCacheAdmission measures ~137 bytes of sync.Map and
+// interface bookkeeping per entry on amd64. Round up so many tiny search terms
+// cannot evade the global byte budget through unaccounted metadata.
+const skipListMapEntryOverhead int64 = 144
+
+func skipListEntrySize(key skipListKey, skipList *SkipList) int64 {
+	return int64(len(key.pattern)+len(key.collation)) + skipListMapEntryOverhead + int64(skipList.ComputeSize())
+}
+
+func (idx *StorageIndex) ownsSkipListCacheLocked(cache *sync.Map) bool {
+	if cache == nil {
+		return false
+	}
+	states := []*storageIndexState{&idx.baseState}
+	for _, state := range idx.variants {
+		states = append(states, state)
+	}
+	for _, state := range states {
+		for _, candidate := range state.skipLists {
+			if candidate == cache {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// clearSkipListsLocked detaches all child caches of one index state in O(columns)
+// and returns their exact accounted bytes. Queries that already snapshotted an
+// old map keep it alive until their direct references leave scope.
+// The caller must hold idx.mu.
+func (idx *StorageIndex) clearSkipListsLocked(state *storageIndexState) int64 {
+	if state == nil {
+		return 0
+	}
+	freed := state.skipListBytes.Swap(0)
+	for i, cache := range state.skipLists {
+		if cache != nil {
+			state.skipLists[i] = new(sync.Map)
+		}
+	}
+	return freed
+}
+
+func (idx *StorageIndex) clearAllSkipListsLocked() int64 {
+	freed := idx.clearSkipListsLocked(&idx.baseState)
+	for _, state := range idx.variants {
+		freed += idx.clearSkipListsLocked(state)
+	}
+	if remaining := idx.skipListCacheBytes.Add(-freed); remaining < 0 {
+		// Defensive for states restored by older persistence/tests which predate
+		// explicit child accounting. All live admissions are serialized by mu.
+		idx.skipListCacheBytes.Store(0)
+	}
+	return freed
+}
+
+func (idx *StorageIndex) evictionOffer(currentSize int64) evictionOffer {
+	partial := idx.skipListCacheBytes.Load()
+	if partial < 0 {
+		partial = 0
+	}
+	if partial > currentSize {
+		partial = currentSize
+	}
+	return evictionOffer{partialBytes: partial, fullBytes: currentSize}
+}
+
+func (idx *StorageIndex) evict(mode evictionMode, currentSize int64, _ *[numEvictableTypes]int64) evictionResult {
+	if !idx.mu.TryLock() {
+		return evictionResult{}
+	}
+	defer idx.mu.Unlock()
+	if mode == evictPartial {
+		freed := idx.clearAllSkipListsLocked()
+		return evictionResult{freedBytes: freed, success: freed > 0}
+	}
+	idx.clearAllSkipListsLocked()
+	idx.baseState = storageIndexState{}
+	idx.variants = nil
+	return evictionResult{freedBytes: currentSize, fullyEvicted: true, success: true}
 }
 
 func (idx *StorageIndex) computeDeltaBtreeSize(state *storageIndexState) uint {
@@ -991,25 +1085,26 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sy
 		return uint32(int64(state.mainIndexes.GetValueUInt(pos)) + state.mainIndexes.offset)
 	}
 	sl := s.ColMatchers[colIdx].BuildSkipList(key.pattern, key.collation, s.t.main_count, getRecid, colStorage)
-	// Cache immutable match sets. sync.Map keeps the read path non-blocking and
-	// LoadOrStore prevents concurrent first users from publishing duplicates.
+	// Slow-path publication is serialized with partial/full index eviction.
+	// Hits above remain lock-free; the active query retains sl directly even if
+	// the recommendation is removed immediately afterwards.
 	cache := caches[colIdx]
+	s.mu.Lock()
+	if !s.ownsSkipListCacheLocked(cache) {
+		s.mu.Unlock()
+		sl.recordUse()
+		return sl
+	}
 	actual, loaded := cache.LoadOrStore(key, sl)
 	sl = actual.(*SkipList)
 	sl.recordUse()
-	if loaded {
-		return sl
+	if !loaded {
+		delta := skipListEntrySize(key, sl)
+		state.skipListBytes.Add(delta)
+		s.skipListCacheBytes.Add(delta)
+		GlobalCache.UpdateSizeAsync(s, delta)
 	}
-	// Register skip lists as soft sub-items of the parent index. Their bytes
-	// are already included in StorageIndex.ComputeSize for total live-RAM
-	// reporting; the separate CacheManager entry exists only so eviction can
-	// choose a cheaper sub-item before dropping the whole index.
-	if sl != nil {
-		entry := &skipListCacheEntry{index: s, colIdx: colIdx, pattern: key.pattern, collation: key.collation, cache: cache, skipList: sl}
-		// The active query owns sl directly, so removing the cache recommendation
-		// cannot invalidate its cursor. Do not impose a wall-clock grace period.
-		GlobalCache.AddItemEx(entry, int64(sl.ComputeSize()), TypeIndex, skipListCleanup, skipListLastUsed, skipListGetScore, 0, likeSkipListMaxIdle)
-	}
+	s.mu.Unlock()
 	return sl
 }
 
@@ -1355,14 +1450,7 @@ start_scan:
 // Returns false if the index lock cannot be acquired (non-blocking).
 func indexCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	idx := ptr.(*StorageIndex)
-	if !idx.mu.TryLock() {
-		return false // index is in use, skip eviction
-	}
-	GlobalCache.removeIndexChildrenInternal(idx, freedByType)
-	idx.baseState = storageIndexState{}
-	idx.variants = nil
-	idx.mu.Unlock()
-	return true
+	return idx.evict(evictFull, 0, freedByType).success
 }
 
 func indexLastUsed(ptr any) time.Time {
@@ -1372,38 +1460,4 @@ func indexLastUsed(ptr any) time.Time {
 
 func indexGetScore(ptr any) float64 {
 	return ptr.(*StorageIndex).Savings
-}
-
-// Exact terms stay useful while a user pages through results, but one-off
-// searches should not retain their match sets for the lifetime of the shard.
-const likeSkipListMaxIdle = 30 * time.Minute
-
-// skipListCacheEntry wraps a single skip list for CacheManager eviction.
-type skipListCacheEntry struct {
-	index     *StorageIndex
-	colIdx    int
-	pattern   string
-	collation string
-	cache     *sync.Map
-	skipList  *SkipList
-}
-
-func skipListCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
-	e := ptr.(*skipListCacheEntry)
-	if !e.index.mu.TryLock() {
-		return false
-	}
-	defer e.index.mu.Unlock()
-	if e.cache != nil {
-		e.cache.CompareAndDelete(skipListKey{pattern: e.pattern, collation: e.collation}, e.skipList)
-	}
-	return true
-}
-
-func skipListLastUsed(ptr any) time.Time {
-	return ptr.(*skipListCacheEntry).skipList.lastUsed()
-}
-
-func skipListGetScore(ptr any) float64 {
-	return ptr.(*skipListCacheEntry).skipList.cacheScore()
 }

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -18,6 +18,7 @@ package storage
 
 import "sync"
 import "testing"
+import "time"
 
 import "github.com/google/btree"
 import "github.com/launix-de/memcp/scm"
@@ -71,34 +72,37 @@ func TestStorageIndexComputeSizeCountsDeltaBtree(t *testing.T) {
 	}
 }
 
-func TestRemoveIndexChildrenInternalDropsSkipListRecords(t *testing.T) {
+func TestStorageIndexPartialEvictionOwnsSkipListChildren(t *testing.T) {
 	idx := &StorageIndex{}
-	other := &StorageIndex{}
-	entry := &skipListCacheEntry{index: idx, colIdx: 0, pattern: "%needle%"}
-	otherEntry := &skipListCacheEntry{index: other, colIdx: 0, pattern: "%needle%"}
-	cm := &CacheManager{
-		itemMap: map[any]*softItem{
-			entry:      {pointer: entry, size: 128, evictType: TypeIndex, heapIndex: -1},
-			otherEntry: {pointer: otherEntry, size: 64, evictType: TypeIndex, heapIndex: -1},
-		},
-		currentMemory: 192,
-		sizeByType:    [numEvictableTypes]int64{TypeIndex: 192},
-		countByType:   [numEvictableTypes]int64{TypeIndex: 2},
-	}
+	cache := new(sync.Map)
+	idx.baseState.active = true
+	idx.baseState.skipLists = []*sync.Map{cache}
+	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
+	skipList := &SkipList{}
+	cache.Store(key, skipList)
+	childBytes := skipListEntrySize(key, skipList)
+	idx.baseState.skipListBytes.Store(childBytes)
+	idx.skipListCacheBytes.Store(childBytes)
 
-	var freed [numEvictableTypes]int64
-	cm.removeIndexChildrenInternal(idx, &freed)
-	if _, ok := cm.itemMap[entry]; ok {
-		t.Fatal("skip list cache entry for removed index is still registered")
+	offer := idx.evictionOffer(childBytes + 1024)
+	if offer.partialBytes != childBytes || offer.fullBytes != childBytes+1024 {
+		t.Fatalf("offer = %+v, want partial=%d full=%d", offer, childBytes, childBytes+1024)
 	}
-	if _, ok := cm.itemMap[otherEntry]; !ok {
-		t.Fatal("skip list cache entry for other index was removed")
+	result := idx.evict(evictPartial, offer.fullBytes, new([numEvictableTypes]int64))
+	if !result.success || result.fullyEvicted || result.freedBytes != childBytes {
+		t.Fatalf("partial result = %+v", result)
 	}
-	if freed[TypeIndex] != 128 {
-		t.Fatalf("freed index bytes = %d, want 128", freed[TypeIndex])
+	if idx.baseState.skipLists[0] == cache {
+		t.Fatal("partial eviction retained the published child map")
 	}
-	if cm.currentMemory != 64 {
-		t.Fatalf("currentMemory = %d, want 64", cm.currentMemory)
+	if _, ok := idx.baseState.skipLists[0].Load(key); ok {
+		t.Fatal("replacement child map is not empty")
+	}
+	if !idx.baseState.active {
+		t.Fatal("partial eviction removed the parent index")
+	}
+	if got := idx.skipListCacheBytes.Load(); got != 0 {
+		t.Fatalf("child bytes = %d, want 0", got)
 	}
 }
 
@@ -124,38 +128,84 @@ func TestLoadCachedSkipListUsesExactTermAndTracksReuse(t *testing.T) {
 	if firstUsed.IsZero() || short.hitCount.Load() != 1 {
 		t.Fatal("exact cache hit did not update per-term lifecycle")
 	}
-	if got := skipListLastUsed(&skipListCacheEntry{skipList: short}); !got.Equal(firstUsed) {
-		t.Fatalf("cache entry last-used = %v, want term timestamp %v", got, firstUsed)
-	}
-
 	loadCachedSkipList(cache, shortKey)
 	if short.lastUsed().Before(firstUsed) {
 		t.Fatal("repeated cache hit moved last-used timestamp backwards")
 	}
-	if got := skipListGetScore(&skipListCacheEntry{skipList: short}); got != 2 {
+	if got := short.cacheScore(); got != 2 {
 		t.Fatalf("cache score = %v, want 2 exact uses", got)
 	}
 }
 
-func TestSkipListCleanupDoesNotDeleteReplacement(t *testing.T) {
+func TestStorageIndexPartialEvictionKeepsActiveQueryReference(t *testing.T) {
 	cache := &sync.Map{}
 	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
-	oldSkipList := &SkipList{}
-	replacement := &SkipList{}
-	cache.Store(key, replacement)
-	entry := &skipListCacheEntry{
-		index:     &StorageIndex{},
-		pattern:   key.pattern,
-		collation: key.collation,
-		cache:     cache,
-		skipList:  oldSkipList,
-	}
+	queryReference := &SkipList{}
+	cache.Store(key, queryReference)
+	idx := &StorageIndex{}
+	idx.baseState.active = true
+	idx.baseState.skipLists = []*sync.Map{cache}
+	idx.baseState.skipListBytes.Store(skipListEntrySize(key, queryReference))
+	idx.skipListCacheBytes.Store(skipListEntrySize(key, queryReference))
 
-	if !skipListCleanup(entry, new([numEvictableTypes]int64)) {
-		t.Fatal("skip-list cleanup unexpectedly failed")
+	result := idx.evict(evictPartial, 1024, new([numEvictableTypes]int64))
+	if !result.success {
+		t.Fatal("partial eviction failed")
 	}
-	got, ok := cache.Load(key)
-	if !ok || got != replacement {
-		t.Fatal("stale eviction removed a newer exact-term cache entry")
+	if idx.baseState.skipLists[0] == cache {
+		t.Fatal("old cache remained published on the parent")
+	}
+	if got, ok := cache.Load(key); !ok || got != queryReference {
+		t.Fatal("active query's snapshotted map was invalidated")
+	}
+	if queryReference.cursor().skip != queryReference {
+		t.Fatal("active query reference was invalidated")
+	}
+}
+
+func TestCacheManagerTracksOnlyTopLevelIndex(t *testing.T) {
+	manager := new(CacheManager)
+	manager.Init(0, 0)
+	defer manager.Stop()
+
+	cache := new(sync.Map)
+	idx := &StorageIndex{}
+	idx.baseState.active = true
+	idx.baseState.skipLists = []*sync.Map{cache}
+	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
+	skipList := &SkipList{}
+	childBytes := skipListEntrySize(key, skipList)
+	const baseBytes = int64(1024)
+	manager.AddItemEx(
+		idx,
+		baseBytes,
+		TypeIndex,
+		func(any, *[numEvictableTypes]int64) bool { return true },
+		func(any) time.Time { return time.Time{} },
+		nil,
+		0,
+		0,
+	)
+	idx.mu.Lock()
+	cache.Store(key, skipList)
+	idx.baseState.skipListBytes.Store(childBytes)
+	idx.skipListCacheBytes.Store(childBytes)
+	manager.UpdateSizeAsync(idx, childBytes)
+	idx.mu.Unlock()
+
+	before := manager.Stat()
+	if before.CountByType[TypeIndex] != 1 {
+		t.Fatalf("global index records = %d, want one top-level object", before.CountByType[TypeIndex])
+	}
+	if before.SizeByType[TypeIndex] != baseBytes+childBytes {
+		t.Fatalf("top-level size = %d, want base+children %d", before.SizeByType[TypeIndex], baseBytes+childBytes)
+	}
+	manager.UpdateBudget(baseBytes, 0)
+	after := manager.Stat()
+	if after.CountByType[TypeIndex] != 1 || after.SizeByType[TypeIndex] != baseBytes {
+		t.Fatalf("after partial eviction: count=%d size=%d", after.CountByType[TypeIndex], after.SizeByType[TypeIndex])
+	}
+	if idx.baseState.skipLists[0] == cache {
+		t.Fatal("partial pressure eviction retained published child map")
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -776,10 +776,8 @@ func shardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	}
 	// remove indexes from CacheManager (recursive free)
 	for _, idx := range s.Indexes {
-		GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 		GlobalCache.removeInternal(idx, freedByType)
-		idx.baseState = storageIndexState{}
-		idx.variants = nil
+		idx.evict(evictFull, 0, freedByType)
 	}
 	// release column storage (deregister compressed string dicts first)
 	for col := range s.columns {
@@ -806,10 +804,8 @@ func cacheShardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	}
 	// remove indexes from CacheManager (recursive free)
 	for _, idx := range s.Indexes {
-		GlobalCache.removeIndexChildrenInternal(idx, freedByType)
 		GlobalCache.removeInternal(idx, freedByType)
-		idx.baseState = storageIndexState{}
-		idx.variants = nil
+		idx.evict(evictFull, 0, freedByType)
 	}
 	// clear in-memory data (no disk backing to flush to)
 	s.inserts = nil


### PR DESCRIPTION
## Summary

- register only top-level cache objects globally and let each object own its child caches
- add offer-based two-pass eviction: partial reclamation first, then full eviction, with bounded top-k expansion when offers cannot be fulfilled
- make LIKE skip-list eviction O(columns) by detaching child maps while active queries retain safe snapshots
- replace lazy TTL references with an indexed expiry heap and account for measured sync.Map entry overhead
- add allocation and scalability benchmarks plus focused eviction/accounting tests

## Performance

- exact LIKE cache hit: ~31-32 ns/op, 0 B/op, 0 allocs/op
- partial index eviction: ~53-69 ns/op from 1k through 100k children (independent of child cardinality)
- async size accounting at 24 CPUs: ~278-293 ns/op, 0 B/op, 0 allocs/op
- measured LIKE child admission metadata: ~138-140 B/op; accounting rounds conservatively to 144 bytes

Compared with the previous per-child CacheManager registration, parent-child discovery no longer scans all global entries and every child avoids its own manager/expiry metadata.

## Validation

- make test (all suites passed)
- go test -race ./storage/ -run Test(Evict|Eviction|RemoveEagerly|StorageIndexPartial|LoadCached|CacheManagerTracks)
- go test ./... -run ^$
- targeted LIKE, prepared-statement, and prefix integration suites
- targeted cache/LIKE benchmarks, three runs each