### PR TITLE
Add recursive function type documentation

### DIFF
--- a/main.go
+++ b/main.go
@@ -717,7 +717,7 @@ func setupIO(wd string) {
 	scm.DeclareTitle("IO")
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "print",
-		Desc: "Prints values to stdout (only in IO environment)",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			var msg string
 			for _, s := range a {
@@ -729,16 +729,16 @@ func setupIO(wd string) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Prints values to stdout (only in IO environment)", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "value...", ParamDesc: "values to print", Variadic: true},
+				{Kind: "any", Label: "value...", Description: "values to print", Variadic: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "env",
-		Desc: "returns the content of a environment variable",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) > 1 {
 				if val, ok := os.LookupEnv(scm.String(a[0])); ok {
@@ -748,17 +748,17 @@ func setupIO(wd string) {
 			}
 			return scm.NewString(os.Getenv(scm.String(a[0])))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the content of a environment variable",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "var", ParamDesc: "envvar"},
-				{Kind: "string", ParamName: "default", ParamDesc: "default if the env is not found", Optional: true},
+				{Kind: "string", Label: "var", Description: "envvar"},
+				{Kind: "string", Label: "default", Description: "default if the env is not found", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "help",
-		Desc: "Lists all functions or returns help for a specific function as a string",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) == 0 {
 				return scm.NewString(scm.Help(scm.NewNil()))
@@ -766,84 +766,84 @@ func setupIO(wd string) {
 				return scm.NewString(scm.Help(a[0]))
 			}
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Lists all functions or returns help for a specific function as a string",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "topic", ParamDesc: "function to get help about", Optional: true},
+				{Kind: "string", Label: "topic", Description: "function to get help about", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "import",
-		Desc: "Imports a file .scm file into current namespace",
-		Fn:   (func(...scm.Scmer) scm.Scmer)(getImport(wd)),
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: (func(...scm.Scmer) scm.Scmer)(getImport(wd)),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Imports a file .scm file into current namespace", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "filename", ParamDesc: "filename relative to folder of source file or absolute path"},
+				{Kind: "string", Label: "filename", Description: "filename relative to folder of source file or absolute path"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "load",
-		Desc: "Loads a file or stream and returns the string or iterates line-wise",
-		Fn:   (func(...scm.Scmer) scm.Scmer)(getLoad(wd)),
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: (func(...scm.Scmer) scm.Scmer)(getLoad(wd)),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Loads a file or stream and returns the string or iterates line-wise", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string|stream", ParamName: "filenameOrStream", ParamDesc: "filename relative to folder of source file, absolute path, or stream to read from"},
-				{Kind: "func", ParamName: "linehandler", ParamDesc: "handler that reads each line; each line may end with delimiter", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "line"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "string", ParamName: "delimiter", ParamDesc: "delimiter to extract; if no delimiter is given, the file is read as whole and returned or passed to linehandler", Optional: true},
+				{Kind: "string|stream", Label: "filenameOrStream", Description: "filename relative to folder of source file, absolute path, or stream to read from"},
+				{Kind: "func", Label: "linehandler", Description: "handler that reads each line; each line may end with delimiter", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "string", Label: "line"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "string", Label: "delimiter", Description: "delimiter to extract; if no delimiter is given, the file is read as whole and returned or passed to linehandler", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string|bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "stream",
-		Desc: "Opens a file readonly as stream",
-		Fn:   (func(...scm.Scmer) scm.Scmer)(getStream(wd)),
-		Type: &scm.TypeDescriptor{
+
+		Fn: (func(...scm.Scmer) scm.Scmer)(getStream(wd)),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Opens a file readonly as stream",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "filename", ParamDesc: "filename relative to folder of source file or absolute path"},
+				{Kind: "string", Label: "filename", Description: "filename relative to folder of source file or absolute path"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "stream"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "watch",
-		Desc: "Loads a file and calls the callback. Whenever the file changes on disk, the file is load again.",
-		Fn:   (func(...scm.Scmer) scm.Scmer)(getWatch(wd)),
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: (func(...scm.Scmer) scm.Scmer)(getWatch(wd)),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Loads a file and calls the callback. Whenever the file changes on disk, the file is load again.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "filename", ParamDesc: "filename relative to folder of source file or absolute path"},
-				{Kind: "func", ParamName: "updatehandler", ParamDesc: "handler that receives the file content func(content)", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "content"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "string", Label: "filename", Description: "filename relative to folder of source file or absolute path"},
+				{Kind: "func", Label: "updatehandler", Description: "handler that receives the file content func(content)", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "content"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "serve",
-		Desc: "Opens a HTTP server at a given port",
-		Fn:   scm.HTTPServe,
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: scm.HTTPServe,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Opens a HTTP server at a given port", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "number", ParamName: "port", ParamDesc: "port number for HTTP server"},
-				{Kind: "func", ParamName: "handler", ParamDesc: "handler: lambda(req res) that handles the http request", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "req"}, {Kind: "any", ParamName: "res"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "number", Label: "port", Description: "port number for HTTP server"},
+				{Kind: "func", Label: "handler", Description: "handler: lambda(req res) that handles the http request", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "req"}, {Kind: "any", Label: "res"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "serveStatic",
-		Desc: "creates a static handler for use as a callback in (serve) - returns a handler lambda(req res)",
-		Fn:   (func(...scm.Scmer) scm.Scmer)(scm.HTTPStaticGetter(wd)),
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: (func(...scm.Scmer) scm.Scmer)(scm.HTTPStaticGetter(wd)),
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a static handler for use as a callback in (serve) - returns a handler lambda(req res)", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "directory", ParamDesc: "folder with the files to serve"},
+				{Kind: "string", Label: "directory", Description: "folder with the files to serve"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "func",
 				Params: []*scm.TypeDescriptor{
-					{Kind: "any", ParamName: "req", ParamDesc: "HTTP request object"},
-					{Kind: "any", ParamName: "res", ParamDesc: "HTTP response object"},
+					{Kind: "any", Label: "req", Description: "HTTP request object"},
+					{Kind: "any", Label: "res", Description: "HTTP response object"},
 				},
 				Return: &scm.TypeDescriptor{Kind: "any"},
 			},
@@ -851,39 +851,39 @@ func setupIO(wd string) {
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "mysql",
-		Desc: "Imports a file .scm file into current namespace",
-		Fn:   scm.MySQLServe,
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: scm.MySQLServe,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Imports a file .scm file into current namespace", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "number", ParamName: "port", ParamDesc: "port number for MySQL server"},
-				{Kind: "func", ParamName: "getPassword", ParamDesc: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
-				{Kind: "func", ParamName: "schemacallback", ParamDesc: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "username"}, {Kind: "string", ParamName: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "handler", ParamDesc: "lambda(schema sql resultrow session) handler to process sql query in schema. resultrow is a lambda(list)", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "schema"}, {Kind: "string", ParamName: "sql"}, {Kind: "func", ParamName: "resultrow"}, {Kind: "func", ParamName: "session"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "number", Label: "port", Description: "port number for MySQL server"},
+				{Kind: "func", Label: "getPassword", Description: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
+				{Kind: "func", Label: "schemacallback", Description: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}, {Kind: "string", Label: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "handler", Description: "processes one SQL query in a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "schema"}, {Kind: "string", Label: "sql"}, {Kind: "func", Label: "resultrow", Description: "emits one result row", Params: []*scm.TypeDescriptor{{Kind: "list", Label: "row", Element: &scm.TypeDescriptor{Kind: "any", Label: "column value"}}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}}, {Kind: "func", Label: "session", Description: "reads or updates request-local values", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "stored value"}}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "mysql_socket",
-		Desc: "Listen on a Unix domain socket for MySQL protocol",
-		Fn:   scm.MySQLServeSocket,
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+
+		Fn: scm.MySQLServeSocket,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Listen on a Unix domain socket for MySQL protocol", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "socketpath", ParamDesc: "path to the Unix domain socket"},
-				{Kind: "func", ParamName: "getPassword", ParamDesc: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
-				{Kind: "func", ParamName: "schemacallback", ParamDesc: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "username"}, {Kind: "string", ParamName: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "handler", ParamDesc: "lambda(schema sql resultrow session) handler to process sql query in schema. resultrow is a lambda(list)", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "schema"}, {Kind: "string", ParamName: "sql"}, {Kind: "func", ParamName: "resultrow"}, {Kind: "func", ParamName: "session"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "string", Label: "socketpath", Description: "path to the Unix domain socket"},
+				{Kind: "func", Label: "getPassword", Description: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
+				{Kind: "func", Label: "schemacallback", Description: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}, {Kind: "string", Label: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "handler", Description: "processes one SQL query in a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "schema"}, {Kind: "string", Label: "sql"}, {Kind: "func", Label: "resultrow", Description: "emits one result row", Params: []*scm.TypeDescriptor{{Kind: "list", Label: "row", Element: &scm.TypeDescriptor{Kind: "any", Label: "column value"}}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}}, {Kind: "func", Label: "session", Description: "reads or updates request-local values", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "stored value"}}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "password",
-		Desc: "Hashes a password with sha1 (for mysql user authentication)",
-		Fn:   scm.MySQLPassword,
-		Type: &scm.TypeDescriptor{
+
+		Fn: scm.MySQLPassword,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Hashes a password with sha1 (for mysql user authentication)",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "password", ParamDesc: "plain text password to hash"},
+				{Kind: "string", Label: "password", Description: "plain text password to hash"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 			Const:  true,
@@ -893,7 +893,7 @@ func setupIO(wd string) {
 	// Graceful shutdown callable from Scheme/SQL (SHUTDOWN)
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "shutdown",
-		Desc: "Initiates a graceful shutdown of memcp after a short delay",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if scm.ReplInstance != nil {
 				scm.ReplInstance.Close()
@@ -903,7 +903,7 @@ func setupIO(wd string) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Initiates a graceful shutdown of memcp after a short delay", HasSideEffects: true,
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
@@ -911,19 +911,19 @@ func setupIO(wd string) {
 	// Hard crash for crash testing — equivalent to kill -9, no cleanup
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "crash",
-		Desc: "Hard process exit with no cleanup (kill -9 equivalent) for crash testing. SCM only, not exposed to SQL.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			os.Exit(137)              // 128 + SIGKILL(9)
 			return scm.NewBool(false) // unreachable
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Hard process exit with no cleanup (kill -9 equivalent) for crash testing. SCM only, not exposed to SQL.", HasSideEffects: true,
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "path",
-		Desc: "Joins path segments using the OS path separator and cleans the result",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			parts := make([]string, len(a))
 			for i, arg := range a {
@@ -931,16 +931,16 @@ func setupIO(wd string) {
 			}
 			return scm.NewString(filepath.Join(parts...))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Joins path segments using the OS path separator and cleans the result",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "segments", ParamDesc: "path segments to join", Variadic: true},
+				{Kind: "string", Label: "segments", Description: "path segments to join", Variadic: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "args",
-		Desc: "Returns command line arguments",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			args := make([]scm.Scmer, len(os.Args))
 			for i, arg := range os.Args {
@@ -948,13 +948,13 @@ func setupIO(wd string) {
 			}
 			return scm.NewSlice(args)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns command line arguments",
 			Return: &scm.TypeDescriptor{Kind: "list"},
 		},
 	})
 	scm.Declare(&IOEnv, &scm.Declaration{
 		Name: "arg",
-		Desc: "Gets a command line argument value",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			longname := scm.String(a[0])
 			var shortname string
@@ -1005,11 +1005,11 @@ func setupIO(wd string) {
 
 			return defaultValue
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Gets a command line argument value",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "longname", ParamDesc: "long argument name (without --)"},
-				{Kind: "string|any", ParamName: "shortname", ParamDesc: "short argument name (without -) or default value if only 2 args"},
-				{Kind: "any", ParamName: "default", ParamDesc: "default value if argument not found", Optional: true},
+				{Kind: "string", Label: "longname", Description: "long argument name (without --)"},
+				{Kind: "string|any", Label: "shortname", Description: "short argument name (without -) or default value if only 2 args"},
+				{Kind: "any", Label: "default", Description: "default value if argument not found", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},

--- a/main.go
+++ b/main.go
@@ -815,7 +815,7 @@ func setupIO(wd string) {
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Loads a file and calls the callback. Whenever the file changes on disk, the file is load again.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "filename", Description: "filename relative to folder of source file or absolute path"},
-				{Kind: "func", Label: "updatehandler", Description: "handler that receives the file content func(content)", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "content"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "updatehandler", Description: "handler that receives the file content whenever it changes", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "content", Description: "new file content"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "ignored handler result"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -827,7 +827,7 @@ func setupIO(wd string) {
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Opens a HTTP server at a given port", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "number", Label: "port", Description: "port number for HTTP server"},
-				{Kind: "func", Label: "handler", Description: "handler: lambda(req res) that handles the http request", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "req"}, {Kind: "any", Label: "res"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "handler", Description: "handler that processes each HTTP request", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "req", Description: "HTTP request object"}, {Kind: "any", Label: "res", Description: "HTTP response object"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "handler result"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -836,16 +836,16 @@ func setupIO(wd string) {
 		Name: "serveStatic",
 
 		Fn: (func(...scm.Scmer) scm.Scmer)(scm.HTTPStaticGetter(wd)),
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a static handler for use as a callback in (serve) - returns a handler lambda(req res)", HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a static-file HTTP handler for use with serve", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "directory", Description: "folder with the files to serve"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "func",
+			Return: &scm.TypeDescriptor{Kind: "func", Label: "handler", Description: "HTTP handler that serves files from the configured directory",
 				Params: []*scm.TypeDescriptor{
 					{Kind: "any", Label: "req", Description: "HTTP request object"},
 					{Kind: "any", Label: "res", Description: "HTTP response object"},
 				},
-				Return: &scm.TypeDescriptor{Kind: "any"},
+				Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "handler result"},
 			},
 		},
 	})
@@ -856,8 +856,8 @@ func setupIO(wd string) {
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Imports a file .scm file into current namespace", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "number", Label: "port", Description: "port number for MySQL server"},
-				{Kind: "func", Label: "getPassword", Description: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
-				{Kind: "func", Label: "schemacallback", Description: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}, {Kind: "string", Label: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "getPassword", Description: "returns the password for a user, or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username", Description: "user attempting to log in"}}, Return: &scm.TypeDescriptor{Kind: "string|nil", Label: "password", Description: "password used for authentication, or nil to deny login"}},
+				{Kind: "func", Label: "schemacallback", Description: "checks whether a user may access a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username", Description: "authenticated user"}, {Kind: "string", Label: "schema", Description: "requested schema"}}, Return: &scm.TypeDescriptor{Kind: "bool", Label: "allowed", Description: "whether access is allowed"}},
 				{Kind: "func", Label: "handler", Description: "processes one SQL query in a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "schema"}, {Kind: "string", Label: "sql"}, {Kind: "func", Label: "resultrow", Description: "emits one result row", Params: []*scm.TypeDescriptor{{Kind: "list", Label: "row", Element: &scm.TypeDescriptor{Kind: "any", Label: "column value"}}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}}, {Kind: "func", Label: "session", Description: "reads or updates request-local values", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "stored value"}}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
@@ -870,8 +870,8 @@ func setupIO(wd string) {
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Listen on a Unix domain socket for MySQL protocol", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "socketpath", Description: "path to the Unix domain socket"},
-				{Kind: "func", Label: "getPassword", Description: "lambda(username string) string|nil has to return the password for a user or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}}, Return: &scm.TypeDescriptor{Kind: "string|nil"}},
-				{Kind: "func", Label: "schemacallback", Description: "lambda(username schema) bool handler check whether user is allowed to schema - you should check access rights here", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username"}, {Kind: "string", Label: "schema"}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "getPassword", Description: "returns the password for a user, or nil to deny login", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username", Description: "user attempting to log in"}}, Return: &scm.TypeDescriptor{Kind: "string|nil", Label: "password", Description: "password used for authentication, or nil to deny login"}},
+				{Kind: "func", Label: "schemacallback", Description: "checks whether a user may access a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "username", Description: "authenticated user"}, {Kind: "string", Label: "schema", Description: "requested schema"}}, Return: &scm.TypeDescriptor{Kind: "bool", Label: "allowed", Description: "whether access is allowed"}},
 				{Kind: "func", Label: "handler", Description: "processes one SQL query in a schema", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "schema"}, {Kind: "string", Label: "sql"}, {Kind: "func", Label: "resultrow", Description: "emits one result row", Params: []*scm.TypeDescriptor{{Kind: "list", Label: "row", Element: &scm.TypeDescriptor{Kind: "any", Label: "column value"}}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}}, {Kind: "func", Label: "session", Description: "reads or updates request-local values", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "stored value"}}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -78,13 +78,13 @@ func init_alu() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "int?",
-		Desc: "tells if the value is a integer",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(a[0].GetTag() == tagInt)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tells if the value is a integer",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value"},
+				{Kind: "any", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -151,14 +151,14 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "number?",
-		Desc: "tells if the value is a number",
+
 		Fn: func(a ...Scmer) Scmer {
 			tag := a[0].GetTag()
 			return NewBool(tag == tagFloat || tag == tagInt || tag == tagDate)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tells if the value is a number",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value"},
+				{Kind: "any", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -750,13 +750,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "symbol?",
-		Desc: "tells if the value is a symbol",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(a[0].GetTag() == tagSymbol)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tells if the value is a symbol",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value"},
+				{Kind: "any", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -824,7 +824,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "+",
-		Desc: "adds two or more numbers",
+
 		Fn: func(a ...Scmer) Scmer {
 			// Fast path: accumulate ints until first non-int, then promote to float if needed
 			var sumInt int64
@@ -852,9 +852,9 @@ func init_alu() {
 			}
 			return NewFloat(sumFloat)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "adds two or more numbers",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value...", ParamDesc: "values to add", Variadic: true},
+				{Kind: "number", Label: "value...", Description: "values to add", Variadic: true},
 			},
 			Return:   &TypeDescriptor{Kind: "number"},
 			Const:    true,
@@ -4121,7 +4121,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_sum_reduce",
-		Desc: "adds two SQL SUM values while treating NULL as the empty aggregate identity",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return a[1]
@@ -4134,10 +4134,10 @@ func init_alu() {
 			}
 			return NewFloat(a[0].Float() + a[1].Float())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "adds two SQL SUM values while treating NULL as the empty aggregate identity",
 			Params: []*TypeDescriptor{
-				{Kind: "number|nil", ParamName: "left", ParamDesc: "partial sum"},
-				{Kind: "number|nil", ParamName: "right", ParamDesc: "next value"},
+				{Kind: "number|nil", Label: "left", Description: "partial sum"},
+				{Kind: "number|nil", Label: "right", Description: "next value"},
 			},
 			Return: &TypeDescriptor{Kind: "number|nil"},
 			Const:  true,
@@ -5449,7 +5449,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "-",
-		Desc: "subtracts two or more numbers from the first one",
+
 		Fn: func(a ...Scmer) Scmer {
 			// Nil short-circuit
 			for _, v := range a {
@@ -5481,9 +5481,9 @@ func init_alu() {
 			}
 			return NewFloat(diffFloat)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "subtracts two or more numbers from the first one",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
+				{Kind: "number", Label: "value...", Description: "values", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -13702,14 +13702,14 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_add_numeric_literals",
-		Desc: "adds two SQL numeric literals using their exact decimal spellings",
+
 		Fn: func(a ...Scmer) Scmer {
 			return sqlLiteralArithmetic(a[0], a[1], false)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "adds two SQL numeric literals using their exact decimal spellings",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "a", ParamDesc: "left literal"},
-				{Kind: "number", ParamName: "b", ParamDesc: "right literal"},
+				{Kind: "number", Label: "a", Description: "left literal"},
+				{Kind: "number", Label: "b", Description: "right literal"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -13865,14 +13865,14 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_sub_numeric_literals",
-		Desc: "subtracts two SQL numeric literals using their exact decimal spellings",
+
 		Fn: func(a ...Scmer) Scmer {
 			return sqlLiteralArithmetic(a[0], a[1], true)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "subtracts two SQL numeric literals using their exact decimal spellings",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "a", ParamDesc: "left literal"},
-				{Kind: "number", ParamName: "b", ParamDesc: "right literal"},
+				{Kind: "number", Label: "a", Description: "left literal"},
+				{Kind: "number", Label: "b", Description: "right literal"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -14028,7 +14028,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "*",
-		Desc: "multiplies two or more numbers",
+
 		Fn: func(a ...Scmer) Scmer {
 			// Nil short-circuit (SQL-style): if any arg is nil, result is nil
 			for _, v := range a {
@@ -14064,9 +14064,9 @@ func init_alu() {
 			}
 			return NewFloat(prodFloat)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "multiplies two or more numbers",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
+				{Kind: "number", Label: "value...", Description: "values", Variadic: true},
 			},
 			Return:   &TypeDescriptor{Kind: "number"},
 			Const:    true,
@@ -20770,7 +20770,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "/",
-		Desc: "divides two or more numbers from the first one",
+
 		Fn: func(a ...Scmer) Scmer {
 			// Nil short-circuit
 			for _, v := range a {
@@ -20784,9 +20784,9 @@ func init_alu() {
 			}
 			return NewFloat(v)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "divides two or more numbers from the first one",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value...", ParamDesc: "values", Variadic: true},
+				{Kind: "number", Label: "value...", Description: "values", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -20796,7 +20796,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mod",
-		Desc: "returns the remainder of integer division (modulo)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -20814,10 +20814,10 @@ func init_alu() {
 			}
 			return NewFloat(float64(int64(a[0].Float()) % int64(b)))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the remainder of integer division (modulo)",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "a", ParamDesc: "dividend"},
-				{Kind: "number", ParamName: "b", ParamDesc: "divisor"},
+				{Kind: "number", Label: "a", Description: "dividend"},
+				{Kind: "number", Label: "b", Description: "divisor"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -22675,17 +22675,17 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "<=",
-		Desc: "compares two numbers or strings; returns nil if either value is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
 			}
 			return NewBool(!Less(a[1], a[0]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compares two numbers or strings; returns nil if either value is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -23214,17 +23214,17 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "<",
-		Desc: "compares two numbers or strings; returns nil if either value is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
 			}
 			return NewBool(Less(a[0], a[1]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compares two numbers or strings; returns nil if either value is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -23717,17 +23717,17 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: ">",
-		Desc: "compares two numbers or strings; returns nil if either value is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
 			}
 			return NewBool(Less(a[1], a[0]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compares two numbers or strings; returns nil if either value is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -24220,17 +24220,17 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: ">=",
-		Desc: "compares two numbers or strings; returns nil if either value is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
 			}
 			return NewBool(!Less(a[0], a[1]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compares two numbers or strings; returns nil if either value is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -24759,14 +24759,14 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "equal?",
-		Desc: "compares two values of the same type, (equal? nil nil) is true",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(Equal(a[0], a[1]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compares two values of the same type, (equal? nil nil) is true",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -24898,14 +24898,14 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "equal??",
-		Desc: "performs a SQL compliant sloppy equality check on primitive values (number, int, string, bool. nil), strings are compared case insensitive, (equal? nil nil) is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			return EqualSQL(a[0], a[1])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "performs a SQL compliant sloppy equality check on primitive values (number, int, string, bool. nil), strings are compared case insensitive, (equal? nil nil) is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "first value"},
-				{Kind: "any", ParamName: "b", ParamDesc: "second value"},
+				{Kind: "any", Label: "a", Description: "first value"},
+				{Kind: "any", Label: "b", Description: "second value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25057,15 +25057,15 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_not",
-		Desc: "negates a SQL predicate while preserving nil as UNKNOWN",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
 			}
 			return NewBool(!a[0].Bool())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{{Kind: "any", ParamName: "value", ParamDesc: "SQL predicate value"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "negates a SQL predicate while preserving nil as UNKNOWN",
+			Params: []*TypeDescriptor{{Kind: "any", Label: "value", Description: "SQL predicate value"}},
 			// SQL NOT is nullable: UNKNOWN remains UNKNOWN. Advertising a concrete
 			// bool lets expression optimization replace it with two-valued `not`.
 			Return: &TypeDescriptor{Kind: "bool|nil"},
@@ -25344,7 +25344,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "equal_collate",
-		Desc: "performs SQL equality with a specified collation (e.g. *_ci case-insensitive, *_bin case-sensitive); returns nil if either arg is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -25362,11 +25362,11 @@ func init_alu() {
 			}
 			return EqualSQL(a[0], a[1])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "performs SQL equality with a specified collation (e.g. *_ci case-insensitive, *_bin case-sensitive); returns nil if either arg is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "left side"},
-				{Kind: "any", ParamName: "b", ParamDesc: "right side"},
-				{Kind: "string", ParamName: "collation", ParamDesc: "collation name"},
+				{Kind: "any", Label: "a", Description: "left side"},
+				{Kind: "any", Label: "b", Description: "right side"},
+				{Kind: "string", Label: "collation", Description: "collation name"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25376,7 +25376,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "notequal_collate",
-		Desc: "performs SQL inequality with a specified collation; returns nil if either arg is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			r := Globalenv.Vars["equal_collate"].Func()(a[0], a[1], a[2])
 			if r.IsNil() {
@@ -25384,11 +25384,11 @@ func init_alu() {
 			}
 			return NewBool(!r.Bool())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "performs SQL inequality with a specified collation; returns nil if either arg is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "a", ParamDesc: "left side"},
-				{Kind: "any", ParamName: "b", ParamDesc: "right side"},
-				{Kind: "string", ParamName: "collation", ParamDesc: "collation name"},
+				{Kind: "any", Label: "a", Description: "left side"},
+				{Kind: "any", Label: "b", Description: "right side"},
+				{Kind: "string", Label: "collation", Description: "collation name"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25398,13 +25398,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "!",
-		Desc: "negates the boolean value",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(!a[0].Bool())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "negates the boolean value",
 			Params: []*TypeDescriptor{
-				{Kind: "bool", ParamName: "value", ParamDesc: "value"},
+				{Kind: "bool", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25487,13 +25487,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "not",
-		Desc: "negates the boolean value",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(!a[0].Bool())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "negates the boolean value",
 			Params: []*TypeDescriptor{
-				{Kind: "bool", ParamName: "value", ParamDesc: "value"},
+				{Kind: "bool", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25576,13 +25576,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "nil?",
-		Desc: "returns true if value is nil",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(a[0].IsNil())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns true if value is nil",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value"},
+				{Kind: "any", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -25640,7 +25640,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "min",
-		Desc: "returns the smallest value",
+
 		Fn: func(a ...Scmer) Scmer {
 			var result Scmer
 			for _, v := range a {
@@ -25652,9 +25652,9 @@ func init_alu() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the smallest value",
 			Params: []*TypeDescriptor{
-				{Kind: "number|string", ParamName: "value...", ParamDesc: "value", Variadic: true},
+				{Kind: "number|string", Label: "value...", Description: "value", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number|string"},
 			Const:  true,
@@ -27889,7 +27889,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "max",
-		Desc: "returns the highest value",
+
 		Fn: func(a ...Scmer) Scmer {
 			var result Scmer
 			for _, v := range a {
@@ -27901,9 +27901,9 @@ func init_alu() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the highest value",
 			Params: []*TypeDescriptor{
-				{Kind: "number|string", ParamName: "value...", ParamDesc: "value", Variadic: true},
+				{Kind: "number|string", Label: "value...", Description: "value", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "number|string"},
 			Const:  true,
@@ -30138,13 +30138,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "floor",
-		Desc: "rounds the number down",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewFloat(math.Floor(a[0].Float()))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "rounds the number down",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value", ParamDesc: "value"},
+				{Kind: "number", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -30238,13 +30238,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "ceil",
-		Desc: "rounds the number up",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewFloat(math.Ceil(a[0].Float()))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "rounds the number up",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value", ParamDesc: "value"},
+				{Kind: "number", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -30338,13 +30338,13 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "round",
-		Desc: "rounds the number",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewFloat(math.Round(a[0].Float()))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "rounds the number",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value", ParamDesc: "value"},
+				{Kind: "number", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -30423,7 +30423,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_decimal_output",
-		Desc: "normalizes a DECIMAL-derived result to its declared output scale",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -30438,10 +30438,10 @@ func init_alu() {
 			}
 			return NewFloat(roundSQLDecimalOutput(value, scale))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "normalizes a DECIMAL-derived result to its declared output scale",
 			Params: []*TypeDescriptor{
-				{Kind: "number|nil", ParamName: "value", ParamDesc: "DECIMAL-derived value"},
-				{Kind: "int", ParamName: "scale", ParamDesc: "declared decimal scale"},
+				{Kind: "number|nil", Label: "value", Description: "DECIMAL-derived value"},
+				{Kind: "int", Label: "scale", Description: "declared decimal scale"},
 			},
 			Return: &TypeDescriptor{Kind: "number|nil"},
 			Const:  true,
@@ -31763,7 +31763,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_abs",
-		Desc: "SQL ABS(): returns absolute value, NULL-safe",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -31778,9 +31778,9 @@ func init_alu() {
 			}
 			return NewFloat(v)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL ABS(): returns absolute value, NULL-safe",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value", ParamDesc: "value"},
+				{Kind: "number", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -33330,7 +33330,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sqrt",
-		Desc: "returns the square root of a number",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -33341,9 +33341,9 @@ func init_alu() {
 			}
 			return NewFloat(math.Sqrt(v))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the square root of a number",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "value", ParamDesc: "value"},
+				{Kind: "number", Label: "value", Description: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
@@ -33838,7 +33838,7 @@ func init_alu() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_rand",
-		Desc: "SQL RAND(): returns a random float in [0,1)",
+
 		Fn: func(a ...Scmer) Scmer {
 			var buf [8]byte
 			if _, err := crand.Read(buf[:]); err != nil {
@@ -33848,7 +33848,7 @@ func init_alu() {
 			u := binary.LittleEndian.Uint64(buf[:]) >> 11
 			return NewFloat(float64(u) / (1 << 53))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL RAND(): returns a random float in [0,1)",
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
 

--- a/scm/date.go
+++ b/scm/date.go
@@ -121,14 +121,14 @@ func init_date() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_temporal_output",
-		Desc: "formats a temporal SQL result according to its compiler-tracked declared type",
+
 		Fn: func(a ...Scmer) Scmer {
 			return sqlTemporalOutput(a[0], a[1].String())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "formats a temporal SQL result according to its compiler-tracked declared type",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "type-flexible temporal value"},
-				{Kind: "string", ParamName: "sql_type", ParamDesc: "declared SQL temporal type"},
+				{Kind: "any", Label: "value", Description: "type-flexible temporal value"},
+				{Kind: "string", Label: "sql_type", Description: "declared SQL temporal type"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -340,11 +340,11 @@ func init_date() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "now",
-		Desc: "returns the current date/time",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewDate(time.Now().Unix())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current date/time",
 			Return: &TypeDescriptor{Kind: "date"},
 
 			JITEmit: nil,
@@ -352,11 +352,11 @@ func init_date() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "nanotime",
-		Desc: "returns a monotonic nanosecond timestamp for benchmarking (not wall-clock)",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewInt(time.Now().UnixNano())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a monotonic nanosecond timestamp for benchmarking (not wall-clock)",
 			Return: &TypeDescriptor{Kind: "int"},
 
 			JITEmit: nil,
@@ -364,14 +364,14 @@ func init_date() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "current_date",
-		Desc: "returns the current date (midnight in session timezone)",
+
 		Fn: func(a ...Scmer) Scmer {
 			loc := GetCurrentSessionLocation()
 			now := time.Now().In(loc)
 			midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 			return NewDate(midnight.Unix())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current date (midnight in session timezone)",
 			Return: &TypeDescriptor{Kind: "date"},
 
 			JITEmit: nil,
@@ -379,7 +379,7 @@ func init_date() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parse_date",
-		Desc: "parses a date from a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -395,8 +395,8 @@ func init_date() {
 			}
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "values to parse"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "parses a date from a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "values to parse"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 
@@ -405,7 +405,7 @@ func init_date() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "format_date",
-		Desc: "formats a unix timestamp, date, or datetime string into a date string",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -418,8 +418,8 @@ func init_date() {
 			t = t.In(GetCurrentSessionLocation())
 			return NewString(formatDateMySQL(t, String(a[1])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "timestamp", ParamDesc: "unix timestamp, date, or datetime string"}, &TypeDescriptor{Kind: "string", ParamName: "format", ParamDesc: "MySQL-style format string (e.g. %Y-%m-%d %H:%i:%s)"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "formats a unix timestamp, date, or datetime string into a date string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "timestamp", Description: "unix timestamp, date, or datetime string"}, &TypeDescriptor{Kind: "string", Label: "format", Description: "MySQL-style format string (e.g. %Y-%m-%d %H:%i:%s)"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -430,7 +430,7 @@ func init_date() {
 	// EXTRACT(field FROM expr) - implemented as extract_date(expr, field)
 	Declare(&Globalenv, &Declaration{
 		Name: "extract_date",
-		Desc: "extracts a date field (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER, WEEK, DAYOFWEEK, WEEKDAY) from a date value",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -469,8 +469,8 @@ func init_date() {
 				panic("unknown EXTRACT field: " + field)
 			}
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "date value"}, &TypeDescriptor{Kind: "string", ParamName: "field", ParamDesc: "field name: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER, WEEK, DAYOFWEEK, WEEKDAY"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "extracts a date field (YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER, WEEK, DAYOFWEEK, WEEKDAY) from a date value",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "date value"}, &TypeDescriptor{Kind: "string", Label: "field", Description: "field name: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER, WEEK, DAYOFWEEK, WEEKDAY"}},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
 
@@ -481,7 +481,7 @@ func init_date() {
 	// DATE_ADD(expr, interval_seconds)
 	Declare(&Globalenv, &Declaration{
 		Name: "date_add",
-		Desc: "adds an interval to a date value",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -512,8 +512,8 @@ func init_date() {
 			}
 			return NewDate(t.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "date value"}, &TypeDescriptor{Kind: "int", ParamName: "amount", ParamDesc: "interval amount"}, &TypeDescriptor{Kind: "string", ParamName: "unit", ParamDesc: "interval unit: DAY, WEEK, MONTH, YEAR, HOUR, MINUTE, SECOND"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "adds an interval to a date value",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "date value"}, &TypeDescriptor{Kind: "int", Label: "amount", Description: "interval amount"}, &TypeDescriptor{Kind: "string", Label: "unit", Description: "interval unit: DAY, WEEK, MONTH, YEAR, HOUR, MINUTE, SECOND"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 
@@ -524,7 +524,7 @@ func init_date() {
 	// DATE_SUB(expr, amount, unit)
 	Declare(&Globalenv, &Declaration{
 		Name: "date_sub",
-		Desc: "subtracts an interval from a date value",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -555,8 +555,8 @@ func init_date() {
 			}
 			return NewDate(t.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "date value"}, &TypeDescriptor{Kind: "int", ParamName: "amount", ParamDesc: "interval amount"}, &TypeDescriptor{Kind: "string", ParamName: "unit", ParamDesc: "interval unit: DAY, WEEK, MONTH, YEAR, HOUR, MINUTE, SECOND"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "subtracts an interval from a date value",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "date value"}, &TypeDescriptor{Kind: "int", Label: "amount", Description: "interval amount"}, &TypeDescriptor{Kind: "string", Label: "unit", Description: "interval unit: DAY, WEEK, MONTH, YEAR, HOUR, MINUTE, SECOND"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 
@@ -567,7 +567,7 @@ func init_date() {
 	// DATE(expr) - truncate to date only (midnight)
 	Declare(&Globalenv, &Declaration{
 		Name: "date_trunc_day",
-		Desc: "truncates a datetime to date (midnight UTC)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -579,8 +579,8 @@ func init_date() {
 			midnight := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 			return NewDate(midnight.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "date/datetime value"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "truncates a datetime to date (midnight UTC)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "date/datetime value"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 
@@ -591,7 +591,7 @@ func init_date() {
 	// TIMESTAMPDIFF(unit, datetime1, datetime2) - returns datetime2 - datetime1 in the given unit
 	Declare(&Globalenv, &Declaration{
 		Name: "timestampdiff",
-		Desc: "returns the difference between two datetime values in the specified unit (datetime2 - datetime1)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[1].IsNil() || a[2].IsNil() {
 				return NewNil()
@@ -647,11 +647,11 @@ func init_date() {
 				panic("unknown TIMESTAMPDIFF unit: " + unit)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the difference between two datetime values in the specified unit (datetime2 - datetime1)",
 			Params: []*TypeDescriptor{
-				{Kind: "string", ParamName: "unit", ParamDesc: "unit: MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR"},
-				{Kind: "any", ParamName: "datetime1", ParamDesc: "first datetime value"},
-				{Kind: "any", ParamName: "datetime2", ParamDesc: "second datetime value"},
+				{Kind: "string", Label: "unit", Description: "unit: MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR"},
+				{Kind: "any", Label: "datetime1", Description: "first datetime value"},
+				{Kind: "any", Label: "datetime2", Description: "second datetime value"},
 			},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
@@ -663,7 +663,7 @@ func init_date() {
 	// DATEDIFF(date1, date2) - returns number of days between two dates
 	Declare(&Globalenv, &Declaration{
 		Name: "datediff",
-		Desc: "returns number of days between two dates (date1 - date2)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -678,8 +678,8 @@ func init_date() {
 			days := int64(d1.Sub(d2).Hours() / 24)
 			return NewInt(days)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "date1", ParamDesc: "first date"}, &TypeDescriptor{Kind: "any", ParamName: "date2", ParamDesc: "second date"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns number of days between two dates (date1 - date2)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "date1", Description: "first date"}, &TypeDescriptor{Kind: "any", Label: "date2", Description: "second date"}},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
 
@@ -690,7 +690,7 @@ func init_date() {
 	// STR_TO_DATE(str, format) - parse string with MySQL format to date
 	Declare(&Globalenv, &Declaration{
 		Name: "str_to_date",
-		Desc: "parses a string with MySQL format specifiers to a date",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -703,8 +703,8 @@ func init_date() {
 			}
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "date string"}, &TypeDescriptor{Kind: "string", ParamName: "format", ParamDesc: "MySQL format string (e.g. %Y-%m-%d)"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "parses a string with MySQL format specifiers to a date",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "date string"}, &TypeDescriptor{Kind: "string", Label: "format", Description: "MySQL format string (e.g. %Y-%m-%d)"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -783,6 +783,21 @@ func replaceTypeKind(kinds, wanted, replacement string) string {
 	return strings.Join(parts, "|")
 }
 
+// documentedTypeName keeps function signatures compact when their parameters
+// and return type are rendered as a nested structure immediately below them.
+func documentedTypeName(td *TypeDescriptor) string {
+	if td == nil {
+		return "any"
+	}
+	if hasTypeKind(td.Kind, "func") && (len(td.Params) > 0 || td.Return != nil) {
+		if td.Kind == "" {
+			return "func"
+		}
+		return td.Kind
+	}
+	return FormatTypeSignature(td)
+}
+
 // WriteDocumentation writes a Markdown list item for a type and recursively
 // documents nested lists, assoc fields, callback parameters, and return types.
 // depth controls the initial list indentation, using two spaces per level.
@@ -803,7 +818,7 @@ func (td *TypeDescriptor) writeDocumentation(w io.Writer, depth int, fallbackLab
 	if label != "" {
 		fmt.Fprintf(w, "**%s** ", label)
 	}
-	fmt.Fprintf(w, "(`%s`)", FormatTypeSignature(td))
+	fmt.Fprintf(w, "(`%s`)", documentedTypeName(td))
 	if td.Description != "" {
 		fmt.Fprintf(w, ": %s", td.Description)
 	}
@@ -844,17 +859,56 @@ func (td *TypeDescriptor) writeDocumentation(w io.Writer, depth int, fallbackLab
 	}
 }
 
-// formatParamLine formats a single parameter for Help/Docs output,
-// including callback signature details when Kind is "func".
-func formatParamLine(p *TypeDescriptor) string {
-	line := " - " + p.Label + " (" + FormatTypeSignature(p) + "): " + p.Description
-	if p.Optional {
-		line += " [optional]"
+func (td *TypeDescriptor) writeHelp(w io.Writer, depth int, fallbackLabel string) {
+	if td == nil {
+		td = &TypeDescriptor{Kind: "any"}
 	}
-	if p.Variadic {
-		line += " [variadic]"
+	label := td.Label
+	if label == "" {
+		label = fallbackLabel
 	}
-	return line
+	indent := strings.Repeat("  ", depth)
+	fmt.Fprint(w, indent+" - ")
+	if label != "" {
+		fmt.Fprint(w, label+" ")
+	}
+	fmt.Fprintf(w, "(%s)", documentedTypeName(td))
+	if td.Description != "" {
+		fmt.Fprint(w, ": "+td.Description)
+	}
+	if td.Optional {
+		fmt.Fprint(w, " [optional]")
+	}
+	if td.Variadic {
+		fmt.Fprint(w, " [variadic]")
+	}
+	fmt.Fprintln(w)
+
+	if hasTypeKind(td.Kind, "list") && td.Element != nil {
+		td.Element.writeHelp(w, depth+1, "elements")
+	}
+	if hasTypeKind(td.Kind, "assoc") {
+		keys := make([]string, 0, len(td.Keys))
+		for key := range td.Keys {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			td.Keys[key].writeHelp(w, depth+1, key)
+		}
+	}
+	if hasTypeKind(td.Kind, "func") {
+		if len(td.Params) > 0 {
+			fmt.Fprintln(w, indent+"   Parameters:")
+			for _, param := range td.Params {
+				param.writeHelp(w, depth+2, "parameter")
+			}
+		}
+		if td.Return != nil {
+			fmt.Fprintln(w, indent+"   Returns:")
+			td.Return.writeHelp(w, depth+2, "value")
+		}
+	}
 }
 
 func Help(fn Scmer) string {
@@ -878,13 +932,13 @@ func Help(fn Scmer) string {
 			if def.Type != nil {
 				for _, p := range def.Type.Params {
 					if p != nil {
-						b.WriteString(formatParamLine(p) + "\n")
+						p.writeHelp(&b, 0, "parameter")
 					}
 				}
 			}
 			if def.Type != nil && def.Type.Return != nil {
-				retStr := FormatTypeSignature(def.Type.Return)
-				b.WriteString("\nReturns: " + retStr + "\n")
+				b.WriteString("\nReturns:\n")
+				def.Type.Return.writeHelp(&b, 0, "value")
 			}
 			b.WriteString("\n")
 		} else {

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -16,15 +16,16 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 */
 package scm
 
-import "os"
 import "fmt"
-import "strings"
+import "io"
+import "os"
 import "path/filepath"
+import "sort"
+import "strings"
 
 // Declaration describes a built-in or Scheme-defined function.
 type Declaration struct {
 	Name string
-	Desc string
 	Fn   func(...Scmer) Scmer
 	Type *TypeDescriptor
 }
@@ -68,8 +69,8 @@ type TypeDescriptor struct {
 	Variadic       bool                       // for func params: last param accepts 0+ values
 	Forbidden      bool                       // for func: optimizer-only, hidden from help
 	HasSideEffects bool                       // for func: true = call has side effects, cannot be eliminated even if result unused
-	ParamName      string                     // for func params: documentation name
-	ParamDesc      string                     // for func params: documentation description
+	Label          string                     // human-readable label at any nesting level
+	Description    string                     // user-facing documentation at any nesting level
 	Params         []*TypeDescriptor          // for Kind="func": parameter types
 	Return         *TypeDescriptor            // for Kind="func": return type
 	Keys           map[string]*TypeDescriptor // for Kind="assoc": per-key type info
@@ -273,6 +274,7 @@ func (d *Declaration) IsFoldable() bool {
 }
 
 func Declare(env *Env, def *Declaration) {
+	validateDeclaration(def)
 	if !def.IsForbidden() {
 		declaration_titles = append(declaration_titles, def.Name)
 	}
@@ -287,6 +289,7 @@ func Declare(env *Env, def *Declaration) {
 // existing named section in the help index. If the section is not found,
 // it falls back to a normal Declare (appending at the end).
 func DeclareInSection(section string, env *Env, def *Declaration) {
+	validateDeclaration(def)
 	declarations[def.Name] = def
 	if def.Fn != nil {
 		declarations_hash[fmt.Sprintf("%p", def.Fn)] = def
@@ -314,6 +317,12 @@ func DeclareInSection(section string, env *Env, def *Declaration) {
 		return
 	}
 	declaration_titles = append(declaration_titles[:insertAt], append([]string{def.Name}, declaration_titles[insertAt:]...)...)
+}
+
+func validateDeclaration(def *Declaration) {
+	if def == nil || def.Type == nil || def.Type.Kind != "func" {
+		panic("declaration requires a function TypeDescriptor")
+	}
 }
 
 // slugify makes a filesystem-safe, lowercase slug from a chapter title.
@@ -431,8 +440,8 @@ func WriteDocumentation(folder string) error {
 		// Functions in this chapter
 		for _, def := range ch.Fns {
 			fmt.Fprintf(f, "## %s\n\n", def.Name)
-			if def.Desc != "" {
-				fmt.Fprintf(f, "%s\n\n", def.Desc)
+			if def.Type.Description != "" {
+				fmt.Fprintf(f, "%s\n\n", def.Type.Description)
 			}
 			fmt.Fprintf(f, "**Allowed number of parameters:** %d–%d\n\n", def.MinParams(), def.MaxParams())
 
@@ -441,27 +450,19 @@ func WriteDocumentation(folder string) error {
 				fmt.Fprintln(f, "_This function has no parameters._")
 			} else if d, ok := declarations[def.Name]; ok && !d.IsForbidden() {
 				for _, p := range def.Type.Params {
-					kind := p.Kind
-					if kind == "func" && len(p.Params) > 0 {
-						kind = FormatTypeSignature(p)
-					}
-					flags := ""
-					if p.Optional {
-						flags += " _(optional)_"
-					}
-					if p.Variadic {
-						flags += " _(variadic)_"
-					}
-					fmt.Fprintf(f, "- **%s** (`%s`): %s%s\n", p.ParamName, kind, p.ParamDesc, flags)
+					p.WriteDocumentation(f, 0)
 				}
 				fmt.Fprintln(f)
 			}
 
-			retStr := "any"
-			if def.Type != nil && def.Type.Return != nil {
-				retStr = FormatTypeSignature(def.Type.Return)
+			fmt.Fprintln(f, "### Returns")
+			fmt.Fprintln(f)
+			if def.Type.Return == nil {
+				(&TypeDescriptor{Kind: "any"}).writeDocumentation(f, 0, "value")
+			} else {
+				def.Type.Return.writeDocumentation(f, 0, "value")
 			}
-			fmt.Fprintf(f, "### Returns\n\n`%s`\n\n", retStr)
+			fmt.Fprintln(f)
 		}
 
 		_ = f.Close()
@@ -716,56 +717,137 @@ func Validate(val Scmer, require string) string {
 	return "any"
 }
 
-// FormatTypeSignature returns a human-readable type string for a TypeDescriptor.
-// For func types with Params, it produces "func(name:type, ...) -> returntype".
+// FormatTypeSignature returns a compact, recursively rendered type signature.
 func FormatTypeSignature(td *TypeDescriptor) string {
 	if td == nil {
 		return "any"
 	}
-	if td.Kind != "func" || len(td.Params) == 0 {
-		if td.Kind == "" {
-			return "any"
-		}
-		return td.Kind
+	kind := td.Kind
+	if kind == "" {
+		kind = "any"
+	}
+	if hasTypeKind(kind, "list") && td.Element != nil {
+		kind = replaceTypeKind(kind, "list", "list<"+FormatTypeSignature(td.Element)+">")
+	}
+	if !hasTypeKind(kind, "func") {
+		return kind
 	}
 	var b strings.Builder
-	b.WriteString("func(")
+	funcSignature := strings.Builder{}
+	funcSignature.WriteString("func(")
 	for i, p := range td.Params {
 		if i > 0 {
-			b.WriteString(", ")
+			funcSignature.WriteString(", ")
 		}
 		if p == nil {
-			b.WriteString("any")
+			funcSignature.WriteString("any")
 			continue
 		}
-		if p.ParamName != "" {
-			b.WriteString(p.ParamName)
-			b.WriteString(":")
+		if p.Label != "" {
+			funcSignature.WriteString(p.Label)
+			funcSignature.WriteString(":")
 		}
-		b.WriteString(FormatTypeSignature(p))
+		funcSignature.WriteString(FormatTypeSignature(p))
 		if p.Optional {
-			b.WriteString("?")
+			funcSignature.WriteString("?")
 		}
 		if p.Variadic {
-			b.WriteString("...")
+			funcSignature.WriteString("...")
 		}
 	}
-	b.WriteString(")")
+	funcSignature.WriteString(")")
 	if td.Return != nil {
-		b.WriteString(" -> ")
-		b.WriteString(FormatTypeSignature(td.Return))
+		funcSignature.WriteString(" -> ")
+		funcSignature.WriteString(FormatTypeSignature(td.Return))
 	}
+	b.WriteString(replaceTypeKind(kind, "func", funcSignature.String()))
 	return b.String()
+}
+
+func hasTypeKind(kinds, wanted string) bool {
+	for _, kind := range strings.Split(kinds, "|") {
+		if kind == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceTypeKind(kinds, wanted, replacement string) string {
+	parts := strings.Split(kinds, "|")
+	for i, kind := range parts {
+		if kind == wanted {
+			parts[i] = replacement
+		}
+	}
+	return strings.Join(parts, "|")
+}
+
+// WriteDocumentation writes a Markdown list item for a type and recursively
+// documents nested lists, assoc fields, callback parameters, and return types.
+// depth controls the initial list indentation, using two spaces per level.
+func (td *TypeDescriptor) WriteDocumentation(w io.Writer, depth int) {
+	td.writeDocumentation(w, depth, "")
+}
+
+func (td *TypeDescriptor) writeDocumentation(w io.Writer, depth int, fallbackLabel string) {
+	if td == nil {
+		td = &TypeDescriptor{Kind: "any"}
+	}
+	label := td.Label
+	if label == "" {
+		label = fallbackLabel
+	}
+	indent := strings.Repeat("  ", depth)
+	fmt.Fprint(w, indent+"- ")
+	if label != "" {
+		fmt.Fprintf(w, "**%s** ", label)
+	}
+	fmt.Fprintf(w, "(`%s`)", FormatTypeSignature(td))
+	if td.Description != "" {
+		fmt.Fprintf(w, ": %s", td.Description)
+	}
+	if td.Optional {
+		fmt.Fprint(w, " _(optional)_")
+	}
+	if td.Variadic {
+		fmt.Fprint(w, " _(variadic)_")
+	}
+	fmt.Fprintln(w)
+
+	if hasTypeKind(td.Kind, "list") {
+		if td.Element != nil {
+			td.Element.writeDocumentation(w, depth+1, "elements")
+		}
+	}
+	if hasTypeKind(td.Kind, "assoc") {
+		keys := make([]string, 0, len(td.Keys))
+		for key := range td.Keys {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			td.Keys[key].writeDocumentation(w, depth+1, key)
+		}
+	}
+	if hasTypeKind(td.Kind, "func") {
+		if len(td.Params) > 0 {
+			fmt.Fprintln(w, indent+"  - **Parameters**")
+			for _, param := range td.Params {
+				param.writeDocumentation(w, depth+2, "parameter")
+			}
+		}
+		if td.Return != nil {
+			fmt.Fprintln(w, indent+"  - **Returns**")
+			td.Return.writeDocumentation(w, depth+2, "value")
+		}
+	}
 }
 
 // formatParamLine formats a single parameter for Help/Docs output,
 // including callback signature details when Kind is "func".
 func formatParamLine(p *TypeDescriptor) string {
-	kind := p.Kind
-	if kind == "func" && len(p.Params) > 0 {
-		kind = FormatTypeSignature(p)
-	}
-	line := " - " + p.ParamName + " (" + kind + "): " + p.ParamDesc
+	line := " - " + p.Label + " (" + FormatTypeSignature(p) + "): " + p.Description
 	if p.Optional {
 		line += " [optional]"
 	}
@@ -783,7 +865,7 @@ func Help(fn Scmer) string {
 			if title[0] == '#' {
 				b.WriteString("\n-- " + title[1:] + " --\n")
 			} else if d, ok := declarations[title]; ok && !d.IsForbidden() {
-				b.WriteString("  " + title + ": " + strings.Split(d.Desc, "\n")[0] + "\n")
+				b.WriteString("  " + title + ": " + strings.Split(d.Type.Description, "\n")[0] + "\n")
 			}
 		}
 		b.WriteString("\nget further information by typing (help \"functionname\") to get more info\n")
@@ -791,7 +873,7 @@ func Help(fn Scmer) string {
 		def := DeclarationForValue(fn)
 		if def != nil {
 			b.WriteString("Help for: " + def.Name + "\n===\n\n")
-			b.WriteString(def.Desc + "\n\n")
+			b.WriteString(def.Type.Description + "\n\n")
 			b.WriteString(fmt.Sprintf("Allowed nø of parameters: %d-%d\n\n", def.MinParams(), def.MaxParams()))
 			if def.Type != nil {
 				for _, p := range def.Type.Params {

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -64,7 +64,7 @@ func TestTypeDescriptorWritesDeepDocumentation(t *testing.T) {
 		"    - **rows** (`list<list<any>>`): input rows",
 		"      - **row** (`list<any>`)",
 		"        - **value** (`any`)",
-		"    - **visit** (`func(row:list<any>) -> bool`): handles one row",
+		"    - **visit** (`func`): handles one row",
 		"      - **Parameters**",
 		"        - **row** (`list<any>`)",
 		"      - **Returns**",
@@ -120,9 +120,55 @@ func TestWriteDocumentationUsesRecursiveTypeDescriptors(t *testing.T) {
 		t.Fatal(err)
 	}
 	doc := string(content)
-	for _, expected := range []string{"**rows** (`list<list<any>>`)", "**visit** (`func(row:list<any>) -> bool`)", "**results** (`list<string>`)", "**result** (`string`)"} {
+	for _, expected := range []string{"**rows** (`list<list<any>>`)", "**visit** (`func`)", "**results** (`list<string>`)", "**result** (`string`)"} {
 		if !strings.Contains(doc, expected) {
 			t.Fatalf("generated documentation does not contain %q:\n%s", expected, doc)
 		}
+	}
+	if strings.Contains(doc, "**visit** (`func(row:list<any>) -> bool`)") {
+		t.Fatalf("generated documentation repeats an expanded callback signature:\n%s", doc)
+	}
+}
+
+func TestHelpUsesRecursiveTypeDescriptors(t *testing.T) {
+	oldTitles, oldDeclarations, oldHashes := declaration_titles, declarations, declarations_hash
+	defer func() {
+		declaration_titles, declarations, declarations_hash = oldTitles, oldDeclarations, oldHashes
+	}()
+	declaration_titles = nil
+	declarations = make(map[string]*Declaration)
+	declarations_hash = make(map[string]*Declaration)
+
+	env := Env{Vars: make(Vars)}
+	Declare(&env, &Declaration{
+		Name: "nested-help",
+		Fn:   func(...Scmer) Scmer { return NewNil() },
+		Type: &TypeDescriptor{
+			Kind:        "func",
+			Description: "documents nested values",
+			Params:      []*TypeDescriptor{nestedDocumentationType()},
+			Return:      &TypeDescriptor{Kind: "bool", Label: "success"},
+		},
+	})
+
+	help := Help(NewString("nested-help"))
+	for _, expected := range []string{
+		" - options (assoc): configuration fields",
+		"   - rows (list<list<any>>): input rows",
+		"     - row (list<any>)",
+		"       - value (any)",
+		"   - visit (func): handles one row",
+		"     Parameters:",
+		"       - row (list<any>)",
+		"     Returns:",
+		"       - accepted (bool)",
+		"Returns:\n - success (bool)",
+	} {
+		if !strings.Contains(help, expected) {
+			t.Fatalf("recursive help does not contain %q:\n%s", expected, help)
+		}
+	}
+	if strings.Contains(help, "visit (func(row:list<any>) -> bool)") {
+		t.Fatalf("recursive help repeats an expanded callback signature:\n%s", help)
 	}
 }

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -19,6 +19,7 @@ package scm
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -170,5 +171,74 @@ func TestHelpUsesRecursiveTypeDescriptors(t *testing.T) {
 	}
 	if strings.Contains(help, "visit (func(row:list<any>) -> bool)") {
 		t.Fatalf("recursive help repeats an expanded callback signature:\n%s", help)
+	}
+}
+
+func TestFunctionFactoriesDescribeReturnedFunctions(t *testing.T) {
+	tests := []struct {
+		name              string
+		returnLabel       string
+		nestedReturnLabel string
+	}{
+		{name: "make_structural_index", returnLabel: "lookup"},
+		{name: "make_structural_catalog", returnLabel: "catalog", nestedReturnLabel: "value"},
+		{name: "newpromise", returnLabel: "promise"},
+		{name: "newsession", returnLabel: "session"},
+		{name: "once", returnLabel: "once_wrapper"},
+		{name: "mutex", returnLabel: "locked"},
+		{name: "parser", returnLabel: "parser"},
+		{name: "lambda", returnLabel: "lambda"},
+		{name: "collate", returnLabel: "relation"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			declaration := declarations[test.name]
+			if declaration == nil || declaration.Type == nil || declaration.Type.Return == nil {
+				t.Fatalf("%s has no declared return type", test.name)
+			}
+			returned := declaration.Type.Return
+			if !hasTypeKind(returned.Kind, "func") {
+				t.Fatalf("%s return kind = %q, want a function", test.name, returned.Kind)
+			}
+			if returned.Label != test.returnLabel || returned.Description == "" {
+				t.Fatalf("%s returned function label/description = %q/%q", test.name, returned.Label, returned.Description)
+			}
+			if returned.Return == nil || returned.Return.Label == "" || returned.Return.Description == "" {
+				t.Fatalf("%s returned function has an undocumented result: %#v", test.name, returned.Return)
+			}
+			if test.nestedReturnLabel != "" {
+				if !hasTypeKind(returned.Return.Kind, "func") || returned.Return.Return == nil {
+					t.Fatalf("%s does not describe its second-level returned function", test.name)
+				}
+				if returned.Return.Return.Label != test.nestedReturnLabel || returned.Return.Return.Description == "" {
+					t.Fatalf("%s second-level result is undocumented: %#v", test.name, returned.Return.Return)
+				}
+			}
+		})
+	}
+}
+
+func TestCallbackDescriptionsDoNotRepeatStructuredSignatures(t *testing.T) {
+	var inspect func(string, *TypeDescriptor)
+	inspect = func(path string, descriptor *TypeDescriptor) {
+		if descriptor == nil {
+			return
+		}
+		if hasTypeKind(descriptor.Kind, "func") && (strings.Contains(descriptor.Description, "func(") || strings.Contains(descriptor.Description, "lambda(")) {
+			t.Errorf("%s repeats a structured function signature in its description: %q", path, descriptor.Description)
+		}
+		for i, param := range descriptor.Params {
+			inspect(path+".param["+strconv.Itoa(i)+"]", param)
+		}
+		inspect(path+".return", descriptor.Return)
+		inspect(path+".element", descriptor.Element)
+		for key, value := range descriptor.Keys {
+			inspect(path+".key["+key+"]", value)
+		}
+	}
+
+	for name, declaration := range declarations {
+		inspect(name, declaration.Type)
 	}
 }

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func nestedDocumentationType() *TypeDescriptor {
+	return &TypeDescriptor{
+		Kind:        "assoc",
+		Label:       "options",
+		Description: "configuration fields",
+		Keys: map[string]*TypeDescriptor{
+			"rows": {
+				Kind:        "list",
+				Label:       "rows",
+				Description: "input rows",
+				Element: &TypeDescriptor{
+					Kind:    "list",
+					Label:   "row",
+					Element: &TypeDescriptor{Kind: "any", Label: "value"},
+				},
+			},
+			"visit": {
+				Kind:        "func",
+				Label:       "visit",
+				Description: "handles one row",
+				Params: []*TypeDescriptor{{
+					Kind:    "list",
+					Label:   "row",
+					Element: &TypeDescriptor{Kind: "any", Label: "value"},
+				}},
+				Return: &TypeDescriptor{Kind: "bool", Label: "accepted"},
+			},
+		},
+	}
+}
+
+func TestTypeDescriptorWritesDeepDocumentation(t *testing.T) {
+	var output strings.Builder
+	nestedDocumentationType().WriteDocumentation(&output, 1)
+	doc := output.String()
+
+	for _, expected := range []string{
+		"  - **options** (`assoc`): configuration fields",
+		"    - **rows** (`list<list<any>>`): input rows",
+		"      - **row** (`list<any>`)",
+		"        - **value** (`any`)",
+		"    - **visit** (`func(row:list<any>) -> bool`): handles one row",
+		"      - **Parameters**",
+		"        - **row** (`list<any>`)",
+		"      - **Returns**",
+		"        - **accepted** (`bool`)",
+	} {
+		if !strings.Contains(doc, expected) {
+			t.Fatalf("nested documentation does not contain %q:\n%s", expected, doc)
+		}
+	}
+	if strings.Index(doc, "**rows**") > strings.Index(doc, "**visit**") {
+		t.Fatalf("assoc fields are not sorted:\n%s", doc)
+	}
+}
+
+func TestFormatTypeSignatureHandlesUnionContainers(t *testing.T) {
+	typeDesc := &TypeDescriptor{
+		Kind:    "list|nil",
+		Element: &TypeDescriptor{Kind: "func|string", Params: []*TypeDescriptor{{Kind: "int", Label: "id"}}, Return: &TypeDescriptor{Kind: "bool"}},
+	}
+	if got, want := FormatTypeSignature(typeDesc), "list<func(id:int) -> bool|string>|nil"; got != want {
+		t.Fatalf("FormatTypeSignature() = %q, want %q", got, want)
+	}
+}
+
+func TestWriteDocumentationUsesRecursiveTypeDescriptors(t *testing.T) {
+	oldTitles, oldDeclarations, oldHashes := declaration_titles, declarations, declarations_hash
+	defer func() {
+		declaration_titles, declarations, declarations_hash = oldTitles, oldDeclarations, oldHashes
+	}()
+	declaration_titles = nil
+	declarations = make(map[string]*Declaration)
+	declarations_hash = make(map[string]*Declaration)
+
+	DeclareTitle("Nested")
+	env := Env{Vars: make(Vars)}
+	Declare(&env, &Declaration{
+		Name: "nested",
+		Fn:   func(...Scmer) Scmer { return NewNil() },
+		Type: &TypeDescriptor{
+			Kind:        "func",
+			Description: "documents nested values",
+			Params:      []*TypeDescriptor{nestedDocumentationType()},
+			Return:      &TypeDescriptor{Kind: "list", Label: "results", Element: &TypeDescriptor{Kind: "string", Label: "result"}},
+		},
+	})
+
+	folder := t.TempDir()
+	if err := WriteDocumentation(folder); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(folder, "nested.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(content)
+	for _, expected := range []string{"**rows** (`list<list<any>>`)", "**visit** (`func(row:list<any>) -> bool`)", "**results** (`list<string>`)", "**result** (`string`)"} {
+		if !strings.Contains(doc, expected) {
+			t.Fatalf("generated documentation does not contain %q:\n%s", expected, doc)
+		}
+	}
+}

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -2110,11 +2110,11 @@ func init_jit() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "jit",
-		Desc: "compiles a lambda to optimized native code when this build enables JIT",
+
 		Fn:   jitCompile,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compiles a lambda to optimized native code when this build enables JIT",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "fn", ParamDesc: "the function to compile"},
+				{Kind: "any", Label: "fn", Description: "the function to compile"},
 			},
 			Return:         &TypeDescriptor{Kind: "any"},
 			HasSideEffects: true,
@@ -2122,13 +2122,13 @@ func init_jit() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "jit?",
-		Desc: "tells whether a value is a JIT-compiled function descriptor",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(a[0].GetTag() == tagJIT || (a[0].GetTag() == tagProc && a[0].Proc() != nil && a[0].Proc().Compiled != nil))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tells whether a value is a JIT-compiled function descriptor",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value to inspect", NoEscape: true},
+				{Kind: "any", Label: "value", Description: "value to inspect", NoEscape: true},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -2195,7 +2195,7 @@ func init_jit() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "jit-warn-if-fallback",
-		Desc: "prints a diagnostic warning when an enabled JIT build kept a procedure interpreted and returns the procedure unchanged",
+
 		Fn: func(a ...Scmer) Scmer {
 			value := a[0]
 			compiled := value.GetTag() == tagJIT || (value.GetTag() == tagProc && value.Proc() != nil && value.Proc().Compiled != nil)
@@ -2208,10 +2208,10 @@ func init_jit() {
 			}
 			return value
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "prints a diagnostic warning when an enabled JIT build kept a procedure interpreted and returns the procedure unchanged",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "procedure", ParamDesc: "procedure expected to be a native compilation candidate"},
-				{Kind: "string", ParamName: "label", ParamDesc: "optional diagnostic label", Optional: true},
+				{Kind: "any", Label: "procedure", Description: "procedure expected to be a native compilation candidate"},
+				{Kind: "string", Label: "label", Description: "optional diagnostic label", Optional: true},
 			},
 			Return:         &TypeDescriptor{Kind: "any"},
 			HasSideEffects: true,
@@ -2219,11 +2219,11 @@ func init_jit() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "jit-enabled?",
-		Desc: "tells whether this binary was built with the patched Go JIT runtime",
+
 		Fn: func(_ ...Scmer) Scmer {
 			return NewBool(jitEnabled)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tells whether this binary was built with the patched Go JIT runtime",
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 

--- a/scm/json_functions.go
+++ b/scm/json_functions.go
@@ -1796,10 +1796,10 @@ func jsonRawScalarResult(value bson.RawValue, returning string) Scmer {
 func declareJSON(name, description string, fn func(...Scmer) Scmer) {
 	Declare(&Globalenv, &Declaration{
 		Name: name,
-		Desc: description,
-		Fn:   fn,
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{{Kind: "any", ParamName: "arguments", Variadic: true}},
+
+		Fn: fn,
+		Type: &TypeDescriptor{Kind: "func", Description: description,
+			Params: []*TypeDescriptor{{Kind: "any", Label: "arguments", Variadic: true}},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 		},

--- a/scm/list.go
+++ b/scm/list.go
@@ -845,7 +845,7 @@ func init_list() {
 	Declare(&Globalenv, &Declaration{
 		Name: "list",
 
-		Fn:   List,
+		Fn: List,
 		Type: &TypeDescriptor{Kind: "func", Description: "constructs a list from its arguments",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "items", Description: "items to put into the list", Variadic: true},
@@ -3128,7 +3128,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that only contains elements that pass the filter function",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be filtered", NoEscape: true},
-				{Kind: "func", Label: "condition", Description: "filter condition func(item)->bool", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "returns whether an item should be included", Params: []*TypeDescriptor{{Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "bool", Label: "included", Description: "whether to include the item"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3156,7 +3156,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns the first list element that passes the condition function, or nil/default if none matches",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list to search", NoEscape: true},
-				{Kind: "func", Label: "condition", Description: "predicate func(any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "predicate applied until the first match", Params: []*TypeDescriptor{{Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "bool", Label: "matches", Description: "whether the item matches"}},
 				{Kind: "any", Label: "default", Description: "optional default value if nothing matches", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
@@ -3180,7 +3180,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the results of a map function that is applied to the list",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be mapped", NoEscape: true},
-				{Kind: "func", Label: "map", Description: "map function func(any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "transforms each item", Params: []*TypeDescriptor{{Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "any", Label: "mapped_item", Description: "transformed item"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -4076,7 +4076,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the results of a map function that is applied to the list",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be mapped", NoEscape: true},
-				{Kind: "func", Label: "map", Description: "map function func(i, any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "transforms each item with its index", Params: []*TypeDescriptor{{Kind: "int", Label: "index", Description: "zero-based item index"}, {Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "any", Label: "mapped_item", Description: "transformed item"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -4108,7 +4108,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the result of a map function",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is a list item", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "current list item"}}, Label: "reduce", Description: "combines the accumulator with each list item", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}},
 				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:   &TypeDescriptor{Kind: "any"},
@@ -6612,7 +6612,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a filtered dictionary according to a filter function",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary that has to be filtered", NoEscape: true},
-				{Kind: "func", Label: "condition", Description: "filter function func(string any)->bool where the first parameter is the key, the second is the value", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "returns whether a dictionary entry should be included", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "bool", Label: "included", Description: "whether to include the entry"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6655,7 +6655,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns the first key/value pair that passes the condition function, or nil/default if none matches",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary to search", NoEscape: true},
-				{Kind: "func", Label: "condition", Description: "predicate func(string any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "predicate applied until the first matching dictionary entry", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "bool", Label: "matches", Description: "whether the entry matches"}},
 				{Kind: "any", Label: "default", Description: "optional default value if nothing matches", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
@@ -6693,7 +6693,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a mapped dictionary according to a map function\nKeys will stay the same but values are mapped.",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary that has to be mapped", NoEscape: true},
-				{Kind: "func", Label: "map", Description: "map function func(string any)->any where the first parameter is the key, the second is the value. It must return the new value.", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "transforms each dictionary value", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "mapped_value", Description: "replacement value"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6723,7 +6723,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "reduces a dictionary according to a reduce function",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary that has to be reduced", NoEscape: true},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "key"}, {Label: "value"}}, Label: "reduce", Description: "reduce function func(any string any)->any where the first parameter is the accumulator, second is key, third is value. It must return the new accumulator.", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Label: "reduce", Description: "combines the accumulator with each dictionary entry", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}},
 				{Kind: "any", Label: "neutral", Description: "initial value for the accumulator"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
@@ -6735,25 +6735,27 @@ func init_list() {
 	Declare(&Globalenv, &Declaration{
 		Name: "make_structural_index",
 
-		Fn:   NewStructuralIndex,
+		Fn: NewStructuralIndex,
 		Type: &TypeDescriptor{Kind: "func", Description: "Builds an immutable structural-expression index. It eagerly hashes every key and every node under roots, then returns a parallel-safe lookup function that maps an equal expression to its zero-based key position or nil.",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "keys", Description: "immutable structural expressions to index"},
 				{Kind: "list", Label: "roots", Description: "immutable expression roots whose descendant hashes are precomputed"},
 			},
 			Return: &TypeDescriptor{
-				Kind: "func",
+				Kind:        "func",
+				Label:       "lookup",
+				Description: "looks up the indexed position of a structurally equal expression",
 				Params: []*TypeDescriptor{
 					{Kind: "any", Label: "expression", Description: "a key, root, descendant of a declared root, or scalar expression"},
 				},
-				Return: &TypeDescriptor{Kind: "int|nil"},
+				Return: &TypeDescriptor{Kind: "int|nil", Label: "position", Description: "zero-based key position, or nil when the expression is not indexed"},
 			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "make_structural_catalog",
 
-		Fn:   NewStructuralCatalog,
+		Fn: NewStructuralCatalog,
 		Type: &TypeDescriptor{Kind: "func", Description: "Creates an atomic compile-local structural catalog. Look up with (catalog key), insert with (catalog key value), or freeze with (catalog) for parallel-safe read-only lookup.",
 			Params: []*TypeDescriptor{
 				{Kind: "bool|symbol", Label: "mode", Description: "true forces collisions for tests; ast selects type-stable compiler equality", Optional: true},
@@ -6763,7 +6765,12 @@ func init_list() {
 					{Kind: "any", Label: "key", Description: "expression to look up; omit to freeze the catalog", Optional: true},
 					{Kind: "any", Label: "value", Description: "value to store for key", Optional: true},
 				},
-				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "stored value, lookup result, or frozen lookup function"},
+				Return: &TypeDescriptor{Kind: "any|func", Label: "result", Description: "stored value, lookup result, or frozen lookup function",
+					Params: []*TypeDescriptor{
+						{Kind: "any", Label: "key", Description: "expression to look up in the frozen catalog"},
+					},
+					Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "value stored for a structurally equal expression, or nil"},
+				},
 			},
 		},
 	})
@@ -6887,7 +6894,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "applies a function (key value) on the dictionary and returns the results as a flat list",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary that has to be checked", NoEscape: true},
-				{Kind: "func", Label: "map", Description: "func(key, value)->any that extracts one element per key-value pair", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "extracts one element per dictionary entry", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "element", Description: "element extracted from the entry"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6939,7 +6946,7 @@ func init_list() {
 				{Kind: "list", Label: "dict", Description: "input dictionary"},
 				{Kind: "string", Label: "key", Description: "key that has to be set"},
 				{Kind: "any", Label: "value", Description: "new value to set"},
-				{Kind: "func", Label: "merge", Description: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value. It must return the merged value that shall be physically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "merge", Description: "combines values when an existing entry is overwritten", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old", Description: "existing value"}, {Kind: "any", Label: "new", Description: "replacement value"}}, Return: &TypeDescriptor{Kind: "any", Label: "merged", Description: "value stored in the new dictionary"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6975,7 +6982,7 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict1", Description: "first input dictionary that has to be changed. You must not use this value again."},
 				{Kind: "list", Label: "dict2", Description: "input dictionary that contains the new values that have to be added"},
-				{Kind: "func", Label: "merge", Description: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value from dict2. It must return the merged value that shall be pysically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "merge", Description: "combines values when both dictionaries contain an entry", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old", Description: "value from the first dictionary"}, {Kind: "any", Label: "new", Description: "value from the second dictionary"}}, Return: &TypeDescriptor{Kind: "any", Label: "merged", Description: "value stored in the merged dictionary"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -7136,7 +7143,7 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
 				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "mapped item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}, Description: "combines the accumulator with each mapped item"},
 				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
@@ -7176,7 +7183,7 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
 				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the list item"},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "current list item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}, Description: "combines the accumulator with each list item"},
 				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
@@ -7224,7 +7231,7 @@ func init_list() {
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "lhs", Description: "first list to reduce"},
 				{Kind: "list", Label: "rhs", Description: "second list to reduce"},
-				{Kind: "func", Label: "reduce", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "func", Label: "reduce", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "mapped item"}}, Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}, Description: "combines the accumulator with each mapped item"},
 				{Kind: "any", Label: "neutral", Description: "optional initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
@@ -7267,7 +7274,7 @@ func init_list() {
 				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
 				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "mapped item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}, Description: "combines the accumulator with each mapped item"},
 				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
@@ -7310,7 +7317,7 @@ func init_list() {
 				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
 				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
 				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "func", Params: []*TypeDescriptor{{Kind: "any", Transfer: true, Label: "acc", Description: "current accumulator"}, {Kind: "any", Label: "item", Description: "mapped item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any", Label: "acc", Description: "next accumulator"}, Description: "combines the accumulator with each mapped item"},
 				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
@@ -8960,7 +8967,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place mapIndex (optimizer-only)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "owned list to map in-place"},
-				{Kind: "func", Label: "map", Description: "map function func(i, any)->any", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "transforms each item with its index", Params: []*TypeDescriptor{{Kind: "int", Label: "index", Description: "zero-based item index"}, {Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "any", Label: "mapped_item", Description: "transformed item"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -8998,7 +9005,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place map_assoc (optimizer-only, slice path only)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "owned dictionary to map in-place"},
-				{Kind: "func", Label: "map", Description: "map function func(key, value)->value", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "transforms each dictionary value", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "mapped_value", Description: "replacement value"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9028,7 +9035,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place filter (optimizer-only)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "list", Description: "owned list to filter in-place"},
-				{Kind: "func", Label: "condition", Description: "filter condition func(any)->bool", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "returns whether an item should be included", Params: []*TypeDescriptor{{Kind: "any", Label: "item", Description: "current list item"}}, Return: &TypeDescriptor{Kind: "bool", Label: "included", Description: "whether to include the item"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9089,7 +9096,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place filter_assoc (optimizer-only)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "owned dictionary to filter in-place"},
-				{Kind: "func", Label: "condition", Description: "filter function func(key, value)->bool", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "returns whether a dictionary entry should be included", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "bool", Label: "included", Description: "whether to include the entry"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9123,7 +9130,7 @@ func init_list() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place extract_assoc (optimizer-only)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "owned dictionary to extract from in-place"},
-				{Kind: "func", Label: "map", Description: "func(key, value)->any that extracts each element", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "extracts one element per dictionary entry", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "entry key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "element", Description: "element extracted from the entry"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,

--- a/scm/list.go
+++ b/scm/list.go
@@ -844,11 +844,11 @@ func init_list() {
 	// in declarations so serialization can resolve the function pointer.
 	Declare(&Globalenv, &Declaration{
 		Name: "list",
-		Desc: "constructs a list from its arguments",
+
 		Fn:   List,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "constructs a list from its arguments",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "items", ParamDesc: "items to put into the list", Variadic: true},
+				{Kind: "any", Label: "items", Description: "items to put into the list", Variadic: true},
 			},
 			Return:         &TypeDescriptor{Kind: "list", Length: UnknownLength},
 			Const:          true,
@@ -900,7 +900,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "count",
-		Desc: "counts the number of elements in the list",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].GetTag() == tagSlice {
 				return NewInt(int64(len(a[0].Slice())))
@@ -914,9 +914,9 @@ func init_list() {
 			}
 			panic("count expects a list")
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "counts the number of elements in the list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "base list", NoEscape: true},
+				{Kind: "list", Label: "list", Description: "base list", NoEscape: true},
 			},
 			Return:   &TypeDescriptor{Kind: "int"},
 			Const:    true,
@@ -927,7 +927,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "nth",
-		Desc: "get the nth item of a list",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "nth")
 			idx := int(a[1].Int())
@@ -936,10 +936,10 @@ func init_list() {
 			}
 			return list[idx]
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "get the nth item of a list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "base list", NoEscape: true},
-				{Kind: "number", ParamName: "index", ParamDesc: "index beginning from 0"},
+				{Kind: "list", Label: "list", Description: "base list", NoEscape: true},
+				{Kind: "number", Label: "index", Description: "index beginning from 0"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -1579,7 +1579,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "nth_mut",
-		Desc: "sets the nth item of an owned list in-place and returns the mutated list",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "nth_mut")
 			idx := int(a[1].Int())
@@ -1589,11 +1589,11 @@ func init_list() {
 			list[idx] = a[2]
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "sets the nth item of an owned list in-place and returns the mutated list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned base list"},
-				{Kind: "number", ParamName: "index", ParamDesc: "index beginning from 0"},
-				{Kind: "any", ParamName: "value", ParamDesc: "new value"},
+				{Kind: "list", Label: "list", Description: "owned base list"},
+				{Kind: "number", Label: "index", Description: "index beginning from 0"},
+				{Kind: "any", Label: "value", Description: "new value"},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -1604,7 +1604,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "slice",
-		Desc: "extract a sublist from start (inclusive) to end (exclusive).\n(slice list start end) returns elements list[start..end).",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "slice")
 			start := int(a[1].Int())
@@ -1622,11 +1622,11 @@ func init_list() {
 			copy(result, list[start:end])
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "extract a sublist from start (inclusive) to end (exclusive).\n(slice list start end) returns elements list[start..end).",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "base list", NoEscape: true},
-				{Kind: "number", ParamName: "start", ParamDesc: "start index (inclusive)"},
-				{Kind: "number", ParamName: "end", ParamDesc: "end index (exclusive)"},
+				{Kind: "list", Label: "list", Description: "base list", NoEscape: true},
+				{Kind: "number", Label: "start", Description: "start index (inclusive)"},
+				{Kind: "number", Label: "end", Description: "end index (exclusive)"},
 			},
 			Return: &TypeDescriptor{Kind: "list"},
 			Const:  true,
@@ -1636,7 +1636,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reverse",
-		Desc: "returns a new list with elements in reversed order.",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "reverse")
 			n := len(list)
@@ -1646,9 +1646,9 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a new list with elements in reversed order.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to reverse", NoEscape: true},
+				{Kind: "list", Label: "list", Description: "list to reverse", NoEscape: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -1659,16 +1659,16 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "append",
-		Desc: "appends items to a list and return the extended list.\nThe original list stays unharmed.",
+
 		Fn: func(a ...Scmer) Scmer {
 			base := append([]Scmer{}, asSlice(a[0], "append")...)
 			base = append(base, a[1:]...)
 			return NewSlice(base)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "appends items to a list and return the extended list.\nThe original list stays unharmed.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "base list"},
-				{Kind: "any", ParamName: "item...", ParamDesc: "items to add", Variadic: true},
+				{Kind: "list", Label: "list", Description: "base list"},
+				{Kind: "any", Label: "item...", Description: "items to add", Variadic: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -1679,7 +1679,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "append_unique",
-		Desc: "appends items to a list but only if they are new.\nThe original list stays unharmed.",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := append([]Scmer{}, asSlice(a[0], "append_unique")...)
 			for _, el := range a[1:] {
@@ -1694,10 +1694,10 @@ func init_list() {
 			}
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "appends items to a list but only if they are new.\nThe original list stays unharmed.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "base list"},
-				{Kind: "any", ParamName: "item...", ParamDesc: "items to add", Variadic: true},
+				{Kind: "list", Label: "list", Description: "base list"},
+				{Kind: "any", Label: "item...", Description: "items to add", Variadic: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -1708,7 +1708,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "cons",
-		Desc: "constructs a list from a head and a tail list",
+
 		Fn: func(a ...Scmer) Scmer {
 			car := a[0]
 			if a[1].GetTag() == tagSlice {
@@ -1716,10 +1716,10 @@ func init_list() {
 			}
 			return NewSlice([]Scmer{car, a[1]})
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "constructs a list from a head and a tail list",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "car", ParamDesc: "new head element"},
-				{Kind: "list", ParamName: "cdr", ParamDesc: "tail that is appended after car", NoEscape: true},
+				{Kind: "any", Label: "car", Description: "new head element"},
+				{Kind: "list", Label: "cdr", Description: "tail that is appended after car", NoEscape: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -1730,7 +1730,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "car",
-		Desc: "extracts the head of a list",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "car")
 			if len(list) == 0 {
@@ -1738,9 +1738,9 @@ func init_list() {
 			}
 			return list[0]
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "extracts the head of a list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list", NoEscape: true},
+				{Kind: "list", Label: "list", Description: "list", NoEscape: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -2118,7 +2118,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "cdr",
-		Desc: "extracts the tail of a list\nThe tail of a list is a list with all items except the head.",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "cdr")
 			if len(list) == 0 {
@@ -2126,9 +2126,9 @@ func init_list() {
 			}
 			return NewSlice(list[1:])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "extracts the tail of a list\nThe tail of a list is a list with all items except the head.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list", NoEscape: true},
+				{Kind: "list", Label: "list", Description: "list", NoEscape: true},
 			},
 			// cdr shares the input slice's backing array; its result is borrowed.
 			Return:   &TypeDescriptor{Kind: "list"},
@@ -2595,7 +2595,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "cadr",
-		Desc: "extracts the second element of a list.\nEquivalent to (car (cdr x)).",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "cadr")
 			if len(list) < 2 {
@@ -2603,9 +2603,9 @@ func init_list() {
 			}
 			return list[1]
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "extracts the second element of a list.\nEquivalent to (car (cdr x)).",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list", NoEscape: true},
+				{Kind: "list", Label: "list", Description: "list", NoEscape: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -2983,7 +2983,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "zip",
-		Desc: "swaps the dimension of a list of lists. If one parameter is given, it is a list of lists that is flattened. If multiple parameters are given, they are treated as the components that will be zipped into the sub list",
+
 		Fn: func(a ...Scmer) Scmer {
 			lists := a
 			if len(a) == 1 {
@@ -3008,9 +3008,9 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "swaps the dimension of a list of lists. If one parameter is given, it is a list of lists that is flattened. If multiple parameters are given, they are treated as the components that will be zipped into the sub list",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "list", ParamDesc: "list of lists of items", NoEscape: true, Variadic: true},
+				{Kind: "any", Label: "list", Description: "list of lists of items", NoEscape: true, Variadic: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3021,7 +3021,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "merge",
-		Desc: "flattens a list of lists into a list containing all the subitems. If one parameter is given, it is a list of lists that is flattened. If multiple parameters are given, they are treated as lists that will be merged into one",
+
 		Fn: func(a ...Scmer) Scmer {
 			lists := a
 			if len(a) == 1 {
@@ -3037,9 +3037,9 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "flattens a list of lists into a list containing all the subitems. If one parameter is given, it is a list of lists that is flattened. If multiple parameters are given, they are treated as lists that will be merged into one",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "list", ParamDesc: "list of lists of items", NoEscape: true, Variadic: true},
+				{Kind: "any", Label: "list", Description: "list of lists of items", NoEscape: true, Variadic: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3050,7 +3050,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "merge_unique",
-		Desc: "flattens a list of lists into a list containing all the subitems. Duplicates are filtered out.",
+
 		Fn: func(a ...Scmer) Scmer {
 			lists := a
 			if len(a) == 1 {
@@ -3077,9 +3077,9 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "flattens a list of lists into a list containing all the subitems. Duplicates are filtered out.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list of lists of items", NoEscape: true, Variadic: true},
+				{Kind: "list", Label: "list", Description: "list of lists of items", NoEscape: true, Variadic: true},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3090,7 +3090,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "has?",
-		Desc: "checks if a list has a certain item (equal?)",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "has?")
 			for _, v := range list {
@@ -3100,10 +3100,10 @@ func init_list() {
 			}
 			return NewBool(false)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "checks if a list has a certain item (equal?)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "haystack", ParamDesc: "list to search in", NoEscape: true},
-				{Kind: "any", ParamName: "needle", ParamDesc: "item to search for"},
+				{Kind: "list", Label: "haystack", Description: "list to search in", NoEscape: true},
+				{Kind: "any", Label: "needle", Description: "item to search for"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -3113,7 +3113,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "filter",
-		Desc: "returns a list that only contains elements that pass the filter function",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "filter")
 			result := make([]Scmer, 0, len(input))
@@ -3125,10 +3125,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that only contains elements that pass the filter function",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be filtered", NoEscape: true},
-				{Kind: "func", ParamName: "condition", ParamDesc: "filter condition func(item)->bool", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list", Description: "list that has to be filtered", NoEscape: true},
+				{Kind: "func", Label: "condition", Description: "filter condition func(item)->bool", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3139,7 +3139,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "find",
-		Desc: "returns the first list element that passes the condition function, or nil/default if none matches",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "find")
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -3153,11 +3153,11 @@ func init_list() {
 			}
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the first list element that passes the condition function, or nil/default if none matches",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to search", NoEscape: true},
-				{Kind: "func", ParamName: "condition", ParamDesc: "predicate func(any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "any", ParamName: "default", ParamDesc: "optional default value if nothing matches", Optional: true},
+				{Kind: "list", Label: "list", Description: "list to search", NoEscape: true},
+				{Kind: "func", Label: "condition", Description: "predicate func(any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "any", Label: "default", Description: "optional default value if nothing matches", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -3167,7 +3167,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "map",
-		Desc: "returns a list that contains the results of a map function that is applied to the list",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "map")
 			result := make([]Scmer, len(list))
@@ -3177,10 +3177,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the results of a map function that is applied to the list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be mapped", NoEscape: true},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "list that has to be mapped", NoEscape: true},
+				{Kind: "func", Label: "map", Description: "map function func(any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -3939,7 +3939,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parallel_map",
-		Desc: "like map, but applies fn to each element in parallel using a worker pool limited to runtime.NumCPU()",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "parallel_map")
 			if len(list) <= 1 {
@@ -3989,10 +3989,10 @@ func init_list() {
 			}
 			return NewSlice(results)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "like map, but applies fn to each element in parallel using a worker pool limited to runtime.NumCPU()",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to map over in parallel", NoEscape: true},
-				{Kind: "func", ParamName: "fn", ParamDesc: "function applied to each element", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "list to map over in parallel", NoEscape: true},
+				{Kind: "func", Label: "fn", Description: "function applied to each element", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Optimize: optimizeFixedLengthInput("parallel_map_mut"),
@@ -4002,7 +4002,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parallel_map_mut",
-		Desc: "like parallel_map, but signals the optimizer that fn may have side effects",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "parallel_map_mut")
 			if len(list) <= 1 {
@@ -4051,10 +4051,10 @@ func init_list() {
 			}
 			return NewSlice(results)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "like parallel_map, but signals the optimizer that fn may have side effects",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to map over in parallel", NoEscape: true},
-				{Kind: "func", ParamName: "fn", ParamDesc: "function with side effects applied to each element", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "list to map over in parallel", NoEscape: true},
+				{Kind: "func", Label: "fn", Description: "function with side effects applied to each element", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: FreshAlloc,
 
@@ -4063,7 +4063,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mapIndex",
-		Desc: "returns a list that contains the results of a map function that is applied to the list",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "mapIndex")
 			result := make([]Scmer, len(list))
@@ -4073,10 +4073,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the results of a map function that is applied to the list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be mapped", NoEscape: true},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(i, any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}, {Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "list that has to be mapped", NoEscape: true},
+				{Kind: "func", Label: "map", Description: "map function func(i, any)->any that is applied to each item", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -4087,7 +4087,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce",
-		Desc: "returns a list that contains the result of a map function",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "reduce")
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -4105,11 +4105,11 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains the result of a map function",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is a list item", Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is a list item", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:   &TypeDescriptor{Kind: "any"},
 			Const:    true,
@@ -5986,7 +5986,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "produce",
-		Desc: "returns a list that contains produced items - it works like for(state = startstate, condition(state), state = iterator(state)) {yield state}",
+
 		Fn: func(a ...Scmer) Scmer {
 			result := make([]Scmer, 0)
 			state := a[0]
@@ -5998,11 +5998,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list that contains produced items - it works like for(state = startstate, condition(state), state = iterator(state)) {yield state}",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "startstate", ParamDesc: "start state to begin with"},
-				{Kind: "func", ParamName: "condition", ParamDesc: "func that returns true whether the state will be inserted into the result or the loop is stopped", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "iterator", ParamDesc: "func that produces the next state", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "startstate", Description: "start state to begin with"},
+				{Kind: "func", Label: "condition", Description: "func that returns true whether the state will be inserted into the result or the loop is stopped", Params: []*TypeDescriptor{{Kind: "any", Label: "state"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "iterator", Description: "func that produces the next state", Params: []*TypeDescriptor{{Kind: "any", Label: "state"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: FreshAlloc,
 			Const:  true,
@@ -6012,7 +6012,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "produceN",
-		Desc: "returns a list with numbers from 0..n-1, optionally mapped through a function",
+
 		Fn: func(a ...Scmer) Scmer {
 			n := int(a[0].Int())
 			if n < 0 {
@@ -6032,10 +6032,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list with numbers from 0..n-1, optionally mapped through a function",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "n", ParamDesc: "number of elements to produce"},
-				{Kind: "func", ParamName: "fn", ParamDesc: "(optional) map function applied to each index", Optional: true, Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "number", Label: "n", Description: "number of elements to produce"},
+				{Kind: "func", Label: "fn", Description: "(optional) map function applied to each index", Optional: true, Params: []*TypeDescriptor{{Kind: "int", Label: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6046,7 +6046,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parallelN",
-		Desc: "returns a list with numbers from 0..n-1 mapped in parallel through a function",
+
 		Fn: func(a ...Scmer) Scmer {
 			n := int(a[0].Int())
 			if n < 0 {
@@ -6102,10 +6102,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list with numbers from 0..n-1 mapped in parallel through a function",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "n", ParamDesc: "number of elements to produce"},
-				{Kind: "func", ParamName: "fn", ParamDesc: "map function applied to each index in parallel", Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "number", Label: "n", Description: "number of elements to produce"},
+				{Kind: "func", Label: "fn", Description: "map function applied to each index in parallel", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6116,7 +6116,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "produceN_mut",
-		Desc: "in-place produceN variant (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			n := int(a[0].Int())
 			if n < 0 {
@@ -6139,11 +6139,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place produceN variant (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "n", ParamDesc: "number of elements to produce"},
-				{Kind: "func", ParamName: "fn", ParamDesc: "map function applied to each index", Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "list", ParamName: "target", ParamDesc: "(optional) preallocated target list", NoEscape: true, Optional: true},
+				{Kind: "number", Label: "n", Description: "number of elements to produce"},
+				{Kind: "func", Label: "fn", Description: "map function applied to each index", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "target", Description: "(optional) preallocated target list", NoEscape: true, Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "list"},
 			Const:     true,
@@ -6154,7 +6154,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parallelN_mut",
-		Desc: "in-place parallelN variant (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			n := int(a[0].Int())
 			if n < 0 {
@@ -6247,11 +6247,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place parallelN variant (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "n", ParamDesc: "number of elements to produce"},
-				{Kind: "func", ParamName: "fn", ParamDesc: "map function applied to each index in parallel", Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "list", ParamName: "target", ParamDesc: "(optional) preallocated target list", NoEscape: true, Optional: true},
+				{Kind: "number", Label: "n", Description: "number of elements to produce"},
+				{Kind: "func", Label: "fn", Description: "map function applied to each index in parallel", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "target", Description: "(optional) preallocated target list", NoEscape: true, Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "list"},
 			Const:     true,
@@ -6262,16 +6262,16 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "list?",
-		Desc: "checks if a value is a list",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsSlice() {
 				return NewBool(true)
 			}
 			return NewBool(false)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "checks if a value is a list",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value to check"},
+				{Kind: "any", Label: "value", Description: "value to check"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -6532,7 +6532,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "contains?",
-		Desc: "checks if a value is in a list; uses the equal?? operator",
+
 		Fn: func(a ...Scmer) Scmer {
 			arr := asSlice(a[0], "contains?")
 			for _, v := range arr {
@@ -6542,10 +6542,10 @@ func init_list() {
 			}
 			return NewBool(false)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "checks if a value is in a list; uses the equal?? operator",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list to check", NoEscape: true},
-				{Kind: "any", ParamName: "value", ParamDesc: "value to check"},
+				{Kind: "list", Label: "list", Description: "list to check", NoEscape: true},
+				{Kind: "any", Label: "value", Description: "value to check"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -6555,7 +6555,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_in",
-		Desc: "tests SQL IN-list membership and returns nil when NULL makes the result UNKNOWN",
+
 		Fn: func(a ...Scmer) Scmer {
 			values := asSlice(a[0], "sql_in")
 			if a[1].IsNil() {
@@ -6575,8 +6575,8 @@ func init_list() {
 			}
 			return NewBool(false)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{{Kind: "list", ParamName: "values", ParamDesc: "SQL IN-list values", NoEscape: true}, {Kind: "any", ParamName: "value", ParamDesc: "value to find"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests SQL IN-list membership and returns nil when NULL makes the result UNKNOWN",
+			Params: []*TypeDescriptor{{Kind: "list", Label: "values", Description: "SQL IN-list values", NoEscape: true}, {Kind: "any", Label: "value", Description: "value to find"}},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 
@@ -6589,7 +6589,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_assoc",
-		Desc: "returns a filtered dictionary according to a filter function",
+
 		Fn: func(a ...Scmer) Scmer {
 			result := make([]Scmer, 0)
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -6609,10 +6609,10 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a filtered dictionary according to a filter function",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary that has to be filtered", NoEscape: true},
-				{Kind: "func", ParamName: "condition", ParamDesc: "filter function func(string any)->bool where the first parameter is the key, the second is the value", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "dict", Description: "dictionary that has to be filtered", NoEscape: true},
+				{Kind: "func", Label: "condition", Description: "filter function func(string any)->bool where the first parameter is the key, the second is the value", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6623,7 +6623,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "find_assoc",
-		Desc: "returns the first key/value pair that passes the condition function, or nil/default if none matches",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "find_assoc"); fd == nil {
@@ -6652,11 +6652,11 @@ func init_list() {
 			}
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the first key/value pair that passes the condition function, or nil/default if none matches",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary to search", NoEscape: true},
-				{Kind: "func", ParamName: "condition", ParamDesc: "predicate func(string any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "any", ParamName: "default", ParamDesc: "optional default value if nothing matches", Optional: true},
+				{Kind: "list", Label: "dict", Description: "dictionary to search", NoEscape: true},
+				{Kind: "func", Label: "condition", Description: "predicate func(string any)->bool that is applied until the first match", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "any", Label: "default", Description: "optional default value if nothing matches", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -6666,7 +6666,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "map_assoc",
-		Desc: "returns a mapped dictionary according to a map function\nKeys will stay the same but values are mapped.",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "map_assoc"); fd == nil {
@@ -6690,10 +6690,10 @@ func init_list() {
 				return NewSlice(result)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a mapped dictionary according to a map function\nKeys will stay the same but values are mapped.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary that has to be mapped", NoEscape: true},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(string any)->any where the first parameter is the key, the second is the value. It must return the new value.", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "dictionary that has to be mapped", NoEscape: true},
+				{Kind: "func", Label: "map", Description: "map function func(string any)->any where the first parameter is the key, the second is the value. It must return the new value.", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6704,7 +6704,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_assoc",
-		Desc: "reduces a dictionary according to a reduce function",
+
 		Fn: func(a ...Scmer) Scmer {
 			result := a[2]
 			reduce := OptimizeProcToSerialFunction(a[1])
@@ -6720,11 +6720,11 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "reduces a dictionary according to a reduce function",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary that has to be reduced", NoEscape: true},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "key"}, {ParamName: "value"}}, ParamName: "reduce", ParamDesc: "reduce function func(any string any)->any where the first parameter is the accumulator, second is key, third is value. It must return the new accumulator.", Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "initial value for the accumulator"},
+				{Kind: "list", Label: "dict", Description: "dictionary that has to be reduced", NoEscape: true},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "key"}, {Label: "value"}}, Label: "reduce", Description: "reduce function func(any string any)->any where the first parameter is the accumulator, second is key, third is value. It must return the new accumulator.", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "neutral", Description: "initial value for the accumulator"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -6734,17 +6734,17 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "make_structural_index",
-		Desc: "Builds an immutable structural-expression index. It eagerly hashes every key and every node under roots, then returns a parallel-safe lookup function that maps an equal expression to its zero-based key position or nil.",
+
 		Fn:   NewStructuralIndex,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Builds an immutable structural-expression index. It eagerly hashes every key and every node under roots, then returns a parallel-safe lookup function that maps an equal expression to its zero-based key position or nil.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "keys", ParamDesc: "immutable structural expressions to index"},
-				{Kind: "list", ParamName: "roots", ParamDesc: "immutable expression roots whose descendant hashes are precomputed"},
+				{Kind: "list", Label: "keys", Description: "immutable structural expressions to index"},
+				{Kind: "list", Label: "roots", Description: "immutable expression roots whose descendant hashes are precomputed"},
 			},
 			Return: &TypeDescriptor{
 				Kind: "func",
 				Params: []*TypeDescriptor{
-					{Kind: "any", ParamName: "expression", ParamDesc: "a key, root, descendant of a declared root, or scalar expression"},
+					{Kind: "any", Label: "expression", Description: "a key, root, descendant of a declared root, or scalar expression"},
 				},
 				Return: &TypeDescriptor{Kind: "int|nil"},
 			},
@@ -6752,18 +6752,24 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "make_structural_catalog",
-		Desc: "Creates an atomic compile-local structural catalog. Look up with (catalog key), insert with (catalog key value), or freeze with (catalog) for parallel-safe read-only lookup.",
+
 		Fn:   NewStructuralCatalog,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates an atomic compile-local structural catalog. Look up with (catalog key), insert with (catalog key value), or freeze with (catalog) for parallel-safe read-only lookup.",
 			Params: []*TypeDescriptor{
-				{Kind: "bool|symbol", ParamName: "mode", ParamDesc: "true forces collisions for tests; ast selects type-stable compiler equality", Optional: true},
+				{Kind: "bool|symbol", Label: "mode", Description: "true forces collisions for tests; ast selects type-stable compiler equality", Optional: true},
 			},
-			Return: &TypeDescriptor{Kind: "func"},
+			Return: &TypeDescriptor{Kind: "func", Label: "catalog", Description: "atomic structural-expression lookup and update function",
+				Params: []*TypeDescriptor{
+					{Kind: "any", Label: "key", Description: "expression to look up; omit to freeze the catalog", Optional: true},
+					{Kind: "any", Label: "value", Description: "value to store for key", Optional: true},
+				},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "stored value, lookup result, or frozen lookup function"},
+			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "has_assoc?",
-		Desc: "checks if a dictionary has a key present",
+
 		Fn: func(a ...Scmer) Scmer {
 			if slice, fd := asAssoc(a[0], "has_assoc?"); fd == nil {
 				for i := 0; i < len(slice); i += 2 {
@@ -6778,10 +6784,10 @@ func init_list() {
 			}
 			return NewBool(false)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "checks if a dictionary has a key present",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary that has to be checked", NoEscape: true},
-				{Kind: "string", ParamName: "key", ParamDesc: "key to test"},
+				{Kind: "list", Label: "dict", Description: "dictionary that has to be checked", NoEscape: true},
+				{Kind: "string", Label: "key", Description: "key to test"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
@@ -6791,7 +6797,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "get_assoc",
-		Desc: "gets a value from a dictionary by key, returns nil if not found",
+
 		Fn: func(a ...Scmer) Scmer {
 			if slice, fd := asAssoc(a[0], "get_assoc"); fd == nil {
 				for i := 0; i < len(slice); i += 2 {
@@ -6810,11 +6816,11 @@ func init_list() {
 			}
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "gets a value from a dictionary by key, returns nil if not found",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary to look up", NoEscape: true},
-				{Kind: "any", ParamName: "key", ParamDesc: "key to look up"},
-				{Kind: "any", ParamName: "default", ParamDesc: "optional default value if key not found", Optional: true},
+				{Kind: "list", Label: "dict", Description: "dictionary to look up", NoEscape: true},
+				{Kind: "any", Label: "key", Description: "key to look up"},
+				{Kind: "any", Label: "default", Description: "optional default value if key not found", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -6824,7 +6830,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "get_assoc_pairlist",
-		Desc: "gets a value from a list of key/value rows without flattening the rows",
+
 		Fn: func(a ...Scmer) Scmer {
 			for _, entry := range asSlice(a[0], "get_assoc_pairlist") {
 				if !entry.IsSlice() {
@@ -6841,11 +6847,11 @@ func init_list() {
 			}
 			return a[2]
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "gets a value from a list of key/value rows without flattening the rows",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "rows", ParamDesc: "list whose rows contain a key followed by one or more values", NoEscape: true},
-				{Kind: "any", ParamName: "key", ParamDesc: "key compared with the first item of each row"},
-				{Kind: "any", ParamName: "default", ParamDesc: "value returned when no row contains the key"},
+				{Kind: "list", Label: "rows", Description: "list whose rows contain a key followed by one or more values", NoEscape: true},
+				{Kind: "any", Label: "key", Description: "key compared with the first item of each row"},
+				{Kind: "any", Label: "default", Description: "value returned when no row contains the key"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -6855,7 +6861,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "extract_assoc",
-		Desc: "applies a function (key value) on the dictionary and returns the results as a flat list",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "extract_assoc"); fd == nil {
@@ -6878,10 +6884,10 @@ func init_list() {
 				return NewSlice(result)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "applies a function (key value) on the dictionary and returns the results as a flat list",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary that has to be checked", NoEscape: true},
-				{Kind: "func", ParamName: "map", ParamDesc: "func(key, value)->any that extracts one element per key-value pair", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "dictionary that has to be checked", NoEscape: true},
+				{Kind: "func", Label: "map", Description: "func(key, value)->any that extracts one element per key-value pair", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6892,7 +6898,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "set_assoc",
-		Desc: "returns a new dictionary where a single value has been changed.\nThe original dictionary is not modified.",
+
 		Fn: func(a ...Scmer) Scmer {
 			var mergeFn func(Scmer, Scmer) Scmer
 			if len(a) > 3 {
@@ -6928,12 +6934,12 @@ func init_list() {
 				return NewFastDict(fd)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a new dictionary where a single value has been changed.\nThe original dictionary is not modified.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "input dictionary"},
-				{Kind: "string", ParamName: "key", ParamDesc: "key that has to be set"},
-				{Kind: "any", ParamName: "value", ParamDesc: "new value to set"},
-				{Kind: "func", ParamName: "merge", ParamDesc: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value. It must return the merged value that shall be physically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", ParamName: "old"}, {Kind: "any", ParamName: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "input dictionary"},
+				{Kind: "string", Label: "key", Description: "key that has to be set"},
+				{Kind: "any", Label: "value", Description: "new value to set"},
+				{Kind: "func", Label: "merge", Description: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value. It must return the merged value that shall be physically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6944,7 +6950,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "merge_assoc",
-		Desc: "returns a dictionary where all keys from dict1 and all keys from dict2 are present.\nIf a key is present in both inputs, the second one will be dominant so the first value will be overwritten unless you provide a merge function",
+
 		Fn: func(a ...Scmer) Scmer {
 			setAssoc := OptimizeProcToSerialFunction(Globalenv.Vars["set_assoc"])
 			dst := a[0]
@@ -6965,11 +6971,11 @@ func init_list() {
 			}
 			return dst
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a dictionary where all keys from dict1 and all keys from dict2 are present.\nIf a key is present in both inputs, the second one will be dominant so the first value will be overwritten unless you provide a merge function",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict1", ParamDesc: "first input dictionary that has to be changed. You must not use this value again."},
-				{Kind: "list", ParamName: "dict2", ParamDesc: "input dictionary that contains the new values that have to be added"},
-				{Kind: "func", ParamName: "merge", ParamDesc: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value from dict2. It must return the merged value that shall be pysically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", ParamName: "old"}, {Kind: "any", ParamName: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict1", Description: "first input dictionary that has to be changed. You must not use this value again."},
+				{Kind: "list", Label: "dict2", Description: "input dictionary that contains the new values that have to be added"},
+				{Kind: "func", Label: "merge", Description: "(optional) func(any any)->any that is called when a value is overwritten. The first parameter is the old value, the second is the new value from dict2. It must return the merged value that shall be pysically stored in the new dictionary.", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -6982,7 +6988,7 @@ func init_list() {
 	// Fused physical operators: optimizer-only, forbidden from .scm code.
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_segments",
-		Desc: "reduces ordered list segments without flattening them (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			segments := asSlice(a[0], "reduce_segments")
 			for _, segment := range segments {
@@ -7006,11 +7012,11 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "reduces ordered list segments without flattening them (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "segments", NoEscape: true},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", Optional: true},
+				{Kind: "list", Label: "segments", NoEscape: true},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "neutral", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7021,7 +7027,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_map",
-		Desc: "fused serial map and filter (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "filter_map")
 			mapper := OptimizeProcToSerialFunction(a[1])
@@ -7035,11 +7041,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map and filter (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -7050,7 +7056,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "map_filter",
-		Desc: "fused serial filter and map (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "map_filter")
 			predicate := OptimizeProcToSerialFunction(a[1])
@@ -7063,11 +7069,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial filter and map (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -7078,7 +7084,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "map_map",
-		Desc: "fused serial map and map (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "map_map")
 			first := OptimizeProcToSerialFunction(a[1])
@@ -7089,11 +7095,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map and map (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -7104,7 +7110,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_map",
-		Desc: "fused serial map and reduce (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "reduce_map")
 			mapper := OptimizeProcToSerialFunction(a[1])
@@ -7126,12 +7132,12 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map and reduce (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}, ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7142,7 +7148,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_filter",
-		Desc: "fused serial filter and reduce (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "reduce_filter")
 			predicate := OptimizeProcToSerialFunction(a[1])
@@ -7166,12 +7172,12 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial filter and reduce (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", ParamName: "filter", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}, ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the list item"},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
+				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the list item"},
+				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7182,7 +7188,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_merge2",
-		Desc: "fused serial merge of two lists and reduce (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if len(a) < 3 {
 				panic("reduce_merge2 expects at least two input lists and a reduce function")
@@ -7214,12 +7220,12 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial merge of two lists and reduce (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "lhs", ParamDesc: "first list to reduce"},
-				{Kind: "list", ParamName: "rhs", ParamDesc: "second list to reduce"},
-				{Kind: "func", ParamName: "reduce", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}, ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "optional initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "lhs", Description: "first list to reduce"},
+				{Kind: "list", Label: "rhs", Description: "second list to reduce"},
+				{Kind: "func", Label: "reduce", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "any", Label: "neutral", Description: "optional initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7230,7 +7236,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_map_filter",
-		Desc: "fused serial map then filter and reduce (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "reduce_map_filter")
 			mapper := OptimizeProcToSerialFunction(a[1])
@@ -7256,13 +7262,13 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map then filter and reduce (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "filter", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}, ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7273,7 +7279,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "reduce_filter_map",
-		Desc: "fused serial filter then map and reduce (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "reduce_filter_map")
 			predicate := OptimizeProcToSerialFunction(a[1])
@@ -7299,13 +7305,13 @@ func init_list() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial filter then map and reduce (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "list that has to be reduced", NoEscape: true},
-				{Kind: "func", ParamName: "filter", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, ParamName: "acc"}, {ParamName: "item"}}, ParamName: "reduce", Return: &TypeDescriptor{Kind: "any"}, ParamDesc: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
+				{Kind: "list", Label: "list", Description: "list that has to be reduced", NoEscape: true},
+				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Params: []*TypeDescriptor{{Transfer: true, Label: "acc"}, {Label: "item"}}, Label: "reduce", Return: &TypeDescriptor{Kind: "any"}, Description: "reduce function func(any any)->any where the first parameter is the accumulator, the second is the mapped item"},
+				{Kind: "any", Label: "neutral", Description: "(optional) initial value of the accumulator, defaults to nil", Optional: true},
 			},
 			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
@@ -7316,7 +7322,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_filter",
-		Desc: "fused serial filter and filter (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "filter_filter")
 			left := OptimizeProcToSerialFunction(a[1])
@@ -7329,11 +7335,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial filter and filter (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "filter", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "filter", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "filter", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:    FreshAlloc,
 			Forbidden: true,
@@ -7343,7 +7349,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "cons_map",
-		Desc: "constructs a list head while mapping its tail (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[1], "cons_map")
 			mapper := OptimizeProcToSerialFunction(a[2])
@@ -7354,11 +7360,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "constructs a list head while mapping its tail (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "head"},
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "head"},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -8226,7 +8232,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "flat_map",
-		Desc: "fused fixed-width serial map and flatten (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "flat_map")
 			mapper := OptimizeProcToSerialFunction(a[1])
@@ -8237,11 +8243,11 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "fused fixed-width serial map and flatten (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "list"}},
-				{Kind: "int", ParamName: "width"},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "list"}},
+				{Kind: "int", Label: "width"},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -8255,7 +8261,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "map_mut",
-		Desc: "in-place map (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := a[0].Slice()
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -8264,10 +8270,10 @@ func init_list() {
 			}
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place map (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned list to map in-place"},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "owned list to map in-place"},
+				{Kind: "func", Label: "map", Description: "map function", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -8942,7 +8948,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "mapIndex_mut",
-		Desc: "in-place mapIndex (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := a[0].Slice()
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -8951,10 +8957,10 @@ func init_list() {
 			}
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place mapIndex (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned list to map in-place"},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(i, any)->any", Params: []*TypeDescriptor{{Kind: "int", ParamName: "index"}, {Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "list", Description: "owned list to map in-place"},
+				{Kind: "func", Label: "map", Description: "map function func(i, any)->any", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -8966,7 +8972,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "map_assoc_mut",
-		Desc: "in-place map_assoc (optimizer-only, slice path only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "map_assoc_mut"); fd == nil {
@@ -8989,10 +8995,10 @@ func init_list() {
 				return NewSlice(result)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place map_assoc (optimizer-only, slice path only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "owned dictionary to map in-place"},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(key, value)->value", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "owned dictionary to map in-place"},
+				{Kind: "func", Label: "map", Description: "map function func(key, value)->value", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9006,7 +9012,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_mut",
-		Desc: "in-place filter (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := a[0].Slice()
 			fn := OptimizeProcToSerialFunction(a[1])
@@ -9019,10 +9025,10 @@ func init_list() {
 			}
 			return NewSlice(input[:w])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place filter (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned list to filter in-place"},
-				{Kind: "func", ParamName: "condition", ParamDesc: "filter condition func(any)->bool", Params: []*TypeDescriptor{{Kind: "any", ParamName: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list", Description: "owned list to filter in-place"},
+				{Kind: "func", Label: "condition", Description: "filter condition func(any)->bool", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9034,7 +9040,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "reverse_mut",
-		Desc: "in-place reverse (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := a[0].Slice()
 			for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
@@ -9042,9 +9048,9 @@ func init_list() {
 			}
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place reverse (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned list to reverse in-place"},
+				{Kind: "list", Label: "list", Description: "owned list to reverse in-place"},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9056,7 +9062,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "filter_assoc_mut",
-		Desc: "in-place filter_assoc (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "filter_assoc_mut"); fd == nil {
@@ -9080,10 +9086,10 @@ func init_list() {
 				return NewSlice(result)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place filter_assoc (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "owned dictionary to filter in-place"},
-				{Kind: "func", ParamName: "condition", ParamDesc: "filter function func(key, value)->bool", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "dict", Description: "owned dictionary to filter in-place"},
+				{Kind: "func", Label: "condition", Description: "filter function func(key, value)->bool", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9095,7 +9101,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "extract_assoc_mut",
-		Desc: "in-place extract_assoc (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			if slice, fd := asAssoc(a[0], "extract_assoc_mut"); fd == nil {
@@ -9114,10 +9120,10 @@ func init_list() {
 				return NewSlice(result)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place extract_assoc (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "owned dictionary to extract from in-place"},
-				{Kind: "func", ParamName: "map", ParamDesc: "func(key, value)->any that extracts each element", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "owned dictionary to extract from in-place"},
+				{Kind: "func", Label: "map", Description: "func(key, value)->any that extracts each element", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9129,7 +9135,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "set_assoc_mut",
-		Desc: "in-place set_assoc (optimizer-only, mutates input directly)",
+
 		Fn: func(a ...Scmer) Scmer {
 			var mergeFn func(Scmer, Scmer) Scmer
 			if len(a) > 3 {
@@ -9167,12 +9173,12 @@ func init_list() {
 				return NewFastDict(fd)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place set_assoc (optimizer-only, mutates input directly)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "owned dictionary to mutate"},
-				{Kind: "string", ParamName: "key", ParamDesc: "key to set"},
-				{Kind: "any", ParamName: "value", ParamDesc: "new value"},
-				{Kind: "func", ParamName: "merge", ParamDesc: "(optional) merge function", Optional: true, Params: []*TypeDescriptor{{Kind: "any", ParamName: "old"}, {Kind: "any", ParamName: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "owned dictionary to mutate"},
+				{Kind: "string", Label: "key", Description: "key to set"},
+				{Kind: "any", Label: "value", Description: "new value"},
+				{Kind: "func", Label: "merge", Description: "(optional) merge function", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9186,16 +9192,16 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "append_mut",
-		Desc: "in-place append (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			base := asSlice(a[0], "append_mut")
 			base = append(base, a[1:]...)
 			return NewSlice(base)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place append (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned base list"},
-				{Kind: "any", ParamName: "item...", ParamDesc: "items to add", Variadic: true},
+				{Kind: "list", Label: "list", Description: "owned base list"},
+				{Kind: "any", Label: "item...", Description: "items to add", Variadic: true},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9207,7 +9213,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "append_unique_mut",
-		Desc: "in-place append_unique (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			list := asSlice(a[0], "append_unique_mut")
 			for _, el := range a[1:] {
@@ -9221,10 +9227,10 @@ func init_list() {
 			}
 			return NewSlice(list)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place append_unique (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned base list"},
-				{Kind: "any", ParamName: "item...", ParamDesc: "items to add", Variadic: true},
+				{Kind: "list", Label: "list", Description: "owned base list"},
+				{Kind: "any", Label: "item...", Description: "items to add", Variadic: true},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9236,7 +9242,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "merge_unique_mut",
-		Desc: "in-place merge_unique (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if len(a) == 1 {
 				lists := asSlice(a[0], "merge_unique_mut")
@@ -9289,9 +9295,9 @@ func init_list() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place merge_unique (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned base list or owned list of lists", Variadic: true},
+				{Kind: "list", Label: "list", Description: "owned base list or owned list of lists", Variadic: true},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9303,7 +9309,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "reset_mut",
-		Desc: "resets an owned list to len=0 while preserving capacity",
+
 		Fn: func(a ...Scmer) Scmer {
 			base := asSlice(a[0], "reset_mut")
 			if base == nil {
@@ -9311,9 +9317,9 @@ func init_list() {
 			}
 			return NewSlice(base[:0:cap(base)])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "resets an owned list to len=0 while preserving capacity",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", ParamDesc: "owned base list"},
+				{Kind: "list", Label: "list", Description: "owned base list"},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9325,7 +9331,7 @@ func init_list() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "merge_assoc_mut",
-		Desc: "in-place merge_assoc (optimizer-only)",
+
 		Fn: func(a ...Scmer) Scmer {
 			setAssoc := OptimizeProcToSerialFunction(Globalenv.Vars["set_assoc_mut"])
 			dst := a[0]
@@ -9346,11 +9352,11 @@ func init_list() {
 			}
 			return dst
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place merge_assoc (optimizer-only)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict1", ParamDesc: "owned first dictionary"},
-				{Kind: "list", ParamName: "dict2", ParamDesc: "dictionary with new values"},
-				{Kind: "func", ParamName: "merge", ParamDesc: "(optional) merge function", Optional: true, Params: []*TypeDescriptor{{Kind: "any", ParamName: "old"}, {Kind: "any", ParamName: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict1", Description: "owned first dictionary"},
+				{Kind: "list", Label: "dict2", Description: "dictionary with new values"},
+				{Kind: "func", Label: "merge", Description: "(optional) merge function", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "old"}, {Kind: "any", Label: "new"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -9361,7 +9367,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sort",
-		Desc: "returns a sorted copy of a list using a comparator (lambda (a b) truthy/falsy)",
+
 		Fn: func(a ...Scmer) Scmer {
 			src := a[0].Slice()
 			cmp := a[1]
@@ -9372,10 +9378,10 @@ func init_list() {
 			})
 			return NewSlice(dst)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a sorted copy of a list using a comparator (lambda (a b) truthy/falsy)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list", NoEscape: true},
-				{Kind: "func", ParamName: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -9386,7 +9392,7 @@ func init_list() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sort_mut",
-		Desc: "sorts a list in-place using a comparator (lambda (a b) truthy/falsy)",
+
 		Fn: func(a ...Scmer) Scmer {
 			src := a[0].Slice()
 			cmp := a[1]
@@ -9395,11 +9401,11 @@ func init_list() {
 			})
 			return a[0]
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "sorts a list in-place using a comparator (lambda (a b) truthy/falsy)",
 			HasSideEffects: true,
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "list"},
-				{Kind: "func", ParamName: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "list", Label: "list"},
+				{Kind: "func", Label: "comparator", Params: []*TypeDescriptor{{Kind: "any"}, {Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return: &TypeDescriptor{Kind: "list"},
 

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -39,7 +39,7 @@ func init_list_assoc_extra() {
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a mapped dictionary according to a map function\nValues stay the same but keys are mapped.",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "dictionary whose keys have to be mapped", NoEscape: true},
-				{Kind: "func", Label: "map", Description: "map function func(key, value)->key where the first parameter is the old key, the second is the value. It must return the new key.", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "computes a replacement key for each dictionary entry", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "existing key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "new_key", Description: "replacement key"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -71,7 +71,7 @@ func init_list_assoc_extra() {
 		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only key remap for dictionaries",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "dict", Description: "owned dictionary whose keys have to be remapped"},
-				{Kind: "func", Label: "map", Description: "map function func(key, value)->key", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "map", Description: "computes a replacement key for each dictionary entry", Params: []*TypeDescriptor{{Kind: "string", Label: "key", Description: "existing key"}, {Kind: "any", Label: "value", Description: "entry value"}}, Return: &TypeDescriptor{Kind: "any", Label: "new_key", Description: "replacement key"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -19,7 +19,7 @@ package scm
 func init_list_assoc_extra() {
 	Declare(&Globalenv, &Declaration{
 		Name: "mapkey_assoc",
-		Desc: "returns a mapped dictionary according to a map function\nValues stay the same but keys are mapped.",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			setAssoc := OptimizeProcToSerialFunction(Globalenv.Vars["set_assoc"])
@@ -36,10 +36,10 @@ func init_list_assoc_extra() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a mapped dictionary according to a map function\nValues stay the same but keys are mapped.",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "dictionary whose keys have to be mapped", NoEscape: true},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(key, value)->key where the first parameter is the old key, the second is the value. It must return the new key.", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "dictionary whose keys have to be mapped", NoEscape: true},
+				{Kind: "func", Label: "map", Description: "map function func(key, value)->key where the first parameter is the old key, the second is the value. It must return the new key.", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -48,7 +48,7 @@ func init_list_assoc_extra() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mapkey_assoc_mut",
-		Desc: "optimizer-only key remap for dictionaries",
+
 		Fn: func(a ...Scmer) Scmer {
 			fn := OptimizeProcToSerialFunction(a[1])
 			setAssoc := OptimizeProcToSerialFunction(Globalenv.Vars["set_assoc_mut"])
@@ -68,10 +68,10 @@ func init_list_assoc_extra() {
 			})
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only key remap for dictionaries",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "dict", ParamDesc: "owned dictionary whose keys have to be remapped"},
-				{Kind: "func", ParamName: "map", ParamDesc: "map function func(key, value)->key", Params: []*TypeDescriptor{{Kind: "string", ParamName: "key"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "list", Label: "dict", Description: "owned dictionary whose keys have to be remapped"},
+				{Kind: "func", Label: "map", Description: "map function func(key, value)->key", Params: []*TypeDescriptor{{Kind: "string", Label: "key"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,

--- a/scm/packrat.go
+++ b/scm/packrat.go
@@ -443,11 +443,13 @@ func init_parser() {
 	DeclareTitle("Parsers")
 	Declare(&Globalenv, &Declaration{
 		Name: "parser",
-		Desc: `creates a parser
-	
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: `creates a parser
+
 	Scm parsers work this way:
 	(parser syntax scmerresult) -> func
-	
+
 	syntax can be one of:
 	(parser syntax scmerresult) will execute scmerresult after parsing syntax
 	(parser syntax scmerresult "skipper") will add a different whitespace skipper regex to the root parser
@@ -465,13 +467,14 @@ func init_parser() {
 	$ EndParser
 	empty EmptyParser
 	symbol -> use other parser defined in env
-	
+
 	for further details on packrat parsers, take a look at https://github.com/launix-de/go-packrat
 	`,
-		Fn: nil,
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "syntax", ParamDesc: "syntax of the grammar (see docs)"}, &TypeDescriptor{Kind: "any", ParamName: "generator", ParamDesc: "(optional) expressions to evaluate. All captured variables are available in the scope.", Optional: true}, &TypeDescriptor{Kind: "string", ParamName: "skipper", ParamDesc: "(optional) string that defines the skip mechanism for whitespaces as regexp", Optional: true}},
-			Return: &TypeDescriptor{Kind: "func"},
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "syntax", Description: "syntax of the grammar (see docs)"}, &TypeDescriptor{Kind: "any", Label: "generator", Description: "(optional) expressions to evaluate. All captured variables are available in the scope.", Optional: true}, &TypeDescriptor{Kind: "string", Label: "skipper", Description: "(optional) string that defines the skip mechanism for whitespaces as regexp", Optional: true}},
+			Return: &TypeDescriptor{Kind: "func", Label: "parser", Description: "parser produced from the grammar",
+				Params: []*TypeDescriptor{{Kind: "string", Label: "input", Description: "text to parse"}},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value produced by the grammar generator"},
+			},
 		},
 	})
 }

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -50,6 +50,11 @@ func (source_info SourceInfo) String() string {
 }
 
 func Simplify(s string) Scmer {
+	if len(s) > 0 && (s[0] == '[' || s[0] == '{') {
+		if value, err := NewBSONFromJSON(s); err == nil {
+			return value
+		}
+	}
 	if f, err := strconv.ParseFloat(s, 64); err == nil {
 		return NewFloat(f)
 	}

--- a/scm/parser_simplify_test.go
+++ b/scm/parser_simplify_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestSimplifyParsesJSONObjectAndArray(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{`{"name":"Ada","active":true}`, `{"active":true,"name":"Ada"}`},
+		{`[1,{"nested":true},null]`, `[1,{"nested":true},null]`},
+	} {
+		value := Simplify(test.input)
+		if !value.IsBSON() {
+			t.Fatalf("Simplify(%q) tag = %d, want BSON", test.input, value.GetTag())
+		}
+		if got := value.String(); got != test.want {
+			t.Fatalf("Simplify(%q) = %q, want %q", test.input, got, test.want)
+		}
+	}
+}
+
+func TestSimplifyLeavesInvalidJSONAsString(t *testing.T) {
+	for _, input := range []string{"{not json}", "[1,]", " [1]"} {
+		value := Simplify(input)
+		if !value.IsString() || value.String() != input {
+			t.Fatalf("Simplify(%q) = %s, want unchanged string", input, value.String())
+		}
+	}
+}
+
+func TestSimplifyStillParsesNumbers(t *testing.T) {
+	value := Simplify("12.5")
+	if !value.IsFloat() || value.Float() != 12.5 {
+		t.Fatalf("Simplify number = %s, want 12.5", value.String())
+	}
+}

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -413,7 +413,7 @@ func init_processlist() {
 	nextSessionID.Store(1)
 	Declare(&Globalenv, &Declaration{
 		Name: "show_processlist",
-		Desc: "returns a list of active sessions for SHOW [FULL] PROCESSLIST; pass true for full info",
+
 		Fn: func(a ...Scmer) Scmer {
 			full := len(a) > 0 && a[0].Bool()
 			sessions := Snapshot()
@@ -437,32 +437,32 @@ func init_processlist() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "bool", ParamName: "full", ParamDesc: "if true, include full Info text", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list of active sessions for SHOW [FULL] PROCESSLIST; pass true for full info",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "bool", Label: "full", Description: "if true, include full Info text", Optional: true}},
 			Return: &TypeDescriptor{Kind: "list"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "connection_id",
-		Desc: "returns the process-list ID of the current session (MySQL CONNECTION_ID() equivalent)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if ss := GetCurrentSessionState(); ss != nil {
 				return NewInt(int64(ss.ID))
 			}
 			return NewInt(0)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the process-list ID of the current session (MySQL CONNECTION_ID() equivalent)",
 			Return: &TypeDescriptor{Kind: "int"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "kill_query",
-		Desc: "cancel the running query in session id; returns true if a query was killed",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewBool(KillSession(uint64(a[0].Int())))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "int", ParamName: "id", ParamDesc: "session ID from SHOW PROCESSLIST"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "cancel the running query in session id; returns true if a query was killed",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "int", Label: "id", Description: "session ID from SHOW PROCESSLIST"}},
 			Return: &TypeDescriptor{Kind: "bool"},
 		},
 	})

--- a/scm/scheduler.go
+++ b/scm/scheduler.go
@@ -250,19 +250,19 @@ func (s *Scheduler) run() {
 func init_scheduler() {
 	Declare(&Globalenv, &Declaration{
 		Name: "setTimeout",
-		Desc: "Schedules a callback to run after the given delay in milliseconds (fractional values allowed for sub-millisecond precision).",
+
 		Fn:   setTimeout,
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "func", ParamName: "callback", ParamDesc: "function to execute once the timeout expires", Params: []*TypeDescriptor{{Kind: "any", ParamName: "args", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "number", ParamName: "milliseconds", ParamDesc: "milliseconds until execution"}, &TypeDescriptor{Kind: "any", ParamName: "args...", ParamDesc: "optional arguments forwarded to the callback", Variadic: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "Schedules a callback to run after the given delay in milliseconds (fractional values allowed for sub-millisecond precision).",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "func", Label: "callback", Description: "function to execute once the timeout expires", Params: []*TypeDescriptor{{Kind: "any", Label: "args", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "number", Label: "milliseconds", Description: "milliseconds until execution"}, &TypeDescriptor{Kind: "any", Label: "args...", Description: "optional arguments forwarded to the callback", Variadic: true}},
 			Return: &TypeDescriptor{Kind: "int"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "clearTimeout",
-		Desc: "Cancels a timeout created with setTimeout.",
+
 		Fn:   clearTimeout,
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", ParamName: "id", ParamDesc: "identifier returned by setTimeout"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "Cancels a timeout created with setTimeout.",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", Label: "id", Description: "identifier returned by setTimeout"}},
 			Return: &TypeDescriptor{Kind: "bool"},
 		},
 	})

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1646,7 +1646,7 @@ func init() {
 		Type: &TypeDescriptor{Kind: "func", Description: "in-place for loop (optimizer-only, skips defensive state copy)",
 			Params: []*TypeDescriptor{
 				{Kind: "list", Label: "init", Description: "owned initial state", Transfer: true},
-				{Kind: "func", Label: "condition", Description: "func(state...) -> bool", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "condition", Description: "determines whether another loop iteration should run", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Description: "current loop state values", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool", Label: "continue", Description: "whether to continue iterating"}},
 				{Kind: "func", Label: "step", Description: "step func returning next state as list", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "list"}},
 			},
 			Return:    FreshAlloc,

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1039,11 +1039,11 @@ func init() {
 	DeclareTitle("SCM Builtins")
 	Declare(&Globalenv, &Declaration{
 		Name: "quote",
-		Desc: "returns a symbol or list without evaluating it",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a symbol or list without evaluating it",
 			Params: []*TypeDescriptor{
-				{Kind: "symbol", ParamName: "symbol", ParamDesc: "symbol to quote"},
+				{Kind: "symbol", Label: "symbol", Description: "symbol to quote"},
 			},
 			Return: &TypeDescriptor{Kind: "symbol"},
 			Const:  true,
@@ -1051,24 +1051,24 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "eval",
-		Desc: "executes the given scheme program in the current environment",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "executes the given scheme program in the current environment",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "code", ParamDesc: "list with head and optional parameters"},
+				{Kind: "list", Label: "code", Description: "list with head and optional parameters"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "size",
-		Desc: "compute the memory size of a value",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewInt(int64(ComputeSize(a[0])))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "compute the memory size of a value",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value to examine"},
+				{Kind: "any", Label: "value", Description: "value to examine"},
 			},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
@@ -1183,7 +1183,7 @@ func init() {
 	}}
 	Declare(&Globalenv, &Declaration{
 		Name: "optimize",
-		Desc: "optimize the given scheme program and optionally report telemetry after completion",
+
 		Fn: func(a ...Scmer) Scmer {
 			var report func(Scmer)
 			if len(a) == 2 {
@@ -1194,11 +1194,11 @@ func init() {
 			}
 			return Optimize(a[0], &Globalenv, report)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "optimize the given scheme program and optionally report telemetry after completion",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "code", ParamDesc: "list with head and optional parameters"},
+				{Kind: "list", Label: "code", Description: "list with head and optional parameters"},
 				{
-					Kind: "func", ParamName: "telemetry_callback", ParamDesc: "optional callback invoked once with optimizer telemetry", Optional: true, NoEscape: true,
+					Kind: "func", Label: "telemetry_callback", Description: "optional callback invoked once with optimizer telemetry", Optional: true, NoEscape: true,
 					Params: []*TypeDescriptor{optimizerTelemetryType}, Return: &TypeDescriptor{Kind: "any"},
 				},
 			},
@@ -1225,25 +1225,25 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "time",
-		Desc: "measures the time it takes to compute the first argument",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "measures the time it takes to compute the first argument",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "code", ParamDesc: "code to execute"},
-				{Kind: "string", ParamName: "label", ParamDesc: "label to print in the log or trace", Optional: true},
+				{Kind: "any", Label: "code", Description: "code to execute"},
+				{Kind: "string", Label: "label", Description: "label to print in the log or trace", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "if",
-		Desc: "checks a condition and then conditionally evaluates code branches; there might be multiple condition+true-branch clauses",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "checks a condition and then conditionally evaluates code branches; there might be multiple condition+true-branch clauses",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "condition...", ParamDesc: "condition to evaluate"},
-				{Kind: "returntype", ParamName: "true-branch...", ParamDesc: "code to evaluate if condition is true"},
-				{Kind: "any", ParamName: "false-branch", ParamDesc: "code to evaluate if condition is false", Variadic: true},
+				{Kind: "any", Label: "condition...", Description: "condition to evaluate"},
+				{Kind: "returntype", Label: "true-branch...", Description: "code to evaluate if condition is true"},
+				{Kind: "any", Label: "false-branch", Description: "code to evaluate if condition is false", Variadic: true},
 			},
 			Return:   &TypeDescriptor{Kind: "returntype"},
 			Const:    true,
@@ -1252,11 +1252,11 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "and",
-		Desc: "lazily combines conditions using SQL three-valued logic; returns false on the first false value, nil for UNKNOWN, otherwise true",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "lazily combines conditions using SQL three-valued logic; returns false on the first false value, nil for UNKNOWN, otherwise true",
 			Params: []*TypeDescriptor{
-				{Kind: "bool", ParamName: "condition", ParamDesc: "condition to evaluate", Variadic: true},
+				{Kind: "bool", Label: "condition", Description: "condition to evaluate", Variadic: true},
 			},
 			Return:   &TypeDescriptor{Kind: "bool"},
 			Const:    true,
@@ -1265,11 +1265,11 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "or",
-		Desc: "lazily combines conditions using SQL three-valued logic; returns true on the first true value, nil for UNKNOWN, otherwise false",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "lazily combines conditions using SQL three-valued logic; returns true on the first true value, nil for UNKNOWN, otherwise false",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "condition", ParamDesc: "condition to evaluate", Variadic: true},
+				{Kind: "any", Label: "condition", Description: "condition to evaluate", Variadic: true},
 			},
 			Return:   &TypeDescriptor{Kind: "bool"},
 			Const:    true,
@@ -1278,11 +1278,11 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "coalesce",
-		Desc: "returns the first value that has a non-zero value",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the first value that has a non-zero value",
 			Params: []*TypeDescriptor{
-				{Kind: "returntype", ParamName: "value", ParamDesc: "value to examine", Variadic: true},
+				{Kind: "returntype", Label: "value", Description: "value to examine", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "returntype"},
 			Const:  true,
@@ -1290,11 +1290,11 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "coalesceNil",
-		Desc: "returns the first value that has a non-nil value",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the first value that has a non-nil value",
 			Params: []*TypeDescriptor{
-				{Kind: "returntype", ParamName: "value", ParamDesc: "value to examine", Variadic: true},
+				{Kind: "returntype", Label: "value", Description: "value to examine", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "returntype"},
 			Const:  true,
@@ -1302,24 +1302,24 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "define",
-		Desc: "defines or sets a variable in the current environment",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "defines or sets a variable in the current environment",
 			Params: []*TypeDescriptor{
-				{Kind: "symbol", ParamName: "variable", ParamDesc: "variable to set"},
-				{Kind: "returntype", ParamName: "value", ParamDesc: "value to set the variable to"},
+				{Kind: "symbol", Label: "variable", Description: "variable to set"},
+				{Kind: "returntype", Label: "value", Description: "value to set the variable to"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "set",
-		Desc: "defines or sets a variable in the current environment",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "defines or sets a variable in the current environment",
 			Params: []*TypeDescriptor{
-				{Kind: "symbol", ParamName: "variable", ParamDesc: "variable to set"},
-				{Kind: "returntype", ParamName: "value", ParamDesc: "value to set the variable to"},
+				{Kind: "symbol", Label: "variable", Description: "variable to set"},
+				{Kind: "returntype", Label: "value", Description: "value to set the variable to"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 		},
@@ -1328,7 +1328,7 @@ func init() {
 	// basic
 	Declare(&Globalenv, &Declaration{
 		Name: "error",
-		Desc: "halts the whole execution thread and throws an error message",
+
 		Fn: func(a ...Scmer) Scmer {
 			if len(a) == 1 {
 				panic(a[0])
@@ -1340,9 +1340,9 @@ func init() {
 				panic(b.String())
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "halts the whole execution thread and throws an error message",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value...", ParamDesc: "value or message to throw", Variadic: true},
+				{Kind: "any", Label: "value...", Description: "value or message to throw", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "string"},
 
@@ -1351,7 +1351,7 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "try",
-		Desc: "tries to execute a function and returns its result. In case of a failure, the error is fed to the second function and its result value will be used",
+
 		Fn: func(a ...Scmer) (result Scmer) {
 			defer func() {
 				err := recover()
@@ -1362,10 +1362,10 @@ func init() {
 			result = Apply(a[0])
 			return
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "tries to execute a function and returns its result. In case of a failure, the error is fed to the second function and its result value will be used",
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "func", ParamDesc: "function with no parameters that will be called", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "errorhandler", ParamDesc: "function that takes the error as parameter", Params: []*TypeDescriptor{{Kind: "any", ParamName: "error"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "func", Description: "function with no parameters that will be called", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "errorhandler", Description: "function that takes the error as parameter", Params: []*TypeDescriptor{{Kind: "any", Label: "error"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -1375,14 +1375,14 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "apply",
-		Desc: "runs the function with its arguments",
+
 		Fn: func(a ...Scmer) Scmer {
 			return Apply(a[0], asSlice(a[1], "apply")...)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "runs the function with its arguments",
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "function", ParamDesc: "function to execute"},
-				{Kind: "list", ParamName: "arguments", ParamDesc: "list of arguments to apply"},
+				{Kind: "func", Label: "function", Description: "function to execute", Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
+				{Kind: "list", Label: "arguments", Description: "list of arguments to apply"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -1392,14 +1392,14 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "apply_assoc",
-		Desc: "runs the function with its arguments but arguments is a assoc list",
+
 		Fn: func(a ...Scmer) Scmer {
 			return ApplyAssoc(a[0], asSlice(a[1], "apply_assoc"))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "runs the function with its arguments but arguments is a assoc list",
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "function", ParamDesc: "function to execute (must be a lambda)"},
-				{Kind: "list", ParamName: "arguments", ParamDesc: "assoc list of arguments to apply"},
+				{Kind: "func", Label: "function", Description: "function to execute (must be a lambda)", Params: []*TypeDescriptor{{Kind: "any", Label: "named argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
+				{Kind: "list", Label: "arguments", Description: "assoc list of arguments to apply"},
 			},
 			Return: &TypeDescriptor{Kind: "symbol"},
 			Const:  true,
@@ -1409,13 +1409,13 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "symbol",
-		Desc: "returns a symbol built from that string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewSymbol(String(a[0]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a symbol built from that string",
 			Params: []*TypeDescriptor{
-				{Kind: "string", ParamName: "value", ParamDesc: "string value that will be converted into a symbol"},
+				{Kind: "string", Label: "value", Description: "string value that will be converted into a symbol"},
 			},
 			Return: &TypeDescriptor{Kind: "symbol"},
 
@@ -1586,11 +1586,11 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "list",
-		Desc: "returns a list containing the parameters as alements",
-		Fn:   nil,
-		Type: &TypeDescriptor{
+
+		Fn: nil,
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a list containing the parameters as alements",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value...", ParamDesc: "value for the list", Variadic: true},
+				{Kind: "any", Label: "value...", Description: "value for the list", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "list"},
 			Const:  true,
@@ -1598,7 +1598,7 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "for",
-		Desc: "Sequential loop over a list state; applies a condition and step function and returns the final state list.\nUse only when iterations have strong data dependencies and must run sequentially.\n\nExamples:\n- Count to 10: (for '(0) (lambda (x) (< x 10)) (lambda (x) (list (+ x 1))))  => '(10)\n- Sum 0..9:   (for '(0 0) (lambda (x sum) (< x 10)) (lambda (x sum) (list (+ x 1) (+ sum x)))) => '(10 45)",
+
 		Fn: func(a ...Scmer) Scmer {
 			state := append([]Scmer{}, asSlice(a[0], "for init")...)
 			cond := OptimizeProcToSerialFunction(a[1])
@@ -1613,11 +1613,11 @@ func init() {
 			}
 			return NewSlice(state)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Sequential loop over a list state; applies a condition and step function and returns the final state list.\nUse only when iterations have strong data dependencies and must run sequentially.\n\nExamples:\n- Count to 10: (for '(0) (lambda (x) (< x 10)) (lambda (x) (list (+ x 1))))  => '(10)\n- Sum 0..9:   (for '(0 0) (lambda (x sum) (< x 10)) (lambda (x sum) (list (+ x 1) (+ sum x)))) => '(10 45)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "init", ParamDesc: "initial state as a list"},
-				{Kind: "func", ParamName: "condition", ParamDesc: "func that receives the current state as parameters and must return true if the loop shall be continued", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "step", ParamDesc: "step func that returns the next state as a list", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "list"}},
+				{Kind: "list", Label: "init", Description: "initial state as a list"},
+				{Kind: "func", Label: "condition", Description: "func that receives the current state as parameters and must return true if the loop shall be continued", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "step", Description: "step func that returns the next state as a list", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "list"}},
 			},
 			Return:   FreshAlloc,
 			Const:    true,
@@ -1628,7 +1628,7 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "for_mut",
-		Desc: "in-place for loop (optimizer-only, skips defensive state copy)",
+
 		Fn: func(a ...Scmer) Scmer {
 			state := asSlice(a[0], "for_mut init")
 			cond := OptimizeProcToSerialFunction(a[1])
@@ -1643,11 +1643,11 @@ func init() {
 			}
 			return NewSlice(state)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "in-place for loop (optimizer-only, skips defensive state copy)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "init", ParamDesc: "owned initial state", Transfer: true},
-				{Kind: "func", ParamName: "condition", ParamDesc: "func(state...) -> bool", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
-				{Kind: "func", ParamName: "step", ParamDesc: "step func returning next state as list", Params: []*TypeDescriptor{{Kind: "any", ParamName: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "list"}},
+				{Kind: "list", Label: "init", Description: "owned initial state", Transfer: true},
+				{Kind: "func", Label: "condition", Description: "func(state...) -> bool", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
+				{Kind: "func", Label: "step", Description: "step func returning next state as list", Params: []*TypeDescriptor{{Kind: "any", Label: "state", Variadic: true}}, Return: &TypeDescriptor{Kind: "list"}},
 			},
 			Return:    FreshAlloc,
 			Const:     true,
@@ -1658,13 +1658,13 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "string",
-		Desc: "converts the given value into string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(String(a[0]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "converts the given value into string",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "any value"},
+				{Kind: "any", Label: "value", Description: "any value"},
 			},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
@@ -1771,7 +1771,10 @@ func init() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "match",
-		Desc: `takes a value evaluates the branch that first matches the given pattern
+
+		Fn:// TODO: returntype as soon as repead validate is implemented */
+		nil,
+		Type: &TypeDescriptor{Kind: "func", Description: `takes a value evaluates the branch that first matches the given pattern
 Patterns can be any of:
  - symbol matches any value and stores is into a variable
  - "string" (matches only this string)
@@ -1782,14 +1785,11 @@ Patterns can be any of:
  - (cons a b) will reverse the cons function, so it will match the head of the list with a and the rest with b
  - (regex "pattern" text var1 var2...) will match the given regex pattern, store the whole string into text and all capture groups into var1, var2...
 `,
-		Fn:// TODO: returntype as soon as repead validate is implemented */
-		nil,
-		Type: &TypeDescriptor{
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value to evaluate"},
-				{Kind: "any", ParamName: "pattern...", ParamDesc: "pattern"},
-				{Kind: "returntype", ParamName: "result...", ParamDesc: "result value when the pattern matches; this code can use the variables matched in the pattern"},
-				{Kind: "any", ParamName: "default", ParamDesc: "(optional) value that is returned when no pattern matches", Variadic: true},
+				{Kind: "any", Label: "value", Description: "value to evaluate"},
+				{Kind: "any", Label: "pattern...", Description: "pattern"},
+				{Kind: "returntype", Label: "result...", Description: "result value when the pattern matches; this code can use the variables matched in the pattern"},
+				{Kind: "any", Label: "default", Description: "(optional) value that is returned when no pattern matches", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -1797,45 +1797,48 @@ Patterns can be any of:
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "lambda",
-		Desc: "returns a function (func) constructed from the given code",
+
 		Fn:// TODO: func(...)->returntype as soon as function types are implemented
 		nil,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a function (func) constructed from the given code",
 			Params: []*TypeDescriptor{
-				{Kind: "symbol|list|nil", ParamName: "parameters", ParamDesc: "if you provide a parameter list, you will have named parameters. If you provide a single symbol, the list of parameters will be provided in that symbol"},
-				{Kind: "any", ParamName: "code", ParamDesc: "value that is evaluated when the lambda is called. code can use the parameters provided in the declaration as well es the scope above"},
-				{Kind: "number", ParamName: "numvars", ParamDesc: "number of unnamed variables that can be accessed via (var 0) (var 1) etc.", Optional: true},
+				{Kind: "symbol|list|nil", Label: "parameters", Description: "if you provide a parameter list, you will have named parameters. If you provide a single symbol, the list of parameters will be provided in that symbol"},
+				{Kind: "any", Label: "code", Description: "value that is evaluated when the lambda is called. code can use the parameters provided in the declaration as well es the scope above"},
+				{Kind: "number", Label: "numvars", Description: "number of unnamed variables that can be accessed via (var 0) (var 1) etc.", Optional: true},
 			},
-			Return: &TypeDescriptor{Kind: "func"},
+			Return: &TypeDescriptor{Kind: "func", Label: "lambda", Description: "function constructed from parameters and code",
+				Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Description: "value bound to the corresponding declared parameter", Variadic: true}},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value produced by code"},
+			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "begin",
-		Desc: "creates a own variable scope, evaluates all sub expressions and returns the result of the last one",
+
 		Fn:// TODO: returntype as soon as repeat is implemented
 		nil,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "creates a own variable scope, evaluates all sub expressions and returns the result of the last one",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "expression...", ParamDesc: "expressions to evaluate", Variadic: true},
+				{Kind: "any", Label: "expression...", Description: "expressions to evaluate", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "parallel",
-		Desc: "executes all parameters in parallel and returns nil if they are finished",
+
 		Fn:// TODO: returntype as soon as repeat is implemented
 		nil,
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "executes all parameters in parallel and returns nil if they are finished",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "expression...", ParamDesc: "expressions to evaluate in parallel", Variadic: true},
+				{Kind: "any", Label: "expression...", Description: "expressions to evaluate in parallel", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "source",
-		Desc: "annotates the node with filename and line information for better backtraces",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewSourceInfo(SourceInfo{
 				source: String(a[0]),
@@ -1844,12 +1847,12 @@ Patterns can be any of:
 				value:  a[3],
 			})
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "annotates the node with filename and line information for better backtraces",
 			Params: []*TypeDescriptor{
-				{Kind: "string", ParamName: "filename", ParamDesc: "Filename of the code"},
-				{Kind: "number", ParamName: "line", ParamDesc: "Line of the code"},
-				{Kind: "number", ParamName: "column", ParamDesc: "Column of the code"},
-				{Kind: "returntype", ParamName: "code", ParamDesc: "code"},
+				{Kind: "string", Label: "filename", Description: "Filename of the code"},
+				{Kind: "number", Label: "line", Description: "Line of the code"},
+				{Kind: "number", Label: "column", Description: "Column of the code"},
+				{Kind: "returntype", Label: "code", Description: "code"},
 			},
 			Return: &TypeDescriptor{Kind: "returntype"},
 			Const:  true,
@@ -1859,18 +1862,18 @@ Patterns can be any of:
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "source_coverage_report",
-		Desc: "returns Scheme source coverage statistics, optionally filtered by source path prefix",
-		Fn:   sourceCoverageReport,
-		Type: &TypeDescriptor{
+
+		Fn: sourceCoverageReport,
+		Type: &TypeDescriptor{Kind: "func", Description: "returns Scheme source coverage statistics, optionally filtered by source path prefix",
 			Params: []*TypeDescriptor{
-				{Kind: "string", ParamName: "prefix", ParamDesc: "source path prefix", Optional: true},
+				{Kind: "string", Label: "prefix", Description: "source path prefix", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "assoc"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "scheme",
-		Desc: "parses a scheme expression into a list",
+
 		Fn: func(a ...Scmer) Scmer {
 			filename := "eval"
 			if len(a) > 1 {
@@ -1878,10 +1881,10 @@ Patterns can be any of:
 			}
 			return Read(filename, String(a[0]))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "parses a scheme expression into a list",
 			Params: []*TypeDescriptor{
-				{Kind: "string", ParamName: "code", ParamDesc: "Scheme code"},
-				{Kind: "string", ParamName: "filename", ParamDesc: "optional filename", Optional: true},
+				{Kind: "string", Label: "code", Description: "Scheme code"},
+				{Kind: "string", Label: "filename", Description: "optional filename", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
@@ -2469,13 +2472,13 @@ Patterns can be any of:
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "serialize",
-		Desc: "serializes a piece of code into a (hopefully) reparsable string; you shall be able to send that code over network and reparse with (scheme)",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(SerializeToString(a[0], &Globalenv))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "serializes a piece of code into a (hopefully) reparsable string; you shall be able to send that code over network and reparse with (scheme)",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "code", ParamDesc: "Scheme code"},
+				{Kind: "list", Label: "code", Description: "Scheme code"},
 			},
 			Return: &TypeDescriptor{Kind: "string"},
 
@@ -2484,7 +2487,7 @@ Patterns can be any of:
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "pretty_print",
-		Desc: "formats Scheme code as an indented, human-readable string; expressions up to width characters are kept on one line, longer ones are expanded with one argument per line",
+
 		Fn: func(a ...Scmer) Scmer {
 			width := 20
 			if len(a) >= 2 {
@@ -2492,10 +2495,10 @@ Patterns can be any of:
 			}
 			return NewString(PrettyPrint(a[0], &Globalenv, width))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "formats Scheme code as an indented, human-readable string; expressions up to width characters are kept on one line, longer ones are expanded with one argument per line",
 			Params: []*TypeDescriptor{
-				{Kind: "list", ParamName: "code", ParamDesc: "Scheme code to format"},
-				{Kind: "int", ParamName: "width", ParamDesc: "max characters before expanding (default 20)", Optional: true},
+				{Kind: "list", Label: "code", Description: "Scheme code to format"},
+				{Kind: "int", Label: "width", Description: "max characters before expanding (default 20)", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "string"},
 
@@ -2649,7 +2652,7 @@ func typeDescriptorRetainedSize(td *TypeDescriptor, visited map[*TypeDescriptor]
 	visited[td] = struct{}{}
 
 	sz := goAllocOverhead + uint(unsafe.Sizeof(*td))
-	sz += align8(uint(len(td.Kind) + len(td.ParamName) + len(td.ParamDesc)))
+	sz += align8(uint(len(td.Kind) + len(td.Label) + len(td.Description)))
 	if len(td.Params) > 0 {
 		sz += goAllocOverhead + align8(uint(len(td.Params))*uint(unsafe.Sizeof(td)))
 		for _, param := range td.Params {

--- a/scm/sql_literals.go
+++ b/scm/sql_literals.go
@@ -66,13 +66,13 @@ func (builder *sqlShapeBuilder) Result() (string, string) {
 func declareSQLLiteralParameterizer() {
 	Declare(&Globalenv, &Declaration{
 		Name: "parameterize_sql_select_literals",
-		Desc: "replaces safe literals in a top-level MySQL SELECT and returns normalized SQL, positional runtime bindings, and its stable shape hash",
+
 		Fn: func(a ...Scmer) Scmer {
 			normalized, bindings, shapeHash := parameterizeSQLSelectLiterals(String(a[0]))
 			return NewSlice([]Scmer{NewString(normalized), NewSlice(bindings), NewString(shapeHash)})
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{{Kind: "string", ParamName: "query"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "replaces safe literals in a top-level MySQL SELECT and returns normalized SQL, positional runtime bindings, and its stable shape hash",
+			Params: []*TypeDescriptor{{Kind: "string", Label: "query"}},
 			Return: &TypeDescriptor{Kind: "list"},
 			Const:  true,
 		},

--- a/scm/streams.go
+++ b/scm/streams.go
@@ -30,12 +30,12 @@ func init_streams() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "streamString",
-		Desc: "creates a stream that contains a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewAny(a[0].Stream())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "content", ParamDesc: "content to put into the stream"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "creates a stream that contains a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "content", Description: "content to put into the stream"}},
 			Return: &TypeDescriptor{Kind: "stream"},
 
 			JITEmit: nil,
@@ -43,7 +43,7 @@ func init_streams() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "gzip",
-		Desc: "compresses a stream with gzip. Create streams with (stream filename)",
+
 		Fn: func(a ...Scmer) Scmer {
 			stream, ok := a[0].Any().(io.Reader)
 			if !ok {
@@ -60,8 +60,8 @@ func init_streams() {
 			}()
 			return NewAny(io.Reader(reader))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", ParamName: "stream", ParamDesc: "input stream"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "compresses a stream with gzip. Create streams with (stream filename)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", Label: "stream", Description: "input stream"}},
 			Return: &TypeDescriptor{Kind: "stream"},
 
 			JITEmit: nil,
@@ -69,7 +69,7 @@ func init_streams() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "xz",
-		Desc: "compresses a stream with xz. Create streams with (stream filename)",
+
 		Fn: func(a ...Scmer) Scmer {
 			stream, ok := a[0].Any().(io.Reader)
 			if !ok {
@@ -89,8 +89,8 @@ func init_streams() {
 			}
 			return NewAny(io.Reader(reader))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", ParamName: "stream", ParamDesc: "input stream"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "compresses a stream with xz. Create streams with (stream filename)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", Label: "stream", Description: "input stream"}},
 			Return: &TypeDescriptor{Kind: "stream"},
 
 			JITEmit: nil,
@@ -98,7 +98,7 @@ func init_streams() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "zcat",
-		Desc: "turns a compressed gzip stream into a stream of uncompressed data. Create streams with (stream filename)",
+
 		Fn: func(a ...Scmer) Scmer {
 			stream, ok := a[0].Any().(io.Reader)
 			if !ok {
@@ -110,8 +110,8 @@ func init_streams() {
 			}
 			return NewAny(reader)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", ParamName: "stream", ParamDesc: "input stream"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns a compressed gzip stream into a stream of uncompressed data. Create streams with (stream filename)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", Label: "stream", Description: "input stream"}},
 			Return: &TypeDescriptor{Kind: "stream"},
 
 			JITEmit: nil,
@@ -119,7 +119,7 @@ func init_streams() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "xzcat",
-		Desc: "turns a compressed xz stream into a stream of uncompressed data. Create streams with (stream filename)",
+
 		Fn: func(a ...Scmer) Scmer {
 			stream, ok := a[0].Any().(io.Reader)
 			if !ok {
@@ -131,8 +131,8 @@ func init_streams() {
 			}
 			return NewAny(reader)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", ParamName: "stream", ParamDesc: "input stream"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns a compressed xz stream into a stream of uncompressed data. Create streams with (stream filename)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "stream", Label: "stream", Description: "input stream"}},
 			Return: &TypeDescriptor{Kind: "stream"},
 
 			JITEmit: nil,

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -4777,7 +4777,9 @@ func init_strings() {
 				ctx.BindReg(d4.Reg, &d4)
 				ctx.BindReg(d4.Reg2, &d4)
 				if d4.Loc == LocImm {
-					if result.Loc == LocAny { return d4 }
+					if result.Loc == LocAny {
+						return d4
+					}
 				}
 				if result.Loc == LocAny {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
@@ -10115,12 +10117,12 @@ func init_strings() {
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a canonical order relation for a collation and direction. MemCP allows natural sorting of numeric literals.",
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "collation", Description: "collation string of the form LANG or LANG_cs or LANG_ci where LANG is a BCP 47 code, for compatibility to MySQL, a CHARSET_ prefix is allowed and ignored as well as the aliases bin, danish, general, german1, german2, spanish and swedish are allowed for language codes"}, &TypeDescriptor{Kind: "bool", Label: "reverse", Description: "whether to reverse the order like in ORDER BY DESC", Optional: true}},
-			Return: &TypeDescriptor{Kind: "func",
+			Return: &TypeDescriptor{Kind: "func", Label: "relation", Description: "compares two values using the selected collation and direction",
 				Params: []*TypeDescriptor{
 					{Kind: "any", Label: "a", Description: "left operand"},
 					{Kind: "any", Label: "b", Description: "right operand"},
 				},
-				Return: &TypeDescriptor{Kind: "bool"},
+				Return: &TypeDescriptor{Kind: "bool", Label: "ordered", Description: "whether a sorts before b"},
 			},
 			Const: true,
 

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -277,13 +277,13 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "string?",
-		Desc: "tells if the value is a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			_, ok := a[0].Any().(string)
 			return NewBool(ok)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "value"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "tells if the value is a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "value"}},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 
@@ -292,7 +292,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "concat",
-		Desc: "concatenates stringable values and returns a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			var sb strings.Builder
 			for _, s := range a {
@@ -307,8 +307,8 @@ func init_strings() {
 			}
 			return NewString(sb.String())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "first value to concat"}, &TypeDescriptor{Kind: "any", ParamName: "more...", ParamDesc: "additional values to concat", Variadic: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "concatenates stringable values and returns a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "first value to concat"}, &TypeDescriptor{Kind: "any", Label: "more...", Description: "additional values to concat", Variadic: true}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -317,12 +317,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_concat",
-		Desc: "SQL CONCAT semantics: returns NULL if any argument is NULL",
+
 		Fn: func(a ...Scmer) Scmer {
 			return Globalenv.Vars["concat"].Func()(a...)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "first value to concat"}, &TypeDescriptor{Kind: "any", ParamName: "more...", ParamDesc: "additional values to concat", Variadic: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL CONCAT semantics: returns NULL if any argument is NULL",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "first value to concat"}, &TypeDescriptor{Kind: "any", Label: "more...", Description: "additional values to concat", Variadic: true}},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 
@@ -331,7 +331,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "substr",
-		Desc: "returns a substring (0-based index)",
+
 		Fn: func(a ...Scmer) Scmer {
 			s := String(a[0])
 			i := ToInt(a[1])
@@ -340,8 +340,8 @@ func init_strings() {
 			}
 			return NewString(s[i:])
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to cut"}, &TypeDescriptor{Kind: "number", ParamName: "start", ParamDesc: "first character index (0-based)"}, &TypeDescriptor{Kind: "number", ParamName: "len", ParamDesc: "optional length", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a substring (0-based index)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to cut"}, &TypeDescriptor{Kind: "number", Label: "start", Description: "first character index (0-based)"}, &TypeDescriptor{Kind: "number", Label: "len", Description: "optional length", Optional: true}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -1012,7 +1012,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_substr",
-		Desc: "SQL SUBSTR/SUBSTRING with 1-based index and bounds checking",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -1038,8 +1038,8 @@ func init_strings() {
 			}
 			return NewString(s[start:])
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to cut"}, &TypeDescriptor{Kind: "number", ParamName: "start", ParamDesc: "first character position (1-based)"}, &TypeDescriptor{Kind: "number", ParamName: "len", ParamDesc: "optional length", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL SUBSTR/SUBSTRING with 1-based index and bounds checking",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to cut"}, &TypeDescriptor{Kind: "number", Label: "start", Description: "first character position (1-based)"}, &TypeDescriptor{Kind: "number", Label: "len", Description: "optional length", Optional: true}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -4637,19 +4637,19 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "simplify",
-		Desc: "turns a stringable input value in the easiest-most value (e.g. turn strings into numbers if they are numeric",
+
 		Fn: func(a ...Scmer) Scmer {
 			// turn string to number or so
 			return Simplify(String(a[0]))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "value to simplify"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "Converts numeric text to a number. Text beginning with { or [ becomes a native JSON value when it is valid JSON; other input remains a string.",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "value to interpret as a number or JSON value"}},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 
-			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
 				/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */
-				argPinned0 := make([]Reg, 0, len(args)*2)
+				argPinned0 := make([]Reg, 0, len(args)*3)
 				seenArgRegs := make(map[Reg]bool)
 				for _, ai := range args {
 					if ai.Loc == LocReg {
@@ -4669,8 +4669,21 @@ func init_strings() {
 							seenArgRegs[ai.Reg2] = true
 							argPinned0 = append(argPinned0, ai.Reg2)
 						}
+					} else if ai.Loc == LocRegTriple {
+						for _, r := range [...]Reg{ai.Reg, ai.Reg2, ai.Reg3} {
+							if !seenArgRegs[r] {
+								ctx.ProtectReg(r)
+								seenArgRegs[r] = true
+								argPinned0 = append(argPinned0, r)
+							}
+						}
 					}
 				}
+				defer func() {
+					for _, r := range argPinned0 {
+						ctx.UnprotectReg(r)
+					}
+				}()
 				d1 := args[0]
 				d1.ID = 0
 				d3 := d1
@@ -4737,19 +4750,10 @@ func init_strings() {
 				ctx.EnsureDesc(&d2)
 				if d2.Loc == LocImm {
 					tmpPair := JITValueDesc{Loc: LocRegPair, Type: d2.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
-					if d2.Imm.GetTag() == tagBool {
-						ctx.EmitMakeBool(tmpPair, d2)
-					} else if d2.Imm.GetTag() == tagInt {
-						ctx.EmitMakeInt(tmpPair, d2)
-					} else if d2.Imm.GetTag() == tagFloat {
-						ctx.EmitMakeFloat(tmpPair, d2)
-					} else if d2.Imm.GetTag() == tagNil {
-						ctx.EmitMakeNil(tmpPair)
-					} else {
-						ptrWord, auxWord := d2.Imm.RawWords()
-						ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
-						ctx.EmitMovRegImm64(tmpPair.Reg2, auxWord)
-					}
+					ctx.TrackImm(d2.Imm)
+					ptrWord, _ := d2.Imm.RawWords()
+					ctx.EmitMovRegImm64(tmpPair.Reg, uint64(ptrWord))
+					ctx.EmitMovRegImm64(tmpPair.Reg2, uint64(len(d2.Imm.String())))
 					d2 = tmpPair
 				} else if d2.Loc == LocReg {
 					tmpPair := JITValueDesc{Loc: LocRegPair, Type: d2.Type, Reg: ctx.AllocRegExcept(d2.Reg), Reg2: ctx.AllocRegExcept(d2.Reg)}
@@ -4773,9 +4777,7 @@ func init_strings() {
 				ctx.BindReg(d4.Reg, &d4)
 				ctx.BindReg(d4.Reg2, &d4)
 				if d4.Loc == LocImm {
-					if result.Loc == LocAny {
-						return d4
-					}
+					if result.Loc == LocAny { return d4 }
 				}
 				if result.Loc == LocAny {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
@@ -4805,21 +4807,18 @@ func init_strings() {
 					}
 				}
 				return result
-				for _, r := range argPinned0 {
-					ctx.UnprotectReg(r)
-				}
 				return result
 			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strlen",
-		Desc: "returns the length of a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewInt(int64(len(String(a[0]))))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the length of a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
 
@@ -4951,7 +4950,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strlike",
-		Desc: "matches the string against a wildcard pattern using SQL NULL semantics",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -4964,8 +4963,8 @@ func init_strings() {
 			}
 			return NewBool(StrLikeCollation(value, pattern, collation))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "pattern", ParamDesc: "pattern with % and _ in them"}, &TypeDescriptor{Kind: "string", ParamName: "collation", ParamDesc: "collation in which to compare them", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "matches the string against a wildcard pattern using SQL NULL semantics",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "pattern with % and _ in them"}, &TypeDescriptor{Kind: "string", Label: "collation", Description: "collation in which to compare them", Optional: true}},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 
@@ -6263,15 +6262,15 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strlike_cs",
-		Desc: "matches the string against a wildcard pattern case-sensitively using SQL NULL semantics",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
 			}
 			return NewBool(StrLike(String(a[0]), String(a[1])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "pattern", ParamDesc: "pattern with % and _ in them"}, &TypeDescriptor{Kind: "string", ParamName: "collation", ParamDesc: "ignored (present for parser compatibility)", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "matches the string against a wildcard pattern case-sensitively using SQL NULL semantics",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "pattern with % and _ in them"}, &TypeDescriptor{Kind: "string", Label: "collation", Description: "ignored (present for parser compatibility)", Optional: true}},
 			Return: &TypeDescriptor{Kind: "bool"},
 			Const:  true,
 
@@ -6925,12 +6924,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "toLower",
-		Desc: "turns a string into lower case",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.ToLower(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns a string into lower case",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -7075,12 +7074,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "toUpper",
-		Desc: "turns a string into upper case",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.ToUpper(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns a string into upper case",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -7225,12 +7224,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "replace",
-		Desc: "replaces all occurances in a string with another string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.ReplaceAll(String(a[0]), String(a[1]), String(a[2])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "s", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "find", ParamDesc: "search string"}, &TypeDescriptor{Kind: "string", ParamName: "replace", ParamDesc: "replace string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "replaces all occurances in a string with another string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "s", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "find", Description: "search string"}, &TypeDescriptor{Kind: "string", Label: "replace", Description: "replace string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -7571,12 +7570,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strtrim",
-		Desc: "trims whitespace from both ends of a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.TrimSpace(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "trims whitespace from both ends of a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -7721,12 +7720,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strltrim",
-		Desc: "trims whitespace from the left of a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.TrimLeft(String(a[0]), " \t\n\r"))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "trims whitespace from the left of a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -7907,12 +7906,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "strrtrim",
-		Desc: "trims whitespace from the right of a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(strings.TrimRight(String(a[0]), " \t\n\r"))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "trims whitespace from the right of a string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -8094,15 +8093,15 @@ func init_strings() {
 	// SQL-level NULL-safe wrappers for TRIM/LTRIM/RTRIM
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_trim",
-		Desc: "SQL TRIM(): NULL-safe trim of whitespace from both ends",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
 			}
 			return NewString(strings.TrimSpace(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL TRIM(): NULL-safe trim of whitespace from both ends",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -8447,15 +8446,15 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_ltrim",
-		Desc: "SQL LTRIM(): NULL-safe trim of whitespace from left",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
 			}
 			return NewString(strings.TrimLeft(String(a[0]), " \t\n\r"))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL LTRIM(): NULL-safe trim of whitespace from left",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -8838,15 +8837,15 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_rtrim",
-		Desc: "SQL RTRIM(): NULL-safe trim of whitespace from right",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
 			}
 			return NewString(strings.TrimRight(String(a[0]), " \t\n\r"))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "SQL RTRIM(): NULL-safe trim of whitespace from right",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -9229,7 +9228,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "split",
-		Desc: "splits a string using a separator or space",
+
 		Fn: func(a ...Scmer) Scmer {
 			split := " "
 			if len(a) > 1 {
@@ -9242,8 +9241,8 @@ func init_strings() {
 			}
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "separator", ParamDesc: "(optional) parameter, defaults to \" \"", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "splits a string using a separator or space",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "separator", Description: "(optional) parameter, defaults to \" \"", Optional: true}},
 			Return: &TypeDescriptor{Kind: "list"},
 			Const:  true,
 
@@ -9253,7 +9252,7 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "string_repeat",
-		Desc: "repeats a string n times",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -9264,8 +9263,8 @@ func init_strings() {
 			}
 			return NewString(strings.Repeat(String(a[0]), int(n)))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to repeat"}, &TypeDescriptor{Kind: "number", ParamName: "count", ParamDesc: "number of repetitions"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "repeats a string n times",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to repeat"}, &TypeDescriptor{Kind: "number", Label: "count", Description: "number of repetitions"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -9875,7 +9874,7 @@ func init_strings() {
 	collation_re := regexp.MustCompile("^([^_]+_)?(.+?)$") // caracterset_language_case
 	Declare(&Globalenv, &Declaration{
 		Name: "collate",
-		Desc: "returns a canonical order relation for a collation and direction. MemCP allows natural sorting of numeric literals.",
+
 		Fn: func(a ...Scmer) Scmer {
 			collationName := String(a[0])
 			reverse := len(a) > 1 && ToBool(a[1])
@@ -10114,12 +10113,12 @@ func init_strings() {
 			canonical, _ := collateCache.LoadOrStore(key, result)
 			return canonical.(Scmer)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "collation", ParamDesc: "collation string of the form LANG or LANG_cs or LANG_ci where LANG is a BCP 47 code, for compatibility to MySQL, a CHARSET_ prefix is allowed and ignored as well as the aliases bin, danish, general, german1, german2, spanish and swedish are allowed for language codes"}, &TypeDescriptor{Kind: "bool", ParamName: "reverse", ParamDesc: "whether to reverse the order like in ORDER BY DESC", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a canonical order relation for a collation and direction. MemCP allows natural sorting of numeric literals.",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "collation", Description: "collation string of the form LANG or LANG_cs or LANG_ci where LANG is a BCP 47 code, for compatibility to MySQL, a CHARSET_ prefix is allowed and ignored as well as the aliases bin, danish, general, german1, german2, spanish and swedish are allowed for language codes"}, &TypeDescriptor{Kind: "bool", Label: "reverse", Description: "whether to reverse the order like in ORDER BY DESC", Optional: true}},
 			Return: &TypeDescriptor{Kind: "func",
 				Params: []*TypeDescriptor{
-					{Kind: "any", ParamName: "a", ParamDesc: "left operand"},
-					{Kind: "any", ParamName: "b", ParamDesc: "right operand"},
+					{Kind: "any", Label: "a", Description: "left operand"},
+					{Kind: "any", Label: "b", Description: "right operand"},
 				},
 				Return: &TypeDescriptor{Kind: "bool"},
 			},
@@ -10132,12 +10131,12 @@ func init_strings() {
 	/* escaping functions similar to PHP */
 	Declare(&Globalenv, &Declaration{
 		Name: "htmlentities",
-		Desc: "escapes the string for use in HTML",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(html.EscapeString(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "input string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "escapes the string for use in HTML",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "input string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10282,12 +10281,12 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "urlencode",
-		Desc: "encodes a string according to URI coding schema",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(url.QueryEscape(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to encode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "encodes a string according to URI coding schema",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to encode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10432,7 +10431,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "urldecode",
-		Desc: "decodes a string according to URI coding schema",
+
 		Fn: func(a ...Scmer) Scmer {
 			result, err := url.QueryUnescape(String(a[0]))
 			if err != nil {
@@ -10440,8 +10439,8 @@ func init_strings() {
 			}
 			return NewString(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to decode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "decodes a string according to URI coding schema",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to decode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10450,7 +10449,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "json_encode",
-		Desc: "encodes a value in JSON, treats lists as lists",
+
 		Fn: func(a ...Scmer) Scmer {
 			b, err := json.Marshal(a[0])
 			if err != nil {
@@ -10458,8 +10457,8 @@ func init_strings() {
 			}
 			return NewString(string(b))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "value to encode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "encodes a value in JSON, treats lists as lists",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "value to encode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10468,7 +10467,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "json_quote",
-		Desc: "quotes a string as a JSON string literal without HTML escaping",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || !a[0].IsString() {
 				return NewNil()
@@ -10481,8 +10480,8 @@ func init_strings() {
 			}
 			return NewString(strings.TrimSuffix(encoded.String(), "\n"))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "string to quote"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "quotes a string as a JSON string literal without HTML escaping",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "string to quote"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10491,7 +10490,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "json_encode_assoc",
-		Desc: "encodes a value in JSON, treats lists as associative arrays",
+
 		Fn: func(a ...Scmer) Scmer {
 			// Build a Go structure where assoc lists (even-length lists or FastDict)
 			// are represented as map[string]any, and leaf values remain Scmer so
@@ -10525,8 +10524,8 @@ func init_strings() {
 			}
 			return NewString(string(b))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "value", ParamDesc: "value to encode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "encodes a value in JSON, treats lists as associative arrays",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "value", Description: "value to encode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10535,7 +10534,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "json_decode",
-		Desc: "parses JSON into a map",
+
 		Fn: func(a ...Scmer) Scmer {
 			var result any
 			err := json.Unmarshal([]byte(String(a[0])), &result)
@@ -10544,8 +10543,8 @@ func init_strings() {
 			}
 			return TransformFromJSON(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to decode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "parses JSON into a map",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to decode"}},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 
@@ -10554,7 +10553,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "json_decode_scmer",
-		Desc: "parses JSON produced by json_encode and preserves Scheme symbols and lists",
+
 		Fn: func(a ...Scmer) Scmer {
 			var result Scmer
 			err := json.Unmarshal([]byte(String(a[0])), &result)
@@ -10563,8 +10562,8 @@ func init_strings() {
 			}
 			return result
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "Scmer JSON to decode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "parses JSON produced by json_encode and preserves Scheme symbols and lists",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "Scmer JSON to decode"}},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 
@@ -10574,12 +10573,12 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "base64_encode",
-		Desc: "encodes a string as Base64 (standard encoding)",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(base64.StdEncoding.EncodeToString([]byte(String(a[0]))))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "binary string to encode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "encodes a string as Base64 (standard encoding)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "binary string to encode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10588,7 +10587,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "base64_decode",
-		Desc: "decodes a Base64 string (standard encoding)",
+
 		Fn: func(a ...Scmer) Scmer {
 			decoded, err := base64.StdEncoding.DecodeString(String(a[0]))
 			if err != nil {
@@ -10596,8 +10595,8 @@ func init_strings() {
 			}
 			return NewString(string(decoded))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "base64-encoded string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "decodes a Base64 string (standard encoding)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "base64-encoded string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10607,7 +10606,7 @@ func init_strings() {
 	sql_escapings := regexp.MustCompile("\\\\[\\\\'\"nr0]")
 	Declare(&Globalenv, &Declaration{
 		Name: "sql_unescape",
-		Desc: "unescapes the inner part of a sql string",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := String(a[0])
 			out := sql_escapings.ReplaceAllStringFunc(input, func(m string) string {
@@ -10629,8 +10628,8 @@ func init_strings() {
 			})
 			return NewString(out)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to decode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "unescapes the inner part of a sql string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to decode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10639,7 +10638,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "bin2hex",
-		Desc: "turns binary data into hex with lowercase letters",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := String(a[0])
 			result := make([]byte, 2*len(input))
@@ -10650,8 +10649,8 @@ func init_strings() {
 			}
 			return NewString(string(result))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to decode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns binary data into hex with lowercase letters",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to decode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10660,7 +10659,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "bin2hex",
-		Desc: "turns binary data into hex with lowercase letters",
+
 		Fn: func(a ...Scmer) Scmer {
 			input := String(a[0])
 			result := make([]byte, 2*len(input))
@@ -10671,8 +10670,8 @@ func init_strings() {
 			}
 			return NewString(string(result))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "string to encode"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "turns binary data into hex with lowercase letters",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to encode"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10681,7 +10680,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "hex2bin",
-		Desc: "decodes a hex string into binary data",
+
 		Fn: func(a ...Scmer) Scmer {
 			decoded, err := hex.DecodeString(String(a[0]))
 			if err != nil {
@@ -10689,8 +10688,8 @@ func init_strings() {
 			}
 			return NewString(string(decoded))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "value", ParamDesc: "hex string (even length)"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "decodes a hex string into binary data",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "hex string (even length)"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10700,7 +10699,7 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "uuid",
-		Desc: "generates a new random UUID v4 string",
+
 		Fn: func(a ...Scmer) Scmer {
 			id, err := uuid.NewRandom()
 			if err != nil {
@@ -10708,7 +10707,7 @@ func init_strings() {
 			}
 			return NewString(id.String())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "generates a new random UUID v4 string",
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  false, /* NOT const — each call must return a unique value */
 
@@ -10718,7 +10717,7 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "randomBytes",
-		Desc: "returns a string with numBytes cryptographically secure random bytes",
+
 		Fn: func(a ...Scmer) Scmer {
 			n := ToInt(a[0])
 			if n < 0 {
@@ -10732,8 +10731,8 @@ func init_strings() {
 			}
 			return NewString(string(buf))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", ParamName: "numBytes", ParamDesc: "number of random bytes"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a string with numBytes cryptographically secure random bytes",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", Label: "numBytes", Description: "number of random bytes"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10743,7 +10742,7 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "regexp_replace",
-		Desc: "replaces matches of a regex pattern in a string",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -10754,8 +10753,8 @@ func init_strings() {
 			}
 			return NewString(re.ReplaceAllString(String(a[0]), String(a[2])))
 		},
-		Type: &TypeDescriptor{
-			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "str", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "pattern", ParamDesc: "regex pattern"}, &TypeDescriptor{Kind: "string", ParamName: "replacement", ParamDesc: "replacement string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "replaces matches of a regex pattern in a string",
+			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "regex pattern"}, &TypeDescriptor{Kind: "string", Label: "replacement", Description: "replacement string"}},
 			Return:   &TypeDescriptor{Kind: "string"},
 			Const:    true,
 			Optimize: optimizeRegexpReplace,
@@ -10766,12 +10765,12 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "fnv_hash",
-		Desc: "computes a fast non-cryptographic 64-bit FNV-1a hash of a string, returns a 16-character hex string",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(fnvHashString(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "str", ParamDesc: "input string to hash"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "computes a fast non-cryptographic 64-bit FNV-1a hash of a string, returns a 16-character hex string",
+			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string to hash"}},
 			Return:   &TypeDescriptor{Kind: "string"},
 			Const:    true,
 			Optimize: optimizeFNVHash,
@@ -10917,7 +10916,7 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "stable_structural_hash",
-		Desc: "streams the string or serialized representation of a Scheme value into stable FNV-1a without constructing the complete representation",
+
 		Fn: func(a ...Scmer) Scmer {
 			if len(a) < 1 || len(a) > 2 {
 				panic("stable_structural_hash expects a value and optional serialize flag")
@@ -10930,10 +10929,10 @@ func init_strings() {
 			}
 			return NewString(formatStructuralHash(writer.hash))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "streams the string or serialized representation of a Scheme value into stable FNV-1a without constructing the complete representation",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "value", ParamDesc: "value to hash", NoEscape: true},
-				{Kind: "bool", ParamName: "serialize", ParamDesc: "use the Scheme serializer instead of string rendering", Optional: true},
+				{Kind: "any", Label: "value", Description: "value to hash", NoEscape: true},
+				{Kind: "bool", Label: "serialize", Description: "use the Scheme serializer instead of string rendering", Optional: true},
 			},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
@@ -10943,13 +10942,13 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sha1",
-		Desc: "computes the SHA-1 digest of a string, returns a 40-character lowercase hex string",
+
 		Fn: func(a ...Scmer) Scmer {
 			sum := sha1.Sum([]byte(String(a[0])))
 			return NewString(hex.EncodeToString(sum[:]))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "str", ParamDesc: "input string to hash"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "computes the SHA-1 digest of a string, returns a 40-character lowercase hex string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string to hash"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10958,13 +10957,13 @@ func init_strings() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sha256",
-		Desc: "computes the SHA-256 digest of a string, returns a 64-character lowercase hex string",
+
 		Fn: func(a ...Scmer) Scmer {
 			sum := sha256.Sum256([]byte(String(a[0])))
 			return NewString(hex.EncodeToString(sum[:]))
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "str", ParamDesc: "input string to hash"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "computes the SHA-256 digest of a string, returns a 64-character lowercase hex string",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string to hash"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -10974,7 +10973,7 @@ func init_strings() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "regexp_test",
-		Desc: "tests if a string matches a regex pattern, returns true/false",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -10985,8 +10984,8 @@ func init_strings() {
 			}
 			return NewBool(re.MatchString(String(a[0])))
 		},
-		Type: &TypeDescriptor{
-			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "str", ParamDesc: "input string"}, &TypeDescriptor{Kind: "string", ParamName: "pattern", ParamDesc: "regex pattern"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests if a string matches a regex pattern, returns true/false",
+			Params:   []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "regex pattern"}},
 			Return:   &TypeDescriptor{Kind: "bool"},
 			Const:    true,
 			Optimize: optimizeRegexpTest,

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -506,33 +506,33 @@ func init_sync() {
 	DeclareTitle("Sync")
 	Declare(&Globalenv, &Declaration{
 		Name: "newpromise",
-		Desc: "Creates a single-value promise cell (thread-safe via CAS spin-lock). Returns a tagPromise Scmer. (newpromise) allocates a [2]Scmer backing; (newpromise list) reuses an existing ≥2-element slice as backing with zero extra allocation. API: (p \"value\") reads current value (nil if pending), (p \"value\" v) resolves, (p \"once\" v) resolves once (panics if already fulfilled/failed), (p \"once\" v msg) resolves once with custom panic message, (p \"state\") returns state (nil/true/false), (p \"fail\") sets failed and clears the stored value, (p \"fail\" err) sets failed and stores err as payload.",
-		Fn:   NewPromise,
-		Type: &TypeDescriptor{
+
+		Fn: NewPromise,
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates a thread-safe promise that lets parallel work publish one result for other code to inspect. Use it for shared initialization, asynchronous results, or ensuring that only the first successful producer resolves a value. Read with (promise \"value\"), inspect completion with (promise \"state\"), resolve with (promise \"value\" value), resolve exactly once with (promise \"once\" value), and mark failure with (promise \"fail\" error).",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "list", ParamDesc: "optional: ≥2-element slice to use as backing", Optional: true},
+				{Kind: "list", Label: "storage", Description: "optional existing two-item list used to hold the promise state; most callers omit this", Optional: true, Element: &TypeDescriptor{Kind: "any", Label: "slot", Description: "promise state or value slot"}},
 			},
-			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
+			Return: &TypeDescriptor{Kind: "func", Label: "promise", Description: "operation-based accessor for reading, resolving, or failing the promise", HasSideEffects: true,
 				Params: []*TypeDescriptor{
-					{Kind: "string", ParamName: "operation", ParamDesc: "one of: value, state, fail, once"},
-					{Kind: "any", ParamName: "value", ParamDesc: "value to store (for value/once/fail)", Optional: true},
-					{Kind: "string", ParamName: "msg", ParamDesc: "custom panic message (for once)", Optional: true},
+					{Kind: "string", Label: "operation", Description: "one of: value, state, fail, once"},
+					{Kind: "any", Label: "value", Description: "value to store (for value/once/fail)", Optional: true},
+					{Kind: "string", Label: "message", Description: "optional error message used when once finds an already completed promise", Optional: true},
 				},
-				Return: &TypeDescriptor{Kind: "any"},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "stored value, state flag, or operation result"},
 			},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "newsession",
-		Desc: "Creates a new session which is a threadsafe key-value store. Besides get/set/list, get_or_compute_scoped shares concurrent computation by a query-local handle.",
-		Fn:   NewSession,
-		Type: &TypeDescriptor{
+
+		Fn: NewSession,
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates a new session which is a threadsafe key-value store. Besides get/set/list, get_or_compute_scoped shares concurrent computation by a query-local handle.",
 			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
 				Params: []*TypeDescriptor{
-					{Kind: "any", ParamName: "key_or_operation", ParamDesc: "key, or get_or_compute_scoped", Optional: true},
-					{Kind: "any", ParamName: "value_scope_or_key", ParamDesc: "value, scope, or compute key", Optional: true},
-					{Kind: "any", ParamName: "key_or_producer", ParamDesc: "scoped key or producer", Optional: true},
-					{Kind: "func", ParamName: "scoped_producer", ParamDesc: "producer for scoped computation", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+					{Kind: "any", Label: "key_or_operation", Description: "key, or get_or_compute_scoped", Optional: true},
+					{Kind: "any", Label: "value_scope_or_key", Description: "value, scope, or compute key", Optional: true},
+					{Kind: "any", Label: "key_or_producer", Description: "scoped key or producer", Optional: true},
+					{Kind: "func", Label: "scoped_producer", Description: "producer for scoped computation", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
 				},
 				Return: &TypeDescriptor{Kind: "any"},
 			},
@@ -540,14 +540,14 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "with_session",
-		Desc: "Executes a function with the given session installed in the execution context, so storage operations can access the session's transaction state.",
+
 		Fn: func(a ...Scmer) Scmer {
 			return WithSession(a[0], a[1])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Executes a function with the given session installed in the execution context, so storage operations can access the session's transaction state.",
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "session", ParamDesc: "the session to install", Params: []*TypeDescriptor{{Kind: "any", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "fn", ParamDesc: "the function to execute", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "session", Description: "the session to install", Params: []*TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "fn", Description: "the function to execute", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 
@@ -698,18 +698,18 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "context",
-		Desc: "Context helper function. Each context also contains a session. (context func args) creates a new context and runs func in that context, (context \"session\") reads the session variable, (context \"check\") will check the liveliness of the context and otherwise throw an error",
-		Fn:   Context,
-		Type: &TypeDescriptor{
+
+		Fn: Context,
+		Type: &TypeDescriptor{Kind: "func", Description: "Context helper function. Each context also contains a session. (context func args) creates a new context and runs func in that context, (context \"session\") reads the session variable, (context \"check\") will check the liveliness of the context and otherwise throw an error",
 			Params: []*TypeDescriptor{
-				{Kind: "any", ParamName: "args...", ParamDesc: "depends on the usage", Variadic: true},
+				{Kind: "any", Label: "args...", Description: "depends on the usage", Variadic: true},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "sleep",
-		Desc: "sleeps the amount of seconds",
+
 		Fn: func(a ...Scmer) Scmer {
 			ctx := GetContext()
 			select {
@@ -719,9 +719,9 @@ func init_sync() {
 				return NewBool(true)
 			}
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "sleeps the amount of seconds",
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "duration", ParamDesc: "number of seconds to sleep"},
+				{Kind: "number", Label: "duration", Description: "number of seconds to sleep"},
 			},
 			Return: &TypeDescriptor{Kind: "bool"},
 
@@ -730,7 +730,7 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "once",
-		Desc: "Creates a function wrapper that you can call multiple times but only gets executed once. The result value is cached and returned on a second call. You can add parameters to that resulting function that will be passed to the first run of the wrapped function.",
+
 		Fn: func(a ...Scmer) Scmer {
 			var params []Scmer
 			once := sync.OnceValue[Scmer](func() Scmer {
@@ -741,13 +741,13 @@ func init_sync() {
 				return once()
 			})
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates a function wrapper that you can call multiple times but only gets executed once. The result value is cached and returned on a second call. You can add parameters to that resulting function that will be passed to the first run of the wrapped function.",
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "f", ParamDesc: "function that produces the result value"},
+				{Kind: "func", Label: "f", Description: "function that produces the result value", Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 			},
 			Return: &TypeDescriptor{Kind: "func",
 				Params: []*TypeDescriptor{
-					{Kind: "any", ParamName: "args", ParamDesc: "arguments forwarded to the wrapped function on first call", Variadic: true},
+					{Kind: "any", Label: "args", Description: "arguments forwarded to the wrapped function on first call", Variadic: true},
 				},
 				Return: &TypeDescriptor{Kind: "any"},
 			},
@@ -757,7 +757,7 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mutex",
-		Desc: "Creates a context-aware mutex. The return value serializes calls to parameterless functions and stops waiting when the current request is cancelled.",
+
 		Fn: func(a ...Scmer) Scmer {
 			token := make(chan struct{}, 1)
 			token <- struct{}{}
@@ -790,11 +790,11 @@ func init_sync() {
 				return Apply(a[0])
 			})
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates a context-aware mutex. The return value serializes calls to parameterless functions and stops waiting when the current request is cancelled.",
 			Params: []*TypeDescriptor{},
 			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
 				Params: []*TypeDescriptor{
-					{Kind: "func", ParamName: "fn", ParamDesc: "parameterless function to execute under the lock"},
+					{Kind: "func", Label: "fn", Description: "parameterless function to execute under the lock", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 				},
 				Return: &TypeDescriptor{Kind: "any"},
 			},
@@ -804,11 +804,11 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "numcpu",
-		Desc: "Returns the number of logical CPUs available for parallel execution",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewInt(int64(runtime.NumCPU()))
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Returns the number of logical CPUs available for parallel execution",
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
 
@@ -863,7 +863,7 @@ func init_sync() {
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "memstats",
-		Desc: "Returns memory statistics as a dict with keys: alloc, total_alloc, sys, heap_alloc, heap_sys (all in bytes)",
+
 		Fn: func(a ...Scmer) Scmer {
 			m := CachedMemStats()
 			fd := NewFastDictValue(5)
@@ -874,7 +874,7 @@ func init_sync() {
 			fd.Set(NewString("heap_sys"), NewInt(int64(m.HeapSys)), nil)
 			return NewFastDict(fd)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "Returns memory statistics as a dict with keys: alloc, total_alloc, sys, heap_alloc, heap_sys (all in bytes)",
 			Return: &TypeDescriptor{Kind: "dict"},
 			Const:  true,
 

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -526,15 +526,15 @@ func init_sync() {
 		Name: "newsession",
 
 		Fn: NewSession,
-		Type: &TypeDescriptor{Kind: "func", Description: "Creates a new session which is a threadsafe key-value store. Besides get/set/list, get_or_compute_scoped shares concurrent computation by a query-local handle.",
-			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
+		Type: &TypeDescriptor{Kind: "func", Description: "Creates a thread-safe key-value session. Call it without arguments to list values, with a key to read, with a key and value to store, or with get_or_compute_scoped, a scope, a key, and a producer to share one concurrent computation.",
+			Return: &TypeDescriptor{Kind: "func", Label: "session", Description: "session accessor accepting exactly zero, one, two, or four arguments", HasSideEffects: true,
 				Params: []*TypeDescriptor{
 					{Kind: "any", Label: "key_or_operation", Description: "key, or get_or_compute_scoped", Optional: true},
-					{Kind: "any", Label: "value_scope_or_key", Description: "value, scope, or compute key", Optional: true},
-					{Kind: "any", Label: "key_or_producer", Description: "scoped key or producer", Optional: true},
-					{Kind: "func", Label: "scoped_producer", Description: "producer for scoped computation", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+					{Kind: "any", Label: "value_or_scope", Description: "value to store, or scope for get_or_compute_scoped", Optional: true},
+					{Kind: "any", Label: "scoped_key", Description: "cache key used by get_or_compute_scoped", Optional: true},
+					{Kind: "func", Label: "scoped_producer", Description: "producer used only by the four-argument get_or_compute_scoped form", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
 				},
-				Return: &TypeDescriptor{Kind: "any"},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value list, stored value, retrieved value, or shared computed value"},
 			},
 		},
 	})
@@ -745,11 +745,11 @@ func init_sync() {
 			Params: []*TypeDescriptor{
 				{Kind: "func", Label: "f", Description: "function that produces the result value", Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 			},
-			Return: &TypeDescriptor{Kind: "func",
+			Return: &TypeDescriptor{Kind: "func", Label: "once_wrapper", Description: "calls the wrapped function once and returns its cached result thereafter",
 				Params: []*TypeDescriptor{
 					{Kind: "any", Label: "args", Description: "arguments forwarded to the wrapped function on first call", Variadic: true},
 				},
-				Return: &TypeDescriptor{Kind: "any"},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "result cached from the first call"},
 			},
 
 			JITEmit: nil,
@@ -792,11 +792,11 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "Creates a context-aware mutex. The return value serializes calls to parameterless functions and stops waiting when the current request is cancelled.",
 			Params: []*TypeDescriptor{},
-			Return: &TypeDescriptor{Kind: "func", HasSideEffects: true,
+			Return: &TypeDescriptor{Kind: "func", Label: "locked", Description: "executes one parameterless function while holding the mutex", HasSideEffects: true,
 				Params: []*TypeDescriptor{
 					{Kind: "func", Label: "fn", Description: "parameterless function to execute under the lock", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 				},
-				Return: &TypeDescriptor{Kind: "any"},
+				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "result returned by the protected function"},
 			},
 
 			JITEmit: nil,

--- a/scm/timezone.go
+++ b/scm/timezone.go
@@ -172,7 +172,7 @@ func init_timezone() {
 	// UNIX_TIMESTAMP(dt): converts datetime string to unix timestamp integer
 	Declare(&Globalenv, &Declaration{
 		Name: "unix_timestamp",
-		Desc: "returns a unix timestamp (integer seconds since epoch)",
+
 		Fn: func(a ...Scmer) Scmer {
 			if len(a) == 0 {
 				return NewInt(time.Now().Unix())
@@ -186,8 +186,8 @@ func init_timezone() {
 			}
 			return NewInt(t.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "dt", ParamDesc: "optional datetime value to convert", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns a unix timestamp (integer seconds since epoch)",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "dt", Description: "optional datetime value to convert", Optional: true}},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
 		},
@@ -196,11 +196,11 @@ func init_timezone() {
 	// system_time_zone: returns the OS-level timezone name
 	Declare(&Globalenv, &Declaration{
 		Name: "system_time_zone",
-		Desc: "returns the operating system's local timezone name",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewString(time.Local.String())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the operating system's local timezone name",
 			Return: &TypeDescriptor{Kind: "string"},
 		},
 	})
@@ -208,7 +208,7 @@ func init_timezone() {
 	// CONVERT_TZ(dt, from_tz, to_tz)
 	Declare(&Globalenv, &Declaration{
 		Name: "convert_tz",
-		Desc: "converts a datetime from one timezone to another",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() || a[2].IsNil() {
 				return NewNil()
@@ -240,8 +240,8 @@ func init_timezone() {
 			naive := time.Date(tInTo.Year(), tInTo.Month(), tInTo.Day(), tInTo.Hour(), tInTo.Minute(), tInTo.Second(), 0, time.UTC)
 			return NewDate(naive.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "dt", ParamDesc: "datetime value"}, &TypeDescriptor{Kind: "string", ParamName: "from_tz", ParamDesc: "source timezone"}, &TypeDescriptor{Kind: "string", ParamName: "to_tz", ParamDesc: "target timezone"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "converts a datetime from one timezone to another",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "dt", Description: "datetime value"}, &TypeDescriptor{Kind: "string", Label: "from_tz", Description: "source timezone"}, &TypeDescriptor{Kind: "string", Label: "to_tz", Description: "target timezone"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 		},
@@ -250,7 +250,7 @@ func init_timezone() {
 	// FROM_UNIXTIME(unix_ts [, format])
 	Declare(&Globalenv, &Declaration{
 		Name: "from_unixtime",
-		Desc: "converts a unix timestamp to a datetime in the session timezone",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() {
 				return NewNil()
@@ -264,8 +264,8 @@ func init_timezone() {
 			}
 			return NewDate(unix)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", ParamName: "unix_ts", ParamDesc: "unix timestamp (seconds since epoch)"}, &TypeDescriptor{Kind: "string", ParamName: "format", ParamDesc: "optional MySQL format string", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "converts a unix timestamp to a datetime in the session timezone",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "number", Label: "unix_ts", Description: "unix timestamp (seconds since epoch)"}, &TypeDescriptor{Kind: "string", Label: "format", Description: "optional MySQL format string", Optional: true}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 		},
@@ -274,11 +274,11 @@ func init_timezone() {
 	// UTC_TIMESTAMP()
 	Declare(&Globalenv, &Declaration{
 		Name: "utc_timestamp",
-		Desc: "returns the current UTC datetime",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewDate(time.Now().UTC().Unix())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current UTC datetime",
 			Return: &TypeDescriptor{Kind: "date"},
 		},
 	})
@@ -286,13 +286,13 @@ func init_timezone() {
 	// UTC_DATE()
 	Declare(&Globalenv, &Declaration{
 		Name: "utc_date",
-		Desc: "returns the current UTC date (midnight)",
+
 		Fn: func(a ...Scmer) Scmer {
 			now := time.Now().UTC()
 			midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 			return NewDate(midnight.Unix())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current UTC date (midnight)",
 			Return: &TypeDescriptor{Kind: "date"},
 		},
 	})
@@ -300,14 +300,14 @@ func init_timezone() {
 	// UTC_TIME()
 	Declare(&Globalenv, &Declaration{
 		Name: "utc_time",
-		Desc: "returns the current UTC time (as a datetime at epoch date)",
+
 		Fn: func(a ...Scmer) Scmer {
 			now := time.Now().UTC()
 			// Return as seconds since midnight
 			seconds := int64(now.Hour()*3600 + now.Minute()*60 + now.Second())
 			return NewDate(seconds)
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current UTC time (as a datetime at epoch date)",
 			Return: &TypeDescriptor{Kind: "date"},
 		},
 	})
@@ -315,11 +315,11 @@ func init_timezone() {
 	// SYSDATE() — re-evaluated on every call (unlike NOW() which is constant per query)
 	Declare(&Globalenv, &Declaration{
 		Name: "sysdate",
-		Desc: "returns the current datetime (re-evaluated per call, unlike now())",
+
 		Fn: func(a ...Scmer) Scmer {
 			return NewDate(time.Now().Unix())
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the current datetime (re-evaluated per call, unlike now())",
 			Return: &TypeDescriptor{Kind: "date"},
 		},
 	})
@@ -329,7 +329,7 @@ func init_timezone() {
 	// If dt has zone_id!=0 (TIMESTAMPTZ): convert UTC moment to local time in zone → return as-is.
 	Declare(&Globalenv, &Declaration{
 		Name: "at_time_zone",
-		Desc: "PostgreSQL AT TIME ZONE operator: converts between timezones",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[0].IsNil() || a[1].IsNil() {
 				return NewNil()
@@ -359,8 +359,8 @@ func init_timezone() {
 			naive := time.Date(utcTime.Year(), utcTime.Month(), utcTime.Day(), utcTime.Hour(), utcTime.Minute(), utcTime.Second(), 0, time.UTC)
 			return NewDate(naive.Unix())
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", ParamName: "dt", ParamDesc: "datetime value"}, &TypeDescriptor{Kind: "string", ParamName: "zone", ParamDesc: "target timezone"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "PostgreSQL AT TIME ZONE operator: converts between timezones",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "any", Label: "dt", Description: "datetime value"}, &TypeDescriptor{Kind: "string", Label: "zone", Description: "target timezone"}},
 			Return: &TypeDescriptor{Kind: "date"},
 			Const:  true,
 		},
@@ -369,7 +369,7 @@ func init_timezone() {
 	// TIMESTAMPDIFF(unit, dt1, dt2)
 	Declare(&Globalenv, &Declaration{
 		Name: "timestampdiff",
-		Desc: "returns the difference between two datetimes in the given unit",
+
 		Fn: func(a ...Scmer) Scmer {
 			if a[1].IsNil() || a[2].IsNil() {
 				return NewNil()
@@ -404,8 +404,8 @@ func init_timezone() {
 				return NewNil() // unknown unit → NULL (MySQL compatible)
 			}
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", ParamName: "unit", ParamDesc: "SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, YEAR"}, &TypeDescriptor{Kind: "any", ParamName: "dt1", ParamDesc: "first datetime"}, &TypeDescriptor{Kind: "any", ParamName: "dt2", ParamDesc: "second datetime"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "returns the difference between two datetimes in the given unit",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "unit", Description: "SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, YEAR"}, &TypeDescriptor{Kind: "any", Label: "dt1", Description: "first datetime"}, &TypeDescriptor{Kind: "any", Label: "dt2", Description: "second datetime"}},
 			Return: &TypeDescriptor{Kind: "int"},
 			Const:  true,
 		},

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -27,7 +27,7 @@ func init_vector() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "dot",
-		Desc: "produced the dot product",
+
 		Fn: func(a ...Scmer) Scmer {
 			var result float64
 			v1 := asSlice(a[0], "dot v1")
@@ -59,8 +59,8 @@ func init_vector() {
 			}
 			return NewFloat(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", ParamName: "v1", ParamDesc: "vector1"}, &TypeDescriptor{Kind: "list", ParamName: "v2", ParamDesc: "vector2"}, &TypeDescriptor{Kind: "string", ParamName: "mode", ParamDesc: "DOT, COSINE, EUCLIDEAN, default is DOT", Optional: true}},
+		Type: &TypeDescriptor{Kind: "func", Description: "produced the dot product",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "v1", Description: "vector1"}, &TypeDescriptor{Kind: "list", Label: "v2", Description: "vector2"}, &TypeDescriptor{Kind: "string", Label: "mode", Description: "DOT, COSINE, EUCLIDEAN, default is DOT", Optional: true}},
 			Return: &TypeDescriptor{Kind: "number"},
 			Const:  true,
 

--- a/scm/window.go
+++ b/scm/window.go
@@ -40,15 +40,15 @@ func init_window() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "stream_emit",
-		Desc: "invokes a streaming callback immediately; marks ordering-sensitive emission as an observable effect",
+
 		Fn: func(a ...Scmer) Scmer {
 			return Apply(a[0], a[1])
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "invokes a streaming callback immediately; marks ordering-sensitive emission as an observable effect",
 			HasSideEffects: true,
 			Params: []*TypeDescriptor{
-				{Kind: "func", ParamName: "emit", Params: []*TypeDescriptor{{Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "value"},
+				{Kind: "func", Label: "emit", Params: []*TypeDescriptor{{Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "value"},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 		},
@@ -56,7 +56,7 @@ func init_window() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "stream_window_reduce",
-		Desc: "applies OFFSET/LIMIT and a serial reducer to complete values emitted by a nested streaming producer without collecting an intermediate relation",
+
 		Fn: func(a ...Scmer) (result Scmer) {
 			offset := ToInt(a[0])
 			limit := ToInt(a[1])
@@ -92,14 +92,14 @@ func init_window() {
 			producerFn(emit)
 			return result
 		},
-		Type: &TypeDescriptor{
+		Type: &TypeDescriptor{Kind: "func", Description: "applies OFFSET/LIMIT and a serial reducer to complete values emitted by a nested streaming producer without collecting an intermediate relation",
 			HasSideEffects: true,
 			Params: []*TypeDescriptor{
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of complete producer values to skip"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "maximum values to reduce, or -1 for no limit"},
-				{Kind: "func", ParamName: "reduce", ParamDesc: "serial accumulator over complete values", Params: []*TypeDescriptor{{Kind: "any", ParamName: "acc"}, {Kind: "any", ParamName: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "initial accumulator"},
-				{Kind: "func", ParamName: "producer", ParamDesc: "nested streaming plan called with a one-value emit callback", Params: []*TypeDescriptor{{Kind: "func", ParamName: "emit"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "number", Label: "offset", Description: "number of complete producer values to skip"},
+				{Kind: "number", Label: "limit", Description: "maximum values to reduce, or -1 for no limit"},
+				{Kind: "func", Label: "reduce", Description: "serial accumulator over complete values", Params: []*TypeDescriptor{{Kind: "any", Label: "acc"}, {Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "neutral", Description: "initial accumulator"},
+				{Kind: "func", Label: "producer", Description: "nested streaming plan called with a one-value emit callback", Params: []*TypeDescriptor{{Kind: "func", Label: "emit", Description: "emits one complete value", Params: []*TypeDescriptor{{Kind: "any", Label: "value"}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return:  &TypeDescriptor{Kind: "any"},
 			JITEmit: nil,
@@ -108,7 +108,7 @@ func init_window() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "window_mut",
-		Desc: "Ring buffer shift-insert for window functions. (window_mut window emit_fn vals) writes vals (a list of stride values) into the current slot, increments counter. If skip>0, decrements skip. Otherwise calls (emit_fn oldest_v0 oldest_v1 ... newest_v0 newest_v1) with all slot values ordered oldest-to-newest. Returns updated window.",
+
 		Fn: func(a ...Scmer) Scmer {
 			win := asSlice(a[0], "window_mut")
 			emitFn := a[1]
@@ -166,8 +166,8 @@ func init_window() {
 
 			return NewSlice(result)
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", ParamName: "window", ParamDesc: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", ParamName: "emit_fn", ParamDesc: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", ParamName: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "list", ParamName: "vals", ParamDesc: "list of stride values to insert"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "Ring buffer shift-insert for window functions. (window_mut window emit_fn vals) writes vals (a list of stride values) into the current slot, increments counter. If skip>0, decrements skip. Otherwise calls (emit_fn oldest_v0 oldest_v1 ... newest_v0 newest_v1) with all slot values ordered oldest-to-newest. Returns updated window.",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "window", Description: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", Label: "emit_fn", Description: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", Label: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "list", Label: "vals", Description: "list of stride values to insert"}},
 			Return: &TypeDescriptor{Kind: "list"},
 
 			JITEmit: nil,
@@ -176,7 +176,7 @@ func init_window() {
 
 	Declare(&Globalenv, &Declaration{
 		Name: "window_flush",
-		Desc: "Flush remaining window buffer by shifting in nils. (window_flush window emit_fn count) shifts in count positions of nils, calling emit_fn for each displaced position. Returns nil.",
+
 		Fn: func(a ...Scmer) Scmer {
 			win := asSlice(a[0], "window_flush")
 			emitFn := a[1]
@@ -214,8 +214,8 @@ func init_window() {
 
 			return NewNil()
 		},
-		Type: &TypeDescriptor{
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", ParamName: "window", ParamDesc: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", ParamName: "emit_fn", ParamDesc: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", ParamName: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "number", ParamName: "count", ParamDesc: "number of nil positions to shift in"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "Flush remaining window buffer by shifting in nils. (window_flush window emit_fn count) shifts in count positions of nils, calling emit_fn for each displaced position. Returns nil.",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "window", Description: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", Label: "emit_fn", Description: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", Label: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "number", Label: "count", Description: "number of nil positions to shift in"}},
 			Return: &TypeDescriptor{Kind: "nil"},
 
 			JITEmit: nil,

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -356,7 +356,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	if p.Params.IsSlice() {
 		params = p.Params.Slice()
 	}
-	resolveParamName := func(node scm.Scmer) (string, bool) {
+	resolveLabel := func(node scm.Scmer) (string, bool) {
 		node = node.WithoutSourceInfo()
 		if node.IsSymbol() {
 			name := node.String()
@@ -377,7 +377,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	// resolveColVar maps a node to a column name.
 	// Handles both symbol params (linear scan, no alloc) and NthLocalVar(i).
 	resolveColVar := func(node scm.Scmer) (string, bool) {
-		if name, ok := resolveParamName(node); ok {
+		if name, ok := resolveLabel(node); ok {
 			if !isScanPseudoColName(name) {
 				return name, true
 			}
@@ -385,7 +385,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		return "", false
 	}
 	resolveBatchSubidx := func(node scm.Scmer) (int, bool) {
-		if name, ok := resolveParamName(node); ok {
+		if name, ok := resolveLabel(node); ok {
 			return parseBatchPseudoColName(name)
 		}
 		return 0, false
@@ -462,7 +462,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		return d != nil && d.Name == name
 	}
 	analyzeContext := &indexAnalyzeContext{
-		resolveParameter: resolveParamName,
+		resolveParameter: resolveLabel,
 		resolveColumn:    resolveColVar,
 		extractConstant:  extractConstant,
 		functionIs:       funcIs,

--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -216,44 +216,44 @@ func initMetricsDeclarations(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "cpu_usage",
-		Desc: "Returns current CPU usage as a percentage (0-100)",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewFloat(loadSnapshot().cpuUsage)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns current CPU usage as a percentage (0-100)",
 			Return: &scm.TypeDescriptor{Kind: "number"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "active_connections",
-		Desc: "Returns the current number of active HTTP connections",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(atomic.LoadInt64(&scm.ActiveHTTPConnections))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns the current number of active HTTP connections",
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "max_connections",
-		Desc: "Returns the maximum number of HTTP connections over the last 10 minutes",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(loadSnapshot().maxConn10min)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns the maximum number of HTTP connections over the last 10 minutes",
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "requests_per_second",
-		Desc: "Returns the average number of HTTP requests per second over the last 10 seconds",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewFloat(loadSnapshot().rps)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns the average number of HTTP requests per second over the last 10 seconds",
 			Return: &scm.TypeDescriptor{Kind: "number"},
 		},
 	})

--- a/storage/mysql_import.go
+++ b/storage/mysql_import.go
@@ -35,7 +35,7 @@ const mysqlImportTriggersTable = "triggers"
 func initMySQLImport(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "mysql_import",
-		Desc: "imports schema+data from a MySQL server into MemCP",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			host := "127.0.0.1"
 			if !a[0].IsNil() {
@@ -147,8 +147,8 @@ func initMySQLImport(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
-			Params: []*scm.TypeDescriptor{&scm.TypeDescriptor{Kind: "string|nil", ParamName: "host", ParamDesc: "MySQL host (nil => 127.0.0.1)"}, &scm.TypeDescriptor{Kind: "int|nil", ParamName: "port", ParamDesc: "MySQL port (nil => 3306)"}, &scm.TypeDescriptor{Kind: "string", ParamName: "username", ParamDesc: "MySQL username"}, &scm.TypeDescriptor{Kind: "string", ParamName: "password", ParamDesc: "MySQL password"}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "sourcedb", ParamDesc: "source database (omit/nil => all non-system dbs)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "targetdb", ParamDesc: "target database (omit/nil => sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "sourcetable", ParamDesc: "source table (omit/nil => all tables in sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "targettable", ParamDesc: "target table (omit/nil => sourcetable)", Optional: true}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "imports schema+data from a MySQL server into MemCP",
+			Params: []*scm.TypeDescriptor{&scm.TypeDescriptor{Kind: "string|nil", Label: "host", Description: "MySQL host (nil => 127.0.0.1)"}, &scm.TypeDescriptor{Kind: "int|nil", Label: "port", Description: "MySQL port (nil => 3306)"}, &scm.TypeDescriptor{Kind: "string", Label: "username", Description: "MySQL username"}, &scm.TypeDescriptor{Kind: "string", Label: "password", Description: "MySQL password"}, &scm.TypeDescriptor{Kind: "string|nil", Label: "sourcedb", Description: "source database (omit/nil => all non-system dbs)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "targetdb", Description: "target database (omit/nil => sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "sourcetable", Description: "source table (omit/nil => all tables in sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "targettable", Description: "target table (omit/nil => sourcetable)", Optional: true}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})

--- a/storage/psql_import.go
+++ b/storage/psql_import.go
@@ -32,7 +32,7 @@ import "github.com/launix-de/memcp/scm"
 func initPSQLImport(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "psql_import",
-		Desc: "imports schema+data from a PostgreSQL server into MemCP",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			host := "127.0.0.1"
 			if !a[0].IsNil() {
@@ -194,8 +194,8 @@ func initPSQLImport(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
-			Params: []*scm.TypeDescriptor{&scm.TypeDescriptor{Kind: "string|nil", ParamName: "host", ParamDesc: "PostgreSQL host (nil => 127.0.0.1)"}, &scm.TypeDescriptor{Kind: "int|nil", ParamName: "port", ParamDesc: "PostgreSQL port (nil => 5432)"}, &scm.TypeDescriptor{Kind: "string", ParamName: "username", ParamDesc: "PostgreSQL username"}, &scm.TypeDescriptor{Kind: "string", ParamName: "password", ParamDesc: "PostgreSQL password"}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "sourcedb", ParamDesc: "source database (omit/nil => all non-system dbs)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "sourceschema", ParamDesc: "source schema (omit/nil => all non-system schemas in sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "targetdb", ParamDesc: "target database (omit/nil => sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "sourcetable", ParamDesc: "source table (omit/nil => all tables in sourceschema)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", ParamName: "targettable", ParamDesc: "target table (omit/nil => sourcetable)", Optional: true}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "imports schema+data from a PostgreSQL server into MemCP",
+			Params: []*scm.TypeDescriptor{&scm.TypeDescriptor{Kind: "string|nil", Label: "host", Description: "PostgreSQL host (nil => 127.0.0.1)"}, &scm.TypeDescriptor{Kind: "int|nil", Label: "port", Description: "PostgreSQL port (nil => 5432)"}, &scm.TypeDescriptor{Kind: "string", Label: "username", Description: "PostgreSQL username"}, &scm.TypeDescriptor{Kind: "string", Label: "password", Description: "PostgreSQL password"}, &scm.TypeDescriptor{Kind: "string|nil", Label: "sourcedb", Description: "source database (omit/nil => all non-system dbs)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "sourceschema", Description: "source schema (omit/nil => all non-system schemas in sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "targetdb", Description: "target database (omit/nil => sourcedb)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "sourcetable", Description: "source table (omit/nil => all tables in sourceschema)", Optional: true}, &scm.TypeDescriptor{Kind: "string|nil", Label: "targettable", Description: "target table (omit/nil => sourcetable)", Optional: true}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -64,14 +64,14 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	}
 
 	// Extract outer param symbol names
-	outerParamNames := extractParamNames(mapParams)
-	stride := len(outerParamNames)
+	outerLabels := extractLabels(mapParams)
+	stride := len(outerLabels)
 	if stride == 0 {
 		return scm.NewNil()
 	}
 
 	// Skip DML scans: $update and other $ params are functions, not data columns
-	for _, name := range outerParamNames {
+	for _, name := range outerLabels {
 		if len(name) > 0 && name[0] == '$' {
 			return scm.NewNil()
 		}
@@ -101,8 +101,8 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	// The inner scan must actually reference at least one outer param
 	// (otherwise it's a cross-join where batching adds overhead for no gain
 	// and can break GROUP BY keytable logic).
-	outerParamSet := make(map[string]bool, len(outerParamNames))
-	for _, name := range outerParamNames {
+	outerParamSet := make(map[string]bool, len(outerLabels))
+	for _, name := range outerLabels {
 		outerParamSet[name] = true
 	}
 	hasOuterRef := false
@@ -121,7 +121,7 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	replaceMap := make(map[string]string, stride)
 	batchPseudocols := make([]scm.Scmer, stride)
 	batchParams := make([]scm.Scmer, stride)
-	for i, name := range outerParamNames {
+	for i, name := range outerLabels {
 		pseudo := fmt.Sprintf("#%d", i)
 		replaceMap[name] = pseudo
 		batchPseudocols[i] = scm.NewString(pseudo)
@@ -146,7 +146,7 @@ func tryScanBatchRewriteMapfn(v []scm.Scmer, mapcolsIdx, mapfnIdx int, hasReduce
 	appendArgs := make([]scm.Scmer, stride+2)
 	appendArgs[0] = scm.NewSymbol("append_mut")
 	appendArgs[1] = scm.NewSymbol("__record")
-	for i, name := range outerParamNames {
+	for i, name := range outerLabels {
 		outerMapParams[i] = scm.NewSymbol(name)
 		appendArgs[i+2] = scm.NewSymbol(name)
 	}
@@ -258,8 +258,8 @@ func extractLambdaParts(expr scm.Scmer) (params []scm.Scmer, body scm.Scmer) {
 	return []scm.Scmer{}, sl[2]
 }
 
-// extractParamNames extracts string names from a lambda parameter list.
-func extractParamNames(params []scm.Scmer) []string {
+// extractLabels extracts string names from a lambda parameter list.
+func extractLabels(params []scm.Scmer) []string {
 	names := make([]string, 0, len(params))
 	for _, p := range params {
 		if p.IsSymbol() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -997,9 +997,9 @@ func Init(en scm.Env) {
 				{Kind: "recset", Label: "source_recset"},
 				{Kind: "list", Label: "source_key_columns"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "func", Params: []*scm.TypeDescriptor{
-				{Kind: "any", Label: "key", Variadic: true},
-			}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+			Return: &scm.TypeDescriptor{Kind: "func", Label: "lookup", Description: "tests whether the recset contains a row with the supplied composite key", Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "key", Description: "one value for each source key column, in the same order", Variadic: true},
+			}, Return: &scm.TypeDescriptor{Kind: "bool", Label: "present", Description: "whether the composite key occurs in the recset"}},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
@@ -3027,7 +3027,7 @@ func Init(en scm.Env) {
 				{Kind: "list", Label: "onCollisionCols", Description: "list of columns of the old dataset that have to be passed to onCollision. Can also request $update, $set:<computed-column>, or NEW.<insert-column>.", Optional: true},
 				{Kind: "func", Label: "onCollision", Description: "function called for each collision. Its positional parameters are the values requested by onCollisionCols, in the same order. If omitted, collisions raise an error.", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", Label: "column values", Description: "one value for each onCollisionCols entry", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}},
 				{Kind: "bool", Label: "mergeNull", Description: "if true, it will handle NULL values as equal according to SQL 2003's definition of DISTINCT (https://en.wikipedia.org/wiki/Null_(SQL)#When_two_nulls_are_equal:_grouping,_sorting,_and_some_set_operations)", Optional: true},
-				{Kind: "func", Label: "onInsertid", Description: "(optional) callback (id)->any; called once with the first auto_increment id assigned for this INSERT", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "number", Label: "id"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "onInsertid", Description: "called once with the first auto_increment id assigned for this INSERT", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "number", Label: "id", Description: "first assigned auto_increment id"}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "ignored callback result"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "number"},
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -589,6 +589,123 @@ func Init(en scm.Env) {
 	const scanFilterColumnsDesc = "physical columns passed to filter before map/reduce; $recset_contains supplies a row-bound RecSet membership closure"
 	const scanMapColumnsDesc = "physical columns passed to map after filtering; pseudo columns are $update (update/delete current row), $recset_contains (row-bound RecSet membership), $set:<column>, $increment:<column>, and $invalidate:<column> (computed-column maintenance), plus NEW.<column> in trigger plans"
 	const scanOrderMapColumnsDesc = scanMapColumnsDesc + "; $break is reserved for internal ORC convergence and must not implement SQL OFFSET/LIMIT, which belong in the native offset and limit arguments"
+	columnList := func(label, description string) *scm.TypeDescriptor {
+		return &scm.TypeDescriptor{
+			Kind:        "list",
+			Label:       label,
+			Description: description,
+			Element: &scm.TypeDescriptor{
+				Kind:        "string",
+				Label:       "column",
+				Description: "column name passed to the corresponding callback parameter",
+			},
+		}
+	}
+	rowCallback := func(label, description, returnKind, returnDescription string) *scm.TypeDescriptor {
+		return &scm.TypeDescriptor{
+			Kind:        "func",
+			Label:       label,
+			Description: description,
+			Params: []*scm.TypeDescriptor{{
+				Kind:        "any",
+				Label:       "columns",
+				Description: "one value for each entry in the matching column list, in the same order",
+				Variadic:    true,
+			}},
+			Return: &scm.TypeDescriptor{Kind: returnKind, Label: "result", Description: returnDescription},
+		}
+	}
+	reducer := func(label, description string) *scm.TypeDescriptor {
+		return &scm.TypeDescriptor{
+			Kind:        "func",
+			Label:       label,
+			Description: description,
+			Optional:    true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "accumulator", Description: "current aggregate, initially the neutral value"},
+				{Kind: "any", Label: "value", Description: "next mapped or partially reduced value"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "any", Label: "accumulator", Description: "aggregate passed to the next reducer call or returned by the scan"},
+		}
+	}
+	sortColumnList := func(label, description string) *scm.TypeDescriptor {
+		return &scm.TypeDescriptor{
+			Kind:        "list",
+			Label:       label,
+			Description: description,
+			Element: &scm.TypeDescriptor{
+				Kind:        "string|func",
+				Label:       "sort column",
+				Description: "a column name, or a function of row-column values that returns the sortable value",
+				Params: []*scm.TypeDescriptor{{
+					Kind: "any", Label: "columns", Description: "column values used to compute the sort key", Variadic: true,
+				}},
+				Return: &scm.TypeDescriptor{Kind: "any", Label: "sort key", Description: "value compared at this sort position"},
+			},
+		}
+	}
+	sortDirectionList := func(label, description string) *scm.TypeDescriptor {
+		return &scm.TypeDescriptor{
+			Kind:        "list",
+			Label:       label,
+			Description: description,
+			Element: &scm.TypeDescriptor{
+				Kind:        "func",
+				Label:       "direction",
+				Description: "strict ordering relation such as <, >, or a collate relation",
+				Params: []*scm.TypeDescriptor{
+					{Kind: "any", Label: "left", Description: "left sort value"},
+					{Kind: "any", Label: "right", Description: "right sort value"},
+				},
+				Return: &scm.TypeDescriptor{Kind: "bool", Label: "ordered", Description: "true when left belongs before right"},
+			},
+		}
+	}
+	tableOptions := &scm.TypeDescriptor{
+		Kind:        "list|assoc",
+		Label:       "options",
+		Description: "table options as an alternating key/value list",
+		Keys: map[string]*scm.TypeDescriptor{
+			"auto_increment": {Kind: "int", Label: "auto_increment", Description: "first automatically assigned value; must be non-negative"},
+			"charset":        {Kind: "string", Label: "charset", Description: "default character set name"},
+			"collation":      {Kind: "string", Label: "collation", Description: "default collation name"},
+			"comment":        {Kind: "string", Label: "comment", Description: "user-visible table comment"},
+			"engine":         {Kind: "string", Label: "engine", Description: "storage engine: safe, logged, sloppy, memory, or cache"},
+			"oninit": {
+				Kind:        "func",
+				Label:       "oninit",
+				Description: "closed zero-argument initializer run synchronously once per data generation; concurrent if-not-exists callers wait for completion",
+				Params:      []*scm.TypeDescriptor{},
+				Return:      &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "ignored initializer result"},
+			},
+		},
+	}
+	columnOptions := &scm.TypeDescriptor{
+		Kind:        "list|assoc",
+		Label:       "options",
+		Description: "column properties and computed-column configuration as an alternating key/value list",
+		Keys: map[string]*scm.TypeDescriptor{
+			"auto_increment":     {Kind: "bool", Label: "auto_increment", Description: "assign increasing values automatically"},
+			"collate":            {Kind: "string", Label: "collate", Description: "collation used for this column"},
+			"comment":            {Kind: "string", Label: "comment", Description: "user-visible column comment"},
+			"default":            {Kind: "any", Label: "default", Description: "literal value used when an insert omits the column"},
+			"default_expression": {Kind: "string", Label: "default_expression", Description: "expression evaluated when an insert omits the column"},
+			"filtercols":         columnList("filtercols", "columns supplied to filter before computing a value"),
+			"filter":             rowCallback("filter", "predicate limiting which rows are computed", "bool", "true when the row should be computed"),
+			"mapcols":            columnList("mapcols", "columns supplied to mapfn for ordered-reduce computation"),
+			"mapfn":              rowCallback("mapfn", "maps one source row into a value for reducefn", "any", "value passed to reducefn"),
+			"null":               {Kind: "bool", Label: "null", Description: "whether the column accepts nil values"},
+			"partitioncount":     {Kind: "int", Label: "partitioncount", Description: "number of leading sort columns that define independent reducer partitions"},
+			"primary":            {Kind: "bool", Label: "primary", Description: "whether this column belongs to the primary key"},
+			"reducefn":           reducer("reducefn", "combines ordered mapped values into the computed-column aggregate"),
+			"reduceinit":         {Kind: "any", Label: "reduceinit", Description: "initial accumulator supplied to reducefn"},
+			"sortcols":           sortColumnList("sortcols", "columns or expressions defining ordered-reduce input order"),
+			"sortdirs":           sortDirectionList("sortdirs", "one ordering relation for every sortcols entry"),
+			"temp":               {Kind: "bool", Label: "temp", Description: "whether this is a query-local temporary computed column"},
+			"unique":             {Kind: "bool", Label: "unique", Description: "whether values must be unique"},
+			"update":             {Kind: "any", Label: "update", Description: "expression evaluated when a row is updated"},
+		},
+	}
 	scm.DeclareTitle("Storage")
 
 	// Register TagTable serializer for the printer.
@@ -601,7 +718,7 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "table",
-		Desc: "resolves a schema+table name pair into a table handle",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
@@ -613,11 +730,10 @@ func Init(en scm.Env) {
 			}
 			return NewTableScmer(t)
 		},
-		Type: &scm.TypeDescriptor{
-			Kind: "func",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "resolves a schema+table name pair into a table handle",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema"},
-				{Kind: "string", ParamName: "table"},
+				{Kind: "string", Label: "schema"},
+				{Kind: "string", Label: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "table"},
 			Optimize: func(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) (scm.Scmer, *scm.TypeDescriptor) {
@@ -634,34 +750,34 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_estimate",
-		Desc: "estimate output row count for a table scan",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			return scm.NewInt(int64(t.CountEstimate()))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "estimate output row count for a table scan",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
+				{Kind: "table", Label: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "table_planner_statistics",
-		Desc: "return the immutable O(1) planner-statistics snapshot for a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return TableFromScmer(a[0]).PlannerStatistics()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return the immutable O(1) planner-statistics snapshot for a table",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
+				{Kind: "table", Label: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_selectivity_estimate",
-		Desc: "bounded estimate of visible rows matching a table filter; stops at max_rows and does not log scan telemetry",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			t := TableFromScmer(a[1])
@@ -751,34 +867,34 @@ func Init(en scm.Env) {
 				scm.NewSlice([]scm.Scmer{scm.NewSymbol("coverage"), scm.NewSymbol("lower_bound")}),
 			})
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "bounded estimate of visible rows matching a table filter; stops at max_rows and does not log scan telemetry",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table", ParamName: "table"},
-				{Kind: "list", ParamName: "condition_cols"},
-				{Kind: "any", ParamName: "condition"},
-				{Kind: "int", ParamName: "max_rows"},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table", Label: "table"},
+				columnList("condition_cols", "columns passed to the selectivity predicate"),
+				rowCallback("condition", "predicate sampled to estimate matching rows", "bool", "true when the sampled row matches"),
+				{Kind: "int", Label: "max_rows"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "list"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "table_empty?",
-		Desc: "returns true if a table currently has no rows",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			return scm.NewBool(t.CountExact() == 0)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns true if a table currently has no rows",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
+				{Kind: "table", Label: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_recset",
-		Desc: "builds a query-local record-set handle from one table scan, or -- when given an existing recset instead of a table -- narrows that recset to the members which also satisfy filter, re-evaluating filter only over its existing membership. The latter is the cheap way to AND a further (possibly subscan-heavy) condition onto an already-narrowed recset without re-touching rows outside it (e.g. evaluating an expensive correlated check only over the rows a cheap selective filter already narrowed a table down to). The returned value is not persisted and can be scanned like a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[2], "filterColumns"))
@@ -788,33 +904,33 @@ func Init(en scm.Env) {
 			t := TableFromScmer(a[1])
 			return NewRecSetScmer(t.scanRecSet(currentTx, filtercols, a[3]))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "builds a query-local record-set handle from one table scan, or -- when given an existing recset instead of a table -- narrows that recset to the members which also satisfy filter, re-evaluating filter only over its existing membership. The latter is the cheap way to AND a further (possibly subscan-heavy) condition onto an already-narrowed recset without re-touching rows outside it (e.g. evaluating an expensive correlated check only over the rows a cheap selective filter already narrowed a table down to). The returned value is not persisted and can be scanned like a table",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "any", ParamName: "table", ParamDesc: "a table, or an existing recset to narrow further"},
-				{Kind: "list", ParamName: "filterColumns"},
-				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a row enters the recset", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "any", Label: "table", Description: "a table, or an existing recset to narrow further"},
+				columnList("filterColumns", scanFilterColumnsDesc),
+				rowCallback("filter", "lambda function that decides whether a row enters the recset", "bool", "true when the row belongs in the recset"),
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_count",
-		Desc: "returns the number of currently stored recids in a query-local recset",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(RecSetFromScmer(a[0]).count)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the number of currently stored recids in a query-local recset",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "recset", ParamName: "recset"},
+				{Kind: "recset", Label: "recset"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "int"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_project_join",
-		Desc: "projects a source recset through key columns into a query-local target-table recset",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			source := RecSetFromScmer(a[1])
@@ -823,21 +939,21 @@ func Init(en scm.Env) {
 			targetKeyCols := scmerSliceToStrings(mustScmerSlice(a[4], "targetKeyColumns"))
 			return NewRecSetScmer(source.projectJoin(currentTx, sourceKeyCols, target, targetKeyCols))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "projects a source recset through key columns into a query-local target-table recset",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "recset", ParamName: "source_recset"},
-				{Kind: "list", ParamName: "source_key_columns"},
-				{Kind: "table", ParamName: "target_table"},
-				{Kind: "list", ParamName: "target_key_columns"},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "recset", Label: "source_recset"},
+				{Kind: "list", Label: "source_key_columns"},
+				{Kind: "table", Label: "target_table"},
+				{Kind: "list", Label: "target_key_columns"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_key_index",
-		Desc: "builds an immutable lookup function for key columns of the rows contained in a query-local recset",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			source := RecSetFromScmer(a[1])
@@ -853,21 +969,21 @@ func Init(en scm.Env) {
 				return scm.NewBool(keys.contains(values))
 			})
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "builds an immutable lookup function for key columns of the rows contained in a query-local recset",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context used while reading source keys"},
-				{Kind: "recset", ParamName: "source_recset"},
-				{Kind: "list", ParamName: "source_key_columns"},
+				{Kind: "any", Label: "tx", Description: "transaction context used while reading source keys"},
+				{Kind: "recset", Label: "source_recset"},
+				{Kind: "list", Label: "source_key_columns"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "func", Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "key", Variadic: true},
+				{Kind: "any", Label: "key", Variadic: true},
 			}, Return: &scm.TypeDescriptor{Kind: "bool"}},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_union",
-		Desc: "combines query-local recsets from the same table and removes duplicate record IDs",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			values := mustScmerSlice(a[0], "recsets")
 			recsets := make([]*recSet, 0, len(values))
@@ -876,17 +992,17 @@ func Init(en scm.Env) {
 			}
 			return NewRecSetScmer(recSetUnion(recsets))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "combines query-local recsets from the same table and removes duplicate record IDs",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "list", ParamName: "recsets"},
+				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_intersect",
-		Desc: "intersects query-local recsets from the same table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			values := mustScmerSlice(a[0], "recsets")
 			recsets := make([]*recSet, 0, len(values))
@@ -895,17 +1011,17 @@ func Init(en scm.Env) {
 			}
 			return NewRecSetScmer(recSetIntersect(recsets))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "intersects query-local recsets from the same table",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "list", ParamName: "recsets"},
+				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_difference",
-		Desc: "returns the records from the first query-local recset which occur in none of the following same-table recsets",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			values := mustScmerSlice(a[0], "recsets")
 			recsets := make([]*recSet, 0, len(values))
@@ -914,31 +1030,31 @@ func Init(en scm.Env) {
 			}
 			return NewRecSetScmer(recSetDifference(recsets))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the records from the first query-local recset which occur in none of the following same-table recsets",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "list", ParamName: "recsets"},
+				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "recset_not",
-		Desc: "returns the complement of a query-local recset relative to the currently visible rows of its base table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return NewRecSetScmer(recSetNot(RecSetFromScmer(a[0])))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the complement of a query-local recset relative to the currently visible rows of its base table",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "recset", ParamName: "recset"},
+				{Kind: "recset", Label: "recset"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_exists",
-		Desc: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[2], "filterColumns"))
@@ -964,12 +1080,12 @@ func Init(en scm.Env) {
 			t := TableFromScmer(tableArg)
 			return scm.NewBool(t.scanExists(currentTx, filtercols, a[3]))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns true if a table contains at least one visible row matching the given filter; uses scan boundary analysis without map/reduce setup",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list|recset", ParamName: "table"},
-				{Kind: "list", ParamName: "filterColumns"},
-				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a row exists", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|list|recset", Label: "table"},
+				columnList("filterColumns", scanFilterColumnsDesc),
+				rowCallback("filter", "lambda function that decides whether a row exists", "bool", "true when the row satisfies the existence test"),
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -977,7 +1093,7 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan",
-		Desc: "does an unordered parallel filter-map-reduce pass on a single table and returns the reduced result",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			layout := scanLayout(a)
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[layout.filterColsIdx], "filterColumns"))
@@ -1065,19 +1181,19 @@ func Init(en scm.Env) {
 			}
 			return t.scan(layout.tx, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "does an unordered parallel filter-map-reduce pass on a single table and returns the reduced result",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local recset, or a list for temporary data"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: scanFilterColumnsDesc},
-				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanMapColumnsDesc},
-				{Kind: "func", ParamName: "map", ParamDesc: "lambda function to extract data from the dataset. You can use any column of that table as lambda parameter. You can return a value you want to extract and pass to reduce, but you can also directly call insert, print or resultrow functions. If you declare a parameter named '$update', this variable will hold a function that you can use to delete or update a row. Call ($update) to delete the dataset, call ($update '(\"field1\" value1 \"field2\" value2)) to update certain columns.", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Params: []*scm.TypeDescriptor{{}, nil}, ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results. It takes two parameters (a b) where a is the accumulator and b the new value. The accumulator for the first reduce call is the neutral element. The return value will be the accumulator input for the next reduce call. There are two reduce phases: shard-local and shard-collect. In the shard-local phase, a starts with neutral and b is fed with the return values of each map call. In the shard-collect phase, a starts with neutral and b is fed with the result of each shard-local pass.", Optional: true},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
-				{Kind: "func", Params: []*scm.TypeDescriptor{{}, nil}, ParamName: "reduce2", ParamDesc: "(optional) second stage reduce function that will apply a result of reduce to the neutral element/accumulator", Optional: true},
-				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|list|recset", Label: "table", Description: "table handle, query-local recset, or a list for temporary data"},
+				columnList("filterColumns", scanFilterColumnsDesc),
+				rowCallback("filter", "lambda function that decides whether a dataset is passed to the map phase. Equality and range comparisons may be translated into indexed scans", "bool", "true when the row proceeds to map"),
+				columnList("mapColumns", scanMapColumnsDesc),
+				rowCallback("map", "lambda function that extracts or produces one value from the row; it may also use documented pseudo columns for mutations or result output", "any", "value passed to reduce, or returned directly when no reducer is supplied"),
+				reducer("reduce", "optional aggregation function used first within shards and then to combine shard results"),
+				{Kind: "any", Label: "neutral", Description: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
+				reducer("reduce2", "optional final reducer that combines the neutral value with the result produced by reduce"),
+				{Kind: "bool", Label: "isOuter", Description: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScan,
@@ -1085,7 +1201,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_batch",
-		Desc: "does an unordered parallel filter-map-reduce pass on a single table using batchdata-backed #N pseudo columns and returns the reduced result",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			layout := scanLayout(a)
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[layout.filterColsIdx], "filterColumns"))
@@ -1183,20 +1299,20 @@ func Init(en scm.Env) {
 			}
 			return t.scanWithBatchFrom(layout.tx, source, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter, stride, batchdata)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "does an unordered parallel filter-map-reduce pass on a single table using batchdata-backed #N pseudo columns and returns the reduced result",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local recset, or a list for temporary data"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of columns that are fed into filter; #0, #1, ... address batchdata slots"},
-				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of columns that are fed into map; #0, #1, ... address batchdata slots"},
-				{Kind: "func", ParamName: "map", ParamDesc: "lambda function to extract data from the dataset", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "int", ParamName: "stride", ParamDesc: "number of batchdata entries per batch row"},
-				{Kind: "list", ParamName: "batchdata", ParamDesc: "flat batch buffer accessed via #N pseudo columns"},
-				{Kind: "func", Params: []*scm.TypeDescriptor{{}, nil}, ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results", Optional: true},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
-				{Kind: "func", Params: []*scm.TypeDescriptor{{}, nil}, ParamName: "reduce2", ParamDesc: "(optional) second stage reduce function that will apply a result of reduce to the neutral element/accumulator", Optional: true},
-				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|list|recset", Label: "table", Description: "table handle, query-local recset, or a list for temporary data"},
+				columnList("filterColumns", "columns passed to filter; #0, #1, ... address batchdata slots"),
+				rowCallback("filter", "lambda function that decides whether a dataset is passed to the map phase", "bool", "true when this table row and batch row proceed to map"),
+				columnList("mapColumns", "columns passed to map; #0, #1, ... address batchdata slots"),
+				rowCallback("map", "lambda function that extracts data from the table row and batch row", "any", "value passed to reduce or returned directly"),
+				{Kind: "int", Label: "stride", Description: "number of batchdata entries per batch row"},
+				{Kind: "list", Label: "batchdata", Description: "flat batch buffer accessed via #N pseudo columns", Element: &scm.TypeDescriptor{Kind: "any", Label: "slot", Description: "one batch value; every stride consecutive slots form a batch row"}},
+				reducer("reduce", "optional lambda function that aggregates mapped values"),
+				{Kind: "any", Label: "neutral", Description: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
+				reducer("reduce2", "optional final reducer that combines the neutral value with the result produced by reduce"),
+				{Kind: "bool", Label: "isOuter", Description: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanBatch,
@@ -1204,7 +1320,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_order_batch_accept",
-		Desc: "incrementally scans a table or existing RecSet in scan_order order and applies a RecSet batch filter before OFFSET/LIMIT and map/reduce. The first candidate RecSet contains offset+limit rows; if too few rows are accepted, subsequent disjoint batches contain twice as many candidates until the accepted limit is satisfied or the input is exhausted. batchFilter is called as (batchFilter input_recset) and must return an exact subset RecSet of the same base table and transaction. A simple batchFilter may call (scan_recset tx input_recset filterColumns realFilter); complex filters may project input_recset to another table, apply search/ACL scans and project the result back to the input table. The returned RecSet is used only as a membership mask against the already ordered candidate vector, so output order is preserved without scanning the unordered RecSet again. For non-unique ORDER BY values, include an explicit unique tie-breaker. sortcols/sortdirs may both be empty; that path greedily collects candidates without sorting. limitPartitionCols is present for scan_order signature compatibility and currently must be 0",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			tableArg := a[1]
@@ -1242,23 +1358,23 @@ func Init(en scm.Env) {
 			return scanOrderBatchAccept(currentTx, source, batchFilter, sortcolsVals, sortdirs,
 				limitPartitionCols, offset, limit, mapcols, callback, aggregate, neutral, isOuter, notFoundValue)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "incrementally scans a table or existing RecSet in scan_order order and applies a RecSet batch filter before OFFSET/LIMIT and map/reduce. The first candidate RecSet contains offset+limit rows; if too few rows are accepted, subsequent disjoint batches contain twice as many candidates until the accepted limit is satisfied or the input is exhausted. batchFilter is called as (batchFilter input_recset) and must return an exact subset RecSet of the same base table and transaction. A simple batchFilter may call (scan_recset tx input_recset filterColumns realFilter); complex filters may project input_recset to another table, apply search/ACL scans and project the result back to the input table. The returned RecSet is used only as a membership mask against the already ordered candidate vector, so output order is preserved without scanning the unordered RecSet again. For non-unique ORDER BY values, include an explicit unique tie-breaker. sortcols/sortdirs may both be empty; that path greedily collects candidates without sorting. limitPartitionCols is present for scan_order signature compatibility and currently must be 0",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context used consistently by the candidate scan and every batch filter operation; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|recset", ParamName: "table_or_recset", ParamDesc: "base table or complete existing query-local RecSet from which ordered candidate batches are drawn"},
-				{Kind: "func", ParamName: "batchFilter", ParamDesc: "function (lambda (input_recset) accepted_recset). It may naively narrow input_recset with scan_recset, or run arbitrary RecSet projections/search/ACL operations and project back. It must return a same-table, same-transaction subset of input_recset", Params: []*scm.TypeDescriptor{{Kind: "recset", ParamName: "input_recset"}}, Return: &scm.TypeDescriptor{Kind: "recset"}},
-				{Kind: "list", ParamName: "sortcols", ParamDesc: "same as scan_order: columns or computed sort functions. Include a unique tie-breaker for a total repeatable order; use an empty list for greedy unsorted collection"},
-				{Kind: "list", ParamName: "sortdirs", ParamDesc: "same as scan_order: one relation per sort column (<, > or collate relation); must also be empty when sortcols is empty"},
-				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "reserved for scan_order signature compatibility; currently must be 0"},
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of batch-filter-accepted rows to skip; it is not the number of driver candidates already examined"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "finite maximum number of accepted rows passed to map; the initial candidate batch size is offset+limit and doubles for every subsequent batch"},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanOrderMapColumnsDesc},
-				{Kind: "func", ParamName: "map", ParamDesc: "same map callback contract as scan_order; accepted record IDs are passed to its shard mapper in batches", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "reduce", ParamDesc: "optional serial reducer over mapped accepted rows, with the same accumulator contract as scan_order", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "acc"}, {Kind: "any", ParamName: "val"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "optional neutral element for reduce; defaults to nil", Optional: true},
-				{Kind: "bool", ParamName: "isOuter", ParamDesc: "optional scan_order-compatible outer behavior: map one NULL row when no accepted row reaches map", Optional: true},
-				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "optional result when no accepted row reaches map and isOuter is false; defaults to neutral", Optional: true},
+				{Kind: "any", Label: "tx", Description: "transaction context used consistently by the candidate scan and every batch filter operation; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|recset", Label: "table_or_recset", Description: "base table or complete existing query-local RecSet from which ordered candidate batches are drawn"},
+				{Kind: "func", Label: "batchFilter", Description: "function (lambda (input_recset) accepted_recset). It may naively narrow input_recset with scan_recset, or run arbitrary RecSet projections/search/ACL operations and project back. It must return a same-table, same-transaction subset of input_recset", Params: []*scm.TypeDescriptor{{Kind: "recset", Label: "input_recset"}}, Return: &scm.TypeDescriptor{Kind: "recset"}},
+				sortColumnList("sortcols", "same as scan_order: columns or computed sort functions. Include a unique tie-breaker for a total repeatable order; use an empty list for greedy unsorted collection"),
+				sortDirectionList("sortdirs", "same as scan_order: one relation per sort column; must also be empty when sortcols is empty"),
+				{Kind: "number", Label: "limitPartitionCols", Description: "reserved for scan_order signature compatibility; currently must be 0"},
+				{Kind: "number", Label: "offset", Description: "number of batch-filter-accepted rows to skip; it is not the number of driver candidates already examined"},
+				{Kind: "number", Label: "limit", Description: "finite maximum number of accepted rows passed to map; the initial candidate batch size is offset+limit and doubles for every subsequent batch"},
+				columnList("mapColumns", scanOrderMapColumnsDesc),
+				rowCallback("map", "same map callback contract as scan_order; accepted record IDs are passed to its shard mapper in batches", "any", "value passed to reduce or returned directly"),
+				reducer("reduce", "optional serial reducer over mapped accepted rows, with the same accumulator contract as scan_order"),
+				{Kind: "any", Label: "neutral", Description: "optional neutral element for reduce; defaults to nil", Optional: true},
+				{Kind: "bool", Label: "isOuter", Description: "optional scan_order-compatible outer behavior: map one NULL row when no accepted row reaches map", Optional: true},
+				{Kind: "any", Label: "notFoundValue", Description: "optional result when no accepted row reaches map and isOuter is false; defaults to neutral", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrderBatchAccept,
@@ -1266,7 +1382,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_order",
-		Desc: "does an ordered parallel filter and serial map-reduce pass on a single table and returns the reduced result",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			layout := scanLayout(a)
 			filtercols := scmerSliceToStrings(mustScmerSlice(a[layout.filterColsIdx], "filterColumns"))
@@ -1420,25 +1536,33 @@ func Init(en scm.Env) {
 
 			return t.scan_order(layout.tx, filtercols, a[layout.filterFnIdx], sortcolsVals, sortdirs, limitPartitionCols, scm.ToInt(a[layout.offsetIdx]), scm.ToInt(a[layout.limitIdx]), mapcols, a[layout.limitIdx+2], aggregate, neutral, isOuter, notFoundValue, postOrderCols, postOrderFilter)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "does an ordered parallel filter and serial map-reduce pass on a single table and returns the reduced result",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
-				{Kind: "table|list|recset", ParamName: "table", ParamDesc: "table handle, query-local RecSet, or a list for temporary data"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: scanFilterColumnsDesc},
-				{Kind: "func", ParamName: "filter", ParamDesc: "lambda function that decides whether a dataset is passed to the map phase. You can use any column of that table as lambda parameter. You should structure your lambda with an (and) at the root element. Every equal? < > <= >= will possibly translated to an indexed scan", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
-				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of columns to sort. Each column is either a string to point to an existing column or a func(cols...)->any to compute a sortable value"},
-				{Kind: "list", ParamName: "sortdirs", ParamDesc: "list of column directions to sort. Must be same length as sortcols. < means ascending, > means descending, (collate ...) will add collations"},
-				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "number of leading sort columns that form the partition key for per-partition offset/limit. 0 (default) means global offset/limit."},
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of globally ordered, filter-accepted items to skip before map; apply SQL OFFSET here rather than in map"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "maximum globally ordered, filter-accepted items passed to map; -1 means unlimited; apply SQL LIMIT here so shard-local Top-K and the global merge can brake early"},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: scanOrderMapColumnsDesc},
-				{Kind: "func", ParamName: "map", ParamDesc: "lambda function to extract data from the dataset. You can use any column of that table as lambda parameter. You can return a value you want to extract and pass to reduce, but you can also directly call insert, print or resultrow functions. If you declare a parameter named '$update', this variable will hold a function that you can use to delete or update a row. Call ($update) to delete the dataset, call ($update '(\"field1\" value1 \"field2\" value2)) to update certain columns.", Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) lambda function to aggregate the map results. It takes two parameters (a b) where a is the accumulator and b the new value. The accumulator for the first reduce call is the neutral element. The return value will be the accumulator input for the next reduce call. There are two reduce phases: shard-local and shard-collect. In the shard-local phase, a starts with neutral and b is fed with the return values of each map call. In the shard-collect phase, a starts with neutral and b is fed with the result of each shard-local pass.", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "acc"}, {Kind: "any", ParamName: "val"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
-				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
-				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
-				{Kind: "list", ParamName: "postOrderFilterColumns", ParamDesc: "(optional) columns for a predicate evaluated in global order before OFFSET/LIMIT are counted; use for expensive acceptance checks that cannot participate in index boundaries", Optional: true},
-				{Kind: "func", ParamName: "postOrderFilter", ParamDesc: "(optional) late acceptance predicate. Rejected rows do not count toward OFFSET/LIMIT and never reach map. SQL plans use this instead of callback-driven $break control flow", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "bool"}},
+				{Kind: "any", Label: "tx", Description: "transaction context to use for visibility and mutations; usually ((context \"session\") \"__memcp_tx\")"},
+				{Kind: "table|list|recset", Label: "table", Description: "table handle, query-local RecSet, or a list for temporary data"},
+				columnList("filterColumns", scanFilterColumnsDesc),
+				rowCallback("filter", "lambda function that decides whether a dataset is passed to the map phase. Equality and range comparisons may be translated into indexed scans", "bool", "true when the row proceeds to ordering and map"),
+				sortColumnList("sortcols", "columns used for ordering; each entry corresponds to one relation in sortdirs"),
+				sortDirectionList("sortdirs", "one ordering relation per entry in sortcols; < is ascending and > is descending"),
+				{Kind: "number", Label: "limitPartitionCols", Description: "number of leading sort columns that form the partition key for per-partition offset/limit. 0 (default) means global offset/limit."},
+				{Kind: "number", Label: "offset", Description: "number of globally ordered, filter-accepted items to skip before map; apply SQL OFFSET here rather than in map"},
+				{Kind: "number", Label: "limit", Description: "maximum globally ordered, filter-accepted items passed to map; -1 means unlimited; apply SQL LIMIT here so shard-local Top-K and the global merge can brake early"},
+				columnList("mapColumns", scanOrderMapColumnsDesc),
+				rowCallback("map", "lambda function that extracts or produces one value from each accepted row", "any", "value passed to reduce or returned directly"),
+				reducer("reduce", "optional serial aggregation function over mapped values"),
+				{Kind: "any", Label: "neutral", Description: "(optional) neutral element for the reduce phase, otherwise nil is assumed", Optional: true},
+				{Kind: "bool", Label: "isOuter", Description: "(optional) if true, in case of no hits, call map once anyway with NULL values", Optional: true},
+				{Kind: "any", Label: "notFoundValue", Description: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
+				func() *scm.TypeDescriptor {
+					value := columnList("postOrderFilterColumns", "optional columns for a predicate evaluated in global order before OFFSET/LIMIT are counted; use for expensive acceptance checks that cannot participate in index boundaries")
+					value.Optional = true
+					return value
+				}(),
+				func() *scm.TypeDescriptor {
+					value := rowCallback("postOrderFilter", "optional late acceptance predicate. Rejected rows do not count toward OFFSET/LIMIT and never reach map", "bool", "true when the ordered row counts toward OFFSET/LIMIT and reaches map")
+					value.Optional = true
+					return value
+				}(),
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrder,
@@ -1446,7 +1570,7 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_order_multi",
-		Desc: "does an ordered parallel filter and serial map-reduce pass across multiple tables simultaneously, merging results into a single sorted stream",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// Parameters:
 			// 0:  tx
@@ -1524,25 +1648,25 @@ func Init(en scm.Env) {
 
 			return scanOrderMulti(currentTx, specs, sortdirs, int(limitPartitionCols), int(offset), int(limit), aggregate, neutral, isOuter, notFoundValue)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "does an ordered parallel filter and serial map-reduce pass across multiple tables simultaneously, merging results into a single sorted stream",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "tx", ParamDesc: "transaction context"},
-				{Kind: "list", ParamName: "tables", ParamDesc: "list of table handles"},
-				{Kind: "list", ParamName: "filterColumns", ParamDesc: "list of filter column lists, one per table"},
-				{Kind: "list", ParamName: "filterFns", ParamDesc: "list of filter lambdas, one per table"},
-				{Kind: "list", ParamName: "sortcols", ParamDesc: "list of sort column lists, one per table"},
-				{Kind: "list", ParamName: "sortdirs", ParamDesc: "list of sort direction comparators (shared)"},
-				{Kind: "list", ParamName: "perTableOffset", ParamDesc: "per-table offset (list of int; -1 disables)"},
-				{Kind: "list", ParamName: "perTableLimit", ParamDesc: "per-table limit (list of int; -1 disables)"},
-				{Kind: "number", ParamName: "limitPartitionCols", ParamDesc: "number of leading sort columns forming partition key"},
-				{Kind: "number", ParamName: "offset", ParamDesc: "number of items to skip (global)"},
-				{Kind: "number", ParamName: "limit", ParamDesc: "max number of items to read (global; -1 = unlimited)"},
-				{Kind: "list", ParamName: "mapColumns", ParamDesc: "list of map column lists, one per table"},
-				{Kind: "list", ParamName: "mapFns", ParamDesc: "list of map lambdas, one per table"},
-				{Kind: "func", ParamName: "reduce", ParamDesc: "(optional) aggregation function", Optional: true},
-				{Kind: "any", ParamName: "neutral", ParamDesc: "(optional) neutral element for reduce", Optional: true},
-				{Kind: "bool", ParamName: "isOuter", ParamDesc: "(optional) if true, emit null row when no hits", Optional: true},
-				{Kind: "any", ParamName: "notFoundValue", ParamDesc: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
+				{Kind: "any", Label: "tx", Description: "transaction context"},
+				{Kind: "list", Label: "tables", Description: "scan sources; all per-table lists must have this length", Element: &scm.TypeDescriptor{Kind: "table|recset", Label: "source", Description: "base table or query-local record set for one input stream"}},
+				{Kind: "list", Label: "filterColumns", Description: "filter column lists, one per table", Element: &scm.TypeDescriptor{Kind: "list", Label: "table filter columns", Description: "columns supplied to the matching filterFns entry", Element: &scm.TypeDescriptor{Kind: "string", Label: "column", Description: "column name in the corresponding table"}}},
+				{Kind: "list", Label: "filterFns", Description: "filter lambdas, one per table", Element: rowCallback("table filter", "predicate for the corresponding table and filterColumns entry", "bool", "true when the row enters that table's ordered stream")},
+				{Kind: "list", Label: "sortcols", Description: "sort column lists, one per table; every inner list must match sortdirs in length and result domains", Element: sortColumnList("table sort columns", "sort expressions for the corresponding table")},
+				sortDirectionList("sortdirs", "shared ordering relations used for every table stream and for the outer merge"),
+				{Kind: "list|nil", Label: "perTableOffset", Description: "optional per-table offsets; nil disables all per-table offsets", Element: &scm.TypeDescriptor{Kind: "int", Label: "offset", Description: "rows skipped in the corresponding table before the outer merge; -1 disables the offset"}},
+				{Kind: "list|nil", Label: "perTableLimit", Description: "optional per-table limits; nil disables all per-table limits", Element: &scm.TypeDescriptor{Kind: "int", Label: "limit", Description: "maximum rows retained from the corresponding table before the outer merge; -1 disables the limit"}},
+				{Kind: "number", Label: "limitPartitionCols", Description: "number of leading sort columns forming partition key"},
+				{Kind: "number", Label: "offset", Description: "number of items to skip (global)"},
+				{Kind: "number", Label: "limit", Description: "max number of items to read (global; -1 = unlimited)"},
+				{Kind: "list", Label: "mapColumns", Description: "map column lists, one per table", Element: &scm.TypeDescriptor{Kind: "list", Label: "table map columns", Description: "columns supplied to the matching mapFns entry", Element: &scm.TypeDescriptor{Kind: "string", Label: "column", Description: "column name in the corresponding table"}}},
+				{Kind: "list", Label: "mapFns", Description: "map lambdas, one per table", Element: rowCallback("table map", "mapper for the corresponding table and mapColumns entry", "any", "value inserted into the merged stream and passed to reduce")},
+				reducer("reduce", "optional aggregation function over mapped values from the merged stream"),
+				{Kind: "any", Label: "neutral", Description: "(optional) neutral element for reduce", Optional: true},
+				{Kind: "bool", Label: "isOuter", Description: "(optional) if true, emit null row when no hits", Optional: true},
+				{Kind: "any", Label: "notFoundValue", Description: "(optional) result for no hits when isOuter is false; defaults to neutral", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanOrderMulti,
@@ -1550,71 +1674,71 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createdatabase",
-		Desc: "creates a new database",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ignoreexists := len(a) > 1 && scm.ToBool(a[1])
 			return scm.NewBool(CreateDatabase(scm.String(a[0]), ignoreexists))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a new database", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the new database"},
-				{Kind: "bool", ParamName: "ignoreexists", ParamDesc: "if true, return false instead of throwing an error", Optional: true},
+				{Kind: "string", Label: "schema", Description: "name of the new database"},
+				{Kind: "bool", Label: "ignoreexists", Description: "if true, return false instead of throwing an error", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "dropdatabase",
-		Desc: "drops a database",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ifexists := len(a) > 1 && scm.ToBool(a[1])
 			return scm.NewBool(DropDatabase(scm.String(a[0]), ifexists))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "drops a database", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "bool", ParamName: "ifexists", ParamDesc: "if true, don't throw an error if it doesn't exist", Optional: true},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "bool", Label: "ifexists", Description: "if true, don't throw an error if it doesn't exist", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "checktablemaintenance",
-		Desc: "checks whether a user-initiated maintenance operation is allowed for a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			operation := maintenanceOperation(scm.String(a[2]))
 			requireTableMaintenance(scm.String(a[0]), scm.String(a[1]), operation)
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "checks whether a user-initiated maintenance operation is allowed for a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema"},
-				{Kind: "string", ParamName: "table"},
-				{Kind: "string", ParamName: "operation"},
+				{Kind: "string", Label: "schema"},
+				{Kind: "string", Label: "table"},
+				{Kind: "string", Label: "operation"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "maintenance_capabilities",
-		Desc: "returns the server-side maintenance capabilities for a database or table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) > 1 {
 				return maintenanceCapabilitiesScmer(tableMaintenanceCapabilities(scm.String(a[0]), scm.String(a[1])))
 			}
 			return maintenanceCapabilitiesScmer(databaseMaintenanceCapabilities(scm.String(a[0])))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the server-side maintenance capabilities for a database or table",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema"},
-				{Kind: "string", ParamName: "table", Optional: true},
+				{Kind: "string", Label: "schema"},
+				{Kind: "string", Label: "table", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "list"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createtable",
-		Desc: "creates a table, runs its oninit option and registered after-create-table lifecycle triggers synchronously, and returns only after initialization completes; concurrent if-not-exists callers wait for that same completion",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ifnotexists := len(a) > 4 && scm.ToBool(a[4])
 			db := GetDatabase(scm.String(a[0]))
@@ -1820,20 +1944,20 @@ func Init(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a table, runs its oninit option and registered after-create-table lifecycle triggers synchronously, and returns only after initialization completes; concurrent if-not-exists callers wait for that same completion", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the existing database that will contain the table"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table to create"},
-				{Kind: "list", ParamName: "cols", ParamDesc: "column and constraint definitions: (\"column\" name type dimensions typeparams), (\"unique\" name columns), or (\"foreign\" name local_columns referenced_table referenced_columns update_mode delete_mode). dimensions is a list of integer type dimensions. typeparams is an alternating key/value list supporting primary (bool), unique (bool), auto_increment (bool), null (bool), default (any), default_expression (string), update (expression), comment (string), collate (string), temp (bool), filtercols (string list), filter (function), sortcols (string list), sortdirs (bool list), partitioncount (integer), mapcols (string list), mapfn (function), reducefn (function), and reduceinit (any). Column lists are string lists; foreign-key modes are restrict, cascade, or set null"},
-				{Kind: "list", ParamName: "options", ParamDesc: "alternating key/value list; supported keys are engine (safe, logged, sloppy, memory, or cache), collation (string), charset (string), comment (string), auto_increment (non-negative integer), and oninit (closed zero-argument function run synchronously once per data generation; concurrent if-not-exists callers wait for it, and memory/cache tables persist the callback so the first idempotent createtable after restart repopulates their empty data)"},
-				{Kind: "bool", ParamName: "ifnotexists", ParamDesc: "when true, return false instead of failing if the table exists; if another caller is still creating it, wait for that caller's after-create-table initialization before returning false", Optional: true},
+				{Kind: "string", Label: "schema", Description: "name of the existing database that will contain the table"},
+				{Kind: "string", Label: "table", Description: "name of the table to create"},
+				{Kind: "list", Label: "cols", Description: "column and constraint definitions", Element: &scm.TypeDescriptor{Kind: "list", Label: "definition", Description: "one of (\"column\" name type dimensions typeparams), (\"unique\" name columns), or (\"foreign\" name local_columns referenced_table referenced_columns update_mode delete_mode). Column lists contain strings; foreign-key modes are restrict, cascade, or set null. A column definition's dimensions contains integers and its typeparams uses the same fields documented by createcolumn options"}},
+				tableOptions,
+				{Kind: "bool", Label: "ifnotexists", Description: "when true, return false instead of failing if the table exists; if another caller is still creating it, wait for that caller's after-create-table initialization before returning false", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "bool", ParamDesc: "true when this call created and initialized the table, false when ifnotexists reused an initialized table"},
+			Return: &scm.TypeDescriptor{Kind: "bool", Description: "true when this call created and initialized the table, false when ifnotexists reused an initialized table"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createcolumn",
-		Desc: "creates a new column in table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 
@@ -1922,22 +2046,30 @@ func Init(en scm.Env) {
 
 			return scm.NewBool(created)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a new column in table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "colname", ParamDesc: "name of the new column"},
-				{Kind: "string", ParamName: "type", ParamDesc: "name of the basetype"},
-				{Kind: "list", ParamName: "dimensions", ParamDesc: "dimensions of the type (e.g. for decimal)"},
-				{Kind: "list", ParamName: "options", ParamDesc: "assoc list: primary, unique, auto_increment, null, comment, default, default_expression, collate; ORC: sortcols, sortdirs, partitioncount, mapcols, mapfn, reducefn, reduceinit"},
-				{Kind: "list", ParamName: "computorCols", ParamDesc: "list of columns that is passed into params of computor", Optional: true},
-				{Kind: "func", ParamName: "computor", ParamDesc: "lambda expression that can take other column values and computes the value of that column", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", ParamName: "columns", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "colname", Description: "name of the new column"},
+				{Kind: "string", Label: "type", Description: "name of the basetype"},
+				{Kind: "list", Label: "dimensions", Description: "dimensions of the type, for example precision and scale for decimal", Element: &scm.TypeDescriptor{Kind: "int", Label: "dimension", Description: "one type-specific dimension"}},
+				columnOptions,
+				func() *scm.TypeDescriptor {
+					value := columnList("computorCols", "columns passed to computor in this order")
+					value.Optional = true
+					return value
+				}(),
+				func() *scm.TypeDescriptor {
+					value := rowCallback("computor", "lambda expression that computes this column from the values selected by computorCols", "any", "computed column value")
+					value.Optional = true
+					return value
+				}(),
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createkey",
-		Desc: "creates a new key on a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 
@@ -1962,19 +2094,19 @@ func Init(en scm.Env) {
 
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a new key on a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "keyname", ParamDesc: "name of the new key"},
-				{Kind: "bool", ParamName: "unique", ParamDesc: "whether the key is unique"},
-				{Kind: "list", ParamName: "columns", ParamDesc: "list of columns to include"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "keyname", Description: "name of the new key"},
+				{Kind: "bool", Label: "unique", Description: "whether the key is unique"},
+				{Kind: "list", Label: "columns", Description: "list of columns to include"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createforeignkey",
-		Desc: "creates a new foreign key on a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t1 := TableFromScmer(a[0])
 			id := scm.String(a[1])
@@ -2002,22 +2134,22 @@ func Init(en scm.Env) {
 
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a new foreign key on a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table1"},
-				{Kind: "string", ParamName: "keyname", ParamDesc: "name of the new key"},
-				{Kind: "list", ParamName: "columns1", ParamDesc: "list of columns to include"},
-				{Kind: "table", ParamName: "table2"},
-				{Kind: "list", ParamName: "columns2", ParamDesc: "list of columns to include"},
-				{Kind: "string", ParamName: "updatemode", ParamDesc: "restrict|cascade|set null"},
-				{Kind: "string", ParamName: "deletemode", ParamDesc: "restrict|cascade|set null"},
+				{Kind: "table", Label: "table1"},
+				{Kind: "string", Label: "keyname", Description: "name of the new key"},
+				{Kind: "list", Label: "columns1", Description: "list of columns to include"},
+				{Kind: "table", Label: "table2"},
+				{Kind: "list", Label: "columns2", Description: "list of columns to include"},
+				{Kind: "string", Label: "updatemode", Description: "restrict|cascade|set null"},
+				{Kind: "string", Label: "deletemode", Description: "restrict|cascade|set null"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "shardcolumn",
-		Desc: "tells us how it would partition a column according to their values. Returns a list of pivot elements.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			numPartitions := 0
@@ -2041,18 +2173,18 @@ func Init(en scm.Env) {
 			return scm.NewSlice(t.NewShardDimension(scm.String(a[1]), numPartitions).Pivots)
 
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "tells us how it would partition a column according to their values. Returns a list of pivot elements.",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "colname", ParamDesc: "name of the column"},
-				{Kind: "number", ParamName: "numpartitions", ParamDesc: "number of partitions; optional. leave 0 if you want to detect the partiton number automatically or copy the partition schema of the table", Optional: true},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "colname", Description: "name of the column"},
+				{Kind: "number", Label: "numpartitions", Description: "number of partitions; optional. leave 0 if you want to detect the partiton number automatically or copy the partition schema of the table", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "list"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "partitiontable",
-		Desc: "suggests a partition scheme for a table. If the table has no partition scheme yet, it will immediately apply that scheme and return true. If the table already has a partition scheme, it will alter the partitioning score such that the partitioning scheme is considered in the next repartitioning and return false.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			cols := normalizePartitionDataset(a[1])
@@ -2118,17 +2250,17 @@ func Init(en scm.Env) {
 				return scm.NewBool(false)
 			}
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "suggests a partition scheme for a table. If the table has no partition scheme yet, it will immediately apply that scheme and return true. If the table already has a partition scheme, it will alter the partitioning score such that the partitioning scheme is considered in the next repartitioning and return false.",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "list", ParamName: "columns", ParamDesc: "associative list of string -> list representing column name -> pivots. You can compute pivots by (shardcolumn ...)"},
+				{Kind: "table", Label: "table"},
+				{Kind: "list", Label: "columns", Description: "associative list of string -> list representing column name -> pivots. You can compute pivots by (shardcolumn ...)"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "altertable",
-		Desc: "alters a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			db := t.schema
@@ -2199,18 +2331,18 @@ func Init(en scm.Env) {
 				panic("unimplemented alter table operation: " + operation)
 			}
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "alters a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "operation", ParamDesc: "one of owner|drop|engine|collation|auto_increment"},
-				{Kind: "any", ParamName: "parameter", ParamDesc: "name of the column to drop or value of the parameter"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "operation", Description: "one of owner|drop|engine|collation|auto_increment"},
+				{Kind: "any", Label: "parameter", Description: "name of the column to drop or value of the parameter"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "altercolumn",
-		Desc: "alters a column",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			db := t.schema
@@ -2245,83 +2377,83 @@ func Init(en scm.Env) {
 			}
 			panic("column " + t.schema.Name + "." + t.Name + "." + scm.String(a[1]) + " does not exist")
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "alters a column",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "name of the column"},
-				{Kind: "string", ParamName: "operation", ParamDesc: "one of drop|type|collation|auto_increment|comment"},
-				{Kind: "any", ParamName: "parameter", ParamDesc: "name of the column to drop or value of the parameter"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "name of the column"},
+				{Kind: "string", Label: "operation", Description: "one of drop|type|collation|auto_increment|comment"},
+				{Kind: "any", Label: "parameter", Description: "name of the column to drop or value of the parameter"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "droptable",
-		Desc: "removes a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ifexists := len(a) > 2 && scm.ToBool(a[2])
 			DropTable(scm.String(a[0]), scm.String(a[1]), ifexists)
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema"},
-				{Kind: "string", ParamName: "table"},
-				{Kind: "bool", ParamName: "ifexists", ParamDesc: "if true, don't throw an error if it already exists", Optional: true},
+				{Kind: "string", Label: "schema"},
+				{Kind: "string", Label: "table"},
+				{Kind: "bool", Label: "ifexists", Description: "if true, don't throw an error if it already exists", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "dropcolumn",
-		Desc: "drops a column from a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			return scm.NewBool(t.DropColumn(scm.String(a[1])))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "drops a column from a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "name of the column to drop"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "name of the column to drop"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "migratedropcolumn",
-		Desc: "drops a legacy system column during startup migration",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			return scm.NewBool(t.dropColumnForMigration(scm.String(a[1])))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "drops a legacy system column during startup migration", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "legacy column name"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "legacy column name"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "invalidatecolumn",
-		Desc: "marks all values of a computed column as stale",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			colName := scm.String(a[1])
 			invalidateComputedColumn(t, colName)
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "marks all values of a computed column as stale",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "name of the computed column"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "name of the computed column"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "invalidateorc",
-		Desc: "invalidates ORC column rows from a sort key onwards via validMask scan",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			// Accept both a single value and a list of sort key values
@@ -2334,18 +2466,18 @@ func Init(en scm.Env) {
 			t.invalidateORCFromSortKey(scm.String(a[1]), sortKeys)
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "invalidates ORC column rows from a sort key onwards via validMask scan",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "name of the ORC column"},
-				{Kind: "list", ParamName: "sortkeys", ParamDesc: "composite sort key values from which to invalidate"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "name of the ORC column"},
+				{Kind: "list", Label: "sortkeys", Description: "composite sort key values from which to invalidate"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "register_keytable_cleanup",
-		Desc: "registers triggers on a base table to maintain keytable entries (insert/delete group keys)",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if a[0].IsNil() {
 				return scm.NewBool(false)
@@ -2602,19 +2734,19 @@ func Init(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers triggers on a base table to maintain keytable entries (insert/delete group keys)",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "base_table"},
-				{Kind: "table", ParamName: "kt_table"},
-				{Kind: "string", ParamName: "tblvar", ParamDesc: "table alias used in scan column prefixes"},
-				{Kind: "list", ParamName: "key_pairs", ParamDesc: "list of (base_col kt_col) pairs"},
+				{Kind: "table", Label: "base_table"},
+				{Kind: "table", Label: "kt_table"},
+				{Kind: "string", Label: "tblvar", Description: "table alias used in scan column prefixes"},
+				{Kind: "list", Label: "key_pairs", Description: "list of (base_col kt_col) pairs"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "initialize_cache_table",
-		Desc: "registers maintenance, locks source tables for a consistent snapshot, and runs a canonical planner-cache initializer exactly once",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			tbl := TableFromScmer(a[1])
@@ -2652,21 +2784,21 @@ func Init(en scm.Env) {
 			})
 			return scm.NewBool(initialized)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers maintenance, locks source tables for a consistent snapshot, and runs a canonical planner-cache initializer exactly once", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "any", ParamName: "transaction", ParamDesc: "explicit transaction context carrying query-session ownership"},
-				{Kind: "table", ParamName: "table"},
-				{Kind: "list", ParamName: "source_tables"},
-				{Kind: "func", ParamName: "register_maintenance", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "initializer", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "finalizer", ParamDesc: "optional zero-argument finalizer run under the same source-table locks after initialization", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}, Optional: true},
+				{Kind: "any", Label: "transaction", Description: "explicit transaction context carrying query-session ownership"},
+				{Kind: "table", Label: "table"},
+				{Kind: "list", Label: "source_tables"},
+				{Kind: "func", Label: "register_maintenance", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "initializer", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "finalizer", Description: "optional zero-argument finalizer run under the same source-table locks after initialization", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}, Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "touch_keytable",
-		Desc: "extends the lease on a keytable so CacheManager defers eviction",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			tbl := TableFromScmer(a[0])
 			now := time.Now()
@@ -2679,16 +2811,16 @@ func Init(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "extends the lease on a keytable so CacheManager defers eviction",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
+				{Kind: "table", Label: "table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "locktables",
-		Desc: "acquires WRITE or READ user-level locks on a list of tables (LOCK TABLES); implicitly releases any previously held locks",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			ss := scm.GetCurrentSessionState()
 			if ss != nil {
@@ -2703,29 +2835,29 @@ func Init(en scm.Env) {
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "acquires WRITE or READ user-level locks on a list of tables (LOCK TABLES); implicitly releases any previously held locks", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "list", ParamName: "locks", ParamDesc: "flat list of schema, table, write? triples"},
+				{Kind: "list", Label: "locks", Description: "flat list of schema, table, write? triples"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "unlocktables",
-		Desc: "releases all user-level table locks held by this session",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if ss := scm.GetCurrentSessionState(); ss != nil {
 				ss.ReleaseAllLocks()
 			}
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "releases all user-level table locks held by this session", HasSideEffects: true,
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "get_fk_target",
-		Desc: "returns (ref_table ref_column) if a single-column FK exists for the given column, nil otherwise",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			tbl := TableFromScmer(a[0])
 			col := scm.String(a[1])
@@ -2736,33 +2868,33 @@ func Init(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns (ref_table ref_column) if a single-column FK exists for the given column, nil otherwise",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "column", ParamDesc: "column name"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column", Description: "column name"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "renametable",
-		Desc: "renames a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			RenameTable(scm.String(a[0]), scm.String(a[1]), scm.String(a[2]))
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "renames a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "oldname", ParamDesc: "current name of the table"},
-				{Kind: "string", ParamName: "newname", ParamDesc: "new name of the table"},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "string", Label: "oldname", Description: "current name of the table"},
+				{Kind: "string", Label: "newname", Description: "new name of the table"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "insert",
-		Desc: "inserts a new dataset into table and returns the number of successful items",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			var onCollisionCols []string
@@ -2798,22 +2930,22 @@ func Init(en scm.Env) {
 			inserted := t.Insert(cols, rows, onCollisionCols, onCollision, mergeNull, onFirst)
 			return scm.NewInt(int64(inserted))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "inserts a new dataset into table and returns the number of successful items", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "list", ParamName: "columns", ParamDesc: "list of column names, e.g. '(\"ID\", \"value\")"},
-				{Kind: "list", ParamName: "datasets", ParamDesc: "list of list of column values, e.g. '('(1 10) '(2 15))"},
-				{Kind: "list", ParamName: "onCollisionCols", ParamDesc: "list of columns of the old dataset that have to be passed to onCollision. Can also request $update, $set:<computed-column>, or NEW.<insert-column>.", Optional: true},
-				{Kind: "func", ParamName: "onCollision", ParamDesc: "function called for each collision. Its positional parameters are the values requested by onCollisionCols, in the same order. If omitted, collisions raise an error.", Optional: true, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "bool", ParamName: "mergeNull", ParamDesc: "if true, it will handle NULL values as equal according to SQL 2003's definition of DISTINCT (https://en.wikipedia.org/wiki/Null_(SQL)#When_two_nulls_are_equal:_grouping,_sorting,_and_some_set_operations)", Optional: true},
-				{Kind: "func", ParamName: "onInsertid", ParamDesc: "(optional) callback (id)->any; called once with the first auto_increment id assigned for this INSERT", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "number", ParamName: "id"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "table", Label: "table"},
+				{Kind: "list", Label: "columns", Description: "list of column names, e.g. '(\"ID\", \"value\")"},
+				{Kind: "list", Label: "datasets", Description: "list of list of column values, e.g. '('(1 10) '(2 15))"},
+				{Kind: "list", Label: "onCollisionCols", Description: "list of columns of the old dataset that have to be passed to onCollision. Can also request $update, $set:<computed-column>, or NEW.<insert-column>.", Optional: true},
+				{Kind: "func", Label: "onCollision", Description: "function called for each collision. Its positional parameters are the values requested by onCollisionCols, in the same order. If omitted, collisions raise an error.", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "any", Label: "column values", Description: "one value for each onCollisionCols entry", Variadic: true}}, Return: &scm.TypeDescriptor{Kind: "any", Label: "result"}},
+				{Kind: "bool", Label: "mergeNull", Description: "if true, it will handle NULL values as equal according to SQL 2003's definition of DISTINCT (https://en.wikipedia.org/wiki/Null_(SQL)#When_two_nulls_are_equal:_grouping,_sorting,_and_some_set_operations)", Optional: true},
+				{Kind: "func", Label: "onInsertid", Description: "(optional) callback (id)->any; called once with the first auto_increment id assigned for this INSERT", Optional: true, Params: []*scm.TypeDescriptor{{Kind: "number", Label: "id"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "number"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "stat",
-		Desc: "return system statistics as assoc: mem_available, mem_total, process_memory, shard_memory, shard_budget, persisted_memory, persisted_budget, cache_entry_count, cache_entry_size.\n(stat schema) and (stat schema tbl) return a string with detailed memory usage.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) == 0 {
 				memTotal, memAvail := ReadMemInfo()
@@ -2839,28 +2971,28 @@ func Init(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc: mem_available, mem_total, process_memory, shard_memory, shard_budget, persisted_memory, persisted_budget, cache_entry_count, cache_entry_size.\n(stat schema) and (stat schema tbl) return a string with detailed memory usage.",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "(optional) database name for detailed string output", Optional: true},
-				{Kind: "string", ParamName: "table", ParamDesc: "(optional) table name for detailed string output", Optional: true},
+				{Kind: "string", Label: "schema", Description: "(optional) database name for detailed string output", Optional: true},
+				{Kind: "string", Label: "table", Description: "(optional) table name for detailed string output", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "totalmem",
-		Desc: "Returns total physical memory in bytes (from /proc/meminfo)",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(totalMemoryBytes())
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns total physical memory in bytes (from /proc/meminfo)",
 			Return: &scm.TypeDescriptor{Kind: "number"},
 			Const:  true,
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "resolve_column_name",
-		Desc: "resolve a physical column name from immutable table metadata",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
@@ -2876,19 +3008,19 @@ func Init(en scm.Env) {
 			}
 			return scm.NewString(name)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "resolve a physical column name from immutable table metadata",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "table", ParamDesc: "table name"},
-				{Kind: "string", ParamName: "column", ParamDesc: "column name"},
-				{Kind: "bool", ParamName: "ignorecase", ParamDesc: "whether identifier case is ignored"},
+				{Kind: "string", Label: "schema", Description: "database name"},
+				{Kind: "string", Label: "table", Description: "table name"},
+				{Kind: "string", Label: "column", Description: "column name"},
+				{Kind: "bool", Label: "ignorecase", Description: "whether identifier case is ignored"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string|nil", Transfer: false},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "show",
-		Desc: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show table_handle) lists the memoized column defs\n(show table_handle true) returns table metadata\n(show table_handle \"statistics\") returns index statistics\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// table-based overloads: (show table) / (show recset) → columns,
 			// (show table "statistics") / (show recset "statistics") → index stats, etc.
@@ -3126,12 +3258,12 @@ func Init(en scm.Env) {
 			}
 			panic("invalid call of show")
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "show databases/tables/columns/shards\n\n(show) lists database names\n(show schema) lists table names\n(show table_handle) lists the memoized column defs\n(show table_handle true) returns table metadata\n(show table_handle \"statistics\") returns index statistics\n(show schema true) lists tables with full info: [{name,engine,row_count,size_bytes,collation,comment},...]\n(show schema tbl) lists column defs\n(show schema tbl true) returns assoc {columns,meta,shards}\n(show schema tbl N) returns shard N overview assoc {shard,state,main_count,delta,deletions,size_bytes}\n(show schema tbl N true) returns shard N full assoc adding columns and indexes\n(show schema tbl \"statistics\") returns index statistics (used by INFORMATION_SCHEMA)",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string|table|recset", ParamName: "schema_or_table", ParamDesc: "(optional) database name or resolved table/recset handle", Optional: true},
-				{Kind: "string|bool", ParamName: "table_or_property", ParamDesc: "(optional) table name, true for full info, or \"statistics\" for a handle", Optional: true},
-				{Kind: "int|bool|string", ParamName: "property", ParamDesc: "(optional) shard index (int), true for full table info, or \"statistics\"", Optional: true},
-				{Kind: "bool", ParamName: "full", ParamDesc: "(optional) true to include columns and indexes in shard detail", Optional: true},
+				{Kind: "string|table|recset", Label: "schema_or_table", Description: "(optional) database name or resolved table/recset handle", Optional: true},
+				{Kind: "string|bool", Label: "table_or_property", Description: "(optional) table name, true for full info, or \"statistics\" for a handle", Optional: true},
+				{Kind: "int|bool|string", Label: "property", Description: "(optional) shard index (int), true for full table info, or \"statistics\"", Optional: true},
+				{Kind: "bool", Label: "full", Description: "(optional) true to include columns and indexes in shard detail", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any", Transfer: false},
 		},
@@ -3139,7 +3271,7 @@ func Init(en scm.Env) {
 	// show_triggers(schema, table): returns a list of triggers for a table (non-system triggers only)
 	scm.Declare(&en, &scm.Declaration{
 		Name: "show_triggers",
-		Desc: "show triggers for a given table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
@@ -3197,10 +3329,10 @@ func Init(en scm.Env) {
 			}
 			return scm.NewSlice(rows)
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "show triggers for a given table",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "table", ParamDesc: "(optional) table name, if omitted shows all triggers in schema", Optional: true},
+				{Kind: "string", Label: "schema", Description: "database name"},
+				{Kind: "string", Label: "table", Description: "(optional) table name, if omitted shows all triggers in schema", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
@@ -3208,7 +3340,7 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "rebuild",
-		Desc: "rebuilds main storages and returns the amount of time it took; with a table handle, rebuilds only that table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) > 0 && a[0].IsCustom(TagTable) {
 				all := len(a) > 1 && scm.ToBool(a[1])
@@ -3232,11 +3364,11 @@ func Init(en scm.Env) {
 
 			return scm.NewString(Rebuild(all, repartition))
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "rebuilds main storages and returns the amount of time it took; with a table handle, rebuilds only that table",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "bool|table", ParamName: "table_or_all", ParamDesc: "table handle for a table-local rebuild; otherwise whether to rebuild unchanged shards globally (default: false)", Optional: true},
-				{Kind: "bool", ParamName: "all_or_repartition", ParamDesc: "with a table: whether to rebuild unchanged shards; globally: whether to repartition (default: true)", Optional: true},
-				{Kind: "bool", ParamName: "repartition", ParamDesc: "with a table handle, whether to repartition that table (default: true)", Optional: true},
+				{Kind: "bool|table", Label: "table_or_all", Description: "table handle for a table-local rebuild; otherwise whether to rebuild unchanged shards globally (default: false)", Optional: true},
+				{Kind: "bool", Label: "all_or_repartition", Description: "with a table: whether to rebuild unchanged shards; globally: whether to repartition (default: true)", Optional: true},
+				{Kind: "bool", Label: "repartition", Description: "with a table handle, whether to repartition that table (default: true)", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
@@ -3246,7 +3378,7 @@ func Init(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "loadCSV",
-		Desc: "loads a CSV stream into a table and returns the amount of time it took.\nThe first line of the file must be the headlines. The headlines must match the table's columns exactly.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// schema, table, filename, delimiter
 			start := time.Now()
@@ -3267,20 +3399,20 @@ func Init(en scm.Env) {
 
 			return scm.NewString(fmt.Sprint(time.Since(start)))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "loads a CSV stream into a table and returns the amount of time it took.\nThe first line of the file must be the headlines. The headlines must match the table's columns exactly.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table"},
-				{Kind: "stream", ParamName: "stream", ParamDesc: "CSV file, load with: (stream filename)"},
-				{Kind: "string", ParamName: "delimiter", ParamDesc: "(optional) delimiter defaults to \";\"", Optional: true},
-				{Kind: "bool", ParamName: "firstline", ParamDesc: "(optional) if the first line contains the column names (otherwise, the tables column order is used)", Optional: true},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "string", Label: "table", Description: "name of the table"},
+				{Kind: "stream", Label: "stream", Description: "CSV file, load with: (stream filename)"},
+				{Kind: "string", Label: "delimiter", Description: "(optional) delimiter defaults to \";\"", Optional: true},
+				{Kind: "bool", Label: "firstline", Description: "(optional) if the first line contains the column names (otherwise, the tables column order is used)", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "loadJSON",
-		Desc: "loads a .jsonl file from stream into a database and returns the amount of time it took.\nJSONL is a linebreak separated file of JSON objects. Each JSON object is one dataset in the database. Before you add rows, you must declare the table in a line '#table <tablename>'. All other lines starting with # are comments. Columns are created dynamically as soon as they occur in a json object.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			// schema, filename
 			start := time.Now()
@@ -3293,22 +3425,22 @@ func Init(en scm.Env) {
 
 			return scm.NewString(fmt.Sprint(time.Since(start)))
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "loads a .jsonl file from stream into a database and returns the amount of time it took.\nJSONL is a linebreak separated file of JSON objects. Each JSON object is one dataset in the database. Before you add rows, you must declare the table in a line '#table <tablename>'. All other lines starting with # are comments. Columns are created dynamically as soon as they occur in a json object.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database where you want to put the tables in"},
-				{Kind: "stream", ParamName: "stream", ParamDesc: "stream of the .jsonl file, read with: (stream filename)"},
+				{Kind: "string", Label: "schema", Description: "name of the database where you want to put the tables in"},
+				{Kind: "stream", Label: "stream", Description: "stream of the .jsonl file, read with: (stream filename)"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "string"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "settings",
-		Desc: "reads or writes a global settings value. This modifies your data/settings.json.",
-		Fn:   ChangeSettings,
-		Type: &scm.TypeDescriptor{
+
+		Fn: ChangeSettings,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "reads or writes a global settings value. This modifies your data/settings.json.",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "key", ParamDesc: "name of the key to set or get (for reference, rts)", Optional: true},
-				{Kind: "any", ParamName: "value", ParamDesc: "new value of that setting", Optional: true},
+				{Kind: "string", Label: "key", Description: "name of the key to set or get (for reference, rts)", Optional: true},
+				{Kind: "any", Label: "value", Description: "new value of that setting", Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},
@@ -3317,7 +3449,7 @@ func Init(en scm.Env) {
 	// Trigger management
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createcreatetabletrigger",
-		Desc: "registers a lifecycle trigger that fires synchronously after a future createtable for the given schema/table succeeds",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			body, deferredPlan := unwrapDeferredTriggerBody(a[4])
 			if triggerScmerMissing(body) && !triggerScmerMissing(deferredPlan) {
@@ -3346,21 +3478,21 @@ func Init(en scm.Env) {
 			})
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers a lifecycle trigger that fires synchronously after a future createtable for the given schema/table succeeds", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table to watch for creation"},
-				{Kind: "string", ParamName: "name", ParamDesc: "name of the trigger"},
-				{Kind: "string", ParamName: "source_sql", ParamDesc: "original SQL body text (for diagnostics)"},
-				{Kind: "any", ParamName: "body", ParamDesc: "trigger body (Scheme procedure or deferred trigger expression)"},
-				{Kind: "bool", ParamName: "visible", ParamDesc: "true = user trigger, false = internal trigger"},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "string", Label: "table", Description: "name of the table to watch for creation"},
+				{Kind: "string", Label: "name", Description: "name of the trigger"},
+				{Kind: "string", Label: "source_sql", Description: "original SQL body text (for diagnostics)"},
+				{Kind: "any", Label: "body", Description: "trigger body (Scheme procedure or deferred trigger expression)"},
+				{Kind: "bool", Label: "visible", Description: "true = user trigger, false = internal trigger"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "dropcreatetabletrigger",
-		Desc: "removes a registered create-table lifecycle trigger",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			schema := scm.String(a[0])
 			table := scm.String(a[1])
@@ -3373,19 +3505,19 @@ func Init(en scm.Env) {
 			}
 			panic("create-table trigger " + schema + "." + table + ":" + name + " does not exist")
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes a registered create-table lifecycle trigger", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "table", ParamDesc: "name of the table watched for creation"},
-				{Kind: "string", ParamName: "name", ParamDesc: "name of the trigger"},
-				{Kind: "bool", ParamName: "ifexists", ParamDesc: "don't throw error if trigger doesn't exist"},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "string", Label: "table", Description: "name of the table watched for creation"},
+				{Kind: "string", Label: "name", Description: "name of the trigger"},
+				{Kind: "bool", Label: "ifexists", Description: "don't throw error if trigger doesn't exist"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createtrigger",
-		Desc: "creates a new trigger on a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			t := TableFromScmer(a[0])
 			db := t.schema
@@ -3441,21 +3573,21 @@ func Init(en scm.Env) {
 			db.saveLockedAndUnlock(t.schemaSaveMode())
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "creates a new trigger on a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "table", ParamName: "table"},
-				{Kind: "string", ParamName: "name", ParamDesc: "name of the trigger"},
-				{Kind: "string", ParamName: "timing", ParamDesc: "one of: before_insert, after_insert, before_update, after_update, before_delete, after_delete"},
-				{Kind: "string", ParamName: "source_sql", ParamDesc: "original SQL body text (for SHOW TRIGGERS)"},
-				{Kind: "any", ParamName: "body", ParamDesc: "trigger body (parsed Scheme expression)"},
-				{Kind: "bool", ParamName: "visible", ParamDesc: "true = user trigger (shown in SHOW TRIGGERS), false = internal trigger (hidden)"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "name", Description: "name of the trigger"},
+				{Kind: "string", Label: "timing", Description: "one of: before_insert, after_insert, before_update, after_update, before_delete, after_delete"},
+				{Kind: "string", Label: "source_sql", Description: "original SQL body text (for SHOW TRIGGERS)"},
+				{Kind: "any", Label: "body", Description: "trigger body (parsed Scheme expression)"},
+				{Kind: "bool", Label: "visible", Description: "true = user trigger (shown in SHOW TRIGGERS), false = internal trigger (hidden)"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "droptrigger",
-		Desc: "removes a trigger from a table",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			db := GetDatabase(scm.String(a[0]))
 			if db == nil {
@@ -3474,11 +3606,11 @@ func Init(en scm.Env) {
 			}
 			panic("trigger " + name + " does not exist")
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "removes a trigger from a table", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "name of the database"},
-				{Kind: "string", ParamName: "name", ParamDesc: "name of the trigger"},
-				{Kind: "bool", ParamName: "ifexists", ParamDesc: "don't throw error if trigger doesn't exist"},
+				{Kind: "string", Label: "schema", Description: "name of the database"},
+				{Kind: "string", Label: "name", Description: "name of the trigger"},
+				{Kind: "bool", Label: "ifexists", Description: "don't throw error if trigger doesn't exist"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
@@ -3490,10 +3622,17 @@ func Init(en scm.Env) {
 	initMetricsDeclarations(en)
 	scm.DeclareInSection("Sync", &en, &scm.Declaration{
 		Name: "newcachemap",
-		Desc: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
-		Fn:   NewCacheMap,
-		Type: &scm.TypeDescriptor{
-			Return: &scm.TypeDescriptor{Kind: "func"},
+
+		Fn: NewCacheMap,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
+			Return: &scm.TypeDescriptor{Kind: "func", Label: "cachemap", Description: "thread-safe cache accessor",
+				Params: []*scm.TypeDescriptor{
+					{Kind: "any", Label: "key_or_operation", Description: "cache key, or get_or_compute", Optional: true},
+					{Kind: "any", Label: "value_or_key", Description: "value to store, or key for get_or_compute", Optional: true},
+					{Kind: "func", Label: "producer", Description: "zero-argument value producer used by get_or_compute", Optional: true, Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any", Label: "value"}},
+				},
+				Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "cached value, previous value, or key list depending on the operation"},
+			},
 		},
 	})
 	initTransaction(en)
@@ -3701,7 +3840,7 @@ func fkCascadeUpdate(currentTx *TxContext, childTbl *table, cols []string, oldVa
 func initFKBuiltins(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "__fk_check_ref",
-		Desc: "check that FK values exist in the parent table, panic if not",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := CurrentTx()
 			schema := scm.String(a[0])
@@ -3728,13 +3867,13 @@ func initFKBuiltins(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "check that FK values exist in the parent table, panic if not",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "parent_table", ParamDesc: "parent table name"},
-				{Kind: "list", ParamName: "parent_cols", ParamDesc: "parent column names"},
-				{Kind: "list", ParamName: "values", ParamDesc: "FK values to check"},
-				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
+				{Kind: "string", Label: "schema", Description: "database name"},
+				{Kind: "string", Label: "parent_table", Description: "parent table name"},
+				{Kind: "list", Label: "parent_cols", Description: "parent column names"},
+				{Kind: "list", Label: "values", Description: "FK values to check"},
+				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -3743,7 +3882,7 @@ func initFKBuiltins(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "__fk_on_parent_delete",
-		Desc: "enforce FK constraint when parent row is deleted",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := CurrentTx()
 			schema := scm.String(a[0])
@@ -3773,14 +3912,14 @@ func initFKBuiltins(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "enforce FK constraint when parent row is deleted",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "child_table", ParamDesc: "child table name"},
-				{Kind: "list", ParamName: "child_cols", ParamDesc: "child FK column names"},
-				{Kind: "list", ParamName: "parent_vals", ParamDesc: "old parent PK values"},
-				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
-				{Kind: "string", ParamName: "mode", ParamDesc: "RESTRICT, CASCADE, or SETNULL"},
+				{Kind: "string", Label: "schema", Description: "database name"},
+				{Kind: "string", Label: "child_table", Description: "child table name"},
+				{Kind: "list", Label: "child_cols", Description: "child FK column names"},
+				{Kind: "list", Label: "parent_vals", Description: "old parent PK values"},
+				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
+				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -3789,7 +3928,7 @@ func initFKBuiltins(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "__fk_on_parent_update",
-		Desc: "enforce FK constraint when parent PK is updated",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := CurrentTx()
 			schema := scm.String(a[0])
@@ -3832,15 +3971,15 @@ func initFKBuiltins(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "enforce FK constraint when parent PK is updated",
 			Params: []*scm.TypeDescriptor{
-				{Kind: "string", ParamName: "schema", ParamDesc: "database name"},
-				{Kind: "string", ParamName: "child_table", ParamDesc: "child table name"},
-				{Kind: "list", ParamName: "child_cols", ParamDesc: "child FK column names"},
-				{Kind: "list", ParamName: "old_vals", ParamDesc: "old parent PK values"},
-				{Kind: "list", ParamName: "new_vals", ParamDesc: "new parent PK values"},
-				{Kind: "string", ParamName: "fk_id", ParamDesc: "FK constraint name"},
-				{Kind: "string", ParamName: "mode", ParamDesc: "RESTRICT, CASCADE, or SETNULL"},
+				{Kind: "string", Label: "schema", Description: "database name"},
+				{Kind: "string", Label: "child_table", Description: "child table name"},
+				{Kind: "list", Label: "child_cols", Description: "child FK column names"},
+				{Kind: "list", Label: "old_vals", Description: "old parent PK values"},
+				{Kind: "list", Label: "new_vals", Description: "new parent PK values"},
+				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
+				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -818,7 +818,7 @@ func initTransaction(en scm.Env) {
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "tx_begin",
-		Desc: "Begins a new cursor-stability transaction. Takes the session function as argument. Stores the transaction context in the session.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
@@ -834,15 +834,15 @@ func initTransaction(en scm.Env) {
 			sessionFn(scm.NewString("transaction"), scm.NewInt(1))
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
-			Params: []*scm.TypeDescriptor{{Kind: "func", ParamName: "session", ParamDesc: "the session function to store tx state in", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Begins a new cursor-stability transaction. Takes the session function as argument. Stores the transaction context in the session.", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{{Kind: "func", Label: "session", Description: "the session function to store tx state in", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "tx_begin_acid",
-		Desc: "Begins a new ACID transaction with snapshot isolation and OCC commit. Takes the session function as argument.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
@@ -857,15 +857,15 @@ func initTransaction(en scm.Env) {
 			sessionFn(scm.NewString("transaction"), scm.NewInt(1))
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
-			Params: []*scm.TypeDescriptor{{Kind: "func", ParamName: "session", ParamDesc: "the session function to store tx state in", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Begins a new ACID transaction with snapshot isolation and OCC commit. Takes the session function as argument.", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{{Kind: "func", Label: "session", Description: "the session function to store tx state in", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "tx_commit",
-		Desc: "Commits the current transaction.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
@@ -882,15 +882,15 @@ func initTransaction(en scm.Env) {
 			sessionFn(scm.NewString("transaction"), scm.NewNil())
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
-			Params: []*scm.TypeDescriptor{{Kind: "func", ParamName: "session", ParamDesc: "the session function that holds tx state", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Commits the current transaction.", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{{Kind: "func", Label: "session", Description: "the session function that holds tx state", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "tx_rollback",
-		Desc: "Rolls back the current transaction.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			sessionFn := a[0].Func()
 			existingTx := sessionFn(scm.NewString("__memcp_tx"))
@@ -903,26 +903,26 @@ func initTransaction(en scm.Env) {
 			sessionFn(scm.NewString("transaction"), scm.NewNil())
 			return scm.NewBool(true)
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
-			Params: []*scm.TypeDescriptor{{Kind: "func", ParamName: "session", ParamDesc: "the session function that holds tx state", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Rolls back the current transaction.", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{{Kind: "func", Label: "session", Description: "the session function that holds tx state", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}}},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},
 	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "with_autocommit",
-		Desc: "Executes fn inside an implicit TxCursorStability transaction if no explicit " +
-			"transaction is active in session. Commits on success, rolls back on error, " +
-			"and re-raises any panic so the caller's error handler still fires. " +
-			"If an explicit transaction is active (session[\"transaction\"] != nil), " +
-			"fn is executed without any wrapping.",
+
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return WithAutocommit(a[0].Func(), a[1])
 		},
-		Type: &scm.TypeDescriptor{HasSideEffects: true,
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Executes fn inside an implicit TxCursorStability transaction if no explicit " +
+			"transaction is active in session. Commits on success, rolls back on error, " +
+			"and re-raises any panic so the caller's error handler still fires. " +
+			"If an explicit transaction is active (session[\"transaction\"] != nil), " +
+			"fn is executed without any wrapping.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
-				{Kind: "func", ParamName: "session", ParamDesc: "the session function holding tx state", Params: []*scm.TypeDescriptor{{Kind: "string", ParamName: "key", Optional: true}, {Kind: "any", ParamName: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", ParamName: "fn", ParamDesc: "zero-argument function to execute", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "session", Description: "the session function holding tx state", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "fn", Description: "zero-argument function to execute", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},
 		},

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/constant"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"math"
@@ -209,6 +210,11 @@ func main() {
 
 		// Single-pass: try to generate, recover on failure
 		newText, genErr := generateClosure(op.name, ssaFn, nil)
+		if genErr == "" {
+			if _, err := parser.ParseExpr(newText); err != nil {
+				genErr = "generated invalid Go expression: " + err.Error()
+			}
+		}
 		// Declaration emitters are expressions nested one indentation level below
 		// their TypeDescriptor field. Keep generated output gofmt-stable both when
 		// inserting a new JITEmit field and when replacing an existing closure.
@@ -351,6 +357,10 @@ func collectOperators(fset *token.FileSet, f *ast.File, path string) []operatorI
 				typeExpr := keyedValue(comp, "Type")
 				if unaryType, ok := typeExpr.(*ast.UnaryExpr); ok && unaryType.Op == token.AND {
 					if typeComp, ok := unaryType.X.(*ast.CompositeLit); ok {
+						kind, ok := stringLiteral(keyedValue(typeComp, "Kind"))
+						if !ok || kind != "func" {
+							return true
+						}
 						jitExpr = keyedValue(typeComp, "JITEmit")
 						if jitExpr == nil {
 							jitInsertPos = typeComp.Rbrace
@@ -387,6 +397,15 @@ func collectOperators(fset *token.FileSet, f *ast.File, path string) []operatorI
 		return true
 	})
 	return ops
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	return value, err == nil
 }
 
 // --- Storage method collection (pattern 2: ColumnStorage.GetValue → JITEmit) ---

--- a/tools/jitgen/main_test.go
+++ b/tools/jitgen/main_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestCollectOperatorsUsesRootFunctionTypeDescriptor(t *testing.T) {
+	const source = `package sample
+func init() {
+	Declare(&env, &Declaration{
+		Name: "nested",
+		Fn: func(a ...Scmer) Scmer { return a[0] },
+		Type: &TypeDescriptor{
+			Kind: "func",
+			Description: "root description",
+			Params: []*TypeDescriptor{{
+				Kind: "list",
+				Label: "callbacks",
+				Element: &TypeDescriptor{Kind: "func"},
+			}},
+			Return: &TypeDescriptor{Kind: "any"},
+		},
+	})
+}`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ops := collectOperators(fset, file, "sample.go")
+	if len(ops) != 1 || ops[0].name != "nested" || !ops[0].jitInsertPos.IsValid() {
+		t.Fatalf("collectOperators() = %#v, want one root declaration insertion", ops)
+	}
+}
+
+func TestCollectOperatorsRejectsNonFunctionRootType(t *testing.T) {
+	const source = `package sample
+func init() {
+	Declare(&env, &Declaration{
+		Name: "not-a-function-type",
+		Fn: func(a ...Scmer) Scmer { return a[0] },
+		Type: &TypeDescriptor{Kind: "list", Element: &TypeDescriptor{Kind: "func"}},
+	})
+}`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ops := collectOperators(fset, file, "sample.go"); len(ops) != 0 {
+		t.Fatalf("collectOperators() found nested function type as an operator: %#v", ops)
+	}
+}


### PR DESCRIPTION
## Summary

- make each Declaration reference one root function TypeDescriptor, including its description
- add labels and recursive Markdown rendering for lists, assoc fields, callback parameters, and return values
- deeply describe scan options and scan_order_multi's nested per-table lists
- rewrite newpromise documentation around user-facing use cases
- parse valid JSON objects and arrays in simplify as BSON values
- update jitgen for the new root descriptor format and reject invalid generated expressions
- regenerate the reference documentation

## Verification

- make test
- go test ./tools/jitgen ./scm
- targeted jitgen regeneration for simplify
- ./memcp -write-docu /tmp/memcp-recursive-type-docs