### PR TITLE
Fix AUTO_INCREMENT routing across range shards

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -37,22 +37,25 @@ type shardDimension struct {
 }
 
 // computes the index of a datapoint in PShards -> if item == pivot, sort left
+func computeShardDimensionIndex(sd shardDimension, value scm.Scmer) int {
+	min := 0                    // greater equal min
+	max := sd.NumPartitions - 1 // smaller than max
+	for min < max {
+		pivot := (min + max - 1) / 2
+		if scm.Less(sd.Pivots[pivot], value) {
+			min = pivot + 1
+		} else {
+			max = pivot
+		}
+	}
+	return min
+}
+
 func computeShardIndex(schema []shardDimension, values []scm.Scmer) (result int) {
 	for i, sd := range schema {
-		// get slice idx of this dimension
-		min := 0                    // greater equal min
-		max := sd.NumPartitions - 1 // smaller than max
-		for min < max {
-			pivot := (min + max - 1) / 2
-			if scm.Less(sd.Pivots[pivot], values[i]) {
-				min = pivot + 1
-			} else {
-				max = pivot
-			}
-		}
-		result = result*sd.NumPartitions + min // accumulate
+		result = result*sd.NumPartitions + computeShardDimensionIndex(sd, values[i])
 	}
-	return // schema[0] has the higest stride; schema[len(schema)-1] is the least significant bit
+	return // schema[0] has the highest stride; the last dimension is least significant
 }
 
 // runFanoutTasks executes a fanout without recursively multiplying worker

--- a/storage/table.go
+++ b/storage/table.go
@@ -2257,12 +2257,31 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 		// TODO: check which shards are involved; a sharding dimension column must be present in ALL unique keys, otherwise we cannot prune
 		dims := topology.dimensions
 		partitionShards := topology.shards
-		shardcols := make([]scm.Scmer, len(dims))
 		translatable := make([]int, len(dims))
+		omittedPartitions := make([]int, len(dims))
 		for i, cd := range dims {
+			translatable[i] = -1
 			for j, col := range columns {
 				if cd.Column == col {
 					translatable[i] = j
+					break
+				}
+			}
+			if translatable[i] >= 0 {
+				continue
+			}
+			defaultValue := scm.NewNil()
+			for _, col := range t.Columns {
+				if cd.Column == col.Name {
+					defaultValue = col.Default
+					if col.AutoIncrement {
+						// Generated AUTO_INCREMENT values are monotonically above the
+						// values from which the immutable range pivots were derived.
+						omittedPartitions[i] = cd.NumPartitions - 1
+						break
+					}
+					omittedPartitions[i] = computeShardDimensionIndex(cd, defaultValue)
+					break
 				}
 			}
 		}
@@ -2312,14 +2331,18 @@ func (t *table) Insert(columns []string, values [][]scm.Scmer, onCollisionCols [
 		last_i := 0
 		var last_shard *storageShard = nil
 		for i := 0; i < len(values); i++ {
-			for j, colidx := range translatable {
-				if colidx < len(values[i]) {
-					shardcols[j] = values[i][colidx]
+			shardnum := 0
+			for j, dim := range dims {
+				partition := 0
+				colidx := translatable[j]
+				if colidx >= 0 && colidx < len(values[i]) {
+					partition = computeShardDimensionIndex(dim, values[i][colidx])
 				} else {
-					shardcols[j] = scm.NewNil()
+					partition = omittedPartitions[j]
 				}
+				shardnum = shardnum*dim.NumPartitions + partition
 			}
-			shard := partitionShards[computeShardIndex(dims, shardcols)]
+			shard := partitionShards[shardnum]
 			if i > 0 && shard != last_shard {
 				checkUniqueForShard(last_shard, values[last_i:i]) // shard has changed: bulk insert all items that belong to this shard
 				last_i = i

--- a/tests/sql/ddl/auto-increment.yaml
+++ b/tests/sql/ddl/auto-increment.yaml
@@ -1,3 +1,10 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
 metadata:
   version: "1.0"
   description: "AUTO_INCREMENT correctness: sequential assignment, explicit ID coexistence, counter persistence"
@@ -10,6 +17,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS ai_restart"
   - sql: "DROP TABLE IF EXISTS ai_same_col"
   - sql: "DROP TABLE IF EXISTS ai_tx"
+  - sql: "DROP TABLE IF EXISTS ai_partitioned"
   - sql: "CREATE TABLE ai_basic (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT)"
   - sql: "CREATE TABLE ai_explicit (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT)"
   - sql: "CREATE TABLE ai_mixed (id INT AUTO_INCREMENT PRIMARY KEY, val INT)"
@@ -23,6 +31,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS ai_mixed"
   - sql: "DROP TABLE IF EXISTS ai_same_col"
   - sql: "DROP TABLE IF EXISTS ai_tx"
+  - sql: "DROP TABLE IF EXISTS ai_partitioned"
 
 test_cases:
 
@@ -236,6 +245,51 @@ test_cases:
       rows: 1
       data:
         - {cnt: 2}
+
+  # --- Partition routing: omitted AUTO_INCREMENT key is generated only after
+  # shard selection and must nevertheless route to the key's range shard. ---
+
+  - name: "Partitioned auto ID: create compact fixture"
+    setup:
+      - scm: '(settings "ShardSize" 3)'
+      - scm: '(settings "PartitionMaxDimensions" 1)'
+      - sql: "CREATE TABLE ai_partitioned (id INT AUTO_INCREMENT PRIMARY KEY, tenant INT, name TEXT)"
+    scm: |
+      (begin
+        (insert (table "memcp-tests" "ai_partitioned") '("id" "tenant" "name")
+          (map (produceN 21) (lambda (i) (list (+ i 1) (mod i 2) (concat "main-" i)))))
+        true)
+
+  - name: "Partitioned auto ID: repartition by ID"
+    scm: |
+      (partitiontable
+        (table "memcp-tests" "ai_partitioned")
+        (list (list "id" (list 3 6 9 12 15 18))))
+
+  - name: "Partitioned auto ID: insert without partition key"
+    sql: "INSERT INTO ai_partitioned (tenant, name) VALUES (0, 'generated-high-id')"
+    expect:
+      affected_rows: 1
+
+  - name: "Partitioned auto ID: generated row exists without ID pruning"
+    sql: "SELECT id, name FROM ai_partitioned WHERE name = 'generated-high-id'"
+    expect:
+      data:
+        - id: 22
+          name: "generated-high-id"
+
+  - name: "Partitioned auto ID: generated key remains index-visible"
+    sql: "SELECT id, name FROM ai_partitioned WHERE id = 22"
+    expect:
+      data:
+        - id: 22
+          name: "generated-high-id"
+
+  - name: "Partitioned auto ID: restore shard size"
+    scm: |
+      (begin
+        (settings "ShardSize" 60000)
+        (settings "PartitionMaxDimensions" 0))
 
   # --- Restart scenario: counter must survive server restart ---
   # ai_restart table was created and seeded in setup (no inserts yet).


### PR DESCRIPTION
## Root cause

For inserts without an explicit `AUTO_INCREMENT` key, MemCP selected the partition before generating the key. Missing partition-dimension columns implicitly mapped to column index 0, so the first value that was actually supplied could be used for shard selection instead. The subsequently generated primary key was therefore stored in the wrong range shard. Full scans still found the row, while sargable ID predicates using shard pruning did not.

## Changes

- explicitly distinguish omitted partition-dimension columns from column index 0;
- route an omitted `AUTO_INCREMENT` dimension to the final immutable range partition;
- route other omitted dimension columns according to their default value;
- extract the binary dimension lookup into a shared helper;
- add a deterministic regression fixture with several ID range shards.

## Performance impact

No performance regression is expected in partitioned inserts. The old hot path first populated a `[]scm.Scmer` scratch slice for every row and then traversed all dimensions again in `computeShardIndex`. The new path computes and accumulates the partition index in a single dimension loop, performs no per-row allocation, and replaces the statement-local `scm.Scmer` scratch storage with precomputed integer fallback partitions. The extracted binary-search helper is small and inlineable.

The additional column/default lookup runs once per insert statement, only for omitted partition dimensions; it is outside the row loop.

## Validation

- unchanged `master`: regression suite reports 43/44; `WHERE id = 22` fails to find the inserted row;
- with this fix: 44/44;
- full `make test`: passed.
