### PR TITLE
Finalize JSON array aggregates in linear time

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -299,14 +299,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(sql_avg_expr s (sql_aggregates "SUM") (sql_aggregates "COUNT")))
 		(parser '((atom "MIN" true) "(" (define s psql_expression) ")") '('aggregate s 'min nil))
 		(parser '((atom "MAX" true) "(" (define s psql_expression) ")") '('aggregate s 'max nil))
-		/* PostgreSQL JSON aggregates. Strict variants encode skipped SQL NULLs as
-		an empty tagged aggregate state, preserving nil as the reducer neutral. */
+		/* PostgreSQL strict JSON aggregates omit SQL NULL before collection. */
 		(parser '((or (atom "JSON_AGG_STRICT" true) (atom "JSONB_AGG_STRICT" true)) "(" (define value psql_expression) ")")
-			'('aggregate '('json_arrayagg_entry value true) 'json_arrayagg_reduce nil))
+			(json_arrayagg_expr value true))
 		(parser '((or (atom "JSON_AGG" true) (atom "JSONB_AGG" true)) "(" (define value psql_expression) ")")
-			'('aggregate '('json_arrayagg_entry value false) 'json_arrayagg_reduce nil))
+			(json_arrayagg_expr value false))
 		(parser '((atom "JSON_ARRAYAGG" true) "(" (define value psql_expression) (atom "ORDER" true) (atom "BY" true) psql_expression (atom "ABSENT" true) (atom "ON" true) (atom "NULL" true) (atom "RETURNING" true) psql_type ")")
-			'('aggregate '('json_arrayagg_entry value true) 'json_arrayagg_reduce nil))
+			(json_arrayagg_expr value true))
 		(parser '((or
 			(atom "JSON_OBJECT_AGG_UNIQUE_STRICT" true) (atom "JSONB_OBJECT_AGG_UNIQUE_STRICT" true)
 			(atom "JSON_OBJECT_AGG_STRICT" true) (atom "JSONB_OBJECT_AGG_STRICT" true))

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -1167,6 +1167,8 @@ instead of capturing whichever session populated the cache first. */
 	(match expr
 		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral) false
 		((quote aggregate) _agg_expr _agg_reduce _agg_neutral) false
+		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) false
+		((quote aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) false
 		((symbol count_distinct) _agg_expr) false
 		((quote count_distinct) _agg_expr) false
 		((symbol group_concat_distinct) _agg_expr _separator) false
@@ -3405,6 +3407,10 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(list (list agg_expr agg_reduce agg_neutral))
 			((quote aggregate) agg_expr agg_reduce agg_neutral)
 			(list (list agg_expr agg_reduce agg_neutral))
+			((symbol aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+			(list (list agg_expr agg_reduce agg_neutral agg_finalize))
+			((quote aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+			(list (list agg_expr agg_reduce agg_neutral agg_finalize))
 			_ (begin
 				(define descriptor (sql_aggregates "SUM"))
 				(list (list (car args) (car descriptor) (cadr descriptor)))))
@@ -5316,6 +5322,8 @@ that actually owns the title consumes the reference. */
 		((quote group_concat_distinct) _agg_expr _separator) true
 		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral) true
 		((quote aggregate) _agg_expr _agg_reduce _agg_neutral) true
+		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) true
+		((quote aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) true
 		(cons _head tail) (reduce tail (lambda (found item)
 			(or found (expr_has_local_aggregates? item))) false)
 		_ false)))

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -5099,6 +5099,7 @@ so generated aliases and dependency IDs do not hide equivalent stage graphs. */
 			(stage_semantic_rewrite_expr alias_map signatures order_exprs)
 			dirs offset_value reduce neutral)
 		'(_value_expr reduce neutral) (list (quote aggregate) reduce neutral)
+		'(_value_expr reduce neutral finalize) (list (quote aggregate) reduce neutral finalize)
 		_ (stage_semantic_rewrite_expr alias_map signatures ag))))
 
 (define stage_semantic_facts (lambda (alias_map signatures facts)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -195,6 +195,8 @@ partner. */
 		(list value_expr (list order_expr) (list dir) 0)
 		'(value_expr _reduce _neutral)
 		(list value_expr '() '() 0)
+		'(value_expr _reduce _neutral _finalize)
+		(list value_expr '() '() 0)
 		_ (neumann_fail "build_queryplan" "scalar-first probe expects aggregate descriptor"))))
 
 (define scalar_first_probe_aggregate (lambda (stage requested_col)
@@ -1408,8 +1410,8 @@ lexical outer row. Projection and key-index consumers can both reuse the same
 (define direct_base_presence_recset_source_parts (lambda (stage)
 	(if (or (not (qassoc_get (gs_facts stage) (quote direct_presence_recset_context) false))
 		(or (not (presence_probe_stage? stage))
-		(or (not (source_is_base_table? (gs_input stage)))
-			(stage_has_residual_outer_refs? stage))))
+			(or (not (source_is_base_table? (gs_input stage)))
+				(stage_has_residual_outer_refs? stage))))
 		nil
 		(begin
 			(define src (gs_input stage))
@@ -1537,46 +1539,46 @@ lexical outer row. Projection and key-index consumers can both reuse the same
 			direct_presence_parts
 			(if (direct_boolean_recset_stage_eligible?
 				stage_catalog graph physical_stage requested_col)
-			(begin
-				(define carrier_src (scalar_first_probe_carrier_source
-					(gs_input physical_stage)))
-				(define row_keys (scalar_first_probe_recset_row_keys
-					physical_stage carrier_src))
-				(define domain_src (boolean_recset_domain_source
-					(gs_input physical_stage) row_keys))
-				(list true
-					(lower_direct_boolean_stage_recset_expr
-						stage_catalog physical_stage share_result allow_direct_presence)
-					(map row_keys (lambda (key)
-						(direct_column_name_for_alias domain_src key)))))
-			(begin
-				(define cache (group_stage_cache physical_stage))
-				(define cache_schema (group_cache_schema cache))
-				(define cache_relation (group_cache_relation cache))
-				(define carrier_src (scalar_first_probe_carrier_source
-					(gs_input physical_stage)))
-				(define row_keys (scalar_first_probe_recset_row_keys
-					physical_stage carrier_src))
-				(define row_key_index (if (empty_list? row_keys) nil
-					(group_key_expr_index (gs_keys physical_stage) (car row_keys))))
-				(if (nil? row_key_index)
-					(neumann_fail "build_queryplan" "scalar RecSet carrier has no row-domain key")
-					true)
-				(list
-					(if share_result
-						(lower_recset_stage_prepare_once_expr stage_catalog physical_stage)
-						(lower_group_stage_prepare_using
-							stage_catalog stage_catalog physical_stage true nil))
-					(list (quote scan_recset)
-						(list (quote session) "__memcp_tx")
-						(list (quote table) cache_schema cache_relation)
-						(quoted_runtime_list (list requested_col))
-						(list (quote lambda) (list (symbol requested_col))
-							(if (presence_probe_stage? physical_stage)
-								(list (quote >)
-									(list (quote coalesceNil) (symbol requested_col) 0) 0)
-								(list (quote equal??) (symbol requested_col) true))))
-					(list (nth (group_key_cols (gs_keys physical_stage)) row_key_index)))))))))
+				(begin
+					(define carrier_src (scalar_first_probe_carrier_source
+						(gs_input physical_stage)))
+					(define row_keys (scalar_first_probe_recset_row_keys
+						physical_stage carrier_src))
+					(define domain_src (boolean_recset_domain_source
+						(gs_input physical_stage) row_keys))
+					(list true
+						(lower_direct_boolean_stage_recset_expr
+							stage_catalog physical_stage share_result allow_direct_presence)
+						(map row_keys (lambda (key)
+							(direct_column_name_for_alias domain_src key)))))
+				(begin
+					(define cache (group_stage_cache physical_stage))
+					(define cache_schema (group_cache_schema cache))
+					(define cache_relation (group_cache_relation cache))
+					(define carrier_src (scalar_first_probe_carrier_source
+						(gs_input physical_stage)))
+					(define row_keys (scalar_first_probe_recset_row_keys
+						physical_stage carrier_src))
+					(define row_key_index (if (empty_list? row_keys) nil
+						(group_key_expr_index (gs_keys physical_stage) (car row_keys))))
+					(if (nil? row_key_index)
+						(neumann_fail "build_queryplan" "scalar RecSet carrier has no row-domain key")
+						true)
+					(list
+						(if share_result
+							(lower_recset_stage_prepare_once_expr stage_catalog physical_stage)
+							(lower_group_stage_prepare_using
+								stage_catalog stage_catalog physical_stage true nil))
+						(list (quote scan_recset)
+							(list (quote session) "__memcp_tx")
+							(list (quote table) cache_schema cache_relation)
+							(quoted_runtime_list (list requested_col))
+							(list (quote lambda) (list (symbol requested_col))
+								(if (presence_probe_stage? physical_stage)
+									(list (quote >)
+										(list (quote coalesceNil) (symbol requested_col) 0) 0)
+									(list (quote equal??) (symbol requested_col) true))))
+						(list (nth (group_key_cols (gs_keys physical_stage)) row_key_index)))))))))
 
 (define lower_recset_scalar_first_probe_expr (lambda (all_stages stage requested_col resolved_lookup_key)
 	(begin
@@ -1854,7 +1856,7 @@ would still have to project that value over the segment. */
 		(define value_expr (nth ag 0))
 		(define reduce_expr (nth ag 1))
 		(define neutral_expr (nth ag 2))
-		(if (query_block? src)
+		(aggregate_finalize_expr ag (if (query_block? src)
 			(lower_scalar_aggregate_query_probe_expr
 				(stage_catalog_with_nested (merge_stage_catalogs (list
 					(qassoc_get (gs_facts stage) (quote probe_catalog) '())
@@ -1889,7 +1891,7 @@ would still have to project that value over the segment. */
 					reduce_expr
 					neutral_expr
 					nil
-					false))))))
+					false)))))))
 
 (define lower_scalar_cardinality_probe_expr (lambda (sources default_alias stage requested_col)
 	(begin
@@ -3623,6 +3625,8 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 	(match expr
 		((symbol aggregate) _expr _reduce _neutral) true
 		((quote aggregate) _expr _reduce _neutral) true
+		((symbol aggregate) _expr _reduce _neutral _finalize) true
+		((quote aggregate) _expr _reduce _neutral _finalize) true
 		((symbol count_distinct) _expr) true
 		((quote count_distinct) _expr) true
 		((symbol group_concat_distinct) _expr _separator) true
@@ -3683,8 +3687,20 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 		((quote group_concat_distinct) agg_expr _separator) (list (count_distinct_descriptor agg_expr))
 		((symbol aggregate) agg_expr agg_reduce agg_neutral) (list (list agg_expr agg_reduce agg_neutral))
 		((quote aggregate) agg_expr agg_reduce agg_neutral) (list (list agg_expr agg_reduce agg_neutral))
+		((symbol aggregate) agg_expr agg_reduce agg_neutral agg_finalize) (list (list agg_expr agg_reduce agg_neutral agg_finalize))
+		((quote aggregate) agg_expr agg_reduce agg_neutral agg_finalize) (list (list agg_expr agg_reduce agg_neutral agg_finalize))
 		(cons head tail) (dedupe_aggregates_by_col (merge (map tail extract_aggregates)))
 		_ '())))
+
+(define aggregate_finalize_expr (lambda (ag value_expr)
+	(if (> (count ag) 3)
+		(list (nth ag 3) value_expr)
+		value_expr)))
+
+(define aggregates_need_finalize? (lambda (ags)
+	(reduce ags (lambda (needed ag)
+		(or needed (or (> (count ag) 3)
+			(not (nil? (scalar_order_aggregate_parts ag)))))) false)))
 
 /* DECIMAL is currently represented as float64 at runtime. Keep calculations
 unmodified, but normalize visible aggregate results to the declared scale of
@@ -3917,6 +3933,8 @@ working on the original values. */
 		((quote group_concat_distinct) _agg_expr _separator) '()
 		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral) '()
 		((quote aggregate) _agg_expr _agg_reduce _agg_neutral) '()
+		((symbol aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) '()
+		((quote aggregate) _agg_expr _agg_reduce _agg_neutral _agg_finalize) '()
 		((symbol get_column) tblvar ignorecase col col_ignorecase)
 		(if (or (nil? tblvar) (equal? (resolve_column_alias tblvar default_alias) default_alias))
 			'()
@@ -4530,6 +4548,10 @@ ever-larger subtrees. */
 				(group_aggregate_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral))
 				((quote aggregate) agg_expr agg_reduce agg_neutral)
 				(group_aggregate_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral))
+				((symbol aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(group_aggregate_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral agg_finalize))
+				((quote aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(group_aggregate_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral agg_finalize))
 				((symbol get_column) _tblvar _ _col _)
 				(if (equal?? (resolve_column_alias _tblvar alias) alias)
 					(neumann_fail "build_queryplan" (concat "non-aggregate output must be a GROUP BY key: " (serialize expr)))
@@ -4583,6 +4605,10 @@ ever-larger subtrees. */
 				(group_aggregate_order_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral))
 				((quote aggregate) agg_expr agg_reduce agg_neutral)
 				(group_aggregate_order_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral))
+				((symbol aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(group_aggregate_order_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral agg_finalize))
+				((quote aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(group_aggregate_order_read_expr input grouptbl (list agg_expr agg_reduce agg_neutral agg_finalize))
 				(cons head tail) (cons head
 					(replace_group_order_expr_tail_indexed input alias grouptbl keys key_names ags key_index tail (cdr resolved)))
 				_ expr)))))
@@ -4784,7 +4810,7 @@ ever-larger subtrees. */
 		(build_group_ordered_scalar_column schema tbl alias grouptbl keys key_names condition ag value_expr (list order_expr) (list dir) 0 agg_reduce agg_neutral)
 		'(((quote scalar_order_value) value_expr order_expr dir) agg_reduce agg_neutral)
 		(build_group_ordered_scalar_column schema tbl alias grouptbl keys key_names condition ag value_expr (list order_expr) (list dir) 0 agg_reduce agg_neutral)
-		'(agg_expr agg_reduce agg_neutral) (begin
+		(cons agg_expr (cons agg_reduce (cons agg_neutral _rest))) (begin
 			(define src (list alias schema tbl false nil))
 			(define agg_col (aggregate_col_name_using src ag))
 			(define membership_parts (base_group_membership_parts src condition))
@@ -4815,7 +4841,7 @@ ever-larger subtrees. */
 					(and (not (reduce keys (lambda (has_columns key)
 						(or has_columns (expr_contains_column_ref? key))) false))
 						(aggregate_counts_every_input_row? ag)))))
-			(define aggregate_value_expr (if direct_recset_count
+			(define aggregate_state_expr (if direct_recset_count
 				(list (quote recset_count)
 					(list
 						(physical_query_session_symbol)
@@ -4840,6 +4866,7 @@ ever-larger subtrees. */
 					agg_neutral
 					(aggregate_shard_combine ag)
 					false)))
+			(define aggregate_value_expr (aggregate_finalize_expr ag aggregate_state_expr))
 			(list (quote createcolumn)
 				(list (quote table) schema grouptbl)
 				agg_col
@@ -4884,6 +4911,10 @@ ever-larger subtrees. */
 				(direct_group_aggregate_read_expr (list agg_expr agg_reduce agg_neutral))
 				((quote aggregate) agg_expr agg_reduce agg_neutral)
 				(direct_group_aggregate_read_expr (list agg_expr agg_reduce agg_neutral))
+				((symbol aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(direct_group_aggregate_read_expr (list agg_expr agg_reduce agg_neutral agg_finalize))
+				((quote aggregate) agg_expr agg_reduce agg_neutral agg_finalize)
+				(direct_group_aggregate_read_expr (list agg_expr agg_reduce agg_neutral agg_finalize))
 				((symbol get_column) _tblvar _ _col _)
 				(if (equal?? (resolve_column_alias _tblvar alias) alias)
 					(neumann_fail "build_queryplan" (concat "non-aggregate output must be a GROUP BY key: " (serialize expr)))
@@ -4930,7 +4961,7 @@ ever-larger subtrees. */
 		(define condition_cols (extract_columns_for_alias src condition))
 		(define agg_value_cols (merge_unique (map ags (lambda (ag)
 			(match ag
-				'(agg_expr _agg_reduce _agg_neutral)
+				(cons agg_expr (cons _agg_reduce (cons _agg_neutral _rest)))
 				(if (equal? ag aggregate_count_descriptor)
 					'()
 					(extract_columns_for_alias src agg_expr))
@@ -4940,7 +4971,7 @@ ever-larger subtrees. */
 		(define key_expr (runtime_cons_list_expr (map keys (lambda (expr) (lower_column_expr_for_alias src expr)))))
 		(define payload_expr (runtime_cons_list_expr (map ags (lambda (ag)
 			(match ag
-				'(agg_expr _agg_reduce _agg_neutral)
+				(cons agg_expr (cons _agg_reduce (cons _agg_neutral _rest)))
 				(if (equal? ag aggregate_count_descriptor)
 					1
 					(aggregate_map_value_expr ag (lower_column_expr_for_alias src agg_expr)))
@@ -5002,7 +5033,7 @@ ever-larger subtrees. */
 					(list (quote lambda) (list (quote grouped))
 						(group_insert_finish_expr schema grouptbl key_names
 							(map ags (lambda (ag) (aggregate_col_name_using src ag))) true))
-					grouped_expr))
+					(finalize_query_grouped_assoc_expr ags grouped_expr)))
 			grouped_scan))
 		(if (nil? membership_expr)
 			plan
@@ -5076,17 +5107,18 @@ ever-larger subtrees. */
 				(list (quote begin)
 					(list (quote reduce_assoc) (quote grouped) group_reduce 0)
 					nil))
-			(if (nil? membership_table_expr)
-				grouped_scan
-				(list
-					(list (quote lambda) (list membership_var) grouped_scan)
-					membership_table_expr))))))
+			(finalize_query_grouped_assoc_expr ags
+				(if (nil? membership_table_expr)
+					grouped_scan
+					(list
+						(list (quote lambda) (list membership_var) grouped_scan)
+						membership_table_expr)))))))
 
 (define aggregate_payload_merge_expr (lambda (ags idx)
 	(if (>= idx (count ags))
 		(quoted_runtime_list '())
 		(match (nth ags idx)
-			'(_agg_expr agg_reduce _agg_neutral)
+			(cons _agg_expr (cons agg_reduce (cons _agg_neutral _rest)))
 			(list (quote cons)
 				(list agg_reduce
 					(list (quote nth) (quote old) idx)
@@ -5226,22 +5258,25 @@ on the same columns. */
 		(begin
 			(define parts (scalar_order_aggregate_parts (nth ags idx)))
 			(define stored (list (quote nth) (quote payload) idx))
+			(define ordered_value (if (nil? parts)
+				stored
+				(list (quote if) (list (quote nil?) stored) nil
+					(list (quote nth) stored (count (nth parts 1))))))
 			(cons (quote cons) (list
-				(if (nil? parts)
-					stored
-					(list (quote if) (list (quote nil?) stored) nil
-						(list (quote nth) stored (count (nth parts 1)))))
+				(aggregate_finalize_expr (nth ags idx) ordered_value)
 				(query_group_final_payload_expr ags (+ idx 1))))))))
 
 (define finalize_query_grouped_assoc_expr (lambda (ags grouped_expr)
-	(list
-		(list (quote lambda) (list (quote grouped))
-			(list (quote reduce_assoc) (quote grouped)
-				(list (quote lambda) (list (quote acc) (quote key) (quote payload))
-					(list (quote set_assoc) (quote acc) (quote key)
-						(query_group_final_payload_expr ags 0)))
-				(list (quote list))))
-		grouped_expr)))
+	(if (not (aggregates_need_finalize? ags))
+		grouped_expr
+		(list
+			(list (quote lambda) (list (quote grouped))
+				(list (quote reduce_assoc) (quote grouped)
+					(list (quote lambda) (list (quote acc) (quote key) (quote payload))
+						(list (quote set_assoc) (quote acc) (quote key)
+							(query_group_final_payload_expr ags 0)))
+					(list (quote list))))
+			grouped_expr))))
 
 (define build_query_grouped_assoc_plan (lambda (input keys key_names ags)
 	(begin
@@ -5253,7 +5288,7 @@ on the same columns. */
 				(list (nth row_key_names i) (nth keys i)))))
 			(merge (map (produceN (count ags)) (lambda (i)
 				(match (nth runtime_ags i)
-					'(agg_expr _agg_reduce _agg_neutral)
+					(cons agg_expr (cons _agg_reduce (cons _agg_neutral _rest)))
 					(list (nth value_cols i)
 						(if (equal? (nth ags i) aggregate_count_descriptor)
 							(car keys)
@@ -5506,7 +5541,7 @@ once and every base-only leaf remains a vectorized domain scan. */
 				(rewrite_derived_ref candidate_alias projection (nth keys i))))))
 		(define value_fields (map (produceN (count ags)) (lambda (i)
 			(match (nth ags i)
-				'(agg_expr _agg_reduce _agg_neutral)
+				(cons agg_expr (cons _agg_reduce (cons _agg_neutral _rest)))
 				(list (nth value_cols i)
 					(if (equal? (nth ags i) aggregate_count_descriptor)
 						(if (empty_list? keys) 1 (rewrite_derived_ref candidate_alias projection (car keys)))
@@ -5556,8 +5591,9 @@ once and every base-only leaf remains a vectorized domain scan. */
 		(define combine_grouped (grouped_state_merge_expr merge_payload))
 		(list
 			(list (quote lambda) (list (quote grouped)) finish_expr)
-			(lower_union_block_as_dataset_reduce
-				input keys row_key_names ags value_cols row_mapper reduce_expr neutral_expr combine_grouped)))))
+			(finalize_query_grouped_assoc_expr ags
+				(lower_union_block_as_dataset_reduce
+					input keys row_key_names ags value_cols row_mapper reduce_expr neutral_expr combine_grouped))))))
 
 (define build_scalar_single_query_stage_fill_plan (lambda (input grouptbl keys key_names value_ag count_ag value_col count_col)
 	(match value_ag '(value_expr _value_reduce _value_neutral) (begin
@@ -6113,6 +6149,8 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 			neutral))
 		'(expr reduce neutral)
 		(list (rewrite_scalar_first_probe_expr stages sources default_alias expr) reduce neutral)
+		'(expr reduce neutral finalize)
+		(list (rewrite_scalar_first_probe_expr stages sources default_alias expr) reduce neutral finalize)
 		_ ag)))
 
 (define rewrite_scalar_first_probe_aggregates (lambda (stages sources default_alias ags)

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -46,6 +46,22 @@ would collapse it with parser-level "no value" and optional-clause defaults. */
 (define sql_null_literal (lambda ()
 	(list (sql_builtins "SQL_NULL"))))
 
+/* JSON_ARRAYAGG keeps its growing state as a list of completed values. The
+finalizer emits one contiguous BSON array after the aggregate has seen every
+row, avoiding a copy of the complete prefix for each input value. */
+(define json_arrayagg_expr (lambda (value skip_null)
+	(list (quote aggregate)
+		(if skip_null
+			(list (quote if) (list (quote nil?) value) nil
+				(list (quote list) value))
+			(list (quote list) value))
+		(list (quote lambda) (list (quote a) (quote b))
+			(list (quote if) (list (quote nil?) (quote a)) (quote b)
+				(list (quote if) (list (quote nil?) (quote b)) (quote a)
+					(list (quote merge) (quote a) (quote b)))))
+		nil
+		(quote json_arrayagg_finalize))))
+
 (define sql_identifier_unquoted (parser (not
 	(regex "[a-zA-Z_][a-zA-Z0-9_]*")
 	/* exceptions for things that can't be identifiers */
@@ -871,8 +887,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "RIGHT" true) "(" (define s sql_expression) "," (define n sql_expression) ")") '((quote if) '((quote nil?) s) nil '((quote sql_substr) s '((quote +) 1 '((quote -) '((quote strlen) s) n)) n)))
 		/* JSON_VALUE has a SQL type clause inside its argument list. */
 		(parser '((atom "JSON_VALUE" true) "(" (define doc sql_expression) "," (define path sql_expression) (atom "RETURNING" true) (define typ sql_identifier) (? "(" sql_int (? "," sql_int) ")") ")") '('json_value doc path typ))
-		/* Wrap every JSON_ARRAYAGG input so SQL NULL remains a JSON null rather than the reducer neutral value. */
-		(parser '((atom "JSON_ARRAYAGG" true) "(" (define value sql_expression) ")") '('aggregate '('json_arrayagg_entry value) 'json_arrayagg_reduce nil))
+		(parser '((atom "JSON_ARRAYAGG" true) "(" (define value sql_expression) ")")
+			(json_arrayagg_expr value false))
 		/* JSON_OBJECTAGG has two input expressions. */
 		(parser '((atom "JSON_OBJECTAGG" true) "(" (define key sql_expression) "," (define value sql_expression) ")") '('aggregate '('json_objectagg_entry key value) 'json_objectagg_reduce nil))
 		/* window functions: parse OVER(...) clause and emit AST node */

--- a/scm/json_bson.go
+++ b/scm/json_bson.go
@@ -272,16 +272,22 @@ func bsonFromSQLScalar(value Scmer) (Scmer, error) {
 }
 
 func bsonArrayFromValues(values []Scmer, flags uint64) Scmer {
-	index, payload := bsoncore.AppendArrayStart(nil)
+	payloadSize := bsoncore.EmptyDocumentLength
 	for i := range values {
-		value, err := bsonFromSQLScalar(values[i])
-		if err != nil {
-			panic(err)
+		_, valueSize := bsonSQLScalarTypeAndSize(values[i])
+		payloadSize += 1 + decimalDigits(i) + 1 + valueSize
+		if payloadSize > math.MaxInt32 {
+			panic("BSON array exceeds the 32-bit BSON size limit")
 		}
-		raw := bsonRawValue(value)
-		payload = bsoncore.AppendValueElement(payload, strconv.Itoa(i), bsoncore.Value{
-			Type: bsoncore.Type(raw.Type), Data: raw.Value,
-		})
+	}
+	payload := make([]byte, 0, payloadSize)
+	index, payload := bsoncore.AppendArrayStart(payload)
+	for i := range values {
+		typ, _ := bsonSQLScalarTypeAndSize(values[i])
+		payload = append(payload, byte(typ))
+		payload = strconv.AppendInt(payload, int64(i), 10)
+		payload = append(payload, 0)
+		payload = appendBSONSQLScalarPayload(payload, values[i])
 	}
 	var err error
 	payload, err = bsoncore.AppendArrayEnd(payload, index)
@@ -289,6 +295,72 @@ func bsonArrayFromValues(values []Scmer, flags uint64) Scmer {
 		panic(err)
 	}
 	return newBSONValueFlags(bson.TypeArray, payload, flags)
+}
+
+func bsonSQLScalarTypeAndSize(value Scmer) (bson.Type, int) {
+	switch {
+	case value.IsBSON():
+		typ, payload := bsonTypeAndBytes(value)
+		return typ, len(payload)
+	case value.IsNil():
+		return bson.TypeNull, 0
+	case value.IsBool():
+		return bson.TypeBoolean, 1
+	case value.IsInt():
+		if integer := value.Int(); integer >= math.MinInt32 && integer <= math.MaxInt32 {
+			return bson.TypeInt32, 4
+		}
+		return bson.TypeInt64, 8
+	case value.IsFloat():
+		return bson.TypeDouble, 8
+	case value.IsString() || value.IsSymbol():
+		return bson.TypeString, 4 + len(value.String()) + 1
+	default:
+		converted, err := bsonFromSQLScalar(value)
+		if err != nil {
+			panic(err)
+		}
+		typ, payload := bsonTypeAndBytes(converted)
+		return typ, len(payload)
+	}
+}
+
+func appendBSONSQLScalarPayload(payload []byte, value Scmer) []byte {
+	switch {
+	case value.IsBSON():
+		_, raw := bsonTypeAndBytes(value)
+		return append(payload, raw...)
+	case value.IsNil():
+		return payload
+	case value.IsBool():
+		return bsoncore.AppendBoolean(payload, value.Bool())
+	case value.IsInt():
+		integer := value.Int()
+		if integer >= math.MinInt32 && integer <= math.MaxInt32 {
+			return bsoncore.AppendInt32(payload, int32(integer))
+		}
+		return bsoncore.AppendInt64(payload, integer)
+	case value.IsFloat():
+		return bsoncore.AppendDouble(payload, value.Float())
+	case value.IsString() || value.IsSymbol():
+		return bsoncore.AppendString(payload, value.String())
+	default:
+		converted, err := bsonFromSQLScalar(value)
+		if err != nil {
+			panic(err)
+		}
+		_, raw := bsonTypeAndBytes(converted)
+		return append(payload, raw...)
+	}
+}
+
+func decimalDigits(value int) int {
+	digits := 1
+	for value >= 10 {
+		value /= 10
+		digits++
+	}
+	return digits
 }
 
 func bsonArrayFromRawValues(values []bson.RawValue, flags uint64) Scmer {

--- a/scm/json_bson_test.go
+++ b/scm/json_bson_test.go
@@ -18,6 +18,7 @@ package scm
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"io"
 	"testing"
@@ -195,6 +196,46 @@ func TestBSONEscapesJSONKeysContainingNUL(t *testing.T) {
 	}
 }
 
+func TestJSONArrayAggFinalizeBuildsOneExactBSONArray(t *testing.T) {
+	values := make([]Scmer, 105)
+	for i := range values {
+		switch i % 3 {
+		case 0:
+			values[i] = NewNil()
+		case 1:
+			values[i] = NewInt(int64(i))
+		case 2:
+			values[i] = bsonDocumentFromPairs([]bsonJSONPair{{
+				key: "nested", value: bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "value"))),
+			}}, 0)
+		}
+	}
+	result := callJSONTest(t, "json_arrayagg_finalize", NewSlice(values))
+	if !result.IsBSON() {
+		t.Fatal("JSON_ARRAYAGG finalizer did not return BSON")
+	}
+	typ, payload := result.BSONRaw()
+	if bson.Type(typ) != bson.TypeArray {
+		t.Fatalf("BSON type = %v, want array", bson.Type(typ))
+	}
+	if declared := int(binary.LittleEndian.Uint32(payload[:4])); declared != len(payload) {
+		t.Fatalf("BSON header length = %d, payload length = %d", declared, len(payload))
+	}
+	items, err := bson.Raw(payload).Values()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != len(values) {
+		t.Fatalf("array length = %d, want %d", len(items), len(values))
+	}
+}
+
+func TestJSONArrayAggFinalizePreservesEmptyAggregate(t *testing.T) {
+	if result := callJSONTest(t, "json_arrayagg_finalize", NewNil()); !result.IsNil() {
+		t.Fatalf("empty JSON_ARRAYAGG = %s, want SQL NULL", result.String())
+	}
+}
+
 func BenchmarkBSONAppendString(b *testing.B) {
 	value, err := NewBSONFromJSON(`{"customer":{"name":"Ada","rank":7},"items":[{"sku":"A","qty":2},{"sku":"B","qty":3}],"active":true}`)
 	if err != nil {
@@ -246,6 +287,38 @@ func BenchmarkJSONArrayAggReduce8(b *testing.B) {
 
 func BenchmarkJSONArrayAggReduce1000(b *testing.B) {
 	benchmarkJSONArrayAggReduce(b, 1000)
+}
+
+func benchmarkJSONArrayAggCollectFinalize(b *testing.B, count int) {
+	values := make([]Scmer, count)
+	for i := range values {
+		values[i] = bsonDocumentFromPairs([]bsonJSONPair{
+			{key: "id", value: bsonRawValue(NewBSONValue(bson.TypeInt64, bsoncore.AppendInt64(nil, int64(i))))},
+			{key: "serialNumber", value: bsonRawValue(NewBSONValue(bson.TypeString, bsoncore.AppendString(nil, "SN-1000000")))},
+		}, 0)
+	}
+	collected := NewSlice(values)
+	finalize := Globalenv.Vars[Symbol("json_arrayagg_finalize")].Func()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		result := finalize(collected)
+		if !result.IsBSON() {
+			b.Fatal("JSON_ARRAYAGG did not return BSON")
+		}
+	}
+}
+
+func BenchmarkJSONArrayAggCollectFinalize3(b *testing.B) {
+	benchmarkJSONArrayAggCollectFinalize(b, 3)
+}
+
+func BenchmarkJSONArrayAggCollectFinalize8(b *testing.B) {
+	benchmarkJSONArrayAggCollectFinalize(b, 8)
+}
+
+func BenchmarkJSONArrayAggCollectFinalize1000(b *testing.B) {
+	benchmarkJSONArrayAggCollectFinalize(b, 1000)
 }
 
 func BenchmarkBSONSerializeNested1000(b *testing.B) {

--- a/scm/json_functions.go
+++ b/scm/json_functions.go
@@ -2803,6 +2803,13 @@ func init_json_functions() {
 		}
 		return bsonArrayFromRawParts(left, leftIsState, right, rightIsState, bsonFlagArrayAgg)
 	})
+	declareJSON("json_arrayagg_finalize", "builds one BSON array from a collected JSON_ARRAYAGG value list", func(args ...Scmer) Scmer {
+		requireJSONArgs("JSON_ARRAYAGG finalizer", args, 1)
+		if args[0].IsNil() {
+			return NewNil()
+		}
+		return bsonArrayFromValues(args[0].Slice(), 0)
+	})
 	declareJSON("json_objectagg_entry", "constructs a JSON_OBJECTAGG key/value entry", func(args ...Scmer) Scmer {
 		requireJSONArgs("JSON_OBJECTAGG", args, 2)
 		if args[0].IsNil() {

--- a/tests/sql/expressions/json-functions.yaml
+++ b/tests/sql/expressions/json-functions.yaml
@@ -372,6 +372,31 @@ test_cases:
       data:
         - values_array: [1, null, 3]
 
+  - name: "JSON_ARRAYAGG over empty input returns SQL NULL"
+    sql: "SELECT (SELECT JSON_ARRAYAGG(id) FROM json_documents WHERE id = 999) AS values_array"
+    expect:
+      rows: 1
+      data:
+        - values_array: null
+
+  - name: "JSON_ARRAYAGG finalizes each GROUP BY state independently"
+    sql: "SELECT category, JSON_ARRAYAGG(id) AS values_array FROM json_documents GROUP BY category ORDER BY category"
+    expect:
+      rows: 2
+      data:
+        - category: customer
+          values_array: [1, 2]
+        - category: event
+          values_array: [3]
+
+  - name: "JSON_ARRAYAGG finalizes every UNION ALL branch"
+    sql: "SELECT JSON_ARRAYAGG(id) AS values_array FROM json_documents WHERE id <= 2 UNION ALL SELECT JSON_ARRAYAGG(id) AS values_array FROM json_documents WHERE id = 3"
+    expect:
+      rows: 2
+      data:
+        - values_array: [1, 2]
+        - values_array: [3]
+
   - name: "nested delivery-note JSON embeds item and serial-number arrays"
     setup:
       - sql: "DROP TABLE IF EXISTS json_delivery_serial_numbers"

--- a/tests/sql/expressions/postgresql-json-functions.yaml
+++ b/tests/sql/expressions/postgresql-json-functions.yaml
@@ -448,6 +448,13 @@ test_cases:
       data:
         - values_array: [10, 30]
 
+  - name: "strict JSON array aggregate with only NULL inputs returns SQL NULL"
+    sql: "SELECT jsonb_agg_strict(NULL) AS strict_values FROM pg_json_docs"
+    expect:
+      rows: 1
+      data:
+        - strict_values: null
+
   - name: "json and jsonb object aggregate variants"
     sql: |
       SELECT json_object_agg(key_name,value_num) AS json_object_value,


### PR DESCRIPTION
## What

- collect `JSON_ARRAYAGG`, `json_agg`, and `jsonb_agg` inputs as an owned aggregate list instead of rebuilding BSON after every row
- extend the general aggregate descriptor with an optional finalizer and run it only after all local/shard/query reductions, before the completed value enters a group cache or scalar result
- build the final BSON array in two passes: first calculate the exact document length from BSON types, array-index cstrings, and payload lengths; then allocate once, emit once, and backfill the BSON header
- preserve SQL NULL, PostgreSQL strict aggregate, GROUP BY, UNION branch, correlated scalar, and nested three-level serialization semantics
- keep the old BSON reducer callable for compatibility and as the A-side microbenchmark

No storage type, BSON output wrapper, or JSON-specific StorageSCMER rule is introduced.

## Complexity

The old reducer appended one BSON array to another for every input and repeatedly copied the complete prefix, making a group quadratic in its element count. The new reducer collects completed values with the existing owned-list optimization and performs one exact-size BSON emission at aggregate finalization. BSON child payload lengths are read in O(1); the length pass does not traverse child documents.

## SQL A/B

Fresh non-coverage binaries from master `b3d1620bb` and this branch, same machine and dataset: 1,000 delivery notes, 8,000 items, 24,000 serial numbers; five measured executions per query, median shown.

| Query shape | Tested features | master | branch | speedup |
|---|---|---:|---:|---:|
| flat delivery object list | 1,000 JSON objects, one outer JSON_ARRAYAGG | 2.052 ms | 1.836 ms | 1.12x |
| delivery list with item arrays | correlated child aggregate, 8 children per parent | 439.621 ms | 165.712 ms | 2.65x |
| MySQL three-level delivery list | JSON_ARRAYAGG + JSON_OBJECT, correlated items and serial arrays | 2,285.474 ms | 1,464.072 ms | 1.56x |
| PostgreSQL three-level delivery list | jsonb_agg + jsonb_build_object, same nesting and cardinalities | 1,990.950 ms | 1,285.478 ms | 1.55x |
| explicit grouped item carrier | GROUP BY carrier plus nested serial arrays and outer aggregate | 2,208.720 ms | 1,523.517 ms | 1.45x |

Sum across all five medians: 6,926.816 ms -> 4,440.616 ms, 1.56x overall.

## Reducer microbenchmarks

Eight runs per size, 500 ms benchtime; median time is summarized.

| Elements | old BSON reduce | collect + final emit | speedup | allocations |
|---:|---:|---:|---:|---:|
| 3 | 568.7 ns | 143.0 ns | 3.98x | 10 -> 2 |
| 8 | 3,070 ns | 287.9 ns | 10.66x | 38 -> 2 |
| 1,000 | 42.850 ms | 30.705 us | 1,396x | about 17,075 -> 2 |

At 1,000 elements allocated bytes fall from about 113.9 MB/op to 57.4 KB/op.

## Validation

- `MEMCP_TEST_JOBS=1 make test`: full hook-equivalent suite passed, coverage report generated
- MySQL JSON suite: 53/53
- PostgreSQL JSON suite: 56/56
- focused ordered-scalar DML regression: 12/12
- focused derived-query regression: 4/4
- focused group-cache invalidation: 129/129
- complete nested serialization performance suite: 5/5
- Scheme formatter run; its existing negative-depth warnings remain, with no pending reformat

## Follow-up operator analysis

Batch probes remain a separate optimization. The existing `scan_batch` rewrite already batches eligible nested plain scans but rejects outer scans, reducer-bearing outer scans, and ordered inner scans. `scan_order_multi` is an ordered UNION carrier, not a join: it has no join predicates, multiplicity boundaries, or null extension.

A future sorted multi-level join cannot simply mirror `scan_order_multi`. The Neumann decorrelation path carries each LEFT boundary through the complete nullable right subtree and emits exactly one all-NULL composite row only when that subtree produces no match; ON predicates run before null extension and nullable-side WHERE predicates after it. Any `scan_order_join` must consume that logical join shape and preserve those boundaries, composite keys, residual predicates, and multiplicities. This PR deliberately does not add a partial operator that would violate those semantics.