### PR TITLE
Optimize cold compilation for independent scalar stages

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5851,48 +5851,59 @@ recipe in one zero-argument helper. */
 					(list (list (quote context) "session") (shared_prepare_owner_key stage))
 					(quoted_runtime_list '())))))))
 
+(define closed_group_prepare_consolidation_required? (lambda (ir)
+	(and (query_block? (ir_root ir))
+		(reduce
+			(stage_catalog_with_nested
+				(query_block_stage_catalog (ir_root ir)))
+			(lambda (shared stage)
+				(or shared (stage_shared_prepare? stage)))
+			false))))
+
 /* Recipe emission is a two-step physical pass: normal lowering records which
 lazy stage keys are actually reachable, then this collector emits one closed
 initializer owner per canonical carrier and replaces local copies with aliases.
 Both AST walks are linear; no pairwise recipe comparison is performed. */
 (define consolidate_closed_group_prepares (lambda (ir plan)
-	(if (not (query_block? (ir_root ir)))
+	(if (not (closed_group_prepare_consolidation_required? ir))
 		plan
 		(begin
 			(define catalog (stage_catalog_with_nested
 				(query_block_stage_catalog (ir_root ir))))
-			(if (empty_list? catalog)
-				plan
-				(begin
-					(define emitted_keys (emitted_prepare_binding_keys plan '()))
-					(define emitted_call_keys (emitted_prepare_call_keys plan '()))
-					(define emitted_strings (physical_string_set plan '()))
-					(define dependency_graph (stage_dependency_graph catalog))
-					(define consumers (filter catalog (lambda (stage)
-						(and (closed_group_prepare_stage? dependency_graph stage)
-							(has_assoc? emitted_keys (stage_prepare_key stage))))))
-					(define selected_backbones (stage_prepare_backbone_set consumers))
-					/* A consumer can read an aggregate column without owning a prepare
-					binding. Once a carrier is reachable, collect every compatible column
-					requirement for it from the canonical catalog. */
-					(define selected (filter catalog (lambda (stage)
-						(and (closed_group_prepare_stage? dependency_graph stage)
-							(and (has_assoc? selected_backbones (stage_prepare_backbone_signature stage))
-								(or (has_assoc? emitted_keys (stage_prepare_key stage))
-									(or (has_assoc? emitted_call_keys (stage_prepare_key stage))
-										(stage_aggregate_referenced? emitted_strings stage))))))))
-					(if (empty_list? selected)
-						plan
-						(begin
-							(define carriers (collect_stage_prepares selected))
-							(define selected_keys (reduce selected (lambda (keys stage)
-								(set_assoc keys (stage_prepare_key stage) true)) '()))
-							(cons (quote !begin)
-								(merge (list
-									(map carriers (lambda (stage)
-										(shared_prepare_owner_binding dependency_graph catalog stage)))
-									(map selected shared_prepare_alias_binding)
-									(list (without_prepare_bindings plan selected_keys)))))))))))))
+			/* Unique carriers already own exactly one initializer. The consolidation
+			pass exists only for canonical backbones shared by multiple logical
+			stages; without one, its repeated full-plan usage and rewrite walks are
+			pure allocation overhead on wide scalar read models. */
+			(begin
+				(define emitted_keys (emitted_prepare_binding_keys plan '()))
+				(define emitted_call_keys (emitted_prepare_call_keys plan '()))
+				(define emitted_strings (physical_string_set plan '()))
+				(define dependency_graph (stage_dependency_graph catalog))
+				(define consumers (filter catalog (lambda (stage)
+					(and (closed_group_prepare_stage? dependency_graph stage)
+						(has_assoc? emitted_keys (stage_prepare_key stage))))))
+				(define selected_backbones (stage_prepare_backbone_set consumers))
+				/* A consumer can read an aggregate column without owning a prepare
+				binding. Once a carrier is reachable, collect every compatible column
+				requirement for it from the canonical catalog. */
+				(define selected (filter catalog (lambda (stage)
+					(and (closed_group_prepare_stage? dependency_graph stage)
+						(and (has_assoc? selected_backbones (stage_prepare_backbone_signature stage))
+							(or (has_assoc? emitted_keys (stage_prepare_key stage))
+								(or (has_assoc? emitted_call_keys (stage_prepare_key stage))
+									(stage_aggregate_referenced? emitted_strings stage))))))))
+				(if (empty_list? selected)
+					plan
+					(begin
+						(define carriers (collect_stage_prepares selected))
+						(define selected_keys (reduce selected (lambda (keys stage)
+							(set_assoc keys (stage_prepare_key stage) true)) '()))
+						(cons (quote !begin)
+							(merge (list
+								(map carriers (lambda (stage)
+									(shared_prepare_owner_binding dependency_graph catalog stage)))
+								(map selected shared_prepare_alias_binding)
+								(list (without_prepare_bindings plan selected_keys))))))))))))
 
 (define physical_plan_uses_query_scope? (lambda (expr)
 	(if (or (equal? expr (physical_query_session_symbol))

--- a/tests/integration/query-shapes/traced-late-projection-read-models.yaml
+++ b/tests/integration/query-shapes/traced-late-projection-read-models.yaml
@@ -1093,6 +1093,29 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "Diverse independent scalar stages skip shared-carrier consolidation"
+    scm: |
+      (begin
+        (define independent_stage (make_group_stage
+          "independent" (list "item" "memcp-tests" "trace_wide_prop" false nil)
+          '() '(1) '() nil '() '() nil nil '()))
+        (define shared_stage (group_stage_with_facts independent_stage
+          (qassoc_set (gs_facts independent_stage) (quote shared_prepare) true)))
+        (define make_test_ir (lambda (stage)
+          (make_ir (quote select)
+            (make_query_block "memcp-tests" '() '(1) true '() nil '() nil nil '()
+              (list stage) '())
+            '() nil (quote rows))))
+        (if (and
+            (not (closed_group_prepare_consolidation_required?
+              (make_test_ir independent_stage)))
+            (closed_group_prepare_consolidation_required?
+              (make_test_ir shared_stage)))
+          "ok"
+          (error "shared-carrier consolidation predicate lost stage ownership")))
+    expect:
+      data: ["ok"]
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trace_case_item"
   - sql: "DROP TABLE IF EXISTS trace_lazy_error"


### PR DESCRIPTION
## Summary

- skip shared-carrier consolidation when physical preparation proves that no stage shares a prepare backbone
- preserve consolidation for genuinely shared carriers
- add a deterministic regression covering both independent and shared stage catalogs

## Evidence

A 128-stage scalar/EXISTS/CASE compile shape took 7.59 s on current master and 7.16–7.30 s with this change. The emitted physical plan is unchanged; the improvement comes from avoiding repeated full-plan collection and rewrite walks.

## Validation

- `python3 run_sql_tests.py tests/integration/query-shapes/traced-late-projection-read-models.yaml` (35/35)
- `python3 run_sql_tests.py tests/storage/indexes/fulltext-like-index.yaml` (86/86)
- `make test` (passed)
- `python3 tools/lint_scm.py`
- `git diff --check`