### PR TITLE
Fix Scheme coverage to count interpreter execution only

### DIFF
--- a/git-pre-commit
+++ b/git-pre-commit
@@ -72,6 +72,12 @@ if [ "${MEMCP_COVERAGE:-}" = "1" ]; then
     mkdir -p "$GOCOVERDIR"
     echo "📊 Coverage mode enabled (GOCOVERDIR=$GOCOVERDIR)"
 fi
+if [ "${MEMCP_SCM_COVERAGE:-}" = "1" ]; then
+    scm_coverdir="${MEMCP_SCM_COVERDIR:-/tmp/memcp-scm-coverage}"
+    rm -rf "$scm_coverdir"
+    mkdir -p "$scm_coverdir"
+    echo "📊 Scheme interpreter coverage enabled (report directory: $scm_coverdir)"
+fi
 if ! go build $build_flags -o memcp; then
     echo "❌ Build failed, commit aborted"
     exit 1
@@ -435,11 +441,12 @@ run_one() {
 }
 
 print_scm_coverage_report() {
-  if [ "${MEMCP_COVERAGE:-}" != "1" ]; then
+  if [ "${MEMCP_SCM_COVERAGE:-}" != "1" ]; then
     return
   fi
   echo ""
-  echo "📊 Generating SCM coverage report..."
+  echo "📊 Generating SCM interpreter coverage report..."
+  echo "   Process-local snapshot; MemCP restarts reset these counters."
   if ! wait_for_sql_ready 15 1; then
     echo "   ⚠️  MemCP is not SQL-ready; SCM coverage unavailable"
     return
@@ -451,11 +458,7 @@ print_scm_coverage_report() {
     return
   fi
   local scm_coverage_file
-  if [ -n "${GOCOVERDIR:-}" ] && [ -d "$GOCOVERDIR" ]; then
-    scm_coverage_file="$GOCOVERDIR/scm-coverage.json"
-  else
-    scm_coverage_file="$tmpdir/scm-coverage.json"
-  fi
+  scm_coverage_file="$scm_coverdir/scm-coverage.json"
   printf '%s\n' "$scm_coverage_json" > "$scm_coverage_file"
   python3 - "$scm_coverage_file" <<'PY'
 import json
@@ -480,7 +483,7 @@ report = assoc_to_dict(report)
 total = int(report.get("total", 0) or 0)
 covered = int(report.get("covered", 0) or 0)
 percent = float(report.get("percent", 100.0) or 0.0)
-print(f"   total: {covered}/{total} source nodes covered ({percent:.1f}%)")
+print(f"   total: {covered}/{total} source forms executed by the interpreter ({percent:.1f}%)")
 
 files = report.get("files", [])
 gaps = [
@@ -506,9 +509,7 @@ else:
             + suffix
         )
 PY
-  if [ -n "${GOCOVERDIR:-}" ] && [ -d "$GOCOVERDIR" ]; then
-    echo "   Full report: $GOCOVERDIR/scm-coverage.json"
-  fi
+  echo "   Full report: $scm_coverage_file"
 }
 
 if [ "$fail_fast_mode" -eq 1 ]; then

--- a/main.go
+++ b/main.go
@@ -1040,7 +1040,8 @@ func readConfigFile(path string) ([]string, error) {
 }
 
 func main() {
-	fmt.Print(`memcp Copyright (C) 2023 - 2025   Carl-Philip Hänsch
+	scm.SettingsTrackSourceCoverage = os.Getenv("MEMCP_SCM_COVERAGE") == "1"
+	fmt.Print(`memcp Copyright (C) 2023 - 2026   Carl-Philip Hänsch
     This program comes with ABSOLUTELY NO WARRANTY;
     This is free software, and you are welcome to redistribute it
     under certain conditions;

--- a/scm/coverage.go
+++ b/scm/coverage.go
@@ -55,7 +55,7 @@ func sourceCoverageReport(a ...Scmer) Scmer {
 			continue
 		}
 		key := sourceCoveragePoint{source: si.source, line: si.line, col: si.col}
-		points[key] = points[key] || si.coverage
+		points[key] = points[key] || si.wasInterpreted()
 	}
 
 	stats := map[string]*fileStats{}

--- a/scm/coverage_test.go
+++ b/scm/coverage_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func sourceCoverageCounts(source string) (covered, total int) {
+	type point struct {
+		line int
+		col  int
+	}
+	points := make(map[point]bool)
+	for _, info := range sourceCoverageInfos {
+		if info != nil && info.source == source {
+			key := point{line: info.line, col: info.col}
+			points[key] = points[key] || info.wasInterpreted()
+		}
+	}
+	for _, executed := range points {
+		total++
+		if executed {
+			covered++
+		}
+	}
+	return covered, total
+}
+
+func TestSourceCoverageTracksInterpreterExecutionOnly(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimizedSource := "coverage-optimizer-only.scm"
+	Optimize(Read(optimizedSource, `(if true (+ 1 2) (+ 3 4))`), env, nil)
+	if covered, total := sourceCoverageCounts(optimizedSource); total != 3 || covered != 0 {
+		t.Fatalf("optimizer marked source coverage: covered=%d total=%d", covered, total)
+	}
+
+	runtimeSource := "coverage-interpreter.scm"
+	Eval(Read(runtimeSource, `(if true (+ 1 2) (+ 3 4))`), env)
+	if covered, total := sourceCoverageCounts(runtimeSource); total != 3 || covered != 2 {
+		t.Fatalf("interpreter coverage = %d/%d, want selected branch plus root = 2/3", covered, total)
+	}
+
+	previous := SettingsTrackSourceCoverage
+	SettingsTrackSourceCoverage = true
+	defer func() { SettingsTrackSourceCoverage = previous }()
+	preservedSource := "coverage-optimized-runtime.scm"
+	optimized := Optimize(Read(preservedSource, `(lambda (x) (+ x 1))`), env, nil)
+	if covered, total := sourceCoverageCounts(preservedSource); total != 3 || covered != 0 {
+		t.Fatalf("coverage-preserving optimizer marked source coverage: covered=%d total=%d", covered, total)
+	}
+	proc := Eval(optimized, env)
+	Apply(proc, NewInt(2))
+	if covered, total := sourceCoverageCounts(preservedSource); total != 3 || covered != 2 {
+		t.Fatalf("optimized interpreter coverage = %d/%d, want lambda and body but not parameter syntax = 2/3", covered, total)
+	}
+}

--- a/scm/match.go
+++ b/scm/match.go
@@ -50,9 +50,7 @@ func scmerSymbolName(s Scmer) (string, bool) {
 func scmerAsSlice(v Scmer) ([]Scmer, bool) {
 	// Unwrap SourceInfo if present
 	if v.IsSourceInfo() {
-		sourceInfo := v.SourceInfo()
-		sourceInfo.coverage = true
-		return scmerAsSlice(sourceInfo.value)
+		return scmerAsSlice(v.SourceInfo().value)
 	}
 	if v.IsSlice() {
 		return v.Slice(), true
@@ -71,9 +69,7 @@ func scmerAsSlice(v Scmer) ([]Scmer, bool) {
 func scmerAsString(v Scmer) (string, bool) {
 	// Unwrap SourceInfo if present
 	if v.IsSourceInfo() {
-		sourceInfo := v.SourceInfo()
-		sourceInfo.coverage = true
-		return scmerAsString(sourceInfo.value)
+		return scmerAsString(v.SourceInfo().value)
 	}
 	if v.GetTag() == tagString {
 		return v.String(), true
@@ -88,14 +84,10 @@ func scmerAsString(v Scmer) (string, bool) {
 
 func valueFromPattern(pattern Scmer, en *Env) Scmer {
 	if pattern.IsSourceInfo() {
-		sourceInfo := pattern.SourceInfo()
-		sourceInfo.coverage = true
-		return valueFromPattern(sourceInfo.value, en)
+		return valueFromPattern(pattern.SourceInfo().value, en)
 	}
 	if pattern.GetTag() == tagSourceInfo {
-		sourceInfo := pattern.SourceInfo()
-		sourceInfo.coverage = true
-		return valueFromPattern(sourceInfo.value, en)
+		return valueFromPattern(pattern.SourceInfo().value, en)
 	}
 	if pattern.IsSymbol() {
 		sym := Symbol(pattern.String())
@@ -143,9 +135,7 @@ func match(val Scmer, pattern Scmer, en *Env, mutable bool) bool {
 	*/
 	switch pattern.GetTag() {
 	case tagSourceInfo:
-		sourceInfo := pattern.SourceInfo()
-		sourceInfo.coverage = true
-		return match(val, sourceInfo.value, en, mutable)
+		return match(val, pattern.SourceInfo().value, en, mutable)
 	case tagInt, tagFloat, tagString:
 		return Equal(val, pattern)
 	case tagSymbol:

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -28,6 +28,10 @@ import "time"
 
 var SettingsHaveGoodBacktraces bool
 
+// SettingsTrackSourceCoverage preserves source wrappers until interpreter
+// execution. It never marks the wrappers as covered itself.
+var SettingsTrackSourceCoverage bool
+
 func procBodyUsesNamedParam(body Scmer, named map[Symbol]struct{}) bool {
 	if len(named) == 0 {
 		return false
@@ -963,13 +967,10 @@ func requiredNumberedSlots(expr Scmer) int {
 
 func scmerStripSourceInfo(v Scmer) (Scmer, bool) {
 	if v.IsSourceInfo() {
-		si := v.SourceInfo()
-		si.coverage = true
-		return si.value, true
+		return v.SourceInfo().value, true
 	}
 	if v.GetTag() == tagAny {
 		if si, ok := v.Any().(SourceInfo); ok {
-			si.coverage = true
 			return si.value, true
 		}
 	}
@@ -1072,7 +1073,14 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 		return optimizeList(val.Slice(), env, ome, useResult)
 	case tagSourceInfo:
 		siPtr := val.SourceInfo()
-		siPtr.coverage = true
+		if SettingsTrackSourceCoverage {
+			result, ti := OptimizeEx(siPtr.value, env, ome, useResult)
+			if ti.Const() {
+				return result, ti
+			}
+			siPtr.value = result
+			return val, ti.WithoutTransfer()
+		}
 		if SettingsHaveGoodBacktraces {
 			result, ti := OptimizeEx(siPtr.value, env, ome, useResult)
 			if ti.Const() {
@@ -1086,7 +1094,6 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 	case tagAny:
 		payload := val.Any()
 		if pv, ok := payload.(SourceInfo); ok {
-			pv.coverage = true
 			if SettingsHaveGoodBacktraces {
 				result, ti := OptimizeEx(pv.value, env, ome, useResult)
 				if ti.Const() {
@@ -2449,12 +2456,9 @@ func OptimizeMatchPattern(value Scmer, pattern Scmer, env *Env, ome *optimizerMe
 
 func OptimizeParser(val Scmer, env *Env, ome *optimizerMetainfo, ignoreResult bool) Scmer {
 	if val.IsSourceInfo() {
-		sourceInfo := val.SourceInfo()
-		sourceInfo.coverage = true
-		val = sourceInfo.value
+		val = val.SourceInfo().value
 	} else if val.GetTag() == tagAny {
 		if sourceInfo, ok := val.Any().(SourceInfo); ok {
-			sourceInfo.coverage = true
 			val = sourceInfo.value
 		}
 	}

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -189,9 +189,7 @@ func parseSyntax(syntax Scmer, en *Env, ome *optimizerMetainfo, ignoreResult boo
 	}
 	switch syntax.GetTag() {
 	case tagSourceInfo:
-		sourceInfo := syntax.SourceInfo()
-		sourceInfo.coverage = true
-		return parseSyntax(sourceInfo.value, en, ome, ignoreResult)
+		return parseSyntax(syntax.SourceInfo().value, en, ome, ignoreResult)
 	case tagFastDict:
 		fd := syntax.FastDict()
 		if fd == nil {

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -22,16 +22,27 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 var schemeStringUnescaper = strings.NewReplacer("\\\"", "\"", "\\\\", "\\", "\\n", "\n", "\\r", "\r", "\\t", "\t", "\\0", "\x00")
 
 type SourceInfo struct {
-	source   string
-	line     int
-	col      int
-	value    Scmer
-	coverage bool
+	source string
+	line   int
+	col    int
+	value  Scmer
+	// Only evalWithSourceInfo may mark this flag. Static consumers such as the
+	// optimizer may inspect or unwrap SourceInfo, but that is not execution.
+	coverage uint32
+}
+
+func (source_info *SourceInfo) markInterpreted() {
+	atomic.StoreUint32(&source_info.coverage, 1)
+}
+
+func (source_info *SourceInfo) wasInterpreted() bool {
+	return atomic.LoadUint32(&source_info.coverage) != 0
 }
 
 func (source_info SourceInfo) String() string {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -37,9 +37,7 @@ import (
 
 func symbolName(v Scmer) (string, bool) {
 	if v.IsSourceInfo() {
-		sourceInfo := v.SourceInfo()
-		sourceInfo.coverage = true
-		return symbolName(sourceInfo.value)
+		return symbolName(v.SourceInfo().value)
 	}
 	if v.GetTag() == tagSymbol {
 		return v.String(), true
@@ -61,9 +59,7 @@ func mustSymbol(v Scmer) Symbol {
 
 func mustNthLocalVar(v Scmer) NthLocalVar {
 	if v.IsSourceInfo() {
-		sourceInfo := v.SourceInfo()
-		sourceInfo.coverage = true
-		return mustNthLocalVar(sourceInfo.value)
+		return mustNthLocalVar(v.SourceInfo().value)
 	}
 	if v.GetTag() == tagNthLocalVar {
 		return v.NthLocalVar()
@@ -80,7 +76,7 @@ func evalWithSourceInfo(si *SourceInfo, en *Env) (value Scmer) {
 	if si == nil {
 		return NewNil()
 	}
-	si.coverage = true
+	si.markInterpreted()
 	if !SettingsHaveGoodBacktraces {
 		return Eval(si.value, en)
 	}

--- a/tests/storage/persistence/serializer-coverage.yaml
+++ b/tests/storage/persistence/serializer-coverage.yaml
@@ -58,7 +58,7 @@ test_cases:
         (if (not (equal? (get_assoc after "covered") 1)) (fail "node not covered after eval"))
         true)
 
-  - name: "SourceInfo coverage marks parser grammar nodes"
+  - name: "SourceInfo coverage ignores parser grammar construction"
     scm: |
       (begin
         (define fail (lambda (msg) (error (concat "source coverage parser syntax: " msg))))
@@ -68,7 +68,7 @@ test_cases:
         (if (not (equal? (parser_instance "abc") "abc")) (fail "parser result mismatch"))
         (define report (source_coverage_report src))
         (if (not (equal? (get_assoc report "total") 1)) (fail "registered grammar node missing"))
-        (if (not (equal? (get_assoc report "covered") 1)) (fail "grammar node not covered by parser construction"))
+        (if (not (equal? (get_assoc report "covered") 0)) (fail "grammar construction counted as runtime execution"))
         true)
 
   - name: "SourceInfo coverage marks parser result generators"

--- a/tests/storage/persistence/serializer-coverage.yaml
+++ b/tests/storage/persistence/serializer-coverage.yaml
@@ -58,7 +58,7 @@ test_cases:
         (if (not (equal? (get_assoc after "covered") 1)) (fail "node not covered after eval"))
         true)
 
-  - name: "SourceInfo coverage ignores parser grammar construction"
+  - name: "SourceInfo coverage marks parser grammar nodes"
     scm: |
       (begin
         (define fail (lambda (msg) (error (concat "source coverage parser syntax: " msg))))


### PR DESCRIPTION
## Summary

- remove false coverage writes from optimizer, matcher, Packrat parser, and static SourceInfo helpers
- preserve source wrappers in the explicit Scheme coverage mode without marking them executed
- make the interpreter the sole coverage writer, using an atomic visit flag
- separate SCM interpreter coverage from normal Go coverage and label reports as process-local snapshots

## Correctness evidence

- optimizing an expression without evaluating it leaves coverage at 0
- interpreting a selected IF branch marks only the root and selected branch
- parser grammar construction no longer counts as runtime execution
- repository-wide search leaves `evalWithSourceInfo` as the only visit-marker caller

## Verification

- `go test -race ./scm`
- SQL runner contract and hard-limit guard tests
- serializer/SourceInfo integration suite: 8/8
- full parallel pre-commit run with Go coverage: passed, 20.7%
- explicit SCM snapshot: 19,648/63,090 interpreter-executed forms (31.1%); one existing hard wall-clock test exceeded its 3s budget only under SourceInfo instrumentation, with correct query output

SCM reports deliberately state that counters are process-local; cross-restart aggregation is follow-up work.
