### PR TITLE
Accelerate JSON filters with computed indexes

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -686,7 +686,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		} else if v[0].SymbolEquals("or") {
 			// If the whole OR is a pure row-column expression, index as computed bool col.
 			// This avoids range-merging that would span too wide.
-			if len(params) > 0 && isRawDataset(params, node) {
+			if len(params) > 0 && !hasSessionRead(node) && isRawDataset(params, node) {
 				canon := canonicalColName(node, params, conditionCols)
 				mc, mf := buildComputedFn(node, p.Params, p.En, conditionCols)
 				if !mf.IsNil() && mc != nil {
@@ -718,7 +718,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		// Fallback: if the whole expression is a pure function of row columns
 		// (no comparison operator matched above), treat it as a computed bool column.
 		// Boundary {true, true} means: only scan rows where the expression is true.
-		if len(params) > 0 && isRawDataset(params, node) {
+		if len(params) > 0 && !hasSessionRead(node) && isRawDataset(params, node) {
 			canon := canonicalColName(node, params, conditionCols)
 			mc, mf := buildComputedFn(node, p.Params, p.En, conditionCols)
 			if !mf.IsNil() && mc != nil {

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -134,6 +134,119 @@ func TestBoundaryRange(t *testing.T) {
 	}
 }
 
+func TestComputedBoundaryUsesDeclarationMetadataWithQueryBinding(t *testing.T) {
+	jsonValue := scm.Globalenv.Vars[scm.Symbol("json_value")]
+	if declaration := scm.DeclarationForValue(jsonValue); declaration == nil || !declaration.IsFoldable() {
+		t.Fatal("json_value must expose Const metadata through DeclarationForValue")
+	}
+	path := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("session"),
+		scm.NewString("v1"),
+	})
+	extraction := scm.NewSlice([]scm.Scmer{
+		jsonValue,
+		scm.NewSymbol("payload"),
+		path,
+		scm.NewString("UNSIGNED"),
+	})
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		extraction,
+		scm.NewInt(17),
+	})
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("payload")}),
+		Body:   body,
+		En:     &scm.Globalenv,
+	})
+
+	bounds := extractBoundaries([]string{"payload"}, condition)
+	if len(bounds) != 1 {
+		t.Fatalf("computed JSON condition produced %d boundaries, want 1", len(bounds))
+	}
+	bound := bounds[0]
+	if bound.matcher != EqualMatcher || bound.mapFn.IsNil() {
+		t.Fatalf("computed boundary = %#v, want an equality map function", bound)
+	}
+	if len(bound.mapCols) != 1 || bound.mapCols[0] != "payload" {
+		t.Fatalf("computed map columns = %v, want [payload]", bound.mapCols)
+	}
+	keys := extractSessionKeys(bound.mapFn)
+	if len(keys) != 1 || keys[0] != "v1" {
+		t.Fatalf("computed map function session keys = %v, want [v1]", keys)
+	}
+}
+
+func TestComputedBoundaryRejectsNonConstDeclaredCall(t *testing.T) {
+	params := []scm.Scmer{scm.NewSymbol("payload")}
+	expression := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("concat"),
+		scm.NewSymbol("payload"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("uuid")}),
+	})
+	if isRawDataset(params, expression) {
+		t.Fatal("row expression containing non-Const uuid call must not be indexable")
+	}
+}
+
+func TestParameterizedBooleanFallbackDoesNotCreateVariantIndex(t *testing.T) {
+	params := scm.NewSlice([]scm.Scmer{scm.NewSymbol("id")})
+	values := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("list"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("session"), scm.NewString("v1")}),
+	})
+	body := scm.NewSlice([]scm.Scmer{
+		scm.Globalenv.Vars[scm.Symbol("sql_in")],
+		values,
+		scm.NewSymbol("id"),
+	})
+	condition := scm.NewProcStruct(scm.Proc{Params: params, Body: body, En: &scm.Globalenv})
+
+	if bounds := extractBoundaries([]string{"id"}, condition); len(bounds) != 0 {
+		t.Fatalf("parameterized boolean fallback produced computed bounds: %#v", bounds)
+	}
+}
+
+func TestSessionIndexSavingsAreTrackedPerVariant(t *testing.T) {
+	index := &StorageIndex{sessionKeys: []string{"v1"}}
+	first := &storageIndexState{}
+	second := &storageIndexState{}
+
+	if got := index.addSavings(first, 1.25); got != 1.25 {
+		t.Fatalf("first variant savings = %v, want 1.25", got)
+	}
+	if got := index.addSavings(second, 0.5); got != 0.5 {
+		t.Fatalf("second variant inherited savings: got %v, want 0.5", got)
+	}
+	if got := index.addSavings(first, 0.75); got != 2.0 {
+		t.Fatalf("first variant accumulated savings = %v, want 2", got)
+	}
+	if index.Savings != 0 {
+		t.Fatalf("session-variant usage changed base savings to %v", index.Savings)
+	}
+}
+
+func TestBindSessionReadsSpecializesComputedProcedure(t *testing.T) {
+	read := scm.NewSlice([]scm.Scmer{scm.NewSymbol("session"), scm.NewString("v1")})
+	proc := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("value")}),
+		Body:   scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewSymbol("value"), read}),
+		En:     &scm.Globalenv,
+	})
+
+	bound := bindSessionReads(proc, nil)
+	if !bound.IsProc() {
+		t.Fatalf("specialized value is %T, want procedure", bound.Any())
+	}
+	body := bound.Proc().Body.Slice()
+	if len(body) != 3 || !body[2].IsNil() {
+		t.Fatalf("specialized body = %s, want nil query binding", bound.Proc().Body.String())
+	}
+	if !proc.Proc().Body.Slice()[2].IsSlice() {
+		t.Fatal("specialization mutated the reusable source procedure")
+	}
+}
+
 func TestScanBufferSizeUsesSmallBufferOnlyForBoundUniqueKey(t *testing.T) {
 	tbl := &table{Unique: []uniqueKey{{Id: "PRIMARY", Cols: []string{"tenant_id", "id"}}}}
 	point := func(col string, value scm.Scmer) columnboundaries {

--- a/storage/compute_index.go
+++ b/storage/compute_index.go
@@ -18,6 +18,63 @@ package storage
 
 import "github.com/launix-de/memcp/scm"
 
+// sessionReadKey recognizes the planner's runtime representation of a
+// read-only query binding. Mutating session calls have a third argument and
+// are deliberately not query-invariant values.
+func sessionReadKey(expr scm.Scmer) (string, bool) {
+	if !expr.IsSlice() {
+		return "", false
+	}
+	items := expr.Slice()
+	if len(items) != 2 || !items[0].IsSymbol() || items[0].String() != "session" || !items[1].IsString() {
+		return "", false
+	}
+	return items[1].String(), true
+}
+
+func hasSessionRead(expr scm.Scmer) bool {
+	if _, ok := sessionReadKey(expr); ok {
+		return true
+	}
+	if expr.IsProc() {
+		return hasSessionRead(expr.Proc().Body)
+	}
+	if expr.IsSlice() {
+		for _, item := range expr.Slice() {
+			if hasSessionRead(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bindSessionReads specializes query-invariant bindings once before a computed
+// function enters the row loop. The original procedure remains immutable and
+// reusable for other session variants.
+func bindSessionReads(expr scm.Scmer, tx *TxContext) scm.Scmer {
+	if key, ok := sessionReadKey(expr); ok {
+		if tx == nil {
+			return scm.NewNil()
+		}
+		return tx.SessionValue(key)
+	}
+	if expr.IsProc() {
+		proc := *expr.Proc()
+		proc.Body = bindSessionReads(proc.Body, tx)
+		return scm.NewProcStruct(proc)
+	}
+	if !expr.IsSlice() {
+		return expr
+	}
+	items := expr.Slice()
+	bound := make([]scm.Scmer, len(items))
+	for i, item := range items {
+		bound[i] = bindSessionReads(item, tx)
+	}
+	return scm.NewSlice(bound)
+}
+
 func extractSessionKeys(expr scm.Scmer) []string {
 	seen := make(map[string]bool)
 	var out []string
@@ -34,13 +91,10 @@ func extractSessionKeys(expr scm.Scmer) []string {
 		if len(items) == 0 {
 			return
 		}
-		if items[0].IsSymbol() && items[0].String() == "session" {
-			if len(items) >= 2 && items[1].IsString() {
-				key := items[1].String()
-				if !seen[key] {
-					seen[key] = true
-					out = append(out, key)
-				}
+		if key, ok := sessionReadKey(node); ok {
+			if !seen[key] {
+				seen[key] = true
+				out = append(out, key)
 			}
 		}
 		for _, it := range items {
@@ -115,6 +169,12 @@ func isRawDataset(params []scm.Scmer, expr scm.Scmer) bool {
 	// NthLocalVar param reference
 	if expr.IsNthLocalVar() {
 		return int(expr.NthLocalVar()) >= 0 && int(expr.NthLocalVar()) < len(params)
+	}
+	// SQL literals and prepared parameters are lowered to read-only query
+	// bindings before the physical scan is built. They are invariant for one
+	// index variant and are tracked by extractSessionKeys.
+	if _, ok := sessionReadKey(expr); ok {
+		return true
 	}
 	// function call: look up declaration and require Foldable.
 	// DeclarationForValue handles both unoptimized (symbol) and

--- a/storage/index.go
+++ b/storage/index.go
@@ -38,6 +38,7 @@ type storageIndexState struct {
 	mainIndexes      StorageInt
 	deltaBtree       *btree.BTreeG[indexPair]
 	active           bool
+	savings          float64
 	minVals          []scm.Scmer
 	maxVals          []scm.Scmer
 	indexHooks       []IndexHook
@@ -200,7 +201,11 @@ func (s *StorageIndex) buildGetters(tx *TxContext) ([]colGetter, []string) {
 					sessionKeys = mergeSessionKeys(sessionKeys, proxy.sessionKeys)
 				}
 			}
-			fn := scm.OptimizeProcToSerialFunction(s.ColMapFn[i])
+			mapFn := s.ColMapFn[i]
+			if hasSessionRead(mapFn) {
+				mapFn = bindSessionReads(mapFn, tx)
+			}
+			fn := scm.OptimizeProcToSerialFunction(mapFn)
 			getters[i] = colGetter{mapCols: mapColReaders, mapFn: fn}
 		} else {
 			cs := s.t.getColumnStorageRLocked(col)
@@ -259,6 +264,22 @@ func (idx *StorageIndex) stateForTx(tx *TxContext, create bool) *storageIndexSta
 		idx.variants[key] = state
 	}
 	return state
+}
+
+// addSavings records reuse against the data variant that would actually be
+// built. A frequently reused prepared value must not prewarm every new value
+// of the same query shape into an immediate full index build.
+func (idx *StorageIndex) addSavings(state *storageIndexState, usageWeight float64) float64 {
+	if len(idx.sessionKeys) == 0 {
+		if usageWeight > 0 {
+			idx.Savings += usageWeight
+		}
+		return idx.Savings
+	}
+	if usageWeight > 0 {
+		state.savings += usageWeight
+	}
+	return state.savings
 }
 
 func (idx *StorageIndex) markVariantsDirty() {
@@ -655,8 +676,11 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		index.ColOrderFast = make([]func(scm.Scmer, scm.Scmer) bool, len(lower))
 		for i := range lower {
 			index.Cols[i] = cols[i].col
-			index.ColMapCols[i] = cols[i].mapCols  // nil for raw columns
-			index.ColMapFn[i] = cols[i].mapFn      // IsNil() for raw columns
+			index.ColMapCols[i] = cols[i].mapCols // nil for raw columns
+			index.ColMapFn[i] = cols[i].mapFn     // IsNil() for raw columns
+			if !cols[i].mapFn.IsNil() {
+				index.sessionKeys = mergeSessionKeys(index.sessionKeys, extractSessionKeys(cols[i].mapFn))
+			}
 			index.ColMatchers[i] = cols[i].matcher // nil for equal/range
 			if cols[i].matcher.IsSorted() {
 				index.ColOrder[i], index.ColOrderMeta[i] = boundaryOrder(t.t, cols[i])
@@ -738,8 +762,9 @@ func snapshotIndexesForRebuild(indexes []*StorageIndex) []*StorageIndex {
 	for _, idx := range indexes {
 		clone := new(StorageIndex)
 		clone.Cols = append([]string(nil), idx.Cols...)
-		clone.ColMapCols = idx.ColMapCols   // shallow copy OK (immutable per-col slices)
-		clone.ColMapFn = idx.ColMapFn       // shallow copy OK
+		clone.ColMapCols = idx.ColMapCols // shallow copy OK (immutable per-col slices)
+		clone.ColMapFn = idx.ColMapFn     // shallow copy OK
+		clone.sessionKeys = append([]string(nil), idx.sessionKeys...)
 		clone.ColMatchers = idx.ColMatchers // shallow copy OK (singletons)
 		clone.ColOrder = append([]func(...scm.Scmer) scm.Scmer(nil), idx.ColOrder...)
 		clone.ColOrderMeta = append([]string(nil), idx.ColOrderMeta...)
@@ -1145,12 +1170,10 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 	// no collation-specific helpers in the current implementation
 
 	savingsThreshold := 2.0 // building an index costs 1x the time as traversing the list
-	if usageWeight > 0 {
-		s.Savings += usageWeight
-	}
+	savings := s.addSavings(state, usageWeight)
 	if !state.active {
 		// index is not built yet
-		if s.Savings < savingsThreshold && !forceBuild {
+		if savings < savingsThreshold && !forceBuild {
 			// iterate over all items because we don't want to store the index
 			if selected != nil {
 				selected(s, false)

--- a/tests/performance/json-functions.yaml
+++ b/tests/performance/json-functions.yaml
@@ -92,6 +92,15 @@ test_cases:
     expect:
       rows: 1
 
+  - name: "Perf JSON: indexed selective row projection"
+    setup: *json_setup
+    sql: |
+      SELECT id
+      FROM json_perf_documents
+      WHERE JSON_VALUE(doc, '$.tenant' RETURNING UNSIGNED) = 17
+    threshold_ms: 30000
+    expect: {}
+
   - name: "Perf JSON: computed path ORDER BY LIMIT"
     setup: *json_setup
     sql: |

--- a/tests/storage/indexes/computed-index-cols.yaml
+++ b/tests/storage/indexes/computed-index-cols.yaml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 # Computed/expression columns used in ORDER BY, WHERE, GROUP BY.
 # Covers MySQL-style YEAR()/MONTH()/DAY() shorthand functions and their
 # use as sort/filter keys (the building blocks for expression-index optimisation).
@@ -8,6 +23,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS ci_events"
+  - sql: "DROP TABLE IF EXISTS ci_json_docs"
   - sql: |
       CREATE TABLE ci_events (
         id   INT,
@@ -24,9 +40,34 @@ setup:
         (6, 'Zeta',    '2024-06-30 23:59:00'),
         (7, 'Eta',     '2024-12-31 00:00:00'),
         (8, 'Theta',   NULL)
+  - sql: |
+      CREATE TABLE ci_json_docs (
+        id INT PRIMARY KEY,
+        payload JSON NOT NULL
+      ) ENGINE=memory
+  - sql: |
+      INSERT INTO ci_json_docs VALUES
+        (0,  '{"tenant":0,"rank":0}'),
+        (1,  '{"tenant":1,"rank":1}'),
+        (2,  '{"tenant":2,"rank":2}'),
+        (3,  '{"tenant":3,"rank":3}'),
+        (4,  '{"tenant":0,"rank":4}'),
+        (5,  '{"tenant":1,"rank":5}'),
+        (6,  '{"tenant":2,"rank":6}'),
+        (7,  '{"tenant":3,"rank":7}'),
+        (8,  '{"tenant":0,"rank":8}'),
+        (9,  '{"tenant":1,"rank":9}'),
+        (10, '{"tenant":2,"rank":10}'),
+        (11, '{"tenant":3,"rank":11}'),
+        (12, '{"tenant":0,"rank":12}'),
+        (13, '{"tenant":1,"rank":13}'),
+        (14, '{"tenant":2,"rank":14}'),
+        (15, '{"tenant":3,"rank":15}')
+  - scm: "(rebuild)"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS ci_events"
+  - sql: "DROP TABLE IF EXISTS ci_json_docs"
 
 test_cases:
 
@@ -312,3 +353,101 @@ test_cases:
     sql: "CREATE INDEX idx_year ON ci_events (YEAR(dt))"
     expect:
       error: true
+
+  # === Adaptive computed indexes over query-bound JSON paths ===
+
+  - name: "Warm computed JSON_VALUE equality index"
+    setup:
+      - scm: '(settings "ScanDebugging" true)'
+      - sql: "DELETE FROM system_statistic.scans WHERE schema = 'memcp-tests' AND `table` = 'ci_json_docs'"
+      - sql: "SELECT id FROM ci_json_docs WHERE JSON_VALUE(payload, '$.tenant' RETURNING UNSIGNED) = 3"
+      - sql: "SELECT id FROM ci_json_docs WHERE JSON_VALUE(payload, '$.tenant' RETURNING UNSIGNED) = 3"
+      - sql: "SELECT id FROM ci_json_docs WHERE JSON_VALUE(payload, '$.tenant' RETURNING UNSIGNED) = 3"
+      - sql: "SELECT id FROM ci_json_docs WHERE JSON_VALUE(payload, '$.tenant' RETURNING UNSIGNED) = 3"
+      - scm: '(sleep 0.1)'
+    sql: |
+      SELECT id
+      FROM ci_json_docs
+      WHERE JSON_VALUE(payload, '$.tenant' RETURNING UNSIGNED) = 3
+    expect:
+      rows: 4
+      data:
+        - id: 3
+        - id: 7
+        - id: 11
+        - id: 15
+
+  - name: "Computed JSON_VALUE scan uses selective candidates"
+    setup:
+      - scm: '(sleep 0.1)'
+    sql: |
+      SELECT inputCount, candidateCount, outputCount,
+        CASE WHEN candidateCount < inputCount AND index_cols LIKE '.%json_value%' THEN 'ok' ELSE 'FAIL' END AS result
+      FROM system_statistic.scans
+      WHERE schema = 'memcp-tests' AND `table` = 'ci_json_docs'
+      ORDER BY timestamp DESC
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - inputCount: 16
+          candidateCount: 4
+          outputCount: 4
+          result: ok
+
+  - name: "Computed JSON index separates query-binding variants"
+    sql: |
+      SELECT id
+      FROM ci_json_docs
+      WHERE JSON_VALUE(payload, '$.rank' RETURNING UNSIGNED) = 3
+      ORDER BY id
+    expect:
+      rows: 1
+      data:
+        - id: 3
+
+  - repeat: 4
+    tests:
+      - name: "Warm PostgreSQL computed JSON extraction index"
+        syntax: postgresql
+        sql: "SELECT id FROM ci_json_docs WHERE (payload->>'tenant')::integer = 2"
+        expect:
+          rows: 4
+          data:
+            - id: 2
+            - id: 6
+            - id: 10
+            - id: 14
+
+  - name: "Probe warmed PostgreSQL computed JSON extraction index"
+    syntax: postgresql
+    setup:
+      - sql: "DELETE FROM system_statistic.scans WHERE schema = 'memcp-tests' AND `table` = 'ci_json_docs'"
+    sql: "SELECT id FROM ci_json_docs WHERE (payload->>'tenant')::integer = 2"
+    expect:
+      rows: 4
+      data:
+        - id: 2
+        - id: 6
+        - id: 10
+        - id: 14
+
+  - name: "PostgreSQL computed JSON scan uses selective candidates"
+    setup:
+      - scm: '(sleep 0.1)'
+    sql: |
+      SELECT inputCount, candidateCount, outputCount,
+        CASE WHEN candidateCount < inputCount THEN 'ok' ELSE 'FAIL' END AS result
+      FROM system_statistic.scans
+      WHERE schema = 'memcp-tests' AND `table` = 'ci_json_docs'
+      ORDER BY timestamp DESC
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - inputCount: 16
+          candidateCount: 4
+          outputCount: 4
+          result: ok
+    cleanup:
+      - scm: '(settings "ScanDebugging" false)'


### PR DESCRIPTION
## Summary

- recognize query-bound scalar values as invariant leaves for computed storage boundaries
- resolve callable purity through `scm.DeclarationForValue(...).IsFoldable()`; no `SourceInfo` dependency and no JSON-specific analyzer cases
- specialize session reads once per index variant before entering the row loop
- keep adaptive build savings isolated per session variant and preserve variant metadata across shard rebuilds
- keep parameterized whole-boolean predicates on their existing physical path instead of creating costly one-off boolean indexes
- cover MySQL `JSON_VALUE` and PostgreSQL JSON extraction with functional scan-stat assertions
- add a JSON-heavy selective projection performance case

## A/B methodology

Detached `origin/master` and this branch were built as normal binaries and run through the same `tests/performance/json-functions.yaml`. Each test case was measured independently 15 times. Setup, document generation, inserts, and rebuilds are outside the reported query time.

The selective index case uses 200,000 documents. The existing control cases use 10,000 documents. Times below are the per-query medians over those 15 repetitions; there is no aggregate across different queries.

## A/B by query and physical shape

### 1. BSON nested-path aggregate scan

```sql
SELECT SUM(JSON_VALUE(doc, '$.nested.score' RETURNING SIGNED)) AS total
FROM json_perf_documents;
```

- Shape: full column scan -> BSON nested-path extraction -> scalar SUM
- Features: BSON traversal, nested object path, numeric conversion, aggregate consumer
- Rows: 10,000
- `origin/master`: 1.534 ms
- PR: 1.577 ms
- Change: **0.97x**; 2.8% slower
- Expected effect: control case; no computed boundary is available to the new index path

### 2. TEXT parse-on-access aggregate scan

```sql
SELECT SUM(JSON_VALUE(doc_text, '$.nested.score' RETURNING SIGNED)) AS total
FROM json_perf_documents;
```

- Shape: full text-column scan -> JSON parse -> nested-path extraction -> scalar SUM
- Features: string input compatibility, parse-on-access, numeric conversion, aggregate consumer
- Rows: 10,000
- `origin/master`: 1.352 ms
- PR: 1.383 ms
- Change: **0.98x**; 2.3% slower
- Expected effect: control case; this PR does not change parsing or aggregate execution

### 3. Two computed JSON predicates under COUNT

```sql
SELECT COUNT(*) AS matches
FROM json_perf_documents
WHERE JSON_VALUE(doc, '$.tenant' RETURNING UNSIGNED) = 17
  AND JSON_VALUE(doc, '$.status' RETURNING CHAR) = 'active';
```

- Shape: two computed scalar predicates -> conjunction -> COUNT
- Features: multiple paths from one BSON value, numeric and string result conversion, aggregate filter
- Rows: 10,000
- `origin/master`: 1.721 ms
- PR: 1.372 ms
- Change: **1.25x faster**; 20.3% lower query time
- Effect: the expressions are now analyzable as declared foldable row functions, although this aggregate shape does not expose the same selective candidate reduction as the direct projection below

### 4. Selective computed equality index

```sql
SELECT id
FROM json_perf_documents
WHERE JSON_VALUE(doc, '$.tenant' RETURNING UNSIGNED) = 17;
```

- Shape: computed equality boundary -> adaptive computed index -> selective row projection
- Features: MySQL `JSON_VALUE`, query-bound path, BSON scalar extraction, unsigned conversion, computed index reuse
- Rows: 200,000
- Selectivity: 1/64, approximately 3,125 projected rows
- `origin/master`: 85.534 ms
- PR: 6.895 ms
- Change: **12.41x faster**; 91.9% lower query time
- Effect: this is the primary optimized physical shape in the PR

### 5. MySQL computed ORDER BY with LIMIT

```sql
SELECT id, JSON_VALUE(doc, '$.rank' RETURNING SIGNED) AS rank_value
FROM json_perf_documents
ORDER BY JSON_VALUE(doc, '$.rank' RETURNING SIGNED) DESC, id DESC
LIMIT 100;
```

- Shape: computed sort key -> descending top-k -> projection
- Features: repeated JSON expression, numeric conversion, deterministic tie-breaker, LIMIT
- Rows: 10,000
- `origin/master`: 2.681 ms
- PR: 2.640 ms
- Change: **1.02x faster**; 1.5% lower query time
- Expected effect: control case; this PR targets computed filter boundaries, not computed ORDER BY lowering

### 6. JSON object construction and array aggregation

```sql
SELECT id % 64 AS tenant,
  JSON_ARRAYAGG(JSON_OBJECT(
    'id', id,
    'rank', JSON_VALUE(doc, '$.rank' RETURNING SIGNED),
    'label', JSON_VALUE(doc, '$.nested.label' RETURNING CHAR)
  )) AS documents
FROM json_perf_documents
GROUP BY id % 64;
```

- Shape: full scan -> two JSON extractions -> JSON object construction -> grouped JSON array aggregation
- Features: BSON traversal, deep path, object serialization, array aggregation, 64 groups
- Rows: 10,000
- `origin/master`: 7.343 ms
- PR: 7.659 ms
- Change: **0.96x**; 4.3% slower
- Expected effect: control case for the later serialization/streaming work; no P2 index boundary applies

### 7. PostgreSQL extraction operator ORDER BY with LIMIT

```sql
SELECT id, (doc->>'rank')::integer AS rank_value
FROM json_perf_documents
ORDER BY (doc->>'rank')::integer DESC, id DESC
LIMIT 100;
```

- Shape: PostgreSQL extraction operator -> integer cast -> descending top-k
- Features: `->>` parser lowering, cast, repeated expression, deterministic LIMIT
- Rows: 10,000
- `origin/master`: 2.780 ms
- PR: 2.821 ms
- Change: **0.99x**; 1.5% slower
- Expected effect: control case; PostgreSQL computed filtering is covered functionally, while this ORDER BY shape is not optimized here

### 8. PostgreSQL JSONPath predicate scan

```sql
SELECT COUNT(*) AS matches
FROM json_perf_documents
WHERE jsonb_path_exists(doc, '$.items[*] ? (@.qty >= 2)');
```

- Shape: full scan -> JSONPath array wildcard predicate -> COUNT
- Features: PostgreSQL JSONPath, array traversal, predicate comparison, aggregate filter
- Rows: 10,000
- `origin/master`: 1.163 ms
- PR: 1.361 ms
- Change: **0.85x**; 17.0% slower
- Expected effect: control case; the PR does not add a JSONPath-specific access method

## What this PR demonstrably optimizes

The large improvement is specific to reusable selective computed scalar boundaries, not every JSON-heavy query. The implementation is function-generic because indexability comes from declaration metadata, but ORDER BY, JSON construction/aggregation, TEXT parsing, and general JSONPath scans remain separate future optimization packages.

## Complete-suite summary

Across the eight independently reported query measurements:

| Metric | `origin/master` | PR | Change |
|---|---:|---:|---:|
| Sum of the eight query times | 104.108 ms | 25.708 ms | 4.05x faster / -75.3% |
| Arithmetic average per test case | 13.013 ms | 3.213 ms | 4.05x faster / -75.3% |

This suite-level average is intentionally shown only after the per-query breakdown. It is dominated by the 200,000-row selective-index case, while the seven control cases use 10,000 rows, so it must not be read as an equal-workload average.

## Tests

- regular repository pre-commit hook: all tests passed
- computed index SQL suite: 39/39
- late-projection regression suite: 35/35
- ACL membership regression suite: 24/24
- focused storage analyzer tests
- MySQL parameter/path variant correctness and selective candidate counts
- PostgreSQL extraction operator selective candidate counts
