### PR TITLE
storage: add adaptive ordered RecSet batch filter

### DIFF
--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1844,7 +1844,12 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
+	result.universe = visibleUpper
 	result.items = make([]uint32, 0, part.count)
+	maxItems := -1
+	if len(sortcols) == 0 && limit >= 0 && limitPartitionCols == 0 {
+		maxItems = offset + limit
+	}
 	colBufs := make([][]scm.Scmer, len(conditionCols))
 	t.forEachVisibleRun(part, visibleUpper, acidMode, currentTx, func(base, count uint32) bool {
 		end := base + count
@@ -1884,6 +1889,9 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 				}
 				if scm.ToBool(conditionFn(cdataset...)) {
 					result.items = append(result.items, idx)
+					if maxItems >= 0 && len(result.items) >= maxItems {
+						return false
+					}
 				}
 			}
 		}
@@ -1901,15 +1909,14 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 			}
 			if scm.ToBool(conditionFn(cdataset...)) {
 				result.items = append(result.items, idx)
+				if maxItems >= 0 && len(result.items) >= maxItems {
+					return false
+				}
 			}
 		}
 		return true
 	})
 
-	itemPos := make(map[uint32]int, len(result.items))
-	for i, idx := range result.items {
-		itemPos[idx] = i
-	}
 	lessByID := func(a, b uint32) bool {
 		cmpCount := len(result.scols)
 		if len(result.sortdirs) < cmpCount {
@@ -1925,7 +1932,7 @@ func (t *storageShard) scan_order_recset_part(part *recSetShard, conditionCols [
 				return false
 			}
 		}
-		return itemPos[a] < itemPos[b]
+		return a < b
 	}
 	if len(sortcols) > 0 {
 		if limit >= 0 && limitPartitionCols == 0 {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -144,6 +144,7 @@ func skipPartition(q *globalqueue, qx *shardqueue, pk []scm.Scmer, n int) {
 type shardqueue struct {
 	shard           *storageShard
 	items           []uint32 // TODO: refactor to chan, so we can block generating too much entries
+	universe        uint32   // visible recid upper bound captured by the shard scan
 	candidateCount  int64
 	err             scanError
 	scols           []func(uint32) scm.Scmer // sort criteria column reader
@@ -195,7 +196,7 @@ func (s *shardqueue) Less(i, j int) bool {
 		} // else: go to next level
 		// otherwise: move on to c++
 	}
-	return false // equal is not less
+	return s.items[i] < s.items[j]
 }
 func (s *shardqueue) Swap(i, j int) {
 	s.items[i], s.items[j] = s.items[j], s.items[i]
@@ -268,7 +269,19 @@ func (s *globalqueue) Less(i, j int) bool {
 		} // else: go to next level
 		// otherwise: move on to c++
 	}
-	return false // equal is not less
+	// SQL leaves peer ordering unspecified, but adaptive batch windows need the
+	// same physical order on every continuation. Shard UUID plus recid supplies
+	// that internal total order without reading or sorting another column. This
+	// also makes the empty-ORDER path repeatable while retaining greedy scans.
+	if s.q[i].tableIdx != s.q[j].tableIdx {
+		return s.q[i].tableIdx < s.q[j].tableIdx
+	}
+	for k := range s.q[i].shard.uuid {
+		if s.q[i].shard.uuid[k] != s.q[j].shard.uuid[k] {
+			return s.q[i].shard.uuid[k] < s.q[j].shard.uuid[k]
+		}
+	}
+	return s.q[i].items[0] < s.q[j].items[0]
 }
 func (s *globalqueue) Swap(i, j int) {
 	s.q[i], s.q[j] = s.q[j], s.q[i]
@@ -326,6 +339,10 @@ type scanOrderTableSpec struct {
 	callback        scm.Scmer
 	postOrderCols   []string
 	postOrderFilter scm.Scmer
+	// recordVisitor is an internal sink used by scan_order_batch_accept. When
+	// present, globally ordered record IDs are delivered directly instead of
+	// being mapped. The visitor must consume the slice before returning.
+	recordVisitor func(*shardqueue, []uint32)
 	// perTableOffset / perTableLimit: -1 disables per-table limiting for this
 	// table; otherwise the first `perTableOffset` rows (in merge order) are
 	// skipped and at most `perTableLimit` rows are emitted from this table.
@@ -333,6 +350,14 @@ type scanOrderTableSpec struct {
 	// merge direction (shared sortdirs). Callers must enforce this.
 	perTableOffset int
 	perTableLimit  int
+}
+
+func streamScanOrderItems(spec *scanOrderTableSpec, queue *shardqueue, acc scm.Scmer, recids []uint32) (scm.Scmer, bool) {
+	if spec.recordVisitor != nil {
+		spec.recordVisitor(queue, recids)
+		return acc, false
+	}
+	return streamOrBreak(queue.mapper, acc, recids)
 }
 
 func (s *scanOrderTableSpec) backingTable() *table {
@@ -755,8 +780,10 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	hadValue := false
 	// initialize MapReducers per shard (each shard uses its table's callbackCols/callback)
 	for _, sq := range q.q {
-		sq.mapper = sq.shard.OpenMapReducer(sq.callbackCols, sq.callback, aggregate, false, 0, nil, currentTx)
 		spec := &tables[sq.tableIdx]
+		if spec.recordVisitor == nil {
+			sq.mapper = sq.shard.OpenMapReducer(sq.callbackCols, sq.callback, aggregate, false, 0, nil, currentTx)
+		}
 		if !spec.postOrderFilter.IsNil() {
 			sq.postOrderMapper = sq.shard.OpenMapReducer(
 				spec.postOrderCols,
@@ -806,7 +833,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		if prevPK == nil || !pkEqual(prevPK, curPK) {
 			// Flush buffer before partition switch
 			if bufN > 0 && bufShard != nil {
-				akkumulator, breakCaught = streamOrBreak(bufShard.mapper, akkumulator, buf[:bufN])
+				akkumulator, breakCaught = streamScanOrderItems(&tables[bufShard.tableIdx], bufShard, akkumulator, buf[:bufN])
 				hadValue = true
 				bufN = 0
 				if breakCaught {
@@ -881,7 +908,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 		// If shard changed, flush the buffer to the previous shard's mapper
 		if bufShard != nil && bufShard != qx {
-			akkumulator, breakCaught = streamOrBreak(bufShard.mapper, akkumulator, buf[:bufN])
+			akkumulator, breakCaught = streamScanOrderItems(&tables[bufShard.tableIdx], bufShard, akkumulator, buf[:bufN])
 			hadValue = true
 			bufN = 0
 			if breakCaught {
@@ -896,7 +923,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 
 		// Flush if buffer full
 		if bufN == len(buf) {
-			akkumulator, breakCaught = streamOrBreak(bufShard.mapper, akkumulator, buf[:bufN])
+			akkumulator, breakCaught = streamScanOrderItems(&tables[bufShard.tableIdx], bufShard, akkumulator, buf[:bufN])
 			hadValue = true
 			bufN = 0
 			if breakCaught {
@@ -913,7 +940,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	}
 	// Flush remaining buffer
 	if !breakCaught && bufN > 0 && bufShard != nil {
-		akkumulator, _ = streamOrBreak(bufShard.mapper, akkumulator, buf[:bufN])
+		akkumulator, _ = streamScanOrderItems(&tables[bufShard.tableIdx], bufShard, akkumulator, buf[:bufN])
 		hadValue = true
 	}
 	if !hadValue && isOuter && len(tables) > 0 {
@@ -1183,7 +1210,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	// scan loop in read lock
 	var maxInsertIndex int
 	var visibleUpper uint32
-	resultAlreadySorted := false
+	resultAlreadySorted := len(sortcols) == 0
 	func() {
 		shardLocked := false
 		if !skipShardReadLock {
@@ -1207,6 +1234,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		// remember current insert status (so don't scan things that are inserted during map)
 		maxInsertIndex = len(t.inserts)
 		visibleUpper = t.main_count + uint32(maxInsertIndex)
+		result.universe = visibleUpper
 
 		// iterate over items (indexed)
 		// TODO(memcp): iterateIndexSorted(boundaries, sortcols) to emit tuples in ORDER BY sequence.
@@ -1222,7 +1250,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		var survivedBuf, mainIdsBuf []uint32
 		colBufs := make([][]scm.Scmer, len(conditionCols))
 		t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, func(index *StorageIndex, active bool) {
-			resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
+			if len(sortcols) > 0 {
+				resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
+			}
 		}, func(batch []uint32) bool {
 			result.candidateCount += int64(len(batch))
 
@@ -1367,7 +1397,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 				return false
 			}
 		}
-		return itemPos[a] < itemPos[b]
+		return a < b
 	}
 	// TODO: find conditions when exactly we don't need to sort anymore.
 	// The sort can be skipped when ALL of these hold:

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -1,0 +1,274 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "sort"
+import "github.com/launix-de/memcp/scm"
+
+type orderedBatchRecord struct {
+	shard *storageShard
+	recid uint32
+}
+
+type orderedBatchPart struct {
+	shard    *storageShard
+	universe uint32
+	recids   []uint32
+}
+
+// collectOrderedCandidateBatch uses scan_order's normal shard Top-K and global
+// merge. Repeated calls request disjoint windows; batch growth is handled by
+// scanOrderBatchAccept. The ordered record vector remains authoritative because
+// a RecSet itself deliberately carries membership, not order.
+func collectOrderedCandidateBatch(currentTx *TxContext, source scanOrderTableSpec, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int) ([]orderedBatchRecord, *recSet) {
+	table := source.backingTable()
+	parts := make(map[*storageShard]*orderedBatchPart)
+	partOrder := make([]*orderedBatchPart, 0)
+	records := make([]orderedBatchRecord, 0, limit)
+	source.conditionCols = nil
+	source.condition = scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	source.sortcols = sortcols
+	source.callbackCols = nil
+	source.callback = scm.NewNil()
+	source.postOrderCols = nil
+	source.postOrderFilter = scm.NewNil()
+	source.perTableOffset = -1
+	source.perTableLimit = -1
+	source.recordVisitor = func(queue *shardqueue, recids []uint32) {
+		part := parts[queue.shard]
+		if part == nil {
+			part = &orderedBatchPart{shard: queue.shard, universe: queue.universe}
+			parts[queue.shard] = part
+			partOrder = append(partOrder, part)
+		}
+		if queue.universe > part.universe {
+			part.universe = queue.universe
+		}
+		for _, recid := range recids {
+			records = append(records, orderedBatchRecord{shard: queue.shard, recid: recid})
+			part.recids = append(part.recids, recid)
+		}
+	}
+
+	scanOrderMulti(currentTx, []scanOrderTableSpec{source}, sortdirs, 0, offset, limit,
+		scm.NewNil(), scm.NewNil(), false, scm.NewNil())
+
+	batch := &recSet{tx: currentTx, table: table, shards: make([]recSetShard, 0, len(partOrder))}
+	for _, part := range partOrder {
+		sort.Slice(part.recids, func(i, j int) bool { return part.recids[i] < part.recids[j] })
+		shardPart := newRecSetShardFromSortedIDs(part.shard, part.universe, part.recids)
+		batch.count += shardPart.count
+		batch.shards = append(batch.shards, shardPart)
+	}
+	return records, batch
+}
+
+func validateAcceptedBatch(currentTx *TxContext, batch *recSet, acceptedValue scm.Scmer) *recSet {
+	if !acceptedValue.IsCustom(TagRecSet) {
+		panic("scan_order_batch_accept: batch filter must return a recset")
+	}
+	accepted := RecSetFromScmer(acceptedValue)
+	if accepted == nil || accepted.table != batch.table {
+		panic("scan_order_batch_accept: batch filter must return a recset of the input table")
+	}
+	if accepted.tx != currentTx {
+		panic("scan_order_batch_accept: batch filter returned a recset from a different transaction")
+	}
+	for i := range accepted.shards {
+		part := &accepted.shards[i]
+		if part.shard == nil || part.shard.t != batch.table {
+			panic("scan_order_batch_accept: batch filter returned a recset of the input table")
+		}
+		part.forEachID(func(recid uint32) bool {
+			if !batch.contains(part.shard, recid) {
+				panic("scan_order_batch_accept: batch filter result is not a subset of its input batch")
+			}
+			return true
+		})
+	}
+	return accepted
+}
+
+func optimizeScanOrderBatchAccept(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
+	const mapEnd = 10
+	const reduceIdx = 11
+	const neutralIdx = 12
+	rawReduce := scm.NewNil()
+	if len(v) > reduceIdx {
+		rawReduce = v[reduceIdx]
+	}
+	for i := 1; i <= mapEnd && i < len(v); i++ {
+		v[i], _ = oc.OptimizeSub(v[i], true)
+	}
+	neutralType := unknownScanType()
+	if len(v) > neutralIdx {
+		v[neutralIdx], neutralType = oc.OptimizeSub(v[neutralIdx], true)
+		neutralType = normalizeScanType(neutralType)
+	}
+	oc.Ome.IncrLoopDepth()
+	if !rawReduce.IsNil() {
+		v[reduceIdx], _ = oc.OptimizeReducerCallback(rawReduce, neutralType, unknownScanType())
+	}
+	for i := 13; i < len(v); i++ {
+		v[i], _ = oc.OptimizeSub(v[i], true)
+	}
+	oc.Ome.DecrLoopDepth()
+	return scm.NewSlice(v), nil
+}
+
+// scanOrderBatchAccept incrementally requests ordered candidate windows. The
+// first window has offset+limit records; every following window is twice as
+// large. The filter sees an exact RecSet for only that window and returns an
+// accepted subset. SQL OFFSET/LIMIT count accepted records, while driverOffset
+// counts every candidate already examined.
+func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batchFilter scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer) scm.Scmer {
+	if limitPartitionCols != 0 {
+		panic("scan_order_batch_accept: partitioned limits are not supported")
+	}
+	if offset < 0 {
+		panic("scan_order_batch_accept: offset must not be negative")
+	}
+	if limit < 0 {
+		panic("scan_order_batch_accept: limit must be finite and non-negative")
+	}
+	if len(sortcols) != len(sortdirs) {
+		panic("scan_order_batch_accept: sortcols and sortdirs must have equal length")
+	}
+	if source.recset != nil && currentTx == nil {
+		currentTx = source.recset.tx
+	}
+	if source.backingTable() == nil {
+		panic("scan_order_batch_accept: input must have a backing table")
+	}
+	if offset > int(^uint(0)>>1)-limit {
+		panic("scan_order_batch_accept: offset plus limit overflows")
+	}
+
+	result := neutral
+	hadValue := false
+	if limit == 0 {
+		if isOuter {
+			callbackFn := scm.OptimizeProcToSerialFunction(callback)
+			reduceFn := scm.OptimizeProcToSerialFunction(aggregate)
+			return reduceFn(result, callbackFn(buildOuterNullCallbackRow(callbackCols)...))
+		}
+		return notFoundValue
+	}
+
+	filterFn := scm.OptimizeProcToSerialFunction(batchFilter)
+	mappers := make(map[*storageShard]*ShardMapReducer)
+	defer func() {
+		for _, mapper := range mappers {
+			mapper.Close()
+			mapper.FlushSideEffects()
+		}
+	}()
+	mapperFor := func(shard *storageShard) *ShardMapReducer {
+		mapper := mappers[shard]
+		if mapper == nil {
+			mapper = shard.OpenMapReducer(callbackCols, callback, aggregate, false, 0, nil, currentTx)
+			mappers[shard] = mapper
+		}
+		return mapper
+	}
+
+	target := offset + limit
+	batchSize := target
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	driverOffset := 0
+	acceptedCount := 0
+	emittedCount := 0
+	ss := SessionStateFromTx(currentTx)
+	querySeq := querySeqFromTx(currentTx)
+
+	for acceptedCount < target {
+		if ss != nil && ss.IsKilledSeq(querySeq) {
+			panic("query killed")
+		}
+		records, batch := collectOrderedCandidateBatch(currentTx, source, sortcols, sortdirs, driverOffset, batchSize)
+		if len(records) == 0 {
+			break
+		}
+		accepted := validateAcceptedBatch(currentTx, batch, filterFn(NewRecSetScmer(batch)))
+
+		var pendingShard *storageShard
+		pending := make([]uint32, 0, len(records))
+		flush := func() bool {
+			if len(pending) == 0 {
+				return false
+			}
+			var broke bool
+			result, broke = streamOrBreak(mapperFor(pendingShard), result, pending)
+			pending = pending[:0]
+			return broke
+		}
+		breakCaught := false
+		for _, record := range records {
+			if !accepted.contains(record.shard, record.recid) {
+				continue
+			}
+			acceptedCount++
+			if acceptedCount <= offset {
+				continue
+			}
+			if emittedCount >= limit {
+				break
+			}
+			if pendingShard != nil && pendingShard != record.shard && flush() {
+				breakCaught = true
+				break
+			}
+			pendingShard = record.shard
+			pending = append(pending, record.recid)
+			emittedCount++
+			hadValue = true
+		}
+		if !breakCaught {
+			breakCaught = flush()
+		}
+		if breakCaught || acceptedCount >= target {
+			break
+		}
+
+		driverOffset += len(records)
+		if len(records) < batchSize {
+			break
+		}
+		if batchSize > (int(^uint(0)>>1)-driverOffset)/2 {
+			batchSize = int(^uint(0)>>1) - driverOffset
+		} else {
+			batchSize *= 2
+		}
+		if batchSize <= 0 {
+			panic(fmt.Sprintf("scan_order_batch_accept: candidate offset %d exceeds platform limits", driverOffset))
+		}
+	}
+
+	if !hadValue && isOuter {
+		callbackFn := scm.OptimizeProcToSerialFunction(callback)
+		reduceFn := scm.OptimizeProcToSerialFunction(aggregate)
+		result = reduceFn(result, callbackFn(buildOuterNullCallbackRow(callbackCols)...))
+		hadValue = true
+	}
+	if !hadValue && !isOuter {
+		return notFoundValue
+	}
+	return result
+}

--- a/storage/scan_order_batch_accept_bench_test.go
+++ b/storage/scan_order_batch_accept_bench_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+const (
+	batchAcceptBenchmarkRows     = 1_000_000
+	batchAcceptBenchmarkACLRows  = 65_536
+	batchAcceptBenchmarkPageSize = 72
+)
+
+type batchAcceptBenchmarkFixture struct {
+	documents *table
+	files     *table
+	sortCols  []scm.Scmer
+	sortDirs  []func(...scm.Scmer) scm.Scmer
+	mapFn     scm.Scmer
+	reduceFn  scm.Scmer
+}
+
+func insertBatchAcceptBenchmarkRows(tbl *table, columns []string, count int, makeRow func(int) []scm.Scmer) {
+	const chunkSize = 16_384
+	for start := 0; start < count; start += chunkSize {
+		end := start + chunkSize
+		if end > count {
+			end = count
+		}
+		rows := make([][]scm.Scmer, end-start)
+		for i := start; i < end; i++ {
+			rows[i-start] = makeRow(i)
+		}
+		tbl.Insert(columns, rows, nil, scm.NewNil(), false, nil)
+	}
+}
+
+func newBatchAcceptBenchmarkFixture(b *testing.B) *batchAcceptBenchmarkFixture {
+	b.Helper()
+	oldShardSize := Settings.ShardSize
+	Settings.ShardSize = 2 * batchAcceptBenchmarkRows
+	defer func() { Settings.ShardSize = oldShardSize }()
+	database := fmt.Sprintf("bench_batch_accept_%p", b)
+	databases.Remove(database)
+	b.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+
+	documents, _ := CreateTable(database, "documents", Memory, true)
+	documents.CreateColumn("id", "INT", nil, nil)
+	documents.CreateColumn("bucket", "INT", nil, nil)
+	documents.CreateColumn("file_id", "INT", nil, nil)
+	insertBatchAcceptBenchmarkRows(documents, []string{"id", "bucket", "file_id"}, batchAcceptBenchmarkRows, func(i int) []scm.Scmer {
+		return []scm.Scmer{
+			scm.NewInt(int64(i)),
+			scm.NewInt(int64(i % 100)),
+			scm.NewInt(int64(i % batchAcceptBenchmarkACLRows)),
+		}
+	})
+	RebuildTable(documents, true, false)
+
+	files, _ := CreateTable(database, "files", Memory, true)
+	files.CreateColumn("id", "INT", nil, nil)
+	files.CreateColumn("bucket", "INT", nil, nil)
+	insertBatchAcceptBenchmarkRows(files, []string{"id", "bucket"}, batchAcceptBenchmarkACLRows, func(i int) []scm.Scmer {
+		return []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i % 100))}
+	})
+	RebuildTable(files, true, false)
+
+	_, ascending := integerOrder(false)
+	fixture := &batchAcceptBenchmarkFixture{
+		documents: documents,
+		files:     files,
+		sortCols:  []scm.Scmer{scm.NewString("id")},
+		sortDirs:  []func(...scm.Scmer) scm.Scmer{ascending},
+		mapFn:     scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		reduceFn:  scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+	}
+
+	// Warm the adaptive unique id order index outside the timed sections.
+	// Four small ordered windows exceed the index savings threshold without
+	// retaining a million-record benchmark result.
+	identity := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+	for i := 0; i < 4; i++ {
+		scanOrderBatchAccept(nil, scanOrderTableSpec{table: documents}, identity,
+			fixture.sortCols, fixture.sortDirs, 0, 0, batchAcceptBenchmarkPageSize,
+			[]string{"id"}, fixture.mapFn, fixture.reduceFn, scm.NewNil(), false, scm.NewNil())
+	}
+	return fixture
+}
+
+func (f *batchAcceptBenchmarkFixture) scanOrder(postOrderCols []string, postOrderFilter scm.Scmer) scm.Scmer {
+	return f.documents.scan_order(nil,
+		nil, scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) }),
+		f.sortCols, f.sortDirs, 0, 0, batchAcceptBenchmarkPageSize,
+		[]string{"id"}, f.mapFn, f.reduceFn, scm.NewNil(), false, scm.NewNil(),
+		postOrderCols, postOrderFilter)
+}
+
+func (f *batchAcceptBenchmarkFixture) batchAccept(batchFilter scm.Scmer) scm.Scmer {
+	return scanOrderBatchAccept(nil, scanOrderTableSpec{table: f.documents}, batchFilter,
+		f.sortCols, f.sortDirs, 0, 0, batchAcceptBenchmarkPageSize,
+		[]string{"id"}, f.mapFn, f.reduceFn, scm.NewNil(), false, scm.NewNil())
+}
+
+func benchmarkBatchAcceptPair(b *testing.B, scan func() scm.Scmer, batch func() scm.Scmer) {
+	b.Helper()
+	want := scan()
+	if got := batch(); scm.String(got) != scm.String(want) {
+		b.Fatalf("batch result %v differs from scan_order result %v", got, want)
+	}
+	for _, implementation := range []struct {
+		name string
+		run  func() scm.Scmer
+	}{
+		{name: "scan_order", run: scan},
+		{name: "batch_accept", run: batch},
+	} {
+		b.Run(implementation.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkBatchAcceptResult = implementation.run()
+			}
+		})
+	}
+}
+
+var benchmarkBatchAcceptResult scm.Scmer
+
+// BenchmarkScanOrderBatchAcceptMillion compares the existing row-at-a-time
+// post-order filter with adaptive RecSet batches over one million driver rows.
+// ACL cases deliberately model the expensive shape this operator targets:
+// document -> file projection, ACL membership, then file -> document projection.
+func BenchmarkScanOrderBatchAcceptMillion(b *testing.B) {
+	fixture := newBatchAcceptBenchmarkFixture(b)
+	for _, percent := range []int{50, 1} {
+		threshold := int64(percent)
+		rowFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			return scm.NewBool(values[0].Int() < threshold)
+		})
+		batchFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			batch := RecSetFromScmer(values[0])
+			return NewRecSetScmer(batch.filterToRecSet(nil, []string{"bucket"}, rowFilter))
+		})
+		b.Run(fmt.Sprintf("simple_%02dpct", percent), func(b *testing.B) {
+			benchmarkBatchAcceptPair(b,
+				func() scm.Scmer { return fixture.scanOrder([]string{"bucket"}, rowFilter) },
+				func() scm.Scmer { return fixture.batchAccept(batchFilter) })
+		})
+	}
+
+	for _, percent := range []int{50, 1} {
+		threshold := int64(percent)
+		allowedCondition := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			return scm.NewBool(values[0].Int() < threshold)
+		})
+		allowedFiles := fixture.files.scanRecSet(nil, []string{"bucket"}, allowedCondition)
+		rowACLFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			fileID := values[0].Int()
+			return scm.NewBool(allowedFiles.scanExists(nil, []string{"id"}, scm.NewFunc(func(candidate ...scm.Scmer) scm.Scmer {
+				return scm.NewBool(candidate[0].Int() == fileID)
+			})))
+		})
+		batchACLFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			batch := RecSetFromScmer(values[0])
+			candidateFiles := batch.projectJoin(nil, []string{"file_id"}, fixture.files, []string{"id"})
+			acceptedFiles := recSetIntersect([]*recSet{candidateFiles, allowedFiles})
+			projectedDocuments := acceptedFiles.projectJoin(nil, []string{"id"}, fixture.documents, []string{"file_id"})
+			return NewRecSetScmer(recSetIntersect([]*recSet{batch, projectedDocuments}))
+		})
+		b.Run(fmt.Sprintf("acl_projection_%02dpct", percent), func(b *testing.B) {
+			benchmarkBatchAcceptPair(b,
+				func() scm.Scmer { return fixture.scanOrder([]string{"file_id"}, rowACLFilter) },
+				func() scm.Scmer { return fixture.batchAccept(batchACLFilter) })
+		})
+	}
+}

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "testing"
+import "github.com/launix-de/memcp/scm"
+
+func setupBatchAcceptTable(t *testing.T, database string, rows int) *table {
+	t.Helper()
+	table := setupScanParallelTestTable(t, database)
+	table.CreateColumn("grp", "INT", nil, nil)
+	values := make([][]scm.Scmer, rows)
+	for i := range values {
+		values[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i % 3))}
+	}
+	table.Insert([]string{"id", "grp"}, values, nil, scm.NewNil(), false, nil)
+	return table
+}
+
+func integerOrder(descending bool) (scm.Scmer, func(...scm.Scmer) scm.Scmer) {
+	relation := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		if descending {
+			return scm.NewBool(scm.ToInt(values[0]) > scm.ToInt(values[1]))
+		}
+		return scm.NewBool(scm.ToInt(values[0]) < scm.ToInt(values[1]))
+	})
+	return relation, scm.OptimizeProcToSerialFunction(relation)
+}
+
+func recSetModuloFilter(batchSizes *[]int64, divisor int, remainder int) scm.Scmer {
+	condition := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(scm.ToInt(values[0])%divisor == remainder)
+	})
+	return scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		batch := RecSetFromScmer(values[0])
+		*batchSizes = append(*batchSizes, batch.count)
+		return NewRecSetScmer(batch.filterToRecSet(batch.tx, []string{"id"}, condition))
+	})
+}
+
+func runBatchAcceptIDs(table *table, input *recSet, batchFilter scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int) []int64 {
+	got := make([]int64, 0, limit)
+	mapFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		got = append(got, int64(scm.ToInt(values[0])))
+		return values[0]
+	})
+	reduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })
+	source := scanOrderTableSpec{table: table}
+	if input != nil {
+		source.table = nil
+		source.recset = input
+	}
+	scanOrderBatchAccept(nil, source, batchFilter, sortcols, sortdirs, 0, offset, limit,
+		[]string{"id"}, mapFn, reduceFn, scm.NewNil(), false, scm.NewNil())
+	return got
+}
+
+func TestScanOrderBatchAcceptDoublesDisjointOrderedBatches(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptordered", 20)
+	_, ascending := integerOrder(false)
+	batchSizes := make([]int64, 0)
+	got := runBatchAcceptIDs(table, nil, recSetModuloFilter(&batchSizes, 4, 0),
+		[]scm.Scmer{scm.NewString("id")}, []func(...scm.Scmer) scm.Scmer{ascending}, 2, 3)
+
+	want := []int64{8, 12, 16}
+	if !equalInt64s(got, want) {
+		t.Fatalf("accepted ordered rows = %v, want %v", got, want)
+	}
+	wantBatchSizes := []int64{5, 10, 5}
+	if !equalInt64s(batchSizes, wantBatchSizes) {
+		t.Fatalf("batch sizes = %v, want disjoint growing windows %v", batchSizes, wantBatchSizes)
+	}
+}
+
+func TestScanOrderBatchAcceptSupportsRecSetInput(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptrecset", 20)
+	even := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(scm.ToInt(values[0])%2 == 0)
+	})
+	input := table.scanRecSet(nil, []string{"id"}, even)
+	_, descending := integerOrder(true)
+	batchSizes := make([]int64, 0)
+	got := runBatchAcceptIDs(table, input, recSetModuloFilter(&batchSizes, 4, 0),
+		[]scm.Scmer{scm.NewString("id")}, []func(...scm.Scmer) scm.Scmer{descending}, 0, 2)
+
+	want := []int64{16, 12}
+	if !equalInt64s(got, want) {
+		t.Fatalf("accepted RecSet rows = %v, want %v", got, want)
+	}
+	if wantSizes := []int64{2, 4}; !equalInt64s(batchSizes, wantSizes) {
+		t.Fatalf("RecSet batch sizes = %v, want %v", batchSizes, wantSizes)
+	}
+}
+
+func TestScanOrderBatchAcceptGreedyWithoutOrder(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptgreedy", 12)
+	batchSizes := make([]int64, 0)
+	got := runBatchAcceptIDs(table, nil, recSetModuloFilter(&batchSizes, 2, 1), nil, nil, 0, 3)
+
+	want := []int64{1, 3, 5}
+	if !equalInt64s(got, want) {
+		t.Fatalf("greedy accepted rows = %v, want %v", got, want)
+	}
+	if wantSizes := []int64{3, 6}; !equalInt64s(batchSizes, wantSizes) {
+		t.Fatalf("greedy batch sizes = %v, want %v", batchSizes, wantSizes)
+	}
+}
+
+func TestScanOrderBatchAcceptMixedOrderAcrossShards(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptshards", 30)
+	RebuildTable(table, true, false)
+	if !table.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	table.repartition([]shardDimension{table.NewShardDimension("id", 3)})
+	if len(table.ActiveShards()) < 2 {
+		t.Fatalf("repartition produced %d shard(s), want at least 2", len(table.ActiveShards()))
+	}
+	_, ascending := integerOrder(false)
+	_, descending := integerOrder(true)
+	batchSizes := make([]int64, 0)
+	got := runBatchAcceptIDs(table, nil, recSetModuloFilter(&batchSizes, 2, 0),
+		[]scm.Scmer{scm.NewString("grp"), scm.NewString("id")},
+		[]func(...scm.Scmer) scm.Scmer{ascending, descending}, 1, 7)
+
+	want := []int64{18, 12, 6, 0, 28, 22, 16}
+	if !equalInt64s(got, want) {
+		t.Fatalf("mixed-order multishard rows = %v, want %v", got, want)
+	}
+}
+
+func TestScanOrderBatchAcceptRejectsNonSubset(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptsubset", 10)
+	allRows := table.scanRecSet(nil, nil, scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) }))
+	badFilter := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return NewRecSetScmer(allRows) })
+	_, ascending := integerOrder(false)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("non-subset batch filter result did not panic")
+		}
+	}()
+	runBatchAcceptIDs(table, nil, badFilter, []scm.Scmer{scm.NewString("id")},
+		[]func(...scm.Scmer) scm.Scmer{ascending}, 0, 2)
+}
+
+func TestScanOrderBatchAcceptDeclarationSignature(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptdeclare", 6)
+	identityFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+	relation, _ := integerOrder(true)
+	got := make([]int64, 0, 2)
+	mapFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		got = append(got, int64(scm.ToInt(values[0])))
+		return values[0]
+	})
+	reduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })
+
+	scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_order_batch_accept")],
+		scm.NewNil(),
+		NewTableScmer(table),
+		identityFilter,
+		scm.NewSlice([]scm.Scmer{scm.NewString("id")}),
+		scm.NewSlice([]scm.Scmer{relation}),
+		scm.NewInt(0),
+		scm.NewInt(1),
+		scm.NewInt(2),
+		scm.NewSlice([]scm.Scmer{scm.NewString("id")}),
+		mapFn,
+		reduceFn,
+		scm.NewNil(),
+	)
+
+	if want := []int64{4, 3}; !equalInt64s(got, want) {
+		t.Fatalf("declared operator rows = %v, want %v", got, want)
+	}
+}
+
+func equalInt64s(a []int64, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type countingColumnReader struct {
+	values     []scm.Scmer
+	singleRead int
+	multiRead  int
+}
+
+func (r *countingColumnReader) GetValue(recid uint32) scm.Scmer {
+	r.singleRead++
+	return r.values[recid]
+}
+
+func (r *countingColumnReader) GetValueMulti(recids []uint32, target []scm.Scmer, stride int) {
+	r.multiRead++
+	for i, recid := range recids {
+		target[i*stride] = r.values[recid]
+	}
+}
+
+func (r *countingColumnReader) GetValueRange(recid uint32, count uint32, target []scm.Scmer, stride int) {
+	for i := uint32(0); i < count; i++ {
+		target[int(i)*stride] = r.values[recid+i]
+	}
+}
+
+func TestShardMapReducerBulkReadsFinalMapColumns(t *testing.T) {
+	first := &countingColumnReader{values: []scm.Scmer{
+		scm.NewInt(10), scm.NewInt(20), scm.NewInt(30), scm.NewInt(40),
+	}}
+	second := &countingColumnReader{values: []scm.Scmer{
+		scm.NewInt(1), scm.NewInt(2), scm.NewInt(3), scm.NewInt(4),
+	}}
+	got := make([]int64, 0, 3)
+	mapper := &ShardMapReducer{
+		mainGetters: []mapArgGetter{
+			func(id uint32, _ uint32) scm.Scmer { return first.GetValue(id) },
+			func(id uint32, _ uint32) scm.Scmer { return second.GetValue(id) },
+			func(id uint32, _ uint32) scm.Scmer { return scm.NewInt(int64(id * 100)) },
+		},
+		mainBulkReaders: []ColumnReader{first, second, nil},
+		args:            make([]scm.Scmer, 3),
+		reduceArgs:      make([]scm.Scmer, 2),
+		mapFn: func(values ...scm.Scmer) scm.Scmer {
+			got = append(got, int64(scm.ToInt(values[0])+scm.ToInt(values[1])+scm.ToInt(values[2])))
+			return values[0]
+		},
+		reduceFn:  func(values ...scm.Scmer) scm.Scmer { return values[1] },
+		mainCount: 4,
+	}
+	mapper.Stream(scm.NewNil(), []uint32{3, 1, 2}, nil)
+
+	if first.multiRead != 1 || first.singleRead != 0 || second.multiRead != 1 || second.singleRead != 0 {
+		t.Fatalf("map reads: first=(multi=%d single=%d) second=(multi=%d single=%d), want one multi and no singles each",
+			first.multiRead, first.singleRead, second.multiRead, second.singleRead)
+	}
+	if want := []int64{344, 122, 233}; !equalInt64s(got, want) {
+		t.Fatalf("mapped values = %v, want %v", got, want)
+	}
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1515,6 +1515,8 @@ type ShardMapReducer struct {
 	mainGetters     []mapArgGetter
 	deltaGetters    []mapArgGetter
 	mainCols        []ColumnStorage        // direct main storage access (nil for $update/$invalidate/$increment cols)
+	mainBulkReaders []ColumnReader         // physical map columns gathered once per Stream main-record run
+	mainBulkValues  []scm.Scmer            // reusable row-major buffer for every physical map column
 	colNames        []string               // column names for delta getDelta access
 	isUpdate        []bool                 // true for $update columns
 	isInvalidate    []bool                 // true for $invalidate: columns
@@ -1577,6 +1579,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		mainGetters:      make([]mapArgGetter, len(cols)),
 		deltaGetters:     make([]mapArgGetter, len(cols)),
 		mainCols:         make([]ColumnStorage, len(cols)),
+		mainBulkReaders:  make([]ColumnReader, len(cols)),
 		colNames:         cols,
 		args:             make([]scm.Scmer, len(cols)),
 		reduceArgs:       make([]scm.Scmer, 2),
@@ -1806,6 +1809,7 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		}
 		mainCol := mr.mainCols[i]
 		mainReader := newCachedColumnReaderTx(mainCol, mr.currentTx)
+		mr.mainBulkReaders[i] = mainReader
 		colName := mr.colNames[i]
 		mr.mainGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
 			return mainReader.GetValue(id)
@@ -1827,6 +1831,36 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		}
 	}
 	return mr
+}
+
+func (m *ShardMapReducer) prefetchMainColumns(recids []uint32) {
+	width := len(m.mainBulkReaders)
+	if width == 0 {
+		return
+	}
+	hasReader := false
+	for _, reader := range m.mainBulkReaders {
+		if reader != nil {
+			hasReader = true
+			break
+		}
+	}
+	if !hasReader {
+		m.mainBulkValues = m.mainBulkValues[:0]
+		return
+	}
+	needed := len(recids) * width
+	if cap(m.mainBulkValues) < needed {
+		m.mainBulkValues = make([]scm.Scmer, needed)
+	} else {
+		m.mainBulkValues = m.mainBulkValues[:needed]
+	}
+	for i, reader := range m.mainBulkReaders {
+		if reader == nil {
+			continue
+		}
+		reader.GetValueMulti(recids, m.mainBulkValues[i:], width)
+	}
 }
 
 func withTxSession(currentTx *TxContext, fn func() scm.Scmer) scm.Scmer {
@@ -1885,7 +1919,12 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 	// not for the whole batch. This allows nested read scans (e.g. EXISTS
 	// inside UPDATE on the same table) to acquire RLock between rows.
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
-	for _, id := range recids {
+	if !needsPerRowLock && !m.hasUpdateCol && !m.hasIncrementCol && !m.hasSetCol {
+		m.prefetchMainColumns(recids)
+	}
+	bulkWidth := len(m.mainBulkReaders)
+	hasBulkValues := bulkWidth > 0 && len(m.mainBulkValues) == len(recids)*bulkWidth
+	for rowIndex, id := range recids {
 		func() {
 			effectiveID := id
 			rowLocked := false
@@ -1913,7 +1952,11 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 				}
 			}
 			for i, getter := range m.mainGetters {
-				m.args[i] = getter(effectiveID, 0)
+				if hasBulkValues && m.mainBulkReaders[i] != nil {
+					m.args[i] = m.mainBulkValues[rowIndex*bulkWidth+i]
+				} else {
+					m.args[i] = getter(effectiveID, 0)
+				}
 			}
 			// Release write lock before mapFn: allows nested scans on same shard.
 			// $update closures will re-acquire the lock when called.
@@ -1930,6 +1973,11 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 
 func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
+	if !needsPerRowLock && !m.hasUpdateCol && !m.hasIncrementCol && !m.hasSetCol {
+		m.prefetchMainColumns(recids)
+	}
+	bulkWidth := len(m.mainBulkReaders)
+	hasBulkValues := bulkWidth > 0 && len(m.mainBulkValues) == len(recids)*bulkWidth
 	for rowidx, id := range recids {
 		func() {
 			effectiveID := id
@@ -1958,7 +2006,11 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 				}
 			}
 			for i, getter := range m.mainGetters {
-				m.args[i] = getter(effectiveID, batchid)
+				if hasBulkValues && m.mainBulkReaders[i] != nil {
+					m.args[i] = m.mainBulkValues[rowidx*bulkWidth+i]
+				} else {
+					m.args[i] = getter(effectiveID, batchid)
+				}
 			}
 			if needsPerRowLock {
 				m.shard.exitWriteOwner()

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1090,6 +1090,68 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "scan_order_batch_accept",
+		Desc: "incrementally scans a table or existing RecSet in scan_order order and applies a RecSet batch filter before OFFSET/LIMIT and map/reduce. The first candidate RecSet contains offset+limit rows; if too few rows are accepted, subsequent disjoint batches contain twice as many candidates until the accepted limit is satisfied or the input is exhausted. batchFilter is called as (batchFilter input_recset) and must return an exact subset RecSet of the same base table and transaction. A simple batchFilter may call (scan_recset tx input_recset filterColumns realFilter); complex filters may project input_recset to another table, apply search/ACL scans and project the result back to the input table. The returned RecSet is used only as a membership mask against the already ordered candidate vector, so output order is preserved without scanning the unordered RecSet again. For non-unique ORDER BY values, include an explicit unique tie-breaker. sortcols/sortdirs may both be empty; that path greedily collects candidates without sorting. limitPartitionCols is present for scan_order signature compatibility and currently must be 0",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			currentTx := scmerToTxContext(a[0])
+			tableArg := a[1]
+			batchFilter := a[2]
+			sortcolsVals := mustScmerSlice(a[3], "sortcols")
+			sortdirsVals := mustScmerSlice(a[4], "sortdirs")
+			sortdirs := make([]func(...scm.Scmer) scm.Scmer, len(sortdirsVals))
+			for i, dir := range sortdirsVals {
+				sortdirs[i] = scm.OptimizeProcToSerialFunction(dir)
+			}
+			limitPartitionCols := scm.ToInt(a[5])
+			offset := scm.ToInt(a[6])
+			limit := scm.ToInt(a[7])
+			mapcols := scmerSliceToStrings(mustScmerSlice(a[8], "mapColumns"))
+			callback := a[9]
+			aggregate := scm.NewNil()
+			if len(a) > 10 {
+				aggregate = a[10]
+			}
+			neutral := scm.NewNil()
+			if len(a) > 11 {
+				neutral = a[11]
+			}
+			isOuter := len(a) > 12 && scm.ToBool(a[12])
+			notFoundValue := neutral
+			if len(a) > 13 {
+				notFoundValue = a[13]
+			}
+			source := scanOrderTableSpec{}
+			if tableArg.IsCustom(TagRecSet) {
+				source.recset = RecSetFromScmer(tableArg)
+			} else {
+				source.table = TableFromScmer(tableArg)
+			}
+			return scanOrderBatchAccept(currentTx, source, batchFilter, sortcolsVals, sortdirs,
+				limitPartitionCols, offset, limit, mapcols, callback, aggregate, neutral, isOuter, notFoundValue)
+		},
+		Type: &scm.TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context used consistently by the candidate scan and every batch filter operation; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|recset", ParamName: "table_or_recset", ParamDesc: "base table or complete existing query-local RecSet from which ordered candidate batches are drawn"},
+				{Kind: "func", ParamName: "batchFilter", ParamDesc: "function (lambda (input_recset) accepted_recset). It may naively narrow input_recset with scan_recset, or run arbitrary RecSet projections/search/ACL operations and project back. It must return a same-table, same-transaction subset of input_recset", Params: []*scm.TypeDescriptor{{Kind: "recset", ParamName: "input_recset"}}, Return: &scm.TypeDescriptor{Kind: "recset"}},
+				{Kind: "list", ParamName: "sortcols", ParamDesc: "same as scan_order: columns or computed sort functions. Include a unique tie-breaker for a total repeatable order; use an empty list for greedy unsorted collection"},
+				{Kind: "list", ParamName: "sortdirs", ParamDesc: "same as scan_order: one relation per sort column (<, > or collate relation); must also be empty when sortcols is empty"},
+				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "reserved for scan_order signature compatibility; currently must be 0"},
+				{Kind: "number", ParamName: "offset", ParamDesc: "number of batch-filter-accepted rows to skip; it is not the number of driver candidates already examined"},
+				{Kind: "number", ParamName: "limit", ParamDesc: "finite maximum number of accepted rows passed to map; the initial candidate batch size is offset+limit and doubles for every subsequent batch"},
+				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanOrderMapColumnsDesc},
+				{Kind: "func", ParamName: "map", ParamDesc: "same map callback contract as scan_order; accepted record IDs are passed to its shard mapper in batches", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", ParamName: "reduce", ParamDesc: "optional serial reducer over mapped accepted rows, with the same accumulator contract as scan_order", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "acc"}, {Kind: "any", ParamName: "val"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "any", ParamName: "neutral", ParamDesc: "optional neutral element for reduce; defaults to nil", Optional: true},
+				{Kind: "bool", ParamName: "isOuter", ParamDesc: "optional scan_order-compatible outer behavior: map one NULL row when no accepted row reaches map", Optional: true},
+				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "optional result when no accepted row reaches map and isOuter is false; defaults to neutral", Optional: true},
+			},
+			Return:   &scm.TypeDescriptor{Kind: "any"},
+			Optimize: optimizeScanOrderBatchAccept,
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_order",
 		Desc: "does an ordered parallel filter and serial map-reduce pass on a single table and returns the reduced result",
 		Fn: func(a ...scm.Scmer) scm.Scmer {


### PR DESCRIPTION
## Summary

Adds the Go-side `scan_order_batch_accept` storage operator without changing `lib/queryplan.scm`. The operator pulls an ordered candidate RecSet of `offset + limit` rows, calls a query-provided `RecSet -> RecSet` batch filter, and doubles each following disjoint candidate window until enough accepted rows have been collected or the input is exhausted.

Key properties:

- accepts a table or a complete input RecSet
- preserves the caller transaction and cancellation generation
- validates that every filter result belongs to the same table/transaction and is an exact subset of its input batch
- keeps the ordered candidate vector authoritative, using the returned RecSet only as a membership mask; no second result sort is necessary
- supports ASC/DESC, mixed directions, deterministic physical ties, multiple shards, accepted-row OFFSET/LIMIT, and an empty ORDER list for greedy collection
- leaves normal RecSet membership semantics unchanged
- preserves `mapColumns`/`map`/`reduce`/`neutral` and outer/not-found behavior
- uses `GetValueRange` while scanning RecSet runs and `GetValueMulti` for final accepted-row materialization

The `scm.Declare` documentation includes both the simple `scan_recset(input_recset, ...)` usage and the document -> file -> search/ACL -> document projection pattern. Planner lowering and costing are intentionally deferred.

## Benchmark

Command:

```text
go test ./storage -run ^$ -bench ^BenchmarkScanOrderBatchAcceptMillion$ -benchtime=5x -count=3
```

Environment: AMD Ryzen 9 7900X3D, linux/amd64, Go 1.24.0. The fixture contains 1,000,000 documents and 65,536 files, uses `ORDER BY id` with a unique key, a warm order-covering adaptive index, and `LIMIT 72`. Values below are the median of three benchmark runs, each with five timed iterations. Index construction and fixture construction are outside the timer.

| Scenario | `scan_order` | `scan_order_batch_accept` | Speedup | Allocated/op |
|---|---:|---:|---:|---:|
| simple column filter, 50% | 99.521 ms | 0.176 ms | 566.5x | 46.26 MB -> 0.177 MB |
| simple column filter, 1% | 109.754 ms | 2.121 ms | 51.7x | 46.26 MB -> 1.929 MB |
| ACL projection, 50% | 136.730 ms | 50.851 ms | 2.69x | 46.36 MB -> 0.763 MB |
| ACL projection, 1% | 206.557 ms | 153.361 ms | 1.35x | 52.02 MB -> 5.459 MB |

The simple baseline models the current per-item braking path with a post-order one-column predicate. The ACL baseline performs an individual subscan of the allowed-file RecSet for each ordered document. The batch variant projects candidate documents to files, intersects ACL membership, projects accepted files back to documents, and intersects with the input batch.

The sparse ACL result is the useful lower bound: adaptive candidate collection avoids the million-row ordered materialization, but repeated forward/reverse projection dominates and limits the gain to 1.35x. It is still 153 ms at the storage-operator level, comfortably inside the 3 s target, but it shows that planner costing and cheaper reverse-projection shapes remain important.

A separate A/B run of the final mapper bulk-read change over 65,536 rows improved one mapped column from about 1.286 ms to 0.947 ms (1.36x) and 16 columns from 9.453 ms to 4.238 ms (2.23x). The reusable row-major buffer trades some bytes/op for fewer virtual getter calls and better column locality.

## Cost-model limitation

This implementation reuses `scan_order` through successively larger prefix windows; it is not a persistent keyset cursor. With an active order-covering index, geometric batch growth keeps examined-prefix work bounded. Without such an index, every round can rescan and re-sort the source. The future planner integration must therefore cost index coverage, expected filter selectivity, projection cost, and the ordinary `scan_order` alternative before selecting this operator. Empty ORDER lists take the greedy early-stop path and do not sort.

## Tests

- ordered disjoint doubling and accepted-row OFFSET/LIMIT
- table and input-RecSet sources
- ASC, DESC, mixed direction, duplicate order values plus unique tie-breaker
- multi-shard merge and empty-order greedy mode
- rejection of non-subset filter output
- public declaration signature
- final map columns use one `GetValueMulti` call per physical column
- targeted tests and race tests pass
- complete pre-commit suite passes

Benchmark implementation is checked in as `BenchmarkScanOrderBatchAcceptMillion` for reproduction.