### PR TITLE
Bound statistics-guarded query plan variants

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -27,6 +27,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (set psql_queryplan_cache (newcachemap))
 (set sql_literal_shape_cache (newcachemap))
 
+/* Statistics guards deliberately specialize physical plans, but exact row
+counts can change after every small write. Keep only the newest regimes: old
+variants remain correct only while their guards match, and can be recompiled
+if an old regime returns. Bounding the list prevents large plans from growing
+the dispatch formula and retained ASTs without limit. */
+(set sql_queryplan_max_variants 4)
+
+(define sql_queryplan_recent_variants (lambda (variants)
+	(map (produceN (min sql_queryplan_max_variants (count variants)))
+		(lambda (idx) (nth variants idx)))))
+
 /* Keep exact SQL variants out of the parser while sharing their compiled plan.
 Only parameterized results enter the small front cache; exact-only statements
 continue to occupy just their existing query-plan entry. The third result item
@@ -303,8 +314,9 @@ otherwise side-effect-free guard. */
 
 (define sql_queryplan_install_variants (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy variants)
 	(begin
-		(entry "variants" variants)
-		(entry "formula" (sql_queryplan_formula queryplan_cache cache_key entry parse_fn schema parse_query policy variants))
+		(define recent_variants (sql_queryplan_recent_variants variants))
+		(entry "variants" recent_variants)
+		(entry "formula" (sql_queryplan_formula queryplan_cache cache_key entry parse_fn schema parse_query policy recent_variants))
 		(entry "formula"))))
 
 (define sql_queryplan_new_entry (lambda (queryplan_cache cache_key parse_fn schema parse_query policy source_session)

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -431,6 +431,41 @@ test_cases:
     expect:
       data: ["ok"]
 
+  - name: "Guarded plan cache bounds obsolete statistics variants"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (define compiles (newsession))
+        (compiles "count" 0)
+        (define parser (lambda (_schema _query _policy) (begin
+          (define value (planner_literal_value (list (quote session) "v1")))
+          (planner_record_guard_condition
+            (list (quote equal?) (list (quote session) "v1") value))
+          (compiles "count" (+ (compiles "count") 1))
+          (list (quote quote) value))))
+        (define query "SELECT id FROM ps_test WHERE EXISTS (SELECT id FROM ps_test) LIMIT ?")
+        (define results (map (produceN 12) (lambda (value) (begin
+          (sess "v1" value)
+          (with_session sess (lambda ()
+            (eval (cached_parse cache parser "memcp-tests" query nil "root" sess true))))))))
+        (define entry (car (cache (car (cache)))))
+        (define bounded_count (count (entry "variants")))
+        (sess "v1" 0)
+        (define revisited (with_session sess (lambda ()
+          (eval (cached_parse cache parser "memcp-tests" query nil "root" sess true)))))
+        (if (and
+          (equal? results (produceN 12))
+          (equal? revisited 0)
+          (<= bounded_count 4)
+          (<= (count (entry "variants")) 4)
+          (equal? (compiles "count") 13))
+          "ok"
+          (error (concat "guarded cache retained obsolete variants: count=" bounded_count
+            " final=" (count (entry "variants")) " compiles=" (compiles "count")))))
+    expect:
+      data: ["ok"]
+
   - name: "Cancelled guarded-plan waiter never compiles after the gate opens"
     steps:
       - scm: |


### PR DESCRIPTION
## Summary
- cap retained guarded plan variants per normalized query
- retain the newest cardinality regimes and recompile an evicted regime when needed
- prevent growing dispatch formulas and retained planner ASTs after repeated writes
- add a regression that crosses twelve statistics regimes and verifies bounded retention plus correct recompilation

## Validation
- `./git-pre-commit`
- regression fails on master with 12 retained variants and passes with at most 4