### PR TITLE
Cost ordered joins with live lookup projections

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1895,11 +1895,11 @@ physical decision: the logical window-stage remains independent of scan/ORC. */
 (define replace_window_offset_expr (lambda (src replacements expr)
 	(match expr
 		((symbol get_column) tblvar tbl_ignorecase column col_ignorecase)
-			(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
-				(qassoc_get replacements column expr) expr)
+		(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+			(qassoc_get replacements column expr) expr)
 		((quote get_column) tblvar tbl_ignorecase column col_ignorecase)
-			(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
-				(qassoc_get replacements column expr) expr)
+		(if (source_alias_matches? src (source_alias src) tblvar tbl_ignorecase)
+			(qassoc_get replacements column expr) expr)
 		(cons head tail) (cons head (map tail (lambda (item)
 			(replace_window_offset_expr src replacements item))))
 		_ expr)))
@@ -4488,6 +4488,16 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 						(table (source_schema src) (source_relation src)) col))))
 			_ nil))))
 
+(define ordered_join_lookup_values_required? (lambda (remaining_sources default_alias output_exprs order_items)
+	(if (empty_list? remaining_sources)
+		false
+		(begin
+			(define lookup_alias (source_alias (car remaining_sources)))
+			(or (reduce output_exprs (lambda (found expr)
+				(or found (expr_refs_alias? default_alias lookup_alias expr))) false)
+				(reduce order_items (lambda (found item)
+					(or found (expr_refs_alias? default_alias lookup_alias item))) false))))))
+
 (define ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition order_items offset limit)
 	(if (or (not (single_source? remaining_sources))
 		(or (source_outer? src) (source_outer? (car remaining_sources))))
@@ -4939,9 +4949,9 @@ until the caller has selected this physical alternative. */
 		column reaches projection, the lookup is semantically dead after the carrier
 		is built. Keeping it would repeat the filtered relation scan for each Top-K
 		row even though the projected RecSet already proved existence. */
-		(define projected_join_lookup_output_required (reduce output_exprs (lambda (found expr)
-			(or found (expr_refs_alias? default_alias
-				(source_alias (car remaining_sources)) expr))) false))
+		(define projected_join_lookup_output_required
+			(ordered_join_lookup_values_required?
+				remaining_sources default_alias output_exprs remaining_order_items))
 		(define projected_join_projection_elidable (and projected_join_exact
 			(and (empty_list? remaining_order_items)
 				(not projected_join_lookup_output_required))))
@@ -5187,6 +5197,9 @@ until the caller has selected this physical alternative. */
 				driver cardinality; otherwise the complete ordered input remains live. */
 				(define legacy_probe_rows (if (nil? projected_legacy_cost)
 					driver_input_rows (cadr projected_legacy_cost)))
+				(define legacy_lookup_values_required
+					(ordered_join_lookup_values_required?
+						(cdr sources) default_alias output_exprs order_items))
 				(define legacy_base_cost (if (nil? projected_legacy_cost)
 					/* The DP join cost does not include the ordered root scan that this
 					lowerer adds. Use Costgen's scan_order invocation calibration; a
@@ -5197,7 +5210,13 @@ until the caller has selected this physical alternative. */
 						legacy_probe_rows 0.65)
 					(car projected_legacy_cost)))
 				(define legacy_cost (planner_cost_add legacy_base_cost
-					(planner_join_work_cost legacy_probe_rows 0.65)
+					/* Each surviving ordered-driver row starts the complete downstream
+					lookup pipeline. Price that physical scan boundary with Costgen's
+					generated probe coefficient only when lookup values remain live.
+					An exact carrier-only projection has no downstream scan to charge. */
+					(if (or (nil? projected_legacy_cost) legacy_lookup_values_required)
+						(planner_membership_downstream_probe_cost legacy_probe_rows)
+						(planner_cost 0 0 0 0 0 0 0 0 0 0.65))
 					(coalesceNil joined_rows legacy_probe_rows) 0.65))
 				(define normal_choice (if (planner_cost_better? scan_cost legacy_cost)
 					"scan_join_order" "legacy_join_tree"))

--- a/tests/performance/reddit-mysql-order-limit-join.yaml
+++ b/tests/performance/reddit-mysql-order-limit-join.yaml
@@ -28,12 +28,16 @@ setup:
   - scm: "(rebuild)"
 
 test_cases:
-  # A/B on the original-scale fixture, warm runs on the reference host:
-  # automatic SQL median 597 ms; handwritten scan_join_order median 465 ms;
-  # prebuilt filtered-account keyset plus ordered batch median 616 ms.
+  # A/B on the original-scale fixture with identical six-column output and
+  # result hashes, warm PR-647 runs on the reference host: forced legacy join
+  # median 682 ms; forced scan_join_order median 514 ms; automatic 523 ms.
   - name: "Reddit MySQL original query"
+    physical_calibration: true
+    calibration_holdout: true
+    calibration_decision: "scan_join_order"
+    warmup: 1
+    repetitions: 5
     threshold_ms: 180000
-    timing_samples: 5
     sql: |
       SELECT t.*, a.*
       FROM reddit_mysql_test2 t
@@ -61,6 +65,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
+        - "chosen scan_join_order"
         - "scan_join_order"
         - "legacy_join_tree"
         - "lowest_total_ns"

--- a/tests/performance/reddit-mysql-order-limit-join.yaml
+++ b/tests/performance/reddit-mysql-order-limit-join.yaml
@@ -1,0 +1,92 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Reproduction of https://www.reddit.com/r/mysql/comments/fl03ml/filesort_fixedadded_when_addingremoving_2_bits_of/
+# at the cardinalities stated in the post. The fixture retains MemCP's default
+# shard size and delegates physical partitioning to rebuild.
+
+metadata:
+  version: "1.0"
+  description: "Reddit MySQL ordered filtered join at original cardinality"
+  isolated: true
+  ci: false
+
+setup:
+  - sql: "DROP TABLE IF EXISTS reddit_mysql_test2"
+  - sql: "DROP TABLE IF EXISTS reddit_mysql_account"
+  - sql: "CREATE TABLE reddit_mysql_account (id INT PRIMARY KEY, age INT, gender VARCHAR(8)) ENGINE=memory"
+  - sql: "CREATE TABLE reddit_mysql_test2 (id INT PRIMARY KEY, account_id INT, active BOOLEAN) ENGINE=memory"
+  - scm: |
+      (insert (table "memcp-tests" "reddit_mysql_account") '("id" "age" "gender")
+        (map (produceN 700000) (lambda (i)
+          (list (+ i 1) (+ 10 (mod i 80))
+            (if (equal? (mod i 2) 0) "MALE" "FEMALE")))))
+  - scm: |
+      (insert (table "memcp-tests" "reddit_mysql_test2") '("id" "account_id" "active")
+        (map (produceN 1000000) (lambda (i)
+          (list (+ i 1) (+ 1 (mod i 700000))
+            (not (equal? (mod i 3) 0))))))
+  - scm: "(rebuild)"
+
+test_cases:
+  # A/B on the original-scale fixture, warm runs on the reference host:
+  # automatic SQL median 597 ms; handwritten scan_join_order median 465 ms;
+  # prebuilt filtered-account keyset plus ordered batch median 616 ms.
+  - name: "Reddit MySQL original query"
+    threshold_ms: 180000
+    timing_samples: 5
+    sql: |
+      SELECT t.*, a.*
+      FROM reddit_mysql_test2 t
+      JOIN reddit_mysql_account a ON t.account_id = a.id
+      WHERE t.id > 0
+        AND t.active = TRUE
+        AND a.age BETWEEN 18 AND 80
+        AND a.gender = 'MALE'
+      ORDER BY t.id DESC
+      LIMIT 20
+    expect: {rows: 20}
+
+  - name: "Reddit MySQL plan costs both ordered join strategies"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT t.*, a.*
+      FROM reddit_mysql_test2 t
+      JOIN reddit_mysql_account a ON t.account_id = a.id
+      WHERE t.id > 0
+        AND t.active = TRUE
+        AND a.age BETWEEN 18 AND 80
+        AND a.gender = 'MALE'
+      ORDER BY t.id DESC
+      LIMIT 20
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_join_order"
+        - "legacy_join_tree"
+        - "lowest_total_ns"
+
+  - name: "Reddit MySQL handwritten scan_join_order"
+    timing_samples: 5
+    scm: |
+      (begin
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list
+              (table "memcp-tests" "reddit_mysql_test2")
+              (table "memcp-tests" "reddit_mysql_account"))
+            (list (list "id" "active") (list "age" "gender"))
+            (list
+              (lambda (id active) (and (> id 0) (equal? active true)))
+              (lambda (age gender)
+                (and (and (>= age 18) (<= age 80)) (equal? gender "MALE"))))
+            (list (list (list 0 "account_id" "id")))
+            (list) nil
+            (list (list 0 "id")) (list >)
+            0 0 20
+            (list (list 0 "id"))
+            (lambda (_id) 1) + 0))
+        (if (equal? found 20) "ok" (error "wrong scan_join_order row count")))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS reddit_mysql_test2"
+  - sql: "DROP TABLE IF EXISTS reddit_mysql_account"


### PR DESCRIPTION
Adds the original-cardinality Reddit MySQL ORDER BY/LIMIT join as a non-CI physical calibration workload and fixes the scan_join_order versus legacy-tree comparison.

The legacy lowerer already knows when an exact projected carrier makes the lookup semantically dead. Its cost now uses Costgen's generated downstream-probe coefficient only when lookup columns or lookup ordering remain live; carrier-only plans keep their existing complete carrier cost.

A/B on 1,000,000 test2 rows and 700,000 account rows with identical six-column output and matching result hashes, on the combined PR 647 code:
- forced legacy_join_tree median: 682 ms
- forced scan_join_order median: 514 ms
- automatic plan after the fix: scan_join_order, 523 ms warm median

Regression check: the SO 73024688 carrier-only query still exposes and selects its partition-pruned ordered_batch_accept path.

Targeted verification:
- go test ./tools/costgen
- go test ./storage -run 'ScanJoinOrder|ScanOrderBatchAccept' -count=1
- tests/performance/stackoverflow-query-shapes.yaml: 15/15
- Scheme formatter run; existing repository-wide negative-depth warnings unchanged

The full suite is left to CI as requested.