### PR TITLE
fix: expose delta-only planner row estimates

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -872,6 +872,7 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 		}
 		// Install main_count — from this point, new inserts get correct recids
 		s.main_count = uint32(mainN)
+		s.plannerMainRows.Store(uint32(mainN))
 		deltaLen := len(s.inserts)
 		if deltaLen > 0 {
 			// Shift deletion bitmap: bits in [0, deltaLen) move to [mainN, mainN+deltaLen).

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -37,6 +37,11 @@ type storageShard struct {
 	uuid uuid.UUID // uuid.String()
 	// main storage
 	main_count uint32 // size of main storage
+	// plannerMainRows and plannerDeltaRows publish only row counts. They may be
+	// read without mu by the compiler; shard containers themselves remain
+	// strictly lock-protected. Writers update these counters while holding mu.
+	plannerMainRows  atomic.Uint32
+	plannerDeltaRows atomic.Uint64
 	// columns, deltaColumns, inserts, deletions and Indexes are shard-local
 	// internals guarded by mu. Code outside this file
 	// must treat s.mu as the only authority for shard-local state and must not
@@ -520,6 +525,7 @@ func (u *storageShard) ensureColumnLoaded(colName string, alreadyLocked bool) Co
 		f.Close()
 		if uint32(cnt) > u.main_count {
 			u.main_count = uint32(cnt)
+			u.plannerMainRows.Store(uint32(cnt))
 		}
 		columnstorage = u.attachColumnRuntime(colName, columnstorage)
 		u.columns[colName] = columnstorage
@@ -809,8 +815,10 @@ func cacheShardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	}
 	// clear in-memory data (no disk backing to flush to)
 	s.inserts = nil
+	s.plannerDeltaRows.Store(0)
 	s.deletions.Reset()
 	s.main_count = 0
+	s.plannerMainRows.Store(0)
 	for col := range s.columns {
 		if str, ok := s.columns[col].(*StorageString); ok && str.compressed {
 			GlobalCache.removeInternal(str, freedByType)
@@ -2434,6 +2442,7 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 			index.mu.Unlock()
 		}
 	}
+	t.plannerDeltaRows.Store(uint64(len(t.inserts)))
 	// If any row had an explicit AI value exceeding the reserved range, bump the counter.
 	// Auto_increment (local) holds the base before reservation; auto-assigned IDs are
 	// in [Auto_increment+1 .. Auto_increment+len(values)]. Any stored value beyond that
@@ -2501,6 +2510,7 @@ func (t *storageShard) insertDatasetFromLog(columns []string, values [][]scm.Scm
 			index.mu.Unlock()
 		}
 	}
+	t.plannerDeltaRows.Store(uint64(len(t.inserts)))
 }
 
 func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer, currentTx *TxContext) (result uint32, present bool) {
@@ -3167,6 +3177,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 				newProxy := cloneComputeProxyRows(oldProxy, result, rebuiltRowIDs)
 				result.columns[col] = newProxy
 				result.main_count = uint32(len(rebuiltRowIDs))
+				result.plannerMainRows.Store(result.main_count)
 				b.WriteString(col)
 				b.WriteString(" ")
 				b.WriteString(newProxy.String())
@@ -3222,6 +3233,7 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 
 			result.columns[col] = newcol
 			result.main_count = i
+			result.plannerMainRows.Store(i)
 
 			// write statistics
 			b.WriteString(col) // colname
@@ -3301,7 +3313,9 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 		result.columns = t.columns
 		result.deltaColumns = t.deltaColumns
 		result.main_count = t.main_count
+		result.plannerMainRows.Store(t.main_count)
 		result.inserts = t.inserts
+		result.plannerDeltaRows.Store(uint64(len(t.inserts)))
 		result.deletions = deletions
 		result.Indexes = t.Indexes
 		if t.t.PersistencyMode == Safe || t.t.PersistencyMode == Logged {

--- a/storage/table.go
+++ b/storage/table.go
@@ -1122,7 +1122,24 @@ func (t *table) Count() (result uint) {
 // lazy shard load. Statistics are refreshed by rebuild/collection; staleness is
 // preferable to adding locks or storage I/O to the query compiler hot path.
 func (t *table) CountEstimate() uint {
-	return uint(t.PlannerRowEstimate.value.Load())
+	rows := t.PlannerRowEstimate.value.Load()
+	if rows != 0 {
+		return uint(rows)
+	}
+	// A newly created table can be populated entirely through its one shard's
+	// delta before the first REBUILD publishes full statistics. Keep this common
+	// schema/import path useful to the planner even if a lower-level loader did
+	// not advance the table-wide estimate. The topology and both counters are
+	// atomically published; never inspect inserts or acquire a shard lock here.
+	topology := t.topology.Load()
+	if topology == nil || len(topology.shards) != 1 || topology.shards[0] == nil {
+		return 0
+	}
+	shard := topology.shards[0]
+	if shard.plannerMainRows.Load() != 0 {
+		return 0
+	}
+	return uint(shard.plannerDeltaRows.Load())
 }
 
 // initializeLegacyPlannerRowEstimate migrates schemas written before the

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -107,6 +107,54 @@ func TestCountEstimateIsLockFreeAndPersisted(t *testing.T) {
 	shard.mu.Unlock()
 }
 
+func TestCountEstimateFallsBackToSingleShardDeltaWithoutLocking(t *testing.T) {
+	dbName := "test_count_estimate_delta_only"
+	databases.Remove(dbName)
+	t.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	values := [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+		{scm.NewInt(3)},
+	}
+	tbl.Insert([]string{"id"}, values, nil, scm.NewNil(), false, nil)
+
+	// Simulate a missing pre-REBUILD table statistic. The fallback must use the
+	// atomically published delta length without looking through shard internals.
+	tbl.PlannerRowEstimate.value.Store(0)
+	shard := tbl.ActiveShards()[0]
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	done := make(chan uint, 1)
+	go func() { done <- tbl.CountEstimate() }()
+	select {
+	case got := <-done:
+		if got != 3 {
+			t.Fatalf("CountEstimate() = %d, want 3 delta rows", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("delta-only CountEstimate blocked on the shard lock")
+	}
+}
+
+func TestCountEstimateDoesNotTreatPersistedRowsAsDeltaOnly(t *testing.T) {
+	tbl := showColumnsTestTable(1)
+	shard := &storageShard{t: tbl, main_count: 9, srState: WRITE}
+	shard.plannerMainRows.Store(9)
+	shard.plannerDeltaRows.Store(3)
+	tbl.Shards = []*storageShard{shard}
+	tbl.mu.Lock()
+	tbl.publishTopologyLocked()
+	tbl.mu.Unlock()
+	tbl.PlannerRowEstimate.value.Store(0)
+
+	if got := tbl.CountEstimate(); got != 0 {
+		t.Fatalf("CountEstimate() = %d, want unavailable estimate with main storage", got)
+	}
+}
+
 func TestLegacyPlannerRowEstimateIsInitializedFromShards(t *testing.T) {
 	tbl := showColumnsTestTable(1)
 	// The first release containing planner_row_estimate could persist a zero


### PR DESCRIPTION
## Summary
- publish per-shard main and delta row counts through atomics
- let CountEstimate use the single-shard delta count before the first REBUILD
- keep the compiler path O(1), lock-free, and free of lazy storage loads
- maintain the counters across inserts, WAL replay, rebuild, repartition, and cache cleanup

## Validation
- go test -race ./storage -run '^(TestCountEstimateFallsBackToSingleShardDeltaWithoutLocking|TestCountEstimateDoesNotTreatPersistedRowsAsDeltaOnly|TestCountEstimateIsLockFreeAndPersisted)$' -count=20
- make test

The fallback is intentionally approximate: it reports the published delta length and does not inspect deletion state. A non-zero table-wide estimate still wins, and main-storage presence disables the delta-only fallback.