### PR TITLE
Optimize costed grouped hierarchy joins

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -49,17 +49,21 @@ jobs:
       - name: Measure base and candidate with the SQL test runner
         shell: bash
         run: |
-          runner="$GITHUB_WORKSPACE/base/run_sql_tests.py"
-          if ! grep -q 'PERF_AB_MODE' "$runner"; then
-            runner="$GITHUB_WORKSPACE/candidate/run_sql_tests.py"
-          fi
+          # The candidate runner defines the A/B protocol under review (including
+          # shared prepare/restart metadata); MEMCP_TEST_WORKTREE still supplies
+          # the exact binary and Scheme library for each measured side.
+          runner="$GITHUB_WORKSPACE/candidate/run_sql_tests.py"
           baseline="$GITHUB_WORKSPACE/perf-baseline.json"
           seed="$GITHUB_WORKSPACE/base/tests/performance/ci-workloads.json"
           if [ ! -f "$seed" ]; then
             seed="$GITHUB_WORKSPACE/candidate/tests/performance/ci-workloads.json"
           fi
 
-          (cd base && env \
+          # Discover YAMLs from the candidate for both sides. This makes newly
+          # added performance suites part of the A/B baseline without copying or
+          # running a separate fill workload; MEMCP_TEST_WORKTREE still selects
+          # the exact base binary and Scheme library.
+          (cd candidate && env \
             PERF_AB_MODE=record \
             PERF_BASELINE_FILE="$baseline" \
             PERF_BASELINE_SEED="$seed" \

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -5220,7 +5220,9 @@ that actually owns the title consumes the reference. */
 								(begin
 									(define staged (make_grouped_derived_stage_source src alias inner))
 									(list
-										(merge (list (nth staged 0) tail_sources))
+										(merge (list
+											(nth staged 0)
+											(rewrite_sources_join_for_derived alias (nth staged 1) tail_sources)))
 										(cons (list alias (nth staged 1)) tail_rewrites)
 										tail_wheres
 										(cons (nth staged 2) (merge (list (qb_stages inner) tail_stages)))))

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -583,6 +583,17 @@ logical trees consumed before physical scan lowering. */
 				(< (qassoc_get candidate (quote memory_bytes) 0)
 					(qassoc_get current (quote memory_bytes) 0)))))))
 
+/* Cost confidence defines a one-sided uncertainty interval for fuzzy physical
+choices. A candidate is a clear winner only when its confidence-adjusted upper
+estimate remains below the other alternative's point estimate. Callers with an
+exact bounded fallback may prefer it while those intervals overlap. */
+(define planner_cost_clear_winner? (lambda (candidate current)
+	(begin
+		(define candidate_confidence (max 0.01
+			(qassoc_get candidate (quote confidence) 0.01)))
+		(< (/ (qassoc_get candidate (quote total_ns) 0) candidate_confidence)
+			(qassoc_get current (quote total_ns) 0)))))
+
 /* Calibrated generic storage facts. They are deliberately free of SQL
 semantics; SCM combines them according to the candidate being evaluated. */
 (define planner_scan_cost (lambda (rows confidence)
@@ -2180,6 +2191,22 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(and complete (join_optimizer_source_column_constant_bound?
 					sources default_alias src col condition))) true))) false))))
 
+(define join_optimizer_source_local_condition (lambda (graph src)
+	(combine_where
+		(source_join_expr src)
+		(combine_where_terms
+			(map (join_optimizer_local_predicates graph (source_alias src))
+				(lambda (entry) (qassoc_get entry (quote predicate) true)))
+			true))))
+
+(define join_optimizer_constant_unique_order_prefix_aliases (lambda (sources default_alias graph stages)
+	(map (filter sources (lambda (src)
+		(and (join_optimizer_inner_source? stages src)
+			(join_optimizer_source_constant_unique_point?
+				sources default_alias src
+				(join_optimizer_source_local_condition graph src)))))
+		source_alias)))
+
 (define join_optimizer_required_order_prefix (lambda (sources required_aliases condition stages prefix)
 	(if (or (empty_list? sources)
 		(or (empty_list? required_aliases)
@@ -2232,8 +2259,32 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(join_optimizer_required_order_prefix sources raw_required_order_aliases
 					(coalesceNil (qb_where block) true) stage_catalog '())
 				raw_required_order_aliases))))
+		/* A constant unique lookup emits at most one row and therefore cannot alter
+		the order of a following ordered scan. Putting every such inner source before
+		the ordered driver strictly dominates repeating the same point lookup from
+		every driver row. Express that proof through the existing ordered-prefix
+		property so DP and the lowerer keep one shared notion of valid order. */
+		(define constant_unique_aliases
+			(join_optimizer_constant_unique_order_prefix_aliases
+				sources default_alias graph stage_catalog))
+		/* A singleton can technically be reported as an ordered driver because its
+		downstream scan supplies the order. It must still remain in the prefix: using
+		it as the repeated ordered root would throw away the singleton proof. Prefer
+		the first non-singleton ordered source as the actual order producer. */
+		(define non_singleton_ordered_drivers (filter ordered_drivers (lambda (alias)
+			(not (contains? constant_unique_aliases alias)))))
+		(define selected_ordered_driver (if (not (empty_list? non_singleton_ordered_drivers))
+			(car non_singleton_ordered_drivers)
+			(if (empty_list? ordered_drivers) nil (car ordered_drivers))))
+		(define dominant_singleton_prefix (if (nil? selected_ordered_driver)
+			'()
+			(filter constant_unique_aliases (lambda (alias)
+				(not (equal? alias selected_ordered_driver))))))
 		(define required_order_property (if (empty_list? required_order_aliases)
-			ordered_drivers
+			(if (empty_list? dominant_singleton_prefix)
+				ordered_drivers
+				(list (list (quote ordered_aliases)
+					(merge (list dominant_singleton_prefix (list selected_ordered_driver))))))
 			(list (list (quote ordered_aliases) required_order_aliases))))
 		(define preserve_row_number_driver (and
 			(not (empty_list? segment))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -6664,8 +6664,9 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_ordered_scan_invocation_ns 3027639)
 (define planner_membership_ordered_recset_sort_unit_ns 1)
 (define planner_group_relation_startup_ns 1)
-(define planner_group_relation_build_row_ns 40356)
-(define planner_scan_join_order_startup_ns 1413251)
+(define planner_group_relation_build_row_ns 40028)
+(define planner_group_relation_probe_ns 476577)
+(define planner_scan_join_order_startup_ns 1802018)
 /* END GENERATED COST CONSTANTS */
 
 /* scan_join_order reuses the calibrated scan/filter/map work units. The

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -6127,6 +6127,14 @@ once and every base-only leaf remains a vectorized domain scan. */
 	(map (coalesceNil sources '()) (lambda (src)
 		(physicalize_stage_output_source stages src)))))
 
+(define physicalize_stage_output_sources_except (lambda (stages sources retained_stage_ids)
+	(map (coalesceNil sources '()) (lambda (src)
+		(if (and (stage_output_relation? (source_relation src))
+			(contains? retained_stage_ids
+				(stage_output_relation_id (source_relation src))))
+			src
+			(physicalize_stage_output_source stages src))))))
+
 (define stage_outputs_from_sources_using (lambda (stages sources)
 	(unique_stages_by_id (filter (map (coalesceNil sources '()) (lambda (src)
 		(match src
@@ -6255,13 +6263,37 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 		source_join_expr)))
 
 (define direct_group_probe_stage_for_block_source (lambda (stages sources src consumers)
-	(if (expr_refs_alias? nil (source_alias src) (source_join_consumers_except sources src))
-		nil
-		(direct_group_probe_stage_for_source stages src consumers))))
+	(direct_group_probe_stage_for_source stages src
+		(list consumers (source_join_consumers_except sources src)))))
 
 (define direct_group_probe_aggregates_safe? (lambda (stage)
 	(reduce (stage_aggregates_for_fields (gs_output stage)) (lambda (safe ag)
-		(and safe (nil? (nth ag 2)))) true)))
+		/* A hidden COUNT(*) in the transformed stage distinguishes an empty LEFT
+		probe from a matched COUNT group whose visible value is zero. */
+		(and safe (or (aggregate_count_like? ag) (nil? (nth ag 2))))) true)))
+
+(define direct_group_probe_aggregates_with_presence (lambda (stage)
+	(begin
+		(define aggregates (stage_aggregates_for_fields (gs_output stage)))
+		(define needs_presence (reduce aggregates
+			(lambda (needed ag)
+				(or needed (and (not (aggregate_count_like? ag))
+					(not (nil? (nth ag 2)))))) false))
+		(if needs_presence
+			(dedupe_aggregates_by_col
+				(merge (list aggregates (list aggregate_count_descriptor))))
+			aggregates))))
+
+(define direct_group_probe_rebind_input_expr (lambda (input_src expr)
+	(match expr
+		((symbol get_column) _alias _alias_ignorecase column column_ignorecase)
+		(list (quote get_column) (source_alias input_src) false column column_ignorecase)
+		((quote get_column) alias alias_ignorecase column column_ignorecase)
+		(direct_group_probe_rebind_input_expr input_src
+			(list (symbol "get_column") alias alias_ignorecase column column_ignorecase))
+		(cons head tail) (cons head (map tail (lambda (item)
+			(direct_group_probe_rebind_input_expr input_src item))))
+		_ expr)))
 
 (define direct_group_probe_stage_for_source (lambda (stages src consumers)
 	(if (or (nil? consumers)
@@ -6274,12 +6306,15 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 				(begin
 					(define input (direct_group_probe_input stage))
 					(define lookups (if (nil? input) nil (direct_group_probe_lookup_keys stage src)))
-					(if (or (not (nil? (qassoc_get (gs_facts stage) (quote purpose) nil)))
-						(or (nil? input)
-							(or (nil? lookups)
-								(or (not (equal? (coalesceNil (gs_having stage) true) true))
-									(or (not (direct_group_probe_aggregates_safe? stage))
-										(not (direct_group_probe_consumers_safe? stage src consumers)))))))
+					(if (reduce (list
+						(not (nil? (qassoc_get (gs_facts stage) (quote purpose) nil)))
+						(nil? input)
+						(nil? lookups)
+						(not (equal? (coalesceNil (gs_having stage) true) true))
+						(stage_has_residual_outer_refs? stage)
+						(not (direct_group_probe_aggregates_safe? stage))
+						(not (direct_group_probe_consumers_safe? stage src consumers)))
+						(lambda (blocked item) (or blocked item)) false)
 						nil
 						(begin
 							(define input_src (car (qb_sources input)))
@@ -6300,14 +6335,17 @@ aggregate scan. Keep every ambiguous outer-join shape on the shared group cache.
 								(gs_id stage)
 								input_src
 								(gs_domain stage)
-								(gs_keys stage)
-								(gs_aggregates stage)
+								(map (gs_keys stage) (lambda (key)
+									(direct_group_probe_rebind_input_expr input_src key)))
+								(map (direct_group_probe_aggregates_with_presence stage) (lambda (ag)
+									(direct_group_probe_rebind_input_expr input_src ag)))
 								(gs_having stage)
 								(gs_output stage)
 								(gs_order stage)
 								(gs_limit stage)
 								(gs_offset stage)
-								(qassoc_set facts (quote condition) condition)))))))))))
+								(qassoc_set facts (quote condition)
+									(direct_group_probe_rebind_input_expr input_src condition)))))))))))
 
 (define presence_stage_output_source? (lambda (stages src)
 	(and (stage_output_relation? (source_relation src))
@@ -6620,6 +6658,9 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_ordered_driver_input_row_ns 1)
 (define planner_membership_ordered_scan_invocation_ns 3027639)
 (define planner_membership_ordered_recset_sort_unit_ns 1)
+(define planner_group_relation_startup_ns 1)
+(define planner_group_relation_build_row_ns 40356)
+(define planner_scan_join_order_startup_ns 1413251)
 /* END GENERATED COST CONSTANTS */
 
 /* scan_join_order reuses the calibrated scan/filter/map work units. The
@@ -6627,7 +6668,7 @@ structural formula belongs to the lowerer; tools/costgen owns every numeric
 coefficient used here. */
 (define planner_scan_join_order_cost (lambda (input_rows joined_rows table_count output_rows)
 	(planner_cost
-		(+ planner_membership_ordered_scan_invocation_ns
+		(+ planner_scan_join_order_startup_ns
 			(* (- table_count 1) planner_membership_scan_invocation_ns))
 		(+ (* input_rows planner_membership_scan_row_ns)
 			(* input_rows (- table_count 1) planner_membership_map_column_row_ns))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2933,6 +2933,7 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 						(if (empty_list? direct_group_join_stages) '()
 							(list (list (quote define) (quote __direct_group_usage)
 								(list (quote newsession)))))
+						(direct_group_join_prepare_recipe_exprs direct_group_join_stages)
 						(direct_group_join_warm_prepare_exprs direct_group_join_stages)
 						(if (nil? scalar_order_cache) '() (list (nth scalar_order_cache 4)))
 						probe_recipe_prepares
@@ -5955,7 +5956,7 @@ only the structural work counts are specific to this operator. */
 						planner_membership_scan_invocation_ns)
 					(* input_rows (+ planner_membership_scan_row_ns
 						(* aggregate_width planner_membership_map_column_row_ns)))
-					(* invocations planner_membership_group_cache_probe_row_ns)
+					(* invocations planner_group_relation_probe_ns)
 					0 0
 					(* input_rows planner_group_relation_build_row_ns)
 					(* group_rows (+ 8 (* aggregate_width 8)))
@@ -6190,10 +6191,34 @@ the costgen threshold. */
 			(max 1 (qassoc_get (cadr costs) (quote total_ns)
 				planner_membership_group_cache_startup_ns))))))
 
-(define direct_group_join_async_build_expr (lambda (stage canonical_name)
+(define direct_group_join_prepare_recipe_symbol (lambda (stage)
+	(symbol (concat "__direct_group_prepare_recipe_"
+		(stable_structural_hash (direct_group_join_canonical_name stage) true)))))
+
+(define direct_group_join_prepare_recipe_binding (lambda (stage)
 	(begin
 		(define prepare_expr
 			(lower_group_stage_prepare_using (list stage) (list stage) stage true nil))
+		(list (quote define)
+			(direct_group_join_prepare_recipe_symbol stage)
+			(list (quote quote) prepare_expr)))))
+
+(define direct_group_join_prepare_recipe_exprs (lambda (stages)
+	(if (direct_group_join_calibration_active?)
+		'()
+		(begin
+			(define unique_stages (extract_assoc
+				(reduce (coalesceNil stages '()) (lambda (by_name stage)
+					(set_assoc by_name (direct_group_join_canonical_name stage) stage)) '())
+				(lambda (_name stage) stage)))
+			(map unique_stages direct_group_join_prepare_recipe_binding)))))
+
+(define direct_group_join_eval_prepare_recipe_expr (lambda (stage)
+	(list (quote eval)
+		(list (quote optimize) (direct_group_join_prepare_recipe_symbol stage)))))
+
+(define direct_group_join_async_build_expr (lambda (stage canonical_name)
+	(begin
 		(list (quote setTimeout)
 			(list (quote lambda) '()
 				(list (quote try)
@@ -6205,8 +6230,7 @@ the costgen threshold. */
 										(list (quote with_autocommit) (quote __group_cache_build_session)
 											(list (quote lambda) '()
 												(list (quote !begin)
-													(list (quote eval)
-														(list (quote optimize) (list (quote quote) prepare_expr)))
+												(direct_group_join_eval_prepare_recipe_expr stage)
 													(list (quote group_cache_candidate_delete)
 														canonical_name))))))
 								(list (quote newsession))))
@@ -6244,12 +6268,14 @@ the costgen threshold. */
 			(list (quote group_cache_candidate_delete) canonical_name)))))
 
 (define direct_group_join_usage_flush_exprs (lambda (stages)
-	(begin
-		(define unique_stages (extract_assoc
-			(reduce (coalesceNil stages '()) (lambda (by_name stage)
-				(set_assoc by_name (direct_group_join_canonical_name stage) stage)) '())
-			(lambda (_name stage) stage)))
-		(map unique_stages direct_group_join_usage_flush_expr))))
+	(if (direct_group_join_calibration_active?)
+		'()
+		(begin
+			(define unique_stages (extract_assoc
+				(reduce (coalesceNil stages '()) (lambda (by_name stage)
+					(set_assoc by_name (direct_group_join_canonical_name stage) stage)) '())
+				(lambda (_name stage) stage)))
+			(map unique_stages direct_group_join_usage_flush_expr)))))
 
 /* A cache can predate aggregate columns first requested by this query. Extend
 an existing carrier once at query scope before joined probes use it; a missing
@@ -6257,8 +6283,6 @@ carrier remains on the measured direct path and is never built eagerly. */
 (define direct_group_join_warm_prepare_expr (lambda (stage)
 	(begin
 		(define cache_promise (quote __direct_group_warm_cache_lookup))
-		(define prepare_expr
-			(lower_group_stage_prepare_using (list stage) (list stage) stage true nil))
 		(list
 			(list (quote lambda) (list cache_promise)
 				(list (quote !begin)
@@ -6274,7 +6298,7 @@ carrier remains on the measured direct path and is never built eagerly. */
 						(list (quote equal?) (list cache_promise "state") false)
 						(list (quote error) (list cache_promise "value"))
 						(list (quote if) (list (quote nil?) (list cache_promise "value"))
-							nil prepare_expr))))
+							nil (direct_group_join_eval_prepare_recipe_expr stage)))))
 			(list (quote newpromise)
 				(list (quote append_mut) (list (symbol "!!list") 2) nil nil))))))
 

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -930,8 +930,10 @@ from silently overriding the physical planner. */
 		(define stage_lookup (if (lowering_catalog? stages)
 			stages
 			(query_block_stage_catalog rewritten)))
-		(define direct_group_sources
-			(direct_group_join_sources_for_block stage_lookup rewritten))
+		(define direct_group_selections
+			(direct_group_join_selections_for_block stage_lookup rewritten))
+		(define direct_group_sources (map direct_group_selections car))
+		(define direct_group_stages (map direct_group_selections cadr))
 		(define direct_group_stage_ids (stage_output_source_ids direct_group_sources))
 		(make_query_block
 			(qb_schema rewritten)
@@ -946,8 +948,11 @@ from silently overriding the physical planner. */
 			(qb_offset rewritten)
 			(qb_hidden rewritten)
 			(qb_stages rewritten)
-			(qassoc_set (qb_facts rewritten) (quote direct_group_join_stage_ids)
-				direct_group_stage_ids)))))
+			(qassoc_set
+				(qassoc_set (qb_facts rewritten) (quote direct_group_join_stage_ids)
+					direct_group_stage_ids)
+				(quote direct_group_join_stages)
+				direct_group_stages)))))
 
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(query_block_with_prepared_sources_using_graph
@@ -2852,7 +2857,8 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 						invariant_probe_bindings
 						probe_recipe_prepares
 						probe_recipe_bindings))
-					recipe_block))
+					recipe_block
+					'()))
 			(begin
 				(define stage_catalog (query_block_stage_catalog block))
 				(define scalar_order_cache
@@ -2889,6 +2895,9 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 							(quote direct_group_join_stage_ids) '())
 						(qassoc_get (qb_facts raw_prepared_block)
 							(quote consumed_probe_stage_ids) '()))))
+				(define direct_group_join_stages
+					(qassoc_get (qb_facts raw_prepared_block)
+						(quote direct_group_join_stages) '()))
 				(define eager_stages (filter candidate_eager_stages (lambda (stage)
 					(and (not (has_assoc? probe_marker_stage_ids (gs_id stage)))
 						(not (contains? direct_group_join_stage_ids (gs_id stage)))))))
@@ -2921,6 +2930,10 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 				(list
 					(merge (list
 						invariant_probe_bindings
+						(if (empty_list? direct_group_join_stages) '()
+							(list (list (quote define) (quote __direct_group_usage)
+								(list (quote newsession)))))
+						(direct_group_join_warm_prepare_exprs direct_group_join_stages)
 						(if (nil? scalar_order_cache) '() (list (nth scalar_order_cache 4)))
 						probe_recipe_prepares
 						probe_recipe_bindings
@@ -2928,7 +2941,8 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 						(prepared_stage_bindings eager_stages)
 						(lower_unique_stage_prepares_with_graph eager_dependency_graph eager_stage_lookup eager_stages)
 						(lower_stage_materialize_all eager_stages)))
-					core_block))))))
+					core_block
+					(direct_group_join_usage_flush_exprs direct_group_join_stages)))))))
 
 (define prepare_simple_query_block_physical_core (lambda (block)
 	(prepare_simple_query_block_physical_core_chosen
@@ -2941,11 +2955,14 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 		(define prepared (prepare_simple_query_block_physical_core block))
 		(define prelude (nth prepared 0))
 		(define core_block (nth prepared 1))
-		(if (empty_list? prelude)
+		(define postlude (nth prepared 2))
+		(if (and (empty_list? prelude) (empty_list? postlude))
 			(lower_query_block_core core_block)
 			(cons (quote !begin) (merge (list
 				prelude
-				(list (lower_query_block_core core_block)))))))))
+				(list (lower_query_block_core core_block))
+				postlude
+				(if (empty_list? postlude) '() (list nil)))))))))
 
 (define lower_query_block_with_cataloged_stages (lambda (block)
 	(if (empty_list? (qb_stages block))
@@ -5944,12 +5961,12 @@ only the structural work counts are specific to this operator. */
 					0 group_rows 0.7))
 				(list direct_cost carrier_cost input_rows group_rows rows_per_probe))))))
 
-(define direct_group_join_source_selected? (lambda (stages sources tree consumers src)
+(define direct_group_join_source_selection (lambda (stages sources tree consumers src)
 	(begin
 		(define stage (direct_group_probe_stage_for_block_source
 			stages sources src consumers))
 		(if (nil? stage)
-			false
+			nil
 			(begin
 				(define invocations (direct_group_join_tree_invocations
 					tree (source_alias src) sources stages 1))
@@ -5978,17 +5995,26 @@ only the structural work counts are specific to this operator. */
 					(list "alternatives" (if (nil? costs) '() (list
 						(list (list "plan" "group_carrier") (list "cost" (planner_cost_explain (cadr costs))))
 						(list (list "plan" "direct_group_join") (list "cost" (planner_cost_explain (car costs)))))))))
-				(equal? chosen "direct_group_join"))))))
+				(if (equal? chosen "direct_group_join") (list src stage) nil))))))
 
-(define direct_group_join_sources_for_block (lambda (stages block)
+(define direct_group_join_selections_for_block (lambda (stages block)
 	(begin
 		(define sources (qb_sources block))
 		(define tree (query_block_join_plan block sources))
 		(define consumers (query_block_probe_consumers block))
-		(filter sources (lambda (src)
-			(direct_group_join_source_selected? stages sources tree consumers src))))))
+		(filter (map sources (lambda (src)
+			(direct_group_join_source_selection stages sources tree consumers src)))
+			(lambda (selection) (not (nil? selection)))))))
 
-(define direct_group_join_scan_expr (lambda (all_sources default_alias stage)
+(define direct_group_join_canonical_name (lambda (stage)
+	(concat (group_stage_cache_schema stage) "\n" (group_stage_cache_relation stage))))
+
+(define direct_group_join_calibration_active? (lambda ()
+	(not (nil? (try
+		(lambda () ((context "session") "__memcp_physical_overrides"))
+		(lambda (_error) nil))))))
+
+(define direct_group_join_raw_scan_expr (lambda (all_sources default_alias stage)
 	(begin
 		(define src (gs_input stage))
 		(define keys (gs_keys stage))
@@ -6037,6 +6063,229 @@ only the structural work counts are specific to this operator. */
 				neutral_payload
 				merge_payload
 				false)))))
+
+(define direct_group_join_cache_scan_expr (lambda (all_sources default_alias stage table_expr)
+	(begin
+		(define ags (gs_aggregates stage))
+		(define key_names (group_key_cols (gs_keys stage)))
+		(define lookup_values (map (qassoc_get (gs_facts stage) (quote lookup-keys) '())
+			(lambda (expr) (lower_column_expr_for_join all_sources default_alias expr))))
+		(define aggregate_cols (map ags (lambda (ag)
+			(aggregate_col_name_using (gs_input stage) ag))))
+		(define neutral_payload
+			(runtime_cons_list_expr (map ags (lambda (ag) (nth ag 2)))))
+		(list (quote scan)
+			'(session "__memcp_tx")
+			table_expr
+			(cons (quote list) key_names)
+			(list (quote lambda) (map key_names symbol)
+				(combine_where_terms (map (produceN (count key_names)) (lambda (i)
+					(list (quote equal??) (symbol (nth key_names i)) (nth lookup_values i))))
+					true))
+			(cons (quote list) aggregate_cols)
+			(list (quote lambda) (map aggregate_cols symbol)
+				(runtime_cons_list_expr (map aggregate_cols symbol)))
+			(list (quote lambda) (list (quote __old_group_values) (quote __new_group_values))
+				(quote __new_group_values))
+			neutral_payload nil false))))
+
+/* Direct grouped probes execute inside an outer join scan. Accumulate their
+measured time in a query-local session and flush it once after the complete
+query, rather than writing planner telemetry once per joined row. Forced
+Costgen alternatives remain uninstrumented so their timings contain only the
+operator being calibrated. */
+(define direct_group_join_scan_expr (lambda (all_sources default_alias stage)
+	(begin
+		(define direct_values
+			(direct_group_join_raw_scan_expr all_sources default_alias stage))
+		(if (direct_group_join_calibration_active?)
+			direct_values
+			(begin
+				(define canonical_name (direct_group_join_canonical_name stage))
+				(define cold_values (list
+					(list (quote lambda) (list (quote __direct_group_started_ns))
+						(list
+							(list (quote lambda) (list (quote __direct_group_result))
+								(list (quote !begin)
+									(list (quote __direct_group_usage)
+										canonical_name
+										(list (quote +)
+											(list (quote coalesceNil)
+												(list (quote __direct_group_usage) canonical_name)
+												0)
+											(list (quote -) (list (quote nanotime))
+												(quote __direct_group_started_ns))))
+									(quote __direct_group_result)))
+							direct_values))
+					(list (quote nanotime))))
+				(define cache_schema (group_stage_cache_schema stage))
+				(define cache_relation (group_stage_cache_relation stage))
+				(define cache_promise (quote __direct_group_cache_lookup))
+				(list
+					(list (quote lambda) (list cache_promise)
+						(list (quote !begin)
+							(list (quote try)
+								(list (quote lambda) '()
+									(list cache_promise "value"
+										(list (quote table) cache_schema cache_relation)))
+								(list (quote lambda) (list (quote __direct_group_cache_error))
+									(list cache_promise "fail" (quote __direct_group_cache_error))))
+							(list (quote if)
+								(list (quote equal?) (list cache_promise "state") false)
+								(list (quote error) (list cache_promise "value"))
+								(list (quote if) (list (quote nil?) (list cache_promise "value"))
+									cold_values
+									(direct_group_join_cache_scan_expr all_sources default_alias stage
+										(list cache_promise "value"))))))
+					(list (quote newpromise)
+						(list (quote append_mut) (list (symbol "!!list") 2) nil nil))))))))
+
+/* Cold group-cache telemetry lives entirely in SCM. The UNIQUE collision path
+is the lookup and update: one storage access atomically adds this query's
+measured direct-probe time and resets the counter for the query that crosses
+the costgen threshold. */
+(define group_cache_candidate_accumulate (lambda (canonical_name elapsed_ns threshold_ns)
+	(begin
+		(createtable "system_statistic" "group_cache_candidates"
+			(list
+				(list "unique" "PRIMARY" (list "canonical_name"))
+				(list "column" "canonical_name" "text" (list) (list))
+				(list "column" "accumulated_ns" "int" (list) (list)))
+			(list "engine" "sloppy") true)
+		(define claim (newsession))
+		(claim "build" (>= elapsed_ns threshold_ns))
+		(insert (table "system_statistic" "group_cache_candidates")
+			'("canonical_name" "accumulated_ns")
+			(list (list canonical_name (if (>= elapsed_ns threshold_ns) 0 elapsed_ns)))
+			'("accumulated_ns" "NEW.accumulated_ns" "$update")
+			(lambda (old_accumulated_ns new_elapsed_ns $update)
+				(begin
+					(define next_accumulated_ns (+ old_accumulated_ns new_elapsed_ns))
+					(define build (>= next_accumulated_ns threshold_ns))
+					(claim "build" build)
+					($update (list "accumulated_ns"
+						(if build 0 next_accumulated_ns)))
+					true))
+			false)
+		(claim "build"))))
+
+(define group_cache_candidate_delete (lambda (canonical_name)
+	(begin
+		(define candidates (table "system_statistic" "group_cache_candidates"))
+		(if (nil? candidates)
+			0
+			(scan (session "__memcp_tx") candidates
+				'("canonical_name")
+				(lambda (candidate_name) (equal? candidate_name canonical_name))
+				'("$update")
+				(lambda ($update) ($update))
+				+ 0 nil false)))))
+
+(define direct_group_join_cache_threshold_ns (lambda (stage)
+	(begin
+		(define costs (direct_group_join_costs stage 1))
+		(if (nil? costs)
+			planner_membership_group_cache_startup_ns
+			(max 1 (qassoc_get (cadr costs) (quote total_ns)
+				planner_membership_group_cache_startup_ns))))))
+
+(define direct_group_join_async_build_expr (lambda (stage canonical_name)
+	(begin
+		(define prepare_expr
+			(lower_group_stage_prepare_using (list stage) (list stage) stage true nil))
+		(list (quote setTimeout)
+			(list (quote lambda) '()
+				(list (quote try)
+					(list (quote lambda) '()
+						(list
+							(list (quote lambda) (list (quote __group_cache_build_session))
+								(list (quote with_session) (quote __group_cache_build_session)
+									(list (quote lambda) '()
+										(list (quote with_autocommit) (quote __group_cache_build_session)
+											(list (quote lambda) '()
+												(list (quote !begin)
+													(list (quote eval)
+														(list (quote optimize) (list (quote quote) prepare_expr)))
+													(list (quote group_cache_candidate_delete)
+														canonical_name))))))
+								(list (quote newsession))))
+						(list (quote lambda) (list (quote __group_cache_build_error))
+							(list (quote !begin)
+								(list (quote try)
+									(list (quote lambda) '()
+										(list (quote droptable)
+											(group_stage_cache_schema stage)
+											(group_stage_cache_relation stage) true))
+									(list (quote lambda) (list (quote __group_cache_cleanup_error)) nil))
+								(list (quote error) (quote __group_cache_build_error))))))
+				0)))))
+
+(define direct_group_join_usage_flush_expr (lambda (stage)
+	(begin
+		(define canonical_name (direct_group_join_canonical_name stage))
+		(define elapsed_ns (list (quote __direct_group_usage) canonical_name))
+		(define cache_lookup (list (quote try)
+			(list (quote lambda) '()
+				(list (quote table) (group_stage_cache_schema stage)
+					(group_stage_cache_relation stage)))
+			(list (quote lambda) (list (quote __group_cache_lookup_error))
+				(list (quote error) (quote __group_cache_lookup_error)))))
+		(list (quote if) (list (quote nil?) cache_lookup)
+			(list (quote if)
+				(list (quote >) (list (quote coalesceNil) elapsed_ns 0) 0)
+				(list (quote if)
+					(list (quote group_cache_candidate_accumulate)
+						canonical_name elapsed_ns
+						(direct_group_join_cache_threshold_ns stage))
+					(direct_group_join_async_build_expr stage canonical_name)
+					nil)
+				nil)
+			(list (quote group_cache_candidate_delete) canonical_name)))))
+
+(define direct_group_join_usage_flush_exprs (lambda (stages)
+	(begin
+		(define unique_stages (extract_assoc
+			(reduce (coalesceNil stages '()) (lambda (by_name stage)
+				(set_assoc by_name (direct_group_join_canonical_name stage) stage)) '())
+			(lambda (_name stage) stage)))
+		(map unique_stages direct_group_join_usage_flush_expr))))
+
+/* A cache can predate aggregate columns first requested by this query. Extend
+an existing carrier once at query scope before joined probes use it; a missing
+carrier remains on the measured direct path and is never built eagerly. */
+(define direct_group_join_warm_prepare_expr (lambda (stage)
+	(begin
+		(define cache_promise (quote __direct_group_warm_cache_lookup))
+		(define prepare_expr
+			(lower_group_stage_prepare_using (list stage) (list stage) stage true nil))
+		(list
+			(list (quote lambda) (list cache_promise)
+				(list (quote !begin)
+					(list (quote try)
+						(list (quote lambda) '()
+							(list cache_promise "value"
+								(list (quote table)
+									(group_stage_cache_schema stage)
+									(group_stage_cache_relation stage))))
+						(list (quote lambda) (list (quote __direct_group_warm_cache_error))
+							(list cache_promise "fail" (quote __direct_group_warm_cache_error))))
+					(list (quote if)
+						(list (quote equal?) (list cache_promise "state") false)
+						(list (quote error) (list cache_promise "value"))
+						(list (quote if) (list (quote nil?) (list cache_promise "value"))
+							nil prepare_expr))))
+			(list (quote newpromise)
+				(list (quote append_mut) (list (symbol "!!list") 2) nil nil))))))
+
+(define direct_group_join_warm_prepare_exprs (lambda (stages)
+	(if (direct_group_join_calibration_active?)
+		'()
+		(begin
+			(define unique_stages (extract_assoc
+				(reduce (coalesceNil stages '()) (lambda (by_name stage)
+					(set_assoc by_name (direct_group_join_canonical_name stage) stage)) '())
+				(lambda (_name stage) stage)))
+			(map unique_stages direct_group_join_warm_prepare_expr)))))
 
 (define direct_group_join_presence_index (lambda (ags)
 	(reduce (produceN (count ags)) (lambda (found index)
@@ -7917,7 +8166,8 @@ every title. */
 		(define prepared (prepare_simple_query_block_physical_core
 			(query_block_with_full_stage_catalog branch)))
 		(define core_block (nth prepared 1))
-		(if (union_ordered_branch_supported? core_block)
+		(if (and (empty_list? (nth prepared 2))
+			(union_ordered_branch_supported? core_block))
 			(list (nth prepared 0) core_block nil)
 			nil))))
 

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -281,11 +281,8 @@ context gates because bare EXISTS also has a separate membership lowerer. */
 				stages sources default_alias limit_value driver_condition src)
 			(or
 				(scalar_aggregate_probe_output_source_for_block? stages sources default_alias limit_value src)
-				(or
-					(scalar_cardinality_probe_output_source_for_block?
-						stages sources default_alias limit_value driver_condition src)
-					(direct_group_probe_output_source_for_block?
-						stages sources default_alias limit_value driver_condition consumers src))))))))
+				(scalar_cardinality_probe_output_source_for_block?
+					stages sources default_alias limit_value driver_condition src)))))))
 
 (define sources_without_probe_outputs (lambda (sources probe_sources)
 	(begin
@@ -933,9 +930,13 @@ from silently overriding the physical planner. */
 		(define stage_lookup (if (lowering_catalog? stages)
 			stages
 			(query_block_stage_catalog rewritten)))
+		(define direct_group_sources
+			(direct_group_join_sources_for_block stage_lookup rewritten))
+		(define direct_group_stage_ids (stage_output_source_ids direct_group_sources))
 		(make_query_block
 			(qb_schema rewritten)
-			(physicalize_stage_output_sources stage_lookup (qb_sources rewritten))
+			(physicalize_stage_output_sources_except
+				stage_lookup (qb_sources rewritten) direct_group_stage_ids)
 			(qb_fields rewritten)
 			(qb_where rewritten)
 			(qb_group rewritten)
@@ -945,7 +946,8 @@ from silently overriding the physical planner. */
 			(qb_offset rewritten)
 			(qb_hidden rewritten)
 			(qb_stages rewritten)
-			(qb_facts rewritten)))))
+			(qassoc_set (qb_facts rewritten) (quote direct_group_join_stage_ids)
+				direct_group_stage_ids)))))
 
 (define query_block_with_prepared_sources_using (lambda (stages block)
 	(query_block_with_prepared_sources_using_graph
@@ -2881,11 +2883,20 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 				consumer's join-node cardinality is known. */
 				(define probe_marker_stage_ids (stage_id_set
 					(map raw_probe_recipe_entries (lambda (entry) (car entry)))))
+				(define direct_group_join_stage_ids
+					(merge_unique (list
+						(qassoc_get (qb_facts raw_prepared_block)
+							(quote direct_group_join_stage_ids) '())
+						(qassoc_get (qb_facts raw_prepared_block)
+							(quote consumed_probe_stage_ids) '()))))
 				(define eager_stages (filter candidate_eager_stages (lambda (stage)
-					(not (has_assoc? probe_marker_stage_ids (gs_id stage))))))
+					(and (not (has_assoc? probe_marker_stage_ids (gs_id stage)))
+						(not (contains? direct_group_join_stage_ids (gs_id stage)))))))
 				(define eager_stage_lookup (stages_without_ids
 					(lowering_catalog_stages stage_lookup)
-					(extract_assoc probe_marker_stage_ids (lambda (id _owned) id))))
+					(merge_unique (list
+						(extract_assoc probe_marker_stage_ids (lambda (id _owned) id))
+						direct_group_join_stage_ids))))
 				(define eager_dependency_graph (stage_dependency_graph eager_stage_lookup))
 				(define bounded_probe_recipe_keys
 					(query_block_bounded_scalar_probe_recipe_keys carrier_block probe_recipe_entries))
@@ -2901,7 +2912,9 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 				/* Different logical stage IDs may resolve to one physical carrier.
 				Once that carrier is eager, no alias-equivalent stage may emit a
 				second lazy initializer for the same session key. */
-				(define lazy_catalog (stages_without_prepare_backbones stage_catalog eager_stages))
+				(define lazy_catalog (stages_without_ids
+					(stages_without_prepare_backbones stage_catalog eager_stages)
+					direct_group_join_stage_ids))
 				(define core_block (query_block_without_stages
 					(query_block_with_stage_catalog prepared_block stage_catalog)))
 				(define lazy_stages (group_cache_stages_from_sources lazy_catalog (qb_sources core_block)))
@@ -4498,6 +4511,24 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 				(reduce order_items (lambda (found item)
 					(or found (expr_refs_alias? default_alias lookup_alias item))) false))))))
 
+(define ordered_join_projected_candidate_exact? (lambda (sources default_alias src lookup terms)
+	(begin
+		(define lookup_alias (source_alias lookup))
+		(define driver_alias (source_alias src))
+		(reduce terms (lambda (supported term)
+			(begin
+				(define aliases (join_hypergraph_expr_aliases
+					default_alias (source_aliases sources) term))
+				(and supported
+					(or (empty_list? aliases)
+						(or (and (single_source? aliases)
+							(or (equal? (car aliases) lookup_alias)
+								(equal? (car aliases) driver_alias)))
+							(and (equal? (count aliases) 2)
+								(and (contains? aliases lookup_alias)
+									(and (contains? aliases driver_alias)
+										(not (nil? (union_semijoin_equal_parts src lookup term))))))))))) true))))
+
 (define ordered_join_projected_candidate (lambda (sources default_alias src remaining_sources condition order_items offset limit)
 	(if (or (not (single_source? remaining_sources))
 		(or (source_outer? src) (source_outer? (car remaining_sources))))
@@ -4510,21 +4541,8 @@ projected back onto the ordered driver before scan_order applies Top-K. */
 				(split_and_terms (coalesceNil (source_join_expr lookup) true)))))
 			(define edge_columns (candidate_recset_edge_columns
 				sources default_alias lookup src terms))
-			(define lookup_alias (source_alias lookup))
-			(define driver_alias (source_alias src))
-			(define exact (reduce terms (lambda (supported term)
-				(begin
-					(define aliases (join_hypergraph_expr_aliases
-						default_alias (source_aliases sources) term))
-					(and supported
-						(or (empty_list? aliases)
-							(or (and (single_source? aliases)
-								(or (equal? (car aliases) lookup_alias)
-									(equal? (car aliases) driver_alias)))
-								(and (equal? (count aliases) 2)
-									(and (contains? aliases lookup_alias)
-										(and (contains? aliases driver_alias)
-											(not (nil? (union_semijoin_equal_parts src lookup term))))))))))) true))
+			(define exact (ordered_join_projected_candidate_exact?
+				sources default_alias src lookup terms))
 			(define lookup_input_rows (planner_source_row_count lookup))
 			(define driver_input_rows (planner_source_row_count src))
 			(define lookup_condition (candidate_recset_local_condition
@@ -4737,6 +4755,8 @@ has selected a lowerer. */
 				(split_and_terms (coalesceNil (source_join_expr lookup) true)))))
 			(define edge_columns (candidate_recset_edge_columns
 				sources default_alias lookup src terms))
+			(define exact (ordered_join_projected_candidate_exact?
+				sources default_alias src lookup terms))
 			(define lookup_input_rows (planner_source_row_count lookup))
 			(define driver_input_rows (planner_source_row_count src))
 			(define lookup_condition (candidate_recset_local_condition
@@ -4799,7 +4819,8 @@ has selected a lowerer. */
 							(if (planner_cost_better? (car alternative) (car current))
 								alternative current))
 						(list candidate_cost projected_rows)))
-					(list (car best) (cadr best))))))))
+					(list (car best) (cadr best)
+						(and exact (equal? (car best) candidate_cost)))))))))
 
 /* Enumerate metadata only. No scan, RecSet, keytable or callback AST is built
 until the caller has selected this physical alternative. */
@@ -5218,8 +5239,21 @@ until the caller has selected this physical alternative. */
 						(planner_membership_downstream_probe_cost legacy_probe_rows)
 						(planner_cost 0 0 0 0 0 0 0 0 0 0.65))
 					(coalesceNil joined_rows legacy_probe_rows) 0.65))
-				(define normal_choice (if (planner_cost_better? scan_cost legacy_cost)
-					"scan_join_order" "legacy_join_tree"))
+				(define projected_legacy_exact (and (not (nil? projected_legacy_cost))
+					(nth projected_legacy_cost 2)))
+				(define scan_clear_winner
+					(planner_cost_clear_winner? scan_cost legacy_cost))
+				(define legacy_clear_winner
+					(planner_cost_clear_winner? legacy_cost scan_cost))
+				(define fuzzy_exact_carrier (and projected_legacy_exact
+					(and (not legacy_lookup_values_required)
+						(and (not scan_clear_winner) (not legacy_clear_winner)))))
+				(define normal_choice (if scan_clear_winner
+					"scan_join_order"
+					(if (or legacy_clear_winner fuzzy_exact_carrier)
+						"legacy_join_tree"
+						(if (planner_cost_better? scan_cost legacy_cost)
+							"scan_join_order" "legacy_join_tree"))))
 				(define decision_id (concat "scan_join_order:"
 					(stable_structural_hash (join_optimizer_tree_aliases plan) true)))
 				(define alternatives (list "legacy_join_tree" "scan_join_order"))
@@ -5232,7 +5266,9 @@ until the caller has selected this physical alternative. */
 					(list "chosen" chosen)
 					(list "normally_chosen" normal_choice)
 					(list "selection" (if (nil? forced) "cost" "calibration_override"))
-					(list "reason" (if (nil? forced) "lowest_total_ns" "calibration_override"))
+					(list "reason" (if (nil? forced)
+						(if fuzzy_exact_carrier "fuzzy_exact_projected_carrier" "cost_dominance")
+						"calibration_override"))
 					(list "inputs" (list
 						(list "join_input_rows" input_rows)
 						(list "join_estimated_rows" joined_rows)
@@ -5732,6 +5768,327 @@ topology inequality by bounded binary search and guard that crossover. */
 		(quote predicate_recset) (scan_access_path_recset_expr stages src candidate)
 		_ (neumann_fail "build_queryplan" "unsupported physical scan access-path descriptor"))))
 
+
+(define direct_group_join_key_column (lambda (stage key)
+	(begin
+		(define input (gs_input stage))
+		(define direct (direct_column_name_for_alias input key))
+		(if (not (nil? direct)) direct
+			(match key
+				((symbol get_column) _alias _alias_ignorecase column column_ignorecase)
+				(resolve_physical_column_name input column column_ignorecase)
+				((quote get_column) _alias alias_ignorecase column column_ignorecase)
+				(direct_group_join_key_column stage
+					(list (symbol "get_column") _alias alias_ignorecase column column_ignorecase))
+				_ nil)))))
+
+(define direct_group_join_group_rows (lambda (stage input_rows)
+	(begin
+		(define input (gs_input stage))
+		(define key_columns (map (gs_keys stage) (lambda (key)
+			(direct_group_join_key_column stage key))))
+		(coalesceNil (reduce key_columns (lambda (estimate column)
+			(if (nil? estimate)
+				nil
+				(begin
+					(define distinct (planner_column_distinct_estimate input column))
+					(if (nil? distinct) nil
+						(min input_rows (* estimate distinct)))))) 1)
+			input_rows))))
+
+(define direct_group_join_source_rows (lambda (stages src)
+	(if (source_is_base_table? src)
+		(planner_source_row_count src)
+		(begin
+			(define stage (source_stage_output_stage stages src))
+			(if (not (group_stage? stage))
+				nil
+				(begin
+					(define input (gs_input stage))
+					(define input_rows (planner_source_row_count input))
+					(if (not (number? input_rows)) nil
+						(direct_group_join_group_rows stage input_rows))))))))
+
+(define direct_group_join_leaf_rows (lambda (stages sources src predicates)
+	(begin
+		(define condition (combine_where (source_join_expr src)
+			(join_optimizer_node_condition predicates)))
+		(if (and (source_is_base_table? src)
+			(join_optimizer_source_constant_unique_point?
+				sources
+				(if (empty_list? sources) (source_alias src) (source_alias (car sources)))
+				src condition))
+			1
+			(begin
+				(define source_rows (direct_group_join_source_rows stages src))
+				(if (and (source_is_base_table? src)
+					(and (number? source_rows) (not (equal? condition true))))
+					(begin
+						(define estimate (planner_source_filter_estimate src condition 512))
+						(max 1 (planner_estimated_matching_rows estimate source_rows
+							(* source_rows (physical_probe_predicate_selectivity predicates)))))
+					source_rows))))))
+
+(define direct_group_join_tree_single_source (lambda (tree sources)
+	(match tree
+		((symbol join-leaf) alias _predicates) (join_optimizer_source_by_alias sources alias)
+		((quote join-leaf) alias predicates)
+		(direct_group_join_tree_single_source
+			(list (symbol "join-leaf") alias predicates) sources)
+		((symbol join-leaf) alias) (join_optimizer_source_by_alias sources alias)
+		((quote join-leaf) alias)
+		(direct_group_join_tree_single_source (list (symbol "join-leaf") alias) sources)
+		_ nil)))
+
+(define direct_group_join_tree_is_functional_lookup? (lambda (tree sources stages)
+	(begin
+		(define src (direct_group_join_tree_single_source tree sources))
+		(and (not (nil? src))
+			(not (nil? (direct_group_probe_stage_for_source stages src (list true))))))))
+
+(define direct_group_join_tree_rows (lambda (tree sources stages)
+	(match tree
+		((symbol join-leaf) alias predicates)
+		(direct_group_join_leaf_rows stages sources
+			(join_optimizer_source_by_alias sources alias) predicates)
+		((quote join-leaf) alias predicates)
+		(direct_group_join_tree_rows
+			(list (symbol "join-leaf") alias predicates) sources stages)
+		((symbol join-leaf) alias)
+		(direct_group_join_tree_rows
+			(list (symbol "join-leaf") alias '()) sources stages)
+		((quote join-leaf) alias)
+		(direct_group_join_tree_rows
+			(list (symbol "join-leaf") alias '()) sources stages)
+		((symbol join-node) kind left right predicates) (begin
+			(define left_rows (direct_group_join_tree_rows left sources stages))
+			(define right_rows (direct_group_join_tree_rows right sources stages))
+			(define selectivity (physical_probe_predicate_selectivity predicates))
+			(if (and (number? left_rows)
+				(direct_group_join_tree_is_functional_lookup? right sources stages))
+				/* A complete group-key lookup contributes at most one row. LEFT JOIN
+				preserves every left row; INNER JOIN can only remove rows. */
+				left_rows
+				(begin
+					(define joined (if (and (number? left_rows) (number? right_rows))
+						(max 1 (* left_rows right_rows selectivity)) nil))
+					(if (and (equal? kind (quote left-outer)) (number? left_rows))
+						(max left_rows (coalesceNil joined left_rows)) joined))))
+		((quote join-node) kind left right predicates)
+		(direct_group_join_tree_rows
+			(list (symbol "join-node") kind left right predicates) sources stages)
+		_ nil)))
+
+(define direct_group_join_tree_invocations (lambda (tree target_alias sources stages multiplier)
+	(if (not (contains? (join_optimizer_tree_aliases tree) target_alias))
+		nil
+		(match tree
+			((symbol join-leaf) _alias _predicates) multiplier
+			((quote join-leaf) alias predicates)
+			(direct_group_join_tree_invocations
+				(list (symbol "join-leaf") alias predicates) target_alias sources stages multiplier)
+			((symbol join-leaf) alias)
+			(direct_group_join_tree_invocations
+				(list (symbol "join-leaf") alias '()) target_alias sources stages multiplier)
+			((quote join-leaf) alias)
+			(direct_group_join_tree_invocations
+				(list (symbol "join-leaf") alias '()) target_alias sources stages multiplier)
+			((symbol join-node) _kind left right predicates)
+			(if (contains? (join_optimizer_tree_aliases left) target_alias)
+				(direct_group_join_tree_invocations left target_alias sources stages multiplier)
+				(begin
+					(define left_rows (direct_group_join_tree_rows left sources stages))
+					(define right_multiplier (if (number? left_rows)
+						/* Every left row executes the keyed group probe. Join
+						selectivity controls matched output rows, not lookup count. */
+						(* multiplier left_rows) nil))
+					(direct_group_join_tree_invocations
+						right target_alias sources stages right_multiplier)))
+			((quote join-node) kind left right predicates)
+			(direct_group_join_tree_invocations
+				(list (symbol "join-node") kind left right predicates)
+				target_alias sources stages multiplier)
+			_ nil))))
+
+/* A direct grouped join probes the grouped input by its complete key and
+reduces all requested aggregates together. Its coefficients are the same
+Costgen-owned scan/group work units used by the carrier and scan_join_order;
+only the structural work counts are specific to this operator. */
+(define direct_group_join_costs (lambda (stage invocations)
+	(begin
+		(define input (gs_input stage))
+		(define input_rows (planner_source_row_count input))
+		(if (or (not (number? input_rows)) (not (number? invocations)))
+			nil
+			(begin
+				(define group_rows (direct_group_join_group_rows stage input_rows))
+				(define rows_per_probe (if (<= group_rows 0) 0
+					(max 1 (/ input_rows group_rows))))
+				(define probed_rows (* invocations rows_per_probe))
+				(define aggregate_width (count (gs_aggregates stage)))
+				(define direct_cost (planner_cost
+					(* invocations planner_membership_scan_invocation_ns)
+					(* probed_rows (+ planner_membership_scan_row_ns
+						(* aggregate_width planner_membership_map_column_row_ns)))
+					(* probed_rows planner_membership_expression_operation_row_ns)
+					0 0 0 (* aggregate_width 8) 0 invocations 0.7))
+				(define carrier_cost (planner_cost
+					(+ planner_group_relation_startup_ns
+						planner_membership_scan_invocation_ns)
+					(* input_rows (+ planner_membership_scan_row_ns
+						(* aggregate_width planner_membership_map_column_row_ns)))
+					(* invocations planner_membership_group_cache_probe_row_ns)
+					0 0
+					(* input_rows planner_group_relation_build_row_ns)
+					(* group_rows (+ 8 (* aggregate_width 8)))
+					0 group_rows 0.7))
+				(list direct_cost carrier_cost input_rows group_rows rows_per_probe))))))
+
+(define direct_group_join_source_selected? (lambda (stages sources tree consumers src)
+	(begin
+		(define stage (direct_group_probe_stage_for_block_source
+			stages sources src consumers))
+		(if (nil? stage)
+			false
+			(begin
+				(define invocations (direct_group_join_tree_invocations
+					tree (source_alias src) sources stages 1))
+				(define costs (direct_group_join_costs stage invocations))
+				(define normal_choice (if (and (not (nil? costs))
+					(planner_cost_better? (car costs) (cadr costs)))
+					"direct_group_join" "group_carrier"))
+				(define decision_id (concat "direct_group_join:" (gs_id stage) ":" (source_alias src)))
+				(define chosen (planner_physical_choice decision_id normal_choice
+					(list "group_carrier" "direct_group_join")))
+				(define forced (planner_physical_override decision_id))
+				(planner_record_physical_decision (list
+					(list "decision_id" decision_id)
+					(list "decision" "direct_group_join")
+					(list "decision_site" "stage_preparation")
+					(list "chosen" chosen)
+					(list "normally_chosen" normal_choice)
+					(list "selection" (if (nil? forced) (if (nil? costs) "fallback" "cost") "calibration_override"))
+					(list "reason" (if (nil? forced) (if (nil? costs) "unknown_statistics_carrier_fallback" "lowest_total_ns") "calibration_override"))
+					(list "inputs" (list
+						(list "probe_invocations" invocations)
+						(list "input_rows" (if (nil? costs) nil (nth costs 2)))
+						(list "group_rows" (if (nil? costs) nil (nth costs 3)))
+						(list "rows_per_probe" (if (nil? costs) nil (nth costs 4)))
+						(list "aggregate_width" (count (gs_aggregates stage)))))
+					(list "alternatives" (if (nil? costs) '() (list
+						(list (list "plan" "group_carrier") (list "cost" (planner_cost_explain (cadr costs))))
+						(list (list "plan" "direct_group_join") (list "cost" (planner_cost_explain (car costs)))))))))
+				(equal? chosen "direct_group_join"))))))
+
+(define direct_group_join_sources_for_block (lambda (stages block)
+	(begin
+		(define sources (qb_sources block))
+		(define tree (query_block_join_plan block sources))
+		(define consumers (query_block_probe_consumers block))
+		(filter sources (lambda (src)
+			(direct_group_join_source_selected? stages sources tree consumers src))))))
+
+(define direct_group_join_scan_expr (lambda (all_sources default_alias stage)
+	(begin
+		(define src (gs_input stage))
+		(define keys (gs_keys stage))
+		(define lookup_keys (qassoc_get (gs_facts stage) (quote lookup-keys) '()))
+		(define condition (coalesceNil
+			(qassoc_get (gs_facts stage) (quote condition) true) true))
+		(define condition_cols (extract_columns_for_alias src condition))
+		(define key_cols (merge_unique (map keys (lambda (expr)
+			(extract_columns_for_alias src expr)))))
+		(define ags (gs_aggregates stage))
+		(define value_cols (merge_unique (map ags (lambda (ag)
+			(if (equal? ag aggregate_count_descriptor)
+				'()
+				(extract_columns_for_alias src (nth ag 0)))))))
+		(define filtercols (merge_unique (list condition_cols key_cols)))
+		(define key_terms (scalar_first_probe_key_terms
+			all_sources default_alias src keys lookup_keys))
+		(define payload_expr (runtime_cons_list_expr (map ags (lambda (ag)
+			(if (equal? ag aggregate_count_descriptor)
+				1
+				(aggregate_map_value_expr ag
+					(lower_column_expr_for_alias src (nth ag 0))))))))
+		(define merge_payload (list (quote lambda) (list (quote old) (quote new))
+			(aggregate_payload_merge_expr ags 0)))
+		(define neutral_payload
+			(runtime_cons_list_expr (map ags (lambda (ag) (nth ag 2)))))
+		(if (single_source? ags)
+			(runtime_cons_list_expr (list
+				(lower_scalar_aggregate_probe_expr all_sources default_alias stage
+					(aggregate_col_name_using src (car ags)))))
+			(list (quote scan)
+				'(session "__memcp_tx")
+				(source_table_expr src)
+				(cons (quote list) filtercols)
+				(list (quote lambda)
+					(map filtercols (lambda (col)
+						(symbol (concat (source_alias src) "." col))))
+					(cons (quote and)
+						(cons (lower_column_expr_for_alias src condition) key_terms)))
+				(cons (quote list) value_cols)
+				(list (quote lambda)
+					(map value_cols (lambda (col)
+						(symbol (concat (source_alias src) "." col))))
+					payload_expr)
+				merge_payload
+				neutral_payload
+				merge_payload
+				false)))))
+
+(define direct_group_join_presence_index (lambda (ags)
+	(reduce (produceN (count ags)) (lambda (found index)
+		(if (>= found 0)
+			found
+			(if (aggregate_count_like? (nth ags index)) index -1))) -1)))
+
+(define build_direct_group_join_leaf_using_recipe (lambda (schema all_sources leaf future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan stage)
+	(begin
+		(define src (physical_join_leaf_source all_sources leaf))
+		(define alias (source_alias src))
+		(define future_sources (join_optimizer_sources_for_order all_sources future_aliases))
+		(define condition_parts (physical_partition_condition
+			default_alias src future_sources final_condition))
+		(define post_outer_condition (nth condition_parts 1))
+		(define remaining_condition (nth condition_parts 2))
+		(define continuation_expr (continuation remaining_condition row_expr order_items))
+		(define ags (gs_aggregates stage))
+		(define count_index (direct_group_join_presence_index ags))
+		/* query_group_final_payload_expr intentionally addresses its canonical
+		payload parameter by name so the same finalizer is shared with grouped
+		carriers. Bind that exact symbol here. */
+		(define payload_symbol (quote payload))
+		(define matched (if (< count_index 0) true
+			(list (quote >) (list (quote nth) payload_symbol count_index) 0)))
+		(define final_payload (query_group_final_payload_expr ags 0))
+		(define key_params (map (group_key_cols (gs_keys stage)) (lambda (col)
+			(symbol (concat alias "." col)))))
+		(define aggregate_params (map ags (lambda (ag)
+			(symbol (concat alias "." (aggregate_col_name_using (gs_input stage) ag))))))
+		(define lookup_values (map (qassoc_get (gs_facts stage) (quote lookup-keys) '())
+			(lambda (expr) (lower_column_expr_for_join all_sources default_alias expr))))
+		(define aggregate_values (map (produceN (count ags)) (lambda (i)
+			(list (quote nth) (quote __direct_group_final_payload) i))))
+		(define bound_continuation (cons
+			(list (quote lambda) (merge (list key_params aggregate_params))
+				(if (equal? post_outer_condition true)
+					continuation_expr
+					(list (quote if)
+						(lower_column_expr_for_join_truth_context all_sources default_alias
+							post_outer_condition (probe_work_context_rows_for_alias probe_context alias))
+						continuation_expr
+						(join_scan_skip_expr result_mode))))
+			(map (merge (list lookup_values aggregate_values)) (lambda (value)
+				(list (quote if) matched value nil)))))
+		(list
+			(list (quote lambda) (list payload_symbol)
+				(list
+					(list (quote lambda) (list (quote __direct_group_final_payload)) bound_continuation)
+					final_payload))
+			(direct_group_join_scan_expr all_sources default_alias stage)))))
+
 (define strip_scan_access_path_predicate (lambda (condition candidate)
 	(if (nil? candidate)
 		condition
@@ -5745,304 +6102,312 @@ topology inequality by bounded binary search and guard that crossover. */
 (define build_join_scan_leaf_using_recipe (lambda (schema all_sources leaf future_aliases default_alias needed_exprs final_condition row_expr order_items offset_value limit_value allow_membership_recset column_recipe stages result_mode probe_context scalar_plan continuation outer_scan)
 	(begin
 		(define src (physical_join_leaf_source all_sources leaf))
-		(define future_sources (join_optimizer_sources_for_order all_sources future_aliases))
-		(if (not (source_is_base_table? src))
-			(neumann_fail "build_queryplan" "multi-source query-block lowering only supports base tables after untangle")
-			true)
-		(define alias (source_alias src))
-		(define condition_parts (physical_partition_condition default_alias src future_sources final_condition))
-		(define local_condition (nth condition_parts 0))
-		(define post_outer_condition (nth condition_parts 1))
-		(define remaining_condition (nth condition_parts 2))
-		(define owned_condition (join_optimizer_node_condition
-			(join_optimizer_leaf_predicates leaf)))
-		(define condition (combine_where
-			(source_join_expr src)
-			(combine_where owned_condition local_condition)))
-		(define ordered_sources (cons src future_sources))
-		(define order_parts (split_order_items_for_join_driver
-			ordered_sources default_alias src order_items stages final_condition '()))
-		(define current_order_items (nth order_parts 0))
-		(define remaining_order_items (nth order_parts 1))
-		(define membership (driver_membership_for_source src condition))
-		(define delay_limit_after_join (ordered_join_limit_requires_complete_rows?
-			(join_optimizer_sources_for_order all_sources (cons alias future_aliases))
-			default_alias final_condition offset_value limit_value stages))
-		(define allow_ordered_batch (and (not (nil? membership))
-			(and (not delay_limit_after_join)
-				(and (not (empty_list? current_order_items))
-					(and (query_limit_active? offset_value limit_value)
-						(and (ordered_batch_stage_supported? (nth membership 0))
-							(downstream_sources_at_most_one_driver_row?
-								ordered_sources default_alias final_condition stages)))))))
-		/* A row-number pipeline owns the order/limit continuation itself. Its
-		logical requirement survives ORC/window lowering, whereas the stage may no
-		longer be present in this leaf's local catalog. It can consume a projected
-		RecSet but cannot execute a separate ordered-driver membership probe without
-		first materializing the derived window. */
-		(define direct_order_limit (and (not (empty_list? current_order_items))
-			(query_limit_active? offset_value limit_value)))
-		(define row_number_membership_consumer
-			(membership_row_number_consumer? membership direct_order_limit))
-		(define current_order_partitioning
-			(planner_source_order_partitioning src current_order_items))
-		(define membership_plan (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
-			nil
-			(recset_project_join_plan_for_membership_using src membership
-				(if (join_scan_reduce? result_mode) (quote aggregate)
-					(if (or direct_order_limit row_number_membership_consumer)
-						(quote order_limit) (quote filter)))
-				(if (and (not (empty_list? current_order_items))
+		(define direct_group_stage
+			(direct_group_probe_stage_for_source stages src (list true)))
+		(if (not (nil? direct_group_stage))
+			(build_direct_group_join_leaf_using_recipe
+				schema all_sources leaf future_aliases default_alias needed_exprs final_condition
+				row_expr order_items offset_value limit_value allow_membership_recset column_recipe
+				stages result_mode probe_context scalar_plan continuation outer_scan direct_group_stage)
+			(begin
+				(define future_sources (join_optimizer_sources_for_order all_sources future_aliases))
+				(if (not (source_is_base_table? src))
+					(neumann_fail "build_queryplan" "multi-source query-block lowering only supports base tables after untangle")
+					true)
+				(define alias (source_alias src))
+				(define condition_parts (physical_partition_condition default_alias src future_sources final_condition))
+				(define local_condition (nth condition_parts 0))
+				(define post_outer_condition (nth condition_parts 1))
+				(define remaining_condition (nth condition_parts 2))
+				(define owned_condition (join_optimizer_node_condition
+					(join_optimizer_leaf_predicates leaf)))
+				(define condition (combine_where
+					(source_join_expr src)
+					(combine_where owned_condition local_condition)))
+				(define ordered_sources (cons src future_sources))
+				(define order_parts (split_order_items_for_join_driver
+					ordered_sources default_alias src order_items stages final_condition '()))
+				(define current_order_items (nth order_parts 0))
+				(define remaining_order_items (nth order_parts 1))
+				(define membership (driver_membership_for_source src condition))
+				(define delay_limit_after_join (ordered_join_limit_requires_complete_rows?
+					(join_optimizer_sources_for_order all_sources (cons alias future_aliases))
+					default_alias final_condition offset_value limit_value stages))
+				(define allow_ordered_batch (and (not (nil? membership))
+					(and (not delay_limit_after_join)
+						(and (not (empty_list? current_order_items))
+							(and (query_limit_active? offset_value limit_value)
+								(and (ordered_batch_stage_supported? (nth membership 0))
+									(downstream_sources_at_most_one_driver_row?
+										ordered_sources default_alias final_condition stages)))))))
+				/* A row-number pipeline owns the order/limit continuation itself. Its
+				logical requirement survives ORC/window lowering, whereas the stage may no
+				longer be present in this leaf's local catalog. It can consume a projected
+				RecSet but cannot execute a separate ordered-driver membership probe without
+				first materializing the derived window. */
+				(define direct_order_limit (and (not (empty_list? current_order_items))
+					(query_limit_active? offset_value limit_value)))
+				(define row_number_membership_consumer
+					(membership_row_number_consumer? membership direct_order_limit))
+				(define current_order_partitioning
+					(planner_source_order_partitioning src current_order_items))
+				(define membership_plan (if (or (nil? membership) (or delay_limit_after_join (not allow_membership_recset)))
+					nil
+					(recset_project_join_plan_for_membership_using src membership
+						(if (join_scan_reduce? result_mode) (quote aggregate)
+							(if (or direct_order_limit row_number_membership_consumer)
+								(quote order_limit) (quote filter)))
+						(if (and (not (empty_list? current_order_items))
+							(query_limit_active? offset_value limit_value))
+							(probe_limit_work_rows limit_value) nil)
+						allow_ordered_batch
+						(prefiltered_driver_recset_expr_for_membership
+							src (source_table_expr_using stages src) condition membership)
+						(+ (count (acceptance_required_sources
+							(membership_downstream_sources all_sources src membership)
+							default_alias final_condition))
+							(count (merge_unique (list
+								(expr_probe_stages final_condition)
+								(physical_scalar_truth_plan_stages scalar_plan)))))
+						(not row_number_membership_consumer)
+						current_order_partitioning
+						(quote join_leaf))))
+				(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
+				(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
+				(define residual_probe_work_rows (membership_plan_residual_work_rows
+					src membership membership_plan
+					(probe_work_context_rows_for_alias probe_context alias)))
+				/* A preceding membership carrier may radically reduce this leaf. Choose
+				the scalar/EXISTS carrier only now, with that node-local cardinality. An
+				adaptive batch keeps the marker inside its batch predicate so each batch
+				runs the same lowerer with its own work estimate. */
+				(define effective_scalar_plan (if (not (nil? scalar_plan))
+					scalar_plan
+					/* Without a preceding membership carrier, retain the established
+					leaf-condition lowering. It owns nullable LEFT-JOIN cardinality and must
+					not be pre-empted by a driver-context estimate from another tree node. */
+					(if (or (nil? membership_plan) use_batch_accept) nil
+						(physical_scalar_truth_plan all_sources src default_alias condition
+							residual_probe_work_rows residual_probe_work_rows stages))))
+				(define effective_scalar_carrier
+					(physical_scalar_truth_plan_carrier effective_scalar_plan))
+				(define scalar_carrier_driver (and (not (nil? effective_scalar_carrier))
+					(equal? alias (car effective_scalar_plan))))
+				/* A truth carrier attached to this leaf is one exact scan boundary. The
+				join tree still decides whether the carrier is built at this node; storage
+				decides how that already-built boundary is traversed. Keeping the latter out
+				of physical lowering prevents a duplicate cardinality observation, guard and
+				plan-cache variant for two representations of the same adaptive operator. */
+				(define consumed_scalar_carrier effective_scalar_carrier)
+				(define scalar_membership_filter false)
+				(define scalar_membership_var (symbol (concat "__ordered_scalar_recset_"
+					(if (nil? (physical_scalar_truth_plan_probe effective_scalar_plan))
+						alias
+						(gs_id (car (physical_scalar_truth_plan_probe effective_scalar_plan)))))))
+				(define carrier_condition
+					(rewrite_physical_scalar_truth_plan effective_scalar_plan condition))
+				(define membership_table_expr (if (and
+					(not (nil? membership_plan))
+					(or (equal? membership_strategy "candidate_keyset")
+						(equal? membership_strategy "prefiltered_candidate_keyset")))
+					(cadr membership_plan)
+					nil))
+				/* Join-tree leaves consume the same ordered RHS key-index alternative as
+				the top-level ordered lowerer. The index is bound outside the scan callback
+				and is therefore built once per query, irrespective of tree depth. */
+				(define membership_keysets (if (and (not (nil? membership))
+					(equal? membership_strategy "driver_order_membership_probe"))
+					(membership_keyset_bindings (list membership))
+					'()))
+				(define use_membership_keyset (not (empty_list? membership_keysets)))
+				(if (expr_contains_driver_membership? condition)
+					(planner_record_physical_decision (list
+						(list "decision" "join_leaf_membership_consumer")
+						(list "chosen" (if (nil? membership_table_expr)
+							"per_row_probe" "projected_recset"))
+						(list "inputs" (list
+							(list "marker_resolved_to_driver" (not (nil? membership)))
+							(list "marker_resolved_to_any_source"
+								(reduce all_sources (lambda (found candidate_src)
+									(or found (not (nil? (driver_membership_for_source candidate_src condition)))))
+									false))
+							(list "keyset_binding_count" (count membership_keysets))
+							(list "carrier_allowed" allow_membership_recset)
+							(list "limit_delayed" delay_limit_after_join)
+							(list "projection_built" (not (nil? membership_table_expr)))))))
+					nil)
+				(define effective_membership (if (or use_batch_accept
+					(not (nil? membership_table_expr))) membership nil))
+				(define effective_condition (if use_membership_keyset
+					(replace_driver_membership_keyset_markers carrier_condition membership_keysets)
+					(strip_driver_membership_for_source src carrier_condition effective_membership)))
+				(define row_number_stage_filter (row_number_stage_for_source stages src effective_condition))
+				/* A candidate-keyset choice makes the projected row positions this leaf's
+				scan carrier even when later join leaves are continuations. A supported
+				driver-probe choice instead keeps the base table and binds one RHS key index
+				outside every continuation. The row-number pipeline still owns a base-table
+				carrier, so it consumes a chosen candidate RecSet as a membership filter until
+				it accepts an explicit source. */
+				(define membership_driver (and
+					(not (nil? membership_table_expr))
+					(nil? row_number_stage_filter)))
+				(define membership_filter (and (not (nil? membership_table_expr)) (not membership_driver)))
+				/* Query-local access-path construction is safe only at the selected driver:
+				inside a continuation it would rebuild the carrier once per outer row. This
+				is an execution-scope capability, not a predicate- or text-specific rule.
+				Join reorder has already selected the driver before this boundary. */
+				(define access_path_build_allowed (and
+					(not membership_driver)
+					(nil? row_number_stage_filter)
+					(> (count all_sources) 1)
+					(equal? alias (probe_work_context_driver_alias probe_context))))
+				(define access_path_order_window (if (and
+					(not (empty_list? current_order_items))
 					(query_limit_active? offset_value limit_value))
-					(probe_limit_work_rows limit_value) nil)
-				allow_ordered_batch
-				(prefiltered_driver_recset_expr_for_membership
-					src (source_table_expr_using stages src) condition membership)
-				(+ (count (acceptance_required_sources
-					(membership_downstream_sources all_sources src membership)
-					default_alias final_condition))
-					(count (merge_unique (list
-						(expr_probe_stages final_condition)
-						(physical_scalar_truth_plan_stages scalar_plan)))))
-				(not row_number_membership_consumer)
-				current_order_partitioning
-				(quote join_leaf))))
-		(define membership_strategy (if (nil? membership_plan) nil (car membership_plan)))
-		(define use_batch_accept (equal? membership_strategy "ordered_batch_accept"))
-		(define residual_probe_work_rows (membership_plan_residual_work_rows
-			src membership membership_plan
-			(probe_work_context_rows_for_alias probe_context alias)))
-		/* A preceding membership carrier may radically reduce this leaf. Choose
-		the scalar/EXISTS carrier only now, with that node-local cardinality. An
-		adaptive batch keeps the marker inside its batch predicate so each batch
-		runs the same lowerer with its own work estimate. */
-		(define effective_scalar_plan (if (not (nil? scalar_plan))
-			scalar_plan
-			/* Without a preceding membership carrier, retain the established
-			leaf-condition lowering. It owns nullable LEFT-JOIN cardinality and must
-			not be pre-empted by a driver-context estimate from another tree node. */
-			(if (or (nil? membership_plan) use_batch_accept) nil
-				(physical_scalar_truth_plan all_sources src default_alias condition
-					residual_probe_work_rows residual_probe_work_rows stages))))
-		(define effective_scalar_carrier
-			(physical_scalar_truth_plan_carrier effective_scalar_plan))
-		(define scalar_carrier_driver (and (not (nil? effective_scalar_carrier))
-			(equal? alias (car effective_scalar_plan))))
-		/* A truth carrier attached to this leaf is one exact scan boundary. The
-		join tree still decides whether the carrier is built at this node; storage
-		decides how that already-built boundary is traversed. Keeping the latter out
-		of physical lowering prevents a duplicate cardinality observation, guard and
-		plan-cache variant for two representations of the same adaptive operator. */
-		(define consumed_scalar_carrier effective_scalar_carrier)
-		(define scalar_membership_filter false)
-		(define scalar_membership_var (symbol (concat "__ordered_scalar_recset_"
-			(if (nil? (physical_scalar_truth_plan_probe effective_scalar_plan))
-				alias
-				(gs_id (car (physical_scalar_truth_plan_probe effective_scalar_plan)))))))
-		(define carrier_condition
-			(rewrite_physical_scalar_truth_plan effective_scalar_plan condition))
-		(define membership_table_expr (if (and
-			(not (nil? membership_plan))
-			(or (equal? membership_strategy "candidate_keyset")
-				(equal? membership_strategy "prefiltered_candidate_keyset")))
-			(cadr membership_plan)
-			nil))
-		/* Join-tree leaves consume the same ordered RHS key-index alternative as
-		the top-level ordered lowerer. The index is bound outside the scan callback
-		and is therefore built once per query, irrespective of tree depth. */
-		(define membership_keysets (if (and (not (nil? membership))
-			(equal? membership_strategy "driver_order_membership_probe"))
-			(membership_keyset_bindings (list membership))
-			'()))
-		(define use_membership_keyset (not (empty_list? membership_keysets)))
-		(if (expr_contains_driver_membership? condition)
-			(planner_record_physical_decision (list
-				(list "decision" "join_leaf_membership_consumer")
-				(list "chosen" (if (nil? membership_table_expr)
-					"per_row_probe" "projected_recset"))
-				(list "inputs" (list
-					(list "marker_resolved_to_driver" (not (nil? membership)))
-					(list "marker_resolved_to_any_source"
-						(reduce all_sources (lambda (found candidate_src)
-							(or found (not (nil? (driver_membership_for_source candidate_src condition)))))
-							false))
-					(list "keyset_binding_count" (count membership_keysets))
-					(list "carrier_allowed" allow_membership_recset)
-					(list "limit_delayed" delay_limit_after_join)
-					(list "projection_built" (not (nil? membership_table_expr)))))))
-			nil)
-		(define effective_membership (if (or use_batch_accept
-			(not (nil? membership_table_expr))) membership nil))
-		(define effective_condition (if use_membership_keyset
-			(replace_driver_membership_keyset_markers carrier_condition membership_keysets)
-			(strip_driver_membership_for_source src carrier_condition effective_membership)))
-		(define row_number_stage_filter (row_number_stage_for_source stages src effective_condition))
-		/* A candidate-keyset choice makes the projected row positions this leaf's
-		scan carrier even when later join leaves are continuations. A supported
-		driver-probe choice instead keeps the base table and binds one RHS key index
-		outside every continuation. The row-number pipeline still owns a base-table
-		carrier, so it consumes a chosen candidate RecSet as a membership filter until
-		it accepts an explicit source. */
-		(define membership_driver (and
-			(not (nil? membership_table_expr))
-			(nil? row_number_stage_filter)))
-		(define membership_filter (and (not (nil? membership_table_expr)) (not membership_driver)))
-		/* Query-local access-path construction is safe only at the selected driver:
-		inside a continuation it would rebuild the carrier once per outer row. This
-		is an execution-scope capability, not a predicate- or text-specific rule.
-		Join reorder has already selected the driver before this boundary. */
-		(define access_path_build_allowed (and
-			(not membership_driver)
-			(nil? row_number_stage_filter)
-			(> (count all_sources) 1)
-			(equal? alias (probe_work_context_driver_alias probe_context))))
-		(define access_path_order_window (if (and
-			(not (empty_list? current_order_items))
-			(query_limit_active? offset_value limit_value))
-			(+ (coalesceNil (planner_literal_value offset_value) 0)
-				(coalesceNil (planner_literal_value limit_value) 0))
-			nil))
-		(define access_path_candidates_before_point_check (if access_path_build_allowed
-			(scan_access_path_candidates src all_sources default_alias effective_condition
-				access_path_order_window)
-			'()))
-		/* A unique point lookup already bounds downstream work. This capability
-		check applies uniformly to every candidate; an enumerator must not hide a
-		second operator decision behind its expression-shape recognizer. */
-		(define access_path_candidates (if (and
-			(not (empty_list? access_path_candidates_before_point_check))
-			(source_unique_point_condition? src effective_condition))
-			'()
-			access_path_candidates_before_point_check))
-		(define access_path_plan (choose_scan_access_path src access_path_candidates))
-		(define access_path_candidate (cadr access_path_plan))
-		(define access_path_selected (and (not (nil? access_path_candidate))
-			(equal? (car access_path_plan)
-				(qassoc_get access_path_candidate (quote plan) nil))))
-		(define residual_condition
-			(strip_scan_access_path_predicate effective_condition
-				(if access_path_selected access_path_candidate nil)))
-		(define membership_var (symbol "__membership_recset"))
-		(define membership_filter_expr (if membership_filter
-			(recset_contains_call_expr membership_var)
-			true))
-		(define scalar_membership_filter_expr (if scalar_membership_filter
-			(recset_contains_call_expr scalar_membership_var)
-			true))
-		(define filter_condition (combine_where scalar_membership_filter_expr
-			(combine_where membership_filter_expr residual_condition)))
-		(define filtercols (merge_unique (list
-			(if (or membership_filter scalar_membership_filter)
-				(list "$recset_contains") '())
-			(join_filter_cols_for_alias all_sources default_alias alias residual_condition))))
-		(define recipe_mapcols (join_recipe_mapcols column_recipe alias))
-		(define raw_mapcols (if (nil? column_recipe)
-			(join_cols_for_alias all_sources default_alias alias needed_exprs)
-			recipe_mapcols))
-		(define mapcols raw_mapcols)
-		(define base_table_expr (if membership_driver membership_table_expr
-			(if (not access_path_selected)
-				(source_table_expr_using stages src)
-				(scan_access_path_table_expr stages src access_path_candidate))))
-		(define table_expr (if (or (not scalar_carrier_driver) scalar_membership_filter)
-			base_table_expr
-			(if (equal? base_table_expr (source_table_expr_using stages src))
-				consumed_scalar_carrier
-				(list (quote recset_intersect)
-					(cons (quote list) (list
+					(+ (coalesceNil (planner_literal_value offset_value) 0)
+						(coalesceNil (planner_literal_value limit_value) 0))
+					nil))
+				(define access_path_candidates_before_point_check (if access_path_build_allowed
+					(scan_access_path_candidates src all_sources default_alias effective_condition
+						access_path_order_window)
+					'()))
+				/* A unique point lookup already bounds downstream work. This capability
+				check applies uniformly to every candidate; an enumerator must not hide a
+				second operator decision behind its expression-shape recognizer. */
+				(define access_path_candidates (if (and
+					(not (empty_list? access_path_candidates_before_point_check))
+					(source_unique_point_condition? src effective_condition))
+					'()
+					access_path_candidates_before_point_check))
+				(define access_path_plan (choose_scan_access_path src access_path_candidates))
+				(define access_path_candidate (cadr access_path_plan))
+				(define access_path_selected (and (not (nil? access_path_candidate))
+					(equal? (car access_path_plan)
+						(qassoc_get access_path_candidate (quote plan) nil))))
+				(define residual_condition
+					(strip_scan_access_path_predicate effective_condition
+						(if access_path_selected access_path_candidate nil)))
+				(define membership_var (symbol "__membership_recset"))
+				(define membership_filter_expr (if membership_filter
+					(recset_contains_call_expr membership_var)
+					true))
+				(define scalar_membership_filter_expr (if scalar_membership_filter
+					(recset_contains_call_expr scalar_membership_var)
+					true))
+				(define filter_condition (combine_where scalar_membership_filter_expr
+					(combine_where membership_filter_expr residual_condition)))
+				(define filtercols (merge_unique (list
+					(if (or membership_filter scalar_membership_filter)
+						(list "$recset_contains") '())
+					(join_filter_cols_for_alias all_sources default_alias alias residual_condition))))
+				(define recipe_mapcols (join_recipe_mapcols column_recipe alias))
+				(define raw_mapcols (if (nil? column_recipe)
+					(join_cols_for_alias all_sources default_alias alias needed_exprs)
+					recipe_mapcols))
+				(define mapcols raw_mapcols)
+				(define base_table_expr (if membership_driver membership_table_expr
+					(if (not access_path_selected)
+						(source_table_expr_using stages src)
+						(scan_access_path_table_expr stages src access_path_candidate))))
+				(define table_expr (if (or (not scalar_carrier_driver) scalar_membership_filter)
+					base_table_expr
+					(if (equal? base_table_expr (source_table_expr_using stages src))
 						consumed_scalar_carrier
-						base_table_expr))))))
-		(define lowered_filter_condition (mark_outer_join_symbols
-			all_sources
-			alias
-			(lower_column_expr_for_join_truth_context
-				all_sources default_alias filter_condition
-				(probe_work_context_rows_for_alias probe_context alias))))
-		(define filter_expr (list (quote lambda)
-			(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
-			lowered_filter_condition))
-		(define batch_filter (if use_batch_accept
-			(ordered_batch_filter_expr all_sources default_alias src condition
-				(list membership) '()
-				(probe_work_context_rows_for_alias probe_context alias) '() true)
-			nil))
-		(define continuation_expr (continuation remaining_condition row_expr remaining_order_items))
-		(define map_body (if (equal? post_outer_condition true)
-			continuation_expr
-			(list (quote if)
-				(lower_column_expr_for_join_truth_context
-					all_sources default_alias post_outer_condition
-					(probe_work_context_rows_for_alias probe_context alias))
-				continuation_expr
-				(join_scan_skip_expr result_mode))))
-		(define map_expr (list (quote lambda)
-			(map mapcols (lambda (col) (scan_callback_symbol_for_alias alias col)))
-			map_body))
-		(define combines_state (not (empty_list? future_aliases)))
-		(define reduce_expr (join_scan_reduce_expr result_mode combines_state))
-		(define scan_expr
-			(if (not (nil? row_number_stage_filter))
-				(build_join_row_number_scan_pipeline schema all_sources src default_alias needed_exprs remaining_condition row_expr row_number_stage_filter membership_var membership_filter column_recipe stages result_mode probe_context combines_state continuation outer_scan)
-				(if use_batch_accept
-					(begin
-						(define ordercols (scan_order_sort_columns_for_join_driver
-							ordered_sources default_alias src current_order_items stages final_condition))
-						(define tiebreaker_cols (filter (source_primary_key_columns src)
-							(lambda (col) (not (contains? ordercols col)))))
-						(list (quote scan_order_batch_accept)
-							'(session "__memcp_tx")
-							table_expr batch_filter
-							(cons (quote list) (merge (list ordercols tiebreaker_cols)))
-							(cons (quote list) (merge (list
-								(order_relations_for_source src current_order_items)
-								(map tiebreaker_cols (lambda (col)
-									(canonical_order_relation <
-										(source_column_order_collation src col)))))))
-							0 (coalesceNil offset_value 0) (coalesceNil limit_value -1)
-							(cons (quote list) mapcols) map_expr reduce_expr
-							(join_scan_neutral_expr result_mode)
-							(or outer_scan (source_outer? src))))
-					(if (and (empty_list? current_order_items) (not (query_limit_active? offset_value limit_value)))
-						(list (quote scan)
-							'(session "__memcp_tx")
-							table_expr
-							(cons (quote list) filtercols)
-							filter_expr
-							(cons (quote list) mapcols)
-							map_expr
-							reduce_expr
-							(join_scan_neutral_expr result_mode)
-							(join_scan_shard_reduce_expr result_mode)
-							(or outer_scan (source_outer? src)))
-						(list (quote scan_order)
-							'(session "__memcp_tx")
-							table_expr
-							(cons (quote list) filtercols)
-							filter_expr
-							(cons (quote list) (if (empty_list? current_order_items) '()
-								(scan_order_sort_columns_for_join_driver ordered_sources default_alias src current_order_items stages final_condition)))
-							(cons (quote list) (if (empty_list? current_order_items) '() (order_relations_for_source src current_order_items)))
-							0
-							(coalesceNil offset_value 0)
-							(coalesceNil limit_value -1)
-							(cons (quote list) mapcols)
-							map_expr
-							reduce_expr
-							(join_scan_neutral_expr result_mode)
-							(or outer_scan (source_outer? src)))))))
-		(define membership_bound_scan (if membership_filter
-			(list
-				(list (quote lambda) (list membership_var) scan_expr)
-				membership_table_expr)
-			scan_expr))
-		(define scalar_bound_scan (if scalar_membership_filter
-			(list
-				(list (quote lambda) (list scalar_membership_var) membership_bound_scan)
-				consumed_scalar_carrier)
-			membership_bound_scan))
-		(if use_membership_keyset
-			(wrap_membership_keyset_bindings membership_keysets scalar_bound_scan)
-			scalar_bound_scan))))
+						(list (quote recset_intersect)
+							(cons (quote list) (list
+								consumed_scalar_carrier
+								base_table_expr))))))
+				(define lowered_filter_condition (mark_outer_join_symbols
+					all_sources
+					alias
+					(lower_column_expr_for_join_truth_context
+						all_sources default_alias filter_condition
+						(probe_work_context_rows_for_alias probe_context alias))))
+				(define filter_expr (list (quote lambda)
+					(map filtercols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+					lowered_filter_condition))
+				(define batch_filter (if use_batch_accept
+					(ordered_batch_filter_expr all_sources default_alias src condition
+						(list membership) '()
+						(probe_work_context_rows_for_alias probe_context alias) '() true)
+					nil))
+				(define continuation_expr (continuation remaining_condition row_expr remaining_order_items))
+				(define map_body (if (equal? post_outer_condition true)
+					continuation_expr
+					(list (quote if)
+						(lower_column_expr_for_join_truth_context
+							all_sources default_alias post_outer_condition
+							(probe_work_context_rows_for_alias probe_context alias))
+						continuation_expr
+						(join_scan_skip_expr result_mode))))
+				(define map_expr (list (quote lambda)
+					(map mapcols (lambda (col) (scan_callback_symbol_for_alias alias col)))
+					map_body))
+				(define combines_state (not (empty_list? future_aliases)))
+				(define reduce_expr (join_scan_reduce_expr result_mode combines_state))
+				(define scan_expr
+					(if (not (nil? row_number_stage_filter))
+						(build_join_row_number_scan_pipeline schema all_sources src default_alias needed_exprs remaining_condition row_expr row_number_stage_filter membership_var membership_filter column_recipe stages result_mode probe_context combines_state continuation outer_scan)
+						(if use_batch_accept
+							(begin
+								(define ordercols (scan_order_sort_columns_for_join_driver
+									ordered_sources default_alias src current_order_items stages final_condition))
+								(define tiebreaker_cols (filter (source_primary_key_columns src)
+									(lambda (col) (not (contains? ordercols col)))))
+								(list (quote scan_order_batch_accept)
+									'(session "__memcp_tx")
+									table_expr batch_filter
+									(cons (quote list) (merge (list ordercols tiebreaker_cols)))
+									(cons (quote list) (merge (list
+										(order_relations_for_source src current_order_items)
+										(map tiebreaker_cols (lambda (col)
+											(canonical_order_relation <
+												(source_column_order_collation src col)))))))
+									0 (coalesceNil offset_value 0) (coalesceNil limit_value -1)
+									(cons (quote list) mapcols) map_expr reduce_expr
+									(join_scan_neutral_expr result_mode)
+									(or outer_scan (source_outer? src))))
+							(if (and (empty_list? current_order_items) (not (query_limit_active? offset_value limit_value)))
+								(list (quote scan)
+									'(session "__memcp_tx")
+									table_expr
+									(cons (quote list) filtercols)
+									filter_expr
+									(cons (quote list) mapcols)
+									map_expr
+									reduce_expr
+									(join_scan_neutral_expr result_mode)
+									(join_scan_shard_reduce_expr result_mode)
+									(or outer_scan (source_outer? src)))
+								(list (quote scan_order)
+									'(session "__memcp_tx")
+									table_expr
+									(cons (quote list) filtercols)
+									filter_expr
+									(cons (quote list) (if (empty_list? current_order_items) '()
+										(scan_order_sort_columns_for_join_driver ordered_sources default_alias src current_order_items stages final_condition)))
+									(cons (quote list) (if (empty_list? current_order_items) '() (order_relations_for_source src current_order_items)))
+									0
+									(coalesceNil offset_value 0)
+									(coalesceNil limit_value -1)
+									(cons (quote list) mapcols)
+									map_expr
+									reduce_expr
+									(join_scan_neutral_expr result_mode)
+									(or outer_scan (source_outer? src)))))))
+				(define membership_bound_scan (if membership_filter
+					(list
+						(list (quote lambda) (list membership_var) scan_expr)
+						membership_table_expr)
+					scan_expr))
+				(define scalar_bound_scan (if scalar_membership_filter
+					(list
+						(list (quote lambda) (list scalar_membership_var) membership_bound_scan)
+						consumed_scalar_carrier)
+					membership_bound_scan))
+				(if use_membership_keyset
+					(wrap_membership_keyset_bindings membership_keysets scalar_bound_scan)
+					scalar_bound_scan))))))
 
 /* Consume the logical join tree recursively. The right subtree is lowered as
 the continuation of the left subtree, so join-node boundaries and outer-join
@@ -8394,7 +8759,18 @@ ordering run. Storage artifacts begin in build_queryplan. */
 			(if (equal? kind "scan_join_order")
 				(if (physical_expr_has_head? plan (quote scan_join_order))
 					"scan_join_order" "legacy_join_tree")
-				"unknown")))))
+				(if (equal? kind "direct_group_join")
+					(if (physical_expr_has_group_relation? plan)
+						"group_carrier" "direct_group_join")
+					"unknown"))))))
+
+(define physical_expr_has_group_relation? (lambda (expr)
+	(match expr
+		(cons head tail) (or (physical_expr_has_group_relation? head)
+			(reduce tail (lambda (found item)
+				(or found (physical_expr_has_group_relation? item))) false))
+		_ (and (or (string? expr) (symbol? expr))
+			(strlike (string expr) ".grp:%")))))
 
 /* recset_project_join is adaptive only inside the physical operator: actual
 source-key and per-shard target cardinalities are available there, while the
@@ -8464,7 +8840,8 @@ potentially large calibrated SELECT result. */
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
 		(define decision_kind (qassoc_get decision "decision" nil))
 		(define expected_family (if (or (equal? decision_kind "membership_carrier")
-			(equal? decision_kind "scan_join_order"))
+			(or (equal? decision_kind "scan_join_order")
+				(equal? decision_kind "direct_group_join")))
 			variant operator_family))
 		(define consistent (equal? operator_family expected_family))
 		(define baseline_hash_key (concat "hash:" decision_id))
@@ -8551,6 +8928,11 @@ potentially large calibrated SELECT result. */
 							"join_output_rows" (physical_calibration_input decision "join_output_rows")
 							"join_table_count" (physical_calibration_input decision "join_table_count")
 							"join_legacy_probe_rows" (physical_calibration_input decision "join_legacy_probe_rows")
+							"probe_invocations" (physical_calibration_input decision "probe_invocations")
+							"input_rows" (physical_calibration_input decision "input_rows")
+							"group_rows" (physical_calibration_input decision "group_rows")
+							"rows_per_probe" (physical_calibration_input decision "rows_per_probe")
+							"aggregate_width" (physical_calibration_input decision "aggregate_width")
 							"rows" (quote __calibration_rows)
 							"result_hash" (quote __calibration_hash)
 							"result_equal" (quote __calibration_equal)))))

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -103,6 +103,52 @@ def get_process_cpu_times(pid: int) -> Optional[Tuple[float, float]]:
     except:
         return None
 
+def find_memcp_pid_for_url(base_url: str) -> Optional[int]:
+    """Find the MemCP instance owned by this runner's HTTP endpoint."""
+    try:
+        port = int(base_url.rsplit(':', 1)[1])
+        result = subprocess.run(
+            ['pgrep', '-f', f'memcp.*--api-port={port}'],
+            capture_output=True, text=True, timeout=2,
+        )
+        for pid_str in result.stdout.splitlines():
+            if pid_str.strip():
+                return int(pid_str.strip())
+    except Exception:
+        pass
+    return None
+
+def wait_for_performance_setup_quiescence(
+    base_url: str, timeout: Optional[float] = None,
+    sample_interval: float = 0.25, quiet_period: float = 1.0,
+) -> bool:
+    """Wait until asynchronous fixture rebuild work stops consuming CPU."""
+    if timeout is None:
+        timeout = PERF_SETUP_MAX_TIME_SEC
+    pid = find_memcp_pid_for_url(base_url)
+    if pid is None:
+        return False
+    started = time.monotonic()
+    previous_at = started
+    previous_cpu = get_process_cpu_times(pid)
+    quiet_since = None
+    while previous_cpu is not None and time.monotonic() - started < timeout:
+        if ram_pressure_abort.wait(sample_interval):
+            return False
+        now = time.monotonic()
+        current_cpu = get_process_cpu_times(pid)
+        if current_cpu is None:
+            return False
+        cpu_fraction = max(0.0, current_cpu - previous_cpu) / max(0.001, now - previous_at)
+        if cpu_fraction <= 0.05:
+            quiet_since = quiet_since or now
+            if now - quiet_since >= quiet_period:
+                return True
+        else:
+            quiet_since = None
+        previous_at, previous_cpu = now, current_cpu
+    return False
+
 def measure_cpu_load(pid: int, start_cpu: float, end_cpu: float, elapsed_sec: float) -> Optional[float]:
     """Calculate CPU load as percentage of total CPU capacity.
     Returns percentage where 100% = one core fully utilized, NUM_CPUS*100% = all cores."""
@@ -618,10 +664,39 @@ class SQLTestRunner:
         self.current_spec_file = None
         self._config_loaded = False
         self.performance_calibration = performance_calibration or load_performance_scale()
+        self._perf_round_setup_barrier = None
+        self._perf_round_done_barrier = None
+        self._perf_round_failed = None
+        self._perf_round_count = 0
+        self._perf_setup_semaphore = None
 
     def set_restart_handler(self, fn):
         """Install a restart handler callable that restarts MemCP (returns True on success)."""
         self._restart_handler = fn
+
+    def abort_performance_round(self) -> None:
+        """Release every suite promptly when one parallel fixture setup fails."""
+        if self._perf_round_failed is not None:
+            self._perf_round_failed.set()
+        for barrier in (self._perf_round_setup_barrier, self._perf_round_done_barrier):
+            if barrier is not None:
+                try:
+                    barrier.abort()
+                except threading.BrokenBarrierError:
+                    pass
+
+    def restart_server_after_setup(self, database: str) -> bool:
+        """Gracefully persist all prepared fixtures, then restart the managed server."""
+        if self._restart_handler is None:
+            print("❌ restart_after_setup requires a runner-managed MemCP process")
+            return False
+        response = self.execute_sql(
+            database, "SHUTDOWN", retry_on_connection_failure=False,
+        )
+        if response is not None and response.status_code >= 500:
+            print(f"❌ SHUTDOWN after setup failed: HTTP {response.status_code}")
+            return False
+        return self._restart_handler()
 
     def load_perf_baselines(self):
         """Load runner config from disk, including perf baselines and failure stats."""
@@ -1123,6 +1198,13 @@ class SQLTestRunner:
         # Supports {rows} and {database} template placeholders for perf tests
         test_setup_steps = test_case.get("setup")
         heap_bytes = 0
+
+        def fail_setup(reason, statement=None, response=None, expected=None):
+            self.abort_performance_round()
+            return self._record_fail(
+                name, reason, statement, response, expected, is_noncritical,
+            )
+
         if test_setup_steps and isinstance(test_setup_steps, list):
             setup_started = time.monotonic()
             for step in test_setup_steps:
@@ -1132,51 +1214,67 @@ class SQLTestRunner:
                 if check_ram_pressure():
                     trip_ram_abort(f"setup step of {name}")
                 if ram_pressure_abort.is_set():
-                    return self._record_fail(name, "Aborted: RAM pressure during setup", None, None, None, is_noncritical)
+                    return fail_setup("Aborted: RAM pressure during setup")
                 setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
                 if PERF_TEST_ENABLED and setup_remaining <= 0:
-                    return self._record_fail(
-                        name, f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit",
-                        None, None, None, is_noncritical,
-                    )
+                    return fail_setup(f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit")
                 if "sql" in step:
                     sql_code = step["sql"]
                     if is_perf_test:
                         sql_code = sql_code.replace("{rows}", str(perf_rows)).replace("{database}", database)
-                    with performance_server_gate():
-                        resp = self.execute_sql(
-                            database, sql_code, syntax=self.suite_syntax,
-                            session_id=session_id,
-                            timeout=(
-                                max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
-                                if PERF_TEST_ENABLED else int(step.get("timeout", 600))
-                            ),
-                        )
+                    if self._perf_setup_semaphore is not None:
+                        if not self._perf_setup_semaphore.acquire(timeout=max(0, setup_remaining)):
+                            return fail_setup(f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit")
+                        setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+                    try:
+                        with performance_server_gate():
+                            resp = self.execute_sql(
+                                database, sql_code, syntax=self.suite_syntax,
+                                session_id=session_id,
+                                timeout=(
+                                    max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
+                                    if PERF_TEST_ENABLED else int(step.get("timeout", 600))
+                                ),
+                            )
+                    finally:
+                        if self._perf_setup_semaphore is not None:
+                            self._perf_setup_semaphore.release()
                     expect_error = self._step_expects_error(step)
                     if resp is None:
-                        return self._record_fail(name, "Setup SQL failed: no response", sql_code, None, None, is_noncritical)
+                        return fail_setup("Setup SQL failed: no response", sql_code)
                     if expect_error:
                         if resp.status_code == 200 and "Error" not in resp.text:
-                            return self._record_fail(name, "Setup SQL expected error but succeeded", sql_code, resp, {"error": True}, is_noncritical)
+                            return fail_setup(
+                                "Setup SQL expected error but succeeded",
+                                sql_code, resp, {"error": True},
+                            )
                     else:
                         if resp.status_code != 200 or "Error" in resp.text:
-                            return self._record_fail(name, "Setup SQL failed", sql_code, resp, None, is_noncritical)
+                            return fail_setup("Setup SQL failed", sql_code, resp)
                 elif "scm" in step:
                     scm = step["scm"]
                     if is_perf_test:
                         scm = scm.replace("{rows}", str(perf_rows)).replace("{database}", database)
                     url = f"{self.base_url}/scm"
                     try:
-                        with performance_server_gate():
-                            resp = requests.post(
-                                url, data=scm, headers=self.auth_header,
-                                timeout=(max(1, min(600, math.ceil(setup_remaining)))
-                                         if PERF_TEST_ENABLED else 600),
-                            )
+                        if self._perf_setup_semaphore is not None:
+                            if not self._perf_setup_semaphore.acquire(timeout=max(0, setup_remaining)):
+                                return fail_setup(f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit")
+                            setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+                        try:
+                            with performance_server_gate():
+                                resp = requests.post(
+                                    url, data=scm, headers=self.auth_header,
+                                    timeout=(max(1, min(600, math.ceil(setup_remaining)))
+                                             if PERF_TEST_ENABLED else 600),
+                                )
+                        finally:
+                            if self._perf_setup_semaphore is not None:
+                                self._perf_setup_semaphore.release()
                     except Exception as e:
-                        return self._record_fail(name, f"Setup SCM error: {e}", scm, None, None, is_noncritical)
+                        return fail_setup(f"Setup SCM error: {e}", scm)
                     if resp is None or resp.status_code != 200:
-                        return self._record_fail(name, "Setup SCM failed", scm, resp, None, is_noncritical)
+                        return fail_setup("Setup SCM failed", scm, resp)
                     # Extract heap stats from response if available
                     try:
                         result = json.loads(resp.text.strip())
@@ -1184,6 +1282,24 @@ class SQLTestRunner:
                             heap_bytes = result[1]
                     except:
                         pass
+
+        # A/B suites advance in lockstep: every YAML prepares its next timed
+        # case in parallel, then all asynchronous rebuild work must settle
+        # before any runner can enter an exclusive measurement window.
+        if is_perf_test and self._perf_round_setup_barrier is not None:
+            try:
+                self._perf_round_setup_barrier.wait(
+                    timeout=PERF_SETUP_MAX_TIME_SEC * 2 + 10,
+                )
+            except threading.BrokenBarrierError:
+                if self._perf_round_failed is not None:
+                    self._perf_round_failed.set()
+            if self._perf_round_failed is not None and self._perf_round_failed.is_set():
+                return self._record_fail(
+                    name,
+                    f"Fixture preparation did not quiesce within {PERF_SETUP_MAX_TIME_SEC:g}s",
+                    None, None, None, is_noncritical,
+                )
 
         # Scheme code execution via /scm endpoint
         scm_code = test_case.get("scm")
@@ -1233,7 +1349,6 @@ class SQLTestRunner:
         # Multi-step test case: steps list with per-step session_id + optional background
         steps = test_case.get("steps")
         if steps:
-            import threading
             bg_results: list = []  # [(step_dict, response_or_exception)]
             bg_threads: list = []
 
@@ -1867,6 +1982,11 @@ class SQLTestRunner:
             print(f"⏱️  Suite duration: {self._format_duration(time.perf_counter() - suite_start)}")
             return False
 
+        if (PERF_TEST_ENABLED and not setup_done and metadata.get('restart_after_setup')
+                and not self.restart_server_after_setup(database)):
+            print("❌ Restart after setup failed")
+            return False
+
         # Expand repeat blocks into flat test_cases list, then run.
         # A repeat block looks like: { repeat: N, delay_ms: 50, tests: [...] }
         # The inner tests are duplicated N times with iteration-suffixed names
@@ -1897,33 +2017,59 @@ class SQLTestRunner:
                 if "threshold_ms" in test_case
             ]
 
-        # Preserve declared concurrency in every mode. Fail-fast stops only
-        # after the complete parallel group containing the first failure.
-        i = 0
-        while i < len(test_cases):
-            tc = test_cases[i]
-            if '_delay_ms' in tc:
-                time.sleep(tc['_delay_ms'] / 1000.0)
-                i += 1
-                continue
-            group = tc.get('parallel')
-            if group:
-                group_tests = [tc]
-                j = i + 1
-                while j < len(test_cases) and test_cases[j].get('parallel') == group:
-                    group_tests.append(test_cases[j])
-                    j += 1
-                print(f"⚡ Running {len(group_tests)} tests in parallel group '{group}'")
-                self._run_parallel_group(group_tests, database)
-                i = j
-            else:
-                self.run_test_case(tc, database)
-                i += 1
-            if self.fail_fast and self.failed_critical > 0:
-                remaining_tests = sum(1 for pending in test_cases[i:] if '_delay_ms' not in pending)
-                if remaining_tests > 0:
-                    print(f"⏭️  Fail-fast skipped {remaining_tests} tests after the first failure")
-                break
+        if PERF_AB_MODE and self._perf_round_count:
+            # Each suite contributes at most one case to a round. Empty suites
+            # still join both barriers so shorter YAMLs cannot let another
+            # suite begin its next fill while measurements are in progress.
+            for round_index in range(self._perf_round_count):
+                if round_index < len(test_cases):
+                    self.run_test_case(test_cases[round_index], database)
+                    if self.failed_critical > 0:
+                        self.abort_performance_round()
+                else:
+                    try:
+                        self._perf_round_setup_barrier.wait(
+                            timeout=PERF_SETUP_MAX_TIME_SEC * 2 + 10,
+                        )
+                    except threading.BrokenBarrierError:
+                        if self._perf_round_failed is not None:
+                            self._perf_round_failed.set()
+                try:
+                    self._perf_round_done_barrier.wait(
+                        timeout=PERF_SETUP_MAX_TIME_SEC * 2 + 10,
+                    )
+                except threading.BrokenBarrierError:
+                    if self._perf_round_failed is not None:
+                        self._perf_round_failed.set()
+                    break
+        else:
+            # Preserve declared concurrency in every mode. Fail-fast stops only
+            # after the complete parallel group containing the first failure.
+            i = 0
+            while i < len(test_cases):
+                tc = test_cases[i]
+                if '_delay_ms' in tc:
+                    time.sleep(tc['_delay_ms'] / 1000.0)
+                    i += 1
+                    continue
+                group = tc.get('parallel')
+                if group:
+                    group_tests = [tc]
+                    j = i + 1
+                    while j < len(test_cases) and test_cases[j].get('parallel') == group:
+                        group_tests.append(test_cases[j])
+                        j += 1
+                    print(f"⚡ Running {len(group_tests)} tests in parallel group '{group}'")
+                    self._run_parallel_group(group_tests, database)
+                    i = j
+                else:
+                    self.run_test_case(tc, database)
+                    i += 1
+                if self.fail_fast and self.failed_critical > 0:
+                    remaining_tests = sum(1 for pending in test_cases[i:] if '_delay_ms' not in pending)
+                    if remaining_tests > 0:
+                        print(f"⏭️  Fail-fast skipped {remaining_tests} tests after the first failure")
+                    break
 
         if spec.get('cleanup'):
             self.run_cleanup(spec['cleanup'], database)
@@ -2186,6 +2332,23 @@ def discover_performance_ci_suites(root: Path = Path("tests/performance")) -> Li
     return suites
 
 
+def performance_measurement_count(spec_file: str) -> int:
+    """Count the timed cases that participate in A/B measurement rounds."""
+    with open(spec_file, 'r') as handle:
+        spec = yaml.safe_load(handle) or {}
+    count = 0
+    for case in spec.get("test_cases", []):
+        if not isinstance(case, dict):
+            continue
+        inner_cases = case.get("tests", []) if "repeat" in case else [case]
+        multiplier = int(case.get("repeat", 1)) if "repeat" in case else 1
+        count += multiplier * sum(
+            1 for inner in inner_cases
+            if isinstance(inner, dict) and "threshold_ms" in inner
+        )
+    return count
+
+
 def run_spec_subprocess(spec_file: str, port: Optional[int], log_times: bool, connect_only: bool, fail_fast: bool) -> Tuple[bool, str]:
     cmd = [sys.executable, os.path.abspath(__file__), spec_file]
     if connect_only and port is not None:
@@ -2203,7 +2366,7 @@ def run_spec_subprocess(spec_file: str, port: Optional[int], log_times: bool, co
 
 def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: bool, jobs: Optional[int],
                    restart_handler=None, connect_only: bool = False, fail_fast: bool = False) -> bool:
-    if len(spec_files) == 1:
+    if len(spec_files) == 1 and not PERF_TEST_ENABLED:
         runner = SQLTestRunner(base_url, log_times=log_times, fail_fast=fail_fast)
         if restart_handler is not None:
             runner.set_restart_handler(restart_handler)
@@ -2219,6 +2382,9 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
             spec_file: SQLTestRunner(base_url, log_times=log_times)
             for spec_file in spec_files
         }
+        if restart_handler is not None:
+            for runner in runners.values():
+                runner.set_restart_handler(restart_handler)
         with ThreadPoolExecutor(max_workers=max_jobs) as executor:
             futures = {
                 executor.submit(runners[spec_file].prepare_test_spec, spec_file): spec_file
@@ -2232,11 +2398,43 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
                 print(f"   ❌ {spec_file}")
             return False
 
+
+        restart_suites = [
+            spec_file for spec_file, runner in runners.items()
+            if runner.suite_metadata.get("restart_after_setup")
+        ]
+        if restart_suites:
+            print(
+                "🔄 Persisting prepared fixtures and restarting MemCP once before "
+                f"measurement ({len(restart_suites)} suite(s) requested it)"
+            )
+            if not next(iter(runners.values())).restart_server_after_setup(
+                    next(iter(runners.values())).default_database):
+                print("❌ Shared restart after performance setup failed")
+                return False
+
+        round_count = max(performance_measurement_count(spec_file) for spec_file in spec_files)
+        round_failed = threading.Event()
+
+        def settle_fixture_work():
+            if not wait_for_performance_setup_quiescence(base_url):
+                round_failed.set()
+
+        setup_barrier = threading.Barrier(len(spec_files), action=settle_fixture_work)
+        done_barrier = threading.Barrier(len(spec_files))
+        setup_semaphore = threading.Semaphore(max_jobs)
+        for runner in runners.values():
+            runner._perf_round_setup_barrier = setup_barrier
+            runner._perf_round_done_barrier = done_barrier
+            runner._perf_round_failed = round_failed
+            runner._perf_round_count = round_count
+            runner._perf_setup_semaphore = setup_semaphore
+
         print(
-            "⏱️  All suite setups complete; continuing fixture work in parallel "
-            "with exclusive timed-query windows"
+            f"⏱️  All suite setups complete; running {round_count} fill/measure "
+            "round(s) with parallel fixture work and serial timed queries"
         )
-        with ThreadPoolExecutor(max_workers=max_jobs) as executor:
+        with ThreadPoolExecutor(max_workers=len(spec_files)) as executor:
             futures = {
                 executor.submit(
                     runners[spec_file].run_test_spec, spec_file, True

--- a/tests/performance/forum-hierarchy-aggregate-joins.yaml
+++ b/tests/performance/forum-hierarchy-aggregate-joins.yaml
@@ -4,7 +4,8 @@ metadata:
   version: "1.0"
   description: "Forum hierarchy lookup with per-forum child and thread aggregates"
   isolated: true
-  ci: false
+  ci: true
+  restart_after_setup: true
 
 # Reproduces https://www.reddit.com/r/mysql/comments/1l0ceun/having_trouble_understanding_the_problem_point_in/
 # at the reported 10k-forum/33k-thread scale. Median A/B on the x86_64
@@ -68,13 +69,6 @@ setup:
   - scm: "(rebuild)"
 
 test_cases:
-  # Persist the large prepared fixture before timing it. The production-sized
-  # benchmark is deliberately excluded from CI and should not charge lazy
-  # reload/finalization work to the SELECT under test.
-  - name: "Persist prepared forum hierarchy fixture"
-    sql: "SHUTDOWN"
-    expect: {rows: 0}
-
   - name: "Hierarchy with child-count group only"
     warmup: 1
     timing_samples: 5
@@ -141,7 +135,6 @@ test_cases:
   - name: "Forum hierarchy with global aggregate subqueries"
     warmup: 1
     timing_samples: 5
-    threshold_ms: 500
     sql: |
       SELECT
         f.forumID, f.title, f.description, f.forumType, f.parentID, f.heritage,

--- a/tests/performance/forum-hierarchy-aggregate-joins.yaml
+++ b/tests/performance/forum-hierarchy-aggregate-joins.yaml
@@ -1,0 +1,279 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+
+metadata:
+  version: "1.0"
+  description: "Forum hierarchy lookup with per-forum child and thread aggregates"
+  isolated: true
+  ci: false
+
+# Reproduces https://www.reddit.com/r/mysql/comments/1l0ceun/having_trouble_understanding_the_problem_point_in/
+# at the reported 10k-forum/33k-thread scale. Median A/B on the x86_64
+# reference host: 4,077ms before direct grouped joins, 8.9ms afterwards.
+
+setup:
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_users"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_posts"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_threads"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_forums"
+  - sql: "CREATE TABLE forum_hierarchy_forums (forumID INT PRIMARY KEY, title VARCHAR(64), description VARCHAR(64), forumType VARCHAR(16), parentID INT, heritage VARCHAR(128), `order` INT, gameID INT, threadCount INT) ENGINE=sloppy"
+  - sql: "CREATE TABLE forum_hierarchy_threads (threadID INT PRIMARY KEY, forumID INT, postCount INT, lastPostID INT) ENGINE=sloppy"
+  - sql: "CREATE TABLE forum_hierarchy_posts (postID INT PRIMARY KEY, authorID INT, datePosted BIGINT) ENGINE=sloppy"
+  - sql: "CREATE TABLE forum_hierarchy_users (userID INT PRIMARY KEY, username VARCHAR(32)) ENGINE=sloppy"
+  - scm: |
+      (insert (table "memcp-tests" "forum_hierarchy_forums")
+        '("forumID" "title" "description" "forumType" "parentID" "heritage" "order" "gameID" "threadCount")
+        (map (produceN 10000) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (list id (concat "Forum " (string id)) "Description" "forum"
+              (if (<= id 8) (- id 1) 0)
+              (if (<= id 8)
+                (nth '("/0001/" "/0001/0002/" "/0001/0002/0003/" "/0001/0002/0003/0004/" "/0001/0002/0003/0004/0005/" "/0001/0002/0003/0004/0005/0006/" "/0001/0002/0003/0004/0005/0006/0007/" "/0001/0002/0003/0004/0005/0006/0007/0008/") (- id 1))
+                (concat "/root/" (string id) "/"))
+              (mod id 100) (mod id 50) (mod id 17))))))
+  - scm: |
+      (insert (table "memcp-tests" "forum_hierarchy_threads")
+        '("threadID" "forumID" "postCount" "lastPostID")
+        (map (produceN 33669) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (list id (+ 1 (mod i 10000)) (+ 1 (mod i 40)) id)))))
+  - scm: |
+      (insert (table "memcp-tests" "forum_hierarchy_posts")
+        '("postID" "authorID" "datePosted")
+        (map (produceN 33669) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (list id (+ 1 (mod i 1000)) (+ 1700000000 id))))))
+  - scm: |
+      (insert (table "memcp-tests" "forum_hierarchy_users")
+        '("userID" "username")
+        (map (produceN 1000) (lambda (i)
+          (list (+ i 1) (concat "user" (string (+ i 1)))))))
+  - scm: "(rebuild)"
+  # Feed representative equality probes into the automatic partition scorer,
+  # then persist the selected layout. Shard size remains the production default.
+  - scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define forums (table "memcp-tests" "forum_hierarchy_forums"))
+        (define threads (table "memcp-tests" "forum_hierarchy_threads"))
+        (map (produceN 8) (lambda (i)
+          (begin
+            (define forum_id (+ i 1))
+            (scan tx forums '("parentID") (lambda (parentID) (equal?? parentID forum_id))
+              '() (lambda () 1) + 0 + false)
+            (scan tx threads '("forumID") (lambda (threadForumID) (equal?? threadForumID forum_id))
+              '("postCount") (lambda (postCount) postCount) + nil nil false)))))
+  - scm: "(rebuild)"
+
+test_cases:
+  # Persist the large prepared fixture before timing it. The production-sized
+  # benchmark is deliberately excluded from CI and should not charge lazy
+  # reload/finalization work to the SELECT under test.
+  - name: "Persist prepared forum hierarchy fixture"
+    sql: "SHUTDOWN"
+    expect: {rows: 0}
+
+  - name: "Hierarchy with child-count group only"
+    warmup: 1
+    timing_samples: 5
+    threshold_ms: 500
+    sql: |
+      SELECT f.forumID, cc.childCount
+      FROM forum_hierarchy_forums f
+      LEFT JOIN (
+        SELECT parentID AS forumID, COUNT(forumID) AS childCount
+        FROM forum_hierarchy_forums GROUP BY parentID
+      ) cc ON cc.forumID = f.forumID
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      ORDER BY LENGTH(f.heritage)
+    expect: {rows: 8}
+
+  - name: "Hierarchy with thread group only"
+    warmup: 1
+    timing_samples: 5
+    threshold_ms: 500
+    sql: |
+      SELECT f.forumID, t.numPosts
+      FROM forum_hierarchy_forums f
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      LEFT JOIN (
+        SELECT forumID, SUM(postCount) AS numPosts
+        FROM forum_hierarchy_threads GROUP BY forumID
+      ) t ON f.forumID = t.forumID
+      ORDER BY LENGTH(f.heritage)
+    expect: {rows: 8}
+
+  - name: "Grouped aggregate output without downstream join"
+    sql: |
+      SELECT f.forumID, t.maxPostID
+      FROM forum_hierarchy_forums f
+      LEFT JOIN (
+        SELECT forumID, MAX(lastPostID) AS maxPostID
+        FROM forum_hierarchy_threads
+        GROUP BY forumID
+      ) t ON f.forumID = t.forumID
+      WHERE f.forumID = 8
+    expect:
+      rows: 1
+      data:
+        - {forumID: 8, maxPostID: 30008}
+
+  - name: "Grouped aggregate output used by downstream join"
+    sql: |
+      SELECT f.forumID, t.maxPostID, lp.postID
+      FROM forum_hierarchy_forums f
+      LEFT JOIN (
+        SELECT forumID, MAX(lastPostID) AS maxPostID
+        FROM forum_hierarchy_threads
+        GROUP BY forumID
+      ) t ON f.forumID = t.forumID
+      LEFT JOIN forum_hierarchy_posts lp ON t.maxPostID = lp.postID
+      WHERE f.forumID = 8
+    expect:
+      rows: 1
+      data:
+        - {forumID: 8, maxPostID: 30008, postID: 30008}
+
+  - name: "Forum hierarchy with global aggregate subqueries"
+    warmup: 1
+    timing_samples: 5
+    threshold_ms: 500
+    sql: |
+      SELECT
+        f.forumID, f.title, f.description, f.forumType, f.parentID, f.heritage,
+        cc.childCount, f.`order`, f.gameID, f.threadCount,
+        t.numPosts AS postCount, t.lastPostID, u.userID, u.username, lp.datePosted
+      FROM forum_hierarchy_forums f
+      LEFT JOIN (
+        SELECT parentID AS forumID, COUNT(forumID) AS childCount
+        FROM forum_hierarchy_forums
+        GROUP BY parentID
+      ) cc ON cc.forumID = f.forumID
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      LEFT JOIN (
+        SELECT forumID, SUM(postCount) AS numPosts, MAX(lastPostID) AS lastPostID
+        FROM forum_hierarchy_threads
+        GROUP BY forumID
+      ) t ON f.forumID = t.forumID
+      LEFT JOIN forum_hierarchy_posts lp ON t.lastPostID = lp.postID
+      LEFT JOIN forum_hierarchy_users u ON lp.authorID = u.userID
+      ORDER BY LENGTH(f.heritage)
+    expect: {rows: 8}
+
+  - name: "Forum hierarchy original physical plan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT f.forumID, cc.childCount, t.numPosts, t.lastPostID
+      FROM forum_hierarchy_forums f
+      LEFT JOIN (
+        SELECT parentID AS forumID, COUNT(forumID) AS childCount
+        FROM forum_hierarchy_forums
+        GROUP BY parentID
+      ) cc ON cc.forumID = f.forumID
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      LEFT JOIN (
+        SELECT forumID, SUM(postCount) AS numPosts, MAX(lastPostID) AS lastPostID
+        FROM forum_hierarchy_threads
+        GROUP BY forumID
+      ) t ON f.forumID = t.forumID
+      ORDER BY LENGTH(f.heritage)
+    expect:
+      rows: 1
+      result_contains: ["physical", "direct_group_join", "chosen direct_group_join"]
+
+  - name: "Forum hierarchy with correlated aggregates after hierarchy filtering"
+    warmup: 1
+    timing_samples: 5
+    threshold_ms: 500
+    sql: |
+      SELECT
+        f.forumID, f.title, f.description, f.forumType, f.parentID, f.heritage,
+        (SELECT COUNT(*)
+          FROM forum_hierarchy_forums child
+          WHERE child.parentID = f.forumID) AS childCount,
+        f.`order`, f.gameID, f.threadCount,
+        (SELECT SUM(th.postCount)
+          FROM forum_hierarchy_threads th
+          WHERE th.forumID = f.forumID) AS postCount,
+        lp.postID AS lastPostID, u.userID, u.username, lp.datePosted
+      FROM forum_hierarchy_forums f
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      LEFT JOIN forum_hierarchy_posts lp ON lp.postID = (
+        SELECT MAX(last_thread.lastPostID)
+        FROM forum_hierarchy_threads last_thread
+        WHERE last_thread.forumID = f.forumID
+      )
+      LEFT JOIN forum_hierarchy_users u ON lp.authorID = u.userID
+      ORDER BY LENGTH(f.heritage)
+    expect: {rows: 8}
+
+  - name: "Forum hierarchy correlated aggregate physical plan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT f.forumID,
+        (SELECT COUNT(*) FROM forum_hierarchy_forums child
+          WHERE child.parentID = f.forumID) AS childCount,
+        (SELECT SUM(th.postCount) FROM forum_hierarchy_threads th
+          WHERE th.forumID = f.forumID) AS postCount
+      FROM forum_hierarchy_forums f
+      INNER JOIN forum_hierarchy_forums p ON p.forumID = 8
+        AND p.heritage LIKE CONCAT(f.heritage, '%')
+      ORDER BY LENGTH(f.heritage)
+    expect:
+      rows: 1
+      result_contains: ["physical"]
+
+  - name: "Forum hierarchy handwritten hierarchy-first scan pipeline"
+    timing_samples: 5
+    scm: |
+      (begin
+        (define tx (session "__memcp_tx"))
+        (define forums (table "memcp-tests" "forum_hierarchy_forums"))
+        (define threads (table "memcp-tests" "forum_hierarchy_threads"))
+        (define posts (table "memcp-tests" "forum_hierarchy_posts"))
+        (define users (table "memcp-tests" "forum_hierarchy_users"))
+        (define selected_heritage
+          (scan tx forums '("forumID") (lambda (forumID) (equal? forumID 8))
+            '("heritage") (lambda (heritage) heritage)
+            (lambda (_old value) value) nil nil false))
+        (define found
+          (scan tx forums '("heritage")
+            (lambda (heritage) (strlike selected_heritage (concat heritage "%")))
+            '("forumID")
+            (lambda (forumID)
+              (begin
+                (define child_count
+                  (scan tx forums '("parentID") (lambda (parentID) (equal?? parentID forumID))
+                    '() (lambda () 1) + 0 + false))
+                (define thread_stats
+                  (scan tx threads '("forumID") (lambda (threadForumID) (equal?? threadForumID forumID))
+                    '("postCount" "lastPostID") (lambda (postCount lastPostID) (list postCount lastPostID))
+                    (lambda (acc row) (list (+ (car acc) (car row)) (max (cadr acc) (cadr row))))
+                    '(0 0)
+                    (lambda (acc row) (list (+ (car acc) (car row)) (max (cadr acc) (cadr row))))
+                    false))
+                (define post
+                  (scan tx posts '("postID") (lambda (postID) (equal?? postID (cadr thread_stats)))
+                    '("authorID" "datePosted") (lambda (authorID datePosted) (list authorID datePosted))
+                    (lambda (_old row) row) nil nil true))
+                (define username
+                  (if (nil? post) nil
+                    (scan tx users '("userID") (lambda (userID) (equal?? userID (car post)))
+                      '("username") (lambda (value) value)
+                      (lambda (_old value) value) nil nil true)))
+                (list forumID child_count (car thread_stats) (cadr thread_stats) username)))
+            (lambda (count _row) (+ count 1)) 0 + false))
+        (if (equal? found 8) "ok" (error (concat "wrong hierarchy row count: " found))))
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_users"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_posts"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_threads"
+  - sql: "DROP TABLE IF EXISTS forum_hierarchy_forums"

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -158,6 +158,41 @@ test_cases:
       ORDER BY d.sort_key DESC
       LIMIT 72
 
+  # Grouped derived relations have a materially different fixed/build cost
+  # from the in-memory membership cache. Pair two input sizes so Costgen can
+  # identify both terms while the forced direct scan validates equal results.
+  - name: "small grouped derived relation versus keyed probes"
+    physical_calibration: true
+    calibration_decision: "direct_group_join"
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT f.id, grouped.total
+      FROM pc_files_small f
+      LEFT JOIN (
+        SELECT file_id, SUM(p1) AS total
+        FROM pc_docs_small
+        GROUP BY file_id
+      ) grouped ON grouped.file_id = f.id
+      WHERE f.id < 10
+      ORDER BY f.id
+
+  - name: "medium grouped derived relation versus keyed probes"
+    physical_calibration: true
+    calibration_decision: "direct_group_join"
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT f.id, grouped.total
+      FROM pc_files_large f
+      LEFT JOIN (
+        SELECT file_id, SUM(p1) AS total
+        FROM pc_docs_large
+        GROUP BY file_id
+      ) grouped ON grouped.file_id = f.id
+      WHERE f.id < 25
+      ORDER BY f.id
+
   - name: "small broad UNION membership"
     physical_calibration: true
     warmup: 1

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -193,6 +193,24 @@ test_cases:
       WHERE f.id < 25
       ORDER BY f.id
 
+  # Keep the grouped input fixed while varying only the number of warm key
+  # lookups, so Costgen can separate carrier build work from probe work.
+  - name: "medium grouped derived relation with many keyed probes"
+    physical_calibration: true
+    calibration_decision: "direct_group_join"
+    warmup: 1
+    repetitions: 3
+    sql: |
+      SELECT f.id, grouped.total
+      FROM pc_files_large f
+      LEFT JOIN (
+        SELECT file_id, SUM(p1) AS total
+        FROM pc_docs_large
+        GROUP BY file_id
+      ) grouped ON grouped.file_id = f.id
+      WHERE f.id < 100
+      ORDER BY f.id
+
   - name: "small broad UNION membership"
     physical_calibration: true
     warmup: 1

--- a/tests/planner/aggregates/group-stage-corners.yaml
+++ b/tests/planner/aggregates/group-stage-corners.yaml
@@ -213,6 +213,28 @@ test_cases:
         - "decision direct_group_join"
         - "probe_invocations 4"
 
+  - name: "Direct grouped join calibration emits both requested operators"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE
+      SELECT c.id, totals.total_amount
+      FROM gs_customers c
+      LEFT JOIN (
+        SELECT customer, SUM(amount) AS total_amount
+        FROM gs_orders
+        GROUP BY customer
+      ) totals ON totals.customer = c.name
+      ORDER BY c.id
+    expect:
+      rows: 2
+      result_contains:
+        - '"plan": "group_carrier"'
+        - '"plan": "direct_group_join"'
+        - '"operator_consistent": true'
+        - '"result_equal": true'
+      result_not_contains:
+        - '"operator_consistent": false'
+        - '"result_equal": false'
+
   - name: "Outer GROUP BY on aggregate alias from left-joined derived table"
     sql: |
       SELECT order_count, COUNT(*) AS customer_count

--- a/tests/planner/aggregates/group-stage-corners.yaml
+++ b/tests/planner/aggregates/group-stage-corners.yaml
@@ -169,6 +169,50 @@ test_cases:
         - customer: "Bob"
           cnt: 2
 
+  - name: "Aggregate alias remains bound in a downstream join"
+    sql: |
+      SELECT c.id, latest.max_order_id, selected.id AS selected_id
+      FROM gs_customers c
+      LEFT JOIN (
+        SELECT customer, MAX(id) AS max_order_id
+        FROM gs_orders
+        GROUP BY customer
+      ) latest ON latest.customer = c.name
+      LEFT JOIN gs_orders selected ON latest.max_order_id = selected.id
+      ORDER BY c.id
+    expect:
+      rows: 4
+      data:
+        - id: 1
+          max_order_id: 6
+          selected_id: 6
+        - id: 2
+          max_order_id: 5
+          selected_id: 5
+        - id: 3
+          max_order_id: 4
+          selected_id: 4
+        - id: 4
+          max_order_id: null
+          selected_id: null
+
+  - name: "Direct grouped join costs one key probe per outer row"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT c.id, totals.total_amount
+      FROM gs_customers c
+      LEFT JOIN (
+        SELECT customer, SUM(amount) AS total_amount
+        FROM gs_orders
+        GROUP BY customer
+      ) totals ON totals.customer = c.name
+      ORDER BY c.id
+    expect:
+      rows: 1
+      result_contains:
+        - "decision direct_group_join"
+        - "probe_invocations 4"
+
   - name: "Outer GROUP BY on aggregate alias from left-joined derived table"
     sql: |
       SELECT order_count, COUNT(*) AS customer_count

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -174,6 +174,11 @@ type calibrationRow struct {
 	JoinOutputRows                   *float64 `json:"join_output_rows"`
 	JoinTableCount                   *float64 `json:"join_table_count"`
 	JoinLegacyProbeRows              *float64 `json:"join_legacy_probe_rows"`
+	ProbeInvocations                 *float64 `json:"probe_invocations"`
+	InputRows                        *float64 `json:"input_rows"`
+	GroupRows                        *float64 `json:"group_rows"`
+	RowsPerProbe                     *float64 `json:"rows_per_probe"`
+	AggregateWidth                   *float64 `json:"aggregate_width"`
 	ResultEqual                      bool     `json:"result_equal"`
 	Rows                             int64    `json:"rows"`
 	ResultHash                       string   `json:"result_hash"`
@@ -216,6 +221,9 @@ type constants struct {
 	groupCacheStartupNS        int64
 	groupCacheBuildRowNS       int64
 	groupCacheProbeRowNS       int64
+	groupRelationStartupNS     int64
+	groupRelationBuildRowNS    int64
+	scanJoinOrderStartupNS     int64
 	orderedDriverInputNS       int64
 	orderedScanInvocationNS    int64
 	orderedRecsetSortUnitNS    int64
@@ -294,6 +302,20 @@ func main() {
 	if err != nil {
 		fatal(err)
 	}
+	directGroupObservations := filterDecisionObservations(observations, "direct_group_join")
+	if len(directGroupObservations) > 0 {
+		startup, build, fitErr := fitGroupRelation(directGroupObservations, c)
+		if fitErr != nil {
+			fatal(fmt.Errorf("direct_group_join: %w", fitErr))
+		}
+		c.groupRelationStartupNS = startup
+		c.groupRelationBuildRowNS = build
+		if err := validateDecisionOrdering(directGroupObservations, c); err != nil {
+			fatal(fmt.Errorf("direct_group_join: %w", err))
+		}
+		printModelComparison("direct_group_join", directGroupObservations, c)
+		printDecisionOrdering(directGroupObservations, c)
+	}
 	logStep("selected downstream probe coefficient=%d ns/probe", c.downstreamProbeRowNS)
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
@@ -322,6 +344,11 @@ func main() {
 		// work units instead of introducing an independently fitted coefficient
 		// set. Its forced variants still form a mandatory ordering check: this
 		// catches a lowerer formula which compiles but chooses the wrong operator.
+		startup, fitErr := fitScanJoinOrderStartup(orderedJoinObservations, c)
+		if fitErr != nil {
+			fatal(fmt.Errorf("scan_join_order: %w", fitErr))
+		}
+		c.scanJoinOrderStartupNS = startup
 		if err := validateDecisionOrdering(orderedJoinObservations, c); err != nil {
 			fatal(fmt.Errorf("scan_join_order: %w", err))
 		}
@@ -334,6 +361,55 @@ func main() {
 		}
 		fmt.Println("patched", queryplanPath)
 	}
+}
+
+func fitScanJoinOrderStartup(rows []observation, c constants) (int64, error) {
+	values := make([]float64, 0)
+	without := c
+	without.scanJoinOrderStartupNS = 0
+	for _, row := range rows {
+		if row.censored || row.plan != "scan_join_order" || len(row.x) <= 21 || row.x[21] <= 0 {
+			continue
+		}
+		values = append(values, math.Max(1,
+			(row.y-estimatedNS(row, without))/row.x[21]))
+	}
+	if len(values) == 0 {
+		return 0, errors.New("no exact scan_join_order observation")
+	}
+	sort.Float64s(values)
+	return int64(math.Round(values[len(values)/2])), nil
+}
+
+func fitGroupRelation(rows []observation, c constants) (int64, int64, error) {
+	groups, err := decisionAlternatives(filterRankObservations(rows))
+	if err != nil {
+		return 0, 0, err
+	}
+	x, y := make([][]float64, 0, len(groups)), make([]float64, 0, len(groups))
+	without := c
+	without.groupRelationStartupNS = 0
+	without.groupRelationBuildRowNS = 0
+	for _, plans := range groups {
+		carrier, carrierOK := plans["group_carrier"]
+		direct, directOK := plans["direct_group_join"]
+		if !carrierOK || !directOK || carrier.censored || direct.censored ||
+			len(carrier.x) <= 20 {
+			continue
+		}
+		residual := (carrier.y - direct.y) -
+			(estimatedNS(carrier, without) - estimatedNS(direct, without))
+		x = append(x, []float64{carrier.x[19], carrier.x[20]})
+		y = append(y, math.Max(1, residual))
+	}
+	if len(x) < 2 {
+		return 0, 0, fmt.Errorf("need at least two exact carrier/direct pairs, got %d", len(x))
+	}
+	beta, err := fitNonnegative(x, y)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int64(math.Round(beta[0])), int64(math.Round(beta[1])), nil
 }
 
 func validateModelImprovement(rows []observation, c constants) error {
@@ -971,6 +1047,11 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 			row.JoinOutputRows == nil || row.JoinTableCount == nil || row.JoinLegacyProbeRows == nil {
 			return fmt.Errorf("ordered join variant has incomplete measurements: %+v", row)
 		}
+	} else if row.Decision == "direct_group_join" {
+		if row.ProbeInvocations == nil || row.InputRows == nil || row.GroupRows == nil ||
+			row.RowsPerProbe == nil || row.AggregateWidth == nil {
+			return fmt.Errorf("direct grouped join variant has incomplete measurements: %+v", row)
+		}
 	} else if row.CandidateInputRows == nil || row.CandidateRows == nil ||
 		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil {
 		return fmt.Errorf("membership variant has incomplete measurements: %+v", row)
@@ -1127,14 +1208,38 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	if row.Decision == "direct_group_join" {
+		if row.ProbeInvocations == nil || row.InputRows == nil || row.GroupRows == nil ||
+			row.RowsPerProbe == nil || row.AggregateWidth == nil {
+			return nil, fmt.Errorf("direct grouped join work profile contains nil inputs: %+v", row)
+		}
+		features := make([]float64, 22)
+		if row.Plan == "direct_group_join" {
+			probedRows := *row.ProbeInvocations * *row.RowsPerProbe
+			features[0] = *row.ProbeInvocations
+			features[1] = probedRows
+			features[3] = probedRows * *row.AggregateWidth
+			features[4] = probedRows
+		} else if row.Plan == "group_carrier" {
+			features[0] = 1
+			features[1] = *row.InputRows
+			features[3] = *row.InputRows * *row.AggregateWidth
+			features[10] = *row.ProbeInvocations
+			features[19] = 1
+			features[20] = *row.InputRows
+		} else {
+			return nil, fmt.Errorf("unsupported direct grouped join plan %q", row.Plan)
+		}
+		return features, nil
+	}
 	if row.Decision == "scan_join_order" {
 		if row.JoinInputRows == nil || row.JoinEstimatedRows == nil ||
 			row.JoinOutputRows == nil || row.JoinTableCount == nil {
 			return nil, fmt.Errorf("ordered join work profile contains nil inputs: %+v", row)
 		}
-		features := make([]float64, 19)
+		features := make([]float64, 22)
 		features[0] = math.Max(0, *row.JoinTableCount-1)
-		features[15] = 1
+		features[21] = 1
 		features[1] = *row.JoinInputRows
 		features[3] = *row.JoinOutputRows + *row.JoinInputRows*math.Max(0, *row.JoinTableCount-1)
 		features[4] = *row.JoinEstimatedRows
@@ -1757,6 +1862,9 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.membershipDirectProbeRowNS),
 		float64(c.orderedRecsetSortUnitNS),
 		float64(c.downstreamProbeRowNS),
+		float64(c.groupRelationStartupNS),
+		float64(c.groupRelationBuildRowNS),
+		float64(c.scanJoinOrderStartupNS),
 	}
 	total := 0.0
 	for i, value := range row.x {
@@ -1860,6 +1968,11 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 				return nil, fmt.Errorf("plan %q belongs to scan_join_order, got decision %q", row.plan, row.decision)
 			}
 			groups[row.caseName][row.plan] = row
+		case "group_carrier", "direct_group_join":
+			if row.decision != "direct_group_join" {
+				return nil, fmt.Errorf("plan %q belongs to direct_group_join, got decision %q", row.plan, row.decision)
+			}
+			groups[row.caseName][row.plan] = row
 		default:
 			return nil, fmt.Errorf("unsupported plan %q", row.plan)
 		}
@@ -1871,6 +1984,15 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 			}
 			if _, ordered := plans["scan_join_order"]; !ordered {
 				return nil, fmt.Errorf("incomplete ordered join alternatives for %q", name)
+			}
+			continue
+		}
+		if decisions[name] == "direct_group_join" {
+			if _, carrier := plans["group_carrier"]; !carrier {
+				return nil, fmt.Errorf("incomplete direct grouped join alternatives for %q", name)
+			}
+			if _, direct := plans["direct_group_join"]; !direct {
+				return nil, fmt.Errorf("incomplete direct grouped join alternatives for %q", name)
 			}
 			continue
 		}
@@ -2124,6 +2246,9 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_downstream_probe_row_ns",
 		"planner_scalar_presence_probe_row_ns",
 		"planner_membership_direct_probe_row_ns",
+		"planner_group_relation_startup_ns",
+		"planner_group_relation_build_row_ns",
+		"planner_scan_join_order_startup_ns",
 	}
 	values := make([]int64, len(names))
 	content := string(data)
@@ -2134,6 +2259,9 @@ func readCurrentConstants(path string) (constants, error) {
 			// A one-nanosecond floor lets the first run fit new membership and
 			// ordered-scan coefficients from their physical-consumer observations.
 			if name == "planner_membership_direct_probe_row_ns" ||
+				name == "planner_group_relation_startup_ns" ||
+				name == "planner_group_relation_build_row_ns" ||
+				name == "planner_scan_join_order_startup_ns" ||
 				name == "planner_membership_ordered_scan_invocation_ns" ||
 				name == "planner_membership_ordered_recset_sort_unit_ns" ||
 				name == "planner_membership_downstream_probe_row_ns" {
@@ -2168,6 +2296,9 @@ func readCurrentConstants(path string) (constants, error) {
 		downstreamProbeRowNS:       values[17],
 		scalarPresenceProbeRowNS:   values[18],
 		membershipDirectProbeRowNS: values[19],
+		groupRelationStartupNS:     values[20],
+		groupRelationBuildRowNS:    values[21],
+		scanJoinOrderStartupNS:     values[22],
 	}, nil
 }
 
@@ -2224,6 +2355,9 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_ordered_driver_input_row_ns %d)
 (define planner_membership_ordered_scan_invocation_ns %d)
 (define planner_membership_ordered_recset_sort_unit_ns %d)
+(define planner_group_relation_startup_ns %d)
+(define planner_group_relation_build_row_ns %d)
+(define planner_scan_join_order_startup_ns %d)
 /* END GENERATED COST CONSTANTS */`, c.scalarPresenceProbeRowNS, c.membershipDirectProbeRowNS,
 		c.downstreamProbeRowNS,
 		c.scanInvocationNS, c.scanRowNS,
@@ -2231,6 +2365,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 		c.recsetStartupNS, c.recsetBuildRowNS, c.recsetProbeRowNS,
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS,
-		c.orderedRecsetSortUnitNS)
+		c.orderedRecsetSortUnitNS, c.groupRelationStartupNS,
+		c.groupRelationBuildRowNS, c.scanJoinOrderStartupNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -224,6 +224,7 @@ type constants struct {
 	groupCacheProbeRowNS       int64
 	groupRelationStartupNS     int64
 	groupRelationBuildRowNS    int64
+	groupRelationProbeNS       int64
 	scanJoinOrderStartupNS     int64
 	orderedDriverInputNS       int64
 	orderedScanInvocationNS    int64
@@ -305,12 +306,13 @@ func main() {
 	}
 	directGroupObservations := filterDecisionObservations(observations, "direct_group_join")
 	if len(directGroupObservations) > 0 {
-		startup, build, fitErr := fitGroupRelation(directGroupObservations, c)
+		startup, build, probe, fitErr := fitGroupRelation(directGroupObservations, c)
 		if fitErr != nil {
 			fatal(fmt.Errorf("direct_group_join: %w", fitErr))
 		}
 		c.groupRelationStartupNS = startup
 		c.groupRelationBuildRowNS = build
+		c.groupRelationProbeNS = probe
 		if err := validateDecisionOrdering(directGroupObservations, c); err != nil {
 			fatal(fmt.Errorf("direct_group_join: %w", err))
 		}
@@ -369,11 +371,11 @@ func fitScanJoinOrderStartup(rows []observation, c constants) (int64, error) {
 	without := c
 	without.scanJoinOrderStartupNS = 0
 	for _, row := range rows {
-		if row.censored || row.plan != "scan_join_order" || len(row.x) <= 21 || row.x[21] <= 0 {
+		if row.censored || row.plan != "scan_join_order" || len(row.x) <= 22 || row.x[22] <= 0 {
 			continue
 		}
 		values = append(values, math.Max(1,
-			(row.y-estimatedNS(row, without))/row.x[21]))
+			(row.y-estimatedNS(row, without))/row.x[22]))
 	}
 	if len(values) == 0 {
 		return 0, errors.New("no exact scan_join_order observation")
@@ -382,35 +384,37 @@ func fitScanJoinOrderStartup(rows []observation, c constants) (int64, error) {
 	return int64(math.Round(values[len(values)/2])), nil
 }
 
-func fitGroupRelation(rows []observation, c constants) (int64, int64, error) {
+func fitGroupRelation(rows []observation, c constants) (int64, int64, int64, error) {
 	groups, err := decisionAlternatives(filterRankObservations(rows))
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	x, y := make([][]float64, 0, len(groups)), make([]float64, 0, len(groups))
 	without := c
 	without.groupRelationStartupNS = 0
 	without.groupRelationBuildRowNS = 0
+	without.groupRelationProbeNS = 0
 	for _, plans := range groups {
 		carrier, carrierOK := plans["group_carrier"]
 		direct, directOK := plans["direct_group_join"]
 		if !carrierOK || !directOK || carrier.censored || direct.censored ||
-			len(carrier.x) <= 20 {
+			len(carrier.x) <= 21 {
 			continue
 		}
 		residual := (carrier.y - direct.y) -
 			(estimatedNS(carrier, without) - estimatedNS(direct, without))
-		x = append(x, []float64{carrier.x[19], carrier.x[20]})
+		x = append(x, []float64{carrier.x[19], carrier.x[20], carrier.x[21]})
 		y = append(y, math.Max(1, residual))
 	}
-	if len(x) < 2 {
-		return 0, 0, fmt.Errorf("need at least two exact carrier/direct pairs, got %d", len(x))
+	if len(x) < 3 {
+		return 0, 0, 0, fmt.Errorf("need at least three exact carrier/direct pairs, got %d", len(x))
 	}
 	beta, err := fitNonnegative(x, y)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
-	return int64(math.Round(beta[0])), int64(math.Round(beta[1])), nil
+	return int64(math.Round(beta[0])), int64(math.Round(beta[1])),
+		int64(math.Round(beta[2])), nil
 }
 
 func validateModelImprovement(rows []observation, c constants) error {
@@ -1224,7 +1228,7 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			row.RowsPerProbe == nil || row.AggregateWidth == nil {
 			return nil, fmt.Errorf("direct grouped join work profile contains nil inputs: %+v", row)
 		}
-		features := make([]float64, 22)
+		features := make([]float64, 23)
 		if row.Plan == "direct_group_join" {
 			probedRows := *row.ProbeInvocations * *row.RowsPerProbe
 			features[0] = *row.ProbeInvocations
@@ -1235,9 +1239,9 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			features[0] = 1
 			features[1] = *row.InputRows
 			features[3] = *row.InputRows * *row.AggregateWidth
-			features[10] = *row.ProbeInvocations
 			features[19] = 1
 			features[20] = *row.InputRows
+			features[21] = *row.ProbeInvocations
 		} else {
 			return nil, fmt.Errorf("unsupported direct grouped join plan %q", row.Plan)
 		}
@@ -1248,9 +1252,9 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			row.JoinOutputRows == nil || row.JoinTableCount == nil {
 			return nil, fmt.Errorf("ordered join work profile contains nil inputs: %+v", row)
 		}
-		features := make([]float64, 22)
+		features := make([]float64, 23)
 		features[0] = math.Max(0, *row.JoinTableCount-1)
-		features[21] = 1
+		features[22] = 1
 		features[1] = *row.JoinInputRows
 		features[3] = *row.JoinOutputRows + *row.JoinInputRows*math.Max(0, *row.JoinTableCount-1)
 		features[4] = *row.JoinEstimatedRows
@@ -1875,6 +1879,7 @@ func estimatedNS(row observation, c constants) float64 {
 		float64(c.downstreamProbeRowNS),
 		float64(c.groupRelationStartupNS),
 		float64(c.groupRelationBuildRowNS),
+		float64(c.groupRelationProbeNS),
 		float64(c.scanJoinOrderStartupNS),
 	}
 	total := 0.0
@@ -2259,6 +2264,7 @@ func readCurrentConstants(path string) (constants, error) {
 		"planner_membership_direct_probe_row_ns",
 		"planner_group_relation_startup_ns",
 		"planner_group_relation_build_row_ns",
+		"planner_group_relation_probe_ns",
 		"planner_scan_join_order_startup_ns",
 	}
 	values := make([]int64, len(names))
@@ -2272,6 +2278,7 @@ func readCurrentConstants(path string) (constants, error) {
 			if name == "planner_membership_direct_probe_row_ns" ||
 				name == "planner_group_relation_startup_ns" ||
 				name == "planner_group_relation_build_row_ns" ||
+				name == "planner_group_relation_probe_ns" ||
 				name == "planner_scan_join_order_startup_ns" ||
 				name == "planner_membership_ordered_scan_invocation_ns" ||
 				name == "planner_membership_ordered_recset_sort_unit_ns" ||
@@ -2309,7 +2316,8 @@ func readCurrentConstants(path string) (constants, error) {
 		membershipDirectProbeRowNS: values[19],
 		groupRelationStartupNS:     values[20],
 		groupRelationBuildRowNS:    values[21],
-		scanJoinOrderStartupNS:     values[22],
+		groupRelationProbeNS:       values[22],
+		scanJoinOrderStartupNS:     values[23],
 	}, nil
 }
 
@@ -2368,6 +2376,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 (define planner_membership_ordered_recset_sort_unit_ns %d)
 (define planner_group_relation_startup_ns %d)
 (define planner_group_relation_build_row_ns %d)
+(define planner_group_relation_probe_ns %d)
 (define planner_scan_join_order_startup_ns %d)
 /* END GENERATED COST CONSTANTS */`, c.scalarPresenceProbeRowNS, c.membershipDirectProbeRowNS,
 		c.downstreamProbeRowNS,
@@ -2377,6 +2386,7 @@ EXPLAIN PHYSICAL CALIBRATE alternative with result and operator validation. */
 		c.recsetAggregateRowNS, c.groupCacheStartupNS, c.groupCacheBuildRowNS,
 		c.groupCacheProbeRowNS, c.orderedDriverInputNS, c.orderedScanInvocationNS,
 		c.orderedRecsetSortUnitNS, c.groupRelationStartupNS,
-		c.groupRelationBuildRowNS, c.scanJoinOrderStartupNS)
+		c.groupRelationBuildRowNS, c.groupRelationProbeNS,
+		c.scanJoinOrderStartupNS)
 	return os.WriteFile(path, []byte(content[:begin]+block+content[end:]), 0o644)
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -124,7 +124,7 @@ func TestRowFeaturesModelsOrderedJoinAlternatives(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scanFeatures[0] != 1 || scanFeatures[1] != 25_000 || scanFeatures[15] != 1 ||
+	if scanFeatures[0] != 1 || scanFeatures[1] != 25_000 || scanFeatures[21] != 1 ||
 		scanFeatures[3] != 25_072 || scanFeatures[4] != 4_000 || scanFeatures[18] != 0 {
 		t.Fatalf("ordered join scan features = %v", scanFeatures)
 	}
@@ -135,6 +135,58 @@ func TestRowFeaturesModelsOrderedJoinAlternatives(t *testing.T) {
 	}
 	if legacyFeatures[18] != 600 {
 		t.Fatalf("legacy ordered join probe work = %v, want 600", legacyFeatures[18])
+	}
+}
+
+func TestRowFeaturesModelsDirectGroupedJoinAlternatives(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	base := calibrationRow{
+		Decision: "direct_group_join", ProbeInvocations: value(10),
+		InputRows: value(1000), GroupRows: value(100),
+		RowsPerProbe: value(10), AggregateWidth: value(2),
+	}
+	base.Plan = "direct_group_join"
+	direct, err := rowFeatures(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct[0] != 10 || direct[1] != 100 || direct[3] != 200 || direct[4] != 100 {
+		t.Fatalf("direct grouped join features = %v", direct)
+	}
+	base.Plan = "group_carrier"
+	carrier, err := rowFeatures(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if carrier[0] != 1 || carrier[1] != 1000 || carrier[3] != 2000 ||
+		carrier[10] != 10 || carrier[19] != 1 || carrier[20] != 1000 {
+		t.Fatalf("group carrier features = %v", carrier)
+	}
+}
+
+func TestFitGroupRelationSeparatesStartupAndBuildWork(t *testing.T) {
+	row := func(caseName, plan string, measured, inputRows float64) observation {
+		features := make([]float64, 22)
+		if plan == "group_carrier" {
+			features[19], features[20] = 1, inputRows
+		}
+		return observation{
+			caseName: caseName, decision: "direct_group_join", plan: plan,
+			y: measured, x: features,
+		}
+	}
+	rows := []observation{
+		row("small", "direct_group_join", 100, 10),
+		row("small", "group_carrier", 1101, 10),
+		row("medium", "direct_group_join", 200, 50),
+		row("medium", "group_carrier", 5201, 50),
+	}
+	startup, build, err := fitGroupRelation(rows, constants{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if startup != 1 || build != 100 {
+		t.Fatalf("group relation fit = (%d, %d), want (1, 100)", startup, build)
 	}
 }
 
@@ -409,12 +461,12 @@ func TestValidateDecisionOrderingUsesOrderedJoinCostBoundary(t *testing.T) {
 	legacy := func(name string, measured, estimated float64) observation {
 		return observation{
 			caseName: name, decision: "scan_join_order", plan: "legacy_join_tree",
-			y: measured, currentEstimate: estimated, x: make([]float64, 19),
+			y: measured, currentEstimate: estimated, x: make([]float64, 22),
 		}
 	}
 	ordered := func(name string, measured float64) observation {
-		features := make([]float64, 19)
-		features[0], features[1], features[3], features[4], features[15] = 1, 25_000, 25_001, 1, 1
+		features := make([]float64, 22)
+		features[0], features[1], features[3], features[4], features[21] = 1, 25_000, 25_001, 1, 1
 		return observation{
 			caseName: name, decision: "scan_join_order", plan: "scan_join_order",
 			y: measured, x: features,
@@ -426,7 +478,7 @@ func TestValidateDecisionOrderingUsesOrderedJoinCostBoundary(t *testing.T) {
 	}
 	constants := constants{
 		scanInvocationNS: 122_080, scanRowNS: 1, mapColumnRowNS: 32,
-		expressionOperationNS: 220, orderedScanInvocationNS: 3_027_639,
+		expressionOperationNS: 220, scanJoinOrderStartupNS: 3_027_639,
 	}
 	if err := validateDecisionOrdering(rows, constants); err != nil {
 		t.Fatal(err)

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -124,7 +124,7 @@ func TestRowFeaturesModelsOrderedJoinAlternatives(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scanFeatures[0] != 1 || scanFeatures[1] != 25_000 || scanFeatures[21] != 1 ||
+	if scanFeatures[0] != 1 || scanFeatures[1] != 25_000 || scanFeatures[22] != 1 ||
 		scanFeatures[3] != 25_072 || scanFeatures[4] != 4_000 || scanFeatures[18] != 0 {
 		t.Fatalf("ordered join scan features = %v", scanFeatures)
 	}
@@ -159,16 +159,16 @@ func TestRowFeaturesModelsDirectGroupedJoinAlternatives(t *testing.T) {
 		t.Fatal(err)
 	}
 	if carrier[0] != 1 || carrier[1] != 1000 || carrier[3] != 2000 ||
-		carrier[10] != 10 || carrier[19] != 1 || carrier[20] != 1000 {
+		carrier[19] != 1 || carrier[20] != 1000 || carrier[21] != 10 {
 		t.Fatalf("group carrier features = %v", carrier)
 	}
 }
 
-func TestFitGroupRelationSeparatesStartupAndBuildWork(t *testing.T) {
-	row := func(caseName, plan string, measured, inputRows float64) observation {
-		features := make([]float64, 22)
+func TestFitGroupRelationSeparatesStartupBuildAndProbeWork(t *testing.T) {
+	row := func(caseName, plan string, measured, inputRows, probes float64) observation {
+		features := make([]float64, 23)
 		if plan == "group_carrier" {
-			features[19], features[20] = 1, inputRows
+			features[19], features[20], features[21] = 1, inputRows, probes
 		}
 		return observation{
 			caseName: caseName, decision: "direct_group_join", plan: plan,
@@ -176,17 +176,20 @@ func TestFitGroupRelationSeparatesStartupAndBuildWork(t *testing.T) {
 		}
 	}
 	rows := []observation{
-		row("small", "direct_group_join", 100, 10),
-		row("small", "group_carrier", 1101, 10),
-		row("medium", "direct_group_join", 200, 50),
-		row("medium", "group_carrier", 5201, 50),
+		row("small", "direct_group_join", 100, 10, 10),
+		row("small", "group_carrier", 1201, 10, 10),
+		row("medium", "direct_group_join", 200, 50, 20),
+		row("medium", "group_carrier", 5401, 50, 20),
+		row("wide", "direct_group_join", 300, 50, 100),
+		row("wide", "group_carrier", 6301, 50, 100),
 	}
-	startup, build, err := fitGroupRelation(rows, constants{})
+	startup, build, probe, err := fitGroupRelation(rows, constants{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if startup != 1 || build != 100 {
-		t.Fatalf("group relation fit = (%d, %d), want (1, 100)", startup, build)
+	if startup != 1 || build != 100 || probe != 10 {
+		t.Fatalf("group relation fit = (%d, %d, %d), want (1, 100, 10)",
+			startup, build, probe)
 	}
 }
 
@@ -461,12 +464,12 @@ func TestValidateDecisionOrderingUsesOrderedJoinCostBoundary(t *testing.T) {
 	legacy := func(name string, measured, estimated float64) observation {
 		return observation{
 			caseName: name, decision: "scan_join_order", plan: "legacy_join_tree",
-			y: measured, currentEstimate: estimated, x: make([]float64, 22),
+			y: measured, currentEstimate: estimated, x: make([]float64, 23),
 		}
 	}
 	ordered := func(name string, measured float64) observation {
-		features := make([]float64, 22)
-		features[0], features[1], features[3], features[4], features[21] = 1, 25_000, 25_001, 1, 1
+		features := make([]float64, 23)
+		features[0], features[1], features[3], features[4], features[22] = 1, 25_000, 25_001, 1, 1
 		return observation{
 			caseName: name, decision: "scan_join_order", plan: "scan_join_order",
 			y: measured, x: features,

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -435,11 +435,100 @@ class FailFastParallelContractTest(unittest.TestCase):
             return True
 
         with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch("run_sql_tests.performance_measurement_count", return_value=1), \
                 mock.patch.object(SQLTestRunner, "prepare_test_spec", prepare), \
                 mock.patch.object(SQLTestRunner, "run_test_spec", measure):
             self.assertTrue(run_test_specs(specs, "http://localhost:1", 1, True, 2))
 
         self.assertCountEqual(events[2:], [("measure", specs[0]), ("measure", specs[1])])
+
+    def test_performance_setup_restart_runs_once_before_measurements(self) -> None:
+        specs = ["tests/performance/a.yaml", "tests/performance/b.yaml"]
+        events = []
+
+        def prepare(runner, spec_file):
+            runner.suite_metadata = {
+                "restart_after_setup": spec_file == specs[0],
+            }
+            events.append(("prepare", spec_file))
+            return True
+
+        def restart(_runner, _database):
+            self.assertEqual(sum(kind == "prepare" for kind, _ in events), 2)
+            events.append(("restart", "shared"))
+            return True
+
+        def measure(_runner, spec_file, setup_done=False):
+            self.assertTrue(setup_done)
+            self.assertEqual(sum(kind == "restart" for kind, _ in events), 1)
+            events.append(("measure", spec_file))
+            return True
+
+        with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch("run_sql_tests.performance_measurement_count", return_value=1), \
+                mock.patch.object(SQLTestRunner, "prepare_test_spec", prepare), \
+                mock.patch.object(SQLTestRunner, "restart_server_after_setup", restart), \
+                mock.patch.object(SQLTestRunner, "run_test_spec", measure):
+            self.assertTrue(run_test_specs(specs, "http://localhost:1", 1, True, 2))
+
+        self.assertEqual(sum(kind == "restart" for kind, _ in events), 1)
+
+    def test_performance_rounds_finish_all_fills_before_serial_measurements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first.yaml"
+            second = Path(tmp) / "second.yaml"
+            first.write_text(
+                "metadata: {description: first}\n"
+                "test_cases:\n"
+                "  - {name: first-1, sql: SELECT 1, threshold_ms: 100}\n"
+                "  - {name: first-2, sql: SELECT 1, threshold_ms: 100}\n",
+                encoding="utf-8",
+            )
+            second.write_text(
+                "metadata: {description: second}\n"
+                "test_cases:\n"
+                "  - {name: second-1, sql: SELECT 1, threshold_ms: 100}\n",
+                encoding="utf-8",
+            )
+            events = []
+            lock = threading.Lock()
+
+            def prepare(runner, spec_file):
+                runner.suite_metadata = {}
+                runner.current_spec_file = spec_file
+                return True
+
+            def run_case(runner, test_case, _database):
+                name = test_case["name"]
+                with lock:
+                    events.append(("fill", name))
+                runner._perf_round_setup_barrier.wait(timeout=2)
+                with lock:
+                    events.append(("measure", name))
+                return True
+
+            def settled(_base_url):
+                with lock:
+                    events.append(("settled", "round"))
+                return True
+
+            with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                    mock.patch("run_sql_tests.PERF_AB_MODE", "record"), \
+                    mock.patch("run_sql_tests.wait_for_performance_setup_quiescence", settled), \
+                    mock.patch.object(SQLTestRunner, "ensure_database"), \
+                    mock.patch.object(SQLTestRunner, "prepare_test_spec", prepare), \
+                    mock.patch.object(SQLTestRunner, "run_test_case", run_case):
+                self.assertTrue(run_test_specs(
+                    [str(first), str(second)], "http://localhost:1", 1, True, 2,
+                ))
+
+        first_round_done = max(
+            events.index(("measure", "first-1")),
+            events.index(("measure", "second-1")),
+        )
+        self.assertLess(events.index(("settled", "round")), first_round_done)
+        self.assertGreater(events.index(("fill", "first-2")), first_round_done)
+        self.assertEqual(sum(kind == "settled" for kind, _ in events), 2)
 
     def test_fail_fast_preserves_parallel_groups(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What

- add a non-CI performance fixture for the MySQL forum-hierarchy workload from https://www.reddit.com/r/mysql/comments/1l0ceun/having_trouble_understanding_the_problem_point_in/ at 10,000 forums and 33,669 threads/posts, using the default shard size and rebuild-driven automatic partitioning
- preserve aggregate aliases when a grouped derived-table output feeds a later join
- retain eligible grouped relations until physical lowering and compare keyed direct aggregation with the canonical group carrier through the physical cost model
- reduce all aggregates requested from one grouped relation in a single keyed scan
- recognize a constant unique lookup as the dominant join driver before the hierarchy scan
- keep `scan_join_order` behind an exact projected carrier when their fuzzy cost intervals overlap, while retaining it for clear winners
- calibrate grouped-relation startup/build coefficients and the separate `scan_join_order` startup coefficient through Costgen
- fix keyed-probe costing: every outer row performs a lookup regardless of join match selectivity, while local source predicates use the existing sampled cardinality estimator
- fix direct-group code generation so aggregate values are passed as lambda arguments rather than as one list argument

The logical planner remains free of physical carriers and RecSets. The direct-group alternative is selected during physical stage preparation and is visible/forceable through `EXPLAIN PHYSICAL CALIBRATE`.

## Adaptive warm-cache policy

The direct grouped path now follows the same pay-for-build idea as automatic indexes, entirely in SCM:

- if the canonical group table already exists, prepare any aggregate columns newly required by this query once in the query prelude and use the cache
- otherwise execute the direct keyed probes and accumulate their measured nanoseconds once per query in `system_statistic.group_cache_candidates`
- the candidate table is `ENGINE=sloppy` and contains only the canonical cache name and accumulated time without the cache
- cross the build threshold using the existing Costgen-calibrated group-relation startup/build cost, then start the canonical group-table preparation asynchronously with `setTimeout`
- delete the candidate after a successful build; clean up a partial cache and rethrow the original asynchronous error on failure
- keep Costgen-forced variants free of telemetry and cache reuse so calibration still measures the requested operator

The table-existence guards use a promise backed by a stack-resident two-cell list. They distinguish a missing table from an exception without allocating a FastDict or hiding execution failures. The direct probes accumulate timings in a query-local session, so the system-statistics upsert happens once per query rather than once per joined row.

## A/B measurements

Reference x86_64 host, persisted automatically partitioned fixture, median of five timed executions:

| Query / alternative | Before | After |
| --- | ---: | ---: |
| Original Reddit SQL | 4,077 ms | 8.9 ms |
| Correlated SQL rewrite | n/a | 14.8 ms |
| Child aggregate only | n/a | 7.8 ms |
| Thread aggregate only | n/a | 8.2 ms |

Latest adaptive-policy verification on the same fixture:

| Query | Time |
| --- | ---: |
| Child aggregate only | 8.6 ms |
| Thread aggregate only | 8.4 ms |
| Combined original query | 11.0 ms |

Forced whole-query physical variants on the same persisted fixture:

| Decision | Direct grouped probe | Group carrier |
| --- | ---: | ---: |
| child-count relation | 4.76 ms | 53.42 ms |
| thread aggregate relation | 4.47 ms | 1,685.92 ms |

Costgen after correcting probe cardinalities:

- direct-group median absolute estimation error: 71.6% -> 1.5%
- direct-group operator choices: 2/2 correct
- general training decision coverage: 18/18
- general holdout decision coverage: 7/7
- forced alternatives produced identical row counts and hashes

The fuzzy ordered-join guard was checked against both sides of its crossover: an exact projected carrier stays at 1.0-1.13 ms where `scan_join_order` needs 3.46-3.74 ms, while the tiny ordered join keeps `scan_join_order` at 0.22-0.25 ms versus 0.59-0.71 ms for the carrier.

## Validation

- `go test ./tools/costgen`
- Scheme bootstrap: 1270/1270
- group-stage corner cases: 39/39
- forum correctness fixture: 6/6
- forum performance fixture: 10/10
- `python3 tools/lint_scm.py` and `git diff --check`
- the complete Costgen fixture and full regression suite are left to CI for the pushed follow-up commit
