### PR TITLE
Preserve streaming callbacks in nested scan rewrites

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3483,7 +3483,8 @@ move the window to the wrong tree level. */
 			(probe_limit_work_rows limit_value)
 			acceptance_probe_work_rows))
 		(define emit_value (quote __ordered_join_emit_value))
-		(define row_expr (list emit_value (value_builder projection_probe_work_rows scalar_probe)))
+		(define row_expr (list (quote stream_emit) emit_value
+			(value_builder projection_probe_work_rows scalar_probe)))
 		(define mapcols (join_cols_for_alias all_sources default_alias alias carrier_needed_exprs))
 		(define projection (build_join_scan_pipeline_using_recipe
 			schema all_sources remaining_plan default_alias carrier_needed_exprs remaining_condition row_expr

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3079,6 +3079,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(stream_window_reduce 2 -1 + 0 (lambda (emit)
 			(begin (emit 1) (emit 2) (emit 3) (emit 4))))
 		7) true "stream_window_reduce supports OFFSET without a finite limit")
+	(assert (equal? (stream_emit (lambda (value) (+ value 1)) 4) 5)
+		true "stream_emit invokes its callback immediately")
 
 	/* promise */
 	(print "testing promise ...")

--- a/scm/window.go
+++ b/scm/window.go
@@ -39,6 +39,22 @@ func init_window() {
 	DeclareTitle("Window Functions")
 
 	Declare(&Globalenv, &Declaration{
+		Name: "stream_emit",
+		Desc: "invokes a streaming callback immediately; marks ordering-sensitive emission as an observable effect",
+		Fn: func(a ...Scmer) Scmer {
+			return Apply(a[0], a[1])
+		},
+		Type: &TypeDescriptor{
+			HasSideEffects: true,
+			Params: []*TypeDescriptor{
+				{Kind: "func", ParamName: "emit", Params: []*TypeDescriptor{{Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", ParamName: "value"},
+			},
+			Return: &TypeDescriptor{Kind: "any"},
+		},
+	})
+
+	Declare(&Globalenv, &Declaration{
 		Name: "stream_window_reduce",
 		Desc: "applies OFFSET/LIMIT and a serial reducer to complete values emitted by a nested streaming producer without collecting an intermediate relation",
 		Fn: func(a ...Scmer) (result Scmer) {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -380,7 +380,47 @@ func scanExprMayHaveSideEffects(v scm.Scmer) bool {
 	if !v.IsSlice() {
 		return false
 	}
-	for _, item := range v.Slice() {
+	items := v.Slice()
+	if len(items) > 0 {
+		if name, ok := scanSymbolName(items[0]); ok {
+			if name == "quote" {
+				return false
+			}
+			if name == "lambda" {
+				if len(items) < 3 {
+					return false
+				}
+				return scanExprMayHaveSideEffects(items[2])
+			}
+			if declaration := scm.DeclarationForValue(items[0]); declaration != nil {
+				if declaration.Type != nil && declaration.Type.HasSideEffects {
+					return true
+				}
+				for _, item := range items[1:] {
+					if scanExprMayHaveSideEffects(item) {
+						return true
+					}
+				}
+				return false
+			}
+			switch name {
+			case "and", "begin", "begin_mut", "if", "or", "outer", "var":
+				// Core forms control evaluation; their children are checked below.
+			default:
+				// A free procedure value can close over an emitter or other effect.
+				// Delaying it across a batch boundary is therefore not semantics-safe.
+				return true
+			}
+		} else if _, _, ok := scanLambdaParts(items[0]); ok {
+			// An immediately invoked lambda is statically visible. Its body and
+			// arguments are checked recursively below like any declared call.
+		} else {
+			// A computed call head, such as ((var 0) row), can resolve to a
+			// closure that emits a result. Its effects cannot be inferred here.
+			return true
+		}
+	}
+	for _, item := range items {
 		if scanExprMayHaveSideEffects(item) {
 			return true
 		}

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -380,47 +380,7 @@ func scanExprMayHaveSideEffects(v scm.Scmer) bool {
 	if !v.IsSlice() {
 		return false
 	}
-	items := v.Slice()
-	if len(items) > 0 {
-		if name, ok := scanSymbolName(items[0]); ok {
-			if name == "quote" {
-				return false
-			}
-			if name == "lambda" {
-				if len(items) < 3 {
-					return false
-				}
-				return scanExprMayHaveSideEffects(items[2])
-			}
-			if declaration := scm.DeclarationForValue(items[0]); declaration != nil {
-				if declaration.Type != nil && declaration.Type.HasSideEffects {
-					return true
-				}
-				for _, item := range items[1:] {
-					if scanExprMayHaveSideEffects(item) {
-						return true
-					}
-				}
-				return false
-			}
-			switch name {
-			case "and", "begin", "begin_mut", "if", "or", "outer", "var":
-				// Core forms control evaluation; their children are checked below.
-			default:
-				// A free procedure value can close over an emitter or other effect.
-				// Delaying it across a batch boundary is therefore not semantics-safe.
-				return true
-			}
-		} else if _, _, ok := scanLambdaParts(items[0]); ok {
-			// An immediately invoked lambda is statically visible. Its body and
-			// arguments are checked recursively below like any declared call.
-		} else {
-			// A computed call head, such as ((var 0) row), can resolve to a
-			// closure that emits a result. Its effects cannot be inferred here.
-			return true
-		}
-	}
-	for _, item := range items {
+	for _, item := range v.Slice() {
 		if scanExprMayHaveSideEffects(item) {
 			return true
 		}

--- a/storage/scan_batch_rewrite_test.go
+++ b/storage/scan_batch_rewrite_test.go
@@ -60,6 +60,28 @@ func TestScanBatchRewriteKeepsEffectfulInnerMapperStreaming(t *testing.T) {
 	}
 }
 
+func TestScanBatchRewriteKeepsDynamicCallbackStreaming(t *testing.T) {
+	emit := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("emit"),
+		scm.NewSymbol("inner_id"),
+	})
+	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(emit)); !rewritten.IsNil() {
+		t.Fatalf("dynamic callback was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
+func TestScanBatchRewriteKeepsDeclaredEffectStreaming(t *testing.T) {
+	insert := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("insert"),
+		scm.NewSymbol("target"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString("ID")}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("inner_id")}),
+	})
+	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(insert)); !rewritten.IsNil() {
+		t.Fatalf("declared effect was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+	}
+}
+
 func TestScanBatchRewriteStillBatchesPureInnerMapper(t *testing.T) {
 	rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(scm.NewSymbol("inner_id")))
 	if rewritten.IsNil() {
@@ -67,5 +89,41 @@ func TestScanBatchRewriteStillBatchesPureInnerMapper(t *testing.T) {
 	}
 	if plan := scm.SerializeToString(rewritten, &scm.Globalenv); !strings.Contains(plan, "scan_batch") {
 		t.Fatalf("rewritten plan contains no scan_batch: %s", plan)
+	}
+}
+
+func TestScanBatchRewriteStillBatchesDeclaredPureCall(t *testing.T) {
+	pureCall := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewSymbol("inner_id"),
+		scm.NewInt(1),
+	})
+	rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(pureCall))
+	if rewritten.IsNil() {
+		t.Fatal("declared pure callback was not batched")
+	}
+}
+
+func TestScanBatchRewriteStillBatchesImmediatePureLambda(t *testing.T) {
+	pureCall := scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("lambda"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("value")}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("value")}),
+		}),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("var"), scm.NewInt(0)}),
+	})
+	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(pureCall)); rewritten.IsNil() {
+		t.Fatal("immediately invoked pure lambda was not batched")
+	}
+}
+
+func TestScanBatchRewriteKeepsComputedCallbackStreaming(t *testing.T) {
+	emit := scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("var"), scm.NewInt(0)}),
+		scm.NewSymbol("inner_id"),
+	})
+	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(emit)); !rewritten.IsNil() {
+		t.Fatalf("computed callback was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
 	}
 }

--- a/storage/scan_batch_rewrite_test.go
+++ b/storage/scan_batch_rewrite_test.go
@@ -60,25 +60,14 @@ func TestScanBatchRewriteKeepsEffectfulInnerMapperStreaming(t *testing.T) {
 	}
 }
 
-func TestScanBatchRewriteKeepsDynamicCallbackStreaming(t *testing.T) {
+func TestScanBatchRewriteKeepsStreamingEmitterOrdered(t *testing.T) {
 	emit := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("stream_emit"),
 		scm.NewSymbol("emit"),
 		scm.NewSymbol("inner_id"),
 	})
 	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(emit)); !rewritten.IsNil() {
-		t.Fatalf("dynamic callback was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
-	}
-}
-
-func TestScanBatchRewriteKeepsDeclaredEffectStreaming(t *testing.T) {
-	insert := scm.NewSlice([]scm.Scmer{
-		scm.NewSymbol("insert"),
-		scm.NewSymbol("target"),
-		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString("ID")}),
-		scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("inner_id")}),
-	})
-	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(insert)); !rewritten.IsNil() {
-		t.Fatalf("declared effect was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
+		t.Fatalf("stream emitter was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
 	}
 }
 
@@ -89,41 +78,5 @@ func TestScanBatchRewriteStillBatchesPureInnerMapper(t *testing.T) {
 	}
 	if plan := scm.SerializeToString(rewritten, &scm.Globalenv); !strings.Contains(plan, "scan_batch") {
 		t.Fatalf("rewritten plan contains no scan_batch: %s", plan)
-	}
-}
-
-func TestScanBatchRewriteStillBatchesDeclaredPureCall(t *testing.T) {
-	pureCall := scm.NewSlice([]scm.Scmer{
-		scm.NewSymbol("equal??"),
-		scm.NewSymbol("inner_id"),
-		scm.NewInt(1),
-	})
-	rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(pureCall))
-	if rewritten.IsNil() {
-		t.Fatal("declared pure callback was not batched")
-	}
-}
-
-func TestScanBatchRewriteStillBatchesImmediatePureLambda(t *testing.T) {
-	pureCall := scm.NewSlice([]scm.Scmer{
-		scm.NewSlice([]scm.Scmer{
-			scm.NewSymbol("lambda"),
-			scm.NewSlice([]scm.Scmer{scm.NewSymbol("value")}),
-			scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("value")}),
-		}),
-		scm.NewSlice([]scm.Scmer{scm.NewSymbol("var"), scm.NewInt(0)}),
-	})
-	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(pureCall)); rewritten.IsNil() {
-		t.Fatal("immediately invoked pure lambda was not batched")
-	}
-}
-
-func TestScanBatchRewriteKeepsComputedCallbackStreaming(t *testing.T) {
-	emit := scm.NewSlice([]scm.Scmer{
-		scm.NewSlice([]scm.Scmer{scm.NewSymbol("var"), scm.NewInt(0)}),
-		scm.NewSymbol("inner_id"),
-	})
-	if rewritten := tryScanBatchRewrite(nestedScanBatchRewriteCall(emit)); !rewritten.IsNil() {
-		t.Fatalf("computed callback was buffered: %s", scm.SerializeToString(rewritten, &scm.Globalenv))
 	}
 }

--- a/tests/integration/regressions/joined-revision-query-pattern.yaml
+++ b/tests/integration/regressions/joined-revision-query-pattern.yaml
@@ -1,4 +1,11 @@
-# Regression coverage for isodoc revision/file metadata via nested scalar subselects.
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Regression coverage for revision/file metadata via joins and scalar subselects.
 
 metadata:
   version: "1.0"
@@ -87,6 +94,21 @@ test_cases:
           operation::pdf: true
           employee::description: null
           employee::canView: null
+
+  - name: "Ordered limited three-table join sees delta rows"
+    sql: |
+      SELECT d.ID, d.subject
+      FROM isodoc d
+      JOIN isodoc_revision r ON r.isodoc = d.ID
+      JOIN fop_files f ON f.ID = r.file
+      WHERE f.filename = 'scan-a2.pdf'
+      ORDER BY d.ID DESC
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          subject: "Akte A"
 
   - name: "Drop isodoc_revision table"
     sql: "DROP TABLE IF EXISTS isodoc_revision"


### PR DESCRIPTION
## Summary
- mark ordering-sensitive streaming emission explicitly with `stream_emit`
- keep the existing nested-scan batching behavior for ordinary pure callbacks
- add regression coverage for an ordered, limited three-table join over unreconstructed delta rows

## Root cause
The nested-scan batch rewrite delayed a runtime result-emission callback until after the ordered driver had completed. With `LIMIT 1`, the delayed emission crossed the streaming boundary and the query returned no row although the joined delta rows existed. The new primitive makes this effect visible to the existing optimizer analysis without conservatively disabling unrelated batch rewrites.

## Validation
- focused scan-batch Go tests
- scan-batch optimizer YAML suite (12/12)
- grouped aggregate corner suite (36/36)
- joined revision query-pattern suite (14/14)
- affected browser flows passed against the patched engine
- parallel application A/B: broad callback suppression 7/19, explicit marker 18/19; remaining popup close timeout passes serially
- full suite delegated to CI as requested