### PR TITLE
Fix missing nested scalar carrier prepares

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5598,6 +5598,62 @@ build_queryplan contract. */
 					(emitted_prepare_binding_keys head keys))
 				_ keys)))))
 
+(define prepare_call_key (lambda (expr)
+	(if (and (list? expr) (equal? (count expr) 3))
+		(begin
+			(define head (nth expr 0))
+			(define target (nth expr 1))
+			(if (and
+				(or (equal? head (quote apply)) (equal? head (symbol "apply")))
+				(list? target)
+				(equal? (count target) 2))
+				(begin
+					(define session_call (nth target 0))
+					(if (and
+						(list? session_call)
+						(equal? (count session_call) 2)
+						(or
+							(equal? (nth session_call 0) (quote context))
+							(equal? (nth session_call 0) (symbol "context")))
+						(equal? (nth session_call 1) "session"))
+						(nth target 1)
+						nil))
+				nil))
+		nil)))
+
+(define emitted_prepare_call_keys (lambda (expr keys)
+	(begin
+		(define key (prepare_call_key expr))
+		(define found (if (nil? key) keys (set_assoc keys key true)))
+		(match expr
+			((symbol quote) _value) found
+			((quote quote) _value) found
+			(cons head tail) (reduce tail (lambda (acc item)
+				(emitted_prepare_call_keys item acc))
+				(emitted_prepare_call_keys head found))
+			_ found))))
+
+/* Carrier consolidation can retain calls through nested consumer paths after
+their physical recipe has been merged into another owner. Keep those logical
+handles callable without rebuilding the already consolidated carrier. */
+(define complete_emitted_prepare_bindings (lambda (ir plan)
+	(if (not (query_block? (ir_root ir)))
+		plan
+		(begin
+			(define catalog (unique_stages_by_id
+				(stage_catalog_with_nested (query_block_stage_catalog (ir_root ir)))))
+			(define bound_keys (emitted_prepare_binding_keys plan '()))
+			(define called_keys (emitted_prepare_call_keys plan '()))
+			(define missing_roots (filter catalog (lambda (stage)
+				(begin
+					(define key (stage_prepare_key stage))
+					(and (has_assoc? called_keys key) (not (has_assoc? bound_keys key)))))))
+			(if (empty_list? missing_roots)
+				plan
+				(cons (quote !begin) (merge (list
+					(map missing_roots prepared_stage_binding)
+					(list plan)))))))))
+
 (define without_prepare_bindings (lambda (expr keys)
 	(begin
 		(define key (prepare_binding_key expr))
@@ -5722,11 +5778,13 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 	(if (not (query_block? (ir_root ir)))
 		plan
 		(begin
-			(define catalog (query_block_stage_catalog (ir_root ir)))
+			(define catalog (stage_catalog_with_nested
+				(query_block_stage_catalog (ir_root ir))))
 			(if (empty_list? catalog)
 				plan
 				(begin
 					(define emitted_keys (emitted_prepare_binding_keys plan '()))
+					(define emitted_call_keys (emitted_prepare_call_keys plan '()))
 					(define emitted_strings (physical_string_set plan '()))
 					(define dependency_graph (stage_dependency_graph catalog))
 					(define consumers (filter catalog (lambda (stage)
@@ -5740,7 +5798,8 @@ Both AST walks are linear; no pairwise recipe comparison is performed. */
 						(and (closed_group_prepare_stage? dependency_graph stage)
 							(and (has_assoc? selected_backbones (stage_prepare_backbone_signature stage))
 								(or (has_assoc? emitted_keys (stage_prepare_key stage))
-									(stage_aggregate_referenced? emitted_strings stage)))))))
+									(or (has_assoc? emitted_call_keys (stage_prepare_key stage))
+										(stage_aggregate_referenced? emitted_strings stage))))))))
 					(if (empty_list? selected)
 						plan
 						(begin
@@ -5887,7 +5946,8 @@ though both handles are constant for the complete query generation. */
 				_ (neumann_fail "build_queryplan" "DML lowering expects a query-block root"))
 			_ (neumann_fail "build_queryplan" "DML lowering is intentionally not scaffolded yet")))
 		(define consolidated_plan (consolidate_closed_group_prepares ir plan))
-		(define deduplicated_plan (deduplicate_lazy_prepare_recipes consolidated_plan))
+		(define complete_plan (complete_emitted_prepare_bindings ir consolidated_plan))
+		(define deduplicated_plan (deduplicate_lazy_prepare_recipes complete_plan))
 		(define memoized_plan (if (empty_list? (ir_stages ir))
 			deduplicated_plan
 			(consolidate_query_invariant_presence_memos deduplicated_plan)))

--- a/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
+++ b/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
@@ -48,6 +48,8 @@ setup:
       CREATE TABLE csa_ref (
         id INT PRIMARY KEY,
         group_id INT,
+        duration_past INT,
+        duration_future INT,
         label VARCHAR(32)
       )
   - sql: |
@@ -90,11 +92,11 @@ setup:
         (31, 3, 3000, 3, 0),
         (41, 4, NULL, 8, 1)
   - sql: |
-      INSERT INTO csa_ref (id, group_id, label) VALUES
-        (1000, 1, 'alpha'),
-        (1001, 1, 'beta'),
-        (2000, 2, 'gamma'),
-        (3000, NULL, 'delta')
+      INSERT INTO csa_ref (id, group_id, duration_past, duration_future, label) VALUES
+        (1000, 1, 1, 1, 'alpha'),
+        (1001, 1, 1, 1, 'beta'),
+        (2000, 2, 2, 2, 'gamma'),
+        (3000, NULL, NULL, NULL, 'delta')
   - sql: |
       INSERT INTO csa_assignment (id, actor_id, tenant_id, ref_id, allowed) VALUES
         (1, 7, 100, 1000, TRUE),
@@ -121,6 +123,48 @@ setup:
       FROM cq_digit d1, cq_digit d2, cq_digit d3
 
 test_cases:
+
+  - name: "Cold nested scalar ranges under OR initialize all dependent carriers"
+    sql: |
+      SELECT (
+        SELECT SUM(1)
+        FROM csa_item i
+        WHERE i.score IS NOT NULL
+          AND (
+            (((100 - i.score) % 100) / 10 BETWEEN 0 AND (
+              SELECT duration_past
+              FROM csa_ref
+              WHERE id = (
+                SELECT p.ref_id
+                FROM csa_parent p
+                WHERE p.id = i.parent_id
+                LIMIT 1
+              )
+            ))
+            OR
+            (((100 - i.score) % 100) / 10 BETWEEN 10 - (
+              SELECT duration_future
+              FROM csa_ref
+              WHERE id = (
+                SELECT p.ref_id
+                FROM csa_parent p
+                WHERE p.id = i.parent_id
+                LIMIT 1
+              )
+            ) AND 10)
+          )
+          AND COALESCE((
+            SELECT TRUE
+            FROM csa_parent visible_parent
+            WHERE visible_parent.id = i.parent_id
+            LIMIT 1
+          ), FALSE)
+        LIMIT 1
+      ) AS reminder
+    expect:
+      rows: 1
+      data:
+        - reminder: 3
 
   - name: "Correlated scalar ORDER BY LIMIT chooses the top item"
     sql: |


### PR DESCRIPTION
## Summary
- add a regression for an aggregate over a correlated collection whose filter combines two nested scalar range bounds with `OR`
- cover an additional `COALESCE`-wrapped scalar-presence branch in the same query
- include called nested stages when consolidating physical group-carrier recipes
- retain callable logical prepare handles when their recipes are merged into a physical owner

## Query shape
The regression computes a sum over outer rows. Each row tests whether any correlated child row falls outside a lower/upper range. Both range bounds come from nested scalar subqueries through a parent/reference relation, and a separate scalar subquery supplies a nullable presence flag via `COALESCE`. On a cold execution, every dependent carrier must therefore be initialized even when compatible physical recipes are consolidated.

## Validation
- the regression fails on unchanged `master` with `Unknown function: nil`
- the captured query shape succeeds against the preserved fixture
- targeted planner, carrier, and concurrency suites pass
- the complete pre-commit suite passes without coverage instrumentation
- the coverage-instrumented suite passes all correctness checks; only the existing one-second wall-clock compile budget is exceeded under instrumentation, while a normal binary passes it