### PR TITLE
Cancel guarded plan compilation promptly

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -6275,14 +6275,30 @@ ordering run. Storage artifacts begin in build_queryplan. */
 	(join_reorder (aggregate_pushdown_logical ir))))
 
 (define neumann_compile_pipeline (lambda (ast)
-	(build_queryplan
-		(optimize_logical_query
-			(decorrelate_logical_query ast)))))
+	(begin
+		(context "check")
+		(define ir (decorrelate_logical_query ast))
+		(context "check")
+		(define reordered (optimize_logical_query ir))
+		(context "check")
+		(define prepared (prepare_physical_queryplan reordered))
+		(context "check")
+		(define plan (emit_physical_queryplan prepared))
+		(context "check")
+		plan)))
 
 (define neumann_compile_ir_pipeline (lambda (ir)
-	(build_queryplan
-		(optimize_logical_query
-			(require_flat_stage_dependencies "compile_ir" (normalize_stage_dependencies ir))))))
+	(begin
+		(context "check")
+		(define normalized (require_flat_stage_dependencies "compile_ir" (normalize_stage_dependencies ir)))
+		(context "check")
+		(define reordered (optimize_logical_query normalized))
+		(context "check")
+		(define prepared (prepare_physical_queryplan reordered))
+		(context "check")
+		(define plan (emit_physical_queryplan prepared))
+		(context "check")
+		plan)))
 
 /* ------------------------------------------------------------------------- */
 /* Parser-facing adapters                                                     */

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -217,10 +217,16 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 
 (define sql_compile_queryplan_variant (lambda (parse_fn schema parse_query policy source_session)
 	(begin
+		(context "check")
 		(define planning_session (sql_queryplan_compile_session source_session))
 		(define compile_policy (sql_compile_table_policy policy))
-		(define plan (optimize (with_session planning_session (lambda ()
-			(parse_fn schema parse_query compile_policy)))))
+		(define raw_plan (with_session planning_session (lambda ()
+			(parse_fn schema parse_query compile_policy))))
+		/* Parsing includes logical and physical planning. Never spend optimizer
+		work or install a variant after its requesting context was cancelled. */
+		(context "check")
+		(define plan (optimize raw_plan))
+		(context "check")
 		(list (sql_queryplan_guard_from_session planning_session) plan))))
 
 (define sql_queryplan_miss_expr (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy)

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -389,7 +389,10 @@ func Context(a ...Scmer) (result Scmer) {
 		case "check":
 			ctxVal, ok := mgr.GetValue("context")
 			if !ok {
-				panic("no context set")
+				// Startup compilation and Scheme self-tests have no request to
+				// cancel. Treat that environment as live while preserving prompt
+				// cancellation whenever a request context exists.
+				return NewBool(true)
 			}
 			e := ctxVal.(context.Context).Err()
 			if e != nil {
@@ -754,13 +757,28 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mutex",
-		Desc: "Creates a mutex. The return value is a function that takes one parameter which is a parameterless function. The mutex is guaranteed that all calls to that mutex get serialized.",
+		Desc: "Creates a context-aware mutex. The return value serializes calls to parameterless functions and stops waiting when the current request is cancelled.",
 		Fn: func(a ...Scmer) Scmer {
-			var mutex sync.Mutex
+			token := make(chan struct{}, 1)
+			token <- struct{}{}
 			return NewFunc(func(a ...Scmer) Scmer {
-				mutex.Lock()
+				ctx := context.Background()
+				if value, ok := GetGLSValue("context"); ok {
+					if current, ok := value.(context.Context); ok {
+						ctx = current
+					}
+				}
+				select {
+				case <-token:
+					if err := ctx.Err(); err != nil {
+						token <- struct{}{}
+						panic(err)
+					}
+				case <-ctx.Done():
+					panic(ctx.Err())
+				}
 				defer func() {
-					mutex.Unlock() // free after return or panic, so we don't get into deadlocks
+					token <- struct{}{} // free after return or panic, so we don't get into deadlocks
 					/* this code happens automatically
 					if r := recover(); r != nil {
 						// rethrow panics

--- a/scm/sync_mutex_test.go
+++ b/scm/sync_mutex_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestContextCheckWithoutRequestContextIsLive(t *testing.T) {
+	if !Context(NewString("check")).Bool() {
+		t.Fatal("context check without a request context should be live")
+	}
+}
+
+func TestMutexWaitStopsWhenContextIsCancelled(t *testing.T) {
+	lock := Apply(Globalenv.Vars[Symbol("mutex")])
+	holderEntered := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan struct{})
+	go NewContext(context.Background(), func() {
+		defer close(holderDone)
+		Apply(lock, NewFunc(func(_ ...Scmer) Scmer {
+			close(holderEntered)
+			<-releaseHolder
+			return NewBool(true)
+		}))
+	})
+	select {
+	case <-holderEntered:
+	case <-time.After(time.Second):
+		t.Fatal("mutex holder did not enter")
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	var waiterRan atomic.Bool
+	waiterDone := make(chan any, 1)
+	go NewContext(waiterCtx, func() {
+		defer func() { waiterDone <- recover() }()
+		Apply(lock, NewFunc(func(_ ...Scmer) Scmer {
+			waiterRan.Store(true)
+			return NewBool(true)
+		}))
+	})
+	cancelWaiter()
+	select {
+	case recovered := <-waiterDone:
+		if recovered != context.Canceled {
+			t.Fatalf("expected context cancellation, got %v", recovered)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled mutex waiter remained blocked")
+	}
+	if waiterRan.Load() {
+		t.Fatal("cancelled mutex waiter executed its callback")
+	}
+
+	close(releaseHolder)
+	select {
+	case <-holderDone:
+	case <-time.After(time.Second):
+		t.Fatal("mutex holder did not finish")
+	}
+}

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -431,6 +431,67 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "Cancelled guarded-plan waiter never compiles after the gate opens"
+    steps:
+      - scm: |
+          (begin
+            (define cache (newcachemap))
+            (define entry (newsession))
+            (define state (newsession))
+            (entry "compile_lock" (mutex))
+            (entry "variants" (list (list false nil)))
+            (globalvars "guarded_plan_cancel_cache" cache)
+            (globalvars "guarded_plan_cancel_entry" entry)
+            (globalvars "guarded_plan_cancel_state" state)
+            (globalvars "guarded_plan_cancel_parser"
+              (lambda (_schema _query _policy) (begin
+                (state "cancelled_waiter_compiled" true)
+                (list (quote quote) "compiled"))))
+            "ready")
+        expect:
+          rows: 1
+          contains: "ready"
+      - scm: |
+          (begin
+            (define entry (globalvars "guarded_plan_cancel_entry"))
+            (define state (globalvars "guarded_plan_cancel_state"))
+            ((entry "compile_lock") (lambda () (begin
+              (state "holder" true)
+              (sleep 2)))))
+        background: true
+        timeout: 5
+        expect:
+          rows: 1
+      - scm: |
+          (begin
+            (define cache (globalvars "guarded_plan_cancel_cache"))
+            (define entry (globalvars "guarded_plan_cancel_entry"))
+            (define parser (globalvars "guarded_plan_cancel_parser"))
+            (sleep 0.2)
+            (sql_queryplan_variant_miss cache "cancel-test" entry parser
+              "memcp-tests" "SELECT 1" nil))
+        background: true
+        timeout: 1
+        expect:
+          interrupted_ok: true
+      - scm: "(sleep 2.5)"
+        timeout: 4
+        expect:
+          rows: 1
+      - wait_for_background: true
+        timeout: 5
+      - scm: |
+          (begin
+            (define state (globalvars "guarded_plan_cancel_state"))
+            (if (and
+              (equal? (state "holder") true)
+              (nil? (state "cancelled_waiter_compiled")))
+              "ok"
+              (error "cancelled guarded-plan waiter ran after its request ended")))
+        expect:
+          rows: 1
+          contains: "ok"
+
   - name: "Variadic concat uses the same broad class at compile and runtime"
     scm: |
       (begin


### PR DESCRIPTION
## Summary
- make Scheme mutex waits request-context aware so cancelled guarded-plan waiters cannot execute later
- check cancellation between coarse query-planner phases and before plan optimization/installation
- add a regression that exercises the real guarded variant-miss compiler path plus a focused mutex unit test

## Validation
- `make test`
- `go test ./scm -run "Test(ContextCheckWithoutRequestContextIsLive|MutexWaitStopsWhenContextIsCancelled)" -count=20`
- `python3 run_sql_tests.py tests/sql/expressions/prepared-stmts.yaml`

The full local hook completed with all critical suites passing. Existing noncritical deep-correlation expectations are unchanged.