### PR TITLE
ci: parallelize performance fixture work

### DIFF
--- a/.github/workflows/performance-fixture-concurrency.yml
+++ b/.github/workflows/performance-fixture-concurrency.yml
@@ -1,0 +1,44 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Performance Fixture Concurrency
+
+on:
+  pull_request:
+    branches: [master, perf-ab-ci]
+
+permissions:
+  contents: read
+
+jobs:
+  performance-fixture-concurrency:
+    name: performance-fixture-concurrency
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install test dependencies
+        run: pip install requests PyYAML
+
+      - name: Build MemCP
+        run: go build -o memcp
+
+      - name: Fill existing large fixtures concurrently
+        env:
+          PERF_TEST: "1"
+          PERF_NORECALIBRATE: "1"
+          PERF_REPEAT: "1"
+          PERF_SETUP_MAX_TIME_SEC: "120"
+          MEMCP_TEST_JOBS: "2"
+        run: >-
+          python3 run_sql_tests.py
+          tests/performance/reddit-mysql-order-limit-join.yaml
+          tests/performance/physical-cost-calibration.yaml
+          --jobs 2
+          --log-times

--- a/.github/workflows/performance-regression-policy.yml
+++ b/.github/workflows/performance-regression-policy.yml
@@ -1,0 +1,40 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Performance Regression Policy
+
+on:
+  pull_request_target:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  protected-performance-policy:
+    name: protected-performance-policy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out trusted policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: policy
+
+      - name: Check out candidate as data
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+
+      - name: Install policy dependencies
+        run: pip install PyYAML
+
+      - name: Apply trusted performance policy
+        run: |
+          python3 policy/tools/test_performance_policy.py
+          python3 policy/tools/check_performance_policy.py \
+            --base-root policy \
+            --candidate-root candidate

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -54,15 +54,17 @@ jobs:
         run: |
           harness=base/tools/perf_ab.py
           harness_tests=base/tools/test_perf_ab.py
+          runner=base/run_sql_tests.py
           if [ ! -f "$harness" ]; then
             harness=candidate/tools/perf_ab.py
             harness_tests=candidate/tools/test_perf_ab.py
+            runner=candidate/run_sql_tests.py
           fi
           python3 "$harness_tests"
           python3 "$harness" \
             --base-tree base \
             --candidate-tree candidate \
-            --runner base/run_sql_tests.py \
+            --runner "$runner" \
             --samples 5 \
             --output perf-results.json
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,75 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Performance A/B
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: memcp-performance
+  cancel-in-progress: false
+
+jobs:
+  performance-ab:
+    name: performance-ab
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out merge candidate
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          path: candidate
+
+      - name: Check out exact base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: candidate/go.mod
+
+      - name: Install benchmark dependencies
+        run: pip install requests PyYAML
+
+      - name: Build base
+        working-directory: base
+        run: go build -o memcp
+
+      - name: Build merge candidate
+        working-directory: candidate
+        run: go build -o memcp
+
+      - name: Run independent performance assertion
+        shell: bash
+        run: |
+          harness=base/tools/perf_ab.py
+          harness_tests=base/tools/test_perf_ab.py
+          if [ ! -f "$harness" ]; then
+            harness=candidate/tools/perf_ab.py
+            harness_tests=candidate/tools/test_perf_ab.py
+          fi
+          python3 "$harness_tests"
+          python3 "$harness" \
+            --base-tree base \
+            --candidate-tree candidate \
+            --runner base/run_sql_tests.py \
+            --samples 5 \
+            --output perf-results.json
+
+      - name: Upload performance comparison
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-ab-results
+          path: perf-results.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ todos/
 .perf_baseline.json
 .perf_baseline.json.lock
 .perf_baseline.json.tmp
+.perf_runner_gate.lock
 .gocache/
 .gomodcache/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ go.sum
 docs/
 todos/
 .perf_baseline.json
+.perf_baseline.json.lock
+.perf_baseline.json.tmp
 .gocache/
 .gomodcache/
 __pycache__/

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -32,6 +32,7 @@ import sys
 import os
 import threading
 import fcntl
+from contextlib import contextmanager, nullcontext
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 # Dependency checks with clear install hints
@@ -181,6 +182,26 @@ PERF_SCALE_FACTOR = 1.3  # scale up/down by 30%
 PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_RAM_FRACTION = 0.30  # abort when MemAvailable drops below (1 - fraction) of MemTotal
 PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))  # measured runs per test; median reported
+PERF_SETUP_MAX_TIME_SEC = float(os.environ.get("PERF_SETUP_MAX_TIME_SEC", "120"))
+PERF_GATE_FILE = os.environ.get("PERF_GATE_FILE", ".perf_runner_gate.lock")
+_perf_gate_context = threading.local()
+
+
+@contextmanager
+def performance_server_gate(exclusive: bool = False):
+    """Allow fixture work concurrently while keeping timed queries uncontended."""
+    if not PERF_TEST_ENABLED or getattr(_perf_gate_context, "exclusive", False):
+        yield
+        return
+    with open(PERF_GATE_FILE, "a", encoding="utf-8") as gate:
+        fcntl.flock(gate.fileno(), fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        previous = getattr(_perf_gate_context, "exclusive", False)
+        _perf_gate_context.exclusive = exclusive
+        try:
+            yield
+        finally:
+            _perf_gate_context.exclusive = previous
+            fcntl.flock(gate.fileno(), fcntl.LOCK_UN)
 # Wall-clock budgets are expressed for a reference CPU.  A fixed SHA-256
 # workload, measured before MemCP starts in the full test hook, maps that budget
 # to the current machine.  The workload is deliberately independent of MemCP:
@@ -678,7 +699,8 @@ class SQLTestRunner:
                     if resp and resp.status_code == 200:
                         parts.append(f"[SQL] {step['sql'][:80]}\n       → {resp.text.strip()[:500]}")
                 elif "scm" in step:
-                    resp = requests.post(f"{self.base_url}/scm", data=step["scm"], headers=self.auth_header, timeout=5)
+                    with performance_server_gate():
+                        resp = requests.post(f"{self.base_url}/scm", data=step["scm"], headers=self.auth_header, timeout=5)
                     if resp and resp.status_code == 200:
                         parts.append(f"[SCM] {step['scm'][:80]}\n       → {resp.text.strip()[:500]}")
                 elif "psql" in step:
@@ -765,7 +787,8 @@ class SQLTestRunner:
         attempts = 5 if retry_on_connection_failure else 1
         for attempt in range(attempts):
             try:
-                return requests.post(url, data=body, headers=headers, timeout=timeout)
+                with performance_server_gate():
+                    return requests.post(url, data=body, headers=headers, timeout=timeout)
             except Exception:
                 if not retry_on_connection_failure:
                     return None
@@ -796,7 +819,8 @@ class SQLTestRunner:
                 headers = dict(headers)
                 headers.setdefault("Content-Type", "text/plain; charset=utf-8")
             body = query.encode("utf-8") if isinstance(query, str) else query
-            return requests.post(url, data=body, headers=headers, timeout=timeout)
+            with performance_server_gate():
+                return requests.post(url, data=body, headers=headers, timeout=timeout)
         except Exception as e:
             print(f"Error executing SPARQL: {e}")
             return None
@@ -805,7 +829,8 @@ class SQLTestRunner:
         try:
             self.ensure_database(database)
             url = f"{self.base_url}/rdf/{quote(database, safe='')}/load_ttl"
-            response = requests.post(url, data=ttl_data, headers=self.auth_header, timeout=10)
+            with performance_server_gate():
+                response = requests.post(url, data=ttl_data, headers=self.auth_header, timeout=10)
             return response is not None and response.status_code == 200
         except Exception as e:
             print(f"Error loading TTL data: {e}")
@@ -953,6 +978,7 @@ class SQLTestRunner:
         test_setup_steps = test_case.get("setup")
         heap_bytes = 0
         if test_setup_steps and isinstance(test_setup_steps, list):
+            setup_started = time.monotonic()
             for step in test_setup_steps:
                 # Inline RAM guard between every setup step — catches large
                 # inserts before the next one starts (monitor thread alone is
@@ -961,13 +987,23 @@ class SQLTestRunner:
                     trip_ram_abort(f"setup step of {name}")
                 if ram_pressure_abort.is_set():
                     return self._record_fail(name, "Aborted: RAM pressure during setup", None, None, None, is_noncritical)
+                setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+                if is_perf_test and setup_remaining <= 0:
+                    return self._record_fail(
+                        name, f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit",
+                        None, None, None, is_noncritical,
+                    )
                 if "sql" in step:
                     sql_code = step["sql"]
                     if is_perf_test:
                         sql_code = sql_code.replace("{rows}", str(perf_rows)).replace("{database}", database)
                     resp = self.execute_sql(
                         database, sql_code, syntax=self.suite_syntax,
-                        session_id=session_id, timeout=int(step.get("timeout", 600)),
+                        session_id=session_id,
+                        timeout=(
+                            max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
+                            if is_perf_test else int(step.get("timeout", 600))
+                        ),
                     )
                     expect_error = self._step_expects_error(step)
                     if resp is None:
@@ -984,7 +1020,12 @@ class SQLTestRunner:
                         scm = scm.replace("{rows}", str(perf_rows)).replace("{database}", database)
                     url = f"{self.base_url}/scm"
                     try:
-                        resp = requests.post(url, data=scm, headers=self.auth_header, timeout=600)
+                        with performance_server_gate():
+                            resp = requests.post(
+                                url, data=scm, headers=self.auth_header,
+                                timeout=(max(1, min(600, math.ceil(setup_remaining)))
+                                         if is_perf_test else 600),
+                            )
                     except Exception as e:
                         return self._record_fail(name, f"Setup SCM error: {e}", scm, None, None, is_noncritical)
                     if resp is None or resp.status_code != 200:
@@ -1010,7 +1051,8 @@ class SQLTestRunner:
             ))
             try:
                 url = f"{self.base_url}/scm"
-                resp = requests.post(url, data=scm_code, headers=self.auth_header, timeout=scm_timeout)
+                with performance_server_gate(exclusive=is_perf_test):
+                    resp = requests.post(url, data=scm_code, headers=self.auth_header, timeout=scm_timeout)
             except Exception as e:
                 if self._expect_interrupted_ok(expect):
                     self._record_success(name, is_noncritical)
@@ -1054,7 +1096,8 @@ class SQLTestRunner:
                 step_timeout = int(step.get("timeout", 30))
                 if "scm" in step:
                     url = f"{self.base_url}/scm"
-                    return requests.post(url, data=step["scm"], headers=self.auth_header, timeout=step_timeout)
+                    with performance_server_gate():
+                        return requests.post(url, data=step["scm"], headers=self.auth_header, timeout=step_timeout)
                 else:
                     return self.execute_sql(database, step["sql"],
                                             session_id=step.get("session_id"),
@@ -1313,17 +1356,6 @@ class SQLTestRunner:
                 warmup_runs = resolve_warmup_runs(test_case, is_perf_test)
             except ValueError as exc:
                 return self._record_fail(name, str(exc), query, None, None, is_noncritical)
-            if warmup_runs:
-                for _ in range(warmup_runs):
-                    self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
-
-            # Get memcp PID and start CPU measurement for perf tests
-            memcp_pid = find_memcp_pid() if is_perf_test else None
-            start_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
-
-            # Execute query. Performance tests and explicitly sampled short
-            # SELECTs report the median so one scheduler/GC pause cannot mask
-            # their steady-state behavior.
             try:
                 repeat = resolve_timing_samples(test_case, is_perf_test)
             except ValueError as exc:
@@ -1333,26 +1365,38 @@ class SQLTestRunner:
                     name, "timing_samples/repetitions is only supported for SELECT queries",
                     query, None, None, is_noncritical,
                 )
-            samples_ns: list = []
-            response = None
-            for _ in range(repeat):
-                start_ns = time.monotonic_ns()
-                response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
-                    database, query, auth_header, active_syntax,
-                    session_id=session_id, timeout=sql_timeout, params=sql_params,
-                    retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
-                )
-                samples_ns.append(time.monotonic_ns() - start_ns)
-                if response is None or response.status_code != 200:
-                    break  # don't hammer a broken endpoint
-            samples_ns.sort()
-            elapsed_ns = samples_ns[len(samples_ns) // 2]  # median
-            elapsed_ms = elapsed_ns / 1_000_000
-            elapsed_sec = elapsed_ms / 1000
 
-            if self.log_times:
-                min_ns, max_ns = samples_ns[0], samples_ns[-1]
-                print(f"QUERY_TIME median_ns={elapsed_ns} total_ns={sum(samples_ns)} min_ns={min_ns} max_ns={max_ns} n={len(samples_ns)} warmup={warmup_runs} name={name}")
+            # Fixture work in other YAML workers uses shared locks. Holding the
+            # exclusive lock across warmup and samples creates an uncontended
+            # measurement window without serializing the fill phases.
+            gate = performance_server_gate(exclusive=True) if is_perf_test else nullcontext()
+            with gate:
+                if warmup_runs:
+                    for _ in range(warmup_runs):
+                        self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
+
+                memcp_pid = find_memcp_pid() if is_perf_test else None
+                start_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
+                samples_ns: list = []
+                response = None
+                for _ in range(repeat):
+                    start_ns = time.monotonic_ns()
+                    response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
+                        database, query, auth_header, active_syntax,
+                        session_id=session_id, timeout=sql_timeout, params=sql_params,
+                        retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
+                    )
+                    samples_ns.append(time.monotonic_ns() - start_ns)
+                    if response is None or response.status_code != 200:
+                        break  # don't hammer a broken endpoint
+                samples_ns.sort()
+                elapsed_ns = samples_ns[len(samples_ns) // 2]  # median
+                elapsed_ms = elapsed_ns / 1_000_000
+                elapsed_sec = elapsed_ms / 1000
+
+                if self.log_times:
+                    min_ns, max_ns = samples_ns[0], samples_ns[-1]
+                    print(f"QUERY_TIME median_ns={elapsed_ns} total_ns={sum(samples_ns)} min_ns={min_ns} max_ns={max_ns} n={len(samples_ns)} warmup={warmup_runs} name={name}")
 
             # End CPU measurement
             end_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
@@ -1478,13 +1522,26 @@ class SQLTestRunner:
     def run_setup(self, setup_steps: List[Dict], database: str) -> bool:
         self.setup_operations = []
         self.current_database = database
+        setup_started = time.monotonic()
         for idx, step in enumerate(setup_steps, start=1):
             self.setup_operations.append(step)
+            if PERF_TEST_ENABLED and check_ram_pressure():
+                trip_ram_abort(f"suite setup step {idx}")
+            if PERF_TEST_ENABLED and ram_pressure_abort.is_set():
+                print(f"❌ Setup step {idx} aborted: RAM pressure")
+                return False
+            setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+            if PERF_TEST_ENABLED and setup_remaining <= 0:
+                print(f"❌ Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit")
+                return False
             expect_error = self._step_expects_error(step)
             if "sql" in step:
                 resp = self.execute_sql(
                     database, step['sql'], syntax=self.suite_syntax,
-                    timeout=int(step.get("timeout", 600)),
+                    timeout=(
+                        max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
+                        if PERF_TEST_ENABLED else int(step.get("timeout", 600))
+                    ),
                 )
                 if resp is None:
                     print(f"❌ Setup step {idx} failed: no response")
@@ -1505,7 +1562,12 @@ class SQLTestRunner:
                 scm_code = step["scm"]
                 try:
                     url = f"{self.base_url}/scm"
-                    resp = requests.post(url, data=scm_code, headers=self.auth_header, timeout=600)
+                    with performance_server_gate():
+                        resp = requests.post(
+                            url, data=scm_code, headers=self.auth_header,
+                            timeout=(max(1, min(600, math.ceil(setup_remaining)))
+                                     if PERF_TEST_ENABLED else 600),
+                        )
                 except Exception as e:
                     print(f"❌ Setup step {idx} failed: SCM exception: {e}")
                     print(f"    SCM: {scm_code[:300]}")
@@ -1942,6 +2004,7 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
         return True
 
     max_jobs = normalize_jobs(jobs)
+
     print(f"🧪 Running {len(spec_files)} suites (parallel where safe, jobs={max_jobs})")
 
     suite_status: Dict[str, bool] = {}
@@ -1953,7 +2016,13 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
         # - all suites retain the shared server and data directory.
         # - only non-isolated, non-restart suites may use the parallel
         #   connect-only worker pool.
-        mode = suite_execution_mode(spec_file)
+        metadata = load_suite_metadata(spec_file)
+        perf_parallel_safe = (
+            PERF_TEST_ENABLED
+            and not suite_requires_managed_restart(spec_file)
+            and not metadata.get("requires_mysql")
+        )
+        mode = "parallel" if perf_parallel_safe else suite_execution_mode(spec_file)
         if mode == "parallel":
             parallel_specs.append(spec_file)
         else:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -314,11 +314,29 @@ def scaled_compile_time_limit_ms(reference_ms: float, calibration: Dict[str, Any
 
 
 def resolve_timing_samples(test_case: Dict[str, Any], is_perf_test: bool) -> int:
-    """Return an odd sample count so the timed result has an unambiguous median."""
+    """Return the number of measured query repetitions."""
     default = PERF_REPEAT if is_perf_test else 1
-    raw = test_case.get("timing_samples", default)
-    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1 or raw % 2 == 0:
-        raise ValueError("timing_samples must be a positive odd integer")
+    has_samples = "timing_samples" in test_case
+    has_repetitions = "repetitions" in test_case
+    if has_samples and has_repetitions:
+        raise ValueError("use either timing_samples or repetitions, not both")
+    raw = test_case.get("repetitions", test_case.get("timing_samples", default))
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
+        raise ValueError("timing_samples/repetitions must be a positive integer")
+    return raw
+
+
+def resolve_warmup_runs(test_case: Dict[str, Any], is_perf_test: bool) -> int:
+    """Return the number of unmeasured runs before a performance measurement."""
+    if not is_perf_test:
+        return 0
+    raw = test_case.get("warmup", 2)
+    if raw is True:
+        return 2
+    if raw is False:
+        return 0
+    if not isinstance(raw, int) or raw < 0:
+        raise ValueError("warmup must be a non-negative integer or boolean")
     return raw
 
 
@@ -1290,9 +1308,13 @@ class SQLTestRunner:
                                                      f"Query plan too large (compile-time blowup): {plan_size} chars > {plan_size_limit}",
                                                      query, explain_resp, test_case.get("expect"), is_noncritical, on_fail_diag=diag)
 
-            # Warmup runs for performance tests (2 unmeasured runs before the measured one)
-            if is_perf_test and test_case.get("warmup", True):
-                for _ in range(2):
+            # Warmup runs are deliberately outside the measured repetition total.
+            try:
+                warmup_runs = resolve_warmup_runs(test_case, is_perf_test)
+            except ValueError as exc:
+                return self._record_fail(name, str(exc), query, None, None, is_noncritical)
+            if warmup_runs:
+                for _ in range(warmup_runs):
                     self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
 
             # Get memcp PID and start CPU measurement for perf tests
@@ -1306,9 +1328,9 @@ class SQLTestRunner:
                 repeat = resolve_timing_samples(test_case, is_perf_test)
             except ValueError as exc:
                 return self._record_fail(name, str(exc), query, None, None, is_noncritical)
-            if "timing_samples" in test_case and not query.lstrip().upper().startswith("SELECT"):
+            if ("timing_samples" in test_case or "repetitions" in test_case) and not query.lstrip().upper().startswith("SELECT"):
                 return self._record_fail(
-                    name, "timing_samples is only supported for SELECT queries",
+                    name, "timing_samples/repetitions is only supported for SELECT queries",
                     query, None, None, is_noncritical,
                 )
             samples_ns: list = []
@@ -1330,7 +1352,7 @@ class SQLTestRunner:
 
             if self.log_times:
                 min_ns, max_ns = samples_ns[0], samples_ns[-1]
-                print(f"QUERY_TIME median_ns={elapsed_ns} min_ns={min_ns} max_ns={max_ns} n={len(samples_ns)} name={name}")
+                print(f"QUERY_TIME median_ns={elapsed_ns} total_ns={sum(samples_ns)} min_ns={min_ns} max_ns={max_ns} n={len(samples_ns)} warmup={warmup_runs} name={name}")
 
             # End CPU measurement
             end_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None

--- a/tools/check_performance_policy.py
+++ b/tools/check_performance_policy.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prevent pull requests from weakening the independent performance gate."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+PROTECTED_POLICY_PATHS = (
+    ".github/workflows/performance.yml",
+    ".github/workflows/performance-regression-policy.yml",
+    "tools/perf_ab.py",
+    "tools/check_performance_policy.py",
+    "tools/test_perf_ab.py",
+    "tools/test_performance_policy.py",
+)
+PROTECTED_CASE_FIELDS = (
+    "sql",
+    "sparql",
+    "scm",
+    "setup",
+    "cleanup",
+    "steps",
+    "expect",
+    "performance_rows",
+)
+
+
+class PolicyFailure(RuntimeError):
+    """The candidate weakens a protected performance contract."""
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle) or {}
+    if not isinstance(document, dict):
+        raise PolicyFailure(f"{path}: suite must be a mapping")
+    if not isinstance(document.get("metadata"), dict):
+        raise PolicyFailure(f"{path}: metadata must be a mapping")
+    if not isinstance(document.get("test_cases"), list):
+        raise PolicyFailure(f"{path}: test_cases must be a list")
+    return document
+
+
+def numbered_cases(document: dict[str, Any]) -> dict[tuple[str, int], dict[str, Any]]:
+    counts: Counter[str] = Counter()
+    result: dict[tuple[str, int], dict[str, Any]] = {}
+    for index, case in enumerate(document["test_cases"]):
+        if not isinstance(case, dict):
+            raise PolicyFailure(f"test case #{index + 1} must be a mapping")
+        name = str(case.get("name", f"case #{index + 1}"))
+        counts[name] += 1
+        result[(name, counts[name])] = case
+    return result
+
+
+def finite_number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PolicyFailure(f"{label} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise PolicyFailure(f"{label} must be finite")
+    return result
+
+
+def regression_limit(case: dict[str, Any], metadata: dict[str, Any], label: str) -> float:
+    value = case.get("max_regression_pct", metadata.get("max_regression_pct", 20))
+    result = finite_number(value, f"{label}.max_regression_pct")
+    if not 10 <= result <= 30:
+        raise PolicyFailure(f"{label}.max_regression_pct must be from 10 through 30")
+    return result
+
+
+def timing_samples(case: dict[str, Any], label: str) -> int:
+    value = case.get("timing_samples", 5)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value % 2 == 0:
+        raise PolicyFailure(f"{label}.timing_samples must be a positive odd integer")
+    return value
+
+
+def compare_suite(base: dict[str, Any], candidate: dict[str, Any], relative: str) -> None:
+    base_metadata = base["metadata"]
+    candidate_metadata = candidate["metadata"]
+    if base_metadata.get("ci", True) is not False and candidate_metadata.get("ci") is False:
+        raise PolicyFailure(f"{relative}: candidate disabled the CI suite")
+    for field in ("setup", "cleanup"):
+        if base.get(field) != candidate.get(field):
+            raise PolicyFailure(f"{relative}: suite {field} is protected benchmark input")
+
+    base_cases = numbered_cases(base)
+    candidate_cases = numbered_cases(candidate)
+    for identity, old in base_cases.items():
+        name, occurrence = identity
+        label = f"{relative}:{name}#{occurrence}"
+        if identity not in candidate_cases:
+            raise PolicyFailure(f"{label}: existing performance case was deleted or renamed")
+        new = candidate_cases[identity]
+        if old.get("disabled") is not True and new.get("disabled") is True:
+            raise PolicyFailure(f"{label}: candidate disabled the case")
+        for field in PROTECTED_CASE_FIELDS:
+            if old.get(field) != new.get(field):
+                raise PolicyFailure(f"{label}.{field} is protected benchmark input")
+        if "threshold_ms" in old and "threshold_ms" not in new:
+            raise PolicyFailure(f"{label}: candidate removed the performance measurement")
+        if "threshold_ms" not in old:
+            continue
+        old_limit = regression_limit(old, base_metadata, label)
+        new_limit = regression_limit(new, candidate_metadata, label)
+        if new_limit > old_limit:
+            raise PolicyFailure(
+                f"{label}: max regression was relaxed from {old_limit:g}% to {new_limit:g}%"
+            )
+        old_samples = timing_samples(old, label)
+        new_samples = timing_samples(new, label)
+        if new_samples < old_samples:
+            raise PolicyFailure(
+                f"{label}: timing samples were reduced from {old_samples} to {new_samples}"
+            )
+        if old.get("warmup", True) is not False and new.get("warmup") is False:
+            raise PolicyFailure(f"{label}: candidate disabled benchmark warmup")
+
+
+def check_policy(base_root: Path, candidate_root: Path) -> None:
+    for relative in PROTECTED_POLICY_PATHS:
+        base_path = base_root / relative
+        candidate_path = candidate_root / relative
+        if candidate_path.is_symlink() or not candidate_path.is_file():
+            raise PolicyFailure(f"{relative}: protected policy file is missing or not regular")
+        if base_path.read_bytes() != candidate_path.read_bytes():
+            raise PolicyFailure(f"{relative}: protected performance policy was modified")
+
+    performance_root = base_root / "tests" / "performance"
+    for base_path in sorted(performance_root.rglob("*.yaml")):
+        relative = base_path.relative_to(base_root).as_posix()
+        candidate_path = candidate_root / relative
+        if candidate_path.is_symlink() or not candidate_path.is_file():
+            raise PolicyFailure(f"{relative}: existing performance suite was deleted")
+        compare_suite(load_yaml(base_path), load_yaml(candidate_path), relative)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-root", type=Path, required=True)
+    parser.add_argument("--candidate-root", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        check_policy(args.base_root.resolve(), args.candidate_root.resolve())
+    except (OSError, PolicyFailure, yaml.YAMLError) as exc:
+        print(f"Performance policy failed: {exc}", file=sys.stderr)
+        return 1
+    print("Performance policy passed: protected tests and A/B gate were not weakened")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_performance_policy.py
+++ b/tools/check_performance_policy.py
@@ -94,11 +94,19 @@ def regression_limit(case: dict[str, Any], metadata: dict[str, Any], label: str)
     return result
 
 
-def timing_samples(case: dict[str, Any], label: str) -> int:
-    value = case.get("timing_samples", 5)
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1 or value % 2 == 0:
-        raise PolicyFailure(f"{label}.timing_samples must be a positive odd integer")
-    return value
+def validate_execution_counts(case: dict[str, Any], label: str) -> None:
+    if "repetitions" in case and "timing_samples" in case:
+        raise PolicyFailure(
+            f"{label}: use either repetitions or timing_samples, not both"
+        )
+    repetitions = case.get("repetitions", case.get("timing_samples", 5))
+    if isinstance(repetitions, bool) or not isinstance(repetitions, int) or repetitions < 1:
+        raise PolicyFailure(f"{label}.repetitions must be a positive integer")
+    warmup = case.get("warmup", 2)
+    if isinstance(warmup, bool):
+        return
+    if not isinstance(warmup, int) or warmup < 0:
+        raise PolicyFailure(f"{label}.warmup must be a non-negative integer or boolean")
 
 
 def compare_suite(base: dict[str, Any], candidate: dict[str, Any], relative: str) -> None:
@@ -127,20 +135,14 @@ def compare_suite(base: dict[str, Any], candidate: dict[str, Any], relative: str
             raise PolicyFailure(f"{label}: candidate removed the performance measurement")
         if "threshold_ms" not in old:
             continue
+        validate_execution_counts(old, label)
+        validate_execution_counts(new, label)
         old_limit = regression_limit(old, base_metadata, label)
         new_limit = regression_limit(new, candidate_metadata, label)
         if new_limit > old_limit:
             raise PolicyFailure(
                 f"{label}: max regression was relaxed from {old_limit:g}% to {new_limit:g}%"
             )
-        old_samples = timing_samples(old, label)
-        new_samples = timing_samples(new, label)
-        if new_samples < old_samples:
-            raise PolicyFailure(
-                f"{label}: timing samples were reduced from {old_samples} to {new_samples}"
-            )
-        if old.get("warmup", True) is not False and new.get("warmup") is False:
-            raise PolicyFailure(f"{label}: candidate disabled benchmark warmup")
 
 
 def check_policy(base_root: Path, candidate_root: Path) -> None:

--- a/tools/perf_ab.py
+++ b/tools/perf_ab.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Measure a trusted performance corpus against a base and candidate tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class PerformanceFailure(RuntimeError):
+    """A missing, invalid, or regressed performance measurement."""
+
+
+def discover_suites(base_tree: Path) -> list[Path]:
+    suites: list[Path] = []
+    for path in sorted((base_tree / "tests" / "performance").rglob("*.yaml")):
+        with path.open("r", encoding="utf-8") as handle:
+            document = yaml.safe_load(handle) or {}
+        metadata = document.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise PerformanceFailure(f"{path}: metadata must be a mapping")
+        if metadata.get("ci", True) is not False:
+            suites.append(path)
+    if not suites:
+        raise PerformanceFailure("trusted base contains no CI performance suites")
+    return suites
+
+
+def measurement_map(payload: dict[str, Any], suite: str) -> dict[str, dict[str, Any]]:
+    if payload.get("schema_version") != 1:
+        raise PerformanceFailure(f"{suite}: unsupported or missing result schema")
+    measurements = payload.get("measurements")
+    if not isinstance(measurements, list):
+        raise PerformanceFailure(f"{suite}: measurements must be a list")
+
+    occurrences: dict[str, int] = {}
+    result: dict[str, dict[str, Any]] = {}
+    for measurement in measurements:
+        if not isinstance(measurement, dict) or not isinstance(measurement.get("name"), str):
+            raise PerformanceFailure(f"{suite}: malformed measurement")
+        name = measurement["name"]
+        occurrences[name] = occurrences.get(name, 0) + 1
+        identity = f"{suite}::{name}#{occurrences[name]}"
+        result[identity] = measurement
+    return result
+
+
+def performance_cases(suite: Path) -> list[dict[str, Any]]:
+    with suite.open("r", encoding="utf-8") as handle:
+        document = yaml.safe_load(handle) or {}
+    metadata = document.get("metadata", {})
+    default_regression = metadata.get("max_regression_pct", 20)
+    cases: list[dict[str, Any]] = []
+    for case in document.get("test_cases", []):
+        expanded = [(case, case.get("name", "?"))]
+        if "repeat" in case:
+            amount = int(case["repeat"])
+            expanded = [
+                (inner, f"{inner.get('name', '?')} (iter {iteration + 1}/{amount})")
+                for iteration in range(amount)
+                for inner in case.get("tests", [])
+            ]
+        for measured, name in expanded:
+            if "threshold_ms" not in measured:
+                continue
+            regression = measured.get("max_regression_pct", default_regression)
+            if (
+                isinstance(regression, bool)
+                or not isinstance(regression, (int, float))
+                or not 10 <= float(regression) <= 30
+            ):
+                raise PerformanceFailure(
+                    f"{suite}:{name}: max_regression_pct must be from 10 through 30"
+                )
+            cases.append({"name": name, "max_regression_pct": float(regression)})
+    return cases
+
+
+def parse_runner_output(output: str, suite: Path) -> dict[str, Any]:
+    timing_pattern = re.compile(
+        r"^QUERY_TIME median_ns=(\d+) min_ns=\d+ max_ns=\d+ n=\d+ name=(.*)$"
+    )
+    success_pattern = re.compile(
+        r"^✅ .*? \([0-9.]+ms / [0-9.]+ms, ([0-9,]+) rows(?:,|\))"
+    )
+    observed_timings = [
+        (int(match.group(1)), match.group(2))
+        for line in output.splitlines()
+        if (match := timing_pattern.match(line))
+    ]
+    rows = [
+        int(match.group(1).replace(",", ""))
+        for line in output.splitlines()
+        if (match := success_pattern.match(line))
+    ]
+    expected = performance_cases(suite)
+    remaining = Counter(case["name"] for case in expected)
+    timings: list[tuple[int, str]] = []
+    for timing in observed_timings:
+        name = timing[1]
+        if remaining[name] > 0:
+            timings.append(timing)
+            remaining[name] -= 1
+    if len(timings) != len(expected) or len(rows) != len(expected):
+        raise PerformanceFailure(
+            f"{suite.name}: expected {len(expected)} measurements, observed "
+            f"{len(timings)} timings and {len(rows)} row counts"
+        )
+    measurements: list[dict[str, Any]] = []
+    for expected_case, (median_ns, actual_name), row_count in zip(expected, timings, rows):
+        if actual_name != expected_case["name"]:
+            raise PerformanceFailure(
+                f"{suite.name}: expected measurement {expected_case['name']!r}, "
+                f"observed {actual_name!r}"
+            )
+        measurements.append(
+            {
+                "name": actual_name,
+                "time_ms": median_ns / 1_000_000,
+                "rows": row_count,
+                "max_regression_pct": expected_case["max_regression_pct"],
+            }
+        )
+    return {"schema_version": 1, "measurements": measurements}
+
+
+def compare_measurements(
+    base: dict[str, dict[str, Any]], candidate: dict[str, dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    errors: list[str] = []
+    if set(base) != set(candidate):
+        for identity in sorted(set(base) - set(candidate)):
+            errors.append(f"{identity}: candidate measurement is missing")
+        for identity in sorted(set(candidate) - set(base)):
+            errors.append(f"{identity}: unexpected candidate measurement")
+
+    comparisons: list[dict[str, Any]] = []
+    for identity in sorted(set(base) & set(candidate)):
+        baseline = base[identity]
+        current = candidate[identity]
+        try:
+            base_ms = float(baseline["time_ms"])
+            candidate_ms = float(current["time_ms"])
+            max_regression_pct = float(baseline["max_regression_pct"])
+            base_rows = int(baseline["rows"])
+            candidate_rows = int(current["rows"])
+        except (KeyError, TypeError, ValueError) as exc:
+            errors.append(f"{identity}: invalid numeric measurement: {exc}")
+            continue
+        if base_ms <= 0 or candidate_ms <= 0:
+            errors.append(f"{identity}: timings must be greater than zero")
+            continue
+        if not 10 <= max_regression_pct <= 30:
+            errors.append(f"{identity}: max_regression_pct must be from 10 through 30")
+            continue
+        if base_rows != candidate_rows:
+            errors.append(
+                f"{identity}: workload differs ({base_rows} base rows, "
+                f"{candidate_rows} candidate rows)"
+            )
+            continue
+
+        ratio = candidate_ms / base_ms
+        allowed_ratio = 1.0 + max_regression_pct / 100.0
+        regressed = ratio > allowed_ratio
+        comparison = {
+            "id": identity,
+            "base_ms": base_ms,
+            "candidate_ms": candidate_ms,
+            "ratio": ratio,
+            "max_regression_pct": max_regression_pct,
+            "regressed": regressed,
+            "rows": base_rows,
+        }
+        comparisons.append(comparison)
+        if regressed:
+            errors.append(
+                f"{identity}: {candidate_ms:.3f}ms is {(ratio - 1) * 100:.1f}% slower "
+                f"than {base_ms:.3f}ms (allowed {max_regression_pct:g}%)"
+            )
+    return comparisons, errors
+
+
+def run_suite(
+    tree: Path,
+    runner: Path,
+    suite: Path,
+    samples: int,
+    timeout: int,
+) -> dict[str, Any]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PERF_TEST": "1",
+            "PERF_CALIBRATE": "1",
+            "PERF_REPEAT": str(samples),
+        }
+    )
+    command = [sys.executable, str(runner), str(suite), "--log-times"]
+    completed = subprocess.run(
+        command,
+        cwd=tree,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
+    if completed.returncode != 0:
+        raise PerformanceFailure(
+            f"{tree.name}: {suite.name} failed with exit code {completed.returncode}"
+        )
+    return parse_runner_output(completed.stdout, suite)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-tree", type=Path, required=True)
+    parser.add_argument("--candidate-tree", type=Path, required=True)
+    parser.add_argument("--runner", type=Path, required=True)
+    parser.add_argument(
+        "--suite",
+        action="append",
+        help="trusted suite path relative to the base tree; repeat to select several",
+    )
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--suite-timeout", type=int, default=3600)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.samples < 1 or args.samples % 2 == 0:
+        raise PerformanceFailure("--samples must be a positive odd integer")
+    base_tree = args.base_tree.resolve()
+    candidate_tree = args.candidate_tree.resolve()
+    runner = args.runner.resolve()
+    suites = discover_suites(base_tree)
+    if args.suite:
+        requested = set(args.suite)
+        suites = [
+            suite for suite in suites
+            if suite.relative_to(base_tree).as_posix() in requested
+        ]
+        found = {suite.relative_to(base_tree).as_posix() for suite in suites}
+        missing = requested - found
+        if missing:
+            raise PerformanceFailure(
+                "unknown or non-CI performance suites: " + ", ".join(sorted(missing))
+            )
+
+    all_base: dict[str, dict[str, Any]] = {}
+    all_candidate: dict[str, dict[str, Any]] = {}
+    for index, suite in enumerate(suites):
+        relative = suite.relative_to(base_tree).as_posix()
+        order = (
+            ((base_tree, all_base, "base"), (candidate_tree, all_candidate, "candidate"))
+            if index % 2 == 0
+            else ((candidate_tree, all_candidate, "candidate"), (base_tree, all_base, "base"))
+        )
+        for tree, destination, label in order:
+            print(f"\n=== {relative}: {label} ===", flush=True)
+            payload = run_suite(
+                tree,
+                runner,
+                suite,
+                args.samples,
+                args.suite_timeout,
+            )
+            destination.update(measurement_map(payload, relative))
+
+    if not all_base:
+        raise PerformanceFailure("trusted performance corpus produced zero measurements")
+    comparisons, errors = compare_measurements(all_base, all_candidate)
+    output = {
+        "schema_version": 1,
+        "base_tree": str(base_tree),
+        "candidate_tree": str(candidate_tree),
+        "comparisons": comparisons,
+        "errors": errors,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(output, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print("\nPerformance comparison:")
+    for item in comparisons:
+        marker = "FAIL" if item["regressed"] else "PASS"
+        print(
+            f"{marker} {item['id']}: {item['base_ms']:.3f}ms -> "
+            f"{item['candidate_ms']:.3f}ms ({(item['ratio'] - 1) * 100:+.1f}%, "
+            f"limit +{item['max_regression_pct']:g}%)"
+        )
+    if errors:
+        raise PerformanceFailure("\n".join(errors))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (PerformanceFailure, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        print(f"Performance A/B failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tools/perf_ab.py
+++ b/tools/perf_ab.py
@@ -32,6 +32,16 @@ from typing import Any
 import yaml
 
 
+# The legacy matrix benchmark treats {rows} as a matrix dimension and therefore
+# performs cubic work. Its old local auto-calibrator converges near 100-300;
+# starting it with the linear-test default of 10,000 exhausts CI memory before
+# a base measurement exists. Keep this trusted bootstrap workload in the
+# harness until the suite declares performance_rows itself.
+BOOTSTRAP_ROWS = {
+    "tests/performance/baseline.yaml::Perf: MATRIX MULT": 100,
+}
+
+
 class PerformanceFailure(RuntimeError):
     """A missing, invalid, or regressed performance measurement."""
 
@@ -70,7 +80,7 @@ def measurement_map(payload: dict[str, Any], suite: str) -> dict[str, dict[str, 
     return result
 
 
-def performance_cases(suite: Path) -> list[dict[str, Any]]:
+def performance_cases(suite: Path, suite_id: str | None = None) -> list[dict[str, Any]]:
     with suite.open("r", encoding="utf-8") as handle:
         document = yaml.safe_load(handle) or {}
     metadata = document.get("metadata", {})
@@ -88,6 +98,10 @@ def performance_cases(suite: Path) -> list[dict[str, Any]]:
         for measured, name in expanded:
             if "threshold_ms" not in measured:
                 continue
+            if "repetitions" in measured and "timing_samples" in measured:
+                raise PerformanceFailure(
+                    f"{suite}:{name}: use either repetitions or timing_samples, not both"
+                )
             regression = measured.get("max_regression_pct", default_regression)
             if (
                 isinstance(regression, bool)
@@ -97,19 +111,50 @@ def performance_cases(suite: Path) -> list[dict[str, Any]]:
                 raise PerformanceFailure(
                     f"{suite}:{name}: max_regression_pct must be from 10 through 30"
                 )
-            cases.append({"name": name, "max_regression_pct": float(regression)})
+            repetitions = measured.get(
+                "repetitions", measured.get("timing_samples", 5)
+            )
+            if isinstance(repetitions, bool) or not isinstance(repetitions, int) or repetitions < 1:
+                raise PerformanceFailure(
+                    f"{suite}:{name}: repetitions must be a positive integer"
+                )
+            warmup = measured.get("warmup", 2)
+            if warmup is True:
+                warmup = 2
+            elif warmup is False:
+                warmup = 0
+            if not isinstance(warmup, int) or warmup < 0:
+                raise PerformanceFailure(
+                    f"{suite}:{name}: warmup must be a non-negative integer or boolean"
+                )
+            cases.append({
+                "name": name,
+                "max_regression_pct": float(regression),
+                "repetitions": repetitions,
+                "warmup": warmup,
+            })
+            identity = f"{suite_id}::{name}" if suite_id else None
+            cases[-1]["rows"] = int(
+                measured.get(
+                    "performance_rows",
+                    BOOTSTRAP_ROWS.get(identity, 10_000),
+                )
+            )
+            if cases[-1]["rows"] < 1:
+                raise PerformanceFailure(f"{suite}:{name}: performance_rows must be positive")
     return cases
 
 
-def parse_runner_output(output: str, suite: Path) -> dict[str, Any]:
+def parse_runner_output(output: str, suite: Path, suite_id: str | None = None) -> dict[str, Any]:
     timing_pattern = re.compile(
-        r"^QUERY_TIME median_ns=(\d+) min_ns=\d+ max_ns=\d+ n=\d+ name=(.*)$"
+        r"^QUERY_TIME median_ns=\d+ total_ns=(\d+) min_ns=\d+ max_ns=\d+ "
+        r"n=(\d+) warmup=(\d+) name=(.*)$"
     )
     success_pattern = re.compile(
         r"^✅ .*? \([0-9.]+ms / [0-9.]+ms, ([0-9,]+) rows(?:,|\))"
     )
     observed_timings = [
-        (int(match.group(1)), match.group(2))
+        (int(match.group(1)), int(match.group(2)), int(match.group(3)), match.group(4))
         for line in output.splitlines()
         if (match := timing_pattern.match(line))
     ]
@@ -118,11 +163,11 @@ def parse_runner_output(output: str, suite: Path) -> dict[str, Any]:
         for line in output.splitlines()
         if (match := success_pattern.match(line))
     ]
-    expected = performance_cases(suite)
+    expected = performance_cases(suite, suite_id)
     remaining = Counter(case["name"] for case in expected)
     timings: list[tuple[int, str]] = []
     for timing in observed_timings:
-        name = timing[1]
+        name = timing[3]
         if remaining[name] > 0:
             timings.append(timing)
             remaining[name] -= 1
@@ -132,7 +177,7 @@ def parse_runner_output(output: str, suite: Path) -> dict[str, Any]:
             f"{len(timings)} timings and {len(rows)} row counts"
         )
     measurements: list[dict[str, Any]] = []
-    for expected_case, (median_ns, actual_name), row_count in zip(expected, timings, rows):
+    for expected_case, (total_ns, repetitions, warmup, actual_name), row_count in zip(expected, timings, rows):
         if actual_name != expected_case["name"]:
             raise PerformanceFailure(
                 f"{suite.name}: expected measurement {expected_case['name']!r}, "
@@ -141,12 +186,25 @@ def parse_runner_output(output: str, suite: Path) -> dict[str, Any]:
         measurements.append(
             {
                 "name": actual_name,
-                "time_ms": median_ns / 1_000_000,
+                "total_ms": total_ns / 1_000_000,
+                "repetitions": repetitions,
+                "warmup": warmup,
                 "rows": row_count,
                 "max_regression_pct": expected_case["max_regression_pct"],
             }
         )
     return {"schema_version": 1, "measurements": measurements}
+
+
+def write_workload_baseline(tree: Path, suite: Path, suite_id: str) -> None:
+    """Give both revisions the same trusted row counts without timing allowances."""
+    baseline = {
+        case["name"]: {"rows": case["rows"]}
+        for case in performance_cases(suite, suite_id)
+    }
+    with (tree / ".perf_baseline.json").open("w", encoding="utf-8") as handle:
+        json.dump(baseline, handle, indent=2, sort_keys=True)
+        handle.write("\n")
 
 
 def compare_measurements(
@@ -164,15 +222,20 @@ def compare_measurements(
         baseline = base[identity]
         current = candidate[identity]
         try:
-            base_ms = float(baseline["time_ms"])
-            candidate_ms = float(current["time_ms"])
+            base_total_ms = float(baseline["total_ms"])
+            candidate_total_ms = float(current["total_ms"])
+            base_repetitions = int(baseline["repetitions"])
+            candidate_repetitions = int(current["repetitions"])
+            base_warmup = int(baseline["warmup"])
+            candidate_warmup = int(current["warmup"])
             max_regression_pct = float(baseline["max_regression_pct"])
             base_rows = int(baseline["rows"])
             candidate_rows = int(current["rows"])
         except (KeyError, TypeError, ValueError) as exc:
             errors.append(f"{identity}: invalid numeric measurement: {exc}")
             continue
-        if base_ms <= 0 or candidate_ms <= 0:
+        if (base_total_ms <= 0 or candidate_total_ms <= 0
+                or base_repetitions < 1 or candidate_repetitions < 1):
             errors.append(f"{identity}: timings must be greater than zero")
             continue
         if not 10 <= max_regression_pct <= 30:
@@ -185,8 +248,14 @@ def compare_measurements(
             )
             continue
 
+        base_ms = base_total_ms / base_repetitions
+        candidate_ms = candidate_total_ms / candidate_repetitions
+        warmup_bonus_pct = (
+            100.0 if base_warmup > 0 and candidate_warmup == 0 else 0.0
+        )
+        allowed_pct = max_regression_pct + warmup_bonus_pct
         ratio = candidate_ms / base_ms
-        allowed_ratio = 1.0 + max_regression_pct / 100.0
+        allowed_ratio = 1.0 + allowed_pct / 100.0
         regressed = ratio > allowed_ratio
         comparison = {
             "id": identity,
@@ -194,6 +263,11 @@ def compare_measurements(
             "candidate_ms": candidate_ms,
             "ratio": ratio,
             "max_regression_pct": max_regression_pct,
+            "warmup_bonus_pct": warmup_bonus_pct,
+            "base_repetitions": base_repetitions,
+            "candidate_repetitions": candidate_repetitions,
+            "base_warmup": base_warmup,
+            "candidate_warmup": candidate_warmup,
             "regressed": regressed,
             "rows": base_rows,
         }
@@ -201,7 +275,7 @@ def compare_measurements(
         if regressed:
             errors.append(
                 f"{identity}: {candidate_ms:.3f}ms is {(ratio - 1) * 100:.1f}% slower "
-                f"than {base_ms:.3f}ms (allowed {max_regression_pct:g}%)"
+                f"than {base_ms:.3f}ms per repetition (allowed {allowed_pct:g}%)"
             )
     return comparisons, errors
 
@@ -210,6 +284,7 @@ def run_suite(
     tree: Path,
     runner: Path,
     suite: Path,
+    suite_id: str,
     samples: int,
     timeout: int,
 ) -> dict[str, Any]:
@@ -217,10 +292,11 @@ def run_suite(
     environment.update(
         {
             "PERF_TEST": "1",
-            "PERF_CALIBRATE": "1",
+            "PERF_NORECALIBRATE": "1",
             "PERF_REPEAT": str(samples),
         }
     )
+    write_workload_baseline(tree, suite, suite_id)
     command = [sys.executable, str(runner), str(suite), "--log-times"]
     completed = subprocess.run(
         command,
@@ -237,7 +313,7 @@ def run_suite(
         raise PerformanceFailure(
             f"{tree.name}: {suite.name} failed with exit code {completed.returncode}"
         )
-    return parse_runner_output(completed.stdout, suite)
+    return parse_runner_output(completed.stdout, suite, suite_id)
 
 
 def parse_args() -> argparse.Namespace:
@@ -288,10 +364,12 @@ def main() -> int:
         )
         for tree, destination, label in order:
             print(f"\n=== {relative}: {label} ===", flush=True)
+            tree_suite = tree / relative
             payload = run_suite(
                 tree,
                 runner,
-                suite,
+                tree_suite,
+                relative,
                 args.samples,
                 args.suite_timeout,
             )
@@ -318,7 +396,8 @@ def main() -> int:
         print(
             f"{marker} {item['id']}: {item['base_ms']:.3f}ms -> "
             f"{item['candidate_ms']:.3f}ms ({(item['ratio'] - 1) * 100:+.1f}%, "
-            f"limit +{item['max_regression_pct']:g}%)"
+            f"limit +{item['max_regression_pct'] + item['warmup_bonus_pct']:g}%, "
+            f"{item['base_repetitions']} -> {item['candidate_repetitions']} repetitions)"
         )
     if errors:
         raise PerformanceFailure("\n".join(errors))

--- a/tools/test_perf_ab.py
+++ b/tools/test_perf_ab.py
@@ -19,12 +19,22 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from perf_ab import PerformanceFailure, compare_measurements, parse_runner_output
+from perf_ab import (
+    PerformanceFailure,
+    compare_measurements,
+    parse_runner_output,
+    performance_cases,
+)
 
 
-def measurement(time_ms: float, rows: int = 10_000, limit: float = 20) -> dict:
+def measurement(
+    total_ms: float, rows: int = 10_000, limit: float = 20,
+    repetitions: int = 1, warmup: int = 2,
+) -> dict:
     return {
-        "time_ms": time_ms,
+        "total_ms": total_ms,
+        "repetitions": repetitions,
+        "warmup": warmup,
         "rows": rows,
         "max_regression_pct": limit,
     }
@@ -46,6 +56,29 @@ class PerformanceComparatorTest(unittest.TestCase):
         )
         self.assertFalse(comparisons[0]["regressed"])
         self.assertEqual(errors, [])
+
+    def test_repetition_changes_are_normalized(self) -> None:
+        comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(500, repetitions=5)},
+            {"suite::query#1": measurement(9_000, repetitions=100)},
+        )
+        self.assertEqual(errors, [])
+        self.assertAlmostEqual(comparisons[0]["ratio"], 0.9)
+
+    def test_disabling_warmup_adds_one_hundred_percentage_points(self) -> None:
+        comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(500, repetitions=5, warmup=2)},
+            {"suite::query#1": measurement(1_100, repetitions=5, warmup=0)},
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(comparisons[0]["warmup_bonus_pct"], 100)
+
+        comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(500, repetitions=5, warmup=2)},
+            {"suite::query#1": measurement(1_105, repetitions=5, warmup=0)},
+        )
+        self.assertTrue(comparisons[0]["regressed"])
+        self.assertRegex(errors[0], "121.0% slower")
 
     def test_missing_candidate_measurement_fails_closed(self) -> None:
         _comparisons, errors = compare_measurements(
@@ -76,12 +109,13 @@ class PerformanceComparatorTest(unittest.TestCase):
             output = (
                 "QUERY_TIME median_ns=9000000 min_ns=8000000 "
                 "max_ns=10000000 n=1 name=correctness-only query\n"
-                "QUERY_TIME median_ns=125000000 min_ns=100000000 "
-                "max_ns=150000000 n=5 name=measured query\n"
+                "QUERY_TIME median_ns=125000000 total_ns=625000000 min_ns=100000000 "
+                "max_ns=150000000 n=5 warmup=2 name=measured query\n"
                 "✅ measured query (125.0ms / 30000ms, 10,000 rows, 12.50µs/row)\n"
             )
             payload = parse_runner_output(output, suite)
-        self.assertEqual(payload["measurements"][0]["time_ms"], 125)
+        self.assertEqual(payload["measurements"][0]["total_ms"], 625)
+        self.assertEqual(payload["measurements"][0]["repetitions"], 5)
         self.assertEqual(payload["measurements"][0]["rows"], 10_000)
         self.assertEqual(payload["measurements"][0]["max_regression_pct"], 15)
 
@@ -96,6 +130,22 @@ class PerformanceComparatorTest(unittest.TestCase):
             )
             with self.assertRaisesRegex(PerformanceFailure, "expected 1 measurements"):
                 parse_runner_output("", suite)
+
+    def test_cubic_matrix_uses_safe_bootstrap_dimension(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            suite = Path(directory) / "baseline.yaml"
+            suite.write_text(
+                "metadata: {description: test}\n"
+                "test_cases:\n"
+                "  - name: 'Perf: MATRIX MULT'\n"
+                "    threshold_ms: 30000\n"
+                "    sql: SELECT 1\n",
+                encoding="utf-8",
+            )
+            cases = performance_cases(
+                suite, "tests/performance/baseline.yaml"
+            )
+        self.assertEqual(cases[0]["rows"], 100)
 
 
 if __name__ == "__main__":

--- a/tools/test_perf_ab.py
+++ b/tools/test_perf_ab.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from perf_ab import PerformanceFailure, compare_measurements, parse_runner_output
+
+
+def measurement(time_ms: float, rows: int = 10_000, limit: float = 20) -> dict:
+    return {
+        "time_ms": time_ms,
+        "rows": rows,
+        "max_regression_pct": limit,
+    }
+
+
+class PerformanceComparatorTest(unittest.TestCase):
+    def test_one_regression_fails_the_comparison(self) -> None:
+        comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(100, limit=10)},
+            {"suite::query#1": measurement(111, limit=10)},
+        )
+        self.assertTrue(comparisons[0]["regressed"])
+        self.assertRegex(errors[0], "11.0% slower")
+
+    def test_boundary_is_allowed(self) -> None:
+        comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(100)},
+            {"suite::query#1": measurement(120)},
+        )
+        self.assertFalse(comparisons[0]["regressed"])
+        self.assertEqual(errors, [])
+
+    def test_missing_candidate_measurement_fails_closed(self) -> None:
+        _comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(100)}, {}
+        )
+        self.assertRegex(errors[0], "candidate measurement is missing")
+
+    def test_workloads_must_match(self) -> None:
+        _comparisons, errors = compare_measurements(
+            {"suite::query#1": measurement(100, rows=10_000)},
+            {"suite::query#1": measurement(100, rows=5_000)},
+        )
+        self.assertRegex(errors[0], "workload differs")
+
+    def test_trusted_yaml_supplies_limit_and_output_supplies_time(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            suite = Path(directory) / "suite.yaml"
+            suite.write_text(
+                "metadata:\n"
+                "  description: test\n"
+                "test_cases:\n"
+                "  - name: measured query\n"
+                "    threshold_ms: 30000\n"
+                "    max_regression_pct: 15\n"
+                "    sql: SELECT 1\n",
+                encoding="utf-8",
+            )
+            output = (
+                "QUERY_TIME median_ns=9000000 min_ns=8000000 "
+                "max_ns=10000000 n=1 name=correctness-only query\n"
+                "QUERY_TIME median_ns=125000000 min_ns=100000000 "
+                "max_ns=150000000 n=5 name=measured query\n"
+                "✅ measured query (125.0ms / 30000ms, 10,000 rows, 12.50µs/row)\n"
+            )
+            payload = parse_runner_output(output, suite)
+        self.assertEqual(payload["measurements"][0]["time_ms"], 125)
+        self.assertEqual(payload["measurements"][0]["rows"], 10_000)
+        self.assertEqual(payload["measurements"][0]["max_regression_pct"], 15)
+
+    def test_partial_output_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            suite = Path(directory) / "suite.yaml"
+            suite.write_text(
+                "metadata: {description: test}\n"
+                "test_cases:\n"
+                "  - {name: measured query, threshold_ms: 30000, sql: SELECT 1}\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(PerformanceFailure, "expected 1 measurements"):
+                parse_runner_output("", suite)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_performance_policy.py
+++ b/tools/test_performance_policy.py
@@ -63,12 +63,12 @@ class PerformancePolicyTest(unittest.TestCase):
         with self.assertRaisesRegex(PolicyFailure, "relaxed from 15% to 20%"):
             compare_suite(base, candidate, "tests/performance/test.yaml")
 
-    def test_sample_count_cannot_be_reduced(self) -> None:
+    def test_sample_count_changes_are_allowed(self) -> None:
         base = suite()
         candidate = copy.deepcopy(base)
         candidate["test_cases"][0]["timing_samples"] = 5
-        with self.assertRaisesRegex(PolicyFailure, "reduced from 7 to 5"):
-            compare_suite(base, candidate, "tests/performance/test.yaml")
+        candidate["test_cases"][0]["warmup"] = 0
+        compare_suite(base, candidate, "tests/performance/test.yaml")
 
     def test_tighter_limit_and_more_samples_are_allowed(self) -> None:
         base = suite()

--- a/tools/test_performance_policy.py
+++ b/tools/test_performance_policy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import copy
+import unittest
+
+from check_performance_policy import PolicyFailure, compare_suite
+
+
+def suite() -> dict:
+    return {
+        "metadata": {"description": "performance"},
+        "test_cases": [
+            {
+                "name": "protected query",
+                "sql": "SELECT COUNT(*) FROM items",
+                "threshold_ms": 30_000,
+                "max_regression_pct": 15,
+                "timing_samples": 7,
+                "expect": {"rows": 1},
+            }
+        ],
+    }
+
+
+class PerformancePolicyTest(unittest.TestCase):
+    def test_unchanged_suite_passes(self) -> None:
+        document = suite()
+        compare_suite(document, copy.deepcopy(document), "tests/performance/test.yaml")
+
+    def test_case_deletion_is_rejected(self) -> None:
+        base = suite()
+        candidate = copy.deepcopy(base)
+        candidate["test_cases"] = []
+        with self.assertRaisesRegex(PolicyFailure, "deleted or renamed"):
+            compare_suite(base, candidate, "tests/performance/test.yaml")
+
+    def test_query_replacement_is_rejected(self) -> None:
+        base = suite()
+        candidate = copy.deepcopy(base)
+        candidate["test_cases"][0]["sql"] = "SELECT 1"
+        with self.assertRaisesRegex(PolicyFailure, "protected benchmark input"):
+            compare_suite(base, candidate, "tests/performance/test.yaml")
+
+    def test_regression_limit_cannot_be_relaxed(self) -> None:
+        base = suite()
+        candidate = copy.deepcopy(base)
+        candidate["test_cases"][0]["max_regression_pct"] = 20
+        with self.assertRaisesRegex(PolicyFailure, "relaxed from 15% to 20%"):
+            compare_suite(base, candidate, "tests/performance/test.yaml")
+
+    def test_sample_count_cannot_be_reduced(self) -> None:
+        base = suite()
+        candidate = copy.deepcopy(base)
+        candidate["test_cases"][0]["timing_samples"] = 5
+        with self.assertRaisesRegex(PolicyFailure, "reduced from 7 to 5"):
+            compare_suite(base, candidate, "tests/performance/test.yaml")
+
+    def test_tighter_limit_and_more_samples_are_allowed(self) -> None:
+        base = suite()
+        candidate = copy.deepcopy(base)
+        candidate["test_cases"][0]["max_regression_pct"] = 10
+        candidate["test_cases"][0]["timing_samples"] = 9
+        compare_suite(base, candidate, "tests/performance/test.yaml")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -43,6 +43,7 @@ from run_sql_tests import (  # noqa: E402
     is_error_response,
     load_performance_scale,
     observe_atomic_json,
+    performance_server_gate,
     performance_architecture,
     performance_scale_from_samples,
     planner_time_limit_with_tolerance_ms,
@@ -59,6 +60,37 @@ from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
 
 class PerformanceScaleContractTest(unittest.TestCase):
+    def test_perf_gate_allows_parallel_work_and_serializes_measurement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            gate_path = str(Path(directory) / "perf.lock")
+            shared_entered = threading.Event()
+            release_shared = threading.Event()
+            exclusive_entered = threading.Event()
+
+            def shared_worker() -> None:
+                with performance_server_gate():
+                    shared_entered.set()
+                    release_shared.wait(2)
+
+            def exclusive_worker() -> None:
+                with performance_server_gate(exclusive=True):
+                    exclusive_entered.set()
+
+            with (
+                mock.patch("run_sql_tests.PERF_TEST_ENABLED", True),
+                mock.patch("run_sql_tests.PERF_GATE_FILE", gate_path),
+            ):
+                shared = threading.Thread(target=shared_worker)
+                exclusive = threading.Thread(target=exclusive_worker)
+                shared.start()
+                self.assertTrue(shared_entered.wait(1))
+                exclusive.start()
+                self.assertFalse(exclusive_entered.wait(0.05))
+                release_shared.set()
+                self.assertTrue(exclusive_entered.wait(1))
+                shared.join(1)
+                exclusive.join(1)
+
     def test_timing_samples_default_and_explicit_repetitions(self) -> None:
         self.assertEqual(resolve_timing_samples({}, False), 1)
         self.assertEqual(resolve_timing_samples({}, True), 5)

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -49,6 +49,7 @@ from run_sql_tests import (  # noqa: E402
     publish_performance_scale,
     request_shared_supervisor_restart,
     resolve_timing_samples,
+    resolve_warmup_runs,
     scaled_compile_time_limit_ms,
     scaled_wall_clock_limit_ms,
     sql_request_is_retry_safe,
@@ -58,16 +59,25 @@ from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
 
 class PerformanceScaleContractTest(unittest.TestCase):
-    def test_timing_samples_default_and_explicit_median(self) -> None:
+    def test_timing_samples_default_and_explicit_repetitions(self) -> None:
         self.assertEqual(resolve_timing_samples({}, False), 1)
         self.assertEqual(resolve_timing_samples({}, True), 5)
         self.assertEqual(resolve_timing_samples({"timing_samples": 3}, False), 3)
+        self.assertEqual(resolve_timing_samples({"timing_samples": 100}, True), 100)
+        self.assertEqual(resolve_timing_samples({"repetitions": 100}, True), 100)
 
-    def test_timing_samples_rejects_ambiguous_or_empty_samples(self) -> None:
-        for invalid in (True, 0, 2, 2.5, "3"):
+    def test_timing_samples_rejects_invalid_or_empty_samples(self) -> None:
+        for invalid in (True, 0, -1, 2.5, "3"):
             with self.subTest(invalid=invalid):
-                with self.assertRaisesRegex(ValueError, "positive odd integer"):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
                     resolve_timing_samples({"timing_samples": invalid}, False)
+
+    def test_warmup_is_a_run_count_with_boolean_compatibility(self) -> None:
+        self.assertEqual(resolve_warmup_runs({}, True), 2)
+        self.assertEqual(resolve_warmup_runs({"warmup": True}, True), 2)
+        self.assertEqual(resolve_warmup_runs({"warmup": 1}, True), 1)
+        self.assertEqual(resolve_warmup_runs({"warmup": 0}, True), 0)
+        self.assertEqual(resolve_warmup_runs({}, False), 0)
 
     def test_cold_planner_budget_allows_bounded_measurement_jitter(self) -> None:
         self.assertEqual(PLANNER_TIME_TOLERANCE_FACTOR, 1.2)


### PR DESCRIPTION
Follow-up to #654. Runs existing performance YAML suites concurrently for setup and other unmeasured work while an inter-process shared/exclusive gate gives warmups and timed repetitions uncontended access to MemCP. Caps each performance setup at 120 seconds and retains the existing RAM-pressure abort. Adds a 15-minute CI stress job using the existing million-row Reddit fixture and physical cost calibration suite; no synthetic fill suites are introduced.