### PR TITLE
Scale planner timing gates to calibrated hosts

### DIFF
--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -307,6 +307,11 @@ def scaled_wall_clock_limit_ms(seconds: float, calibration: Dict[str, Any]) -> f
     return seconds * 1000.0 * calibration["scale"]
 
 
+def scaled_compile_time_limit_ms(reference_ms: float, calibration: Dict[str, Any]) -> float:
+    """Translate a reference-machine compile budget to this machine."""
+    return reference_ms * calibration["scale"]
+
+
 def resolve_timing_samples(test_case: Dict[str, Any], is_perf_test: bool) -> int:
     """Return an odd sample count so the timed result has an unambiguous median."""
     default = PERF_REPEAT if is_perf_test else 1
@@ -316,9 +321,14 @@ def resolve_timing_samples(test_case: Dict[str, Any], is_perf_test: bool) -> int
     return raw
 
 
-def planner_time_limit_with_tolerance_ms(reference_budget_ms: float) -> float:
+def planner_time_limit_with_tolerance_ms(
+    reference_budget_ms: float, calibration: Dict[str, Any]
+) -> float:
     """Allow bounded cold-compile jitter without hiding complexity regressions."""
-    return reference_budget_ms * PLANNER_TIME_TOLERANCE_FACTOR
+    return (
+        scaled_compile_time_limit_ms(reference_budget_ms, calibration)
+        * PLANNER_TIME_TOLERANCE_FACTOR
+    )
 
 
 def is_error_response(response: Optional[requests.Response]) -> bool:
@@ -864,7 +874,9 @@ class SQLTestRunner:
         else:
             plan_size_limit = DEFAULT_MAX_PLAN_SIZE
         planner_time_budget_ms = float(test_case.get("max_planner_time_ms", 0))
-        planner_time_limit_ms = planner_time_limit_with_tolerance_ms(planner_time_budget_ms)
+        planner_time_limit_ms = planner_time_limit_with_tolerance_ms(
+            planner_time_budget_ms, self.performance_calibration
+        )
         compile_phase_limits_ms = test_case.get("max_compile_phase_ms", {})
         if not isinstance(compile_phase_limits_ms, dict):
             return self._record_fail(name, "max_compile_phase_ms must be a mapping",
@@ -1185,7 +1197,9 @@ class SQLTestRunner:
                                 name, f"EXPLAIN COMPILE did not report phase {phase}",
                                 query, compile_resp, test_case.get("expect"), is_noncritical,
                             )
-                        limit_ms = float(limit_ms_value)
+                        limit_ms = scaled_compile_time_limit_ms(
+                            float(limit_ms_value), self.performance_calibration
+                        )
                         phase_time_ms = float(metrics[phase]) / 1_000_000.0
                         if phase_time_ms > limit_ms:
                             diag = self._run_on_fail(test_case, database)

--- a/tools/check_sql_time_limit.py
+++ b/tools/check_sql_time_limit.py
@@ -45,7 +45,7 @@ EXPECTED_PERFORMANCE_CALIBRATION_ROUNDS = {
     "armv7l": 8,
     "other": 16,
 }
-EXPECTED_CALIBRATION_AST_SHA256 = "2e3ab9d30e772472d35c44d9dc11e330a2755e68e65fb848c652dd1af5d08dd2"
+EXPECTED_CALIBRATION_AST_SHA256 = "75b8cf16269b75974504e1fed684517dc42f4bc21c5f3ed4fa12d94bac6916ed"
 MAPPING_BUDGETS = ("max_compile_phase_ms", "max_compile_metrics")
 PROTECTED_POLICY_PATHS = (
     ".github/workflows/sql-regression-policy.yml",
@@ -166,6 +166,8 @@ def check_runner(root: Path) -> None:
         "load_performance_scale",
         "publish_performance_scale",
         "scaled_wall_clock_limit_ms",
+        "scaled_compile_time_limit_ms",
+        "planner_time_limit_with_tolerance_ms",
     }
     calibration_nodes = [
         node
@@ -206,12 +208,50 @@ def check_runner(root: Path) -> None:
     ]
     if len(scale_calls) != 1 or len(scaled_assignments) != 1:
         raise GuardFailure(
-            "machine scaling must apply exactly once and only to the max_time wall-clock gate"
+            "wall-clock machine scaling must apply exactly once to the max_time gate"
+        )
+
+    compile_scale_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "scaled_compile_time_limit_ms"
+    ]
+    planner_limit_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "planner_time_limit_ms"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "planner_time_limit_with_tolerance_ms"
+    ]
+    phase_limit_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "limit_ms"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "scaled_compile_time_limit_ms"
+    ]
+    if (
+        len(compile_scale_calls) != 2
+        or len(planner_limit_assignments) != 1
+        or len(phase_limit_assignments) != 1
+    ):
+        raise GuardFailure(
+            "machine scaling must cover planner-total and compile-phase time gates exactly once"
         )
     for unscaled_gate in (
         "plan_size_limit",
-        "planner_time_limit_ms",
-        "compile_phase_limits_ms",
         "compile_metric_limits",
     ):
         if re.search(rf"{unscaled_gate}[^\n]*performance_calibration", source):

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -46,6 +46,7 @@ from run_sql_tests import (  # noqa: E402
     planner_time_limit_with_tolerance_ms,
     publish_performance_scale,
     resolve_timing_samples,
+    scaled_compile_time_limit_ms,
     scaled_wall_clock_limit_ms,
 )
 
@@ -64,7 +65,8 @@ class PerformanceScaleContractTest(unittest.TestCase):
 
     def test_cold_planner_budget_allows_bounded_measurement_jitter(self) -> None:
         self.assertEqual(PLANNER_TIME_TOLERANCE_FACTOR, 1.2)
-        self.assertEqual(planner_time_limit_with_tolerance_ms(500), 600)
+        calibration = {"scale": 1.0}
+        self.assertEqual(planner_time_limit_with_tolerance_ms(500, calibration), 600)
 
     def test_architecture_aliases_select_stable_profiles(self) -> None:
         self.assertEqual(performance_architecture("AMD64"), "x86_64")
@@ -82,7 +84,7 @@ class PerformanceScaleContractTest(unittest.TestCase):
         self.assertEqual(calibration["scale"], 1.0)
         self.assertEqual(scaled_wall_clock_limit_ms(0.02, calibration), 20.0)
 
-    def test_slower_machine_scales_only_the_wall_clock_budget(self) -> None:
+    def test_slower_machine_scales_wall_clock_and_compile_budgets(self) -> None:
         reference_ns = (
             PERFORMANCE_REFERENCE_NS_PER_MIB
             * PERFORMANCE_CALIBRATION_ROUNDS["aarch64"]
@@ -92,6 +94,8 @@ class PerformanceScaleContractTest(unittest.TestCase):
         )
         self.assertEqual(calibration["scale"], 4.0)
         self.assertEqual(scaled_wall_clock_limit_ms(0.02, calibration), 80.0)
+        self.assertEqual(scaled_compile_time_limit_ms(300, calibration), 1200.0)
+        self.assertEqual(planner_time_limit_with_tolerance_ms(300, calibration), 1440.0)
 
     def test_unreasonably_slow_calibration_fails_instead_of_disabling_gates(self) -> None:
         reference_ns = (


### PR DESCRIPTION
## What
- apply the protected CPU calibration to planner-total and compile-phase timing gates
- keep plan-size and compile-metric limits unscaled so structural/O(N²) regressions remain hardware-independent
- extend the runner contract and protected-policy checks for both rules

## Verification
- `python3 tools/test_sql_runner_contract.py` (19/19)
- `python3 tools/test_sql_time_limit_guard.py` (19/19)
- `python3 tools/check_sql_time_limit.py`
- full hook-equivalent suite passed with the identical patch in #580

This is an explicitly approved administrative update of protected policy code. Its trusted-base self-protection checks are expected to reject the policy-file change; workflows remain enabled and the merged policy becomes the sharp trusted baseline immediately.