### PR TITLE
Fix physical membership calibration and estimates

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -3955,14 +3955,14 @@ carrier selection remains a later, per-stage cost decision. */
 				(and (query_block? subquery)
 					(and (not (empty_list? (qb_sources subquery)))
 						(and (equal? (count (qb_fields subquery)) 2)
-						(and (equal? (qb_limit subquery) 1)
-							(empty_list? (extract_aggregates (query_block_first_expr subquery))))))))))))
+							(and (equal? (qb_limit subquery) 1)
+								(empty_list? (extract_aggregates (query_block_first_expr subquery))))))))))))
 
 (define btw2025_scalar_bundle_key (lambda (marker)
 	(concat "scalar-bundle:"
 		(serialize (list
-		(dependent_subquery_scope_backbone (quote scalar) (dep_subquery_query marker))
-		(dep_subquery_outer_sources marker))))))
+			(dependent_subquery_scope_backbone (quote scalar) (dep_subquery_query marker))
+			(dep_subquery_outer_sources marker))))))
 
 (define btw2025_scalar_bundle_output_budget 16)
 
@@ -6718,12 +6718,16 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(list (quote membership_candidate_estimate_capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
 					(list (quote membership_candidate_estimate_input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
 					(list (quote membership_candidate_estimate_sampled) (qassoc_get facts (quote membership_candidate_estimate_sampled) nil))
+					(list (quote membership_candidate_estimate_population) (qassoc_get facts (quote membership_candidate_estimate_population) (quote table_rows)))
+					(list (quote membership_candidate_estimate_coverage) (qassoc_get facts (quote membership_candidate_estimate_coverage) (quote sampled)))
 					(list (quote membership_candidate_scan_invocations) (qassoc_get facts (quote membership_candidate_scan_invocations) 1))
 					(list (quote membership_candidate_filter_columns) (qassoc_get facts (quote membership_candidate_filter_columns) 0))
 					(list (quote membership_candidate_map_columns) (qassoc_get facts (quote membership_candidate_map_columns) 1))
 					(list (quote membership_candidate_cache_map_columns) (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
 					(list (quote membership_candidate_expression_operations) (qassoc_get facts (quote membership_candidate_expression_operations) 0))
 					(list (quote membership_candidate_expression_depth) (qassoc_get facts (quote membership_candidate_expression_depth) 0))
+					(list (quote membership_candidate_broad_text_match_rows) (qassoc_get facts (quote membership_candidate_broad_text_match_rows) 0))
+					(list (quote membership_candidate_broad_text_match_bytes) (qassoc_get facts (quote membership_candidate_broad_text_match_bytes) 0))
 					(list (quote membership_candidate_filter_value_rows) (qassoc_get facts (quote membership_candidate_filter_value_rows) nil))
 					(list (quote membership_candidate_expression_operation_rows) (qassoc_get facts (quote membership_candidate_expression_operation_rows) nil))
 					(list (quote membership_driver_rows) (qassoc_get facts (quote membership_driver_rows) nil))
@@ -7223,7 +7227,8 @@ source itself has no known row count (not a base table). */
 			(list (quote distinct_source) (quote unknown))
 			(list (quote null_fraction) nil)
 			(list (quote min) nil)
-			(list (quote max) nil))
+			(list (quote max) nil)
+			(list (quote average_value_bytes) nil))
 		(try
 			(lambda ()
 				(reduce (get_schema (source_schema src) (source_relation src)) (lambda (found row)
@@ -7240,7 +7245,8 @@ source itself has no known row count (not a base table). */
 								(list (quote distinct_source) (symbol (row "DistinctEstimateSource")))
 								(list (quote null_fraction) (row "NullFraction"))
 								(list (quote min) (row "MinEstimate"))
-								(list (quote max) (row "MaxEstimate")))
+								(list (quote max) (row "MaxEstimate"))
+								(list (quote average_value_bytes) (row "AverageValueBytes")))
 							nil)))
 					nil))
 			(lambda (_e) (list
@@ -7249,10 +7255,14 @@ source itself has no known row count (not a base table). */
 				(list (quote source) (quote unknown))
 				(list (quote distinct) nil)
 				(list (quote distinct_confidence) 0)
-				(list (quote distinct_source) (quote unknown))))))))
+				(list (quote distinct_source) (quote unknown))
+				(list (quote average_value_bytes) nil))))))))
 
 (define planner_column_distinct_estimate (lambda (src column)
 	(qassoc_get (planner_column_statistics src column) (quote distinct) nil)))
+
+(define planner_column_average_value_bytes (lambda (src column)
+	(qassoc_get (planner_column_statistics src column) (quote average_value_bytes) nil)))
 
 (define planner_group_distinct_estimate (lambda (src keys row_count)
 	(reduce keys (lambda (estimate key)
@@ -7462,6 +7472,31 @@ resulting tree in semantic order. */
 		(if (nil? value) acc (+ acc value)))
 		0)))
 
+(define planner_estimate_population (lambda (estimate)
+	(qassoc_get estimate (quote population) (quote table_rows))))
+
+(define planner_estimate_coverage (lambda (estimate)
+	(qassoc_get estimate (quote coverage)
+		(if (qassoc_get estimate (quote capped) false) (quote sampled) (quote exact)))))
+
+(define planner_merge_estimate_population (lambda (estimates)
+	(if (reduce estimates (lambda (found estimate)
+		(or found (equal? (planner_estimate_population estimate) (quote index_candidates)))) false)
+		(quote index_candidates)
+		(if (reduce estimates (lambda (found estimate)
+			(or found (equal? (planner_estimate_population estimate) (quote recset_candidates)))) false)
+			(quote recset_candidates)
+			(quote table_rows)))))
+
+(define planner_merge_estimate_coverage (lambda (estimates)
+	(if (reduce estimates (lambda (found estimate)
+		(or found (equal? (planner_estimate_coverage estimate) (quote lower_bound)))) false)
+		(quote lower_bound)
+		(if (reduce estimates (lambda (found estimate)
+			(or found (equal? (planner_estimate_coverage estimate) (quote sampled)))) false)
+			(quote sampled)
+			(quote exact)))))
+
 (define planner_query_block_input_rows (lambda (block)
 	(planner_add_estimates (map (qb_sources block) planner_source_row_count))))
 
@@ -7497,7 +7532,9 @@ resulting tree in semantic order. */
 						(list (quote rows) rows)
 						(list (quote capped) capped)
 						(list (quote sampled) sampled_rows)
-						(list (quote input) input_rows)))))
+						(list (quote input) input_rows)
+						(list (quote population) (planner_merge_estimate_population available))
+						(list (quote coverage) (planner_merge_estimate_coverage available))))))
 		(if (query_block? input)
 			(if (single_source? (qb_sources input))
 				(begin
@@ -7540,28 +7577,54 @@ resulting tree in semantic order. */
 /* Physical costing needs the amount of scalar work, not a speculative copy of
 each alternative plan. This walker visits the already canonical expression
 once; get_column is a leaf because column reads are costed independently. */
-(define physical_expression_work_profile (lambda (expr)
+(define physical_broad_text_match_operation? (lambda (expr)
+	(match expr
+		((symbol strlike) _value pattern _collation) (planner_broad_like_expr? pattern)
+		((quote strlike) _value pattern _collation) (planner_broad_like_expr? pattern)
+		((symbol strlike_cs) _value pattern _collation) (planner_broad_like_expr? pattern)
+		((quote strlike_cs) _value pattern _collation) (planner_broad_like_expr? pattern)
+		_ false)))
+
+/* REBUILD already walks and decodes every base value. Its exact average byte
+width lets costing distinguish short labels from large text documents without
+building either physical alternative or sampling the table again. */
+(define physical_expression_work_profile (lambda (src expr)
 	(match expr
 		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
-		(list (list (quote operations) 0) (list (quote depth) 0))
+		(list (list (quote operations) 0) (list (quote depth) 0)
+			(list (quote broad_text_matches) 0) (list (quote broad_text_average_bytes) 0))
 		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase)
-		(list (list (quote operations) 0) (list (quote depth) 0))
+		(list (list (quote operations) 0) (list (quote depth) 0)
+			(list (quote broad_text_matches) 0) (list (quote broad_text_average_bytes) 0))
 		(cons head tail) (begin
-			(define children (map tail physical_expression_work_profile))
+			(define children (map tail (lambda (child) (physical_expression_work_profile src child))))
 			(define own (if (symbol? head) 1 0))
 			(list
 				(list (quote operations) (+ own (reduce children (lambda (total child)
 					(+ total (qassoc_get child (quote operations) 0))) 0)))
 				(list (quote depth) (+ own (reduce children (lambda (depth child)
-					(max depth (qassoc_get child (quote depth) 0))) 0)))))
-		_ (list (list (quote operations) 0) (list (quote depth) 0)))))
+					(max depth (qassoc_get child (quote depth) 0))) 0)))
+				(list (quote broad_text_matches) (+
+					(if (physical_broad_text_match_operation? expr) 1 0)
+					(reduce children (lambda (total child)
+						(+ total (qassoc_get child (quote broad_text_matches) 0))) 0)))
+				(list (quote broad_text_average_bytes) (+
+					(if (physical_broad_text_match_operation? expr)
+						(reduce (extract_columns_for_alias src (car tail)) (lambda (total column)
+							(+ total (coalesceNil (planner_column_average_value_bytes src column) 0))) 0)
+						0)
+					(reduce children (lambda (total child)
+						(+ total (qassoc_get child (quote broad_text_average_bytes) 0))) 0)))))
+		_ (list (list (quote operations) 0) (list (quote depth) 0)
+			(list (quote broad_text_matches) 0) (list (quote broad_text_average_bytes) 0)))))
 
 (define membership_source_work_profile (lambda (src condition map_expr)
 	(begin
 		(define input_rows (planner_source_row_count src))
 		(define filter_columns (extract_columns_for_alias src condition))
 		(define map_columns (extract_columns_for_alias src map_expr))
-		(define expression_work (physical_expression_work_profile condition))
+		(define expression_work (physical_expression_work_profile src condition))
+		(define broad_text_average_bytes (qassoc_get expression_work (quote broad_text_average_bytes) 0))
 		(list
 			(list (quote scan_invocations) 1)
 			(list (quote input_rows) input_rows)
@@ -7569,6 +7632,11 @@ once; get_column is a leaf because column reads are costed independently. */
 			(list (quote map_columns) (count map_columns))
 			(list (quote expression_operations) (qassoc_get expression_work (quote operations) 0))
 			(list (quote expression_depth) (qassoc_get expression_work (quote depth) 0))
+			(list (quote broad_text_match_rows)
+				(if (number? input_rows)
+					(* input_rows (qassoc_get expression_work (quote broad_text_matches) 0)) nil))
+			(list (quote broad_text_match_bytes)
+				(if (number? input_rows) (* input_rows broad_text_average_bytes) nil))
 			(list (quote filter_value_rows)
 				(if (number? input_rows) (* input_rows (count filter_columns)) nil))
 			(list (quote expression_operation_rows)
@@ -7607,6 +7675,12 @@ once; get_column is a leaf because column reads are costed independently. */
 				(list (quote expression_depth) (max
 					(qassoc_get combined (quote expression_depth) 0)
 					(qassoc_get profile (quote expression_depth) 0)))
+				(list (quote broad_text_match_rows) (+
+					(coalesceNil (qassoc_get combined (quote broad_text_match_rows) nil) 0)
+					(coalesceNil (qassoc_get profile (quote broad_text_match_rows) nil) 0)))
+				(list (quote broad_text_match_bytes) (+
+					(coalesceNil (qassoc_get combined (quote broad_text_match_bytes) nil) 0)
+					(coalesceNil (qassoc_get profile (quote broad_text_match_bytes) nil) 0)))
 				(list (quote filter_value_rows) (+
 					(coalesceNil (qassoc_get combined (quote filter_value_rows) nil) 0)
 					(coalesceNil (qassoc_get profile (quote filter_value_rows) nil) 0)))
@@ -7628,6 +7702,20 @@ once; get_column is a leaf because column reads are costed independently. */
 						(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
 						(gs_keys stage))
 					'()))))))
+
+(define membership_candidate_work_facts (lambda (stage)
+	(begin
+		(define work (membership_candidate_work_profile stage))
+		(list
+			(list (quote membership_candidate_scan_invocations) (qassoc_get work (quote scan_invocations) 1))
+			(list (quote membership_candidate_filter_columns) (qassoc_get work (quote filter_columns) 0))
+			(list (quote membership_candidate_map_columns) (qassoc_get work (quote map_columns) (count (gs_keys stage))))
+			(list (quote membership_candidate_expression_operations) (qassoc_get work (quote expression_operations) 0))
+			(list (quote membership_candidate_expression_depth) (qassoc_get work (quote expression_depth) 0))
+			(list (quote membership_candidate_broad_text_match_rows) (qassoc_get work (quote broad_text_match_rows) 0))
+			(list (quote membership_candidate_broad_text_match_bytes) (qassoc_get work (quote broad_text_match_bytes) 0))
+			(list (quote membership_candidate_filter_value_rows) (qassoc_get work (quote filter_value_rows) nil))
+			(list (quote membership_candidate_expression_operation_rows) (qassoc_get work (quote expression_operation_rows) nil))))))
 
 (define membership_driver_work_profile (lambda (driver sources block)
 	(if (nil? driver)
@@ -7670,6 +7758,8 @@ once; get_column is a leaf because column reads are costed independently. */
 		(define estimate_capped (qassoc_get candidate_estimate (quote capped) false))
 		(define estimate_input (qassoc_get candidate_estimate (quote input) nil))
 		(define estimate_sampled (qassoc_get candidate_estimate (quote sampled) nil))
+		(define estimate_population (planner_estimate_population candidate_estimate))
+		(define estimate_coverage (planner_estimate_coverage candidate_estimate))
 		(define estimate_ratio_broad (and
 			(and (not (nil? estimate_rows)) (and (not (nil? estimate_sampled)) (> estimate_sampled 0)))
 			(>= (* estimate_rows 4) estimate_sampled)))
@@ -7679,6 +7769,8 @@ once; get_column is a leaf because column reads are costed independently. */
 		(define ordered_driver (if (nil? driver) false
 			(or (source_order_limit_driver? driver (qb_order block) (qb_limit block))
 				(source_row_number_limit_driver? (qb_stages block) driver))))
+		(define consumer (if (query_block_has_aggregates? block) (quote aggregate)
+			(if ordered_driver (quote order_limit) (quote filter))))
 		(define candidate_work (membership_candidate_work_profile stage))
 		(define driver_work (membership_driver_work_profile driver sources block))
 		(list
@@ -7693,6 +7785,8 @@ once; get_column is a leaf because column reads are costed independently. */
 			(list (quote membership_candidate_estimate_capped) estimate_capped)
 			(list (quote membership_candidate_estimate_input) estimate_input)
 			(list (quote membership_candidate_estimate_sampled) estimate_sampled)
+			(list (quote membership_candidate_estimate_population) estimate_population)
+			(list (quote membership_candidate_estimate_coverage) estimate_coverage)
 			(list (quote membership_candidate_probe_branches) candidate_probe_branches)
 			(list (quote membership_candidate_scan_invocations) (qassoc_get candidate_work (quote scan_invocations) candidate_probe_branches))
 			(list (quote membership_candidate_filter_columns) (qassoc_get candidate_work (quote filter_columns) 0))
@@ -7700,6 +7794,8 @@ once; get_column is a leaf because column reads are costed independently. */
 			(list (quote membership_candidate_cache_map_columns) (+ (count (gs_keys stage)) (count (gs_aggregates stage))))
 			(list (quote membership_candidate_expression_operations) (qassoc_get candidate_work (quote expression_operations) 0))
 			(list (quote membership_candidate_expression_depth) (qassoc_get candidate_work (quote expression_depth) 0))
+			(list (quote membership_candidate_broad_text_match_rows) (qassoc_get candidate_work (quote broad_text_match_rows) 0))
+			(list (quote membership_candidate_broad_text_match_bytes) (qassoc_get candidate_work (quote broad_text_match_bytes) 0))
 			(list (quote membership_candidate_filter_value_rows)
 				(coalesceNil (qassoc_get candidate_work (quote filter_value_rows) nil)
 					(if (number? candidate_rows)
@@ -7716,7 +7812,8 @@ once; get_column is a leaf because column reads are costed independently. */
 			(list (quote membership_driver_alternative) driver_alternative)
 			(list (quote membership_order_limit) (qb_limit block))
 			(list (quote membership_order_offset) (coalesceNil (qb_offset block) 0))
-			(list (quote membership_order_limit_driver) ordered_driver)))))
+			(list (quote membership_order_limit_driver) ordered_driver)
+			(list (quote membership_consumer) consumer)))))
 
 (define stage_reorder_telemetry (lambda (stage)
 	(list
@@ -7855,10 +7952,11 @@ in the canonicalization functions above. */
 			(coalesceNil (qassoc_get estimate (quote input) nil) fallback)
 			(coalesceNil (qassoc_get estimate (quote rows) nil) fallback)))))
 
-/* A capped sample still carries measured selectivity: rows/input is the
-observed hit rate before the cap was reached. Extrapolate that rate over the
-known input instead of confusing sampled input rows with matching rows. The
-cap remains an uncertainty signal for guards and EXPLAIN. */
+/* Only rows examined independently of the predicate's access index form a
+selectivity sample. Once an index or RecSet has restricted the iterator,
+sampled means "index candidates examined", not "table rows sampled". A capped
+restricted estimate is therefore merely a lower bound and must not be
+extrapolated as though the iterator were an unbiased table sample. */
 (define membership_estimated_matching_rows (lambda (estimate input_rows fallback)
 	(if (nil? estimate)
 		fallback
@@ -7868,7 +7966,9 @@ cap remains an uncertainty signal for guards and EXPLAIN. */
 			(if (and (qassoc_get estimate (quote capped) false)
 				(and (number? input_rows)
 					(and (number? rows) (and (number? sampled_input) (> sampled_input 0)))))
-				(min input_rows (* input_rows (/ rows sampled_input)))
+				(if (equal? (planner_estimate_coverage estimate) (quote lower_bound))
+					(coalesceNil fallback input_rows)
+					(min input_rows (* input_rows (/ rows sampled_input))))
 				(coalesceNil rows fallback))))))
 
 (define membership_driver_filter (lambda (condition)
@@ -7971,8 +8071,17 @@ physical alternative. */
 		(define projected_rows (membership_projected_driver_rows
 			candidate_input_rows candidate_rows projection_rows work))
 		(define base_cost (planner_cost_add
-			(membership_common_scan_cost candidate_input_rows candidate_rows projection_rows
-				(membership_work_value work (quote membership_candidate_map_columns) 1) work)
+			(planner_cost_add
+				(membership_common_scan_cost candidate_input_rows candidate_rows projection_rows
+					(membership_work_value work (quote membership_candidate_map_columns) 1) work)
+				(planner_cost 0
+					(+
+						(* (membership_work_value work (quote membership_candidate_broad_text_match_rows) 0)
+							planner_membership_broad_text_match_row_ns)
+						(* (membership_work_value work (quote membership_candidate_broad_text_match_bytes) 0)
+							planner_membership_broad_text_match_byte_ns))
+					0 0 0 0 0 0 candidate_input_rows 0.55)
+				candidate_input_rows 0.55)
 			(planner_cost planner_membership_recset_startup_ns 0 (* driver_rows planner_membership_recset_probe_row_ns)
 				0 0 (* (+ candidate_rows projected_rows) planner_membership_recset_build_row_ns)
 				(* (+ candidate_rows projected_rows) 8) 0 projection_rows 0.65)
@@ -8035,7 +8144,9 @@ physical alternative. */
 				(list (quote rows) (qassoc_get telemetry (quote membership_candidate_estimated_rows) nil))
 				(list (quote input) (qassoc_get telemetry (quote membership_candidate_estimate_input) nil))
 				(list (quote sampled) (qassoc_get telemetry (quote membership_candidate_estimate_sampled) nil))
-				(list (quote capped) (qassoc_get telemetry (quote membership_candidate_estimate_capped) false)))
+				(list (quote capped) (qassoc_get telemetry (quote membership_candidate_estimate_capped) false))
+				(list (quote population) (qassoc_get telemetry (quote membership_candidate_estimate_population) (quote table_rows)))
+				(list (quote coverage) (qassoc_get telemetry (quote membership_candidate_estimate_coverage) (quote sampled))))
 			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)
 			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)))
 		(define driver_strategy (membership_driver_strategy_for_telemetry telemetry))
@@ -8054,32 +8165,59 @@ physical alternative. */
 
 (define record_membership_physical_choice (lambda (requirement strategy reason candidates)
 	(begin
+		(define decision_id (concat "membership_carrier:"
+			(qassoc_get requirement (quote membership_stage_id) "unknown")))
+		(define alternatives (map candidates (lambda (candidate) (string (car candidate)))))
+		(define forced (planner_physical_override decision_id))
+		(define chosen (planner_physical_choice decision_id (string strategy) alternatives))
+		(define candidate_input_rows (qassoc_get requirement (quote membership_candidate_input_rows) nil))
+		(define candidate_rows (membership_estimated_matching_rows
+			(list
+				(list (quote rows) (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
+				(list (quote input) (qassoc_get requirement (quote membership_candidate_estimate_input) nil))
+				(list (quote sampled) (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
+				(list (quote capped) (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
+				(list (quote population) (qassoc_get requirement (quote membership_candidate_estimate_population) (quote table_rows)))
+				(list (quote coverage) (qassoc_get requirement (quote membership_candidate_estimate_coverage) (quote sampled))))
+			candidate_input_rows candidate_input_rows))
+		(define driver_input_rows (qassoc_get requirement (quote membership_driver_input_rows) nil))
+		(define driver_rows (if (qassoc_get requirement (quote membership_order_limit_driver) false)
+			(coalesceNil (probe_limit_work_rows (qassoc_get requirement (quote membership_order_limit) nil))
+				(qassoc_get requirement (quote membership_driver_rows) nil))
+			(qassoc_get requirement (quote membership_driver_rows) nil)))
 		(planner_record_physical_decision
 			(list
-				(list "decision_id" (concat "membership_carrier:"
-					(qassoc_get requirement (quote membership_stage_id) "unknown")))
+				(list "decision_id" decision_id)
 				(list "decision" "membership_carrier")
+				(list "decision_site" "physical_requirement")
 				(list "stage" (qassoc_get requirement (quote membership_stage_id) nil))
 				(list "consumer" (string
 					(qassoc_get requirement (quote membership_consumer) (quote filter))))
-				(list "chosen" (string strategy))
-				(list "reason" (string reason))
+				(list "chosen" chosen)
+				(list "normally_chosen" (string strategy))
+				(list "selection" (if (nil? forced) "cost" "forced"))
+				(list "reason" (if (nil? forced) (string reason) "calibration_override"))
 				(list "inputs" (list
-					(list "candidate_rows" (membership_estimated_matching_rows
-						(list
-							(list (quote rows) (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
-							(list (quote input) (qassoc_get requirement (quote membership_candidate_estimate_input) nil))
-							(list (quote sampled) (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
-							(list (quote capped) (qassoc_get requirement (quote membership_candidate_estimate_capped) false)))
-						(qassoc_get requirement (quote membership_candidate_input_rows) nil)
-						(qassoc_get requirement (quote membership_candidate_input_rows) nil)))
-					(list "candidate_input_rows" (qassoc_get requirement (quote membership_candidate_input_rows) nil))
-					(list "driver_rows" (qassoc_get requirement (quote membership_driver_rows) nil))
-					(list "driver_input_rows" (qassoc_get requirement (quote membership_driver_input_rows) nil))
+					(list "candidate_rows" candidate_rows)
+					(list "candidate_input_rows" candidate_input_rows)
+					(list "candidate_density" (if (and (number? candidate_input_rows) (number? candidate_rows))
+						(membership_candidate_density candidate_input_rows candidate_rows requirement) nil))
+					(list "projected_driver_rows" (if (and (number? candidate_input_rows)
+						(and (number? candidate_rows) (number? driver_input_rows)))
+						(membership_projected_driver_rows candidate_input_rows candidate_rows driver_input_rows requirement) nil))
+					(list "driver_rows" driver_rows)
+					(list "driver_input_rows" driver_input_rows)
+					(list "expected_driver_rows_visited" (if (and (number? candidate_input_rows)
+						(and (number? candidate_rows) (number? driver_rows)))
+						(membership_expected_driver_rows_visited candidate_input_rows candidate_rows driver_rows requirement) nil))
+					(list "limit" (qassoc_get requirement (quote membership_order_limit) nil))
+					(list "offset" (qassoc_get requirement (quote membership_order_offset) 0))
 					(list "driver_estimate_capped" (qassoc_get requirement (quote membership_driver_estimate_capped) false))
 					(list "selectivity_class" (string (qassoc_get requirement (quote membership_selectivity_class) nil)))
 					(list "estimate_capped" (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
 					(list "estimate_sampled_rows" (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
+					(list "estimate_population" (string (qassoc_get requirement (quote membership_candidate_estimate_population) (quote table_rows))))
+					(list "estimate_coverage" (string (qassoc_get requirement (quote membership_candidate_estimate_coverage) (quote sampled))))
 					(list "probe_branches" (qassoc_get requirement (quote membership_candidate_probe_branches) 1))
 					(list "candidate_scan_invocations" (qassoc_get requirement (quote membership_candidate_scan_invocations) 1))
 					(list "candidate_filter_columns" (qassoc_get requirement (quote membership_candidate_filter_columns) 0))
@@ -8087,6 +8225,8 @@ physical alternative. */
 					(list "candidate_cache_map_columns" (qassoc_get requirement (quote membership_candidate_cache_map_columns) 2))
 					(list "candidate_expression_operations" (qassoc_get requirement (quote membership_candidate_expression_operations) 0))
 					(list "candidate_expression_depth" (qassoc_get requirement (quote membership_candidate_expression_depth) 0))
+					(list "candidate_broad_text_match_rows" (qassoc_get requirement (quote membership_candidate_broad_text_match_rows) 0))
+					(list "candidate_broad_text_match_bytes" (qassoc_get requirement (quote membership_candidate_broad_text_match_bytes) 0))
 					(list "candidate_filter_value_rows" (qassoc_get requirement (quote membership_candidate_filter_value_rows) nil))
 					(list "candidate_expression_operation_rows" (qassoc_get requirement (quote membership_candidate_expression_operation_rows) nil))
 					(list "driver_scan_invocations" (qassoc_get requirement (quote membership_driver_scan_invocations) 1))
@@ -8098,12 +8238,12 @@ physical alternative. */
 				(list "alternatives" (map candidates (lambda (candidate)
 					(list
 						(list "plan" (string (car candidate)))
-						(list "status" (if (equal? (car candidate) strategy) "chosen" "rejected"))
-						(list "reason" (if (equal? (car candidate) strategy) "lowest_total_ns" "higher_total_ns_or_memory_tiebreak"))
+						(list "status" (if (equal? (string (car candidate)) chosen) "chosen" "rejected"))
+						(list "reason" (if (equal? (string (car candidate)) chosen) "selected" "higher_total_ns_or_forced_alternative"))
 						(list "cost" (planner_cost_explain (cadr candidate)))))))))
 		(if (qassoc_get requirement (quote membership_order_limit_driver) false)
 			(begin
-				(define recset_source (equal? strategy (quote candidate_keyset)))
+				(define recset_source (equal? chosen "candidate_keyset"))
 				(planner_record_physical_decision
 					(list
 						(list "decision" "ordered_recset_iterator")
@@ -8149,7 +8289,12 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(make_query_block
 					(qb_schema block) (qb_sources block) (qb_fields block) (qb_where block)
 					(qb_group block) (qb_having block) (qb_order block) (qb_limit block)
-					(qb_offset block) (qb_hidden block) (qb_stages block) physical_facts))))))
+					(qb_offset block) (qb_hidden block)
+					(map (qb_stages block) (lambda (stage)
+						(if (equal? (gs_id stage) (qassoc_get requirement (quote membership_stage_id) nil))
+							(group_stage_with_facts stage (merge (list requirement (gs_facts stage))))
+							stage)))
+					physical_facts))))))
 
 (define membership_broad_driver_probe_preferred? (lambda (block stage)
 	(begin
@@ -8164,6 +8309,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 (define membership_truth_projection_preferred? (lambda (block stage _guarded_alternative)
 	(begin
 		(define input (gs_input stage))
+		(define stage_facts (merge (list (membership_candidate_work_facts stage) (gs_facts stage))))
 		(define base_sources (filter (qb_sources block) source_is_base_table?))
 		/* Projection from the canonical group cache currently guarantees a
 		direct key map only for base-table membership stages. Derived inputs keep
@@ -8177,7 +8323,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 			false
 			(begin
 				(define candidate_estimate (planner_source_filter_estimate input
-					(coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true)
+					(coalesceNil (qassoc_get stage_facts (quote condition) true) true)
 					512))
 				(define capped (if (nil? candidate_estimate) false
 					(qassoc_get candidate_estimate (quote capped) false)))
@@ -8219,7 +8365,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
 				(define normal_choice (if broad_driver
 					"driver_order_membership_probe"
-					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows (gs_facts stage))
+					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows stage_facts)
 						"candidate_keyset"
 						"driver_order_membership_probe")))
 				(define normal_projection (equal? normal_choice projected_choice))
@@ -8227,15 +8373,16 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define chosen_projection (equal? chosen_choice projected_choice))
 				(define forced_choice (planner_physical_override decision_id))
 				(define candidate_cost (if (number? candidate_rows)
-					(membership_projection_cost candidate_total_rows candidate_rows driver_rows (gs_facts stage))
+					(membership_projection_cost candidate_total_rows candidate_rows driver_rows stage_facts)
 					nil))
 				(define driver_cost (if (number? driver_rows)
-					(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows (gs_facts stage))
+					(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows stage_facts)
 					nil))
 				(planner_record_physical_decision
 					(list
 						(list "decision_id" decision_id)
 						(list "decision" "membership_carrier")
+						(list "decision_site" "truth_projection")
 						(list "stage" (gs_id stage))
 						(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
 						(list "chosen" chosen_choice)
@@ -8250,32 +8397,36 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 							(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
 							(list "candidate_rows" candidate_rows)
 							(list "candidate_density" (membership_candidate_density
-								candidate_total_rows candidate_rows (gs_facts stage)))
+								candidate_total_rows candidate_rows stage_facts))
 							(list "projected_driver_rows"
-								(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows (gs_facts stage)))
+								(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows stage_facts))
 							(list "driver_input_rows" driver_total_rows)
 							(list "driver_rows" driver_rows)
 							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
-								candidate_total_rows candidate_rows driver_rows (gs_facts stage)))
+								candidate_total_rows candidate_rows driver_rows stage_facts))
 							(list "limit" (qb_limit block))
 							(list "offset" (coalesceNil (qb_offset block) 0))
 							(list "estimate_capped" capped)
 							(list "estimate_sampled_rows" (qassoc_get candidate_estimate (quote sampled) nil))
-							(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get (gs_facts stage) (quote selectivity_class) (quote unknown)))))
-							(list "candidate_scan_invocations" (qassoc_get (gs_facts stage) (quote membership_candidate_scan_invocations) 1))
-							(list "candidate_filter_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_filter_columns) 0))
-							(list "candidate_map_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_map_columns) 1))
-							(list "candidate_cache_map_columns" (qassoc_get (gs_facts stage) (quote membership_candidate_cache_map_columns) 2))
-							(list "candidate_expression_operations" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_operations) 0))
-							(list "candidate_expression_depth" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_depth) 0))
-							(list "candidate_filter_value_rows" (qassoc_get (gs_facts stage) (quote membership_candidate_filter_value_rows) nil))
-							(list "candidate_expression_operation_rows" (qassoc_get (gs_facts stage) (quote membership_candidate_expression_operation_rows) nil))
-							(list "driver_scan_invocations" (qassoc_get (gs_facts stage) (quote membership_driver_scan_invocations) 1))
-							(list "driver_filter_columns" (qassoc_get (gs_facts stage) (quote membership_driver_filter_columns) 0))
-							(list "driver_map_columns" (qassoc_get (gs_facts stage) (quote membership_driver_map_columns) 0))
-							(list "driver_expression_operations" (qassoc_get (gs_facts stage) (quote membership_driver_expression_operations) 0))
-							(list "driver_expression_depth" (qassoc_get (gs_facts stage) (quote membership_driver_expression_depth) 0))
-							(list "reuse" (qassoc_get (gs_facts stage) (quote reuse) 1))))
+							(list "estimate_population" (string (planner_estimate_population candidate_estimate)))
+							(list "estimate_coverage" (string (planner_estimate_coverage candidate_estimate)))
+							(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get stage_facts (quote selectivity_class) (quote unknown)))))
+							(list "candidate_scan_invocations" (qassoc_get stage_facts (quote membership_candidate_scan_invocations) 1))
+							(list "candidate_filter_columns" (qassoc_get stage_facts (quote membership_candidate_filter_columns) 0))
+							(list "candidate_map_columns" (qassoc_get stage_facts (quote membership_candidate_map_columns) 1))
+							(list "candidate_cache_map_columns" (qassoc_get stage_facts (quote membership_candidate_cache_map_columns) 2))
+							(list "candidate_expression_operations" (qassoc_get stage_facts (quote membership_candidate_expression_operations) 0))
+							(list "candidate_expression_depth" (qassoc_get stage_facts (quote membership_candidate_expression_depth) 0))
+							(list "candidate_broad_text_match_rows" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_rows) 0))
+							(list "candidate_broad_text_match_bytes" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_bytes) 0))
+							(list "candidate_filter_value_rows" (qassoc_get stage_facts (quote membership_candidate_filter_value_rows) nil))
+							(list "candidate_expression_operation_rows" (qassoc_get stage_facts (quote membership_candidate_expression_operation_rows) nil))
+							(list "driver_scan_invocations" (qassoc_get stage_facts (quote membership_driver_scan_invocations) 1))
+							(list "driver_filter_columns" (qassoc_get stage_facts (quote membership_driver_filter_columns) 0))
+							(list "driver_map_columns" (qassoc_get stage_facts (quote membership_driver_map_columns) 0))
+							(list "driver_expression_operations" (qassoc_get stage_facts (quote membership_driver_expression_operations) 0))
+							(list "driver_expression_depth" (qassoc_get stage_facts (quote membership_driver_expression_depth) 0))
+							(list "reuse" (qassoc_get stage_facts (quote reuse) 1))))
 						(list "alternatives" (list
 							(list
 								(list "plan" "candidate_keyset")
@@ -12838,7 +12989,10 @@ That makes the recorded and forced choice identical to the executable plan. */
 (define recset_project_join_expr_for_membership_using (lambda (src membership consumer ordered_filter driver_rows_override)
 	(begin
 		(define stage (nth membership 0))
-		(define facts (gs_facts stage))
+		/* Some late RecSet consumers are introduced after reorder telemetry was
+		attached. Reconstruct only the candidate's scalar work from the existing
+		logical stage; this is one formula walk, never an alternative plan build. */
+		(define facts (merge (list (membership_candidate_work_facts stage) (gs_facts stage))))
 		(define cost_facts (if (equal? consumer (quote aggregate))
 			(qassoc_set facts (quote membership_consumer) (quote aggregate))
 			facts))
@@ -12850,6 +13004,12 @@ That makes the recorded and forced choice identical to the executable plan. */
 			raw_expr
 			(begin
 				(define measured_estimate (planner_stage_filter_estimate (gs_input stage) 512))
+				(define estimate_population (coalesceNil
+					(qassoc_get facts (quote membership_candidate_estimate_population) nil)
+					(planner_estimate_population measured_estimate)))
+				(define estimate_coverage (coalesceNil
+					(qassoc_get facts (quote membership_candidate_estimate_coverage) nil)
+					(planner_estimate_coverage measured_estimate)))
 				(define capped (or
 					(qassoc_get facts (quote membership_candidate_estimate_capped) false)
 					(qassoc_get measured_estimate (quote capped) false)))
@@ -12868,7 +13028,9 @@ That makes the recorded and forced choice identical to the executable plan. */
 						(list (quote sampled) (coalesceNil
 							(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
 							(qassoc_get measured_estimate (quote sampled) nil)))
-						(list (quote capped) capped))
+						(list (quote capped) capped)
+						(list (quote population) estimate_population)
+						(list (quote coverage) estimate_coverage))
 					candidate_input_rows candidate_input_rows))
 				/* Ordered LIMIT consumes only its local window before downstream
 				operators. Cost this edge with that workload instead of a global
@@ -12904,6 +13066,7 @@ That makes the recorded and forced choice identical to the executable plan. */
 					(list
 						(list "decision_id" decision_id)
 						(list "decision" "membership_carrier")
+						(list "decision_site" "recset_lowering")
 						(list "stage" (gs_id stage))
 						(list "consumer" (string (coalesceNil consumer
 							(qassoc_get facts (quote membership_consumer) (quote filter)))))
@@ -12935,6 +13098,8 @@ That makes the recorded and forced choice identical to the executable plan. */
 							(list "estimate_sampled_rows" (coalesceNil
 								(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
 								(qassoc_get measured_estimate (quote sampled) nil)))
+							(list "estimate_population" (string estimate_population))
+							(list "estimate_coverage" (string estimate_coverage))
 							(list "probe_branches" (qassoc_get facts (quote membership_candidate_probe_branches) 1))
 							(list "selectivity_class" (string (qassoc_get facts (quote membership_selectivity_class) (quote unknown))))
 							(list "candidate_scan_invocations" (qassoc_get facts (quote membership_candidate_scan_invocations) 1))
@@ -12943,6 +13108,8 @@ That makes the recorded and forced choice identical to the executable plan. */
 							(list "candidate_cache_map_columns" (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
 							(list "candidate_expression_operations" (qassoc_get facts (quote membership_candidate_expression_operations) 0))
 							(list "candidate_expression_depth" (qassoc_get facts (quote membership_candidate_expression_depth) 0))
+							(list "candidate_broad_text_match_rows" (qassoc_get facts (quote membership_candidate_broad_text_match_rows) 0))
+							(list "candidate_broad_text_match_bytes" (qassoc_get facts (quote membership_candidate_broad_text_match_bytes) 0))
 							(list "candidate_filter_value_rows" (qassoc_get facts (quote membership_candidate_filter_value_rows) nil))
 							(list "candidate_expression_operation_rows" (qassoc_get facts (quote membership_candidate_expression_operation_rows) nil))
 							(list "driver_scan_invocations" (qassoc_get facts (quote membership_driver_scan_invocations) 1))
@@ -15475,10 +15642,12 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_filter_column_row_ns 1)
 (define planner_membership_map_column_row_ns 28)
 (define planner_membership_expression_operation_row_ns 98)
+(define planner_membership_broad_text_match_row_ns 1)
+(define planner_membership_broad_text_match_byte_ns 4)
 (define planner_membership_recset_startup_ns 1)
 (define planner_membership_recset_build_row_ns 1)
 (define planner_membership_recset_probe_row_ns 1)
-(define planner_membership_recset_aggregate_row_ns 132)
+(define planner_membership_recset_aggregate_row_ns 215)
 (define planner_membership_group_cache_startup_ns 17538872)
 (define planner_membership_group_cache_build_row_ns 11590)
 (define planner_membership_group_cache_probe_row_ns 132886)
@@ -17063,14 +17232,14 @@ get_column refs to the source) are excluded automatically too. */
 											(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 												(extract_columns_for_alias src expr)))))
 											(define scan_mapcols (merge_unique (list (without_col fieldcols col) mapcols)))
-										(define filter_expr (list (quote lambda)
-											(map filtercols (lambda (filter_col) (scan_callback_symbol_for_alias (source_alias src) filter_col)))
-											(lower_column_expr_for_alias src filter_condition)))
+											(define filter_expr (list (quote lambda)
+												(map filtercols (lambda (filter_col) (scan_callback_symbol_for_alias (source_alias src) filter_col)))
+												(lower_column_expr_for_alias src filter_condition)))
 											(define row_expr (list (quote resultrow)
 												(cons (quote list) (lower_row_number_result_fields src col fields))))
-										(define continuation_expr (list (quote lambda) (list (quote __row_number))
-											(list (quote if)
-												(lower_column_expr_for_alias src rewritten_condition)
+											(define continuation_expr (list (quote lambda) (list (quote __row_number))
+												(list (quote if)
+													(lower_column_expr_for_alias src rewritten_condition)
 													row_expr
 													nil)))
 											(define map_expr (list (quote lambda)
@@ -17993,10 +18162,10 @@ path. */
 					(list (quote scan_recset)
 						'(session "__memcp_tx")
 						(source_table_expr input_src)
-					(cons (quote list) filtercols)
-					(list (quote lambda)
-						(map filtercols (lambda (col) (symbol (concat alias "." col))))
-						(lower_column_expr_for_alias input_src condition)))))))))
+						(cons (quote list) filtercols)
+						(list (quote lambda)
+							(map filtercols (lambda (col) (symbol (concat alias "." col))))
+							(lower_column_expr_for_alias input_src condition)))))))))
 
 (define membership_keyset_bindings (lambda (memberships)
 	(begin
@@ -20809,6 +20978,7 @@ potentially large calibrated SELECT result. */
 			(equal? operator_family expected_family)))
 		(define baseline_hash_key (concat "hash:" decision_id))
 		(define baseline_count_key (concat "count:" decision_id))
+		(define shared_suite (equal? suite_var (quote __physical_calibration_suite)))
 		(list
 			(list (quote lambda) (list (quote __calibration_emit))
 				(list (quote !begin)
@@ -20852,9 +21022,13 @@ potentially large calibrated SELECT result. */
 							"estimated_ns" estimated_ns
 							"whole_query_execution_ns" (quote __calibration_whole_query_execution_ns)
 							"operator_ns" nil
+							"measurement_scope" (if shared_suite "shared_sequential_diagnostic" "isolated_variant_request")
+							"fit_eligible" (not shared_suite)
 							"candidate_input_rows" (physical_calibration_input decision "candidate_input_rows")
 							"candidate_rows" (physical_calibration_input decision "candidate_rows")
 							"candidate_density" (physical_calibration_input decision "candidate_density")
+							"estimate_population" (physical_calibration_input decision "estimate_population")
+							"estimate_coverage" (physical_calibration_input decision "estimate_coverage")
 							"projected_driver_rows" (physical_calibration_input decision "projected_driver_rows")
 							"driver_input_rows" (physical_calibration_input decision "driver_input_rows")
 							"driver_rows" (physical_calibration_input decision "driver_rows")
@@ -20868,6 +21042,8 @@ potentially large calibrated SELECT result. */
 							"candidate_cache_map_columns" (physical_calibration_input decision "candidate_cache_map_columns")
 							"candidate_expression_operations" (physical_calibration_input decision "candidate_expression_operations")
 							"candidate_expression_depth" (physical_calibration_input decision "candidate_expression_depth")
+							"candidate_broad_text_match_rows" (physical_calibration_input decision "candidate_broad_text_match_rows")
+							"candidate_broad_text_match_bytes" (physical_calibration_input decision "candidate_broad_text_match_bytes")
 							"candidate_filter_value_rows" (physical_calibration_input decision "candidate_filter_value_rows")
 							"candidate_expression_operation_rows" (physical_calibration_input decision "candidate_expression_operation_rows")
 							"driver_scan_invocations" (physical_calibration_input decision "driver_scan_invocations")

--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7150,19 +7150,25 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(not (nil? (extract_row_number_filter src (os_column stage) (source_join_expr src))))))))
 		false)))
 
-(define planner_table_row_count (lambda (schema relation)
+(define planner_table_statistics (lambda (schema relation)
 	(try
 		(lambda ()
-			/* SHOW exposes shard-local row_count values. Physical choices need the
-			whole relation cardinality, which the storage table estimate already
-			aggregates across active shards. */
-			(define live_count (scan_estimate (table schema relation)))
-			(if (and (not (nil? live_count)) (> live_count 0))
-				live_count
-				(match (get_schema schema relation)
-					(cons col _rest) (col "RowEstimate")
-					_ live_count)))
+			(begin
+				(define cache (session "__memcp_queryplan_statistics"))
+				(define key (concat schema "." relation))
+				(define cached (if (nil? cache) nil (cache key)))
+				(if (nil? cached)
+					(begin
+						(define snapshot (table_planner_statistics (table schema relation)))
+						(if (nil? cache) nil (cache key snapshot))
+						snapshot)
+					cached)))
 		(lambda (_e) nil))))
+
+(define planner_table_row_count (lambda (schema relation)
+	(begin
+		(define stats (planner_table_statistics schema relation))
+		(if (nil? stats) nil (stats "row_count")))))
 
 (define planner_source_filter_estimate (lambda (src condition max_rows)
 	(if (not (source_is_base_table? src))
@@ -7231,24 +7237,18 @@ source itself has no known row count (not a base table). */
 			(list (quote average_value_bytes) nil))
 		(try
 			(lambda ()
-				(reduce (get_schema (source_schema src) (source_relation src)) (lambda (found row)
-					(if (not (nil? found))
-						found
-						(if (equal?? (row "Field") column)
-							(list
-								(list (quote known) (row "StatisticsKnown"))
-								(list (quote confidence) (row "StatisticsConfidence"))
-								(list (quote source) (symbol (row "StatisticsSource")))
-								(list (quote distinct) (row "DistinctEstimate"))
-								(list (quote distinct_confidence)
-									(if (row "StatisticsKnown") (row "StatisticsConfidence") 0))
-								(list (quote distinct_source) (symbol (row "DistinctEstimateSource")))
-								(list (quote null_fraction) (row "NullFraction"))
-								(list (quote min) (row "MinEstimate"))
-								(list (quote max) (row "MaxEstimate"))
-								(list (quote average_value_bytes) (row "AverageValueBytes")))
-							nil)))
-					nil))
+				(begin
+					(define stats (planner_table_statistics (source_schema src) (source_relation src)))
+					(define columns (if (nil? stats) nil (stats "columns")))
+					(define column_stats (if (nil? columns) nil (columns column)))
+					/* The immutable column catalog deliberately does not get rebuilt
+					for every INSERT/DELETE. Resolve its row-count fallback against
+					the current two-entry table snapshot in constant time instead. */
+					(if (or (nil? column_stats)
+						(not (equal? (qassoc_get column_stats (quote distinct_source) (quote unknown))
+							(quote fallback_row_count))))
+						column_stats
+						(qassoc_set column_stats (quote distinct) (stats "row_count")))))
 			(lambda (_e) (list
 				(list (quote known) false)
 				(list (quote confidence) 0)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -154,6 +154,7 @@ functional planner return value. */
 		(planning_session "__memcp_queryplan_guard_bindings" (newsession))
 		(planning_session "__memcp_queryplan_guarded_session_keys" (newsession))
 		(planning_session "__memcp_queryplan_observed_session_keys" (newsession))
+		(planning_session "__memcp_queryplan_statistics" (newsession))
 		planning_session)))
 
 (define sql_queryplan_uncovered_binding_conditions (lambda (planning_session)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -566,6 +566,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"keytable cost check refuses the carrier when probe_work_rows is a non-numeric sentinel")
 	(assert (scalar_first_probe_keytable_cost_preferred? cost_probe_stage "72") false
 		"keytable cost check refuses the carrier when probe_work_rows is a non-numeric string")
+	(assert (membership_estimated_matching_rows
+		(list
+			(list (quote rows) 512)
+			(list (quote sampled) 512)
+			(list (quote capped) true)
+			(list (quote population) (quote index_candidates))
+			(list (quote coverage) (quote lower_bound)))
+		100000 100000) 100000
+		"capped index candidates remain a lower bound instead of becoming 100% selectivity")
+	(assert (membership_estimated_matching_rows
+		(list
+			(list (quote rows) 128)
+			(list (quote sampled) 512)
+			(list (quote capped) true)
+			(list (quote population) (quote table_rows))
+			(list (quote coverage) (quote sampled)))
+		100000 100000) 25000
+		"capped table samples retain proportional selectivity extrapolation")
 	/* planner_recset_carrier_cost / scalar_first_probe_recset_cost_preferred?:
 	same "unknown stays unknown" discipline as the keytable check above, plus
 	the actual three-way comparison. A RecSet's build cost scales with

--- a/storage/database.go
+++ b/storage/database.go
@@ -898,6 +898,7 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 			if !hasColdShard {
 				// Update per-column statistics only when every rebuilt shard has
 				// authoritative in-memory counters and column statistics.
+				t.collectStatisticsFromShards(newShardList)
 				rowEst := uint64(t.CountEstimate())
 				for ci := range t.Columns {
 					var distinctSum uint64
@@ -923,7 +924,6 @@ func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, o
 						t.Columns[ci].PlannerStats.Store(nil)
 					}
 				}
-				t.collectStatisticsFromShards(newShardList)
 			}
 			t.publishShowColumnsSnapshot()
 			t.mu.Lock()

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -62,9 +62,37 @@ func TestEstimateFilteredRowsReportsExaminedSample(t *testing.T) {
 	if len(shards) != 1 {
 		t.Fatalf("active shards = %d, want 1", len(shards))
 	}
-	matches, capped, sampled := shards[0].EstimateFilteredRows(cols[:1], condition, 3, nil)
-	if matches != 3 || !capped || sampled != 5 {
-		t.Fatalf("estimate = matches %d, capped %t, sampled %d; want 3, true, 5", matches, capped, sampled)
+	estimate := shards[0].EstimateFilteredRows(cols[:1], condition, 3, nil)
+	if estimate.rows != 3 || !estimate.capped || estimate.examined != 5 ||
+		estimate.population != "table_rows" || estimate.coverage != "sampled" {
+		t.Fatalf("estimate = %+v; want 3 sampled matches after 5 table rows", estimate)
+	}
+}
+
+func TestEstimateFilteredRowsMarksCappedIndexPopulationAsLowerBound(t *testing.T) {
+	tbl, cols := scanColumnCostTable(t, "estimate_index_population", 10)
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("c0")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal?"), scm.NewSymbol("c0"), scm.NewInt(4),
+		}),
+		En: &scm.Globalenv,
+	})
+	shard := tbl.ActiveShards()[0]
+	bounds := extractBoundaries(cols[:1], condition)
+	lower, upperLast := indexFromBoundaries(bounds)
+	var buf [16]uint32
+	for range 2 {
+		shard.mu.RLock()
+		shard.iterateIndex(nil, bounds, lower, upperLast, len(shard.inserts), buf[:], 1, nil,
+			func([]uint32) bool { return true })
+		shard.mu.RUnlock()
+	}
+
+	estimate := shard.EstimateFilteredRows(cols[:1], condition, 1, nil)
+	if estimate.rows != 1 || !estimate.capped || estimate.examined != 1 ||
+		estimate.population != "index_candidates" || estimate.coverage != "lower_bound" {
+		t.Fatalf("estimate = %+v; want capped index lower bound", estimate)
 	}
 }
 

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -532,6 +532,7 @@ func TestTableStatisticsReadsPublishedSnapshotWithoutShardLock(t *testing.T) {
 	}
 	tbl := &table{schema: &database{Name: "table-statistics-test"}, Shards: []*storageShard{shard}}
 	shard.t = tbl
+	tbl.PlannerRowEstimate.value.Store(1)
 	tbl.publishShowColumnsSnapshot()
 	if stats := tbl.statistics(); stats.rowCount != 1 || stats.sizeBytes != 0 {
 		t.Fatalf("startup statistics = %+v, want row estimate 1 before size collection", stats)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2512,7 +2512,15 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	return
 }
 
-func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition scm.Scmer, limit int, currentTx *TxContext) (int64, bool, int64) {
+type filteredRowEstimate struct {
+	rows       int64
+	capped     bool
+	examined   int64
+	population string
+	coverage   string
+}
+
+func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition scm.Scmer, limit int, currentTx *TxContext) filteredRowEstimate {
 	if limit <= 0 {
 		limit = 1024
 	}
@@ -2527,7 +2535,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	if recsetFilter != nil {
 		recsetPart = recsetFilter.shardEntry(t)
 		if recsetPart == nil || recsetPart.count == 0 {
-			return 0, false, 0
+			return filteredRowEstimate{population: "recset_candidates", coverage: "exact"}
 		}
 	}
 	recsetBoundaryCoversCondition := recsetPart != nil && recSetBoundaryCallCount(conditionCols, condition) == 1
@@ -2560,10 +2568,13 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	count := int64(0)
 	sampled := int64(0)
 	capped := false
+	indexRestricted := false
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var buf [256]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, func(_ *StorageIndex, active bool) {
+		indexRestricted = active && len(lower) > 0
+	}, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if recsetPart != nil && !recsetPart.contains(idx) {
 				continue
@@ -2610,7 +2621,27 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		return true
 	})
 
-	return count, capped, sampled
+	population := "table_rows"
+	if recsetPart != nil {
+		population = "recset_candidates"
+	} else if indexRestricted {
+		population = "index_candidates"
+	}
+	coverage := "exact"
+	if capped {
+		if population == "table_rows" {
+			coverage = "sampled"
+		} else {
+			coverage = "lower_bound"
+		}
+	}
+	return filteredRowEstimate{
+		rows:       count,
+		capped:     capped,
+		examined:   sampled,
+		population: population,
+		coverage:   coverage,
+	}
 }
 
 func (t *storageShard) getDelta(idx int, col string) scm.Scmer {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -954,7 +954,7 @@ func (t *storageShard) resolveVisiblePrimaryRecidLocked(staleRecid uint32) (uint
 }
 
 func (t *storageShard) UpdateFunction(idx uint32, withTrigger bool, alreadyLocked bool, currentTx *TxContext) func(...scm.Scmer) scm.Scmer {
-	return t.UpdateFunctionBatch(idx, withTrigger, alreadyLocked, nil, currentTx)
+	return t.UpdateFunctionBatch(idx, withTrigger, alreadyLocked, nil, nil, currentTx)
 }
 
 // sameUpdateValue keeps Scheme's useful numeric/coercive equality while
@@ -971,7 +971,7 @@ func isRuntimeComputedColumn(colDesc *column) bool {
 	return len(colDesc.OrcSortCols) > 0 || !colDesc.Computor.IsNil() || len(colDesc.ComputorInputCols) > 0
 }
 
-func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, alreadyLocked bool, batch *triggerBatch, currentTx *TxContext) func(...scm.Scmer) scm.Scmer {
+func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, alreadyLocked bool, batch *triggerBatch, deletedRows *uint64, currentTx *TxContext) func(...scm.Scmer) scm.Scmer {
 	// returns a callback with which you can delete or update an item
 	return func(a ...scm.Scmer) scm.Scmer {
 		//fmt.Println("update/delete", a)
@@ -1432,6 +1432,9 @@ func (t *storageShard) UpdateFunctionBatch(idx uint32, withTrigger bool, already
 			}
 		}
 		if result {
+			if len(a) == 0 && deletedRows != nil {
+				*deletedRows++
+			}
 			// Dual-write: forward DELETE to PShards during repartition
 			if t.t.repartitionDualWriteActive.Load() && t.t.isRepartitionSource(t) {
 				t.t.dualWriteDelete(t, idx, currentTx)
@@ -1538,6 +1541,7 @@ type ShardMapReducer struct {
 	reduceFn       func(...scm.Scmer) scm.Scmer
 	mapScmer       scm.Scmer     // original Scmer for network serialization
 	deleteBatch    *triggerBatch // when set, DELETE triggers are batched instead of per-row
+	deletedRows    uint64        // applied DELETEs, published once when the mapper flushes
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
@@ -1798,7 +1802,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		}
 		if needsMutationMetadata && mr.isUpdate[i] {
 			getter := func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewFunc(mr.shard.UpdateFunctionBatch(id, true, mr.shardWriteLocked, mr.deleteBatch, mr.currentTx))
+				return scm.NewFunc(mr.shard.UpdateFunctionBatch(id, true, mr.shardWriteLocked, mr.deleteBatch, &mr.deletedRows, mr.currentTx))
 			}
 			mr.mainGetters[i] = getter
 			mr.deltaGetters[i] = getter
@@ -2086,6 +2090,10 @@ func (m *ShardMapReducer) FlushSideEffects() {
 	if m.deleteBatch != nil {
 		m.deleteBatch.Flush()
 		m.deleteBatch = nil
+	}
+	if m.deletedRows > 0 {
+		m.shard.t.adjustPlannerRows(-int64(m.deletedRows))
+		m.deletedRows = 0
 	}
 }
 

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -672,8 +672,7 @@ func TestPartitionTableEmptySpecKeepsFreeShardMode(t *testing.T) {
 	origUUID := tbl.Shards[0].uuid
 
 	res := callBuiltin(t, "partitiontable",
-		scm.NewString("temptypartition"),
-		scm.NewString("items"),
+		NewTableScmer(tbl),
 		scm.NewSlice(nil),
 	)
 	if scm.ToBool(res) {
@@ -721,8 +720,7 @@ func TestPartitionTableNestedAssocAppliesRealPartitioning(t *testing.T) {
 	}, nil, scm.NewNil(), false, nil)
 
 	res := callBuiltin(t, "partitiontable",
-		scm.NewString("tnestedpartition"),
-		scm.NewString("items"),
+		NewTableScmer(tbl),
 		scm.NewSlice([]scm.Scmer{
 			scm.NewSlice([]scm.Scmer{
 				scm.NewString("id"),
@@ -772,8 +770,7 @@ func TestPartitionTableSinglePartitionSpecIsNoop(t *testing.T) {
 	origUUID := tbl.Shards[0].uuid
 
 	res := callBuiltin(t, "partitiontable",
-		scm.NewString("tsinglepartition"),
-		scm.NewString("items"),
+		NewTableScmer(tbl),
 		scm.NewSlice([]scm.Scmer{
 			scm.NewSlice([]scm.Scmer{
 				scm.NewString("id"),
@@ -1172,8 +1169,7 @@ func TestCreateColumnBuiltinUpgradesExistingColumnToORC(t *testing.T) {
 	createcolumn := scm.Globalenv.Vars[scm.Symbol("createcolumn")]
 	result := scm.Apply(
 		createcolumn,
-		scm.NewString("tcreatecolumnorc"),
-		scm.NewString("items"),
+		NewTableScmer(tbl),
 		scm.NewString("running"),
 		scm.NewString("INT"),
 		scm.NewSlice(nil),

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -611,6 +611,19 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "table_planner_statistics",
+		Desc: "return the immutable O(1) planner-statistics snapshot for a table",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			return TableFromScmer(a[0]).PlannerStatistics()
+		},
+		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "table", ParamName: "table"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "any"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_selectivity_estimate",
 		Desc: "bounded estimate of visible rows matching a table filter; stops at max_rows and does not log scan telemetry",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
@@ -671,7 +684,7 @@ func Init(en scm.Env) {
 		Desc: "returns true if a table currently has no rows",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
-			return scm.NewBool(t.CountEstimate() == 0)
+			return scm.NewBool(t.CountExact() == 0)
 		},
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -625,14 +625,22 @@ func Init(en scm.Env) {
 			var rows int64
 			var sampled int64
 			capped := false
+			population := "table_rows"
+			coverage := "exact"
 			for _, shard := range t.ActiveShards() {
 				if shard == nil {
 					continue
 				}
-				shardRows, shardCapped, shardSampled := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
-				rows += shardRows
-				sampled += shardSampled
-				if shardCapped || rows >= int64(limit) {
+				estimate := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
+				rows += estimate.rows
+				sampled += estimate.examined
+				if estimate.population != "table_rows" {
+					population = estimate.population
+				}
+				if estimate.coverage != "exact" {
+					coverage = estimate.coverage
+				}
+				if estimate.capped || rows >= int64(limit) {
 					capped = true
 					break
 				}
@@ -643,6 +651,8 @@ func Init(en scm.Env) {
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(capped)}),
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(sampled)}),
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol(population)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(coverage)}),
 			})
 		},
 		Type: &scm.TypeDescriptor{

--- a/storage/table.go
+++ b/storage/table.go
@@ -67,6 +67,26 @@ type columnPlannerStatistics struct {
 	MaxEstimate       scm.Scmer
 }
 
+// atomicPlannerRowEstimate persists the last rebuild estimate while retaining
+// lock-free access. Its JSON methods use atomic operations too, so concurrent
+// schema persistence cannot race query compilation.
+type atomicPlannerRowEstimate struct {
+	value atomic.Uint64
+}
+
+func (estimate *atomicPlannerRowEstimate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(estimate.value.Load())
+}
+
+func (estimate *atomicPlannerRowEstimate) UnmarshalJSON(data []byte) error {
+	var value uint64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	estimate.value.Store(value)
+	return nil
+}
+
 type column struct {
 	Name              string
 	Typ               string
@@ -451,6 +471,10 @@ type table struct {
 	// load it without locking; metadata writers replace the complete snapshot.
 	showColumnsSnapshot atomic.Pointer[tableShowColumnsSnapshot]
 	columnNamesSnapshot atomic.Pointer[tableColumnNamesSnapshot]
+	// plannerRowEstimate is deliberately approximate. Rebuild/statistics
+	// publication replaces it atomically; query compilation must never load a
+	// cold shard or take a shard read lock merely to obtain a row estimate.
+	PlannerRowEstimate atomicPlannerRowEstimate `json:"planner_row_estimate"`
 
 	// storage: ShardMode controls which shard set is the read/write target
 	ShardMode   ShardMode
@@ -694,6 +718,7 @@ func (t *table) collectStatisticsFromShards(shards []*storageShard) {
 		stats.rowCount += shardStats.rowCount()
 		stats.sizeBytes += int64(shardStats.size)
 	}
+	t.PlannerRowEstimate.value.Store(uint64(stats.rowCount))
 	for {
 		current := t.showColumnsSnapshot.Load()
 		if current == nil {
@@ -705,9 +730,10 @@ func (t *table) collectStatisticsFromShards(shards []*storageShard) {
 			}
 			continue
 		}
-		replacement := *current
+		replacement := t.buildShowColumnsSnapshot(uint(stats.rowCount))
 		replacement.statistics = stats
-		if t.showColumnsSnapshot.CompareAndSwap(current, &replacement) {
+		if t.showColumnsSnapshot.CompareAndSwap(current, replacement) {
+			t.columnNamesSnapshot.Store(replacement.columnNames)
 			return
 		}
 	}
@@ -1089,18 +1115,71 @@ func (t *table) Count() (result uint) {
 	return
 }
 
-// CountEstimate returns the exact table-wide visible-row estimate. It is O(the
-// number of shards), not O(rows); summing matters because the final shard is
-// commonly partial and first-shard extrapolation can be wrong by orders of
-// magnitude after repartitioning.
-func (t *table) CountEstimate() (result uint) {
+// CountEstimate returns the last atomically published table-wide estimate.
+// It is O(1), non-blocking, and never acquires concurrency rights or causes a
+// lazy shard load. Statistics are refreshed by rebuild/collection; staleness is
+// preferable to adding locks or storage I/O to the query compiler hot path.
+func (t *table) CountEstimate() uint {
+	return uint(t.PlannerRowEstimate.value.Load())
+}
+
+// adjustPlannerRows advances the approximate cardinality after one DML batch.
+// Only the two-entry snapshot root is replaced; the immutable hashed column
+// catalog is reused. This keeps maintenance O(1) per batch and avoids forcing
+// the next compiler through shard state.
+func (t *table) adjustPlannerRows(delta int64) {
+	if delta == 0 {
+		return
+	}
+	var rowEstimate uint64
+	for {
+		oldEstimate := t.PlannerRowEstimate.value.Load()
+		if delta > 0 {
+			rowEstimate = oldEstimate + uint64(delta)
+		} else if decrement := uint64(-delta); decrement < oldEstimate {
+			rowEstimate = oldEstimate - decrement
+		} else {
+			rowEstimate = 0
+		}
+		if t.PlannerRowEstimate.value.CompareAndSwap(oldEstimate, rowEstimate) {
+			break
+		}
+	}
+	for {
+		current := t.showColumnsSnapshot.Load()
+		if current == nil || current.plannerValue.IsNil() {
+			return
+		}
+		columns, ok := current.plannerValue.FastDict().Get(scm.NewString("columns"))
+		if !ok {
+			return
+		}
+		plannerRoot := scm.NewFastDictValue(2)
+		plannerRoot.Set(scm.NewString("row_count"), scm.NewInt(int64(rowEstimate)), nil)
+		plannerRoot.Set(scm.NewString("columns"), columns, nil)
+		replacement := *current
+		replacement.plannerValue = scm.NewFastDict(plannerRoot)
+		replacement.rowEstimate = uint(rowEstimate)
+		if t.showColumnsSnapshot.CompareAndSwap(current, &replacement) {
+			return
+		}
+	}
+}
+
+// CountExact returns the current visible row count. It may load shards and is
+// reserved for correctness-sensitive execution paths, never query planning.
+func (t *table) CountExact() (result uint) {
 	for _, shard := range t.ActiveShards() {
 		if shard == nil {
 			continue
 		}
-		unlock := shard.GetRead()
-		result += uint(shard.Count())
-		unlock()
+		func() {
+			unlock := shard.GetRead()
+			defer unlock()
+			shard.mu.RLock()
+			defer shard.mu.RUnlock()
+			result += uint(shard.Count())
+		}()
 	}
 	return result
 }
@@ -1198,11 +1277,12 @@ func getForeignKeyMode(val scm.Scmer) foreignKeyMode {
 }
 
 type tableShowColumnsSnapshot struct {
-	value       scm.Scmer
-	rowEstimate uint
-	columns     *tableShowColumnsMetadata
-	columnNames *tableColumnNamesSnapshot
-	statistics  *tableStatisticsSnapshot
+	value        scm.Scmer
+	plannerValue scm.Scmer
+	rowEstimate  uint
+	columns      *tableShowColumnsMetadata
+	columnNames  *tableColumnNamesSnapshot
+	statistics   *tableStatisticsSnapshot
 }
 
 type tableShowColumnsMetadata struct {
@@ -1235,28 +1315,9 @@ func foldIdentifier(name string) string {
 	return strings.ToLower(name)
 }
 
-func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, rowEstimate uint) bool {
-	if snapshot == nil || snapshot.columns == nil || snapshot.rowEstimate != rowEstimate ||
-		len(snapshot.columns.distinctEstimates) != len(t.Columns) || len(snapshot.columns.plannerStatistics) != len(t.Columns) {
-		return false
-	}
-	for i, c := range t.Columns {
-		distinctEstimate := atomic.LoadUint64(&c.DistinctEstimate)
-		if distinctEstimate == 0 {
-			distinctEstimate = uint64(rowEstimate)
-		}
-		if snapshot.columns.distinctEstimates[i] != distinctEstimate {
-			return false
-		}
-		if snapshot.columns.plannerStatistics[i] != c.PlannerStats.Load() {
-			return false
-		}
-	}
-	return true
-}
-
 func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnapshot {
 	result := make([]scm.Scmer, len(t.Columns))
+	plannerColumns := scm.NewFastDictValue(len(t.Columns))
 	distinctEstimates := make([]uint64, len(t.Columns))
 	plannerStatistics := make([]*columnPlannerStatistics, len(t.Columns))
 	columnNames := t.buildColumnNamesSnapshot()
@@ -1280,10 +1341,19 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 		distinctEstimates[i] = distinctEstimate
 		plannerStatistics[i] = c.PlannerStats.Load()
 		result[i] = c.show(keyType, distinctEstimate, rowEstimate, plannerStatistics[i])
+		plannerStatsValue := plannerColumnStatisticsValue(distinctEstimate, plannerStatistics[i])
+		plannerColumns.Set(scm.NewString(c.Name), plannerStatsValue, nil)
+		if folded := foldIdentifier(c.Name); folded != c.Name {
+			plannerColumns.Set(scm.NewString(folded), plannerStatsValue, nil)
+		}
 	}
+	plannerRoot := scm.NewFastDictValue(2)
+	plannerRoot.Set(scm.NewString("row_count"), scm.NewInt(int64(rowEstimate)), nil)
+	plannerRoot.Set(scm.NewString("columns"), scm.NewFastDict(plannerColumns), nil)
 	snapshot := &tableShowColumnsSnapshot{
-		value:       scm.NewSlice(result),
-		rowEstimate: rowEstimate,
+		value:        scm.NewSlice(result),
+		plannerValue: scm.NewFastDict(plannerRoot),
+		rowEstimate:  rowEstimate,
 		columns: &tableShowColumnsMetadata{
 			distinctEstimates: distinctEstimates,
 			plannerStatistics: plannerStatistics,
@@ -1350,12 +1420,59 @@ func (t *table) ShowColumns() scm.Scmer {
 	if t == nil {
 		return scm.NewNil()
 	}
-	rowEstimate := t.CountEstimate()
 	snapshot := t.showColumnsSnapshot.Load()
-	if t.showColumnsSnapshotMatches(snapshot, rowEstimate) {
+	if snapshot != nil {
 		return snapshot.value
 	}
 	return t.publishShowColumnsSnapshot()
+}
+
+// PlannerStatistics returns one immutable, atomically published catalog value.
+// The compiler can retain this value for its complete planning scope and use
+// hashed column lookup without revisiting SHOW metadata.
+func (t *table) PlannerStatistics() scm.Scmer {
+	if t == nil {
+		return scm.NewNil()
+	}
+	for {
+		snapshot := t.showColumnsSnapshot.Load()
+		if snapshot != nil {
+			return snapshot.plannerValue
+		}
+		t.publishShowColumnsSnapshot()
+	}
+}
+
+func plannerColumnStatisticsValue(distinctEstimate uint64, stats *columnPlannerStatistics) scm.Scmer {
+	known := stats != nil
+	confidence := float64(0)
+	source := "unknown"
+	distinctSource := "fallback_row_count"
+	nullFraction := scm.NewNil()
+	minEstimate := scm.NewNil()
+	maxEstimate := scm.NewNil()
+	averageValueBytes := scm.NewNil()
+	if stats != nil {
+		confidence = stats.Confidence
+		source = stats.Source
+		distinctSource = "rebuild"
+		nullFraction = scm.NewFloat(stats.NullFraction)
+		minEstimate = stats.MinEstimate
+		maxEstimate = stats.MaxEstimate
+		averageValueBytes = scm.NewFloat(stats.AverageValueBytes)
+	}
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("known"), scm.NewBool(known)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("confidence"), scm.NewFloat(confidence)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("source"), scm.NewSymbol(source)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("distinct"), scm.NewInt(int64(distinctEstimate))}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("distinct_confidence"), scm.NewFloat(confidence)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("distinct_source"), scm.NewSymbol(distinctSource)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("null_fraction"), nullFraction}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("min"), minEstimate}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("max"), maxEstimate}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("average_value_bytes"), averageValueBytes}),
+	})
 }
 
 func (c *column) Show(keyType string, t *table) scm.Scmer {
@@ -1962,6 +2079,7 @@ func (t *table) finishOverflowRebuild(index int, source *storageShard) {
 
 func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols []string, onCollision scm.Scmer, mergeNull bool, onFirstInsertId func(int64)) int {
 	result := 0
+	inserted := 0
 	isIgnore := !onCollision.IsNil() // INSERT IGNORE or ON DUPLICATE KEY UPDATE
 	// FK checks are enforced via auto-generated system triggers (see createforeignkey)
 
@@ -2066,6 +2184,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				t.ProcessUniqueCollision(columns, chunk, mergeNull, func(chunk [][]scm.Scmer) {
 					shard.Insert(columns, chunk, false, onFirstInsertId, isIgnore)
 					result += len(chunk)
+					inserted += len(chunk)
 				}, onCollisionCols, func(errmsg string, data []scm.Scmer) {
 					if !onCollision.IsNil() {
 						// Evaluate onCollision and add to affected rows per MySQL semantics
@@ -2095,6 +2214,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				// physically insert (no unique constraints)
 				shard.Insert(columns, chunk, false, onFirstInsertId, isIgnore)
 				result += len(chunk)
+				inserted += len(chunk)
 			}
 			release()
 		}
@@ -2129,6 +2249,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 					// physically insert
 					s.Insert(columns, values, false, onFirstInsertId, isIgnore)
 					result += len(values)
+					inserted += len(values)
 				}, onCollisionCols, func(errmsg string, data []scm.Scmer) {
 					if !onCollision.IsNil() {
 						// Evaluate onCollision and add to affected rows per MySQL semantics
@@ -2155,6 +2276,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 				// physically insert (parallel)
 				s.Insert(columns, values, false, onFirstInsertId, isIgnore)
 				result += len(values)
+				inserted += len(values)
 			}
 		}
 
@@ -2181,6 +2303,7 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 	}
 
 insertDone:
+	t.adjustPlannerRows(int64(inserted))
 	return result
 }
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -58,12 +58,13 @@ type dataset []scm.Scmer
 // columnPlannerStatistics is an immutable rebuild-generation snapshot. The
 // pointer is published atomically so query compilation never needs shard locks.
 type columnPlannerStatistics struct {
-	Confidence   float64
-	Source       string
-	NullCount    uint64
-	NullFraction float64
-	MinEstimate  scm.Scmer
-	MaxEstimate  scm.Scmer
+	Confidence        float64
+	Source            string
+	NullCount         uint64
+	NullFraction      float64
+	AverageValueBytes float64
+	MinEstimate       scm.Scmer
+	MaxEstimate       scm.Scmer
 }
 
 type column struct {
@@ -725,6 +726,7 @@ func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName st
 		MaxEstimate: scm.NewNil(),
 	}
 	var rowCount uint64
+	var valueBytes uint64
 	var hasValue bool
 	var buf []scm.Scmer
 	for _, shard := range shards {
@@ -750,6 +752,9 @@ func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName st
 					stats.NullCount++
 					continue
 				}
+				if value.IsString() || value.IsCString() || value.IsBString() {
+					valueBytes += uint64(len(value.String()))
+				}
 				if !hasValue {
 					stats.MinEstimate = value
 					stats.MaxEstimate = value
@@ -767,6 +772,7 @@ func collectRebuiltColumnPlannerStatistics(shards []*storageShard, columnName st
 	}
 	if rowCount > 0 {
 		stats.NullFraction = float64(stats.NullCount) / float64(rowCount)
+		stats.AverageValueBytes = float64(valueBytes) / float64(rowCount)
 	}
 	return stats
 }
@@ -1192,12 +1198,16 @@ func getForeignKeyMode(val scm.Scmer) foreignKeyMode {
 }
 
 type tableShowColumnsSnapshot struct {
-	value             scm.Scmer
-	rowEstimate       uint
+	value       scm.Scmer
+	rowEstimate uint
+	columns     *tableShowColumnsMetadata
+	columnNames *tableColumnNamesSnapshot
+	statistics  *tableStatisticsSnapshot
+}
+
+type tableShowColumnsMetadata struct {
 	distinctEstimates []uint64
 	plannerStatistics []*columnPlannerStatistics
-	columnNames       *tableColumnNamesSnapshot
-	statistics        *tableStatisticsSnapshot
 }
 
 type tableColumnNamesSnapshot struct {
@@ -1226,7 +1236,8 @@ func foldIdentifier(name string) string {
 }
 
 func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, rowEstimate uint) bool {
-	if snapshot == nil || snapshot.rowEstimate != rowEstimate || len(snapshot.distinctEstimates) != len(t.Columns) || len(snapshot.plannerStatistics) != len(t.Columns) {
+	if snapshot == nil || snapshot.columns == nil || snapshot.rowEstimate != rowEstimate ||
+		len(snapshot.columns.distinctEstimates) != len(t.Columns) || len(snapshot.columns.plannerStatistics) != len(t.Columns) {
 		return false
 	}
 	for i, c := range t.Columns {
@@ -1234,10 +1245,10 @@ func (t *table) showColumnsSnapshotMatches(snapshot *tableShowColumnsSnapshot, r
 		if distinctEstimate == 0 {
 			distinctEstimate = uint64(rowEstimate)
 		}
-		if snapshot.distinctEstimates[i] != distinctEstimate {
+		if snapshot.columns.distinctEstimates[i] != distinctEstimate {
 			return false
 		}
-		if snapshot.plannerStatistics[i] != c.PlannerStats.Load() {
+		if snapshot.columns.plannerStatistics[i] != c.PlannerStats.Load() {
 			return false
 		}
 	}
@@ -1271,11 +1282,13 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 		result[i] = c.show(keyType, distinctEstimate, rowEstimate, plannerStatistics[i])
 	}
 	snapshot := &tableShowColumnsSnapshot{
-		value:             scm.NewSlice(result),
-		rowEstimate:       rowEstimate,
-		distinctEstimates: distinctEstimates,
-		plannerStatistics: plannerStatistics,
-		columnNames:       columnNames,
+		value:       scm.NewSlice(result),
+		rowEstimate: rowEstimate,
+		columns: &tableShowColumnsMetadata{
+			distinctEstimates: distinctEstimates,
+			plannerStatistics: plannerStatistics,
+		},
+		columnNames: columnNames,
 	}
 	if current := t.showColumnsSnapshot.Load(); current != nil {
 		snapshot.statistics = current.statistics
@@ -1378,12 +1391,14 @@ func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint,
 	nullFraction := scm.NewNil()
 	minEstimate := scm.NewNil()
 	maxEstimate := scm.NewNil()
+	averageValueBytes := scm.NewNil()
 	if statisticsKnown {
 		statisticsConfidence = plannerStats.Confidence
 		statisticsSource = plannerStats.Source
 		nullFraction = scm.NewFloat(plannerStats.NullFraction)
 		minEstimate = plannerStats.MinEstimate
 		maxEstimate = plannerStats.MaxEstimate
+		averageValueBytes = scm.NewFloat(plannerStats.AverageValueBytes)
 	}
 	return scm.NewSlice([]scm.Scmer{
 		scm.NewString("Field"), scm.NewString(c.Name),
@@ -1411,6 +1426,7 @@ func (c *column) show(keyType string, distinctEstimate uint64, rowEstimate uint,
 		scm.NewString("NullFraction"), nullFraction,
 		scm.NewString("MinEstimate"), minEstimate,
 		scm.NewString("MaxEstimate"), maxEstimate,
+		scm.NewString("AverageValueBytes"), averageValueBytes,
 	})
 }
 
@@ -1640,6 +1656,11 @@ func (t *table) createColumnLocked(name string, typ string, typdimensions []int,
 	}
 
 	var c column
+	// Scmer's Go zero value is not Scheme nil. Base columns must be explicitly
+	// non-computed immediately after DDL; otherwise rebuild statistics are
+	// skipped until a schema reload happens to normalize this field.
+	c.Computor = scm.NewNil()
+	c.ComputorFilter = scm.NewNil()
 	c.Name = name
 	c.Typ = typ
 	c.Typdimensions = typdimensions

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -67,6 +67,18 @@ func TestShowColumnsReusesImmutableSnapshot(t *testing.T) {
 	}
 }
 
+func TestFreshBaseColumnIsNotMarkedComputed(t *testing.T) {
+	db := &database{Name: "fresh-column-statistics"}
+	tbl := &table{schema: db}
+	column, ok := tbl.createColumnLocked("value", "TEXT", nil, nil)
+	if !ok {
+		t.Fatal("createColumnLocked rejected a fresh column")
+	}
+	if !column.Computor.IsNil() || !column.ComputorFilter.IsNil() {
+		t.Fatal("fresh base column contains a non-nil computed expression")
+	}
+}
+
 func TestShowColumnsPublishesReplacementSnapshot(t *testing.T) {
 	tbl := showColumnsTestTable(1)
 	before := tbl.ShowColumns()

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -17,9 +17,11 @@ Copyright (C) 2026  Carl-Philip Haensch
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/launix-de/memcp/scm"
 )
@@ -67,6 +69,131 @@ func TestShowColumnsReusesImmutableSnapshot(t *testing.T) {
 	}
 }
 
+func TestCountEstimateIsLockFreeAndPersisted(t *testing.T) {
+	tbl := showColumnsTestTable(1)
+	tbl.PlannerRowEstimate.value.Store(73)
+
+	encoded, err := json.Marshal(tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored table
+	if err := json.Unmarshal(encoded, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if got := restored.CountEstimate(); got != 73 {
+		t.Fatalf("restored CountEstimate() = %d, want 73", got)
+	}
+
+	// An estimate read must not consult shard state, even while it is exclusively
+	// locked by a writer. This guards the compiler hot path against regressions
+	// to GetRead/lazy loading.
+	shard := &storageShard{t: tbl}
+	tbl.Shards = []*storageShard{shard}
+	tbl.mu.Lock()
+	tbl.publishTopologyLocked()
+	tbl.mu.Unlock()
+	shard.mu.Lock()
+	done := make(chan uint, 1)
+	go func() { done <- tbl.CountEstimate() }()
+	select {
+	case got := <-done:
+		if got != 73 {
+			t.Fatalf("CountEstimate() = %d, want 73", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CountEstimate blocked on the shard lock")
+	}
+	shard.mu.Unlock()
+}
+
+func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
+	tbl := showColumnsTestTable(2)
+	tbl.Columns[1].Name = "MixedCase"
+	tbl.PlannerRowEstimate.value.Store(91)
+	tbl.Columns[1].PlannerStats.Store(&columnPlannerStatistics{
+		Confidence:        1,
+		Source:            "rebuild",
+		AverageValueBytes: 12.5,
+		MinEstimate:       scm.NewString("a"),
+		MaxEstimate:       scm.NewString("z"),
+	})
+	atomic.StoreUint64(&tbl.Columns[1].DistinctEstimate, 17)
+	tbl.publishShowColumnsSnapshot()
+
+	root := tbl.PlannerStatistics().FastDict()
+	rowCount, ok := root.Get(scm.NewString("row_count"))
+	if !ok || rowCount.Int() != 91 {
+		t.Fatalf("planner row_count = %v, %t; want 91, true", rowCount, ok)
+	}
+	columnsValue, ok := root.Get(scm.NewString("columns"))
+	if !ok {
+		t.Fatal("planner snapshot has no columns index")
+	}
+	columnStats, ok := columnsValue.FastDict().Get(scm.NewString("mixedcase"))
+	if !ok {
+		t.Fatal("case-folded planner column lookup missed MixedCase")
+	}
+	if got := scm.ToInt(columnStats.Slice()[3].Slice()[1]); got != 17 {
+		t.Fatalf("planner distinct estimate = %d, want 17", got)
+	}
+	if tbl.PlannerStatistics().FastDict() != root {
+		t.Fatal("planner statistics rebuilt an already-published snapshot")
+	}
+
+	tbl.adjustPlannerRows(9)
+	updatedRoot := tbl.PlannerStatistics().FastDict()
+	updatedRows, _ := updatedRoot.Get(scm.NewString("row_count"))
+	if updatedRows.Int() != 100 {
+		t.Fatalf("planner row_count after insert batch = %d, want 100", updatedRows.Int())
+	}
+	updatedColumns, _ := updatedRoot.Get(scm.NewString("columns"))
+	if updatedColumns.FastDict() != columnsValue.FastDict() {
+		t.Fatal("row-count update rebuilt the immutable column catalog")
+	}
+
+	mapper := &ShardMapReducer{shard: &storageShard{t: tbl}, deletedRows: 4}
+	mapper.FlushSideEffects()
+	if got := tbl.CountEstimate(); got != 96 {
+		t.Fatalf("CountEstimate() after delete batch = %d, want 96", got)
+	}
+	tbl.adjustPlannerRows(-200)
+	if got := tbl.CountEstimate(); got != 0 {
+		t.Fatalf("saturated CountEstimate() = %d, want 0", got)
+	}
+}
+
+func BenchmarkPlannerStatisticsLookup(b *testing.B) {
+	tbl := showColumnsTestTable(256)
+	tbl.PlannerRowEstimate.value.Store(1_000_000)
+	tbl.publishShowColumnsSnapshot()
+	target := scm.NewString("column_255")
+	plannerColumns, _ := tbl.PlannerStatistics().FastDict().Get(scm.NewString("columns"))
+	showColumns := tbl.ShowColumns().Slice()
+
+	b.Run("published_hash", func(b *testing.B) {
+		for range b.N {
+			if _, ok := plannerColumns.FastDict().Get(target); !ok {
+				b.Fatal("planner column disappeared")
+			}
+		}
+	})
+	b.Run("legacy_show_linear", func(b *testing.B) {
+		for range b.N {
+			found := false
+			for _, row := range showColumns {
+				if scm.String(showColumnProperty(row, "Field")) == "column_255" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				b.Fatal("SHOW column disappeared")
+			}
+		}
+	})
+}
+
 func TestFreshBaseColumnIsNotMarkedComputed(t *testing.T) {
 	db := &database{Name: "fresh-column-statistics"}
 	tbl := &table{schema: db}
@@ -94,10 +221,11 @@ func TestShowColumnsPublishesReplacementSnapshot(t *testing.T) {
 	}
 }
 
-func TestShowColumnsRefreshesChangedStatistics(t *testing.T) {
+func TestShowColumnsUsesExplicitStatisticsPublication(t *testing.T) {
 	tbl := showColumnsTestTable(1)
 	before := tbl.ShowColumns()
 	atomic.StoreUint64(&tbl.Columns[0].DistinctEstimate, 17)
+	tbl.publishShowColumnsSnapshot()
 	after := tbl.ShowColumns()
 
 	if &before.Slice()[0] == &after.Slice()[0] {

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -48,12 +48,14 @@ test_cases:
     scm: |
       (begin
         (define idcol (car (get_schema "memcp-tests" "rs_data")))
+        (define categorycol (nth (get_schema "memcp-tests" "rs_data") 2))
         (and
           (equal? (idcol "StatisticsKnown") false)
           (equal? (idcol "StatisticsConfidence") 0)
           (equal? (idcol "StatisticsSource") "unknown")
           (equal? (idcol "DistinctEstimateSource") "fallback_row_count")
-          (nil? (idcol "NullFraction"))))
+          (nil? (idcol "NullFraction"))
+          (nil? (idcol "AverageValueBytes"))))
     expect:
       data: [true]
 
@@ -715,7 +717,9 @@ test_cases:
           (equal? (idcol "DistinctEstimateSource") "rebuild")
           (equal? (idcol "NullFraction") 0)
           (equal? (idcol "MinEstimate") 0)
-          (equal? (idcol "MaxEstimate") 199)))
+          (equal? (idcol "MaxEstimate") 199)
+          (equal? (idcol "AverageValueBytes") 0)
+          (equal? (categorycol "AverageValueBytes") 4.75)))
     expect:
       data: [true]
 

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -14,17 +14,30 @@ metadata:
   compile_state: "cached_plan_execution_only"
 
 setup:
+  # Keep the 100k-row text relation in one authoritative generation. Cold
+  # multi-shard statistics are a separate fallback workload and must not be
+  # mixed into the known-statistics coefficient fit.
   - scm: '(settings "ShardSize" 125000)'
   - sql: "DROP TABLE IF EXISTS pc_files_small"
   - sql: "DROP TABLE IF EXISTS pc_docs_small"
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
+  # Inline values contribute more than 15 MB of candidate text work while the
+  # ordered driver still exercises the production-scale million-row shape. A
+  # separate component fixture below covers wider values without turning this
+  # carrier benchmark into a blob-filesystem benchmark.
+  - sql: "DROP TABLE IF EXISTS pc_files_text"
+  # A small-row-count, wide-value fixture separates byte-dependent LIKE/MATCH
+  # work from row-dependent scan work without allocating another million rows.
+  - sql: "DROP TABLE IF EXISTS pc_files_wide"
   - sql: "CREATE TABLE pc_files_small (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32), f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT)"
   - sql: "CREATE TABLE pc_docs_small (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
   - sql: "CREATE TABLE pc_files_large (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32), f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT)"
   - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
   - sql: "CREATE TABLE pc_docs_million (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT) ENGINE=sloppy"
+  - sql: "CREATE TABLE pc_files_text (id INT PRIMARY KEY, filename VARCHAR(255), search VARCHAR(255)) ENGINE=memory"
+  - sql: "CREATE TABLE pc_files_wide (id INT PRIMARY KEY, filename VARCHAR(16384), search VARCHAR(16384)) ENGINE=sloppy"
   - scm: |
       (begin
         (define make_files (lambda (n)
@@ -44,6 +57,15 @@ setup:
         (map (produceN 250000) (lambda (i) (list i (mod i 5000) i i))))
   - scm: "(rebuild)"
   - scm: |
+      (insert (table "memcp-tests" "pc_files_text") '("id" "filename" "search")
+        (map (produceN 100000) (lambda (i)
+          (list i
+            (concat (if (equal? (mod i 10) 0)
+              "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx") (string i))
+            (concat (string_repeat (if (equal? (mod i 7) 0) "c" "x") 96) (string i))))))
+  - scm: "(rebuild)"
+  - scm: |
       (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
         (map (produceN 250000) (lambda (i)
           (list (+ i 250000) (mod (+ i 250000) 5000) (+ i 250000) (+ i 250000)))))
@@ -58,6 +80,13 @@ setup:
         (map (produceN 250000) (lambda (i)
           (list (+ i 750000) (mod (+ i 750000) 5000) (+ i 750000) (+ i 750000)))))
   - scm: "(rebuild)"
+  - scm: |
+      (insert (table "memcp-tests" "pc_files_wide") '("id" "filename" "search")
+        (map (produceN 5000) (lambda (i)
+          (list i
+            (concat (string_repeat (if (equal? (mod i 10) 0) "c" "x") 8192) (string i))
+            (concat (string_repeat (if (equal? (mod i 7) 0) "c" "x") 8192) (string i))))))
+  - scm: "(rebuild)"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_small"
@@ -65,6 +94,8 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
+  - sql: "DROP TABLE IF EXISTS pc_files_text"
+  - sql: "DROP TABLE IF EXISTS pc_files_wide"
 
 test_cases:
   - name: "small broad UNION membership"
@@ -275,3 +306,48 @@ test_cases:
         UNION
         SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
       )
+
+  - name: "production-scale broad text ordered membership"
+    physical_calibration: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    expected_broad_text_bytes: 15000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
+        UNION
+        SELECT f.id FROM pc_files_text f
+        WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
+      )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
+  - name: "wide-value broad text ordered membership"
+    physical_calibration: true
+    calibration_component: "broad_text_bytes"
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    expected_broad_text_bytes: 10000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_wide f WHERE f.filename LIKE '%c%'
+        UNION
+        SELECT f.id FROM pc_files_wide f
+        WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
+      )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1240,6 +1240,8 @@ test_cases:
             - "estimated_ns"
             - "whole_query_execution_ns"
             - "operator_ns"
+            - "shared_sequential_diagnostic"
+            - "fit_eligible"
             - "candidate_rows"
             - "driver_rows"
             - "result_equal"

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -89,11 +89,13 @@ type testCase struct {
 	PhysicalCalibration     bool    `yaml:"physical_calibration"`
 	CalibrationHoldout      bool    `yaml:"calibration_holdout"`
 	CalibrationDecision     string  `yaml:"calibration_decision"`
+	CalibrationComponent    string  `yaml:"calibration_component"`
 	Race                    bool    `yaml:"race"`
 	RaceGrace               float64 `yaml:"race_grace"`
 	CacheState              string  `yaml:"cache_state"`
 	CompileState            string  `yaml:"compile_state"`
 	ExpectedDriverInputRows float64 `yaml:"expected_driver_input_rows"`
+	ExpectedBroadTextBytes  float64 `yaml:"expected_broad_text_bytes"`
 	Warmup                  int     `yaml:"warmup"`
 	Repetitions             int     `yaml:"repetitions"`
 	Setup                   []step  `yaml:"setup"`
@@ -114,6 +116,7 @@ type calibrationRow struct {
 	CompileState                     string   `json:"compile_state"`
 	DecisionID                       string   `json:"decision_id"`
 	Decision                         string   `json:"decision"`
+	DecisionSite                     string   `json:"decision_site"`
 	Consumer                         string   `json:"consumer"`
 	Plan                             string   `json:"plan"`
 	OperatorFamily                   string   `json:"operator_family"`
@@ -139,6 +142,8 @@ type calibrationRow struct {
 	CandidateCacheMapColumns         *float64 `json:"candidate_cache_map_columns"`
 	CandidateExpressionOperations    *float64 `json:"candidate_expression_operations"`
 	CandidateExpressionDepth         *float64 `json:"candidate_expression_depth"`
+	CandidateBroadTextMatchRows      *float64 `json:"candidate_broad_text_match_rows"`
+	CandidateBroadTextMatchBytes     *float64 `json:"candidate_broad_text_match_bytes"`
 	CandidateFilterValueRows         *float64 `json:"candidate_filter_value_rows"`
 	CandidateExpressionOperationRows *float64 `json:"candidate_expression_operation_rows"`
 	DriverScanInvocations            *float64 `json:"driver_scan_invocations"`
@@ -161,6 +166,8 @@ type calibrationDiscovery struct {
 
 type observation struct {
 	caseName        string
+	cacheState      string
+	component       string
 	plan            string
 	y               float64
 	currentEstimate float64
@@ -176,6 +183,8 @@ type constants struct {
 	filterColumnRowNS     int64
 	mapColumnRowNS        int64
 	expressionOperationNS int64
+	broadTextMatchRowNS   int64
+	broadTextMatchByteNS  int64
 	recsetStartupNS       int64
 	recsetBuildRowNS      int64
 	recsetProbeRowNS      int64
@@ -243,9 +252,9 @@ func main() {
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\n",
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\n",
 		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
-		c.expressionOperationNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
+		c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
 	printModelComparison("training", training, c)
@@ -511,33 +520,19 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 				}
 				allRows = append(allRows, raceRows...)
 			} else {
-				for run := 0; run < warmup+repetitions; run++ {
-					payload, err := server.execute("/sql/"+database, query, 10*time.Minute)
-					if err != nil {
-						return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
-					}
-					rows, err := decodeRows(payload)
-					if err != nil {
-						return nil, nil, fmt.Errorf("%s/%s: %w; response=%s", currentSuite.Path, test.Name, err, payload)
-					}
-					decision := test.CalibrationDecision
-					if decision == "" {
-						decision = "membership_carrier"
-					}
-					rows = filterCalibrationDecision(rows, decision)
-					if err := validateRows(rows); err != nil {
-						return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
-					}
-					if run >= warmup {
-						for rowIndex := range rows {
-							rows[rowIndex].CaseName = test.Name
-							rows[rowIndex].CacheState = cacheState
-							rows[rowIndex].CompileState = compileState
-						}
-						runs = append(runs, rows)
-						allRows = append(allRows, rows...)
-					}
+				baseQuery := strings.TrimSpace(strings.TrimPrefix(query, "EXPLAIN PHYSICAL CALIBRATE"))
+				separateRuns, separateRows, separateErr := runCalibrationVariantsSeparately(
+					server, baseQuery, test, warmup, repetitions)
+				if separateErr != nil {
+					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, separateErr)
 				}
+				runs = separateRuns
+				for rowIndex := range separateRows {
+					separateRows[rowIndex].CaseName = test.Name
+					separateRows[rowIndex].CacheState = cacheState
+					separateRows[rowIndex].CompileState = compileState
+				}
+				allRows = append(allRows, separateRows...)
 			}
 			medians, err := medianRows(runs)
 			if err != nil {
@@ -555,6 +550,18 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 					}
 				}
 			}
+			if test.ExpectedBroadTextBytes > 0 {
+				for _, row := range medians {
+					if row.CandidateBroadTextMatchBytes == nil || *row.CandidateBroadTextMatchBytes < test.ExpectedBroadTextBytes {
+						actual := "nil"
+						if row.CandidateBroadTextMatchBytes != nil {
+							actual = fmt.Sprintf("%.0f", *row.CandidateBroadTextMatchBytes)
+						}
+						return nil, nil, fmt.Errorf("%s/%s: candidate_broad_text_match_bytes=%s, want at least %.0f",
+							currentSuite.Path, test.Name, actual, test.ExpectedBroadTextBytes)
+					}
+				}
+			}
 			for _, row := range medians {
 				features, err := rowFeatures(row)
 				if err != nil {
@@ -562,6 +569,7 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 				}
 				observations = append(observations, observation{
 					caseName: test.Name, plan: row.Plan, y: row.WholeQueryExecutionNS,
+					cacheState: cacheState, component: test.CalibrationComponent,
 					currentEstimate: *row.EstimatedNS, holdout: test.CalibrationHoldout,
 					noiseNS: medianAbsoluteDeviation(runs, row.Plan), censored: row.TimedOut, x: features,
 				})
@@ -591,7 +599,7 @@ type calibrationVariantResult struct {
 	err     error
 }
 
-func runCalibrationRaces(server *memcpServer, query string, test testCase, repetitions int) ([][]calibrationRow, []calibrationRow, error) {
+func discoverCalibrationDecision(server *memcpServer, query, decisionName string) (*calibrationDiscovery, map[string]*float64, error) {
 	discoveryPayload, err := server.execute("/sql/"+database,
 		"EXPLAIN PHYSICAL CALIBRATE DISCOVER\n"+query, 10*time.Minute)
 	if err != nil {
@@ -601,7 +609,6 @@ func runCalibrationRaces(server *memcpServer, query string, test testCase, repet
 	if err != nil {
 		return nil, nil, fmt.Errorf("decode calibration discovery: %w; response=%s", err, discoveryPayload)
 	}
-	decisionName := test.CalibrationDecision
 	if decisionName == "" {
 		decisionName = "membership_carrier"
 	}
@@ -612,17 +619,77 @@ func runCalibrationRaces(server *memcpServer, query string, test testCase, repet
 		}
 		if discovered[i].Decision == decisionName {
 			if decision != nil {
-				return nil, nil, fmt.Errorf("race requires one %s decision, found several", decisionName)
+				return nil, nil, fmt.Errorf("calibration requires one %s decision, found several", decisionName)
 			}
 			decision = &discovered[i]
 		}
 	}
 	if decision == nil || len(decision.Alternatives) != 2 || len(decision.EstimatedNS) != 2 {
-		return nil, nil, fmt.Errorf("race discovery did not expose two costed alternatives: %+v", decision)
+		return nil, nil, fmt.Errorf("discovery did not expose two costed alternatives: %+v", decision)
 	}
 	estimates := map[string]*float64{}
 	for i, plan := range decision.Alternatives {
 		estimates[plan] = decision.EstimatedNS[i]
+	}
+	return decision, estimates, nil
+}
+
+func executeCalibrationVariant(server *memcpServer, query, decisionID, plan string, timeout time.Duration) (calibrationRow, error) {
+	statement := "EXPLAIN PHYSICAL CALIBRATE VARIANT '" + sqlQuote(decisionID) + "' '" + sqlQuote(plan) + "'\n" + query
+	payload, err := server.execute("/sql/"+database, statement, timeout)
+	if err != nil {
+		return calibrationRow{}, err
+	}
+	rows, err := decodeRows(payload)
+	if err != nil || len(rows) != 1 {
+		return calibrationRow{}, fmt.Errorf("decode %s variant: %v; response=%s", plan, err, payload)
+	}
+	if err := validateRaceWinner(rows[0], decisionID, plan); err != nil {
+		return calibrationRow{}, err
+	}
+	return rows[0], nil
+}
+
+func runCalibrationVariantsSeparately(server *memcpServer, query string, test testCase, warmup, repetitions int) ([][]calibrationRow, []calibrationRow, error) {
+	decision, _, err := discoverCalibrationDecision(server, query, test.CalibrationDecision)
+	if err != nil {
+		return nil, nil, err
+	}
+	var runs [][]calibrationRow
+	var raw []calibrationRow
+	for run := 0; run < warmup+repetitions; run++ {
+		plans := append([]string(nil), decision.Alternatives...)
+		if run%2 == 1 {
+			plans[0], plans[1] = plans[1], plans[0]
+		}
+		rows := make([]calibrationRow, 0, len(plans))
+		for _, plan := range plans {
+			row, err := executeCalibrationVariant(server, query, decision.DecisionID, plan, 10*time.Minute)
+			if err != nil {
+				return nil, nil, err
+			}
+			rows = append(rows, row)
+		}
+		equal := rows[0].Rows == rows[1].Rows && rows[0].ResultHash == rows[1].ResultHash
+		for i := range rows {
+			rows[i].ResultEqual = equal
+		}
+		if !equal {
+			return nil, nil, errors.New("separately executed variants returned different results")
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].Plan < rows[j].Plan })
+		if run >= warmup {
+			runs = append(runs, rows)
+			raw = append(raw, rows...)
+		}
+	}
+	return runs, raw, nil
+}
+
+func runCalibrationRaces(server *memcpServer, query string, test testCase, repetitions int) ([][]calibrationRow, []calibrationRow, error) {
+	decision, estimates, err := discoverCalibrationDecision(server, query, test.CalibrationDecision)
+	if err != nil {
+		return nil, nil, err
 	}
 	grace := test.RaceGrace
 	if grace <= 0 {
@@ -738,6 +805,23 @@ func raceCalibrationVariants(server *memcpServer, query, decisionID string, plan
 	for _, cancel := range cancels {
 		cancel()
 	}
+	cleanFirst, err := executeCalibrationVariant(server, query, decisionID, first.plan, 10*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("standalone winner %s: %w", first.plan, err)
+	}
+	first.row = cleanFirst
+	if !second.row.TimedOut {
+		cleanSecond, err := executeCalibrationVariant(server, query, decisionID, second.plan, 10*time.Minute)
+		if err != nil {
+			return nil, fmt.Errorf("standalone bounded alternative %s: %w", second.plan, err)
+		}
+		second.row = cleanSecond
+		equal := first.row.Rows == second.row.Rows && first.row.ResultHash == second.row.ResultHash
+		first.row.ResultEqual, second.row.ResultEqual = equal, equal
+		if !equal {
+			return nil, fmt.Errorf("standalone variants returned different results")
+		}
+	}
 	rows := []calibrationRow{first.row, second.row}
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Plan < rows[j].Plan })
 	return rows, nil
@@ -845,6 +929,7 @@ func validateRows(rows []calibrationRow) error {
 			row.CandidateScanInvocations, row.CandidateFilterColumns,
 			row.CandidateMapColumns, row.CandidateCacheMapColumns,
 			row.CandidateExpressionOperations, row.CandidateExpressionDepth,
+			row.CandidateBroadTextMatchRows, row.CandidateBroadTextMatchBytes,
 			row.DriverScanInvocations, row.DriverFilterColumns,
 			row.DriverMapColumns, row.DriverExpressionOperations,
 			row.DriverExpressionDepth,
@@ -853,6 +938,9 @@ func validateRows(rows []calibrationRow) error {
 			if input == nil {
 				return fmt.Errorf("physical work profile contains nil inputs: %+v", row)
 			}
+		}
+		if *row.CandidateBroadTextMatchRows > 0 && *row.CandidateBroadTextMatchBytes <= 0 {
+			return fmt.Errorf("broad-text decision has no value-byte statistics: %+v", row)
 		}
 		if row.WholeQueryExecutionNS <= 0 {
 			return fmt.Errorf("invalid whole_query_execution_ns for %s", row.Plan)
@@ -925,13 +1013,15 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
 			1, *row.CandidateRows + *row.ProjectedDriverRows, *row.DriverRows, 0, 0, 0,
-			aggregateDriverRows, 0,
+			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
+			*row.CandidateBroadTextMatchBytes,
 		}, nil
 	case "driver_order_membership_probe":
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
 			0, 0, 0, 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited,
-			0, orderedDriverInputRows,
+			0, orderedDriverInputRows, 0,
+			0,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
@@ -1003,6 +1093,8 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		filterColumnRowNS:     int64(math.Round(beta[2])),
 		mapColumnRowNS:        int64(math.Round(beta[3])),
 		expressionOperationNS: int64(math.Round(beta[4])),
+		broadTextMatchRowNS:   1,
+		broadTextMatchByteNS:  1,
 		recsetStartupNS:       int64(math.Round(beta[5])),
 		recsetBuildRowNS:      int64(math.Round(beta[6])),
 		recsetProbeRowNS:      int64(math.Round(beta[7])),
@@ -1045,20 +1137,46 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 	if value, ok := fitExactResidualPerRow(allRows, selected, 11); ok {
 		selected.recsetAggregateRowNS = value
 	}
-	// A timed-out slower ordered alternative contributes lower_bound <= cost.
-	// Choose the smallest coefficient satisfying every observed constraint.
+	if value, ok := fitBroadTextResidualPerByte(allRows, selected); ok {
+		selected.broadTextMatchByteNS = value
+	}
+	/* A race timeout mixes cold startup and incomplete operator work. It is a
+	lower bound for that whole alternative, not evidence for a linear ordered
+	driver coefficient. Only exact paired workloads may change that term. */
+	// A cancelled broad-text candidate supplies the symmetric inequality:
+	// its materialization cost is at least the observed lower bound. Preserve
+	// that evidence instead of treating a timeout as an exact duration.
 	for _, row := range allRows {
-		if !row.censored || len(row.x) <= 12 || row.x[12] <= 0 {
+		if !row.censored || row.component != "broad_text_bytes" ||
+			row.plan != "candidate_keyset" || len(row.x) <= 14 || row.x[14] <= 0 {
 			continue
 		}
 		without := selected
-		without.orderedDriverInputNS = 0
-		required := int64(math.Ceil((row.y - estimatedNS(row, without)) / row.x[12]))
-		if required > selected.orderedDriverInputNS {
-			selected.orderedDriverInputNS = required
+		without.broadTextMatchByteNS = 0
+		required := int64(math.Ceil((row.y - estimatedNS(row, without)) / row.x[14]))
+		if required > selected.broadTextMatchByteNS {
+			selected.broadTextMatchByteNS = required
 		}
 	}
 	return selected, nil
+}
+
+func fitBroadTextResidualPerByte(rows []observation, c constants) (int64, bool) {
+	values := make([]float64, 0)
+	for _, row := range rows {
+		if row.censored || row.component != "broad_text_bytes" || row.plan != "candidate_keyset" ||
+			len(row.x) <= 14 || row.x[14] <= 0 {
+			continue
+		}
+		without := c
+		without.broadTextMatchByteNS = 0
+		values = append(values, math.Max(1, (row.y-estimatedNS(row, without))/row.x[14]))
+	}
+	if len(values) == 0 {
+		return 0, false
+	}
+	sort.Float64s(values)
+	return int64(math.Round(values[len(values)/2])), true
 }
 
 func fitExactResidualPerRow(rows []observation, c constants, feature int) (int64, bool) {
@@ -1139,6 +1257,8 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.groupCacheProbeRowNS),
 		float64(c.recsetAggregateRowNS),
 		float64(c.orderedDriverInputNS),
+		float64(c.broadTextMatchRowNS),
+		float64(c.broadTextMatchByteNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1170,13 +1290,23 @@ func filterExactObservations(rows []observation) []observation {
 func filterCompleteExactPairs(rows []observation) []observation {
 	censoredCases := make(map[string]bool)
 	for _, row := range rows {
-		if row.censored {
+		if row.censored || row.component != "" {
 			censoredCases[row.caseName] = true
 		}
 	}
 	filtered := make([]observation, 0, len(rows))
 	for _, row := range rows {
 		if !censoredCases[row.caseName] {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func filterRankObservations(rows []observation) []observation {
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if row.component == "" {
 			filtered = append(filtered, row)
 		}
 	}
@@ -1216,7 +1346,7 @@ func measureModelError(rows []observation, estimate func(observation) float64) m
 }
 
 func decisionAccuracy(rows []observation, estimate func(observation) float64) (int, int) {
-	pairs, err := decisionPairs(rows)
+	pairs, err := decisionPairs(filterRankObservations(rows))
 	if err != nil {
 		return 0, 0
 	}
@@ -1310,7 +1440,7 @@ func decisionPairs(rows []observation) (map[string]decisionPair, error) {
 }
 
 func validateDecisionOrdering(rows []observation, c constants) error {
-	pairs, err := decisionPairs(rows)
+	pairs, err := decisionPairs(filterRankObservations(rows))
 	if err != nil {
 		return err
 	}
@@ -1327,7 +1457,7 @@ func validateDecisionOrdering(rows []observation, c constants) error {
 }
 
 func printDecisionOrdering(rows []observation, c constants) {
-	pairs, err := decisionPairs(rows)
+	pairs, err := decisionPairs(filterRankObservations(rows))
 	if err != nil {
 		return
 	}
@@ -1384,6 +1514,8 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_group_cache_build_row_ns",
 		"planner_membership_group_cache_probe_row_ns",
 		"planner_membership_ordered_driver_input_row_ns",
+		"planner_membership_broad_text_match_row_ns",
+		"planner_membership_broad_text_match_byte_ns",
 	}
 	values := make([]int64, len(names))
 	content := string(data)
@@ -1412,6 +1544,8 @@ func readCurrentConstants(path string) (constants, error) {
 		recsetAggregateRowNS: values[8], groupCacheStartupNS: values[9],
 		groupCacheBuildRowNS: values[10], groupCacheProbeRowNS: values[11],
 		orderedDriverInputNS: values[12],
+		broadTextMatchRowNS:  values[13],
+		broadTextMatchByteNS: values[14],
 	}, nil
 }
 
@@ -1447,6 +1581,8 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_filter_column_row_ns %d)
 (define planner_membership_map_column_row_ns %d)
 (define planner_membership_expression_operation_row_ns %d)
+(define planner_membership_broad_text_match_row_ns %d)
+(define planner_membership_broad_text_match_byte_ns %d)
 (define planner_membership_recset_startup_ns %d)
 (define planner_membership_recset_build_row_ns %d)
 (define planner_membership_recset_probe_row_ns %d)
@@ -1456,7 +1592,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_probe_row_ns %d)
 (define planner_membership_ordered_driver_input_row_ns %d)
 /* END GENERATED COST CONSTANTS */`, c.scanInvocationNS, c.scanRowNS,
-		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS,
+		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS,
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS)

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -56,6 +56,27 @@ func TestValidateRowsRejectsDecisionPlanMismatch(t *testing.T) {
 	}
 }
 
+func TestRowFeaturesKeepsBroadTextRowsAndBytesSeparate(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "candidate_keyset", Consumer: "order_limit",
+		CandidateInputRows: value(100), CandidateRows: value(10), ProjectedDriverRows: value(20),
+		DriverInputRows: value(1000), DriverRows: value(5), ExpectedDriverRowsVisited: value(50),
+		CandidateScanInvocations: value(1), CandidateFilterColumns: value(1),
+		CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
+		CandidateExpressionOperations: value(1), CandidateBroadTextMatchRows: value(100),
+		CandidateBroadTextMatchBytes: value(819200), DriverScanInvocations: value(1),
+		DriverFilterColumns: value(0), DriverMapColumns: value(1), DriverExpressionOperations: value(0),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features[13] != 100 || features[14] != 819200 {
+		t.Fatalf("broad text features = (%v, %v), want (100, 819200)", features[13], features[14])
+	}
+}
+
 func TestRaceCalibrationVariantsCancelsSlowerPlan(t *testing.T) {
 	const decisionID = "membership_carrier:test"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- make index-restricted selectivity estimates explicit lower bounds instead of extrapolating them as table samples
- carry local cardinality, decision-site, filter/map-column, expression, and broad-text byte work into the final membership decision
- collect average string widths during the existing REBUILD scan and use them without generating alternative plans
- isolate CALIBRATE variants, validate decision/operator coverage, race dangerous alternatives in parallel, and cancel the loser after winner runtime + 50%
- teach costgen to report current vs updated error, fit tagged YAML workloads, and rewrite the generated planner constants
- add million-row driver, COUNT, ordered LIMIT, wide-expression, column-width, and holdout calibration shapes

## Calibration evidence

`make costgen` on this host:

- training median absolute error: **10.1% -> 6.8%**
- training decision ranking: **12/12** before and after fitting
- wide-text candidate estimate error: **-19.1% -> -4.6%**
- million-row COUNT candidate estimate: **-13.5% -> -0.0%**

The generated constants in `lib/queryplan.scm` now include a 4 ns/input-byte broad-text term and a recalibrated 215 ns/driver-input-row RecSet aggregate term. Exact nanoseconds remain secondary to preserving the measured cost inequality; the report prints both errors and plan rankings.

Combined `EXPLAIN PHYSICAL CALIBRATE` output is marked `shared_sequential_diagnostic` and `fit_eligible=false`; costgen uses isolated `CALIBRATE VARIANT` requests. Timed-out alternatives are reported as lower bounds, not fitted as exact durations.

## Validation

- `make costgen`
- `go test ./tools/costgen`
- `python3 run_sql_tests.py tests/execution/operators/range-scan-coverage.yaml` (99/99)
- `python3 run_sql_tests.py tests/planner/subqueries/in-subquery.yaml` (69/69)
- `make test` (all CI-active YAML suites; Scheme coverage 63,535/63,535 nodes)
