### PR TITLE
perf: cost text carriers from index selectivity

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -1692,6 +1692,44 @@ guarded by the values observed while compiling the cached plan. */
 (define like_pattern_core (lambda (pattern)
 	(replace (replace (coalesceNil pattern "") "%" "") "_" "")))
 
+(define text_pattern_selectivity_prior_for_length (lambda (length)
+	(if (<= length 0)
+		1
+		(if (equal? length 1)
+			0.7
+			(max 0.01 (* 0.35
+				(text_pattern_selectivity_prior_for_length (- length 1))))))))
+
+/* Before an index has a measured candidate density, text length is still
+useful statistical evidence. Single-character searches are usually broad;
+each additional literal character rapidly narrows the candidate set. The
+floor avoids pretending that an unseen word is impossible. */
+(define text_pattern_selectivity_prior (lambda (pattern)
+	(if (not (string? pattern))
+		nil
+		(text_pattern_selectivity_prior_for_length
+			(strlen (like_pattern_core pattern))))))
+
+(define expr_text_selectivity_prior (lambda (expr)
+	(match expr
+		((symbol strlike) _value pattern _collation)
+		(text_pattern_selectivity_prior (planner_string_expr_value pattern))
+		((quote strlike) _value pattern _collation)
+		(text_pattern_selectivity_prior (planner_string_expr_value pattern))
+		(cons head tail) (reduce tail (lambda (found item)
+			(if (number? found) found (expr_text_selectivity_prior item)))
+			(expr_text_selectivity_prior head))
+		_ nil)))
+
+(define expr_text_pattern_expr (lambda (expr)
+	(match expr
+		((symbol strlike) _value pattern _collation) pattern
+		((quote strlike) _value pattern _collation) pattern
+		(cons head tail) (reduce tail (lambda (found item)
+			(if (nil? found) (expr_text_pattern_expr item) found))
+			(expr_text_pattern_expr head))
+		_ nil)))
+
 (define broad_like_pattern? (lambda (pattern)
 	(if (not (string? pattern))
 		false
@@ -1784,12 +1822,16 @@ guarded by the values observed while compiling the cached plan. */
 					(define filter_expr (optimize (list (quote lambda)
 						(map filtercols (lambda (col) (symbol (concat alias "." col))))
 						(lower_column_expr_for_alias src condition))))
-					(scan_selectivity_estimate
+					(define estimate (scan_selectivity_estimate
 						(session "__memcp_tx")
 						(table (source_schema src) (source_relation src))
 						filtercols
 						(eval filter_expr)
-						max_rows)))
+						max_rows))
+					(define text_prior (expr_text_selectivity_prior condition))
+					(if (number? text_prior)
+						(qassoc_set estimate (quote fallback_selectivity) text_prior)
+						estimate)))
 			(lambda (_e) nil)))))
 
 (define planner_source_row_count (lambda (src)
@@ -2576,7 +2618,12 @@ extrapolated as though the iterator were an unbiased table sample. */
 				(and (number? input_rows)
 					(and (number? rows) (and (number? sampled_input) (> sampled_input 0)))))
 				(if (equal? (planner_estimate_coverage estimate) (quote lower_bound))
-					(coalesceNil fallback input_rows)
+					(begin
+						(define fallback_selectivity
+							(qassoc_get estimate (quote fallback_selectivity) nil))
+						(if (number? fallback_selectivity)
+							(min input_rows (max rows (* input_rows fallback_selectivity)))
+							(coalesceNil fallback input_rows)))
 					(min input_rows (* input_rows (/ rows sampled_input))))
 				(coalesceNil rows fallback))))))
 

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3406,12 +3406,6 @@ it does not recover parser spelling or leak a scan into logical IR. */
 						(list alias))))
 					best
 					(begin
-						(reduce (query_expr_session_reads term) (lambda (_ expr)
-							(begin
-								(define value (planner_literal_value expr))
-								(planner_record_guard_condition
-									(list (quote equal?) expr
-										(if (list? value) (list (quote quote) value) value))))) nil)
 						(define estimate (planner_source_filter_estimate src term 512))
 						(define rows (membership_estimated_matching_rows estimate input_rows nil))
 						(define work (membership_source_work_profile src term true))
@@ -3476,6 +3470,48 @@ this lowering boundary. */
 			(planner_join_work_cost rows 0.65)
 			rows 0.65))))
 
+/* Both alternatives contain the same text scan. Solve the remaining linear
+cost inequality once and guard the cached plan by that crossover, not by an
+exact parameter value. */
+(define selective_text_filter_crossover_rows (lambda (src candidate)
+	(begin
+		(define zero_candidate (qassoc_set candidate (quote rows) 0))
+		(define one_candidate (qassoc_set candidate (quote rows) 1))
+		(define recset_zero (qassoc_get
+			(selective_text_filter_recset_cost src zero_candidate) (quote total_ns) 0))
+		(define recset_one (qassoc_get
+			(selective_text_filter_recset_cost src one_candidate) (quote total_ns) 0))
+		(define base_total (qassoc_get
+			(selective_text_filter_base_cost src candidate) (quote total_ns) 0))
+		(define row_slope (- recset_one recset_zero))
+		(if (<= row_slope 0)
+			0
+			(max 0 (/ (- base_total recset_zero) row_slope))))))
+
+(define selective_text_filter_runtime_rows_expr (lambda (src candidate)
+	(begin
+		(define predicate (qassoc_get candidate (quote predicate) true))
+		(define alias (source_alias src))
+		(define cols (extract_columns_for_alias src predicate))
+		(define pattern_expr (expr_text_pattern_expr predicate))
+		(define estimate_expr (list (quote scan_selectivity_estimate)
+			'(session "__memcp_tx")
+			(list (quote table) (source_schema src) (source_relation src))
+			(cons (quote list) cols)
+			(list (quote lambda)
+				(map cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+				(lower_column_expr_for_alias src predicate))
+			512))
+		(list (quote membership_estimated_matching_rows)
+			(if (nil? pattern_expr)
+				estimate_expr
+				(list (quote qassoc_set)
+					estimate_expr
+					(list (quote quote) (quote fallback_selectivity))
+					(list (quote text_pattern_selectivity_prior) pattern_expr)))
+			(qassoc_get candidate (quote input_rows) nil)
+			(qassoc_get candidate (quote input_rows) nil)))))
+
 (define choose_selective_text_filter_carrier (lambda (src candidate)
 	(if (nil? candidate)
 		(list "fused_base_scan" nil)
@@ -3487,6 +3523,18 @@ this lowering boundary. */
 			(define work (qassoc_get candidate (quote work) '()))
 			(define normal_choice (if (planner_cost_better? recset_cost base_cost)
 				"scan_recset" "fused_base_scan"))
+			(define crossover_rows (selective_text_filter_crossover_rows src candidate))
+			(if (empty_list? (query_expr_session_reads
+				(qassoc_get candidate (quote predicate) true)))
+				nil
+				(planner_record_guard_condition
+					(if (equal? normal_choice "scan_recset")
+						(list (quote <)
+							(selective_text_filter_runtime_rows_expr src candidate)
+							crossover_rows)
+						(list (quote >=)
+							(selective_text_filter_runtime_rows_expr src candidate)
+							crossover_rows))))
 			(define alternatives (list "scan_recset" "fused_base_scan"))
 			(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 			(define forced (planner_physical_override decision_id))
@@ -3513,7 +3561,8 @@ this lowering boundary. */
 					(list "driver_rows" (qassoc_get candidate (quote rows) nil))
 					(list "driver_input_rows" (qassoc_get candidate (quote input_rows) nil))
 					(list "density" (/ (qassoc_get candidate (quote rows) 0)
-						(qassoc_get candidate (quote input_rows) 1)))))
+						(qassoc_get candidate (quote input_rows) 1)))
+					(list "crossover_rows" crossover_rows)))
 				(list "alternatives" (list
 					(list
 						(list "plan" "scan_recset")

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -576,6 +576,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(list (quote coverage) (quote lower_bound)))
 		100000 100000) 100000
 		"capped index candidates remain a lower bound instead of becoming 100% selectivity")
+	(assert (text_pattern_selectivity_prior "%x%") 0.7
+		"single-character text patterns use a broad prior")
+	(assert (text_pattern_selectivity_prior "%needle%") 0.01
+		"long text patterns use the selective prior floor")
+	(assert (membership_estimated_matching_rows
+		(list
+			(list (quote rows) 512)
+			(list (quote sampled) 512)
+			(list (quote capped) true)
+			(list (quote population) (quote index_candidates))
+			(list (quote coverage) (quote lower_bound))
+			(list (quote fallback_selectivity) 0.01))
+		100000 100000) 1000
+		"capped text index candidates use the statistical prior instead of 100 percent")
 	(assert (membership_estimated_matching_rows
 		(list
 			(list (quote rows) 128)

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -37,6 +37,13 @@ type IndexHook interface {
 	ComputeSize() uint
 }
 
+// IndexCandidateEstimator is an optional, constant-time cardinality view over
+// a bound hook. Candidate counts may be upper bounds because the residual SQL
+// predicate remains authoritative for correctness.
+type IndexCandidateEstimator interface {
+	EstimateCandidates(lower scm.Scmer) (candidates uint32, universe uint32, ok bool)
+}
+
 // IndexDeployContext is passed while binding an analyzer to one shard. External
 // custom indexes can use the public batch reader without accessing shard state.
 type IndexDeployContext struct {

--- a/storage/compressed_recset_test.go
+++ b/storage/compressed_recset_test.go
@@ -292,8 +292,17 @@ func TestLikeBigramIndexCandidatesAreSafeSuperset(t *testing.T) {
 	check("%casino%", []uint32{0, 1})
 	check("%needle%", []uint32{4})
 	check("%missing%", []uint32{})
+	if candidates, universe, ok := index.EstimateCandidates(scm.NewString("%casino%")); !ok || candidates != 2 || universe != uint32(len(values)) {
+		t.Fatalf("casino estimate = (%d, %d, %v), want (2, %d, true)", candidates, universe, ok, len(values))
+	}
+	if candidates, universe, ok := index.EstimateCandidates(scm.NewString("%missing%")); !ok || candidates != 0 || universe != uint32(len(values)) {
+		t.Fatalf("missing estimate = (%d, %d, %v), want (0, %d, true)", candidates, universe, ok, len(values))
+	}
 	if _, constrained := index.candidatesPattern("%x%"); constrained {
 		t.Fatal("single-rune pattern unexpectedly produced a bigram constraint")
+	}
+	if _, _, ok := index.EstimateCandidates(scm.NewString("%x%")); ok {
+		t.Fatal("single-rune pattern unexpectedly produced a cardinality estimate")
 	}
 }
 

--- a/storage/index-recset.go
+++ b/storage/index-recset.go
@@ -50,6 +50,21 @@ type recSetIndexHook struct {
 
 func (h *recSetIndexHook) ComputeSize() uint { return 0 }
 
+func (h *recSetIndexHook) EstimateCandidates(lower scm.Scmer) (uint32, uint32, bool) {
+	if h == nil || h.shard == nil || !lower.IsCustom(TagRecSet) {
+		return 0, 0, false
+	}
+	set := RecSetFromScmer(lower)
+	if set == nil || set.table != h.shard.t {
+		return 0, 0, false
+	}
+	part := set.shardEntry(h.shard)
+	if part == nil {
+		return 0, h.shard.main_count, true
+	}
+	return uint32(part.count), h.shard.main_count, true
+}
+
 func (h *recSetIndexHook) Bind(lower scm.Scmer) IndexRowMatcher {
 	if h == nil || h.shard == nil || !lower.IsCustom(TagRecSet) {
 		return nil

--- a/storage/index-strlike.go
+++ b/storage/index-strlike.go
@@ -151,6 +151,33 @@ func (s *bigramIndex) Bind(lower scm.Scmer) IndexRowMatcher {
 	}
 }
 
+func (s *bigramIndex) EstimateCandidates(lower scm.Scmer) (uint32, uint32, bool) {
+	minimum := s.universe
+	constrained := false
+	var previous rune
+	havePrevious := false
+	for _, current := range lower.String() {
+		if current == '%' || current == '_' {
+			havePrevious = false
+			continue
+		}
+		current = normalizeBigramRune(current)
+		if havePrevious {
+			position := s.grams.find(normalizedBigramKey(previous, current))
+			if position < 0 {
+				return 0, s.universe, true
+			}
+			constrained = true
+			if count := s.grams.counts[position]; count < minimum {
+				minimum = count
+			}
+		}
+		previous = current
+		havePrevious = true
+	}
+	return minimum, s.universe, constrained
+}
+
 func normalizedBigramKey(left, right rune) uint64 {
 	return uint64(uint32(left))<<32 | uint64(uint32(right))
 }

--- a/storage/index.go
+++ b/storage/index.go
@@ -1085,6 +1085,45 @@ func (s *StorageIndex) bindRowMatchers(bounds boundaries, cols []colGetter, hook
 	}
 }
 
+func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds boundaries) (uint32, uint32, bool) {
+	state := s.stateForTx(tx, false)
+	if state == nil {
+		return 0, 0, false
+	}
+	s.mu.Lock()
+	if !state.active {
+		s.mu.Unlock()
+		return 0, 0, false
+	}
+	hooks := append([]IndexHook(nil), state.indexHooks...)
+	s.mu.Unlock()
+
+	var candidates uint32
+	var universe uint32
+	found := false
+	for colIdx, bound := range bounds {
+		if bound.matcher == nil || bound.matcher.IsSorted() || colIdx >= len(hooks) {
+			continue
+		}
+		estimator, ok := hooks[colIdx].(IndexCandidateEstimator)
+		if !ok {
+			continue
+		}
+		count, hookUniverse, ok := estimator.EstimateCandidates(bound.lower)
+		if !ok {
+			continue
+		}
+		if !found || count < candidates {
+			candidates = count
+		}
+		if hookUniverse > universe {
+			universe = hookUniverse
+		}
+		found = true
+	}
+	return candidates, universe, found
+}
+
 // iterate over index using a caller-provided buffer for batching
 func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2621,12 +2621,23 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	sampled := int64(0)
 	capped := false
 	indexRestricted := false
+	hookCandidates := int64(-1)
+	hookUniverse := int64(0)
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var buf [256]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, func(_ *StorageIndex, active bool) {
+	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, func(index *StorageIndex, active bool) {
 		indexRestricted = active && len(lower) > 0
+		if active {
+			if candidates, universe, ok := index.estimateHookCandidates(currentTx, bounds); ok {
+				hookCandidates = int64(candidates) + int64(len(t.inserts))
+				hookUniverse = int64(universe) + int64(len(t.inserts))
+			}
+		}
 	}, func(batch []uint32) bool {
+		if hookCandidates >= 0 {
+			return false
+		}
 		for _, idx := range batch {
 			if acidMode {
 				if !currentTx.IsVisible(t, idx) {
@@ -2669,6 +2680,14 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		}
 		return true
 	})
+	if hookCandidates >= 0 {
+		return filteredRowEstimate{
+			rows:       hookCandidates,
+			examined:   hookUniverse,
+			population: "index_hook_candidates",
+			coverage:   "upper_bound",
+		}
+	}
 
 	population := "table_rows"
 	if indexRestricted {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "io"
+import "math/rand"
 import "sort"
 import "unsafe"
 import "github.com/carli2/hybridsort"
@@ -641,11 +642,29 @@ func Init(en scm.Env) {
 			capped := false
 			population := "table_rows"
 			coverage := "exact"
-			for _, shard := range t.ActiveShards() {
+			shards := t.ActiveShards()
+			start := 0
+			if len(shards) > 1 {
+				start = rand.Intn(len(shards))
+			}
+			for offset := range shards {
+				shard := shards[(start+offset)%len(shards)]
 				if shard == nil {
 					continue
 				}
 				estimate := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
+				if estimate.population == "index_hook_candidates" && estimate.examined > 0 {
+					input := int64(t.CountEstimate())
+					estimatedRows := input * estimate.rows / estimate.examined
+					return scm.NewSlice([]scm.Scmer{
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(estimatedRows)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(false)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(estimate.examined)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol(estimate.population)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(estimate.coverage)}),
+					})
+				}
 				rows += estimate.rows
 				sampled += estimate.examined
 				if estimate.population != "table_rows" {

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -518,6 +518,29 @@ test_cases:
         - 'selective_text_filter_carrier'
         - 'chosen fused_base_scan'
 
+  - name: "Cached text filter recompiles across the RecSet cost crossover"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define resultrow (lambda (_row) nil))
+        (define selective_query "SELECT f.id, d.label FROM selective_text_driver f LEFT JOIN selective_text_dim d ON d.id = f.dim_id WHERE f.search LIKE '%needle%' ORDER BY f.id LIMIT 4")
+        (define broad_query "SELECT f.id, d.label FROM selective_text_driver f LEFT JOIN selective_text_dim d ON d.id = f.dim_id WHERE f.search LIKE '%asset%' ORDER BY f.id LIMIT 4")
+        (define first_formula (cached_parse cache parse_sql "memcp-tests" selective_query nil "root" sess true))
+        (with_session sess (lambda () (eval first_formula)))
+        (define entry (car (cache (car (cache)))))
+        (define variants_after_first (count (entry "variants")))
+        (define second_formula (cached_parse cache parse_sql "memcp-tests" broad_query nil "root" sess true))
+        (with_session sess (lambda () (eval second_formula)))
+        (if (and (equal? variants_after_first 1) (equal? (count (entry "variants")) 2))
+          "ok"
+          (error (concat "unexpected text selectivity variants: first=" variants_after_first
+            " final=" (count (entry "variants"))))))
+    expect:
+      data: ["ok"]
+
   - name: "EXPLAIN IR swaps to selective driver"
     fail_comment: "query is not fully decorrelated anymore; logical IR must not contain subquery markers"
     sql: "EXPLAIN IR SELECT d.label, m.id FROM perf_main m JOIN perf_dim d ON m.category = d.cat_id WHERE d.label = 'one'"


### PR DESCRIPTION
## What

- derive a bounded cold-start selectivity prior from the literal text length instead of treating every capped text estimate as 100% of the table
- let active RecSet and bigram index hooks expose a cheap candidate-count upper bound
- sample one random shard for active index cardinality and extrapolate it to the table; no all-shard statistics scan is added
- derive the RecSet-vs-fused-scan crossover algebraically from the calibrated operator cost functions
- guard cached parameterized plans by that crossover, so an index build or a different LIKE value recompiles only when the physical choice should actually change

## Why

The physical lowerer already had both `scan_recset` and fused base-scan alternatives, but a capped/unknown LIKE estimate fell back to the full input cardinality. That made a genuinely selective text carrier look maximally broad. Conversely, a fixed low default alone would misplan genuinely broad patterns.

This keeps correctness in the residual SQL predicate and uses candidate counts only for costing. The bigram estimate is a safe upper bound (minimum posting cardinality), while a RecSet supplies its exact shard-local cardinality.

## Tests

- unchanged broad `%asset%` fixture still chooses `fused_base_scan`
- selective `%needle%` fixture chooses `scan_recset`
- cached SQL changes from selective to broad and creates a second plan variant at the cost crossover
- bigram estimator covers present, absent, and unsupported one-character patterns
- full local hook-equivalent suite passed twice, including after rebasing onto current `master`

## Scope and measured counterexample

A prototype that blindly drove a wide `SELECT t.*` from the text filter was deliberately discarded: it repeated expensive correlated projections and measured about 256 s cold / 245 s warm on the real-data fixture. This PR does not hide that architectural issue behind a special rule. Wide repeated ACL projections need shared logical-stage/CSE work before that reorder can be profitable; this PR makes the already-valid RecSet/text-carrier decisions evidence- and cost-driven.
