### PR TITLE
Fix joined ordered scalar subqueries in updates

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -1652,11 +1652,12 @@ physical membership probe. */
 
 (define scalar_once_supported? (lambda (inner)
 	(and (query_block? inner)
-		(and (scalar_source_shape_supported? (qb_sources inner))
-			(and (empty_list? (qb_group inner))
-				(and (nil? (qb_having inner))
-					(and (or (nil? (qb_offset inner)) (not (empty_list? (qb_order inner))))
-						(equal? (qb_limit inner) 1))))))))
+		(and (not (empty_list? (qb_sources inner)))
+			(and (or (scalar_source_shape_supported? (qb_sources inner)) (nil? (qb_offset inner)))
+				(and (empty_list? (qb_group inner))
+					(and (nil? (qb_having inner))
+						(and (or (nil? (qb_offset inner)) (not (empty_list? (qb_order inner))))
+							(equal? (qb_limit inner) 1)))))))))
 
 (define single_row_derived_supported? (lambda (inner)
 	(and (query_block? inner)
@@ -2954,7 +2955,7 @@ without separately proving two-valued semantics. */
 				(decorrelate_expr_with_pairs inner_default lookup_pairs expr)) dir)))))
 		(define ags (dedupe_aggregates_by_col (map values_for_inner (lambda (value_for_inner)
 			(scalar_once_descriptor value_for_inner order_for_inner (qb_offset inner))))))
-		(define stage_input (if (empty_list? (qb_stages inner))
+		(define stage_input (if (and (single_source? local_sources) (empty_list? (qb_stages inner)))
 			inner_src
 			(make_query_block
 				(qb_schema inner)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5108,15 +5108,76 @@ ever-larger subtrees. */
 expressions. Persistent column identity was selected from the original logical
 stage before that rewrite; thread it through unchanged to keep create and fill
 on the same columns. */
+(define scalar_order_payload_before_expr (lambda (dirs idx)
+	(if (>= idx (count dirs))
+		false
+		(begin
+			(define old_value (list (quote nth) (quote old) idx))
+			(define new_value (list (quote nth) (quote new) idx))
+			(list (quote if)
+				(list (quote equal??) old_value new_value)
+				(scalar_order_payload_before_expr dirs (+ idx 1))
+				(list (nth dirs idx) old_value new_value))))))
+
+(define query_group_aggregate_descriptor (lambda (ag)
+	(begin
+		(define parts (scalar_order_aggregate_parts ag))
+		(if (nil? parts)
+			ag
+			(begin
+				(define value_expr (nth parts 0))
+				(define order_exprs (nth parts 1))
+				(define dirs (nth parts 2))
+				(define offset_value (nth parts 3))
+				(if (not (equal? offset_value 0))
+					(neumann_fail "build_queryplan" "joined scalar ORDER/LIMIT currently requires OFFSET 0")
+					true)
+				(list
+					(runtime_cons_list_expr (merge (list order_exprs (list value_expr))))
+					(list (quote lambda) (list (quote old) (quote new))
+						(list (quote if) (list (quote nil?) (quote old))
+							(quote new)
+							(list (quote if) (list (quote nil?) (quote new))
+								(quote old)
+								(list (quote if)
+									(scalar_order_payload_before_expr dirs 0)
+									(quote old)
+									(quote new)))))
+					nil))))))
+
+(define query_group_final_payload_expr (lambda (ags idx)
+	(if (>= idx (count ags))
+		(quoted_runtime_list '())
+		(begin
+			(define parts (scalar_order_aggregate_parts (nth ags idx)))
+			(define stored (list (quote nth) (quote payload) idx))
+			(cons (quote cons) (list
+				(if (nil? parts)
+					stored
+					(list (quote if) (list (quote nil?) stored) nil
+						(list (quote nth) stored (count (nth parts 1)))))
+				(query_group_final_payload_expr ags (+ idx 1))))))))
+
+(define finalize_query_grouped_assoc_expr (lambda (ags grouped_expr)
+	(list
+		(list (quote lambda) (list (quote grouped))
+			(list (quote reduce_assoc) (quote grouped)
+				(list (quote lambda) (list (quote acc) (quote key) (quote payload))
+					(list (quote set_assoc) (quote acc) (quote key)
+						(query_group_final_payload_expr ags 0)))
+				(list (quote list))))
+		grouped_expr)))
+
 (define build_query_grouped_assoc_plan (lambda (input keys key_names ags)
 	(begin
+		(define runtime_ags (map ags query_group_aggregate_descriptor))
 		(define row_key_names (map key_names (lambda (col) (concat "__row_" col))))
 		(define value_cols (map (produceN (count ags)) (lambda (i) (concat "__agg" i))))
 		(define row_fields (merge (list
 			(merge (map (produceN (count keys)) (lambda (i)
 				(list (nth row_key_names i) (nth keys i)))))
 			(merge (map (produceN (count ags)) (lambda (i)
-				(match (nth ags i)
+				(match (nth runtime_ags i)
 					'(agg_expr _agg_reduce _agg_neutral)
 					(list (nth value_cols i)
 						(if (equal? (nth ags i) aggregate_count_descriptor)
@@ -5131,22 +5192,23 @@ on the same columns. */
 				1
 				(aggregate_map_value_expr (nth ags i) (nth value_symbols i)))))))
 		(define merge_payload (list (quote lambda) (list (quote old) (quote new))
-			(aggregate_payload_merge_expr ags 0)))
+			(aggregate_payload_merge_expr runtime_ags 0)))
 		(define combine_grouped (grouped_state_merge_expr merge_payload))
-		(lower_query_block_as_dataset_reduce
-			input
-			row_fields
-			(list (quote lambda)
-				(extract_assoc row_fields (lambda (title _expr) (symbol title)))
-				(runtime_cons_list_expr (list key_expr payload_expr)))
-			(list (quote lambda) (list (quote acc) (quote rowvals))
-				(list (quote set_assoc)
-					(quote acc)
-					(list (quote car) (quote rowvals))
-					(list (quote cadr) (quote rowvals))
-					merge_payload))
-			(list (quote list))
-			combine_grouped))))
+		(finalize_query_grouped_assoc_expr ags
+			(lower_query_block_as_dataset_reduce
+				input
+				row_fields
+				(list (quote lambda)
+					(extract_assoc row_fields (lambda (title _expr) (symbol title)))
+					(runtime_cons_list_expr (list key_expr payload_expr)))
+				(list (quote lambda) (list (quote acc) (quote rowvals))
+					(list (quote set_assoc)
+						(quote acc)
+						(list (quote car) (quote rowvals))
+						(list (quote cadr) (quote rowvals))
+						merge_payload))
+				(list (quote list))
+				combine_grouped)))))
 
 (define build_query_group_aggregates_insert_plan (lambda (input grouptbl keys key_names ags aggregate_cols)
 	(begin

--- a/tests/sql/dml/multi-table-dml.yaml
+++ b/tests/sql/dml/multi-table-dml.yaml
@@ -10,6 +10,9 @@ setup:
   - sql: "DROP TABLE IF EXISTS mtd_log"
   - sql: "DROP TABLE IF EXISTS mtd_assoc"
   - sql: "DROP TABLE IF EXISTS mtd_source"
+  - sql: "DROP TABLE IF EXISTS mtd_document"
+  - sql: "DROP TABLE IF EXISTS mtd_revision"
+  - sql: "DROP TABLE IF EXISTS mtd_file"
   - sql: |
       CREATE TABLE mtd_source (
         ID INT PRIMARY KEY,
@@ -34,6 +37,12 @@ setup:
   - sql: "INSERT INTO mtd_source VALUES (1, 'hello', 3000, 6000), (2, 'world', 1000, 2000)"
   - sql: "INSERT INTO mtd_assoc VALUES (1, 1, 10, 1000), (2, 2, 20, 2000)"
   - sql: "INSERT INTO mtd_log VALUES (1, 1, 999, 'old1'), (2, 2, 888, 'old2')"
+  - sql: "CREATE TABLE mtd_document (ID INT PRIMARY KEY, subject TEXT)"
+  - sql: "CREATE TABLE mtd_revision (ID INT PRIMARY KEY, document_id INT, file_id INT, created BIGINT)"
+  - sql: "CREATE TABLE mtd_file (ID INT PRIMARY KEY, filename TEXT)"
+  - sql: "INSERT INTO mtd_document VALUES (1, NULL), (2, ''), (3, 'keep')"
+  - sql: "INSERT INTO mtd_file VALUES (10, 'old.txt'), (11, 'latest.txt'), (12, 'only.txt')"
+  - sql: "INSERT INTO mtd_revision VALUES (100, 1, 10, 1000), (101, 1, 11, 2000), (102, 2, 12, 1500)"
 
 test_cases:
 
@@ -55,6 +64,32 @@ test_cases:
           notiz: "hello"
         - ref_id: 2
           notiz: "old2"
+
+  - name: "UPDATE from correlated ordered joined scalar subquery"
+    sql: |
+      UPDATE mtd_document SET subject = (
+        SELECT f.filename
+        FROM mtd_revision r
+        JOIN mtd_file f ON f.ID = r.file_id
+        WHERE r.document_id = mtd_document.ID
+        ORDER BY r.created DESC
+        LIMIT 1
+      )
+      WHERE subject = '' OR subject IS NULL
+    expect:
+      rows_affected: 2
+
+  - name: "verify correlated ordered joined scalar UPDATE"
+    sql: "SELECT ID, subject FROM mtd_document ORDER BY ID"
+    expect:
+      rows: 3
+      data:
+        - ID: 1
+          subject: "latest.txt"
+        - ID: 2
+          subject: "only.txt"
+        - ID: 3
+          subject: "keep"
 
   - name: "multi-table UPDATE SET to constant zero"
     sql: |
@@ -124,3 +159,6 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS mtd_assoc"
   - sql: "DROP TABLE IF EXISTS mtd_source"
   - sql: "DROP TABLE IF EXISTS mtd_ordered"
+  - sql: "DROP TABLE IF EXISTS mtd_document"
+  - sql: "DROP TABLE IF EXISTS mtd_revision"
+  - sql: "DROP TABLE IF EXISTS mtd_file"


### PR DESCRIPTION
## Summary
- decorrelate ordered `LIMIT 1` scalar subqueries whose input contains joins
- preserve deterministic ORDER BY selection while aggregating joined rows
- cover an UPDATE whose scalar value comes from the newest joined child row

## Validation
- `./git-pre-commit`
- targeted DML regression fails on master and passes with the fix