### PR TITLE
Unify costed scan access-path selection

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -270,6 +270,26 @@ and barrier ownership come from the pre-normalization query block. */
 		((quote >) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
 		((symbol >=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
 		((quote >=) _left _right) (planner_estimate nil 0 (quote range_unknown) false)
+		((symbol strlike) _value pattern)
+		(begin
+			(define prior (text_pattern_selectivity_prior
+				(planner_string_expr_value pattern)))
+			(if (number? prior)
+				(planner_estimate prior 0.25 (quote text_pattern_prior) true)
+				(planner_unknown_selectivity_estimate)))
+		((symbol strlike) _value pattern _collation)
+		(begin
+			(define prior (text_pattern_selectivity_prior
+				(planner_string_expr_value pattern)))
+			(if (number? prior)
+				(planner_estimate prior 0.25 (quote text_pattern_prior) true)
+				(planner_unknown_selectivity_estimate)))
+		((quote strlike) value pattern)
+		(join_optimizer_expr_selectivity_estimate sources default_alias
+			(list (symbol "strlike") value pattern))
+		((quote strlike) value pattern collation)
+		(join_optimizer_expr_selectivity_estimate sources default_alias
+			(list (symbol "strlike") value pattern collation))
 		_ (planner_unknown_selectivity_estimate))))
 
 (define join_optimizer_expr_selectivity (lambda (sources default_alias expr)
@@ -1386,6 +1406,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(list (quote membership_consumer) (qassoc_get facts (quote membership_consumer) (quote filter)))
 					(list (quote membership_candidate_input_rows) (qassoc_get facts (quote membership_candidate_input_rows) nil))
 					(list (quote membership_candidate_estimated_rows) (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
+					(list (quote membership_candidate_matching_rows) (qassoc_get facts (quote membership_candidate_matching_rows) nil))
 					(list (quote membership_candidate_estimate_capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
 					(list (quote membership_candidate_estimate_input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
 					(list (quote membership_candidate_estimate_sampled) (qassoc_get facts (quote membership_candidate_estimate_sampled) nil))
@@ -1844,9 +1865,14 @@ floor avoids pretending that an unseen word is impossible. */
 						(eval filter_expr)
 						max_rows))
 					(define text_prior (expr_text_selectivity_prior condition))
-					(if (number? text_prior)
+					(define enriched (if (number? text_prior)
 						(qassoc_set estimate (quote fallback_selectivity) text_prior)
-						estimate)))
+						estimate))
+					(define source_rows (planner_source_row_count src))
+					(if (number? source_rows)
+						(qassoc_set enriched (quote estimated_rows)
+							(planner_estimated_matching_rows enriched source_rows source_rows))
+						enriched)))
 			(lambda (_e) nil)))))
 
 (define planner_source_row_count (lambda (src)
@@ -2188,6 +2214,9 @@ resulting tree in semantic order. */
 						(qassoc_get estimate (quote input) nil)))))
 					(define sampled_rows (planner_add_estimates (map available (lambda (estimate)
 						(qassoc_get estimate (quote sampled) nil)))))
+					(define estimated_rows (planner_add_estimates (map available (lambda (estimate)
+						(qassoc_get estimate (quote estimated_rows)
+							(qassoc_get estimate (quote rows) nil))))))
 					(define capped (or (>= rows max_rows)
 						(reduce available (lambda (found estimate)
 							(or found (qassoc_get estimate (quote capped) false)))
@@ -2197,6 +2226,7 @@ resulting tree in semantic order. */
 						(list (quote capped) capped)
 						(list (quote sampled) sampled_rows)
 						(list (quote input) input_rows)
+						(list (quote estimated_rows) estimated_rows)
 						(list (quote population) (planner_merge_estimate_population available))
 						(list (quote coverage) (planner_merge_estimate_coverage available))))))
 		(if (query_block? input)
@@ -2419,15 +2449,20 @@ either physical alternative or sampling the table again. */
 			(count (union_branches (gs_input stage)))
 			1))
 		(define candidate_estimate (planner_stage_filter_estimate (gs_input stage) 512))
-		(define estimate_rows (qassoc_get candidate_estimate (quote rows) nil))
+		(define estimate_matching_rows (qassoc_get candidate_estimate (quote rows) nil))
+		(define estimate_rows (qassoc_get candidate_estimate (quote estimated_rows)
+			estimate_matching_rows))
 		(define estimate_capped (qassoc_get candidate_estimate (quote capped) false))
 		(define estimate_input (qassoc_get candidate_estimate (quote input) nil))
 		(define estimate_sampled (qassoc_get candidate_estimate (quote sampled) nil))
 		(define estimate_population (planner_estimate_population candidate_estimate))
 		(define estimate_coverage (planner_estimate_coverage candidate_estimate))
+		/* estimated_rows has already been scaled to the full candidate input.
+		Classify it against that same population; comparing it with sampled rows
+		mixes units and labels most capped selective estimates as broad. */
 		(define estimate_ratio_broad (and
-			(and (not (nil? estimate_rows)) (and (not (nil? estimate_sampled)) (> estimate_sampled 0)))
-			(>= (* estimate_rows 4) estimate_sampled)))
+			(and (number? estimate_rows) (and (number? candidate_rows) (> candidate_rows 0)))
+			(>= (* estimate_rows 4) candidate_rows)))
 		(define driver_alternative (membership_expr_has_driver_alternative? (qb_where block)))
 		(define class (if (or estimate_ratio_broad
 			(if driver_alternative (candidate_stage_broad? stage) false)) (quote broad) (quote selective)))
@@ -2448,6 +2483,7 @@ either physical alternative or sampling the table again. */
 				(qassoc_get driver_estimate (quote capped) false))
 			(list (quote membership_candidate_input_rows) candidate_rows)
 			(list (quote membership_candidate_estimated_rows) estimate_rows)
+			(list (quote membership_candidate_matching_rows) estimate_matching_rows)
 			(list (quote membership_candidate_estimate_capped) estimate_capped)
 			(list (quote membership_candidate_estimate_input) estimate_input)
 			(list (quote membership_candidate_estimate_sampled) estimate_sampled)
@@ -2623,16 +2659,28 @@ selectivity sample. Once an index or RecSet has restricted the iterator,
 sampled means "index candidates examined", not "table rows sampled". A capped
 restricted estimate is therefore merely a lower bound and must not be
 extrapolated as though the iterator were an unbiased table sample. */
-(define membership_estimated_matching_rows (lambda (estimate input_rows fallback)
+(define planner_estimated_matching_rows (lambda (estimate input_rows fallback)
 	(if (nil? estimate)
 		fallback
 		(begin
 			(define rows (qassoc_get estimate (quote rows) nil))
 			(define sampled_input (qassoc_get estimate (quote sampled) nil))
-			(if (and (qassoc_get estimate (quote capped) false)
+			(define coverage (planner_estimate_coverage estimate))
+			/* A random-shard estimate is a population sample even when the shard was
+			read to completion. Scale that sample exactly once here. Zero observed
+			matches retain the expression prior because one shard cannot prove that
+			the complete table is empty for the predicate. */
+			(if (and (equal? coverage (quote sampled))
 				(and (number? input_rows)
 					(and (number? rows) (and (number? sampled_input) (> sampled_input 0)))))
-				(if (equal? (planner_estimate_coverage estimate) (quote lower_bound))
+				(if (and (equal? rows 0)
+					(number? (qassoc_get estimate (quote fallback_selectivity) nil)))
+					(* input_rows (qassoc_get estimate (quote fallback_selectivity) 1))
+					(min input_rows (* input_rows (/ rows sampled_input))))
+				(if (and (qassoc_get estimate (quote capped) false)
+				(and (number? input_rows)
+					(and (number? rows) (and (number? sampled_input) (> sampled_input 0)))))
+				(if (equal? coverage (quote lower_bound))
 					(begin
 						(define fallback_selectivity
 							(qassoc_get estimate (quote fallback_selectivity) nil))
@@ -2640,7 +2688,7 @@ extrapolated as though the iterator were an unbiased table sample. */
 							(min input_rows (max rows (* input_rows fallback_selectivity)))
 							(coalesceNil fallback input_rows)))
 					(min input_rows (* input_rows (/ rows sampled_input))))
-				(coalesceNil rows fallback))))))
+					(coalesceNil rows fallback)))))))
 
 (define membership_driver_filter (lambda (condition)
 	/* Only top-level conjuncts which do not contain membership are guaranteed
@@ -2865,15 +2913,11 @@ expression, and RecSet components used by the other membership carriers. */
 
 (define membership_cost_options_for_telemetry (lambda (telemetry)
 	(begin
-		(define candidate_rows (membership_estimated_matching_rows
-			(list
-				(list (quote rows) (qassoc_get telemetry (quote membership_candidate_estimated_rows) nil))
-				(list (quote input) (qassoc_get telemetry (quote membership_candidate_estimate_input) nil))
-				(list (quote sampled) (qassoc_get telemetry (quote membership_candidate_estimate_sampled) nil))
-				(list (quote capped) (qassoc_get telemetry (quote membership_candidate_estimate_capped) false))
-				(list (quote population) (qassoc_get telemetry (quote membership_candidate_estimate_population) (quote table_rows)))
-				(list (quote coverage) (qassoc_get telemetry (quote membership_candidate_estimate_coverage) (quote sampled))))
-			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)
+		/* candidate_estimated_rows is the shared cardinality result. Reapplying
+		planner_estimated_matching_rows here would treat a UNION's merged raw
+		sample as a fresh table sample and can inflate a selective path to 100%. */
+		(define candidate_rows (qassoc_get telemetry
+			(quote membership_candidate_estimated_rows)
 			(qassoc_get telemetry (quote membership_candidate_input_rows) nil)))
 		(define driver_strategy (membership_driver_strategy_for_telemetry telemetry))
 		(define driver_rows (qassoc_get telemetry (quote membership_driver_rows) nil))
@@ -2897,15 +2941,8 @@ expression, and RecSet components used by the other membership carriers. */
 		(define forced (planner_physical_override decision_id))
 		(define chosen (planner_physical_choice decision_id (string strategy) alternatives))
 		(define candidate_input_rows (qassoc_get requirement (quote membership_candidate_input_rows) nil))
-		(define candidate_rows (membership_estimated_matching_rows
-			(list
-				(list (quote rows) (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
-				(list (quote input) (qassoc_get requirement (quote membership_candidate_estimate_input) nil))
-				(list (quote sampled) (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
-				(list (quote capped) (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
-				(list (quote population) (qassoc_get requirement (quote membership_candidate_estimate_population) (quote table_rows)))
-				(list (quote coverage) (qassoc_get requirement (quote membership_candidate_estimate_coverage) (quote sampled))))
-			candidate_input_rows candidate_input_rows))
+		(define candidate_rows (qassoc_get requirement
+			(quote membership_candidate_estimated_rows) candidate_input_rows))
 		(define driver_input_rows (qassoc_get requirement (quote membership_driver_input_rows) nil))
 		(define driver_rows (if (qassoc_get requirement (quote membership_order_limit_driver) false)
 			(coalesceNil (probe_limit_work_rows (qassoc_get requirement (quote membership_order_limit) nil))
@@ -3062,7 +3099,7 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(define capped (if (nil? candidate_estimate) false
 					(qassoc_get candidate_estimate (quote capped) false)))
 				(define candidate_total_rows (planner_source_row_count input))
-				(define candidate_rows (membership_estimated_matching_rows
+				(define candidate_rows (planner_estimated_matching_rows
 					candidate_estimate candidate_total_rows candidate_total_rows))
 				(define driver (car base_sources))
 				(define driver_total_rows (planner_source_row_count driver))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2581,21 +2581,28 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 					(qassoc_get facts (quote membership_candidate_input_rows) nil)
 					(planner_stage_input_rows (gs_input stage))))
 				(define candidate_matching_rows (coalesceNil
-					(qassoc_get facts (quote membership_candidate_estimated_rows) nil)
+					(qassoc_get facts (quote membership_candidate_matching_rows) nil)
 					(qassoc_get measured_estimate (quote rows) nil)))
-				(define candidate_rows (membership_estimated_matching_rows
-					(list
-						(list (quote rows) candidate_matching_rows)
-						(list (quote input) (coalesceNil
-							(qassoc_get facts (quote membership_candidate_estimate_input) nil)
-							(qassoc_get measured_estimate (quote input) nil)))
-						(list (quote sampled) (coalesceNil
-							(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
-							(qassoc_get measured_estimate (quote sampled) nil)))
-						(list (quote capped) capped)
-						(list (quote population) estimate_population)
-						(list (quote coverage) estimate_coverage))
-					candidate_input_rows candidate_input_rows))
+				(define costed_candidate_rows
+					(qassoc_get facts (quote membership_candidate_estimated_rows) nil))
+				/* Reorder owns stage cardinality. Physical lowering consumes that
+				estimate verbatim; re-extrapolating the merged UNION sample here was a
+				second, contradictory planner that could turn a selective text path
+				back into 100% of its input. */
+				(define candidate_rows (coalesceNil costed_candidate_rows
+					(planner_estimated_matching_rows
+						(list
+							(list (quote rows) candidate_matching_rows)
+							(list (quote input) (coalesceNil
+								(qassoc_get facts (quote membership_candidate_estimate_input) nil)
+								(qassoc_get measured_estimate (quote input) nil)))
+							(list (quote sampled) (coalesceNil
+								(qassoc_get facts (quote membership_candidate_estimate_sampled) nil)
+								(qassoc_get measured_estimate (quote sampled) nil)))
+							(list (quote capped) capped)
+							(list (quote population) estimate_population)
+							(list (quote coverage) estimate_coverage))
+						candidate_input_rows candidate_input_rows)))
 				(define source_rows (planner_source_row_count src))
 				/* Ordered LIMIT consumes only its local window before downstream
 				operators. Cost this edge with that workload instead of a global

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2598,15 +2598,10 @@ RecSet; membership edges retain their own physical operators. */
 (define ordered_batch_accept_cost (lambda (facts)
 	(begin
 		(define candidate_input_rows (qassoc_get facts (quote membership_candidate_input_rows) nil))
-		(define candidate_rows (membership_estimated_matching_rows
-			(list
-				(list (quote rows) (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
-				(list (quote input) (qassoc_get facts (quote membership_candidate_estimate_input) nil))
-				(list (quote sampled) (qassoc_get facts (quote membership_candidate_estimate_sampled) nil))
-				(list (quote capped) (qassoc_get facts (quote membership_candidate_estimate_capped) false))
-				(list (quote population) (qassoc_get facts (quote membership_candidate_estimate_population) (quote table_rows)))
-				(list (quote coverage) (qassoc_get facts (quote membership_candidate_estimate_coverage) (quote sampled))))
-			candidate_input_rows candidate_input_rows))
+		/* Physical consumers use the one cardinality produced by logical costing.
+		They may compare operators, but must not reinterpret statistics. */
+		(define candidate_rows (qassoc_get facts
+			(quote membership_candidate_estimated_rows) candidate_input_rows))
 		(define driver_rows (qassoc_get facts (quote membership_driver_rows) nil))
 		(define driver_input_rows (membership_driver_input_rows driver_rows facts))
 		(define visited_rows (membership_expected_driver_rows_visited
@@ -3388,47 +3383,51 @@ driver. This is physical costing metadata only; it never enters logical IR. */
 			(list (quote default) (coalesceNil (car work) default_rows))
 			(list (quote by_alias) (cadr work))))))
 
-/* A source-local text predicate is already a canonical logical predicate by
-the time it reaches this boundary. For a selective join driver, enumerate an
-exact RecSet carrier so expensive downstream ACL/join work runs only for the
-matching record IDs. This is a physical choice over the normalized predicate;
-it does not recover parser spelling or leak a scan into logical IR. */
-(define selective_text_filter_candidate (lambda (src all_sources default_alias condition)
+/* Access-path enumerators describe executable alternatives; they do not pick
+an operator, change join order, or remove a predicate. Adding a leaf-local
+"if this expression then use that scan" below the common selector is a code
+smell: add a descriptor here and let choose_scan_access_path compare it with
+every other carrier instead. Logical join order remains owned by join_plan. */
+(define scan_access_path_text_candidates (lambda (src all_sources default_alias condition)
 	(begin
 		(define alias (source_alias src))
 		(define aliases (source_aliases all_sources))
 		(define input_rows (planner_source_row_count src))
 		(if (or (not (number? input_rows)) (< input_rows 1024))
-			nil
-			(reduce (split_and_terms (coalesceNil condition true)) (lambda (best term)
-				(if (or (not (expr_contains_text_match? term))
-					(not (equal? (join_hypergraph_expr_aliases default_alias aliases term)
-						(list alias))))
-					best
-					(begin
-						(define estimate (planner_source_filter_estimate src term 512))
-						(define rows (membership_estimated_matching_rows estimate input_rows nil))
-						(define work (membership_source_work_profile src term true))
-						(define candidate (if (number? rows)
-							(list
-								(list (quote predicate) term)
-								(list (quote rows) rows)
-								(list (quote input_rows) input_rows)
-								(list (quote work) work)
-								(list (quote estimate) estimate))
-							nil))
-						(if (or (nil? candidate)
-							(and (not (nil? best))
-								(<= (qassoc_get best (quote rows) input_rows) rows)))
-							best candidate))))
-				nil)))))
+			'()
+			(filter
+				(map (split_and_terms (coalesceNil condition true)) (lambda (term)
+					(if (or (not (expr_contains_text_match? term))
+						(not (equal? (join_hypergraph_expr_aliases default_alias aliases term)
+							(list alias))))
+						nil
+						(begin
+							(define estimate (planner_source_filter_estimate src term 512))
+							(define rows (qassoc_get estimate (quote estimated_rows) nil))
+							(define work (membership_source_work_profile src term true))
+							(if (number? rows)
+								(list
+									(list (quote kind) (quote predicate_recset))
+									(list (quote plan) "scan_recset")
+									(list (quote predicate) term)
+									(list (quote rows) rows)
+									(list (quote input_rows) input_rows)
+									(list (quote work) work)
+									(list (quote estimate) estimate))
+								nil)))))
+				(lambda (item) (not (nil? item))))))))
+
+(define scan_access_path_candidates (lambda (src all_sources default_alias condition)
+	/* Text-backed exact RecSets are the first descriptor kind. Index ranges,
+	persisted RecSets, or future scan primitives belong in this same list. */
+	(scan_access_path_text_candidates src all_sources default_alias condition)))
 
 /* The text predicate itself is common work. The carrier decision determines
 whether the downstream join continuation is entered for every driver row or
 only for exact matches after a parallel RecSet-producing pass. Reuse the
 calibrated physical primitives; do not hide another selectivity threshold in
 this lowering boundary. */
-(define selective_text_filter_scan_cost (lambda (src candidate)
+(define scan_access_path_scan_cost (lambda (src candidate)
 	(begin
 		(define input_rows (qassoc_get candidate (quote input_rows) 0))
 		(define work (qassoc_get candidate (quote work) '()))
@@ -3447,21 +3446,21 @@ this lowering boundary. */
 					planner_membership_broad_text_match_byte_ns))
 			0 0 0 0 0 0 input_rows 0.75))))
 
-(define selective_text_filter_base_cost (lambda (src candidate)
+(define scan_access_path_base_cost (lambda (src candidate)
 	(begin
 		(define input_rows (qassoc_get candidate (quote input_rows) 0))
 		(planner_cost_add
-			(selective_text_filter_scan_cost src candidate)
+			(scan_access_path_scan_cost src candidate)
 			(planner_join_work_cost input_rows 0.65)
 			(qassoc_get candidate (quote rows) input_rows) 0.65))))
 
-(define selective_text_filter_recset_cost (lambda (src candidate)
+(define scan_access_path_recset_cost (lambda (src candidate)
 	(begin
 		(define input_rows (qassoc_get candidate (quote input_rows) 0))
 		(define rows (qassoc_get candidate (quote rows) input_rows))
 		(planner_cost_add
 			(planner_cost_add
-				(selective_text_filter_scan_cost src candidate)
+				(scan_access_path_scan_cost src candidate)
 				(planner_cost planner_membership_recset_startup_ns
 					(* rows planner_membership_scan_row_ns) 0 0 0
 					(* rows planner_membership_recset_build_row_ns)
@@ -3470,25 +3469,30 @@ this lowering boundary. */
 			(planner_join_work_cost rows 0.65)
 			rows 0.65))))
 
+(define scan_access_path_candidate_cost (lambda (src candidate)
+	(match (qassoc_get candidate (quote kind) nil)
+		(quote predicate_recset) (scan_access_path_recset_cost src candidate)
+		_ (neumann_fail "build_queryplan" "unsupported physical scan access-path descriptor"))))
+
 /* Both alternatives contain the same text scan. Solve the remaining linear
 cost inequality once and guard the cached plan by that crossover, not by an
 exact parameter value. */
-(define selective_text_filter_crossover_rows (lambda (src candidate)
+(define scan_access_path_crossover_rows (lambda (src candidate)
 	(begin
 		(define zero_candidate (qassoc_set candidate (quote rows) 0))
 		(define one_candidate (qassoc_set candidate (quote rows) 1))
 		(define recset_zero (qassoc_get
-			(selective_text_filter_recset_cost src zero_candidate) (quote total_ns) 0))
+			(scan_access_path_recset_cost src zero_candidate) (quote total_ns) 0))
 		(define recset_one (qassoc_get
-			(selective_text_filter_recset_cost src one_candidate) (quote total_ns) 0))
+			(scan_access_path_recset_cost src one_candidate) (quote total_ns) 0))
 		(define base_total (qassoc_get
-			(selective_text_filter_base_cost src candidate) (quote total_ns) 0))
+			(scan_access_path_base_cost src candidate) (quote total_ns) 0))
 		(define row_slope (- recset_one recset_zero))
 		(if (<= row_slope 0)
 			0
 			(max 0 (/ (- base_total recset_zero) row_slope))))))
 
-(define selective_text_filter_runtime_rows_expr (lambda (src candidate)
+(define scan_access_path_runtime_rows_expr (lambda (src candidate)
 	(begin
 		(define predicate (qassoc_get candidate (quote predicate) true))
 		(define alias (source_alias src))
@@ -3502,7 +3506,7 @@ exact parameter value. */
 				(map cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 				(lower_column_expr_for_alias src predicate))
 			512))
-		(list (quote membership_estimated_matching_rows)
+		(list (quote planner_estimated_matching_rows)
 			(if (nil? pattern_expr)
 				estimate_expr
 				(list (quote qassoc_set)
@@ -3512,35 +3516,42 @@ exact parameter value. */
 			(qassoc_get candidate (quote input_rows) nil)
 			(qassoc_get candidate (quote input_rows) nil)))))
 
-(define choose_selective_text_filter_carrier (lambda (src candidate)
-	(if (nil? candidate)
+(define choose_scan_access_path (lambda (src candidates)
+	(if (empty_list? candidates)
 		(list "fused_base_scan" nil)
 		(begin
+			(define candidate (reduce candidates (lambda (best item)
+				(if (or (nil? best)
+					(planner_cost_better?
+						(scan_access_path_candidate_cost src item)
+						(scan_access_path_candidate_cost src best)))
+					item best)) nil))
 			(define alias (source_alias src))
-			(define decision_id (concat "selective_text_filter_carrier:" alias))
-			(define recset_cost (selective_text_filter_recset_cost src candidate))
-			(define base_cost (selective_text_filter_base_cost src candidate))
+			(define decision_id (concat "scan_access_path:" alias))
+			(define candidate_plan (qassoc_get candidate (quote plan) nil))
+			(define candidate_cost (scan_access_path_candidate_cost src candidate))
+			(define base_cost (scan_access_path_base_cost src candidate))
 			(define work (qassoc_get candidate (quote work) '()))
-			(define normal_choice (if (planner_cost_better? recset_cost base_cost)
-				"scan_recset" "fused_base_scan"))
-			(define crossover_rows (selective_text_filter_crossover_rows src candidate))
-			(if (empty_list? (query_expr_session_reads
-				(qassoc_get candidate (quote predicate) true)))
-				nil
-				(planner_record_guard_condition
-					(if (equal? normal_choice "scan_recset")
-						(list (quote <)
-							(selective_text_filter_runtime_rows_expr src candidate)
-							crossover_rows)
-						(list (quote >=)
-							(selective_text_filter_runtime_rows_expr src candidate)
-							crossover_rows))))
-			(define alternatives (list "scan_recset" "fused_base_scan"))
+			(define normal_choice (if (planner_cost_better? candidate_cost base_cost)
+				candidate_plan "fused_base_scan"))
+			(define crossover_rows (scan_access_path_crossover_rows src candidate))
+			/* Guard the cost crossover even for a literal predicate. Auto-index
+			construction can improve the same query's estimate after compilation;
+			the cached variant must then be rejected if the winning path changes. */
+			(planner_record_guard_condition
+				(if (equal? normal_choice candidate_plan)
+					(list (quote <)
+						(scan_access_path_runtime_rows_expr src candidate)
+						crossover_rows)
+					(list (quote >=)
+						(scan_access_path_runtime_rows_expr src candidate)
+						crossover_rows)))
+			(define alternatives (list candidate_plan "fused_base_scan"))
 			(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 			(define forced (planner_physical_override decision_id))
 			(planner_record_physical_decision (list
 				(list "decision_id" decision_id)
-				(list "decision" "selective_text_filter_carrier")
+				(list "decision" "scan_access_path")
 				(list "decision_site" "join_scan_leaf")
 				(list "source" alias)
 				(list "chosen" chosen)
@@ -3565,10 +3576,10 @@ exact parameter value. */
 					(list "crossover_rows" crossover_rows)))
 				(list "alternatives" (list
 					(list
-						(list "plan" "scan_recset")
-						(list "status" (if (equal? chosen "scan_recset") "chosen" "rejected"))
-						(list "reason" (if (equal? chosen "scan_recset") "selected" "higher_total_ns_or_forced_alternative"))
-						(list "cost" (planner_cost_explain recset_cost)))
+						(list "plan" candidate_plan)
+						(list "status" (if (equal? chosen candidate_plan) "chosen" "rejected"))
+						(list "reason" (if (equal? chosen candidate_plan) "selected" "higher_total_ns_or_forced_alternative"))
+						(list "cost" (planner_cost_explain candidate_cost)))
 					(list
 						(list "plan" "fused_base_scan")
 						(list "status" (if (equal? chosen "fused_base_scan") "chosen" "rejected"))
@@ -3576,7 +3587,7 @@ exact parameter value. */
 						(list "cost" (planner_cost_explain base_cost)))))))
 			(list chosen candidate)))))
 
-(define selective_text_filter_recset_expr (lambda (stages src candidate)
+(define scan_access_path_recset_expr (lambda (stages src candidate)
 	(begin
 		(define alias (source_alias src))
 		(define predicate (qassoc_get candidate (quote predicate) true))
@@ -3589,7 +3600,12 @@ exact parameter value. */
 				(map cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 				(lower_column_expr_for_alias src predicate))))))
 
-(define strip_selective_text_filter_candidate (lambda (condition candidate)
+(define scan_access_path_table_expr (lambda (stages src candidate)
+	(match (qassoc_get candidate (quote kind) nil)
+		(quote predicate_recset) (scan_access_path_recset_expr stages src candidate)
+		_ (neumann_fail "build_queryplan" "unsupported physical scan access-path descriptor"))))
+
+(define strip_scan_access_path_predicate (lambda (condition candidate)
 	(if (nil? candidate)
 		condition
 		(begin
@@ -3670,28 +3686,34 @@ exact parameter value. */
 			(not (nil? membership_table_expr))
 			(nil? row_number_stage_filter)))
 		(define membership_filter (and (not (nil? membership_table_expr)) (not membership_driver)))
-		(define text_filter_eligible (and
+		/* Query-local access-path construction is safe only at the selected driver:
+		inside a continuation it would rebuild the carrier once per outer row. This
+		is an execution-scope capability, not a predicate- or text-specific rule.
+		Join reorder has already selected the driver before this boundary. */
+		(define access_path_build_allowed (and
 			(not membership_driver)
 			(nil? row_number_stage_filter)
 			(> (count all_sources) 1)
 			(equal? alias (probe_work_context_driver_alias probe_context))))
-		(define text_filter_candidate_before_point_check (if text_filter_eligible
-			(selective_text_filter_candidate src all_sources default_alias effective_condition)
-			nil))
-		/* Most join leaves have no text predicate. Avoid walking their full
-		condition a second time to prove point access before the cheap candidate
-		classifier has established that this decision is relevant at all. */
-		(define text_filter_candidate (if (and
-			(not (nil? text_filter_candidate_before_point_check))
+		(define access_path_candidates_before_point_check (if access_path_build_allowed
+			(scan_access_path_candidates src all_sources default_alias effective_condition)
+			'()))
+		/* A unique point lookup already bounds downstream work. This capability
+		check applies uniformly to every candidate; an enumerator must not hide a
+		second operator decision behind its expression-shape recognizer. */
+		(define access_path_candidates (if (and
+			(not (empty_list? access_path_candidates_before_point_check))
 			(source_unique_point_condition? src effective_condition))
-			nil
-			text_filter_candidate_before_point_check))
-		(define text_filter_plan (choose_selective_text_filter_carrier src text_filter_candidate))
-		(define text_filter_recset (and (not (nil? text_filter_candidate))
-			(equal? (car text_filter_plan) "scan_recset")))
+			'()
+			access_path_candidates_before_point_check))
+		(define access_path_plan (choose_scan_access_path src access_path_candidates))
+		(define access_path_candidate (cadr access_path_plan))
+		(define access_path_selected (and (not (nil? access_path_candidate))
+			(equal? (car access_path_plan)
+				(qassoc_get access_path_candidate (quote plan) nil))))
 		(define residual_condition
-			(strip_selective_text_filter_candidate effective_condition
-				(if text_filter_recset text_filter_candidate nil)))
+			(strip_scan_access_path_predicate effective_condition
+				(if access_path_selected access_path_candidate nil)))
 		(define membership_var (symbol "__membership_recset"))
 		(define membership_filter_expr (if membership_filter
 			(recset_contains_call_expr membership_var)
@@ -3706,9 +3728,9 @@ exact parameter value. */
 			recipe_mapcols))
 		(define mapcols raw_mapcols)
 		(define table_expr (if membership_driver membership_table_expr
-			(if (not text_filter_recset)
+			(if (not access_path_selected)
 				(source_table_expr_using stages src)
-				(selective_text_filter_recset_expr stages src text_filter_candidate))))
+				(scan_access_path_table_expr stages src access_path_candidate))))
 		(define lowered_filter_condition (mark_outer_join_symbols
 			all_sources
 			alias

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -567,7 +567,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"keytable cost check refuses the carrier when probe_work_rows is a non-numeric sentinel")
 	(assert (scalar_first_probe_keytable_cost_preferred? cost_probe_stage "72") false
 		"keytable cost check refuses the carrier when probe_work_rows is a non-numeric string")
-	(assert (membership_estimated_matching_rows
+	(assert (planner_estimated_matching_rows
 		(list
 			(list (quote rows) 512)
 			(list (quote sampled) 512)
@@ -580,7 +580,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"single-character text patterns use a broad prior")
 	(assert (text_pattern_selectivity_prior "%needle%") 0.01
 		"long text patterns use the selective prior floor")
-	(assert (membership_estimated_matching_rows
+	(assert (planner_estimated_matching_rows
 		(list
 			(list (quote rows) 512)
 			(list (quote sampled) 512)
@@ -590,7 +590,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(list (quote fallback_selectivity) 0.01))
 		100000 100000) 1000
 		"capped text index candidates use the statistical prior instead of 100 percent")
-	(assert (membership_estimated_matching_rows
+	(assert (planner_estimated_matching_rows
 		(list
 			(list (quote rows) 128)
 			(list (quote sampled) 512)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -637,24 +637,37 @@ func Init(en scm.Env) {
 			if limit <= 0 {
 				limit = 1024
 			}
-			var rows int64
-			var sampled int64
-			capped := false
-			population := "table_rows"
-			coverage := "exact"
 			shards := t.ActiveShards()
+			input := int64(t.CountEstimate())
+			if len(shards) == 0 || input == 0 {
+				return scm.NewSlice([]scm.Scmer{
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(0)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(false)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(0)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol("table_rows")}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol("exact")}),
+				})
+			}
 			start := 0
 			if len(shards) > 1 {
 				start = rand.Intn(len(shards))
 			}
+			// Costing must never depend on whether an auto-index already exists and
+			// must not turn planning into a scan of every shard. Sample one randomly
+			// selected non-empty shard. An installed index hook makes the same call
+			// constant-time and more precise; the generated crossover guard then
+			// invalidates a cached choice if that new selectivity changes the winner.
 			for offset := range shards {
 				shard := shards[(start+offset)%len(shards)]
 				if shard == nil {
 					continue
 				}
-				estimate := shard.EstimateFilteredRows(conditionCols, condition, limit-int(rows), currentTx)
+				estimate := shard.EstimateFilteredRows(conditionCols, condition, limit, currentTx)
+				if estimate.examined == 0 {
+					continue
+				}
 				if estimate.population == "index_hook_candidates" && estimate.examined > 0 {
-					input := int64(t.CountEstimate())
 					estimatedRows := input * estimate.rows / estimate.examined
 					return scm.NewSlice([]scm.Scmer{
 						scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(estimatedRows)}),
@@ -665,27 +678,24 @@ func Init(en scm.Env) {
 						scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(estimate.coverage)}),
 					})
 				}
-				rows += estimate.rows
-				sampled += estimate.examined
-				if estimate.population != "table_rows" {
-					population = estimate.population
-				}
-				if estimate.coverage != "exact" {
-					coverage = estimate.coverage
-				}
-				if estimate.capped || rows >= int64(limit) {
-					capped = true
-					break
-				}
+				return scm.NewSlice([]scm.Scmer{
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(estimate.rows)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(estimate.capped)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(estimate.examined)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol("table_rows")}),
+					scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol("sampled")}),
+				})
 			}
-			input := int64(t.CountEstimate())
+			// All active shards were empty snapshots. The table estimate may include
+			// concurrent deltas; keep the estimate unknown rather than claiming zero.
 			return scm.NewSlice([]scm.Scmer{
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(rows)}),
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(capped)}),
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(sampled)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(0)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(true)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(0)}),
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol(population)}),
-				scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(coverage)}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol("table_rows")}),
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol("lower_bound")}),
 			})
 		},
 		Type: &scm.TypeDescriptor{

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -20,6 +20,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS selective_text_driver"
   - sql: "DROP TABLE IF EXISTS selective_text_dim"
+  - sql: "DROP TABLE IF EXISTS selective_text_peer"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"
   - sql: "DROP TABLE IF EXISTS stats_contract_child"
@@ -435,6 +436,11 @@ test_cases:
     expect:
       rows: 0
 
+  - name: "Create text reorder peer"
+    sql: "CREATE TABLE selective_text_peer (id INT PRIMARY KEY)"
+    expect:
+      rows: 0
+
   - name: "Insert selective text RecSet fixture"
     scm: |
       (begin
@@ -445,6 +451,8 @@ test_cases:
           (map (produceN 2048) (lambda (i)
             (list i (mod i 4)
               (if (< i 8) (concat "asset-needle-" i) (concat "asset-other-" i))))))
+        (insert (table "memcp-tests" "selective_text_peer") '("id")
+          (map (produceN 100) (lambda (i) (list i))))
         (rebuild)
         2048)
 
@@ -460,7 +468,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - 'selective_text_filter_carrier'
+        - 'scan_access_path'
         - 'chosen scan_recset'
         - 'candidate_rows 8'
         - 'candidate_input_rows 2048'
@@ -478,7 +486,7 @@ test_cases:
     expect:
       rows: 2
       contains:
-        - 'selective_text_filter_carrier'
+        - 'scan_access_path'
         - 'scan_recset'
         - 'fused_base_scan'
         - 'result_equal'
@@ -515,8 +523,21 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - 'selective_text_filter_carrier'
+        - 'scan_access_path'
         - 'chosen fused_base_scan'
+
+  - name: "Text cardinality participates in the common join reorder"
+    sql: |
+      EXPLAIN REORDER
+      SELECT f.id
+      FROM selective_text_peer p
+      JOIN selective_text_driver f ON f.id = p.id
+      WHERE f.search LIKE '%needle%'
+    expect:
+      rows: 1
+      result_contains:
+        - '(source text_pattern_prior)'
+        - '(planning_value 0.01)'
 
   - name: "Cached text filter recompiles across the RecSet cost crossover"
     scm: |
@@ -1049,6 +1070,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS perf_tiny"
   - sql: "DROP TABLE IF EXISTS selective_text_driver"
   - sql: "DROP TABLE IF EXISTS selective_text_dim"
+  - sql: "DROP TABLE IF EXISTS selective_text_peer"
   - sql: "DROP TABLE IF EXISTS pushdown_main"
   - sql: "DROP TABLE IF EXISTS pushdown_lookup"
   - sql: "DROP TABLE IF EXISTS stats_contract_child"


### PR DESCRIPTION
## Why

PR #575 improved one text-filter shape by selecting a predicate RecSet inside the physical leaf builder. That local second planner did not cover projected/UNION membership shapes and allowed join reorder and physical lowering to disagree about cardinality. In capped samples, a genuinely selective predicate could consequently be expanded back to 100% of the input.

## Architecture

- Replace the text-only shortcut with common scan-access-path candidates and one cost selector. Candidate enumeration is deliberately side-effect free: it may neither reorder joins nor remove predicates.
- Feed text-pattern priors into the normal join reorder, including the collation-bearing STRLIKE shape.
- Compute population-scale matching rows once in logical planning. UNION stages sum branch estimates; physical membership lowering consumes that shared value without extrapolating a second time.
- Keep index existence out of planning. Autoindexes are an execution detail; an installed statistics hook only makes the same selectivity estimate cheaper and more precise.
- Register the algebraically derived cost crossover as a plan assumption even for literal predicates. The runtime guard samples one random non-empty shard and checks the current selectivity against that threshold. If the winning operator changes, normal variant recompilation prepends the alternative cached plan. Common row-count guards independently cover changes in table population.
- Add comments identifying leaf-local operator selection beneath the common selector as a planner code smell.

This does not attempt the broader decorrelated LEFT JOIN reorder work. It makes physical access-path choice and its cardinality contract coherent first.

## Evidence

- New regression assertions are RED on master: 106/109 in range-scan-coverage.
- Branch: range-scan-coverage 109/109; recset 34/34; fulltext-like-index 85/85; ACL scaling 13/13; compound boolean 20/20; startup Scheme tests 1250/1250.
- The non-CI production-scale calibration case completes in 7.81s on this branch; unchanged master exceeded the runner response timeout. It is improved but remains above that suites 5s aspirational bound.
- The saved live full-text SELECT completed in 6.90s after a cold restart. Earlier warm SELECT+COUNT traces totaled about 7.2s, so this is useful reachability evidence but not a controlled warm A/B claim. The live server is available for application-level measurements with TracePrint enabled.

## Local full-suite note

The full hook was run. Two parallel SQL failures passed immediately in isolation. The final storage test process then hit a native/JIT SIGSEGV in tcursorrollbackreload; the identical command reproduces the same fault on unchanged master. No existing test or timing bound was weakened. CI remains the merge gate.