### PR TITLE
Inline helpers with capture-free callbacks

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -767,8 +767,12 @@ func analyzeLeafInlineBody(expr Scmer, callee Symbol, paramCount int, refs []int
 	}
 	if head, ok := scmerSymbol(items[0]); ok {
 		switch head {
-		case callee, "lambda", "define", "set", "setN", "eval", "parser", "outer", "begin", "begin_mut", "!begin", "match", "match_mut":
+		case callee, "define", "set", "setN", "eval", "parser", "outer", "begin", "begin_mut", "!begin", "match", "match_mut":
 			return false
+		case "lambda":
+			// A nested lambda is an opaque constant for this substitution. It is
+			// safe only when it does not capture the surrounding Proc frame.
+			return !expressionContainsOuterReference(expr)
 		}
 	}
 	for _, item := range items {
@@ -787,7 +791,7 @@ func substituteLeafInlineParams(expr Scmer, args []Scmer) Scmer {
 		return args[int(expr.NthLocalVar())]
 	}
 	items, ok := scmerSlice(expr)
-	if !ok || len(items) == 0 || scmerIsSymbol(items[0], "quote") {
+	if !ok || len(items) == 0 || scmerIsSymbol(items[0], "quote") || scmerIsSymbol(items[0], "lambda") {
 		return expr
 	}
 	rewritten := make([]Scmer, len(items))
@@ -795,6 +799,51 @@ func substituteLeafInlineParams(expr Scmer, args []Scmer) Scmer {
 		rewritten[i] = substituteLeafInlineParams(item, args)
 	}
 	return NewSlice(rewritten)
+}
+
+func expressionContainsOuterReference(expr Scmer) bool {
+	var pending [maxLeafInlineNodes]Scmer
+	var seen [maxLeafInlineNodes]Scmer
+	pending[0] = expr
+	pendingCount := 1
+	seenCount := 0
+	for pendingCount > 0 {
+		pendingCount--
+		current := pending[pendingCount]
+		if stripped, ok := scmerStripSourceInfo(current); ok {
+			current = stripped
+		}
+		visited := false
+		for i := 0; i < seenCount; i++ {
+			if seen[i] == current {
+				visited = true
+				break
+			}
+		}
+		if visited {
+			continue
+		}
+		if seenCount >= len(seen) {
+			return true
+		}
+		seen[seenCount] = current
+		seenCount++
+		items, ok := scmerSlice(current)
+		if !ok || len(items) == 0 || items[0].SymbolEquals("quote") {
+			continue
+		}
+		if items[0].SymbolEquals("outer") {
+			return true
+		}
+		if len(items) > len(pending)-pendingCount {
+			return true
+		}
+		for _, item := range items {
+			pending[pendingCount] = item
+			pendingCount++
+		}
+	}
+	return false
 }
 
 func leafInlineBindingsStable(expr Scmer, source, target *Env) bool {
@@ -818,6 +867,9 @@ func leafInlineBindingsStable(expr Scmer, source, target *Env) bool {
 	items := expr.Slice()
 	if len(items) == 0 || scmerIsSymbol(items[0], "quote") {
 		return true
+	}
+	if scmerIsSymbol(items[0], "lambda") {
+		return source == target && !expressionContainsOuterReference(expr)
 	}
 	for _, item := range items {
 		if !leafInlineBindingsStable(item, source, target) {
@@ -847,12 +899,13 @@ func tryInlineLeafProc(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bo
 	if proc == nil || proc.En == nil {
 		return NewNil(), tiZero, false
 	}
+	args := v[1:]
 	params := proc.Params
 	if stripped, ok := scmerStripSourceInfo(params); ok {
 		params = stripped
 	}
 	paramItems, ok := scmerSlice(params)
-	if !ok || len(paramItems) != len(v)-1 || proc.NumVars != len(paramItems) {
+	if !ok || len(paramItems) != len(args) || proc.NumVars != len(paramItems) {
 		return NewNil(), tiZero, false
 	}
 	refs := make([]int, len(paramItems))
@@ -868,7 +921,7 @@ func tryInlineLeafProc(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bo
 			return NewNil(), tiZero, false
 		}
 	}
-	inlined := substituteLeafInlineParams(proc.Body, v[1:])
+	inlined := substituteLeafInlineParams(proc.Body, args)
 	if ome.inlineStack == nil {
 		ome.inlineStack = make(map[Symbol]bool)
 	}

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -140,6 +140,87 @@ func TestSchemeReturnHintsPreserveNestedMutRewrite(t *testing.T) {
 	}
 }
 
+func TestOptimizeInlinesHelperWithCaptureFreeNestedLambda(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("nested lambda inline test", `(define filter_owned (lambda (values)
+		(filter values (lambda (x) (> x 1)))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (a b c)
+		(filter_owned (list a b c)))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "filter_owned") {
+		t.Fatalf("helper with capture-free nested lambda was not inlined: %s", serialized)
+	}
+	if !strings.Contains(serialized, "!list") && !strings.Contains(serialized, "filter_mut") {
+		t.Fatalf("inlined helper did not reuse or stack-allocate its input: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, env), NewInt(0), NewInt(2), NewInt(3)); !Equal(got, NewSlice([]Scmer{NewInt(2), NewInt(3)})) {
+		t.Fatalf("inlined helper returned %s", String(got))
+	}
+}
+
+func TestInlinedNestedLambdaHelperDoesNotMutateBorrowedParameter(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("nested lambda inline test", `(define filter_borrowed (lambda (values)
+		(filter values (lambda (x) (> x 1)))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (values) (filter_borrowed values))`)
+	if serialized := serializedTestExpr(t, env, optimized); strings.Contains(serialized, "filter_mut") {
+		t.Fatalf("borrowed helper parameter selected filter_mut: %s", serialized)
+	}
+	shared := NewSlice([]Scmer{NewInt(0), NewInt(2), NewInt(3)})
+	if got := Apply(Eval(optimized, env), shared); !Equal(got, NewSlice([]Scmer{NewInt(2), NewInt(3)})) {
+		t.Fatalf("borrowed helper returned %s", String(got))
+	}
+	if !Equal(shared, NewSlice([]Scmer{NewInt(0), NewInt(2), NewInt(3)})) {
+		t.Fatalf("borrowed helper mutated its input: %s", String(shared))
+	}
+}
+
+func TestOptimizeKeepsNestedLambdaHelperWithOuterCapture(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("nested lambda inline test", `(define add_offset (lambda (offset values)
+		(map values (lambda (value) (+ value offset)))))`, env)
+
+	optimized := optimizeTestSource(t, env, `(lambda (values) (add_offset 2 values))`)
+	if serialized := serializedTestExpr(t, env, optimized); !strings.Contains(serialized, "add_offset") {
+		t.Fatalf("helper with nested outer capture was inlined: %s", serialized)
+	}
+	got := Apply(Eval(optimized, env), NewSlice([]Scmer{NewInt(1), NewInt(3)}))
+	if !Equal(got, NewSlice([]Scmer{NewInt(3), NewInt(5)})) {
+		t.Fatalf("capturing helper returned %s", String(got))
+	}
+}
+
+func TestOptimizeKeepsNestedLambdaHelperFromDifferentEnvironment(t *testing.T) {
+	source := newOptimizerTestEnv()
+	EvalAll("nested lambda inline test", `(define nested_captured_value 7)`, source)
+	EvalAll("nested lambda inline test", `(define nested_captured_helper (lambda (values)
+		(map values (lambda (value) (+ value nested_captured_value)))))`, source)
+
+	target := newOptimizerTestEnv()
+	target.Vars[Symbol("nested_captured_value")] = NewInt(9)
+	target.Vars[Symbol("nested_captured_helper")] = source.Vars[Symbol("nested_captured_helper")]
+	optimized := optimizeTestSource(t, target, `(lambda (values) (nested_captured_helper values))`)
+	if serialized := serializedTestExpr(t, target, optimized); !strings.Contains(serialized, "nested_captured_helper") {
+		t.Fatalf("nested helper from a different environment was inlined: %s", serialized)
+	}
+	got := Apply(Eval(optimized, target), NewSlice([]Scmer{NewInt(1)}))
+	if !Equal(got, NewSlice([]Scmer{NewInt(8)})) {
+		t.Fatalf("nested helper used target capture: %s", String(got))
+	}
+}
+
+func TestNestedLambdaCaptureAnalysisHandlesCycles(t *testing.T) {
+	items := make([]Scmer, 2)
+	cycle := NewSlice(items)
+	items[0] = NewSymbol("lambda")
+	items[1] = cycle
+	if expressionContainsOuterReference(cycle) {
+		t.Fatal("capture analysis treated a small capture-free cycle as an outer reference")
+	}
+}
+
 func TestOptimizeInlinesSingleUseLeafProc(t *testing.T) {
 	env := newOptimizerTestEnv()
 	EvalAll("leaf inline test", `(define leaf_second (lambda (values) (nth values 1)))`, env)
@@ -209,6 +290,23 @@ func BenchmarkSchemeHelperOwnedReturnAppend(b *testing.B) {
 	env := newOptimizerTestEnv()
 	EvalAll("optimizer return benchmark", `(define benchmark_filtered (lambda (a b c d) (filter (list a b c d) (lambda (x) (> x 1)))))`, env)
 	optimized := optimizeTestSource(b, env, `(lambda (a b c d e) (append (benchmark_filtered a b c d) e))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	args := []Scmer{NewInt(0), NewInt(2), NewInt(3), NewInt(4), NewInt(5)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := fn(args...)
+		if len(result.Slice()) != 4 {
+			b.Fatal("unexpected result length")
+		}
+	}
+}
+
+func BenchmarkOptimizeInlinedNestedLambdaHelper(b *testing.B) {
+	env := newOptimizerTestEnv()
+	EvalAll("nested lambda inline benchmark", `(define benchmark_filter_owned (lambda (values) (filter values (lambda (x) (> x 1)))))`, env)
+	optimized := optimizeTestSource(b, env, `(lambda (a b c d e)
+		(append (benchmark_filter_owned (list a b c d)) e))`)
 	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
 	args := []Scmer{NewInt(0), NewInt(2), NewInt(3), NewInt(4), NewInt(5)}
 	b.ReportAllocs()


### PR DESCRIPTION
## What

- allow the leaf Proc inliner to treat capture-free nested lambdas as opaque constants
- preserve lambda-local numbered variables by stopping parameter substitution at nested lambda boundaries
- reject outer captures and cross-environment closures conservatively
- make capture analysis bounded, cycle-safe, and allocation-free

## Evidence

BenchmarkOptimizeInlinedNestedLambdaHelper, 10 runs on Ryzen 9 7900X3D:

- median: 1841 ns/op -> 1605 ns/op (-12.8%)
- memory: 1216 B/op -> 1000 B/op (-17.8%)
- allocations: 47 -> 42 allocs/op (-10.6%)

Existing neighboring benchmarks retain identical allocation counts.

## Validation

- go test ./scm
- full make test with normal parallelism: passed
- Scheme coverage: 100.0%
- Go coverage: 20.4%

No single-worker override was used.