### PR TITLE
Calibrate and explain physical membership decisions

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -861,6 +861,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query psql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query psql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query psql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (atom "DISCOVER" true) (define query psql_select)) (explain_queryplan_physical_calibrate_discover (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (atom "VARIANT" true) (define decision_id psql_string) (define variant psql_string) (define query psql_select)) (explain_queryplan_physical_calibrate_variant (sql_expand_views query policy) decision_id variant))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (define query psql_select)) (explain_queryplan_physical_calibrate (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (define query psql_select)) (explain_queryplan_physical (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (define query psql_select)) '('resultrow '('list "code" (pretty_print (optimize (build_queryplan_term (sql_expand_views query policy))) (settings "ExplainWidth")))))

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -6479,16 +6479,35 @@ source catalog. join_plan remains the single owner of physical join order. */
 			(gs_limit stage) (gs_offset stage)
 			(merge (list
 				(list
+					(list (quote membership_stage_id)
+						(qassoc_get facts (quote membership_stage_id) (gs_id stage)))
 					(list (quote physical_membership_requirement) true)
 					(list (quote membership_consumer) (qassoc_get facts (quote membership_consumer) (quote filter)))
 					(list (quote membership_candidate_input_rows) (qassoc_get facts (quote membership_candidate_input_rows) nil))
 					(list (quote membership_candidate_estimated_rows) (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
 					(list (quote membership_candidate_estimate_capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
 					(list (quote membership_candidate_estimate_input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
+					(list (quote membership_candidate_estimate_sampled) (qassoc_get facts (quote membership_candidate_estimate_sampled) nil))
+					(list (quote membership_candidate_scan_invocations) (qassoc_get facts (quote membership_candidate_scan_invocations) 1))
+					(list (quote membership_candidate_filter_columns) (qassoc_get facts (quote membership_candidate_filter_columns) 0))
+					(list (quote membership_candidate_map_columns) (qassoc_get facts (quote membership_candidate_map_columns) 1))
+					(list (quote membership_candidate_cache_map_columns) (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
+					(list (quote membership_candidate_expression_operations) (qassoc_get facts (quote membership_candidate_expression_operations) 0))
+					(list (quote membership_candidate_expression_depth) (qassoc_get facts (quote membership_candidate_expression_depth) 0))
+					(list (quote membership_candidate_filter_value_rows) (qassoc_get facts (quote membership_candidate_filter_value_rows) nil))
+					(list (quote membership_candidate_expression_operation_rows) (qassoc_get facts (quote membership_candidate_expression_operation_rows) nil))
 					(list (quote membership_driver_rows) (qassoc_get facts (quote membership_driver_rows) nil))
+					(list (quote membership_driver_input_rows) (qassoc_get facts (quote membership_driver_input_rows) nil))
+					(list (quote membership_driver_scan_invocations) (qassoc_get facts (quote membership_driver_scan_invocations) 1))
+					(list (quote membership_driver_filter_columns) (qassoc_get facts (quote membership_driver_filter_columns) 0))
+					(list (quote membership_driver_map_columns) (qassoc_get facts (quote membership_driver_map_columns) 0))
+					(list (quote membership_driver_expression_operations) (qassoc_get facts (quote membership_driver_expression_operations) 0))
+					(list (quote membership_driver_expression_depth) (qassoc_get facts (quote membership_driver_expression_depth) 0))
 					(list (quote membership_selectivity_class) (qassoc_get facts (quote membership_selectivity_class) (quote unknown)))
 					(list (quote membership_driver_alternative) (qassoc_get facts (quote membership_driver_alternative) false))
 					(list (quote membership_order_limit_driver) (qassoc_get facts (quote membership_order_limit_driver) false))
+					(list (quote membership_order_limit) (qassoc_get facts (quote membership_order_limit) nil))
+					(list (quote membership_order_offset) (qassoc_get facts (quote membership_order_offset) 0))
 					(list (quote reuse) (qassoc_get facts (quote reuse) 1)))
 				(gs_facts stage)))))))
 
@@ -6900,13 +6919,10 @@ source catalog. join_plan remains the single owner of physical join order. */
 (define planner_table_row_count (lambda (schema relation)
 	(try
 		(lambda ()
-			(define live_count (reduce (show schema true) (lambda (found row)
-				(if (not (nil? found))
-					found
-					(if (equal?? (row "name") relation)
-						(row "row_count")
-						nil)))
-				nil))
+			/* SHOW exposes shard-local row_count values. Physical choices need the
+			whole relation cardinality, which the storage table estimate already
+			aggregates across active shards. */
+			(define live_count (scan_estimate (table schema relation)))
 			(if (and (not (nil? live_count)) (> live_count 0))
 				live_count
 				(match (get_schema schema relation)
@@ -7238,6 +7254,8 @@ resulting tree in semantic order. */
 						(qassoc_get estimate (quote rows) nil)))))
 					(define input_rows (planner_add_estimates (map available (lambda (estimate)
 						(qassoc_get estimate (quote input) nil)))))
+					(define sampled_rows (planner_add_estimates (map available (lambda (estimate)
+						(qassoc_get estimate (quote sampled) nil)))))
 					(define capped (or (>= rows max_rows)
 						(reduce available (lambda (found estimate)
 							(or found (qassoc_get estimate (quote capped) false)))
@@ -7245,6 +7263,7 @@ resulting tree in semantic order. */
 					(list
 						(list (quote rows) rows)
 						(list (quote capped) capped)
+						(list (quote sampled) sampled_rows)
 						(list (quote input) input_rows)))))
 		(if (query_block? input)
 			(if (single_source? (qb_sources input))
@@ -7285,6 +7304,113 @@ resulting tree in semantic order. */
 			nil
 			(qassoc_get pushdown (quote estimated_driver_rows) nil)))))
 
+/* Physical costing needs the amount of scalar work, not a speculative copy of
+each alternative plan. This walker visits the already canonical expression
+once; get_column is a leaf because column reads are costed independently. */
+(define physical_expression_work_profile (lambda (expr)
+	(match expr
+		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+		(list (list (quote operations) 0) (list (quote depth) 0))
+		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
+		(list (list (quote operations) 0) (list (quote depth) 0))
+		(cons head tail) (begin
+			(define children (map tail physical_expression_work_profile))
+			(define own (if (symbol? head) 1 0))
+			(list
+				(list (quote operations) (+ own (reduce children (lambda (total child)
+					(+ total (qassoc_get child (quote operations) 0))) 0)))
+				(list (quote depth) (+ own (reduce children (lambda (depth child)
+					(max depth (qassoc_get child (quote depth) 0))) 0)))))
+		_ (list (list (quote operations) 0) (list (quote depth) 0)))))
+
+(define membership_source_work_profile (lambda (src condition map_expr)
+	(begin
+		(define input_rows (planner_source_row_count src))
+		(define filter_columns (extract_columns_for_alias src condition))
+		(define map_columns (extract_columns_for_alias src map_expr))
+		(define expression_work (physical_expression_work_profile condition))
+		(list
+			(list (quote scan_invocations) 1)
+			(list (quote input_rows) input_rows)
+			(list (quote filter_columns) (count filter_columns))
+			(list (quote map_columns) (count map_columns))
+			(list (quote expression_operations) (qassoc_get expression_work (quote operations) 0))
+			(list (quote expression_depth) (qassoc_get expression_work (quote depth) 0))
+			(list (quote filter_value_rows)
+				(if (number? input_rows) (* input_rows (count filter_columns)) nil))
+			(list (quote expression_operation_rows)
+				(if (number? input_rows)
+					(* input_rows (qassoc_get expression_work (quote operations) 0)) nil))))))
+
+(define membership_candidate_branch_work_profile (lambda (branch)
+	(if (and (query_block? branch) (single_real_source? (qb_sources branch)))
+		(begin
+			(define src (single_real_source (qb_sources branch)))
+			(membership_source_work_profile src
+				(combine_where (qb_where branch) (source_join_expr src))
+				(query_block_first_expr branch)))
+		nil)))
+
+(define membership_merge_candidate_work_profiles (lambda (profiles)
+	(reduce profiles (lambda (combined profile)
+		(if (nil? profile)
+			combined
+			(list
+				(list (quote scan_invocations) (+
+					(qassoc_get combined (quote scan_invocations) 0)
+					(qassoc_get profile (quote scan_invocations) 0)))
+				(list (quote input_rows) (+
+					(coalesceNil (qassoc_get combined (quote input_rows) nil) 0)
+					(coalesceNil (qassoc_get profile (quote input_rows) nil) 0)))
+				(list (quote filter_columns) (max
+					(qassoc_get combined (quote filter_columns) 0)
+					(qassoc_get profile (quote filter_columns) 0)))
+				(list (quote map_columns) (max
+					(qassoc_get combined (quote map_columns) 0)
+					(qassoc_get profile (quote map_columns) 0)))
+				(list (quote expression_operations) (max
+					(qassoc_get combined (quote expression_operations) 0)
+					(qassoc_get profile (quote expression_operations) 0)))
+				(list (quote expression_depth) (max
+					(qassoc_get combined (quote expression_depth) 0)
+					(qassoc_get profile (quote expression_depth) 0)))
+				(list (quote filter_value_rows) (+
+					(coalesceNil (qassoc_get combined (quote filter_value_rows) nil) 0)
+					(coalesceNil (qassoc_get profile (quote filter_value_rows) nil) 0)))
+				(list (quote expression_operation_rows) (+
+					(coalesceNil (qassoc_get combined (quote expression_operation_rows) nil) 0)
+					(coalesceNil (qassoc_get profile (quote expression_operation_rows) nil) 0))))))
+		'())))
+
+(define membership_candidate_work_profile (lambda (stage)
+	(begin
+		(define input (gs_input stage))
+		(if (union_block? input)
+			(membership_merge_candidate_work_profiles
+				(map (union_branches input) membership_candidate_branch_work_profile))
+			(if (query_block? input)
+				(membership_candidate_branch_work_profile input)
+				(if (source_is_base_table? input)
+					(membership_source_work_profile input
+						(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+						(gs_keys stage))
+					'()))))))
+
+(define membership_driver_work_profile (lambda (driver sources block)
+	(if (nil? driver)
+		'()
+		(begin
+			(define condition (membership_driver_local_filter driver sources block))
+			(define profile (membership_source_work_profile driver condition
+				(list (qb_fields block) (qb_group block) (qb_having block)
+					(qb_order block) (qb_hidden block))))
+			/* Stage rebinding may replace base get_column leaves before this point.
+			The output arity is still a cheap lower bound for values the scan mapper
+			must produce, and preserves the distinction between narrow and wide
+			consumers without constructing either physical alternative. */
+			(qassoc_set profile (quote map_columns)
+				(max (qassoc_get profile (quote map_columns) 0) (count (qb_fields block))))))))
+
 (define candidate_reorder_telemetry (lambda (stage sources block)
 	(begin
 		(define driver (reduce (coalesceNil sources '()) (lambda (found src)
@@ -7310,16 +7436,20 @@ resulting tree in semantic order. */
 		(define estimate_rows (qassoc_get candidate_estimate (quote rows) nil))
 		(define estimate_capped (qassoc_get candidate_estimate (quote capped) false))
 		(define estimate_input (qassoc_get candidate_estimate (quote input) nil))
+		(define estimate_sampled (qassoc_get candidate_estimate (quote sampled) nil))
 		(define estimate_ratio_broad (and
-			(and (not (nil? estimate_rows)) (and (not (nil? estimate_input)) (> estimate_input 0)))
-			(>= (* estimate_rows 4) estimate_input)))
+			(and (not (nil? estimate_rows)) (and (not (nil? estimate_sampled)) (> estimate_sampled 0)))
+			(>= (* estimate_rows 4) estimate_sampled)))
 		(define driver_alternative (membership_expr_has_driver_alternative? (qb_where block)))
 		(define class (if (or estimate_ratio_broad
 			(if driver_alternative (candidate_stage_broad? stage) false)) (quote broad) (quote selective)))
 		(define ordered_driver (if (nil? driver) false
 			(or (source_order_limit_driver? driver (qb_order block) (qb_limit block))
 				(source_row_number_limit_driver? (qb_stages block) driver))))
+		(define candidate_work (membership_candidate_work_profile stage))
+		(define driver_work (membership_driver_work_profile driver sources block))
 		(list
+			(list (quote membership_stage_id) (gs_id stage))
 			(list (quote membership_selectivity_class) class)
 			(list (quote membership_driver_rows) driver_rows)
 			(list (quote membership_driver_input_rows) driver_input_rows)
@@ -7329,9 +7459,30 @@ resulting tree in semantic order. */
 			(list (quote membership_candidate_estimated_rows) estimate_rows)
 			(list (quote membership_candidate_estimate_capped) estimate_capped)
 			(list (quote membership_candidate_estimate_input) estimate_input)
+			(list (quote membership_candidate_estimate_sampled) estimate_sampled)
 			(list (quote membership_candidate_probe_branches) candidate_probe_branches)
+			(list (quote membership_candidate_scan_invocations) (qassoc_get candidate_work (quote scan_invocations) candidate_probe_branches))
+			(list (quote membership_candidate_filter_columns) (qassoc_get candidate_work (quote filter_columns) 0))
+			(list (quote membership_candidate_map_columns) (qassoc_get candidate_work (quote map_columns) (count (gs_keys stage))))
+			(list (quote membership_candidate_cache_map_columns) (+ (count (gs_keys stage)) (count (gs_aggregates stage))))
+			(list (quote membership_candidate_expression_operations) (qassoc_get candidate_work (quote expression_operations) 0))
+			(list (quote membership_candidate_expression_depth) (qassoc_get candidate_work (quote expression_depth) 0))
+			(list (quote membership_candidate_filter_value_rows)
+				(coalesceNil (qassoc_get candidate_work (quote filter_value_rows) nil)
+					(if (number? candidate_rows)
+						(* candidate_rows (qassoc_get candidate_work (quote filter_columns) 0)) nil)))
+			(list (quote membership_candidate_expression_operation_rows)
+				(coalesceNil (qassoc_get candidate_work (quote expression_operation_rows) nil)
+					(if (number? candidate_rows)
+						(* candidate_rows (qassoc_get candidate_work (quote expression_operations) 0)) nil)))
+			(list (quote membership_driver_scan_invocations) (qassoc_get driver_work (quote scan_invocations) (if (nil? driver) 0 1)))
+			(list (quote membership_driver_filter_columns) (qassoc_get driver_work (quote filter_columns) 0))
+			(list (quote membership_driver_map_columns) (qassoc_get driver_work (quote map_columns) 0))
+			(list (quote membership_driver_expression_operations) (qassoc_get driver_work (quote expression_operations) 0))
+			(list (quote membership_driver_expression_depth) (qassoc_get driver_work (quote expression_depth) 0))
 			(list (quote membership_driver_alternative) driver_alternative)
 			(list (quote membership_order_limit) (qb_limit block))
+			(list (quote membership_order_offset) (coalesceNil (qb_offset block) 0))
 			(list (quote membership_order_limit_driver) ordered_driver)))))
 
 (define stage_reorder_telemetry (lambda (stage)
@@ -7471,6 +7622,22 @@ in the canonicalization functions above. */
 			(coalesceNil (qassoc_get estimate (quote input) nil) fallback)
 			(coalesceNil (qassoc_get estimate (quote rows) nil) fallback)))))
 
+/* A capped sample still carries measured selectivity: rows/input is the
+observed hit rate before the cap was reached. Extrapolate that rate over the
+known input instead of confusing sampled input rows with matching rows. The
+cap remains an uncertainty signal for guards and EXPLAIN. */
+(define membership_estimated_matching_rows (lambda (estimate input_rows fallback)
+	(if (nil? estimate)
+		fallback
+		(begin
+			(define rows (qassoc_get estimate (quote rows) nil))
+			(define sampled_input (qassoc_get estimate (quote sampled) nil))
+			(if (and (qassoc_get estimate (quote capped) false)
+				(and (number? input_rows)
+					(and (number? rows) (and (number? sampled_input) (> sampled_input 0)))))
+				(min input_rows (* input_rows (/ rows sampled_input)))
+				(coalesceNil rows fallback))))))
+
 (define membership_driver_filter (lambda (condition)
 	/* Only top-level conjuncts which do not contain membership are guaranteed
 	to restrict every evaluation of the membership formula. Predicates inside
@@ -7482,18 +7649,108 @@ in the canonicalization functions above. */
 			(not (expr_contains_membership_truth? term))))
 		true)))
 
-(define membership_projection_cost_preferred? (lambda (candidate_input_rows candidate_rows driver_rows)
+(define membership_work_value (lambda (work key fallback)
+	(coalesceNil (qassoc_get work key nil) fallback)))
+
+(define membership_candidate_filter_value_rows (lambda (candidate_input_rows work)
+	(membership_work_value work (quote membership_candidate_filter_value_rows)
+		(* candidate_input_rows
+			(membership_work_value work (quote membership_candidate_filter_columns) 0)))))
+
+(define membership_candidate_expression_operation_rows (lambda (candidate_input_rows work)
+	(membership_work_value work (quote membership_candidate_expression_operation_rows)
+		(* candidate_input_rows
+			(membership_work_value work (quote membership_candidate_expression_operations) 0)))))
+
+(define membership_projected_driver_rows (lambda (candidate_input_rows candidate_rows driver_rows work)
+	(begin
+		(define branches (max 1 (membership_work_value work (quote membership_candidate_probe_branches) 1)))
+		(define candidate_domain_rows (/ candidate_input_rows branches))
+		(if (> candidate_domain_rows 0)
+			(* driver_rows (min 1 (/ candidate_rows candidate_domain_rows)))
+			0))))
+
+(define membership_candidate_density (lambda (candidate_input_rows candidate_rows work)
+	(begin
+		(define branches (max 1 (membership_work_value work (quote membership_candidate_probe_branches) 1)))
+		(define candidate_domain_rows (/ candidate_input_rows branches))
+		(if (> candidate_domain_rows 0)
+			(min 1 (/ candidate_rows candidate_domain_rows))
+			0))))
+
+(define membership_driver_input_rows (lambda (driver_rows work)
+	(coalesceNil (membership_work_value work (quote membership_driver_input_rows) nil)
+		driver_rows)))
+
+/* An ordered scan can stop only after it has visited enough rows to obtain the
+requested number of membership hits. This estimate uses logical cardinalities
+and the already available predicate profile; it does not construct either
+physical alternative. */
+(define membership_expected_driver_rows_visited (lambda (candidate_input_rows candidate_rows driver_rows work)
+	(begin
+		(define driver_input_rows (membership_driver_input_rows driver_rows work))
+		(if (not (membership_work_value work (quote membership_order_limit_driver) false))
+			driver_rows
+			(begin
+				(define density (membership_candidate_density candidate_input_rows candidate_rows work))
+				(define requested_rows (+ driver_rows
+					(membership_work_value work (quote membership_order_offset) 0)))
+				(if (> density 0)
+					(min driver_input_rows (/ requested_rows density))
+					driver_input_rows))))))
+
+(define membership_common_scan_cost (lambda (candidate_input_rows candidate_rows driver_rows candidate_map_columns work)
+	(begin
+		(define scan_invocations (+
+			(membership_work_value work (quote membership_candidate_scan_invocations) 1)
+			(membership_work_value work (quote membership_driver_scan_invocations) 1)))
+		(define filter_value_rows (+
+			(membership_candidate_filter_value_rows candidate_input_rows work)
+			(* driver_rows (membership_work_value work (quote membership_driver_filter_columns) 0))))
+		(define map_value_rows (+
+			(* candidate_rows candidate_map_columns)
+			(* (membership_projected_driver_rows candidate_input_rows candidate_rows driver_rows work)
+				(membership_work_value work (quote membership_driver_map_columns) 0))))
+		(define expression_operation_rows (+
+			(membership_candidate_expression_operation_rows candidate_input_rows work)
+			(* driver_rows (membership_work_value work (quote membership_driver_expression_operations) 0))))
+		(planner_cost
+			(* scan_invocations planner_membership_scan_invocation_ns)
+			(+
+				(* (+ candidate_input_rows driver_rows) planner_membership_scan_row_ns)
+				(* filter_value_rows planner_membership_filter_column_row_ns)
+				(* map_value_rows planner_membership_map_column_row_ns)
+				(* expression_operation_rows planner_membership_expression_operation_row_ns))
+			0 0 0 0 0 0 driver_rows 0.75))))
+
+(define membership_projection_cost_preferred? (lambda (candidate_input_rows candidate_rows driver_rows work)
 	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
 		false
 		(planner_cost_better?
-			(membership_projection_cost candidate_input_rows candidate_rows)
-			(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows)))))
+			(membership_projection_cost candidate_input_rows candidate_rows driver_rows work)
+			(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows work)))))
 
-(define membership_projection_cost (lambda (candidate_input_rows candidate_rows)
-	(planner_cost planner_membership_startup_ns
-		(* candidate_input_rows planner_membership_candidate_scan_row_ns)
-		0 0 0 (* candidate_rows planner_membership_recset_build_row_ns)
-		(* candidate_rows 8) 0 candidate_rows 0.5)))
+(define membership_projection_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
+	(begin
+		/* FK projection must visit the target relation even when the downstream
+		ordered consumer accepts only a small LIMIT window. */
+		(define projection_rows (membership_driver_input_rows driver_rows work))
+		(define projected_rows (membership_projected_driver_rows
+			candidate_input_rows candidate_rows projection_rows work))
+		(define base_cost (planner_cost_add
+			(membership_common_scan_cost candidate_input_rows candidate_rows projection_rows
+				(membership_work_value work (quote membership_candidate_map_columns) 1) work)
+			(planner_cost planner_membership_recset_startup_ns 0 (* driver_rows planner_membership_recset_probe_row_ns)
+				0 0 (* (+ candidate_rows projected_rows) planner_membership_recset_build_row_ns)
+				(* (+ candidate_rows projected_rows) 8) 0 projection_rows 0.65)
+			projection_rows 0.65))
+		(if (equal? (membership_work_value work (quote membership_consumer) (quote filter))
+			(quote aggregate))
+			(planner_cost_add base_cost
+				(planner_cost 0 (* projection_rows planner_membership_recset_aggregate_row_ns)
+					0 0 0 0 0 0 projection_rows 0.65)
+				projection_rows 0.65)
+			base_cost))))
 
 (define membership_cached_driver_probe_cost (lambda (driver_rows)
 	(planner_cost 0 0 (* driver_rows 54) 0 0 0 0 0 driver_rows 0.5)))
@@ -7506,28 +7763,48 @@ in the canonicalization functions above. */
 		candidate-key index calibrated below. */
 		(planner_direct_presence_probe_cost probes))))
 
-(define membership_ordered_driver_probe_cost (lambda (candidate_input_rows candidate_rows driver_rows)
-	(planner_cost planner_membership_startup_ns
-		(* candidate_input_rows planner_membership_candidate_scan_row_ns)
-		(* driver_rows planner_membership_group_cache_probe_row_ns)
-		0 0 (* candidate_rows planner_membership_group_cache_build_row_ns)
-		(* candidate_rows 8) 0 (+ candidate_rows driver_rows) 0.5)))
+(define membership_ordered_driver_probe_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
+	(begin
+		(define visited_rows (membership_expected_driver_rows_visited
+			candidate_input_rows candidate_rows driver_rows work))
+		(define driver_input_rows (membership_driver_input_rows driver_rows work))
+		(define base_cost (planner_cost_add
+			(membership_common_scan_cost candidate_input_rows candidate_rows visited_rows
+				(membership_work_value work (quote membership_candidate_cache_map_columns) 2) work)
+			(planner_cost planner_membership_group_cache_startup_ns 0 (* visited_rows planner_membership_group_cache_probe_row_ns)
+				0 0 (* candidate_rows planner_membership_group_cache_build_row_ns)
+				(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65)
+			visited_rows 0.65))
+		(if (and (membership_work_value work (quote membership_order_limit_driver) false)
+			(not (membership_work_value work (quote membership_driver_alternative) false)))
+			(planner_cost_add base_cost
+				(planner_cost 0
+					(* (/ (* driver_input_rows driver_input_rows) 1000000)
+						planner_membership_ordered_driver_input_row_ns)
+					0 0 0 0 0 0 driver_input_rows 0.65)
+				visited_rows 0.65)
+			base_cost))))
 
-(define membership_cost_options (lambda (candidate_input_rows candidate_rows driver_rows probe_branches driver_strategy)
+(define membership_cost_options (lambda (candidate_input_rows candidate_rows driver_rows probe_branches driver_strategy work)
 	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
 		'()
 		(list
-			(list (quote candidate_keyset) (membership_projection_cost candidate_input_rows candidate_rows))
+			(list (quote candidate_keyset) (membership_projection_cost candidate_input_rows candidate_rows driver_rows work))
 			(list driver_strategy
 				(if (equal? driver_strategy (quote driver_order_membership_probe))
-					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows)
+					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows work)
 					(membership_driver_probe_cost driver_rows probe_branches)))))))
 
 (define membership_cost_options_for_telemetry (lambda (telemetry)
 	(begin
-		(define candidate_rows (if (qassoc_get telemetry (quote membership_candidate_estimate_capped) false)
-			(qassoc_get telemetry (quote membership_candidate_estimate_input) nil)
-			(qassoc_get telemetry (quote membership_candidate_estimated_rows) nil)))
+		(define candidate_rows (membership_estimated_matching_rows
+			(list
+				(list (quote rows) (qassoc_get telemetry (quote membership_candidate_estimated_rows) nil))
+				(list (quote input) (qassoc_get telemetry (quote membership_candidate_estimate_input) nil))
+				(list (quote sampled) (qassoc_get telemetry (quote membership_candidate_estimate_sampled) nil))
+				(list (quote capped) (qassoc_get telemetry (quote membership_candidate_estimate_capped) false)))
+			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)
+			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)))
 		(define driver_strategy (membership_driver_strategy_for_telemetry telemetry))
 		(define driver_rows (qassoc_get telemetry (quote membership_driver_rows) nil))
 		(define costed_driver_rows (if (equal? driver_strategy (quote driver_order_membership_probe))
@@ -7539,27 +7816,51 @@ in the canonicalization functions above. */
 			candidate_rows
 			costed_driver_rows
 			(qassoc_get telemetry (quote membership_candidate_probe_branches) 1)
-			driver_strategy))))
+			driver_strategy
+			telemetry))))
 
 (define record_membership_physical_choice (lambda (requirement strategy reason candidates)
 	(begin
 		(planner_record_physical_decision
 			(list
+				(list "decision_id" (concat "membership_carrier:"
+					(qassoc_get requirement (quote membership_stage_id) "unknown")))
 				(list "decision" "membership_carrier")
+				(list "stage" (qassoc_get requirement (quote membership_stage_id) nil))
+				(list "consumer" (string
+					(qassoc_get requirement (quote membership_consumer) (quote filter))))
 				(list "chosen" (string strategy))
 				(list "reason" (string reason))
 				(list "inputs" (list
-					(list "candidate_rows"
-						(if (qassoc_get requirement (quote membership_candidate_estimate_capped) false)
-							(qassoc_get requirement (quote membership_candidate_estimate_input) nil)
-							(qassoc_get requirement (quote membership_candidate_estimated_rows) nil)))
+					(list "candidate_rows" (membership_estimated_matching_rows
+						(list
+							(list (quote rows) (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
+							(list (quote input) (qassoc_get requirement (quote membership_candidate_estimate_input) nil))
+							(list (quote sampled) (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
+							(list (quote capped) (qassoc_get requirement (quote membership_candidate_estimate_capped) false)))
+						(qassoc_get requirement (quote membership_candidate_input_rows) nil)
+						(qassoc_get requirement (quote membership_candidate_input_rows) nil)))
 					(list "candidate_input_rows" (qassoc_get requirement (quote membership_candidate_input_rows) nil))
 					(list "driver_rows" (qassoc_get requirement (quote membership_driver_rows) nil))
 					(list "driver_input_rows" (qassoc_get requirement (quote membership_driver_input_rows) nil))
 					(list "driver_estimate_capped" (qassoc_get requirement (quote membership_driver_estimate_capped) false))
 					(list "selectivity_class" (string (qassoc_get requirement (quote membership_selectivity_class) nil)))
 					(list "estimate_capped" (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
+					(list "estimate_sampled_rows" (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
 					(list "probe_branches" (qassoc_get requirement (quote membership_candidate_probe_branches) 1))
+					(list "candidate_scan_invocations" (qassoc_get requirement (quote membership_candidate_scan_invocations) 1))
+					(list "candidate_filter_columns" (qassoc_get requirement (quote membership_candidate_filter_columns) 0))
+					(list "candidate_map_columns" (qassoc_get requirement (quote membership_candidate_map_columns) 1))
+					(list "candidate_cache_map_columns" (qassoc_get requirement (quote membership_candidate_cache_map_columns) 2))
+					(list "candidate_expression_operations" (qassoc_get requirement (quote membership_candidate_expression_operations) 0))
+					(list "candidate_expression_depth" (qassoc_get requirement (quote membership_candidate_expression_depth) 0))
+					(list "candidate_filter_value_rows" (qassoc_get requirement (quote membership_candidate_filter_value_rows) nil))
+					(list "candidate_expression_operation_rows" (qassoc_get requirement (quote membership_candidate_expression_operation_rows) nil))
+					(list "driver_scan_invocations" (qassoc_get requirement (quote membership_driver_scan_invocations) 1))
+					(list "driver_filter_columns" (qassoc_get requirement (quote membership_driver_filter_columns) 0))
+					(list "driver_map_columns" (qassoc_get requirement (quote membership_driver_map_columns) 0))
+					(list "driver_expression_operations" (qassoc_get requirement (quote membership_driver_expression_operations) 0))
+					(list "driver_expression_depth" (qassoc_get requirement (quote membership_driver_expression_depth) 0))
 					(list "reuse" (qassoc_get requirement (quote reuse) 1))))
 				(list "alternatives" (map candidates (lambda (candidate)
 					(list
@@ -7602,7 +7903,9 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define reason (if (equal? strategy (quote candidate_keyset))
 					(quote projected_membership_cost)
 					(quote indexed_driver_probe_cost)))
-				(record_membership_physical_choice requirement strategy reason candidates)
+				(if (equal? strategy (quote candidate_keyset))
+					nil
+					(record_membership_physical_choice requirement strategy reason candidates))
 				(define physical_facts (merge (list
 					(list
 						(list (quote membership_plan_strategy) strategy)
@@ -7628,13 +7931,13 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 (define membership_truth_projection_preferred? (lambda (block stage _guarded_alternative)
 	(begin
 		(define input (gs_input stage))
+		(define base_sources (filter (qb_sources block) source_is_base_table?))
 		/* Projection from the canonical group cache currently guarantees a
 		direct key map only for base-table membership stages. Derived inputs keep
 		the same primitive and use indexed existence probing until their cache-key
 		lineage is represented explicitly. A canonical simple UNION is also valid
 		for the driver probe because each branch lowers independently against the
 		current lookup key; this does not project or materialize the UNION. */
-		(define base_sources (filter (qb_sources block) source_is_base_table?))
 		(if (or
 			(or (not (source_is_base_table? input)) (not (single_source? base_sources)))
 			(not (empty_list? (group_stage_session_domain_keys stage))))
@@ -7646,7 +7949,8 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define capped (if (nil? candidate_estimate) false
 					(qassoc_get candidate_estimate (quote capped) false)))
 				(define candidate_total_rows (planner_source_row_count input))
-				(define candidate_rows (membership_estimated_work_rows candidate_estimate candidate_total_rows))
+				(define candidate_rows (membership_estimated_matching_rows
+					candidate_estimate candidate_total_rows candidate_total_rows))
 				(define driver (car base_sources))
 				(define driver_total_rows (planner_source_row_count driver))
 				(define driver_estimate (planner_source_filter_estimate driver
@@ -7682,7 +7986,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
 				(define normal_choice (if broad_driver
 					"driver_order_membership_probe"
-					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows)
+					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows (gs_facts stage))
 						"candidate_keyset"
 						"driver_order_membership_probe")))
 				(define normal_projection (equal? normal_choice projected_choice))
@@ -7690,10 +7994,10 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define chosen_projection (equal? chosen_choice projected_choice))
 				(define forced_choice (planner_physical_override decision_id))
 				(define candidate_cost (if (number? candidate_rows)
-					(membership_projection_cost candidate_total_rows candidate_rows)
+					(membership_projection_cost candidate_total_rows candidate_rows driver_rows (gs_facts stage))
 					nil))
 				(define driver_cost (if (number? driver_rows)
-					(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows)
+					(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows (gs_facts stage))
 					nil))
 				(planner_record_physical_decision
 					(list
@@ -7712,10 +8016,32 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 							(list "candidate_input_rows" candidate_total_rows)
 							(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
 							(list "candidate_rows" candidate_rows)
+							(list "candidate_density" (membership_candidate_density
+								candidate_total_rows candidate_rows (gs_facts stage)))
+							(list "projected_driver_rows"
+								(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows (gs_facts stage)))
 							(list "driver_input_rows" driver_total_rows)
 							(list "driver_rows" driver_rows)
+							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
+								candidate_total_rows candidate_rows driver_rows (gs_facts stage)))
+							(list "limit" (qb_limit block))
+							(list "offset" (coalesceNil (qb_offset block) 0))
 							(list "estimate_capped" capped)
+							(list "estimate_sampled_rows" (qassoc_get candidate_estimate (quote sampled) nil))
 							(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get (gs_facts stage) (quote selectivity_class) (quote unknown)))))
+							(list "candidate_scan_invocations" (qassoc_get (gs_facts stage) (quote membership_candidate_scan_invocations) 1))
+							(list "candidate_filter_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_filter_columns) 0))
+							(list "candidate_map_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_map_columns) 1))
+							(list "candidate_cache_map_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_cache_map_columns) 2))
+							(list "candidate_expression_operations" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_operations) 0))
+							(list "candidate_expression_depth" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_depth) 0))
+							(list "candidate_filter_value_rows" (qassoc_get (gs_facts stage) (quote membership_candidate_filter_value_rows) nil))
+							(list "candidate_expression_operation_rows" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_operation_rows) nil))
+							(list "driver_scan_invocations" (qassoc_get (gs_facts stage) (quote membership_driver_scan_invocations) 1))
+							(list "driver_filter_columns" (qassoc_get (gs_facts stage) (quote membership_driver_filter_columns) 0))
+							(list "driver_map_columns" (qassoc_get (gs_facts stage) (quote membership_driver_map_columns) 0))
+							(list "driver_expression_operations" (qassoc_get (gs_facts stage) (quote membership_driver_expression_operations) 0))
+							(list "driver_expression_depth" (qassoc_get (gs_facts stage) (quote membership_driver_expression_depth) 0))
 							(list "reuse" (qassoc_get (gs_facts stage) (quote reuse) 1))))
 						(list "alternatives" (list
 							(list
@@ -8375,13 +8701,16 @@ boolean probe, matched against the specific logical output alias. */
 								(define rewritten_sources (rewrite_scalar_first_probe_sources_using
 									(qb_stages block) sources probe_sources default_alias))
 								(define driver_sources (without_source_alias rewritten_sources (source_alias exists_src)))
-								(define probe (first_driver_lookup_key stage driver_sources))
+								(define candidate_telemetry (candidate_reorder_telemetry stage driver_sources block))
+								(define costed_stage (group_stage_with_facts stage
+									(merge (list candidate_telemetry (gs_facts stage)))))
+								(define probe (first_driver_lookup_key costed_stage driver_sources))
 								(define rewrite_consumer (lambda (expr)
 									(rewrite_scalar_first_probe_expr
 										(qb_stages block) probe_sources default_alias expr)))
 								(define base_where (rewrite_exists_recset_probe_refs
 									(source_alias exists_src)
-									stage
+									costed_stage
 									probe
 									(qb_where block)))
 								(hybrid_reorder_query_block_using stage_catalog
@@ -8399,7 +8728,7 @@ boolean probe, matched against the specific logical output alias. */
 										(candidate_stage_without_source (qb_stages block) stage_id)
 										(merge (list
 											(query_block_reorder_telemetry block)
-											(candidate_reorder_telemetry stage driver_sources block)
+											candidate_telemetry
 											(list (list (quote membership_requirement) (list
 												(list (quote access) (quote membership))
 												(list (quote reuse) 1))))
@@ -8423,7 +8752,12 @@ boolean probe, matched against the specific logical output alias. */
 								(qb_limit block)
 								(qb_offset block)
 								(qb_hidden block)
-								(map (qb_stages block) (lambda (stage) (join_reorder_stage_using stage_catalog stage)))
+								(map (qb_stages block) (lambda (current_stage)
+									(join_reorder_stage_using stage_catalog
+										(if (equal? (gs_id current_stage) (gs_id stage))
+											(group_stage_with_facts current_stage
+												(merge (list candidate_telemetry (gs_facts current_stage))))
+											current_stage))))
 								(qb_facts block))
 							facts))))))))
 
@@ -12236,6 +12570,9 @@ That makes the recorded and forced choice identical to the executable plan. */
 	(begin
 		(define stage (nth membership 0))
 		(define facts (gs_facts stage))
+		(define cost_facts (if (equal? consumer (quote aggregate))
+			(qassoc_set facts (quote membership_consumer) (quote aggregate))
+			facts))
 		(define raw_expr (recset_project_join_expr_for_membership_raw src membership))
 		(if (or (nil? raw_expr)
 			(not (or
@@ -12243,17 +12580,27 @@ That makes the recorded and forced choice identical to the executable plan. */
 				(equal? (qassoc_get facts (quote purpose) nil) (quote in_candidate)))))
 			raw_expr
 			(begin
-				(define capped (qassoc_get facts (quote membership_candidate_estimate_capped) false))
 				(define measured_estimate (planner_stage_filter_estimate (gs_input stage) 512))
+				(define capped (or
+					(qassoc_get facts (quote membership_candidate_estimate_capped) false)
+					(qassoc_get measured_estimate (quote capped) false)))
 				(define candidate_input_rows (coalesceNil
 					(qassoc_get facts (quote membership_candidate_input_rows) nil)
 					(planner_stage_input_rows (gs_input stage))))
 				(define candidate_matching_rows (coalesceNil
 					(qassoc_get facts (quote membership_candidate_estimated_rows) nil)
 					(qassoc_get measured_estimate (quote rows) nil)))
-				(define candidate_rows (if capped
-					(coalesceNil (qassoc_get facts (quote membership_candidate_estimate_input) nil) candidate_input_rows)
-					candidate_matching_rows))
+				(define candidate_rows (membership_estimated_matching_rows
+					(list
+						(list (quote rows) candidate_matching_rows)
+						(list (quote input) (coalesceNil
+							(qassoc_get facts (quote membership_candidate_estimate_input) nil)
+							(qassoc_get measured_estimate (quote input) nil)))
+						(list (quote sampled) (coalesceNil
+							(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
+							(qassoc_get measured_estimate (quote sampled) nil)))
+						(list (quote capped) capped))
+					candidate_input_rows candidate_input_rows))
 				/* Ordered LIMIT consumes only its local window before downstream
 				operators. Cost this edge with that workload instead of a global
 				driver cardinality; it is the relevant side of the plan inequality. */
@@ -12273,16 +12620,16 @@ That makes the recorded and forced choice identical to the executable plan. */
 				(define normal_choice (if guarded_broad_order_driver
 					"driver_order_membership_probe"
 					(if known
-						(if (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows)
+						(if (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows cost_facts)
 							"candidate_keyset"
 							"driver_order_membership_probe")
 						(if owns_requirement "driver_order_membership_probe" "candidate_keyset"))))
 				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
-				(define candidate_cost (if known (membership_projection_cost candidate_input_rows candidate_rows) nil))
+				(define candidate_cost (if known (membership_projection_cost candidate_input_rows candidate_rows driver_rows cost_facts) nil))
 				(define driver_cost (if known
-					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows)
+					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows cost_facts)
 					nil))
 				(planner_record_physical_decision
 					(list
@@ -12303,11 +12650,37 @@ That makes the recorded and forced choice identical to the executable plan. */
 							(list "candidate_input_rows" candidate_input_rows)
 							(list "candidate_matching_rows" candidate_matching_rows)
 							(list "candidate_rows" candidate_rows)
+							(list "candidate_density" (membership_candidate_density
+								candidate_input_rows candidate_rows facts))
+							(list "projected_driver_rows"
+								(membership_projected_driver_rows candidate_input_rows candidate_rows
+									(membership_driver_input_rows driver_rows facts) facts))
 							(list "driver_input_rows" (planner_source_row_count src))
 							(list "driver_rows" driver_rows)
+							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
+								candidate_input_rows candidate_rows driver_rows facts))
 							(list "probe_rows" driver_rows)
+							(list "limit" (qassoc_get facts (quote membership_order_limit) nil))
+							(list "offset" (qassoc_get facts (quote membership_order_offset) 0))
 							(list "estimate_capped" capped)
+							(list "estimate_sampled_rows" (coalesceNil
+								(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
+								(qassoc_get measured_estimate (quote sampled) nil)))
+							(list "probe_branches" (qassoc_get facts (quote membership_candidate_probe_branches) 1))
 							(list "selectivity_class" (string (qassoc_get facts (quote membership_selectivity_class) (quote unknown))))
+							(list "candidate_scan_invocations" (qassoc_get facts (quote membership_candidate_scan_invocations) 1))
+							(list "candidate_filter_columns" (qassoc_get facts (quote membership_candidate_filter_columns) 0))
+							(list "candidate_map_columns" (qassoc_get facts (quote membership_candidate_map_columns) 1))
+							(list "candidate_cache_map_columns" (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
+							(list "candidate_expression_operations" (qassoc_get facts (quote membership_candidate_expression_operations) 0))
+							(list "candidate_expression_depth" (qassoc_get facts (quote membership_candidate_expression_depth) 0))
+							(list "candidate_filter_value_rows" (qassoc_get facts (quote membership_candidate_filter_value_rows) nil))
+							(list "candidate_expression_operation_rows" (qassoc_get facts (quote membership_candidate_expression_operation_rows) nil))
+							(list "driver_scan_invocations" (qassoc_get facts (quote membership_driver_scan_invocations) 1))
+							(list "driver_filter_columns" (qassoc_get facts (quote membership_driver_filter_columns) 0))
+							(list "driver_map_columns" (qassoc_get facts (quote membership_driver_map_columns) 0))
+							(list "driver_expression_operations" (qassoc_get facts (quote membership_driver_expression_operations) 0))
+							(list "driver_expression_depth" (qassoc_get facts (quote membership_driver_expression_depth) 0))
 							(list "reuse" (qassoc_get facts (quote reuse) 1))))
 						(list "alternatives" (list
 							(list
@@ -14832,11 +15205,19 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
 
-(define planner_membership_startup_ns 0)
-(define planner_membership_candidate_scan_row_ns 1)
-(define planner_membership_recset_build_row_ns 15115)
-(define planner_membership_group_cache_build_row_ns 75342)
-(define planner_membership_group_cache_probe_row_ns 134910)
+(define planner_membership_scan_invocation_ns 1)
+(define planner_membership_scan_row_ns 178)
+(define planner_membership_filter_column_row_ns 1)
+(define planner_membership_map_column_row_ns 28)
+(define planner_membership_expression_operation_row_ns 98)
+(define planner_membership_recset_startup_ns 1)
+(define planner_membership_recset_build_row_ns 1)
+(define planner_membership_recset_probe_row_ns 1)
+(define planner_membership_recset_aggregate_row_ns 132)
+(define planner_membership_group_cache_startup_ns 17538872)
+(define planner_membership_group_cache_build_row_ns 11590)
+(define planner_membership_group_cache_probe_row_ns 132886)
+(define planner_membership_ordered_driver_input_row_ns 255)
 /* END GENERATED COST CONSTANTS */
 
 (define planner_direct_presence_probe_preferred? (lambda (probe_rows input_rows)
@@ -18147,7 +18528,14 @@ driver. This is physical costing metadata only; it never enters logical IR. */
 			default_alias final_condition offset_value limit_value))
 		(define membership_table_expr (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
 			nil
-			(recset_project_join_expr_for_membership src membership)))
+			(recset_project_join_expr_for_membership_using src membership
+				(if (join_scan_reduce? result_mode) (quote aggregate)
+					(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter)))
+				(and (not (empty_list? current_order_items))
+					(query_limit_active? offset_value limit_value))
+				(if (and (not (empty_list? current_order_items))
+					(query_limit_active? offset_value limit_value))
+					(probe_limit_work_rows limit_value) nil))))
 		(if (expr_contains_driver_membership? condition)
 			(planner_record_physical_decision (list
 				(list "decision" "join_leaf_membership_consumer")
@@ -20176,7 +20564,7 @@ potentially large calibrated SELECT result. */
 								nil)))
 					(list (quote define) (quote __calibration_started_ns) (list (quote nanotime)))
 					plan
-					(list (quote define) (quote __calibration_actual_ns)
+					(list (quote define) (quote __calibration_whole_query_execution_ns)
 						(list (quote -) (list (quote nanotime)) (quote __calibration_started_ns)))
 					(list (quote define) (quote __calibration_rows) (list (quote __calibration_capture) "count"))
 					(list (quote define) (quote __calibration_hash) (list (quote __calibration_capture) "hash"))
@@ -20199,10 +20587,31 @@ potentially large calibrated SELECT result. */
 							"operator_family" operator_family
 							"operator_consistent" consistent
 							"estimated_ns" estimated_ns
-							"actual_ns" (quote __calibration_actual_ns)
+							"whole_query_execution_ns" (quote __calibration_whole_query_execution_ns)
+							"operator_ns" nil
 							"candidate_input_rows" (physical_calibration_input decision "candidate_input_rows")
 							"candidate_rows" (physical_calibration_input decision "candidate_rows")
+							"candidate_density" (physical_calibration_input decision "candidate_density")
+							"projected_driver_rows" (physical_calibration_input decision "projected_driver_rows")
+							"driver_input_rows" (physical_calibration_input decision "driver_input_rows")
 							"driver_rows" (physical_calibration_input decision "driver_rows")
+							"expected_driver_rows_visited" (physical_calibration_input decision "expected_driver_rows_visited")
+							"limit" (physical_calibration_input decision "limit")
+							"offset" (physical_calibration_input decision "offset")
+							"probe_branches" (physical_calibration_input decision "probe_branches")
+							"candidate_scan_invocations" (physical_calibration_input decision "candidate_scan_invocations")
+							"candidate_filter_columns" (physical_calibration_input decision "candidate_filter_columns")
+							"candidate_map_columns" (physical_calibration_input decision "candidate_map_columns")
+							"candidate_cache_map_columns" (physical_calibration_input decision "candidate_cache_map_columns")
+							"candidate_expression_operations" (physical_calibration_input decision "candidate_expression_operations")
+							"candidate_expression_depth" (physical_calibration_input decision "candidate_expression_depth")
+							"candidate_filter_value_rows" (physical_calibration_input decision "candidate_filter_value_rows")
+							"candidate_expression_operation_rows" (physical_calibration_input decision "candidate_expression_operation_rows")
+							"driver_scan_invocations" (physical_calibration_input decision "driver_scan_invocations")
+							"driver_filter_columns" (physical_calibration_input decision "driver_filter_columns")
+							"driver_map_columns" (physical_calibration_input decision "driver_map_columns")
+							"driver_expression_operations" (physical_calibration_input decision "driver_expression_operations")
+							"driver_expression_depth" (physical_calibration_input decision "driver_expression_depth")
 							"rows" (quote __calibration_rows)
 							"result_hash" (quote __calibration_hash)
 							"result_equal" (quote __calibration_equal)))))
@@ -20227,23 +20636,85 @@ potentially large calibrated SELECT result. */
 					(nth compilation 2)
 					suite_var)))))))
 
+(define physical_membership_decision_calibratable? (lambda (decision)
+	(if (not (equal? (qassoc_get decision "decision" nil) "membership_carrier"))
+		true
+		(begin
+			(define inputs (qassoc_get decision "inputs" '()))
+			(and (not (nil? (qassoc_get decision "decision_id" nil)))
+				(and (> (count (qassoc_get decision "alternatives" '())) 1)
+					(and (number? (qassoc_get inputs "candidate_input_rows" nil))
+						(and (number? (qassoc_get inputs "candidate_rows" nil))
+							(and (number? (qassoc_get inputs "driver_input_rows" nil))
+								(number? (qassoc_get inputs "driver_rows" nil)))))))))))
+
+(define explain_queryplan_physical_calibrate_discover (lambda (query)
+	(begin
+		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
+		(define compilation (compile_physical_explain_variant reordered nil))
+		(define decisions (filter (nth compilation 1) (lambda (decision)
+			(and (physical_membership_decision_calibratable? decision)
+				(equal? (qassoc_get decision "decision" nil) "membership_carrier")))))
+		(if (empty_list? decisions)
+			(list (quote resultrow) (list (quote list)
+				"error" "no calibratable physical decision"))
+			(cons (quote !begin) (map decisions (lambda (decision)
+				(list (quote resultrow) (list (quote list)
+					"decision_id" (qassoc_get decision "decision_id" nil)
+					"decision" (qassoc_get decision "decision" nil)
+					"alternatives" (cons (quote list)
+						(map (qassoc_get decision "alternatives" '()) (lambda (alternative)
+							(qassoc_get alternative "plan" nil))))
+					"estimated_ns" (cons (quote list)
+						(map (qassoc_get decision "alternatives" '()) (lambda (alternative)
+							(qassoc_get (qassoc_get alternative "cost" '()) "total_ns" nil)))))))))))))
+
+(define explain_queryplan_physical_calibrate_variant (lambda (query decision_id variant)
+	(begin
+		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
+		(define compilation (compile_physical_explain_variant reordered
+			(list (list decision_id variant))))
+		(define decision (physical_decision_by_id (nth compilation 1) decision_id))
+		(define alternative (if (nil? decision) nil
+			(physical_decision_alternative decision variant)))
+		(if (or (nil? decision) (nil? alternative))
+			(list (quote resultrow) (list (quote list)
+				"error" "unknown physical calibration decision or variant"))
+			(begin
+				(define suite_var (quote __physical_calibration_variant_suite))
+				(list (quote !begin)
+					(list (quote define) suite_var (list (quote newsession)))
+					(physical_calibration_runtime_plan
+						(nth compilation 0)
+						decision
+						variant
+						(qassoc_get (qassoc_get alternative "cost" '()) "total_ns" nil)
+						(nth compilation 2)
+						suite_var)))))))
+
 (define explain_queryplan_physical_calibrate (lambda (query)
 	(begin
 		(define reordered (optimize_logical_query (decorrelate_logical_query query)))
 		(define default_compilation (compile_physical_explain_variant reordered nil))
+		(define uncalibratable (filter (nth default_compilation 1) (lambda (decision)
+			(not (physical_membership_decision_calibratable? decision)))))
 		(define decisions (filter (nth default_compilation 1) (lambda (decision)
 			(and (not (nil? (qassoc_get decision "decision_id" nil)))
 				(> (count (qassoc_get decision "alternatives" '())) 1)))))
-		(if (empty_list? decisions)
+		(if (not (empty_list? uncalibratable))
 			(list (quote resultrow) (list (quote list)
-				"error" "no calibratable physical decision"))
-			(begin
-				(define suite_var (quote __physical_calibration_suite))
-				(define variants (merge (map decisions (lambda (decision)
-					(physical_calibration_variants_for_decision reordered decision suite_var)))))
-				(cons (quote !begin) (cons
-					(list (quote define) suite_var (list (quote newsession)))
-					variants)))))))
+				"error" "uncalibratable physical membership decision"
+				"decision" (string (car uncalibratable))))
+			(if (empty_list? decisions)
+				(list (quote resultrow) (list (quote list)
+					"error" "no calibratable physical decision"))
+				(begin
+					(define suite_var (quote __physical_calibration_suite))
+					(define variants (merge (map decisions (lambda (decision)
+						(physical_calibration_variants_for_decision reordered decision suite_var)))))
+					(cons (quote !begin) (cons
+						(list (quote define) suite_var (list (quote newsession)))
+						variants))))))))
 
 (define explain_queryplan_physical (lambda (query)
 	(begin

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1539,6 +1539,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query sql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query sql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query sql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (atom "DISCOVER" true) (define query sql_select)) (explain_queryplan_physical_calibrate_discover (sql_expand_views query policy)))
+		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (atom "VARIANT" true) (define decision_id sql_string) (define variant sql_string) (define query sql_select)) (explain_queryplan_physical_calibrate_variant (sql_expand_views query policy) decision_id variant))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (atom "CALIBRATE" true) (define query sql_select)) (explain_queryplan_physical_calibrate (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "PHYSICAL" true) (define query sql_select)) (explain_queryplan_physical (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (define query sql_select)) '('resultrow '('list "code" (pretty_print (optimize (build_queryplan_term (sql_expand_views query policy))) (settings "ExplainWidth")))))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -547,7 +547,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(nth rebound_parent_ref 3)
 		(aggregate_col_name (car (gs_aggregates rebound_parent_stage))))
 		true "derived stage rebinding updates aggregate column handles")
-	/* scalar_first_probe_keytable_cost_preferred? safety: an unknown (non-number)
+/* scalar_first_probe_keytable_cost_preferred? safety: an unknown (non-number)
 	probe_work_rows must never be treated as "the carrier is cheaper". The shared
 	comparison (planner_direct_presence_probe_preferred?) only weighs the two
 	costs when both estimates are numbers; without a probe-count estimate, the
@@ -1763,7 +1763,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (once_fn 99) 3) true "once second call returns cached")
 	(assert (equal? (once_calls "n") 1) true "once executes only once")
 	/* a zero-arg once-wrapped builder returns a closure, not the closure's result;
-	   single-applying it to an argument just ignores that argument as noise */
+	single-applying it to an argument just ignores that argument as noise */
 	(define once_builder (once (lambda () (lambda (x) (equal? x 1)))))
 	(assert (nil? (apply once_builder (list 1))) false
 		"single-applying a zero-arg once-wrapper still returns a closure (non-nil/truthy), not the intended boolean result")

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+const scanColumnCostRows = 65536
+
+func scanColumnCostTable(b testing.TB, name string, rows int) (*table, []string) {
+	b.Helper()
+	dbName := "bench_scan_column_cost_" + name
+	databases.Remove(dbName)
+	b.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	cols := make([]string, 16)
+	for i := range cols {
+		cols[i] = fmt.Sprintf("c%d", i)
+		tbl.CreateColumn(cols[i], "INT", nil, nil)
+	}
+	if rows == 0 {
+		return tbl, cols
+	}
+	values := make([][]scm.Scmer, rows)
+	for row := range values {
+		values[row] = make([]scm.Scmer, len(cols))
+		for col := range cols {
+			values[row][col] = scm.NewInt(int64(row + col))
+		}
+	}
+	tbl.Insert(cols, values, nil, scm.NewNil(), false, nil)
+	RebuildTable(tbl, true, false)
+	return tbl, cols
+}
+
+func TestEstimateFilteredRowsReportsExaminedSample(t *testing.T) {
+	tbl, cols := scanColumnCostTable(t, "estimate_sample", 10)
+	condition := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(args[0].Int()%2 == 0)
+	})
+	shards := tbl.ActiveShards()
+	if len(shards) != 1 {
+		t.Fatalf("active shards = %d, want 1", len(shards))
+	}
+	matches, capped, sampled := shards[0].EstimateFilteredRows(cols[:1], condition, 3, nil)
+	if matches != 3 || !capped || sampled != 5 {
+		t.Fatalf("estimate = matches %d, capped %t, sampled %d; want 3, true, 5", matches, capped, sampled)
+	}
+}
+
+func TestCountEstimateSumsUnevenShards(t *testing.T) {
+	oldShardSize := Settings.ShardSize
+	Settings.ShardSize = 3
+	t.Cleanup(func() { Settings.ShardSize = oldShardSize })
+
+	tbl, _ := scanColumnCostTable(t, "count_estimate_uneven", 7)
+	if shards := len(tbl.ActiveShards()); shards < 2 {
+		t.Fatalf("active shards = %d, want a multi-shard table", shards)
+	}
+	if got := tbl.CountEstimate(); got != 7 {
+		t.Fatalf("CountEstimate() = %d, want exact uneven-shard total 7", got)
+	}
+}
+
+func benchmarkScanColumnMatrix(b *testing.B, name string, rows int, filterPasses bool, varyFilter bool) {
+	tbl, allCols := scanColumnCostTable(b, name, rows)
+	condition := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(filterPasses) })
+	callback := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewNil() })
+	for _, count := range []int{0, 1, 2, 4, 8, 16} {
+		filterCols := []string(nil)
+		mapCols := []string(nil)
+		if varyFilter {
+			filterCols = allCols[:count]
+		} else {
+			mapCols = allCols[:count]
+		}
+		b.Run(fmt.Sprintf("cols=%02d", count), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tbl.scan(nil, filterCols, condition, mapCols, callback,
+					scm.NewNil(), scm.NewNil(), scm.NewNil(), false)
+			}
+		})
+	}
+}
+
+func BenchmarkScanColumnReaderSetupFilter(b *testing.B) {
+	benchmarkScanColumnMatrix(b, "setup_filter", 0, false, true)
+}
+
+func BenchmarkScanColumnReaderSetupMap(b *testing.B) {
+	benchmarkScanColumnMatrix(b, "setup_map", 0, true, false)
+}
+
+func BenchmarkScanFilterColumnCost(b *testing.B) {
+	benchmarkScanColumnMatrix(b, "filter", scanColumnCostRows, false, true)
+}
+
+func BenchmarkScanMapColumnCost(b *testing.B) {
+	benchmarkScanColumnMatrix(b, "map", scanColumnCostRows, true, false)
+}
+
+func BenchmarkScanMapColumnCostBySelectivity(b *testing.B) {
+	tbl, allCols := scanColumnCostTable(b, "map_selectivity", scanColumnCostRows)
+	callback := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewNil() })
+	for _, percent := range []int{1, 10, 50, 100} {
+		threshold := int64(scanColumnCostRows * percent / 100)
+		condition := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+			return scm.NewBool(args[0].Int() < threshold)
+		})
+		for _, count := range []int{0, 4, 16} {
+			mapCols := allCols[:count]
+			b.Run(fmt.Sprintf("selectivity=%03d/cols=%02d", percent, count), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					tbl.scan(nil, allCols[:1], condition, mapCols, callback,
+						scm.NewNil(), scm.NewNil(), scm.NewNil(), false)
+				}
+			})
+		}
+	}
+}
+
+func scanTypedColumnCostTable(b *testing.B, name string, typ string, rows int, value func(int, int) scm.Scmer) (*table, []string) {
+	b.Helper()
+	dbName := "bench_scan_column_type_" + name
+	databases.Remove(dbName)
+	b.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	cols := make([]string, 8)
+	for i := range cols {
+		cols[i] = fmt.Sprintf("c%d", i)
+		tbl.CreateColumn(cols[i], typ, nil, nil)
+	}
+	values := make([][]scm.Scmer, rows)
+	for row := range values {
+		values[row] = make([]scm.Scmer, len(cols))
+		for col := range cols {
+			values[row][col] = value(row, col)
+		}
+	}
+	tbl.Insert(cols, values, nil, scm.NewNil(), false, nil)
+	RebuildTable(tbl, true, false)
+	return tbl, cols
+}
+
+func BenchmarkScanColumnCostByType(b *testing.B) {
+	const rows = 32768
+	types := []struct {
+		name  string
+		typ   string
+		value func(int, int) scm.Scmer
+	}{
+		{name: "int", typ: "INT", value: func(row, col int) scm.Scmer {
+			return scm.NewInt(int64(row + col))
+		}},
+		{name: "short_string", typ: "VARCHAR", value: func(row, col int) scm.Scmer {
+			return scm.NewString(fmt.Sprintf("%08x", row*17+col))
+		}},
+		{name: "long_string", typ: "VARCHAR", value: func(row, col int) scm.Scmer {
+			return scm.NewString(fmt.Sprintf("%08x-%s", row*17+col, strings.Repeat(string(rune('a'+col)), 112)))
+		}},
+	}
+	falseFn := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(false) })
+	trueFn := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	callback := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewNil() })
+	for _, kind := range types {
+		tbl, cols := scanTypedColumnCostTable(b, kind.name, kind.typ, rows, kind.value)
+		for _, phase := range []string{"filter", "map"} {
+			for _, count := range []int{0, 1, 4, 8} {
+				filterCols := []string(nil)
+				mapCols := []string(nil)
+				condition := trueFn
+				if phase == "filter" {
+					filterCols = cols[:count]
+					condition = falseFn
+				} else {
+					mapCols = cols[:count]
+				}
+				b.Run(fmt.Sprintf("type=%s/phase=%s/cols=%02d", kind.name, phase, count), func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						tbl.scan(nil, filterCols, condition, mapCols, callback,
+							scm.NewNil(), scm.NewNil(), scm.NewNil(), false)
+					}
+				})
+			}
+		}
+	}
+}
+
+func scanColumnCostPredicate(b *testing.B, terms int, distinctCols bool) scm.Scmer {
+	b.Helper()
+	parts := make([]string, terms)
+	params := []string{"c0"}
+	if distinctCols {
+		params = make([]string, terms)
+	}
+	for i := range parts {
+		col := "c0"
+		if distinctCols {
+			col = fmt.Sprintf("c%d", i)
+			params[i] = col
+		}
+		if i%2 == 0 {
+			parts[i] = fmt.Sprintf("(> %s %d)", col, -i-1)
+		} else {
+			parts[i] = fmt.Sprintf("(< %s %d)", col, scanColumnCostRows+i)
+		}
+	}
+	source := fmt.Sprintf("(lambda (%s) (and %s))", strings.Join(params, " "), strings.Join(parts, " "))
+	return scm.Eval(scm.Optimize(scm.Read("scan column cost benchmark", source), &scm.Globalenv, nil), &scm.Globalenv)
+}
+
+func BenchmarkScanFilterExpressionCost(b *testing.B) {
+	tbl, cols := scanColumnCostTable(b, "filter_expression", scanColumnCostRows)
+	callback := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewNil() })
+	for _, shape := range []string{"same_column", "distinct_columns"} {
+		for _, terms := range []int{1, 2, 4, 8, 16} {
+			distinctCols := shape == "distinct_columns"
+			condition := scanColumnCostPredicate(b, terms, distinctCols)
+			filterCols := cols[:1]
+			if distinctCols {
+				filterCols = cols[:terms]
+			}
+			b.Run(fmt.Sprintf("shape=%s/terms=%02d", shape, terms), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					tbl.scan(nil, filterCols, condition, nil, callback,
+						scm.NewNil(), scm.NewNil(), scm.NewNil(), false)
+				}
+			})
+		}
+	}
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2516,7 +2516,7 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	return
 }
 
-func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition scm.Scmer, limit int, currentTx *TxContext) (int64, bool) {
+func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition scm.Scmer, limit int, currentTx *TxContext) (int64, bool, int64) {
 	if limit <= 0 {
 		limit = 1024
 	}
@@ -2531,7 +2531,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	if recsetFilter != nil {
 		recsetPart = recsetFilter.shardEntry(t)
 		if recsetPart == nil || recsetPart.count == 0 {
-			return 0, false
+			return 0, false, 0
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
@@ -2562,6 +2562,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	count := int64(0)
+	sampled := int64(0)
 	capped := false
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
@@ -2578,6 +2579,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 			} else if t.deletions.Get(uint(idx)) {
 				continue
 			}
+			sampled++
 			if idx < mainCount {
 				for i, c := range ccols {
 					if getter := conditionGetters[i]; getter != nil {
@@ -2612,7 +2614,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		return true
 	})
 
-	return count, capped
+	return count, capped, sampled
 }
 
 func (t *storageShard) getDelta(idx int, col string) scm.Scmer {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -623,13 +623,15 @@ func Init(en scm.Env) {
 				limit = 1024
 			}
 			var rows int64
+			var sampled int64
 			capped := false
 			for _, shard := range t.ActiveShards() {
 				if shard == nil {
 					continue
 				}
-				shardRows, shardCapped := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
+				shardRows, shardCapped, shardSampled := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
 				rows += shardRows
+				sampled += shardSampled
 				if shardCapped || rows >= int64(limit) {
 					capped = true
 					break
@@ -639,6 +641,7 @@ func Init(en scm.Env) {
 			return scm.NewSlice([]scm.Scmer{
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(rows)}),
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(capped)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(sampled)}),
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
 			})
 		},

--- a/storage/table.go
+++ b/storage/table.go
@@ -1083,19 +1083,20 @@ func (t *table) Count() (result uint) {
 	return
 }
 
-// CountEstimate returns a quick estimate of the number of items by taking the
-// first shard's count and multiplying it by the number of shards. This avoids
-// iterating all shards and can be used as an inputCount estimate for planning.
+// CountEstimate returns the exact table-wide visible-row estimate. It is O(the
+// number of shards), not O(rows); summing matters because the final shard is
+// commonly partial and first-shard extrapolation can be wrong by orders of
+// magnitude after repartitioning.
 func (t *table) CountEstimate() (result uint) {
-	shards := t.ActiveShards()
-	if len(shards) == 0 {
-		return 0
+	for _, shard := range t.ActiveShards() {
+		if shard == nil {
+			continue
+		}
+		unlock := shard.GetRead()
+		result += uint(shard.Count())
+		unlock()
 	}
-	// Ensure shard is loaded and main_count initialized
-	unlock := shards[0].GetRead()
-	defer unlock()
-	c := shards[0].Count()
-	return uint(c) * uint(len(shards))
+	return result
 }
 
 /* Implement NonLockingReadMap */

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -10,36 +10,61 @@ metadata:
   isolated: true
   ci: false
   physical_calibration: true
+  cache_state: "warm_operator_state"
+  compile_state: "cached_plan_execution_only"
 
 setup:
+  - scm: '(settings "ShardSize" 125000)'
   - sql: "DROP TABLE IF EXISTS pc_files_small"
   - sql: "DROP TABLE IF EXISTS pc_docs_small"
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
-  - sql: "CREATE TABLE pc_files_small (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32))"
-  - sql: "CREATE TABLE pc_docs_small (id INT PRIMARY KEY, file_id INT, sort_key INT)"
-  - sql: "CREATE TABLE pc_files_large (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32))"
-  - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT)"
+  - sql: "DROP TABLE IF EXISTS pc_docs_million"
+  - sql: "CREATE TABLE pc_files_small (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32), f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT)"
+  - sql: "CREATE TABLE pc_docs_small (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
+  - sql: "CREATE TABLE pc_files_large (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32), f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT)"
+  - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
+  - sql: "CREATE TABLE pc_docs_million (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT) ENGINE=sloppy"
   - scm: |
       (begin
         (define make_files (lambda (n)
           (map (produceN n) (lambda (i)
             (list i
               (if (equal? (mod i 10) 0) "filename-hit" "filename-other")
-              (if (equal? (mod i 7) 0) "search-hit" "search-other"))))))
+              (if (equal? (mod i 7) 0) "search-hit" "search-other")
+              i i i i i i i i)))))
         (define make_docs (lambda (n file_count)
-          (map (produceN n) (lambda (i) (list i (mod i file_count) i)))))
-        (insert (table "memcp-tests" "pc_files_small") '("id" "filename" "search") (make_files 1000))
-        (insert (table "memcp-tests" "pc_docs_small") '("id" "file_id" "sort_key") (make_docs 4000 1000))
-        (insert (table "memcp-tests" "pc_files_large") '("id" "filename" "search") (make_files 5000))
-        (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key") (make_docs 20000 5000))
-        (rebuild))
+          (map (produceN n) (lambda (i) (list i (mod i file_count) i i i i i i i i i)))))
+        (insert (table "memcp-tests" "pc_files_small") '("id" "filename" "search" "f1" "f2" "f3" "f4" "f5" "f6" "f7" "f8") (make_files 1000))
+        (insert (table "memcp-tests" "pc_docs_small") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 4000 1000))
+        (insert (table "memcp-tests" "pc_files_large") '("id" "filename" "search" "f1" "f2" "f3" "f4" "f5" "f6" "f7" "f8") (make_files 5000))
+        (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 20000 5000)))
+  - scm: |
+      (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
+        (map (produceN 250000) (lambda (i) (list i (mod i 5000) i i))))
+  - scm: "(rebuild)"
+  - scm: |
+      (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
+        (map (produceN 250000) (lambda (i)
+          (list (+ i 250000) (mod (+ i 250000) 5000) (+ i 250000) (+ i 250000)))))
+  - scm: "(rebuild)"
+  - scm: |
+      (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
+        (map (produceN 250000) (lambda (i)
+          (list (+ i 500000) (mod (+ i 500000) 5000) (+ i 500000) (+ i 500000)))))
+  - scm: "(rebuild)"
+  - scm: |
+      (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
+        (map (produceN 250000) (lambda (i)
+          (list (+ i 750000) (mod (+ i 750000) 5000) (+ i 750000) (+ i 750000)))))
+  - scm: "(rebuild)"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_small"
   - sql: "DROP TABLE IF EXISTS pc_docs_small"
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
+  - sql: "DROP TABLE IF EXISTS pc_docs_million"
 
 test_cases:
   - name: "small broad UNION membership"
@@ -83,6 +108,7 @@ test_cases:
 
   - name: "large candidates with small driver"
     physical_calibration: true
+    calibration_holdout: true
     warmup: 1
     repetitions: 5
     sql: |
@@ -109,6 +135,7 @@ test_cases:
 
   - name: "selective membership below ordered limit one"
     physical_calibration: true
+    calibration_holdout: true
     warmup: 1
     repetitions: 5
     sql: |
@@ -121,3 +148,130 @@ test_cases:
       )
       ORDER BY d.sort_key
       LIMIT 1
+
+  - name: "ordered membership startup at limit ten"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.sort_key
+      LIMIT 10
+
+  - name: "same candidate column with several predicate operations"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f
+        WHERE f.filename LIKE '%hit%' AND f.filename IS NOT NULL AND f.filename <> 'never'
+        UNION
+        SELECT f.id FROM pc_files_large f
+        WHERE f.search LIKE '%hit%' AND f.search IS NOT NULL AND f.search <> 'never'
+      )
+
+  - name: "five candidate filter columns"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f
+        WHERE f.filename LIKE '%hit%' AND f.f1 >= 0 AND f.f2 >= 0 AND f.f3 >= 0 AND f.f4 >= 0
+        UNION
+        SELECT f.id FROM pc_files_large f
+        WHERE f.search LIKE '%hit%' AND f.f1 >= 0 AND f.f2 >= 0 AND f.f3 >= 0 AND f.f4 >= 0
+      )
+
+  - name: "four driver filter columns"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.p1 >= 0 AND d.p2 >= 0 AND d.p3 >= 0 AND d.p4 >= 0
+        AND d.file_id IN (
+          SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+          UNION
+          SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+        )
+
+  - name: "wide driver projection"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id, d.p1, d.p2, d.p3, d.p4, d.p5, d.p6, d.p7, d.p8
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+
+  - name: "mixed width holdout"
+    physical_calibration: true
+    calibration_holdout: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id, d.p1, d.p2, d.p3
+      FROM pc_docs_small d
+      WHERE d.p4 >= 0 AND d.p5 >= 0
+        AND d.file_id IN (
+          SELECT f.id FROM pc_files_large f
+          WHERE f.filename LIKE '%hit%' AND f.f1 >= 0 AND f.f2 >= 0
+          UNION
+          SELECT f.id FROM pc_files_large f
+          WHERE f.search LIKE '%hit%' AND f.f1 >= 0 AND f.f2 >= 0
+        )
+
+  - name: "million-row four-key ordered membership constraint"
+    physical_calibration: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    warmup: 0
+    repetitions: 3
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
+  - name: "million-row membership count constraint"
+    physical_calibration: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT COUNT(*)
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -71,7 +71,7 @@ setup:
         true)
 
 test_cases:
-  - name: "Selective IN branches under OR retain the ordered driver"
+  - name: "Selective IN branches under OR use projected membership recsets"
     sql: |
       EXPLAIN
       SELECT ID

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -71,7 +71,7 @@ setup:
         true)
 
 test_cases:
-  - name: "Selective IN branches under OR use projected membership recsets"
+  - name: "Selective IN branches under OR retain the ordered driver"
     sql: |
       EXPLAIN
       SELECT ID
@@ -91,11 +91,8 @@ test_cases:
       LIMIT 20
     expect:
       result_contains:
-        - "recset_project_join"
-        - "recset_union"
-        - "scan_recset"
-        - "$recset_contains"
         - "scan_order"
+        - "touch_keytable"
 
   - name: "Selective IN branches under OR preserve ordered results"
     sql: |
@@ -1241,10 +1238,25 @@ test_cases:
             - "driver_order_membership_probe"
             - "operator_consistent"
             - "estimated_ns"
-            - "actual_ns"
+            - "whole_query_execution_ns"
+            - "operator_ns"
             - "candidate_rows"
             - "driver_rows"
             - "result_equal"
+      - sql: |
+          EXPLAIN PHYSICAL
+          SELECT COUNT(*)
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+        expect:
+          contains:
+            - "membership_carrier"
+            - "consumer"
+            - "aggregate"
 
   - name: "IN UNION after derived ACL EXISTS keeps rows and lowers probes"
     fail_comment: "planner must not leak driver_membership_probe into final code or drop rows"

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -34,10 +34,13 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -48,6 +51,8 @@ const (
 	endMarker   = "/* END GENERATED COST CONSTANTS */"
 	database    = "memcp-tests"
 )
+
+var activeServer *memcpServer
 
 type syncBuffer struct {
 	mu  sync.Mutex
@@ -67,7 +72,9 @@ func (b *syncBuffer) String() string {
 }
 
 type metadata struct {
-	PhysicalCalibration bool `yaml:"physical_calibration"`
+	PhysicalCalibration bool   `yaml:"physical_calibration"`
+	CacheState          string `yaml:"cache_state"`
+	CompileState        string `yaml:"compile_state"`
 }
 
 type step struct {
@@ -76,13 +83,20 @@ type step struct {
 }
 
 type testCase struct {
-	Name                string `yaml:"name"`
-	SQL                 string `yaml:"sql"`
-	SCM                 string `yaml:"scm"`
-	PhysicalCalibration bool   `yaml:"physical_calibration"`
-	Warmup              int    `yaml:"warmup"`
-	Repetitions         int    `yaml:"repetitions"`
-	Setup               []step `yaml:"setup"`
+	Name                    string  `yaml:"name"`
+	SQL                     string  `yaml:"sql"`
+	SCM                     string  `yaml:"scm"`
+	PhysicalCalibration     bool    `yaml:"physical_calibration"`
+	CalibrationHoldout      bool    `yaml:"calibration_holdout"`
+	CalibrationDecision     string  `yaml:"calibration_decision"`
+	Race                    bool    `yaml:"race"`
+	RaceGrace               float64 `yaml:"race_grace"`
+	CacheState              string  `yaml:"cache_state"`
+	CompileState            string  `yaml:"compile_state"`
+	ExpectedDriverInputRows float64 `yaml:"expected_driver_input_rows"`
+	Warmup                  int     `yaml:"warmup"`
+	Repetitions             int     `yaml:"repetitions"`
+	Setup                   []step  `yaml:"setup"`
 }
 
 type suite struct {
@@ -94,33 +108,82 @@ type suite struct {
 }
 
 type calibrationRow struct {
-	DecisionID         string   `json:"decision_id"`
-	Decision           string   `json:"decision"`
-	Consumer           string   `json:"consumer"`
-	Plan               string   `json:"plan"`
-	OperatorFamily     string   `json:"operator_family"`
-	OperatorConsistent bool     `json:"operator_consistent"`
-	EstimatedNS        *float64 `json:"estimated_ns"`
-	ActualNS           float64  `json:"actual_ns"`
-	CandidateInputRows *float64 `json:"candidate_input_rows"`
-	CandidateRows      *float64 `json:"candidate_rows"`
-	DriverRows         *float64 `json:"driver_rows"`
-	ResultEqual        bool     `json:"result_equal"`
+	CaseName                         string   `json:"case_name"`
+	Error                            string   `json:"error"`
+	CacheState                       string   `json:"cache_state"`
+	CompileState                     string   `json:"compile_state"`
+	DecisionID                       string   `json:"decision_id"`
+	Decision                         string   `json:"decision"`
+	Consumer                         string   `json:"consumer"`
+	Plan                             string   `json:"plan"`
+	OperatorFamily                   string   `json:"operator_family"`
+	OperatorConsistent               bool     `json:"operator_consistent"`
+	EstimatedNS                      *float64 `json:"estimated_ns"`
+	WholeQueryExecutionNS            float64  `json:"whole_query_execution_ns"`
+	OperatorNS                       *float64 `json:"operator_ns"`
+	TimedOut                         bool     `json:"timed_out"`
+	LowerBoundNS                     float64  `json:"lower_bound_ns"`
+	CandidateInputRows               *float64 `json:"candidate_input_rows"`
+	CandidateRows                    *float64 `json:"candidate_rows"`
+	CandidateDensity                 *float64 `json:"candidate_density"`
+	ProjectedDriverRows              *float64 `json:"projected_driver_rows"`
+	DriverInputRows                  *float64 `json:"driver_input_rows"`
+	DriverRows                       *float64 `json:"driver_rows"`
+	ExpectedDriverRowsVisited        *float64 `json:"expected_driver_rows_visited"`
+	Limit                            *float64 `json:"limit"`
+	Offset                           *float64 `json:"offset"`
+	ProbeBranches                    *float64 `json:"probe_branches"`
+	CandidateScanInvocations         *float64 `json:"candidate_scan_invocations"`
+	CandidateFilterColumns           *float64 `json:"candidate_filter_columns"`
+	CandidateMapColumns              *float64 `json:"candidate_map_columns"`
+	CandidateCacheMapColumns         *float64 `json:"candidate_cache_map_columns"`
+	CandidateExpressionOperations    *float64 `json:"candidate_expression_operations"`
+	CandidateExpressionDepth         *float64 `json:"candidate_expression_depth"`
+	CandidateFilterValueRows         *float64 `json:"candidate_filter_value_rows"`
+	CandidateExpressionOperationRows *float64 `json:"candidate_expression_operation_rows"`
+	DriverScanInvocations            *float64 `json:"driver_scan_invocations"`
+	DriverFilterColumns              *float64 `json:"driver_filter_columns"`
+	DriverMapColumns                 *float64 `json:"driver_map_columns"`
+	DriverExpressionOperations       *float64 `json:"driver_expression_operations"`
+	DriverExpressionDepth            *float64 `json:"driver_expression_depth"`
+	ResultEqual                      bool     `json:"result_equal"`
+	Rows                             int64    `json:"rows"`
+	ResultHash                       string   `json:"result_hash"`
+}
+
+type calibrationDiscovery struct {
+	Error        string     `json:"error"`
+	DecisionID   string     `json:"decision_id"`
+	Decision     string     `json:"decision"`
+	Alternatives []string   `json:"alternatives"`
+	EstimatedNS  []*float64 `json:"estimated_ns"`
 }
 
 type observation struct {
-	caseName string
-	plan     string
-	y        float64
-	x        []float64
+	caseName        string
+	plan            string
+	y               float64
+	currentEstimate float64
+	holdout         bool
+	noiseNS         float64
+	censored        bool
+	x               []float64
 }
 
 type constants struct {
-	startupNS             int64
-	candidateScanRowNS    int64
-	candidateRecsetRowNS  int64
-	driverCacheBuildRowNS int64
-	driverCacheProbeRowNS int64
+	scanInvocationNS      int64
+	scanRowNS             int64
+	filterColumnRowNS     int64
+	mapColumnRowNS        int64
+	expressionOperationNS int64
+	recsetStartupNS       int64
+	recsetBuildRowNS      int64
+	recsetProbeRowNS      int64
+	recsetAggregateRowNS  int64
+	groupCacheStartupNS   int64
+	groupCacheBuildRowNS  int64
+	groupCacheProbeRowNS  int64
+	orderedDriverInputNS  int64
 }
 
 func main() {
@@ -139,11 +202,25 @@ func main() {
 	if len(suites) == 0 {
 		fatal(errors.New("no tests/**/*.yaml suite has metadata.physical_calibration: true"))
 	}
+	queryplanPath := filepath.Join(root, "lib", "queryplan.scm")
+	currentConstants, err := readCurrentConstants(queryplanPath)
+	if err != nil {
+		fatal(err)
+	}
 	server, err := startServer(root)
 	if err != nil {
 		fatal(err)
 	}
+	activeServer = server
 	defer server.stop()
+	interrupts := make(chan os.Signal, 1)
+	signal.Notify(interrupts, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(interrupts)
+	go func() {
+		<-interrupts
+		server.stop()
+		os.Exit(130)
+	}()
 
 	observations, raw, err := runSuites(server, suites)
 	if err != nil {
@@ -154,27 +231,59 @@ func main() {
 			fatal(err)
 		}
 	}
-	c, err := solve(observations)
+	training := filterObservations(observations, false)
+	fitTraining := filterCompleteExactPairs(training)
+	if err := validateMeasurementSignal(fitTraining); err != nil {
+		fatal(err)
+	}
+	c, err := solve(fitTraining, training, currentConstants)
 	if err != nil {
 		fatal(err)
 	}
-	if err := validateDecisionOrdering(observations, c); err != nil {
+	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("membership startup:  %d ns\ncandidate scan:      %d ns/input-row\nrecset build:        %d ns/matching-row\ngroup-cache build:   %d ns/matching-row\ngroup-cache probe:   %d ns/driver-row\n",
-		c.startupNS, c.candidateScanRowNS, c.candidateRecsetRowNS,
-		c.driverCacheBuildRowNS, c.driverCacheProbeRowNS)
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\n",
+		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
+		c.expressionOperationNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
+		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
+	printModelComparison("training", training, c)
+	holdout := filterObservations(observations, true)
+	if len(holdout) > 0 {
+		printModelComparison("holdout", holdout, c)
+		if err := validateDecisionOrdering(holdout, c); err != nil {
+			fatal(fmt.Errorf("holdout: %w", err))
+		}
+		if err := validateModelImprovement(holdout, c); err != nil {
+			fatal(fmt.Errorf("holdout: %w", err))
+		}
+	}
 	printDecisionOrdering(observations, c)
 	if *patch {
-		path := filepath.Join(root, "lib", "queryplan.scm")
-		if err := patchQueryplan(path, c); err != nil {
+		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
 		}
-		fmt.Println("patched", path)
+		fmt.Println("patched", queryplanPath)
 	}
 }
 
+func validateModelImprovement(rows []observation, c constants) error {
+	current := measureModelError(rows, func(row observation) float64 { return row.currentEstimate })
+	updated := measureModelError(rows, func(row observation) float64 { return estimatedNS(row, c) })
+	if updated.medianAbsolutePercent > current.medianAbsolutePercent || updated.meanFactor > current.meanFactor {
+		return fmt.Errorf("updated model does not improve exact holdouts: median %.1f%% -> %.1f%%, mean factor %.2fx -> %.2fx",
+			current.medianAbsolutePercent, updated.medianAbsolutePercent,
+			current.meanFactor, updated.meanFactor)
+	}
+	return nil
+}
+
 func fatal(err error) {
+	if activeServer != nil {
+		activeServer.stop()
+		activeServer = nil
+	}
 	fmt.Fprintln(os.Stderr, "costgen:", err)
 	os.Exit(1)
 }
@@ -226,12 +335,13 @@ func discoverSuites(root string) ([]suite, error) {
 }
 
 type memcpServer struct {
-	baseURL string
-	binPath string
-	dataDir string
-	cmd     *exec.Cmd
-	out     *syncBuffer
-	cancel  context.CancelFunc
+	baseURL  string
+	binPath  string
+	dataDir  string
+	cmd      *exec.Cmd
+	out      *syncBuffer
+	cancel   context.CancelFunc
+	stopOnce sync.Once
 }
 
 func startServer(root string) (*memcpServer, error) {
@@ -283,13 +393,15 @@ func startServer(root string) (*memcpServer, error) {
 }
 
 func (s *memcpServer) stop() {
-	s.cancel()
-	if s.cmd.Process != nil {
-		_ = s.cmd.Process.Kill()
-		_, _ = s.cmd.Process.Wait()
-	}
-	_ = os.Remove(s.binPath)
-	_ = os.RemoveAll(s.dataDir)
+	s.stopOnce.Do(func() {
+		s.cancel()
+		if s.cmd.Process != nil {
+			_ = s.cmd.Process.Kill()
+			_, _ = s.cmd.Process.Wait()
+		}
+		_ = os.Remove(s.binPath)
+		_ = os.RemoveAll(s.dataDir)
+	})
 }
 
 func freePort() (int, error) {
@@ -304,6 +416,10 @@ func freePort() (int, error) {
 func (s *memcpServer) execute(endpoint, body string, timeout time.Duration) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	return s.executeContext(ctx, endpoint, body)
+}
+
+func (s *memcpServer) executeContext(ctx context.Context, endpoint, body string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+endpoint, strings.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -326,11 +442,11 @@ func (s *memcpServer) execute(endpoint, body string, timeout time.Duration) ([]b
 
 func (s *memcpServer) runStep(current step) error {
 	if current.SQL != "" {
-		_, err := s.execute("/sql/"+database, current.SQL, 10*time.Minute)
+		_, err := s.execute("/sql/"+database, current.SQL, 30*time.Minute)
 		return err
 	}
 	if current.SCM != "" {
-		_, err := s.execute("/scm", current.SCM, 10*time.Minute)
+		_, err := s.execute("/scm", current.SCM, 30*time.Minute)
 		return err
 	}
 	return nil
@@ -340,16 +456,22 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 	var observations []observation
 	var allRows []calibrationRow
 	for _, currentSuite := range suites {
-		logStep("suite %s", currentSuite.Path)
+		if currentSuite.Metadata.CacheState == "" || currentSuite.Metadata.CompileState == "" {
+			return nil, nil, fmt.Errorf("%s: calibration metadata requires cache_state and compile_state", currentSuite.Path)
+		}
+		logStep("suite %s (%s, %s)", currentSuite.Path,
+			currentSuite.Metadata.CacheState, currentSuite.Metadata.CompileState)
 		for _, setup := range currentSuite.Setup {
 			if err := server.runStep(setup); err != nil {
-				return nil, nil, fmt.Errorf("%s setup: %w", currentSuite.Path, err)
+				return nil, nil, fmt.Errorf("%s setup: %w; server output: %s",
+					currentSuite.Path, err, tail(server.out.String(), 8000))
 			}
 		}
 		for _, test := range currentSuite.TestCases {
 			if !test.PhysicalCalibration {
 				continue
 			}
+			logStep("measure %s", test.Name)
 			for _, setup := range test.Setup {
 				if err := server.runStep(setup); err != nil {
 					return nil, nil, fmt.Errorf("%s/%s setup: %w", currentSuite.Path, test.Name, err)
@@ -363,38 +485,88 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 				query = "EXPLAIN PHYSICAL CALIBRATE\n" + query
 			}
 			warmup, repetitions := test.Warmup, test.Repetitions
+			cacheState, compileState := currentSuite.Metadata.CacheState, currentSuite.Metadata.CompileState
+			if test.CacheState != "" {
+				cacheState = test.CacheState
+			}
+			if test.CompileState != "" {
+				compileState = test.CompileState
+			}
 			if repetitions <= 0 {
 				repetitions = 5
 			}
 			var runs [][]calibrationRow
-			for run := 0; run < warmup+repetitions; run++ {
-				payload, err := server.execute("/sql/"+database, query, 10*time.Minute)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+			if test.Race {
+				baseQuery := strings.TrimSpace(strings.TrimPrefix(query, "EXPLAIN PHYSICAL CALIBRATE"))
+				var raceRows []calibrationRow
+				raceRuns, raceRows, raceErr := runCalibrationRaces(server, baseQuery, test, repetitions)
+				if raceErr != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, raceErr)
 				}
-				rows, err := decodeRows(payload)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s/%s: %w; response=%s", currentSuite.Path, test.Name, err, payload)
+				runs = raceRuns
+				for rowIndex := range raceRows {
+					raceRows[rowIndex].CaseName = test.Name
+					raceRows[rowIndex].CacheState = cacheState
+					raceRows[rowIndex].CompileState = compileState
 				}
-				if err := validateRows(rows); err != nil {
-					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
-				}
-				if run >= warmup {
-					runs = append(runs, rows)
-					allRows = append(allRows, rows...)
+				allRows = append(allRows, raceRows...)
+			} else {
+				for run := 0; run < warmup+repetitions; run++ {
+					payload, err := server.execute("/sql/"+database, query, 10*time.Minute)
+					if err != nil {
+						return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+					}
+					rows, err := decodeRows(payload)
+					if err != nil {
+						return nil, nil, fmt.Errorf("%s/%s: %w; response=%s", currentSuite.Path, test.Name, err, payload)
+					}
+					decision := test.CalibrationDecision
+					if decision == "" {
+						decision = "membership_carrier"
+					}
+					rows = filterCalibrationDecision(rows, decision)
+					if err := validateRows(rows); err != nil {
+						return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
+					}
+					if run >= warmup {
+						for rowIndex := range rows {
+							rows[rowIndex].CaseName = test.Name
+							rows[rowIndex].CacheState = cacheState
+							rows[rowIndex].CompileState = compileState
+						}
+						runs = append(runs, rows)
+						allRows = append(allRows, rows...)
+					}
 				}
 			}
 			medians, err := medianRows(runs)
 			if err != nil {
 				return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
 			}
+			if test.ExpectedDriverInputRows > 0 {
+				for _, row := range medians {
+					if row.DriverInputRows == nil || *row.DriverInputRows != test.ExpectedDriverInputRows {
+						actual := "nil"
+						if row.DriverInputRows != nil {
+							actual = fmt.Sprintf("%.0f", *row.DriverInputRows)
+						}
+						return nil, nil, fmt.Errorf("%s/%s: driver_input_rows=%s, want %.0f",
+							currentSuite.Path, test.Name, actual, test.ExpectedDriverInputRows)
+					}
+				}
+			}
 			for _, row := range medians {
 				features, err := rowFeatures(row)
 				if err != nil {
 					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
 				}
-				observations = append(observations, observation{caseName: test.Name, plan: row.Plan, y: row.ActualNS, x: features})
+				observations = append(observations, observation{
+					caseName: test.Name, plan: row.Plan, y: row.WholeQueryExecutionNS,
+					currentEstimate: *row.EstimatedNS, holdout: test.CalibrationHoldout,
+					noiseNS: medianAbsoluteDeviation(runs, row.Plan), censored: row.TimedOut, x: features,
+				})
 			}
+			logStep("measured %s", test.Name)
 		}
 		for _, cleanup := range currentSuite.Cleanup {
 			if err := server.runStep(cleanup); err != nil {
@@ -403,6 +575,223 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 		}
 	}
 	return observations, allRows, nil
+}
+
+func tail(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	return value[len(value)-limit:]
+}
+
+type calibrationVariantResult struct {
+	plan    string
+	row     calibrationRow
+	elapsed time.Duration
+	err     error
+}
+
+func runCalibrationRaces(server *memcpServer, query string, test testCase, repetitions int) ([][]calibrationRow, []calibrationRow, error) {
+	discoveryPayload, err := server.execute("/sql/"+database,
+		"EXPLAIN PHYSICAL CALIBRATE DISCOVER\n"+query, 10*time.Minute)
+	if err != nil {
+		return nil, nil, err
+	}
+	discovered, err := decodeDiscoveries(discoveryPayload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode calibration discovery: %w; response=%s", err, discoveryPayload)
+	}
+	decisionName := test.CalibrationDecision
+	if decisionName == "" {
+		decisionName = "membership_carrier"
+	}
+	var decision *calibrationDiscovery
+	for i := range discovered {
+		if discovered[i].Error != "" {
+			return nil, nil, errors.New(discovered[i].Error)
+		}
+		if discovered[i].Decision == decisionName {
+			if decision != nil {
+				return nil, nil, fmt.Errorf("race requires one %s decision, found several", decisionName)
+			}
+			decision = &discovered[i]
+		}
+	}
+	if decision == nil || len(decision.Alternatives) != 2 || len(decision.EstimatedNS) != 2 {
+		return nil, nil, fmt.Errorf("race discovery did not expose two costed alternatives: %+v", decision)
+	}
+	estimates := map[string]*float64{}
+	for i, plan := range decision.Alternatives {
+		estimates[plan] = decision.EstimatedNS[i]
+	}
+	grace := test.RaceGrace
+	if grace <= 0 {
+		grace = 0.5
+	}
+	var runs [][]calibrationRow
+	var raw []calibrationRow
+	for run := 0; run < repetitions; run++ {
+		rows, err := raceCalibrationVariants(server, query, decision.DecisionID,
+			decision.Alternatives, estimates, grace)
+		if err != nil {
+			return nil, nil, err
+		}
+		runs = append(runs, rows)
+		raw = append(raw, rows...)
+	}
+	return runs, raw, nil
+}
+
+func decodeDiscoveries(payload []byte) ([]calibrationDiscovery, error) {
+	var rows []calibrationDiscovery
+	if err := json.Unmarshal(payload, &rows); err == nil {
+		return rows, nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	for {
+		var row calibrationDiscovery
+		if err := decoder.Decode(&row); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) == 0 {
+		return nil, errors.New("empty calibration discovery")
+	}
+	return rows, nil
+}
+
+func raceCalibrationVariants(server *memcpServer, query, decisionID string, plans []string, estimates map[string]*float64, grace float64) ([]calibrationRow, error) {
+	result := make(chan calibrationVariantResult, 2)
+	cancels := make(map[string]context.CancelFunc, len(plans))
+	for _, plan := range plans {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels[plan] = cancel
+		go func(plan string) {
+			started := time.Now()
+			statement := "EXPLAIN PHYSICAL CALIBRATE VARIANT '" + sqlQuote(decisionID) + "' '" + sqlQuote(plan) + "'\n" + query
+			payload, err := server.executeContext(ctx, "/sql/"+database, statement)
+			row := calibrationRow{}
+			if err == nil {
+				rows, decodeErr := decodeRows(payload)
+				if decodeErr != nil || len(rows) != 1 {
+					err = fmt.Errorf("decode %s variant: %v; response=%s", plan, decodeErr, payload)
+				} else {
+					row = rows[0]
+				}
+			}
+			result <- calibrationVariantResult{plan: plan, row: row, elapsed: time.Since(started), err: err}
+		}(plan)
+	}
+	first := <-result
+	if first.err != nil {
+		for _, cancel := range cancels {
+			cancel()
+		}
+		return nil, first.err
+	}
+	if err := validateRaceWinner(first.row, decisionID, first.plan); err != nil {
+		return nil, err
+	}
+	remainingPlan := plans[0]
+	if remainingPlan == first.plan {
+		remainingPlan = plans[1]
+	}
+	remaining := time.Duration(float64(first.elapsed) * grace)
+	if remaining < time.Millisecond {
+		remaining = time.Millisecond
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	var second calibrationVariantResult
+	select {
+	case second = <-result:
+		if second.err != nil {
+			return nil, second.err
+		}
+		if err := validateRaceWinner(second.row, decisionID, second.plan); err != nil {
+			return nil, err
+		}
+		equal := first.row.Rows == second.row.Rows && first.row.ResultHash == second.row.ResultHash
+		first.row.ResultEqual, second.row.ResultEqual = equal, equal
+		if !equal {
+			return nil, fmt.Errorf("raced variants returned different results")
+		}
+	case <-timer.C:
+		cancels[remainingPlan]()
+		second = <-result
+		lowerBound := float64(first.elapsed+remaining) * float64(time.Nanosecond)
+		second = calibrationVariantResult{plan: remainingPlan, row: first.row}
+		second.row.Plan = remainingPlan
+		second.row.OperatorFamily = remainingPlan
+		second.row.EstimatedNS = estimates[remainingPlan]
+		second.row.WholeQueryExecutionNS = lowerBound
+		second.row.TimedOut = true
+		second.row.LowerBoundNS = lowerBound
+		second.row.ResultEqual = false
+		second.row.ResultHash = ""
+		second.row.Rows = 0
+	}
+	for _, cancel := range cancels {
+		cancel()
+	}
+	rows := []calibrationRow{first.row, second.row}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Plan < rows[j].Plan })
+	return rows, nil
+}
+
+func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
+	if row.Error != "" {
+		return errors.New(row.Error)
+	}
+	if row.DecisionID != decisionID || row.Plan != plan || !row.OperatorConsistent || row.OperatorFamily != plan {
+		return fmt.Errorf("forced race variant did not emit the requested operator: %+v", row)
+	}
+	if row.EstimatedNS == nil || row.CandidateInputRows == nil || row.CandidateRows == nil ||
+		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil ||
+		row.WholeQueryExecutionNS <= 0 {
+		return fmt.Errorf("forced race variant has incomplete measurements: %+v", row)
+	}
+	return nil
+}
+
+func sqlQuote(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func medianAbsoluteDeviation(runs [][]calibrationRow, plan string) float64 {
+	values := make([]float64, 0, len(runs))
+	for _, run := range runs {
+		for _, row := range run {
+			if row.Plan == plan && !row.TimedOut {
+				values = append(values, row.WholeQueryExecutionNS)
+			}
+		}
+	}
+	if len(values) == 0 {
+		return 0
+	}
+	sort.Float64s(values)
+	median := values[len(values)/2]
+	deviations := make([]float64, len(values))
+	for i, value := range values {
+		deviations[i] = math.Abs(value - median)
+	}
+	sort.Float64s(deviations)
+	return deviations[len(deviations)/2]
+}
+
+func filterCalibrationDecision(rows []calibrationRow, decision string) []calibrationRow {
+	filtered := make([]calibrationRow, 0, len(rows))
+	for _, row := range rows {
+		if row.Error != "" || row.Decision == decision {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
 }
 
 func decodeRows(payload []byte) ([]calibrationRow, error) {
@@ -428,6 +817,11 @@ func decodeRows(payload []byte) ([]calibrationRow, error) {
 }
 
 func validateRows(rows []calibrationRow) error {
+	for _, row := range rows {
+		if row.Error != "" {
+			return errors.New(row.Error)
+		}
+	}
 	if len(rows) != 2 {
 		return fmt.Errorf("expected exactly two membership alternatives, got %d", len(rows))
 	}
@@ -442,11 +836,26 @@ func validateRows(rows []calibrationRow) error {
 		if !row.ResultEqual {
 			return fmt.Errorf("forced alternative %s changed the result", row.Plan)
 		}
-		if row.CandidateInputRows == nil || row.CandidateRows == nil || row.DriverRows == nil || row.EstimatedNS == nil {
+		if row.CandidateInputRows == nil || row.CandidateRows == nil || row.CandidateDensity == nil ||
+			row.ProjectedDriverRows == nil || row.DriverInputRows == nil || row.DriverRows == nil ||
+			row.ExpectedDriverRowsVisited == nil || row.ProbeBranches == nil || row.EstimatedNS == nil {
 			return fmt.Errorf("known-statistics row contains nil inputs: %+v", row)
 		}
-		if row.ActualNS <= 0 {
-			return fmt.Errorf("invalid actual_ns for %s", row.Plan)
+		workInputs := []*float64{
+			row.CandidateScanInvocations, row.CandidateFilterColumns,
+			row.CandidateMapColumns, row.CandidateCacheMapColumns,
+			row.CandidateExpressionOperations, row.CandidateExpressionDepth,
+			row.DriverScanInvocations, row.DriverFilterColumns,
+			row.DriverMapColumns, row.DriverExpressionOperations,
+			row.DriverExpressionDepth,
+		}
+		for _, input := range workInputs {
+			if input == nil {
+				return fmt.Errorf("physical work profile contains nil inputs: %+v", row)
+			}
+		}
+		if row.WholeQueryExecutionNS <= 0 {
+			return fmt.Errorf("invalid whole_query_execution_ns for %s", row.Plan)
 		}
 		seen[row.Plan] = true
 	}
@@ -469,56 +878,231 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 		if len(rows) == 0 {
 			return nil, fmt.Errorf("no rows for %s", plan)
 		}
-		sort.Slice(rows, func(i, j int) bool { return rows[i].ActualNS < rows[j].ActualNS })
+		sort.Slice(rows, func(i, j int) bool {
+			return rows[i].WholeQueryExecutionNS < rows[j].WholeQueryExecutionNS
+		})
 		result = append(result, rows[len(rows)/2])
 	}
 	return result, nil
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	scanInvocations := *row.CandidateScanInvocations + *row.DriverScanInvocations
+	driverWorkRows := *row.DriverInputRows
+	if row.Plan == "driver_order_membership_probe" {
+		driverWorkRows = *row.ExpectedDriverRowsVisited
+	}
+	scanRows := *row.CandidateInputRows + driverWorkRows
+	candidateFilterValues := *row.CandidateInputRows * *row.CandidateFilterColumns
+	if row.CandidateFilterValueRows != nil {
+		candidateFilterValues = *row.CandidateFilterValueRows
+	}
+	candidateExpressionOperations := *row.CandidateInputRows * *row.CandidateExpressionOperations
+	if row.CandidateExpressionOperationRows != nil {
+		candidateExpressionOperations = *row.CandidateExpressionOperationRows
+	}
+	filterValues := candidateFilterValues + driverWorkRows**row.DriverFilterColumns
+	expressionOperations := candidateExpressionOperations + driverWorkRows**row.DriverExpressionOperations
+	mapColumns := *row.CandidateMapColumns
+	if row.Plan == "driver_order_membership_probe" {
+		mapColumns = *row.CandidateCacheMapColumns
+	}
+	driverMapRows := *row.ProjectedDriverRows
+	if row.Plan == "driver_order_membership_probe" {
+		driverMapRows = *row.DriverRows
+	}
+	mapValues := *row.CandidateRows*mapColumns + driverMapRows**row.DriverMapColumns
+	aggregateDriverRows := 0.0
+	if row.Consumer == "aggregate" {
+		aggregateDriverRows = *row.DriverInputRows
+	}
+	orderedDriverInputRows := 0.0
+	if row.Limit != nil {
+		orderedDriverInputRows = *row.DriverInputRows * *row.DriverInputRows / 1_000_000
+	}
 	switch row.Plan {
 	case "candidate_keyset":
-		return []float64{*row.CandidateInputRows, *row.CandidateRows, 0, 0}, nil
+		return []float64{
+			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
+			1, *row.CandidateRows + *row.ProjectedDriverRows, *row.DriverRows, 0, 0, 0,
+			aggregateDriverRows, 0,
+		}, nil
 	case "driver_order_membership_probe":
-		return []float64{*row.CandidateInputRows, 0, *row.CandidateRows, *row.DriverRows}, nil
+		return []float64{
+			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
+			0, 0, 0, 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited,
+			0, orderedDriverInputRows,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
 	}
 }
 
-// solve fits the physical work both alternatives actually perform:
+// solveEquationSystem fits the physical work both alternatives actually perform:
 //
-//	candidate = candidate_input*scan + candidate_rows*recset_build
-//	driver    = candidate_input*scan + candidate_rows*cache_build + driver_rows*cache_probe
+//	common = scan_invocations*startup + scan_rows*scan
+//	       + filter_values*filter_column + map_values*map_column
+//	       + expression_operation_rows*expression_operation
+//	candidate = recset_startup + common
+//	          + candidate_rows*recset_build + driver_rows*recset_probe
+//	driver    = group_cache_startup + common
+//	          + candidate_rows*cache_build + driver_rows*cache_probe
 //
-// Keeping candidate materialization in the driver equation prevents its cost
-// from being incorrectly absorbed into a workload-specific per-driver probe.
-// A shared startup is deliberately not fitted: it cancels from the plan
-// inequality and otherwise absorbs noise while making the row constants
-// underdetermined.
-// Non-negative coordinate descent
-// prevents noisy samples from generating impossible negative costs.
-func solve(rows []observation) (constants, error) {
-	if len(rows) < 5 {
-		return constants{}, fmt.Errorf("need at least five observations, got %d", len(rows))
+// Non-negative coordinate descent prevents noisy samples from generating
+// impossible negative costs. Weighting every equation by 1/actual^2 minimizes
+// relative rather than absolute error: otherwise multi-second driver probes
+// drown out the millisecond candidate plans whose inequality we also need to
+// predict correctly.
+func solveEquationSystem(rows []observation) (constants, error) {
+	if len(rows) < 11 {
+		return constants{}, fmt.Errorf("need at least eleven training observations, got %d", len(rows))
 	}
-	beta := []float64{1, 1, 1, 1}
+	candidateX, candidateY := make([][]float64, 0), make([]float64, 0)
+	for _, row := range rows {
+		if row.plan != "candidate_keyset" {
+			continue
+		}
+		candidateX = append(candidateX, []float64{
+			row.x[0], row.x[1], row.x[2], row.x[3], row.x[4], row.x[6],
+		})
+		// Startup and the final contains check stay at their conservative one-ns
+		// floor. Projection/build rows, unlike whole-query startup, vary across
+		// the workload and are therefore identifiable from exact winner runs.
+		candidateY = append(candidateY, math.Max(1, row.y-row.x[5]-row.x[7]))
+	}
+	common, err := fitNonnegative(candidateX, candidateY)
+	if err != nil {
+		return constants{}, fmt.Errorf("common candidate work: %w", err)
+	}
+	pairs, err := decisionPairs(rows)
+	if err != nil {
+		return constants{}, err
+	}
+	groupX, groupY := make([][]float64, 0, len(pairs)), make([]float64, 0, len(pairs))
+	for _, pair := range pairs {
+		commonDifference := 0.0
+		for i := 0; i < 5; i++ {
+			commonDifference += (pair.driver.x[i] - pair.candidate.x[i]) * common[i]
+		}
+		candidateCarrier := pair.candidate.x[5] + pair.candidate.x[6]*common[5] + pair.candidate.x[7]
+		groupX = append(groupX, pair.driver.x[8:11])
+		groupY = append(groupY, math.Max(1,
+			pair.driver.y-pair.candidate.y-commonDifference+candidateCarrier))
+	}
+	group, err := fitNonnegative(groupX, groupY)
+	if err != nil {
+		return constants{}, fmt.Errorf("paired carrier difference: %w", err)
+	}
+	beta := []float64{
+		common[0], common[1], common[2], common[3], common[4],
+		1, common[5], 1, group[0], group[1], group[2],
+	}
+	return constants{
+		scanInvocationNS:      int64(math.Round(beta[0])),
+		scanRowNS:             int64(math.Round(beta[1])),
+		filterColumnRowNS:     int64(math.Round(beta[2])),
+		mapColumnRowNS:        int64(math.Round(beta[3])),
+		expressionOperationNS: int64(math.Round(beta[4])),
+		recsetStartupNS:       int64(math.Round(beta[5])),
+		recsetBuildRowNS:      int64(math.Round(beta[6])),
+		recsetProbeRowNS:      int64(math.Round(beta[7])),
+		groupCacheStartupNS:   int64(math.Round(beta[8])),
+		groupCacheBuildRowNS:  int64(math.Round(beta[9])),
+		groupCacheProbeRowNS:  int64(math.Round(beta[10])),
+		recsetAggregateRowNS:  1,
+		orderedDriverInputNS:  1,
+	}, nil
+}
+
+// solve keeps an already calibrated base model unless a fresh unconstrained
+// equation fit improves both its numerical error and its plan inequalities.
+// The two large-shape additions are fitted separately because a cancelled race
+// yields an inequality, not an exact duration: y_slow is only known to exceed
+// lower_bound_ns.
+func solve(exactRows, allRows []observation, baseline constants) (constants, error) {
+	fitted, err := solveEquationSystem(exactRows)
+	if err != nil {
+		return constants{}, err
+	}
+	selected := baseline
+	baseError := measureModelError(exactRows, func(row observation) float64 {
+		return estimatedNS(row, baseline)
+	})
+	fitError := measureModelError(exactRows, func(row observation) float64 {
+		return estimatedNS(row, fitted)
+	})
+	baseCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
+		return estimatedNS(row, baseline)
+	})
+	fitCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
+		return estimatedNS(row, fitted)
+	})
+	if fitError.medianAbsolutePercent <= baseError.medianAbsolutePercent &&
+		fitError.meanFactor <= baseError.meanFactor && fitCorrect >= baseCorrect {
+		selected = fitted
+	}
+
+	if value, ok := fitExactResidualPerRow(allRows, selected, 11); ok {
+		selected.recsetAggregateRowNS = value
+	}
+	// A timed-out slower ordered alternative contributes lower_bound <= cost.
+	// Choose the smallest coefficient satisfying every observed constraint.
+	for _, row := range allRows {
+		if !row.censored || len(row.x) <= 12 || row.x[12] <= 0 {
+			continue
+		}
+		without := selected
+		without.orderedDriverInputNS = 0
+		required := int64(math.Ceil((row.y - estimatedNS(row, without)) / row.x[12]))
+		if required > selected.orderedDriverInputNS {
+			selected.orderedDriverInputNS = required
+		}
+	}
+	return selected, nil
+}
+
+func fitExactResidualPerRow(rows []observation, c constants, feature int) (int64, bool) {
+	values := make([]float64, 0)
+	for _, row := range rows {
+		if row.censored || len(row.x) <= feature || row.x[feature] <= 0 {
+			continue
+		}
+		without := c
+		without.recsetAggregateRowNS = 0
+		values = append(values, math.Max(1, (row.y-estimatedNS(row, without))/row.x[feature]))
+	}
+	if len(values) == 0 {
+		return 0, false
+	}
+	sort.Float64s(values)
+	return int64(math.Round(values[len(values)/2])), true
+}
+
+func fitNonnegative(x [][]float64, y []float64) ([]float64, error) {
+	if len(x) == 0 || len(x) != len(y) {
+		return nil, errors.New("invalid equation matrix")
+	}
+	beta := make([]float64, len(x[0]))
+	for i := range beta {
+		beta[i] = 1
+	}
 	for iteration := 0; iteration < 10000; iteration++ {
 		largestChange := 0.0
 		for column := range beta {
 			numerator, denominator := 0.0, 0.0
-			for _, row := range rows {
-				residual := row.y
+			for rowIndex, features := range x {
+				weight := 1 / math.Max(1, y[rowIndex]*y[rowIndex])
+				residual := y[rowIndex]
 				for other, value := range beta {
 					if other != column {
-						residual -= row.x[other] * value
+						residual -= features[other] * value
 					}
 				}
-				numerator += row.x[column] * residual
-				denominator += row.x[column] * row.x[column]
+				numerator += weight * features[column] * residual
+				denominator += weight * features[column] * features[column]
 			}
 			if denominator == 0 {
-				return constants{}, fmt.Errorf("cost equation column %d is not covered", column)
+				return nil, fmt.Errorf("cost equation column %d is not covered", column)
 			}
 			next := numerator / denominator
 			if next < 1 {
@@ -537,27 +1121,157 @@ func solve(rows []observation) (constants, error) {
 			break
 		}
 	}
-	return constants{
-		startupNS:             0,
-		candidateScanRowNS:    int64(math.Round(beta[0])),
-		candidateRecsetRowNS:  int64(math.Round(beta[1])),
-		driverCacheBuildRowNS: int64(math.Round(beta[2])),
-		driverCacheProbeRowNS: int64(math.Round(beta[3])),
-	}, nil
+	return beta, nil
 }
 
 func estimatedNS(row observation, c constants) float64 {
 	beta := []float64{
-		float64(c.candidateScanRowNS),
-		float64(c.candidateRecsetRowNS),
-		float64(c.driverCacheBuildRowNS),
-		float64(c.driverCacheProbeRowNS),
+		float64(c.scanInvocationNS),
+		float64(c.scanRowNS),
+		float64(c.filterColumnRowNS),
+		float64(c.mapColumnRowNS),
+		float64(c.expressionOperationNS),
+		float64(c.recsetStartupNS),
+		float64(c.recsetBuildRowNS),
+		float64(c.recsetProbeRowNS),
+		float64(c.groupCacheStartupNS),
+		float64(c.groupCacheBuildRowNS),
+		float64(c.groupCacheProbeRowNS),
+		float64(c.recsetAggregateRowNS),
+		float64(c.orderedDriverInputNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
 		total += value * beta[i]
 	}
 	return total
+}
+
+func filterObservations(rows []observation, holdout bool) []observation {
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if row.holdout == holdout {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func filterExactObservations(rows []observation) []observation {
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if !row.censored {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func filterCompleteExactPairs(rows []observation) []observation {
+	censoredCases := make(map[string]bool)
+	for _, row := range rows {
+		if row.censored {
+			censoredCases[row.caseName] = true
+		}
+	}
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if !censoredCases[row.caseName] {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+type modelError struct {
+	medianAbsolutePercent float64
+	p90AbsolutePercent    float64
+	meanFactor            float64
+}
+
+func measureModelError(rows []observation, estimate func(observation) float64) modelError {
+	percentErrors := make([]float64, 0, len(rows))
+	factorTotal := 0.0
+	exactCount := 0
+	for _, row := range rows {
+		if row.censored {
+			continue
+		}
+		predicted := math.Max(1, estimate(row))
+		actual := math.Max(1, row.y)
+		percentErrors = append(percentErrors, math.Abs(predicted-actual)/actual*100)
+		factorTotal += math.Max(predicted/actual, actual/predicted)
+		exactCount++
+	}
+	sort.Float64s(percentErrors)
+	if len(percentErrors) == 0 {
+		return modelError{}
+	}
+	p90Index := int(math.Ceil(float64(len(percentErrors))*0.9)) - 1
+	return modelError{
+		medianAbsolutePercent: percentErrors[len(percentErrors)/2],
+		p90AbsolutePercent:    percentErrors[p90Index],
+		meanFactor:            factorTotal / float64(exactCount),
+	}
+}
+
+func decisionAccuracy(rows []observation, estimate func(observation) float64) (int, int) {
+	pairs, err := decisionPairs(rows)
+	if err != nil {
+		return 0, 0
+	}
+	correct := 0
+	for _, pair := range pairs {
+		if (pair.candidate.y < pair.driver.y) == (estimate(pair.candidate) < estimate(pair.driver)) {
+			correct++
+		}
+	}
+	return correct, len(pairs)
+}
+
+func printModelComparison(label string, rows []observation, c constants) {
+	models := []struct {
+		name     string
+		estimate func(observation) float64
+	}{
+		{name: "current", estimate: func(row observation) float64 { return row.currentEstimate }},
+		{name: "updated", estimate: func(row observation) float64 { return estimatedNS(row, c) }},
+	}
+	for _, model := range models {
+		err := measureModelError(rows, model.estimate)
+		correct, total := decisionAccuracy(rows, model.estimate)
+		fmt.Printf("model %-8s %-7s median-abs-error=%6.1f%% p90-abs-error=%6.1f%% mean-factor=%5.2fx decisions=%d/%d\n",
+			label, model.name, err.medianAbsolutePercent, err.p90AbsolutePercent,
+			err.meanFactor, correct, total)
+	}
+	for _, row := range rows {
+		updated := estimatedNS(row, c)
+		if row.censored {
+			fmt.Printf("estimate %-8s %-42s %-30s whole-query>%8.3fms timed-out current=%9.3fms updated=%9.3fms\n",
+				label, row.caseName, row.plan, row.y/1e6, row.currentEstimate/1e6, updated/1e6)
+			continue
+		}
+		fmt.Printf("estimate %-8s %-42s %-30s whole-query=%9.3fms mad=%7.3fms current=%9.3fms (%+7.1f%%) updated=%9.3fms (%+7.1f%%)\n",
+			label, row.caseName, row.plan, row.y/1e6, row.noiseNS/1e6,
+			row.currentEstimate/1e6, (row.currentEstimate-row.y)/row.y*100,
+			updated/1e6, (updated-row.y)/row.y*100)
+	}
+}
+
+func validateMeasurementSignal(rows []observation) error {
+	pairs, err := decisionPairs(rows)
+	if err != nil {
+		return err
+	}
+	for name, pair := range pairs {
+		difference := math.Abs(pair.driver.y - pair.candidate.y)
+		noise := 3 * (pair.driver.noiseNS + pair.candidate.noiseNS)
+		if difference <= noise {
+			return fmt.Errorf("%q has no calibratable A/B signal: difference %.3fms <= 3*(MAD candidate + driver) %.3fms",
+				name, difference/1e6, noise/1e6)
+		}
+	}
+	return nil
 }
 
 type decisionPair struct {
@@ -651,6 +1365,56 @@ func writeJSONL(path string, rows []calibrationRow) error {
 	return os.WriteFile(path, output.Bytes(), 0o644)
 }
 
+func readCurrentConstants(path string) (constants, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return constants{}, err
+	}
+	names := []string{
+		"planner_membership_scan_invocation_ns",
+		"planner_membership_scan_row_ns",
+		"planner_membership_filter_column_row_ns",
+		"planner_membership_map_column_row_ns",
+		"planner_membership_expression_operation_row_ns",
+		"planner_membership_recset_startup_ns",
+		"planner_membership_recset_build_row_ns",
+		"planner_membership_recset_probe_row_ns",
+		"planner_membership_recset_aggregate_row_ns",
+		"planner_membership_group_cache_startup_ns",
+		"planner_membership_group_cache_build_row_ns",
+		"planner_membership_group_cache_probe_row_ns",
+		"planner_membership_ordered_driver_input_row_ns",
+	}
+	values := make([]int64, len(names))
+	content := string(data)
+	for i, name := range names {
+		prefix := "(define " + name + " "
+		start := strings.Index(content, prefix)
+		if start < 0 {
+			return constants{}, fmt.Errorf("cost constant %s not found", name)
+		}
+		start += len(prefix)
+		end := strings.IndexByte(content[start:], ')')
+		if end < 0 {
+			return constants{}, fmt.Errorf("cost constant %s is unterminated", name)
+		}
+		value, err := strconv.ParseInt(strings.TrimSpace(content[start:start+end]), 10, 64)
+		if err != nil {
+			return constants{}, fmt.Errorf("cost constant %s: %w", name, err)
+		}
+		values[i] = value
+	}
+	return constants{
+		scanInvocationNS: values[0], scanRowNS: values[1],
+		filterColumnRowNS: values[2], mapColumnRowNS: values[3],
+		expressionOperationNS: values[4], recsetStartupNS: values[5],
+		recsetBuildRowNS: values[6], recsetProbeRowNS: values[7],
+		recsetAggregateRowNS: values[8], groupCacheStartupNS: values[9],
+		groupCacheBuildRowNS: values[10], groupCacheProbeRowNS: values[11],
+		orderedDriverInputNS: values[12],
+	}, nil
+}
+
 func patchQueryplan(path string, c constants) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -678,12 +1442,23 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
 
-(define planner_membership_startup_ns %d)
-(define planner_membership_candidate_scan_row_ns %d)
+(define planner_membership_scan_invocation_ns %d)
+(define planner_membership_scan_row_ns %d)
+(define planner_membership_filter_column_row_ns %d)
+(define planner_membership_map_column_row_ns %d)
+(define planner_membership_expression_operation_row_ns %d)
+(define planner_membership_recset_startup_ns %d)
 (define planner_membership_recset_build_row_ns %d)
+(define planner_membership_recset_probe_row_ns %d)
+(define planner_membership_recset_aggregate_row_ns %d)
+(define planner_membership_group_cache_startup_ns %d)
 (define planner_membership_group_cache_build_row_ns %d)
 (define planner_membership_group_cache_probe_row_ns %d)
-/* END GENERATED COST CONSTANTS */`, c.startupNS, c.candidateScanRowNS,
-		c.candidateRecsetRowNS, c.driverCacheBuildRowNS, c.driverCacheProbeRowNS)
+(define planner_membership_ordered_driver_input_row_ns %d)
+/* END GENERATED COST CONSTANTS */`, c.scanInvocationNS, c.scanRowNS,
+		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS,
+		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
+		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -9,30 +9,34 @@ the Free Software Foundation, either version 3 of the License, or
 
 package main
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
 
-func TestSolvePhysicalCostEquation(t *testing.T) {
-	want := constants{
-		startupNS: 0, candidateScanRowNS: 5, candidateRecsetRowNS: 20,
-		driverCacheBuildRowNS: 30, driverCacheProbeRowNS: 80,
+func TestFitNonnegativePhysicalCostEquation(t *testing.T) {
+	coefficients := []float64{2, 3, 4, 5, 6}
+	x := make([][]float64, len(coefficients))
+	y := make([]float64, len(coefficients))
+	for i, coefficient := range coefficients {
+		features := make([]float64, len(coefficients))
+		features[i] = 100
+		x[i] = features
+		y[i] = 100 * coefficient
 	}
-	rows := []observation{
-		{caseName: "a", plan: "candidate_keyset", x: []float64{100, 10, 0, 0}, y: 100*5 + 10*20},
-		{caseName: "b", plan: "candidate_keyset", x: []float64{1000, 100, 0, 0}, y: 1000*5 + 100*20},
-		{caseName: "c", plan: "candidate_keyset", x: []float64{1000, 800, 0, 0}, y: 1000*5 + 800*20},
-		{caseName: "a", plan: "driver_order_membership_probe", x: []float64{100, 0, 10, 100}, y: 100*5 + 10*30 + 100*80},
-		{caseName: "b", plan: "driver_order_membership_probe", x: []float64{1000, 0, 100, 1000}, y: 1000*5 + 100*30 + 1000*80},
-		{caseName: "c", plan: "driver_order_membership_probe", x: []float64{1000, 0, 800, 4000}, y: 1000*5 + 800*30 + 4000*80},
-	}
-	got, err := solve(rows)
+	got, err := fitNonnegative(x, y)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != want {
-		t.Fatalf("solve() = %+v, want %+v", got, want)
-	}
-	if err := validateDecisionOrdering(rows, got); err != nil {
-		t.Fatal(err)
+	for i := range got {
+		if got[i] != coefficients[i] {
+			t.Fatalf("fit[%d] = %f, want %f", i, got[i], coefficients[i])
+		}
 	}
 }
 
@@ -42,12 +46,49 @@ func TestValidateRowsRejectsDecisionPlanMismatch(t *testing.T) {
 		{
 			DecisionID: "membership_carrier:1", Decision: "membership_carrier",
 			Plan: "candidate_keyset", OperatorFamily: "driver_order_membership_probe",
-			OperatorConsistent: false, EstimatedNS: &estimated, ActualNS: 200,
+			OperatorConsistent: false, EstimatedNS: &estimated, WholeQueryExecutionNS: 200,
 			CandidateInputRows: &candidateInput, CandidateRows: &candidateRows,
 			DriverRows: &driverRows, ResultEqual: true,
 		},
 	}
 	if err := validateRows(rows); err == nil {
 		t.Fatal("validateRows accepted a chosen/emitted operator mismatch")
+	}
+}
+
+func TestRaceCalibrationVariantsCancelsSlowerPlan(t *testing.T) {
+	const decisionID = "membership_carrier:test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		plan := "candidate_keyset"
+		if strings.Contains(string(body), "driver_order_membership_probe") {
+			plan = "driver_order_membership_probe"
+			<-r.Context().Done()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+		fmt.Fprintf(w, `{"decision_id":%q,"decision":"membership_carrier","plan":%q,"operator_family":%q,"operator_consistent":true,"estimated_ns":100,"whole_query_execution_ns":1000000,"candidate_input_rows":100,"candidate_rows":10,"candidate_density":0.1,"projected_driver_rows":100,"driver_input_rows":1000,"driver_rows":10,"expected_driver_rows_visited":100,"rows":1,"result_hash":"same"}`,
+			decisionID, plan, plan)
+	}))
+	defer server.Close()
+
+	fastEstimate, slowEstimate := 100.0, 1000.0
+	memcp := &memcpServer{baseURL: server.URL}
+	started := time.Now()
+	rows, err := raceCalibrationVariants(memcp, "SELECT 1", decisionID,
+		[]string{"candidate_keyset", "driver_order_membership_probe"},
+		map[string]*float64{"candidate_keyset": &fastEstimate, "driver_order_membership_probe": &slowEstimate}, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(started) > 250*time.Millisecond {
+		t.Fatalf("race did not cancel the slower plan promptly: %s", time.Since(started))
+	}
+	if len(rows) != 2 || rows[0].Plan != "candidate_keyset" || rows[0].TimedOut ||
+		rows[1].Plan != "driver_order_membership_probe" || !rows[1].TimedOut {
+		t.Fatalf("unexpected race rows: %+v", rows)
+	}
+	if rows[1].LowerBoundNS <= rows[0].WholeQueryExecutionNS {
+		t.Fatalf("timeout lower bound %f must exceed winner time %f", rows[1].LowerBoundNS, rows[0].WholeQueryExecutionNS)
 	}
 }


### PR DESCRIPTION
## Summary
- make EXPLAIN PHYSICAL report stable, operator-consistent membership decisions with local cardinalities, rejected alternatives, formula work and exact cost components
- add EXPLAIN PHYSICAL CALIBRATE discovery/forced-variant execution plus paired parallel races that cancel the slower plan after a 50% winner-time grace period
- extend tools/costgen into one tagged-workload runner that measures, validates, reports current versus updated model error/ranking, solves nonnegative costs and rewrites generated planner constants
- add column/filter/map/expression microbenchmarks and calibration workloads through one million driver rows
- fix table-wide cardinality estimates across uneven shards and recalibrate planner constants

## Calibration evidence
- training median absolute error: 13.7% -> 9.0%
- training p90 absolute error: 244.1% -> 81.2%
- estimated and measured alternative ranking: 11/11 training and 3/3 holdout decisions
- million-row COUNT candidate estimate: 1381 ms -> 371 ms, measured 371 ms
- race losers are stored as censored lower bounds and excluded from exact regression fitting

## Validation
- make test
- go test ./tools/costgen
- targeted storage cardinality/sample tests
- scan column-cost benchmark matrix
- complete costgen calibration run with JSONL output and source patching