### PR TITLE
Batch ephemeral cache schema publication

### DIFF
--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -56,6 +56,16 @@ func (p *failSchemaWritePersistence) WriteSchema(schema []byte) {
 	p.PersistenceEngine.WriteSchema(schema)
 }
 
+type countingSchemaWritePersistence struct {
+	PersistenceEngine
+	calls atomic.Int32
+}
+
+func (p *countingSchemaWritePersistence) WriteSchema(schema []byte) {
+	p.calls.Add(1)
+	p.PersistenceEngine.WriteSchema(schema)
+}
+
 type blockingSchemaWritePersistence struct {
 	PersistenceEngine
 	entered chan struct{}
@@ -1728,6 +1738,57 @@ func TestRebuildInsideActiveTransactionDoesNotWaitForItself(t *testing.T) {
 	}
 	if got := tbl.Count(); got != 2 {
 		t.Fatalf("row count after transactional rebuild = %d, want 2", got)
+	}
+}
+
+func TestEphemeralCacheColumnDDLBuffersSchemaPublicationUntilRebuild(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-cache-schema-batching-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBasepath := Basepath
+	Basepath = dir
+	t.Cleanup(func() {
+		databases.Remove("tcachecolumnbatch")
+		Basepath = oldBasepath
+		os.RemoveAll(dir)
+	})
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	CreateDatabase("tcachecolumnbatch", false)
+	db := GetDatabase("tcachecolumnbatch")
+	tbl, created := CreateTable("tcachecolumnbatch", ".grp:query:test", Cache, false)
+	if !created {
+		t.Fatal("ephemeral cache table was not created")
+	}
+	db.ensureBlobTable()
+	counting := &countingSchemaWritePersistence{PersistenceEngine: db.persistence}
+	db.persistence = counting
+
+	for i := 0; i < 32; i++ {
+		if !tbl.CreateColumn(fmt.Sprintf("agg_%d", i), "int", nil, nil) {
+			t.Fatalf("cache column %d was not created", i)
+		}
+	}
+	if got := counting.calls.Load(); got != 0 {
+		t.Fatalf("ephemeral cache column DDL published schema %d times, want 0 before rebuild", got)
+	}
+	if !db.schemaDirty.Load() {
+		t.Fatal("buffered ephemeral cache columns did not mark the schema dirty")
+	}
+	if got := len(tbl.Columns); got != 32 {
+		t.Fatalf("live cache table has %d columns, want 32 before schema publication", got)
+	}
+
+	if result := RebuildTable(tbl, true, false); strings.Contains(result, "errors:") {
+		t.Fatalf("cache table rebuild failed: %s", result)
+	}
+	if got := counting.calls.Load(); got != 1 {
+		t.Fatalf("rebuild published schema %d times, want one deduplicated snapshot", got)
+	}
+	if db.schemaDirty.Load() {
+		t.Fatal("rebuild left the buffered schema dirty")
 	}
 }
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -1004,9 +1004,13 @@ func (t *table) isEphemeralQueryTable() bool {
 	return strings.HasPrefix(t.Name, ".") && t.PersistencyMode == Cache
 }
 
-// schemaSaveMode selects the synchronous persistence guarantee for ordinary
-// DDL. Callers explicitly override it for reconstructible temp metadata.
+// schemaSaveMode selects the persistence guarantee for table DDL. Planner-owned
+// cache tables remain immediately usable in memory, while their reconstructible
+// catalog changes are coalesced into the next schema save or rebuild.
 func (t *table) schemaSaveMode() schemaSaveMode {
+	if t.isEphemeralQueryTable() {
+		return schemaSaveBuffered
+	}
 	return schemaSaveModeForDurability(t.PersistencyMode == Safe)
 }
 

--- a/tests/storage/indexes/fulltext-like-index.yaml
+++ b/tests/storage/indexes/fulltext-like-index.yaml
@@ -274,6 +274,22 @@ test_cases:
     on_fail:
       - sql: "SELECT ROW_NUMBER() OVER (ORDER BY timestamp) AS rn, `table`, index_cols, inputCount, outputCount, exec_ns FROM `system_statistic`.`scans` WHERE `table` = 'ft_large' OR `table` LIKE '.grp:ft_large:%' ORDER BY timestamp LIMIT 16"
 
+  - name: "LIKE carrier avoids repeated base-table work"
+    sql: |
+      SELECT full_rows, cache_rows,
+        CASE WHEN full_rows >= 10000 AND cache_rows > 0 AND cache_rows < full_rows
+          THEN 'ok' ELSE 'FAIL' END AS result
+      FROM (
+        SELECT
+          SUM(CASE WHEN `table` = 'ft_large' AND inputCount >= 10000 THEN inputCount ELSE 0 END) AS full_rows,
+          SUM(CASE WHEN `table` LIKE '.grp:ft_large:%' THEN inputCount ELSE 0 END) AS cache_rows
+        FROM `system_statistic`.`scans`
+        WHERE `table` = 'ft_large' OR `table` LIKE '.grp:ft_large:%'
+      ) s
+    expect: { rows: 1, data: [{ result: "ok" }] }
+    on_fail:
+      - sql: "SELECT ROW_NUMBER() OVER (ORDER BY timestamp) AS rn, `table`, index_cols, inputCount, candidateCount, outputCount, exec_ns FROM `system_statistic`.`scans` WHERE `table` = 'ft_large' OR `table` LIKE '.grp:ft_large:%' ORDER BY timestamp LIMIT 16"
+
   # The aggregate above has its own query-level carrier. Exercise a normal
   # SQL row scan separately so the storage-level bigram candidate is visible.
   - name: "Clear log for direct LIKE bigram scan"
@@ -304,20 +320,20 @@ test_cases:
 
   - name: "SQL compiler reaches selective bigram candidate"
     sql: |
-      SELECT CASE
-        WHEN matched_scans > 0 AND absent_scans > 0 THEN 'ok'
+      SELECT matched_candidates, absent_candidates, CASE
+        WHEN matched_candidates > 0 AND matched_candidates < 30000 AND absent_candidates = 0 THEN 'ok'
         ELSE 'FAIL'
       END AS result
       FROM (
         SELECT
-          SUM(CASE WHEN outputCount = 5 THEN 1 ELSE 0 END) AS matched_scans,
-          SUM(CASE WHEN outputCount = 0 THEN 1 ELSE 0 END) AS absent_scans
+          MIN(CASE WHEN outputCount = 5 THEN candidateCount ELSE NULL END) AS matched_candidates,
+          MIN(CASE WHEN outputCount = 0 THEN candidateCount ELSE NULL END) AS absent_candidates
         FROM `system_statistic`.`scans`
         WHERE `table` = 'ft_large' AND index_cols = 'name'
       ) s
     expect: { rows: 1, data: [{ result: "ok" }] }
     on_fail:
-      - sql: "SELECT ROW_NUMBER() OVER (ORDER BY timestamp) AS rn, `table`, index_cols, inputCount, outputCount, exec_ns FROM `system_statistic`.`scans` WHERE `table` = 'ft_large' ORDER BY timestamp LIMIT 16"
+      - sql: "SELECT ROW_NUMBER() OVER (ORDER BY timestamp) AS rn, `table`, index_cols, inputCount, candidateCount, outputCount, exec_ns FROM `system_statistic`.`scans` WHERE `table` = 'ft_large' ORDER BY timestamp LIMIT 16"
 
   # -- Test 2: Equal id=42 (regression test, must not be slower) --
   - name: "EXPLAIN Equal uses direct id scan"


### PR DESCRIPTION
## Summary

- buffer schema publication for planner-owned dot-prefixed `ENGINE=cache` tables
- keep cache columns and GroupTable initialization immediately visible in memory
- coalesce repeated cache-column DDL through the existing atomic schema-dirty flag and publish one complete snapshot on the next save/rebuild
- add a storage regression test proving 32 column mutations cause zero intermediate schema writes and exactly one rebuild publication
- make parallel fulltext gates validate `inputCount` and `candidateCount` work instead of scheduler-sensitive nanosecond ordering

## Root cause

The ERPL production schema is about 10 MB. Creating non-temp aggregate columns on `.grp:query:*` tables previously selected `schemaSaveNoFsync`, which still marshalled and atomically published the complete database schema once per column while holding the schema lock. Profiling attributed about 3.15 s to that path, including about 2.88 s JSON marshalling plus publication, independent of the actual GroupTable build.

This change does not delay cache construction. It only marks reconstructible internal cache metadata dirty after the live schema mutation. Ordinary user tables, including ordinary `ENGINE=cache` tables without an internal dot-prefixed name, retain synchronous schema publication.

## A/B validation

Same #578 codebase, identical copies of the production-shaped ERPL database and identical query result hash:

- first cold plan: 4.10 s -> 0.87 s (4.7x)
- second fresh plan key with warm storage: 9.77 s -> 0.46 s (21x)
- result SHA-256: `3f9172f111562529e13e2b375becaa5d209f133fcfd90b4f38dcd8b97a320589`

The increasing baseline time was caused by repeatedly serializing the growing schema. The patched build still constructs and populates every cache immediately.

## Validation

- targeted storage regression, 25 repetitions
- fulltext index suite: 86/86
- full `make test` on current master with standard parallel scheduling (`MEMCP_TEST_JOBS=4`): passed, exit 0

