### PR TITLE
Remove remaining dead query planner code

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -337,7 +337,6 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 		reducefn
 		reduceinit)))
 
-(define os_id (lambda (node) (nth node 1)))
 (define os_source (lambda (node) (nth node 2)))
 (define os_column (lambda (node) (nth node 3)))
 (define os_sortcols (lambda (node) (nth node 4)))
@@ -406,7 +405,6 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 		context
 		(coalesceNil return_mode (quote rows)))))
 
-(define neumann_ir? (lambda (ir) (equal? (logical_op ir) (quote neumann-ir))))
 (define ir_kind (lambda (ir) (nth ir 1)))
 (define ir_root (lambda (ir) (nth ir 2)))
 (define ir_stages (lambda (ir) (nth ir 3)))
@@ -1216,13 +1214,8 @@ then matched without repeated deep comparisons. */
 (define btw2025_info_handle (lambda (info) (nth info 1)))
 (define btw2025_info_parent (lambda (info) (nth info 2)))
 (define btw2025_info_ancestors (lambda (info) (nth info 3)))
-(define btw2025_info_outer_refs (lambda (info) (nth info 4)))
-(define btw2025_info_domain (lambda (info) (nth info 5)))
 (define btw2025_info_accessing (lambda (info) (nth info 6)))
 (define btw2025_info_accessing_after_simple (lambda (info) (nth info 7)))
-(define btw2025_info_cclasses (lambda (info) (nth info 8)))
-(define btw2025_info_repr (lambda (info) (nth info 9)))
-
 (define group_keys_for_correlations (lambda (inner_default pairs explicit_group_keys)
 	(begin
 		(define corr_keys (correlation_inner_keys inner_default pairs))
@@ -1454,9 +1447,6 @@ physical membership probe. */
 (define source_is_stage_output? (lambda (src)
 	(stage_output_relation? (source_relation src))))
 
-(define source_is_not_stage_output? (lambda (src)
-	(not (source_is_stage_output? src))))
-
 (define scalar_source_shape_supported? (lambda (sources)
 	(match (coalesceNil sources '())
 		(cons base helpers)
@@ -1626,11 +1616,6 @@ physical membership probe. */
 			(or found (expr_refs_one_of_aliases? item aliases)))
 			false)
 		_ false)))
-
-(define query_block_base_aliases (lambda (block)
-	(map
-		(filter (qb_sources block) (lambda (src) (not (source_is_stage_output? src))))
-		source_alias)))
 
 (define scalar_first_query_stage_output_key? (lambda (stage)
 	(and (query_block? (gs_input stage))
@@ -4198,9 +4183,6 @@ carrier selection remains a later, per-stage cost decision. */
 				(nth tail 3)))
 		_ (list '() '() '() resolved))))
 
-(define btw2025_decorrelate_fields_with_stages (lambda (fields ctx)
-	(btw2025_decorrelate_fields_with_stages_using fields ctx '())))
-
 (define btw2025_decorrelate_order_with_stages_using (lambda (order_items ctx resolved)
 	(match (coalesceNil order_items '())
 		(cons item rest) (begin
@@ -4980,21 +4962,6 @@ source alias is the stable identity consumed by all later planner phases. */
 	(build_and_terms (merge (list
 		(split_and_terms (coalesceNil seed true))
 		(merge (map (coalesceNil terms '()) (lambda (term) (split_and_terms (coalesceNil term true))))))))))
-
-(define untangle_source (lambda (src ctx)
-	(begin
-		(define relation (normalize_query_ast (source_relation src)))
-		(if (or (query_block? relation) (union_block? relation))
-			(neumann_fail "untangle_query" "FROM-subquery flattening must be implemented inside query-block, not left as source")
-			(list
-				(source_alias src)
-				(source_schema src)
-				relation
-				(source_outer? src)
-				(untangle_expr (source_join_expr src) ctx))))))
-
-(define untangle_sources (lambda (sources ctx)
-	(map (coalesceNil sources '()) (lambda (src) (untangle_source src ctx)))))
 
 (define untangle_source_join_expr_with_stages (lambda (src outer_sources ctx)
 	(match (source_join_expr src)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -757,9 +757,6 @@ which selected a cached join plan without rerunning join enumeration. */
 			(list nil 0)
 			(join_order_dphyp_connected nodes aliases predicates (car connected))))))
 
-(define join_order_dphyp (lambda (nodes aliases predicates)
-	(join_order_dphyp_budgeted nodes aliases predicates (join_order_dp_state_budget))))
-
 (define join_order_alias_position (lambda (aliases alias)
 	(reduce (produceN (count aliases)) (lambda (found i)
 		(if (not (nil? found)) found
@@ -1510,81 +1507,6 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(join_optimizer_metadata_costed_predicates
 					all_sources default_alias graph aliases))))))
 
-(define join_optimizer_ref_matches? (lambda (ref src col)
-	(and (not (nil? ref))
-		(and (equal? (source_alias (car ref)) (source_alias src))
-			(equal? (cadr ref) col)))))
-
-(define join_optimizer_key_bound_to_driver? (lambda (sources default_alias graph driver lookup key_col)
-	(reduce (join_optimizer_predicates graph) (lambda (found entry)
-		(or found
-			(match (qassoc_get entry (quote predicate) true)
-				'(op left right) (if (or
-					(equal? op (quote equal?))
-					(equal? op (quote equal??))
-					(equal? op (quote =)))
-					(begin
-						(define left_ref (join_optimizer_column_ref sources default_alias left))
-						(define right_ref (join_optimizer_column_ref sources default_alias right))
-						(or
-							(and (join_optimizer_ref_matches? left_ref lookup key_col)
-								(and (not (nil? right_ref))
-									(equal? (source_alias (car right_ref)) (source_alias driver))))
-							(and (join_optimizer_ref_matches? right_ref lookup key_col)
-								(and (not (nil? left_ref))
-									(equal? (source_alias (car left_ref)) (source_alias driver))))))
-					false)
-				_ false)))
-		false)))
-
-(define join_optimizer_unique_lookup_from_driver? (lambda (sources default_alias graph driver lookup)
-	(begin
-		(define key_sets (source_unique_key_sets lookup))
-		(reduce key_sets (lambda (unique key_cols)
-			(or unique
-				(and (not (empty_list? key_cols))
-					(reduce key_cols (lambda (complete key_col)
-						(and complete (join_optimizer_key_bound_to_driver?
-							sources default_alias graph driver lookup key_col)))
-						true))))
-			false))))
-
-(define join_optimizer_order_expr_available_from_driver? (lambda (sources default_alias graph driver expr)
-	(begin
-		(define aliases (join_hypergraph_expr_aliases default_alias (source_aliases sources) expr))
-		(reduce aliases (lambda (available alias)
-			(and available
-				(or (equal? alias (source_alias driver))
-					(begin
-						(define lookup (join_optimizer_source_by_alias sources alias))
-						(and (not (nil? lookup))
-							(join_optimizer_unique_lookup_from_driver?
-								sources default_alias graph driver lookup))))))
-			true))))
-
-(define join_optimizer_bounded_order_driver? (lambda (sources segment default_alias graph driver order_items)
-	(and
-		(reduce segment (lambda (safe src)
-			(and safe
-				(or (equal? (source_alias src) (source_alias driver))
-					(join_optimizer_unique_lookup_from_driver?
-						sources default_alias graph driver src))))
-			true)
-		(reduce (order_exprs order_items) (lambda (available expr)
-			(and available (join_optimizer_order_expr_available_from_driver?
-				sources default_alias graph driver expr)))
-			true))))
-
-(define join_optimizer_bounded_order_driver (lambda (sources segment default_alias graph order_items)
-	(reduce segment (lambda (found candidate)
-		(if (not (nil? found))
-			found
-			(if (join_optimizer_bounded_order_driver?
-				sources segment default_alias graph candidate order_items)
-				candidate
-				nil)))
-		nil)))
-
 (define join_optimizer_order_alias_prefix_loop (lambda (sources segment_aliases default_alias exprs prefix)
 	(match exprs
 		(cons expr rest)
@@ -1784,14 +1706,6 @@ guarded by the values observed while compiling the cached plan. */
 			(planner_guarded_choice broad
 				(list (quote broad_like_pattern?) pattern))
 			broad))))
-
-(define planner_record_session_value_guards (lambda (node)
-	(reduce (query_expr_session_reads node) (lambda (_ expr)
-		(begin
-			(define value (planner_literal_value expr))
-			(planner_record_guard_condition
-				(list (quote equal?) expr
-					(if (list? value) (list (quote quote) value) value))))) nil)))
 
 (define expr_contains_broad_text_match? (lambda (expr)
 	(match expr
@@ -2788,9 +2702,6 @@ physical alternative. */
 				projection_rows 0.65)
 			base_cost))))
 
-(define membership_cached_driver_probe_cost (lambda (driver_rows)
-	(planner_cost 0 0 (* driver_rows 54) 0 0 0 0 0 driver_rows 0.5)))
-
 (define membership_driver_probe_cost (lambda (driver_rows probe_branches)
 	(begin
 		(define probes (* driver_rows probe_branches))
@@ -3393,11 +3304,6 @@ those stages remain excluded rather than crashing during preparation. */
 				broad_by_count
 				(equal? (qassoc_get facts (quote membership_selectivity_class) nil) (quote broad)))))))
 
-(define broad_driver_order_membership_probe? (lambda (facts)
-	(and
-		(driver_order_membership_strategy? facts)
-		(membership_estimate_broad? facts))))
-
 (define ordered_driver_membership_keyset? (lambda (facts)
 	(and
 		(qassoc_get facts (quote membership_driver_alternative) false)
@@ -3840,9 +3746,6 @@ boolean probe, matched against the specific logical output alias. */
 								(qb_facts block))
 							facts))))))))
 
-(define reorder_query_block_with_candidate_strategy (lambda (block)
-	(reorder_query_block_with_candidate_strategy_using (qb_stages block) block)))
-
 (define join_reorder_node_using (lambda (stage_catalog node)
 	(if (query_block? node)
 		(reorder_query_block_with_candidate_strategy_using stage_catalog node)
@@ -3855,9 +3758,6 @@ boolean probe, matched against the specific logical output alias. */
 				(union_offset node)
 				(union_facts node))
 			node))))
-
-(define join_reorder_node (lambda (node)
-	(join_reorder_node_using (if (query_block? node) (qb_stages node) '()) node)))
 
 (define join_reorder_stage_using (lambda (stage_catalog stage)
 	(if (group_stage? stage)
@@ -3875,9 +3775,6 @@ boolean probe, matched against the specific logical output alias. */
 				(gs_offset stage)
 				(gs_facts stage)))
 		stage)))
-
-(define join_reorder_stage (lambda (stage)
-	(join_reorder_stage_using (list stage) stage)))
 
 (define query_block_without_logical_stages (lambda (block)
 	(make_query_block

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1989,12 +1989,6 @@ is still available. Explicit COLLATE and user callbacks pass through intact. */
 			_ false)))
 		true)))
 
-(define direct_order_expr_for_source? (lambda (src expr)
-	(match expr
-		((symbol get_column) tblvar tbl_ignorecase _col _col_ignorecase) (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
-		((quote get_column) tblvar tbl_ignorecase _col _col_ignorecase) (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
-		_ false)))
-
 (define lower_grouped_scalar_top_expr (lambda (stage)
 	(begin
 		(define alias (group_stage_input_alias stage))
@@ -2676,22 +2670,6 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 (define count_distinct_combine (lambda ()
 	(count_distinct_reduce)))
 
-(define count_distinct_count_reduce (lambda ()
-	(list (quote lambda) (list (quote a) (quote b))
-		(list (quote count)
-			(list (quote begin)
-				(list (quote define) (quote aa) (list (quote if)
-					(list (quote list?) (quote a))
-					(quote a)
-					(list (quote if) (list (quote nil?) (quote a)) (list (quote list)) (list (quote cons) (quote a) (list (quote list))))))
-				(list (quote define) (quote bb) (list (quote if)
-					(list (quote list?) (quote b))
-					(quote b)
-					(list (quote if) (list (quote nil?) (quote b)) (list (quote list)) (list (quote cons) (quote b) (list (quote list))))))
-				(list (quote merge_unique)
-					(list (quote cons) (quote aa)
-						(list (quote cons) (quote bb) (list (quote list))))))))))
-
 (define count_distinct_descriptor (lambda (expr)
 	(list expr (count_distinct_reduce) (list (quote list)))))
 
@@ -2704,11 +2682,6 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 	(if (count_distinct_descriptor? ag)
 		(count_distinct_combine)
 		nil)))
-
-(define query_aggregate_shard_combine (lambda (ag)
-	(if (count_distinct_descriptor? ag)
-		(count_distinct_count_reduce)
-		(aggregate_shard_combine ag))))
 
 (define aggregate_map_value_expr (lambda (ag expr)
 	(if (count_distinct_descriptor? ag)
@@ -3930,42 +3903,6 @@ ever-larger subtrees. */
 			(extract_assoc resolved_fields (lambda (_title expr) expr))))
 		(direct_group_result_assoc_expr_indexed alias keys key_names ags key_index items resolved_fields))))
 
-(define direct_group_agg_index (lambda (ags expr)
-	(reduce (produceN (count ags)) (lambda (found i)
-		(if (not (nil? found))
-			found
-			(if (equal? expr (nth ags i)) i nil)))
-		nil)))
-
-(define direct_group_order_column_indexed (lambda (alias keys key_names ags key_index expr resolved)
-	(begin
-		(define key_idx (lookup_group_key_index key_index resolved))
-		(if (not (nil? key_idx))
-			(nth key_names key_idx)
-			(match expr
-				((symbol aggregate) agg_expr agg_reduce agg_neutral)
-				(begin
-					(define agg_idx (direct_group_agg_index ags (list agg_expr agg_reduce agg_neutral)))
-					(if (nil? agg_idx) nil (aggregate_col_name (nth ags agg_idx))))
-				((quote aggregate) agg_expr agg_reduce agg_neutral)
-				(begin
-					(define agg_idx (direct_group_agg_index ags (list agg_expr agg_reduce agg_neutral)))
-					(if (nil? agg_idx) nil (aggregate_col_name (nth ags agg_idx))))
-				_ nil)))))
-
-(define direct_group_order_supported? (lambda (alias keys key_names ags order_items)
-	(begin
-		(define items (coalesceNil order_items '()))
-		(define resolved_items (map items (lambda (item)
-			(match item '(expr dir) (list (canonical_column_expr_for_alias alias expr) dir)))))
-		(define key_index (make_group_key_index keys (map resolved_items car)))
-		(reduce (produceN (count items)) (lambda (ok i)
-			(and ok (match (nth items i)
-				'(expr _dir) (not (nil? (direct_group_order_column_indexed
-					alias keys key_names ags key_index expr (car (nth resolved_items i)))))
-				_ false)))
-			true))))
-
 (define build_base_group_scan_assoc_plan (lambda (schema tbl alias table_expr keys condition ags)
 	(begin
 		(define src (list alias schema tbl false nil))
@@ -4052,9 +3989,6 @@ ever-larger subtrees. */
 			(list
 				(list (quote lambda) (list membership_var) plan)
 				membership_expr)))))
-
-(define direct_group_map_params (lambda (key_names ags)
-	(map (merge (list key_names (map ags aggregate_col_name))) symbol)))
 
 (define direct_group_assoc_from_key_payload_expr (lambda (key_names ags)
 	(begin

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -568,9 +568,6 @@ context gates because bare EXISTS also has a separate membership lowerer. */
 	(query_block_with_full_stage_catalog_using block
 		(stage_catalog_with_nested (query_block_stage_catalog block)))))
 
-(define stage_ids (lambda (stages)
-	(map (coalesceNil stages '()) gs_id)))
-
 (define stages_without_ids (lambda (stages ids)
 	(filter (coalesceNil stages '()) (lambda (stage)
 		(not (contains? ids (gs_id stage)))))))
@@ -724,9 +721,6 @@ context gates because bare EXISTS also has a separate membership lowerer. */
 			'()
 			(query_block_facts_with_stage_catalog rewritten available_stages)))))
 
-(define query_block_without_stages_after_prepare (lambda (block)
-	(query_block_without_stages_after_prepare_using (qb_stages block) block)))
-
 (define group_stage_with_eager_prepared_metadata (lambda (stage)
 	(if (not (group_stage? stage))
 		stage
@@ -818,9 +812,6 @@ context gates because bare EXISTS also has a separate membership lowerer. */
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(query_block_with_prepared_sources_using_graph
 		stages (stage_dependency_graph stages) block)))
-
-(define query_block_with_prepared_sources (lambda (block)
-	(query_block_with_prepared_sources_using (qb_stages block) block)))
 
 (define group_stage_final_block (lambda (stage extra_sources)
 	(begin
@@ -1395,9 +1386,6 @@ get_column refs to the source) are excluded automatically too. */
 			(if (window_stage? stage)
 				(lower_window_stage_prepare stage)
 				(neumann_fail "build_queryplan" "unknown logical stage"))))))
-(define lower_stage_prepare (lambda (stage)
-	(lower_stage_prepare_using (list stage) (list stage) stage)))
-
 (define nested_stage_catalog (lambda (stage)
 	(begin
 		(define input (if (group_stage? stage) (gs_input stage) nil))
@@ -1761,19 +1749,6 @@ get_column refs to the source) are excluded automatically too. */
 		(or found (row_number_stage_consumed_by_source? stage src)))
 		false)))
 
-(define expr_contains_driver_membership? (lambda (expr)
-	(match expr
-		((symbol driver_membership_probe) _stage _probe) true
-		((quote driver_membership_probe) _stage _probe) true
-		((symbol driver_membership_subscan_probe) _stage _probe) true
-		((quote driver_membership_subscan_probe) _stage _probe) true
-		(cons head tail) (or
-			(expr_contains_driver_membership? head)
-			(reduce tail (lambda (found item)
-				(or found (expr_contains_driver_membership? item)))
-				false))
-		_ false)))
-
 (define stage_consumed_by_probe_source? (lambda (stage stages sources default_alias limit_value driver_condition)
 	(reduce (coalesceNil sources '()) (lambda (found src)
 		(or found
@@ -1802,9 +1777,6 @@ get_column refs to the source) are excluded automatically too. */
 
 (define stage_ids_for_sources_with_closure (lambda (stages sources)
 	(map (stages_consumed_by_sources_with_closure stages sources) gs_id)))
-
-(define stage_ids_for_sources_with_closure_using_graph (lambda (dependency_graph stages sources)
-	(map (stages_consumed_by_sources_with_closure_using_graph dependency_graph stages sources) gs_id)))
 
 (define prelimit_sources_for (lambda (sources default_alias where_expr order_items)
 	(begin
@@ -1885,9 +1857,6 @@ get_column refs to the source) are excluded automatically too. */
 				(stage_direct_prepare_semantic_candidate? consumed_probe_ids consumed_source_probe_ids stage_output_ids stage)))))
 		direct)))
 
-(define query_block_stages_to_prepare_base (lambda (block)
-	(query_block_stages_to_prepare_base_using (qb_stages block) block)))
-
 (define selected_group_cache_keys (lambda (stages)
 	(reduce (coalesceNil stages '()) (lambda (keys stage)
 		(if (and (group_stage? stage) (source_is_base_table? (gs_input stage)))
@@ -1923,9 +1892,6 @@ get_column refs to the source) are excluded automatically too. */
 				(or
 					(not late_projection)
 					(stage_id_in? stage prelimit_stage_ids))))))))
-
-(define query_block_stages_to_prepare (lambda (block)
-	(query_block_stages_to_prepare_using (qb_stages block) block)))
 
 (define query_block_bounded_scalar_probe_recipe_context? (lambda (block)
 	(begin
@@ -5231,17 +5197,6 @@ ordering run. Storage artifacts begin in build_queryplan. */
 
 (define build_queryplan_term (lambda (query)
 	(neumann_compile_pipeline query)))
-
-(define build_queryplan_term_with_sink (lambda (query sink_mode)
-	(neumann_compile_ir_pipeline
-		(ir_with_return (decorrelate_logical_query query) sink_mode))))
-
-(define build_queryplan_term_from_logical (lambda (logical_ir)
-	(neumann_compile_ir_pipeline logical_ir)))
-
-(define build_queryplan_term_from_logical_with_sink (lambda (logical_ir sink_mode)
-	(neumann_compile_ir_pipeline
-		(ir_with_return logical_ir sink_mode))))
 
 (define build_dml_plan (lambda (schema tbl _tblalias all_defs cols condition order limit offset)
 	(begin


### PR DESCRIPTION
## Summary

- remove 42 unreferenced or shadowed top-level definitions from the four query-planner modules
- follow transitive dead references to a fixed point instead of leaving helpers whose only caller was removed
- leave active planner call sites, parser adapters, tests, and behavior unchanged

## Evidence

- exact repository-wide Scheme-symbol token inventory starts with 31 definitions having no call site
- two duplicate top-level names were shadowed before any runtime caller could reach the earlier definition
- removing those definitions exposed nine additional helpers whose only callers were dead
- after cleanup, all 1,590 remaining planner definitions have at least one exact repository reference and no top-level definition name is duplicated
- net change: 247 lines deleted, zero lines added

## Validation

- full normal parallel pre-commit suite: pass
- tests/planner/subqueries/in-subquery.yaml: 70/70
- tests/planner/order-window/order-limit.yaml: 47/47
- tests/planner/aggregates/group-by-sum.yaml: 7/7
- tests/storage/persistence/memory-engine.yaml: 24/24 isolated and green in the successful full run
- SQL regression guard: pass
- Go build: pass
- Scheme formatter run; only the repository's existing negative-depth warnings remain

No tests or regression thresholds were changed.