### PR TITLE
Reject empty dashboard authentication scans

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -17,17 +17,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* Dashboard: admin-only live metrics via WebSocket */
 
+/* Parallel scan reduction may represent an empty result as nil or (). */
+(define dashboard_auth_row_present? (lambda (row)
+	(not (empty_list? row))))
+
 /* check admin credentials against system.user table */
 (define dashboard_check_admin (lambda (req) (begin
 	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
-	(if (nil? pw) false
+	(if (not (dashboard_auth_row_present? pw)) false
 		(and (equal? (car pw) (password (req "password"))) (car (cdr pw))))
 )))
 
 /* check any authenticated user (returns admin flag or false) */
 (define dashboard_check_user (lambda (req) (begin
 	(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password" "admin") (lambda (password admin) (list password admin)) (lambda (a b) b) nil))
-	(if (nil? pw) nil
+	(if (not (dashboard_auth_row_present? pw)) nil
 		(if (equal? (car pw) (password (req "password"))) (equal? (car (cdr pw)) 1) nil))
 )))
 

--- a/tests/sql/security/mysql-auth-tx-nil.yaml
+++ b/tests/sql/security/mysql-auth-tx-nil.yaml
@@ -52,5 +52,14 @@ test_cases:
         "ok"
         (error "missing dashboard admin credentials should be rejected"))
 
+  - name: "Dashboard authentication treats an empty scan list as no user"
+    scm: |
+      (if
+        (and
+          (not (dashboard_auth_row_present? nil))
+          (not (dashboard_auth_row_present? '())))
+        "ok"
+        (error "an empty authentication scan result must be rejected"))
+
 cleanup:
   - sql: "DELETE FROM system.user WHERE username IN ('auth_scan_nil_repro', 'auth_scan_nil_other')"


### PR DESCRIPTION
## Summary
- treat both `nil` and the empty list as an authentication miss
- prevent dashboard authentication from calling `car` on an empty parallel scan result
- cover both empty-result representations in the security suite

## Verification
- `python3 tools/lint_scm.py --path lib/dashboard.scm --check`
- `go build -o memcp .`
- `python3 run_sql_tests.py tests/sql/security/mysql-auth-tx-nil.yaml <port> --connect-only` (6/6)
- `make test` (full hook-equivalent suite, green)