### PR TITLE
Bound wide predicate compilation and isolate physical query context

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -659,6 +659,40 @@ parent stages are merged into a multi-output stage. */
 		(make_query_block schema sources fields where group having order limit offset '() '() '())
 		_ query)))
 
+/* Binding must still validate every referenced column, even below a constant
+truth guard. Once binding has succeeded, an absorbing AND FALSE / OR TRUE can
+discard its siblings before decorrelation constructs stages for them. Inspect
+only the connective's immediate children: this keeps the check proportional to
+the shallow guard instead of walking the wide expression it is about to drop. */
+(define fold_bound_truth_guard (lambda (expr)
+	(match expr
+		(cons head tail) (if (expr_head_and? head)
+			(if (reduce tail (lambda (found term)
+				(or found (literal_false? term))) false)
+				false
+				expr)
+			(if (expr_head_or? head)
+				(if (reduce tail (lambda (found term)
+					(or found (literal_true? term))) false)
+					true
+					expr)
+				expr))
+		_ expr)))
+
+(define fold_bound_query_truth_guards (lambda (query)
+	(begin
+		(define normalized (normalize_query_ast query))
+		(if (query_block? normalized)
+			(make_query_block
+				(qb_schema normalized) (qb_sources normalized) (qb_fields normalized)
+				(fold_bound_truth_guard (qb_where normalized))
+				(qb_group normalized)
+				(if (nil? (qb_having normalized)) nil
+					(fold_bound_truth_guard (qb_having normalized)))
+				(qb_order normalized) (qb_limit normalized) (qb_offset normalized)
+				(qb_hidden normalized) (qb_stages normalized) (qb_facts normalized))
+			normalized))))
+
 (define query_block_no_from? (lambda (node)
 	(and (query_block? node)
 		(empty_list? (qb_sources node))
@@ -5656,7 +5690,8 @@ names in projections, predicates, and correlated subqueries. */
 (define untangle_query_term (lambda (query ctx)
 	(begin
 		(define bound_query (bind_query_names query '()))
-		(define root (require_unnested_node "untangle_query" (untangle_query bound_query ctx)))
+		(define guarded_query (fold_bound_query_truth_guards bound_query))
+		(define root (require_unnested_node "untangle_query" (untangle_query guarded_query ctx)))
 		(define ir (make_ir (if (union_block? root) (quote union) (quote select))
 			root
 			(if (query_block? root) (qb_stages root) '())

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1382,13 +1382,17 @@ membership set. */
 	(concat "__recset_probe_" (fnv_hash (gs_id stage)))))
 
 (define physical_query_session_symbol (lambda ()
-	(symbol "__physical_query_session")))
+	(quote __physical_query_session)))
 
 (define physical_query_scope_symbol (lambda ()
-	(symbol "__physical_query_scope")))
+	(quote __physical_query_scope)))
 
 (define physical_query_tx_symbol (lambda ()
-	(symbol "__physical_query_tx")))
+	(quote __physical_query_tx)))
+
+(define physical_query_symbol_named? (lambda (expr expected_name)
+	(and (symbol? expr)
+		(equal? (string expr) expected_name))))
 
 (define lower_recset_stage_prepare_once_expr (lambda (stage_catalog stage)
 	(list

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3250,11 +3250,11 @@ cost decision with an exact request-local observation and a crossover guard. */
 not live inside with_physical_query_context's lexical bindings. Rebind only the
 three physical context symbols; quoted data remains opaque. */
 (define ordered_recset_observation_expr (lambda (expr)
-	(if (equal? expr (physical_query_session_symbol))
+	(if (physical_query_symbol_named? expr "__physical_query_session")
 		(list (quote context) "session")
-		(if (equal? expr (physical_query_scope_symbol))
+		(if (physical_query_symbol_named? expr "__physical_query_scope")
 			(list (quote context) "query")
-			(if (equal? expr (physical_query_tx_symbol))
+			(if (physical_query_symbol_named? expr "__physical_query_tx")
 				(list (list (quote context) "session") "__memcp_tx")
 				(match expr
 					((symbol quote) _value) expr
@@ -6833,7 +6833,7 @@ though both handles are constant for the complete query generation. */
 		(define rewritten (rewrite_physical_transaction_reads plan))
 		(if (not (physical_plan_uses_query_scope? rewritten))
 			rewritten
-			(cons (quote !begin) (merge (list
+			(cons (quote begin) (merge (list
 				(list (list (quote define) (physical_query_session_symbol)
 					(list (quote context) "session")))
 				(list (list (quote define) (physical_query_scope_symbol)

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -182,7 +182,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(assert (equal? (ir_context_get (ir_context_of simple_ir) 'compile-budget-ms nil) 1000) true "untangle_query carries compile budget in context")
 	(assert (equal? (join_reorder simple_ir) simple_ir) true "join_reorder is an IR-only phase")
 	(define simple_physical_plan (build_queryplan_term simple_select_ast))
-	(assert (equal? (logical_op simple_physical_plan) '!begin) true "build_queryplan adds the physical query context boundary")
+	(assert (equal? (logical_op simple_physical_plan) 'begin) true "build_queryplan adds a lexical physical query context boundary")
 	(assert (equal? (logical_op (nth simple_physical_plan 4)) 'scan) true "build_queryplan lowers simple query-block to physical scan")
 	(assert (physical_relational_list_collector?
 		(list 'sort 'arbitrarily_renamed_rows (list 'lambda '(a b) true)))
@@ -823,7 +823,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		true nil nil nil nil nil))
 	(assert (expr_contains_subquery? (untangle_query_term scalar_no_from_ast nil)) false "untangle_query unnests zero-domain expression subqueries")
 	(define scalar_no_from_plan (build_queryplan_term scalar_no_from_ast))
-	(assert (equal? (logical_op scalar_no_from_plan) '!begin) true "zero-domain subqueries retain the physical query context boundary")
+	(assert (equal? (ordered_recset_observation_expr true) true) true "ordered RecSet observation preserves boolean literals")
+	(assert (equal? (logical_op scalar_no_from_plan) 'begin) true "zero-domain subqueries retain the lexical physical query context boundary")
 	(assert (equal? (serialize (nth scalar_no_from_plan 4))
 		"(resultrow '(\"x\" 8 \"in_ok\" (if (nil? 8) nil (if (nil? 8) nil (equal?? 8 8))) \"exists_ok\" true))") true "build_queryplan_term lowers zero-domain expression subqueries")
 	(define nested_catalog_stage (make_group_stage

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -23,8 +23,53 @@ import "sync"
 import packrat "github.com/launix-de/go-packrat/v2"
 
 type parserResult struct {
-	value Scmer
-	env   map[Symbol]Scmer
+	value         Scmer
+	env           map[Symbol]Scmer
+	variable      Symbol
+	variableValue Scmer
+	hasVariable   bool
+}
+
+func (r *parserResult) eachVariable(fn func(Symbol, Scmer)) {
+	if r == nil {
+		return
+	}
+	if r.hasVariable {
+		fn(r.variable, r.variableValue)
+	}
+	for key, value := range r.env {
+		fn(key, value)
+	}
+}
+
+func (r *parserResult) addVariable(key Symbol, value Scmer) {
+	if r.env != nil {
+		r.env[key] = value
+		return
+	}
+	if !r.hasVariable || r.variable == key {
+		r.variable = key
+		r.variableValue = value
+		r.hasVariable = true
+		return
+	}
+	r.env = map[Symbol]Scmer{
+		r.variable: r.variableValue,
+		key:        value,
+	}
+	r.variable = ""
+	r.variableValue = NewNil()
+	r.hasVariable = false
+}
+
+func (r *parserResult) variables() map[Symbol]Scmer {
+	if r.env != nil {
+		return r.env
+	}
+	if r.hasVariable {
+		return map[Symbol]Scmer{r.variable: r.variableValue}
+	}
+	return nil
 }
 
 type ScmParser struct {
@@ -63,8 +108,9 @@ func (b *ScmCaptureParser) Match(s *packrat.Scanner[*parserResult]) (packrat.Nod
 	matchedText := s.Substring(startPos, endPos)
 	// Return a list: (matched_text parsed_result)
 	result := []Scmer{NewString(matchedText), m.Payload.value}
-	env := m.Payload.env
-	return packrat.Node[*parserResult]{Payload: &parserResult{value: NewSlice(result), env: env}}, true
+	captured := *m.Payload
+	captured.value = NewSlice(result)
+	return packrat.Node[*parserResult]{Payload: &captured}, true
 }
 
 func parserSymbolEquals(v Scmer, name string) bool {
@@ -110,7 +156,7 @@ func (b *ScmParser) Match(s *packrat.Scanner[*parserResult]) (packrat.Node[*pars
 	} else {
 		var en2 Env
 		// evaluate parser
-		en2.Vars = m.Payload.env // take variable assignments
+		en2.Vars = m.Payload.variables() // take variable assignments
 		en2.Outer = b.Outer
 		en2.Nodefine = true
 		return packrat.Node[*parserResult]{Payload: &parserResult{value: Eval(b.Generator, &en2), env: nil}}, true
@@ -119,8 +165,8 @@ func (b *ScmParser) Match(s *packrat.Scanner[*parserResult]) (packrat.Node[*pars
 
 // TODO: create two variants of mergeParserResults, one where the result is not needed and thus nil can be returned as payload
 func mergeParserResults(s string, r ...*parserResult) *parserResult {
-	var env map[Symbol]Scmer
 	arr := make([]Scmer, 0, len(r))
+	result := &parserResult{}
 	for _, e := range r {
 		if e == nil {
 			continue
@@ -132,30 +178,19 @@ func mergeParserResults(s string, r ...*parserResult) *parserResult {
 			}
 		}
 		arr = append(arr, v)
-		if e.env != nil {
-			if env == nil {
-				env = make(map[Symbol]Scmer)
-			}
-			for k, v := range e.env {
-				env[k] = v
-			}
-		}
+		e.eachVariable(result.addVariable)
 	}
-	return &parserResult{value: NewSlice(arr), env: env}
+	result.value = NewSlice(arr)
+	return result
 }
 func mergeParserResultsNil(s string, r ...*parserResult) *parserResult {
-	var env map[Symbol]Scmer
+	result := &parserResult{value: NewNil()}
 	for _, e := range r {
-		if e != nil && e.env != nil {
-			if env == nil {
-				env = make(map[Symbol]Scmer)
-			}
-			for k, v := range e.env {
-				env[k] = v
-			}
+		if e != nil {
+			e.eachVariable(result.addVariable)
 		}
 	}
-	return &parserResult{value: NewNil(), env: env}
+	return result
 }
 
 func (b *ScmParser) Execute(str string, en *Env) Scmer {
@@ -176,12 +211,9 @@ func (b *ScmParserVariable) Match(s *packrat.Scanner[*parserResult]) (packrat.No
 	if !ok {
 		return m, ok
 	}
-	env := m.Payload.env
-	if env == nil {
-		env = make(map[Symbol]Scmer)
-	}
-	env[b.Variable] = m.Payload.value
-	return packrat.Node[*parserResult]{Payload: &parserResult{value: m.Payload.value, env: env}}, true
+	result := *m.Payload
+	result.addVariable(b.Variable, m.Payload.value)
+	return packrat.Node[*parserResult]{Payload: &result}, true
 }
 
 func parseSyntax(syntax Scmer, en *Env, ome *optimizerMetainfo, ignoreResult bool) packrat.Parser[*parserResult] {

--- a/tests/performance/constant-false-wide-predicate.yaml
+++ b/tests/performance/constant-false-wide-predicate.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Constant-false guards bound compilation of wide generated predicates"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS compile_schedule"
+  - sql: |
+      CREATE TABLE compile_schedule (
+        id INT PRIMARY KEY,
+        mode VARCHAR(32),
+        first_execution BIGINT,
+        last_execution BIGINT
+      )
+  - sql: "INSERT INTO compile_schedule VALUES (1, 'daily', 1700000000, 0)"
+
+test_cases:
+  - name: "A false guard discards a wide schedule predicate before decorrelation"
+    max_time: 5.0
+    scm: |
+      (begin
+        (define branch (lambda (i)
+          (concat
+            "(mode = 'yearly-date'"
+            " AND MONTH(FROM_UNIXTIME(first_execution)) = " (+ 1 (mod i 12))
+            " AND DAY(FROM_UNIXTIME(first_execution)) = " (+ 1 (mod i 28))
+            " AND first_execution <= CASE WHEN 1800000000 >= first_execution + " i
+            " THEN first_execution + " i " ELSE first_execution - " i " END"
+            " AND COALESCE(last_execution, 0) < CASE WHEN 1800000000 >= first_execution + " i
+            " THEN first_execution + " i " ELSE first_execution - " i " END)")))
+        (define predicate (reduce (produceN 400) (lambda (sql i)
+          (concat sql (if (equal? i 0) "" " OR ") (branch i))) ""))
+        (define query (concat
+          "SELECT id FROM compile_schedule WHERE (" predicate ") AND FALSE"))
+        (define session (newsession))
+        (session "username" "root")
+        (session "schema" "memcp-tests")
+        (define started (nanotime))
+        (cached_parse (newcachemap) parse_sql "memcp-tests" query
+          (lambda (_schema _table _write) true) "root" session false)
+        (define elapsed (- (nanotime) started))
+        (if (< elapsed 1200000000)
+          "ok"
+          (error (concat "constant-false wide predicate compiled in " elapsed "ns"))))
+    expect:
+      data: ["ok"]
+
+  - name: "Constant-false wide predicate returns no rows"
+    sql: |
+      SELECT id
+      FROM compile_schedule
+      WHERE (
+        mode = 'daily'
+        OR mode = 'monthly-day'
+        OR mode = 'yearly-date'
+      ) AND FALSE
+    expect:
+      rows: 0
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS compile_schedule"

--- a/tests/planner/subqueries/derived-table-limit-scalar.yaml
+++ b/tests/planner/subqueries/derived-table-limit-scalar.yaml
@@ -194,6 +194,58 @@ test_cases:
         - ID: 2
         - ID: 1
 
+  - name: "Drop cached correlated permission source"
+    sql: "DROP TABLE IF EXISTS dtl_cached_permission_base"
+
+  - name: "Create cached correlated permission source"
+    sql: "CREATE TABLE dtl_cached_permission_base (ID INT PRIMARY KEY, type_id INT, archive BOOL, sort_value INT)"
+
+  - name: "Compile correlated permission plan while driver is empty"
+    sql: |
+      SELECT t.*
+      FROM (
+        SELECT b.ID, b.type_id, b.archive, b.sort_value
+        FROM dtl_cached_permission_base b
+        WHERE COALESCE((
+          SELECT CASE WHEN TRUE THEN TRUE ELSE FALSE END
+          FROM dtl_ref permission_type
+          WHERE permission_type.ID = b.type_id
+          LIMIT 1
+        ), FALSE)
+      ) t
+      LEFT JOIN dtl_ref sorter ON sorter.ID = t.type_id
+      WHERE t.ID IN (1) AND (t.archive IS NULL OR t.archive = FALSE)
+      ORDER BY t.sort_value DESC LIMIT 72 OFFSET 0
+    expect:
+      rows: 0
+
+  - name: "Insert first driver after correlated permission plan was cached"
+    sql: "INSERT INTO dtl_cached_permission_base (ID, type_id, archive, sort_value) VALUES (1, 10, FALSE, 100)"
+
+  - name: "Cached correlated permission plan observes first driver"
+    sql: |
+      SELECT t.*
+      FROM (
+        SELECT b.ID, b.type_id, b.archive, b.sort_value
+        FROM dtl_cached_permission_base b
+        WHERE COALESCE((
+          SELECT CASE WHEN TRUE THEN TRUE ELSE FALSE END
+          FROM dtl_ref permission_type
+          WHERE permission_type.ID = b.type_id
+          LIMIT 1
+        ), FALSE)
+      ) t
+      LEFT JOIN dtl_ref sorter ON sorter.ID = t.type_id
+      WHERE t.ID IN (1) AND (t.archive IS NULL OR t.archive = FALSE)
+      ORDER BY t.sort_value DESC LIMIT 72 OFFSET 0
+    expect:
+      rows: 1
+      data:
+        - ID: 1
+          type_id: 10
+          archive: 0
+          sort_value: 100
+
   - name: "physical outer ORDER BY contains no scalar probe IR"
     sql: |
       EXPLAIN

--- a/third_party/go-packrat/parser.go
+++ b/third_party/go-packrat/parser.go
@@ -1,5 +1,5 @@
 /*
-	(c) 2019 Launix, Inh. Carl-Philip Hänsch
+	(c) 2019, 2026 Launix, Inh. Carl-Philip Hänsch
 	Author: Tim Kluge
 
 	Dual licensed with custom aggreements or GPLv3
@@ -19,8 +19,15 @@ type Parser[T any] interface {
 }
 
 func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
-	startPosition := s.position
+	// Terminals cannot participate in left recursion. Running them directly
+	// avoids memo-map, MemoEntry, and LR-frame allocations for every keyword,
+	// identifier, literal, and punctuation token in large inputs.
+	switch rule.(type) {
+	case *AtomParser[T], *RegexParser[T], *EmptyParser[T], *EndParser[T], *RestParser[T]:
+		return rule.Match(s)
+	}
 
+	startPosition := s.position
 	memmap := s.memoization[startPosition]
 	if memmap == nil {
 		memmap = make(map[Parser[T]]*MemoEntry[T])
@@ -65,7 +72,7 @@ func (s *Scanner[T]) applyRule(rule Parser[T]) (Node[T], bool) {
 var emptyString = ""
 
 type Node[T any] struct {
-	Payload  T
+	Payload T
 }
 
 type ParserError[T any] struct {


### PR DESCRIPTION
## Summary
- fold top-level absorbing boolean guards after name binding and before decorrelation
- avoid packrat memo/capture allocations on terminal-heavy generated SQL
- make ordered RecSet context-symbol rewriting type-safe and keep physical query bindings lexical
- add regressions for wide generated predicates and cached ordered scalar carriers populated after first compilation

## Evidence
- representative ~776 KB statement compile time reduced from about 1.61 s to about 0.78 s
- focused derived/ordered-scalar suite: 44/44 passed
- full `make test`: passed (`commit allowed`)
