### PR TITLE
fix: isolate parser state across concurrent queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,8 @@ replace github.com/launix-de/NonLockingReadMap => ./third_party/NonLockingReadMa
 
 replace github.com/launix-de/go-mysqlstack => ./third_party/go-mysqlstack
 
+replace github.com/launix-de/go-packrat/v2 => ./third_party/go-packrat
+
 replace golang.org/x/text => github.com/carli2/text v0.34.1-0.20260305004517-20c7a406302a
 
 replace github.com/jtolds/gls => ./third_party/gls

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -19,6 +19,7 @@ package scm
 
 import "fmt"
 import "regexp"
+import "sync"
 import packrat "github.com/launix-de/go-packrat/v2"
 
 type parserResult struct {
@@ -43,6 +44,7 @@ type UndefinedParser struct {
 	Parser packrat.Parser[*parserResult]
 	En     *Env
 	Sym    Symbol
+	once   sync.Once
 }
 
 // ScmCaptureParser wraps a parser to capture the matched text
@@ -83,14 +85,14 @@ func scmerToParser(v Scmer) packrat.Parser[*parserResult] {
 
 // allows self recursion on parsers
 func (b *UndefinedParser) Match(s *packrat.Scanner[*parserResult]) (packrat.Node[*parserResult], bool) {
-	if b.Parser == nil {
+	b.once.Do(func() {
 		en2 := b.En.FindRead(b.Sym)
 		val, ok := en2.Vars[b.Sym]
 		if !ok {
 			panic("error parsing parser: variable does not contain a valid parser: " + string(b.Sym))
 		}
 		b.Parser = scmerToParser(val)
-	}
+	})
 	return b.Parser.Match(s)
 }
 

--- a/scm/packrat_test.go
+++ b/scm/packrat_test.go
@@ -16,7 +16,11 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-import "testing"
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
 
 func TestKleeneParserWithoutMemoization(t *testing.T) {
 	parserValue := Eval(Read("no-memo parser", `(parser '(
@@ -31,4 +35,64 @@ func TestKleeneParserWithoutMemoization(t *testing.T) {
 	if got := parser.Execute("", &Globalenv); String(got) != `()` {
 		t.Fatalf("empty no-memo parser returned %s", String(got))
 	}
+}
+
+func TestSharedParserConcurrentCaptures(t *testing.T) {
+	parserValue := Eval(Read("concurrent parser", `(parser '(
+		(define value (or
+			(regex "value-[0-9]+" false false)
+			(regex "word-[a-z]+" false false)))
+		$
+	) value "")`), &Globalenv)
+	parser := parserValue.Parser()
+
+	const workers = 64
+	const iterations = 200
+	start := make(chan struct{})
+	errors := make(chan string, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for iteration := 0; iteration < iterations; iteration++ {
+				input := fmt.Sprintf("value-%d", worker*iterations+iteration)
+				if got := parser.Execute(input, &Globalenv).String(); got != input {
+					errors <- fmt.Sprintf("input %q returned %q", input, got)
+					return
+				}
+			}
+		}(worker)
+	}
+	close(start)
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		t.Error(err)
+	}
+}
+
+func benchmarkCaptureParser(b *testing.B) *ScmParser {
+	b.Helper()
+	return Eval(Read("parser benchmark", `(parser '(
+		(define values (* (regex "[a-z]+" false false) "," true))
+		$
+	) values "")`), &Globalenv).Parser()
+}
+
+func BenchmarkSharedParserSequential(b *testing.B) {
+	parser := benchmarkCaptureParser(b)
+	for b.Loop() {
+		parser.Execute("alpha,beta,gamma,delta,epsilon", &Globalenv)
+	}
+}
+
+func BenchmarkSharedParserParallel(b *testing.B) {
+	parser := benchmarkCaptureParser(b)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			parser.Execute("alpha,beta,gamma,delta,epsilon", &Globalenv)
+		}
+	})
 }

--- a/tests/planner/core/name-resolution-scopes.yaml
+++ b/tests/planner/core/name-resolution-scopes.yaml
@@ -499,6 +499,62 @@ test_cases:
         - {ID: 1, visible: true}
         - {ID: 2, visible: false}
 
+  - name: "Deep scalar scopes bind aliases independently below a derived window"
+    parallel: cold_scope_binding
+    sql: |
+      SELECT vacation.ID,
+        (
+          SELECT COALESCE((
+            SELECT SUM(period.day_factor * LEAST(
+              COALESCE(period.part_end, COALESCE((
+                SELECT employee.inner_only
+                FROM nr_inner employee
+                WHERE employee.ID = vacation.file_id
+                LIMIT 1
+              ), 999)),
+              COALESCE((
+                SELECT employee.inner_only
+                FROM nr_inner employee
+                WHERE employee.ID = vacation.file_id
+                LIMIT 1
+              ), 999)
+            ))
+            FROM (
+              SELECT line.o AS ID,
+                1 AS day_factor,
+                line.ID AS part_start,
+                LEAD(line.ID) OVER (PARTITION BY line.o ORDER BY line.ID) AS part_end
+              FROM nr_line line
+            ) period
+            WHERE period.ID = owner.ID
+              AND period.part_start < COALESCE((
+                SELECT employee.inner_only
+                FROM nr_inner employee
+                WHERE employee.ID = vacation.file_id
+                LIMIT 1
+              ), 999)
+          ), 0)
+          FROM nr_outer owner
+          WHERE owner.ID = vacation.ID
+          LIMIT 1
+        ) AS weighted_end
+      FROM nr_outer vacation
+      ORDER BY vacation.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 1, weighted_end: 206}
+        - {ID: 2, weighted_end: 202}
+
+  - name: "Shared SQL grammar keeps deep alias captures isolated"
+    scm: |
+      (begin
+        (define query "SELECT vacation.ID, (SELECT COALESCE((SELECT SUM(period.day_factor * LEAST(COALESCE(period.part_end, COALESCE((SELECT employee.inner_only FROM nr_inner employee WHERE employee.ID = vacation.file_id LIMIT 1), 999)), COALESCE((SELECT employee.inner_only FROM nr_inner employee WHERE employee.ID = vacation.file_id LIMIT 1), 999))) FROM (SELECT line.o AS ID, 1 AS day_factor, line.ID AS part_start, LEAD(line.ID) OVER (PARTITION BY line.o ORDER BY line.ID) AS part_end FROM nr_line line) period WHERE period.ID = owner.ID AND period.part_start < COALESCE((SELECT employee.inner_only FROM nr_inner employee WHERE employee.ID = vacation.file_id LIMIT 1), 999)), 0) FROM nr_outer owner WHERE owner.ID = vacation.ID LIMIT 1) AS weighted_end FROM nr_outer vacation ORDER BY vacation.ID")
+        (count (parallelN 32 (lambda (_i)
+          (parse_sql "memcp-tests" query (lambda (_schema _table _write) true))))))
+    expect:
+      data: [32]
+
   - name: "JOIN ON cannot reference a later source"
     sql: |
       SELECT o.ID

--- a/third_party/go-packrat/LICENSE
+++ b/third_party/go-packrat/LICENSE
@@ -1,0 +1,679 @@
+(c) 2019, 2024 Launix, Inh. Carl-Philip Hänsch
+Author: Tim Kluge, Carl-Philip Hänsch
+
+Dual licensed with custom aggreements or GPLv3.
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/third_party/go-packrat/README.md
+++ b/third_party/go-packrat/README.md
@@ -1,0 +1,59 @@
+go-packrat
+============================
+
+[![Build Status](https://travis-ci.com/launix-de/go-packrat.svg?branch=master)](https://travis-ci.com/launix-de/go-packrat)
+[![GoDoc](https://godoc.org/github.com/launix-de/go-packrat?status.png)](https://godoc.org/github.com/launix-de/go-packrat)
+
+
+This library allows to construct backtracking top down packrat parsers in Go using parser combination. Packrat parsing enables the parsing of PEG Grammars in linear time. Parsers are combinated using the following basic parsers:
+
+- `AtomParser`: Matches only a specified UTF8 string
+- `RegexParser`: Matches a regular expression
+- `AndParser`: Matches a given list of parsers sequentially
+- `OrParser`: Matches if any of a given list of parsers matches
+- `KleeneParser`: Matches a parser 0 to `n` times, optionally separated by another parser
+- `ManyParser`: Matches a parser 1 to `n` times, optionally separated by another parser
+- `MaybeParser`: Matches a parser 0 or 1 times
+- `EmptyParser`: Does not read any input and matches in every case
+- `EndParser`: Matches only if the scanner has reached the end of the input string
+
+By default, `Atom` and `Regex` parsers skip (but do not match on) leading whitespace. This can be configured per parser.
+
+If a parser matches, it returns an syntax tree `*Node`. Every node points to the parser that produced it, the matched text, and a list of child nodes. AST callbacks are not provided atm, so a full syntax tree traversal is needed to process the parse results.
+
+To construct recursive parsers, create parser combinators with `nil` as the sub parser. After creating the sub parser that itself uses the parent parser, use the `Set` function on the parent parser to update its children. The [JSON parser](./json_test.go) provides an example for this.
+
+This library is currently used in production, but some rarely used features may be broken. Additional documentation is ToDo.
+
+Example
+-----------
+
+A full example in form of a working json parser is provided in [json_test.go](./json_test.go).
+
+```go
+import (
+    packrat "github.com/launix-de/go-packrat"
+)
+
+func main(){
+    input := "Hello World"
+    scanner := NewScanner[string](input, true)
+
+    helloParser := NewAtomParser("noun", "Hello", true)
+    worldParser := NewAtomParser("noun", "World", true)
+    helloAndWorldParser := NewAndParser(func (s string, parts ...string) string {
+	    return "found " + parts[0] + " + " + parts[1]
+    }, helloParser, worldParser)
+
+    result, err := Parse(helloAndWorldParser, scanner)
+    // result will contain "found noun + noun"
+}
+```
+
+Use case
+-----------
+Using this library, you can dynamically define and parse PEG grammars at runtime. Parsing time is proportional to the input length and grammar complexity. Note that if you do not need to build grammars at runtime, a parser generator like [gocc](https://github.com/goccmack/gocc) will produce a static LR parser that is both faster and uses less memory than `go-packrat`. If you want to use a parser combinator, worst-case exponential runtime is not a problem or low memory consumption is required, consider using [goparsec](https://github.com/prataprc/goparsec). `go-packrat` was written as a replacement for `goparsec` that solves the time complexity issue using a simple memoization cache.
+
+License
+------------
+Dual licensed with custom aggreements or GPLv3. See [LICENSE](./LICENSE).

--- a/third_party/go-packrat/and.go
+++ b/third_party/go-packrat/and.go
@@ -1,0 +1,60 @@
+/*
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import "sync"
+
+// AndParser accepts an input if all sub parsers accept the input sequentially
+type AndParser[T any] struct {
+	callback  func(string, ...T) T
+	subParser []Parser[T]
+	buf       sync.Pool
+}
+
+// NewAndParser constructs a new AndParser with the given sub parsers. An AndParser accepts an input if all sub parsers accept the input sequentially.
+func NewAndParser[T any](callback func(string, ...T) T, subparser ...Parser[T]) *AndParser[T] {
+	p := &AndParser[T]{callback: callback, subParser: subparser}
+	p.initPool()
+	return p
+}
+
+func (p *AndParser[T]) initPool() {
+	p.buf = sync.Pool{New: func() any {
+		buffer := make([]T, 0, len(p.subParser))
+		return &buffer
+	}}
+}
+
+// Set updates the sub parsers. This can be used to construct recursive parsers.
+func (p *AndParser[T]) Set(embedded ...Parser[T]) {
+	p.subParser = embedded
+	p.initPool()
+}
+
+// Match matches all given parsers sequentially.
+func (p *AndParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	buffer := p.buf.Get().(*[]T)
+	nodes := (*buffer)[:0]
+	defer func() {
+		clear(nodes)
+		*buffer = nodes[:0]
+		p.buf.Put(buffer)
+	}()
+	start := s.position
+	startPosition := s.position
+	for _, c := range p.subParser {
+		node, ok := s.applyRule(c)
+		if !ok {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+		nodes = append(nodes, node.Payload)
+	}
+
+	return Node[T]{Payload: p.callback(s.input[start:s.position], nodes...)}, true
+}

--- a/third_party/go-packrat/atom.go
+++ b/third_party/go-packrat/atom.go
@@ -1,0 +1,66 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import (
+	"strings"
+)
+
+type AtomParser[T any] struct {
+	value           T
+	skipWs          bool
+	atom            string
+	caseInsensitive bool
+}
+
+func NewAtomParser[T any](value T, str string, caseInsensitive bool, skipWs bool) *AtomParser[T] {
+	p := &AtomParser[T]{value: value, skipWs: skipWs, atom: str, caseInsensitive: caseInsensitive}
+	return p
+}
+
+// Match matches only the given string. If skipWs is set to true, leading whitespace according to the scanner's skip regexp is skipped, but not matched by the parser.
+func (p *AtomParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	startPosition := s.position
+
+	if p.skipWs {
+		s.Skip()
+
+		if !s.isAtBreak() {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	}
+
+	atomLen := len(p.atom)
+	if len(s.remainingInput) < atomLen {
+		s.setPosition(startPosition)
+		return Node[T]{}, false
+	}
+	candidate := s.remainingInput[:atomLen]
+	if p.caseInsensitive {
+		if !strings.EqualFold(candidate, p.atom) {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	} else {
+		if candidate != p.atom {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	}
+	s.move(atomLen)
+
+	if p.skipWs {
+		if !s.isAtBreak() {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	}
+
+	return Node[T]{Payload: p.value}, true
+}

--- a/third_party/go-packrat/charmap.go
+++ b/third_party/go-packrat/charmap.go
@@ -1,0 +1,338 @@
+/*
+	(c) 2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Carl-Philip Hänsch
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+// parserFirstBytes returns the set of first bytes that parser p could match
+// (after whitespace has been skipped by the parent OrParser). The second return
+// value indicates whether the parser can match at end-of-input (empty match or
+// EndParser).
+func parserFirstBytes[T any](p Parser[T], visited map[any]bool) (bytes [256]bool, canMatchEOF bool) {
+	// Cycle detection for recursive grammars
+	key := any(p)
+	if visited[key] {
+		// Already visiting this parser — return empty to break the cycle.
+		// The caller will union results, so omitting bytes here is safe:
+		// the recursive reference can only match what the non-recursive
+		// alternatives already cover.
+		return bytes, false
+	}
+	visited[key] = true
+
+	switch pp := p.(type) {
+	case *AtomParser[T]:
+		if len(pp.atom) == 0 {
+			fillAllBytes(&bytes)
+			return bytes, true
+		}
+		b := pp.atom[0]
+		bytes[b] = true
+		if pp.caseInsensitive {
+			if b >= 'a' && b <= 'z' {
+				bytes[b-32] = true
+			} else if b >= 'A' && b <= 'Z' {
+				bytes[b+32] = true
+			}
+		}
+		return bytes, false
+
+	case *RegexParser[T]:
+		eof := regexFirstBytes(pp.rs, pp.caseInsensitive, &bytes)
+		return bytes, eof
+
+	case *AndParser[T]:
+		// Walk children: if a child can match empty, also include the
+		// next child's first bytes (because the empty-matching child
+		// may be skipped and the successor determines the first byte).
+		for _, child := range pp.subParser {
+			cb, ceof := parserFirstBytes[T](child, visited)
+			for i := range bytes {
+				bytes[i] = bytes[i] || cb[i]
+			}
+			if !ceof {
+				// This child is required, stop here
+				return bytes, false
+			}
+		}
+		// All children can match empty
+		return bytes, true
+
+	case *OrParser[T]:
+		for _, child := range pp.subParser {
+			cb, ceof := parserFirstBytes[T](child, visited)
+			canMatchEOF = canMatchEOF || ceof
+			for i := range bytes {
+				bytes[i] = bytes[i] || cb[i]
+			}
+		}
+		return bytes, canMatchEOF
+
+	case *ManyParser[T]:
+		// ManyParser requires at least 1 match of subParser
+		return parserFirstBytes[T](pp.subParser, visited)
+
+	case *NotParser[T]:
+		return parserFirstBytes[T](pp.mainParser, visited)
+
+	case *EmptyParser[T]:
+		// Matches empty — no active first bytes, but canMatchEOF=true
+		return bytes, true
+
+	case *KleeneParser[T]:
+		// Can match empty (zero repetitions). First bytes are from subParser
+		// (what it matches when non-empty). canMatchEOF=true lets parent
+		// And-nodes union successor bytes.
+		cb, _ := parserFirstBytes[T](pp.subParser, visited)
+		return cb, true
+
+	case *MaybeParser[T]:
+		// Can match empty. First bytes are from subParser.
+		cb, _ := parserFirstBytes[T](pp.subParser, visited)
+		return cb, true
+
+	case *RestParser[T]:
+		fillAllBytes(&bytes)
+		return bytes, true
+
+	case *EndParser[T]:
+		// Only matches end of input, no bytes
+		return bytes, true
+
+	default:
+		// Unknown parser type: conservative fallback
+		fillAllBytes(&bytes)
+		return bytes, true
+	}
+}
+
+func fillAllBytes(bytes *[256]bool) {
+	for i := range bytes {
+		bytes[i] = true
+	}
+}
+
+// regexFirstBytes extracts possible first bytes from a regex pattern string.
+// Returns true if the pattern can match empty input.
+func regexFirstBytes(rs string, caseInsensitive bool, bytes *[256]bool) bool {
+	if len(rs) == 0 {
+		return true // empty pattern matches empty
+	}
+	return regexFirstBytesAt(rs, 0, caseInsensitive, bytes)
+}
+
+// regexFirstBytesAt analyzes the regex element starting at pos, fills bytes
+// with possible first bytes, and returns whether the pattern can match empty.
+func regexFirstBytesAt(rs string, pos int, caseInsensitive bool, bytes *[256]bool) bool {
+	if pos >= len(rs) {
+		return true // end of pattern → matches empty
+	}
+
+	var elemBytes [256]bool
+	nextPos := pos
+
+	switch {
+	case rs[pos] == '(':
+		// Group: find matching close paren
+		closePos := findGroupClose(rs, pos)
+		if closePos < 0 {
+			fillAllBytes(bytes)
+			return true
+		}
+		nextPos = closePos + 1
+
+		// Extract group content, skip ?: prefix for non-capturing groups
+		groupContent := rs[pos+1 : closePos]
+		if len(groupContent) >= 2 && groupContent[0] == '?' && groupContent[1] == ':' {
+			groupContent = groupContent[2:]
+		}
+
+		// Split by | at depth 0 and analyze each alternative
+		alts := splitAlternatives(groupContent)
+		for _, alt := range alts {
+			regexFirstBytesAt(alt, 0, caseInsensitive, &elemBytes)
+		}
+
+	case rs[pos] == '[':
+		content, end := extractBracketExpr(rs, pos)
+		if end < 0 {
+			fillAllBytes(bytes)
+			return true
+		}
+		nextPos = end
+
+		if len(content) > 0 && content[0] == '^' {
+			// Negated class: all bytes except excluded
+			fillAllBytes(&elemBytes)
+			table, ok := buildBitmap(content[1:], caseInsensitive)
+			if ok {
+				for i := 0; i < 256; i++ {
+					if bitmapMatch(&table, byte(i)) {
+						elemBytes[i] = false
+					}
+				}
+			}
+		} else {
+			table, ok := buildBitmap(content, caseInsensitive)
+			if ok {
+				for i := 0; i < 256; i++ {
+					if bitmapMatch(&table, byte(i)) {
+						elemBytes[i] = true
+					}
+				}
+			} else {
+				fillAllBytes(&elemBytes)
+			}
+		}
+
+	case rs[pos] == '.':
+		fillAllBytes(&elemBytes)
+		nextPos = pos + 1
+
+	case rs[pos] == '\\':
+		if pos+1 < len(rs) {
+			ch := rs[pos+1]
+			elemBytes[ch] = true
+			if caseInsensitive {
+				if ch >= 'a' && ch <= 'z' {
+					elemBytes[ch-32] = true
+				} else if ch >= 'A' && ch <= 'Z' {
+					elemBytes[ch+32] = true
+				}
+			}
+			nextPos = pos + 2
+		} else {
+			fillAllBytes(bytes)
+			return true
+		}
+
+	default:
+		ch := rs[pos]
+		elemBytes[ch] = true
+		if caseInsensitive {
+			if ch >= 'a' && ch <= 'z' {
+				elemBytes[ch-32] = true
+			} else if ch >= 'A' && ch <= 'Z' {
+				elemBytes[ch+32] = true
+			}
+		}
+		nextPos = pos + 1
+	}
+
+	// Check quantifier
+	optional := false
+	if nextPos < len(rs) {
+		switch rs[nextPos] {
+		case '?', '*':
+			optional = true
+			nextPos++
+		case '+':
+			nextPos++
+		}
+	}
+
+	// Add this element's bytes to result
+	for i := 0; i < 256; i++ {
+		if elemBytes[i] {
+			bytes[i] = true
+		}
+	}
+
+	if optional {
+		// Element is optional, also consider what comes next
+		eof := regexFirstBytesAt(rs, nextPos, caseInsensitive, bytes)
+		return eof
+	}
+
+	return false
+}
+
+// findGroupClose finds the position of the closing ) for a group starting at pos.
+// Returns -1 if not found.
+func findGroupClose(rs string, pos int) int {
+	depth := 1
+	i := pos + 1
+	for i < len(rs) && depth > 0 {
+		if rs[i] == '\\' && i+1 < len(rs) {
+			i += 2
+			continue
+		}
+		if rs[i] == '(' {
+			depth++
+		} else if rs[i] == ')' {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+		i++
+	}
+	return -1
+}
+
+// splitAlternatives splits a regex string by | at depth 0.
+func splitAlternatives(rs string) []string {
+	var alts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(rs); i++ {
+		if rs[i] == '\\' && i+1 < len(rs) {
+			i++
+			continue
+		}
+		switch rs[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '|':
+			if depth == 0 {
+				alts = append(alts, rs[start:i])
+				start = i + 1
+			}
+		}
+	}
+	alts = append(alts, rs[start:])
+	return alts
+}
+
+// buildCharMap constructs the character dispatch map for an OrParser.
+func buildCharMap[T any](subParsers []Parser[T]) (cm *[256][]int, eofCandidates []int) {
+	cm = &[256][]int{}
+
+	for idx, child := range subParsers {
+		visited := make(map[any]bool)
+		childBytes, canEOF := parserFirstBytes[T](child, visited)
+
+		// Check if any byte is set
+		hasBytes := false
+		for b := 0; b < 256; b++ {
+			if childBytes[b] {
+				hasBytes = true
+				break
+			}
+		}
+
+		if canEOF || !hasBytes {
+			// Parser can match empty, or analysis was incomplete (e.g. left
+			// recursion broke the cycle with no bytes). Add to all entries.
+			if canEOF {
+				eofCandidates = append(eofCandidates, idx)
+			}
+			for b := 0; b < 256; b++ {
+				cm[b] = append(cm[b], idx)
+			}
+		} else {
+			for b := 0; b < 256; b++ {
+				if childBytes[b] {
+					cm[b] = append(cm[b], idx)
+				}
+			}
+		}
+	}
+
+	return cm, eofCandidates
+}

--- a/third_party/go-packrat/empty.go
+++ b/third_party/go-packrat/empty.go
@@ -1,0 +1,23 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+type EmptyParser[T any] struct {
+	// Stub field to prevent compiler from optimizing out &EmptyParser{}
+	value T
+	_hidden bool
+}
+
+func NewEmptyParser[T any](value T) *EmptyParser[T] {
+	return &EmptyParser[T]{value: value}
+}
+
+// Match matches only the given string. If skipWs is set to true, leading whitespace according to the scanner's skip regexp is skipped, but not matched by the parser.
+func (p *EmptyParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	return Node[T]{Payload: p.value}, true
+}

--- a/third_party/go-packrat/end.go
+++ b/third_party/go-packrat/end.go
@@ -1,0 +1,32 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+type EndParser[T any] struct {
+	value T
+	skipWs bool
+}
+
+func NewEndParser[T any](value T, skipWs bool) *EndParser[T] {
+	return &EndParser[T]{value: value, skipWs: skipWs}
+}
+
+// Match accepts only the end of the scanner's input and will not match any input.
+func (p *EndParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	startPosition := s.position
+	if p.skipWs {
+		s.Skip()
+	}
+
+	if len(s.remainingInput) == 0 {
+		return Node[T]{Payload: p.value}, true
+	}
+
+	s.setPosition(startPosition)
+	return Node[T]{}, false
+}

--- a/third_party/go-packrat/fastpath.go
+++ b/third_party/go-packrat/fastpath.go
@@ -1,0 +1,431 @@
+/*
+	(c) 2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Carl-Philip Hänsch
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import (
+	"strings"
+)
+
+// detectFastPath analyzes a regex pattern string and returns a specialized
+// matcher function if the pattern matches a known fast-path category.
+// Returns nil if no specialization is available.
+// The returned function takes the remaining input and returns the match length
+// or -1 if no match.
+func detectFastPath(rs string, caseInsensitive bool) func(string) int {
+	// Category E: exact numeric patterns (most specific, check first)
+	if fp := detectNumeric(rs); fp != nil {
+		return fp
+	}
+
+	// Category F: escaped-string-body patterns
+	if fp := detectEscapedStringBody(rs); fp != nil {
+		return fp
+	}
+
+	// Category D: identifier [class1][class2]*
+	if fp := detectIdentifier(rs, caseInsensitive); fp != nil {
+		return fp
+	}
+
+	// Category G: literal-prefix + class \?[class]+
+	if fp := detectLiteralPrefixClass(rs, caseInsensitive); fp != nil {
+		return fp
+	}
+
+	// Category C: negated single-char [^X]+ / [^X]*
+	if fp := detectNegatedClass(rs); fp != nil {
+		return fp
+	}
+
+	// Category A: [class]+
+	if fp := detectCharClassPlus(rs, caseInsensitive); fp != nil {
+		return fp
+	}
+
+	// Category B: [class]*
+	if fp := detectCharClassStar(rs, caseInsensitive); fp != nil {
+		return fp
+	}
+
+	return nil
+}
+
+// buildBitmap parses a bracket expression content (without the surrounding [ ])
+// and returns a 256-bit lookup table.
+func buildBitmap(charClass string, caseInsensitive bool) ([4]uint64, bool) {
+	var table [4]uint64
+	i := 0
+	for i < len(charClass) {
+		var ch byte
+		if charClass[i] == '\\' {
+			if i+1 >= len(charClass) {
+				return table, false
+			}
+			switch charClass[i+1] {
+			case 'n':
+				ch = '\n'
+			case 'r':
+				ch = '\r'
+			case 't':
+				ch = '\t'
+			case '\\':
+				ch = '\\'
+			case '[', ']', '-', '^':
+				ch = charClass[i+1]
+			default:
+				return table, false // unknown escape
+			}
+			i += 2
+		} else {
+			ch = charClass[i]
+			i++
+		}
+
+		// Check for range: ch-end
+		if i+1 < len(charClass) && charClass[i] == '-' {
+			i++ // skip '-'
+			var end byte
+			if charClass[i] == '\\' {
+				if i+1 >= len(charClass) {
+					return table, false
+				}
+				switch charClass[i+1] {
+				case 'n':
+					end = '\n'
+				case 'r':
+					end = '\r'
+				case 't':
+					end = '\t'
+				case '\\':
+					end = '\\'
+				case '[', ']', '-', '^':
+					end = charClass[i+1]
+				default:
+					return table, false
+				}
+				i += 2
+			} else {
+				end = charClass[i]
+				i++
+			}
+			if end < ch {
+				return table, false
+			}
+			for c := ch; c <= end; c++ {
+				setBit(&table, c, caseInsensitive)
+			}
+		} else {
+			setBit(&table, ch, caseInsensitive)
+		}
+	}
+	return table, true
+}
+
+func setBit(table *[4]uint64, b byte, caseInsensitive bool) {
+	table[b>>6] |= 1 << (b & 63)
+	if caseInsensitive {
+		if b >= 'a' && b <= 'z' {
+			upper := b - 32
+			table[upper>>6] |= 1 << (upper & 63)
+		} else if b >= 'A' && b <= 'Z' {
+			lower := b + 32
+			table[lower>>6] |= 1 << (lower & 63)
+		}
+	}
+}
+
+func bitmapMatch(table *[4]uint64, b byte) bool {
+	return table[b>>6]&(1<<(b&63)) != 0
+}
+
+// extractBracketExpr tries to extract a bracket expression starting at rs[pos].
+// Returns the content (without [ ]) and the position after the closing ].
+// Returns "", -1 on failure.
+func extractBracketExpr(rs string, pos int) (string, int) {
+	if pos >= len(rs) || rs[pos] != '[' {
+		return "", -1
+	}
+	depth := 0
+	start := pos + 1
+	for i := pos; i < len(rs); i++ {
+		if rs[i] == '\\' && i+1 < len(rs) {
+			i++ // skip escaped char
+			continue
+		}
+		if rs[i] == '[' {
+			depth++
+		} else if rs[i] == ']' {
+			depth--
+			if depth == 0 {
+				return rs[start:i], i + 1
+			}
+		}
+	}
+	return "", -1
+}
+
+// Category A: [class]+
+func detectCharClassPlus(rs string, caseInsensitive bool) func(string) int {
+	content, end := extractBracketExpr(rs, 0)
+	if end < 0 || end >= len(rs) || rs[end] != '+' || end+1 != len(rs) {
+		return nil
+	}
+	if len(content) > 0 && content[0] == '^' {
+		return nil // negated class handled by Category C
+	}
+	table, ok := buildBitmap(content, caseInsensitive)
+	if !ok {
+		return nil
+	}
+	return func(input string) int {
+		i := 0
+		for i < len(input) && bitmapMatch(&table, input[i]) {
+			i++
+		}
+		if i == 0 {
+			return -1
+		}
+		return i
+	}
+}
+
+// Category B: [class]*
+func detectCharClassStar(rs string, caseInsensitive bool) func(string) int {
+	content, end := extractBracketExpr(rs, 0)
+	if end < 0 || end >= len(rs) || rs[end] != '*' || end+1 != len(rs) {
+		return nil
+	}
+	if len(content) > 0 && content[0] == '^' {
+		return nil
+	}
+	table, ok := buildBitmap(content, caseInsensitive)
+	if !ok {
+		return nil
+	}
+	return func(input string) int {
+		i := 0
+		for i < len(input) && bitmapMatch(&table, input[i]) {
+			i++
+		}
+		return i // * always succeeds, even with 0 length
+	}
+}
+
+// Category C: [^X]+ or [^X]* or (?:[^X])+
+func detectNegatedClass(rs string) func(string) int {
+	actual := rs
+	plus := true
+
+	// Handle (?:[^X])+ wrapper
+	if strings.HasPrefix(rs, "(?:") {
+		if !strings.HasSuffix(rs, ")+") && !strings.HasSuffix(rs, ")*") {
+			return nil
+		}
+		if strings.HasSuffix(rs, ")*") {
+			plus = false
+		}
+		actual = rs[3 : len(rs)-2]
+	} else {
+		if strings.HasSuffix(rs, "+") {
+			actual = rs[:len(rs)-1]
+			plus = true
+		} else if strings.HasSuffix(rs, "*") {
+			actual = rs[:len(rs)-1]
+			plus = false
+		} else {
+			return nil
+		}
+	}
+
+	// Must be [^...] with a single excluded byte
+	if len(actual) < 4 || actual[0] != '[' || actual[1] != '^' || actual[len(actual)-1] != ']' {
+		return nil
+	}
+	excluded := actual[2 : len(actual)-1]
+	if len(excluded) != 1 {
+		return nil // only single-byte exclusion for now
+	}
+	excludedByte := excluded[0]
+
+	return func(input string) int {
+		i := 0
+		for i < len(input) && input[i] != excludedByte {
+			i++
+		}
+		if plus && i == 0 {
+			return -1
+		}
+		return i
+	}
+}
+
+// Category D: [class1][class2]*
+func detectIdentifier(rs string, caseInsensitive bool) func(string) int {
+	content1, end1 := extractBracketExpr(rs, 0)
+	if end1 < 0 {
+		return nil
+	}
+	content2, end2 := extractBracketExpr(rs, end1)
+	if end2 < 0 || end2 >= len(rs) || rs[end2] != '*' || end2+1 != len(rs) {
+		return nil
+	}
+	if len(content1) > 0 && content1[0] == '^' {
+		return nil
+	}
+	if len(content2) > 0 && content2[0] == '^' {
+		return nil
+	}
+	table1, ok := buildBitmap(content1, caseInsensitive)
+	if !ok {
+		return nil
+	}
+	table2, ok := buildBitmap(content2, caseInsensitive)
+	if !ok {
+		return nil
+	}
+	return func(input string) int {
+		if len(input) == 0 || !bitmapMatch(&table1, input[0]) {
+			return -1
+		}
+		i := 1
+		for i < len(input) && bitmapMatch(&table2, input[i]) {
+			i++
+		}
+		return i
+	}
+}
+
+// Category E: signed numeric patterns
+func detectNumeric(rs string) func(string) int {
+	if rs == `-?[0-9]+` {
+		return matchSignedInt
+	}
+	if rs == `-?[0-9]+\.?[0-9]*(?:e-?[0-9]+)?` {
+		return matchSignedFloat
+	}
+	return nil
+}
+
+func matchSignedInt(input string) int {
+	i := 0
+	if i < len(input) && input[i] == '-' {
+		i++
+	}
+	start := i
+	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+		i++
+	}
+	if i == start {
+		return -1
+	}
+	return i
+}
+
+func matchSignedFloat(input string) int {
+	i := 0
+	if i < len(input) && input[i] == '-' {
+		i++
+	}
+	start := i
+	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+		i++
+	}
+	if i == start {
+		return -1 // no digits
+	}
+	// optional .digits
+	if i < len(input) && input[i] == '.' {
+		i++
+		for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+			i++
+		}
+	}
+	// optional exponent e-?digits
+	if i < len(input) && input[i] == 'e' {
+		expStart := i + 1
+		j := expStart
+		if j < len(input) && input[j] == '-' {
+			j++
+		}
+		digitStart := j
+		for j < len(input) && input[j] >= '0' && input[j] <= '9' {
+			j++
+		}
+		if j > digitStart {
+			i = j // only consume exponent if digits followed
+		}
+	}
+	return i
+}
+
+// Category F: escaped-string-body (\\.|[^\\Q])*
+func detectEscapedStringBody(rs string) func(string) int {
+	// Match pattern: (\\.|[^\\Q])*
+	// where Q is the quote character
+	prefix := `(\\.|[^\\`
+	suffix := `])*`
+	if !strings.HasPrefix(rs, prefix) || !strings.HasSuffix(rs, suffix) {
+		return nil
+	}
+	middle := rs[len(prefix) : len(rs)-len(suffix)]
+	if len(middle) != 1 {
+		return nil
+	}
+	quoteByte := middle[0]
+
+	return func(input string) int {
+		i := 0
+		for i < len(input) {
+			if input[i] == '\\' {
+				if i+1 >= len(input) {
+					break // trailing backslash, stop
+				}
+				i += 2 // skip escaped char
+			} else if input[i] == quoteByte {
+				break
+			} else {
+				i++
+			}
+		}
+		return i // * quantifier, always succeeds (0 is valid)
+	}
+}
+
+// Category G: literal-prefix + class: \?[class]+
+func detectLiteralPrefixClass(rs string, caseInsensitive bool) func(string) int {
+	// Look for \? prefix (escaped question mark)
+	if !strings.HasPrefix(rs, `\?`) {
+		return nil
+	}
+	rest := rs[2:]
+	// Rest must be [class]+
+	content, end := extractBracketExpr(rest, 0)
+	if end < 0 || end >= len(rest) || rest[end] != '+' || end+1 != len(rest) {
+		return nil
+	}
+	if len(content) > 0 && content[0] == '^' {
+		return nil
+	}
+	table, ok := buildBitmap(content, caseInsensitive)
+	if !ok {
+		return nil
+	}
+	return func(input string) int {
+		if len(input) == 0 || input[0] != '?' {
+			return -1
+		}
+		i := 1
+		for i < len(input) && bitmapMatch(&table, input[i]) {
+			i++
+		}
+		if i == 1 {
+			return -1 // need at least one char after ?
+		}
+		return i
+	}
+}

--- a/third_party/go-packrat/go.mod
+++ b/third_party/go-packrat/go.mod
@@ -1,0 +1,3 @@
+module github.com/launix-de/go-packrat/v2
+
+go 1.21

--- a/third_party/go-packrat/kleene.go
+++ b/third_party/go-packrat/kleene.go
@@ -1,0 +1,73 @@
+/*
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import "sync"
+
+type KleeneParser[T any] struct {
+	callback             func(string, ...T) T
+	subParser, sepParser Parser[T]
+	buf                  sync.Pool
+	NoMemo               bool
+}
+
+func NewKleeneParser[T any](callback func(string, ...T) T, subparser Parser[T], sepparser Parser[T]) *KleeneParser[T] {
+	p := &KleeneParser[T]{callback: callback, subParser: subparser, sepParser: sepparser}
+	p.buf.New = func() any {
+		buffer := make([]T, 0, 8)
+		return &buffer
+	}
+	return p
+}
+
+func (p *KleeneParser[T]) Set(embedded Parser[T], separator Parser[T]) {
+	p.subParser = embedded
+	p.sepParser = separator
+}
+
+// Match matches the embedded parser or the empty string.
+func (p *KleeneParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	buffer := p.buf.Get().(*[]T)
+	nodes := (*buffer)[:0]
+	defer func() {
+		clear(nodes)
+		*buffer = nodes[:0]
+		p.buf.Put(buffer)
+	}()
+	start := s.position
+
+	i := 0
+	lastValidPosition := s.position
+	applyFn := s.applyRule
+	if p.NoMemo {
+		applyFn = func(rule Parser[T]) (Node[T], bool) { return rule.Match(s) }
+	}
+	for {
+		if i > 0 && p.sepParser != nil {
+			_, ok := applyFn(p.sepParser)
+			if !ok {
+				break
+			}
+		}
+		i++
+
+		node, ok := applyFn(p.subParser)
+		if !ok {
+			break
+		}
+
+		nodes = append(nodes, node.Payload)
+		lastValidPosition = s.position
+	}
+	s.setPosition(lastValidPosition)
+
+	if len(nodes) == 0 {
+		return Node[T]{Payload: p.callback("")}, true
+	}
+	return Node[T]{p.callback(s.input[start:s.position], nodes...)}, true
+}

--- a/third_party/go-packrat/many.go
+++ b/third_party/go-packrat/many.go
@@ -1,0 +1,73 @@
+/*
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import "sync"
+
+type ManyParser[T any] struct {
+	callback             func(string, ...T) T
+	subParser, sepParser Parser[T]
+	buf                  sync.Pool
+	NoMemo               bool
+}
+
+func NewManyParser[T any](callback func(string, ...T) T, subparser Parser[T], sepparser Parser[T]) *ManyParser[T] {
+	p := &ManyParser[T]{callback: callback, subParser: subparser, sepParser: sepparser}
+	p.buf.New = func() any {
+		buffer := make([]T, 0, 8)
+		return &buffer
+	}
+	return p
+}
+
+func (p *ManyParser[T]) Set(embedded Parser[T], separator Parser[T]) {
+	p.subParser = embedded
+	p.sepParser = separator
+}
+
+func (p *ManyParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	buffer := p.buf.Get().(*[]T)
+	nodes := (*buffer)[:0]
+	defer func() {
+		clear(nodes)
+		*buffer = nodes[:0]
+		p.buf.Put(buffer)
+	}()
+	start := s.position
+
+	i := 0
+	lastValidPos := s.position
+	applyFn := s.applyRule
+	if p.NoMemo {
+		applyFn = func(rule Parser[T]) (Node[T], bool) { return rule.Match(s) }
+	}
+	for {
+		if i > 0 && p.sepParser != nil {
+			_, ok := applyFn(p.sepParser)
+			if !ok {
+				break
+			}
+		}
+		i++
+
+		node, ok := applyFn(p.subParser)
+		if !ok {
+			break
+		}
+
+		nodes = append(nodes, node.Payload)
+		lastValidPos = s.position
+	}
+	s.setPosition(lastValidPos)
+
+	if len(nodes) >= 1 {
+		return Node[T]{Payload: p.callback(s.input[start:s.position], nodes...)}, true
+	}
+
+	return Node[T]{}, false
+}

--- a/third_party/go-packrat/maybe.go
+++ b/third_party/go-packrat/maybe.go
@@ -1,0 +1,34 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+type MaybeParser[T any] struct {
+	valueFalse T
+	subParser Parser[T]
+}
+
+func NewMaybeParser[T any](valueFalse T, subparser Parser[T]) *MaybeParser[T] {
+	return &MaybeParser[T]{valueFalse: valueFalse, subParser: subparser}
+}
+
+func (p *MaybeParser[T]) Set(embedded Parser[T]) {
+	p.subParser = embedded
+}
+
+// Match matches the embedded parser or the empty string.
+func (p *MaybeParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	startPosition := s.position
+	node, ok := s.applyRule(p.subParser)
+
+	if !ok {
+		s.setPosition(startPosition)
+		return Node[T]{Payload: p.valueFalse}, true
+	}
+
+	return Node[T]{Payload: node.Payload}, true
+}

--- a/third_party/go-packrat/not.go
+++ b/third_party/go-packrat/not.go
@@ -1,0 +1,41 @@
+/*
+	(c) 2024 Launix, Inh. Carl-Philip Hänsch
+	Author: Carl-Philip Hänsch
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+// AndParser accepts an input if all sub parsers accept the input sequentially
+type NotParser[T any] struct {
+	mainParser Parser[T]
+	notParser []Parser[T]
+}
+
+// NewAndParser constructs a new AndParser with the given sub parsers. An AndParser accepts an input if all sub parsers accept the input sequentially.
+func NewNotParser[T any](main Parser[T], subparser ...Parser[T]) *NotParser[T] {
+	return &NotParser[T]{mainParser: main, notParser: subparser}
+}
+
+// Match matches all given parsers sequentially.
+func (p *NotParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	start := s.position
+	node, ok := s.applyRule(p.mainParser)
+	if !ok {
+		return node, ok
+	}
+	cont := s.position
+
+	for _, c := range p.notParser {
+		s.setPosition(start)
+		_, ok := s.applyRule(c)
+		if ok { // a not-parser matched, so reset and tell it dosen't work
+			s.setPosition(start)
+			return Node[T]{}, false
+		}
+	}
+	s.setPosition(cont) // go back to old scanner position
+
+	return node, true
+}

--- a/third_party/go-packrat/or.go
+++ b/third_party/go-packrat/or.go
@@ -1,0 +1,76 @@
+/*
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import "sync"
+
+type OrParser[T any] struct {
+	subParser     []Parser[T]
+	charMap       *[256][]int
+	eofCandidates []int
+	charMapBuilt  bool
+	charMapOnce   sync.Once
+}
+
+func NewOrParser[T any](subparser ...Parser[T]) *OrParser[T] {
+	return &OrParser[T]{subParser: subparser}
+}
+
+func (p *OrParser[T]) Set(embedded ...Parser[T]) {
+	p.subParser = embedded
+	p.charMap = nil
+	p.eofCandidates = nil
+	p.charMapBuilt = false
+	p.charMapOnce = sync.Once{}
+}
+
+// SetCharMap installs a manual first-byte dispatch table, overriding auto-build.
+func (p *OrParser[T]) SetCharMap(cm [256][]int) {
+	p.charMap = &cm
+	p.charMapBuilt = true
+	p.charMapOnce.Do(func() {})
+}
+
+// Match tries sub-parsers until one succeeds. On first call, a charMap is
+// automatically built from the sub-parsers' first-byte sets. Only the
+// sub-parsers whose first byte matches the current input byte are tried.
+func (p *OrParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	p.charMapOnce.Do(func() {
+		if !p.charMapBuilt {
+			p.charMap, p.eofCandidates = buildCharMap[T](p.subParser)
+			p.charMapBuilt = true
+		}
+	})
+
+	origPosition := s.position
+	s.Skip()
+
+	if s.position >= len(s.input) {
+		for _, idx := range p.eofCandidates {
+			node, ok := s.applyRule(p.subParser[idx])
+			if ok {
+				return Node[T]{Payload: node.Payload}, true
+			}
+			s.setPosition(s.position)
+		}
+		s.setPosition(origPosition)
+		return Node[T]{}, false
+	}
+
+	candidates := p.charMap[s.input[s.position]]
+	skipPosition := s.position
+	for _, idx := range candidates {
+		node, ok := s.applyRule(p.subParser[idx])
+		if ok {
+			return Node[T]{Payload: node.Payload}, true
+		}
+		s.setPosition(skipPosition)
+	}
+	s.setPosition(origPosition)
+	return Node[T]{}, false
+}

--- a/third_party/go-packrat/parser.go
+++ b/third_party/go-packrat/parser.go
@@ -1,0 +1,241 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type Parser[T any] interface {
+	Match(s *Scanner[T]) (Node[T], bool)
+}
+
+func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
+	startPosition := s.position
+
+	memmap := s.memoization[startPosition]
+	if memmap == nil {
+		memmap = make(map[Parser[T]]*MemoEntry[T])
+		s.memoization[startPosition] = memmap
+	}
+
+	m := s.Recall(rule, startPosition)
+	if m == nil {
+		lr := s.lrPool.Get().(*Lr[T])
+		*lr = Lr[T]{seed: Node[T]{}, seedOk: false, rule: rule, head: nil, next: s.invocationStack}
+		s.invocationStack = lr
+		m := &MemoEntry[T]{Lr: lr, Position: startPosition}
+		memmap[rule] = m
+		ans, ok := rule.Match(s)
+		s.invocationStack = s.invocationStack.next
+		m.Position = s.position
+		if lr.head != nil {
+			lr.seed = ans
+			lr.seedOk = ok
+			result, resultOk := s.LrAnswer(rule, startPosition, m)
+			s.lrPool.Put(lr)
+			return result, resultOk
+		}
+
+		m.Lr = nil
+		m.Ans = ans
+		m.Ok = ok
+		s.lrPool.Put(lr)
+		return ans, ok
+	}
+
+	s.setPosition(m.Position)
+
+	if m.Lr != nil {
+		s.SetupLr(rule, m.Lr)
+		return m.Lr.seed, m.Lr.seedOk
+	}
+
+	return m.Ans, m.Ok
+}
+
+var emptyString = ""
+
+type Node[T any] struct {
+	Payload  T
+}
+
+type ParserError[T any] struct {
+	Parser        Parser[T]
+	Line          int
+	Column        int
+	Position      int
+	FailedParsers []Parser[T]
+	Input         string
+}
+
+func (e *ParserError[T]) Error() string {
+	linestartpos := e.Position - 30
+
+	startpos := linestartpos
+	if startpos < 0 {
+		startpos = 0
+	}
+
+	endpos := e.Position + 10
+	if endpos >= len(e.Input) {
+		endpos = len(e.Input)
+		if endpos < 0 {
+			endpos = 0
+		}
+	}
+
+	atomParsers := make(map[*AtomParser[T]]bool)
+	regexParsers := make(map[*RegexParser[T]]bool)
+	eofParser := false
+	allskipws := true
+
+	for _, p := range e.FailedParsers {
+		switch pa := p.(type) {
+		case *AtomParser[T]:
+			atomParsers[pa] = true
+			if !pa.skipWs {
+				allskipws = false
+			}
+		case *RegexParser[T]:
+			regexParsers[pa] = true
+			if !pa.skipWs {
+				allskipws = false
+			}
+		case *EndParser[T]:
+			eofParser = true
+		}
+	}
+
+	expected := strings.Builder{}
+	count := 0
+	for r := range atomParsers {
+		if count >= 5 {
+			break
+		}
+		expected.WriteString("- " + r.atom)
+		if r.skipWs {
+			expected.WriteString(" (with leading whitespace)")
+		}
+		expected.WriteString("\r\n")
+		count++
+	}
+	for r := range regexParsers {
+		if count >= 5 {
+			break
+		}
+		expected.WriteString("- Regex: " + r.rs)
+		if r.skipWs {
+			expected.WriteString(" (with leading whitespace)")
+		}
+		expected.WriteString("\r\n")
+		count++
+	}
+	if eofParser && count < 5 {
+		expected.WriteString("- End of input\r\n")
+	}
+
+	epos := e.Position
+	for allskipws && epos < len(e.Input)-1 && unicode.IsSpace(rune(e.Input[epos])) {
+		epos++
+	}
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("Parser failed at line %d, column %d (position %d of input string).", e.Line, e.Column, e.Position+1))
+	replacer := strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\t", "  ")
+	builder.WriteString("\r\n" + replacer.Replace(e.Input[startpos:endpos]))
+	builder.WriteString("\r\n")
+	runes := []rune(e.Input)
+	for i := startpos; i < epos && i < len(runes); i++ {
+		c := runes[i]
+		switch c {
+		case '\n':
+			builder.WriteString("  ")
+		case '\t':
+			builder.WriteString("  ")
+		default:
+			builder.WriteRune(' ')
+		}
+	}
+	builder.WriteString("^\r\n")
+	builder.WriteString("Expected one of " + strconv.Itoa(len(atomParsers)+len(regexParsers)) + " alternatives:\r\n" + expected.String() + "Found: " + strings.ReplaceAll(e.Input[e.Position:endpos], "\n", "\\n"))
+
+	return builder.String()
+}
+
+func ParsePartial[T any](p Parser[T], originalScanner *Scanner[T]) (Node[T], *ParserError[T]) {
+	node, ok := originalScanner.applyRule(p)
+	if ok {
+		return node, nil
+	}
+
+	maxPos := 0
+	var failedParsers []Parser[T]
+	for index := len(originalScanner.input); index >= 0; index-- {
+		m := originalScanner.memoization[index]
+		if len(m) > 0 {
+			maxPos = index
+			for k := range m {
+				failedParsers = append(failedParsers, k)
+			}
+			break
+		}
+	}
+
+	consumed := originalScanner.input[:maxPos]
+	line := strings.Count(consumed, "\n") + 1
+	lastBreak := strings.LastIndex(consumed, "\n")
+	if lastBreak < 0 {
+		lastBreak = 0
+	}
+	column := maxPos - lastBreak + 1
+	e := &ParserError[T]{FailedParsers: failedParsers, Parser: p, Line: line, Column: column, Position: maxPos, Input: originalScanner.input}
+	return Node[T]{}, e
+}
+
+func Parse[T any](p Parser[T], originalScanner *Scanner[T]) (Node[T], *ParserError[T]) {
+	node, ok := originalScanner.applyRule(p)
+	if ok {
+		originalScanner.Skip()
+		if len(originalScanner.remainingInput) > 0 {
+			consumed := originalScanner.input[:originalScanner.position]
+			line := strings.Count(consumed, "\n") + 1
+			column := originalScanner.position - strings.LastIndex(consumed, "\n") + 1
+			e := &ParserError[T]{Parser: p, Line: line, Column: column, Position: originalScanner.position, Input: originalScanner.input}
+			return Node[T]{}, e
+		}
+
+		return node, nil
+	}
+
+	maxPos := 0
+	var failedParsers []Parser[T]
+	for index := len(originalScanner.input); index >= 0; index-- {
+		m := originalScanner.memoization[index]
+		if len(m) > 0 {
+			maxPos = index
+			for k := range m {
+				failedParsers = append(failedParsers, k)
+			}
+			break
+		}
+	}
+
+	consumed := originalScanner.input[:maxPos]
+	line := strings.Count(consumed, "\n") + 1
+	lastBreak := strings.LastIndex(consumed, "\n")
+	if lastBreak < 0 {
+		lastBreak = 0
+	}
+	column := maxPos - lastBreak + 1
+	e := &ParserError[T]{FailedParsers: failedParsers, Parser: p, Line: line, Column: column, Position: maxPos, Input: originalScanner.input}
+
+	return Node[T]{}, e
+}

--- a/third_party/go-packrat/regex.go
+++ b/third_party/go-packrat/regex.go
@@ -1,0 +1,82 @@
+/*
+	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import (
+	"regexp"
+)
+
+type RegexParser[T any] struct {
+	callback        func(string) T
+	regex           *regexp.Regexp
+	fastPath        func(string) int
+	skipWs          bool
+	caseInsensitive bool
+	rs              string
+}
+
+func NewRegexParser[T any](callback func(string) T, rs string, caseInsensitive bool, skipWs bool) *RegexParser[T] {
+	fp := detectFastPath(rs, caseInsensitive)
+	if fp != nil {
+		return &RegexParser[T]{callback: callback, fastPath: fp, skipWs: skipWs, caseInsensitive: caseInsensitive, rs: rs}
+	}
+	prefix := ""
+	if caseInsensitive {
+		prefix += "(?i)"
+	}
+	prefix += "^"
+	r := regexp.MustCompile(prefix + rs)
+	return &RegexParser[T]{callback: callback, regex: r, skipWs: skipWs, caseInsensitive: caseInsensitive, rs: rs}
+}
+
+// Regex matches only the given regexp. If skipWs is set to true, leading whitespace according to the scanner's skip regexp is skipped, but not matched by the parser.
+// Regex panics if rs is not a valid regex string.
+func (p *RegexParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	startPosition := s.position
+	if p.skipWs {
+		s.Skip()
+		if !s.isAtBreak() {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	}
+
+	if p.fastPath != nil {
+		matchLen := p.fastPath(s.remainingInput)
+		if matchLen < 0 {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+		matchedStr := s.remainingInput[:matchLen]
+		s.move(matchLen)
+
+		if p.skipWs {
+			if !s.isAtBreak() {
+				s.setPosition(startPosition)
+				return Node[T]{}, false
+			}
+		}
+
+		return Node[T]{Payload: p.callback(matchedStr)}, true
+	}
+
+	matched := s.MatchRegexp(p.regex)
+	if matched == nil {
+		s.setPosition(startPosition)
+		return Node[T]{}, false
+	}
+
+	if p.skipWs {
+		if !s.isAtBreak() {
+			s.setPosition(startPosition)
+			return Node[T]{}, false
+		}
+	}
+
+	return Node[T]{Payload: p.callback(*matched)}, true
+}

--- a/third_party/go-packrat/rest.go
+++ b/third_party/go-packrat/rest.go
@@ -1,0 +1,23 @@
+/*
+	(c) 2024 Launix, Inh. Carl-Philip Hänsch
+	Author: Carl-Philip Hänsch
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+type RestParser[T any] struct {
+	converter func (string) T
+}
+
+func NewRestParser[T any](converter func (string) T) *RestParser[T] {
+	return &RestParser[T]{converter: converter}
+}
+
+func (p *RestParser[T]) Match(s *Scanner[T]) (Node[T], bool) {
+	// just slice away the rest
+	v := s.remainingInput
+	s.setPosition(len(s.input))
+	return Node[T]{Payload: p.converter(v)}, true
+}

--- a/third_party/go-packrat/scanner.go
+++ b/third_party/go-packrat/scanner.go
@@ -1,0 +1,309 @@
+/*
+	(c) 2019, 2023 Launix, Inh. Carl-Philip Hänsch
+	Author: Tim Kluge
+	Author: Carl-Philip Hänsch
+
+	Dual licensed with custom aggreements or GPLv3
+*/
+
+package packrat
+
+import (
+	"sync"
+	"regexp"
+	"unicode"
+)
+
+type MemoEntry[T any] struct {
+	Lr  *Lr[T]
+	Ans Node[T]
+	Ok bool
+
+	Position int
+}
+
+type Head[T any] struct {
+	rule        Parser[T]
+	involvedSet map[Parser[T]]bool
+	evalSet     map[Parser[T]]bool
+}
+
+func (s *Scanner[T]) NewHead(rule Parser[T]) *Head[T] {
+	h := s.headpool.Get().(*Head[T])
+	h.rule = rule
+	clear(h.involvedSet)
+	clear(h.evalSet)
+	return h
+}
+
+func (h *Head[T]) IsInvolved(rule Parser[T]) bool {
+	if rule == h.rule {
+		return true
+	}
+
+	_, isInvoled := h.involvedSet[rule]
+	return isInvoled
+}
+
+func (h *Head[T]) IsEvaluated(rule Parser[T]) bool {
+	_, isEvaluated := h.evalSet[rule]
+	return isEvaluated
+}
+
+type Lr[T any] struct {
+	seed Node[T]
+	seedOk bool
+	rule Parser[T]
+	head *Head[T]
+	next *Lr[T]
+}
+
+type Scanner[T any] struct {
+	input           string
+	remainingInput  string
+	position        int
+	memoization     []map[Parser[T]]*MemoEntry[T]
+	heads           map[int]*Head[T]
+	invocationStack *Lr[T]
+	breaks          []bool
+
+	headpool        sync.Pool
+	lrPool          sync.Pool
+
+	skipRegex *regexp.Regexp
+}
+
+// Copy clones the scanner state. Memoization and break slices are shared.
+// Pools are shared by copying the New functions.
+func (s *Scanner[T]) Copy() *Scanner[T] {
+	ns := &Scanner[T]{
+		input:           s.input,
+		remainingInput:  s.remainingInput,
+		position:        s.position,
+		memoization:     s.memoization,
+		heads:           s.heads,
+		invocationStack: s.invocationStack,
+		breaks:          s.breaks,
+		skipRegex:       s.skipRegex,
+	}
+	ns.headpool.New = s.headpool.New
+	ns.lrPool.New = s.lrPool.New
+	return ns
+}
+
+func (s *Scanner[T]) Recall(rule Parser[T], pos int) *MemoEntry[T] {
+	mmap := s.memoization[pos]
+	var m *MemoEntry[T]
+	if mmap != nil {
+		m = mmap[rule]
+	}
+
+	// If not growing a seed parse, just return what is stored in the memo table
+	head, headExists := s.heads[pos]
+	if !headExists {
+		return m
+	}
+
+	// Do not evaluate any rule that is not involved in this left recursion
+	if m == nil && !head.IsInvolved(rule) {
+		return &MemoEntry[T]{Position: s.position}
+	}
+
+	// Allow involved rules to be evaluated, but only once, during a seed-growing iteration
+	if head.IsEvaluated(rule) {
+		delete(head.evalSet, rule)
+		node, ok := rule.Match(s)
+		return &MemoEntry[T]{Position: s.position, Ans: node, Ok: ok}
+	}
+
+	return m
+}
+
+func (s *Scanner[T]) SetupLr(rule Parser[T], l *Lr[T]) {
+	if l.head == nil {
+		l.head = s.NewHead(rule)
+	}
+	stack := s.invocationStack
+	for stack != nil && stack.head != l.head {
+		stack.head = l.head
+		newInvolved := make(map[Parser[T]]bool)
+		for k := range l.head.involvedSet {
+			newInvolved[k] = true
+		}
+		newInvolved[stack.rule] = true
+		l.head.involvedSet = newInvolved
+		stack = stack.next
+	}
+}
+
+func (s *Scanner[T]) GrowLr(rule Parser[T], p int, m *MemoEntry[T], h *Head[T]) (Node[T], bool) {
+	s.heads[p] = h
+	for {
+		s.setPosition(p)
+		h.evalSet = make(map[Parser[T]]bool)
+		for k, v := range h.involvedSet {
+			h.evalSet[k] = v
+		}
+		ans, ok := rule.Match(s)
+		if !ok || s.position <= m.Position {
+			break
+		}
+		m.Lr = nil
+		m.Ans = ans
+		m.Ok = ok
+		m.Position = s.position
+	}
+	s.headpool.Put(s.heads[p])
+	delete(s.heads, p)
+	s.setPosition(m.Position)
+	return m.Ans, m.Ok
+}
+
+func (s *Scanner[T]) LrAnswer(rule Parser[T], pos int, m *MemoEntry[T]) (Node[T], bool) {
+	h := m.Lr.head
+	if h.rule != rule {
+		return m.Lr.seed, m.Lr.seedOk
+	}
+	m.Ans = m.Lr.seed
+	m.Ok = m.Lr.seedOk
+	m.Lr = nil
+
+	if !m.Ok {
+		return Node[T]{}, false
+	}
+	return s.GrowLr(rule, pos, m, h)
+}
+
+var SkipWhitespaceRegex = regexp.MustCompile("^[\r\n\t ]+")
+var SkipWhitespaceAndCommentsRegex = regexp.MustCompile("^(?:/\\*.*?\\*/|[\r\n\t ]+)+") // regex for comments
+
+// skipper: use nil, SkipWhitespaceRegex or your very own regex
+func NewScanner[T any](input string, skipper *regexp.Regexp) *Scanner[T] {
+	s := &Scanner[T]{input: input, position: 0,
+		memoization: make([]map[Parser[T]]*MemoEntry[T], len(input)+1),
+		heads: make(map[int]*Head[T])}
+	s.headpool.New = func() any {
+		return &Head[T]{nil, make(map[Parser[T]]bool), make(map[Parser[T]]bool)}
+	}
+	s.lrPool.New = func() any { return &Lr[T]{} }
+	s.remainingInput = s.input
+	s.skipRegex = skipper
+	s.breaks = make([]bool, len(input)+1)
+
+	previousWord := false
+	for pos, r := range input {
+		currentWord := unicode.In(r, unicode.N, unicode.L, unicode.Pc)
+		if !currentWord || !previousWord {
+			s.breaks[pos] = true
+		}
+
+		previousWord = currentWord
+	}
+
+	s.breaks[len(input)] = true
+
+	return s
+}
+
+// Reset reinitializes the scanner for a new input, reusing allocated slices
+// when possible. This allows pooling Scanners across queries to avoid per-query
+// construction allocations.
+func (s *Scanner[T]) Reset(input string, skipper *regexp.Regexp) {
+	s.input = input
+	s.position = 0
+	s.remainingInput = input
+	s.skipRegex = skipper
+	s.invocationStack = nil
+
+	// Clear heads map (reuse the map object)
+	clear(s.heads)
+
+	needed := len(input) + 1
+
+	// Reuse memoization slice if large enough
+	if cap(s.memoization) >= needed {
+		s.memoization = s.memoization[:needed]
+		for i := range s.memoization {
+			s.memoization[i] = nil
+		}
+	} else {
+		s.memoization = make([]map[Parser[T]]*MemoEntry[T], needed)
+	}
+
+	// Reuse breaks slice if large enough
+	if cap(s.breaks) >= needed {
+		s.breaks = s.breaks[:needed]
+		for i := range s.breaks {
+			s.breaks[i] = false
+		}
+	} else {
+		s.breaks = make([]bool, needed)
+	}
+
+	// Rebuild word breaks
+	previousWord := false
+	for pos, r := range input {
+		currentWord := unicode.In(r, unicode.N, unicode.L, unicode.Pc)
+		if !currentWord || !previousWord {
+			s.breaks[pos] = true
+		}
+		previousWord = currentWord
+	}
+	s.breaks[len(input)] = true
+}
+
+func (s *Scanner[T]) isAtBreak() bool {
+	return s.breaks[s.position]
+}
+
+func (s *Scanner[T]) move(n int) {
+	s.position += n
+	s.remainingInput = s.input[s.position:]
+}
+
+func (s *Scanner[T]) setPosition(n int) {
+	s.position = n
+	s.remainingInput = s.input[s.position:]
+}
+
+func (s *Scanner[T]) MatchRegexp(r *regexp.Regexp) *string {
+	loc := r.FindStringIndex(s.remainingInput)
+	if loc != nil {
+		matched := s.remainingInput[:loc[1]]
+		s.move(loc[1])
+		return &matched
+	}
+
+	return nil
+}
+
+func (s *Scanner[T]) Skip() {
+	if s.skipRegex != nil && s.position < len(s.input) &&
+		(s.input[s.position] <= ' ' || s.input[s.position] == '/') {
+		s.MatchRegexp(s.skipRegex)
+	}
+}
+
+// GetPosition returns the current position in the input
+func (s *Scanner[T]) GetPosition() int {
+	return s.position
+}
+
+// GetInput returns the full input string
+func (s *Scanner[T]) GetInput() string {
+	return s.input
+}
+
+// Substring returns the substring from start to end positions
+func (s *Scanner[T]) Substring(start, end int) string {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(s.input) {
+		end = len(s.input)
+	}
+	if start >= end {
+		return ""
+	}
+	return s.input[start:end]
+}


### PR DESCRIPTION
## Root cause

The SQL grammar is intentionally shared, but go-packrat stored capture buffers, recursion depth, and lazy dispatch state directly on parser nodes. Concurrent cold query compilation therefore raced while constructing parse results. The later bind_query_names error was only the first consumer to detect the corrupted AST.

## Fix

- vendor the current go-packrat release and replace shared match buffers with per-invocation pooled buffers
- publish lazy OR dispatch and recursive parser references exactly once
- keep grammar nodes shared and immutable during matching; no global parse lock and no alias-specific binder fallback
- add an ERPL-shaped nested scalar/window regression under tests/
- add a direct concurrent parse regression plus a Go race-detector test and parser benchmarks

## Validation

- make test: all tests passed
- go test -race ./scm -run ^TestSharedParserConcurrentCaptures$ -count=1
- name-resolution-scopes.yaml: 40/40 passed
- vendored go-packrat upstream suite: passed
- sequential parser benchmark remains effectively unchanged; parallel parsing is slightly faster and allocation count is unchanged