### PR TITLE
Specialize common scan callback pipelines

### DIFF
--- a/scm/declare.go
+++ b/scm/declare.go
@@ -25,9 +25,10 @@ import "strings"
 
 // Declaration describes a built-in or Scheme-defined function.
 type Declaration struct {
-	Name string
-	Fn   func(...Scmer) Scmer
-	Type *TypeDescriptor
+	Name            string
+	Fn              func(...Scmer) Scmer
+	Type            *TypeDescriptor
+	RetainsCallArgs bool // native result or state may retain the variadic argument array
 }
 
 // MinParams returns the minimum number of required parameters.

--- a/scm/list.go
+++ b/scm/list.go
@@ -843,7 +843,8 @@ func init_list() {
 	// list is already in Globalenv.Vars (scm.go init); register it
 	// in declarations so serialization can resolve the function pointer.
 	Declare(&Globalenv, &Declaration{
-		Name: "list",
+		Name:            "list",
+		RetainsCallArgs: true,
 
 		Fn: List,
 		Type: &TypeDescriptor{Kind: "func", Description: "constructs a list from its arguments",

--- a/scm/serial_proc.go
+++ b/scm/serial_proc.go
@@ -1,0 +1,287 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+// SerialProcKind describes callback shapes whose semantics can be consumed by
+// a physical operator without entering Eval. Operators must dispatch on Kind
+// outside their row loops; Call is the compatibility path for code which does
+// not have a shape-specific kernel.
+type SerialProcKind uint8
+
+const (
+	SerialProcGeneral SerialProcKind = iota
+	SerialProcConstant
+	SerialProcArgument
+	SerialProcNative
+	SerialProcNativeArgConstant
+)
+
+// SerialProc exposes trivial executable shapes to physical operators. Callers
+// retain the original procedure when analysis or serialization needs it; not
+// duplicating it here keeps every scan mapper compact. The value is immutable
+// after preparation. The general interpreter fallback remains serial.
+type SerialProc struct {
+	Kind     SerialProcKind
+	Value    Scmer // constant result or native-function identity
+	Argument int16
+	// ConstantFirst records whether Value is the first operand of the
+	// binary native call represented by SerialProcNativeArgConstant.
+	ConstantFirst bool
+	Function      func(...Scmer) Scmer
+}
+
+func serialProcBody(v Scmer) Scmer {
+	if stripped, ok := scmerStripSourceInfo(v); ok {
+		return stripped
+	}
+	return v
+}
+
+func serialProcConstantBody(v Scmer) bool {
+	switch v.GetTag() {
+	case tagNil, tagBool, tagInt, tagFloat, tagString:
+		return true
+	default:
+		return false
+	}
+}
+
+func serialProcArgumentIndex(proc *Proc, body Scmer) (int, bool) {
+	body = serialProcBody(body)
+	if body.IsNthLocalVar() {
+		return int(body.NthLocalVar()), true
+	}
+	params := serialProcBody(proc.Params)
+	if !body.IsSymbol() || !params.IsSlice() {
+		return 0, false
+	}
+	for i, param := range params.Slice() {
+		param = serialProcBody(param)
+		if param.IsSymbol() && mustSymbol(param) == mustSymbol(body) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func serialProcResolveNative(proc *Proc, value Scmer) (Scmer, bool) {
+	value = serialProcBody(value)
+	if value.GetTag() == tagFunc {
+		return value, true
+	}
+	if !value.IsSymbol() {
+		return NewNil(), false
+	}
+	environment := proc.En
+	if environment == nil {
+		environment = &Globalenv
+	}
+	binding := environment.FindRead(mustSymbol(value))
+	if binding == nil {
+		return NewNil(), false
+	}
+	resolved, ok := binding.Vars[mustSymbol(value)]
+	return resolved, ok && resolved.GetTag() == tagFunc
+}
+
+func serialProcNativeForward(proc *Proc, body Scmer) (Scmer, bool) {
+	body = serialProcBody(body)
+	if !body.IsSlice() {
+		return NewNil(), false
+	}
+	call := body.Slice()
+	params := serialProcBody(proc.Params)
+	if !params.IsSlice() || len(call) != len(params.Slice())+1 {
+		return NewNil(), false
+	}
+	for i, operand := range call[1:] {
+		argument, ok := serialProcArgumentIndex(proc, operand)
+		if !ok || argument != i {
+			return NewNil(), false
+		}
+	}
+	native, ok := serialProcResolveNative(proc, call[0])
+	if !ok {
+		return NewNil(), false
+	}
+	// Operators reuse their argument buffers. A native function which retains
+	// that variadic slice (not merely its values) must keep the adapter-created
+	// fresh call frame or every retained result would alias the next row.
+	declaration := DeclarationForValue(native)
+	if declaration == nil || declaration.RetainsCallArgs {
+		return NewNil(), false
+	}
+	return native, true
+}
+
+func serialProcLiteral(value Scmer) (Scmer, bool) {
+	value = serialProcBody(value)
+	if serialProcConstantBody(value) {
+		return value, true
+	}
+	if value.SymbolEquals("true") || value.SymbolEquals("false") {
+		return Globalenv.Vars[mustSymbol(value)], true
+	}
+	return NewNil(), false
+}
+
+func serialProcNativeArgConstant(proc *Proc, body Scmer) (native Scmer, argument int, constant Scmer, constantFirst bool, ok bool) {
+	body = serialProcBody(body)
+	if !body.IsSlice() || len(body.Slice()) != 3 {
+		return NewNil(), 0, NewNil(), false, false
+	}
+	call := body.Slice()
+	native, ok = serialProcResolveNative(proc, call[0])
+	if !ok {
+		return NewNil(), 0, NewNil(), false, false
+	}
+	if argument, ok = serialProcArgumentIndex(proc, call[1]); ok {
+		if constant, ok = serialProcLiteral(call[2]); ok {
+			return native, argument, constant, false, true
+		}
+	}
+	if argument, ok = serialProcArgumentIndex(proc, call[2]); ok {
+		if constant, ok = serialProcLiteral(call[1]); ok {
+			return native, argument, constant, true, true
+		}
+	}
+	return NewNil(), 0, NewNil(), false, false
+}
+
+// PrepareSerialProc classifies the dominant constant, argument-projection and
+// exact native-forwarding callback shapes. More complex procedures retain the
+// existing interpreter adapter until the fused scan JIT owns them.
+func PrepareSerialProc(source Scmer) SerialProc {
+	prepared := SerialProc{Argument: -1}
+	if source.IsNil() {
+		prepared.Kind = SerialProcConstant
+		prepared.Value = NewNil()
+		return prepared
+	}
+	if source.GetTag() == tagFunc {
+		prepared.Kind = SerialProcNative
+		prepared.Function = source.Func()
+		prepared.Value = source
+		return prepared
+	}
+	if source.GetTag() == tagAny {
+		if fn, ok := source.Any().(func(...Scmer) Scmer); ok {
+			prepared.Kind = SerialProcNative
+			prepared.Function = fn
+			prepared.Value = source
+			return prepared
+		}
+	}
+	if source.GetTag() != tagProc {
+		prepared.Kind = SerialProcConstant
+		prepared.Value = source
+		return prepared
+	}
+
+	proc := source.Proc()
+	// Compiled is the authoritative implementation of a Proc. Its retained
+	// source body is diagnostic input, not necessarily an executable equivalent;
+	// classifying that body could silently bypass code generation semantics.
+	if proc.Compiled != nil {
+		prepared.Kind = SerialProcGeneral
+		prepared.Function = OptimizeProcToSerialFunction(source)
+		return prepared
+	}
+	body := serialProcBody(proc.Body)
+	if serialProcConstantBody(body) {
+		prepared.Kind = SerialProcConstant
+		prepared.Value = body
+		return prepared
+	}
+	if body.SymbolEquals("true") || body.SymbolEquals("false") {
+		prepared.Kind = SerialProcConstant
+		prepared.Value = Globalenv.Vars[mustSymbol(body)]
+		return prepared
+	}
+	if argument, ok := serialProcArgumentIndex(proc, body); ok && argument <= 32767 {
+		prepared.Kind = SerialProcArgument
+		prepared.Argument = int16(argument)
+		return prepared
+	}
+	if native, ok := serialProcNativeForward(proc, body); ok {
+		prepared.Kind = SerialProcNative
+		fn := native.Func()
+		// Eval strips source annotations while resolving lambda arguments. Keep
+		// exact forwarding equivalent for syntactic values such as a quoted
+		// neutral list without allocating a fresh argument slice per call.
+		prepared.Function = func(args ...Scmer) Scmer {
+			for i, arg := range args {
+				if stripped, ok := scmerStripSourceInfo(arg); ok {
+					args[i] = stripped
+				}
+			}
+			return fn(args...)
+		}
+		prepared.Value = native
+		return prepared
+	}
+	if native, argument, constant, constantFirst, ok := serialProcNativeArgConstant(proc, body); ok && argument <= 32767 {
+		prepared.Kind = SerialProcNativeArgConstant
+		prepared.Function = native.Func()
+		prepared.Argument = int16(argument)
+		prepared.Value = constant
+		prepared.ConstantFirst = constantFirst
+		return prepared
+	}
+
+	prepared.Kind = SerialProcGeneral
+	prepared.Function = OptimizeProcToSerialFunction(source)
+	return prepared
+}
+
+// Call evaluates a prepared callback. Hot physical loops should instead
+// dispatch once on Kind and use the corresponding fields directly.
+func (p *SerialProc) Call(args []Scmer) Scmer {
+	switch p.Kind {
+	case SerialProcConstant:
+		return p.Value
+	case SerialProcArgument:
+		return args[int(p.Argument)]
+	case SerialProcNative:
+		return p.Function(args...)
+	case SerialProcNativeArgConstant:
+		var call [2]Scmer
+		if p.ConstantFirst {
+			call[0], call[1] = p.Value, args[int(p.Argument)]
+		} else {
+			call[0], call[1] = args[int(p.Argument)], p.Value
+		}
+		return p.Function(call[:]...)
+	default:
+		return p.Function(args...)
+	}
+}
+
+// IsNative reports whether the prepared callback is exactly the named global
+// native implementation. It is used only for algebraically dominant kernels
+// such as constant-one reduction by +.
+func (p *SerialProc) IsNative(name Symbol) bool {
+	if p.Kind != SerialProcNative {
+		return false
+	}
+	binding := Globalenv.FindRead(name)
+	if binding == nil {
+		return false
+	}
+	value, ok := binding.Vars[name]
+	return ok && value.GetTag() == tagFunc && value.ptr == p.Value.ptr && value.aux == p.Value.aux
+}

--- a/scm/serial_proc_test.go
+++ b/scm/serial_proc_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func preparedTestProc(t *testing.T, source string) Scmer {
+	t.Helper()
+	return Eval(Optimize(Read("serial proc test", source), &Globalenv, nil), &Globalenv)
+}
+
+func TestPrepareSerialProcShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		kind     SerialProcKind
+		argument int
+		want     int64
+	}{
+		{name: "constant", source: "(lambda (value) 7)", kind: SerialProcConstant, argument: -1, want: 7},
+		{name: "constant true", source: "(lambda () true)", kind: SerialProcConstant, argument: -1, want: 1},
+		{name: "identity", source: "(lambda (value) value)", kind: SerialProcArgument, argument: 0, want: 11},
+		{name: "second argument", source: "(lambda (acc value) value)", kind: SerialProcArgument, argument: 1, want: 13},
+		{name: "native forwarding", source: "(lambda (acc value) (+ acc value))", kind: SerialProcNative, argument: -1, want: 24},
+		{name: "native forwarding preserves argument order", source: "(lambda (left right) (- left right))", kind: SerialProcNative, argument: -1, want: -2},
+		{name: "native argument constant", source: "(lambda (value) (equal?? value 11))", kind: SerialProcNativeArgConstant, argument: 0, want: 1},
+		{name: "native constant argument", source: "(lambda (value) (< 10 value))", kind: SerialProcNativeArgConstant, argument: 0, want: 1},
+		{name: "native arithmetic argument constant", source: "(lambda (value) (+ value 1))", kind: SerialProcNativeArgConstant, argument: 0, want: 12},
+		{name: "general", source: "(lambda (value) (+ (* value 2) 1))", kind: SerialProcGeneral, argument: -1, want: 23},
+	}
+	args := []Scmer{NewInt(11), NewInt(13)}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := preparedTestProc(t, test.source)
+			prepared := PrepareSerialProc(source)
+			if prepared.Kind != test.kind || int(prepared.Argument) != test.argument {
+				t.Fatalf("shape = (%d, %d), want (%d, %d); source=%s body=%s", prepared.Kind, prepared.Argument, test.kind, test.argument, source.String(), source.Proc().Body.String())
+			}
+			if got := int64(ToInt(prepared.Call(args))); got != test.want {
+				t.Fatalf("result = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPrepareSerialProcRecognizesDirectNative(t *testing.T) {
+	prepared := PrepareSerialProc(Globalenv.Vars[Symbol("+")])
+	if !prepared.IsNative(Symbol("+")) {
+		t.Fatal("direct + callback was not recognized")
+	}
+	if got := prepared.Call([]Scmer{NewInt(3), NewInt(4)}).Int(); got != 7 {
+		t.Fatalf("direct native result = %d, want 7", got)
+	}
+}
+
+func TestPrepareSerialProcKeepsCompiledEntryPointAuthoritative(t *testing.T) {
+	source := preparedTestProc(t, "(lambda () 7)")
+	source.Proc().Compiled = &JITEntryPoint{Native: func(...Scmer) Scmer { return NewInt(99) }}
+	prepared := PrepareSerialProc(source)
+	if prepared.Kind != SerialProcGeneral {
+		t.Fatalf("compiled procedure shape = %d, want general entry-point dispatch", prepared.Kind)
+	}
+}
+
+func TestPrepareSerialProcNativeForwardMatchesInterpreterAdapter(t *testing.T) {
+	source := preparedTestProc(t, "(lambda (acc row) (append acc row))")
+	empty := Eval(Read("serial proc test", "'()"), &Globalenv)
+	row := NewSlice([]Scmer{NewInt(1)})
+	baseline := OptimizeProcToSerialFunction(source)(empty, row)
+	prepared := PrepareSerialProc(source)
+	got := prepared.Call([]Scmer{empty, row})
+	if !Equal(got, baseline) {
+		t.Fatalf("native forwarding result = %s, adapter = %s; body=%s", got.String(), baseline.String(), source.Proc().Body.String())
+	}
+}
+
+func TestPrepareSerialProcDoesNotReuseRetainedCallArguments(t *testing.T) {
+	source := preparedTestProc(t, "(lambda (value) (list value))")
+	prepared := PrepareSerialProc(source)
+	if prepared.Kind != SerialProcGeneral {
+		t.Fatalf("retaining native shape = %d, want general adapter", prepared.Kind)
+	}
+	args := []Scmer{NewInt(1)}
+	first := prepared.Call(args)
+	args[0] = NewInt(2)
+	second := prepared.Call(args)
+	if got := first.Slice()[0].Int(); got != 1 {
+		t.Fatalf("first retained result changed to %d", got)
+	}
+	if got := second.Slice()[0].Int(); got != 2 {
+		t.Fatalf("second retained result = %d, want 2", got)
+	}
+}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -498,35 +498,47 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 }
 
 func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsCachedReader := make([]bool, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols {
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			if recsetBoundaryCoversCondition {
-				fnptr = recSetAlreadyMatchedClosure()
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var cNeedsCachedReader []bool
+	var conditionGetters []mapArgGetter
+	var cdataset []scm.Scmer
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		cNeedsCachedReader = make([]bool, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols {
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				if recsetBoundaryCoversCondition {
+					fnptr = recSetAlreadyMatchedClosure()
+				}
+				getter := func(id uint32, batchid uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				conditionGetters[i] = getter
+				continue
 			}
-			getter := func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			if _, ok := ccols[i].(*StorageComputeProxy); ok {
+				cNeedsCachedReader[i] = true
 			}
-			conditionGetters[i] = getter
-			continue
 		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if _, ok := ccols[i].(*StorageComputeProxy); ok {
-			cNeedsCachedReader[i] = true
-		}
+		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	locked := false
 	if !skipShardReadLock {
@@ -564,7 +576,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 		} else if t.deletions.Get(uint(idx)) {
 			return false
 		}
-		if idx < t.main_count && exactLikeMain && singleExactLike {
+		if conditionAlwaysTrue || idx < t.main_count && exactLikeMain && singleExactLike {
 			return true
 		}
 		if idx < t.main_count {
@@ -1458,7 +1470,12 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 // e.g. evaluating an expensive correlated ACL check only over the ~30k rows a
 // mandant filter already narrowed a table down to, not the full table.
 func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -1470,22 +1487,28 @@ func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, condit
 	boundaries := recSetFilterBoundaries(owner, conditionCols, condition)
 	lower, upperLast := indexFromBoundaries(boundaries)
 
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols {
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			getter := func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var conditionGetters []mapArgGetter
+	var cdataset []scm.Scmer
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols {
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				getter := func(id uint32, batchid uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				conditionGetters[i] = getter
+				continue
 			}
-			conditionGetters[i] = getter
-			continue
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	locked := false
 	if !skipShardReadLock {
@@ -1518,6 +1541,10 @@ func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, condit
 				return
 			}
 		} else if t.deletions.Get(uint(idx)) {
+			return
+		}
+		if conditionAlwaysTrue {
+			builder.add(idx, true)
 			return
 		}
 		if idx < mainCount {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -783,39 +783,182 @@ func (t *storageShard) scanExists(boundaries boundaries, lower []scm.Scmer, uppe
 	return found
 }
 
+func (t *storageShard) filterVisibleScanBatch(batch []uint32, visibleUpper uint32, hasMutationCallback bool, currentTx *TxContext, mutationSeen map[uint32]struct{}) int {
+	outN := 0
+	for _, idx := range batch {
+		effectiveIdx := idx
+		if effectiveIdx >= visibleUpper {
+			continue
+		}
+		if hasMutationCallback && (currentTx == nil || currentTx.Mode != TxACID) {
+			if t.deletions.Get(uint(effectiveIdx)) {
+				if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(effectiveIdx); ok {
+					effectiveIdx = followIdx
+				} else {
+					continue
+				}
+			}
+			if _, ok := mutationSeen[effectiveIdx]; ok {
+				continue
+			}
+			mutationSeen[effectiveIdx] = struct{}{}
+		}
+		if currentTx != nil && currentTx.Mode == TxACID {
+			if !currentTx.IsVisible(t, effectiveIdx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(effectiveIdx)) {
+			continue
+		}
+		batch[outN] = effectiveIdx
+		outN++
+	}
+	return outN
+}
+
+func (t *storageShard) filterConditionScanBatch(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, cdataset []scm.Scmer, conditionFn func(...scm.Scmer) scm.Scmer) int {
+	outN := 0
+	for _, effectiveIdx := range batch {
+		if effectiveIdx < t.main_count {
+			for i, reader := range cReaders {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(effectiveIdx, 0)
+				} else {
+					cdataset[i] = reader.GetValue(effectiveIdx)
+				}
+			}
+		} else {
+			for i, col := range conditionCols {
+				if getter := conditionGetters[i]; getter != nil {
+					cdataset[i] = getter(effectiveIdx, 0)
+				} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+					cdataset[i] = cReaders[i].GetValue(effectiveIdx)
+				} else {
+					cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), col)
+				}
+			}
+		}
+		if !scm.ToBool(conditionFn(cdataset...)) {
+			continue
+		}
+		batch[outN] = effectiveIdx
+		outN++
+	}
+	return outN
+}
+
+func (t *storageShard) filterNativeArgConstantScanBatch(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, condition *scm.SerialProc) int {
+	argument := int(condition.Argument)
+	if argument < 0 || argument >= len(conditionCols) {
+		panic("serial filter argument outside condition columns")
+	}
+	var call [2]scm.Scmer
+	outN := 0
+	for _, idx := range batch {
+		var value scm.Scmer
+		if getter := conditionGetters[argument]; getter != nil {
+			value = getter(idx, 0)
+		} else if idx < t.main_count {
+			value = cReaders[argument].GetValue(idx)
+		} else if _, isProxy := ccols[argument].(*StorageComputeProxy); isProxy {
+			value = cReaders[argument].GetValue(idx)
+		} else {
+			value = t.getDelta(int(idx-t.main_count), conditionCols[argument])
+		}
+		if condition.ConstantFirst {
+			call[0], call[1] = condition.Value, value
+		} else {
+			call[0], call[1] = value, condition.Value
+		}
+		if !scm.ToBool(condition.Function(call[:]...)) {
+			continue
+		}
+		batch[outN] = idx
+		outN++
+	}
+	return outN
+}
+
+func (t *storageShard) filterVisibleBatchedScanBatch(batch []uint32, batchIDs []uint32, batchID uint32, visibleUpper uint32, hasMutationCallback bool, currentTx *TxContext, mutationSeen map[uint64]struct{}) int {
+	outN := 0
+	for _, idx := range batch {
+		effectiveIdx := idx
+		if effectiveIdx >= visibleUpper {
+			continue
+		}
+		if hasMutationCallback && (currentTx == nil || currentTx.Mode != TxACID) {
+			if t.deletions.Get(uint(effectiveIdx)) {
+				if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(effectiveIdx); ok {
+					effectiveIdx = followIdx
+				} else {
+					continue
+				}
+			}
+			key := uint64(batchID)<<32 | uint64(effectiveIdx)
+			if _, ok := mutationSeen[key]; ok {
+				continue
+			}
+			mutationSeen[key] = struct{}{}
+		}
+		if currentTx != nil && currentTx.Mode == TxACID {
+			if !currentTx.IsVisible(t, effectiveIdx) {
+				continue
+			}
+		} else if t.deletions.Get(uint(effectiveIdx)) {
+			continue
+		}
+		batch[outN] = effectiveIdx
+		batchIDs[outN] = batchID
+		outN++
+	}
+	return outN
+}
+
 func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsCachedReader := make([]bool, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols {
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			if recsetBoundaryCoversCondition {
-				fnptr = recSetAlreadyMatchedClosure()
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var cNeedsCachedReader []bool
+	var conditionGetters []mapArgGetter
+	var cdataset []scm.Scmer
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		cNeedsCachedReader = make([]bool, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols {
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				if recsetBoundaryCoversCondition {
+					fnptr = recSetAlreadyMatchedClosure()
+				}
+				conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				continue
 			}
-			conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			if _, ok := ccols[i].(*StorageComputeProxy); ok {
+				cNeedsCachedReader[i] = true
 			}
-			continue
 		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if _, ok := ccols[i].(*StorageComputeProxy); ok {
-			cNeedsCachedReader[i] = true
-		}
+		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	locked := false
 	if !skipShardReadLock {
@@ -847,6 +990,47 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
+		}
+		if conditionAlwaysTrue {
+			for _, idx := range batch {
+				if idx >= visibleUpper {
+					continue
+				}
+				if acidMode {
+					if !currentTx.IsVisible(t, idx) {
+						continue
+					}
+				} else if t.deletions.Get(uint(idx)) {
+					continue
+				}
+				found = true
+				foundID = idx
+				return false
+			}
+			return true
+		}
+		if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
+			var candidate [1]uint32
+			for _, idx := range batch {
+				if idx >= visibleUpper {
+					continue
+				}
+				if acidMode {
+					if !currentTx.IsVisible(t, idx) {
+						continue
+					}
+				} else if t.deletions.Get(uint(idx)) {
+					continue
+				}
+				candidate[0] = idx
+				if t.filterNativeArgConstantScanBatch(candidate[:], conditionCols, ccols, cReaders, conditionGetters, &conditionProgram) == 0 {
+					continue
+				}
+				found = true
+				foundID = idx
+				return false
+			}
+			return true
 		}
 		for _, idx := range batch {
 			if idx >= visibleUpper {
@@ -905,7 +1089,12 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 		ss = SessionStateFromTx(currentTx)
 	}
 
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -1009,29 +1198,31 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 
 	// condition column readers
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsCachedReader := make([]bool, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols {
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			if recsetBoundaryCoversCondition {
-				fnptr = recSetAlreadyMatchedClosure()
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var conditionGetters []mapArgGetter
+	var cdataset []scm.Scmer
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols {
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				if recsetBoundaryCoversCondition {
+					fnptr = recSetAlreadyMatchedClosure()
+				}
+				getter := func(id uint32, batchid uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				conditionGetters[i] = getter
+				continue
 			}
-			getter := func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
-			}
-			conditionGetters[i] = getter
-			continue
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
 		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if _, ok := ccols[i].(*StorageComputeProxy); ok {
-			cNeedsCachedReader[i] = true
-		}
+		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	// MapReducer for map+reduce phase (builds column readers internally)
 	var mapperStorage ShardMapReducer
@@ -1091,66 +1282,13 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 
 	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		candidateCount += int64(len(batch))
-		// filter in-place: overwrite batch with passing IDs
-		outN := 0
-		for _, idx := range batch {
-			effectiveIdx := idx
-			if effectiveIdx >= visibleUpper {
-				continue
-			}
-			if hasMutationCallback && (currentTx == nil || currentTx.Mode != TxACID) {
-				if t.deletions.Get(uint(effectiveIdx)) {
-					if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(effectiveIdx); ok {
-						effectiveIdx = followIdx
-					} else {
-						continue
-					}
-				}
-				// Multiple stale index entries can resolve to the same current row.
-				// Mutate each current row at most once per statement.
-				if _, ok := mutationSeen[effectiveIdx]; ok {
-					continue
-				}
-				mutationSeen[effectiveIdx] = struct{}{}
-			}
-			if currentTx != nil && currentTx.Mode == TxACID {
-				if !currentTx.IsVisible(t, effectiveIdx) {
-					continue
-				}
-			} else if t.deletions.Get(uint(effectiveIdx)) {
-				continue // item is on delete list
-			}
-
-			// condition check
-			if effectiveIdx < t.main_count {
-				for i, k := range cReaders {
-					if getter := conditionGetters[i]; getter != nil {
-						cdataset[i] = getter(effectiveIdx, 0)
-					} else {
-						cdataset[i] = k.GetValue(effectiveIdx)
-					}
-				}
+		outN := t.filterVisibleScanBatch(batch, visibleUpper, hasMutationCallback, currentTx, mutationSeen)
+		if !conditionAlwaysTrue && outN > 0 {
+			if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
+				outN = t.filterNativeArgConstantScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, &conditionProgram)
 			} else {
-				for i, k := range conditionCols {
-					if getter := conditionGetters[i]; getter != nil {
-						cdataset[i] = getter(effectiveIdx, 0)
-					} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
-						cdataset[i] = cReaders[i].GetValue(effectiveIdx)
-					} else {
-						cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), k)
-					}
-				}
+				outN = t.filterConditionScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, conditionFn)
 			}
-			var condResult bool
-			var condVal scm.Scmer
-			condVal = conditionFn(cdataset...)
-			condResult = scm.ToBool(condVal)
-			if !condResult {
-				continue
-			}
-
-			batch[outN] = effectiveIdx
-			outN++
 		}
 		if outN > 0 {
 			if hasMutationCallback {
@@ -1291,7 +1429,12 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 		ss = SessionStateFromTx(currentTx)
 	}
 
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -1327,33 +1470,41 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 	t.ensureMainCount(skipShardReadLock)
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsCachedReader := make([]bool, len(conditionCols))
-	conditionBatchSubidx := make([]int, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols {
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			if recsetBoundaryCoversCondition {
-				fnptr = recSetAlreadyMatchedClosure()
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var cNeedsCachedReader []bool
+	var conditionBatchSubidx []int
+	var conditionGetters []mapArgGetter
+	var cdataset []scm.Scmer
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		cNeedsCachedReader = make([]bool, len(conditionCols))
+		conditionBatchSubidx = make([]int, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols {
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				if recsetBoundaryCoversCondition {
+					fnptr = recSetAlreadyMatchedClosure()
+				}
+				conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				continue
 			}
-			conditionGetters[i] = func(id uint32, _ uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
+			if subidx, ok := parseBatchPseudoColName(k); ok {
+				conditionBatchSubidx[i] = subidx + 1
+				continue
 			}
-			continue
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			if _, ok := ccols[i].(*StorageComputeProxy); ok {
+				cNeedsCachedReader[i] = true
+			}
 		}
-		if subidx, ok := parseBatchPseudoColName(k); ok {
-			conditionBatchSubidx[i] = subidx + 1
-			continue
-		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if _, ok := ccols[i].(*StorageComputeProxy); ok {
-			cNeedsCachedReader[i] = true
-		}
+		cdataset = make([]scm.Scmer, len(conditionCols))
 	}
-	cdataset := make([]scm.Scmer, len(conditionCols))
 
 	var mapperStorage ShardMapReducer
 	var mapperWorkspace shardMapReducerWorkspace
@@ -1410,68 +1561,44 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 
 		t.iterateIndex(currentTx, activeBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))
-			outN := 0
-			for _, idx := range batch {
-				effectiveIdx := idx
-				if effectiveIdx >= visibleUpper {
-					continue
-				}
-				if hasMutationCallback && (currentTx == nil || currentTx.Mode != TxACID) {
-					if t.deletions.Get(uint(effectiveIdx)) {
-						if followIdx, ok := t.resolveVisiblePrimaryRecidLocked(effectiveIdx); ok {
-							effectiveIdx = followIdx
-						} else {
-							continue
+			outN := t.filterVisibleBatchedScanBatch(batch, batchBuf[:], uint32(batchid), visibleUpper, hasMutationCallback, currentTx, mutationSeen)
+			if !conditionAlwaysTrue {
+				filteredN := 0
+				for _, effectiveIdx := range batch[:outN] {
+					if effectiveIdx < t.main_count {
+						for i, k := range ccols {
+							if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
+								cdataset[i] = batchdata[batchid*stride+subidx]
+							} else if getter := conditionGetters[i]; getter != nil {
+								cdataset[i] = getter(effectiveIdx, uint32(batchid))
+							} else if cNeedsCachedReader[i] {
+								cdataset[i] = cReaders[i].GetValue(effectiveIdx)
+							} else {
+								cdataset[i] = k.GetValue(effectiveIdx)
+							}
+						}
+					} else {
+						for i, k := range conditionCols {
+							if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
+								cdataset[i] = batchdata[batchid*stride+subidx]
+							} else if getter := conditionGetters[i]; getter != nil {
+								cdataset[i] = getter(effectiveIdx, uint32(batchid))
+							} else if cNeedsCachedReader[i] {
+								cdataset[i] = cReaders[i].GetValue(effectiveIdx)
+							} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+								cdataset[i] = ccols[i].GetValue(effectiveIdx)
+							} else {
+								cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), k)
+							}
 						}
 					}
-					key := (uint64(uint32(batchid)) << 32) | uint64(effectiveIdx)
-					if _, ok := mutationSeen[key]; ok {
+					if !scm.ToBool(conditionFn(cdataset...)) {
 						continue
 					}
-					mutationSeen[key] = struct{}{}
+					batch[filteredN] = effectiveIdx
+					filteredN++
 				}
-				if currentTx != nil && currentTx.Mode == TxACID {
-					if !currentTx.IsVisible(t, effectiveIdx) {
-						continue
-					}
-				} else if t.deletions.Get(uint(effectiveIdx)) {
-					continue
-				}
-
-				if effectiveIdx < t.main_count {
-					for i, k := range ccols {
-						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
-							cdataset[i] = batchdata[batchid*stride+subidx]
-						} else if getter := conditionGetters[i]; getter != nil {
-							cdataset[i] = getter(effectiveIdx, uint32(batchid))
-						} else if cNeedsCachedReader[i] {
-							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
-						} else {
-							cdataset[i] = k.GetValue(effectiveIdx)
-						}
-					}
-				} else {
-					for i, k := range conditionCols {
-						if subidx := conditionBatchSubidx[i] - 1; subidx >= 0 {
-							cdataset[i] = batchdata[batchid*stride+subidx]
-						} else if getter := conditionGetters[i]; getter != nil {
-							cdataset[i] = getter(effectiveIdx, uint32(batchid))
-						} else if cNeedsCachedReader[i] {
-							cdataset[i] = cReaders[i].GetValue(effectiveIdx)
-						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
-							cdataset[i] = ccols[i].GetValue(effectiveIdx)
-						} else {
-							cdataset[i] = t.getDelta(int(effectiveIdx-t.main_count), k)
-						}
-					}
-				}
-				if !scm.ToBool(conditionFn(cdataset...)) {
-					continue
-				}
-
-				batch[outN] = effectiveIdx
-				batchBuf[outN] = uint32(batchid)
-				outN++
+				outN = filteredN
 			}
 			if outN > 0 {
 				if hasMutationCallback {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1162,7 +1162,12 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		ss = SessionStateFromTx(currentTx)
 	}
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
+	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
+	var conditionFn func(...scm.Scmer) scm.Scmer
+	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
+		conditionFn = scm.OptimizeProcToSerialFunction(condition)
+	}
 
 	// prepare filter function
 	cdataset := make([]scm.Scmer, len(conditionCols))
@@ -1224,26 +1229,32 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	}
 
 	// main storage — use skipShardReadLock to avoid redundant hasWriteOwner() per column
-	ccols := make([]ColumnStorage, len(conditionCols))
-	cReaders := make([]ColumnReader, len(conditionCols))
-	cNeedsCachedReader := make([]bool, len(conditionCols))
-	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	for i, k := range conditionCols { // iterate over columns
-		if k == "$recset_contains" {
-			fnptr := recSetContainsClosure(t)
-			if recsetBoundaryCoversCondition {
-				fnptr = recSetAlreadyMatchedClosure()
+	var ccols []ColumnStorage
+	var cReaders []ColumnReader
+	var cNeedsCachedReader []bool
+	var conditionGetters []mapArgGetter
+	if !conditionAlwaysTrue {
+		ccols = make([]ColumnStorage, len(conditionCols))
+		cReaders = make([]ColumnReader, len(conditionCols))
+		cNeedsCachedReader = make([]bool, len(conditionCols))
+		conditionGetters = make([]mapArgGetter, len(conditionCols))
+		for i, k := range conditionCols { // iterate over columns
+			if k == "$recset_contains" {
+				fnptr := recSetContainsClosure(t)
+				if recsetBoundaryCoversCondition {
+					fnptr = recSetAlreadyMatchedClosure()
+				}
+				getter := func(id uint32, batchid uint32) scm.Scmer {
+					return scm.NewClosure(fnptr, id)
+				}
+				conditionGetters[i] = getter
+				continue
 			}
-			getter := func(id uint32, batchid uint32) scm.Scmer {
-				return scm.NewClosure(fnptr, id)
+			ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
+			cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
+			if _, ok := ccols[i].(*StorageComputeProxy); ok {
+				cNeedsCachedReader[i] = true
 			}
-			conditionGetters[i] = getter
-			continue
-		}
-		ccols[i] = t.getColumnStorageOrPanicEx(k, skipShardReadLock, currentTx)
-		cReaders[i] = newCachedColumnReaderTx(ccols[i], currentTx)
-		if _, ok := ccols[i].(*StorageComputeProxy); ok {
-			cNeedsCachedReader[i] = true
 		}
 	}
 	// initialize main_count lazily if needed
@@ -1322,68 +1333,81 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 			}
 			survivedBuf = survived
 
-			// pass 2: bulk-fetch every non-getter condition column for the
-			// main-storage survivors of this batch, one call per column.
-			mainIds := mainIdsBuf[:0]
-			for _, idx := range survived {
-				if idx < t.main_count {
-					mainIds = append(mainIds, idx)
-				}
-			}
-			mainIdsBuf = mainIds
-			for i := range ccols {
-				if conditionGetters[i] != nil {
-					continue
-				}
-				if cap(colBufs[i]) < len(mainIds) {
-					colBufs[i] = make([]scm.Scmer, len(mainIds))
-				}
-				colBufs[i] = colBufs[i][:len(mainIds)]
-				if len(mainIds) == 0 {
-					continue
-				}
-				if cNeedsCachedReader[i] {
-					cReaders[i].GetValueMulti(mainIds, colBufs[i], 1)
-				} else {
-					ccols[i].GetValueMulti(mainIds, colBufs[i], 1)
-				}
-			}
-
-			// pass 3: evaluate the condition per row using the pre-fetched
-			// main-storage values; delta rows are still read one at a time.
-			outN := 0
-			mainBufIdx := 0
-			for _, idx := range survived {
-				if idx < t.main_count {
-					for i := range ccols {
-						if conditionGetters[i] != nil {
-							cdataset[i] = conditionGetters[i](idx, 0)
-						} else {
-							cdataset[i] = colBufs[i][mainBufIdx]
-						}
-					}
-					mainBufIdx++
-				} else {
-					// value from delta storage
-					for i, k := range conditionCols { // iterate over columns
-						if conditionGetters[i] != nil {
-							cdataset[i] = conditionGetters[i](idx, 0)
-						} else if cNeedsCachedReader[i] {
-							cdataset[i] = cReaders[i].GetValue(idx)
-						} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
-							cdataset[i] = ccols[i].GetValue(idx)
-						} else {
-							cdataset[i] = t.getDelta(int(idx-t.main_count), k) // fill value
+			outN := len(survived)
+			if conditionAlwaysTrue {
+				copy(batch, survived)
+			} else {
+				// pass 2: bulk-fetch every non-getter condition column for the
+				// main-storage survivors of this batch, one call per column.
+				mainIds := mainIdsBuf[:0]
+				if conditionProgram.Kind != scm.SerialProcNativeArgConstant {
+					for _, idx := range survived {
+						if idx < t.main_count {
+							mainIds = append(mainIds, idx)
 						}
 					}
 				}
-				// check condition
-				if !scm.ToBool(conditionFn(cdataset...)) {
-					continue // condition did not match
+				mainIdsBuf = mainIds
+				for i := range ccols {
+					if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
+						continue
+					}
+					if conditionGetters[i] != nil {
+						continue
+					}
+					if cap(colBufs[i]) < len(mainIds) {
+						colBufs[i] = make([]scm.Scmer, len(mainIds))
+					}
+					colBufs[i] = colBufs[i][:len(mainIds)]
+					if len(mainIds) == 0 {
+						continue
+					}
+					if cNeedsCachedReader[i] {
+						cReaders[i].GetValueMulti(mainIds, colBufs[i], 1)
+					} else {
+						ccols[i].GetValueMulti(mainIds, colBufs[i], 1)
+					}
 				}
 
-				batch[outN] = idx
-				outN++
+				// Pass 3 dispatches once per batch. Simple binary predicates read
+				// only their argument column and call the native primitive directly;
+				// general expressions retain the existing interpreter adapter.
+				if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
+					outN = t.filterNativeArgConstantScanBatch(survived, conditionCols, ccols, cReaders, conditionGetters, &conditionProgram)
+					copy(batch, survived[:outN])
+				} else {
+					outN = 0
+					mainBufIdx := 0
+					for _, idx := range survived {
+						if idx < t.main_count {
+							for i := range ccols {
+								if conditionGetters[i] != nil {
+									cdataset[i] = conditionGetters[i](idx, 0)
+								} else {
+									cdataset[i] = colBufs[i][mainBufIdx]
+								}
+							}
+							mainBufIdx++
+						} else {
+							for i, k := range conditionCols {
+								if conditionGetters[i] != nil {
+									cdataset[i] = conditionGetters[i](idx, 0)
+								} else if cNeedsCachedReader[i] {
+									cdataset[i] = cReaders[i].GetValue(idx)
+								} else if _, isProxy := ccols[i].(*StorageComputeProxy); isProxy {
+									cdataset[i] = ccols[i].GetValue(idx)
+								} else {
+									cdataset[i] = t.getDelta(int(idx-t.main_count), k)
+								}
+							}
+						}
+						if !scm.ToBool(conditionFn(cdataset...)) {
+							continue
+						}
+						batch[outN] = idx
+						outN++
+					}
+				}
 			}
 			// grow result if needed, then flush filtered batch
 			for resultN+outN > resultCap {

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -263,12 +263,12 @@ func TestShardMapReducerBulkReadsFinalMapColumns(t *testing.T) {
 		mainBulkReaders: []ColumnReader{first, second, nil},
 		args:            make([]scm.Scmer, 3),
 		reduceArgs:      make([]scm.Scmer, 2),
-		mapFn: func(values ...scm.Scmer) scm.Scmer {
+		mapProgram: scm.PrepareSerialProc(scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 			got = append(got, int64(scm.ToInt(values[0])+scm.ToInt(values[1])+scm.ToInt(values[2])))
 			return values[0]
-		},
-		reduceFn:  func(values ...scm.Scmer) scm.Scmer { return values[1] },
-		mainCount: 4,
+		})),
+		reduceProgram: scm.PrepareSerialProc(scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] })),
+		mainCount:     4,
 	}
 	mapper.Stream(scm.NewNil(), []uint32{3, 1, 2}, nil)
 

--- a/storage/scan_pipeline_bench_test.go
+++ b/storage/scan_pipeline_bench_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func optimizedScanProc(tb testing.TB, source string) scm.Scmer {
+	tb.Helper()
+	return scm.Eval(scm.Optimize(scm.Read("scan pipeline benchmark", source), &scm.Globalenv, nil), &scm.Globalenv)
+}
+
+func TestScanPipelineSpecializationsPreserveMainAndDeltaResults(t *testing.T) {
+	const dbName = "test_scan_pipeline_specializations"
+	databases.Remove(dbName)
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.Insert([]string{"id"}, [][]scm.Scmer{
+		{scm.NewInt(1)},
+		{scm.NewInt(2)},
+		{scm.NewInt(3)},
+	}, nil, scm.NewNil(), false, nil)
+
+	constantOne := optimizedScanProc(t, "(lambda () 1)")
+	identity := optimizedScanProc(t, "(lambda (value) value)")
+	greaterEqualTwo := optimizedScanProc(t, "(lambda (value) (>= value 2))")
+	reversedLessThan := optimizedScanProc(t, "(lambda (value) (< 1 value))")
+	plus := scm.Globalenv.Vars[scm.Symbol("+")]
+	sqlSum := scm.Globalenv.Vars[scm.Symbol("sql_sum_reduce")]
+
+	assertResults := func(stage string) {
+		t.Helper()
+		for _, condition := range []scm.Scmer{greaterEqualTwo, reversedLessThan} {
+			count := tbl.scan(nil, []string{"id"}, condition, nil, constantOne,
+				plus, scm.NewInt(0), scm.NewNil(), false)
+			if got := scm.ToInt(count); got != 2 {
+				t.Fatalf("%s count = %d, want 2", stage, got)
+			}
+			sum := tbl.scan(nil, []string{"id"}, condition, []string{"id"}, identity,
+				sqlSum, scm.NewNil(), scm.NewNil(), false)
+			if got := scm.ToInt(sum); got != 5 {
+				t.Fatalf("%s sum = %d, want 5", stage, got)
+			}
+		}
+	}
+
+	assertResults("delta")
+	result := GetDatabase(dbName).rebuild(true, false, true)
+	if len(result.errors) > 0 {
+		t.Fatalf("rebuild errors: %v", result.errors)
+	}
+	assertResults("main")
+}
+
+// BenchmarkScanPipelineOLTP records the common physical callback shapes emitted
+// for OLTP projections and aggregates. Keep the callbacks as optimized Scheme
+// procedures: native Go benchmark callbacks would bypass the adapter and hide
+// the setup and interpreter work this benchmark is intended to measure.
+func BenchmarkScanPipelineOLTP(b *testing.B) {
+	const rowsN = 60_000
+	dbName := "bench_scan_pipeline_oltp"
+	databases.Remove(dbName)
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("amount", "INT", nil, nil)
+	rows := make([][]scm.Scmer, rowsN)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i%100 + 1))}
+	}
+	tbl.Insert([]string{"id", "amount"}, rows, nil, scm.NewNil(), false, nil)
+	result := GetDatabase(dbName).rebuild(true, false, true)
+	if len(result.errors) > 0 {
+		b.Fatalf("rebuild errors: %v", result.errors)
+	}
+
+	trueFilter := optimizedScanProc(b, "(lambda () true)")
+	lastIDFilter := optimizedScanProc(b, "(lambda (id) (equal?? id 59999))")
+	constantOne := optimizedScanProc(b, "(lambda () 1)")
+	identity := optimizedScanProc(b, "(lambda (value) value)")
+	takeRight := optimizedScanProc(b, "(lambda (acc value) value)")
+	plus := scm.Globalenv.Vars[scm.Symbol("+")]
+	sqlSum := scm.Globalenv.Vars[scm.Symbol("sql_sum_reduce")]
+
+	benchmarks := []struct {
+		name          string
+		conditionCols []string
+		condition     scm.Scmer
+		mapCols       []string
+		mapper        scm.Scmer
+		reducer       scm.Scmer
+		neutral       scm.Scmer
+	}{
+		{name: "count", condition: trueFilter, mapper: constantOne, reducer: plus, neutral: scm.NewInt(0)},
+		{name: "filtered_count", conditionCols: []string{"id"}, condition: lastIDFilter, mapper: constantOne, reducer: plus, neutral: scm.NewInt(0)},
+		{name: "sum", condition: trueFilter, mapCols: []string{"amount"}, mapper: identity, reducer: sqlSum, neutral: scm.NewNil()},
+		{name: "take_right", condition: trueFilter, mapCols: []string{"amount"}, mapper: identity, reducer: takeRight, neutral: scm.NewNil()},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tbl.scan(nil, benchmark.conditionCols, benchmark.condition, benchmark.mapCols, benchmark.mapper,
+					benchmark.reducer, benchmark.neutral, scm.NewNil(), false)
+			}
+		})
+	}
+}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1663,8 +1663,8 @@ type ShardMapReducer struct {
 	breakClosureFn *func(uint32, ...scm.Scmer) scm.Scmer   // shared break
 	args           []scm.Scmer                             // pre-allocated args buffer
 	reduceArgs     []scm.Scmer                             // pre-allocated binary reducer arguments
-	mapFn          func(...scm.Scmer) scm.Scmer
-	reduceFn       func(...scm.Scmer) scm.Scmer
+	mapProgram     scm.SerialProc
+	reduceProgram  scm.SerialProc
 	mapScmer       scm.Scmer     // original Scmer for network serialization
 	deleteBatch    *triggerBatch // when set, DELETE triggers are batched instead of per-row
 	deletedRows    uint64        // applied DELETEs, published once when the mapper flushes
@@ -1721,8 +1721,8 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 	mr.currentTx = currentTx
 	mr.acidMode = currentTx != nil && currentTx.Mode == TxACID
 	mr.colNames = cols
-	mr.mapFn = scm.OptimizeProcToSerialFunction(mapFn)
-	mr.reduceFn = scm.OptimizeProcToSerialFunction(reduceFn)
+	mr.mapProgram = scm.PrepareSerialProc(mapFn)
+	mr.reduceProgram = scm.PrepareSerialProc(reduceFn)
 	mr.mapScmer = mapFn
 	mr.reduceScmer = reduceFn
 	mr.mainCount = t.main_count
@@ -1742,7 +1742,7 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 func (m *ShardMapReducer) MapOne(id uint32) scm.Scmer {
 	if m.directRead {
 		m.loadDirectReadArgs(id, 0, false)
-		return m.mapFn(m.args...)
+		return m.mapProgram.Call(m.args)
 	}
 	getters := m.mainGetters
 	if id >= m.mainCount {
@@ -1751,7 +1751,7 @@ func (m *ShardMapReducer) MapOne(id uint32) scm.Scmer {
 	for i, getter := range getters {
 		m.args[i] = getter(id, 0)
 	}
-	return m.mapFn(m.args...)
+	return m.mapProgram.Call(m.args)
 }
 
 // initMapReducer initializes the general mapper, including pseudo-columns and
@@ -1768,8 +1768,8 @@ func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapFn 
 		colNames:         cols,
 		args:             make([]scm.Scmer, len(cols)),
 		reduceArgs:       make([]scm.Scmer, 2),
-		mapFn:            scm.OptimizeProcToSerialFunction(mapFn),
-		reduceFn:         scm.OptimizeProcToSerialFunction(reduceFn),
+		mapProgram:       scm.PrepareSerialProc(mapFn),
+		reduceProgram:    scm.PrepareSerialProc(reduceFn),
 		mapScmer:         mapFn,
 		reduceScmer:      reduceFn,
 		mainCount:        t.main_count,
@@ -2088,12 +2088,111 @@ func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32)
 	if len(recids) == 0 {
 		return acc
 	}
+	switch m.mapProgram.Kind {
+	case scm.SerialProcArgument:
+		return m.processDirectArgumentBlock(acc, recids, int(m.mapProgram.Argument))
+	case scm.SerialProcConstant:
+		return m.processDirectConstantBlock(acc, recids, m.mapProgram.Value)
+	}
 	if recids[0] < m.mainCount {
 		m.prefetchMainColumns(recids)
 	}
 	for rowOffset, id := range recids {
 		m.loadDirectReadArgs(id, rowOffset, true)
-		acc = m.reduce(acc, m.mapFn(m.args...))
+		acc = m.reduce(acc, m.mapProgram.Call(m.args))
+	}
+	return acc
+}
+
+func (m *ShardMapReducer) directArgumentValue(id uint32, argument int) scm.Scmer {
+	if id < m.mainCount {
+		return m.mainBulkReaders[argument].GetValue(id)
+	}
+	if _, isProxy := m.mainCols[argument].(*StorageComputeProxy); isProxy {
+		return m.mainBulkReaders[argument].GetValue(id)
+	}
+	return m.shard.getDelta(int(id-m.mainCount), m.colNames[argument])
+}
+
+func (m *ShardMapReducer) directArgumentValues(recids []uint32, argument int) []scm.Scmer {
+	if cap(m.mainBulkValues) < len(recids) {
+		m.mainBulkValues = make([]scm.Scmer, len(recids))
+	} else {
+		m.mainBulkValues = m.mainBulkValues[:len(recids)]
+	}
+	if recids[0] < m.mainCount {
+		m.mainBulkReaders[argument].GetValueMulti(recids, m.mainBulkValues, 1)
+		return m.mainBulkValues
+	}
+	for i, id := range recids {
+		m.mainBulkValues[i] = m.directArgumentValue(id, argument)
+	}
+	return m.mainBulkValues
+}
+
+// processDirectArgumentBlock removes an identity/projection mapper from the
+// row loop. Reducer shape dispatch happens once per batch, not once per row.
+func (m *ShardMapReducer) processDirectArgumentBlock(acc scm.Scmer, recids []uint32, argument int) scm.Scmer {
+	if argument < 0 || argument >= len(m.mainCols) {
+		panic("serial mapper argument outside callback columns")
+	}
+	switch m.reduceProgram.Kind {
+	case scm.SerialProcArgument:
+		switch m.reduceProgram.Argument {
+		case 0:
+			return acc
+		case 1:
+			return m.directArgumentValue(recids[len(recids)-1], argument)
+		}
+	case scm.SerialProcConstant:
+		return m.reduceProgram.Value
+	case scm.SerialProcNative:
+		for _, value := range m.directArgumentValues(recids, argument) {
+			m.reduceArgs[0] = acc
+			m.reduceArgs[1] = value
+			acc = m.reduceProgram.Function(m.reduceArgs...)
+		}
+		return acc
+	}
+	for _, value := range m.directArgumentValues(recids, argument) {
+		m.reduceArgs[0] = acc
+		m.reduceArgs[1] = value
+		acc = m.reduceProgram.Call(m.reduceArgs)
+	}
+	return acc
+}
+
+// processDirectConstantBlock recognizes the canonical COUNT pipeline. Mapping
+// every row to one and reducing with + is exactly one addition by the accepted
+// batch length; this is a dominance rewrite, not a cost-dependent plan choice.
+func (m *ShardMapReducer) processDirectConstantBlock(acc scm.Scmer, recids []uint32, value scm.Scmer) scm.Scmer {
+	if m.reduceProgram.IsNative(scm.Symbol("+")) && value.IsInt() && value.Int() == 1 {
+		m.reduceArgs[0] = acc
+		m.reduceArgs[1] = scm.NewInt(int64(len(recids)))
+		return m.reduceProgram.Function(m.reduceArgs...)
+	}
+	switch m.reduceProgram.Kind {
+	case scm.SerialProcArgument:
+		switch m.reduceProgram.Argument {
+		case 0:
+			return acc
+		case 1:
+			return value
+		}
+	case scm.SerialProcConstant:
+		return m.reduceProgram.Value
+	case scm.SerialProcNative:
+		for range recids {
+			m.reduceArgs[0] = acc
+			m.reduceArgs[1] = value
+			acc = m.reduceProgram.Function(m.reduceArgs...)
+		}
+		return acc
+	}
+	for range recids {
+		m.reduceArgs[0] = acc
+		m.reduceArgs[1] = value
+		acc = m.reduceProgram.Call(m.reduceArgs)
 	}
 	return acc
 }
@@ -2144,7 +2243,7 @@ func (m *ShardMapReducer) reduce(acc scm.Scmer, value scm.Scmer) scm.Scmer {
 	// slice on every row because reduceFn may retain it.
 	m.reduceArgs[0] = acc
 	m.reduceArgs[1] = value
-	return m.reduceFn(m.reduceArgs...)
+	return m.reduceProgram.Call(m.reduceArgs)
 }
 
 // processMainBlock is a tight loop over main-storage records – no branching
@@ -2203,7 +2302,7 @@ func (m *ShardMapReducer) processMainBlock(acc scm.Scmer, recids []uint32) scm.S
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduce(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapProgram.Call(m.args))
 		}()
 	}
 	return acc
@@ -2258,7 +2357,7 @@ func (m *ShardMapReducer) processMainBlockBatch(acc scm.Scmer, recids []uint32, 
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduce(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapProgram.Call(m.args))
 		}()
 	}
 	return acc
@@ -2305,7 +2404,7 @@ func (m *ShardMapReducer) processDeltaBlock(acc scm.Scmer, recids []uint32) scm.
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduce(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapProgram.Call(m.args))
 		}()
 	}
 	return acc
@@ -2351,7 +2450,7 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 				m.shard.mu.Unlock()
 				rowLocked = false
 			}
-			acc = m.reduce(acc, m.mapFn(m.args...))
+			acc = m.reduce(acc, m.mapProgram.Call(m.args))
 		}()
 	}
 	return acc


### PR DESCRIPTION
## Why

The scan family still routed trivial Scheme callbacks through the generic interpreter adapter for every row. Common OLTP shapes such as constant predicates, identity projections, COUNT and SUM therefore paid an allocation and dynamic evaluation cost per item even though the callback shape is known before entering the loop.

## Architecture

- Add one immutable `SerialProc` descriptor that classifies constant results, argument projections, exact native forwarding and native argument/constant calls once.
- Keep compiled procedures authoritative and leave every complex callback on the existing interpreter path for the later fused scan JIT.
- Dispatch outside hot loops in the shared shard map/reduce pipeline and the active `scan`, `scan_order` and RecSet condition paths.
- Treat algebraically dominant shapes directly: identity/constant mapping, accumulator/value reducers, and constant-one reduction by `+`.
- Document native functions that retain their variadic argument slice. Such callbacks stay on the frame-owning general path, preventing reused scan buffers from aliasing retained result rows.

This is operator specialization, not a planner cost override: it changes the implementation cost of semantically identical callbacks and does not force a physical plan.

## A/B benchmark

60,000 rows, same benchmark and machine, master -> this branch:

| Pipeline | master | branch | allocations |
| --- | ---: | ---: | ---: |
| COUNT | ~3.36 ms | ~0.59 ms | 60,018 -> 13 |
| SUM(identity) | ~3.63 ms | ~0.62 ms | 60,019 -> 14 |
| take-right reducer | ~3.38 ms | ~0.12 ms | 60,021 -> 14 |
| indexed filtered COUNT | — | ~7.6 us | 15 |

The remaining SUM bytes are numeric result boxing, not one interpreter frame per row.

## Correctness and validation

- Added callback classification tests, including compiled procedures, operand order, source annotations, and retained-call-argument aliasing.
- Added scan tests covering direct filters, COUNT and SUM across both main storage and delta rows.
- Covered ordered batch acceptance and RecSet result ownership. The full suite caught and led to fixes for ordered candidate compaction and retained native `list` arguments.
- `make test`: green.
- Targeted race run for classifier and scan tests: green.
- Targeted group, RecSet and correlated-lookup YAML suites: green.
