### PR TITLE
Lower ordered membership filters with adaptive batches

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -3000,6 +3000,14 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 					(and (order_items_belong_to_source? (car base_sources) (qb_order block))
 						(expr_contains_broad_text_match? condition))))))))
 
+(define ordered_batch_stage_supported? (lambda (stage)
+	(begin
+		(define input (gs_input stage))
+		(if (union_block? input)
+			(reduce (union_branches input) (lambda (supported branch)
+				(and supported (not (nil? (recset_project_join_branch_parts branch))))) true)
+			(not (nil? (membership_keyset_descriptor (list stage nil "__target" nil))))))))
+
 (define membership_truth_projection_preferred? (lambda (block stage _guarded_alternative)
 	(begin
 		(define input (gs_input stage))
@@ -3049,90 +3057,107 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 												(and (number? candidate_total_rows)
 													(>= (* candidate_rows 4) candidate_total_rows)))))))))
 					false))
-				/* The rewrite target depends on the surrounding shape: below a
-				broad ordered OR it is the lazy driver marker used to build one
-				source-key index; otherwise it is the projected candidate RecSet. */
-				(define projected_choice (if broad_text_driver
-					"driver_order_membership_probe"
-					"candidate_keyset"))
-				(define decision_id (concat "membership_carrier:" (gs_id stage)))
-				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
-				(define normal_choice (if broad_driver
-					"driver_order_membership_probe"
-					(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows stage_facts)
-						"candidate_keyset"
-						"driver_order_membership_probe")))
-				(define normal_projection (equal? normal_choice projected_choice))
-				(define chosen_choice (planner_physical_choice decision_id normal_choice alternatives))
-				(define chosen_projection (equal? chosen_choice projected_choice))
-				(define forced_choice (planner_physical_override decision_id))
-				(define candidate_cost (if (number? candidate_rows)
-					(membership_projection_cost candidate_total_rows candidate_rows driver_rows stage_facts)
-					nil))
-				(define driver_cost (if (number? driver_rows)
-					(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows stage_facts)
-					nil))
-				(planner_record_physical_decision
-					(list
-						(list "decision_id" decision_id)
-						(list "decision" "membership_carrier")
-						(list "decision_site" "truth_projection")
-						(list "stage" (gs_id stage))
-						(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
-						(list "chosen" chosen_choice)
-						(list "selection" (if (nil? forced_choice) (if broad_driver "constraint" "cost") "forced"))
-						(list "normally_chosen" normal_choice)
-						(list "reason" (if (not (nil? forced_choice)) "calibration_override"
-							(if guarded_small_driver "guarded_small_local_driver"
-								(if broad_driver "guarded_broad_order_limit_driver"
-									(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))))
-						(list "inputs" (list
-							(list "candidate_input_rows" candidate_total_rows)
-							(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
-							(list "candidate_rows" candidate_rows)
-							(list "candidate_density" (membership_candidate_density
-								candidate_total_rows candidate_rows stage_facts))
-							(list "projected_driver_rows"
-								(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows stage_facts))
-							(list "driver_input_rows" driver_total_rows)
-							(list "driver_rows" driver_rows)
-							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
-								candidate_total_rows candidate_rows driver_rows stage_facts))
-							(list "limit" (qb_limit block))
-							(list "offset" (coalesceNil (qb_offset block) 0))
-							(list "estimate_capped" capped)
-							(list "estimate_sampled_rows" (qassoc_get candidate_estimate (quote sampled) nil))
-							(list "estimate_population" (string (planner_estimate_population candidate_estimate)))
-							(list "estimate_coverage" (string (planner_estimate_coverage candidate_estimate)))
-							(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get stage_facts (quote selectivity_class) (quote unknown)))))
-							(list "candidate_scan_invocations" (qassoc_get stage_facts (quote membership_candidate_scan_invocations) 1))
-							(list "candidate_filter_columns" (qassoc_get stage_facts (quote membership_candidate_filter_columns) 0))
-							(list "candidate_map_columns" (qassoc_get stage_facts (quote membership_candidate_map_columns) 1))
-							(list "candidate_cache_map_columns" (qassoc_get stage_facts (quote membership_candidate_cache_map_columns) 2))
-							(list "candidate_expression_operations" (qassoc_get stage_facts (quote membership_candidate_expression_operations) 0))
-							(list "candidate_expression_depth" (qassoc_get stage_facts (quote membership_candidate_expression_depth) 0))
-							(list "candidate_broad_text_match_rows" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_rows) 0))
-							(list "candidate_broad_text_match_bytes" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_bytes) 0))
-							(list "candidate_filter_value_rows" (qassoc_get stage_facts (quote membership_candidate_filter_value_rows) nil))
-							(list "candidate_expression_operation_rows" (qassoc_get stage_facts (quote membership_candidate_expression_operation_rows) nil))
-							(list "driver_scan_invocations" (qassoc_get stage_facts (quote membership_driver_scan_invocations) 1))
-							(list "driver_filter_columns" (qassoc_get stage_facts (quote membership_driver_filter_columns) 0))
-							(list "driver_map_columns" (qassoc_get stage_facts (quote membership_driver_map_columns) 0))
-							(list "driver_expression_operations" (qassoc_get stage_facts (quote membership_driver_expression_operations) 0))
-							(list "driver_expression_depth" (qassoc_get stage_facts (quote membership_driver_expression_depth) 0))
-							(list "reuse" (qassoc_get stage_facts (quote reuse) 1))))
-						(list "alternatives" (list
+				(define batch_shape_supported (and
+					(query_limit_active? (qb_offset block) (qb_limit block))
+					(and (order_items_belong_to_source? driver (qb_order block))
+						(not (membership_expr_has_driver_alternative? (qb_where block))))))
+				/* Avoid rediscovering the membership subtree on the overwhelmingly
+				common unbounded path. This preparation is only useful to the bounded
+				ordered consumer that can emit the batch operator. */
+				(define batch_membership (if batch_shape_supported
+					(driver_membership_for_source driver (qb_where block)) nil))
+				(define batch_supported (and (not (nil? batch_membership))
+					(and (equal? (gs_id (nth batch_membership 0)) (gs_id stage))
+						(ordered_batch_stage_supported? stage))))
+				/* Batch eligibility only preserves the abstract membership marker.
+				The consuming tree edge below owns the single three-way physical
+				decision once its driver cardinality is known. */
+				(if batch_supported
+					true
+					(begin
+						/* The rewrite target depends on the surrounding shape: below a
+						broad ordered OR it is the lazy driver marker used to build one
+						source-key index; otherwise it is the projected candidate RecSet. */
+						(define projected_choice (if broad_text_driver
+							"driver_order_membership_probe"
+							"candidate_keyset"))
+						(define decision_id (concat "membership_carrier:" (gs_id stage)))
+						(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
+						(define normal_choice (if broad_driver
+							"driver_order_membership_probe"
+							(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows stage_facts)
+								"candidate_keyset"
+								"driver_order_membership_probe")))
+						(define forced_choice (planner_physical_override decision_id))
+						(define candidate_cost (if (number? candidate_rows)
+							(membership_projection_cost candidate_total_rows candidate_rows driver_rows stage_facts)
+							nil))
+						(define driver_cost (if (number? driver_rows)
+							(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows stage_facts)
+							nil))
+						(define chosen_choice (planner_physical_choice decision_id normal_choice alternatives))
+						(define chosen_projection (equal? chosen_choice projected_choice))
+						(planner_record_physical_decision
 							(list
-								(list "plan" "candidate_keyset")
-								(list "status" (if (equal? chosen_choice "candidate_keyset") "chosen" "rejected"))
-								(list "reason" (if (equal? chosen_choice "candidate_keyset") "selected" "higher_total_ns_or_forced_alternative"))
-								(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
-							(list
-								(list "plan" "driver_order_membership_probe")
-								(list "status" (if (equal? chosen_choice "driver_order_membership_probe") "chosen" "rejected"))
-								(list "reason" (if (equal? chosen_choice "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
-								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
-				chosen_projection)))))
+								(list "decision_id" decision_id)
+								(list "decision" "membership_carrier")
+								(list "decision_site" "truth_projection")
+								(list "stage" (gs_id stage))
+								(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
+								(list "chosen" chosen_choice)
+								(list "selection" (if (nil? forced_choice) (if broad_driver "constraint" "cost") "forced"))
+								(list "normally_chosen" normal_choice)
+								(list "reason" (if (not (nil? forced_choice)) "calibration_override"
+									(if guarded_small_driver "guarded_small_local_driver"
+										(if broad_driver "guarded_broad_order_limit_driver"
+											(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))))
+								(list "inputs" (list
+									(list "candidate_input_rows" candidate_total_rows)
+									(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
+									(list "candidate_rows" candidate_rows)
+									(list "candidate_density" (membership_candidate_density
+										candidate_total_rows candidate_rows stage_facts))
+									(list "projected_driver_rows"
+										(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows stage_facts))
+									(list "driver_input_rows" driver_total_rows)
+									(list "driver_rows" driver_rows)
+									(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
+										candidate_total_rows candidate_rows driver_rows stage_facts))
+									(list "limit" (qb_limit block))
+									(list "offset" (coalesceNil (qb_offset block) 0))
+									(list "estimate_capped" capped)
+									(list "estimate_sampled_rows" (qassoc_get candidate_estimate (quote sampled) nil))
+									(list "estimate_population" (string (planner_estimate_population candidate_estimate)))
+									(list "estimate_coverage" (string (planner_estimate_coverage candidate_estimate)))
+									(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get stage_facts (quote selectivity_class) (quote unknown)))))
+									(list "candidate_scan_invocations" (qassoc_get stage_facts (quote membership_candidate_scan_invocations) 1))
+									(list "candidate_filter_columns" (qassoc_get stage_facts (quote membership_candidate_filter_columns) 0))
+									(list "candidate_map_columns" (qassoc_get stage_facts (quote membership_candidate_map_columns) 1))
+									(list "candidate_cache_map_columns" (qassoc_get stage_facts (quote membership_candidate_cache_map_columns) 2))
+									(list "candidate_expression_operations" (qassoc_get stage_facts (quote membership_candidate_expression_operations) 0))
+									(list "candidate_expression_depth" (qassoc_get stage_facts (quote membership_candidate_expression_depth) 0))
+									(list "candidate_broad_text_match_rows" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_rows) 0))
+									(list "candidate_broad_text_match_bytes" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_bytes) 0))
+									(list "candidate_filter_value_rows" (qassoc_get stage_facts (quote membership_candidate_filter_value_rows) nil))
+									(list "candidate_expression_operation_rows" (qassoc_get stage_facts (quote membership_candidate_expression_operation_rows) nil))
+									(list "driver_scan_invocations" (qassoc_get stage_facts (quote membership_driver_scan_invocations) 1))
+									(list "driver_filter_columns" (qassoc_get stage_facts (quote membership_driver_filter_columns) 0))
+									(list "driver_map_columns" (qassoc_get stage_facts (quote membership_driver_map_columns) 0))
+									(list "driver_expression_operations" (qassoc_get stage_facts (quote membership_driver_expression_operations) 0))
+									(list "driver_expression_depth" (qassoc_get stage_facts (quote membership_driver_expression_depth) 0))
+									(list "reuse" (qassoc_get stage_facts (quote reuse) 1))))
+								(list "alternatives" (list
+									(list
+										(list "plan" "candidate_keyset")
+										(list "status" (if (equal? chosen_choice "candidate_keyset") "chosen" "rejected"))
+										(list "reason" (if (equal? chosen_choice "candidate_keyset") "selected" "higher_total_ns_or_forced_alternative"))
+										(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
+									(list
+										(list "plan" "driver_order_membership_probe")
+										(list "status" (if (equal? chosen_choice "driver_order_membership_probe") "chosen" "rejected"))
+										(list "reason" (if (equal? chosen_choice "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
+										(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
+						chosen_projection)))))))
 
 (define choose_membership_truth_items (lambda (block items guarded_alternative)
 	(match items

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2342,6 +2342,95 @@ here: their UNKNOWN rows are in neither SQL truth set. */
 				(quoted_runtime_list (list target_col))))
 		_ nil)))
 
+/* Build the exact, query-local membership subset for one ordered driver batch.
+The forward projection limits the candidate relation before its predicate is
+evaluated; the reverse projection returns matching keys to the driver table.
+The final intersection is required because a repeated driver key may project
+rows outside the current batch. */
+(define batch_membership_branch_expr (lambda (target_src branch target_col batch_expr)
+	(match (recset_project_join_branch_parts branch)
+		'(src source_col) (begin
+			(define alias (source_alias src))
+			(define condition (combine_where (qb_where branch) (source_join_expr src)))
+			(define filtercols (extract_columns_for_alias src condition))
+			(define source_candidates (list (quote recset_project_join)
+				'(session "__memcp_tx")
+				batch_expr
+				(quoted_runtime_list (list target_col))
+				(source_table_expr src)
+				(quoted_runtime_list (list source_col))))
+			(define source_matches (list (quote scan_recset)
+				'(session "__memcp_tx")
+				source_candidates
+				(cons (quote list) filtercols)
+				(list (quote lambda)
+					(map filtercols (lambda (col) (symbol (concat alias "." col))))
+					(lower_column_expr_for_alias src condition))))
+			(list (quote recset_intersect)
+				(cons (quote list) (list
+					batch_expr
+					(list (quote recset_project_join)
+						'(session "__memcp_tx")
+						source_matches
+						(quoted_runtime_list (list source_col))
+						(source_table_expr target_src)
+						(quoted_runtime_list (list target_col)))))))
+		_ nil)))
+
+(define batch_membership_base_expr (lambda (target_src stage target_col batch_expr)
+	(begin
+		(define descriptor (membership_keyset_descriptor (list stage nil target_col nil)))
+		(if (nil? descriptor)
+			nil
+			(begin
+				(define src (nth descriptor 0))
+				(define source_col (nth descriptor 1))
+				(define condition (nth descriptor 2))
+				(define alias (source_alias src))
+				(define filtercols (extract_columns_for_alias src condition))
+				(define source_candidates (list (quote recset_project_join)
+					'(session "__memcp_tx")
+					batch_expr
+					(quoted_runtime_list (list target_col))
+					(source_table_expr src)
+					(quoted_runtime_list (list source_col))))
+				(define source_matches (list (quote scan_recset)
+					'(session "__memcp_tx")
+					source_candidates
+					(cons (quote list) filtercols)
+					(list (quote lambda)
+						(map filtercols (lambda (col) (symbol (concat alias "." col))))
+						(lower_column_expr_for_alias src condition))))
+				(list (quote recset_intersect)
+					(cons (quote list) (list
+						batch_expr
+						(list (quote recset_project_join)
+							'(session "__memcp_tx")
+							source_matches
+							(quoted_runtime_list (list source_col))
+							(source_table_expr target_src)
+							(quoted_runtime_list (list target_col)))))))))))
+
+(define batch_membership_expr (lambda (target_src membership batch_expr)
+	(begin
+		(define stage (nth membership 0))
+		(define target_col (nth membership 2))
+		(define input (gs_input stage))
+		(if (union_block? input)
+			(begin
+				(define branches (map (union_branches input) (lambda (branch)
+					(batch_membership_branch_expr target_src branch target_col batch_expr))))
+				(if (reduce branches (lambda (unsupported branch_expr)
+					(or unsupported (nil? branch_expr))) false)
+					nil
+					(list (quote recset_intersect)
+						(cons (quote list) (list
+							batch_expr
+							(if (single_source? branches)
+								(car branches)
+								(list (quote recset_union) (cons (quote list) branches))))))))
+			(batch_membership_base_expr target_src stage target_col batch_expr)))))
+
 /* A stage's own group-cache is keyed positionally by its gs_keys, named
 k0, k1, ... regardless of what those key expressions look like -- so the
 recset can be built by scanning the cache directly (already correctly
@@ -2461,7 +2550,7 @@ the auto-index chooses the concrete access path on both tables. */
 /* Cost one physical tree edge once and return (strategy RecSet-expression).
 Consumers decide whether that RecSet is their scan carrier or a membership
 filter; they must not reconstruct the choice from enclosing block facts. */
-(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override)
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define stage (nth membership 0))
 		/* Some late RecSet consumers are introduced after reorder telemetry was
@@ -2513,13 +2602,14 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(list (quote population) estimate_population)
 						(list (quote coverage) estimate_coverage))
 					candidate_input_rows candidate_input_rows))
+				(define source_rows (planner_source_row_count src))
 				/* Ordered LIMIT consumes only its local window before downstream
 				operators. Cost this edge with that workload instead of a global
 				driver cardinality; it is the relevant side of the plan inequality. */
 				(define driver_rows (coalesceNil driver_rows_override
 					(coalesceNil
 						(qassoc_get facts (quote membership_driver_rows) nil)
-						(planner_source_row_count src))))
+						source_rows)))
 				(define decision_id (concat "membership_carrier:" (gs_id stage)))
 				(define known (and (number? candidate_rows) (number? driver_rows)))
 				(define owns_requirement (qassoc_get facts (quote physical_membership_requirement) false))
@@ -2529,20 +2619,39 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				feasible carrier pair outside this semantic/Top-K constraint. */
 				(define guarded_broad_order_driver
 					(qassoc_get facts (quote guarded_broad_order_driver) false))
-				(define normal_choice (if guarded_broad_order_driver
+				(define candidate_cost (if known
+					(membership_projection_cost candidate_input_rows candidate_rows driver_rows cost_facts)
+					nil))
+				(define driver_cost (if known
+					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows cost_facts)
+					nil))
+				(define batch_cost_facts (if allow_ordered_batch
+					(merge (list
+						(list
+							(list (quote membership_candidate_input_rows) candidate_input_rows)
+							(list (quote membership_candidate_estimated_rows) candidate_rows)
+							(list (quote membership_driver_rows) driver_rows)
+							(list (quote membership_driver_input_rows) source_rows))
+						cost_facts)) nil))
+				(define batch_cost (if (and allow_ordered_batch known)
+					(ordered_batch_accept_cost batch_cost_facts)
+					nil))
+				(define base_choice (if guarded_broad_order_driver
 					"driver_order_membership_probe"
 					(if known
 						(if (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows cost_facts)
 							"candidate_keyset"
 							"driver_order_membership_probe")
 						(if owns_requirement "driver_order_membership_probe" "candidate_keyset"))))
-				(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
+				(define batch_wins (and (not (nil? batch_cost))
+					(and (planner_cost_better? batch_cost candidate_cost)
+						(planner_cost_better? batch_cost driver_cost))))
+				(define normal_choice (if batch_wins "ordered_batch_accept" base_choice))
+				(define alternatives (if allow_ordered_batch
+					(list "candidate_keyset" "driver_order_membership_probe" "ordered_batch_accept")
+					(list "candidate_keyset" "driver_order_membership_probe")))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
-				(define candidate_cost (if known (membership_projection_cost candidate_input_rows candidate_rows driver_rows cost_facts) nil))
-				(define driver_cost (if known
-					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows cost_facts)
-					nil))
 				(planner_record_physical_decision
 					(list
 						(list "decision_id" decision_id)
@@ -2555,10 +2664,11 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(list "selection" (if (nil? forced) (if known "cost" "fallback") "forced"))
 						(list "normally_chosen" normal_choice)
 						(list "reason" (if (not (nil? forced)) "calibration_override"
-							(if guarded_broad_order_driver "guarded_broad_order_limit_driver"
-								(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
-									(if owns_requirement "unknown_statistics_driver_fallback"
-										"unknown_statistics_projection_fallback")))))
+							(if batch_wins "batch_filter_implementation_lowest_total_ns"
+								(if guarded_broad_order_driver "guarded_broad_order_limit_driver"
+									(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
+										(if owns_requirement "unknown_statistics_driver_fallback"
+											"unknown_statistics_projection_fallback"))))))
 						(list "inputs" (list
 							(list "candidate_input_rows" candidate_input_rows)
 							(list "candidate_matching_rows" candidate_matching_rows)
@@ -2568,7 +2678,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							(list "projected_driver_rows"
 								(membership_projected_driver_rows candidate_input_rows candidate_rows
 									(membership_driver_input_rows driver_rows facts) facts))
-							(list "driver_input_rows" (planner_source_row_count src))
+							(list "driver_input_rows" source_rows)
 							(list "driver_rows" driver_rows)
 							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
 								candidate_input_rows candidate_rows driver_rows facts))
@@ -2599,7 +2709,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							(list "driver_expression_operations" (qassoc_get facts (quote membership_driver_expression_operations) 0))
 							(list "driver_expression_depth" (qassoc_get facts (quote membership_driver_expression_depth) 0))
 							(list "reuse" (qassoc_get facts (quote reuse) 1))))
-						(list "alternatives" (list
+						(list "alternatives" (filter (list
 							(list
 								(list "plan" "candidate_keyset")
 								(list "status" (if (equal? chosen "candidate_keyset") "chosen" "rejected"))
@@ -2609,21 +2719,28 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 								(list "plan" "driver_order_membership_probe")
 								(list "status" (if (equal? chosen "driver_order_membership_probe") "chosen" "rejected"))
 								(list "reason" (if (equal? chosen "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
-								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
+								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))
+							(if allow_ordered_batch
+								(list
+									(list "plan" "ordered_batch_accept")
+									(list "status" (if (equal? chosen "ordered_batch_accept") "chosen" "rejected"))
+									(list "reason" (if (equal? chosen "ordered_batch_accept") "selected" "higher_total_ns_or_forced_alternative"))
+									(list "cost" (if (nil? batch_cost) '() (planner_cost_explain batch_cost))))
+								nil)) (lambda (alternative) (not (nil? alternative)))))))
 				(list chosen raw_expr))))))
 
 /* General expression callers preserve the established contract: only a
 candidate-keyset choice replaces the marker with a projected RecSet carrier. */
-(define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override)
+(define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define plan (recset_project_join_plan_for_membership_using
-			src membership consumer driver_rows_override))
+			src membership consumer driver_rows_override allow_ordered_batch))
 		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 			(cadr plan)
 			nil))))
 
 (define recset_project_join_expr_for_membership (lambda (src membership)
-	(recset_project_join_expr_for_membership_using src membership nil nil)))
+	(recset_project_join_expr_for_membership_using src membership nil nil false)))
 
 (define lower_scalar_marker_expr (lambda (expr)
 	(match expr
@@ -4972,4 +5089,5 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_build_row_ns 11590)
 (define planner_membership_group_cache_probe_row_ns 132886)
 (define planner_membership_ordered_driver_input_row_ns 255)
+(define planner_ordered_batch_accept_startup_ns 1)
 /* END GENERATED COST CONSTANTS */

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2317,16 +2317,16 @@ scan boundary only when the complete predicate implies it. */
 						(replace_driver_membership_markers src item memberships))))
 					_ expr))))))
 
-(define membership_recset_bindings_using (lambda (src memberships consumer driver_rows_override)
+(define membership_recset_bindings_using (lambda (src memberships consumer driver_rows_override allow_ordered_batch)
 	(filter (map memberships (lambda (membership)
 		(begin
 			(define expr (recset_project_join_expr_for_membership_using
-				src membership consumer driver_rows_override))
+				src membership consumer driver_rows_override allow_ordered_batch))
 			(if (nil? expr) nil (list membership (membership_recset_var src membership) expr)))))
 		(lambda (binding) (not (nil? binding))))))
 
 (define membership_recset_bindings (lambda (src memberships)
-	(membership_recset_bindings_using src memberships nil nil)))
+	(membership_recset_bindings_using src memberships nil nil false)))
 
 (define wrap_membership_recset_bindings (lambda (bindings body)
 	(if (empty_list? bindings)
@@ -2555,6 +2555,120 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 					nil
 					(list (quote recset_union) (cons (quote list) candidates))))))))
 
+(define ordered_batch_membership_terms (lambda (src condition)
+	(filter (map (split_and_terms (coalesceNil condition true)) (lambda (term)
+		(begin
+			(define marker (driver_membership_probe_term term))
+			(if (nil? marker)
+				nil
+				(begin
+					(define target_col (direct_column_name_for_alias src (nth marker 1)))
+					(if (nil? target_col)
+						nil
+						(list (nth marker 0) (nth marker 1) target_col term)))))))
+		(lambda (membership) (not (nil? membership))))))
+
+(define ordered_batch_filter_expr (lambda (src condition memberships)
+	(begin
+		(define input_batch (symbol "__ordered_input_batch"))
+		(define local_batch (symbol "__ordered_local_batch"))
+		(define residual (reduce memberships (lambda (remaining membership)
+			(strip_driver_membership_for_source src remaining membership)) condition))
+		(define residual_cols (extract_columns_for_alias src residual))
+		(define locally_filtered (if (equal? residual true)
+			input_batch
+			(list (quote scan_recset)
+				'(session "__memcp_tx")
+				input_batch
+				(cons (quote list) residual_cols)
+				(list (quote lambda)
+					(map residual_cols (lambda (col)
+						(scan_callback_symbol_for_alias (source_alias src) col)))
+					(lower_column_expr_for_alias src residual)))))
+		(define membership_exprs (map memberships (lambda (membership)
+			(batch_membership_expr src membership local_batch))))
+		(if (reduce membership_exprs (lambda (unsupported expr)
+			(or unsupported (nil? expr))) false)
+			nil
+			(list (quote lambda) (list input_batch)
+				(list
+					(list (quote lambda) (list local_batch)
+						(if (empty_list? membership_exprs)
+							local_batch
+							(list (quote recset_intersect)
+								(cons (quote list) (cons local_batch membership_exprs)))))
+					locally_filtered))))))
+
+(define ordered_batch_count_estimate (lambda (first_batch visited_rows)
+	(if (or (not (number? first_batch)) (or (<= first_batch 0) (not (number? visited_rows))))
+		1
+		(if (<= visited_rows first_batch)
+			1
+			(+ 1 (ordered_batch_count_estimate (* first_batch 2) (- visited_rows first_batch)))))))
+
+(define ordered_batch_accept_cost (lambda (facts)
+	(begin
+		(define candidate_input_rows (qassoc_get facts (quote membership_candidate_input_rows) nil))
+		(define candidate_rows (membership_estimated_matching_rows
+			(list
+				(list (quote rows) (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
+				(list (quote input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
+				(list (quote sampled) (qassoc_get facts (quote membership_candidate_estimate_sampled) nil))
+				(list (quote capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
+				(list (quote population) (qassoc_get facts (quote membership_candidate_estimate_population) (quote table_rows)))
+				(list (quote coverage) (qassoc_get facts (quote membership_candidate_estimate_coverage) (quote sampled))))
+			candidate_input_rows candidate_input_rows))
+		(define driver_rows (qassoc_get facts (quote membership_driver_rows) nil))
+		(define driver_input_rows (membership_driver_input_rows driver_rows facts))
+		(define visited_rows (membership_expected_driver_rows_visited
+			candidate_input_rows candidate_rows driver_rows facts))
+		(define first_batch (+
+			(coalesceNil (qassoc_get facts (quote membership_order_offset) nil) 0)
+			(coalesceNil (qassoc_get facts (quote membership_order_limit) nil) 0)))
+		(define batches (ordered_batch_count_estimate first_batch visited_rows))
+		(define probe_branches (max 1
+			(qassoc_get facts (quote membership_candidate_probe_branches) 1)))
+		(define candidate_scan_invocations (max 1
+			(qassoc_get facts (quote membership_candidate_scan_invocations) probe_branches)))
+		(define driver_scan_invocations (max 1
+			(qassoc_get facts (quote membership_driver_scan_invocations) 1)))
+		(define candidate_fraction (if (and (number? driver_input_rows) (> driver_input_rows 0))
+			(min 1 (/ visited_rows driver_input_rows)) 1))
+		/* Disjoint driver batches may contain the same foreign-key value. In the
+		absence of key-frequency statistics, charge every batch for its projected
+		fraction instead of assuming candidate source rows are globally disjoint. */
+		(define candidate_repeat_fraction (min batches (* candidate_fraction batches)))
+		(define candidate_work_rows (* candidate_input_rows candidate_repeat_fraction))
+		(define candidate_match_rows (* candidate_rows candidate_repeat_fraction))
+		(define projection_rows (* probe_branches
+			(+ (* visited_rows 2) candidate_work_rows candidate_match_rows)))
+		(define broad_text_rows (*
+			(qassoc_get facts (quote membership_candidate_broad_text_match_rows) 0)
+			candidate_repeat_fraction))
+		(define broad_text_bytes (*
+			(qassoc_get facts (quote membership_candidate_broad_text_match_bytes) 0)
+			candidate_repeat_fraction))
+		(planner_cost
+			(+ planner_ordered_batch_accept_startup_ns
+				(* (+ driver_scan_invocations (* batches candidate_scan_invocations))
+					planner_membership_scan_invocation_ns))
+			(+
+				(* (+ visited_rows candidate_work_rows projection_rows)
+					planner_membership_scan_row_ns)
+				(* candidate_work_rows
+					(qassoc_get facts (quote membership_candidate_filter_columns) 0)
+					planner_membership_filter_column_row_ns)
+				(* candidate_work_rows
+					(qassoc_get facts (quote membership_candidate_expression_operations) 0)
+					planner_membership_expression_operation_row_ns)
+				(* broad_text_rows planner_membership_broad_text_match_row_ns)
+				(* broad_text_bytes planner_membership_broad_text_match_byte_ns))
+			0 0 0
+			(* projection_rows
+				planner_membership_recset_build_row_ns)
+			(* projection_rows 8)
+			0 visited_rows 0.55))))
+
 (define lower_single_source_query_block (lambda (block)
 	(begin
 		(define src (car (qb_sources block)))
@@ -2589,21 +2703,44 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 					'()))
 				(define use_membership_keysets (and keyset_membership_probe
 					(equal? (count membership_keysets) (count memberships))))
+				(define allow_ordered_batch_binding (and scan_order_supported
+					(and bounded
+						(and (equal? (count memberships) 1)
+							(and (not (membership_expr_has_driver_alternative? condition))
+								(and (or (empty_list? order_items)
+									(not (empty_list? (source_primary_key_columns src))))
+									(ordered_batch_stage_supported? (nth (car memberships) 0))))))))
 				(define forced_candidate_membership (reduce memberships (lambda (forced membership)
-					(or forced (equal?
-						(planner_physical_override (concat "membership_carrier:" (gs_id (nth membership 0))))
-						"candidate_keyset"))) false))
+					(begin
+						(define override (planner_physical_override
+							(concat "membership_carrier:" (gs_id (nth membership 0)))))
+						(or forced (or (equal? override "candidate_keyset")
+							(equal? override "ordered_batch_accept"))))) false))
 				(define prefer_membership_filter (and scan_order_supported
 					(and bounded
 						(and (not forced_candidate_membership)
 							(and (qassoc_get (qb_facts block) (quote membership_driver_alternative) false)
 								(membership_estimate_broad? (qb_facts block)))))))
-				(define membership_bindings (if (or keyset_membership_probe prefer_membership_filter)
+				(define membership_plans (if (or keyset_membership_probe prefer_membership_filter)
 					'()
-					(membership_recset_bindings_using src memberships
-						(if bounded (quote order_limit) (quote filter))
-						(if (and scan_order_supported bounded)
-							(probe_limit_work_rows (qb_limit block)) nil))))
+					(filter (map memberships (lambda (membership)
+						(begin
+							(define plan (recset_project_join_plan_for_membership_using
+								src membership
+								(if bounded (quote order_limit) (quote filter))
+								(if (and scan_order_supported bounded)
+									(probe_limit_work_rows (qb_limit block)) nil)
+								allow_ordered_batch_binding))
+							(if (nil? plan) nil (list membership plan)))))
+						(lambda (entry) (not (nil? entry))))))
+				(define membership_bindings (filter (map membership_plans (lambda (entry)
+					(begin
+						(define membership (nth entry 0))
+						(define plan (nth entry 1))
+						(if (equal? (car plan) "candidate_keyset")
+							(list membership (membership_recset_var src membership) (cadr plan))
+							nil))))
+					(lambda (binding) (not (nil? binding)))))
 				(define bound_memberships (map membership_bindings (lambda (binding) (nth binding 0))))
 				(define membership_formula (if keyset_membership_probe
 					nil
@@ -2662,6 +2799,15 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 				(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
 				(define ordercols (if (empty_list? order_items) '() (scan_order_sort_columns_for_alias src order_items)))
+				(define batch_tiebreaker_cols (if (empty_list? order_items)
+					'()
+					(filter (source_primary_key_columns src)
+						(lambda (col) (not (contains? ordercols col))))))
+				(define batch_ordercols (merge (list ordercols batch_tiebreaker_cols)))
+				(define batch_orderdirs (merge (list
+					(if (empty_list? order_items) '() (order_relations_for_source src order_items))
+					(map batch_tiebreaker_cols (lambda (col)
+						(canonical_order_relation < (source_column_order_collation src col)))))))
 				(define mapcols fieldcols)
 				(define membership_candidates (if membership_filter
 					(membership_or_candidate_recset src source_table condition membership_bindings)
@@ -2674,6 +2820,15 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 				(define filter_expr (list (quote lambda)
 					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 					(lower_column_expr_for_alias src filter_condition)))
+				(define remaining_memberships (driver_memberships_for_source src filter_condition))
+				(define remaining_batch_memberships (ordered_batch_membership_terms src filter_condition))
+				(define batch_filter (if (and (equal? table_expr source_table)
+					(equal? (count remaining_memberships) (count remaining_batch_memberships)))
+					(ordered_batch_filter_expr src filter_condition remaining_batch_memberships)
+					nil))
+				(define use_batch_accept (and (not (nil? batch_filter))
+					(reduce membership_plans (lambda (chosen entry)
+						(or chosen (equal? (car (nth entry 1)) "ordered_batch_accept"))) false)))
 				(define map_expr (list (quote lambda)
 					(map mapcols (lambda (col) (symbol (concat alias "." col))))
 					(list (quote resultrow)
@@ -2693,21 +2848,36 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 						(source_outer? src))
 					(if scan_order_supported
 						(begin
-							(define scan_expr (list (quote scan_order)
-								'(session "__memcp_tx")
-								table_expr
-								(cons (quote list) filtercols)
-								filter_expr
-								(cons (quote list) ordercols)
-								(cons (quote list) (if (empty_list? order_items) '() (order_relations_for_source src order_items)))
-								0
-								(coalesceNil (qb_offset block) 0)
-								(coalesceNil (qb_limit block) -1)
-								(cons (quote list) mapcols)
-								map_expr
-								nil
-								nil
-								(source_outer? src)))
+							(define scan_expr (if use_batch_accept
+								(list (quote scan_order_batch_accept)
+									'(session "__memcp_tx")
+									table_expr
+									batch_filter
+									(cons (quote list) batch_ordercols)
+									(cons (quote list) batch_orderdirs)
+									0
+									(coalesceNil (qb_offset block) 0)
+									(coalesceNil (qb_limit block) -1)
+									(cons (quote list) mapcols)
+									map_expr
+									nil
+									nil
+									(source_outer? src))
+								(list (quote scan_order)
+									'(session "__memcp_tx")
+									table_expr
+									(cons (quote list) filtercols)
+									filter_expr
+									(cons (quote list) ordercols)
+									(cons (quote list) (if (empty_list? order_items) '() (order_relations_for_source src order_items)))
+									0
+									(coalesceNil (qb_offset block) 0)
+									(coalesceNil (qb_limit block) -1)
+									(cons (quote list) mapcols)
+									map_expr
+									nil
+									nil
+									(source_outer? src))))
 							scan_expr)
 						(neumann_fail "build_queryplan" "single-source ORDER BY requires a storage carrier"))))
 				(if use_membership_keysets
@@ -2908,7 +3078,8 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 			(recset_project_join_plan_for_membership_using src membership
 				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
 				(if (query_limit_active? offset_value limit_value)
-					(probe_limit_work_rows limit_value) nil))))
+					(probe_limit_work_rows limit_value) nil)
+				false)))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
@@ -3238,7 +3409,12 @@ it does not recover parser spelling or leak a scan into logical IR. */
 						(list alias))))
 					best
 					(begin
-						(planner_record_session_value_guards term)
+						(reduce (query_expr_session_reads term) (lambda (_ expr)
+							(begin
+								(define value (planner_literal_value expr))
+								(planner_record_guard_condition
+									(list (quote equal?) expr
+										(if (list? value) (list (quote quote) value) value))))) nil)
 						(define estimate (planner_source_filter_estimate src term 512))
 						(define rows (membership_estimated_matching_rows estimate input_rows nil))
 						(define work (membership_source_work_profile src term true))
@@ -3410,7 +3586,8 @@ this lowering boundary. */
 					(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter)))
 				(if (and (not (empty_list? current_order_items))
 					(query_limit_active? offset_value limit_value))
-					(probe_limit_work_rows limit_value) nil))))
+					(probe_limit_work_rows limit_value) nil)
+				false)))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
@@ -5378,14 +5555,23 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		_ false)))
 
 (define physical_membership_operator_family (lambda (plan)
-	(if (physical_expr_has_head? plan (quote recset_project_join))
-		"candidate_keyset"
-		/* A forced membership variant reaches this function only after
-		require_physical_scan_relations has rejected every surviving logical
-		marker. Without a projected RecSet its emitted carrier is therefore the
-		driver-side probe family, independent of the concrete group-cache/index
-		primitive selected inside that family. */
-		"driver_order_membership_probe")))
+	(if (physical_expr_has_head? plan (quote scan_order_batch_accept))
+		"ordered_batch_accept"
+		(if (physical_expr_has_head? plan (quote recset_project_join))
+			"candidate_keyset"
+			/* A forced membership variant reaches this function only after
+			require_physical_scan_relations has rejected every surviving logical
+			marker. Without a projected RecSet its emitted carrier is therefore the
+			driver-side probe family, independent of the concrete group-cache/index
+			primitive selected inside that family. */
+			"driver_order_membership_probe"))))
+
+(define physical_operator_family_for_decision (lambda (plan decision)
+	(begin
+		(define kind (qassoc_get decision "decision" nil))
+		(if (equal? kind "membership_carrier")
+			(physical_membership_operator_family plan)
+			"unknown"))))
 
 /* recset_project_join is adaptive only inside the physical operator: actual
 source-key and per-shard target cardinalities are available there, while the
@@ -5453,11 +5639,10 @@ potentially large calibrated SELECT result. */
 (define physical_calibration_runtime_plan (lambda (plan decision variant estimated_ns operator_family suite_var)
 	(begin
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
-		(define expected_family (if (equal? (qassoc_get decision "decision" nil) "membership_carrier")
-			variant
-			operator_family))
-		(define consistent (or (not (equal? (qassoc_get decision "decision" nil) "membership_carrier"))
-			(equal? operator_family expected_family)))
+		(define decision_kind (qassoc_get decision "decision" nil))
+		(define expected_family (if (equal? decision_kind "membership_carrier")
+			variant operator_family))
+		(define consistent (equal? operator_family expected_family))
 		(define baseline_hash_key (concat "hash:" decision_id))
 		(define baseline_count_key (concat "count:" decision_id))
 		(define shared_suite (equal? suite_var (quote __physical_calibration_suite)))
@@ -5554,7 +5739,8 @@ potentially large calibrated SELECT result. */
 					variant_decision
 					variant
 					(qassoc_get variant_cost "total_ns" nil)
-					(nth compilation 2)
+					(physical_operator_family_for_decision
+						(nth compilation 0) variant_decision)
 					suite_var)))))))
 
 (define physical_decision_has_costed_alternatives? (lambda (decision)
@@ -5577,6 +5763,7 @@ potentially large calibrated SELECT result. */
 					(and (number? (qassoc_get inputs "candidate_rows" nil))
 						(and (number? (qassoc_get inputs "driver_input_rows" nil))
 							(number? (qassoc_get inputs "driver_rows" nil))))))))))
+
 
 (define explain_queryplan_physical_calibrate_discover (lambda (query)
 	(begin
@@ -5618,7 +5805,7 @@ potentially large calibrated SELECT result. */
 						decision
 						variant
 						(qassoc_get (qassoc_get alternative "cost" '()) "total_ns" nil)
-						(nth compilation 2)
+						(physical_operator_family_for_decision (nth compilation 0) decision)
 						suite_var)))))))
 
 (define explain_queryplan_physical_calibrate (lambda (query)

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -149,8 +149,12 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 	if len(sortcols) != len(sortdirs) {
 		panic("scan_order_batch_accept: sortcols and sortdirs must have equal length")
 	}
-	if source.recset != nil && currentTx == nil {
-		currentTx = source.recset.tx
+	if source.recset != nil {
+		if currentTx == nil {
+			currentTx = source.recset.tx
+		} else if currentTx != source.recset.tx {
+			panic("scan_order_batch_accept: input recset belongs to a different transaction")
+		}
 	}
 	if source.backingTable() == nil {
 		panic("scan_order_batch_accept: input must have a backing table")

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -158,6 +158,27 @@ func TestScanOrderBatchAcceptRejectsNonSubset(t *testing.T) {
 		[]func(...scm.Scmer) scm.Scmer{ascending}, 0, 2)
 }
 
+func TestScanOrderBatchAcceptRejectsInputFromDifferentTransaction(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptinputtx", 4)
+	inputTx := &TxContext{}
+	otherTx := &TxContext{}
+	input := table.scanRecSet(nil, nil,
+		scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) }))
+	input.tx = inputTx
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("input RecSet from another transaction did not panic")
+		}
+	}()
+	scanOrderBatchAccept(otherTx, scanOrderTableSpec{recset: input},
+		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		nil, nil, 0, 0, 1, []string{"id"},
+		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+		scm.NewNil(), false, scm.NewNil())
+}
+
 func TestScanOrderBatchAcceptDeclarationSignature(t *testing.T) {
 	table := setupBatchAcceptTable(t, "tbatchacceptdeclare", 6)
 	identityFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -329,6 +329,30 @@ test_cases:
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 
+  - name: "production-scale adaptive ordered batch filter"
+    physical_calibration: true
+    calibration_decision: "ordered_batch_accept"
+    calibration_holdout: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    expected_broad_text_bytes: 15000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
+        UNION
+        SELECT f.id FROM pc_files_text f
+        WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
+      )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
   - name: "wide-value broad text ordered membership"
     physical_calibration: true
     calibration_component: "broad_text_bytes"

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -331,7 +331,7 @@ test_cases:
 
   - name: "production-scale adaptive ordered batch filter"
     physical_calibration: true
-    calibration_decision: "ordered_batch_accept"
+    calibration_decision: "membership_carrier"
     calibration_holdout: true
     race: true
     race_grace: 0.5

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -744,6 +744,8 @@ test_cases:
       - sql: "DROP TABLE IF EXISTS in_dv_doc"
       - sql: "DROP TABLE IF EXISTS in_dv_file"
       - sql: "DROP TABLE IF EXISTS in_dv_acl"
+      - sql: "DROP TABLE IF EXISTS in_batch_doc"
+      - sql: "DROP TABLE IF EXISTS in_batch_file"
       - sql: |
           CREATE TABLE in_dv_file (
             ID INT PRIMARY KEY,
@@ -763,6 +765,8 @@ test_cases:
             tenant INT,
             allowed INT
           )
+      - sql: "CREATE TABLE in_batch_file (ID INT PRIMARY KEY, flag INT)"
+      - sql: "CREATE TABLE in_batch_doc (ID INT PRIMARY KEY, file_id INT, sort_key INT)"
       - sql: |
           INSERT INTO in_dv_file (ID, filename, search) VALUES
           (10, 'invoice-hit.pdf', 'other'),
@@ -785,6 +789,15 @@ test_cases:
           INSERT INTO in_dv_acl (ID, tenant, allowed) VALUES
           (1, 1, 1),
           (2, 2, 0)
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "in_batch_file") '("ID" "flag")
+              (map (produceN 8000) (lambda (i)
+                (list (+ i 1) 1))))
+            (insert (table "memcp-tests" "in_batch_doc") '("ID" "file_id" "sort_key")
+              (map (produceN 10000) (lambda (i)
+                (list (+ i 1) (if (< i 8000) (+ i 1) (- i 7999)) (- 10000 i)))))
+            true)
     steps:
       - sql: |
           SELECT d.ID
@@ -992,6 +1005,20 @@ test_cases:
       - sql: |
           EXPLAIN
           SELECT d.ID
+          FROM in_batch_doc d
+          WHERE d.file_id IN (
+            SELECT f.ID FROM in_batch_file f WHERE f.flag = 0
+            UNION
+            SELECT f.ID FROM in_batch_file f WHERE f.flag = 1
+          )
+          ORDER BY d.sort_key
+          LIMIT 5
+        expect:
+          contains:
+            - "scan_order_batch_accept"
+      - sql: |
+          EXPLAIN
+          SELECT d.ID
           FROM in_dv_doc d
           WHERE d.file_id IN (
             SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
@@ -1026,6 +1053,7 @@ test_cases:
             - "membership_carrier"
             - "candidate_keyset"
             - "driver_order_membership_probe"
+            - "ordered_batch_accept"
             - "recset_project_join"
             - "recset_union"
             - "scan_order"
@@ -1043,11 +1071,10 @@ test_cases:
           ORDER BY d.sort_key
           LIMIT 2
         expect:
-          rows: 2
+          rows: 1
           contains:
             - "membership_carrier"
             - "ordered_batch_accept"
-            - "scan_order_batch_accept"
       - sql: |
           EXPLAIN PHYSICAL CALIBRATE
           SELECT d.ID
@@ -1060,11 +1087,11 @@ test_cases:
           ORDER BY d.sort_key
           LIMIT 2 OFFSET 1
         expect:
-          rows: 4
+          rows: 3
           contains:
+            - "candidate_keyset"
+            - "driver_order_membership_probe"
             - "ordered_batch_accept"
-            - "scan_order"
-            - "scan_order_batch_accept"
             - "operator_consistent"
             - "result_equal"
           not_contains:

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1032,6 +1032,44 @@ test_cases:
             - "chosen"
             - "rejected"
       - sql: |
+          EXPLAIN PHYSICAL CALIBRATE DISCOVER
+          SELECT d.ID
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+          ORDER BY d.sort_key
+          LIMIT 2
+        expect:
+          rows: 2
+          contains:
+            - "membership_carrier"
+            - "ordered_batch_accept"
+            - "scan_order_batch_accept"
+      - sql: |
+          EXPLAIN PHYSICAL CALIBRATE
+          SELECT d.ID
+          FROM in_dv_doc d
+          WHERE d.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+          ORDER BY d.sort_key
+          LIMIT 2 OFFSET 1
+        expect:
+          rows: 4
+          contains:
+            - "ordered_batch_accept"
+            - "scan_order"
+            - "scan_order_batch_accept"
+            - "operator_consistent"
+            - "result_equal"
+          not_contains:
+            - "result_equal false"
+      - sql: |
           EXPLAIN
           SELECT t.ID
           FROM (

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -194,6 +194,7 @@ type constants struct {
 	groupCacheBuildRowNS  int64
 	groupCacheProbeRowNS  int64
 	orderedDriverInputNS  int64
+	orderedBatchStartupNS int64
 }
 
 func main() {
@@ -241,18 +242,9 @@ func main() {
 			fatal(err)
 		}
 	}
-	membershipObservations := make([]observation, 0, len(observations))
-	batchObservations := make([]observation, 0, len(observations))
-	for _, row := range observations {
-		switch row.decision {
-		case "membership_carrier":
-			membershipObservations = append(membershipObservations, row)
-		case "ordered_batch_accept":
-			batchObservations = append(batchObservations, row)
-		}
-	}
-	training := filterObservations(membershipObservations, false)
-	fitTraining := filterCompleteExactPairs(training)
+	training := filterObservations(observations, false)
+	carrierTraining := filterCarrierObservations(training)
+	fitTraining := filterCompleteExactPairs(carrierTraining)
 	if err := validateMeasurementSignal(fitTraining); err != nil {
 		fatal(err)
 	}
@@ -263,13 +255,13 @@ func main() {
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\n",
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered batch startup:%d ns\n",
 		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
 		c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedBatchStartupNS)
 	printModelComparison("training", training, c)
-	holdout := filterObservations(membershipObservations, true)
+	holdout := filterObservations(observations, true)
 	if len(holdout) > 0 {
 		printModelComparison("holdout", holdout, c)
 		if err := validateDecisionOrdering(holdout, c); err != nil {
@@ -279,36 +271,12 @@ func main() {
 			fatal(fmt.Errorf("holdout: %w", err))
 		}
 	}
-	printDecisionOrdering(membershipObservations, c)
-	printOrderedBatchCalibration(batchObservations)
+	printDecisionOrdering(observations, c)
 	if *patch {
 		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
 		}
 		fmt.Println("patched", queryplanPath)
-	}
-}
-
-func printOrderedBatchCalibration(rows []observation) {
-	if len(rows) == 0 {
-		return
-	}
-	byCase := map[string][]observation{}
-	for _, row := range rows {
-		byCase[row.caseName] = append(byCase[row.caseName], row)
-	}
-	names := make([]string, 0, len(byCase))
-	for name := range byCase {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		plans := byCase[name]
-		sort.Slice(plans, func(i, j int) bool { return plans[i].plan < plans[j].plan })
-		for _, row := range plans {
-			fmt.Printf("ordered batch %-32s plan=%-24s actual=%8.3fms estimated=%8.3fms\n",
-				name, row.plan, row.y/1e6, row.currentEstimate/1e6)
-		}
 	}
 }
 
@@ -659,8 +627,9 @@ func discoverCalibrationDecision(server *memcpServer, query, decisionName string
 			decision = &discovered[i]
 		}
 	}
-	if decision == nil || len(decision.Alternatives) != 2 || len(decision.EstimatedNS) != 2 {
-		return nil, nil, fmt.Errorf("discovery did not expose two costed alternatives: %+v", decision)
+	if decision == nil || len(decision.Alternatives) < 2 || len(decision.Alternatives) > 3 ||
+		len(decision.EstimatedNS) != len(decision.Alternatives) {
+		return nil, nil, fmt.Errorf("discovery did not expose two or three costed alternatives: %+v", decision)
 	}
 	estimates := map[string]*float64{}
 	for i, plan := range decision.Alternatives {
@@ -705,7 +674,10 @@ func runCalibrationVariantsSeparately(server *memcpServer, query string, test te
 			}
 			rows = append(rows, row)
 		}
-		equal := rows[0].Rows == rows[1].Rows && rows[0].ResultHash == rows[1].ResultHash
+		equal := true
+		for i := 1; i < len(rows); i++ {
+			equal = equal && rows[0].Rows == rows[i].Rows && rows[0].ResultHash == rows[i].ResultHash
+		}
 		for i := range rows {
 			rows[i].ResultEqual = equal
 		}
@@ -725,6 +697,9 @@ func runCalibrationRaces(server *memcpServer, query string, test testCase, repet
 	decision, estimates, err := discoverCalibrationDecision(server, query, test.CalibrationDecision)
 	if err != nil {
 		return nil, nil, err
+	}
+	if len(decision.Alternatives) != 2 {
+		return runCalibrationVariantsSeparately(server, query, test, 0, repetitions)
 	}
 	grace := test.RaceGrace
 	if grace <= 0 {
@@ -941,8 +916,8 @@ func validateRows(rows []calibrationRow) error {
 			return errors.New(row.Error)
 		}
 	}
-	if len(rows) != 2 {
-		return fmt.Errorf("expected exactly two membership alternatives, got %d", len(rows))
+	if len(rows) < 2 || len(rows) > 3 {
+		return fmt.Errorf("expected two or three membership alternatives, got %d", len(rows))
 	}
 	seen := map[string]bool{}
 	for _, row := range rows {
@@ -984,6 +959,9 @@ func validateRows(rows []calibrationRow) error {
 	}
 	if !seen["candidate_keyset"] || !seen["driver_order_membership_probe"] {
 		return fmt.Errorf("alternatives incomplete: %v", seen)
+	}
+	if len(rows) == 3 && !seen["ordered_batch_accept"] {
+		return fmt.Errorf("three-way decision is missing ordered_batch_accept: %v", seen)
 	}
 	return nil
 }
@@ -1054,21 +1032,20 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
 			1, *row.CandidateRows + *row.ProjectedDriverRows, *row.DriverRows, 0, 0, 0,
 			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
-			*row.CandidateBroadTextMatchBytes,
+			*row.CandidateBroadTextMatchBytes, 0,
 		}, nil
 	case "driver_order_membership_probe", "scan_order":
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
 			0, 0, 0, 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited,
 			0, orderedDriverInputRows, 0,
-			0,
+			0, 0,
 		}, nil
-	case "scan_order_batch_accept":
+	case "ordered_batch_accept":
 		fraction := 1.0
 		if *row.DriverInputRows > 0 {
 			fraction = math.Min(1, *row.ExpectedDriverRowsVisited / *row.DriverInputRows)
 		}
-		candidateWorkRows := *row.CandidateInputRows * fraction
 		firstBatch := *row.Limit + *row.Offset
 		batches, remaining, size := 1.0, *row.ExpectedDriverRowsVisited-firstBatch, firstBatch*2
 		for remaining > 0 && size > 0 {
@@ -1076,17 +1053,23 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			remaining -= size
 			size *= 2
 		}
+		repeatFraction := math.Min(batches, fraction*batches)
+		candidateWorkRows := *row.CandidateInputRows * repeatFraction
+		candidateMatchRows := *row.CandidateRows * repeatFraction
+		projectionRows := *row.ProbeBranches *
+			(2**row.ExpectedDriverRowsVisited + candidateWorkRows + candidateMatchRows)
 		return []float64{
-			batches,
-			2**row.ExpectedDriverRowsVisited + candidateWorkRows,
+			*row.DriverScanInvocations + batches**row.CandidateScanInvocations,
+			*row.ExpectedDriverRowsVisited + candidateWorkRows + projectionRows,
 			candidateWorkRows * *row.CandidateFilterColumns,
 			0,
 			candidateWorkRows * *row.CandidateExpressionOperations,
 			0,
-			*row.ExpectedDriverRowsVisited + candidateWorkRows + *row.CandidateRows,
+			projectionRows,
 			0, 0, 0, 0, 0, 0,
-			*row.CandidateBroadTextMatchRows * fraction,
-			*row.CandidateBroadTextMatchBytes * fraction,
+			*row.CandidateBroadTextMatchRows * repeatFraction,
+			*row.CandidateBroadTextMatchBytes * repeatFraction,
+			1,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
@@ -1168,6 +1151,7 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		groupCacheProbeRowNS:  int64(math.Round(beta[10])),
 		recsetAggregateRowNS:  1,
 		orderedDriverInputNS:  1,
+		orderedBatchStartupNS: 1,
 	}, nil
 }
 
@@ -1205,6 +1189,9 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 	if value, ok := fitBroadTextResidualPerByte(allRows, selected); ok {
 		selected.broadTextMatchByteNS = value
 	}
+	if value, ok := fitOrderedBatchStartup(allRows, selected); ok {
+		selected.orderedBatchStartupNS = value
+	}
 	/* A race timeout mixes cold startup and incomplete operator work. It is a
 	lower bound for that whole alternative, not evidence for a linear ordered
 	driver coefficient. Only exact paired workloads may change that term. */
@@ -1236,6 +1223,23 @@ func fitBroadTextResidualPerByte(rows []observation, c constants) (int64, bool) 
 		without := c
 		without.broadTextMatchByteNS = 0
 		values = append(values, math.Max(1, (row.y-estimatedNS(row, without))/row.x[14]))
+	}
+	if len(values) == 0 {
+		return 0, false
+	}
+	sort.Float64s(values)
+	return int64(math.Round(values[len(values)/2])), true
+}
+
+func fitOrderedBatchStartup(rows []observation, c constants) (int64, bool) {
+	values := make([]float64, 0)
+	for _, row := range rows {
+		if row.censored || row.plan != "ordered_batch_accept" || len(row.x) <= 15 || row.x[15] <= 0 {
+			continue
+		}
+		without := c
+		without.orderedBatchStartupNS = 0
+		values = append(values, math.Max(1, (row.y-estimatedNS(row, without))/row.x[15]))
 	}
 	if len(values) == 0 {
 		return 0, false
@@ -1324,6 +1328,7 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.orderedDriverInputNS),
 		float64(c.broadTextMatchRowNS),
 		float64(c.broadTextMatchByteNS),
+		float64(c.orderedBatchStartupNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1378,6 +1383,54 @@ func filterRankObservations(rows []observation) []observation {
 	return filtered
 }
 
+func filterCarrierObservations(rows []observation) []observation {
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if row.plan != "ordered_batch_accept" {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func decisionAlternatives(rows []observation) (map[string]map[string]observation, error) {
+	groups := make(map[string]map[string]observation)
+	for _, row := range rows {
+		if groups[row.caseName] == nil {
+			groups[row.caseName] = make(map[string]observation)
+		}
+		if _, duplicate := groups[row.caseName][row.plan]; duplicate {
+			return nil, fmt.Errorf("duplicate %s observation for %q", row.plan, row.caseName)
+		}
+		switch row.plan {
+		case "candidate_keyset", "driver_order_membership_probe", "ordered_batch_accept":
+			groups[row.caseName][row.plan] = row
+		default:
+			return nil, fmt.Errorf("unsupported plan %q", row.plan)
+		}
+	}
+	for name, plans := range groups {
+		if _, ok := plans["candidate_keyset"]; !ok {
+			return nil, fmt.Errorf("incomplete alternatives for %q", name)
+		}
+		if _, ok := plans["driver_order_membership_probe"]; !ok {
+			return nil, fmt.Errorf("incomplete alternatives for %q", name)
+		}
+	}
+	return groups, nil
+}
+
+func winningPlan(plans map[string]observation, estimate func(observation) float64) string {
+	winner := ""
+	best := math.Inf(1)
+	for plan, row := range plans {
+		if value := estimate(row); value < best {
+			winner, best = plan, value
+		}
+	}
+	return winner
+}
+
 type modelError struct {
 	medianAbsolutePercent float64
 	p90AbsolutePercent    float64
@@ -1411,17 +1464,17 @@ func measureModelError(rows []observation, estimate func(observation) float64) m
 }
 
 func decisionAccuracy(rows []observation, estimate func(observation) float64) (int, int) {
-	pairs, err := decisionPairs(filterRankObservations(rows))
+	groups, err := decisionAlternatives(filterRankObservations(rows))
 	if err != nil {
 		return 0, 0
 	}
 	correct := 0
-	for _, pair := range pairs {
-		if (pair.candidate.y < pair.driver.y) == (estimate(pair.candidate) < estimate(pair.driver)) {
+	for _, plans := range groups {
+		if winningPlan(plans, func(row observation) float64 { return row.y }) == winningPlan(plans, estimate) {
 			correct++
 		}
 	}
-	return correct, len(pairs)
+	return correct, len(groups)
 }
 
 func printModelComparison(label string, rows []observation, c constants) {
@@ -1505,47 +1558,37 @@ func decisionPairs(rows []observation) (map[string]decisionPair, error) {
 }
 
 func validateDecisionOrdering(rows []observation, c constants) error {
-	pairs, err := decisionPairs(filterRankObservations(rows))
+	groups, err := decisionAlternatives(filterRankObservations(rows))
 	if err != nil {
 		return err
 	}
-	for name, pair := range pairs {
-		actualCandidateWins := pair.candidate.y < pair.driver.y
-		estimatedCandidateWins := estimatedNS(pair.candidate, c) < estimatedNS(pair.driver, c)
-		if actualCandidateWins != estimatedCandidateWins {
-			return fmt.Errorf("calibrated inequality disagrees for %q: actual candidate=%0.fns driver=%0.fns, estimated candidate=%0.fns driver=%0.fns",
-				name, pair.candidate.y, pair.driver.y,
-				estimatedNS(pair.candidate, c), estimatedNS(pair.driver, c))
+	for name, plans := range groups {
+		actualWinner := winningPlan(plans, func(row observation) float64 { return row.y })
+		estimatedWinner := winningPlan(plans, func(row observation) float64 { return estimatedNS(row, c) })
+		if actualWinner != estimatedWinner {
+			return fmt.Errorf("calibrated ordering disagrees for %q: actual winner=%s estimated winner=%s",
+				name, actualWinner, estimatedWinner)
 		}
 	}
 	return nil
 }
 
 func printDecisionOrdering(rows []observation, c constants) {
-	pairs, err := decisionPairs(filterRankObservations(rows))
+	groups, err := decisionAlternatives(filterRankObservations(rows))
 	if err != nil {
 		return
 	}
-	names := make([]string, 0, len(pairs))
-	for name := range pairs {
+	names := make([]string, 0, len(groups))
+	for name := range groups {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		pair := pairs[name]
-		estimatedCandidate := estimatedNS(pair.candidate, c)
-		estimatedDriver := estimatedNS(pair.driver, c)
-		actualWinner := pair.driver.plan
-		if pair.candidate.y < pair.driver.y {
-			actualWinner = pair.candidate.plan
-		}
-		estimatedWinner := pair.driver.plan
-		if estimatedCandidate < estimatedDriver {
-			estimatedWinner = pair.candidate.plan
-		}
-		fmt.Printf("decision %-40s actual=%-30s driver-candidate=%+.3fms estimated=%-30s driver-candidate=%+.3fms\n",
-			name, actualWinner, (pair.driver.y-pair.candidate.y)/1e6,
-			estimatedWinner, (estimatedDriver-estimatedCandidate)/1e6)
+		plans := groups[name]
+		actualWinner := winningPlan(plans, func(row observation) float64 { return row.y })
+		estimatedWinner := winningPlan(plans, func(row observation) float64 { return estimatedNS(row, c) })
+		fmt.Printf("decision %-40s actual=%-30s estimated=%-30s alternatives=%d\n",
+			name, actualWinner, estimatedWinner, len(plans))
 	}
 }
 
@@ -1581,6 +1624,7 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_ordered_driver_input_row_ns",
 		"planner_membership_broad_text_match_row_ns",
 		"planner_membership_broad_text_match_byte_ns",
+		"planner_ordered_batch_accept_startup_ns",
 	}
 	values := make([]int64, len(names))
 	content := string(data)
@@ -1608,9 +1652,10 @@ func readCurrentConstants(path string) (constants, error) {
 		recsetBuildRowNS: values[6], recsetProbeRowNS: values[7],
 		recsetAggregateRowNS: values[8], groupCacheStartupNS: values[9],
 		groupCacheBuildRowNS: values[10], groupCacheProbeRowNS: values[11],
-		orderedDriverInputNS: values[12],
-		broadTextMatchRowNS:  values[13],
-		broadTextMatchByteNS: values[14],
+		orderedDriverInputNS:  values[12],
+		broadTextMatchRowNS:   values[13],
+		broadTextMatchByteNS:  values[14],
+		orderedBatchStartupNS: values[15],
 	}, nil
 }
 
@@ -1656,10 +1701,11 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_build_row_ns %d)
 (define planner_membership_group_cache_probe_row_ns %d)
 (define planner_membership_ordered_driver_input_row_ns %d)
+(define planner_ordered_batch_accept_startup_ns %d)
 /* END GENERATED COST CONSTANTS */`, c.scanInvocationNS, c.scanRowNS,
 		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS,
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedBatchStartupNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -168,6 +168,7 @@ type observation struct {
 	caseName        string
 	cacheState      string
 	component       string
+	decision        string
 	plan            string
 	y               float64
 	currentEstimate float64
@@ -240,7 +241,17 @@ func main() {
 			fatal(err)
 		}
 	}
-	training := filterObservations(observations, false)
+	membershipObservations := make([]observation, 0, len(observations))
+	batchObservations := make([]observation, 0, len(observations))
+	for _, row := range observations {
+		switch row.decision {
+		case "membership_carrier":
+			membershipObservations = append(membershipObservations, row)
+		case "ordered_batch_accept":
+			batchObservations = append(batchObservations, row)
+		}
+	}
+	training := filterObservations(membershipObservations, false)
 	fitTraining := filterCompleteExactPairs(training)
 	if err := validateMeasurementSignal(fitTraining); err != nil {
 		fatal(err)
@@ -258,7 +269,7 @@ func main() {
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS)
 	printModelComparison("training", training, c)
-	holdout := filterObservations(observations, true)
+	holdout := filterObservations(membershipObservations, true)
 	if len(holdout) > 0 {
 		printModelComparison("holdout", holdout, c)
 		if err := validateDecisionOrdering(holdout, c); err != nil {
@@ -268,12 +279,36 @@ func main() {
 			fatal(fmt.Errorf("holdout: %w", err))
 		}
 	}
-	printDecisionOrdering(observations, c)
+	printDecisionOrdering(membershipObservations, c)
+	printOrderedBatchCalibration(batchObservations)
 	if *patch {
 		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
 		}
 		fmt.Println("patched", queryplanPath)
+	}
+}
+
+func printOrderedBatchCalibration(rows []observation) {
+	if len(rows) == 0 {
+		return
+	}
+	byCase := map[string][]observation{}
+	for _, row := range rows {
+		byCase[row.caseName] = append(byCase[row.caseName], row)
+	}
+	names := make([]string, 0, len(byCase))
+	for name := range byCase {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		plans := byCase[name]
+		sort.Slice(plans, func(i, j int) bool { return plans[i].plan < plans[j].plan })
+		for _, row := range plans {
+			fmt.Printf("ordered batch %-32s plan=%-24s actual=%8.3fms estimated=%8.3fms\n",
+				name, row.plan, row.y/1e6, row.currentEstimate/1e6)
+		}
 	}
 }
 
@@ -568,7 +603,7 @@ func runSuites(server *memcpServer, suites []suite) ([]observation, []calibratio
 					return nil, nil, fmt.Errorf("%s/%s: %w", currentSuite.Path, test.Name, err)
 				}
 				observations = append(observations, observation{
-					caseName: test.Name, plan: row.Plan, y: row.WholeQueryExecutionNS,
+					caseName: test.Name, decision: row.Decision, plan: row.Plan, y: row.WholeQueryExecutionNS,
 					cacheState: cacheState, component: test.CalibrationComponent,
 					currentEstimate: *row.EstimatedNS, holdout: test.CalibrationHoldout,
 					noiseNS: medianAbsoluteDeviation(runs, row.Plan), censored: row.TimedOut, x: features,
@@ -960,8 +995,13 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 			byPlan[row.Plan] = append(byPlan[row.Plan], row)
 		}
 	}
+	plans := make([]string, 0, len(byPlan))
+	for plan := range byPlan {
+		plans = append(plans, plan)
+	}
+	sort.Strings(plans)
 	var result []calibrationRow
-	for _, plan := range []string{"candidate_keyset", "driver_order_membership_probe"} {
+	for _, plan := range plans {
 		rows := byPlan[plan]
 		if len(rows) == 0 {
 			return nil, fmt.Errorf("no rows for %s", plan)
@@ -977,7 +1017,7 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 func rowFeatures(row calibrationRow) ([]float64, error) {
 	scanInvocations := *row.CandidateScanInvocations + *row.DriverScanInvocations
 	driverWorkRows := *row.DriverInputRows
-	if row.Plan == "driver_order_membership_probe" {
+	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
 		driverWorkRows = *row.ExpectedDriverRowsVisited
 	}
 	scanRows := *row.CandidateInputRows + driverWorkRows
@@ -992,11 +1032,11 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 	filterValues := candidateFilterValues + driverWorkRows**row.DriverFilterColumns
 	expressionOperations := candidateExpressionOperations + driverWorkRows**row.DriverExpressionOperations
 	mapColumns := *row.CandidateMapColumns
-	if row.Plan == "driver_order_membership_probe" {
+	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
 		mapColumns = *row.CandidateCacheMapColumns
 	}
 	driverMapRows := *row.ProjectedDriverRows
-	if row.Plan == "driver_order_membership_probe" {
+	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
 		driverMapRows = *row.DriverRows
 	}
 	mapValues := *row.CandidateRows*mapColumns + driverMapRows**row.DriverMapColumns
@@ -1016,12 +1056,37 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
 			*row.CandidateBroadTextMatchBytes,
 		}, nil
-	case "driver_order_membership_probe":
+	case "driver_order_membership_probe", "scan_order":
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
 			0, 0, 0, 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited,
 			0, orderedDriverInputRows, 0,
 			0,
+		}, nil
+	case "scan_order_batch_accept":
+		fraction := 1.0
+		if *row.DriverInputRows > 0 {
+			fraction = math.Min(1, *row.ExpectedDriverRowsVisited / *row.DriverInputRows)
+		}
+		candidateWorkRows := *row.CandidateInputRows * fraction
+		firstBatch := *row.Limit + *row.Offset
+		batches, remaining, size := 1.0, *row.ExpectedDriverRowsVisited-firstBatch, firstBatch*2
+		for remaining > 0 && size > 0 {
+			batches++
+			remaining -= size
+			size *= 2
+		}
+		return []float64{
+			batches,
+			2**row.ExpectedDriverRowsVisited + candidateWorkRows,
+			candidateWorkRows * *row.CandidateFilterColumns,
+			0,
+			candidateWorkRows * *row.CandidateExpressionOperations,
+			0,
+			*row.ExpectedDriverRowsVisited + candidateWorkRows + *row.CandidateRows,
+			0, 0, 0, 0, 0, 0,
+			*row.CandidateBroadTextMatchRows * fraction,
+			*row.CandidateBroadTextMatchBytes * fraction,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -77,6 +77,48 @@ func TestRowFeaturesKeepsBroadTextRowsAndBytesSeparate(t *testing.T) {
 	}
 }
 
+func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "scan_order_batch_accept", Consumer: "order_limit",
+		CandidateInputRows: value(1000), CandidateRows: value(50), ProjectedDriverRows: value(50),
+		DriverInputRows: value(1000), DriverRows: value(100), ExpectedDriverRowsVisited: value(100),
+		Limit: value(10), Offset: value(0), CandidateScanInvocations: value(1),
+		CandidateFilterColumns: value(2), CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
+		CandidateExpressionOperations: value(3), CandidateBroadTextMatchRows: value(1000),
+		CandidateBroadTextMatchBytes: value(8192000), DriverScanInvocations: value(1),
+		DriverFilterColumns: value(0), DriverMapColumns: value(1), DriverExpressionOperations: value(0),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features[0] != 4 || features[1] != 300 || features[2] != 200 ||
+		features[4] != 300 || features[6] != 250 {
+		t.Fatalf("adaptive features = %v", features)
+	}
+	if features[13] != 100 || features[14] != 819200 {
+		t.Fatalf("fractional broad text features = (%v, %v), want (100, 819200)",
+			features[13], features[14])
+	}
+}
+
+func TestMedianRowsAcceptsOrderedBatchPlans(t *testing.T) {
+	runs := [][]calibrationRow{
+		{{Plan: "scan_order", WholeQueryExecutionNS: 30}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 20}},
+		{{Plan: "scan_order", WholeQueryExecutionNS: 10}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 40}},
+		{{Plan: "scan_order", WholeQueryExecutionNS: 20}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 30}},
+	}
+	rows, err := medianRows(runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].Plan != "scan_order" || rows[0].WholeQueryExecutionNS != 20 ||
+		rows[1].Plan != "scan_order_batch_accept" || rows[1].WholeQueryExecutionNS != 30 {
+		t.Fatalf("unexpected medians: %+v", rows)
+	}
+}
+
 func TestRaceCalibrationVariantsCancelsSlowerPlan(t *testing.T) {
 	const decisionID = "membership_carrier:test"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -80,10 +80,10 @@ func TestRowFeaturesKeepsBroadTextRowsAndBytesSeparate(t *testing.T) {
 func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
 	value := func(v float64) *float64 { return &v }
 	row := calibrationRow{
-		Plan: "scan_order_batch_accept", Consumer: "order_limit",
+		Plan: "ordered_batch_accept", Consumer: "order_limit",
 		CandidateInputRows: value(1000), CandidateRows: value(50), ProjectedDriverRows: value(50),
 		DriverInputRows: value(1000), DriverRows: value(100), ExpectedDriverRowsVisited: value(100),
-		Limit: value(10), Offset: value(0), CandidateScanInvocations: value(1),
+		Limit: value(10), Offset: value(0), ProbeBranches: value(2), CandidateScanInvocations: value(2),
 		CandidateFilterColumns: value(2), CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
 		CandidateExpressionOperations: value(3), CandidateBroadTextMatchRows: value(1000),
 		CandidateBroadTextMatchBytes: value(8192000), DriverScanInvocations: value(1),
@@ -93,29 +93,59 @@ func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if features[0] != 4 || features[1] != 300 || features[2] != 200 ||
-		features[4] != 300 || features[6] != 250 {
+	if features[0] != 9 || features[1] != 1740 || features[2] != 800 ||
+		features[4] != 1200 || features[6] != 1240 {
 		t.Fatalf("adaptive features = %v", features)
 	}
-	if features[13] != 100 || features[14] != 819200 {
-		t.Fatalf("fractional broad text features = (%v, %v), want (100, 819200)",
+	if features[13] != 400 || features[14] != 3276800 {
+		t.Fatalf("repeated broad text features = (%v, %v), want (400, 3276800)",
 			features[13], features[14])
+	}
+	if features[15] != 1 {
+		t.Fatalf("ordered batch startup feature = %v, want 1", features[15])
+	}
+}
+
+func TestFitOrderedBatchStartupUsesExactBatchObservations(t *testing.T) {
+	features := make([]float64, 16)
+	features[15] = 1
+	value, ok := fitOrderedBatchStartup([]observation{
+		{plan: "ordered_batch_accept", y: 42000, x: features},
+	}, constants{})
+	if !ok || value != 42000 {
+		t.Fatalf("ordered batch startup = (%d, %v), want (42000, true)", value, ok)
 	}
 }
 
 func TestMedianRowsAcceptsOrderedBatchPlans(t *testing.T) {
 	runs := [][]calibrationRow{
-		{{Plan: "scan_order", WholeQueryExecutionNS: 30}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 20}},
-		{{Plan: "scan_order", WholeQueryExecutionNS: 10}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 40}},
-		{{Plan: "scan_order", WholeQueryExecutionNS: 20}, {Plan: "scan_order_batch_accept", WholeQueryExecutionNS: 30}},
+		{{Plan: "driver_order_membership_probe", WholeQueryExecutionNS: 30}, {Plan: "ordered_batch_accept", WholeQueryExecutionNS: 20}},
+		{{Plan: "driver_order_membership_probe", WholeQueryExecutionNS: 10}, {Plan: "ordered_batch_accept", WholeQueryExecutionNS: 40}},
+		{{Plan: "driver_order_membership_probe", WholeQueryExecutionNS: 20}, {Plan: "ordered_batch_accept", WholeQueryExecutionNS: 30}},
 	}
 	rows, err := medianRows(runs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 2 || rows[0].Plan != "scan_order" || rows[0].WholeQueryExecutionNS != 20 ||
-		rows[1].Plan != "scan_order_batch_accept" || rows[1].WholeQueryExecutionNS != 30 {
+	if len(rows) != 2 || rows[0].Plan != "driver_order_membership_probe" || rows[0].WholeQueryExecutionNS != 20 ||
+		rows[1].Plan != "ordered_batch_accept" || rows[1].WholeQueryExecutionNS != 30 {
 		t.Fatalf("unexpected medians: %+v", rows)
+	}
+}
+
+func TestValidateDecisionOrderingIncludesOrderedBatch(t *testing.T) {
+	features := func(first float64) []float64 {
+		values := make([]float64, 15)
+		values[0] = first
+		return values
+	}
+	rows := []observation{
+		{caseName: "three-way", plan: "candidate_keyset", y: 10, x: features(1)},
+		{caseName: "three-way", plan: "driver_order_membership_probe", y: 20, x: features(2)},
+		{caseName: "three-way", plan: "ordered_batch_accept", y: 5, x: features(100)},
+	}
+	if err := validateDecisionOrdering(rows, constants{scanInvocationNS: 1}); err == nil {
+		t.Fatal("three-way validation accepted an incorrectly ranked ordered batch plan")
 	}
 }
 


### PR DESCRIPTION
## Summary

- lower finite single-source `ORDER BY ... LIMIT` membership filters to `scan_order_batch_accept` when its calibrated cost beats both full candidate projection and scalar driver probes
- compile a query-local `RecSet -> RecSet` filter that projects each ordered driver batch to the membership source, evaluates it with `scan_recset`, projects matches back, and intersects with the input batch
- keep unordered bounded scans greedy, and append the primary key as a hidden total-order tie-breaker for explicit ordering
- expose the conditional operator through `EXPLAIN PHYSICAL`, `EXPLAIN PHYSICAL CALIBRATE DISCOVER`, forced calibration variants, and costgen
- reject input RecSets from a transaction other than the explicit current transaction

## Costing and scope

The membership edge has one three-way decision:

1. `candidate_keyset`
2. `driver_order_membership_probe`
3. `ordered_batch_accept`

Eligibility remains conservative: finite LIMIT, source-local order, complete positive membership shape, supported projection, and a primary key for explicit ordering. OR alternatives, aggregates, unbounded queries, and unsupported or partial membership shapes stay on their existing paths.

## SQL end-to-end measurement

These are not storage-operator microbenchmarks. They were collected with:

```text
go run ./tools/costgen -jsonl /tmp/pr564-sql-calibration.jsonl
```

The harness builds the SQL fixture, asks the SQL compiler for the physical membership decision, then compiles and executes every forced physical alternative through `EXPLAIN PHYSICAL CALIBRATE VARIANT`. All alternatives run against the same query snapshot. The harness validates the emitted operator family and compares output row count plus result hash.

The production-shaped holdout query scans a one-million-row ordered document relation and applies two text-membership branches (`LIKE` plus `MATCH`) over 200,000 candidate input rows / 20.18 MB of text work before returning 72 rows:

```sql
SELECT d.id, d.p1
FROM pc_docs_million d
WHERE d.file_id IN (
  SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
  UNION
  SELECT f.id FROM pc_files_text f
  WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
)
ORDER BY d.sort_key, d.p1, d.id, d.file_id
LIMIT 72;
```

| Compiled physical alternative | Whole SQL query |
|---|---:|
| `candidate_keyset` | 67.53 ms |
| `driver_order_membership_probe` | 375.24 ms |
| `ordered_batch_accept` | **52.59 ms** |

For this query, the compiler's normal cost decision is `ordered_batch_accept`. It reduces whole-query time by 22.1% versus the best pre-existing alternative (1.28x throughput) and by 86.0% versus per-driver membership probes. All three executions returned the same 72 rows and SHA-256 result hash `b25185ca…10080bd`.

## Benchmark finding: cost model is not ready to merge

The same SQL calibration also found shapes where the current model selects batch accept even though candidate materialization is faster:

| SQL shape | Normal choice | `candidate_keyset` | `ordered_batch_accept` | Result |
|---|---|---:|---:|---|
| 20k driver rows, broad candidate set, `LIMIT 10` (median of 5) | batch | **2.47 ms** | 7.31 ms | candidate is 2.96x faster |
| 1M driver rows, simple four-key order, `LIMIT 72` (median of 3) | batch | **35.74 ms** | 44.53 ms | candidate latency is 19.7% lower |

The calibration command consequently exited non-zero because the noisy million-row case did not satisfy its A/B signal gate. The estimates also materially understate batch startup/work (for the production holdout: 0.086 ms estimated versus 52.59 ms observed).

This PR therefore remains a draft. The operator and lowering are reachable and the complex search query is measurably faster, but the cost model must be corrected and the SQL calibration suite must pass before merge.

## Validation

- `make test` — full hook-equivalent suite passed after rebasing onto current `master`
- `tests/planner/subqueries/in-subquery.yaml`: 70/70
- ACL membership scaling suite: 13/13 in three repeated focused runs and in the final full run
- `go test ./storage -run TestScanOrderBatchAccept`
- `go test ./tools/costgen`
- SQL calibration: 149 raw compiler/execution observations collected; result equality passed, A/B signal gate failed as documented above

The merge with current master preserves the session-value guard at the selective text carrier call site after #562 removed its helper definition.
