### PR TITLE
Restore planner session value guards

### DIFF
--- a/lib/queryplan.scm
+++ b/lib/queryplan.scm
@@ -7065,6 +7065,14 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(list (quote broad_like_pattern?) pattern))
 			broad))))
 
+(define planner_record_session_value_guards (lambda (node)
+	(reduce (query_expr_session_reads node) (lambda (_ expr)
+		(begin
+			(define value (planner_literal_value expr))
+			(planner_record_guard_condition
+				(list (quote equal?) expr
+					(if (list? value) (list (quote quote) value) value))))) nil)))
+
 (define expr_contains_broad_text_match? (lambda (expr)
 	(match expr
 		((symbol strlike) _value pattern _collation)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -173,6 +173,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(list "id" expr_gc)
 		true nil nil nil nil nil))
 	(define simple_ir (untangle_query_term simple_select_ast nil))
+	(assert (planner_record_session_value_guards true) nil "physical cost choices can record session-value guards")
 	(assert (equal? (ir_kind simple_ir) 'select) true "untangle_query_term returns select IR")
 	(assert (equal? (logical_op (ir_root simple_ir)) 'query-block) true "untangle_query builds a combined query-block root")
 	(assert (equal? (source_relation (car (qb_sources (ir_root simple_ir)))) "t") true "query-block keeps base relation logical")


### PR DESCRIPTION
## Summary
- restore the active planner_record_session_value_guards helper removed by #562
- add a direct Scheme unit assertion so coverage-based cleanup cannot classify it as unreferenced again

## Correctness evidence
- unchanged origin/master: tests/execution/operators/range-scan-coverage.yaml fails 4 cases with Unknown function: planner_record_session_value_guards (102/106)
- this branch: the same suite passes 106/106
- normal full pre-commit hook: passed

This is intentionally separate from the mechanical queryplan module split.