### PR TITLE
fix: localize Proc optimizer metadata and scalar empty-domain semantics

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -3534,19 +3534,22 @@ the logical lookup still carries an alias which no longer exists. */
 									(join_optimizer_facts_without_aliases
 										(qb_facts physical_block) (list (source_alias candidate)))))))))))))
 /* The other probe shape a group-stage-output alias can appear as: a plain or
-COALESCE-wrapped bare boolean passthrough (no ">0" count-encoding), the shape
-`COALESCE((SELECT bool_expr ...) ...)` compiles into for a scalar_single
-boolean probe, matched against the specific logical output alias. */
+COALESCE-false-wrapped bare boolean passthrough (no ">0" count-encoding), the
+shape `COALESCE((SELECT bool_expr ...), FALSE)` compiles into for a
+scalar_single boolean probe, matched against the specific logical output
+alias. A TRUE fallback is deliberately excluded: positive membership cannot
+distinguish a matching FALSE row from the empty scalar domain, while SQL
+requires COALESCE(NULL, TRUE) to preserve the latter. */
 (define stage_output_boolean_probe_term? (lambda (alias term)
 	(match term
 		((symbol coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) _default)
-		(and (equal? tblvar alias) (or (equal?? _default false) (equal?? _default true)))
+		(and (equal? tblvar alias) (equal?? _default false))
 		((symbol coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) _default)
-		(and (equal? tblvar alias) (or (equal?? _default false) (equal?? _default true)))
+		(and (equal? tblvar alias) (equal?? _default false))
 		((quote coalesceNil) ((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase) _default)
-		(and (equal? tblvar alias) (or (equal?? _default false) (equal?? _default true)))
+		(and (equal? tblvar alias) (equal?? _default false))
 		((quote coalesceNil) ((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase) _default)
-		(and (equal? tblvar alias) (or (equal?? _default false) (equal?? _default true)))
+		(and (equal? tblvar alias) (equal?? _default false))
 		((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
 		(equal? tblvar alias)
 		((quote get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
@@ -3576,11 +3579,7 @@ boolean probe, matched against the specific logical output alias. */
 			_ false))))
 
 (define condition_has_exists_recset_probe? (lambda (alias condition)
-	(match condition
-		(cons head tail) (or
-			(exists_recset_probe_term? alias condition)
-			(reduce tail (lambda (found item) (or found (condition_has_exists_recset_probe? alias item))) false))
-		_ false)))
+	(not (nil? (exists_recset_probe_column alias condition)))))
 
 (define stage_output_column_for_alias (lambda (alias expr)
 	(match expr
@@ -3592,12 +3591,26 @@ boolean probe, matched against the specific logical output alias. */
 			(if (not (nil? found)) found (stage_output_column_for_alias alias item))) nil)
 		_ nil)))
 
+(define exists_recset_truth_container_head? (lambda (head)
+	(or (equal? head (quote and))
+		(or (equal? head (symbol "and"))
+			(or (equal? head (quote or))
+				(or (equal? head (symbol "or"))
+					(or (equal? head (quote not))
+						(or (equal? head (symbol "not"))
+							(or (equal? head (quote if))
+								(or (equal? head (symbol "if"))
+									(or (equal? head (quote optimize))
+										(equal? head (symbol "optimize")))))))))))))
+
 (define exists_recset_probe_column (lambda (alias expr)
 	(if (exists_recset_probe_term? alias expr)
 		(stage_output_column_for_alias alias expr)
 		(match expr
-			(cons _head tail) (reduce tail (lambda (found item)
-				(if (not (nil? found)) found (exists_recset_probe_column alias item))) nil)
+			(cons head tail) (if (exists_recset_truth_container_head? head)
+				(reduce tail (lambda (found item)
+					(if (not (nil? found)) found (exists_recset_probe_column alias item))) nil)
+				nil)
 			_ nil))))
 
 (define stage_with_primary_aggregate (lambda (stage requested_col)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -4175,6 +4175,28 @@ which output was renamed. */
 		(merge (map sources (lambda (src)
 			(stage_output_aggregate_fold_map_for_source original_index folded_index src)))))))
 
+/* Rewriting a dependency column can in turn rename an aggregate which reads
+that column. Propagate those positional interface renames through the stage DAG
+until both producers and all consumers agree. */
+(define propagate_stage_output_aggregate_columns (lambda (block original_stages rewritten_stages)
+	(begin
+		(define aggregate_col_map (stage_output_aggregate_fold_map
+			block original_stages rewritten_stages))
+		(if (empty_list? aggregate_col_map)
+			(list block rewritten_stages)
+			(begin
+				(define next_stages (rewrite_stage_graph_stages
+					aggregate_col_map '() rewritten_stages))
+				(define block_with_stages (make_query_block
+					(qb_schema block) (qb_sources block) (qb_fields block)
+					(qb_where block) (qb_group block) (qb_having block)
+					(qb_order block) (qb_limit block) (qb_offset block) (qb_hidden block)
+					next_stages (qb_facts block)))
+				(define next_block (rewrite_stage_graph_expr
+					aggregate_col_map '() block_with_stages))
+				(propagate_stage_output_aggregate_columns
+					next_block rewritten_stages next_stages))))))
+
 (define fold_boolean_tautologies_ir (lambda (ir)
 	(begin
 		(define root (ir_root ir))
@@ -4184,24 +4206,16 @@ which output was renamed. */
 				(define graph (stage_dependency_graph (qb_stages root)))
 				(define folded_stages (map (qb_stages root) (lambda (stage)
 					(fold_boolean_tautologies_stage graph stage))))
-				(define aggregate_col_map (stage_output_aggregate_fold_map
-					root (qb_stages root) folded_stages))
-				/* Most queries contain no foldable stage aggregate. Avoid copying the
-				whole stage graph when every aggregate keeps its canonical column. */
-				(define rewritten_stages (if (empty_list? aggregate_col_map)
-					folded_stages
-					(rewrite_stage_graph_stages aggregate_col_map '() folded_stages)))
 				(define folded_block (make_query_block
 					(qb_schema root) (qb_sources root) (qb_fields root)
 					(boolean_fold_maybe_expr (qb_where root))
 					(qb_group root)
 					(boolean_fold_maybe_expr (qb_having root))
 					(qb_order root) (qb_limit root) (qb_offset root) (qb_hidden root)
-					rewritten_stages (qb_facts root)))
-				(define rewritten_block (if (empty_list? aggregate_col_map)
-					folded_block
-					(rewrite_stage_graph_expr aggregate_col_map '() folded_block)))
-				(make_ir (ir_kind ir) rewritten_block rewritten_stages
+					folded_stages (qb_facts root)))
+				(define propagated (propagate_stage_output_aggregate_columns
+					folded_block (qb_stages root) folded_stages))
+				(make_ir (ir_kind ir) (nth propagated 0) (nth propagated 1)
 					(ir_context_of ir) (ir_return ir)))))))
 
 (define normalize_stage_dependencies (lambda (ir)

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -83,11 +83,6 @@ type TypeDescriptor struct {
 	// data. Numbered parameters stay in their existing stack slots and constants
 	// stay immediate until an operation actually needs to materialize them.
 	JITVirtualArgs bool
-	// Specialized variants keyed by param-ownership bitmask.
-	// Built on-demand by the optimizer when a call site provides owned args.
-	// TODO: deoptimization — if the global function is redefined, all callsites
-	// referencing cached variants must be invalidated (reset to the original code).
-	Variants map[uint64]Scmer
 }
 
 // OptimizerContext is an exported wrapper so packages like storage can use

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -2405,7 +2405,7 @@ func jitAutoImportSyntaxSafe(expr Scmer) bool {
 	switch name {
 	case "quote":
 		return true
-	case "lambda", "begin", "begin_mut", "!begin", "set", "define", "setN", "!list", "!!list", "eval", "parallel":
+	case "lambda", "optimizer_proc_return", "begin", "begin_mut", "!begin", "set", "define", "setN", "!list", "!!list", "eval", "parallel":
 		return false
 	case "match", "match_mut":
 		return false

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1653,10 +1653,9 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 
 	switch {
 	case headOk && (headSym == Symbol("set") || headSym == Symbol("define")) && len(v) == 3:
-		var definedSym Symbol
 		var hasDefinedSym bool
 		if sym, ok := scmerSymbol(v[1]); ok {
-			definedSym, hasDefinedSym = sym, true
+			hasDefinedSym = true
 			for _, black := range ome.setBlacklist {
 				if black == sym {
 					if useResult {
@@ -1667,9 +1666,6 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 			if repl, ok := ome.variableReplacement[sym]; ok && repl.IsNthLocalVar() {
 				v[1] = repl
-			}
-			if ome.lambdaDepth == 0 && ome.beginDepth == 0 {
-				env.deleteOptimizerHint(sym)
 			}
 		}
 		if v[1].IsNthLocalVar() {
@@ -1684,7 +1680,14 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				rhs = stripped
 			}
 			if items, ok := scmerSlice(rhs); ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda") && returnType.Kind() != KindAny {
-				env.setOptimizerHint(definedSym, returnType.WithoutConst())
+				procReturn := returnType.WithoutConst()
+				v[2] = NewSlice([]Scmer{
+					NewSymbol("optimizer_proc_return"),
+					v[2],
+					NewInt(int64(procReturn.kind)),
+					NewInt(int64(procReturn.flags)),
+					NewInt(int64(procReturn.length)),
+				})
 			}
 		}
 	case headOk && (headSym == Symbol("match") || headSym == Symbol("match_mut")):

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -558,6 +558,37 @@ func copyTypeDescriptor(td *TypeDescriptor) *TypeDescriptor {
 	return &result
 }
 
+func cloneTypeDescriptor(td *TypeDescriptor, cloned map[*TypeDescriptor]*TypeDescriptor) *TypeDescriptor {
+	if td == nil {
+		return nil
+	}
+	if result, exists := cloned[td]; exists {
+		return result
+	}
+	result := *td
+	cloned[td] = &result
+	if len(td.Params) > 0 {
+		result.Params = make([]*TypeDescriptor, len(td.Params))
+		for i, param := range td.Params {
+			result.Params[i] = cloneTypeDescriptor(param, cloned)
+		}
+	}
+	result.Return = cloneTypeDescriptor(td.Return, cloned)
+	if len(td.Keys) > 0 {
+		result.Keys = make(map[string]*TypeDescriptor, len(td.Keys))
+		for key, child := range td.Keys {
+			result.Keys[key] = cloneTypeDescriptor(child, cloned)
+		}
+	}
+	result.Element = cloneTypeDescriptor(td.Element, cloned)
+	return &result
+}
+
+func immutableTypeInfo(info TypeInfo) TypeInfo {
+	info.Extra = cloneTypeDescriptor(info.Extra, make(map[*TypeDescriptor]*TypeDescriptor))
+	return info
+}
+
 func callbackParameterType(td *TypeDescriptor) *TypeDescriptor {
 	if td == nil {
 		return nil
@@ -1680,13 +1711,11 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				rhs = stripped
 			}
 			if items, ok := scmerSlice(rhs); ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda") && returnType.Kind() != KindAny {
-				procReturn := returnType.WithoutConst()
+				procReturn := immutableTypeInfo(returnType.WithoutConst())
 				v[2] = NewSlice([]Scmer{
 					NewSymbol("optimizer_proc_return"),
 					v[2],
-					NewInt(int64(procReturn.kind)),
-					NewInt(int64(procReturn.flags)),
-					NewInt(int64(procReturn.length)),
+					NewAny(optimizerProcReturnTemplate{Return: procReturn}),
 				})
 			}
 		}

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -18,6 +18,7 @@ package scm
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -72,8 +73,22 @@ func TestSchemeHelperReturnMetadataBelongsToBoundProc(t *testing.T) {
 		t.Fatalf("expected procedure binding, got %s", String(bound))
 	}
 	proc := bound.Proc()
-	if !proc.HasOptimizerReturn || proc.OptimizerReturn.Kind() != KindList || proc.OptimizerReturn.Length() != 2 {
-		t.Fatalf("return metadata is not attached to procedure: %#v", proc.OptimizerReturn)
+	if proc.OptimizerMeta == nil || proc.OptimizerMeta.Return.Kind() != KindList || proc.OptimizerMeta.Return.Length() != 2 {
+		t.Fatalf("return metadata is not attached to procedure: %#v", proc.OptimizerMeta)
+	}
+}
+
+func TestSchemeHelperReturnMetadataPreservesStructuredTypes(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define structured_pair (lambda (number text) (list (+ number 1) (concat text "x"))))`, env)
+
+	proc := env.FindRead(Symbol("structured_pair")).Vars[Symbol("structured_pair")].Proc()
+	if proc.OptimizerMeta == nil || proc.OptimizerMeta.Return.Extra == nil {
+		t.Fatal("structured return metadata is missing")
+	}
+	keys := proc.OptimizerMeta.Return.Extra.Keys
+	if keys["0"] == nil || keys["0"].Kind != "number" || keys["1"] == nil || keys["1"].Kind != "string" {
+		t.Fatalf("structured return metadata lost element types: %#v", keys)
 	}
 }
 
@@ -88,18 +103,65 @@ func TestConcurrentSchemeReturnInferenceDoesNotMutateEnvironment(t *testing.T) {
 			NewSlice([]Scmer{NewSymbol("list"), NewSymbol("a"), NewSymbol("b")}),
 		}),
 	})
+	callExpr := NewSlice([]Scmer{
+		NewSymbol("append"),
+		NewSlice([]Scmer{NewSymbol("concurrent_pair"), NewInt(1), NewInt(2)}),
+		NewInt(3),
+	})
 
+	errors := make(chan error, 16)
 	var wg sync.WaitGroup
 	for worker := 0; worker < 16; worker++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			workerEnv := &Env{Vars: make(Vars), Outer: env}
 			for iteration := 0; iteration < 100; iteration++ {
-				Optimize(CloneOptimizerExpression(expr), env, nil)
+				optimized := Optimize(CloneOptimizerExpression(expr), env, nil)
+				Eval(optimized, workerEnv)
+				proc := workerEnv.Vars[Symbol("concurrent_pair")].Proc()
+				if proc == nil || proc.OptimizerMeta == nil || proc.OptimizerMeta.Return.Length() != 2 {
+					errors <- fmt.Errorf("iteration %d lost return metadata", iteration)
+					return
+				}
+				call := Optimize(CloneOptimizerExpression(callExpr), workerEnv, nil)
+				if !strings.Contains(String(call), "append_mut") {
+					errors <- fmt.Errorf("iteration %d lost transfer rewrite: %s", iteration, String(call))
+					return
+				}
 			}
 		}()
 	}
 	wg.Wait()
+	close(errors)
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func TestSchemeHelperReturnMetadataSurvivesReoptimizationAndProcCopies(t *testing.T) {
+	env := newOptimizerTestEnv()
+	definition := optimizeTestSource(t, env, `(define copied_pair (lambda () (list 1 2)))`)
+	definition = Optimize(CloneOptimizerExpression(definition), env, nil)
+	Eval(definition, env)
+
+	bound := env.Vars[Symbol("copied_pair")]
+	closed := CloseProcedure(bound)
+	if bound.Proc().OptimizerMeta == nil || closed.Proc().OptimizerMeta != bound.Proc().OptimizerMeta {
+		t.Fatal("procedure copy did not preserve optimizer metadata identity")
+	}
+}
+
+func TestProcComputeSizeIncludesOptimizerMetadata(t *testing.T) {
+	plain := NewProcStruct(Proc{Params: NewSlice(nil), Body: NewNil()})
+	typed := *plain.Proc()
+	typed.OptimizerMeta = &ProcOptimizerMeta{Return: TypeInfoFromTD(&TypeDescriptor{
+		Kind: "list",
+		Keys: map[string]*TypeDescriptor{"0": {Kind: "int"}},
+	})}
+	if ComputeSize(NewProcStruct(typed)) <= ComputeSize(plain) {
+		t.Fatal("procedure size does not include optimizer metadata")
+	}
 }
 
 func TestSchemeHelperReturnHintFollowsEnvironmentChain(t *testing.T) {

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -19,6 +19,7 @@ package scm
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -60,6 +61,45 @@ func TestSchemeHelperReturnLengthPropagates(t *testing.T) {
 	if !optimized.IsInt() || optimized.Int() != 2 {
 		t.Fatalf("expected exact helper return length to fold count, got %s", serializedTestExpr(t, env, optimized))
 	}
+}
+
+func TestSchemeHelperReturnMetadataBelongsToBoundProc(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("optimizer return test", `(define proc_owned_pair (lambda () (list 1 2)))`, env)
+
+	bound := env.FindRead(Symbol("proc_owned_pair")).Vars[Symbol("proc_owned_pair")]
+	if bound.GetTag() != tagProc {
+		t.Fatalf("expected procedure binding, got %s", String(bound))
+	}
+	proc := bound.Proc()
+	if !proc.HasOptimizerReturn || proc.OptimizerReturn.Kind() != KindList || proc.OptimizerReturn.Length() != 2 {
+		t.Fatalf("return metadata is not attached to procedure: %#v", proc.OptimizerReturn)
+	}
+}
+
+func TestConcurrentSchemeReturnInferenceDoesNotMutateEnvironment(t *testing.T) {
+	env := newOptimizerTestEnv()
+	expr := NewSlice([]Scmer{
+		NewSymbol("define"),
+		NewSymbol("concurrent_pair"),
+		NewSlice([]Scmer{
+			NewSymbol("lambda"),
+			NewSlice([]Scmer{NewSymbol("a"), NewSymbol("b")}),
+			NewSlice([]Scmer{NewSymbol("list"), NewSymbol("a"), NewSymbol("b")}),
+		}),
+	})
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 16; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iteration := 0; iteration < 100; iteration++ {
+				Optimize(CloneOptimizerExpression(expr), env, nil)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestSchemeHelperReturnHintFollowsEnvironmentChain(t *testing.T) {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -287,6 +287,22 @@ restart:
 					return NewScmParser(NewParser(list[1], list[2], NewNil(), en, true))
 				}
 				return NewScmParser(NewParser(list[1], NewNil(), NewNil(), en, false))
+			case "optimizer_proc_return":
+				if len(list) != 5 {
+					panic("optimizer_proc_return expects procedure, kind, flags and length")
+				}
+				value := Eval(list[1], en)
+				if value.GetTag() != tagProc {
+					return value
+				}
+				proc := *value.Proc()
+				proc.OptimizerReturn = TypeInfo{
+					kind:   uint8(ToInt(list[2])),
+					flags:  uint8(ToInt(list[3])),
+					length: int(ToInt(list[4])),
+				}
+				proc.HasOptimizerReturn = true
+				return NewProcStruct(proc)
 			case "lambda":
 				params := list[1]
 				if params.IsSourceInfo() {
@@ -804,6 +820,12 @@ type Proc struct {
 	// original body remains attached so storage scan callbacks can later be
 	// specialized and recompiled against concrete column/storage types.
 	Compiled *JITEntryPoint
+	// OptimizerReturn belongs to this concrete procedure value. Keeping the
+	// metadata on the Proc makes lexical shadowing and redefinition follow the
+	// actual binding and avoids a mutable, process-wide optimizer side table.
+	// Keep optimizer-only fields after the runtime/JIT-facing Proc layout.
+	OptimizerReturn    TypeInfo
+	HasOptimizerReturn bool
 }
 
 // CloseProcedure snapshots explicit captures of a procedure without retaining
@@ -906,11 +928,10 @@ type NthLocalVar uint8 // equals to (var i)
 
 type Vars map[Symbol]Scmer
 type Env struct {
-	Vars           Vars
-	VarsNumbered   []Scmer // <- for the optimizer
-	Outer          *Env
-	Nodefine       bool // define will write to Outer
-	optimizerHints map[Symbol]TypeInfo
+	Vars         Vars
+	VarsNumbered []Scmer // <- for the optimizer
+	Outer        *Env
+	Nodefine     bool // define will write to Outer
 }
 
 func (e *Env) definitionTarget() *Env {
@@ -925,30 +946,15 @@ func (e *Env) definitionTarget() *Env {
 
 func (e *Env) optimizerProcHint(s Symbol) (TypeInfo, bool) {
 	binding := e.FindRead(s)
-	if binding == nil || binding.optimizerHints == nil {
+	if binding == nil {
 		return tiZero, false
 	}
 	bound, exists := binding.Vars[s]
 	if !exists || bound.GetTag() != tagProc {
 		return tiZero, false
 	}
-	ti, ok := binding.optimizerHints[s]
-	return ti, ok
-}
-
-func (e *Env) setOptimizerHint(s Symbol, ti TypeInfo) {
-	target := e.definitionTarget()
-	if target.optimizerHints == nil {
-		target.optimizerHints = make(map[Symbol]TypeInfo)
-	}
-	target.optimizerHints[s] = ti
-}
-
-func (e *Env) deleteOptimizerHint(s Symbol) {
-	target := e.definitionTarget()
-	if target.optimizerHints != nil {
-		delete(target.optimizerHints, s)
-	}
+	proc := bound.Proc()
+	return proc.OptimizerReturn, proc.HasOptimizerReturn
 }
 
 func (e *Env) FindRead(s Symbol) *Env {
@@ -1005,7 +1011,6 @@ func init() {
 		nil,
 		nil,
 		false,
-		nil,
 	}
 
 	// system

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -288,20 +288,26 @@ restart:
 				}
 				return NewScmParser(NewParser(list[1], NewNil(), NewNil(), en, false))
 			case "optimizer_proc_return":
-				if len(list) != 5 {
-					panic("optimizer_proc_return expects procedure, kind, flags and length")
+				if len(list) != 3 {
+					panic("optimizer_proc_return expects procedure and return metadata")
 				}
 				value := Eval(list[1], en)
 				if value.GetTag() != tagProc {
 					return value
 				}
-				proc := *value.Proc()
-				proc.OptimizerReturn = TypeInfo{
-					kind:   uint8(ToInt(list[2])),
-					flags:  uint8(ToInt(list[3])),
-					length: int(ToInt(list[4])),
+				metadataValue := Eval(list[2], en)
+				if metadataValue.GetTag() != tagAny {
+					panic("optimizer_proc_return expects internal return metadata")
 				}
-				proc.HasOptimizerReturn = true
+				metadata, ok := metadataValue.Any().(optimizerProcReturnTemplate)
+				if !ok {
+					panic("optimizer_proc_return received invalid return metadata")
+				}
+				proc := *value.Proc()
+				// Allocate one metadata identity per evaluated lambda. Proc value
+				// copies deliberately share it; independently evaluated lambdas do
+				// not share future specialization state.
+				proc.OptimizerMeta = &ProcOptimizerMeta{Return: metadata.Return}
 				return NewProcStruct(proc)
 			case "lambda":
 				params := list[1]
@@ -820,12 +826,25 @@ type Proc struct {
 	// original body remains attached so storage scan callbacks can later be
 	// specialized and recompiled against concrete column/storage types.
 	Compiled *JITEntryPoint
-	// OptimizerReturn belongs to this concrete procedure value. Keeping the
-	// metadata on the Proc makes lexical shadowing and redefinition follow the
-	// actual binding and avoids a mutable, process-wide optimizer side table.
+	// OptimizerMeta belongs to this concrete procedure identity. Proc values are
+	// copied by CloseProcedure and the JIT, so optimizer state must remain behind
+	// a pointer: copies share one identity without copying future locks or
+	// specialization tables. A fresh lambda evaluation allocates a fresh meta.
 	// Keep optimizer-only fields after the runtime/JIT-facing Proc layout.
-	OptimizerReturn    TypeInfo
-	HasOptimizerReturn bool
+	OptimizerMeta *ProcOptimizerMeta
+}
+
+// ProcOptimizerMeta is immutable today. Future specialization variants belong
+// here and must publish immutable snapshots for lock-free reads; only a miss for
+// the same procedure and specialization key may coordinate compilation.
+type ProcOptimizerMeta struct {
+	Return TypeInfo
+}
+
+// optimizerProcReturnTemplate is embedded in optimizer-generated ASTs. Eval
+// turns the immutable template into a new ProcOptimizerMeta identity.
+type optimizerProcReturnTemplate struct {
+	Return TypeInfo
 }
 
 // CloseProcedure snapshots explicit captures of a procedure without retaining
@@ -954,7 +973,10 @@ func (e *Env) optimizerProcHint(s Symbol) (TypeInfo, bool) {
 		return tiZero, false
 	}
 	proc := bound.Proc()
-	return proc.OptimizerReturn, proc.HasOptimizerReturn
+	if proc.OptimizerMeta == nil {
+		return tiZero, false
+	}
+	return proc.OptimizerMeta.Return, true
 }
 
 func (e *Env) FindRead(s Symbol) *Env {
@@ -2532,13 +2554,15 @@ func ComputeSize(v Scmer) uint {
 		if p == nil {
 			return base
 		}
-		// Proc struct: Params(16) + Body(16) + En(8) + NumVars(8) plus
-		// NumberedOnly padding and the optional compiled-entry pointer.
-		// Params and Body are inline Scmer fields — their slots are covered by
-		// the recursive ComputeSize base (same pattern as slice backing array).
-		// Only count non-Scmer fields here; avoid recursively recounting the
-		// source Proc retained by the compiled entry point.
-		sz := base + goAllocOverhead + 24 + ComputeSize(p.Params) + ComputeSize(p.Body)
+		// Params and Body are inline Scmer fields. Their slots are covered by
+		// recursive ComputeSize calls, so count the remaining Proc layout here.
+		// unsafe.Sizeof keeps this accounting in sync when Proc grows.
+		procFields := uint(unsafe.Sizeof(*p)) - 2*uint(unsafe.Sizeof(Scmer{}))
+		sz := base + goAllocOverhead + procFields + ComputeSize(p.Params) + ComputeSize(p.Body)
+		if p.OptimizerMeta != nil {
+			sz += goAllocOverhead + uint(unsafe.Sizeof(*p.OptimizerMeta))
+			sz += typeDescriptorRetainedSize(p.OptimizerMeta.Return.Extra, make(map[*TypeDescriptor]struct{}))
+		}
 		if p.Compiled != nil {
 			sz += goAllocOverhead + align8(uint(p.Compiled.CodeLen))
 		}
@@ -2606,6 +2630,35 @@ func ComputeSize(v Scmer) uint {
 		fmt.Println(fmt.Sprintf("warning: unknown tag %d", v.GetTag()))
 		return base
 	}
+}
+
+func typeDescriptorRetainedSize(td *TypeDescriptor, visited map[*TypeDescriptor]struct{}) uint {
+	if td == nil {
+		return 0
+	}
+	if _, exists := visited[td]; exists {
+		return 0
+	}
+	visited[td] = struct{}{}
+
+	sz := goAllocOverhead + uint(unsafe.Sizeof(*td))
+	sz += align8(uint(len(td.Kind) + len(td.ParamName) + len(td.ParamDesc)))
+	if len(td.Params) > 0 {
+		sz += goAllocOverhead + align8(uint(len(td.Params))*uint(unsafe.Sizeof(td)))
+		for _, param := range td.Params {
+			sz += typeDescriptorRetainedSize(param, visited)
+		}
+	}
+	if len(td.Keys) > 0 {
+		sz += goAllocOverhead
+		for key, child := range td.Keys {
+			sz += align8(uint(len(key)))
+			sz += typeDescriptorRetainedSize(child, visited)
+		}
+	}
+	sz += typeDescriptorRetainedSize(td.Return, visited)
+	sz += typeDescriptorRetainedSize(td.Element, visited)
+	return sz
 }
 
 func computeGoPayload(val any) uint {

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -421,7 +421,7 @@ test_cases:
         - "chosen driver_filter_join_probe"
 
   - name: "selective driver filter probes membership only on its subset"
-    max_time: 1.25
+    max_time: 1
     sql: |
       SELECT COUNT(*) AS total
       FROM bqm_document d

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -421,7 +421,7 @@ test_cases:
         - "chosen driver_filter_join_probe"
 
   - name: "selective driver filter probes membership only on its subset"
-    max_time: 1
+    max_time: 1.25
     sql: |
       SELECT COUNT(*) AS total
       FROM bqm_document d

--- a/tests/planner/subqueries/derived-table-limit-scalar.yaml
+++ b/tests/planner/subqueries/derived-table-limit-scalar.yaml
@@ -603,6 +603,67 @@ test_cases:
           "ok"
           (error "multi aggregate stage output guessed a column")))
 
+  - name: "Boolean aggregate renames propagate through nested stage outputs"
+    scm: |
+      (begin
+        (define y66_fold_child_ag (list
+          (list (quote and) true false) (quote max) false))
+        (define y66_fold_child (make_group_stage
+          "fold-child"
+          (list "child-row" "memcp-tests" "dtl_join_ref" false nil)
+          '() '(1) (list y66_fold_child_ag) nil '() '() nil nil '()))
+        (define y66_fold_child_col (aggregate_col_name_using
+          (gs_input y66_fold_child) y66_fold_child_ag))
+        (define y66_fold_middle_ag (list
+          (list (quote get_column) "fold-child-output" false y66_fold_child_col false)
+          (quote max) false))
+        (define y66_fold_middle (make_group_stage
+          "fold-middle"
+          (make_query_block "memcp-tests"
+            (list (list "fold-child-output" "memcp-tests"
+              (make_stage_output_relation "fold-child") true true))
+            '() true nil nil nil nil nil '() '() '())
+          '() '(1) (list y66_fold_middle_ag) nil '() '() nil nil '()))
+        (define y66_fold_middle_col (aggregate_col_name_using
+          (gs_input y66_fold_middle) y66_fold_middle_ag))
+        (define y66_fold_top_ag (list
+          (list (quote get_column) "fold-middle-output" false y66_fold_middle_col false)
+          (quote max) false))
+        (define y66_fold_top (make_group_stage
+          "fold-top"
+          (make_query_block "memcp-tests"
+            (list (list "fold-middle-output" "memcp-tests"
+              (make_stage_output_relation "fold-middle") true true))
+            '() true nil nil nil nil nil '() '() '())
+          '() '(1) (list y66_fold_top_ag) nil '() '() nil nil '()))
+        (define y66_fold_top_col (aggregate_col_name_using
+          (gs_input y66_fold_top) y66_fold_top_ag))
+        (define y66_fold_root (make_query_block "memcp-tests"
+          (list (list "fold-top-output" "memcp-tests"
+            (make_stage_output_relation "fold-top") true true))
+          (list "value" (list (quote get_column)
+            "fold-top-output" false y66_fold_top_col false))
+          true nil nil nil nil nil '()
+          (list y66_fold_child y66_fold_middle y66_fold_top) '()))
+        (define y66_folded (fold_boolean_tautologies_ir
+          (make_ir (quote select) y66_fold_root
+            (qb_stages y66_fold_root) nil (quote rows))))
+        (define y66_folded_stages (ir_stages y66_folded))
+        (define y66_folded_middle (stage_by_id y66_folded_stages "fold-middle"))
+        (define y66_folded_top (stage_by_id y66_folded_stages "fold-top"))
+        (define y66_final_middle_col (aggregate_col_name_using
+          (gs_input y66_folded_middle) (car (gs_aggregates y66_folded_middle))))
+        (define y66_final_top_col (aggregate_col_name_using
+          (gs_input y66_folded_top) (car (gs_aggregates y66_folded_top))))
+        (define y66_top_input_col (nth
+          (car (car (gs_aggregates y66_folded_top))) 3))
+        (define y66_root_output_col (nth (nth (qb_fields (ir_root y66_folded)) 1) 3))
+        (if (and
+          (equal? y66_top_input_col y66_final_middle_col)
+          (equal? y66_root_output_col y66_final_top_col))
+          "ok"
+          (error "nested boolean folding kept a stale stage-output column")))
+
   - name: "Repeated global EXISTS in derived wrapper stays scalar"
     sql: |
       SELECT t.* FROM (

--- a/tests/planner/subqueries/scalar-subselect-patterns.yaml
+++ b/tests/planner/subqueries/scalar-subselect-patterns.yaml
@@ -259,6 +259,20 @@ test_cases:
     expect:
       rows: 0
 
+  - name: "COALESCE true preserves false from an existing scalar row"
+    sql: |
+      SELECT child.ID
+      FROM sq_cat AS child
+      WHERE child.ID = 1
+        AND COALESCE(
+          (SELECT FALSE
+           FROM sq_cat AS present
+           WHERE present.ID = child.ID
+           LIMIT 1),
+          TRUE)
+    expect:
+      rows: 0
+
   - name: "COALESCE true preserves nullable scalar lookup keys"
     sql: |
       SELECT child.ID

--- a/tests/planner/subqueries/scalar-subselect-patterns.yaml
+++ b/tests/planner/subqueries/scalar-subselect-patterns.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+
 metadata:
   version: "1.0"
   description: "Scalar subselect patterns: derived tables, CASE WHEN, badge queries, permission checks"
@@ -226,6 +228,54 @@ test_cases:
       rows: 1
       data:
         - color: invoice
+
+  - name: "COALESCE true preserves an empty correlated scalar domain in truth context"
+    sql: |
+      SELECT sq_doc.ID
+      FROM sq_doc
+      WHERE sq_doc.ID = 1
+        AND COALESCE(
+          (SELECT TRUE
+           FROM sq_cat
+           WHERE sq_cat.ID = sq_doc.boxid + 1000
+           LIMIT 1),
+          TRUE)
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+
+  - name: "COALESCE false rejects an empty correlated scalar domain in truth context"
+    sql: |
+      SELECT sq_doc.ID
+      FROM sq_doc
+      WHERE sq_doc.ID = 1
+        AND COALESCE(
+          (SELECT TRUE
+           FROM sq_cat
+           WHERE sq_cat.ID = sq_doc.boxid + 1000
+           LIMIT 1),
+          FALSE)
+    expect:
+      rows: 0
+
+  - name: "COALESCE true preserves nullable scalar lookup keys"
+    sql: |
+      SELECT child.ID
+      FROM sq_cat AS child
+      WHERE COALESCE(
+        (SELECT TRUE
+         FROM sq_cat AS parent
+         WHERE parent.ID = child.parent
+         LIMIT 1),
+        TRUE)
+      ORDER BY child.ID
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+        - ID: 2
+        - ID: 3
 
   - name: "NOT IS NULL wrapper around scalar subselect"
     sql: |


### PR DESCRIPTION
## Summary

- attach complete inferred Scheme return metadata to the concrete procedure identity instead of mutating a shared environment map
- keep optimizer metadata behind a Proc-local pointer so CloseProcedure and JIT value copies share identity without copying future locks or specialization caches
- preserve nested TypeInfo details such as fixed-list keys, element types, function parameters, return types, and side-effect facts
- keep Proc at 64 bytes on 64-bit targets by storing its bounded numbered-variable count as int32
- trust the finalized Proc.NumVars metadata when adapting optimized map/filter/reduce callbacks, avoiding a full callback-body traversal for every adapter
- account for Proc optimizer metadata and retained type descriptors in ComputeSize
- prevent RecSet lowering from crossing COALESCE(..., TRUE), where an empty correlated scalar domain must remain distinguishable from a matching false row
- remove the unused global TypeDescriptor.Variants placeholder

## Design

This PR establishes the ownership boundary needed for later parameter-specialized procedure variants without implementing the variant compiler prematurely.

Each evaluated lambda receives a fresh ProcOptimizerMeta identity. Copies of that concrete Proc share the pointer. Future variants should publish immutable snapshots for lock-free reads and coordinate only an identical Proc plus specialization-key miss; unrelated procedures and keys must compile independently.

Optimized lambdas already finalize NumVars after introducing numbered temporaries. OptimizeProcToSerialFunction therefore consumes that metadata directly instead of recursively rediscovering the highest numbered slot whenever queryplan Scheme code passes a callback to map, filter, reduce, or another list primitive. Direct Proc constructors remain responsible for setting NumVars when their bodies contain NthLocalVar values.

## Compile-time A/B evidence

Compared `master` at `4e3e86efa` with this branch at `33c42c948` using separate binaries and MemCP processes on the same host. For every workload, both processes received identical schema setup and identical `EXPLAIN COMPILE` SQL. After two warmups per process, 25 measured runs per revision were interleaved in randomized order. Values below are medians; the parenthesized value is the median absolute deviation (MAD).

| Complex query workload | `compile_total_ns` master | `compile_total_ns` PR | Delta | `planner_total_ns` master | `planner_total_ns` PR | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Selective nested UNION/EXISTS | 375.179 ms (7.157) | 353.894 ms (4.556) | **-5.67%** | 341.770 ms (6.629) | 324.003 ms (5.557) | **-5.20%** |
| 48 distinct scalar probes | 539.159 ms (6.128) | 513.787 ms (4.658) | **-4.71%** | 497.762 ms (4.442) | 473.501 ms (3.835) | **-4.87%** |
| 256 dependent metrics | 630.594 ms (12.622) | 567.905 ms (13.647) | **-9.94%** | 206.278 ms (6.976) | 189.147 ms (8.993) | **-8.31%** |

The external HTTP wall-time medians moved in the same direction: -5.55%, -4.67%, and -9.46%, respectively. CPU profiles before the change attributed about 2 seconds of a 58-second sample window to repeated `requiredNumberedSlots` callback-body walks; the final A/B result confirms that removing those walks improves complete complex-query compilation rather than only a microbenchmark.

## Validation

- complete normal-parallel pre-commit suite: pass
- `go test ./scm -count=1`
- `go test -race ./scm -run TestConcurrentSchemeReturnInferenceDoesNotMutateEnvironment -count=1`
- scalar subselect patterns: 25/25
- compound correlated boolean/RecSet suite: 20/20
- selective membership scaling suite: 13/13
- `git diff --check`

The structured metadata test verifies per-position number/string return types, not only the top-level kind and length. The concurrency test evaluates every optimized definition in an isolated environment and verifies both Proc metadata and the expected `append_mut` consumer rewrite.

`tools/lint_scm.py --check` still reports only the repository baseline negative-depth warnings; none of the reported lines were changed by this update.
