### PR TITLE
Fix LIMIT placement for nested scalar joins

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -59,9 +59,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'(op left right) (if (or (equal? op (quote equal?)) (equal? op (quote equal??)))
 					(or
 						(and (equal?? (direct_column_name_for_alias src left) col)
-							(not (expr_refs_alias? (source_alias src) (source_alias src) right)))
+							(not (expr_contains_column_ref? right)))
 						(and (equal?? (direct_column_name_for_alias src right) col)
-							(not (expr_refs_alias? (source_alias src) (source_alias src) left))))
+							(not (expr_contains_column_ref? left))))
 					false)
 				_ false)))
 		false)))
@@ -2569,14 +2569,13 @@ probes remain recipes and still execute after root braking. */
 	(begin
 		(define compile_offset (planner_literal_value offset_value))
 		(define compile_limit (planner_literal_value limit_value))
-		(define rows (if (empty_list? sources) nil
-			(if (source_unique_point_condition? (car sources) final_condition)
-				1
-				/* A selectivity estimate is not an upper bound. Native LIMIT may
-				stop at the driver only when its complete relation is provably
-				inside the window; downstream 0:1 predicates can still reject an
-				estimatedly selective driver row. */
-				(planner_source_row_count (car sources)))))
+		/* Row-count statistics are estimates, not upper bounds, and may lag
+		concurrent inserts. They can rank plans but cannot prove that LIMIT covers
+		the complete driver. A unique point predicate is the available structural
+		upper bound; every wider scan must let the completed-row consumer own the
+		window. */
+		(define rows (if (and (not (empty_list? sources))
+			(source_unique_point_condition? (car sources) final_condition)) 1 nil))
 		(and (or (nil? compile_offset) (equal? compile_offset 0))
 			(and (number? compile_limit)
 				(and (>= compile_limit 0)

--- a/tests/planner/subqueries/nested-correlated-subquery.yaml
+++ b/tests/planner/subqueries/nested-correlated-subquery.yaml
@@ -23,6 +23,9 @@ metadata:
   description: "Doubly-nested correlated scalar subquery returns NULL instead of value"
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS nc_chain_revision"
+  - sql: "DROP TABLE IF EXISTS nc_chain_files"
+  - sql: "DROP TABLE IF EXISTS nc_chain_outer"
   - sql: "DROP TABLE IF EXISTS nc_scope_state"
   - sql: "DROP TABLE IF EXISTS nc_scope_outer"
   - sql: "DROP TABLE IF EXISTS nc_scope_lookup"
@@ -38,6 +41,12 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS nc_config"
 
 setup:
+  - sql: "CREATE TABLE nc_chain_outer (ID INT PRIMARY KEY)"
+  - sql: "CREATE TABLE nc_chain_revision (ID INT PRIMARY KEY, outer_id INT, file_id INT, created INT)"
+  - sql: "CREATE TABLE nc_chain_files (ID INT PRIMARY KEY, kind VARCHAR(30))"
+  - sql: "INSERT INTO nc_chain_outer VALUES (8), (9)"
+  - sql: "INSERT INTO nc_chain_revision VALUES (7, 8, 15, 100), (8, 9, 16, 100)"
+  - sql: "INSERT INTO nc_chain_files VALUES (15, 'application/pdf'), (16, 'application/pdf')"
   - sql: "CREATE TABLE nc_scope_lookup (ID INT PRIMARY KEY, value INT)"
   - sql: "CREATE TABLE nc_scope_outer (ID INT PRIMARY KEY, nc_scope_lookup INT, state_id INT)"
   - sql: "CREATE TABLE nc_scope_state (ID INT PRIMARY KEY, label VARCHAR(20), nc_scope_lookup INT)"
@@ -66,6 +75,49 @@ setup:
   - sql: "INSERT INTO nc_config VALUES (1, 99)"
 
 test_cases:
+  - name: "Nested scalar lookup preserves every outer row"
+    sql: |
+      SELECT o.ID,
+        (SELECT f.kind
+          FROM nc_chain_files AS f
+          WHERE f.ID = (
+            SELECT r.file_id
+            FROM nc_chain_revision AS r
+            WHERE r.outer_id = o.ID
+            ORDER BY r.created DESC, r.ID DESC
+            LIMIT 1
+          )
+          LIMIT 1) AS kind
+      FROM nc_chain_outer AS o
+      ORDER BY o.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 8, kind: "application/pdf"}
+        - {ID: 9, kind: "application/pdf"}
+
+  - name: "Nested scalar predicate preserves every matching outer row"
+    sql: |
+      SELECT o.ID
+      FROM nc_chain_outer AS o
+      WHERE o.ID IN (8, 9)
+        AND (SELECT f.kind
+          FROM nc_chain_files AS f
+          WHERE f.ID = (
+            SELECT r.file_id
+            FROM nc_chain_revision AS r
+            WHERE r.outer_id = o.ID
+            ORDER BY r.created DESC, r.ID DESC
+            LIMIT 1
+          )
+          LIMIT 1) = 'application/pdf'
+      ORDER BY o.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 8}
+        - {ID: 9}
+
   - name: "Derived join hides non-projected column from correlated scope"
     sql: |
       SELECT o.ID,


### PR DESCRIPTION
## Problem

A nested scalar lookup could return the value for only the first outer row. Physical lowering treated a primary-key equality against a column produced by a decorrelated stage as a query-local unique point lookup. It could then apply the scalar LIMIT to the base scan before the joined stage supplied and accepted the row.

Planner row-count estimates were also used as hard upper bounds when deciding whether an early LIMIT was semantically safe.

## Fix

- recognize a query-local unique-key binding only when the opposite equality operand contains no column reference
- use only structurally proven unique-point predicates as hard one-row bounds; keep estimates for costing rather than correctness
- add projection and predicate regressions with multiple outer rows and a two-level ordered scalar lookup

The existing native ORDER/LIMIT late-projection regression remains at three probes, so the fix does not turn that path into a full scan.

## Validation

- new regression fails on the parent revision and passes with this patch
- focused nested-scalar and native ORDER/LIMIT suites pass
- full `make test` passes, including coverage, persistence, crash-recovery, concurrency, and planner-performance suites