### PR TITLE
Fix indexed stage catalog composition during nested lowering

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -287,7 +287,7 @@ partner. */
 		(define fact_catalog (group_stage_lowering_catalog stage))
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define stage_lookup (stage_catalog_with_nested
-			(merge (list all_stages
+			(merge_stage_catalogs (list all_stages
 				(if (lowering_catalog? fact_catalog)
 					(lowering_catalog_stages fact_catalog)
 					(coalesceNil fact_catalog '()))
@@ -513,7 +513,7 @@ partner. */
 	(begin
 		(define direct_stages (scalar_first_query_probe_direct_nested_stages all_stages stage))
 		(define probe_catalog (stage_catalog_with_nested
-			(merge (list all_stages direct_stages))))
+			(merge_stage_catalogs (list all_stages direct_stages))))
 		(define dependency_graph (stage_dependency_graph probe_catalog))
 		(define closure_index (stage_dependency_closure_index_using_graph dependency_graph direct_stages))
 		(define nested_stages
@@ -1114,7 +1114,7 @@ until lowering without creating a depth-proportional binary OR chain. */
 		(define branch_stages (merge (map (coalesceNil branches '()) (lambda (branch)
 			(if (query_block? branch) (qb_stages branch) '())))))
 		(define stage_lookup
-			(make_lowering_catalog (unique_stages_by_id (merge (list all_stages branch_stages)))))
+			(make_lowering_catalog (merge_stage_catalogs (list all_stages branch_stages))))
 		(define dependency_graph (stage_dependency_graph stage_lookup))
 		(cons (quote or)
 			(map (coalesceNil branches '()) (lambda (branch)
@@ -1214,7 +1214,7 @@ through to reach the base table -- src already is it. */
 	(begin
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
-			(merge (list all_stages probe_catalog (nested_stage_catalog stage)))))
+			(merge_stage_catalogs (list all_stages probe_catalog (nested_stage_catalog stage)))))
 		(define physical_stage (if (empty_list? probe_catalog)
 			stage
 			(group_stage_with_stage_catalog stage stage_catalog)))
@@ -1338,7 +1338,7 @@ membership set. */
 	(begin
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
-			(merge (list all_stages probe_catalog (nested_stage_catalog stage)))))
+			(merge_stage_catalogs (list all_stages probe_catalog (nested_stage_catalog stage)))))
 		(define physical_stage (if (empty_list? probe_catalog)
 			stage
 			(group_stage_with_stage_catalog stage stage_catalog)))
@@ -1503,7 +1503,7 @@ choice table instead of adding another promotion path. */
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define lowering_catalog (group_stage_lowering_catalog stage))
 		(define probe_stages (stage_catalog_with_nested
-			(merge (list
+			(merge_stage_catalogs (list
 				all_stages
 				probe_catalog
 				(if (lowering_catalog? lowering_catalog)
@@ -1589,7 +1589,7 @@ choice table instead of adding another promotion path. */
 		(define neutral_expr (nth ag 2))
 		(if (query_block? src)
 			(lower_scalar_aggregate_query_probe_expr
-				(stage_catalog_with_nested (merge (list
+				(stage_catalog_with_nested (merge_stage_catalogs (list
 					(qassoc_get (gs_facts stage) (quote probe_catalog) '())
 					(if (lowering_catalog? (group_stage_lowering_catalog stage))
 						(lowering_catalog_stages (group_stage_lowering_catalog stage))
@@ -1643,7 +1643,7 @@ choice table instead of adding another promotion path. */
 		(define value_expr (nth ag 0))
 		(if (query_block? src)
 			(lower_scalar_first_query_probe_expr
-				(stage_catalog_with_nested (merge (list
+				(stage_catalog_with_nested (merge_stage_catalogs (list
 					(qassoc_get (gs_facts stage) (quote probe_catalog) '())
 					(if (lowering_catalog? (group_stage_lowering_catalog stage))
 						(lowering_catalog_stages (group_stage_lowering_catalog stage))
@@ -2324,7 +2324,7 @@ cache identity or a logical fallback. */
 		(define raw_input (gs_input stage))
 		(define stamped_catalog (qassoc_get (gs_facts stage) (quote stage_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
-			(merge (list stamped_catalog (nested_stage_catalog stage)
+			(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
 				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 		(list (quote begin)
 			(lower_group_stage_prepare_using stage_catalog stage_catalog stage)
@@ -2820,7 +2820,7 @@ NULL semantics, never the syntactic reason that introduced the stage. */
 					true))
 				(define stamped_catalog (qassoc_get (gs_facts stage) (quote stage_catalog) '()))
 				(define stage_catalog (stage_catalog_with_nested
-					(merge (list stamped_catalog (nested_stage_catalog stage)
+					(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
 						(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 				(list (quote begin)
 					(lower_group_stage_prepare_using stage_catalog stage_catalog stage)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1460,9 +1460,21 @@ get_column refs to the source) are excluded automatically too. */
 				catalog
 				(merge (map nested nested_stage_catalog))))))))
 
+(define stage_catalog_entries (lambda (stages)
+	(if (lowering_catalog? stages)
+		(lowering_catalog_stages stages)
+		(merge (map (coalesceNil stages '()) (lambda (stage)
+			(if (lowering_catalog? stage)
+				(lowering_catalog_stages stage)
+				(list stage))))))))
+
+(define merge_stage_catalogs (lambda (catalogs)
+	(unique_stages_by_id
+		(merge (map (coalesceNil catalogs '()) lowering_catalog_stages)))))
+
 (define stage_catalog_with_nested (lambda (stages)
 	(unique_stages_by_id
-		(merge (map (coalesceNil stages '()) nested_stage_catalog)))))
+		(merge (map (stage_catalog_entries stages) nested_stage_catalog)))))
 
 (define lower_group_stage (lambda (stage)
 	(begin
@@ -4621,7 +4633,7 @@ source of that driver leaf. */
 				(define target_col (if (nil? key_index) nil
 					(direct_column_name_for_alias driver_src (nth lookup_keys key_index))))
 				(define probe_stages (stage_catalog_with_nested
-					(merge (list stages dependencies
+					(merge_stage_catalogs (list stages dependencies
 						(qassoc_get (gs_facts stage) (quote probe_catalog) '())
 						(list stage)))))
 				(define operator (if (nil? target_col) (quote unsupported)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -870,6 +870,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define prepared_lowering_catalog (make_lowering_catalog indexed_catalog_stages))
 	(assert (lowering_catalog? prepared_lowering_catalog) true
 		"physical preparation indexes stage catalogs above the measured crossover")
+	(define merged_catalog_stage (make_group_stage
+		"merged-catalog-stage"
+		(list "merged" "memcp-tests" "merged_source" false nil)
+		'() '(1) '() nil '() '() nil nil '()))
+	(define merged_indexed_catalog (merge_stage_catalogs
+		(list prepared_lowering_catalog (list merged_catalog_stage))))
+	(assert (equal? (count merged_indexed_catalog) 26) true
+		"physical catalog composition expands indexed handles before merging stages")
+	(assert (empty_list? (filter merged_indexed_catalog lowering_catalog?)) true
+		"physical catalog composition never leaks an indexed handle into a stage list")
+	(assert (equal? (gs_id (stage_by_id
+		(stage_catalog_with_nested merged_indexed_catalog)
+		"merged-catalog-stage")) "merged-catalog-stage") true
+		"nested physical catalog traversal accepts stages composed with an indexed root")
 	(assert (lowering_catalog? (make_lowering_catalog (cdr indexed_catalog_stages))) false
 		"physical preparation keeps exactly 24 stages on the list path")
 	(assert (equal? (gs_id (stage_for_output_relation prepared_lowering_catalog

--- a/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
+++ b/tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml
@@ -684,6 +684,128 @@ test_cases:
         - id: 5
 
 
+  - name: "Indexed nested stage catalogs preserve compound scalar evaluation"
+    sql: |
+      SELECT p.id,
+        COALESCE((
+          SELECT (
+          COALESCE((SELECT a1.allowed FROM csa_assignment a1
+                    WHERE a1.id = 1
+                      AND a1.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a2.allowed FROM csa_assignment a2
+                    WHERE a2.id = 2
+                      AND a2.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a3.allowed FROM csa_assignment a3
+                    WHERE a3.id = 3
+                      AND a3.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a4.allowed FROM csa_assignment a4
+                    WHERE a4.id = 4
+                      AND a4.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a5.allowed FROM csa_assignment a5
+                    WHERE a5.id = 5
+                      AND a5.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a6.allowed FROM csa_assignment a6
+                    WHERE a6.id = 6
+                      AND a6.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a7.allowed FROM csa_assignment a7
+                    WHERE a7.id = 7
+                      AND a7.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a8.allowed FROM csa_assignment a8
+                    WHERE a8.id = 8
+                      AND a8.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a9.allowed FROM csa_assignment a9
+                    WHERE a9.id = 9
+                      AND a9.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a10.allowed FROM csa_assignment a10
+                    WHERE a10.id = 10
+                      AND a10.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a11.allowed FROM csa_assignment a11
+                    WHERE a11.id = 11
+                      AND a11.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a12.allowed FROM csa_assignment a12
+                    WHERE a12.id = 12
+                      AND a12.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a13.allowed FROM csa_assignment a13
+                    WHERE a13.id = 13
+                      AND a13.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a14.allowed FROM csa_assignment a14
+                    WHERE a14.id = 14
+                      AND a14.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a15.allowed FROM csa_assignment a15
+                    WHERE a15.id = 15
+                      AND a15.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a16.allowed FROM csa_assignment a16
+                    WHERE a16.id = 16
+                      AND a16.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a17.allowed FROM csa_assignment a17
+                    WHERE a17.id = 17
+                      AND a17.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a18.allowed FROM csa_assignment a18
+                    WHERE a18.id = 18
+                      AND a18.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a19.allowed FROM csa_assignment a19
+                    WHERE a19.id = 19
+                      AND a19.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a20.allowed FROM csa_assignment a20
+                    WHERE a20.id = 20
+                      AND a20.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a21.allowed FROM csa_assignment a21
+                    WHERE a21.id = 21
+                      AND a21.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a22.allowed FROM csa_assignment a22
+                    WHERE a22.id = 22
+                      AND a22.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a23.allowed FROM csa_assignment a23
+                    WHERE a23.id = 23
+                      AND a23.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a24.allowed FROM csa_assignment a24
+                    WHERE a24.id = 24
+                      AND a24.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE) AND
+          COALESCE((SELECT a25.allowed FROM csa_assignment a25
+                    WHERE a25.id = 25
+                      AND a25.tenant_id = nested_parent.tenant_id
+                    LIMIT 1), TRUE)
+            AND (COALESCE((SELECT rr.label FROM csa_ref rr
+                           WHERE rr.id = nested_parent.ref_id
+                           LIMIT 1), '') <> '')
+          )
+          FROM csa_parent nested_parent
+          WHERE nested_parent.id = p.id
+          LIMIT 1
+        ), FALSE) AS allowed
+      FROM csa_parent p
+      WHERE p.id = 1
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          allowed: false
+
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS cq_large_parent"
   - sql: "DROP TABLE IF EXISTS cq_digit"


### PR DESCRIPTION
## Summary
- normalize indexed lowering catalogs before composing nested physical stage sets
- use the catalog-aware merge across scalar, union, keytable, RecSet, and projected-membership lowering
- cover the indexed representation boundary and a compound nested scalar query shape

## Root cause
Queries with more than 24 logical stages use an indexed lowering-catalog handle. Generic list merging dismantled that opaque handle, so later nested traversal could interpret the catalog tag as a group stage and fail during semantic-signature lookup.

## Validation
- exact large derived-query replay fails on the parent revision and succeeds with this change
- targeted aggregate-shape suite: 25/25
- compiler-scaling suite: 8/8
- full pre-commit suite: passed
- Scheme formatter executed; its check still reports the repository's pre-existing depth warnings