### PR TITLE
Fix indexed filter selectivity estimates

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -562,11 +562,18 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 // Buffer size controls early-out granularity: use small buffers (e.g. [8]uint32)
 // for existence checks, large buffers (e.g. [1024]uint32) for full scans.
 func (t *storageShard) iterateIndex(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, nil, selected, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, nil, nil, selected, callback)
+}
+
+// iterateIndexEstimate additionally reports the complete candidate range found
+// by an active sorted index. Delta rows are included conservatively because
+// they are merged after the main range and may still satisfy the predicate.
+func (t *storageShard) iterateIndexEstimate(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, 0, false, nil, nil, candidateSpan, selected, callback)
 }
 
 func (t *storageShard) iterateIndexOrdered(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, limit int, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit}, selected, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit}, nil, selected, callback)
 }
 
 func (t *storageShard) iterateIndexForce(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
@@ -574,7 +581,7 @@ func (t *storageShard) iterateIndexForce(tx *TxContext, cols boundaries, lower [
 	if countUsage {
 		usageWeight = 1.0
 	}
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, true, nil, nil, nil, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, true, nil, nil, nil, nil, callback)
 }
 
 func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, exactMain *bool, callback func([]uint32) bool) {
@@ -582,7 +589,7 @@ func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols boundaries, lo
 	if countUsage {
 		usageWeight = 1.0
 	}
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, exactMain, nil, nil, callback)
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, exactMain, nil, nil, nil, callback)
 }
 
 func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, bool) {
@@ -597,7 +604,7 @@ func effectiveBoundaryInclusiveness(cols boundaries, lower []scm.Scmer) (bool, b
 	return true, true
 }
 
-func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 	if exactMain != nil {
 		*exactMain = false
 	}
@@ -665,7 +672,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 					}
 				}
 				// this index fits!
-				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, selected, callback)
+				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 				return
 			}
 		skip_index:
@@ -701,7 +708,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 				if covered {
 					// longer index covers this query; use it instead of creating a shorter one
 					t.indexMutex.Unlock()
-					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, selected, callback)
+					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 					return
 				}
 			}
@@ -781,7 +788,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		}
 		t.Indexes = append(t.Indexes, index)
 		t.indexMutex.Unlock()
-		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, selected, callback)
+		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 		return
 	}
 
@@ -1488,7 +1495,7 @@ func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds boundaries) 
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -1720,6 +1727,9 @@ start_scan:
 	}
 	mainStart := mainIdx
 	indexSpanRows = int64(mainEnd-mainStart) + int64(maxInsertIndex)
+	if candidateSpan != nil {
+		*candidateSpan = indexSpanRows
+	}
 	if hasRecSetBoundary {
 		rows := int64(0)
 		if recsetPart != nil {

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -69,7 +69,7 @@ func TestEstimateFilteredRowsReportsExaminedSample(t *testing.T) {
 	}
 }
 
-func TestEstimateFilteredRowsMarksCappedIndexPopulationAsLowerBound(t *testing.T) {
+func TestEstimateFilteredRowsRecognizesCompleteCappedIndexRange(t *testing.T) {
 	tbl, cols := scanColumnCostTable(t, "estimate_index_population", 10)
 	condition := scm.NewProcStruct(scm.Proc{
 		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("c0")}),
@@ -90,9 +90,74 @@ func TestEstimateFilteredRowsMarksCappedIndexPopulationAsLowerBound(t *testing.T
 	}
 
 	estimate := shard.EstimateFilteredRows(cols[:1], condition, 1, nil)
-	if estimate.rows != 1 || !estimate.capped || estimate.examined != 1 ||
-		estimate.population != "index_candidates" || estimate.coverage != "lower_bound" {
-		t.Fatalf("estimate = %+v; want capped index lower bound", estimate)
+	if estimate.rows != 1 || estimate.capped || estimate.examined != 1 ||
+		estimate.population != "index_candidates" || estimate.coverage != "exact" {
+		t.Fatalf("estimate = %+v; want complete one-row index range", estimate)
+	}
+}
+
+func TestScanSelectivityEstimateScalesIndexCandidatesByShardPopulation(t *testing.T) {
+	Init(scm.Globalenv)
+	dbName := "test_selectivity_index_population"
+	databases.Remove(dbName)
+	t.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("tenant", "INT", nil, nil)
+
+	values := make([][]scm.Scmer, 1000)
+	for row := range values {
+		values[row] = []scm.Scmer{scm.NewInt(int64(row % 10))}
+	}
+	tbl.Insert([]string{"tenant"}, values, nil, scm.NewNil(), false, nil)
+	RebuildTable(tbl, true, false)
+
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("tenant")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal?"), scm.NewSymbol("tenant"), scm.NewInt(4),
+		}),
+		En: &scm.Globalenv,
+	})
+	shard := tbl.ActiveShards()[0]
+	for range 2 {
+		bounds := extractBoundaries([]string{"tenant"}, condition)
+		lower, upperLast := indexFromBoundaries(bounds)
+		var buf [128]uint32
+		shard.mu.RLock()
+		shard.iterateIndex(nil, bounds, lower, upperLast, len(shard.inserts), buf[:], 100, nil,
+			func([]uint32) bool { return true })
+		shard.mu.RUnlock()
+	}
+	shardEstimate := shard.EstimateFilteredRows([]string{"tenant"}, condition, 512, nil)
+	if shardEstimate.population != "index_candidates" || shardEstimate.examined != 100 {
+		t.Fatalf("shard estimate = %+v, want 100 index candidates", shardEstimate)
+	}
+	boundedEstimate := shard.EstimateFilteredRows([]string{"tenant"}, condition, 50, nil)
+	if boundedEstimate.rows != 100 || boundedEstimate.capped ||
+		boundedEstimate.population != "index_candidates" || boundedEstimate.coverage != "upper_bound" {
+		t.Fatalf("bounded shard estimate = %+v, want 100-row index upper bound", boundedEstimate)
+	}
+
+	estimate := scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_selectivity_estimate")],
+		scm.NewNil(), NewTableScmer(tbl),
+		scm.NewSlice([]scm.Scmer{scm.NewString("tenant")}), condition, scm.NewInt(512))
+	fields := mustScmerSlice(estimate, "selectivity estimate")
+	fieldInt := func(name string) int64 {
+		for _, field := range fields {
+			pair := mustScmerSlice(field, "selectivity estimate field")
+			if scm.String(pair[0]) == name {
+				return int64(scm.ToInt(pair[1]))
+			}
+		}
+		t.Fatalf("missing selectivity estimate field %q", name)
+		return 0
+	}
+	if got := fieldInt("rows"); got != 100 {
+		t.Fatalf("estimated rows = %d, want 100", got)
+	}
+	if got := fieldInt("sampled"); got != 1000 {
+		t.Fatalf("sampled population = %d, want 1000", got)
 	}
 }
 

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2630,6 +2630,7 @@ type filteredRowEstimate struct {
 	rows       int64
 	capped     bool
 	examined   int64
+	universe   int64
 	population string
 	coverage   string
 }
@@ -2671,16 +2672,18 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	mainCount := t.main_count
+	visibleUniverse := int64(mainCount) + int64(len(t.inserts)) - int64(t.deletions.Count())
 	count := int64(0)
 	sampled := int64(0)
 	capped := false
 	indexRestricted := false
+	candidateSpan := int64(-1)
 	hookCandidates := int64(-1)
 	hookUniverse := int64(0)
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var buf [256]uint32
-	t.iterateIndex(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], 0, func(index *StorageIndex, active bool) {
+	t.iterateIndexEstimate(currentTx, bounds, lower, upperLast, len(t.inserts), buf[:], &candidateSpan, func(index *StorageIndex, active bool) {
 		indexRestricted = active && len(lower) > 0
 		if active {
 			if candidates, universe, ok := index.estimateHookCandidates(currentTx, bounds); ok {
@@ -2738,6 +2741,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		return filteredRowEstimate{
 			rows:       hookCandidates,
 			examined:   hookUniverse,
+			universe:   visibleUniverse,
 			population: "index_hook_candidates",
 			coverage:   "upper_bound",
 		}
@@ -2751,6 +2755,15 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	if capped {
 		if population == "table_rows" {
 			coverage = "sampled"
+		} else if candidateSpan >= 0 {
+			// The active sorted index already located both ends of its range.
+			// That span is a conservative match upper bound even when residual
+			// evaluation stopped at the row budget.
+			if candidateSpan > count {
+				count = candidateSpan
+				coverage = "upper_bound"
+			}
+			capped = false
 		} else {
 			coverage = "lower_bound"
 		}
@@ -2759,6 +2772,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		rows:       count,
 		capped:     capped,
 		examined:   sampled,
+		universe:   visibleUniverse,
 		population: population,
 		coverage:   coverage,
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -712,6 +712,25 @@ func Init(en scm.Env) {
 						scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(estimate.coverage)}),
 					})
 				}
+				// An ordinary index range examines only matching candidates. Its
+				// candidate count is the numerator of a shard sample, not the sample
+				// population itself. Scale it by the selected shard's visible row
+				// universe; using examined here turns every exact equality range into
+				// an apparent 100%-selective predicate.
+				if estimate.population == "index_candidates" && estimate.universe > 0 {
+					coverage := estimate.coverage
+					if len(shards) > 1 {
+						coverage = "sampled"
+					}
+					return scm.NewSlice([]scm.Scmer{
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(estimate.rows)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(estimate.capped)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("sampled"), scm.NewInt(estimate.universe)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("input"), scm.NewInt(input)}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("population"), scm.NewSymbol("table_rows")}),
+						scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol(coverage)}),
+					})
+				}
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("rows"), scm.NewInt(estimate.rows)}),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("capped"), scm.NewBool(estimate.capped)}),

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -2680,7 +2680,8 @@ test_cases:
                 (list (+ i 1) (concat "asset-" i) (concat "broad needle text " i)))))
             (insert (table "memcp-tests" "in_prefilter_doc") '("ID" "file_id" "tenant" "sort_key")
               (map (produceN 20000) (lambda (i)
-                (list (+ i 1) (+ i 1) (if (>= i 19900) 7 9) i))))
+                (list (+ i 1) (+ i 1)
+                  (if (>= i 19900) 7 (if (>= i 19148) 8 9)) i))))
             (rebuild)
             true)
     steps:
@@ -2719,6 +2720,30 @@ test_cases:
             - "recset_project_join"
             - "recset_intersect"
             - "scan_order"
+      - sql: "SELECT d.ID FROM in_prefilter_doc d WHERE d.tenant = 8"
+        expect:
+          rows: 752
+      - sql: "SELECT d.ID FROM in_prefilter_doc d WHERE d.tenant = 8"
+        expect:
+          rows: 752
+      - sql: |
+          EXPLAIN PHYSICAL
+          SELECT d.ID
+          FROM in_prefilter_doc d
+          WHERE d.tenant = 8
+            AND d.file_id IN (
+            SELECT f.ID FROM in_prefilter_file f WHERE f.filename LIKE '%missing%'
+            UNION
+            SELECT f.ID FROM in_prefilter_file f WHERE f.search LIKE '%also-missing%'
+          )
+          ORDER BY d.sort_key
+          LIMIT 10
+        expect:
+          rows: 1
+          contains:
+            - "membership_carrier"
+            - "prefiltered_driver_rows 752"
+            - "chosen prefiltered_candidate_keyset"
       - sql: |
           EXPLAIN PHYSICAL CALIBRATE
           SELECT d.ID


### PR DESCRIPTION
## Problem

An active ordinary equality index reported an estimate such as “752 matching rows out of 752 examined index candidates”. The global selectivity adapter treated the examined candidate count as the sample population, turning every exact equality range into an apparent 100% predicate.

That made the physical planner ignore a genuinely selective tenant/location restriction and build the membership carrier over the complete 855k-row driver.

## Fix

- carry the visible row universe of the selected shard with bounded filter estimates;
- normalize ordinary index candidate counts against that universe, not against matching candidates;
- expose the complete sorted-index candidate span already known after lower/upper bisect;
- use that span as a conservative upper bound when residual evaluation reaches its 512-row budget;
- preserve one-shard sampling and existing runtime-plan guards; no index-existence special case or new planner branch is introduced.

The existing cost model can now compare the real prefiltered cardinality and chooses the existing `prefiltered_candidate_keyset` topology.

## Regression coverage

The existing IN/subquery fixture now includes a 752-row selective domain and verifies after auto-index activation that `EXPLAIN PHYSICAL` reports:

- `prefiltered_driver_rows 752`
- `chosen prefiltered_candidate_keyset`

A Go regression independently verifies that a 100-row equality range in a 1,000-row shard is exposed as 100/1,000, including the bounded-estimation path.

## Validation

- focused storage estimate tests: pass
- `tests/planner/subqueries/in-subquery.yaml`: 71/71
- build and diff check: pass
- full SQL suite: CI

## Production-shaped A/B

For the same selective-domain fulltext query:

- before: physical estimate `prefiltered_driver_rows 855496`, chose `candidate_keyset`
- after: physical estimate `prefiltered_driver_rows 752`, chose `prefiltered_candidate_keyset`
- after timings: 11.49 s cold, 5.11 s warming, 1.54 s warm

## Storage safety

This changes only in-memory scan statistics and index range estimation. It does not alter persistence formats, cleanup, DDL, WAL, or engine transitions.