### PR TITLE
Calibrate compound membership consumers holistically

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2824,6 +2824,29 @@ their tighter direct bound; this product is only an additional candidate. */
 				(planner_source_row_count input)
 				nil)))))
 
+/* Equality bindings for every column of a unique key are a cardinality proof,
+not a selectivity guess: the branch can return at most one row for any runtime
+binding. Runtime sampling may still report the table-wide fallback before the
+corresponding autoindex exists. Cap that estimate here so UNION membership
+planning preserves the proven bound without consulting index availability. */
+(define planner_unique_point_filter_estimate (lambda (src condition estimate)
+	(if (not (join_optimizer_source_constant_unique_point?
+		(list src) (source_alias src) src condition))
+		estimate
+		(begin
+			(define input_rows (planner_source_row_count src))
+			(define base (coalesceNil estimate (list
+				(list (quote input) input_rows)
+				(list (quote population) (quote table_rows))
+				(list (quote coverage) (quote exact)))))
+			(qassoc_set
+				(qassoc_set
+					(qassoc_set base (quote rows)
+						(min 1 (coalesceNil (qassoc_get base (quote rows) nil) 1)))
+					(quote estimated_rows)
+					(min 1 (coalesceNil (qassoc_get base (quote estimated_rows) nil) 1)))
+				(quote capped) false)))))
+
 (define planner_stage_filter_estimate (lambda (input max_rows)
 	(if (union_block? input)
 		(begin
@@ -2858,7 +2881,9 @@ their tighter direct bound; this product is only an additional candidate. */
 			(if (single_source? (qb_sources input))
 				(begin
 					(define src (car (qb_sources input)))
-					(planner_source_filter_estimate src (combine_where (qb_where input) (source_join_expr src)) max_rows))
+					(define condition (combine_where (qb_where input) (source_join_expr src)))
+					(planner_unique_point_filter_estimate src condition
+						(planner_source_filter_estimate src condition max_rows)))
 				nil)
 			nil))))
 
@@ -3076,6 +3101,39 @@ either physical alternative or sampling the table again. */
 			(qassoc_set profile (quote map_columns)
 				(max (qassoc_get profile (quote map_columns) 0) (count (qb_fields block))))))))
 
+/* Count row-rejecting relations which remain after the membership carrier.
+This fact must be captured while the complete logical source set is still
+available: physical membership rewriting removes the candidate relation and
+probe promotion may replace a correlated LEFT JOIN by an expression marker.
+Each surviving non-membership relation is one downstream probe unit; nested
+work remains part of that relation's calibrated per-probe cost. Sibling
+membership stages are alternatives within the same canonical predicate and
+are already represented by membership_candidate_probe_branches. Counting them
+again here would make one carrier choice recursively tax the others.
+Projection-only LEFT JOINs do not reject rows and therefore do not affect the
+carrier crossover. */
+(define membership_downstream_probe_branches (lambda (stage driver sources block)
+	(if (nil? driver)
+		0
+		(begin
+			(define default_alias (qassoc_get (qb_facts block)
+				(quote default_alias) (source_alias driver)))
+			(count (filter (coalesceNil sources '()) (lambda (src)
+				(begin
+					(define relation (source_relation src))
+					(define downstream_stage (if (stage_output_relation? relation)
+						(stage_by_id (qb_stages block) (stage_output_relation_id relation)) nil))
+					(define downstream_purpose (if (group_stage? downstream_stage)
+						(qassoc_get (gs_facts downstream_stage) (quote purpose) nil) nil))
+					(and (not (equal? (source_alias src) (source_alias driver)))
+						(and (not (and (stage_output_relation? relation)
+							(equal? (stage_output_relation_id relation) (gs_id stage))))
+							(and (not (contains? (list (quote in_membership) (quote in_candidate))
+								downstream_purpose))
+								(or (not (source_outer? src))
+									(expr_refs_alias? default_alias (source_alias src)
+										(qb_where block)))))))))))))))
+
 (define candidate_reorder_telemetry (lambda (stage sources block)
 	(begin
 		(define driver (reduce (coalesceNil sources '()) (lambda (found src)
@@ -3139,6 +3197,8 @@ either physical alternative or sampling the table again. */
 			(list (quote membership_candidate_estimate_population) estimate_population)
 			(list (quote membership_candidate_estimate_coverage) estimate_coverage)
 			(list (quote membership_candidate_probe_branches) candidate_probe_branches)
+			(list (quote membership_downstream_probe_branches)
+				(membership_downstream_probe_branches stage driver sources block))
 			(list (quote membership_candidate_scan_invocations) (qassoc_get candidate_work (quote scan_invocations) candidate_probe_branches))
 			(list (quote membership_candidate_filter_columns) (qassoc_get candidate_work (quote filter_columns) 0))
 			(list (quote membership_candidate_map_columns) (qassoc_get candidate_work (quote map_columns) (count (gs_keys stage))))
@@ -3447,6 +3507,18 @@ physical alternative. */
 				(* candidate_rows planner_membership_group_cache_build_row_ns)
 				(* candidate_rows 8) 0 candidate_rows 0.65)
 			(planner_zero_cost candidate_rows 0.65)))
+		/* A projected RecSet is not free to consume under ORDER/LIMIT. Unlike an
+		ordered base scan it must fetch the ordering columns at the projected row
+		positions and order the complete carrier before LIMIT can brake. Keep this
+		consumer term in the same candidate-vs-driver decision: a later shape-specific
+		selector would compare two incomplete plans and could mask the calibrated
+		carrier inequality. */
+		(define ordered_recset_consumer_cost (if
+			(membership_work_value work (quote membership_order_limit_driver) false)
+			(planner_cost 0
+				(* projected_rows planner_membership_ordered_recset_row_ns)
+				0 0 0 0 0 0 projected_rows 0.75)
+			(planner_zero_cost projected_rows 0.75)))
 		(define base_cost (planner_cost_add (planner_cost_add
 			(planner_cost_add
 				(membership_common_scan_cost candidate_input_rows candidate_rows projection_rows
@@ -3464,10 +3536,12 @@ physical alternative. */
 				(* (+ candidate_rows projected_rows) 8) 0 projection_rows 0.65)
 			projection_rows 0.65)
 			candidate_cache_cost projection_rows 0.65))
-		(define downstream_cost (planner_membership_direct_probe_cost
+		(define downstream_cost (planner_membership_downstream_probe_cost
 			(* projected_rows
 				(membership_work_value work (quote membership_downstream_probe_branches) 0))))
-		(define carrier_cost (planner_cost_add base_cost downstream_cost projected_rows 0.65))
+		(define carrier_cost (planner_cost_add
+			(planner_cost_add base_cost ordered_recset_consumer_cost projected_rows 0.65)
+			downstream_cost projected_rows 0.65))
 		(if (equal? (membership_work_value work (quote membership_consumer) (quote filter))
 			(quote aggregate))
 			(planner_cost_add carrier_cost
@@ -3480,8 +3554,10 @@ physical alternative. */
 membership edge before an expensive candidate predicate runs. The emitted
 tree scans the driver once, projects its exact RecSet to the candidate source,
 filters only that subset, projects matches back, and intersects with the
-original driver RecSet. Cost it entirely from the same calibrated scan,
-expression, and RecSet components used by the other membership carriers. */
+original driver RecSet. Independent downstream predicates are planned for the
+complete local driver subset before that intersection, so candidate density
+must not discount their work. Cost the exact emitted order from the same
+calibrated components used by the other membership carriers. */
 (define membership_prefiltered_candidate_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
 	(begin
 		(define driver_input_rows (membership_driver_input_rows driver_rows work))
@@ -3531,18 +3607,22 @@ expression, and RecSet components used by the other membership carriers. */
 			(* projection_rows planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
 			0 driver_rows 0.65)
-			(planner_membership_direct_probe_cost
-				(* driver_rows candidate_density
+			(planner_membership_downstream_probe_cost
+				(* driver_rows
 					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			driver_rows 0.65))))
 
-(define membership_driver_probe_cost (lambda (driver_rows probe_branches)
+(define membership_driver_probe_cost (lambda (driver_rows probe_branches downstream_probe_branches)
 	(begin
 		(define probes (* driver_rows probe_branches))
 		/* A driver membership check lowers each candidate branch to an indexed
 		point-presence probe. Keep that storage subscan distinct from the ordered
 		candidate-key index calibrated below. */
-		(planner_membership_direct_probe_cost probes))))
+		(planner_cost_add
+			(planner_membership_direct_probe_cost probes)
+			(planner_membership_downstream_probe_cost
+				(* driver_rows downstream_probe_branches))
+			driver_rows 0.75))))
 
 (define membership_ordered_driver_probe_cost (lambda (candidate_input_rows candidate_rows driver_rows work)
 	(begin
@@ -3568,7 +3648,7 @@ expression, and RecSet components used by the other membership carriers. */
 					(* candidate_rows 8) 0 (+ candidate_rows visited_rows) 0.65))
 			visited_rows 0.65))
 		(define carrier_cost (planner_cost_add base_cost
-			(planner_membership_direct_probe_cost
+			(planner_membership_downstream_probe_cost
 				(* visited_rows
 					(membership_work_value work (quote membership_downstream_probe_branches) 0)))
 			visited_rows 0.65))
@@ -3590,7 +3670,8 @@ expression, and RecSet components used by the other membership carriers. */
 			(list driver_strategy
 				(if (equal? driver_strategy (quote driver_order_membership_probe))
 					(membership_ordered_driver_probe_cost candidate_input_rows candidate_rows driver_rows work)
-					(membership_driver_probe_cost driver_rows probe_branches)))))))
+					(membership_driver_probe_cost driver_rows probe_branches
+						(membership_work_value work (quote membership_downstream_probe_branches) 0))))))))
 
 (define membership_cost_options_for_telemetry (lambda (telemetry)
 	(begin

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1399,19 +1399,58 @@ membership set. */
 				(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 				true)))))
 
+/* A decorrelated base-table presence stage already is a semijoin relation:
+scan the child-side predicate, then let its grouping columns identify the true
+domain keys. This carrier is closed before the parent-domain scan and therefore
+must not initialize a correlated group-cache column which still expects a
+lexical outer row. Projection and key-index consumers can both reuse the same
+(prepare, RecSet, source-key-columns) representation below. */
+(define direct_base_presence_recset_source_parts (lambda (stage)
+	(if (or (not (qassoc_get (gs_facts stage) (quote direct_presence_recset_context) false))
+		(or (not (presence_probe_stage? stage))
+		(or (not (source_is_base_table? (gs_input stage)))
+			(stage_has_residual_outer_refs? stage))))
+		nil
+		(begin
+			(define src (gs_input stage))
+			(define source_key_cols (map (gs_keys stage) (lambda (key)
+				(direct_column_name_for_alias src key))))
+			(if (or (empty_list? source_key_cols)
+				(reduce source_key_cols (lambda (invalid col)
+					(or invalid (nil? col))) false))
+				nil
+				(begin
+					(define condition (coalesceNil
+						(qassoc_get (gs_facts stage) (quote condition) true) true))
+					(define filtercols (extract_columns_for_alias src condition))
+					(list true
+						(list (quote scan_recset)
+							(list (quote session) "__memcp_tx")
+							(source_table_expr src)
+							(cons (quote list) filtercols)
+							(list (quote lambda)
+								(map filtercols (lambda (col)
+									(symbol (concat (source_alias src) "." col))))
+								(lower_column_expr_for_alias src condition)))
+						source_key_cols)))))))
+
 (define direct_boolean_recset_query_scope_dependency? (lambda (stage)
 	(and (empty_list? (gs_domain stage))
 		(empty_list? (qassoc_get (gs_facts stage) (quote lookup-keys) '())))))
 
-(define direct_boolean_recset_input_ownership_closed? (lambda (stage_catalog stage)
+(define direct_boolean_recset_input_stages (lambda (stage_catalog stage)
 	(begin
 		(define owner_handle (qassoc_get (gs_facts stage) (quote btw2025_handle) nil))
-		(define direct_stages (unique_stages_by_id (merge (list
+		(unique_stages_by_id (merge (list
 			(stage_outputs_from_sources_using stage_catalog (qb_sources (gs_input stage)))
 			(if (nil? owner_handle) '()
 				(filter (lowering_catalog_stages stage_catalog) (lambda (candidate)
 					(equal? (qassoc_get (gs_facts candidate) (quote btw2025_parent) nil)
-						owner_handle))))))))
+						owner_handle))))))))))
+
+(define direct_boolean_recset_input_ownership_closed? (lambda (stage_catalog stage)
+	(begin
+		(define direct_stages (direct_boolean_recset_input_stages stage_catalog stage))
 		(define has_invariant (reduce direct_stages (lambda (found dependency)
 			(or found (direct_boolean_recset_query_scope_dependency? dependency))) false))
 		(define has_correlated (reduce direct_stages (lambda (found dependency)
@@ -1436,8 +1475,26 @@ membership set. */
 								(gs_input stage)
 								(scalar_first_probe_recset_row_keys stage carrier_src))))))))))))
 
-(define lower_direct_boolean_stage_recset_expr (lambda (stage_catalog stage share_result)
+(define lower_direct_boolean_stage_recset_expr (lambda (stage_catalog stage share_result allow_direct_presence)
 	(begin
+		/* A projected outer carrier closes its complete boolean tree before any
+		driver callback. Overlay only the presence leaves so they can use their direct
+		semijoin RecSet; unrelated stages remain in the indexed parent catalog. A
+		per-row key-index consumer leaves the catalog unchanged and retains the
+		canonical shared group relation. */
+		(define direct_catalog (if allow_direct_presence
+			(begin
+				(define annotated_presence_stages (map
+					(filter (lowering_catalog_stages stage_catalog) presence_probe_stage?)
+					(lambda (candidate)
+						(group_stage_with_facts candidate
+							(qassoc_set (gs_facts candidate)
+								(quote direct_presence_recset_context) true)))))
+				(make_indexed_lowering_catalog annotated_presence_stages
+					(if (lowering_catalog? stage_catalog)
+						stage_catalog
+						(make_indexed_lowering_catalog stage_catalog nil))))
+			stage_catalog))
 		(define decision_id (concat "boolean_stage_recset:" (gs_id stage)))
 		(planner_record_physical_decision (list
 			(list "decision_id" decision_id)
@@ -1454,7 +1511,7 @@ membership set. */
 		The resulting expression has no lexical outer-row dependency and is therefore
 		safe to share between filters and projections in this query generation. */
 		(define producer (lower_group_stage_prepare_using
-			stage_catalog stage_catalog stage true (quote boolean-recset)))
+			direct_catalog direct_catalog stage true (quote boolean-recset)))
 		(if share_result
 			(list
 				(physical_query_session_symbol)
@@ -1464,17 +1521,22 @@ membership set. */
 				(list (quote lambda) '() producer))
 			producer))))
 
-(define scalar_first_probe_recset_source_parts (lambda (all_stages stage requested_col share_result)
+(define scalar_first_probe_recset_source_parts (lambda (all_stages stage requested_col share_result allow_direct_presence)
 	(begin
 		(define probe_catalog (qassoc_get (gs_facts stage) (quote probe_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
 			(merge_stage_catalogs (list all_stages probe_catalog (nested_stage_catalog stage)))))
+		(define catalog_stage (stage_by_id stage_catalog (gs_id stage)))
 		(define physical_stage (if (empty_list? probe_catalog)
-			stage
-			(group_stage_with_stage_catalog stage stage_catalog)))
+			(coalesceNil catalog_stage stage)
+			(group_stage_with_stage_catalog (coalesceNil catalog_stage stage) stage_catalog)))
 		(define graph (stage_dependency_graph stage_catalog))
-		(if (direct_boolean_recset_stage_eligible?
-			stage_catalog graph physical_stage requested_col)
+		(define direct_presence_parts
+			(direct_base_presence_recset_source_parts physical_stage))
+		(if (not (nil? direct_presence_parts))
+			direct_presence_parts
+			(if (direct_boolean_recset_stage_eligible?
+				stage_catalog graph physical_stage requested_col)
 			(begin
 				(define carrier_src (scalar_first_probe_carrier_source
 					(gs_input physical_stage)))
@@ -1484,7 +1546,7 @@ membership set. */
 					(gs_input physical_stage) row_keys))
 				(list true
 					(lower_direct_boolean_stage_recset_expr
-						stage_catalog physical_stage share_result)
+						stage_catalog physical_stage share_result allow_direct_presence)
 					(map row_keys (lambda (key)
 						(direct_column_name_for_alias domain_src key)))))
 			(begin
@@ -1510,13 +1572,16 @@ membership set. */
 						(list (quote table) cache_schema cache_relation)
 						(quoted_runtime_list (list requested_col))
 						(list (quote lambda) (list (symbol requested_col))
-							(list (quote equal??) (symbol requested_col) true)))
-					(list (nth (group_key_cols (gs_keys physical_stage)) row_key_index))))))))
+							(if (presence_probe_stage? physical_stage)
+								(list (quote >)
+									(list (quote coalesceNil) (symbol requested_col) 0) 0)
+								(list (quote equal??) (symbol requested_col) true))))
+					(list (nth (group_key_cols (gs_keys physical_stage)) row_key_index)))))))))
 
 (define lower_recset_scalar_first_probe_expr (lambda (all_stages stage requested_col resolved_lookup_key)
 	(begin
 		(define source_parts
-			(scalar_first_probe_recset_source_parts all_stages stage requested_col true))
+			(scalar_first_probe_recset_source_parts all_stages stage requested_col true false))
 		(define lookup_key (recset_scalar_first_probe_lookup_key stage))
 		(define lookup_value (symbol (concat "__recset_lookup_value_"
 			(fnv_hash (gs_id stage)))))
@@ -1554,7 +1619,7 @@ choice at the consuming join edge. */
 	(begin
 		(define source_parts
 			(scalar_first_probe_recset_source_parts
-				all_stages stage requested_col share_result))
+				all_stages stage requested_col share_result true))
 		(define source_key_cols (nth source_parts 2))
 		(if (not (equal? (count source_key_cols) 1))
 			(neumann_fail "build_queryplan" "projected scalar RecSet has no resolved row-domain key")
@@ -3177,7 +3242,15 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				(qassoc_set facts (quote membership_consumer) (quote aggregate))
 				facts)
 			(quote membership_downstream_probe_branches)
-			(coalesceNil downstream_probe_branches 0)))
+			/* ORDER/LIMIT carriers change how many rows reach downstream work even
+			when adaptive batching is structurally unavailable (for example an ordered
+			joined driver). Filter/aggregate carriers feed the same complete residual
+			pipeline, so charging their common work here would estimate the enclosing
+			query a second time. */
+			(if (equal? consumer (quote order_limit))
+				(max (coalesceNil downstream_probe_branches 0)
+					(qassoc_get facts (quote membership_downstream_probe_branches) 0))
+				0)))
 		(define driver_probe_supported (and allow_driver_probe
 			(membership_driver_subscan_supported? stage)))
 		(define raw_expr (recset_project_join_expr_for_membership_raw src membership))
@@ -3284,7 +3357,8 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 						(membership_ordered_driver_probe_cost
 							candidate_input_rows candidate_rows driver_rows cost_facts)
 						(membership_driver_probe_cost driver_rows
-							(qassoc_get facts (quote membership_candidate_probe_branches) 1)))
+							(qassoc_get facts (quote membership_candidate_probe_branches) 1)
+							(qassoc_get cost_facts (quote membership_downstream_probe_branches) 0)))
 					nil))
 				(define batch_cost_facts (if allow_ordered_batch
 					(merge (list
@@ -3457,6 +3531,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 							(list "estimate_population" (string estimate_population))
 							(list "estimate_coverage" (string estimate_coverage))
 							(list "probe_branches" (qassoc_get facts (quote membership_candidate_probe_branches) 1))
+							(list "downstream_probe_branches" (qassoc_get facts (quote membership_downstream_probe_branches) 0))
 							(list "selectivity_class" (string (qassoc_get facts (quote membership_selectivity_class) (quote unknown))))
 							(list "candidate_scan_invocations" (qassoc_get facts (quote membership_candidate_scan_invocations) 1))
 							(list "candidate_filter_columns" (qassoc_get facts (quote membership_candidate_filter_columns) 0))
@@ -6108,6 +6183,10 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_direct_probe_cost (lambda (probe_rows)
 	(planner_cost 0 0 (* probe_rows planner_membership_direct_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
+(define planner_membership_downstream_probe_row_ns 1372917)
+(define planner_membership_downstream_probe_cost (lambda (probe_rows)
+	(planner_cost 0 0 (* probe_rows planner_membership_downstream_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
 		(* domain_rows 8) 0 domain_rows 0.65)))
@@ -6132,4 +6211,5 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_probe_row_ns 1)
 (define planner_membership_ordered_driver_input_row_ns 1)
 (define planner_membership_ordered_scan_invocation_ns 3027639)
+(define planner_membership_ordered_recset_row_ns 1)
 /* END GENERATED COST CONSTANTS */

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -507,6 +507,13 @@ only partitioned FROM source would erase the block's row multiplicity
 		(merge_unique (map tail expr_probe_stages))
 		_ '())))
 
+(define physical_scalar_truth_plan_stages (lambda (plan)
+	(if (nil? plan)
+		'()
+		(begin
+			(define probe (physical_scalar_truth_plan_probe plan))
+			(if (nil? probe) '() (list (car probe)))))))
+
 (define query_block_probe_expr_stages (lambda (block)
 	(merge_unique (list
 		(expr_probe_stages (qb_sources block))
@@ -3027,7 +3034,7 @@ driver-predicate-first execution. Keeping those alternatives distinct makes
 the emitted work agree with the cost comparison. All residual conditions then
 re-enter the ordinary expression lowerer with the candidate-reduced row count,
 so complex ACL trees receive the same per-node physical choices as any scan. */
-(define ordered_batch_filter_expr (lambda (sources default_alias src condition memberships probe_work_rows acceptance_cols acceptance_probe)
+(define ordered_batch_filter_expr (lambda (sources default_alias src condition memberships required_recsets probe_work_rows acceptance_cols acceptance_probe)
 	(begin
 		(define input_batch (symbol "__ordered_input_batch"))
 		(define residual (reduce memberships (lambda (remaining membership)
@@ -3040,10 +3047,17 @@ so complex ACL trees receive the same per-node physical choices as any scan. */
 			(or unsupported (nil? expr))) false)
 			nil
 			(begin
-				(define membership_expr (if (empty_list? membership_exprs)
+				/* Exact carriers selected for independent conjuncts are part of the
+				batch input, not row callbacks. Intersecting them here preserves the same
+				AND semantics as the ordinary scan while retaining ordered braking. */
+				(define batch_inputs (merge (list
+					(list input_batch)
+					required_recsets
+					membership_exprs)))
+				(define membership_expr (if (equal? (count batch_inputs) 1)
 					input_batch
 					(list (quote recset_intersect)
-						(cons (quote list) (cons input_batch membership_exprs)))))
+						(cons (quote list) batch_inputs))))
 				(define residual_probe_work_rows
 					(batch_membership_survivor_rows memberships probe_work_rows))
 				(planner_record_physical_decision (list
@@ -3176,7 +3190,7 @@ RecSet; membership edges retain their own physical operators. */
 				planner_membership_recset_build_row_ns)
 			(* projection_rows 8)
 			0 visited_rows 0.55)
-			(planner_membership_direct_probe_cost
+			(planner_membership_downstream_probe_cost
 				(* visited_rows
 					(membership_candidate_density candidate_input_rows candidate_rows facts)
 					(qassoc_get facts (quote membership_downstream_probe_branches) 0)))
@@ -3397,7 +3411,9 @@ dependent choices must pass through this function and retain their guard. */
 							(+ (count (acceptance_required_sources
 								(membership_downstream_sources (qb_sources block) src membership)
 								alias raw_condition))
-								(count (expr_probe_stages raw_condition)))
+								(count (merge_unique (list
+									(expr_probe_stages raw_condition)
+									(physical_scalar_truth_plan_stages scalar_plan)))))
 							(not row_number_membership_consumer)))
 						(if (nil? plan) nil (list membership plan)))))
 					(lambda (entry) (not (nil? entry)))))
@@ -3526,7 +3542,9 @@ dependent choices must pass through this function and retain their guard. */
 						(or chosen (equal? (car (nth entry 1)) "ordered_batch_accept"))) false)))
 				(define batch_filter (if use_batch_accept
 					(ordered_batch_filter_expr (list src) alias src filter_condition
-						remaining_batch_memberships (probe_context_row_count (list src)) '() true)
+						remaining_batch_memberships
+						(if scalar_membership_filter (list scalar_membership_var) '())
+						(probe_context_row_count (list src)) '() true)
 					nil))
 				(define raw_map_row (list (quote resultrow)
 					(cons (quote list) (map_assoc bundled_fields (lambda (title expr)
@@ -4051,7 +4069,7 @@ move the window to the wrong tree level. */
 			acceptance_probe))
 		(define batch_filter (if use_batch_accept
 			(ordered_batch_filter_expr all_sources default_alias src condition
-				(list membership) acceptance_probe_work_rows acceptance_cols acceptance_probe)
+				(list membership) '() acceptance_probe_work_rows acceptance_cols acceptance_probe)
 			nil))
 		(if (and use_batch_accept (nil? batch_filter))
 			(neumann_fail "build_queryplan" "chosen ordered batch membership has no executable filter")
@@ -4632,7 +4650,9 @@ exact parameter value. */
 				(+ (count (acceptance_required_sources
 					(membership_downstream_sources all_sources src membership)
 					default_alias final_condition))
-					(count (expr_probe_stages final_condition)))
+					(count (merge_unique (list
+						(expr_probe_stages final_condition)
+						(physical_scalar_truth_plan_stages scalar_plan)))))
 				(not row_number_membership_consumer))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
@@ -4794,7 +4814,8 @@ exact parameter value. */
 			lowered_filter_condition))
 		(define batch_filter (if use_batch_accept
 			(ordered_batch_filter_expr all_sources default_alias src condition
-				(list membership) (probe_work_context_rows_for_alias probe_context alias) '() true)
+				(list membership) '()
+				(probe_work_context_rows_for_alias probe_context alias) '() true)
 			nil))
 		(define continuation_expr (continuation remaining_condition row_expr remaining_order_items))
 		(define map_body (if (equal? post_outer_condition true)
@@ -7207,6 +7228,7 @@ potentially large calibrated SELECT result. */
 							"limit" (physical_calibration_input decision "limit")
 							"offset" (physical_calibration_input decision "offset")
 							"probe_branches" (physical_calibration_input decision "probe_branches")
+							"downstream_probe_branches" (physical_calibration_input decision "downstream_probe_branches")
 							"candidate_scan_invocations" (physical_calibration_input decision "candidate_scan_invocations")
 							"candidate_filter_columns" (physical_calibration_input decision "candidate_filter_columns")
 							"candidate_map_columns" (physical_calibration_input decision "candidate_map_columns")

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -24,6 +24,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
   - sql: "DROP TABLE IF EXISTS pc_doc_meta"
+  - sql: "DROP TABLE IF EXISTS pc_acl_domain"
+  - sql: "DROP TABLE IF EXISTS pc_acl_assignment"
+  - sql: "DROP TABLE IF EXISTS pc_acl_override"
   # String-key membership prevents the target-side prefiltered projection and
   # isolates candidate startup from direct probe work.
   - sql: "DROP TABLE IF EXISTS pc_events"
@@ -42,6 +45,9 @@ setup:
   - sql: "CREATE TABLE pc_docs_large (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT, p2 INT, p3 INT, p4 INT, p5 INT, p6 INT, p7 INT, p8 INT)"
   - sql: "CREATE TABLE pc_docs_million (id INT PRIMARY KEY, file_id INT, sort_key INT, p1 INT) ENGINE=sloppy"
   - sql: "CREATE TABLE pc_doc_meta (id INT PRIMARY KEY, label VARCHAR(32))"
+  - sql: "CREATE TABLE pc_acl_domain (id INT PRIMARY KEY, direct_flag INT)"
+  - sql: "CREATE TABLE pc_acl_assignment (domain_id INT, actor_id INT, allowed INT)"
+  - sql: "CREATE TABLE pc_acl_override (domain_id INT, actor_id INT, allowed INT)"
   - sql: "CREATE TABLE pc_events (id INT PRIMARY KEY, entity_key VARCHAR(32), event_time INT, kind VARCHAR(16))"
   - sql: "CREATE TABLE pc_keys (id INT PRIMARY KEY, enabled INT)"
   - sql: "CREATE TABLE pc_files_text (id INT PRIMARY KEY, filename VARCHAR(255), search VARCHAR(255)) ENGINE=memory"
@@ -62,6 +68,12 @@ setup:
         (insert (table "memcp-tests" "pc_docs_large") '("id" "file_id" "sort_key" "p1" "p2" "p3" "p4" "p5" "p6" "p7" "p8") (make_docs 20000 5000))
         (insert (table "memcp-tests" "pc_doc_meta") '("id" "label")
           (map (produceN 5000) (lambda (i) (list i (concat "meta-" (string i))))))
+        (insert (table "memcp-tests" "pc_acl_domain") '("id" "direct_flag")
+          (map (produceN 5000) (lambda (i) (list i (if (equal? (mod i 11) 0) 1 0)))))
+        (insert (table "memcp-tests" "pc_acl_assignment") '("domain_id" "actor_id" "allowed")
+          (map (produceN 2500) (lambda (i) (list (* i 2) 7 1))))
+        (insert (table "memcp-tests" "pc_acl_override") '("domain_id" "actor_id" "allowed")
+          (map (produceN 1667) (lambda (i) (list (* i 3) 7 1))))
         (insert (table "memcp-tests" "pc_events") '("id" "entity_key" "event_time" "kind")
           (map (produceN 10000) (lambda (i)
             (list i (if (>= i 9990) "key:1" (concat "noise:" (string i))) i
@@ -111,6 +123,9 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_docs_large"
   - sql: "DROP TABLE IF EXISTS pc_docs_million"
   - sql: "DROP TABLE IF EXISTS pc_doc_meta"
+  - sql: "DROP TABLE IF EXISTS pc_acl_domain"
+  - sql: "DROP TABLE IF EXISTS pc_acl_assignment"
+  - sql: "DROP TABLE IF EXISTS pc_acl_override"
   - sql: "DROP TABLE IF EXISTS pc_events"
   - sql: "DROP TABLE IF EXISTS pc_keys"
   - sql: "DROP TABLE IF EXISTS pc_files_text"
@@ -513,6 +528,74 @@ test_cases:
         SELECT f.id FROM pc_files_wide f
         WHERE MATCH(f.search) AGAINST ('c' IN NATURAL LANGUAGE MODE)
       )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
+  # A tiny exact candidate set must remain eligible to drive the ordered scan.
+  # This holdout prevents a coefficient learned from broad/compound consumers
+  # from turning the cost model into an unconditional base-table preference.
+  - name: "production-scale tiny ordered membership holdout"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    calibration_holdout: true
+    race: true
+    race_grace: 0.5
+    cache_state: "cold_operator_state_race"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    warmup: 0
+    repetitions: 1
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.id = 4999
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.id = -1
+      )
+      ORDER BY d.sort_key, d.p1, d.id, d.file_id
+      LIMIT 72
+
+  # Reproduce the complete expensive suffix rather than calibrating membership
+  # in isolation. The candidate-vs-ordered-driver inequality must include the
+  # compound scalar/EXISTS work which follows the projected search RecSet.
+  - name: "ordered membership with compound ACL suffix"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    cache_state: "warm_operator_state"
+    compile_state: "cached_plan_execution_only"
+    expected_driver_input_rows: 4000
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT d.id, d.p1
+      FROM pc_docs_small d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_small f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_small f WHERE f.search LIKE '%hit%'
+      )
+        AND COALESCE((
+          SELECT CASE WHEN acl.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE
+              FROM pc_acl_assignment assignment
+              WHERE assignment.domain_id = acl.id
+                AND assignment.actor_id = 7
+                AND assignment.allowed = 1
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT override.allowed
+              FROM pc_acl_override override
+              WHERE override.domain_id = acl.id
+                AND override.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM pc_acl_domain acl
+          WHERE acl.id = d.file_id
+          LIMIT 1
+        ), FALSE)
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -80,6 +80,87 @@ setup:
         40000)
 
 test_cases:
+  - name: "Selective search RecSet retains the base order"
+    sql: |
+      EXPLAIN PHYSICAL SELECT d.id
+      FROM bqm_document d
+      WHERE d.file_id IN (
+        SELECT search_file.id
+        FROM bqm_file search_file
+        WHERE search_file.search LIKE '%needle-C-search%'
+        UNION
+        SELECT filename_file.id
+        FROM bqm_file filename_file
+        WHERE filename_file.filename LIKE '%needle-C-search%'
+      )
+        AND COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = 7
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      result_contains:
+        - "membership_carrier"
+        - "chosen ordered_batch_accept"
+        - "batch_predicate_lowering"
+
+  - name: "Selective search RecSet with ACL preserves ordered results"
+    sql: |
+      SELECT d.id
+      FROM bqm_document d
+      WHERE d.file_id IN (
+        SELECT search_file.id
+        FROM bqm_file search_file
+        WHERE search_file.search LIKE '%needle-C-search%'
+        UNION
+        SELECT filename_file.id
+        FROM bqm_file filename_file
+        WHERE filename_file.filename LIKE '%needle-C-search%'
+      )
+        AND COALESCE((
+          SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+            EXISTS (
+              SELECT TRUE FROM bqm_mandant_assignment ma
+              WHERE ma.standort_id = s.id
+                AND ma.actor_id = 7
+                AND ma.allowed = TRUE
+              LIMIT 1
+            ) OR COALESCE((
+              SELECT sa.allowed FROM bqm_standort_assignment sa
+              WHERE sa.standort_id = s.id
+                AND sa.actor_id = 7
+              LIMIT 1
+            ), FALSE)
+          ) END
+          FROM bqm_standort s
+          WHERE s.id = d.standort_id
+          LIMIT 1
+        ), FALSE)
+      ORDER BY d.id DESC
+      LIMIT 3
+    expect:
+      rows: 3
+      data:
+        - {id: 20510}
+        - {id: 20507}
+        - {id: 20501}
+
   - name: "outer count prunes unused derived and sorter lookups"
     max_time: 3
     setup:

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -140,6 +140,7 @@ type calibrationRow struct {
 	Limit                            *float64 `json:"limit"`
 	Offset                           *float64 `json:"offset"`
 	ProbeBranches                    *float64 `json:"probe_branches"`
+	DownstreamProbeBranches          *float64 `json:"downstream_probe_branches"`
 	CandidateScanInvocations         *float64 `json:"candidate_scan_invocations"`
 	CandidateFilterColumns           *float64 `json:"candidate_filter_columns"`
 	CandidateMapColumns              *float64 `json:"candidate_map_columns"`
@@ -200,6 +201,8 @@ type constants struct {
 	groupCacheProbeRowNS       int64
 	orderedDriverInputNS       int64
 	orderedScanInvocationNS    int64
+	orderedRecsetRowNS         int64
+	downstreamProbeRowNS       int64
 	scalarPresenceProbeRowNS   int64
 	membershipDirectProbeRowNS int64
 }
@@ -254,23 +257,25 @@ func main() {
 	// must not be mistaken for additional equations of this coefficient model.
 	membershipObservations := filterDecisionObservations(observations, "membership_carrier")
 	training := filterObservations(membershipObservations, false)
+	allTraining := filterObservations(observations, false)
 	carrierTraining := filterCarrierObservations(training)
 	fitTraining := filterCompleteExactPairs(carrierTraining)
 	if err := validateMeasurementSignal(fitTraining); err != nil {
 		fatal(err)
 	}
-	c, err := solve(carrierTraining, training, currentConstants)
+	c, err := solve(carrierTraining, allTraining, currentConstants)
 	if err != nil {
 		fatal(err)
 	}
+	logStep("selected downstream probe coefficient=%d ns/probe", c.downstreamProbeRowNS)
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
 	}
-	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered scan startup: %d ns/invocation\nscalar presence probe:%d ns/probe\nmembership probe:     %d ns/probe\n",
+	fmt.Printf("scan invocation:      %d ns/invocation\nscan row:             %d ns/input-row\nfilter column:        %d ns/value\nmap column:           %d ns/value\nexpression operation: %d ns/row-operation\nbroad text match:     %d ns/input-row + %d ns/input-byte\nrecset startup:       %d ns\nrecset build:         %d ns/matching-row\nrecset probe:         %d ns/driver-row\nrecset aggregate:     %d ns/driver-input-row\ngroup-cache startup:  %d ns\ngroup-cache build:    %d ns/matching-row\ngroup-cache probe:    %d ns/driver-row\nordered driver input: %d ns/(rows²/1M)\nordered scan startup: %d ns/invocation\nordered RecSet row:   %d ns/row\ndownstream probe:     %d ns/probe\nscalar presence probe:%d ns/probe\nmembership probe:     %d ns/probe\n",
 		c.scanInvocationNS, c.scanRowNS, c.filterColumnRowNS, c.mapColumnRowNS,
 		c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS, c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS, c.scalarPresenceProbeRowNS,
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS, c.orderedRecsetRowNS, c.downstreamProbeRowNS, c.scalarPresenceProbeRowNS,
 		c.membershipDirectProbeRowNS)
 	printModelComparison("training", training, c)
 	holdout := filterObservations(membershipObservations, true)
@@ -284,6 +289,25 @@ func main() {
 		}
 	}
 	printDecisionOrdering(membershipObservations, c)
+	orderedObservations := filterDecisionObservations(observations, "ordered_recset_consumer")
+	orderedTraining := filterObservations(orderedObservations, false)
+	if len(orderedTraining) > 0 {
+		printModelComparison("ordered-training", orderedTraining, c)
+		if err := validateDecisionOrdering(orderedTraining, c); err != nil {
+			fatal(fmt.Errorf("ordered consumer training: %w", err))
+		}
+	}
+	orderedHoldout := filterObservations(orderedObservations, true)
+	if len(orderedHoldout) > 0 {
+		printModelComparison("ordered-holdout", orderedHoldout, c)
+		if err := validateDecisionOrdering(orderedHoldout, c); err != nil {
+			fatal(fmt.Errorf("ordered consumer holdout: %w", err))
+		}
+		if err := validateModelImprovement(orderedHoldout, c); err != nil {
+			fatal(fmt.Errorf("ordered consumer holdout: %w", err))
+		}
+	}
+	printDecisionOrdering(orderedObservations, c)
 	if *patch {
 		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
@@ -1040,15 +1064,35 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
-	// Ordered scalar-RecSet consumer observations validate a second physical
-	// decision family. They deliberately reuse the membership coefficients but
-	// do not participate in fitting them: both alternatives share the (possibly
-	// complex) carrier producer, while this decision measures only its consumer.
+	// Ordered RecSet consumer variants share their producer. Their non-zero work
+	// vectors describe only the competing consumers so paired measurements can
+	// fit the cost without charging carrier construction to either alternative.
 	if row.Decision == "ordered_recset_consumer" {
 		if row.CarrierRows == nil || row.DriverInputRows == nil || row.Limit == nil {
 			return nil, fmt.Errorf("ordered RecSet consumer contains nil inputs: %+v", row)
 		}
-		return make([]float64, 17), nil
+		features := make([]float64, 19)
+		window := *row.Limit
+		if row.Offset != nil {
+			window += *row.Offset
+		}
+		visited := *row.DriverInputRows
+		if *row.CarrierRows > 0 {
+			visited = math.Min(visited, math.Max(window,
+				window**row.DriverInputRows / *row.CarrierRows))
+		}
+		switch row.Plan {
+		case "ordered_direct_recset":
+			features[15] = 1
+			features[17] = *row.CarrierRows
+		case "ordered_base_membership":
+			features[1] = visited
+			features[7] = visited
+			features[15] = 1
+		default:
+			return nil, fmt.Errorf("unsupported ordered RecSet plan %q", row.Plan)
+		}
+		return features, nil
 	}
 	scanInvocations := *row.CandidateScanInvocations + *row.DriverScanInvocations
 	driverWorkRows := *row.DriverInputRows
@@ -1083,6 +1127,21 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 	}
 	orderedDriverInputRows := 0.0
 	orderedScanInvocations := 0.0
+	downstreamProbeBranches := 0.0
+	if row.DownstreamProbeBranches != nil {
+		downstreamProbeBranches = *row.DownstreamProbeBranches
+	}
+	candidateDensity := 0.0
+	candidateProbeBranches := 1.0
+	if row.ProbeBranches != nil {
+		candidateProbeBranches = math.Max(1, *row.ProbeBranches)
+	}
+	if row.CandidateDensity != nil {
+		candidateDensity = *row.CandidateDensity
+	} else if *row.CandidateInputRows > 0 {
+		candidateDensity = math.Min(1,
+			*row.CandidateRows/(*row.CandidateInputRows/candidateProbeBranches))
+	}
 	if row.Limit != nil {
 		orderedDriverInputRows = *row.DriverInputRows * *row.DriverInputRows / 1_000_000
 		orderedScanInvocations = *row.DriverScanInvocations
@@ -1099,6 +1158,8 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			cacheStartup, cacheBuildRows, 0,
 			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
 			*row.CandidateBroadTextMatchBytes, orderedScanInvocations, 0,
+			orderedRecsetRows(row),
+			*row.ProjectedDriverRows * downstreamProbeBranches,
 		}, nil
 	case "driver_order_membership_probe", "scan_order":
 		recsetStartup, recsetBuildRows, recsetProbeRows := 1.0, *row.CandidateRows, *row.ExpectedDriverRowsVisited
@@ -1112,7 +1173,8 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			recsetStartup, recsetBuildRows, recsetProbeRows,
 			cacheStartup, cacheBuildRows, cacheProbeRows,
 			0, orderedDriverInputRows, 0,
-			0, orderedScanInvocations, 0,
+			0, orderedScanInvocations, 0, 0,
+			*row.ExpectedDriverRowsVisited * downstreamProbeBranches,
 		}, nil
 	case "ordered_batch_accept":
 		fraction := 1.0
@@ -1143,7 +1205,8 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			0, 0, 0, 0, 0, orderedDriverWork,
 			*row.CandidateBroadTextMatchRows * repeatFraction,
 			*row.CandidateBroadTextMatchBytes * repeatFraction,
-			batches * *row.DriverScanInvocations, 0,
+			batches * *row.DriverScanInvocations, 0, 0,
+			*row.ExpectedDriverRowsVisited * candidateDensity * downstreamProbeBranches,
 		}, nil
 	case "driver_filter_join_probe":
 		return []float64{
@@ -1151,7 +1214,8 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			0, 0, 0, 0, 0, 0,
 			aggregateDriverRows, 0, *row.CandidateBroadTextMatchRows,
 			*row.CandidateBroadTextMatchBytes, 0,
-			*row.DriverRows * *row.ProbeBranches,
+			*row.DriverRows * *row.ProbeBranches, 0,
+			*row.DriverRows * downstreamProbeBranches,
 		}, nil
 	case "prefiltered_candidate_keyset":
 		branches := math.Max(1, *row.ProbeBranches)
@@ -1172,11 +1236,19 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			1, projectionRows, 0, 0, 0, 0, 0, 0,
 			*row.CandidateBroadTextMatchRows * candidateFraction,
 			*row.CandidateBroadTextMatchBytes * candidateFraction,
-			orderedScanInvocations, 0,
+			orderedScanInvocations, 0, 0,
+			*row.PrefilteredDriverRows * downstreamProbeBranches,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
 	}
+}
+
+func orderedRecsetRows(row calibrationRow) float64 {
+	if row.Consumer == "order_limit" && row.ProjectedDriverRows != nil {
+		return *row.ProjectedDriverRows
+	}
+	return 0
 }
 
 // solveEquationSystem fits the physical work both alternatives actually perform:
@@ -1237,6 +1309,8 @@ func solveEquationSystem(rows []observation) (constants, error) {
 		recsetAggregateRowNS:       1,
 		orderedDriverInputNS:       1,
 		orderedScanInvocationNS:    1,
+		orderedRecsetRowNS:         1,
+		downstreamProbeRowNS:       1,
 		membershipDirectProbeRowNS: 1,
 	}, nil
 }
@@ -1281,18 +1355,41 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 			baseCorrect, fitCorrect, selected == fitted)
 	}
 
+	/* Residual fits isolate individual coefficients after the joint model has
+	been selected. They are still planner changes, not harmless duration
+	calibration: accepting one merely because it reduces residual error can undo
+	the selected model's inequalities. Apply each refinement atomically and only
+	when it fixes an additional measured decision across the complete pool. */
 	if value, ok := fitExactResidualPerRow(allRows, selected, 11); ok {
-		selected.recsetAggregateRowNS = value
+		trial := selected
+		trial.recsetAggregateRowNS = value
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
 	}
 	if value, ok := fitBroadTextResidualPerByte(allRows, selected); ok {
-		selected.broadTextMatchByteNS = value
+		trial := selected
+		trial.broadTextMatchByteNS = value
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
 	}
 	if value, ok := fitOrderedScanInvocation(allRows, selected); ok {
-		selected.orderedScanInvocationNS = value
+		trial := selected
+		trial.orderedScanInvocationNS = value
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
+	}
+	if value, ok := fitOrderedRecsetRow(allRows, selected); ok {
+		trial := selected
+		trial.orderedRecsetRowNS = value
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
+	}
+	if value, ok := fitDownstreamProbeRow(allRows, selected); ok {
+		trial := selected
+		trial.downstreamProbeRowNS = value
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
 	}
 	if startup, probe, ok := fitDirectCarrierPair(allRows, selected); ok {
-		selected.groupCacheStartupNS = startup
-		selected.membershipDirectProbeRowNS = probe
+		trial := selected
+		trial.groupCacheStartupNS = startup
+		trial.membershipDirectProbeRowNS = probe
+		selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
 	}
 	/* A race timeout mixes cold startup and incomplete operator work. It is a
 	lower bound for that whole alternative, not evidence for a linear ordered
@@ -1309,10 +1406,25 @@ func solve(exactRows, allRows []observation, baseline constants) (constants, err
 		without.broadTextMatchByteNS = 0
 		required := int64(math.Ceil((row.y - estimatedNS(row, without)) / row.x[14]))
 		if required > selected.broadTextMatchByteNS {
-			selected.broadTextMatchByteNS = required
+			trial := selected
+			trial.broadTextMatchByteNS = required
+			selected = acceptDecisionImprovingRefinement(allRows, selected, trial)
 		}
 	}
 	return selected, nil
+}
+
+func acceptDecisionImprovingRefinement(rows []observation, current, trial constants) constants {
+	currentCorrect, total := decisionAccuracy(rows, func(row observation) float64 {
+		return estimatedNS(row, current)
+	})
+	trialCorrect, _ := decisionAccuracy(rows, func(row observation) float64 {
+		return estimatedNS(row, trial)
+	})
+	if total > 0 && trialCorrect > currentCorrect {
+		return trial
+	}
+	return current
 }
 
 func fitBroadTextResidualPerByte(rows []observation, c constants) (int64, bool) {
@@ -1361,6 +1473,89 @@ func fitOrderedScanInvocation(rows []observation, c constants) (int64, bool) {
 	}
 	sort.Float64s(values)
 	return int64(math.Round(values[len(values)/2])), true
+}
+
+func fitOrderedRecsetRow(rows []observation, c constants) (int64, bool) {
+	direct := make(map[string]observation)
+	base := make(map[string]observation)
+	for _, row := range rows {
+		if row.censored || row.component != "" || len(row.x) <= 17 {
+			continue
+		}
+		switch row.plan {
+		case "candidate_keyset", "ordered_direct_recset":
+			if row.x[17] > 0 {
+				direct[row.caseName] = row
+			}
+		case "driver_order_membership_probe", "ordered_base_membership":
+			base[row.caseName] = row
+		}
+	}
+	values := make([]float64, 0)
+	for name, directRow := range direct {
+		baseRow, paired := base[name]
+		if !paired {
+			continue
+		}
+		without := c
+		without.orderedRecsetRowNS = 0
+		/* Carrier production and result emission are shared by the forced pair.
+		Subtracting the base alternative isolates the random ordered reads performed
+		only when the projected RecSet itself becomes the scan source. */
+		residual := (directRow.y - baseRow.y) -
+			(estimatedNS(directRow, without) - estimatedNS(baseRow, without))
+		values = append(values, math.Max(1, residual/directRow.x[17]))
+	}
+	if len(values) == 0 {
+		return 0, false
+	}
+	sort.Float64s(values)
+	return int64(math.Round(values[len(values)/2])), true
+}
+
+func fitDownstreamProbeRow(rows []observation, c constants) (int64, bool) {
+	byCase := make(map[string][]observation)
+	for _, row := range rows {
+		if !row.censored && row.component == "" && len(row.x) > 18 {
+			byCase[row.caseName] = append(byCase[row.caseName], row)
+		}
+	}
+	candidates := []int64{1, c.downstreamProbeRowNS}
+	without := c
+	without.downstreamProbeRowNS = 0
+	for _, alternatives := range byCase {
+		for leftIndex, left := range alternatives {
+			for _, right := range alternatives[leftIndex+1:] {
+				deltaWork := left.x[18] - right.x[18]
+				if deltaWork == 0 {
+					continue
+				}
+				value := ((left.y - right.y) -
+					(estimatedNS(left, without) - estimatedNS(right, without))) / deltaWork
+				if value >= 1 && !math.IsInf(value, 0) && !math.IsNaN(value) {
+					candidates = append(candidates, int64(math.Round(value)))
+				}
+			}
+		}
+	}
+	if len(candidates) == 2 && candidates[0] == candidates[1] {
+		return 0, false
+	}
+	best, bestCorrect, bestError := candidates[0], -1, math.Inf(1)
+	for _, candidate := range candidates {
+		trial := c
+		trial.downstreamProbeRowNS = candidate
+		correct, _ := decisionAccuracy(rows, func(row observation) float64 {
+			return estimatedNS(row, trial)
+		})
+		err := measureModelError(rows, func(row observation) float64 {
+			return estimatedNS(row, trial)
+		}).meanFactor
+		if correct > bestCorrect || (correct == bestCorrect && err < bestError) {
+			best, bestCorrect, bestError = candidate, correct, err
+		}
+	}
+	return best, true
 }
 
 func fitDirectCarrierPair(rows []observation, c constants) (int64, int64, bool) {
@@ -1485,6 +1680,8 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.broadTextMatchByteNS),
 		float64(c.orderedScanInvocationNS),
 		float64(c.membershipDirectProbeRowNS),
+		float64(c.orderedRecsetRowNS),
+		float64(c.downstreamProbeRowNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1568,6 +1765,7 @@ func filterCarrierObservations(rows []observation) []observation {
 
 func decisionAlternatives(rows []observation) (map[string]map[string]observation, error) {
 	groups := make(map[string]map[string]observation)
+	decisions := make(map[string]string)
 	for _, row := range rows {
 		if groups[row.caseName] == nil {
 			groups[row.caseName] = make(map[string]observation)
@@ -1575,21 +1773,34 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 		if _, duplicate := groups[row.caseName][row.plan]; duplicate {
 			return nil, fmt.Errorf("duplicate %s observation for %q", row.plan, row.caseName)
 		}
+		if existing := decisions[row.caseName]; existing != "" && existing != row.decision {
+			return nil, fmt.Errorf("mixed decision families for %q", row.caseName)
+		}
+		decisions[row.caseName] = row.decision
 		switch row.plan {
-		case "candidate_keyset", "driver_order_membership_probe", "driver_filter_join_probe", "ordered_batch_accept", "prefiltered_candidate_keyset":
+		case "candidate_keyset", "driver_order_membership_probe", "driver_filter_join_probe", "ordered_batch_accept", "prefiltered_candidate_keyset", "ordered_direct_recset", "ordered_base_membership":
 			groups[row.caseName][row.plan] = row
 		default:
 			return nil, fmt.Errorf("unsupported plan %q", row.plan)
 		}
 	}
 	for name, plans := range groups {
-		if _, ok := plans["candidate_keyset"]; !ok {
-			return nil, fmt.Errorf("incomplete alternatives for %q", name)
-		}
-		_, ordered := plans["driver_order_membership_probe"]
-		_, direct := plans["driver_filter_join_probe"]
-		if !ordered && !direct {
-			return nil, fmt.Errorf("incomplete alternatives for %q", name)
+		if decisions[name] == "ordered_recset_consumer" {
+			if _, direct := plans["ordered_direct_recset"]; !direct {
+				return nil, fmt.Errorf("incomplete ordered RecSet alternatives for %q", name)
+			}
+			if _, base := plans["ordered_base_membership"]; !base {
+				return nil, fmt.Errorf("incomplete ordered RecSet alternatives for %q", name)
+			}
+		} else {
+			if _, ok := plans["candidate_keyset"]; !ok {
+				return nil, fmt.Errorf("incomplete alternatives for %q", name)
+			}
+			_, ordered := plans["driver_order_membership_probe"]
+			_, direct := plans["driver_filter_join_probe"]
+			if !ordered && !direct {
+				return nil, fmt.Errorf("incomplete alternatives for %q", name)
+			}
 		}
 	}
 	return groups, nil
@@ -1819,6 +2030,8 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_broad_text_match_row_ns",
 		"planner_membership_broad_text_match_byte_ns",
 		"planner_membership_ordered_scan_invocation_ns",
+		"planner_membership_ordered_recset_row_ns",
+		"planner_membership_downstream_probe_row_ns",
 		"planner_scalar_presence_probe_row_ns",
 		"planner_membership_direct_probe_row_ns",
 	}
@@ -1831,7 +2044,9 @@ func readCurrentConstants(path string) (constants, error) {
 			// A one-nanosecond floor lets the first run fit new membership and
 			// ordered-scan coefficients from their physical-consumer observations.
 			if name == "planner_membership_direct_probe_row_ns" ||
-				name == "planner_membership_ordered_scan_invocation_ns" {
+				name == "planner_membership_ordered_scan_invocation_ns" ||
+				name == "planner_membership_ordered_recset_row_ns" ||
+				name == "planner_membership_downstream_probe_row_ns" {
 				values[i] = 1
 				continue
 			}
@@ -1859,8 +2074,10 @@ func readCurrentConstants(path string) (constants, error) {
 		broadTextMatchRowNS:        values[13],
 		broadTextMatchByteNS:       values[14],
 		orderedScanInvocationNS:    values[15],
-		scalarPresenceProbeRowNS:   values[16],
-		membershipDirectProbeRowNS: values[17],
+		orderedRecsetRowNS:         values[16],
+		downstreamProbeRowNS:       values[17],
+		scalarPresenceProbeRowNS:   values[18],
+		membershipDirectProbeRowNS: values[19],
 	}, nil
 }
 
@@ -1888,6 +2105,10 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_direct_probe_cost (lambda (probe_rows)
 	(planner_cost 0 0 (* probe_rows planner_membership_direct_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
 
+(define planner_membership_downstream_probe_row_ns %d)
+(define planner_membership_downstream_probe_cost (lambda (probe_rows)
+	(planner_cost 0 0 (* probe_rows planner_membership_downstream_probe_row_ns) 0 0 0 0 0 probe_rows 0.75)))
+
 (define planner_presence_carrier_cost (lambda (domain_rows probe_rows)
 	(planner_cost 1421611 (* probe_rows 136938) 0 0 0 0
 		(* domain_rows 8) 0 domain_rows 0.65)))
@@ -1912,11 +2133,14 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_group_cache_probe_row_ns %d)
 (define planner_membership_ordered_driver_input_row_ns %d)
 (define planner_membership_ordered_scan_invocation_ns %d)
+(define planner_membership_ordered_recset_row_ns %d)
 /* END GENERATED COST CONSTANTS */`, c.scalarPresenceProbeRowNS, c.membershipDirectProbeRowNS,
+		c.downstreamProbeRowNS,
 		c.scanInvocationNS, c.scanRowNS,
 		c.filterColumnRowNS, c.mapColumnRowNS, c.expressionOperationNS, c.broadTextMatchRowNS, c.broadTextMatchByteNS,
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
-		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS)
+		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS,
+		c.orderedRecsetRowNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -131,21 +131,105 @@ func TestRowFeaturesModelsDirectPresenceProbes(t *testing.T) {
 		CandidateExpressionOperations: value(1), CandidateBroadTextMatchRows: value(0),
 		CandidateBroadTextMatchBytes: value(0), DriverScanInvocations: value(1),
 		DriverFilterColumns: value(0), DriverMapColumns: value(1), DriverExpressionOperations: value(0),
+		DownstreamProbeBranches: value(2),
 	}
 	features, err := rowFeatures(row)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(features) != 17 || features[16] != 75 {
+	if len(features) != 19 || features[16] != 75 {
 		t.Fatalf("direct presence features = %v, want 75 probes", features)
 	}
 }
 
+func TestRowFeaturesChargesOrderedProjectedRecsetRows(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "candidate_keyset", Consumer: "order_limit",
+		CandidateInputRows: value(100), CandidateRows: value(10), ProjectedDriverRows: value(25),
+		DriverInputRows: value(1000), DriverRows: value(3), ExpectedDriverRowsVisited: value(120),
+		CandidateScanInvocations: value(1), CandidateFilterColumns: value(1),
+		CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
+		CandidateExpressionOperations: value(1), CandidateBroadTextMatchRows: value(0),
+		CandidateBroadTextMatchBytes: value(0), DriverScanInvocations: value(1),
+		DriverFilterColumns: value(0), DriverMapColumns: value(1), DriverExpressionOperations: value(0),
+		DownstreamProbeBranches: value(2),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features[17] != 25 {
+		t.Fatalf("ordered RecSet rows = %v, want 25", features[17])
+	}
+	if features[18] != 50 {
+		t.Fatalf("downstream probe rows = %v, want 50", features[18])
+	}
+}
+
+func TestRowFeaturesModelsOrderedRecsetConsumerAlternatives(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	direct, err := rowFeatures(calibrationRow{
+		Decision: "ordered_recset_consumer", Plan: "ordered_direct_recset",
+		CarrierRows: value(100), DriverInputRows: value(1000), Limit: value(10), Offset: value(0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := rowFeatures(calibrationRow{
+		Decision: "ordered_recset_consumer", Plan: "ordered_base_membership",
+		CarrierRows: value(100), DriverInputRows: value(1000), Limit: value(10), Offset: value(0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct[17] != 100 || direct[15] != 1 {
+		t.Fatalf("direct ordered features = %v", direct)
+	}
+	if base[1] != 100 || base[7] != 100 || base[15] != 1 || base[17] != 0 {
+		t.Fatalf("base ordered features = %v", base)
+	}
+}
+
+func TestFitOrderedRecsetRowCancelsSharedCarrierWork(t *testing.T) {
+	directA, baseA := make([]float64, 19), make([]float64, 19)
+	directA[17], baseA[1] = 100, 20
+	directB, baseB := make([]float64, 19), make([]float64, 19)
+	directB[17], baseB[1] = 10, 200
+	value, ok := fitOrderedRecsetRow([]observation{
+		{caseName: "broad", plan: "candidate_keyset", y: 11000, x: directA},
+		{caseName: "broad", plan: "driver_order_membership_probe", y: 1000, x: baseA},
+		{caseName: "sparse", plan: "ordered_direct_recset", y: 2000, x: directB},
+		{caseName: "sparse", plan: "ordered_base_membership", y: 1000, x: baseB},
+	}, constants{})
+	if !ok || value != 100 {
+		t.Fatalf("ordered RecSet row = (%d, %v), want (100, true)", value, ok)
+	}
+}
+
+func TestFitDownstreamProbeRowUsesDecisionOrdering(t *testing.T) {
+	candidate, driver, batch := make([]float64, 19), make([]float64, 19), make([]float64, 19)
+	candidate[18], driver[18], batch[18] = 100, 1000, 10
+	rows := []observation{
+		{caseName: "compound", decision: "membership_carrier", plan: "candidate_keyset", y: 2000, x: candidate},
+		{caseName: "compound", decision: "membership_carrier", plan: "driver_order_membership_probe", y: 10000, x: driver},
+		{caseName: "compound", decision: "membership_carrier", plan: "ordered_batch_accept", y: 1000, x: batch},
+	}
+	value, ok := fitDownstreamProbeRow(rows, constants{})
+	if !ok || value <= 1 {
+		t.Fatalf("downstream probe row = (%d, %v), want calibrated value above floor", value, ok)
+	}
+	model := constants{downstreamProbeRowNS: value}
+	if err := validateDecisionOrdering(rows, model); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFitOrderedScanInvocationUsesExactBatchObservations(t *testing.T) {
-	features := make([]float64, 17)
+	features := make([]float64, 19)
 	features[15] = 4
 	value, ok := fitOrderedScanInvocation([]observation{
-		{caseName: "batch", plan: "candidate_keyset", y: 1000, x: make([]float64, 17)},
+		{caseName: "batch", plan: "candidate_keyset", y: 1000, x: make([]float64, 19)},
 		{caseName: "batch", plan: "ordered_batch_accept", y: 2680, x: features},
 	}, constants{})
 	if !ok || value != 420 {
@@ -178,10 +262,34 @@ func TestRowFeaturesModelsPrefilteredCandidateWork(t *testing.T) {
 	}
 }
 
+func TestRowFeaturesChargesPrefilteredDownstreamWorkToLocalDriverSubset(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Plan: "prefiltered_candidate_keyset", Consumer: "order_limit",
+		CandidateInputRows: value(2000), CandidateRows: value(250), CandidateDensity: value(0.25),
+		ProjectedDriverRows: value(1000), DriverInputRows: value(4000), DriverRows: value(72),
+		PrefilteredDriverRows: value(4000), ExpectedDriverRowsVisited: value(300),
+		ProbeBranches: value(2), DownstreamProbeBranches: value(1),
+		CandidateScanInvocations: value(2), CandidateFilterColumns: value(1),
+		CandidateMapColumns: value(1), CandidateCacheMapColumns: value(2),
+		CandidateExpressionOperations: value(1), CandidateBroadTextMatchRows: value(2000),
+		CandidateBroadTextMatchBytes: value(0), DriverScanInvocations: value(1),
+		DriverFilterColumns: value(0), DriverMapColumns: value(4), DriverExpressionOperations: value(0),
+		Limit: value(72), Offset: value(0),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features[18] != 4000 {
+		t.Fatalf("prefiltered downstream probes = %v, want 4000", features[18])
+	}
+}
+
 func TestFitDirectCarrierPairCancelsPairedCommonWork(t *testing.T) {
-	candidateA, driverA := make([]float64, 17), make([]float64, 17)
+	candidateA, driverA := make([]float64, 19), make([]float64, 19)
 	candidateA[5], candidateA[8], driverA[16] = 1, 1, 100
-	candidateB, driverB := make([]float64, 17), make([]float64, 17)
+	candidateB, driverB := make([]float64, 19), make([]float64, 19)
 	candidateB[5], candidateB[8], driverB[16] = 1, 1, 10
 	startup, probe, ok := fitDirectCarrierPair([]observation{
 		{caseName: "large", plan: "candidate_keyset", y: 10000, x: candidateA},
@@ -226,7 +334,7 @@ func TestMedianRowsAcceptsOrderedBatchPlans(t *testing.T) {
 
 func TestValidateDecisionOrderingIncludesOrderedBatch(t *testing.T) {
 	features := func(first float64) []float64 {
-		values := make([]float64, 17)
+		values := make([]float64, 19)
 		values[0] = first
 		return values
 	}
@@ -242,7 +350,7 @@ func TestValidateDecisionOrderingIncludesOrderedBatch(t *testing.T) {
 
 func TestDecisionOrderingAcceptsOnlyMeasuredNoiseTies(t *testing.T) {
 	features := func(first float64) []float64 {
-		values := make([]float64, 17)
+		values := make([]float64, 19)
 		values[0] = first
 		return values
 	}
@@ -256,6 +364,32 @@ func TestDecisionOrderingAcceptsOnlyMeasuredNoiseTies(t *testing.T) {
 	rows[1].y = 200
 	if err := validateDecisionOrdering(rows, constants{scanInvocationNS: 1}); err == nil {
 		t.Fatal("materially slower estimated winner accepted as a noise tie")
+	}
+}
+
+func TestResidualRefinementMustImproveDecisionPool(t *testing.T) {
+	features := func(first, ordered float64) []float64 {
+		values := make([]float64, 19)
+		values[0], values[15] = first, ordered
+		return values
+	}
+	rows := []observation{
+		{caseName: "stable", plan: "candidate_keyset", y: 10, x: features(1, 0)},
+		{caseName: "stable", plan: "driver_order_membership_probe", y: 20, x: features(0, 1)},
+	}
+	current := constants{scanInvocationNS: 1, orderedScanInvocationNS: 2}
+	trial := current
+	trial.orderedScanInvocationNS = 100
+	if got := acceptDecisionImprovingRefinement(rows, current, trial); got != current {
+		t.Fatalf("equal-accuracy residual fit replaced selected baseline: %+v", got)
+	}
+
+	wrong := current
+	better := wrong
+	better.orderedScanInvocationNS = 0
+	rows[0].y, rows[1].y = 20, 10
+	if got := acceptDecisionImprovingRefinement(rows, wrong, better); got != better {
+		t.Fatalf("decision-improving residual fit was rejected: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## What

Make correlated membership carrier selection account for the complete physical subtree instead of optimizing the candidate relation in isolation.

- Record row-rejecting downstream relations separately from UNION candidate branches.
- Cost downstream probes for every carrier alternative at the row count where that alternative actually executes them.
- Cost ordered consumption of projected RecSets independently from carrier construction.
- Let ordered batch filters intersect already selected exact scalar RecSets before compiling the residual predicate through the ordinary lowerer.
- Treat a complete unique-key equality as a cardinality proof without checking whether an autoindex currently exists.
- Lower closed base-table presence leaves directly to RecSets when they belong to a projected boolean carrier, while retaining canonical shared group caches for per-row consumers.

This is not a text-search, ACL, table-name, or LIMIT-72 special case. The membership node still compares `candidate_keyset`, ordered driver probes, prefiltered candidates, and `ordered_batch_accept` through the calibrated cost model. Unknown cardinalities retain the existing runtime observation/recompile gates.

## Calibration safety

The calibration generator now models downstream probe work and ordered RecSet consumption as separate features. Residual coefficient fits are accepted only when they improve an additional measured decision across the complete training pool; a lower numeric residual for one case can no longer overwrite constants while silently regressing another decision.

The workload contains 26 calibration shapes spanning broad/selective memberships, several LIMITs and cardinalities, COUNT, wide projections, text matching, adaptive batches, exact point filters, compound boolean ACL work, and holdouts.

- training decisions: 17/18 before, 18/18 after
- membership holdouts: 6/6
- ordered-consumer decisions: 1/1
- the generated downstream coefficient is 1,372,917 ns/probe; no planner weight was edited by hand

## Correctness and compile scalability

The projected boolean carrier passes ownership context only to presence leaves through a small indexed catalog overlay. It does not mutate logical stages or copy the complete sibling catalog. A per-row consumer therefore still reuses the canonical group relation.

On the 80 KB nested-dependent-join compile benchmark (10 runs):

| revision | median total | median planner | max total |
| --- | ---: | ---: | ---: |
| master | 760 ms | 340 ms | 889 ms |
| this PR | 751 ms | 335 ms | 816 ms |

## Real-data evidence

For a representative fulltext + compound ACL + ORDER/LIMIT query:

- cold successful execution: 26.6 s
- subsequent executions: 7.24 s, 4.14 s, 4.15 s
- observed candidate cardinality after warmup/recompile: 18,233
- physical choice after observation: `ordered_batch_accept` with `candidate_then_residual`
- the plan records two downstream probe branches and emits the batched ordered consumer

This removes the prior 1-2 minute tail and makes the intended operator family mechanically reachable. The remaining roughly 4.1 s steady-state result is close to, but not yet below, the separate 3 s end-to-end target.

## Tests

- Full pre-commit repository suite: green (unchanged timing limits, non-coverage hook-equivalent run).
- Scheme startup: 1267/1267.
- ACL/ordered membership regression: 26/26.
- shared presence/group-cache regression: 35/35.
- compile scaling: 8/8 and five additional repeated focused runs.
- fulltext LIKE index suite: 5/5 repeated suite runs, each 86/86.
- `go test ./tools/costgen` and Scheme lint: green.

The coverage-instrumented aggregate run exposed the existing approximately 5-8 ms LIKE speed-ratio flake twice; the same unchanged storage suite passed five consecutive isolated runs and the complete ordinary pre-commit run. No test threshold, expectation, or criticality was changed.
