### PR TITLE
Lower ordered batch predicates at candidate cardinality

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5530,7 +5530,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_direct_presence_probe_cost (lambda (probe_rows)
 	(planner_cost 0 0 (* probe_rows planner_scalar_presence_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
-(define planner_membership_direct_probe_row_ns 28470)
+(define planner_membership_direct_probe_row_ns 28965)
 (define planner_membership_direct_probe_cost (lambda (probe_rows)
 	(planner_cost 0 0 (* probe_rows planner_membership_direct_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
@@ -5552,10 +5552,10 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_recset_startup_ns 1)
 (define planner_membership_recset_build_row_ns 1)
 (define planner_membership_recset_probe_row_ns 1)
-(define planner_membership_recset_aggregate_row_ns 149)
-(define planner_membership_group_cache_startup_ns 4825882)
+(define planner_membership_recset_aggregate_row_ns 129)
+(define planner_membership_group_cache_startup_ns 4924972)
 (define planner_membership_group_cache_build_row_ns 1)
 (define planner_membership_group_cache_probe_row_ns 1)
 (define planner_membership_ordered_driver_input_row_ns 1)
-(define planner_membership_ordered_scan_invocation_ns 2784159)
+(define planner_membership_ordered_scan_invocation_ns 3027639)
 /* END GENERATED COST CONSTANTS */

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2777,48 +2777,113 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 						(list (nth marker 0) (nth marker 1) target_col term)))))))
 		(lambda (membership) (not (nil? membership))))))
 
+(define scan_input_recset_for_condition (lambda (sources default_alias src input condition probe_work_rows)
+	(if (equal? condition true)
+		input
+		(begin
+			(define cols (extract_columns_for_alias src condition))
+			(list (quote scan_recset)
+				'(session "__memcp_tx")
+				input
+				(cons (quote list) cols)
+				(list (quote lambda)
+					(map cols (lambda (col)
+						(scan_callback_symbol_for_alias (source_alias src) col)))
+					(lower_column_expr_for_join_truth_context
+						sources default_alias condition probe_work_rows)))))))
+
+/* Estimate the rows which reach the residual predicate from the exact same
+membership facts used to choose the outer carrier. The residual lowerer can
+therefore choose RecSet, keytable, or direct probes for the smaller batch just
+as it would for an ordinary scan input. */
+(define batch_membership_survivor_rows (lambda (memberships probe_work_rows)
+	(reduce memberships (lambda (rows membership)
+		(if (not (number? (planner_literal_value rows)))
+			rows
+			(begin
+				(define stage (nth membership 0))
+				(define facts (merge (list
+					(membership_candidate_work_facts stage)
+					(gs_facts stage))))
+				(define candidate_input_rows (coalesceNil
+					(qassoc_get facts (quote membership_candidate_input_rows) nil)
+					(planner_stage_input_rows (gs_input stage))))
+				(define candidate_rows (qassoc_get facts
+					(quote membership_candidate_estimated_rows) candidate_input_rows))
+				(if (or (not (number? candidate_input_rows))
+					(not (number? candidate_rows)))
+					rows
+					(begin
+						/* For an ordered LIMIT, rows is the requested survivor count,
+						not the number of driver rows visited. Use the same adaptive
+						visit estimate as ordered_batch_accept_cost before applying the
+						candidate density. Otherwise a 10%-dense candidate for LIMIT 72
+						would incorrectly lower the residual as seven probes even though
+						the batch expands to roughly 720 driver rows and 72 survivors. */
+						(define visited_rows (membership_expected_driver_rows_visited
+							candidate_input_rows candidate_rows
+							(planner_literal_value rows) facts))
+						(* visited_rows
+						(membership_candidate_density
+							candidate_input_rows candidate_rows facts)))))))
+		probe_work_rows)))
+
+/* Compile one exact predicate pipeline over an arbitrary RecSet input. The
+ordered_batch_accept alternative specifically represents candidate-first
+execution; the separately costed prefiltered_candidate_keyset alternative owns
+driver-predicate-first execution. Keeping those alternatives distinct makes
+the emitted work agree with the cost comparison. All residual conditions then
+re-enter the ordinary expression lowerer with the candidate-reduced row count,
+so complex ACL trees receive the same per-node physical choices as any scan. */
 (define ordered_batch_filter_expr (lambda (sources default_alias src condition memberships probe_work_rows acceptance_cols acceptance_probe)
 	(begin
 		(define input_batch (symbol "__ordered_input_batch"))
-		(define local_batch (symbol "__ordered_local_batch"))
 		(define residual (reduce memberships (lambda (remaining membership)
 			(strip_driver_membership_for_source src remaining membership)) condition))
-		(define residual_cols (extract_columns_for_alias src residual))
-		(define locally_filtered (if (equal? residual true)
-			input_batch
-			(list (quote scan_recset)
-				'(session "__memcp_tx")
-				input_batch
-				(cons (quote list) residual_cols)
-				(list (quote lambda)
-					(map residual_cols (lambda (col)
-						(scan_callback_symbol_for_alias (source_alias src) col)))
-					(lower_column_expr_for_join_truth_context
-						sources default_alias residual probe_work_rows)))))
+		(define membership_batch (symbol "__ordered_membership_batch"))
+		(define late_batch (symbol "__ordered_late_batch"))
 		(define membership_exprs (map memberships (lambda (membership)
-			(batch_membership_expr src membership local_batch))))
+			(batch_membership_expr src membership input_batch))))
 		(if (reduce membership_exprs (lambda (unsupported expr)
 			(or unsupported (nil? expr))) false)
 			nil
-			(list (quote lambda) (list input_batch)
-				(list
-					(list (quote lambda) (list local_batch)
-						(begin
-							(define accepted (if (empty_list? membership_exprs)
-							local_batch
-							(list (quote recset_intersect)
-								(cons (quote list) (cons local_batch membership_exprs)))))
-							(if (equal? acceptance_probe true)
-								accepted
-								(list (quote scan_recset)
-									'(session "__memcp_tx")
-									accepted
-									(cons (quote list) acceptance_cols)
-									(list (quote lambda)
-										(map acceptance_cols (lambda (col)
-											(scan_callback_symbol_for_alias (source_alias src) col)))
-										acceptance_probe)))))
-					locally_filtered))))))
+			(begin
+				(define membership_expr (if (empty_list? membership_exprs)
+					input_batch
+					(list (quote recset_intersect)
+						(cons (quote list) (cons input_batch membership_exprs)))))
+				(define residual_probe_work_rows
+					(batch_membership_survivor_rows memberships probe_work_rows))
+				(planner_record_physical_decision (list
+					(list "decision" "batch_predicate_lowering")
+					(list "chosen" "candidate_then_residual")
+					(list "reason" "selected_ordered_batch_carrier_cost")
+					(list "inputs" (list
+						(list "input_rows" (planner_literal_value probe_work_rows))
+						(list "residual_probe_rows"
+							(planner_literal_value residual_probe_work_rows))
+						(list "membership_count" (count memberships))
+						(list "residual_probe_count" (count (expr_probe_stages residual)))))))
+				(define late_expr (scan_input_recset_for_condition
+					sources default_alias src membership_batch residual
+					residual_probe_work_rows))
+				(define accepted_expr (if (equal? acceptance_probe true)
+					late_batch
+					(list (quote scan_recset)
+						'(session "__memcp_tx")
+						late_batch
+						(cons (quote list) acceptance_cols)
+						(list (quote lambda)
+							(map acceptance_cols (lambda (col)
+								(scan_callback_symbol_for_alias (source_alias src) col)))
+							acceptance_probe))))
+				(list (quote lambda) (list input_batch)
+					(list
+						(list (quote lambda) (list membership_batch)
+							(list
+								(list (quote lambda) (list late_batch) accepted_expr)
+								late_expr))
+						membership_expr)))))))
 
 /* Produce the exact driver subset shared by a prefiltered membership tree.
 Every remaining top-level conjunct is evaluated once while building the driver
@@ -3115,13 +3180,13 @@ RecSet; membership edges retain their own physical operators. */
 				residual expression and lower through the ordinary probe machinery. This
 				makes adaptive ordered batching a property of the consuming scan, not of
 				one privileged predicate shape. */
-				(define batch_filter (if (equal? table_expr source_table)
+				(define use_batch_accept (and (equal? table_expr source_table)
+					(reduce membership_plans (lambda (chosen entry)
+						(or chosen (equal? (car (nth entry 1)) "ordered_batch_accept"))) false)))
+				(define batch_filter (if use_batch_accept
 					(ordered_batch_filter_expr (list src) alias src filter_condition
 						remaining_batch_memberships (probe_context_row_count (list src)) '() true)
 					nil))
-				(define use_batch_accept (and (not (nil? batch_filter))
-					(reduce membership_plans (lambda (chosen entry)
-						(or chosen (equal? (car (nth entry 1)) "ordered_batch_accept"))) false)))
 				(define raw_map_row (list (quote resultrow)
 					(cons (quote list) (map_assoc bundled_fields (lambda (title expr)
 						(lower_column_expr_for_alias src expr))))))

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -420,6 +420,34 @@ test_cases:
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 
+  # Exercise the exact emitted pipeline behind the ordered-batch alternative:
+  # candidate membership first, then the remaining driver predicate on the
+  # reduced RecSet. This keeps the downstream-work coefficient identifiable
+  # instead of training only queries whose residual condition is TRUE.
+  - name: "production-scale adaptive batch with residual predicate"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    expected_broad_text_bytes: 15000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.p1 >= 0
+        AND d.file_id IN (
+          SELECT f.id FROM pc_files_text f WHERE f.filename LIKE '%c%'
+          UNION
+          SELECT f.id FROM pc_files_text f
+          WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
+        )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
   - name: "ordered batch with unique late projection"
     physical_calibration: true
     calibration_decision: "membership_carrier"

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1025,6 +1025,43 @@ test_cases:
           contains:
             - "scan_order_batch_accept"
       - sql: |
+          EXPLAIN PHYSICAL
+          SELECT d.ID
+          FROM in_batch_doc d
+          WHERE d.ID > 0
+            AND d.file_id IN (
+              SELECT f.ID FROM in_batch_file f WHERE f.flag = 0
+              UNION
+              SELECT f.ID FROM in_batch_file f WHERE f.flag = 1
+            )
+          ORDER BY d.sort_key
+          LIMIT 5
+        expect:
+          contains:
+            - "ordered_batch_accept"
+            - "batch_predicate_lowering"
+            - "candidate_then_residual"
+            - "residual_probe_rows"
+      - sql: |
+          SELECT d.ID
+          FROM in_batch_doc d
+          WHERE d.ID > 0
+            AND d.file_id IN (
+              SELECT f.ID FROM in_batch_file f WHERE f.flag = 0
+              UNION
+              SELECT f.ID FROM in_batch_file f WHERE f.flag = 1
+            )
+          ORDER BY d.sort_key
+          LIMIT 5
+        expect:
+          rows: 5
+          data:
+            - ID: 10000
+            - ID: 9999
+            - ID: 9998
+            - ID: 9997
+            - ID: 9996
+      - sql: |
           EXPLAIN
           SELECT d.ID
           FROM in_dv_doc d


### PR DESCRIPTION
## What

Make `scan_order_batch_accept` execute the pipeline represented by its cost model:

1. build/project the membership candidate RecSet for the current ordered batch,
2. intersect it with that batch,
3. compile the remaining predicate over the surviving RecSet through the ordinary join-expression lowerer,
4. run downstream acceptance and projection.

The outer membership-carrier decision remains cost-based. Candidate keysets, driver probes, adaptive ordered batches, and prefiltered candidate keysets are still independent alternatives; this change does not force the batch operator for a SQL shape.

## Why

The old emitted batch evaluated the complete residual predicate before membership. Expensive correlated ACL probes therefore ran on driver rows which a cheap selective membership candidate subsequently discarded. At the same time, `ordered_batch_accept_cost` already charged downstream probes after candidate selectivity. The selected cost and the generated physical work disagreed.

The new `scan_input_recset_for_condition` helper accepts any RecSet input and calls `lower_column_expr_for_join_truth_context` with a batch-local work estimate. Nested scalar/EXISTS nodes can consequently make their usual RecSet, keytable, or direct-probe choice at each tree node. The work estimate uses the same adaptive driver-visit and candidate-density functions as the outer carrier cost, including LIMIT expansion.

## Calibration and evidence

A new production-scale calibration workload adds nontrivial residual work to the adaptive ordered membership shape. `tools/costgen` measured all four forced alternatives:

| alternative | measured whole query |
|---|---:|
| ordered batch, candidate then residual | 48.1 ms |
| candidate keyset | 148.7 ms |
| ordered membership probe | 216.3 ms |
| prefiltered candidate keyset | 892.1 ms |

The generated coefficients are committed; no cost constant was edited by hand.

A production-copy full-text query also demonstrates why this must remain a per-query choice: the forced candidate keyset measured 21.1 s cold / 5.2 s warm, while the ordered membership probe measured 2.48 s warm and was the cost-selected plan. A blanket preference for RecSets or batches would regress that query.

## Tests run locally

- Scheme startup tests: 1267/1267
- `tests/planner/subqueries/in-subquery.yaml`: 71/71
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 15/15
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml`: 20/20
- `tests/performance/unselective-scalar-order-limit.yaml`: 11/11
- Scheme formatter/check, `go build`, `go test ./tools/costgen`, and `git diff --check`
- `make costgen` completed and preserved the observed winners

The full YAML suite is intentionally left to CI.

## Explicit follow-up

A calibration experiment with a correlated scalar residual exposed a separate multi-dimensional case: an independently selected scalar truth carrier can combine with the membership carrier, so a forced single-decision calibration variant no longer maps to exactly one operator family. This PR does not mislabel that combination to make calibration pass. Factorial calibration of `membership carrier × scalar carrier` should be added separately; correctness and physical lowering of compound scalar ACLs remain covered by the targeted planner suites above.
