### PR TITLE
Cost prefiltered membership carriers per physical node

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2385,6 +2385,7 @@ either physical alternative or sampling the table again. */
 			(list (quote membership_stage_id) (gs_id stage))
 			(list (quote membership_selectivity_class) class)
 			(list (quote membership_driver_rows) driver_rows)
+			(list (quote membership_local_filter_rows) driver_rows)
 			(list (quote membership_driver_input_rows) driver_input_rows)
 			(list (quote membership_driver_estimate_capped)
 				(qassoc_get driver_estimate (quote capped) false))
@@ -2633,7 +2634,13 @@ physical alternative. */
 		(if (not (membership_work_value work (quote membership_order_limit_driver) false))
 			driver_rows
 			(begin
-				(define density (membership_candidate_density candidate_input_rows candidate_rows work))
+				(define local_filter_rows
+					(membership_work_value work (quote membership_local_filter_rows) driver_input_rows))
+				(define local_filter_density (if (> driver_input_rows 0)
+					(min 1 (/ local_filter_rows driver_input_rows)) 0))
+				(define density (*
+					(membership_candidate_density candidate_input_rows candidate_rows work)
+					local_filter_density))
 				(define requested_rows (+ driver_rows
 					(membership_work_value work (quote membership_order_offset) 0)))
 				(if (> density 0)
@@ -2701,6 +2708,58 @@ physical alternative. */
 					0 0 0 0 0 0 projection_rows 0.65)
 				projection_rows 0.65)
 			base_cost))))
+
+/* A selective, source-local driver predicate can restrict both sides of the
+membership edge before an expensive candidate predicate runs. The emitted
+tree scans the driver once, projects its exact RecSet to the candidate source,
+filters only that subset, projects matches back, and intersects with the
+original driver RecSet. Cost it entirely from the same calibrated scan,
+expression, and RecSet components used by the other membership carriers. */
+(define membership_prefiltered_candidate_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
+	(begin
+		(define driver_input_rows (membership_driver_input_rows driver_rows work))
+		(define branches (max 1
+			(membership_work_value work (quote membership_candidate_probe_branches) 1)))
+		(define candidate_domain_rows (/ candidate_input_rows branches))
+		(define projected_candidate_rows (min driver_rows candidate_domain_rows))
+		(define candidate_work_rows (* projected_candidate_rows branches))
+		(define candidate_density (membership_candidate_density
+			candidate_input_rows candidate_rows work))
+		(define candidate_match_rows (* candidate_work_rows candidate_density))
+		(define candidate_fraction (if (> candidate_input_rows 0)
+			(min 1 (/ candidate_work_rows candidate_input_rows)) 0))
+		(define projection_rows (+
+			(* driver_rows 2)
+			candidate_work_rows
+			candidate_match_rows))
+		(planner_cost
+			(* (+
+				(membership_work_value work (quote membership_driver_scan_invocations) 1)
+				(membership_work_value work (quote membership_candidate_scan_invocations) branches))
+				planner_membership_scan_invocation_ns)
+			(+
+				(* (+ driver_input_rows candidate_work_rows projection_rows)
+					planner_membership_scan_row_ns)
+				(* driver_input_rows
+					(membership_work_value work (quote membership_driver_filter_columns) 0)
+					planner_membership_filter_column_row_ns)
+				(* driver_input_rows
+					(membership_work_value work (quote membership_driver_expression_operations) 0)
+					planner_membership_expression_operation_row_ns)
+				(* candidate_work_rows
+					(membership_work_value work (quote membership_candidate_filter_columns) 0)
+					planner_membership_filter_column_row_ns)
+				(* candidate_work_rows
+					(membership_work_value work (quote membership_candidate_expression_operations) 0)
+					planner_membership_expression_operation_row_ns)
+				(* (membership_work_value work (quote membership_candidate_broad_text_match_rows) 0)
+					candidate_fraction planner_membership_broad_text_match_row_ns)
+				(* (membership_work_value work (quote membership_candidate_broad_text_match_bytes) 0)
+					candidate_fraction planner_membership_broad_text_match_byte_ns))
+			0 0 0
+			(* projection_rows planner_membership_recset_build_row_ns)
+			(* projection_rows 8)
+			0 driver_rows 0.65))))
 
 (define membership_driver_probe_cost (lambda (driver_rows probe_branches)
 	(begin
@@ -2981,7 +3040,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 					(and (equal? (gs_id (nth batch_membership 0)) (gs_id stage))
 						(ordered_batch_stage_supported? stage))))
 				/* Batch eligibility only preserves the abstract membership marker.
-				The consuming tree edge below owns the single three-way physical
+				The consuming tree edge below owns the node-local physical
 				decision once its driver cardinality is known. */
 				(if batch_supported
 					true

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2544,7 +2544,7 @@ the auto-index chooses the concrete access path on both tables. */
 /* Cost one physical tree edge once and return (strategy RecSet-expression).
 Consumers decide whether that RecSet is their scan carrier or a membership
 filter; they must not reconstruct the choice from enclosing block facts. */
-(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr)
 	(begin
 		(define stage (nth membership 0))
 		/* Some late RecSet consumers are introduced after reorder telemetry was
@@ -2630,20 +2630,46 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				(define batch_cost (if (and allow_ordered_batch known)
 					(ordered_batch_accept_cost batch_cost_facts)
 					nil))
-				(define base_choice (if guarded_broad_order_driver
+				(define prefiltered_driver_rows
+					(qassoc_get facts (quote membership_driver_rows) nil))
+				(define prefiltered_driver_var (symbol "__prefiltered_membership_recset"))
+				(define prefiltered_body (if (nil? prefiltered_driver_expr)
+					nil
+					(batch_membership_expr src membership prefiltered_driver_var)))
+				(define prefiltered_expr (if (nil? prefiltered_body)
+					nil
+					(list
+						(list (quote lambda) (list prefiltered_driver_var) prefiltered_body)
+						prefiltered_driver_expr)))
+				(define prefiltered_eligible (and
+					(not (nil? prefiltered_expr))
+					(and (number? prefiltered_driver_rows)
+						(and (number? source_rows) (< prefiltered_driver_rows source_rows)))))
+				(define prefiltered_cost (if (and prefiltered_eligible (number? candidate_rows))
+					(membership_prefiltered_candidate_cost
+						candidate_input_rows candidate_rows prefiltered_driver_rows cost_facts)
+					nil))
+				(define cost_choices (filter (list
+					(if (nil? candidate_cost) nil (list "candidate_keyset" candidate_cost))
+					(if (nil? driver_cost) nil (list "driver_order_membership_probe" driver_cost))
+					(if (nil? batch_cost) nil (list "ordered_batch_accept" batch_cost))
+					(if (nil? prefiltered_cost) nil
+						(list "prefiltered_candidate_keyset" prefiltered_cost)))
+					(lambda (choice) (not (nil? choice)))))
+				(define cost_choice (if (empty_list? cost_choices)
+					nil
+					(reduce (cdr cost_choices) (lambda (best choice)
+						(if (planner_cost_better? (cadr choice) (cadr best)) choice best))
+						(car cost_choices))))
+				(define normal_choice (if guarded_broad_order_driver
 					"driver_order_membership_probe"
-					(if known
-						(if (membership_projection_cost_preferred? candidate_input_rows candidate_rows driver_rows cost_facts)
-							"candidate_keyset"
-							"driver_order_membership_probe")
-						(if owns_requirement "driver_order_membership_probe" "candidate_keyset"))))
-				(define batch_wins (and (not (nil? batch_cost))
-					(and (planner_cost_better? batch_cost candidate_cost)
-						(planner_cost_better? batch_cost driver_cost))))
-				(define normal_choice (if batch_wins "ordered_batch_accept" base_choice))
-				(define alternatives (if allow_ordered_batch
-					(list "candidate_keyset" "driver_order_membership_probe" "ordered_batch_accept")
-					(list "candidate_keyset" "driver_order_membership_probe")))
+					(if (nil? cost_choice)
+						(if owns_requirement "driver_order_membership_probe" "candidate_keyset")
+						(car cost_choice))))
+				(define alternatives (merge (list
+					(list "candidate_keyset" "driver_order_membership_probe")
+					(if allow_ordered_batch (list "ordered_batch_accept") '())
+					(if prefiltered_eligible (list "prefiltered_candidate_keyset") '()))))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
 				(planner_record_physical_decision
@@ -2658,11 +2684,10 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(list "selection" (if (nil? forced) (if known "cost" "fallback") "forced"))
 						(list "normally_chosen" normal_choice)
 						(list "reason" (if (not (nil? forced)) "calibration_override"
-							(if batch_wins "batch_filter_implementation_lowest_total_ns"
-								(if guarded_broad_order_driver "guarded_broad_order_limit_driver"
-									(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
-										(if owns_requirement "unknown_statistics_driver_fallback"
-											"unknown_statistics_projection_fallback"))))))
+							(if guarded_broad_order_driver "guarded_broad_order_limit_driver"
+								(if known (if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")
+									(if owns_requirement "unknown_statistics_driver_fallback"
+										"unknown_statistics_projection_fallback")))))
 						(list "inputs" (list
 							(list "candidate_input_rows" candidate_input_rows)
 							(list "candidate_matching_rows" candidate_matching_rows)
@@ -2674,6 +2699,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 									(membership_driver_input_rows driver_rows facts) facts))
 							(list "driver_input_rows" source_rows)
 							(list "driver_rows" driver_rows)
+							(list "prefiltered_driver_rows" prefiltered_driver_rows)
 							(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
 								candidate_input_rows candidate_rows driver_rows facts))
 							(list "probe_rows" driver_rows)
@@ -2720,15 +2746,23 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 									(list "status" (if (equal? chosen "ordered_batch_accept") "chosen" "rejected"))
 									(list "reason" (if (equal? chosen "ordered_batch_accept") "selected" "higher_total_ns_or_forced_alternative"))
 									(list "cost" (if (nil? batch_cost) '() (planner_cost_explain batch_cost))))
+								nil)
+							(if prefiltered_eligible
+								(list
+									(list "plan" "prefiltered_candidate_keyset")
+									(list "status" (if (equal? chosen "prefiltered_candidate_keyset") "chosen" "rejected"))
+									(list "reason" (if (equal? chosen "prefiltered_candidate_keyset") "selected" "higher_total_ns_or_forced_alternative"))
+									(list "cost" (planner_cost_explain prefiltered_cost)))
 								nil)) (lambda (alternative) (not (nil? alternative)))))))
-				(list chosen raw_expr))))))
+				(list chosen (if (equal? chosen "prefiltered_candidate_keyset")
+					prefiltered_expr raw_expr)))))))
 
 /* General expression callers preserve the established contract: only a
 candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 (define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define plan (recset_project_join_plan_for_membership_using
-			src membership consumer driver_rows_override allow_ordered_batch))
+			src membership consumer driver_rows_override allow_ordered_batch nil))
 		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 			(cadr plan)
 			nil))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2565,6 +2565,29 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 								(cons (quote list) (cons local_batch membership_exprs)))))
 					locally_filtered))))))
 
+/* Produce the exact driver subset shared by a prefiltered membership tree.
+Every remaining top-level conjunct is evaluated once while building the driver
+RecSet; membership edges retain their own physical operators. */
+(define prefiltered_driver_recset_expr_for_membership (lambda (src source_table condition membership)
+	(begin
+		(define residual_condition (strip_driver_membership_for_source src condition membership))
+		(define driver_condition (combine_where_terms
+			(filter (split_and_terms (coalesceNil residual_condition true)) (lambda (term)
+				(not (expr_contains_driver_membership? term))))
+			true))
+		(if (equal? driver_condition true)
+			nil
+			(begin
+				(define alias (source_alias src))
+				(define cols (extract_columns_for_alias src driver_condition))
+				(list (quote scan_recset)
+					'(session "__memcp_tx")
+					source_table
+					(cons (quote list) cols)
+					(list (quote lambda)
+						(map cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+						(lower_column_expr_for_alias src driver_condition))))))))
+
 (define ordered_batch_count_estimate (lambda (first_batch visited_rows)
 	(if (or (not (number? first_batch)) (or (<= first_batch 0) (not (number? visited_rows))))
 		1
@@ -2681,7 +2704,8 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 						(define override (planner_physical_override
 							(concat "membership_carrier:" (gs_id (nth membership 0)))))
 						(or forced (or (equal? override "candidate_keyset")
-							(equal? override "ordered_batch_accept"))))) false))
+							(or (equal? override "ordered_batch_accept")
+								(equal? override "prefiltered_candidate_keyset")))))) false))
 				(define prefer_membership_filter (and scan_order_supported
 					(and bounded
 						(and (not forced_candidate_membership)
@@ -2696,14 +2720,17 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 								(if bounded (quote order_limit) (quote filter))
 								(if (and scan_order_supported bounded)
 									(probe_limit_work_rows (qb_limit block)) nil)
-								allow_ordered_batch_binding))
+								allow_ordered_batch_binding
+								(prefiltered_driver_recset_expr_for_membership
+									src source_table condition membership)))
 							(if (nil? plan) nil (list membership plan)))))
 						(lambda (entry) (not (nil? entry))))))
 				(define membership_bindings (filter (map membership_plans (lambda (entry)
 					(begin
 						(define membership (nth entry 0))
 						(define plan (nth entry 1))
-						(if (equal? (car plan) "candidate_keyset")
+						(if (or (equal? (car plan) "candidate_keyset")
+							(equal? (car plan) "prefiltered_candidate_keyset"))
 							(list membership (membership_recset_var src membership) (cadr plan))
 							nil))))
 					(lambda (binding) (not (nil? binding)))))
@@ -3045,18 +3072,22 @@ stream before its native OFFSET/LIMIT counters; projection only sees the window.
 				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
 				(if (query_limit_active? offset_value limit_value)
 					(probe_limit_work_rows limit_value) nil)
-				false)))
+				false
+				(prefiltered_driver_recset_expr_for_membership
+					src (source_table_expr_using stages src) condition membership))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
-			(equal? membership_strategy "candidate_keyset"))
+			(or (equal? membership_strategy "candidate_keyset")
+				(equal? membership_strategy "prefiltered_candidate_keyset")))
 			(cadr membership_plan)
 			nil))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
 		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
-		/* The node-local physical choice is final. A candidate keyset becomes the
-		ordered carrier; a driver-probe choice leaves the marker in the base-table
-		filter so its established direct probe lowering remains in charge. */
+		/* The node-local physical choice is final. A full or driver-prefiltered
+		candidate keyset becomes the ordered carrier; a driver-probe choice leaves
+		the marker in the base-table filter so its established direct probe lowering
+		remains in charge. */
 		(define filter_condition effective_condition)
 		/* Acceptance runs before OFFSET/LIMIT and therefore contains only joins
 		which can reject a driver row. Projection-only nullable lookups belong to
@@ -3553,11 +3584,14 @@ this lowering boundary. */
 				(if (and (not (empty_list? current_order_items))
 					(query_limit_active? offset_value limit_value))
 					(probe_limit_work_rows limit_value) nil)
-				false)))
+				false
+				(prefiltered_driver_recset_expr_for_membership
+					src (source_table_expr_using stages src) condition membership))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
-			(equal? membership_strategy "candidate_keyset"))
+			(or (equal? membership_strategy "candidate_keyset")
+				(equal? membership_strategy "prefiltered_candidate_keyset")))
 			(cadr membership_plan)
 			nil))
 		(if (expr_contains_driver_membership? condition)
@@ -5509,17 +5543,31 @@ ordering run. Storage artifacts begin in build_queryplan. */
 				(or found (physical_expr_has_head? item target))) false))
 		_ false)))
 
+(define physical_prefiltered_membership_expr? (lambda (expr)
+	(match expr
+		((symbol scan_recset) _tx source _cols _filter)
+		(or (physical_expr_has_head? source (quote recset_project_join))
+			(physical_prefiltered_membership_expr? source))
+		((quote scan_recset) _tx source _cols _filter)
+		(or (physical_expr_has_head? source (quote recset_project_join))
+			(physical_prefiltered_membership_expr? source))
+		(cons _head tail) (reduce tail (lambda (found item)
+			(or found (physical_prefiltered_membership_expr? item))) false)
+		_ false)))
+
 (define physical_membership_operator_family (lambda (plan)
 	(if (physical_expr_has_head? plan (quote scan_order_batch_accept))
 		"ordered_batch_accept"
-		(if (physical_expr_has_head? plan (quote recset_project_join))
-			"candidate_keyset"
-			/* A forced membership variant reaches this function only after
-			require_physical_scan_relations has rejected every surviving logical
-			marker. Without a projected RecSet its emitted carrier is therefore the
-			driver-side probe family, independent of the concrete group-cache/index
-			primitive selected inside that family. */
-			"driver_order_membership_probe"))))
+		(if (physical_prefiltered_membership_expr? plan)
+			"prefiltered_candidate_keyset"
+			(if (physical_expr_has_head? plan (quote recset_project_join))
+				"candidate_keyset"
+				/* A forced membership variant reaches this function only after
+				require_physical_scan_relations has rejected every surviving logical
+				marker. Without a projected RecSet its emitted carrier is therefore the
+				driver-side probe family, independent of the concrete group-cache/index
+				primitive selected inside that family. */
+				"driver_order_membership_probe")))))
 
 (define physical_operator_family_for_decision (lambda (plan decision)
 	(begin

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -585,6 +585,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(list (quote coverage) (quote sampled)))
 		100000 100000) 25000
 		"capped table samples retain proportional selectivity extrapolation")
+	(assert (membership_expected_driver_rows_visited
+		40000 1000 10
+		(list
+			(list (quote membership_candidate_probe_branches) 2)
+			(list (quote membership_driver_input_rows) 20000)
+			(list (quote membership_local_filter_rows) 100)
+			(list (quote membership_order_limit_driver) true)))
+		20000
+		"ordered membership costing combines local driver and membership selectivity")
 	(assert (physical_text_scan_operation?
 		(list (quote strlike) "value" "%selective-term%" "utf8mb4_general_ci")) true
 		"text scan work is byte-sensitive even when the predicate is selective")
@@ -593,7 +602,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"non-text comparisons do not acquire text scan work")
 	/* planner_recset_carrier_cost / scalar_first_probe_recset_cost_preferred?:
 	same "unknown stays unknown" discipline as the keytable check above, plus
-	the actual three-way comparison. A RecSet's build cost scales with
+	the carrier cost comparison. A RecSet's build cost scales with
 	probe_rows (recset_project_join visits the driving side once, however
 	large it is); a keytable's dominant cost is its per-driving-row read
 	(row_ns, also scaled by probe_rows). For a large probe_rows count RecSet's

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -353,6 +353,31 @@ test_cases:
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 
+  - name: "production-scale prefiltered membership carrier"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    calibration_holdout: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    expected_broad_text_bytes: 15000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.p1 >= 999000
+        AND d.file_id IN (
+          SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
+          UNION
+          SELECT f.id FROM pc_files_text f
+          WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
+        )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
   - name: "wide-value broad text ordered membership"
     physical_calibration: true
     calibration_component: "broad_text_bytes"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -2489,7 +2489,107 @@ test_cases:
           "tenant:description": "Tenant Eight"
           "tenant:canView": true
 
+  - name: "Selective driver predicates restrict broad membership candidates"
+    setup:
+      - sql: "DROP TABLE IF EXISTS in_prefilter_doc"
+      - sql: "DROP TABLE IF EXISTS in_prefilter_file"
+      - sql: "CREATE TABLE in_prefilter_file (ID INT PRIMARY KEY, filename VARCHAR(64), search VARCHAR(128))"
+      - sql: "CREATE TABLE in_prefilter_doc (ID INT PRIMARY KEY, file_id INT, tenant INT, sort_key INT)"
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "in_prefilter_file") '("ID" "filename" "search")
+              (map (produceN 20000) (lambda (i)
+                (list (+ i 1) (concat "asset-" i) (concat "broad needle text " i)))))
+            (insert (table "memcp-tests" "in_prefilter_doc") '("ID" "file_id" "tenant" "sort_key")
+              (map (produceN 20000) (lambda (i)
+                (list (+ i 1) (+ i 1) (if (>= i 19900) 7 9) i))))
+            (rebuild)
+            true)
+    steps:
+      - sql: |
+          EXPLAIN PHYSICAL
+          SELECT d.ID
+          FROM in_prefilter_doc d
+          WHERE d.tenant = 7
+            AND d.file_id IN (
+              SELECT f.ID FROM in_prefilter_file f WHERE f.filename LIKE '%missing%'
+              UNION
+              SELECT f.ID FROM in_prefilter_file f WHERE f.search LIKE '%needle%'
+            )
+          ORDER BY d.sort_key
+          LIMIT 10
+        expect:
+          rows: 1
+          contains:
+            - "membership_carrier"
+            - "prefiltered_candidate_keyset"
+            - "chosen prefiltered_candidate_keyset"
+      - sql: |
+          EXPLAIN
+          SELECT d.ID
+          FROM in_prefilter_doc d
+          WHERE d.tenant = 7
+            AND d.file_id IN (
+              SELECT f.ID FROM in_prefilter_file f WHERE f.filename LIKE '%missing%'
+              UNION
+              SELECT f.ID FROM in_prefilter_file f WHERE f.search LIKE '%needle%'
+            )
+          ORDER BY d.sort_key
+          LIMIT 10
+        expect:
+          contains:
+            - "recset_project_join"
+            - "recset_intersect"
+            - "scan_order"
+      - sql: |
+          EXPLAIN PHYSICAL CALIBRATE
+          SELECT d.ID
+          FROM in_prefilter_doc d
+          WHERE d.tenant = 7
+            AND d.file_id IN (
+              SELECT f.ID FROM in_prefilter_file f WHERE f.filename LIKE '%missing%'
+              UNION
+              SELECT f.ID FROM in_prefilter_file f WHERE f.search LIKE '%needle%'
+            )
+          ORDER BY d.sort_key
+          LIMIT 10
+        expect:
+          rows: 4
+          contains:
+            - "prefiltered_candidate_keyset"
+            - "operator_consistent"
+            - "result_equal"
+          not_contains:
+            - '"operator_consistent": false'
+            - '"result_equal": false'
+      - sql: |
+          SELECT d.ID
+          FROM in_prefilter_doc d
+          WHERE d.tenant = 7
+            AND d.file_id IN (
+              SELECT f.ID FROM in_prefilter_file f WHERE f.filename LIKE '%missing%'
+              UNION
+              SELECT f.ID FROM in_prefilter_file f WHERE f.search LIKE '%needle%'
+            )
+          ORDER BY d.sort_key
+          LIMIT 10
+        expect:
+          rows: 10
+          data:
+            - ID: 19901
+            - ID: 19902
+            - ID: 19903
+            - ID: 19904
+            - ID: 19905
+            - ID: 19906
+            - ID: 19907
+            - ID: 19908
+            - ID: 19909
+            - ID: 19910
+
 cleanup:
+  - sql: "DROP TABLE IF EXISTS in_prefilter_doc"
+  - sql: "DROP TABLE IF EXISTS in_prefilter_file"
   - sql: "DROP TABLE IF EXISTS membership_broad_key"
   - sql: "DROP TABLE IF EXISTS membership_narrow_key_b"
   - sql: "DROP TABLE IF EXISTS membership_narrow_key_a"


### PR DESCRIPTION
## What

Add `prefiltered_candidate_keyset` as a fourth node-local physical membership alternative beside full candidate projection, driver probing, and ordered batch acceptance.

The carrier builds the exact filtered driver RecSet once, projects only that subset to the candidate relation, evaluates the candidate predicate on the projected subset, projects matches back, and intersects them with the original driver RecSet. The logical IR remains unchanged; RecSet operators are introduced only during physical lowering.

The cost comparison uses the existing calibrated scan, expression, text-match, and RecSet components. It also corrects ordered membership work estimates so candidate density and source-local driver density are combined. No calibration constants were edited by hand.

## Correctness and architecture

- one cost comparison owns all feasible carrier alternatives at the consuming physical tree edge
- the same lowering works for single-source, ordered joined, and general join-tree leaves
- multi-branch candidate evaluation binds the driver RecSet once and reuses it
- EXPLAIN PHYSICAL CALIBRATE identifies the emitted operator family and verifies forced variants return identical results
- a production-shaped 20k-row regression covers a selective driver filter plus broad two-branch text membership
- a calibration holdout workload covers the new shape without changing generated constants

The permanent regression was written first. On `master` it failed structurally (70/71: no `prefiltered_candidate_keyset`); this branch passes 71/71 and preserves the hand-computed non-empty result set.

## A/B on the exact production-shaped zero-result search

Same persisted data, SQL text, session binding, process invocation, and machine; server restarted between variants. The complete result was identical in every run.

| Build | restart/cold | second execution |
|---|---:|---:|
| `master` | 9.12 s | 3.95 s |
| this branch (A/B/A counter-run) | 5.94 s | 1.34–1.37 s |

That is about 35% faster after restart and 65% faster for a warm plan execution. A later full-query-cache hit on `master` (0.09 s) is reported separately and excluded from the physical-plan comparison.

EXPLAIN PHYSICAL changed mechanically from driver-order/per-row membership probing to two chosen `prefiltered_candidate_keyset` edges, with an ordered RecSet scan consumer. This proves the new operator is reachable on the real query shape rather than only on the synthetic fixture.

## Application-level comparison

An interactive comparison on roughly 800k items after the PR server restart measured:

| Query | MemCP | PostgreSQL |
|---|---:|---:|
| document list | 4 s | 10 s |
| zero-result search | 12 s | still running after 90 s |

These are application-level observations rather than the controlled compiler A/B above. The unfinished PostgreSQL search is therefore reported as a lower bound, not as a completed duration.

## Validation

- `make test` — full hook-equivalent suite green, including Scheme, SQL, concurrency, storage, crash recovery, and persistence tests
- focused suites: IN subqueries 71/71, ACL membership 13/13, compound boolean RecSet 20/20, ordered scans, deep correlation, and nested scalar scaling
- Scheme formatter run across `lib/`
- normal `go build -o memcp .`
