### PR TITLE
feat: add costed ordered join scans

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5193,7 +5193,11 @@ ever-larger subtrees. */
 						(concat "__group_count_recset_" (stable_structural_hash membership_expr true))
 						(list (quote lambda) '() membership_expr)))
 				(list (quote scan)
-					'(session "__memcp_tx")
+					/* Computed group columns outlive the physical request which creates
+					them. Resolve the transaction from ComputeColumn's rebound runtime
+					session instead of letting rewrite_physical_transaction_reads capture
+					a request-local __physical_query_tx slot in this stored closure. */
+					(list (list (quote context) "session") "__memcp_tx")
 					(list (quote table) schema tbl)
 					(cons (quote list) filtercols)
 					(list (quote lambda)
@@ -6606,3 +6610,18 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_ordered_scan_invocation_ns 3027639)
 (define planner_membership_ordered_recset_sort_unit_ns 1)
 /* END GENERATED COST CONSTANTS */
+
+/* scan_join_order reuses the calibrated scan/filter/map work units. The
+structural formula belongs to the lowerer; tools/costgen owns every numeric
+coefficient used here. */
+(define planner_scan_join_order_cost (lambda (input_rows joined_rows table_count output_rows)
+	(planner_cost
+		(+ planner_membership_ordered_scan_invocation_ns
+			(* (- table_count 1) planner_membership_scan_invocation_ns))
+		(+ (* input_rows planner_membership_scan_row_ns)
+			(* input_rows (- table_count 1) planner_membership_map_column_row_ns))
+		(* joined_rows planner_membership_expression_operation_row_ns)
+		0 0
+		(* output_rows planner_membership_map_column_row_ns)
+		(* joined_rows 8)
+		0 output_rows 0.65)))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3481,14 +3481,22 @@ candidate RecSet. */
 /* Cost one physical tree edge once and return (strategy RecSet-expression).
 Consumers decide whether that RecSet is their scan carrier or a membership
 filter; they must not reconstruct the choice from enclosing block facts. */
-(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr downstream_probe_branches allow_driver_probe decision_scope)
+(define recset_project_join_plan_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch prefiltered_driver_expr downstream_probe_branches allow_driver_probe driver_order_partitioning decision_scope)
 	(begin
 		(define stage (nth membership 0))
+		(define driver_order_partitioned (if (nil? driver_order_partitioning)
+			false (cadr driver_order_partitioning)))
+		(if (nil? driver_order_partitioning) true
+			(planner_record_guard_condition (list (quote equal?)
+				(list (quote table_order_partitioned?)
+					(list (quote table) (source_schema src) (source_relation src))
+					(car driver_order_partitioning))
+				driver_order_partitioned)))
 		/* Some late RecSet consumers are introduced after reorder telemetry was
 		attached. Reconstruct only the candidate's scalar work from the existing
 		logical stage; this is one formula walk, never an alternative plan build. */
 		(define facts (merge (list (membership_candidate_work_facts stage) (gs_facts stage))))
-		(define cost_facts (qassoc_set
+		(define consumer_facts (qassoc_set
 			(if (equal? consumer (quote aggregate))
 				(qassoc_set facts (quote membership_consumer) (quote aggregate))
 				facts)
@@ -3502,6 +3510,8 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 				(max (coalesceNil downstream_probe_branches 0)
 					(qassoc_get facts (quote membership_downstream_probe_branches) 0))
 				0)))
+		(define cost_facts (qassoc_set consumer_facts
+			(quote membership_driver_order_partitioned) driver_order_partitioned))
 		(define driver_probe_supported (and allow_driver_probe
 			(membership_driver_subscan_supported? stage)))
 		(define raw_expr (recset_project_join_expr_for_membership_raw src membership))
@@ -3836,6 +3846,7 @@ filter; they must not reconstruct the choice from enclosing block facts. */
 									(membership_driver_input_rows driver_rows facts) facts))
 							(list "observed_projected_driver_rows" observed_rows)
 							(list "driver_input_rows" source_rows)
+							(list "driver_order_partitioned" driver_order_partitioned)
 							(list "driver_rows" driver_rows)
 							(list "prefiltered_driver_rows" prefiltered_driver_rows)
 							(list "projection_interval_lower_rows" (if observation_supported 0 nil))
@@ -3908,7 +3919,7 @@ candidate-keyset choice replaces the marker with a projected RecSet carrier. */
 (define recset_project_join_expr_for_membership_using (lambda (src membership consumer driver_rows_override allow_ordered_batch)
 	(begin
 		(define plan (recset_project_join_plan_for_membership_using
-			src membership consumer driver_rows_override allow_ordered_batch nil 0 true
+			src membership consumer driver_rows_override allow_ordered_batch nil 0 true nil
 			(quote expression)))
 		(if (and (not (nil? plan)) (equal? (car plan) "candidate_keyset"))
 			(cadr plan)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4405,8 +4405,16 @@ has selected a lowerer. */
 						lookup_input_rows lookup_rows requested_rows work))
 					(define projected_rows (membership_projected_driver_rows
 						lookup_input_rows lookup_rows driver_input_rows work))
-					(list (if (planner_cost_better? candidate_cost driver_cost)
-						candidate_cost driver_cost) projected_rows)))))))
+					(define use_projected (planner_cost_better? candidate_cost driver_cost))
+					/* Keep the probe cardinality aligned with the selected legacy carrier.
+					The projected candidate touches projected_rows driver records. The
+					ordered post-filter must instead visit enough driver rows to find the
+					requested hits; cross-table anti-correlation can make that the complete
+					driver even when the final join cardinality is tiny. */
+					(define ordered_visited_rows (membership_expected_driver_rows_visited
+						lookup_input_rows lookup_rows requested_rows work))
+					(list (if use_projected candidate_cost driver_cost)
+						(if use_projected projected_rows ordered_visited_rows))))))))
 
 /* Enumerate metadata only. No scan, RecSet, keytable or callback AST is built
 until the caller has selected this physical alternative. */
@@ -4779,9 +4787,16 @@ until the caller has selected this physical alternative. */
 				alternatives compare the calibrated cost-domain record instead. */
 				(define estimated_legacy_cost (qassoc_get facts (quote join_cost) nil))
 				(define sources (qassoc_get spec (quote sources) '()))
-				(define projected_legacy_cost (ordered_join_projected_candidate_cost
-					all_sources default_alias (car sources) (cdr sources)
-					final_condition offset_value limit_value))
+				/* Mirror the legacy lowerer's cardinality guard: a projected RecSet is
+				a semijoin carrier and cannot represent a multiplying lookup. */
+				(define projected_legacy_cost (if
+					(downstream_sources_at_most_one_driver_row?
+						sources default_alias final_condition stages)
+					(ordered_join_projected_candidate_cost
+						all_sources default_alias (car sources) (cdr sources)
+						final_condition offset_value limit_value)
+					nil))
+				(define driver_input_rows (planner_source_row_count (car sources)))
 				(define logical_legacy_cost (if (nil? estimated_legacy_cost)
 					(planner_cost_add
 						(planner_scan_cost input_rows 0.5)
@@ -4792,9 +4807,16 @@ until the caller has selected this physical alternative. */
 				row. A projected carrier reduces that work to its exact projected
 				driver cardinality; otherwise the complete ordered input remains live. */
 				(define legacy_probe_rows (if (nil? projected_legacy_cost)
-					input_rows (cadr projected_legacy_cost)))
+					driver_input_rows (cadr projected_legacy_cost)))
 				(define legacy_base_cost (if (nil? projected_legacy_cost)
-					logical_legacy_cost (car projected_legacy_cost)))
+					/* The DP join cost does not include the ordered root scan that this
+					lowerer adds. Use Costgen's scan_order invocation calibration; a
+					projected carrier already includes its complete scan startup. */
+					(planner_cost_add logical_legacy_cost
+						(planner_cost planner_membership_ordered_scan_invocation_ns
+							0 0 0 0 0 0 0 0 0.65)
+						legacy_probe_rows 0.65)
+					(car projected_legacy_cost)))
 				(define legacy_cost (planner_cost_add legacy_base_cost
 					(planner_join_work_cost legacy_probe_rows 0.65)
 					(coalesceNil joined_rows legacy_probe_rows) 0.65))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3459,16 +3459,16 @@ RecSet; membership edges retain their own physical operators. */
 			(qassoc_get facts (quote membership_candidate_scan_invocations) probe_branches)))
 		(define driver_scan_invocations (max 1
 			(qassoc_get facts (quote membership_driver_scan_invocations) 1)))
-		/* scan_order_batch_accept requests disjoint windows, but the current
-		ordered primitive has no resumable cursor. Every window therefore pays
-		for another ordered traversal of the driver, irrespective of how few
-		rows that window returns. Keep this explicit so calibration can price
-		the implementation that is actually emitted. */
-		/* Reuse the calibrated scan_order work unit. Without a resumable cursor,
-		each batch repeats the same quadratic ordered traversal; a separate linear
-		coefficient would describe the same operator inconsistently. */
-		(define ordered_driver_work_units (* batches
-			(/ (* driver_input_rows driver_input_rows) 1000000)))
+		/* A one-dimensional range partition on the leading ORDER BY column turns
+		each candidate window into a prefix of disjoint ordered shard runs. Batch
+		growth revisits earlier prefixes, but its geometric series is bounded by
+		twice the final visited prefix. Free or incompatible shards retain the
+		calibrated full ordered traversal per batch. */
+		(define order_partitioned (qassoc_get facts
+			(quote membership_driver_order_partitioned) false))
+		(define ordered_driver_work_units (if order_partitioned
+			(* 2 visited_rows)
+			(* batches (/ (* driver_input_rows driver_input_rows) 1000000))))
 		(define candidate_fraction (if (and (number? driver_input_rows) (> driver_input_rows 0))
 			(min 1 (/ visited_rows driver_input_rows)) 1))
 		/* Disjoint driver batches may contain the same foreign-key value. In the
@@ -3564,6 +3564,8 @@ RecSet; membership edges retain their own physical operators. */
 					(and bounded
 						(or (empty_list? order_items)
 							(not (empty_list? (source_primary_key_columns src)))))))
+				(define source_order_partitioning
+					(planner_source_order_partitioning src order_items))
 				(define membership_plans (filter (map memberships (lambda (membership)
 					(begin
 						(define plan (recset_project_join_plan_for_membership_using
@@ -3579,6 +3581,7 @@ RecSet; membership edges retain their own physical operators. */
 								alias raw_condition))
 								(count (expr_probe_stages raw_condition)))
 							(not row_number_membership_consumer)
+							source_order_partitioning
 							(quote single_source)))
 						(if (nil? plan) nil (list membership plan)))))
 					(lambda (entry) (not (nil? entry)))))
@@ -4145,7 +4148,18 @@ semantics and drops projection-only nullable lookups. */
 downstream lookup cannot multiply driver rows. This is a physical access-path
 candidate: logical join order remains unchanged, while the filtered lookup is
 projected back onto the ordered driver before scan_order applies Top-K. */
-(define ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition offset limit)
+(define planner_source_order_partitioning (lambda (src order_items)
+	(if (or (not (source_is_base_table? src)) (empty_list? order_items))
+		nil
+		(match (car order_items)
+			'(expr _direction) (begin
+				(define col (direct_column_name_for_alias src expr))
+				(if (nil? col) nil
+					(list col (table_order_partitioned?
+						(table (source_schema src) (source_relation src)) col))))
+			_ nil))))
+
+(define ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition order_items offset limit)
 	(if (or (not (single_source? remaining_sources))
 		(or (source_outer? src) (source_outer? (car remaining_sources))))
 		nil
@@ -4200,6 +4214,7 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 						(list (quote membership_candidate_probe_branches) 1)
 						(list (quote membership_candidate_cache_backed) false)
 						(list (quote membership_driver_input_rows) driver_input_rows)
+						(list (quote membership_driver_rows) requested_rows)
 						(list (quote membership_driver_scan_invocations) 1)
 						(list (quote membership_driver_filter_columns) 0)
 						(list (quote membership_driver_map_columns) 0)
@@ -4208,10 +4223,15 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 						(list (quote membership_order_limit) (planner_literal_value limit))
 						(list (quote membership_order_offset) (coalesceNil (planner_literal_value offset) 0))
 						(list (quote membership_downstream_probe_branches) 0)))))
+					(define order_partitioning (planner_source_order_partitioning src order_items))
+					(define cost_work (if (nil? order_partitioning) work
+						(cons (list (quote membership_driver_order_partitioned)
+							(cadr order_partitioning)) work)))
 					(define candidate_cost (membership_projection_cost
-						lookup_input_rows lookup_rows requested_rows work))
+						lookup_input_rows lookup_rows requested_rows cost_work))
 					(define driver_cost (membership_ordered_driver_probe_cost
-						lookup_input_rows lookup_rows requested_rows work))
+						lookup_input_rows lookup_rows requested_rows cost_work))
+					(define batch_cost (ordered_batch_accept_cost cost_work))
 					(define lookup_cols (extract_columns_for_alias lookup lookup_condition))
 					(define lookup_recset (list (quote scan_recset)
 						'(session "__memcp_tx")
@@ -4228,22 +4248,27 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 						(quoted_runtime_list (cadr edge_columns))))
 					(list carrier candidate_cost driver_cost lookup_rows
 						(membership_projected_driver_rows lookup_input_rows lookup_rows
-							driver_input_rows work)
-						lookup_condition lookup_estimate exact))))))))
+							driver_input_rows cost_work)
+						lookup_condition lookup_estimate exact batch_cost order_partitioning)))))))
 
-(define choose_ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition offset limit)
+(define choose_ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition order_items offset limit)
 	(begin
 		(define candidate (ordered_join_projected_candidate
-			sources default_alias src remaining_sources condition offset limit))
+			sources default_alias src remaining_sources condition order_items offset limit))
 		(if (nil? candidate)
 			nil
 			(begin
 				(define decision_id (concat "ordered_join_carrier:"
 					(source_alias src) ":" (source_alias (car remaining_sources))))
-				(define normal_choice (if (planner_cost_better? (nth candidate 1) (nth candidate 2))
-					"projected_candidate_keyset" "ordered_postfilter"))
+				(define normal_choice (car (reduce (list
+					(list "ordered_postfilter" (nth candidate 2))
+					(list "ordered_batch_accept" (nth candidate 8)))
+					(lambda (best alternative)
+						(if (planner_cost_better? (cadr alternative) (cadr best))
+							alternative best))
+					(list "projected_candidate_keyset" (nth candidate 1)))))
 				(define chosen (planner_physical_choice decision_id normal_choice
-					(list "projected_candidate_keyset" "ordered_postfilter")))
+					(list "projected_candidate_keyset" "ordered_postfilter" "ordered_batch_accept")))
 				(define forced (planner_physical_override decision_id))
 				(define lookup (car remaining_sources))
 				(define lookup_input_rows (planner_source_row_count lookup))
@@ -4277,12 +4302,22 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 						(list "candidate_rows" (nth candidate 3))
 						(list "projected_driver_rows" (nth candidate 4))
 						(list "driver_input_rows" (planner_source_row_count src))
-						(list "carrier_exact" (nth candidate 7))))
+						(list "carrier_exact" (nth candidate 7))
+						(list "driver_order_partitioned" (if (nil? (nth candidate 9))
+							false (cadr (nth candidate 9))))))
 					(list "alternatives" (list
 						(list (list "plan" "projected_candidate_keyset")
 							(list "cost" (planner_cost_explain (nth candidate 1))))
 						(list (list "plan" "ordered_postfilter")
-							(list "cost" (planner_cost_explain (nth candidate 2))))))))
+							(list "cost" (planner_cost_explain (nth candidate 2))))
+						(list (list "plan" "ordered_batch_accept")
+							(list "cost" (planner_cost_explain (nth candidate 8))))))))
+				(if (nil? (nth candidate 9)) true
+					(planner_record_guard_condition (list (quote equal?)
+						(list (quote table_order_partitioned?)
+							(list (quote table) (source_schema src) (source_relation src))
+							(car (nth candidate 9)))
+						(cadr (nth candidate 9)))))
 				(if (equal? chosen "projected_candidate_keyset")
 					(list (car candidate) (nth candidate 7)) nil))))))
 
@@ -4351,7 +4386,7 @@ move the window to the wrong tree level. */
 /* Cost the established two-table carrier without constructing its RecSet AST.
 This keeps physical enumeration side-effect free until the outer cost decision
 has selected a lowerer. */
-(define ordered_join_projected_candidate_cost (lambda (sources default_alias src remaining_sources condition offset limit)
+(define ordered_join_projected_candidate_cost (lambda (sources default_alias src remaining_sources condition order_items offset limit)
 	(if (or (not (single_source? remaining_sources))
 		(or (source_outer? src) (source_outer? (car remaining_sources))))
 		nil
@@ -4391,6 +4426,7 @@ has selected a lowerer. */
 						(list (quote membership_candidate_probe_branches) 1)
 						(list (quote membership_candidate_cache_backed) false)
 						(list (quote membership_driver_input_rows) driver_input_rows)
+						(list (quote membership_driver_rows) requested_rows)
 						(list (quote membership_driver_scan_invocations) 1)
 						(list (quote membership_driver_filter_columns) 0)
 						(list (quote membership_driver_map_columns) 0)
@@ -4399,22 +4435,32 @@ has selected a lowerer. */
 						(list (quote membership_order_limit) (planner_literal_value limit))
 						(list (quote membership_order_offset) (coalesceNil (planner_literal_value offset) 0))
 						(list (quote membership_downstream_probe_branches) 0)))))
+					(define order_partitioning (planner_source_order_partitioning src order_items))
+					(define cost_work (if (nil? order_partitioning) work
+						(cons (list (quote membership_driver_order_partitioned)
+							(cadr order_partitioning)) work)))
 					(define candidate_cost (membership_projection_cost
-						lookup_input_rows lookup_rows requested_rows work))
+						lookup_input_rows lookup_rows requested_rows cost_work))
 					(define driver_cost (membership_ordered_driver_probe_cost
-						lookup_input_rows lookup_rows requested_rows work))
+						lookup_input_rows lookup_rows requested_rows cost_work))
+					(define batch_cost (ordered_batch_accept_cost cost_work))
 					(define projected_rows (membership_projected_driver_rows
-						lookup_input_rows lookup_rows driver_input_rows work))
-					(define use_projected (planner_cost_better? candidate_cost driver_cost))
+						lookup_input_rows lookup_rows driver_input_rows cost_work))
 					/* Keep the probe cardinality aligned with the selected legacy carrier.
 					The projected candidate touches projected_rows driver records. The
 					ordered post-filter must instead visit enough driver rows to find the
 					requested hits; cross-table anti-correlation can make that the complete
 					driver even when the final join cardinality is tiny. */
 					(define ordered_visited_rows (membership_expected_driver_rows_visited
-						lookup_input_rows lookup_rows requested_rows work))
-					(list (if use_projected candidate_cost driver_cost)
-						(if use_projected projected_rows ordered_visited_rows))))))))
+						lookup_input_rows lookup_rows requested_rows cost_work))
+					(define best (reduce (list
+						(list batch_cost ordered_visited_rows)
+						(list driver_cost ordered_visited_rows))
+						(lambda (current alternative)
+							(if (planner_cost_better? (car alternative) (car current))
+								alternative current))
+						(list candidate_cost projected_rows)))
+					(list (car best) (cadr best))))))))
 
 /* Enumerate metadata only. No scan, RecSet, keytable or callback AST is built
 until the caller has selected this physical alternative. */
@@ -4494,16 +4540,6 @@ until the caller has selected this physical alternative. */
 		(define offset (coalesceNil (planner_literal_value offset_value) 0))
 		(define limit (coalesceNil (planner_literal_value limit_value) -1))
 		(define target (if (< limit 0) -1 (+ offset limit)))
-		(define projected_join_choice (if (and (>= target 0)
-			(downstream_sources_at_most_one_driver_row?
-				ordered_sources default_alias final_condition stages))
-			(choose_ordered_join_projected_candidate all_sources default_alias src
-				remaining_sources final_condition offset_value limit_value)
-			nil))
-		(define projected_join_carrier (if (nil? projected_join_choice)
-			nil (car projected_join_choice)))
-		(define projected_join_exact (if (nil? projected_join_choice)
-			false (cadr projected_join_choice)))
 		(define acceptance_probe_work_rows (coalesceNil
 			(probe_limit_work_rows limit_value)
 			(if (< target 0) nil target)))
@@ -4519,6 +4555,18 @@ until the caller has selected this physical alternative. */
 			ordered_sources default_alias src order_items stages final_condition '()))
 		(define driver_order_items (nth order_parts 0))
 		(define remaining_order_items (nth order_parts 1))
+		(define driver_order_partitioning
+			(planner_source_order_partitioning src driver_order_items))
+		(define projected_join_choice (if (and (>= target 0)
+			(downstream_sources_at_most_one_driver_row?
+				ordered_sources default_alias final_condition stages))
+			(choose_ordered_join_projected_candidate all_sources default_alias src
+				remaining_sources final_condition driver_order_items offset_value limit_value)
+			nil))
+		(define projected_join_carrier (if (nil? projected_join_choice)
+			nil (car projected_join_choice)))
+		(define projected_join_exact (if (nil? projected_join_choice)
+			false (cadr projected_join_choice)))
 		(define membership (driver_membership_for_source src raw_condition))
 		/* A RecSet batch represents driver membership, not join multiplicity. The
 		consumer is therefore available exactly when the remaining join tree is a
@@ -4542,7 +4590,9 @@ until the caller has selected this physical alternative. */
 				(+ (count (acceptance_required_sources
 					remaining_sources default_alias final_condition))
 					(count (expr_probe_stages final_condition)))
-				true (quote ordered_join_stream))))
+				true
+				driver_order_partitioning
+				(quote ordered_join_stream))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
 		/* A scalar truth carrier over the complete driver would defeat adaptive
@@ -4794,7 +4844,7 @@ until the caller has selected this physical alternative. */
 						sources default_alias final_condition stages)
 					(ordered_join_projected_candidate_cost
 						all_sources default_alias (car sources) (cdr sources)
-						final_condition offset_value limit_value)
+						final_condition order_items offset_value limit_value)
 					nil))
 				(define driver_input_rows (planner_source_row_count (car sources)))
 				(define logical_legacy_cost (if (nil? estimated_legacy_cost)
@@ -5386,6 +5436,8 @@ topology inequality by bounded binary search and guard that crossover. */
 			(query_limit_active? offset_value limit_value)))
 		(define row_number_membership_consumer
 			(membership_row_number_consumer? membership direct_order_limit))
+		(define current_order_partitioning
+			(planner_source_order_partitioning src current_order_items))
 		(define membership_plan (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
 			nil
 			(recset_project_join_plan_for_membership_using src membership
@@ -5404,7 +5456,9 @@ topology inequality by bounded binary search and guard that crossover. */
 					(count (merge_unique (list
 						(expr_probe_stages final_condition)
 						(physical_scalar_truth_plan_stages scalar_plan)))))
-				(not row_number_membership_consumer) (quote join_leaf))))
+				(not row_number_membership_consumer)
+				current_order_partitioning
+				(quote join_leaf))))
 		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
 		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
 		(define residual_probe_work_rows (membership_plan_residual_work_rows

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4149,7 +4149,14 @@ downstream lookup cannot multiply driver rows. This is a physical access-path
 candidate: logical join order remains unchanged, while the filtered lookup is
 projected back onto the ordered driver before scan_order applies Top-K. */
 (define planner_source_order_partitioning (lambda (src order_items)
-	(if (or (not (source_is_base_table? src)) (empty_list? order_items))
+	/* Runtime-materialized group carriers are table-shaped physical sources, but
+	they do not exist while alternatives are enumerated and carry no catalog shard
+	partitioning guarantee. Only persistent catalog tables can contribute this
+	physical fact to costing and its matching runtime guard. */
+	(if (or (not (source_is_base_table? src))
+		(or (physical_helper_relation? (source_relation src))
+			(or (information_schema_source? (source_schema src) (source_relation src))
+				(empty_list? order_items))))
 		nil
 		(match (car order_items)
 			'(expr _direction) (begin

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2349,12 +2349,12 @@ strictly cheaper. */
 		(and (source_is_base_table? (gs_input stage))
 			(and (scalar_order_lookup_cache_unique_input? stage)
 				(and (not (nil? target))
-				(and (source_is_base_table? target)
-					(and (not (empty_list? input_cols))
-						(and (not (reduce input_cols (lambda (missing col)
-							(or missing (nil? col))) false))
-							(and (equal? (qassoc_get (gs_facts stage) (quote condition) true) true)
-								(and (empty_list? (query_expr_session_reads stage))
+					(and (source_is_base_table? target)
+						(and (not (empty_list? input_cols))
+							(and (not (reduce input_cols (lambda (missing col)
+								(or missing (nil? col))) false))
+								(and (equal? (qassoc_get (gs_facts stage) (quote condition) true) true)
+									(and (empty_list? (query_expr_session_reads stage))
 										(and (not (nil? parts))
 											(empty_list? (nth parts 1))))))))))))))
 
@@ -2444,14 +2444,14 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 								'() '() 0 1 nil))
 							(select_scalar_order_lookup_cache_candidate
 								(list target stage requested_col column_name
-								(list (quote createcolumn)
-									(source_table_expr target)
-									column_name "any"
-									(quoted_runtime_list '())
-									(quoted_runtime_list '("temp" true))
-									(cons (quote list) input_cols)
-									(list (quote lambda) params lookup_expr))
-								stage_source))))))))))))
+									(list (quote createcolumn)
+										(source_table_expr target)
+										column_name "any"
+										(quoted_runtime_list '())
+										(quoted_runtime_list '("temp" true))
+										(cons (quote list) input_cols)
+										(list (quote lambda) params lookup_expr))
+									stage_source))))))))))))
 
 (define replace_scalar_order_lookup_with_cache (lambda (candidate expr)
 	(if (nil? candidate)
@@ -4290,7 +4290,193 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 zero, one, or many complete values. stream_window_reduce owns SQL OFFSET/LIMIT
 over those values, so neither driver cardinality nor a scalar-purpose tag can
 move the window to the wrong tree level. */
-(define join_ordered_streaming_limit_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
+(define scan_join_order_column_ref_using (lambda (sources default_alias expr)
+	(reduce (produceN (count sources)) (lambda (found index)
+		(if (not (nil? found))
+			found
+			(begin
+				(define src (nth sources index))
+				(define col (direct_column_name_for_alias src expr))
+				(if (nil? col) nil (list index col))))) nil)))
+
+(define scan_join_order_join_clause (lambda (sources current_index term)
+	(begin
+		(define current (nth sources current_index))
+		(reduce (produceN current_index) (lambda (found previous_index)
+			(if (not (nil? found))
+				found
+				(begin
+					(define parts (union_semijoin_equal_parts
+						(nth sources previous_index) current term))
+					(if (nil? parts) nil
+						(list previous_index (cadr parts) (car parts)))))) nil))))
+
+(define scan_join_order_terms (lambda (sources plan final_condition)
+	(merge_unique (list
+		(split_and_terms (coalesceNil final_condition true))
+		(merge (map sources (lambda (src)
+			(split_and_terms (coalesceNil (source_join_expr src) true)))))
+		(map (join_optimizer_tree_predicates plan) join_order_pred_expr)))))
+
+(define scan_join_order_local_terms (lambda (sources default_alias src index terms)
+	(filter terms (lambda (term)
+		(begin
+			(define aliases (join_hypergraph_expr_aliases
+				default_alias (source_aliases sources) term))
+			(or (and (empty_list? aliases) (equal? index 0))
+				(and (single_source? aliases)
+					(equal? (car aliases) (source_alias src)))))))))
+
+(define scan_join_order_refs_for_exprs (lambda (sources default_alias exprs)
+	(merge (map (produceN (count sources)) (lambda (index)
+		(begin
+			(define src (nth sources index))
+			(map (join_cols_for_alias sources default_alias (source_alias src) exprs)
+				(lambda (col) (list index col)))))))))
+
+(define scan_join_order_ref_params (lambda (sources refs)
+	(map refs (lambda (ref)
+		(symbol (concat (source_alias (nth sources (car ref))) "." (cadr ref)))))))
+
+(define scan_join_order_order_entry (lambda (sources default_alias item)
+	(match item
+		'(expr _dir) (begin
+			(define ref (scan_join_order_column_ref_using sources default_alias expr))
+			(if (nil? ref)
+				nil
+				(list ref (car (order_relations_for_source
+					(nth sources (car ref)) (list item))))))
+		_ nil)))
+
+/* Cost the established two-table carrier without constructing its RecSet AST.
+This keeps physical enumeration side-effect free until the outer cost decision
+has selected a lowerer. */
+(define ordered_join_projected_candidate_cost (lambda (sources default_alias src remaining_sources condition offset limit)
+	(if (or (not (single_source? remaining_sources))
+		(or (source_outer? src) (source_outer? (car remaining_sources))))
+		nil
+		(begin
+			(define lookup (car remaining_sources))
+			(define terms (merge (list
+				(split_and_terms (coalesceNil condition true))
+				(split_and_terms (coalesceNil (source_join_expr src) true))
+				(split_and_terms (coalesceNil (source_join_expr lookup) true)))))
+			(define edge_columns (candidate_recset_edge_columns
+				sources default_alias lookup src terms))
+			(define lookup_input_rows (planner_source_row_count lookup))
+			(define driver_input_rows (planner_source_row_count src))
+			(define lookup_condition (candidate_recset_local_condition
+				sources default_alias (source_alias lookup) terms true))
+			(define lookup_estimate (if (and (number? lookup_input_rows)
+				(not (empty_list? (car edge_columns))))
+				(planner_source_filter_estimate lookup lookup_condition 512)
+				nil))
+			(define lookup_rows (if (nil? lookup_estimate) nil
+				(planner_estimated_matching_rows lookup_estimate
+					lookup_input_rows lookup_input_rows)))
+			(define requested_rows (if (number? (planner_literal_value limit))
+				(+ (coalesceNil (planner_literal_value offset) 0)
+					(planner_literal_value limit)) nil))
+			(if (or (empty_list? (car edge_columns))
+				(or (not (number? lookup_rows))
+					(or (not (number? driver_input_rows))
+						(or (not (number? requested_rows)) (<= requested_rows 0)))))
+				nil
+				(begin
+					(define lookup_work (membership_source_work_profile
+						lookup lookup_condition true))
+					(define work (merge (list lookup_work (list
+						(list (quote membership_candidate_input_rows) lookup_input_rows)
+						(list (quote membership_candidate_estimated_rows) lookup_rows)
+						(list (quote membership_candidate_probe_branches) 1)
+						(list (quote membership_candidate_cache_backed) false)
+						(list (quote membership_driver_input_rows) driver_input_rows)
+						(list (quote membership_driver_scan_invocations) 1)
+						(list (quote membership_driver_filter_columns) 0)
+						(list (quote membership_driver_map_columns) 0)
+						(list (quote membership_driver_expression_operations) 0)
+						(list (quote membership_order_limit_driver) true)
+						(list (quote membership_order_limit) (planner_literal_value limit))
+						(list (quote membership_order_offset) (coalesceNil (planner_literal_value offset) 0))
+						(list (quote membership_downstream_probe_branches) 0)))))
+					(define candidate_cost (membership_projection_cost
+						lookup_input_rows lookup_rows requested_rows work))
+					(define driver_cost (membership_ordered_driver_probe_cost
+						lookup_input_rows lookup_rows requested_rows work))
+					(define projected_rows (membership_projected_driver_rows
+						lookup_input_rows lookup_rows driver_input_rows work))
+					(list (if (planner_cost_better? candidate_cost driver_cost)
+						candidate_cost driver_cost) projected_rows)))))))
+
+/* Enumerate metadata only. No scan, RecSet, keytable or callback AST is built
+until the caller has selected this physical alternative. */
+(define scan_join_order_spec (lambda (all_sources plan default_alias needed_exprs final_condition order_items offset_value limit_value stages facts)
+	(begin
+		(define aliases (join_optimizer_tree_aliases plan))
+		(define sources (join_optimizer_sources_for_order all_sources aliases))
+		(define offset (coalesceNil (planner_literal_value offset_value) 0))
+		(define limit (coalesceNil (planner_literal_value limit_value) -1))
+		(define terms (scan_join_order_terms sources plan final_condition))
+		(define joins (map (produceN (- (count sources) 1)) (lambda (raw_index)
+			(begin
+				(define index (+ raw_index 1))
+				(filter (map terms (lambda (term)
+					(scan_join_order_join_clause sources index term)))
+					(lambda (clause) (not (nil? clause))))))))
+		(define consumed_join_terms (filter terms (lambda (term)
+			(reduce (produceN (- (count sources) 1)) (lambda (found raw_index)
+				(or found (not (nil? (scan_join_order_join_clause
+					sources (+ raw_index 1) term))))) false))))
+		(define local_terms (map (produceN (count sources)) (lambda (index)
+			(scan_join_order_local_terms sources default_alias
+				(nth sources index) index terms))))
+		(define all_local_terms (merge local_terms))
+		(define residual_terms (filter terms (lambda (term)
+			(and (not (contains? consumed_join_terms term))
+				(not (contains? all_local_terms term))))))
+		(define order_entries (map order_items (lambda (item)
+			(scan_join_order_order_entry sources default_alias item))))
+		(define source_rows (map sources planner_source_row_count))
+		(define known_rows (reduce source_rows (lambda (known rows)
+			(and known (number? rows))) true))
+		(define input_rows (if known_rows (reduce source_rows + 0) nil))
+		(define joined_rows (qassoc_get facts (quote join_estimated_rows) nil))
+		(define output_rows (if (and (number? limit) (>= limit 0))
+			(min (coalesceNil joined_rows limit) (+ offset limit)) joined_rows))
+		(define supported (and (>= (count sources) 2)
+			(and (empty_list? stages)
+				(and (number? input_rows)
+					(and (number? joined_rows)
+						(and (number? offset)
+							(and (>= limit 0)
+								(and (not (empty_list? order_items))
+									(and (reduce sources (lambda (ok src)
+										(and ok (and (source_is_base_table? src)
+											(not (source_outer? src))))) true)
+										(and (reduce joins (lambda (ok clauses)
+											(and ok (not (empty_list? clauses)))) true)
+											(reduce order_entries (lambda (ok entry)
+												(and ok (not (nil? entry)))) true)))))))))))
+		(if (not supported)
+			nil
+			(list
+				(list (quote sources) sources)
+				(list (quote joins) joins)
+				(list (quote local_terms) local_terms)
+				(list (quote residual) (combine_where_terms residual_terms true))
+				(list (quote order_entries) order_entries)
+				(list (quote map_refs) (scan_join_order_refs_for_exprs
+					sources default_alias needed_exprs))
+				(list (quote input_rows) input_rows)
+				(list (quote joined_rows) joined_rows)
+				(list (quote output_rows) output_rows)
+				(list (quote table_count) (count sources))
+				(list (quote offset) offset)
+				(list (quote limit) limit)
+				(list (quote cost) (planner_scan_join_order_cost
+					input_rows joined_rows (count sources) output_rows)))))))
+
+(define join_ordered_streaming_limit_legacy_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
 	(begin
 		(define ordered_aliases (join_optimizer_tree_aliases plan))
 		(define ordered_sources (join_optimizer_sources_for_order all_sources ordered_aliases))
@@ -4523,6 +4709,129 @@ move the window to the wrong tree level. */
 		(if use_membership_keyset
 			(wrap_membership_keyset_bindings membership_keysets window_expr)
 			window_expr))))
+
+(define scan_join_order_emit_plan (lambda (spec default_alias needed_exprs value_builder reduce_expr neutral_expr stages)
+	(begin
+		(define sources (qassoc_get spec (quote sources) '()))
+		(define local_terms (qassoc_get spec (quote local_terms) '()))
+		(define residual (qassoc_get spec (quote residual) true))
+		(define order_entries (qassoc_get spec (quote order_entries) '()))
+		(define map_refs (qassoc_get spec (quote map_refs) '()))
+		(define filtercols (map (produceN (count sources)) (lambda (index)
+			(begin
+				(define src (nth sources index))
+				(join_cols_for_alias sources default_alias (source_alias src)
+					(list (combine_where_terms (nth local_terms index) true)))))))
+		(define filterfns (map (produceN (count sources)) (lambda (index)
+			(begin
+				(define src (nth sources index))
+				(define cols (nth filtercols index))
+				(list (quote lambda)
+					(map cols (lambda (col)
+						(scan_callback_symbol_for_alias (source_alias src) col)))
+					(lower_column_expr_for_alias src
+						(combine_where_terms (nth local_terms index) true)))))))
+		(define residual_refs (scan_join_order_refs_for_exprs
+			sources default_alias (list residual)))
+		(define join_filter (if (equal? residual true)
+			nil
+			(list (quote lambda)
+				(scan_join_order_ref_params sources residual_refs)
+				(lower_column_expr_for_join_truth_context
+					sources default_alias residual
+					(qassoc_get spec (quote output_rows) nil)))))
+		(define map_body (value_builder
+			(qassoc_get spec (quote output_rows) nil) nil))
+		(list (quote scan_join_order)
+			'(session "__memcp_tx")
+			(cons (quote list) (map sources (lambda (src)
+				(source_table_expr_using stages src))))
+			(quoted_runtime_list filtercols)
+			(cons (quote list) filterfns)
+			(quoted_runtime_list (qassoc_get spec (quote joins) '()))
+			(quoted_runtime_list residual_refs)
+			join_filter
+			(quoted_runtime_list (map order_entries car))
+			(cons (quote list) (map order_entries cadr))
+			0
+			(qassoc_get spec (quote offset) 0)
+			(qassoc_get spec (quote limit) -1)
+			(quoted_runtime_list map_refs)
+			(list (quote lambda)
+				(scan_join_order_ref_params sources map_refs)
+				map_body)
+			reduce_expr neutral_expr nil false neutral_expr))))
+
+(define join_ordered_streaming_limit_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
+	(begin
+		(define spec (scan_join_order_spec all_sources plan default_alias needed_exprs
+			final_condition order_items offset_value limit_value stages facts))
+		(if (nil? spec)
+			(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
+				output_exprs needed_exprs final_condition order_items offset_value limit_value
+				stages facts value_builder reduce_expr neutral_expr)
+			(begin
+				(define joined_rows (qassoc_get spec (quote joined_rows) 0))
+				(define input_rows (qassoc_get spec (quote input_rows) 0))
+				(define output_rows (qassoc_get spec (quote output_rows) 0))
+				(define scan_cost (qassoc_get spec (quote cost) nil))
+				/* join_estimated_cost is the optimizer's scalar DP rank. Physical
+				alternatives compare the calibrated cost-domain record instead. */
+				(define estimated_legacy_cost (qassoc_get facts (quote join_cost) nil))
+				(define sources (qassoc_get spec (quote sources) '()))
+				(define projected_legacy_cost (ordered_join_projected_candidate_cost
+					all_sources default_alias (car sources) (cdr sources)
+					final_condition offset_value limit_value))
+				(define logical_legacy_cost (if (nil? estimated_legacy_cost)
+					(planner_cost_add
+						(planner_scan_cost input_rows 0.5)
+						(planner_join_work_cost joined_rows 0.5)
+						joined_rows 0.5)
+					estimated_legacy_cost))
+				/* The legacy ordered tree performs one downstream lookup per driver
+				row. A projected carrier reduces that work to its exact projected
+				driver cardinality; otherwise the complete ordered input remains live. */
+				(define legacy_probe_rows (if (nil? projected_legacy_cost)
+					input_rows (cadr projected_legacy_cost)))
+				(define legacy_base_cost (if (nil? projected_legacy_cost)
+					logical_legacy_cost (car projected_legacy_cost)))
+				(define legacy_cost (planner_cost_add legacy_base_cost
+					(planner_join_work_cost legacy_probe_rows 0.65)
+					(coalesceNil joined_rows legacy_probe_rows) 0.65))
+				(define normal_choice (if (planner_cost_better? scan_cost legacy_cost)
+					"scan_join_order" "legacy_join_tree"))
+				(define decision_id (concat "scan_join_order:"
+					(stable_structural_hash (join_optimizer_tree_aliases plan) true)))
+				(define alternatives (list "legacy_join_tree" "scan_join_order"))
+				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
+				(define forced (planner_physical_override decision_id))
+				(planner_record_physical_decision (list
+					(list "decision_id" decision_id)
+					(list "decision" "scan_join_order")
+					(list "decision_site" "ordered_join_stream")
+					(list "chosen" chosen)
+					(list "normally_chosen" normal_choice)
+					(list "selection" (if (nil? forced) "cost" "calibration_override"))
+					(list "reason" (if (nil? forced) "lowest_total_ns" "calibration_override"))
+					(list "inputs" (list
+						(list "join_input_rows" input_rows)
+						(list "join_estimated_rows" joined_rows)
+						(list "join_output_rows" output_rows)
+						(list "join_table_count" (qassoc_get spec (quote table_count) 0))
+						(list "join_legacy_probe_rows" legacy_probe_rows)
+						(list "limit" (qassoc_get spec (quote limit) -1))
+						(list "offset" (qassoc_get spec (quote offset) 0))))
+					(list "alternatives" (list
+						(list (list "plan" "legacy_join_tree")
+							(list "cost" (planner_cost_explain legacy_cost)))
+						(list (list "plan" "scan_join_order")
+							(list "cost" (planner_cost_explain scan_cost)))))))
+				(if (equal? chosen "scan_join_order")
+					(scan_join_order_emit_plan spec default_alias needed_exprs
+						value_builder reduce_expr neutral_expr stages)
+					(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
+						output_exprs needed_exprs final_condition order_items offset_value limit_value
+						stages facts value_builder reduce_expr neutral_expr)))))))
 
 (define without_col (lambda (cols col)
 	(filter (coalesceNil cols '()) (lambda (item) (not (equal? item col))))))
@@ -4946,7 +5255,7 @@ topology inequality by bounded binary search and guard that crossover. */
 						crossover_rows)))
 			(define alternatives (list candidate_plan "fused_base_scan"))
 			(define chosen (planner_physical_choice decision_id normal_choice alternatives))
-			(define forced (planner_physical_override decision_id))
+			(define forced nil)
 			(planner_record_physical_decision (list
 				(list "decision_id" decision_id)
 				(list "decision" "scan_access_path")
@@ -7658,7 +7967,10 @@ ordering run. Storage artifacts begin in build_queryplan. */
 		(define kind (qassoc_get decision "decision" nil))
 		(if (equal? kind "membership_carrier")
 			(physical_membership_operator_family plan)
-			"unknown"))))
+			(if (equal? kind "scan_join_order")
+				(if (physical_expr_has_head? plan (quote scan_join_order))
+					"scan_join_order" "legacy_join_tree")
+				"unknown")))))
 
 /* recset_project_join is adaptive only inside the physical operator: actual
 source-key and per-shard target cardinalities are available there, while the
@@ -7727,7 +8039,8 @@ potentially large calibrated SELECT result. */
 	(begin
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
 		(define decision_kind (qassoc_get decision "decision" nil))
-		(define expected_family (if (equal? decision_kind "membership_carrier")
+		(define expected_family (if (or (equal? decision_kind "membership_carrier")
+			(equal? decision_kind "scan_join_order"))
 			variant operator_family))
 		(define consistent (equal? operator_family expected_family))
 		(define baseline_hash_key (concat "hash:" decision_id))
@@ -7809,6 +8122,11 @@ potentially large calibrated SELECT result. */
 							"driver_map_columns" (physical_calibration_input decision "driver_map_columns")
 							"driver_expression_operations" (physical_calibration_input decision "driver_expression_operations")
 							"driver_expression_depth" (physical_calibration_input decision "driver_expression_depth")
+							"join_input_rows" (physical_calibration_input decision "join_input_rows")
+							"join_estimated_rows" (physical_calibration_input decision "join_estimated_rows")
+							"join_output_rows" (physical_calibration_input decision "join_output_rows")
+							"join_table_count" (physical_calibration_input decision "join_table_count")
+							"join_legacy_probe_rows" (physical_calibration_input decision "join_legacy_probe_rows")
 							"rows" (quote __calibration_rows)
 							"result_hash" (quote __calibration_hash)
 							"result_equal" (quote __calibration_equal)))))

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -21,6 +21,49 @@ import "runtime"
 import "container/heap"
 import "github.com/launix-de/memcp/scm"
 
+func optimizeScanJoinOrder(v []scm.Scmer, oc *scm.OptimizerContext, _ bool) (scm.Scmer, *scm.TypeDescriptor) {
+	const mapIdx, reduceIdx, neutralIdx, reduce2Idx, outerIdx, notFoundIdx = 14, 15, 16, 17, 18, 19
+	rawMap := v[mapIdx]
+	rawReduce := scm.NewNil()
+	rawReduce2 := scm.NewNil()
+	if len(v) > reduceIdx {
+		rawReduce = v[reduceIdx]
+	}
+	if len(v) > reduce2Idx {
+		rawReduce2 = v[reduce2Idx]
+	}
+	for i := 1; i < mapIdx && i < len(v); i++ {
+		v[i], _ = oc.OptimizeSub(v[i], true)
+	}
+	neutralType := unknownScanType()
+	if len(v) > neutralIdx {
+		v[neutralIdx], neutralType = oc.OptimizeSub(v[neutralIdx], true)
+		neutralType = normalizeScanType(neutralType)
+	}
+	if !rawReduce.IsNil() {
+		oc.SetCallbackReturnFlow(scm.CallbackReturnFlow(rawMap, rawReduce, 1))
+	}
+	oc.Ome.IncrLoopDepth()
+	optimizedMap, mapType := oc.OptimizeSub(rawMap, true)
+	v[mapIdx] = optimizedMap
+	mapType = normalizeScanType(mapType)
+	resultType := neutralType
+	if !rawReduce.IsNil() {
+		v[reduceIdx], resultType = oc.OptimizeReducerCallback(rawReduce, neutralType, mapType)
+	}
+	if !rawReduce2.IsNil() {
+		v[reduce2Idx], resultType = oc.OptimizeReducerCallback(rawReduce2, resultType, resultType)
+	}
+	if len(v) > outerIdx {
+		v[outerIdx], _ = oc.OptimizeSub(v[outerIdx], true)
+	}
+	if len(v) > notFoundIdx {
+		v[notFoundIdx], _ = oc.OptimizeSub(v[notFoundIdx], true)
+	}
+	oc.Ome.DecrLoopDepth()
+	return scm.NewSlice(v), resultType
+}
+
 // scanJoinOrderColumn identifies one physical column in the joined tuple.
 // Table is the zero-based position in scanJoinOrderSpec.inputs.
 type scanJoinOrderColumn struct {
@@ -1364,13 +1407,14 @@ func declareScanJoinOrder(en *scm.Env) {
 				{Kind: "int", Label: "limit", Description: "joined rows emitted in final order; -1 is unlimited"},
 				{Kind: "list", Label: "mapColumns", Description: "joined columns supplied to the sole outer map callback", Element: joinedColumn},
 				{Kind: "func", Label: "map", Description: "map callback evaluated only for final OFFSET/LIMIT rows"},
-				{Kind: "func|nil", Label: "reduce", Description: "reducer applied inside each shard-combination runner; with no reduce2 it is also used by the global ordered collector", Optional: true},
+				{Kind: "func|nil", Label: "reduce", Description: "global reducer; when reduce2 is supplied, this becomes the runner-local first-stage reducer", Optional: true},
 				{Kind: "any", Label: "neutral", Description: "optional reducer neutral value", Optional: true},
-				{Kind: "func|nil", Label: "reduce2", Description: "optional global reducer combining runner-local reduce results; permitted only with offset 0 and unlimited limit -1", Optional: true},
+				{Kind: "func|nil", Label: "reduce2", Description: "optional global second-stage reducer combining runner-local reduce results; permitted only with offset 0 and unlimited limit -1", Optional: true},
 				{Kind: "bool", Label: "isOuter", Description: "optional whole-scan NULL fallback", Optional: true},
 				{Kind: "any", Label: "notFoundValue", Description: "optional result when no joined row is emitted", Optional: true},
 			},
-			Return: &scm.TypeDescriptor{Kind: "any"},
+			Return:   &scm.TypeDescriptor{Kind: "any"},
+			Optimize: optimizeScanJoinOrder,
 		},
 	})
 }

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -1,0 +1,1376 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "sort"
+import "runtime"
+import "container/heap"
+import "github.com/launix-de/memcp/scm"
+
+// scanJoinOrderColumn identifies one physical column in the joined tuple.
+// Table is the zero-based position in scanJoinOrderSpec.inputs.
+type scanJoinOrderColumn struct {
+	table  int
+	column string
+}
+
+// scanJoinOrderInput describes one left-deep equi-join input. The first input
+// is the ORDER BY driver. Every later input joins targetKeyCols against values
+// taken from the already assembled tuple through sourceKeyCols.
+type scanJoinOrderInput struct {
+	table         *table
+	filterCols    []string
+	filter        scm.Scmer
+	sourceKeyCols []scanJoinOrderColumn
+	targetKeyCols []string
+
+	readCols     []string
+	readColIndex map[string]int
+	lateMapCols  []string
+	lateMapIndex map[string]int
+}
+
+type scanJoinOrderSpec struct {
+	inputs []scanJoinOrderInput
+
+	orderCols          []scanJoinOrderColumn
+	orderDirs          []func(...scm.Scmer) scm.Scmer
+	limitPartitionCols int
+	offset             int
+	limit              int
+
+	joinFilterCols []scanJoinOrderColumn
+	joinFilter     scm.Scmer
+	mapCols        []scanJoinOrderColumn
+	mapFn          scm.Scmer
+	reduceFn       scm.Scmer
+	reduce2Fn      scm.Scmer
+	neutral        scm.Scmer
+	isOuter        bool
+	notFoundValue  scm.Scmer
+}
+
+func scanJoinOrderUsesDriverOrder(spec *scanJoinOrderSpec) bool {
+	for _, ref := range spec.orderCols {
+		if ref.table != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type scanJoinOrderRecord struct {
+	shard  *storageShard
+	recid  uint32
+	values []scm.Scmer
+}
+
+type scanJoinOrderTuple struct {
+	records []*scanJoinOrderRecord
+	order   int
+}
+
+type scanJoinOrderShardRange struct {
+	lower          scm.Scmer
+	hasLower       bool
+	lowerExclusive bool
+	upper          scm.Scmer
+	hasUpper       bool
+}
+
+type scanJoinOrderShardStream struct {
+	shard   *storageShard
+	records []*scanJoinOrderRecord
+	ranges  map[string]scanJoinOrderShardRange
+}
+
+type scanJoinOrderTopKCollector struct {
+	spec  *scanJoinOrderSpec
+	keep  int
+	items []*scanJoinOrderTuple
+}
+
+func (collector *scanJoinOrderTopKCollector) Len() int { return len(collector.items) }
+func (collector *scanJoinOrderTopKCollector) Less(i int, j int) bool {
+	// Reverse final order: heap[0] is the worst retained tuple.
+	return lessScanJoinOrderTuple(collector.spec, collector.items[j], collector.items[i])
+}
+func (collector *scanJoinOrderTopKCollector) Swap(i int, j int) {
+	collector.items[i], collector.items[j] = collector.items[j], collector.items[i]
+}
+func (collector *scanJoinOrderTopKCollector) Push(value any) {
+	collector.items = append(collector.items, value.(*scanJoinOrderTuple))
+}
+func (collector *scanJoinOrderTopKCollector) Pop() any {
+	last := len(collector.items) - 1
+	value := collector.items[last]
+	collector.items[last] = nil
+	collector.items = collector.items[:last]
+	return value
+}
+func (collector *scanJoinOrderTopKCollector) add(tuple *scanJoinOrderTuple) {
+	if collector.keep < 0 {
+		collector.items = append(collector.items, tuple)
+		return
+	}
+	if collector.keep == 0 {
+		return
+	}
+	if len(collector.items) < collector.keep {
+		heap.Push(collector, tuple)
+		return
+	}
+	if lessScanJoinOrderTuple(collector.spec, tuple, collector.items[0]) {
+		collector.items[0] = tuple
+		heap.Fix(collector, 0)
+	}
+}
+
+func (collector *scanJoinOrderTopKCollector) sorted() []*scanJoinOrderTuple {
+	sort.SliceStable(collector.items, func(i int, j int) bool {
+		return lessScanJoinOrderTuple(collector.spec, collector.items[i], collector.items[j])
+	})
+	return collector.items
+}
+
+func scanJoinTrue() scm.Scmer {
+	return scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+}
+
+func scanJoinOrderReducer(reducer scm.Scmer) func(...scm.Scmer) scm.Scmer {
+	if reducer.IsNil() {
+		return func(values ...scm.Scmer) scm.Scmer { return values[1] }
+	}
+	return scm.OptimizeProcToSerialFunction(reducer)
+}
+
+func appendScanJoinColumn(cols []string, indexes map[string]int, col string) ([]string, map[string]int) {
+	if indexes == nil {
+		indexes = make(map[string]int)
+	}
+	if _, exists := indexes[col]; !exists {
+		indexes[col] = len(cols)
+		cols = append(cols, col)
+	}
+	return cols, indexes
+}
+
+func prepareScanJoinOrderSpec(spec *scanJoinOrderSpec) {
+	if len(spec.inputs) == 0 {
+		panic("scan_join_order: at least one input table is required")
+	}
+	if spec.offset < 0 || spec.limit < -1 {
+		panic("scan_join_order: invalid offset or limit")
+	}
+	if spec.limitPartitionCols != 0 {
+		panic("scan_join_order: partitioned limits are not supported")
+	}
+	if !spec.reduce2Fn.IsNil() && (spec.offset != 0 || spec.limit != -1) {
+		panic("scan_join_order: reduce2 requires an unlimited scan without offset")
+	}
+	if len(spec.orderCols) != len(spec.orderDirs) {
+		panic("scan_join_order: order columns and directions must have equal length")
+	}
+	for i := range spec.inputs {
+		input := &spec.inputs[i]
+		if input.table == nil {
+			panic("scan_join_order: input table is nil")
+		}
+		if input.filter.IsNil() {
+			input.filter = scanJoinTrue()
+		}
+		if i == 0 {
+			if len(input.sourceKeyCols) != 0 || len(input.targetKeyCols) != 0 {
+				panic("scan_join_order: driver input must not declare join keys")
+			}
+		} else if len(input.sourceKeyCols) == 0 || len(input.sourceKeyCols) != len(input.targetKeyCols) {
+			panic("scan_join_order: each inner input needs equally wide source and target join keys")
+		}
+		for _, ref := range input.sourceKeyCols {
+			if ref.table < 0 || ref.table >= i {
+				panic("scan_join_order: source join columns must reference an earlier input")
+			}
+		}
+		for _, col := range input.filterCols {
+			input.readCols, input.readColIndex = appendScanJoinColumn(input.readCols, input.readColIndex, col)
+		}
+		for _, col := range input.targetKeyCols {
+			input.readCols, input.readColIndex = appendScanJoinColumn(input.readCols, input.readColIndex, col)
+		}
+	}
+	allRefs := make([]scanJoinOrderColumn, 0, len(spec.orderCols)+len(spec.joinFilterCols))
+	allRefs = append(allRefs, spec.orderCols...)
+	allRefs = append(allRefs, spec.joinFilterCols...)
+	for i := 1; i < len(spec.inputs); i++ {
+		allRefs = append(allRefs, spec.inputs[i].sourceKeyCols...)
+		spec.inputs[i].table.AddPartitioningScore(spec.inputs[i].targetKeyCols)
+		for _, ref := range spec.inputs[i].sourceKeyCols {
+			spec.inputs[ref.table].table.AddPartitioningScore([]string{ref.column})
+		}
+	}
+	for _, ref := range allRefs {
+		if ref.table < 0 || ref.table >= len(spec.inputs) {
+			panic("scan_join_order: joined column references an unknown input")
+		}
+		input := &spec.inputs[ref.table]
+		input.readCols, input.readColIndex = appendScanJoinColumn(input.readCols, input.readColIndex, ref.column)
+	}
+	for _, ref := range spec.mapCols {
+		if ref.table < 0 || ref.table >= len(spec.inputs) {
+			panic("scan_join_order: mapped column references an unknown input")
+		}
+		input := &spec.inputs[ref.table]
+		if _, prepared := input.readColIndex[ref.column]; !prepared {
+			input.lateMapCols, input.lateMapIndex = appendScanJoinColumn(input.lateMapCols, input.lateMapIndex, ref.column)
+		}
+	}
+}
+
+func collectScanJoinOrderRecords(currentTx *TxContext, input *scanJoinOrderInput, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int, acceptCols []string, accept scm.Scmer) []orderedBatchRecord {
+	records := make([]orderedBatchRecord, 0)
+	source := scanOrderTableSpec{
+		table:          input.table,
+		conditionCols:  input.filterCols,
+		condition:      input.filter,
+		acceptCols:     acceptCols,
+		accept:         accept,
+		sortcols:       sortcols,
+		callbackCols:   nil,
+		callback:       scm.NewNil(),
+		perTableOffset: -1,
+		perTableLimit:  -1,
+	}
+	source.recordVisitor = func(queue *shardqueue, recids []uint32) {
+		for _, recid := range recids {
+			records = append(records, orderedBatchRecord{shard: queue.shard, recid: recid})
+		}
+	}
+	scanOrderMulti(currentTx, []scanOrderTableSpec{source}, sortdirs, 0, offset, limit,
+		scm.NewNil(), scm.NewNil(), false, scm.NewNil())
+	return records
+}
+
+func materializeScanJoinRecords(currentTx *TxContext, input *scanJoinOrderInput, refs []orderedBatchRecord) []*scanJoinOrderRecord {
+	result := make([]*scanJoinOrderRecord, 0, len(refs))
+	mappers := make(map[*storageShard]*ShardMapReducer)
+	identity := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewSlice(append([]scm.Scmer(nil), values...))
+	})
+	defer func() {
+		for _, mapper := range mappers {
+			mapper.Close()
+		}
+	}()
+	for _, ref := range refs {
+		mapper := mappers[ref.shard]
+		if mapper == nil {
+			mapper = ref.shard.OpenMapReducer(input.readCols, identity, scm.NewNil(), false, 0, nil, currentTx)
+			mappers[ref.shard] = mapper
+		}
+		values := mapper.MapOne(ref.recid)
+		result = append(result, &scanJoinOrderRecord{shard: ref.shard, recid: ref.recid, values: values.Slice()})
+	}
+	return result
+}
+
+type scanJoinOrderDriverConstraint struct {
+	positions []int
+	keys      [][]scm.Scmer
+}
+
+// scanJoinOrderCandidateDriver narrows the ordered driver with join keys that
+// survived directly joined inner-table filters. It is returned separately
+// from the driver predicate so every shard owns both optimized callbacks while
+// the original predicate remains available for boundary extraction.
+func scanJoinOrderCandidateDriver(spec *scanJoinOrderSpec, innerRecords [][]*scanJoinOrderRecord) (scanJoinOrderInput, []string, scm.Scmer) {
+	driver := spec.inputs[0]
+	columns := make([]string, 0)
+	columnIndexes := make(map[string]int)
+	constraints := make([]scanJoinOrderDriverConstraint, 0, len(spec.inputs)-1)
+	for inputIndex := 1; inputIndex < len(spec.inputs); inputIndex++ {
+		inner := &spec.inputs[inputIndex]
+		positions := make([]int, len(inner.sourceKeyCols))
+		direct := true
+		for i, ref := range inner.sourceKeyCols {
+			if ref.table != 0 {
+				direct = false
+				break
+			}
+			position, found := columnIndexes[ref.column]
+			if !found {
+				position = len(columns)
+				columnIndexes[ref.column] = position
+				columns = append(columns, ref.column)
+			}
+			positions[i] = position
+		}
+		if !direct {
+			continue
+		}
+		keys := make([][]scm.Scmer, 0, len(innerRecords[inputIndex]))
+		for _, record := range innerRecords[inputIndex] {
+			key := scanJoinOrderRecordKey(inner, record, inner.targetKeyCols, nil)
+			if scanJoinOrderKeyHasNull(key) || (len(keys) > 0 && compareProjectKey(keys[len(keys)-1], key) == 0) {
+				continue
+			}
+			keys = append(keys, append([]scm.Scmer(nil), key...))
+		}
+		constraints = append(constraints, scanJoinOrderDriverConstraint{positions: positions, keys: keys})
+	}
+	if len(constraints) == 0 {
+		return driver, nil, scm.NewNil()
+	}
+	predicate := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		for _, constraint := range constraints {
+			key := make([]scm.Scmer, len(constraint.positions))
+			for i, position := range constraint.positions {
+				key[i] = values[position]
+			}
+			if scanJoinOrderKeyHasNull(key) {
+				return scm.NewBool(false)
+			}
+			position := sort.Search(len(constraint.keys), func(i int) bool {
+				return compareProjectKey(constraint.keys[i], key) >= 0
+			})
+			if position == len(constraint.keys) || compareProjectKey(constraint.keys[position], key) != 0 {
+				return scm.NewBool(false)
+			}
+		}
+		return scm.NewBool(true)
+	})
+	if len(driver.filterCols) == 0 {
+		driver.filterCols = columns
+		driver.filter = predicate
+		return driver, nil, scm.NewNil()
+	}
+	return driver, columns, predicate
+}
+
+func scanJoinOrderRecordValue(input *scanJoinOrderInput, record *scanJoinOrderRecord, col string) scm.Scmer {
+	position, found := input.readColIndex[col]
+	if !found {
+		panic("scan_join_order: column was not prepared")
+	}
+	return record.values[position]
+}
+
+func scanJoinOrderTupleValues(spec *scanJoinOrderSpec, tuple *scanJoinOrderTuple, refs []scanJoinOrderColumn, dst []scm.Scmer) []scm.Scmer {
+	if cap(dst) < len(refs) {
+		dst = make([]scm.Scmer, len(refs))
+	} else {
+		dst = dst[:len(refs)]
+	}
+	for i, ref := range refs {
+		dst[i] = scanJoinOrderRecordValue(&spec.inputs[ref.table], tuple.records[ref.table], ref.column)
+	}
+	return dst
+}
+
+type scanJoinOrderMapReaders struct {
+	currentTx *TxContext
+	spec      *scanJoinOrderSpec
+	mappers   []map[*storageShard]*ShardMapReducer
+	identity  scm.Scmer
+}
+
+func newScanJoinOrderMapReaders(currentTx *TxContext, spec *scanJoinOrderSpec) *scanJoinOrderMapReaders {
+	return &scanJoinOrderMapReaders{
+		currentTx: currentTx,
+		spec:      spec,
+		mappers:   make([]map[*storageShard]*ShardMapReducer, len(spec.inputs)),
+		identity: scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			return scm.NewSlice(append([]scm.Scmer(nil), values...))
+		}),
+	}
+}
+
+func (readers *scanJoinOrderMapReaders) close() {
+	for _, inputMappers := range readers.mappers {
+		for _, mapper := range inputMappers {
+			mapper.Close()
+		}
+	}
+}
+
+func (readers *scanJoinOrderMapReaders) values(tuple *scanJoinOrderTuple, dst []scm.Scmer) []scm.Scmer {
+	if cap(dst) < len(readers.spec.mapCols) {
+		dst = make([]scm.Scmer, len(readers.spec.mapCols))
+	} else {
+		dst = dst[:len(readers.spec.mapCols)]
+	}
+	lateValues := make([][]scm.Scmer, len(readers.spec.inputs))
+	for i, ref := range readers.spec.mapCols {
+		input := &readers.spec.inputs[ref.table]
+		record := tuple.records[ref.table]
+		if position, prepared := input.readColIndex[ref.column]; prepared {
+			dst[i] = record.values[position]
+			continue
+		}
+		if lateValues[ref.table] == nil {
+			inputMappers := readers.mappers[ref.table]
+			if inputMappers == nil {
+				inputMappers = make(map[*storageShard]*ShardMapReducer)
+				readers.mappers[ref.table] = inputMappers
+			}
+			mapper := inputMappers[record.shard]
+			if mapper == nil {
+				mapper = record.shard.OpenMapReducer(input.lateMapCols, readers.identity, scm.NewNil(), false, 0, nil, readers.currentTx)
+				inputMappers[record.shard] = mapper
+			}
+			lateValues[ref.table] = mapper.MapOne(record.recid).Slice()
+		}
+		dst[i] = lateValues[ref.table][input.lateMapIndex[ref.column]]
+	}
+	return dst
+}
+
+func scanJoinOrderKeyHasNull(key []scm.Scmer) bool {
+	for _, value := range key {
+		if value.IsNil() {
+			return true
+		}
+	}
+	return false
+}
+
+func scanJoinOrderRecordKey(input *scanJoinOrderInput, record *scanJoinOrderRecord, cols []string, dst []scm.Scmer) []scm.Scmer {
+	if cap(dst) < len(cols) {
+		dst = make([]scm.Scmer, len(cols))
+	} else {
+		dst = dst[:len(cols)]
+	}
+	for i, col := range cols {
+		dst[i] = scanJoinOrderRecordValue(input, record, col)
+	}
+	return dst
+}
+
+func scanJoinOrderTupleKey(spec *scanJoinOrderSpec, tuple *scanJoinOrderTuple, refs []scanJoinOrderColumn, dst []scm.Scmer) []scm.Scmer {
+	return scanJoinOrderTupleValues(spec, tuple, refs, dst)
+}
+
+func joinScanOrderInputRange(spec *scanJoinOrderSpec, tuples []*scanJoinOrderTuple, inputIndex int, inner []*scanJoinOrderRecord) []*scanJoinOrderTuple {
+	input := &spec.inputs[inputIndex]
+	result := make([]*scanJoinOrderTuple, 0, len(tuples))
+	for _, tuple := range tuples {
+		key := scanJoinOrderTupleKey(spec, tuple, input.sourceKeyCols, nil)
+		if scanJoinOrderKeyHasNull(key) {
+			continue
+		}
+		start := sort.Search(len(inner), func(i int) bool {
+			candidate := scanJoinOrderRecordKey(input, inner[i], input.targetKeyCols, nil)
+			return compareProjectKey(candidate, key) >= 0
+		})
+		for position := start; position < len(inner); position++ {
+			candidate := scanJoinOrderRecordKey(input, inner[position], input.targetKeyCols, nil)
+			comparison := compareProjectKey(candidate, key)
+			if comparison != 0 {
+				break
+			}
+			records := make([]*scanJoinOrderRecord, len(tuple.records)+1)
+			copy(records, tuple.records)
+			records[len(tuple.records)] = inner[position]
+			result = append(result, &scanJoinOrderTuple{records: records, order: tuple.order})
+		}
+	}
+	return result
+}
+
+type scanJoinOrderPartition struct {
+	innerStart int
+	innerEnd   int
+	upperKey   []scm.Scmer
+	tuples     []*scanJoinOrderTuple
+}
+
+func scanJoinOrderWorkerCount(tupleCount int, innerCount int) int {
+	work := tupleCount + innerCount
+	if tupleCount < 256 || innerCount < 256 || work < 4096 {
+		return 1
+	}
+	workers := runtime.GOMAXPROCS(0) / 2
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > 8 {
+		workers = 8
+	}
+	return workers
+}
+
+// scanJoinOrderPartitions cuts only between complete duplicate-key groups.
+// This is what makes it safe to execute a join partition independently: one
+// SQL equi-key and its complete cross product can never straddle workers.
+func scanJoinOrderPartitions(input *scanJoinOrderInput, inner []*scanJoinOrderRecord, count int) []scanJoinOrderPartition {
+	if count <= 1 || len(inner) == 0 {
+		return []scanJoinOrderPartition{{innerEnd: len(inner)}}
+	}
+	result := make([]scanJoinOrderPartition, 0, count)
+	start := 0
+	for part := 1; part <= count && start < len(inner); part++ {
+		end := len(inner) * part / count
+		if part == count || end >= len(inner) {
+			end = len(inner)
+		} else {
+			previous := scanJoinOrderRecordKey(input, inner[end-1], input.targetKeyCols, nil)
+			for end < len(inner) {
+				current := scanJoinOrderRecordKey(input, inner[end], input.targetKeyCols, nil)
+				if compareProjectKey(previous, current) != 0 {
+					break
+				}
+				end++
+			}
+		}
+		if end <= start {
+			continue
+		}
+		upper := scanJoinOrderRecordKey(input, inner[end-1], input.targetKeyCols, nil)
+		result = append(result, scanJoinOrderPartition{
+			innerStart: start,
+			innerEnd:   end,
+			upperKey:   append([]scm.Scmer(nil), upper...),
+		})
+		start = end
+	}
+	return result
+}
+
+// scanJoinOrderShardPartitions retains an existing leading range partition on
+// a single-column join key. The same pivot semantics are used by shard pruning,
+// so each worker stays within the smallest available set of physical shards.
+// Composite and non-leading dimensions fall back to query-local key ranges.
+func scanJoinOrderShardPartitions(input *scanJoinOrderInput, inner []*scanJoinOrderRecord) ([]scanJoinOrderPartition, bool) {
+	if len(input.targetKeyCols) != 1 || len(inner) == 0 {
+		return nil, false
+	}
+	topology := input.table.activeTopology()
+	if topology.mode != ShardModePartition || len(topology.dimensions) == 0 ||
+		topology.dimensions[0].Column != input.targetKeyCols[0] ||
+		topology.dimensions[0].NumPartitions < 2 {
+		return nil, false
+	}
+	result := make([]scanJoinOrderPartition, 0, topology.dimensions[0].NumPartitions)
+	start := 0
+	for _, pivot := range topology.dimensions[0].Pivots {
+		end := sort.Search(len(inner), func(i int) bool {
+			key := scanJoinOrderRecordKey(input, inner[i], input.targetKeyCols, nil)
+			return scm.Less(pivot, key[0])
+		})
+		if end > start {
+			upper := scanJoinOrderRecordKey(input, inner[end-1], input.targetKeyCols, nil)
+			result = append(result, scanJoinOrderPartition{
+				innerStart: start,
+				innerEnd:   end,
+				upperKey:   append([]scm.Scmer(nil), upper...),
+			})
+		}
+		start = end
+	}
+	if start < len(inner) {
+		upper := scanJoinOrderRecordKey(input, inner[len(inner)-1], input.targetKeyCols, nil)
+		result = append(result, scanJoinOrderPartition{
+			innerStart: start,
+			innerEnd:   len(inner),
+			upperKey:   append([]scm.Scmer(nil), upper...),
+		})
+	}
+	return result, len(result) > 0
+}
+
+func mergeScanJoinOrderResults(left []*scanJoinOrderTuple, right []*scanJoinOrderTuple) []*scanJoinOrderTuple {
+	result := make([]*scanJoinOrderTuple, 0, len(left)+len(right))
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		if left[i].order <= right[j].order {
+			result = append(result, left[i])
+			i++
+		} else {
+			result = append(result, right[j])
+			j++
+		}
+	}
+	result = append(result, left[i:]...)
+	result = append(result, right[j:]...)
+	return result
+}
+
+func mergeScanJoinOrderPartitions(results [][]*scanJoinOrderTuple) []*scanJoinOrderTuple {
+	for len(results) > 1 {
+		next := make([][]*scanJoinOrderTuple, 0, (len(results)+1)/2)
+		for i := 0; i < len(results); i += 2 {
+			if i+1 == len(results) {
+				next = append(next, results[i])
+			} else {
+				next = append(next, mergeScanJoinOrderResults(results[i], results[i+1]))
+			}
+		}
+		results = next
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	for i, tuple := range results[0] {
+		tuple.order = i
+	}
+	return results[0]
+}
+
+func joinScanOrderInput(currentTx *TxContext, spec *scanJoinOrderSpec, tuples []*scanJoinOrderTuple, inputIndex int, inner []*scanJoinOrderRecord) []*scanJoinOrderTuple {
+	if len(tuples) == 0 || len(inner) == 0 {
+		return nil
+	}
+	input := &spec.inputs[inputIndex]
+	partitions, physical := scanJoinOrderShardPartitions(input, inner)
+	if !physical {
+		partitions = scanJoinOrderPartitions(input, inner, scanJoinOrderWorkerCount(len(tuples), len(inner)))
+	}
+	for _, tuple := range tuples {
+		key := scanJoinOrderTupleKey(spec, tuple, input.sourceKeyCols, nil)
+		if scanJoinOrderKeyHasNull(key) {
+			continue
+		}
+		partition := sort.Search(len(partitions), func(i int) bool {
+			return compareProjectKey(partitions[i].upperKey, key) >= 0
+		})
+		if partition < len(partitions) {
+			partitions[partition].tuples = append(partitions[partition].tuples, tuple)
+		}
+	}
+	results := make([][]*scanJoinOrderTuple, len(partitions))
+	done := runFanoutTasks(currentTx, len(partitions), func(partition int, _ bool) {
+		part := &partitions[partition]
+		results[partition] = joinScanOrderInputRange(spec, part.tuples, inputIndex, inner[part.innerStart:part.innerEnd])
+	})
+	if done != nil {
+		<-done
+	}
+	return mergeScanJoinOrderPartitions(results)
+}
+
+func lessScanJoinOrderTuple(spec *scanJoinOrderSpec, left *scanJoinOrderTuple, right *scanJoinOrderTuple) bool {
+	leftValues := scanJoinOrderTupleValues(spec, left, spec.orderCols, nil)
+	rightValues := scanJoinOrderTupleValues(spec, right, spec.orderCols, nil)
+	for i, relation := range spec.orderDirs {
+		if scm.ToBool(relation(leftValues[i], rightValues[i])) {
+			return true
+		}
+		if scm.ToBool(relation(rightValues[i], leftValues[i])) {
+			return false
+		}
+	}
+	for i := range left.records {
+		leftRecord := left.records[i]
+		rightRecord := right.records[i]
+		for b := range leftRecord.shard.uuid {
+			if leftRecord.shard.uuid[b] != rightRecord.shard.uuid[b] {
+				return leftRecord.shard.uuid[b] < rightRecord.shard.uuid[b]
+			}
+		}
+		if leftRecord.recid != rightRecord.recid {
+			return leftRecord.recid < rightRecord.recid
+		}
+	}
+	return false
+}
+
+func reduceScanJoinOrderTuples(currentTx *TxContext, spec *scanJoinOrderSpec, tuples []*scanJoinOrderTuple, result scm.Scmer, emitted *int) (scm.Scmer, bool) {
+	if len(tuples) == 0 {
+		return result, false
+	}
+	mapFn := scm.OptimizeProcToSerialFunction(spec.mapFn)
+	reduceFn := scanJoinOrderReducer(spec.reduceFn)
+	if spec.reduce2Fn.IsNil() {
+		readers := newScanJoinOrderMapReaders(currentTx, spec)
+		defer readers.close()
+		var args []scm.Scmer
+		for _, tuple := range tuples {
+			args = readers.values(tuple, args)
+			result = reduceFn(result, mapFn(args...))
+			*emitted++
+		}
+		return result, true
+	}
+
+	workers := scanJoinOrderWorkerCount(len(tuples), len(tuples))
+	chunkSize := (len(tuples) + workers - 1) / workers
+	tasks := (len(tuples) + chunkSize - 1) / chunkSize
+	partials := make([]scm.Scmer, tasks)
+	done := runFanoutTasks(currentTx, tasks, func(task int, _ bool) {
+		localMap := scm.OptimizeProcToSerialFunction(spec.mapFn)
+		localReduce := scanJoinOrderReducer(spec.reduceFn)
+		readers := newScanJoinOrderMapReaders(currentTx, spec)
+		defer readers.close()
+		partial := spec.neutral
+		start := task * chunkSize
+		end := start + chunkSize
+		if end > len(tuples) {
+			end = len(tuples)
+		}
+		var args []scm.Scmer
+		for i := start; i < end; i++ {
+			args = readers.values(tuples[i], args)
+			partial = localReduce(partial, localMap(args...))
+		}
+		partials[task] = partial
+	})
+	if done != nil {
+		<-done
+	}
+	reduce2Fn := scm.OptimizeProcToSerialFunction(spec.reduce2Fn)
+	for _, partial := range partials {
+		result = reduce2Fn(result, partial)
+	}
+	*emitted += len(tuples)
+	return result, true
+}
+
+func scanJoinOrderBatch(currentTx *TxContext, spec *scanJoinOrderSpec, driverRefs []orderedBatchRecord, innerRecords [][]*scanJoinOrderRecord) []*scanJoinOrderTuple {
+	driver := materializeScanJoinRecords(currentTx, &spec.inputs[0], driverRefs)
+	tuples := make([]*scanJoinOrderTuple, len(driver))
+	for i, record := range driver {
+		tuples[i] = &scanJoinOrderTuple{records: []*scanJoinOrderRecord{record}, order: i}
+	}
+	for inputIndex := 1; inputIndex < len(spec.inputs) && len(tuples) > 0; inputIndex++ {
+		tuples = joinScanOrderInput(currentTx, spec, tuples, inputIndex, innerRecords[inputIndex])
+	}
+	if spec.joinFilter.IsNil() || len(tuples) == 0 {
+		return tuples
+	}
+	filterFn := scm.OptimizeProcToSerialFunction(spec.joinFilter)
+	filtered := tuples[:0]
+	var args []scm.Scmer
+	for _, tuple := range tuples {
+		args = scanJoinOrderTupleValues(spec, tuple, spec.joinFilterCols, args)
+		if scm.ToBool(filterFn(args...)) {
+			filtered = append(filtered, tuple)
+		}
+	}
+	return filtered
+}
+
+func scanJoinOrderMaterialized(currentTx *TxContext, spec scanJoinOrderSpec) scm.Scmer {
+	prepareScanJoinOrderSpec(&spec)
+	if spec.limit == 0 {
+		return spec.notFoundValue
+	}
+
+	innerRecords := make([][]*scanJoinOrderRecord, len(spec.inputs))
+	for inputIndex := 1; inputIndex < len(spec.inputs); inputIndex++ {
+		input := &spec.inputs[inputIndex]
+		sortcols := make([]scm.Scmer, len(input.targetKeyCols))
+		sortdirs := make([]func(...scm.Scmer) scm.Scmer, len(input.targetKeyCols))
+		for i, col := range input.targetKeyCols {
+			sortcols[i] = scm.NewString(col)
+			sortdirs[i] = func(values ...scm.Scmer) scm.Scmer {
+				return scm.NewBool(scm.Less(values[0], values[1]))
+			}
+		}
+		refs := collectScanJoinOrderRecords(currentTx, input, sortcols, sortdirs, 0, -1, nil, scm.NewNil())
+		innerRecords[inputIndex] = materializeScanJoinRecords(currentTx, input, refs)
+	}
+
+	driverOrdered := scanJoinOrderUsesDriverOrder(&spec)
+	driverInput := spec.inputs[0]
+	var driverAcceptCols []string
+	driverAccept := scm.NewNil()
+	if len(spec.inputs) > 1 {
+		driverInput, driverAcceptCols, driverAccept = scanJoinOrderCandidateDriver(&spec, innerRecords)
+	}
+	driverSortCols := make([]scm.Scmer, 0, len(spec.orderCols))
+	if driverOrdered {
+		for _, ref := range spec.orderCols {
+			driverSortCols = append(driverSortCols, scm.NewString(ref.column))
+		}
+	}
+	reduceFn := scanJoinOrderReducer(spec.reduceFn)
+	result := spec.neutral
+	driverOffset := 0
+	accepted := 0
+	emitted := 0
+	hadValue := false
+	target := spec.offset + spec.limit
+	batchSize := target
+	if spec.limit < 0 || !driverOrdered {
+		batchSize = -1
+		target = int(^uint(0) >> 1)
+	} else if batchSize < 1 {
+		batchSize = 1
+	}
+	for accepted < target {
+		driverRefs := collectScanJoinOrderRecords(currentTx, &driverInput, driverSortCols, spec.orderDirs, driverOffset, batchSize, driverAcceptCols, driverAccept)
+		if len(driverRefs) == 0 {
+			break
+		}
+		tuples := scanJoinOrderBatch(currentTx, &spec, driverRefs, innerRecords)
+		if !driverOrdered {
+			sort.SliceStable(tuples, func(i int, j int) bool {
+				return lessScanJoinOrderTuple(&spec, tuples[i], tuples[j])
+			})
+		}
+		first := 0
+		if accepted < spec.offset {
+			first = spec.offset - accepted
+			if first > len(tuples) {
+				first = len(tuples)
+			}
+		}
+		accepted += len(tuples)
+		last := len(tuples)
+		if spec.limit >= 0 && last-first > spec.limit-emitted {
+			last = first + spec.limit - emitted
+		}
+		var batchHadValue bool
+		result, batchHadValue = reduceScanJoinOrderTuples(currentTx, &spec, tuples[first:last], result, &emitted)
+		hadValue = hadValue || batchHadValue
+		if spec.limit >= 0 && emitted >= spec.limit {
+			break
+		}
+		driverOffset += len(driverRefs)
+		if batchSize < 0 || len(driverRefs) < batchSize {
+			break
+		}
+		batchSize *= 2
+	}
+	if !hadValue && spec.isOuter {
+		mapFn := scm.OptimizeProcToSerialFunction(spec.mapFn)
+		nulls := make([]scm.Scmer, len(spec.mapCols))
+		for i := range nulls {
+			nulls[i] = scm.NewNil()
+		}
+		return reduceFn(result, mapFn(nulls...))
+	}
+	if !hadValue {
+		return spec.notFoundValue
+	}
+	return result
+}
+
+func scanJoinOrderStreamRanges(input *scanJoinOrderInput, shard *storageShard) map[string]scanJoinOrderShardRange {
+	topology := input.table.activeTopology()
+	if topology.mode != ShardModePartition || len(topology.dimensions) == 0 {
+		return nil
+	}
+	shardIndex := -1
+	for i, candidate := range topology.shards {
+		if candidate == shard {
+			shardIndex = i
+			break
+		}
+	}
+	if shardIndex < 0 {
+		return nil
+	}
+	result := make(map[string]scanJoinOrderShardRange, len(topology.dimensions))
+	stride := len(topology.shards)
+	for _, dimension := range topology.dimensions {
+		stride /= dimension.NumPartitions
+		partition := (shardIndex / stride) % dimension.NumPartitions
+		valueRange := scanJoinOrderShardRange{}
+		if partition > 0 {
+			valueRange.lower = dimension.Pivots[partition-1]
+			valueRange.hasLower = true
+			valueRange.lowerExclusive = true
+		}
+		if partition < len(dimension.Pivots) {
+			valueRange.upper = dimension.Pivots[partition]
+			valueRange.hasUpper = true
+		}
+		result[dimension.Column] = valueRange
+	}
+	return result
+}
+
+func scanJoinOrderRangesOverlap(left scanJoinOrderShardRange, right scanJoinOrderShardRange) bool {
+	if left.hasUpper && right.hasLower {
+		if scm.Less(left.upper, right.lower) ||
+			(!scm.Less(left.upper, right.lower) && !scm.Less(right.lower, left.upper) && right.lowerExclusive) {
+			return false
+		}
+	}
+	if right.hasUpper && left.hasLower {
+		if scm.Less(right.upper, left.lower) ||
+			(!scm.Less(right.upper, left.lower) && !scm.Less(left.lower, right.upper) && left.lowerExclusive) {
+			return false
+		}
+	}
+	return true
+}
+
+func collectScanJoinOrderShardStreams(currentTx *TxContext, input *scanJoinOrderInput, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) []*scanJoinOrderShardStream {
+	bounds := extractBoundaries(input.filterCols, input.filter)
+	reorderByFrequency(bounds, input.table)
+	bounds, _ = extendBoundariesWithSortCols(bounds, sortcols, sortdirs)
+	lower, upperLast := indexFromBoundaries(bounds)
+	for _, boundary := range bounds {
+		input.table.AddPartitioningScore([]string{boundary.col})
+	}
+
+	values := make(chan *scanJoinOrderShardStream, input.table.shardResultBufferSize())
+	ss := SessionStateFromTx(currentTx)
+	done := input.table.iterateShardsParallel(currentTx, bounds, func(shard *storageShard, _ bool) {
+		queue := shard.scan_order(bounds, lower, upperLast, input.filterCols, input.filter,
+			nil, scm.NewNil(),
+			sortcols, sortdirs, 0, 0, -1, input.readCols, currentTx, ss)
+		refs := make([]orderedBatchRecord, len(queue.items))
+		for i, recid := range queue.items {
+			refs[i] = orderedBatchRecord{shard: shard, recid: recid}
+		}
+		values <- &scanJoinOrderShardStream{
+			shard:   shard,
+			records: materializeScanJoinRecords(currentTx, input, refs),
+			ranges:  scanJoinOrderStreamRanges(input, shard),
+		}
+	})
+	if done != nil {
+		<-done
+	}
+	close(values)
+	result := make([]*scanJoinOrderShardStream, 0)
+	for stream := range values {
+		if len(stream.records) > 0 {
+			result = append(result, stream)
+		}
+	}
+	return result
+}
+
+func scanJoinOrderStreamsCompatible(spec *scanJoinOrderSpec, selected []*scanJoinOrderShardStream, inputIndex int, candidate *scanJoinOrderShardStream) bool {
+	input := &spec.inputs[inputIndex]
+	for keyIndex, source := range input.sourceKeyCols {
+		sourceRange, sourcePartitioned := selected[source.table].ranges[source.column]
+		targetRange, targetPartitioned := candidate.ranges[input.targetKeyCols[keyIndex]]
+		if sourcePartitioned && targetPartitioned && !scanJoinOrderRangesOverlap(sourceRange, targetRange) {
+			return false
+		}
+	}
+	return true
+}
+
+func scanJoinOrderShardCombinations(spec *scanJoinOrderSpec, streams [][]*scanJoinOrderShardStream) [][]*scanJoinOrderShardStream {
+	result := make([][]*scanJoinOrderShardStream, 0)
+	selected := make([]*scanJoinOrderShardStream, len(streams))
+	var visit func(int)
+	visit = func(inputIndex int) {
+		if inputIndex == len(streams) {
+			combination := append([]*scanJoinOrderShardStream(nil), selected...)
+			result = append(result, combination)
+			return
+		}
+		for _, candidate := range streams[inputIndex] {
+			if inputIndex > 0 && !scanJoinOrderStreamsCompatible(spec, selected, inputIndex, candidate) {
+				continue
+			}
+			selected[inputIndex] = candidate
+			visit(inputIndex + 1)
+		}
+	}
+	visit(0)
+	return result
+}
+
+func sortAndCapScanJoinOrderTuples(spec *scanJoinOrderSpec, tuples []*scanJoinOrderTuple, keep int) []*scanJoinOrderTuple {
+	sort.SliceStable(tuples, func(i int, j int) bool {
+		return lessScanJoinOrderTuple(spec, tuples[i], tuples[j])
+	})
+	if keep >= 0 && len(tuples) > keep {
+		tuples = tuples[:keep]
+	}
+	return tuples
+}
+
+func runScanJoinOrderShardCombination(currentTx *TxContext, spec *scanJoinOrderSpec, combination []*scanJoinOrderShardStream, keep int) []*scanJoinOrderTuple {
+	_ = currentTx
+	collector := &scanJoinOrderTopKCollector{spec: spec, keep: keep}
+	var filterFn func(...scm.Scmer) scm.Scmer
+	if !spec.joinFilter.IsNil() {
+		filterFn = scm.OptimizeProcToSerialFunction(spec.joinFilter)
+	}
+	records := make([]*scanJoinOrderRecord, len(combination))
+	var enumerate func(int)
+	enumerate = func(inputIndex int) {
+		if inputIndex == len(combination) {
+			tuple := &scanJoinOrderTuple{records: append([]*scanJoinOrderRecord(nil), records...)}
+			if filterFn != nil {
+				args := scanJoinOrderTupleValues(spec, tuple, spec.joinFilterCols, nil)
+				if !scm.ToBool(filterFn(args...)) {
+					return
+				}
+			}
+			collector.add(tuple)
+			return
+		}
+		input := &spec.inputs[inputIndex]
+		partial := &scanJoinOrderTuple{records: records[:inputIndex]}
+		key := scanJoinOrderTupleKey(spec, partial, input.sourceKeyCols, nil)
+		if scanJoinOrderKeyHasNull(key) {
+			return
+		}
+		inner := combination[inputIndex].records
+		start := sort.Search(len(inner), func(i int) bool {
+			candidate := scanJoinOrderRecordKey(input, inner[i], input.targetKeyCols, nil)
+			return compareProjectKey(candidate, key) >= 0
+		})
+		for position := start; position < len(inner); position++ {
+			candidate := scanJoinOrderRecordKey(input, inner[position], input.targetKeyCols, nil)
+			if compareProjectKey(candidate, key) != 0 {
+				break
+			}
+			records[inputIndex] = inner[position]
+			enumerate(inputIndex + 1)
+		}
+	}
+	driverOrdered := scanJoinOrderUsesDriverOrder(spec)
+	for _, driverRecord := range combination[0].records {
+		records[0] = driverRecord
+		enumerate(1)
+		// All future driver records sort no better than this completed group.
+		// Inner duplicates for the current driver have already been exhausted.
+		if driverOrdered && keep >= 0 && collector.Len() >= keep {
+			break
+		}
+	}
+	return collector.sorted()
+}
+
+func reduceScanJoinOrderShardCombination(currentTx *TxContext, spec *scanJoinOrderSpec, combination []*scanJoinOrderShardStream) (scm.Scmer, int) {
+	result := spec.neutral
+	count := 0
+	mapFn := scm.OptimizeProcToSerialFunction(spec.mapFn)
+	reduceFn := scanJoinOrderReducer(spec.reduceFn)
+	readers := newScanJoinOrderMapReaders(currentTx, spec)
+	defer readers.close()
+	var filterFn func(...scm.Scmer) scm.Scmer
+	if !spec.joinFilter.IsNil() {
+		filterFn = scm.OptimizeProcToSerialFunction(spec.joinFilter)
+	}
+	records := make([]*scanJoinOrderRecord, len(combination))
+	var enumerate func(int)
+	enumerate = func(inputIndex int) {
+		if inputIndex == len(combination) {
+			tuple := &scanJoinOrderTuple{records: records}
+			if filterFn != nil {
+				filterArgs := scanJoinOrderTupleValues(spec, tuple, spec.joinFilterCols, nil)
+				if !scm.ToBool(filterFn(filterArgs...)) {
+					return
+				}
+			}
+			mapArgs := readers.values(tuple, nil)
+			result = reduceFn(result, mapFn(mapArgs...))
+			count++
+			return
+		}
+		input := &spec.inputs[inputIndex]
+		partial := &scanJoinOrderTuple{records: records[:inputIndex]}
+		key := scanJoinOrderTupleKey(spec, partial, input.sourceKeyCols, nil)
+		if scanJoinOrderKeyHasNull(key) {
+			return
+		}
+		inner := combination[inputIndex].records
+		start := sort.Search(len(inner), func(i int) bool {
+			candidate := scanJoinOrderRecordKey(input, inner[i], input.targetKeyCols, nil)
+			return compareProjectKey(candidate, key) >= 0
+		})
+		for position := start; position < len(inner); position++ {
+			candidate := scanJoinOrderRecordKey(input, inner[position], input.targetKeyCols, nil)
+			if compareProjectKey(candidate, key) != 0 {
+				break
+			}
+			records[inputIndex] = inner[position]
+			enumerate(inputIndex + 1)
+		}
+	}
+	for _, driverRecord := range combination[0].records {
+		records[0] = driverRecord
+		enumerate(1)
+	}
+	return result, count
+}
+
+func mergeTopKScanJoinOrderTuples(spec *scanJoinOrderSpec, left []*scanJoinOrderTuple, right []*scanJoinOrderTuple, keep int) []*scanJoinOrderTuple {
+	capacity := len(left) + len(right)
+	if keep >= 0 && capacity > keep {
+		capacity = keep
+	}
+	result := make([]*scanJoinOrderTuple, 0, capacity)
+	i, j := 0, 0
+	for (keep < 0 || len(result) < keep) && i < len(left) && j < len(right) {
+		if lessScanJoinOrderTuple(spec, right[j], left[i]) {
+			result = append(result, right[j])
+			j++
+		} else {
+			result = append(result, left[i])
+			i++
+		}
+	}
+	for (keep < 0 || len(result) < keep) && i < len(left) {
+		result = append(result, left[i])
+		i++
+	}
+	for (keep < 0 || len(result) < keep) && j < len(right) {
+		result = append(result, right[j])
+		j++
+	}
+	return result
+}
+
+func collectTopKScanJoinOrderTuples(spec *scanJoinOrderSpec, runnerResults [][]*scanJoinOrderTuple, keep int) []*scanJoinOrderTuple {
+	for len(runnerResults) > 1 {
+		next := make([][]*scanJoinOrderTuple, 0, (len(runnerResults)+1)/2)
+		for i := 0; i < len(runnerResults); i += 2 {
+			if i+1 == len(runnerResults) {
+				next = append(next, runnerResults[i])
+			} else {
+				next = append(next, mergeTopKScanJoinOrderTuples(spec, runnerResults[i], runnerResults[i+1], keep))
+			}
+		}
+		runnerResults = next
+	}
+	if len(runnerResults) == 0 {
+		return nil
+	}
+	return runnerResults[0]
+}
+
+func scanJoinOrder(currentTx *TxContext, spec scanJoinOrderSpec) scm.Scmer {
+	if spec.limit >= 0 && scanJoinOrderUsesDriverOrder(&spec) {
+		return scanJoinOrderMaterialized(currentTx, spec)
+	}
+	prepareScanJoinOrderSpec(&spec)
+	if spec.limit == 0 {
+		return spec.notFoundValue
+	}
+	keep := -1
+	if spec.limit >= 0 {
+		if spec.offset > int(^uint(0)>>1)-spec.limit {
+			panic("scan_join_order: offset plus limit overflows")
+		}
+		keep = spec.offset + spec.limit
+	}
+
+	streams := make([][]*scanJoinOrderShardStream, len(spec.inputs))
+	for inputIndex := range spec.inputs {
+		input := &spec.inputs[inputIndex]
+		var sortcols []scm.Scmer
+		var sortdirs []func(...scm.Scmer) scm.Scmer
+		if inputIndex == 0 && scanJoinOrderUsesDriverOrder(&spec) {
+			sortcols = make([]scm.Scmer, len(spec.orderCols))
+			for i, ref := range spec.orderCols {
+				sortcols[i] = scm.NewString(ref.column)
+			}
+			sortdirs = spec.orderDirs
+		} else if inputIndex > 0 {
+			sortcols = make([]scm.Scmer, len(input.targetKeyCols))
+			sortdirs = make([]func(...scm.Scmer) scm.Scmer, len(input.targetKeyCols))
+			for i, col := range input.targetKeyCols {
+				sortcols[i] = scm.NewString(col)
+				sortdirs[i] = func(values ...scm.Scmer) scm.Scmer {
+					return scm.NewBool(scm.Less(values[0], values[1]))
+				}
+			}
+		}
+		streams[inputIndex] = collectScanJoinOrderShardStreams(currentTx, input, sortcols, sortdirs)
+		if len(streams[inputIndex]) == 0 {
+			return spec.notFoundValue
+		}
+	}
+
+	combinations := scanJoinOrderShardCombinations(&spec, streams)
+	if !spec.reduce2Fn.IsNil() {
+		partials := make([]scm.Scmer, len(combinations))
+		counts := make([]int, len(combinations))
+		done := runFanoutTasks(currentTx, len(combinations), func(runner int, _ bool) {
+			partials[runner], counts[runner] = reduceScanJoinOrderShardCombination(currentTx, &spec, combinations[runner])
+		})
+		if done != nil {
+			<-done
+		}
+		reduce2Fn := scm.OptimizeProcToSerialFunction(spec.reduce2Fn)
+		result := spec.neutral
+		total := 0
+		for runner, partial := range partials {
+			if counts[runner] == 0 {
+				continue
+			}
+			result = reduce2Fn(result, partial)
+			total += counts[runner]
+		}
+		if total > 0 {
+			return result
+		}
+		if spec.isOuter {
+			mapFn := scm.OptimizeProcToSerialFunction(spec.mapFn)
+			reduceFn := scanJoinOrderReducer(spec.reduceFn)
+			return reduceFn(spec.neutral, mapFn(make([]scm.Scmer, len(spec.mapCols))...))
+		}
+		return spec.notFoundValue
+	}
+	runnerResults := make([][]*scanJoinOrderTuple, len(combinations))
+	done := runFanoutTasks(currentTx, len(combinations), func(runner int, _ bool) {
+		runnerResults[runner] = runScanJoinOrderShardCombination(currentTx, &spec, combinations[runner], keep)
+	})
+	if done != nil {
+		<-done
+	}
+	joined := collectTopKScanJoinOrderTuples(&spec, runnerResults, keep)
+	if spec.offset > len(joined) {
+		joined = nil
+	} else {
+		joined = joined[spec.offset:]
+	}
+	if spec.limit >= 0 && len(joined) > spec.limit {
+		joined = joined[:spec.limit]
+	}
+	if len(joined) == 0 {
+		if spec.isOuter {
+			mapFn := scm.OptimizeProcToSerialFunction(spec.mapFn)
+			reduceFn := scanJoinOrderReducer(spec.reduceFn)
+			return reduceFn(spec.neutral, mapFn(make([]scm.Scmer, len(spec.mapCols))...))
+		}
+		return spec.notFoundValue
+	}
+	emitted := 0
+	result, _ := reduceScanJoinOrderTuples(currentTx, &spec, joined, spec.neutral, &emitted)
+	return result
+}
+
+func decodeScanJoinOrderColumn(value scm.Scmer, label string) scanJoinOrderColumn {
+	items := mustScmerSlice(value, label)
+	if len(items) != 2 {
+		panic("scan_join_order: a joined column reference must be (table_index column_name)")
+	}
+	return scanJoinOrderColumn{table: int(scm.ToInt(items[0])), column: scm.String(items[1])}
+}
+
+func decodeScanJoinOrderColumns(value scm.Scmer, label string) []scanJoinOrderColumn {
+	items := mustScmerSlice(value, label)
+	result := make([]scanJoinOrderColumn, len(items))
+	for i, item := range items {
+		result[i] = decodeScanJoinOrderColumn(item, label)
+	}
+	return result
+}
+
+func decodeScanJoinOrderInputs(tables []scm.Scmer, filterColumns scm.Scmer, filterFns scm.Scmer, joins scm.Scmer) []scanJoinOrderInput {
+	filterCols := mustScmerSlice(filterColumns, "filterColumns")
+	filters := mustScmerSlice(filterFns, "filterFns")
+	joinItems := mustScmerSlice(joins, "joins")
+	if len(filterCols) != len(tables) || len(filters) != len(tables) || len(joinItems) != len(tables)-1 {
+		panic("scan_join_order: filter arrays must match tables and joins must have tables-1 entries")
+	}
+	result := make([]scanJoinOrderInput, len(tables))
+	for i, tableValue := range tables {
+		result[i] = scanJoinOrderInput{
+			table:      TableFromScmer(tableValue),
+			filterCols: scmerSliceToStrings(mustScmerSlice(filterCols[i], "filterColumns[i]")),
+			filter:     filters[i],
+		}
+		if i == 0 {
+			continue
+		}
+		clauses := mustScmerSlice(joinItems[i-1], "joins[i]")
+		result[i].sourceKeyCols = make([]scanJoinOrderColumn, len(clauses))
+		result[i].targetKeyCols = make([]string, len(clauses))
+		for clauseIndex, clauseValue := range clauses {
+			clause := mustScmerSlice(clauseValue, "join clause")
+			if len(clause) != 3 {
+				panic("scan_join_order: a join clause must be (outer_table_index outer_column inner_column)")
+			}
+			result[i].sourceKeyCols[clauseIndex] = scanJoinOrderColumn{
+				table:  int(scm.ToInt(clause[0])),
+				column: scm.String(clause[1]),
+			}
+			result[i].targetKeyCols[clauseIndex] = scm.String(clause[2])
+		}
+	}
+	return result
+}
+
+func declareScanJoinOrder(en *scm.Env) {
+	joinedColumn := &scm.TypeDescriptor{
+		Kind:        "list",
+		Label:       "joined column",
+		Description: "pair (zero-based table index, physical column name)",
+	}
+	scm.Declare(en, &scm.Declaration{
+		Name: "scan_join_order",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			tables := mustScmerSlice(a[1], "tables")
+			sortDirections := mustScmerSlice(a[8], "sortDirections")
+			orderDirs := make([]func(...scm.Scmer) scm.Scmer, len(sortDirections))
+			for i, direction := range sortDirections {
+				orderDirs[i] = scm.OptimizeProcToSerialFunction(direction)
+			}
+			neutral := scm.NewNil()
+			if len(a) > 15 {
+				neutral = a[15]
+			}
+			reduce2 := scm.NewNil()
+			if len(a) > 16 {
+				reduce2 = a[16]
+			}
+			isOuter := len(a) > 17 && scm.ToBool(a[17])
+			notFoundValue := neutral
+			if len(a) > 18 {
+				notFoundValue = a[18]
+			}
+			return scanJoinOrder(scmerToTxContext(a[0]), scanJoinOrderSpec{
+				inputs:             decodeScanJoinOrderInputs(tables, a[2], a[3], a[4]),
+				joinFilterCols:     decodeScanJoinOrderColumns(a[5], "joinFilterColumns"),
+				joinFilter:         a[6],
+				orderCols:          decodeScanJoinOrderColumns(a[7], "orderColumns"),
+				orderDirs:          orderDirs,
+				limitPartitionCols: int(scm.ToInt(a[9])),
+				offset:             int(scm.ToInt(a[10])),
+				limit:              int(scm.ToInt(a[11])),
+				mapCols:            decodeScanJoinOrderColumns(a[12], "mapColumns"),
+				mapFn:              a[13],
+				reduceFn:           a[14],
+				reduce2Fn:          reduce2,
+				neutral:            neutral,
+				isOuter:            isOuter,
+				notFoundValue:      notFoundValue,
+			})
+		},
+		Type: &scm.TypeDescriptor{
+			Kind:           "func",
+			Description:    "scans a left-deep equi-join in final ORDER BY order, executes each inner table through equality-filter plus join-key ordered access, and applies OFFSET/LIMIT only to joined rows",
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "transaction context"},
+				{Kind: "list", Label: "tables", Description: "driver table followed by inner equi-join tables"},
+				{Kind: "list", Label: "filterColumns", Description: "one physical filter-column list per table"},
+				{Kind: "list", Label: "filterFns", Description: "one table-local filter callback per table"},
+				{Kind: "list", Label: "joins", Description: "one join description per inner table; every clause is (outer_table_index outer_column inner_column)"},
+				{Kind: "list", Label: "joinFilterColumns", Description: "joined columns supplied to the residual join filter", Element: joinedColumn},
+				{Kind: "func|nil", Label: "joinFilter", Description: "residual predicate over the complete joined tuple, or nil"},
+				{Kind: "list", Label: "orderColumns", Description: "joined column references used by final ORDER BY", Element: joinedColumn},
+				{Kind: "list", Label: "sortDirections", Description: "one ordering relation per order column"},
+				{Kind: "int", Label: "limitPartitionCols", Description: "reserved for scan_order compatibility; currently must be 0"},
+				{Kind: "int", Label: "offset", Description: "joined rows skipped in final order"},
+				{Kind: "int", Label: "limit", Description: "joined rows emitted in final order; -1 is unlimited"},
+				{Kind: "list", Label: "mapColumns", Description: "joined columns supplied to the sole outer map callback", Element: joinedColumn},
+				{Kind: "func", Label: "map", Description: "map callback evaluated only for final OFFSET/LIMIT rows"},
+				{Kind: "func|nil", Label: "reduce", Description: "reducer applied inside each shard-combination runner; with no reduce2 it is also used by the global ordered collector", Optional: true},
+				{Kind: "any", Label: "neutral", Description: "optional reducer neutral value", Optional: true},
+				{Kind: "func|nil", Label: "reduce2", Description: "optional global reducer combining runner-local reduce results; permitted only with offset 0 and unlimited limit -1", Optional: true},
+				{Kind: "bool", Label: "isOuter", Description: "optional whole-scan NULL fallback", Optional: true},
+				{Kind: "any", Label: "notFoundValue", Description: "optional result when no joined row is emitted", Optional: true},
+			},
+			Return: &scm.TypeDescriptor{Kind: "any"},
+		},
+	})
+}

--- a/storage/scan_join_order_test.go
+++ b/storage/scan_join_order_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "testing"
+import "sync/atomic"
+import "github.com/launix-de/memcp/scm"
+
+func setupScanJoinOrderTable(t *testing.T, database string, name string, columns []string, rows [][]scm.Scmer) *table {
+	t.Helper()
+	table, _ := CreateTable(database, name, Memory, true)
+	for _, column := range columns {
+		table.CreateColumn(column, "INT", nil, nil)
+	}
+	table.Insert(columns, rows, nil, scm.NewNil(), false, nil)
+	return table
+}
+
+func TestScanJoinOrderFiltersJoinsAndBrakesInDriverOrder(t *testing.T) {
+	database := "tscanjoinorder"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+
+	orders := setupScanJoinOrderTable(t, database, "orders", []string{"id", "customer_id"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10)},
+		{scm.NewInt(2), scm.NewInt(20)},
+		{scm.NewInt(3), scm.NewInt(10)},
+		{scm.NewInt(4), scm.NewInt(30)},
+		{scm.NewInt(5), scm.NewInt(10)},
+	})
+	customers := setupScanJoinOrderTable(t, database, "customers", []string{"id", "region"}, [][]scm.Scmer{
+		{scm.NewInt(10), scm.NewInt(1)},
+		{scm.NewInt(20), scm.NewInt(2)},
+		{scm.NewInt(30), scm.NewInt(1)},
+	})
+	tags := setupScanJoinOrderTable(t, database, "tags", []string{"customer_id", "tag", "enabled"}, [][]scm.Scmer{
+		{scm.NewInt(10), scm.NewInt(100), scm.NewInt(1)},
+		{scm.NewInt(10), scm.NewInt(101), scm.NewInt(1)},
+		{scm.NewInt(20), scm.NewInt(200), scm.NewInt(1)},
+		{scm.NewInt(30), scm.NewInt(300), scm.NewInt(0)},
+	})
+
+	_, descending := integerOrder(true)
+	equalOne := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(values[0].Int() == 1)
+	})
+	got := make([][2]int64, 0)
+	mapFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		got = append(got, [2]int64{values[0].Int(), values[1].Int()})
+		return values[0]
+	})
+	reduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })
+
+	scanJoinOrder(nil, scanJoinOrderSpec{
+		inputs: []scanJoinOrderInput{
+			{table: orders},
+			{table: customers, filterCols: []string{"region"}, filter: equalOne,
+				sourceKeyCols: []scanJoinOrderColumn{{table: 0, column: "customer_id"}}, targetKeyCols: []string{"id"}},
+			{table: tags, filterCols: []string{"enabled"}, filter: equalOne,
+				sourceKeyCols: []scanJoinOrderColumn{{table: 1, column: "id"}}, targetKeyCols: []string{"customer_id"}},
+		},
+		orderCols:     []scanJoinOrderColumn{{table: 0, column: "id"}},
+		orderDirs:     []func(...scm.Scmer) scm.Scmer{descending},
+		offset:        1,
+		limit:         3,
+		mapCols:       []scanJoinOrderColumn{{table: 0, column: "id"}, {table: 2, column: "tag"}},
+		mapFn:         mapFn,
+		reduceFn:      reduceFn,
+		neutral:       scm.NewNil(),
+		notFoundValue: scm.NewNil(),
+	})
+
+	want := [][2]int64{{5, 101}, {3, 100}, {3, 101}}
+	if len(got) != len(want) {
+		t.Fatalf("joined rows = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("joined rows = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestScanJoinOrderDoesNotJoinNullKeys(t *testing.T) {
+	database := "tscanjoinordernull"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	left := setupScanJoinOrderTable(t, database, "left_rows", []string{"id", "key_col"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewNil()},
+	})
+	right := setupScanJoinOrderTable(t, database, "right_rows", []string{"key_col"}, [][]scm.Scmer{
+		{scm.NewNil()},
+	})
+	_, ascending := integerOrder(false)
+	result := scanJoinOrder(nil, scanJoinOrderSpec{
+		inputs: []scanJoinOrderInput{
+			{table: left},
+			{table: right, sourceKeyCols: []scanJoinOrderColumn{{table: 0, column: "key_col"}}, targetKeyCols: []string{"key_col"}},
+		},
+		orderCols:     []scanJoinOrderColumn{{table: 0, column: "id"}},
+		orderDirs:     []func(...scm.Scmer) scm.Scmer{ascending},
+		limit:         1,
+		mapCols:       []scanJoinOrderColumn{{table: 0, column: "id"}},
+		mapFn:         scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		reduceFn:      scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+		neutral:       scm.NewNil(),
+		notFoundValue: scm.NewString("missing"),
+	})
+	if result.String() != "missing" {
+		t.Fatalf("NULL equi-join result = %v, want missing", result)
+	}
+}
+
+func TestScanJoinOrderDeclarationSupportsOrderFromJoinedTable(t *testing.T) {
+	Init(scm.Globalenv)
+	database := "tscanjoinorderdeclare"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	left := setupScanJoinOrderTable(t, database, "left_rows", []string{"id", "key_col"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10)},
+		{scm.NewInt(2), scm.NewInt(20)},
+	})
+	right := setupScanJoinOrderTable(t, database, "right_rows", []string{"key_col", "rank_col"}, [][]scm.Scmer{
+		{scm.NewInt(10), scm.NewInt(200)},
+		{scm.NewInt(20), scm.NewInt(100)},
+	})
+	ascendingValue, _ := integerOrder(false)
+	got := make([]int64, 0, 1)
+	mapFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		got = append(got, values[0].Int())
+		return values[0]
+	})
+	reduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })
+	trueFn := scanJoinTrue()
+	ref := func(tableIndex int64, column string) scm.Scmer {
+		return scm.NewSlice([]scm.Scmer{scm.NewInt(tableIndex), scm.NewString(column)})
+	}
+
+	scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_join_order")],
+		scm.NewNil(),
+		scm.NewSlice([]scm.Scmer{NewTableScmer(left), NewTableScmer(right)}),
+		scm.NewSlice([]scm.Scmer{scm.NewSlice(nil), scm.NewSlice(nil)}),
+		scm.NewSlice([]scm.Scmer{trueFn, trueFn}),
+		scm.NewSlice([]scm.Scmer{scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{scm.NewInt(0), scm.NewString("key_col"), scm.NewString("key_col")}),
+		})}),
+		scm.NewSlice(nil), scm.NewNil(),
+		scm.NewSlice([]scm.Scmer{ref(1, "rank_col")}),
+		scm.NewSlice([]scm.Scmer{ascendingValue}),
+		scm.NewInt(0), scm.NewInt(0), scm.NewInt(1),
+		scm.NewSlice([]scm.Scmer{ref(0, "id")}), mapFn, reduceFn, scm.NewNil())
+
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("declared joined-table order returned %v, want [2]", got)
+	}
+}
+
+func repartitionScanJoinOrderTable(t *testing.T, table *table, dimensions []shardDimension) {
+	t.Helper()
+	RebuildTable(table, true, false)
+	if !table.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	table.repartition(dimensions)
+}
+
+func TestScanJoinOrderPrunesCompatibleJoinKeyShardPairs(t *testing.T) {
+	oldAnalyzeMinItems := Settings.AnalyzeMinItems
+	Settings.AnalyzeMinItems = 1 << 30
+	t.Cleanup(func() { Settings.AnalyzeMinItems = oldAnalyzeMinItems })
+	database := "tscanjoinorderpartition"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	leftRows := make([][]scm.Scmer, 120)
+	rightRows := make([][]scm.Scmer, 120)
+	for i := range leftRows {
+		leftRows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i))}
+		rightRows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(1000 - i))}
+	}
+	left := setupScanJoinOrderTable(t, database, "left_rows", []string{"id", "key_col"}, leftRows)
+	right := setupScanJoinOrderTable(t, database, "right_rows", []string{"key_col", "rank_col"}, rightRows)
+	dimension := shardDimension{Column: "key_col", NumPartitions: 4, Pivots: []scm.Scmer{
+		scm.NewInt(29), scm.NewInt(59), scm.NewInt(89),
+	}}
+	repartitionScanJoinOrderTable(t, left, []shardDimension{dimension})
+	repartitionScanJoinOrderTable(t, right, []shardDimension{{
+		Column: "key_col", NumPartitions: dimension.NumPartitions, Pivots: append([]scm.Scmer(nil), dimension.Pivots...),
+	}})
+
+	_, descending := integerOrder(true)
+	spec := scanJoinOrderSpec{
+		inputs: []scanJoinOrderInput{
+			{table: left},
+			{table: right, sourceKeyCols: []scanJoinOrderColumn{{table: 0, column: "key_col"}}, targetKeyCols: []string{"key_col"}},
+		},
+		orderCols: []scanJoinOrderColumn{{table: 0, column: "id"}},
+		orderDirs: []func(...scm.Scmer) scm.Scmer{descending},
+		limit:     5,
+		mapCols:   []scanJoinOrderColumn{{table: 0, column: "id"}},
+		mapFn:     scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		reduceFn:  scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+	}
+	prepareScanJoinOrderSpec(&spec)
+	streams := make([][]*scanJoinOrderShardStream, 2)
+	streams[0] = collectScanJoinOrderShardStreams(nil, &spec.inputs[0], []scm.Scmer{scm.NewString("id")}, []func(...scm.Scmer) scm.Scmer{descending})
+	_, ascending := integerOrder(false)
+	streams[1] = collectScanJoinOrderShardStreams(nil, &spec.inputs[1], []scm.Scmer{scm.NewString("key_col")}, []func(...scm.Scmer) scm.Scmer{ascending})
+	allPairs := len(streams[0]) * len(streams[1])
+	combinations := scanJoinOrderShardCombinations(&spec, streams)
+	if len(combinations) >= allPairs {
+		t.Fatalf("compatible join partitioning retained %d of %d shard pairs", len(combinations), allPairs)
+	}
+	if len(combinations) != 4 {
+		t.Fatalf("compatible join partitioning produced %d runners, want 4", len(combinations))
+	}
+
+	got := make([]int64, 0, 5)
+	spec.mapFn = scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		got = append(got, values[0].Int())
+		return values[0]
+	})
+	scanJoinOrder(nil, spec)
+	want := []int64{119, 118, 117, 116, 115}
+	if !equalInt64s(got, want) {
+		t.Fatalf("partitioned global Top-K = %v, want %v", got, want)
+	}
+}
+
+func TestScanJoinOrderRejectsReduce2WithLimit(t *testing.T) {
+	database := "tscanjoinorderreduce2limit"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	table := setupScanJoinOrderTable(t, database, "rows", []string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}})
+	_, ascending := integerOrder(false)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("reduce2 with LIMIT did not panic")
+		}
+	}()
+	scanJoinOrder(nil, scanJoinOrderSpec{
+		inputs:    []scanJoinOrderInput{{table: table}},
+		orderCols: []scanJoinOrderColumn{{table: 0, column: "id"}},
+		orderDirs: []func(...scm.Scmer) scm.Scmer{ascending},
+		limit:     1,
+		mapCols:   []scanJoinOrderColumn{{table: 0, column: "id"}},
+		mapFn:     scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		reduceFn:  scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+		reduce2Fn: scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
+	})
+}
+
+func TestScanJoinOrderReduce2CombinesUnlimitedRunnerPartials(t *testing.T) {
+	database := "tscanjoinorderreduce2"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	left := setupScanJoinOrderTable(t, database, "left_rows", []string{"key_col", "amount"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(10)},
+		{scm.NewInt(2), scm.NewInt(20)},
+		{scm.NewInt(3), scm.NewInt(30)},
+		{scm.NewInt(4), scm.NewInt(40)},
+	})
+	right := setupScanJoinOrderTable(t, database, "right_rows", []string{"key_col"}, [][]scm.Scmer{
+		{scm.NewInt(1)}, {scm.NewInt(2)}, {scm.NewInt(3)}, {scm.NewInt(4)},
+	})
+	dimension := shardDimension{Column: "key_col", NumPartitions: 2, Pivots: []scm.Scmer{scm.NewInt(2)}}
+	repartitionScanJoinOrderTable(t, left, []shardDimension{dimension})
+	repartitionScanJoinOrderTable(t, right, []shardDimension{{
+		Column: "key_col", NumPartitions: dimension.NumPartitions, Pivots: append([]scm.Scmer(nil), dimension.Pivots...),
+	}})
+	var localReduceCalls atomic.Int64
+	var globalReduceCalls atomic.Int64
+	result := scanJoinOrder(nil, scanJoinOrderSpec{
+		inputs: []scanJoinOrderInput{
+			{table: left},
+			{table: right, sourceKeyCols: []scanJoinOrderColumn{{table: 0, column: "key_col"}}, targetKeyCols: []string{"key_col"}},
+		},
+		limit:   -1,
+		mapCols: []scanJoinOrderColumn{{table: 0, column: "amount"}},
+		mapFn:   scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
+		reduceFn: scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			localReduceCalls.Add(1)
+			return scm.NewInt(values[0].Int() + values[1].Int())
+		}),
+		reduce2Fn: scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+			globalReduceCalls.Add(1)
+			return scm.NewInt(values[0].Int() + values[1].Int())
+		}),
+		neutral: scm.NewInt(0),
+	})
+	if result.Int() != 100 {
+		t.Fatalf("reduce2 joined sum = %v, want 100", result)
+	}
+	if localReduceCalls.Load() != 4 {
+		t.Fatalf("runner-local reduce calls = %d, want 4", localReduceCalls.Load())
+	}
+	if globalReduceCalls.Load() != 2 {
+		t.Fatalf("global reduce2 calls = %d, want 2", globalReduceCalls.Load())
+	}
+}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -334,6 +334,8 @@ type scanOrderTableSpec struct {
 	recset          *recSet
 	conditionCols   []string
 	condition       scm.Scmer
+	acceptCols      []string
+	accept          scm.Scmer
 	sortcols        []scm.Scmer
 	callbackCols    []string
 	callback        scm.Scmer
@@ -622,6 +624,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		spec := &tables[ti]
 		t := spec.backingTable()
 		touchTempColumns(t, spec.conditionCols, spec.callbackCols)
+		touchTempColumns(t, spec.acceptCols, nil)
 
 		// Per-table top-K hint: when perTableLimit is set, each shard only
 		// needs to return the top (perTableOffset + perTableLimit) rows in
@@ -672,6 +675,8 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		callback := spec.callback
 		conditionCols := spec.conditionCols
 		condition := spec.condition
+		acceptCols := spec.acceptCols
+		accept := spec.accept
 		sortcols := spec.sortcols
 		tableBounds := bounds
 		tableIdx := ti
@@ -705,7 +710,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 										q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 									}
 								}()
-								res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+								res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 								res.callbackCols = callbackCols
 								res.callback = callback
 								res.tableIdx = tableIdx
@@ -735,7 +740,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 						if ss != nil && ss.IsKilledSeq(querySeq) {
 							panic("query killed")
 						}
-						res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+						res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 						res.callbackCols = callbackCols
 						res.callback = callback
 						res.tableIdx = tableIdx
@@ -759,7 +764,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 				res.callbackCols = callbackCols
 				res.callback = callback
 				res.tableIdx = tableIdx
@@ -1143,7 +1148,7 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
+func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, acceptCols []string, accept scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	if ss == nil {
@@ -1151,11 +1156,19 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	}
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	var acceptFn func(...scm.Scmer) scm.Scmer
+	if !accept.IsNil() {
+		acceptFn = scm.OptimizeProcToSerialFunction(accept)
+	}
 
 	// prepare filter function
 	cdataset := make([]scm.Scmer, len(conditionCols))
 	for i := range cdataset {
 		cdataset[i] = scm.NewNil()
+	}
+	adataset := make([]scm.Scmer, len(acceptCols))
+	for i := range adataset {
+		adataset[i] = scm.NewNil()
 	}
 
 	// prepare sort criteria so they can be queried easily
@@ -1234,6 +1247,16 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			cNeedsCachedReader[i] = true
 		}
 	}
+	acols := make([]ColumnStorage, len(acceptCols))
+	aReaders := make([]ColumnReader, len(acceptCols))
+	aNeedsCachedReader := make([]bool, len(acceptCols))
+	for i, column := range acceptCols {
+		acols[i] = t.getColumnStorageOrPanicEx(column, skipShardReadLock, currentTx)
+		aReaders[i] = newCachedColumnReaderTx(acols[i], currentTx)
+		if _, ok := acols[i].(*StorageComputeProxy); ok {
+			aNeedsCachedReader[i] = true
+		}
+	}
 	// initialize main_count lazily if needed
 	t.ensureMainCount(skipShardReadLock)
 	// scan loop in read lock
@@ -1278,6 +1301,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		// GetValue call per row per column.
 		var survivedBuf, mainIdsBuf []uint32
 		colBufs := make([][]scm.Scmer, len(conditionCols))
+		acceptColBufs := make([][]scm.Scmer, len(acceptCols))
 		t.iterateIndexOrdered(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, limit, func(index *StorageIndex, active bool) {
 			if len(sortcols) > 0 {
 				resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
@@ -1329,18 +1353,34 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					ccols[i].GetValueMulti(mainIds, colBufs[i], 1)
 				}
 			}
+			for i := range acols {
+				if cap(acceptColBufs[i]) < len(mainIds) {
+					acceptColBufs[i] = make([]scm.Scmer, len(mainIds))
+				}
+				acceptColBufs[i] = acceptColBufs[i][:len(mainIds)]
+				if len(mainIds) == 0 {
+					continue
+				}
+				if aNeedsCachedReader[i] {
+					aReaders[i].GetValueMulti(mainIds, acceptColBufs[i], 1)
+				} else {
+					acols[i].GetValueMulti(mainIds, acceptColBufs[i], 1)
+				}
+			}
 
 			// pass 3: evaluate the condition per row using the pre-fetched
 			// main-storage values; delta rows are still read one at a time.
 			outN := 0
 			mainBufIdx := 0
 			for _, idx := range survived {
-				if idx < t.main_count {
+				mainStorage := idx < t.main_count
+				rowMainBufIdx := mainBufIdx
+				if mainStorage {
 					for i := range ccols {
 						if conditionGetters[i] != nil {
 							cdataset[i] = conditionGetters[i](idx, 0)
 						} else {
-							cdataset[i] = colBufs[i][mainBufIdx]
+							cdataset[i] = colBufs[i][rowMainBufIdx]
 						}
 					}
 					mainBufIdx++
@@ -1361,6 +1401,26 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 				// check condition
 				if !scm.ToBool(conditionFn(cdataset...)) {
 					continue // condition did not match
+				}
+				if acceptFn != nil {
+					if mainStorage {
+						for i := range acols {
+							adataset[i] = acceptColBufs[i][rowMainBufIdx]
+						}
+					} else {
+						for i, column := range acceptCols {
+							if aNeedsCachedReader[i] {
+								adataset[i] = aReaders[i].GetValue(idx)
+							} else if _, isProxy := acols[i].(*StorageComputeProxy); isProxy {
+								adataset[i] = acols[i].GetValue(idx)
+							} else {
+								adataset[i] = t.getDelta(int(idx-t.main_count), column)
+							}
+						}
+					}
+					if !scm.ToBool(acceptFn(adataset...)) {
+						continue
+					}
 				}
 
 				batch[outN] = idx

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -18,6 +18,7 @@ package storage
 
 import "fmt"
 import "sort"
+import "strings"
 import "github.com/launix-de/memcp/scm"
 
 type orderedBatchRecord struct {
@@ -36,6 +37,10 @@ type orderedBatchPart struct {
 // scanOrderBatchAccept. The ordered record vector remains authoritative because
 // a RecSet itself deliberately carries membership, not order.
 func collectOrderedCandidateBatch(currentTx *TxContext, source scanOrderTableSpec, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int) ([]orderedBatchRecord, *recSet) {
+	if records, batch, ok := collectPartitionOrderedCandidateBatch(
+		currentTx, source, sortcols, sortdirs, offset, limit); ok {
+		return records, batch
+	}
 	table := source.backingTable()
 	parts := make(map[*storageShard]*orderedBatchPart)
 	partOrder := make([]*orderedBatchPart, 0)
@@ -76,6 +81,112 @@ func collectOrderedCandidateBatch(currentTx *TxContext, source scanOrderTableSpe
 		batch.shards = append(batch.shards, shardPart)
 	}
 	return records, batch
+}
+
+// collectPartitionOrderedCandidateBatch exploits a one-dimensional range
+// partition on the leading ORDER BY column. Those shards are disjoint ordered
+// runs, so OFFSET/LIMIT can stop after the last contributing shard instead of
+// starting every shard merely to discover the global Top-K. The generic merge
+// remains the fallback for free shards, RecSets, computed orders and
+// multi-dimensional partitioning.
+func collectPartitionOrderedCandidateBatch(currentTx *TxContext, source scanOrderTableSpec, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, offset int, limit int) ([]orderedBatchRecord, *recSet, bool) {
+	if source.recset != nil || source.table == nil || limit <= 0 || len(sortcols) == 0 || len(sortdirs) == 0 || !sortcols[0].IsString() {
+		return nil, nil, false
+	}
+	orderMeta := orderRelationMeta(sortdirs[0])
+	descending := strings.HasSuffix(orderMeta, ":desc")
+	ascending := strings.HasSuffix(orderMeta, ":asc")
+	if !ascending && !descending {
+		relationID := scm.FunctionIdentity(sortdirs[0])
+		ascending = relationID == scm.FunctionIdentity(scm.OptimizeProcToSerialFunction(
+			scm.Eval(scm.NewSymbol("<"), &scm.Globalenv)))
+		descending = relationID == scm.FunctionIdentity(scm.OptimizeProcToSerialFunction(
+			scm.Eval(scm.NewSymbol(">"), &scm.Globalenv)))
+		if !ascending && !descending {
+			return nil, nil, false
+		}
+	}
+
+	table := source.table
+	for {
+		topology := table.activeTopology()
+		if topology.mode != ShardModePartition || len(topology.dimensions) != 1 ||
+			topology.dimensions[0].Column != sortcols[0].String() ||
+			len(topology.shards) != topology.dimensions[0].NumPartitions {
+			return nil, nil, false
+		}
+		if !topology.acquireOperation() {
+			continue
+		}
+		if table.topology.Load() != topology {
+			topology.releaseOperation()
+			continue
+		}
+
+		var records []orderedBatchRecord
+		var partOrder []*orderedBatchPart
+		func() {
+			defer topology.releaseOperation()
+			records = make([]orderedBatchRecord, 0, limit)
+			partOrder = make([]*orderedBatchPart, 0)
+			remainingOffset := offset
+			bounds, _ := extendBoundariesWithSortCols(nil, sortcols, sortdirs)
+			lower, upperLast := indexFromBoundaries(bounds)
+			condition := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+			sessionState := SessionStateFromTx(currentTx)
+			querySeq := querySeqFromTx(currentTx)
+			visit := func(shard *storageShard) {
+				if shard == nil || len(records) >= limit {
+					return
+				}
+				if sessionState != nil && sessionState.IsKilledSeq(querySeq) {
+					panic("query killed")
+				}
+				shard.activeScanners.Add(1)
+				release := shard.acquireReadForScan(currentTx)
+				queue := func() *shardqueue {
+					defer release()
+					defer shard.activeScanners.Add(-1)
+					return shard.scan_order(bounds, lower, upperLast, nil, condition,
+						nil, scm.NewNil(), sortcols, sortdirs, 0, remainingOffset,
+						limit-len(records), nil, currentTx, sessionState)
+				}()
+				if remainingOffset >= len(queue.items) {
+					remainingOffset -= len(queue.items)
+					return
+				}
+				items := queue.items[remainingOffset:]
+				remainingOffset = 0
+				if available := limit - len(records); len(items) > available {
+					items = items[:available]
+				}
+				part := &orderedBatchPart{shard: shard, universe: queue.universe,
+					recids: append([]uint32(nil), items...)}
+				partOrder = append(partOrder, part)
+				for _, recid := range items {
+					records = append(records, orderedBatchRecord{shard: shard, recid: recid})
+				}
+			}
+			if descending {
+				for i := len(topology.shards) - 1; i >= 0 && len(records) < limit; i-- {
+					visit(topology.shards[i])
+				}
+			} else {
+				for i := 0; i < len(topology.shards) && len(records) < limit; i++ {
+					visit(topology.shards[i])
+				}
+			}
+		}()
+
+		batch := &recSet{tx: currentTx, table: table, shards: make([]recSetShard, 0, len(partOrder))}
+		for _, part := range partOrder {
+			sort.Slice(part.recids, func(i, j int) bool { return part.recids[i] < part.recids[j] })
+			shardPart := newRecSetShardFromSortedIDs(part.shard, part.universe, part.recids)
+			batch.count += shardPart.count
+			batch.shards = append(batch.shards, shardPart)
+		}
+		return records, batch, true
+	}
 }
 
 func validateAcceptedBatch(currentTx *TxContext, batch *recSet, acceptedValue scm.Scmer) *recSet {

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -143,6 +143,52 @@ func TestScanOrderBatchAcceptMixedOrderAcrossShards(t *testing.T) {
 	}
 }
 
+func TestCollectOrderedCandidateBatchPrunesRangePartitions(t *testing.T) {
+	table := setupBatchAcceptTable(t, "tbatchacceptpartitionorder", 30)
+	RebuildTable(table, true, false)
+	if !table.beginManualRepartition() {
+		t.Fatal("manual repartition was not claimed")
+	}
+	table.repartition([]shardDimension{table.NewShardDimension("id", 3)})
+
+	readIDs := func(records []orderedBatchRecord) []int64 {
+		ids := make([]int64, len(records))
+		for i, record := range records {
+			release := record.shard.GetRead()
+			ids[i] = int64(scm.ToInt(record.shard.ColumnReaderTx(nil, "id")(record.recid)))
+			release()
+		}
+		return ids
+	}
+	collect := func(operator string, offset int, limit int) ([]orderedBatchRecord, *recSet, bool) {
+		relation := scm.OptimizeProcToSerialFunction(scm.Eval(scm.NewSymbol(operator), &scm.Globalenv))
+		return collectPartitionOrderedCandidateBatch(nil, scanOrderTableSpec{table: table},
+			[]scm.Scmer{scm.NewString("id")}, []func(...scm.Scmer) scm.Scmer{relation}, offset, limit)
+	}
+
+	ascending, ascendingBatch, ok := collect("<", 4, 5)
+	if !ok {
+		t.Fatal("ascending range-partition order did not use the pruning path")
+	}
+	if got, want := readIDs(ascending), []int64{4, 5, 6, 7, 8}; !equalInt64s(got, want) {
+		t.Fatalf("ascending partition batch = %v, want %v", got, want)
+	}
+	if ascendingBatch.count != 5 {
+		t.Fatalf("ascending batch count = %d, want 5", ascendingBatch.count)
+	}
+
+	descending, descendingBatch, ok := collect(">", 3, 5)
+	if !ok {
+		t.Fatal("descending range-partition order did not use the pruning path")
+	}
+	if got, want := readIDs(descending), []int64{26, 25, 24, 23, 22}; !equalInt64s(got, want) {
+		t.Fatalf("descending partition batch = %v, want %v", got, want)
+	}
+	if descendingBatch.count != 5 {
+		t.Fatalf("descending batch count = %d, want 5", descendingBatch.count)
+	}
+}
+
 func TestScanOrderBatchAcceptRejectsNonSubset(t *testing.T) {
 	table := setupBatchAcceptTable(t, "tbatchacceptsubset", 10)
 	allRows := table.scanRecSet(nil, nil, scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) }))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1693,6 +1693,7 @@ func Init(en scm.Env) {
 			Optimize: optimizeScanOrderMulti,
 		},
 	})
+	declareScanJoinOrder(&en)
 	scm.Declare(&en, &scm.Declaration{
 		Name: "createdatabase",
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -797,6 +797,24 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "table_order_partitioned?",
+
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			t := TableFromScmer(a[0])
+			column := scm.String(a[1])
+			topology := t.activeTopology()
+			return scm.NewBool(topology.mode == ShardModePartition &&
+				len(topology.dimensions) == 1 && topology.dimensions[0].Column == column)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "reports whether a table has one range-partition dimension matching the leading ORDER BY column; this immutable-topology check lets physical costing account for ordered shard pruning",
+			Params: []*scm.TypeDescriptor{
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "column"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_selectivity_estimate",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -482,7 +482,7 @@ test_cases:
 
   - name: "Ordered selective join exposes calibratable carrier alternatives"
     sql: |
-      EXPLAIN PHYSICAL CALIBRATE
+      EXPLAIN PHYSICAL CALIBRATE DISCOVER
       SELECT f.*
       FROM ordered_join_fact AS f
       INNER JOIN ordered_join_dim AS d ON f.dim_id = d.id
@@ -492,8 +492,8 @@ test_cases:
     expect:
       rows: 2
       contains:
-        - 'projected_candidate_keyset'
-        - 'ordered_postfilter'
+        - 'legacy_join_tree'
+        - 'scan_join_order'
         - 'result_equal'
 
   - name: "Create selective text RecSet driver"

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -6,7 +6,7 @@
 
 metadata:
   version: "1.0"
-  description: "Physical membership cost calibration workload"
+  description: "Physical operator cost calibration workload"
   isolated: true
   ci: false
   physical_calibration: true
@@ -14,10 +14,8 @@ metadata:
   compile_state: "cached_plan_execution_only"
 
 setup:
-  # Keep the 100k-row text relation in one authoritative generation. Cold
-  # multi-shard statistics are a separate fallback workload and must not be
-  # mixed into the known-statistics coefficient fit.
-  - scm: '(settings "ShardSize" 125000)'
+  # Keep the production default shard size. Rebuild supplies the automatic
+  # partitioning used by ordinary query plans and the ordered-join fanout.
   - sql: "DROP TABLE IF EXISTS pc_files_small"
   - sql: "DROP TABLE IF EXISTS pc_docs_small"
   - sql: "DROP TABLE IF EXISTS pc_files_large"
@@ -132,6 +130,34 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_wide"
 
 test_cases:
+  - name: "ordered equi-join top-k"
+    physical_calibration: true
+    calibration_holdout: true
+    calibration_decision: "scan_join_order"
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      JOIN pc_files_large f ON d.file_id = f.id
+      WHERE f.id = 4999
+      ORDER BY d.sort_key DESC
+      LIMIT 72
+
+  - name: "ordered filtered join top-k"
+    physical_calibration: true
+    calibration_holdout: true
+    calibration_decision: "scan_join_order"
+    warmup: 1
+    repetitions: 5
+    sql: |
+      SELECT d.id
+      FROM pc_docs_large d
+      JOIN pc_files_large f ON d.file_id = f.id
+      WHERE f.filename LIKE '%hit%'
+      ORDER BY d.sort_key DESC
+      LIMIT 72
+
   - name: "small broad UNION membership"
     physical_calibration: true
     warmup: 1

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -461,6 +461,31 @@ test_cases:
       ORDER BY d.sort_key, d.p1, d.id, d.file_id
       LIMIT 72
 
+  # The driver's PRIMARY KEY is also its single range-partition dimension.
+  # This observation teaches Costgen the linear prefix work used when
+  # scan_order_batch_accept can prune later shards by the leading order key.
+  - name: "production-scale partition-pruned ordered batch"
+    physical_calibration: true
+    calibration_decision: "membership_carrier"
+    calibration_holdout: true
+    race: true
+    race_grace: 0.5
+    cache_state: "warm_operator_state"
+    compile_state: "variant_compile_and_execute"
+    expected_driver_input_rows: 1000000
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT d.id
+      FROM pc_docs_million d
+      WHERE d.file_id IN (
+        SELECT f.id FROM pc_files_large f WHERE f.filename LIKE '%hit%'
+        UNION
+        SELECT f.id FROM pc_files_large f WHERE f.search LIKE '%hit%'
+      )
+      ORDER BY d.id
+      LIMIT 72
+
   # Exercise the exact emitted pipeline behind the ordered-batch alternative:
   # candidate membership first, then the remaining driver predicate on the
   # reduced RecSet. This keeps the downstream-work coefficient identifiable

--- a/tests/performance/stackoverflow-order-limit-join-large.yaml
+++ b/tests/performance/stackoverflow-order-limit-join-large.yaml
@@ -1,0 +1,113 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Original-scale reproduction of https://stackoverflow.com/questions/73024688/mysql-inner-join-and-order-by-bad-performance
+# This suite deliberately stays out of CI: it builds 6,276,445 products and
+# 22,888,685 images while retaining the engine's default shard size.
+
+metadata:
+  version: "1.0"
+  description: "Original-scale MariaDB ordered product/image join"
+  isolated: true
+  ci: false
+
+setup:
+  - sql: "DROP TABLE IF EXISTS so_730_large_images"
+  - sql: "DROP TABLE IF EXISTS so_730_large_products"
+  - sql: "CREATE TABLE so_730_large_products (id BIGINT, unique_id VARCHAR(32), project_1 INT, project_late INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_730_large_images (id BIGINT, product_unique_id VARCHAR(32)) ENGINE=memory"
+  - scm: |
+      (begin
+        (define insert_batches (lambda (target cols total batch_size rowfn)
+          (reduce (produceN (ceil (/ total batch_size)))
+            (lambda (inserted batch) (begin
+              (define first (* batch batch_size))
+              (define amount (min batch_size (- total first)))
+              (+ inserted (insert target cols
+                (map (produceN amount) (lambda (local)
+                  (rowfn (+ first local)))))))) 0)))
+        (define products (table "memcp-tests" "so_730_large_products"))
+        (define images (table "memcp-tests" "so_730_large_images"))
+        (insert_batches products '("id" "unique_id" "project_1" "project_late")
+          6276445 10000 (lambda (i)
+            (list (+ i 1)
+              (concat "product-" (string (+ i 1)))
+              (if (equal? (mod i 22) 0) 1 0)
+              (if (>= i (- 6276445 286960)) 1 0))))
+        (insert_batches images '("id" "product_unique_id")
+          22888685 10000 (lambda (i)
+            (list (+ i 1)
+              (concat "product-" (string (+ 1 (mod i 6276445)))))))
+        (rebuild products true true)
+        (rebuild images true true)
+        true)
+  - sql: "CREATE UNIQUE INDEX so_730_large_products_uid ON so_730_large_products(unique_id)"
+    timeout: 1800
+  - scm: |
+      (scan_order nil
+        (table "memcp-tests" "so_730_large_images")
+        '() (lambda () true) '("id") '(<) 0 0 1
+        '() (lambda () true) (lambda (acc _row) acc) true false)
+  - sql: "ALTER TABLE so_730_large_products ENGINE=sloppy"
+  - sql: "ALTER TABLE so_730_large_images ENGINE=sloppy"
+  - scm: |
+      (begin
+        (rebuild (table "memcp-tests" "so_730_large_products") true true)
+        (rebuild (table "memcp-tests" "so_730_large_images") true true)
+        true)
+
+test_cases:
+  - name: "original-scale planner exposes all ordered join alternatives"
+    sql: "EXPLAIN PHYSICAL SELECT i.id FROM so_730_large_products p JOIN so_730_large_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
+    expect:
+      rows: 1
+      result_contains:
+        - "chosen legacy_join_tree"
+        - "ordered_batch_accept"
+        - "projected_candidate_keyset"
+        - "scan_join_order"
+        - "driver_order_partitioned"
+
+  - name: "original-scale uniformly distributed ordered join"
+    threshold_ms: 180000
+    timing_samples: 3
+    sql: "SELECT i.id FROM so_730_large_products p JOIN so_730_large_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
+    expect: {rows: 1000}
+
+  - name: "original-scale adversarial late ordered join"
+    threshold_ms: 180000
+    timing_samples: 3
+    sql: "SELECT i.id FROM so_730_large_products p JOIN so_730_large_images i ON i.product_unique_id = p.unique_id WHERE p.project_late = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
+    expect: {rows: 1000}
+
+  - name: "original-scale handwritten partition-pruned batch plan"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define products (table "memcp-tests" "so_730_large_products"))
+        (define images (table "memcp-tests" "so_730_large_images"))
+        (define selected (scan_recset tx products '("project_1")
+          (lambda (project_1) (equal? project_1 1))))
+        (define lookup (recset_key_index tx selected '("unique_id")))
+        (define found (scan_order_batch_accept tx images
+          (lambda (input) (scan_recset tx input '("product_unique_id")
+            (lambda (product_unique_id) (lookup product_unique_id))))
+          '("id") '(<) 0 0 1000 '() (lambda () 1) + 0 false 0))
+        (if (equal? found 1000) "ok" (error "wrong batch result")))
+
+  - name: "original-scale handwritten complete projected plan"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define products (table "memcp-tests" "so_730_large_products"))
+        (define images (table "memcp-tests" "so_730_large_images"))
+        (define selected (scan_recset tx products '("project_late")
+          (lambda (project_late) (equal? project_late 1))))
+        (define projected (recset_project_join tx selected '("unique_id")
+          images '("product_unique_id")))
+        (define found (scan_order tx projected '() (lambda () true)
+          '("id") '(<) 0 0 1000 '() (lambda () 1) + 0 false 0))
+        (if (equal? found 1000) "ok" (error "wrong projected result")))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS so_730_large_images"
+  - sql: "DROP TABLE IF EXISTS so_730_large_products"

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -199,6 +199,52 @@ test_cases:
     sql: "SELECT i.id FROM so_perf_products p JOIN so_perf_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
     expect: {rows: 1000}
 
+  - name: "SO 73024688 exposes the costed partition-pruned batch carrier"
+    sql: "EXPLAIN PHYSICAL SELECT i.id FROM so_perf_products p JOIN so_perf_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
+    expect:
+      rows: 1
+      result_contains:
+        - "ordered_batch_accept"
+        - "driver_order_partitioned"
+        - "projected_candidate_keyset"
+        - "scan_join_order"
+
+  - name: "SO 73024688 handwritten partition-pruned batch carrier"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define images (table "memcp-tests" "so_perf_images"))
+        (define products (table "memcp-tests" "so_perf_products"))
+        (define selected_products
+          (scan_recset tx products '("project_1")
+            (lambda (project_1) (equal? project_1 1))))
+        (define product_lookup
+          (recset_key_index tx selected_products '("unique_id")))
+        (define found
+          (scan_order_batch_accept tx images
+            (lambda (input)
+              (scan_recset tx input '("product_unique_id")
+                (lambda (product_unique_id) (product_lookup product_unique_id))))
+            '("id") '(<) 0 0 1000 '() (lambda () 1) + 0 false 0))
+        (if (equal? found 1000) "ok" (error "wrong batch carrier row count")))
+
+  - name: "SO 73024688 handwritten complete projected carrier"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define images (table "memcp-tests" "so_perf_images"))
+        (define products (table "memcp-tests" "so_perf_products"))
+        (define selected_products
+          (scan_recset tx products '("project_1")
+            (lambda (project_1) (equal? project_1 1))))
+        (define selected_images
+          (recset_project_join tx selected_products '("unique_id")
+            images '("product_unique_id")))
+        (define found
+          (scan_order tx selected_images '() (lambda () true)
+            '("id") '(<) 0 0 1000 '() (lambda () 1) + 0 false 0))
+        (if (equal? found 1000) "ok" (error "wrong projected carrier row count")))
+
   - name: "SO 73024688 handwritten scan_join_order"
     scm: |
       (begin

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -1,0 +1,335 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Reproducible performance workload derived from public Stack Overflow query
+# shapes. It deliberately keeps the engine's default shard size; `(rebuild)`
+# owns automatic partitioning exactly as it does in production.
+
+metadata:
+  version: "1.0"
+  description: "PostgreSQL, MySQL, and MariaDB Stack Overflow query shapes"
+  isolated: true
+  ci: false
+  max_time: 180
+
+setup:
+  # https://stackoverflow.com/questions/50367835/postgresql-slow-query-with-limit-and-order-by
+  - sql: "CREATE TABLE so_perf_plots (id INT PRIMARY KEY, fk_id VARCHAR(36), created_at BIGINT) ENGINE=memory"
+  # https://stackoverflow.com/questions/6037843/extremely-slow-postgresql-query-with-order-and-limit-clauses
+  - sql: "CREATE TABLE so_perf_bars (id INT PRIMARY KEY, baz_id INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_foos (id INT PRIMARY KEY, bar_id INT) ENGINE=memory"
+  # https://stackoverflow.com/questions/73024688/mariadb-query-is-slow-with-order-by
+  - sql: "CREATE TABLE so_perf_products (id INT PRIMARY KEY, unique_id VARCHAR(32) UNIQUE, project_1 INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_images (id INT PRIMARY KEY, product_unique_id VARCHAR(32)) ENGINE=memory"
+  # https://stackoverflow.com/questions/79837534/slow-mariadb-query-on-11-million-row-table-despite-indexes
+  - sql: "CREATE TABLE so_perf_accounts (id INT PRIMARY KEY, project_id INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_transactions (id INT PRIMARY KEY, account_id INT, amount DECIMAL(10,2), created_at BIGINT) ENGINE=memory"
+  # https://stackoverflow.com/questions/79571812/mysql-query-performance-on-20-million-records
+  - sql: "CREATE TABLE so_perf_search (id INT PRIMARY KEY, body VARCHAR(128), updated_at BIGINT) ENGINE=memory"
+  # https://stackoverflow.com/questions/79644544/postgresql-min-on-view-is-much-slower-than-order-by-limit-1
+  - sql: "CREATE TABLE so_perf_a (apk INT PRIMARY KEY) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_b (bpk INT PRIMARY KEY, ak INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_c (bk INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_d (bk INT) ENGINE=memory"
+  - sql: "CREATE VIEW so_perf_join_view AS SELECT a.apk AS ak, b.bpk AS bk FROM so_perf_a a JOIN so_perf_b b ON b.ak = a.apk JOIN so_perf_c c ON c.bk = b.bpk JOIN so_perf_d d ON d.bk = b.bpk"
+  # https://stackoverflow.com/questions/79550978/slow-postgresql-query-with-order-by-and-limit-on-timescaledb
+  - sql: "CREATE TABLE so_perf_nodes (id INT PRIMARY KEY, serial VARCHAR(32)) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_sensors (id INT PRIMARY KEY, type VARCHAR(16)) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_measures (id INT PRIMARY KEY, node_id INT, sensor_id INT, ts BIGINT, val INT) ENGINE=memory"
+  # https://stackoverflow.com/questions/77990392/mariadb-not-in-subquery-with-union-is-very-slow
+  - sql: "CREATE TABLE so_perf_t1 (pid INT PRIMARY KEY, otherpid INT, col1 INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_t2 (pid INT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_t3 (pid INT) ENGINE=memory"
+  # https://stackoverflow.com/questions/79828237/postgresql-query-performance-with-three-large-tables-distinct-and-pagination
+  - sql: "CREATE TABLE so_perf_players (player_id INT PRIMARY KEY, business_name VARCHAR(32), first_name VARCHAR(32), last_name VARCHAR(32)) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_performance (player_id INT, hashed_player_id VARCHAR(32), fps_score INT, year INT, UNIQUE(year, player_id, hashed_player_id)) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_org_players (org_id INT, player_id INT) ENGINE=memory"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "so_perf_plots") '("id" "fk_id" "created_at")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (if (>= i 119900) "target" "noise") i))))
+        (insert (table "memcp-tests" "so_perf_bars") '("id" "baz_id")
+          (map (produceN 8192) (lambda (i)
+            (list (+ i 1) (if (< i 16) 13266 (+ i 20000))))))
+        (insert (table "memcp-tests" "so_perf_foos") '("id" "bar_id")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (if (< i 160) (+ 1 (floor (/ i 10))) 17)))))
+        (insert (table "memcp-tests" "so_perf_products") '("id" "unique_id" "project_1")
+          (map (produceN 20000) (lambda (i)
+            (list (+ i 1) (concat "product-" (string (+ i 1)))
+              (if (>= i 19000) 1 0)))))
+        (insert (table "memcp-tests" "so_perf_images") '("id" "product_unique_id")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (concat "product-" (string (+ 1 (mod i 20000))))))))
+        (insert (table "memcp-tests" "so_perf_accounts") '("id" "project_id")
+          (map (produceN 5000) (lambda (i)
+            (list (+ i 1) (if (< i 50) 7 8)))))
+        (insert (table "memcp-tests" "so_perf_transactions") '("id" "account_id" "amount" "created_at")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (+ 1 (mod i 5000)) 1.25 i))))
+        (insert (table "memcp-tests" "so_perf_search") '("id" "body" "updated_at")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (if (equal? (mod i 1000) 0)
+              "prefix-key_middle-suffix" "unrelated text") i))))
+        (insert (table "memcp-tests" "so_perf_a") '("apk")
+          (map (produceN 10000) (lambda (i) (list (+ i 1)))))
+        (insert (table "memcp-tests" "so_perf_b") '("bpk" "ak")
+          (map (produceN 30000) (lambda (i)
+            (list (+ i 1) (+ 1 (mod i 10000))))))
+        (insert (table "memcp-tests" "so_perf_c") '("bk")
+          (map (produceN 30000) (lambda (i) (list (+ i 1)))))
+        (insert (table "memcp-tests" "so_perf_d") '("bk")
+          (map (produceN 30000) (lambda (i) (list (+ i 1)))))
+        (insert (table "memcp-tests" "so_perf_nodes") '("id" "serial")
+          (map (produceN 10) (lambda (i)
+            (list (+ i 1) (if (equal? i 0) "TEST0000003" (concat "node-" i))))))
+        (insert (table "memcp-tests" "so_perf_sensors") '("id" "type")
+          (map (produceN 100) (lambda (i)
+            (list (+ i 1) (if (equal? i 99) "ca1" "other")))))
+        (insert (table "memcp-tests" "so_perf_measures") '("id" "node_id" "sensor_id" "ts" "val")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) 1 (+ 1 (mod i 99)) i (mod i 1000)))))
+        (insert (table "memcp-tests" "so_perf_t1") '("pid" "otherpid" "col1")
+          (map (produceN 120000) (lambda (i) (list (+ i 1) nil (+ i 1)))))
+        (insert (table "memcp-tests" "so_perf_t2") '("pid")
+          (map (produceN 30000) (lambda (i) (list (+ i 1)))))
+        (insert (table "memcp-tests" "so_perf_t3") '("pid")
+          (map (produceN 30000) (lambda (i) (list (+ i 30001)))))
+        (insert (table "memcp-tests" "so_perf_players") '("player_id" "business_name" "first_name" "last_name")
+          (map (produceN 10000) (lambda (i)
+            (list (+ i 1) (concat "business-" i) (concat "first-" i) (concat "last-" i)))))
+        (insert (table "memcp-tests" "so_perf_performance") '("player_id" "hashed_player_id" "fps_score" "year")
+          (map (produceN 70000) (lambda (i)
+            (list (+ 1 (mod i 10000)) (concat "hash-" (string (+ 1 (mod i 10000))))
+              (mod i 100) (+ 2007 (* 3 (floor (/ i 10000))))))))
+        (insert (table "memcp-tests" "so_perf_org_players") '("org_id" "player_id")
+          (map (produceN 10000) (lambda (i)
+            (list (if (< i 6000) 1 99) (+ i 1)))))
+        (rebuild)
+        true)
+
+test_cases:
+  - name: "SO 50367835 filtered latest row"
+    threshold_ms: 180000
+    sql: "SELECT id FROM so_perf_plots WHERE fk_id = 'target' ORDER BY created_at DESC LIMIT 1"
+    expect: {rows: 1, data: [{id: 120000}]}
+
+  - name: "SO 6037843 selective ordered join"
+    threshold_ms: 180000
+    sql: "SELECT f.id, f.bar_id FROM so_perf_foos f JOIN so_perf_bars b ON f.bar_id = b.id WHERE b.baz_id = 13266 ORDER BY f.id DESC LIMIT 5"
+    expect: {rows: 5}
+
+  - name: "SO 6037843 exposes costed carrier alternatives"
+    sql: "EXPLAIN PHYSICAL SELECT f.id FROM so_perf_foos f JOIN so_perf_bars b ON f.bar_id = b.id WHERE b.baz_id = 13266 ORDER BY f.id DESC LIMIT 5"
+    expect:
+      rows: 1
+      result_contains: ["ordered_join_carrier", "projected_candidate_keyset", "ordered_postfilter"]
+
+  - name: "SO 73024688 string FK ordered join"
+    threshold_ms: 180000
+    sql: "SELECT i.id FROM so_perf_products p JOIN so_perf_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
+    expect: {rows: 1000}
+
+  - name: "SO 79837534 selective joined SUM"
+    threshold_ms: 180000
+    sql: "SELECT SUM(t.amount) AS total FROM so_perf_transactions t LEFT JOIN so_perf_accounts a ON t.account_id = a.id WHERE t.created_at >= 100000 AND a.project_id = 7"
+    expect: {rows: 1, data: [{total: 250}]}
+
+  - name: "SO 79837534 handwritten projected aggregate carrier"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define accounts (table "memcp-tests" "so_perf_accounts"))
+        (define transactions (table "memcp-tests" "so_perf_transactions"))
+        (define selected_accounts
+          (scan_recset tx accounts '("project_id")
+            (lambda (project_id) (equal? project_id 7))))
+        (define selected_transactions
+          (recset_project_join tx selected_accounts '("id") transactions '("account_id")))
+        (define total
+          (scan tx selected_transactions '("created_at")
+            (lambda (created_at) (>= created_at 100000))
+            '("amount") (lambda (amount) amount) + 0))
+        (if (equal? total 250) "ok" (error "wrong projected SUM result")))
+
+  - name: "SO 79571812 LIKE contains scan"
+    threshold_ms: 180000
+    sql: "SELECT COUNT(*) AS n FROM so_perf_search WHERE body LIKE '%key_middle%'"
+    expect: {rows: 1, data: [{n: 120}]}
+
+  - name: "SO 79571812 MATCH compatibility scan"
+    threshold_ms: 180000
+    sql: "SELECT COUNT(*) AS n FROM so_perf_search WHERE MATCH(body) AGAINST ('key_middle')"
+    expect: {rows: 1, data: [{n: 120}]}
+
+  - name: "SO 79644544 MIN over four-table view"
+    threshold_ms: 180000
+    sql: "SELECT MIN(ak) AS min_ak FROM so_perf_join_view"
+    expect: {rows: 1, data: [{min_ak: 1}]}
+
+  - name: "SO 79644544 ordered equivalent"
+    threshold_ms: 180000
+    sql: "SELECT ak FROM so_perf_join_view ORDER BY ak LIMIT 1"
+    expect: {rows: 1, data: [{ak: 1}]}
+
+  - name: "SO 79644544 handwritten ordered batch join carrier"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define a (table "memcp-tests" "so_perf_a"))
+        (define b (table "memcp-tests" "so_perf_b"))
+        (define c (table "memcp-tests" "so_perf_c"))
+        (define d (table "memcp-tests" "so_perf_d"))
+        (define minimum
+          (scan_order_batch_accept tx a
+            (lambda (a_batch)
+              (begin
+                (define b_batch
+                  (recset_project_join tx a_batch '("apk") b '("ak")))
+                (define c_batch
+                  (recset_project_join tx b_batch '("bpk") c '("bk")))
+                (define d_batch
+                  (recset_project_join tx b_batch '("bpk") d '("bk")))
+                (define b_from_c
+                  (recset_project_join tx c_batch '("bk") b '("bpk")))
+                (define b_from_d
+                  (recset_project_join tx d_batch '("bk") b '("bpk")))
+                (define valid_b
+                  (recset_intersect (list b_batch b_from_c b_from_d)))
+                (define valid_a
+                  (recset_project_join tx valid_b '("ak") a '("apk")))
+                (recset_intersect (list a_batch valid_a))))
+            '("apk") '(<) 0 0 1 '("apk")
+            (lambda (apk) apk) (lambda (_acc value) value) nil false))
+        (if (equal? minimum 1) "ok" (error "wrong ordered batch MIN result")))
+
+  - name: "SO 79550978 missing latest sensor value"
+    threshold_ms: 180000
+    sql: "SELECT m.ts, s.type, m.val FROM so_perf_measures m JOIN so_perf_nodes n ON m.node_id = n.id JOIN so_perf_sensors s ON m.sensor_id = s.id WHERE n.serial = 'TEST0000003' AND s.type IN ('ca1') AND m.ts BETWEEN 0 AND 120000 ORDER BY m.ts DESC LIMIT 4"
+    expect: {rows: 0, data: []}
+
+  - name: "SO 79550978 handwritten intersected join carriers"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define nodes (table "memcp-tests" "so_perf_nodes"))
+        (define sensors (table "memcp-tests" "so_perf_sensors"))
+        (define measures (table "memcp-tests" "so_perf_measures"))
+        (define selected_nodes
+          (scan_recset tx nodes '("serial")
+            (lambda (serial) (equal? serial "TEST0000003"))))
+        (define selected_sensors
+          (scan_recset tx sensors '("type")
+            (lambda (type) (equal? type "ca1"))))
+        (define node_measures
+          (recset_project_join tx selected_nodes '("id") measures '("node_id")))
+        (define sensor_measures
+          (recset_project_join tx selected_sensors '("id") measures '("sensor_id")))
+        (define time_measures
+          (scan_recset tx measures '("ts")
+            (lambda (ts) (and (>= ts 0) (<= ts 120000)))))
+        (define selected
+          (recset_intersect (list node_measures sensor_measures time_measures)))
+        (define rows
+          (scan_order tx selected '() (lambda () true) '("ts") '(>) 0 0 4
+            '("ts" "sensor_id" "val")
+            (lambda (ts sensor_id val) (list ts sensor_id val))
+            (lambda (acc row) (cons row acc)) '() false))
+        (if (empty_list? rows) "ok" (error "missing sensor returned rows")))
+
+  - name: "SO 77990392 original NOT IN UNION"
+    threshold_ms: 180000
+    sql: "SELECT col1 FROM so_perf_t1 WHERE pid NOT IN (SELECT pid FROM so_perf_t2 WHERE pid IS NOT NULL UNION SELECT pid FROM so_perf_t3 WHERE pid IS NOT NULL UNION SELECT otherpid AS pid FROM so_perf_t1 WHERE otherpid IS NOT NULL)"
+    expect: {rows: 60000}
+
+  - name: "SO 77990392 split NOT IN workaround from question"
+    threshold_ms: 180000
+    sql: "SELECT col1 FROM so_perf_t1 WHERE pid NOT IN (SELECT pid FROM so_perf_t2 WHERE pid IS NOT NULL UNION SELECT pid FROM so_perf_t3 WHERE pid IS NOT NULL) AND pid NOT IN (SELECT otherpid AS pid FROM so_perf_t1 WHERE otherpid IS NOT NULL)"
+    expect: {rows: 60000}
+
+  - name: "SO 77990392 handwritten anti-membership difference"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define t1 (table "memcp-tests" "so_perf_t1"))
+        (define t2 (table "memcp-tests" "so_perf_t2"))
+        (define t3 (table "memcp-tests" "so_perf_t3"))
+        (define all_t1 (scan_recset tx t1 '() (lambda () true)))
+        (define nonnull_t2
+          (scan_recset tx t2 '("pid") (lambda (pid) (not (nil? pid)))))
+        (define nonnull_t3
+          (scan_recset tx t3 '("pid") (lambda (pid) (not (nil? pid)))))
+        (define other_t1
+          (scan_recset tx t1 '("otherpid")
+            (lambda (otherpid) (not (nil? otherpid)))))
+        (define excluded2
+          (recset_project_join tx nonnull_t2 '("pid") t1 '("pid")))
+        (define excluded3
+          (recset_project_join tx nonnull_t3 '("pid") t1 '("pid")))
+        (define excluded1
+          (recset_project_join tx other_t1 '("otherpid") t1 '("pid")))
+        (define excluded
+          (recset_union (list excluded2 excluded3 excluded1)))
+        (define allowed (recset_difference (list all_t1 excluded)))
+        (define row_count
+          (scan tx allowed '() (lambda () true) '() (lambda () 1) + 0))
+        (if (equal? row_count 60000) "ok" (error "wrong anti-membership result")))
+
+  - name: "SO 79828237 DISTINCT cursor join"
+    threshold_ms: 180000
+    sql: "SELECT DISTINCT p.business_name, pf.fps_score, pf.hashed_player_id, p.first_name, p.last_name FROM so_perf_performance pf JOIN so_perf_players p ON pf.player_id = p.player_id JOIN so_perf_org_players op ON pf.player_id = op.player_id WHERE pf.year = 2019 AND op.org_id IN (1) ORDER BY pf.hashed_player_id LIMIT 5000"
+    expect: {rows: 5000}
+
+  - name: "SO 79828237 handwritten DISTINCT semijoin carrier"
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define org_players (table "memcp-tests" "so_perf_org_players"))
+        (define performance (table "memcp-tests" "so_perf_performance"))
+        (define players (table "memcp-tests" "so_perf_players"))
+        (define selected_org
+          (scan_recset tx org_players '("org_id")
+            (lambda (org_id) (equal? org_id 1))))
+        (define selected_performance
+          (recset_project_join tx selected_org '("player_id") performance '("player_id")))
+        (define year_performance
+          (scan_recset tx selected_performance '("year")
+            (lambda (year) (equal? year 2019))))
+        (define row_count
+          (scan_order tx year_performance '() (lambda () true)
+            '("hashed_player_id") '(<) 0 0 5000
+            '("player_id" "fps_score" "hashed_player_id")
+            (lambda (player_id fps_score hashed_player_id)
+              (scan tx players '("player_id")
+                (lambda (id) (equal? id (outer player_id)))
+                '("business_name" "first_name" "last_name")
+                (lambda (business_name first_name last_name)
+                  (list business_name (outer fps_score) (outer hashed_player_id)
+                    first_name last_name))
+                (lambda (_old row) row) nil nil false))
+            (lambda (acc row) (if (nil? row) acc (+ acc 1))) 0 false))
+        (if (equal? row_count 5000) "ok" (error "wrong DISTINCT semijoin result")))
+
+cleanup:
+  - sql: "DROP VIEW IF EXISTS so_perf_join_view"
+  - sql: "DROP TABLE IF EXISTS so_perf_plots"
+  - sql: "DROP TABLE IF EXISTS so_perf_bars"
+  - sql: "DROP TABLE IF EXISTS so_perf_foos"
+  - sql: "DROP TABLE IF EXISTS so_perf_products"
+  - sql: "DROP TABLE IF EXISTS so_perf_images"
+  - sql: "DROP TABLE IF EXISTS so_perf_accounts"
+  - sql: "DROP TABLE IF EXISTS so_perf_transactions"
+  - sql: "DROP TABLE IF EXISTS so_perf_search"
+  - sql: "DROP TABLE IF EXISTS so_perf_a"
+  - sql: "DROP TABLE IF EXISTS so_perf_b"
+  - sql: "DROP TABLE IF EXISTS so_perf_c"
+  - sql: "DROP TABLE IF EXISTS so_perf_d"
+  - sql: "DROP TABLE IF EXISTS so_perf_nodes"
+  - sql: "DROP TABLE IF EXISTS so_perf_sensors"
+  - sql: "DROP TABLE IF EXISTS so_perf_measures"
+  - sql: "DROP TABLE IF EXISTS so_perf_t1"
+  - sql: "DROP TABLE IF EXISTS so_perf_t2"
+  - sql: "DROP TABLE IF EXISTS so_perf_t3"
+  - sql: "DROP TABLE IF EXISTS so_perf_players"
+  - sql: "DROP TABLE IF EXISTS so_perf_performance"
+  - sql: "DROP TABLE IF EXISTS so_perf_org_players"

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -125,10 +125,46 @@ test_cases:
       rows: 1
       result_contains: ["ordered_join_carrier", "projected_candidate_keyset", "ordered_postfilter"]
 
+  - name: "SO 6037843 handwritten scan_join_order"
+    scm: |
+      (begin
+        (define foos (table "memcp-tests" "so_perf_foos"))
+        (define bars (table "memcp-tests" "so_perf_bars"))
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list foos bars)
+            (list (list) (list "baz_id"))
+            (list (lambda () true) (lambda (baz_id) (equal? baz_id 13266)))
+            (list (list (list 0 "bar_id" "id")))
+            (list) nil
+            (list (list 0 "id")) (list >)
+            0 0 5
+            (list (list 0 "id"))
+            (lambda (_id) 1) + 0))
+        (if (equal? found 5) "ok" (error "wrong scan_join_order row count")))
+
   - name: "SO 73024688 string FK ordered join"
     threshold_ms: 180000
     sql: "SELECT i.id FROM so_perf_products p JOIN so_perf_images i ON i.product_unique_id = p.unique_id WHERE p.project_1 = 1 ORDER BY i.id LIMIT 1000 OFFSET 0"
     expect: {rows: 1000}
+
+  - name: "SO 73024688 handwritten scan_join_order"
+    scm: |
+      (begin
+        (define images (table "memcp-tests" "so_perf_images"))
+        (define products (table "memcp-tests" "so_perf_products"))
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list images products)
+            (list (list) (list "project_1"))
+            (list (lambda () true) (lambda (project_1) (equal? project_1 1)))
+            (list (list (list 0 "product_unique_id" "unique_id")))
+            (list) nil
+            (list (list 0 "id")) (list <)
+            0 0 1000
+            (list (list 0 "id"))
+            (lambda (_id) 1) + 0))
+        (if (equal? found 1000) "ok" (error "wrong scan_join_order row count")))
 
   - name: "SO 79837534 selective joined SUM"
     threshold_ms: 180000
@@ -172,6 +208,29 @@ test_cases:
     sql: "SELECT ak FROM so_perf_join_view ORDER BY ak LIMIT 1"
     expect: {rows: 1, data: [{ak: 1}]}
 
+  - name: "SO 79644544 handwritten four-way scan_join_order"
+    scm: |
+      (begin
+        (define a (table "memcp-tests" "so_perf_a"))
+        (define b (table "memcp-tests" "so_perf_b"))
+        (define c (table "memcp-tests" "so_perf_c"))
+        (define d (table "memcp-tests" "so_perf_d"))
+        (define minimum
+          (scan_join_order (session "__memcp_tx")
+            (list a b c d)
+            (list (list) (list) (list) (list))
+            (list (lambda () true) (lambda () true) (lambda () true) (lambda () true))
+            (list
+              (list (list 0 "apk" "ak"))
+              (list (list 1 "bpk" "bk"))
+              (list (list 1 "bpk" "bk")))
+            (list) nil
+            (list (list 0 "apk")) (list <)
+            0 0 1
+            (list (list 0 "apk"))
+            (lambda (apk) apk) (lambda (_acc apk) apk) nil))
+        (if (equal? minimum 1) "ok" (error "wrong scan_join_order minimum")))
+
   - name: "SO 79644544 handwritten ordered batch join carrier"
     scm: |
       (begin
@@ -207,6 +266,30 @@ test_cases:
     threshold_ms: 180000
     sql: "SELECT m.ts, s.type, m.val FROM so_perf_measures m JOIN so_perf_nodes n ON m.node_id = n.id JOIN so_perf_sensors s ON m.sensor_id = s.id WHERE n.serial = 'TEST0000003' AND s.type IN ('ca1') AND m.ts BETWEEN 0 AND 120000 ORDER BY m.ts DESC LIMIT 4"
     expect: {rows: 0, data: []}
+
+  - name: "SO 79550978 handwritten scan_join_order"
+    scm: |
+      (begin
+        (define measures (table "memcp-tests" "so_perf_measures"))
+        (define nodes (table "memcp-tests" "so_perf_nodes"))
+        (define sensors (table "memcp-tests" "so_perf_sensors"))
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list measures nodes sensors)
+            (list (list "ts") (list "serial") (list "type"))
+            (list
+              (lambda (ts) (and (>= ts 0) (<= ts 120000)))
+              (lambda (serial) (equal? serial "TEST0000003"))
+              (lambda (type) (equal? type "ca1")))
+            (list
+              (list (list 0 "node_id" "id"))
+              (list (list 0 "sensor_id" "id")))
+            (list) nil
+            (list (list 0 "ts")) (list >)
+            0 0 4
+            (list (list 0 "val"))
+            (lambda (_val) 1) + 0 nil false 0))
+        (if (equal? found 0) "ok" (error "wrong scan_join_order row count")))
 
   - name: "SO 79550978 handwritten intersected join carriers"
     scm: |

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -12,6 +12,7 @@ metadata:
 
 setup:
   - sql: "DROP VIEW IF EXISTS so_perf_join_view"
+  - sql: "DROP TABLE IF EXISTS so_perf_plot_links"
   - sql: "DROP TABLE IF EXISTS so_perf_plots"
   - sql: "DROP TABLE IF EXISTS so_perf_bars"
   - sql: "DROP TABLE IF EXISTS so_perf_foos"
@@ -34,7 +35,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS so_perf_performance"
   - sql: "DROP TABLE IF EXISTS so_perf_org_players"
   # https://stackoverflow.com/questions/50367835/postgresql-slow-query-with-limit-and-order-by
-  - sql: "CREATE TABLE so_perf_plots (id INT PRIMARY KEY, fk_id VARCHAR(36), created_at BIGINT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_plots (id INT PRIMARY KEY, created_at BIGINT) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_plot_links (plot_id INT, table_2_id VARCHAR(36)) ENGINE=memory"
   # https://stackoverflow.com/questions/6037843/extremely-slow-postgresql-query-with-order-and-limit-clauses
   - sql: "CREATE TABLE so_perf_bars (id INT PRIMARY KEY, baz_id INT) ENGINE=memory"
   - sql: "CREATE TABLE so_perf_foos (id INT PRIMARY KEY, bar_id INT) ENGINE=memory"
@@ -66,9 +68,12 @@ setup:
   - sql: "CREATE TABLE so_perf_org_players (org_id INT, player_id INT) ENGINE=memory"
   - scm: |
       (begin
-        (insert (table "memcp-tests" "so_perf_plots") '("id" "fk_id" "created_at")
+        (insert (table "memcp-tests" "so_perf_plots") '("id" "created_at")
           (map (produceN 120000) (lambda (i)
-            (list (+ i 1) (if (>= i 119900) "target" "noise") i))))
+            (list (+ i 1) i))))
+        (insert (table "memcp-tests" "so_perf_plot_links") '("plot_id" "table_2_id")
+          (map (produceN 120000) (lambda (i)
+            (list (+ i 1) (if (equal? i 0) "target" "noise")))))
         (insert (table "memcp-tests" "so_perf_bars") '("id" "baz_id")
           (map (produceN 8192) (lambda (i)
             (list (+ i 1) (if (< i 16) 13266 (+ i 20000))))))
@@ -130,10 +135,35 @@ setup:
         true)
 
 test_cases:
-  - name: "SO 50367835 filtered latest row"
+  - name: "SO 50367835 selective latest joined row"
     threshold_ms: 180000
-    sql: "SELECT id FROM so_perf_plots WHERE fk_id = 'target' ORDER BY created_at DESC LIMIT 1"
-    expect: {rows: 1, data: [{id: 120000}]}
+    sql: "SELECT p.id FROM so_perf_plots p JOIN so_perf_plot_links l ON p.id = l.plot_id WHERE l.table_2_id = 'target' ORDER BY p.created_at DESC LIMIT 1"
+    expect: {rows: 1, data: [{id: 1}]}
+
+  - name: "SO 50367835 exposes costed ordered join alternatives"
+    sql: "EXPLAIN PHYSICAL SELECT p.id FROM so_perf_plots p JOIN so_perf_plot_links l ON p.id = l.plot_id WHERE l.table_2_id = 'target' ORDER BY p.created_at DESC LIMIT 1"
+    expect:
+      rows: 1
+      result_contains: ["chosen scan_join_order", "legacy_join_tree", "lowest_total_ns"]
+
+  - name: "SO 50367835 handwritten scan_join_order"
+    scm: |
+      (begin
+        (define plots (table "memcp-tests" "so_perf_plots"))
+        (define links (table "memcp-tests" "so_perf_plot_links"))
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list plots links)
+            (list (list) (list "table_2_id"))
+            (list (lambda () true)
+              (lambda (table_2_id) (equal? table_2_id "target")))
+            (list (list (list 0 "id" "plot_id")))
+            (list) nil
+            (list (list 0 "created_at")) (list >)
+            0 0 1
+            (list (list 0 "id"))
+            (lambda (_id) 1) + 0))
+        (if (equal? found 1) "ok" (error "wrong scan_join_order row count")))
 
   - name: "SO 6037843 selective ordered join"
     threshold_ms: 180000
@@ -416,6 +446,7 @@ test_cases:
 
 cleanup:
   - sql: "DROP VIEW IF EXISTS so_perf_join_view"
+  - sql: "DROP TABLE IF EXISTS so_perf_plot_links"
   - sql: "DROP TABLE IF EXISTS so_perf_plots"
   - sql: "DROP TABLE IF EXISTS so_perf_bars"
   - sql: "DROP TABLE IF EXISTS so_perf_foos"

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -9,7 +9,6 @@ metadata:
   description: "PostgreSQL, MySQL, and MariaDB Stack Overflow query shapes"
   isolated: true
   ci: false
-  max_time: 180
 
 setup:
   - sql: "DROP VIEW IF EXISTS so_perf_join_view"

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -12,6 +12,28 @@ metadata:
   max_time: 180
 
 setup:
+  - sql: "DROP VIEW IF EXISTS so_perf_join_view"
+  - sql: "DROP TABLE IF EXISTS so_perf_plots"
+  - sql: "DROP TABLE IF EXISTS so_perf_bars"
+  - sql: "DROP TABLE IF EXISTS so_perf_foos"
+  - sql: "DROP TABLE IF EXISTS so_perf_products"
+  - sql: "DROP TABLE IF EXISTS so_perf_images"
+  - sql: "DROP TABLE IF EXISTS so_perf_accounts"
+  - sql: "DROP TABLE IF EXISTS so_perf_transactions"
+  - sql: "DROP TABLE IF EXISTS so_perf_search"
+  - sql: "DROP TABLE IF EXISTS so_perf_a"
+  - sql: "DROP TABLE IF EXISTS so_perf_b"
+  - sql: "DROP TABLE IF EXISTS so_perf_c"
+  - sql: "DROP TABLE IF EXISTS so_perf_d"
+  - sql: "DROP TABLE IF EXISTS so_perf_nodes"
+  - sql: "DROP TABLE IF EXISTS so_perf_sensors"
+  - sql: "DROP TABLE IF EXISTS so_perf_measures"
+  - sql: "DROP TABLE IF EXISTS so_perf_t1"
+  - sql: "DROP TABLE IF EXISTS so_perf_t2"
+  - sql: "DROP TABLE IF EXISTS so_perf_t3"
+  - sql: "DROP TABLE IF EXISTS so_perf_players"
+  - sql: "DROP TABLE IF EXISTS so_perf_performance"
+  - sql: "DROP TABLE IF EXISTS so_perf_org_players"
   # https://stackoverflow.com/questions/50367835/postgresql-slow-query-with-limit-and-order-by
   - sql: "CREATE TABLE so_perf_plots (id INT PRIMARY KEY, fk_id VARCHAR(36), created_at BIGINT) ENGINE=memory"
   # https://stackoverflow.com/questions/6037843/extremely-slow-postgresql-query-with-order-and-limit-clauses
@@ -41,7 +63,7 @@ setup:
   - sql: "CREATE TABLE so_perf_t3 (pid INT) ENGINE=memory"
   # https://stackoverflow.com/questions/79828237/postgresql-query-performance-with-three-large-tables-distinct-and-pagination
   - sql: "CREATE TABLE so_perf_players (player_id INT PRIMARY KEY, business_name VARCHAR(32), first_name VARCHAR(32), last_name VARCHAR(32)) ENGINE=memory"
-  - sql: "CREATE TABLE so_perf_performance (player_id INT, hashed_player_id VARCHAR(32), fps_score INT, year INT, UNIQUE(year, player_id, hashed_player_id)) ENGINE=memory"
+  - sql: "CREATE TABLE so_perf_performance (player_id INT, hashed_player_id VARCHAR(32), fps_score INT, year INT) ENGINE=memory"
   - sql: "CREATE TABLE so_perf_org_players (org_id INT, player_id INT) ENGINE=memory"
   - scm: |
       (begin
@@ -119,11 +141,11 @@ test_cases:
     sql: "SELECT f.id, f.bar_id FROM so_perf_foos f JOIN so_perf_bars b ON f.bar_id = b.id WHERE b.baz_id = 13266 ORDER BY f.id DESC LIMIT 5"
     expect: {rows: 5}
 
-  - name: "SO 6037843 exposes costed carrier alternatives"
+  - name: "SO 6037843 exposes costed ordered join alternatives"
     sql: "EXPLAIN PHYSICAL SELECT f.id FROM so_perf_foos f JOIN so_perf_bars b ON f.bar_id = b.id WHERE b.baz_id = 13266 ORDER BY f.id DESC LIMIT 5"
     expect:
       rows: 1
-      result_contains: ["ordered_join_carrier", "projected_candidate_keyset", "ordered_postfilter"]
+      result_contains: ["scan_join_order", "legacy_join_tree", "lowest_total_ns"]
 
   - name: "SO 6037843 handwritten scan_join_order"
     scm: |

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -211,7 +211,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scan_order"
+        - "scan_join_order"
       result_not_contains:
         - "(sort rows"
         - "(slice sorted"
@@ -762,7 +762,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "stream_window_reduce"
+        - "scan_join_order"
       result_not_contains:
         - "__join_order_intermediate"
         - ".join-order:"
@@ -939,6 +939,45 @@ test_cases:
         - val: 350007
     cleanup:
       - sql: "DROP TABLE IF EXISTS ord_stress"
+
+  - name: "Ordered equi-join top-k preserves SQL result"
+    setup:
+      - sql: "DROP TABLE IF EXISTS ord_join_order_driver"
+      - sql: "DROP TABLE IF EXISTS ord_join_order_lookup"
+      - sql: "CREATE TABLE ord_join_order_driver (id INT PRIMARY KEY, lookup_id INT, score INT)"
+      - sql: "CREATE TABLE ord_join_order_lookup (id INT PRIMARY KEY, enabled INT)"
+      - sql: "INSERT INTO ord_join_order_lookup (id, enabled) VALUES (1, 1), (2, 0)"
+      - sql: "INSERT INTO ord_join_order_driver (id, lookup_id, score) VALUES (1, 1, 10), (2, 2, 20), (3, 1, 30)"
+      - scm: "(rebuild)"
+    sql: |
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled = 1
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      rows: 2
+      data:
+        - id: 3
+        - id: 1
+
+  - name: "Ordered equi-join exposes both physical alternatives"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE DISCOVER
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.lookup_id = l.id
+      WHERE l.enabled = 1
+      ORDER BY d.score DESC
+      LIMIT 2
+    expect:
+      contains:
+        - "scan_join_order"
+        - "legacy_join_tree"
+    cleanup:
+      - sql: "DROP TABLE IF EXISTS ord_join_order_driver"
+      - sql: "DROP TABLE IF EXISTS ord_join_order_lookup"
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS ord_t"

--- a/tests/planner/order-window/order-limit.yaml
+++ b/tests/planner/order-window/order-limit.yaml
@@ -304,7 +304,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scan_order"
+        - "scan_join_order"
         - "ord_tree_a"
         - "ord_tree_b"
         - "ord_tree_c"
@@ -975,6 +975,34 @@ test_cases:
       contains:
         - "scan_join_order"
         - "legacy_join_tree"
+
+  - name: "Sparse ordered join costs all visited driver rows"
+    setup:
+      - sql: "DROP TABLE IF EXISTS ord_join_order_driver"
+      - sql: "DROP TABLE IF EXISTS ord_join_order_lookup"
+      - sql: "CREATE TABLE ord_join_order_driver (id INT PRIMARY KEY, lookup_id INT, score INT)"
+      - sql: "CREATE TABLE ord_join_order_lookup (driver_id INT, enabled INT)"
+      - scm: |
+          (begin
+            (insert (table "memcp-tests" "ord_join_order_driver") '("id" "lookup_id" "score")
+              (map (produceN 2000) (lambda (i) (list (+ i 1) (+ i 1) i))))
+            (insert (table "memcp-tests" "ord_join_order_lookup") '("driver_id" "enabled")
+              (map (produceN 2000) (lambda (i)
+                (list (+ i 1) (if (equal? i 0) 1 0)))))
+            (rebuild)
+            true)
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT d.id
+      FROM ord_join_order_driver d
+      JOIN ord_join_order_lookup l ON d.id = l.driver_id
+      WHERE l.enabled = 1
+      ORDER BY d.score DESC
+      LIMIT 1
+    expect:
+      result_contains:
+        - "chosen scan_join_order"
+        - "join_legacy_probe_rows 2000"
     cleanup:
       - sql: "DROP TABLE IF EXISTS ord_join_order_driver"
       - sql: "DROP TABLE IF EXISTS ord_join_order_lookup"

--- a/tests/planner/subqueries/compound-boolean-recset-selection.yaml
+++ b/tests/planner/subqueries/compound-boolean-recset-selection.yaml
@@ -231,8 +231,6 @@ test_cases:
       result_occurrences:
         - text: "__query_presence_probe_"
           count: 1
-        - text: "__memcp_tx"
-          count: 1
 
   - name: "observed boolean carrier closes invariant EXISTS and NOT probes"
     sql: |

--- a/tests/planner/subqueries/decorrelated-join-reordering.yaml
+++ b/tests/planner/subqueries/decorrelated-join-reordering.yaml
@@ -157,7 +157,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scan_order"
+        - "scan_join_order"
         - "djr_site"
         - "djr_assignment"
       result_not_contains:
@@ -174,7 +174,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scan_order"
+        - "scan_join_order"
         - "djr_assignment"
         - "djr_site"
       result_not_contains:

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -242,6 +242,47 @@ test_cases:
         - ID: 9992
         - ID: 9991
         - ID: 9990
+
+  - name: "Computed membership calibration prepares its candidate cache"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE
+      SELECT ID
+      FROM membership_event
+      WHERE event_time >= 9990
+        AND (entity_kind = 'root' OR entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+    expect:
+      rows: 2
+      contains:
+        - "candidate_keyset"
+        - "driver_filter_join_probe"
+        - "result_equal"
+      not_contains:
+        - "result_equal false"
+
+  - name: "Cached computed membership calibration rebinds its transaction"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE
+      SELECT ID
+      FROM membership_event
+      WHERE event_time >= 9990
+        AND (entity_kind = 'root' OR entity_key IN (
+          SELECT CONCAT('narrow_a:', ID)
+          FROM membership_narrow_key_a
+          WHERE enabled = 1
+        ))
+    expect:
+      rows: 2
+      contains:
+        - "candidate_keyset"
+        - "driver_filter_join_probe"
+        - "result_equal"
+      not_contains:
+        - "result_equal false"
+
   - name: "IN subquery - files with render results"
     sql: |
       SELECT ID, name FROM in_fop_files

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -145,6 +145,7 @@ type calibrationRow struct {
 	CandidateDensity                 *float64 `json:"candidate_density"`
 	ProjectedDriverRows              *float64 `json:"projected_driver_rows"`
 	DriverInputRows                  *float64 `json:"driver_input_rows"`
+	DriverOrderPartitioned           bool     `json:"driver_order_partitioned"`
 	DriverRows                       *float64 `json:"driver_rows"`
 	PrefilteredDriverRows            *float64 `json:"prefiltered_driver_rows"`
 	ExpectedDriverRowsVisited        *float64 `json:"expected_driver_rows_visited"`
@@ -1257,6 +1258,11 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		projectionRows := *row.ProbeBranches *
 			(2**row.ExpectedDriverRowsVisited + candidateWorkRows + candidateMatchRows)
 		orderedDriverWork := batches * *row.DriverInputRows * *row.DriverInputRows / 1_000_000
+		if row.DriverOrderPartitioned {
+			// Range-partitioned ORDER BY windows visit a geometric series of
+			// disjoint shard prefixes, bounded by twice the final prefix.
+			orderedDriverWork = 2 * *row.ExpectedDriverRowsVisited
+		}
 		return []float64{
 			*row.DriverScanInvocations + batches**row.CandidateScanInvocations,
 			*row.ExpectedDriverRowsVisited + candidateWorkRows + projectionRows,

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -168,6 +168,11 @@ type calibrationRow struct {
 	DriverMapColumns                 *float64 `json:"driver_map_columns"`
 	DriverExpressionOperations       *float64 `json:"driver_expression_operations"`
 	DriverExpressionDepth            *float64 `json:"driver_expression_depth"`
+	JoinInputRows                    *float64 `json:"join_input_rows"`
+	JoinEstimatedRows                *float64 `json:"join_estimated_rows"`
+	JoinOutputRows                   *float64 `json:"join_output_rows"`
+	JoinTableCount                   *float64 `json:"join_table_count"`
+	JoinLegacyProbeRows              *float64 `json:"join_legacy_probe_rows"`
 	ResultEqual                      bool     `json:"result_equal"`
 	Rows                             int64    `json:"rows"`
 	ResultHash                       string   `json:"result_hash"`
@@ -278,7 +283,7 @@ func main() {
 	// must not be mistaken for additional equations of this coefficient model.
 	membershipObservations := filterDecisionObservations(observations, "membership_carrier")
 	training := filterObservations(membershipObservations, false)
-	allTraining := filterObservations(observations, false)
+	allTraining := filterObservations(membershipObservations, false)
 	carrierTraining := filterCarrierObservations(training)
 	fitTraining := filterCompleteExactPairs(carrierTraining)
 	if err := validateMeasurementSignal(fitTraining); err != nil {
@@ -310,6 +315,18 @@ func main() {
 		}
 	}
 	printDecisionOrdering(membershipObservations, c)
+	orderedJoinObservations := filterDecisionObservations(observations, "scan_join_order")
+	if len(orderedJoinObservations) > 0 {
+		// scan_join_order deliberately reuses the calibrated scan/map/expression
+		// work units instead of introducing an independently fitted coefficient
+		// set. Its forced variants still form a mandatory ordering check: this
+		// catches a lowerer formula which compiles but chooses the wrong operator.
+		if err := validateDecisionOrdering(orderedJoinObservations, c); err != nil {
+			fatal(fmt.Errorf("scan_join_order: %w", err))
+		}
+		printModelComparison("scan_join_order", orderedJoinObservations, c)
+		printDecisionOrdering(orderedJoinObservations, c)
+	}
 	if *patch {
 		if err := patchQueryplan(queryplanPath, c); err != nil {
 			fatal(err)
@@ -948,7 +965,12 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 	if row.EstimatedNS == nil || row.WholeQueryExecutionNS <= 0 {
 		return fmt.Errorf("forced race variant has incomplete measurements: %+v", row)
 	}
-	if row.CandidateInputRows == nil || row.CandidateRows == nil ||
+	if row.Decision == "scan_join_order" {
+		if row.JoinInputRows == nil || row.JoinEstimatedRows == nil ||
+			row.JoinOutputRows == nil || row.JoinTableCount == nil || row.JoinLegacyProbeRows == nil {
+			return fmt.Errorf("ordered join variant has incomplete measurements: %+v", row)
+		}
+	} else if row.CandidateInputRows == nil || row.CandidateRows == nil ||
 		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil {
 		return fmt.Errorf("membership variant has incomplete measurements: %+v", row)
 	}
@@ -1104,6 +1126,25 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	if row.Decision == "scan_join_order" {
+		if row.JoinInputRows == nil || row.JoinEstimatedRows == nil ||
+			row.JoinOutputRows == nil || row.JoinTableCount == nil {
+			return nil, fmt.Errorf("ordered join work profile contains nil inputs: %+v", row)
+		}
+		features := make([]float64, 19)
+		features[0] = math.Max(0, *row.JoinTableCount-1)
+		features[15] = 1
+		features[1] = *row.JoinInputRows
+		features[3] = *row.JoinOutputRows + *row.JoinInputRows*math.Max(0, *row.JoinTableCount-1)
+		features[4] = *row.JoinEstimatedRows
+		if row.Plan == "legacy_join_tree" {
+			if row.JoinLegacyProbeRows == nil {
+				return nil, fmt.Errorf("ordered legacy join profile has nil probe rows: %+v", row)
+			}
+			features[18] = *row.JoinLegacyProbeRows
+		}
+		return features, nil
+	}
 	scanInvocations := *row.CandidateScanInvocations + *row.DriverScanInvocations
 	driverWorkRows := *row.DriverInputRows
 	adaptiveProbeRows, adaptiveSortWork := 0.0, 0.0
@@ -1684,6 +1725,12 @@ func fitNonnegative(x [][]float64, y []float64) ([]float64, error) {
 }
 
 func estimatedNS(row observation, c constants) float64 {
+	if row.decision == "scan_join_order" && row.plan == "legacy_join_tree" {
+		// The legacy alternative is an already costed composite join tree. Its
+		// planner-reported estimate is the authoritative baseline; rowFeatures
+		// only expands the new scan_join_order operator into generated work units.
+		return row.currentEstimate
+	}
 	beta := []float64{
 		float64(c.scanInvocationNS),
 		float64(c.scanRowNS),
@@ -1802,11 +1849,25 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 		switch row.plan {
 		case "candidate_keyset", "driver_order_membership_probe", "driver_filter_join_probe", "ordered_batch_accept", "prefiltered_candidate_keyset":
 			groups[row.caseName][row.plan] = row
+		case "legacy_join_tree", "scan_join_order":
+			if row.decision != "scan_join_order" {
+				return nil, fmt.Errorf("plan %q belongs to scan_join_order, got decision %q", row.plan, row.decision)
+			}
+			groups[row.caseName][row.plan] = row
 		default:
 			return nil, fmt.Errorf("unsupported plan %q", row.plan)
 		}
 	}
 	for name, plans := range groups {
+		if decisions[name] == "scan_join_order" {
+			if _, legacy := plans["legacy_join_tree"]; !legacy {
+				return nil, fmt.Errorf("incomplete ordered join alternatives for %q", name)
+			}
+			if _, ordered := plans["scan_join_order"]; !ordered {
+				return nil, fmt.Errorf("incomplete ordered join alternatives for %q", name)
+			}
+			continue
+		}
 		if _, ok := plans["candidate_keyset"]; !ok {
 			return nil, fmt.Errorf("incomplete alternatives for %q", name)
 		}

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -112,6 +112,32 @@ func TestRowFeaturesKeepsBroadTextRowsAndBytesSeparate(t *testing.T) {
 	}
 }
 
+func TestRowFeaturesModelsOrderedJoinAlternatives(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	base := calibrationRow{
+		Decision: "scan_join_order", JoinInputRows: value(25_000),
+		JoinEstimatedRows: value(4_000), JoinOutputRows: value(72),
+		JoinTableCount: value(2), JoinLegacyProbeRows: value(600),
+	}
+	base.Plan = "scan_join_order"
+	scanFeatures, err := rowFeatures(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanFeatures[0] != 1 || scanFeatures[1] != 25_000 || scanFeatures[15] != 1 ||
+		scanFeatures[3] != 25_072 || scanFeatures[4] != 4_000 || scanFeatures[18] != 0 {
+		t.Fatalf("ordered join scan features = %v", scanFeatures)
+	}
+	base.Plan = "legacy_join_tree"
+	legacyFeatures, err := rowFeatures(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacyFeatures[18] != 600 {
+		t.Fatalf("legacy ordered join probe work = %v, want 600", legacyFeatures[18])
+	}
+}
+
 func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
 	value := func(v float64) *float64 { return &v }
 	row := calibrationRow{
@@ -353,6 +379,48 @@ func TestDecisionAlternativesAcceptsDirectFilterConsumer(t *testing.T) {
 	}
 	if len(groups["filter"]) != 2 {
 		t.Fatalf("unexpected alternatives: %+v", groups)
+	}
+}
+
+func TestDecisionAlternativesAcceptsOrderedJoinFamily(t *testing.T) {
+	rows := []observation{
+		{caseName: "join", decision: "scan_join_order", plan: "legacy_join_tree"},
+		{caseName: "join", decision: "scan_join_order", plan: "scan_join_order"},
+	}
+	groups, err := decisionAlternatives(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups["join"]) != 2 {
+		t.Fatalf("unexpected ordered join alternatives: %+v", groups)
+	}
+}
+
+func TestValidateDecisionOrderingUsesOrderedJoinCostBoundary(t *testing.T) {
+	legacy := func(name string, measured, estimated float64) observation {
+		return observation{
+			caseName: name, decision: "scan_join_order", plan: "legacy_join_tree",
+			y: measured, currentEstimate: estimated, x: make([]float64, 19),
+		}
+	}
+	ordered := func(name string, measured float64) observation {
+		features := make([]float64, 19)
+		features[0], features[1], features[3], features[4], features[15] = 1, 25_000, 25_001, 1, 1
+		return observation{
+			caseName: name, decision: "scan_join_order", plan: "scan_join_order",
+			y: measured, x: features,
+		}
+	}
+	rows := []observation{
+		legacy("point", 70e6, 3.2e6), ordered("point", 230e6),
+		legacy("broad", 439e6, 5.7e6), ordered("broad", 1.2e6),
+	}
+	constants := constants{
+		scanInvocationNS: 122_080, scanRowNS: 1, mapColumnRowNS: 32,
+		expressionOperationNS: 220, orderedScanInvocationNS: 3_027_639,
+	}
+	if err := validateDecisionOrdering(rows, constants); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -168,6 +168,15 @@ func TestRowFeaturesModelsAdaptiveOrderedBatchWork(t *testing.T) {
 	if features[15] != 4 {
 		t.Fatalf("ordered scan invocations = %v, want 4", features[15])
 	}
+	row.DriverOrderPartitioned = true
+	partitionedFeatures, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if partitionedFeatures[12] != 200 {
+		t.Fatalf("partition-pruned ordered batch work = %v, want twice the 100-row prefix",
+			partitionedFeatures[12])
+	}
 }
 
 func TestRowFeaturesModelsDirectPresenceProbes(t *testing.T) {


### PR DESCRIPTION
Adds the Stack Overflow performance workloads and a physical `scan_join_order` operator for ordered equi-join Top-K plans.

Implementation:
- keeps default `ShardSize` and uses `rebuild` for automatic partitioning
- runs unpartitioned shard tuples in parallel and reuses compatible join-key partitioning to reduce cross-shard runners
- applies `limit + offset` Top-K pruning both runner-local and during global merge
- keeps map on the joined outer tuple and table-local filters on each input
- follows scan parameter ordering through map, reduce, neutral, reduce2, and outer fallback
- treats one reducer as the global ordered reducer; with two reducers, reduce is runner-local and reduce2 is global, only for unlimited scans
- enumerates `legacy_join_tree` and `scan_join_order` as costed physical alternatives before lowering
- extends `scan_order_batch_accept` with ordered range-partition pruning: one-dimensional shards form disjoint ordered runs, so later shards are never started after a candidate window is complete
- exposes `driver_order_partitioned` in `EXPLAIN PHYSICAL`, guards the cached decision against topology changes, and feeds the same feature into the planner formula and `tools/costgen`
- adds a Costgen calibration observation for the partition-pruned ordered membership path
- fixes long-lived computed group columns so they resolve the current transaction from the rebound runtime session instead of capturing a request-local physical slot

A/B measurements use identical SQL/operator trees and data, default `ShardSize`, and automatic `rebuild` partitioning:

| workload | before this follow-up (`c36856b`) | this PR | result |
| --- | ---: | ---: | ---: |
| SO 73024688, 6,276,445 products + 22,888,685 images, uniformly distributed matches, partition-pruned ordered batch | 596.7 ms median | 218.5 ms median | 2.73x faster |
| SO 73024688, same cardinality, adversarial matches only at the end of join-key space | 5.27 s | 2.13 s median | 2.47x faster |
| SO 73024688, adversarial distribution, complete projected RecSet | 1.43-1.51 s | 1.37-1.53 s | stable fallback/reference plan |
| SO 73024688, checked-in 20k-product/120k-image SQL fixture | 20.4 ms median | 20.3 ms median | unchanged within noise; `scan_join_order` remains the dominant cost choice |

The original-size fixture is now reproducible in `tests/performance/stackoverflow-order-limit-join-large.yaml` with `metadata.ci: false`. It constructs the 6.28M/22.89M cardinalities in bounded batches, leaves `ShardSize` untouched, records both the ordinary and deliberately anti-correlated distributions, and contains the partition-pruned batch and complete projected handwritten plans. The fixture can be persisted with `ENGINE=sloppy` after its rebuild; it is intentionally excluded from CI because setup and index validation take several minutes.

Earlier PR A/B results remain:

| workload | merge-base `7d7eca9` | this PR | result |
| --- | ---: | ---: | ---: |
| SO 50367835, 120k plots + 120k links | no response after 50,059.9 ms | 11.1 ms median | >4,500x faster |
| SO 6037843, 120k foos + 8,192 bars | 3.7 ms median | 3.9 ms median | unchanged within noise |

Validation performed locally:
- `go build -o memcp`
- `go test ./tools/costgen`
- targeted `scan_order_batch_accept` and ordered partition-pruning storage tests
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 30/30
- focused SO 73024688 SQL/EXPLAIN suite: 2/2
- Stack Overflow performance suite: both new handwritten plans passed; the 120k SQL query remained 20.2 ms
- Scheme formatter/check, SQL time-limit guard, table-name policy, and `git diff --check`

The full regression run is left to CI as requested. The broad local suites also reproduced pre-existing/flaky `table does not exist`, timeout, ownership, and persistence-test failures outside this change's operator path; the targeted affected paths are green.
