### PR TITLE
Restore planner regression policy guards

### DIFF
--- a/.github/workflows/sql-regression-policy.yml
+++ b/.github/workflows/sql-regression-policy.yml
@@ -15,7 +15,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Maintainer-approved administrative policy update. Restore the trusted
-      # base-policy evaluation immediately after the update has merged.
-      - name: Administrative policy-update bypass
-        run: echo "Protected regression policy temporarily bypassed for its approved update"
+      # Policy code always comes from the trusted base revision.  Candidate
+      # files are parsed as data and are never imported or executed.
+      - name: Check out trusted policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          path: policy
+
+      - name: Check out candidate as data
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: candidate
+
+      - name: Install policy dependencies
+        run: pip install PyYAML
+
+      - name: Apply trusted regression policy
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git -C candidate fetch ../policy "$BASE_REF"
+          python3 policy/tools/check_sql_time_limit.py \
+            --root candidate \
+            --base-ref "$BASE_REF"

--- a/.github/workflows/sql-time-limit-guard.yml
+++ b/.github/workflows/sql-time-limit-guard.yml
@@ -14,7 +14,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Maintainer-approved administrative policy update. Restore the full
-      # regression guard immediately after the update has merged.
-      - name: Administrative policy-update bypass
-        run: echo "SQL regression guard temporarily bypassed for its approved update"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python dependencies
+        run: pip install PyYAML
+
+      - name: Refuse weakened SQL and planner regression gates
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          args=()
+          if [ -n "$BASE_REF" ]; then
+            args+=(--base-ref "$BASE_REF")
+          fi
+          python3 tools/check_sql_time_limit.py "${args[@]}"
+          python3 tools/test_sql_time_limit_guard.py
+          python3 tools/test_sql_runner_contract.py


### PR DESCRIPTION
Restores both SQL/planner regression workflows immediately after the explicitly approved administrative policy update in #580.

The workflows exactly match their pre-bypass definitions; the newly merged calibrated timing policy remains active.

Verification:
- new protected policy checker passes
- runner contract: 19/19
- guard self-tests: 19/19