### PR TITLE
Reduce read scan setup allocations

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -969,13 +969,13 @@ func rebuildIndexes(candidates []*StorageIndex, t2 *storageShard) {
 
 // fullScan iterates all record IDs (main + delta) in natural order.
 // Used when the index is not built yet or was evicted.
-func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, callback func([]uint32) bool) {
+func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, matchers []IndexRowMatcher, callback func([]uint32) bool) {
 	bufN := 0
 	for i := uint32(0); i < s.t.main_count; i++ {
 		buf[bufN] = i
 		bufN++
 		if bufN == len(buf) {
-			if !callback(buf[:bufN]) {
+			if !emitRowMatchers(matchers, buf[:bufN], callback) {
 				return
 			}
 			bufN = 0
@@ -985,14 +985,14 @@ func (s *StorageIndex) fullScan(maxInsertIndex int, buf []uint32, callback func(
 		buf[bufN] = s.t.main_count + uint32(i)
 		bufN++
 		if bufN == len(buf) {
-			if !callback(buf[:bufN]) {
+			if !emitRowMatchers(matchers, buf[:bufN], callback) {
 				return
 			}
 			bufN = 0
 		}
 	}
 	if bufN > 0 {
-		callback(buf[:bufN])
+		emitRowMatchers(matchers, buf[:bufN], callback)
 	}
 }
 
@@ -1417,30 +1417,30 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 		})
 	}
 
-	callback = s.bindRowMatchers(bounds, cols, func() []IndexHook {
+	matchers := s.bindRowMatchers(bounds, cols, func() []IndexHook {
 		if persistent && state != nil {
 			return state.indexHooks
 		}
 		return nil
-	}(), persistent, exactMain, callback)
+	}(), persistent, exactMain)
 	for len(items) > 0 {
 		count := len(items)
 		if count > len(buf) {
 			count = len(buf)
 		}
 		copy(buf, items[:count])
-		if !callback(buf[:count]) {
+		if !emitRowMatchers(matchers, buf[:count], callback) {
 			return
 		}
 		items = items[count:]
 	}
 }
 
-// bindRowMatchers binds every non-ordering boundary once for this index run.
-// The returned callback applies the resulting functions in place to every
-// batch; no allocation or lock is added to the per-batch path.
-func (s *StorageIndex) bindRowMatchers(bounds boundaries, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool, callback func([]uint32) bool) func([]uint32) bool {
-	matchers := make([]IndexRowMatcher, 0, len(bounds))
+// bindRowMatchers returns only matcher state. The terminal callback deliberately
+// stays outside this value: storing it in a returned wrapper closure makes the
+// complete shard scan state escape even though index iteration is synchronous.
+func (s *StorageIndex) bindRowMatchers(bounds boundaries, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
+	var matchers []IndexRowMatcher
 	for colIdx, bound := range bounds {
 		if bound.matcher == nil || bound.matcher.IsSorted() {
 			continue
@@ -1467,24 +1467,23 @@ func (s *StorageIndex) bindRowMatchers(bounds boundaries, cols []colGetter, hook
 			matchers = append(matchers, matcher)
 		}
 	}
-	if len(matchers) == 0 {
-		return callback
-	}
 	// Candidate matchers never replace the original predicate. This is
 	// required for approximate indexes such as n-grams and harmless for exact
 	// matchers such as RecSet membership.
-	if exactMain != nil {
+	if len(matchers) > 0 && exactMain != nil {
 		*exactMain = false
 	}
-	return func(ids []uint32) bool {
-		for _, matcher := range matchers {
-			ids = matcher(ids)
-			if len(ids) == 0 {
-				return true
-			}
+	return matchers
+}
+
+func emitRowMatchers(matchers []IndexRowMatcher, ids []uint32, callback func([]uint32) bool) bool {
+	for _, matcher := range matchers {
+		ids = matcher(ids)
+		if len(ids) == 0 {
+			return true
 		}
-		return callback(ids)
 	}
+	return callback(ids)
 }
 
 func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds boundaries) (uint32, uint32, bool) {
@@ -1600,8 +1599,8 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 			if selected != nil {
 				selected(s, false)
 			}
-			callback = s.bindRowMatchers(bounds, cols, nil, false, exactMain, callback)
-			s.fullScan(maxInsertIndex, buf, callback)
+			matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+			s.fullScan(maxInsertIndex, buf, matchers, callback)
 			return
 		} else {
 			// Rebuild index without blocking on index mutex contention.
@@ -1612,8 +1611,8 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 				if selected != nil {
 					selected(s, false)
 				}
-				callback = s.bindRowMatchers(bounds, cols, nil, false, exactMain, callback)
-				s.fullScan(maxInsertIndex, buf, callback)
+				matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+				s.fullScan(maxInsertIndex, buf, matchers, callback)
 				return
 			}
 			if state.active {
@@ -1636,8 +1635,8 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		callback = s.bindRowMatchers(bounds, cols, nil, false, exactMain, callback)
-		s.fullScan(maxInsertIndex, buf, callback)
+		matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
 	if !state.active {
@@ -1646,8 +1645,8 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		callback = s.bindRowMatchers(bounds, cols, nil, false, exactMain, callback)
-		s.fullScan(maxInsertIndex, buf, callback)
+		matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
 	snapMainIndexes := state.mainIndexes
@@ -1797,7 +1796,7 @@ start_scan:
 	}
 
 	rawCallback := callback
-	callback = s.bindRowMatchers(bounds, cols, snapIndexHooks, true, exactMain, callback)
+	matchers := s.bindRowMatchers(bounds, cols, snapIndexHooks, true, exactMain)
 	adaptiveSwitchRows := int64(0)
 	if options != nil && hasRecSetBoundary && maxInsertIndex == 0 {
 		adaptiveSwitchRows = orderedRecSetSwitchRows(recsetPart.count)
@@ -1843,7 +1842,7 @@ start_scan:
 		buf[bufN] = id
 		bufN++
 		if bufN == len(buf) {
-			if !callback(buf[:bufN]) {
+			if !emitRowMatchers(matchers, buf[:bufN], callback) {
 				stopped = true
 			}
 			bufN = 0
@@ -1932,7 +1931,7 @@ start_scan:
 			// optimistic LIMIT-only estimate, so continue from the next un-emitted
 			// index position through the inverse RecSet kernel.
 			if bufN > 0 {
-				if !callback(buf[:bufN]) {
+				if !emitRowMatchers(matchers, buf[:bufN], callback) {
 					stopped = true
 				}
 				bufN = 0
@@ -1948,7 +1947,7 @@ start_scan:
 		}
 	}
 	if bufN > 0 && !stopped {
-		callback(buf[:bufN])
+		emitRowMatchers(matchers, buf[:bufN], callback)
 	}
 }
 

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1317,7 +1317,15 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
-	mapper := t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, 0, nil, currentTx)
+	var mapperStorage ShardMapReducer
+	var mapperWorkspace shardMapReducerWorkspace
+	mapper := &mapperStorage
+	if mapReducerCanUseReadWorkspace(callbackCols) {
+		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		t.initReadMapReducer(&mapperStorage, callbackCols, callback, aggregate, skipShardReadLock, currentTx)
+	} else {
+		mapper = t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, 0, nil, currentTx)
+	}
 	defer mapper.Close()
 
 	locked := false

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -992,7 +992,15 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	// MapReducer for map+reduce phase (builds column readers internally)
-	mapper := t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, 0, nil, currentTx)
+	var mapperStorage ShardMapReducer
+	var mapperWorkspace shardMapReducerWorkspace
+	mapper := &mapperStorage
+	if mapReducerCanUseReadWorkspace(callbackCols) {
+		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		t.initReadMapReducer(&mapperStorage, callbackCols, callback, aggregate, skipShardReadLock, currentTx)
+	} else {
+		mapper = t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, 0, nil, currentTx)
+	}
 	defer mapper.Close()
 	// Use a guarded lock that will always be released on panic to avoid leaked locks.
 	locked := false
@@ -1304,7 +1312,15 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 
-	mapper := t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, stride, batchdata, currentTx)
+	var mapperStorage ShardMapReducer
+	var mapperWorkspace shardMapReducerWorkspace
+	mapper := &mapperStorage
+	if stride == 0 && mapReducerCanUseReadWorkspace(callbackCols) {
+		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		t.initReadMapReducer(&mapperStorage, callbackCols, callback, aggregate, skipShardReadLock, currentTx)
+	} else {
+		mapper = t.OpenMapReducer(callbackCols, callback, aggregate, skipShardReadLock, stride, batchdata, currentTx)
+	}
 	defer mapper.Close()
 
 	locked := false

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -29,6 +29,7 @@ package storage
 //	_WithAutocommit – full HTTP handler path: GLS + autocommit transaction
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
@@ -203,6 +204,65 @@ func TestOpenMapReducerAllocatesMutationMetadataLazily(t *testing.T) {
 	defer mutationMapper.Close()
 	if len(mutationMapper.isUpdate) != 1 || !mutationMapper.isUpdate[0] || len(mutationMapper.setClosureFn) != 1 {
 		t.Fatal("mutation mapper did not initialize mutation metadata")
+	}
+}
+
+func TestReadMapReducerWorkspaceMainDeltaAndWideProjection(t *testing.T) {
+	const dbName = "test_scan_read_mapper_workspace"
+	databases.Remove(dbName)
+	t.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	columns := make([]string, inlineMapReducerColumns+1)
+	for i := range columns {
+		columns[i] = "c" + strconv.Itoa(i)
+		tbl.CreateColumn(columns[i], "INT", nil, nil)
+	}
+	mainRows := make([][]scm.Scmer, 2)
+	for rowIndex := range mainRows {
+		mainRows[rowIndex] = make([]scm.Scmer, len(columns))
+		for columnIndex := range mainRows[rowIndex] {
+			mainRows[rowIndex][columnIndex] = scm.NewInt(int64(rowIndex*20 + columnIndex + 1))
+		}
+	}
+	tbl.Insert(columns, mainRows, nil, scm.NewNil(), false, nil)
+	result := GetDatabase(dbName).rebuild(true, false, true)
+	if len(result.errors) > 0 {
+		t.Fatalf("rebuild errors: %v", result.errors)
+	}
+
+	shard := tbl.Shards[0]
+	mapLast := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer { return args[len(args)-1] })
+	reduceLast := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer { return args[1] })
+
+	// A small projection uses the inline workspace. MapOne follows Stream to
+	// ensure it reads its requested row instead of reusing prefetched values.
+	var inlineMapper ShardMapReducer
+	var inlineWorkspace shardMapReducerWorkspace
+	prepareReadMapReducerStorage(&inlineMapper, &inlineWorkspace, 2)
+	shard.initReadMapReducer(&inlineMapper, columns[:2], mapLast, reduceLast, false, nil)
+	inlineMapper.Stream(scm.NewNil(), []uint32{0}, nil)
+	if got := inlineMapper.MapOne(1).Int(); got != mainRows[1][1].Int() {
+		t.Fatalf("inline main-row projection = %d, want %d", got, mainRows[1][1].Int())
+	}
+
+	// Wider projections use the allocation-backed fallback rather than
+	// truncating the caller-owned inline arrays.
+	var mapper ShardMapReducer
+	var workspace shardMapReducerWorkspace
+	prepareReadMapReducerStorage(&mapper, &workspace, len(columns))
+	shard.initReadMapReducer(&mapper, columns, mapLast, reduceLast, false, nil)
+	if got := mapper.Stream(scm.NewNil(), []uint32{0}, nil).Int(); got != mainRows[0][len(columns)-1].Int() {
+		t.Fatalf("wide main-row projection = %d, want %d", got, mainRows[0][len(columns)-1].Int())
+	}
+
+	deltaRow := make([]scm.Scmer, len(columns))
+	for i := range deltaRow {
+		deltaRow[i] = scm.NewInt(int64(100 + i))
+	}
+	tbl.Insert(columns, [][]scm.Scmer{deltaRow}, nil, scm.NewNil(), false, nil)
+	if got := mapper.MapOne(shard.main_count).Int(); got != deltaRow[len(deltaRow)-1].Int() {
+		t.Fatalf("wide delta-row projection = %d, want %d", got, deltaRow[len(deltaRow)-1].Int())
 	}
 }
 

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1101,7 +1101,15 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 		return notFoundValue
 	}
 	mapperAlreadyLocked := foundShard.hasWriteOwnerForTx(currentTx)
-	mapper := foundShard.OpenMapReducer(callbackCols, callback, aggregate, mapperAlreadyLocked, 0, nil, currentTx)
+	var mapperStorage ShardMapReducer
+	var mapperWorkspace shardMapReducerWorkspace
+	mapper := &mapperStorage
+	if mapReducerCanUseReadWorkspace(callbackCols) {
+		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		foundShard.initReadMapReducer(&mapperStorage, callbackCols, callback, aggregate, mapperAlreadyLocked, currentTx)
+	} else {
+		mapper = foundShard.OpenMapReducer(callbackCols, callback, aggregate, mapperAlreadyLocked, 0, nil, currentTx)
+	}
 	result := mapper.Stream(neutral, []uint32{foundID}, nil)
 	mapper.FlushSideEffects()
 	return result

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1617,6 +1617,19 @@ type breakSentinel struct{}
 
 type mapArgGetter func(uint32, uint32) scm.Scmer
 
+const inlineMapReducerColumns = 8
+
+// shardMapReducerWorkspace supplies bounded caller-owned storage for the common
+// read-only mapper. Wider projections fall back to sized heap slices; mutation
+// pseudo-columns use the retained general mapper because their closures may
+// legitimately outlive one streaming call.
+type shardMapReducerWorkspace struct {
+	mainCols        [inlineMapReducerColumns]ColumnStorage
+	mainBulkReaders [inlineMapReducerColumns]ColumnReader
+	args            [inlineMapReducerColumns]scm.Scmer
+	reduceArgs      [2]scm.Scmer
+}
+
 // ShardMapReducer pre-allocates args and applies map+reduce over batches of record IDs.
 // Local implementation of the streaming MapReducer pattern (see todos/cluster.md §15.7).
 // Stream() partitions recid batches into main/delta runs and dispatches to
@@ -1667,11 +1680,70 @@ type ShardMapReducer struct {
 	// and registered write ownership before opening this mapper. When true,
 	// processMainBlock/processDeltaBlock must NOT try to re-acquire the lock.
 	shardWriteLocked bool
+	directRead       bool
+}
+
+func mapReducerCanUseReadWorkspace(cols []string) bool {
+	for _, col := range cols {
+		if _, ok := parseBatchPseudoColName(col); ok {
+			return false
+		}
+		if col == "$recset_contains" || col == "$update" || col == "$break" ||
+			len(col) >= 4 && col[:4] == "NEW." ||
+			len(col) > 12 && col[:12] == "$invalidate:" ||
+			len(col) > 11 && col[:11] == "$increment:" ||
+			len(col) > 5 && col[:5] == "$set:" {
+			return false
+		}
+	}
+	return true
+}
+
+// prepareReadMapReducerStorage assigns caller-owned fixed storage for common
+// narrow projections and allocation-backed slices for unusually wide ones.
+func prepareReadMapReducerStorage(mr *ShardMapReducer, workspace *shardMapReducerWorkspace, width int) {
+	if width <= inlineMapReducerColumns {
+		mr.mainCols = workspace.mainCols[:width]
+		mr.mainBulkReaders = workspace.mainBulkReaders[:width]
+		mr.args = workspace.args[:width]
+	} else {
+		mr.mainCols = make([]ColumnStorage, width)
+		mr.mainBulkReaders = make([]ColumnReader, width)
+		mr.args = make([]scm.Scmer, width)
+	}
+	mr.reduceArgs = workspace.reduceArgs[:]
+}
+
+// initReadMapReducer initializes an ordinary read-only mapper without the
+// per-column closures required by pseudo-column and mutation scans.
+func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool, currentTx *TxContext) {
+	mr.shard = t
+	mr.currentTx = currentTx
+	mr.acidMode = currentTx != nil && currentTx.Mode == TxACID
+	mr.colNames = cols
+	mr.mapFn = scm.OptimizeProcToSerialFunction(mapFn)
+	mr.reduceFn = scm.OptimizeProcToSerialFunction(reduceFn)
+	mr.mapScmer = mapFn
+	mr.reduceScmer = reduceFn
+	mr.mainCount = t.main_count
+	mr.shardWriteLocked = alreadyLocked
+	mr.directRead = true
+
+	for i, colName := range cols {
+		mainCol := t.getColumnStorageOrPanicEx(colName, alreadyLocked, currentTx)
+		mainReader := newCachedColumnReaderTx(mainCol, currentTx)
+		mr.mainCols[i] = mainCol
+		mr.mainBulkReaders[i] = mainReader
+	}
 }
 
 // MapOne evaluates the mapper for one already-visible record. Ordered scans use
 // this outside shard locks for predicates that must run after global ordering.
 func (m *ShardMapReducer) MapOne(id uint32) scm.Scmer {
+	if m.directRead {
+		m.loadDirectReadArgs(id, 0, false)
+		return m.mapFn(m.args...)
+	}
 	getters := m.mainGetters
 	if id >= m.mainCount {
 		getters = m.deltaGetters
@@ -1682,12 +1754,10 @@ func (m *ShardMapReducer) MapOne(id uint32) scm.Scmer {
 	return m.mapFn(m.args...)
 }
 
-// OpenMapReducer creates a MapReducer for the given columns. Column readers and
-// main storage references are built once; the args buffer is pre-allocated.
-// mapFn and reduceFn are stored as Scmer for future network serialization;
-// OptimizeProcToSerialFunction is called here (TODO: replace with JIT compilation).
-func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool, stride int, batchdata []scm.Scmer, currentTx *TxContext) *ShardMapReducer {
-	mr := &ShardMapReducer{
+// initMapReducer initializes the general mapper, including pseudo-columns and
+// mutation metadata. Retained operators allocate it through OpenMapReducer.
+func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool, stride int, batchdata []scm.Scmer, currentTx *TxContext) {
+	*mr = ShardMapReducer{
 		shard:            t,
 		currentTx:        currentTx,
 		acidMode:         currentTx != nil && currentTx.Mode == TxACID,
@@ -1953,6 +2023,13 @@ func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn s
 			tx.RegisterTouchedShard(t)
 		}
 	}
+}
+
+// OpenMapReducer creates a retained MapReducer for operators whose mapper
+// outlives one synchronous shard call.
+func (t *storageShard) OpenMapReducer(cols []string, mapFn scm.Scmer, reduceFn scm.Scmer, alreadyLocked bool, stride int, batchdata []scm.Scmer, currentTx *TxContext) *ShardMapReducer {
+	mr := new(ShardMapReducer)
+	t.initMapReducer(mr, cols, mapFn, reduceFn, alreadyLocked, stride, batchdata, currentTx)
 	return mr
 }
 
@@ -1984,6 +2061,41 @@ func (m *ShardMapReducer) prefetchMainColumns(recids []uint32) {
 		}
 		reader.GetValueMulti(recids, m.mainBulkValues[i:], width)
 	}
+}
+
+func (m *ShardMapReducer) loadDirectReadArgs(id uint32, rowOffset int, useBulkValues bool) {
+	if id < m.mainCount {
+		width := len(m.mainBulkReaders)
+		if useBulkValues && width > 0 && len(m.mainBulkValues) >= (rowOffset+1)*width {
+			copy(m.args, m.mainBulkValues[rowOffset*width:(rowOffset+1)*width])
+			return
+		}
+		for i, reader := range m.mainBulkReaders {
+			m.args[i] = reader.GetValue(id)
+		}
+		return
+	}
+	for i, mainCol := range m.mainCols {
+		if _, isProxy := mainCol.(*StorageComputeProxy); isProxy {
+			m.args[i] = m.mainBulkReaders[i].GetValue(id)
+		} else {
+			m.args[i] = m.shard.getDelta(int(id-m.mainCount), m.colNames[i])
+		}
+	}
+}
+
+func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
+	if len(recids) == 0 {
+		return acc
+	}
+	if recids[0] < m.mainCount {
+		m.prefetchMainColumns(recids)
+	}
+	for rowOffset, id := range recids {
+		m.loadDirectReadArgs(id, rowOffset, true)
+		acc = m.reduce(acc, m.mapFn(m.args...))
+	}
+	return acc
 }
 
 func withTxSession(currentTx *TxContext, fn func() scm.Scmer) scm.Scmer {
@@ -2038,6 +2150,9 @@ func (m *ShardMapReducer) reduce(acc scm.Scmer, value scm.Scmer) scm.Scmer {
 // processMainBlock is a tight loop over main-storage records – no branching
 // on main vs delta, direct ColumnStorage.GetValue calls. JIT candidate.
 func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
+	if m.directRead {
+		return m.processDirectReadBlock(acc, recids)
+	}
 	// Per-row lock: acquire write lock only around each row's mutation,
 	// not for the whole batch. This allows nested read scans (e.g. EXISTS
 	// inside UPDATE on the same table) to acquire RLock between rows.
@@ -2095,6 +2210,9 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 }
 
 func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
+	if m.directRead {
+		return m.processDirectReadBlock(acc, recids)
+	}
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	if !needsPerRowLock && !m.hasUpdateCol && !m.hasIncrementCol && !m.hasSetCol {
 		m.prefetchMainColumns(recids)
@@ -2148,6 +2266,9 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 
 // processDeltaBlock handles delta-storage records via getDelta. JIT candidate.
 func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.Scmer {
+	if m.directRead {
+		return m.processDirectReadBlock(acc, recids)
+	}
 	// Same hoisting as processMainBlock (see comment there).
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	for _, id := range recids {
@@ -2191,6 +2312,9 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 }
 
 func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32, batchids []uint32) scm.Scmer {
+	if m.directRead {
+		return m.processDirectReadBlock(acc, recids)
+	}
 	needsPerRowLock := (m.hasUpdateCol || m.hasIncrementCol || m.hasSetCol) && !m.shardWriteLocked
 	for rowidx, id := range recids {
 		func() {


### PR DESCRIPTION
## What

- keep ordinary read-only map/reducers in caller-owned storage for synchronous scan, scan_batch, scan_recset, and scan_order-first paths
- use fixed-capacity workspace arrays for projections up to eight columns and a correctly sized fallback for wider projections
- read ordinary columns directly instead of allocating one main and delta getter closure per column
- carry index row matchers as data and apply them at emission sites, avoiding a wrapper closure that made the complete scan callback graph escape
- preserve the existing retained mapper for batch pseudo-columns and all mutation/side-effect paths

This is a storage execution improvement only. It does not alter logical planning, cost weights, scan selection, or index selection.

## A/B measurements

Same Ryzen 9 7900X3D host, Go benchmark harness, ten 1-second samples against the merged #641 baseline and this branch:

| Benchmark | Baseline | This PR | Allocation change |
|---|---:|---:|---:|
| empty scan | roughly 8.0 us, 6160 B, 34 allocs | roughly 7.1 us, 5481 B, 19 allocs | -44% allocs |
| transactional unique point probe | roughly 4.8 us, 2076 B, 42 allocs | roughly 4.1 us, 1388 B, 26 allocs | -38% allocs |
| 8-column mapper setup | roughly 8.9 us, 6912 B, 41 allocs | roughly 7.1 us, 5392 B, 12 allocs | -71% allocs |
| 16-column mapper setup | roughly 10.5 us, 7872 B, 57 allocs | roughly 10.9 us, 6160 B, 15 allocs | -74% allocs; time statistically noisy |

The current variadic Scheme callback and ColumnReader interface may legally retain their slice arguments, so the compiler still moves the backing workspace to the heap. This PR consolidates that storage and removes per-column closures without unsafe noescape annotations or pooling. Fully stack-backed callback frames would require a separate arity-specific/non-retaining Scheme invocation API.

## Correctness

- new Go coverage for inline and wide projections, prefetched Stream followed by MapOne, and main/delta reads
- mutation metadata remains lazy and mutation scans stay on the general mapper
- relevant RecSet/index/ordered-scan tests repeated ten times
- targeted race tests pass
- `go build -o memcp .` passes
- full hook-equivalent `make test` passes
