### PR TITLE
Keep physical carriers consistent across query scopes

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -245,6 +245,30 @@ metric, and makes them visible to a recompilation of the same request. */
 (define planner_queryplan_observation_metric_key (lambda (decision_id)
 	(concat "__memcp_queryplan_observation_metric_" (fnv_hash decision_id))))
 
+/* Adaptive values are executable request-local objects (often RecSets), not
+connection state. The outer session owns their concurrent flight, while the
+query generation is the scope that releases them after execution. */
+(define planner_queryplan_observation_session_expr (lambda ()
+	(list
+		(list (quote context) "session")
+		"get_or_compute_scoped"
+		(list (quote context) "query")
+		"__memcp_queryplan_observations"
+		(list (quote lambda) '() (list (quote newsession))))))
+
+(define planner_queryplan_observation_read_expr (lambda (key)
+	(list
+		(list
+			(physical_query_session_symbol)
+			"get_or_compute_scoped"
+			(physical_query_scope_symbol)
+			"__memcp_queryplan_observations"
+			(list (quote lambda) '() (list (quote newsession))))
+		key)))
+
+(define planner_queryplan_observation_current_read_expr (lambda (key)
+	(list (planner_queryplan_observation_session_expr) key)))
+
 (define planner_register_queryplan_observation (lambda (decision_id producer metric_expr)
 	(begin
 		(define preparations (try
@@ -276,8 +300,11 @@ metric, and makes them visible to a recompilation of the same request. */
 
 (define planner_queryplan_observed_metric (lambda (decision_id)
 	(try
-		(lambda () ((context "session")
-			(planner_queryplan_observation_metric_key decision_id)))
+		(lambda () (begin
+			(define compile_observations ((context "session") "__memcp_queryplan_observation_scope"))
+			(if (nil? compile_observations)
+				nil
+				(compile_observations (planner_queryplan_observation_metric_key decision_id)))))
 		(lambda (_e) nil))))
 
 (define empty_list? (lambda (xs)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1521,12 +1521,12 @@ membership set. */
 		(define lookup_value (symbol (concat "__recset_lookup_value_"
 			(fnv_hash (gs_id stage)))))
 		/* Bind the consumer-row key before entering the producer begin. begin owns a
-			shared numbered scope, while scan adapters may close the producer callbacks
-			independently. Lowering the row key inside that scope would bake its extra
-			outer hop into the cached producer and can escape the actual row closure when
-			several correlated projections share one continuation. The explicit value
-			parameter keeps producer construction closed and makes lexical ownership
-			independent of the surrounding projection shape. */
+		shared numbered scope, while scan adapters may close the producer callbacks
+		independently. Lowering the row key inside that scope would bake its extra
+		outer hop into the cached producer and can escape the actual row closure when
+		several correlated projections share one continuation. The explicit value
+		parameter keeps producer construction closed and makes lexical ownership
+		independent of the surrounding projection shape. */
 		(list
 			(list (quote lambda) (list lookup_value)
 				(list (quote begin)
@@ -2956,7 +2956,7 @@ rows outside the current batch. */
 			repeating text scans and FK projection for every expanded window. */
 			(list (quote recset_intersect)
 				(cons (quote list) (list batch_expr
-					(list (quote session)
+					(planner_queryplan_observation_read_expr
 						(planner_queryplan_observation_value_key decision_id)))))
 			(if (union_block? input)
 				(begin
@@ -3502,7 +3502,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 									(list "cost" (planner_cost_explain prefiltered_cost)))
 								nil)) (lambda (alternative) (not (nil? alternative)))))))
 				(list chosen (if (not (nil? observation_keys))
-					(list (quote session) (car observation_keys))
+					(planner_queryplan_observation_read_expr (car observation_keys))
 					(if (equal? chosen "prefiltered_candidate_keyset")
 						prefiltered_expr raw_expr))))))))
 
@@ -5244,9 +5244,9 @@ ordinary physical carrier choice. */
 				bound value yields the exact full-or-empty truth set. */
 				(boolean_recset_domain_scan_plan domain_src expr)
 				(if (nil? target_col)
-				(neumann_fail "build_queryplan" "boolean RecSet probe requires one direct domain lookup key")
-				(lower_projected_recset_scalar_first_probe_expr
-					stage_catalog stage requested_col domain_src target_col false))))
+					(neumann_fail "build_queryplan" "boolean RecSet probe requires one direct domain lookup key")
+					(lower_projected_recset_scalar_first_probe_expr
+						stage_catalog stage requested_col domain_src target_col false))))
 		((symbol scalar_first_probe) stage requested_col _dependencies)
 		(boolean_recset_probe_leaf_plan stage_catalog domain_src
 			(list (quote scalar_first_probe) stage requested_col))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3310,7 +3310,7 @@ dependent choices must pass through this function and retain their guard. */
 					(list "status" (if (equal? chosen "ordered_base_membership") "chosen" "rejected"))
 					(list "cost" (planner_cost_explain base_cost)))))))
 		(list chosen (if (nil? observation_keys) carrier
-			(list (quote session) (car observation_keys)))))))
+			(planner_queryplan_observation_read_expr (car observation_keys)))))))
 
 (define lower_single_source_query_block (lambda (block)
 	(begin

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -152,6 +152,11 @@ functional planner return value. */
 	(begin
 		(define planning_session (newsession))
 		(define compile_bindings (newsession))
+		(define observation_scope (source_session
+			"get_or_compute_scoped"
+			(context "query")
+			"__memcp_queryplan_observations"
+			(lambda () (newsession))))
 		(reduce (source_session) (lambda (_ key)
 			(if (match key (regex "^v[0-9]+$" _) true false)
 				(begin
@@ -165,6 +170,7 @@ functional planner return value. */
 					nil
 					(planning_session key (source_session key))))) nil)
 		(planning_session "__memcp_queryplan_compile_bindings" compile_bindings)
+		(planning_session "__memcp_queryplan_observation_scope" observation_scope)
 		(planning_session "__memcp_queryplan_guard_conditions" (newsession))
 		(planning_session "__memcp_queryplan_guard_condition_catalog" (make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_guard_bindings" (newsession))
@@ -204,8 +210,16 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 (define sql_queryplan_runtime_guard_expr (lambda (expr)
 	(match expr
 		((symbol quote) _value) expr
-		((symbol session) key) (list (list (quote context) "session") key)
-		((quote session) key) (list (list (quote context) "session") key)
+		((symbol session) key) (if (match key
+			(regex "^__memcp_queryplan_observation_(?:value|metric)_" _) true
+			_ false)
+			(planner_queryplan_observation_current_read_expr key)
+			(list (list (quote context) "session") key))
+		((quote session) key) (if (match key
+			(regex "^__memcp_queryplan_observation_(?:value|metric)_" _) true
+			_ false)
+			(planner_queryplan_observation_current_read_expr key)
+			(list (list (quote context) "session") key))
 		(cons head tail) (cons
 			(sql_queryplan_runtime_guard_expr head)
 			(map tail sql_queryplan_runtime_guard_expr))
@@ -258,25 +272,28 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 	(match preparation '(decision_id producer metric_expr) (begin
 		(define value_key (planner_queryplan_observation_value_key decision_id))
 		(define metric_key (planner_queryplan_observation_metric_key decision_id))
-		(define request_session (list (quote context) "session"))
+		(define observation_session (symbol "__queryplan_observation_session"))
 		(define prepared_value (symbol "__queryplan_prepared_value"))
-		(list (quote if)
-			(list (quote number?) (list request_session metric_key))
-			true
-			(list (quote !begin)
-				(list (quote context) "check")
-				(list
-					(list (quote lambda) (list prepared_value)
-						(list (quote !begin)
-							(list request_session value_key prepared_value)
-							(list request_session metric_key
-								(list
-									(list (quote lambda) (list (symbol "__queryplan_observed_value")) metric_expr)
-									prepared_value))
-							true))
-					(sql_queryplan_runtime_guard_expr producer))
-				(list (quote context) "check")
-				true))))))
+		(list
+			(list (quote lambda) (list observation_session)
+				(list (quote if)
+					(list (quote number?) (list observation_session metric_key))
+					true
+					(list (quote !begin)
+						(list (quote context) "check")
+						(list
+							(list (quote lambda) (list prepared_value)
+								(list (quote !begin)
+									(list observation_session value_key prepared_value)
+									(list observation_session metric_key
+										(list
+											(list (quote lambda) (list (symbol "__queryplan_observed_value")) metric_expr)
+											prepared_value))
+									true))
+							(sql_queryplan_runtime_guard_expr producer))
+						(list (quote context) "check")
+						true)))
+			(planner_queryplan_observation_session_expr))))))
 
 /* Walk variants in priority order. A cheap guarded variant can return before
 an older expensive observation is prepared. Once a variant needs an

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -78,9 +78,15 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 	// preparation and repair instead.
 	t.schema.schemalock.Lock()
 	metadataLocked := true
+	ddlLocked := true
 	defer func() {
 		if metadataLocked {
 			t.schema.schemalock.Unlock()
+		}
+		// The caller owns ddlMu and must always receive it back, including when a
+		// shard computor panics while the materialization window is unlocked.
+		if !ddlLocked {
+			t.ddlMu.Lock()
 		}
 	}()
 	for i, c := range t.Columns {
@@ -106,6 +112,12 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 			}
 			t.schema.schemalock.Unlock()
 			metadataLocked = false
+			// Computors may lazily prepare another physical column on this table.
+			// Keep metadata publication serialized, but do not hold the table DDL
+			// mutex while executing arbitrary computors and waiting for shard jobs:
+			// a nested createcolumn would otherwise wait for its own parent forever.
+			t.ddlMu.Unlock()
+			ddlLocked = false
 			done := make(chan error, 6)
 			shardlist := t.ActiveShards()
 			currentTx := CurrentTx()
@@ -144,6 +156,8 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 				GlobalCache.UpdateSize(c, totalRows*16) // ~16 bytes per value estimate
 			}
 			if metadataChanged {
+				t.ddlMu.Lock()
+				ddlLocked = true
 				t.schema.schemalock.Lock()
 				metadataLocked = true
 				mode := t.schemaSaveMode()
@@ -152,6 +166,10 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 				}
 				t.finishSchemaMutationLocked(mode)
 				metadataLocked = false
+			}
+			if !ddlLocked {
+				t.ddlMu.Lock()
+				ddlLocked = true
 			}
 			return
 		}
@@ -725,7 +743,7 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 }
 
 func stripSourceInfo(expr scm.Scmer) scm.Scmer {
-	return expr
+	return expr.WithoutSourceInfo()
 }
 
 func callHeadIs(head scm.Scmer, names ...string) bool {
@@ -1659,9 +1677,46 @@ func buildSelectiveORCInvalidationBody(targetSchema, targetTable, colName string
 	}
 }
 
+func registerInvalidationPropagationTrigger(prefix string, srcTable, targetTable *table, colName string, acquire func() bool, release func()) string {
+	triggerName := prefix + targetTable.Name + ":" + colName + "|" + srcTable.Name + "|" + AfterInvalidate.String()
+	targetKey := targetTable.schema.Name + "\x00" + targetTable.Name + "\x00" + colName
+	propagationAcquire := func() bool {
+		if value, ok := scm.GetGLSValue(computeInvalidationWaveKey); ok && value.(map[string]bool)[targetKey] {
+			return false
+		}
+		return acquire()
+	}
+	for _, tr := range srcTable.Triggers {
+		if tr.Name == triggerName {
+			srcTable.SetTriggerTarget(triggerName, propagationAcquire, release)
+			return triggerName
+		}
+	}
+	tblExpr := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("table"),
+		scm.NewString(targetTable.schema.Name),
+		scm.NewString(targetTable.Name),
+	})
+	srcTable.AddTrigger(TriggerDescription{
+		Name:     triggerName,
+		Timing:   AfterInvalidate,
+		IsSystem: true,
+		Priority: 100,
+		Func: buildFKProc(scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("invalidatecolumn"),
+			tblExpr,
+			scm.NewString(colName),
+		})),
+		Acquire: propagationAcquire,
+		Release: release,
+	})
+	return triggerName
+}
+
 // registerComputeTriggers installs AfterInsert/AfterUpdate/AfterDelete triggers
 // on source tables so that changes automatically invalidate the computed column.
-// Also installs AfterDropTable so that dropping a source table cascades to the target.
+// AfterInvalidate edges propagate changes through nested computed caches. It also
+// installs AfterDropTable so that dropping a source table cascades to the target.
 func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 	refs := extractScanJoinInfo(computor)
 	targetSchema := t.schema.Name
@@ -1680,6 +1735,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 	// Collect trigger names placed on source tables for self-cleanup
 	type triggerRef struct{ schema, name string }
 	var registeredNames []triggerRef
+	registeredInvalidationSources := make(map[*table]bool)
 	for refIdx, ref := range refs {
 		srcDB := GetDatabase(ref.schema)
 		if srcDB == nil {
@@ -1759,6 +1815,12 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 			}
 			registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
 		}
+		if !registeredInvalidationSources[srcTable] {
+			registeredInvalidationSources[srcTable] = true
+			triggerName := registerInvalidationPropagationTrigger(
+				".cache:", srcTable, t, name, acquireTarget, releaseTarget)
+			registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
+		}
 		// AfterDropTable: when source table is dropped, drop the target table too
 		// Only for internal temp tables (dot-prefixed) — never drop user base tables
 		if strings.HasPrefix(t.Name, ".") {
@@ -1832,6 +1894,7 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 	releaseTarget := func() { t.releaseColumnCacheUse(col) }
 	type triggerRef struct{ schema, name string }
 	var registeredNames []triggerRef
+	registeredInvalidationSources := make(map[*table]bool)
 	for refIdx, ref := range refs {
 		srcDB := GetDatabase(ref.schema)
 		if srcDB == nil {
@@ -1880,6 +1943,12 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 			if srcTable != t {
 				registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
 			}
+		}
+		if srcTable != t && !registeredInvalidationSources[srcTable] {
+			registeredInvalidationSources[srcTable] = true
+			triggerName := registerInvalidationPropagationTrigger(
+				".orcdep:", srcTable, t, name, acquireTarget, releaseTarget)
+			registeredNames = append(registeredNames, triggerRef{ref.schema, triggerName})
 		}
 	}
 	if len(registeredNames) == 0 {

--- a/storage/compute_concurrency_test.go
+++ b/storage/compute_concurrency_test.go
@@ -45,6 +45,30 @@ func setupComputeConcurrencyTest(t *testing.T) func() {
 	}
 }
 
+func TestApplyWithTxRebindsCapturedPhysicalQueryTransaction(t *testing.T) {
+	staleTx := &TxContext{}
+	currentTx := &TxContext{}
+	computor := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice(nil),
+		Body:   scm.NewSymbol("__physical_query_tx"),
+		En: &scm.Env{
+			Vars: scm.Vars{
+				scm.Symbol("__physical_query_tx"): scm.NewAny(staleTx),
+			},
+			Outer: &scm.Globalenv,
+		},
+	})
+
+	got := applyWithTx(currentTx, computor)
+	if got.Any().(*TxContext) != currentTx {
+		t.Fatal("computed column reused the transaction captured by its creating query")
+	}
+	binding := computor.Proc().En.FindRead(scm.Symbol("__physical_query_tx"))
+	if binding.Vars[scm.Symbol("__physical_query_tx")].Any().(*TxContext) != staleTx {
+		t.Fatal("transaction rebinding mutated the shared computed-column closure")
+	}
+}
+
 func countCollapsedComputor() scm.Scmer {
 	filter := scm.NewProcStruct(scm.Proc{
 		Params: scm.NewSlice([]scm.Scmer{

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -64,7 +64,20 @@ type computeProxyReader struct {
 func applyWithTx(tx *TxContext, fn scm.Scmer, args ...scm.Scmer) scm.Scmer {
 	if fn.IsProc() {
 		proc := *fn.Proc()
-		proc.En = bindSessionEnv(proc.En, txSessionScmer(tx))
+		runtimeSession := txSessionScmer(tx)
+		proc.En = bindSessionEnv(proc.En, runtimeSession)
+		// Physical computed-column lambdas can outlive the query which created
+		// them. Never let their captured physical context pin a stale snapshot or
+		// request-local carrier: reads and lazy repairs use the current consumer.
+		// The fresh binding environment is procedure-local, so concurrent readers
+		// do not mutate the shared closure.
+		physicalTx := scm.NewNil()
+		if tx != nil {
+			physicalTx = scm.NewAny(tx)
+		}
+		proc.En.Vars[scm.Symbol("__physical_query_session")] = runtimeSession
+		proc.En.Vars[scm.Symbol("__physical_query_scope")] = scm.NewInt(int64(scm.CurrentQuerySeq()))
+		proc.En.Vars[scm.Symbol("__physical_query_tx")] = physicalTx
 		fn = scm.NewProcStruct(proc)
 	}
 	if tx == nil || tx.Session.IsNil() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -551,6 +551,40 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 	}
 }
 
+const computeInvalidationWaveKey = "memcpComputeInvalidationWave"
+
+// invalidateComputedColumn propagates invalidation through computed-cache
+// dependency edges. A GLS-local visited set makes one synchronous invalidation
+// wave idempotent and prevents malformed cyclic computed definitions from
+// recursing forever without introducing a global lock or cross-query state.
+func invalidateComputedColumn(t *table, colName string) {
+	if value, ok := scm.GetGLSValue(computeInvalidationWaveKey); ok {
+		visited := value.(map[string]bool)
+		key := t.schema.Name + "\x00" + t.Name + "\x00" + colName
+		if visited[key] {
+			return
+		}
+		visited[key] = true
+		invalidated := false
+		for _, s := range t.maintenanceShards() {
+			s.mu.RLock()
+			col := s.columns[colName]
+			s.mu.RUnlock()
+			if proxy, isProxy := col.(*StorageComputeProxy); isProxy {
+				proxy.InvalidateAll()
+				invalidated = true
+			}
+		}
+		if invalidated {
+			t.ExecuteTriggers(AfterInvalidate, nil, nil)
+		}
+		return
+	}
+	scm.SetValues(map[string]any{computeInvalidationWaveKey: make(map[string]bool)}, func() {
+		invalidateComputedColumn(t, colName)
+	})
+}
+
 func Init(en scm.Env) {
 	const scanFilterColumnsDesc = "physical columns passed to filter before map/reduce; $recset_contains supplies a row-bound RecSet membership closure"
 	const scanMapColumnsDesc = "physical columns passed to map after filtering; pseudo columns are $update (update/delete current row), $recset_contains (row-bound RecSet membership), $set:<column>, $increment:<column>, and $invalidate:<column> (computed-column maintenance), plus NEW.<column> in trigger plans"
@@ -2195,14 +2229,7 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			colName := scm.String(a[1])
-			for _, s := range t.maintenanceShards() {
-				s.mu.RLock()
-				col := s.columns[colName]
-				s.mu.RUnlock()
-				if proxy, ok := col.(*StorageComputeProxy); ok {
-					proxy.InvalidateAll()
-				}
-			}
+			invalidateComputedColumn(t, colName)
 			return scm.NewBool(true)
 		},
 		Type: &scm.TypeDescriptor{

--- a/tests/execution/concurrency/session-carrier-publication.yaml
+++ b/tests/execution/concurrency/session-carrier-publication.yaml
@@ -1,0 +1,375 @@
+# Copyright (C) 2026  MemCP Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Concurrent request-local predicates remain isolated in a shared physical carrier"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS scp_late_access"
+  - sql: "DROP TABLE IF EXISTS scp_late_item"
+  - sql: "DROP TABLE IF EXISTS scp_late_domain"
+  - sql: "DROP TABLE IF EXISTS scp_outer_cache"
+  - sql: "DROP TABLE IF EXISTS scp_middle_cache"
+  - sql: "DROP TABLE IF EXISTS scp_source"
+  - sql: "DROP TABLE IF EXISTS scp_access"
+  - sql: "DROP TABLE IF EXISTS scp_item"
+  - sql: "DROP TABLE IF EXISTS scp_domain"
+  - sql: "CREATE TABLE scp_domain (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE scp_late_domain (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE scp_late_item (id INT PRIMARY KEY, domain_id INT, created_at INT)"
+  - sql: "CREATE TABLE scp_late_access (id INT PRIMARY KEY, actor_id INT, domain_id INT)"
+  - sql: "INSERT INTO scp_late_item VALUES (55, 1, 10)"
+  - sql: "CREATE TABLE scp_item (id INT PRIMARY KEY, domain_id INT, created_at INT)"
+  - sql: "CREATE TABLE scp_access (id INT PRIMARY KEY, actor_id INT, domain_id INT)"
+  - sql: "INSERT INTO scp_domain VALUES (1), (2), (3), (4)"
+  - sql: "INSERT INTO scp_item VALUES (11, 1, 40), (22, 2, 30), (33, 3, 20), (44, 4, 10)"
+  - sql: "INSERT INTO scp_access VALUES (1, 101, 1), (2, 202, 2)"
+  - sql: "CREATE TABLE scp_source (id INT PRIMARY KEY, amount INT)"
+  - sql: "CREATE TABLE scp_middle_cache (id INT PRIMARY KEY)"
+  - sql: "CREATE TABLE scp_outer_cache (id INT PRIMARY KEY)"
+  - sql: "INSERT INTO scp_source VALUES (1, 10)"
+  - sql: "INSERT INTO scp_middle_cache VALUES (1)"
+  - sql: "INSERT INTO scp_outer_cache VALUES (1)"
+
+test_cases:
+  - name: "Set request domain before the physical cache is prepared"
+    session_id: "scp_late_reader"
+    sql: "SET @scp_actor = 303"
+    expect:
+      rows_affected: 0
+
+  - &late_read
+    name: "Prepare an empty physical cache"
+    session_id: "scp_late_reader"
+    sql: |
+      SELECT i.id
+      FROM scp_late_item i
+      WHERE COALESCE((
+        SELECT EXISTS (
+          SELECT 1 FROM scp_late_access a
+          WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+        )
+        FROM scp_late_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      rows: 0
+      data: []
+
+  - name: "Populate the domain after the empty cache was published"
+    sql: "INSERT INTO scp_late_domain VALUES (1)"
+    expect:
+      affected_rows: 1
+
+  - name: "Populate the access edge after the empty cache was published"
+    sql: "INSERT INTO scp_late_access VALUES (1, 303, 1)"
+    expect:
+      affected_rows: 1
+
+  - <<: *late_read
+    name: "The first read after population observes newly published cache keys"
+    expect:
+      rows: 1
+      data:
+        - id: 55
+
+  - name: "Set first request domain"
+    session_id: "scp_first"
+    sql: "SET @scp_actor = 101, @scp_role = 1"
+    expect:
+      rows_affected: 0
+
+  - name: "Set second request domain"
+    session_id: "scp_second"
+    sql: "SET @scp_actor = 202, @scp_role = 1"
+    expect:
+      rows_affected: 0
+
+  - name: "Compound scalar predicate lowers to an ordered projected carrier"
+    session_id: "scp_first"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT i.id
+      FROM scp_item i
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @scp_role = 1 THEN EXISTS (
+            SELECT 1 FROM scp_access a
+            WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+          )
+          ELSE TRUE
+        END
+        FROM scp_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      result_contains:
+        - "recset_project_join"
+        - "scan_order_recset_part"
+
+  - &first_read
+    name: "First request reads only its permitted row"
+    session_id: "scp_first"
+    sql: |
+      SELECT i.id
+      FROM scp_item i
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @scp_role = 1 THEN EXISTS (
+            SELECT 1 FROM scp_access a
+            WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+          )
+          ELSE TRUE
+        END
+        FROM scp_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      rows: 1
+      data:
+        - id: 11
+
+  - &second_read
+    name: "Second request reads only its permitted row"
+    session_id: "scp_second"
+    sql: |
+      SELECT i.id
+      FROM scp_item i
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @scp_role = 1 THEN EXISTS (
+            SELECT 1 FROM scp_access a
+            WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+          )
+          ELSE TRUE
+        END
+        FROM scp_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      rows: 1
+      data:
+        - id: 22
+
+  - <<: *first_read
+    name: "First request stays isolated during concurrent carrier preparation A"
+    parallel: "scp_carrier"
+  - <<: *second_read
+    name: "Second request stays isolated during concurrent carrier preparation A"
+    parallel: "scp_carrier"
+  - <<: *first_read
+    name: "First request stays isolated during concurrent carrier preparation B"
+    parallel: "scp_carrier"
+  - <<: *second_read
+    name: "Second request stays isolated during concurrent carrier preparation B"
+    parallel: "scp_carrier"
+  - <<: *first_read
+    name: "First request stays isolated during concurrent carrier preparation C"
+    parallel: "scp_carrier"
+  - <<: *second_read
+    name: "Second request stays isolated during concurrent carrier preparation C"
+    parallel: "scp_carrier"
+
+  - name: "A source mutation extends only the first request domain"
+    session_id: "scp_writer"
+    sql: "INSERT INTO scp_access VALUES (3, 101, 3)"
+    expect:
+      affected_rows: 1
+
+  - name: "First request observes a fresh carrier after the commit"
+    session_id: "scp_first"
+    sql: |
+      SELECT i.id
+      FROM scp_item i
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @scp_role = 1 THEN EXISTS (
+            SELECT 1 FROM scp_access a
+            WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+          )
+          ELSE TRUE
+        END
+        FROM scp_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      rows: 2
+      data:
+        - id: 11
+        - id: 33
+
+  - <<: *second_read
+    name: "Second request remains isolated after the commit"
+
+  - &shared_scalar_read
+    name: "A reused scalar predicate builds the materialized carrier"
+    session_id: "scp_first"
+    sql: |
+      SELECT i.id,
+        COALESCE((
+          SELECT CASE
+            WHEN @scp_role = 1 THEN EXISTS (
+              SELECT 1 FROM scp_access a
+              WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+            )
+            ELSE TRUE
+          END
+          FROM scp_domain d
+          WHERE d.id = i.domain_id
+          LIMIT 1
+        ), FALSE) AS permitted
+      FROM scp_item i
+      WHERE COALESCE((
+        SELECT CASE
+          WHEN @scp_role = 1 THEN EXISTS (
+            SELECT 1 FROM scp_access a
+            WHERE a.domain_id = d.id AND a.actor_id = @scp_actor
+          )
+          ELSE TRUE
+        END
+        FROM scp_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      ORDER BY i.created_at DESC
+      LIMIT 72
+    expect:
+      rows: 2
+      data:
+        - id: 11
+          permitted: 1
+        - id: 33
+          permitted: 1
+
+  - name: "A second source mutation extends the materialized request domain"
+    session_id: "scp_writer"
+    sql: "INSERT INTO scp_access VALUES (4, 101, 4)"
+    expect:
+      affected_rows: 1
+
+  - <<: *shared_scalar_read
+    name: "The reused scalar carrier observes transitive source invalidation"
+    expect:
+      rows: 3
+      data:
+        - id: 11
+          permitted: 1
+        - id: 33
+          permitted: 1
+        - id: 44
+          permitted: 1
+
+  - name: "Build a computed cache over a mutable source"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "scp_middle_cache")
+        "total" "INT" '() '("temp" true)
+        '("id")
+        (lambda (id)
+          (scan nil
+            (table "memcp-tests" "scp_source")
+            '() (lambda () true)
+            '("amount") (lambda (amount) amount)
+            + 0)))
+
+  - name: "Build a second computed cache over the first cache"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "scp_outer_cache")
+        "doubled_total" "INT" '() '("temp" true)
+        '("id")
+        (lambda (id)
+          (scan nil
+            (table "memcp-tests" "scp_middle_cache")
+            '() (lambda () true)
+            '("total") (lambda (total) (* total 2))
+            + 0)))
+
+  - name: "Nested computed cache has its initial value"
+    sql: "SELECT doubled_total FROM scp_outer_cache WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - doubled_total: 20
+
+  - name: "Mutate the transitive source"
+    sql: "INSERT INTO scp_source VALUES (2, 20)"
+    expect:
+      affected_rows: 1
+
+  - name: "The directly dependent cache is invalidated"
+    sql: "SELECT total FROM scp_middle_cache WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - total: 30
+
+  - name: "Invalidation propagates through computed cache dependencies"
+    sql: "SELECT doubled_total FROM scp_outer_cache WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - doubled_total: 60
+
+  - name: "A computed column may prepare a dependent column on the same table"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "scp_middle_cache")
+        "nested_outer" "INT" '() '("temp" true)
+        '("id")
+        (lambda (id)
+          (begin
+            (createcolumn
+              (table "memcp-tests" "scp_middle_cache")
+              "nested_inner" "INT" '() '("temp" true)
+              '("id")
+              (lambda (inner_id) (+ inner_id 1)))
+            (+ id 2))))
+
+  - name: "Nested same-table column preparation publishes both values"
+    sql: "SELECT nested_inner, nested_outer FROM scp_middle_cache WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - nested_inner: 2
+          nested_outer: 3
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS scp_late_access"
+  - sql: "DROP TABLE IF EXISTS scp_late_item"
+  - sql: "DROP TABLE IF EXISTS scp_late_domain"
+  - sql: "DROP TABLE IF EXISTS scp_outer_cache"
+  - sql: "DROP TABLE IF EXISTS scp_middle_cache"
+  - sql: "DROP TABLE IF EXISTS scp_source"
+  - sql: "DROP TABLE IF EXISTS scp_access"
+  - sql: "DROP TABLE IF EXISTS scp_item"
+  - sql: "DROP TABLE IF EXISTS scp_domain"


### PR DESCRIPTION
## Summary

- scope adaptive physical observations to one query generation instead of leaking executable RecSets through a long-lived connection session
- route every observed carrier consumer through the same scoped lookup, including ordered batch and projected membership lowering
- rebind persistent computed callbacks to the current physical query context
- propagate invalidation through transitive computed-cache dependencies
- avoid same-table nested physical-column preparation deadlocks by releasing the DDL mutex while shard computors execute
- strip parser source metadata before extracting computed-cache dependencies

## Regression coverage

Adds a neutral SQL/YAML suite covering:

- empty-cache publication followed by source population
- compound CASE/COALESCE/EXISTS carriers with ORDER BY/LIMIT
- concurrent request/session isolation and post-commit freshness
- reused scalar carriers after source mutation
- transitive computed-cache invalidation
- nested same-table physical-column preparation

Also adds a Go regression proving persistent computed callbacks use the current transaction without mutating the shared closure.

## Validation

- full pre-commit hook: green
- IN/UNION + LEFT JOIN + ordered-limit suite: 71/71
- new concurrency/cache-publication suite: 30/30
- planner-scaling suite: 8/8