### PR TITLE
Reduce per-scan allocation overhead

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -144,40 +144,56 @@ func (t *table) shardResultBufferSize() int {
 	return size
 }
 
-func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnboundaries, callback_old func(*storageShard, bool)) <-chan struct{} {
+func traceShardScanCallback(callback func(*storageShard, bool), shard *storageShard, solo bool) {
+	scm.Trace.Duration(fmt.Sprintf("%p", shard), "shard", func() {
+		callback(shard, solo)
+	})
+}
+
+// runSingleShardScan keeps panic-safe resource release outside the topology
+// retry loop. Defers inside that loop cannot be open-coded by Go and used to
+// allocate a separate closure for every ordinary one-shard scan.
+func runSingleShardScan(currentTx *TxContext, topology *tableShardTopology, shard *storageShard, callback func(*storageShard, bool)) {
+	defer topology.releaseOperation()
+	defer shard.activeScanners.Add(-1)
+	release := shard.acquireReadForScan(currentTx)
+	defer release()
+	if scm.Trace == nil {
+		callback(shard, true)
+	} else {
+		traceShardScanCallback(callback, shard, true)
+	}
+}
+
+func runParallelShardScans(currentTx *TxContext, shards []*storageShard, topology *tableShardTopology, callback func(*storageShard, bool)) <-chan struct{} {
+	return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
+		shard := shards[i]
+		defer topology.releaseOperation()
+		defer shard.activeScanners.Add(-1)
+		release := shard.acquireReadForScan(currentTx)
+		defer release()
+		if scm.Trace == nil {
+			callback(shard, synchronous)
+		} else {
+			traceShardScanCallback(callback, shard, synchronous)
+		}
+	})
+}
+
+func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnboundaries, callback func(*storageShard, bool)) <-chan struct{} {
 	// Keep shard acquisition outside physical scan callbacks. In clustered mode
 	// this is the orchestration point that can choose a local SHARED copy or send
 	// the whole shard-local scan pipeline to a remote holder; row readers must not
 	// perform another resource acquisition from inside the callback.
-	callback := callback_old
-	if scm.Trace != nil {
-		// hook on tracing
-		callback = func(s *storageShard, solo bool) {
-			scm.Trace.Duration(fmt.Sprintf("%p", s), "shard", func() {
-				callback_old(s, solo)
-			})
-		}
-	}
-
-	runWorkers := func(shards []*storageShard, topology *tableShardTopology) <-chan struct{} {
-		return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
-			s := shards[i]
-			defer topology.releaseOperation()
-			defer s.activeScanners.Add(-1)
-			release := s.acquireReadForScan(currentTx)
-			defer release()
-			callback(s, synchronous)
-		})
-	}
-
 	for {
 		topology := t.activeTopology()
 		var relevant []*storageShard
 		if topology.mode == ShardModeFree {
-			relevant = make([]*storageShard, 0, len(topology.shards))
-			for _, s := range topology.shards {
-				if s != nil {
-					relevant = append(relevant, s)
+			relevant = topology.shards
+			for _, shard := range relevant {
+				if shard == nil {
+					relevant = collectRelevantShards(nil, boundaries, topology.shards)
+					break
 				}
 			}
 		} else {
@@ -208,15 +224,10 @@ func (t *table) iterateShardsParallel(currentTx *TxContext, boundaries []columnb
 		}
 
 		if len(relevant) == 1 {
-			s := relevant[0]
-			defer topology.releaseOperation()
-			defer s.activeScanners.Add(-1)
-			release := s.acquireReadForScan(currentTx)
-			defer release()
-			callback(s, true)
+			runSingleShardScan(currentTx, topology, relevant[0], callback)
 			return nil
 		}
-		return runWorkers(relevant, topology)
+		return runParallelShardScans(currentTx, relevant, topology, callback)
 	}
 }
 

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -592,8 +592,9 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 		}
 		return scm.ToBool(conditionFn(cdataset...))
 	}
-	var buf [1024]uint32
-	t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], true, &exactLikeMain, func(batch []uint32) bool {
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
+	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
+	t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if idx >= visibleUpper {
 				continue
@@ -1556,8 +1557,9 @@ func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, condit
 			return true
 		})
 	} else {
-		var buf [1024]uint32
-		t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, len(t.inserts), buf[:], true, nil, evaluateBatch)
+		buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
+		defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
+		t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, len(t.inserts), buf, true, nil, evaluateBatch)
 	}
 	return builder.finish()
 }

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -842,8 +842,9 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	found := false
 	var foundID uint32
 
-	var buf [8]uint32
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(uniquePointScanBufferSize)
+	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
+	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}
@@ -1391,7 +1392,8 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		mutationSeen = make(map[uint64]struct{}, 128)
 	}
 
-	var buf [1024]uint32
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
+	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 	var batchBuf [1024]uint32
 	hadValue := false
 	batchCount := len(batchdata) / stride
@@ -1406,7 +1408,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 			activeLower, activeUpperLast = indexFromBoundaries(activeBoundaries)
 		}
 
-		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf[:], 1, nil, func(batch []uint32) bool {
+		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))
 			outN := 0
 			for _, idx := range batch {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -441,6 +441,47 @@ const (
 	uniquePointScanBufferSize = 8
 )
 
+type fullScanIDBuffer struct {
+	values [defaultScanBufferSize]uint32
+}
+
+type pointScanIDBuffer struct {
+	values [uniquePointScanBufferSize]uint32
+}
+
+// The index iterator callback makes a dynamically sized []uint32 escape even
+// though it is consumed before scan returns. Reuse the two calibrated batch
+// sizes instead of paying for a heap allocation on every scan. sync.Pool keeps
+// concurrent scans independent and permits the runtime to discard idle memory.
+var fullScanIDBufferPool = sync.Pool{
+	New: func() any { return new(fullScanIDBuffer) },
+}
+
+var pointScanIDBufferPool = sync.Pool{
+	New: func() any { return new(pointScanIDBuffer) },
+}
+
+func acquireScanIDBuffer(size int) ([]uint32, *fullScanIDBuffer, *pointScanIDBuffer) {
+	if size == defaultScanBufferSize {
+		buffer := fullScanIDBufferPool.Get().(*fullScanIDBuffer)
+		return buffer.values[:], buffer, nil
+	}
+	if size == uniquePointScanBufferSize {
+		buffer := pointScanIDBufferPool.Get().(*pointScanIDBuffer)
+		return buffer.values[:], nil, buffer
+	}
+	return make([]uint32, size), nil, nil
+}
+
+func releaseScanIDBuffer(full *fullScanIDBuffer, point *pointScanIDBuffer) {
+	if full != nil {
+		fullScanIDBufferPool.Put(full)
+	}
+	if point != nil {
+		pointScanIDBufferPool.Put(point)
+	}
+}
+
 // scanBufferSize keeps full scans batched while avoiding a 4 KiB allocation
 // for the common join case where an exact unique key can yield at most one
 // currently visible row. A few slots remain for stale index entries left by
@@ -1043,7 +1084,8 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	}
 
 	// filter phase: iterateIndex fills the reusable buffer, callback filters in-place and flushes to MapReducer
-	buf := make([]uint32, t.t.scanBufferSize(boundaries))
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(t.t.scanBufferSize(boundaries))
+	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 	hadValue := false
 
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {

--- a/storage/scan_family_bench_test.go
+++ b/storage/scan_family_bench_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+// BenchmarkScanFamilyFixedCosts keeps the empty-table setup paths of every
+// physical scan operator visible to the allocation profiler. Row throughput is
+// covered by the operator-specific benchmarks; these cases isolate dispatch,
+// index-iterator scratch, queues and map/reduce setup.
+func BenchmarkScanFamilyFixedCosts(b *testing.B) {
+	tbl := benchScanTable(b, "family")
+	trueFn := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	mapFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		if len(values) == 0 {
+			return scm.NewNil()
+		}
+		return values[0]
+	})
+	reduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })
+	nilValue := scm.NewNil()
+	sortCols := []scm.Scmer{scm.NewString("id")}
+	sortDirs := []func(...scm.Scmer) scm.Scmer{scm.OptimizeProcToSerialFunction(scm.Globalenv.Vars[scm.Symbol("<")])}
+	orderedSpec := scanOrderTableSpec{
+		table:          tbl,
+		condition:      trueFn,
+		sortcols:       sortCols,
+		callbackCols:   []string{"id"},
+		callback:       mapFn,
+		perTableOffset: -1,
+		perTableLimit:  -1,
+	}
+	recSetInputTable := benchScanTable(b, "family_recset_input")
+	recSetInputTable.Insert([]string{"id"}, [][]scm.Scmer{{scm.NewInt(1)}}, nil, scm.NewNil(), false, nil)
+	RebuildTable(recSetInputTable, true, false)
+	recSetInput := recSetInputTable.scanRecSet(nil, nil, trueFn)
+	identityRecSet := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+
+	benchmarks := []struct {
+		name string
+		run  func()
+	}{
+		{
+			name: "recset",
+			run: func() {
+				tbl.scanRecSet(nil, nil, trueFn)
+			},
+		},
+		{
+			name: "recset_input",
+			run: func() {
+				recSetInput.filterToRecSet(nil, nil, trueFn)
+			},
+		},
+		{
+			name: "exists",
+			run: func() {
+				tbl.scanExists(nil, nil, trueFn)
+			},
+		},
+		{
+			name: "batch",
+			run: func() {
+				tbl.scanWithBatch(nil, []string{"#0"}, trueFn, []string{"id"}, mapFn,
+					reduceFn, nilValue, nilValue, false, 1, []scm.Scmer{scm.NewInt(1)})
+			},
+		},
+		{
+			name: "order",
+			run: func() {
+				tbl.scan_order(nil, nil, trueFn, sortCols, sortDirs, 0, 0, 72,
+					[]string{"id"}, mapFn, reduceFn, nilValue, false, nilValue, nil, nilValue)
+			},
+		},
+		{
+			name: "order_recset",
+			run: func() {
+				recSetInput.scan_order(nil, nil, trueFn, sortCols, sortDirs, 0, 0, 72,
+					[]string{"id"}, mapFn, reduceFn, nilValue, false, nilValue, nil, nilValue)
+			},
+		},
+		{
+			name: "order_multi",
+			run: func() {
+				scanOrderMulti(nil, []scanOrderTableSpec{orderedSpec, orderedSpec}, sortDirs,
+					0, 0, 72, reduceFn, nilValue, false, nilValue)
+			},
+		},
+		{
+			name: "order_batch_accept",
+			run: func() {
+				scanOrderBatchAccept(nil, orderedSpec, identityRecSet, sortCols, sortDirs,
+					0, 0, 72, []string{"id"}, mapFn, reduceFn, nilValue, false, nilValue)
+			},
+		},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmark.run()
+			}
+		})
+	}
+}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -832,7 +832,11 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		}
 	}
 
-	var buf [1024]uint32 // stack-allocated batch buffer (4 KB, fits in L1)
+	// The optional record visitor makes this batch escape even though ordered
+	// scans consume it synchronously. Keep one exclusive, pointer-free 4 KiB
+	// workspace per active merge instead of allocating it for every invocation.
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
+	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 	bufN := 0
 	var bufShard *shardqueue
 	breakCaught := false
@@ -1275,8 +1279,15 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 
 		// iterate over items (indexed)
 		// TODO(memcp): iterateIndexSorted(boundaries, sortcols) to emit tuples in ORDER BY sequence.
-		var buf [1024]uint32
+		buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
+		defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 		resultCap := 1024
+		if limitPartitionCols == 0 && limit >= 0 && limit < resultCap {
+			resultCap = limit
+		}
+		if resultCap < 1 {
+			resultCap = 1
+		}
 		result.items = make([]uint32, resultCap)
 		resultN := 0
 		usageWeight := orderedScanIndexUsageWeight(boundaries, int(visibleUpper), limit)
@@ -1286,7 +1297,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		// GetValue call per row per column.
 		var survivedBuf, mainIdsBuf []uint32
 		colBufs := make([][]scm.Scmer, len(conditionCols))
-		t.iterateIndexOrdered(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf[:], usageWeight, limit, func(index *StorageIndex, active bool) {
+		t.iterateIndexOrdered(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, usageWeight, limit, func(index *StorageIndex, active bool) {
 			if len(sortcols) > 0 {
 				resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
 			}


### PR DESCRIPTION
## What

- reuse calibrated 1024-record and 8-record ID workspaces across the complete public scan family
- cover `scan`, `scan_recset`, RecSet-input filtering, `scan_exists`, `scan_batch`, `scan_order`, `scan_order_multi`, and `scan_order_batch_accept`
- keep the ordinary single-shard topology slice allocation-free
- move panic-safe single-shard resource release out of the retry loop so Go can open-code the defers
- size finite, unpartitioned ordered result queues from LIMIT instead of eagerly reserving 1024 IDs
- add one allocation benchmark that keeps every public scan shape visible

## Why

The fixed scan cost was dominated by ID buffers which escape through index callbacks and by multi-shard orchestration state constructed even for the common one-shard case. Each pooled buffer remains exclusive to one synchronous scan invocation and contains no pointers. This is a tactical implementation detail, not a planner or public API change.

The remaining ordered result queues intentionally stay dynamically allocated: their contents can outlive an individual shard callback and their size depends on query results.

Two broader alternatives were measured and left out:

- one large inline condition frame still escaped through the variadic Scheme callback, retained 415 extra bytes per scan, and slowed the benchmark by roughly 5-10 percent
- wrapping the condition as an already executable Go function hid its AST from boundary analysis; the unique probe lost its index and regressed from about 3.7 microseconds to about 185 microseconds

A future zero-allocation callback API therefore needs one object that retains both analyzable AST and reusable execution state.

## A/B measurements

Fixed-cost operator benchmarks on the same machine, comparing commit `7f4be3acd` before the family extension with this PR:

| operator | before | after | allocation change |
| --- | ---: | ---: | ---: |
| scan_exists | ~5.0 us | ~5.0 us | 900 to 869 B; 9 to 8 allocs |
| scan_batch | ~8.3 us | ~6.7 us | 6384 to 2296 B; 27 to 26 allocs |
| scan_order | ~14.3 us | ~10.0 us | 14712 to 2702 B; 34 to 32 allocs |
| scan_order_multi | ~26.3 us | ~18.7-19.2 us | 25137 to 5220 B; 57 to 54 allocs |
| scan_recset | ~7.0 us | ~5.5 us | 5456 to 1365 B; 14 to 13 allocs |
| RecSet input filter | ~4.8 us | ~3.55 us | 5464 to 1373 B; 20 to 19 allocs |

The existing million-row `scan_order_batch_accept` benchmark improved from about 2.72 ms to 2.43 ms (roughly 10 percent, with run-to-run noise); its plain ordered control remained neutral at about 102-103 ms.

The original commit also improved ordinary scans versus master `62511bb4e`:

| benchmark | baseline | this PR | allocation change |
| --- | ---: | ---: | ---: |
| empty one-shard scan | median 6.23 us | median 5.79 us | 19 to 15 allocs; 5481 to 1470 B |
| unique point probe with transaction | median 3.73 us | median 3.61 us | 26 to 21 allocs; 1387 to 1309 B |
| 60k-row full scan | median 331.3 us | median 323.1 us | 23 to 19 allocs; 10661 to 2458 B |

## Validation

- targeted correctness tests for ordered, RecSet, EXISTS, and adaptive batch scans
- targeted race tests for ordered batch accept and RecSet source scans
- identical repeated A/B benchmarks against the pre-extension commit
- full hook-equivalent `make test`: all critical suites passed

No planner semantics, index analysis, scan result order, or public operator signatures change.