### PR TITLE
Optimize dynamic substring joins

### DIFF
--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -1202,12 +1202,22 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* Locking reads are accepted for MySQL compatibility. MemCP's
 		transaction layer owns visibility and write serialization. */
 		(? (atom "FOR" true) (atom "UPDATE" true))
-	) (list (quote query-block) schema (if (nil? from) '() (merge from)) (merge cols) condition
-			(if distinct (extract_assoc (merge cols) (lambda (_title expr) expr)) group)
-			having order limit offset '() '()
-			(merge (list
-				(if calc_found_rows (list (list (quote sql_calc_found_rows) true)) '())
-				(if distinct (list (list (quote select_distinct) true)) '()))))))
+	) (begin
+			(define projected_exprs (extract_assoc (merge cols) (lambda (_title expr) expr)))
+			/* GROUP BY already makes the result unique when every grouping key is
+			projected. Preserve that explicit group instead of replacing it with the
+			DISTINCT projection (which may contain aggregate expressions). */
+			(define distinct_preserved_by_group (and distinct
+				(and (not (nil? group))
+					(and (not (empty_list? group))
+						(reduce group (lambda (preserved expr)
+							(and preserved (contains? projected_exprs expr))) true)))))
+			(list (quote query-block) schema (if (nil? from) '() (merge from)) (merge cols) condition
+				(if (and distinct (not distinct_preserved_by_group)) projected_exprs group)
+				having order limit offset '() '()
+				(merge (list
+					(if calc_found_rows (list (list (quote sql_calc_found_rows) true)) '())
+					(if distinct (list (list (quote select_distinct) true)) '())))))))
 	(define sql_select (parser (or
 		(parser '(
 			(define left sql_select_core)

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -227,6 +227,91 @@ func likePatternNeedsCaseFold(pattern string) bool {
 	return false
 }
 
+func asciiFoldByte(value byte) byte {
+	if value >= 'A' && value <= 'Z' {
+		return value + ('a' - 'A')
+	}
+	return value
+}
+
+func asciiFoldEqual(left, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := 0; index < len(left); index++ {
+		if left[index] >= utf8.RuneSelf || right[index] >= utf8.RuneSelf || asciiFoldByte(left[index]) != asciiFoldByte(right[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiFoldContains(value, needle string) (bool, bool) {
+	if len(needle) > len(value) {
+		return false, true
+	}
+	for offset := 0; offset <= len(value)-len(needle); offset++ {
+		matched := true
+		for index := 0; index < len(needle); index++ {
+			left, right := value[offset+index], needle[index]
+			if left >= utf8.RuneSelf || right >= utf8.RuneSelf {
+				return false, false
+			}
+			if asciiFoldByte(left) != asciiFoldByte(right) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// strLikeASCIIFold handles the exact/prefix/suffix/contains forms emitted by
+// ordinary SQL predicates without allocating lower-cased copies per row. The
+// second return value is false whenever Unicode or general wildcard matching
+// must retain the canonical StrLikeFold path.
+func strLikeASCIIFold(value, pattern string) (bool, bool) {
+	if strings.ContainsAny(pattern, "_\\\\") {
+		return false, false
+	}
+	wildcards := strings.Count(pattern, "%")
+	switch {
+	case wildcards == 0:
+		for index := 0; index < len(value); index++ {
+			if value[index] >= utf8.RuneSelf {
+				return false, false
+			}
+		}
+		for index := 0; index < len(pattern); index++ {
+			if pattern[index] >= utf8.RuneSelf {
+				return false, false
+			}
+		}
+		return asciiFoldEqual(value, pattern), true
+	case wildcards == 1 && len(pattern) > 0 && pattern[0] == '%':
+		needle := pattern[1:]
+		if len(needle) > len(value) {
+			return false, true
+		}
+		matched, ascii := asciiFoldContains(value[len(value)-len(needle):], needle)
+		return matched, ascii
+	case wildcards == 1 && len(pattern) > 0 && pattern[len(pattern)-1] == '%':
+		needle := pattern[:len(pattern)-1]
+		if len(needle) > len(value) {
+			return false, true
+		}
+		matched, ascii := asciiFoldContains(value[:len(needle)], needle)
+		return matched, ascii
+	case wildcards == 2 && len(pattern) >= 2 && pattern[0] == '%' && pattern[len(pattern)-1] == '%':
+		return asciiFoldContains(value, pattern[1:len(pattern)-1])
+	default:
+		return false, false
+	}
+}
+
 // StrLikeCollation is the canonical LIKE implementation shared by the Scheme
 // builtin and storage match indexes. Keeping both paths here guarantees that an
 // exact cached match set has the same case semantics as residual evaluation.
@@ -237,6 +322,9 @@ func StrLikeCollation(str, pattern, collation string) bool {
 		// Keep '_' on the folded path because folding may change its byte width.
 		if !likePatternNeedsCaseFold(pattern) {
 			return StrLike(str, pattern)
+		}
+		if matched, handled := strLikeASCIIFold(str, pattern); handled {
+			return matched
 		}
 		return StrLikeFold(str, pattern)
 	}

--- a/scm/strings_test.go
+++ b/scm/strings_test.go
@@ -47,6 +47,56 @@ func TestStrLikeCollationUncasedPattern(t *testing.T) {
 	}
 }
 
+func TestStrLikeCollationASCIIFastPaths(t *testing.T) {
+	tests := []struct {
+		value   string
+		pattern string
+		want    bool
+	}{
+		{"A,C", "%a%", true},
+		{"A,C", "%b%", false},
+		{"Alpha", "a%", true},
+		{"Alpha", "%HA", true},
+		{"Alpha", "ALPHA", true},
+		{"Straße", "%STRASSE%", false},
+		{"Straße", "%straße%", true},
+	}
+	for _, test := range tests {
+		if got := StrLikeCollation(test.value, test.pattern, "utf8mb4_general_ci"); got != test.want {
+			t.Errorf("StrLikeCollation(%q, %q) = %v, want %v", test.value, test.pattern, got, test.want)
+		}
+	}
+}
+
+func TestStrLikeCollationASCIIFastPathAllocations(t *testing.T) {
+	allocations := testing.AllocsPerRun(1000, func() {
+		if !StrLikeCollation("A,C", "%a%", "utf8mb4_general_ci") {
+			t.Fatal("ASCII contains pattern should match")
+		}
+	})
+	if allocations != 0 {
+		t.Fatalf("ASCII contains LIKE allocated %.2f objects per call, want 0", allocations)
+	}
+}
+
+func BenchmarkStrLikeCollationDynamicCategory(b *testing.B) {
+	b.ReportAllocs()
+	for index := 0; index < b.N; index++ {
+		if !StrLikeCollation("A,C", "%a%", "utf8mb4_general_ci") {
+			b.Fatal("ASCII contains pattern should match")
+		}
+	}
+}
+
+func BenchmarkStrLikeCollationDynamicCategoryLegacy(b *testing.B) {
+	b.ReportAllocs()
+	for index := 0; index < b.N; index++ {
+		if !StrLikeFold("A,C", "%a%") {
+			b.Fatal("ASCII contains pattern should match")
+		}
+	}
+}
+
 func TestStrLikeEscapedWildcards(t *testing.T) {
 	if !StrLike("_transient_sample", `\_transient\_%`) {
 		t.Fatal("escaped underscores should match literal underscores")

--- a/tests/performance/dynamic-substring-union-join.yaml
+++ b/tests/performance/dynamic-substring-union-join.yaml
@@ -1,0 +1,226 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# Reproduction of https://www.reddit.com/r/mysql/comments/1r88gsz/query_performance_issue/
+# The 1:10 development fixture preserves the reported distinct counts and
+# selectivities. The original-scale measurements use the same formulas with
+# 6,000,000 transactions and are intentionally kept outside CI.
+
+metadata:
+  version: "1.0"
+  description: "Dynamic substring join and repeated UNION scans"
+  isolated: true
+  ci: false
+
+setup:
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_risk_checks"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_v2"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_v1"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_all"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_transactions"
+  - sql: "CREATE TABLE dynamic_substring_transactions (id INT PRIMARY KEY, instruction_id INT, batch_id INT, entity_id VARCHAR(16), timestamp_seg BIGINT, category_code VARCHAR(4)) ENGINE=sloppy"
+  - sql: "CREATE TABLE dynamic_substring_config_v1 (id INT PRIMARY KEY, unit_id INT, instruction_id INT, cat_list VARCHAR(32), hold_cat_list VARCHAR(32), job_expression VARCHAR(32)) ENGINE=sloppy"
+  - sql: "CREATE TABLE dynamic_substring_config_v2 (id INT PRIMARY KEY, unit_id INT, instruction_id INT, cat_list VARCHAR(32), hold_cat_list VARCHAR(32), job_expression VARCHAR(32)) ENGINE=sloppy"
+  - sql: "CREATE TABLE dynamic_substring_config_all (id INT PRIMARY KEY, unit_id INT, instruction_id INT, cat_list VARCHAR(32), hold_cat_list VARCHAR(32), job_expression VARCHAR(32)) ENGINE=sloppy"
+  - sql: "CREATE TABLE dynamic_substring_risk_checks (instruction_id INT PRIMARY KEY, hold_flag INT) ENGINE=sloppy"
+  - scm: |
+      (map (produceN 6) (lambda (batch)
+        (insert (table "memcp-tests" "dynamic_substring_transactions")
+          '("id" "instruction_id" "batch_id" "entity_id" "timestamp_seg" "category_code")
+          (map (produceN 100000) (lambda (offset)
+            (begin
+              (define i (+ (* batch 100000) offset))
+              (list i
+                (mod i 18400)
+                (if (< i 100000) nil (mod i 150000))
+                (if (< i 500000) "E0756" (concat "E" (string (+ 1000 (mod i 192)))))
+                (mod i 21800)
+                (nth '("A" "B" "C" "D") (mod i 4)))))))))
+  - scm: |
+      (insert (table "memcp-tests" "dynamic_substring_config_v1")
+        '("id" "unit_id" "instruction_id" "cat_list" "hold_cat_list" "job_expression")
+        (map (produceN 44000) (lambda (i)
+          (list i (mod i 48) (mod i 18400)
+            (if (equal? (mod i 3) 0) "A,C" "B,D")
+            (if (equal? (mod i 5) 0) "A,B" "C,D")
+            (if (equal? (mod i 4) 0) "0 20 * * ? *" "other")))))
+  - scm: |
+      (insert (table "memcp-tests" "dynamic_substring_config_v2")
+        '("id" "unit_id" "instruction_id" "cat_list" "hold_cat_list" "job_expression")
+        (map (produceN 1000) (lambda (i)
+          (list i 100 (mod i 18400) "A,C" "B,D"
+            (if (equal? (mod i 2) 0) "0 20 * * ? *" "other")))))
+  - scm: |
+      (insert (table "memcp-tests" "dynamic_substring_config_all")
+        '("id" "unit_id" "instruction_id" "cat_list" "hold_cat_list" "job_expression")
+        (map (produceN 45000) (lambda (i)
+          (if (< i 44000)
+            (list i (mod i 48) (mod i 18400)
+              (if (equal? (mod i 3) 0) "A,C" "B,D")
+              (if (equal? (mod i 5) 0) "A,B" "C,D")
+              (if (equal? (mod i 4) 0) "0 20 * * ? *" "other"))
+            ((lambda (j)
+              (list i 100 (mod j 18400) "A,C" "B,D"
+                (if (equal? (mod j 2) 0) "0 20 * * ? *" "other")))
+              (- i 44000))))))
+  - scm: |
+      (insert (table "memcp-tests" "dynamic_substring_risk_checks")
+        '("instruction_id" "hold_flag")
+        (map (produceN 18400) (lambda (i)
+          (list i (if (equal? (mod i 40) 0) 0 1)))))
+  - scm: "(rebuild)"
+
+test_cases:
+  - name: "Dynamic substring join with grouping"
+    sql: |
+      SELECT DISTINCT
+        cfg.unit_id,
+        cfg.instruction_id,
+        cfg.cat_list,
+        cfg.hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_v1 cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 671
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+    expect: {rows: 214}
+
+  - name: "Dynamic substring joins across UNION branches"
+    warmup: 1
+    repetitions: 5
+    threshold_ms: 180000
+    sql: &original_query |
+      SELECT DISTINCT
+        cfg.unit_id,
+        cfg.instruction_id,
+        cfg.cat_list,
+        cfg.hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_v1 cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 671
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+      UNION
+      SELECT DISTINCT
+        cfg.unit_id,
+        cfg.instruction_id,
+        cfg.cat_list,
+        cfg.hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_v2 cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 671
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+    expect: {rows: 231}
+
+  - name: "Dynamic substring join with a unified relation"
+    warmup: 1
+    repetitions: 5
+    threshold_ms: 180000
+    sql: |
+      SELECT DISTINCT
+        cfg.unit_id,
+        cfg.instruction_id,
+        cfg.cat_list,
+        cfg.hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_all cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 671
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+    expect: {rows: 231}
+
+  - name: "Dynamic substring join with deterministic grouping"
+    warmup: 1
+    repetitions: 5
+    threshold_ms: 180000
+    sql: |
+      SELECT
+        cfg.unit_id,
+        MIN(cfg.instruction_id) AS instruction_id,
+        MIN(cfg.cat_list) AS cat_list,
+        MIN(cfg.hold_cat_list) AS hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_all cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 671
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+    expect: {rows: 7}
+
+  - name: "Dynamic substring join physical plan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT DISTINCT
+        cfg.unit_id,
+        cfg.instruction_id,
+        cfg.cat_list,
+        cfg.hold_cat_list,
+        MIN(txn.timestamp_seg) AS earliest_seg
+      FROM dynamic_substring_transactions txn
+      JOIN dynamic_substring_config_v1 cfg
+        ON cfg.instruction_id = txn.instruction_id
+      LEFT JOIN dynamic_substring_risk_checks rc
+        ON txn.instruction_id = rc.instruction_id
+      WHERE txn.timestamp_seg < 7
+        AND txn.batch_id IS NULL
+        AND txn.entity_id = 'E0756'
+        AND (cfg.cat_list LIKE CONCAT('%', txn.category_code, '%')
+          OR cfg.hold_cat_list LIKE CONCAT('%', txn.category_code, '%'))
+        AND cfg.job_expression = '0 20 * * ? *'
+        AND (rc.instruction_id IS NULL OR rc.hold_flag = 0)
+      GROUP BY cfg.unit_id
+    expect:
+      rows: 1
+      result_contains:
+        - "physical"
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_risk_checks"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_v2"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_v1"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_config_all"
+  - sql: "DROP TABLE IF EXISTS dynamic_substring_transactions"

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -171,6 +171,21 @@ test_cases:
           post_type: wp_template
           post_status: publish
 
+  - name: "DISTINCT preserves a projected GROUP BY key with aggregates"
+    sql: |
+      SELECT DISTINCT post_type, COUNT(*) AS posts
+      FROM wpcompat_posts
+      WHERE post_type IN ('post', 'wp_template')
+      GROUP BY post_type
+      ORDER BY post_type
+    expect:
+      rows: 2
+      data:
+        - post_type: post
+          posts: 3
+        - post_type: wp_template
+          posts: 1
+
   - name: "Grouping by a primary key permits every source column after a LEFT JOIN"
     sql: |
       SELECT wpcompat_posts.*


### PR DESCRIPTION
## Summary

- add a feature-named 600k-row performance fixture for dynamic substring joins, repeated UNION scans, and EXPLAIN coverage
- preserve an explicit GROUP BY when its projected keys already prove SELECT DISTINCT redundant, avoiding aggregate expressions as accidental grouping keys
- add allocation-free ASCII exact/prefix/suffix/contains LIKE paths while retaining the Unicode fallback
- document and measure the faster physical shape: unify equivalent config relations so the selective transaction driver runs once

No planner operator choice was changed. EXPLAIN/runtime statistics already select the batch_id, entity_id, timestamp_seg access path plus instruction_id probes. Therefore there is no new lowering alternative to calibrate in costgen; the larger gain comes from removing a repeated relational branch, not bypassing the cost model.

## A/B measurement

Default shard size, 600,000 transactions, 44,000 + 1,000 config rows, 18,400 risk rows, rebuilt columnar fixture:

- original two UNION branches: 726.8 ms
- unified config relation, identical 231-row result: 456.7 ms (-37.2%)
- unified relation with deterministic 7-group projection: 358.1 ms (-50.7%)

A separate warm median run measured 533.6 / 340.7 / 265.2 ms respectively.

ASCII dynamic LIKE microbenchmark, five 2-second samples:

- optimized: 46.5-51.3 ns/op, 0 B/op, 0 allocs/op
- legacy fold: 57.2-58.4 ns/op, 8 B/op, 1 alloc/op

## Validation

- mysql-application-sql.yaml: 40/40 passed
- dynamic-substring-union-join.yaml: 5/5 passed
- focused LIKE tests passed
- Go package tests for root and scm passed; full YAML matrix left to CI as requested