### PR TITLE
Reduce scan analysis setup overhead

### DIFF
--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -166,21 +166,117 @@ func (b columnboundaries) Binding() scm.Scmer { return b.lower }
 func (b columnboundaries) Collation() string  { return b.collation }
 
 type indexAnalyzeContext struct {
-	resolveParameter func(scm.Scmer) (string, bool)
-	resolveColumn    func(scm.Scmer) (string, bool)
-	extractConstant  func(scm.Scmer) (scm.Scmer, bool)
-	functionIs       func(scm.Scmer, string) bool
+	proc          *scm.Proc
+	params        []scm.Scmer
+	conditionCols []string
 }
 
 func (c *indexAnalyzeContext) ResolveParameter(v scm.Scmer) (string, bool) {
-	return c.resolveParameter(v)
+	v = v.WithoutSourceInfo()
+	if v.IsSymbol() {
+		name := v.String()
+		for i, sym := range c.params {
+			if i < len(c.conditionCols) && sym.IsSymbol() && sym.String() == name {
+				return c.conditionCols[i], true
+			}
+		}
+	}
+	if v.IsNthLocalVar() {
+		idx := int(v.NthLocalVar())
+		if idx < len(c.conditionCols) {
+			return c.conditionCols[idx], true
+		}
+	}
+	return "", false
 }
-func (c *indexAnalyzeContext) ResolveColumn(v scm.Scmer) (string, bool) { return c.resolveColumn(v) }
+
+func (c *indexAnalyzeContext) ResolveColumn(v scm.Scmer) (string, bool) {
+	name, ok := c.ResolveParameter(v)
+	if !ok || isScanPseudoColName(name) {
+		return "", false
+	}
+	return name, true
+}
+
+func (c *indexAnalyzeContext) resolveBatchSubidx(v scm.Scmer) (int, bool) {
+	name, ok := c.ResolveParameter(v)
+	if !ok {
+		return 0, false
+	}
+	return parseBatchPseudoColName(name)
+}
+
+func (c *indexAnalyzeContext) resolveOuterReference(v scm.Scmer) (scm.Scmer, bool) {
+	depth := 0
+	for {
+		parts, ok := scmerSlice(v)
+		if !ok || len(parts) != 2 || !scanSymbolIs(parts[0], "outer") {
+			break
+		}
+		depth++
+		v = parts[1]
+	}
+	if depth == 0 {
+		return scm.NewNil(), false
+	}
+
+	env := c.proc.En
+	for level := 1; level < depth && env != nil; level++ {
+		env = env.Outer
+	}
+	if env == nil {
+		return scm.NewNil(), false
+	}
+	if v.IsSymbol() {
+		sym := scm.Symbol(v.String())
+		if binding := env.FindRead(sym); binding != nil {
+			value, ok := binding.Vars[sym]
+			return value, ok
+		}
+	}
+	if v.IsNthLocalVar() {
+		idx := int(v.NthLocalVar())
+		if idx < len(env.VarsNumbered) {
+			return env.VarsNumbered[idx], true
+		}
+	}
+	return scm.NewNil(), false
+}
+
 func (c *indexAnalyzeContext) ExtractConstant(v scm.Scmer) (scm.Scmer, bool) {
-	return c.extractConstant(v)
+	v = v.WithoutSourceInfo()
+	if v.IsInt() || v.IsFloat() || v.IsString() || v.IsBool() || v.IsCustom(TagRecSet) {
+		return v, true
+	}
+	if v.IsSymbol() {
+		if value, ok := c.proc.En.Vars[scm.Symbol(v.String())]; ok {
+			if value.IsInt() || value.IsFloat() || value.IsString() || value.IsCustom(TagRecSet) {
+				return value, true
+			}
+		}
+	}
+	if value, ok := c.resolveOuterReference(v); ok {
+		if value.IsInt() || value.IsFloat() || value.IsString() || value.IsCustom(TagRecSet) {
+			return value, true
+		}
+	}
+	if isIndependent(c.params, v) {
+		if value, ok := evalIndependentScmer(v, c.proc.En); ok {
+			if value.IsInt() || value.IsFloat() || value.IsString() || value.IsBool() || value.IsNil() || value.IsCustom(TagRecSet) {
+				return value, true
+			}
+		}
+	}
+	return scm.NewNil(), false
 }
+
 func (c *indexAnalyzeContext) FunctionIs(v scm.Scmer, name string) bool {
-	return c.functionIs(v, name)
+	v = v.WithoutSourceInfo()
+	if v.SymbolEquals(name) {
+		return true
+	}
+	declaration := scm.DeclarationForValue(v)
+	return declaration != nil && declaration.Name == name
 }
 
 // boundaryValueEqual compares boundary values in index-order semantics.
@@ -340,133 +436,176 @@ func widenBounds(a, b boundaries) boundaries {
 	return a[:n]
 }
 
-// analyzes a lambda expression for value boundaries, so the best index can be found
-func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
-	var p scm.Proc
+func conditionAnalyzeContext(conditionCols []string, condition scm.Scmer) (indexAnalyzeContext, bool) {
+	var p *scm.Proc
 	if condition.IsProc() {
-		p = *condition.Proc()
+		p = condition.Proc()
 	} else if si, ok := condition.Any().(scm.Proc); ok {
 		// fallback for legacy tagAny procs
-		p = si
+		p = &si
 	} else {
-		// native Go function - no boundary extraction possible (full scan)
-		return nil
+		return indexAnalyzeContext{}, false
 	}
 	var params []scm.Scmer
 	if p.Params.IsSlice() {
 		params = p.Params.Slice()
 	}
-	resolveLabel := func(node scm.Scmer) (string, bool) {
-		node = node.WithoutSourceInfo()
-		if node.IsSymbol() {
-			name := node.String()
-			for i, sym := range params {
-				if sym.IsSymbol() && sym.String() == name {
-					return conditionCols[i], true
-				}
-			}
-		}
-		if node.IsNthLocalVar() {
-			idx := int(node.NthLocalVar())
-			if idx < len(conditionCols) {
-				return conditionCols[idx], true
-			}
-		}
-		return "", false
-	}
-	// resolveColVar maps a node to a column name.
-	// Handles both symbol params (linear scan, no alloc) and NthLocalVar(i).
-	resolveColVar := func(node scm.Scmer) (string, bool) {
-		if name, ok := resolveLabel(node); ok {
-			if !isScanPseudoColName(name) {
-				return name, true
-			}
-		}
-		return "", false
-	}
-	resolveBatchSubidx := func(node scm.Scmer) (int, bool) {
-		if name, ok := resolveLabel(node); ok {
-			return parseBatchPseudoColName(name)
-		}
-		return 0, false
-	}
-	resolveOuterReference := func(node scm.Scmer) (scm.Scmer, bool) {
-		depth := 0
-		for {
-			parts, ok := scmerSlice(node)
-			if !ok || len(parts) != 2 || !scanSymbolIs(parts[0], "outer") {
-				break
-			}
-			depth++
-			node = parts[1]
-		}
-		if depth == 0 {
-			return scm.NewNil(), false
-		}
+	return indexAnalyzeContext{
+		proc:          p,
+		params:        params,
+		conditionCols: conditionCols,
+	}, true
+}
 
-		env := p.En
-		for level := 1; level < depth && env != nil; level++ {
-			env = env.Outer
-		}
-		if env == nil {
-			return scm.NewNil(), false
-		}
-		if node.IsSymbol() {
-			sym := scm.Symbol(node.String())
-			if binding := env.FindRead(sym); binding != nil {
-				value, ok := binding.Vars[sym]
-				return value, ok
-			}
-		}
-		if node.IsNthLocalVar() {
-			idx := int(node.NthLocalVar())
-			if idx < len(env.VarsNumbered) {
-				return env.VarsNumbered[idx], true
-			}
-		}
-		return scm.NewNil(), false
+func conditionMayHaveBoundaries(condition scm.Scmer) bool {
+	if condition.IsProc() {
+		return true
 	}
-	// analyze condition for AND clauses, equal? < > <= >= BETWEEN
-	extractConstant := func(v scm.Scmer) (scm.Scmer, bool) {
-		v = v.WithoutSourceInfo()
-		if v.IsInt() || v.IsFloat() || v.IsString() || v.IsBool() || v.IsCustom(TagRecSet) {
-			return v, true
+	_, ok := condition.Any().(scm.Proc)
+	return ok
+}
+
+func extractCustomBoundary(ctx indexAnalyzeContext, node scm.Scmer) (columnboundaries, bool) {
+	for _, analyzer := range boundaryMatchers {
+		if analyzer == EqualMatcher || analyzer == RangeMatcher {
+			continue
 		}
-		if v.IsSymbol() {
-			if val2, ok := p.En.Vars[scm.Symbol(v.String())]; ok {
-				if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
-					return val2, true
-				}
+		if boundary, found := analyzer.Analyze(&ctx, node); found {
+			return boundary, true
+		}
+	}
+	return columnboundaries{}, false
+}
+
+func unwrapAnalyzeNode(ctx *indexAnalyzeContext, node scm.Scmer) scm.Scmer {
+	for {
+		items, sliced := scmerSlice(node)
+		if !sliced || len(items) != 2 || !ctx.FunctionIs(items[0], "optimize") {
+			return node
+		}
+		node = items[1]
+	}
+}
+
+// extractSingleBoundary recognizes one indexable predicate without
+// constructing the recursive general-analyzer closure or an intermediate
+// singleton slice.
+func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (columnboundaries, bool) {
+	node = unwrapAnalyzeNode(ctx, node)
+	v, ok := scmerSlice(node)
+	if !ok || len(v) < 2 {
+		return columnboundaries{}, false
+	}
+	makeComparison := func(columnNode, valueNode scm.Scmer, matcher IndexAnalyzer, lower bool, inclusive bool) (columnboundaries, bool) {
+		col, columnOK := ctx.ResolveColumn(columnNode)
+		if !columnOK {
+			return columnboundaries{}, false
+		}
+		bound := columnboundaries{col: col, matcher: matcher}
+		if value, constant := ctx.ExtractConstant(valueNode); constant {
+			if matcher == EqualMatcher {
+				bound.lower, bound.upper = value, value
+				bound.lowerInclusive, bound.upperInclusive = true, true
+			} else if lower {
+				bound.lower, bound.lowerInclusive = value, inclusive
+			} else {
+				bound.upper, bound.upperInclusive = value, inclusive
+			}
+			return bound, true
+		}
+		if subidx, batch := ctx.resolveBatchSubidx(valueNode); batch {
+			if matcher == EqualMatcher {
+				bound.lowerBatch, bound.upperBatch = true, true
+				bound.lowerBatchSubidx, bound.upperBatchSubidx = subidx, subidx
+				bound.lowerInclusive, bound.upperInclusive = true, true
+			} else if lower {
+				bound.lowerBatch, bound.lowerBatchSubidx, bound.lowerInclusive = true, subidx, inclusive
+			} else {
+				bound.upperBatch, bound.upperBatchSubidx, bound.upperInclusive = true, subidx, inclusive
+			}
+			return bound, true
+		}
+		return columnboundaries{}, false
+	}
+	if len(v) >= 3 && (ctx.FunctionIs(v[0], "equal?") || ctx.FunctionIs(v[0], "equal??")) {
+		if bound, found := makeComparison(v[1], v[2], EqualMatcher, true, true); found {
+			return bound, true
+		}
+		return makeComparison(v[2], v[1], EqualMatcher, true, true)
+	}
+	if len(v) >= 3 && (ctx.FunctionIs(v[0], "<") || ctx.FunctionIs(v[0], "<=")) {
+		inclusive := ctx.FunctionIs(v[0], "<=")
+		if bound, found := makeComparison(v[1], v[2], RangeMatcher, false, inclusive); found {
+			return bound, true
+		}
+		return makeComparison(v[2], v[1], RangeMatcher, true, inclusive)
+	}
+	if len(v) >= 3 && (ctx.FunctionIs(v[0], ">") || ctx.FunctionIs(v[0], ">=")) {
+		inclusive := ctx.FunctionIs(v[0], ">=")
+		if bound, found := makeComparison(v[1], v[2], RangeMatcher, true, inclusive); found {
+			return bound, true
+		}
+		return makeComparison(v[2], v[1], RangeMatcher, false, inclusive)
+	}
+	if ctx.FunctionIs(v[0], "nil?") {
+		if col, found := ctx.ResolveColumn(v[1]); found {
+			return columnboundaries{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}, true
+		}
+	}
+	return extractCustomBoundary(*ctx, node)
+}
+
+// extractSimpleBoundaries appends the dominant simple predicate class directly
+// into caller-owned storage. Flat or nested AND trees remain allocation-free;
+// OR widening and computed-column synthesis retain the complete general path.
+func extractSimpleBoundaries(ctx *indexAnalyzeContext, node scm.Scmer, storage boundaries) (boundaries, bool) {
+	node = unwrapAnalyzeNode(ctx, node)
+	items, sliced := scmerSlice(node)
+	if sliced && len(items) > 1 && items[0].SymbolEquals("and") {
+		result := storage
+		for _, child := range items[1:] {
+			var ok bool
+			result, ok = extractSimpleBoundaries(ctx, child, result)
+			if !ok {
+				return storage, false
 			}
 		}
-		if val2, ok := resolveOuterReference(v); ok {
-			if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsCustom(TagRecSet) {
-				return val2, true
-			}
-		}
-		if isIndependent(params, v) {
-			if val2, ok := evalIndependentScmer(v, p.En); ok {
-				if val2.IsInt() || val2.IsFloat() || val2.IsString() || val2.IsBool() || val2.IsNil() || val2.IsCustom(TagRecSet) {
-					return val2, true
-				}
-			}
-		}
-		return scm.NewNil(), false
+		return result, true
 	}
-	funcIs := func(head scm.Scmer, name string) bool {
-		head = head.WithoutSourceInfo()
-		if head.SymbolEquals(name) {
-			return true
+	boundary, ok := extractSingleBoundary(ctx, node)
+	if !ok {
+		return storage, false
+	}
+	return addConstraint(storage, boundary), true
+}
+
+func extractBoundariesInto(storage boundaries, conditionCols []string, condition scm.Scmer) boundaries {
+	ctx, ok := conditionAnalyzeContext(conditionCols, condition)
+	if ok {
+		if result, simple := extractSimpleBoundaries(&ctx, ctx.proc.Body, storage); simple {
+			return result
 		}
-		d := scm.DeclarationForValue(head)
-		return d != nil && d.Name == name
 	}
-	analyzeContext := &indexAnalyzeContext{
-		resolveParameter: resolveLabel,
-		resolveColumn:    resolveColVar,
-		extractConstant:  extractConstant,
-		functionIs:       funcIs,
+	return append(storage, extractBoundariesGeneral(conditionCols, condition)...)
+}
+
+// analyzes a lambda expression for value boundaries, so the best index can be found
+func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
+	return extractBoundariesInto(nil, conditionCols, condition)
+}
+
+// extractBoundariesGeneral retains the complete recursive analyzer for OR
+// widening, computed columns and any future shape not handled by the simple
+// allocation-free path.
+func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) boundaries {
+	analyzeContextValue, ok := conditionAnalyzeContext(conditionCols, condition)
+	if !ok {
+		// native Go function - no boundary extraction possible (full scan)
+		return nil
 	}
+	analyzeContext := &analyzeContextValue
+	p := analyzeContext.proc
+	params := analyzeContext.params
 	// traverseCondition returns boundaries for a single AST node.
 	// nil means "unknown node, no bounds extractable".
 	// AND: merge children (intersect). OR: widen children (union).
@@ -479,7 +618,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 		if len(v) == 0 {
 			return nil
 		}
-		if funcIs(v[0], "optimize") && len(v) == 2 {
+		if analyzeContext.FunctionIs(v[0], "optimize") && len(v) == 2 {
 			return traverseCondition(v[1])
 		}
 		for _, analyzer := range boundaryMatchers {
@@ -487,21 +626,21 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				return boundaries{boundary}
 			}
 		}
-		if funcIs(v[0], "equal?") || funcIs(v[0], "equal??") {
-			if col, ok := resolveColVar(v[1]); ok {
-				if v2, ok := extractConstant(v[2]); ok {
+		if analyzeContext.FunctionIs(v[0], "equal?") || analyzeContext.FunctionIs(v[0], "equal??") {
+			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[2]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (equal? const col)
-			if col, ok := resolveColVar(v[2]); ok {
-				if v2, ok := extractConstant(v[1]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[1]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
@@ -516,7 +655,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[1]) {
-					if subidx, ok := resolveBatchSubidx(v[2]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 						canon := canonicalColName(v[1], params, conditionCols)
 						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -535,7 +674,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[2]) {
-					if subidx, ok := resolveBatchSubidx(v[1]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 						canon := canonicalColName(v[2], params, conditionCols)
 						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -545,22 +684,22 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				}
 			}
 			return nil
-		} else if funcIs(v[0], "<") || funcIs(v[0], "<=") {
+		} else if analyzeContext.FunctionIs(v[0], "<") || analyzeContext.FunctionIs(v[0], "<=") {
 			incl := v[0].SymbolEquals("<=")
-			if col, ok := resolveColVar(v[1]); ok {
-				if v2, ok := extractConstant(v[2]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[2]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (< const col) means col > const, (<= const col) means col >= const
-			if col, ok := resolveColVar(v[2]); ok {
-				if v2, ok := extractConstant(v[1]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[1]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
 				}
 			}
@@ -575,7 +714,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[1]) {
-					if subidx, ok := resolveBatchSubidx(v[2]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 						canon := canonicalColName(v[1], params, conditionCols)
 						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -595,7 +734,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[2]) {
-					if subidx, ok := resolveBatchSubidx(v[1]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 						canon := canonicalColName(v[2], params, conditionCols)
 						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -605,22 +744,22 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				}
 			}
 			return nil
-		} else if funcIs(v[0], ">") || funcIs(v[0], ">=") {
+		} else if analyzeContext.FunctionIs(v[0], ">") || analyzeContext.FunctionIs(v[0], ">=") {
 			incl := v[0].SymbolEquals(">=")
-			if col, ok := resolveColVar(v[1]); ok {
-				if v2, ok := extractConstant(v[2]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[2]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (> const col) means col < const, (>= const col) means col <= const
-			if col, ok := resolveColVar(v[2]); ok {
-				if v2, ok := extractConstant(v[1]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
+				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
 				}
-				if subidx, ok := resolveBatchSubidx(v[1]); ok {
+				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
@@ -635,7 +774,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[1]) {
-					if subidx, ok := resolveBatchSubidx(v[2]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
 						canon := canonicalColName(v[1], params, conditionCols)
 						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -655,7 +794,7 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 						}
 					}
 				} else if isRawDataset(params, v[2]) {
-					if subidx, ok := resolveBatchSubidx(v[1]); ok {
+					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
 						canon := canonicalColName(v[2], params, conditionCols)
 						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
@@ -665,9 +804,9 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 				}
 			}
 			return nil
-		} else if funcIs(v[0], "nil?") && len(v) >= 2 {
+		} else if analyzeContext.FunctionIs(v[0], "nil?") && len(v) >= 2 {
 			// IS NULL: (nil? col)
-			if col, ok := resolveColVar(v[1]); ok {
+			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
 				return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}}
 			}
 			return nil
@@ -1140,7 +1279,7 @@ func scmerStructEqual(a, b scm.Scmer) bool {
 	return false
 }
 
-func indexFromBoundaries(cols boundaries) (lower []scm.Scmer, upperLast scm.Scmer) {
+func indexFromBoundariesInto(storage []scm.Scmer, cols boundaries) (lower []scm.Scmer, upperLast scm.Scmer) {
 	if len(cols) > 0 {
 		sortedEnd := 0
 		for sortedEnd < len(cols) && cols[sortedEnd].matcher.IsSorted() {
@@ -1164,7 +1303,11 @@ func indexFromBoundaries(cols boundaries) (lower []scm.Scmer, upperLast scm.Scme
 		if effectiveLen == 0 {
 			return nil, scm.NewNil()
 		}
-		lower = make([]scm.Scmer, effectiveLen)
+		if cap(storage) >= effectiveLen {
+			lower = storage[:effectiveLen]
+		} else {
+			lower = make([]scm.Scmer, effectiveLen)
+		}
 		for i, v := range cols[:effectiveLen] {
 			lower[i] = v.lower
 		}
@@ -1173,4 +1316,8 @@ func indexFromBoundaries(cols boundaries) (lower []scm.Scmer, upperLast scm.Scme
 		}
 	}
 	return
+}
+
+func indexFromBoundaries(cols boundaries) ([]scm.Scmer, scm.Scmer) {
+	return indexFromBoundariesInto(nil, cols)
 }

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -22,6 +22,88 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+var benchmarkBoundaries boundaries
+
+func BenchmarkExtractBoundariesEqual(b *testing.B) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal?"),
+		scm.NewSymbol("x"),
+		scm.NewInt(42),
+	})
+	condition := buildProc([]string{"x"}, body)
+	columns := []string{"id"}
+	var storage [4]columnboundaries
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkBoundaries = extractBoundariesInto(storage[:0], columns, condition)
+	}
+}
+
+func BenchmarkExtractBoundariesAnd(b *testing.B) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("and"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal?"),
+			scm.NewSymbol("tenant"),
+			scm.NewInt(42),
+		}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol(">="),
+			scm.NewSymbol("created"),
+			scm.NewInt(100),
+		}),
+	})
+	condition := buildProc([]string{"tenant", "created"}, body)
+	columns := []string{"tenant", "created"}
+	var storage [4]columnboundaries
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkBoundaries = extractBoundariesInto(storage[:0], columns, condition)
+	}
+}
+
+func TestSimpleAndBoundariesReuseCallerStorage(t *testing.T) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("and"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal?"),
+			scm.NewSymbol("tenant"),
+			scm.NewInt(42),
+		}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol(">="),
+			scm.NewSymbol("created"),
+			scm.NewInt(100),
+		}),
+	})
+	condition := buildProc([]string{"tenant", "created"}, body)
+	columns := []string{"tenant_id", "created_at"}
+	var storage [4]columnboundaries
+
+	got := extractBoundariesInto(storage[:0], columns, condition)
+	if len(got) != 2 {
+		t.Fatalf("simple AND boundaries = %d, want 2", len(got))
+	}
+	if &got[0] != &storage[0] {
+		t.Fatal("simple AND did not reuse caller-owned boundary storage")
+	}
+	if got[0].col != "tenant_id" || got[0].matcher != EqualMatcher || got[0].lower.Int() != 42 {
+		t.Fatalf("unexpected equality boundary: %#v", got[0])
+	}
+	if got[1].col != "created_at" || got[1].matcher != RangeMatcher || got[1].lower.Int() != 100 || !got[1].lowerInclusive {
+		t.Fatalf("unexpected range boundary: %#v", got[1])
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		benchmarkBoundaries = extractBoundariesInto(storage[:0], columns, condition)
+	})
+	if allocs != 0 {
+		t.Fatalf("simple AND extraction allocated %.2f times per run, want 0", allocs)
+	}
+}
+
 // buildProc constructs a Proc with the given param names and body AST.
 func buildProc(params []string, body scm.Scmer) scm.Scmer {
 	paramSlice := make([]scm.Scmer, len(params))

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -316,7 +316,7 @@ func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, so
 		t.schema.schemalock.Unlock()
 		panic("ComputeOrderedColumn: column " + t.Name + "." + name + " does not exist")
 	}
-
+	t.hasOrderedColumns.Store(true)
 	// Register triggers while the table-local DDL contract is held. Durable
 	// columns publish synchronously; reconstructible temp metadata joins the next
 	// complete schema snapshot.

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -20,12 +20,40 @@ import "fmt"
 import "time"
 import "runtime/debug"
 import "strings"
+import "sync"
 import "sync/atomic"
 import "github.com/launix-de/memcp/scm"
 
 type scanError struct {
 	r     interface{}
 	stack string
+}
+
+const scanAnalyzeScratchCapacity = 8
+
+// scanAnalyzeScratch owns the short-lived physical analyzer output until all
+// parallel shard consumers have completed. A pool is preferable to a caller
+// stack array here: the shard callback escapes into goroutines, which would
+// force the complete stack array onto the heap on every scan. Most SQL scans
+// fit in these inline buffers; unusual wide predicates retain the ordinary
+// append fallback without changing analyzer semantics.
+type scanAnalyzeScratch struct {
+	boundaries [scanAnalyzeScratchCapacity]columnboundaries
+	lower      [scanAnalyzeScratchCapacity]scm.Scmer
+}
+
+var scanAnalyzeScratchPool = sync.Pool{
+	New: func() any { return new(scanAnalyzeScratch) },
+}
+
+func acquireScanAnalyzeScratch() *scanAnalyzeScratch {
+	return scanAnalyzeScratchPool.Get().(*scanAnalyzeScratch)
+}
+
+func releaseScanAnalyzeScratch(scratch *scanAnalyzeScratch) {
+	clear(scratch.boundaries[:])
+	clear(scratch.lower[:])
+	scanAnalyzeScratchPool.Put(scratch)
 }
 
 func (s scanError) Error() string {
@@ -459,10 +487,20 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, conditionCo
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
 	touchTempColumns(t, conditionCols, nil)
-	boundaries := extractBoundaries(conditionCols, condition)
+	var scratch *scanAnalyzeScratch
+	var boundaries boundaries
+	if source != nil || conditionMayHaveBoundaries(condition) {
+		scratch = acquireScanAnalyzeScratch()
+		defer releaseScanAnalyzeScratch(scratch)
+		boundaries = extractBoundariesInto(scratch.boundaries[:0], conditionCols, condition)
+	}
 	reorderByFrequency(boundaries, t)
 	boundaries = appendRecSetBoundary(boundaries, source)
-	lower, upperLast := indexFromBoundaries(boundaries)
+	var lowerStorage []scm.Scmer
+	if scratch != nil {
+		lowerStorage = scratch.lower[:0]
+	}
+	lower, upperLast := indexFromBoundariesInto(lowerStorage, boundaries)
 	for _, b := range boundaries {
 		t.AddPartitioningScore([]string{b.col})
 	}
@@ -547,10 +585,20 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 	// Measure analysis time (boundary extraction, sharding hints)
 	analyzeStart := time.Now()
 	/* analyze query */
-	boundaries := extractBoundaries(conditionCols, condition)
+	var scratch *scanAnalyzeScratch
+	var boundaries boundaries
+	if source != nil || conditionMayHaveBoundaries(condition) {
+		scratch = acquireScanAnalyzeScratch()
+		defer releaseScanAnalyzeScratch(scratch)
+		boundaries = extractBoundariesInto(scratch.boundaries[:0], conditionCols, condition)
+	}
 	reorderByFrequency(boundaries, t)
 	boundaries = appendRecSetBoundary(boundaries, source)
-	lower, upperLast := indexFromBoundaries(boundaries)
+	var lowerStorage []scm.Scmer
+	if scratch != nil {
+		lowerStorage = scratch.lower[:0]
+	}
+	lower, upperLast := indexFromBoundariesInto(lowerStorage, boundaries)
 	if Settings.ScanDebugging {
 		dbg := fmt.Sprintf("[SCAN] %s.%s", t.schema.Name, t.Name)
 		for _, b := range boundaries {
@@ -668,7 +716,10 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 	// log statistics (best-effort, async so it doesn't add latency)
 	execNs := time.Since(execStart).Nanoseconds()
 	if Settings.ScanDebugging || candidateCount > int64(Settings.AnalyzeMinItems) {
-		go func(anNs, exNs int64) {
+		// Boundaries may live in pooled scan scratch. Encode them before the
+		// asynchronous logger starts so no reference outlives this scan.
+		indexColsEnc := boundaryIndexCols(boundaries)
+		go func(anNs, exNs int64, indexColsEnc string) {
 			defer func() { _ = recover() }()
 			filterEnc := ""
 			if proc, ok := condition.Any().(scm.Proc); ok {
@@ -680,9 +731,8 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 				}
 				filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
 			}
-			indexColsEnc := boundaryIndexCols(boundaries)
 			safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", indexColsEnc, inputCount, candidateCount, outCount, anNs, exNs)
-		}(analyzeNs, execNs)
+		}(analyzeNs, execNs, indexColsEnc)
 	}
 	return akkumulator
 }
@@ -828,8 +878,15 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	// ensureMainCount then loads at least one column to initialize main_count.
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	scanCols := append(append([]string(nil), conditionCols...), callbackCols...)
-	orderedProxies := t.orderedScanProxies(scanCols, currentTx)
+	// Most scans do not read an ordered computed column. Keep discovery on the
+	// caller's stack and inspect the two existing column slices directly, so the
+	// correctness preflight below adds no heap work to an ordinary scan.
+	var orderedProxies []*StorageComputeProxy
+	if t.hasOrderedScanProxy(conditionCols, currentTx) || t.hasOrderedScanProxy(callbackCols, currentTx) {
+		var orderedProxyStorage [4]*StorageComputeProxy
+		orderedProxies = t.appendOrderedScanProxies(orderedProxyStorage[:0], conditionCols, currentTx)
+		orderedProxies = t.appendOrderedScanProxies(orderedProxies, callbackCols, currentTx)
+	}
 	prepareOrdered := func() {
 		if len(orderedProxies) == 0 {
 			return
@@ -857,6 +914,9 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		}
 	}
 	orderedReadyLocked := func() bool {
+		if len(orderedProxies) == 0 {
+			return true
+		}
 		upper := t.main_count + uint32(len(t.inserts))
 		for id := uint32(0); id < upper; id++ {
 			if currentTx != nil && currentTx.Mode == TxACID {
@@ -1113,13 +1173,13 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	return akkumulator, outCount, candidateCount
 }
 
-// orderedScanProxies returns the ORC-backed columns that a scan may read.
+// appendOrderedScanProxies appends the ORC-backed columns that a scan may read.
 // They must be made valid before the shard lock is acquired: an on-demand ORC
 // repair takes shard write locks and therefore cannot run under a scan-held
-// shard read or write lock.
-func (t *storageShard) orderedScanProxies(cols []string, currentTx *TxContext) []*StorageComputeProxy {
-	seen := make(map[*StorageComputeProxy]struct{})
-	result := make([]*StorageComputeProxy, 0)
+// shard read or write lock. The caller supplies stack capacity for the normal
+// case; linear deduplication is cheaper than allocating a map for a handful of
+// projected columns.
+func (t *storageShard) appendOrderedScanProxies(result []*StorageComputeProxy, cols []string, currentTx *TxContext) []*StorageComputeProxy {
 	for _, col := range cols {
 		if col == "$recset_contains" || col == "$update" || col == "$break" ||
 			strings.HasPrefix(col, "NEW.") || strings.HasPrefix(col, "$invalidate:") ||
@@ -1133,13 +1193,43 @@ func (t *storageShard) orderedScanProxies(cols []string, currentTx *TxContext) [
 		if !ok || !proxy.isOrdered {
 			continue
 		}
-		if _, exists := seen[proxy]; exists {
+		seen := false
+		for _, existing := range result {
+			if existing == proxy {
+				seen = true
+				break
+			}
+		}
+		if seen {
 			continue
 		}
-		seen[proxy] = struct{}{}
 		result = append(result, proxy)
 	}
 	return result
+}
+
+// hasOrderedScanProxy keeps the overwhelmingly common non-ORC path free of
+// proxy-list storage. It deliberately performs only the same stable column
+// lookup appendOrderedScanProxies would perform; ORC scans pay the second pass.
+func (t *storageShard) hasOrderedScanProxy(cols []string, currentTx *TxContext) bool {
+	if !t.t.hasOrderedColumns.Load() {
+		return false
+	}
+	for _, col := range cols {
+		if col == "$recset_contains" || col == "$update" || col == "$break" ||
+			strings.HasPrefix(col, "NEW.") || strings.HasPrefix(col, "$invalidate:") ||
+			strings.HasPrefix(col, "$increment:") || strings.HasPrefix(col, "$set:") {
+			continue
+		}
+		if _, ok := parseBatchPseudoColName(col); ok {
+			continue
+		}
+		proxy, ok := t.getColumnStorageOrPanicEx(col, false, currentTx).(*StorageComputeProxy)
+		if ok && proxy.isOrdered {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -508,6 +508,7 @@ func (u *storageShard) attachColumnRuntime(colName string, columnstorage ColumnS
 		proxy.sessionKeys = extractSessionKeys(proxy.computor)
 		if col != nil && len(col.OrcSortCols) > 0 {
 			proxy.isOrdered = true
+			u.t.hasOrderedColumns.Store(true)
 		}
 		return proxy
 	}
@@ -517,6 +518,7 @@ func (u *storageShard) attachColumnRuntime(colName string, columnstorage ColumnS
 	// ordered proxy so readers/rebuilds never publish the placeholder as a real
 	// user-visible value column.
 	if proxy := u.makeComputedColumnProxy(colName, col); proxy != nil {
+		u.t.hasOrderedColumns.Store(true)
 		return proxy
 	}
 	return columnstorage

--- a/storage/table.go
+++ b/storage/table.go
@@ -522,8 +522,12 @@ type table struct {
 	// orcMu serializes ORC recomputes: only one full scan_order pass at a time per table.
 	orcMu          sync.Mutex
 	orcRecomputing int32 // atomic: >0 means an ORC recompute is in progress (skip re-entry in GetValue)
-
-	lastAccessed uint64 // atomic; UnixNano timestamp for CacheManager LRU of TempKeytable
+	// hasOrderedColumns is a monotonic runtime hint for the scan fast path.
+	// False proves that no ORC preflight is necessary; stale true is harmless
+	// after temporary-column eviction because the shard-level check remains
+	// authoritative.
+	hasOrderedColumns atomic.Bool
+	lastAccessed      uint64 // atomic; UnixNano timestamp for CacheManager LRU of TempKeytable
 
 	// creationMu is held while a newly published table runs its synchronous
 	// oninit hook. Concurrent if-not-exists calls wait on the same barrier.


### PR DESCRIPTION
## Summary

- keep boundary analysis mandatory while adding an allocation-free fast path for common equality, range, NULL, custom-hook, and nested `AND` predicates
- let scans provide reusable boundary and lower-key storage, with the complete recursive analyzer retained for OR widening, computed columns, and future shapes
- avoid ordinary-scan allocations from ordered-computed-column discovery and skip the ordered-column readiness walk when no ordered column is involved
- encode scan statistics before asynchronous logging so pooled analyzer storage never escapes its scan lifetime

This changes physical scan setup only. It does not add planner shape exceptions, change cost weights, or bypass index analysis.

## Architecture

The analyzer now separates reusable resolution context from traversal. Common predicate trees append directly into caller-owned storage; shapes requiring the full generic machinery fall back to the existing recursive analyzer. Scan-owned scratch remains alive until all parallel shard consumers finish and is cleared before reuse.

Ordered-computed-column preflight now uses a monotonic table hint for the dominant no-ORC case and a small inline proxy list instead of allocating a concatenated column slice, map, and result slice. A stale positive hint is harmless because shard-level proxy inspection remains authoritative.

## Benchmarks

AMD Ryzen 9 7900X3D, Go benchmark medians, `-benchmem`:

| Benchmark | master | this PR | change |
| --- | ---: | ---: | ---: |
| `BenchmarkScanUniquePoint` | 11.39 us, 3147 B, 55 allocs | 9.39 us, 2590 B, 46 allocs | -17.6%, -557 B, -9 allocs |
| previous fast baseline | 9.73 us, 3097 B, 53 allocs | 9.39 us, 2590 B, 46 allocs | -3.5%, -507 B, -7 allocs |
| `BenchmarkExtractBoundariesEqual` | ~430 ns, 496 B, 6 allocs | 74 ns, 0 B, 0 allocs | ~-83%, allocation-free |
| `BenchmarkExtractBoundariesAnd` | ~1.2 us, 1072 B, 8 allocs | 236 ns, 0 B, 0 allocs | ~-80%, allocation-free |

Native filters that cannot yield boundaries remain on a lazy no-scratch path. `BenchmarkScanFixedCosts_NoSession` improved from roughly 7.3 us / 36 allocs to 6.9 us / 34 allocs rather than paying analyzer setup.

## Validation

- `make test` — full hook-equivalent suite passed
- targeted storage scan, boundary, RecSet, ORC, and ordered-column tests passed
- targeted race checks for boundary and ORC paths passed
- post-rebase `tests/execution/operators/range-scan-coverage.yaml`: 113/113 passed
- `tests/planner/order-window/ordered-computed-column.yaml`: 19/19 passed
- `tests/storage/indexes/suffix-recompute.yaml`: 52/52 passed
- `tests/integration/regressions/revision-query-pattern.yaml`: 18/18 passed
- `go build -o memcp .`
