### PR TITLE
Preserve aggregate extensions on shared logical stages

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -309,31 +309,47 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 	(reduce (merge (coalesceNil parts '())) (lambda (items item)
 		(logical_append_unique items item)) '())))
 
+(define logical_contains_all? (lambda (items required)
+	(reduce (coalesceNil required '()) (lambda (contains_all item)
+		(and contains_all (contains? (coalesceNil items '()) item))) true)))
+
+(define same_group_carrier_backbone? (lambda (left right)
+	(and (equal? (gs_input left) (gs_input right))
+		(equal? (gs_domain left) (gs_domain right))
+		(equal? (gs_keys left) (gs_keys right))
+		(equal? (gs_having left) (gs_having right))
+		(equal? (gs_order left) (gs_order right))
+		(equal? (gs_limit left) (gs_limit right))
+		(equal? (gs_offset left) (gs_offset right)))))
+
+(define group_stage_merges_aggregate_extensions? (lambda (stage)
+	(equal? (qassoc_get (gs_facts stage) (quote merge-aggregate-extensions) false) true)))
+
 /* A shared group-stage ID denotes one logical carrier which may be discovered
 through several consumers. Later consumers can extend that carrier with more
-aggregate columns. Keep the complete extending variant as the carrier template
-and add aggregates found by the other variants. Dropping those extensions leaves
-physical readers pointing at columns which no retained prepare stage creates. */
+aggregate columns. Preserve the first stage's domain and output contract and add
+only aggregates from a compatible superset variant which explicitly declares
+this extension contract. Same-ID scalar carriers remain independent. Dropping
+true extensions leaves physical readers pointing at columns which no retained
+prepare stage creates. */
 (define merge_same_id_stage_variants (lambda (retained candidate)
-	(if (and (group_stage? retained) (group_stage? candidate))
-		(begin
-			(define aggregates (logical_merge_unique
-				(list (gs_aggregates retained) (gs_aggregates candidate))))
-			(define base (if (> (count aggregates) (count (gs_aggregates retained)))
-				candidate
-				retained))
-			(make_group_stage
-				(gs_id base)
-				(gs_input base)
-				(gs_domain base)
-				(gs_keys base)
-				aggregates
-				(gs_having base)
-				(gs_output base)
-				(gs_order base)
-				(gs_limit base)
-				(gs_offset base)
-				(gs_facts base)))
+	(if (and (group_stage? retained) (group_stage? candidate)
+		(group_stage_merges_aggregate_extensions? retained)
+		(group_stage_merges_aggregate_extensions? candidate)
+		(same_group_carrier_backbone? retained candidate)
+		(logical_contains_all? (gs_aggregates candidate) (gs_aggregates retained)))
+		(make_group_stage
+			(gs_id retained)
+			(gs_input retained)
+			(gs_domain retained)
+			(gs_keys retained)
+			(logical_merge_unique (list (gs_aggregates retained) (gs_aggregates candidate)))
+			(gs_having retained)
+			(gs_output retained)
+			(gs_order retained)
+			(gs_limit retained)
+			(gs_offset retained)
+			(gs_facts retained))
 		retained)))
 
 (define collect_stage_variants_by_id (lambda (stages variants)
@@ -3710,6 +3726,7 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(list
 				(list (quote condition) true)
 				(list (quote purpose) (quote window_partition_aggregate))
+				(list (quote merge-aggregate-extensions) true)
 				(list (quote domain) outer_domain)
 				(list (quote lookup-keys) outer_domain)
 				(list (quote preserve_empty_domain) false)

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -300,19 +300,68 @@ catalog for every comparison. The binding catalog is compile-local as well. */
 				(concat "window:" (nth stage 1))
 				nil)))))
 
-(define unique_stages_by_id_acc (lambda (stages seen)
+(define logical_append_unique (lambda (items item)
+	(if (contains? (coalesceNil items '()) item)
+		(coalesceNil items '())
+		(merge (coalesceNil items '()) (list item)))))
+
+(define logical_merge_unique (lambda (parts)
+	(reduce (merge (coalesceNil parts '())) (lambda (items item)
+		(logical_append_unique items item)) '())))
+
+/* A shared group-stage ID denotes one logical carrier which may be discovered
+through several consumers. Later consumers can extend that carrier with more
+aggregate columns. Keep the complete extending variant as the carrier template
+and add aggregates found by the other variants. Dropping those extensions leaves
+physical readers pointing at columns which no retained prepare stage creates. */
+(define merge_same_id_stage_variants (lambda (retained candidate)
+	(if (and (group_stage? retained) (group_stage? candidate))
+		(begin
+			(define aggregates (logical_merge_unique
+				(list (gs_aggregates retained) (gs_aggregates candidate))))
+			(define base (if (> (count aggregates) (count (gs_aggregates retained)))
+				candidate
+				retained))
+			(make_group_stage
+				(gs_id base)
+				(gs_input base)
+				(gs_domain base)
+				(gs_keys base)
+				aggregates
+				(gs_having base)
+				(gs_output base)
+				(gs_order base)
+				(gs_limit base)
+				(gs_offset base)
+				(gs_facts base)))
+		retained)))
+
+(define collect_stage_variants_by_id (lambda (stages variants)
+	(match (coalesceNil stages '())
+		(cons stage rest) (begin
+			(define key (logical_stage_key stage))
+			(if (nil? key)
+				(collect_stage_variants_by_id rest variants)
+				(collect_stage_variants_by_id rest
+					(set_assoc variants key
+						(if (has_assoc? variants key)
+							(merge_same_id_stage_variants (variants key) stage)
+							stage)))))
+		_ variants)))
+
+(define unique_stages_by_id_acc (lambda (stages variants seen)
 	(match (coalesceNil stages '())
 		(cons stage rest) (begin
 			(define key (logical_stage_key stage))
 			(if (and (not (nil? key)) (has_assoc? seen key))
-				(unique_stages_by_id_acc rest seen)
-				(cons stage
-					(unique_stages_by_id_acc rest
+				(unique_stages_by_id_acc rest variants seen)
+				(cons (if (nil? key) stage (variants key))
+					(unique_stages_by_id_acc rest variants
 						(if (nil? key) seen (set_assoc seen key true))))))
 		_ '())))
 
 (define unique_stages_by_id (lambda (stages)
-	(unique_stages_by_id_acc stages '())))
+	(unique_stages_by_id_acc stages (collect_stage_variants_by_id stages '()) '())))
 
 (define qb_schema (lambda (node) (nth node 1)))
 (define qb_sources (lambda (node) (nth node 2)))

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -35,16 +35,36 @@ test_cases:
         (define narrow (make_group_stage "shared-window-carrier"
           (list "src" "memcp-tests" "aggregate_source" false nil)
           (list) (list 1) (list "count-aggregate") nil
-          (list "count" "count-expression") (list) nil nil (list)))
+          (list "count" "count-expression") (list) nil nil
+          (list (list (quote merge-aggregate-extensions) true))))
         (define extended (make_group_stage "shared-window-carrier"
           (list "src" "memcp-tests" "aggregate_source" false nil)
           (list) (list 1) (list "count-aggregate" "sum-aggregate") nil
-          (list "count" "count-expression" "sum" "sum-expression") (list) nil nil (list)))
+          (list "count" "count-expression" "sum" "sum-expression") (list) nil nil
+          (list (list (quote merge-aggregate-extensions) true))))
         (define retained (unique_stages_by_id (list narrow extended)))
         (if (and (equal? (count retained) 1)
             (equal? (count (gs_aggregates (car retained))) 2))
           true
           (error "deduplicating a shared stage discarded aggregate columns")))
+
+  - name: "Same stage ID does not merge unrelated aggregate variants"
+    scm: |
+      (begin
+        (define retained (make_group_stage "canonical-scalar-carrier"
+          (list "first" "memcp-tests" "aggregate_source" false nil)
+          (list "first-domain") (list 1) (list "count-aggregate") nil
+          (list "count" "count-expression") (list) 1 nil (list)))
+        (define alias_variant (make_group_stage "canonical-scalar-carrier"
+          (list "first" "memcp-tests" "aggregate_source" false nil)
+          (list "first-domain") (list 1) (list "sum-aggregate") nil
+          (list "sum" "sum-expression") (list) 1 nil (list)))
+        (define stages (unique_stages_by_id (list retained alias_variant)))
+        (if (and (equal? (count stages) 1)
+            (equal? (gs_input (car stages)) (gs_input retained))
+            (equal? (gs_aggregates (car stages)) (gs_aggregates retained)))
+          true
+          (error "deduplicating an alias variant changed the scalar carrier contract")))
 
   - name: "Creator waits for existing table initialization 1/2"
     parallel: existing_creation_barrier

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -29,6 +29,23 @@ setup:
       )
 
 test_cases:
+  - name: "Duplicate logical stage IDs retain every aggregate extension"
+    scm: |
+      (begin
+        (define narrow (make_group_stage "shared-window-carrier"
+          (list "src" "memcp-tests" "aggregate_source" false nil)
+          (list) (list 1) (list "count-aggregate") nil
+          (list "count" "count-expression") (list) nil nil (list)))
+        (define extended (make_group_stage "shared-window-carrier"
+          (list "src" "memcp-tests" "aggregate_source" false nil)
+          (list) (list 1) (list "count-aggregate" "sum-aggregate") nil
+          (list "count" "count-expression" "sum" "sum-expression") (list) nil nil (list)))
+        (define retained (unique_stages_by_id (list narrow extended)))
+        (if (and (equal? (count retained) 1)
+            (equal? (count (gs_aggregates (car retained))) 2))
+          true
+          (error "deduplicating a shared stage discarded aggregate columns")))
+
   - name: "Creator waits for existing table initialization 1/2"
     parallel: existing_creation_barrier
     scm: &create_with_initializer |


### PR DESCRIPTION
## Problem
A grouped window-query can discover the same logical carrier through multiple consumers. A later variant may extend the carrier with additional aggregates, but first-wins stage deduplication discarded those columns. Physical readers then referenced aggregate columns which no retained prepare stage created.

Blindly merging every same-ID group stage is also incorrect: independently shaped scalar carriers may share a canonical ID while retaining different domain and output contracts.

## Fix
- Mark window aggregate carriers which explicitly support aggregate extension merging.
- Merge only marked same-ID stages with identical carrier backbones and a true aggregate-superset relationship.
- Preserve the first carrier domain and output contract while retaining the aggregate extension.
- Keep unrelated same-ID scalar carrier variants independent.
- Add regressions for both the missing-extension failure and the unsafe-merge counterexample.

## Validation
- Full local make test passed.
- The grouped-window reproduction builds and executes with every referenced aggregate present.
- The repeated scalar-carrier reproduction executes without an unknown aggregate-column compiler failure.