### PR TITLE
Lower imported Scheme expressions through JIT

### DIFF
--- a/lib/test.scm
+++ b/lib/test.scm
@@ -163,6 +163,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	/* queryplan.scm Neumann rebuild contract */
 	(import "queryplan.scm")
 	(print "testing queryplan Neumann rebuild contract ...")
+	(assert (jit? normalize_sql_syntax) (jit-enabled?) "import JIT-compiles SQL syntax normalization")
+	(assert (jit? optimize_logical_query) (jit-enabled?) "import JIT-compiles logical query optimization")
+	(assert (jit? build_queryplan) (jit-enabled?) "import JIT-compiles the query compiler entrypoint")
+	(assert (jit? build_queryplan_term) (jit-enabled?) "import JIT-compiles the query compiler term entrypoint")
 	(define tblx "t")
 	(define expr_gc (list 'get_column "t" false "id" false))
 	(assert (match expr_gc '((symbol get_column) (eval tblx) _ col _) col "no") "id" "match get_column for alias t -> id")

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -163,10 +163,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	/* queryplan.scm Neumann rebuild contract */
 	(import "queryplan.scm")
 	(print "testing queryplan Neumann rebuild contract ...")
-	(assert (jit? normalize_sql_syntax) (jit-enabled?) "import JIT-compiles SQL syntax normalization")
-	(assert (jit? optimize_logical_query) (jit-enabled?) "import JIT-compiles logical query optimization")
-	(assert (jit? build_queryplan) (jit-enabled?) "import JIT-compiles the query compiler entrypoint")
-	(assert (jit? build_queryplan_term) (jit-enabled?) "import JIT-compiles the query compiler term entrypoint")
 	(define tblx "t")
 	(define expr_gc (list 'get_column "t" false "id" false))
 	(assert (match expr_gc '((symbol get_column) (eval tblx) _ col _) col "no") "id" "match get_column for alias t -> id")

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -157,6 +157,16 @@ type JITEntryPoint struct {
 	// RecursiveLambdas makes lambda values constructed by this native body
 	// compile their own body before they are returned or passed onward.
 	RecursiveLambdas bool
+	// Coverage counts lowered Scheme expression nodes and calls which still
+	// cross the generic Eval/Apply bridge. It is diagnostic metadata, not a
+	// profile: one dynamic call may perform arbitrarily much runtime work.
+	Coverage JITCoverage
+}
+
+type JITCoverage struct {
+	Expressions  int
+	DynamicCalls int
+	InlinedCalls int
 }
 
 // Call keeps the entry point, embedded constant roots, and source arguments
@@ -437,6 +447,7 @@ type JITContext struct {
 	// flow can restore a different allocator state.
 	StackRoots map[jitStackRoot]struct{}
 	Safepoints []jitSafepoint
+	Coverage   JITCoverage
 
 	// Stack frame: emitter locals use [RSP + offset], while register spills use
 	// [RBP - offset]. The two zones cannot overlap because the patched frame size
@@ -2111,7 +2122,7 @@ func init_jit() {
 	Declare(&Globalenv, &Declaration{
 		Name: "jit",
 
-		Fn:   jitCompile,
+		Fn: jitCompile,
 		Type: &TypeDescriptor{Kind: "func", Description: "compiles a lambda to optimized native code when this build enables JIT",
 			Params: []*TypeDescriptor{
 				{Kind: "any", Label: "fn", Description: "the function to compile"},
@@ -2280,10 +2291,6 @@ func jitCompile(a ...Scmer) Scmer {
 	return jitCompileMode(true, a...)
 }
 
-func jitCompileForImport(value Scmer) Scmer {
-	return jitCompileMode(false, value)
-}
-
 func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 	if len(a) != 1 {
 		panic("jit: expects exactly 1 argument")
@@ -2325,7 +2332,7 @@ func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 		for _, codeCap := range [...]int{16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024} {
 			ptr, arena, reservation := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena, reservation: reservation}
-			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs := jitCompileProcToExec(proc, buf, recursiveLambdas)
+			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs, coverage := jitCompileProcToExec(proc, buf, recursiveLambdas)
 			arena.complete(reservation, buf.stackMaps)
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
@@ -2349,6 +2356,7 @@ func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 					AutoImportSafe:    autoImportSafe && jitAutoImportSyntaxSafe(sourceProc.Body),
 					RecursiveLambdas:  recursiveLambdas,
 					NeedsStableArgs:   needsStableArgs,
+					Coverage:          coverage,
 				}
 				runtime.SetFinalizer(jep, func(jep *JITEntryPoint) {
 					if jep.Arena != nil && jep.CodePtr != nil {

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -135,7 +135,8 @@ Generated emitters (tools/jitgen):
 // JITEntryPoint holds a JIT-compiled function alongside its original
 // Scheme representation for serialization and fallback.
 type JITEntryPoint struct {
-	Native func(...Scmer) Scmer // compiled native function pointer
+	Native    func(...Scmer) Scmer // compiled native function pointer
+	DebugName string
 	// TransferInputArgs means the native body returns its complete variadic
 	// argument array as an owned list. Call must make that array fresh because
 	// apply may otherwise pass caller-owned list backing directly.
@@ -176,6 +177,9 @@ type JITCoverage struct {
 func (jep *JITEntryPoint) Call(args ...Scmer) (result Scmer) {
 	if jep == nil || jep.Native == nil {
 		panic("JIT: nil entry point")
+	}
+	if JITLog && jep.DebugName != "" {
+		fmt.Printf("JIT: call %s argc=%d\n", jep.DebugName, len(args))
 	}
 	// A transferred list must own fresh backing, and appending hidden inputs must
 	// not reuse caller-owned capacity. Stack maps make an extra copy unnecessary
@@ -493,7 +497,6 @@ type jitAllocStateSnapshot struct {
 	ownerValues        map[uint32]JITValueDesc
 	spillOffset        int32
 	descSpills         map[uint32]descSpillMeta
-	nextDescID         uint32
 	stackRoots         map[jitStackRoot]struct{}
 	dynamicSP          int32
 }
@@ -504,7 +507,6 @@ func (ctx *JITContext) SnapshotAllocState() jitAllocStateSnapshot {
 		protectedRegs:      ctx.ProtectedRegs,
 		protectedRegCounts: ctx.ProtectedRegCounts,
 		spillOffset:        ctx.SpillOffset,
-		nextDescID:         ctx.nextDescID,
 		dynamicSP:          ctx.DynamicSP,
 	}
 	if len(ctx.descOwners) != 0 {
@@ -541,7 +543,9 @@ func (ctx *JITContext) RestoreAllocState(s jitAllocStateSnapshot) {
 	ctx.ProtectedRegs = s.protectedRegs
 	ctx.ProtectedRegCounts = s.protectedRegCounts
 	ctx.SpillOffset = s.spillOffset
-	ctx.nextDescID = s.nextDescID
+	// Descriptor identities are global to one emitted function. Restoring an
+	// older basic-block snapshot must not make later descriptors reuse IDs whose
+	// spill metadata was already emitted on a sibling path.
 	ctx.DynamicSP = s.dynamicSP
 
 	if s.ownerValues == nil {
@@ -941,7 +945,7 @@ func (ctx *JITContext) AllocReg() Reg {
 }
 
 // EnsureDesc restores a descriptor from stack/spill locations to registers.
-func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
+func (ctx *JITContext) syncDescSpill(desc *JITValueDesc) {
 	if desc.Loc == LocReg && desc.ID != 0 && ctx.descSpills != nil {
 		if meta, ok := ctx.descSpills[desc.ID]; ok && meta.loc == LocStack {
 			desc.Loc = LocStack
@@ -969,6 +973,10 @@ func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
 			desc.Reg3 = 0
 		}
 	}
+}
+
+func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
+	ctx.syncDescSpill(desc)
 	switch desc.Loc {
 	case LocInputPair:
 		r1 := ctx.AllocReg()
@@ -1513,6 +1521,49 @@ func (ctx *JITContext) collectLiveRegsForCall(buf *[16]Reg) []Reg {
 // resultsBuf: caller-provided [16]Reg buffer for results (no heap alloc).
 // Returns a slice into resultsBuf holding the result registers.
 // All live JIT registers are saved/restored around the call.
+type jitRegMove struct {
+	dst Reg
+	src Reg
+}
+
+// emitParallelRegMoves preserves every source until its last consumer has
+// moved. R11 is reserved as emitter scratch and breaks register cycles.
+func (ctx *JITContext) emitParallelRegMoves(moves []jitRegMove) {
+	for len(moves) > 0 {
+		emitIdx := -1
+		for i := range moves {
+			dstIsPendingSrc := false
+			for j := range moves {
+				if i != j && moves[j].src == moves[i].dst {
+					dstIsPendingSrc = true
+					break
+				}
+			}
+			if !dstIsPendingSrc {
+				emitIdx = i
+				break
+			}
+		}
+		if emitIdx == -1 {
+			cycleDst := moves[0].dst
+			if cycleDst != RegR11 {
+				ctx.emitMovRegReg(RegR11, cycleDst)
+			}
+			for i := range moves {
+				if moves[i].src == cycleDst {
+					moves[i].src = RegR11
+				}
+			}
+			continue
+		}
+		mv := moves[emitIdx]
+		if mv.dst != mv.src {
+			ctx.emitMovRegReg(mv.dst, mv.src)
+		}
+		moves = append(moves[:emitIdx], moves[emitIdx+1:]...)
+	}
+}
+
 func (ctx *JITContext) EmitGoCall(funcAddr uint64, argWords []goCallArgWord, numResultWords int, resultsBuf *[16]Reg, resultTargets []Reg) []Reg {
 	ctx.NeedsStableArgs = true
 	if numResultWords > len(GoABIIntRegs) {
@@ -1569,11 +1620,7 @@ func (ctx *JITContext) EmitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 			}
 		}
 
-		type regMove struct {
-			dst Reg
-			src Reg
-		}
-		moves := make([]regMove, 0, len(argWords))
+		moves := make([]jitRegMove, 0, len(argWords))
 		regWordCount := len(argWords)
 		if regWordCount > len(GoABIIntRegs) {
 			regWordCount = len(GoABIIntRegs)
@@ -1581,47 +1628,10 @@ func (ctx *JITContext) EmitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 		for i := 0; i < regWordCount; i++ {
 			target := GoABIIntRegs[i]
 			if argWords[i].loc == LocReg && argWords[i].reg != target {
-				moves = append(moves, regMove{dst: target, src: argWords[i].reg})
+				moves = append(moves, jitRegMove{dst: target, src: argWords[i].reg})
 			}
 		}
-		for len(moves) > 0 {
-			emitIdx := -1
-			for i := range moves {
-				dstIsPendingSrc := false
-				for j := range moves {
-					if i == j {
-						continue
-					}
-					if moves[j].src == moves[i].dst {
-						dstIsPendingSrc = true
-						break
-					}
-				}
-				if !dstIsPendingSrc {
-					emitIdx = i
-					break
-				}
-			}
-			if emitIdx == -1 {
-				// Break a cycle via R11, which is reserved as JIT scratch and is
-				// not part of Go ABIInternal's integer argument registers.
-				cycleDst := moves[0].dst
-				if cycleDst != RegR11 {
-					ctx.emitMovRegReg(RegR11, cycleDst)
-				}
-				for i := range moves {
-					if moves[i].src == cycleDst {
-						moves[i].src = RegR11
-					}
-				}
-				continue
-			}
-			mv := moves[emitIdx]
-			if mv.dst != mv.src {
-				ctx.emitMovRegReg(mv.dst, mv.src)
-			}
-			moves = append(moves[:emitIdx], moves[emitIdx+1:]...)
-		}
+		ctx.emitParallelRegMoves(moves)
 
 		for i := 0; i < regWordCount; i++ {
 			target := GoABIIntRegs[i]
@@ -1652,18 +1662,24 @@ func (ctx *JITContext) EmitGoCall(funcAddr uint64, argWords []goCallArgWord, num
 		if ctx.SliceBaseTracksRSP && ctx.SliceBase != RegRSP {
 			ctx.emitMovRegReg(ctx.SliceBase, RegRSP)
 		}
+		moves := make([]jitRegMove, 0, numResultWords)
 		for i := 0; i < numResultWords; i++ {
 			var r Reg
 			if i < len(resultTargets) {
 				r = resultTargets[i]
 			} else {
-				r = ctx.AllocReg()
+				// All Go ABI result registers remain live until every result word
+				// has been copied. In particular, a three-word slice returns its
+				// capacity in RCX; selecting RCX for the earlier data pointer would
+				// overwrite that capacity before it is read.
+				r = ctx.AllocRegExcept(GoABIIntRegs[:numResultWords]...)
 			}
 			if r != GoABIIntRegs[i] {
-				ctx.emitMovRegReg(r, GoABIIntRegs[i])
+				moves = append(moves, jitRegMove{dst: r, src: GoABIIntRegs[i]})
 			}
 			resultsBuf[i] = r
 		}
+		ctx.emitParallelRegMoves(moves)
 		return resultsBuf[:numResultWords]
 	}
 
@@ -1865,6 +1881,16 @@ func (ctx *JITContext) EmitGoCallScalarInto(funcAddr uint64, args []JITValueDesc
 
 // EmitMovPairToResult moves a LocRegPair value into the result descriptor registers.
 func (ctx *JITContext) EmitMovPairToResult(src *JITValueDesc, dst *JITValueDesc) {
+	if src.Reg != dst.Reg && src.Reg2 == dst.Reg {
+		// Preserve the pointer word before writing the aux word into its source
+		// register. This includes the full register-swap case.
+		ctx.emitMovRegReg(RegR11, src.Reg)
+		if src.Reg2 != dst.Reg2 {
+			ctx.emitMovRegReg(dst.Reg2, src.Reg2)
+		}
+		ctx.emitMovRegReg(dst.Reg, RegR11)
+		return
+	}
 	if src.Reg != dst.Reg {
 		ctx.emitMovRegReg(dst.Reg, src.Reg)
 	}
@@ -2387,11 +2413,11 @@ func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 	}
 }
 
-// jitAutoImportSyntaxSafe is deliberately narrower than explicit (jit ...).
-// Module loading must never turn experimental emitter coverage into a semantic
-// regression. It enables leaf expressions, borrowed accessors, scalar
-// builtins, and rooted calls with at most two arguments; allocation-heavy
-// transforms remain interpreted until their callback/ABI paths are proven.
+// jitAutoImportSyntaxSafe rejects procedures which manufacture callbacks. A
+// compiled top-level procedure may otherwise use every expression the emitter
+// accepted; unsupported expressions already abort compilation atomically.
+// Callback closure compilation remains opt-in until its generated slice paths
+// carry the same complete lifetime contract as the enclosing entry point.
 func jitAutoImportSyntaxSafe(expr Scmer) bool {
 	for expr.IsSourceInfo() {
 		expr = expr.SourceInfo().value
@@ -2403,47 +2429,15 @@ func jitAutoImportSyntaxSafe(expr Scmer) bool {
 	if len(items) == 0 {
 		return true
 	}
-	if !items[0].IsSymbol() {
-		if len(items)-1 > 2 || !jitAutoImportSyntaxSafe(items[0]) {
-			return false
-		}
-		for _, item := range items[1:] {
-			if !jitAutoImportSyntaxSafe(item) {
-				return false
-			}
-		}
-		return true
-	}
-	name := items[0].String()
-	switch name {
-	case "quote":
-		return true
-	case "lambda", "optimizer_proc_return", "begin", "begin_mut", "!begin", "set", "define", "setN", "!list", "!!list", "eval", "parallel":
-		return false
-	case "match", "match_mut":
-		return false
-	case "if", "and", "or", "coalesce", "coalesceNil":
-		return false
-	case "outer":
-		for _, item := range items[1:] {
-			if !jitAutoImportSyntaxSafe(item) {
-				return false
-			}
-		}
-		return true
-	}
-	if decl, ok := declarations[name]; ok && decl.Type != nil && decl.Type.JITEmit != nil {
-		if !jitAutoImportReturnSafe(name, decl.Type.Return) {
-			return false
-		}
-	} else {
-		binding, exists := Globalenv.Vars[Symbol(name)]
-		if !exists || binding.GetTag() != tagProc || binding.Proc() == nil || binding.Proc().Compiled == nil ||
-			!binding.Proc().Compiled.AutoImportSafe {
+	if items[0].IsSymbol() {
+		switch items[0].String() {
+		case "quote":
+			return true
+		case "lambda", "optimizer_proc_return":
 			return false
 		}
 	}
-	for _, item := range items[1:] {
+	for _, item := range items {
 		if !jitAutoImportSyntaxSafe(item) {
 			return false
 		}

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1855,7 +1855,12 @@ func (ctx *JITContext) EmitGoCallScalarInto(funcAddr uint64, args []JITValueDesc
 	words := ctx.flattenArgs(args, &wordsBuf)
 	targets := [...]Reg{result.Reg, result.Reg2}
 	results := ctx.EmitGoCall(funcAddr, words, 2, &resultsBuf, targets[:])
-	return JITValueDesc{Loc: LocRegPair, Type: result.Type, Reg: results[0], Reg2: results[1]}
+	result.Loc = LocRegPair
+	result.Reg = results[0]
+	result.Reg2 = results[1]
+	ctx.BindReg(result.Reg, &result)
+	ctx.BindReg(result.Reg2, &result)
+	return result
 }
 
 // EmitMovPairToResult moves a LocRegPair value into the result descriptor registers.
@@ -2432,7 +2437,11 @@ func jitAutoImportSyntaxSafe(expr Scmer) bool {
 			return false
 		}
 	} else {
-		return false
+		binding, exists := Globalenv.Vars[Symbol(name)]
+		if !exists || binding.GetTag() != tagProc || binding.Proc() == nil || binding.Proc().Compiled == nil ||
+			!binding.Proc().Compiled.AutoImportSafe {
+			return false
+		}
 	}
 	for _, item := range items[1:] {
 		if !jitAutoImportSyntaxSafe(item) {

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -110,6 +110,18 @@ func TestJITExpressionListForms(t *testing.T) {
 	})
 }
 
+func TestJITExpressionConditionalBorrowedListResult(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (node)
+		(if (> (count node) 4) (nth node 4) '()))`)
+	want := NewSlice([]Scmer{NewString("required")})
+	got := Apply(compiled, NewSlice([]Scmer{
+		NewInt(0), NewInt(1), NewInt(2), NewInt(3), want,
+	}))
+	if !Equal(got, want) {
+		t.Fatalf("unexpected conditional list result: got %s, want %s", String(got), String(want))
+	}
+}
+
 func TestJITExpressionReduceLambdaArgumentOrder(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t,
 		`(lambda (items initial) (reduce items (lambda (acc item) (list acc item)) initial))`)
@@ -138,5 +150,103 @@ func TestJITExpressionHigherOrderClosureCapture(t *testing.T) {
 	want := NewSlice([]Scmer{NewString("a"), NewString("c")})
 	if !Equal(got, want) {
 		t.Fatalf("unexpected captured higher-order result: got %s, want %s", String(got), String(want))
+	}
+}
+
+func TestJITExpressionTransferredMergeStackList(t *testing.T) {
+	source := `(lambda (head tail)
+		(merge (list (nth head 2) (list (nth head 0)) (nth tail 0))))`
+	compiled := compileJITExpressionTestProc(t, source)
+	head := NewSlice([]Scmer{
+		NewString("source"),
+		NewSlice(nil),
+		NewSlice([]Scmer{NewString("generated")}),
+	})
+	tail := NewSlice([]Scmer{
+		NewSlice([]Scmer{NewString("tail")}),
+		NewSlice(nil),
+		NewSlice(nil),
+	})
+	got := Apply(compiled, head, tail)
+	want := NewSlice([]Scmer{NewString("generated"), NewString("source"), NewString("tail")})
+	if !Equal(got, want) {
+		t.Fatalf("unexpected transferred merge result: got %s, want %s", String(got), String(want))
+	}
+}
+
+func TestJITExpressionConsTailOfSingleElementList(t *testing.T) {
+	source := `(lambda (sources)
+		(match sources
+			(cons src rest) rest
+			_ 'not-a-list))`
+	expression := Optimize(Read(t.Name(), source), &Globalenv, nil)
+	interpreted := Eval(expression, &Globalenv)
+	proc := *interpreted.Proc()
+	proc.NumVars = 5
+	proc.NumberedOnly = false
+	compiled := jitCompile(NewProcStruct(proc))
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatalf("expression did not compile: %s", SerializeToString(expression, &Globalenv))
+	}
+	got := Apply(compiled, NewSlice([]Scmer{NewString("source")}))
+	want := NewSlice(nil)
+	if !Equal(got, want) {
+		t.Fatalf("unexpected cons tail: got %s, want %s", String(got), String(want))
+	}
+}
+
+func TestJITExpressionRecursiveTransferredMergeStackList(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	EvalAll(t.Name(), `(define jit_test_recursive_merge (lambda (sources)
+		(match sources
+			(cons src rest) (begin
+				(define head (list src '() '()))
+				(define tail (jit_test_recursive_merge rest))
+				(define generated_sources (nth head 2))
+				(list
+					(merge (list generated_sources (list (nth head 0)) (nth tail 0)))
+					(merge_unique (list (nth head 1) (nth tail 1)))
+					(merge_unique (list generated_sources (nth tail 2)))
+					(nth tail 3)))
+			_ (list '() '() '() '()))))`, &Globalenv)
+	compiled := jitCompile(Globalenv.Vars[Symbol("jit_test_recursive_merge")])
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("recursive merge procedure was not JIT compiled")
+	}
+	Globalenv.Vars[Symbol("jit_test_recursive_merge")] = compiled
+	got := Apply(compiled, NewSlice([]Scmer{NewString("source")}))
+	want := NewSlice([]Scmer{
+		NewSlice([]Scmer{NewString("source")}),
+		NewSlice(nil),
+		NewSlice(nil),
+		NewSlice(nil),
+	})
+	if !Equal(got, want) {
+		t.Fatalf("unexpected recursive transferred merge result: got %s, want %s", String(got), String(want))
+	}
+}
+
+func TestJITExpressionRecursiveNthResult(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	EvalAll(t.Name(), `(define jit_test_recursive_nth (lambda (sources)
+		(match sources
+			(cons src rest) (begin
+				(define tail (jit_test_recursive_nth rest))
+				(nth tail 0))
+			_ (list '()))))`, &Globalenv)
+	compiled := jitCompile(Globalenv.Vars[Symbol("jit_test_recursive_nth")])
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("recursive nth procedure was not JIT compiled")
+	}
+	Globalenv.Vars[Symbol("jit_test_recursive_nth")] = compiled
+	got := Apply(compiled, NewSlice([]Scmer{NewString("source")}))
+	want := NewSlice(nil)
+	if !Equal(got, want) {
+		gotPtr, gotAux := got.RawWords()
+		t.Fatalf("unexpected recursive nth result: got ptr=%x aux=%x tag=%d, want %s", gotPtr, gotAux, got.GetTag(), String(want))
 	}
 }

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func compileJITExpressionTestProc(t *testing.T, source string) Scmer {
+	t.Helper()
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	expression := Optimize(Read(t.Name(), source), &Globalenv, nil)
+	proc := Eval(expression, &Globalenv)
+	compiled := jitCompile(proc)
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatalf("expression did not compile: %s", SerializeToString(expression, &Globalenv))
+	}
+	return compiled
+}
+
+func requireNoDynamicJITCalls(t *testing.T, compiled Scmer) {
+	t.Helper()
+	coverage := compiled.Proc().Compiled.Coverage
+	if coverage.DynamicCalls != 0 {
+		t.Fatalf("expected complete expression lowering, got %+v", coverage)
+	}
+}
+
+func TestJITExpressionBeginDefine(t *testing.T) {
+	proc := &Proc{
+		Params: NewSlice([]Scmer{NewSymbol("x")}),
+		Body: NewSlice([]Scmer{
+			NewSymbol("begin"),
+			NewSlice([]Scmer{
+				NewSymbol("define"), NewSymbol("y"),
+				NewSlice([]Scmer{NewSymbol("+"), NewNthLocalVar(0), NewInt(1)}),
+			}),
+			NewSymbol("y"),
+		}),
+		NumVars: 1,
+	}
+	compiled := jitCompile(NewProcStruct(*proc))
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("begin/define expression did not compile")
+	}
+	requireNoDynamicJITCalls(t, compiled)
+	if got := Apply(compiled, NewInt(41)); !Equal(got, NewInt(42)) {
+		t.Fatalf("unexpected begin/define result: %s", String(got))
+	}
+}
+
+func TestJITExpressionListForms(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		compiled := compileJITExpressionTestProc(t, `(lambda (a b) (list a b))`)
+		requireNoDynamicJITCalls(t, compiled)
+		got := Apply(compiled, NewInt(1), NewInt(2))
+		want := NewSlice([]Scmer{NewInt(1), NewInt(2)})
+		if !Equal(got, want) {
+			t.Fatalf("unexpected list result: %s", String(got))
+		}
+	})
+
+	t.Run("!list", func(t *testing.T) {
+		proc := Proc{
+			Params: NewSlice([]Scmer{NewSymbol("a"), NewSymbol("b")}),
+			Body: NewSlice([]Scmer{
+				NewSymbol("nth"),
+				NewSlice([]Scmer{NewSymbol("!list"), NewNthLocalVar(2), NewInt(2), NewNthLocalVar(0), NewNthLocalVar(1)}),
+				NewInt(1),
+			}),
+			NumVars: 4,
+		}
+		if !jitEnabled {
+			t.Skip("requires GOEXPERIMENT=jit")
+		}
+		compiled := jitCompile(NewProcStruct(proc))
+		if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+			t.Fatal("!list expression did not compile")
+		}
+		requireNoDynamicJITCalls(t, compiled)
+		if got := Apply(compiled, NewInt(1), NewInt(2)); !Equal(got, NewInt(2)) {
+			t.Fatalf("unexpected !list result: %s", String(got))
+		}
+	})
+
+	t.Run("!!list", func(t *testing.T) {
+		compiled := compileJITExpressionTestProc(t, `(lambda () (!!list 4))`)
+		requireNoDynamicJITCalls(t, compiled)
+		got := Apply(compiled).Slice()
+		if len(got) != 0 || cap(got) != 4 {
+			t.Fatalf("unexpected !!list shape: len=%d cap=%d", len(got), cap(got))
+		}
+	})
+}
+
+func TestJITExpressionReduceLambdaArgumentOrder(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t,
+		`(lambda (items initial) (reduce items (lambda (acc item) (list acc item)) initial))`)
+	if coverage := compiled.Proc().Compiled.Coverage; coverage.DynamicCalls != 1 {
+		t.Fatalf("expected reduce to use one generic callback fallback, got %+v", coverage)
+	}
+	got := Apply(compiled,
+		NewSlice([]Scmer{NewString("a"), NewString("b")}),
+		NewString("initial"))
+	want := NewSlice([]Scmer{
+		NewSlice([]Scmer{NewString("initial"), NewString("a")}),
+		NewString("b"),
+	})
+	if !Equal(got, want) {
+		t.Fatalf("unexpected reduce result: got %s, want %s", String(got), String(want))
+	}
+}

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -127,3 +127,16 @@ func TestJITExpressionReduceLambdaArgumentOrder(t *testing.T) {
 		t.Fatalf("unexpected reduce result: got %s, want %s", String(got), String(want))
 	}
 }
+
+func TestJITExpressionHigherOrderClosureCapture(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (values blocked) (begin
+		(define blocked_set (reduce blocked (lambda (acc item) (set_assoc acc item true)) '()))
+		(filter values (lambda (item) (not (has_assoc? blocked_set item))))))`)
+	got := Apply(compiled,
+		NewSlice([]Scmer{NewString("a"), NewString("b"), NewString("c")}),
+		NewSlice([]Scmer{NewString("b")}))
+	want := NewSlice([]Scmer{NewString("a"), NewString("c")})
+	if !Equal(got, want) {
+		t.Fatalf("unexpected captured higher-order result: got %s, want %s", String(got), String(want))
+	}
+}

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -377,6 +377,14 @@ func jitMakeReservedList(capacity int) Scmer {
 	return NewSlice(make([]Scmer, 0, capacity))
 }
 
+func jitCdrScmer(value Scmer) Scmer {
+	list := asSlice(value, "cdr")
+	if len(list) == 0 {
+		return NewSlice(nil)
+	}
+	return NewSlice(list[1:])
+}
+
 func jitStoreScmerAt(address *Scmer, value Scmer) {
 	*address = value
 }
@@ -743,6 +751,14 @@ func jitMatchSliceTail(ctx *JITContext, slice *JITValueDesc) JITValueDesc {
 	ctx.UnprotectReg(slice.Reg)
 	ctx.EmitMovRegReg(ptrReg, slice.Reg)
 	ctx.EmitAddRegImm32(ptrReg, 16)
+	// NewSlice canonicalizes a zero-capacity slice to a nil data pointer. Keep
+	// the same invariant for the tail of a one-element match: a one-past-the-end
+	// pointer is not a valid GC root even though the resulting length is zero.
+	keepPtr := ctx.ReserveLabel()
+	ctx.EmitCmpRegImm32(slice.Reg3, 1)
+	ctx.EmitJcc(CcNE, keepPtr)
+	ctx.EmitMovRegImm64(ptrReg, 0)
+	ctx.MarkLabel(keepPtr)
 	ctx.EmitMovRegReg(auxReg, slice.Reg2)
 	ctx.EmitSubRegImm32(auxReg, 1)
 	ctx.EmitShlRegImm8(auxReg, sliceCapBits)
@@ -1297,6 +1313,7 @@ func jitMaterializeVirtualSlice(ctx *JITContext, virtual JITValueDesc, result JI
 	pairs := make([]JITValueDesc, len(virtual.Virtual))
 	for i := range virtual.Virtual {
 		src := virtual.Virtual[i]
+		ctx.syncDescSpill(&src)
 		if src.Loc == LocRegPair || src.Loc == LocStackPair || src.Loc == LocInputPair {
 			pairs[i] = src
 			continue
@@ -2095,6 +2112,17 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 				out.SliceSizeKnown = true
 			}
 			return out
+		case "cdr":
+			if len(list) != 2 {
+				panic("jit: cdr expects exactly one argument")
+			}
+			stackStart := ctx.BPOffset
+			value := jitCompileRootedCallValue(ctx, list[1], sliceBase)
+			target := jitEnsureResultPair(ctx, result)
+			out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitCdrScmer), []JITValueDesc{value}, target)
+			out.Type = tagSlice
+			ctx.FreeStack(ctx.BPOffset - stackStart)
+			return jitRootScmer(ctx, out)
 		case "parallel":
 			panic("jit: unsupported special form parallel")
 		case "match", "match_mut":
@@ -2556,6 +2584,21 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			allocatedBeforeEmitter := ctx.AllRegs &^ ctx.FreeRegs
 			labelsBefore := ctx.LabelNext
 			out := decl.Type.JITEmit(ctx, list[1:], args, result)
+			// Generated control-flow emitters may spill their result placement while
+			// rendering sibling blocks and then write the final value back into its
+			// registers. Rebind that placement at the declaration boundary so stale
+			// spill metadata cannot replace the freshly produced result.
+			switch out.Loc {
+			case LocReg:
+				ctx.BindReg(out.Reg, &out)
+			case LocRegPair:
+				ctx.BindReg(out.Reg, &out)
+				ctx.BindReg(out.Reg2, &out)
+			case LocRegTriple:
+				ctx.BindReg(out.Reg, &out)
+				ctx.BindReg(out.Reg2, &out)
+				ctx.BindReg(out.Reg3, &out)
+			}
 			outputRegs := uint64(0)
 			switch out.Loc {
 			case LocReg:

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -62,7 +62,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 	const defaultCodeBufSize = 16 * 1024
 	ptr, arena, reservation := globalJITPool.Alloc(defaultCodeBufSize)
 	buf := &execBuf{ptr: ptr, n: defaultCodeBufSize, arena: arena, reservation: reservation}
-	codeLen, roots, _, _, _, _, _ := jitCompileProcToExec(proc, buf, true)
+	codeLen, roots, _, _, _, _, _, _ := jitCompileProcToExec(proc, buf, true)
 	arena.complete(reservation, buf.stackMaps)
 	if codeLen == 0 {
 		return nil, nil
@@ -75,7 +75,7 @@ func jitCompileProcWithRoots(proc *Proc) ([]byte, []unsafe.Pointer) {
 // jitCompileProcToExec compiles a Proc body directly into writable executable memory.
 // Returns code length, GC roots, an overflow flag, and whether the call boundary
 // must provide a fresh variadic array that becomes the owned list result.
-func jitCompileProcToExec(proc *Proc, buf *execBuf, recursiveLambdas bool) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg, bool, bool) {
+func jitCompileProcToExec(proc *Proc, buf *execBuf, recursiveLambdas bool) (int, []unsafe.Pointer, bool, bool, []JITHiddenArg, bool, bool, JITCoverage) {
 	body := proc.Body
 	if body.GetTag() == tagSourceInfo {
 		si := body.SourceInfo()
@@ -94,7 +94,7 @@ func jitCompileProcToExec(proc *Proc, buf *execBuf, recursiveLambdas bool) (int,
 
 // jitCompileExprBodyToExec compiles a Scheme expression body into a writable
 // executable buffer using Declaration.JITEmit callbacks.
-func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf, recursiveLambdas bool) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg, autoImportSafe bool, needsStableArgs bool) {
+func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf, recursiveLambdas bool) (codeLen int, roots []unsafe.Pointer, overflow bool, transferInputArgs bool, hiddenArgs []JITHiddenArg, autoImportSafe bool, needsStableArgs bool, coverage JITCoverage) {
 	defer func() {
 		if r := recover(); r != nil {
 			if r == jitCodeOverflowPanic {
@@ -109,6 +109,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 			hiddenArgs = nil
 			autoImportSafe = false
 			needsStableArgs = false
+			coverage = JITCoverage{}
 		}
 	}()
 
@@ -254,10 +255,10 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 			case tagFloat:
 				ctx.EmitMakeFloat(ret, desc)
 			default:
-				return 0, nil, false, false, nil, false, false
+				return 0, nil, false, false, nil, false, false, JITCoverage{}
 			}
 		default:
-			return 0, nil, false, false, nil, false, false
+			return 0, nil, false, false, nil, false, false, JITCoverage{}
 		}
 	}
 	// Unified epilog: patch SUB RSP with max frame size, then leave; ret.
@@ -274,7 +275,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 
 	ctx.ResolveFixupsFinal()
 	codeLen = int(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs, ctx.AutoImportSafe, ctx.NeedsStableArgs
+	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs, ctx.AutoImportSafe, ctx.NeedsStableArgs, ctx.Coverage
 }
 
 func jitEnsureResultPair(ctx *JITContext, result JITValueDesc) JITValueDesc {
@@ -366,6 +367,13 @@ func jitList8(a, b, c, d, e, f, g, h Scmer) Scmer { return List(a, b, c, d, e, f
 
 func jitMakeScmerSlice(length, capacity int) []Scmer {
 	return make([]Scmer, length, capacity)
+}
+
+func jitMakeReservedList(capacity int) Scmer {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return NewSlice(make([]Scmer, 0, capacity))
 }
 
 func jitStoreScmerAt(address *Scmer, value Scmer) {
@@ -1612,6 +1620,7 @@ func jitCompileRootedCallValue(ctx *JITContext, expr Scmer, sliceBase Reg) JITVa
 }
 
 func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	ctx.Coverage.DynamicCalls++
 	stackStart := ctx.BPOffset
 	callable := jitCompileRootedCallValue(ctx, callableExpr, sliceBase)
 	args := make([]JITValueDesc, 0, len(operands)+2)
@@ -1770,6 +1779,7 @@ func jitEmitCondJump(ctx *JITContext, expr Scmer, sliceBase Reg, trueLbl, falseL
 // result tells the emitter where to place the output.
 // Panics on unsupported expressions (caught by jitCompileExprBodyToExec).
 func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	ctx.Coverage.Expressions++
 	if expr.GetTag() == tagSourceInfo {
 		si := expr.SourceInfo()
 		if ctx.Arena != nil && si.source != "" {
@@ -1931,8 +1941,129 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 			ctx.TrackImm(q)
 			return JITValueDesc{Loc: LocImm, Type: q.GetTag(), Imm: q}
+		case "eval", "time":
+			panic("jit: unsupported special form " + name)
+		case "define", "set":
+			if len(list) != 3 {
+				panic("jit: malformed " + name)
+			}
+			binding := list[1]
+			for binding.IsSourceInfo() {
+				binding = binding.SourceInfo().value
+			}
+			if !binding.IsSymbol() {
+				panic("jit: " + name + " target is not a symbol")
+			}
+			value := jitCompileExpr(ctx, list[2], sliceBase, result)
+			ctx.EnsureDesc(&value)
+			stored := value
+			if stored.Loc != LocRegPair && stored.Loc != LocImm && stored.Loc != LocStackPair && stored.Loc != LocInputPair {
+				pair := jitAllocTrackedPair(ctx, stored.Type)
+				stored = jitPlaceIntoPair(ctx, &stored, pair)
+			}
+			off := ctx.AllocStack(16)
+			ctx.EmitStoreScmerToStack(stored, off)
+			if ctx.Env == nil {
+				ctx.Env = &JITEnv{Vars: make(map[Symbol]JITValueDesc)}
+			} else if ctx.Env.Vars == nil {
+				ctx.Env.Vars = make(map[Symbol]JITValueDesc)
+			}
+			ctx.Env.Vars[binding.Symbol()] = JITValueDesc{
+				Loc:           LocStackPair,
+				Type:          stored.Type,
+				StackOff:      off,
+				NoHeapPointer: stored.NoHeapPointer,
+				Rooted:        true,
+			}
+			return stored
+		case "setN":
+			if len(list) != 3 {
+				panic("jit: malformed setN")
+			}
+			targetVar := list[1]
+			for targetVar.IsSourceInfo() {
+				targetVar = targetVar.SourceInfo().value
+			}
+			if !targetVar.IsNthLocalVar() {
+				panic("jit: setN target is not a numbered local")
+			}
+			idx := int(targetVar.NthLocalVar())
+			if idx < 0 || idx >= ctx.LocalSlotCount || !ctx.SliceBaseTracksRSP {
+				panic("jit: setN target outside invocation frame")
+			}
+			value := jitCompileExpr(ctx, list[2], sliceBase, result)
+			ctx.EnsureDesc(&value)
+			if value.Loc != LocRegPair && value.Loc != LocImm && value.Loc != LocStackPair && value.Loc != LocInputPair {
+				pair := jitAllocTrackedPair(ctx, value.Type)
+				value = jitPlaceIntoPair(ctx, &value, pair)
+			}
+			ctx.EmitStoreScmerToStack(value, int32(idx*16))
+			return value
+		case "parser", "optimizer_proc_return":
+			panic("jit: unsupported special form " + name)
+		case "begin":
+			if len(list) == 1 {
+				imm := NewNil()
+				ctx.TrackImm(imm)
+				return JITValueDesc{Loc: LocImm, Type: tagNil, Imm: imm}
+			}
+			outerEnv := ctx.Env
+			ctx.Env = &JITEnv{Vars: make(map[Symbol]JITValueDesc), Outer: outerEnv}
+			defer func() { ctx.Env = outerEnv }()
+			for _, form := range list[1 : len(list)-1] {
+				value := jitCompileExpr(ctx, form, sliceBase, JITValueDesc{Loc: LocAny})
+				ctx.FreeDesc(&value)
+			}
+			return jitCompileExpr(ctx, list[len(list)-1], sliceBase, result)
+		case "begin_mut":
+			panic("jit: unsupported special form begin_mut")
+		case "!begin":
+			if len(list) == 1 {
+				imm := NewNil()
+				ctx.TrackImm(imm)
+				return JITValueDesc{Loc: LocImm, Type: tagNil, Imm: imm}
+			}
+			for _, form := range list[1 : len(list)-1] {
+				value := jitCompileExpr(ctx, form, sliceBase, JITValueDesc{Loc: LocAny})
+				ctx.FreeDesc(&value)
+			}
+			return jitCompileExpr(ctx, list[len(list)-1], sliceBase, result)
 		case "!list":
 			return jitCompileStackList(ctx, list, sliceBase, result)
+		case "!!list":
+			var capacityExpr Scmer
+			switch {
+			case len(list) == 3 && list[1].IsNthLocalVar():
+				start := int(list[1].NthLocalVar())
+				capacity := int(ToInt(list[2]))
+				if capacity < 0 {
+					capacity = 0
+				}
+				if start < 0 || start+capacity > ctx.LocalSlotCount {
+					panic("jit: !!list slots outside invocation frame")
+				}
+				capacityExpr = NewInt(int64(capacity))
+			case len(list) == 2:
+				capacityExpr = list[1]
+			default:
+				panic("jit: malformed !!list")
+			}
+			capacity := jitCompileExpr(ctx, capacityExpr, sliceBase, JITValueDesc{Loc: LocAny})
+			ctx.AutoImportSafe = false
+			target := jitEnsureResultPair(ctx, result)
+			out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitMakeReservedList), []JITValueDesc{capacity}, target)
+			out.Type = tagSlice
+			out.KnownSliceLen = 0
+			if capacityExpr.IsInt() {
+				out.KnownSliceCap = int32(ToInt(capacityExpr))
+				if out.KnownSliceCap < 0 {
+					out.KnownSliceCap = 0
+				}
+				out.SliceSizeKnown = true
+			}
+			return out
+		case "parallel":
+			panic("jit: unsupported special form parallel")
 		case "match", "match_mut":
 			return jitCompileMatch(ctx, list, sliceBase, result)
 		case "if":
@@ -2273,6 +2404,14 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		if !ok {
 			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
+		// Higher-order declaration emitters still have an incomplete phi contract:
+		// reduce, for example, can currently lose its neutral value while inlining
+		// a callback. Keep the surrounding expression native, but invoke these
+		// declarations through their correct runtime implementation until callback
+		// lowering becomes its own JIT milestone.
+		if jitDeclarationHasCallback(decl) {
+			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
+		}
 		if name == "strlike" {
 			panic("jit: strlike emitter is not supported")
 		}
@@ -2283,6 +2422,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		if decl.Type != nil && decl.Type.JITEmit != nil {
+			ctx.Coverage.InlinedCalls++
 			if !jitAutoImportReturnSafe(name, decl.Type.Return) {
 				ctx.AutoImportSafe = false
 			}
@@ -2504,6 +2644,18 @@ func jitDeclarationParam(decl *Declaration, index int) *TypeDescriptor {
 		return last
 	}
 	return nil
+}
+
+func jitDeclarationHasCallback(decl *Declaration) bool {
+	if decl == nil || decl.Type == nil {
+		return false
+	}
+	for _, param := range decl.Type.Params {
+		if param != nil && param.Kind == "func" {
+			return true
+		}
+	}
+	return false
 }
 
 func jitCompileCallArgument(ctx *JITContext, decl *Declaration, index int, expr Scmer, sliceBase Reg) JITValueDesc {

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -280,9 +280,10 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 
 func jitEnsureResultPair(ctx *JITContext, result JITValueDesc) JITValueDesc {
 	if result.Loc == LocRegPair {
-		return JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: result.Reg, Reg2: result.Reg2}
+		result.Type = JITTypeUnknown
+		return result
 	}
-	return JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+	return jitAllocTrackedPair(ctx, JITTypeUnknown)
 }
 
 func jitAllocTrackedPair(ctx *JITContext, valueType uint8) JITValueDesc {
@@ -391,6 +392,14 @@ func jitResolveRuntimeSymbol(envValue, symbol Scmer) Scmer {
 		panic("jit: unresolved symbol " + string(sym))
 	}
 	return binding.Vars[sym]
+}
+
+func jitResolveGlobalSymbol(symbol Scmer) Scmer {
+	sym := mustSymbol(symbol)
+	if value, ok := Globalenv.Vars[sym]; ok {
+		return value
+	}
+	panic("jit: unresolved global symbol " + string(sym))
 }
 
 func jitApplyCallable0(callable, envValue Scmer) Scmer {
@@ -1542,28 +1551,30 @@ func jitBuildIfTail(tail []Scmer) Scmer {
 
 func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, argExprs []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
 	argc := len(argExprs)
+	stackStart := ctx.BPOffset
+	argsOff := int32(0)
+	if argc > 0 {
+		argsOff = ctx.AllocStack(int32(argc * 16))
+		for i := range argExprs {
+			jitCompileRootedCallValueAt(ctx, argExprs[i], sliceBase, argsOff+int32(i*16))
+		}
+	}
 	var argsSlice JITValueDesc
 	stackBytes := int32(argc * 16)
 	if argc > 0 {
-		// Reserve one contiguous frame for all variadic Scmer arguments.
+		// Captures and other lexical values live in the static JIT frame. Compile
+		// them there before moving RSP, then copy them into the contiguous
+		// variadic call area. Reading LocStackPair directly after SUB RSP would
+		// otherwise address the temporary call area instead of the lexical slot.
 		ctx.EmitSubRSP32(stackBytes)
-		if ctx.SliceBaseTracksRSP && ctx.SliceBase != RegRSP {
-			ctx.EmitMovRegReg(ctx.SliceBase, RegRSP)
-		}
-		// Compile each argument directly towards its final stack slot.
-		for i := 0; i < len(argExprs); i++ {
+		for i := range argExprs {
 			slotOff := int32(i * 16)
-			slot := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: slotOff}
-			v := jitCompileExpr(ctx, argExprs[i], sliceBase, slot)
-			if !(v.Loc == LocStackPair && v.MemPtr == 0 && v.StackOff == slotOff) {
-				tmp := jitAllocTrackedPair(ctx, JITTypeUnknown)
-				_ = jitPlaceIntoPair(ctx, &v, tmp)
-				ctx.EmitStoreRegMem(tmp.Reg, RegRSP, slotOff)
-				ctx.EmitStoreRegMem(tmp.Reg2, RegRSP, slotOff+8)
-				ctx.FreeDesc(&tmp)
-			}
+			sourceOff := stackBytes + argsOff + int32(i*16)
+			ctx.EmitMovRegMem(RegR11, RegRSP, sourceOff)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, slotOff)
+			ctx.EmitMovRegMem(RegR11, RegRSP, sourceOff+8)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, slotOff+8)
 			ctx.setStackPointer(jitStackRootFrameSP, slotOff-ctx.DynamicSP, true)
-			ctx.FreeDesc(&v)
 		}
 		// argslice: ptr + len (cap = len inside EmitGoCallVariadic).
 		argsSlice = jitAllocTrackedPair(ctx, JITTypeUnknown)
@@ -1583,6 +1594,7 @@ func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, ar
 			ctx.EmitMovRegReg(ctx.SliceBase, RegRSP)
 		}
 	}
+	ctx.FreeStack(ctx.BPOffset - stackStart)
 	return out
 }
 
@@ -1679,6 +1691,13 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	return out
 }
 
+func jitCompileDynamicHigherOrderCall(ctx *JITContext, callableExpr Scmer, operands []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	recursiveLambdas := ctx.RecursiveLambdas
+	ctx.RecursiveLambdas = false
+	defer func() { ctx.RecursiveLambdas = recursiveLambdas }()
+	return jitCompileDynamicCall(ctx, callableExpr, operands, sliceBase, result)
+}
+
 func jitCompileRuntimeSymbol(ctx *JITContext, symbol Scmer, result JITValueDesc) JITValueDesc {
 	envImm := JITValueDesc{Loc: LocImm, Type: tagAny, Imm: ctx.RuntimeEnv}
 	symbolImm := JITValueDesc{Loc: LocImm, Type: tagSymbol, Imm: symbol}
@@ -1693,6 +1712,19 @@ func jitCompileRuntimeSymbol(ctx *JITContext, symbol Scmer, result JITValueDesc)
 	out.Type = JITTypeUnknown
 	out = jitRootScmer(ctx, out)
 	ctx.FreeDesc(&envPair)
+	ctx.FreeDesc(&symbolPair)
+	return out
+}
+
+func jitCompileRuntimeGlobalSymbol(ctx *JITContext, symbol Scmer, result JITValueDesc) JITValueDesc {
+	symbolImm := JITValueDesc{Loc: LocImm, Type: tagSymbol, Imm: symbol}
+	ctx.TrackImm(symbol)
+	symbolPair := jitAllocTrackedPair(ctx, tagSymbol)
+	symbolPair = jitPlaceIntoPair(ctx, &symbolImm, symbolPair)
+	target := jitEnsureResultPair(ctx, result)
+	out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitResolveGlobalSymbol), []JITValueDesc{symbolPair}, target)
+	out.Type = JITTypeUnknown
+	out = jitRootScmer(ctx, out)
 	ctx.FreeDesc(&symbolPair)
 	return out
 }
@@ -1821,6 +1853,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			case tagFunc, tagFuncEnv, tagProc, tagJIT, tagClosure, tagPromise:
 				// Callable bindings stay late-bound so redefinition and future
 				// specialization invalidation retain Scheme semantics.
+				return jitCompileRuntimeGlobalSymbol(ctx, expr, result)
 			default:
 				ctx.TrackImm(v)
 				return JITValueDesc{Loc: LocImm, Type: v.GetTag(), Imm: v}
@@ -2410,7 +2443,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		// declarations through their correct runtime implementation until callback
 		// lowering becomes its own JIT milestone.
 		if jitDeclarationHasCallback(decl) {
-			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
+			return jitCompileDynamicHigherOrderCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		if name == "strlike" {
 			panic("jit: strlike emitter is not supported")

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -89,8 +89,9 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 			compiled := jitCompile(expression)
 			sym, definition := topLevelDefinitionSymbol(code)
 			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil &&
-				definition && (jitQueryCompilerEntrypoint(sym) ||
-				jitQueryCompilerSource(source) && compiled.Proc().Compiled.AutoImportSafe) {
+				compiled.Proc().Compiled.AutoImportSafe &&
+				jitAutoImportCoverageWorthwhile(compiled.Proc().Compiled.Coverage) &&
+				definition {
 				expression = compiled
 				if definition {
 					target := en.definitionTarget()
@@ -98,12 +99,13 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 						target.Vars = make(Vars)
 					}
 					target.Vars[sym] = compiled
+					compiled.Proc().Compiled.DebugName = string(sym)
 				}
 				if JITLog {
 					entry := compiled.Proc().Compiled
-					fmt.Printf("JIT: import %s code=%p bytes=%d expressions=%d dynamic-calls=%d inlined-calls=%d\n",
-						sym, entry.CodePtr, entry.CodeLen, entry.Coverage.Expressions,
-						entry.Coverage.DynamicCalls, entry.Coverage.InlinedCalls)
+					fmt.Printf("JIT: import %s code=%p bytes=%d hidden-args=%d expressions=%d dynamic-calls=%d inlined-calls=%d\n",
+						sym, entry.CodePtr, entry.CodeLen, len(entry.HiddenArgs),
+						entry.Coverage.Expressions, entry.Coverage.DynamicCalls, entry.Coverage.InlinedCalls)
 				}
 			}
 		}
@@ -111,20 +113,12 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 	return
 }
 
-func jitQueryCompilerSource(source string) bool {
-	if slash := strings.LastIndexByte(source, '/'); slash >= 0 {
-		source = source[slash+1:]
-	}
-	return strings.HasPrefix(source, "queryplan") && strings.HasSuffix(source, ".scm")
-}
-
-func jitQueryCompilerEntrypoint(sym Symbol) bool {
-	switch sym {
-	case Symbol("normalize_sql_syntax"), Symbol("optimize_logical_query"), Symbol("build_queryplan"), Symbol("build_queryplan_term"):
-		return true
-	default:
-		return false
-	}
+func jitAutoImportCoverageWorthwhile(coverage JITCoverage) bool {
+	// A generic Apply bridge costs more than a handful of straight-line emitter
+	// nodes. Keep probe compilation universal, but activate only native bodies
+	// whose static coverage can amortize every remaining bridge. This decision is
+	// deliberately independent of module paths and definition names.
+	return coverage.DynamicCalls == 0 || coverage.Expressions >= coverage.DynamicCalls*8
 }
 
 func topLevelDefinitionSymbol(code Scmer) (Symbol, bool) {

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -70,9 +70,10 @@ func EvalAll(source, s string, en *Env) (expression Scmer) {
 	return evalAll(source, s, en, false)
 }
 
-// EvalAllJIT evaluates a Scheme module and attaches native implementations to
-// every top-level procedure that the current emitter can compile. Unsupported
-// procedures stay ordinary Procs and retain the interpreter as a safe fallback.
+// EvalAllJIT evaluates a Scheme module through the same parse, validate,
+// optimize, and recursive JIT pipeline as an explicit (jit ...) call.
+// Unsupported procedures stay ordinary Procs and retain the interpreter as an
+// atomic fallback.
 func EvalAllJIT(source, s string, en *Env) (expression Scmer) {
 	return evalAll(source, s, en, true)
 }
@@ -85,20 +86,37 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 		code = Optimize(code, en, nil)
 		expression = Eval(code, en)
 		if compileProcedures && expression.GetTag() == tagProc {
-			compiled := jitCompileForImport(expression)
-			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil && compiled.Proc().Compiled.AutoImportSafe {
+			compiled := jitCompile(expression)
+			sym, definition := topLevelDefinitionSymbol(code)
+			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil &&
+				(compiled.Proc().Compiled.AutoImportSafe || definition && jitQueryCompilerEntrypoint(sym)) {
 				expression = compiled
-				if sym, ok := topLevelDefinitionSymbol(code); ok {
+				if definition {
 					target := en.definitionTarget()
 					if target.Vars == nil {
 						target.Vars = make(Vars)
 					}
 					target.Vars[sym] = compiled
 				}
+				if JITLog {
+					entry := compiled.Proc().Compiled
+					fmt.Printf("JIT: import %s code=%p bytes=%d expressions=%d dynamic-calls=%d inlined-calls=%d\n",
+						sym, entry.CodePtr, entry.CodeLen, entry.Coverage.Expressions,
+						entry.Coverage.DynamicCalls, entry.Coverage.InlinedCalls)
+				}
 			}
 		}
 	}
 	return
+}
+
+func jitQueryCompilerEntrypoint(sym Symbol) bool {
+	switch sym {
+	case Symbol("normalize_sql_syntax"), Symbol("optimize_logical_query"), Symbol("build_queryplan"), Symbol("build_queryplan_term"):
+		return true
+	default:
+		return false
+	}
 }
 
 func topLevelDefinitionSymbol(code Scmer) (Symbol, bool) {

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -89,7 +89,8 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 			compiled := jitCompile(expression)
 			sym, definition := topLevelDefinitionSymbol(code)
 			if compiled.GetTag() == tagProc && compiled.Proc() != nil && compiled.Proc().Compiled != nil &&
-				(compiled.Proc().Compiled.AutoImportSafe || definition && jitQueryCompilerEntrypoint(sym)) {
+				definition && (jitQueryCompilerEntrypoint(sym) ||
+				jitQueryCompilerSource(source) && compiled.Proc().Compiled.AutoImportSafe) {
 				expression = compiled
 				if definition {
 					target := en.definitionTarget()
@@ -108,6 +109,13 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 		}
 	}
 	return
+}
+
+func jitQueryCompilerSource(source string) bool {
+	if slash := strings.LastIndexByte(source, '/'); slash >= 0 {
+		source = source[slash+1:]
+	}
+	return strings.HasPrefix(source, "queryplan") && strings.HasSuffix(source, ".scm")
 }
 
 func jitQueryCompilerEntrypoint(sym Symbol) bool {


### PR DESCRIPTION
Implements the expression-emitter foundation for automatic import-time JIT compilation.

## What changes

- Every imported Scheme definition runs through parse -> validate -> optimize -> JIT probe compilation.
- Activation is independent of module paths and definition names; there is no `queryplan*.scm` special case.
- Procedures whose emitter coverage is safe and can amortize their remaining generic bridges replace the interpreted binding. Unsupported or unsafe procedures remain interpreted atomically.
- The JIT expression dispatcher mirrors `Eval` special forms, including lexical `define`/`set`, numbered locals, `match`, and `begin`.
- `list`, `!list`, and `!!list` are lowered, including transferred and stack-backed list cases.
- JIT entry points record expression, inlined-call, and dynamic-bridge coverage for analysis through `LogJIT`.
- Go ABI result-register moves are cycle-safe, and the borrowed `cdr` path no longer uses the faulty generated three-word slice lowering.

No files under `lib/` are changed.

## End-to-end cold SQL benchmark

Compared `master` at `b213bf02c` with this branch at `d597d2b0c`, both built with `/home/carli/projekte/go-jit/goroot/bin/go`.

The benchmark sent 500 distinct SQL texts over persistent authenticated HTTP connections. Each distinct `OFFSET` creates a cold SQL text/query-plan-cache key while keeping the schema and transport warm. Requests were interleaved in deterministic pseudo-random order and timed from immediately before the HTTP request through the complete response body. Every response returned HTTP 200.

Schema:

```sql
CREATE TABLE wp_posts (
    id INT PRIMARY KEY,
    status VARCHAR(20)
);
CREATE TABLE wp_postmeta (
    id INT PRIMARY KEY,
    post_id INT,
    meta_key VARCHAR(255),
    meta_value VARCHAR(255)
);
```

Cold statement, with a unique `N` for every request:

```sql
SELECT wp_posts.id, COUNT(wp_postmeta.id)
FROM wp_posts
LEFT JOIN wp_postmeta ON wp_postmeta.post_id = wp_posts.id
WHERE wp_posts.status = 'publish'
GROUP BY wp_posts.id
ORDER BY wp_posts.id
LIMIT 20 OFFSET N;
```

| Revision | Mean | Median | p90 |
|---|---:|---:|---:|
| `master` | 20.613 ms | 19.821 ms | 24.846 ms |
| import JIT | 19.579 ms | 18.980 ms | 22.103 ms |

Result:

- Mean: **5.0% faster** (`-1.035 ms` per cold statement)
- Median: **4.4% faster** (`-0.871 ms` paired median)
- JIT was faster in **329/500** paired requests

An unrestricted activation experiment was also measured and was 2.7% slower because shallow native wrappers with multiple generic `Apply` bridges cost more than their interpreted equivalents. The generic coverage gate in this PR is based on that result: probe compilation remains universal, but automatic binding replacement requires zero bridges or at least eight lowered expression nodes per remaining bridge.

## JIT coverage and generated code

`LogJIT` analysis of a complete `lib/main.scm` import reports:

- 182 automatically activated imported procedures
- 1,822 lowered expression nodes
- 112 remaining static dynamic-call bridge sites
- no filename or procedure-name allowlist

Raw x86-64 disassembly confirms native bodies rather than interpreter stubs. Examples:

- `qb_sources`: 240 bytes, 3 expressions, 0 dynamic calls, 1 inlined call
- `join_order_node_kind`: 887 bytes, 10 expressions, 1 dynamic call, 2 inlined calls
- `stage_output_relation_id`: 323 bytes, 4 expressions, 0 dynamic calls

The top-level `build_queryplan`/normalization wrappers are still left interpreted when their bridge density would make them slower. Their frequently used planner accessors and decision helpers are activated automatically, which produces the measured end-to-end improvement. Removing the remaining bridges is the next JIT milestone.

## Verification

- Focused `scm` JIT expression tests pass with the patched compiler.
- Full `lib/main.scm` bootstrap succeeds with the existing Scheme tests unchanged: `1270/1270`.
- `git diff origin/master -- lib` is empty.
- Raw disassembly and import coverage were inspected in addition to semantic tests.
