### PR TITLE
Reuse sorted index prefixes across boundary kinds

### DIFF
--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -466,3 +466,47 @@ func TestMatcherKindEqual(t *testing.T) {
 		t.Error("range and like should not be kind-equal")
 	}
 }
+
+func TestSortedIndexMatchersAreInterchangeable(t *testing.T) {
+	for _, query := range []IndexAnalyzer{EqualMatcher, RangeMatcher} {
+		for _, indexed := range []IndexAnalyzer{nil, EqualMatcher, RangeMatcher} {
+			if !indexMatcherCompatible(query, indexed) {
+				t.Fatalf("query matcher %v did not accept sorted index matcher %v", query, indexed)
+			}
+		}
+		if indexMatcherCompatible(query, LikeMatcher) {
+			t.Fatalf("query matcher %v accepted a custom LIKE index", query)
+		}
+	}
+}
+
+func TestEqualityPrefixRequiresActiveSortedIndex(t *testing.T) {
+	idx := &StorageIndex{Cols: []string{"a", "b"}}
+	shard := &storageShard{Indexes: []*StorageIndex{idx}}
+
+	if shard.hasEqualityIndexPrefix(nil, []string{"a"}) {
+		t.Fatal("inactive sorted index must not select the sparse RecSet lookup path")
+	}
+	idx.baseState.active = true
+	if !shard.hasEqualityIndexPrefix(nil, []string{"a"}) {
+		t.Fatal("active sorted compound index must cover its equality prefix")
+	}
+	idx.ColMatchers = []IndexAnalyzer{LikeMatcher, nil}
+	if shard.hasEqualityIndexPrefix(nil, []string{"a"}) {
+		t.Fatal("custom analyzer index must not cover an equality prefix")
+	}
+}
+
+func TestSnapshotDropsLegacySortedMatcherMetadata(t *testing.T) {
+	legacy := &StorageIndex{
+		Cols:        []string{"status", "id"},
+		ColMatchers: []IndexAnalyzer{EqualMatcher, RangeMatcher},
+	}
+	snapshot := snapshotIndexesForRebuild([]*StorageIndex{legacy})
+	if len(snapshot) != 1 {
+		t.Fatalf("snapshot count = %d, want 1", len(snapshot))
+	}
+	if len(snapshot[0].ColMatchers) != 0 {
+		t.Fatalf("snapshot retained sorted matcher metadata: %#v", snapshot[0].ColMatchers)
+	}
+}

--- a/storage/index.go
+++ b/storage/index.go
@@ -88,20 +88,18 @@ type StorageIndex struct {
 	Cols []string // sort equal-cols alphabetically, so similar conditions are canonical
 	// ColMapCols[i] and ColMapFn[i] are set for computed index columns (col starts with ".").
 	// Both are nil for raw columns.
-	ColMapCols  [][]string      // per-column source col names; nil entry means raw column
-	ColMapFn    []scm.Scmer     // per-column compute fn; IsNil() entry means raw column
-	ColMatchers []IndexAnalyzer // per-column analyzer (singleton: EqualMatcher/RangeMatcher/LikeMatcher)
+	ColMapCols [][]string  // per-column source col names; nil entry means raw column
+	ColMapFn   []scm.Scmer // per-column compute fn; IsNil() entry means raw column
+	// ColMatchers stores only custom, non-sorted analyzers. A nil entry (or an
+	// absent slice) denotes an ordinary sorted column; equal/range belong to the
+	// query boundary and are deliberately not persisted as index metadata.
+	ColMatchers []IndexAnalyzer
 	// ColOrder is the immutable per-column strict relation used by build, delta
 	// merge, lookup, and ordered scans. Each callback owns collation, direction,
 	// and NULL placement; storage must not infer or wrap those semantics.
-	ColOrder []func(...scm.Scmer) scm.Scmer
-	// ColOrderMeta is diagnostic metadata only. Equality and reuse are decided
-	// by canonical callback identity, never by reparsing this string.
+	ColOrder []func(scm.Scmer, scm.Scmer) bool
+	// ColOrderMeta identifies the source relation for equality and reuse checks.
 	ColOrderMeta []string
-	// ColOrderFast is derived once from ColOrder by the callback factory. It
-	// removes Scmer(bool) traffic from comparison loops without becoming a
-	// second source of ordering semantics.
-	ColOrderFast []func(scm.Scmer, scm.Scmer) bool
 	Savings      float64 // store the amount of time savings here -> add selectivity (outputted / size) on each
 	Native       bool    // true when data is physically sorted by this index (zero-cost)
 	t            *storageShard
@@ -125,14 +123,7 @@ func orderRelationMeta(order func(...scm.Scmer) scm.Scmer) string {
 	return fmt.Sprintf("callback:%x", scm.FunctionIdentity(order))
 }
 
-func sameOrderRelation(a, b func(...scm.Scmer) scm.Scmer) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
-	}
-	return scm.FunctionIdentity(a) == scm.FunctionIdentity(b)
-}
-
-func canonicalColumnOrder(t *table, col string) (func(...scm.Scmer) scm.Scmer, string) {
+func canonicalColumnOrder(t *table, col string) (func(scm.Scmer, scm.Scmer) bool, string) {
 	collation := "bin"
 	for _, definition := range t.Columns {
 		if definition.Name == col {
@@ -144,26 +135,23 @@ func canonicalColumnOrder(t *table, col string) (func(...scm.Scmer) scm.Scmer, s
 	}
 	value := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString(collation), scm.NewBool(false))
 	order := scm.OptimizeProcToSerialFunction(value)
-	return order, orderRelationMeta(order)
+	return scm.OrderRelationLess(order), orderRelationMeta(order)
 }
 
-func boundaryOrder(t *table, boundary columnboundaries) (func(...scm.Scmer) scm.Scmer, string) {
+func boundaryOrder(t *table, boundary columnboundaries) (func(scm.Scmer, scm.Scmer) bool, string) {
 	if boundary.order != nil {
 		meta := boundary.orderMeta
 		if meta == "" {
 			meta = orderRelationMeta(boundary.order)
 		}
-		return boundary.order, meta
+		return scm.OrderRelationLess(boundary.order), meta
 	}
 	return canonicalColumnOrder(t, boundary.col)
 }
 
 func (s *StorageIndex) lessAt(col int, a, b scm.Scmer) bool {
-	if col < len(s.ColOrderFast) && s.ColOrderFast[col] != nil {
-		return s.ColOrderFast[col](a, b)
-	}
 	if col < len(s.ColOrder) && s.ColOrder[col] != nil {
-		return scm.ToBool(s.ColOrder[col](a, b))
+		return s.ColOrder[col](a, b)
 	}
 	return scm.Less(a, b)
 }
@@ -182,11 +170,14 @@ func (s *StorageIndex) usesNaturalAscendingOrder(col int) bool {
 	if col >= len(s.ColOrder) || s.ColOrder[col] == nil {
 		return true
 	}
-	collation, reverse, ok := scm.LookupCollate(s.ColOrder[col])
-	if !ok || reverse {
+	if col >= len(s.ColOrderMeta) {
 		return false
 	}
-	switch collation {
+	meta := s.ColOrderMeta[col]
+	if !strings.HasSuffix(meta, ":asc") {
+		return false
+	}
+	switch strings.TrimSuffix(meta, ":asc") {
 	case "bin", "binary", "utf8", "utf8mb4":
 		return true
 	default:
@@ -200,7 +191,7 @@ func (s *StorageIndex) buildGetters(tx *TxContext) ([]colGetter, []string) {
 	getters := make([]colGetter, len(s.Cols))
 	sessionKeys := make([]string, 0)
 	for i, col := range s.Cols {
-		if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() && isScanPseudoColName(col) {
+		if !s.columnIsSorted(i) && isScanPseudoColName(col) {
 			continue
 		}
 		if len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil() {
@@ -277,9 +268,23 @@ func sameComputedRevisions(a, b []computedRevision) bool {
 	return true
 }
 
-// matcherKindEqual checks if two matchers have the same kind for index deduplication.
+// matcherKindEqual checks if two matchers have the same kind.
 func matcherKindEqual(a, b IndexAnalyzer) bool {
 	return a.Kind() == b.Kind()
+}
+
+// indexMatcherCompatible reports whether an index column can serve a query
+// boundary. Equal and range boundaries both use the same sorted index data;
+// only custom row matchers require an exact analyzer kind.
+func indexMatcherCompatible(query, indexed IndexAnalyzer) bool {
+	if query == nil || query.IsSorted() {
+		return indexed == nil || indexed.IsSorted()
+	}
+	return indexed != nil && matcherKindEqual(query, indexed)
+}
+
+func (idx *StorageIndex) columnIsSorted(i int) bool {
+	return len(idx.ColMatchers) <= i || idx.ColMatchers[i] == nil || idx.ColMatchers[i].IsSorted()
 }
 
 func (idx *StorageIndex) sessionVariantKey(tx *TxContext) string {
@@ -419,7 +424,8 @@ func (idx *StorageIndex) computeDeltaBtreeSize(state *storageIndexState) uint {
 	return sz
 }
 
-// pretty-print: name(like)|birthdate(range)
+// String describes the physical index. Equal/range are query properties, not
+// distinct index kinds, so only custom analyzers are included in the output.
 func (idx *StorageIndex) String() string {
 	var b strings.Builder
 	for i, col := range idx.Cols {
@@ -427,7 +433,7 @@ func (idx *StorageIndex) String() string {
 			b.WriteByte('|')
 		}
 		b.WriteString(col)
-		if len(idx.ColMatchers) > i && idx.ColMatchers[i] != nil {
+		if len(idx.ColMatchers) > i && idx.ColMatchers[i] != nil && !idx.ColMatchers[i].IsSorted() {
 			b.WriteByte('(')
 			b.WriteString(idx.ColMatchers[i].Kind())
 			b.WriteByte(')')
@@ -489,12 +495,12 @@ func (s *StorageIndex) getDeltaColValueTx(tx *TxContext, recid uint32, data []sc
 func (s *StorageIndex) rowWithinBounds(bounds boundaries, cmpCols int, lower []scm.Scmer, upperLast scm.Scmer, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
 	lastSorted := -1
 	for i := 0; i < cmpCols; i++ {
-		if len(s.ColMatchers) <= i || s.ColMatchers[i].IsSorted() {
+		if s.columnIsSorted(i) {
 			lastSorted = i
 		}
 	}
 	for i := 0; i < cmpCols; i++ {
-		if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() {
+		if !s.columnIsSorted(i) {
 			continue // non-sorted: block-skip handles this, scan() filters exact
 		}
 		v := getter(i)
@@ -532,7 +538,7 @@ func (s *StorageIndex) rowWithinBounds(bounds boundaries, cmpCols int, lower []s
 
 func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid uint32, mainGetters []colGetter, delta indexPair) int {
 	for i := range s.Cols {
-		if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() {
+		if !s.columnIsSorted(i) {
 			continue
 		}
 		mainVal := mainGetters[i].get(mainRecid)
@@ -653,13 +659,16 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 					if cols[i].col != index.Cols[i] {
 						goto skip_index // column mismatch
 					}
-					// matcher kind check (old indexes without ColMatchers are equal/range only)
-					if len(index.ColMatchers) > i && !matcherKindEqual(cols[i].matcher, index.ColMatchers[i]) {
+					var indexedMatcher IndexAnalyzer
+					if len(index.ColMatchers) > i {
+						indexedMatcher = index.ColMatchers[i]
+					}
+					if !indexMatcherCompatible(cols[i].matcher, indexedMatcher) {
 						goto skip_index // matcher kind mismatch
 					}
 					if cols[i].matcher.IsSorted() && !boundaryIsPoint(cols[i]) {
-						requiredOrder, _ := boundaryOrder(t.t, cols[i])
-						if len(index.ColOrder) <= i || !sameOrderRelation(requiredOrder, index.ColOrder[i]) {
+						_, requiredOrderMeta := boundaryOrder(t.t, cols[i])
+						if len(index.ColOrderMeta) <= i || requiredOrderMeta != index.ColOrderMeta[i] {
 							goto skip_index
 						}
 					}
@@ -686,13 +695,17 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 						covered = false
 						break
 					}
-					if len(index.ColMatchers) > i && !matcherKindEqual(cols[i].matcher, index.ColMatchers[i]) {
+					var indexedMatcher IndexAnalyzer
+					if len(index.ColMatchers) > i {
+						indexedMatcher = index.ColMatchers[i]
+					}
+					if !indexMatcherCompatible(cols[i].matcher, indexedMatcher) {
 						covered = false
 						break
 					}
 					if cols[i].matcher.IsSorted() && !boundaryIsPoint(cols[i]) {
-						requiredOrder, _ := boundaryOrder(t.t, cols[i])
-						if len(index.ColOrder) <= i || !sameOrderRelation(requiredOrder, index.ColOrder[i]) {
+						_, requiredOrderMeta := boundaryOrder(t.t, cols[i])
+						if len(index.ColOrderMeta) <= i || requiredOrderMeta != index.ColOrderMeta[i] {
 							covered = false
 							break
 						}
@@ -752,10 +765,8 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 		index.Cols = make([]string, indexCols)
 		index.ColMapCols = make([][]string, indexCols)
 		index.ColMapFn = make([]scm.Scmer, indexCols)
-		index.ColMatchers = make([]IndexAnalyzer, indexCols)
-		index.ColOrder = make([]func(...scm.Scmer) scm.Scmer, indexCols)
+		index.ColOrder = make([]func(scm.Scmer, scm.Scmer) bool, indexCols)
 		index.ColOrderMeta = make([]string, indexCols)
-		index.ColOrderFast = make([]func(scm.Scmer, scm.Scmer) bool, indexCols)
 		for i := 0; i < indexCols; i++ {
 			index.Cols[i] = cols[i].col
 			index.ColMapCols[i] = cols[i].mapCols // nil for raw columns
@@ -763,18 +774,21 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols boundaries, lower []sc
 			if !cols[i].mapFn.IsNil() {
 				index.sessionKeys = mergeSessionKeys(index.sessionKeys, extractSessionKeys(cols[i].mapFn))
 			}
-			index.ColMatchers[i] = cols[i].matcher // nil for equal/range
 			if cols[i].matcher.IsSorted() {
 				index.ColOrder[i], index.ColOrderMeta[i] = boundaryOrder(t.t, cols[i])
-				index.ColOrderFast[i] = scm.OrderRelationLess(index.ColOrder[i])
+			} else {
+				if index.ColMatchers == nil {
+					index.ColMatchers = make([]IndexAnalyzer, indexCols)
+				}
+				index.ColMatchers[i] = cols[i].matcher
 			}
 		}
 		index.Savings = 0.0            // count how many cost we wasted so we decide when to build the index
 		index.baseState.active = false // tell the engine that index has to be built first
 		index.t = t
 		index.Native = true
-		for _, matcher := range index.ColMatchers {
-			if matcher.IsSorted() {
+		for i := range index.Cols {
+			if index.columnIsSorted(i) {
 				index.Native = false
 				break
 			}
@@ -847,10 +861,17 @@ func snapshotIndexesForRebuild(indexes []*StorageIndex) []*StorageIndex {
 		clone.ColMapCols = idx.ColMapCols // shallow copy OK (immutable per-col slices)
 		clone.ColMapFn = idx.ColMapFn     // shallow copy OK
 		clone.sessionKeys = append([]string(nil), idx.sessionKeys...)
-		clone.ColMatchers = idx.ColMatchers // shallow copy OK (singletons)
-		clone.ColOrder = append([]func(...scm.Scmer) scm.Scmer(nil), idx.ColOrder...)
+		for i, matcher := range idx.ColMatchers {
+			if matcher == nil || matcher.IsSorted() {
+				continue
+			}
+			if clone.ColMatchers == nil {
+				clone.ColMatchers = make([]IndexAnalyzer, len(idx.ColMatchers))
+			}
+			clone.ColMatchers[i] = matcher
+		}
+		clone.ColOrder = append([]func(scm.Scmer, scm.Scmer) bool(nil), idx.ColOrder...)
 		clone.ColOrderMeta = append([]string(nil), idx.ColOrderMeta...)
-		clone.ColOrderFast = append([]func(scm.Scmer, scm.Scmer) bool(nil), idx.ColOrderFast...)
 		clone.Savings = idx.Savings * 0.9
 		clone.baseState.active = false
 		candidates = append(candidates, clone)
@@ -891,8 +912,19 @@ func rebuildIndexes(candidates []*StorageIndex, t2 *storageShard) {
 					isPrefix = false
 					break
 				}
-				if len(shorter.ColOrder) <= k || len(longer.ColOrder) <= k ||
-					!sameOrderRelation(shorter.ColOrder[k], longer.ColOrder[k]) {
+				var shorterMatcher, longerMatcher IndexAnalyzer
+				if len(shorter.ColMatchers) > k {
+					shorterMatcher = shorter.ColMatchers[k]
+				}
+				if len(longer.ColMatchers) > k {
+					longerMatcher = longer.ColMatchers[k]
+				}
+				if !indexMatcherCompatible(shorterMatcher, longerMatcher) {
+					isPrefix = false
+					break
+				}
+				if len(shorter.ColOrderMeta) <= k || len(longer.ColOrderMeta) <= k ||
+					shorter.ColOrderMeta[k] != longer.ColOrderMeta[k] {
 					isPrefix = false
 					break
 				}
@@ -967,10 +999,8 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		tmp := make([]uint32, s.t.main_count)
 		relations := make([]func(scm.Scmer, scm.Scmer) bool, len(cols))
 		for i := range relations {
-			if i < len(s.ColOrderFast) && s.ColOrderFast[i] != nil {
-				relations[i] = s.ColOrderFast[i]
-			} else if i < len(s.ColOrder) && s.ColOrder[i] != nil {
-				relations[i] = scm.OrderRelationLess(s.ColOrder[i])
+			if i < len(s.ColOrder) && s.ColOrder[i] != nil {
+				relations[i] = s.ColOrder[i]
 			} else {
 				relations[i] = scm.Less
 			}
@@ -997,7 +1027,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		materialized := make([]scm.Scmer, mainCount*uint(numCols))
 		hasSortCol := make([]bool, numCols)
 		for colIdx, g := range cols {
-			if len(s.ColMatchers) > colIdx && !s.ColMatchers[colIdx].IsSorted() {
+			if !s.columnIsSorted(colIdx) {
 				continue // query-level overlay column: never read by the comparator below
 			}
 			hasSortCol[colIdx] = true
@@ -1040,7 +1070,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			state.minVals = make([]scm.Scmer, len(cols))
 			state.maxVals = make([]scm.Scmer, len(cols))
 			for i, g := range cols {
-				if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() {
+				if !s.columnIsSorted(i) {
 					continue
 				}
 				state.minVals[i] = g.get(tmp[0])
@@ -1052,7 +1082,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		state.minVals = make([]scm.Scmer, len(cols))
 		state.maxVals = make([]scm.Scmer, len(cols))
 		for i, g := range cols {
-			if len(s.ColMatchers) > i && !s.ColMatchers[i].IsSorted() {
+			if !s.columnIsSorted(i) {
 				continue
 			}
 			state.minVals[i] = g.get(0)
@@ -1071,7 +1101,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		// Repeated predicates of the same index kind bind independently but
 		// share their shard-local cache.
 		for previous := 0; previous < colIdx; previous++ {
-			if s.Cols[previous] == s.Cols[colIdx] && matcherKindEqual(s.ColMatchers[previous], analyzer) {
+			if s.Cols[previous] == s.Cols[colIdx] && s.ColMatchers[previous] != nil && matcherKindEqual(s.ColMatchers[previous], analyzer) {
 				state.indexHooks[colIdx] = state.indexHooks[previous]
 				break
 			}
@@ -1107,7 +1137,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			compareCols = b.compareCols
 		}
 		for colIdx := 0; colIdx < compareCols; colIdx++ {
-			if len(s.ColMatchers) > colIdx && !s.ColMatchers[colIdx].IsSorted() {
+			if !s.columnIsSorted(colIdx) {
 				continue
 			}
 			var av, bv scm.Scmer
@@ -1135,7 +1165,7 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 		if len(s.sessionKeys) > 0 {
 			values := make([]scm.Scmer, len(s.Cols))
 			for colIdx := range s.Cols {
-				if len(s.ColMatchers) > colIdx && !s.ColMatchers[colIdx].IsSorted() {
+				if !s.columnIsSorted(colIdx) {
 					continue
 				}
 				values[colIdx] = s.getDeltaColValueTx(tx, recid, data, colIdx)

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -50,6 +50,12 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	if shard.Indexes[0].Savings != 0 {
 		t.Fatalf("estimate must not count as index usage, savings = %v", shard.Indexes[0].Savings)
 	}
+	if len(shard.Indexes[0].ColMatchers) != 0 {
+		t.Fatalf("sorted index persisted redundant matcher metadata: %#v", shard.Indexes[0].ColMatchers)
+	}
+	if got := shard.Indexes[0].String(); got != "id" {
+		t.Fatalf("sorted index description = %q, want %q", got, "id")
+	}
 	if shard.Indexes[0].baseState.active {
 		t.Fatal("estimate must not materialize a cold auto-index before real usage")
 	}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -999,14 +999,21 @@ func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []st
 	return result
 }
 
-// hasEqualityIndexPrefix reports whether an existing index already covers
-// cols as an equality prefix, without triggering a build. The sparse
+// hasEqualityIndexPrefix reports whether an active index already covers cols
+// as an equality prefix, without triggering a build. The sparse
 // per-key lookup path below is only cheap when such an index already
 // exists; forcing one into existence for a single ad-hoc query can cost far
 // more than the linear scan it was meant to avoid.
-func (t *storageShard) hasEqualityIndexPrefix(cols []string) bool {
+func (t *storageShard) hasEqualityIndexPrefix(currentTx *TxContext, cols []string) bool {
 	for _, index := range t.Indexes {
 		if len(index.Cols) < len(cols) {
+			continue
+		}
+		state := index.stateForTx(currentTx, false)
+		index.mu.Lock()
+		active := state != nil && state.active
+		index.mu.Unlock()
+		if !active {
 			continue
 		}
 		match := true
@@ -1015,7 +1022,11 @@ func (t *storageShard) hasEqualityIndexPrefix(cols []string) bool {
 				match = false
 				break
 			}
-			if len(index.ColMatchers) > i && !matcherKindEqual(EqualMatcher, index.ColMatchers[i]) {
+			var indexedMatcher IndexAnalyzer
+			if len(index.ColMatchers) > i {
+				indexedMatcher = index.ColMatchers[i]
+			}
+			if !indexMatcherCompatible(EqualMatcher, indexedMatcher) {
 				match = false
 				break
 			}
@@ -1064,7 +1075,7 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 	visibleUpper := t.main_count + uint32(maxInsertIndex)
 	numericDense := numeric && len(targetCols) == 1 && projectJoinNumericColumn(targetCols[0])
 	dense := projectJoinDensePreferred(keys.count(), int(visibleUpper), numericDense,
-		t.hasEqualityIndexPrefix(targetKeyCols))
+		t.hasEqualityIndexPrefix(currentTx, targetKeyCols))
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	if dense {
 		builder := newRecSetShardBuilder(t, visibleUpper, true, t.main_count)

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -472,7 +472,11 @@ func indexCoversBoundaryOrder(index *StorageIndex, active bool, bounds boundarie
 		if i >= effectiveCols || i >= len(index.Cols) || i >= len(index.ColOrder) {
 			return false
 		}
-		if index.Cols[i] != boundary.col || !sameOrderRelation(index.ColOrder[i], boundary.order) {
+		orderMeta := boundary.orderMeta
+		if orderMeta == "" {
+			orderMeta = orderRelationMeta(boundary.order)
+		}
+		if index.Cols[i] != boundary.col || i >= len(index.ColOrderMeta) || index.ColOrderMeta[i] != orderMeta {
 			return false
 		}
 	}

--- a/tests/storage/indexes/fulltext-like-index.yaml
+++ b/tests/storage/indexes/fulltext-like-index.yaml
@@ -119,7 +119,7 @@ test_cases:
           (begin
             (define cols (get_assoc index "cols"))
             (or found (and
-              (strlike cols "%id(equal)%" "utf8mb4_bin")
+              (strlike cols "id|%vorname(like)%" "utf8mb4_bin")
               (strlike cols "%vorname(like)%" "utf8mb4_bin"))))) false))
         (if bad
           (error "point lookup built a full-table LIKE matcher index")

--- a/tests/storage/indexes/index-prefix-dedup.yaml
+++ b/tests/storage/indexes/index-prefix-dedup.yaml
@@ -82,7 +82,7 @@ test_cases:
         (set indexes ((show "memcp-tests" "idx_nopfx" 0 true) "indexes"))
         (set idx (nth indexes 0))
         (set cols (get_assoc idx "cols"))
-        (if (equal? cols "a(equal)|b(equal)") "ok"
+        (if (equal? cols "a|b") "ok"
           (error (concat "expected a|b, got " cols))))
 
   - name: "Compound index has accumulated savings from prefix queries"
@@ -118,7 +118,7 @@ test_cases:
         (set indexes ((show "memcp-tests" "idx_nopfx" 0 true) "indexes"))
         (set idx (nth indexes 0))
         (set cols (get_assoc idx "cols"))
-        (if (equal? cols "a(equal)|b(equal)") "ok"
+        (if (equal? cols "a|b") "ok"
           (error (concat "expected a|b after rebuild, got " cols))))
 
   - name: "Post-rebuild: savings decayed (< pre-rebuild value)"
@@ -225,7 +225,7 @@ test_cases:
         (set indexes ((show "memcp-tests" "idx_rev" 0 true) "indexes"))
         (set idx (nth indexes 0))
         (set cols (get_assoc idx "cols"))
-        (if (equal? cols "p(equal)|q(equal)") "ok"
+        (if (equal? cols "p|q") "ok"
           (error (concat "expected p|q, got " cols))))
 
   - name: "Post-rebuild: merged savings from both indexes"
@@ -617,7 +617,46 @@ test_cases:
         - ID: 8
         - ID: 9
 
+  # ==============================================================
+  # Phase 8: equal/range query boundaries share one sorted index
+  # ==============================================================
+
+  - name: "Setup matcher-independent sorted index table"
+    setup:
+      - sql: "DROP TABLE IF EXISTS idx_matcher_reuse"
+    sql: "CREATE TABLE idx_matcher_reuse (a INT, b INT)"
+
+  - name: "Populate matcher-independent sorted index table"
+    sql: |
+      INSERT INTO idx_matcher_reuse VALUES
+        (1, 10), (2, 20), (3, 30), (4, 40),
+        (5, 50), (6, 60), (7, 70), (8, 80)
+
+  - name: "Create compound index through equal and range boundaries"
+    sql: "SELECT b FROM idx_matcher_reuse WHERE a = 4 AND b > 0"
+    expect:
+      data:
+        - b: 40
+
+  - name: "Range boundary reuses equal prefix"
+    sql: "SELECT a FROM idx_matcher_reuse WHERE a > 6 ORDER BY a"
+    expect:
+      data:
+        - a: 7
+        - a: 8
+
+  - name: "Sorted matcher metadata is omitted and no prefix index is created"
+    scm: |
+      (begin
+        (set indexes ((show "memcp-tests" "idx_matcher_reuse" 0 true) "indexes"))
+        (if (and (equal? (count indexes) 1)
+                 (equal? (get_assoc (nth indexes 0) "cols") "a|b"))
+          "ok"
+          (error "expected one matcher-independent a|b index")))
+
 cleanup:
+
+  - sql: "DROP TABLE IF EXISTS idx_matcher_reuse"
   - sql: "DROP TABLE IF EXISTS idx_prefix_or_range"
   - sql: "DROP TABLE IF EXISTS idx_desc_delta_prefix"
   - sql: "DROP TABLE IF EXISTS idx_nopfx"


### PR DESCRIPTION
## Summary
- treat equality and range predicates as boundaries over the same sorted physical index
- store each index collation directly as a bool Less(a, b) relation and omit equal/range matcher metadata from index state and dashboard output
- reuse longer compatible indexes by prefix and merge redundant prefix indexes during rebuild
- retain custom analyzer metadata and require compatible collation/order metadata
- only select the sparse RecSet lookup path when the compatible sorted prefix index is already active

## Correctness details
- NULL placement remains part of the stored Less relation
- lower/upper values and inclusive/exclusive flags remain query-local traversal boundaries
- custom matchers such as LIKE remain distinct

## Tests
- targeted Go storage tests pass
- index-prefix-dedup: 75/75
- fulltext-like-index: 86/86
- order-limit: 48/48 on a fresh instance
- acl-boolean-membership-scaling: 30/30 on a fresh instance
- full hook was also exercised; under the shared coverage run, existing hard timing/global scan-stat checks were load-sensitive, while both affected suites pass in isolation