### PR TITLE
Invalidate computed lookup caches by row

### DIFF
--- a/storage/compute.go
+++ b/storage/compute.go
@@ -869,18 +869,30 @@ type scanJoinInfo struct {
 // filter lambda. If the filter cannot be analyzed, the info is returned with
 // empty srcCols/inputCols so callers can fall back to full invalidation.
 func extractScanJoinInfo(computor scm.Scmer) []scanJoinInfo {
-	if computor.IsProc() {
-		return extractScanJoinInfoBody(computor.Proc().Body)
-	}
-	return extractScanJoinInfoBody(computor)
+	return extractScanJoinInfoBody(computor, nil)
 }
 
-func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
+func extractScanJoinInfoBody(expr scm.Scmer, outerParams []scm.Scmer) []scanJoinInfo {
 	expr = stripSourceInfo(expr)
+	if expr.IsProc() {
+		proc := expr.Proc()
+		params := outerParams
+		paramExpr := stripSourceInfo(proc.Params)
+		if paramExpr.IsSlice() {
+			params = paramExpr.Slice()
+		}
+		return extractScanJoinInfoBody(proc.Body, params)
+	}
 	if !expr.IsSlice() {
 		return nil
 	}
 	items := expr.Slice()
+	if len(items) >= 3 && callHeadIs(items[0], "lambda") {
+		paramExpr := stripSourceInfo(items[1])
+		if paramExpr.IsSlice() {
+			return extractScanJoinInfoBody(items[2], paramExpr.Slice())
+		}
+	}
 	if len(items) >= 5 && callHeadIs(items[0], "scan", "scan_order", "scalar_scan", "scalar_scan_order") {
 		tableIdx := 2
 		condColsIdx, filterIdx := 3, 4
@@ -918,7 +930,7 @@ func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
 			info.mapCols = extractStringListFromAST(items[5])
 		}
 		if len(condCols) > 0 {
-			info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols)
+			info.srcCols, info.inputCols = extractEqualityJoins(items[filterIdx], condCols, outerParams)
 		}
 		// A physical table expression can itself be a plan (for example a
 		// recset_project_join whose producer prepares correlated stage caches).
@@ -926,26 +938,43 @@ func extractScanJoinInfoBody(expr scm.Scmer) []scanJoinInfo {
 		// scans in the filter and mapper are; otherwise source mutations leave a
 		// cached aggregate valid even though its projected input changed.
 		result := []scanJoinInfo{info}
-		result = append(result, extractScanJoinInfoBody(tableExpr)...)
+		result = append(result, extractScanJoinInfoBody(tableExpr, outerParams)...)
 		for _, item := range items[filterIdx+1:] {
-			result = append(result, extractScanJoinInfoBody(item)...)
+			result = append(result, extractScanJoinInfoBody(item, outerParams)...)
 		}
 		return result
 	}
 	var result []scanJoinInfo
 	for _, item := range items {
-		result = append(result, extractScanJoinInfoBody(item)...)
+		result = append(result, extractScanJoinInfoBody(item, outerParams)...)
 	}
 	return result
 }
 
-// extractStringListFromAST parses (list "a" "b" ...) into a Go string slice.
-// The first element may be the symbol "list" or a resolved native function.
+// extractStringListFromAST parses both (list "a" "b" ...) and the quoted
+// column-list form '("a" "b") emitted by physical scan plans.
 func extractStringListFromAST(expr scm.Scmer) []string {
+	expr = stripSourceInfo(expr)
 	if !expr.IsSlice() {
 		return nil
 	}
 	items := expr.Slice()
+	if len(items) == 2 && callHeadIs(items[0], "quote") {
+		literal := stripSourceInfo(items[1])
+		if !literal.IsSlice() {
+			return nil
+		}
+		items = literal.Slice()
+		result := make([]string, len(items))
+		for i, item := range items {
+			item = stripSourceInfo(item)
+			if !item.IsString() {
+				return nil
+			}
+			result[i] = item.String()
+		}
+		return result
+	}
 	if len(items) < 2 {
 		return nil
 	}
@@ -974,7 +1003,7 @@ func extractStringListFromAST(expr scm.Scmer) []string {
 // extractEqualityJoins inspects a filter lambda for patterns like
 // (equal? filterParam (outer inputCol)) and returns matched srcCol/inputCol pairs.
 // filterParam is matched by position against condCols.
-func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inputCols []string) {
+func extractEqualityJoins(filterExpr scm.Scmer, condCols []string, computorParams []scm.Scmer) (srcCols, inputCols []string) {
 	var params []scm.Scmer
 	var body scm.Scmer
 	filterExpr = stripSourceInfo(filterExpr)
@@ -987,10 +1016,11 @@ func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inp
 	} else if filterExpr.IsSlice() {
 		items := filterExpr.Slice()
 		if len(items) >= 3 && callHeadIs(items[0], "lambda") {
-			if items[1].IsSlice() {
-				params = items[1].Slice()
+			paramExpr := stripSourceInfo(items[1])
+			if paramExpr.IsSlice() {
+				params = paramExpr.Slice()
 			}
-			body = items[2]
+			body = stripSourceInfo(items[2])
 		}
 	}
 	if len(params) == 0 || body.IsNil() {
@@ -1005,9 +1035,9 @@ func extractEqualityJoins(filterExpr scm.Scmer, condCols []string) (srcCols, inp
 	}
 	equalities := collectEqualities(body)
 	for _, eq := range equalities {
-		pIdx, iCol := matchJoinEquality(eq[0], eq[1], paramIdx, len(params), nil)
+		pIdx, iCol := matchJoinEquality(eq[0], eq[1], paramIdx, len(params), computorParams)
 		if pIdx < 0 {
-			pIdx, iCol = matchJoinEquality(eq[1], eq[0], paramIdx, len(params), nil)
+			pIdx, iCol = matchJoinEquality(eq[1], eq[0], paramIdx, len(params), computorParams)
 		}
 		if pIdx >= 0 && pIdx < len(condCols) {
 			srcCols = append(srcCols, condCols[pIdx])
@@ -1070,6 +1100,20 @@ func matchJoinEquality(a, b scm.Scmer, paramIdx map[string]int, paramCount int, 
 			inner := stripSourceInfo(bItems[1])
 			if inner.IsSymbol() {
 				return idx, inner.String()
+			}
+			if inner.IsNthLocalVar() && computorParams != nil {
+				outerIdx := int(inner.NthLocalVar())
+				// A compiled filter numbers its own parameters first and
+				// closure captures afterwards.  Raw ASTs have no such offset.
+				if outerIdx >= paramCount {
+					outerIdx -= paramCount
+				}
+				if outerIdx >= 0 && outerIdx < len(computorParams) {
+					param := stripSourceInfo(computorParams[outerIdx])
+					if param.IsSymbol() {
+						return idx, param.String()
+					}
+				}
 			}
 			if inner.IsSlice() {
 				gcItems := inner.Slice()
@@ -1407,8 +1451,33 @@ func mergeUniqueStrings(parts ...[]string) []string {
 	return result
 }
 
-func scanRelevantSourceCols(ref scanJoinInfo) []string {
-	return mergeUniqueStrings(ref.condCols, ref.mapCols)
+func scanRelevantSourceCols(ref scanJoinInfo, srcTable *table) []string {
+	result := mergeUniqueStrings(ref.condCols, ref.mapCols)
+	if srcTable == nil {
+		return result
+	}
+
+	// Trigger rows do not materialize runtime-computed columns. If a scan reads
+	// one, comparing OLD/NEW for that column would therefore compare nil with nil
+	// and incorrectly suppress the dependency trigger. Expand it to the physical
+	// source columns that can change its value. The traversal is transitive and
+	// cycle-safe so nested lookup and ordered caches keep their invalidation edge.
+	seen := make(map[string]bool, len(result))
+	for i := 0; i < len(result); i++ {
+		name := result[i]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		for _, col := range srcTable.Columns {
+			if col.Name != name || !isRuntimeComputedColumn(col) {
+				continue
+			}
+			result = mergeUniqueStrings(result, col.ComputorInputCols, col.OrcSortCols, col.OrcMapCols)
+			break
+		}
+	}
+	return result
 }
 
 func buildColsChangedExpr(cols []string) scm.Scmer {
@@ -1724,7 +1793,7 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 
 		// Determine trigger bodies: selective if join pairs are available
 		selective := len(ref.srcCols) > 0 && len(ref.srcCols) == len(ref.inputCols)
-		relevantCols := scanRelevantSourceCols(ref)
+		relevantCols := scanRelevantSourceCols(ref, srcTable)
 
 		// Check if this scan is an additive aggregate eligible for incremental update.
 		var scanNode []scm.Scmer
@@ -1761,8 +1830,15 @@ func (t *table) registerComputeTriggers(name string, computor scm.Scmer) {
 					} else {
 						body = buildIncrementalBody(targetSchema, t.Name, name, ref.srcCols, ref.inputCols, scanNode[mapColsIdx], scanNode[mapFnIdx], timing)
 					}
+				} else if selective {
+					// A scalar/lookup computor with analyzable equality keys defines an
+					// exact reverse mapping from the changed source key to cache rows.
+					// Preserve that subset; $invalidate batches record IDs and applies
+					// the invalidations only after the maintenance scan releases locks.
+					body = buildSelectiveInvalidationBody(targetSchema, t.Name, name, ref.srcCols, ref.inputCols, timing)
 				} else {
-					// Full invalidation: for non-additive aggregates and AfterInvalidate propagation.
+					// Opaque scans have no proven reverse mapping. They must retain the
+					// complete invalidation fallback for correctness.
 					tblExpr := scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(targetSchema), scm.NewString(t.Name)})
 					body = scm.NewSlice([]scm.Scmer{
 						scm.NewSymbol("invalidatecolumn"),
@@ -1877,7 +1953,7 @@ func (t *table) registerORCDependencyTriggers(name string, col *column, refs []s
 			continue
 		}
 		selective := len(ref.srcCols) > 0 && len(ref.srcCols) == len(ref.inputCols)
-		relevantCols := scanRelevantSourceCols(ref)
+		relevantCols := scanRelevantSourceCols(ref, srcTable)
 		for _, timing := range []TriggerTiming{AfterInsert, AfterUpdate, AfterDelete} {
 			triggerName := ".orcdep:" + t.Name + ":" + name + "|scan" + strconv.Itoa(refIdx) + "|" + srcTable.Name + "|" + timing.String()
 			exists := false

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -1097,8 +1097,18 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 			scmer.SetValue(idx, val)
 			return // stay compressed, no bitmap change needed
 		}
-		// main is compressed type → can't SetValue → fall back to lazy
-		p.compressed = false
+		// Compressed immutable storages cannot update in place. Keep the compact
+		// base column and install one sparse override instead of switching the
+		// complete proxy back to lazy mode: validMask is intentionally empty after
+		// Compress(), so that transition would make every unrelated row look stale.
+		if idx < p.count {
+			colvalues := make([]scm.Scmer, len(p.inputCols))
+			for i, col := range p.inputCols {
+				colvalues[i] = p.shard.getColumnStorageOrPanic(col).GetValue(idx)
+			}
+			p.delta[idx] = applyWithTx(CurrentTx(), p.computor, colvalues...)
+			return
+		}
 	}
 	p.validMask.Set(uint(idx), false)
 	delete(p.delta, idx)

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -124,9 +124,10 @@ type StorageComputeProxy struct {
 	// Validity is tracked per-row via validMask (1=valid, 0=needs compute).
 	// Invalidation sets bits to 0; on-demand recompute sets them back to 1.
 	isOrdered bool
-	// Invalidation telemetry: tracks cumulative cost of selective invalidations
-	// since last read. When invalidation cost exceeds last recompute cost,
-	// switches to InvalidateAll() to avoid death-by-a-thousand-cuts.
+	// Invalidation telemetry compares measured selective maintenance with the
+	// last complete or suffix recompute. It is an operator-local runtime gate:
+	// exact row invalidation is retained when it is cheaper, while broad fanout
+	// can fall back to InvalidateAll instead of serially recomputing most rows.
 	invalidateNsSinceRead atomic.Int64  // cumulative invalidation nanoseconds since last read
 	lastRecomputeNs       atomic.Int64  // nanoseconds of the last full/suffix recompute
 	revision              atomic.Uint64 // logical value changes; index readers use this for lazy invalidation
@@ -942,6 +943,8 @@ func (p *StorageComputeProxy) GetCachedReader() ColumnReader {
 
 // Compress materializes all values into a compressed main storage.
 func (p *StorageComputeProxy) Compress() {
+	compressStart := time.Now()
+	compressedNow := false
 	tx := CurrentTx()
 	if variant := p.currentVariant(tx, true); variant != nil {
 		p.compressVariant(variant, tx)
@@ -959,6 +962,7 @@ func (p *StorageComputeProxy) Compress() {
 		}
 		if p.count == 0 {
 			p.compressed = true
+			compressedNow = true
 			return
 		}
 
@@ -1002,8 +1006,12 @@ func (p *StorageComputeProxy) Compress() {
 		}
 		p.validMask.Reset()
 		p.compressed = true
+		compressedNow = true
 	}()
 	p.prewarmDeltaRows(tx, nil, scm.NewNil(), true)
+	if compressedNow {
+		p.ResetInvalidationTelemetry(time.Since(compressStart).Nanoseconds())
+	}
 }
 
 // CompressFiltered prewarms an ordinary computed column only for rows matching
@@ -1112,6 +1120,52 @@ func (p *StorageComputeProxy) Invalidate(idx uint32) {
 	}
 	p.validMask.Set(uint(idx), false)
 	delete(p.delta, idx)
+}
+
+// InvalidateRows chooses between exact point repair and complete lazy
+// invalidation from measurements of this proxy's own computor. Dominating
+// cases remain unconditional: small batches are repaired directly. For a
+// broad batch, a short measured sample is extrapolated and compared with the
+// last complete materialization. This avoids both a global cost constant and
+// a schema-specific heuristic; the same physical operator adapts to cheap and
+// expensive lookup bodies and to changing table cardinalities.
+func (p *StorageComputeProxy) InvalidateRows(recids map[uint32]struct{}) {
+	if len(recids) == 0 {
+		return
+	}
+	const sampleRows = 32
+	if len(recids) <= sampleRows || p.hasSessionVariants() {
+		for recid := range recids {
+			p.Invalidate(recid)
+		}
+		return
+	}
+
+	fullRecomputeNs := p.lastRecomputeNs.Load()
+	if fullRecomputeNs <= 0 {
+		for recid := range recids {
+			p.Invalidate(recid)
+		}
+		return
+	}
+
+	ids := make([]uint32, 0, len(recids))
+	for recid := range recids {
+		ids = append(ids, recid)
+	}
+	started := time.Now()
+	for _, recid := range ids[:sampleRows] {
+		p.Invalidate(recid)
+	}
+	sampleNs := time.Since(started).Nanoseconds()
+	estimatedNs := float64(sampleNs) * float64(len(ids)) / float64(sampleRows)
+	if estimatedNs >= float64(fullRecomputeNs) {
+		p.InvalidateAll()
+		return
+	}
+	for _, recid := range ids[sampleRows:] {
+		p.Invalidate(recid)
+	}
 }
 
 // IncrementalUpdate adds delta to the cached value at idx.

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -174,6 +174,164 @@ func TestComputeTriggersGuardRelevantSourceColumns(t *testing.T) {
 	}
 }
 
+func TestLookupComputeTriggersInvalidateMatchingRows(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-lookup-trigger-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tlookuptrigger")
+
+	CreateDatabase("tlookuptrigger", false)
+	base, _ := CreateTable("tlookuptrigger", "base", Safe, false)
+	src, _ := CreateTable("tlookuptrigger", "src", Safe, false)
+	base.CreateColumn("id", "INT", nil, nil)
+	base.CreateColumn("ref_id", "INT", nil, nil)
+	base.CreateColumn("cached", "INT", nil, nil)
+	src.CreateColumn("ref_id", "INT", nil, nil)
+	src.CreateColumn("val", "INT", nil, nil)
+
+	computorSource := `(lambda (ref_id)
+		(scan nil (table "tlookuptrigger" "src")
+			'("ref_id") (lambda (source_ref_id) (equal? source_ref_id (outer ref_id)))
+			'("val") (lambda (val) val)
+			(lambda (old value) value) 0 nil false))`
+	rawComputor := scm.Eval(scm.Read("raw lookup trigger test", computorSource), &scm.Globalenv)
+	compiledComputor := scm.Eval(scm.Optimize(scm.Read("compiled lookup trigger test", computorSource), &scm.Globalenv, nil), &scm.Globalenv)
+	for variant, computor := range map[string]scm.Scmer{"raw": rawComputor, "compiled": compiledComputor} {
+		refs := extractScanJoinInfo(computor)
+		if len(refs) != 1 || len(refs[0].srcCols) != 1 || refs[0].srcCols[0] != "ref_id" || refs[0].inputCols[0] != "ref_id" {
+			t.Fatalf("%s lookup relation was not extracted: %#v", variant, refs)
+		}
+	}
+	base.registerComputeTriggers("cached", compiledComputor)
+
+	tr, ok := findTriggerByPrefixAndTiming(src.Triggers, ".cache:base:cached|scan0|src|", AfterUpdate)
+	if !ok {
+		t.Fatal("missing AfterUpdate lookup dependency trigger")
+	}
+	plan := triggerPlanStringForTest(tr)
+	if !strings.Contains(plan, `"$invalidate:cached"`) {
+		t.Fatalf("lookup-shaped compute trigger must invalidate matching cache rows:\n%s", plan)
+	}
+	if strings.Contains(plan, `(invalidatecolumn`) {
+		t.Fatalf("lookup-shaped compute trigger must not invalidate the complete cache:\n%s", plan)
+	}
+}
+
+func TestLookupInvalidationIncludesComputedDeltaRows(t *testing.T) {
+	db := newDatabase()
+	db.Name = "tlookupdelta"
+	tbl := &table{schema: db, Name: "base", Columns: []*column{{Name: "cached"}}}
+	shard := &storageShard{
+		t:            tbl,
+		main_count:   1,
+		columns:      make(map[string]ColumnStorage),
+		deltaColumns: make(map[string]int),
+	}
+	proxy := &StorageComputeProxy{
+		delta:   map[uint32]scm.Scmer{1: scm.NewInt(20)},
+		shard:   shard,
+		colName: "cached",
+		count:   1,
+	}
+	proxy.validMask.Set(0, true)
+	proxy.validMask.Set(1, true)
+	shard.columns["cached"] = proxy
+
+	mapFn := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		return scm.Apply(args[0])
+	})
+	reduceFn := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+		return args[1]
+	})
+	mr := shard.OpenMapReducer([]string{"$invalidate:cached"}, mapFn, reduceFn, false, 0, nil, nil)
+	mr.processDeltaBlock(scm.NewNil(), []uint32{1})
+	mr.FlushSideEffects()
+
+	if !proxy.validMask.Get(0) {
+		t.Fatal("delta-row invalidation cleared an unrelated main cache row")
+	}
+	if proxy.validMask.Get(1) {
+		t.Fatal("delta-row invalidation did not clear the matching cache row")
+	}
+	if _, ok := proxy.delta[1]; ok {
+		t.Fatal("delta-row invalidation retained the stale cached value")
+	}
+}
+
+func buildIntStorageForLookupTest(values ...int64) *StorageInt {
+	result := new(StorageInt)
+	result.prepare()
+	for i, value := range values {
+		result.scan(uint32(i), scm.NewInt(value))
+	}
+	result.init(uint32(len(values)))
+	for i, value := range values {
+		result.build(uint32(i), scm.NewInt(value))
+	}
+	result.finish()
+	return result
+}
+
+func buildScmerStorageForLookupTest(values ...int64) *StorageSCMER {
+	result := new(StorageSCMER)
+	result.init(uint32(len(values)))
+	for i, value := range values {
+		result.build(uint32(i), scm.NewInt(value))
+	}
+	result.finish()
+	return result
+}
+
+func TestLookupInvalidationKeepsCompressedBaseRows(t *testing.T) {
+	db := newDatabase()
+	db.Name = "tlookupcompressed"
+	tbl := &table{schema: db, Name: "base", Columns: []*column{{Name: "input"}, {Name: "cached"}}}
+	shard := &storageShard{
+		t:            tbl,
+		main_count:   3,
+		columns:      make(map[string]ColumnStorage),
+		deltaColumns: make(map[string]int),
+	}
+	input := buildScmerStorageForLookupTest(1, 2, 3)
+	proxy := &StorageComputeProxy{
+		main:       buildIntStorageForLookupTest(11, 12, 13),
+		delta:      make(map[uint32]scm.Scmer),
+		compressed: true,
+		computor: scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+			return scm.NewInt(args[0].Int() + 10)
+		}),
+		inputCols: []string{"input"},
+		shard:     shard,
+		colName:   "cached",
+		count:     3,
+	}
+	shard.columns["input"] = input
+	shard.columns["cached"] = proxy
+
+	input.SetValue(1, scm.NewInt(20))
+	proxy.Invalidate(1)
+
+	if !proxy.compressed {
+		t.Fatal("one lookup invalidation discarded the compressed cache base")
+	}
+	for idx, want := range []int64{11, 30, 13} {
+		if got := proxy.GetValue(uint32(idx)).Int(); got != want {
+			t.Fatalf("cached row %d = %d, want %d", idx, got, want)
+		}
+	}
+	if len(proxy.delta) != 1 {
+		t.Fatalf("sparse override count = %d, want 1", len(proxy.delta))
+	}
+}
+
 func TestORCDependencyTriggersUseRelevantColumnsAndInvalidateSuffix(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-orc-trigger-*")
 	if err != nil {

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -332,6 +332,76 @@ func TestLookupInvalidationKeepsCompressedBaseRows(t *testing.T) {
 	}
 }
 
+func newAdaptiveLookupProxyForTest(rowCount int) (*StorageComputeProxy, *int) {
+	db := newDatabase()
+	db.Name = "tlookupadaptive"
+	tbl := &table{schema: db, Name: "base", Columns: []*column{{Name: "input"}, {Name: "cached"}}}
+	shard := &storageShard{
+		t:            tbl,
+		main_count:   uint32(rowCount),
+		columns:      make(map[string]ColumnStorage),
+		deltaColumns: make(map[string]int),
+	}
+	values := make([]int64, rowCount)
+	for i := range values {
+		values[i] = int64(i)
+	}
+	input := buildScmerStorageForLookupTest(values...)
+	calls := 0
+	proxy := &StorageComputeProxy{
+		main:       buildScmerStorageForLookupTest(values...),
+		delta:      make(map[uint32]scm.Scmer),
+		compressed: true,
+		computor: scm.NewFunc(func(args ...scm.Scmer) scm.Scmer {
+			calls++
+			return args[0]
+		}),
+		inputCols: []string{"input"},
+		shard:     shard,
+		colName:   "cached",
+		count:     uint32(rowCount),
+	}
+	shard.columns["input"] = input
+	shard.columns["cached"] = proxy
+	return proxy, &calls
+}
+
+func TestLookupInvalidationFallsBackForExpensiveBroadFanout(t *testing.T) {
+	proxy, calls := newAdaptiveLookupProxyForTest(64)
+	proxy.lastRecomputeNs.Store(1)
+	recids := make(map[uint32]struct{}, 64)
+	for i := uint32(0); i < 64; i++ {
+		recids[i] = struct{}{}
+	}
+
+	proxy.InvalidateRows(recids)
+
+	if proxy.compressed {
+		t.Fatal("broad point invalidation did not fall back to full lazy invalidation")
+	}
+	if *calls >= len(recids) {
+		t.Fatalf("adaptive probe recomputed %d rows, want fewer than %d", *calls, len(recids))
+	}
+}
+
+func TestLookupInvalidationKeepsCheaperExactFanout(t *testing.T) {
+	proxy, calls := newAdaptiveLookupProxyForTest(64)
+	proxy.lastRecomputeNs.Store(1 << 62)
+	recids := make(map[uint32]struct{}, 64)
+	for i := uint32(0); i < 64; i++ {
+		recids[i] = struct{}{}
+	}
+
+	proxy.InvalidateRows(recids)
+
+	if !proxy.compressed {
+		t.Fatal("cheap point invalidation unexpectedly discarded the compressed cache")
+	}
+	if *calls != len(recids) {
+		t.Fatalf("exact invalidation recomputed %d rows, want %d", *calls, len(recids))
+	}
+}
+
 func TestORCDependencyTriggersUseRelevantColumnsAndInvalidateSuffix(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-orc-trigger-*")
 	if err != nil {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1599,7 +1599,7 @@ type ShardMapReducer struct {
 	// Batched side effects: collected during scan, flushed after lock release.
 	// $increment calls are aggregated per (proxy, recid) → one update per unique target.
 	incrementBatch  map[*StorageComputeProxy]map[uint32]scm.Scmer // proxy → recid → accumulated delta
-	invalidateBatch map[*StorageComputeProxy]bool                 // proxies to InvalidateAll after scan
+	invalidateBatch map[*StorageComputeProxy]map[uint32]struct{}  // proxy -> matching rows to invalidate after scan
 	reduceScmer     scm.Scmer                                     // original Scmer for network serialization
 	mainCount       uint32
 	hasUpdateCol    bool
@@ -1787,12 +1787,19 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		}
 		if needsMutationMetadata && mr.isInvalidate[i] {
 			if proxy := mr.invalidateProxy[i]; proxy != nil {
-				// Batch invalidations: mark proxy for InvalidateAll after scan
+				// Keep the exact matching record IDs. Lookup-cache maintenance scans
+				// already paid to identify this subset; collapsing it to InvalidateAll
+				// would discard that information and turn one source-row mutation into
+				// a complete cache rebuild.
 				if mr.invalidateBatch == nil {
-					mr.invalidateBatch = make(map[*StorageComputeProxy]bool)
+					mr.invalidateBatch = make(map[*StorageComputeProxy]map[uint32]struct{})
 				}
+				if mr.invalidateBatch[proxy] == nil {
+					mr.invalidateBatch[proxy] = make(map[uint32]struct{})
+				}
+				proxyBatch := mr.invalidateBatch[proxy]
 				fn := func(id uint32, args ...scm.Scmer) scm.Scmer {
-					mr.invalidateBatch[proxy] = true
+					proxyBatch[id] = struct{}{}
 					return scm.NewBool(true)
 				}
 				mr.invClosureFn[i] = &fn
@@ -1803,16 +1810,17 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 		}
 		if needsMutationMetadata && mr.isInvalidate[i] {
 			if fnptr := mr.invClosureFn[i]; fnptr != nil {
-				mr.mainGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
+				getter := func(id uint32, batchid uint32) scm.Scmer {
 					return scm.NewClosure(fnptr, id)
 				}
+				mr.mainGetters[i] = getter
+				mr.deltaGetters[i] = getter
 			} else {
-				mr.mainGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
+				getter := func(id uint32, batchid uint32) scm.Scmer {
 					return scm.NewClosure(mr.noopClosureFn, id)
 				}
-			}
-			mr.deltaGetters[i] = func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewClosure(mr.noopClosureFn, id)
+				mr.mainGetters[i] = getter
+				mr.deltaGetters[i] = getter
 			}
 			continue
 		}
@@ -2176,9 +2184,12 @@ func (m *ShardMapReducer) Close() {
 // invalidations). Must be called AFTER the scan completes and all shard
 // locks are released, to avoid deadlocks.
 func (m *ShardMapReducer) FlushSideEffects() {
-	// 1. Flush batched invalidations (cheapest: just set bits)
-	for proxy := range m.invalidateBatch {
-		proxy.InvalidateAll()
+	// 1. Flush batched invalidations while preserving the row subset selected by
+	// the maintenance scan. Propagation remains column-level for now: downstream
+	// computed columns are invalidated through the existing cycle-safe
+	// AfterInvalidate graph after this proxy has been updated.
+	for proxy, recids := range m.invalidateBatch {
+		invalidateComputedRows(proxy, recids)
 	}
 	m.invalidateBatch = nil
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -601,9 +601,7 @@ func invalidateComputedRows(proxy *StorageComputeProxy, recids map[uint32]struct
 		return
 	}
 	withComputeInvalidationWave(proxy.shard.t, proxy.colName, func() bool {
-		for recid := range recids {
-			proxy.Invalidate(recid)
-		}
+		proxy.InvalidateRows(recids)
 		return true
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -553,11 +553,7 @@ func lockTable(schema, name string, write bool, ss *scm.SessionState) {
 
 const computeInvalidationWaveKey = "memcpComputeInvalidationWave"
 
-// invalidateComputedColumn propagates invalidation through computed-cache
-// dependency edges. A GLS-local visited set makes one synchronous invalidation
-// wave idempotent and prevents malformed cyclic computed definitions from
-// recursing forever without introducing a global lock or cross-query state.
-func invalidateComputedColumn(t *table, colName string) {
+func withComputeInvalidationWave(t *table, colName string, invalidate func() bool) {
 	if value, ok := scm.GetGLSValue(computeInvalidationWaveKey); ok {
 		visited := value.(map[string]bool)
 		key := t.schema.Name + "\x00" + t.Name + "\x00" + colName
@@ -565,6 +561,22 @@ func invalidateComputedColumn(t *table, colName string) {
 			return
 		}
 		visited[key] = true
+		if invalidate() {
+			t.ExecuteTriggers(AfterInvalidate, nil, nil)
+		}
+		return
+	}
+	scm.SetValues(map[string]any{computeInvalidationWaveKey: make(map[string]bool)}, func() {
+		withComputeInvalidationWave(t, colName, invalidate)
+	})
+}
+
+// invalidateComputedColumn propagates invalidation through computed-cache
+// dependency edges. A GLS-local visited set makes one synchronous invalidation
+// wave idempotent and prevents malformed cyclic computed definitions from
+// recursing forever without introducing a global lock or cross-query state.
+func invalidateComputedColumn(t *table, colName string) {
+	withComputeInvalidationWave(t, colName, func() bool {
 		invalidated := false
 		for _, s := range t.maintenanceShards() {
 			s.mu.RLock()
@@ -575,13 +587,24 @@ func invalidateComputedColumn(t *table, colName string) {
 				invalidated = true
 			}
 		}
-		if invalidated {
-			t.ExecuteTriggers(AfterInvalidate, nil, nil)
-		}
+		return invalidated
+	})
+}
+
+// invalidateComputedRows preserves the exact subset found by an analyzed
+// lookup-maintenance scan. The AfterInvalidate edge stays column-level, so a
+// nested cache remains correct even when its own lookup relation cannot be
+// narrowed safely. The common invalidation-wave guard prevents dependency
+// cycles exactly as for invalidateComputedColumn.
+func invalidateComputedRows(proxy *StorageComputeProxy, recids map[uint32]struct{}) {
+	if proxy == nil || proxy.shard == nil || len(recids) == 0 {
 		return
 	}
-	scm.SetValues(map[string]any{computeInvalidationWaveKey: make(map[string]bool)}, func() {
-		invalidateComputedColumn(t, colName)
+	withComputeInvalidationWave(proxy.shard.t, proxy.colName, func() bool {
+		for recid := range recids {
+			proxy.Invalidate(recid)
+		}
+		return true
 	})
 }
 

--- a/tests/performance/computed-lookup-cache-invalidation.yaml
+++ b/tests/performance/computed-lookup-cache-invalidation.yaml
@@ -1,0 +1,72 @@
+# Copyright (C) 2026  MemCP Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Row-local invalidation of a canonical computed lookup cache"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS lookup_invalidation_driver"
+  - sql: "DROP TABLE IF EXISTS lookup_invalidation_source"
+  - sql: "CREATE TABLE lookup_invalidation_source (id INT PRIMARY KEY, val INT)"
+  - sql: "CREATE TABLE lookup_invalidation_driver (id INT PRIMARY KEY, source_id INT)"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "lookup_invalidation_source") '("id" "val")
+          (map (produceN 8000) (lambda (i) (list (+ i 1) (+ i 10))))
+          '() (lambda () true) false)
+        (insert (table "memcp-tests" "lookup_invalidation_driver") '("id" "source_id")
+          (map (produceN 8000) (lambda (i) (list (+ i 1) (+ i 1))))
+          '() (lambda () true) false)
+        (rebuild (table "memcp-tests" "lookup_invalidation_source") true false)
+        (rebuild (table "memcp-tests" "lookup_invalidation_driver") true false))
+
+test_cases:
+  - name: "Build and warm the canonical lookup cache"
+    scm: |
+      (begin
+        (createcolumn
+          (table "memcp-tests" "lookup_invalidation_driver")
+          ".lookup:value" "INT" '() '("temp" true)
+          '("source_id")
+          (lambda (source_id)
+            (scan nil (table "memcp-tests" "lookup_invalidation_source")
+              '("id") (lambda (id) (equal? id (outer source_id)))
+              '("val") (lambda (val) val)
+              (lambda (old value) value) 0 nil false)))
+        (scan nil (table "memcp-tests" "lookup_invalidation_driver")
+          '() (lambda () true)
+          '(".lookup:value") (lambda (value) value)
+          + 0 nil false))
+
+  - name: "Mutate one lookup source"
+    sql: "UPDATE lookup_invalidation_source SET val = 999999 WHERE id = 4000"
+    expect:
+      affected_rows: 1
+
+  - name: "One source mutation does not rebuild every cached lookup"
+    max_time: 0.5
+    sql: |
+      SELECT SUM(`.lookup:value`) AS total
+      FROM lookup_invalidation_driver
+    expect:
+      rows: 1
+      data:
+        - total: 33071990
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS lookup_invalidation_driver"
+  - sql: "DROP TABLE IF EXISTS lookup_invalidation_source"

--- a/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
+++ b/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
@@ -22,10 +22,10 @@ setup:
   - sql: "DROP TABLE IF EXISTS lookup_cache_document"
   - sql: "DROP TABLE IF EXISTS lookup_cache_file"
   - sql: "DROP TABLE IF EXISTS lookup_cache_folder"
-  - sql: "CREATE TABLE lookup_cache_folder (id INT PRIMARY KEY, stamp INT)"
+  - sql: "CREATE TABLE lookup_cache_folder (id INT PRIMARY KEY, stamp INT, label_code INT)"
   - sql: "CREATE TABLE lookup_cache_file (id INT PRIMARY KEY, folder_id INT)"
   - sql: "CREATE TABLE lookup_cache_document (id INT PRIMARY KEY, file_id INT)"
-  - sql: "INSERT INTO lookup_cache_folder VALUES (1, 100), (2, 200)"
+  - sql: "INSERT INTO lookup_cache_folder VALUES (1, 100, 7), (2, 200, 9)"
   - sql: "INSERT INTO lookup_cache_file VALUES (10, 1), (20, 2)"
   - sql: "INSERT INTO lookup_cache_document VALUES (1000, 10), (2000, 20)"
 
@@ -43,6 +43,19 @@ test_cases:
             '("stamp") (lambda (stamp) stamp)
             (lambda (old value) value) 0 nil false)))
 
+  - name: "Create a fused lookup cache reading multiple source columns"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "lookup_cache_file")
+        ".lookup:folder_pair" "INT" '() '("temp" true)
+        '("folder_id")
+        (lambda (folder_id)
+          (scan nil
+            (table "memcp-tests" "lookup_cache_folder")
+            '("id") (lambda (id) (equal? id (outer folder_id)))
+            '("stamp" "label_code") (lambda (stamp label_code) (+ stamp label_code))
+            (lambda (old value) value) 0 nil false)))
+
   - name: "Create a lookup cache depending on another lookup cache"
     scm: |
       (createcolumn
@@ -56,9 +69,23 @@ test_cases:
             '(".lookup:folder_stamp") (lambda (folder_stamp) folder_stamp)
             (lambda (old value) value) 0 nil false)))
 
+  - name: "Create a nested cache from the fused lookup output"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "lookup_cache_document")
+        ".lookup:file_folder_pair" "INT" '() '("temp" true)
+        '("file_id")
+        (lambda (file_id)
+          (scan nil
+            (table "memcp-tests" "lookup_cache_file")
+            '("id") (lambda (id) (equal? id (outer file_id)))
+            '(".lookup:folder_pair") (lambda (folder_pair) folder_pair)
+            (lambda (old value) value) 0 nil false)))
+
   - name: "Nested lookup caches expose their initial values"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -66,8 +93,10 @@ test_cases:
       data:
         - id: 1000
           stamp: 100
+          pair_value: 107
         - id: 2000
           stamp: 200
+          pair_value: 209
 
   - name: "Mutate the source of one nested lookup branch"
     sql: "UPDATE lookup_cache_folder SET stamp = 111 WHERE id = 1"
@@ -76,7 +105,8 @@ test_cases:
 
   - name: "Invalidation cascades through both lookup cache levels"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -84,8 +114,52 @@ test_cases:
       data:
         - id: 1000
           stamp: 111
+          pair_value: 118
         - id: 2000
           stamp: 200
+          pair_value: 209
+
+  - name: "Point a cache row at a source key that does not exist yet"
+    sql: "UPDATE lookup_cache_file SET folder_id = 3 WHERE id = 20"
+    expect:
+      affected_rows: 1
+
+  - name: "The missing lookup result is cached without affecting its sibling"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 111
+          pair_value: 118
+        - id: 2000
+          stamp: 0
+          pair_value: 0
+
+  - name: "Move a source row onto the previously missing lookup key"
+    sql: "UPDATE lookup_cache_folder SET id = 3 WHERE id = 2"
+    expect:
+      affected_rows: 1
+
+  - name: "Changing the source join key invalidates matches for the new key"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 111
+          pair_value: 118
+        - id: 2000
+          stamp: 200
+          pair_value: 209
 
   - name: "Move a lookup row to another parent"
     sql: "UPDATE lookup_cache_file SET folder_id = 1 WHERE id = 20"
@@ -94,7 +168,8 @@ test_cases:
 
   - name: "Changing an intermediate lookup key invalidates its consumers"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -102,8 +177,10 @@ test_cases:
       data:
         - id: 1000
           stamp: 111
+          pair_value: 118
         - id: 2000
           stamp: 111
+          pair_value: 118
 
   - name: "Move a driver row to another cached lookup"
     sql: "UPDATE lookup_cache_document SET file_id = 20 WHERE id = 1000"
@@ -112,7 +189,8 @@ test_cases:
 
   - name: "Changing the local lookup key computes the new row value"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -120,8 +198,10 @@ test_cases:
       data:
         - id: 1000
           stamp: 111
+          pair_value: 118
         - id: 2000
           stamp: 111
+          pair_value: 118
 
   - name: "Delete the nested lookup source"
     sql: "DELETE FROM lookup_cache_folder WHERE id = 1"
@@ -130,7 +210,8 @@ test_cases:
 
   - name: "Deleting a lookup source invalidates all matching cache levels"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -138,17 +219,20 @@ test_cases:
       data:
         - id: 1000
           stamp: 0
+          pair_value: 0
         - id: 2000
           stamp: 0
+          pair_value: 0
 
   - name: "Reinsert the nested lookup source"
-    sql: "INSERT INTO lookup_cache_folder VALUES (1, 333)"
+    sql: "INSERT INTO lookup_cache_folder VALUES (1, 333, 17)"
     expect:
       affected_rows: 1
 
   - name: "Inserting a lookup source repairs all matching cache levels"
     sql: |
-      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      SELECT id, `.lookup:file_folder_stamp` AS stamp,
+             `.lookup:file_folder_pair` AS pair_value
       FROM lookup_cache_document
       ORDER BY id
     expect:
@@ -156,8 +240,10 @@ test_cases:
       data:
         - id: 1000
           stamp: 333
+          pair_value: 350
         - id: 2000
           stamp: 333
+          pair_value: 350
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS lookup_cache_document"

--- a/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
+++ b/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
@@ -1,0 +1,165 @@
+# Copyright (C) 2026  MemCP Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Canonical computed lookup caches and cascading invalidation"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS lookup_cache_document"
+  - sql: "DROP TABLE IF EXISTS lookup_cache_file"
+  - sql: "DROP TABLE IF EXISTS lookup_cache_folder"
+  - sql: "CREATE TABLE lookup_cache_folder (id INT PRIMARY KEY, stamp INT)"
+  - sql: "CREATE TABLE lookup_cache_file (id INT PRIMARY KEY, folder_id INT)"
+  - sql: "CREATE TABLE lookup_cache_document (id INT PRIMARY KEY, file_id INT)"
+  - sql: "INSERT INTO lookup_cache_folder VALUES (1, 100), (2, 200)"
+  - sql: "INSERT INTO lookup_cache_file VALUES (10, 1), (20, 2)"
+  - sql: "INSERT INTO lookup_cache_document VALUES (1000, 10), (2000, 20)"
+
+test_cases:
+  - name: "Create the first canonical lookup cache"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "lookup_cache_file")
+        ".lookup:folder_stamp" "INT" '() '("temp" true)
+        '("folder_id")
+        (lambda (folder_id)
+          (scan nil
+            (table "memcp-tests" "lookup_cache_folder")
+            '("id") (lambda (id) (equal? id (outer folder_id)))
+            '("stamp") (lambda (stamp) stamp)
+            (lambda (old value) value) 0 nil false)))
+
+  - name: "Create a lookup cache depending on another lookup cache"
+    scm: |
+      (createcolumn
+        (table "memcp-tests" "lookup_cache_document")
+        ".lookup:file_folder_stamp" "INT" '() '("temp" true)
+        '("file_id")
+        (lambda (file_id)
+          (scan nil
+            (table "memcp-tests" "lookup_cache_file")
+            '("id") (lambda (id) (equal? id (outer file_id)))
+            '(".lookup:folder_stamp") (lambda (folder_stamp) folder_stamp)
+            (lambda (old value) value) 0 nil false)))
+
+  - name: "Nested lookup caches expose their initial values"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 100
+        - id: 2000
+          stamp: 200
+
+  - name: "Mutate the source of one nested lookup branch"
+    sql: "UPDATE lookup_cache_folder SET stamp = 111 WHERE id = 1"
+    expect:
+      affected_rows: 1
+
+  - name: "Invalidation cascades through both lookup cache levels"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 111
+        - id: 2000
+          stamp: 200
+
+  - name: "Move a lookup row to another parent"
+    sql: "UPDATE lookup_cache_file SET folder_id = 1 WHERE id = 20"
+    expect:
+      affected_rows: 1
+
+  - name: "Changing an intermediate lookup key invalidates its consumers"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 111
+        - id: 2000
+          stamp: 111
+
+  - name: "Move a driver row to another cached lookup"
+    sql: "UPDATE lookup_cache_document SET file_id = 20 WHERE id = 1000"
+    expect:
+      affected_rows: 1
+
+  - name: "Changing the local lookup key computes the new row value"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 111
+        - id: 2000
+          stamp: 111
+
+  - name: "Delete the nested lookup source"
+    sql: "DELETE FROM lookup_cache_folder WHERE id = 1"
+    expect:
+      affected_rows: 1
+
+  - name: "Deleting a lookup source invalidates all matching cache levels"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 0
+        - id: 2000
+          stamp: 0
+
+  - name: "Reinsert the nested lookup source"
+    sql: "INSERT INTO lookup_cache_folder VALUES (1, 333)"
+    expect:
+      affected_rows: 1
+
+  - name: "Inserting a lookup source repairs all matching cache levels"
+    sql: |
+      SELECT id, `.lookup:file_folder_stamp` AS stamp
+      FROM lookup_cache_document
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1000
+          stamp: 333
+        - id: 2000
+          stamp: 333
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS lookup_cache_document"
+  - sql: "DROP TABLE IF EXISTS lookup_cache_file"
+  - sql: "DROP TABLE IF EXISTS lookup_cache_folder"


### PR DESCRIPTION
## Summary

- recognize equality lookup dependencies in both raw and optimized physical Scheme ASTs, including quoted scan column lists
- preserve the exact target record IDs found by `$invalidate:<column>` maintenance scans, including delta rows
- keep immutable compressed cache storage intact and place repaired rows in sparse overrides
- retain cycle-safe `AfterInvalidate` propagation, and expand computed source columns to their physical inputs so nested lookup caches stay correct after FK changes
- choose adaptively between exact row repair and complete lazy invalidation for broad lookup fanout, using the operator's measured full-materialization cost instead of a query-shape heuristic

This PR is deliberately the storage/cache foundation only. It does not teach the SQL planner when to choose a computed lookup column, and it does not add planner-level multi-output lookup fusion. Those planner and cost-model integrations can follow after this behavior is on master.

## Architecture

The SQL logical planner and Neumann decorrelation are unchanged. `createcolumn` already receives a physical Scheme computor after physical lowering; trigger dependency analysis and the adaptive invalidation decision operate only on that physical cache operator.

Dominating choices remain unconditional: small exact invalidation batches are repaired directly. For broad batches with an unclear cost relation, the proxy samples 32 exact repairs and compares their extrapolated cost with its own previously measured full materialization. This is a runtime gate local to the operator, not a global planner weight or a hard-coded query shape.

## Correctness

The integration suite covers:

- a two-level lookup chain
- source value updates
- intermediate and driver FK updates
- a source join-key update, including the newly matching `NEW` key
- delete and reinsert
- delta-row invalidation
- a single physical lookup computor reading multiple source columns, with cascading reuse of its result

Opaque lookup relations retain complete invalidation as the correctness fallback.

## Performance proof

The permanent 8,000-row regression gate fails on unchanged master at **5,471.9 ms** after one source-row mutation (500 ms limit) and passes on this branch.

A controlled 20,000-source / 20,000-cache-row A/B excluded initial cache construction and measured mutation plus the first complete cached-column read:

| affected cache rows | revision / strategy | mutation | first read | total |
| ---: | --- | ---: | ---: | ---: |
| 1 | unchanged master, full invalidation | 8.6 ms | 13.75 s | 13.75 s |
| 1 | this PR, exact repair | 22.0 ms | 63.1 ms | 85.1 ms |
| 200 | unchanged master, full invalidation | 9.0 ms | 13.69 s | 13.70 s |
| 200 | this PR, exact repair | 408.9 ms | 64.2 ms | 473.1 ms |
| 10,000 | exact-only implementation before adaptive gate | 19.65 s | 67.6 ms | 19.71 s |
| 10,000 | this PR, measured fallback | 63.0 ms | 13.74 s | 13.80 s |

The broad-fanout measurement found and fixed a real regression risk before merge: exact repair is retained for selective changes, while a mutation touching half the cache no longer serially recomputes 10,000 lookup bodies.

## Validation

- `make test` — all critical SQL/YAML suites passed
- `go test -race ./storage -run 'TestLookup' -count=1`
- targeted compute-proxy, repartition, session-carrier, delta-row, group-cache, source-key-change, and multi-source-column lookup cases passed

Running the entire Go storage package in one process still hits the same pre-existing native SIGSEGV on both this branch and unchanged master; the focused storage tests and the hook-equivalent suite are green.
