### PR TITLE
Quote large constant list structures

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2157,13 +2157,13 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 				v[i] = unwrapConstListFromCode(v[i])
 			}
 			result := d.Fn(v[1:]...)
-			result = wrapConstListForCode(result)
 			td := &TypeDescriptor{Transfer: true, Const: true, Length: UnknownLength}
 			if d.Type != nil && d.Type.Return != nil {
 				td = &TypeDescriptor{Transfer: true, Const: true, Kind: d.Type.Return.Kind,
 					Params: d.Type.Return.Params, Return: d.Type.Return.Return,
 					HasSideEffects: d.Type.Return.HasSideEffects, Length: d.Type.Return.Length}
 			}
+			result = wrapConstListForCode(result, td, false)
 			return result, td
 		}
 		if d.Type != nil && d.Type.Return != nil {
@@ -2261,19 +2261,26 @@ func (oc *OptimizerContext) applyDefaultOptimizationWithTypes(v []Scmer, useResu
 	return optimizedCall{code: code, typeInfo: typeInfo, argumentTypes: argumentTypes}
 }
 
+const constListQuoteThreshold = 32
+
 // wrapConstListForCode wraps a constant-folded Scmer value so it can safely
 // be embedded in generated code. Raw list/slice values would be misinterpreted
-// as function calls by Eval, so they are wrapped as (list ...) calls recursively.
-// Symbols are wrapped in (quote sym) so they evaluate to the symbol value rather
-// than being looked up as variable references.
+// as function calls by Eval. The optimizer's return descriptor is authoritative:
+// large constant lists are retained behind one non-transferable quote. Symbols are
+// also quoted so they evaluate to the symbol value rather than being looked up
+// as variable references.
 // Only wraps plain slices — FastDicts are left as-is since they are self-evaluating.
-func wrapConstListForCode(val Scmer) Scmer {
+func wrapConstListForCode(val Scmer, resultType *TypeDescriptor, embedded bool) Scmer {
 	if val.IsSlice() {
+		if !embedded && resultType != nil && resultType.Const && len(val.Slice()) >= constListQuoteThreshold {
+			resultType.Transfer = false
+			return NewSlice([]Scmer{NewSymbol("quote"), val})
+		}
 		list := val.Slice()
 		packed := make([]Scmer, 1, len(list)+1)
 		packed[0] = NewSymbol("list")
 		for _, elem := range list {
-			packed = append(packed, wrapConstListForCode(elem))
+			packed = append(packed, wrapConstListForCode(elem, resultType, true))
 		}
 		return NewSlice(packed)
 	}
@@ -2283,10 +2290,13 @@ func wrapConstListForCode(val Scmer) Scmer {
 	return val
 }
 
-// unwrapConstListFromCode is the inverse of wrapConstListForCode: it recursively
-// strips (list ...) wrappers so that the raw data values can be passed to a
-// foldable function at constant-fold time.
+// unwrapConstListFromCode is the inverse of wrapConstListForCode: it extracts
+// quoted values and still accepts the legacy recursive (list ...) encoding so
+// that raw data values can be passed to a foldable function at constant-fold time.
 func unwrapConstListFromCode(val Scmer) Scmer {
+	if list, ok := scmerSlice(val); ok && len(list) == 2 && scmerIsSymbol(list[0], "quote") {
+		return list[1]
+	}
 	if list, ok := scmerSlice(val); ok && len(list) > 0 && (isList(list[0]) || scmerIsSymbol(list[0], "list")) {
 		items := make([]Scmer, len(list)-1)
 		for i, elem := range list[1:] {

--- a/scm/optimizer_quoted_constants_test.go
+++ b/scm/optimizer_quoted_constants_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func TestOptimizeQuoteIsBorrowedPassthrough(t *testing.T) {
+	ome := newOptimizerMetainfo()
+	optimized, resultType := OptimizeEx(Read("test", "(quote ((1 2) (3 4)))"), &Globalenv, &ome, true)
+	if resultType.Const() {
+		t.Fatal("source-level quote must remain an optimizer barrier")
+	}
+	if resultType.Transfer() {
+		t.Fatal("quoted list must not transfer ownership")
+	}
+	want := Eval(Read("test", "(quote ((1 2) (3 4)))"), &Globalenv)
+	if got := Eval(optimized, &Globalenv); !Equal(got, want) {
+		t.Fatalf("optimized quote evaluated to %s", String(got))
+	}
+}
+
+func TestOptimizeConstantListUsesSingleQuote(t *testing.T) {
+	nested := make([]Scmer, 1, constListQuoteThreshold)
+	nested[0] = NewSymbol("list")
+	for i := 0; i < constListQuoteThreshold; i++ {
+		nested = append(nested, NewSlice([]Scmer{NewSymbol("list"), NewInt(int64(i))}))
+	}
+	ome := newOptimizerMetainfo()
+	optimized, resultType := OptimizeEx(NewSlice(nested), &Globalenv, &ome, true)
+	if !resultType.Const() || resultType.Transfer() {
+		t.Fatalf("constant list type = const %t, transfer %t; want borrowed constant", resultType.Const(), resultType.Transfer())
+	}
+	items, ok := scmerSlice(optimized)
+	if !ok || len(items) != 2 || !scmerIsSymbol(items[0], "quote") {
+		t.Fatalf("optimized constant list = %s; want one quote wrapper", String(optimized))
+	}
+	if countQuoteForms(optimized) != 1 {
+		t.Fatalf("optimized nested constant contains embedded quote forms: %s", String(optimized))
+	}
+	if got := Eval(optimized, &Globalenv); len(got.Slice()) != constListQuoteThreshold {
+		t.Fatalf("optimized constant list has %d elements", len(got.Slice()))
+	}
+}
+
+func TestWrapConstantListRetainsBackingStorage(t *testing.T) {
+	literal := NewSlice(make([]Scmer, constListQuoteThreshold))
+	td := &TypeDescriptor{Const: true, Transfer: true}
+	wrapped := wrapConstListForCode(literal, td, false).Slice()
+	if len(wrapped) != 2 || !scmerIsSymbol(wrapped[0], "quote") {
+		t.Fatalf("wrapped constant = %s; want quote", String(NewSlice(wrapped)))
+	}
+	if td.Transfer {
+		t.Fatal("quoted constant must not transfer ownership")
+	}
+	if wrapped[1].ptr != literal.ptr || wrapped[1].aux != literal.aux {
+		t.Fatal("quote wrapper copied constant list storage")
+	}
+}
+
+func TestWrapEmbeddedConstantListDoesNotAddQuotes(t *testing.T) {
+	literal := NewSlice(make([]Scmer, constListQuoteThreshold))
+	wrapped := wrapConstListForCode(literal, &TypeDescriptor{Const: true}, true)
+	wrappedItems, ok := scmerSlice(wrapped)
+	if !ok || len(wrappedItems) == 0 || !scmerIsSymbol(wrappedItems[0], "list") {
+		t.Fatalf("embedded constant list = %s; want list constructor", String(wrapped))
+	}
+	if countQuoteForms(wrapped) != 0 {
+		t.Fatalf("embedded constant list contains quote forms: %s", String(wrapped))
+	}
+}
+
+func TestOptimizeSmallConstantListKeepsFreshOwnership(t *testing.T) {
+	ome := newOptimizerMetainfo()
+	optimized, resultType := OptimizeEx(Read("test", "(list 1 2)"), &Globalenv, &ome, true)
+	items, ok := scmerSlice(optimized)
+	if !ok || len(items) != 3 || !scmerIsSymbol(items[0], "list") {
+		t.Fatalf("small constant list = %s; want list constructor", String(optimized))
+	}
+	if !resultType.Const() || !resultType.Transfer() {
+		t.Fatalf("small constant list type = const %t, transfer %t; want fresh constant", resultType.Const(), resultType.Transfer())
+	}
+}
+
+func TestOptimizeDoesNotFoldMutatingCallOnQuotedList(t *testing.T) {
+	expr := Read("test", "(nth_mut (quote (1 2)) 0 9)")
+	exprItems, _ := scmerSlice(expr)
+	literal := Eval(exprItems[1], &Globalenv)
+	literal, _ = scmerStripSourceInfo(literal)
+	optimized := Optimize(expr, &Globalenv, nil)
+	items, ok := scmerSlice(optimized)
+	if !ok || len(items) == 0 || !scmerIsSymbol(items[0], "nth_mut") {
+		t.Fatalf("mutating call was folded over shared literal: %s", String(optimized))
+	}
+	if got := literal.Slice()[0].Int(); got != 1 {
+		t.Fatalf("optimizer mutated quoted literal to %d", got)
+	}
+}
+
+func countQuoteForms(val Scmer) int {
+	items, ok := scmerSlice(val)
+	if !ok {
+		return 0
+	}
+	count := 0
+	if len(items) > 0 && scmerIsSymbol(items[0], "quote") {
+		count++
+	}
+	for _, item := range items {
+		count += countQuoteForms(item)
+	}
+	return count
+}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1043,9 +1043,9 @@ func init() {
 		Fn: nil,
 		Type: &TypeDescriptor{Kind: "func", Description: "returns a symbol or list without evaluating it",
 			Params: []*TypeDescriptor{
-				{Kind: "symbol", Label: "symbol", Description: "symbol to quote"},
+				{Kind: "any", Label: "value", Description: "value to quote"},
 			},
-			Return: &TypeDescriptor{Kind: "symbol"},
+			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,
 		},
 	})


### PR DESCRIPTION
## Summary
- pass large constant-folded lists through one outer `quote` without copying nested list data
- use the optimizer return descriptor's `Const` flag plus an O(1) top-level length threshold
- preserve embedded-list context so nested values do not receive individual quote wrappers
- keep small constant lists on the existing fresh `(list ...)` path
- declare `quote` as `any -> any`, matching evaluator behavior

## Tests
- `go test ./scm -count=1`
- the five initially regressed SQL suites rerun individually: all passed
- full `make test`: all Scheme and SQL suites passed (exit code 0)