### PR TITLE
Stream compatible LAG and LEAD windows

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -510,6 +510,7 @@ prepare stage creates. */
 (define os_mapfn (lambda (node) (nth node 8)))
 (define os_reducefn (lambda (node) (nth node 9)))
 (define os_reduceinit (lambda (node) (nth node 10)))
+(define os_facts (lambda (node) (if (window_stage? node) (nth node 11) '())))
 
 (define make_window_stage (lambda (id source column sortcols sortdirs partitioncount mapcols mapfn reducefn reduceinit facts)
 	(list (quote window-stage)
@@ -3639,7 +3640,18 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 							(make_window_offset_mapfn partition_cols value_col)
 							(make_window_offset_reducefn offset (not (empty_list? partition_exprs)))
 							(if (empty_list? partition_exprs) (list (quote list)) (list (quote list) (list (quote list)) nil))
-							(list (list (quote kind) (quote ordered-window)))))
+							(list
+								(list (quote kind) (quote ordered-window))
+								(list (quote window_function) fn)
+								(list (quote window_offset) offset)
+								(list (quote window_value_column) value_col)
+								/* The ORC fallback implements LEAD by reversing its scan.
+								Keep the semantic forward order as a logical fact so physical
+								lowering can instead stream the window in output order. */
+								(list (quote window_stream_sortdirs)
+									(merge (list
+										(map partition_exprs (lambda (_expr) false))
+										order_dirs))))))
 						(qp_any (list
 							(list (quote get_column) alias false col false)
 							(list stage)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1621,11 +1621,28 @@ outer joins. */
 
 (define lower_window_stage_prepare (lambda (stage)
 	(match stage
-		'(_ id source column sortcols sortdirs partitioncount mapcols mapfn reducefn reduceinit _facts)
-		(lower_orc_stage_prepare (make_orc_stage
-			id source column
-			sortcols sortdirs partitioncount
-			mapcols mapfn reducefn reduceinit))
+		'(_ _id source column sortcols sortdirs partitioncount mapcols mapfn reducefn reduceinit facts)
+		(begin
+			(if (not (source_is_base_table? source))
+				(neumann_fail "build_queryplan" "window-stage lowering only supports base tables")
+				true)
+			(list (quote createcolumn)
+				(source_table_expr source)
+				column
+				"any"
+				(quoted_runtime_list '())
+				(list (quote list)
+					"temp" true
+					"sortcols" (quoted_runtime_list sortcols)
+					"sortdirs" (cons (quote list) sortdirs)
+					"partitioncount" partitioncount
+					"filtercols" (quoted_runtime_list
+						(qassoc_get facts (quote physical_filtercols) '()))
+					"filter" (qassoc_get facts (quote physical_filterfn) nil)
+					"mapcols" (quoted_runtime_list mapcols)
+					"mapfn" mapfn
+					"reducefn" reducefn
+					"reduceinit" reduceinit)))
 		_ (neumann_fail "build_queryplan" "malformed window-stage"))))
 
 (define lower_orc_stage_materialize (lambda (stage)
@@ -1647,10 +1664,35 @@ outer joins. */
 				false))
 		_ nil)))
 
+(define lower_window_stage_materialize (lambda (stage)
+	(match stage
+		'(_ _id src col _sortcols _sortdirs _partitioncount _mapcols _mapfn _reducefn _reduceinit facts)
+		(if (not (source_is_base_table? src))
+			(neumann_fail "build_queryplan" "window materialization expects base table source")
+			(begin
+				(define filtercols (qassoc_get facts (quote physical_filtercols) '()))
+				(define filterfn (qassoc_get facts (quote physical_filterfn)
+					(list (quote lambda) '() true)))
+				(list (quote scan)
+					'(session "__memcp_tx")
+					(source_table_expr src)
+					(quoted_runtime_list filtercols)
+					filterfn
+					(quoted_runtime_list (list col))
+					(list (quote lambda) (list (quote __orc_value))
+						(list (quote if) (list (quote nil?) (quote __orc_value)) 0 1))
+					(quote +)
+					0
+					nil
+					false)))
+		_ nil)))
+
 (define lower_stage_materialize (lambda (stage)
-	(if (or (orc_stage? stage) (window_stage? stage))
+	(if (orc_stage? stage)
 		(lower_orc_stage_materialize stage)
-		nil)))
+		(if (window_stage? stage)
+			(lower_window_stage_materialize stage)
+			nil))))
 
 (define lower_stage_materialize_all (lambda (stages)
 	(filter (map (coalesceNil stages '()) lower_stage_materialize)
@@ -1812,6 +1854,281 @@ outer joins. */
 		(and
 			(equal? (order_cols_for_alias src order_items) sortcols)
 			(equal? (serialize (order_dirs order_items)) (serialize (window_scan_dirs sortdirs)))))))
+
+/* Offset windows are streamable when the result has no requested order or its
+order is exactly the semantic PARTITION BY + window ORDER BY sequence. Only an
+incompatible consumer order needs the ORC materialization barrier. This is a
+physical decision: the logical window-stage remains independent of scan/ORC. */
+(define window_offset_stage? (lambda (stage)
+	(and (window_stage? stage)
+		(equal? (qassoc_get (os_facts stage) (quote kind) nil) (quote ordered-window))
+		(or
+			(equal? (qassoc_get (os_facts stage) (quote window_function) nil) "LAG")
+			(equal? (qassoc_get (os_facts stage) (quote window_function) nil) "LEAD")))))
+
+(define window_offset_order_compatible? (lambda (src order_items stage)
+	(if (empty_list? order_items)
+		true
+		(and
+			(equal? (order_cols_for_alias src order_items) (os_sortcols stage))
+			(equal?
+				(serialize (order_dirs order_items))
+				(serialize (window_scan_dirs
+					(qassoc_get (os_facts stage) (quote window_stream_sortdirs) (os_sortdirs stage)))))))))
+
+(define window_offset_column_position (lambda (columns target position)
+	(match columns
+		(cons col rest) (if (equal? col target) position
+			(window_offset_column_position rest target (+ position 1)))
+		_ (neumann_fail "build_queryplan" (concat "window input column not found: " target)))))
+
+(define window_offset_slot_symbol (lambda (slot column)
+	(symbol (concat "__window_slot_" slot "_" column))))
+
+(define window_offset_emit_params (lambda (window_size stride selected_slot alias mapcols)
+	(merge (map (produceN window_size) (lambda (slot)
+		(map (produceN stride) (lambda (column)
+			(if (equal? slot selected_slot)
+				(symbol (concat alias "." (nth mapcols column)))
+				(window_offset_slot_symbol slot column)))))))))
+
+(define replace_window_offset_expr (lambda (src replacements expr)
+	(match expr
+		((symbol get_column) tblvar tbl_ignorecase column col_ignorecase)
+			(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+				(qassoc_get replacements column expr) expr)
+		((quote get_column) tblvar tbl_ignorecase column col_ignorecase)
+			(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+				(qassoc_get replacements column expr) expr)
+		(cons head tail) (cons head (map tail (lambda (item)
+			(replace_window_offset_expr src replacements item))))
+		_ expr)))
+
+(define window_offset_fresh_state_expr (lambda (skip window_size stride)
+	(cons (quote list) (merge (list
+		(list skip 0 stride)
+		(map (produceN (* window_size stride)) (lambda (_index) nil)))))))
+
+(define window_offset_stage_stream_dirs (lambda (stage)
+	(qassoc_get (os_facts stage) (quote window_stream_sortdirs) (os_sortdirs stage))))
+
+/* An ORC is a persistent computed column, so an incompatible consumer order
+cannot reuse the unfiltered window column when SQL WHERE narrows its input.
+Physical lowering gives that query domain its own canonical column recipe. The
+logical window-stage remains unchanged and contains no createcolumn artifact. */
+(define filtered_window_stage (lambda (stage src condition filtercols filterfn)
+	(begin
+		(define filtered_col (canonical_orc_column_name "filtered_window" src
+			(list
+				(os_column stage)
+				filtercols
+				(lower_column_expr_for_alias src condition))))
+		(define facts (qassoc_set
+			(qassoc_set (os_facts stage) (quote physical_filtercols) filtercols)
+			(quote physical_filterfn) filterfn))
+		(make_window_stage
+			(nth stage 1) src filtered_col
+			(os_sortcols stage) (os_sortdirs stage) (os_partitioncount stage)
+			(os_mapcols stage) (os_mapfn stage) (os_reducefn stage) (os_reduceinit stage)
+			facts))))
+
+(define filtered_window_stages (lambda (stages src condition filtercols filterfn)
+	(map stages (lambda (stage)
+		(if (window_offset_stage? stage)
+			(filtered_window_stage stage src condition filtercols filterfn)
+			stage)))))
+
+(define filtered_window_replacements (lambda (src old_stages new_stages)
+	(mapIndex old_stages (lambda (index stage)
+		(if (window_offset_stage? stage)
+			(list (os_column stage)
+				(list (quote get_column) (source_alias src) false
+					(os_column (nth new_stages index)) false))
+			(list (os_column stage)
+				(list (quote get_column) (source_alias src) false (os_column stage) false)))))))
+
+(define filtered_window_catalog (lambda (catalog physical_stages)
+	(begin
+		(define stage_index (reduce physical_stages (lambda (index stage)
+			(set_assoc index (logical_stage_key stage) stage)) '()))
+		(map catalog (lambda (stage)
+			(coalesceNil (get_assoc stage_index (logical_stage_key stage)) stage))))))
+
+(define query_block_with_filtered_window_orcs (lambda (block)
+	(match (qb_sources block)
+		(cons src rest) (begin
+			(define condition (combine_where (qb_where block) (source_join_expr src)))
+			(if (or (not (empty_list? rest))
+				(or (not (source_is_base_table? src))
+					(or (equal? condition true)
+						(empty_list? (filter (qb_stages block) window_offset_stage?)))))
+				block
+				(begin
+					/* A session-bound predicate cannot identify a shared computed column.
+					Fail instead of caching one session's window for another session. */
+					(if (not (empty_list? (query_expr_session_reads condition)))
+						(neumann_fail "build_queryplan"
+							"incompatible ordered window with session-dependent WHERE needs a query-local carrier")
+						true)
+					(define filtercols (extract_columns_for_alias src condition))
+					(define filterfn (list (quote lambda)
+						(map filtercols (lambda (column)
+							(scan_callback_symbol_for_alias (source_alias src) column)))
+						(lower_column_expr_for_alias src condition)))
+					(define physical_stages (filtered_window_stages
+						(qb_stages block) src condition filtercols filterfn))
+					(define replacements (filtered_window_replacements
+						src (qb_stages block) physical_stages))
+					(define rewrite (lambda (expr)
+						(replace_window_offset_expr src replacements expr)))
+					(define catalog (filtered_window_catalog
+						(query_block_stage_catalog block) physical_stages))
+					(make_query_block
+						(qb_schema block)
+						(qb_sources block)
+						(rewrite (qb_fields block))
+						(qb_where block)
+						(qb_group block)
+						(if (nil? (qb_having block)) nil (rewrite (qb_having block)))
+						(if (nil? (qb_order block)) nil (rewrite (qb_order block)))
+						(qb_limit block)
+						(qb_offset block)
+						(rewrite (qb_hidden block))
+						physical_stages
+						(qassoc_set_without (qb_facts block)
+							(quote stage_catalog) catalog (quote lowering_catalog))))))
+		_ block)))
+
+(define window_offset_stages_compatible? (lambda (stages reference)
+	(reduce stages (lambda (compatible stage)
+		(and compatible
+			(and (window_offset_stage? stage)
+				(and (equal? (source_schema (os_source stage)) (source_schema (os_source reference)))
+					(and (equal? (source_relation (os_source stage)) (source_relation (os_source reference)))
+						(and (equal? (os_sortcols stage) (os_sortcols reference))
+							(and (equal? (os_partitioncount stage) (os_partitioncount reference))
+								(equal? (serialize (window_offset_stage_stream_dirs stage))
+									(serialize (window_offset_stage_stream_dirs reference)))))))))) true)))
+
+(define window_offset_max_for_function (lambda (stages fn)
+	(reduce stages (lambda (largest stage)
+		(if (equal? (qassoc_get (os_facts stage) (quote window_function) nil) fn)
+			(max largest (qassoc_get (os_facts stage) (quote window_offset) 1))
+			largest)) 0)))
+
+(define lower_fused_window_offset_block (lambda (block)
+	(match (qb_stages block)
+		(cons stage rest) (if (not (window_offset_stages_compatible? (cons stage rest) stage))
+			nil
+			(match (qb_sources block)
+				(cons src src_rest) (if (or (not (empty_list? src_rest))
+					(or (not (source_is_base_table? src))
+						(or (not (nil? (qb_limit block))) (not (nil? (qb_offset block))))))
+					nil
+					(if (or
+						(not (equal? (source_schema (os_source stage)) (source_schema src)))
+						(not (equal? (source_relation (os_source stage)) (source_relation src))))
+						nil
+						(if (not (window_offset_order_compatible? src (coalesceNil (qb_order block) '()) stage))
+							nil
+							(begin
+								(define stages (cons stage rest))
+								(define facts (os_facts stage))
+								(define max_lag (window_offset_max_for_function stages "LAG"))
+								(define max_lead (window_offset_max_for_function stages "LEAD"))
+								(define fields (expand_query_block_fields (list src) (qb_fields block)))
+								(define condition (combine_where (qb_where block) (source_join_expr src)))
+								(define filtercols (merge_unique (list (extract_columns_for_alias src condition))))
+								(define fieldcols (merge_unique (extract_assoc fields (lambda (_title expr)
+									(extract_columns_for_alias src expr)))))
+								(define mapcols (merge_unique (list
+									(filter fieldcols (lambda (column) (not (contains? (map stages os_column) column))))
+									(merge (map stages os_mapcols)))))
+								(define stride (count mapcols))
+								(define window_size (+ max_lag max_lead 1))
+								(define selected_slot max_lag)
+								(define emit_params (window_offset_emit_params
+									window_size stride selected_slot (source_alias src) mapcols))
+								(define replacements (map stages (lambda (window_stage)
+									(begin
+										(define stage_facts (os_facts window_stage))
+										(define stage_fn (qassoc_get stage_facts (quote window_function) nil))
+										(define stage_offset (qassoc_get stage_facts (quote window_offset) 1))
+										(define value_col (qassoc_get stage_facts (quote window_value_column) nil))
+										(define value_slot (if (equal? stage_fn "LAG")
+											(- selected_slot stage_offset) (+ selected_slot stage_offset)))
+										(list (os_column window_stage)
+											(window_offset_slot_symbol value_slot
+												(window_offset_column_position mapcols value_col 0)))))))
+								/* The selected row receives its ordinary alias.column parameter
+								names. Only the logical window column is replaced, so the standard
+								expression lowerer still owns SQL value semantics. */
+								(define emit_expr (list (quote lambda) emit_params
+									(list (quote resultrow) (cons (quote list)
+										(map_assoc fields (lambda (_title expr)
+											(lower_column_expr_for_alias src
+												(replace_window_offset_expr src replacements expr))))))))
+								(define filter_expr (list (quote lambda)
+									(map filtercols (lambda (column)
+										(scan_callback_symbol_for_alias (source_alias src) column)))
+									(lower_column_expr_for_alias src condition)))
+								(define map_expr (list (quote lambda)
+									(map mapcols (lambda (column) (symbol (concat (source_alias src) "." column))))
+									(cons (quote list) (map mapcols (lambda (column)
+										(symbol (concat (source_alias src) "." column)))))))
+								(define fresh_window (window_offset_fresh_state_expr
+									max_lead window_size stride))
+								(define partition_cols (slice (os_sortcols stage) 0 (os_partitioncount stage)))
+								(define row_partition (if (empty_list? partition_cols)
+									nil
+									(if (single_source? partition_cols)
+										(list (quote nth) (quote mapped)
+											(window_offset_column_position mapcols (car partition_cols) 0))
+										(cons (quote list) (map partition_cols (lambda (column)
+											(list (quote nth) (quote mapped)
+												(window_offset_column_position mapcols column 0))))))))
+								(define reduce_expr (list (quote lambda) (list (quote state) (quote mapped))
+									(list (quote begin)
+										(list (quote define) (quote initialized) (list (quote car) (quote state)))
+										(list (quote define) (quote previous_partition) (list (quote cadr) (quote state)))
+										(list (quote define) (quote old_window) (list (quote nth) (quote state) 2))
+										(list (quote define) (quote current_partition) row_partition)
+										(list (quote define) (quote same_partition) (list (quote and)
+											(quote initialized)
+											(list (quote equal?) (quote previous_partition) (quote current_partition))))
+										(list (quote define) (quote active_window) (list (quote if)
+											(quote same_partition)
+											(quote old_window)
+											(list (quote begin)
+												(list (quote if) (list (quote and) (quote initialized) (> max_lead 0))
+													(list (quote window_flush) (quote old_window) emit_expr max_lead)
+													nil)
+												fresh_window)))
+										(list (quote window_mut) (quote active_window) emit_expr (quote mapped))
+										(list (quote list) true (quote current_partition) (quote active_window)))))
+								(define scan_expr (list (quote scan_order)
+									'(session "__memcp_tx")
+									(source_table_expr src)
+									(cons (quote list) filtercols)
+									filter_expr
+									(quoted_runtime_list (os_sortcols stage))
+									(cons (quote list) (window_scan_dirs
+										(window_offset_stage_stream_dirs stage)))
+									0 0 -1
+									(cons (quote list) mapcols)
+									map_expr reduce_expr
+									(list (quote list) false nil fresh_window)
+									(source_outer? src)))
+								(if (> max_lead 0)
+									(list
+										(list (quote lambda) (list (quote final_state))
+											(list (quote if) (list (quote car) (quote final_state))
+												(list (quote window_flush) (list (quote nth) (quote final_state) 2) emit_expr max_lead)
+												nil))
+										scan_expr)
+									scan_expr)))))
+				_ nil))
+		_ nil)))
 
 (define lower_fused_row_number_block (lambda (block)
 	(match (qb_stages block)
@@ -2623,10 +2940,15 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 		(if (or (not (empty_list? (qb_group block))) (or (not (nil? (qb_having block))) (query_block_has_aggregates? block)))
 			(lower_grouped_query_block_with_stages block)
 			(begin
-				(define fused_row_number (lower_fused_row_number_block block))
-				(if (not (nil? fused_row_number))
-					fused_row_number
-					(lower_simple_query_block_with_cataloged_stages block)))))))
+				(define fused_window_offset (lower_fused_window_offset_block block))
+				(if (not (nil? fused_window_offset))
+					fused_window_offset
+					(begin
+						(define fused_row_number (lower_fused_row_number_block block))
+						(if (not (nil? fused_row_number))
+							fused_row_number
+							(lower_simple_query_block_with_cataloged_stages
+								(query_block_with_filtered_window_orcs block)))))))))))
 
 (define lower_query_block_with_stages (lambda (block)
 	(lower_query_block_with_cataloged_stages (query_block_with_full_stage_catalog block))))

--- a/scm/window.go
+++ b/scm/window.go
@@ -18,22 +18,83 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package scm
 
 /*
- Window ring buffer helpers for LEAD/LAG window functions.
+ Sliding window helpers for LEAD/LAG window functions.
 
  Accumulator layout (flat list):
    (skip_count counter stride slot_0_v0 slot_0_v1 ... slot_N_vM)
 
  - skip_count: rows to skip before first emit (LEAD offset, 0 for LAG)
- - counter: monotonic write position
+ - counter: monotonic number of inserted positions
  - stride: number of values per slot
  - slots: window_size * stride values
 
- window_mut writes vals into the current slot, increments counter,
+ window_mut shifts vals into the caller-owned window, increments counter,
  and either decrements skip or calls emit_fn with all slot values
  ordered oldest-to-newest.
 
  window_flush shifts in count positions of nils, emitting each time.
 */
+
+func windowMut(a ...Scmer) Scmer {
+	win := asSlice(a[0], "window_mut")
+	emitFn := a[1]
+	vals := asSlice(a[2], "window_mut vals")
+
+	if len(win) < 3 {
+		panic("window_mut: window must have at least 3 elements (skip, counter, stride)")
+	}
+
+	skip := int(win[0].Int())
+	counter := int(win[1].Int())
+	stride := int(win[2].Int())
+	slots := win[3:]
+	if stride <= 0 || len(slots) == 0 || len(slots)%stride != 0 {
+		panic("window_mut: invalid window dimensions")
+	}
+
+	// The accumulator belongs exclusively to the serial reducer. Keep its slots
+	// physically oldest-to-newest so the variadic emit call can borrow the
+	// contiguous backing array instead of allocating a rotated argument frame.
+	copy(slots, slots[stride:])
+	tail := slots[len(slots)-stride:]
+	for i := range tail {
+		if i < len(vals) {
+			tail[i] = vals[i]
+		} else {
+			tail[i] = NewNil()
+		}
+	}
+	win[1] = NewInt(int64(counter + 1))
+	if skip > 0 {
+		win[0] = NewInt(int64(skip - 1))
+		return a[0]
+	}
+	Apply(emitFn, slots...)
+	return a[0]
+}
+
+func windowFlush(a ...Scmer) Scmer {
+	win := asSlice(a[0], "window_flush")
+	emitFn := a[1]
+	count := int(a[2].Int())
+	if len(win) < 3 {
+		panic("window_flush: window must have at least 3 elements")
+	}
+	stride := int(win[2].Int())
+	slots := win[3:]
+	if stride <= 0 || len(slots) == 0 || len(slots)%stride != 0 {
+		panic("window_flush: invalid window dimensions")
+	}
+	for n := 0; n < count; n++ {
+		copy(slots, slots[stride:])
+		for i := len(slots) - stride; i < len(slots); i++ {
+			slots[i] = NewNil()
+		}
+		win[1] = NewInt(win[1].Int() + 1)
+		Apply(emitFn, slots...)
+	}
+	return NewNil()
+}
 
 func init_window() {
 	DeclareTitle("Window Functions")
@@ -109,65 +170,9 @@ func init_window() {
 	Declare(&Globalenv, &Declaration{
 		Name: "window_mut",
 
-		Fn: func(a ...Scmer) Scmer {
-			win := asSlice(a[0], "window_mut")
-			emitFn := a[1]
-			vals := asSlice(a[2], "window_mut vals")
-
-			if len(win) < 3 {
-				panic("window_mut: window must have at least 3 elements (skip, counter, stride)")
-			}
-
-			skip := int(win[0].Int())
-			counter := int(win[1].Int())
-			stride := int(win[2].Int())
-			slots := win[3:] // flat: window_size * stride values
-			windowSize := len(slots) / stride
-
-			if windowSize == 0 || stride == 0 {
-				panic("window_mut: invalid window dimensions")
-			}
-
-			// write vals into current slot
-			writePos := (counter % windowSize) * stride
-			for i := 0; i < stride; i++ {
-				if i < len(vals) {
-					slots[writePos+i] = vals[i]
-				} else {
-					slots[writePos+i] = NewNil()
-				}
-			}
-			counter++
-
-			// build result window
-			result := make([]Scmer, len(win))
-			if skip > 0 {
-				result[0] = NewInt(int64(skip - 1))
-			} else {
-				result[0] = NewInt(0)
-			}
-			result[1] = NewInt(int64(counter))
-			result[2] = NewInt(int64(stride))
-			copy(result[3:], slots)
-
-			// emit if not skipping
-			if skip <= 0 {
-				// build args: all values oldest-to-newest
-				args := make([]Scmer, len(slots))
-				for i := 0; i < windowSize; i++ {
-					srcPos := ((counter + i) % windowSize) * stride
-					dstPos := i * stride
-					for j := 0; j < stride; j++ {
-						args[dstPos+j] = slots[srcPos+j]
-					}
-				}
-				Apply(emitFn, args...)
-			}
-
-			return NewSlice(result)
-		},
-		Type: &TypeDescriptor{Kind: "func", Description: "Ring buffer shift-insert for window functions. (window_mut window emit_fn vals) writes vals (a list of stride values) into the current slot, increments counter. If skip>0, decrements skip. Otherwise calls (emit_fn oldest_v0 oldest_v1 ... newest_v0 newest_v1) with all slot values ordered oldest-to-newest. Returns updated window.",
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "window", Description: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", Label: "emit_fn", Description: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", Label: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "list", Label: "vals", Description: "list of stride values to insert"}},
+		Fn: windowMut,
+		Type: &TypeDescriptor{Kind: "func", Description: "Owned sliding-window shift. (window_mut window emit_fn vals) mutates its serial accumulator in place, keeping values oldest-to-newest so emit_fn can borrow them without an allocation.", HasSideEffects: true,
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "window", Description: "caller-owned serial window accumulator"}, &TypeDescriptor{Kind: "func", Label: "emit_fn", Description: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", Label: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "list", Label: "vals", Description: "list of stride values to insert"}},
 			Return: &TypeDescriptor{Kind: "list"},
 
 			JITEmit: nil,
@@ -177,44 +182,8 @@ func init_window() {
 	Declare(&Globalenv, &Declaration{
 		Name: "window_flush",
 
-		Fn: func(a ...Scmer) Scmer {
-			win := asSlice(a[0], "window_flush")
-			emitFn := a[1]
-			count := int(a[2].Int())
-
-			if len(win) < 3 {
-				panic("window_flush: window must have at least 3 elements")
-			}
-
-			counter := int(win[1].Int())
-			stride := int(win[2].Int())
-			slots := make([]Scmer, len(win)-3)
-			copy(slots, win[3:])
-			windowSize := len(slots) / stride
-
-			for n := 0; n < count; n++ {
-				// write nils into current slot
-				writePos := (counter % windowSize) * stride
-				for i := 0; i < stride; i++ {
-					slots[writePos+i] = NewNil()
-				}
-				counter++
-
-				// build args: all values oldest-to-newest
-				args := make([]Scmer, len(slots))
-				for i := 0; i < windowSize; i++ {
-					srcPos := ((counter + i) % windowSize) * stride
-					dstPos := i * stride
-					for j := 0; j < stride; j++ {
-						args[dstPos+j] = slots[srcPos+j]
-					}
-				}
-				Apply(emitFn, args...)
-			}
-
-			return NewNil()
-		},
-		Type: &TypeDescriptor{Kind: "func", Description: "Flush remaining window buffer by shifting in nils. (window_flush window emit_fn count) shifts in count positions of nils, calling emit_fn for each displaced position. Returns nil.",
+		Fn: windowFlush,
+		Type: &TypeDescriptor{Kind: "func", Description: "Flush a caller-owned window by shifting in nils without allocating and invoking emit_fn for each displaced position.", HasSideEffects: true,
 			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "list", Label: "window", Description: "ring buffer accumulator"}, &TypeDescriptor{Kind: "func", Label: "emit_fn", Description: "callback receiving all window values oldest-to-newest", Params: []*TypeDescriptor{{Kind: "any", Label: "values", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}}, &TypeDescriptor{Kind: "number", Label: "count", Description: "number of nil positions to shift in"}},
 			Return: &TypeDescriptor{Kind: "nil"},
 

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -288,7 +288,7 @@ func (s *storageShard) ComputeColumn(name string, inputCols []string, computor s
 // mapFn:     (lambda ($set mapCols...) ...) — passes data through to reduceFn
 // reduceFn:  (lambda (acc mapped) ...) — calls ($set newVal), returns new acc
 // reduceInit: initial accumulator value
-func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
+func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, sortDirs []bool, partCount int, filterCols []string, filterFn scm.Scmer, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
 	found := false
 	paramsChanged := false
 	isTemp := false
@@ -299,10 +299,13 @@ func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, so
 			paramsChanged = !slicesEqual(c.OrcSortCols, sortCols) ||
 				!boolSlicesEqual(c.OrcSortDirs, sortDirs) ||
 				c.OrcPartitionCount != partCount ||
+				!slicesEqual(c.OrcFilterCols, filterCols) ||
 				!slicesEqual(c.OrcMapCols, mapCols)
 			t.Columns[i].OrcSortCols = sortCols
 			t.Columns[i].OrcSortDirs = sortDirs
 			t.Columns[i].OrcPartitionCount = partCount
+			t.Columns[i].OrcFilterCols = filterCols
+			t.Columns[i].OrcFilterFn = filterFn
 			t.Columns[i].OrcMapCols = mapCols
 			t.Columns[i].OrcMapFn = mapFn
 			t.Columns[i].OrcReduceFn = reduceFn
@@ -347,10 +350,10 @@ func (t *table) computeOrderedColumnDDLLocked(name string, sortCols []string, so
 	}
 }
 
-func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []bool, partCount int, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
+func (t *table) ComputeOrderedColumn(name string, sortCols []string, sortDirs []bool, partCount int, filterCols []string, filterFn scm.Scmer, mapCols []string, mapFn scm.Scmer, reduceFn scm.Scmer, reduceInit scm.Scmer) {
 	t.ddlMu.Lock()
 	defer t.ddlMu.Unlock()
-	t.computeOrderedColumnDDLLocked(name, sortCols, sortDirs, partCount, mapCols, mapFn, reduceFn, reduceInit)
+	t.computeOrderedColumnDDLLocked(name, sortCols, sortDirs, partCount, filterCols, filterFn, mapCols, mapFn, reduceFn, reduceInit)
 }
 
 // initORCShard ensures a StorageComputeProxy with isOrdered=true exists on shard s.
@@ -440,15 +443,17 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 
 	// Build condition filter. For partitioned ORCs, restrict the scan to the
 	// partition containing the requested row. This avoids scanning all partitions
-	// when only one was invalidated.
+	// when only one was invalidated. A query-domain filter is evaluated in the
+	// same callback, before the ordered reducer, so SQL WHERE semantics precede
+	// LAG/LEAD rather than filtering a window over the complete base table.
 	partCount := analyzeOrcPartition(col)
-	var condCols []string
-	var condFn scm.Scmer
+	var partCols []string
+	var partKeys []scm.Scmer
 
 	if partCount > 0 {
 		// Read partition key of the requested row
-		partCols := col.OrcSortCols[:partCount]
-		partKeys := make([]scm.Scmer, partCount)
+		partCols = col.OrcSortCols[:partCount]
+		partKeys = make([]scm.Scmer, partCount)
 		for i, pc := range partCols {
 			requestShard.mu.RLock()
 			cs := requestShard.columns[pc]
@@ -459,19 +464,86 @@ func (t *table) incrementalRecomputeORC(name string, requestShard *storageShard,
 				partKeys[i] = requestShard.getDelta(int(requestIdx-requestShard.main_count), pc)
 			}
 		}
-		// Filter: only rows in the same partition
-		condCols = partCols
-		condFn = scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
-			for i := 0; i < partCount; i++ {
-				if scm.Less(a[i], partKeys[i]) || scm.Less(partKeys[i], a[i]) {
-					return scm.NewBool(false) // different partition
+	}
+	condCols := make([]string, 0, len(partCols)+len(col.OrcFilterCols))
+	condCols = append(condCols, partCols...)
+	condCols = append(condCols, col.OrcFilterCols...)
+	filterFn := scm.OptimizeProcToSerialFunction(col.OrcFilterFn)
+	condFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+		for i := 0; i < partCount; i++ {
+			if scm.Less(a[i], partKeys[i]) || scm.Less(partKeys[i], a[i]) {
+				return scm.NewBool(false)
+			}
+		}
+		if col.OrcFilterFn.IsNil() {
+			return scm.NewBool(true)
+		}
+		return scm.NewBool(scm.ToBool(filterFn(a[partCount:]...)))
+	})
+
+	// A domain-filtered ORC has intentional holes: rows outside the predicate
+	// never receive a value. Rebuild its accepted domain directly instead of
+	// reading the same computed column for prefix/convergence detection. Besides
+	// being the correct validity model for sparse domains, this avoids making a
+	// worker wait on the orcMu currently held by its own recomputation.
+	if !col.OrcFilterFn.IsNil() {
+		type filteredProxy struct {
+			proxy *StorageComputeProxy
+			limit uint32
+		}
+		proxies := make([]filteredProxy, 0)
+		for _, s := range t.maintenanceShards() {
+			s.mu.RLock()
+			proxy, ok := s.columns[name].(*StorageComputeProxy)
+			limit := s.main_count + uint32(len(s.inserts))
+			s.mu.RUnlock()
+			if !ok {
+				continue
+			}
+			// The filtered recipe is sparse by definition. Drop stale materialized
+			// values before rebuilding; readers of invalid rows wait on orcMu.
+			proxy.mu.Lock()
+			proxy.main = nil
+			proxy.delta = make(map[uint32]scm.Scmer)
+			proxy.compressed = false
+			proxy.validMask.Reset()
+			proxy.mu.Unlock()
+			proxies = append(proxies, filteredProxy{proxy: proxy, limit: limit})
+		}
+
+		domainCondFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+			return scm.NewBool(scm.ToBool(filterFn(a...)))
+		})
+		scanCallbackCols := make([]string, 0, 1+len(col.OrcMapCols))
+		scanCallbackCols = append(scanCallbackCols, "$set:"+name)
+		scanCallbackCols = append(scanCallbackCols, col.OrcMapCols...)
+		scm.SetValues(map[string]any{orcRecomputeMarkerKey: t}, func() {
+			t.scan_order(
+				CurrentTx(),
+				col.OrcFilterCols, domainCondFn,
+				sortcolsScmer, sortdirsFns,
+				0, 0, -1,
+				scanCallbackCols,
+				col.OrcMapFn,
+				col.OrcReduceFn,
+				col.OrcReduceInit,
+				false,
+				col.OrcReduceInit,
+				nil,
+				scm.NewNil(),
+			)
+		})
+		// Speculative callback-column prefetch may read rows rejected by the
+		// predicate. Publish those holes as valid nils after every accepted row
+		// has been written, so it never starts a second domain rebuild.
+		for _, item := range proxies {
+			for idx := uint32(0); idx < item.limit; idx++ {
+				if !item.proxy.validMask.Get(uint(idx)) {
+					item.proxy.validMask.Set(uint(idx), true)
 				}
 			}
-			return scm.NewBool(true)
-		})
-	} else {
-		condCols = []string{}
-		condFn = scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+		}
+		return
 	}
 
 	// Callback: $set + $break + stored ORC value + mapCols
@@ -763,7 +835,7 @@ func (t *table) registerORCTriggers(name string) {
 	hasSortKey := col != nil && len(col.OrcSortCols) > 0
 	relevantCols := []string(nil)
 	if col != nil {
-		relevantCols = mergeUniqueStrings(col.OrcSortCols, col.OrcMapCols)
+		relevantCols = mergeUniqueStrings(col.OrcSortCols, col.OrcFilterCols, col.OrcMapCols)
 	}
 
 	// Build composite sort key expression: (list (get_assoc dict "col1") (get_assoc dict "col2") ...)
@@ -1485,7 +1557,7 @@ func scanRelevantSourceCols(ref scanJoinInfo, srcTable *table) []string {
 			if col.Name != name || !isRuntimeComputedColumn(col) {
 				continue
 			}
-			result = mergeUniqueStrings(result, col.ComputorInputCols, col.OrcSortCols, col.OrcMapCols)
+			result = mergeUniqueStrings(result, col.ComputorInputCols, col.OrcSortCols, col.OrcFilterCols, col.OrcMapCols)
 			break
 		}
 	}

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -1091,6 +1091,8 @@ func TestEnsureColumnLoadedRehydratesOrderedProxyFromSchemaPlaceholder(t *testin
 		[]string{"day"},
 		[]bool{false},
 		0,
+		nil,
+		scm.NewNil(),
 		[]string{"id"},
 		scm.NewNil(),
 		scm.NewNil(),

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1997,8 +1997,9 @@ func Init(en scm.Env) {
 			var orcSortCols []string
 			var orcSortDirs []bool
 			var orcPartCount int
+			var orcFilterCols []string
 			var orcMapCols []string
-			var orcMapFn, orcReduceFn, orcReduceInit scm.Scmer
+			var orcFilterFn, orcMapFn, orcReduceFn, orcReduceInit scm.Scmer
 			for i := 0; i+1 < len(typeparams); i += 2 {
 				key := scm.String(typeparams[i])
 				val := typeparams[i+1]
@@ -2013,6 +2014,10 @@ func Init(en scm.Env) {
 					}
 				case "partitioncount":
 					orcPartCount = scm.ToInt(val)
+				case "filtercols":
+					orcFilterCols = scmerSliceToStrings(mustScmerSlice(val, "filtercols"))
+				case "filter":
+					orcFilterFn = val
 				case "mapcols":
 					orcMapCols = scmerSliceToStrings(mustScmerSlice(val, "mapcols"))
 				case "mapfn":
@@ -2040,10 +2045,11 @@ func Init(en scm.Env) {
 			// 3. "Always materialize, but correctly" means the runtime path may reuse
 			//    an already-populated temp column; it must not silently fall back to a
 			//    throwaway one-shot computation because the column already exists.
-			// 4. filtercols/filter further narrow which keys need eager materialization;
-			//    they do not change the identity of the canonical temp column itself.
+			// 4. filtercols/filter define an ordered column's input domain. The
+			//    planner therefore includes the predicate recipe in its canonical
+			//    temp-column name; this entrypoint must preserve that identity.
 			if len(orcSortCols) > 0 {
-				t.computeOrderedColumnDDLLocked(colname, orcSortCols, orcSortDirs, orcPartCount, orcMapCols, orcMapFn, orcReduceFn, orcReduceInit)
+				t.computeOrderedColumnDDLLocked(colname, orcSortCols, orcSortDirs, orcPartCount, orcFilterCols, orcFilterFn, orcMapCols, orcMapFn, orcReduceFn, orcReduceInit)
 				return scm.NewBool(true)
 			}
 

--- a/storage/table.go
+++ b/storage/table.go
@@ -126,6 +126,8 @@ type column struct {
 	OrcSortCols       []string  `json:",omitempty"` // ORDER BY column names (partition cols first, then order cols)
 	OrcSortDirs       []bool    `json:",omitempty"` // false=ASC, true=DESC, one per OrcSortCol
 	OrcPartitionCount int       `json:",omitempty"` // number of leading OrcSortCols that form the window partition
+	OrcFilterCols     []string  `json:",omitempty"` // rows admitted to the ordered reduction before window evaluation
+	OrcFilterFn       scm.Scmer // predicate over OrcFilterCols; nil means every row
 	OrcMapCols        []string  `json:",omitempty"` // additional input columns passed to OrcMapFn
 	OrcMapFn          scm.Scmer // (lambda ($set mapcols...) ...) — passes data to reduceFn
 	OrcReduceFn       scm.Scmer // (lambda (acc mapped) ...) — accumulates and writes via $set

--- a/tests/planner/order-window/window-functions.yaml
+++ b/tests/planner/order-window/window-functions.yaml
@@ -328,6 +328,75 @@ test_cases:
         - {id: 4, time_val: 15, prev_time: 30, next_amt: 400}
         - {id: 5, time_val: 25, prev_time: 15, next_amt: null}
 
+  - name: "Compatible LAG and LEAD share one streaming window"
+    sql: "EXPLAIN PHYSICAL SELECT id, LAG(time_val, 2) OVER (ORDER BY time_val) AS prev_time, LEAD(amount) OVER (ORDER BY time_val) AS next_amount FROM win_emp ORDER BY time_val"
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "window_mut"
+        - "window_flush"
+      result_not_contains:
+        - "createcolumn"
+
+  - name: "Compatible LAG streams in the requested window order"
+    sql: "EXPLAIN PHYSICAL SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp ORDER BY time_val"
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "window_mut"
+      result_not_contains:
+        - "createcolumn"
+
+  - name: "LAG without an outer order may choose its window order"
+    sql: "EXPLAIN PHYSICAL SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp"
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "window_mut"
+      result_not_contains:
+        - "createcolumn"
+
+  - name: "Compatible partitioned LEAD streams and flushes its tail"
+    sql: "EXPLAIN PHYSICAL SELECT id, parent, time_val, LEAD(time_val) OVER (PARTITION BY parent ORDER BY time_val) AS next_time FROM win_emp ORDER BY parent, time_val"
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_order"
+        - "window_mut"
+        - "window_flush"
+      result_not_contains:
+        - "createcolumn"
+
+  - name: "Filtered LAG windows contain only accepted input rows"
+    sql: "SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp WHERE parent = 100 ORDER BY time_val"
+    expect:
+      rows: 3
+      data:
+        - {id: 1, time_val: 10, prev_time: null}
+        - {id: 2, time_val: 20, prev_time: 10}
+        - {id: 3, time_val: 30, prev_time: 20}
+
+  - name: "Incompatible output order retains the materialized ORC barrier"
+    sql: "EXPLAIN PHYSICAL SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp ORDER BY id"
+    expect:
+      rows: 1
+      result_contains:
+        - "createcolumn"
+      result_not_contains:
+        - "window_mut"
+
+  - name: "Materialized fallback applies WHERE before the window"
+    sql: "SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp WHERE parent = 100 ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - {id: 1, time_val: 10, prev_time: null}
+        - {id: 2, time_val: 20, prev_time: 10}
+        - {id: 3, time_val: 30, prev_time: 20}
+
   # ==========================================================================
   # Case 8: Multiple window functions — different OVER clauses use separate ORCs
   # ==========================================================================
@@ -509,6 +578,35 @@ test_cases:
         - {id: 3, parent: 100, amount: 700, rnk: 3}
         - {id: 4, parent: 200, amount: 200, rnk: 1}
         - {id: 5, parent: 200, amount: 400, rnk: 2}
+
+  - name: "A filter-column update invalidates the materialized window domain"
+    sql: "UPDATE win_emp SET parent = 100 WHERE id = 4"
+    expect:
+      affected_rows: 1
+
+  - name: "A row entering the filtered domain participates in LAG"
+    sql: "SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp WHERE parent = 100 ORDER BY id"
+    expect:
+      rows: 4
+      data:
+        - {id: 1, time_val: 10, prev_time: null}
+        - {id: 2, time_val: 20, prev_time: 15}
+        - {id: 3, time_val: 30, prev_time: 20}
+        - {id: 4, time_val: 15, prev_time: 10}
+
+  - name: "Restore the filtered window fixture"
+    sql: "UPDATE win_emp SET parent = 200 WHERE id = 4"
+    expect:
+      affected_rows: 1
+
+  - name: "A row leaving the filtered domain no longer affects LAG"
+    sql: "SELECT id, time_val, LAG(time_val) OVER (ORDER BY time_val) AS prev_time FROM win_emp WHERE parent = 100 ORDER BY id"
+    expect:
+      rows: 3
+      data:
+        - {id: 1, time_val: 10, prev_time: null}
+        - {id: 2, time_val: 20, prev_time: 10}
+        - {id: 3, time_val: 30, prev_time: 20}
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS win_emp"


### PR DESCRIPTION
## What

- lower compatible `LAG`/`LEAD` windows to one fused `scan_order` + `window_mut`/`window_flush` pipeline
- retain the ORC barrier when the requested output order is incompatible
- make filtered ORC fallbacks compute the window over the accepted SQL input domain
- invalidate filtered materialized windows when referenced filter columns change
- make the sliding-window runtime mutate caller-owned storage without per-row allocations

The logical plan records only semantic window facts. Streaming versus materialization remains a physical-lowering decision. The lowerer takes the streaming path only where it dominates: no outer order, or an outer order matching partition plus window order. Unclear/incompatible shapes preserve the existing barrier.

## Correctness coverage

Extended `tests/planner/order-window/window-functions.yaml` with permanent YAML cases for:

- compatible and order-free streaming `LAG`
- partitioned `LEAD` tail flushing
- fusion of compatible `LAG` and `LEAD`
- filtering before window evaluation
- incompatible-order ORC fallback
- invalidation when rows enter or leave a filtered materialized domain

No new Go tests or benchmarks are committed. The existing Go test call site only follows the changed internal function signature.

## Measurements

Temporary primitive benchmark (not committed):

- offset 1: ~150 ns, 160 B, 3 allocs -> ~19 ns, 0 B, 0 allocs
- offset 8: ~226 ns, 384 B, 3 allocs -> ~20 ns, 0 B, 0 allocs
- offset 64: ~705 ns, 2352 B, 3 allocs -> ~25 ns, 0 B, 0 allocs

Identical 200k-row SQL A/B for a filtered ordered `LAG` query:

- master physical plan: `createcolumn`, no `window_mut`
- branch physical plan: `scan_order` + `window_mut`, no `createcolumn`
- master: 4.559 s cold; 18.8/18.5 ms warm
- branch: 22.9 ms cold; 3.15/1.43 ms warm

## Validation

- targeted order-window, ORC trigger/invalidation, index suffix, persistence and concurrency YAML suites: green
- startup Scheme unit tests: 1270/1270
- Scheme lint: green
- Go build and diff check: green
- complete YAML matrix: delegated to CI
