### PR TITLE
Stream nested BSON serialization

### DIFF
--- a/scm/json_bson.go
+++ b/scm/json_bson.go
@@ -306,6 +306,45 @@ func bsonArrayFromRawValues(values []bson.RawValue, flags uint64) Scmer {
 	return newBSONValueFlags(bson.TypeArray, payload, flags)
 }
 
+func bsonArrayFromRawParts(left bson.RawValue, leftArray bool, right bson.RawValue, rightArray bool, flags uint64) Scmer {
+	index, payload := bsoncore.AppendArrayStart(nil)
+	valueIndex := 0
+	appendValue := func(value bson.RawValue) {
+		payload = append(payload, byte(value.Type))
+		payload = strconv.AppendInt(payload, int64(valueIndex), 10)
+		payload = append(payload, 0)
+		payload = append(payload, value.Value...)
+		valueIndex++
+	}
+	appendPart := func(value bson.RawValue, array bool) {
+		if !array {
+			appendValue(value)
+			return
+		}
+		if len(value.Value) < bsoncore.EmptyDocumentLength {
+			panic(fmt.Errorf("invalid BSON array length %d", len(value.Value)))
+		}
+		remaining := value.Value[4 : len(value.Value)-1]
+		for len(remaining) > 0 {
+			element, rest, ok := bsoncore.ReadElement(remaining)
+			if !ok {
+				panic("invalid BSON array element")
+			}
+			child := element.Value()
+			appendValue(bson.RawValue{Type: bson.Type(child.Type), Value: child.Data})
+			remaining = rest
+		}
+	}
+	appendPart(left, leftArray)
+	appendPart(right, rightArray)
+	var err error
+	payload, err = bsoncore.AppendArrayEnd(payload, index)
+	if err != nil {
+		panic(err)
+	}
+	return newBSONValueFlags(bson.TypeArray, payload, flags)
+}
+
 func bsonDocumentFromPairs(pairs []bsonJSONPair, flags uint64) Scmer {
 	// JSON object keys are canonicalized to deterministic order. For duplicate
 	// keys the last input pair wins.
@@ -667,6 +706,105 @@ func appendBSONJSON(dst []byte, value bson.RawValue, pretty bool, prefix string,
 
 func appendBSONText(dst []byte, value Scmer, pretty bool, prefix string) ([]byte, error) {
 	return appendBSONJSON(dst, bsonRawValue(value), pretty, prefix, 0)
+}
+
+func writeBSONJSON(writer io.Writer, value bson.RawValue) error {
+	bufferSize := len(value.Value)
+	if bufferSize < 256 {
+		bufferSize = 256
+	} else if bufferSize > 16*1024 {
+		bufferSize = 16 * 1024
+	}
+	buffer := make([]byte, 0, bufferSize)
+	flush := func() error {
+		pending := buffer
+		for len(pending) > 0 {
+			written, err := writer.Write(pending)
+			if err != nil {
+				return err
+			}
+			if written == 0 {
+				return io.ErrShortWrite
+			}
+			pending = pending[written:]
+		}
+		buffer = buffer[:0]
+		return nil
+	}
+	appendByte := func(value byte) error {
+		buffer = append(buffer, value)
+		if len(buffer) >= cap(buffer) {
+			return flush()
+		}
+		return nil
+	}
+	var walk func(bson.RawValue) error
+	walk = func(current bson.RawValue) error {
+		if current.Type != bson.TypeEmbeddedDocument && current.Type != bson.TypeArray {
+			var err error
+			buffer, err = appendBSONJSON(buffer, current, false, "", 0)
+			if err != nil {
+				return err
+			}
+			if len(buffer) >= cap(buffer) {
+				return flush()
+			}
+			return nil
+		}
+
+		if len(current.Value) < bsoncore.EmptyDocumentLength {
+			return fmt.Errorf("invalid BSON container length %d", len(current.Value))
+		}
+		isDocument := current.Type == bson.TypeEmbeddedDocument
+		if isDocument {
+			if err := appendByte('{'); err != nil {
+				return err
+			}
+		} else if err := appendByte('['); err != nil {
+			return err
+		}
+		remaining := current.Value[4 : len(current.Value)-1]
+		count := 0
+		for len(remaining) > 0 {
+			element, rest, ok := bsoncore.ReadElement(remaining)
+			if !ok {
+				return fmt.Errorf("invalid BSON element")
+			}
+			if count > 0 {
+				if err := appendByte(','); err != nil {
+					return err
+				}
+			}
+			if isDocument {
+				key, err := element.KeyBytesErr()
+				if err != nil {
+					return err
+				}
+				if bytes.HasPrefix(key, []byte(bsonEscapedKeyPrefix)) {
+					buffer = appendJSONString(buffer, decodeBSONKey(string(key)))
+				} else {
+					buffer = appendJSONStringBytes(buffer, key)
+				}
+				if err := appendByte(':'); err != nil {
+					return err
+				}
+			}
+			child := element.Value()
+			if err := walk(bson.RawValue{Type: bson.Type(child.Type), Value: child.Data}); err != nil {
+				return err
+			}
+			remaining = rest
+			count++
+		}
+		if isDocument {
+			return appendByte('}')
+		}
+		return appendByte(']')
+	}
+	if err := walk(value); err != nil {
+		return err
+	}
+	return flush()
 }
 
 func bsonText(value Scmer) string {

--- a/scm/json_bson_test.go
+++ b/scm/json_bson_test.go
@@ -17,9 +17,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package scm
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"testing"
 	"unsafe"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
 func callJSONTest(t *testing.T, name string, args ...Scmer) Scmer {
@@ -80,6 +85,25 @@ func TestBSONAppendStringUsesCallerBuffer(t *testing.T) {
 	text, appended := value.AppendString(buffer)
 	if got, want := string(appended[7:]), `{"escaped":"line\n\u0001","nested":[true,2.5,null]}`; got != want || text != want {
 		t.Fatalf("AppendString text=%q appended=%q want=%q", text, got, want)
+	}
+}
+
+func TestBSONWriteAndStreamMatchString(t *testing.T) {
+	value, err := NewBSONFromJSON(`{"customer":{"name":"Ada\nLovelace","rank":7},"items":[{"sku":"A","qty":2},null],"active":true}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	value.Write(&output)
+	if got, want := output.String(), value.String(); got != want {
+		t.Fatalf("written BSON = %q, want %q", got, want)
+	}
+	streamed, err := io.ReadAll(value.Stream())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(streamed), value.String(); got != want {
+		t.Fatalf("streamed BSON = %q, want %q", got, want)
 	}
 }
 
@@ -187,4 +211,75 @@ func BenchmarkBSONAppendString(b *testing.B) {
 		}
 		buffer = appended[:0]
 	}
+}
+
+func benchmarkJSONArrayAggReduce(b *testing.B, count int) {
+	entry := Globalenv.Vars[Symbol("json_arrayagg_entry")].Func()
+	reduce := Globalenv.Vars[Symbol("json_arrayagg_reduce")].Func()
+	values := make([]Scmer, count)
+	for i := range values {
+		values[i] = entry(bsonDocumentFromPairs([]bsonJSONPair{
+			{key: "id", value: bsonRawValue(NewBSONValue(bson.TypeInt64, bsoncore.AppendInt64(nil, int64(i))))},
+			{key: "serialNumber", value: bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "SN-1000000")))},
+		}, 0))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result := NewNil()
+		for i := range values {
+			result = reduce(result, values[i])
+		}
+		if !result.IsBSON() {
+			b.Fatal("JSON_ARRAYAGG did not return BSON")
+		}
+	}
+}
+
+func BenchmarkJSONArrayAggReduce3(b *testing.B) {
+	benchmarkJSONArrayAggReduce(b, 3)
+}
+
+func BenchmarkJSONArrayAggReduce8(b *testing.B) {
+	benchmarkJSONArrayAggReduce(b, 8)
+}
+
+func BenchmarkJSONArrayAggReduce1000(b *testing.B) {
+	benchmarkJSONArrayAggReduce(b, 1000)
+}
+
+func BenchmarkBSONSerializeNested1000(b *testing.B) {
+	serials := bsonArrayFromRawValues([]bson.RawValue{
+		bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "SN-1000000"))),
+		bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "SN-1000001"))),
+		bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "SN-1000002"))),
+	}, 0)
+	values := make([]bson.RawValue, 1000)
+	for i := range values {
+		values[i] = bsonRawValue(bsonDocumentFromPairs([]bsonJSONPair{
+			{key: "id", value: bsonRawValue(NewBSONValue(bson.TypeInt64, bsoncore.AppendInt64(nil, int64(i))))},
+			{key: "number", value: bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "DN-1000000")))},
+			{key: "serialNumbers", value: bsonRawValue(serials)},
+		}, 0))
+	}
+	value := bsonArrayFromRawValues(values, 0)
+
+	b.Run("append-materialize", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			encoded, err := appendBSONText(nil, value, false, "")
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(encoded) == 0 {
+				b.Fatal("empty BSON serialization")
+			}
+		}
+	})
+	b.Run("write-stream", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			value.Write(io.Discard)
+		}
+	})
 }

--- a/scm/json_functions.go
+++ b/scm/json_functions.go
@@ -2785,23 +2785,23 @@ func init_json_functions() {
 		case args[1].IsNil():
 			return bsonArrayFromValues(args[:1], bsonFlagArrayAgg)
 		}
-		left := []bson.RawValue(nil)
+		left := bson.RawValue{}
 		if leftIsState {
-			left = mustBSONValues(bsonRawValue(args[0]))
+			left = bsonRawValue(args[0])
 		} else {
 			value, err := bsonFromSQLScalar(args[0])
 			jsonPanic(err)
-			left = []bson.RawValue{bsonRawValue(value)}
+			left = bsonRawValue(value)
 		}
-		right := []bson.RawValue(nil)
+		right := bson.RawValue{}
 		if rightIsState {
-			right = mustBSONValues(bsonRawValue(args[1]))
+			right = bsonRawValue(args[1])
 		} else {
 			value, err := bsonFromSQLScalar(args[1])
 			jsonPanic(err)
-			right = []bson.RawValue{bsonRawValue(value)}
+			right = bsonRawValue(value)
 		}
-		return newBSONValueFlags(bson.TypeArray, jsonRawArray(append(append([]bson.RawValue(nil), left...), right...)).Value, bsonFlagArrayAgg)
+		return bsonArrayFromRawParts(left, leftIsState, right, rightIsState, bsonFlagArrayAgg)
 	})
 	declareJSON("json_objectagg_entry", "constructs a JSON_OBJECTAGG key/value entry", func(args ...Scmer) Scmer {
 		requireJSONArgs("JSON_OBJECTAGG", args, 2)

--- a/scm/network.go
+++ b/scm/network.go
@@ -223,11 +223,15 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 					res.Write(bytes)
 					io.WriteString(res, ": ")
 				} else {
-					bytes, err := json.Marshal(scmerToGo(v))
-					if err != nil {
-						panic(err)
+					if v.IsBSON() {
+						v.Write(res)
+					} else {
+						bytes, err := json.Marshal(scmerToGo(v))
+						if err != nil {
+							panic(err)
+						}
+						res.Write(bytes)
 					}
-					res.Write(bytes)
 					if i < len(dict)-1 {
 						io.WriteString(res, ", ")
 					}

--- a/scm/printer.go
+++ b/scm/printer.go
@@ -161,8 +161,12 @@ func WriteStringValue(w *schemeTextWriter, v Scmer) {
 	switch v.GetTag() {
 	case tagNil:
 		w.WriteString("nil")
-	case tagBool, tagString, tagCString, tagBString, tagBSON, tagSymbol:
+	case tagBool, tagString, tagCString, tagBString, tagSymbol:
 		w.WriteString(v.String())
+	case tagBSON:
+		if err := writeBSONJSON(w, bsonRawValue(v)); err != nil {
+			panic(err)
+		}
 	case tagInt:
 		var buffer [32]byte
 		value := strconv.AppendInt(buffer[:0], v.Int(), 10)

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -840,12 +840,21 @@ func (s Scmer) String() string {
 
 // Stream returns an io.Reader for the value.
 // - If the underlying value is already an io.Reader (streams are encoded as Any), it is passed through.
-// - Otherwise, the value is converted to its string form and a strings.Reader is returned.
+// - BSON is serialized incrementally through the existing writer path.
+// - Other values are converted to their string form and returned through a strings.Reader.
 func (s Scmer) Stream() io.Reader {
 	if s.GetTag() == tagAny {
 		if r, ok := s.Any().(io.Reader); ok {
 			return r
 		}
+	}
+	if s.IsBSON() {
+		reader, writer := io.Pipe()
+		go func() {
+			err := writeBSONJSON(writer, bsonRawValue(s))
+			_ = writer.CloseWithError(err)
+		}()
+		return reader
 	}
 	return strings.NewReader(s.String())
 }
@@ -1188,12 +1197,9 @@ func (s *Scmer) Write(w io.Writer) {
 	case tagString, tagSymbol:
 		io.WriteString(w, s.String())
 	case tagBSON:
-		var buffer [512]byte
-		encoded, err := appendBSONText(buffer[:0], *s, false, "")
-		if err != nil {
+		if err := writeBSONJSON(w, bsonRawValue(*s)); err != nil {
 			panic(err)
 		}
-		w.Write(encoded)
 	case tagFunc:
 		io.WriteString(w, "[func]")
 	case tagSlice:

--- a/scm/streams.go
+++ b/scm/streams.go
@@ -32,12 +32,7 @@ func init_streams() {
 		Name: "streamString",
 		Desc: "creates a stream that contains a string",
 		Fn: func(a ...Scmer) Scmer {
-			reader, writer := io.Pipe()
-			go func() {
-				io.WriteString(writer, String(a[0]))
-				writer.Close()
-			}()
-			return NewAny(io.Reader(reader))
+			return NewAny(a[0].Stream())
 		},
 		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "content", ParamDesc: "content to put into the stream"}},

--- a/tests/performance/json-nested-serialization.yaml
+++ b/tests/performance/json-nested-serialization.yaml
@@ -1,0 +1,235 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# These queries intentionally emit one complete JSON/BSON value without
+# pagination. Each shape adds one serialization level so A/B reports can
+# distinguish flat aggregation, child-array embedding, and full three-level
+# delivery-note serialization.
+
+metadata:
+  version: "1.0"
+  description: "Complete nested JSON/BSON serialization without pagination"
+  isolated: true
+
+x-delivery-setup: &delivery_setup
+  - sql: "DROP TABLE IF EXISTS json_perf_serial_numbers"
+  - sql: "DROP TABLE IF EXISTS json_perf_delivery_items"
+  - sql: "DROP TABLE IF EXISTS json_perf_delivery_notes"
+  - scm: "(rebuild)"
+  - sql: |
+      CREATE TABLE json_perf_delivery_notes (
+        id INT PRIMARY KEY,
+        note_number VARCHAR(32) NOT NULL,
+        customer_name VARCHAR(64) NOT NULL,
+        delivery_date INT NOT NULL,
+        status VARCHAR(16) NOT NULL
+      ) ENGINE=memory
+  - sql: |
+      CREATE TABLE json_perf_delivery_items (
+        id INT PRIMARY KEY,
+        delivery_note_id INT NOT NULL,
+        sku VARCHAR(32) NOT NULL,
+        quantity INT NOT NULL,
+        unit_price INT NOT NULL,
+        FOREIGN KEY (delivery_note_id) REFERENCES json_perf_delivery_notes(id)
+      ) ENGINE=memory
+  - sql: |
+      CREATE TABLE json_perf_serial_numbers (
+        id INT PRIMARY KEY,
+        delivery_item_id INT NOT NULL,
+        serial_number VARCHAR(48) NOT NULL,
+        FOREIGN KEY (delivery_item_id) REFERENCES json_perf_delivery_items(id)
+      ) ENGINE=memory
+  - scm: |
+      (begin
+        (define delivery_count {rows})
+        (define item_count (* delivery_count 8))
+        (define serial_count (* item_count 3))
+        (define inserted_deliveries
+          (insert (table "{database}" "json_perf_delivery_notes")
+            '("id" "note_number" "customer_name" "delivery_date" "status")
+            (map (produceN delivery_count) (lambda (i)
+              (list (+ i 1)
+                (concat "DN-" (+ i 1))
+                (concat "Customer " (mod i 4096))
+                (+ 1700000000 i)
+                (if (equal? (mod i 5) 0) "open" "shipped"))))))
+        (define inserted_items
+          (insert (table "{database}" "json_perf_delivery_items")
+            '("id" "delivery_note_id" "sku" "quantity" "unit_price")
+            (map (produceN item_count) (lambda (i)
+              (list (+ i 1)
+                (+ (floor (/ i 8)) 1)
+                (concat "SKU-" (mod i 16384))
+                (+ (mod i 7) 1)
+                (+ (mod (* i 37) 10000) 100))))))
+        (define inserted_serials
+          (insert (table "{database}" "json_perf_serial_numbers")
+            '("id" "delivery_item_id" "serial_number")
+            (map (produceN serial_count) (lambda (i)
+              (list (+ i 1)
+                (+ (floor (/ i 3)) 1)
+                (concat "SN-" (+ i 1000000)))))))
+        (rebuild)
+        (define mem (memstats))
+        (list (+ inserted_deliveries inserted_items inserted_serials) (mem "heap_alloc")))
+
+test_cases:
+  - name: "Perf JSON delivery: emit complete flat object list"
+    setup: *delivery_setup
+    sql: |
+      SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'customer', delivery_note.customer_name,
+        'date', delivery_note.delivery_date,
+        'status', delivery_note.status
+      )) AS delivery_notes
+      FROM json_perf_delivery_notes AS delivery_note
+    threshold_ms: 30000
+    expect:
+      rows: 1
+
+  - name: "Perf JSON delivery: emit complete list with item arrays"
+    setup: *delivery_setup
+    sql: |
+      SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'customer', delivery_note.customer_name,
+        'date', delivery_note.delivery_date,
+        'status', delivery_note.status,
+        'items', (
+          SELECT JSON_ARRAYAGG(JSON_OBJECT(
+            'id', delivery_item.id,
+            'sku', delivery_item.sku,
+            'quantity', delivery_item.quantity,
+            'unitPrice', delivery_item.unit_price
+          ))
+          FROM json_perf_delivery_items AS delivery_item
+          WHERE delivery_item.delivery_note_id = delivery_note.id
+        )
+      )) AS delivery_notes
+      FROM json_perf_delivery_notes AS delivery_note
+    threshold_ms: 30000
+    expect:
+      rows: 1
+
+  - name: "Perf JSON delivery: emit complete three-level list with serial arrays"
+    setup: *delivery_setup
+    sql: |
+      SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'customer', delivery_note.customer_name,
+        'date', delivery_note.delivery_date,
+        'status', delivery_note.status,
+        'items', (
+          SELECT JSON_ARRAYAGG(JSON_OBJECT(
+            'id', delivery_item.id,
+            'sku', delivery_item.sku,
+            'quantity', delivery_item.quantity,
+            'unitPrice', delivery_item.unit_price,
+            'serialNumbers', (
+              SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                'id', serial_number.id,
+                'serialNumber', serial_number.serial_number
+              ))
+              FROM json_perf_serial_numbers AS serial_number
+              WHERE serial_number.delivery_item_id = delivery_item.id
+            )
+          ))
+          FROM json_perf_delivery_items AS delivery_item
+          WHERE delivery_item.delivery_note_id = delivery_note.id
+        )
+      )) AS delivery_notes
+      FROM json_perf_delivery_notes AS delivery_note
+    threshold_ms: 30000
+    expect:
+      rows: 1
+
+  - name: "Perf JSON PostgreSQL delivery: emit complete three-level list with serial arrays"
+    syntax: postgresql
+    setup: *delivery_setup
+    sql: |
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'customer', delivery_note.customer_name,
+        'date', delivery_note.delivery_date,
+        'status', delivery_note.status,
+        'items', (
+          SELECT jsonb_agg(jsonb_build_object(
+            'id', delivery_item.id,
+            'sku', delivery_item.sku,
+            'quantity', delivery_item.quantity,
+            'unitPrice', delivery_item.unit_price,
+            'serialNumbers', (
+              SELECT jsonb_agg(jsonb_build_object(
+                'id', serial_number.id,
+                'serialNumber', serial_number.serial_number
+              ))
+              FROM json_perf_serial_numbers AS serial_number
+              WHERE serial_number.delivery_item_id = delivery_item.id
+            )
+          ))
+          FROM json_perf_delivery_items AS delivery_item
+          WHERE delivery_item.delivery_note_id = delivery_note.id
+        )
+      )) AS delivery_notes
+      FROM json_perf_delivery_notes AS delivery_note
+    threshold_ms: 30000
+    expect:
+      rows: 1
+
+  - name: "Perf JSON delivery control: explicit grouped item carrier"
+    setup: *delivery_setup
+    sql: |
+      SELECT JSON_ARRAYAGG(JSON_OBJECT(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'customer', delivery_note.customer_name,
+        'date', delivery_note.delivery_date,
+        'status', delivery_note.status,
+        'items', grouped_items.items
+      )) AS delivery_notes
+      FROM json_perf_delivery_notes AS delivery_note
+      LEFT JOIN (
+        SELECT delivery_item.delivery_note_id,
+          JSON_ARRAYAGG(JSON_OBJECT(
+            'id', delivery_item.id,
+            'sku', delivery_item.sku,
+            'quantity', delivery_item.quantity,
+            'unitPrice', delivery_item.unit_price,
+            'serialNumbers', (
+              SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                'id', serial_number.id,
+                'serialNumber', serial_number.serial_number
+              ))
+              FROM json_perf_serial_numbers AS serial_number
+              WHERE serial_number.delivery_item_id = delivery_item.id
+            )
+          )) AS items
+        FROM json_perf_delivery_items AS delivery_item
+        GROUP BY delivery_item.delivery_note_id
+      ) AS grouped_items ON grouped_items.delivery_note_id = delivery_note.id
+    threshold_ms: 30000
+    expect:
+      rows: 1
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS json_perf_serial_numbers"
+  - sql: "DROP TABLE IF EXISTS json_perf_delivery_items"
+  - sql: "DROP TABLE IF EXISTS json_perf_delivery_notes"

--- a/tests/sql/expressions/json-functions.yaml
+++ b/tests/sql/expressions/json-functions.yaml
@@ -372,6 +372,73 @@ test_cases:
       data:
         - values_array: [1, null, 3]
 
+  - name: "nested delivery-note JSON embeds item and serial-number arrays"
+    setup:
+      - sql: "DROP TABLE IF EXISTS json_delivery_serial_numbers"
+      - sql: "DROP TABLE IF EXISTS json_delivery_items"
+      - sql: "DROP TABLE IF EXISTS json_delivery_notes"
+      - sql: "CREATE TABLE json_delivery_notes (id INT PRIMARY KEY, note_number VARCHAR(16), delivery_date INT)"
+      - sql: "CREATE TABLE json_delivery_items (id INT PRIMARY KEY, delivery_note_id INT, sku VARCHAR(16), quantity INT)"
+      - sql: "CREATE TABLE json_delivery_serial_numbers (id INT PRIMARY KEY, delivery_item_id INT, serial_number VARCHAR(16))"
+      - sql: "INSERT INTO json_delivery_notes VALUES (1, 'DN-1', 200), (2, 'DN-2', 100)"
+      - sql: "INSERT INTO json_delivery_items VALUES (10, 1, 'SKU-A', 2), (11, 1, 'SKU-B', 1), (20, 2, 'SKU-C', 4)"
+      - sql: "INSERT INTO json_delivery_serial_numbers VALUES (100, 10, 'SN-A1'), (101, 10, 'SN-A2'), (110, 11, 'SN-B1'), (200, 20, 'SN-C1')"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS json_delivery_serial_numbers"
+      - sql: "DROP TABLE IF EXISTS json_delivery_items"
+      - sql: "DROP TABLE IF EXISTS json_delivery_notes"
+    sql: |
+      SELECT JSON_OBJECT(
+        'id', delivery_note.id,
+        'number', delivery_note.note_number,
+        'items', (
+          SELECT JSON_ARRAYAGG(JSON_OBJECT(
+            'id', delivery_item.id,
+            'sku', delivery_item.sku,
+            'quantity', delivery_item.quantity,
+            'serialNumbers', (
+              SELECT JSON_ARRAYAGG(JSON_OBJECT(
+                'id', serial_number.id,
+                'serialNumber', serial_number.serial_number
+              ))
+              FROM json_delivery_serial_numbers AS serial_number
+              WHERE serial_number.delivery_item_id = delivery_item.id
+            )
+          ))
+          FROM json_delivery_items AS delivery_item
+          WHERE delivery_item.delivery_note_id = delivery_note.id
+        )
+      ) AS delivery_note
+      FROM json_delivery_notes AS delivery_note
+      ORDER BY delivery_note.delivery_date DESC
+    expect:
+      rows: 2
+      data:
+        - delivery_note:
+            id: 1
+            number: "DN-1"
+            items:
+              - id: 10
+                sku: "SKU-A"
+                quantity: 2
+                serialNumbers:
+                  - {id: 100, serialNumber: "SN-A1"}
+                  - {id: 101, serialNumber: "SN-A2"}
+              - id: 11
+                sku: "SKU-B"
+                quantity: 1
+                serialNumbers:
+                  - {id: 110, serialNumber: "SN-B1"}
+        - delivery_note:
+            id: 2
+            number: "DN-2"
+            items:
+              - id: 20
+                sku: "SKU-C"
+                quantity: 4
+                serialNumbers:
+                  - {id: 200, serialNumber: "SN-C1"}
+
   - name: "JSON_OBJECTAGG over table rows"
     sql: "SELECT JSON_OBJECTAGG(id, JSON_VALUE(doc, '$.customer.name')) AS names FROM json_documents"
     expect:


### PR DESCRIPTION
## Summary

- streams normal `tagBSON` values through the existing `Scmer.Write` / `Scmer.Stream` and `io.Reader` / `io.Writer` paths; no BSON output type, SCM tag, or storage special case was added
- emits BSON-backed JSON directly from the HTTP JSONL endpoint instead of materializing `bsonText -> json.RawMessage -> json.Marshal`
- makes `streamString` reuse the existing value stream and makes structural `WriteStringValue` stream BSON as well
- reduces `JSON_ARRAYAGG` by copying raw BSON elements directly into the result array instead of expanding both sides into Go slices and encoding them again
- adds a correctness fixture with delivery notes -> items -> serial-number arrays and a dedicated no-`LIMIT` performance suite for complete nested result emission

## Physical-plan analysis

The three-level correlated shape is already decorrelated. Its physical plan builds the serial-number aggregate carrier once, scans the eight matching item rows per delivery note, and performs a keyed serial carrier probe per item. The explicit-control query instead groups the item carrier once and joins it to delivery notes.

The control is only close to the correlated shape, so this PR does not alter planner costing or add a query-specific rule. The measured improvement comes from BSON aggregation and final serialization. All five queries emit one complete root JSON/BSON value; none uses `LIMIT`.

## SQL A/B

Dataset per case: 1,000 delivery notes, 8,000 items, 24,000 serial numbers. Two warmups, then three samples; table reports median and min-max. Same machine and suite, `origin/master` versus this branch.

| Query shape / exercised features | master median (min-max) | branch median (min-max) | change |
|---|---:|---:|---:|
| Flat complete list: root `JSON_ARRAYAGG(JSON_OBJECT(...))`, HTTP emission | 4.569 ms (3.792-5.688) | 1.924 ms (1.791-2.066) | 2.375x / -57.9% |
| One nested level: correlated item-array extraction, 1,000 item probes, root emission | 478.109 ms (477.544-489.293) | 461.614 ms (459.018-477.272) | 1.036x / -3.5% |
| MySQL three levels: notes -> item arrays -> serial arrays, nested scalar aggregates, full emission | 2,296.492 ms (2,292.817-2,350.537) | 2,272.269 ms (2,258.485-2,292.971) | 1.011x / -1.1% |
| PostgreSQL three levels: `jsonb_agg/jsonb_build_object`, same hierarchy and full emission | 2,078.136 ms (2,048.353-2,088.646) | 2,040.817 ms (2,032.106-2,046.889) | 1.018x / -1.8% |
| Control: explicit grouped item carrier plus nested serial carrier | 2,327.960 ms (2,302.995-2,327.982) | 2,263.937 ms (2,255.943-2,276.572) | 1.028x / -2.8% |

Arithmetic mean of the five query medians: 1,437.053 ms -> 1,408.112 ms (1.021x / -2.0%). This mean is secondary to the per-shape results above.

Command:

```
PERF_TEST=1 PERF_REPEAT=3 PERF_NORECALIBRATE=1 \
  python3 run_sql_tests.py tests/performance/json-nested-serialization.yaml --log-times
```

## Focused microbenchmarks

Five-run medians for the original reducer versus raw-BSON reduction:

| Benchmark | time | bytes/op | allocs/op |
|---|---:|---:|---:|
| `JSON_ARRAYAGG`, 3 objects | 1.351 us -> 578.3 ns (2.34x) | 1,536 -> 752 (-51.0%) | 23 -> 10 (-56.5%) |
| `JSON_ARRAYAGG`, 8 objects | 8.162 us -> 3.073 us (2.66x) | 11,880 -> 4,728 (-60.2%) | 94 -> 38 (-59.6%) |
| `JSON_ARRAYAGG`, 1,000 objects | 84.323 ms -> 40.128 ms (2.10x) | 202,851,378 -> 113,900,778 (-43.9%) | 436,504 -> 17,077 (-96.1%) |

The final implementation's nested-1000 serializer alternatives measure:

- append/materialize: 612.929 us, 447,747 B/op, 4,023 allocs/op
- bounded writer stream: 507.701 us, 171,779 B/op, 4,004 allocs/op
- result: 1.21x faster and 61.6% fewer allocated bytes

The aggregate remains a normal contiguous BSON value; for very large single groups its immutable accumulation still copies accumulated payload bytes. This PR deliberately does not introduce a rope/output value to change that representation.

## Verification

- `go test ./scm -count=1`
- JSON SQL suite: 50/50 passed
- nested performance suite: 5/5 passed
- full `./git-pre-commit`: all tests passed, commit allowed
