### PR TITLE
Reuse membership key indexes after join reordering

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3376,12 +3376,23 @@ move the window to the wrong tree level. */
 				(equal? membership_strategy "prefiltered_candidate_keyset")))
 			(cadr membership_plan)
 			nil))
+		/* An ordered driver probe owns one immutable RHS key index. Reuse the
+		same carrier representation as the single-source lowerer so join reordering
+		cannot turn this alternative into one relational subscan per driver row. */
+		(define membership_keysets (if (and (not (nil? membership))
+			(equal? membership_strategy "driver_order_membership_probe"))
+			(membership_keyset_bindings (list membership))
+			'()))
+		(define use_membership_keyset (not (empty_list? membership_keysets)))
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
-		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		(define effective_condition (if use_membership_keyset
+			(replace_driver_membership_keyset_markers condition membership_keysets)
+			(strip_driver_membership_for_source src condition effective_membership)))
 		/* The node-local physical choice is final. A full or driver-prefiltered
-		candidate keyset becomes the ordered carrier; a driver-probe choice leaves
-		the marker in the base-table filter so its established direct probe lowering
-		remains in charge. */
+		candidate keyset becomes the ordered carrier. A driver-probe choice keeps the
+		base table ordered and replaces a supported direct-column marker with the
+		query-scoped key index; unsupported computed keys retain the established probe
+		fallback and its separately calibrated cost. */
 		(define filter_condition effective_condition)
 		/* A scalar probe already owns a nested relational callback. Copying it into
 		the scan_order acceptance callback adds another outer scope and would make
@@ -3456,9 +3467,12 @@ move the window to the wrong tree level. */
 			map_expr nil nil false nil
 			(cons (quote list) acceptance_cols)
 			acceptance_expr))
-		(list (quote stream_window_reduce)
+		(define window_expr (list (quote stream_window_reduce)
 			offset limit reduce_expr neutral_expr
-			(list (quote lambda) (list emit_value) scan_expr)))))
+			(list (quote lambda) (list emit_value) scan_expr)))
+		(if use_membership_keyset
+			(wrap_membership_keyset_bindings membership_keysets window_expr)
+			window_expr))))
 
 (define without_col (lambda (cols col)
 	(filter (coalesceNil cols '()) (lambda (item) (not (equal? item col))))))
@@ -3971,6 +3985,14 @@ exact parameter value. */
 				(equal? membership_strategy "prefiltered_candidate_keyset")))
 			(cadr membership_plan)
 			nil))
+		/* Join-tree leaves consume the same ordered RHS key-index alternative as
+		the top-level ordered lowerer. The index is bound outside the scan callback
+		and is therefore built once per query, irrespective of tree depth. */
+		(define membership_keysets (if (and (not (nil? membership))
+			(equal? membership_strategy "driver_order_membership_probe"))
+			(membership_keyset_bindings (list membership))
+			'()))
+		(define use_membership_keyset (not (empty_list? membership_keysets)))
 		(if (expr_contains_driver_membership? condition)
 			(planner_record_physical_decision (list
 				(list "decision" "join_leaf_membership_consumer")
@@ -3982,18 +4004,22 @@ exact parameter value. */
 						(reduce all_sources (lambda (found candidate_src)
 							(or found (not (nil? (driver_membership_for_source candidate_src condition)))))
 							false))
+					(list "keyset_binding_count" (count membership_keysets))
 					(list "carrier_allowed" allow_membership_recset)
 					(list "limit_delayed" delay_limit_after_join)
 					(list "projection_built" (not (nil? membership_table_expr)))))))
 			nil)
 		(define effective_membership (if (nil? membership_table_expr) nil membership))
-		(define effective_condition (strip_driver_membership_for_source src condition effective_membership))
+		(define effective_condition (if use_membership_keyset
+			(replace_driver_membership_keyset_markers condition membership_keysets)
+			(strip_driver_membership_for_source src condition effective_membership)))
 		(define row_number_stage_filter (row_number_stage_for_source stages src effective_condition))
 		/* A candidate-keyset choice makes the projected row positions this leaf's
-		scan carrier even when later join leaves are continuations. A driver-probe
-		choice leaves the logical marker in the established direct probe path. The
-		row-number pipeline still owns a base-table carrier, so it consumes a chosen
-		candidate RecSet as a membership filter until it accepts an explicit source. */
+		scan carrier even when later join leaves are continuations. A supported
+		driver-probe choice instead keeps the base table and binds one RHS key index
+		outside every continuation. The row-number pipeline still owns a base-table
+		carrier, so it consumes a chosen candidate RecSet as a membership filter until
+		it accepts an explicit source. */
 		(define membership_driver (and
 			(not (nil? membership_table_expr))
 			(nil? row_number_stage_filter)))
@@ -4107,11 +4133,14 @@ exact parameter value. */
 						reduce_expr
 						(join_scan_neutral_expr result_mode)
 						(or outer_scan (source_outer? src))))))
-		(if membership_filter
+		(define membership_bound_scan (if membership_filter
 			(list
 				(list (quote lambda) (list membership_var) scan_expr)
 				membership_table_expr)
-			scan_expr))))
+			scan_expr))
+		(if use_membership_keyset
+			(wrap_membership_keyset_bindings membership_keysets membership_bound_scan)
+			membership_bound_scan))))
 
 /* Consume the logical join tree recursively. The right subtree is lowered as
 the continuation of the left subtree, so join-node boundaries and outer-join
@@ -6150,14 +6179,15 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		"ordered_batch_accept"
 		(if (physical_prefiltered_membership_expr? plan)
 			"prefiltered_candidate_keyset"
-			(if (physical_expr_has_head? plan (quote recset_project_join))
-				"candidate_keyset"
-				/* A forced membership variant reaches this function only after
-				require_physical_scan_relations has rejected every surviving logical
-				marker. Without a projected RecSet its emitted carrier is therefore the
-				driver-side probe family, independent of the concrete group-cache/index
-				primitive selected inside that family. */
-				"driver_order_membership_probe")))))
+			/* Calibration compiles one membership decision at a time, but the query
+			may contain unrelated projected RecSets (for example an ACL carrier). The
+			key index uniquely identifies the selected ordered-driver implementation,
+			so inspect it before the more general recset_project_join primitive. */
+			(if (physical_expr_has_head? plan (quote recset_key_index))
+				"driver_order_membership_probe"
+				(if (physical_expr_has_head? plan (quote recset_project_join))
+					"candidate_keyset"
+					"driver_order_membership_probe"))))))
 
 (define physical_operator_family_for_decision (lambda (plan decision)
 	(begin

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -767,7 +767,7 @@ test_cases:
             tenant INT,
             allowed INT
           )
-      - sql: "CREATE TABLE in_batch_file (ID INT PRIMARY KEY, flag INT)"
+      - sql: "CREATE TABLE in_batch_file (ID INT PRIMARY KEY, flag INT, search VARCHAR(8192))"
       - sql: "CREATE TABLE in_batch_doc (ID INT PRIMARY KEY, file_id INT, sort_key INT)"
       - sql: |
           INSERT INTO in_dv_file (ID, filename, search) VALUES
@@ -793,12 +793,16 @@ test_cases:
           (2, 2, 0)
       - scm: |
           (begin
-            (insert (table "memcp-tests" "in_batch_file") '("ID" "flag")
+            (define long_search (reduce (produceN 192) (lambda (text _i)
+              (concat text "common searchable text ")) ""))
+            (insert (table "memcp-tests" "in_batch_file") '("ID" "flag" "search")
               (map (produceN 8000) (lambda (i)
-                (list (+ i 1) 1))))
+                (list (+ i 1) 1 long_search))))
             (insert (table "memcp-tests" "in_batch_doc") '("ID" "file_id" "sort_key")
               (map (produceN 10000) (lambda (i)
                 (list (+ i 1) (if (< i 8000) (+ i 1) (- i 7999)) (- 10000 i)))))
+            (rebuild (table "memcp-tests" "in_batch_file") true false)
+            (rebuild (table "memcp-tests" "in_batch_doc") true false)
             true)
     steps:
       - sql: |
@@ -1260,6 +1264,42 @@ test_cases:
             - "chosen"
             - "rejected"
       - sql: |
+          SELECT t.ID, t.allowed
+          FROM (
+            SELECT d.ID, d.file_id, d.sort_key, a.allowed
+            FROM in_batch_doc d
+            LEFT JOIN in_dv_acl a ON a.ID = d.file_id
+          ) t
+          WHERE t.file_id IN (
+            SELECT f.ID FROM in_batch_file f WHERE f.search LIKE '%common%'
+            UNION
+            SELECT f.ID FROM in_batch_file f WHERE f.flag = 0
+          )
+          ORDER BY t.sort_key
+          LIMIT 72
+        expect:
+          rows: 72
+      - sql: |
+          EXPLAIN PHYSICAL
+          SELECT t.ID, t.allowed
+          FROM (
+            SELECT d.ID, d.file_id, d.sort_key, a.allowed
+            FROM in_batch_doc d
+            LEFT JOIN in_dv_acl a ON a.ID = d.file_id
+          ) t
+          WHERE t.file_id IN (
+            SELECT f.ID FROM in_batch_file f WHERE f.search LIKE '%common%'
+            UNION
+            SELECT f.ID FROM in_batch_file f WHERE f.flag = 0
+          )
+          ORDER BY t.sort_key
+          LIMIT 72
+        expect:
+          contains:
+            - "driver_order_membership_probe"
+            - "recset_key_index"
+            - "scan_order"
+      - sql: |
           EXPLAIN
           SELECT t.ID
           FROM (
@@ -1312,6 +1352,8 @@ test_cases:
             - "candidate_rows"
             - "driver_rows"
             - "result_equal"
+          not_contains:
+            - "operator_consistent false"
       - sql: |
           EXPLAIN PHYSICAL CALIBRATE DISCOVER
           SELECT t.ID


### PR DESCRIPTION
## Summary

- make the ordered-driver membership alternative consume one query-scoped RHS key index after logical join reordering
- use the same physical carrier in both streaming `ORDER BY ... LIMIT` lowering and recursive join-tree leaves
- classify the specific `recset_key_index` operator before unrelated projected RecSets during physical calibration
- add a permanent broad `IN (... UNION ...)` + derived ACL + ordered-limit regression shape

## Root cause

Join reordering correctly selected `driver_order_membership_probe`, but two physical consumers left the logical membership marker on the base-table condition. That sent execution through a relational RHS probe for every driver row. The already-existing single-source path could build a bounded RHS key index, but reordered join trees and streaming limits did not consume it.

The physical choice therefore existed in the cost model but did not consistently determine the emitted operator.

## Implementation

For the selected ordered-driver strategy, supported direct-column membership keys now:

1. build the RHS RecSet/key index once outside scan callbacks;
2. replace the logical driver-membership marker with a key-index lookup;
3. reuse the immutable binding throughout the ordered window or recursive join leaf.

Computed-key shapes that cannot use this carrier keep the established calibrated probe fallback. No generated weights or planner constants are changed.

## Regression proof

The added SQL fixture deliberately combines:

- a reordered derived LEFT JOIN with nested permission projections;
- broad membership produced by a UNION;
- an ordered document driver with `LIMIT 72`;
- more than 1,000 driving rows and rebuilt statistics.

On master, the logical plan selects the ordered driver strategy but the physical plan contains no `recset_key_index`; the new structural assertion fails. With this change the physical plan contains `driver_order_membership_probe`, `recset_key_index`, and `scan_order`, while returning the same 72 rows.

## Production-copy A/B

Exact broad full-text list query over roughly 855k driving rows, same result set:

| Build | First/cold | Warm |
| --- | ---: | ---: |
| master baseline | 122.8 s | 91.8 s |
| this branch | 10.37 s | 5.99 s |

This is about a 15x warm improvement. It does not yet reach the final 3 s target: remaining work is concentrated in ACL/projection carriers and the remaining `scan_exists`/keytable consumers. An inventory-only query has no corresponding membership edge and remains outside this patch at about 5.6 s warm.

## Validation

- Scheme startup tests: 1260/1260
- `tests/planner/subqueries/in-subquery.yaml`: 71/71
- `tests/planner/aggregates/composed-scalar-aggregate-shapes.yaml`: 25/25
- `tests/performance/traced-planner-scaling.yaml`: 8/8
- focused RecSet, range-scan, correlated-left-join, and compound-ACL suites passed
- Scheme formatter check passed
- `go build -o memcp .` passed
- full suite delegated to CI
