### PR TITLE
Reduce SQL parser memoization overhead

### DIFF
--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1941,7 +1941,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "ROLLBACK" true)) (list (quote tx_rollback) (list (quote context) "session")))
 		"" /* comment only command */
 	)))
-	((parser (define command p) command "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|[\r\n\t ]+)+") s)
+	((parser (define command p) command "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|[\r\n\t ]+)+" true) s)
 )))
 
 (define load_sql (lambda (schema stream) (begin

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -28,11 +28,12 @@ type parserResult struct {
 }
 
 type ScmParser struct {
-	Root      packrat.Parser[*parserResult]
-	Syntax    Scmer
-	Generator Scmer
-	Outer     *Env
-	Skipper   *regexp.Regexp
+	Root                packrat.Parser[*parserResult]
+	Syntax              Scmer
+	Generator           Scmer
+	Outer               *Env
+	Skipper             *regexp.Regexp
+	SkipLeafMemoization bool
 }
 
 type ScmParserVariable struct {
@@ -164,6 +165,9 @@ func (b *ScmParser) Execute(str string, en *Env) Scmer {
 		skipper = packrat.SkipWhitespaceAndCommentsRegex // also skip C-style comments as whitespaces
 	}
 	scanner := packrat.NewScanner[*parserResult](str, skipper)
+	if b.SkipLeafMemoization {
+		scanner.SkipLeafMemoization()
+	}
 	node, err := packrat.Parse(b, scanner)
 	if err != nil {
 		panic(err)
@@ -252,10 +256,16 @@ func parseSyntax(syntax Scmer, en *Env, ome *optimizerMetainfo, ignoreResult boo
 					Validate(list[3], "string")
 					skipper = list[3]
 				}
+				skipLeafMemoization := false
+				if len(list) > 4 {
+					skipLeafMemoization = list[4].Bool()
+				}
 				if ome != nil {
 					return nil
 				}
-				return NewParser(list[1], resulter, skipper, en, ignoreResult)
+				result := NewParser(list[1], resulter, skipper, en, ignoreResult)
+				result.SkipLeafMemoization = skipLeafMemoization
+				return result
 			case "atom":
 				caseInsensitive := false
 				if len(list) > 2 {
@@ -419,6 +429,7 @@ func init_parser() {
 	syntax can be one of:
 	(parser syntax scmerresult) will execute scmerresult after parsing syntax
 	(parser syntax scmerresult "skipper") will add a different whitespace skipper regex to the root parser
+	(parser syntax scmerresult "skipper" true) skips redundant terminal-parser memoization while keeping composite and named grammar rules memoized
 	(define var syntax) valid inside (parser...), stores the result of syntax into var for use in scmerresult
 	"str" AtomParser
 	(atom "str" caseinsensitive skipws) AtomParser
@@ -438,7 +449,7 @@ func init_parser() {
 	`,
 		Fn: nil,
 		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "syntax", ParamDesc: "syntax of the grammar (see docs)"}, &TypeDescriptor{Kind: "any", ParamName: "generator", ParamDesc: "(optional) expressions to evaluate. All captured variables are available in the scope.", Optional: true}, &TypeDescriptor{Kind: "string", ParamName: "skipper", ParamDesc: "(optional) string that defines the skip mechanism for whitespaces as regexp", Optional: true}},
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "syntax", ParamDesc: "syntax of the grammar (see docs)"}, &TypeDescriptor{Kind: "any", ParamName: "generator", ParamDesc: "(optional) expressions to evaluate. All captured variables are available in the scope.", Optional: true}, &TypeDescriptor{Kind: "string", ParamName: "skipper", ParamDesc: "(optional) string that defines the skip mechanism for whitespaces as regexp", Optional: true}, &TypeDescriptor{Kind: "bool", ParamName: "skip_leaf_memoization", ParamDesc: "(optional) retain packrat memoization only for composite and named grammar rules", Optional: true}},
 			Return: &TypeDescriptor{Kind: "func"},
 		},
 	})

--- a/scm/packrat_test.go
+++ b/scm/packrat_test.go
@@ -37,6 +37,23 @@ func TestKleeneParserWithoutMemoization(t *testing.T) {
 	}
 }
 
+func TestSkippedLeafMemoizationKeepsNamedLeftRecursion(t *testing.T) {
+	parserValue := Eval(Read("leaf memo parser", `(begin
+		(define expression (parser (or
+			(parser '((define left expression) "+" (define right (regex "[0-9]+" false false)))
+				(concat left "+" right))
+			(regex "[0-9]+" false false))))
+		(parser '((define value expression) $) value "" true))`), &Globalenv)
+	parser := parserValue.Parser()
+
+	if !parser.SkipLeafMemoization {
+		t.Fatal("parser did not disable terminal-parser memoization")
+	}
+	if got := parser.Execute("1+2+3", &Globalenv).String(); got != "1+2+3" {
+		t.Fatalf("left-recursive parser returned %q", got)
+	}
+}
+
 func TestSharedParserConcurrentCaptures(t *testing.T) {
 	parserValue := Eval(Read("concurrent parser", `(parser '(
 		(define value (or

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -282,7 +282,11 @@ restart:
 				return val
 			case "parser":
 				if len(list) > 3 {
-					return NewScmParser(NewParser(list[1], list[2], list[3], en, true))
+					parser := NewParser(list[1], list[2], list[3], en, true)
+					if len(list) > 4 {
+						parser.SkipLeafMemoization = list[4].Bool()
+					}
+					return NewScmParser(parser)
 				} else if len(list) > 2 {
 					return NewScmParser(NewParser(list[1], list[2], NewNil(), en, true))
 				}

--- a/tests/performance/sql-parser-scaling.yaml
+++ b/tests/performance/sql-parser-scaling.yaml
@@ -1,0 +1,83 @@
+# Copyright (C) 2026  MemCP Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "SQL parser scaling for generated conditional updates"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS parser_scale_event"
+  - sql: |
+      CREATE TABLE parser_scale_event (
+        id INT PRIMARY KEY,
+        mode TEXT,
+        first_at BIGINT,
+        last_at BIGINT,
+        next_1 BIGINT,
+        next_2 BIGINT,
+        next_3 BIGINT,
+        next_4 BIGINT,
+        next_5 BIGINT,
+        next_6 BIGINT
+      )
+  - sql: |
+      INSERT INTO parser_scale_event
+        (id, mode, first_at, last_at, next_1, next_2, next_3, next_4, next_5, next_6)
+      VALUES (1, 'periodic', 100, 90, 1, 2, 3, 4, 5, 6)
+
+test_cases:
+  - name: "Large conditional no-op update remains correct"
+    timeout: 30
+    scm: |
+      (begin
+        (define branches (reduce (produceN 764) (lambda (sql i)
+          (begin
+            (concat sql
+              " WHEN mode = 'periodic' AND first_at <= (CASE WHEN 1800000000 >= first_at + " i
+              " THEN first_at + " i " ELSE first_at END)"
+              " AND COALESCE(last_at, 0) < (CASE WHEN 1800000000 >= first_at + " i
+              " THEN first_at + " i " ELSE first_at END)"
+              " THEN first_at + " i))) ""))
+        (define case_expr (concat "CASE" branches " ELSE last_at END"))
+        (define ids (reduce (produceN 764) (lambda (sql i)
+          (concat sql (if (equal? i 0) "" " OR ") "id = " (+ i 1000))) ""))
+        (define query (concat
+          "UPDATE parser_scale_event SET "
+          "next_1 = " case_expr ", next_2 = " case_expr ", next_3 = " case_expr
+          ", next_4 = " case_expr ", next_5 = " case_expr ", next_6 = " case_expr
+          " WHERE (" ids ") AND FALSE"))
+        (eval (parse_sql "memcp-tests" query (lambda (_schema _table _write) true)))
+        "ok")
+    expect:
+      data: ["ok"]
+
+  - name: "No-op update leaves the row unchanged"
+    sql: |
+      SELECT next_1, next_2, next_3, next_4, next_5, next_6
+      FROM parser_scale_event
+      WHERE id = 1
+    expect:
+      rows: 1
+      data:
+        - next_1: 1
+          next_2: 2
+          next_3: 3
+          next_4: 4
+          next_5: 5
+          next_6: 6
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS parser_scale_event"

--- a/third_party/go-packrat/parser.go
+++ b/third_party/go-packrat/parser.go
@@ -1,5 +1,5 @@
 /*
-	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
 	Author: Tim Kluge
 
 	Dual licensed with custom aggreements or GPLv3
@@ -19,13 +19,14 @@ type Parser[T any] interface {
 }
 
 func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
-	startPosition := s.position
-
-	memmap := s.memoization[startPosition]
-	if memmap == nil {
-		memmap = make(map[Parser[T]]*MemoEntry[T])
-		s.memoization[startPosition] = memmap
+	if s.skipLeafMemoization {
+		switch rule.(type) {
+		case *AtomParser[T], *EmptyParser[T], *EndParser[T], *RegexParser[T], *RestParser[T]:
+			return rule.Match(s)
+		}
 	}
+
+	startPosition := s.position
 
 	m := s.Recall(rule, startPosition)
 	if m == nil {
@@ -33,6 +34,11 @@ func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
 		*lr = Lr[T]{seed: Node[T]{}, seedOk: false, rule: rule, head: nil, next: s.invocationStack}
 		s.invocationStack = lr
 		m := &MemoEntry[T]{Lr: lr, Position: startPosition}
+		memmap := s.memoization[startPosition]
+		if memmap == nil {
+			memmap = make(map[Parser[T]]*MemoEntry[T])
+			s.memoization[startPosition] = memmap
+		}
 		memmap[rule] = m
 		ans, ok := rule.Match(s)
 		s.invocationStack = s.invocationStack.next
@@ -65,7 +71,7 @@ func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
 var emptyString = ""
 
 type Node[T any] struct {
-	Payload  T
+	Payload T
 }
 
 type ParserError[T any] struct {
@@ -182,8 +188,8 @@ func ParsePartial[T any](p Parser[T], originalScanner *Scanner[T]) (Node[T], *Pa
 		m := originalScanner.memoization[index]
 		if len(m) > 0 {
 			maxPos = index
-			for k := range m {
-				failedParsers = append(failedParsers, k)
+			for rule := range m {
+				failedParsers = append(failedParsers, rule)
 			}
 			break
 		}
@@ -221,8 +227,8 @@ func Parse[T any](p Parser[T], originalScanner *Scanner[T]) (Node[T], *ParserErr
 		m := originalScanner.memoization[index]
 		if len(m) > 0 {
 			maxPos = index
-			for k := range m {
-				failedParsers = append(failedParsers, k)
+			for rule := range m {
+				failedParsers = append(failedParsers, rule)
 			}
 			break
 		}

--- a/third_party/go-packrat/scanner.go
+++ b/third_party/go-packrat/scanner.go
@@ -1,5 +1,5 @@
 /*
-	(c) 2019, 2023 Launix, Inh. Carl-Philip Hänsch
+	(c) 2019-2026 Launix, Inh. Carl-Philip Hänsch
 	Author: Tim Kluge
 	Author: Carl-Philip Hänsch
 
@@ -9,15 +9,15 @@
 package packrat
 
 import (
-	"sync"
 	"regexp"
+	"sync"
 	"unicode"
 )
 
 type MemoEntry[T any] struct {
 	Lr  *Lr[T]
 	Ans Node[T]
-	Ok bool
+	Ok  bool
 
 	Position int
 }
@@ -51,24 +51,25 @@ func (h *Head[T]) IsEvaluated(rule Parser[T]) bool {
 }
 
 type Lr[T any] struct {
-	seed Node[T]
+	seed   Node[T]
 	seedOk bool
-	rule Parser[T]
-	head *Head[T]
-	next *Lr[T]
+	rule   Parser[T]
+	head   *Head[T]
+	next   *Lr[T]
 }
 
 type Scanner[T any] struct {
-	input           string
-	remainingInput  string
-	position        int
-	memoization     []map[Parser[T]]*MemoEntry[T]
-	heads           map[int]*Head[T]
-	invocationStack *Lr[T]
-	breaks          []bool
+	input               string
+	remainingInput      string
+	position            int
+	memoization         []map[Parser[T]]*MemoEntry[T]
+	heads               map[int]*Head[T]
+	invocationStack     *Lr[T]
+	breaks              []bool
+	skipLeafMemoization bool
 
-	headpool        sync.Pool
-	lrPool          sync.Pool
+	headpool sync.Pool
+	lrPool   sync.Pool
 
 	skipRegex *regexp.Regexp
 }
@@ -77,24 +78,31 @@ type Scanner[T any] struct {
 // Pools are shared by copying the New functions.
 func (s *Scanner[T]) Copy() *Scanner[T] {
 	ns := &Scanner[T]{
-		input:           s.input,
-		remainingInput:  s.remainingInput,
-		position:        s.position,
-		memoization:     s.memoization,
-		heads:           s.heads,
-		invocationStack: s.invocationStack,
-		breaks:          s.breaks,
-		skipRegex:       s.skipRegex,
+		input:               s.input,
+		remainingInput:      s.remainingInput,
+		position:            s.position,
+		memoization:         s.memoization,
+		heads:               s.heads,
+		invocationStack:     s.invocationStack,
+		breaks:              s.breaks,
+		skipLeafMemoization: s.skipLeafMemoization,
+		skipRegex:           s.skipRegex,
 	}
 	ns.headpool.New = s.headpool.New
 	ns.lrPool.New = s.lrPool.New
 	return ns
 }
 
+// SkipLeafMemoization avoids retaining results for terminal parsers, which
+// cannot close a recursive grammar cycle. Composite and named grammar rules
+// remain memoized and continue to provide packrat recursion handling.
+func (s *Scanner[T]) SkipLeafMemoization() {
+	s.skipLeafMemoization = true
+}
+
 func (s *Scanner[T]) Recall(rule Parser[T], pos int) *MemoEntry[T] {
-	mmap := s.memoization[pos]
 	var m *MemoEntry[T]
-	if mmap != nil {
+	if mmap := s.memoization[pos]; mmap != nil {
 		m = mmap[rule]
 	}
 
@@ -181,7 +189,7 @@ var SkipWhitespaceAndCommentsRegex = regexp.MustCompile("^(?:/\\*.*?\\*/|[\r\n\t
 func NewScanner[T any](input string, skipper *regexp.Regexp) *Scanner[T] {
 	s := &Scanner[T]{input: input, position: 0,
 		memoization: make([]map[Parser[T]]*MemoEntry[T], len(input)+1),
-		heads: make(map[int]*Head[T])}
+		heads:       make(map[int]*Head[T])}
 	s.headpool.New = func() any {
 		return &Head[T]{nil, make(map[Parser[T]]bool), make(map[Parser[T]]bool)}
 	}


### PR DESCRIPTION
## Summary
- avoid memoizing terminal parser matches in the SQL root parser while retaining memoization for composite and named grammar rules
- preserve left-recursive grammar handling and cover it with a focused Go regression test
- add a generated large CASE/OR UPDATE integration shape to the performance test taxonomy

## Evidence
- exact 1.86 MB generated UPDATE, repeated cold A/B: 12.78 s -> 9.91 s (22.5% faster)
- full `make test` passed, including the new 4,584-WHEN / 763-OR regression
- Scheme formatter check passed

This changes parser allocation/GC overhead only; the SQL AST and planner phase boundaries remain unchanged.