### PR TITLE
Fix trigger SELECT UNION cardinality

### DIFF
--- a/lib/sql-builtins.scm
+++ b/lib/sql-builtins.scm
@@ -127,6 +127,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ))))
 
 /* vectors */
+(sql_builtins "JSON_QUOTE" json_quote)
 (sql_builtins "VECTOR_DISTANCE" dot)
 (sql_builtins "STRING_TO_VECTOR" json_decode)
 (sql_builtins "VECTOR_TO_STRING" json_encode)

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -366,37 +366,33 @@ arithmetic; leave expressions containing columns or functions untouched. */
 											(cons h t) (cons (transform_new_old h) (map t transform_new_old))
 											expr)))
 										(define inner_t (transform_new_old inner))
-										/* Extract SELECT field names from the 9-tuple (fields is a flat assoc list) */
-										(define select_fields (match inner_t
+										/* UNION output names are defined by its first branch. Extract
+										them recursively instead of mistaking a UNION for a SELECT
+										without FROM and synthesizing one empty row. */
+										(define trigger_select_fields (lambda (query) (match query
 											((symbol query-block) _ _ fields _ _ _ _ _ _ _ _ _) fields
 											'(_ _ fields _ _ _ _ _ _) fields
-											_ '()))
+											((symbol union-block) _ (cons first _) _ _ _ _) (trigger_select_fields first)
+											((symbol union_all) (cons first _) _ _ _) (trigger_select_fields first)
+											((symbol union_distinct) (cons first _) _ _ _) (trigger_select_fields first)
+											_ (error "trigger INSERT SELECT has no output fields"))))
+										(define select_fields (trigger_select_fields inner_t))
 										(define select_names (extract_assoc select_fields (lambda (k v) k)))
-										(define select_values (extract_assoc select_fields (lambda (_k v) v)))
-										(define select_sources (match inner_t
-											((symbol query-block) _ tables _ _ _ _ _ _ _ _ _ _) tables
-											'(_ tables _ _ _ _ _ _ _) tables
-											_ '()))
-										(if (empty_list? select_sources)
-											(list (list (symbol "insert") (list (symbol "table") schema tbl)
-												(cons (symbol "list") cols)
-												(list (symbol "list") (cons (symbol "list") select_values))
-												(list (symbol "list"))
-												(if ignore (list (symbol "lambda") '() 0) nil)
-												false nil))
-											/* Generate code: set resultrow + build_queryplan_term */
-											(list (list (symbol "begin")
-												(list (symbol "set") (symbol "resultrow")
-													(list (symbol "lambda") (list (symbol "item"))
-														(list (symbol "insert") (list (symbol "table") schema tbl)
-															(cons (symbol "list") cols)
-															(list (symbol "list")
-																(cons (symbol "list")
-																	(map select_names (lambda (name) (list (symbol "get_assoc") (symbol "item") name)))))
-															(list (symbol "list"))
-															(if ignore (list (symbol "lambda") '() 0) nil)
-															false nil)))
-												(build_queryplan_term (sql_expand_views inner_t policy))))))
+										/* Use the relational plan for every SELECT shape, including
+										SELECT literals without FROM. It alone owns whether zero, one,
+										or many rows are emitted. */
+										(list (list (symbol "begin")
+											(list (symbol "set") (symbol "resultrow")
+												(list (symbol "lambda") (list (symbol "item"))
+													(list (symbol "insert") (list (symbol "table") schema tbl)
+														(cons (symbol "list") cols)
+														(list (symbol "list")
+															(cons (symbol "list")
+																(map select_names (lambda (name) (list (symbol "get_assoc") (symbol "item") name)))))
+														(list (symbol "list"))
+														(if ignore (list (symbol "lambda") '() 0) nil)
+														false nil)))
+											(build_queryplan_term (sql_expand_views inner_t policy)))))
 									(if (equal? tag '!update)
 										/* UPDATE table SET ... WHERE ... - stmt is (!update tbl assignments where) */
 										(begin

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -19,6 +19,7 @@ package scm
 import "io"
 import "fmt"
 import "html"
+import "bytes"
 import "sync"
 import "regexp"
 import "unicode"
@@ -10442,6 +10443,29 @@ func init_strings() {
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "value to encode"}},
+			Return: &TypeDescriptor{Kind: "string"},
+			Const:  true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "json_quote",
+		Desc: "quotes a string as a JSON string literal without HTML escaping",
+		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || !a[0].IsString() {
+				return NewNil()
+			}
+			var encoded bytes.Buffer
+			encoder := json.NewEncoder(&encoded)
+			encoder.SetEscapeHTML(false)
+			if err := encoder.Encode(a[0].String()); err != nil {
+				panic(err)
+			}
+			return NewString(strings.TrimSuffix(encoded.String(), "\n"))
+		},
+		Type: &TypeDescriptor{
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "string to quote"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 

--- a/tests/sql/triggers/trigger-compat.yaml
+++ b/tests/sql/triggers/trigger-compat.yaml
@@ -20,6 +20,13 @@ setup:
   - sql: "DROP TABLE IF EXISTS trig_invoice"
   - sql: "DROP TABLE IF EXISTS trig_invitem"
   - sql: "DROP TABLE IF EXISTS trig_year"
+  - sql: "DROP TABLE IF EXISTS json_quote_log"
+  - sql: "DROP TABLE IF EXISTS json_quote_src"
+  - sql: "DROP TABLE IF EXISTS trigger_union_event"
+  - sql: "DROP TABLE IF EXISTS trigger_union_log"
+  - sql: "DROP TABLE IF EXISTS trigger_union_src"
+  - sql: "DROP TABLE IF EXISTS trigger_literal_log"
+  - sql: "DROP TABLE IF EXISTS trigger_literal_src"
   - sql: "DROP TRIGGER IF EXISTS after_items_insert"
   - sql: "DROP TRIGGER IF EXISTS after_bill_insert"
   - sql: "DROP TRIGGER IF EXISTS trig_no_begin"
@@ -27,6 +34,9 @@ setup:
   - sql: "DROP TRIGGER IF EXISTS `trig_year.ia`"
   - sql: "DROP TRIGGER IF EXISTS `derived_src.ai`"
   - sql: "DROP TRIGGER IF EXISTS `derived_src.au`"
+  - sql: "DROP TRIGGER IF EXISTS json_quote_src_ai"
+  - sql: "DROP TRIGGER IF EXISTS trigger_union_src_ai"
+  - sql: "DROP TRIGGER IF EXISTS trigger_literal_src_ai"
   - sql: "CREATE TABLE derived_src (id INT PRIMARY KEY, group_id INT)"
   - sql: "CREATE TABLE derived_assoc (id INT PRIMARY KEY, src_id INT, marker INT)"
   - sql: "CREATE TABLE derived_target (assoc_id INT PRIMARY KEY, marker INT)"
@@ -46,6 +56,13 @@ setup:
   - sql: "CREATE TABLE trig_invoice (ID INT AUTO_INCREMENT PRIMARY KEY, rnr TEXT, rdate INT)"
   - sql: "CREATE TABLE trig_invitem (ID INT AUTO_INCREMENT PRIMARY KEY, invoice INT, amount DECIMAL(10,2))"
   - sql: "CREATE TABLE trig_year (ID INT AUTO_INCREMENT PRIMARY KEY, xstart INT, xend INT, mode INT)"
+  - sql: "CREATE TABLE json_quote_src (id INT PRIMARY KEY, payload TEXT)"
+  - sql: "CREATE TABLE json_quote_log (id INT PRIMARY KEY, payload TEXT)"
+  - sql: "CREATE TABLE trigger_union_event (kind TEXT, payload TEXT)"
+  - sql: "CREATE TABLE trigger_union_log (method TEXT, payload TEXT)"
+  - sql: "CREATE TABLE trigger_union_src (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE trigger_literal_log (method TEXT, payload TEXT)"
+  - sql: "CREATE TABLE trigger_literal_src (id INT PRIMARY KEY)"
 
 cleanup:
   - sql: "DROP TRIGGER IF EXISTS `derived_src.ai`"
@@ -56,6 +73,9 @@ cleanup:
   - sql: "DROP TRIGGER IF EXISTS trig_no_begin"
   - sql: "DROP TRIGGER IF EXISTS `trig_main.ia`"
   - sql: "DROP TRIGGER IF EXISTS `trig_year.ia`"
+  - sql: "DROP TRIGGER IF EXISTS json_quote_src_ai"
+  - sql: "DROP TRIGGER IF EXISTS trigger_union_src_ai"
+  - sql: "DROP TRIGGER IF EXISTS trigger_literal_src_ai"
   - sql: "DROP TABLE IF EXISTS derived_target"
   - sql: "DROP TABLE IF EXISTS derived_assoc"
   - sql: "DROP TABLE IF EXISTS derived_src"
@@ -71,8 +91,104 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS trig_invoice"
   - sql: "DROP TABLE IF EXISTS trig_invitem"
   - sql: "DROP TABLE IF EXISTS trig_year"
+  - sql: "DROP TABLE IF EXISTS json_quote_log"
+  - sql: "DROP TABLE IF EXISTS json_quote_src"
+  - sql: "DROP TABLE IF EXISTS trigger_union_event"
+  - sql: "DROP TABLE IF EXISTS trigger_union_log"
+  - sql: "DROP TABLE IF EXISTS trigger_union_src"
+  - sql: "DROP TABLE IF EXISTS trigger_literal_log"
+  - sql: "DROP TABLE IF EXISTS trigger_literal_src"
 
 test_cases:
+
+  # --- JSON string quoting used by generated event triggers ---
+
+  - name: "JSON_QUOTE preserves SQL NULL and escapes JSON string content"
+    sql: |
+      SELECT JSON_QUOTE('a"b') AS quoted, JSON_QUOTE(NULL) AS null_value
+    expect:
+      rows: 1
+      data:
+        - {quoted: '"a\"b"', null_value: null}
+
+  - name: "CREATE TRIGGER containing JSON_QUOTE"
+    sql: |
+      CREATE TRIGGER json_quote_src_ai
+      AFTER INSERT ON json_quote_src
+      FOR EACH ROW
+      BEGIN
+        INSERT INTO json_quote_log (id, payload)
+        VALUES (NEW.id, CONCAT('[', JSON_QUOTE(NEW.payload), ']'));
+      END
+    expect:
+      affected_rows: 1
+
+  - name: "Trigger executes JSON_QUOTE"
+    sql: "INSERT INTO json_quote_src (id, payload) VALUES (1, 'a\"b')"
+    expect:
+      affected_rows: 1
+
+  - name: "Trigger stored valid quoted JSON string"
+    sql: "SELECT id, payload FROM json_quote_log WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - {id: 1, payload: '["a\"b"]'}
+
+  - name: "CREATE event trigger with empty UNION ALL alternatives"
+    sql: |
+      CREATE TRIGGER trigger_union_src_ai
+      AFTER INSERT ON trigger_union_src
+      FOR EACH ROW
+      BEGIN
+        INSERT INTO trigger_union_log (method, payload)
+        SELECT
+          CASE WHEN kind = 'webhook' THEN 'run_webhook' ELSE 'fallback' END,
+          CONCAT('[', NEW.id, ', ', JSON_QUOTE(payload), ']')
+        FROM trigger_union_event
+        WHERE kind = 'created'
+        UNION ALL
+        SELECT
+          CASE WHEN kind = 'webhook' THEN 'run_webhook' ELSE 'fallback' END,
+          CONCAT('[', NEW.id, ', ', JSON_QUOTE(payload), ']')
+        FROM trigger_union_event
+        WHERE kind = 'changed';
+      END
+    expect:
+      affected_rows: 1
+
+  - name: "Fire event trigger without matching events"
+    sql: "INSERT INTO trigger_union_src (id) VALUES (7)"
+    expect:
+      affected_rows: 1
+
+  - name: "Empty UNION ALL trigger does not synthesize NULL row"
+    sql: "SELECT COUNT(*) AS cnt FROM trigger_union_log"
+    expect:
+      rows: 1
+      data:
+        - {cnt: 0}
+
+  - name: "CREATE trigger with SELECT literals without FROM"
+    sql: |
+      CREATE TRIGGER trigger_literal_src_ai
+      AFTER INSERT ON trigger_literal_src
+      FOR EACH ROW
+      BEGIN
+        INSERT INTO trigger_literal_log (method, payload)
+        SELECT 'literal', CONCAT('[', NEW.id, ']');
+      END
+    expect:
+      affected_rows: 1
+
+  - name: "SELECT literals trigger emits exactly one row"
+    setup:
+      - sql: "INSERT INTO trigger_literal_src (id) VALUES (11)"
+    sql: "SELECT method, payload FROM trigger_literal_log"
+    expect:
+      rows: 1
+      data:
+        - {method: literal, payload: '[11]'}
 
   # --- Basic trigger with backtick-quoted table names (Bug 4a) ---
 


### PR DESCRIPTION
## Summary

- add MariaDB-compatible `JSON_QUOTE` support used by generated event triggers
- compile every trigger `INSERT ... SELECT` through the relational planner, including `UNION ALL`, so empty branches emit zero rows instead of one synthetic NULL row
- retain the one-row semantics of `SELECT` literals without a `FROM` clause
- add regression coverage for JSON quoting, trigger compilation, empty UNION branches, and literal SELECT triggers

## Root cause

The trigger compiler only inspected `query-block` nodes. A `union-block` therefore looked like a source-less SELECT and was lowered into a synthetic single-row insert. When both UNION branches were empty, this incorrectly enqueued an all-NULL row. Delegating cardinality to `build_queryplan_term` preserves the normal relational zero/one/many-row semantics.

## Validation

- regression reproduced before the fix: empty `UNION ALL` inserted one NULL row
- focused trigger suites pass
- Scheme formatter/check passes
- full hook-equivalent `make test` passes