### PR TITLE
Skip irrelevant planner tree rebuilds

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -433,6 +433,14 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 		((quote dependent-subquery) _kind _probe _subquery _outer_sources) true
 		_ false)))
 
+(define expr_contains_dependent_subquery_marker? (lambda (expr)
+	(if (dependent_subquery_marker? expr)
+		true
+		(match expr
+			(cons _head tail) (reduce tail (lambda (found item)
+				(or found (expr_contains_dependent_subquery_marker? item))) false)
+			_ false))))
+
 (define dep_subquery_kind (lambda (expr) (nth expr 1)))
 (define dep_subquery_probe (lambda (expr) (nth expr 2)))
 (define dep_subquery_query (lambda (expr) (nth expr 3)))
@@ -4137,15 +4145,15 @@ carrier selection remains a later, per-stage cost decision. */
 			(nth rewritten 3))
 		rewritten)))
 
-(define btw2025_decorrelate_exprs_using (lambda (exprs ctx resolved)
+(define btw2025_decorrelate_marked_exprs_using (lambda (exprs ctx resolved)
 	(match exprs
 		(cons expr rest) (begin
-			(define current (btw2025_decorrelate_expr_using expr ctx resolved))
-			(define tail (btw2025_decorrelate_exprs_using rest ctx (nth current 1)))
+			(define current (btw2025_decorrelate_marked_expr_using expr ctx resolved))
+			(define tail (btw2025_decorrelate_marked_exprs_using rest ctx (nth current 1)))
 			(list (cons (nth current 0) (nth tail 0)) (nth tail 1)))
 		_ (list '() resolved))))
 
-(define btw2025_decorrelate_expr_using (lambda (expr ctx resolved)
+(define btw2025_decorrelate_marked_expr_using (lambda (expr ctx resolved)
 	(begin
 		(define key (btw2025_dependent_marker_key expr))
 		(if (and (not (nil? key)) (has_assoc? resolved key))
@@ -4158,11 +4166,16 @@ carrier selection remains a later, per-stage cost decision. */
 					(define rewritten (btw2025_resolve_dependent_subquery expr ctx))
 					(list rewritten (set_assoc resolved key rewritten)))
 				(cons head tail) (begin
-					(define rewritten_tail (btw2025_decorrelate_exprs_using tail ctx resolved))
+					(define rewritten_tail (btw2025_decorrelate_marked_exprs_using tail ctx resolved))
 					(list
 						(combine_stage_rewrite_results head (nth rewritten_tail 0))
 						(nth rewritten_tail 1)))
 				_ (list (list expr '() '()) resolved))))))
+
+(define btw2025_decorrelate_expr_using (lambda (expr ctx resolved)
+	(if (expr_contains_dependent_subquery_marker? expr)
+		(btw2025_decorrelate_marked_expr_using expr ctx resolved)
+		(list (list expr '() '()) resolved))))
 
 (define btw2025_decorrelate_expr_with_stages (lambda (expr ctx)
 	(nth (btw2025_decorrelate_expr_using expr ctx '()) 0)))

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -1442,33 +1442,48 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(begin
 			(define planned (apply_join_optimizer_plan node))
 			(define physical_planned (query_block_with_physical_requirement_choices planned))
-			(define physical_consumer (if (query_block_has_aggregates? physical_planned)
-				(quote aggregate)
-				(if (query_limit_active? (qb_offset physical_planned) (qb_limit physical_planned))
-					(quote order_limit)
-					(quote filter))))
-			(define local_driver_rows (if (equal? physical_consumer (quote order_limit))
-				(probe_limit_work_rows (qb_limit physical_planned)) nil))
-			(define physical_facts (merge (list
-				(list
-					(list (quote membership_consumer) physical_consumer)
-					(list (quote membership_driver_rows) (coalesceNil local_driver_rows
-						(qassoc_get (qb_facts physical_planned) (quote membership_driver_rows) nil))))
-				(qb_facts physical_planned))))
-			(make_query_block
-				(qb_schema physical_planned)
-				(map (qb_sources physical_planned) (lambda (src)
-					(physicalize_membership_requirement_source_using src physical_facts)))
-				(physicalize_membership_requirement_expr_using (qb_fields physical_planned) physical_facts)
-				(physicalize_membership_requirement_expr_using (qb_where physical_planned) physical_facts)
-				(physicalize_membership_requirement_expr_using (qb_group physical_planned) physical_facts)
-				(physicalize_membership_requirement_expr_using (qb_having physical_planned) physical_facts)
-				(physicalize_membership_requirement_expr_using (qb_order physical_planned) physical_facts)
-				(qb_limit physical_planned)
-				(qb_offset physical_planned)
-				(physicalize_membership_requirement_expr_using (qb_hidden physical_planned) physical_facts)
-				(map (qb_stages physical_planned) apply_join_optimizer_plan_stage)
-				(physicalize_membership_requirement_expr_using physical_facts physical_facts)))
+			(define physical_stages (map (qb_stages physical_planned) apply_join_optimizer_plan_stage))
+			(define requirement (qassoc_get (qb_facts physical_planned) (quote membership_requirement) nil))
+			/* Reorder attaches the requirement to the query block which owns every
+			membership_requirement_probe. Nested blocks and stages recurse separately.
+			Keep the ordinary query expressions structurally shared instead of walking
+			and rebuilding the complete block when there is no physical choice here. */
+			(if (nil? requirement)
+				(make_query_block
+					(qb_schema physical_planned) (qb_sources physical_planned)
+					(qb_fields physical_planned) (qb_where physical_planned)
+					(qb_group physical_planned) (qb_having physical_planned)
+					(qb_order physical_planned) (qb_limit physical_planned)
+					(qb_offset physical_planned) (qb_hidden physical_planned)
+					physical_stages (qb_facts physical_planned))
+				(begin
+					(define physical_consumer (if (query_block_has_aggregates? physical_planned)
+						(quote aggregate)
+						(if (query_limit_active? (qb_offset physical_planned) (qb_limit physical_planned))
+							(quote order_limit)
+							(quote filter))))
+					(define local_driver_rows (if (equal? physical_consumer (quote order_limit))
+						(probe_limit_work_rows (qb_limit physical_planned)) nil))
+					(define physical_facts (merge (list
+						(list
+							(list (quote membership_consumer) physical_consumer)
+							(list (quote membership_driver_rows) (coalesceNil local_driver_rows
+								(qassoc_get (qb_facts physical_planned) (quote membership_driver_rows) nil))))
+						(qb_facts physical_planned))))
+					(make_query_block
+						(qb_schema physical_planned)
+						(map (qb_sources physical_planned) (lambda (src)
+							(physicalize_membership_requirement_source_using src physical_facts)))
+						(physicalize_membership_requirement_expr_using (qb_fields physical_planned) physical_facts)
+						(physicalize_membership_requirement_expr_using (qb_where physical_planned) physical_facts)
+						(physicalize_membership_requirement_expr_using (qb_group physical_planned) physical_facts)
+						(physicalize_membership_requirement_expr_using (qb_having physical_planned) physical_facts)
+						(physicalize_membership_requirement_expr_using (qb_order physical_planned) physical_facts)
+						(qb_limit physical_planned)
+						(qb_offset physical_planned)
+						(physicalize_membership_requirement_expr_using (qb_hidden physical_planned) physical_facts)
+						physical_stages
+						(physicalize_membership_requirement_expr_using physical_facts physical_facts)))))
 		(if (union_block? node)
 			(make_union_block
 				(union_mode node)


### PR DESCRIPTION
## What

- preserve marker-free expressions during Neumann decorrelation after one cheap marker scan
- skip membership-specific expression rebuilding and aggregate classification for query blocks without a membership requirement
- keep nested stages recursive and leave membership-bearing blocks on the existing path

## Evidence

Alternating 45-sample A/B on the 128-column indexed-column-resolution query after warmup:

- untangle median: 13.99 ms -> 10.80 ms
- physical_prepare median: 2.76 ms -> 0.90 ms
- planner_total median: 27.37 ms -> 22.87 ms
- compile_total median: 40.97 ms -> 35.68 ms

A marker-rich nested Neumann query remained neutral, and a UNION membership query retained identical logical and physical plan shapes.

Historical bisection identified two independent regressions: nested decorrelation result reuse in #399 introduced persistent reconstruction for marker-free ASTs, and physical membership calibration in #543 added unconditional membership preparation work.

## Validation

- full make test passed
- indexed-column-resolution: 1/1
- traced late projection: all required tests passed
- range scan coverage: 106/106
- ACL membership scaling: 13/13
- IN subquery: 71/71