### PR TITLE
Cost ordered membership carriers at their physical consumer

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2002,6 +2002,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 					(list (quote membership_candidate_filter_columns) (qassoc_get facts (quote membership_candidate_filter_columns) 0))
 					(list (quote membership_candidate_map_columns) (qassoc_get facts (quote membership_candidate_map_columns) 1))
 					(list (quote membership_candidate_cache_map_columns) (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
+					(list (quote membership_candidate_cache_backed) (qassoc_get facts (quote membership_candidate_cache_backed) false))
 					(list (quote membership_candidate_expression_operations) (qassoc_get facts (quote membership_candidate_expression_operations) 0))
 					(list (quote membership_candidate_expression_depth) (qassoc_get facts (quote membership_candidate_expression_depth) 0))
 					(list (quote membership_candidate_broad_text_match_rows) (qassoc_get facts (quote membership_candidate_broad_text_match_rows) 0))
@@ -2048,7 +2049,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 	(if (query_block? node)
 		(begin
 			(define planned (apply_join_optimizer_plan node))
-			(define physical_planned (query_block_with_physical_requirement_choices planned))
+			(define physical_planned (query_block_with_physical_requirement_facts planned))
 			(define physical_stages (map (qb_stages physical_planned) apply_join_optimizer_plan_stage))
 			(define requirement (qassoc_get (qb_facts physical_planned) (quote membership_requirement) nil))
 			/* Reorder attaches the requirement to the query block which owns every
@@ -3046,6 +3047,10 @@ either physical alternative or sampling the table again. */
 	(begin
 		(define work (membership_candidate_work_profile stage))
 		(list
+			/* UNION candidates project RecSets directly from their branches. Every
+			other supported candidate carrier reads a prepared group-stage cache. */
+			(list (quote membership_candidate_cache_backed)
+				(not (union_block? (gs_input stage))))
 			(list (quote membership_candidate_scan_invocations) (qassoc_get work (quote scan_invocations) 1))
 			(list (quote membership_candidate_filter_columns) (qassoc_get work (quote filter_columns) 0))
 			(list (quote membership_candidate_map_columns) (qassoc_get work (quote map_columns) (count (gs_keys stage))))
@@ -3138,6 +3143,7 @@ either physical alternative or sampling the table again. */
 			(list (quote membership_candidate_filter_columns) (qassoc_get candidate_work (quote filter_columns) 0))
 			(list (quote membership_candidate_map_columns) (qassoc_get candidate_work (quote map_columns) (count (gs_keys stage))))
 			(list (quote membership_candidate_cache_map_columns) (+ (count (gs_keys stage)) (count (gs_aggregates stage))))
+			(list (quote membership_candidate_cache_backed) (not (union_block? (gs_input stage))))
 			(list (quote membership_candidate_expression_operations) (qassoc_get candidate_work (quote expression_operations) 0))
 			(list (quote membership_candidate_expression_depth) (qassoc_get candidate_work (quote expression_depth) 0))
 			(list (quote membership_candidate_broad_text_match_rows) (qassoc_get candidate_work (quote broad_text_match_rows) 0))
@@ -3203,15 +3209,6 @@ a second global catalog through every physical expression helper. */
 		(gs_limit stage)
 		(gs_offset stage)
 		(merge (list (stage_reorder_telemetry stage) (gs_facts stage))))))
-
-(define physical_candidate_membership_strategy (lambda (telemetry)
-	(begin
-		(define candidates (membership_cost_options_for_telemetry telemetry))
-		(if (empty_list? candidates)
-			(membership_driver_strategy_for_telemetry telemetry)
-			(car (reduce (cdr candidates) (lambda (chosen candidate)
-				(if (planner_cost_better? (cadr candidate) (cadr chosen)) candidate chosen))
-				(car candidates)))))))
 
 (define membership_driver_strategy_for_telemetry (lambda (telemetry)
 	(if (qassoc_get telemetry (quote membership_order_limit_driver) false)
@@ -3420,7 +3417,9 @@ physical alternative. */
 			(membership_candidate_expression_operation_rows candidate_input_rows work)
 			(* driver_rows (membership_work_value work (quote membership_driver_expression_operations) 0))))
 		(planner_cost
-			(* scan_invocations planner_membership_scan_invocation_ns)
+			(+ (* scan_invocations planner_membership_scan_invocation_ns)
+				(if (membership_work_value work (quote membership_order_limit_driver) false)
+					planner_membership_ordered_scan_invocation_ns 0))
 			(+
 				(* (+ candidate_input_rows driver_rows) planner_membership_scan_row_ns)
 				(* filter_value_rows planner_membership_filter_column_row_ns)
@@ -3442,7 +3441,13 @@ physical alternative. */
 		(define projection_rows (membership_driver_input_rows driver_rows work))
 		(define projected_rows (membership_projected_driver_rows
 			candidate_input_rows candidate_rows projection_rows work))
-		(define base_cost (planner_cost_add
+		(define candidate_cache_cost (if
+			(membership_work_value work (quote membership_candidate_cache_backed) false)
+			(planner_cost planner_membership_group_cache_startup_ns 0 0 0 0
+				(* candidate_rows planner_membership_group_cache_build_row_ns)
+				(* candidate_rows 8) 0 candidate_rows 0.65)
+			(planner_zero_cost candidate_rows 0.65)))
+		(define base_cost (planner_cost_add (planner_cost_add
 			(planner_cost_add
 				(membership_common_scan_cost candidate_input_rows candidate_rows projection_rows
 					(membership_work_value work (quote membership_candidate_map_columns) 1) work)
@@ -3457,14 +3462,19 @@ physical alternative. */
 			(planner_cost planner_membership_recset_startup_ns 0 (* driver_rows planner_membership_recset_probe_row_ns)
 				0 0 (* (+ candidate_rows projected_rows) planner_membership_recset_build_row_ns)
 				(* (+ candidate_rows projected_rows) 8) 0 projection_rows 0.65)
-			projection_rows 0.65))
+			projection_rows 0.65)
+			candidate_cache_cost projection_rows 0.65))
+		(define downstream_cost (planner_direct_presence_probe_cost
+			(* projected_rows
+				(membership_work_value work (quote membership_downstream_probe_branches) 0))))
+		(define carrier_cost (planner_cost_add base_cost downstream_cost projected_rows 0.65))
 		(if (equal? (membership_work_value work (quote membership_consumer) (quote filter))
 			(quote aggregate))
-			(planner_cost_add base_cost
+			(planner_cost_add carrier_cost
 				(planner_cost 0 (* projection_rows planner_membership_recset_aggregate_row_ns)
 					0 0 0 0 0 0 projection_rows 0.65)
 				projection_rows 0.65)
-			base_cost))))
+			carrier_cost))))
 
 /* A selective, source-local driver predicate can restrict both sides of the
 membership edge before an expensive candidate predicate runs. The emitted
@@ -3489,11 +3499,14 @@ expression, and RecSet components used by the other membership carriers. */
 			(* driver_rows 2)
 			candidate_work_rows
 			candidate_match_rows))
-		(planner_cost
-			(* (+
-				(membership_work_value work (quote membership_driver_scan_invocations) 1)
-				(membership_work_value work (quote membership_candidate_scan_invocations) branches))
-				planner_membership_scan_invocation_ns)
+		(planner_cost_add (planner_cost
+			(+ planner_membership_recset_startup_ns
+				(* (+
+					(membership_work_value work (quote membership_driver_scan_invocations) 1)
+					(membership_work_value work (quote membership_candidate_scan_invocations) branches))
+					planner_membership_scan_invocation_ns)
+				(if (membership_work_value work (quote membership_order_limit_driver) false)
+					planner_membership_ordered_scan_invocation_ns 0))
 			(+
 				(* (+ driver_input_rows candidate_work_rows projection_rows)
 					planner_membership_scan_row_ns)
@@ -3509,6 +3522,7 @@ expression, and RecSet components used by the other membership carriers. */
 				(* candidate_work_rows
 					(membership_work_value work (quote membership_candidate_expression_operations) 0)
 					planner_membership_expression_operation_row_ns)
+				(* projection_rows planner_membership_map_column_row_ns)
 				(* (membership_work_value work (quote membership_candidate_broad_text_match_rows) 0)
 					candidate_fraction planner_membership_broad_text_match_row_ns)
 				(* (membership_work_value work (quote membership_candidate_broad_text_match_bytes) 0)
@@ -3516,7 +3530,11 @@ expression, and RecSet components used by the other membership carriers. */
 			0 0 0
 			(* projection_rows planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
-			0 driver_rows 0.65))))
+			0 driver_rows 0.65)
+			(planner_direct_presence_probe_cost
+				(* driver_rows candidate_density
+					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
+			driver_rows 0.65))))
 
 (define membership_driver_probe_cost (lambda (driver_rows probe_branches)
 	(begin
@@ -3531,22 +3549,38 @@ expression, and RecSet components used by the other membership carriers. */
 		(define visited_rows (membership_expected_driver_rows_visited
 			candidate_input_rows candidate_rows driver_rows work))
 		(define driver_input_rows (membership_driver_input_rows driver_rows work))
+		(define cache_backed
+			(membership_work_value work (quote membership_candidate_cache_backed) false))
 		(define base_cost (planner_cost_add
 			(membership_common_scan_cost candidate_input_rows candidate_rows visited_rows
-				(membership_work_value work (quote membership_candidate_cache_map_columns) 2) work)
-			(planner_cost planner_membership_group_cache_startup_ns 0 (* visited_rows planner_membership_group_cache_probe_row_ns)
-				0 0 (* candidate_rows planner_membership_group_cache_build_row_ns)
-				(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65)
+				(membership_work_value work
+					(if cache_backed (quote membership_candidate_cache_map_columns)
+						(quote membership_candidate_map_columns))
+					(if cache_backed 2 1)) work)
+			(if cache_backed
+				(planner_cost planner_membership_group_cache_startup_ns 0
+					(* visited_rows planner_membership_group_cache_probe_row_ns)
+					0 0 (* candidate_rows planner_membership_group_cache_build_row_ns)
+					(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65)
+				(planner_cost planner_membership_recset_startup_ns 0
+					(* visited_rows planner_membership_recset_probe_row_ns)
+					0 0 (* candidate_rows planner_membership_recset_build_row_ns)
+					(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65))
+			visited_rows 0.65))
+		(define carrier_cost (planner_cost_add base_cost
+			(planner_direct_presence_probe_cost
+				(* visited_rows
+					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			visited_rows 0.65))
 		(if (and (membership_work_value work (quote membership_order_limit_driver) false)
 			(not (membership_work_value work (quote membership_driver_alternative) false)))
-			(planner_cost_add base_cost
+			(planner_cost_add carrier_cost
 				(planner_cost 0
 					(* (/ (* driver_input_rows driver_input_rows) 1000000)
 						planner_membership_ordered_driver_input_row_ns)
 					0 0 0 0 0 0 driver_input_rows 0.65)
 				visited_rows 0.65)
-			base_cost))))
+			carrier_cost))))
 
 (define membership_cost_options (lambda (candidate_input_rows candidate_rows driver_rows probe_branches driver_strategy work)
 	(if (or (nil? candidate_input_rows) (or (nil? candidate_rows) (nil? driver_rows)))
@@ -3580,120 +3614,22 @@ expression, and RecSet components used by the other membership carriers. */
 			driver_strategy
 			telemetry))))
 
-(define record_membership_physical_choice (lambda (requirement strategy reason candidates)
-	(begin
-		(define decision_id (concat "membership_carrier:"
-			(qassoc_get requirement (quote membership_stage_id) "unknown")))
-		(define alternatives (map candidates (lambda (candidate) (string (car candidate)))))
-		(define forced (planner_physical_override decision_id))
-		(define chosen (planner_physical_choice decision_id (string strategy) alternatives))
-		(define candidate_input_rows (qassoc_get requirement (quote membership_candidate_input_rows) nil))
-		(define candidate_rows (qassoc_get requirement
-			(quote membership_candidate_estimated_rows) candidate_input_rows))
-		(define driver_input_rows (qassoc_get requirement (quote membership_driver_input_rows) nil))
-		(define driver_rows (if (qassoc_get requirement (quote membership_order_limit_driver) false)
-			(coalesceNil (probe_limit_work_rows (qassoc_get requirement (quote membership_order_limit) nil))
-				(qassoc_get requirement (quote membership_driver_rows) nil))
-			(qassoc_get requirement (quote membership_driver_rows) nil)))
-		(planner_record_physical_decision
-			(list
-				(list "decision_id" decision_id)
-				(list "decision" "membership_carrier")
-				(list "decision_site" "physical_requirement")
-				(list "stage" (qassoc_get requirement (quote membership_stage_id) nil))
-				(list "consumer" (string
-					(qassoc_get requirement (quote membership_consumer) (quote filter))))
-				(list "chosen" chosen)
-				(list "normally_chosen" (string strategy))
-				(list "selection" (if (nil? forced) "cost" "forced"))
-				(list "reason" (if (nil? forced) (string reason) "calibration_override"))
-				(list "inputs" (list
-					(list "candidate_rows" candidate_rows)
-					(list "candidate_input_rows" candidate_input_rows)
-					(list "candidate_density" (if (and (number? candidate_input_rows) (number? candidate_rows))
-						(membership_candidate_density candidate_input_rows candidate_rows requirement) nil))
-					(list "projected_driver_rows" (if (and (number? candidate_input_rows)
-						(and (number? candidate_rows) (number? driver_input_rows)))
-						(membership_projected_driver_rows candidate_input_rows candidate_rows driver_input_rows requirement) nil))
-					(list "driver_rows" driver_rows)
-					(list "driver_input_rows" driver_input_rows)
-					(list "expected_driver_rows_visited" (if (and (number? candidate_input_rows)
-						(and (number? candidate_rows) (number? driver_rows)))
-						(membership_expected_driver_rows_visited candidate_input_rows candidate_rows driver_rows requirement) nil))
-					(list "limit" (qassoc_get requirement (quote membership_order_limit) nil))
-					(list "offset" (qassoc_get requirement (quote membership_order_offset) 0))
-					(list "driver_estimate_capped" (qassoc_get requirement (quote membership_driver_estimate_capped) false))
-					(list "selectivity_class" (string (qassoc_get requirement (quote membership_selectivity_class) nil)))
-					(list "estimate_capped" (qassoc_get requirement (quote membership_candidate_estimate_capped) false))
-					(list "estimate_sampled_rows" (qassoc_get requirement (quote membership_candidate_estimate_sampled) nil))
-					(list "estimate_population" (string (qassoc_get requirement (quote membership_candidate_estimate_population) (quote table_rows))))
-					(list "estimate_coverage" (string (qassoc_get requirement (quote membership_candidate_estimate_coverage) (quote sampled))))
-					(list "probe_branches" (qassoc_get requirement (quote membership_candidate_probe_branches) 1))
-					(list "candidate_scan_invocations" (qassoc_get requirement (quote membership_candidate_scan_invocations) 1))
-					(list "candidate_filter_columns" (qassoc_get requirement (quote membership_candidate_filter_columns) 0))
-					(list "candidate_map_columns" (qassoc_get requirement (quote membership_candidate_map_columns) 1))
-					(list "candidate_cache_map_columns" (qassoc_get requirement (quote membership_candidate_cache_map_columns) 2))
-					(list "candidate_expression_operations" (qassoc_get requirement (quote membership_candidate_expression_operations) 0))
-					(list "candidate_expression_depth" (qassoc_get requirement (quote membership_candidate_expression_depth) 0))
-					(list "candidate_broad_text_match_rows" (qassoc_get requirement (quote membership_candidate_broad_text_match_rows) 0))
-					(list "candidate_broad_text_match_bytes" (qassoc_get requirement (quote membership_candidate_broad_text_match_bytes) 0))
-					(list "candidate_filter_value_rows" (qassoc_get requirement (quote membership_candidate_filter_value_rows) nil))
-					(list "candidate_expression_operation_rows" (qassoc_get requirement (quote membership_candidate_expression_operation_rows) nil))
-					(list "driver_scan_invocations" (qassoc_get requirement (quote membership_driver_scan_invocations) 1))
-					(list "driver_filter_columns" (qassoc_get requirement (quote membership_driver_filter_columns) 0))
-					(list "driver_map_columns" (qassoc_get requirement (quote membership_driver_map_columns) 0))
-					(list "driver_expression_operations" (qassoc_get requirement (quote membership_driver_expression_operations) 0))
-					(list "driver_expression_depth" (qassoc_get requirement (quote membership_driver_expression_depth) 0))
-					(list "reuse" (qassoc_get requirement (quote reuse) 1))))
-				(list "alternatives" (map candidates (lambda (candidate)
-					(list
-						(list "plan" (string (car candidate)))
-						(list "status" (if (equal? (string (car candidate)) chosen) "chosen" "rejected"))
-						(list "reason" (if (equal? (string (car candidate)) chosen) "selected" "higher_total_ns_or_forced_alternative"))
-						(list "cost" (planner_cost_explain (cadr candidate)))))))))
-		(if (qassoc_get requirement (quote membership_order_limit_driver) false)
-			(begin
-				(define recset_source (equal? chosen "candidate_keyset"))
-				(planner_record_physical_decision
-					(list
-						(list "decision" "ordered_recset_iterator")
-						(list "chosen" (if recset_source "scan_order_recset_part" "recset_contains_probe"))
-						(list "reason" (if recset_source "projected_recset_scan_source" "base_table_scan_with_membership_filter"))
-						(list "inputs" (list
-							(list "limit" (qassoc_get requirement (quote membership_order_limit) nil))
-							(list "candidate_rows" (qassoc_get requirement (quote membership_candidate_estimated_rows) nil))
-							(list "driver_rows" (qassoc_get requirement (quote membership_driver_rows) nil))))
-						(list "alternatives" (list
-							(list
-								(list "plan" "scan_order_recset_part")
-								(list "status" (if recset_source "chosen" "rejected"))
-								(list "reason" (if recset_source "projected_recset_scan_source" "source_is_base_table")))
-							(list
-								(list "plan" "recset_contains_probe")
-								(list "status" (if recset_source "rejected" "chosen"))
-								(list "reason" (if recset_source "direct_intersection_available" "membership_is_filter"))))))))
-			nil))))
-/* The reorder phase carries only an abstract membership requirement. Concrete
-keyset/probe names enter the IR here, at the physical preparation boundary. */
-(define query_block_with_physical_requirement_choices (lambda (block)
+/* The reorder phase carries only an abstract membership requirement. This
+preparation step attaches its estimates to the stage, but deliberately does
+not choose a carrier: only the consuming physical tree edge knows whether an
+ordered batch is executable and what its actual driver workload is. */
+(define query_block_with_physical_requirement_facts (lambda (block)
 	(begin
 		(define requirement (qassoc_get (qb_facts block) (quote membership_requirement) nil))
 		(if (nil? requirement)
 			block
 			(begin
-				(define strategy (physical_candidate_membership_strategy requirement))
 				(define candidates (membership_cost_options_for_telemetry requirement))
-				(define reason (if (equal? strategy (quote candidate_keyset))
-					(quote projected_membership_cost)
-					(quote indexed_driver_probe_cost)))
-				(if (equal? strategy (quote candidate_keyset))
-					nil
-					(record_membership_physical_choice requirement strategy reason candidates))
 				(define physical_facts (merge (list
 					(list
-						(list (quote membership_plan_strategy) strategy)
-						(list (quote membership_cost_candidates) candidates)
-						(list (quote membership_cost_reason) reason))
+						(list (quote membership_plan_strategy)
+							(quote projected_membership_alternatives))
+						(list (quote membership_cost_candidates) candidates))
 					requirement
 					(qb_facts block))))
 				(make_query_block
@@ -3724,156 +3660,54 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(and supported (not (nil? (recset_project_join_branch_parts branch))))) true)
 			(not (nil? (membership_keyset_descriptor (list stage nil "__target" nil))))))))
 
+(define membership_truth_cost_facts (lambda (block stage)
+	(begin
+		(define input (gs_input stage))
+		(define sources (filter (qb_sources block) source_is_base_table?))
+		(define driver (if (empty_list? sources) nil (car sources)))
+		(define condition (coalesceNil (qassoc_get (gs_facts stage) (quote condition) true) true))
+		(define candidate_estimate (if (source_is_base_table? input)
+			(planner_source_filter_estimate input condition 512) nil))
+		(define candidate_input_rows (if (source_is_base_table? input)
+			(planner_source_row_count input) nil))
+		(define candidate_rows (planner_estimated_matching_rows
+			candidate_estimate candidate_input_rows candidate_input_rows))
+		(define driver_input_rows (if (nil? driver) nil (planner_source_row_count driver)))
+		(define driver_estimate (if (nil? driver) nil
+			(planner_source_filter_estimate driver
+				(membership_driver_filter (qb_where block)) 512)))
+		(define driver_rows (membership_estimated_work_rows driver_estimate driver_input_rows))
+		(merge (list
+			(list
+				(list (quote membership_candidate_input_rows) candidate_input_rows)
+				(list (quote membership_candidate_estimated_rows) candidate_rows)
+				(list (quote membership_candidate_matching_rows)
+					(qassoc_get candidate_estimate (quote rows) nil))
+				(list (quote membership_candidate_estimate_capped)
+					(qassoc_get candidate_estimate (quote capped) false))
+				(list (quote membership_candidate_estimate_input)
+					(qassoc_get candidate_estimate (quote input) nil))
+				(list (quote membership_candidate_estimate_sampled)
+					(qassoc_get candidate_estimate (quote sampled) nil))
+				(list (quote membership_candidate_estimate_population)
+					(planner_estimate_population candidate_estimate))
+				(list (quote membership_candidate_estimate_coverage)
+					(planner_estimate_coverage candidate_estimate))
+				(list (quote membership_driver_input_rows) driver_input_rows)
+				(list (quote membership_driver_rows) driver_rows))
+			(membership_candidate_work_facts stage)
+			(gs_facts stage))))))
+
 (define membership_truth_projection_preferred? (lambda (block stage _guarded_alternative)
 	(begin
 		(define input (gs_input stage))
-		(define stage_facts (merge (list (membership_candidate_work_facts stage) (gs_facts stage))))
 		(define base_sources (filter (qb_sources block) source_is_base_table?))
-		/* Projection from the canonical group cache currently guarantees a
-		direct key map only for base-table membership stages. Derived inputs keep
-		the same primitive and use indexed existence probing until their cache-key
-		lineage is represented explicitly. A canonical simple UNION is also valid
-		for the driver probe because each branch lowers independently against the
-		current lookup key; this does not project or materialize the UNION. */
-		(if (or
-			(or (not (source_is_base_table? input)) (not (single_source? base_sources)))
-			(not (empty_list? (group_stage_session_domain_keys stage))))
-			false
-			(begin
-				(define candidate_estimate (planner_source_filter_estimate input
-					(coalesceNil (qassoc_get stage_facts (quote condition) true) true)
-					512))
-				(define capped (if (nil? candidate_estimate) false
-					(qassoc_get candidate_estimate (quote capped) false)))
-				(define candidate_total_rows (planner_source_row_count input))
-				(define candidate_rows (planner_estimated_matching_rows
-					candidate_estimate candidate_total_rows candidate_total_rows))
-				(define driver (car base_sources))
-				(define driver_total_rows (planner_source_row_count driver))
-				(define driver_estimate (planner_source_filter_estimate driver
-					(membership_driver_filter (qb_where block)) 512))
-				(define local_driver_rows (if (and (query_limit_active? (qb_offset block) (qb_limit block))
-					(order_items_belong_to_source? driver (qb_order block)))
-					(probe_limit_work_rows (qb_limit block)) nil))
-				(define driver_rows (coalesceNil local_driver_rows
-					(membership_estimated_work_rows driver_estimate driver_total_rows)))
-				(define guarded_small_driver (and _guarded_alternative
-					(and (not (query_limit_active? (qb_offset block) (qb_limit block)))
-						(and (number? driver_rows) (<= driver_rows 512)))))
-				(define broad_text_driver (and _guarded_alternative
-					(membership_broad_driver_probe_preferred? block stage)))
-				(define broad_driver (if _guarded_alternative
-					(or guarded_small_driver
-						(or broad_text_driver
-							(and (query_limit_active? (qb_offset block) (qb_limit block))
-								(and (order_items_belong_to_source? driver (qb_order block))
-									(or capped
-										(and (and (number? candidate_total_rows) (> candidate_total_rows 512))
-											(and (number? candidate_rows)
-												(and (number? candidate_total_rows)
-													(>= (* candidate_rows 4) candidate_total_rows)))))))))
-					false))
-				(define batch_shape_supported (and
-					(query_limit_active? (qb_offset block) (qb_limit block))
-					(and (order_items_belong_to_source? driver (qb_order block))
-						(not (membership_expr_has_driver_alternative? (qb_where block))))))
-				/* Avoid rediscovering the membership subtree on the overwhelmingly
-				common unbounded path. This preparation is only useful to the bounded
-				ordered consumer that can emit the batch operator. */
-				(define batch_membership (if batch_shape_supported
-					(driver_membership_for_source driver (qb_where block)) nil))
-				(define batch_supported (and (not (nil? batch_membership))
-					(and (equal? (gs_id (nth batch_membership 0)) (gs_id stage))
-						(ordered_batch_stage_supported? stage))))
-				/* Batch eligibility only preserves the abstract membership marker.
-				The consuming tree edge below owns the node-local physical
-				decision once its driver cardinality is known. */
-				(if batch_supported
-					true
-					(begin
-						/* The rewrite target depends on the surrounding shape: below a
-						broad ordered OR it is the lazy driver marker used to build one
-						source-key index; otherwise it is the projected candidate RecSet. */
-						(define projected_choice (if broad_text_driver
-							"driver_order_membership_probe"
-							"candidate_keyset"))
-						(define decision_id (concat "membership_carrier:" (gs_id stage)))
-						(define alternatives (list "candidate_keyset" "driver_order_membership_probe"))
-						(define normal_choice (if broad_driver
-							"driver_order_membership_probe"
-							(if (membership_projection_cost_preferred? candidate_total_rows candidate_rows driver_rows stage_facts)
-								"candidate_keyset"
-								"driver_order_membership_probe")))
-						(define forced_choice (planner_physical_override decision_id))
-						(define candidate_cost (if (number? candidate_rows)
-							(membership_projection_cost candidate_total_rows candidate_rows driver_rows stage_facts)
-							nil))
-						(define driver_cost (if (number? driver_rows)
-							(membership_ordered_driver_probe_cost candidate_total_rows candidate_rows driver_rows stage_facts)
-							nil))
-						(define chosen_choice (planner_physical_choice decision_id normal_choice alternatives))
-						(define chosen_projection (equal? chosen_choice projected_choice))
-						(planner_record_physical_decision
-							(list
-								(list "decision_id" decision_id)
-								(list "decision" "membership_carrier")
-								(list "decision_site" "truth_projection")
-								(list "stage" (gs_id stage))
-								(list "consumer" (if (query_block_has_aggregates? block) "aggregate" (if (query_limit_active? (qb_offset block) (qb_limit block)) "order_limit" "filter")))
-								(list "chosen" chosen_choice)
-								(list "selection" (if (nil? forced_choice) (if broad_driver "constraint" "cost") "forced"))
-								(list "normally_chosen" normal_choice)
-								(list "reason" (if (not (nil? forced_choice)) "calibration_override"
-									(if guarded_small_driver "guarded_small_local_driver"
-										(if broad_driver "guarded_broad_order_limit_driver"
-											(if capped "capped_estimate_uses_input_lower_bound" "lowest_total_ns")))))
-								(list "inputs" (list
-									(list "candidate_input_rows" candidate_total_rows)
-									(list "candidate_matching_rows" (if (nil? candidate_estimate) nil (qassoc_get candidate_estimate (quote rows) nil)))
-									(list "candidate_rows" candidate_rows)
-									(list "candidate_density" (membership_candidate_density
-										candidate_total_rows candidate_rows stage_facts))
-									(list "projected_driver_rows"
-										(membership_projected_driver_rows candidate_total_rows candidate_rows driver_total_rows stage_facts))
-									(list "driver_input_rows" driver_total_rows)
-									(list "driver_rows" driver_rows)
-									(list "expected_driver_rows_visited" (membership_expected_driver_rows_visited
-										candidate_total_rows candidate_rows driver_rows stage_facts))
-									(list "limit" (qb_limit block))
-									(list "offset" (coalesceNil (qb_offset block) 0))
-									(list "estimate_capped" capped)
-									(list "estimate_sampled_rows" (qassoc_get candidate_estimate (quote sampled) nil))
-									(list "estimate_population" (string (planner_estimate_population candidate_estimate)))
-									(list "estimate_coverage" (string (planner_estimate_coverage candidate_estimate)))
-									(list "selectivity_class" (if capped "unknown_or_broad" (string (qassoc_get stage_facts (quote selectivity_class) (quote unknown)))))
-									(list "candidate_scan_invocations" (qassoc_get stage_facts (quote membership_candidate_scan_invocations) 1))
-									(list "candidate_filter_columns" (qassoc_get stage_facts (quote membership_candidate_filter_columns) 0))
-									(list "candidate_map_columns" (qassoc_get stage_facts (quote membership_candidate_map_columns) 1))
-									(list "candidate_cache_map_columns" (qassoc_get stage_facts (quote membership_candidate_cache_map_columns) 2))
-									(list "candidate_expression_operations" (qassoc_get stage_facts (quote membership_candidate_expression_operations) 0))
-									(list "candidate_expression_depth" (qassoc_get stage_facts (quote membership_candidate_expression_depth) 0))
-									(list "candidate_broad_text_match_rows" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_rows) 0))
-									(list "candidate_broad_text_match_bytes" (qassoc_get stage_facts (quote membership_candidate_broad_text_match_bytes) 0))
-									(list "candidate_filter_value_rows" (qassoc_get stage_facts (quote membership_candidate_filter_value_rows) nil))
-									(list "candidate_expression_operation_rows" (qassoc_get stage_facts (quote membership_candidate_expression_operation_rows) nil))
-									(list "driver_scan_invocations" (qassoc_get stage_facts (quote membership_driver_scan_invocations) 1))
-									(list "driver_filter_columns" (qassoc_get stage_facts (quote membership_driver_filter_columns) 0))
-									(list "driver_map_columns" (qassoc_get stage_facts (quote membership_driver_map_columns) 0))
-									(list "driver_expression_operations" (qassoc_get stage_facts (quote membership_driver_expression_operations) 0))
-									(list "driver_expression_depth" (qassoc_get stage_facts (quote membership_driver_expression_depth) 0))
-									(list "reuse" (qassoc_get stage_facts (quote reuse) 1))))
-								(list "alternatives" (list
-									(list
-										(list "plan" "candidate_keyset")
-										(list "status" (if (equal? chosen_choice "candidate_keyset") "chosen" "rejected"))
-										(list "reason" (if (equal? chosen_choice "candidate_keyset") "selected" "higher_total_ns_or_forced_alternative"))
-										(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
-									(list
-										(list "plan" "driver_order_membership_probe")
-										(list "status" (if (equal? chosen_choice "driver_order_membership_probe") "chosen" "rejected"))
-										(list "reason" (if (equal? chosen_choice "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
-										(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))))))
-						chosen_projection)))))))
+		/* This predicate proves only that the abstract membership marker has a
+		physical consumer. It must not inspect cardinality or choose a carrier;
+		those facts are meaningful only at the consuming scan-tree edge. */
+		(and (source_is_base_table? input)
+			(and (single_source? base_sources)
+				(empty_list? (group_stage_session_domain_keys stage)))))))
 
 (define choose_membership_truth_items (lambda (block items guarded_alternative)
 	(match items
@@ -3898,11 +3732,22 @@ keyset/probe names enter the IR here, at the physical preparation boundary. */
 				(if (and (not (nil? stage))
 					(membership_truth_projection_preferred? block stage guarded_alternative))
 					(begin
-						(define guarded_stage (if (and guarded_alternative
-							(membership_broad_driver_probe_preferred? block stage))
-							(group_stage_with_facts stage
-								(qassoc_set (gs_facts stage) (quote guarded_broad_order_driver) true))
-							stage))
+						/* Cost facts travel with the abstract marker; carrier selection
+						remains deferred to its physical consumer. */
+						(define costed_stage (group_stage_with_facts stage
+							(membership_truth_cost_facts block stage)))
+						/* A membership branch below OR is not implied by the complete
+						predicate. Preserve that semantic placement fact for unknown-cost
+						fallbacks; it is not a physical carrier decision. */
+						(define guarded_stage (if guarded_alternative
+							(group_stage_with_facts costed_stage
+								(qassoc_set
+									(if (membership_broad_driver_probe_preferred? block stage)
+										(qassoc_set (gs_facts costed_stage)
+											(quote guarded_broad_order_driver) true)
+										(gs_facts costed_stage))
+									(quote membership_branch_not_implied) true))
+							costed_stage))
 						(list (driver_membership_probe_expr guarded_stage (nth parts 0)) (list (nth parts 1))))
 					(list (expand_in_membership_truth_expr (nth parts 0) (nth parts 1) (nth parts 2)) '())))
 			(if (and (list? expr)
@@ -3978,42 +3823,14 @@ qb_where already contains the selected physical alternative. */
 			(define chosen (choose_membership_truth_expr block (qb_where block)))
 			(define removed_aliases (nth chosen 1))
 			(define chosen_where (nth chosen 0))
-			(define base_sources (filter (qb_sources block) source_is_base_table?))
-			(define ordered_memberships (if (single_source? base_sources)
-				(driver_memberships_for_source (car base_sources) chosen_where)
-				'()))
-			/* Capability checks deliberately inspect only logical source/key
-			signatures. Physical RecSet scan ASTs are emitted once, during lowering. */
-			(define keysets_supported (membership_keysets_supported? ordered_memberships))
-			(define ordered_driver_probe (and
-				(not (empty_list? removed_aliases))
-				(and keysets_supported
-					(and (membership_expr_has_driver_alternative? (qb_where block))
-						(and (query_limit_active? (qb_offset block) (qb_limit block))
-							(and (single_source? base_sources)
-								(order_items_belong_to_source? (car base_sources) (qb_order block))))))))
-			(define strategy_facts (if ordered_driver_probe
-				(merge (list
-					(list
-						(list (quote membership_plan_strategy) (quote driver_order_membership_probe))
-						(list (quote membership_driver_alternative) true)
-						(list (quote membership_order_limit_driver) true))
-					(qb_facts block)))
-				(qassoc_set (qb_facts block) (quote membership_plan_strategy)
-					(quote projected_membership_alternatives))))
+			/* This pass replaces logical membership truth with an abstract driver
+			marker and removes the redundant relational stage-output source. It must
+			not choose or delete the stage for a physical carrier: derived row-number,
+			join-leaf, and ordered consumers have different executable alternatives. */
+			(define strategy_facts (qassoc_set (qb_facts block)
+				(quote membership_plan_strategy) (quote projected_membership_alternatives)))
 			(define chosen_facts
 				(membership_choice_rewrite_join_facts block strategy_facts removed_aliases))
-			(define removed_stage_ids (if ordered_driver_probe
-				(filter (map (filter (qb_sources block) (lambda (src)
-					(contains? removed_aliases (source_alias src))))
-					(lambda (src) (if (stage_output_relation? (source_relation src))
-						(stage_output_relation_id (source_relation src)) nil)))
-					(lambda (stage_id) (not (nil? stage_id))))
-				'()))
-			(define chosen_stages (if ordered_driver_probe
-				(filter (qb_stages block) (lambda (stage)
-					(not (contains? removed_stage_ids (gs_id stage)))))
-				(qb_stages block)))
 			(if (empty_list? removed_aliases)
 				(make_query_block
 					(qb_schema block) (qb_sources block) (qb_fields block) chosen_where
@@ -4024,7 +3841,7 @@ qb_where already contains the selected physical alternative. */
 					(filter (qb_sources block) (lambda (src) (not (contains? removed_aliases (source_alias src)))))
 					(qb_fields block) chosen_where (qb_group block) (qb_having block)
 					(qb_order block) (qb_limit block) (qb_offset block) (qb_hidden block)
-					chosen_stages
+					(qb_stages block)
 					chosen_facts))))))
 
 (define dml_preserve_driver_membership_probe (lambda (fallback_schema expr)
@@ -4248,27 +4065,6 @@ special here. */
 				(and supported (candidate_recset_branch_supported? branch)))
 				true)))))
 
-(define membership_estimate_broad? (lambda (facts)
-	(begin
-		(define estimated_rows (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
-		(define estimate_input (qassoc_get facts (quote membership_candidate_estimate_input) nil))
-		(define capped (qassoc_get facts (quote membership_candidate_estimate_capped) false))
-		(define broad_by_count (and
-			(and (not (nil? estimated_rows)) (and (not (nil? estimate_input)) (> estimate_input 0)))
-			(>= (* estimated_rows 4) estimate_input)))
-		(or
-			capped
-			(or
-				broad_by_count
-				(equal? (qassoc_get facts (quote membership_selectivity_class) nil) (quote broad)))))))
-
-(define ordered_driver_membership_keyset? (lambda (facts)
-	(and
-		(qassoc_get facts (quote membership_driver_alternative) false)
-		(and
-			(driver_order_membership_strategy? facts)
-			(qassoc_get facts (quote membership_order_limit_driver) false)))))
-
 (define stage_consumed_by_membership_source? (lambda (stage stages sources facts)
 	(if (not (membership_strategy? facts))
 		false
@@ -4394,7 +4190,7 @@ the logical lookup still carries an alias which no longer exists. */
 
 (define query_block_with_physical_membership_using (lambda (stages block)
 	(begin
-		(define physical_block (query_block_with_physical_requirement_choices block))
+		(define physical_block (query_block_with_physical_requirement_facts block))
 		(if (not (membership_strategy? (qb_facts physical_block)))
 			physical_block
 			(begin

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -3464,7 +3464,7 @@ physical alternative. */
 				(* (+ candidate_rows projected_rows) 8) 0 projection_rows 0.65)
 			projection_rows 0.65)
 			candidate_cache_cost projection_rows 0.65))
-		(define downstream_cost (planner_direct_presence_probe_cost
+		(define downstream_cost (planner_membership_direct_probe_cost
 			(* projected_rows
 				(membership_work_value work (quote membership_downstream_probe_branches) 0))))
 		(define carrier_cost (planner_cost_add base_cost downstream_cost projected_rows 0.65))
@@ -3531,7 +3531,7 @@ expression, and RecSet components used by the other membership carriers. */
 			(* projection_rows planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
 			0 driver_rows 0.65)
-			(planner_direct_presence_probe_cost
+			(planner_membership_direct_probe_cost
 				(* driver_rows candidate_density
 					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			driver_rows 0.65))))
@@ -3542,7 +3542,7 @@ expression, and RecSet components used by the other membership carriers. */
 		/* A driver membership check lowers each candidate branch to an indexed
 		point-presence probe. Keep that storage subscan distinct from the ordered
 		candidate-key index calibrated below. */
-		(planner_direct_presence_probe_cost probes))))
+		(planner_membership_direct_probe_cost probes))))
 
 (define membership_ordered_driver_probe_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
 	(begin
@@ -3568,7 +3568,7 @@ expression, and RecSet components used by the other membership carriers. */
 					(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65))
 			visited_rows 0.65))
 		(define carrier_cost (planner_cost_add base_cost
-			(planner_direct_presence_probe_cost
+			(planner_membership_direct_probe_cost
 				(* visited_rows
 					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			visited_rows 0.65))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2918,17 +2918,21 @@ the auto-index chooses the concrete access path on both tables. */
 /* Cost one physical tree edge once and return (strategy RecSet-expression).
 Consumers decide whether that RecSet is their scan carrier or a membership
 filter; they must not reconstruct the choice from enclosing block facts. */
-(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr)
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr downstream_probe_branches allow_driver_probe)
 	(begin
 		(define stage (nth membership 0))
 		/* Some late RecSet consumers are introduced after reorder telemetry was
 		attached. Reconstruct only the candidate's scalar work from the existing
 		logical stage; this is one formula walk, never an alternative plan build. */
 		(define facts (merge (list (membership_candidate_work_facts stage) (gs_facts stage))))
-		(define cost_facts (if (equal? consumer (quote aggregate))
-			(qassoc_set facts (quote membership_consumer) (quote aggregate))
-			facts))
-		(define driver_probe_supported (membership_driver_subscan_supported? stage))
+		(define cost_facts (qassoc_set
+			(if (equal? consumer (quote aggregate))
+				(qassoc_set facts (quote membership_consumer) (quote aggregate))
+				facts)
+			(quote membership_downstream_probe_branches)
+			(coalesceNil downstream_probe_branches 0)))
+		(define driver_probe_supported (and allow_driver_probe
+			(membership_driver_subscan_supported? stage)))
 		(define raw_expr (recset_project_join_expr_for_membership_raw src membership))
 		(if (or (nil? raw_expr)
 			(not (or
@@ -2940,8 +2944,12 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				measure here for callers that reached physical lowering without those
 				facts; repeating a selective estimate may build an entire adaptive text
 				index even though the sample itself is capped. */
+				(define stage_input (gs_input stage))
 				(define measured_estimate (if (nil? (qassoc_get facts (quote membership_candidate_estimated_rows) nil))
-					(planner_stage_filter_estimate (gs_input stage) 512)
+					(if (source_is_base_table? stage_input)
+						(planner_source_filter_estimate stage_input
+							(coalesceNil (qassoc_get facts (quote condition) true) true) 512)
+						(planner_stage_filter_estimate stage_input 512))
 					nil))
 				(define estimate_population (coalesceNil
 					(qassoc_get facts (quote membership_candidate_estimate_population) nil)
@@ -2954,7 +2962,9 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 					(qassoc_get measured_estimate (quote capped) false)))
 				(define candidate_input_rows (coalesceNil
 					(qassoc_get facts (quote membership_candidate_input_rows) nil)
-					(planner_stage_input_rows (gs_input stage))))
+					(if (source_is_base_table? stage_input)
+						(planner_source_row_count stage_input)
+						(planner_stage_input_rows stage_input))))
 				(define candidate_matching_rows (coalesceNil
 					(qassoc_get facts (quote membership_candidate_matching_rows) nil)
 					(qassoc_get measured_estimate (quote rows) nil)))
@@ -2995,11 +3005,28 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				feasible carrier pair outside this semantic/Top-K constraint. */
 				(define guarded_broad_order_driver
 					(qassoc_get facts (quote guarded_broad_order_driver) false))
+				(define branch_not_implied
+					(qassoc_get facts (quote membership_branch_not_implied) false))
+				/* The consumer determines which lazy driver operator is executable.
+				An ordered LIMIT probes one prepared RHS key index while it walks the
+				order. An ordinary filter/aggregate can instead lower the marker to
+				direct indexed presence probes over its already-filtered driver rows. */
+				(define ordered_driver_keyset_supported
+					(not (empty_list? (membership_keyset_bindings (list membership)))))
+				(define driver_strategy (if (and
+					(equal? consumer (quote order_limit))
+					ordered_driver_keyset_supported)
+					"driver_order_membership_probe"
+					"driver_filter_join_probe"))
 				(define candidate_cost (if known
 					(membership_projection_cost candidate_input_rows candidate_rows driver_rows cost_facts)
 					nil))
 				(define driver_cost (if (and known driver_probe_supported)
-					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows cost_facts)
+					(if (equal? driver_strategy "driver_order_membership_probe")
+						(membership_ordered_driver_probe_cost
+							candidate_input_rows candidate_rows driver_rows cost_facts)
+						(membership_driver_probe_cost driver_rows
+							(qassoc_get facts (quote membership_candidate_probe_branches) 1)))
 					nil))
 				(define batch_cost_facts (if allow_ordered_batch
 					(merge (list
@@ -3023,17 +3050,20 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 					(list
 						(list (quote lambda) (list prefiltered_driver_var) prefiltered_body)
 						prefiltered_driver_expr)))
-				(define prefiltered_eligible (and
+				/* Executability is structural and must remain stable when an autoindex
+				refines cardinality after compilation. Selectivity affects the cost, not
+				whether CALIBRATE or a later recompile may choose this carrier. */
+				(define prefiltered_supported (and
 					(not (nil? prefiltered_expr))
 					(and (number? prefiltered_driver_rows)
-						(and (number? source_rows) (< prefiltered_driver_rows source_rows)))))
-				(define prefiltered_cost (if (and prefiltered_eligible (number? candidate_rows))
+						(number? source_rows))))
+				(define prefiltered_cost (if (and prefiltered_supported (number? candidate_rows))
 					(membership_prefiltered_candidate_cost
 						candidate_input_rows candidate_rows prefiltered_driver_rows cost_facts)
 					nil))
 				(define cost_choices (filter (list
 					(if (nil? candidate_cost) nil (list "candidate_keyset" candidate_cost))
-					(if (nil? driver_cost) nil (list "driver_order_membership_probe" driver_cost))
+					(if (nil? driver_cost) nil (list driver_strategy driver_cost))
 					(if (nil? batch_cost) nil (list "ordered_batch_accept" batch_cost))
 					(if (nil? prefiltered_cost) nil
 						(list "prefiltered_candidate_keyset" prefiltered_cost)))
@@ -3044,16 +3074,17 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(if (planner_cost_better? (cadr choice) (cadr best)) choice best))
 						(car cost_choices))))
 				(define normal_choice (if (and guarded_broad_order_driver driver_probe_supported)
-					"driver_order_membership_probe"
+					driver_strategy
 					(if (nil? cost_choice)
-						(if (and owns_requirement driver_probe_supported)
-							"driver_order_membership_probe" "candidate_keyset")
+						(if (and driver_probe_supported
+							(or owns_requirement branch_not_implied))
+							driver_strategy "candidate_keyset")
 						(car cost_choice))))
 				(define alternatives (merge (list
 					(cons "candidate_keyset"
-						(if driver_probe_supported (list "driver_order_membership_probe") '()))
+						(if driver_probe_supported (list driver_strategy) '()))
 					(if allow_ordered_batch (list "ordered_batch_accept") '())
-					(if prefiltered_eligible (list "prefiltered_candidate_keyset") '()))))
+					(if prefiltered_supported (list "prefiltered_candidate_keyset") '()))))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
 				(planner_record_physical_decision
@@ -3101,6 +3132,8 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							(list "candidate_filter_columns" (qassoc_get facts (quote membership_candidate_filter_columns) 0))
 							(list "candidate_map_columns" (qassoc_get facts (quote membership_candidate_map_columns) 1))
 							(list "candidate_cache_map_columns" (qassoc_get facts (quote membership_candidate_cache_map_columns) 2))
+							(list "candidate_cache_backed"
+								(qassoc_get facts (quote membership_candidate_cache_backed) false))
 							(list "candidate_expression_operations" (qassoc_get facts (quote membership_candidate_expression_operations) 0))
 							(list "candidate_expression_depth" (qassoc_get facts (quote membership_candidate_expression_depth) 0))
 							(list "candidate_broad_text_match_rows" (qassoc_get facts (quote membership_candidate_broad_text_match_rows) 0))
@@ -3120,9 +3153,9 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 								(list "reason" (if (equal? chosen "candidate_keyset") "selected" (if known "higher_total_ns_or_forced_alternative" "unknown_statistics_fallback")))
 								(list "cost" (if (nil? candidate_cost) '() (planner_cost_explain candidate_cost))))
 							(list
-								(list "plan" "driver_order_membership_probe")
-								(list "status" (if (equal? chosen "driver_order_membership_probe") "chosen" "rejected"))
-								(list "reason" (if (equal? chosen "driver_order_membership_probe") "selected" "higher_total_ns_or_forced_alternative"))
+								(list "plan" driver_strategy)
+								(list "status" (if (equal? chosen driver_strategy) "chosen" "rejected"))
+								(list "reason" (if (equal? chosen driver_strategy) "selected" "higher_total_ns_or_forced_alternative"))
 								(list "cost" (if (nil? driver_cost) '() (planner_cost_explain driver_cost))))
 							(if allow_ordered_batch
 								(list
@@ -3131,7 +3164,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 									(list "reason" (if (equal? chosen "ordered_batch_accept") "selected" "higher_total_ns_or_forced_alternative"))
 									(list "cost" (if (nil? batch_cost) '() (planner_cost_explain batch_cost))))
 								nil)
-							(if prefiltered_eligible
+							(if prefiltered_supported
 								(list
 									(list "plan" "prefiltered_candidate_keyset")
 									(list "status" (if (equal? chosen "prefiltered_candidate_keyset") "chosen" "rejected"))
@@ -3146,7 +3179,7 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 (define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define plan (recset_project_join_plan_for_membership_using
-			src membership consumer driver_rows_override allow_ordered_batch nil))
+			src membership consumer driver_rows_override allow_ordered_batch nil 0 true))
 		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 			(cadr plan)
 			nil))))
@@ -5467,8 +5500,9 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
 metadata.physical_calibration. Each observation is an executed, forced
 EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
+(define planner_direct_presence_probe_row_ns 20243)
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
-	(planner_cost 0 0 (* probe_rows 48685) 0 0 0 0 0 probe_rows 0.75)))
+	(planner_cost 0 0 (* probe_rows planner_direct_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
@@ -5478,20 +5512,20 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
 		(* probe_rows 1) 0 probe_rows 0.6)))
 
-(define planner_membership_scan_invocation_ns 1)
-(define planner_membership_scan_row_ns 178)
+(define planner_membership_scan_invocation_ns 122080)
+(define planner_membership_scan_row_ns 1)
 (define planner_membership_filter_column_row_ns 1)
-(define planner_membership_map_column_row_ns 28)
-(define planner_membership_expression_operation_row_ns 98)
+(define planner_membership_map_column_row_ns 32)
+(define planner_membership_expression_operation_row_ns 220)
 (define planner_membership_broad_text_match_row_ns 1)
-(define planner_membership_broad_text_match_byte_ns 4)
+(define planner_membership_broad_text_match_byte_ns 2)
 (define planner_membership_recset_startup_ns 1)
 (define planner_membership_recset_build_row_ns 1)
 (define planner_membership_recset_probe_row_ns 1)
-(define planner_membership_recset_aggregate_row_ns 215)
-(define planner_membership_group_cache_startup_ns 17538872)
-(define planner_membership_group_cache_build_row_ns 11590)
-(define planner_membership_group_cache_probe_row_ns 132886)
-(define planner_membership_ordered_driver_input_row_ns 255)
-(define planner_ordered_batch_accept_startup_ns 1)
+(define planner_membership_recset_aggregate_row_ns 132)
+(define planner_membership_group_cache_startup_ns 4489531)
+(define planner_membership_group_cache_build_row_ns 1)
+(define planner_membership_group_cache_probe_row_ns 1)
+(define planner_membership_ordered_driver_input_row_ns 1)
+(define planner_membership_ordered_scan_invocation_ns 2523969)
 /* END GENERATED COST CONSTANTS */

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5500,9 +5500,13 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
 metadata.physical_calibration. Each observation is an executed, forced
 EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
-(define planner_direct_presence_probe_row_ns 20243)
+(define planner_scalar_presence_probe_row_ns 48685)
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
-	(planner_cost 0 0 (* probe_rows planner_direct_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+	(planner_cost 0 0 (* probe_rows planner_scalar_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+
+(define planner_membership_direct_probe_row_ns 28470)
+(define planner_membership_direct_probe_cost (lambda (probe_rows)
+	(planner_cost 0 0 (* probe_rows planner_membership_direct_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
@@ -5518,14 +5522,14 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_map_column_row_ns 32)
 (define planner_membership_expression_operation_row_ns 220)
 (define planner_membership_broad_text_match_row_ns 1)
-(define planner_membership_broad_text_match_byte_ns 2)
+(define planner_membership_broad_text_match_byte_ns 3)
 (define planner_membership_recset_startup_ns 1)
 (define planner_membership_recset_build_row_ns 1)
 (define planner_membership_recset_probe_row_ns 1)
-(define planner_membership_recset_aggregate_row_ns 132)
-(define planner_membership_group_cache_startup_ns 4489531)
+(define planner_membership_recset_aggregate_row_ns 149)
+(define planner_membership_group_cache_startup_ns 4825882)
 (define planner_membership_group_cache_build_row_ns 1)
 (define planner_membership_group_cache_probe_row_ns 1)
 (define planner_membership_ordered_driver_input_row_ns 1)
-(define planner_membership_ordered_scan_invocation_ns 2523969)
+(define planner_membership_ordered_scan_invocation_ns 2784159)
 /* END GENERATED COST CONSTANTS */

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3076,9 +3076,15 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				(define normal_choice (if (and guarded_broad_order_driver driver_probe_supported)
 					driver_strategy
 					(if (nil? cost_choice)
-						(if (and driver_probe_supported
-							(or owns_requirement branch_not_implied))
-							driver_strategy "candidate_keyset")
+						/* With no cardinality facts, adaptive batching is the only bounded
+						alternative: it preserves ORDER while increasing its candidate window
+						until LIMIT is satisfied. Candidate materialization and unbounded
+						driver filtering would both commit to unknown full-relation work. */
+						(if allow_ordered_batch
+							"ordered_batch_accept"
+							(if (and driver_probe_supported
+								(or owns_requirement branch_not_implied))
+								driver_strategy "candidate_keyset"))
 						(car cost_choice))))
 				(define alternatives (merge (list
 					(cons "candidate_keyset"

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2839,6 +2839,30 @@ NULL semantics, never the syntactic reason that introduced the stage. */
 		(list (quote >) (symbol value_col) 0)
 		(list (quote equal??) (symbol value_col) true))))
 
+/* A cache-backed carrier owns the preparation of the cache it reads. The
+query-block prelude must not also build a logical stage whose selected physical
+alternative is a raw RecSet or direct probe. */
+(define prepared_group_cache_expr (lambda (stage carrier)
+	(begin
+		(define raw_input (gs_input stage))
+		(define stamped_catalog (qassoc_get (gs_facts stage) (quote stage_catalog) '()))
+		(define stage_catalog (stage_catalog_with_nested
+			(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
+				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
+		(list (quote begin)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog stage)
+			carrier))))
+
+(define prepared_group_cache_recset_expr (lambda (stage)
+	(begin
+		(define cache (group_stage_cache stage))
+		(prepared_group_cache_expr stage
+			(list (quote scan_recset)
+				'(session "__memcp_tx")
+				(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
+				(list (quote list))
+				(list (quote lambda) '() true))))))
+
 (define exists_recset_project_join_expr (lambda (target_src stage)
 	(begin
 		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
@@ -2886,11 +2910,7 @@ the auto-index chooses the concrete access path on both tables. */
 			(define cache (group_stage_cache stage))
 			(list (quote recset_project_join)
 				'(session "__memcp_tx")
-				(list (quote scan_recset)
-					'(session "__memcp_tx")
-					(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
-					(list (quote list))
-					(list (quote lambda) '() true))
+				(prepared_group_cache_recset_expr stage)
 				(quoted_runtime_list (list "k0"))
 				(source_table_expr target_src)
 				(quoted_runtime_list (list target_col)))))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1949,6 +1949,19 @@ get_column refs to the source) are excluded automatically too. */
 							(not (scalar_aggregate_probe_stage? stage))
 							(contains? stage_output_ids (gs_id stage))))))))))
 
+/* A physical membership marker is the exclusive owner of its carrier. Stop at
+the marker instead of walking into the embedded logical stage; cache-backed
+alternatives prepare themselves, while raw RecSet and direct-probe alternatives
+must not pay for an unused group cache. */
+(define physical_membership_probe_stage_ids (lambda (expr)
+	(match expr
+		((symbol driver_membership_probe) stage _probe) (list (gs_id stage))
+		((quote driver_membership_probe) stage _probe) (list (gs_id stage))
+		((symbol driver_membership_subscan_probe) stage _probe) (list (gs_id stage))
+		((quote driver_membership_subscan_probe) stage _probe) (list (gs_id stage))
+		(cons _head tail) (merge_unique (map tail physical_membership_probe_stage_ids))
+		_ '())))
+
 (define query_block_stages_to_prepare_base_using (lambda (all_stages block)
 	(begin
 		(define sources (qb_sources block))
@@ -1957,10 +1970,14 @@ get_column refs to the source) are excluded automatically too. */
 		(define consumed_source_probe_ids (stage_output_source_ids (probe_output_sources_for_block
 			all_stages sources default_alias (qb_limit block) (qb_where block) (query_block_probe_consumers block))))
 		(define stage_output_ids (stage_output_source_ids sources))
+		(define physical_membership_stage_ids
+			(physical_membership_probe_stage_ids (query_block_probe_consumers block)))
 		(define direct (filter (qb_stages block) (lambda (stage)
 			(and
-				(stage_direct_prepare_source_visible? block sources default_alias stage)
-				(stage_direct_prepare_semantic_candidate? consumed_probe_ids consumed_source_probe_ids stage_output_ids stage)))))
+				(not (contains? physical_membership_stage_ids (gs_id stage)))
+				(and
+					(stage_direct_prepare_source_visible? block sources default_alias stage)
+					(stage_direct_prepare_semantic_candidate? consumed_probe_ids consumed_source_probe_ids stage_output_ids stage))))))
 		direct)))
 
 (define selected_group_cache_keys (lambda (stages)
@@ -2559,9 +2576,9 @@ path. */
 
 /* Computed membership keys are already stored canonically as k0 in the group
 cache. Probing that keytable is cheaper than first copying its rows into a
-query-local RecSet index. The surrounding physical prelude prepares the cache
-once; this closure performs only the indexed presence lookup for each ordered
-driver candidate. */
+query-local RecSet index. This selected carrier prepares its cache once before
+returning the closure; the closure then performs only the indexed presence
+lookup for each ordered driver candidate. */
 (define membership_cache_key_probe_expr (lambda (stage)
 	(begin
 		(define cache (group_stage_cache stage))
@@ -2569,16 +2586,17 @@ driver candidate. */
 		(define key_name "k0")
 		(define value_col (aggregate_col_name_using (gs_input stage) (car (gs_aggregates stage))))
 		(define filtercols (list key_name value_col))
-		(list (quote lambda) (list probe_var)
-			(list (quote scan_exists)
-				'(session "__memcp_tx")
-				(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
-				(cons (quote list) filtercols)
-				(list (quote lambda) (map filtercols symbol)
-					(list (quote and)
-						(list (quote equal??) (symbol key_name)
-							(list (quote outer) probe_var))
-						(stage_recset_value_filter_term stage value_col))))))))
+		(prepared_group_cache_expr stage
+			(list (quote lambda) (list probe_var)
+				(list (quote scan_exists)
+					'(session "__memcp_tx")
+					(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
+					(cons (quote list) filtercols)
+					(list (quote lambda) (map filtercols symbol)
+						(list (quote and)
+							(list (quote equal??) (symbol key_name)
+								(list (quote outer) probe_var))
+							(stage_recset_value_filter_term stage value_col)))))))))
 
 (define membership_keyset_parts (lambda (membership)
 	(begin

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2557,6 +2557,29 @@ path. */
 							(source_table_expr (nth first_descriptor 0)))
 							(equal? (nth descriptor 1) (nth first_descriptor 1))))) true))))))
 
+/* Computed membership keys are already stored canonically as k0 in the group
+cache. Probing that keytable is cheaper than first copying its rows into a
+query-local RecSet index. The surrounding physical prelude prepares the cache
+once; this closure performs only the indexed presence lookup for each ordered
+driver candidate. */
+(define membership_cache_key_probe_expr (lambda (stage)
+	(begin
+		(define cache (group_stage_cache stage))
+		(define probe_var (symbol "__membership_probe"))
+		(define key_name "k0")
+		(define value_col (aggregate_col_name_using (gs_input stage) (car (gs_aggregates stage))))
+		(define filtercols (list key_name value_col))
+		(list (quote lambda) (list probe_var)
+			(list (quote scan_exists)
+				'(session "__memcp_tx")
+				(list (quote table) (group_cache_schema cache) (group_cache_relation cache))
+				(cons (quote list) filtercols)
+				(list (quote lambda) (map filtercols symbol)
+					(list (quote and)
+						(list (quote equal??) (symbol key_name)
+							(list (quote outer) probe_var))
+						(stage_recset_value_filter_term stage value_col))))))))
+
 (define membership_keyset_parts (lambda (membership)
 	(begin
 		(define descriptor (membership_keyset_descriptor membership))
@@ -2565,7 +2588,17 @@ path. */
 				(define stage (nth membership 0))
 				(define input (gs_input stage))
 				(if (not (union_block? input))
-					nil
+					(if (and (group_stage? stage)
+						(equal? (count (gs_keys stage)) 1))
+						(begin
+							(define cache (group_stage_cache stage))
+							(list
+								(list (quote table)
+									(group_cache_schema cache) (group_cache_relation cache))
+								"k0"
+								(membership_cache_key_probe_expr stage)
+								(quote group_cache_probe)))
+						nil)
 					(begin
 						(define carriers (map (union_branches input) candidate_recset_branch_carrier))
 						(define supported (and (not (empty_list? carriers))
@@ -2615,27 +2648,45 @@ path. */
 				(and same
 					(and (equal? (nth item 0) (nth (car parts) 0))
 						(equal? (nth item 1) (nth (car parts) 1))))) true)))
-		(if (not compatible)
+		(if (not supported)
 			'()
+			(if (not compatible)
+				(merge (map memberships (lambda (membership)
+					(membership_keyset_bindings (list membership)))))
 			(begin
-				(define keyset_var (symbol "__membership_keyset"))
+				(define keyset_var (symbol (concat "__membership_keyset_"
+					(stable_structural_hash (map memberships (lambda (membership)
+						(gs_id (nth membership 0)))) true))))
+				(define group_cache_probe (and (single_source? parts)
+					(equal? (count (car parts)) 4)))
 				(define candidate_recsets (map parts (lambda (item) (nth item 2))))
 				(define candidate_recset (if (single_source? candidate_recsets)
 					(car candidate_recsets)
 					(list (quote recset_union) (cons (quote list) candidate_recsets))))
-				(define keyset_expr (list (quote recset_key_index)
-					'(session "__memcp_tx")
-					candidate_recset
-					(quoted_runtime_list (list (nth (car parts) 1)))))
+				(define keyset_expr (if group_cache_probe
+					(nth (car parts) 2)
+					(list (quote recset_key_index)
+						'(session "__memcp_tx")
+						candidate_recset
+						(quoted_runtime_list (list (nth (car parts) 1))))))
 				(map memberships (lambda (membership)
-					(list membership keyset_var keyset_expr))))))))
+					(list membership keyset_var keyset_expr)))))))))
+
+(define unique_membership_keyset_bindings (lambda (bindings)
+	(reduce bindings (lambda (unique binding)
+		(if (reduce unique (lambda (found existing)
+			(or found (equal? (nth existing 1) (nth binding 1)))) false)
+			unique
+			(cons binding unique))) '())))
 
 (define wrap_membership_keyset_bindings (lambda (bindings body)
 	(if (empty_list? bindings)
 		body
-		(list
-			(list (quote lambda) (list (nth (car bindings) 1)) body)
-			(nth (car bindings) 2)))))
+		(begin
+			(define unique (reverse (unique_membership_keyset_bindings bindings)))
+			(cons
+				(list (quote lambda) (map unique (lambda (binding) (nth binding 1))) body)
+				(map unique (lambda (binding) (nth binding 2))))))))
 
 (define replace_driver_membership_keyset_markers (lambda (expr bindings)
 	(begin
@@ -2909,11 +2960,8 @@ RecSet; membership edges retain their own physical operators. */
 						nil (car memberships)) (and scan_order_supported bounded)))
 				(define allow_ordered_batch_binding (and scan_order_supported
 					(and bounded
-						(and (equal? (count memberships) 1)
-							(and (not (membership_expr_has_driver_alternative? condition))
-								(and (or (empty_list? order_items)
-									(not (empty_list? (source_primary_key_columns src))))
-									(ordered_batch_stage_supported? (nth (car memberships) 0))))))))
+						(or (empty_list? order_items)
+							(not (empty_list? (source_primary_key_columns src)))))))
 				/* This node-local lowering is the sole carrier decision. Older code
 				selected a keyset from block-level broadness facts before reaching this
 				point; that duplicate choice could label an alternative as selected while
@@ -3042,10 +3090,14 @@ RecSet; membership edges retain their own physical operators. */
 				(define filter_expr (list (quote lambda)
 					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 					(lower_column_expr_for_alias src filter_condition)))
-				(define remaining_memberships (driver_memberships_for_source src filter_condition))
-				(define remaining_batch_memberships (ordered_batch_membership_terms src filter_condition))
-				(define batch_filter (if (and (equal? table_expr source_table)
-					(equal? (count remaining_memberships) (count remaining_batch_memberships)))
+				(define remaining_batch_memberships (filter
+					(ordered_batch_membership_terms src filter_condition)
+					(lambda (membership) (ordered_batch_stage_supported? (nth membership 0)))))
+				/* Membership markers which cannot project a batch RecSet remain in the
+				residual expression and lower through the ordinary probe machinery. This
+				makes adaptive ordered batching a property of the consuming scan, not of
+				one privileged predicate shape. */
+				(define batch_filter (if (equal? table_expr source_table)
 					(ordered_batch_filter_expr (list src) alias src filter_condition
 						remaining_batch_memberships (probe_context_row_count (list src)) '() true)
 					nil))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2850,7 +2850,7 @@ RecSet; membership edges retain their own physical operators. */
 				planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
 			0 visited_rows 0.55)
-			(planner_direct_presence_probe_cost
+			(planner_membership_direct_probe_cost
 				(* visited_rows
 					(membership_candidate_density candidate_input_rows candidate_rows facts)
 					(qassoc_get facts (quote membership_downstream_probe_branches) 0)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2127,8 +2127,7 @@ probes remain recipes and still execute after root braking. */
 	(prepare_simple_query_block_physical_core_chosen
 		(query_block_with_physical_membership_choices
 			(query_block_with_physical_membership_using
-				(query_block_stage_lookup block)
-				(query_block_with_physical_requirement_choices block))))))
+				(query_block_stage_lookup block) block)))))
 
 (define lower_simple_query_block_with_cataloged_stages (lambda (block)
 	(begin
@@ -2709,7 +2708,7 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 						(list (nth marker 0) (nth marker 1) target_col term)))))))
 		(lambda (membership) (not (nil? membership))))))
 
-(define ordered_batch_filter_expr (lambda (src condition memberships)
+(define ordered_batch_filter_expr (lambda (sources default_alias src condition memberships probe_work_rows acceptance_cols acceptance_probe)
 	(begin
 		(define input_batch (symbol "__ordered_input_batch"))
 		(define local_batch (symbol "__ordered_local_batch"))
@@ -2725,7 +2724,8 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 				(list (quote lambda)
 					(map residual_cols (lambda (col)
 						(scan_callback_symbol_for_alias (source_alias src) col)))
-					(lower_column_expr_for_alias src residual)))))
+					(lower_column_expr_for_join_truth_context
+						sources default_alias residual probe_work_rows)))))
 		(define membership_exprs (map memberships (lambda (membership)
 			(batch_membership_expr src membership local_batch))))
 		(if (reduce membership_exprs (lambda (unsupported expr)
@@ -2734,10 +2734,21 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 			(list (quote lambda) (list input_batch)
 				(list
 					(list (quote lambda) (list local_batch)
-						(if (empty_list? membership_exprs)
+						(begin
+							(define accepted (if (empty_list? membership_exprs)
 							local_batch
 							(list (quote recset_intersect)
 								(cons (quote list) (cons local_batch membership_exprs)))))
+							(if (equal? acceptance_probe true)
+								accepted
+								(list (quote scan_recset)
+									'(session "__memcp_tx")
+									accepted
+									(cons (quote list) acceptance_cols)
+									(list (quote lambda)
+										(map acceptance_cols (lambda (col)
+											(scan_callback_symbol_for_alias (source_alias src) col)))
+										acceptance_probe)))))
 					locally_filtered))))))
 
 /* Produce the exact driver subset shared by a prefiltered membership tree.
@@ -2791,6 +2802,16 @@ RecSet; membership edges retain their own physical operators. */
 			(qassoc_get facts (quote membership_candidate_scan_invocations) probe_branches)))
 		(define driver_scan_invocations (max 1
 			(qassoc_get facts (quote membership_driver_scan_invocations) 1)))
+		/* scan_order_batch_accept requests disjoint windows, but the current
+		ordered primitive has no resumable cursor. Every window therefore pays
+		for another ordered traversal of the driver, irrespective of how few
+		rows that window returns. Keep this explicit so calibration can price
+		the implementation that is actually emitted. */
+		/* Reuse the calibrated scan_order work unit. Without a resumable cursor,
+		each batch repeats the same quadratic ordered traversal; a separate linear
+		coefficient would describe the same operator inconsistently. */
+		(define ordered_driver_work_units (* batches
+			(/ (* driver_input_rows driver_input_rows) 1000000)))
 		(define candidate_fraction (if (and (number? driver_input_rows) (> driver_input_rows 0))
 			(min 1 (/ visited_rows driver_input_rows)) 1))
 		/* Disjoint driver batches may contain the same foreign-key value. In the
@@ -2807,11 +2828,13 @@ RecSet; membership edges retain their own physical operators. */
 		(define broad_text_bytes (*
 			(qassoc_get facts (quote membership_candidate_broad_text_match_bytes) 0)
 			candidate_repeat_fraction))
-		(planner_cost
-			(+ planner_ordered_batch_accept_startup_ns
-				(* (+ driver_scan_invocations (* batches candidate_scan_invocations))
-					planner_membership_scan_invocation_ns))
+		(planner_cost_add (planner_cost
+			(+ (* (+ driver_scan_invocations (* batches candidate_scan_invocations))
+					planner_membership_scan_invocation_ns)
+				(* batches driver_scan_invocations
+					planner_membership_ordered_scan_invocation_ns))
 			(+
+				(* ordered_driver_work_units planner_membership_ordered_driver_input_row_ns)
 				(* (+ visited_rows candidate_work_rows projection_rows)
 					planner_membership_scan_row_ns)
 				(* candidate_work_rows
@@ -2826,7 +2849,19 @@ RecSet; membership edges retain their own physical operators. */
 			(* projection_rows
 				planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
-			0 visited_rows 0.55))))
+			0 visited_rows 0.55)
+			(planner_direct_presence_probe_cost
+				(* visited_rows
+					(membership_candidate_density candidate_input_rows candidate_rows facts)
+					(qassoc_get facts (quote membership_downstream_probe_branches) 0)))
+			visited_rows 0.55))))
+
+(define membership_row_number_consumer? (lambda (membership direct_order_limit)
+	(and (not (nil? membership))
+		(and (not direct_order_limit)
+			(equal? (qassoc_get (gs_facts (nth membership 0))
+				(quote membership_consumer) nil)
+				(quote order_limit))))))
 
 (define lower_single_source_query_block (lambda (block)
 	(begin
@@ -2866,16 +2901,12 @@ RecSet; membership edges retain their own physical operators. */
 				(define scan_order_supported (order_items_belong_to_source? src order_items))
 				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
 				(define memberships (driver_memberships_for_source src condition))
-				/* For a bounded ordered driver, union branch-local source candidates
-				before building one immutable key index. The driver stays a scan_order
-				and probes that index in its filter, so Top-K braking remains effective
-				without projecting every candidate into a target RecSet. */
-				(define keyset_membership_probe (ordered_driver_membership_keyset? (qb_facts block)))
-				(define membership_keysets (if keyset_membership_probe
-					(membership_keyset_bindings memberships)
-					'()))
-				(define use_membership_keysets (and keyset_membership_probe
-					(equal? (count membership_keysets) (count memberships))))
+				/* A derived Top-K has already moved ORDER/LIMIT into its row-number
+				consumer. The logical membership requirement retains that ownership even
+				when this block no longer carries a direct ORDER/LIMIT pair. */
+				(define row_number_membership_consumer
+					(membership_row_number_consumer? (if (empty_list? memberships)
+						nil (car memberships)) (and scan_order_supported bounded)))
 				(define allow_ordered_batch_binding (and scan_order_supported
 					(and bounded
 						(and (equal? (count memberships) 1)
@@ -2883,21 +2914,11 @@ RecSet; membership edges retain their own physical operators. */
 								(and (or (empty_list? order_items)
 									(not (empty_list? (source_primary_key_columns src))))
 									(ordered_batch_stage_supported? (nth (car memberships) 0))))))))
-				(define forced_candidate_membership (reduce memberships (lambda (forced membership)
-					(begin
-						(define override (planner_physical_override
-							(concat "membership_carrier:" (gs_id (nth membership 0)))))
-						(or forced (or (equal? override "candidate_keyset")
-							(or (equal? override "ordered_batch_accept")
-								(equal? override "prefiltered_candidate_keyset")))))) false))
-				(define prefer_membership_filter (and scan_order_supported
-					(and bounded
-						(and (not forced_candidate_membership)
-							(and (qassoc_get (qb_facts block) (quote membership_driver_alternative) false)
-								(membership_estimate_broad? (qb_facts block)))))))
-				(define membership_plans (if (or keyset_membership_probe prefer_membership_filter)
-					'()
-					(filter (map memberships (lambda (membership)
+				/* This node-local lowering is the sole carrier decision. Older code
+				selected a keyset from block-level broadness facts before reaching this
+				point; that duplicate choice could label an alternative as selected while
+				emitting the correlated subscan fallback. */
+				(define membership_plans (filter (map memberships (lambda (membership)
 						(begin
 							(define plan (recset_project_join_plan_for_membership_using
 								src membership
@@ -2905,10 +2926,24 @@ RecSet; membership edges retain their own physical operators. */
 								(if (and scan_order_supported bounded)
 									(probe_limit_work_rows (qb_limit block)) nil)
 								allow_ordered_batch_binding
-								(prefiltered_driver_recset_expr_for_membership
-									src source_table condition membership)))
+							(prefiltered_driver_recset_expr_for_membership
+								src source_table condition membership)
+								(+ (count (acceptance_required_sources
+									(membership_downstream_sources (qb_sources block) src membership)
+									alias raw_condition))
+									(count (expr_probe_stages raw_condition)))
+								(not row_number_membership_consumer)))
 							(if (nil? plan) nil (list membership plan)))))
-						(lambda (entry) (not (nil? entry))))))
+					(lambda (entry) (not (nil? entry)))))
+				(define driver_memberships (map (filter membership_plans (lambda (entry)
+					(equal? (car (nth entry 1)) "driver_order_membership_probe")))
+					(lambda (entry) (nth entry 0))))
+				/* For a bounded ordered driver, union branch-local candidates into one
+				immutable key index. The chosen physical plans, not a logical fact or
+				expression-shape heuristic, are the authority for this binding. */
+				(define membership_keysets (membership_keyset_bindings driver_memberships))
+				(define use_membership_keysets (and (not (empty_list? driver_memberships))
+					(equal? (count membership_keysets) (count driver_memberships))))
 				(define membership_bindings (filter (map membership_plans (lambda (entry)
 					(begin
 						(define membership (nth entry 0))
@@ -2919,18 +2954,15 @@ RecSet; membership edges retain their own physical operators. */
 							nil))))
 					(lambda (binding) (not (nil? binding)))))
 				(define bound_memberships (map membership_bindings (lambda (binding) (nth binding 0))))
-				(define membership_formula (if keyset_membership_probe
-					nil
-					(driver_membership_recset_formula src condition membership_bindings)))
+				(define membership_formula
+					(driver_membership_recset_formula src condition membership_bindings))
 				/* A membership predicate which is implied by the whole WHERE clause is
 				eligible to become the scan driver. A branch-local predicate below OR is
 				not: its RecSet must remain a probe or rows accepted by sibling branches
 				would disappear. This distinction also preserves the established fast
 				single-IN path while allowing several guarded RecSets in one scan. */
 				(define direct_membership (driver_membership_for_source src condition))
-				(define membership_formula_driver (and
-					(not (nil? membership_formula))
-					(not prefer_membership_filter)))
+				(define membership_formula_driver (not (nil? membership_formula)))
 				(define membership_formula_residual (if membership_formula_driver
 					(strip_driver_membership_formula_terms condition (car membership_formula))
 					condition))
@@ -2956,20 +2988,21 @@ RecSet; membership edges retain their own physical operators. */
 				(define membership_driver (and
 					(not membership_formula_driver)
 					(and (not (nil? direct_membership))
-						(and (not prefer_membership_filter)
-							(and (not (empty_list? membership_bindings))
+						(and (not (empty_list? membership_bindings))
 								(and (empty_list? (cdr membership_bindings))
-									(equal? direct_membership (car bound_memberships))))))))
+									(equal? direct_membership (car bound_memberships)))))))
 				(define membership_filter (and
 					(not (or membership_driver membership_formula_driver))
 					(not (empty_list? membership_bindings))))
-				(define filter_condition (if use_membership_keysets
-					(replace_driver_membership_keyset_markers condition membership_keysets)
-					(if membership_formula_driver
+				(define candidate_filter_condition (if membership_formula_driver
 						(if membership_formula_difference_driver true membership_formula_residual)
 						(if membership_driver
 							(strip_driver_membership_for_source src condition direct_membership)
-							(replace_driver_membership_markers src condition bound_memberships)))))
+							(replace_driver_membership_markers src condition bound_memberships))))
+				(define filter_condition (if use_membership_keysets
+					(replace_driver_membership_keyset_markers
+						candidate_filter_condition membership_keysets)
+					candidate_filter_condition))
 				(define filtercols (merge_unique (list
 					(if membership_filter (list "$recset_contains") '())
 					(extract_columns_for_alias src filter_condition))))
@@ -3013,7 +3046,8 @@ RecSet; membership edges retain their own physical operators. */
 				(define remaining_batch_memberships (ordered_batch_membership_terms src filter_condition))
 				(define batch_filter (if (and (equal? table_expr source_table)
 					(equal? (count remaining_memberships) (count remaining_batch_memberships)))
-					(ordered_batch_filter_expr src filter_condition remaining_batch_memberships)
+					(ordered_batch_filter_expr (list src) alias src filter_condition
+						remaining_batch_memberships (probe_context_row_count (list src)) '() true)
 					nil))
 				(define use_batch_accept (and (not (nil? batch_filter))
 					(reduce membership_plans (lambda (chosen entry)
@@ -3361,6 +3395,18 @@ either bound a real row or supplied the synthetic NULL row. */
 		(filter (coalesceNil sources '()) (lambda (src)
 			(contains? required (source_alias src)))))))
 
+/* Carrier costing happens at one scan-tree edge, but rejecting LEFT JOIN
+sources may already sit in its continuation. Derive them from the complete
+source catalog; exclude only the driver and the membership stage whose carrier
+is being compared. acceptance_required_sources retains SQL NULL-extension
+semantics and drops projection-only nullable lookups. */
+(define membership_downstream_sources (lambda (sources driver_src membership)
+	(filter (coalesceNil sources '()) (lambda (candidate)
+		(and (not (equal? (source_alias candidate) (source_alias driver_src)))
+			(not (and (stage_output_relation? (source_relation candidate))
+				(equal? (stage_output_relation_id (source_relation candidate))
+					(gs_id (nth membership 0))))))))))
+
 /* The ordered root remains the storage driver while its continuation may emit
 zero, one, or many complete values. stream_window_reduce owns SQL OFFSET/LIMIT
 over those values, so neither driver cardinality nor a scalar-purpose tag can
@@ -3371,44 +3417,69 @@ move the window to the wrong tree level. */
 		(define ordered_sources (join_optimizer_sources_for_order all_sources ordered_aliases))
 		(define src (car ordered_sources))
 		(define remaining_sources (cdr ordered_sources))
+		(define alias (source_alias src))
 		(define offset (coalesceNil offset_value 0))
 		(define limit (coalesceNil limit_value -1))
 		(define target (if (< limit 0) -1 (+ offset limit)))
 		(define acceptance_probe_work_rows (coalesceNil
 			(probe_limit_work_rows limit_value)
 			(if (< target 0) nil target)))
-		(define scalar_carrier (physical_scalar_truth_carrier
-			all_sources src default_alias final_condition acceptance_probe_work_rows stages))
-		(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
-		(define carrier_condition (if (nil? scalar_probe) final_condition
-			(rewrite_physical_scalar_probe_as_true scalar_probe final_condition)))
-		(define carrier_needed_exprs (if (nil? scalar_probe) needed_exprs
-			(rewrite_physical_scalar_probe_as_true scalar_probe needed_exprs)))
 		/* The ordered driver is consumed here. Preserve the optimizer's remaining
 		subtree instead of rebuilding a left-deep tree from the source catalog. */
 		(define remaining_plan (join_optimizer_tree_without_aliases
 			plan (list (source_alias src))))
-		(define alias (source_alias src))
-		(define condition_parts (physical_partition_condition default_alias src remaining_sources carrier_condition))
-		(define local_condition (nth condition_parts 0))
-		(define remaining_condition (combine_where
-			(nth condition_parts 2)
-			(join_optimizer_node_condition (join_optimizer_tree_predicates plan))))
-		(define condition (combine_where (source_join_expr src) local_condition))
+		(define raw_condition_parts (physical_partition_condition
+			default_alias src remaining_sources final_condition))
+		(define raw_condition (combine_where
+			(source_join_expr src) (nth raw_condition_parts 0)))
 		(define order_parts (split_order_items_for_join_driver
-			ordered_sources default_alias src order_items stages carrier_condition '()))
+			ordered_sources default_alias src order_items stages final_condition '()))
 		(define driver_order_items (nth order_parts 0))
 		(define remaining_order_items (nth order_parts 1))
-		(define membership (driver_membership_for_source src condition))
+		(define membership (driver_membership_for_source src raw_condition))
+		/* A RecSet batch represents driver membership, not join multiplicity. The
+		consumer is therefore available exactly when the remaining join tree is a
+		chain of 0:1/1:1 lookups. Predicate complexity is deliberately not a gate:
+		the ordinary expression and probe lowerers run inside the smaller batch. */
+		(define allow_ordered_batch (and (not (nil? membership))
+			(and (>= target 0)
+				(and (not (empty_list? driver_order_items))
+					(and (ordered_batch_stage_supported? (nth membership 0))
+						(and (not (expr_refs_stage_output_alias? final_condition))
+							(downstream_sources_at_most_one_driver_row?
+								ordered_sources default_alias final_condition stages)))))))
 		(define membership_plan (if (nil? membership) nil
 			(recset_project_join_plan_for_membership_using src membership
 				(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter))
 				(if (query_limit_active? offset_value limit_value)
 					(probe_limit_work_rows limit_value) nil)
-				false
+				allow_ordered_batch
 				(prefiltered_driver_recset_expr_for_membership
-					src (source_table_expr_using stages src) condition membership))))
+					src (source_table_expr_using stages src) raw_condition membership)
+				(+ (count (acceptance_required_sources
+					remaining_sources default_alias final_condition))
+					(count (expr_probe_stages final_condition)))
+				true)))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
+		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
+		/* A scalar truth carrier over the complete driver would defeat adaptive
+		batching. When the batch alternative wins, keep the scalar marker in the
+		predicate and lower it with the batch cardinality inside scan_recset. */
+		(define scalar_carrier (if use_batch_accept nil
+			(physical_scalar_truth_carrier
+				all_sources src default_alias final_condition acceptance_probe_work_rows stages)))
+		(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
+		(define carrier_condition (if (nil? scalar_probe) final_condition
+			(rewrite_physical_scalar_probe_as_true scalar_probe final_condition)))
+		(define carrier_needed_exprs (if (nil? scalar_probe) needed_exprs
+			(rewrite_physical_scalar_probe_as_true scalar_probe needed_exprs)))
+		(define condition_parts (physical_partition_condition
+			default_alias src remaining_sources carrier_condition))
+		(define local_condition (nth condition_parts 0))
+		(define remaining_condition (combine_where
+			(nth condition_parts 2)
+			(join_optimizer_node_condition (join_optimizer_tree_predicates plan))))
+		(define condition (combine_where (source_join_expr src) local_condition))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
 			(or (equal? membership_strategy "candidate_keyset")
@@ -3423,7 +3494,8 @@ move the window to the wrong tree level. */
 			(membership_keyset_bindings (list membership))
 			'()))
 		(define use_membership_keyset (not (empty_list? membership_keysets)))
-		(define effective_membership (if (nil? membership_table_expr) nil membership))
+		(define effective_membership (if (or use_batch_accept
+			(not (nil? membership_table_expr))) membership nil))
 		(define effective_condition (if use_membership_keyset
 			(replace_driver_membership_keyset_markers condition membership_keysets)
 			(strip_driver_membership_for_source src condition effective_membership)))
@@ -3433,13 +3505,11 @@ move the window to the wrong tree level. */
 		query-scoped key index; unsupported computed keys retain the established probe
 		fallback and its separately calibrated cost. */
 		(define filter_condition effective_condition)
-		/* A scalar probe already owns a nested relational callback. Copying it into
-		the scan_order acceptance callback adds another outer scope and would make
-		that copy disagree with the projection continuation. Evaluate it once in
-		the complete join and let stream_window_reduce count emitted rows. */
+		/* Stage-output column references require a relational source and cannot be
+		read directly from the driver callback. Scalar/EXISTS probe markers are not
+		deferred: lowering them at batch cardinality is the purpose of this path. */
 		(define defer_complex_acceptance
-			(or (expr_refs_stage_output_alias? remaining_condition)
-				(not (empty_list? (expr_probe_stages remaining_condition)))))
+			(expr_refs_stage_output_alias? remaining_condition))
 		/* Acceptance runs before OFFSET/LIMIT and therefore contains only joins
 		which can reject a driver row. Projection-only nullable lookups belong to
 		the map callback after the native window and must not be probed twice. */
@@ -3479,6 +3549,13 @@ move the window to the wrong tree level. */
 		(define acceptance_expr (list (quote lambda)
 			(map acceptance_cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 			acceptance_probe))
+		(define batch_filter (if use_batch_accept
+			(ordered_batch_filter_expr all_sources default_alias src condition
+				(list membership) acceptance_probe_work_rows acceptance_cols acceptance_probe)
+			nil))
+		(if (and use_batch_accept (nil? batch_filter))
+			(neumann_fail "build_queryplan" "chosen ordered batch membership has no executable filter")
+			true)
 		(define projection_probe_work_rows (coalesceNil
 			(probe_limit_work_rows limit_value)
 			acceptance_probe_work_rows))
@@ -3487,28 +3564,45 @@ move the window to the wrong tree level. */
 			(value_builder projection_probe_work_rows scalar_probe)))
 		(define mapcols (join_cols_for_alias all_sources default_alias alias carrier_needed_exprs))
 		(define projection (build_join_scan_pipeline_using_recipe
-			schema all_sources remaining_plan default_alias carrier_needed_exprs remaining_condition row_expr
+			schema all_sources remaining_plan default_alias carrier_needed_exprs
+			(if use_batch_accept true remaining_condition) row_expr
 			remaining_order_items 0 -1 true projection_probe_work_rows nil stages nil))
 		(define map_expr (list (quote lambda)
 			(map mapcols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 			projection))
-		(define scan_expr (list (quote scan_order)
-			'(session "__memcp_tx")
-			(if (nil? scalar_carrier)
-				(coalesceNil membership_table_expr (source_table_expr_using stages src))
-				(nth scalar_carrier 1))
-			(cons (quote list) filtercols)
-			filter_expr
-			(cons (quote list) (scan_order_sort_columns_for_join_driver
-				ordered_sources default_alias src driver_order_items stages carrier_condition))
-			(cons (quote list) (order_relations_for_source src driver_order_items))
-			0 0 (if defer_complex_acceptance -1 target)
-			(cons (quote list) mapcols)
-			map_expr nil nil false nil
-			(cons (quote list) acceptance_cols)
-			acceptance_expr))
+		(define ordercols (scan_order_sort_columns_for_join_driver
+			ordered_sources default_alias src driver_order_items stages carrier_condition))
+		(define tiebreaker_cols (if use_batch_accept
+			(filter (source_primary_key_columns src)
+				(lambda (col) (not (contains? ordercols col)))) '()))
+		(define physical_ordercols (merge (list ordercols tiebreaker_cols)))
+		(define physical_orderdirs (merge (list
+			(order_relations_for_source src driver_order_items)
+			(map tiebreaker_cols (lambda (col)
+				(canonical_order_relation < (source_column_order_collation src col)))))))
+		(define table_expr (if (nil? scalar_carrier)
+			(coalesceNil membership_table_expr (source_table_expr_using stages src))
+			(nth scalar_carrier 1)))
+		(define scan_expr (if use_batch_accept
+			(list (quote scan_order_batch_accept)
+				'(session "__memcp_tx") table_expr batch_filter
+				(cons (quote list) physical_ordercols)
+				(cons (quote list) physical_orderdirs)
+				0 offset limit
+				(cons (quote list) mapcols) map_expr nil nil false)
+			(list (quote scan_order)
+				'(session "__memcp_tx") table_expr
+				(cons (quote list) filtercols) filter_expr
+				(cons (quote list) physical_ordercols)
+				(cons (quote list) physical_orderdirs)
+				0 0 (if defer_complex_acceptance -1 target)
+				(cons (quote list) mapcols)
+				map_expr nil nil false nil
+				(cons (quote list) acceptance_cols)
+				acceptance_expr)))
 		(define window_expr (list (quote stream_window_reduce)
-			offset limit reduce_expr neutral_expr
+			(if use_batch_accept 0 offset) (if use_batch_accept -1 limit)
+			reduce_expr neutral_expr
 			(list (quote lambda) (list emit_value) scan_expr)))
 		(if use_membership_keyset
 			(wrap_membership_keyset_bindings membership_keysets window_expr)
@@ -4007,18 +4101,41 @@ exact parameter value. */
 		(define delay_limit_after_join (ordered_join_limit_requires_complete_rows?
 			(join_optimizer_sources_for_order all_sources (cons alias future_aliases))
 			default_alias final_condition offset_value limit_value stages))
+		(define allow_ordered_batch (and (not (nil? membership))
+			(and (not delay_limit_after_join)
+				(and (not (empty_list? current_order_items))
+					(and (query_limit_active? offset_value limit_value)
+						(and (ordered_batch_stage_supported? (nth membership 0))
+							(downstream_sources_at_most_one_driver_row?
+								ordered_sources default_alias final_condition stages)))))))
+		/* A row-number pipeline owns the order/limit continuation itself. Its
+		logical requirement survives ORC/window lowering, whereas the stage may no
+		longer be present in this leaf's local catalog. It can consume a projected
+		RecSet but cannot execute a separate ordered-driver membership probe without
+		first materializing the derived window. */
+		(define direct_order_limit (and (not (empty_list? current_order_items))
+			(query_limit_active? offset_value limit_value)))
+		(define row_number_membership_consumer
+			(membership_row_number_consumer? membership direct_order_limit))
 		(define membership_plan (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
 			nil
 			(recset_project_join_plan_for_membership_using src membership
 				(if (join_scan_reduce? result_mode) (quote aggregate)
-					(if (query_limit_active? offset_value limit_value) (quote order_limit) (quote filter)))
+					(if (or direct_order_limit row_number_membership_consumer)
+						(quote order_limit) (quote filter)))
 				(if (and (not (empty_list? current_order_items))
 					(query_limit_active? offset_value limit_value))
 					(probe_limit_work_rows limit_value) nil)
-				false
+				allow_ordered_batch
 				(prefiltered_driver_recset_expr_for_membership
-					src (source_table_expr_using stages src) condition membership))))
+					src (source_table_expr_using stages src) condition membership)
+				(+ (count (acceptance_required_sources
+					(membership_downstream_sources all_sources src membership)
+					default_alias final_condition))
+					(count (expr_probe_stages final_condition)))
+				(not row_number_membership_consumer))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
+		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
 			(or (equal? membership_strategy "candidate_keyset")
@@ -4049,7 +4166,8 @@ exact parameter value. */
 					(list "limit_delayed" delay_limit_after_join)
 					(list "projection_built" (not (nil? membership_table_expr)))))))
 			nil)
-		(define effective_membership (if (nil? membership_table_expr) nil membership))
+		(define effective_membership (if (or use_batch_accept
+			(not (nil? membership_table_expr))) membership nil))
 		(define effective_condition (if use_membership_keyset
 			(replace_driver_membership_keyset_markers condition membership_keysets)
 			(strip_driver_membership_for_source src condition effective_membership)))
@@ -4128,6 +4246,10 @@ exact parameter value. */
 		(define filter_expr (list (quote lambda)
 			(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 			lowered_filter_condition))
+		(define batch_filter (if use_batch_accept
+			(ordered_batch_filter_expr all_sources default_alias src condition
+				(list membership) (probe_work_context_rows_for_alias probe_context alias) '() true)
+			nil))
 		(define continuation_expr (continuation remaining_condition row_expr remaining_order_items))
 		(define map_body (if (equal? post_outer_condition true)
 			continuation_expr
@@ -4145,7 +4267,26 @@ exact parameter value. */
 		(define scan_expr
 			(if (not (nil? row_number_stage_filter))
 				(build_join_row_number_scan_pipeline schema all_sources src default_alias needed_exprs remaining_condition row_expr row_number_stage_filter membership_var membership_filter column_recipe stages result_mode probe_context combines_state continuation outer_scan)
-				(if (and (empty_list? current_order_items) (not (query_limit_active? offset_value limit_value)))
+				(if use_batch_accept
+					(begin
+						(define ordercols (scan_order_sort_columns_for_join_driver
+							ordered_sources default_alias src current_order_items stages final_condition))
+						(define tiebreaker_cols (filter (source_primary_key_columns src)
+							(lambda (col) (not (contains? ordercols col)))))
+						(list (quote scan_order_batch_accept)
+							'(session "__memcp_tx")
+							table_expr batch_filter
+							(cons (quote list) (merge (list ordercols tiebreaker_cols)))
+							(cons (quote list) (merge (list
+								(order_relations_for_source src current_order_items)
+								(map tiebreaker_cols (lambda (col)
+									(canonical_order_relation <
+										(source_column_order_collation src col)))))))
+							0 (coalesceNil offset_value 0) (coalesceNil limit_value -1)
+							(cons (quote list) mapcols) map_expr reduce_expr
+							(join_scan_neutral_expr result_mode)
+							(or outer_scan (source_outer? src))))
+					(if (and (empty_list? current_order_items) (not (query_limit_active? offset_value limit_value)))
 					(list (quote scan)
 						'(session "__memcp_tx")
 						table_expr
@@ -4172,7 +4313,7 @@ exact parameter value. */
 						map_expr
 						reduce_expr
 						(join_scan_neutral_expr result_mode)
-						(or outer_scan (source_outer? src))))))
+						(or outer_scan (source_outer? src)))))))
 		(define membership_bound_scan (if membership_filter
 			(list
 				(list (quote lambda) (list membership_var) scan_expr)
@@ -6198,8 +6339,9 @@ ordering run. Storage artifacts begin in build_queryplan. */
 	(match expr
 		(cons head tail) (or
 			(physical_head_matches? head target)
-			(reduce tail (lambda (found item)
-				(or found (physical_expr_has_head? item target))) false))
+			(or (physical_expr_has_head? head target)
+				(reduce tail (lambda (found item)
+					(or found (physical_expr_has_head? item target))) false)))
 		_ false)))
 
 (define physical_prefiltered_membership_expr? (lambda (expr)
@@ -6210,8 +6352,15 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		((quote scan_recset) _tx source _cols _filter)
 		(or (physical_expr_has_head? source (quote recset_project_join))
 			(physical_prefiltered_membership_expr? source))
-		(cons _head tail) (reduce tail (lambda (found item)
-			(or found (physical_prefiltered_membership_expr? item))) false)
+		(cons head tail) (or
+			/* Prefiltered candidates are encoded as an immediately applied lambda:
+			the body projects membership over the RecSet supplied by its argument.
+			A list-valued call head is executable AST and must be traversed too. */
+			(and (physical_expr_has_head? head (quote recset_project_join))
+				(physical_expr_has_head? tail (quote scan_recset)))
+			(or (physical_prefiltered_membership_expr? head)
+				(reduce tail (lambda (found item)
+					(or found (physical_prefiltered_membership_expr? item))) false)))
 		_ false)))
 
 (define physical_membership_operator_family (lambda (plan)
@@ -6227,7 +6376,7 @@ ordering run. Storage artifacts begin in build_queryplan. */
 				"driver_order_membership_probe"
 				(if (physical_expr_has_head? plan (quote recset_project_join))
 					"candidate_keyset"
-					"driver_order_membership_probe"))))))
+					"driver_filter_join_probe"))))))
 
 (define physical_operator_family_for_decision (lambda (plan decision)
 	(begin
@@ -6362,6 +6511,7 @@ potentially large calibrated SELECT result. */
 							"projected_driver_rows" (physical_calibration_input decision "projected_driver_rows")
 							"driver_input_rows" (physical_calibration_input decision "driver_input_rows")
 							"driver_rows" (physical_calibration_input decision "driver_rows")
+							"prefiltered_driver_rows" (physical_calibration_input decision "prefiltered_driver_rows")
 							"expected_driver_rows_visited" (physical_calibration_input decision "expected_driver_rows_visited")
 							"limit" (physical_calibration_input decision "limit")
 							"offset" (physical_calibration_input decision "offset")
@@ -6370,6 +6520,7 @@ potentially large calibrated SELECT result. */
 							"candidate_filter_columns" (physical_calibration_input decision "candidate_filter_columns")
 							"candidate_map_columns" (physical_calibration_input decision "candidate_map_columns")
 							"candidate_cache_map_columns" (physical_calibration_input decision "candidate_cache_map_columns")
+							"candidate_cache_backed" (physical_calibration_input decision "candidate_cache_backed")
 							"candidate_expression_operations" (physical_calibration_input decision "candidate_expression_operations")
 							"candidate_expression_depth" (physical_calibration_input decision "candidate_expression_depth")
 							"candidate_broad_text_match_rows" (physical_calibration_input decision "candidate_broad_text_match_rows")
@@ -6402,8 +6553,9 @@ potentially large calibrated SELECT result. */
 					variant_decision
 					variant
 					(qassoc_get variant_cost "total_ns" nil)
-					(physical_operator_family_for_decision
-						(nth compilation 0) variant_decision)
+					/* compile_physical_explain_variant records this before the generic
+					AST optimizer can fold a carrier wrapper into its consumer. */
+					(nth compilation 2)
 					suite_var)))))))
 
 (define physical_decision_has_costed_alternatives? (lambda (decision)
@@ -6468,7 +6620,7 @@ potentially large calibrated SELECT result. */
 						decision
 						variant
 						(qassoc_get (qassoc_get alternative "cost" '()) "total_ns" nil)
-						(physical_operator_family_for_decision (nth compilation 0) decision)
+						(nth compilation 2)
 						suite_var)))))))
 
 (define explain_queryplan_physical_calibrate (lambda (query)

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -264,6 +264,27 @@ func TestBoundaryLikeNonPrefix(t *testing.T) {
 	}
 }
 
+func TestRecSetFilterBoundariesKeepLikeAndMembershipHooks(t *testing.T) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("strlike"),
+		scm.NewSymbol("text"),
+		scm.NewString("%needle%"),
+	})
+	condition := buildProc([]string{"text"}, body)
+	owner := &recSet{}
+	bounds := recSetFilterBoundaries(owner, []string{"search"}, condition)
+	if len(bounds) != 2 {
+		t.Fatalf("combined RecSet/LIKE boundaries = %d, want 2", len(bounds))
+	}
+	if bounds[0].matcher != LikeMatcher || bounds[1].matcher != RecSetMatcher {
+		t.Fatalf("combined matcher order = (%s, %s), want (like, recset)",
+			bounds[0].matcher.Kind(), bounds[1].matcher.Kind())
+	}
+	if !bounds[1].lower.IsCustom(TagRecSet) || RecSetFromScmer(bounds[1].lower) != owner {
+		t.Fatal("RecSet boundary did not retain the exact input membership")
+	}
+}
+
 // TestMatcherIsPointLike verifies IsPointLike for all matcher types.
 func TestMatcherIsPointLike(t *testing.T) {
 	if !EqualMatcher.IsPointLike() {

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1582,11 +1582,18 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 // subscans) without ever touching rows outside the incoming membership --
 // e.g. evaluating an expensive correlated ACL check only over the ~30k rows a
 // mandant filter already narrowed a table down to, not the full table.
-func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
+	// Keep RecSet narrowing on the ordinary index-boundary path. The exact
+	// RecSet matcher and approximate hooks such as Bigram LIKE then prune the
+	// same candidate batches before the residual predicate reads any columns.
+	// This is an operator capability, not a planner shape rule: every
+	// scan_recset whose input is a RecSet gets the same combined boundaries.
+	boundaries := recSetFilterBoundaries(owner, conditionCols, condition)
+	lower, upperLast := indexFromBoundaries(boundaries)
 
 	ccols := make([]ColumnStorage, len(conditionCols))
 	cReaders := make([]ColumnReader, len(conditionCols))
@@ -1626,17 +1633,17 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
 	visibleUpper := mainCount + uint32(len(t.inserts))
-	matches := make([]uint32, 0, part.count)
-	part.forEachID(func(idx uint32) bool {
+	builder := newRecSetShardBuilder(t, visibleUpper, false, mainCount)
+	evaluateOne := func(idx uint32) {
 		if idx >= visibleUpper {
-			return true
+			return
 		}
 		if acidMode {
 			if !currentTx.IsVisible(t, idx) {
-				return true
+				return
 			}
 		} else if t.deletions.Get(uint(idx)) {
-			return true
+			return
 		}
 		if idx < mainCount {
 			for i, c := range cReaders {
@@ -1657,13 +1664,33 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 				}
 			}
 		}
-		if !scm.ToBool(conditionFn(cdataset...)) {
-			return true
+		builder.add(idx, scm.ToBool(conditionFn(cdataset...)))
+	}
+	evaluateBatch := func(batch []uint32) bool {
+		for _, idx := range batch {
+			evaluateOne(idx)
 		}
-		matches = append(matches, idx)
 		return true
-	})
-	return newRecSetShardFromSortedIDs(t, visibleUpper, matches)
+	}
+	/* A tiny batch is already the cheapest exact candidate iterator; walking a
+	whole inactive boundary index just to rediscover those IDs would defeat
+	adaptive LIMIT. Broad RecSets take the normal boundary path, where LIKE and
+	other hooks can reduce work below the incoming membership cardinality. */
+	if part.count*4 < int64(visibleUpper) {
+		part.forEachID(func(idx uint32) bool {
+			evaluateOne(idx)
+			return true
+		})
+	} else {
+		var buf [1024]uint32
+		t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, len(t.inserts), buf[:], true, nil, evaluateBatch)
+	}
+	return builder.finish()
+}
+
+func recSetFilterBoundaries(owner *recSet, conditionCols []string, condition scm.Scmer) boundaries {
+	result := extractBoundaries(conditionCols, condition)
+	return append(result, NewIndexBoundary("$recset_contains", RecSetMatcher, NewRecSetScmer(owner), ""))
 }
 
 // filterToRecSet narrows r to the members that also satisfy condition,
@@ -1699,7 +1726,7 @@ func (r *recSet) filterToRecSet(currentTx *TxContext, conditionCols []string, co
 				panic("query killed")
 			}
 			values <- recSetBuildResult{
-				part: part.shard.filterRecSetPart(&part, conditionCols, condition, currentTx, ss),
+				part: part.shard.filterRecSetPart(r, &part, conditionCols, condition, currentTx, ss),
 			}
 			return scm.NewNil()
 		})

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -23,6 +23,11 @@ setup:
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
+  - sql: "DROP TABLE IF EXISTS pc_doc_meta"
+  # String-key membership prevents the target-side prefiltered projection and
+  # isolates candidate startup from direct probe work.
+  - sql: "DROP TABLE IF EXISTS pc_events"
+  - sql: "DROP TABLE IF EXISTS pc_keys"
   # Inline values contribute more than 15 MB of candidate text work while the
   # ordered driver still exercises the production-scale million-row shape. A
   # separate component fixture below covers wider values without turning this
@@ -36,6 +41,9 @@ setup:
   - sql: "CREATE TABLE pc_files_large (id INT PRIMARY KEY, filename VARCHAR(32), search VARCHAR(32), f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT)"
   - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
   - sql: "CREATE TABLE pc_docs_million (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT) ENGINE=sloppy"
+  - sql: "CREATE TABLE pc_doc_meta (id INT PRIMARY KEY, label VARCHAR(32))"
+  - sql: "CREATE TABLE pc_events (id INT PRIMARY KEY, entity_key VARCHAR(32), event_time INT, kind VARCHAR(16))"
+  - sql: "CREATE TABLE pc_keys (id INT PRIMARY KEY, enabled INT)"
   - sql: "CREATE TABLE pc_files_text (id INT PRIMARY KEY, filename VARCHAR(255), search VARCHAR(255)) ENGINE=memory"
   - sql: "CREATE TABLE pc_files_wide (id INT PRIMARY KEY, filename VARCHAR(16384), search VARCHAR(16384)) ENGINE=sloppy"
   - scm: |
@@ -51,7 +59,15 @@ setup:
         (insert (table "memcp-tests" "pc_files_small") '("id" "filename" "search" "f1" "f2" "f3" "f4" "f5" "f6" "f7" "f8") (make_files 1000))
         (insert (table "memcp-tests" "pc_docs_small") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 4000 1000))
         (insert (table "memcp-tests" "pc_files_large") '("id" "filename" "search" "f1" "f2" "f3" "f4" "f5" "f6" "f7" "f8") (make_files 5000))
-        (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 20000 5000)))
+        (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 20000 5000))
+        (insert (table "memcp-tests" "pc_doc_meta") '("id" "label")
+          (map (produceN 5000) (lambda (i) (list i (concat "meta-" (string i))))))
+        (insert (table "memcp-tests" "pc_events") '("id" "entity_key" "event_time" "kind")
+          (map (produceN 10000) (lambda (i)
+            (list i (if (>= i 9990) "key:1" (concat "noise:" (string i))) i
+              (if (equal? (mod i 2) 0) "root" "leaf")))))
+        (insert (table "memcp-tests" "pc_keys") '("id" "enabled")
+          (list (list 1 1) (list 2 0))))
   - scm: |
       (insert (table "memcp-tests" "pc_docs_million") '("id" "file_id" "sort_key" "p1")
         (map (produceN 250000) (lambda (i) (list i (mod i 5000) i i))))
@@ -94,6 +110,9 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
+  - sql: "DROP TABLE IF EXISTS pc_doc_meta"
+  - sql: "DROP TABLE IF EXISTS pc_events"
+  - sql: "DROP TABLE IF EXISTS pc_keys"
   - sql: "DROP TABLE IF EXISTS pc_files_text"
   - sql: "DROP TABLE IF EXISTS pc_files_wide"
 
@@ -164,6 +183,37 @@ test_cases:
         SELECT f.id FROM pc_files_small f WHERE f.search LIKE '%hit%'
       )
 
+  # A branch-local membership below a highly selective outer predicate makes
+  # candidate startup and direct per-probe work independently identifiable.
+  # Without this row-count scale the two terms are collinear in broad scans and
+  # the fitted model can only describe their large-driver sum.
+  - name: "computed-key membership with tiny driver"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT e.id
+      FROM pc_events e
+      WHERE e.event_time >= 9990
+        AND (e.kind = 'root' OR e.entity_key IN (
+          SELECT CONCAT('key:', k.id) FROM pc_keys k WHERE k.enabled = 1
+        ))
+
+  # Pair the same cache-backed candidate with a larger driver. The two driver
+  # cardinalities make fixed group-cache startup and per-row direct probes
+  # independently identifiable instead of fitting their combined duration.
+  - name: "computed-key membership with medium driver"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT e.id
+      FROM pc_events e
+      WHERE e.event_time >= 9900
+        AND (e.kind = 'root' OR e.entity_key IN (
+          SELECT CONCAT('key:', k.id) FROM pc_keys k WHERE k.enabled = 1
+        ))
+
   - name: "selective membership below ordered limit one"
     physical_calibration: true
     calibration_holdout: true
@@ -194,6 +244,23 @@ test_cases:
       )
       ORDER BY d.sort_key
       LIMIT 10
+
+  # The production pagination width varies driver and projection work and
+  # provides the sixth independent exact observation for the common fit.
+  - name: "ordered membership at limit seventy-two"
+    physical_calibration: true
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.sort_key
+      LIMIT 72
 
   - name: "same candidate column with several predicate operations"
     physical_calibration: true
@@ -277,7 +344,7 @@ test_cases:
     compile_state: "variant_compile_and_execute"
     expected_driver_input_rows: 1000000
     warmup: 0
-    repetitions: 3
+    repetitions: 7
     sql: |
       SELECT d.id, d.p1
       FROM pc_docs_million d
@@ -353,6 +420,26 @@ test_cases:
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 
+  - name: "ordered batch with unique late projection"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id, m.label
+      FROM pc_docs_large d
+      LEFT JOIN pc_doc_meta m ON m.id = d.file_id
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.sort_key, d.id
+      LIMIT 72
+
+  # A uniformly distributed selective equality models tenant/location filters
+  # without making a random one-shard estimate depend on which range shard was
+  # sampled. The physical winner should narrow the driver before text/ACL work.
   - name: "production-scale prefiltered membership carrier"
     physical_calibration: true
     calibration_decision: "membership_carrier"
@@ -368,7 +455,7 @@ test_cases:
     sql: |
       SELECT d.id, d.p1
       FROM pc_docs_million d
-      WHERE d.p1 >= 999000
+      WHERE d.file_id = 4999
         AND d.file_id IN (
           SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
           UNION

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1002,7 +1002,7 @@ test_cases:
           LIMIT 10
         expect:
           contains:
-            - "recset_project_join"
+            - "recset_key_index"
             - "scan_order"
           not_contains:
             - "touch_keytable"
@@ -1296,9 +1296,9 @@ test_cases:
           LIMIT 72
         expect:
           contains:
+            - "ordered_batch_accept"
+            - "candidate_keyset"
             - "driver_order_membership_probe"
-            - "recset_key_index"
-            - "scan_order"
       - sql: |
           EXPLAIN
           SELECT t.ID
@@ -1317,7 +1317,7 @@ test_cases:
         expect:
           contains:
             - "in_dv_file"
-            - "recset_project_join"
+            - "recset_key_index"
             - "recset_union"
           not_contains:
             - "$break"
@@ -1354,6 +1354,32 @@ test_cases:
             - "result_equal"
           not_contains:
             - "operator_consistent false"
+      - sql: |
+          EXPLAIN PHYSICAL CALIBRATE
+          SELECT t.ID
+          FROM (
+            SELECT d.ID, d.file_id, d.sort_key
+            FROM in_dv_doc d
+            LEFT JOIN in_dv_acl a ON a.ID = d.file_id
+          ) t
+          WHERE t.file_id IN (
+            SELECT f.ID FROM in_dv_file f WHERE f.filename LIKE '%e%'
+            UNION
+            SELECT f.ID FROM in_dv_file f WHERE f.search LIKE '%e%'
+          )
+          ORDER BY t.sort_key
+          LIMIT 2
+        expect:
+          rows: 3
+          contains:
+            - "candidate_keyset"
+            - "driver_order_membership_probe"
+            - "ordered_batch_accept"
+            - "operator_consistent"
+            - "result_equal"
+          not_contains:
+            - "operator_consistent false"
+            - "result_equal false"
       - sql: |
           EXPLAIN PHYSICAL CALIBRATE DISCOVER
           SELECT t.ID

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -92,6 +92,7 @@ test_cases:
     expect:
       result_contains:
         - "scan_order"
+        - "scan_order_batch_accept"
         - "touch_keytable"
 
   - name: "Selective IN branches under OR preserve ordered results"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -93,6 +93,7 @@ test_cases:
       result_contains:
         - "scan_order"
         - "scan_order_batch_accept"
+      result_not_contains:
         - "touch_keytable"
 
   - name: "Selective IN branches under OR preserve ordered results"

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -229,7 +229,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "recset_key_index"
+        - "recset_project_join"
         - "recset_union"
         - "scan_order"
       result_not_contains:

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -183,23 +183,24 @@ type observation struct {
 }
 
 type constants struct {
-	scanInvocationNS         int64
-	scanRowNS                int64
-	filterColumnRowNS        int64
-	mapColumnRowNS           int64
-	expressionOperationNS    int64
-	broadTextMatchRowNS      int64
-	broadTextMatchByteNS     int64
-	recsetStartupNS          int64
-	recsetBuildRowNS         int64
-	recsetProbeRowNS         int64
-	recsetAggregateRowNS     int64
-	groupCacheStartupNS      int64
-	groupCacheBuildRowNS     int64
-	groupCacheProbeRowNS     int64
-	orderedDriverInputNS     int64
-	orderedScanInvocationNS  int64
-	directPresenceProbeRowNS int64
+	scanInvocationNS           int64
+	scanRowNS                  int64
+	filterColumnRowNS          int64
+	mapColumnRowNS             int64
+	expressionOperationNS      int64
+	broadTextMatchRowNS        int64
+	broadTextMatchByteNS       int64
+	recsetStartupNS            int64
+	recsetBuildRowNS           int64
+	recsetProbeRowNS           int64
+	recsetAggregateRowNS       int64
+	groupCacheStartupNS        int64
+	groupCacheBuildRowNS       int64
+	groupCacheProbeRowNS       int64
+	orderedDriverInputNS       int64
+	orderedScanInvocationNS    int64
+	scalarPresenceProbeRowNS   int64
+	membershipDirectProbeRowNS int64
 }
 
 func main() {
@@ -260,12 +261,12 @@ func main() {
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered scan startup: %d ns/invocation\ndirect presence probe:%d ns/probe\n",
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered scan startup: %d ns/invocation\nscalar presence probe:%d ns/probe\nmembership probe:     %d ns/probe\n",
 		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
 		c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS,
-		c.directPresenceProbeRowNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS, c.scalarPresenceProbeRowNS,
+		c.membershipDirectProbeRowNS)
 	printModelComparison("training", training, c)
 	holdout := filterObservations(observations, true)
 	if len(holdout) > 0 {
@@ -1207,13 +1208,13 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		recsetProbeRowNS:      int64(math.Round(beta[7])),
 		// Cache startup is identified below from cache-backed/direct pairs.
 		// Build and probe stay at their floor until fixtures vary them independently.
-		groupCacheStartupNS:      1,
-		groupCacheBuildRowNS:     1,
-		groupCacheProbeRowNS:     1,
-		recsetAggregateRowNS:     1,
-		orderedDriverInputNS:     1,
-		orderedScanInvocationNS:  1,
-		directPresenceProbeRowNS: 1,
+		groupCacheStartupNS:        1,
+		groupCacheBuildRowNS:       1,
+		groupCacheProbeRowNS:       1,
+		recsetAggregateRowNS:       1,
+		orderedDriverInputNS:       1,
+		orderedScanInvocationNS:    1,
+		membershipDirectProbeRowNS: 1,
 	}, nil
 }
 
@@ -1268,7 +1269,7 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 	}
 	if startup, probe, ok := fitDirectCarrierPair(allRows, selected); ok {
 		selected.groupCacheStartupNS = startup
-		selected.directPresenceProbeRowNS = probe
+		selected.membershipDirectProbeRowNS = probe
 	}
 	/* A race timeout mixes cold startup and incomplete operator work. It is a
 	lower bound for that whole alternative, not evidence for a linear ordered
@@ -1355,7 +1356,7 @@ func fitDirectCarrierPair(rows []observation, c constants) (int64, int64, bool) 
 		}
 		without := c
 		without.groupCacheStartupNS = 0
-		without.directPresenceProbeRowNS = 0
+		without.membershipDirectProbeRowNS = 0
 		/* Both variants execute the surrounding query. Fitting a direct probe from
 		its absolute duration attributes all shared scan/join work to every probe
 		and grossly overprices small selective drivers. Paired differences expose
@@ -1460,7 +1461,7 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.broadTextMatchRowNS),
 		float64(c.broadTextMatchByteNS),
 		float64(c.orderedScanInvocationNS),
-		float64(c.directPresenceProbeRowNS),
+		float64(c.membershipDirectProbeRowNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1785,7 +1786,8 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_broad_text_match_row_ns",
 		"planner_membership_broad_text_match_byte_ns",
 		"planner_membership_ordered_scan_invocation_ns",
-		"planner_direct_presence_probe_row_ns",
+		"planner_scalar_presence_probe_row_ns",
+		"planner_membership_direct_probe_row_ns",
 	}
 	values := make([]int64, len(names))
 	content := string(data)
@@ -1793,11 +1795,9 @@ func readCurrentConstants(path string) (constants, error) {
 		prefix := "(define " + name + " "
 		start := strings.Index(content, prefix)
 		if start < 0 {
-			// The direct-probe coefficient used to be an anonymous literal inside
-			// planner_direct_presence_probe_cost. A one-nanosecond floor lets the
-			// first run fit it from direct-consumer observations and then persist
-			// the named coefficient in the generated block.
-			if name == "planner_direct_presence_probe_row_ns" ||
+			// A one-nanosecond floor lets the first run fit new membership and
+			// ordered-scan coefficients from their physical-consumer observations.
+			if name == "planner_membership_direct_probe_row_ns" ||
 				name == "planner_membership_ordered_scan_invocation_ns" {
 				values[i] = 1
 				continue
@@ -1822,11 +1822,12 @@ func readCurrentConstants(path string) (constants, error) {
 		recsetBuildRowNS: values[6], recsetProbeRowNS: values[7],
 		recsetAggregateRowNS: values[8], groupCacheStartupNS: values[9],
 		groupCacheBuildRowNS: values[10], groupCacheProbeRowNS: values[11],
-		orderedDriverInputNS:     values[12],
-		broadTextMatchRowNS:      values[13],
-		broadTextMatchByteNS:     values[14],
-		orderedScanInvocationNS:  values[15],
-		directPresenceProbeRowNS: values[16],
+		orderedDriverInputNS:       values[12],
+		broadTextMatchRowNS:        values[13],
+		broadTextMatchByteNS:       values[14],
+		orderedScanInvocationNS:    values[15],
+		scalarPresenceProbeRowNS:   values[16],
+		membershipDirectProbeRowNS: values[17],
 	}, nil
 }
 
@@ -1846,9 +1847,13 @@ func patchQueryplan(path string, c constants) error {
 Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
 metadata.physical_calibration. Each observation is an executed, forced
 EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
-(define planner_direct_presence_probe_row_ns %d)
+(define planner_scalar_presence_probe_row_ns %d)
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
-	(planner_cost 0 0 (* probe_rows planner_direct_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+	(planner_cost 0 0 (* probe_rows planner_scalar_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+
+(define planner_membership_direct_probe_row_ns %d)
+(define planner_membership_direct_probe_cost (lambda (probe_rows)
+	(planner_cost 0 0 (* probe_rows planner_membership_direct_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
@@ -1874,7 +1879,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_probe_row_ns %d)
 (define planner_membership_ordered_driver_input_row_ns %d)
 (define planner_membership_ordered_scan_invocation_ns %d)
-/* END GENERATED COST CONSTANTS */`, c.directPresenceProbeRowNS,
+/* END GENERATED COST CONSTANTS */`, c.scalarPresenceProbeRowNS, c.membershipDirectProbeRowNS,
 		c.scanInvocationNS, c.scanRowNS,
 		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS,
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -52,6 +52,8 @@ const (
 	database    = "memcp-tests"
 )
 
+var errInsufficientCalibrationObservations = errors.New("insufficient calibration observations")
+
 var activeServer *memcpServer
 
 type syncBuffer struct {
@@ -132,6 +134,7 @@ type calibrationRow struct {
 	ProjectedDriverRows              *float64 `json:"projected_driver_rows"`
 	DriverInputRows                  *float64 `json:"driver_input_rows"`
 	DriverRows                       *float64 `json:"driver_rows"`
+	PrefilteredDriverRows            *float64 `json:"prefiltered_driver_rows"`
 	ExpectedDriverRowsVisited        *float64 `json:"expected_driver_rows_visited"`
 	Limit                            *float64 `json:"limit"`
 	Offset                           *float64 `json:"offset"`
@@ -140,6 +143,7 @@ type calibrationRow struct {
 	CandidateFilterColumns           *float64 `json:"candidate_filter_columns"`
 	CandidateMapColumns              *float64 `json:"candidate_map_columns"`
 	CandidateCacheMapColumns         *float64 `json:"candidate_cache_map_columns"`
+	CandidateCacheBacked             bool     `json:"candidate_cache_backed"`
 	CandidateExpressionOperations    *float64 `json:"candidate_expression_operations"`
 	CandidateExpressionDepth         *float64 `json:"candidate_expression_depth"`
 	CandidateBroadTextMatchRows      *float64 `json:"candidate_broad_text_match_rows"`
@@ -179,22 +183,23 @@ type observation struct {
 }
 
 type constants struct {
-	scanInvocationNS      int64
-	scanRowNS             int64
-	filterColumnRowNS     int64
-	mapColumnRowNS        int64
-	expressionOperationNS int64
-	broadTextMatchRowNS   int64
-	broadTextMatchByteNS  int64
-	recsetStartupNS       int64
-	recsetBuildRowNS      int64
-	recsetProbeRowNS      int64
-	recsetAggregateRowNS  int64
-	groupCacheStartupNS   int64
-	groupCacheBuildRowNS  int64
-	groupCacheProbeRowNS  int64
-	orderedDriverInputNS  int64
-	orderedBatchStartupNS int64
+	scanInvocationNS         int64
+	scanRowNS                int64
+	filterColumnRowNS        int64
+	mapColumnRowNS           int64
+	expressionOperationNS    int64
+	broadTextMatchRowNS      int64
+	broadTextMatchByteNS     int64
+	recsetStartupNS          int64
+	recsetBuildRowNS         int64
+	recsetProbeRowNS         int64
+	recsetAggregateRowNS     int64
+	groupCacheStartupNS      int64
+	groupCacheBuildRowNS     int64
+	groupCacheProbeRowNS     int64
+	orderedDriverInputNS     int64
+	orderedScanInvocationNS  int64
+	directPresenceProbeRowNS int64
 }
 
 func main() {
@@ -248,18 +253,19 @@ func main() {
 	if err := validateMeasurementSignal(fitTraining); err != nil {
 		fatal(err)
 	}
-	c, err := solve(fitTraining, training, currentConstants)
+	c, err := solve(carrierTraining, training, currentConstants)
 	if err != nil {
 		fatal(err)
 	}
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered batch startup:%d ns\n",
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered scan startup: %d ns/invocation\ndirect presence probe:%d ns/probe\n",
 		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
 		c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedBatchStartupNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS,
+		c.directPresenceProbeRowNS)
 	printModelComparison("training", training, c)
 	holdout := filterObservations(observations, true)
 	if len(holdout) > 0 {
@@ -283,6 +289,19 @@ func main() {
 func validateModelImprovement(rows []observation, c constants) error {
 	current := measureModelError(rows, func(row observation) float64 { return row.currentEstimate })
 	updated := measureModelError(rows, func(row observation) float64 { return estimatedNS(row, c) })
+	currentCorrect, total := decisionAccuracy(rows, func(row observation) float64 { return row.currentEstimate })
+	updatedCorrect, _ := decisionAccuracy(rows, func(row observation) float64 { return estimatedNS(row, c) })
+	if updatedCorrect < currentCorrect {
+		return fmt.Errorf("updated model regresses holdout decisions: %d/%d -> %d/%d",
+			currentCorrect, total, updatedCorrect, total)
+	}
+	/* Exact duration is a tie-breaker for an incomplete decision model. Once all
+	holdout inequalities are correct, rejecting a newly identifiable coefficient
+	because unrelated absolute residuals move by a few percent preserves stale
+	constants indefinitely and contradicts solve's decision-first selection. */
+	if updatedCorrect == total {
+		return nil
+	}
 	if updated.medianAbsolutePercent > current.medianAbsolutePercent || updated.meanFactor > current.meanFactor {
 		return fmt.Errorf("updated model does not improve exact holdouts: median %.1f%% -> %.1f%%, mean factor %.2fx -> %.2fx",
 			current.medianAbsolutePercent, updated.medianAbsolutePercent,
@@ -324,6 +343,12 @@ func discoverSuites(root string) ([]suite, error) {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
+		}
+		/* The SQL runner accepts a broader YAML surface than this calibration
+		tool needs. Avoid strictly decoding unrelated suites: only files which
+		explicitly opt into physical calibration can contribute observations. */
+		if !bytes.Contains(data, []byte("physical_calibration: true")) {
+			return nil
 		}
 		var header struct {
 			Metadata metadata `yaml:"metadata"`
@@ -627,9 +652,9 @@ func discoverCalibrationDecision(server *memcpServer, query, decisionName string
 			decision = &discovered[i]
 		}
 	}
-	if decision == nil || len(decision.Alternatives) < 2 || len(decision.Alternatives) > 3 ||
+	if decision == nil || len(decision.Alternatives) < 2 || len(decision.Alternatives) > 4 ||
 		len(decision.EstimatedNS) != len(decision.Alternatives) {
-		return nil, nil, fmt.Errorf("discovery did not expose two or three costed alternatives: %+v", decision)
+		return nil, nil, fmt.Errorf("discovery did not expose two to four costed alternatives: %+v", decision)
 	}
 	estimates := map[string]*float64{}
 	for i, plan := range decision.Alternatives {
@@ -916,8 +941,8 @@ func validateRows(rows []calibrationRow) error {
 			return errors.New(row.Error)
 		}
 	}
-	if len(rows) < 2 || len(rows) > 3 {
-		return fmt.Errorf("expected two or three membership alternatives, got %d", len(rows))
+	if len(rows) < 2 || len(rows) > 4 {
+		return fmt.Errorf("expected two to four membership alternatives, got %d", len(rows))
 	}
 	seen := map[string]bool{}
 	for _, row := range rows {
@@ -956,12 +981,20 @@ func validateRows(rows []calibrationRow) error {
 			return fmt.Errorf("invalid whole_query_execution_ns for %s", row.Plan)
 		}
 		seen[row.Plan] = true
+		if row.Plan == "prefiltered_candidate_keyset" && row.PrefilteredDriverRows == nil {
+			return fmt.Errorf("prefiltered alternative has no driver cardinality: %+v", row)
+		}
 	}
-	if !seen["candidate_keyset"] || !seen["driver_order_membership_probe"] {
+	if !seen["candidate_keyset"] ||
+		(!seen["driver_order_membership_probe"] && !seen["driver_filter_join_probe"]) {
 		return fmt.Errorf("alternatives incomplete: %v", seen)
 	}
-	if len(rows) == 3 && !seen["ordered_batch_accept"] {
+	if len(rows) == 3 && (!seen["ordered_batch_accept"] || !seen["driver_order_membership_probe"]) {
 		return fmt.Errorf("three-way decision is missing ordered_batch_accept: %v", seen)
+	}
+	if len(rows) == 4 && (!seen["ordered_batch_accept"] ||
+		!seen["driver_order_membership_probe"] || !seen["prefiltered_candidate_keyset"]) {
+		return fmt.Errorf("four-way decision is incomplete: %v", seen)
 	}
 	return nil
 }
@@ -1011,7 +1044,9 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 	expressionOperations := candidateExpressionOperations + driverWorkRows**row.DriverExpressionOperations
 	mapColumns := *row.CandidateMapColumns
 	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
-		mapColumns = *row.CandidateCacheMapColumns
+		if row.CandidateCacheBacked {
+			mapColumns = *row.CandidateCacheMapColumns
+		}
 	}
 	driverMapRows := *row.ProjectedDriverRows
 	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
@@ -1023,23 +1058,37 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		aggregateDriverRows = *row.DriverInputRows
 	}
 	orderedDriverInputRows := 0.0
+	orderedScanInvocations := 0.0
 	if row.Limit != nil {
 		orderedDriverInputRows = *row.DriverInputRows * *row.DriverInputRows / 1_000_000
+		orderedScanInvocations = *row.DriverScanInvocations
 	}
 	switch row.Plan {
 	case "candidate_keyset":
+		cacheStartup, cacheBuildRows := 0.0, 0.0
+		if row.CandidateCacheBacked {
+			cacheStartup, cacheBuildRows = 1, *row.CandidateRows
+		}
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
-			1, *row.CandidateRows + *row.ProjectedDriverRows, *row.DriverRows, 0, 0, 0,
+			1, *row.CandidateRows + *row.ProjectedDriverRows, *row.DriverRows,
+			cacheStartup, cacheBuildRows, 0,
 			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
-			*row.CandidateBroadTextMatchBytes, 0,
+			*row.CandidateBroadTextMatchBytes, orderedScanInvocations, 0,
 		}, nil
 	case "driver_order_membership_probe", "scan_order":
+		recsetStartup, recsetBuildRows, recsetProbeRows := 1.0, *row.CandidateRows, *row.ExpectedDriverRowsVisited
+		cacheStartup, cacheBuildRows, cacheProbeRows := 0.0, 0.0, 0.0
+		if row.CandidateCacheBacked {
+			recsetStartup, recsetBuildRows, recsetProbeRows = 0, 0, 0
+			cacheStartup, cacheBuildRows, cacheProbeRows = 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited
+		}
 		return []float64{
 			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
-			0, 0, 0, 1, *row.CandidateRows, *row.ExpectedDriverRowsVisited,
+			recsetStartup, recsetBuildRows, recsetProbeRows,
+			cacheStartup, cacheBuildRows, cacheProbeRows,
 			0, orderedDriverInputRows, 0,
-			0, 0,
+			0, orderedScanInvocations, 0,
 		}, nil
 	case "ordered_batch_accept":
 		fraction := 1.0
@@ -1058,6 +1107,7 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		candidateMatchRows := *row.CandidateRows * repeatFraction
 		projectionRows := *row.ProbeBranches *
 			(2**row.ExpectedDriverRowsVisited + candidateWorkRows + candidateMatchRows)
+		orderedDriverWork := batches * *row.DriverInputRows * *row.DriverInputRows / 1_000_000
 		return []float64{
 			*row.DriverScanInvocations + batches**row.CandidateScanInvocations,
 			*row.ExpectedDriverRowsVisited + candidateWorkRows + projectionRows,
@@ -1066,10 +1116,39 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			candidateWorkRows * *row.CandidateExpressionOperations,
 			0,
 			projectionRows,
-			0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, orderedDriverWork,
 			*row.CandidateBroadTextMatchRows * repeatFraction,
 			*row.CandidateBroadTextMatchBytes * repeatFraction,
-			1,
+			batches * *row.DriverScanInvocations, 0,
+		}, nil
+	case "driver_filter_join_probe":
+		return []float64{
+			scanInvocations, scanRows, filterValues, mapValues, expressionOperations,
+			0, 0, 0, 0, 0, 0,
+			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
+			*row.CandidateBroadTextMatchBytes, 0,
+			*row.DriverRows * *row.ProbeBranches,
+		}, nil
+	case "prefiltered_candidate_keyset":
+		branches := math.Max(1, *row.ProbeBranches)
+		candidateDomainRows := *row.CandidateInputRows / branches
+		candidateWorkRows := math.Min(*row.PrefilteredDriverRows, candidateDomainRows) * branches
+		candidateMatchRows := candidateWorkRows * *row.CandidateDensity
+		candidateFraction := 0.0
+		if *row.CandidateInputRows > 0 {
+			candidateFraction = math.Min(1, candidateWorkRows / *row.CandidateInputRows)
+		}
+		projectionRows := 2**row.PrefilteredDriverRows + candidateWorkRows + candidateMatchRows
+		return []float64{
+			*row.DriverScanInvocations + *row.CandidateScanInvocations,
+			*row.DriverInputRows + candidateWorkRows + projectionRows,
+			*row.DriverInputRows**row.DriverFilterColumns + candidateWorkRows**row.CandidateFilterColumns,
+			projectionRows,
+			*row.DriverInputRows**row.DriverExpressionOperations + candidateWorkRows**row.CandidateExpressionOperations,
+			1, projectionRows, 0, 0, 0, 0, 0, 0,
+			*row.CandidateBroadTextMatchRows * candidateFraction,
+			*row.CandidateBroadTextMatchBytes * candidateFraction,
+			orderedScanInvocations, 0,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
@@ -1083,8 +1162,6 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 //	       + expression_operation_rows*expression_operation
 //	candidate = recset_startup + common
 //	          + candidate_rows*recset_build + driver_rows*recset_probe
-//	driver    = group_cache_startup + common
-//	          + candidate_rows*cache_build + driver_rows*cache_probe
 //
 // Non-negative coordinate descent prevents noisy samples from generating
 // impossible negative costs. Weighting every equation by 1/actual^2 minimizes
@@ -1092,12 +1169,9 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 // drown out the millisecond candidate plans whose inequality we also need to
 // predict correctly.
 func solveEquationSystem(rows []observation) (constants, error) {
-	if len(rows) < 11 {
-		return constants{}, fmt.Errorf("need at least eleven training observations, got %d", len(rows))
-	}
 	candidateX, candidateY := make([][]float64, 0), make([]float64, 0)
 	for _, row := range rows {
-		if row.plan != "candidate_keyset" {
+		if row.censored || row.plan != "candidate_keyset" || row.x[8] > 0 {
 			continue
 		}
 		candidateX = append(candidateX, []float64{
@@ -1108,32 +1182,17 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		// the workload and are therefore identifiable from exact winner runs.
 		candidateY = append(candidateY, math.Max(1, row.y-row.x[5]-row.x[7]))
 	}
+	if len(candidateX) < 6 {
+		return constants{}, fmt.Errorf("%w: common scan fit needs six candidate observations, got %d",
+			errInsufficientCalibrationObservations, len(candidateX))
+	}
 	common, err := fitNonnegative(candidateX, candidateY)
 	if err != nil {
 		return constants{}, fmt.Errorf("common candidate work: %w", err)
 	}
-	pairs, err := decisionPairs(rows)
-	if err != nil {
-		return constants{}, err
-	}
-	groupX, groupY := make([][]float64, 0, len(pairs)), make([]float64, 0, len(pairs))
-	for _, pair := range pairs {
-		commonDifference := 0.0
-		for i := 0; i < 5; i++ {
-			commonDifference += (pair.driver.x[i] - pair.candidate.x[i]) * common[i]
-		}
-		candidateCarrier := pair.candidate.x[5] + pair.candidate.x[6]*common[5] + pair.candidate.x[7]
-		groupX = append(groupX, pair.driver.x[8:11])
-		groupY = append(groupY, math.Max(1,
-			pair.driver.y-pair.candidate.y-commonDifference+candidateCarrier))
-	}
-	group, err := fitNonnegative(groupX, groupY)
-	if err != nil {
-		return constants{}, fmt.Errorf("paired carrier difference: %w", err)
-	}
 	beta := []float64{
 		common[0], common[1], common[2], common[3], common[4],
-		1, common[5], 1, group[0], group[1], group[2],
+		1, common[5], 1,
 	}
 	return constants{
 		scanInvocationNS:      int64(math.Round(beta[0])),
@@ -1146,12 +1205,15 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		recsetStartupNS:       int64(math.Round(beta[5])),
 		recsetBuildRowNS:      int64(math.Round(beta[6])),
 		recsetProbeRowNS:      int64(math.Round(beta[7])),
-		groupCacheStartupNS:   int64(math.Round(beta[8])),
-		groupCacheBuildRowNS:  int64(math.Round(beta[9])),
-		groupCacheProbeRowNS:  int64(math.Round(beta[10])),
-		recsetAggregateRowNS:  1,
-		orderedDriverInputNS:  1,
-		orderedBatchStartupNS: 1,
+		// Cache startup is identified below from cache-backed/direct pairs.
+		// Build and probe stay at their floor until fixtures vary them independently.
+		groupCacheStartupNS:      1,
+		groupCacheBuildRowNS:     1,
+		groupCacheProbeRowNS:     1,
+		recsetAggregateRowNS:     1,
+		orderedDriverInputNS:     1,
+		orderedScanInvocationNS:  1,
+		directPresenceProbeRowNS: 1,
 	}, nil
 }
 
@@ -1162,25 +1224,37 @@ func solveEquationSystem(rows []observation) (constants, error) {
 // lower_bound_ns.
 func solve(exactRows, allRows []observation, baseline constants) (constants, error) {
 	fitted, err := solveEquationSystem(exactRows)
-	if err != nil {
+	if err != nil && !errors.Is(err, errInsufficientCalibrationObservations) {
 		return constants{}, err
 	}
+	if errors.Is(err, errInsufficientCalibrationObservations) {
+		logStep("model selection preserves baseline: %v", err)
+	}
 	selected := baseline
-	baseError := measureModelError(exactRows, func(row observation) float64 {
-		return estimatedNS(row, baseline)
-	})
-	fitError := measureModelError(exactRows, func(row observation) float64 {
-		return estimatedNS(row, fitted)
-	})
-	baseCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
-		return estimatedNS(row, baseline)
-	})
-	fitCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
-		return estimatedNS(row, fitted)
-	})
-	if fitError.medianAbsolutePercent <= baseError.medianAbsolutePercent &&
-		fitError.meanFactor <= baseError.meanFactor && fitCorrect >= baseCorrect {
-		selected = fitted
+	if err == nil {
+		baseError := measureModelError(exactRows, func(row observation) float64 {
+			return estimatedNS(row, baseline)
+		})
+		fitError := measureModelError(exactRows, func(row observation) float64 {
+			return estimatedNS(row, fitted)
+		})
+		baseCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
+			return estimatedNS(row, baseline)
+		})
+		fitCorrect, _ := decisionAccuracy(exactRows, func(row observation) float64 {
+			return estimatedNS(row, fitted)
+		})
+		/* The model exists to rank physical alternatives. Prefer a fit which gets
+		more measured decisions right even when a few absolute-duration residuals
+		grow; use duration accuracy only to break equal-ranking fits. Requiring all
+		metrics to improve lets stale constants survive indefinitely. */
+		if fitCorrect > baseCorrect || (fitCorrect == baseCorrect &&
+			fitError.medianAbsolutePercent <= baseError.medianAbsolutePercent &&
+			fitError.meanFactor <= baseError.meanFactor) {
+			selected = fitted
+		}
+		logStep("model selection baseline decisions=%d fitted decisions=%d selected_fitted=%t",
+			baseCorrect, fitCorrect, selected == fitted)
 	}
 
 	if value, ok := fitExactResidualPerRow(allRows, selected, 11); ok {
@@ -1189,8 +1263,12 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 	if value, ok := fitBroadTextResidualPerByte(allRows, selected); ok {
 		selected.broadTextMatchByteNS = value
 	}
-	if value, ok := fitOrderedBatchStartup(allRows, selected); ok {
-		selected.orderedBatchStartupNS = value
+	if value, ok := fitOrderedScanInvocation(allRows, selected); ok {
+		selected.orderedScanInvocationNS = value
+	}
+	if startup, probe, ok := fitDirectCarrierPair(allRows, selected); ok {
+		selected.groupCacheStartupNS = startup
+		selected.directPresenceProbeRowNS = probe
 	}
 	/* A race timeout mixes cold startup and incomplete operator work. It is a
 	lower bound for that whole alternative, not evidence for a linear ordered
@@ -1231,21 +1309,74 @@ func fitBroadTextResidualPerByte(rows []observation, c constants) (int64, bool) 
 	return int64(math.Round(values[len(values)/2])), true
 }
 
-func fitOrderedBatchStartup(rows []observation, c constants) (int64, bool) {
+func fitOrderedScanInvocation(rows []observation, c constants) (int64, bool) {
+	candidates := make(map[string]observation)
+	for _, row := range rows {
+		if !row.censored && row.component == "" && row.plan == "candidate_keyset" {
+			candidates[row.caseName] = row
+		}
+	}
 	values := make([]float64, 0)
 	for _, row := range rows {
-		if row.censored || row.plan != "ordered_batch_accept" || len(row.x) <= 15 || row.x[15] <= 0 {
+		candidate, paired := candidates[row.caseName]
+		if row.censored || row.component != "" ||
+			(row.plan != "driver_order_membership_probe" && row.plan != "ordered_batch_accept") ||
+			!paired || len(row.x) <= 15 || row.x[15] <= 0 {
 			continue
 		}
 		without := c
-		without.orderedBatchStartupNS = 0
-		values = append(values, math.Max(1, (row.y-estimatedNS(row, without))/row.x[15]))
+		without.orderedScanInvocationNS = 0
+		/* Both alternatives execute the surrounding query. Their difference
+		isolates ordered scan startup without charging common scan and result work
+		to every adaptive batch. */
+		values = append(values, math.Max(1, (row.y-candidate.y-
+			(estimatedNS(row, without)-estimatedNS(candidate, without)))/row.x[15]))
 	}
 	if len(values) == 0 {
 		return 0, false
 	}
 	sort.Float64s(values)
 	return int64(math.Round(values[len(values)/2])), true
+}
+
+func fitDirectCarrierPair(rows []observation, c constants) (int64, int64, bool) {
+	candidates := make(map[string]observation)
+	for _, row := range rows {
+		if !row.censored && row.component == "" && row.plan == "candidate_keyset" {
+			candidates[row.caseName] = row
+		}
+	}
+	x, y := make([][]float64, 0), make([]float64, 0)
+	for _, row := range rows {
+		candidate, paired := candidates[row.caseName]
+		if row.censored || row.component != "" || row.plan != "driver_filter_join_probe" ||
+			!paired || len(row.x) <= 16 || row.x[16] <= 0 {
+			continue
+		}
+		without := c
+		without.groupCacheStartupNS = 0
+		without.directPresenceProbeRowNS = 0
+		/* Both variants execute the surrounding query. Fitting a direct probe from
+		its absolute duration attributes all shared scan/join work to every probe
+		and grossly overprices small selective drivers. Paired differences expose
+		the two physical terms which do not cancel: the candidate's fixed group-cache
+		startup and the driver's per-probe work. Signed features let non-negative
+		least squares identify both without a hand-written crossover threshold. */
+		if candidate.x[8] <= 0 {
+			continue
+		}
+		x = append(x, []float64{candidate.x[8], -row.x[16]})
+		y = append(y, candidate.y-row.y-
+			(estimatedNS(candidate, without)-estimatedNS(row, without)))
+	}
+	if len(x) < 2 {
+		return 0, 0, false
+	}
+	beta, err := fitNonnegative(x, y)
+	if err != nil {
+		return 0, 0, false
+	}
+	return int64(math.Round(beta[0])), int64(math.Round(beta[1])), true
 }
 
 func fitExactResidualPerRow(rows []observation, c constants, feature int) (int64, bool) {
@@ -1328,7 +1459,8 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.orderedDriverInputNS),
 		float64(c.broadTextMatchRowNS),
 		float64(c.broadTextMatchByteNS),
-		float64(c.orderedBatchStartupNS),
+		float64(c.orderedScanInvocationNS),
+		float64(c.directPresenceProbeRowNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1384,9 +1516,16 @@ func filterRankObservations(rows []observation) []observation {
 }
 
 func filterCarrierObservations(rows []observation) []observation {
+	directCases := make(map[string]bool)
+	for _, row := range rows {
+		if row.plan == "driver_filter_join_probe" {
+			directCases[row.caseName] = true
+		}
+	}
 	filtered := make([]observation, 0, len(rows))
 	for _, row := range rows {
-		if row.plan != "ordered_batch_accept" {
+		if row.plan != "ordered_batch_accept" && row.plan != "prefiltered_candidate_keyset" &&
+			!directCases[row.caseName] {
 			filtered = append(filtered, row)
 		}
 	}
@@ -1403,7 +1542,7 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 			return nil, fmt.Errorf("duplicate %s observation for %q", row.plan, row.caseName)
 		}
 		switch row.plan {
-		case "candidate_keyset", "driver_order_membership_probe", "ordered_batch_accept":
+		case "candidate_keyset", "driver_order_membership_probe", "driver_filter_join_probe", "ordered_batch_accept", "prefiltered_candidate_keyset":
 			groups[row.caseName][row.plan] = row
 		default:
 			return nil, fmt.Errorf("unsupported plan %q", row.plan)
@@ -1413,7 +1552,9 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 		if _, ok := plans["candidate_keyset"]; !ok {
 			return nil, fmt.Errorf("incomplete alternatives for %q", name)
 		}
-		if _, ok := plans["driver_order_membership_probe"]; !ok {
+		_, ordered := plans["driver_order_membership_probe"]
+		_, direct := plans["driver_filter_join_probe"]
+		if !ordered && !direct {
 			return nil, fmt.Errorf("incomplete alternatives for %q", name)
 		}
 	}
@@ -1470,7 +1611,9 @@ func decisionAccuracy(rows []observation, estimate func(observation) float64) (i
 	}
 	correct := 0
 	for _, plans := range groups {
-		if winningPlan(plans, func(row observation) float64 { return row.y }) == winningPlan(plans, estimate) {
+		actualWinner := winningPlan(plans, func(row observation) float64 { return row.y })
+		estimatedWinner := winningPlan(plans, estimate)
+		if actualWinner == estimatedWinner || plansStatisticallyEquivalent(plans, actualWinner, estimatedWinner) {
 			correct++
 		}
 	}
@@ -1511,13 +1654,16 @@ func validateMeasurementSignal(rows []observation) error {
 	if err != nil {
 		return err
 	}
-	for name, pair := range pairs {
+	signals := 0
+	for _, pair := range pairs {
 		difference := math.Abs(pair.driver.y - pair.candidate.y)
 		noise := 3 * (pair.driver.noiseNS + pair.candidate.noiseNS)
-		if difference <= noise {
-			return fmt.Errorf("%q has no calibratable A/B signal: difference %.3fms <= 3*(MAD candidate + driver) %.3fms",
-				name, difference/1e6, noise/1e6)
+		if difference > noise {
+			signals++
 		}
+	}
+	if signals == 0 {
+		return errors.New("calibration workload has no carrier A/B signal outside its measured noise")
 	}
 	return nil
 }
@@ -1565,12 +1711,26 @@ func validateDecisionOrdering(rows []observation, c constants) error {
 	for name, plans := range groups {
 		actualWinner := winningPlan(plans, func(row observation) float64 { return row.y })
 		estimatedWinner := winningPlan(plans, func(row observation) float64 { return estimatedNS(row, c) })
-		if actualWinner != estimatedWinner {
-			return fmt.Errorf("calibrated ordering disagrees for %q: actual winner=%s estimated winner=%s",
-				name, actualWinner, estimatedWinner)
+		if actualWinner != estimatedWinner && !plansStatisticallyEquivalent(plans, actualWinner, estimatedWinner) {
+			actualRow := plans[actualWinner]
+			estimatedRow := plans[estimatedWinner]
+			return fmt.Errorf("calibrated ordering disagrees for %q: actual winner=%s (measured %.0f ns, estimated %.0f ns), estimated winner=%s (measured %.0f ns, estimated %.0f ns)",
+				name, actualWinner, actualRow.y, estimatedNS(actualRow, c),
+				estimatedWinner, estimatedRow.y, estimatedNS(estimatedRow, c))
 		}
 	}
 	return nil
+}
+
+func plansStatisticallyEquivalent(plans map[string]observation, left, right string) bool {
+	leftRow, leftOK := plans[left]
+	rightRow, rightOK := plans[right]
+	if !leftOK || !rightOK || leftRow.censored || rightRow.censored {
+		return false
+	}
+	difference := math.Abs(leftRow.y - rightRow.y)
+	noise := 3 * (leftRow.noiseNS + rightRow.noiseNS)
+	return difference <= noise
 }
 
 func printDecisionOrdering(rows []observation, c constants) {
@@ -1624,7 +1784,8 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_ordered_driver_input_row_ns",
 		"planner_membership_broad_text_match_row_ns",
 		"planner_membership_broad_text_match_byte_ns",
-		"planner_ordered_batch_accept_startup_ns",
+		"planner_membership_ordered_scan_invocation_ns",
+		"planner_direct_presence_probe_row_ns",
 	}
 	values := make([]int64, len(names))
 	content := string(data)
@@ -1632,6 +1793,15 @@ func readCurrentConstants(path string) (constants, error) {
 		prefix := "(define " + name + " "
 		start := strings.Index(content, prefix)
 		if start < 0 {
+			// The direct-probe coefficient used to be an anonymous literal inside
+			// planner_direct_presence_probe_cost. A one-nanosecond floor lets the
+			// first run fit it from direct-consumer observations and then persist
+			// the named coefficient in the generated block.
+			if name == "planner_direct_presence_probe_row_ns" ||
+				name == "planner_membership_ordered_scan_invocation_ns" {
+				values[i] = 1
+				continue
+			}
 			return constants{}, fmt.Errorf("cost constant %s not found", name)
 		}
 		start += len(prefix)
@@ -1652,10 +1822,11 @@ func readCurrentConstants(path string) (constants, error) {
 		recsetBuildRowNS: values[6], recsetProbeRowNS: values[7],
 		recsetAggregateRowNS: values[8], groupCacheStartupNS: values[9],
 		groupCacheBuildRowNS: values[10], groupCacheProbeRowNS: values[11],
-		orderedDriverInputNS:  values[12],
-		broadTextMatchRowNS:   values[13],
-		broadTextMatchByteNS:  values[14],
-		orderedBatchStartupNS: values[15],
+		orderedDriverInputNS:     values[12],
+		broadTextMatchRowNS:      values[13],
+		broadTextMatchByteNS:     values[14],
+		orderedScanInvocationNS:  values[15],
+		directPresenceProbeRowNS: values[16],
 	}, nil
 }
 
@@ -1675,8 +1846,9 @@ func patchQueryplan(path string, c constants) error {
 Calibrated by tools/costgen from tests/**/*.yaml workloads tagged with
 metadata.physical_calibration. Each observation is an executed, forced
 EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
+(define planner_direct_presence_probe_row_ns %d)
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
-	(planner_cost 0 0 (* probe_rows 48685) 0 0 0 0 0 probe_rows 0.75)))
+	(planner_cost 0 0 (* probe_rows planner_direct_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
@@ -1701,11 +1873,12 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_build_row_ns %d)
 (define planner_membership_group_cache_probe_row_ns %d)
 (define planner_membership_ordered_driver_input_row_ns %d)
-(define planner_ordered_batch_accept_startup_ns %d)
-/* END GENERATED COST CONSTANTS */`, c.scanInvocationNS, c.scanRowNS,
+(define planner_membership_ordered_scan_invocation_ns %d)
+/* END GENERATED COST CONSTANTS */`, c.directPresenceProbeRowNS,
+		c.scanInvocationNS, c.scanRowNS,
 		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS,
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedBatchStartupNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -40,6 +40,17 @@ func TestFitNonnegativePhysicalCostEquation(t *testing.T) {
 	}
 }
 
+func TestSolveKeepsBaselineWhenLegacyCarrierFitIsUnderdetermined(t *testing.T) {
+	baseline := constants{scanRowNS: 123}
+	got, err := solve(nil, nil, baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.scanRowNS != baseline.scanRowNS {
+		t.Fatalf("scan row coefficient = %d, want preserved baseline %d", got.scanRowNS, baseline.scanRowNS)
+	}
+}
+
 func TestValidateRowsRejectsDecisionPlanMismatch(t *testing.T) {
 	estimated, candidateInput, candidateRows, driverRows := 100.0, 1000.0, 100.0, 4000.0
 	rows := []calibrationRow{
@@ -101,19 +112,99 @@ func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
 		t.Fatalf("repeated broad text features = (%v, %v), want (400, 3276800)",
 			features[13], features[14])
 	}
-	if features[15] != 1 {
-		t.Fatalf("ordered batch startup feature = %v, want 1", features[15])
+	if features[12] != 4 {
+		t.Fatalf("ordered batch driver work = %v, want 4 rows²/1M", features[12])
+	}
+	if features[15] != 4 {
+		t.Fatalf("ordered scan invocations = %v, want 4", features[15])
 	}
 }
 
-func TestFitOrderedBatchStartupUsesExactBatchObservations(t *testing.T) {
-	features := make([]float64, 16)
-	features[15] = 1
-	value, ok := fitOrderedBatchStartup([]observation{
-		{plan: "ordered_batch_accept", y: 42000, x: features},
+func TestRowFeaturesModelsDirectPresenceProbes(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "driver_filter_join_probe", Consumer: "filter",
+		CandidateInputRows: value(100), CandidateRows: value(10), ProjectedDriverRows: value(20),
+		DriverInputRows: value(1000), DriverRows: value(25), ExpectedDriverRowsVisited: value(25),
+		ProbeBranches: value(3), CandidateScanInvocations: value(1), CandidateFilterColumns: value(1),
+		CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
+		CandidateExpressionOperations: value(1), CandidateBroadTextMatchRows: value(0),
+		CandidateBroadTextMatchBytes: value(0), DriverScanInvocations: value(1),
+		DriverFilterColumns: value(0), DriverMapColumns: value(1), DriverExpressionOperations: value(0),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(features) != 17 || features[16] != 75 {
+		t.Fatalf("direct presence features = %v, want 75 probes", features)
+	}
+}
+
+func TestFitOrderedScanInvocationUsesExactBatchObservations(t *testing.T) {
+	features := make([]float64, 17)
+	features[15] = 4
+	value, ok := fitOrderedScanInvocation([]observation{
+		{caseName: "batch", plan: "candidate_keyset", y: 1000, x: make([]float64, 17)},
+		{caseName: "batch", plan: "ordered_batch_accept", y: 2680, x: features},
 	}, constants{})
-	if !ok || value != 42000 {
-		t.Fatalf("ordered batch startup = (%d, %v), want (42000, true)", value, ok)
+	if !ok || value != 420 {
+		t.Fatalf("ordered scan invocation = (%d, %v), want (420, true)", value, ok)
+	}
+}
+
+func TestRowFeaturesModelsPrefilteredCandidateWork(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "prefiltered_candidate_keyset", Consumer: "order_limit",
+		CandidateInputRows: value(1000), CandidateRows: value(100), CandidateDensity: value(0.1),
+		ProjectedDriverRows: value(20), DriverInputRows: value(10000), DriverRows: value(72),
+		PrefilteredDriverRows: value(100), ExpectedDriverRowsVisited: value(100), ProbeBranches: value(2),
+		CandidateScanInvocations: value(2), CandidateFilterColumns: value(1), CandidateMapColumns: value(1),
+		CandidateCacheMapColumns: value(2), CandidateExpressionOperations: value(1),
+		CandidateBroadTextMatchRows: value(1000), CandidateBroadTextMatchBytes: value(8000),
+		DriverScanInvocations: value(1), DriverFilterColumns: value(1), DriverMapColumns: value(1),
+		DriverExpressionOperations: value(2),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// candidate work=200, matches=20, projection=420.
+	if features[0] != 3 || features[1] != 10620 || features[2] != 10200 || features[5] != 1 ||
+		features[3] != 420 || features[4] != 20200 || features[6] != 420 ||
+		features[13] != 200 || features[14] != 1600 {
+		t.Fatalf("prefiltered features = %v", features)
+	}
+}
+
+func TestFitDirectCarrierPairCancelsPairedCommonWork(t *testing.T) {
+	candidateA, driverA := make([]float64, 17), make([]float64, 17)
+	candidateA[5], candidateA[8], driverA[16] = 1, 1, 100
+	candidateB, driverB := make([]float64, 17), make([]float64, 17)
+	candidateB[5], candidateB[8], driverB[16] = 1, 1, 10
+	startup, probe, ok := fitDirectCarrierPair([]observation{
+		{caseName: "large", plan: "candidate_keyset", y: 10000, x: candidateA},
+		{caseName: "large", plan: "driver_filter_join_probe", y: 42000, x: driverA},
+		{caseName: "small", plan: "candidate_keyset", y: 10000, x: candidateB},
+		{caseName: "small", plan: "driver_filter_join_probe", y: 9000, x: driverB},
+	}, constants{})
+	if !ok || startup != 4667 || probe != 367 {
+		t.Fatalf("direct carrier pair = (%d, %d, %v), want (4667, 367, true)", startup, probe, ok)
+	}
+}
+
+func TestDecisionAlternativesAcceptsDirectFilterConsumer(t *testing.T) {
+	rows := []observation{
+		{caseName: "filter", plan: "candidate_keyset"},
+		{caseName: "filter", plan: "driver_filter_join_probe"},
+	}
+	groups, err := decisionAlternatives(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups["filter"]) != 2 {
+		t.Fatalf("unexpected alternatives: %+v", groups)
 	}
 }
 
@@ -135,7 +226,7 @@ func TestMedianRowsAcceptsOrderedBatchPlans(t *testing.T) {
 
 func TestValidateDecisionOrderingIncludesOrderedBatch(t *testing.T) {
 	features := func(first float64) []float64 {
-		values := make([]float64, 15)
+		values := make([]float64, 17)
 		values[0] = first
 		return values
 	}
@@ -146,6 +237,25 @@ func TestValidateDecisionOrderingIncludesOrderedBatch(t *testing.T) {
 	}
 	if err := validateDecisionOrdering(rows, constants{scanInvocationNS: 1}); err == nil {
 		t.Fatal("three-way validation accepted an incorrectly ranked ordered batch plan")
+	}
+}
+
+func TestDecisionOrderingAcceptsOnlyMeasuredNoiseTies(t *testing.T) {
+	features := func(first float64) []float64 {
+		values := make([]float64, 17)
+		values[0] = first
+		return values
+	}
+	rows := []observation{
+		{caseName: "tie", plan: "candidate_keyset", y: 100, noiseNS: 10, x: features(2)},
+		{caseName: "tie", plan: "driver_order_membership_probe", y: 120, noiseNS: 10, x: features(1)},
+	}
+	if err := validateDecisionOrdering(rows, constants{scanInvocationNS: 1}); err != nil {
+		t.Fatalf("noise-equivalent alternatives rejected: %v", err)
+	}
+	rows[1].y = 200
+	if err := validateDecisionOrdering(rows, constants{scanInvocationNS: 1}); err == nil {
+		t.Fatal("materially slower estimated winner accepted as a noise tie")
 	}
 }
 


### PR DESCRIPTION
## What

- moves membership carrier selection to the consuming physical scan-tree edge, where executable alternatives and downstream probe work are known
- makes ordered LIMIT consumers compare projected RecSets, ordered key probes, adaptive `scan_order_batch_accept`, and prefiltered candidates through one calibrated cost model
- lets the batch callback lower residual predicates and nested probes against the smaller batch cardinality
- combines RecSet membership with LIKE/bigram index-hook boundaries inside `scan_recset`, independent of SQL shape
- keeps logical reorder output physical-artifact-free and records all alternatives through `EXPLAIN PHYSICAL CALIBRATE`

## Calibration A/B

Fresh forced-plan measurements from the committed calibration suite:

- cache-backed computed key, tiny driver: direct probe 0.61 ms vs candidate cache 5.16 ms
- ordered LIMIT 10: ordered key probe 2.12 ms vs candidate 2.59 ms vs adaptive batch 6.71 ms
- production-scale broad text: adaptive batch 48.88 ms vs candidate 101.03 ms vs ordered probe 128.43 ms
- production-scale adaptive holdout: adaptive batch 48.01 ms vs ordered probe 78.10 ms vs candidate 116.75 ms
- selective prefilter holdout: prefiltered candidate 36.75 ms vs ordered probe 132.22 ms vs candidate 142.53 ms
- wide text: adaptive batch 54.58 ms vs candidate 263.35 ms vs ordered probe 551.42 ms

The fitted model gets 16/16 training decisions and 5/5 holdout decisions correct. Calibration separates direct UNION RecSets from group-cache-backed candidates and derives ordered-scan/group-cache coefficients from paired variants, so shared query work is not misattributed to a carrier.

## CI follow-ups

The first CI run exposed an incorrect model coupling: the calibrated membership-probe coefficient was also driving compound scalar-presence carriers. Commit `0a4a1bf0a` gives scalar-presence and membership probes separate generated coefficients and switches only membership consumers to the membership model. This restored both structural planner assertions.

The next CI run exposed a real ordered-filter regression (37.2 ms against a scaled 29 ms limit), not a flaky gate. Fresh-data A/B showed:

- parent path: 11.9 ms, then 2.1/2.4 ms
- regressed path: 28.0 ms, then 17.1/17.2 ms
- fixed adaptive path: 5.3–8.4 ms median samples, then 2.2–3.1 ms warm

Scan telemetry identified the cause: fusing multiple OR-nested membership predicates into `scan_order` made it visit and re-sort all 10,000 driver rows on every execution (about 15 ms scan time). Commit `6e4aa9b2c` generalizes adaptive batching so the consuming ordered scan can send any number of nested membership probes through its residual batch filter. Unsupported RecSet projections remain ordinary exact probes inside that smaller batch. With unknown cardinalities, adaptive batching is the bounded fallback; with known statistics, the same calibrated alternatives still compete by total cost. A permanent EXPLAIN assertion now requires this shape.

Computed group-cache keys can also remain direct indexed keytable probes instead of being copied into a RecSet index. Multiple independent membership keytables receive separate bindings, while compatible candidates may still share one immutable key index.

## Live application result

After warming the current branch, the application start page is back to approximately **60 ms**. This is the best recent result and confirms that the planner work is moving the broad workload in the intended direction, not only the synthetic fixtures.

## Validation

- startup Scheme tests: 1267/1267
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml`: 20/20
- `tests/planner/subqueries/in-subquery.yaml`: 71/71, including the 6.2 ms local median and adaptive-batch EXPLAIN assertion
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 15/15
- `tests/execution/operators/recset.yaml`: 34/34
- `go test ./tools/costgen`
- new RecSet+LIKE boundary test: 10/10 repeated
- Scheme formatter/check for all changed planner files
- rebased over the nested streaming-callback fix from master

The complete SQL suite is intentionally left to CI.

The third CI run exposed an ownership bug in physical lowering: membership markers selected the correct raw RecSet carrier, but the query-block prelude still prepared the marker's now-unused logical group cache. Commit `54a8b80ea` makes the selected physical carrier the exclusive owner of preparation. Raw RecSet and direct-probe alternatives therefore create no cache; cache-backed RecSet and direct-key-probe alternatives prepare their cache exactly once themselves. Structural tests now reject an unused `touch_keytable` on adaptive ordered membership and require the complete joined-file candidate relation to reach the document driver through `recset_project_join`.

Additional targeted validation after that fix:

- `tests/sql/expressions/prepared-stmts.yaml`: 49/49
- `tests/planner/subqueries/in-subquery.yaml`: 71/71
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml`: 20/20
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 15/15
- `tests/execution/operators/recset.yaml`: 34/34