### PR TITLE
Prepare allocation-free callback frames for physical scans

### DIFF
--- a/scm/declare.go
+++ b/scm/declare.go
@@ -256,7 +256,10 @@ var NoEscape = &TypeDescriptor{Kind: "any", NoEscape: true, Length: UnknownLengt
 
 var declaration_titles []string
 var declarations map[string]*Declaration = make(map[string]*Declaration)
-var declarations_hash map[string]*Declaration = make(map[string]*Declaration)
+
+// Keying by the complete function identity preserves distinct closure contexts
+// and avoids fmt.Sprintf allocating on every prepared callback lookup.
+var declarationsByFunction map[uintptr]*Declaration = make(map[uintptr]*Declaration)
 
 func DeclareTitle(title string) {
 	declaration_titles = append(declaration_titles, "#"+title)
@@ -281,7 +284,7 @@ func Declare(env *Env, def *Declaration) {
 	}
 	declarations[def.Name] = def
 	if def.Fn != nil {
-		declarations_hash[fmt.Sprintf("%p", def.Fn)] = def
+		declarationsByFunction[FunctionIdentity(def.Fn)] = def
 		env.Vars[Symbol(def.Name)] = NewFunc(def.Fn)
 	}
 }
@@ -293,7 +296,7 @@ func DeclareInSection(section string, env *Env, def *Declaration) {
 	validateDeclaration(def)
 	declarations[def.Name] = def
 	if def.Fn != nil {
-		declarations_hash[fmt.Sprintf("%p", def.Fn)] = def
+		declarationsByFunction[FunctionIdentity(def.Fn)] = def
 		env.Vars[Symbol(def.Name)] = NewFunc(def.Fn)
 	}
 	if def.IsForbidden() {
@@ -690,7 +693,7 @@ func Validate(val Scmer, require string) string {
 					def = def2
 				}
 			} else if head.GetTag() == tagFunc {
-				if def2, ok := declarations_hash[fmt.Sprintf("%p", head.Func())]; ok {
+				if def2, ok := declarationsByFunction[FunctionIdentity(head.Func())]; ok {
 					def = def2
 				}
 			}
@@ -1034,7 +1037,7 @@ func DeclarationForValue(v Scmer) *Declaration {
 			return d
 		}
 	case tagFunc:
-		if d, ok := declarations_hash[fmt.Sprintf("%p", v.Func())]; ok {
+		if d, ok := declarationsByFunction[FunctionIdentity(v.Func())]; ok {
 			return d
 		}
 	case tagAny:
@@ -1049,7 +1052,7 @@ func DeclarationForValue(v Scmer) *Declaration {
 			}
 		}
 		if fn, ok := v.Any().(func(...Scmer) Scmer); ok {
-			if d, ok := declarations_hash[fmt.Sprintf("%p", fn)]; ok {
+			if d, ok := declarationsByFunction[FunctionIdentity(fn)]; ok {
 				return d
 			}
 		}

--- a/scm/declare_test.go
+++ b/scm/declare_test.go
@@ -91,13 +91,13 @@ func TestFormatTypeSignatureHandlesUnionContainers(t *testing.T) {
 }
 
 func TestWriteDocumentationUsesRecursiveTypeDescriptors(t *testing.T) {
-	oldTitles, oldDeclarations, oldHashes := declaration_titles, declarations, declarations_hash
+	oldTitles, oldDeclarations, oldFunctions := declaration_titles, declarations, declarationsByFunction
 	defer func() {
-		declaration_titles, declarations, declarations_hash = oldTitles, oldDeclarations, oldHashes
+		declaration_titles, declarations, declarationsByFunction = oldTitles, oldDeclarations, oldFunctions
 	}()
 	declaration_titles = nil
 	declarations = make(map[string]*Declaration)
-	declarations_hash = make(map[string]*Declaration)
+	declarationsByFunction = make(map[uintptr]*Declaration)
 
 	DeclareTitle("Nested")
 	env := Env{Vars: make(Vars)}
@@ -132,13 +132,13 @@ func TestWriteDocumentationUsesRecursiveTypeDescriptors(t *testing.T) {
 }
 
 func TestHelpUsesRecursiveTypeDescriptors(t *testing.T) {
-	oldTitles, oldDeclarations, oldHashes := declaration_titles, declarations, declarations_hash
+	oldTitles, oldDeclarations, oldFunctions := declaration_titles, declarations, declarationsByFunction
 	defer func() {
-		declaration_titles, declarations, declarations_hash = oldTitles, oldDeclarations, oldHashes
+		declaration_titles, declarations, declarationsByFunction = oldTitles, oldDeclarations, oldFunctions
 	}()
 	declaration_titles = nil
 	declarations = make(map[string]*Declaration)
-	declarations_hash = make(map[string]*Declaration)
+	declarationsByFunction = make(map[uintptr]*Declaration)
 
 	env := Env{Vars: make(Vars)}
 	Declare(&env, &Declaration{

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -81,8 +81,26 @@ func procCanUseNumberedOnly(params, body Scmer, numVars int) bool {
 	return !procBodyUsesNamedParam(body, named)
 }
 
-// to optimize lambdas serially; the resulting function MUST NEVER run on multiple threads simultanously since state is reduced to save mallocs
+// OptimizeProcToSerialFunction is the compatibility adapter for callers which
+// still require a Go variadic function. New physical hot paths must use
+// PrepareSerialProc and caller-owned []Scmer frames: Eval's temporary variadic
+// call arrays otherwise escape once per nested expression and row. The returned
+// function MUST NEVER run on multiple threads simultaneously because its
+// environment is reused to avoid allocations.
 func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
+	if val.GetTag() == tagFunc {
+		return val.Func()
+	}
+	if val.GetTag() == tagAny {
+		if fn, ok := val.Any().(func(...Scmer) Scmer); ok {
+			return fn
+		}
+	}
+	borrowed := optimizeProcToSerialBorrowed(val)
+	return func(args ...Scmer) Scmer { return borrowed(args) }
+}
+
+func optimizeProcToSerialBorrowed(val Scmer) func([]Scmer) Scmer {
 	/* API contract:
 	- the returned func must only be called with the correct number of declared parameters
 	- thus we will perform no boundary checks
@@ -91,14 +109,15 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	- TODO: we want to hook up the JIT here to produce some machine code for hotpaths
 	*/
 	if val.IsNil() {
-		return func(...Scmer) Scmer { return NewNil() }
+		return func([]Scmer) Scmer { return NewNil() }
 	}
 	if val.GetTag() == tagFunc {
-		return val.Func()
+		fn := val.Func()
+		return func(args []Scmer) Scmer { return fn(args...) }
 	}
 	if val.GetTag() == tagAny {
 		if fn, ok := val.Any().(func(...Scmer) Scmer); ok {
-			return fn
+			return func(args []Scmer) Scmer { return fn(args...) }
 		}
 	}
 
@@ -111,14 +130,14 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 		// Not a lambda/proc: treat as constant value and return it regardless of args.
 		// This avoids attempting to Apply() non-callables like true/0/"x" which would panic.
 		captured := val
-		return func(args ...Scmer) Scmer { return captured }
+		return func([]Scmer) Scmer { return captured }
 	}
 	p := *proc
 	// A Proc keeps its source body even after native compilation. Execute the
 	// attached entry point now; future scan specialization may recompile the same
 	// filter/map/reduce body against concrete storage and column types first.
 	if p.Compiled != nil {
-		return func(args ...Scmer) Scmer {
+		return func(args []Scmer) Scmer {
 			return p.Compiled.Call(args...)
 		}
 	}
@@ -127,7 +146,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	switch p.Body.GetTag() {
 	case tagNil, tagBool, tagInt, tagFloat, tagString:
 		constant := p.Body
-		return func(...Scmer) Scmer { return constant }
+		return func([]Scmer) Scmer { return constant }
 	}
 
 	// Fast-path: lambda body is exactly one of its parameters -> return that arg directly
@@ -139,7 +158,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 		// numbered locals: (var i)
 		if body.IsNthLocalVar() {
 			idx := int(body.NthLocalVar())
-			return func(args ...Scmer) Scmer {
+			return func(args []Scmer) Scmer {
 				return args[idx]
 			}
 		}
@@ -157,7 +176,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 				}
 				if ps.IsSymbol() && mustSymbol(ps) == bSym {
 					idx := i
-					return func(args ...Scmer) Scmer {
+					return func(args []Scmer) Scmer {
 						return args[idx]
 					}
 				}
@@ -177,6 +196,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 	}
 	var vars Vars
 	en := &Env{Vars: vars, VarsNumbered: make([]Scmer, numVars), Outer: p.En, Nodefine: false}
+	body := prepareSerialExpr(&p, p.Body)
 	params := p.Params
 	if stripped, ok := scmerStripSourceInfo(params); ok {
 		params = stripped
@@ -204,7 +224,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 					en.Vars = vars
 				}
 			}
-			return func(args ...Scmer) Scmer {
+			return func(args []Scmer) Scmer {
 				for i := 0; i < numVars; i++ {
 					if i < len(args) {
 						en.VarsNumbered[i] = args[i]
@@ -228,12 +248,12 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 						}
 					}
 				}
-				return Eval(p.Body, en)
+				return body(en)
 			}
 		}
 		vars = make(Vars, len(paramSlice))
 		en.Vars = vars
-		return func(args ...Scmer) Scmer {
+		return func(args []Scmer) Scmer {
 			for i, param := range paramSlice {
 				if stripped, ok := scmerStripSourceInfo(param); ok {
 					param = stripped
@@ -248,7 +268,7 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 					en.Vars[sym] = NewNil()
 				}
 			}
-			return Eval(p.Body, en)
+			return body(en)
 		}
 	}
 	if params.IsSymbol() {
@@ -262,24 +282,24 @@ func OptimizeProcToSerialFunction(val Scmer) func(...Scmer) Scmer {
 					en.Vars = vars
 				}
 			}
-			return func(args ...Scmer) Scmer {
-				argsList := NewSlice(args)
+			return func(args []Scmer) Scmer {
+				argsList := NewSlice(append([]Scmer(nil), args...))
 				en.VarsNumbered[0] = argsList
 				if bindNamed {
 					en.Vars[sym] = argsList
 				}
-				return Eval(p.Body, en)
+				return body(en)
 			}
 		}
 		vars = make(Vars, 1)
 		en.Vars = vars
-		return func(args ...Scmer) Scmer {
-			en.Vars[sym] = NewSlice(args)
-			return Eval(p.Body, en)
+		return func(args []Scmer) Scmer {
+			en.Vars[sym] = NewSlice(append([]Scmer(nil), args...))
+			return body(en)
 		}
 	}
-	return func(args ...Scmer) Scmer {
-		return Eval(p.Body, en)
+	return func(args []Scmer) Scmer {
+		return body(en)
 	}
 }
 

--- a/scm/serial_expr.go
+++ b/scm/serial_expr.go
@@ -1,0 +1,181 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+// serialExpr is the small prepared-expression layer between callback shape
+// recognition and the future fused JIT. It compiles structure once while
+// preserving Eval as the compatibility implementation for uncommon forms.
+// Every native call node owns its argument frame; instances are serial and
+// must never be shared between physical workers.
+type serialExpr func(*Env) Scmer
+
+// serialCallFrames owns the nested variadic argument arrays used by one
+// serially executed callback. A frame is acquired before evaluating operands,
+// so recursive calls naturally use the next depth. Native declarations which
+// retain their argument array deliberately bypass this storage.
+type serialCallFrames struct {
+	frames [][]Scmer
+	depth  int
+}
+
+func (s *serialCallFrames) acquire(size int) []Scmer {
+	depth := s.depth
+	s.depth++
+	if depth == len(s.frames) {
+		s.frames = append(s.frames, make([]Scmer, size))
+	} else if cap(s.frames[depth]) < size {
+		s.frames[depth] = make([]Scmer, size)
+	}
+	return s.frames[depth][:size]
+}
+
+func (s *serialCallFrames) release() {
+	s.depth--
+}
+
+func prepareSerialExpr(proc *Proc, expression Scmer) serialExpr {
+	expression = serialProcBody(expression)
+	if expression.IsNthLocalVar() {
+		index := int(expression.NthLocalVar())
+		return func(en *Env) Scmer { return en.VarsNumbered[index] }
+	}
+	if !expression.IsSlice() {
+		if expression.IsSymbol() {
+			symbol := mustSymbol(expression)
+			return func(en *Env) Scmer {
+				if binding := en.FindRead(symbol); binding != nil {
+					if value, ok := binding.Vars[symbol]; ok {
+						return value
+					}
+				}
+				return NewNil()
+			}
+		}
+		return func(*Env) Scmer { return expression }
+	}
+
+	items := expression.Slice()
+	if len(items) == 0 {
+		return func(*Env) Scmer { return expression }
+	}
+	if items[0].IsSymbol() {
+		// These control forms intentionally mirror Eval's short-circuit and SQL
+		// NULL semantics. Keep both implementations in sync; every other form
+		// falls through to Eval instead of growing a second interpreter here.
+		switch items[0].String() {
+		case "quote":
+			value := items[1]
+			return func(*Env) Scmer { return value }
+		case "and":
+			operands := prepareSerialOperands(proc, items[1:])
+			return func(en *Env) Scmer {
+				unknown := false
+				for _, operand := range operands {
+					value := operand(en)
+					if value.IsNil() {
+						unknown = true
+					} else if !value.Bool() {
+						return NewBool(false)
+					}
+				}
+				if unknown {
+					return NewNil()
+				}
+				return NewBool(true)
+			}
+		case "or":
+			operands := prepareSerialOperands(proc, items[1:])
+			return func(en *Env) Scmer {
+				unknown := false
+				for _, operand := range operands {
+					value := operand(en)
+					if value.IsNil() {
+						unknown = true
+					} else if value.Bool() {
+						return NewBool(true)
+					}
+				}
+				if unknown {
+					return NewNil()
+				}
+				return NewBool(false)
+			}
+		case "if":
+			operands := prepareSerialOperands(proc, items[1:])
+			return func(en *Env) Scmer {
+				i := 0
+				for i+1 < len(operands) {
+					if operands[i](en).Bool() {
+						return operands[i+1](en)
+					}
+					i += 2
+				}
+				if i < len(operands) {
+					return operands[i](en)
+				}
+				return NewNil()
+			}
+		case "coalesce", "coalesceNil":
+			operands := prepareSerialOperands(proc, items[1:])
+			coalesceNil := items[0].String() == "coalesceNil"
+			return func(en *Env) Scmer {
+				for i, operand := range operands {
+					value := operand(en)
+					if coalesceNil {
+						if !value.IsNil() {
+							return value
+						}
+					} else if i == len(operands)-1 || value.Bool() {
+						return value
+					}
+				}
+				return NewNil()
+			}
+		}
+	}
+
+	// Stable non-retaining natives can borrow a call-node-owned frame. A native
+	// such as list deliberately falls through to Eval, which supplies an owned
+	// frame because the result may retain it.
+	native, ok := serialProcResolveNative(proc, items[0])
+	if ok {
+		declaration := DeclarationForValue(native)
+		if declaration != nil && !declaration.RetainsCallArgs {
+			fn := native.Func()
+			operands := prepareSerialOperands(proc, items[1:])
+			frames := serialCallFrames{}
+			return func(en *Env) Scmer {
+				args := frames.acquire(len(operands))
+				defer frames.release()
+				for i, operand := range operands {
+					args[i] = operand(en)
+				}
+				return fn(args...)
+			}
+		}
+	}
+
+	return func(en *Env) Scmer { return Eval(expression, en) }
+}
+
+func prepareSerialOperands(proc *Proc, expressions []Scmer) []serialExpr {
+	result := make([]serialExpr, len(expressions))
+	for i, expression := range expressions {
+		result[i] = prepareSerialExpr(proc, expression)
+	}
+	return result
+}

--- a/scm/serial_proc.go
+++ b/scm/serial_proc.go
@@ -32,8 +32,9 @@ const (
 
 // SerialProc exposes trivial executable shapes to physical operators. Callers
 // retain the original procedure when analysis or serialization needs it; not
-// duplicating it here keeps every scan mapper compact. The value is immutable
-// after preparation. The general interpreter fallback remains serial.
+// duplicating it here keeps every scan mapper compact. General programs own a
+// mutable environment and call-frame stack; prepare one per serial worker and
+// do not copy or share it after execution starts.
 type SerialProc struct {
 	Kind     SerialProcKind
 	Value    Scmer // constant result or native-function identity
@@ -42,6 +43,7 @@ type SerialProc struct {
 	// binary native call represented by SerialProcNativeArgConstant.
 	ConstantFirst bool
 	Function      func(...Scmer) Scmer
+	borrowed      func([]Scmer) Scmer
 }
 
 func serialProcBody(v Scmer) Scmer {
@@ -149,6 +151,10 @@ func serialProcNativeArgConstant(proc *Proc, body Scmer) (native Scmer, argument
 	if !ok {
 		return NewNil(), 0, NewNil(), false, false
 	}
+	declaration := DeclarationForValue(native)
+	if declaration == nil || declaration.RetainsCallArgs {
+		return NewNil(), 0, NewNil(), false, false
+	}
 	if argument, ok = serialProcArgumentIndex(proc, call[1]); ok {
 		if constant, ok = serialProcLiteral(call[2]); ok {
 			return native, argument, constant, false, true
@@ -198,7 +204,7 @@ func PrepareSerialProc(source Scmer) SerialProc {
 	// classifying that body could silently bypass code generation semantics.
 	if proc.Compiled != nil {
 		prepared.Kind = SerialProcGeneral
-		prepared.Function = OptimizeProcToSerialFunction(source)
+		prepared.borrowed = optimizeProcToSerialBorrowed(source)
 		return prepared
 	}
 	body := serialProcBody(proc.Body)
@@ -244,12 +250,13 @@ func PrepareSerialProc(source Scmer) SerialProc {
 	}
 
 	prepared.Kind = SerialProcGeneral
-	prepared.Function = OptimizeProcToSerialFunction(source)
+	prepared.borrowed = optimizeProcToSerialBorrowed(source)
 	return prepared
 }
 
-// Call evaluates a prepared callback. Hot physical loops should instead
-// dispatch once on Kind and use the corresponding fields directly.
+// Call evaluates a prepared callback with a caller-owned argument frame. Hot
+// physical loops should dispatch dominant simple Kinds once; compound programs
+// use Call so the prepared expression can reuse its nested native-call frames.
 func (p *SerialProc) Call(args []Scmer) Scmer {
 	switch p.Kind {
 	case SerialProcConstant:
@@ -267,7 +274,7 @@ func (p *SerialProc) Call(args []Scmer) Scmer {
 		}
 		return p.Function(call[:]...)
 	default:
-		return p.Function(args...)
+		return p.borrowed(args)
 	}
 }
 

--- a/scm/window.go
+++ b/scm/window.go
@@ -131,8 +131,10 @@ func init_window() {
 			if limit == 0 {
 				return result
 			}
-			reduceFn := OptimizeProcToSerialFunction(a[2])
-			producerFn := OptimizeProcToSerialFunction(a[4])
+			reduceProgram := PrepareSerialProc(a[2])
+			producerProgram := PrepareSerialProc(a[4])
+			var reduceArgs [2]Scmer
+			var producerArgs [1]Scmer
 			seen := 0
 			emitted := 0
 			emit := NewFunc(func(values ...Scmer) Scmer {
@@ -146,11 +148,13 @@ func init_window() {
 				if limit >= 0 && emitted >= limit {
 					return result
 				}
-				result = reduceFn(result, values[0])
+				reduceArgs[0], reduceArgs[1] = result, values[0]
+				result = reduceProgram.Call(reduceArgs[:])
 				emitted++
 				return result
 			})
-			producerFn(emit)
+			producerArgs[0] = emit
+			producerProgram.Call(producerArgs[:])
 			return result
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "applies OFFSET/LIMIT and a serial reducer to complete values emitted by a nested streaming producer without collecting an intermediate relation",

--- a/storage/compute_proxy.go
+++ b/storage/compute_proxy.go
@@ -653,7 +653,7 @@ func (p *StorageComputeProxy) compressVariant(v *storageComputeVariant, tx *TxCo
 }
 
 func (p *StorageComputeProxy) compressFilteredVariant(v *storageComputeVariant, tx *TxContext, filterCols []string, filter scm.Scmer) {
-	filterFn := scm.OptimizeProcToSerialFunction(filter)
+	filterProgram := scm.PrepareSerialProc(filter)
 	filterReaders := make([]ColumnReader, len(filterCols))
 	for i, col := range filterCols {
 		filterReaders[i] = ColumnReaderFunc(p.shard.ColumnReaderTx(tx, col))
@@ -672,7 +672,7 @@ func (p *StorageComputeProxy) compressFilteredVariant(v *storageComputeVariant, 
 			for j := range filterReaders {
 				filterValues[j] = filterReaders[j].GetValue(i)
 			}
-			if scm.ToBool(filterFn(filterValues...)) {
+			if scm.ToBool(filterProgram.Call(filterValues)) {
 				for j := range readers {
 					colvalues[j] = readers[j].GetValue(i)
 				}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -500,10 +500,6 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -602,7 +598,7 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 				}
 			}
 		}
-		return scm.ToBool(conditionFn(cdataset...))
+		return scm.ToBool(conditionProgram.Call(cdataset))
 	}
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
@@ -1472,10 +1468,6 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
@@ -1566,7 +1558,7 @@ func (t *storageShard) filterRecSetPart(owner *recSet, part *recSetShard, condit
 				}
 			}
 		}
-		builder.add(idx, scm.ToBool(conditionFn(cdataset...)))
+		builder.add(idx, scm.ToBool(conditionProgram.Call(cdataset)))
 	}
 	evaluateBatch := func(batch []uint32) bool {
 		for _, idx := range batch {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -816,7 +816,7 @@ func (t *storageShard) filterVisibleScanBatch(batch []uint32, visibleUpper uint3
 	return outN
 }
 
-func (t *storageShard) filterConditionScanBatch(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, cdataset []scm.Scmer, conditionFn func(...scm.Scmer) scm.Scmer) int {
+func (t *storageShard) filterConditionScanBatch(batch []uint32, conditionCols []string, ccols []ColumnStorage, cReaders []ColumnReader, conditionGetters []mapArgGetter, cdataset []scm.Scmer, condition *scm.SerialProc) int {
 	outN := 0
 	for _, effectiveIdx := range batch {
 		if effectiveIdx < t.main_count {
@@ -838,7 +838,7 @@ func (t *storageShard) filterConditionScanBatch(batch []uint32, conditionCols []
 				}
 			}
 		}
-		if !scm.ToBool(conditionFn(cdataset...)) {
+		if !scm.ToBool(condition.Call(cdataset)) {
 			continue
 		}
 		batch[outN] = effectiveIdx
@@ -920,10 +920,6 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 	}
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
@@ -1066,7 +1062,7 @@ func (t *storageShard) scanFirstRecord(boundaries boundaries, lower []scm.Scmer,
 					}
 				}
 			}
-			if scm.ToBool(conditionFn(cdataset...)) {
+			if scm.ToBool(conditionProgram.Call(cdataset)) {
 				found = true
 				foundID = idx
 				return false
@@ -1091,10 +1087,6 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -1287,7 +1279,7 @@ func (t *storageShard) scan(boundaries boundaries, lower []scm.Scmer, upperLast 
 			if conditionProgram.Kind == scm.SerialProcNativeArgConstant {
 				outN = t.filterNativeArgConstantScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, &conditionProgram)
 			} else {
-				outN = t.filterConditionScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, conditionFn)
+				outN = t.filterConditionScanBatch(batch[:outN], conditionCols, ccols, cReaders, conditionGetters, cdataset, &conditionProgram)
 			}
 		}
 		if outN > 0 {
@@ -1431,10 +1423,6 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {
@@ -1592,7 +1580,7 @@ func (t *storageShard) scanBatch(boundaries boundaries, lower []scm.Scmer, upper
 							}
 						}
 					}
-					if !scm.ToBool(conditionFn(cdataset...)) {
+					if !scm.ToBool(conditionProgram.Call(cdataset)) {
 						continue
 					}
 					batch[filteredN] = effectiveIdx

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -993,10 +993,13 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 	if !hadValue && isOuter && len(tables) > 0 {
 		cbCols := tables[0].callbackCols
 		cb := tables[0].callback
-		callbackFn := scm.OptimizeProcToSerialFunction(cb)
-		aggregateFn := scm.OptimizeProcToSerialFunction(aggregate)
+		callbackProgram := scm.PrepareSerialProc(cb)
+		aggregateProgram := scm.PrepareSerialProc(aggregate)
 		nullRow := buildOuterNullCallbackRow(cbCols)
-		akkumulator = aggregateFn(akkumulator, callbackFn(nullRow...))
+		var aggregateArgs [2]scm.Scmer
+		aggregateArgs[0] = akkumulator
+		aggregateArgs[1] = callbackProgram.Call(nullRow)
+		akkumulator = aggregateProgram.Call(aggregateArgs[:])
 	}
 	if !hadValue && !isOuter {
 		akkumulator = notFoundValue
@@ -1169,10 +1172,6 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
-	var conditionFn func(...scm.Scmer) scm.Scmer
-	if !conditionAlwaysTrue && conditionProgram.Kind != scm.SerialProcNativeArgConstant {
-		conditionFn = scm.OptimizeProcToSerialFunction(condition)
-	}
 	var acceptProgram *scm.SerialProc
 	if !accept.IsNil() {
 		prepared := scm.PrepareSerialProc(accept)
@@ -1224,13 +1223,13 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 					largs[j] = t.ColumnReaderTx(currentTx, name)
 				}
 			}
-			procFn := scm.OptimizeProcToSerialFunction(scol)
+			procFn := scm.PrepareSerialProc(scol)
+			vals := make([]scm.Scmer, len(largs))
 			result.scols[i] = func(idx uint32) scm.Scmer {
-				vals := make([]scm.Scmer, len(largs))
 				for j, getter := range largs {
 					vals[j] = getter(idx)
 				}
-				return procFn(vals...)
+				return procFn.Call(vals)
 			}
 			continue
 		}
@@ -1428,7 +1427,7 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 								}
 							}
 						}
-						if !scm.ToBool(conditionFn(cdataset...)) {
+						if !scm.ToBool(conditionProgram.Call(cdataset)) {
 							continue
 						}
 						batch[outN] = idx

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -278,14 +278,18 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 	hadValue := false
 	if limit == 0 {
 		if isOuter {
-			callbackFn := scm.OptimizeProcToSerialFunction(callback)
-			reduceFn := scm.OptimizeProcToSerialFunction(aggregate)
-			return reduceFn(result, callbackFn(buildOuterNullCallbackRow(callbackCols)...))
+			callbackProgram := scm.PrepareSerialProc(callback)
+			reduceProgram := scm.PrepareSerialProc(aggregate)
+			var reduceArgs [2]scm.Scmer
+			reduceArgs[0] = result
+			reduceArgs[1] = callbackProgram.Call(buildOuterNullCallbackRow(callbackCols))
+			return reduceProgram.Call(reduceArgs[:])
 		}
 		return notFoundValue
 	}
 
-	filterFn := scm.OptimizeProcToSerialFunction(batchFilter)
+	filterProgram := scm.PrepareSerialProc(batchFilter)
+	var filterArgs [1]scm.Scmer
 	mappers := make(map[*storageShard]*ShardMapReducer)
 	defer func() {
 		for _, mapper := range mappers {
@@ -321,7 +325,8 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 		if len(records) == 0 {
 			break
 		}
-		accepted := validateAcceptedBatch(currentTx, batch, filterFn(NewRecSetScmer(batch)))
+		filterArgs[0] = NewRecSetScmer(batch)
+		accepted := validateAcceptedBatch(currentTx, batch, filterProgram.Call(filterArgs[:]))
 
 		var pendingShard *storageShard
 		pending := make([]uint32, 0, len(records))
@@ -377,9 +382,12 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 	}
 
 	if !hadValue && isOuter {
-		callbackFn := scm.OptimizeProcToSerialFunction(callback)
-		reduceFn := scm.OptimizeProcToSerialFunction(aggregate)
-		result = reduceFn(result, callbackFn(buildOuterNullCallbackRow(callbackCols)...))
+		callbackProgram := scm.PrepareSerialProc(callback)
+		reduceProgram := scm.PrepareSerialProc(aggregate)
+		var reduceArgs [2]scm.Scmer
+		reduceArgs[0] = result
+		reduceArgs[1] = callbackProgram.Call(buildOuterNullCallbackRow(callbackCols))
+		result = reduceProgram.Call(reduceArgs[:])
 		hadValue = true
 	}
 	if !hadValue && !isOuter {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2972,7 +2972,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		}
 	}
 
-	conditionFn := scm.OptimizeProcToSerialFunction(condition)
+	conditionProgram := scm.PrepareSerialProc(condition)
 
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -3034,7 +3034,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 					}
 				}
 			}
-			if scm.ToBool(conditionFn(cdataset...)) {
+			if scm.ToBool(conditionProgram.Call(cdataset)) {
 				count++
 				if count >= int64(limit) {
 					capped = true

--- a/tests/sql/expressions/case-coalesce-nullif.yaml
+++ b/tests/sql/expressions/case-coalesce-nullif.yaml
@@ -56,6 +56,19 @@ test_cases:
         - id: 1
         - id: 7
 
+  - name: "Nested boolean scan callback preserves SQL NULL truth semantics"
+    sql: |
+      SELECT id FROM ccn_data
+      WHERE (amount > 40 AND amount < 250 AND (status = 1 OR category = 'B'))
+         OR (amount IS NULL AND status IS NULL)
+      ORDER BY id
+    expect:
+      rows: 3
+      data:
+        - id: 1
+        - id: 2
+        - id: 8
+
   - name: "EXPLAIN hoists invariant CASE dispatch outside scan filter"
     session_id: "ccn_invariant_filter"
     sql: |


### PR DESCRIPTION
## What

Replace the general variadic scan-callback adapter with a prepared serial executor that accepts caller-owned `[]Scmer` frames.

- preserve the dominant constant, argument, identity-map, native reducer, and native-argument/constant specializations from #645
- prepare compound `AND`/`OR`/`IF`/`COALESCE` expressions once, with the same SQL NULL and short-circuit semantics as `Eval`
- give each non-retaining native call node reusable frames; retaining natives continue through the owned-frame compatibility path
- use `SerialProc` throughout scan, scan batch, ordered scan, RecSet filtering, batch accept, filtered compute compression, selectivity sampling, and streaming windows
- use allocation-free complete function identity for declaration lookup instead of formatting pointers
- keep ownership local to a serial shard/worker; no mutable frame arena crosses nested or parallel callback boundaries

This does not alter logical planning, operator selection, cost weights, or query-plan serialization. `OptimizeProcToSerialFunction` remains only as a compatibility adapter; physical hot paths use `PrepareSerialProc`.

## A/B benchmark

Existing `BenchmarkScanFilterExpressionCost`, 60,000 rows, distinct filter columns, median steady-state runs on the same machine:

| filter shape | master | patch | allocations master | allocations patch |
|---|---:|---:|---:|---:|
| 2 terms | 34.30 ms | 8.86 ms | 720,956 | 75 |
| 16 terms | 216.58 ms | 35.34 ms | 5,308,524 | 275 |

That is about 3.9x and 6.1x faster while removing effectively all row-proportional allocations.

The fixed-cost benchmarks retain the master allocation counts: scan 13, filtered scan 15, exists 8, ordered scan 32, ordered RecSet scan 52, and sum 14 allocations/op.

## Correctness and validation

Added a permanent SQL test for nested `AND`/`OR` comparisons with NULL truth values. During validation, the broad correlated-scalar suite exposed an unsafe prototype that shared a frame arena into nested parallel callbacks; that design was removed. The final ownership model passes:

- `go test ./scm ./storage -run SerialProc|Declaration|Scan|RecSet|Order|Window|Index|Compute -count=1`
- `tests/sql/expressions/case-coalesce-nullif.yaml` (35/35)
- `tests/execution/operators/recset.yaml` (34/34)
- `tests/execution/operators/scan-order-native-limit.yaml` (11/11)
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml` (23/23)
- `tests/planner/order-window/window-functions.yaml` (54/54)

The complete suite is left to CI as requested.