### PR TITLE
Run performance A/B checks through SQL test runner

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,84 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Performance A/B
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: performance-ab-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  performance-ab:
+    name: performance-ab
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out merge candidate
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          path: candidate
+
+      - name: Check out exact base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: candidate/go.mod
+
+      - name: Install test dependencies
+        run: pip install requests PyYAML
+
+      - name: Build base and candidate
+        shell: bash
+        run: |
+          (cd base && go build -o memcp)
+          (cd candidate && go build -o memcp)
+
+      - name: Measure base and candidate with the SQL test runner
+        shell: bash
+        run: |
+          runner="$GITHUB_WORKSPACE/base/run_sql_tests.py"
+          if ! grep -q 'PERF_AB_MODE' "$runner"; then
+            runner="$GITHUB_WORKSPACE/candidate/run_sql_tests.py"
+          fi
+          baseline="$GITHUB_WORKSPACE/perf-baseline.json"
+
+          (cd base && env \
+            PERF_AB_MODE=record \
+            PERF_BASELINE_FILE="$baseline" \
+            PERF_REPEAT=5 \
+            PERF_SETUP_MAX_TIME_SEC=120 \
+            MEMCP_TEST_JOBS=4 \
+            MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/base" \
+            MEMCP_TEST_DATA_DIR=/tmp/memcp-perf-base \
+            python3 -u "$runner" --perf-ci --jobs 4 --log-times)
+
+          (cd candidate && env \
+            PERF_AB_MODE=compare \
+            PERF_BASELINE_FILE="$baseline" \
+            PERF_REPEAT=5 \
+            PERF_SETUP_MAX_TIME_SEC=120 \
+            MEMCP_TEST_JOBS=4 \
+            MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/candidate" \
+            MEMCP_TEST_DATA_DIR=/tmp/memcp-perf-candidate \
+            python3 -u "$runner" --perf-ci --jobs 4 --log-times)
+
+      - name: Upload measured base
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-ab-baseline
+          path: perf-baseline.json
+          if-no-files-found: warn

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -54,11 +54,17 @@ jobs:
             runner="$GITHUB_WORKSPACE/candidate/run_sql_tests.py"
           fi
           baseline="$GITHUB_WORKSPACE/perf-baseline.json"
+          seed="$GITHUB_WORKSPACE/base/tests/performance/ci-workloads.json"
+          if [ ! -f "$seed" ]; then
+            seed="$GITHUB_WORKSPACE/candidate/tests/performance/ci-workloads.json"
+          fi
 
           (cd base && env \
             PERF_AB_MODE=record \
             PERF_BASELINE_FILE="$baseline" \
-            PERF_REPEAT=5 \
+            PERF_BASELINE_SEED="$seed" \
+            PERF_REPEAT=100 \
+            PERF_MIN_MEASURE_MS=250 \
             PERF_SETUP_MAX_TIME_SEC=120 \
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/base" \
@@ -68,7 +74,8 @@ jobs:
           (cd candidate && env \
             PERF_AB_MODE=compare \
             PERF_BASELINE_FILE="$baseline" \
-            PERF_REPEAT=5 \
+            PERF_REPEAT=100 \
+            PERF_MIN_MEASURE_MS=250 \
             PERF_SETUP_MAX_TIME_SEC=120 \
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/candidate" \

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ go.sum
 docs/
 todos/
 .perf_baseline.json
+.perf_baseline.json.lock
+.perf_runner_gate.lock
 .gocache/
 .gomodcache/
 __pycache__/

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -177,6 +177,7 @@ PERF_CALIBRATE = os.environ.get("PERF_CALIBRATE", "0") == "1"  # reset baselines
 PERF_NORECALIBRATE = os.environ.get("PERF_NORECALIBRATE", "0") == "1"  # freeze row counts for bisecting
 PERF_EXPLAIN = os.environ.get("PERF_EXPLAIN", "0") == "1"  # show query plans
 PERF_BASELINE_FILE = os.environ.get("PERF_BASELINE_FILE", ".perf_baseline.json")
+PERF_BASELINE_SEED = os.environ.get("PERF_BASELINE_SEED", "")
 PERF_DEFAULT_REGRESSION_PCT = 20.0
 PERF_TARGET_MIN_MS = 10000  # target minimum query time (10s)
 PERF_TARGET_MAX_MS = 20000  # target maximum query time (20s)
@@ -184,6 +185,7 @@ PERF_SCALE_FACTOR = 1.3  # scale up/down by 30%
 PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_RAM_FRACTION = 0.30  # abort when MemAvailable drops below (1 - fraction) of MemTotal
 PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))
+PERF_MIN_MEASURE_MS = float(os.environ.get("PERF_MIN_MEASURE_MS", "250"))
 PERF_SETUP_MAX_TIME_SEC = float(os.environ.get("PERF_SETUP_MAX_TIME_SEC", "120"))
 PERF_GATE_FILE = os.environ.get("PERF_GATE_FILE", ".perf_runner_gate.lock")
 _perf_gate_context = threading.local()
@@ -225,6 +227,7 @@ MEMCP_START_TIMEOUT = int(os.environ.get("MEMCP_START_TIMEOUT", "180"))
 RUNNER_CONFIG_LOCK_FILE = f"{PERF_BASELINE_FILE}.lock"
 RUNNER_META_KEY = "_runner"
 FAILURE_MAP_KEY = "failures"
+CI_WORKLOAD_KEY = "_ci_workload"
 
 
 class PerformanceGate:
@@ -417,6 +420,10 @@ def performance_ab_threshold_ms(
     )
 
 
+def adaptive_measurement_complete(repetitions: int, total_ns: int) -> bool:
+    return repetitions >= 5 and total_ns >= PERF_MIN_MEASURE_MS * 1_000_000
+
+
 def planner_time_limit_with_tolerance_ms(
     reference_budget_ms: float, calibration: Dict[str, Any]
 ) -> float:
@@ -457,6 +464,25 @@ def _write_runner_config(config: Dict[str, Any]) -> None:
         json.dump(config, f, indent=2)
         f.write("\n")
     os.replace(tmp_file, PERF_BASELINE_FILE)
+
+
+def initialize_performance_recording() -> None:
+    config: Dict[str, Any] = {"schema_version": 1}
+    if PERF_BASELINE_SEED:
+        with open(PERF_BASELINE_SEED, 'r', encoding='utf-8') as handle:
+            seed = json.load(handle)
+        if seed.get("schema_version") != 1:
+            raise ValueError("performance baseline seed has an unsupported schema")
+        default_rows = seed.get("default_rows", PERF_DEFAULT_ROWS)
+        if isinstance(default_rows, bool) or not isinstance(default_rows, int) or default_rows < 1:
+            raise ValueError("performance baseline seed default_rows must be positive")
+        config[CI_WORKLOAD_KEY] = {"default_rows": default_rows}
+        for key, rows in seed.get("rows", {}).items():
+            if (not isinstance(key, str) or isinstance(rows, bool)
+                    or not isinstance(rows, int) or rows < 1):
+                raise ValueError("performance baseline seed rows must map names to positive integers")
+            config[key] = {"rows": rows}
+    _write_runner_config(config)
 
 def _update_runner_config(mutator) -> Dict[str, Any]:
     Path(RUNNER_CONFIG_LOCK_FILE).touch(exist_ok=True)
@@ -525,6 +551,8 @@ def max_rows_for_ram(bytes_per_row: int = 1024) -> int:
 
 # Global RAM pressure flag — set by monitor thread OR inline checks, read everywhere.
 ram_pressure_abort = threading.Event()
+_ram_monitor_lock = threading.Lock()
+_ram_monitor_started = False
 
 def trip_ram_abort(reason: str):
     """Record RAM abort, kill memcp so it releases RAM immediately, set the flag."""
@@ -552,9 +580,14 @@ def ram_monitor_loop(interval: float = 0.5):
 
 def start_ram_monitor():
     """Start the background RAM monitor thread (daemon — dies with main process)."""
-    t = threading.Thread(target=ram_monitor_loop, daemon=True)
-    t.start()
-    return t
+    global _ram_monitor_started
+    with _ram_monitor_lock:
+        if _ram_monitor_started:
+            return None
+        _ram_monitor_started = True
+        t = threading.Thread(target=ram_monitor_loop, daemon=True)
+        t.start()
+        return t
 
 class SQLTestRunner:
     def __init__(self, base_url="http://localhost:4321", username="root", password="admin", default_database="memcp-tests", log_times=False, fail_fast=False, performance_calibration=None):
@@ -1009,6 +1042,12 @@ class SQLTestRunner:
         if is_perf_test:
             perf_key = performance_case_key(self.current_spec_file or "?", name)
             self.perf_seen.add(perf_key)
+            workload_config = self.perf_baselines.get(CI_WORKLOAD_KEY, {})
+            ci_default_rows = (
+                workload_config.get("default_rows", PERF_DEFAULT_ROWS)
+                if isinstance(workload_config, dict) else PERF_DEFAULT_ROWS
+            )
+            declared_rows = test_case.get("performance_rows", ci_default_rows)
             baseline = self.perf_baselines.get(
                 perf_key, self.perf_baselines.get(name, {})
             )
@@ -1017,12 +1056,12 @@ class SQLTestRunner:
                     "time_per_repetition_ms", baseline.get("time_ms")
                 )
                 baseline_rows = baseline.get(
-                    "rows", test_case.get("performance_rows", PERF_DEFAULT_ROWS)
+                    "rows", declared_rows
                 )
             else:
                 # Legacy format: just a number
                 baseline_time = baseline
-                baseline_rows = test_case.get("performance_rows", PERF_DEFAULT_ROWS)
+                baseline_rows = declared_rows
 
             try:
                 if (isinstance(baseline_rows, bool)
@@ -1476,6 +1515,12 @@ class SQLTestRunner:
                 start_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
                 samples_ns: list = []
                 response = None
+                adaptive_repetitions = (
+                    is_perf_test
+                    and "repetitions" not in test_case
+                    and "timing_samples" not in test_case
+                )
+                measured_total_ns = 0
                 for _ in range(repeat):
                     start_ns = time.monotonic_ns()
                     response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
@@ -1483,11 +1528,17 @@ class SQLTestRunner:
                         session_id=session_id, timeout=sql_timeout, params=sql_params,
                         retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
                     )
-                    samples_ns.append(time.monotonic_ns() - start_ns)
+                    sample_ns = time.monotonic_ns() - start_ns
+                    samples_ns.append(sample_ns)
+                    measured_total_ns += sample_ns
                     if response is None or response.status_code != 200:
                         break  # don't hammer a broken endpoint
+                    if adaptive_repetitions and adaptive_measurement_complete(
+                        len(samples_ns), measured_total_ns
+                    ):
+                        break
 
-                total_ns = sum(samples_ns)
+                total_ns = measured_total_ns
                 elapsed_ns = total_ns / len(samples_ns)
                 elapsed_ms = elapsed_ns / 1_000_000
                 elapsed_sec = elapsed_ms / 1000
@@ -2367,7 +2418,7 @@ def main():
         sys.exit(1)
 
     if PERF_AB_MODE == "record" and not connect_only:
-        _write_runner_config({"schema_version": 1})
+        initialize_performance_recording()
     elif PERF_AB_MODE == "compare":
         baseline = _load_runner_config()
         if baseline.get("schema_version") != 1:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -169,18 +169,24 @@ def observe_atomic_json(path: Path, duration_seconds: float) -> Tuple[int, Optio
     return reads, None
 
 # Performance test configuration
-PERF_TEST_ENABLED = os.environ.get("PERF_TEST", "0") == "1"
+PERF_AB_MODE = os.environ.get("PERF_AB_MODE", "").strip().lower()
+if PERF_AB_MODE not in ("", "record", "compare"):
+    raise ValueError("PERF_AB_MODE must be 'record' or 'compare'")
+PERF_TEST_ENABLED = os.environ.get("PERF_TEST", "0") == "1" or bool(PERF_AB_MODE)
 PERF_CALIBRATE = os.environ.get("PERF_CALIBRATE", "0") == "1"  # reset baselines to current times
 PERF_NORECALIBRATE = os.environ.get("PERF_NORECALIBRATE", "0") == "1"  # freeze row counts for bisecting
 PERF_EXPLAIN = os.environ.get("PERF_EXPLAIN", "0") == "1"  # show query plans
-PERF_BASELINE_FILE = ".perf_baseline.json"
-PERF_THRESHOLD_FACTOR = 1.1  # 10% tolerance over baseline
+PERF_BASELINE_FILE = os.environ.get("PERF_BASELINE_FILE", ".perf_baseline.json")
+PERF_DEFAULT_REGRESSION_PCT = 20.0
 PERF_TARGET_MIN_MS = 10000  # target minimum query time (10s)
 PERF_TARGET_MAX_MS = 20000  # target maximum query time (20s)
 PERF_SCALE_FACTOR = 1.3  # scale up/down by 30%
 PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_RAM_FRACTION = 0.30  # abort when MemAvailable drops below (1 - fraction) of MemTotal
-PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))  # measured runs per test; median reported
+PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))
+PERF_SETUP_MAX_TIME_SEC = float(os.environ.get("PERF_SETUP_MAX_TIME_SEC", "120"))
+PERF_GATE_FILE = os.environ.get("PERF_GATE_FILE", ".perf_runner_gate.lock")
+_perf_gate_context = threading.local()
 # Wall-clock budgets are expressed for a reference CPU.  A fixed SHA-256
 # workload, measured before MemCP starts in the full test hook, maps that budget
 # to the current machine.  The workload is deliberately independent of MemCP:
@@ -219,6 +225,34 @@ MEMCP_START_TIMEOUT = int(os.environ.get("MEMCP_START_TIMEOUT", "180"))
 RUNNER_CONFIG_LOCK_FILE = f"{PERF_BASELINE_FILE}.lock"
 RUNNER_META_KEY = "_runner"
 FAILURE_MAP_KEY = "failures"
+
+
+class PerformanceGate:
+    """Let fixture requests overlap, but give timed queries an exclusive window."""
+
+    def __init__(self, exclusive: bool = False):
+        self.exclusive = exclusive
+        self.gate = None
+
+    def __enter__(self):
+        if not PERF_TEST_ENABLED or getattr(_perf_gate_context, "exclusive", False):
+            return self
+        self.gate = open(PERF_GATE_FILE, "a", encoding="utf-8")
+        fcntl.flock(
+            self.gate.fileno(), fcntl.LOCK_EX if self.exclusive else fcntl.LOCK_SH
+        )
+        _perf_gate_context.exclusive = self.exclusive
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.gate is not None:
+            _perf_gate_context.exclusive = False
+            fcntl.flock(self.gate.fileno(), fcntl.LOCK_UN)
+            self.gate.close()
+
+
+def performance_server_gate(exclusive: bool = False) -> PerformanceGate:
+    return PerformanceGate(exclusive)
 
 
 def performance_architecture(machine: Optional[str] = None) -> str:
@@ -314,12 +348,73 @@ def scaled_compile_time_limit_ms(reference_ms: float, calibration: Dict[str, Any
 
 
 def resolve_timing_samples(test_case: Dict[str, Any], is_perf_test: bool) -> int:
-    """Return an odd sample count so the timed result has an unambiguous median."""
+    """Return the number of measured repetitions for one test case."""
+    if "repetitions" in test_case and "timing_samples" in test_case:
+        raise ValueError("use either repetitions or timing_samples, not both")
     default = PERF_REPEAT if is_perf_test else 1
-    raw = test_case.get("timing_samples", default)
-    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1 or raw % 2 == 0:
-        raise ValueError("timing_samples must be a positive odd integer")
+    raw = test_case.get("repetitions", test_case.get("timing_samples", default))
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
+        raise ValueError("repetitions must be a positive integer")
     return raw
+
+
+def resolve_warmup_runs(test_case: Dict[str, Any], is_perf_test: bool) -> int:
+    if not is_perf_test:
+        return 0
+    raw = test_case.get("warmup", 2)
+    if raw is True:
+        return 2
+    if raw is False:
+        return 0
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        raise ValueError("warmup must be a non-negative integer or boolean")
+    return raw
+
+
+def performance_case_key(spec_file: str, name: str) -> str:
+    normalized = Path(spec_file).as_posix()
+    marker = "tests/"
+    position = normalized.rfind(marker)
+    if position >= 0:
+        normalized = normalized[position:]
+    return f"{normalized}::{name}"
+
+
+def performance_case_fingerprint(
+    test_case: Dict[str, Any], suite_setup: Any = None, suite_syntax: Any = None
+) -> str:
+    """Protect the measured workload while allowing timing-policy changes."""
+    protected = {
+        key: value for key, value in test_case.items()
+        if key not in {"repetitions", "timing_samples", "warmup"}
+    }
+    payload = json.dumps(
+        {"suite_setup": suite_setup or [], "suite_syntax": suite_syntax, "test": protected},
+        sort_keys=True, separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def performance_regression_pct(test_case: Dict[str, Any], metadata: Dict[str, Any]) -> float:
+    value = test_case.get(
+        "max_regression_pct",
+        metadata.get("max_regression_pct", PERF_DEFAULT_REGRESSION_PCT),
+    )
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not 10 <= float(value) <= 30:
+        raise ValueError("max_regression_pct must be from 10 through 30")
+    return float(value)
+
+
+def performance_ab_threshold_ms(
+    baseline_time_per_repetition_ms: float,
+    max_regression_pct: float,
+    baseline_warmup: int,
+    candidate_warmup: int,
+) -> float:
+    warmup_bonus_pct = 100.0 if baseline_warmup > 0 and candidate_warmup == 0 else 0.0
+    return baseline_time_per_repetition_ms * (
+        1.0 + (max_regression_pct + warmup_bonus_pct) / 100.0
+    )
 
 
 def planner_time_limit_with_tolerance_ms(
@@ -484,6 +579,7 @@ class SQLTestRunner:
         self._test_context = threading.local()
         self.perf_baselines = {}  # test_name -> {"time_ms": float, "rows": int}
         self.perf_results = {}  # test_name -> {"time_ms": float, "rows": int}
+        self.perf_seen = set()
         self.log_times = log_times  # emit QUERY_TIME ns=... lines for A/B benchmarking
         self.fail_fast = fail_fast
         self.current_spec_file = None
@@ -504,7 +600,7 @@ class SQLTestRunner:
             self.load_perf_baselines()
 
     def _bump_failure_counter(self, key: str):
-        if not key:
+        if not key or PERF_AB_MODE:
             return
 
         def mutate(config: Dict[str, Any]) -> None:
@@ -534,6 +630,10 @@ class SQLTestRunner:
         max_rows = max_rows_for_ram()
 
         def mutate(config: Dict[str, Any]) -> None:
+            if PERF_AB_MODE == "record":
+                for key, result in self.perf_results.items():
+                    config[key] = result
+                return
             if PERF_NORECALIBRATE:
                 # Just update times, keep existing rows
                 for name, result in self.perf_results.items():
@@ -901,26 +1001,76 @@ class SQLTestRunner:
             return self._record_fail(name, "max_compile_metrics must be a mapping",
                                      query, None, None, is_noncritical)
         perf_rows = PERF_DEFAULT_ROWS  # default row count
+        perf_key = None
+        baseline = {}
+        warmup_runs = 0
+        repeat = 1
+        max_regression_pct = PERF_DEFAULT_REGRESSION_PCT
         if is_perf_test:
-            # Get baseline data if available
-            baseline = self.perf_baselines.get(name, {})
+            perf_key = performance_case_key(self.current_spec_file or "?", name)
+            self.perf_seen.add(perf_key)
+            baseline = self.perf_baselines.get(
+                perf_key, self.perf_baselines.get(name, {})
+            )
             if isinstance(baseline, dict):
-                baseline_time = baseline.get("time_ms")
-                baseline_rows = baseline.get("rows", PERF_DEFAULT_ROWS)
+                baseline_time = baseline.get(
+                    "time_per_repetition_ms", baseline.get("time_ms")
+                )
+                baseline_rows = baseline.get(
+                    "rows", test_case.get("performance_rows", PERF_DEFAULT_ROWS)
+                )
             else:
                 # Legacy format: just a number
                 baseline_time = baseline
-                baseline_rows = PERF_DEFAULT_ROWS
+                baseline_rows = test_case.get("performance_rows", PERF_DEFAULT_ROWS)
 
-            # Use baseline time × 1.3 as threshold ONLY if in target range
-            # During scaling, use YAML threshold (generous)
-            if baseline_time and not PERF_CALIBRATE and baseline_time >= PERF_TARGET_MIN_MS:
-                threshold_ms = baseline_time * PERF_THRESHOLD_FACTOR
-            else:
-                threshold_ms = yaml_threshold_ms
+            try:
+                if (isinstance(baseline_rows, bool)
+                        or not isinstance(baseline_rows, int) or baseline_rows < 1):
+                    raise ValueError("performance_rows must be a positive integer")
+                repeat = resolve_timing_samples(test_case, True)
+                warmup_runs = resolve_warmup_runs(test_case, True)
+                max_regression_pct = performance_regression_pct(
+                    test_case, self.suite_metadata
+                )
+            except ValueError as exc:
+                return self._record_fail(name, str(exc), query, None, None, is_noncritical)
 
-            # Use baseline rows (which may have been scaled), capped by current RAM
-            perf_rows = min(baseline_rows, max_rows_for_ram())
+            fingerprint = performance_case_fingerprint(
+                test_case,
+                getattr(self, "current_suite_setup", []),
+                self.suite_metadata.get("syntax"),
+            )
+            if (PERF_AB_MODE == "compare" and baseline_time
+                    and baseline.get("workload_sha256") != fingerprint):
+                return self._record_fail(
+                    name,
+                    "Measured workload differs from trusted base; only repetitions/timing_samples and warmup may change",
+                    query, None, None, is_noncritical,
+                )
+
+            threshold_ms = yaml_threshold_ms
+            if PERF_AB_MODE == "compare" and baseline_time:
+                max_regression_pct = float(
+                    baseline.get("max_regression_pct", PERF_DEFAULT_REGRESSION_PCT)
+                )
+                if not 10 <= max_regression_pct <= 30:
+                    return self._record_fail(
+                        name, "Baseline max_regression_pct must be from 10 through 30",
+                        query, None, None, is_noncritical,
+                    )
+                threshold_ms = performance_ab_threshold_ms(
+                    float(baseline_time), max_regression_pct,
+                    int(baseline.get("warmup", 2)), warmup_runs,
+                )
+
+            # A/B workloads must be identical. The RAM guard aborts instead of
+            # silently shrinking only the candidate side.
+            perf_rows = (
+                int(baseline_rows)
+                if PERF_AB_MODE == "compare" and baseline_time
+                else min(int(baseline_rows), max_rows_for_ram())
+            )
 
             if not PERF_TEST_ENABLED:
                 print(f"⏭️  {name} (skipped - set PERF_TEST=1 to run)")
@@ -935,6 +1085,7 @@ class SQLTestRunner:
         test_setup_steps = test_case.get("setup")
         heap_bytes = 0
         if test_setup_steps and isinstance(test_setup_steps, list):
+            setup_started = time.monotonic()
             for step in test_setup_steps:
                 # Inline RAM guard between every setup step — catches large
                 # inserts before the next one starts (monitor thread alone is
@@ -943,14 +1094,25 @@ class SQLTestRunner:
                     trip_ram_abort(f"setup step of {name}")
                 if ram_pressure_abort.is_set():
                     return self._record_fail(name, "Aborted: RAM pressure during setup", None, None, None, is_noncritical)
+                setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+                if PERF_TEST_ENABLED and setup_remaining <= 0:
+                    return self._record_fail(
+                        name, f"Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit",
+                        None, None, None, is_noncritical,
+                    )
                 if "sql" in step:
                     sql_code = step["sql"]
                     if is_perf_test:
                         sql_code = sql_code.replace("{rows}", str(perf_rows)).replace("{database}", database)
-                    resp = self.execute_sql(
-                        database, sql_code, syntax=self.suite_syntax,
-                        session_id=session_id, timeout=int(step.get("timeout", 600)),
-                    )
+                    with performance_server_gate():
+                        resp = self.execute_sql(
+                            database, sql_code, syntax=self.suite_syntax,
+                            session_id=session_id,
+                            timeout=(
+                                max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
+                                if PERF_TEST_ENABLED else int(step.get("timeout", 600))
+                            ),
+                        )
                     expect_error = self._step_expects_error(step)
                     if resp is None:
                         return self._record_fail(name, "Setup SQL failed: no response", sql_code, None, None, is_noncritical)
@@ -966,7 +1128,12 @@ class SQLTestRunner:
                         scm = scm.replace("{rows}", str(perf_rows)).replace("{database}", database)
                     url = f"{self.base_url}/scm"
                     try:
-                        resp = requests.post(url, data=scm, headers=self.auth_header, timeout=600)
+                        with performance_server_gate():
+                            resp = requests.post(
+                                url, data=scm, headers=self.auth_header,
+                                timeout=(max(1, min(600, math.ceil(setup_remaining)))
+                                         if PERF_TEST_ENABLED else 600),
+                            )
                     except Exception as e:
                         return self._record_fail(name, f"Setup SCM error: {e}", scm, None, None, is_noncritical)
                     if resp is None or resp.status_code != 200:
@@ -1290,51 +1457,49 @@ class SQLTestRunner:
                                                      f"Query plan too large (compile-time blowup): {plan_size} chars > {plan_size_limit}",
                                                      query, explain_resp, test_case.get("expect"), is_noncritical, on_fail_diag=diag)
 
-            # Warmup runs for performance tests (2 unmeasured runs before the measured one)
-            if is_perf_test and test_case.get("warmup", True):
-                for _ in range(2):
-                    self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
-
-            # Get memcp PID and start CPU measurement for perf tests
-            memcp_pid = find_memcp_pid() if is_perf_test else None
-            start_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
-
-            # Execute query. Performance tests and explicitly sampled short
-            # SELECTs report the median so one scheduler/GC pause cannot mask
-            # their steady-state behavior.
-            try:
-                repeat = resolve_timing_samples(test_case, is_perf_test)
-            except ValueError as exc:
-                return self._record_fail(name, str(exc), query, None, None, is_noncritical)
-            if "timing_samples" in test_case and not query.lstrip().upper().startswith("SELECT"):
+            if not is_perf_test:
+                try:
+                    repeat = resolve_timing_samples(test_case, False)
+                except ValueError as exc:
+                    return self._record_fail(name, str(exc), query, None, None, is_noncritical)
+            if ("timing_samples" in test_case or "repetitions" in test_case) and not query.lstrip().upper().startswith("SELECT"):
                 return self._record_fail(
-                    name, "timing_samples is only supported for SELECT queries",
+                    name, "timing_samples/repetitions is only supported for SELECT queries",
                     query, None, None, is_noncritical,
                 )
-            samples_ns: list = []
-            response = None
-            for _ in range(repeat):
-                start_ns = time.monotonic_ns()
-                response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
-                    database, query, auth_header, active_syntax,
-                    session_id=session_id, timeout=sql_timeout, params=sql_params,
-                    retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
-                )
-                samples_ns.append(time.monotonic_ns() - start_ns)
-                if response is None or response.status_code != 200:
-                    break  # don't hammer a broken endpoint
-            samples_ns.sort()
-            elapsed_ns = samples_ns[len(samples_ns) // 2]  # median
-            elapsed_ms = elapsed_ns / 1_000_000
-            elapsed_sec = elapsed_ms / 1000
+            gate = performance_server_gate(exclusive=True) if is_perf_test else PerformanceGate()
+            with gate:
+                for _ in range(warmup_runs):
+                    self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(database, query, auth_header, active_syntax, timeout=sql_timeout)
 
-            if self.log_times:
-                min_ns, max_ns = samples_ns[0], samples_ns[-1]
-                print(f"QUERY_TIME median_ns={elapsed_ns} min_ns={min_ns} max_ns={max_ns} n={len(samples_ns)} name={name}")
+                memcp_pid = find_memcp_pid() if is_perf_test else None
+                start_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
+                samples_ns: list = []
+                response = None
+                for _ in range(repeat):
+                    start_ns = time.monotonic_ns()
+                    response = self.execute_sparql(database, query, auth_header, timeout=sql_timeout) if is_sparql else self.execute_sql(
+                        database, query, auth_header, active_syntax,
+                        session_id=session_id, timeout=sql_timeout, params=sql_params,
+                        retry_on_connection_failure=not self._expect_interrupted_ok(test_case.get("expect")),
+                    )
+                    samples_ns.append(time.monotonic_ns() - start_ns)
+                    if response is None or response.status_code != 200:
+                        break  # don't hammer a broken endpoint
 
-            # End CPU measurement
-            end_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
-            cpu_pct = measure_cpu_load(memcp_pid, start_cpu, end_cpu, elapsed_sec) if memcp_pid else None
+                total_ns = sum(samples_ns)
+                elapsed_ns = total_ns / len(samples_ns)
+                elapsed_ms = elapsed_ns / 1_000_000
+                elapsed_sec = elapsed_ms / 1000
+
+                if self.log_times:
+                    print(
+                        f"QUERY_TIME total_ns={total_ns} n={len(samples_ns)} "
+                        f"time_per_repetition_ns={elapsed_ns:.0f} warmup={warmup_runs} name={name}"
+                    )
+
+                end_cpu = get_process_cpu_times(memcp_pid) if memcp_pid else None
+                cpu_pct = measure_cpu_load(memcp_pid, start_cpu, end_cpu, elapsed_sec) if memcp_pid else None
 
         if response is None:
             expect = test_case.get("expect", {})
@@ -1346,6 +1511,12 @@ class SQLTestRunner:
         results = self.parse_jsonl_response(response)
 
         # Check performance threshold
+        if is_perf_test and PERF_AB_MODE == "compare" and baseline_time:
+            change_pct = (elapsed_ms / float(baseline_time) - 1.0) * 100.0
+            print(
+                f"PERF_AB {name}: {float(baseline_time):.3f}ms -> "
+                f"{elapsed_ms:.3f}ms per repetition ({change_pct:+.1f}%)"
+            )
         if is_perf_test and elapsed_ms > threshold_ms:
             diag = self._run_on_fail(test_case, database)
             return self._record_fail(name, f"Too slow: {elapsed_ms:.1f}ms > {threshold_ms:.0f}ms", query, response,
@@ -1372,8 +1543,17 @@ class SQLTestRunner:
             if is_perf_test:
                 heap_mb = heap_bytes / (1024 * 1024) if heap_bytes else None
                 self._record_success(name, is_noncritical, elapsed_ms, threshold_ms, perf_rows, heap_mb, cpu_pct)
-                # Store result for baseline update (time and row count)
-                self.perf_results[name] = {"time_ms": elapsed_ms, "rows": perf_rows}
+                result = {
+                    "time_ms": elapsed_ms,
+                    "time_per_repetition_ms": elapsed_ms,
+                    "total_ms": total_ns / 1_000_000,
+                    "repetitions": len(samples_ns),
+                    "warmup": warmup_runs,
+                    "rows": perf_rows,
+                    "max_regression_pct": max_regression_pct,
+                    "workload_sha256": fingerprint,
+                }
+                self.perf_results[perf_key if PERF_AB_MODE else name] = result
             else:
                 self._record_success(name, is_noncritical)
             return True
@@ -1456,14 +1636,28 @@ class SQLTestRunner:
     def run_setup(self, setup_steps: List[Dict], database: str) -> bool:
         self.setup_operations = []
         self.current_database = database
+        setup_started = time.monotonic()
         for idx, step in enumerate(setup_steps, start=1):
             self.setup_operations.append(step)
+            if check_ram_pressure():
+                trip_ram_abort(f"suite setup step {idx}")
+            if ram_pressure_abort.is_set():
+                print("❌ Setup aborted due to RAM pressure")
+                return False
+            setup_remaining = PERF_SETUP_MAX_TIME_SEC - (time.monotonic() - setup_started)
+            if PERF_TEST_ENABLED and setup_remaining <= 0:
+                print(f"❌ Setup exceeded {PERF_SETUP_MAX_TIME_SEC:g}s limit")
+                return False
             expect_error = self._step_expects_error(step)
             if "sql" in step:
-                resp = self.execute_sql(
-                    database, step['sql'], syntax=self.suite_syntax,
-                    timeout=int(step.get("timeout", 600)),
-                )
+                with performance_server_gate():
+                    resp = self.execute_sql(
+                        database, step['sql'], syntax=self.suite_syntax,
+                        timeout=(
+                            max(1, min(int(step.get("timeout", 600)), math.ceil(setup_remaining)))
+                            if PERF_TEST_ENABLED else int(step.get("timeout", 600))
+                        ),
+                    )
                 if resp is None:
                     print(f"❌ Setup step {idx} failed: no response")
                     print(f"    SQL: {step.get('sql','')[:300]}")
@@ -1483,7 +1677,12 @@ class SQLTestRunner:
                 scm_code = step["scm"]
                 try:
                     url = f"{self.base_url}/scm"
-                    resp = requests.post(url, data=scm_code, headers=self.auth_header, timeout=600)
+                    with performance_server_gate():
+                        resp = requests.post(
+                            url, data=scm_code, headers=self.auth_header,
+                            timeout=(max(1, min(600, math.ceil(setup_remaining)))
+                                     if PERF_TEST_ENABLED else 600),
+                        )
                 except Exception as e:
                     print(f"❌ Setup step {idx} failed: SCM exception: {e}")
                     print(f"    SCM: {scm_code[:300]}")
@@ -1510,7 +1709,8 @@ class SQLTestRunner:
 
     def run_cleanup(self, cleanup_steps: List[Dict], database: str) -> None:
         for step in cleanup_steps:
-            self.execute_sql(database, step['sql'], syntax=self.suite_syntax)
+            with performance_server_gate():
+                self.execute_sql(database, step['sql'], syntax=self.suite_syntax)
 
     def _step_expects_error(self, step: Any) -> bool:
         if not isinstance(step, dict):
@@ -1554,7 +1754,21 @@ class SQLTestRunner:
     # ----------------------
     # Spec Runner
     # ----------------------
-    def run_test_spec(self, spec_file: str) -> bool:
+    def prepare_test_spec(self, spec_file: str) -> bool:
+        """Run a suite's top-level setup without starting any test case."""
+        with open(spec_file, 'r') as f:
+            spec = yaml.safe_load(f) or {}
+        metadata = spec.get('metadata', {}) or {}
+        self.current_spec_file = spec_file
+        self.suite_metadata = metadata
+        self.suite_syntax = self._normalize_syntax(metadata.get("syntax"))
+        self.current_suite_setup = spec.get('setup') or []
+        self.ensure_runner_config_loaded()
+        self.ensure_database(self.default_database)
+        setup = spec.get('setup')
+        return not setup or self.run_setup(setup, self.default_database)
+
+    def run_test_spec(self, spec_file: str, setup_done: bool = False) -> bool:
         with open(spec_file, 'r') as f:
             spec = yaml.safe_load(f)
 
@@ -1562,6 +1776,7 @@ class SQLTestRunner:
         metadata = spec.get('metadata', {})
         self.suite_metadata = metadata or {}
         self.suite_syntax = self._normalize_syntax(self.suite_metadata.get("syntax"))
+        self.current_suite_setup = spec.get('setup') or []
         database = self.default_database
 
         if metadata.get('disabled'):
@@ -1593,7 +1808,7 @@ class SQLTestRunner:
         raw_cases = spec.get('test_cases', [])
         total_declared_cases = sum(int(tc.get('repeat', 1)) * len(tc.get('tests', [])) if isinstance(tc, dict) and 'repeat' in tc else 1 for tc in raw_cases)
 
-        if spec.get('setup') and not self.run_setup(spec['setup'], database):
+        if not setup_done and spec.get('setup') and not self.run_setup(spec['setup'], database):
             print("❌ Setup failed")
             self._bump_failure_counter(_suite_failure_key(spec_file))
             if self.fail_fast and total_declared_cases > 0:
@@ -1674,8 +1889,23 @@ class SQLTestRunner:
         print("="*60)
 
         # Update performance baselines on success (or in calibration mode)
-        if PERF_TEST_ENABLED and self.perf_results and (failed_crit == 0 or PERF_CALIBRATE):
+        if (PERF_TEST_ENABLED and PERF_AB_MODE != "compare" and self.perf_results
+                and (failed_crit == 0 or PERF_CALIBRATE)):
             self.save_perf_baselines()
+
+        if PERF_AB_MODE == "compare":
+            prefix = performance_case_key(spec_file, "").removesuffix("::") + "::"
+            expected = {
+                key for key in self.perf_baselines
+                if isinstance(key, str) and key.startswith(prefix)
+            }
+            missing = sorted(expected - self.perf_seen)
+            for key in missing:
+                self._record_fail(
+                    key, "Performance case from baseline is missing in candidate",
+                    None, None, None,
+                )
+            failed_crit = self.failed_critical
 
         # Print memcp log on critical failures to aid debugging
         if failed_crit > 0:
@@ -1742,7 +1972,10 @@ def start_memcp_process(port: int, enable_mysql: bool = False) -> subprocess.Pop
         if not enable_mysql:
             cmd.append("--disable-mysql")
         cmd.append("lib/main.scm")
-        proc = subprocess.Popen(cmd, cwd=os.path.dirname(os.path.abspath(__file__)),
+        worktree = os.environ.get(
+            "MEMCP_TEST_WORKTREE", os.path.dirname(os.path.abspath(__file__))
+        )
+        proc = subprocess.Popen(cmd, cwd=worktree,
            env=env, stdin=subprocess.PIPE, stdout=logfile, stderr=logfile, text=True)
         if not wait_for_memcp(port, timeout=MEMCP_START_TIMEOUT):
             print_memcp_log(tail=50)
@@ -1874,6 +2107,28 @@ def normalize_jobs(jobs: Optional[int]) -> int:
     return jobs
 
 
+def discover_performance_ci_suites(root: Path = Path("tests/performance")) -> List[str]:
+    suites = []
+    for path in sorted(root.rglob("*.yaml")):
+        with path.open('r', encoding='utf-8') as handle:
+            spec = yaml.safe_load(handle) or {}
+        metadata = spec.get("metadata", {}) or {}
+        if metadata.get("ci", True) is False:
+            continue
+        cases = spec.get("test_cases", [])
+        has_measurement = any(
+            "threshold_ms" in inner
+            for case in cases if isinstance(case, dict)
+            for inner in (case.get("tests", []) if "repeat" in case else [case])
+            if isinstance(inner, dict)
+        )
+        if has_measurement:
+            suites.append(path.as_posix())
+    if not suites:
+        raise ValueError("no CI performance suites with threshold_ms found")
+    return suites
+
+
 def run_spec_subprocess(spec_file: str, port: Optional[int], log_times: bool, connect_only: bool, fail_fast: bool) -> Tuple[bool, str]:
     cmd = [sys.executable, os.path.abspath(__file__), spec_file]
     if connect_only and port is not None:
@@ -1896,6 +2151,50 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
         if restart_handler is not None:
             runner.set_restart_handler(restart_handler)
         return runner.run_test_spec(spec_files[0])
+
+    if PERF_TEST_ENABLED:
+        max_jobs = normalize_jobs(jobs)
+        print(
+            f"🧪 Preparing {len(spec_files)} performance suites in parallel "
+            f"(jobs={max_jobs})"
+        )
+        runners = {
+            spec_file: SQLTestRunner(base_url, log_times=log_times)
+            for spec_file in spec_files
+        }
+        with ThreadPoolExecutor(max_workers=max_jobs) as executor:
+            futures = {
+                executor.submit(runners[spec_file].prepare_test_spec, spec_file): spec_file
+                for spec_file in spec_files
+            }
+            prepared = {future: future.result() for future in as_completed(futures)}
+        failed_setup = [futures[future] for future, ok in prepared.items() if not ok]
+        if failed_setup:
+            print("❌ Performance setup failed; no measurements were started:")
+            for spec_file in failed_setup:
+                print(f"   ❌ {spec_file}")
+            return False
+
+        print(
+            "⏱️  All suite setups complete; continuing fixture work in parallel "
+            "with exclusive timed-query windows"
+        )
+        with ThreadPoolExecutor(max_workers=max_jobs) as executor:
+            futures = {
+                executor.submit(
+                    runners[spec_file].run_test_spec, spec_file, True
+                ): spec_file
+                for spec_file in spec_files
+            }
+            measured = {future: future.result() for future in as_completed(futures)}
+        failed_files = [futures[future] for future, ok in measured.items() if not ok]
+        if failed_files:
+            print("❌ Performance suites failed:")
+            for spec_file in failed_files:
+                print(f"   ❌ {spec_file}")
+            return False
+        print("🎉 All performance suites passed!")
+        return True
 
     if fail_fast:
         ordered_specs = prioritize_spec_files(spec_files)
@@ -1972,22 +2271,25 @@ def run_test_specs(spec_files: List[str], base_url: str, port: int, log_times: b
 
 
 def print_usage() -> None:
-    print("Usage: python3 run_sql_tests.py <test_spec.yaml> [<test_spec2.yaml> ...] [port] [--port N] [--connect-only] [--jobs N] [--fail-fast]")
+    print("Usage: python3 run_sql_tests.py <test_spec.yaml> [<test_spec2.yaml> ...] [port] [--perf-ci] [--port N] [--connect-only] [--jobs N] [--fail-fast]")
 
 
-def parse_cli_args(argv: List[str]) -> Tuple[List[str], Optional[int], bool, bool, Optional[int], bool]:
+def parse_cli_args(argv: List[str]) -> Tuple[List[str], Optional[int], bool, bool, Optional[int], bool, bool]:
     spec_files: List[str] = []
     port: Optional[int] = None
     connect_only = False
     log_times = False
     jobs: Optional[int] = None
     fail_fast = False
+    perf_ci = False
 
     i = 0
     while i < len(argv):
         arg = argv[i]
         if arg == "--connect-only":
             connect_only = True
+        elif arg == "--perf-ci":
+            perf_ci = True
         elif arg == "--fail-fast":
             fail_fast = True
         elif arg == "--log-times":
@@ -2027,7 +2329,7 @@ def parse_cli_args(argv: List[str]) -> Tuple[List[str], Optional[int], bool, boo
             spec_files.append(arg)
         i += 1
 
-    return spec_files, port, connect_only, log_times, jobs, fail_fast
+    return spec_files, port, connect_only, log_times, jobs, fail_fast, perf_ci
 
 
 def main():
@@ -2040,11 +2342,36 @@ def main():
     performance_calibration = load_performance_scale()
     publish_performance_scale(performance_calibration)
 
-    spec_files, port, connect_only, log_times, jobs, fail_fast = parse_cli_args(sys.argv[1:])
+    spec_files, port, connect_only, log_times, jobs, fail_fast, perf_ci = parse_cli_args(sys.argv[1:])
+
+    if perf_ci:
+        if spec_files:
+            raise ValueError("--perf-ci discovers its suites; do not pass YAML paths")
+        spec_files = discover_performance_ci_suites()
+        if PERF_AB_MODE == "compare":
+            baseline_suites = {
+                key.split("::", 1)[0]
+                for key in _load_runner_config()
+                if isinstance(key, str) and key.startswith("tests/") and "::" in key
+            }
+            missing_suites = sorted(path for path in baseline_suites if not Path(path).is_file())
+            if missing_suites:
+                raise ValueError(
+                    "candidate deleted baseline performance suites: "
+                    + ", ".join(missing_suites)
+                )
+            spec_files = sorted(set(spec_files) | baseline_suites)
 
     if not spec_files:
         print_usage()
         sys.exit(1)
+
+    if PERF_AB_MODE == "record" and not connect_only:
+        _write_runner_config({"schema_version": 1})
+    elif PERF_AB_MODE == "compare":
+        baseline = _load_runner_config()
+        if baseline.get("schema_version") != 1:
+            raise ValueError("performance A/B baseline is missing or has an unsupported schema")
 
     if port is None:
         if connect_only:

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1568,7 +1568,7 @@ class SQLTestRunner:
                 f"PERF_AB {name}: {float(baseline_time):.3f}ms -> "
                 f"{elapsed_ms:.3f}ms per repetition ({change_pct:+.1f}%)"
             )
-        if is_perf_test and elapsed_ms > threshold_ms:
+        if is_perf_test and PERF_AB_MODE != "record" and elapsed_ms > threshold_ms:
             diag = self._run_on_fail(test_case, database)
             return self._record_fail(name, f"Too slow: {elapsed_ms:.1f}ms > {threshold_ms:.0f}ms", query, response,
                                      test_case.get("expect"), is_noncritical, elapsed_ms, threshold_ms, diag)
@@ -1890,6 +1890,12 @@ class SQLTestRunner:
                         test_cases.append(expanded)
             else:
                 test_cases.append(tc)
+
+        if PERF_AB_MODE:
+            test_cases = [
+                test_case for test_case in test_cases
+                if "threshold_ms" in test_case
+            ]
 
         # Preserve declared concurrency in every mode. Fail-fast stops only
         # after the complete parallel group containing the first failure.

--- a/tests/performance/baseline.yaml
+++ b/tests/performance/baseline.yaml
@@ -148,7 +148,6 @@ test_cases:
   # Total work: O({rows}^3) — auto-scaler will find dim ~100-300
   # GROUP BY on joins not yet supported; raw join is the dominant cost anyway
   - name: "Perf: MATRIX MULT"
-    performance_rows: 100
     setup:
       - sql: "DROP TABLE IF EXISTS `perf_mat_a`"
       - sql: "DROP TABLE IF EXISTS `perf_mat_b`"

--- a/tests/performance/baseline.yaml
+++ b/tests/performance/baseline.yaml
@@ -148,6 +148,7 @@ test_cases:
   # Total work: O({rows}^3) — auto-scaler will find dim ~100-300
   # GROUP BY on joins not yet supported; raw join is the dominant cost anyway
   - name: "Perf: MATRIX MULT"
+    performance_rows: 100
     setup:
       - sql: "DROP TABLE IF EXISTS `perf_mat_a`"
       - sql: "DROP TABLE IF EXISTS `perf_mat_b`"

--- a/tests/performance/ci-workloads.json
+++ b/tests/performance/ci-workloads.json
@@ -1,0 +1,14 @@
+{
+  "copyright": "Copyright (C) 2026 Carl-Philip Hänsch",
+  "license": "GPL-3.0-or-later",
+  "schema_version": 1,
+  "default_rows": 1000,
+  "rows": {
+    "tests/performance/baseline.yaml::Perf: MATRIX MULT": 30,
+    "tests/performance/json-nested-serialization.yaml::Perf JSON delivery: emit complete flat object list": 1000,
+    "tests/performance/json-nested-serialization.yaml::Perf JSON delivery: emit complete list with item arrays": 1000,
+    "tests/performance/json-nested-serialization.yaml::Perf JSON delivery: emit complete three-level list with serial arrays": 1000,
+    "tests/performance/json-nested-serialization.yaml::Perf JSON PostgreSQL delivery: emit complete three-level list with serial arrays": 1000,
+    "tests/performance/json-nested-serialization.yaml::Perf JSON delivery control: explicit grouped item carrier": 1000
+  }
+}

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -398,6 +398,24 @@ class AtomicJSONObserverContractTest(unittest.TestCase):
 
 
 class FailFastParallelContractTest(unittest.TestCase):
+    def test_ab_mode_skips_non_measurement_cases_in_performance_suite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp) / "performance.yaml"
+            spec.write_text(
+                "metadata: {description: A/B selection}\n"
+                "test_cases:\n"
+                "  - {name: correctness helper, sql: SELECT 1}\n"
+                "  - {name: measured query, sql: SELECT 1, threshold_ms: 30000}\n",
+                encoding="utf-8",
+            )
+            runner = SQLTestRunner("http://localhost:1")
+            runner.ensure_database = lambda _database: None
+            observed = []
+            runner.run_test_case = lambda case, _database: observed.append(case["name"]) or True
+            with mock.patch("run_sql_tests.PERF_AB_MODE", "record"):
+                self.assertTrue(runner.run_test_spec(str(spec)))
+        self.assertEqual(observed, ["measured query"])
+
     def test_performance_suite_setups_finish_before_measurement_phase(self) -> None:
         specs = ["tests/performance/a.yaml", "tests/performance/b.yaml"]
         barrier = threading.Barrier(2)

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -43,12 +43,18 @@ from run_sql_tests import (  # noqa: E402
     is_error_response,
     load_performance_scale,
     observe_atomic_json,
+    performance_ab_threshold_ms,
+    performance_case_fingerprint,
+    performance_case_key,
     performance_architecture,
+    performance_regression_pct,
     performance_scale_from_samples,
     planner_time_limit_with_tolerance_ms,
     publish_performance_scale,
     request_shared_supervisor_restart,
     resolve_timing_samples,
+    resolve_warmup_runs,
+    run_test_specs,
     scaled_compile_time_limit_ms,
     scaled_wall_clock_limit_ms,
     sql_request_is_retry_safe,
@@ -58,16 +64,65 @@ from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
 
 class PerformanceScaleContractTest(unittest.TestCase):
-    def test_timing_samples_default_and_explicit_median(self) -> None:
+    def test_repetitions_default_and_explicit_count(self) -> None:
         self.assertEqual(resolve_timing_samples({}, False), 1)
         self.assertEqual(resolve_timing_samples({}, True), 5)
         self.assertEqual(resolve_timing_samples({"timing_samples": 3}, False), 3)
+        self.assertEqual(resolve_timing_samples({"repetitions": 100}, True), 100)
 
-    def test_timing_samples_rejects_ambiguous_or_empty_samples(self) -> None:
-        for invalid in (True, 0, 2, 2.5, "3"):
+    def test_repetitions_reject_ambiguous_or_empty_counts(self) -> None:
+        for invalid in (True, 0, 2.5, "3"):
             with self.subTest(invalid=invalid):
-                with self.assertRaisesRegex(ValueError, "positive odd integer"):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
                     resolve_timing_samples({"timing_samples": invalid}, False)
+
+    def test_repetitions_and_timing_samples_are_mutually_exclusive(self) -> None:
+        with self.assertRaisesRegex(ValueError, "either repetitions or timing_samples"):
+            resolve_timing_samples({"repetitions": 5, "timing_samples": 5}, True)
+
+    def test_warmup_accepts_zero_and_counts(self) -> None:
+        self.assertEqual(resolve_warmup_runs({}, True), 2)
+        self.assertEqual(resolve_warmup_runs({"warmup": False}, True), 0)
+        self.assertEqual(resolve_warmup_runs({"warmup": 7}, True), 7)
+
+    def test_ab_metric_is_per_repetition_and_cold_candidate_gets_bonus(self) -> None:
+        self.assertEqual(performance_ab_threshold_ms(100, 20, 2, 2), 120)
+        self.assertAlmostEqual(performance_ab_threshold_ms(100, 20, 2, 0), 220)
+
+    def test_regression_limit_is_bounded_and_case_overrides_suite(self) -> None:
+        self.assertEqual(performance_regression_pct({}, {}), 20)
+        self.assertEqual(
+            performance_regression_pct({"max_regression_pct": 15}, {"max_regression_pct": 25}),
+            15,
+        )
+        with self.assertRaisesRegex(ValueError, "10 through 30"):
+            performance_regression_pct({"max_regression_pct": 31}, {})
+
+    def test_performance_identity_is_stable_across_worktrees(self) -> None:
+        self.assertEqual(
+            performance_case_key("/tmp/base/tests/performance/a.yaml", "query"),
+            "tests/performance/a.yaml::query",
+        )
+
+    def test_workload_fingerprint_allows_only_repetition_and_warmup_changes(self) -> None:
+        base = {
+            "name": "query", "sql": "SELECT 1", "threshold_ms": 30000,
+            "repetitions": 5, "warmup": 2,
+        }
+        timing_change = dict(base, repetitions=100, warmup=0)
+        query_change = dict(base, sql="SELECT 2")
+        self.assertEqual(
+            performance_case_fingerprint(base),
+            performance_case_fingerprint(timing_change),
+        )
+        self.assertNotEqual(
+            performance_case_fingerprint(base),
+            performance_case_fingerprint(query_change),
+        )
+        self.assertNotEqual(
+            performance_case_fingerprint(base, [{"sql": "INSERT INTO t VALUES (1)"}]),
+            performance_case_fingerprint(base, [{"sql": "INSERT INTO t VALUES (2)"}]),
+        )
 
     def test_cold_planner_budget_allows_bounded_measurement_jitter(self) -> None:
         self.assertEqual(PLANNER_TIME_TOLERANCE_FACTOR, 1.2)
@@ -320,6 +375,31 @@ class AtomicJSONObserverContractTest(unittest.TestCase):
 
 
 class FailFastParallelContractTest(unittest.TestCase):
+    def test_performance_suite_setups_finish_before_measurement_phase(self) -> None:
+        specs = ["tests/performance/a.yaml", "tests/performance/b.yaml"]
+        barrier = threading.Barrier(2)
+        events = []
+        lock = threading.Lock()
+
+        def prepare(_runner, spec_file):
+            barrier.wait(timeout=1)
+            with lock:
+                events.append(("prepare", spec_file))
+            return True
+
+        def measure(_runner, spec_file, setup_done=False):
+            self.assertTrue(setup_done)
+            self.assertEqual(sum(kind == "prepare" for kind, _ in events), 2)
+            events.append(("measure", spec_file))
+            return True
+
+        with mock.patch("run_sql_tests.PERF_TEST_ENABLED", True), \
+                mock.patch.object(SQLTestRunner, "prepare_test_spec", prepare), \
+                mock.patch.object(SQLTestRunner, "run_test_spec", measure):
+            self.assertTrue(run_test_specs(specs, "http://localhost:1", 1, True, 2))
+
+        self.assertCountEqual(events[2:], [("measure", specs[0]), ("measure", specs[1])])
+
     def test_fail_fast_preserves_parallel_groups(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             spec = Path(tmp) / "parallel.yaml"

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -40,7 +40,10 @@ from run_sql_tests import (  # noqa: E402
     PERFORMANCE_SCALE_ENV,
     PLANNER_TIME_TOLERANCE_FACTOR,
     SQLTestRunner,
+    _load_runner_config,
+    adaptive_measurement_complete,
     is_error_response,
+    initialize_performance_recording,
     load_performance_scale,
     observe_atomic_json,
     performance_ab_threshold_ms,
@@ -64,6 +67,20 @@ from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
 
 class PerformanceScaleContractTest(unittest.TestCase):
+    def test_ci_workload_seed_initializes_safe_rows(self) -> None:
+        seed = Path(__file__).resolve().parents[1] / "tests/performance/ci-workloads.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "baseline.json"
+            with mock.patch("run_sql_tests.PERF_BASELINE_SEED", str(seed)), \
+                    mock.patch("run_sql_tests.PERF_BASELINE_FILE", str(baseline)):
+                initialize_performance_recording()
+                config = _load_runner_config()
+        self.assertEqual(config["_ci_workload"]["default_rows"], 1000)
+        self.assertEqual(
+            config["tests/performance/baseline.yaml::Perf: MATRIX MULT"]["rows"],
+            30,
+        )
+
     def test_repetitions_default_and_explicit_count(self) -> None:
         self.assertEqual(resolve_timing_samples({}, False), 1)
         self.assertEqual(resolve_timing_samples({}, True), 5)
@@ -79,6 +96,12 @@ class PerformanceScaleContractTest(unittest.TestCase):
     def test_repetitions_and_timing_samples_are_mutually_exclusive(self) -> None:
         with self.assertRaisesRegex(ValueError, "either repetitions or timing_samples"):
             resolve_timing_samples({"repetitions": 5, "timing_samples": 5}, True)
+
+    def test_adaptive_measurement_requires_five_runs_and_time_budget(self) -> None:
+        with mock.patch("run_sql_tests.PERF_MIN_MEASURE_MS", 250):
+            self.assertFalse(adaptive_measurement_complete(4, 1_000_000_000))
+            self.assertFalse(adaptive_measurement_complete(100, 249_999_999))
+            self.assertTrue(adaptive_measurement_complete(5, 250_000_000))
 
     def test_warmup_accepts_zero_and_counts(self) -> None:
         self.assertEqual(resolve_warmup_runs({}, True), 2)


### PR DESCRIPTION
## What

- add one independent `performance-ab` CI job
- record master and compare the merge candidate using `run_sql_tests.py` only
- prepare existing YAML setup sections concurrently, then protect timed query windows with an exclusive gate
- compare total time per repetition with a trusted 10-30% regression allowance
- normalize changed repetition counts and grant +100 percentage points when candidate warmup is disabled
- cap performance setup wall time and retain RAM-pressure guards
- reject deleted or modified trusted workloads while allowing repetition/warmup changes

## Validation

- `python3 tools/test_sql_runner_contract.py` (40 tests)
- real record/compare smoke using `tests/performance/derived-count-pruning.yaml`: 1398.448ms -> 1387.292ms per repetition (-0.8%)
- full suite delegated to CI as requested
