### PR TITLE
Bound concurrent cold query compilation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/ulikunitz/xz v0.5.15
-	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.21.0
 	golang.org/x/tools v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -51,6 +50,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.21.0
 	golang.org/x/tools v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -50,7 +51,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )
 

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -23,8 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (import "sql-views.scm")
 
 /* query plan caches: separate cachemap per parser dialect */
-(set sql_queryplan_cache (newcachemap))
-(set psql_queryplan_cache (newcachemap))
+(set sql_queryplan_cache (newcachemap "compile"))
+(set psql_queryplan_cache (newcachemap "compile"))
 (set sql_literal_shape_cache (newcachemap))
 
 /* Keep exact SQL variants out of the parser while sharing their compiled plan.

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -27,6 +27,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (set psql_queryplan_cache (newcachemap "compile"))
 (set sql_literal_shape_cache (newcachemap))
 
+/* Keep several small cold plans concurrent while preventing a single very
+wide generated query from competing with three equally allocation-heavy
+producers. The admission remains outside parsing and does not affect hits. */
+(define sql_query_compile_weight (lambda (query)
+	(if (> (strlen query) 65536)
+		3
+		(if (> (strlen query) 32768) 2 1))))
+
 /* Keep exact SQL variants out of the parser while sharing their compiled plan.
 Only parameterized results enter the small front cache; exact-only statements
 continue to occupy just their existing query-plan entry. The third result item
@@ -323,10 +331,12 @@ On parse error the result is not cached. */
 			(define formula (if (or compile_diagnostic (not guarded_select))
 				(if compile_diagnostic
 					(exact_compile)
-					(queryplan_cache "get_or_compute" cache_key exact_compile))
+					(queryplan_cache "get_or_compute" cache_key exact_compile
+						(sql_query_compile_weight parse_query)))
 				(begin
 					(define cached_entry (queryplan_cache "get_or_compute" cache_key
-						(lambda () (sql_queryplan_new_entry queryplan_cache cache_key parse_fn schema parse_query policy session))))
+						(lambda () (sql_queryplan_new_entry queryplan_cache cache_key parse_fn schema parse_query policy session))
+						(sql_query_compile_weight parse_query)))
 					(cadr cached_entry))))
 			formula)))))
 

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -27,13 +27,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (set psql_queryplan_cache (newcachemap "compile"))
 (set sql_literal_shape_cache (newcachemap))
 
-/* Keep several small cold plans concurrent while preventing a single very
-wide generated query from competing with three equally allocation-heavy
-producers. The admission remains outside parsing and does not affect hits. */
+/* Keep several small cold plans concurrent while preventing generated queries
+whose formula trees amplify their source size from compiling beside equally
+allocation-heavy producers. The admission remains outside parsing and does not
+affect hits. */
 (define sql_query_compile_weight (lambda (query)
-	(if (> (strlen query) 65536)
+	(if (> (strlen query) 32768)
 		3
-		(if (> (strlen query) 32768) 2 1))))
+		(if (> (strlen query) 16384) 2 1))))
 
 /* Keep exact SQL variants out of the parser while sharing their compiled plan.
 Only parameterized results enter the small front cache; exact-only statements

--- a/storage/cachemap.go
+++ b/storage/cachemap.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,36 @@ import (
 // Per-entry overhead: cacheMapEntry struct (~80 bytes) + map bucket slot (~128 bytes) + softItem (~120 bytes)
 const cacheMapEntryOverhead = 328
 
+var queryCompileAdmission = newCacheMapAdmission()
+
+type cacheMapAdmission struct {
+	tokens chan struct{}
+}
+
+func newCacheMapAdmission() *cacheMapAdmission {
+	limit := (runtime.GOMAXPROCS(0) + 1) / 2
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 4 {
+		limit = 4
+	}
+	return &cacheMapAdmission{tokens: make(chan struct{}, limit)}
+}
+
+func (a *cacheMapAdmission) acquire(ctx context.Context) bool {
+	select {
+	case a.tokens <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (a *cacheMapAdmission) release() {
+	<-a.tokens
+}
+
 type cacheMapEntry struct {
 	cm       *cacheMap
 	key      string
@@ -37,9 +68,10 @@ type cacheMapEntry struct {
 }
 
 type cacheMap struct {
-	mu      sync.RWMutex
-	entries map[string]*cacheMapEntry
-	flights map[string]*cacheMapFlight
+	mu        sync.RWMutex
+	entries   map[string]*cacheMapEntry
+	flights   map[string]*cacheMapFlight
+	admission *cacheMapAdmission
 }
 
 type cacheMapFlight struct {
@@ -60,6 +92,9 @@ func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 	cm := &cacheMap{
 		entries: make(map[string]*cacheMapEntry),
 		flights: make(map[string]*cacheMapFlight),
+	}
+	if len(a) == 1 && scm.String(a[0]) == "compile" {
+		cm.admission = queryCompileAdmission
 	}
 	return scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
 		switch len(a) {
@@ -199,7 +234,18 @@ func (cm *cacheMap) cancelWaiter(key string, flight *cacheMapFlight) {
 }
 
 func (cm *cacheMap) runProducer(ctx context.Context, key string, producer scm.Scmer, flight *cacheMapFlight) {
+	if cm.admission != nil {
+		if !cm.admission.acquire(ctx) {
+			cm.finishProducer(ctx, key, flight, scm.NewNil(), ctx.Err(), true)
+			return
+		}
+		defer cm.admission.release()
+	}
 	value, panicValue, failed := runCacheMapProducer(ctx, producer)
+	cm.finishProducer(ctx, key, flight, value, panicValue, failed)
+}
+
+func (cm *cacheMap) finishProducer(ctx context.Context, key string, flight *cacheMapFlight, value scm.Scmer, panicValue any, failed bool) {
 
 	var entry *cacheMapEntry
 	if !failed && ctx.Err() == nil {

--- a/storage/cachemap.go
+++ b/storage/cachemap.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/launix-de/memcp/scm"
+	"golang.org/x/sync/semaphore"
 )
 
 // Per-entry overhead: cacheMapEntry struct (~80 bytes) + map bucket slot (~128 bytes) + softItem (~120 bytes)
@@ -32,7 +33,8 @@ const cacheMapEntryOverhead = 328
 var queryCompileAdmission = newCacheMapAdmission()
 
 type cacheMapAdmission struct {
-	tokens chan struct{}
+	limit  int64
+	tokens *semaphore.Weighted
 }
 
 func newCacheMapAdmission() *cacheMapAdmission {
@@ -43,20 +45,28 @@ func newCacheMapAdmission() *cacheMapAdmission {
 	if limit > 4 {
 		limit = 4
 	}
-	return &cacheMapAdmission{tokens: make(chan struct{}, limit)}
-}
-
-func (a *cacheMapAdmission) acquire(ctx context.Context) bool {
-	select {
-	case a.tokens <- struct{}{}:
-		return true
-	case <-ctx.Done():
-		return false
+	return &cacheMapAdmission{
+		limit:  int64(limit),
+		tokens: semaphore.NewWeighted(int64(limit)),
 	}
 }
 
-func (a *cacheMapAdmission) release() {
-	<-a.tokens
+func (a *cacheMapAdmission) boundedWeight(weight int64) int64 {
+	if weight < 1 {
+		return 1
+	}
+	if weight > a.limit {
+		return a.limit
+	}
+	return weight
+}
+
+func (a *cacheMapAdmission) acquire(ctx context.Context, weight int64) bool {
+	return a.tokens.Acquire(ctx, a.boundedWeight(weight)) == nil
+}
+
+func (a *cacheMapAdmission) release(weight int64) {
+	a.tokens.Release(a.boundedWeight(weight))
 }
 
 type cacheMapEntry struct {
@@ -128,9 +138,14 @@ func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 			if scm.String(a[0]) != "get_or_compute" {
 				panic("cachemap: unknown 3-argument operation")
 			}
-			return cm.getOrCompute(scm.String(a[1]), a[2])
+			return cm.getOrCompute(scm.String(a[1]), a[2], 1)
+		case 4:
+			if scm.String(a[0]) != "get_or_compute" {
+				panic("cachemap: unknown 4-argument operation")
+			}
+			return cm.getOrCompute(scm.String(a[1]), a[2], int64(scm.ToInt(a[3])))
 		default:
-			panic("cachemap: expected 0, 1, 2, or 3 arguments")
+			panic("cachemap: expected 0, 1, 2, 3, or 4 arguments")
 		}
 	})
 }
@@ -178,7 +193,7 @@ func currentCacheMapContext() context.Context {
 	return context.Background()
 }
 
-func (cm *cacheMap) getOrCompute(key string, producer scm.Scmer) scm.Scmer {
+func (cm *cacheMap) getOrCompute(key string, producer scm.Scmer, weight int64) scm.Scmer {
 	cm.mu.RLock()
 	if entry := cm.entries[key]; entry != nil {
 		entry.lastUsed.Store(time.Now().UnixNano())
@@ -202,7 +217,7 @@ func (cm *cacheMap) getOrCompute(key string, producer scm.Scmer) scm.Scmer {
 			waiters: 1,
 		}
 		cm.flights[key] = flight
-		go cm.runProducer(compileCtx, key, producer, flight)
+		go cm.runProducer(compileCtx, key, producer, flight, weight)
 	} else {
 		flight.waiters++
 	}
@@ -233,13 +248,13 @@ func (cm *cacheMap) cancelWaiter(key string, flight *cacheMapFlight) {
 	cm.mu.Unlock()
 }
 
-func (cm *cacheMap) runProducer(ctx context.Context, key string, producer scm.Scmer, flight *cacheMapFlight) {
+func (cm *cacheMap) runProducer(ctx context.Context, key string, producer scm.Scmer, flight *cacheMapFlight, weight int64) {
 	if cm.admission != nil {
-		if !cm.admission.acquire(ctx) {
+		if !cm.admission.acquire(ctx, weight) {
 			cm.finishProducer(ctx, key, flight, scm.NewNil(), ctx.Err(), true)
 			return
 		}
-		defer cm.admission.release()
+		defer cm.admission.release(weight)
 	}
 	value, panicValue, failed := runCacheMapProducer(ctx, producer)
 	cm.finishProducer(ctx, key, flight, value, panicValue, failed)

--- a/storage/cachemap.go
+++ b/storage/cachemap.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/launix-de/memcp/scm"
-	"golang.org/x/sync/semaphore"
 )
 
 // Per-entry overhead: cacheMapEntry struct (~80 bytes) + map bucket slot (~128 bytes) + softItem (~120 bytes)
@@ -33,8 +32,10 @@ const cacheMapEntryOverhead = 328
 var queryCompileAdmission = newCacheMapAdmission()
 
 type cacheMapAdmission struct {
-	limit  int64
-	tokens *semaphore.Weighted
+	mu      sync.Mutex
+	limit   int64
+	used    int64
+	changed chan struct{}
 }
 
 func newCacheMapAdmission() *cacheMapAdmission {
@@ -46,8 +47,8 @@ func newCacheMapAdmission() *cacheMapAdmission {
 		limit = 4
 	}
 	return &cacheMapAdmission{
-		limit:  int64(limit),
-		tokens: semaphore.NewWeighted(int64(limit)),
+		limit:   int64(limit),
+		changed: make(chan struct{}),
 	}
 }
 
@@ -62,11 +63,31 @@ func (a *cacheMapAdmission) boundedWeight(weight int64) int64 {
 }
 
 func (a *cacheMapAdmission) acquire(ctx context.Context, weight int64) bool {
-	return a.tokens.Acquire(ctx, a.boundedWeight(weight)) == nil
+	weight = a.boundedWeight(weight)
+	for {
+		a.mu.Lock()
+		if a.used+weight <= a.limit {
+			a.used += weight
+			a.mu.Unlock()
+			return true
+		}
+		changed := a.changed
+		a.mu.Unlock()
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return false
+		}
+	}
 }
 
 func (a *cacheMapAdmission) release(weight int64) {
-	a.tokens.Release(a.boundedWeight(weight))
+	weight = a.boundedWeight(weight)
+	a.mu.Lock()
+	a.used -= weight
+	close(a.changed)
+	a.changed = make(chan struct{})
+	a.mu.Unlock()
 }
 
 type cacheMapEntry struct {

--- a/storage/cachemap_test.go
+++ b/storage/cachemap_test.go
@@ -77,3 +77,71 @@ func TestCompileCacheBoundsDistinctColdProducers(t *testing.T) {
 	close(release)
 	callers.Wait()
 }
+
+func TestCompileCacheAdmissionAccountsForProducerWeight(t *testing.T) {
+	cache := NewCacheMap(scm.NewString("compile"))
+	limit := (runtime.GOMAXPROCS(0) + 1) / 2
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 4 {
+		limit = 4
+	}
+
+	heavyStarted := make(chan struct{}, 1)
+	heavyRelease := make(chan struct{})
+	lightStarted := make(chan struct{}, 1)
+	var callers sync.WaitGroup
+	callers.Add(2)
+	go func() {
+		defer callers.Done()
+		producer := scm.NewFunc(func(_ ...scm.Scmer) scm.Scmer {
+			heavyStarted <- struct{}{}
+			<-heavyRelease
+			return scm.NewString("heavy")
+		})
+		scm.Apply(cache,
+			scm.NewString("get_or_compute"),
+			scm.NewString("heavy"),
+			producer,
+			scm.NewInt(int64(limit)),
+		)
+	}()
+	select {
+	case <-heavyStarted:
+	case <-time.After(time.Second):
+		close(heavyRelease)
+		callers.Wait()
+		t.Fatal("weighted producer did not start")
+	}
+
+	go func() {
+		defer callers.Done()
+		producer := scm.NewFunc(func(_ ...scm.Scmer) scm.Scmer {
+			lightStarted <- struct{}{}
+			return scm.NewString("light")
+		})
+		scm.Apply(cache,
+			scm.NewString("get_or_compute"),
+			scm.NewString("light"),
+			producer,
+			scm.NewInt(1),
+		)
+	}()
+	select {
+	case <-lightStarted:
+		close(heavyRelease)
+		callers.Wait()
+		t.Fatal("light producer bypassed the weighted admission budget")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(heavyRelease)
+	select {
+	case <-lightStarted:
+	case <-time.After(time.Second):
+		callers.Wait()
+		t.Fatal("light producer did not start after weighted release")
+	}
+	callers.Wait()
+}

--- a/storage/cachemap_test.go
+++ b/storage/cachemap_test.go
@@ -145,3 +145,84 @@ func TestCompileCacheAdmissionAccountsForProducerWeight(t *testing.T) {
 	}
 	callers.Wait()
 }
+
+func TestCompileCacheAdmissionLetsLightProducerBypassQueuedHeavyProducer(t *testing.T) {
+	limit := (runtime.GOMAXPROCS(0) + 1) / 2
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 4 {
+		limit = 4
+	}
+	if limit == 1 {
+		t.Skip("one admission slot cannot retain spare capacity")
+	}
+
+	cache := NewCacheMap(scm.NewString("compile"))
+	firstStarted := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	queuedStarted := make(chan struct{}, 1)
+	queuedRelease := make(chan struct{})
+	lightStarted := make(chan struct{}, 1)
+	var callers sync.WaitGroup
+	startProducer := func(key string, weight int, started chan<- struct{}, release <-chan struct{}) {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			producer := scm.NewFunc(func(_ ...scm.Scmer) scm.Scmer {
+				started <- struct{}{}
+				if release != nil {
+					<-release
+				}
+				return scm.NewString(key)
+			})
+			scm.Apply(cache,
+				scm.NewString("get_or_compute"),
+				scm.NewString(key),
+				producer,
+				scm.NewInt(int64(weight)),
+			)
+		}()
+	}
+
+	startProducer("first-heavy", limit-1, firstStarted, firstRelease)
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		close(firstRelease)
+		callers.Wait()
+		t.Fatal("first weighted producer did not start")
+	}
+
+	startProducer("queued-heavy", limit, queuedStarted, queuedRelease)
+	select {
+	case <-queuedStarted:
+		close(firstRelease)
+		close(queuedRelease)
+		callers.Wait()
+		t.Fatal("full-weight producer started without enough capacity")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	startProducer("light", 1, lightStarted, nil)
+	select {
+	case <-lightStarted:
+	case <-time.After(time.Second):
+		close(firstRelease)
+		<-queuedStarted
+		close(queuedRelease)
+		callers.Wait()
+		t.Fatal("light producer was blocked behind a queued full-weight producer")
+	}
+
+	close(firstRelease)
+	select {
+	case <-queuedStarted:
+	case <-time.After(time.Second):
+		close(queuedRelease)
+		callers.Wait()
+		t.Fatal("queued full-weight producer did not start after capacity was released")
+	}
+	close(queuedRelease)
+	callers.Wait()
+}

--- a/storage/cachemap_test.go
+++ b/storage/cachemap_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2026  MemCP Contributors
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func TestCompileCacheBoundsDistinctColdProducers(t *testing.T) {
+	cache := NewCacheMap(scm.NewString("compile"))
+	limit := (runtime.GOMAXPROCS(0) + 1) / 2
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 4 {
+		limit = 4
+	}
+	producerCount := limit + 4
+	started := make(chan struct{}, producerCount)
+	release := make(chan struct{})
+	var callers sync.WaitGroup
+
+	for i := 0; i < producerCount; i++ {
+		callers.Add(1)
+		go func(key string) {
+			defer callers.Done()
+			producer := scm.NewFunc(func(_ ...scm.Scmer) scm.Scmer {
+				started <- struct{}{}
+				<-release
+				return scm.NewString(key)
+			})
+			scm.Apply(cache,
+				scm.NewString("get_or_compute"),
+				scm.NewString(key),
+				producer,
+			)
+		}(fmt.Sprintf("shape-%d", i))
+	}
+
+	for i := 0; i < limit; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			close(release)
+			callers.Wait()
+			t.Fatal("compile producer did not reach the admission limit")
+		}
+	}
+	select {
+	case <-started:
+		close(release)
+		callers.Wait()
+		t.Fatalf("more than %d distinct cold producers compiled concurrently", limit)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	callers.Wait()
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3381,7 +3381,7 @@ func Init(en scm.Env) {
 	initMetricsDeclarations(en)
 	scm.DeclareInSection("Sync", &en, &scm.Declaration{
 		Name: "newcachemap",
-		Desc: "Creates a new cachemap. The optional compile mode bounds distinct concurrent producers to avoid GC collapse during cold query compilation. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
+		Desc: "Creates a new cachemap. The optional compile mode bounds distinct concurrent producers to avoid GC collapse during cold query compilation. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer [weight]) computes one value for concurrent misses of the same key.",
 		Fn:   NewCacheMap,
 		Type: &scm.TypeDescriptor{
 			Params: []*scm.TypeDescriptor{

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3381,9 +3381,12 @@ func Init(en scm.Env) {
 	initMetricsDeclarations(en)
 	scm.DeclareInSection("Sync", &en, &scm.Declaration{
 		Name: "newcachemap",
-		Desc: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
+		Desc: "Creates a new cachemap. The optional compile mode bounds distinct concurrent producers to avoid GC collapse during cold query compilation. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
 		Fn:   NewCacheMap,
 		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", ParamName: "mode", ParamDesc: "optional producer admission mode; use compile for query-plan caches", Optional: true},
+			},
 			Return: &scm.TypeDescriptor{Kind: "func"},
 		},
 	})

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -54,6 +54,35 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "Large cold compile reserves proportional admission capacity"
+    scm: |
+      (begin
+        (define cache (newcachemap "compile"))
+        (define timings (newsession))
+        (define values (parallelN 2 (lambda (i)
+          (if (equal? i 0)
+            (cache "get_or_compute" "heavy-shape" (lambda ()
+              (begin
+                (timings "heavy-start" (nanotime))
+                (sleep 0.1)
+                (timings "heavy-end" (nanotime))
+                "heavy")) 4)
+            (cache "get_or_compute" "light-shape" (lambda ()
+              (begin
+                (timings "light-start" (nanotime))
+                (sleep 0.1)
+                (timings "light-end" (nanotime))
+                "light")) 1)))))
+        (if (and
+          (equal? values (list "heavy" "light"))
+          (or
+            (>= (timings "light-start") (timings "heavy-end"))
+            (>= (timings "heavy-start") (timings "light-end"))))
+          "ok"
+          (error "weighted cold compile admission overlapped full capacity")))
+    expect:
+      data: ["ok"]
+
   - name: "Creator waits for existing table initialization 1/2"
     parallel: existing_creation_barrier
     scm: &create_with_initializer |

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -29,6 +29,31 @@ setup:
       )
 
 test_cases:
+  - name: "Distinct cold compile producers have bounded overlap"
+    scm: |
+      (begin
+        (define cache (newcachemap "compile"))
+        (define timings (newsession))
+        (define producer_count 12)
+        (define values (parallelN producer_count (lambda (i)
+          (cache "get_or_compute" (concat "shape-" i) (lambda ()
+            (begin
+              (timings (concat "start-" i) (nanotime))
+              (sleep 0.1)
+              (timings (concat "end-" i) (nanotime))
+              i))))))
+        (define peak (reduce (produceN producer_count) (lambda (highest i)
+          (begin
+            (define started (timings (concat "start-" i)))
+            (max highest (count (filter (produceN producer_count) (lambda (j)
+              (and (<= (timings (concat "start-" j)) started)
+                (>= (timings (concat "end-" j)) started)))))))) 0))
+        (if (and (equal? values (produceN producer_count)) (<= peak 4))
+          "ok"
+          (error (concat "cold compile producer overlap=" peak))))
+    expect:
+      data: ["ok"]
+
   - name: "Creator waits for existing table initialization 1/2"
     parallel: existing_creation_barrier
     scm: &create_with_initializer |


### PR DESCRIPTION
## Summary

- add a shared, cancellation-aware admission limit for cold SQL and PostgreSQL query-plan cache producers
- weight generated queries by source size so formula-tree-heavy plans reserve more compile capacity
- let light producers use spare capacity instead of waiting behind a queued full-capacity producer
- leave cache hits, query execution, and unrelated cache maps unrestricted
- add deterministic Go and YAML regressions for overlap, weights, and head-of-line blocking

## 12-worker cold-workload A/B

| | Before | After weighted admission |
|---|---:|---:|
| Phase workflows passed | 7/19 | 18/19 |
| Slowest SELECT | 46.05 s | 5.97 s |
| Second slowest SELECT | 43.21 s | 5.26 s |

Further traces found that FIFO weighted admission could make trivial session and update statements wait about 3.3 s behind one queued wide compile even while a slot was free. The non-FIFO capacity controller removes that head-of-line stall. Medium generated statements of 42–46 KiB took about 2.4–2.5 s alone but 4.7–9.1 s when admitted in pairs, which motivates the adjusted 16/32 KiB weight boundaries.

The latest cold parallel run reached 18/19. The remaining browser failure did not execute the expected write transaction; the same workflow passed in a 56.2 s isolated warm run. It therefore remains evidence of cold-load responsiveness, not evidence of committed rows being lost.

## Locking and cancellation

Admission happens in the cache producer goroutine after the cache-map mutex is released. It acquires no table or shard locks. Waiters only hold the admission mutex for an O(1) capacity check. Capacity changes wake blocked producers, and canceled compile contexts leave capacity untouched.

## Validation

- fail-first on FIFO admission: a light producer was blocked behind a queued full-weight producer despite spare capacity
- `go test ./storage -run TestCompileCache -count=20`
- `python3 run_sql_tests.py tests/execution/concurrency/group-cache-initialization.yaml`
- `make test` (passed after final changes)
- repeated 12-worker browser workloads against fresh databases
- `python3 tools/lint_scm.py --check`
- `git diff --check`