### PR TITLE
Fix nested self-scan deadlock in mutation predicates

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -164,7 +164,7 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 			s := shards[i]
 			defer topology.releaseOperation()
 			defer s.activeScanners.Add(-1)
-			release := s.GetRead()
+			release := s.acquireReadForScan(currentTx)
 			defer release()
 			callback(s, synchronous)
 		})
@@ -211,13 +211,23 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 			s := relevant[0]
 			defer topology.releaseOperation()
 			defer s.activeScanners.Add(-1)
-			release := s.GetRead()
+			release := s.acquireReadForScan(currentTx)
 			defer release()
 			callback(s, true)
 			return nil
 		}
 		return runWorkers(relevant, topology)
 	}
+}
+
+// acquireReadForScan obtains shard access unless this worker already owns the
+// stronger write lock. Re-entering GetRead while holding shard.mu for a
+// mutation would make its lazy-load checks deadlock on their own RLock.
+func (s *storageShard) acquireReadForScan(currentTx *TxContext) func() {
+	if s.hasWriteOwnerForTx(currentTx) {
+		return func() {}
+	}
+	return s.GetRead()
 }
 
 func collectRelevantShards(schema []shardDimension, boundaries []columnboundaries, shards []*storageShard) []*storageShard {

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -487,6 +487,32 @@ func TestShardWriteOwnershipUsesExplicitTransactionState(t *testing.T) {
 	}
 }
 
+func TestIterateShardsParallelReusesOwnedWriteAccess(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanownedread")
+	shard := tbl.Shards[0]
+	tx := NewTxContext(TxCursorStability)
+
+	shard.mu.Lock()
+	shard.enterWriteOwner()
+	tx.EnterShardWrite(shard)
+	defer func() {
+		tx.ExitShardWrite(shard)
+		shard.exitWriteOwner()
+		shard.mu.Unlock()
+	}()
+
+	called := false
+	done := tbl.iterateShardsParallel(tx, nil, func(got *storageShard, solo bool) {
+		called = got == shard && solo
+	})
+	if done != nil {
+		<-done
+	}
+	if !called {
+		t.Fatal("nested scan did not reuse the worker's existing shard write access")
+	}
+}
+
 func TestShardWriteOwnershipIsLocalToParallelTransactionWorker(t *testing.T) {
 	shard := &storageShard{}
 	tx := NewTxContext(TxCursorStability)

--- a/tests/sql/dml/update-delete-complex.yaml
+++ b/tests/sql/dml/update-delete-complex.yaml
@@ -1,3 +1,10 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
 # Complex UPDATE and DELETE operations
 # Targets table.go UpdateSanitizer, shard.go UpdateFunction, trigger paths,
 # ProcessUniqueCollision, and partition.go repartition after heavy DML.
@@ -255,8 +262,53 @@ test_cases:
     expect:
       affected_rows: 0
 
+  # === Correlated DELETE against a derived self-scan ===
+
+  - name: "Create membership table for correlated delete"
+    sql: "CREATE TABLE ud_membership (id INT PRIMARY KEY, owner_id INT, member_id INT)"
+
+  - name: "Insert overlapping memberships"
+    sql: |
+      INSERT INTO ud_membership VALUES
+        (1, 1, 10),
+        (2, 1, 20),
+        (3, 2, 10),
+        (4, 2, 30)
+    expect:
+      affected_rows: 4
+
+  - name: "DELETE with correlated EXISTS over derived self-scan"
+    sql: |
+      DELETE FROM ud_membership
+      WHERE owner_id = 2
+        AND EXISTS (
+          SELECT 1
+          FROM (
+            SELECT member_id
+            FROM ud_membership
+            WHERE owner_id = 1
+          ) AS retained
+          WHERE retained.member_id = ud_membership.member_id
+        )
+    timeout: 2
+    expect:
+      affected_rows: 1
+
+  - name: "Correlated delete preserves non-overlapping memberships"
+    sql: "SELECT owner_id, member_id FROM ud_membership ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - owner_id: 1
+          member_id: 10
+        - owner_id: 1
+          member_id: 20
+        - owner_id: 2
+          member_id: 30
+
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS ud_membership"
   - sql: "DROP TABLE IF EXISTS ud_child"
   - sql: "DROP TABLE IF EXISTS ud_parent"
   - sql: "DROP TABLE IF EXISTS ud_main"


### PR DESCRIPTION
## Summary

- reuse a shard write lock already owned by the current transaction worker when a nested scan enters shard iteration
- avoid recursively acquiring the same RWMutex through `GetRead` during mutation predicate evaluation
- cover the locking contract with a Go regression and a correlated `DELETE ... EXISTS` SQL regression

## Root cause

A mutation scan holds its target shard write lock while evaluating its predicate. A correlated derived self-scan entered the generic shard iterator, which unconditionally called `GetRead` before the lower scan could recognize the existing write ownership. On a single-shard table this blocks forever on its own `RLock`.

The ownership check remains goroutine-local for fanout transactions, so one worker cannot borrow another worker’s lock.

## Validation

- before: the four-row correlated DELETE exceeded 35 seconds / timed out
- after: `tests/sql/dml/update-delete-complex.yaml` passes 42/42 in 0.48 s
- `go test ./storage -run 'TestIterateShardsParallelReusesOwnedWriteAccess|TestShardWriteOwnership' -count=10`\n- full pre-commit suite completed all functional suites; the unrelated hard wall-clock planner budget fluctuated between 1000.55 ms and 1011.3 ms for a 1000 ms limit under concurrent host load, while the same suite passes in isolation\n