### PR TITLE
Cost equality-bound ACL probes at their real workload

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1291,14 +1291,16 @@ RecSet's per-driving-row cost is folded entirely into its one-pass build --
 unlike the keytable carrier, there is no separate per-row read term because
 recset_project_join already visits every driving row once while building the
 membership set. */
-(define scalar_first_probe_recset_cost_preferred? (lambda (stage probe_work_rows)
+(define scalar_first_probe_recset_cost_preferred? (lambda (stage probe_work_rows carrier_work_rows)
 	(and (number? (planner_literal_value probe_work_rows))
+		(and (number? (planner_literal_value carrier_work_rows))
 		(begin
 			(define probe_rows (planner_literal_value probe_work_rows))
+			(define carrier_rows (planner_literal_value carrier_work_rows))
 			(define input_rows (planner_stage_input_rows (gs_input stage)))
 			(and (number? input_rows)
 				(begin
-					(define recset_cost (planner_recset_carrier_cost input_rows probe_rows))
+					(define recset_cost (planner_recset_carrier_cost input_rows carrier_rows))
 					(define direct_cost (planner_direct_presence_probe_cost probe_rows))
 					(define keytable_cost (planner_presence_carrier_cost input_rows probe_rows))
 					(define chosen (if (planner_cost_better? recset_cost direct_cost)
@@ -1317,7 +1319,8 @@ membership set. */
 							(list "reason" "lowest_total_ns")
 							(list "inputs" (list
 								(list "domain_rows" input_rows)
-								(list "probe_rows" probe_rows)))
+								(list "probe_rows" probe_rows)
+								(list "carrier_rows" carrier_rows)))
 							(list "alternatives" (map
 								(list
 									(list (quote recset_carrier) recset_cost)
@@ -1331,9 +1334,9 @@ membership set. */
 										(list "cost" (planner_cost_explain (cadr candidate)))))))))
 					(and
 						(planner_cost_better? recset_cost (planner_direct_presence_probe_cost probe_rows))
-						(planner_cost_better? recset_cost (planner_presence_carrier_cost input_rows probe_rows)))))))))
+						(planner_cost_better? recset_cost (planner_presence_carrier_cost input_rows probe_rows))))))))))
 
-(define scalar_first_probe_recset_eligible? (lambda (graph stage src keys probe_work_rows requested_col)
+(define scalar_first_probe_recset_eligible? (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col)
 	(and (single_real_source? (qb_sources src))
 		(and (source_is_base_table? (single_real_source (qb_sources src)))
 			(and (empty_list? (qb_group src))
@@ -1342,12 +1345,12 @@ membership set. */
 						(and (nil? (qb_limit src)) (nil? (qb_offset src))
 							(and (not (nil? (scalar_first_probe_keytable_key_index stage (single_real_source (qb_sources src)) keys)))
 								(and (stage_boolean_shaped? graph stage requested_col)
-									(scalar_first_probe_recset_cost_preferred? stage probe_work_rows)))))))))))
+									(scalar_first_probe_recset_cost_preferred? stage probe_work_rows carrier_work_rows)))))))))))
 
-(define scalar_first_probe_recset_eligible_base? (lambda (graph stage src keys probe_work_rows requested_col)
+(define scalar_first_probe_recset_eligible_base? (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col)
 	(and (not (nil? (scalar_first_probe_keytable_key_index stage src keys)))
 		(and (stage_boolean_shaped? graph stage requested_col)
-			(scalar_first_probe_recset_cost_preferred? stage probe_work_rows)))))
+			(scalar_first_probe_recset_cost_preferred? stage probe_work_rows carrier_work_rows)))))
 
 (define recset_scalar_first_probe_lookup_key (lambda (stage)
 	(concat "__recset_probe_" (fnv_hash (gs_id stage)))))
@@ -1435,25 +1438,29 @@ Logical decorrelation contributes the stage shape; the current scan node
 contributes its work estimate. Emitters below only implement the selected
 operator and do not repeat policy gates, so future carriers join this one
 choice table instead of adding another promotion path. */
-(define scalar_first_probe_physical_operator (lambda (graph stage src keys probe_work_rows requested_col probe_semantics)
+(define scalar_first_probe_physical_operator (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col probe_semantics)
 	(if (union_block? src)
 		(quote union-probe)
 		(if (query_block? src)
-			(if (and (equal? probe_semantics (quote truth))
+			(if (qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+				(quote query-scan)
+				(if (and (equal? probe_semantics (quote truth))
 				(scalar_first_probe_recset_eligible?
-					graph stage src keys probe_work_rows requested_col))
+					graph stage src keys probe_work_rows carrier_work_rows requested_col))
 				(quote recset)
 				(if (scalar_first_probe_keytable_eligible? stage src keys probe_work_rows)
 					(quote keytable)
-					(quote query-scan)))
+					(quote query-scan))))
 			(if (source_is_base_table? src)
-				(if (and (equal? probe_semantics (quote truth))
+				(if (qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+					(quote table-scan)
+					(if (and (equal? probe_semantics (quote truth))
 					(scalar_first_probe_recset_eligible_base?
-						graph stage src keys probe_work_rows requested_col))
+						graph stage src keys probe_work_rows carrier_work_rows requested_col))
 					(quote recset)
 					(if (scalar_first_probe_keytable_eligible_base? stage src keys probe_work_rows)
 						(quote keytable)
-						(quote table-scan)))
+						(quote table-scan))))
 				(quote unsupported))))))
 
 (define scalar_first_probe_carrier_source (lambda (src)
@@ -1549,8 +1556,10 @@ choice table instead of adding another promotion path. */
 					'())
 				(list stage)))))
 		(define graph (stage_dependency_graph probe_stages))
+		(define lowered_lookup_keys (map lookup_keys (lambda (key)
+			(lower_column_expr_for_join sources default_alias key))))
 		(define operator (scalar_first_probe_physical_operator
-			graph stage src keys effective_probe_work_rows requested_col probe_semantics))
+			graph stage src keys effective_probe_work_rows effective_probe_work_rows requested_col probe_semantics))
 		(define lowered (match operator
 			(symbol union-probe)
 			(list (quote if)
@@ -1582,7 +1591,7 @@ choice table instead of adding another promotion path. */
 				stage
 				value_expr
 				keys
-				(map lookup_keys (lambda (key) (lower_column_expr_for_join sources default_alias key)))
+				lowered_lookup_keys
 				probe_work_rows
 				effective_probe_work_rows)
 			(symbol table-scan)
@@ -1600,9 +1609,20 @@ choice table instead of adding another promotion path. */
 					sources default_alias src stage value_expr keys lookup_keys
 					order_exprs dirs offset_value partition_limit))
 			_ (neumann_fail "build_queryplan" "scalar-first probe has no physical operator")))
+		(define memoized_lowered (if
+			(qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+			(list
+				(physical_query_session_symbol)
+				"get_or_compute_scoped"
+				(physical_query_scope_symbol)
+				(list (quote concat)
+					(concat (query_invariant_scalar_first_probe_key stage requested_col) ":bound:")
+					(list (quote serialize) (cons (quote list) lowered_lookup_keys)))
+				(list (quote lambda) '() lowered))
+			lowered))
 		(if (scalar_first_probe_query_invariant? stage requested_col)
-			(lower_query_invariant_scalar_first_probe_expr stage requested_col lowered)
-			lowered)))
+			(lower_query_invariant_scalar_first_probe_expr stage requested_col memoized_lowered)
+			memoized_lowered)))
 )
 
 (define lower_scalar_aggregate_probe_expr (lambda (sources default_alias stage requested_col)
@@ -5680,9 +5700,9 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
 		(* domain_rows 8) 0 domain_rows 0.65)))
 
-(define planner_recset_carrier_cost (lambda (domain_rows probe_rows)
-	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
-		(* probe_rows 1) 0 probe_rows 0.6)))
+(define planner_recset_carrier_cost (lambda (domain_rows carrier_rows)
+	(planner_cost 365607 0 0 0 0 (* carrier_rows 17681)
+		(* carrier_rows 1) 0 carrier_rows 0.6)))
 
 (define planner_membership_scan_invocation_ns 122080)
 (define planner_membership_scan_row_ns 1)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1437,12 +1437,20 @@ choice at the consuming join edge. */
 Logical decorrelation contributes the stage shape; the current scan node
 contributes its work estimate. Emitters below only implement the selected
 operator and do not repeat policy gates, so future carriers join this one
-choice table instead of adding another promotion path. */
+choice table instead of adding another promotion path.
+
+Decision contract: resolve an operator without comparing costs only when a
+semantic proof makes every competing realization strictly redundant. Every
+choice that can change with cardinality, selectivity, cache state, or data
+growth belongs in the calibrated comparison above and must retain the planner's
+recompile gate. A segment-invariant scalar is the proof case here: one cached
+scalar value replaces the same value for every segment row, while a carrier
+would still have to project that value over the segment. */
 (define scalar_first_probe_physical_operator (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col probe_semantics)
 	(if (union_block? src)
 		(quote union-probe)
 		(if (query_block? src)
-			(if (qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+			(if (qassoc_get (gs_facts stage) (quote segment_invariant_scalar_probe) false)
 				(quote query-scan)
 				(if (and (equal? probe_semantics (quote truth))
 				(scalar_first_probe_recset_eligible?
@@ -1452,7 +1460,7 @@ choice table instead of adding another promotion path. */
 					(quote keytable)
 					(quote query-scan))))
 			(if (source_is_base_table? src)
-				(if (qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+				(if (qassoc_get (gs_facts stage) (quote segment_invariant_scalar_probe) false)
 					(quote table-scan)
 					(if (and (equal? probe_semantics (quote truth))
 					(scalar_first_probe_recset_eligible_base?
@@ -1610,7 +1618,7 @@ choice table instead of adding another promotion path. */
 					order_exprs dirs offset_value partition_limit))
 			_ (neumann_fail "build_queryplan" "scalar-first probe has no physical operator")))
 		(define memoized_lowered (if
-			(qassoc_get (gs_facts stage) (quote memoize_bound_scalar_probe) false)
+			(qassoc_get (gs_facts stage) (quote segment_invariant_scalar_probe) false)
 			(list
 				(physical_query_session_symbol)
 				"get_or_compute_scoped"

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5156,7 +5156,13 @@ base-index segment even though the logical expression remains correlated. */
 					(merge_stage_catalogs (list stages dependencies
 						(qassoc_get (gs_facts raw_stage) (quote probe_catalog) '())
 						(list raw_stage)))))
-				(define effective_probe_work_rows (if (nil? bound_stage) probe_work_rows 1))
+				/* LIMIT bounds returned rows, not necessarily rejected candidates. Only a
+				segment-constant probe is guaranteed to execute once. A row-varying ACL may
+				inspect the complete segment before filling the window, so retain the full
+				carrier workload for that comparison. */
+				(define effective_probe_work_rows (if (nil? bound_stage)
+					(if bounded_direct_context carrier_work_rows probe_work_rows)
+					1))
 				(define operator (if (nil? target_col) (quote unsupported)
 					(scalar_first_probe_physical_operator
 						(stage_dependency_graph probe_stages)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5080,7 +5080,7 @@ conjunct of AND is safe because every surviving row must satisfy it. */
 			(group_stage_with_facts stage
 				(qassoc_set
 					(qassoc_set (gs_facts stage) (quote lookup-keys) bound_keys)
-					(quote memoize_bound_scalar_probe) true))))))
+					(quote segment_invariant_scalar_probe) true))))))
 
 (define rewrite_physical_scalar_probe_stage (lambda (probe replacement expr)
 	(match expr
@@ -5121,8 +5121,14 @@ conjunct of AND is safe because every surviving row must satisfy it. */
 /* Return (driver-alias carrier-expression original-probe selected-stage).
 The carrier is non-nil only for the projected RecSet alternative. When every
 correlation key is fixed by a source-local equality, selected-stage instead
-marks the direct probe as query-memoized: its value is constant for the whole
-base-index segment even though the logical expression remains correlated. */
+records the semantic proof that its value is constant for the whole base-index
+segment even though the logical expression remains correlated.
+
+That proof is an immediate dominance decision: evaluating and caching the one
+scalar cannot require more driver work than projecting a full carrier. Do not
+extend this branch with estimated-selectivity or row-count thresholds. Whenever
+either alternative can win for different data, feed both costs into the normal
+physical decision and preserve its runtime recompile gate. */
 (define physical_scalar_truth_plan (lambda (sources driver_src default_alias condition probe_work_rows carrier_work_rows stages)
 	(begin
 		(define probe (physical_scalar_truth_probe condition))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -66,6 +66,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				_ false)))
 		false)))
 
+/* Return (found expression), rather than the expression alone, because SQL NULL
+is itself a valid equality binding. The opposite side must be independent of
+the source row; otherwise this is a join equality, not a query-local value. */
+(define source_column_equality_binding (lambda (src col condition)
+	(reduce
+		(split_and_terms (coalesceNil condition true))
+		(lambda (found term)
+			(if (car found)
+				found
+				(match term
+					'(op left right)
+					(if (or (equal? op (quote equal?)) (equal? op (quote equal??)))
+						(if (and (equal?? (direct_column_name_for_alias src left) col)
+							(not (expr_contains_column_ref? right)))
+							(list true right)
+							(if (and (equal?? (direct_column_name_for_alias src right) col)
+								(not (expr_contains_column_ref? left)))
+								(list true left)
+								found))
+						found)
+					_ found)))
+		(list false nil))))
+
 (define source_unique_point_condition? (lambda (src condition)
 	(if (not (source_is_base_table? src))
 		false
@@ -3049,24 +3072,29 @@ RecSet; membership edges retain their own physical operators. */
 			(begin
 				(define alias (source_alias src))
 				(define raw_condition (combine_where (qb_where block) (source_join_expr src)))
-				(define scalar_carrier (physical_scalar_truth_carrier
+				(define order_items (coalesceNil (qb_order block) '()))
+				(define scan_order_supported (order_items_belong_to_source? src order_items))
+				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
+				/* The scalar carrier and the eventual scan must cost the same consumer.
+				A native ordered LIMIT asks only for its bounded result window; an
+				unorderable LIMIT cannot brake the source and retains full-table work. */
+				(define probe_work_rows (if (and scan_order_supported bounded)
+					(coalesceNil (probe_limit_work_rows (qb_limit block))
+						(probe_context_row_count (list src)))
+					(probe_context_row_count (list src))))
+				(define scalar_plan (physical_scalar_truth_plan
 					(list src) src alias raw_condition
-					(probe_context_row_count (list src))
+					probe_work_rows (probe_context_row_count (list src))
 					(query_block_stage_catalog block)))
-				(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
-				(define condition (if (nil? scalar_probe) raw_condition
-					(rewrite_physical_scalar_probe_as_true scalar_probe raw_condition)))
-				(define effective_fields (if (nil? scalar_probe) fields
-					(rewrite_physical_scalar_probe_as_true scalar_probe fields)))
+				(define scalar_carrier (physical_scalar_truth_plan_carrier scalar_plan))
+				(define condition (rewrite_physical_scalar_truth_plan scalar_plan raw_condition))
+				(define effective_fields (rewrite_physical_scalar_truth_plan scalar_plan fields))
 				(define projection_bundle (physical_scalar_projection_bundle
 					(list src) alias effective_fields))
 				(define bundled_fields (if (nil? projection_bundle)
 					effective_fields
 					(nth projection_bundle 1)))
 				(define source_table (source_table_expr_using (query_block_stage_catalog block) src))
-				(define order_items (coalesceNil (qb_order block) '()))
-				(define scan_order_supported (order_items_belong_to_source? src order_items))
-				(define bounded (query_limit_active? (qb_offset block) (qb_limit block)))
 				(define memberships (driver_memberships_for_source src condition))
 				/* A derived Top-K has already moved ORDER/LIMIT into its row-number
 				consumer. The logical membership requirement retains that ownership even
@@ -3198,10 +3226,10 @@ RecSet; membership edges retain their own physical operators. */
 				(define table_expr (if (nil? scalar_carrier)
 					membership_table_expr
 					(if (equal? membership_table_expr source_table)
-						(nth scalar_carrier 1)
+						scalar_carrier
 						(list (quote recset_intersect)
 							(cons (quote list) (list
-								(nth scalar_carrier 1)
+								scalar_carrier
 								membership_table_expr))))))
 				(define filter_expr (list (quote lambda)
 					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
@@ -3652,14 +3680,14 @@ move the window to the wrong tree level. */
 		/* A scalar truth carrier over the complete driver would defeat adaptive
 		batching. When the batch alternative wins, keep the scalar marker in the
 		predicate and lower it with the batch cardinality inside scan_recset. */
-		(define scalar_carrier (if use_batch_accept nil
-			(physical_scalar_truth_carrier
-				all_sources src default_alias final_condition acceptance_probe_work_rows stages)))
-		(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
-		(define carrier_condition (if (nil? scalar_probe) final_condition
-			(rewrite_physical_scalar_probe_as_true scalar_probe final_condition)))
-		(define carrier_needed_exprs (if (nil? scalar_probe) needed_exprs
-			(rewrite_physical_scalar_probe_as_true scalar_probe needed_exprs)))
+		(define scalar_plan (if use_batch_accept nil
+			(physical_scalar_truth_plan
+				all_sources src default_alias final_condition acceptance_probe_work_rows
+				(planner_source_row_count src) stages)))
+		(define scalar_carrier (physical_scalar_truth_plan_carrier scalar_plan))
+		(define scalar_probe (physical_scalar_truth_plan_probe scalar_plan))
+		(define carrier_condition (rewrite_physical_scalar_truth_plan scalar_plan final_condition))
+		(define carrier_needed_exprs (rewrite_physical_scalar_truth_plan scalar_plan needed_exprs))
 		(define condition_parts (physical_partition_condition
 			default_alias src remaining_sources carrier_condition))
 		(define local_condition (nth condition_parts 0))
@@ -3769,7 +3797,7 @@ move the window to the wrong tree level. */
 				(canonical_order_relation < (source_column_order_collation src col)))))))
 		(define table_expr (if (nil? scalar_carrier)
 			(coalesceNil membership_table_expr (source_table_expr_using stages src))
-			(nth scalar_carrier 1)))
+			scalar_carrier))
 		(define scan_expr (if use_batch_accept
 			(list (quote scan_order_batch_accept)
 				'(session "__memcp_tx") table_expr batch_filter
@@ -4262,7 +4290,7 @@ exact parameter value. */
 					(not (equal? term predicate))))
 				true)))))
 
-(define build_join_scan_leaf_using_recipe (lambda (schema all_sources leaf future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+(define build_join_scan_leaf_using_recipe (lambda (schema all_sources leaf future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 	(begin
 		(define src (physical_join_leaf_source all_sources leaf))
 		(define future_sources (join_optimizer_sources_for_order all_sources future_aliases))
@@ -4330,18 +4358,18 @@ exact parameter value. */
 		the scalar/EXISTS carrier only now, with that node-local cardinality. An
 		adaptive batch keeps the marker inside its batch predicate so each batch
 		runs the same lowerer with its own work estimate. */
-		(define effective_scalar_carrier (if (not (nil? scalar_carrier))
-			scalar_carrier
+		(define effective_scalar_plan (if (not (nil? scalar_plan))
+			scalar_plan
 			/* Without a preceding membership carrier, retain the established
 			leaf-condition lowering. It owns nullable LEFT-JOIN cardinality and must
 			not be pre-empted by a driver-context estimate from another tree node. */
 			(if (or (nil? membership_plan) use_batch_accept) nil
-				(physical_scalar_truth_carrier all_sources src default_alias condition
-					residual_probe_work_rows stages))))
-		(define local_scalar_probe (if (nil? effective_scalar_carrier)
-			nil (nth effective_scalar_carrier 2)))
-		(define carrier_condition (if (nil? local_scalar_probe) condition
-			(rewrite_physical_scalar_probe_as_true local_scalar_probe condition)))
+				(physical_scalar_truth_plan all_sources src default_alias condition
+					residual_probe_work_rows residual_probe_work_rows stages))))
+		(define effective_scalar_carrier
+			(physical_scalar_truth_plan_carrier effective_scalar_plan))
+		(define carrier_condition
+			(rewrite_physical_scalar_truth_plan effective_scalar_plan condition))
 		(define membership_table_expr (if (and
 			(not (nil? membership_plan))
 			(or (equal? membership_strategy "candidate_keyset")
@@ -4430,7 +4458,7 @@ exact parameter value. */
 			recipe_mapcols))
 		(define mapcols raw_mapcols)
 		(define scalar_carrier_driver (and (not (nil? effective_scalar_carrier))
-			(equal? alias (car effective_scalar_carrier))))
+			(equal? alias (car effective_scalar_plan))))
 		(define base_table_expr (if membership_driver membership_table_expr
 			(if (not access_path_selected)
 				(source_table_expr_using stages src)
@@ -4438,10 +4466,10 @@ exact parameter value. */
 		(define table_expr (if (not scalar_carrier_driver)
 			base_table_expr
 			(if (equal? base_table_expr (source_table_expr_using stages src))
-				(nth effective_scalar_carrier 1)
+				effective_scalar_carrier
 				(list (quote recset_intersect)
 					(cons (quote list) (list
-						(nth effective_scalar_carrier 1)
+						effective_scalar_carrier
 						base_table_expr))))))
 		(define lowered_filter_condition (mark_outer_join_symbols
 			all_sources
@@ -4532,19 +4560,19 @@ exact parameter value. */
 /* Consume the logical join tree recursively. The right subtree is lowered as
 the continuation of the left subtree, so join-node boundaries and outer-join
 ownership remain available until the physical scans are emitted. */
-(define build_join_tree_scan_using_recipe (lambda (schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+(define build_join_tree_scan_using_recipe (lambda (schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 	(match tree
 		((symbol join-leaf) _alias)
-		(build_join_scan_leaf_using_recipe schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+		(build_join_scan_leaf_using_recipe schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 		((quote join-leaf) alias)
-		(build_join_tree_scan_using_recipe schema all_sources (make_join_optimizer_leaf alias) future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+		(build_join_tree_scan_using_recipe schema all_sources (make_join_optimizer_leaf alias) future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 		((symbol join-leaf) _alias _predicates)
-		(build_join_scan_leaf_using_recipe schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+		(build_join_scan_leaf_using_recipe schema all_sources tree future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 		((quote join-leaf) alias predicates)
 		(build_join_tree_scan_using_recipe schema all_sources
 			(list (quote join-leaf) alias predicates) future_aliases default_alias needed_exprs
 			final_condition row_expr order_items offset_value limit_value allow_membership_recset
-			column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+			column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 		((symbol join-node) kind left right predicates)
 		(begin
 			/* NULL extension is a property of the LEFT boundary, independent of
@@ -4562,22 +4590,22 @@ ownership remain available until the physical scans are emitted. */
 				makes a rejecting downstream predicate visible before the left carrier
 				chooses whether its native LIMIT is semantically safe. */
 				default_alias needed_exprs (combine_where final_condition node_condition) row_expr
-				order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier
+				order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan
 				(lambda (left_condition left_row_expr left_order_items)
 					(build_join_tree_scan_using_recipe
 						schema all_sources right future_aliases
 						default_alias needed_exprs left_condition left_row_expr
-						left_order_items 0 -1 allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation
+						left_order_items 0 -1 allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation
 						(equal? kind (quote left-outer))))
 				outer_scan))
 		((quote join-node) kind left right predicates)
 		(build_join_tree_scan_using_recipe schema all_sources
 			(make_join_optimizer_node kind left right predicates) future_aliases
 			default_alias needed_exprs final_condition row_expr order_items offset_value limit_value
-			allow_membership_recset column_recipe stages result_mode probe_context scalar_carrier continuation outer_scan)
+			allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 		_ (neumann_fail "build_queryplan" "malformed logical join tree"))))
 
-(define build_join_scan_with_mapper_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_work_rows scalar_carrier)
+(define build_join_scan_with_mapper_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_work_rows scalar_plan)
 	(begin
 		(define tree (physical_join_plan_for_sources sources))
 		(define probe_context (join_scan_probe_context tree all_sources probe_work_rows))
@@ -4601,19 +4629,19 @@ ownership remain available until the physical scans are emitted. */
 			(build_join_tree_scan_using_recipe
 				schema all_sources tree '() default_alias needed_exprs residual_condition row_expr
 				order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context
-				scalar_carrier terminal false)))))
+				scalar_plan terminal false)))))
 
-(define build_join_scan_pipeline_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier probe_work_rows column_recipe stages scalar_carrier)
+(define build_join_scan_pipeline_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier probe_work_rows column_recipe stages scalar_plan)
 	(build_join_scan_with_mapper_using_recipe
 		schema all_sources sources default_alias needed_exprs final_condition row_expr
 		order_items offset_value limit_value allow_membership_carrier column_recipe stages
-		(list (quote pipeline)) probe_work_rows scalar_carrier)))
+		(list (quote pipeline)) probe_work_rows scalar_plan)))
 
-(define build_join_scan_reduce_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier probe_work_rows column_recipe stages reduce_expr neutral_expr shard_reduce_expr scalar_carrier)
+(define build_join_scan_reduce_using_recipe (lambda (schema all_sources sources default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_carrier probe_work_rows column_recipe stages reduce_expr neutral_expr shard_reduce_expr scalar_plan)
 	(build_join_scan_with_mapper_using_recipe
 		schema all_sources sources default_alias needed_exprs final_condition row_expr
 		order_items offset_value limit_value allow_membership_carrier column_recipe stages
-		(list (quote reduce) reduce_expr neutral_expr shard_reduce_expr) probe_work_rows scalar_carrier)))
+		(list (quote reduce) reduce_expr neutral_expr shard_reduce_expr) probe_work_rows scalar_plan)))
 
 (define build_join_scan_sink (lambda (schema sources default_alias needed_exprs final_condition sink_expr stages)
 	(build_join_scan_pipeline_using_recipe
@@ -5026,67 +5054,151 @@ conjunct of AND is safe because every surviving row must satisfy it. */
 			(rewrite_physical_scalar_probe_as_true probe item))))
 		_ expr)))
 
-/* Return (driver-alias carrier-expression probe). The carrier expression is
-already the selected physical operator and is consumed directly as the scan
-source of that driver leaf. */
-(define physical_scalar_truth_carrier (lambda (sources driver_src default_alias condition probe_work_rows stages)
+(define scalar_probe_bound_lookup_keys (lambda (driver_src condition lookup_keys)
+	(reverse (nth (reduce lookup_keys (lambda (state key)
+		(if (not (car state))
+			state
+			(begin
+				(define col (direct_column_name_for_alias driver_src key))
+				(if (nil? col)
+					(if (expr_contains_column_ref? key)
+						(list false '())
+						(list true (cons key (cadr state))))
+					(begin
+						(define binding (source_column_equality_binding driver_src col condition))
+						(if (car binding)
+							(list true (cons (cadr binding) (cadr state)))
+							(list false '())))))))
+		(list true '())) 1))))
+
+(define scalar_probe_stage_with_bound_lookup_keys (lambda (driver_src condition stage)
+	(begin
+		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(define bound_keys (scalar_probe_bound_lookup_keys driver_src condition lookup_keys))
+		(if (or (empty_list? lookup_keys) (not (equal? (count bound_keys) (count lookup_keys))))
+			nil
+			(group_stage_with_facts stage
+				(qassoc_set
+					(qassoc_set (gs_facts stage) (quote lookup-keys) bound_keys)
+					(quote memoize_bound_scalar_probe) true))))))
+
+(define rewrite_physical_scalar_probe_stage (lambda (probe replacement expr)
+	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(if (physical_scalar_probe_matches? probe stage requested_col)
+			(list (quote scalar_first_probe) replacement requested_col)
+			expr)
+		((quote scalar_first_probe) stage requested_col)
+		(rewrite_physical_scalar_probe_stage probe replacement
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((symbol scalar_first_probe) stage requested_col dependencies)
+		(if (physical_scalar_probe_matches? probe stage requested_col)
+			(list (quote scalar_first_probe) replacement requested_col
+				(map dependencies (lambda (dependency)
+					(if (and (group_stage? dependency) (equal? (gs_id dependency) (gs_id stage)))
+						replacement dependency))))
+			expr)
+		((quote scalar_first_probe) stage requested_col dependencies)
+		(rewrite_physical_scalar_probe_stage probe replacement
+			(list (symbol "scalar_first_probe") stage requested_col dependencies))
+		(cons head tail) (cons head (map tail (lambda (item)
+			(rewrite_physical_scalar_probe_stage probe replacement item))))
+		_ expr)))
+
+(define physical_scalar_truth_plan_carrier (lambda (plan)
+	(if (nil? plan) nil (nth plan 1))))
+
+(define physical_scalar_truth_plan_probe (lambda (plan)
+	(if (or (nil? plan) (nil? (physical_scalar_truth_plan_carrier plan))) nil (nth plan 2))))
+
+(define rewrite_physical_scalar_truth_plan (lambda (plan expr)
+	(if (nil? plan)
+		expr
+		(if (not (nil? (physical_scalar_truth_plan_carrier plan)))
+			(rewrite_physical_scalar_probe_as_true (nth plan 2) expr)
+			(rewrite_physical_scalar_probe_stage (nth plan 2) (nth plan 3) expr)))))
+
+/* Return (driver-alias carrier-expression original-probe selected-stage).
+The carrier is non-nil only for the projected RecSet alternative. When every
+correlation key is fixed by a source-local equality, selected-stage instead
+marks the direct probe as query-memoized: its value is constant for the whole
+base-index segment even though the logical expression remains correlated. */
+(define physical_scalar_truth_plan (lambda (sources driver_src default_alias condition probe_work_rows carrier_work_rows stages)
 	(begin
 		(define probe (physical_scalar_truth_probe condition))
 		(if (nil? probe)
 			nil
 			(begin
-				(define stage (car probe))
+				(define raw_stage (car probe))
 				(define requested_col (cadr probe))
 				(define dependencies (nth probe 2))
+				(define bounded_direct_context (and
+					(number? (planner_literal_value probe_work_rows))
+					(and (number? (planner_literal_value carrier_work_rows))
+						(< (planner_literal_value probe_work_rows)
+							(planner_literal_value carrier_work_rows)))))
+				(define bound_stage (if bounded_direct_context
+					(scalar_probe_stage_with_bound_lookup_keys driver_src condition raw_stage)
+					nil))
+				(define stage (coalesceNil bound_stage raw_stage))
 				(define src (gs_input stage))
+				(define raw_lookup_keys (qassoc_get (gs_facts raw_stage) (quote lookup-keys) '()))
 				(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
 				(define keys (if (empty_list? lookup_keys) '() (gs_keys stage)))
 				(define carrier_src (scalar_first_probe_carrier_source src))
 				(define key_index (if (or (nil? carrier_src)
-					(not (equal? (count keys) (count lookup_keys))))
+					(not (equal? (count keys) (count raw_lookup_keys))))
 					nil
-					(scalar_first_probe_keytable_key_index stage carrier_src keys)))
+					(scalar_first_probe_keytable_key_index raw_stage carrier_src keys)))
 				(define target_col (if (nil? key_index) nil
-					(direct_column_name_for_alias driver_src (nth lookup_keys key_index))))
+					(direct_column_name_for_alias driver_src (nth raw_lookup_keys key_index))))
 				(define probe_stages (stage_catalog_with_nested
 					(merge_stage_catalogs (list stages dependencies
-						(qassoc_get (gs_facts stage) (quote probe_catalog) '())
-						(list stage)))))
+						(qassoc_get (gs_facts raw_stage) (quote probe_catalog) '())
+						(list raw_stage)))))
+				(define effective_probe_work_rows (if (nil? bound_stage) probe_work_rows 1))
 				(define operator (if (nil? target_col) (quote unsupported)
 					(scalar_first_probe_physical_operator
 						(stage_dependency_graph probe_stages)
-						stage src keys probe_work_rows requested_col (quote truth))))
-				(if (not (equal? operator (quote recset)))
+						raw_stage src keys effective_probe_work_rows carrier_work_rows requested_col (quote truth))))
+				(if (and (not (equal? operator (quote recset))) (nil? bound_stage))
 					nil
 					(list
 						(source_alias driver_src)
-						(lower_projected_recset_scalar_first_probe_expr
-							probe_stages stage requested_col driver_src target_col)
-						probe)))))))
+						(if (equal? operator (quote recset))
+							(lower_projected_recset_scalar_first_probe_expr
+								probe_stages raw_stage requested_col driver_src target_col)
+							nil)
+						probe
+						(if (equal? operator (quote recset)) raw_stage stage))))))))
 
-(define build_join_scan_rows (lambda (schema sources plan default_alias needed_exprs final_condition fields order_items offset_value limit_value stages facts)
+(define build_join_scan_rows (lambda (schema sources plan default_alias needed_exprs final_condition fields order_items offset_value limit_value limit_brakes stages facts)
 	(begin
 		(define driver_source (join_optimizer_source_by_alias sources
 			(join_optimizer_tree_first_alias plan)))
 		(define filter_probe_work_rows (membership_probe_work_rows facts final_condition
 			(planner_row_count_after_selectivity
 				driver_source sources default_alias final_condition nil)))
+		/* A native ordered LIMIT bounds every consumer inside the driver scan,
+		including rejecting scalar probes. Cost that continuation by the rows the
+		window requests, just as join_ordered_streaming_limit_plan does. Plans whose
+		ORDER cannot brake retain the complete filtered workload. */
+		(define bounded_probe_work_rows (if limit_brakes
+			(coalesceNil (probe_limit_work_rows limit_value) filter_probe_work_rows)
+			filter_probe_work_rows))
 		/* Membership is an AND-carrier alternative, not merely a predicate leaf.
 		When present at the driver, its physical choice must establish the rows
 		seen by an expensive scalar/EXISTS conjunct before that conjunct chooses
 		between probes and a complete RecSet. The leaf owns that second choice. */
 		(define defer_scalar_carrier
 			(not (nil? (driver_membership_for_source driver_source final_condition))))
-		(define scalar_carrier (if defer_scalar_carrier nil
-			(physical_scalar_truth_carrier
-				sources driver_source default_alias final_condition filter_probe_work_rows stages)))
-		(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
-		(define effective_condition (if (nil? scalar_probe) final_condition
-			(rewrite_physical_scalar_probe_as_true scalar_probe final_condition)))
-		(define effective_fields (if (nil? scalar_probe) fields
-			(rewrite_physical_scalar_probe_as_true scalar_probe fields)))
-		(define effective_needed_exprs (if (nil? scalar_probe) needed_exprs
-			(rewrite_physical_scalar_probe_as_true scalar_probe needed_exprs)))
+		(define scalar_plan (if defer_scalar_carrier nil
+			(physical_scalar_truth_plan
+				sources driver_source default_alias final_condition
+				bounded_probe_work_rows filter_probe_work_rows stages)))
+		(define effective_condition (rewrite_physical_scalar_truth_plan scalar_plan final_condition))
+		(define effective_fields (rewrite_physical_scalar_truth_plan scalar_plan fields))
+		(define effective_needed_exprs (rewrite_physical_scalar_truth_plan scalar_plan needed_exprs))
 		(define projection_probe_work_rows (if (query_limit_active? offset_value limit_value)
 			(coalesceNil (probe_limit_work_rows limit_value) 0)
 			(if (probe_context_unique_point? sources default_alias effective_condition)
@@ -5107,7 +5219,7 @@ source of that driver leaf. */
 				(nth projection_bundle 2))))
 		(build_join_scan_pipeline_using_recipe
 			schema sources plan default_alias effective_needed_exprs effective_condition row_expr
-			order_items offset_value limit_value true filter_probe_work_rows nil stages scalar_carrier))))
+			order_items offset_value limit_value true bounded_probe_work_rows nil stages scalar_plan))))
 
 (define lower_query_block_as_dataset_reduce (lambda (block fields row_mapper reduce_expr neutral_expr shard_reduce_expr)
 	(begin
@@ -5155,22 +5267,22 @@ source of that driver leaf. */
 			(coalesceNil (probe_limit_work_rows (qb_limit block)) 0)
 			(if (probe_context_unique_point? scan_sources first_alias final_condition) 1
 				unbounded_probe_work_rows)))
+		(define scalar_carrier_probe_work_rows (if direct_order_safe
+			projection_probe_work_rows
+			unbounded_probe_work_rows))
 		(if (or direct_order_safe
 			(and hierarchical_order
 				(driver_limit_cannot_brake?
 					ordered_sources first_alias final_condition
 					(qb_offset block) (qb_limit block) (query_block_stage_catalog block))))
 			(begin
-				(define scalar_carrier (physical_scalar_truth_carrier
+				(define scalar_plan (physical_scalar_truth_plan
 					scan_sources driver_source first_alias final_condition
-					unbounded_probe_work_rows (query_block_stage_catalog block)))
-				(define scalar_probe (if (nil? scalar_carrier) nil (nth scalar_carrier 2)))
-				(define effective_condition (if (nil? scalar_probe) final_condition
-					(rewrite_physical_scalar_probe_as_true scalar_probe final_condition)))
-				(define effective_field_exprs (if (nil? scalar_probe) field_exprs
-					(rewrite_physical_scalar_probe_as_true scalar_probe field_exprs)))
-				(define effective_needed_exprs (if (nil? scalar_probe) needed_exprs
-					(rewrite_physical_scalar_probe_as_true scalar_probe needed_exprs)))
+					scalar_carrier_probe_work_rows unbounded_probe_work_rows
+					(query_block_stage_catalog block)))
+				(define effective_condition (rewrite_physical_scalar_truth_plan scalar_plan final_condition))
+				(define effective_field_exprs (rewrite_physical_scalar_truth_plan scalar_plan field_exprs))
+				(define effective_needed_exprs (rewrite_physical_scalar_truth_plan scalar_plan needed_exprs))
 				(define row_expr (cons row_mapper (map effective_field_exprs (lambda (expr)
 					(lower_column_expr_for_join_in_context
 						scan_sources first_alias expr projection_probe_work_rows)))))
@@ -5186,7 +5298,7 @@ source of that driver leaf. */
 					(coalesceNil (qb_offset block) 0)
 					(coalesceNil (qb_limit block) -1)
 					true projection_probe_work_rows nil (query_block_stage_catalog block)
-					reduce_expr neutral_expr shard_reduce_expr scalar_carrier))
+					reduce_expr neutral_expr shard_reduce_expr scalar_plan))
 			(if hierarchical_order
 				(join_ordered_streaming_limit_plan
 					(qb_schema block) scan_sources scan_plan first_alias needed_exprs final_condition
@@ -5311,7 +5423,7 @@ source of that driver leaf. */
 					(build_join_scan_rows
 						(qb_schema block) scan_sources scan_plan first_alias needed_exprs
 						final_condition fields order_items (qb_offset block) (qb_limit block)
-						stage_catalog (qb_facts block))
+						direct_order_safe stage_catalog (qb_facts block))
 					(if hierarchical_order
 						(if (ordered_join_native_limit_supported?
 							scan_sources scan_plan first_alias order_items stage_catalog final_condition)

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -520,6 +520,109 @@ test_cases:
         - "recset_project_join"
         - ".grp:union"
 
+  - name: "bounded equality and order keep the base table as ACL driver"
+    sql: |
+      EXPLAIN PHYSICAL SELECT d.id
+      FROM bqm_document d
+      WHERE d.standort_id = 1
+        AND COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = 7
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      result_contains:
+        - "scalar_presence_carrier"
+        - "chosen direct_subscan"
+        - "probe_rows 1"
+        - "carrier_rows 40000"
+        - "scan_order"
+        - "bound:"
+      result_not_contains:
+        - "scan_order_recset_part"
+
+  - name: "bounded equality and order preserve ACL results"
+    max_time: 1
+    sql: |
+      SELECT d.id
+      FROM bqm_document d
+      WHERE d.standort_id = 1
+        AND COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = 7
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - id: 39997
+        - id: 39993
+        - id: 39989
+
+  - name: "unbounded equality count retains the segmented ACL carrier"
+    sql: |
+      EXPLAIN PHYSICAL SELECT COUNT(*) AS total
+      FROM bqm_document d
+      WHERE d.standort_id = 1
+        AND COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = 7
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+    expect:
+      result_contains:
+        - "scalar_presence_carrier"
+        - "chosen recset_carrier"
+        - "recset_project_join"
+      result_not_contains:
+        - "bound:"
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS bqm_file"
   - sql: "DROP TABLE IF EXISTS bqm_unused_lookup"

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -1859,9 +1859,9 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
 		(* domain_rows 8) 0 domain_rows 0.65)))
 
-(define planner_recset_carrier_cost (lambda (domain_rows probe_rows)
-	(planner_cost 365607 0 0 0 0 (* probe_rows 17681)
-		(* probe_rows 1) 0 probe_rows 0.6)))
+(define planner_recset_carrier_cost (lambda (domain_rows carrier_rows)
+	(planner_cost 365607 0 0 0 0 (* carrier_rows 17681)
+		(* carrier_rows 1) 0 carrier_rows 0.6)))
 
 (define planner_membership_scan_invocation_ns %d)
 (define planner_membership_scan_row_ns %d)


### PR DESCRIPTION
## What

- separate the number of direct scalar probes from the number of rows required to build/project a complete RecSet carrier
- let an ordered LIMIT bound direct probe work without incorrectly making a full carrier look LIMIT-sized
- recognize correlation keys fixed by source-local equality predicates
- evaluate such a bounded scalar probe once per distinct bound key through the existing query-scoped memo facility while retaining the ordered base-table scan
- keep unbounded aggregate consumers on the complete segmented carrier
- keep the generated cost model as the source of coefficients; the generator change only clarifies that the RecSet term is carrier work, not bounded probe work

This is a physical consumer decision. Logical decorrelation and the combined query-block/group-stage model remain unchanged.

## Why

The previous comparison fed the same row estimate to fundamentally different alternatives. Under `ORDER BY ... LIMIT 72`, a direct probe may need only a bounded window, but `recset_project_join` still visits the complete filtered driver. Treating both as 72 rows caused a full projected carrier to win and hid the useful equality+ORDER base index.

A plain LIMIT estimate is also insufficient when the ACL rejects most candidates. If the correlated lookup key is fixed by `column = literal/session-value`, every candidate asks the same scalar question. The compiler now proves that invariant, costs one distinct direct probe, and memoizes it instead of performing the same point subscan tens of thousands of times.

## Permanent regression coverage

Extended `acl-boolean-membership-scaling.yaml` with a paired production-shaped check:

- bounded equality + ORDER + compound ACL selects `direct_subscan`, reports `probe_rows 1`, keeps `scan_order`, and emits no projected RecSet carrier
- result correctness is checked independently
- the corresponding unbounded COUNT still selects `recset_carrier` and `recset_project_join`

The focused suite is green: 18/18.

Additional targeted suites are green:

- ordered scan sources: 3/3
- ORDER/LIMIT: 48/48
- nested correlated subqueries: 11/11
- decorrelated join reordering: 8/8
- unselective scalar ORDER/LIMIT: 11/11
- Scheme startup tests: 1267/1267
- cost generator Go tests

The complete YAML suite is intentionally left to CI.

## Real-data A/B

On the production-copy dataset (~855k driving rows), user 112, using the exact application SELECT shape:

- location 242, 27,372 ordered candidates and only 3 ACL-visible rows:
  - previous direct plan after the initial LIMIT costing change: 4.75-5.29 s warm
  - this PR: 2.64 s cold, then 0.42-0.43 s warm
- location 89, 61,481 ordered candidates and 72 returned rows:
  - this PR: 0.81 s

Scan telemetry confirms the intended base access path in both cases: equality prefix plus order columns (`standort,jahr,abteilung,pruefung`), with no `recset_project_join`/`scan_order_recset_part` in the paginated SELECT. The unbounded synthetic COUNT proof retains the segmented carrier.
