### PR TITLE
Fix nested join-order carrier isolation

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3690,8 +3690,7 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 		(define lowered_values (map (merge (list value_exprs order_values)) (lambda (expr)
 			(lower_column_expr_for_join_in_context
 				scan_sources default_alias expr probe_work_rows))))
-		(define table_key (concat "__join_order_intermediate:" (uuid)))
-		(define table_name (list (quote session) table_key))
+		(define table_name (symbol (concat "__join_order_intermediate_" (uuid))))
 		(define table_expr (list (quote table) (qb_schema block) table_name))
 		/* Keep a logically implied membership as the scan source while filling
 		the storage carrier. Other joins retain their established base-table scan
@@ -3704,18 +3703,20 @@ scan_order can build the appropriate auto-index and apply OFFSET/LIMIT. */
 			'() 0 -1 allow_membership_carrier probe_work_rows nil stage_catalog))
 		(define scan_plan_expr (scan_builder table_expr value_names order_names))
 		(define drop_plan (list (quote droptable) (qb_schema block) table_name true))
-		(list (quote !begin)
-			(list (quote session) table_key (list (quote concat) ".join-order:" (list (quote uuid))))
-			(list (quote createtable) (qb_schema block) table_name
-				(join_order_intermediate_columns column_names)
-				(quoted_runtime_list '("engine" "memory")) true)
-			(list
-				(list (quote lambda) (list (quote __intermediate_result))
-					(list (quote !begin) drop_plan (quote __intermediate_result)))
-				(list (quote try)
-					(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
-					(list (quote lambda) (list (quote __intermediate_error))
-						(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error))))))))))
+		(list
+			(list (quote lambda) (list table_name)
+				(list (quote !begin)
+					(list (quote createtable) (qb_schema block) table_name
+						(join_order_intermediate_columns column_names)
+						(quoted_runtime_list '("engine" "memory")) true)
+					(list
+						(list (quote lambda) (list (quote __intermediate_result))
+							(list (quote !begin) drop_plan (quote __intermediate_result)))
+						(list (quote try)
+							(list (quote lambda) '() (list (quote !begin) fill_plan scan_plan_expr))
+							(list (quote lambda) (list (quote __intermediate_error))
+								(list (quote !begin) drop_plan (list (quote error) (quote __intermediate_error))))))))
+			(list (quote concat) ".join-order:" (list (quote uuid)))))))
 
 (define lower_join_order_through_intermediate (lambda (block fields scan_sources scan_plan default_alias needed_exprs final_condition order_items stage_catalog)
 	(begin

--- a/tests/integration/regressions/nested-aggregate-carrier.yaml
+++ b/tests/integration/regressions/nested-aggregate-carrier.yaml
@@ -1,0 +1,99 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Nested aggregate projections retain every physical carrier initializer"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS nac_team_item"
+  - sql: "DROP TABLE IF EXISTS nac_ticket"
+  - sql: "DROP TABLE IF EXISTS nac_state"
+  - sql: "DROP TABLE IF EXISTS nac_actor"
+  - sql: "CREATE TABLE nac_actor (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE nac_state (id INT PRIMARY KEY, final BOOL)"
+  - sql: |
+      CREATE TABLE nac_ticket (
+        id INT PRIMARY KEY,
+        state INT,
+        assigned INT,
+        assigned_team INT,
+        creator INT
+      )
+  - sql: "CREATE TABLE nac_team_item (id INT PRIMARY KEY, list_id INT, actor_id INT)"
+  - sql: "INSERT INTO nac_actor VALUES (1)"
+  - sql: |
+      INSERT INTO nac_state VALUES
+        (1, TRUE), (2, FALSE), (3, FALSE),
+        (4, FALSE), (5, FALSE), (6, FALSE)
+  - scm: '(settings "ShardSize" 2)'
+  - sql: |
+      INSERT INTO nac_ticket VALUES
+        (1, 5, NULL, NULL, 1),
+        (2, 5, NULL, NULL, 1),
+        (5, 4, NULL, NULL, 1)
+  - scm: '(settings "ShardSize" 60000)'
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS nac_team_item"
+  - sql: "DROP TABLE IF EXISTS nac_ticket"
+  - sql: "DROP TABLE IF EXISTS nac_state"
+  - sql: "DROP TABLE IF EXISTS nac_actor"
+
+test_cases:
+  - name: "parallel-shard nested scalar aggregate owns its intermediate"
+    fail_comment: "a carrier used below the scalar aggregate was scanned before its query-local table existed"
+    sql: |
+      SELECT (
+        SELECT SUM((
+          SELECT 1
+          FROM nac_state aggregate_state
+          WHERE aggregate_state.id = ticket.state
+            AND NOT aggregate_state.final
+          LIMIT 1
+        ))
+        FROM nac_ticket ticket
+        WHERE TRUE
+          AND NOT ((
+            SELECT filter_state.final
+            FROM nac_state filter_state
+            WHERE filter_state.id = ticket.state
+            LIMIT 1
+          ))
+          AND (
+            (SELECT actor.id = 1
+             FROM nac_actor actor
+             WHERE actor.id = ticket.assigned
+             LIMIT 1)
+            OR EXISTS (
+              SELECT TRUE
+              FROM nac_team_item team_item
+              WHERE team_item.list_id = ticket.assigned_team
+                AND (SELECT member.id = 1
+                     FROM nac_actor member
+                     WHERE member.id = team_item.actor_id
+                     LIMIT 1)
+              LIMIT 1
+            )
+          )
+        LIMIT 1
+      ) AS assigned_count
+      FROM nac_actor
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - {assigned_count: null}


### PR DESCRIPTION
## Summary

- bind each runtime join-order intermediate table name lexically to its execution
- prevent parallel shard callbacks from overwriting a shared session table name
- add a multi-shard nested scalar aggregate regression reproducing the ERPL failure

## Root cause

Nested join-order lowering stored the generated intermediate table name under a shared query-session key. Parallel shard executions could overwrite that key, causing one callback to scan or drop another callback’s temporary table and return SQL Error: table does not exist.

## Validation

- verified the new YAML test fails on the unmodified implementation
- nested-aggregate-carrier.yaml: 1/1 passed after the fix
- subquery-complex.yaml: 41/41 passed
- order-limit.yaml: 47/47 passed
- dashboard-unnesting-regressions.yaml: 9/9 passed
- range-scan-coverage.yaml: 106/106 passed on current master
- make test: passed, including Go coverage generation
- original ERPL reminder projection returned successfully; the Doc route completed with HTTP 200