### PR TITLE
Preserve relational metadata across mysqldump round trips

### DIFF
--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -49,10 +49,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			(reduce (map (uk "Cols") (lambda (c) (concat "`" c "`"))) (lambda (a b) (concat a "," b)))
 			")")
 	)))
-	(define all_defs (merge col_defs uk_defs))
+	(define fk_defs (map (filter (meta "ForeignKeys") (lambda (fk)
+		(equal? (fk "Role") "referencing"))) (lambda (fk)
+			(concat "  CONSTRAINT " (quote_mysql_identifier (fk "Id")) " FOREIGN KEY ("
+				(reduce (map (fk "LocalColumns") quote_mysql_identifier) (lambda (a b) (concat a "," b)))
+				") REFERENCES " (quote_mysql_identifier (fk "OtherTable")) " ("
+				(reduce (map (fk "OtherColumns") quote_mysql_identifier) (lambda (a b) (concat a "," b)))
+				") ON DELETE " (toUpper (fk "DeleteMode"))
+				" ON UPDATE " (toUpper (fk "UpdateMode")))
+	)))
+	(define all_defs (merge col_defs uk_defs fk_defs))
 	(define body (reduce all_defs (lambda (acc item) (concat acc ",\n" item))))
 	(concat "CREATE TABLE `" tbl "` (\n" body
-		"\n) ENGINE=" (meta "Engine")
+		"\n) ENGINE=" (if (equal? (meta "Engine") "memory") "MEMORY" "InnoDB")
 		(if (not (equal? (meta "Collation") "")) (concat " COLLATE=" (meta "Collation")) "")
 		(if (not (equal? (meta "Comment") "")) (concat " COMMENT=" (quote_mysql_string (meta "Comment"))) "")
 	)
@@ -79,6 +88,13 @@ original body, while SHOW TRIGGERS supplies the table, timing, and event. */
 			"Created" NULL))
 )))
 
+(define info_schema_column_default (lambda (col)
+	(if (nil? (col "Default"))
+		(if (col "Null") "NULL" NULL)
+		(if (string? (col "Default"))
+			(quote_mysql_string (col "Default"))
+			(concat (col "Default"))))))
+
 (define info_schema_columns_for_table (lambda (schema table_name) (begin
 	(define columns (show schema table_name))
 	(map (produceN (count columns)) (lambda (ordinal) (begin
@@ -89,7 +105,7 @@ original body, while SHOW TRIGGERS supplies the table, timing, and event. */
 			"table_name" table_name
 			"column_name" (col "Field")
 			"ordinal_position" (+ ordinal 1)
-			"column_default" (col "Default")
+			"column_default" (info_schema_column_default col)
 			"is_nullable" (if (col "Null") "YES" "NO")
 			"data_type" (col "RawType")
 			"column_type" (col "Type")
@@ -124,6 +140,78 @@ original body, while SHOW TRIGGERS supplies the table, timing, and event. */
 				"character_set_client" (tr "character_set_client")
 				"collation_connection" (tr "collation_connection")
 				"database_collation" (tr "Database Collation")))))))))
+
+(define info_schema_fk_column_rows (lambda (schema tbl fk local_columns other_columns ordinal)
+	(if (empty_list? local_columns)
+		(if (empty_list? other_columns) '()
+			(error (concat "foreign key " (fk "Id") " has mismatched column lists")))
+		(if (empty_list? other_columns)
+			(error (concat "foreign key " (fk "Id") " has mismatched column lists"))
+			(cons (list "constraint_catalog" "def" "constraint_schema" schema
+				"constraint_name" (fk "Id") "table_catalog" "def"
+				"table_schema" schema "table_name" tbl
+				"column_name" (car local_columns)
+				"ordinal_position" ordinal
+				"position_in_unique_constraint" ordinal
+				"referenced_table_schema" schema
+				"referenced_table_name" (fk "OtherTable")
+				"referenced_column_name" (car other_columns))
+				(info_schema_fk_column_rows schema tbl fk
+					(cdr local_columns) (cdr other_columns) (+ ordinal 1)))))))
+
+(define info_schema_unique_column_rows (lambda (schema tbl key columns ordinal)
+	(if (empty_list? columns) '()
+		(cons (list "constraint_catalog" "def" "constraint_schema" schema
+			"constraint_name" (key "Id") "table_catalog" "def"
+			"table_schema" schema "table_name" tbl
+			"column_name" (car columns)
+			"ordinal_position" ordinal
+			"position_in_unique_constraint" NULL
+			"referenced_table_schema" NULL
+			"referenced_table_name" NULL
+			"referenced_column_name" NULL)
+			(info_schema_unique_column_rows schema tbl key (cdr columns) (+ ordinal 1))))))
+
+(define info_schema_fk_unique_name (lambda (schema fk) (begin
+	(define referenced_info (show schema (fk "OtherTable") true))
+	(define referenced_meta (referenced_info "meta"))
+	(define referenced_key (find (referenced_meta "Unique") (lambda (key)
+		(equal? (key "Cols") (fk "OtherColumns")))))
+	(if (nil? referenced_key) NULL (referenced_key "Id"))
+)))
+
+(define info_schema_key_column_usage_rows (lambda ()
+	(merge (map (show) (lambda (schema)
+		(merge (map (show schema) (lambda (tbl) (begin
+			(define tblinfo (show schema tbl true))
+			(define meta (tblinfo "meta"))
+			(define unique_rows (merge (map (meta "Unique") (lambda (key)
+				(info_schema_unique_column_rows schema tbl key (key "Cols") 1)))))
+			(define foreign_rows (merge (map (filter (meta "ForeignKeys") (lambda (fk)
+				(equal? (fk "Role") "referencing"))) (lambda (fk)
+					(info_schema_fk_column_rows schema tbl fk
+						(fk "LocalColumns") (fk "OtherColumns") 1)))))
+			(merge unique_rows foreign_rows)
+)))))))))
+
+(define info_schema_referential_constraint_rows (lambda ()
+	(merge (map (show) (lambda (schema)
+		(merge (map (show schema) (lambda (tbl) (begin
+			(define tblinfo (show schema tbl true))
+			(define meta (tblinfo "meta"))
+			(map (filter (meta "ForeignKeys") (lambda (fk)
+				(equal? (fk "Role") "referencing"))) (lambda (fk)
+					(list "constraint_catalog" "def" "constraint_schema" schema
+						"constraint_name" (fk "Id")
+						"unique_constraint_catalog" "def"
+						"unique_constraint_schema" schema
+						"unique_constraint_name" (info_schema_fk_unique_name schema fk)
+						"match_option" "NONE"
+						"update_rule" (toUpper (fk "UpdateMode"))
+						"delete_rule" (toUpper (fk "DeleteMode"))
+						"table_name" tbl
+						"referenced_table_name" (fk "OtherTable"))))
+)))))))))
 
 /* build one INFORMATION_SCHEMA.TABLES row from the catalog snapshot returned
 by (show schema true).  Keeping table discovery and metadata collection in one
@@ -298,10 +386,10 @@ relations are deliberately resolved by the single public get_schema dispatcher. 
 			(info_schema_columns_for_table db table_name)))))))
 
 	'((ignorecase "information_schema") (ignorecase "key_column_usage"))
-	(list)
+	(info_schema_key_column_usage_rows)
 
 	'((ignorecase "information_schema") (ignorecase "referential_constraints"))
-	(list)
+	(info_schema_referential_constraint_rows)
 
 	'((ignorecase "information_schema") (ignorecase "statistics"))
 	(merge (map (show) (lambda (db)
@@ -342,9 +430,9 @@ relations are deliberately resolved by the single public get_schema dispatcher. 
 		'((quote merge) '((quote map) '((quote show)) '((quote lambda) '((quote schema)) '((quote merge) '((quote map) '((quote show) (quote schema)) '((quote lambda) '((quote tbl)) '((quote info_schema_columns_for_table) (quote schema) (quote tbl))))))))
 	) rest)
 	'((ignorecase "information_schema") (ignorecase "key_column_usage"))
-	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* TODO: list constraints */
+	(merge '(scanfn '(session "__memcp_tx") '('info_schema_key_column_usage_rows)) rest)
 	'((ignorecase "information_schema") (ignorecase "referential_constraints"))
-	(merge '(scanfn '(session "__memcp_tx") '(list)) rest) /* TODO: list constraints */
+	(merge '(scanfn '(session "__memcp_tx") '('info_schema_referential_constraint_rows)) rest)
 	'((ignorecase "information_schema") (ignorecase "statistics"))
 	(merge '(scanfn '(session "__memcp_tx") '('merge '('map '('show) '('lambda '('schema) '('merge '('map '('show 'schema) '('lambda '('tbl) '('show 'schema 'tbl "statistics")))))))) rest)
 	'((ignorecase "information_schema") (ignorecase "triggers"))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -160,12 +160,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 
 (define parse_sql (lambda (schema s policy) (begin
 	(define parse_started_ns (nanotime))
-	/* mysqldump wraps CREATE TRIGGER in a versioned executable comment. Other
+	/* mysqldump wraps CREATE TRIGGER in a versioned executable comment. MariaDB
+	splits CREATE, DEFINER, and TRIGGER across three comments; discard the
+	account-specific DEFINER while reconstructing executable trigger DDL. Other
 	versioned comments remain compatibility no-ops unless their SQL form is
 	explicitly supported; trigger DDL must execute for a lossless restore. */
 	(set s (if (and (>= (strlen s) 3) (equal? (substr s 0 3) "/*!"))
 		(match s
 			(regex "^/\\*![0-9]+[\\r\\n\\t ]+((?is:CREATE[\\r\\n\\t ]+TRIGGER.*))[\\r\\n\\t ]*\\*/$" _ body) body
+			(regex "^/\\*![0-9]+[\\r\\n\\t ]+CREATE[\\r\\n\\t ]*\\*/[\\r\\n\\t ]*/\\*![0-9]+[\\r\\n\\t ]+DEFINER=(?is:.*?)[\\r\\n\\t ]*\\*/[\\r\\n\\t ]*/\\*![0-9]+[\\r\\n\\t ]+((?is:TRIGGER.*))[\\r\\n\\t ]*\\*/$" _ body) (concat "CREATE " body)
 			s)
 		s))
 	/* MemCP has no MySQL tablespaces or undo logs. Match the two exact
@@ -1813,6 +1816,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 				(if policy (policy view_schema id true) true)
 				(list (quote drop_sql_view) (list (quote session) "__memcp_tx") view_schema id (if if_exists true false)))))
 		(parser '((atom "RENAME" true) (atom "TABLE" true) (define oldname sql_identifier) (atom "TO" true) (define newname sql_identifier)) '((quote renametable) schema oldname newname))
+		/* mysqldump --single-transaction establishes this before START TRANSACTION. */
+		(parser '((atom "SET" true) (atom "SESSION" true) (atom "TRANSACTION" true)
+			(atom "ISOLATION" true) (atom "LEVEL" true) (atom "REPEATABLE" true) (atom "READ" true)) (quote true))
 		(parser '((atom "SET" true) (? (atom "SESSION" true)) (? "@") (define key sql_identifier)
 			(or "=" (atom ":=" true)) (atom "DEFAULT" true))
 			(list (list (quote context) "session") key nil))
@@ -1896,6 +1902,11 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "START" true) (atom "TRANSACTION" true)) (list (quote tx_begin) (list (quote context) "session")))
 		(parser '((atom "BEGIN" true)) (list (quote tx_begin) (list (quote context) "session")))
 		(parser '((atom "COMMIT" true)) (list (quote tx_commit) (list (quote context) "session")))
+		/* mysqldump uses read-only savepoints around each table. MemCP keeps the
+		outer consistent transaction and accepts these markers as no-ops. */
+		(parser '((atom "SAVEPOINT" true) sql_identifier) (quote true))
+		(parser '((atom "ROLLBACK" true) (atom "TO" true) (? (atom "SAVEPOINT" true)) sql_identifier) (quote true))
+		(parser '((atom "RELEASE" true) (atom "SAVEPOINT" true) sql_identifier) (quote true))
 		(parser '((atom "ROLLBACK" true)) (list (quote tx_rollback) (list (quote context) "session")))
 		"" /* comment only command */
 	)))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3878,6 +3878,17 @@ func showStringSlice(values []string) scm.Scmer {
 	return scm.NewSlice(items)
 }
 
+func showForeignKeyMode(mode foreignKeyMode) string {
+	switch mode {
+	case CASCADE:
+		return "cascade"
+	case SETNULL:
+		return "set null"
+	default:
+		return "restrict"
+	}
+}
+
 func plannerDistinctForColumns(t *table, columns []string) (float64, float64, string) {
 	rows := float64(t.CountEstimate())
 	if len(columns) == 0 {
@@ -3957,6 +3968,8 @@ func showBuildMeta(db *database, t *table) scm.Scmer {
 			scm.NewString("LocalColumns"), showStringSlice(localColumns),
 			scm.NewString("OtherTable"), scm.NewString(otherTable),
 			scm.NewString("OtherColumns"), showStringSlice(otherColumns),
+			scm.NewString("UpdateMode"), scm.NewString(showForeignKeyMode(fk.Updatemode)),
+			scm.NewString("DeleteMode"), scm.NewString(showForeignKeyMode(fk.Deletemode)),
 		}))
 		fanoutEstimate := scm.NewNil()
 		confidenceValue := 0.0

--- a/tests/sql/compatibility/dbcheck-ddl-compat.yaml
+++ b/tests/sql/compatibility/dbcheck-ddl-compat.yaml
@@ -23,6 +23,15 @@ test_cases:
   - name: "UNLOCK TABLES"
     sql: "UNLOCK TABLES"
 
+  - name: "mysqldump repeatable-read session isolation"
+    sql: "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ"
+  - name: "mysqldump savepoint"
+    sql: "SAVEPOINT sp"
+  - name: "mysqldump rollback to savepoint"
+    sql: "ROLLBACK TO SAVEPOINT sp"
+  - name: "mysqldump release savepoint"
+    sql: "RELEASE SAVEPOINT sp"
+
   # --- SHOW operations ---
   - name: "SHOW TABLES"
     sql: "SHOW TABLES"
@@ -186,6 +195,14 @@ test_cases:
     sql: "SHOW CREATE TRIGGER `dbc_t.dump_bi`"
     expect:
       rows: 1
+  - name: "MariaDB executable-comment CREATE TRIGGER"
+    sql: "/*!50003 CREATE*/ /*!50017 DEFINER=`root`@`localhost`*/ /*!50003 TRIGGER `dbc_t.dump_ai` AFTER INSERT ON `dbc_t` FOR EACH ROW SET @dump_seen = NEW.id */"
+  - name: "SHOW CREATE restored MariaDB trigger"
+    sql: "SHOW CREATE TRIGGER `dbc_t.dump_ai`"
+    expect:
+      rows: 1
+  - name: "DROP restored MariaDB trigger"
+    sql: "DROP TRIGGER IF EXISTS `dbc_t.dump_ai`"
   - name: "DROP restored mysqldump trigger"
     sql: "DROP TRIGGER IF EXISTS `dbc_t.dump_bi`"
   - name: "DROP TRIGGER IF EXISTS after create"

--- a/tests/sql/compatibility/information-schema.yaml
+++ b/tests/sql/compatibility/information-schema.yaml
@@ -82,6 +82,23 @@ test_cases:
     expect:
       rows: 1
 
+  - name: "COLUMNS: MySQL-compatible default expressions"
+    setup:
+      - sql: "DROP TABLE IF EXISTS isc_defaults"
+      - sql: "CREATE TABLE isc_defaults (id INT NOT NULL, optional_value INT NULL, label VARCHAR(20) DEFAULT 'fallback')"
+    sql: "SELECT column_name, column_default FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = 'memcp-tests' AND table_name = 'isc_defaults' ORDER BY ordinal_position"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS isc_defaults"
+    expect:
+      rows: 3
+      data:
+        - column_name: "id"
+          column_default: null
+        - column_name: "optional_value"
+          column_default: "NULL"
+        - column_name: "label"
+          column_default: "'fallback'"
+
   - name: "COLUMNS: mysqldump generation metadata is non-null"
     sql: >
       SELECT column_name, extra, generation_expression, data_type
@@ -190,6 +207,64 @@ test_cases:
         AND table_schema = 'memcp-tests'
     expect:
       min_rows: 0
+
+  - name: "Foreign key metadata includes columns and actions"
+    setup:
+      - sql: "DROP TABLE IF EXISTS is_fk_child"
+      - sql: "DROP TABLE IF EXISTS is_fk_parent"
+      - sql: "CREATE TABLE is_fk_parent (id INT PRIMARY KEY, external_id INT, UNIQUE KEY is_uq_external (external_id))"
+      - sql: "CREATE TABLE is_fk_child (id INT PRIMARY KEY, parent_id INT, CONSTRAINT is_fk_child_parent FOREIGN KEY (parent_id) REFERENCES is_fk_parent(id) ON DELETE SET NULL ON UPDATE CASCADE)"
+    sql: >
+      SELECT key_column_usage.constraint_name AS constraint_name,
+             key_column_usage.column_name AS column_name,
+             key_column_usage.referenced_table_name AS referenced_table_name,
+             key_column_usage.referenced_column_name AS referenced_column_name,
+             referential_constraints.update_rule AS update_rule,
+             referential_constraints.delete_rule AS delete_rule
+      FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+      JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+        ON key_column_usage.constraint_schema = referential_constraints.constraint_schema
+       AND key_column_usage.constraint_name = referential_constraints.constraint_name
+      WHERE key_column_usage.table_schema = 'memcp-tests'
+        AND key_column_usage.constraint_name = 'is_fk_child_parent'
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS is_fk_child"
+      - sql: "DROP TABLE IF EXISTS is_fk_parent"
+    expect:
+      rows: 1
+      data:
+        - constraint_name: "is_fk_child_parent"
+          column_name: "parent_id"
+          referenced_table_name: "is_fk_parent"
+          referenced_column_name: "id"
+          update_rule: "CASCADE"
+          delete_rule: "SET NULL"
+
+  - name: "Unique constraints appear in key column usage"
+    setup:
+      - sql: "DROP TABLE IF EXISTS is_unique_metadata"
+      - sql: "CREATE TABLE is_unique_metadata (id INT PRIMARY KEY, external_id INT, UNIQUE KEY is_uq_metadata_external (external_id))"
+    sql: "SELECT constraint_name, column_name FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE table_schema = 'memcp-tests' AND table_name = 'is_unique_metadata' ORDER BY ordinal_position, constraint_name"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS is_unique_metadata"
+    expect:
+      rows: 2
+      data:
+        - constraint_name: "PRIMARY"
+          column_name: "id"
+        - constraint_name: "is_uq_metadata_external"
+          column_name: "external_id"
+
+  - name: "Unique constraint remains enforced"
+    setup:
+      - sql: "DROP TABLE IF EXISTS is_unique_enforced"
+      - sql: "CREATE TABLE is_unique_enforced (id INT PRIMARY KEY, external_id INT, UNIQUE KEY is_uq_enforced_external (external_id))"
+      - sql: "INSERT INTO is_unique_enforced VALUES (1, 7)"
+    sql: "INSERT INTO is_unique_enforced VALUES (2, 7)"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS is_unique_enforced"
+    expect:
+      error: true
 
   - name: "A genuinely ambiguous metadata column is rejected"
     sql: >


### PR DESCRIPTION
## Summary
- restore MariaDB split executable-comment trigger definitions
- expose foreign keys, referential actions, primary keys, and unique constraints through SHOW CREATE TABLE and INFORMATION_SCHEMA
- emit MariaDB-compatible table engines and column defaults
- accept the transaction isolation and savepoint statements emitted by unmodified mysqldump

## Round-trip review
Repeated neutral-fixture exports/imports covered MariaDB to MemCP, MemCP to MemCP, and MemCP back to MariaDB. Every hop was checked for exact data and schema snapshots plus active foreign-key, trigger, and unique-constraint behavior. Both normal and --single-transaction mysqldump invocations succeeded.

## Verification
- make test (after rebase): passed
- DDL compatibility: 68/68
- INFORMATION_SCHEMA compatibility: 31/31
- no production instance modified; no customer data or dumps included