### PR TITLE
Bound parameterized compilation of wide join graphs

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -99,8 +99,8 @@ PostgreSQL parsers should both lower to the same combined operators.
 
 /* Cost-model decisions register the condition which keeps their chosen branch
 valid in a compile-local newsession. cached_parse installs the accumulator;
-direct planner users deliberately remain unaffected. Structural string keys
-deduplicate identical conditions without mutable Scheme lists. */
+direct planner users deliberately remain unaffected. The structural catalogs
+deduplicate immutable ASTs without serializing the growing expressions. */
 (define planner_record_guard_condition (lambda (condition)
 	(begin
 		(define condition_accumulator (try
@@ -109,14 +109,25 @@ deduplicate identical conditions without mutable Scheme lists. */
 		(if (nil? condition_accumulator)
 			condition
 			(begin
-				(condition_accumulator (string condition) condition)
+				(define condition_catalog (try
+					(lambda () ((context "session") "__memcp_queryplan_guard_condition_catalog"))
+					(lambda (_e) nil)))
+				(if (nil? condition_catalog)
+					(condition_accumulator (string condition) condition)
+					(if (condition_catalog condition)
+						nil
+						(begin
+							(define count (coalesceNil (condition_accumulator "count") 0))
+							(condition_catalog condition true)
+							(condition_accumulator (concat "condition:" count) condition)
+							(condition_accumulator "count" (+ count 1)))))
 				(define covered_bindings (try
 					(lambda () ((context "session") "__memcp_queryplan_guarded_session_keys"))
 					(lambda (_e) nil)))
 				(if (nil? covered_bindings)
 					nil
 					(reduce (query_expr_session_reads condition) (lambda (_ expr)
-						(covered_bindings (string expr) true)) nil))
+						(covered_bindings (if (nil? condition_catalog) (string expr) expr) true)) nil))
 				condition)))))
 
 (define planner_guarded_choice (lambda (chosen condition)
@@ -202,14 +213,23 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 		(if (nil? bindings)
 			expr
 			(begin
-				(define key (string expr))
-				(define existing (bindings key))
+				(define binding_catalog (try
+					(lambda () ((context "session") "__memcp_queryplan_guard_binding_catalog"))
+					(lambda (_e) nil)))
+				(define key (if (nil? binding_catalog) (string expr) expr))
+				(define existing (if (nil? binding_catalog) (bindings key) (binding_catalog key)))
 				(if (nil? existing)
 					(begin
 						(define binding (list
-							(symbol (concat "__queryplan_guard_value_" (fnv_hash key)))
+							(symbol (concat "__queryplan_guard_value_" (stable_structural_hash expr false)))
 							expr))
-						(bindings key binding)
+						(if (nil? binding_catalog)
+							(bindings key binding)
+							(begin
+								(define count (coalesceNil (bindings "count") 0))
+								(binding_catalog key binding)
+								(bindings (concat "binding:" count) binding)
+								(bindings "count" (+ count 1))))
 						(car binding))
 					(car existing)))))))
 
@@ -1968,7 +1988,7 @@ general recursive boolean proof above. */
 			(canonical_column_expr_for_alias inner_default expr))))
 		(define keys (merge (list explicit_keys (filter session_keys (lambda (expr)
 			(not (contains? explicit_keys expr)))))))
-		(define stage_id (concat "scalar-group-top:" (fnv_hash (serialize (list subquery keys ags (qb_order inner))))))
+		(define stage_id (concat "scalar-group-top:" (stable_structural_hash (list subquery keys ags (qb_order inner)) true)))
 		(define stage (make_group_stage
 			stage_id
 			inner_src
@@ -2033,7 +2053,7 @@ general recursive boolean proof above. */
 				(qb_stages inner)
 				(qb_facts inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
-		(define stage_id (concat "exists:" (fnv_hash (string (list subquery keys outer_domain condition)))))
+		(define stage_id (concat "exists:" (stable_structural_hash (list subquery keys outer_domain condition) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -2109,8 +2129,8 @@ general recursive boolean proof above. */
 			'()
 			(qb_stages inner)
 			(qb_facts inner)))
-		(define stage_id (concat "exists-group:" (fnv_hash
-			(string (list subquery keys outer_domain condition (qb_having inner))))))
+		(define stage_id (concat "exists-group:" (stable_structural_hash
+			(list subquery keys outer_domain condition (qb_having inner)) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -2249,7 +2269,7 @@ general recursive boolean proof above. */
 		serialization once and reuse the compact identity below; serializing that
 		large immutable tree twice made canonicalization scale with an avoidable
 		second full traversal. */
-		(define inner_hash (fnv_hash (serialize inner)))
+		(define inner_hash (stable_structural_hash inner true))
 		(define candidate_alias (concat "__exists_union_" inner_hash))
 		(define union_input (make_union_block
 			(union_mode inner)
@@ -2262,7 +2282,7 @@ general recursive boolean proof above. */
 		(define keys (mapIndex (gs_keys first_stage) (lambda (i _key)
 			(list (quote get_column) candidate_alias false (concat "k" (string i)) false))))
 		(define stage_id (concat "exists-union:"
-			(fnv_hash (serialize (list inner_hash outer_domain lookup_keys)))))
+			(stable_structural_hash (list inner_hash outer_domain lookup_keys) true)))
 		(define stage (make_group_stage
 			stage_id
 			union_input
@@ -2420,7 +2440,7 @@ without separately proving two-valued semantics. */
 		(define where_mode (if (>= (count args) 4) (nth args 3) false))
 		(define truth_membership (string? where_mode))
 		(define semijoin_where (and (not truth_membership) where_mode))
-		(define candidate_alias (concat "__in_candidate_" (fnv_hash (string (list probe inner)))))
+		(define candidate_alias (concat "__in_candidate_" (stable_structural_hash (list probe inner) false)))
 		(define union_input (make_union_block
 			(union_mode inner)
 			(map (union_branches inner) make_in_union_candidate_branch)
@@ -2430,8 +2450,8 @@ without separately proving two-valued semantics. */
 				(list (quote alias) candidate_alias))))
 		(define candidate_key (list (quote get_column) candidate_alias false "v" false))
 		(define keys (list candidate_key))
-		(define stage_id (concat "in-candidate:" (fnv_hash (string (list probe inner)))))
-		(define null_stage_id (concat "in-candidate-null:" (fnv_hash (string inner))))
+		(define stage_id (concat "in-candidate:" (stable_structural_hash (list probe inner) false)))
+		(define null_stage_id (concat "in-candidate-null:" (stable_structural_hash inner false)))
 		(define null_ag (in_rhs_state_descriptor candidate_key))
 		(define stage (make_group_stage
 			stage_id
@@ -2555,9 +2575,9 @@ without separately proving two-valued semantics. */
 				(qb_stages membership_inner)
 				(qb_facts membership_inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
-		(define stage_id (concat "in:" (fnv_hash (string (list probe keys lookup_keys condition)))))
+		(define stage_id (concat "in:" (stable_structural_hash (list probe keys lookup_keys condition) false)))
 		(define null_ag (in_rhs_state_descriptor rhs_expr))
-		(define null_stage_id (concat "in-null:" (fnv_hash (string (list outer_domain condition rhs_expr)))))
+		(define null_stage_id (concat "in-null:" (stable_structural_hash (list outer_domain condition rhs_expr) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -2741,7 +2761,7 @@ without separately proving two-valued semantics. */
 				(qb_stages inner)
 				(qb_facts inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
-		(define stage_id (concat "scalar-agg:" (fnv_hash (string (list subquery keys outer_domain condition ags)))))
+		(define stage_id (concat "scalar-agg:" (stable_structural_hash (list subquery keys outer_domain condition ags) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -2829,7 +2849,7 @@ without separately proving two-valued semantics. */
 				(qb_stages inner)
 				(qb_facts inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
-		(define stage_id (concat "scalar-once:" (fnv_hash (string (list subquery keys outer_domain condition ags)))))
+		(define stage_id (concat "scalar-once:" (stable_structural_hash (list subquery keys outer_domain condition ags) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -2898,7 +2918,7 @@ without separately proving two-valued semantics. */
 			'()
 			(qb_stages inner)
 			(qb_facts inner)))
-		(define stage_id (concat "derived-once:" (fnv_hash (string (list original_relation alias ags)))))
+		(define stage_id (concat "derived-once:" (stable_structural_hash (list original_relation alias ags) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -3080,7 +3100,7 @@ without separately proving two-valued semantics. */
 
 (define derived_stage_rebind_id_map (lambda (alias stages)
 	(map (coalesceNil stages '()) (lambda (stage)
-		(list (gs_id stage) (concat (gs_id stage) ":derived:" (fnv_hash (string alias))))))))
+		(list (gs_id stage) (concat (gs_id stage) ":derived:" (stable_structural_hash alias false)))))))
 
 (define derived_stage_rebind_alias_map (lambda (id_map stages)
 	(begin
@@ -3191,7 +3211,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 				(qb_stages inner)
 				(qb_facts inner))))
 		(define stage_condition (if (query_block? stage_input) true condition))
-		(define stage_id (concat "scalar-single:" (fnv_hash (string (list subquery keys outer_domain condition ags)))))
+		(define stage_id (concat "scalar-single:" (stable_structural_hash (list subquery keys outer_domain condition ags) false)))
 		(define stage (make_group_stage
 			stage_id
 			stage_input
@@ -3627,7 +3647,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(define outer_domain (if (empty_list? partition_exprs)
 			'()
 			partition_exprs))
-		(define stage_id (concat "window-agg:" (fnv_hash (string (list fn canonical_args keys)))))
+		(define stage_id (concat "window-agg:" (stable_structural_hash (list fn canonical_args keys) false)))
 		(define stage (make_group_stage
 			stage_id
 			src
@@ -4119,10 +4139,10 @@ carrier selection remains a later, per-stage cost decision. */
 		(define parent (uctx_get ctx (quote btw2025-current-handle) nil))
 		(define parent_ancestors (uctx_get ctx (quote btw2025-ancestor-handles) '()))
 		(define current_ancestors (if (nil? parent) '() (cons parent parent_ancestors)))
-		(define current_handle (concat "djoin:" (fnv_hash (string (list
+		(define current_handle (concat "djoin:" (stable_structural_hash (list
 			kind
 			(dependent_subquery_scope_backbone kind subquery)
-			outer_sources)))))
+			outer_sources) false)))
 		(define current_info (btw2025_pending_unnesting_info subquery outer_sources current_handle parent current_ancestors))
 		(define resolve_ctx (make_uctx ctx (list
 			(list (quote defer-subquery-rewrites) true)
@@ -4173,11 +4193,11 @@ carrier selection remains a later, per-stage cost decision. */
 (define btw2025_dependent_marker_key (lambda (expr)
 	(if (dependent_subquery_marker? expr)
 		(if (equal? (dep_subquery_kind expr) (quote scalar-output))
-			(concat "dependent-bundle:" (fnv_hash (string (list
+			(concat "dependent-bundle:" (stable_structural_hash (list
 				(dep_subquery_kind expr)
 				(dep_subquery_query expr)
-				(dep_subquery_outer_sources expr)))))
-			(concat "dependent:" (fnv_hash (string expr))))
+				(dep_subquery_outer_sources expr)) false))
+			(concat "dependent:" (stable_structural_hash expr false)))
 		nil)))
 
 (define btw2025_cached_dependent_rewrite (lambda (marker rewritten)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -825,19 +825,6 @@ plan = (tree aliases cardinality cost size atomic driver-cardinality left right 
 		(and (equal? (join_order_plan_cost candidate) (join_order_plan_cost current))
 			(< (join_order_driver_cardinality candidate) (join_order_driver_cardinality current))))))
 
-(define join_order_candidate_better_expr (lambda (current candidate)
-	(list (quote or)
-		(list (quote <)
-			(join_order_plan_cost_expr candidate)
-			(join_order_plan_cost_expr current))
-		(list (quote and)
-			(list (quote equal?)
-				(join_order_plan_cost_expr candidate)
-				(join_order_plan_cost_expr current))
-			(list (quote <)
-				(join_order_plan_driver_expr candidate)
-				(join_order_plan_driver_expr current))))))
-
 (define join_order_plan_driver_alias (lambda (plan)
 	(if (nil? plan) nil (join_optimizer_tree_first_alias (join_order_plan_tree plan)))))
 
@@ -886,9 +873,7 @@ plan = (tree aliases cardinality cost size atomic driver-cardinality left right 
 					candidate
 					(if (and current_valid (not candidate_valid))
 						current
-						(if (planner_guarded_choice
-							(join_order_candidate_better? current candidate)
-							(join_order_candidate_better_expr current candidate))
+						(if (join_order_candidate_better? current candidate)
 							candidate current))))))))
 
 (define join_order_best_orientation (lambda (universe predicates left right required_drivers)
@@ -1755,8 +1740,9 @@ running DP over a wide projection-only graph. */
 			(count aliases) predicate_hypergraph (cadr connected_count)))
 		(define exact (equal? strategy (quote dphyp)))
 		/* Cached plans depend on the sampled cardinalities even when DPHyp keeps a
-		fixed physical driver. Record the inputs as guards as well as the pairwise
-		choice inequalities so a statistics change can trigger re-costing. */
+		fixed physical driver. Guard every cost input once. Pairwise DP inequalities
+		are deterministic consequences of these inputs and retaining all of them
+		would duplicate complete intermediate plan trees. */
 		(join_order_record_exact_cost_inputs nodes predicates)
 		(define result (if (not (nil? functional_relation_plan))
 			(list functional_relation_plan (- (count aliases) 1))
@@ -5266,7 +5252,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				(gs_limit stage)
 				(gs_offset stage)
 				(stage_semantic_facts alias_map signatures (gs_facts stage))))
-			(concat "stage-backbone:" (fnv_hash (serialize payload)))))))
+			(concat "stage-backbone:" (stable_structural_hash payload true))))))
 
 (define stage_semantic_signature (lambda (signatures stage)
 	(if (not (group_stage? stage))
@@ -5285,7 +5271,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				(gs_limit stage)
 				(gs_offset stage)
 				(stage_semantic_facts alias_map signatures (gs_facts stage))))
-			(concat "stage-semantic:" (fnv_hash (serialize payload)))))))
+			(concat "stage-semantic:" (stable_structural_hash payload true))))))
 
 (define stage_semantic_signature_index (lambda (stages)
 	(reduce (coalesceNil stages '()) (lambda (index stage)
@@ -5344,10 +5330,10 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 				(define stage_key (stage_output_left_join_stage_key signature_index stage))
 				(if (nil? stage_key)
 					nil
-					(concat "stage-output-left-join:" (fnv_hash (serialize (list
+					(concat "stage-output-left-join:" (stable_structural_hash (list
 						stage_key
 						(source_schema src)
-						(normalize_stage_output_left_join_expr (source_alias src) (source_join_expr src))))))))))))
+						(normalize_stage_output_left_join_expr (source_alias src) (source_join_expr src))) true))))))))
 
 (define stage_output_left_join_stage_with_aggregates (lambda (stage ags)
 	(make_group_stage
@@ -5954,8 +5940,8 @@ accept exactly the same aggregate descriptors. */
 		(define movable (combine_where_terms movable_terms true))
 		(define filtered_stage_aliases
 			(map (aggregate_pushdown_filtered_stage_sources block movable_terms) source_alias))
-		(define partition_id (concat "aggregate-partition:" (fnv_hash (serialize (list
-			(source_schema driver) (source_relation driver) keys residual)))))
+		(define partition_id (concat "aggregate-partition:" (stable_structural_hash (list
+			(source_schema driver) (source_relation driver) keys residual) true)))
 		(define partition_alias (concat "__aggregate_partition_" (fnv_hash partition_id)))
 		(define partition_stage (make_group_stage
 			partition_id

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1468,7 +1468,7 @@ choice table instead of adding another promotion path. */
 (define query_invariant_scalar_first_probe_key (lambda (stage requested_col)
 	(concat
 		(if (presence_probe_stage? stage) "__query_presence_probe_" "__query_scalar_probe_")
-		(fnv_hash (serialize (list (gs_id stage) requested_col))))))
+		(stable_structural_hash (list (gs_id stage) requested_col) true))))
 
 (define lower_query_invariant_scalar_first_probe_expr (lambda (stage requested_col expr)
 	(list
@@ -3499,7 +3499,7 @@ working on the original values. */
 	(concat "k" i)))
 
 (define aggregate_col_name (lambda (ag)
-	(concat "agg_" (fnv_hash (serialize ag)))))
+	(concat "agg_" (stable_structural_hash ag true))))
 
 (define canonical_aggregate_probe_reference (lambda (stage requested_col)
 	(begin
@@ -3538,9 +3538,9 @@ the enclosing carrier identity supplies the remaining query context. */
 			(define alias_map (merge (list
 				(stage_semantic_alias_entries local_aliases "__aggregate_local_")
 				(stage_semantic_alias_entries outer_aliases "__aggregate_outer_"))))
-			(concat "agg_" (fnv_hash (serialize (list
+			(concat "agg_" (stable_structural_hash (list
 				"canonical-aggregate-v5"
-				(stage_semantic_rewrite_expr alias_map '() ag)))))))))
+				(stage_semantic_rewrite_expr alias_map '() ag)) true))))))
 
 (define dedupe_aggregates_by_col (lambda (ags)
 	(begin
@@ -3560,8 +3560,8 @@ the enclosing carrier identity supplies the remaining query context. */
 	/* The readable label is not an identity. The hash covers the canonical input
 	graph, source-role-aware keys, and complete filter, so equivalent aliases
 	converge while self-join roles and different predicates remain separated. */
-	(concat ".grp:" label ":" (fnv_hash (serialize (list
-		"canonical-group-keytable-v5" schema input_identity keys condition))))))
+	(concat ".grp:" label ":" (stable_structural_hash (list
+		"canonical-group-keytable-v5" schema input_identity keys condition) true))))
 
 /* Persistent helper objects must be named by the physical data they represent,
 not by disposable SQL aliases. Source position remains part of the identity so
@@ -3698,10 +3698,10 @@ self-joins of the same base table still describe two distinct row roles. */
 (define canonical_orc_column_name (lambda (kind src payload)
 	/* ORCs live on one base table. Their identity is the table plus the complete
 	physical window recipe; SELECT aliases and read-time LIMIT/OFFSET are absent. */
-	(concat "__orc_" kind "_" (fnv_hash (serialize (list
+	(concat "__orc_" kind "_" (stable_structural_hash (list
 		"canonical-orc-v2"
 		(list (source_schema src) (source_relation src))
-		payload))))))
+		payload) true))))
 
 (define make_group_keytable_cache (lambda (schema relation)
 	(list (quote group-keytable) schema relation)))
@@ -3737,9 +3737,9 @@ self-joins of the same base table still describe two distinct row roles. */
 	(begin
 		(define input (gs_input stage))
 		(if (union_block? input)
-			(concat "union:" (fnv_hash (string input)))
+			(concat "union:" (stable_structural_hash input false))
 			(if (query_block? input)
-				(concat "query:" (fnv_hash (string input)))
+				(concat "query:" (stable_structural_hash input false))
 				(source_relation input))))))
 
 (define group_stage_default_cache (lambda (stage signatures)
@@ -3860,7 +3860,7 @@ self-joins of the same base table still describe two distinct row roles. */
 		(define keys (merge (list explicit_keys (filter session_keys (lambda (expr)
 			(not (contains? explicit_keys expr)))))))
 		(make_group_stage
-			(concat "group:" (source_relation src) ":" (fnv_hash (string (list keys ags))))
+			(concat "group:" (source_relation src) ":" (stable_structural_hash (list keys ags) false))
 			src
 			session_keys
 			keys
@@ -3898,8 +3898,8 @@ self-joins of the same base table still describe two distinct row roles. */
 			(qb_stages block)
 			(qb_facts block)))
 		(make_group_stage
-			(concat "group:query:" (fnv_hash (serialize (list
-				(qb_sources block) (qb_where block) keys ags))))
+			(concat "group:query:" (stable_structural_hash (list
+				(qb_sources block) (qb_where block) keys ags) true))
 			input
 			session_keys
 			keys
@@ -4161,7 +4161,7 @@ ever-larger subtrees. */
 		_ false)))
 
 (define group_computed_order_col_name (lambda (expr)
-	(concat "ord_" (fnv_hash (serialize expr)))))
+	(concat "ord_" (stable_structural_hash expr true))))
 
 (define group_order_physical_expr (lambda (grouptbl expr)
 	(if (direct_group_order_expr? expr)
@@ -4381,7 +4381,7 @@ ever-larger subtrees. */
 						(physical_query_session_symbol)
 						"get_or_compute_scoped"
 						(physical_query_scope_symbol)
-						(concat "__group_count_recset_" (fnv_hash (serialize membership_expr)))
+						(concat "__group_count_recset_" (stable_structural_hash membership_expr true))
 						(list (quote lambda) '() membership_expr)))
 				(list (quote scan)
 					'(session "__memcp_tx")

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -987,9 +987,9 @@ key-fill recipe per carrier. */
 			condition semantics. It is therefore the physical identity used to
 			collect all aggregate columns and emit exactly one initializer. */
 			(concat "stage-prepare:"
-				(fnv_hash (serialize (list
+				(stable_structural_hash (list
 					(group_cache_schema cache)
-					(group_cache_relation cache)))))))))
+					(group_cache_relation cache)) true))))))
 
 (define group_prepare_stage_with_aggregates (lambda (stage aggregates)
 	(make_group_stage
@@ -1052,7 +1052,7 @@ key-fill recipe per carrier. */
 				(group_cache_relation cache)
 				(map (gs_aggregates stage) (lambda (ag)
 					(aggregate_col_name_using (gs_input stage) ag)))
-				(map (gs_order stage) (lambda (item) (fnv_hash (serialize item))))
+				(map (gs_order stage) (lambda (item) (stable_structural_hash item true)))
 				(if (source_is_base_table? (gs_input stage))
 					nil
 					(list
@@ -2400,12 +2400,12 @@ accepted by non-membership branches. The storage analyzer may use a RecSet as a
 scan boundary only when the complete predicate implies it. */
 
 (define membership_recset_var (lambda (src membership)
-	(symbol (concat "__membership_recset_" (fnv_hash (serialize (list
+	(symbol (concat "__membership_recset_" (stable_structural_hash (list
 		(source_schema src)
 		(source_relation src)
 		(gs_id (nth membership 0))
 		(nth membership 1)
-		(nth membership 2))))))))
+		(nth membership 2)) true)))))
 
 (define replace_driver_membership_markers (lambda (src expr memberships)
 	(begin
@@ -4290,7 +4290,7 @@ ownership remain available until the physical scans are emitted. */
 		(define pos (prejoin_source_position sources alias))
 		(if (nil? pos)
 			(neumann_fail "build_queryplan" (concat "prejoin source alias not found: " alias))
-			(concat "s" pos "_" (fnv_hash (string col)))))))
+			(concat "s" pos "_" (stable_structural_hash col false))))))
 
 (define prejoin_source_table_key (lambda (src)
 	(list (source_schema src) (source_relation src))))
@@ -4398,7 +4398,7 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 			"physical-prejoin-v2"
 			(map sources prejoin_source_table_key)
 			(prejoin_rewrite_expr sources default_alias canonical_alias (prejoin_join_condition block))))
-		(concat ".prejoin:" (fnv_hash (serialize signature))))))
+		(concat ".prejoin:" (stable_structural_hash signature true)))))
 
 (define prejoin_primary_key_exprs (lambda (sources)
 	(merge (map sources (lambda (src)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -151,8 +151,10 @@ functional planner return value. */
 					(planning_session key (source_session key))))) nil)
 		(planning_session "__memcp_queryplan_compile_bindings" compile_bindings)
 		(planning_session "__memcp_queryplan_guard_conditions" (newsession))
+		(planning_session "__memcp_queryplan_guard_condition_catalog" (make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_guard_bindings" (newsession))
-		(planning_session "__memcp_queryplan_guarded_session_keys" (newsession))
+		(planning_session "__memcp_queryplan_guard_binding_catalog" (make_structural_catalog (quote ast)))
+		(planning_session "__memcp_queryplan_guarded_session_keys" (make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_observed_session_keys" (newsession))
 		(planning_session "__memcp_queryplan_statistics" (newsession))
 		planning_session)))
@@ -160,10 +162,13 @@ functional planner return value. */
 (define sql_queryplan_uncovered_binding_conditions (lambda (planning_session)
 	(begin
 		(define covered (planning_session "__memcp_queryplan_guarded_session_keys"))
+		(define structural (planning_session "__memcp_queryplan_guard_condition_catalog"))
 		(define observed (planning_session "__memcp_queryplan_observed_session_keys"))
 		(define compile_bindings (planning_session "__memcp_queryplan_compile_bindings"))
 		(map (filter (observed) (lambda (key)
-			(not (covered (string (list (quote session) key))))))
+			(not (covered (if (nil? structural)
+				(string (list (quote session) key))
+				(list (quote session) key))))))
 			(lambda (key)
 				(begin
 					(define value (compile_bindings key))
@@ -187,15 +192,23 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 (define sql_queryplan_guard_from_session (lambda (planning_session)
 	(begin
 		(define condition_accumulator (planning_session "__memcp_queryplan_guard_conditions"))
+		(define condition_catalog (planning_session "__memcp_queryplan_guard_condition_catalog"))
 		(define conditions (merge (list
-			(map (condition_accumulator) (lambda (key) (condition_accumulator key)))
+			(if (nil? condition_catalog)
+				(map (condition_accumulator) (lambda (key) (condition_accumulator key)))
+				(map (produceN (coalesceNil (condition_accumulator "count") 0))
+					(lambda (idx) (condition_accumulator (concat "condition:" idx)))))
 			(sql_queryplan_uncovered_binding_conditions planning_session))))
 		(define raw_guard (match conditions
 			(cons condition '()) condition
 			(cons _head _tail) (cons (quote and) conditions)
 			_ true))
 		(define binding_session (planning_session "__memcp_queryplan_guard_bindings"))
-		(define bindings (map (binding_session) (lambda (key) (binding_session key))))
+		(define binding_catalog (planning_session "__memcp_queryplan_guard_binding_catalog"))
+		(define bindings (if (nil? binding_catalog)
+			(map (binding_session) (lambda (key) (binding_session key)))
+			(map (produceN (coalesceNil (binding_session "count") 0))
+				(lambda (idx) (binding_session (concat "binding:" idx))))))
 		(sql_queryplan_runtime_guard_expr (if (empty_list? bindings)
 			raw_guard
 			(cons

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -2803,6 +2803,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define structural_collision_frozen (structural_collision))
 	(assert (structural_collision_frozen "collision6") 6 "structural catalog resolves deliberate collisions with equality")
 	(assert (nil? (structural_collision_frozen "collision99")) true "structural collision bucket cannot create false identity")
+	(define structural_ast_typed (make_structural_catalog (quote ast)))
+	(structural_ast_typed (list (quote literal) "2024-06-15") "string")
+	(structural_ast_typed (list (quote literal) (parse_date "2024-06-15")) "date")
+	(structural_ast_typed (list (quote literal) (symbol "2024-06-15")) "symbol")
+	(define structural_ast_typed_frozen (structural_ast_typed))
+	(assert (structural_ast_typed_frozen (list (quote literal) "2024-06-15")) "string"
+		"AST catalog keeps string literals type-stable")
+	(assert (structural_ast_typed_frozen (list (quote literal) (parse_date "2024-06-15"))) "date"
+		"AST catalog does not parse strings while hashing")
+	(assert (structural_ast_typed_frozen (list (quote literal) (symbol "2024-06-15"))) "symbol"
+		"AST catalog distinguishes symbols from strings")
 	(define structural_literal_ast (list (quote if) true))
 	(define structural_probe_ast (list (quote if) (list (quote probe))))
 	(define structural_ast_catalog (make_structural_catalog))

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -262,6 +262,75 @@ func hashStructuralReadonly(key Scmer) uint64 {
 	}
 }
 
+// hashASTKey keeps compiler node types distinct. Unlike Scheme equality it
+// never parses strings as dates or numbers while indexing an immutable AST.
+func hashASTKey(key Scmer, memo map[Scmer]uint64) uint64 {
+	switch key.GetTag() {
+	case tagSourceInfo:
+		return hashASTKey(key.SourceInfo().value, memo)
+	case tagAny:
+		if source, ok := key.Any().(SourceInfo); ok {
+			return hashASTKey(source.value, memo)
+		}
+		return HashKey(key)
+	case tagSlice:
+		if hash, ok := memo[key]; ok {
+			return hash
+		}
+		items := key.Slice()
+		hash := combineStructuralHash(0xbb67ae8584caa73b, uint64(len(items)))
+		for _, item := range items {
+			hash = combineStructuralHash(hash, hashASTKey(item, memo))
+		}
+		memo[key] = hash
+		return hash
+	case tagFastDict:
+		panic("AST hashing rejects mutable FastDict expressions")
+	default:
+		return HashKey(key)
+	}
+}
+
+func hashASTReadonly(key Scmer) uint64 {
+	return hashASTKey(key, make(map[Scmer]uint64))
+}
+
+func astStructuralEqual(a, b Scmer) bool {
+	if a.IsSourceInfo() {
+		return astStructuralEqual(a.SourceInfo().value, b)
+	}
+	if b.IsSourceInfo() {
+		return astStructuralEqual(a, b.SourceInfo().value)
+	}
+	if a.GetTag() == tagAny {
+		if source, ok := a.Any().(SourceInfo); ok {
+			return astStructuralEqual(source.value, b)
+		}
+	}
+	if b.GetTag() == tagAny {
+		if source, ok := b.Any().(SourceInfo); ok {
+			return astStructuralEqual(a, source.value)
+		}
+	}
+	if a.GetTag() != b.GetTag() {
+		return false
+	}
+	if a.GetTag() != tagSlice {
+		return Equal(a, b)
+	}
+	left := a.Slice()
+	right := b.Slice()
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !astStructuralEqual(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func structuralScalarTag(tag uint8) bool {
 	switch tag {
 	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagSymbol, tagCString, tagBString:
@@ -324,19 +393,40 @@ type structuralCatalog struct {
 	entries        []structuralIndexEntry
 	buckets        map[uint64][]int
 	forceCollision bool
+	strictAST      bool
 }
 
 func (catalog *structuralCatalog) hash(key Scmer, memo map[Scmer]uint64) uint64 {
 	if catalog.forceCollision {
 		return 0
 	}
+	if catalog.strictAST {
+		return hashASTKey(key, memo)
+	}
 	return hashStructuralKey(key, memo)
+}
+
+func (catalog *structuralCatalog) hashReadonly(key Scmer) uint64 {
+	if catalog.forceCollision {
+		return 0
+	}
+	if catalog.strictAST {
+		return hashASTReadonly(key)
+	}
+	return hashStructuralReadonly(key)
+}
+
+func (catalog *structuralCatalog) equal(left, right Scmer) bool {
+	if catalog.strictAST {
+		return astStructuralEqual(left, right)
+	}
+	return structuralEqual(left, right)
 }
 
 func (catalog *structuralCatalog) set(key, value Scmer) {
 	if catalog.buckets == nil {
 		for i := range catalog.entries {
-			if structuralEqual(catalog.entries[i].key, key) {
+			if catalog.equal(catalog.entries[i].key, key) {
 				catalog.entries[i].value = value
 				return
 			}
@@ -353,12 +443,9 @@ func (catalog *structuralCatalog) set(key, value Scmer) {
 		}
 		return
 	}
-	hash := uint64(0)
-	if !catalog.forceCollision {
-		hash = hashStructuralReadonly(key)
-	}
+	hash := catalog.hashReadonly(key)
 	for _, i := range catalog.buckets[hash] {
-		if structuralEqual(catalog.entries[i].key, key) {
+		if catalog.equal(catalog.entries[i].key, key) {
 			catalog.entries[i].value = value
 			return
 		}
@@ -379,18 +466,15 @@ func (catalog *structuralCatalog) get(key Scmer) Scmer {
 	defer catalog.mu.Unlock()
 	if catalog.buckets == nil {
 		for _, entry := range catalog.entries {
-			if structuralEqual(entry.key, key) {
+			if catalog.equal(entry.key, key) {
 				return entry.value
 			}
 		}
 		return NewNil()
 	}
-	hash := uint64(0)
-	if !catalog.forceCollision {
-		hash = hashStructuralReadonly(key)
-	}
+	hash := catalog.hashReadonly(key)
 	for _, index := range catalog.buckets[hash] {
-		if structuralEqual(catalog.entries[index].key, key) {
+		if catalog.equal(catalog.entries[index].key, key) {
 			return catalog.entries[index].value
 		}
 	}
@@ -403,7 +487,7 @@ func (catalog *structuralCatalog) snapshot() []structuralIndexEntry {
 	return append([]structuralIndexEntry(nil), catalog.entries...)
 }
 
-func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool) Scmer {
+func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision, strictAST bool) Scmer {
 	memo := make(map[Scmer]uint64)
 	var buckets map[uint64][]structuralIndexEntry
 	if len(entries) >= structuralCatalogFastThreshold {
@@ -411,7 +495,11 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 		for _, entry := range entries {
 			hash := uint64(0)
 			if !forceCollision {
-				hash = hashStructuralKey(entry.key, memo)
+				if strictAST {
+					hash = hashASTKey(entry.key, memo)
+				} else {
+					hash = hashStructuralKey(entry.key, memo)
+				}
 			}
 			buckets[hash] = append(buckets[hash], entry)
 		}
@@ -426,7 +514,7 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 		}
 		if buckets == nil {
 			for _, entry := range entries {
-				if structuralEqual(entry.key, key) {
+				if (strictAST && astStructuralEqual(entry.key, key)) || (!strictAST && structuralEqual(entry.key, key)) {
 					return entry.value
 				}
 			}
@@ -436,12 +524,14 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 		if !forceCollision {
 			if memoHash, ok := memo[key]; ok {
 				hash = memoHash
+			} else if strictAST {
+				hash = hashASTReadonly(key)
 			} else {
 				hash = hashStructuralReadonly(key)
 			}
 		}
 		for _, entry := range buckets[hash] {
-			if structuralEqual(entry.key, key) {
+			if (strictAST && astStructuralEqual(entry.key, key)) || (!strictAST && structuralEqual(entry.key, key)) {
 				return entry.value
 			}
 		}
@@ -452,17 +542,20 @@ func frozenStructuralLookup(entries []structuralIndexEntry, forceCollision bool)
 // NewStructuralCatalog returns an atomic compile-local collector. Calling it
 // with (key value) inserts or replaces an equal key; (catalog key) performs an
 // atomic compile-local lookup; calling it with no arguments publishes and
-// returns a frozen read-only lookup closure. The optional constructor flag
-// forces one bucket for collision tests.
+// returns a frozen read-only lookup closure. The optional constructor argument
+// is true for collision tests or the symbol ast for type-stable compiler ASTs.
 func NewStructuralCatalog(a ...Scmer) Scmer {
 	if len(a) > 1 {
-		panic("make_structural_catalog expects an optional collision-test flag")
+		panic("make_structural_catalog expects an optional mode")
 	}
-	catalog := &structuralCatalog{forceCollision: len(a) == 1 && a[0].Bool()}
+	catalog := &structuralCatalog{
+		forceCollision: len(a) == 1 && a[0].GetTag() == tagBool && a[0].Bool(),
+		strictAST:      len(a) == 1 && a[0].String() == "ast",
+	}
 	return NewFunc(func(args ...Scmer) Scmer {
 		switch len(args) {
 		case 0:
-			return frozenStructuralLookup(catalog.snapshot(), catalog.forceCollision)
+			return frozenStructuralLookup(catalog.snapshot(), catalog.forceCollision, catalog.strictAST)
 		case 1:
 			if args[0].GetTag() == tagFastDict {
 				panic("structural catalog rejects mutable FastDict keys")

--- a/scm/list.go
+++ b/scm/list.go
@@ -6756,7 +6756,7 @@ func init_list() {
 		Fn:   NewStructuralCatalog,
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
-				{Kind: "bool", ParamName: "force_collision", ParamDesc: "test-only: place every key in one bucket", Optional: true},
+				{Kind: "bool|symbol", ParamName: "mode", ParamDesc: "true forces collisions for tests; ast selects type-stable compiler equality", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "func"},
 		},

--- a/tests/integration/query-shapes/traced-late-projection-read-models.yaml
+++ b/tests/integration/query-shapes/traced-late-projection-read-models.yaml
@@ -1029,6 +1029,70 @@ test_cases:
         - id: 2
           can_view: false
 
+  - name: "Join DP comparisons do not duplicate guarded cost inputs"
+    scm: |
+      (begin
+        (define compile_session (newsession))
+        (define conditions (newsession))
+        (compile_session "__memcp_queryplan_guard_conditions" conditions)
+        (compile_session "__memcp_queryplan_guard_condition_catalog"
+          (make_structural_catalog (quote ast)))
+        (compile_session "__memcp_queryplan_guarded_session_keys"
+          (make_structural_catalog (quote ast)))
+        (define chosen (with_session compile_session (lambda ()
+          (join_order_better_plan
+            (join_order_leaf_plan (list "larger" 100))
+            (join_order_leaf_plan (list "smaller" 1))
+            '()))))
+        (if (and (equal? (join_order_plan_aliases chosen) '("smaller"))
+            (equal? (count (conditions)) 0))
+          "ok"
+          (error (concat "join DP retained " (count (conditions))
+            " redundant intermediate guards"))))
+    expect:
+      data: ["ok"]
+
+  - name: "Parameterized derived scalar and outer-join compilation stays bounded"
+    max_time: 5.0
+    scm: |
+      (begin
+        (define inner (reduce (produceN 48) (lambda (sql i)
+          (begin
+            (define suffix (string i))
+            (concat sql
+              ", COALESCE((SELECT parent_" suffix ".owner_id = " (+ i 1)
+              " OR EXISTS (SELECT TRUE FROM trace_wide_assignment member_" suffix
+              " WHERE member_" suffix ".team_id = parent_" suffix ".team_id"
+              " AND member_" suffix ".member_id = " (+ i 1) " LIMIT 1)"
+              " FROM trace_wide_parent parent_" suffix
+              " WHERE parent_" suffix ".id = item.parent_id LIMIT 1), FALSE) AS access_" suffix)))
+          "SELECT item.id"))
+        (define inner (concat inner " FROM trace_wide_prop item WHERE item.id < 0"))
+        (define query (reduce (produceN 18) (lambda (sql i)
+          (begin
+            (define suffix (string i))
+            (concat sql " LEFT JOIN trace_actor sorter_" suffix
+              " ON sorter_" suffix ".id = projected.id")))
+          (concat "SELECT projected.*, sorter_0.enabled AS sort_0 FROM (" inner ") projected")))
+        (define query (concat query " ORDER BY projected.id LIMIT 72"))
+        (define session (newsession))
+        (session "username" "root")
+        (session "schema" "memcp-tests")
+        (define exact_started (nanotime))
+        (cached_parse (newcachemap) parse_sql "memcp-tests" query
+          (lambda (_schema _table _write) true) "root" session false)
+        (define exact_elapsed (- (nanotime) exact_started))
+        (define started (nanotime))
+        (cached_parse (newcachemap) parse_sql "memcp-tests" query
+          (lambda (_schema _table _write) true) "root" session true)
+        (define elapsed (- (nanotime) started))
+        (if (and (< elapsed 5000000000)
+            (< elapsed (+ 1000000000 (* exact_elapsed 3))))
+          "ok"
+          (error (concat "derived compile exact=" exact_elapsed "ns parameterized=" elapsed "ns"))))
+    expect:
+      data: ["ok"]
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_case_item"
   - sql: "DROP TABLE IF EXISTS trace_lazy_error"


### PR DESCRIPTION
## Summary
- deduplicate compile guards with type-stable structural AST catalogs instead of serializing growing expressions
- guard join-order cost inputs once instead of retaining every deterministic DP intermediate inequality
- stream structural hashes for planner identities without allocating serialized AST copies
- add regression coverage for redundant DP guards and a wide derived scalar/EXISTS plus LEFT JOIN compile shape

## Evidence
A preserved production-shaped query with an empty driving relation previously remained in compilation after 60 seconds and grew the server to roughly 10 GiB RSS. With this change the same query completes in 3.56 seconds at roughly 448 MiB RSS and returns the same empty result. CPU profiles showed the eliminated work in AST string construction, date-like scalar coercion during generic structural hashing, and duplicated DP guard traversal.

The focused regression fails on the base revision because one intermediate DP comparison is retained as an additional guard; it passes with the change while the existing cardinality-crossover cache test continues to recompile correctly.

## Validation
- full `make test` hook-equivalent suite: passed
- Scheme unit tests: 1266/1266
- focused query-shape suite: 34/34
- prepared statement / guarded-cache suite: 49/49
- preserved wide-query A/B: >60 s timeout / ~10 GiB before, 3.56 s / ~448 MiB after