### PR TITLE
Short-circuit query-invariant RecSet branches

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5378,6 +5378,127 @@ of values protected by COALESCE are the common generated two-valued forms. */
 				(boolean_recset_nonnull_value? expr)))
 		_ (boolean_recset_nonnull_value? expr))))
 
+/* A query-invariant boolean may decide an entire RecSet branch before any
+dependent carrier is built. Keep that decision in the emitted control flow:
+building every input first and applying recset_union/intersect afterwards
+would erase SQL's useful short-circuit opportunity. This is a dominance rule,
+not a selectivity choice: the skipped branch cannot change the TRUE-row set.
+All data-dependent alternatives continue through the calibrated cost model. */
+(define expr_contains_query_invariant_binding? (lambda (expr)
+	(if (symbol? expr)
+		/* Compact scalar recipes retain the generated lexical binding but may
+		deliberately omit its producer stage from their local catalog. The binding
+		prefix is an internal physical-AST marker created exclusively by
+		query_invariant_probe_binding_key, not a SQL/table-shape heuristic. */
+		(strlike (string expr) "__query_invariant_probe_%" "binary")
+		(match expr
+			((symbol quote) _value) false
+			(cons head tail) (or
+				(expr_contains_query_invariant_binding? head)
+				(reduce tail (lambda (found item)
+					(or found (expr_contains_query_invariant_binding? item))) false))
+			_ false))))
+
+/* Probe markers may carry a complete lowering catalog as their fourth item.
+That catalog is lookup metadata, not a value dependency of this expression
+leaf. Invariance therefore follows the directly referenced stage only; treating
+every catalog entry as an operand makes an unrelated correlated sibling poison
+an otherwise query-constant boolean term. */
+(define expr_direct_probe_stages (lambda (expr)
+	(match expr
+		((symbol scalar_first_probe) stage _requested_col) (list stage)
+		((quote scalar_first_probe) stage _requested_col) (list stage)
+		((symbol scalar_first_probe) stage _requested_col _catalog) (list stage)
+		((quote scalar_first_probe) stage _requested_col _catalog) (list stage)
+		((symbol scalar_aggregate_probe) stage _requested_col) (list stage)
+		((quote scalar_aggregate_probe) stage _requested_col) (list stage)
+		((symbol scalar_cardinality_probe) stage _requested_col) (list stage)
+		((quote scalar_cardinality_probe) stage _requested_col) (list stage)
+		(cons head tail) (merge_unique (list
+			(expr_direct_probe_stages head)
+			(merge (map tail expr_direct_probe_stages))))
+		_ '())))
+
+(define probe_value_expr_contains_column_ref? (lambda (expr)
+	(match expr
+		((symbol scalar_first_probe) stage _requested_col)
+		(reduce (qassoc_get (gs_facts stage) (quote lookup-keys) '())
+			(lambda (found key) (or found (expr_contains_column_ref? key))) false)
+		((quote scalar_first_probe) stage requested_col)
+		(probe_value_expr_contains_column_ref?
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((symbol scalar_first_probe) stage requested_col _catalog)
+		(probe_value_expr_contains_column_ref?
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((quote scalar_first_probe) stage requested_col _catalog)
+		(probe_value_expr_contains_column_ref?
+			(list (symbol "scalar_first_probe") stage requested_col))
+		((symbol get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) true
+		((quote get_column) _tblvar _tbl_ignorecase _col _col_ignorecase) true
+		((symbol quote) _value) false
+		(cons head tail) (or
+			(probe_value_expr_contains_column_ref? head)
+			(reduce tail (lambda (found item)
+				(or found (probe_value_expr_contains_column_ref? item))) false))
+		_ false)))
+
+(define boolean_recset_query_invariant_expr? (lambda (expr)
+	(begin
+		(define probe_stages (expr_direct_probe_stages expr))
+		(define has_invariant_binding (expr_contains_query_invariant_binding? expr))
+		(define has_invariant_stage (reduce probe_stages (lambda (found stage)
+			(or found (query_invariant_presence_stage? stage))) false))
+		(and (or has_invariant_binding has_invariant_stage)
+			(and (not (probe_value_expr_contains_column_ref? expr))
+				(reduce probe_stages (lambda (invariant stage)
+					(and invariant (query_invariant_presence_stage? stage))) true))))))
+
+(define boolean_recset_identity_plan (lambda (domain_src operator)
+	(boolean_recset_domain_scan_plan domain_src
+		(if (equal? operator (quote and)) true false))))
+
+(define boolean_recset_record_invariant_short_circuit (lambda (expr)
+	(planner_record_physical_decision (list
+		(list "decision_id" (concat "query_invariant_recset_short_circuit:"
+			(stable_structural_hash expr true)))
+		(list "decision" "query_invariant_recset_short_circuit")
+		(list "decision_site" "boolean_recset_algebra")
+		(list "chosen" "runtime_guard")
+		(list "selection" "dominance")
+		(list "reason" "invariant_true_skips_dependent_carrier")))))
+
+(define boolean_recset_short_circuit_plan (lambda (stage_catalog domain_src operator items)
+	(begin
+		(define classified_items (reduce items (lambda (classified item)
+			(if (boolean_recset_query_invariant_expr? item)
+				(list (cons item (nth classified 0)) (nth classified 1))
+				(list (nth classified 0) (cons item (nth classified 1)))))
+			(list '() '())))
+		(define invariant_items (reverse (nth classified_items 0)))
+		(if (empty_list? invariant_items)
+			nil
+			(begin
+				(define dependent_items (reverse (nth classified_items 1)))
+				(define invariant_expr (if (equal? (count invariant_items) 1)
+					(car invariant_items)
+					(cons operator invariant_items)))
+				(define dependent_plan (if (empty_list? dependent_items)
+					(boolean_recset_identity_plan domain_src operator)
+					(boolean_recset_expr_plan stage_catalog domain_src
+						(if (equal? (count dependent_items) 1)
+							(car dependent_items)
+							(cons operator dependent_items)))))
+				(boolean_recset_record_invariant_short_circuit invariant_expr)
+				(if (equal? operator (quote and))
+					(list (quote if)
+						(lower_column_expr_for_alias domain_src invariant_expr)
+						dependent_plan
+						(boolean_recset_domain_scan_plan domain_src false))
+					(list (quote if)
+						(lower_column_expr_for_alias domain_src invariant_expr)
+						(boolean_recset_domain_scan_plan domain_src true)
+						dependent_plan))))))))
+
 /* Compile true-row sets recursively. AND/OR are exact set intersection/union.
 CASE is a disjoint union of its true and false-condition branches; SQL treats a
 NULL WHEN condition like false, which is exactly the complement of its true-row
@@ -5445,13 +5566,19 @@ one ordinary scan_recset, while stage leaves use the carrier projection above. *
 					(list (symbol "if") condition then_expr else_expr))
 				(cons head items) (if (or (equal? head (quote and))
 					(equal? head (symbol "and")))
-					(boolean_recset_combine (quote recset_intersect)
-						(map items (lambda (item)
-							(boolean_recset_expr_plan stage_catalog domain_src item))))
-					(if (or (equal? head (quote or)) (equal? head (symbol "or")))
-						(boolean_recset_combine (quote recset_union)
+					(coalesceNil
+						(boolean_recset_short_circuit_plan
+							stage_catalog domain_src (quote and) items)
+						(boolean_recset_combine (quote recset_intersect)
 							(map items (lambda (item)
-								(boolean_recset_expr_plan stage_catalog domain_src item))))
+								(boolean_recset_expr_plan stage_catalog domain_src item)))))
+					(if (or (equal? head (quote or)) (equal? head (symbol "or")))
+						(coalesceNil
+							(boolean_recset_short_circuit_plan
+								stage_catalog domain_src (quote or) items)
+							(boolean_recset_combine (quote recset_union)
+								(map items (lambda (item)
+									(boolean_recset_expr_plan stage_catalog domain_src item)))))
 						(if (empty_list? (expr_probe_stages expr))
 							(boolean_recset_domain_scan_plan domain_src expr)
 							(neumann_fail "build_queryplan"

--- a/tests/planner/subqueries/traced-union-scalar-probes.yaml
+++ b/tests/planner/subqueries/traced-union-scalar-probes.yaml
@@ -487,11 +487,104 @@ test_cases:
         - text: "__query_invariant_probe_"
           count: 4
 
+  - name: "Query-invariant OR short-circuits its dependent RecSet carrier"
+    session_id: "trace-invariant-probe"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT a.id
+      FROM trace_asset a
+      WHERE COALESCE((
+        SELECT (
+          EXISTS (
+            SELECT TRUE FROM trace_global_access global_access
+            WHERE global_access.actor_id = @trace_actor
+              AND global_access.scope_id IS NULL
+            LIMIT 1
+          )
+          OR EXISTS (
+            SELECT TRUE FROM trace_share local_access
+            WHERE local_access.box_id = box_row.id
+              AND local_access.owner_id = @trace_actor
+            LIMIT 1
+          )
+        )
+        FROM trace_box box_row
+        WHERE box_row.id = a.id * 100
+        LIMIT 1
+      ), FALSE)
+      ORDER BY a.id
+      LIMIT 72
+    expect:
+      result_contains:
+        - "query_invariant_recset_short_circuit"
+        - "invariant_true_skips_dependent_carrier"
+
+  - name: "True query-invariant branch admits rows without local access"
+    session_id: "trace-invariant-probe"
+    sql: |
+      SELECT a.id
+      FROM trace_asset a
+      WHERE COALESCE((
+        SELECT (
+          EXISTS (
+            SELECT TRUE FROM trace_global_access global_access
+            WHERE global_access.actor_id = @trace_actor
+              AND global_access.scope_id IS NULL
+            LIMIT 1
+          )
+          OR EXISTS (
+            SELECT TRUE FROM trace_share local_access
+            WHERE local_access.box_id = box_row.id
+              AND local_access.owner_id = @trace_actor
+            LIMIT 1
+          )
+        )
+        FROM trace_box box_row
+        WHERE box_row.id = a.id * 100
+        LIMIT 1
+      ), FALSE)
+      ORDER BY a.id
+    expect:
+      rows: 2
+      data:
+        - {id: 1}
+        - {id: 2}
+
   - name: "Query-invariant presence binding observes the next session value"
     session_id: "trace-invariant-probe"
     sql: "SET @trace_actor = 8"
     expect:
       rows_affected: 0
+
+  - name: "False query-invariant branch preserves local access filtering"
+    session_id: "trace-invariant-probe"
+    sql: |
+      SELECT a.id
+      FROM trace_asset a
+      WHERE COALESCE((
+        SELECT (
+          EXISTS (
+            SELECT TRUE FROM trace_global_access global_access
+            WHERE global_access.actor_id = @trace_actor
+              AND global_access.scope_id IS NULL
+            LIMIT 1
+          )
+          OR EXISTS (
+            SELECT TRUE FROM trace_share local_access
+            WHERE local_access.box_id = box_row.id
+              AND local_access.owner_id = @trace_actor
+            LIMIT 1
+          )
+        )
+        FROM trace_box box_row
+        WHERE box_row.id = a.id * 100
+        LIMIT 1
+      ), FALSE)
+      ORDER BY a.id
+    expect:
+      rows: 1
+      data:
+        - {id: 2}
 
   - name: "Equivalent invariant grants preserve the false and fallback branches"
     session_id: "trace-invariant-probe"


### PR DESCRIPTION
## Summary

- preserve query-invariant boolean branches as runtime control flow while lowering RecSet AND/OR algebra
- skip dependent correlated carriers when an invariant branch already determines the true-row set
- distinguish a probe marker's direct stage and lookup keys from its attached lowering catalog, which is metadata rather than an expression dependency
- record the dominance decision in `EXPLAIN PHYSICAL`

This is a structural dominance rule, not a new selectivity heuristic. It changes no calibration constants and does not force a physical operator. Data-dependent alternatives still go through the existing calibrated cost model; only a branch that provably cannot affect the result is skipped.

## Production-copy A/B

Exact captured inventory-filter query, same data and session binding:

| | cold | warm | hot |
|---|---:|---:|---:|
| master | 15.64 s | 12.07 s | 10.94 s |
| this PR | 3.03 s | 2.26 s | 0.35 s |

The physical plan contains three runtime dominance guards. Its `scan_recset` occurrences fall from 36 to 18; `recset_project_join` remains at 4, demonstrating that the relevant projection shape is retained while unreachable dependent work is no longer initialized.

## Correctness coverage

The regression tests cover both runtime outcomes of the invariant grant:

- true: rows are admitted without evaluating the row-dependent fallback carrier
- false: the correlated local-access predicate still filters exactly
- `EXPLAIN PHYSICAL`: the runtime guard and its dominance reason are present

The structural assertion was confirmed red on master and green with this patch.

## Validation

- Scheme startup tests: 1267/1267
- targeted Subquery/RecSet/LEFT JOIN pool: green
- all planner subquery and aggregate suites: green
- compile-scaling gate: green on three consecutive reruns after removing repeated invariant classification work
- complete pre-commit suite without coverage instrumentation: all tests passed
- Scheme lint, build, and diff checks: green

A coverage-instrumented full run was also attempted. It progressed through the planner suites but the local test process was eventually OOM-killed during storage stress tests; the full non-instrumented hook-equivalent run completed successfully.
