### PR TITLE
Harden storage accounting and crash-safe cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -1227,7 +1227,11 @@ func main() {
 		}
 	})
 	<-initDone
-	go storage.Clean() // remove crash-orphaned blobs/shard files after init completes
+	go func() {
+		// Cleanup is deliberately observable: legacy manifest backfill and orphan
+		// removal may reclaim substantial disk space on the first upgraded start.
+		fmt.Println(storage.Clean())
+	}()
 
 	// install exit handler
 	cancelChan := make(chan os.Signal, 1)

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -25,44 +25,26 @@ import "runtime"
 import "sync/atomic"
 import "github.com/jtolds/gls"
 
-// cachedMemStats provides a cached version of runtime.ReadMemStats.
-// The cache is refreshed when older than 1 minute. Between refreshes,
-// Alloc and HeapAlloc are adjusted by deltas reported via AdjustMemStats.
+// cachedMemStats provides a cached version of runtime.ReadMemStats. Cache
+// ownership accounting must not be added to this snapshot: those allocations
+// are already part of the Go heap, and doing so would double-count them.
 var (
 	cachedStats     runtime.MemStats
 	cachedStatsTime time.Time
 	cachedStatsMu   sync.Mutex
-	memStatsDelta   int64 // accumulated delta since last refresh
 )
 
-// CachedMemStats returns a cached runtime.MemStats, refreshing only when
-// the cache is older than 1 minute. Between refreshes, Alloc and HeapAlloc
-// are adjusted by tracked deltas from the CacheManager.
+// CachedMemStats returns a runtime snapshot cached for one minute. Operational
+// endpoints use process RSS and CacheManager ownership counters for live data;
+// this function deliberately avoids expensive runtime scans on every request.
 func CachedMemStats() runtime.MemStats {
 	cachedStatsMu.Lock()
 	defer cachedStatsMu.Unlock()
 	if time.Since(cachedStatsTime) > time.Minute {
 		runtime.ReadMemStats(&cachedStats)
 		cachedStatsTime = time.Now()
-		memStatsDelta = 0
 	}
-	result := cachedStats
-	if memStatsDelta > 0 {
-		result.Alloc += uint64(memStatsDelta)
-		result.HeapAlloc += uint64(memStatsDelta)
-	} else if memStatsDelta < 0 && uint64(-memStatsDelta) < result.Alloc {
-		result.Alloc -= uint64(-memStatsDelta)
-		result.HeapAlloc -= uint64(-memStatsDelta)
-	}
-	return result
-}
-
-// AdjustMemStats adjusts the cached memory stats by a delta (in bytes).
-// Call this when tracked memory changes (e.g. CacheManager add/remove).
-func AdjustMemStats(delta int64) {
-	cachedStatsMu.Lock()
-	memStatsDelta += delta
-	cachedStatsMu.Unlock()
+	return cachedStats
 }
 
 /* promise: single-value cell (thread-safe via CAS spin-lock on cells[1].aux) */

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
-	"github.com/launix-de/memcp/scm"
 )
 
 // EvictableType identifies the kind of cached object for factor lookup and stat reporting.
@@ -254,6 +253,7 @@ type cacheOp struct {
 	del                any
 	updatePtr          any
 	updateDelta        int64
+	setSize            bool
 	budgetUpdate       bool
 	budgetVal          int64
 	persistedBudgetVal int64
@@ -392,6 +392,18 @@ func (cm *CacheManager) UpdateSize(pointer any, delta int64) {
 	<-done
 }
 
+// SetSize replaces the accounted size of pointer. Use it after recomputing an
+// owner's complete footprint; unlike UpdateSize, repeated calls with the same
+// observation are idempotent.
+func (cm *CacheManager) SetSize(pointer any, size int64) {
+	if cm.opChan == nil || cm.stopped.Load() {
+		return
+	}
+	done := make(chan struct{})
+	cm.opChan <- cacheOp{updatePtr: pointer, updateDelta: size, setSize: true, done: done}
+	<-done
+}
+
 // UpdateSizeAsync queues an ownership-local size change without waiting for
 // eviction. It is intended for callers that already hold storage locks. Such
 // objects serialize enqueue order with their own lock; the single manager then
@@ -502,7 +514,11 @@ func (cm *CacheManager) run() {
 			} else if op.del != nil {
 				cm.removeByPointer(op.del)
 			} else if op.updatePtr != nil {
-				cm.updateSizeInternal(op.updatePtr, op.updateDelta)
+				if op.setSize {
+					cm.setSizeInternal(op.updatePtr, op.updateDelta)
+				} else {
+					cm.updateSizeInternal(op.updatePtr, op.updateDelta)
+				}
 			} else if op.budgetUpdate {
 				cm.memoryBudget = op.budgetVal
 				cm.persistedBudget = op.persistedBudgetVal
@@ -568,7 +584,6 @@ func (cm *CacheManager) addInternal(item *softItem) {
 		// re-registration: update in place
 		delta := item.size - old.size
 		cm.currentMemory += delta
-		scm.AdjustMemStats(delta)
 		cm.sizeByType[old.evictType] -= old.size
 		cm.countByType[old.evictType]--
 		cm.sizeByType[item.evictType] += item.size
@@ -591,7 +606,6 @@ func (cm *CacheManager) addInternal(item *softItem) {
 	}
 	cm.itemMap[item.pointer] = item
 	cm.currentMemory += item.size
-	scm.AdjustMemStats(item.size)
 	cm.sizeByType[item.evictType] += item.size
 	cm.countByType[item.evictType]++
 	heap.Push(&cm.h, item)
@@ -613,7 +627,6 @@ func (cm *CacheManager) removeInternal(pointer any, freedByType *[numEvictableTy
 		return
 	}
 	cm.currentMemory -= item.size
-	scm.AdjustMemStats(-item.size)
 	cm.sizeByType[item.evictType] -= item.size
 	cm.countByType[item.evictType]--
 	if freedByType != nil {
@@ -638,13 +651,23 @@ func (cm *CacheManager) updateSizeInternal(pointer any, delta int64) {
 		delta = -item.size
 	}
 	cm.currentMemory += delta
-	scm.AdjustMemStats(delta)
 	cm.sizeByType[item.evictType] += delta
 	item.size += delta
 	item.evictionScore = item.size * evictableWeights[item.evictType]
 	if item.heapIndex >= 0 {
 		heap.Fix(&cm.h, item.heapIndex)
 	}
+}
+
+func (cm *CacheManager) setSizeInternal(pointer any, size int64) {
+	item, ok := cm.itemMap[pointer]
+	if !ok {
+		return
+	}
+	if size < 0 {
+		size = 0
+	}
+	cm.updateSizeInternal(pointer, size-item.size)
 }
 
 // telemetryWeight calibrates telemetry (rebuild-decayed usage score) against
@@ -699,7 +722,6 @@ func (cm *CacheManager) applyEviction(candidate evictionCandidate, mode eviction
 		return 0
 	}
 	cm.currentMemory -= freed
-	scm.AdjustMemStats(-freed)
 	cm.sizeByType[item.evictType] -= freed
 	freedByType[item.evictType] += freed
 	item.size -= freed
@@ -800,14 +822,10 @@ func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFi
 
 	// log summary
 	if totalFreed > 0 {
-		shardColsOnly := freedByType[TypeShard] - freedByType[TypeIndex]
-		if shardColsOnly < 0 {
-			shardColsOnly = 0
-		}
 		log.Printf("memory pressure: freed %s total (%s temp columns, %s shard columns, %s indexes, %s keytables, %s cache entries, %s string dicts)",
 			units.BytesSize(float64(totalFreed)),
 			units.BytesSize(float64(freedByType[TypeTempColumn])),
-			units.BytesSize(float64(shardColsOnly)),
+			units.BytesSize(float64(freedByType[TypeShard])),
 			units.BytesSize(float64(freedByType[TypeIndex])),
 			units.BytesSize(float64(freedByType[TypeTempKeytable])),
 			units.BytesSize(float64(freedByType[TypeCacheEntry])),
@@ -818,12 +836,8 @@ func (cm *CacheManager) evict(currentUsage, budget, additionalSize int64, typeFi
 
 // FormatStat returns a human-readable string of the cache state.
 func (cs CacheStat) FormatStat() string {
-	shardColsOnly := cs.SizeByType[TypeShard] - cs.SizeByType[TypeIndex]
-	if shardColsOnly < 0 {
-		shardColsOnly = 0
-	}
-	// Child caches are included in their top-level owner's size and count as one
-	// object. This keeps global cache metadata independent of child cardinality.
+	// Every byte has one owner. Indexes, materialized string dictionaries and
+	// temp columns are therefore disjoint from their parent shard totals.
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("TotalBudget = %s\tPersistedBudget = %s\tTracked = %s\tPersisted = %s\n",
@@ -833,7 +847,7 @@ func (cs CacheStat) FormatStat() string {
 		units.BytesSize(float64(cs.PersistedMemory))))
 	b.WriteString("Type                     \tCount\tSize\n")
 	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Temp columns", cs.CountByType[TypeTempColumn], units.BytesSize(float64(cs.SizeByType[TypeTempColumn]))))
-	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Shard columns", cs.CountByType[TypeShard], units.BytesSize(float64(shardColsOnly))))
+	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Shard columns", cs.CountByType[TypeShard], units.BytesSize(float64(cs.SizeByType[TypeShard]))))
 	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Indexes", cs.CountByType[TypeIndex], units.BytesSize(float64(cs.SizeByType[TypeIndex]))))
 	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Temp keytables", cs.CountByType[TypeTempKeytable], units.BytesSize(float64(cs.SizeByType[TypeTempKeytable]))))
 	b.WriteString(fmt.Sprintf("%-25s\t%d\t%s\n", "Cache entries", cs.CountByType[TypeCacheEntry], units.BytesSize(float64(cs.SizeByType[TypeCacheEntry]))))

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -143,11 +143,7 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 			}
 			// update CacheManager size for temp columns
 			if c.IsTemp {
-				var totalRows int64
-				for _, s := range shardlist {
-					totalRows += int64(s.Count())
-				}
-				GlobalCache.UpdateSize(c, totalRows*16) // ~16 bytes per value estimate
+				GlobalCache.SetSize(c, t.tempColumnMemory(c, shardlist))
 			}
 			if metadataChanged {
 				t.ddlMu.Lock()
@@ -169,6 +165,22 @@ func (t *table) computeColumnDDLLocked(name string, inputCols []string, computor
 		}
 	}
 	panic("column " + t.Name + "." + name + " does not exist")
+}
+
+func (t *table) tempColumnMemory(column *column, shards []*storageShard) int64 {
+	var size int64
+	for _, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		shard.mu.RLock()
+		storage := shard.columns[column.Name]
+		if storage != nil {
+			size += int64(storage.ComputeSize())
+		}
+		shard.mu.RUnlock()
+	}
+	return size
 }
 
 func (t *table) ComputeColumn(name string, inputCols []string, computor scm.Scmer, filterCols []string, filter scm.Scmer) {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -176,7 +176,7 @@ func (t *table) tempColumnMemory(column *column, shards []*storageShard) int64 {
 		shard.mu.RLock()
 		storage := shard.columns[column.Name]
 		if storage != nil {
-			size += int64(storage.ComputeSize())
+			size += int64(ownedColumnMemory(storage))
 		}
 		shard.mu.RUnlock()
 	}

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -697,9 +697,30 @@ func (p *StorageComputeProxy) orcCol() *column {
 func (p *StorageComputeProxy) ComputeSize() uint {
 	var sz uint = 128 // struct overhead
 	sz += p.validMask.ComputeSize()
+	p.mu.RLock()
 	sz += uint(len(p.delta)) * 24 // rough estimate per map entry
 	if p.main != nil {
 		sz += p.main.ComputeSize()
+	}
+	p.mu.RUnlock()
+
+	// Session-bound variants are owned by this proxy as well. Snapshot the map
+	// under variantsMu, then measure each variant under its own lock so size
+	// accounting never races lazy materialization or invalidation.
+	p.variantsMu.RLock()
+	variants := make([]*storageComputeVariant, 0, len(p.variants))
+	for _, variant := range p.variants {
+		variants = append(variants, variant)
+	}
+	p.variantsMu.RUnlock()
+	for _, variant := range variants {
+		variant.mu.RLock()
+		sz += 96 + variant.validMask.ComputeSize()
+		sz += uint(len(variant.delta)) * 24
+		if variant.main != nil {
+			sz += variant.main.ComputeSize()
+		}
+		variant.mu.RUnlock()
 	}
 	return sz
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -57,6 +57,11 @@ type database struct {
 	savePanic       any           `json:"-"`
 	schemaDirty     atomic.Bool   `json:"-"`
 	blobRefs        *blobRefState `json:"-"`
+	// persistenceLifecycle prevents cleanup from inspecting generation-private
+	// files between their write and schema publication. Rebuild/repartition take
+	// a read capability; cleanup takes the exclusive capability. Query and DML
+	// paths do not participate.
+	persistenceLifecycle sync.RWMutex `json:"-"`
 
 	// lazy-loading/shared-resource state (not serialized)
 	srState SharedState `json:"-"`
@@ -223,7 +228,9 @@ func RebuildTable(tbl *table, all bool, repartition bool) string {
 		panic("cannot rebuild a stale table handle")
 	}
 
-	result := tbl.schema.rebuild(all, repartition, true, tbl)
+	tbl.schema.persistenceLifecycle.RLock()
+	defer tbl.schema.persistenceLifecycle.RUnlock()
+	result := tbl.schema.rebuildWithLifecycle(all, repartition, true, tbl)
 	errs := append([]string(nil), result.errors...)
 	if len(errs) == 0 {
 		if err := func() (err error) {
@@ -253,7 +260,9 @@ func rebuildDatabases(all bool, repartition bool, includeEphemeral bool) string 
 	var errs []string
 	for _, db := range dbs {
 		func(db *database) {
-			result := db.rebuild(all, repartition, includeEphemeral)
+			db.persistenceLifecycle.RLock()
+			defer db.persistenceLifecycle.RUnlock()
+			result := db.rebuildWithLifecycle(all, repartition, includeEphemeral)
 			if len(result.errors) > 0 {
 				errs = append(errs, result.errors...)
 				return
@@ -533,6 +542,15 @@ func (db *database) ensureLoaded() {
 		// FK enforcement triggers are serializable Procs and persist with the table JSON.
 		// No re-installation needed on load.
 		db.srState = SHARED
+		// Dot-prefixed cache tables are planner-owned and persisted only so a
+		// warm query cache can survive restart. Re-register their table-level
+		// owner after loading; durable internal tables such as .blobs remain
+		// ordinary shard-owned storage.
+		for _, table := range db.tables.GetAll() {
+			if table.isEphemeralQueryTable() {
+				registerCreatedTable(table)
+			}
+		}
 	})
 }
 
@@ -626,6 +644,15 @@ func (db *database) ShowTables() scm.Scmer {
 }
 
 func (db *database) rebuild(all bool, repartition bool, includeEphemeral bool, only ...*table) rebuildDatabaseResult {
+	db.persistenceLifecycle.RLock()
+	defer db.persistenceLifecycle.RUnlock()
+	return db.rebuildWithLifecycle(all, repartition, includeEphemeral, only...)
+}
+
+// rebuildWithLifecycle requires a persistenceLifecycle read capability. The
+// public rebuild paths retain it through schema publication, so cleanup cannot
+// observe generation-private files in the build→publish interval.
+func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphemeral bool, only ...*table) rebuildDatabaseResult {
 	if db.srState == COLD {
 		// do nothing for cold databases; avoid loading during rebuild
 		return rebuildDatabaseResult{}
@@ -1300,7 +1327,7 @@ func (db *database) newTable(name string, pm PersistencyMode) *table {
 func registerCreatedTable(t *table) {
 	// register temp keytable with CacheManager AFTER releasing schemalock
 	// to avoid deadlock: AddItem → run() → evict → keytableCleanup → TryLock(schemalock)
-	if strings.HasPrefix(t.Name, ".") {
+	if t.isEphemeralQueryTable() {
 		schemaName := t.schema.Name
 		GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeTempKeytable, func(ptr any, freedByType *[numEvictableTypes]int64) bool {
 			return keytableCleanup(ptr.(*table), schemaName, freedByType)
@@ -1308,6 +1335,10 @@ func registerCreatedTable(t *table) {
 	} else if t.PersistencyMode == Cache {
 		// Register the initial shard so eviction can reach it before the first rebuild.
 		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+	} else if t.PersistencyMode != Memory {
+		// The initial writable generation owns WAL/delta memory before its first
+		// rebuild just as much as a rebuilt shard does.
+		GlobalCache.AddItem(t.Shards[0], int64(t.Shards[0].ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 }
 

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -20,8 +20,11 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -50,7 +53,8 @@ func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
 // cleanBlobs deletes a blob only when every active persistent shard generation
 // has supplied a valid ownership manifest. The refcount table is operational
 // metadata and can lag after a crash, so it is never proof that deletion is
-// safe. Legacy or incomplete generations make cleanup a conservative no-op.
+// safe. Missing legacy manifests are reconstructed from committed column files;
+// corrupt manifests and all ambiguous I/O failures remain a fail-closed no-op.
 func cleanBlobs(db *database) int {
 	references, complete := activeBlobReferences(db)
 	if !complete {
@@ -82,45 +86,130 @@ func activeBlobReferences(db *database) (map[string]struct{}, bool) {
 				continue
 			}
 			reader := db.persistence.ReadColumn(shard.uuid.String(), blobManifestColumn)
-			if _, failed := reader.(ErrorReader); failed {
+			if readErr, failed := reader.(ErrorReader); failed {
 				reader.Close()
-				return nil, false
-			}
-			scanner := bufio.NewScanner(reader)
-			if !scanner.Scan() || scanner.Text()+"\n" != blobManifestHeader {
-				reader.Close()
-				return nil, false
-			}
-			if !scanner.Scan() {
-				reader.Close()
-				return nil, false
-			}
-			expectedChecksum, err := hex.DecodeString(scanner.Text())
-			if err != nil || len(expectedChecksum) != sha256.Size {
-				reader.Close()
-				return nil, false
-			}
-			hasher := sha256.New()
-			for scanner.Scan() {
-				hash := strings.TrimSpace(scanner.Text())
-				if decoded, err := hex.DecodeString(hash); err != nil || len(decoded) != sha256.Size {
-					reader.Close()
+				if !readErr.Missing() {
 					return nil, false
 				}
-				hasher.Write([]byte(hash + "\n"))
+				legacyReferences, ok := backfillBlobManifest(shard)
+				if !ok {
+					return nil, false
+				}
+				for hash := range legacyReferences {
+					references[hash] = struct{}{}
+				}
+				continue
+			}
+			manifestReferences, ok := readBlobManifest(reader)
+			if !ok {
+				return nil, false
+			}
+			for hash := range manifestReferences {
 				references[hash] = struct{}{}
-			}
-			if err := scanner.Err(); err != nil {
-				reader.Close()
-				return nil, false
-			}
-			reader.Close()
-			if !bytes.Equal(hasher.Sum(nil), expectedChecksum) {
-				return nil, false
 			}
 		}
 	}
 	return references, true
+}
+
+func readBlobManifest(reader io.ReadCloser) (map[string]struct{}, bool) {
+	defer reader.Close()
+	references := make(map[string]struct{})
+	scanner := bufio.NewScanner(reader)
+	if !scanner.Scan() || scanner.Text()+"\n" != blobManifestHeader || !scanner.Scan() {
+		return nil, false
+	}
+	expectedChecksum, err := hex.DecodeString(scanner.Text())
+	if err != nil || len(expectedChecksum) != sha256.Size {
+		return nil, false
+	}
+	hasher := sha256.New()
+	for scanner.Scan() {
+		hash := strings.TrimSpace(scanner.Text())
+		if decoded, err := hex.DecodeString(hash); err != nil || len(decoded) != sha256.Size {
+			return nil, false
+		}
+		hasher.Write([]byte(hash + "\n"))
+		references[hash] = struct{}{}
+	}
+	if scanner.Err() != nil || !bytes.Equal(hasher.Sum(nil), expectedChecksum) {
+		return nil, false
+	}
+	return references, true
+}
+
+// backfillBlobManifest upgrades one legacy active generation without loading
+// blob payloads or forcing a rebuild. It inspects only committed column files,
+// deserializes reference-bearing OverlayBlob/compute-proxy columns, and then
+// publishes the same checksummed manifest used by new generations.
+func backfillBlobManifest(shard *storageShard) (references map[string]struct{}, ok bool) {
+	if shard == nil || shard.t == nil || shard.t.schema == nil {
+		return nil, false
+	}
+	references = make(map[string]struct{})
+	for _, column := range shard.t.Columns {
+		if column.IsTemp {
+			continue
+		}
+		reader := shard.t.schema.persistence.ReadColumn(shard.uuid.String(), column.Name)
+		if readErr, failed := reader.(ErrorReader); failed {
+			reader.Close()
+			if readErr.Missing() {
+				// The ordinary column loader represents an absent committed column
+				// as sparse NULLs, so it cannot own an external blob.
+				continue
+			}
+			return nil, false
+		}
+		var magic uint8
+		if err := binary.Read(reader, binary.LittleEndian, &magic); err != nil {
+			reader.Close()
+			return nil, false
+		}
+		if magic != 31 && magic != 50 {
+			reader.Close()
+			continue
+		}
+		storageType, known := storages[magic]
+		if !known {
+			reader.Close()
+			return nil, false
+		}
+		storage := reflect.New(storageType).Interface().(ColumnStorage)
+		count, decoded := deserializeReferenceStorage(storage, reader)
+		reader.Close()
+		if !decoded {
+			return nil, false
+		}
+		appendColumnBlobReferences(storage, references, count)
+	}
+	if !tryWriteBlobManifestReferences(shard, references) {
+		return nil, false
+	}
+	return references, true
+}
+
+func deserializeReferenceStorage(storage ColumnStorage, reader io.Reader) (count uint32, ok bool) {
+	defer func() {
+		if recover() != nil {
+			count, ok = 0, false
+		}
+	}()
+	decoded := storage.Deserialize(reader)
+	if uint(uint32(decoded)) != decoded {
+		return 0, false
+	}
+	return uint32(decoded), true
+}
+
+func tryWriteBlobManifestReferences(shard *storageShard, references map[string]struct{}) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	writeBlobManifestReferences(shard, references)
+	return true
 }
 
 func writeBlobManifest(shard *storageShard) {
@@ -132,10 +221,41 @@ func writeBlobManifest(shard *storageShard) {
 	}
 	references := make(map[string]struct{})
 	for _, column := range shard.columns {
-		if blobs, ok := column.(*OverlayBlob); ok {
-			blobs.appendBlobReferences(references, shard.main_count)
+		appendColumnBlobReferences(column, references, shard.main_count)
+	}
+	writeBlobManifestReferences(shard, references)
+}
+
+// appendColumnBlobReferences follows persisted storage wrappers. This keeps
+// manifests complete when a computed column compresses to OverlayBlob rather
+// than exposing that overlay as the shard's top-level storage.
+func appendColumnBlobReferences(storage ColumnStorage, references map[string]struct{}, count uint32) {
+	switch typed := storage.(type) {
+	case *OverlayBlob:
+		typed.appendBlobReferences(references, count)
+	case *StorageComputeProxy:
+		typed.mu.RLock()
+		if typed.main != nil {
+			appendColumnBlobReferences(typed.main, references, count)
+		}
+		typed.mu.RUnlock()
+		typed.variantsMu.RLock()
+		variants := make([]*storageComputeVariant, 0, len(typed.variants))
+		for _, variant := range typed.variants {
+			variants = append(variants, variant)
+		}
+		typed.variantsMu.RUnlock()
+		for _, variant := range variants {
+			variant.mu.RLock()
+			if variant.main != nil {
+				appendColumnBlobReferences(variant.main, references, variant.count)
+			}
+			variant.mu.RUnlock()
 		}
 	}
+}
+
+func writeBlobManifestReferences(shard *storageShard, references map[string]struct{}) {
 	hashes := make([]string, 0, len(references))
 	for hash := range references {
 		hashes = append(hashes, hash)

--- a/storage/gc.go
+++ b/storage/gc.go
@@ -17,55 +17,142 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 package storage
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
+	"strings"
 
-	"github.com/launix-de/memcp/scm"
+	"github.com/google/uuid"
 )
 
-// CleanDatabase removes orphaned blob files and shard column/log files for db.
-// Orphaned blobs are those on disk with no entry (or refcount=0) in the .blobs table.
-// Orphaned shard files are those whose UUID-prefix is not in any active shard.
-// Safe to call on a live, loaded database.
+const blobManifestColumn = ".blobrefs-v1"
+
+const blobManifestHeader = "memcp-blob-references-v1\n"
+
+// CleanDatabase removes only disk objects proven unowned by the complete active
+// generation. It serializes against rebuild/repartition publication, but does
+// not stop ordinary queries or DML.
 func CleanDatabase(db *database) (blobsDeleted, shardsDeleted int) {
+	// Startup cleanup runs immediately after the lazy database catalog is
+	// discovered. An unloaded schema is not an empty schema: load its committed
+	// topology before proving that any disk object is unowned.
+	db.ensureLoaded()
+	db.persistenceLifecycle.Lock()
+	defer db.persistenceLifecycle.Unlock()
 	blobsDeleted = cleanBlobs(db)
 	shardsDeleted = cleanShards(db)
 	return
 }
 
-// cleanBlobs deletes blob files that are not referenced in the .blobs table.
-// IncrBlobRefcount is always called BEFORE WriteBlob, and the per-hash lock
-// prevents cleanup from racing a missing-row insert or final decrement.
-// Queries the .blobs table per blob file instead of building an in-memory map.
+// cleanBlobs deletes a blob only when every active persistent shard generation
+// has supplied a valid ownership manifest. The refcount table is operational
+// metadata and can lag after a crash, so it is never proof that deletion is
+// safe. Legacy or incomplete generations make cleanup a conservative no-op.
 func cleanBlobs(db *database) int {
-	bt := db.GetTable(".blobs")
-	if bt == nil {
+	references, complete := activeBlobReferences(db)
+	if !complete {
 		return 0
 	}
-	aggr := sumProc()
 
-	// Walk disk blobs one by one; check refcount via scan on .blobs table.
 	deleted := 0
 	db.persistence.WalkBlobs(func(hash string) error {
 		defer db.lockBlobRef(hash)()
-		state := db.blobRefState()
-		state.rows.RLock()
-		defer state.rows.RUnlock()
-		hashVal := scm.NewString(hash)
-		// scan .blobs WHERE hash = <hash>, sum refcount
-		rc := bt.scan(
-			nil,
-			[]string{"hash"}, blobCondition(hashVal),
-			[]string{"refcount"},
-			scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[0] }),
-			aggr, scm.NewInt(0), aggr, false,
-		)
-		if scm.ToInt(rc) <= 0 {
+		if _, live := references[hash]; !live {
 			db.persistence.DeleteBlob(hash)
 			deleted++
 		}
 		return nil
 	})
 	return deleted
+}
+
+func activeBlobReferences(db *database) (map[string]struct{}, bool) {
+	db.schemalock.RLock()
+	defer db.schemalock.RUnlock()
+	references := make(map[string]struct{})
+	for _, table := range db.tables.GetAll() {
+		if table.Name == ".blobs" || table.PersistencyMode == Memory || table.PersistencyMode == Cache {
+			continue
+		}
+		for _, shard := range table.ActiveShards() {
+			if shard == nil {
+				continue
+			}
+			reader := db.persistence.ReadColumn(shard.uuid.String(), blobManifestColumn)
+			if _, failed := reader.(ErrorReader); failed {
+				reader.Close()
+				return nil, false
+			}
+			scanner := bufio.NewScanner(reader)
+			if !scanner.Scan() || scanner.Text()+"\n" != blobManifestHeader {
+				reader.Close()
+				return nil, false
+			}
+			if !scanner.Scan() {
+				reader.Close()
+				return nil, false
+			}
+			expectedChecksum, err := hex.DecodeString(scanner.Text())
+			if err != nil || len(expectedChecksum) != sha256.Size {
+				reader.Close()
+				return nil, false
+			}
+			hasher := sha256.New()
+			for scanner.Scan() {
+				hash := strings.TrimSpace(scanner.Text())
+				if decoded, err := hex.DecodeString(hash); err != nil || len(decoded) != sha256.Size {
+					reader.Close()
+					return nil, false
+				}
+				hasher.Write([]byte(hash + "\n"))
+				references[hash] = struct{}{}
+			}
+			if err := scanner.Err(); err != nil {
+				reader.Close()
+				return nil, false
+			}
+			reader.Close()
+			if !bytes.Equal(hasher.Sum(nil), expectedChecksum) {
+				return nil, false
+			}
+		}
+	}
+	return references, true
+}
+
+func writeBlobManifest(shard *storageShard) {
+	if shard == nil || shard.t == nil || shard.t.schema == nil || shard.uuid == uuid.Nil {
+		return
+	}
+	if shard.t.PersistencyMode == Memory || shard.t.PersistencyMode == Cache || shard.t.Name == ".blobs" {
+		return
+	}
+	references := make(map[string]struct{})
+	for _, column := range shard.columns {
+		if blobs, ok := column.(*OverlayBlob); ok {
+			blobs.appendBlobReferences(references, shard.main_count)
+		}
+	}
+	hashes := make([]string, 0, len(references))
+	for hash := range references {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+	body := ""
+	if len(hashes) > 0 {
+		body = strings.Join(hashes, "\n") + "\n"
+	}
+	checksum := sha256.Sum256([]byte(body))
+	writer := shard.t.schema.persistence.WriteColumn(shard.uuid.String(), blobManifestColumn)
+	manifest := blobManifestHeader + hex.EncodeToString(checksum[:]) + "\n" + body
+	if _, err := writer.Write([]byte(manifest)); err != nil {
+		_ = writer.Close()
+		panic(err)
+	}
+	finishColumnWrite(writer, shard.t.PersistencyMode == Safe)
 }
 
 // cleanShards deletes shard column/log files whose UUID is not in any active shard.

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/launix-de/memcp/scm"
 )
@@ -41,6 +42,31 @@ func setupGCTest(t *testing.T) func() {
 		databases.Remove("gcdb")
 		Basepath = oldBasepath
 		os.RemoveAll(dir)
+	}
+}
+
+func TestCleanDatabaseWaitsForGenerationPublication(t *testing.T) {
+	defer setupGCTest(t)()
+	CreateDatabase("gcdb", false)
+	db := GetDatabase("gcdb")
+
+	db.persistenceLifecycle.RLock()
+	done := make(chan struct{})
+	go func() {
+		CleanDatabase(db)
+		close(done)
+	}()
+	select {
+	case <-done:
+		db.persistenceLifecycle.RUnlock()
+		t.Fatal("cleanup entered while an unpublished generation was active")
+	case <-time.After(25 * time.Millisecond):
+	}
+	db.persistenceLifecycle.RUnlock()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not resume after generation publication")
 	}
 }
 
@@ -163,6 +189,141 @@ func TestCleanOrphanedBlob(t *testing.T) {
 		scm.NewNil(), scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[1] }), false)
 	if count != 3 {
 		t.Errorf("expected 3 rows after GC, got %d", count)
+	}
+}
+
+// TestCleanBlobsRequiresCompleteActiveManifests verifies the conservative
+// deletion contract: a blob is garbage only when every active shard generation
+// has proved its references. A missing manifest must turn cleanup into a no-op,
+// never into a best-effort deletion based on secondary refcount metadata.
+func TestCleanBlobsRequiresCompleteActiveManifests(t *testing.T) {
+	defer setupGCTest(t)()
+
+	CreateDatabase("gcdb", false)
+	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("content", "TEXT", nil, nil)
+	insertLongRows(t, tbl, []string{
+		strings.Repeat("m", maxInlineBlobBytes+1),
+		strings.Repeat("n", maxInlineBlobBytes+1),
+		strings.Repeat("o", maxInlineBlobBytes+1),
+	})
+
+	shards := tbl.ActiveShards()
+	if len(shards) == 0 || shards[0] == nil {
+		t.Fatal("expected an active shard")
+	}
+	tbl.schema.persistence.RemoveColumn(shards[0].uuid.String(), blobManifestColumn)
+
+	orphanHash := "feedfacefeedfacefeedfacefeedface"
+	orphanPath := filepath.Join(Basepath, "gcdb", "blob", orphanHash[:2], orphanHash[2:4])
+	if err := os.MkdirAll(orphanPath, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("orphan"), 0640); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, _ := CleanDatabase(tbl.schema)
+	if deleted != 0 {
+		t.Fatalf("cleanup deleted %d blobs without a complete active manifest", deleted)
+	}
+	if _, err := os.Stat(filepath.Join(orphanPath, orphanHash)); err != nil {
+		t.Fatalf("unproven blob was removed: %v", err)
+	}
+}
+
+func TestStartupCleanLoadsColdSchemaBeforeBlobDeletion(t *testing.T) {
+	defer setupGCTest(t)()
+
+	CreateDatabase("gcdb", false)
+	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("content", "TEXT", nil, nil)
+	insertLongRows(t, tbl, []string{
+		strings.Repeat("c", maxInlineBlobBytes+1),
+		strings.Repeat("d", maxInlineBlobBytes+1),
+		strings.Repeat("e", maxInlineBlobBytes+1),
+	})
+	wantBlobs := len(blobFiles(t, "gcdb"))
+	if wantBlobs == 0 {
+		t.Fatal("expected external blob fixture")
+	}
+
+	databases.Remove("gcdb")
+	LoadDatabases()
+	cold := GetDatabase("gcdb")
+	if cold == nil || cold.srState != COLD {
+		t.Fatal("expected lazily loaded database after catalog discovery")
+	}
+	deleted, _ := CleanDatabase(cold)
+	if deleted != 0 {
+		t.Fatalf("startup cleanup deleted %d live blobs from a cold schema", deleted)
+	}
+	if got := len(blobFiles(t, "gcdb")); got != wantBlobs {
+		t.Fatalf("live blob count after startup cleanup = %d, want %d", got, wantBlobs)
+	}
+}
+
+func TestCleanBlobsRejectsCorruptManifest(t *testing.T) {
+	defer setupGCTest(t)()
+
+	CreateDatabase("gcdb", false)
+	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("content", "TEXT", nil, nil)
+	insertLongRows(t, tbl, []string{
+		strings.Repeat("p", maxInlineBlobBytes+1),
+		strings.Repeat("q", maxInlineBlobBytes+1),
+		strings.Repeat("r", maxInlineBlobBytes+1),
+	})
+	shard := tbl.ActiveShards()[0]
+	writer := tbl.schema.persistence.WriteColumn(shard.uuid.String(), blobManifestColumn)
+	if _, err := writer.Write([]byte(blobManifestHeader + strings.Repeat("0", 64) + "\n" + strings.Repeat("f", 64) + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanHash := "01230123012301230123012301230123"
+	orphanPath := filepath.Join(Basepath, "gcdb", "blob", orphanHash[:2], orphanHash[2:4])
+	if err := os.MkdirAll(orphanPath, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("orphan"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	deleted, _ := CleanDatabase(tbl.schema)
+	if deleted != 0 {
+		t.Fatalf("cleanup trusted a corrupt manifest and deleted %d blobs", deleted)
+	}
+}
+
+func TestRepartitionPublishesBlobManifests(t *testing.T) {
+	defer setupGCTest(t)()
+
+	CreateDatabase("gcdb", false)
+	tbl, _ := CreateTable("gcdb", "docs", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("content", "TEXT", nil, nil)
+	insertLongRows(t, tbl, []string{
+		strings.Repeat("s", maxInlineBlobBytes+1),
+		strings.Repeat("t", maxInlineBlobBytes+1),
+		strings.Repeat("u", maxInlineBlobBytes+1),
+		strings.Repeat("v", maxInlineBlobBytes+1),
+	})
+	if !tbl.beginManualRepartition() {
+		t.Fatal("could not claim repartition")
+	}
+	tbl.repartition([]shardDimension{tbl.NewShardDimension("id", 2)})
+	for _, shard := range tbl.ActiveShards() {
+		reader := tbl.schema.persistence.ReadColumn(shard.uuid.String(), blobManifestColumn)
+		if _, failed := reader.(ErrorReader); failed {
+			reader.Close()
+			t.Fatalf("repartitioned shard %s has no blob manifest", shard.uuid)
+		}
+		reader.Close()
 	}
 }
 

--- a/storage/gc_test.go
+++ b/storage/gc_test.go
@@ -192,11 +192,11 @@ func TestCleanOrphanedBlob(t *testing.T) {
 	}
 }
 
-// TestCleanBlobsRequiresCompleteActiveManifests verifies the conservative
-// deletion contract: a blob is garbage only when every active shard generation
-// has proved its references. A missing manifest must turn cleanup into a no-op,
-// never into a best-effort deletion based on secondary refcount metadata.
-func TestCleanBlobsRequiresCompleteActiveManifests(t *testing.T) {
+// TestCleanBlobsBackfillsMissingLegacyManifest verifies the upgrade path: a
+// legacy active generation is proven from its committed columns before cleanup
+// proceeds. Live blobs survive, the new manifest is durable, and only then may
+// an orphan be deleted.
+func TestCleanBlobsBackfillsMissingLegacyManifest(t *testing.T) {
 	defer setupGCTest(t)()
 
 	CreateDatabase("gcdb", false)
@@ -225,11 +225,22 @@ func TestCleanBlobsRequiresCompleteActiveManifests(t *testing.T) {
 	}
 
 	deleted, _ := CleanDatabase(tbl.schema)
-	if deleted != 0 {
-		t.Fatalf("cleanup deleted %d blobs without a complete active manifest", deleted)
+	if deleted != 1 {
+		t.Fatalf("cleanup deleted %d blobs after legacy backfill, want 1 orphan", deleted)
 	}
-	if _, err := os.Stat(filepath.Join(orphanPath, orphanHash)); err != nil {
-		t.Fatalf("unproven blob was removed: %v", err)
+	if _, err := os.Stat(filepath.Join(orphanPath, orphanHash)); !os.IsNotExist(err) {
+		t.Fatalf("orphan survived completed legacy proof: %v", err)
+	}
+	reader := tbl.schema.persistence.ReadColumn(shards[0].uuid.String(), blobManifestColumn)
+	if _, failed := reader.(ErrorReader); failed {
+		reader.Close()
+		t.Fatal("legacy manifest was not persisted")
+	}
+	if _, valid := readBlobManifest(reader); !valid {
+		t.Fatal("backfilled manifest is invalid")
+	}
+	if got := len(blobFiles(t, "gcdb")); got != 3 {
+		t.Fatalf("live blob count after legacy backfill = %d, want 3", got)
 	}
 }
 
@@ -250,6 +261,18 @@ func TestStartupCleanLoadsColdSchemaBeforeBlobDeletion(t *testing.T) {
 		t.Fatal("expected external blob fixture")
 	}
 
+	for _, shard := range tbl.ActiveShards() {
+		tbl.schema.persistence.RemoveColumn(shard.uuid.String(), blobManifestColumn)
+	}
+	orphanHash := "cabba9ecabba9ecabba9ecabba9ecabb"
+	orphanPath := filepath.Join(Basepath, "gcdb", "blob", orphanHash[:2], orphanHash[2:4])
+	if err := os.MkdirAll(orphanPath, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanPath, orphanHash), []byte("orphan"), 0640); err != nil {
+		t.Fatal(err)
+	}
+
 	databases.Remove("gcdb")
 	LoadDatabases()
 	cold := GetDatabase("gcdb")
@@ -257,8 +280,8 @@ func TestStartupCleanLoadsColdSchemaBeforeBlobDeletion(t *testing.T) {
 		t.Fatal("expected lazily loaded database after catalog discovery")
 	}
 	deleted, _ := CleanDatabase(cold)
-	if deleted != 0 {
-		t.Fatalf("startup cleanup deleted %d live blobs from a cold schema", deleted)
+	if deleted != 1 {
+		t.Fatalf("startup cleanup deleted %d blobs, want only the legacy orphan", deleted)
 	}
 	if got := len(blobFiles(t, "gcdb")); got != wantBlobs {
 		t.Fatalf("live blob count after startup cleanup = %d, want %d", got, wantBlobs)
@@ -324,6 +347,18 @@ func TestRepartitionPublishesBlobManifests(t *testing.T) {
 			t.Fatalf("repartitioned shard %s has no blob manifest", shard.uuid)
 		}
 		reader.Close()
+	}
+}
+
+func TestBlobManifestFollowsComputedStorageWrappers(t *testing.T) {
+	marker := "!0123456789abcdef0123456789abcdef"
+	blob := &OverlayBlob{Base: &StorageConst{value: scm.NewString(marker), count: 1}}
+	proxy := &StorageComputeProxy{main: blob, compressed: true, count: 1, delta: make(map[uint32]scm.Scmer)}
+	references := make(map[string]struct{})
+	appendColumnBlobReferences(proxy, references, 1)
+	want := "3031323334353637383961626364656630313233343536373839616263646566"
+	if _, ok := references[want]; !ok || len(references) != 1 {
+		t.Fatalf("nested computed blob references = %v, want only %s", references, want)
 	}
 }
 

--- a/storage/memory_ownership_test.go
+++ b/storage/memory_ownership_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func TestPersistedInternalTableIsNotRegisteredAsTempKeytable(t *testing.T) {
+	defer setupGCTest(t)()
+
+	CreateDatabase("gcdb", false)
+	db := GetDatabase("gcdb")
+	before := GlobalCache.Stat()
+	blobs := db.ensureBlobTable()
+	after := GlobalCache.Stat()
+	defer func() {
+		GlobalCache.Remove(blobs)
+		for _, shard := range blobs.ActiveShards() {
+			GlobalCache.Remove(shard)
+		}
+	}()
+
+	if after.CountByType[TypeTempKeytable] != before.CountByType[TypeTempKeytable] {
+		t.Fatalf("persisted internal table registered as temp keytable: before=%d after=%d",
+			before.CountByType[TypeTempKeytable], after.CountByType[TypeTempKeytable])
+	}
+	if after.CountByType[TypeShard] != before.CountByType[TypeShard]+1 {
+		t.Fatalf("persisted internal shard has no durable owner: before=%d after=%d",
+			before.CountByType[TypeShard], after.CountByType[TypeShard])
+	}
+}
+
+func TestShardMemoryExcludesSeparatelyOwnedTempColumn(t *testing.T) {
+	table := &table{Columns: []*column{
+		{Name: "base"},
+		{Name: "cached", IsTemp: true},
+	}}
+	shard := &storageShard{
+		t:            table,
+		columns:      map[string]ColumnStorage{"base": &StorageConst{value: scm.NewInt(1), count: 1}},
+		deltaColumns: make(map[string]int),
+		srState:      SHARED,
+	}
+	before := shard.ComputeSize()
+	shard.columns["cached"] = &StorageConst{value: scm.NewString("separately-owned"), count: 1}
+	after := shard.ComputeSize()
+	if after != before {
+		t.Fatalf("shard owns separately accounted temp-column bytes: before=%d after=%d", before, after)
+	}
+}
+
+func TestShardMemoryExcludesMaterializedCompressedDictionary(t *testing.T) {
+	strings := &StorageString{
+		compressedDict: []byte("compressed"),
+		compressed:     true,
+	}
+	shard := &storageShard{
+		columns:      map[string]ColumnStorage{"value": strings},
+		deltaColumns: make(map[string]int),
+		srState:      SHARED,
+	}
+	before := shard.ComputeSize()
+	strings.dictionary = "materialized-dictionary"
+	if after := shard.ComputeSize(); after != before {
+		t.Fatalf("shard size grew with separately owned dictionary: before=%d after=%d", before, after)
+	}
+}
+
+func TestShardMemoryExcludesSeparatelyOwnedIndex(t *testing.T) {
+	shard := &storageShard{
+		columns:      make(map[string]ColumnStorage),
+		deltaColumns: make(map[string]int),
+		srState:      SHARED,
+	}
+	before := shard.ComputeSize()
+	idx := &StorageIndex{}
+	idx.baseState.mainIndexes.initValuesUInt32(1024, 0, 1023)
+	shard.Indexes = []*StorageIndex{idx}
+	after := shard.ComputeSize()
+	if after != before {
+		t.Fatalf("shard owns separately accounted index bytes: before=%d after=%d index=%d",
+			before, after, idx.ComputeSize())
+	}
+}
+
+func TestCacheManagerSetSizeIsAbsolute(t *testing.T) {
+	manager := new(CacheManager)
+	manager.Init(0, 0)
+	defer manager.Stop()
+
+	pointer := new(int)
+	manager.AddItem(pointer, 10, TypeCacheEntry,
+		func(any, *[numEvictableTypes]int64) bool { return true },
+		func(any) time.Time { return time.Time{} }, nil)
+	manager.SetSize(pointer, 25)
+	manager.SetSize(pointer, 25)
+	stat := manager.Stat()
+	if stat.CurrentMemory != 25 {
+		t.Fatalf("absolute size update accumulated: got %d want 25", stat.CurrentMemory)
+	}
+}
+
+func TestScmerCustomHandleDoesNotClaimOwnedPayload(t *testing.T) {
+	// Custom handles are non-owning pointers. Their payload belongs to a table,
+	// RecSet, or another explicitly accounted owner and must not be traversed by
+	// generic AST/cache accounting.
+	tbl := new(table)
+	if got := scm.ComputeSize(NewTableScmer(tbl)); got != 16 {
+		t.Fatalf("custom handle size = %d, want one Scmer slot", got)
+	}
+}
+
+func TestComputeProxySizeIncludesSessionVariants(t *testing.T) {
+	proxy := &StorageComputeProxy{
+		delta:    make(map[uint32]scm.Scmer),
+		variants: make(map[string]*storageComputeVariant),
+	}
+	before := proxy.ComputeSize()
+	variant := newStorageComputeVariant(1)
+	variant.delta[0] = scm.NewString("variant-owned-value")
+	proxy.variants["tenant"] = variant
+	after := proxy.ComputeSize()
+	if after <= before {
+		t.Fatalf("session variant is absent from proxy ownership: before=%d after=%d", before, after)
+	}
+}

--- a/storage/memory_ownership_test.go
+++ b/storage/memory_ownership_test.go
@@ -84,6 +84,26 @@ func TestShardMemoryExcludesMaterializedCompressedDictionary(t *testing.T) {
 	}
 }
 
+func TestOwnedMemoryExcludesNestedMaterializedDictionaries(t *testing.T) {
+	base := &StorageString{compressedDict: []byte("compressed"), compressed: true}
+	blob := &OverlayBlob{Base: base}
+	before := ownedColumnMemory(blob)
+	base.dictionary = "materialized-under-blob"
+	if after := ownedColumnMemory(blob); after != before {
+		t.Fatalf("blob owner includes separately weighted nested dictionary: before=%d after=%d", before, after)
+	}
+
+	prefix := &StoragePrefix{values: StorageString{compressed: true, dictionary: "materialized-under-prefix"}}
+	if got, want := materializedDictionaryMemory(prefix), uint(len(prefix.values.dictionary)); got != want {
+		t.Fatalf("nested prefix dictionary ownership = %d, want %d", got, want)
+	}
+
+	proxy := &StorageComputeProxy{main: base, delta: make(map[uint32]scm.Scmer)}
+	if got, want := materializedDictionaryMemory(proxy), uint(len(base.dictionary)); got != want {
+		t.Fatalf("nested compute-proxy dictionary ownership = %d, want %d", got, want)
+	}
+}
+
 func TestShardMemoryExcludesSeparatelyOwnedIndex(t *testing.T) {
 	shard := &storageShard{
 		columns:      make(map[string]ColumnStorage),
@@ -115,6 +135,13 @@ func TestCacheManagerSetSizeIsAbsolute(t *testing.T) {
 	stat := manager.Stat()
 	if stat.CurrentMemory != 25 {
 		t.Fatalf("absolute size update accumulated: got %d want 25", stat.CurrentMemory)
+	}
+}
+
+func TestDisjointOwnershipDoesNotChangeEvictionWeights(t *testing.T) {
+	want := [numEvictableTypes]int64{20, 1, 20, 2, 20, 20}
+	if evictableWeights != want {
+		t.Fatalf("eviction weights changed with accounting ownership: got %v want %v", evictableWeights, want)
 	}
 }
 

--- a/storage/overlay-blob.go
+++ b/storage/overlay-blob.go
@@ -330,6 +330,28 @@ func (s *OverlayBlob) finish() {
 	}
 	s.Base.finish()
 }
+
+// appendBlobReferences adds the content-addressed objects owned by this column
+// generation. References are generation metadata: cleanup may delete a blob
+// only after every active generation supplied this proof.
+func (s *OverlayBlob) appendBlobReferences(dst map[string]struct{}, count uint32) {
+	if len(s.refs) > 0 {
+		for hash := range s.refs {
+			dst[hash] = struct{}{}
+		}
+		return
+	}
+	for i := uint32(0); i < count; i++ {
+		value := s.Base.GetValue(i)
+		if !value.IsString() {
+			continue
+		}
+		raw := value.String()
+		if len(raw) == 33 && raw[0] == '!' && raw[1] != '!' {
+			dst[fmt.Sprintf("%x", []byte(raw[1:]))] = struct{}{}
+		}
+	}
+}
 func (s *OverlayBlob) proposeCompression(i uint32) ColumnStorage {
 	// dont't propose another pass
 	return nil

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -542,6 +542,8 @@ func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimen
 // before invoking repartition). It manages its own shard-level locking.
 // maintenanceMu is already held and maintenanceKind is set to 2 by the caller.
 func (t *table) repartition(shardCandidates []shardDimension) {
+	t.schema.persistenceLifecycle.RLock()
+	defer t.schema.persistenceLifecycle.RUnlock()
 	t.ddlMu.RLock()
 	defer t.ddlMu.RUnlock()
 	t.repartitionDDLReadLocked(shardCandidates)
@@ -957,6 +959,11 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	for i, built := range builtData {
 		mainCounts[i] = built.mainCount
 	}
+	// Blob ownership belongs to the unpublished shard generation. Persist its
+	// manifest before schema.json can make that generation authoritative.
+	for _, shard := range newshards {
+		writeBlobManifest(shard)
+	}
 	applyPendingDeletes := func() int {
 		t.repartitionPendingMu.Lock()
 		pending := t.repartitionPendingDels
@@ -1157,7 +1164,12 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 			s.RemoveFromDisk()
 		}
 
-		if t.PersistencyMode != Memory && !strings.HasPrefix(t.Name, ".") {
+		if t.PersistencyMode == Cache && !t.isEphemeralQueryTable() {
+			for _, s := range newshards {
+				atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
+				GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
+			}
+		} else if t.PersistencyMode != Memory && !t.isEphemeralQueryTable() {
 			for _, s := range newshards {
 				atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 				GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)

--- a/storage/persistence-ceph.go
+++ b/storage/persistence-ceph.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/carli2/hybridsort"
 	"io"
@@ -171,12 +172,12 @@ func (s *CephStorage) ReadColumn(shard string, column string) io.ReadCloser {
 	// If you want streaming, you'd need chunked reads; for now columns are usually loaded fully anyway.
 	stat, err := s.ioctx.Stat(obj)
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	data := make([]byte, stat.Size)
 	n, err := s.ioctx.Read(obj, data, 0)
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	return io.NopCloser(bytes.NewReader(data[:n]))
 }
@@ -223,12 +224,12 @@ func (s *CephStorage) ReadBlob(hash string) io.ReadCloser {
 	obj := s.obj("blob/" + hash)
 	stat, err := s.ioctx.Stat(obj)
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	data := make([]byte, stat.Size)
 	n, err := s.ioctx.Read(obj, data, 0)
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: errors.Is(err, rados.ErrNotFound)}
 	}
 	return io.NopCloser(bytes.NewReader(data[:n]))
 }

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -164,12 +164,46 @@ func (s *FileStorage) ReadBlob(hash string) io.ReadCloser {
 
 func (s *FileStorage) WriteBlob(hash string) io.WriteCloser {
 	p := s.blobPath(hash)
-	os.MkdirAll(p[:strings.LastIndex(p, "/")], 0750)
-	f, err := os.Create(p)
+	dir := p[:strings.LastIndex(p, "/")]
+	os.MkdirAll(dir, 0750)
+	f, err := os.CreateTemp(dir, ".blob-write-")
 	if err != nil {
 		panic(err)
 	}
-	return f
+	return &fileBlobWriter{File: f, finalPath: p, directory: dir}
+}
+
+// fileBlobWriter publishes a content-addressed blob only after the complete
+// payload is durable. Linking is a no-replace operation: concurrent writers of
+// the same hash keep the first complete object instead of truncating it.
+type fileBlobWriter struct {
+	*os.File
+	finalPath string
+	directory string
+}
+
+func (w *fileBlobWriter) Close() error {
+	if err := w.File.Sync(); err != nil {
+		w.File.Close()
+		os.Remove(w.File.Name())
+		return err
+	}
+	if err := w.File.Close(); err != nil {
+		os.Remove(w.File.Name())
+		return err
+	}
+	err := os.Link(w.File.Name(), w.finalPath)
+	if err != nil && !os.IsExist(err) {
+		os.Remove(w.File.Name())
+		return err
+	}
+	os.Remove(w.File.Name())
+	dir, err := os.Open(w.directory)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
 }
 
 func (s *FileStorage) DeleteBlob(hash string) {
@@ -180,6 +214,9 @@ func (s *FileStorage) WalkBlobs(fn func(hash string) error) error {
 	return filepath.Walk(s.path+"blob/", func(p string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return err
+		}
+		if strings.HasPrefix(info.Name(), ".blob-write-") {
+			return nil
 		}
 		return fn(info.Name())
 	})

--- a/storage/persistence-files.go
+++ b/storage/persistence-files.go
@@ -129,7 +129,7 @@ func (s *FileStorage) ReadColumn(shard string, column string) io.ReadCloser {
 	f, err := os.Open(s.path + shard + "-" + ProcessColumnName(column))
 	if err != nil {
 		// file does not exist -> no data available
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: os.IsNotExist(err)}
 	}
 	return f
 }
@@ -157,7 +157,7 @@ func (s *FileStorage) blobPath(hash string) string {
 func (s *FileStorage) ReadBlob(hash string) io.ReadCloser {
 	f, err := os.Open(s.blobPath(hash))
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: os.IsNotExist(err)}
 	}
 	return f
 }

--- a/storage/persistence-s3.go
+++ b/storage/persistence-s3.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/carli2/hybridsort"
 	"io"
@@ -33,8 +34,21 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 	"github.com/launix-de/memcp/scm"
 )
+
+func s3ObjectMissing(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NoSuchKey", "NotFound", "NoSuchObject":
+		return true
+	}
+	return false
+}
 
 func init() {
 	BackendRegistry["s3"] = func(dbName string, raw json.RawMessage) PersistenceEngine {
@@ -203,7 +217,7 @@ func (s *S3Storage) ReadColumn(shard string, column string) io.ReadCloser {
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: s3ObjectMissing(err)}
 	}
 	return resp.Body
 }
@@ -259,7 +273,7 @@ func (s *S3Storage) ReadBlob(hash string) io.ReadCloser {
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return ErrorReader{err}
+		return ErrorReader{e: err, notFound: s3ObjectMissing(err)}
 	}
 	return resp.Body
 }

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -128,8 +128,14 @@ func MoveDatabase(src PersistenceEngine, dst PersistenceEngine) {
 
 // ErrorReader implements io.ReadCloser
 type ErrorReader struct {
-	e error
+	e        error
+	notFound bool
 }
+
+// Missing reports whether the backend proved that the requested object does
+// not exist. Callers must not equate arbitrary read failures with absence:
+// doing so could turn a transient backend outage into destructive cleanup.
+func (e ErrorReader) Missing() bool { return e.notFound }
 
 func (e ErrorReader) Read([]byte) (int, error) {
 	// reflects the error (e.g. file not found)

--- a/storage/persistence_blob_test.go
+++ b/storage/persistence_blob_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestFileBlobWriteDoesNotExposePartialReplacement(t *testing.T) {
+	dir := t.TempDir()
+	store := &FileStorage{path: dir + "/"}
+	hash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	first := store.WriteBlob(hash)
+	if _, err := io.WriteString(first, "published"); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	interrupted := store.WriteBlob(hash)
+	if _, err := io.WriteString(interrupted, "partial"); err != nil {
+		t.Fatal(err)
+	}
+	// Before Close publishes the new generation, readers must still see the
+	// complete content-addressed object which was already present.
+	reader := store.ReadBlob(hash)
+	got, err := io.ReadAll(reader)
+	reader.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "published" {
+		t.Fatalf("partial blob write became visible: got %q", got)
+	}
+	if err := interrupted.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = os.ReadFile(filepath.Clean(store.blobPath(hash)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "published" {
+		t.Fatalf("content-addressed blob was overwritten: got %q", got)
+	}
+}
+
+func TestConcurrentFileBlobWritersPublishOneCompleteObject(t *testing.T) {
+	dir := t.TempDir()
+	store := &FileStorage{path: dir + "/"}
+	hash := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	payloads := []string{"complete-left", "complete-right"}
+	var ready sync.WaitGroup
+	ready.Add(len(payloads))
+	release := make(chan struct{})
+	var writers sync.WaitGroup
+	for _, payload := range payloads {
+		writers.Add(1)
+		go func(payload string) {
+			defer writers.Done()
+			writer := store.WriteBlob(hash)
+			if _, err := io.WriteString(writer, payload); err != nil {
+				t.Errorf("write blob: %v", err)
+				return
+			}
+			ready.Done()
+			<-release
+			if err := writer.Close(); err != nil {
+				t.Errorf("close blob: %v", err)
+			}
+		}(payload)
+	}
+	ready.Wait()
+	close(release)
+	writers.Wait()
+	got, err := os.ReadFile(store.blobPath(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payloads[0] && string(got) != payloads[1] {
+		t.Fatalf("published partial/interleaved blob %q", got)
+	}
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -274,16 +274,13 @@ func (s *storageShard) recordNextInsertRange(oldStartRecid, newStartRecid uint32
 func (s *storageShard) computeSizeLocked() uint {
 	var result uint = 14*8 + 32*8 // heuristic for columns map
 	if s.srState != COLD {
-		for _, c := range s.columns {
-			if c != nil {
-				result += c.ComputeSize()
+		for name, c := range s.columns {
+			if c != nil && s.ownsColumnMemory(name) {
+				result += ownedColumnMemory(c)
 			}
 		}
 		result += s.deletions.ComputeSize()
 		result += scm.ComputeSize(scm.NewAny(s.inserts))
-		for _, idx := range s.Indexes {
-			result += idx.ComputeSize()
-		}
 		return result
 	}
 	result += s.deletions.ComputeSize()
@@ -292,28 +289,37 @@ func (s *storageShard) computeSizeLocked() uint {
 }
 
 func (s *storageShard) ComputeSize() uint {
-	var result uint = 14*8 + 32*8 // heuristic for columns map
-	if s.srState != COLD {
-		s.mu.RLock()
-		for _, c := range s.columns {
-			if c != nil {
-				result += c.ComputeSize()
-			}
-		}
-		s.mu.RUnlock()
-		result += s.deletions.ComputeSize()
-		result += scm.ComputeSize(scm.NewAny(s.inserts))
-		for _, idx := range s.Indexes {
-			result += idx.ComputeSize()
-		}
-		return result
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.computeSizeLocked()
+}
+
+func (s *storageShard) ownsColumnMemory(name string) bool {
+	if s.t == nil {
+		return true
 	}
-	result += s.deletions.ComputeSize()
-	result += scm.ComputeSize(scm.NewAny(s.inserts))
-	for _, idx := range s.Indexes {
-		result += idx.ComputeSize()
+	for _, column := range s.t.Columns {
+		if column.Name == name {
+			return !column.IsTemp
+		}
 	}
-	return result
+	return true
+}
+
+// ownedColumnMemory excludes child allocations which have their own cache
+// registration. The column object still reports its complete diagnostic size;
+// ownership is resolved only where the shard total is assembled.
+func ownedColumnMemory(storage ColumnStorage) uint {
+	size := storage.ComputeSize()
+	if strings, ok := storage.(*StorageString); ok && strings.compressed {
+		strings.dictMu.RLock()
+		materialized := uint(len(strings.dictionary))
+		strings.dictMu.RUnlock()
+		if materialized <= size {
+			size -= materialized
+		}
+	}
+	return size
 }
 
 type shardStatsSnapshot struct {
@@ -756,9 +762,9 @@ func (s *storageShard) ensureLoaded() {
 	s.mu.Unlock()
 	atomic.StoreUint64(&s.lastAccessed, uint64(time.Now().UnixNano()))
 	// register with CacheManager (skip Memory-engine shards and temp tables)
-	if s.t.PersistencyMode == Cache && !strings.HasPrefix(s.t.Name, ".") {
+	if s.t.PersistencyMode == Cache && !s.t.isEphemeralQueryTable() {
 		GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
-	} else if s.t.PersistencyMode != Memory && !strings.HasPrefix(s.t.Name, ".") {
+	} else if s.t.PersistencyMode != Memory && !s.t.isEphemeralQueryTable() {
 		GlobalCache.AddItem(s, int64(s.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 }
@@ -779,6 +785,10 @@ func shardCleanup(ptr any, freedByType *[numEvictableTypes]int64) bool {
 	if len(s.inserts) > 0 || s.deletions.Count() > 0 {
 		s.mu.Unlock()
 		return false // has unflushed deltas, skip eviction (rebuild will flush them)
+	}
+	if s.logfile != nil {
+		s.logfile.Close()
+		s.logfile = nil
 	}
 	// remove indexes from CacheManager (recursive free)
 	for _, idx := range s.Indexes {
@@ -2461,6 +2471,8 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 		onFirstInsertId = nil
 	}
 
+	var insertedBytes int64
+	indexDeltaBytes := make(map[*StorageIndex]int64)
 	for _, row := range values {
 		newrow := make([]scm.Scmer, len(t.deltaColumns))
 		for _, c := range t.t.Columns {
@@ -2485,6 +2497,7 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 			}
 		}
 		t.inserts = append(t.inserts, newrow)
+		insertedBytes += int64(scm.ComputeSize(scm.NewAny(newrow)))
 
 		// also notify indices
 		for _, index := range t.Indexes {
@@ -2496,6 +2509,9 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 			index.mu.Lock()
 			if index.baseState.deltaBtree != nil {
 				index.baseState.deltaBtree.ReplaceOrInsert(indexPair{itemid: int(recid), data: newrow})
+				// The row payload belongs to the shard. The index owns only its
+				// B-tree entry/node overhead until rebuild produces compact arrays.
+				indexDeltaBytes[index] += 32
 			}
 			index.mu.Unlock()
 		}
@@ -2523,11 +2539,16 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 			t.t.mu.Unlock()
 		}
 	}
-	// Size tracking happens on rebuild only (computeSizeLocked gives accurate malloc-aware size).
-	// For temp keytables we still do a cheap heuristic update here (they are never rebuilt).
-	if strings.HasPrefix(t.t.Name, ".") {
-		delta := int64(len(values)) * int64(len(t.deltaColumns)) * 16
-		GlobalCache.UpdateSize(t.t, delta)
+	// Charge only the new allocation to each disjoint CacheManager owner. A
+	// rebuild later replaces these deltas with each owner's absolute measured
+	// size; insert must not traverse an ever-growing shard or index here.
+	if t.t.isEphemeralQueryTable() {
+		GlobalCache.UpdateSize(t.t, insertedBytes)
+	} else if t.t.PersistencyMode != Memory {
+		GlobalCache.UpdateSizeAsync(t, insertedBytes)
+		for index, delta := range indexDeltaBytes {
+			GlobalCache.UpdateSizeAsync(index, delta)
+		}
 	}
 }
 
@@ -2829,6 +2850,7 @@ func (t *storageShard) RemoveFromDisk() {
 		for _, col := range t.t.Columns {
 			t.t.schema.persistence.RemoveColumn(t.uuid.String(), col.Name)
 		}
+		t.t.schema.persistence.RemoveColumn(t.uuid.String(), blobManifestColumn)
 		t.t.schema.persistence.RemoveLog(t.uuid.String())
 	})
 }
@@ -2851,6 +2873,7 @@ func discardUnpublishedShard(s *storageShard) {
 	for _, col := range s.t.Columns {
 		s.t.schema.persistence.RemoveColumn(s.uuid.String(), col.Name)
 	}
+	s.t.schema.persistence.RemoveColumn(s.uuid.String(), blobManifestColumn)
 	s.t.schema.persistence.RemoveLog(s.uuid.String())
 }
 
@@ -2873,6 +2896,7 @@ func (s *storageShard) removePersistence() {
 	for _, col := range s.t.Columns {
 		s.t.schema.persistence.RemoveColumn(s.uuid.String(), col.Name)
 	}
+	s.t.schema.persistence.RemoveColumn(s.uuid.String(), blobManifestColumn)
 	s.t.schema.persistence.RemoveLog(s.uuid.String())
 }
 
@@ -2901,7 +2925,7 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 		// Only reached via explicit ALTER TABLE ENGINE=memory/cache.
 		GlobalCache.Remove(s)
 		s.removePersistence()
-		if newMode == Cache && !strings.HasPrefix(s.t.Name, ".") {
+		if newMode == Cache && !s.t.isEphemeralQueryTable() {
 			s.srState = SHARED
 			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 		} else {
@@ -2925,19 +2949,20 @@ func transitionShardEngine(s *storageShard, oldMode, newMode PersistencyMode) {
 			cs.Serialize(f)
 			finishColumnWrite(f, newMode == Safe)
 		}
+		writeBlobManifest(s)
 		// open logfile for Safe/Logged
 		if newMode == Safe || newMode == Logged {
 			s.logfile = s.t.schema.persistence.OpenLog(s.uuid.String())
 		}
 		s.srState = SHARED
-		if !strings.HasPrefix(s.t.Name, ".") {
+		if !s.t.isEphemeralQueryTable() {
 			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeShard, shardCleanup, shardLastUsed, nil)
 		}
 
 	case oldMode == Memory && newMode == Cache:
 		// Memory → Cache: register with CacheManager as TypeCacheEntry
 		s.srState = SHARED
-		if !strings.HasPrefix(s.t.Name, ".") {
+		if !s.t.isEphemeralQueryTable() {
 			GlobalCache.AddItem(s, int64(s.computeSizeLocked()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
 		}
 
@@ -3096,12 +3121,16 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 						result.t.schema.persistence.RemoveColumn(result.uuid.String(), col.Name)
 					}()
 				}
+				func() {
+					defer func() { _ = recover() }()
+					result.t.schema.persistence.RemoveColumn(result.uuid.String(), blobManifestColumn)
+				}()
 			}
 			// Re-register old shard with CacheManager if we deregistered it
 			if removedFromCache && t.t != nil {
-				if t.t.PersistencyMode == Cache && !strings.HasPrefix(t.t.Name, ".") {
+				if t.t.PersistencyMode == Cache && !t.t.isEphemeralQueryTable() {
 					GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
-				} else if t.t.PersistencyMode != Memory && !strings.HasPrefix(t.t.Name, ".") {
+				} else if t.t.PersistencyMode != Memory && !t.t.isEphemeralQueryTable() {
 					GlobalCache.AddItem(t, int64(t.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 				}
 			}
@@ -3433,15 +3462,16 @@ func (t *storageShard) rebuild(all bool) *storageShard {
 		GlobalCache.Remove(t)
 		removedFromCache = true
 	}
+	writeBlobManifest(result)
 	// Unlock result before registration (ComputeSize needs RLock)
 	result.exitWriteOwner()
 	result.mu.Unlock()
 	resultLocked = false
 	// Register the new shard with CacheManager
 	atomic.StoreUint64(&result.lastAccessed, uint64(time.Now().UnixNano()))
-	if result.t.PersistencyMode == Cache && !strings.HasPrefix(result.t.Name, ".") {
+	if result.t.PersistencyMode == Cache && !result.t.isEphemeralQueryTable() {
 		GlobalCache.AddItem(result, int64(result.ComputeSize()), TypeCacheEntry, cacheShardCleanup, shardLastUsed, nil)
-	} else if result.t.PersistencyMode != Memory && !strings.HasPrefix(result.t.Name, ".") {
+	} else if result.t.PersistencyMode != Memory && !result.t.isEphemeralQueryTable() {
 		GlobalCache.AddItem(result, int64(result.ComputeSize()), TypeShard, shardCleanup, shardLastUsed, nil)
 	}
 	return result

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -310,16 +310,63 @@ func (s *storageShard) ownsColumnMemory(name string) bool {
 // registration. The column object still reports its complete diagnostic size;
 // ownership is resolved only where the shard total is assembled.
 func ownedColumnMemory(storage ColumnStorage) uint {
+	if storage == nil {
+		return 0
+	}
 	size := storage.ComputeSize()
-	if strings, ok := storage.(*StorageString); ok && strings.compressed {
-		strings.dictMu.RLock()
-		materialized := uint(len(strings.dictionary))
-		strings.dictMu.RUnlock()
-		if materialized <= size {
-			size -= materialized
-		}
+	materialized := materializedDictionaryMemory(storage)
+	if materialized <= size {
+		size -= materialized
 	}
 	return size
+}
+
+// materializedDictionaryMemory follows storage wrappers because a compressed
+// StorageString may be nested below OverlayBlob, StoragePrefix, or a computed
+// column proxy. Every materialized dictionary is a separately weighted
+// TypeStringDict cache owner and must therefore be excluded from its parent's
+// bytes at every nesting depth.
+func materializedDictionaryMemory(storage any) uint {
+	switch typed := storage.(type) {
+	case *StorageString:
+		if !typed.compressed {
+			return 0
+		}
+		typed.dictMu.RLock()
+		size := uint(len(typed.dictionary))
+		typed.dictMu.RUnlock()
+		return size
+	case *OverlayBlob:
+		if typed.Base == nil {
+			return 0
+		}
+		return materializedDictionaryMemory(typed.Base)
+	case *StoragePrefix:
+		return materializedDictionaryMemory(&typed.values)
+	case *StorageComputeProxy:
+		var size uint
+		typed.mu.RLock()
+		if typed.main != nil {
+			size += materializedDictionaryMemory(typed.main)
+		}
+		typed.mu.RUnlock()
+		typed.variantsMu.RLock()
+		variants := make([]*storageComputeVariant, 0, len(typed.variants))
+		for _, variant := range typed.variants {
+			variants = append(variants, variant)
+		}
+		typed.variantsMu.RUnlock()
+		for _, variant := range variants {
+			variant.mu.RLock()
+			if variant.main != nil {
+				size += materializedDictionaryMemory(variant.main)
+			}
+			variant.mu.RUnlock()
+		}
+		return size
+	default:
+		return 0
+	}
 }
 
 type shardStatsSnapshot struct {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3034,22 +3034,35 @@ func Init(en scm.Env) {
 	})
 	scm.Declare(&en, &scm.Declaration{
 		Name: "stat",
-
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			if len(a) == 0 {
 				memTotal, memAvail := ReadMemInfo()
 				processMem := ReadProcessRSS()
 				cs := GlobalCache.Stat()
+				nonEvictable := processMem - cs.CurrentMemory
+				if nonEvictable < 0 {
+					nonEvictable = 0
+				}
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewString("mem_available"), scm.NewInt(memAvail),
 					scm.NewString("mem_total"), scm.NewInt(memTotal),
 					scm.NewString("process_memory"), scm.NewInt(processMem),
+					scm.NewString("evictable_memory"), scm.NewInt(cs.CurrentMemory),
+					scm.NewString("non_evictable_process_memory"), scm.NewInt(nonEvictable),
 					scm.NewString("shard_memory"), scm.NewInt(cs.CurrentMemory),
 					scm.NewString("shard_budget"), scm.NewInt(cs.MemoryBudget),
 					scm.NewString("persisted_memory"), scm.NewInt(cs.PersistedMemory),
 					scm.NewString("persisted_budget"), scm.NewInt(cs.PersistedBudget),
 					scm.NewString("cache_entry_count"), scm.NewInt(cs.CountByType[TypeCacheEntry]),
 					scm.NewString("cache_entry_size"), scm.NewInt(cs.SizeByType[TypeCacheEntry]),
+					scm.NewString("shard_column_size"), scm.NewInt(cs.SizeByType[TypeShard]),
+					scm.NewString("index_size"), scm.NewInt(cs.SizeByType[TypeIndex]),
+					scm.NewString("temp_column_size"), scm.NewInt(cs.SizeByType[TypeTempColumn]),
+					scm.NewString("temp_column_count"), scm.NewInt(cs.CountByType[TypeTempColumn]),
+					scm.NewString("temp_keytable_size"), scm.NewInt(cs.SizeByType[TypeTempKeytable]),
+					scm.NewString("temp_keytable_count"), scm.NewInt(cs.CountByType[TypeTempKeytable]),
+					scm.NewString("string_dictionary_size"), scm.NewInt(cs.SizeByType[TypeStringDict]),
+					scm.NewString("string_dictionary_count"), scm.NewInt(cs.CountByType[TypeStringDict]),
 				})
 			} else if len(a) == 1 {
 				return scm.NewString(GetDatabase(scm.String(a[0])).PrintMemUsage())
@@ -3060,7 +3073,7 @@ func Init(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc: mem_available, mem_total, process_memory, shard_memory, shard_budget, persisted_memory, persisted_budget, cache_entry_count, cache_entry_size.\n(stat schema) and (stat schema tbl) return a string with detailed memory usage.",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc. process_memory is RSS; evictable_memory and its per-owner size/count fields are disjoint CacheManager ownership; non_evictable_process_memory is their difference. shard_memory remains a compatibility alias for evictable_memory.\n(stat schema) and (stat schema tbl) return a string with detailed memory usage.",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "schema", Description: "(optional) database name for detailed string output", Optional: true},
 				{Kind: "string", Label: "table", Description: "(optional) table name for detailed string output", Optional: true},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3064,16 +3064,16 @@ func Init(en scm.Env) {
 					scm.NewString("string_dictionary_size"), scm.NewInt(cs.SizeByType[TypeStringDict]),
 					scm.NewString("string_dictionary_count"), scm.NewInt(cs.CountByType[TypeStringDict]),
 				})
-			} else if len(a) == 1 {
-				return scm.NewString(GetDatabase(scm.String(a[0])).PrintMemUsage())
 			} else if len(a) == 1 && a[0].IsCustom(TagTable) {
 				return scm.NewString(TableFromScmer(a[0]).PrintMemUsage())
+			} else if len(a) == 1 {
+				return scm.NewString(GetDatabase(scm.String(a[0])).PrintMemUsage())
 			} else if len(a) == 2 {
 				return scm.NewString(GetDatabase(scm.String(a[0])).GetTable(scm.String(a[1])).PrintMemUsage())
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc. process_memory is RSS; evictable_memory and its per-owner size/count fields are disjoint CacheManager ownership; non_evictable_process_memory is their difference. shard_memory remains a compatibility alias for evictable_memory.\n(stat schema) and (stat schema tbl) return a string with detailed memory usage.",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc. process_memory is exact process RSS; evictable_memory and its per-owner size/count fields are disjoint estimated Go payload ownership; non_evictable_process_memory is the RSS remainder including allocator, runtime, stacks, and untracked shared overhead. shard_memory remains a compatibility alias for evictable_memory.\n(stat schema) and (stat schema tbl) return disjoint owner-payload estimates, not per-schema RSS.",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "schema", Description: "(optional) database name for detailed string output", Optional: true},
 				{Kind: "string", Label: "table", Description: "(optional) table name for detailed string output", Optional: true},
@@ -3754,75 +3754,104 @@ func sharedStateStr(s SharedState) string {
 }
 
 func (db *database) PrintMemUsage() string {
-	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
 	var b strings.Builder
 	if db.srState == COLD {
 		b.WriteString("State: COLD (no schema loaded)\n")
 		return b.String()
 	}
-	b.WriteString("Table                    \tColumns\tShards\tDims\tSize/Bytes\n")
-	var dsize uint
+	b.WriteString("Disjoint owner-payload estimate (not RSS; excludes Go runtime, allocator slack, stacks, and shared process overhead)\n")
+	b.WriteString("Table                    \tColumns\tShards\tBase\tIndexes\tTemp columns\tString dicts\tMetadata\tTotal\n")
+	var total memoryOwnerSnapshot
+	db.schemalock.RLock()
+	defer db.schemalock.RUnlock()
 	for _, t := range db.tables.GetAll() {
-		var size uint = 10*8 + 32*uint(len(t.Columns))
-		for _, s := range t.Shards {
-			size += s.ComputeSize()
-		}
-		for _, s := range t.PShards {
-			if s != nil {
-				size += s.ComputeSize()
-			}
-		}
-		b.WriteString(fmt.Sprintf("%-25s\t%d\t%d\t%d\t%s\n", t.Name, len(t.Columns), len(t.Shards)+len(t.PShards), len(t.PDimensions), units.BytesSize(float64(size))))
-		dsize += size
+		snapshot := t.memoryOwnerSnapshotLocked()
+		b.WriteString(fmt.Sprintf("%-25s\t%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			t.Name, len(t.Columns), len(t.ActiveShards()),
+			units.BytesSize(float64(snapshot.base)),
+			units.BytesSize(float64(snapshot.indexes)),
+			units.BytesSize(float64(snapshot.tempColumns)),
+			units.BytesSize(float64(snapshot.stringDictionaries)),
+			units.BytesSize(float64(snapshot.metadata)),
+			units.BytesSize(float64(snapshot.total()))))
+		total.add(snapshot)
 	}
-	b.WriteString(fmt.Sprintf("\ntotal size = %s\n", units.BytesSize(float64(dsize))))
+	b.WriteString(fmt.Sprintf("\ntotal owner payload estimate = %s\n", units.BytesSize(float64(total.total()))))
 	return b.String()
 }
 
 func (t *table) PrintMemUsage() string {
 	var b strings.Builder
-	var dsize uint = 0
-	shards := t.ActiveShards()
-	if t.ShardMode == ShardModePartition {
-		b.WriteString(fmt.Sprint("Partitioning Schema:", t.PDimensions) + "\n\n")
+	t.schema.schemalock.RLock()
+	snapshot := t.memoryOwnerSnapshotLocked()
+	shardCount := len(t.ActiveShards())
+	columnCount := len(t.Columns)
+	partitioned := t.ShardMode == ShardModePartition
+	partitioningSchema := fmt.Sprint(t.PDimensions)
+	t.schema.schemalock.RUnlock()
+	if partitioned {
+		b.WriteString("Partitioning Schema:" + partitioningSchema + "\n\n")
 	}
-	for i, s := range shards {
-		var ssz uint = 14 * 8 // overhead
-		if s.srState == COLD {
-			b.WriteString(fmt.Sprintf("Shard %d [COLD] (no content loaded)\n---\n\n", i))
-			dsize += ssz
+	b.WriteString("Disjoint owner-payload estimate (not RSS)\n")
+	b.WriteString(fmt.Sprintf("columns: %d, shards: %d\n", columnCount, shardCount))
+	b.WriteString(fmt.Sprintf("base shard payload: %s\n", units.BytesSize(float64(snapshot.base))))
+	b.WriteString(fmt.Sprintf("indexes: %s\n", units.BytesSize(float64(snapshot.indexes))))
+	b.WriteString(fmt.Sprintf("temporary columns: %s\n", units.BytesSize(float64(snapshot.tempColumns))))
+	b.WriteString(fmt.Sprintf("materialized string dictionaries: %s\n", units.BytesSize(float64(snapshot.stringDictionaries))))
+	b.WriteString(fmt.Sprintf("table metadata estimate: %s\n", units.BytesSize(float64(snapshot.metadata))))
+	b.WriteString(fmt.Sprintf("total owner payload estimate: %s\n", units.BytesSize(float64(snapshot.total()))))
+	return b.String()
+}
+
+type memoryOwnerSnapshot struct {
+	base               uint
+	indexes            uint
+	tempColumns        uint
+	stringDictionaries uint
+	metadata           uint
+}
+
+func (m memoryOwnerSnapshot) total() uint {
+	return m.base + m.indexes + m.tempColumns + m.stringDictionaries + m.metadata
+}
+
+func (m *memoryOwnerSnapshot) add(other memoryOwnerSnapshot) {
+	m.base += other.base
+	m.indexes += other.indexes
+	m.tempColumns += other.tempColumns
+	m.stringDictionaries += other.stringDictionaries
+	m.metadata += other.metadata
+}
+
+// memoryOwnerSnapshotLocked attributes every loaded storage payload to exactly
+// one owner. CacheManager weights and partial/full eviction policy are not part
+// of size ownership and remain independently applied by cache.go. The caller
+// holds the schema read lock so table topology and column ownership are stable.
+func (t *table) memoryOwnerSnapshotLocked() memoryOwnerSnapshot {
+	snapshot := memoryOwnerSnapshot{metadata: 10*8 + 32*uint(len(t.Columns))}
+	for _, shard := range t.ActiveShards() {
+		if shard == nil {
 			continue
 		}
-		b.WriteString(fmt.Sprintf("Shard %d [%s]\n---\n", i, sharedStateStr(s.srState)))
-		b.WriteString(fmt.Sprintf("main count: %d, delta count: %d, deletions: %d\n", s.main_count, len(s.inserts), s.deletions.Count()))
-		for c, v := range s.columns {
-			if v == nil {
-				b.WriteString(fmt.Sprintf(" %s: COLD\n", c))
+		shard.mu.RLock()
+		snapshot.base += shard.computeSizeLocked()
+		for name, storage := range shard.columns {
+			if storage == nil {
 				continue
 			}
-			sz := v.ComputeSize()
-			b.WriteString(fmt.Sprintf(" %s: %s, size = %s\n", c, v.String(), units.BytesSize(float64(sz))))
-			ssz += sz
+			if !shard.ownsColumnMemory(name) {
+				snapshot.tempColumns += ownedColumnMemory(storage)
+			}
+			snapshot.stringDictionaries += materializedDictionaryMemory(storage)
 		}
-		b.WriteString(" ---\n")
-		for _, idx := range s.Indexes {
-			indexSize := idx.ComputeSize()
-			b.WriteString(fmt.Sprintf(" index %s: %s\n", idx.String(), units.BytesSize(float64(indexSize))))
-			ssz += indexSize
+		for _, index := range shard.Indexes {
+			if index != nil {
+				snapshot.indexes += index.ComputeSize()
+			}
 		}
-		b.WriteString(" ---\n")
-		insertionSize := scm.ComputeSize(scm.NewAny(s.inserts))
-		deletionSize := s.deletions.ComputeSize()
-		ssz += insertionSize
-		ssz += deletionSize
-		b.WriteString(fmt.Sprintf(" + insertions %s\n", units.BytesSize(float64(insertionSize))))
-		b.WriteString(fmt.Sprintf(" + deletions %s\n", units.BytesSize(float64(deletionSize))))
-		b.WriteString(" ---\n")
-		b.WriteString(fmt.Sprintf("= total %s\n\n", units.BytesSize(float64(ssz))))
-		dsize += ssz
+		shard.mu.RUnlock()
 	}
-	b.WriteString(fmt.Sprintf("= total %s\n\n", units.BytesSize(float64(dsize))))
-	return b.String()
+	return snapshot
 }
 
 // fkExistenceCheck checks if values exist in tbl[filterCols]. Returns true if found or all NULL.

--- a/tests/storage/persistence/lifecycle-accounting.yaml
+++ b/tests/storage/persistence/lifecycle-accounting.yaml
@@ -30,6 +30,17 @@ test_cases:
     expect:
       data: [true]
 
+  - name: "Schema stat labels owner payload as an estimate rather than RSS"
+    scm: |
+      (begin
+        (define summary (stat "memcp-tests"))
+        (and
+          (strlike summary "%Disjoint owner-payload estimate (not RSS%")
+          (strlike summary "%Base%Indexes%Temp columns%String dicts%Metadata%Total%")
+          (strlike summary "%total owner payload estimate%")))
+    expect:
+      data: [true]
+
   - name: "Persistent blob metadata is not registered as a temporary keytable"
     scm: |
       (begin

--- a/tests/storage/persistence/lifecycle-accounting.yaml
+++ b/tests/storage/persistence/lifecycle-accounting.yaml
@@ -1,0 +1,104 @@
+# Copyright (C) 2026  MemCP Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+metadata:
+  version: "1.0"
+  description: "Storage ownership accounting and persistent blob lifecycle"
+  isolated: true
+
+setup:
+  - sql: "DROP TABLE IF EXISTS lifecycle_accounting"
+  - sql: "CREATE TABLE lifecycle_accounting (id INT PRIMARY KEY, payload TEXT) ENGINE=SAFE"
+
+test_cases:
+  - name: "Global stat exposes disjoint ownership totals"
+    scm: |
+      (begin
+        (define values (stat))
+        (and
+          (has_assoc? values "process_memory")
+          (has_assoc? values "evictable_memory")
+          (has_assoc? values "non_evictable_process_memory")
+          (has_assoc? values "shard_column_size")
+          (has_assoc? values "index_size")
+          (equal? (get_assoc values "shard_memory") (get_assoc values "evictable_memory"))
+          (>= (get_assoc values "process_memory") (get_assoc values "evictable_memory"))))
+    expect:
+      data: [true]
+
+  - name: "Persistent blob metadata is not registered as a temporary keytable"
+    scm: |
+      (begin
+        (define before (get_assoc (stat) "temp_keytable_count"))
+        (insert
+          (table "memcp-tests" "lifecycle_accounting")
+          '("id" "payload")
+          (list (list 1 (concat (sha256 "blob-a") (sha256 "blob-b") (sha256 "blob-c")
+            (sha256 "blob-d") (sha256 "blob-e") (sha256 "blob-f") (sha256 "blob-g")
+            (sha256 "blob-h") (sha256 "blob-i") (sha256 "blob-j") (sha256 "blob-k")
+            (sha256 "blob-l") (sha256 "blob-m") (sha256 "blob-n") (sha256 "blob-o")
+            (sha256 "blob-p") (sha256 "blob-q") (sha256 "blob-r") (sha256 "blob-s")
+            (sha256 "blob-t") (sha256 "blob-u") (sha256 "blob-v") (sha256 "blob-w")
+            (sha256 "blob-x") (sha256 "blob-y") (sha256 "blob-z") (sha256 "blob-aa")
+            (sha256 "blob-ab") (sha256 "blob-ac") (sha256 "blob-ad") (sha256 "blob-ae")
+            (sha256 "blob-af") (sha256 "blob-ag"))))
+          '() (lambda () true) false)
+        (rebuild (table "memcp-tests" "lifecycle_accounting") true false)
+        (equal? before (get_assoc (stat) "temp_keytable_count")))
+    expect:
+      data: [true]
+
+  - name: "Create a separately owned temporary computed column"
+    scm: &prepare_temp_column |
+      (createcolumn
+        (table "memcp-tests" "lifecycle_accounting")
+        "cached_length" "int" '() '("temp" true)
+        '("payload") (lambda (payload) (strlen payload)))
+
+  - name: "Repeated temp-column preparation sets rather than accumulates its size"
+    scm: |
+      (begin
+        (define before (get_assoc (stat) "temp_column_size"))
+        (createcolumn
+          (table "memcp-tests" "lifecycle_accounting")
+          "cached_length" "int" '() '("temp" true)
+          '("payload") (lambda (payload) (strlen payload)))
+        (equal? before (get_assoc (stat) "temp_column_size")))
+    expect:
+      data: [true]
+
+  - name: "Computed value remains correct before restart"
+    sql: "SELECT id, cached_length FROM lifecycle_accounting"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          cached_length: 2112
+
+  - name: "Restart after publishing the blob generation"
+    action: restart
+
+  - name: "Persistent blob payload survives restart"
+    sql: "SELECT id, LENGTH(payload) AS payload_length FROM lifecycle_accounting"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          payload_length: 2112
+
+  - name: "Canonical temp-column preparation repairs the restarted cache"
+    scm: *prepare_temp_column
+
+  - name: "Reprepared computed value is correct after restart"
+    sql: "SELECT cached_length FROM lifecycle_accounting"
+    expect:
+      rows: 1
+      data:
+        - cached_length: 2112
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS lifecycle_accounting"


### PR DESCRIPTION
## What

This makes memory reporting ownership-based and makes startup cleanup reclaim crash-/update-orphaned persistent objects only after durable ownership proof.

### Disjoint memory ownership

- Treat shard columns, indexes, temporary computed columns, temporary keytables, materialized string dictionaries, and cache entries as disjoint CacheManager owners.
- Follow nested storage wrappers, including blob and computed-column storage, so a materialized string dictionary is never charged both to its parent and to its separately weighted cache owner.
- Add absolute, idempotent `SetSize` updates for recomputed owners instead of repeatedly accumulating estimates.
- Account insert deltas without rescanning the growing shard or index on every row.
- Count session-bound computed-column variants under their real locks.
- Stop adding CacheManager bytes to `runtime.MemStats`; those objects already live on the Go heap.
- Expose exact process RSS as `process_memory`; expose disjoint estimated Go owner payload through `evictable_memory` and per-owner fields. Per-schema/table output now explicitly says that it is an owner-payload estimate, not attributable RSS, and breaks out base shards, indexes, temp columns, materialized dictionaries, and metadata.
- Preserve all existing eviction weights and the partial/full eviction passes; ownership correction changes byte attribution, not eviction policy.
- Classify persistent dot-prefixed internal tables as durable shard storage rather than planner keytables.

### Crash-safe persistence and cleanup

- Publish content-addressed blobs through a same-directory temporary file, file sync, no-replace link, and directory sync. Concurrent writers can no longer truncate an already published object.
- Write checksummed, per-shard blob ownership manifests before publishing a rebuilt/repartitioned generation in `schema.json`.
- Serialize cleanup against rebuild/repartition generation publication.
- Load cold database topology before startup cleanup examines disk objects.
- Automatically backfill a truly missing legacy manifest from committed active column files, including blob storage nested below persisted compute proxies. This reads compact column metadata/reference values, not blob payloads, and does not require a full rebuild.
- Distinguish backend-proven absence from arbitrary I/O failure on filesystem, S3, and Ceph. Corrupt manifests, corrupt reference columns, and ambiguous backend failures remain fail-closed: no blob is deleted.
- Once every active generation is proven, delete orphan blobs immediately during startup cleanup. The startup log reports the numbers of deleted blob and shard objects.
- Keep eviction non-destructive: shard cleanup releases RAM and closes its WAL handle but does not remove persistence.

Therefore existing legacy data directories no longer retain orphan blobs indefinitely: the first upgraded startup backfills their active manifests and removes only objects absent from the proven live-reference union.

## Tests

- SQL/YAML suite covering public memory fields, honest schema accounting labels, persistent internal-table classification, idempotent temp-column accounting, blob persistence, restart, and cache repair.
- Go tests covering disjoint/nested ownership, unchanged eviction weights, session-variant accounting, incomplete/concurrent blob publication, automatic legacy manifest backfill, corrupt-manifest rejection, cold-start cleanup, nested computed blob ownership, repartition manifests, and cleanup/publication serialization.
- Targeted affected tests: green.
- Targeted `go test -race`: green.
- SQL lifecycle suite: 10/10 green.
- Full hook-equivalent `make test` on commit `e3f5c5e26`: green, including engine transitions, memory-pressure eviction, crash/rebuild publication, SAFE rollover, and compute-proxy restart suites.

## Data-safety review

- No cleanup/eviction path calls `removePersistence` or `RemoveFromDisk`.
- Missing legacy proof is reconstructed only from the committed active generation; no secondary refcount table is trusted as deletion proof.
- Backend failures and corrupt manifests never become "missing" and cannot enable deletion.
- No on-disk column serialization format or assigned magic byte changes.
- ENGINE durability and transition semantics are unchanged.
- No trigger callback behavior is broadened.
