### PR TITLE
fix: retain reused LIKE entries during partial eviction

### DIFF
--- a/storage/cache_object_benchmark_test.go
+++ b/storage/cache_object_benchmark_test.go
@@ -50,6 +50,7 @@ func BenchmarkCacheManagerAsyncSizeUpdate(b *testing.B) {
 func BenchmarkStorageIndexEvictionOffer(b *testing.B) {
 	idx := new(StorageIndex)
 	idx.skipListCacheBytes.Store(64 << 20)
+	idx.skipListPartialBytes.Store(32 << 20)
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -63,29 +64,42 @@ func BenchmarkStorageIndexEvictionOffer(b *testing.B) {
 
 func BenchmarkStorageIndexPartialEviction(b *testing.B) {
 	for _, childCount := range []int{1_000, 10_000, 100_000} {
-		b.Run(fmt.Sprintf("children-%d", childCount), func(b *testing.B) {
-			idx := new(StorageIndex)
-			cache := new(sync.Map)
-			var size int64
-			for child := 0; child < childCount; child++ {
-				key := skipListKey{pattern: fmt.Sprintf("%%term-%d%%", child), collation: "utf8_bin"}
-				skipList := new(SkipList)
-				cache.Store(key, skipList)
-				size += skipListEntrySize(key, skipList)
+		for _, hotEvery := range []int{0, 2} {
+			name := fmt.Sprintf("cold-%d", childCount)
+			if hotEvery > 0 {
+				name = fmt.Sprintf("half-hot-%d", childCount)
 			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for iteration := 0; iteration < b.N; iteration++ {
-				idx.baseState.skipLists = []*sync.Map{cache}
-				idx.baseState.skipListBytes.Store(size)
-				idx.skipListCacheBytes.Store(size)
-				result := idx.evict(evictPartial, size+1024, new([numEvictableTypes]int64))
-				if !result.success || result.freedBytes != size {
-					b.Fatalf("partial result = %+v, want %d bytes", result, size)
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				for iteration := 0; iteration < b.N; iteration++ {
+					b.StopTimer()
+					idx := new(StorageIndex)
+					cache := new(sync.Map)
+					idx.baseState.skipLists = []*sync.Map{cache}
+					var size int64
+					var coldSize int64
+					for child := 0; child < childCount; child++ {
+						key := skipListKey{pattern: fmt.Sprintf("%%term-%d%%", child), collation: "utf8_bin"}
+						skipList := new(SkipList)
+						childSize := attachTestSkipList(idx, &idx.baseState, cache, key, skipList)
+						size += childSize
+						if hotEvery > 0 && child%hotEvery == 0 {
+							skipList.recordUse()
+						} else {
+							coldSize += skipListEntrySize(key, skipList)
+						}
+					}
+					candidateBytes := idx.baseState.skipListPartialCandidateBytes
+					b.StartTimer()
+					result := idx.evict(evictPartial, size+1024, new([numEvictableTypes]int64))
+					expectedFreed := coldSize + candidateBytes
+					if !result.success || result.freedBytes != expectedFreed {
+						b.Fatalf("partial result = %+v, want %d bytes", result, expectedFreed)
+					}
 				}
-			}
-			b.ReportMetric(float64(childCount), "children/op")
-		})
+				b.ReportMetric(float64(childCount), "candidates/op")
+			})
+		}
 	}
 }
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -34,15 +34,28 @@ type indexPair struct {
 	data   []scm.Scmer
 }
 
+type skipListPartialCandidate struct {
+	key      skipListKey
+	skipList *SkipList
+}
+
 type storageIndexState struct {
-	mainIndexes      StorageInt
-	deltaBtree       *btree.BTreeG[indexPair]
-	active           bool
-	minVals          []scm.Scmer
-	maxVals          []scm.Scmer
-	skipLists        []*sync.Map  // map[skipListKey]*SkipList; immutable values, lock-free reads
-	skipListBytes    atomic.Int64 // exact bytes owned by skipLists
-	precomputedDelta bool
+	mainIndexes   StorageInt
+	deltaBtree    *btree.BTreeG[indexPair]
+	active        bool
+	minVals       []scm.Scmer
+	maxVals       []scm.Scmer
+	skipLists     []*sync.Map  // map[skipListKey]*SkipList; immutable values, lock-free reads
+	skipListBytes atomic.Int64 // exact bytes owned by skipLists
+	// partialCandidates contains admissions since the last partial eviction.
+	// Usage is sampled only when pressure arrives, keeping cache hits lock-free
+	// and avoiding permanent per-child eviction metadata.
+	skipListPartialCandidates [][]skipListPartialCandidate
+	// Protected by StorageIndex.mu. Capacity, rather than length, is accounted
+	// so append growth cannot hide unused backing-array memory from the budget.
+	skipListPartialCandidateBytes int64
+	skipListPartialBytes          atomic.Int64
+	precomputedDelta              bool
 }
 
 // (no op) numeric helper removed; collations now use golang.org/x/text/collate for ordering
@@ -93,10 +106,13 @@ type StorageIndex struct {
 	// CacheManager sees only this StorageIndex; child admission updates the
 	// parent's registered size while eviction remains local to the index.
 	skipListCacheBytes atomic.Int64
-	mu                 sync.Mutex
-	sessionKeys        []string
-	baseState          storageIndexState
-	variants           map[string]*storageIndexState
+	// skipListPartialBytes is the O(1) upper bound offered for partial eviction.
+	// The exact reclaimable amount is sampled from child hit counts on pressure.
+	skipListPartialBytes atomic.Int64
+	mu                   sync.Mutex
+	sessionKeys          []string
+	baseState            storageIndexState
+	variants             map[string]*storageIndexState
 }
 
 func orderRelationMeta(order func(...scm.Scmer) scm.Scmer) string {
@@ -261,8 +277,11 @@ func (idx *StorageIndex) stateForTx(tx *TxContext, create bool) *storageIndexSta
 func (idx *StorageIndex) markVariantsDirty() {
 	idx.mu.Lock()
 	var freed int64
+	var freedPartial int64
 	for _, state := range idx.variants {
-		freed += idx.clearSkipListsLocked(state)
+		stateFreed, stateFreedPartial := idx.clearSkipListsLocked(state)
+		freed += stateFreed
+		freedPartial += stateFreedPartial
 		state.active = false
 		state.mainIndexes = StorageInt{}
 		state.deltaBtree = nil
@@ -273,6 +292,7 @@ func (idx *StorageIndex) markVariantsDirty() {
 	}
 	if freed > 0 {
 		idx.skipListCacheBytes.Add(-freed)
+		idx.skipListPartialBytes.Add(-freedPartial)
 		GlobalCache.UpdateSizeAsync(idx, -freed)
 	}
 	idx.mu.Unlock()
@@ -310,6 +330,7 @@ func (idx *StorageIndex) ComputeSize() uint {
 // interface bookkeeping per entry on amd64. Round up so many tiny search terms
 // cannot evade the global byte budget through unaccounted metadata.
 const skipListMapEntryOverhead int64 = 144
+const skipListPartialCandidateSize int64 = int64(unsafe.Sizeof(skipListPartialCandidate{}))
 
 func skipListEntrySize(key skipListKey, skipList *SkipList) int64 {
 	return int64(len(key.pattern)+len(key.collation)) + skipListMapEntryOverhead + int64(skipList.ComputeSize())
@@ -337,34 +358,108 @@ func (idx *StorageIndex) ownsSkipListCacheLocked(cache *sync.Map) bool {
 // and returns their exact accounted bytes. Queries that already snapshotted an
 // old map keep it alive until their direct references leave scope.
 // The caller must hold idx.mu.
-func (idx *StorageIndex) clearSkipListsLocked(state *storageIndexState) int64 {
+func (idx *StorageIndex) clearSkipListsLocked(state *storageIndexState) (int64, int64) {
 	if state == nil {
-		return 0
+		return 0, 0
 	}
 	freed := state.skipListBytes.Swap(0)
+	freedPartial := state.skipListPartialBytes.Swap(0)
+	state.skipListPartialCandidates = nil
+	state.skipListPartialCandidateBytes = 0
 	for i, cache := range state.skipLists {
 		if cache != nil {
 			state.skipLists[i] = new(sync.Map)
 		}
 	}
-	return freed
+	return freed, freedPartial
 }
 
 func (idx *StorageIndex) clearAllSkipListsLocked() int64 {
-	freed := idx.clearSkipListsLocked(&idx.baseState)
+	freed, freedPartial := idx.clearSkipListsLocked(&idx.baseState)
 	for _, state := range idx.variants {
-		freed += idx.clearSkipListsLocked(state)
+		stateFreed, stateFreedPartial := idx.clearSkipListsLocked(state)
+		freed += stateFreed
+		freedPartial += stateFreedPartial
 	}
 	if remaining := idx.skipListCacheBytes.Add(-freed); remaining < 0 {
 		// Defensive for states restored by older persistence/tests which predate
 		// explicit child accounting. All live admissions are serialized by mu.
 		idx.skipListCacheBytes.Store(0)
 	}
+	if remaining := idx.skipListPartialBytes.Add(-freedPartial); remaining < 0 {
+		idx.skipListPartialBytes.Store(0)
+	}
+	return freed
+}
+
+// attachSkipListLocked publishes one newly built child after accounting and
+// lifecycle metadata are complete. The caller must hold idx.mu.
+func (idx *StorageIndex) attachSkipListLocked(state *storageIndexState, cache *sync.Map, colIdx int, key skipListKey, skipList *SkipList) int64 {
+	skipList.recordUse()
+	entryBytes := skipListEntrySize(key, skipList)
+	if len(state.skipListPartialCandidates) < len(state.skipLists) {
+		candidates := make([][]skipListPartialCandidate, len(state.skipLists))
+		copy(candidates, state.skipListPartialCandidates)
+		state.skipListPartialCandidates = candidates
+	}
+	candidates := state.skipListPartialCandidates[colIdx]
+	oldCapacity := cap(candidates)
+	candidates = append(candidates, skipListPartialCandidate{
+		key:      key,
+		skipList: skipList,
+	})
+	state.skipListPartialCandidates[colIdx] = candidates
+	candidateBytes := int64(cap(candidates)-oldCapacity) * skipListPartialCandidateSize
+	state.skipListPartialCandidateBytes += candidateBytes
+	bytes := entryBytes + candidateBytes
+	state.skipListBytes.Add(bytes)
+	state.skipListPartialBytes.Add(bytes)
+	idx.skipListCacheBytes.Add(bytes)
+	idx.skipListPartialBytes.Add(bytes)
+	cache.Store(key, skipList)
+	return bytes
+}
+
+// evictColdSkipListsLocked removes only children which have not reached a
+// second exact use. Hit counts are recommendations: a query which races with
+// removal keeps its direct pointer and remains correct. The caller holds idx.mu.
+func (idx *StorageIndex) evictColdSkipListsLocked(state *storageIndexState) int64 {
+	if state == nil {
+		return 0
+	}
+	freed := state.skipListPartialCandidateBytes
+	for colIdx, candidates := range state.skipListPartialCandidates {
+		cache := state.skipLists[colIdx]
+		for _, candidate := range candidates {
+			skipList := candidate.skipList
+			if skipList.hitCount.Load() <= 1 && cache.CompareAndDelete(candidate.key, skipList) {
+				freed += skipListEntrySize(candidate.key, skipList)
+			}
+		}
+	}
+	partialBytes := state.skipListPartialBytes.Swap(0)
+	state.skipListPartialCandidates = nil
+	state.skipListPartialCandidateBytes = 0
+	if freed > 0 {
+		state.skipListBytes.Add(-freed)
+		idx.skipListCacheBytes.Add(-freed)
+	}
+	if partialBytes > 0 {
+		idx.skipListPartialBytes.Add(-partialBytes)
+	}
+	return freed
+}
+
+func (idx *StorageIndex) evictColdSkipListsAllStatesLocked() int64 {
+	freed := idx.evictColdSkipListsLocked(&idx.baseState)
+	for _, state := range idx.variants {
+		freed += idx.evictColdSkipListsLocked(state)
+	}
 	return freed
 }
 
 func (idx *StorageIndex) evictionOffer(currentSize int64) evictionOffer {
-	partial := idx.skipListCacheBytes.Load()
+	partial := idx.skipListPartialBytes.Load()
 	if partial < 0 {
 		partial = 0
 	}
@@ -380,7 +475,7 @@ func (idx *StorageIndex) evict(mode evictionMode, currentSize int64, _ *[numEvic
 	}
 	defer idx.mu.Unlock()
 	if mode == evictPartial {
-		freed := idx.clearAllSkipListsLocked()
+		freed := idx.evictColdSkipListsAllStatesLocked()
 		return evictionResult{freedBytes: freed, success: freed > 0}
 	}
 	idx.clearAllSkipListsLocked()
@@ -1095,15 +1190,17 @@ func (s *StorageIndex) getOrBuildSkipList(state *storageIndexState, caches []*sy
 		sl.recordUse()
 		return sl
 	}
-	actual, loaded := cache.LoadOrStore(key, sl)
-	sl = actual.(*SkipList)
-	sl.recordUse()
-	if !loaded {
-		delta := skipListEntrySize(key, sl)
-		state.skipListBytes.Add(delta)
-		s.skipListCacheBytes.Add(delta)
-		GlobalCache.UpdateSizeAsync(s, delta)
+	// Admissions are serialized by s.mu. Recheck after the potentially
+	// expensive build so accounting can be completed before publication and a
+	// lock-free reader can never observe a half-attached cache child.
+	if actual, loaded := cache.Load(key); loaded {
+		sl = actual.(*SkipList)
+		sl.recordUse()
+		s.mu.Unlock()
+		return sl
 	}
+	delta := s.attachSkipListLocked(state, cache, colIdx, key, sl)
+	GlobalCache.UpdateSizeAsync(s, delta)
 	s.mu.Unlock()
 	return sl
 }

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -23,6 +23,12 @@ import "time"
 import "github.com/google/btree"
 import "github.com/launix-de/memcp/scm"
 
+func attachTestSkipList(idx *StorageIndex, state *storageIndexState, cache *sync.Map, key skipListKey, skipList *SkipList) int64 {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	return idx.attachSkipListLocked(state, cache, 0, key, skipList)
+}
+
 func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	Init(scm.Globalenv)
 	dbname := "test_estimate_no_savings"
@@ -72,37 +78,108 @@ func TestStorageIndexComputeSizeCountsDeltaBtree(t *testing.T) {
 	}
 }
 
-func TestStorageIndexPartialEvictionOwnsSkipListChildren(t *testing.T) {
+func TestStorageIndexPartialEvictionDropsOnlySingleUseChildren(t *testing.T) {
 	idx := &StorageIndex{}
 	cache := new(sync.Map)
 	idx.baseState.active = true
 	idx.baseState.skipLists = []*sync.Map{cache}
-	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
-	skipList := &SkipList{}
-	cache.Store(key, skipList)
-	childBytes := skipListEntrySize(key, skipList)
-	idx.baseState.skipListBytes.Store(childBytes)
-	idx.skipListCacheBytes.Store(childBytes)
+	coldKey := skipListKey{pattern: "%one-off%", collation: "utf8_bin"}
+	hotKey := skipListKey{pattern: "%paged%", collation: "utf8_bin"}
+	cold := &SkipList{}
+	hot := &SkipList{}
+	coldBytes := attachTestSkipList(idx, &idx.baseState, cache, coldKey, cold)
+	hotBytes := attachTestSkipList(idx, &idx.baseState, cache, hotKey, hot)
+	if _, ok := loadCachedSkipList(cache, hotKey); !ok {
+		t.Fatal("second exact use did not find hot child")
+	}
+	candidateBytes := idx.baseState.skipListPartialCandidateBytes
 
-	offer := idx.evictionOffer(childBytes + 1024)
-	if offer.partialBytes != childBytes || offer.fullBytes != childBytes+1024 {
-		t.Fatalf("offer = %+v, want partial=%d full=%d", offer, childBytes, childBytes+1024)
+	offer := idx.evictionOffer(coldBytes + hotBytes + 1024)
+	if offer.partialBytes != coldBytes+hotBytes || offer.fullBytes != coldBytes+hotBytes+1024 {
+		t.Fatalf("offer = %+v, want partial=%d full=%d", offer, coldBytes+hotBytes, coldBytes+hotBytes+1024)
 	}
 	result := idx.evict(evictPartial, offer.fullBytes, new([numEvictableTypes]int64))
-	if !result.success || result.fullyEvicted || result.freedBytes != childBytes {
+	expectedFreed := skipListEntrySize(coldKey, cold) + candidateBytes
+	if !result.success || result.fullyEvicted || result.freedBytes != expectedFreed {
 		t.Fatalf("partial result = %+v", result)
 	}
-	if idx.baseState.skipLists[0] == cache {
-		t.Fatal("partial eviction retained the published child map")
+	if _, ok := cache.Load(coldKey); ok {
+		t.Fatal("partial eviction retained one-use child")
 	}
-	if _, ok := idx.baseState.skipLists[0].Load(key); ok {
-		t.Fatal("replacement child map is not empty")
+	if got, ok := cache.Load(hotKey); !ok || got != hot {
+		t.Fatal("partial eviction removed repeatedly used child")
 	}
 	if !idx.baseState.active {
 		t.Fatal("partial eviction removed the parent index")
 	}
-	if got := idx.skipListCacheBytes.Load(); got != 0 {
-		t.Fatalf("child bytes = %d, want 0", got)
+	expectedRemaining := coldBytes + hotBytes - expectedFreed
+	if got := idx.skipListCacheBytes.Load(); got != expectedRemaining {
+		t.Fatalf("child bytes = %d, want hot bytes %d", got, expectedRemaining)
+	}
+	if got := idx.skipListPartialBytes.Load(); got != 0 {
+		t.Fatalf("partial candidate bytes = %d, want 0", got)
+	}
+}
+
+func TestStorageIndexPartialEvictionRetainsSecondUse(t *testing.T) {
+	idx := &StorageIndex{}
+	cache := new(sync.Map)
+	idx.baseState.skipLists = []*sync.Map{cache}
+	key := skipListKey{pattern: "%reused%", collation: "utf8_bin"}
+	skipList := &SkipList{}
+	bytes := attachTestSkipList(idx, &idx.baseState, cache, key, skipList)
+	if got := idx.evictionOffer(bytes).partialBytes; got != bytes {
+		t.Fatalf("first-use offer = %d, want %d", got, bytes)
+	}
+	loadCachedSkipList(cache, key)
+	candidateBytes := idx.baseState.skipListPartialCandidateBytes
+	if got := idx.evictionOffer(bytes).partialBytes; got != bytes {
+		t.Fatalf("pre-sampling offer = %d, want upper bound %d", got, bytes)
+	}
+	result := idx.evict(evictPartial, bytes, new([numEvictableTypes]int64))
+	if !result.success || result.fullyEvicted || result.freedBytes != candidateBytes {
+		t.Fatalf("partial eviction did not release hot admission metadata: %+v", result)
+	}
+	if _, ok := cache.Load(key); !ok {
+		t.Fatal("hot child disappeared")
+	}
+	if got := idx.skipListCacheBytes.Load(); got != bytes-candidateBytes {
+		t.Fatalf("child bytes = %d, want %d", got, bytes-candidateBytes)
+	}
+	if got := idx.skipListPartialBytes.Load(); got != 0 {
+		t.Fatalf("partial candidate bytes = %d, want 0", got)
+	}
+}
+
+func TestStorageIndexPromotionRacesPartialEvictionAccounting(t *testing.T) {
+	for iteration := 0; iteration < 1000; iteration++ {
+		idx := &StorageIndex{}
+		cache := new(sync.Map)
+		idx.baseState.skipLists = []*sync.Map{cache}
+		key := skipListKey{pattern: "%race%", collation: "utf8_bin"}
+		skipList := &SkipList{}
+		bytes := attachTestSkipList(idx, &idx.baseState, cache, key, skipList)
+		start := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			<-start
+			skipList.recordUse()
+			close(done)
+		}()
+		close(start)
+		idx.evict(evictPartial, bytes, new([numEvictableTypes]int64))
+		<-done
+		if got := idx.skipListPartialBytes.Load(); got != 0 {
+			t.Fatalf("iteration %d: partial candidate bytes = %d, want 0", iteration, got)
+		}
+		hotBytes := skipListEntrySize(key, skipList)
+		if got := idx.skipListCacheBytes.Load(); got != 0 && got != hotBytes {
+			t.Fatalf("iteration %d: total bytes = %d, want 0 or %d", iteration, got, hotBytes)
+		}
+		_, retained := cache.Load(key)
+		if retained != (idx.skipListCacheBytes.Load() == hotBytes) {
+			t.Fatalf("iteration %d: retained=%t disagrees with accounting", iteration, retained)
+		}
 	}
 }
 
@@ -141,22 +218,17 @@ func TestStorageIndexPartialEvictionKeepsActiveQueryReference(t *testing.T) {
 	cache := &sync.Map{}
 	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
 	queryReference := &SkipList{}
-	cache.Store(key, queryReference)
 	idx := &StorageIndex{}
 	idx.baseState.active = true
 	idx.baseState.skipLists = []*sync.Map{cache}
-	idx.baseState.skipListBytes.Store(skipListEntrySize(key, queryReference))
-	idx.skipListCacheBytes.Store(skipListEntrySize(key, queryReference))
+	attachTestSkipList(idx, &idx.baseState, cache, key, queryReference)
 
 	result := idx.evict(evictPartial, 1024, new([numEvictableTypes]int64))
 	if !result.success {
 		t.Fatal("partial eviction failed")
 	}
-	if idx.baseState.skipLists[0] == cache {
-		t.Fatal("old cache remained published on the parent")
-	}
-	if got, ok := cache.Load(key); !ok || got != queryReference {
-		t.Fatal("active query's snapshotted map was invalidated")
+	if _, ok := cache.Load(key); ok {
+		t.Fatal("one-use child remained cached")
 	}
 	if queryReference.cursor().skip != queryReference {
 		t.Fatal("active query reference was invalidated")
@@ -174,7 +246,6 @@ func TestCacheManagerTracksOnlyTopLevelIndex(t *testing.T) {
 	idx.baseState.skipLists = []*sync.Map{cache}
 	key := skipListKey{pattern: "%needle%", collation: "utf8_bin"}
 	skipList := &SkipList{}
-	childBytes := skipListEntrySize(key, skipList)
 	const baseBytes = int64(1024)
 	manager.AddItemEx(
 		idx,
@@ -186,12 +257,8 @@ func TestCacheManagerTracksOnlyTopLevelIndex(t *testing.T) {
 		0,
 		0,
 	)
-	idx.mu.Lock()
-	cache.Store(key, skipList)
-	idx.baseState.skipListBytes.Store(childBytes)
-	idx.skipListCacheBytes.Store(childBytes)
+	childBytes := attachTestSkipList(idx, &idx.baseState, cache, key, skipList)
 	manager.UpdateSizeAsync(idx, childBytes)
-	idx.mu.Unlock()
 
 	before := manager.Stat()
 	if before.CountByType[TypeIndex] != 1 {
@@ -205,7 +272,7 @@ func TestCacheManagerTracksOnlyTopLevelIndex(t *testing.T) {
 	if after.CountByType[TypeIndex] != 1 || after.SizeByType[TypeIndex] != baseBytes {
 		t.Fatalf("after partial eviction: count=%d size=%d", after.CountByType[TypeIndex], after.SizeByType[TypeIndex])
 	}
-	if idx.baseState.skipLists[0] == cache {
-		t.Fatal("partial pressure eviction retained published child map")
+	if _, ok := cache.Load(key); ok {
+		t.Fatal("partial pressure eviction retained one-use child")
 	}
 }


### PR DESCRIPTION
## Summary

- keep the `StorageIndex` as the only globally managed cache object while letting it shed one-use LIKE skip lists selectively
- retain LIKE terms that reached a second exact use, so pagination and repeated queries continue to reuse their match sets
- collect admissions locally and sample hit counts only under memory pressure; the normal cache-hit path remains lock-free and gains no permanent eviction metadata
- account candidate backing-array capacity in the parent index memory budget and publish new children only after accounting is complete

## Complexity and measurements

- partial offer: O(1)
- partial eviction: O(k) over admissions since the previous partial pass, with no sorting and no allocations in the eviction path
- exact LIKE cache hit: 32.68 ns/op, 0 B/op, 0 allocs/op (master: 32.78-33.28 ns/op)
- 100k candidates: 14.94 ms all cold; 8.12 ms half reused, 0 allocs/op

## Tests

- `make test`
- `go test -race ./storage -run 'TestStorageIndexPartialEviction|TestStorageIndexPromotion|TestLoadCachedSkipList|TestCacheManagerTracksOnlyTopLevelIndex' -count=1`
- targeted storage eviction tests and microbenchmarks
