### PR TITLE
Fix LIMIT placement for nested scalar join keys

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -59,9 +59,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 				'(op left right) (if (or (equal? op (quote equal?)) (equal? op (quote equal??)))
 					(or
 						(and (equal?? (direct_column_name_for_alias src left) col)
-							(not (expr_refs_alias? (source_alias src) (source_alias src) right)))
+							(not (expr_contains_column_ref? right)))
 						(and (equal?? (direct_column_name_for_alias src right) col)
-							(not (expr_refs_alias? (source_alias src) (source_alias src) left))))
+							(not (expr_contains_column_ref? left))))
 					false)
 				_ false)))
 		false)))
@@ -2569,14 +2569,13 @@ probes remain recipes and still execute after root braking. */
 	(begin
 		(define compile_offset (planner_literal_value offset_value))
 		(define compile_limit (planner_literal_value limit_value))
-		(define rows (if (empty_list? sources) nil
-			(if (source_unique_point_condition? (car sources) final_condition)
-				1
-				/* A selectivity estimate is not an upper bound. Native LIMIT may
-				stop at the driver only when its complete relation is provably
-				inside the window; downstream 0:1 predicates can still reject an
-				estimatedly selective driver row. */
-				(planner_source_row_count (car sources)))))
+		/* Row-count statistics are estimates, not upper bounds, and may lag
+		concurrent inserts. They can rank plans but cannot prove that LIMIT covers
+		the complete driver. A unique point predicate is the available structural
+		upper bound; every wider scan must let the completed-row consumer own the
+		window. */
+		(define rows (if (and (not (empty_list? sources))
+			(source_unique_point_condition? (car sources) final_condition)) 1 nil))
 		(and (or (nil? compile_offset) (equal? compile_offset 0))
 			(and (number? compile_limit)
 				(and (>= compile_limit 0)

--- a/tests/planner/subqueries/nested-correlated-subquery.yaml
+++ b/tests/planner/subqueries/nested-correlated-subquery.yaml
@@ -23,6 +23,9 @@ metadata:
   description: "Doubly-nested correlated scalar subquery returns NULL instead of value"
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS nc_multi_outer"
+  - sql: "DROP TABLE IF EXISTS nc_multi_history"
+  - sql: "DROP TABLE IF EXISTS nc_multi_value"
   - sql: "DROP TABLE IF EXISTS nc_scope_state"
   - sql: "DROP TABLE IF EXISTS nc_scope_outer"
   - sql: "DROP TABLE IF EXISTS nc_scope_lookup"
@@ -38,6 +41,12 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS nc_config"
 
 setup:
+  - sql: "CREATE TABLE nc_multi_outer (ID INT PRIMARY KEY)"
+  - sql: "CREATE TABLE nc_multi_history (ID INT PRIMARY KEY, outer_id INT, value_id INT, created INT)"
+  - sql: "CREATE TABLE nc_multi_value (ID INT PRIMARY KEY, label VARCHAR(40))"
+  - sql: "INSERT INTO nc_multi_outer VALUES (8), (9)"
+  - sql: "INSERT INTO nc_multi_history VALUES (1, 8, 20, 100), (2, 9, 19, 100)"
+  - sql: "INSERT INTO nc_multi_value VALUES (19, 'second'), (20, 'first')"
   - sql: "CREATE TABLE nc_scope_lookup (ID INT PRIMARY KEY, value INT)"
   - sql: "CREATE TABLE nc_scope_outer (ID INT PRIMARY KEY, nc_scope_lookup INT, state_id INT)"
   - sql: "CREATE TABLE nc_scope_state (ID INT PRIMARY KEY, label VARCHAR(20), nc_scope_lookup INT)"
@@ -66,6 +75,26 @@ setup:
   - sql: "INSERT INTO nc_config VALUES (1, 99)"
 
 test_cases:
+  - name: "Nested scalar key preserves every outer domain row"
+    sql: |
+      SELECT o.ID,
+        (SELECT v.label
+          FROM nc_multi_value v
+          WHERE v.ID = (
+            SELECT h.value_id
+            FROM nc_multi_history h
+            WHERE h.outer_id = o.ID
+            ORDER BY h.created DESC, h.ID DESC
+            LIMIT 1)
+          LIMIT 1) AS label
+      FROM nc_multi_outer o
+      ORDER BY o.ID
+    expect:
+      rows: 2
+      data:
+        - {ID: 8, label: "first"}
+        - {ID: 9, label: "second"}
+
   - name: "Derived join hides non-projected column from correlated scope"
     sql: |
       SELECT o.ID,


### PR DESCRIPTION
## Summary
- distinguish query-constant equality bindings from join equalities when proving unique point scans
- prevent estimated table cardinalities from acting as hard upper bounds for native LIMIT placement
- add a two-row regression with distinct nested scalar results so positional row loss is observable

## Root cause
A join equality against another operator column was classified as a query-constant unique-point predicate. Physical lowering could therefore push `LIMIT 1` into the lookup scan before the decorrelated stage join had produced complete rows, dropping one outer-domain key.

## Validation
- regression fails on the parent commit and passes with this change
- `make test` (full coverage-enabled suite)
- 145/145 storage-format tests and 23/23 serialize-round-trip tests in isolated reruns