### PR TITLE
Cancel read-only scans between batches

### DIFF
--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -225,9 +225,8 @@ func (s *SessionState) ClearCancel(seq uint64) {
 
 // IsKilled returns true if this session has been killed.
 //
-// Storage execution contract: callers may check cancellation while scheduling
-// shard jobs, but never after entering a shard. Shard execution is atomic and
-// must not contain cancellation checks in index, batch, or row loops.
+// Storage execution contract: mutation shards remain atomic. Read-only scans
+// may observe the query context between batches, never in per-row loops.
 func (s *SessionState) IsKilled() bool {
 	return s.IsKilledSeq(CurrentQuerySeq())
 }
@@ -252,9 +251,8 @@ func CurrentQuerySeq() uint64 {
 
 // IsKilledSeq returns true if the given query generation has been killed.
 //
-// Storage execution contract: callers may check cancellation while scheduling
-// shard jobs, but never after entering a shard. Shard execution is atomic and
-// must not contain cancellation checks in index, batch, or row loops.
+// Storage execution contract: mutation shards remain atomic. Read-only scans
+// may observe the query context between batches, never in per-row loops.
 func (s *SessionState) IsKilledSeq(seq uint64) bool {
 	if seq == 0 {
 		return false

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -16,6 +16,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
+import "context"
 import "fmt"
 import "time"
 import "runtime/debug"
@@ -34,6 +35,20 @@ func (s scanError) Error() string {
 
 func buildOuterNullCallbackRow(callbackCols []string) []scm.Scmer {
 	return make([]scm.Scmer, len(callbackCols))
+}
+
+// queryContextDone is a lock-free cancellation check. Read-only scans call it
+// once per index batch; mutation scans deliberately remain shard-atomic.
+func queryContextDone(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 /* TODO: interface Scannable (scan + scan_order) and (table schema tbl) to get a scannable */
@@ -453,7 +468,11 @@ func (t *table) hasBoundUniquePoint(boundaries boundaries) bool {
 
 func (t *table) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
 	ss := SessionStateFromTx(currentTx)
-	querySeq := scm.CurrentQuerySeq()
+	querySeq := querySeqFromTx(currentTx)
+	var queryCtx context.Context
+	if ss != nil {
+		queryCtx = ss.QueryContext(querySeq)
+	}
 	touchTempColumns(t, conditionCols, nil)
 	boundaries := extractBoundaries(conditionCols, condition)
 	reorderByFrequency(boundaries, t)
@@ -474,12 +493,12 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
 		}()
-		// Cancellation contract: check only at the scheduling boundary, before entering
-		// the shard. Once entered, a shard runs atomically without cancellation checks.
+		// Reject work killed before shard admission. Read-only shards additionally
+		// observe their context between batches; mutation shards remain atomic.
 		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
-		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found) {
+		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, queryCtx, &found) {
 			found.Store(true)
 			values <- scanResult{outCount: 1}
 			return
@@ -516,7 +535,11 @@ func (t *table) scan(currentTx *TxContext, conditionCols []string, condition scm
 
 func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
-	querySeq := scm.CurrentQuerySeq()
+	querySeq := querySeqFromTx(currentTx)
+	var queryCtx context.Context
+	if ss != nil {
+		queryCtx = ss.QueryContext(querySeq)
+	}
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -567,12 +590,12 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 				values <- scanResult{err: scanError{r, string(debug.Stack())}}
 			}
 		}()
-		// Cancellation contract: check only at the scheduling boundary, before entering
-		// the shard. Once entered, a shard runs atomically without cancellation checks.
+		// Reject work killed before shard admission. Read-only shards additionally
+		// observe their context between batches; mutation shards remain atomic.
 		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
-		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss)
+		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, queryCtx)
 		values <- scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount}
 	})
 	if done != nil {
@@ -677,12 +700,12 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 	return akkumulator
 }
 
-func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
-	_, found := t.scanFirstRecord(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, stop)
+func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, queryCtx context.Context, stop *atomic.Bool) bool {
+	_, found := t.scanFirstRecord(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, queryCtx, stop)
 	return found
 }
 
-func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
+func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, queryCtx context.Context, stop *atomic.Bool) (uint32, bool) {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -743,6 +766,9 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 
 	var buf [8]uint32
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
+		if queryContextDone(queryCtx) {
+			panic("query killed")
+		}
 		if stop != nil && stop.Load() {
 			return false
 		}
@@ -792,9 +818,9 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	return foundID, found
 }
 
-func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, queryCtx context.Context) (scm.Scmer, int64, int64) {
 	if stride > 0 {
-		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss)
+		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, callback, aggregate, neutral, stride, batchdata, currentTx, ss, queryCtx)
 	}
 	akkumulator := neutral
 	var outCount int64
@@ -905,6 +931,9 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	hadValue := false
 
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+		if !hasMutationCallback && queryContextDone(queryCtx) {
+			panic("query killed")
+		}
 		candidateCount += int64(len(batch))
 		// filter in-place: overwrite batch with passing IDs
 		outN := 0
@@ -1039,7 +1068,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	return akkumulator, outCount, candidateCount
 }
 
-func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState, queryCtx context.Context) (scm.Scmer, int64, int64) {
 	akkumulator := neutral
 	var outCount int64
 	var candidateCount int64
@@ -1156,6 +1185,9 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		}
 
 		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
+			if !hasMutationCallback && queryContextDone(queryCtx) {
+				panic("query killed")
+			}
 			candidateCount += int64(len(batch))
 			outN := 0
 			for _, idx := range batch {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -16,6 +16,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
+import "context"
 import "fmt"
 import "math"
 import "sort"
@@ -1048,6 +1049,10 @@ func (t *table) scan_order(currentTx *TxContext, conditionCols []string, conditi
 func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, notFoundValue scm.Scmer) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := querySeqFromTx(currentTx)
+	var queryCtx context.Context
+	if ss != nil {
+		queryCtx = ss.QueryContext(querySeq)
+	}
 	bounds := extractBoundaries(conditionCols, condition)
 	reorderByFrequency(bounds, t)
 	lower, upperLast := indexFromBoundaries(bounds)
@@ -1075,7 +1080,7 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
-		recid, present := shard.scanFirstRecord(bounds, lower, upperLast, conditionCols, condition, currentTx, ss, nil)
+		recid, present := shard.scanFirstRecord(bounds, lower, upperLast, conditionCols, condition, currentTx, ss, queryCtx, nil)
 		if !present {
 			return
 		}

--- a/tests/execution/concurrency/kill-lock.yaml
+++ b/tests/execution/concurrency/kill-lock.yaml
@@ -404,6 +404,38 @@ test_cases:
         expect:
           rows: 1
 
+  - name: "KILL QUERY interrupts read-only work at scan batch boundaries"
+    setup:
+      - sql: "DROP TABLE IF EXISTS kill_batch_ctrl"
+      - sql: "DROP TABLE IF EXISTS kill_batch_rows"
+      - sql: "CREATE TABLE kill_batch_ctrl (id BIGINT)"
+      - sql: "CREATE TABLE kill_batch_rows (id INT)"
+      - sql: "INSERT INTO kill_batch_rows SELECT id FROM kill_big"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 1000 FROM kill_batch_rows"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 2000 FROM kill_batch_rows"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 4000 FROM kill_batch_rows"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 8000 FROM kill_batch_rows"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 16000 FROM kill_batch_rows"
+      - sql: "INSERT INTO kill_batch_rows SELECT id + 32000 FROM kill_batch_rows"
+    steps:
+      - scm: "(begin (define kill_batch_state (newsession)) (define kill_batch_spin (lambda (x) (begin (kill_batch_state \"started\" true) (strlen (regexp_replace (string_repeat (concat x) 10000) \"1\" \"2\"))))) (sql_builtins \"KILL_BATCH_SPIN\" kill_batch_spin) true)"
+      - session_id: "kill-batch-victim"
+        sql: "INSERT INTO kill_batch_ctrl VALUES (CONNECTION_ID())"
+      - session_id: "kill-batch-victim"
+        sql: "SELECT COUNT(*) FROM kill_batch_rows WHERE KILL_BATCH_SPIN(id) > 0"
+        background: true
+        expect:
+          error: true
+        timeout: 20
+      - scm: "(begin (define wait_kill_batch_started (lambda (remaining) (if (or (kill_batch_state \"started\") (<= remaining 0)) true (begin (sleep 0.01) (wait_kill_batch_started (- remaining 1)))))) (wait_kill_batch_started 500))"
+      # The expression can be sampled during planning. Give execution enough time
+      # to enter the single shard before sending KILL QUERY.
+      - scm: "(begin (sleep 0.5) true)"
+      - session_id: "kill-batch-attacker"
+        sql: "SELECT KILL_QUERY(id) FROM kill_batch_ctrl LIMIT 1"
+      - wait_for_background: true
+        timeout: 8
+
   # ── KILL mid-INSERT rollback: no partial state ────────────────────────────
   #
   # Validates the kill→drain→rollback path introduced alongside the
@@ -477,6 +509,12 @@ test_cases:
 
   - name: "cleanup: drop kill_ctrl2 table"
     sql: "DROP TABLE IF EXISTS kill_ctrl2"
+
+  - name: "cleanup: drop batch cancellation tables"
+    sql: "DROP TABLE IF EXISTS kill_batch_rows"
+
+  - name: "cleanup: drop batch cancellation control table"
+    sql: "DROP TABLE IF EXISTS kill_batch_ctrl"
 
   - name: "cleanup: drop lock_test2 table"
     sql: "DROP TABLE IF EXISTS lock_test2"


### PR DESCRIPTION
## Summary
- propagate the active query context into shard scans
- stop read-only scans at index-batch boundaries after cancellation
- preserve shard-atomic execution for mutation scans
- add a regression test for cancelling CPU-heavy work inside one shard

## Locking and overhead
- one existing session-state lookup per scan obtains the query context
- batch checks read `context.Done()` without locks or allocations
- no checks are added to row loops
- no storage locks are added or upgraded

## Validation
- regression on `origin/master`: background scan still active after the 8 s synchronization budget; suite/process drain took about 25 s
- patched regression suite: 31/31 passed in about 6.7 s in the direct A/B run
- `go test ./scm` passed
- targeted persistence rollback test passed repeatedly
- full `make test` passed

The full `go test ./storage` command also exposed an unrelated pre-existing unsafe persistence/mmap fault in a restart test; the exact test passes repeatedly in isolation and the complete SQL persistence/crash-recovery suite passed.