### PR TITLE
Protect internal tables from destructive maintenance

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2026  Carl-Philip Hänsch
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1522,7 +1526,8 @@ for(var k=0;k<without.length;k++)accessHtml+="<option value='"+esc(without[k].us
 accessHtml+="</select>";
 }
 var accessCell=isAdmin?"<td>"+accessHtml+"</td>":"";
-h+="<tr><td class='clickable' onclick=\"location.hash='db/"+dn+"'\">"+esc(d.name)+"</td><td>"+esc(d.backend||"filesystem")+"</td><td class='r'>"+d.tables+"</td><td class='r'>"+fmt(d.size_bytes||0)+"</td>"+accessCell+"<td class='action-cell'><button class='btn-warn' data-querydb='"+esc(d.name)+"'>Query</button> <button class='btn-warn' data-truncdb='"+esc(d.name)+"'>Truncate</button> <button class='btn-danger' data-dropdb='"+esc(d.name)+"'>Drop</button></td></tr>";
+var destructiveActions=(d.can_truncate?" <button class='btn-warn' data-truncdb='"+esc(d.name)+"'>Truncate</button>":"")+(d.can_drop?" <button class='btn-danger' data-dropdb='"+esc(d.name)+"'>Drop</button>":"");
+h+="<tr><td class='clickable' onclick=\"location.hash='db/"+dn+"'\">"+esc(d.name)+"</td><td>"+esc(d.backend||"filesystem")+"</td><td class='r'>"+d.tables+"</td><td class='r'>"+fmt(d.size_bytes||0)+"</td>"+accessCell+"<td class='action-cell'><button class='btn-warn' data-querydb='"+esc(d.name)+"'>Query</button>"+destructiveActions+"</td></tr>";
 }
 tb.innerHTML=h||"<tr><td colspan='"+(isAdmin?6:5)+"' style='color:#888;text-align:center'>No databases</td></tr>";
 tb.querySelectorAll("[data-truncdb]").forEach(function(btn){
@@ -1577,7 +1582,9 @@ var h="";
 for(var i=0;i<data.length;i++){
 var d=data[i];
 var dbn=esc(encodeURIComponent(dbname)),tn=esc(encodeURIComponent(d.name));
-h+="<tr><td class='clickable' onclick=\"location.hash='db/"+dbn+"/@"+tn+"'\" title='"+esc(d.name)+"'>"+esc(truncName(d.name))+"</td><td>"+esc(d.engine||"")+"</td><td class='r'>"+d.columns+"</td><td class='r'>"+d.shards+"</td><td class='r'>"+(d.rows===null?"<span style=\"color:#888\">N/A</span>":d.rows)+"</td><td class='r'>"+fmt(d.size_bytes||0)+"</td><td class='action-cell'><button class='btn-warn' data-querytbl='"+esc(d.name)+"'>Query</button> <button class='btn-warn' data-trunctbl='"+esc(d.name)+"'>Truncate</button> <button class='btn-danger' data-droptbl='"+esc(d.name)+"'>Drop</button></td></tr>";
+var showTableMaintenance=d.maintenance_class==="user";
+var destructiveActions=(showTableMaintenance&&d.can_truncate?" <button class='btn-warn' data-trunctbl='"+esc(d.name)+"'>Truncate</button>":"")+(showTableMaintenance&&d.can_drop?" <button class='btn-danger' data-droptbl='"+esc(d.name)+"'>Drop</button>":"");
+h+="<tr><td class='clickable' onclick=\"location.hash='db/"+dbn+"/@"+tn+"'\" title='"+esc(d.name)+"'>"+esc(truncName(d.name))+"</td><td>"+esc(d.engine||"")+"</td><td class='r'>"+d.columns+"</td><td class='r'>"+d.shards+"</td><td class='r'>"+(d.rows===null?"<span style=\"color:#888\">N/A</span>":d.rows)+"</td><td class='r'>"+fmt(d.size_bytes||0)+"</td><td class='action-cell'><button class='btn-warn' data-querytbl='"+esc(d.name)+"'>Query</button>"+destructiveActions+"</td></tr>";
 }
 tb.innerHTML=h||"<tr><td colspan='7' style='color:#888;text-align:center'>No tables</td></tr>";
 tb.querySelectorAll("[data-trunctbl]").forEach(function(btn){
@@ -1601,7 +1608,7 @@ var engines=[
 {v:"sloppy",sql:"SLOPPY"},
 {v:"memory",sql:"MEMORY"}
 ];
-var engSel="<select class='inline-select' id='engine-select'>";
+var engSel="<select class='inline-select' id='engine-select'"+(meta.can_change_engine?"":" disabled")+">";
 for(var i=0;i<engines.length;i++){
 engSel+="<option value='"+engines[i].v+"'"+(meta.engine===engines[i].v?" selected":"")+">"+engines[i].v+"</option>";
 }
@@ -1612,11 +1619,11 @@ var uniq=meta.uniques||[];
 mc+="<div class='meta-card'><div class='label'>Unique Keys</div><div class='val'>"+uniq.length+"</div></div>";
 var parts=meta.partitions||[];
 if(parts.length>0){var ps=parts.map(function(p){return p.n+"x"+p.column}).join(", ");mc+="<div class='meta-card'><div class='label'>Partition Schema</div><div class='val'>"+esc(ps)+"</div></div>";}
-mc+="<div class='meta-card'><button class='btn-warn' id='btn-query-tbl'>Query</button> <button class='btn-warn' id='btn-truncate-tbl'>Truncate Table</button></div>";
+mc+="<div class='meta-card'><button class='btn-warn' id='btn-query-tbl'>Query</button>"+(meta.can_truncate?" <button class='btn-warn' id='btn-truncate-tbl'>Truncate Table</button>":"")+"</div>";
 document.getElementById("detail-meta").innerHTML=mc;
 var engEl=document.getElementById("engine-select");
 var origEngine=engEl.value;
-engEl.addEventListener("change",function(){
+if(meta.can_change_engine)engEl.addEventListener("change",function(){
 var eng=this.value;
 var engSpec=engines.filter(function(e){return e.v===eng})[0];
 var engSql=engSpec?engSpec.sql:eng.toUpperCase();
@@ -1629,7 +1636,8 @@ return r.text();
 document.getElementById("btn-query-tbl").addEventListener("click",function(){
 openConsole(dbname,"SELECT * FROM `"+tblname+"` LIMIT 100");
 });
-document.getElementById("btn-truncate-tbl").addEventListener("click",function(){
+var truncateTableButton=document.getElementById("btn-truncate-tbl");
+if(truncateTableButton)truncateTableButton.addEventListener("click",function(){
 if(window.confirm("Truncate table '"+tblname+"'? All data will be deleted."))execSQL(dbname,"TRUNCATE TABLE `"+tblname+"`",function(){route()});
 });
 /* columns */
@@ -1640,7 +1648,8 @@ var c=cols[i];
 var keyBadge="";
 if(c.key==="PRI")keyBadge="<span class='badge badge-pri'>PRI</span>";
 else if(c.key==="UNI")keyBadge="<span class='badge badge-uni'>UNI</span>";
-ch+="<tr><td>"+esc(c.name)+"</td><td>"+esc(c.type)+"</td><td>"+(c.nullable?"<span class='badge badge-null'>NULL</span>":"NOT NULL")+"</td><td>"+keyBadge+"</td><td class='action-cell'><button class='btn-danger' data-dropcol='"+esc(c.name)+"'>Drop</button></td></tr>";
+var dropColumnAction=meta.can_alter?"<button class='btn-danger' data-dropcol='"+esc(c.name)+"'>Drop</button>":"";
+ch+="<tr><td>"+esc(c.name)+"</td><td>"+esc(c.type)+"</td><td>"+(c.nullable?"<span class='badge badge-null'>NULL</span>":"NOT NULL")+"</td><td>"+keyBadge+"</td><td class='action-cell'>"+dropColumnAction+"</td></tr>";
 }
 document.querySelector("#tbl-columns tbody").innerHTML=ch||"<tr><td colspan='5' style='color:#888;text-align:center'>No columns</td></tr>";
 document.querySelectorAll("#tbl-columns [data-dropcol]").forEach(function(btn){
@@ -1683,7 +1692,8 @@ var triggers=data.triggers||[];
 var trh="";
 for(var i=0;i<triggers.length;i++){
 var tr=triggers[i];
-trh+="<tr><td>"+esc(tr.name)+"</td><td>"+esc(tr.timing)+"</td><td>"+esc(tr.event)+"</td><td><code style='font-size:.8rem;white-space:pre-wrap;word-break:break-all'>"+esc(tr.body)+"</code></td><td class='action-cell'><button class='btn-danger' data-droptrigger='"+esc(tr.name)+"'>Drop</button></td></tr>";
+var dropTriggerAction=meta.can_alter?"<button class='btn-danger' data-droptrigger='"+esc(tr.name)+"'>Drop</button>":"";
+trh+="<tr><td>"+esc(tr.name)+"</td><td>"+esc(tr.timing)+"</td><td>"+esc(tr.event)+"</td><td><code style='font-size:.8rem;white-space:pre-wrap;word-break:break-all'>"+esc(tr.body)+"</code></td><td class='action-cell'>"+dropTriggerAction+"</td></tr>";
 }
 document.querySelector("#tbl-triggers tbody").innerHTML=trh||"<tr><td colspan='5' style='color:#888;text-align:center'>No triggers</td></tr>";
 document.querySelectorAll("#tbl-triggers [data-droptrigger]").forEach(function(btn){
@@ -2144,7 +2154,7 @@ for(var i=0;i<data.length;i++){
 var u=data[i];
 var permHtml="";
 if(u.admin){
-permHtml="<span class='badge badge-pri'>admin <a href='#' class='revoke-admin' data-user='"+esc(u.username)+"' style='color:#fff;text-decoration:none;margin-left:4px'>&times;</a></span>";
+permHtml="<span class='badge badge-pri'>admin"+(u.username==="root"?"":" <a href='#' class='revoke-admin' data-user='"+esc(u.username)+"' style='color:#fff;text-decoration:none;margin-left:4px'>&times;</a>")+"</span>";
 }else{
 var uDbs=u.databases||[];
 for(var j=0;j<uDbs.length;j++){
@@ -2161,7 +2171,7 @@ permHtml+=" <button class='btn-warn make-admin' data-user='"+esc(u.username)+"' 
 }
 var actHtml="";
 actHtml+="<button class='btn-warn change-pw' data-user='"+esc(u.username)+"'>Change PW</button> ";
-actHtml+="<button class='btn-danger remove-user' data-user='"+esc(u.username)+"'>Remove</button>";
+if(u.username!=="root")actHtml+="<button class='btn-danger remove-user' data-user='"+esc(u.username)+"'>Remove</button>";
 h+="<tr><td>"+esc(u.username)+"</td><td>"+permHtml+"</td><td class='action-cell'>"+actHtml+"</td></tr>";
 }
 tb.innerHTML=h||"<tr><td colspan='3' style='color:#888;text-align:center'>No users</td></tr>";
@@ -2211,7 +2221,7 @@ tb.querySelectorAll(".remove-user").forEach(function(btn){
 btn.addEventListener("click",function(){
 var user=btn.getAttribute("data-user");
 if(window.confirm("Remove user '"+user+"'? This cannot be undone!"))
-execSQL("system","DELETE FROM user WHERE username="+sqlStr(user),function(){fetchUsers(renderUsers)});
+execSQL("system","DROP USER "+sqlId(user),function(){fetchUsers(renderUsers)});
 });
 });
 });

--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -160,10 +160,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(define dbs (dashboard_user_databases (req "username") is_admin))
 					(define items (map dbs (lambda (db) (begin
 						(define tables (show db))
+						(define maintenance (maintenance_capabilities db))
 						(define table_count (if (nil? tables) 0 (count tables)))
 						(define total_size (if (nil? tables) 0
 							(reduce (map tables (lambda (tbl) (dashboard_table_size db tbl))) (lambda (a b) (+ a b)) 0)))
-						(json_encode_assoc (list "name" db "tables" table_count "size_bytes" total_size))
+						(json_encode_assoc (list
+							"name" db
+							"tables" table_count
+							"size_bytes" total_size
+							"maintenance_class" (maintenance "Class")
+							"can_drop" (maintenance "CanDrop")
+							"can_truncate" (maintenance "CanTruncate")))
 					))))
 					(dashboard_send_json res (dashboard_json_array items))
 				))
@@ -267,6 +274,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 						",\"triggers\":" trigger_items
 						",\"meta\":{\"engine\":" (json_encode (meta "Engine"))
 						",\"collation\":" (json_encode (meta "Collation"))
+						",\"maintenance_class\":" (json_encode (meta "MaintenanceClass"))
+						",\"can_drop\":" (json_encode (meta "CanDrop"))
+						",\"can_truncate\":" (json_encode (meta "CanTruncate"))
+						",\"can_rename\":" (json_encode (meta "CanRename"))
+						",\"can_alter\":" (json_encode (meta "CanAlter"))
+						",\"can_change_engine\":" (json_encode (meta "CanChangeEngine"))
 						",\"uniques\":" unique_items
 						",\"partitions\":" partition_items "}}"
 					))
@@ -295,6 +308,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 							"shards" shard_count
 							"rows" row_count
 							"size_bytes" total_size
+							"maintenance_class" (meta "MaintenanceClass")
+							"can_drop" (meta "CanDrop")
+							"can_truncate" (meta "CanTruncate")
+							"can_rename" (meta "CanRename")
+							"can_alter" (meta "CanAlter")
+							"can_change_engine" (meta "CanChangeEngine")
 						))
 					)))))
 					(dashboard_send_json res (dashboard_json_array items))

--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -740,7 +740,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	) (begin
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(define trunc_schema (coalesce schema2 schema))
-			(build_dml_plan trunc_schema tbl nil (list (list tbl trunc_schema tbl false nil)) nil true nil nil nil)
+			(cons '!begin (list
+				(list (quote checktablemaintenance) trunc_schema tbl "truncate")
+				(build_dml_plan trunc_schema tbl nil (list (list tbl trunc_schema tbl false nil)) nil true nil nil nil)))
 	)))
 
 	(define psql_insert_into (parser '(
@@ -1051,12 +1053,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		))
 		(parser '((atom "ALTER" true) (atom "USER" true) (define username psql_identifier) (atom "NOSUPERUSER" true))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" '('protected_sql_admin_revoke_value username)))))
 		))
 		/* DROP USER/ROLE [IF EXISTS] — cascade-deletes access entries then the user row */
 		(parser '((atom "DROP" true) (or (atom "USER" true) (atom "ROLE" true)) (? (atom "IF" true) (atom "EXISTS" true)) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
 				(cons '!begin (list
+					'((quote protect_sql_root_admin) username "drop")
 					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
@@ -1083,7 +1086,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* REVOKE ALL [PRIVILEGES] ON *.* FROM user -> set admin false */
 		(parser '((atom "REVOKE" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "FROM" true) (define username psql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" '('protected_sql_admin_revoke_value username)))))
 		))
 		/* GRANT <any> ON DATABASE db TO user (idempotent) */
 		(parser '((atom "GRANT" true) (+ (or psql_identifier "," (atom "ALL" true) (atom "PRIVILEGES" true) (atom "SELECT" true) (atom "CONNECT" true) (atom "USAGE" true))) (atom "ON" true) (atom "DATABASE" true) (define db psql_identifier) (atom "TO" true) (define username psql_identifier))
@@ -1212,7 +1215,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "SET" true) (atom "timezone" true) (or "=" (atom "TO" true)) (define tz psql_expression)) '((quote session) "time_zone" tz))
 
 
-		(parser '((atom "DROP" true) (atom "DATABASE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) (begin (if policy (policy "system" true true) true) '((quote dropdatabase) id (if if_exists true false))))
+		(parser '((atom "DROP" true) (atom "DATABASE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) (begin
+			(if policy (policy "system" true true) true)
+			(list (quote drop_sql_database) (list (quote session) "__memcp_tx") id (if if_exists true false))))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema psql_identifier) (atom "." true) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id psql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "VIEW" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true)))
@@ -1412,7 +1417,7 @@ substring replace (which is the historical behaviour). */
 
 (define psql_import_dropdatabase (lambda (plan)
 	(match plan
-		(cons op tail) (equal? op (quote dropdatabase))
+		(cons op tail) (or (equal? op (quote dropdatabase)) (equal? op (quote drop_sql_database)))
 		false)
 ))
 

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1267,7 +1267,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	) (begin
 			(if policy (policy (coalesce schema2 schema) tbl true) true)
 			(define trunc_schema (coalesce schema2 schema))
-			(build_dml_plan trunc_schema tbl nil (list (list tbl trunc_schema tbl false nil)) nil true nil nil nil)
+			(cons '!begin (list
+				(list (quote checktablemaintenance) trunc_schema tbl "truncate")
+				(build_dml_plan trunc_schema tbl nil (list (list tbl trunc_schema tbl false nil)) nil true nil nil nil)))
 	)))
 
 	/* Multi-table DELETE: route through query planner pipeline via build_dml_plan */
@@ -1624,6 +1626,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "DROP" true) (atom "USER" true) (? (atom "IF" true) (atom "EXISTS" true)) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
 				(cons '!begin (list
+					'((quote protect_sql_root_admin) username "drop")
 					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
 						'('list "username")
 						'((quote lambda) '('username) '((quote equal??) (quote username) username))
@@ -1675,7 +1678,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* REVOKE ALL [PRIVILEGES] ON *.* FROM user -> set admin false */
 		(parser '((atom "REVOKE" true) (atom "ALL" true) (? (atom "PRIVILEGES" true)) (atom "ON" true) (atom "*" true) (atom "." true) (atom "*" true) (atom "FROM" true) (define username sql_user_ident))
 			(begin (if policy (policy "system" true true) true)
-				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" false))))
+				'((quote scan) '(session "__memcp_tx") '('table "system" "user") '('list "username") '((quote lambda) '('username) '((quote equal?) (quote username) username)) '('list "$update") '('lambda '('$update) '('$update '('list "admin" '('protected_sql_admin_revoke_value username)))))
 		))
 		/* REVOKE <anything> ON db.* FROM user -> delete access entry */
 		(parser '((atom "REVOKE" true) (+ (or sql_identifier "," (atom "SELECT" true) (atom "ALL" true) (atom "PRIVILEGES" true))) (atom "ON" true) (define db sql_identifier) (atom "." true) (or (atom "*" true) sql_identifier) (atom "FROM" true) (define username sql_user_ident))
@@ -1825,17 +1828,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 
 		(parser '((atom "DROP" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier))
 			(begin (if policy (policy "system" true true) true)
-				(cons '!begin (list
-					'((quote scan) '(session "__memcp_tx") '('table "system" "access")
-						'('list "database")
-						'((quote lambda) '('database) '((quote equal??) (quote database) id))
-						'(list "$update")
-						'((quote lambda) '((quote $update)) '((quote if) '((quote $update)) 1 0))
-						(quote +)
-						0)
-					'((quote dropdatabase) id (if if_exists true false))
-				))
-		))
+				(list (quote drop_sql_database) (list (quote session) "__memcp_tx") id (if if_exists true false))))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define schema sql_identifier) (atom "." true) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "TABLE" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier)) '((quote droptable) schema id (if if_exists true false)))
 		(parser '((atom "DROP" true) (atom "VIEW" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true)))

--- a/lib/sql-views.scm
+++ b/lib/sql-views.scm
@@ -166,3 +166,28 @@ derived SELECT before untangle_query sees the complete query. */
 			(sql_view_catalog_changed)
 			removed)
 		(if if_exists 0 (error (concat "view " schema "." name " does not exist")))))))
+
+/* Drop the physical database before cleaning its catalog rows. This ordering
+prevents a refused or failed protected-schema drop from changing access or view
+metadata. */
+(define drop_sql_database (lambda (tx schema if_exists) (begin
+	(define dropped (dropdatabase schema if_exists))
+	(if dropped (begin
+		(scan tx (table "system" "access")
+			'("database")
+			(lambda (database) (equal?? database schema))
+			'("$update")
+			(lambda ($update) ($update))
+			+ 0)
+		(define removed_views (scan tx (table "system" "views")
+			'("database")
+			(lambda (database) (equal?? database schema))
+			'("$update")
+			(lambda ($update) ($update))
+			+ 0))
+		(if (> removed_views 0) (begin
+			(sql_view_catalog_set_count (max 0 (- (sql_view_catalog_state "count") removed_views)))
+			(sql_view_catalog_changed)
+		) true)
+	) true)
+	dropped)))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -22,6 +22,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (import "queryplan.scm")
 (import "sql-views.scm")
 
+/* Root is the recovery identity for a fresh/local installation. User-facing
+maintenance commands may change its password, but may not remove the account
+or its administrator capability. */
+(define protect_sql_root_admin (lambda (username operation)
+	(if (equal?? username "root")
+		(error (concat "cannot " operation " protected user root"))
+		true)))
+
+(define protected_sql_admin_revoke_value (lambda (username) (begin
+	(protect_sql_root_admin username "remove administrator privileges from")
+	false)))
+
 /* query plan caches: separate cachemap per parser dialect */
 (set sql_queryplan_cache (newcachemap))
 (set psql_queryplan_cache (newcachemap))
@@ -487,7 +499,7 @@ if the user is not allowed to access this property, the function will throw an e
 (try (lambda () (begin
 	(if (has? (show "system") "user") (begin
 		(if (has? (map (show "system" "user") (lambda (col) (get_assoc col "Field"))) "id")
-			(dropcolumn (table "system" "user") "id")
+			(migratedropcolumn (table "system" "user") "id")
 			true)
 	) true)
 )) (lambda (e) true))

--- a/storage/database.go
+++ b/storage/database.go
@@ -1193,7 +1193,15 @@ func DatabaseBackendName(schema string) string {
 }
 
 func DropDatabase(schema string, ifexists bool) bool {
-	db := databases.Remove(schema)
+	db := databases.Get(schema)
+	if db == nil {
+		if ifexists {
+			return false
+		}
+		panic("Database " + schema + " does not exist")
+	}
+	requireDatabaseMaintenance(schema, maintenanceDrop)
+	db = databases.Remove(schema)
 	if db == nil {
 		if ifexists {
 			return false
@@ -1312,6 +1320,10 @@ func DropTable(schema, name string, ifexists bool) {
 		}
 		panic("Table " + schema + "." + name + " does not exist")
 	}
+	if !tableMaintenanceCapabilities(schema, name).canDrop {
+		db.schemalock.Unlock()
+		requireTableMaintenance(schema, name, maintenanceDrop)
+	}
 	db.tables.Remove(name)
 	if name == ".blobs" {
 		db.blobRefState().table.Store(nil)
@@ -1353,6 +1365,14 @@ func RenameTable(schema, oldname, newname string) {
 	if t == nil {
 		db.schemalock.Unlock()
 		panic("Table " + schema + "." + oldname + " does not exist")
+	}
+	if !tableMaintenanceCapabilities(schema, oldname).canRename {
+		db.schemalock.Unlock()
+		requireTableMaintenance(schema, oldname, maintenanceRename)
+	}
+	if !tableMaintenanceCapabilities(schema, newname).canRename {
+		db.schemalock.Unlock()
+		requireTableMaintenance(schema, newname, maintenanceRename)
 	}
 	if db.tables.Get(newname) != nil {
 		db.schemalock.Unlock()

--- a/storage/database_protection_test.go
+++ b/storage/database_protection_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "testing"
+
+import "github.com/launix-de/NonLockingReadMap"
+
+func requirePanic(t *testing.T, action func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("operation did not panic")
+		}
+	}()
+	action()
+}
+
+func TestInternalDatabaseProtection(t *testing.T) {
+	for _, schema := range []string{"system", "SYSTEM", "system_statistic"} {
+		if databaseMaintenanceCapabilities(schema).canDrop {
+			t.Errorf("databaseMaintenanceCapabilities(%q).canDrop = true, want false", schema)
+		}
+	}
+	if !databaseMaintenanceCapabilities("application").canDrop {
+		t.Fatal("application database must remain droppable")
+	}
+}
+
+func TestInternalTableProtection(t *testing.T) {
+	for _, test := range []struct {
+		schema string
+		table  string
+	}{
+		{schema: "system", table: "user"},
+		{schema: "system_statistic", table: "logs"},
+		{schema: "application", table: ".blobs"},
+	} {
+		if tableMaintenanceCapabilities(test.schema, test.table).canDrop {
+			t.Errorf("tableMaintenanceCapabilities(%q, %q).canDrop = true, want false", test.schema, test.table)
+		}
+	}
+	if !tableMaintenanceCapabilities("application", "logs").canDrop {
+		t.Fatal("ordinary application tables must remain droppable")
+	}
+}
+
+func TestMaintenanceCapabilityMatrix(t *testing.T) {
+	catalog := tableMaintenanceCapabilities("system", "user")
+	if catalog.canDrop || catalog.canTruncate || catalog.canRename || catalog.canAlter || catalog.canChangeEngine {
+		t.Fatalf("system catalog has destructive capability: %+v", catalog)
+	}
+
+	telemetry := tableMaintenanceCapabilities("system_statistic", "logs")
+	if telemetry.canDrop || !telemetry.canTruncate || telemetry.canRename || telemetry.canAlter || telemetry.canChangeEngine {
+		t.Fatalf("telemetry capability matrix is invalid: %+v", telemetry)
+	}
+
+	user := tableMaintenanceCapabilities("application", "logs")
+	if !user.canDrop || !user.canTruncate || !user.canRename || !user.canAlter || !user.canChangeEngine {
+		t.Fatalf("user table capability matrix is unexpectedly restricted: %+v", user)
+	}
+}
+
+func TestDropRefusesInternalObjectsBeforeMutation(t *testing.T) {
+	oldSystem := databases.Get("system")
+	db := newDatabase()
+	db.Name = "system"
+	db.tables = NonLockingReadMap.New[table, string]()
+	db.tables.Set(&table{schema: db, Name: "user", PersistencyMode: Safe})
+	databases.Set(db)
+	t.Cleanup(func() {
+		databases.Remove("system")
+		if oldSystem != nil {
+			databases.Set(oldSystem)
+		}
+	})
+
+	requirePanic(t, func() { DropTable("system", "user", false) })
+	if db.tables.Get("user") == nil {
+		t.Fatal("protected table was removed")
+	}
+	requirePanic(t, func() { RenameTable("system", "user", "renamed_user") })
+	if db.tables.Get("user") == nil || db.tables.Get("renamed_user") != nil {
+		t.Fatal("protected table was renamed")
+	}
+	requirePanic(t, func() { db.tables.Get("user").DropColumn("admin") })
+
+	requirePanic(t, func() { DropDatabase("system", false) })
+	if databases.Get("system") != db {
+		t.Fatal("protected database was removed")
+	}
+}

--- a/storage/maintenance.go
+++ b/storage/maintenance.go
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "strings"
+
+import "github.com/launix-de/memcp/scm"
+
+type maintenanceCapabilities struct {
+	class           string
+	canDrop         bool
+	canTruncate     bool
+	canRename       bool
+	canAlter        bool
+	canChangeEngine bool
+}
+
+type maintenanceOperation string
+
+const (
+	maintenanceDrop         maintenanceOperation = "drop"
+	maintenanceTruncate     maintenanceOperation = "truncate"
+	maintenanceRename       maintenanceOperation = "rename"
+	maintenanceAlter        maintenanceOperation = "alter"
+	maintenanceChangeEngine maintenanceOperation = "change engine"
+)
+
+func unrestrictedMaintenanceCapabilities() maintenanceCapabilities {
+	return maintenanceCapabilities{
+		class:           "user",
+		canDrop:         true,
+		canTruncate:     true,
+		canRename:       true,
+		canAlter:        true,
+		canChangeEngine: true,
+	}
+}
+
+func databaseMaintenanceCapabilities(schema string) maintenanceCapabilities {
+	switch strings.ToLower(schema) {
+	case "system":
+		return maintenanceCapabilities{class: "system_catalog"}
+	case "system_statistic":
+		return maintenanceCapabilities{class: "telemetry"}
+	default:
+		return unrestrictedMaintenanceCapabilities()
+	}
+}
+
+func tableMaintenanceCapabilities(schema, name string) maintenanceCapabilities {
+	if strings.EqualFold(name, ".blobs") {
+		return maintenanceCapabilities{class: "engine_internal"}
+	}
+	switch strings.ToLower(schema) {
+	case "system":
+		return maintenanceCapabilities{class: "system_catalog"}
+	case "system_statistic":
+		return maintenanceCapabilities{class: "telemetry", canTruncate: true}
+	default:
+		return unrestrictedMaintenanceCapabilities()
+	}
+}
+
+func (capabilities maintenanceCapabilities) allows(operation maintenanceOperation) bool {
+	switch operation {
+	case maintenanceDrop:
+		return capabilities.canDrop
+	case maintenanceTruncate:
+		return capabilities.canTruncate
+	case maintenanceRename:
+		return capabilities.canRename
+	case maintenanceAlter:
+		return capabilities.canAlter
+	case maintenanceChangeEngine:
+		return capabilities.canChangeEngine
+	default:
+		return false
+	}
+}
+
+func maintenanceCapabilitiesScmer(capabilities maintenanceCapabilities) scm.Scmer {
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewString("Class"), scm.NewString(capabilities.class),
+		scm.NewString("CanDrop"), scm.NewBool(capabilities.canDrop),
+		scm.NewString("CanTruncate"), scm.NewBool(capabilities.canTruncate),
+		scm.NewString("CanRename"), scm.NewBool(capabilities.canRename),
+		scm.NewString("CanAlter"), scm.NewBool(capabilities.canAlter),
+		scm.NewString("CanChangeEngine"), scm.NewBool(capabilities.canChangeEngine),
+	})
+}
+
+func requireDatabaseMaintenance(schema string, operation maintenanceOperation) {
+	if !databaseMaintenanceCapabilities(schema).allows(operation) {
+		panic("Database " + schema + " is required by MemCP and does not allow " + string(operation))
+	}
+}
+
+func requireTableMaintenance(schema, name string, operation maintenanceOperation) {
+	if !tableMaintenanceCapabilities(schema, name).allows(operation) {
+		panic("Table " + schema + "." + name + " is required by MemCP and does not allow " + string(operation))
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1553,6 +1553,40 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "checktablemaintenance",
+		Desc: "checks whether a user-initiated maintenance operation is allowed for a table",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			operation := maintenanceOperation(scm.String(a[2]))
+			requireTableMaintenance(scm.String(a[0]), scm.String(a[1]), operation)
+			return scm.NewBool(true)
+		},
+		Type: &scm.TypeDescriptor{HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", ParamName: "schema"},
+				{Kind: "string", ParamName: "table"},
+				{Kind: "string", ParamName: "operation"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "maintenance_capabilities",
+		Desc: "returns the server-side maintenance capabilities for a database or table",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if len(a) > 1 {
+				return maintenanceCapabilitiesScmer(tableMaintenanceCapabilities(scm.String(a[0]), scm.String(a[1])))
+			}
+			return maintenanceCapabilitiesScmer(databaseMaintenanceCapabilities(scm.String(a[0])))
+		},
+		Type: &scm.TypeDescriptor{
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", ParamName: "schema"},
+				{Kind: "string", ParamName: "table", Optional: true},
+			},
+			Return: &scm.TypeDescriptor{Kind: "list"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "createtable",
 		Desc: "creates a table, runs its oninit option and registered after-create-table lifecycle triggers synchronously, and returns only after initialization completes; concurrent if-not-exists callers wait for that same completion",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
@@ -2072,8 +2106,9 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			db := t.schema
+			operation := scm.String(a[1])
 
-			switch scm.String(a[1]) {
+			switch operation {
 			case "drop":
 				return scm.NewBool(t.DropColumn(scm.String(a[2])))
 			case "drop_if_exists":
@@ -2084,6 +2119,7 @@ func Init(en scm.Env) {
 				if oldMode == newMode {
 					return scm.NewBool(true) // no-op
 				}
+				requireTableMaintenance(db.Name, t.Name, maintenanceChangeEngine)
 
 				t.mu.Lock()
 
@@ -2122,6 +2158,7 @@ func Init(en scm.Env) {
 			case "owner":
 				return scm.NewBool(false) // ignore
 			case "auto_increment":
+				requireTableMaintenance(db.Name, t.Name, maintenanceAlter)
 				next := uint64(scm.ToInt(a[2]))
 				if next > 0 {
 					t.mu.Lock()
@@ -2133,7 +2170,7 @@ func Init(en scm.Env) {
 				}
 				return scm.NewBool(true)
 			default:
-				panic("unimplemented alter table operation: " + scm.String(a[1]))
+				panic("unimplemented alter table operation: " + operation)
 			}
 		},
 		Type: &scm.TypeDescriptor{HasSideEffects: true,
@@ -2151,6 +2188,7 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			db := t.schema
+			requireTableMaintenance(db.Name, t.Name, maintenanceAlter)
 			for i, c := range t.Columns {
 				if c.Name == scm.String(a[1]) {
 					switch scm.String(a[2]) {
@@ -2219,6 +2257,21 @@ func Init(en scm.Env) {
 			Params: []*scm.TypeDescriptor{
 				{Kind: "table", ParamName: "table"},
 				{Kind: "string", ParamName: "column", ParamDesc: "name of the column to drop"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
+		Name: "migratedropcolumn",
+		Desc: "drops a legacy system column during startup migration",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			t := TableFromScmer(a[0])
+			return scm.NewBool(t.dropColumnForMigration(scm.String(a[1])))
+		},
+		Type: &scm.TypeDescriptor{HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "table", ParamName: "table"},
+				{Kind: "string", ParamName: "column", ParamDesc: "legacy column name"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -3340,6 +3393,9 @@ func Init(en scm.Env) {
 			sourceSQL := scm.String(a[3])
 			body, deferredPlan := unwrapDeferredTriggerBody(a[4])
 			visible := scm.ToBool(a[5])
+			if visible {
+				requireTableMaintenance(db.Name, t.Name, maintenanceAlter)
+			}
 
 			trigger := TriggerDescription{
 				Name:      name,
@@ -3966,6 +4022,7 @@ func plannerDistinctForColumns(t *table, columns []string) (float64, float64, st
 // multi-column planner statistics. All statistics are immutable snapshots.
 func showBuildMeta(db *database, t *table) scm.Scmer {
 	engine := showEngineStr(t)
+	maintenance := tableMaintenanceCapabilities(db.Name, t.Name)
 	t.mu.Lock()
 	nextAutoIncrement := t.Auto_increment + 1
 	t.mu.Unlock()
@@ -4057,6 +4114,12 @@ func showBuildMeta(db *database, t *table) scm.Scmer {
 		scm.NewString("Fanout"), scm.NewSlice(fanouts),
 		scm.NewString("MultiColumnDistinct"), scm.NewSlice(multiColumnDistinct),
 		scm.NewString("Partitions"), scm.NewSlice(partitions),
+		scm.NewString("MaintenanceClass"), scm.NewString(maintenance.class),
+		scm.NewString("CanDrop"), scm.NewBool(maintenance.canDrop),
+		scm.NewString("CanTruncate"), scm.NewBool(maintenance.canTruncate),
+		scm.NewString("CanRename"), scm.NewBool(maintenance.canRename),
+		scm.NewString("CanAlter"), scm.NewBool(maintenance.canAlter),
+		scm.NewString("CanChangeEngine"), scm.NewBool(maintenance.canChangeEngine),
 	})
 }
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -2039,6 +2039,13 @@ func (t *table) dropColumnDDLLocked(name string) bool {
 }
 
 func (t *table) DropColumn(name string) bool {
+	requireTableMaintenance(t.schema.Name, t.Name, maintenanceAlter)
+	t.ddlMu.Lock()
+	defer t.ddlMu.Unlock()
+	return t.dropColumnDDLLocked(name)
+}
+
+func (t *table) dropColumnForMigration(name string) bool {
 	t.ddlMu.Lock()
 	defer t.ddlMu.Unlock()
 	return t.dropColumnDDLLocked(name)

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -397,6 +397,22 @@ func (db *database) dropTrigger(name string) bool {
 			t.ddlMu.Unlock()
 			continue
 		}
+		if !tableMaintenanceCapabilities(db.Name, t.Name).canAlter {
+			t.mu.Lock()
+			found := false
+			for _, trigger := range t.Triggers {
+				if trigger.Name == name {
+					found = true
+					break
+				}
+			}
+			t.mu.Unlock()
+			if found {
+				db.schemalock.Unlock()
+				t.ddlMu.Unlock()
+				requireTableMaintenance(db.Name, t.Name, maintenanceAlter)
+			}
+		}
 		if t.RemoveTrigger(name) {
 			db.saveLockedAndUnlock(t.schemaSaveMode())
 			t.ddlMu.Unlock()

--- a/tests/sql/ddl/truncate.yaml
+++ b/tests/sql/ddl/truncate.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
 # TRUNCATE TABLE — alias for DELETE FROM without WHERE
 
 metadata:
@@ -8,6 +10,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS trunc_t"
   - sql: "CREATE TABLE trunc_t (id INT, val VARCHAR(50))"
   - sql: "INSERT INTO trunc_t (id, val) VALUES (1, 'a'), (2, 'b'), (3, 'c')"
+  - sql: "DELETE FROM system.access WHERE username = 'maintenance-guard-marker'"
+  - sql: "INSERT INTO system.access (username, database) VALUES ('maintenance-guard-marker', 'system_statistic')"
 
 test_cases:
   - name: "Rows exist before truncate"
@@ -46,5 +50,74 @@ test_cases:
       data:
         - c: 0
 
+  - name: "System tables cannot be dropped"
+    sql: "DROP TABLE system.user"
+    expect: { error: true }
+
+  - name: "Statistic tables cannot be dropped"
+    sql: "DROP TABLE system_statistic.logs"
+    expect: { error: true }
+
+  - name: "System database cannot be dropped"
+    sql: "DROP DATABASE system"
+    expect: { error: true }
+
+  - name: "Statistic database cannot be dropped"
+    sql: "DROP DATABASE system_statistic"
+    expect: { error: true }
+
+  - name: "Refused database drop leaves access catalog untouched"
+    sql: "SELECT COUNT(*) AS c FROM system.access WHERE username = 'maintenance-guard-marker' AND database = 'system_statistic'"
+    expect:
+      rows: 1
+      data:
+        - c: 1
+
+  - name: "System catalog cannot be truncated"
+    sql: "TRUNCATE TABLE system.`user`"
+    expect: { error: true }
+
+  - name: "System catalog columns cannot be dropped"
+    sql: "ALTER TABLE system.`user` DROP COLUMN admin"
+    expect: { error: true }
+
+  - name: "System catalog engine cannot be changed"
+    sql: "ALTER TABLE system.`user` ENGINE=MEMORY"
+    expect: { error: true }
+
+  - name: "Recovery root user cannot be dropped"
+    sql: "DROP USER root"
+    expect: { error: true }
+
+  - name: "Recovery root administrator privilege cannot be revoked"
+    sql: "REVOKE ALL ON *.* FROM root"
+    expect: { error: true }
+
+  - name: "PostgreSQL recovery root administrator privilege cannot be removed"
+    syntax: postgresql
+    sql: "ALTER USER root NOSUPERUSER"
+    expect: { error: true }
+
+  - name: "Recovery root remains an administrator"
+    sql: "SELECT admin FROM system.`user` WHERE username = 'root'"
+    expect:
+      rows: 1
+      data:
+        - admin: true
+
+  - name: "Log tables can still be truncated"
+    setup:
+      - sql: "INSERT INTO system_statistic.logs (datetime, message) VALUES ('maintenance-test', 'truncate remains allowed')"
+    sql: "TRUNCATE TABLE system_statistic.logs"
+    expect: {}
+
+  - name: "Log table is empty after truncate"
+    sql: "SELECT COUNT(*) AS c FROM system_statistic.logs"
+    expect:
+      rows: 1
+      data:
+        - c: 0
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS trunc_t"
+  - sql: "DELETE FROM system.access WHERE username = 'maintenance-guard-marker'"


### PR DESCRIPTION
## Summary
- centralize database/table maintenance capabilities in the Go storage layer
- reject DROP, rename, destructive ALTER, engine changes, and user trigger changes for MemCP system catalogs and engine-internal blob tables
- keep TRUNCATE available for `system_statistic` telemetry tables while hiding destructive controls for both protected schemas in database/table lists
- expose server capabilities to the dashboard and protect the recovery root account from removal or admin revocation
- perform database catalog cleanup only after the physical database drop succeeds
- retain an explicit internal-only escape hatch for the legacy `system.user.id` startup migration

## Verification
- targeted Go storage protection tests pass
- `tests/sql/ddl/truncate.yaml`: 20/20
- `tests/sql/security/grant-revoke.yaml`: 64/64
- `tests/sql/ddl/rename-table.yaml`: 10/10
- Scheme formatting/checks for every touched `lib/` file
- dashboard JavaScript syntax check
- full hook-equivalent suite completed functionally; the host-only run hit the pre-existing timing-sensitive `traced-planner-scaling` threshold under high concurrent system load, while that suite passed 3/3 isolated reruns
