### PR TITLE
Plan compound boolean probes as costed RecSet carriers

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -681,6 +681,18 @@ bound once outside row callbacks; a column reference would make that unsafe. */
 			(map (lowering_catalog_stages stages) (lambda (stage)
 				(stage_with_query_invariant_probe_binding_using binding_keys stage)))))))
 
+/* A closed physical producer cannot capture the main plan's lexical invariant
+binding. Mark only its invariant stages for an inline query-scoped probe; the
+ordinary scalar lowerer keeps its established outer-binding behavior. */
+(define stage_lookup_with_inline_query_invariant_probes (lambda (stages)
+	(make_lowering_catalog
+		(map (lowering_catalog_stages stages) (lambda (stage)
+			(if (query_invariant_presence_stage? stage)
+				(group_stage_with_facts stage
+					(qassoc_set (gs_facts stage)
+						(quote inline_query_invariant_probe) true))
+				stage))))))
+
 (define query_invariant_probe_sources (lambda (stages sources)
 	(filter (coalesceNil sources '()) (lambda (src)
 		(begin
@@ -1209,6 +1221,17 @@ and RecSet carriers additionally verify its uniqueness below. */
 					idx
 					nil))))))
 
+/* A request-local carrier has already bound session-domain expressions while
+building its rows. Only the remaining row-varying key belongs to a RecSet key
+index or a projection onto another base table. Keeping this projection shape
+canonical prevents session keys from becoming fake target columns. */
+(define scalar_first_probe_recset_row_keys (lambda (stage src)
+	(begin
+		(define keys (gs_keys stage))
+		(define idx (if (nil? src) nil
+			(scalar_first_probe_row_key_index stage src keys)))
+		(if (nil? idx) '() (list (nth keys idx))))))
+
 /* stage_direct_probe_cost_preferred? only weighs the two costs against each
 other when probe_work_rows is a known number; planner_direct_presence_probe_preferred?
 short-circuits to false otherwise, purely because (number? probe_rows) fails,
@@ -1260,7 +1283,7 @@ through to reach the base table -- src already is it. */
 		(define cache_schema (group_cache_schema cache))
 		(define cache_relation (group_cache_relation cache))
 		(list (quote begin)
-			(lower_group_stage_prepare_using stage_catalog stage_catalog physical_stage true)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog physical_stage true nil)
 			(list (quote scan_order)
 				'(session "__memcp_tx")
 				(list (quote table) cache_schema cache_relation)
@@ -1294,47 +1317,47 @@ membership set. */
 (define scalar_first_probe_recset_cost_preferred? (lambda (stage probe_work_rows carrier_work_rows)
 	(and (number? (planner_literal_value probe_work_rows))
 		(and (number? (planner_literal_value carrier_work_rows))
-		(begin
-			(define probe_rows (planner_literal_value probe_work_rows))
-			(define carrier_rows (planner_literal_value carrier_work_rows))
-			(define input_rows (planner_stage_input_rows (gs_input stage)))
-			(and (number? input_rows)
-				(begin
-					(define recset_cost (planner_recset_carrier_cost input_rows carrier_rows))
-					(define direct_cost (planner_direct_presence_probe_cost probe_rows))
-					(define keytable_cost (planner_presence_carrier_cost input_rows probe_rows))
-					(define chosen (if (planner_cost_better? recset_cost direct_cost)
-						(if (planner_cost_better? recset_cost keytable_cost)
-							(quote recset_carrier)
-							(quote group_keytable))
-						(if (planner_cost_better? direct_cost keytable_cost)
-							(quote direct_subscan)
-							(quote group_keytable))))
-					(planner_record_physical_decision
-						(list
-							(list "decision_id" (concat "scalar_presence_carrier:" (gs_id stage)))
-							(list "decision" "scalar_presence_carrier")
-							(list "stage" (gs_id stage))
-							(list "chosen" (string chosen))
-							(list "reason" "lowest_total_ns")
-							(list "inputs" (list
-								(list "domain_rows" input_rows)
-								(list "probe_rows" probe_rows)
-								(list "carrier_rows" carrier_rows)))
-							(list "alternatives" (map
-								(list
-									(list (quote recset_carrier) recset_cost)
-									(list (quote group_keytable) keytable_cost)
-									(list (quote direct_subscan) direct_cost))
-								(lambda (candidate)
+			(begin
+				(define probe_rows (planner_literal_value probe_work_rows))
+				(define carrier_rows (planner_literal_value carrier_work_rows))
+				(define input_rows (planner_stage_input_rows (gs_input stage)))
+				(and (number? input_rows)
+					(begin
+						(define recset_cost (planner_recset_carrier_cost input_rows carrier_rows))
+						(define direct_cost (planner_direct_presence_probe_cost probe_rows))
+						(define keytable_cost (planner_presence_carrier_cost input_rows probe_rows))
+						(define chosen (if (planner_cost_better? recset_cost direct_cost)
+							(if (planner_cost_better? recset_cost keytable_cost)
+								(quote recset_carrier)
+								(quote group_keytable))
+							(if (planner_cost_better? direct_cost keytable_cost)
+								(quote direct_subscan)
+								(quote group_keytable))))
+						(planner_record_physical_decision
+							(list
+								(list "decision_id" (concat "scalar_presence_carrier:" (gs_id stage)))
+								(list "decision" "scalar_presence_carrier")
+								(list "stage" (gs_id stage))
+								(list "chosen" (string chosen))
+								(list "reason" "lowest_total_ns")
+								(list "inputs" (list
+									(list "domain_rows" input_rows)
+									(list "probe_rows" probe_rows)
+									(list "carrier_rows" carrier_rows)))
+								(list "alternatives" (map
 									(list
-										(list "plan" (string (car candidate)))
-										(list "status" (if (equal? (car candidate) chosen) "chosen" "rejected"))
-										(list "reason" (if (equal? (car candidate) chosen) "lowest_total_ns" "higher_total_ns_or_memory_tiebreak"))
-										(list "cost" (planner_cost_explain (cadr candidate)))))))))
-					(and
-						(planner_cost_better? recset_cost (planner_direct_presence_probe_cost probe_rows))
-						(planner_cost_better? recset_cost (planner_presence_carrier_cost input_rows probe_rows))))))))))
+										(list (quote recset_carrier) recset_cost)
+										(list (quote group_keytable) keytable_cost)
+										(list (quote direct_subscan) direct_cost))
+									(lambda (candidate)
+										(list
+											(list "plan" (string (car candidate)))
+											(list "status" (if (equal? (car candidate) chosen) "chosen" "rejected"))
+											(list "reason" (if (equal? (car candidate) chosen) "lowest_total_ns" "higher_total_ns_or_memory_tiebreak"))
+											(list "cost" (planner_cost_explain (cadr candidate)))))))))
+						(and
+							(planner_cost_better? recset_cost (planner_direct_presence_probe_cost probe_rows))
+							(planner_cost_better? recset_cost (planner_presence_carrier_cost input_rows probe_rows))))))))))
 
 (define scalar_first_probe_recset_eligible? (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col)
 	(and (single_real_source? (qb_sources src))
@@ -1372,10 +1395,49 @@ membership set. */
 		(stage_prepare_key stage)
 		(list (quote lambda) '()
 			(list (quote !begin)
-				(lower_group_stage_prepare_using stage_catalog stage_catalog stage true)
+				(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 				true)))))
 
-(define scalar_first_probe_recset_source_parts (lambda (all_stages stage requested_col)
+(define direct_boolean_recset_stage_eligible? (lambda (graph stage requested_col)
+	(and (query_block? (gs_input stage))
+		(and (scalar_value_stage? stage)
+			(and (equal? (count (gs_aggregates stage)) 1)
+				(and (stage_boolean_shaped? graph stage requested_col)
+					(begin
+						(define carrier_src (scalar_first_probe_carrier_source (gs_input stage)))
+						(not (nil? (boolean_recset_domain_source
+							(gs_input stage)
+							(scalar_first_probe_recset_row_keys stage carrier_src)))))))))))
+
+(define lower_direct_boolean_stage_recset_expr (lambda (stage_catalog stage share_result)
+	(begin
+		(define decision_id (concat "boolean_stage_recset:" (gs_id stage)))
+		(planner_record_physical_decision (list
+			(list "decision_id" decision_id)
+			(list "decision" "boolean_stage_recset")
+			(list "decision_site" "group_stage_result_sink")
+			(list "chosen" "direct_recset")
+			(list "selection" "dominance")
+			(list "reason" "single_exact_boolean_consumer_needs_no_group_relation")
+			(list "alternatives" (list
+				(list (list "plan" "direct_recset") (list "status" "chosen"))
+				(list (list "plan" "group_cache_recset") (list "status" "rejected")
+					(list "reason" "redundant_mutable_materialization"))))))
+		/* RecSet algebra closes every nested stage producer before the domain scan.
+		The resulting expression has no lexical outer-row dependency and is therefore
+		safe to share between filters and projections in this query generation. */
+		(define producer (lower_group_stage_prepare_using
+			stage_catalog stage_catalog stage true (quote boolean-recset)))
+		(if share_result
+			(list
+				(physical_query_session_symbol)
+				"get_or_compute_scoped"
+				(physical_query_scope_symbol)
+				(concat "__direct_boolean_recset_" (fnv_hash (gs_id stage)))
+				(list (quote lambda) '() producer))
+			producer))))
+
+(define scalar_first_probe_recset_source_parts (lambda (all_stages stage requested_col share_result)
 	(begin
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
@@ -1383,22 +1445,50 @@ membership set. */
 		(define physical_stage (if (empty_list? probe_catalog)
 			stage
 			(group_stage_with_stage_catalog stage stage_catalog)))
-		(define cache (group_stage_cache physical_stage))
-		(define cache_schema (group_cache_schema cache))
-		(define cache_relation (group_cache_relation cache))
-		(list
-			(lower_recset_stage_prepare_once_expr stage_catalog physical_stage)
-			(list (quote scan_recset)
-				(list (quote session) "__memcp_tx")
-				(list (quote table) cache_schema cache_relation)
-				(quoted_runtime_list (list requested_col))
-				(list (quote lambda) (list (symbol requested_col))
-					(list (quote equal??) (symbol requested_col) true)))))))
+		(define graph (stage_dependency_graph stage_catalog))
+		(if (direct_boolean_recset_stage_eligible? graph physical_stage requested_col)
+			(begin
+				(define carrier_src (scalar_first_probe_carrier_source
+					(gs_input physical_stage)))
+				(define row_keys (scalar_first_probe_recset_row_keys
+					physical_stage carrier_src))
+				(define domain_src (boolean_recset_domain_source
+					(gs_input physical_stage) row_keys))
+				(list true
+					(lower_direct_boolean_stage_recset_expr
+						stage_catalog physical_stage share_result)
+					(map row_keys (lambda (key)
+						(direct_column_name_for_alias domain_src key)))))
+			(begin
+				(define cache (group_stage_cache physical_stage))
+				(define cache_schema (group_cache_schema cache))
+				(define cache_relation (group_cache_relation cache))
+				(define carrier_src (scalar_first_probe_carrier_source
+					(gs_input physical_stage)))
+				(define row_keys (scalar_first_probe_recset_row_keys
+					physical_stage carrier_src))
+				(define row_key_index (if (empty_list? row_keys) nil
+					(group_key_expr_index (gs_keys physical_stage) (car row_keys))))
+				(if (nil? row_key_index)
+					(neumann_fail "build_queryplan" "scalar RecSet carrier has no row-domain key")
+					true)
+				(list
+					(if share_result
+						(lower_recset_stage_prepare_once_expr stage_catalog physical_stage)
+						(lower_group_stage_prepare_using
+							stage_catalog stage_catalog physical_stage true nil))
+					(list (quote scan_recset)
+						(list (quote session) "__memcp_tx")
+						(list (quote table) cache_schema cache_relation)
+						(quoted_runtime_list (list requested_col))
+						(list (quote lambda) (list (symbol requested_col))
+							(list (quote equal??) (symbol requested_col) true)))
+					(list (nth (group_key_cols (gs_keys physical_stage)) row_key_index))))))))
 
 (define lower_recset_scalar_first_probe_expr (lambda (all_stages stage requested_col resolved_lookup_key)
 	(begin
 		(define source_parts
-			(scalar_first_probe_recset_source_parts all_stages stage requested_col))
+			(scalar_first_probe_recset_source_parts all_stages stage requested_col true))
 		(define lookup_key (recset_scalar_first_probe_lookup_key stage))
 		(list (quote begin)
 			(car source_parts)
@@ -1412,7 +1502,7 @@ membership set. */
 						(list (quote recset_key_index)
 							(list (quote session) "__memcp_tx")
 							(cadr source_parts)
-							(quoted_runtime_list (list "k0")))))
+							(quoted_runtime_list (nth source_parts 2)))))
 				(list (quote list) resolved_lookup_key))))))
 
 /* Once the consuming scan has selected the RecSet alternative, project the
@@ -1420,16 +1510,21 @@ true group keys directly onto that scan's base-table record positions. This
 is the carrier itself, not another membership decision: the group-stage
 preparation, truth RecSet, and key projection all belong to the same physical
 choice at the consuming join edge. */
-(define lower_projected_recset_scalar_first_probe_expr (lambda (all_stages stage requested_col target_src target_col)
+(define lower_projected_recset_scalar_first_probe_expr (lambda (all_stages stage requested_col target_src target_col share_result)
 	(begin
 		(define source_parts
-			(scalar_first_probe_recset_source_parts all_stages stage requested_col))
+			(scalar_first_probe_recset_source_parts
+				all_stages stage requested_col share_result))
+		(define source_key_cols (nth source_parts 2))
+		(if (not (equal? (count source_key_cols) 1))
+			(neumann_fail "build_queryplan" "projected scalar RecSet has no resolved row-domain key")
+			true)
 		(list (quote begin)
 			(car source_parts)
 			(list (quote recset_project_join)
 				(list (quote session) "__memcp_tx")
 				(cadr source_parts)
-				(quoted_runtime_list (list "k0"))
+				(quoted_runtime_list source_key_cols)
 				(source_table_expr target_src)
 				(quoted_runtime_list (list target_col)))))))
 
@@ -1453,22 +1548,22 @@ would still have to project that value over the segment. */
 			(if (qassoc_get (gs_facts stage) (quote segment_invariant_scalar_probe) false)
 				(quote query-scan)
 				(if (and (equal? probe_semantics (quote truth))
-				(scalar_first_probe_recset_eligible?
-					graph stage src keys probe_work_rows carrier_work_rows requested_col))
-				(quote recset)
-				(if (scalar_first_probe_keytable_eligible? stage src keys probe_work_rows)
-					(quote keytable)
-					(quote query-scan))))
+					(scalar_first_probe_recset_eligible?
+						graph stage src keys probe_work_rows carrier_work_rows requested_col))
+					(quote recset)
+					(if (scalar_first_probe_keytable_eligible? stage src keys probe_work_rows)
+						(quote keytable)
+						(quote query-scan))))
 			(if (source_is_base_table? src)
 				(if (qassoc_get (gs_facts stage) (quote segment_invariant_scalar_probe) false)
 					(quote table-scan)
 					(if (and (equal? probe_semantics (quote truth))
-					(scalar_first_probe_recset_eligible_base?
-						graph stage src keys probe_work_rows carrier_work_rows requested_col))
-					(quote recset)
-					(if (scalar_first_probe_keytable_eligible_base? stage src keys probe_work_rows)
-						(quote keytable)
-						(quote table-scan))))
+						(scalar_first_probe_recset_eligible_base?
+							graph stage src keys probe_work_rows carrier_work_rows requested_col))
+						(quote recset)
+						(if (scalar_first_probe_keytable_eligible_base? stage src keys probe_work_rows)
+							(quote keytable)
+							(quote table-scan))))
 				(quote unsupported))))))
 
 (define scalar_first_probe_carrier_source (lambda (src)
@@ -1478,7 +1573,8 @@ would still have to project that value over the segment. */
 
 (define scalar_first_probe_query_invariant? (lambda (stage requested_col)
 	(and (presence_probe_stage? stage)
-		(not (nil? (query_invariant_probe_binding_for_col stage requested_col))))))
+		(or (qassoc_get (gs_facts stage) (quote inline_query_invariant_probe) false)
+			(not (nil? (query_invariant_probe_binding_for_col stage requested_col)))))))
 
 (define query_invariant_scalar_first_probe_key (lambda (stage requested_col)
 	(concat
@@ -2393,7 +2489,7 @@ cache identity or a logical fallback. */
 			(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
 				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 		(list (quote begin)
-			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 			(list (quote scan_exists)
 				'(session "__memcp_tx")
 				(list (quote table) (group_stage_cache_schema stage) (group_stage_cache_relation stage))
@@ -2887,7 +2983,7 @@ alternative is a raw RecSet or direct probe. */
 			(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
 				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 		(list (quote begin)
-			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 			carrier))))
 
 (define prepared_group_cache_recset_expr (lambda (stage)
@@ -2922,7 +3018,7 @@ alternative is a raw RecSet or direct probe. */
 					(merge_stage_catalogs (list stamped_catalog (nested_stage_catalog stage)
 						(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 				(list (quote begin)
-					(lower_group_stage_prepare_using stage_catalog stage_catalog stage true)
+					(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 					(list (quote recset_project_join)
 						'(session "__memcp_tx")
 						(list (quote scan_recset)
@@ -4972,12 +5068,8 @@ ever-larger subtrees. */
 expressions. Persistent column identity was selected from the original logical
 stage before that rewrite; thread it through unchanged to keep create and fill
 on the same columns. */
-(define build_query_group_aggregates_insert_plan (lambda (input grouptbl keys key_names ags aggregate_cols)
+(define build_query_grouped_assoc_plan (lambda (input keys key_names ags)
 	(begin
-		(if (not (equal? (count ags) (count aggregate_cols)))
-			(neumann_fail "build_queryplan" "query-input aggregate columns do not match aggregate descriptors")
-			true)
-		(define schema (qb_schema input))
 		(define row_key_names (map key_names (lambda (col) (concat "__row_" col))))
 		(define value_cols (map (produceN (count ags)) (lambda (i) (concat "__agg" i))))
 		(define row_fields (merge (list
@@ -5000,24 +5092,234 @@ on the same columns. */
 				(aggregate_map_value_expr (nth ags i) (nth value_symbols i)))))))
 		(define merge_payload (list (quote lambda) (list (quote old) (quote new))
 			(aggregate_payload_merge_expr ags 0)))
-		(define finish_expr (group_insert_finish_expr schema grouptbl key_names aggregate_cols false))
 		(define combine_grouped (grouped_state_merge_expr merge_payload))
+		(lower_query_block_as_dataset_reduce
+			input
+			row_fields
+			(list (quote lambda)
+				(extract_assoc row_fields (lambda (title _expr) (symbol title)))
+				(runtime_cons_list_expr (list key_expr payload_expr)))
+			(list (quote lambda) (list (quote acc) (quote rowvals))
+				(list (quote set_assoc)
+					(quote acc)
+					(list (quote car) (quote rowvals))
+					(list (quote cadr) (quote rowvals))
+					merge_payload))
+			(list (quote list))
+			combine_grouped))))
+
+(define build_query_group_aggregates_insert_plan (lambda (input grouptbl keys key_names ags aggregate_cols)
+	(begin
+		(if (not (equal? (count ags) (count aggregate_cols)))
+			(neumann_fail "build_queryplan" "query-input aggregate columns do not match aggregate descriptors")
+			true)
 		(list
-			(list (quote lambda) (list (quote grouped)) finish_expr)
-			(lower_query_block_as_dataset_reduce
-				input
-				row_fields
-				(list (quote lambda)
-					(extract_assoc row_fields (lambda (title _expr) (symbol title)))
-					(runtime_cons_list_expr (list key_expr payload_expr)))
-				(list (quote lambda) (list (quote acc) (quote rowvals))
-					(list (quote set_assoc)
-						(quote acc)
-						(list (quote car) (quote rowvals))
-						(list (quote cadr) (quote rowvals))
-						merge_payload))
-				(list (quote list))
-				combine_grouped)))))
+			(list (quote lambda) (list (quote grouped))
+				(group_insert_finish_expr (qb_schema input) grouptbl key_names aggregate_cols false))
+			(build_query_grouped_assoc_plan input keys key_names ags)))))
+
+/* Produce a domain RecSet for a scalar probe leaf before entering the domain
+scan. scan_recset callbacks are batch-parallel filters, so a nested scan cannot
+serve as their synchronous scalar return value. Projecting the already exact
+stage carrier keeps that work outside the callback and preserves the stage's
+ordinary physical carrier choice. */
+(define boolean_recset_probe_leaf_plan (lambda (stage_catalog domain_src expr)
+	(match expr
+		((symbol scalar_first_probe) stage requested_col)
+		(begin
+			(define carrier_src (scalar_first_probe_carrier_source (gs_input stage)))
+			(define row_keys (scalar_first_probe_recset_row_keys stage carrier_src))
+			(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+			(define target_cols (filter (map lookup_keys (lambda (lookup_key)
+				(direct_column_name_for_alias domain_src lookup_key)))
+				(lambda (col) (not (nil? col)))))
+			(define target_col (if (equal? (count target_cols) 1)
+				(car target_cols) nil))
+			(if (or (query_invariant_presence_stage? stage)
+				(empty_list? row_keys))
+				/* A session-only leaf is constant for this request. The ordinary
+				scalar lowerer memoizes it once; scanning the small domain with that
+				bound value yields the exact full-or-empty truth set. */
+				(boolean_recset_domain_scan_plan domain_src expr)
+				(if (nil? target_col)
+				(neumann_fail "build_queryplan" "boolean RecSet probe requires one direct domain lookup key")
+				(lower_projected_recset_scalar_first_probe_expr
+					stage_catalog stage requested_col domain_src target_col false))))
+		((symbol scalar_first_probe) stage requested_col _dependencies)
+		(boolean_recset_probe_leaf_plan stage_catalog domain_src
+			(list (quote scalar_first_probe) stage requested_col))
+		((quote scalar_first_probe) stage requested_col)
+		(boolean_recset_probe_leaf_plan stage_catalog domain_src
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((quote scalar_first_probe) stage requested_col dependencies)
+		(boolean_recset_probe_leaf_plan stage_catalog domain_src
+			(list (symbol "scalar_first_probe") stage requested_col dependencies))
+		_ nil)))
+
+(define boolean_recset_combine (lambda (operator plans)
+	(if (equal? (count plans) 1)
+		(car plans)
+		(list operator (cons (quote list) plans)))))
+
+/* RecSet complement represents FALSE as "not in the TRUE set" and is exact
+only for a two-valued operand. SQL NOT must retain UNKNOWN, so nullable probe
+values cannot use this identity. Null-safe equality/nil tests and comparisons
+of values protected by COALESCE are the common generated two-valued forms. */
+(define boolean_recset_nonnull_value? (lambda (expr)
+	(match expr
+		((symbol coalesceNil) _inner default) (not (nil? default))
+		((quote coalesceNil) _inner default) (not (nil? default))
+		((symbol equal??) _left _right) true
+		((quote equal??) _left _right) true
+		((symbol nil?) _inner) true
+		((quote nil?) _inner) true
+		_ (or (number? expr)
+			(or (string? expr) (or (equal? expr true) (equal? expr false)))))))
+
+(define boolean_recset_two_valued? (lambda (expr)
+	(match expr
+		((symbol equal??) _left _right) true
+		((quote equal??) _left _right) true
+		((symbol nil?) _inner) true
+		((quote nil?) _inner) true
+		((symbol >) left right) (and
+			(boolean_recset_nonnull_value? left)
+			(boolean_recset_nonnull_value? right))
+		((quote >) left right) (boolean_recset_two_valued?
+			(list (symbol ">") left right))
+		((symbol sql_not) inner) (boolean_recset_two_valued? inner)
+		((quote sql_not) inner) (boolean_recset_two_valued? inner)
+		((symbol not) inner) (boolean_recset_two_valued? inner)
+		((quote not) inner) (boolean_recset_two_valued? inner)
+		(cons head items) (if (or (equal? head (quote and))
+			(equal? head (symbol "and")))
+			(reduce items (lambda (ok item)
+				(and ok (boolean_recset_two_valued? item))) true)
+			(if (or (equal? head (quote or)) (equal? head (symbol "or")))
+				(reduce items (lambda (ok item)
+					(and ok (boolean_recset_two_valued? item))) true)
+				(boolean_recset_nonnull_value? expr)))
+		_ (boolean_recset_nonnull_value? expr))))
+
+/* Compile true-row sets recursively. AND/OR are exact set intersection/union.
+CASE is a disjoint union of its true and false-condition branches; SQL treats a
+NULL WHEN condition like false, which is exactly the complement of its true-row
+set. COALESCE(x,FALSE) preserves x's true rows. Leaves without stage probes stay
+one ordinary scan_recset, while stage leaves use the carrier projection above. */
+(define boolean_recset_expr_plan (lambda (stage_catalog domain_src expr)
+	(begin
+		(define probe_leaf (boolean_recset_probe_leaf_plan stage_catalog domain_src expr))
+		(if (not (nil? probe_leaf))
+			probe_leaf
+			(match expr
+				((symbol sql_not) inner)
+				(if (boolean_recset_two_valued? inner)
+					(list (quote recset_not)
+						(boolean_recset_expr_plan stage_catalog domain_src inner))
+					(neumann_fail "build_queryplan"
+						"boolean RecSet complement requires a two-valued operand"))
+				((quote sql_not) inner)
+				(boolean_recset_expr_plan stage_catalog domain_src
+					(list (symbol "sql_not") inner))
+				((symbol not) inner)
+				(boolean_recset_expr_plan stage_catalog domain_src
+					(list (symbol "sql_not") inner))
+				((quote not) inner)
+				(boolean_recset_expr_plan stage_catalog domain_src
+					(list (symbol "sql_not") inner))
+				((symbol equal??) inner true)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((quote equal??) inner true)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((symbol coalesceNil) inner false)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((quote coalesceNil) inner false)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((symbol coalesceNil) inner 0)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((quote coalesceNil) inner 0)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((symbol coalesceNil) inner nil)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((quote coalesceNil) inner nil)
+				(boolean_recset_expr_plan stage_catalog domain_src inner)
+				((symbol >) inner 0)
+				(if (empty_list? (expr_probe_stages inner))
+					(boolean_recset_domain_scan_plan domain_src expr)
+					(boolean_recset_expr_plan stage_catalog domain_src inner))
+				((quote >) inner 0)
+				(boolean_recset_expr_plan stage_catalog domain_src
+					(list (symbol ">") inner 0))
+				((symbol if) condition then_expr else_expr)
+				(begin
+					(define condition_set
+						(boolean_recset_expr_plan stage_catalog domain_src condition))
+					(define then_set
+						(boolean_recset_expr_plan stage_catalog domain_src then_expr))
+					(define else_set
+						(boolean_recset_expr_plan stage_catalog domain_src else_expr))
+					(boolean_recset_combine (quote recset_union) (list
+						(boolean_recset_combine (quote recset_intersect)
+							(list condition_set then_set))
+						(boolean_recset_combine (quote recset_intersect)
+							(list (list (quote recset_not) condition_set) else_set)))))
+				((quote if) condition then_expr else_expr)
+				(boolean_recset_expr_plan stage_catalog domain_src
+					(list (symbol "if") condition then_expr else_expr))
+				(cons head items) (if (or (equal? head (quote and))
+					(equal? head (symbol "and")))
+					(boolean_recset_combine (quote recset_intersect)
+						(map items (lambda (item)
+							(boolean_recset_expr_plan stage_catalog domain_src item))))
+					(if (or (equal? head (quote or)) (equal? head (symbol "or")))
+						(boolean_recset_combine (quote recset_union)
+							(map items (lambda (item)
+								(boolean_recset_expr_plan stage_catalog domain_src item))))
+						(if (empty_list? (expr_probe_stages expr))
+							(boolean_recset_domain_scan_plan domain_src expr)
+							(neumann_fail "build_queryplan"
+								(concat "boolean RecSet expression contains an unsupported probe shape: "
+									(serialize expr))))))
+				_ (if (empty_list? (expr_probe_stages expr))
+					(boolean_recset_domain_scan_plan domain_src expr)
+					(neumann_fail "build_queryplan"
+						(concat "boolean RecSet expression contains an unsupported probe shape: "
+							(serialize expr)))))))))
+
+(define boolean_recset_domain_scan_plan (lambda (domain_src expr)
+	(begin
+		(define alias (source_alias domain_src))
+		(define filtercols (extract_columns_for_alias domain_src expr))
+		(list (quote scan_recset)
+			'(session "__memcp_tx")
+			(source_table_expr domain_src)
+			(cons (quote list) filtercols)
+			(list (quote lambda)
+				(map filtercols (lambda (col)
+					(scan_callback_symbol_for_alias alias col)))
+				(lower_column_expr_for_alias domain_src expr))))))
+
+/* A boolean scalar grouped by a unique key needs no mutable query-group table.
+The boolean tree is lowered to RecSet algebra, so every nested carrier is built
+once and every base-only leaf remains a vectorized domain scan. */
+(define build_query_boolean_recset_plan (lambda (stage_catalog input domain_src keys ags)
+	(begin
+		(define alias (source_alias domain_src))
+		(define key_cols (map keys (lambda (key)
+			(direct_column_name_for_alias domain_src key))))
+		(if (or (not (equal? (count ags) 1))
+			(reduce key_cols (lambda (invalid col) (or invalid (nil? col))) false))
+			(neumann_fail "build_queryplan" "boolean RecSet sink requires one value and direct domain keys")
+			true)
+		(if (or (not (equal? (count (qb_sources input)) 1))
+			(not (equal? (source_alias (car (qb_sources input))) alias)))
+			(neumann_fail "build_queryplan" "boolean RecSet sink requires one fully lowered domain source")
+			true)
+		(define bool_expr (car (scalar_first_probe_parts (car ags))))
+		(define condition (combine_where
+			(combine_where (qb_where input) (source_join_expr domain_src))
+			(list (quote equal??) bool_expr true)))
+		(boolean_recset_expr_plan stage_catalog domain_src condition))))
 
 (define union_branch_group_row_fields (lambda (candidate_alias branch keys key_names ags value_cols)
 	(begin

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1359,7 +1359,7 @@ membership set. */
 							(planner_cost_better? recset_cost (planner_direct_presence_probe_cost probe_rows))
 							(planner_cost_better? recset_cost (planner_presence_carrier_cost input_rows probe_rows))))))))))
 
-(define scalar_first_probe_recset_eligible? (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col)
+(define scalar_first_probe_recset_eligible? (lambda (stages graph stage src keys probe_work_rows carrier_work_rows requested_col)
 	(and (single_real_source? (qb_sources src))
 		(and (source_is_base_table? (single_real_source (qb_sources src)))
 			(and (empty_list? (qb_group src))
@@ -1368,7 +1368,8 @@ membership set. */
 						(and (nil? (qb_limit src)) (nil? (qb_offset src))
 							(and (not (nil? (scalar_first_probe_keytable_key_index stage (single_real_source (qb_sources src)) keys)))
 								(and (stage_boolean_shaped? graph stage requested_col)
-									(scalar_first_probe_recset_cost_preferred? stage probe_work_rows carrier_work_rows)))))))))))
+									(and (direct_boolean_recset_input_ownership_closed? stages stage)
+										(scalar_first_probe_recset_cost_preferred? stage probe_work_rows carrier_work_rows))))))))))))
 
 (define scalar_first_probe_recset_eligible_base? (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col)
 	(and (not (nil? (scalar_first_probe_keytable_key_index stage src keys)))
@@ -1398,16 +1399,42 @@ membership set. */
 				(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 				true)))))
 
-(define direct_boolean_recset_stage_eligible? (lambda (graph stage requested_col)
+(define direct_boolean_recset_query_scope_dependency? (lambda (stage)
+	(and (empty_list? (gs_domain stage))
+		(empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '())))))
+
+(define direct_boolean_recset_input_ownership_closed? (lambda (stage_catalog stage)
+	(begin
+		(define owner_handle (qassoc_get (gs_facts stage) (quote btw2025_handle) nil))
+		(define direct_stages (unique_stages_by_id (merge (list
+			(stage_outputs_from_sources_using stage_catalog (qb_sources (gs_input stage)))
+			(if (nil? owner_handle) '()
+				(filter (lowering_catalog_stages stage_catalog) (lambda (candidate)
+					(equal? (qassoc_get (gs_facts candidate) (quote btw2025_parent) nil)
+						owner_handle))))))))
+		(define has_invariant (reduce direct_stages (lambda (found dependency)
+			(or found (direct_boolean_recset_query_scope_dependency? dependency))) false))
+		(define has_correlated (reduce direct_stages (lambda (found dependency)
+			(or found (not (direct_boolean_recset_query_scope_dependency? dependency)))) false))
+		(not (and has_invariant has_correlated)))))
+
+(define direct_boolean_recset_stage_eligible? (lambda (stage_catalog graph stage requested_col)
 	(and (query_block? (gs_input stage))
 		(and (scalar_value_stage? stage)
 			(and (equal? (count (gs_aggregates stage)) 1)
 				(and (stage_boolean_shaped? graph stage requested_col)
 					(begin
+						/* Correlated child stages are closed by this producer; invariant child
+						stages belong to the enclosing query scope. Either ownership model is
+						exact alone, including transitive mixtures already closed by a child.
+						Direct siblings using both models would cross a lexical boundary, so
+						leave that operator-infeasible shape on the ordinary exact carrier.
+						This is a scope proof, never a SQL-shape or cardinality heuristic. */
 						(define carrier_src (scalar_first_probe_carrier_source (gs_input stage)))
-						(not (nil? (boolean_recset_domain_source
-							(gs_input stage)
-							(scalar_first_probe_recset_row_keys stage carrier_src)))))))))))
+						(and (direct_boolean_recset_input_ownership_closed? stage_catalog stage)
+							(not (nil? (boolean_recset_domain_source
+								(gs_input stage)
+								(scalar_first_probe_recset_row_keys stage carrier_src))))))))))))
 
 (define lower_direct_boolean_stage_recset_expr (lambda (stage_catalog stage share_result)
 	(begin
@@ -1446,7 +1473,8 @@ membership set. */
 			stage
 			(group_stage_with_stage_catalog stage stage_catalog)))
 		(define graph (stage_dependency_graph stage_catalog))
-		(if (direct_boolean_recset_stage_eligible? graph physical_stage requested_col)
+		(if (direct_boolean_recset_stage_eligible?
+			stage_catalog graph physical_stage requested_col)
 			(begin
 				(define carrier_src (scalar_first_probe_carrier_source
 					(gs_input physical_stage)))
@@ -1490,20 +1518,32 @@ membership set. */
 		(define source_parts
 			(scalar_first_probe_recset_source_parts all_stages stage requested_col true))
 		(define lookup_key (recset_scalar_first_probe_lookup_key stage))
-		(list (quote begin)
-			(car source_parts)
-			(list (quote apply)
-				(list
-					(physical_query_session_symbol)
-					"get_or_compute_scoped"
-					(physical_query_scope_symbol)
-					lookup_key
-					(list (quote lambda) '()
-						(list (quote recset_key_index)
-							(list (quote session) "__memcp_tx")
-							(cadr source_parts)
-							(quoted_runtime_list (nth source_parts 2)))))
-				(list (quote list) resolved_lookup_key))))))
+		(define lookup_value (symbol (concat "__recset_lookup_value_"
+			(fnv_hash (gs_id stage)))))
+		/* Bind the consumer-row key before entering the producer begin. begin owns a
+			shared numbered scope, while scan adapters may close the producer callbacks
+			independently. Lowering the row key inside that scope would bake its extra
+			outer hop into the cached producer and can escape the actual row closure when
+			several correlated projections share one continuation. The explicit value
+			parameter keeps producer construction closed and makes lexical ownership
+			independent of the surrounding projection shape. */
+		(list
+			(list (quote lambda) (list lookup_value)
+				(list (quote begin)
+					(car source_parts)
+					(list (quote apply)
+						(list
+							(physical_query_session_symbol)
+							"get_or_compute_scoped"
+							(physical_query_scope_symbol)
+							lookup_key
+							(list (quote lambda) '()
+								(list (quote recset_key_index)
+									(list (quote session) "__memcp_tx")
+									(cadr source_parts)
+									(quoted_runtime_list (nth source_parts 2)))))
+						(list (quote list) lookup_value))))
+			resolved_lookup_key))))
 
 /* Once the consuming scan has selected the RecSet alternative, project the
 true group keys directly onto that scan's base-table record positions. This
@@ -1541,7 +1581,7 @@ growth belongs in the calibrated comparison above and must retain the planner's
 recompile gate. A segment-invariant scalar is the proof case here: one cached
 scalar value replaces the same value for every segment row, while a carrier
 would still have to project that value over the segment. */
-(define scalar_first_probe_physical_operator (lambda (graph stage src keys probe_work_rows carrier_work_rows requested_col probe_semantics)
+(define scalar_first_probe_physical_operator (lambda (stages graph stage src keys probe_work_rows carrier_work_rows requested_col probe_semantics)
 	(if (union_block? src)
 		(quote union-probe)
 		(if (query_block? src)
@@ -1549,7 +1589,7 @@ would still have to project that value over the segment. */
 				(quote query-scan)
 				(if (and (equal? probe_semantics (quote truth))
 					(scalar_first_probe_recset_eligible?
-						graph stage src keys probe_work_rows carrier_work_rows requested_col))
+						stages graph stage src keys probe_work_rows carrier_work_rows requested_col))
 					(quote recset)
 					(if (scalar_first_probe_keytable_eligible? stage src keys probe_work_rows)
 						(quote keytable)
@@ -1663,7 +1703,7 @@ would still have to project that value over the segment. */
 		(define lowered_lookup_keys (map lookup_keys (lambda (key)
 			(lower_column_expr_for_join sources default_alias key))))
 		(define operator (scalar_first_probe_physical_operator
-			graph stage src keys effective_probe_work_rows effective_probe_work_rows requested_col probe_semantics))
+			probe_stages graph stage src keys effective_probe_work_rows effective_probe_work_rows requested_col probe_semantics))
 		(define lowered (match operator
 			(symbol union-probe)
 			(list (quote if)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5488,6 +5488,7 @@ physical decision and preserve its runtime recompile gate. */
 					1))
 				(define operator (if (nil? target_col) (quote unsupported)
 					(scalar_first_probe_physical_operator
+						probe_stages
 						(stage_dependency_graph probe_stages)
 						raw_stage src keys effective_probe_work_rows carrier_work_rows requested_col (quote truth))))
 				(if (and (not (equal? operator (quote recset))) (nil? bound_stage))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -320,7 +320,7 @@ only partitioned FROM source would erase the block's row multiplicity
 		(or (not (nil? (qb_having block)))
 			(query_block_has_aggregates? block)))))
 
-(define presence_probe_output_sources (lambda (stages sources default_alias)
+(define presence_probe_output_sources (lambda (stages sources default_alias allow_unbounded)
 	(filter (coalesceNil sources '()) (lambda (src)
 		(if (not (presence_stage_output_source? stages src))
 			false
@@ -328,7 +328,8 @@ only partitioned FROM source would erase the block's row multiplicity
 				(define stage (stage_by_id stages (stage_output_relation_id (source_relation src))))
 				(define probe_sources (filter sources (lambda (candidate) (not (equal? (source_alias candidate) (source_alias src))))))
 				(and
-					(presence_stage_probe_allowed_in_context? stage probe_sources)
+					(or allow_unbounded
+						(presence_stage_probe_allowed_in_context? stage probe_sources))
 					(or
 						(stage_has_residual_outer_refs? stage)
 						(or
@@ -782,13 +783,13 @@ only partitioned FROM source would erase the block's row multiplicity
 						(stage_output_source_ids selected_probe_sources))))
 				(map selected_probe_sources source_alias))))))
 
-(define query_block_with_presence_probes_using (lambda (stages block)
+(define query_block_with_presence_probes_using (lambda (stages block allow_unbounded)
 	(begin
 		(define sources (qb_sources block))
 		(define default_alias (qassoc_get (qb_facts block) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
 		(query_block_with_presence_probe_sources_using
 			stages
-			(presence_probe_output_sources stages sources default_alias)
+			(presence_probe_output_sources stages sources default_alias allow_unbounded)
 			block))))
 
 (define query_block_without_stages_after_prepare_using (lambda (stages block)
@@ -879,7 +880,7 @@ only partitioned FROM source would erase the block's row multiplicity
 			'()
 			(qb_facts block)))))
 
-(define query_block_with_prepared_sources_using_graph (lambda (stages dependency_graph block)
+(define query_block_with_probe_markers_using_graph (lambda (stages dependency_graph block allow_unbounded_presence)
 	(begin
 		(define available_stages (if (lowering_catalog? stages)
 			(lowering_catalog_stages stages)
@@ -894,11 +895,13 @@ only partitioned FROM source would erase the block's row multiplicity
 				"logical membership marker survived physical choice") true)
 		(define sources (qb_sources membership_rewritten))
 		(define default_alias (qassoc_get (qb_facts membership_rewritten) (quote default_alias) (if (empty_list? sources) nil (source_alias (car sources)))))
-		(define presence_probe_sources (presence_probe_output_sources stage_lookup sources default_alias))
-		(define rewritten (query_block_with_presence_probes_using stage_lookup membership_rewritten))
+		(define presence_probe_sources (presence_probe_output_sources
+			stage_lookup sources default_alias allow_unbounded_presence))
+		(define rewritten (query_block_with_presence_probes_using
+			stage_lookup membership_rewritten allow_unbounded_presence))
 		(make_query_block
 			(qb_schema rewritten)
-			(physicalize_stage_output_sources stage_lookup (qb_sources rewritten))
+			(qb_sources rewritten)
 			(qb_fields rewritten)
 			(qb_where rewritten)
 			(qb_group rewritten)
@@ -910,6 +913,27 @@ only partitioned FROM source would erase the block's row multiplicity
 			(stages_without_probe_sources_using_graph
 				dependency_graph stage_lookup (qb_stages rewritten) presence_probe_sources)
 			(query_block_facts_with_stage_catalog rewritten available_stages)))))
+
+(define query_block_with_prepared_sources_using_graph (lambda (stages dependency_graph block)
+	(begin
+		(define rewritten
+			(query_block_with_probe_markers_using_graph stages dependency_graph block false))
+		(define stage_lookup (if (lowering_catalog? stages)
+			stages
+			(query_block_stage_catalog rewritten)))
+		(make_query_block
+			(qb_schema rewritten)
+			(physicalize_stage_output_sources stage_lookup (qb_sources rewritten))
+			(qb_fields rewritten)
+			(qb_where rewritten)
+			(qb_group rewritten)
+			(qb_having rewritten)
+			(qb_order rewritten)
+			(qb_limit rewritten)
+			(qb_offset rewritten)
+			(qb_hidden rewritten)
+			(qb_stages rewritten)
+			(qb_facts rewritten)))))
 
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(query_block_with_prepared_sources_using_graph
@@ -1168,7 +1192,46 @@ get_column refs to the source) are excluded automatically too. */
 			nil
 			(list (quote partitiontable) (list (quote table) schema grouptbl) (cons (quote list) hints))))))
 
-(define lower_group_stage_prepare_using (lambda (all_stages lookup_stages stage include_nested_prepares)
+(define boolean_recset_domain_source (lambda (input keys)
+	(if (not (query_block? input))
+		nil
+		(reduce (qb_sources input) (lambda (found candidate)
+			(if (not (nil? found))
+				found
+				(if (not (source_is_base_table? candidate))
+					nil
+					(begin
+						(define cols (map keys (lambda (key)
+							(direct_column_name_for_alias candidate key))))
+						(if (and (not (empty_list? cols))
+							(and (not (reduce cols (lambda (missing col)
+								(or missing (nil? col))) false))
+								(planner_columns_unique? candidate cols)))
+							candidate
+							nil))))) nil))))
+
+/* A decorrelated stage input is represented as a LEFT-JOIN chain, including
+the domain source because it was nullable relative to the former outer row.
+When the stage is evaluated as an independent relation, that first domain is
+the driver and must be scanned normally; only its dependent sources remain
+outer joins. */
+(define query_block_with_inner_domain_source (lambda (input domain_src)
+	(make_query_block
+		(qb_schema input)
+		(map (qb_sources input) (lambda (src)
+			(if (equal? (source_alias src) (source_alias domain_src))
+				(list (source_alias src) (source_schema src) (source_relation src)
+					false (source_join_expr src))
+				src)))
+		(qb_fields input) (qb_where input) (qb_group input) (qb_having input)
+		(qb_order input) (qb_limit input) (qb_offset input) (qb_hidden input)
+		(qb_stages input)
+		(filter (qb_facts input) (lambda (entry)
+			(match entry
+				(cons key _value) (not (equal? key (quote join_plan)))
+				_ true))))))
+
+(define lower_group_stage_prepare_using (lambda (all_stages lookup_stages stage include_nested_prepares result_sink)
 	(begin
 		(define src (gs_input stage))
 		(define prepare_catalog (unique_stages_by_id (merge (list (list stage) all_stages))))
@@ -1198,9 +1261,17 @@ get_column refs to the source) are excluded automatically too. */
 		instead of a fresh per-row probe. Mirrors
 		prepare_simple_query_block_physical_core_chosen. */
 		(define invariant_probe_entries (query_invariant_probe_entries_for_stages raw_stage_lookup))
-		(define stage_lookup (stage_lookup_with_query_invariant_probe_bindings
-			raw_stage_lookup invariant_probe_entries))
-		(define invariant_probe_bindings (query_invariant_probe_bindings invariant_probe_entries))
+		/* A boolean RecSet producer is also executed by cardinality observations,
+		before the main query's lexical bindings exist. Keep invariant probes as
+		query-scoped markers inside that closed producer; its own lowering memoizes
+		them once. Other result sinks retain the established outer binding. */
+		(define closed_boolean_sink (equal? result_sink (quote boolean-recset)))
+		(define stage_lookup (if closed_boolean_sink
+			(stage_lookup_with_inline_query_invariant_probes raw_stage_lookup)
+			(stage_lookup_with_query_invariant_probe_bindings
+				raw_stage_lookup invariant_probe_entries)))
+		(define invariant_probe_bindings (if closed_boolean_sink '()
+			(query_invariant_probe_bindings invariant_probe_entries)))
 		(if (and (not (union_block? src)) (and (not (query_block? src)) (not (source_is_base_table? src))))
 			(neumann_fail "build_queryplan" "group-stage lowering expects a base table, query-block, or union-block input")
 			true)
@@ -1227,16 +1298,20 @@ get_column refs to the source) are excluded automatically too. */
 		caches are already dependency-ordered here, so consume those relational
 		outputs directly once the chain contains more than one dependency. */
 		(define rewritten_src (if (query_block? membership_src)
-			(if relational_presence_chain
-				membership_src
-				(query_block_with_presence_probes_using stage_lookup membership_src))
+			(if (equal? result_sink (quote boolean-recset))
+				(query_block_with_probe_markers_using_graph
+					stage_lookup prepare_dependency_graph membership_src true)
+				(if relational_presence_chain
+					membership_src
+					(query_block_with_presence_probes_using stage_lookup membership_src false)))
 			membership_src))
 		(define rewrite_sources (if (query_block? membership_src) (qb_sources membership_src) '()))
 		(define rewrite_default_alias (if (query_block? src)
 			(qassoc_get (qb_facts membership_src) (quote default_alias) (if (empty_list? rewrite_sources) nil (source_alias (car rewrite_sources))))
 			nil))
 		(define presence_probe_sources_for_rewrite (if (query_block? src)
-			(presence_probe_output_sources stage_lookup rewrite_sources rewrite_default_alias)
+			(presence_probe_output_sources stage_lookup rewrite_sources rewrite_default_alias
+				(equal? result_sink (quote boolean-recset)))
 			'()))
 		(define keys (if (empty_list? (gs_keys stage))
 			'(1)
@@ -1260,6 +1335,13 @@ get_column refs to the source) are excluded automatically too. */
 		(define lowering_ags (if (query_block? src)
 			(rewrite_scalar_first_probe_aggregates stage_lookup presence_probe_sources_for_rewrite rewrite_default_alias ags)
 			ags))
+		(define result_sink_ags (if (and (equal? result_sink (quote boolean-recset))
+			(query_block? src))
+			(rewrite_scalar_first_probe_aggregates stage_lookup
+				(filter rewrite_sources (lambda (candidate)
+					(stage_output_relation? (source_relation candidate))))
+				rewrite_default_alias ags)
+			lowering_ags))
 		(define key_names (group_key_cols keys))
 		(define aggregate_condition (replace_group_session_expr stage keys key_names condition))
 		(define grouptbl (group_cache_relation cache))
@@ -1281,16 +1363,18 @@ get_column refs to the source) are excluded automatically too. */
 			'()))
 		(define scalar_aggregate_stage (scalar_aggregate_probe_stage? stage))
 		(define prepared_src (if (query_block? rewritten_src)
-			(if scalar_aggregate_stage
-				(begin
-					(define constant_reorder_stages (if (lowering_catalog? stage_lookup)
-						stage_lookup
-						(unique_stages_by_id (merge (list stage_lookup (qb_stages rewritten_src))))))
-					(if (not (empty_list? (filter (qb_sources rewritten_src) (lambda (src)
-						(constant_scalar_or_presence_stage_output_source? constant_reorder_stages src)))))
-						(query_block_without_stages_after_eager_prepare_with_constant_scalars_first constant_reorder_stages rewritten_src)
-						(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src)))
-				(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src))
+			(if (equal? result_sink (quote boolean-recset))
+				rewritten_src
+				(if scalar_aggregate_stage
+					(begin
+						(define constant_reorder_stages (if (lowering_catalog? stage_lookup)
+							stage_lookup
+							(unique_stages_by_id (merge (list stage_lookup (qb_stages rewritten_src))))))
+						(if (not (empty_list? (filter (qb_sources rewritten_src) (lambda (src)
+							(constant_scalar_or_presence_stage_output_source? constant_reorder_stages src)))))
+							(query_block_without_stages_after_eager_prepare_with_constant_scalars_first constant_reorder_stages rewritten_src)
+							(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src)))
+					(query_block_without_stages_after_eager_prepare_using stage_lookup rewritten_src)))
 			rewritten_src))
 		(define direct_nested_stages (if (query_block? rewritten_src)
 			(merge_unique (list
@@ -1418,45 +1502,58 @@ get_column refs to the source) are excluded automatically too. */
 					(list (quote touch_keytable) (list (quote table) schema grouptbl))
 					group_cache_created))
 			(list (quote createtable) schema grouptbl create_cols create_options true)))
-		(define lowered_plan_core (if scalar_query_stage
-			(list (quote !begin)
-				nested_prepare_expr
-				(if initializer_owner keytable_init nil)
-				ensure_agg_expr
-				(build_scalar_single_query_stage_fill_plan
-					prepared_src grouptbl keys key_names
-					(car lowering_ags) (cadr lowering_ags)
-					(car aggregate_cols) (cadr aggregate_cols)))
-			(if query_input
-				(cons (quote !begin)
-					(merge (list
-						nested_prepare
-						nested_materialize
-						(if initializer_owner (list keytable_init) '())
-						ensure_agg_columns
-						computed_order_plans
-						(if (and initializer_owner (empty_list? ags)) (list collect_plan) '())
-						agg_plans
-						empty_aggregate_seed_plans)))
-				(if scalar_order_base_stage
-					(list (quote !begin)
-						nested_prepare_expr
-						(if initializer_owner keytable_init nil)
-						aggregate_prepare_expr)
-					(list (quote !begin)
-						nested_prepare_expr
-						(if initializer_owner
-							(list
-								(list (quote lambda) (list group_cache_created)
-									(list (quote if) group_cache_created
-										nil
-										(list (quote if) (group_stage_session_binding_missing_expr stage schema grouptbl keys key_names)
-											(list (quote !begin)
-												aggregate_prepare_expr
-												base_group_fill_call)
-											aggregate_prepare_expr)))
-								keytable_init)
-							aggregate_prepare_expr))))))
+		(define boolean_row_keys (if (equal? result_sink (quote boolean-recset))
+			(scalar_first_probe_recset_row_keys stage
+				(scalar_first_probe_carrier_source prepared_src)) '()))
+		(define boolean_domain_src (if (equal? result_sink (quote boolean-recset))
+			(boolean_recset_domain_source prepared_src boolean_row_keys) nil))
+		(define boolean_input (if (nil? boolean_domain_src) prepared_src
+			(query_block_with_inner_domain_source prepared_src boolean_domain_src)))
+		(if (and (equal? result_sink (quote boolean-recset)) (nil? boolean_domain_src))
+			(neumann_fail "build_queryplan" "boolean RecSet sink requires a unique base-table domain")
+			true)
+		(define lowered_plan_core (if (equal? result_sink (quote boolean-recset))
+			(build_query_boolean_recset_plan
+				stage_lookup boolean_input boolean_domain_src boolean_row_keys result_sink_ags)
+			(if scalar_query_stage
+				(list (quote !begin)
+					nested_prepare_expr
+					(if initializer_owner keytable_init nil)
+					ensure_agg_expr
+					(build_scalar_single_query_stage_fill_plan
+						prepared_src grouptbl keys key_names
+						(car lowering_ags) (cadr lowering_ags)
+						(car aggregate_cols) (cadr aggregate_cols)))
+				(if query_input
+					(cons (quote !begin)
+						(merge (list
+							nested_prepare
+							nested_materialize
+							(if initializer_owner (list keytable_init) '())
+							ensure_agg_columns
+							computed_order_plans
+							(if (and initializer_owner (empty_list? ags)) (list collect_plan) '())
+							agg_plans
+							empty_aggregate_seed_plans)))
+					(if scalar_order_base_stage
+						(list (quote !begin)
+							nested_prepare_expr
+							(if initializer_owner keytable_init nil)
+							aggregate_prepare_expr)
+						(list (quote !begin)
+							nested_prepare_expr
+							(if initializer_owner
+								(list
+									(list (quote lambda) (list group_cache_created)
+										(list (quote if) group_cache_created
+											nil
+											(list (quote if) (group_stage_session_binding_missing_expr stage schema grouptbl keys key_names)
+												(list (quote !begin)
+													aggregate_prepare_expr
+													base_group_fill_call)
+												aggregate_prepare_expr)))
+									keytable_init)
+								aggregate_prepare_expr)))))))
 		/* A query-invariant presence/scalar-first probe (see the comment at
 		raw_stage_lookup above) is bound exactly once here, ahead of whatever
 		this stage's own prepare plan does, so every rewritten reference below
@@ -1530,7 +1627,7 @@ get_column refs to the source) are excluded automatically too. */
 
 (define lower_stage_prepare_using (lambda (all_stages lookup_stages stage include_nested_prepares)
 	(if (group_stage? stage)
-		(lower_group_stage_prepare_using all_stages lookup_stages stage include_nested_prepares)
+		(lower_group_stage_prepare_using all_stages lookup_stages stage include_nested_prepares nil)
 		(if (orc_stage? stage)
 			(lower_orc_stage_prepare stage)
 			(if (window_stage? stage)
@@ -1588,7 +1685,7 @@ get_column refs to the source) are excluded automatically too. */
 				(nested_stage_catalog stage)
 				(if (query_block? src) (query_block_stage_catalog src) '())))))
 		(list (quote begin)
-			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true)
+			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 			(lower_query_block_core
 				(group_stage_final_block stage (group_stage_final_extra_sources_using stage_catalog stage)))))))
 
@@ -1872,7 +1969,7 @@ get_column refs to the source) are excluded automatically too. */
 							Window and ORC stages still require their explicit materialization. */
 							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup outer_prepare_stages)
 							(lower_stage_materialize_all outer_prepare_stages)
-							(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage true))
+							(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage true nil))
 							(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources))))))))))))
 
 (define query_block_without_stages (lambda (block)
@@ -2766,24 +2863,24 @@ lookup for each ordered driver candidate. */
 			(if (not compatible)
 				(merge (map memberships (lambda (membership)
 					(membership_keyset_bindings (list membership)))))
-			(begin
-				(define keyset_var (symbol (concat "__membership_keyset_"
-					(stable_structural_hash (map memberships (lambda (membership)
-						(gs_id (nth membership 0)))) true))))
-				(define group_cache_probe (and (single_source? parts)
-					(equal? (count (car parts)) 4)))
-				(define candidate_recsets (map parts (lambda (item) (nth item 2))))
-				(define candidate_recset (if (single_source? candidate_recsets)
-					(car candidate_recsets)
-					(list (quote recset_union) (cons (quote list) candidate_recsets))))
-				(define keyset_expr (if group_cache_probe
-					(nth (car parts) 2)
-					(list (quote recset_key_index)
-						'(session "__memcp_tx")
-						candidate_recset
-						(quoted_runtime_list (list (nth (car parts) 1))))))
-				(map memberships (lambda (membership)
-					(list membership keyset_var keyset_expr)))))))))
+				(begin
+					(define keyset_var (symbol (concat "__membership_keyset_"
+						(stable_structural_hash (map memberships (lambda (membership)
+							(gs_id (nth membership 0)))) true))))
+					(define group_cache_probe (and (single_source? parts)
+						(equal? (count (car parts)) 4)))
+					(define candidate_recsets (map parts (lambda (item) (nth item 2))))
+					(define candidate_recset (if (single_source? candidate_recsets)
+						(car candidate_recsets)
+						(list (quote recset_union) (cons (quote list) candidate_recsets))))
+					(define keyset_expr (if group_cache_probe
+						(nth (car parts) 2)
+						(list (quote recset_key_index)
+							'(session "__memcp_tx")
+							candidate_recset
+							(quoted_runtime_list (list (nth (car parts) 1))))))
+					(map memberships (lambda (membership)
+						(list membership keyset_var keyset_expr)))))))))
 
 (define unique_membership_keyset_bindings (lambda (bindings)
 	(reduce bindings (lambda (unique binding)
@@ -2919,8 +3016,8 @@ as it would for an ordinary scan input. */
 							candidate_input_rows candidate_rows
 							(planner_literal_value rows) facts))
 						(* visited_rows
-						(membership_candidate_density
-							candidate_input_rows candidate_rows facts)))))))
+							(membership_candidate_density
+								candidate_input_rows candidate_rows facts)))))))
 		probe_work_rows)))
 
 /* Compile one exact predicate pipeline over an arbitrary RecSet input. The
@@ -3059,7 +3156,7 @@ RecSet; membership edges retain their own physical operators. */
 			candidate_repeat_fraction))
 		(planner_cost_add (planner_cost
 			(+ (* (+ driver_scan_invocations (* batches candidate_scan_invocations))
-					planner_membership_scan_invocation_ns)
+				planner_membership_scan_invocation_ns)
 				(* batches driver_scan_invocations
 					planner_membership_ordered_scan_invocation_ns))
 			(+
@@ -3091,6 +3188,129 @@ RecSet; membership edges retain their own physical operators. */
 			(equal? (qassoc_get (gs_facts (nth membership 0))
 				(quote membership_consumer) nil)
 				(quote order_limit))))))
+
+/* An exact RecSet used by ORDER/LIMIT has two physical consumers. Scanning the
+RecSet directly is proportional to its cardinality. Scanning the ordered base
+table and probing membership is proportional to the expected prefix needed to
+fill the requested window. Neither dominates for all densities, so this is a
+cost decision with an exact request-local observation and a crossover guard. */
+(define ordered_recset_expected_base_rows (lambda (source_rows carrier_rows window_rows)
+	(if (or (not (number? source_rows)) (<= source_rows 0))
+		window_rows
+		(if (or (not (number? carrier_rows)) (<= carrier_rows 0))
+			source_rows
+			(min source_rows (max window_rows
+				(/ (* window_rows source_rows) carrier_rows)))))))
+
+(define ordered_direct_recset_cost (lambda (carrier_rows)
+	(planner_cost
+		planner_membership_ordered_scan_invocation_ns
+		(+
+			(* carrier_rows planner_membership_scan_row_ns)
+			(* (/ (* carrier_rows carrier_rows) 1000000)
+				planner_membership_ordered_driver_input_row_ns))
+		0 0 0 0 0 0 carrier_rows 0.95)))
+
+(define ordered_base_membership_cost (lambda (source_rows carrier_rows window_rows)
+	(begin
+		(define visited_rows
+			(ordered_recset_expected_base_rows source_rows carrier_rows window_rows))
+		(planner_cost
+			planner_membership_ordered_scan_invocation_ns
+			(* visited_rows (+ planner_membership_scan_row_ns
+				planner_membership_recset_probe_row_ns))
+			0 0 0 0 0 0 visited_rows 0.95))))
+
+(define ordered_recset_crossover_search (lambda (source_rows window_rows low high remaining)
+	(if (or (<= remaining 0) (>= low high))
+		low
+		(begin
+			(define mid (/ (+ low high) 2))
+			(if (planner_cost_better?
+				(ordered_direct_recset_cost mid)
+				(ordered_base_membership_cost source_rows mid window_rows))
+				(ordered_recset_crossover_search source_rows window_rows (+ mid 1) high (- remaining 1))
+				(ordered_recset_crossover_search source_rows window_rows low mid (- remaining 1)))))))
+
+/* Preparations execute immediately before the compiled plan and therefore do
+not live inside with_physical_query_context's lexical bindings. Rebind only the
+three physical context symbols; quoted data remains opaque. */
+(define ordered_recset_observation_expr (lambda (expr)
+	(if (equal? expr (physical_query_session_symbol))
+		(list (quote context) "session")
+		(if (equal? expr (physical_query_scope_symbol))
+			(list (quote context) "query")
+			(if (equal? expr (physical_query_tx_symbol))
+				(list (list (quote context) "session") "__memcp_tx")
+				(match expr
+					((symbol quote) _value) expr
+					((quote quote) _value) expr
+					(cons head tail) (cons
+						(ordered_recset_observation_expr head)
+						(map tail ordered_recset_observation_expr))
+					_ expr))))))
+
+/* Return (chosen carrier). The carrier is replaced by the prepared observation
+when cached_parse is active, so preparing cardinality never duplicates its
+construction. Semantic dominance decisions are made elsewhere; cardinality-
+dependent choices must pass through this function and retain their guard. */
+(define ordered_scalar_recset_consumer_plan (lambda (src scalar_plan carrier offset limit)
+	(begin
+		(define source_rows (planner_source_row_count src))
+		(define window_rows (+ (coalesceNil offset 0) (coalesceNil limit 0)))
+		(define probe (physical_scalar_truth_plan_probe scalar_plan))
+		(define stage (if (nil? probe) nil (car probe)))
+		(define decision_id (concat "ordered_recset_consumer:"
+			(if (nil? stage) (source_alias src) (gs_id stage))))
+		/* Carrier producers are closed before reaching this consumer: direct boolean
+		stages are RecSet algebra and ordinary membership carriers are relational
+		plans. cached_parse can therefore observe the exact request-local cardinality
+		without changing an outer-row binding or constructing the carrier twice. */
+		(define observation_keys (planner_register_queryplan_observation decision_id
+			(ordered_recset_observation_expr carrier)
+			(list (quote recset_count) (symbol "__queryplan_observed_value"))))
+		(define observed_rows (if (nil? observation_keys) nil
+			(planner_queryplan_observed_metric decision_id)))
+		(define planning_rows (if (number? observed_rows) observed_rows source_rows))
+		(define direct_cost (ordered_direct_recset_cost planning_rows))
+		(define base_cost (ordered_base_membership_cost source_rows planning_rows window_rows))
+		(define normal_choice (if (planner_cost_better? direct_cost base_cost)
+			"ordered_direct_recset" "ordered_base_membership"))
+		(define crossover (if (number? source_rows)
+			(ordered_recset_crossover_search source_rows window_rows 0 source_rows 32)
+			nil))
+		(if (or (nil? observation_keys) (not (number? crossover)))
+			nil
+			(planner_record_guard_condition
+				(list (if (equal? normal_choice "ordered_direct_recset") (quote <) (quote >=))
+					(list (quote session) (cadr observation_keys)) crossover)))
+		(define chosen (planner_physical_choice decision_id normal_choice
+			(list "ordered_direct_recset" "ordered_base_membership")))
+		(define forced (planner_physical_override decision_id))
+		(planner_record_physical_decision (list
+			(list "decision_id" decision_id)
+			(list "decision" "ordered_recset_consumer")
+			(list "decision_site" "ordered_scan_lowering")
+			(list "chosen" chosen)
+			(list "selection" (if (nil? forced) "cost" "forced"))
+			(list "reason" (if (nil? forced) "lowest_total_ns" "calibration_override"))
+			(list "inputs" (list
+				(list "carrier_rows" planning_rows)
+				(list "driver_input_rows" source_rows)
+				(list "offset" offset)
+				(list "limit" limit)
+				(list "crossover_rows" crossover)))
+			(list "alternatives" (list
+				(list
+					(list "plan" "ordered_direct_recset")
+					(list "status" (if (equal? chosen "ordered_direct_recset") "chosen" "rejected"))
+					(list "cost" (planner_cost_explain direct_cost)))
+				(list
+					(list "plan" "ordered_base_membership")
+					(list "status" (if (equal? chosen "ordered_base_membership") "chosen" "rejected"))
+					(list "cost" (planner_cost_explain base_cost)))))))
+		(list chosen (if (nil? observation_keys) carrier
+			(list (quote session) (car observation_keys)))))))
 
 (define lower_single_source_query_block (lambda (block)
 	(begin
@@ -3126,6 +3346,21 @@ RecSet; membership edges retain their own physical operators. */
 					probe_work_rows (probe_context_row_count (list src))
 					(query_block_stage_catalog block)))
 				(define scalar_carrier (physical_scalar_truth_plan_carrier scalar_plan))
+				(define scalar_consumer_plan (if (and (not (nil? scalar_carrier))
+					(and scan_order_supported bounded))
+					(ordered_scalar_recset_consumer_plan src scalar_plan scalar_carrier
+						(qb_offset block) (qb_limit block))
+					nil))
+				(define scalar_consumer (if (nil? scalar_consumer_plan) nil
+					(car scalar_consumer_plan)))
+				(define effective_scalar_carrier (if (nil? scalar_consumer_plan)
+					scalar_carrier (cadr scalar_consumer_plan)))
+				(define scalar_membership_filter
+					(equal? scalar_consumer "ordered_base_membership"))
+				(define scalar_membership_var (symbol (concat "__ordered_scalar_recset_"
+					(if (nil? (physical_scalar_truth_plan_probe scalar_plan))
+						(source_alias src)
+						(gs_id (car (physical_scalar_truth_plan_probe scalar_plan)))))))
 				(define condition (rewrite_physical_scalar_truth_plan scalar_plan raw_condition))
 				(define effective_fields (rewrite_physical_scalar_truth_plan scalar_plan fields))
 				(define projection_bundle (physical_scalar_projection_bundle
@@ -3150,21 +3385,21 @@ RecSet; membership edges retain their own physical operators. */
 				point; that duplicate choice could label an alternative as selected while
 				emitting the correlated subscan fallback. */
 				(define membership_plans (filter (map memberships (lambda (membership)
-						(begin
-							(define plan (recset_project_join_plan_for_membership_using
-								src membership
-								(if bounded (quote order_limit) (quote filter))
-								(if (and scan_order_supported bounded)
-									(probe_limit_work_rows (qb_limit block)) nil)
-								allow_ordered_batch_binding
+					(begin
+						(define plan (recset_project_join_plan_for_membership_using
+							src membership
+							(if bounded (quote order_limit) (quote filter))
+							(if (and scan_order_supported bounded)
+								(probe_limit_work_rows (qb_limit block)) nil)
+							allow_ordered_batch_binding
 							(prefiltered_driver_recset_expr_for_membership
 								src source_table condition membership)
-								(+ (count (acceptance_required_sources
-									(membership_downstream_sources (qb_sources block) src membership)
-									alias raw_condition))
-									(count (expr_probe_stages raw_condition)))
-								(not row_number_membership_consumer)))
-							(if (nil? plan) nil (list membership plan)))))
+							(+ (count (acceptance_required_sources
+								(membership_downstream_sources (qb_sources block) src membership)
+								alias raw_condition))
+								(count (expr_probe_stages raw_condition)))
+							(not row_number_membership_consumer)))
+						(if (nil? plan) nil (list membership plan)))))
 					(lambda (entry) (not (nil? entry)))))
 				(define driver_memberships (map (filter membership_plans (lambda (entry)
 					(equal? (car (nth entry 1)) "driver_order_membership_probe")))
@@ -3220,22 +3455,23 @@ RecSet; membership edges retain their own physical operators. */
 					(not membership_formula_driver)
 					(and (not (nil? direct_membership))
 						(and (not (empty_list? membership_bindings))
-								(and (empty_list? (cdr membership_bindings))
-									(equal? direct_membership (car bound_memberships)))))))
+							(and (empty_list? (cdr membership_bindings))
+								(equal? direct_membership (car bound_memberships)))))))
 				(define membership_filter (and
 					(not (or membership_driver membership_formula_driver))
 					(not (empty_list? membership_bindings))))
 				(define candidate_filter_condition (if membership_formula_driver
-						(if membership_formula_difference_driver true membership_formula_residual)
-						(if membership_driver
-							(strip_driver_membership_for_source src condition direct_membership)
-							(replace_driver_membership_markers src condition bound_memberships))))
+					(if membership_formula_difference_driver true membership_formula_residual)
+					(if membership_driver
+						(strip_driver_membership_for_source src condition direct_membership)
+						(replace_driver_membership_markers src condition bound_memberships))))
 				(define filter_condition (if use_membership_keysets
 					(replace_driver_membership_keyset_markers
 						candidate_filter_condition membership_keysets)
 					candidate_filter_condition))
 				(define filtercols (merge_unique (list
-					(if membership_filter (list "$recset_contains") '())
+					(if (or membership_filter scalar_membership_filter)
+						(list "$recset_contains") '())
 					(extract_columns_for_alias src filter_condition))))
 				(define fieldcols (merge_unique (extract_assoc bundled_fields (lambda (_title expr)
 					(extract_columns_for_alias src expr)))))
@@ -3262,17 +3498,22 @@ RecSet; membership edges retain their own physical operators. */
 				sources. Their conjunction is the exact physical intersection; replacing
 				one with the other after either predicate was stripped would lose a WHERE
 				term. */
-				(define table_expr (if (nil? scalar_carrier)
+				(define table_expr (if (or (nil? effective_scalar_carrier)
+					scalar_membership_filter)
 					membership_table_expr
 					(if (equal? membership_table_expr source_table)
-						scalar_carrier
+						effective_scalar_carrier
 						(list (quote recset_intersect)
 							(cons (quote list) (list
-								scalar_carrier
+								effective_scalar_carrier
 								membership_table_expr))))))
 				(define filter_expr (list (quote lambda)
 					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
-					(lower_column_expr_for_alias src filter_condition)))
+					(if scalar_membership_filter
+						(list (quote and)
+							(recset_contains_call_expr scalar_membership_var)
+							(lower_column_expr_for_alias src filter_condition))
+						(lower_column_expr_for_alias src filter_condition))))
 				(define remaining_batch_memberships (filter
 					(ordered_batch_membership_terms src filter_condition)
 					(lambda (membership) (ordered_batch_stage_supported? (nth membership 0)))))
@@ -3344,11 +3585,16 @@ RecSet; membership edges retain their own physical operators. */
 									(source_outer? src))))
 							scan_expr)
 						(neumann_fail "build_queryplan" "single-source ORDER BY requires a storage carrier"))))
-				(if use_membership_keysets
+				(define wrapped_scan_plan (if use_membership_keysets
 					(wrap_membership_keyset_bindings membership_keysets scan_plan)
 					(if membership_filter
 						(wrap_membership_recset_bindings membership_bindings scan_plan)
-						scan_plan)))))))
+						scan_plan)))
+				(if scalar_membership_filter
+					(list
+						(list (quote lambda) (list scalar_membership_var) wrapped_scan_plan)
+						effective_scalar_carrier)
+					wrapped_scan_plan))))))
 
 (define order_exprs (lambda (order_items)
 	(map (coalesceNil order_items '()) (lambda (item)
@@ -4407,6 +4653,30 @@ exact parameter value. */
 					residual_probe_work_rows residual_probe_work_rows stages))))
 		(define effective_scalar_carrier
 			(physical_scalar_truth_plan_carrier effective_scalar_plan))
+		(define scalar_carrier_driver (and (not (nil? effective_scalar_carrier))
+			(equal? alias (car effective_scalar_plan))))
+		/* An exact truth RecSet does not imply that iterating that RecSet is the
+		cheapest ordered access path. At the selected join-tree driver, compare the
+		complete projected carrier with the base index plus one membership test per
+		visited row. This is the same node-local choice used by a single-source
+		block; keeping it here makes added projection/LEFT-JOIN leaves irrelevant to
+		the operator decision. Cardinality-dependent choices retain the observation
+		and recompile guard installed by ordered_scalar_recset_consumer_plan. */
+		(define scalar_consumer_plan (if (and scalar_carrier_driver
+			(and direct_order_limit (not delay_limit_after_join)))
+			(ordered_scalar_recset_consumer_plan src effective_scalar_plan
+				effective_scalar_carrier offset_value limit_value)
+			nil))
+		(define scalar_consumer (if (nil? scalar_consumer_plan) nil
+			(car scalar_consumer_plan)))
+		(define consumed_scalar_carrier (if (nil? scalar_consumer_plan)
+			effective_scalar_carrier (cadr scalar_consumer_plan)))
+		(define scalar_membership_filter
+			(equal? scalar_consumer "ordered_base_membership"))
+		(define scalar_membership_var (symbol (concat "__ordered_scalar_recset_"
+			(if (nil? (physical_scalar_truth_plan_probe effective_scalar_plan))
+				alias
+				(gs_id (car (physical_scalar_truth_plan_probe effective_scalar_plan)))))))
 		(define carrier_condition
 			(rewrite_physical_scalar_truth_plan effective_scalar_plan condition))
 		(define membership_table_expr (if (and
@@ -4487,28 +4757,31 @@ exact parameter value. */
 		(define membership_filter_expr (if membership_filter
 			(recset_contains_call_expr membership_var)
 			true))
-		(define filter_condition (combine_where membership_filter_expr residual_condition))
+		(define scalar_membership_filter_expr (if scalar_membership_filter
+			(recset_contains_call_expr scalar_membership_var)
+			true))
+		(define filter_condition (combine_where scalar_membership_filter_expr
+			(combine_where membership_filter_expr residual_condition)))
 		(define filtercols (merge_unique (list
-			(if membership_filter (list "$recset_contains") '())
+			(if (or membership_filter scalar_membership_filter)
+				(list "$recset_contains") '())
 			(join_filter_cols_for_alias all_sources default_alias alias residual_condition))))
 		(define recipe_mapcols (join_recipe_mapcols column_recipe alias))
 		(define raw_mapcols (if (nil? column_recipe)
 			(join_cols_for_alias all_sources default_alias alias needed_exprs)
 			recipe_mapcols))
 		(define mapcols raw_mapcols)
-		(define scalar_carrier_driver (and (not (nil? effective_scalar_carrier))
-			(equal? alias (car effective_scalar_plan))))
 		(define base_table_expr (if membership_driver membership_table_expr
 			(if (not access_path_selected)
 				(source_table_expr_using stages src)
 				(scan_access_path_table_expr stages src access_path_candidate))))
-		(define table_expr (if (not scalar_carrier_driver)
+		(define table_expr (if (or (not scalar_carrier_driver) scalar_membership_filter)
 			base_table_expr
 			(if (equal? base_table_expr (source_table_expr_using stages src))
-				effective_scalar_carrier
+				consumed_scalar_carrier
 				(list (quote recset_intersect)
 					(cons (quote list) (list
-						effective_scalar_carrier
+						consumed_scalar_carrier
 						base_table_expr))))))
 		(define lowered_filter_condition (mark_outer_join_symbols
 			all_sources
@@ -4560,41 +4833,46 @@ exact parameter value. */
 							(join_scan_neutral_expr result_mode)
 							(or outer_scan (source_outer? src))))
 					(if (and (empty_list? current_order_items) (not (query_limit_active? offset_value limit_value)))
-					(list (quote scan)
-						'(session "__memcp_tx")
-						table_expr
-						(cons (quote list) filtercols)
-						filter_expr
-						(cons (quote list) mapcols)
-						map_expr
-						reduce_expr
-						(join_scan_neutral_expr result_mode)
-						(join_scan_shard_reduce_expr result_mode)
-						(or outer_scan (source_outer? src)))
-					(list (quote scan_order)
-						'(session "__memcp_tx")
-						table_expr
-						(cons (quote list) filtercols)
-						filter_expr
-						(cons (quote list) (if (empty_list? current_order_items) '()
-							(scan_order_sort_columns_for_join_driver ordered_sources default_alias src current_order_items stages final_condition)))
-						(cons (quote list) (if (empty_list? current_order_items) '() (order_relations_for_source src current_order_items)))
-						0
-						(coalesceNil offset_value 0)
-						(coalesceNil limit_value -1)
-						(cons (quote list) mapcols)
-						map_expr
-						reduce_expr
-						(join_scan_neutral_expr result_mode)
-						(or outer_scan (source_outer? src)))))))
+						(list (quote scan)
+							'(session "__memcp_tx")
+							table_expr
+							(cons (quote list) filtercols)
+							filter_expr
+							(cons (quote list) mapcols)
+							map_expr
+							reduce_expr
+							(join_scan_neutral_expr result_mode)
+							(join_scan_shard_reduce_expr result_mode)
+							(or outer_scan (source_outer? src)))
+						(list (quote scan_order)
+							'(session "__memcp_tx")
+							table_expr
+							(cons (quote list) filtercols)
+							filter_expr
+							(cons (quote list) (if (empty_list? current_order_items) '()
+								(scan_order_sort_columns_for_join_driver ordered_sources default_alias src current_order_items stages final_condition)))
+							(cons (quote list) (if (empty_list? current_order_items) '() (order_relations_for_source src current_order_items)))
+							0
+							(coalesceNil offset_value 0)
+							(coalesceNil limit_value -1)
+							(cons (quote list) mapcols)
+							map_expr
+							reduce_expr
+							(join_scan_neutral_expr result_mode)
+							(or outer_scan (source_outer? src)))))))
 		(define membership_bound_scan (if membership_filter
 			(list
 				(list (quote lambda) (list membership_var) scan_expr)
 				membership_table_expr)
 			scan_expr))
+		(define scalar_bound_scan (if scalar_membership_filter
+			(list
+				(list (quote lambda) (list scalar_membership_var) membership_bound_scan)
+				consumed_scalar_carrier)
+			membership_bound_scan))
 		(if use_membership_keyset
-			(wrap_membership_keyset_bindings membership_keysets membership_bound_scan)
-			membership_bound_scan))))
+			(wrap_membership_keyset_bindings membership_keysets scalar_bound_scan)
+			scalar_bound_scan))))
 
 /* Consume the logical join tree recursively. The right subtree is lowered as
 the continuation of the left subtree, so join-node boundaries and outer-join
@@ -5218,7 +5496,7 @@ physical decision and preserve its runtime recompile gate. */
 						(source_alias driver_src)
 						(if (equal? operator (quote recset))
 							(lower_projected_recset_scalar_first_probe_expr
-								probe_stages raw_stage requested_col driver_src target_col)
+								probe_stages raw_stage requested_col driver_src target_col true)
 							nil)
 						probe
 						(if (equal? operator (quote recset)) raw_stage stage))))))))
@@ -5801,7 +6079,7 @@ every title. */
 				(define stage (make_group_stage_for_block branch src))
 				(define final_block (group_stage_final_block stage (group_stage_final_extra_sources stage)))
 				(if (union_ordered_branch_supported? final_block)
-					(list (list (lower_group_stage_prepare_using (list stage) (list stage) stage true)) final_block nil)
+					(list (list (lower_group_stage_prepare_using (list stage) (list stage) stage true nil)) final_block nil)
 					nil))))))
 
 (define union_semijoin_equal_parts (lambda (driver lookup expr)
@@ -6786,7 +7064,14 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		(define kind (qassoc_get decision "decision" nil))
 		(if (equal? kind "membership_carrier")
 			(physical_membership_operator_family plan)
-			"unknown"))))
+			(if (equal? kind "ordered_recset_consumer")
+				(begin
+					(define chosen (qassoc_get decision "chosen" nil))
+					(if (or (equal? chosen "ordered_direct_recset")
+						(equal? chosen "ordered_base_membership"))
+						chosen
+						"unknown"))
+				"unknown")))))
 
 /* recset_project_join is adaptive only inside the physical operator: actual
 source-key and per-shard target cardinalities are available there, while the
@@ -6855,7 +7140,8 @@ potentially large calibrated SELECT result. */
 	(begin
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
 		(define decision_kind (qassoc_get decision "decision" nil))
-		(define expected_family (if (equal? decision_kind "membership_carrier")
+		(define expected_family (if (or (equal? decision_kind "membership_carrier")
+			(equal? decision_kind "ordered_recset_consumer"))
 			variant operator_family))
 		(define consistent (equal? operator_family expected_family))
 		(define baseline_hash_key (concat "hash:" decision_id))
@@ -6908,6 +7194,7 @@ potentially large calibrated SELECT result. */
 							"fit_eligible" (not shared_suite)
 							"candidate_input_rows" (physical_calibration_input decision "candidate_input_rows")
 							"candidate_rows" (physical_calibration_input decision "candidate_rows")
+							"carrier_rows" (physical_calibration_input decision "carrier_rows")
 							"candidate_density" (physical_calibration_input decision "candidate_density")
 							"estimate_population" (physical_calibration_input decision "estimate_population")
 							"estimate_coverage" (physical_calibration_input decision "estimate_coverage")
@@ -6956,9 +7243,8 @@ potentially large calibrated SELECT result. */
 					variant_decision
 					variant
 					(qassoc_get variant_cost "total_ns" nil)
-					/* compile_physical_explain_variant records this before the generic
-					AST optimizer can fold a carrier wrapper into its consumer. */
-					(nth compilation 2)
+					(physical_operator_family_for_decision
+						(nth compilation 0) variant_decision)
 					suite_var)))))))
 
 (define physical_decision_has_costed_alternatives? (lambda (decision)
@@ -7023,7 +7309,8 @@ potentially large calibrated SELECT result. */
 						decision
 						variant
 						(qassoc_get (qassoc_get alternative "cost" '()) "total_ns" nil)
-						(nth compilation 2)
+						(physical_operator_family_for_decision
+							(nth compilation 0) decision)
 						suite_var)))))))
 
 (define explain_queryplan_physical_calibrate (lambda (query)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -841,7 +841,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		nested_catalog_input
 		'() '(1) '() nil '() '() nil nil
 		(list (list 'stage_catalog (list nested_catalog_stage)))))
-	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) (list outer_catalog_stage) outer_catalog_stage))
+	(assert (list? (lower_group_stage_prepare_using (list outer_catalog_stage) (list outer_catalog_stage) outer_catalog_stage true nil))
 		true "group-stage lowering keeps nested stage-output metadata from the full catalog")
 	(define catalog_root (make_query_block
 		"memcp-tests"

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -257,6 +257,21 @@ func (s ErrorWrapper) Error() string {
 	return string(s)
 }
 
+const mysqlClientErrorMessageLimit = 2048
+
+// mysqlClientErrorMessage keeps protocol errors below mysqlnd's fixed command
+// buffer. Internal panics include their full stack for the server log, but the
+// first line contains the actionable cause and is the only part clients need.
+func mysqlClientErrorMessage(message string) string {
+	if lineEnd := strings.IndexByte(message, '\n'); lineEnd >= 0 {
+		message = message[:lineEnd]
+	}
+	if len(message) <= mysqlClientErrorMessageLimit {
+		return message
+	}
+	return message[:mysqlClientErrorMessageLimit]
+}
+
 func updateMySQLFieldMetadata(field *querypb.Field, val sqltypes.Value) {
 	field.Type = val.Type()
 	switch val.Type() {
@@ -415,7 +430,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 				} else {
 					errMsg := fmt.Sprint(r)
 					PrintError("error in mysql connection: " + errMsg)
-					myerr = ErrorWrapper(errMsg)
+					myerr = ErrorWrapper(mysqlClientErrorMessage(errMsg))
 				}
 			}
 		}()

--- a/scm/mysql_test.go
+++ b/scm/mysql_test.go
@@ -18,11 +18,30 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package scm
 
 import (
+	"strings"
 	"testing"
 
 	querypb "github.com/launix-de/go-mysqlstack/sqlparser/depends/query"
 	"github.com/launix-de/go-mysqlstack/sqlparser/depends/sqltypes"
 )
+
+func TestMySQLClientErrorMessageDropsInternalStackAndFitsCommandBuffer(t *testing.T) {
+	stack := strings.Repeat("runtime stack frame\n", 1000)
+	got := mysqlClientErrorMessage("NthLocalVar(2) out of range (len=0)\n" + stack)
+	if got != "NthLocalVar(2) out of range (len=0)" {
+		t.Fatalf("unexpected client error %q", got)
+	}
+	if len(got) > mysqlClientErrorMessageLimit {
+		t.Fatalf("client error uses %d bytes, limit is %d", len(got), mysqlClientErrorMessageLimit)
+	}
+}
+
+func TestMySQLClientErrorMessageBoundsSingleLineErrors(t *testing.T) {
+	got := mysqlClientErrorMessage(strings.Repeat("x", mysqlClientErrorMessageLimit+100))
+	if len(got) != mysqlClientErrorMessageLimit {
+		t.Fatalf("client error uses %d bytes, want %d", len(got), mysqlClientErrorMessageLimit)
+	}
+}
 
 func TestAppendMySQLResultRowDuplicateAliasUsesLastValueType(t *testing.T) {
 	result := sqltypes.Result{}

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -515,3 +515,25 @@ test_cases:
       )
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
+
+  # The scalar stage is intentionally broad: its exact RecSet is cheaper to
+  # consume by walking the ordered document index and probing membership than
+  # by sorting the carrier. A separate decision family validates that crossover
+  # without feeding the shared carrier-production work back into its coefficient
+  # fit.
+  - name: "ordered scalar RecSet consumer crossover"
+    physical_calibration: true
+    calibration_decision: "ordered_recset_consumer"
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      WHERE COALESCE((
+        SELECT f.id < 4500
+        FROM pc_files_large f
+        WHERE f.id = d.file_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.sort_key, d.id
+      LIMIT 72

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -591,6 +591,170 @@ test_cases:
         - id: 39993
         - id: 39989
 
+  - name: "broad ordered ACL compares exact RecSet consumers"
+    sql: |
+      EXPLAIN PHYSICAL SELECT d.id
+      FROM bqm_document d
+      WHERE COALESCE((
+        SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+          EXISTS (
+            SELECT TRUE FROM bqm_mandant_assignment ma
+            WHERE ma.standort_id = s.id
+              AND ma.actor_id = 7
+              AND ma.allowed = TRUE
+            LIMIT 1
+          ) OR COALESCE((
+            SELECT sa.allowed FROM bqm_standort_assignment sa
+            WHERE sa.standort_id = s.id
+              AND sa.actor_id = 7
+            LIMIT 1
+          ), FALSE)
+        ) END
+        FROM bqm_standort s
+        WHERE s.id = d.standort_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      result_contains:
+        - "boolean_stage_recset"
+        - "ordered_recset_consumer"
+        - "ordered_base_membership"
+        - "ordered_direct_recset"
+        - "chosen ordered_base_membership"
+
+  - name: "broad ordered ACL preserves direct RecSet results"
+    max_time: 1
+    sql: |
+      SELECT d.id
+      FROM bqm_document d
+      WHERE COALESCE((
+        SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+          EXISTS (
+            SELECT TRUE FROM bqm_mandant_assignment ma
+            WHERE ma.standort_id = s.id
+              AND ma.actor_id = 7
+              AND ma.allowed = TRUE
+            LIMIT 1
+          ) OR COALESCE((
+            SELECT sa.allowed FROM bqm_standort_assignment sa
+            WHERE sa.standort_id = s.id
+              AND sa.actor_id = 7
+            LIMIT 1
+          ), FALSE)
+        ) END
+        FROM bqm_standort s
+        WHERE s.id = d.standort_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - id: 39999
+        - id: 39998
+        - id: 39997
+
+  - name: "joined broad ordered ACL compares the same RecSet consumers"
+    sql: |
+      EXPLAIN PHYSICAL SELECT d.id, sorter.label
+      FROM bqm_document d
+      LEFT JOIN bqm_unused_lookup sorter
+        ON sorter.id = d.standort_id
+      WHERE COALESCE((
+        SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+          EXISTS (
+            SELECT TRUE FROM bqm_mandant_assignment ma
+            WHERE ma.standort_id = s.id
+              AND ma.actor_id = 7
+              AND ma.allowed = TRUE
+            LIMIT 1
+          ) OR COALESCE((
+            SELECT sa.allowed FROM bqm_standort_assignment sa
+            WHERE sa.standort_id = s.id
+              AND sa.actor_id = 7
+            LIMIT 1
+          ), FALSE)
+        ) END
+        FROM bqm_standort s
+        WHERE s.id = d.standort_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      result_contains:
+        - "boolean_stage_recset"
+        - "ordered_recset_consumer"
+        - "ordered_base_membership"
+        - "ordered_direct_recset"
+        - "chosen ordered_base_membership"
+
+  - name: "joined broad ordered ACL preserves LEFT JOIN results"
+    max_time: 1
+    sql: |
+      SELECT d.id, sorter.label
+      FROM bqm_document d
+      LEFT JOIN bqm_unused_lookup sorter
+        ON sorter.id = d.standort_id
+      WHERE COALESCE((
+        SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+          EXISTS (
+            SELECT TRUE FROM bqm_mandant_assignment ma
+            WHERE ma.standort_id = s.id
+              AND ma.actor_id = 7
+              AND ma.allowed = TRUE
+            LIMIT 1
+          ) OR COALESCE((
+            SELECT sa.allowed FROM bqm_standort_assignment sa
+            WHERE sa.standort_id = s.id
+              AND sa.actor_id = 7
+            LIMIT 1
+          ), FALSE)
+        ) END
+        FROM bqm_standort s
+        WHERE s.id = d.standort_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - {id: 39999, label: "three"}
+        - {id: 39998, label: "two"}
+        - {id: 39997, label: "one"}
+
+  - name: "bind actor for row-domain projection test"
+    session_id: "bqm_row_domain"
+    sql: "SET @bqm_row_actor = 7"
+
+  - name: "ordered scalar carrier projects only its row-domain key"
+    session_id: "bqm_row_domain"
+    max_time: 1
+    sql: |
+      SELECT d.id
+      FROM bqm_document d
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @bqm_row_actor = 7 THEN TRUE
+          ELSE s.direct_flag = 1
+        END
+        FROM bqm_standort s
+        WHERE s.id = d.standort_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - id: 40000
+        - id: 39999
+        - id: 39998
+
   - name: "unbounded equality count retains the segmented ACL carrier"
     sql: |
       EXPLAIN PHYSICAL SELECT COUNT(*) AS total

--- a/tests/planner/subqueries/compound-boolean-recset-selection.yaml
+++ b/tests/planner/subqueries/compound-boolean-recset-selection.yaml
@@ -234,6 +234,35 @@ test_cases:
         - text: "__memcp_tx"
           count: 1
 
+  - name: "observed boolean carrier closes invariant EXISTS and NOT probes"
+    sql: |
+      SELECT i.id
+      FROM cbr_large_item i
+      WHERE COALESCE((
+        SELECT CASE WHEN EXISTS (
+          SELECT TRUE FROM cbr_global_acl global_acl
+          WHERE global_acl.actor = @cbr_actor
+            AND global_acl.allowed = TRUE
+          LIMIT 1
+        ) THEN TRUE ELSE NOT EXISTS (
+          SELECT TRUE FROM cbr_global_acl denied_acl
+          WHERE denied_acl.actor = @cbr_actor
+            AND denied_acl.allowed = FALSE
+          LIMIT 1
+        ) END
+        FROM cbr_scope s
+        WHERE s.id = i.scope_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - {id: 5000}
+        - {id: 4999}
+        - {id: 4998}
+
   - name: "compound scalar boolean filter selects a projected RecSet driver"
     sql: |
       EXPLAIN SELECT COUNT(*) FROM cbr_item i

--- a/tests/planner/subqueries/compound-boolean-recset-selection.yaml
+++ b/tests/planner/subqueries/compound-boolean-recset-selection.yaml
@@ -353,6 +353,120 @@ test_cases:
         - text: "get_or_compute_scoped"
           count: 1
 
+  - name: "shared boolean carrier keeps driver lookup bound across joined projections"
+    sql: |
+      SELECT i.id, joined_scope.direct_flag,
+        COALESCE((
+          SELECT CASE WHEN scalar_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+            SELECT TRUE FROM cbr_exists_acl ea
+            WHERE ea.scope_id = scalar_scope.id AND ea.allowed = TRUE
+            LIMIT 1
+          ) END
+          FROM cbr_scope scalar_scope
+          WHERE scalar_scope.id = i.scope_id
+          LIMIT 1
+        ), FALSE) AS can_view,
+        COALESCE((
+          SELECT CASE WHEN scalar_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+            SELECT TRUE FROM cbr_exists_acl ea
+            WHERE ea.scope_id = scalar_scope.id AND ea.allowed = TRUE
+            LIMIT 1
+          ) END
+          FROM cbr_scope scalar_scope
+          WHERE scalar_scope.id = i.scope_id
+          LIMIT 1
+        ), FALSE) AS can_edit
+      FROM cbr_large_item i
+      LEFT JOIN cbr_scope joined_scope ON joined_scope.id = i.scope_id
+      WHERE COALESCE((
+        SELECT CASE WHEN scalar_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+          SELECT TRUE FROM cbr_exists_acl ea
+          WHERE ea.scope_id = scalar_scope.id AND ea.allowed = TRUE
+          LIMIT 1
+        ) END
+        FROM cbr_scope scalar_scope
+        WHERE scalar_scope.id = i.scope_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.id
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - {id: 1, direct_flag: 1, can_view: true, can_edit: true}
+        - {id: 2, direct_flag: 0, can_view: true, can_edit: true}
+        - {id: 5, direct_flag: 1, can_view: true, can_edit: true}
+
+  - name: "driver boolean carrier stays closed beside a derived boolean projection"
+    sql: |
+      SELECT i.id, joined_scope.joined_can_view,
+        COALESCE((
+          SELECT (CASE WHEN driver_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM cbr_exists_acl driver_acl
+              WHERE driver_acl.scope_id = driver_scope.id
+                AND driver_acl.allowed = TRUE
+              LIMIT 1
+            ) END) AND COALESCE((
+              SELECT (nested_scope.direct_flag = 1) OR EXISTS (
+                SELECT TRUE FROM cbr_fallback_acl nested_acl
+                WHERE nested_acl.scope_id = nested_scope.id
+                  AND nested_acl.allowed = TRUE
+                LIMIT 1
+              )
+              FROM cbr_scope nested_scope
+              WHERE nested_scope.id = driver_scope.id
+              LIMIT 1
+            ), FALSE)
+          FROM cbr_scope driver_scope
+          WHERE driver_scope.id = i.scope_id
+          LIMIT 1
+        ), FALSE) AS driver_can_view
+      FROM cbr_large_item i
+      LEFT JOIN (
+        SELECT joined_base.id,
+          COALESCE((
+            SELECT CASE WHEN joined_acl_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+              SELECT TRUE FROM cbr_exists_acl joined_acl
+              WHERE joined_acl.scope_id = joined_acl_scope.id
+                AND joined_acl.allowed = TRUE
+              LIMIT 1
+            ) END
+            FROM cbr_scope joined_acl_scope
+            WHERE joined_acl_scope.id = joined_base.id
+            LIMIT 1
+          ), FALSE) AS joined_can_view
+        FROM cbr_scope joined_base
+      ) joined_scope ON joined_scope.id = i.scope_id
+      WHERE COALESCE((
+        SELECT (CASE WHEN driver_scope.direct_flag = 1 THEN TRUE ELSE EXISTS (
+            SELECT TRUE FROM cbr_exists_acl driver_acl
+            WHERE driver_acl.scope_id = driver_scope.id
+              AND driver_acl.allowed = TRUE
+            LIMIT 1
+          ) END) AND COALESCE((
+            SELECT (nested_scope.direct_flag = 1) OR EXISTS (
+              SELECT TRUE FROM cbr_fallback_acl nested_acl
+              WHERE nested_acl.scope_id = nested_scope.id
+                AND nested_acl.allowed = TRUE
+              LIMIT 1
+            )
+            FROM cbr_scope nested_scope
+            WHERE nested_scope.id = driver_scope.id
+            LIMIT 1
+          ), FALSE)
+        FROM cbr_scope driver_scope
+        WHERE driver_scope.id = i.scope_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.id
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - {id: 1, joined_can_view: true, driver_can_view: true}
+        - {id: 5, joined_can_view: true, driver_can_view: true}
+        - {id: 9, joined_can_view: true, driver_can_view: true}
+
   - name: "nullable join node costs its own scalar probe work"
     sql: |
       EXPLAIN SELECT COUNT(*)

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -130,6 +130,7 @@ type calibrationRow struct {
 	LowerBoundNS                     float64  `json:"lower_bound_ns"`
 	CandidateInputRows               *float64 `json:"candidate_input_rows"`
 	CandidateRows                    *float64 `json:"candidate_rows"`
+	CarrierRows                      *float64 `json:"carrier_rows"`
 	CandidateDensity                 *float64 `json:"candidate_density"`
 	ProjectedDriverRows              *float64 `json:"projected_driver_rows"`
 	DriverInputRows                  *float64 `json:"driver_input_rows"`
@@ -248,7 +249,11 @@ func main() {
 			fatal(err)
 		}
 	}
-	training := filterObservations(observations, false)
+	// Coefficient fitting remains scoped to the membership-carrier family. Other
+	// calibrated decision families are executed and result-checked above, but
+	// must not be mistaken for additional equations of this coefficient model.
+	membershipObservations := filterDecisionObservations(observations, "membership_carrier")
+	training := filterObservations(membershipObservations, false)
 	carrierTraining := filterCarrierObservations(training)
 	fitTraining := filterCompleteExactPairs(carrierTraining)
 	if err := validateMeasurementSignal(fitTraining); err != nil {
@@ -268,7 +273,7 @@ func main() {
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS, c.scalarPresenceProbeRowNS,
 		c.membershipDirectProbeRowNS)
 	printModelComparison("training", training, c)
-	holdout := filterObservations(observations, true)
+	holdout := filterObservations(membershipObservations, true)
 	if len(holdout) > 0 {
 		printModelComparison("holdout", holdout, c)
 		if err := validateDecisionOrdering(holdout, c); err != nil {
@@ -278,7 +283,7 @@ func main() {
 			fatal(fmt.Errorf("holdout: %w", err))
 		}
 	}
-	printDecisionOrdering(observations, c)
+	printDecisionOrdering(membershipObservations, c)
 	if *patch {
 		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
@@ -870,10 +875,18 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 	if row.DecisionID != decisionID || row.Plan != plan || !row.OperatorConsistent || row.OperatorFamily != plan {
 		return fmt.Errorf("forced race variant did not emit the requested operator: %+v", row)
 	}
-	if row.EstimatedNS == nil || row.CandidateInputRows == nil || row.CandidateRows == nil ||
-		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil ||
-		row.WholeQueryExecutionNS <= 0 {
+	if row.EstimatedNS == nil || row.WholeQueryExecutionNS <= 0 {
 		return fmt.Errorf("forced race variant has incomplete measurements: %+v", row)
+	}
+	if row.Decision == "ordered_recset_consumer" {
+		if row.CarrierRows == nil || row.DriverInputRows == nil || row.Limit == nil {
+			return fmt.Errorf("ordered RecSet variant has incomplete measurements: %+v", row)
+		}
+		return nil
+	}
+	if row.CandidateInputRows == nil || row.CandidateRows == nil ||
+		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil {
+		return fmt.Errorf("membership variant has incomplete measurements: %+v", row)
 	}
 	return nil
 }
@@ -1027,6 +1040,16 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	// Ordered scalar-RecSet consumer observations validate a second physical
+	// decision family. They deliberately reuse the membership coefficients but
+	// do not participate in fitting them: both alternatives share the (possibly
+	// complex) carrier producer, while this decision measures only its consumer.
+	if row.Decision == "ordered_recset_consumer" {
+		if row.CarrierRows == nil || row.DriverInputRows == nil || row.Limit == nil {
+			return nil, fmt.Errorf("ordered RecSet consumer contains nil inputs: %+v", row)
+		}
+		return make([]float64, 17), nil
+	}
 	scanInvocations := *row.CandidateScanInvocations + *row.DriverScanInvocations
 	driverWorkRows := *row.DriverInputRows
 	if row.Plan == "driver_order_membership_probe" || row.Plan == "scan_order" {
@@ -1510,6 +1533,16 @@ func filterRankObservations(rows []observation) []observation {
 	filtered := make([]observation, 0, len(rows))
 	for _, row := range rows {
 		if row.component == "" {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func filterDecisionObservations(rows []observation, decision string) []observation {
+	filtered := make([]observation, 0, len(rows))
+	for _, row := range rows {
+		if row.decision == decision {
 			filtered = append(filtered, row)
 		}
 	}


### PR DESCRIPTION
## What

Make decorrelated compound boolean scalar stages reachable as physical probe carriers, then choose the carrier consumer at the join-tree node with the calibrated cost model.

## Architecture

- recursively recognize boolean CASE/AND/OR/NOT/comparison/COALESCE trees instead of two fixed aggregate shapes
- preserve scalar/presence probe markers through the physical phase boundary instead of eagerly turning them back into relational JOIN sources
- lower exact boolean trees to RecSet union/intersection/complement and key projection
- keep query-invariant probes inside closed Boolean producers, so cardinality observation can execute them before the main plan without capturing undefined lexical bindings
- separate row-varying domain keys from session-domain keys when projecting carriers
- apply the same ordered RecSet consumer decision in single-source and join-tree leaf lowering
- compare direct ordered RecSet iteration with ordered base access plus membership probes using calibrated costs
- observe exact request-local carrier cardinality once, reuse the prepared carrier, and install a crossover recompile guard
- feed filter lowering the same node-local work estimate already used by projection lowering
- add the ordered consumer as its own calibration decision family without contaminating membership-carrier coefficient fitting

Dominance is used only where one representation is semantically and physically redundant (an exact boolean result needs no mutable group table). Cardinality-dependent consumer choices stay costed and guarded.

The follow-up fix makes RecSet operator feasibility respect lexical ownership. A producer may close correlated children, or reference query-scope invariant children, but a direct mixture of both sibling ownership models cannot be captured by one generated closure. That mixed direct shape now remains on the ordinary exact carrier. The decision uses domain/lookup ownership facts, not SQL syntax, stale purpose tags, table size, or index existence. Transitive mixtures already closed inside a child remain eligible.

Consumer lookup keys are now bound through an explicit generated-lambda parameter before producer initialization. This prevents numbered-scope references from escaping when several correlated projections share one continuation.

## Correctness coverage

Regression coverage includes:

- compound CASE + OR + EXISTS + nested scalar COALESCE
- broad ordered drivers above the old promotion threshold
- multi-source LEFT JOIN consumers
- session-domain plus row-domain projection
- query-invariant EXISTS and NOT inside a carrier prepared by observation
- nullable boolean value contexts remaining outside truth-only RecSet lowering
- exact RecSet NOT/difference semantics
- one shared boolean carrier consumed by joined projections
- a row-correlated driver carrier beside an independently derived boolean projection

The observation and closure regressions are execution tests, not only EXPLAIN assertions. They catch both an empty carrier caused by evaluating a lexical invariant before its binding existed and the later `NthLocalVar(...) out of range` failure caused by a consumer lookup escaping its row closure.

## MySQL protocol safety

Internal panics continue to be logged in full on the server. MySQL clients now receive only the actionable first line, bounded to 2 KiB. This prevents a large internal stack from being misreported by mysqlnd as error 2035 (`Packet buffer wasn't big enough`) and keeps the original server-side diagnostic available.

## Production-copy A/B

Exact saved application SELECT, same data and session binding:

| build | cold | warm | rows |
|---|---:|---:|---:|
| current master | 5.39 s | - | 72 |
| this PR | 3.84 s | 1.19 s | 72 |

The isolated ACL/order query completes in 0.85 s. Master and both PR runs produced the same SHA-256 over the complete 72-row output.

EXPLAIN PHYSICAL reports `boolean_stage_recset` followed by `ordered_recset_consumer`; for this binding it observes 855,496 carrier rows and selects `ordered_base_membership` with a recorded crossover of about 11,039 rows. Both direct RecSet and base-membership alternatives remain available.

The later broad joined/projection query that exposed the closure defect previously failed internally and surfaced as mysqlnd error 2035. With the closure fix it returned all 72 rows without protocol error in 19.30 s. The server on API 4521/MySQL 3521 is now running the final branch build for application verification.

## Validation

- startup Scheme tests: 1267/1267
- compound boolean RecSet suite: 23/23
- ACL boolean membership/scaling suite: 24/24
- derived-table LIMIT/scalar suite: 39/39
- EXISTS suite: 35/35
- IN/NOT IN suite: 71/71
- `go test ./scm/`
- `go build -o memcp .`
- Scheme formatter/check on both changed planner files
- full hook-equivalent repository suite: green (`make test`)
