### PR TITLE
Improve MySQL application SQL compatibility

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3953,6 +3953,20 @@ working on the original values. */
 			'()
 			(list (canonical_column_expr_for_alias default_alias expr))))))))
 
+/* MySQL permits ORDER BY expressions which are neither projected aggregates
+nor GROUP BY keys. Preserve the grouping cardinality by selecting one value
+per group instead of silently widening the group key. */
+(define group_order_items_for_alias (lambda (default_alias keys order_items)
+	(map (coalesceNil order_items '()) (lambda (item) (match item
+		'(expr dir) (begin
+			(define resolved (canonical_column_expr_for_alias default_alias expr))
+			(if (or (contains? keys resolved) (expr_has_aggregates? expr))
+				(list expr dir)
+				(list
+					(list (quote aggregate) resolved (scalar_once_reduce_first) nil)
+					dir)))
+		_ item)))))
+
 (define group_key_col_name (lambda (i)
 	(concat "k" i)))
 
@@ -4306,17 +4320,21 @@ self-joins of the same base table still describe two distinct row roles. */
 
 (define make_group_stage_for_block (lambda (block src)
 	(begin
-		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
-		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
-		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
-			(merge (list visible_ags having_ags))
-			(merge (list visible_ags having_ags (list aggregate_count_descriptor))))))
 		(define alias (source_alias src))
 		(define session_keys (query_expr_session_reads block))
 		(define explicit_keys (map (coalesceNil (qb_group block) '()) (lambda (expr)
 			(canonical_column_expr_for_alias alias expr))))
 		(define keys (merge (list explicit_keys (filter session_keys (lambda (expr)
 			(not (contains? explicit_keys expr)))))))
+		(define group_order (group_order_items_for_alias alias keys (qb_order block)))
+		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
+		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
+		(define order_ags (merge (map group_order (lambda (item) (match item
+			'(expr _dir) (extract_aggregates expr)
+			_ '())))))
+		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
+			(merge (list visible_ags having_ags order_ags))
+			(merge (list visible_ags having_ags order_ags (list aggregate_count_descriptor))))))
 		(make_group_stage
 			(concat "group:" (source_relation src) ":" (stable_structural_hash (list keys ags) false))
 			src
@@ -4325,7 +4343,7 @@ self-joins of the same base table still describe two distinct row roles. */
 			ags
 			(qb_having block)
 			(qb_fields block)
-			(qb_order block)
+			group_order
 			(qb_limit block)
 			(qb_offset block)
 			(list
@@ -4335,17 +4353,21 @@ self-joins of the same base table still describe two distinct row roles. */
 
 (define make_group_stage_for_query_block (lambda (block)
 	(begin
-		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
-		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
-		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
-			(merge (list visible_ags having_ags))
-			(merge (list visible_ags having_ags (list aggregate_count_descriptor))))))
 		(define alias (source_alias (car (qb_sources block))))
 		(define group_keys (map (coalesceNil (qb_group block) '()) (lambda (expr) (canonical_column_expr_for_alias alias expr))))
 		(define field_passthrough_keys (field_passthrough_keys_for_alias alias (qb_fields block)))
 		(define passthrough_keys (external_column_refs_for_alias alias (coalesceNil (qb_having block) true)))
 		(define session_keys (query_expr_session_reads block))
 		(define keys (merge_unique (list group_keys field_passthrough_keys passthrough_keys session_keys)))
+		(define group_order (group_order_items_for_alias alias keys (qb_order block)))
+		(define visible_ags (stage_aggregates_for_fields (qb_fields block)))
+		(define having_ags (extract_aggregates (coalesceNil (qb_having block) true)))
+		(define order_ags (merge (map group_order (lambda (item) (match item
+			'(expr _dir) (extract_aggregates expr)
+			_ '())))))
+		(define ags (dedupe_aggregates_by_col (if (empty_list? (qb_group block))
+			(merge (list visible_ags having_ags order_ags))
+			(merge (list visible_ags having_ags order_ags (list aggregate_count_descriptor))))))
 		(define input (make_query_block
 			(qb_schema block)
 			(qb_sources block)
@@ -4364,7 +4386,7 @@ self-joins of the same base table still describe two distinct row roles. */
 			ags
 			(qb_having block)
 			(qb_fields block)
-			(qb_order block)
+			group_order
 			(qb_limit block)
 			(qb_offset block)
 			(list

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2471,6 +2471,57 @@ probes remain recipes and still execute after root braking. */
 				(cons title (cons expr (expand_query_block_fields sources rest)))))
 		_ '())))
 
+/* SQL permits columns functionally dependent on a grouped primary key. Expand
+qualified stars before group lowering and carry the selected source columns as
+keys when that source's complete primary key is already grouped. Adding those
+columns cannot change group cardinality because the primary key is unique. */
+(define fields_request_star_for_source? (lambda (fields src)
+	(reduce (coalesceNil fields '()) (lambda (requested title_or_expr)
+		(if requested
+			true
+			(if (string? title_or_expr)
+				false
+				(and (star_expr? title_or_expr)
+					(begin
+						(define requested_alias (star_expr_alias title_or_expr))
+						(or (nil? requested_alias)
+							(equal? requested_alias (source_alias src)))))))) false)))
+
+(define source_primary_key_grouped? (lambda (block src)
+	(begin
+		(define primary_key (source_primary_key_columns src))
+		(define default_alias (source_alias (car (qb_sources block))))
+		(define grouped (map (coalesceNil (qb_group block) '()) (lambda (expr)
+			(canonical_column_expr_for_alias default_alias expr))))
+		(and (not (empty_list? primary_key))
+			(reduce primary_key (lambda (complete col)
+				(and complete (contains? grouped
+					(canonical_column_expr_for_alias default_alias
+						(list (quote get_column) (source_alias src) false col false))))) true)))))
+
+(define functional_dependency_star_group_keys (lambda (block)
+	(merge (map (qb_sources block) (lambda (src)
+		(if (and (fields_request_star_for_source? (qb_fields block) src)
+			(source_primary_key_grouped? block src))
+			(map (table_column_names (source_schema src) (source_relation src)) (lambda (col)
+				(list (quote get_column) (source_alias src) false col false)))
+			'()))))))
+
+(define expand_grouped_query_block (lambda (block)
+	(make_query_block
+		(qb_schema block)
+		(qb_sources block)
+		(expand_query_block_fields (qb_sources block) (qb_fields block))
+		(qb_where block)
+		(merge_unique (list (qb_group block) (functional_dependency_star_group_keys block)))
+		(qb_having block)
+		(qb_order block)
+		(qb_limit block)
+		(qb_offset block)
+		(qb_hidden block)
+		(qb_stages block)
+		(qb_facts block))))
+
 (define query_limit_active? (lambda (offset_value limit_value)
 	(or (and (not (nil? offset_value)) (not (equal? offset_value 0)))
 		(and (not (nil? limit_value)) (not (equal? limit_value -1))))))
@@ -3330,6 +3381,7 @@ dependent choices must pass through this function and retain their guard. */
 	(begin
 		(define src (car (qb_sources block)))
 		(define fields (expand_query_block_fields (qb_sources block) (qb_fields block)))
+		(define grouped_block (expand_grouped_query_block block))
 		(if (not (source_is_base_table? src))
 			(neumann_fail "build_queryplan" "single-source query-block lowering only supports base tables")
 			true)
@@ -3338,7 +3390,7 @@ dependent choices must pass through this function and retain their guard. */
 			true)
 		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
 			(begin
-				(define group_stage (make_group_stage_for_block block src))
+				(define group_stage (make_group_stage_for_block grouped_block src))
 				(if (direct_base_group_plan_preferred? group_stage)
 					(lower_direct_base_group_stage group_stage fields (qb_order block) (qb_offset block) (qb_limit block))
 					(lower_group_stage group_stage)))
@@ -5736,10 +5788,11 @@ physical decision and preserve its runtime recompile gate. */
 (define lower_multi_source_query_block (lambda (block)
 	(begin
 		(define fields (expand_query_block_fields (qb_sources block) (qb_fields block)))
+		(define grouped_block (expand_grouped_query_block block))
 		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
-			(if (physical_prejoin_supported? block)
-				(lower_query_block_through_prejoin block)
-				(lower_group_stage (make_group_stage_for_query_block block)))
+			(if (physical_prejoin_supported? grouped_block)
+				(lower_query_block_through_prejoin grouped_block)
+				(lower_group_stage (make_group_stage_for_query_block grouped_block)))
 			(begin
 				(define sources (qb_sources block))
 				(define first_alias (qassoc_get (qb_facts block) (quote default_alias) (source_alias (car sources))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -5863,6 +5863,114 @@ every title. */
 				nil)))
 		nil)))
 
+(define dml_target_source_for_spec (lambda (sources target_spec)
+	(match target_spec
+		'(target_alias target_schema target_tbl)
+		(reduce (coalesceNil sources '()) (lambda (found src)
+			(if (not (nil? found))
+				found
+				(if (and (equal?? (source_alias src) target_alias)
+					(and (equal? (source_schema src) target_schema)
+						(equal? (source_relation src) target_tbl)))
+					src
+					nil)))
+			nil)
+		_ nil)))
+
+(define dml_sum_exprs (lambda (exprs)
+	(match exprs
+		(cons expr rest) (if (empty_list? rest)
+			expr
+			(list (quote +) expr (dml_sum_exprs rest)))
+		_ 0)))
+
+(define multi_delete_target_scan_plan (lambda (target_src target_rows)
+	(begin
+		(define alias (source_alias target_src))
+		(define keycols (source_primary_key_columns target_src))
+		(if (empty_list? keycols)
+			(neumann_fail "build_queryplan" "multi-target DELETE requires a primary key on every target")
+			true)
+		(define keyparams (map keycols (lambda (col) (symbol (concat alias "." col)))))
+		(list (quote scan)
+			'(session "__memcp_tx")
+			(source_table_expr target_src)
+			(cons (quote list) keycols)
+			(list (quote lambda) keyparams
+				(list (quote has_assoc?) target_rows
+					(cons (quote list) keyparams)))
+			(quoted_runtime_list (list "$update"))
+			(list (quote lambda) (list (symbol "$update"))
+				(list (quote if) (list (symbol "$update")) 1 0))
+			(quote +)
+			0
+			nil
+			false))))
+
+(define lower_multi_target_delete_query_block (lambda (block target_specs)
+	(begin
+		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
+			(neumann_fail "build_queryplan" "DML over grouped query-block is not implemented yet")
+			true)
+		(if (query_limit_active? (qb_offset block) (qb_limit block))
+			(neumann_fail "build_queryplan" "multi-source DML with ORDER/LIMIT is not implemented yet")
+			true)
+		(define sources (qb_sources block))
+		(define scan_plan (query_block_join_plan block sources))
+		(define first_alias (source_alias (car sources)))
+		(define target_sources (map target_specs (lambda (target_spec)
+			(begin
+				(define target_src (dml_target_source_for_spec sources target_spec))
+				(if (nil? target_src)
+					(neumann_fail "build_queryplan" "multi-target DELETE relation mismatch")
+					target_src)))))
+		(define target_key_refs (map target_sources (lambda (target_src)
+			(map (source_primary_key_columns target_src) (lambda (col)
+				(list (quote get_column) (source_alias target_src) false col false))))))
+		(if (reduce target_key_refs (lambda (valid refs) (and valid (not (empty_list? refs)))) true)
+			true
+			(neumann_fail "build_queryplan" "multi-target DELETE requires a primary key on every target"))
+		(define cond (dml_preserve_driver_membership_probe (qb_schema block) (coalesceNil (qb_where block) true)))
+		(define needed_exprs (merge (list
+			(list cond)
+			(merge target_key_refs)
+			(source_join_exprs sources))))
+		(define target_indexes (produceN (count target_sources)))
+		/* A self-join may hold read rights for two aliases of the same shard.
+		Collect immutable primary keys for every target while joins are open, then
+		mutate only after every key-plan argument has released its scan rights. */
+		(define target_rows_symbols (map target_indexes (lambda (i)
+			(symbol (concat "target_rows_" i)))))
+		(define keep_old_key (list (quote lambda) (list (quote old) (quote _new)) (quote old)))
+		(define merge_target_rows (list (quote lambda) (list (quote rows) (quote grouped))
+			(list (quote merge_assoc) (quote rows) (quote grouped) keep_old_key)))
+		(define target_rows_plans (map target_indexes (lambda (i)
+			(build_join_scan_reduce_using_recipe
+				(qb_schema block)
+				sources
+				scan_plan
+				first_alias
+				needed_exprs
+				cond
+				(cons (quote list) (map (nth target_key_refs i) (lambda (key_ref)
+					(lower_column_expr_for_join sources first_alias key_ref))))
+				'()
+				0
+				-1
+				true nil nil (qb_stages block)
+				(list (quote lambda) (list (quote rows) (quote row))
+					(list (quote set_assoc) (quote rows) (quote row) true))
+				(list (quote list))
+				merge_target_rows
+				nil))))
+		(cons
+			(list (quote lambda) target_rows_symbols
+				(dml_sum_exprs (map target_indexes (lambda (i)
+					(multi_delete_target_scan_plan
+						(nth target_sources i)
+						(nth target_rows_symbols i))))))
+			target_rows_plans))))
+
 (define lower_multi_source_dml_query_block (lambda (block target_schema target_tbl)
 	(begin
 		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
@@ -5989,6 +6097,19 @@ every title. */
 				(merge (list
 					(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages block))
 					(list (lower_dml_query_block_core (query_block_without_stages_after_prepare_using stage_lookup block) target_schema target_tbl)))))))))
+
+(define lower_multi_target_delete_with_stages (lambda (block target_specs)
+	(if (empty_list? (qb_stages block))
+		(lower_multi_target_delete_query_block block target_specs)
+		(begin
+			(define stage_lookup (query_block_stage_lookup block))
+			(define dependency_graph (stage_dependency_graph stage_lookup))
+			(cons (quote begin)
+				(merge (list
+					(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup (qb_stages block))
+					(list (lower_multi_target_delete_query_block
+						(query_block_without_stages_after_prepare_using stage_lookup block)
+						target_specs)))))))))
 
 (define lower_dml_union_block_with_stages (lambda (block target_schema target_tbl)
 	(cons (quote begin)
@@ -6853,6 +6974,9 @@ though both handles are constant for the complete query generation. */
 				(symbol query-block) (lower_dml_query_block_with_stages (ir_root ir) target_schema target_tbl)
 				(symbol union-block) (lower_dml_union_block_with_stages (ir_root ir) target_schema target_tbl)
 				_ (neumann_fail "build_queryplan" "DML lowering expects a query-block root"))
+			((symbol dml-many) target_specs) (match (logical_op (ir_root ir))
+				(symbol query-block) (lower_multi_target_delete_with_stages (ir_root ir) target_specs)
+				_ (neumann_fail "build_queryplan" "multi-target DELETE lowering expects a query-block root"))
 			_ (neumann_fail "build_queryplan" "DML lowering is intentionally not scaffolded yet")))
 		(define consolidated_plan (consolidate_closed_group_prepares ir plan))
 		(define complete_plan (complete_emitted_prepare_bindings ir consolidated_plan))
@@ -6927,6 +7051,19 @@ ordering run. Storage artifacts begin in build_queryplan. */
 			(list (list (quote dml) true))))
 		(neumann_compile_ir_pipeline
 			(ir_with_return (decorrelate_logical_query query) (list (quote dml) schema tbl))))))
+
+(define build_multi_delete_plan (lambda (schema target_specs all_defs condition)
+	(begin
+		(define query (make_query_block
+			schema
+			all_defs
+			nil
+			(coalesceNil condition true)
+			'() nil '() nil nil '() '()
+			(list (list (quote dml) true))))
+		(neumann_compile_ir_pipeline
+			(ir_with_return (decorrelate_logical_query query)
+				(list (quote dml-many) target_specs))))))
 
 (define sql_truncate (lambda (schema tbl)
 	(build_dml_plan schema tbl nil

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2508,19 +2508,23 @@ columns cannot change group cardinality because the primary key is unique. */
 			'()))))))
 
 (define expand_grouped_query_block (lambda (block)
-	(make_query_block
-		(qb_schema block)
-		(qb_sources block)
-		(expand_query_block_fields (qb_sources block) (qb_fields block))
-		(qb_where block)
-		(merge_unique (list (qb_group block) (functional_dependency_star_group_keys block)))
-		(qb_having block)
-		(qb_order block)
-		(qb_limit block)
-		(qb_offset block)
-		(qb_hidden block)
-		(qb_stages block)
-		(qb_facts block))))
+	(begin
+		(define dependency_keys (functional_dependency_star_group_keys block))
+		(if (empty_list? dependency_keys)
+			block
+			(make_query_block
+				(qb_schema block)
+				(qb_sources block)
+				(expand_query_block_fields (qb_sources block) (qb_fields block))
+				(qb_where block)
+				(merge_unique (list (qb_group block) dependency_keys))
+				(qb_having block)
+				(qb_order block)
+				(qb_limit block)
+				(qb_offset block)
+				(qb_hidden block)
+				(qb_stages block)
+				(qb_facts block))))))
 
 (define query_limit_active? (lambda (offset_value limit_value)
 	(or (and (not (nil? offset_value)) (not (equal? offset_value 0)))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -863,6 +863,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "MOD" true) "(" (define a sql_expression) "," (define b sql_expression) ")") (sql_mod_expr a b))
 		/* MySQL LAST_INSERT_ID(): direct session lookup to support session scoping */
 		(parser '((atom "LAST_INSERT_ID" true) "(" ")") '('session "last_insert_id"))
+		(parser '((atom "FOUND_ROWS" true) "(" ")") '('session "found_rows"))
 		/* MySQL IF(condition, true_expr, false_expr) with short-circuit semantics */
 		(parser '((atom "IF" true) "(" (define cond sql_expression) "," (define t sql_expression) "," (define f sql_expression) ")") '((quote if) cond t f))
 		(parser '((atom "VALUES" true) "(" (define e sql_identifier_unquoted) ")") '('get_column "VALUES" true e true)) /* passthrough VALUES for now, the extract_stupid and replace_stupid will do their job for now */
@@ -935,7 +936,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* TODO: left [outer] join, right [outer] join recursive buildup */
 		(parser '((define l tabledefs) (define x (or
 			(parser '((atom "LEFT" true) (? (atom "OUTER" true)) (atom "JOIN" true) (define r tabledef) (atom "ON" true) (define e sql_expression)) (match r '(id schema tbl _ nil) '('(id schema tbl true e))))
-			(parser '((atom "JOIN" true) (define r tabledef) (atom "ON" true) (define e sql_expression)) (match r '(id schema tbl _ nil) '('(id schema tbl false e))))
+			(parser '((? (atom "INNER" true)) (atom "JOIN" true) (define r tabledef) (atom "ON" true) (define e sql_expression)) (match r '(id schema tbl _ nil) '('(id schema tbl false e))))
 			(parser '((? (atom "CROSS" true)) (atom "JOIN" true) (define r tabledefs)) r)
 		))) (merge l x))
 		/* Normalize RIGHT JOIN to the existing LEFT JOIN execution contract:
@@ -999,6 +1000,26 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(list (quote query-block) schema tables fields condition group having nil nil nil '() '() '())
 		'(schema tables fields condition group having order limit offset) (list schema tables fields condition group having nil nil nil)
 		_ query
+	)))
+	(define sql_select_calc_found_rows? (lambda (query) (match query
+		((symbol query-block) _schema _tables _fields _condition _group _having _order _limit _offset _hidden _stages facts)
+		(qassoc_get facts (quote sql_calc_found_rows) false)
+		_ false
+	)))
+	(define sql_build_select_plan (lambda (query) (begin
+		(define actual_plan (build_queryplan_term (sql_expand_views query policy)))
+		(if (sql_select_calc_found_rows? query)
+			(begin
+				(define count_plan (build_queryplan_term (sql_expand_views (sql_select_clear_stage query) policy)))
+				(list (quote !begin)
+					(list (quote session) "found_rows" 0)
+					(list
+						(list (quote lambda) (list (quote resultrow)) count_plan)
+						(list (quote lambda) (list (quote item))
+							(list (quote session) "found_rows"
+								(list (quote +) (list (quote session) "found_rows") 1))))
+					actual_plan))
+			actual_plan)
 	)))
 	(define sql_union_all_parts (lambda (query)
 		(match query
@@ -1093,6 +1114,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 	(define sql_select_core (parser '(
 		(atom "SELECT" true)
+		(define calc_found_rows (? (atom "SQL_CALC_FOUND_ROWS" true)))
 		(? (atom "DISTINCT" true))
 		(define cols (+ (or
 			(parser "*" '("*" '((quote get_column) nil false "*" false)))
@@ -1150,7 +1172,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 				'((define limit sql_expression))
 			)
 		)
-	) (list (quote query-block) schema (if (nil? from) '() (merge from)) (merge cols) condition group having order limit offset '() '() '())))
+	) (list (quote query-block) schema (if (nil? from) '() (merge from)) (merge cols) condition group having order limit offset '() '()
+			(if calc_found_rows (list (list (quote sql_calc_found_rows) true)) '()))))
 	(define sql_select (parser (or
 		(parser '(
 			(define left sql_select_core)
@@ -1272,21 +1295,23 @@ arithmetic; leave expressions containing columns or functions untouched. */
 				(build_dml_plan trunc_schema tbl nil (list (list tbl trunc_schema tbl false nil)) nil true nil nil nil)))
 	)))
 
-	/* Multi-table DELETE: route through query planner pipeline via build_dml_plan */
-	(define gen_multi_delete (lambda (target all_defs condition) (begin
-		/* Find target table definition */
-		(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
-			'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
-			acc)) nil))
-		(define target_alias (match target_def '(id _ _ _ _) id))
-		(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
-		(build_dml_plan schema target_tbl target_alias all_defs nil condition nil nil nil)
+	/* Multi-table DELETE: retain every target alias through physical lowering. */
+	(define gen_multi_delete (lambda (targets all_defs condition) (begin
+		(define target_specs (map targets (lambda (target) (begin
+			(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
+				'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
+				acc)) nil))
+			(if (nil? target_def)
+				(error (concat "DELETE target not found: " target))
+				(match target_def '(id target_schema target_tbl _ _)
+					(list id target_schema target_tbl)))))))
+		(build_multi_delete_plan schema target_specs all_defs condition)
 	)))
 	(define sql_multi_delete (parser (or
 		/* DELETE t1 FROM t1 JOIN t2 ON ... WHERE ... */
 		(parser '(
 			(atom "DELETE" true)
-			(define target sql_identifier)
+			(define targets (+ sql_identifier ","))
 			(atom "FROM" true)
 			(define tbldefs (+ tabledefs ","))
 			(? '(
@@ -1297,18 +1322,21 @@ arithmetic; leave expressions containing columns or functions untouched. */
 				(define all_defs (merge tbldefs))
 				(set condition (coalesceNil condition true))
 				/* policy: write access check */
-				(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
-					'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
-					acc)) nil))
-				(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
-				(if policy (policy schema target_tbl true) true)
-				(gen_multi_delete target all_defs condition)
+				(map targets (lambda (target) (begin
+					(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
+						'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
+						acc)) nil))
+					(if (nil? target_def)
+						(error (concat "DELETE target not found: " target))
+						(match target_def '(_ target_schema target_tbl _ _)
+							(if policy (policy target_schema target_tbl true) true))))))
+				(gen_multi_delete targets all_defs condition)
 		))
 		/* DELETE FROM t1 USING t1 JOIN t2 ON ... WHERE ... */
 		(parser '(
 			(atom "DELETE" true)
 			(atom "FROM" true)
-			(define target sql_identifier)
+			(define targets (+ sql_identifier ","))
 			(atom "USING" true)
 			(define tbldefs (+ tabledefs ","))
 			(? '(
@@ -1318,12 +1346,15 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		) (begin
 				(define all_defs (merge tbldefs))
 				(set condition (coalesceNil condition true))
-				(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
-					'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
-					acc)) nil))
-				(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
-				(if policy (policy schema target_tbl true) true)
-				(gen_multi_delete target all_defs condition)
+				(map targets (lambda (target) (begin
+					(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
+						'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
+						acc)) nil))
+					(if (nil? target_def)
+						(error (concat "DELETE target not found: " target))
+						(match target_def '(_ target_schema target_tbl _ _)
+							(if policy (policy target_schema target_tbl true) true))))))
+				(gen_multi_delete targets all_defs condition)
 		))
 	)))
 
@@ -1485,7 +1516,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(parser '((atom "UNIQUE" true) (atom "KEY" true) (define id sql_identifier) "(" (define cols (+ sql_identifier ",")) ")" (? (atom "USING" true) (atom "BTREE" true))) '((quote list) "unique" id (cons (quote list) cols)))
 			(parser '((atom "CONSTRAINT" true) (define id (? sql_identifier)) (atom "FOREIGN" true) (atom "KEY" true) "(" (define cols1 (+ sql_identifier ",")) ")" (atom "REFERENCES" true) (define tbl2 sql_identifier) "(" (define cols2 (+ sql_identifier ",")) ")" (? (atom "ON" true) (atom "DELETE" true) (define deletemode sql_foreign_key_mode)) (? (atom "ON" true) (atom "UPDATE" true) (define updatemode sql_foreign_key_mode))) '((quote list) "foreign" id (cons (quote list) cols1) tbl2 (cons (quote list) cols2) updatemode deletemode))
 			(parser '((atom "FOREIGN" true) (atom "KEY" true) (define id (? sql_identifier)) "(" (define cols1 (+ sql_identifier ",")) ")" (atom "REFERENCES" true) (define tbl2 sql_identifier) "(" (define cols2 (+ sql_identifier ",")) ")" (? (atom "ON" true) (atom "DELETE" true) (or (atom "RESTRICT" true) (atom "CASCADE" true) (atom "SET NULL" true))) (? (atom "ON" true) (atom "UPDATE" true) (or (atom "RESTRICT" true) (atom "CASCADE" true) (atom "SET NULL" true)))) '((quote list) "foreign" id (cons (quote list) cols1) tbl2 (cons (quote list) cols2)))
-			(parser '((atom "KEY" true) sql_identifier "(" (+ sql_identifier ",") ")" (? (atom "USING" true) (atom "BTREE" true))) '((quote list))) /* ignore index definitions */
+			(parser '((atom "KEY" true) sql_identifier "(" (+ (parser '((define col sql_identifier) (? "(" sql_int ")")) col) ",") ")" (? (atom "USING" true) (atom "BTREE" true))) '((quote list))) /* ignore index definitions */
 			(parser '(
 				(define col sql_identifier)
 				(define type sql_column_type)
@@ -1500,6 +1531,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		) ","))
 		")"
 		(define options (* (or
+			(parser '((atom "DEFAULT" true) (atom "CHARACTER" true) (atom "SET" true) (define id sql_identifier)) '("charset" id))
 			(parser '((atom "CHARACTER" true) (atom "SET" true) (define id sql_identifier)) '("charset" id))
 			(parser '((atom "ENGINE" true) "=" (atom "MEMORY" true)) '("engine" "memory"))
 			(parser '((atom "ENGINE" true) "=" (atom "CACHE" true)) '("engine" "cache"))
@@ -1595,7 +1627,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	/* TODO: ignore comments wherever they occur --> Lexer */
 	(define p (parser (or
 		(parser (atom "SHUTDOWN" true) (begin (if policy (policy "system" true true) true) '(shutdown)))
-		(parser (define query sql_select) (build_queryplan_term (sql_expand_views query policy)))
+		(parser (define query sql_select) (sql_build_select_plan query))
 		(parser '((atom "EXPLAIN" true) (atom "IR" true) (define query sql_select)) (explain_queryplan_ir (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "REORDER" true) (define query sql_select)) (explain_queryplan_reorder (sql_expand_views query policy)))
 		(parser '((atom "EXPLAIN" true) (atom "COMPILE" true) (define query sql_select)) (explain_queryplan_compile (sql_expand_views query policy) parse_started_ns (strlen s)))
@@ -1823,7 +1855,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "SHOW" true) (atom "timezone" true)) (list (quote resultrow) (list (quote list) "TimeZone" (list (quote session_globalvar) "time_zone"))))
 		/* SET GLOBAL time_zone */
 		(parser '((atom "SET" true) (atom "GLOBAL" true) (define key sql_identifier) "=" (define value sql_expression)) '((quote globalvars) key value))
-		(parser '((atom "SET" true) (atom "NAMES" true) (define charset sql_expression)) (quote true)) /* ignore */
+		(parser '((atom "SET" true) (atom "NAMES" true) (define charset sql_expression) (? (atom "COLLATE" true) (or sql_identifier sql_string))) (quote true)) /* ignore */
 
 
 		(parser '((atom "DROP" true) (or (atom "DATABASE" true) (atom "SCHEMA" true)) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define id sql_identifier))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -860,6 +860,8 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		(parser '((atom "COALESCE" true) "(" (define args (* sql_expression ",")) ")") (cons (quote coalesceNil) args))
 		/* MySQL IFNULL(val, default) — alias for COALESCE with 2 args */
 		(parser '((atom "IFNULL" true) "(" (define a sql_expression) "," (define b sql_expression) ")") '((quote coalesceNil) a b))
+		/* SQL NULLIF(a, b) returns NULL when the values compare equal, otherwise a. */
+		(parser '((atom "NULLIF" true) "(" (define a sql_expression) "," (define b sql_expression) ")") '((quote if) '((quote equal??) a b) nil a))
 		(parser '((atom "MOD" true) "(" (define a sql_expression) "," (define b sql_expression) ")") (sql_mod_expr a b))
 		/* MySQL LAST_INSERT_ID(): direct session lookup to support session scoping */
 		(parser '((atom "LAST_INSERT_ID" true) "(" ")") '('session "last_insert_id"))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -804,12 +804,13 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 			(resultrow '("result" (eval (scheme sql))))
 		) (time (begin
 				/* SQL syntax mode */
+				(define sql_parse_input (strtrim sql))
 				/* tolerate an optional trailing ';' - must be at end of string */
-				(set sql (match sql (regex "^((?s:.*));\\s*$" _ body) body sql))
+				(set sql_parse_input (match sql_parse_input (regex "^((?s:.*));\\s*$" _ body) body sql_parse_input))
 				(define mysql_username (coalesce (session "username") "root"))
 				(define formula (if (equal? (session "syntax") "postgresql")
-					(cached_parse psql_queryplan_cache parse_psql schema sql (sql_policy mysql_username) mysql_username session false)
-					(cached_parse sql_queryplan_cache parse_sql schema sql (sql_policy mysql_username) mysql_username session true)))
+					(cached_parse psql_queryplan_cache parse_psql schema sql_parse_input (sql_policy mysql_username) mysql_username session false)
+					(cached_parse sql_queryplan_cache parse_sql schema sql_parse_input (sql_policy mysql_username) mysql_username session true)))
 				(with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula))))
 			) sql))
 	)) (lambda (e) (begin

--- a/scm/date.go
+++ b/scm/date.go
@@ -32,9 +32,28 @@ var allowedDateFormats = []string{
 	"06-01-02",
 }
 
+// mysqlZeroDateUnix is outside Go's practical SQL date range and fits exactly
+// into Scmer's signed 45-bit date payload. It preserves MySQL's zero date
+// without conflating it with the Unix epoch.
+const mysqlZeroDateUnix int64 = -(1 << 44)
+
+func isMySQLZeroDate(s string) bool {
+	if s == "0000-00-00" || s == "0000-00-00 00:00:00" {
+		return true
+	}
+	if !strings.HasPrefix(s, "0000-00-00 00:00:00.") {
+		return false
+	}
+	fraction := strings.TrimPrefix(s, "0000-00-00 00:00:00.")
+	return fraction != "" && strings.Trim(fraction, "0") == ""
+}
+
 // ParseDateString tries to parse a date/datetime string using the allowed formats.
 // Returns the Unix timestamp and true on success, or 0 and false on failure.
 func ParseDateString(s string) (int64, bool) {
+	if isMySQLZeroDate(s) {
+		return mysqlZeroDateUnix, true
+	}
 	for _, format := range allowedDateFormats {
 		if t, err := time.Parse(format, s); err == nil {
 			return t.Unix(), true
@@ -68,6 +87,16 @@ func toTime(v Scmer) (time.Time, bool) {
 func sqlTemporalOutput(value Scmer, sqlType string) Scmer {
 	if value.IsNil() {
 		return NewNil()
+	}
+	if value.GetTag() == tagDate && value.Int() == mysqlZeroDateUnix {
+		switch strings.ToUpper(sqlType) {
+		case "DATE":
+			return NewString("0000-00-00")
+		case "DATETIME", "TIMESTAMP":
+			return NewString("0000-00-00 00:00:00")
+		default:
+			return value
+		}
 	}
 	t, ok := toTime(value)
 	if !ok {

--- a/scm/date_output_test.go
+++ b/scm/date_output_test.go
@@ -36,3 +36,22 @@ func TestSQLTemporalOutputPreservesNilAndUnknownType(t *testing.T) {
 		t.Fatalf("unknown temporal type changed value: got %v, want %v", got, value)
 	}
 }
+
+func TestSQLTemporalOutputPreservesMySQLZeroDates(t *testing.T) {
+	for _, test := range []struct {
+		input   string
+		sqlType string
+		want    string
+	}{
+		{input: "0000-00-00", sqlType: "DATE", want: "0000-00-00"},
+		{input: "0000-00-00 00:00:00", sqlType: "DATETIME", want: "0000-00-00 00:00:00"},
+	} {
+		unix, ok := ParseDateString(test.input)
+		if !ok {
+			t.Fatalf("ParseDateString(%q) rejected a MySQL zero date", test.input)
+		}
+		if got := sqlTemporalOutput(NewDate(unix), test.sqlType).String(); got != test.want {
+			t.Fatalf("%s output = %q, want %q", test.sqlType, got, test.want)
+		}
+	}
+}

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -26,6 +26,7 @@ import "unicode"
 import "unsafe"
 import "net/url"
 import "strings"
+import "unicode/utf8"
 import crand "crypto/rand"
 import "crypto/sha1"
 import "encoding/hex"
@@ -134,10 +135,10 @@ func OrderRelationLess(fn func(...Scmer) Scmer) func(Scmer, Scmer) bool {
 
 /* SQL LIKE operator implementation on strings */
 func StrLike(str, pattern string) bool {
-	if !strings.ContainsAny(pattern, "%_") {
+	if !strings.ContainsAny(pattern, "%_\\") {
 		return str == pattern
 	}
-	if !strings.Contains(pattern, "_") {
+	if !strings.ContainsAny(pattern, "_\\") {
 		wildcards := strings.Count(pattern, "%")
 		if wildcards == 1 {
 			if pattern[0] == '%' {
@@ -151,44 +152,60 @@ func StrLike(str, pattern string) bool {
 			return strings.Contains(str, pattern[1:len(pattern)-1])
 		}
 	}
-	for {
-		// boundary check
-		if len(pattern) == 0 {
-			if len(str) == 0 {
-				// we finished matching
-				return true
-			} else {
-				// pattern is consumed but no string left: no match
-				return false
-			}
+	type likePosition struct {
+		str     int
+		pattern int
+	}
+	memo := make(map[likePosition]bool)
+	visited := make(map[likePosition]bool)
+	var match func(int, int) bool
+	match = func(strPos, patternPos int) bool {
+		position := likePosition{str: strPos, pattern: patternPos}
+		if visited[position] {
+			return memo[position]
 		}
-		// now str[0] and pattern[0] are assured to exist
-		if pattern[0] == '%' { // wildcard
-			pattern = pattern[1:]
-			if pattern == "" {
-				return true // string ends with wildcard
-			}
-			// otherwise: match against all possible endings
-			for i := len(str) - 1; i >= 0; i-- { // run from right to left to be as greedy and performant as possible
-				if str[i] == pattern[0] {
-					// check if this caracter matches the rest
-					if StrLike(str[i:], pattern) {
-						return true // we found a match with this position as continuation
-					}
+		visited[position] = true
+		matched := false
+		if patternPos == len(pattern) {
+			matched = strPos == len(str)
+		} else {
+			patternRune, patternSize := utf8.DecodeRuneInString(pattern[patternPos:])
+			switch patternRune {
+			case '%':
+				matched = match(strPos, patternPos+patternSize)
+				if !matched && strPos < len(str) {
+					_, strSize := utf8.DecodeRuneInString(str[strPos:])
+					matched = match(strPos+strSize, patternPos)
+				}
+			case '_':
+				if strPos < len(str) {
+					_, strSize := utf8.DecodeRuneInString(str[strPos:])
+					matched = match(strPos+strSize, patternPos+patternSize)
+				}
+			case '\\':
+				literalPos := patternPos + patternSize
+				literalRune := patternRune
+				literalSize := patternSize
+				if literalPos < len(pattern) {
+					literalRune, literalSize = utf8.DecodeRuneInString(pattern[literalPos:])
+				} else {
+					literalPos = patternPos
+				}
+				if strPos < len(str) {
+					strRune, strSize := utf8.DecodeRuneInString(str[strPos:])
+					matched = strRune == literalRune && match(strPos+strSize, literalPos+literalSize)
+				}
+			default:
+				if strPos < len(str) {
+					strRune, strSize := utf8.DecodeRuneInString(str[strPos:])
+					matched = strRune == patternRune && match(strPos+strSize, patternPos+patternSize)
 				}
 			}
-			return false // no continuation found
-		} else {
-			if len(str) > 0 && (pattern[0] == '_' || pattern[0] == str[0]) {
-				// match -> move one character forward
-				pattern = pattern[1:]
-				str = str[1:]
-			} else {
-				// mismatch -> we're out
-				return false
-			}
 		}
+		memo[position] = matched
+		return matched
 	}
+	return match(0, 0)
 }
 
 // StrLikeFold retains the established Unicode lower-case behavior. StrLike's

--- a/scm/strings_test.go
+++ b/scm/strings_test.go
@@ -46,3 +46,15 @@ func TestStrLikeCollationUncasedPattern(t *testing.T) {
 		t.Fatal("cased pattern should retain case-insensitive matching")
 	}
 }
+
+func TestStrLikeEscapedWildcards(t *testing.T) {
+	if !StrLike("_transient_sample", `\_transient\_%`) {
+		t.Fatal("escaped underscores should match literal underscores")
+	}
+	if StrLike("xtransient_sample", `\_transient\_%`) {
+		t.Fatal("escaped leading underscore must not act as a wildcard")
+	}
+	if !StrLike("discount%", `discount\%`) {
+		t.Fatal("escaped percent should match a literal percent")
+	}
+}

--- a/scm/timezone.go
+++ b/scm/timezone.go
@@ -148,6 +148,9 @@ func GetCurrentSessionLocation() *time.Location {
 // If the value's zone_id != 0, displays in that zone; otherwise uses sessionLoc.
 func DateToDisplay(v Scmer, sessionLoc *time.Location) string {
 	unix := TagDateDecodeUnix(auxVal(v.aux))
+	if unix == mysqlZeroDateUnix {
+		return "0000-00-00 00:00:00"
+	}
 	zoneID := TagDateDecodeZone(auxVal(v.aux))
 	loc := sessionLoc
 	if loc == nil {

--- a/tests/sql/compatibility/dbcheck-ddl-compat.yaml
+++ b/tests/sql/compatibility/dbcheck-ddl-compat.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
 metadata:
   version: "1.0"
   description: "DDL compatibility for dbcheck.php migration tool"
@@ -11,6 +13,14 @@ test_cases:
   # --- Table creation with full MySQL syntax ---
   - name: "CREATE TABLE with CHARSET COLLATE ENGINE"
     sql: "CREATE TABLE dbc_t (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(100) NOT NULL, email VARCHAR(200) COLLATE utf8mb4_unicode_ci, notes TEXT, active BOOLEAN DEFAULT true) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB"
+
+  - name: "CREATE TABLE accepts DEFAULT CHARACTER SET and prefix keys"
+    sql: "CREATE TABLE dbc_prefix_key (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, meta_key VARCHAR(255) DEFAULT NULL, PRIMARY KEY (id), KEY meta_key (meta_key(191))) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci"
+
+  - name: "Malformed prefix key remains rejected"
+    sql: "CREATE TABLE dbc_bad_prefix (id BIGINT, KEY bad (id(foo)))"
+    expect:
+      error: true
 
   - name: "CREATE TABLE with DOUBLE PRECISION and ENGINE equals spacing"
     sql: "CREATE TABLE dbc_double_precision (id INT PRIMARY KEY AUTO_INCREMENT, val DOUBLE PRECISION) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = INNODB"

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -15,6 +15,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS wpcompat_options"
   - sql: "DROP TABLE IF EXISTS wpcompat_mysql_leading"
   - sql: "DROP TABLE IF EXISTS wpcompat_no_primary_key"
+  - sql: "DROP TABLE IF EXISTS sqlcompat_usermeta"
+  - sql: "DROP TABLE IF EXISTS sqlcompat_users"
   - sql: |
       CREATE TABLE wpcompat_posts (
         ID BIGINT PRIMARY KEY AUTO_INCREMENT,
@@ -36,12 +38,16 @@ setup:
   - sql: "CREATE TABLE wpcompat_term_relationships (object_id BIGINT, term_taxonomy_id BIGINT)"
   - sql: "CREATE TABLE wpcompat_options (option_id BIGINT PRIMARY KEY, option_name VARCHAR(191), option_value TEXT)"
   - sql: "CREATE TABLE wpcompat_no_primary_key (value INT)"
-  - sql: "INSERT INTO wpcompat_posts VALUES (1, '2026-08-20 10:00:00', '2026-08-20 10:00:00', 'first', 'post', 'publish'), (2, '2026-08-21 10:00:00', '2026-08-21 10:00:00', 'second', 'post', 'publish'), (3, '2026-08-22 10:00:00', '2026-08-22 10:00:00', 'third', 'post', 'publish')"
+  - sql: "CREATE TABLE sqlcompat_users (ID BIGINT PRIMARY KEY)"
+  - sql: "CREATE TABLE sqlcompat_usermeta (umeta_id BIGINT PRIMARY KEY, user_id BIGINT, meta_key VARCHAR(255), meta_value TEXT)"
+  - sql: "INSERT INTO wpcompat_posts VALUES (1, '2026-08-20 10:00:00', '2026-08-20 10:00:00', 'first', 'post', 'publish'), (2, '2026-08-21 10:00:00', '2026-08-21 10:00:00', 'second', 'post', 'publish'), (3, '2026-08-22 10:00:00', '2026-08-22 10:00:00', 'third', 'post', 'publish'), (4, '2026-08-23 10:00:00', '2026-08-23 10:00:00', 'header', 'wp_template', 'publish'), (5, '2026-08-24 10:00:00', '2026-08-24 10:00:00', 'footer', 'wp_template_part', 'publish')"
   - sql: "INSERT INTO wpcompat_comments VALUES (1, '1', 'comment', '2026-08-22 10:00:00'), (2, '0', 'comment', '2026-08-22 11:00:00'), (3, '1', 'note', '2026-08-22 12:00:00')"
   - sql: "INSERT INTO wpcompat_terms VALUES (1, 'twentytwentyfive')"
   - sql: "INSERT INTO wpcompat_term_taxonomy VALUES (10, 1, 'wp_theme'), (11, 1, 'category')"
-  - sql: "INSERT INTO wpcompat_term_relationships VALUES (5, 11)"
+  - sql: "INSERT INTO wpcompat_term_relationships VALUES (5, 11), (5, 15), (5, 15)"
   - sql: "INSERT INTO wpcompat_options VALUES (1, '_transient_sample', 'cached'), (2, '_transient_timeout_sample', '1'), (3, 'keep', 'value')"
+  - sql: "INSERT INTO sqlcompat_users VALUES (1)"
+  - sql: "INSERT INTO sqlcompat_usermeta VALUES (1, 1, 'capabilities', 'a:1:{s:13:\"administrator\";b:1;}')"
 
 test_cases:
   - name: "SET NAMES with COLLATE and leading whitespace work over MySQL"
@@ -136,6 +142,69 @@ test_cases:
         - ID: 3
         - ID: 2
 
+  - name: "Grouping by a primary key permits selecting every source column"
+    sql: |
+      SELECT wpcompat_posts.*
+      FROM wpcompat_posts
+      WHERE wpcompat_posts.post_type = 'wp_template'
+      GROUP BY wpcompat_posts.ID
+      ORDER BY wpcompat_posts.post_date DESC
+    expect:
+      rows: 1
+      data:
+        - ID: 4
+          post_date: "2026-08-23 10:00:00"
+          post_date_gmt: "2026-08-23 10:00:00"
+          post_name: header
+          post_type: wp_template
+          post_status: publish
+
+  - name: "Grouping by a primary key permits every source column after a LEFT JOIN"
+    sql: |
+      SELECT wpcompat_posts.*
+      FROM wpcompat_posts
+      LEFT JOIN wpcompat_term_relationships
+        ON wpcompat_posts.ID = wpcompat_term_relationships.object_id
+      WHERE wpcompat_term_relationships.term_taxonomy_id IN (15)
+        AND wpcompat_posts.post_type = 'wp_template_part'
+      GROUP BY wpcompat_posts.ID
+      ORDER BY wpcompat_posts.post_date DESC
+    expect:
+      rows: 1
+      data:
+        - ID: 5
+          post_date: "2026-08-24 10:00:00"
+          post_date_gmt: "2026-08-24 10:00:00"
+          post_name: footer
+          post_type: wp_template_part
+          post_status: publish
+
+  - name: "Selecting every source column without a grouped key remains invalid"
+    sql: |
+      SELECT wpcompat_posts.*
+      FROM wpcompat_posts
+      GROUP BY wpcompat_posts.post_type
+    expect:
+      error: true
+
+  - name: "NULLIF composes with boolean expressions inside COUNT"
+    sql: |
+      SELECT
+        COUNT(NULLIF(meta_value LIKE '%\"administrator\"%', false)) AS administrators,
+        COUNT(NULLIF(meta_value LIKE '%\"editor\"%', false)) AS editors,
+        COUNT(NULLIF(meta_value = 'a:0:{}', false)) AS empty_roles,
+        COUNT(*) AS total
+      FROM sqlcompat_usermeta
+      INNER JOIN sqlcompat_users ON user_id = ID
+      WHERE meta_key = 'capabilities'
+    expect:
+      rows: 1
+      data:
+        - administrators: 1
+          editors: 0
+          empty_roles: 0
+          total: 1
+
   - name: "INSERT accepts a MySQL zero datetime"
     sql: "INSERT INTO wpcompat_posts (post_date, post_date_gmt, post_name, post_type, post_status) VALUES ('2026-08-26 10:00:00', '0000-00-00 00:00:00', 'auto-draft', 'post', 'auto-draft')"
 
@@ -227,3 +296,5 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS wpcompat_options"
   - sql: "DROP TABLE IF EXISTS wpcompat_mysql_leading"
   - sql: "DROP TABLE IF EXISTS wpcompat_no_primary_key"
+  - sql: "DROP TABLE IF EXISTS sqlcompat_usermeta"
+  - sql: "DROP TABLE IF EXISTS sqlcompat_users"

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -1,0 +1,229 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+metadata:
+  version: "1.0"
+  description: "MySQL application SQL compatibility: connection setup, row counting, joins, grouping, temporal values, patterns, and multi-table DELETE"
+  requires_mysql: true
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS wpcompat_posts"
+  - sql: "DROP TABLE IF EXISTS wpcompat_comments"
+  - sql: "DROP TABLE IF EXISTS wpcompat_terms"
+  - sql: "DROP TABLE IF EXISTS wpcompat_term_taxonomy"
+  - sql: "DROP TABLE IF EXISTS wpcompat_term_relationships"
+  - sql: "DROP TABLE IF EXISTS wpcompat_options"
+  - sql: "DROP TABLE IF EXISTS wpcompat_mysql_leading"
+  - sql: "DROP TABLE IF EXISTS wpcompat_no_primary_key"
+  - sql: |
+      CREATE TABLE wpcompat_posts (
+        ID BIGINT PRIMARY KEY AUTO_INCREMENT,
+        post_date DATETIME,
+        post_date_gmt DATETIME,
+        post_name VARCHAR(200),
+        post_type VARCHAR(20),
+        post_status VARCHAR(20)
+      )
+  - sql: |
+      CREATE TABLE wpcompat_comments (
+        comment_ID BIGINT PRIMARY KEY,
+        comment_approved VARCHAR(20),
+        comment_type VARCHAR(20),
+        comment_date_gmt DATETIME
+      )
+  - sql: "CREATE TABLE wpcompat_terms (term_id BIGINT PRIMARY KEY, name VARCHAR(200))"
+  - sql: "CREATE TABLE wpcompat_term_taxonomy (term_taxonomy_id BIGINT PRIMARY KEY, term_id BIGINT, taxonomy VARCHAR(32))"
+  - sql: "CREATE TABLE wpcompat_term_relationships (object_id BIGINT, term_taxonomy_id BIGINT)"
+  - sql: "CREATE TABLE wpcompat_options (option_id BIGINT PRIMARY KEY, option_name VARCHAR(191), option_value TEXT)"
+  - sql: "CREATE TABLE wpcompat_no_primary_key (value INT)"
+  - sql: "INSERT INTO wpcompat_posts VALUES (1, '2026-08-20 10:00:00', '2026-08-20 10:00:00', 'first', 'post', 'publish'), (2, '2026-08-21 10:00:00', '2026-08-21 10:00:00', 'second', 'post', 'publish'), (3, '2026-08-22 10:00:00', '2026-08-22 10:00:00', 'third', 'post', 'publish')"
+  - sql: "INSERT INTO wpcompat_comments VALUES (1, '1', 'comment', '2026-08-22 10:00:00'), (2, '0', 'comment', '2026-08-22 11:00:00'), (3, '1', 'note', '2026-08-22 12:00:00')"
+  - sql: "INSERT INTO wpcompat_terms VALUES (1, 'twentytwentyfive')"
+  - sql: "INSERT INTO wpcompat_term_taxonomy VALUES (10, 1, 'wp_theme'), (11, 1, 'category')"
+  - sql: "INSERT INTO wpcompat_term_relationships VALUES (5, 11)"
+  - sql: "INSERT INTO wpcompat_options VALUES (1, '_transient_sample', 'cached'), (2, '_transient_timeout_sample', '1'), (3, 'keep', 'value')"
+
+test_cases:
+  - name: "SET NAMES with COLLATE and leading whitespace work over MySQL"
+    mysql:
+      statements:
+        - sql: "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'"
+          expect: {}
+        - sql: "\nCREATE TABLE wpcompat_mysql_leading (id INT PRIMARY KEY)"
+          expect: {}
+        - sql: "INSERT INTO wpcompat_mysql_leading VALUES (1)"
+          expect: {}
+        - sql: "SELECT id FROM wpcompat_mysql_leading"
+          expect:
+            rows: 1
+            data:
+              - id: 1
+
+  - name: "SQL_CALC_FOUND_ROWS reports rows before LIMIT"
+    mysql:
+      statements:
+        - sql: "SELECT SQL_CALC_FOUND_ROWS wpcompat_posts.ID FROM wpcompat_posts WHERE post_type = 'post' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 0, 2"
+          expect:
+            rows: 2
+            data:
+              - ID: 3
+              - ID: 2
+        - sql: "SELECT FOUND_ROWS() AS total"
+          expect:
+            rows: 1
+            data:
+              - total: 3
+
+  - name: "Filtered COUNT binds unqualified columns"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM wpcompat_comments
+      WHERE comment_approved = '1' AND comment_type NOT IN ('note')
+    expect:
+      rows: 1
+      data:
+        - total: 1
+
+  - name: "Explicit INNER JOIN supports a two-table lookup"
+    sql: |
+      SELECT t.term_id
+      FROM wpcompat_terms AS t INNER JOIN wpcompat_term_taxonomy AS tt ON t.term_id = tt.term_id
+      WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentyfive')
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - term_id: 1
+
+  - name: "Chained INNER JOIN supports DISTINCT and ORDER BY"
+    sql: |
+      SELECT DISTINCT t.term_id, tr.object_id
+      FROM wpcompat_terms AS t
+      INNER JOIN wpcompat_term_taxonomy AS tt ON t.term_id = tt.term_id
+      INNER JOIN wpcompat_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id
+      WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5)
+      ORDER BY t.name ASC
+    expect:
+      rows: 1
+      data:
+        - term_id: 1
+          object_id: 5
+
+  - name: "Empty grouped result may order by a non-projected source column"
+    sql: |
+      SELECT wpcompat_posts.ID
+      FROM wpcompat_posts
+      WHERE 1 = 1 AND wpcompat_posts.post_name IN ('front-page') AND (0 = 1)
+        AND wpcompat_posts.post_type = 'wp_template'
+        AND wpcompat_posts.post_status = 'publish'
+      GROUP BY wpcompat_posts.ID
+      ORDER BY wpcompat_posts.post_date DESC
+      LIMIT 0, 1
+    expect:
+      rows: 0
+
+  - name: "Grouped rows retain ordering by a non-projected source column"
+    sql: |
+      SELECT wpcompat_posts.ID
+      FROM wpcompat_posts
+      WHERE wpcompat_posts.post_type = 'post'
+      GROUP BY wpcompat_posts.ID
+      ORDER BY wpcompat_posts.post_date DESC
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - ID: 3
+        - ID: 2
+
+  - name: "INSERT accepts a MySQL zero datetime"
+    sql: "INSERT INTO wpcompat_posts (post_date, post_date_gmt, post_name, post_type, post_status) VALUES ('2026-08-26 10:00:00', '0000-00-00 00:00:00', 'auto-draft', 'post', 'auto-draft')"
+
+  - name: "MySQL zero datetime round-trips"
+    sql: "SELECT post_date_gmt FROM wpcompat_posts WHERE post_name = 'auto-draft'"
+    expect:
+      rows: 1
+      data:
+        - post_date_gmt: "0000-00-00 00:00:00"
+
+  - name: "Self-join combines escaped LIKE patterns and a generated key"
+    sql: |
+      SELECT a.option_id AS value_id, b.option_id AS timeout_id
+      FROM wpcompat_options a, wpcompat_options b
+      WHERE a.option_name LIKE '\_transient\_%'
+        AND a.option_name NOT LIKE '\_transient\_timeout\_%'
+        AND b.option_name = CONCAT('_transient_timeout_', SUBSTRING(a.option_name, 12))
+        AND b.option_value < 2
+    expect:
+      rows: 1
+      data:
+        - value_id: 1
+          timeout_id: 2
+
+  - name: "Escaped LIKE wildcards bind on the selected alias"
+    sql: |
+      SELECT a.option_id
+      FROM wpcompat_options a
+      WHERE a.option_name LIKE '\_transient\_%'
+        AND a.option_name NOT LIKE '\_transient\_timeout\_%'
+    expect:
+      rows: 1
+      data:
+        - option_id: 1
+
+  - name: "Self-join aliases match a CONCAT and SUBSTRING generated key"
+    sql: |
+      SELECT a.option_id AS value_id, b.option_id AS timeout_id
+      FROM wpcompat_options a, wpcompat_options b
+      WHERE a.option_name LIKE '\_transient\_%'
+        AND a.option_name NOT LIKE '\_transient\_timeout\_%'
+        AND b.option_name = CONCAT('_transient_timeout_', SUBSTRING(a.option_name, 12))
+    expect:
+      rows: 1
+      data:
+        - value_id: 1
+          timeout_id: 2
+
+  - name: "Numeric comparison coerces a TEXT operand"
+    sql: "SELECT option_id FROM wpcompat_options WHERE option_name = '_transient_timeout_sample' AND option_value < 2"
+    expect:
+      rows: 1
+      data:
+        - option_id: 2
+
+  - name: "Multi-table DELETE removes both joined targets"
+    sql: |
+      DELETE a, b FROM wpcompat_options a, wpcompat_options b
+      WHERE a.option_name LIKE '\_transient\_%'
+        AND a.option_name NOT LIKE '\_transient\_timeout\_%'
+        AND b.option_name = CONCAT('_transient_timeout_', SUBSTRING(a.option_name, 12))
+        AND b.option_value < 2
+    expect:
+      affected_rows: 2
+
+  - name: "Multi-table DELETE preserves non-matching rows"
+    sql: "SELECT option_name FROM wpcompat_options ORDER BY option_name"
+    expect:
+      rows: 1
+      data:
+        - option_name: "keep"
+
+  - name: "Multi-target DELETE without stable row identities fails explicitly"
+    sql: "DELETE a, b FROM wpcompat_no_primary_key a, wpcompat_no_primary_key b WHERE a.value = b.value"
+    expect:
+      error: true
+
+  - name: "Malformed SET NAMES remains rejected"
+    sql: "SET NAMES 'utf8mb4' COLLATE"
+    expect:
+      error: true
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS wpcompat_posts"
+  - sql: "DROP TABLE IF EXISTS wpcompat_comments"
+  - sql: "DROP TABLE IF EXISTS wpcompat_terms"
+  - sql: "DROP TABLE IF EXISTS wpcompat_term_taxonomy"
+  - sql: "DROP TABLE IF EXISTS wpcompat_term_relationships"
+  - sql: "DROP TABLE IF EXISTS wpcompat_options"
+  - sql: "DROP TABLE IF EXISTS wpcompat_mysql_leading"
+  - sql: "DROP TABLE IF EXISTS wpcompat_no_primary_key"

--- a/tests/sql/compatibility/mysql-client-introspection.yaml
+++ b/tests/sql/compatibility/mysql-client-introspection.yaml
@@ -1,3 +1,5 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
 # MySQL Client Introspection — DBeaver/CLI probes
 
 metadata:
@@ -37,6 +39,28 @@ test_cases:
 
   - name: "SET session variable to DEFAULT"
     sql: "SET optimizer_switch=DEFAULT"
+
+  - name: "SET NAMES accepts a connection collation"
+    sql: "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'"
+
+  - name: "Leading whitespace is ignored over the MySQL frontend"
+    sql: "\n\t SELECT 1 AS value"
+    expect:
+      rows: 1
+      data:
+        - value: 1
+
+  - name: "SQL_CALC_FOUND_ROWS modifier is accepted"
+    sql: "SELECT SQL_CALC_FOUND_ROWS 1 AS value LIMIT 1"
+    expect:
+      rows: 1
+      data:
+        - value: 1
+
+  - name: "Misspelled SQL_CALC_FOUND_ROWS modifier is rejected"
+    sql: "SELECT SQL_CALC_FOUND_ROW 1 AS value"
+    expect:
+      error: true
 
   - name: "mysqldump database collation probe is non-null"
     sql: "SELECT @@collation_database AS collation_database"


### PR DESCRIPTION
## What

- accept MySQL connection setup, DEFAULT CHARACTER SET, prefix keys, explicit INNER JOIN, SQL_CALC_FOUND_ROWS / FOUND_ROWS(), and zero datetimes
- preserve ordering by non-projected source columns in grouped queries
- implement escaped LIKE wildcard semantics
- support primary-key-backed multi-table DELETE without holding join read rights during writes
- keep the original, untrimmed SQL text for TracePrint and error logging; normalize only a separate parser input

## Correctness and deadlock prevention

Multi-table DELETE now completes all read-side key collection before starting any target mutation. This prevents the self-join reader/writer lock cycle seen in application cleanup queries. Targets without stable primary-key identities fail explicitly.

## Tests-first evidence

The new focused cases failed before their corresponding fixes and now pass:

- MySQL application SQL compatibility: 17/17
- DDL compatibility: 70/70
- MySQL client introspection: 12/12
- go test ./scm

The full suite is intentionally delegated to PR CI.