### PR TITLE
planner: keep membership carrier choices node-local

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -12831,11 +12831,10 @@ the auto-index chooses the concrete access path on both tables. */
 					(exists_recset_project_join_expr src stage)
 					nil))))))
 
-/* A membership requirement becomes physical only here. Returning nil keeps
-the marker in the filter, whose ordinary lowering emits the driver-side
-scan_exists/keytable path. Returning the expression emits the RecSet carrier.
-That makes the recorded and forced choice identical to the executable plan. */
-(define recset_project_join_expr_for_membership_using (lambda (src membership consumer ordered_filter driver_rows_override)
+/* Cost one physical tree edge once and return (strategy RecSet-expression).
+Consumers decide whether that RecSet is their scan carrier or a membership
+filter; they must not reconstruct the choice from enclosing block facts. */
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override)
 	(begin
 		(define stage (nth membership 0))
 		(define facts (gs_facts stage))
@@ -12847,7 +12846,7 @@ That makes the recorded and forced choice identical to the executable plan. */
 			(not (or
 				(equal? (qassoc_get facts (quote purpose) nil) (quote in_membership))
 				(equal? (qassoc_get facts (quote purpose) nil) (quote in_candidate)))))
-			raw_expr
+			(if (nil? raw_expr) nil (list "candidate_keyset" raw_expr))
 			(begin
 				(define measured_estimate (planner_stage_filter_estimate (gs_input stage) 512))
 				(define capped (or
@@ -12962,29 +12961,20 @@ That makes the recorded and forced choice identical to the executable plan. */
 								(list "status" (if (equal? chosen "driver_order_membership_probe") "chosen" "rejected"))
 								(list "reason" (if (equal? chosen "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
 								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
-				(if (and (equal? chosen "candidate_keyset") ordered_filter)
-					(planner_record_physical_decision
-						(list
-							(list "decision" "ordered_recset_iterator")
-							(list "chosen" "recset_contains_probe")
-							(list "reason" "base_table_scan_with_membership_filter")
-							(list "inputs" (list
-								(list "candidate_rows" candidate_rows)
-								(list "driver_rows" driver_rows)))
-							(list "alternatives" (list
-								(list
-									(list "plan" "scan_order_recset_part")
-									(list "status" "rejected")
-									(list "reason" "source_is_base_table"))
-								(list
-									(list "plan" "recset_contains_probe")
-									(list "status" "chosen")
-									(list "reason" "base_table_scan_with_membership_filter"))))))
-					nil)
-				(if (equal? chosen "candidate_keyset") raw_expr nil))))))
+				(list chosen raw_expr))))))
+
+/* General expression callers preserve the established contract: only a
+candidate-keyset choice replaces the marker with a projected RecSet carrier. */
+(define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override)
+	(begin
+		(define plan (recset_project_join_plan_for_membership_using
+			src membership consumer driver_rows_override))
+		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
+			(cadr plan)
+			nil))))
 
 (define recset_project_join_expr_for_membership (lambda (src membership)
-	(recset_project_join_expr_for_membership_using src membership nil false nil)))
+	(recset_project_join_expr_for_membership_using src membership nil nil)))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -17850,16 +17840,16 @@ scan boundary only when the complete predicate implies it. */
 						(replace_driver_membership_markers src item memberships))))
 					_ expr))))))
 
-(define membership_recset_bindings_using (lambda (src memberships consumer ordered_filter driver_rows_override)
+(define membership_recset_bindings_using (lambda (src memberships consumer driver_rows_override)
 	(filter (map memberships (lambda (membership)
 		(begin
 			(define expr (recset_project_join_expr_for_membership_using
-				src membership consumer ordered_filter driver_rows_override))
+				src membership consumer driver_rows_override))
 			(if (nil? expr) nil (list membership (membership_recset_var src membership) expr)))))
 		(lambda (binding) (not (nil? binding))))))
 
 (define membership_recset_bindings (lambda (src memberships)
-	(membership_recset_bindings_using src memberships nil false nil)))
+	(membership_recset_bindings_using src memberships nil nil)))
 
 (define wrap_membership_recset_bindings (lambda (bindings body)
 	(if (empty_list? bindings)
@@ -18135,7 +18125,6 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 					'()
 					(membership_recset_bindings_using src memberships
 						(if bounded (quote order_limit) (quote filter))
-						(and scan_order_supported bounded)
 						(if (and scan_order_supported bounded)
 							(probe_limit_work_rows (qb_limit block)) nil))))
 				(define bound_memberships (map membership_bindings (lambda (binding) (nth binding 0))))
@@ -18438,25 +18427,23 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 		(define driver_order_items (nth order_parts 0))
 		(define remaining_order_items (nth order_parts 1))
 		(define membership (driver_membership_for_source src condition))
-		(define membership_table_expr (if (nil? membership) nil
-			(recset_project_join_expr_for_membership_using src membership
+		(define membership_plan (if (nil? membership) nil
+			(recset_project_join_plan_for_membership_using src membership
 				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
-				(and (not (empty_list? driver_order_items))
-					(query_limit_active? offset_value limit_value))
 				(if (query_limit_active? offset_value limit_value)
 					(probe_limit_work_rows limit_value) nil))))
+		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
+		(define membership_table_expr (if (and
+			(not (nil? membership_plan))
+			(equal? membership_strategy "candidate_keyset"))
+			(cadr membership_plan)
+			nil))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
-		/* A broad membership set cannot narrow an ordered driver. Keep the base
-		table as the order carrier and probe the RecSet in the filter so scan_order
-		can use its native Top-K braking instead of sorting the projected domain. */
-		(define membership_filter (and
-			(not (nil? membership_table_expr))
-			(broad_driver_order_membership_probe? facts)))
-		(define membership_var (symbol "__ordered_membership_recset"))
-		(define filter_condition (combine_where
-			(if membership_filter (recset_contains_call_expr membership_var) true)
-			effective_condition))
+		/* The node-local physical choice is final. A candidate keyset becomes the
+		ordered carrier; a driver-probe choice leaves the marker in the base-table
+		filter so its established direct probe lowering remains in charge. */
+		(define filter_condition effective_condition)
 		/* Acceptance runs before OFFSET/LIMIT and therefore contains only joins
 		which can reject a driver row. Projection-only nullable lookups belong to
 		the map callback after the native window and must not be probed twice. */
@@ -18481,7 +18468,6 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 				(list (quote lambda) (list (quote accepted) (quote shard_accepted))
 					(list (quote or) (quote accepted) (quote shard_accepted))))))
 		(define filtercols (merge_unique (list
-			(if membership_filter (list "$recset_contains") '())
 			(join_cols_for_alias all_sources default_alias alias (list effective_condition)))))
 		(define filter_expr (list (quote lambda)
 			(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
@@ -18509,9 +18495,7 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 			projection))
 		(define scan_expr (list (quote scan_order)
 			'(session "__memcp_tx")
-			(if membership_filter
-				(source_table_expr_using stages src)
-				(coalesceNil membership_table_expr (source_table_expr_using stages src)))
+			(coalesceNil membership_table_expr (source_table_expr_using stages src))
 			(cons (quote list) filtercols)
 			filter_expr
 			(cons (quote list) (scan_order_sort_columns_for_join_driver
@@ -18522,11 +18506,7 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 			map_expr nil nil false nil
 			(cons (quote list) acceptance_cols)
 			acceptance_expr))
-		(if membership_filter
-			(list
-				(list (quote lambda) (list membership_var) scan_expr)
-				membership_table_expr)
-			scan_expr))))
+		scan_expr)))
 
 (define without_col (lambda (cols col)
 	(filter (coalesceNil cols '()) (lambda (item) (not (equal? item col))))))
@@ -18789,16 +18769,20 @@ driver. This is physical costing metadata only; it never enters logical IR. */
 		(define delay_limit_after_join (ordered_join_limit_requires_complete_rows?
 			(join_optimizer_sources_for_order all_sources (cons alias future_aliases))
 			default_alias final_condition offset_value limit_value))
-		(define membership_table_expr (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
+		(define membership_plan (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
 			nil
-			(recset_project_join_expr_for_membership_using src membership
+			(recset_project_join_plan_for_membership_using src membership
 				(if (join_scan_reduce? result_mode) (quote aggregate)
 					(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter)))
-				(and (not (empty_list? current_order_items))
-					(query_limit_active? offset_value limit_value))
 				(if (and (not (empty_list? current_order_items))
 					(query_limit_active? offset_value limit_value))
 					(probe_limit_work_rows limit_value) nil))))
+		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
+		(define membership_table_expr (if (and
+			(not (nil? membership_plan))
+			(equal? membership_strategy "candidate_keyset"))
+			(cadr membership_plan)
+			nil))
 		(if (expr_contains_driver_membership? condition)
 			(planner_record_physical_decision (list
 				(list "decision" "join_leaf_membership_consumer")
@@ -18814,16 +18798,23 @@ driver. This is physical costing metadata only; it never enters logical IR. */
 					(list "limit_delayed" delay_limit_after_join)
 					(list "projection_built" (not (nil? membership_table_expr)))))))
 			nil)
-		(define membership_driver (and (not (nil? membership_table_expr)) (empty_list? future_aliases)))
-		(define membership_filter (and (not (nil? membership_table_expr)) (not membership_driver)))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		(define row_number_stage_filter (row_number_stage_for_source stages src effective_condition))
+		/* A candidate-keyset choice makes the projected row positions this leaf's
+		scan carrier even when later join leaves are continuations. A driver-probe
+		choice deliberately keeps the base table and tests that same RecSet. The
+		row-number pipeline has its own base-table carrier and therefore consumes
+		the RecSet as a filter until that operator accepts an explicit source. */
+		(define membership_driver (and
+			(not (nil? membership_table_expr))
+			(nil? row_number_stage_filter)))
+		(define membership_filter (and (not (nil? membership_table_expr)) (not membership_driver)))
 		(define membership_var (symbol "__membership_recset"))
 		(define membership_filter_expr (if membership_filter
 			(recset_contains_call_expr membership_var)
 			true))
 		(define filter_condition (combine_where membership_filter_expr effective_condition))
-		(define row_number_stage_filter (row_number_stage_for_source stages src effective_condition))
 		(define filtercols (merge_unique (list
 			(if membership_filter (list "$recset_contains") '())
 			(join_filter_cols_for_alias all_sources default_alias alias effective_condition))))

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1258,6 +1258,107 @@ test_cases:
             - "consumer"
             - "aggregate"
 
+  - name: "Selective ordered membership keeps its node-local RecSet carrier"
+    fail_comment: "a selective candidate_keyset choice must reach scan_order as its RecSet source"
+    setup:
+      - sql: "DROP TABLE IF EXISTS in_ordered_carrier_doc"
+      - sql: "DROP TABLE IF EXISTS in_ordered_carrier_file"
+      - sql: "DROP TABLE IF EXISTS in_ordered_carrier_acl"
+      - sql: "DROP TABLE IF EXISTS in_ordered_carrier_owner"
+      - sql: |
+          CREATE TABLE in_ordered_carrier_file (
+            ID INT PRIMARY KEY,
+            filename VARCHAR(64),
+            search VARCHAR(128)
+          )
+      - sql: |
+          CREATE TABLE in_ordered_carrier_doc (
+            ID INT PRIMARY KEY,
+            file_id INT,
+            tenant INT,
+            owner INT,
+            sort_key INT
+          )
+      - sql: "CREATE TABLE in_ordered_carrier_acl (ID INT PRIMARY KEY, usr INT, tenant INT)"
+      - sql: "CREATE TABLE in_ordered_carrier_owner (ID INT PRIMARY KEY, name VARCHAR(64))"
+      - sql: "INSERT INTO in_ordered_carrier_file VALUES (1, 'cold.pdf', 'cold')"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 1, CONCAT('cold-', ID + 1, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 2, CONCAT('cold-', ID + 2, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 4, CONCAT('cold-', ID + 4, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 8, CONCAT('cold-', ID + 8, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 16, CONCAT('cold-', ID + 16, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 32, CONCAT('cold-', ID + 32, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 64, CONCAT('cold-', ID + 64, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 128, CONCAT('cold-', ID + 128, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 256, CONCAT('cold-', ID + 256, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_file SELECT ID + 512, CONCAT('cold-', ID + 512, '.pdf'), 'cold' FROM in_ordered_carrier_file"
+      - sql: "UPDATE in_ordered_carrier_file SET filename = 'rare-target.pdf' WHERE ID = 1024"
+      - sql: "INSERT INTO in_ordered_carrier_doc SELECT ID, ID, 1, 1, 1025 - ID FROM in_ordered_carrier_file"
+      - sql: "INSERT INTO in_ordered_carrier_acl VALUES (1, 105, 1)"
+      - sql: "INSERT INTO in_ordered_carrier_owner VALUES (1, 'Ada')"
+    steps:
+      - sql: |
+          SELECT wrapped.ID, wrapped.owner_name
+          FROM (
+            SELECT visible.ID, visible.file_id, visible.sort_key, owner.name AS owner_name
+            FROM (
+              SELECT d.ID, d.file_id, d.owner, d.sort_key
+              FROM in_ordered_carrier_doc d
+              WHERE EXISTS (
+                SELECT TRUE FROM in_ordered_carrier_acl acl
+                WHERE acl.usr = 105 AND acl.tenant = d.tenant
+                LIMIT 1
+              )
+            ) visible
+            LEFT JOIN in_ordered_carrier_owner owner ON owner.ID = visible.owner
+          ) wrapped
+          WHERE wrapped.file_id IN (
+            SELECT f.ID FROM in_ordered_carrier_file f WHERE f.filename LIKE '%rare-target%'
+            UNION
+            SELECT f.ID FROM in_ordered_carrier_file f WHERE f.search LIKE '%rare-target%'
+          )
+          ORDER BY wrapped.sort_key
+          LIMIT 72
+        expect:
+          rows: 1
+          data:
+            - ID: 1024
+              owner_name: "Ada"
+      - sql: |
+          EXPLAIN PHYSICAL
+          SELECT wrapped.ID, wrapped.owner_name
+          FROM (
+            SELECT visible.ID, visible.file_id, visible.sort_key, owner.name AS owner_name
+            FROM (
+              SELECT d.ID, d.file_id, d.owner, d.sort_key
+              FROM in_ordered_carrier_doc d
+              WHERE EXISTS (
+                SELECT TRUE FROM in_ordered_carrier_acl acl
+                WHERE acl.usr = 105 AND acl.tenant = d.tenant
+                LIMIT 1
+              )
+            ) visible
+            LEFT JOIN in_ordered_carrier_owner owner ON owner.ID = visible.owner
+          ) wrapped
+          WHERE wrapped.file_id IN (
+            SELECT f.ID FROM in_ordered_carrier_file f WHERE f.filename LIKE '%rare-target%'
+            UNION
+            SELECT f.ID FROM in_ordered_carrier_file f WHERE f.search LIKE '%rare-target%'
+          )
+          ORDER BY wrapped.sort_key
+          LIMIT 72
+        expect:
+          contains:
+            - "chosen candidate_keyset"
+            - "chosen scan_order_recset_part"
+            - "recset_scan_source"
+            - "recset_project_join"
+          not_contains:
+            - "chosen recset_contains_probe"
+            - "base_table_scan_with_membership_filter"
+            - "source_is_base_table"
+            - "$recset_contains"
+
   - name: "IN UNION after derived ACL EXISTS keeps rows and lowers probes"
     fail_comment: "planner must not leak driver_membership_probe into final code or drop rows"
     setup:


### PR DESCRIPTION
## What

Make each physical membership consumer use the strategy and RecSet expression chosen for that exact tree edge.

Previously, costing could choose `candidate_keyset`, but later lowering reconstructed the decision from enclosing block facts and emitted a base-table scan with `$recset_contains`. The choice was visible in `EXPLAIN PHYSICAL` but did not control the executable operator.

This change:

- returns `(strategy, RecSet expression)` from the membership cost decision;
- makes ordered and join-leaf consumers use that exact pair once;
- feeds selective projected RecSets directly into `scan`/`scan_order`, including across downstream join continuations;
- keeps broad `driver_order_membership_probe` choices on the established direct driver-probe path instead of materializing a candidate set;
- documents the current row-number capability boundary, where the operator still requires a base-table source.

No calibration constants or logical IR shapes are changed.

## Regression proof

The new integration case reproduces an ordered derived document shape with:

- a selective UNION membership query;
- projection from the searched relation to the driving relation;
- a correlated ACL-style `EXISTS` predicate;
- a downstream `LEFT JOIN`;
- `ORDER BY ... LIMIT`.

On `master`, physical costing reports `candidate_keyset` but emitted code still contains `$recset_contains`. On this branch, the same query reports and emits:

- `chosen candidate_keyset`;
- `chosen scan_order_recset_part`;
- `recset_scan_source`;
- `recset_project_join`;

and contains neither `$recset_contains` nor `source_is_base_table` for that edge.

The real captured query shows the same physical diff: the previous saved plan had `candidate_keyset` plus `chosen recset_contains_probe`/`source_is_base_table`; this branch has two candidate-keyset decisions, `chosen scan_order_recset_part`, two `recset_scan_source` occurrences, and no membership-filter fallback.

Observed end-to-end timings on the restarted data-copy server were 131.95 s for the first cold file-search load, 5.61 s warm, and 89.7 ms from query cache. A new zero-hit search term took 5.45 s warm and 3.9 ms cached. The remaining first-load/string-search cost is separate from this carrier-selection bug.

## Validation

- Scheme startup unit tests: 1239/1239
- `tests/planner/subqueries/in-subquery.yaml`: 70/70
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 13/13
- `tests/planner/order-window/order-limit.yaml`: 47/47, repeated three times
- `tests/execution/operators/recset.yaml`: 34/34
- repartition concurrency suite: 143/143, repeated
- rebuild concurrency suite: 16/16, repeated three times after an unrelated shared-host process interruption
- Scheme lint, `git diff --check`, and build pass

The full local hook was attempted while other worktrees were running concurrent coverage/calibration jobs. Its planner suites passed; shared-host server restarts made unrelated storage concurrency cases flaky. CI is therefore the authoritative full-suite gate for this draft.
