### PR TITLE
perf: compact bigram postings and intersections

### DIFF
--- a/storage/compressed_recset.go
+++ b/storage/compressed_recset.go
@@ -27,7 +27,195 @@ type CompressedRecSet interface {
 }
 
 func (s *recSetShard) AndMut(dst *recSetShard) {
-	intersectRecSetShardMut(dst, s)
+	if dst == nil || dst.count == 0 {
+		return
+	}
+	if s == nil || s.count == 0 {
+		dst.kind = recSetRanges
+		dst.data = nil
+		dst.used = 0
+		dst.count = 0
+		return
+	}
+	if dst.universe != s.universe {
+		panic("recset mutable intersection: universe mismatch")
+	}
+	switch s.kind {
+	case recSetBitmap:
+		(&compressedBitmap{universe: s.universe, words: s.data}).AndMut(dst)
+	case recSetPositive:
+		positiveValuesAndMut(dst, s.listedValues())
+	case recSetRanges:
+		rangeValuesAndMut(dst, s.listedRanges(), s.count)
+	}
+}
+
+func positiveValuesAndMut(dst *recSetShard, source []uint32) {
+	if recSetShardIsFull(dst) {
+		dst.kind = recSetPositive
+		dst.data = append([]uint32(nil), source...)
+		dst.used = uint32(len(source))
+		dst.count = int64(len(source))
+		return
+	}
+	if dst.kind == recSetRanges {
+		maximumMatches := min(uint64(len(source)), uint64(dst.count))
+		if maximumMatches*4 < uint64((dst.universe+31)/32*4) {
+			ranges := dst.listedRanges()
+			result := make([]uint32, 0, maximumMatches)
+			rangePosition := 0
+			for _, candidate := range source {
+				for rangePosition < len(ranges) && ranges[rangePosition]+ranges[rangePosition+1] <= candidate {
+					rangePosition += 2
+				}
+				if rangePosition == len(ranges) {
+					break
+				}
+				if candidate >= ranges[rangePosition] {
+					result = append(result, candidate)
+				}
+			}
+			dst.kind = recSetPositive
+			dst.data = result
+			dst.used = uint32(len(result))
+			dst.count = int64(len(result))
+			return
+		}
+		ranges := dst.listedRanges()
+		result := make([]uint32, (dst.universe+31)/32)
+		rangePosition := 0
+		for _, candidate := range source {
+			for rangePosition < len(ranges) && ranges[rangePosition]+ranges[rangePosition+1] <= candidate {
+				rangePosition += 2
+			}
+			if rangePosition == len(ranges) {
+				break
+			}
+			if candidate >= ranges[rangePosition] {
+				result[candidate>>5] |= uint32(1) << (candidate & 31)
+			}
+		}
+		dst.kind = recSetBitmap
+		dst.data = result
+		dst.used = 0
+		dst.count = int64(countBitmap(result))
+		return
+	}
+	if dst.kind == recSetBitmap {
+		cursor := uint32(0)
+		for _, candidate := range source {
+			clearRecSetBitmapRange(dst.data, cursor, candidate)
+			cursor = candidate + 1
+		}
+		clearRecSetBitmapRange(dst.data, cursor, dst.universe)
+		dst.count = int64(countBitmap(dst.data))
+		return
+	}
+	values := dst.listedValues()
+	left, right, kept := 0, 0, 0
+	for left < len(values) && right < len(source) {
+		switch {
+		case values[left] < source[right]:
+			left++
+		case values[left] > source[right]:
+			right++
+		default:
+			values[kept] = values[left]
+			kept++
+			left++
+			right++
+		}
+	}
+	dst.data = dst.data[:kept]
+	dst.used = uint32(kept)
+	dst.count = int64(kept)
+}
+
+func rangeValuesAndMut(dst *recSetShard, source []uint32, sourceCount int64) {
+	if len(source) == 2 && source[0] == 0 && source[1] == dst.universe {
+		return
+	}
+	if recSetShardIsFull(dst) {
+		dst.kind = recSetRanges
+		dst.data = append([]uint32(nil), source...)
+		dst.used = uint32(len(source) / 2)
+		dst.count = sourceCount
+		return
+	}
+	if dst.kind == recSetPositive {
+		values := dst.listedValues()
+		left, kept := 0, 0
+		for pair := 0; pair < len(source) && left < len(values); pair += 2 {
+			base, end := source[pair], source[pair]+source[pair+1]
+			for left < len(values) && values[left] < base {
+				left++
+			}
+			for left < len(values) && values[left] < end {
+				values[kept] = values[left]
+				kept++
+				left++
+			}
+		}
+		dst.data = dst.data[:kept]
+		dst.used = uint32(kept)
+		dst.count = int64(kept)
+		return
+	}
+	if dst.kind == recSetRanges {
+		maximumRangeBytes := uint64(dst.used+uint32(len(source)/2)) * 8
+		if maximumRangeBytes < uint64((dst.universe+31)/32*4) {
+			rangeCount, _ := intersectRangeValues(dst.listedRanges(), source, nil, nil)
+			result := make([]uint32, rangeCount*2)
+			_, rowCount := intersectRangeValues(dst.listedRanges(), source, result, nil)
+			dst.data = result
+			dst.used = rangeCount
+			dst.count = rowCount
+			return
+		}
+		result := make([]uint32, (dst.universe+31)/32)
+		_, rowCount := intersectRangeValues(dst.listedRanges(), source, nil, result)
+		dst.kind = recSetBitmap
+		dst.data = result
+		dst.used = 0
+		dst.count = rowCount
+		return
+	}
+	cursor := uint32(0)
+	for pair := 0; pair < len(source); pair += 2 {
+		base, end := source[pair], source[pair]+source[pair+1]
+		clearRecSetBitmapRange(dst.data, cursor, base)
+		cursor = min(end, dst.universe)
+	}
+	clearRecSetBitmapRange(dst.data, cursor, dst.universe)
+	dst.count = int64(countBitmap(dst.data))
+}
+
+func intersectRangeValues(left, right, output, bitmap []uint32) (uint32, int64) {
+	leftPosition, rightPosition := 0, 0
+	var outputRanges uint32
+	var outputRows int64
+	for leftPosition < len(left) && rightPosition < len(right) {
+		leftBase, leftEnd := left[leftPosition], left[leftPosition]+left[leftPosition+1]
+		rightBase, rightEnd := right[rightPosition], right[rightPosition]+right[rightPosition+1]
+		base, end := max(leftBase, rightBase), min(leftEnd, rightEnd)
+		if base < end {
+			if output != nil {
+				output[outputRanges*2] = base
+				output[outputRanges*2+1] = end - base
+			}
+			if bitmap != nil {
+				setBitmapRange(bitmap, base, end)
+			}
+			outputRanges++
+			outputRows += int64(end - base)
+		}
+		if leftEnd < rightEnd {
+			leftPosition += 2
+		} else {
+			rightPosition += 2
+		}
+	}
+	return outputRanges, outputRows
 }
 
 type compressedRecSet struct {
@@ -42,155 +230,425 @@ type compressedBitmap struct {
 }
 
 func (s *compressedBitmap) AndMut(dst *recSetShard) {
-	part := recSetShard{kind: recSetBitmap, universe: s.universe, data: s.words, count: int64(countBitmap(s.words))}
-	intersectRecSetShardMut(dst, &part)
+	if !compressedRecSetCanNarrow(dst, s.universe) {
+		return
+	}
+	if recSetShardIsFull(dst) {
+		dst.kind = recSetBitmap
+		dst.data = append([]uint32(nil), s.words...)
+		if tail := s.universe & 31; tail != 0 && len(dst.data) > 0 {
+			dst.data[len(dst.data)-1] &= uint32(1)<<tail - 1
+		}
+		dst.used = 0
+		dst.count = int64(countBitmap(dst.data))
+		return
+	}
+	switch dst.kind {
+	case recSetBitmap:
+		for index := range dst.data {
+			dst.data[index] &= s.words[index]
+		}
+		dst.count = int64(countBitmap(dst.data))
+	case recSetPositive:
+		values := dst.listedValues()
+		kept := 0
+		for _, value := range values {
+			if s.words[value>>5]&(uint32(1)<<(value&31)) != 0 {
+				values[kept] = value
+				kept++
+			}
+		}
+		dst.data = dst.data[:kept]
+		dst.used = uint32(kept)
+		dst.count = int64(kept)
+	case recSetRanges:
+		ranges := dst.listedRanges()
+		bitmapBytes := uint64((dst.universe + 31) / 32 * 4)
+		if uint64(dst.count)*4 < bitmapBytes {
+			values := make([]uint32, 0, dst.count)
+			for pair := 0; pair < len(ranges); pair += 2 {
+				values = appendBitmapValues(values, s.words, ranges[pair], ranges[pair]+ranges[pair+1])
+			}
+			dst.kind = recSetPositive
+			dst.data = values
+			dst.used = uint32(len(values))
+			dst.count = int64(len(values))
+			return
+		}
+		result := make([]uint32, len(s.words))
+		for pair := 0; pair < len(ranges); pair += 2 {
+			copyBitmapRange(result, s.words, ranges[pair], ranges[pair]+ranges[pair+1])
+		}
+		dst.kind = recSetBitmap
+		dst.data = result
+		dst.used = 0
+		dst.count = int64(countBitmap(result))
+	}
 }
 
-type packedUint32s struct {
-	data  []uint64
-	base  uint32
-	count uint32
-	width uint8
+func bitmapWordInRange(words []uint32, wordIndex, begin, end uint32) uint32 {
+	word := words[wordIndex]
+	if wordIndex == begin>>5 {
+		word &= ^uint32(0) << (begin & 31)
+	}
+	if tail := end & 31; tail != 0 && wordIndex == end>>5 {
+		word &= uint32(1)<<tail - 1
+	}
+	return word
 }
 
-func packUint32s(values []uint32) packedUint32s {
-	if len(values) == 0 {
-		return packedUint32s{}
-	}
-	base, maximum := values[0], values[0]
-	for _, value := range values[1:] {
-		if value < base {
-			base = value
-		}
-		if value > maximum {
-			maximum = value
+func appendBitmapValues(dst []uint32, words []uint32, begin, end uint32) []uint32 {
+	for wordIndex, limit := begin>>5, (end+31)>>5; wordIndex < limit; wordIndex++ {
+		word := bitmapWordInRange(words, wordIndex, begin, end)
+		for word != 0 {
+			dst = append(dst, wordIndex*32+uint32(bits.TrailingZeros32(word)))
+			word &= word - 1
 		}
 	}
-	width := uint8(bits.Len32(maximum - base))
+	return dst
+}
+
+func copyBitmapRange(dst, source []uint32, begin, end uint32) {
+	for wordIndex, limit := begin>>5, (end+31)>>5; wordIndex < limit; wordIndex++ {
+		dst[wordIndex] |= bitmapWordInRange(source, wordIndex, begin, end)
+	}
+}
+
+func newCompressedStorageInt(count, minimum, maximum uint32) StorageInt {
+	var result StorageInt
+	result.initValuesUInt32(count, minimum, maximum)
+	return result
+}
+
+func compressedStorageIntBytes(count, minimum, maximum uint32) uint32 {
+	if count == 0 {
+		return 0
+	}
+	width := uint8(bits.Len32(maximum - minimum))
 	if width == 0 {
 		width = 1
 	}
-	packed := packedUint32s{
-		data:  make([]uint64, (uint64(len(values))*uint64(width)+63)/64+1),
-		base:  base,
-		count: uint32(len(values)),
-		width: width,
-	}
-	for i, value := range values {
-		packed.set(uint32(i), value-base)
-	}
-	return packed
+	return uint32((((uint64(count)-1)*uint64(width)+65)/64 + 1) * 8)
 }
 
-func (s *packedUint32s) set(index, value uint32) {
-	bit := uint64(index) * uint64(s.width)
-	word, shift := bit>>6, bit&63
-	s.data[word] |= uint64(value) << shift
-	if shift+uint64(s.width) > 64 {
-		s.data[word+1] |= uint64(value) >> (64 - shift)
-	}
+func setCompressedStorageInt(storage *StorageInt, index, value uint32) {
+	storage.buildValueUInt32(index, value)
 }
 
-func (s *packedUint32s) get(index uint32) uint32 {
-	bit := uint64(index) * uint64(s.width)
-	word, shift := bit>>6, bit&63
-	value := s.data[word] >> shift
-	if shift+uint64(s.width) > 64 {
-		value |= s.data[word+1] << (64 - shift)
+func compressedStorageIntFromValues(values []uint32) StorageInt {
+	if len(values) == 0 {
+		return StorageInt{}
 	}
-	mask := uint64(1)<<s.width - 1
-	return s.base + uint32(value&mask)
+	result := newCompressedStorageInt(uint32(len(values)), values[0], values[len(values)-1])
+	for index, value := range values {
+		setCompressedStorageInt(&result, uint32(index), value)
+	}
+	return result
 }
 
 type compressedPositive struct {
 	universe uint32
-	values   packedUint32s
+	count    uint32
+	values   StorageInt
 }
 
 func (s *compressedPositive) AndMut(dst *recSetShard) {
-	values := make([]uint32, s.values.count)
-	for i := range values {
-		values[i] = s.values.get(uint32(i))
+	if !compressedRecSetCanNarrow(dst, s.universe) {
+		return
 	}
-	part := recSetShard{kind: recSetPositive, universe: s.universe, data: values, used: uint32(len(values)), count: int64(len(values))}
-	intersectRecSetShardMut(dst, &part)
+	if recSetShardIsFull(dst) {
+		values := make([]uint32, s.count)
+		s.values.GetValuesUInt32Range(0, s.count, values, 1)
+		dst.kind = recSetPositive
+		dst.data = values
+		dst.used = uint32(len(values))
+		dst.count = int64(len(values))
+		return
+	}
+	if dst.kind == recSetRanges {
+		maximumMatches := min(uint64(s.count), uint64(dst.count))
+		bitmapBytes := uint64((dst.universe + 31) / 32 * 4)
+		if maximumMatches*4 < bitmapBytes {
+			ranges := dst.listedRanges()
+			result := make([]uint32, 0, maximumMatches)
+			rangePosition := 0
+			var scratch [256]uint32
+			for sourceBase := uint32(0); sourceBase < s.count && rangePosition < len(ranges); {
+				batchCount := min(uint32(len(scratch)), s.count-sourceBase)
+				s.values.GetValuesUInt32Range(sourceBase, batchCount, scratch[:], 1)
+				for _, candidate := range scratch[:batchCount] {
+					for rangePosition < len(ranges) && ranges[rangePosition]+ranges[rangePosition+1] <= candidate {
+						rangePosition += 2
+					}
+					if rangePosition == len(ranges) {
+						break
+					}
+					if candidate >= ranges[rangePosition] {
+						result = append(result, candidate)
+					}
+				}
+				sourceBase += batchCount
+			}
+			dst.kind = recSetPositive
+			dst.data = result
+			dst.used = uint32(len(result))
+			dst.count = int64(len(result))
+			return
+		}
+		ranges := dst.listedRanges()
+		result := make([]uint32, (dst.universe+31)/32)
+		rangePosition := 0
+		var scratch [256]uint32
+		for sourceBase := uint32(0); sourceBase < s.count && rangePosition < len(ranges); {
+			batchCount := min(uint32(len(scratch)), s.count-sourceBase)
+			s.values.GetValuesUInt32Range(sourceBase, batchCount, scratch[:], 1)
+			for _, candidate := range scratch[:batchCount] {
+				for rangePosition < len(ranges) && ranges[rangePosition]+ranges[rangePosition+1] <= candidate {
+					rangePosition += 2
+				}
+				if rangePosition == len(ranges) {
+					break
+				}
+				if candidate >= ranges[rangePosition] {
+					result[candidate>>5] |= uint32(1) << (candidate & 31)
+				}
+			}
+			sourceBase += batchCount
+		}
+		dst.kind = recSetBitmap
+		dst.data = result
+		dst.used = 0
+		dst.count = int64(countBitmap(result))
+		return
+	}
+	if dst.kind == recSetBitmap {
+		var scratch [256]uint32
+		cursor := uint32(0)
+		for base := uint32(0); base < s.count; {
+			batchCount := min(uint32(len(scratch)), s.count-base)
+			s.values.GetValuesUInt32Range(base, batchCount, scratch[:], 1)
+			for _, candidate := range scratch[:batchCount] {
+				clearRecSetBitmapRange(dst.data, cursor, candidate)
+				cursor = candidate + 1
+			}
+			base += batchCount
+		}
+		clearRecSetBitmapRange(dst.data, cursor, dst.universe)
+		dst.count = int64(countBitmap(dst.data))
+		return
+	}
+
+	values := dst.listedValues()
+	left, kept := 0, 0
+	var scratch [256]uint32
+	for base := uint32(0); base < s.count && left < len(values); {
+		batchCount := min(uint32(len(scratch)), s.count-base)
+		s.values.GetValuesUInt32Range(base, batchCount, scratch[:], 1)
+		for _, candidate := range scratch[:batchCount] {
+			for left < len(values) && values[left] < candidate {
+				left++
+			}
+			if left < len(values) && values[left] == candidate {
+				values[kept] = candidate
+				kept++
+				left++
+			}
+		}
+		base += batchCount
+	}
+	dst.data = dst.data[:kept]
+	dst.used = uint32(kept)
+	dst.count = int64(kept)
 }
 
 type compressedRanges struct {
 	universe uint32
 	count    uint32
-	bases    packedUint32s
-	lengths  packedUint32s
+	ranges   uint32
+	bases    StorageInt
+	lengths  StorageInt
 }
 
 func (s *compressedRanges) AndMut(dst *recSetShard) {
-	ranges := make([]uint32, s.bases.count*2)
-	for i := uint32(0); i < s.bases.count; i++ {
-		ranges[i*2] = s.bases.get(i)
-		ranges[i*2+1] = s.lengths.get(i)
+	if !compressedRecSetCanNarrow(dst, s.universe) {
+		return
 	}
-	part := recSetShard{kind: recSetRanges, universe: s.universe, data: ranges, used: s.bases.count, count: int64(s.count)}
-	intersectRecSetShardMut(dst, &part)
+	if recSetShardIsFull(dst) {
+		ranges := make([]uint32, s.ranges*2)
+		s.bases.GetValuesUInt32Range(0, s.ranges, ranges, 2)
+		s.lengths.GetValuesUInt32Range(0, s.ranges, ranges[1:], 2)
+		dst.kind = recSetRanges
+		dst.data = ranges
+		dst.used = s.ranges
+		dst.count = int64(s.count)
+		return
+	}
+	if dst.kind == recSetPositive {
+		values := dst.listedValues()
+		left, kept := 0, 0
+		var scratch [256]uint32
+		for rangeBase := uint32(0); rangeBase < s.ranges && left < len(values); {
+			batchCount := min(uint32(len(scratch)/2), s.ranges-rangeBase)
+			s.bases.GetValuesUInt32Range(rangeBase, batchCount, scratch[:], 2)
+			s.lengths.GetValuesUInt32Range(rangeBase, batchCount, scratch[1:], 2)
+			for pair := uint32(0); pair < batchCount; pair++ {
+				base := scratch[pair*2]
+				end := base + scratch[pair*2+1]
+				for left < len(values) && values[left] < base {
+					left++
+				}
+				for left < len(values) && values[left] < end {
+					values[kept] = values[left]
+					kept++
+					left++
+				}
+			}
+			rangeBase += batchCount
+		}
+		dst.data = dst.data[:kept]
+		dst.used = uint32(kept)
+		dst.count = int64(kept)
+		return
+	}
+	if dst.kind == recSetRanges {
+		maximumRangeBytes := uint64(dst.used+s.ranges) * 2 * 4
+		bitmapBytes := uint64((dst.universe + 31) / 32 * 4)
+		if maximumRangeBytes < bitmapBytes {
+			rangeCount, _ := intersectCompressedRanges(dst.listedRanges(), s, nil, nil)
+			result := make([]uint32, rangeCount*2)
+			_, rowCount := intersectCompressedRanges(dst.listedRanges(), s, result, nil)
+			dst.data = result
+			dst.used = rangeCount
+			dst.count = rowCount
+			return
+		}
+		result := make([]uint32, (dst.universe+31)/32)
+		_, rowCount := intersectCompressedRanges(dst.listedRanges(), s, nil, result)
+		dst.kind = recSetBitmap
+		dst.data = result
+		dst.used = 0
+		dst.count = rowCount
+		return
+	}
+	var scratch [256]uint32
+	cursor := uint32(0)
+	for rangeBase := uint32(0); rangeBase < s.ranges; {
+		batchCount := min(uint32(len(scratch)/2), s.ranges-rangeBase)
+		s.bases.GetValuesUInt32Range(rangeBase, batchCount, scratch[:], 2)
+		s.lengths.GetValuesUInt32Range(rangeBase, batchCount, scratch[1:], 2)
+		for pair := uint32(0); pair < batchCount; pair++ {
+			base := scratch[pair*2]
+			clearRecSetBitmapRange(dst.data, cursor, base)
+			cursor = base + scratch[pair*2+1]
+			if cursor >= dst.universe {
+				cursor = dst.universe
+				break
+			}
+		}
+		rangeBase += batchCount
+	}
+	clearRecSetBitmapRange(dst.data, cursor, dst.universe)
+	dst.count = int64(countBitmap(dst.data))
 }
 
-const ransByteLowerBound uint32 = 1 << 23
-
-type compressedRANSBitmap struct {
-	universe uint32
-	ones     uint32
-	freqOne  uint16
-	state    uint32
-	data     []byte
+func intersectCompressedRanges(left []uint32, right *compressedRanges, output, bitmap []uint32) (uint32, int64) {
+	leftPosition := 0
+	var outputRanges uint32
+	var outputRows int64
+	var lastBase, lastEnd uint32
+	var scratch [256]uint32
+	for rightBase := uint32(0); rightBase < right.ranges && leftPosition < len(left); {
+		batchCount := min(uint32(len(scratch)/2), right.ranges-rightBase)
+		right.bases.GetValuesUInt32Range(rightBase, batchCount, scratch[:], 2)
+		right.lengths.GetValuesUInt32Range(rightBase, batchCount, scratch[1:], 2)
+		for pair := uint32(0); pair < batchCount; pair++ {
+			base := scratch[pair*2]
+			end := base + scratch[pair*2+1]
+			for leftPosition < len(left) && left[leftPosition]+left[leftPosition+1] <= base {
+				leftPosition += 2
+			}
+			position := leftPosition
+			for position < len(left) && left[position] < end {
+				intersectionBase := max(left[position], base)
+				intersectionEnd := min(left[position]+left[position+1], end)
+				if intersectionBase < intersectionEnd {
+					if bitmap != nil {
+						setBitmapRange(bitmap, intersectionBase, intersectionEnd)
+					}
+					if outputRanges > 0 && intersectionBase <= lastEnd {
+						if intersectionEnd > lastEnd {
+							outputRows += int64(intersectionEnd - lastEnd)
+							lastEnd = intersectionEnd
+							if output != nil {
+								output[(outputRanges-1)*2+1] = lastEnd - lastBase
+							}
+						}
+					} else {
+						lastBase, lastEnd = intersectionBase, intersectionEnd
+						outputRows += int64(intersectionEnd - intersectionBase)
+						if output != nil {
+							output[outputRanges*2] = intersectionBase
+							output[outputRanges*2+1] = intersectionEnd - intersectionBase
+						}
+						outputRanges++
+					}
+				}
+				if position < len(left) && left[position]+left[position+1] <= end {
+					position += 2
+				} else {
+					break
+				}
+			}
+			leftPosition = position
+		}
+		rightBase += batchCount
+	}
+	return outputRanges, outputRows
 }
 
-func encodeRANSBitmap(words []uint32, universe, ones uint32) *compressedRANSBitmap {
-	freqOne := uint32((uint64(ones)*256 + uint64(universe)/2) / uint64(universe))
-	if freqOne == 0 {
-		freqOne = 1
-	}
-	if freqOne == 256 {
-		freqOne = 255
-	}
-	state := ransByteLowerBound
-	encoded := make([]byte, 0, universe/8)
-	for position := universe; position > 0; position-- {
-		one := words[(position-1)>>5]&(uint32(1)<<((position-1)&31)) != 0
-		frequency, start := uint32(256)-freqOne, freqOne
-		if one {
-			frequency, start = freqOne, 0
+func setBitmapRange(words []uint32, begin, end uint32) {
+	for wordIndex, limit := begin>>5, (end+31)>>5; wordIndex < limit; wordIndex++ {
+		mask := ^uint32(0)
+		if wordIndex == begin>>5 {
+			mask &= ^uint32(0) << (begin & 31)
 		}
-		maximum := ((ransByteLowerBound >> 8) << 8) * frequency
-		for state >= maximum {
-			encoded = append(encoded, byte(state))
-			state >>= 8
+		if tail := end & 31; tail != 0 && wordIndex == end>>5 {
+			mask &= uint32(1)<<tail - 1
 		}
-		state = (state/frequency)*256 + state%frequency + start
+		words[wordIndex] |= mask
 	}
-	data := make([]byte, len(encoded))
-	copy(data, encoded)
-	return &compressedRANSBitmap{universe: universe, ones: ones, freqOne: uint16(freqOne), state: state, data: data}
 }
 
-func (s *compressedRANSBitmap) AndMut(dst *recSetShard) {
-	words := make([]uint32, (s.universe+31)/32)
-	state := s.state
-	input := len(s.data) - 1
-	freqOne := uint32(s.freqOne)
-	for position := uint32(0); position < s.universe; position++ {
-		slot := state & 255
-		frequency, start := uint32(256)-freqOne, freqOne
-		if slot < freqOne {
-			words[position>>5] |= uint32(1) << (position & 31)
-			frequency, start = freqOne, 0
+func clearRecSetBitmapRange(words []uint32, begin, end uint32) {
+	for begin < end {
+		wordIndex := begin >> 5
+		wordEnd := min(end, (wordIndex+1)<<5)
+		from, count := begin&31, wordEnd-begin
+		mask := ^uint32(0) << from
+		if from+count < 32 {
+			mask &= uint32(1)<<(from+count) - 1
 		}
-		state = frequency*(state>>8) + slot - start
-		for state < ransByteLowerBound && input >= 0 {
-			state = state<<8 | uint32(s.data[input])
-			input--
-		}
+		words[wordIndex] &^= mask
+		begin = wordEnd
 	}
-	part := recSetShard{kind: recSetBitmap, universe: s.universe, data: words, count: int64(s.ones)}
-	intersectRecSetShardMut(dst, &part)
+}
+
+func recSetShardIsFull(dst *recSetShard) bool {
+	if dst == nil || dst.kind != recSetRanges || dst.count != int64(dst.universe) {
+		return false
+	}
+	return (dst.used == 0 && len(dst.data) == 0) ||
+		(dst.used == 1 && len(dst.data) >= 2 && dst.data[0] == 0 && dst.data[1] == dst.universe)
+}
+
+func compressedRecSetCanNarrow(dst *recSetShard, universe uint32) bool {
+	if dst == nil || dst.count == 0 {
+		return false
+	}
+	if dst.universe != universe {
+		panic("compressed recset mutable intersection: universe mismatch")
+	}
+	return true
 }
 
 func countBitmap(words []uint32) uint32 {
@@ -201,26 +659,47 @@ func countBitmap(words []uint32) uint32 {
 	return count
 }
 
-func compressRecSetBitmap(words []uint32, universe uint32) compressedRecSet {
-	count := countBitmap(words)
-	ids := make([]uint32, 0, count)
-	bases := make([]uint32, 0)
-	lengths := make([]uint32, 0)
+type bitmapRecSetStats struct {
+	count                        uint32
+	runs                         uint32
+	minimum, maximum             uint32
+	baseMinimum, baseMaximum     uint32
+	lengthMinimum, lengthMaximum uint32
+}
+
+func analyzeRecSetBitmap(words []uint32, universe uint32) bitmapRecSetStats {
+	var result bitmapRecSetStats
 	var runBase, runEnd uint32
 	haveRun := false
+	finishRun := func() {
+		length := runEnd - runBase
+		if result.runs == 0 {
+			result.baseMinimum, result.baseMaximum = runBase, runBase
+			result.lengthMinimum, result.lengthMaximum = length, length
+		} else {
+			result.baseMinimum = min(result.baseMinimum, runBase)
+			result.baseMaximum = max(result.baseMaximum, runBase)
+			result.lengthMinimum = min(result.lengthMinimum, length)
+			result.lengthMaximum = max(result.lengthMaximum, length)
+		}
+		result.runs++
+	}
 	for wordIndex, source := range words {
 		for source != 0 {
 			position := uint32(wordIndex*32 + bits.TrailingZeros32(source))
 			if position >= universe {
 				break
 			}
-			ids = append(ids, position)
+			if result.count == 0 {
+				result.minimum = position
+			}
+			result.maximum = position
+			result.count++
 			if haveRun && position == runEnd {
 				runEnd++
 			} else {
 				if haveRun {
-					bases = append(bases, runBase)
-					lengths = append(lengths, runEnd-runBase)
+					finishRun()
 				}
 				runBase, runEnd, haveRun = position, position+1, true
 			}
@@ -228,27 +707,165 @@ func compressRecSetBitmap(words []uint32, universe uint32) compressedRecSet {
 		}
 	}
 	if haveRun {
-		bases = append(bases, runBase)
-		lengths = append(lengths, runEnd-runBase)
+		finishRun()
 	}
+	return result
+}
 
-	rawWords := make([]uint32, len(words))
-	copy(rawWords, words)
-	raw := &compressedBitmap{universe: universe, words: rawWords}
-	best := compressedRecSet{set: raw, count: count, bytes: uint32(unsafe.Sizeof(*raw)) + uint32(cap(raw.words))*4}
-	positive := &compressedPositive{universe: universe, values: packUint32s(ids)}
-	if size := uint32(unsafe.Sizeof(*positive)) + uint32(cap(positive.values.data))*8; size < best.bytes {
-		best = compressedRecSet{set: positive, count: count, bytes: size}
-	}
-	ranges := &compressedRanges{universe: universe, count: count, bases: packUint32s(bases), lengths: packUint32s(lengths)}
-	if size := uint32(unsafe.Sizeof(*ranges)) + uint32(cap(ranges.bases.data)+cap(ranges.lengths.data))*8; size < best.bytes {
-		best = compressedRecSet{set: ranges, count: count, bytes: size}
-	}
-	if universe > 0 && count > 0 && count < universe {
-		rans := encodeRANSBitmap(words, universe, count)
-		if size := uint32(unsafe.Sizeof(*rans)) + uint32(cap(rans.data)); size < best.bytes {
-			best = compressedRecSet{set: rans, count: count, bytes: size}
+func packBitmapIDs(words []uint32, universe uint32, stats bitmapRecSetStats) StorageInt {
+	result := newCompressedStorageInt(stats.count, stats.minimum, stats.maximum)
+	index := uint32(0)
+	for wordIndex, source := range words {
+		for source != 0 {
+			position := uint32(wordIndex*32 + bits.TrailingZeros32(source))
+			if position >= universe {
+				break
+			}
+			setCompressedStorageInt(&result, index, position)
+			index++
+			source &= source - 1
 		}
 	}
-	return best
+	return result
+}
+
+func packBitmapRanges(words []uint32, universe uint32, stats bitmapRecSetStats) (StorageInt, StorageInt) {
+	bases := newCompressedStorageInt(stats.runs, stats.baseMinimum, stats.baseMaximum)
+	lengths := newCompressedStorageInt(stats.runs, stats.lengthMinimum, stats.lengthMaximum)
+	var runBase, runEnd uint32
+	haveRun, index := false, uint32(0)
+	finishRun := func() {
+		setCompressedStorageInt(&bases, index, runBase)
+		setCompressedStorageInt(&lengths, index, runEnd-runBase)
+		index++
+	}
+	for wordIndex, source := range words {
+		for source != 0 {
+			position := uint32(wordIndex*32 + bits.TrailingZeros32(source))
+			if position >= universe {
+				break
+			}
+			if haveRun && position == runEnd {
+				runEnd++
+			} else {
+				if haveRun {
+					finishRun()
+				}
+				runBase, runEnd, haveRun = position, position+1, true
+			}
+			source &= source - 1
+		}
+	}
+	if haveRun {
+		finishRun()
+	}
+	return bases, lengths
+}
+
+func analyzeRecSetIDs(ids []uint32) bitmapRecSetStats {
+	if len(ids) == 0 {
+		return bitmapRecSetStats{}
+	}
+	result := bitmapRecSetStats{
+		count:   uint32(len(ids)),
+		minimum: ids[0],
+		maximum: ids[len(ids)-1],
+	}
+	runBase, runEnd := ids[0], ids[0]+1
+	finishRun := func() {
+		length := runEnd - runBase
+		if result.runs == 0 {
+			result.baseMinimum, result.baseMaximum = runBase, runBase
+			result.lengthMinimum, result.lengthMaximum = length, length
+		} else {
+			result.baseMaximum = runBase
+			result.lengthMinimum = min(result.lengthMinimum, length)
+			result.lengthMaximum = max(result.lengthMaximum, length)
+		}
+		result.runs++
+	}
+	for _, position := range ids[1:] {
+		if position == runEnd {
+			runEnd++
+		} else {
+			finishRun()
+			runBase, runEnd = position, position+1
+		}
+	}
+	finishRun()
+	return result
+}
+
+func packIDRanges(ids []uint32, stats bitmapRecSetStats) (StorageInt, StorageInt) {
+	bases := newCompressedStorageInt(stats.runs, stats.baseMinimum, stats.baseMaximum)
+	lengths := newCompressedStorageInt(stats.runs, stats.lengthMinimum, stats.lengthMaximum)
+	if len(ids) == 0 {
+		return bases, lengths
+	}
+	runBase, runEnd, index := ids[0], ids[0]+1, uint32(0)
+	finishRun := func() {
+		setCompressedStorageInt(&bases, index, runBase)
+		setCompressedStorageInt(&lengths, index, runEnd-runBase)
+		index++
+	}
+	for _, position := range ids[1:] {
+		if position == runEnd {
+			runEnd++
+		} else {
+			finishRun()
+			runBase, runEnd = position, position+1
+		}
+	}
+	finishRun()
+	return bases, lengths
+}
+
+func compressRecSetIDs(ids []uint32, universe uint32) compressedRecSet {
+	stats := analyzeRecSetIDs(ids)
+	positiveSize := uint32(unsafe.Sizeof(compressedPositive{})) + compressedStorageIntBytes(stats.count, stats.minimum, stats.maximum)
+	rangesSize := uint32(unsafe.Sizeof(compressedRanges{})) +
+		compressedStorageIntBytes(stats.runs, stats.baseMinimum, stats.baseMaximum) +
+		compressedStorageIntBytes(stats.runs, stats.lengthMinimum, stats.lengthMaximum)
+	if rangesSize < positiveSize {
+		bases, lengths := packIDRanges(ids, stats)
+		return compressedRecSet{
+			set:   &compressedRanges{universe: universe, count: stats.count, ranges: stats.runs, bases: bases, lengths: lengths},
+			count: stats.count,
+			bytes: rangesSize,
+		}
+	}
+	return compressedRecSet{
+		set:   &compressedPositive{universe: universe, count: stats.count, values: compressedStorageIntFromValues(ids)},
+		count: stats.count,
+		bytes: positiveSize,
+	}
+}
+
+func compressRecSetBitmap(words []uint32, universe uint32) compressedRecSet {
+	stats := analyzeRecSetBitmap(words, universe)
+	kind := uint8(0)
+	bestSize := uint32(unsafe.Sizeof(compressedBitmap{})) + uint32(len(words))*4
+	positiveSize := uint32(unsafe.Sizeof(compressedPositive{})) + compressedStorageIntBytes(stats.count, stats.minimum, stats.maximum)
+	if positiveSize < bestSize {
+		kind, bestSize = 1, positiveSize
+	}
+	rangesSize := uint32(unsafe.Sizeof(compressedRanges{})) +
+		compressedStorageIntBytes(stats.runs, stats.baseMinimum, stats.baseMaximum) +
+		compressedStorageIntBytes(stats.runs, stats.lengthMinimum, stats.lengthMaximum)
+	if rangesSize < bestSize {
+		kind, bestSize = 2, rangesSize
+	}
+	var set CompressedRecSet
+	switch kind {
+	case 0:
+		ownedWords := make([]uint32, len(words))
+		copy(ownedWords, words)
+		set = &compressedBitmap{universe: universe, words: ownedWords}
+	case 1:
+		set = &compressedPositive{universe: universe, count: stats.count, values: packBitmapIDs(words, universe, stats)}
+	case 2:
+		bases, lengths := packBitmapRanges(words, universe, stats)
+		set = &compressedRanges{universe: universe, count: stats.count, ranges: stats.runs, bases: bases, lengths: lengths}
+	}
+	return compressedRecSet{set: set, count: stats.count, bytes: bestSize}
 }

--- a/storage/compressed_recset_test.go
+++ b/storage/compressed_recset_test.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
+import "fmt"
 import "unsafe"
 import "reflect"
 import "testing"
@@ -57,17 +58,200 @@ func TestCompressedRecSetRepresentationsAndMut(t *testing.T) {
 	}
 }
 
+func TestCompressedPositiveAndMutStreamsWithoutAllocation(t *testing.T) {
+	source := &compressedPositive{
+		universe: 64,
+		count:    6,
+		values:   compressedStorageIntFromValues([]uint32{1, 3, 8, 21, 34, 55}),
+	}
+	initial := [...]uint32{0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 63}
+	backing := make([]uint32, len(initial))
+	var got []uint32
+	allocs := testing.AllocsPerRun(100, func() {
+		copy(backing, initial[:])
+		dst := recSetShard{
+			kind:     recSetPositive,
+			universe: 64,
+			data:     backing,
+			used:     uint32(len(backing)),
+			count:    int64(len(backing)),
+		}
+		source.AndMut(&dst)
+		got = dst.listedValues()
+	})
+	if allocs != 0 {
+		t.Fatalf("compressed positive intersection allocations = %v, want 0", allocs)
+	}
+	if !reflect.DeepEqual(got, []uint32{1, 3, 8, 21, 34, 55}) {
+		t.Fatalf("streamed intersection = %v", got)
+	}
+}
+
+func TestCompressedRecSetIntersectionRepresentationMatrix(t *testing.T) {
+	const universe = uint32(1 << 20)
+	sources := []struct {
+		name      string
+		predicate func(uint32) bool
+		want      any
+	}{
+		{"raw", func(position uint32) bool { return position%2 == 0 }, (*compressedBitmap)(nil)},
+		{"positive", func(position uint32) bool { return position%10007 == 0 }, (*compressedPositive)(nil)},
+		{"ranges", func(position uint32) bool { return position >= 1000 && position < 60000 }, (*compressedRanges)(nil)},
+	}
+	destinations := []struct {
+		name      string
+		predicate func(uint32) bool
+	}{
+		{"full", func(uint32) bool { return true }},
+		{"bitmap", func(position uint32) bool { return position%3 != 0 }},
+		{"positive", func(position uint32) bool { return position%997 == 0 }},
+		{"ranges", func(position uint32) bool {
+			return (position >= 500 && position < 3000) || (position >= 40000 && position < 62000)
+		}},
+		{"empty", func(uint32) bool { return false }},
+	}
+	for _, source := range sources {
+		words, sourceWant := bitmapForPredicate(universe, source.predicate)
+		compressed := compressRecSetBitmap(words, universe)
+		if reflect.TypeOf(compressed.set) != reflect.TypeOf(source.want) {
+			t.Fatalf("matrix source %s selected %T, want %T", source.name, compressed.set, source.want)
+		}
+		for _, destination := range destinations {
+			t.Run(source.name+"/"+destination.name, func(t *testing.T) {
+				destinationWords, destinationWant := bitmapForPredicate(universe, destination.predicate)
+				dst := buildRecSetShard(destinationWant)
+				// Force the bitmap destination named above; the adaptive builder is
+				// intentionally free to select another representation.
+				if destination.name == "bitmap" {
+					dst = recSetShardFromBitmap(nil, universe, destinationWords)
+				}
+				compressed.set.AndMut(&dst)
+				want := make([]bool, universe)
+				for position := range want {
+					want[position] = sourceWant[position] && destinationWant[position]
+				}
+				verifyRecSetShard(t, source.name+"/"+destination.name, dst, want)
+			})
+		}
+	}
+}
+
+func TestRecSetCompressedInterfaceDirectRepresentationMatrix(t *testing.T) {
+	const universe = uint32(257)
+	bitmapWords, bitmapWant := bitmapForPredicate(universe, func(position uint32) bool { return position%3 != 0 })
+	positiveValues := []uint32{1, 7, 31, 32, 128, 255}
+	positiveWant := boolValues(universe, positiveValues)
+	rangeData := []uint32{3, 29, 80, 71, 200, 40}
+	rangeWant := make([]bool, universe)
+	for pair := 0; pair < len(rangeData); pair += 2 {
+		for value := rangeData[pair]; value < rangeData[pair]+rangeData[pair+1]; value++ {
+			rangeWant[value] = true
+		}
+	}
+	sources := []struct {
+		name string
+		set  recSetShard
+		want []bool
+	}{
+		{"bitmap", recSetShardFromBitmap(nil, universe, bitmapWords), bitmapWant},
+		{"positive", recSetShardFromList(nil, universe, positiveValues, uint32(len(positiveValues))), positiveWant},
+		{"ranges", recSetShardFromRangePairs(nil, universe, rangeData, uint32(len(rangeData)/2)), rangeWant},
+	}
+	destinationPredicates := []struct {
+		name      string
+		predicate func(uint32) bool
+	}{
+		{"bitmap", func(position uint32) bool { return position%5 != 0 }},
+		{"positive", func(position uint32) bool { return position%17 == 0 }},
+		{"ranges", func(position uint32) bool { return position >= 20 && position < 230 }},
+		{"full", func(uint32) bool { return true }},
+	}
+	for _, source := range sources {
+		for _, destination := range destinationPredicates {
+			t.Run(source.name+"/"+destination.name, func(t *testing.T) {
+				words, destinationWant := bitmapForPredicate(universe, destination.predicate)
+				dst := buildRecSetShard(destinationWant)
+				if destination.name == "bitmap" {
+					dst = recSetShardFromBitmap(nil, universe, words)
+				}
+				if destination.name == "full" {
+					dst = recSetShardFromSingleFullRange(nil, universe)
+				}
+				source.set.AndMut(&dst)
+				want := make([]bool, universe)
+				for position := range want {
+					want[position] = source.want[position] && destinationWant[position]
+				}
+				verifyRecSetShard(t, source.name+"/"+destination.name, dst, want)
+			})
+		}
+	}
+}
+
+func TestCompressedRecSetAndMutRejectsUniverseMismatch(t *testing.T) {
+	words, _ := bitmapForPredicate(64, func(position uint32) bool { return position%3 == 0 })
+	compressed := compressRecSetBitmap(words, 64)
+	dst := recSetShardFromSingleFullRange(nil, 65)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("AndMut accepted different RecSet universes")
+		}
+	}()
+	compressed.set.AndMut(&dst)
+}
+
+func TestCompressedRecSetAndMutRandomizedTailAndRepresentations(t *testing.T) {
+	random := rand.New(rand.NewSource(4711))
+	for _, universe := range []uint32{1, 2, 31, 32, 33, 63, 64, 65, 257, 1009} {
+		for iteration := 0; iteration < 40; iteration++ {
+			sourceWords := make([]uint32, (universe+31)/32)
+			destinationWords := make([]uint32, len(sourceWords))
+			destinationValues := make([]uint32, 0, universe/2)
+			want := make([]bool, universe)
+			for position := uint32(0); position < universe; position++ {
+				source := random.Intn(9) < 3
+				destination := random.Intn(7) < 4
+				if source {
+					sourceWords[position>>5] |= uint32(1) << (position & 31)
+				}
+				if destination {
+					destinationWords[position>>5] |= uint32(1) << (position & 31)
+					destinationValues = append(destinationValues, position)
+				}
+				want[position] = source && destination
+			}
+			compressed := compressRecSetBitmap(sourceWords, universe)
+			destinations := []recSetShard{
+				recSetShardFromBitmap(nil, universe, append([]uint32(nil), destinationWords...)),
+				recSetShardFromList(nil, universe, append([]uint32(nil), destinationValues...), uint32(len(destinationValues))),
+				buildRecSetShard(boolValues(universe, destinationValues)),
+			}
+			for destinationIndex, destination := range destinations {
+				compressed.set.AndMut(&destination)
+				verifyRecSetShard(t, fmt.Sprintf("universe=%d iteration=%d destination=%d", universe, iteration, destinationIndex), destination, want)
+			}
+		}
+	}
+}
+
+func boolValues(universe uint32, values []uint32) []bool {
+	result := make([]bool, universe)
+	for _, value := range values {
+		result[value] = true
+	}
+	return result
+}
+
 func TestCompressedRecSetAdaptiveKinds(t *testing.T) {
-	const universe = uint32(65536)
+	const universe = uint32(1 << 20)
 	fixtures := []struct {
 		name      string
 		predicate func(uint32) bool
 		want      any
 	}{
 		{"raw", func(position uint32) bool { return position%2 == 0 }, (*compressedBitmap)(nil)},
-		{"rans", func(position uint32) bool { return position%5 == 0 }, (*compressedRANSBitmap)(nil)},
-		{"positive", func(position uint32) bool { return position%10007 == 0 }, (*compressedPositive)(nil)},
-		{"ranges", func(position uint32) bool { return position >= 1000 && position < 60000 }, (*compressedRanges)(nil)},
+		{"positive", func(position uint32) bool { return position%100003 == 0 }, (*compressedPositive)(nil)},
+		{"ranges", func(position uint32) bool { return position >= 1000 && position < 1_000_000 }, (*compressedRanges)(nil)},
 	}
 	for _, fixture := range fixtures {
 		t.Run(fixture.name, func(t *testing.T) {
@@ -80,33 +264,6 @@ func TestCompressedRecSetAdaptiveKinds(t *testing.T) {
 	}
 }
 
-func TestRANSBitmapRoundTrip(t *testing.T) {
-	for _, divisor := range []uint32{2, 3, 17, 101} {
-		const universe = uint32(4099)
-		words, want := bitmapForPredicate(universe, func(position uint32) bool {
-			return (position*2654435761+17)%divisor == 0
-		})
-		encoded := encodeRANSBitmap(words, universe, countBitmap(words))
-		dst := recSetShardFromSingleFullRange(nil, universe)
-		encoded.AndMut(&dst)
-		verifyRecSetShard(t, "rans", dst, want)
-	}
-}
-
-func TestLikePatternBigrams(t *testing.T) {
-	want := []uint64{
-		bigramKey('C', 'a'),
-		bigramKey('a', 's'),
-		bigramKey('n', 'o'),
-	}
-	if got := patternBigrams("%CaS_no%"); !reflect.DeepEqual(got, want) {
-		t.Fatalf("bigrams = %v, want %v", got, want)
-	}
-	if got := patternBigrams("%x%"); len(got) != 0 {
-		t.Fatalf("single-rune pattern produced bigrams: %v", got)
-	}
-}
-
 func TestLikeBigramIndexCandidatesAreSafeSuperset(t *testing.T) {
 	values := []string{"Casino", "CASINO", "Cas-no", "basic", "needle", ""}
 	reader := ColumnReaderFunc(func(recid uint32) scm.Scmer { return scm.NewString(values[recid]) })
@@ -114,7 +271,13 @@ func TestLikeBigramIndexCandidatesAreSafeSuperset(t *testing.T) {
 
 	check := func(pattern string, want []uint32) {
 		t.Helper()
-		candidate := index.candidates(patternBigrams(pattern))
+		candidate, constrained := index.candidatesPattern(pattern)
+		if !constrained {
+			t.Fatalf("%q did not produce a candidate constraint", pattern)
+		}
+		if len(want) > 0 && candidate.kind != recSetBitmap {
+			t.Fatalf("%q query-local candidates use %v, want bitmap", pattern, candidate.kind)
+		}
 		got := make([]uint32, 0)
 		candidate.forEachRange(func(base, count uint32) bool {
 			for position := base; position < base+count; position++ {
@@ -129,10 +292,14 @@ func TestLikeBigramIndexCandidatesAreSafeSuperset(t *testing.T) {
 	check("%casino%", []uint32{0, 1})
 	check("%needle%", []uint32{4})
 	check("%missing%", []uint32{})
+	if _, constrained := index.candidatesPattern("%x%"); constrained {
+		t.Fatal("single-rune pattern unexpectedly produced a bigram constraint")
+	}
 }
 
 func TestLikeIndexThreeStageBindingReusesCache(t *testing.T) {
-	values := []string{"Casino", "plain", "CASINO", "needle"}
+	values := make([]string, minimumBigramIndexRows)
+	copy(values, []string{"Casino", "plain", "CASINO", "needle"})
 	reader := ColumnReaderFunc(func(recid uint32) scm.Scmer { return scm.NewString(values[recid]) })
 	hook := LikeMatcher.Deploy(IndexDeployContext{MainCount: uint32(len(values)), Column: reader}, true)
 	if hook == nil {
@@ -158,14 +325,14 @@ func TestLikeIndexThreeStageBindingReusesCache(t *testing.T) {
 func TestLikeIndexLeavesDeltaRowsForResidualFilter(t *testing.T) {
 	values := []string{"Casino", "plain", "CASINO", "needle"}
 	reader := ColumnReaderFunc(func(recid uint32) scm.Scmer { return scm.NewString(values[recid]) })
-	hook := LikeMatcher.Deploy(IndexDeployContext{MainCount: uint32(len(values)), Column: reader}, true)
+	hook := buildBigramIndex(uint32(len(values)), reader)
 	matcher := hook.Bind(scm.NewString("%missing%"))
 	if got := matcher([]uint32{0, 1, 2, 3, 4, 5}); !reflect.DeepEqual(got, []uint32{4, 5}) {
 		t.Fatalf("matcher dropped or admitted wrong rows: %v, want delta rows [4 5]", got)
 	}
 }
 
-func TestLikeIndexComputeSizeIncludesCompleteHashTable(t *testing.T) {
+func TestLikeIndexComputeSizeIncludesCompleteSortedTable(t *testing.T) {
 	values := []string{"Casino", "plain", "CASINO", "needle"}
 	reader := ColumnReaderFunc(func(recid uint32) scm.Scmer { return scm.NewString(values[recid]) })
 	index := buildBigramIndex(uint32(len(values)), reader)
@@ -173,15 +340,69 @@ func TestLikeIndexComputeSizeIncludesCompleteHashTable(t *testing.T) {
 	if got := index.ComputeSize(); got != want {
 		t.Fatalf("ComputeSize = %d, want exact owned size %d", got, want)
 	}
-	minimumPayload := uint(unsafe.Sizeof(*index)) + uint(index.bytes) +
-		uint(index.grams.count)*uint(unsafe.Sizeof(uint64(0))+unsafe.Sizeof(compressedRecSet{}))
-	if index.ComputeSize() <= minimumPayload {
-		t.Fatalf("ComputeSize %d omits empty hash buckets or occupancy bitmap", index.ComputeSize())
+	if cap(index.grams.keys) != len(index.grams.keys) || cap(index.grams.sets) != len(index.grams.sets) || cap(index.grams.counts) != len(index.grams.counts) {
+		t.Fatalf("persistent gram table retains spare capacity: keys=%d/%d sets=%d/%d counts=%d/%d",
+			len(index.grams.keys), cap(index.grams.keys), len(index.grams.sets), cap(index.grams.sets), len(index.grams.counts), cap(index.grams.counts))
+	}
+	minimumPayload := uint(unsafe.Sizeof(*index)) + uint(index.bytes) + uint(len(index.grams.keys))*(uint(unsafe.Sizeof(uint64(0)))+uint(unsafe.Sizeof(CompressedRecSet(nil)))+uint(unsafe.Sizeof(uint32(0))))
+	if index.ComputeSize() != minimumPayload {
+		t.Fatalf("ComputeSize %d differs from exact sorted-table payload %d", index.ComputeSize(), minimumPayload)
+	}
+}
+
+func TestCompressedRecSetStoredSizeMatchesOwnedCapacity(t *testing.T) {
+	bitmapWords := make([]uint32, 1024)
+	for index := range bitmapWords {
+		if index&1 == 0 {
+			bitmapWords[index] = 0xaaaaaaaa
+		} else {
+			bitmapWords[index] = 0x55555555
+		}
+	}
+	positiveWords := make([]uint32, 1024)
+	positiveWords[0] = 1
+	rangeWords := make([]uint32, 1024)
+	for index := 0; index < 16; index++ {
+		rangeWords[index] = ^uint32(0)
+		rangeWords[len(rangeWords)-1-index] = ^uint32(0)
+	}
+	tests := []struct {
+		name     string
+		words    []uint32
+		wantKind any
+	}{
+		{name: "bitmap", words: bitmapWords, wantKind: (*compressedBitmap)(nil)},
+		{name: "positive", words: positiveWords, wantKind: (*compressedPositive)(nil)},
+		{name: "ranges", words: rangeWords, wantKind: (*compressedRanges)(nil)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compressed := compressRecSetBitmap(test.words, uint32(len(test.words)*32))
+			if reflect.TypeOf(compressed.set) != reflect.TypeOf(test.wantKind) {
+				t.Fatalf("representation = %T, want %T", compressed.set, test.wantKind)
+			}
+			var owned uint32
+			switch set := compressed.set.(type) {
+			case *compressedBitmap:
+				owned = uint32(unsafe.Sizeof(*set)) + uint32(cap(set.words))*uint32(unsafe.Sizeof(uint32(0)))
+			case *compressedPositive:
+				owned = uint32(unsafe.Sizeof(*set)) + uint32(cap(set.values.chunk))*uint32(unsafe.Sizeof(uint64(0)))
+			case *compressedRanges:
+				owned = uint32(unsafe.Sizeof(*set)) +
+					uint32(cap(set.bases.chunk)+cap(set.lengths.chunk))*uint32(unsafe.Sizeof(uint64(0)))
+			default:
+				t.Fatalf("unexpected compressed representation %T", compressed.set)
+			}
+			if compressed.bytes != owned {
+				t.Fatalf("stored size = %d, actual owned capacity = %d for %T", compressed.bytes, owned, compressed.set)
+			}
+		})
 	}
 }
 
 func TestIndexRowMatcherAllocatesNothingPerBatch(t *testing.T) {
-	values := []string{"Casino", "plain", "CASINO", "needle"}
+	values := make([]string, minimumBigramIndexRows)
+	copy(values, []string{"Casino", "plain", "CASINO", "needle"})
 	reader := ColumnReaderFunc(func(recid uint32) scm.Scmer { return scm.NewString(values[recid]) })
 	hook := LikeMatcher.Deploy(IndexDeployContext{MainCount: uint32(len(values)), Column: reader}, true)
 	matcher := hook.Bind(scm.NewString("%casino%"))
@@ -194,5 +415,17 @@ func TestIndexRowMatcherAllocatesNothingPerBatch(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("IndexRowMatcher allocations per batch = %v, want 0", allocs)
+	}
+}
+
+func TestLikeIndexSmallShardUsesSharedNoopHook(t *testing.T) {
+	reader := ColumnReaderFunc(func(uint32) scm.Scmer { return scm.NewString("Casino") })
+	first := LikeMatcher.Deploy(IndexDeployContext{MainCount: minimumBigramIndexRows - 1, Column: reader}, true)
+	second := LikeMatcher.Deploy(IndexDeployContext{MainCount: 1, Column: reader}, true)
+	if first == nil || first != second || first.ComputeSize() != 0 {
+		t.Fatalf("small shards did not reuse zero-size hook: first=%T second=%T", first, second)
+	}
+	if matcher := first.Bind(scm.NewString("%casino%")); matcher != nil {
+		t.Fatal("small-shard hook unexpectedly installed a row matcher")
 	}
 }

--- a/storage/index-strlike.go
+++ b/storage/index-strlike.go
@@ -20,11 +20,19 @@ import "sort"
 import "unsafe"
 import "strings"
 import "unicode"
-import "unicode/utf8"
 
 import "github.com/launix-de/memcp/scm"
 
 type likeMatcher struct{}
+
+const minimumBigramIndexRows uint32 = 256
+
+type noopIndexHook struct{}
+
+func (*noopIndexHook) Bind(scm.Scmer) IndexRowMatcher { return nil }
+func (*noopIndexHook) ComputeSize() uint              { return 0 }
+
+var sharedNoopIndexHook IndexHook = &noopIndexHook{}
 
 func (m *likeMatcher) Kind() string      { return "like" }
 func (m *likeMatcher) IsSorted() bool    { return false }
@@ -68,6 +76,9 @@ func (m *likeMatcher) Deploy(ctx IndexDeployContext, persistent bool) IndexHook 
 	if !persistent || ctx.MainCount == 0 || ctx.Column == nil {
 		return nil
 	}
+	if ctx.MainCount < minimumBigramIndexRows {
+		return sharedNoopIndexHook
+	}
 	return buildBigramIndex(ctx.MainCount, ctx.Column)
 }
 
@@ -77,74 +88,43 @@ type bigramIndex struct {
 	bytes    uint64 // owned compressed posting storage
 }
 
-// bigramTable is an immutable open-addressed hash table. Unlike Go's map, all
-// persistent bucket storage is visible to ComputeSize and can be accounted for
-// exactly according to the storage package's owned-memory convention.
+// bigramTable is immutable and sorted. A LIKE pattern performs only a handful
+// of lookups, so compact binary search touches fewer cache lines than a sparse
+// hash table while eliminating empty buckets and their occupancy bitmap.
 type bigramTable struct {
-	keys     []uint64
-	values   []compressedRecSet
-	occupied []uint64
-	count    uint32
+	keys   []uint64
+	sets   []CompressedRecSet
+	counts []uint32
 }
 
-func newBigramTable(count int) bigramTable {
-	capacity := 1
-	for capacity*3/4 < count {
-		capacity <<= 1
-	}
-	return bigramTable{
-		keys:     make([]uint64, capacity),
-		values:   make([]compressedRecSet, capacity),
-		occupied: make([]uint64, (capacity+63)/64),
-	}
+func (t *bigramTable) Len() int           { return len(t.keys) }
+func (t *bigramTable) Less(i, j int) bool { return t.keys[i] < t.keys[j] }
+func (t *bigramTable) Swap(i, j int) {
+	t.keys[i], t.keys[j] = t.keys[j], t.keys[i]
+	t.sets[i], t.sets[j] = t.sets[j], t.sets[i]
+	t.counts[i], t.counts[j] = t.counts[j], t.counts[i]
 }
 
-func bigramHash(key uint64) uint64 {
-	key ^= key >> 30
-	key *= 0xbf58476d1ce4e5b9
-	key ^= key >> 27
-	key *= 0x94d049bb133111eb
-	return key ^ (key >> 31)
+func (t *bigramTable) append(key uint64, value compressedRecSet) {
+	t.keys = append(t.keys, key)
+	t.sets = append(t.sets, value.set)
+	t.counts = append(t.counts, value.count)
 }
 
-func (t *bigramTable) insert(key uint64, value compressedRecSet) {
-	mask := uint64(len(t.keys) - 1)
-	for slot := bigramHash(key) & mask; ; slot = (slot + 1) & mask {
-		word, bit := slot>>6, uint(slot&63)
-		if t.occupied[word]&(uint64(1)<<bit) == 0 {
-			t.occupied[word] |= uint64(1) << bit
-			t.keys[slot] = key
-			t.values[slot] = value
-			t.count++
-			return
-		}
-		if t.keys[slot] == key {
-			t.values[slot] = value
-			return
-		}
+func (t *bigramTable) find(key uint64) int {
+	position := sort.Search(len(t.keys), func(position int) bool {
+		return t.keys[position] >= key
+	})
+	if position < len(t.keys) && t.keys[position] == key {
+		return position
 	}
-}
-
-func (t *bigramTable) get(key uint64) (compressedRecSet, bool) {
-	if len(t.keys) == 0 {
-		return compressedRecSet{}, false
-	}
-	mask := uint64(len(t.keys) - 1)
-	for slot := bigramHash(key) & mask; ; slot = (slot + 1) & mask {
-		word, bit := slot>>6, uint(slot&63)
-		if t.occupied[word]&(uint64(1)<<bit) == 0 {
-			return compressedRecSet{}, false
-		}
-		if t.keys[slot] == key {
-			return t.values[slot], true
-		}
-	}
+	return -1
 }
 
 func (t *bigramTable) ComputeSize() uint64 {
 	return uint64(cap(t.keys))*uint64(unsafe.Sizeof(uint64(0))) +
-		uint64(cap(t.values))*uint64(unsafe.Sizeof(compressedRecSet{})) +
-		uint64(cap(t.occupied))*uint64(unsafe.Sizeof(uint64(0)))
+		uint64(cap(t.sets))*uint64(unsafe.Sizeof(CompressedRecSet(nil))) +
+		uint64(cap(t.counts))*uint64(unsafe.Sizeof(uint32(0)))
 }
 
 func (s *bigramIndex) ComputeSize() uint {
@@ -152,17 +132,18 @@ func (s *bigramIndex) ComputeSize() uint {
 }
 
 func (s *bigramIndex) Bind(lower scm.Scmer) IndexRowMatcher {
-	keys := patternBigrams(lower.String())
-	if len(keys) == 0 {
+	candidates, constrained := s.candidatesPattern(lower.String())
+	if !constrained {
 		return nil
 	}
-	candidates := s.candidates(keys)
+	candidateWords := candidates.data
+	universe := s.universe
 	return func(ids []uint32) []uint32 {
 		out := ids[:0]
 		for _, id := range ids {
 			// The immutable bigram index covers main rows. Delta rows retain the
 			// original STRLIKE residual and must pass this candidate filter.
-			if id >= s.universe || candidates.contains(id) {
+			if id >= universe || (int(id>>5) < len(candidateWords) && candidateWords[id>>5]&(uint32(1)<<(id&31)) != 0) {
 				out = append(out, id)
 			}
 		}
@@ -170,38 +151,66 @@ func (s *bigramIndex) Bind(lower scm.Scmer) IndexRowMatcher {
 	}
 }
 
-func bigramKey(left, right rune) uint64 {
-	return uint64(uint32(unicode.ToLower(left)))<<32 | uint64(uint32(unicode.ToLower(right)))
+func normalizedBigramKey(left, right rune) uint64 {
+	return uint64(uint32(left))<<32 | uint64(uint32(right))
 }
 
-func patternBigrams(pattern string) []uint64 {
-	result := make([]uint64, 0, max(0, utf8.RuneCountInString(pattern)-1))
-	var previous rune
-	havePrevious := false
-	for _, current := range pattern {
-		if current == '%' || current == '_' {
-			havePrevious = false
-			continue
-		}
-		if havePrevious {
-			key := bigramKey(previous, current)
-			if !containsBigram(result, key) {
-				result = append(result, key)
-			}
-		}
-		previous = current
-		havePrevious = true
+func normalizeBigramRune(value rune) rune {
+	if value >= 'A' && value <= 'Z' {
+		return value + ('a' - 'A')
 	}
-	return result
+	if value <= 127 {
+		return value
+	}
+	return unicode.ToLower(value)
 }
 
-func containsBigram(keys []uint64, key uint64) bool {
-	for _, candidate := range keys {
-		if candidate == key {
-			return true
-		}
+type bigramPostingBuilder struct {
+	key      uint64
+	data     []uint32
+	last     uint32
+	haveLast bool
+	bitmap   bool
+}
+
+func (b *bigramPostingBuilder) add(recid, wordCount uint32) {
+	if b.haveLast && b.last == recid {
+		return
 	}
-	return false
+	b.last, b.haveLast = recid, true
+	if b.bitmap {
+		b.data[recid>>5] |= uint32(1) << (recid & 31)
+		return
+	}
+	b.data = append(b.data, recid)
+	// A uint32 RecID list and a uint32 bitmap break even at one hit per
+	// bitmap word. Promote once; dense postings then stop growing entirely.
+	if uint32(len(b.data)) < wordCount {
+		return
+	}
+	bitmap := make([]uint32, wordCount)
+	for _, value := range b.data {
+		bitmap[value>>5] |= uint32(1) << (value & 31)
+	}
+	b.data, b.bitmap = bitmap, true
+}
+
+func (b *bigramPostingBuilder) finish(universe uint32) compressedRecSet {
+	if b.bitmap {
+		return compressRecSetBitmap(b.data, universe)
+	}
+	wordCount := (universe + 31) / 32
+	// At moderate density entropy coding can beat an absolute StorageInt list.
+	// Materialize one temporary bitmap only during finalization; unlike #571's
+	// builder, sparse postings never retain one concurrently with all others.
+	if len(b.data) >= max(16, int(wordCount/8)) {
+		bitmap := make([]uint32, wordCount)
+		for _, value := range b.data {
+			bitmap[value>>5] |= uint32(1) << (value & 31)
+		}
+		return compressRecSetBitmap(bitmap, universe)
+	}
+	return compressRecSetIDs(b.data, universe)
 }
 
 func buildBigramIndex(count uint32, reader ColumnReader) *bigramIndex {
@@ -209,7 +218,12 @@ func buildBigramIndex(count uint32, reader ColumnReader) *bigramIndex {
 	const readBatch = 1024
 	values := make([]scm.Scmer, readBatch)
 	wordCount := (count + 31) / 32
-	temporary := make(map[uint64][]uint32)
+	// PDF/text payloads are overwhelmingly byte-range text. Resolve those
+	// bigrams through one temporary direct table; only genuinely wide Unicode
+	// pairs pay for a hash lookup while the index is being built.
+	asciiPosting := make([]uint32, 1<<16)
+	unicodePostingByKey := make(map[uint64]uint32)
+	postings := make([]bigramPostingBuilder, 0)
 	for base := uint32(0); base < count; base += readBatch {
 		batchCount := uint32(readBatch)
 		if remaining := count - base; remaining < batchCount {
@@ -222,15 +236,29 @@ func buildBigramIndex(count uint32, reader ColumnReader) *bigramIndex {
 				var previous rune
 				havePrevious := false
 				for _, current := range value.String() {
+					current = normalizeBigramRune(current)
 					if havePrevious {
-						key := bigramKey(previous, current)
-						words := temporary[key]
-						if words == nil {
-							words = make([]uint32, wordCount)
-							temporary[key] = words
+						key := normalizedBigramKey(previous, current)
+						var postingIndex uint32
+						if previous <= 255 && current <= 255 {
+							slot := &asciiPosting[uint16(previous)<<8|uint16(current)]
+							if *slot == 0 {
+								postingIndex = uint32(len(postings))
+								postings = append(postings, bigramPostingBuilder{key: key})
+								*slot = postingIndex + 1
+							} else {
+								postingIndex = *slot - 1
+							}
+						} else {
+							var exists bool
+							postingIndex, exists = unicodePostingByKey[key]
+							if !exists {
+								postingIndex = uint32(len(postings))
+								unicodePostingByKey[key] = postingIndex
+								postings = append(postings, bigramPostingBuilder{key: key})
+							}
 						}
-						position := base + offset
-						words[position>>5] |= uint32(1) << (position & 31)
+						postings[postingIndex].add(base+offset, wordCount)
 					}
 					previous = current
 					havePrevious = true
@@ -239,26 +267,94 @@ func buildBigramIndex(count uint32, reader ColumnReader) *bigramIndex {
 			values[offset] = scm.NewNil()
 		}
 	}
-	index.grams = newBigramTable(len(temporary))
-	for key, words := range temporary {
-		compressed := compressRecSetBitmap(words, count)
+	// The lookup structures are build-only. Make them unreachable before
+	// final posting compression, whose peak memory should contain only the
+	// posting builders currently being replaced and their final encodings.
+	asciiPosting = nil
+	unicodePostingByKey = nil
+	values = nil
+	index.grams.keys = make([]uint64, 0, len(postings))
+	index.grams.sets = make([]CompressedRecSet, 0, len(postings))
+	index.grams.counts = make([]uint32, 0, len(postings))
+	for postingIndex := range postings {
+		compressed := postings[postingIndex].finish(count)
 		index.bytes += uint64(compressed.bytes)
-		index.grams.insert(key, compressed)
+		index.grams.append(postings[postingIndex].key, compressed)
+		postings[postingIndex].data = nil
 	}
+	sort.Sort(&index.grams)
 	return index
 }
 
-func (s *bigramIndex) candidates(keys []uint64) recSetShard {
-	sets := make([]compressedRecSet, 0, len(keys))
-	for _, key := range keys {
-		set, exists := s.grams.get(key)
-		if !exists {
-			return recSetShard{kind: recSetRanges, universe: s.universe}
+// candidatesPattern fuses pattern decoding, case normalization and immutable
+// index lookup. No intermediate []uint64 is produced in the query path.
+func (s *bigramIndex) candidatesPattern(pattern string) (recSetShard, bool) {
+	var setScratch [32]queryBigramPosting
+	sets := setScratch[:0]
+	var previous rune
+	havePrevious := false
+	for _, current := range pattern {
+		if current == '%' || current == '_' {
+			havePrevious = false
+			continue
 		}
-		sets = append(sets, set)
+		current = normalizeBigramRune(current)
+		if havePrevious {
+			position := s.grams.find(normalizedBigramKey(previous, current))
+			if position < 0 {
+				return recSetShard{kind: recSetRanges, universe: s.universe}, true
+			}
+			duplicate := false
+			for _, existing := range sets {
+				if existing.position == position {
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate {
+				sets = append(sets, queryBigramPosting{
+					set: s.grams.sets[position], count: s.grams.counts[position], position: position,
+				})
+			}
+		}
+		previous = current
+		havePrevious = true
 	}
-	sort.Slice(sets, func(i, j int) bool { return sets[i].count < sets[j].count })
-	result := recSetShardFromSingleFullRange(nil, s.universe)
+	if len(sets) == 0 {
+		return recSetShard{}, false
+	}
+	return s.intersectCandidates(sets), true
+}
+
+type queryBigramPosting struct {
+	set      CompressedRecSet
+	count    uint32
+	position int
+}
+
+func (s *bigramIndex) intersectCandidates(sets []queryBigramPosting) recSetShard {
+	// Patterns normally contain only a few distinct bigrams. Insertion sort
+	// avoids sort.Interface/closure escape overhead and is optimal here.
+	for position := 1; position < len(sets); position++ {
+		value := sets[position]
+		previous := position - 1
+		for previous >= 0 && sets[previous].count > value.count {
+			sets[previous+1] = sets[previous]
+			previous--
+		}
+		sets[previous+1] = value
+	}
+	// Persistent postings optimize resident size; this query-local result
+	// optimizes repeated intersections and membership probes. Materialize one
+	// disposable full bitmap and let every compressed source clear it in place.
+	words := make([]uint32, (s.universe+31)/32)
+	for index := range words {
+		words[index] = ^uint32(0)
+	}
+	if tail := s.universe & 31; tail != 0 && len(words) > 0 {
+		words[len(words)-1] = uint32(1)<<tail - 1
+	}
+	result := recSetShard{kind: recSetBitmap, universe: s.universe, data: words, count: int64(s.universe)}
 	for _, set := range sets {
 		set.set.AndMut(&result)
 		if result.count == 0 {

--- a/storage/storage-int.go
+++ b/storage/storage-int.go
@@ -2099,6 +2099,77 @@ func (s *StorageInt) GetValueUInt(i uint32) uint64 {
 	return uint64(v) >> (64 - uint(s.bitsize)) // shift right without sign
 }
 
+// GetValuesUInt32Range decodes consecutive, non-NULL integers without Scmer
+// boxing. Composite storage types use this for internal uint32 vectors. The
+// caller guarantees that all decoded values fit uint32.
+func (s *StorageInt) GetValuesUInt32Range(recid uint32, count uint32, target []uint32, stride int) {
+	if count == 0 {
+		return
+	}
+	if s.hasNull {
+		panic("StorageInt: UInt32 extraction does not support NULL")
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	bitsize := uint(s.bitsize)
+	bitpos := uint(recid) * bitsize
+	chunkIdx := bitpos / 64
+	bitOff := bitpos % 64
+	targetIndex := 0
+	for range count {
+		value := s.chunk[chunkIdx] << bitOff
+		if bitOff+bitsize > 64 {
+			value |= s.chunk[chunkIdx+1] >> (64 - bitOff)
+		}
+		target[targetIndex] = uint32(int64(value>>(64-bitsize)) + s.offset)
+		targetIndex += stride
+		bitOff += bitsize
+		if bitOff >= 64 {
+			bitOff -= 64
+			chunkIdx++
+		}
+	}
+}
+
+// GetValuesUInt32Multi is the arbitrary-position counterpart to
+// GetValuesUInt32Range. Adjacent IDs retain the rolling bit cursor.
+func (s *StorageInt) GetValuesUInt32Multi(recids []uint32, target []uint32, stride int) {
+	if len(recids) == 0 {
+		return
+	}
+	if s.hasNull {
+		panic("StorageInt: UInt32 extraction does not support NULL")
+	}
+	if stride <= 0 {
+		stride = 1
+	}
+	bitsize := uint(s.bitsize)
+	var chunkIdx, bitOff uint
+	var previous uint32
+	havePosition := false
+	targetIndex := 0
+	for _, recid := range recids {
+		if !havePosition || recid != previous+1 {
+			bitpos := uint(recid) * bitsize
+			chunkIdx = bitpos / 64
+			bitOff = bitpos % 64
+		}
+		value := s.chunk[chunkIdx] << bitOff
+		if bitOff+bitsize > 64 {
+			value |= s.chunk[chunkIdx+1] >> (64 - bitOff)
+		}
+		target[targetIndex] = uint32(int64(value>>(64-bitsize)) + s.offset)
+		targetIndex += stride
+		previous, havePosition = recid, true
+		bitOff += bitsize
+		if bitOff >= 64 {
+			bitOff -= 64
+			chunkIdx++
+		}
+	}
+}
+
 // GetValueRange decodes count consecutive bit-packed values starting at
 // recid. Unlike calling GetValueUInt in a loop, it keeps a running
 // chunk/bit-offset cursor and advances it by bitsize each step instead of
@@ -2236,6 +2307,33 @@ func (s *StorageInt) prepare() {
 	s.offset = int64(1<<63 - 1)
 	s.max = -s.offset - 1
 	s.hasNull = false
+}
+
+// initValuesUInt32 initializes the normal StorageInt bit layout when a
+// composite storage already knows its exact non-NULL uint32 range.
+func (s *StorageInt) initValuesUInt32(count uint32, minimum, maximum uint32) {
+	*s = StorageInt{offset: int64(minimum), max: int64(maximum), count: uint64(count)}
+	s.bitsize = uint8(bits.Len32(maximum - minimum))
+	if s.bitsize == 0 {
+		s.bitsize = 1
+	}
+	if count > 0 {
+		s.chunk = make([]uint64, ((uint(count)-1)*uint(s.bitsize)+65)/64+1)
+	}
+}
+
+// buildValueUInt32 stores one value in an initValuesUInt32 backing without
+// constructing a Scmer.
+func (s *StorageInt) buildValueUInt32(i uint32, value uint32) {
+	if i >= uint32(s.count) || int64(value) < s.offset || int64(value) > s.max {
+		panic("StorageInt: uint32 value outside initialized range")
+	}
+	bitpos := uint(i) * uint(s.bitsize)
+	packed := uint64(int64(value)-s.offset) << (64 - uint(s.bitsize))
+	s.chunk[bitpos/64] |= packed >> (bitpos % 64)
+	if bitpos%64+uint(s.bitsize) > 64 {
+		s.chunk[bitpos/64+1] |= packed << (64 - bitpos%64)
+	}
 }
 func (s *StorageInt) scan(i uint32, value scm.Scmer) {
 	// storage is so simple, dont need scan

--- a/storage/storage-int_test.go
+++ b/storage/storage-int_test.go
@@ -1,10 +1,48 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 package storage
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
 )
+
+func TestStorageIntUInt32BuildAndBatchExtraction(t *testing.T) {
+	values := []uint32{1000, 1001, 1007, 1031, 1032, 1063, 1064, 1099, 1100, 1127, 1128}
+	var storage StorageInt
+	storage.initValuesUInt32(uint32(len(values)), values[0], values[len(values)-1])
+	for index, value := range values {
+		storage.buildValueUInt32(uint32(index), value)
+	}
+
+	rangeTarget := make([]uint32, 9)
+	storage.GetValuesUInt32Range(2, 4, rangeTarget[1:], 2)
+	if want := []uint32{0, 1007, 0, 1031, 0, 1032, 0, 1063, 0}; !reflect.DeepEqual(rangeTarget, want) {
+		t.Fatalf("UInt32 range = %v, want %v", rangeTarget, want)
+	}
+
+	multiTarget := make([]uint32, 8)
+	storage.GetValuesUInt32Multi([]uint32{0, 1, 5, 9}, multiTarget, 2)
+	if want := []uint32{1000, 0, 1001, 0, 1063, 0, 1127, 0}; !reflect.DeepEqual(multiTarget, want) {
+		t.Fatalf("UInt32 multi = %v, want %v", multiTarget, want)
+	}
+}
 
 // buildStorageInt builds a StorageInt via the standard prepare/scan/init/build/finish pipeline.
 func buildStorageInt(values []scm.Scmer) *StorageInt {


### PR DESCRIPTION
## What

Follow-up to #571 that keeps the public `CompressedRecSet.AndMut` contract but replaces its expensive resident and query-time implementation:

- choose per posting between a packed `StorageInt` RecID list, packed `StorageInt` ranges, and a raw bitmap;
- remove rANS from postings after profiling showed that its small resident-size advantage did not repay its decode/build cost;
- intersect every source representation directly and in place with bitmap, positive-list, and range RecSet destinations (3×3), without normalizing through a copied bitmap;
- decode packed integer batches through new unboxed `StorageInt.GetValuesUInt32Range` / `GetValuesUInt32Multi` APIs with stride support;
- build postings sparsely and promote to a temporary bitmap only at list/bitmap break-even;
- keep the query-local intersection as one disposable bitmap for fast repeated `AndMut` and row membership;
- replace the resident bigram hashmap with sorted compact key/set/count arrays; the build-only ASCII lookup table and Unicode map are released before final compression;
- scan LIKE patterns directly as runes without allocating an intermediate bigram array.

The shard-local index still covers main rows only. Delta rows pass through the row matcher and remain checked by the existing residual `STRLIKE` predicate.

## Memory accounting

`bigramIndex.ComputeSize` includes the index struct, the capacities of all three sorted-table backing arrays, every concrete compressed posting struct, and all bitmap/`StorageInt` backing capacities. There is no resident hashmap. Tests independently reconstruct the owned size for bitmap, positive-list, and range postings and compare it to the stored accounting value.

This is more exact than older storage accounting such as `StorageSparse`/`StorageEnum`, which still uses fixed management estimates and often counts lengths rather than capacities. As elsewhere in storage accounting, Go allocator size-class rounding is not included because it is not observable from an allocation.

## SQL A/B/C benchmark

All timings and allocations below come from real SQL sent through MemCP's HTTP SQL compiler/executor, not hand-built storage plans. The same persisted fixture and query sequence was used for:

- A: pre-#571 master (`04af4e092`)
- B: merged #571 (`635a9832d`)
- C: this PR (`8a69be655`)

Fixture: 1,000,000 rows in one deliberately fixed shard; compressed text column exactly 40,765,703 B (38.88 MiB); 100 controlled matches each for `fox`, `needle`, and `casinoword`. The runner discovers and sums every shard through table metadata instead of assuming a shard count.

### End-to-end SQL latency

| SQL pattern | A: old master | B: #571 | C: this PR | C vs A | C vs B |
|---|---:|---:|---:|---:|---:|
| hit, 3 chars (`%fox%`) | 89.42 ms | 15.43 ms | 12.15 ms | 7.4× faster | 1.27× faster |
| hit, 6 chars (`%needle%`) | 83.92 ms | 14.64 ms | 11.49 ms | 7.3× faster | 1.27× faster |
| hit, 10 chars (`%casinoword%`) | 86.76 ms | 17.44 ms | 11.36 ms | 7.6× faster | 1.53× faster |
| miss, 2 chars (`%xy%`) | 85.28 ms | 13.47 ms | 10.76 ms | 7.9× faster | 1.25× faster |
| miss, 3 chars (`%zzz%`) | 85.79 ms | 12.20 ms | 11.14 ms | 7.7× faster | 1.10× faster |
| miss, 6 chars (`%zzzzzz%`) | 87.31 ms | 12.23 ms | 11.04 ms | 7.9× faster | 1.11× faster |
| miss, 10 chars (`%zzzzzzzzzz%`) | 89.41 ms | 16.49 ms | 12.01 ms | 7.4× faster | 1.37× faster |

### Cold build and allocations

The first row includes normal process/column cold-start work. “Activate index” is the following unseen-bigram SQL that actually deploys/builds the shard-local index. “Warm same SQL” repeats it.

| Phase | A time / mallocs / allocated | B time / mallocs / allocated | C time / mallocs / allocated |
|---|---:|---:|---:|
| cold process SQL | 503.95 ms / 9,054,583 / 227,914,872 B | 489.43 ms / 9,054,601 / 227,879,056 B | 496.89 ms / 9,054,624 / 227,931,400 B |
| activate index | 88.32 ms / 796 / 251,040 B | 1,083.47 ms / 12,477 / 436,865,280 B | 264.29 ms / 9,565 / 159,086,264 B |
| warm same SQL | 0.83 ms / 760 / 70,632 B | 14.07 ms / 813 / 116,448 B | 11.72 ms / 807 / 116,536 B |

Compared with #571, index activation is 4.10× faster, performs 23.3% fewer allocations, and allocates 63.6% fewer bytes.

Representative unseen 6-character miss allocations are 816 mallocs / 203,864 B on old master, 859 / 111,744 B on #571, and 848 / 74,336 B here. The row matcher itself remains at 0 allocations per input batch.

### Resident index size (`ComputeSize`)

| Build | LIKE index | Ratio to compressed text |
|---|---:|---:|
| A: old per-pattern cache state | 3,422 B | 0.01% |
| B: #571 | 4,080,329 B (3.89 MiB) | 10.01% |
| C: this PR | 5,775,312 B (5.51 MiB) | 14.17% |

C intentionally spends 1.62 MiB (41.5%) more than #571 on this repetitive fixture to remove rANS. A representation breakdown independently reconstructs the totals: #571 uses 110 rANS postings totaling 4,059,673 B; C uses 10 bitmaps totaling 1,250,320 B, 41 packed positive postings totaling 8,016 B, and 135 packed range postings totaling 4,511,424 B. Sorted-table overhead is only 5,208 B, so the increase is representation data rather than double-counted table or map memory.

The profile showed rANS size calculation and encoding dominating the previous cold build. The corrected benchmark quantifies the trade: +41.5% resident index memory for 4.10× faster construction, 63.6% fewer constructed bytes, and consistently faster arbitrary SQL terms. For the reported real dataset with about 60 MiB compressed text, this fixture's ratio projects to roughly 8.5 MiB of bigram index if its distribution is comparable.

## Profile

Before removal, rANS bitmap size calculation was 26.8% flat CPU and encoding another 8.9% flat (21.6% cumulative). In the final no-rANS SQL profile those functions disappear entirely; remaining index work is posting insertion, one-time bitmap statistics, and final `StorageInt` packing.

## Verification

- targeted compressed RecSet/StorageInt/index tests, including all representation pairings and randomized tail-word boundaries: pass
- `tests/storage/indexes/fulltext-like-index.yaml`: 85/85
- `tests/execution/operators/recset.yaml`: 34/34
- SQL coverage: `buildBigramIndex` 88.5%, posting `add`/`finish` 100%, sorted table and size methods 100%, candidate-pattern path 96%; direct compressed intersection branches additionally covered by storage tests
- `git diff --check`: pass
