### PR TITLE
Prepare computed delta rows without shard rebuilds

### DIFF
--- a/storage/compute.go
+++ b/storage/compute.go
@@ -121,8 +121,8 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 			done := make(chan error, 6)
 			shardlist := t.ActiveShards()
 			currentTx := CurrentTx()
-			for i, s := range shardlist {
-				gls.Go(func(i int, s *storageShard) func() {
+			for _, s := range shardlist {
+				gls.Go(func(s *storageShard) func() {
 					return func() {
 						defer func() {
 							if r := recover(); r != nil {
@@ -130,16 +130,10 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 								done <- scanError{r, string(debug.Stack())}
 							}
 						}()
-						for !s.ComputeColumn(name, inputCols, computor, filterCols, filter, len(shardlist) == 1, currentTx) {
-							// couldn't compute column because delta is still active
-							t.mu.Lock()
-							s = s.rebuild(false)
-							shardlist[i] = s
-							t.mu.Unlock()
-						}
+						s.ComputeColumn(name, inputCols, computor, filterCols, filter, currentTx)
 						done <- nil
 					}
-				}(i, s))
+				}(s))
 			}
 			for range shardlist {
 				err := <-done // collect finish signal before return
@@ -183,28 +177,7 @@ func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scme
 	t.computeColumnDDLLocked(name, inputCols, computor, filterCols, filter)
 }
 
-// hasUnprotectedDelta reports whether compaction can make progress. Tombstones
-// retained solely for an active transaction are already part of main storage;
-// rebuilding them again cannot remove them until that transaction resolves.
-func (s *storageShard) hasUnprotectedDelta() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if len(s.inserts) > 0 {
-		return true
-	}
-	hasUnprotectedDeletion := false
-	s.deletions.Iterate(func(recid uint) {
-		if !s.rollbackProtected.Get(recid) {
-			hasUnprotectedDeletion = true
-		}
-	})
-	return hasUnprotectedDeletion
-}
-
-func (s *storageShard) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer, parallel bool, tx *TxContext) bool {
-	if s.hasUnprotectedDelta() {
-		return false // can't compute in shards with delta storage
-	}
+func (s *storageShard) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer, tx *TxContext) {
 	// Ensure shard is loaded from disk before we mark it WRITE (ensureLoaded
 	// guards on COLD state; setting WRITE first would skip the load entirely).
 	s.ensureLoaded()
@@ -240,18 +213,18 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 					proxy.Compress()
 				}
 			})
-			return true
+			return
 		}
 		// skip recompute if proxy is still valid (no invalidation since last compute)
-		if proxy.compressed && len(proxy.delta) == 0 {
+		if !proxy.needsUnfilteredPreparation() {
 			if filter.IsNil() {
-				return true // fully compressed, nothing to do
+				return // fully prepared, nothing to do
 			}
 			// filter given: ensure filtered rows are valid (CompressFiltered is idempotent)
 			runWithTxSession(tx, func() {
 				proxy.CompressFiltered(filterCols, filter)
 			})
-			return true
+			return
 		}
 		runWithTxSession(tx, func() {
 			if !filter.IsNil() {
@@ -260,7 +233,7 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 				proxy.Compress()
 			}
 		})
-		return true
+		return
 	}
 
 	// Publish the definition before preparing values. Readers may immediately use
@@ -289,7 +262,6 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 			proxy.Compress() // eagerly compute + compress all values (same behavior as before)
 		}
 	})
-	return true
 }
 
 // ComputeOrderedColumn materializes an ordered-reduce computed (ORC) column.

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -127,8 +127,9 @@ type StorageComputeProxy struct {
 	// Invalidation telemetry: tracks cumulative cost of selective invalidations
 	// since last read. When invalidation cost exceeds last recompute cost,
 	// switches to InvalidateAll() to avoid death-by-a-thousand-cuts.
-	invalidateNsSinceRead atomic.Int64 // cumulative invalidation nanoseconds since last read
-	lastRecomputeNs       atomic.Int64 // nanoseconds of the last full/suffix recompute
+	invalidateNsSinceRead atomic.Int64  // cumulative invalidation nanoseconds since last read
+	lastRecomputeNs       atomic.Int64  // nanoseconds of the last full/suffix recompute
+	revision              atomic.Uint64 // logical value changes; index readers use this for lazy invalidation
 	sessionKeys           []string
 	variants              map[string]*storageComputeVariant
 	variantsMu            sync.RWMutex
@@ -459,69 +460,198 @@ func (p *StorageComputeProxy) forEachVariant(fn func(*storageComputeVariant)) {
 	}
 }
 
-func (p *StorageComputeProxy) compressVariant(v *storageComputeVariant, tx *TxContext) {
+func (p *StorageComputeProxy) visibleDeltaRecids() []uint32 {
+	p.shard.mu.RLock()
+	recids := make([]uint32, 0, len(p.shard.inserts))
+	for recid := p.shard.main_count; recid < p.shard.main_count+uint32(len(p.shard.inserts)); recid++ {
+		if !p.shard.deletions.Get(uint(recid)) {
+			recids = append(recids, recid)
+		}
+	}
+	p.shard.mu.RUnlock()
+	return recids
+}
+
+func (p *StorageComputeProxy) needsUnfilteredPreparation() bool {
+	recids := p.visibleDeltaRecids()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.compressed {
+		return true
+	}
+	for _, recid := range recids {
+		if _, present := p.delta[recid]; !present {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *StorageComputeProxy) prewarmDeltaRows(tx *TxContext, filterCols []string, filter scm.Scmer, onlyMissing bool) {
+	filterReaders := make([]ColumnReader, len(filterCols))
+	for i, col := range filterCols {
+		filterReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+	}
+	inputReaders := make([]ColumnReader, len(p.inputCols))
+	for i, col := range p.inputCols {
+		inputReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+	}
+
+	recids := p.visibleDeltaRecids()
+	if onlyMissing {
+		p.mu.RLock()
+		missing := recids[:0]
+		for _, recid := range recids {
+			if _, present := p.delta[recid]; !present {
+				missing = append(missing, recid)
+			}
+		}
+		p.mu.RUnlock()
+		recids = missing
+	}
+	prepared := make(map[uint32]scm.Scmer)
+	filterValues := make([]scm.Scmer, len(filterReaders))
+	inputValues := make([]scm.Scmer, len(inputReaders))
+	for _, recid := range recids {
+		if !filter.IsNil() {
+			for i, reader := range filterReaders {
+				filterValues[i] = reader.GetValue(recid)
+			}
+			if !scm.ToBool(applyWithTx(tx, filter, filterValues...)) {
+				continue
+			}
+		}
+		for i, reader := range inputReaders {
+			inputValues[i] = reader.GetValue(recid)
+		}
+		prepared[recid] = applyWithTx(tx, p.computor, inputValues...)
+	}
+	p.mu.Lock()
+	for recid, value := range prepared {
+		if onlyMissing {
+			if _, present := p.delta[recid]; present {
+				continue
+			}
+		}
+		p.delta[recid] = value
+		p.validMask.Set(uint(recid), true)
+	}
+	p.mu.Unlock()
+}
+
+func (p *StorageComputeProxy) prewarmVariantDeltaRows(v *storageComputeVariant, tx *TxContext, filterCols []string, filter scm.Scmer, onlyMissing bool) {
+	filterReaders := make([]ColumnReader, len(filterCols))
+	for i, col := range filterCols {
+		filterReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+	}
+	inputReaders := make([]ColumnReader, len(p.inputCols))
+	for i, col := range p.inputCols {
+		inputReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
+	}
+
+	recids := p.visibleDeltaRecids()
+	if onlyMissing {
+		v.mu.RLock()
+		missing := recids[:0]
+		for _, recid := range recids {
+			if _, present := v.delta[recid]; !present {
+				missing = append(missing, recid)
+			}
+		}
+		v.mu.RUnlock()
+		recids = missing
+	}
+	prepared := make(map[uint32]scm.Scmer)
+	filterValues := make([]scm.Scmer, len(filterReaders))
+	inputValues := make([]scm.Scmer, len(inputReaders))
+	for _, recid := range recids {
+		if !filter.IsNil() {
+			for i, reader := range filterReaders {
+				filterValues[i] = reader.GetValue(recid)
+			}
+			if !scm.ToBool(applyWithTx(tx, filter, filterValues...)) {
+				continue
+			}
+		}
+		for i, reader := range inputReaders {
+			inputValues[i] = reader.GetValue(recid)
+		}
+		prepared[recid] = applyWithTx(tx, p.computor, inputValues...)
+	}
 	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	if v.compressed && len(v.delta) == 0 {
-		return
+	for recid, value := range prepared {
+		if onlyMissing {
+			if _, present := v.delta[recid]; present {
+				continue
+			}
+		}
+		v.delta[recid] = value
+		v.validMask.Set(uint(recid), true)
 	}
-	if v.count == 0 {
-		v.compressed = true
-		return
-	}
+	v.mu.Unlock()
+}
 
+func (p *StorageComputeProxy) compressVariant(v *storageComputeVariant, tx *TxContext) {
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
 		readers[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
 	}
+	func() {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		if v.compressed {
+			return
+		}
+		if v.count == 0 {
+			v.compressed = true
+			return
+		}
 
-	colvalues := make([]scm.Scmer, len(p.inputCols))
-	getValue := func(idx uint32) scm.Scmer {
-		if val, ok := v.delta[idx]; ok {
-			return val
+		colvalues := make([]scm.Scmer, len(p.inputCols))
+		getValue := func(idx uint32) scm.Scmer {
+			if val, ok := v.delta[idx]; ok {
+				return val
+			}
+			if v.main != nil && v.validMask.Get(uint(idx)) {
+				return v.main.GetValue(idx)
+			}
+			for j := range readers {
+				colvalues[j] = readers[j].GetValue(idx)
+			}
+			return applyWithTx(tx, p.computor, colvalues...)
 		}
-		if v.main != nil && v.validMask.Get(uint(idx)) {
-			return v.main.GetValue(idx)
-		}
-		for j := range readers {
-			colvalues[j] = readers[j].GetValue(idx)
-		}
-		return applyWithTx(tx, p.computor, colvalues...)
-	}
 
-	var newcol ColumnStorage = new(StorageSCMER)
-	for {
-		newcol.prepare()
+		var newcol ColumnStorage = new(StorageSCMER)
+		for {
+			newcol.prepare()
+			for i := uint32(0); i < v.count; i++ {
+				newcol.scan(i, getValue(i))
+			}
+			proposed := newcol.proposeCompression(v.count)
+			if proposed == nil {
+				break
+			}
+			newcol = proposed
+		}
+		newcol.init(v.count)
 		for i := uint32(0); i < v.count; i++ {
-			newcol.scan(i, getValue(i))
+			newcol.build(i, getValue(i))
 		}
-		proposed := newcol.proposeCompression(v.count)
-		if proposed == nil {
-			break
-		}
-		newcol = proposed
-	}
-	newcol.init(v.count)
-	for i := uint32(0); i < v.count; i++ {
-		newcol.build(i, getValue(i))
-	}
-	newcol.finish()
+		newcol.finish()
 
-	v.main = newcol
-	v.delta = make(map[uint32]scm.Scmer)
-	v.validMask.Reset()
-	v.compressed = true
+		v.main = newcol
+		for recid := range v.delta {
+			if recid < v.count {
+				delete(v.delta, recid)
+			}
+		}
+		v.validMask.Reset()
+		v.compressed = true
+	}()
+	p.prewarmVariantDeltaRows(v, tx, nil, scm.NewNil(), true)
 }
 
 func (p *StorageComputeProxy) compressFilteredVariant(v *storageComputeVariant, tx *TxContext, filterCols []string, filter scm.Scmer) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	if v.count == 0 {
-		return
-	}
-
 	filterFn := scm.OptimizeProcToSerialFunction(filter)
 	filterReaders := make([]ColumnReader, len(filterCols))
 	for i, col := range filterCols {
@@ -532,20 +662,25 @@ func (p *StorageComputeProxy) compressFilteredVariant(v *storageComputeVariant, 
 		readers[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
 	}
 
-	filterValues := make([]scm.Scmer, len(filterCols))
-	colvalues := make([]scm.Scmer, len(p.inputCols))
-	for i := uint32(0); i < v.count; i++ {
-		for j := range filterReaders {
-			filterValues[j] = filterReaders[j].GetValue(i)
-		}
-		if scm.ToBool(filterFn(filterValues...)) {
-			for j := range readers {
-				colvalues[j] = readers[j].GetValue(i)
+	func() {
+		v.mu.Lock()
+		defer v.mu.Unlock()
+		filterValues := make([]scm.Scmer, len(filterCols))
+		colvalues := make([]scm.Scmer, len(p.inputCols))
+		for i := uint32(0); i < v.count; i++ {
+			for j := range filterReaders {
+				filterValues[j] = filterReaders[j].GetValue(i)
 			}
-			v.delta[i] = applyWithTx(tx, p.computor, colvalues...)
-			v.validMask.Set(uint(i), true)
+			if scm.ToBool(filterFn(filterValues...)) {
+				for j := range readers {
+					colvalues[j] = readers[j].GetValue(i)
+				}
+				v.delta[i] = applyWithTx(tx, p.computor, colvalues...)
+				v.validMask.Set(uint(i), true)
+			}
 		}
-	}
+	}()
+	p.prewarmVariantDeltaRows(v, tx, filterCols, filter, false)
 }
 
 // orcCol returns the column definition for this ORC proxy's column.
@@ -654,6 +789,89 @@ func (p *StorageComputeProxy) GetValue(idx uint32) scm.Scmer {
 	return val
 }
 
+// getValueRLocked evaluates an ordinary computed column while the caller owns
+// the shard read lock. It must not re-enter shard.mu: Go's writer-preferring
+// RWMutex would deadlock if a writer queued between the two read acquisitions.
+func (p *StorageComputeProxy) getValueRLocked(tx *TxContext, idx uint32) scm.Scmer {
+	if variant := p.currentVariant(tx, true); variant != nil {
+		variant.mu.RLock()
+		if value, present := variant.delta[idx]; present {
+			variant.mu.RUnlock()
+			return value
+		}
+		main := variant.main
+		count := variant.count
+		compressed := variant.compressed
+		variant.mu.RUnlock()
+		if idx < count && main != nil && (compressed || variant.validMask.Get(uint(idx))) {
+			return main.GetValue(idx)
+		}
+
+		values := make([]scm.Scmer, len(p.inputCols))
+		for i, col := range p.inputCols {
+			cs := p.shard.getColumnStorageRLocked(col)
+			if dependency, ok := cs.(*StorageComputeProxy); ok && !dependency.isOrdered {
+				values[i] = dependency.getValueRLocked(tx, idx)
+				continue
+			}
+			if idx < p.shard.main_count {
+				values[i] = newCachedColumnReaderTx(cs, tx).GetValue(idx)
+				continue
+			}
+			deltaIndex := int(idx - p.shard.main_count)
+			if columnIndex, ok := p.shard.deltaColumns[col]; ok && deltaIndex < len(p.shard.inserts) && columnIndex < len(p.shard.inserts[deltaIndex]) {
+				values[i] = p.shard.inserts[deltaIndex][columnIndex]
+			} else {
+				values[i] = scm.NewNil()
+			}
+		}
+		value := applyWithTx(tx, p.computor, values...)
+		variant.mu.Lock()
+		variant.delta[idx] = value
+		variant.mu.Unlock()
+		variant.validMask.Set(uint(idx), true)
+		return value
+	}
+
+	p.mu.RLock()
+	if value, present := p.delta[idx]; present {
+		p.mu.RUnlock()
+		return value
+	}
+	main := p.main
+	count := p.count
+	compressed := p.compressed
+	p.mu.RUnlock()
+	if idx < count && main != nil && (compressed || p.validMask.Get(uint(idx))) {
+		return main.GetValue(idx)
+	}
+
+	values := make([]scm.Scmer, len(p.inputCols))
+	for i, col := range p.inputCols {
+		cs := p.shard.getColumnStorageRLocked(col)
+		if dependency, ok := cs.(*StorageComputeProxy); ok && !dependency.isOrdered {
+			values[i] = dependency.getValueRLocked(tx, idx)
+			continue
+		}
+		if idx < p.shard.main_count {
+			values[i] = newCachedColumnReaderTx(cs, tx).GetValue(idx)
+			continue
+		}
+		deltaIndex := int(idx - p.shard.main_count)
+		if columnIndex, ok := p.shard.deltaColumns[col]; ok && deltaIndex < len(p.shard.inserts) && columnIndex < len(p.shard.inserts[deltaIndex]) {
+			values[i] = p.shard.inserts[deltaIndex][columnIndex]
+		} else {
+			values[i] = scm.NewNil()
+		}
+	}
+	value := applyWithTx(tx, p.computor, values...)
+	p.mu.Lock()
+	p.delta[idx] = value
+	p.mu.Unlock()
+	p.validMask.Set(uint(idx), true)
+	return value
+}
+
 // GetValueRange and GetValueMulti take the fast path — one bulk call
 // straight into p.main — only when every requested row is guaranteed to
 // come from main with no repair work: not an ORC column, no pending delta
@@ -729,63 +947,63 @@ func (p *StorageComputeProxy) Compress() {
 		p.compressVariant(variant, tx)
 		return
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	// Early exit if already compressed and no dirty delta
-	if p.compressed && len(p.delta) == 0 {
-		return
-	}
-
-	// Empty shard: nothing to compute, avoid accessing input column storages
-	if p.count == 0 {
-		p.compressed = true
-		return
-	}
-
 	readers := make([]ColumnReader, len(p.inputCols))
 	for i, col := range p.inputCols {
 		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col), tx)
 	}
+	func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.compressed {
+			return
+		}
+		if p.count == 0 {
+			p.compressed = true
+			return
+		}
 
-	colvalues := make([]scm.Scmer, len(p.inputCols))
-	getValue := func(idx uint32) scm.Scmer {
-		if val, ok := p.delta[idx]; ok {
-			return val
+		colvalues := make([]scm.Scmer, len(p.inputCols))
+		getValue := func(idx uint32) scm.Scmer {
+			if val, ok := p.delta[idx]; ok {
+				return val
+			}
+			if p.main != nil && p.validMask.Get(uint(idx)) {
+				return p.main.GetValue(idx)
+			}
+			for j := range readers {
+				colvalues[j] = readers[j].GetValue(idx)
+			}
+			return applyWithTx(tx, p.computor, colvalues...)
 		}
-		if p.main != nil && p.validMask.Get(uint(idx)) {
-			return p.main.GetValue(idx)
-		}
-		// compute
-		for j := range readers {
-			colvalues[j] = readers[j].GetValue(idx)
-		}
-		return applyWithTx(tx, p.computor, colvalues...)
-	}
 
-	// Standard proposeCompression loop (same as shard rebuild)
-	var newcol ColumnStorage = new(StorageSCMER)
-	for {
-		newcol.prepare()
+		var newcol ColumnStorage = new(StorageSCMER)
+		for {
+			newcol.prepare()
+			for i := uint32(0); i < p.count; i++ {
+				newcol.scan(i, getValue(i))
+			}
+			proposed := newcol.proposeCompression(p.count)
+			if proposed == nil {
+				break
+			}
+			newcol = proposed
+		}
+		newcol.init(p.count)
 		for i := uint32(0); i < p.count; i++ {
-			newcol.scan(i, getValue(i))
+			newcol.build(i, getValue(i))
 		}
-		proposed := newcol.proposeCompression(p.count)
-		if proposed == nil {
-			break
-		}
-		newcol = proposed
-	}
-	newcol.init(p.count)
-	for i := uint32(0); i < p.count; i++ {
-		newcol.build(i, getValue(i))
-	}
-	newcol.finish()
+		newcol.finish()
 
-	p.main = newcol
-	p.delta = make(map[uint32]scm.Scmer)
-	p.validMask.Reset()
-	p.compressed = true
+		p.main = newcol
+		for recid := range p.delta {
+			if recid < p.count {
+				delete(p.delta, recid)
+			}
+		}
+		p.validMask.Reset()
+		p.compressed = true
+	}()
+	p.prewarmDeltaRows(tx, nil, scm.NewNil(), true)
 }
 
 // CompressFiltered prewarms an ordinary computed column only for rows matching
@@ -800,14 +1018,6 @@ func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.S
 		p.compressFilteredVariant(variant, tx, filterCols, filter)
 		return
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	// Empty shard: nothing to compute
-	if p.count == 0 {
-		return
-	}
-
 	filterReaders := make([]ColumnReader, len(filterCols))
 	for i, col := range filterCols {
 		filterReaders[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col), tx)
@@ -817,31 +1027,42 @@ func (p *StorageComputeProxy) CompressFiltered(filterCols []string, filter scm.S
 		readers[i] = newCachedColumnReaderTx(p.shard.getColumnStorageOrPanic(col), tx)
 	}
 
-	filterValues := make([]scm.Scmer, len(filterCols))
-	colvalues := make([]scm.Scmer, len(p.inputCols))
-	for i := uint32(0); i < p.count; i++ {
-		for j := range filterReaders {
-			filterValues[j] = filterReaders[j].GetValue(i)
-		}
-		if scm.ToBool(applyWithTx(tx, filter, filterValues...)) {
-			for j := range readers {
-				colvalues[j] = readers[j].GetValue(i)
+	func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		filterValues := make([]scm.Scmer, len(filterCols))
+		colvalues := make([]scm.Scmer, len(p.inputCols))
+		for i := uint32(0); i < p.count; i++ {
+			for j := range filterReaders {
+				filterValues[j] = filterReaders[j].GetValue(i)
 			}
-			p.delta[i] = applyWithTx(tx, p.computor, colvalues...)
-			p.validMask.Set(uint(i), true)
+			if scm.ToBool(applyWithTx(tx, filter, filterValues...)) {
+				for j := range readers {
+					colvalues[j] = readers[j].GetValue(i)
+				}
+				p.delta[i] = applyWithTx(tx, p.computor, colvalues...)
+				p.validMask.Set(uint(i), true)
+			}
 		}
-	}
+	}()
+	p.prewarmDeltaRows(tx, filterCols, filter, false)
 	// Don't set compressed=true → unmatched rows stay lazy for on-demand GetValue
 }
 
 // Invalidate marks a single row as needing recomputation.
 func (p *StorageComputeProxy) Invalidate(idx uint32) {
+	p.revision.Add(1)
 	if p.hasSessionVariants() {
 		p.forEachVariant(func(v *storageComputeVariant) {
 			v.mu.Lock()
 			defer v.mu.Unlock()
 			if v.compressed {
 				if scmer, ok := v.main.(*StorageSCMER); ok {
+					if idx >= v.count {
+						v.validMask.Set(uint(idx), false)
+						delete(v.delta, idx)
+						return
+					}
 					colvalues := make([]scm.Scmer, len(p.inputCols))
 					for i, col := range p.inputCols {
 						colvalues[i] = p.shard.ColumnReaderTx(CurrentTx(), col)(idx)
@@ -862,6 +1083,11 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 	// Try in-place update if main supports SetValue (StorageSCMER)
 	if p.compressed {
 		if scmer, ok := p.main.(*StorageSCMER); ok {
+			if idx >= p.count {
+				p.validMask.Set(uint(idx), false)
+				delete(p.delta, idx)
+				return
+			}
 			// recompute single value and write directly
 			colvalues := make([]scm.Scmer, len(p.inputCols))
 			for i, col := range p.inputCols {
@@ -883,6 +1109,7 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 // state instead of silently dropping the update. This keeps FK-reuse and other
 // incremental aggregate caches correct across empty<->non-empty transitions.
 func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
+	p.revision.Add(1)
 	if p.hasSessionVariants() {
 		p.forEachVariant(func(v *storageComputeVariant) {
 			v.mu.Lock()
@@ -894,9 +1121,10 @@ func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
 			var oldVal scm.Scmer
 			if val, ok := v.delta[idx]; ok {
 				oldVal = val
-			} else if v.main != nil {
+			} else if idx < v.count && v.main != nil {
 				oldVal = v.main.GetValue(idx)
 			} else {
+				v.validMask.Set(uint(idx), false)
 				v.mu.Unlock()
 				return
 			}
@@ -931,9 +1159,14 @@ func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
 	var oldVal scm.Scmer
 	if v, ok := p.delta[idx]; ok {
 		oldVal = v
-	} else if p.main != nil {
+	} else if idx < p.count && p.main != nil {
 		oldVal = p.main.GetValue(idx)
 	} else {
+		p.mu.Unlock()
+		// The row was appended after main storage was compressed. Its source
+		// state already contains this trigger update, so materialize that state
+		// once instead of applying delta a second time.
+		p.GetValue(idx)
 		return
 	}
 	// Add oldVal + delta using Go arithmetic (avoids Scheme runtime overhead)
@@ -962,12 +1195,13 @@ func (p *StorageComputeProxy) IncrementalUpdate(idx uint32, delta scm.Scmer) {
 // If the shard is compressed and main is a StorageSCMER, the value is written in-place.
 // Otherwise the value is written to the delta map.
 func (p *StorageComputeProxy) SetValue(idx uint32, val scm.Scmer) {
+	p.revision.Add(1)
 	if p.hasSessionVariants() {
 		p.forEachVariant(func(v *storageComputeVariant) {
 			v.mu.Lock()
 			defer v.mu.Unlock()
 			if v.compressed && v.main != nil {
-				if scmer, ok := v.main.(*StorageSCMER); ok {
+				if scmer, ok := v.main.(*StorageSCMER); ok && idx < v.count {
 					scmer.SetValue(idx, val)
 					return
 				}
@@ -984,7 +1218,7 @@ func (p *StorageComputeProxy) SetValue(idx uint32, val scm.Scmer) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.compressed && p.main != nil {
-		if scmer, ok := p.main.(*StorageSCMER); ok {
+		if scmer, ok := p.main.(*StorageSCMER); ok && idx < p.count {
 			scmer.SetValue(idx, val)
 			return
 		}
@@ -1001,6 +1235,7 @@ func (p *StorageComputeProxy) SetValue(idx uint32, val scm.Scmer) {
 
 // InvalidateAll marks all rows as needing recomputation (resets validMask).
 func (p *StorageComputeProxy) InvalidateAll() {
+	p.revision.Add(1)
 	if p.hasSessionVariants() {
 		p.forEachVariant(func(v *storageComputeVariant) {
 			v.mu.Lock()

--- a/storage/index.go
+++ b/storage/index.go
@@ -35,15 +35,21 @@ type indexPair struct {
 }
 
 type storageIndexState struct {
-	mainIndexes      StorageInt
-	deltaBtree       *btree.BTreeG[indexPair]
-	active           bool
-	savings          float64
-	minVals          []scm.Scmer
-	maxVals          []scm.Scmer
-	indexHooks       []IndexHook
-	indexHookBytes   atomic.Int64
-	precomputedDelta bool
+	mainIndexes       StorageInt
+	deltaBtree        *btree.BTreeG[indexPair]
+	active            bool
+	savings           float64
+	minVals           []scm.Scmer
+	maxVals           []scm.Scmer
+	indexHooks        []IndexHook
+	indexHookBytes    atomic.Int64
+	precomputedDelta  bool
+	computedRevisions []computedRevision
+}
+
+type computedRevision struct {
+	proxy    *StorageComputeProxy
+	revision uint64
 }
 
 // (no op) numeric helper removed; collations now use golang.org/x/text/collate for ordering
@@ -218,6 +224,49 @@ func (s *StorageIndex) buildGetters(tx *TxContext) ([]colGetter, []string) {
 	return getters, sessionKeys
 }
 
+// computedRevisionsRLocked snapshots the logical generations of computed
+// columns used as index keys. The caller already owns the shard read lock.
+func (s *StorageIndex) computedRevisionsRLocked() []computedRevision {
+	result := make([]computedRevision, 0)
+	add := func(col string) {
+		if isScanPseudoColName(col) {
+			return
+		}
+		proxy, ok := s.t.getColumnStorageRLocked(col).(*StorageComputeProxy)
+		if !ok {
+			return
+		}
+		for _, existing := range result {
+			if existing.proxy == proxy {
+				return
+			}
+		}
+		result = append(result, computedRevision{proxy: proxy, revision: proxy.revision.Load()})
+	}
+	for i, col := range s.Cols {
+		if len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil() {
+			for _, mapCol := range s.ColMapCols[i] {
+				add(mapCol)
+			}
+			continue
+		}
+		add(col)
+	}
+	return result
+}
+
+func sameComputedRevisions(a, b []computedRevision) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // matcherKindEqual checks if two matchers have the same kind for index deduplication.
 func matcherKindEqual(a, b IndexAnalyzer) bool {
 	return a.Kind() == b.Kind()
@@ -384,16 +433,8 @@ func (s *StorageIndex) getDeltaValue(data []scm.Scmer, col string) scm.Scmer {
 
 // getDeltaColValue returns the index-column value for a delta row at column index colIdx.
 // For computed columns it reads the source cols and applies the mapFn.
-func (s *StorageIndex) getDeltaColValue(data []scm.Scmer, colIdx int) scm.Scmer {
-	if len(s.ColMapFn) > colIdx && !s.ColMapFn[colIdx].IsNil() {
-		fn := scm.OptimizeProcToSerialFunction(s.ColMapFn[colIdx])
-		vals := make([]scm.Scmer, len(s.ColMapCols[colIdx]))
-		for i, mc := range s.ColMapCols[colIdx] {
-			vals[i] = s.getDeltaValue(data, mc)
-		}
-		return fn(vals...)
-	}
-	return s.getDeltaValue(data, s.Cols[colIdx])
+func (s *StorageIndex) getDeltaColValue(recid uint32, data []scm.Scmer, colIdx int) scm.Scmer {
+	return s.getDeltaColValueTx(nil, recid, data, colIdx)
 }
 
 func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []scm.Scmer, colIdx int) scm.Scmer {
@@ -405,17 +446,24 @@ func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []sc
 				vals[i] = scm.NewNil()
 				continue
 			}
-			cs := s.t.getColumnStorageOrPanic(mc)
-			if proxy, ok := cs.(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
-				vals[i] = s.t.ColumnReaderTx(tx, mc)(recid)
+			cs := s.t.getColumnStorageRLocked(mc)
+			if proxy, ok := cs.(*StorageComputeProxy); ok {
+				if !proxy.isOrdered {
+					vals[i] = proxy.getValueRLocked(tx, recid)
+				} else {
+					vals[i] = s.t.ColumnReaderTx(tx, mc)(recid)
+				}
 			} else {
 				vals[i] = s.getDeltaValue(data, mc)
 			}
 		}
 		return fn(vals...)
 	}
-	cs := s.t.getColumnStorageOrPanic(s.Cols[colIdx])
-	if proxy, ok := cs.(*StorageComputeProxy); ok && proxy.hasSessionVariants() {
+	cs := s.t.getColumnStorageRLocked(s.Cols[colIdx])
+	if proxy, ok := cs.(*StorageComputeProxy); ok {
+		if !proxy.isOrdered {
+			return proxy.getValueRLocked(tx, recid)
+		}
 		return s.t.ColumnReaderTx(tx, s.Cols[colIdx])(recid)
 	}
 	return s.getDeltaValue(data, s.Cols[colIdx])
@@ -476,7 +524,7 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 		mainVal := mainGetters[i].get(mainRecid)
 		deltaVal := delta.data[i]
 		if !state.precomputedDelta {
-			deltaVal = s.getDeltaColValue(delta.data, i)
+			deltaVal = s.getDeltaColValue(uint32(delta.itemid), delta.data, i)
 		}
 		if s.lessAt(i, mainVal, deltaVal) {
 			return -1
@@ -879,6 +927,7 @@ func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, callback func(
 // cols must contain value getters for each index column in order.
 // The caller must hold s.mu.Lock() or have exclusive access.
 func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx *TxContext) {
+	startRevisions := s.computedRevisionsRLocked()
 	if !s.Native {
 		// main storage: build sort-order index
 		tmp := make([]uint32, s.t.main_count)
@@ -1032,8 +1081,8 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 				av = a.data[colIdx]
 				bv = b.data[colIdx]
 			} else {
-				av = s.getDeltaColValue(a.data, colIdx)
-				bv = s.getDeltaColValue(b.data, colIdx)
+				av = s.getDeltaColValue(uint32(a.itemid), a.data, colIdx)
+				bv = s.getDeltaColValue(uint32(b.itemid), b.data, colIdx)
 			}
 			if s.lessAt(colIdx, av, bv) {
 				return true // less
@@ -1064,7 +1113,9 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		}
 	}
 
-	state.active = true // mark as ready
+	endRevisions := s.computedRevisionsRLocked()
+	state.computedRevisions = endRevisions
+	state.active = sameComputedRevisions(startRevisions, endRevisions)
 }
 
 // bindRowMatchers binds every non-ordering boundary once for this index run.
@@ -1167,11 +1218,18 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 	cols, sessionKeys := s.buildGetters(tx)
 	s.syncSessionKeys(sessionKeys)
 	state := s.stateForTx(tx, true)
+	currentRevisions := s.computedRevisionsRLocked()
+	s.mu.Lock()
+	if state.active && !sameComputedRevisions(state.computedRevisions, currentRevisions) {
+		state.active = false
+	}
+	stateActive := state.active
+	s.mu.Unlock()
 	// no collation-specific helpers in the current implementation
 
 	savingsThreshold := 2.0 // building an index costs 1x the time as traversing the list
 	savings := s.addSavings(state, usageWeight)
-	if !state.active {
+	if !stateActive {
 		// index is not built yet
 		if savings < savingsThreshold && !forceBuild {
 			// iterate over all items because we don't want to store the index
@@ -1382,7 +1440,7 @@ start_scan:
 				if state.precomputedDelta {
 					return p.data[i]
 				}
-				return s.getDeltaColValue(p.data, i)
+				return s.getDeltaColValue(recid, p.data, i)
 			})
 			if !inRange {
 				return !beyond

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1537,12 +1537,18 @@ func (t *storageShard) propagateDeleteToNext(next *storageShard, oldRecid uint32
 func (t *storageShard) ColumnReaderTx(tx *TxContext, col string) func(uint32) scm.Scmer {
 	cstorage := t.getColumnStorageOrPanic(col)
 	reader := newCachedColumnReaderTx(cstorage, tx)
+	_, computed := cstorage.(*StorageComputeProxy)
 	return func(idx uint32) scm.Scmer {
 		if idx < t.main_count {
 			return reader.GetValue(idx)
-		} else {
-			return t.getDelta(int(idx-t.main_count), col)
 		}
+		// A computed column has no physical delta slot. Keep the transaction-
+		// bound reader so session-sensitive variants use the same binding for
+		// main and delta rows.
+		if computed {
+			return reader.GetValue(idx)
+		}
+		return t.getDelta(int(idx-t.main_count), col)
 	}
 }
 

--- a/tests/storage/indexes/computed-delta-non-lazy-range.yaml
+++ b/tests/storage/indexes/computed-delta-non-lazy-range.yaml
@@ -1,0 +1,73 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Computed-column non-lazy ranges include active delta rows without rebuilding the shard"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS computed_delta_rows"
+  - sql: "CREATE TABLE computed_delta_rows (id INT PRIMARY KEY, amount INT) ENGINE=memory"
+  - sql: "INSERT INTO computed_delta_rows VALUES (1, 10), (2, 20), (3, 30)"
+
+test_cases:
+  - name: "Filtered non-lazy range evaluates matching delta rows"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "computed_delta_rows")
+        "filtered_amount" "INT" '() '("temp" true)
+        '("amount")
+        (lambda (amount) (* amount 10))
+        '("amount")
+        (lambda (amount) (> amount 10)))
+
+  - name: "Filtered computed delta values are immediately readable"
+    sql: "SELECT id, filtered_amount FROM computed_delta_rows WHERE amount > 10 ORDER BY id"
+    expect:
+      rows: 2
+      data:
+        - {id: 2, filtered_amount: 200}
+        - {id: 3, filtered_amount: 300}
+
+  - name: "Computed-column preparation preserves the delta generation"
+    scm: |
+      (begin
+        (define shard (show "memcp-tests" "computed_delta_rows" 0))
+        (if (equal? (get_assoc shard "delta") 3)
+          true
+          (error "computed-column preparation rebuilt active delta rows")))
+    expect:
+      data: [true]
+
+  - name: "Unfiltered non-lazy range evaluates every delta row"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "computed_delta_rows")
+        "amount_copy" "INT" '() '("temp" true)
+        '("amount")
+        (lambda (amount) amount))
+
+  - name: "Unfiltered computed delta values preserve their inputs"
+    sql: "SELECT id, amount_copy FROM computed_delta_rows ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - {id: 1, amount_copy: 10}
+        - {id: 2, amount_copy: 20}
+        - {id: 3, amount_copy: 30}
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS computed_delta_rows"


### PR DESCRIPTION
Computed-column non-lazy preparation previously rebuilt any shard with active delta rows. That made cache-table construction block on full compaction and also left computed delta index keys stale.\n\nThis change:\n- snapshots visible delta row IDs under a short shard read lock, then evaluates outside the shard lock\n- eagerly prepares only the requested non-lazy range while keeping other values lazy\n- preserves transaction/session-bound computed variants\n- lazily invalidates indexes when a computed key generation changes\n- adds a regression proving filtered and unfiltered delta preparation without compaction\n\nValidation:\n- new regression: 5/5\n- group-cache invalidation: 129/129\n- concurrent session-carrier publication: 30/30\n- full SQL suite: all functional suites passed; one existing timing-only LIKE speedup assertion failed under concurrent host load, while its isolated 86-case suite passed\n\nThe parallel application-level run progressed past the original synchronous rebuild path. Its remaining timeouts correlate with a separate compiler hotspot in very large repeated scalar-expression trees and are intentionally not folded into this storage fix.