### PR TITLE
Brake index-covered ORDER LIMIT scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ To optimize memcp for a query you must consider the following steps:
  - once the existing operators do not yield any more speedup but you think, there is more potential, you are allowed to dig into operator's internas: optimizing corner cases, reducing allocations, introducing new operators or intermediate result buffers like recset
  - for operators, regard the following hints: Avoid further branches inside loops. Try to keep setup and loops allocation-free (e.g. using stack buffers), parallelize big workloads into big-enough chunks (often at shard boundaries), cap the number of parallel goroutines of one operator by the session/transaction's boundaries.
  - make sure you do not produce performance regressions -> there is a CI runner with A/B benchmarks master vs PR - it does not allow to decrease query performance more than 20% for any of the test cases.
- - every performance optimization PR must include A/B measurements for the query being optimized in the PR description. State the fixture/setup, warmup and sample configuration, baseline and PR latency, and the absolute or relative change. When the CI master-vs-PR result is available, add that authoritative result to the PR description as well.
+ - every performance optimization PR must include A/B measurements for the query being optimized in the PR description. State the fixture/setup, warmup and sample configuration, baseline and PR latency, and the absolute or relative change.
  - do not run the fulltest alone - always commit no-verify after the needle testcases work and look sane, push PR and watch the CI's results
 
 ## Release Process

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ To optimize memcp for a query you must consider the following steps:
  - once the existing operators do not yield any more speedup but you think, there is more potential, you are allowed to dig into operator's internas: optimizing corner cases, reducing allocations, introducing new operators or intermediate result buffers like recset
  - for operators, regard the following hints: Avoid further branches inside loops. Try to keep setup and loops allocation-free (e.g. using stack buffers), parallelize big workloads into big-enough chunks (often at shard boundaries), cap the number of parallel goroutines of one operator by the session/transaction's boundaries.
  - make sure you do not produce performance regressions -> there is a CI runner with A/B benchmarks master vs PR - it does not allow to decrease query performance more than 20% for any of the test cases.
- - every performance optimization PR must include A/B measurements for the query being optimized in the PR description. State the fixture/setup, warmup and sample configuration, baseline and PR latency, and the absolute or relative change.
+ - every performance optimization PR must include in its description the manual A/B measurements performed during development for the query being optimized. These measurements must exist before the PR is created and compare the development baseline with the proposed change using the same fixture/setup, warmup, and sample configuration. State both latencies and the absolute or relative change. CI results are not a substitute for these hand measurements.
  - do not run the fulltest alone - always commit no-verify after the needle testcases work and look sane, push PR and watch the CI's results
 
 ## Release Process

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,7 @@ To optimize memcp for a query you must consider the following steps:
  - once the existing operators do not yield any more speedup but you think, there is more potential, you are allowed to dig into operator's internas: optimizing corner cases, reducing allocations, introducing new operators or intermediate result buffers like recset
  - for operators, regard the following hints: Avoid further branches inside loops. Try to keep setup and loops allocation-free (e.g. using stack buffers), parallelize big workloads into big-enough chunks (often at shard boundaries), cap the number of parallel goroutines of one operator by the session/transaction's boundaries.
  - make sure you do not produce performance regressions -> there is a CI runner with A/B benchmarks master vs PR - it does not allow to decrease query performance more than 20% for any of the test cases.
+ - every performance optimization PR must include A/B measurements for the query being optimized in the PR description. State the fixture/setup, warmup and sample configuration, baseline and PR latency, and the absolute or relative change. When the CI master-vs-PR result is available, add that authoritative result to the PR description as well.
  - do not run the fulltest alone - always commit no-verify after the needle testcases work and look sane, push PR and watch the CI's results
 
 ## Release Process

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -2160,8 +2160,8 @@ source catalog. join_plan remains the single owner of physical join order. */
 				(qassoc_get planned (quote tree) nil)
 				predicates)))))
 
-(define join_optimizer_reorder_result (lambda (tree strategy dp_entries cost cardinality cost_components)
-	(list tree strategy dp_entries cost cardinality cost_components)))
+(define join_optimizer_reorder_result (lambda (tree strategy dp_entries cost cardinality cost_components properties)
+	(list tree strategy dp_entries cost cardinality cost_components properties)))
 
 (define join_optimizer_required_order_aliases (lambda (sources default_alias order_items)
 	(reduce (order_exprs order_items) (lambda (aliases expr)
@@ -2221,6 +2221,69 @@ source catalog. join_plan remains the single owner of physical join order. */
 			(join_optimizer_required_order_prefix (cdr sources) required_aliases condition stages
 				(append prefix (source_alias (car sources))))
 			prefix))))
+
+/* Keep one complete DPHyp result for every base-table driver which can realize
+the required order. Combined ordered joins have directional work: the driver
+brakes at LIMIT while every other input is prepared for joined lookup. A single
+memo winner for a set of aliases would discard that physical property before
+the lowerer can cost it. */
+(define join_optimizer_ordered_source_rows (lambda (stage_catalog sources default_alias graph src)
+	(begin
+		(define fallback (join_optimizer_source_rows
+			stage_catalog sources default_alias graph src))
+		(define base_rows (planner_source_row_count src))
+		(define condition (join_optimizer_source_local_condition graph src))
+		(if (or (not (number? base_rows)) (equal? condition true))
+			fallback
+			(begin
+				(define estimate (planner_source_filter_estimate src condition 512))
+				(max 1 (planner_estimated_matching_rows estimate base_rows fallback)))))))
+
+(define join_optimizer_ordered_driver_work (lambda (sources base_row_catalog filtered_row_catalog planned target)
+	(begin
+		(define ordered_sources (join_optimizer_sources_for_order sources
+			(join_optimizer_tree_aliases (qassoc_get planned (quote tree) nil))))
+		(define base_rows (map ordered_sources (lambda (src)
+			(qassoc_get base_row_catalog (source_alias src) 1))))
+		(define driver_filtered_rows
+			(qassoc_get filtered_row_catalog (source_alias (car ordered_sources)) (car base_rows)))
+		(define driver_rows (planner_ordered_driver_rows_visited
+			(car base_rows) driver_filtered_rows target))
+		(define inner_rows (reduce (cdr base_rows) + 0))
+		(define joined_rows (qassoc_get planned (quote cardinality) 1))
+		(list (planner_scan_join_order_orientation_cost driver_rows inner_rows
+			(count ordered_sources) target)
+			driver_rows inner_rows joined_rows))))
+
+(define join_optimizer_ordered_driver_candidate_better? (lambda (current candidate)
+	(if (nil? current)
+		true
+		(planner_cost_better? (cadr candidate) (cadr current)))))
+
+(define join_optimizer_plan_ordered_drivers (lambda (stage_catalog relation_units sources default_alias graph ordered_drivers target)
+	(begin
+		(define base_row_catalog (map sources (lambda (src)
+			(list (source_alias src)
+				(coalesceNil (planner_source_row_count src)
+					(join_optimizer_source_rows stage_catalog sources default_alias graph src))))))
+		(define filtered_row_catalog (map sources (lambda (src)
+			(list (source_alias src)
+				(join_optimizer_ordered_source_rows
+					stage_catalog sources default_alias graph src)))))
+		(reduce ordered_drivers (lambda (state driver)
+			(begin
+				(define planned (join_optimizer_plan_segment stage_catalog relation_units
+					sources sources default_alias graph (list driver)))
+				(define work (join_optimizer_ordered_driver_work
+					sources base_row_catalog filtered_row_catalog planned target))
+				(define candidate (list planned (car work)
+					driver))
+				(list (if (join_optimizer_ordered_driver_candidate_better? (car state) candidate)
+					candidate (car state))
+					(append (cadr state) (list (list driver
+						(qassoc_get (car work) (quote total_ns) nil)
+						(nth work 1) (nth work 2) (nth work 3)))))))
+			(list nil '())))))
 
 (define join_optimizer_reorder_sources (lambda (stage_catalog block graph)
 	(begin
@@ -2297,19 +2360,45 @@ source catalog. join_plan remains the single owner of physical join order. */
 			(join_optimizer_reorder_result
 				(join_optimizer_left_deep_tree sources)
 				(if preserve_row_number_driver (quote preserve-row-number-limit) (quote fixed))
-				0 nil nil nil)
+				0 nil nil nil '())
 			(begin
-				(define planned (join_optimizer_plan_segment
-					stage_catalog
-					(qassoc_get (qb_facts block) (quote join_relation_units) '())
-					sources segment default_alias graph required_order_property))
+				(define relation_units
+					(qassoc_get (qb_facts block) (quote join_relation_units) '()))
+				(define literal_limit (planner_literal_value (qb_limit block)))
+				(define literal_offset (coalesceNil
+					(planner_literal_value (qb_offset block)) 0))
+				(define enumerate_ordered_drivers (and
+					(number? literal_limit)
+					(and (>= literal_limit 0)
+						(and (number? literal_offset)
+							(and (empty_list? required_order_aliases)
+								(and (> (count ordered_drivers) 1)
+									(and (empty_list? (qb_stages block))
+										(reduce sources (lambda (supported src)
+											(and supported (and (source_is_base_table? src)
+												(join_optimizer_inner_source? stage_catalog src)))) true))))))))
+				(define ordered_driver_plans (if enumerate_ordered_drivers
+					(join_optimizer_plan_ordered_drivers stage_catalog relation_units
+						sources default_alias graph ordered_drivers (+ literal_offset literal_limit)) nil))
+				(define ordered_choice (if (nil? ordered_driver_plans) nil
+					(car ordered_driver_plans)))
+				(define planned (if (nil? ordered_choice)
+					(join_optimizer_plan_segment stage_catalog relation_units
+						sources segment default_alias graph required_order_property)
+					(car ordered_choice)))
 				(join_optimizer_reorder_result
 					(qassoc_get planned (quote tree) nil)
 					(qassoc_get planned (quote strategy) (quote fixed))
 					(qassoc_get planned (quote dp_entries) 0)
 					(qassoc_get planned (quote cost) nil)
 					(qassoc_get planned (quote cardinality) nil)
-					(qassoc_get planned (quote cost_components) nil)))))))
+					(qassoc_get planned (quote cost_components) nil)
+					(list
+						(list (quote ordered_driver_candidates) ordered_drivers)
+						(list (quote selected_ordered_driver)
+							(if (nil? ordered_choice) nil (nth ordered_choice 2)))
+						(list (quote ordered_driver_costs)
+							(if (nil? ordered_driver_plans) '() (cadr ordered_driver_plans))))))))))
 
 (define join_optimizer_telemetry (lambda (graph reordered)
 	(list
@@ -2320,6 +2409,7 @@ source catalog. join_plan remains the single owner of physical join order. */
 		(list (quote join_estimated_cost) (nth reordered 3))
 		(list (quote join_estimated_rows) (nth reordered 4))
 		(list (quote join_cost) (nth reordered 5))
+		(list (quote join_order_properties) (nth reordered 6))
 		(list (quote join_dp_state_budget) (join_order_dp_state_budget))
 		(list (quote join_graph_nodes) (count (qassoc_get graph (quote nodes) '())))
 		(list (quote join_graph_edges) (count (qassoc_get graph (quote edges) '())))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2382,14 +2382,13 @@ retain the scalar's complete value, including SQL NULL. */
 			nil)
 		_ nil)))
 
-(define order_expr_driver_equivalent (lambda (sources driver expr)
-	(reduce (cdr sources) (lambda (found src)
-		(if (not (nil? found))
-			found
-			(reduce (split_and_terms (coalesceNil (source_join_expr src) true))
-				(lambda (equivalent term)
-					(coalesceNil equivalent (join_term_driver_equivalent driver expr term))) nil)))
-		nil)))
+(define order_expr_driver_equivalent (lambda (sources driver expr condition)
+	(reduce (merge_unique (list
+		(split_and_terms (coalesceNil condition true))
+		(merge (map sources (lambda (src)
+			(split_and_terms (coalesceNil (source_join_expr src) true)))))))
+		(lambda (equivalent term)
+			(coalesceNil equivalent (join_term_driver_equivalent driver expr term))) nil)))
 
 (define scan_order_unique_lookup_sort_column (lambda (sources default_alias driver lookup expr stages condition)
 	(begin
@@ -2428,7 +2427,7 @@ retain the scalar's complete value, including SQL NULL. */
 	(if (order_expr_belongs_to_source? driver expr)
 		(scan_order_sort_column_for_alias driver expr)
 		(begin
-			(define equivalent (order_expr_driver_equivalent sources driver expr))
+			(define equivalent (order_expr_driver_equivalent sources driver expr condition))
 			(if (not (nil? equivalent))
 				(scan_order_sort_column_for_alias driver equivalent)
 				(begin
@@ -2447,7 +2446,7 @@ retain the scalar's complete value, including SQL NULL. */
 	(reduce (order_exprs order_items) (lambda (supported expr)
 		(and supported (or
 			(order_expr_belongs_to_source? driver expr)
-			(not (nil? (order_expr_driver_equivalent sources driver expr)))
+			(not (nil? (order_expr_driver_equivalent sources driver expr condition)))
 			(not (nil? (order_expr_unique_lookup_source sources driver default_alias expr stages condition)))))) true)))
 
 (define split_order_items_for_join_driver (lambda (sources default_alias driver order_items stages condition accepted)
@@ -6683,3 +6682,18 @@ coefficient used here. */
 		(* output_rows planner_membership_map_column_row_ns)
 		(* joined_rows 8)
 		0 output_rows 0.65)))
+
+/* Directional ORDER/LIMIT planning compares equal operator families, so fixed
+startup cancels out. The driver can brake after enough local matches while
+every inner input must be prepared completely. Keep this property score out of
+the absolute scan_join_order-versus-legacy calibration. */
+(define planner_ordered_driver_rows_visited (lambda (input_rows filtered_rows target)
+	(if (or (not (number? input_rows)) (not (number? filtered_rows)))
+		input_rows
+		(if (<= filtered_rows 0)
+			input_rows
+			(min input_rows (max target (* target (/ input_rows filtered_rows))))))))
+
+(define planner_scan_join_order_orientation_cost (lambda (driver_rows inner_rows table_count target)
+	(planner_scan_join_order_cost (+ driver_rows inner_rows)
+		target table_count target)))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -6771,6 +6771,20 @@ the absolute scan_join_order-versus-legacy calibration. */
 each later equality input with those query-local keys. Reuse the calibrated
 scan_join_order work units so this alternative introduces no hand-tuned
 threshold outside Costgen's model. */
+(define planner_growing_batch_invocations_from (lambda (rows batch invocations)
+	(if (<= rows 0)
+		invocations
+		(planner_growing_batch_invocations_from
+			(- rows batch) (* batch 2) (+ invocations 1)))))
+
 (define planner_scan_join_order_batched_probe_cost (lambda (driver_rows table_count target map_width)
-	(planner_scan_join_order_cost driver_rows
-		(* driver_rows (- table_count 1)) target table_count target map_width)))
+	(begin
+		(define batch_invocations (planner_growing_batch_invocations_from
+			driver_rows (max 1 target) 0))
+		(planner_cost_add
+			(planner_scan_join_order_cost driver_rows
+				(* driver_rows (- table_count 1)) target table_count target map_width)
+			(planner_cost (* (max 0 (- batch_invocations 1)) table_count
+				planner_membership_scan_invocation_ns)
+				0 0 0 0 0 0 0 target 0.65)
+			target 0.65))))

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -6766,3 +6766,11 @@ the absolute scan_join_order-versus-legacy calibration. */
 (define planner_scan_join_order_orientation_cost (lambda (driver_rows inner_rows table_count target)
 	(planner_scan_join_order_cost (+ driver_rows inner_rows)
 		target target table_count target 0)))
+
+/* The batched probe variant visits only the ordered driver window and probes
+each later equality input with those query-local keys. Reuse the calibrated
+scan_join_order work units so this alternative introduces no hand-tuned
+threshold outside Costgen's model. */
+(define planner_scan_join_order_batched_probe_cost (lambda (driver_rows table_count target map_width)
+	(planner_scan_join_order_cost driver_rows
+		(* driver_rows (- table_count 1)) target table_count target map_width)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4749,10 +4749,17 @@ move the window to the wrong tree level. */
 	(map refs (lambda (ref)
 		(symbol (concat (source_alias (nth sources (car ref))) "." (cadr ref)))))))
 
-(define scan_join_order_order_entry (lambda (sources default_alias item)
+(define scan_join_order_order_entry (lambda (sources default_alias terms item)
 	(match item
 		'(expr _dir) (begin
-			(define ref (scan_join_order_column_ref_using sources default_alias expr))
+			(define driver (car sources))
+			(define direct_ref (scan_join_order_column_ref_using sources default_alias expr))
+			(define equivalent (if (and (not (nil? direct_ref))
+				(equal? (car direct_ref) 0)) nil
+				(reduce terms (lambda (found term)
+					(coalesceNil found (join_term_driver_equivalent driver expr term))) nil)))
+			(define ref (if (nil? equivalent) direct_ref
+				(scan_join_order_column_ref_using sources default_alias equivalent)))
 			(if (nil? ref)
 				nil
 				(list ref (car (order_relations_for_source
@@ -4868,11 +4875,30 @@ until the caller has selected this physical alternative. */
 			(and (not (contains? consumed_join_terms term))
 				(not (contains? all_local_terms term))))))
 		(define order_entries (map order_items (lambda (item)
-			(scan_join_order_order_entry sources default_alias item))))
+			(scan_join_order_order_entry sources default_alias terms item))))
 		(define source_rows (map sources planner_source_row_count))
 		(define known_rows (reduce source_rows (lambda (known rows)
 			(and known (number? rows))) true))
 		(define input_rows (if known_rows (reduce source_rows + 0) nil))
+		(define filtered_rows (if known_rows
+			(map (produceN (count sources)) (lambda (index)
+				(begin
+					(define src (nth sources index))
+					(define base_rows (nth source_rows index))
+					(define local_condition
+						(combine_where_terms (nth local_terms index) true))
+					(if (equal? local_condition true)
+						base_rows
+						(begin
+							(define estimate
+								(planner_source_filter_estimate src local_condition 512))
+							(max 1 (planner_estimated_matching_rows estimate
+								base_rows base_rows))))))) nil))
+		(define driver_rows (if (empty_list? filtered_rows) nil
+			(planner_ordered_driver_rows_visited (car source_rows) (car filtered_rows)
+				(+ offset limit))))
+		(define inner_rows (if (empty_list? source_rows) nil
+			(reduce (cdr source_rows) + 0)))
 		(define joined_rows (qassoc_get facts (quote join_estimated_rows) nil))
 		(define output_rows (if (and (number? limit) (>= limit 0))
 			(min (coalesceNil joined_rows limit) (+ offset limit)) joined_rows))
@@ -4901,6 +4927,8 @@ until the caller has selected this physical alternative. */
 				(list (quote map_refs) (scan_join_order_refs_for_exprs
 					sources default_alias needed_exprs))
 				(list (quote input_rows) input_rows)
+				(list (quote driver_rows) driver_rows)
+				(list (quote inner_rows) inner_rows)
 				(list (quote joined_rows) joined_rows)
 				(list (quote output_rows) output_rows)
 				(list (quote table_count) (count sources))
@@ -5201,7 +5229,10 @@ until the caller has selected this physical alternative. */
 
 (define join_ordered_streaming_limit_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
 	(begin
-		(define spec (scan_join_order_spec all_sources plan default_alias needed_exprs
+		/* scan_join_order owns filters, joins, residuals, and ordering in separate
+		operator arguments. Keep its late map boundary projection-only so columns
+		already consumed by those paths are not materialized a second time. */
+		(define spec (scan_join_order_spec all_sources plan default_alias output_exprs
 			final_condition order_items offset_value limit_value stages facts))
 		(if (nil? spec)
 			(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
@@ -5290,6 +5321,8 @@ until the caller has selected this physical alternative. */
 						"calibration_override"))
 					(list "inputs" (list
 						(list "join_input_rows" input_rows)
+						(list "join_driver_rows" (qassoc_get spec (quote driver_rows) nil))
+						(list "join_inner_rows" (qassoc_get spec (quote inner_rows) nil))
 						(list "join_estimated_rows" joined_rows)
 						(list "join_output_rows" output_rows)
 						(list "join_table_count" (qassoc_get spec (quote table_count) 0))
@@ -9219,6 +9252,8 @@ potentially large calibrated SELECT result. */
 							"driver_expression_operations" (physical_calibration_input decision "driver_expression_operations")
 							"driver_expression_depth" (physical_calibration_input decision "driver_expression_depth")
 							"join_input_rows" (physical_calibration_input decision "join_input_rows")
+							"join_driver_rows" (physical_calibration_input decision "join_driver_rows")
+							"join_inner_rows" (physical_calibration_input decision "join_inner_rows")
 							"join_estimated_rows" (physical_calibration_input decision "join_estimated_rows")
 							"join_output_rows" (physical_calibration_input decision "join_output_rows")
 							"join_table_count" (physical_calibration_input decision "join_table_count")

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4942,9 +4942,28 @@ until the caller has selected this physical alternative. */
 								(planner_source_filter_estimate src local_condition 512))
 							(max 1 (planner_estimated_matching_rows estimate
 								base_rows base_rows))))))) nil))
+		/* A local driver predicate is only the first acceptance stage. Every
+		later input may reject the driver row as well, so price ordered braking
+		from the product of the independently estimated inner selectivities.
+		This keeps a selective exact carrier competitive when join matches are
+		rare, while an almost-unfiltered FK lookup remains a cheap batch probe. */
+		(define inner_acceptance (if (and ordered_window
+			(not (empty_list? filtered_rows)))
+			(reduce (produceN (- (count sources) 1)) (lambda (acceptance offset_index)
+				(begin
+					(define index (+ offset_index 1))
+					(define base_rows (nth source_rows index))
+					(define matching_rows (nth filtered_rows index))
+					(* acceptance (if (<= base_rows 0) 0
+						(min 1 (/ matching_rows base_rows)))))) 1)
+			nil))
+		(define accepted_driver_target (if (and (number? inner_acceptance)
+			(> inner_acceptance 0))
+			(/ (+ offset limit) inner_acceptance)
+			(if (number? inner_acceptance) (car source_rows) nil)))
 		(define driver_rows (if (and ordered_window (not (empty_list? filtered_rows)))
 			(planner_ordered_driver_rows_visited (car source_rows) (car filtered_rows)
-				(+ offset limit)) nil))
+				accepted_driver_target) nil))
 		(define inner_rows (if (and ordered_window (not (empty_list? source_rows)))
 			(reduce (cdr source_rows) + 0) nil))
 		(define joined_rows (qassoc_get facts (quote join_estimated_rows) nil))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4924,7 +4924,11 @@ until the caller has selected this physical alternative. */
 		(define known_rows (reduce source_rows (lambda (known rows)
 			(and known (number? rows))) true))
 		(define input_rows (if known_rows (reduce source_rows + 0) nil))
-		(define filtered_rows (if known_rows
+		/* Driver selectivity is only an ORDER/LIMIT property. In particular, do
+		not inspect session-dependent predicates while costing unordered joined
+		aggregation: those plans are cached before an execution session exists. */
+		(define ordered_window (and (>= limit 0) (not (empty_list? order_items))))
+		(define filtered_rows (if (and ordered_window known_rows)
 			(map (produceN (count sources)) (lambda (index)
 				(begin
 					(define src (nth sources index))
@@ -4938,9 +4942,6 @@ until the caller has selected this physical alternative. */
 								(planner_source_filter_estimate src local_condition 512))
 							(max 1 (planner_estimated_matching_rows estimate
 								base_rows base_rows))))))) nil))
-		/* Driver/inner work is a directional ORDER/LIMIT property. Unordered
-		reduction shares this specification but has no braked driver. */
-		(define ordered_window (and (>= limit 0) (not (empty_list? order_items))))
 		(define driver_rows (if (and ordered_window (not (empty_list? filtered_rows)))
 			(planner_ordered_driver_rows_visited (car source_rows) (car filtered_rows)
 				(+ offset limit)) nil))
@@ -4995,7 +4996,10 @@ until the caller has selected this physical alternative. */
 				(list (quote limit) limit)
 				(list (quote cost) (planner_scan_join_order_cost
 					input_rows probe_rows joined_rows (count sources)
-					output_rows map_width)))))))
+					output_rows map_width))
+				(list (quote batched_probe_cost) (if (number? driver_rows)
+					(planner_scan_join_order_batched_probe_cost driver_rows
+						(count sources) (+ offset limit) map_width) nil)))))))
 
 (define join_ordered_streaming_limit_legacy_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
 	(begin
@@ -5235,7 +5239,7 @@ until the caller has selected this physical alternative. */
 			(wrap_membership_keyset_bindings membership_keysets window_expr)
 			window_expr))))
 
-(define scan_join_order_emit_plan (lambda (spec default_alias needed_exprs value_builder reduce_expr neutral_expr shard_reduce_expr stages)
+(define scan_join_order_emit_plan (lambda (spec default_alias needed_exprs value_builder reduce_expr neutral_expr shard_reduce_expr stages batched_probe)
 	(begin
 		(define sources (qassoc_get spec (quote sources) '()))
 		(define local_terms (qassoc_get spec (quote local_terms) '()))
@@ -5285,14 +5289,11 @@ until the caller has selected this physical alternative. */
 			(list (quote lambda)
 				(scan_join_order_ref_params sources map_refs)
 				map_body)
-			reduce_expr neutral_expr shard_reduce_expr false neutral_expr))))
+			reduce_expr neutral_expr shard_reduce_expr false neutral_expr batched_probe))))
 
 (define join_ordered_streaming_limit_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
 	(begin
-		/* scan_join_order owns filters, joins, residuals, and ordering in separate
-		operator arguments. Keep its late map boundary projection-only so columns
-		already consumed by those paths are not materialized a second time. */
-		(define spec (scan_join_order_spec all_sources plan default_alias output_exprs
+		(define spec (scan_join_order_spec all_sources plan default_alias needed_exprs
 			final_condition order_items offset_value limit_value stages facts false))
 		(if (nil? spec)
 			(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
@@ -5303,6 +5304,7 @@ until the caller has selected this physical alternative. */
 				(define input_rows (qassoc_get spec (quote input_rows) 0))
 				(define output_rows (qassoc_get spec (quote output_rows) 0))
 				(define scan_cost (qassoc_get spec (quote cost) nil))
+				(define batched_probe_cost (qassoc_get spec (quote batched_probe_cost) nil))
 				/* join_estimated_cost is the optimizer's scalar DP rank. Physical
 				alternatives compare the calibrated cost-domain record instead. */
 				(define estimated_legacy_cost (qassoc_get facts (quote join_cost) nil))
@@ -5355,11 +5357,17 @@ until the caller has selected this physical alternative. */
 					(coalesceNil joined_rows legacy_probe_rows) 0.65))
 				/* Both alternatives are fully costed in the same generated cost domain.
 				Do not override a close comparison with an operator-specific preference. */
-				(define normal_choice (if (planner_cost_better? scan_cost legacy_cost)
+				(define materialized_choice (if (planner_cost_better? scan_cost legacy_cost)
 					"scan_join_order" "legacy_join_tree"))
+				(define materialized_cost (if (equal? materialized_choice "scan_join_order")
+					scan_cost legacy_cost))
+				(define normal_choice (if (and (not (nil? batched_probe_cost))
+					(planner_cost_better? batched_probe_cost materialized_cost))
+					"scan_join_order_batched_probe" materialized_choice))
 				(define decision_id (concat "scan_join_order:"
 					(stable_structural_hash (join_optimizer_tree_aliases plan) true)))
-				(define alternatives (list "legacy_join_tree" "scan_join_order"))
+				(define alternatives (list "legacy_join_tree" "scan_join_order"
+					"scan_join_order_batched_probe"))
 				(define chosen (planner_physical_choice decision_id normal_choice alternatives))
 				(define forced (planner_physical_override decision_id))
 				(planner_record_physical_decision (list
@@ -5388,10 +5396,14 @@ until the caller has selected this physical alternative. */
 						(list (list "plan" "legacy_join_tree")
 							(list "cost" (planner_cost_explain legacy_cost)))
 						(list (list "plan" "scan_join_order")
-							(list "cost" (planner_cost_explain scan_cost)))))))
-				(if (equal? chosen "scan_join_order")
+							(list "cost" (planner_cost_explain scan_cost)))
+						(list (list "plan" "scan_join_order_batched_probe")
+							(list "cost" (planner_cost_explain batched_probe_cost)))))))
+				(if (or (equal? chosen "scan_join_order")
+					(equal? chosen "scan_join_order_batched_probe"))
 					(scan_join_order_emit_plan spec default_alias needed_exprs
-						value_builder reduce_expr neutral_expr nil stages)
+						value_builder reduce_expr neutral_expr nil stages
+						(equal? chosen "scan_join_order_batched_probe"))
 					(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
 						output_exprs needed_exprs final_condition order_items offset_value limit_value
 						stages facts value_builder reduce_expr neutral_expr)))))))
@@ -5458,7 +5470,7 @@ ordered operator's Costgen-owned scan, map and expression coefficients. */
 							(list "cost" (planner_cost_explain scan_cost)))))))
 				(if (equal? chosen "scan_join_order")
 					(scan_join_order_emit_plan spec default_alias needed_exprs value_builder
-						reduce_expr neutral_expr shard_reduce_expr stages)
+						reduce_expr neutral_expr shard_reduce_expr stages false)
 					legacy_plan))))))
 
 (define without_col (lambda (cols col)
@@ -9294,7 +9306,10 @@ ordering run. Storage artifacts begin in build_queryplan. */
 					(physical_membership_operator_family plan)))
 			(if (equal? kind "scan_join_order")
 				(if (physical_expr_has_head? plan (quote scan_join_order))
-					"scan_join_order" "legacy_join_tree")
+					(if (equal? (qassoc_get decision "chosen" nil)
+						"scan_join_order_batched_probe")
+						"scan_join_order_batched_probe" "scan_join_order")
+					"legacy_join_tree")
 				(if (equal? kind "direct_group_join")
 					(if (physical_expr_has_group_relation? plan)
 						"group_carrier" "direct_group_join")

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -642,8 +642,15 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(define resultrow (lambda (row) (begin
 						(set resultrow_called true)
 						(original_resultrow row))))
-					/* Execute inside auto-commit tx (or existing explicit tx) */
-					(set query_result (with_session session (lambda () (with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula)))))))
+					/* network.go already installed the request-local Scheme session. Only
+					the legacy persistent X-Session-Id map can select a different session;
+					avoid a second goroutine-stack lookup for ordinary autocommit queries. */
+					(define execute_formula (lambda ()
+						(with_autocommit session (lambda ()
+							(eval (source "SQL Query" 1 1 formula))))))
+					(set query_result (if session_id
+						(with_session session execute_formula)
+						(execute_formula)))
 					/* If no resultrow was called and we got a number, return it as affected_rows */
 					(if (and (not resultrow_called) (number? query_result)) (begin
 						(original_resultrow '("affected_rows" query_result))

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -594,6 +594,45 @@ func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
 	return extractBoundariesInto(nil, conditionCols, condition)
 }
 
+// sortedBoundariesCoverCondition proves that every predicate in condition was
+// lowered into an identical sorted boundary. Ordered scans may use this proof
+// to size their index batches from LIMIT without turning residual rejection
+// into a sequence of tiny batches. Additional ORDER-only boundaries are fine.
+func sortedBoundariesCoverCondition(conditionCols []string, condition scm.Scmer, bounds boundaries) bool {
+	ctx, ok := conditionAnalyzeContext(conditionCols, condition)
+	if !ok {
+		return false
+	}
+	required, simple := extractSimpleBoundaries(&ctx, ctx.proc.Body, nil)
+	if !simple || len(required) == 0 {
+		return false
+	}
+	for _, want := range required {
+		if want.matcher == nil || !want.matcher.IsSorted() || want.lowerBatch || want.upperBatch {
+			return false
+		}
+		covered := false
+		for _, have := range bounds {
+			if have.col != want.col || have.matcher == nil ||
+				!matcherKindEqual(have.matcher, want.matcher) ||
+				have.lowerBatch || have.upperBatch ||
+				have.lowerInclusive != want.lowerInclusive ||
+				have.upperInclusive != want.upperInclusive ||
+				have.collation != want.collation ||
+				!boundaryValueEqual(have.lower, want.lower) ||
+				!boundaryValueEqual(have.upper, want.upper) {
+				continue
+			}
+			covered = true
+			break
+		}
+		if !covered {
+			return false
+		}
+	}
+	return true
+}
+
 // extractBoundariesGeneral retains the complete recursive analyzer for OR
 // widening, computed columns and any future shape not handled by the simple
 // allocation-free path.

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -24,6 +24,23 @@ import (
 
 var benchmarkBoundaries boundaries
 
+func TestSortedBoundariesCoverCondition(t *testing.T) {
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewSymbol("value"),
+		scm.NewString("needle"),
+	})
+	condition := buildProc([]string{"value"}, body)
+	bounds := extractBoundaries([]string{"meta_key"}, condition)
+	if !sortedBoundariesCoverCondition([]string{"meta_key"}, condition, bounds) {
+		t.Fatal("simple equality should be covered by its extracted boundary")
+	}
+	bounds[0].upper = scm.NewString("other")
+	if sortedBoundariesCoverCondition([]string{"meta_key"}, condition, bounds) {
+		t.Fatal("different boundary must not cover the condition")
+	}
+}
+
 func BenchmarkExtractBoundariesEqual(b *testing.B) {
 	body := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),

--- a/storage/index.go
+++ b/storage/index.go
@@ -54,7 +54,8 @@ type storageIndexState struct {
 }
 
 type indexIterationOptions struct {
-	orderedLimit int
+	orderedLimit         int
+	boundaryCoveredLimit bool
 }
 
 type computedRevision struct {
@@ -578,8 +579,8 @@ func (t *storageShard) iterateIndexEstimate(tx *TxContext, cols boundaries, lowe
 	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, 0, false, nil, nil, candidateSpan, selected, callback)
 }
 
-func (t *storageShard) iterateIndexOrdered(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, limit int, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit}, nil, selected, callback)
+func (t *storageShard) iterateIndexOrdered(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, limit int, boundaryCoveredLimit bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit, boundaryCoveredLimit: boundaryCoveredLimit}, nil, selected, callback)
 }
 
 func (t *storageShard) iterateIndexForce(tx *TxContext, cols boundaries, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
@@ -1659,6 +1660,15 @@ start_scan:
 	s.mu.Unlock()
 	if selected != nil {
 		selected(s, true)
+	}
+	// A fully index-covered filter cannot reject an otherwise visible row. When
+	// this active index also supplies ORDER BY, emit only the requested prefix
+	// per callback so LIMIT can brake inside the index walk. The caller-owned
+	// pooled buffer remains allocated at its normal size; only its visible slice
+	// is shortened, so the hot path adds no allocation.
+	if options != nil && options.boundaryCoveredLimit && options.orderedLimit > 0 &&
+		options.orderedLimit < len(buf) && indexCoversBoundaryOrder(s, true, bounds, len(lower)) {
+		buf = buf[:options.orderedLimit]
 	}
 
 	// record-ID lookup: identity when data is physically sorted (Native), index dereference otherwise

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -1205,7 +1205,7 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 		currentTx = r.tx
 	}
 	return r.table.scanWithBatchFrom(currentTx, r, conditionCols, condition,
-		callbackCols, callback, aggregate, neutral, aggregate2, isOuter, 0, nil)
+		callbackCols, callback, aggregate, neutral, aggregate2, isOuter, 0, nil, nil)
 }
 
 func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -595,14 +595,14 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, conditionCo
 
 // map reduce implementation based on scheme scripts
 func (t *table) scan(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool) scm.Scmer {
-	return t.scanWithBatchFrom(currentTx, nil, conditionCols, condition, callbackCols, callback, aggregate, neutral, aggregate2, isOuter, 0, nil)
+	return t.scanWithBatchFrom(currentTx, nil, conditionCols, condition, callbackCols, callback, aggregate, neutral, aggregate2, isOuter, 0, nil, nil)
 }
 
 func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
-	return t.scanWithBatchFrom(currentTx, nil, conditionCols, condition, callbackCols, callback, aggregate, neutral, aggregate2, isOuter, stride, batchdata)
+	return t.scanWithBatchFrom(currentTx, nil, conditionCols, condition, callbackCols, callback, aggregate, neutral, aggregate2, isOuter, stride, batchdata, nil)
 }
 
-func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
+func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer, requiredBoundaries boundaries) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := scm.CurrentQuerySeq()
 	hasMutationCallback := false
@@ -633,6 +633,7 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 		defer releaseScanAnalyzeScratch(scratch)
 		boundaries = extractBoundariesInto(scratch.boundaries[:0], conditionCols, condition)
 	}
+	boundaries = append(boundaries, requiredBoundaries...)
 	reorderByFrequency(boundaries, t)
 	boundaries = appendRecSetBoundary(boundaries, source)
 	var lowerStorage []scm.Scmer

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -161,6 +161,48 @@ func TestScanSelectivityEstimateScalesIndexCandidatesByShardPopulation(t *testin
 	}
 }
 
+func TestScanSelectivityEstimateLoadsColdPersistentShard(t *testing.T) {
+	Init(scm.Globalenv)
+	tbl, persistence := createDurabilityTestTable(t, "test_selectivity_cold_shard", 100)
+	RebuildTable(tbl, true, false)
+
+	db := newDatabase()
+	db.Name = "test_selectivity_cold_shard"
+	db.persistence = persistence
+	db.srState = COLD
+	db.ensureLoaded()
+	coldTable := db.GetTable("items")
+	if coldTable == nil {
+		t.Fatal("reloaded database has no items table")
+	}
+	coldShard := coldTable.ActiveShards()[0]
+	if coldShard.srState != COLD {
+		t.Fatalf("reloaded shard state = %v, want COLD", coldShard.srState)
+	}
+
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("id")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("<="), scm.NewSymbol("id"), scm.NewInt(50),
+		}),
+		En: &scm.Globalenv,
+	})
+	estimate := scm.Apply(scm.Globalenv.Vars[scm.Symbol("scan_selectivity_estimate")],
+		scm.NewNil(), NewTableScmer(coldTable),
+		scm.NewSlice([]scm.Scmer{scm.NewString("id")}), condition, scm.NewInt(512))
+	fields := mustScmerSlice(estimate, "cold selectivity estimate")
+	values := make(map[string]int64, len(fields))
+	for _, field := range fields {
+		pair := mustScmerSlice(field, "cold selectivity estimate field")
+		if pair[1].IsInt() {
+			values[scm.String(pair[0])] = int64(scm.ToInt(pair[1]))
+		}
+	}
+	if values["rows"] != 50 || values["sampled"] != 100 || values["input"] != 100 {
+		t.Fatalf("cold selectivity estimate = %v, want rows=50 sampled=100 input=100", values)
+	}
+}
+
 func TestCountEstimateSumsUnevenShards(t *testing.T) {
 	oldShardSize := Settings.ShardSize
 	Settings.ShardSize = 3

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
+import "fmt"
 import "sort"
 import "runtime"
 import "container/heap"
@@ -105,6 +106,7 @@ type scanJoinOrderSpec struct {
 	neutral        scm.Scmer
 	isOuter        bool
 	notFoundValue  scm.Scmer
+	batchedProbe   bool
 }
 
 func scanJoinOrderUsesDriverOrder(spec *scanJoinOrderSpec) bool {
@@ -850,6 +852,218 @@ func scanJoinOrderBatch(currentTx *TxContext, spec *scanJoinOrderSpec, driverRef
 	return filtered
 }
 
+// probeScanJoinOrderInput keeps the ordered side as a compact tuple batch and
+// turns its join keys into mandatory scan_batch index boundaries. Equal driver
+// keys share one physical probe and expand back to every originating tuple, so
+// SQL multiplicity is retained without a query-wide inner record set.
+func probeScanJoinOrderInput(currentTx *TxContext, spec *scanJoinOrderSpec, tuples []*scanJoinOrderTuple, inputIndex int) []*scanJoinOrderTuple {
+	if len(tuples) == 0 {
+		return nil
+	}
+	input := &spec.inputs[inputIndex]
+	keyWidth := len(input.sourceKeyCols)
+	stride := keyWidth
+	batchdata := make([]scm.Scmer, 0, len(tuples)*keyWidth)
+	probeKeys := make([][]scm.Scmer, 0, len(tuples))
+	tupleIndexes := make([][]int, 0, len(tuples))
+	for tupleIndex, tuple := range tuples {
+		key := scanJoinOrderTupleKey(spec, tuple, input.sourceKeyCols, nil)
+		if scanJoinOrderKeyHasNull(key) {
+			continue
+		}
+		probeIndex := -1
+		for index, existing := range probeKeys {
+			if compareProjectKey(existing, key) == 0 {
+				probeIndex = index
+				break
+			}
+		}
+		if probeIndex < 0 {
+			probeIndex = len(probeKeys)
+			probeKeys = append(probeKeys, append([]scm.Scmer(nil), key...))
+			tupleIndexes = append(tupleIndexes, nil)
+			batchdata = append(batchdata, key...)
+		}
+		tupleIndexes[probeIndex] = append(tupleIndexes[probeIndex], tupleIndex)
+	}
+	if len(batchdata) == 0 {
+		return nil
+	}
+
+	conditionCols := append([]string(nil), input.filterCols...)
+	conditionCols = append(conditionCols, input.targetKeyCols...)
+	for keyIndex := 0; keyIndex < keyWidth; keyIndex++ {
+		conditionCols = append(conditionCols, fmt.Sprintf("#%d", keyIndex))
+	}
+	filterProgram := scm.PrepareSerialProc(input.filter)
+	filterWidth := len(input.filterCols)
+	condition := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		if !scm.ToBool(filterProgram.Call(values[:filterWidth])) {
+			return scm.NewBool(false)
+		}
+		for keyIndex := 0; keyIndex < keyWidth; keyIndex++ {
+			left := values[filterWidth+keyIndex]
+			right := values[filterWidth+keyWidth+keyIndex]
+			if left.IsNil() || right.IsNil() || !scm.Equal(left, right) {
+				return scm.NewBool(false)
+			}
+		}
+		return scm.NewBool(true)
+	})
+	required := make(boundaries, keyWidth)
+	for keyIndex, column := range input.targetKeyCols {
+		required[keyIndex] = columnboundaries{
+			col: column, matcher: EqualMatcher,
+			lowerBatch: true, lowerBatchSubidx: keyIndex,
+			upperBatch: true, upperBatchSubidx: keyIndex,
+			lowerInclusive: true, upperInclusive: true, mandatory: true,
+		}
+	}
+
+	callbackCols := append([]string(nil), input.readCols...)
+	for keyIndex := 0; keyIndex < keyWidth; keyIndex++ {
+		callbackCols = append(callbackCols, fmt.Sprintf("#%d", keyIndex))
+	}
+	callback := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewSlice(append([]scm.Scmer(nil), values...))
+	})
+	collect := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewSlice(append(values[0].Slice(), values[1]))
+	})
+	combine := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewSlice(append(values[0].Slice(), values[1].Slice()...))
+	})
+	rows := input.table.scanWithBatchFrom(currentTx, nil, conditionCols, condition,
+		callbackCols, callback, collect, scm.NewSlice(nil), combine, false,
+		stride, batchdata, required).Slice()
+	hits := make([][]*scanJoinOrderRecord, len(tuples))
+	for _, rowValue := range rows {
+		row := rowValue.Slice()
+		key := row[len(input.readCols):]
+		matches := true
+		for keyIndex, column := range input.targetKeyCols {
+			value := row[input.readColIndex[column]]
+			if value.IsNil() || key[keyIndex].IsNil() || !scm.Equal(value, key[keyIndex]) {
+				matches = false
+				break
+			}
+		}
+		if !matches {
+			continue
+		}
+		probeIndex := -1
+		for index, existing := range probeKeys {
+			if compareProjectKey(existing, key) == 0 {
+				probeIndex = index
+				break
+			}
+		}
+		if probeIndex < 0 {
+			continue
+		}
+		record := &scanJoinOrderRecord{values: row[:len(input.readCols)]}
+		for _, tupleIndex := range tupleIndexes[probeIndex] {
+			hits[tupleIndex] = append(hits[tupleIndex], record)
+		}
+	}
+
+	result := make([]*scanJoinOrderTuple, 0, len(tuples))
+	for tupleIndex, tuple := range tuples {
+		for _, record := range hits[tupleIndex] {
+			records := make([]*scanJoinOrderRecord, len(tuple.records)+1)
+			copy(records, tuple.records)
+			records[len(tuple.records)] = record
+			result = append(result, &scanJoinOrderTuple{records: records, order: tuple.order})
+		}
+	}
+	return result
+}
+
+func scanJoinOrderBatchedProbe(currentTx *TxContext, spec scanJoinOrderSpec) scm.Scmer {
+	prepareScanJoinOrderSpec(&spec)
+	if spec.limit == 0 {
+		return spec.notFoundValue
+	}
+	// Probe hits have no stable record handle after the batched scan returns.
+	// Read the narrow final projection with the hit and keep the later mapper
+	// allocation-free for the small LIMIT window.
+	for inputIndex := 1; inputIndex < len(spec.inputs); inputIndex++ {
+		input := &spec.inputs[inputIndex]
+		for _, column := range input.lateMapCols {
+			input.readCols, input.readColIndex = appendScanJoinColumn(input.readCols, input.readColIndex, column)
+		}
+		input.lateMapCols = nil
+		input.lateMapIndex = nil
+	}
+	driverSortCols := make([]scm.Scmer, len(spec.orderCols))
+	for index, ref := range spec.orderCols {
+		driverSortCols[index] = scm.NewString(ref.column)
+	}
+	result := spec.neutral
+	driverOffset := 0
+	accepted := 0
+	emitted := 0
+	hadValue := false
+	target := spec.offset + spec.limit
+	batchSize := target
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	for accepted < target {
+		driverRefs := collectScanJoinOrderRecords(currentTx, &spec.inputs[0], driverSortCols,
+			spec.orderDirs, driverOffset, batchSize, nil, scm.NewNil())
+		if len(driverRefs) == 0 {
+			break
+		}
+		driver := materializeScanJoinRecords(currentTx, &spec.inputs[0], driverRefs)
+		tuples := make([]*scanJoinOrderTuple, len(driver))
+		for index, record := range driver {
+			tuples[index] = &scanJoinOrderTuple{records: []*scanJoinOrderRecord{record}, order: index}
+		}
+		for inputIndex := 1; inputIndex < len(spec.inputs) && len(tuples) > 0; inputIndex++ {
+			tuples = probeScanJoinOrderInput(currentTx, &spec, tuples, inputIndex)
+		}
+		if !spec.joinFilter.IsNil() && len(tuples) > 0 {
+			filterProgram := scm.PrepareSerialProc(spec.joinFilter)
+			filtered := tuples[:0]
+			for _, tuple := range tuples {
+				args := scanJoinOrderTupleValues(&spec, tuple, spec.joinFilterCols, nil)
+				if scm.ToBool(filterProgram.Call(args)) {
+					filtered = append(filtered, tuple)
+				}
+			}
+			tuples = filtered
+		}
+		first := 0
+		if accepted < spec.offset {
+			first = min(len(tuples), spec.offset-accepted)
+		}
+		accepted += len(tuples)
+		last := len(tuples)
+		if last-first > spec.limit-emitted {
+			last = first + spec.limit - emitted
+		}
+		var batchHadValue bool
+		result, batchHadValue = reduceScanJoinOrderTuples(currentTx, &spec, tuples[first:last], result, &emitted)
+		hadValue = hadValue || batchHadValue
+		if emitted >= spec.limit {
+			break
+		}
+		driverOffset += len(driverRefs)
+		if len(driverRefs) < batchSize {
+			break
+		}
+		batchSize *= 2
+	}
+	if !hadValue && spec.isOuter {
+		return scanJoinOrderOuterResult(&spec, result)
+	}
+	if !hadValue {
+		return spec.notFoundValue
+	}
+	return result
+}
+
 func scanJoinOrderMaterialized(currentTx *TxContext, spec scanJoinOrderSpec) scm.Scmer {
 	prepareScanJoinOrderSpec(&spec)
 	if spec.limit == 0 {
@@ -1260,6 +1474,9 @@ func collectTopKScanJoinOrderTuples(spec *scanJoinOrderSpec, runnerResults [][]*
 
 func scanJoinOrder(currentTx *TxContext, spec scanJoinOrderSpec) scm.Scmer {
 	if spec.limit >= 0 && scanJoinOrderUsesDriverOrder(&spec) {
+		if spec.batchedProbe {
+			return scanJoinOrderBatchedProbe(currentTx, spec)
+		}
 		return scanJoinOrderMaterialized(currentTx, spec)
 	}
 	prepareScanJoinOrderSpec(&spec)
@@ -1438,6 +1655,7 @@ func declareScanJoinOrder(en *scm.Env) {
 			if len(a) > 18 {
 				notFoundValue = a[18]
 			}
+			batchedProbe := len(a) > 19 && scm.ToBool(a[19])
 			return scanJoinOrder(scmerToTxContext(a[0]), scanJoinOrderSpec{
 				inputs:             decodeScanJoinOrderInputs(tables, a[2], a[3], a[4]),
 				joinFilterCols:     decodeScanJoinOrderColumns(a[5], "joinFilterColumns"),
@@ -1454,6 +1672,7 @@ func declareScanJoinOrder(en *scm.Env) {
 				neutral:            neutral,
 				isOuter:            isOuter,
 				notFoundValue:      notFoundValue,
+				batchedProbe:       batchedProbe,
 			})
 		},
 		Type: &scm.TypeDescriptor{
@@ -1480,6 +1699,7 @@ func declareScanJoinOrder(en *scm.Env) {
 				{Kind: "func|nil", Label: "reduce2", Description: "optional global second-stage reducer combining runner-local reduce results; permitted only with offset 0 and unlimited limit -1", Optional: true},
 				{Kind: "bool", Label: "isOuter", Description: "optional whole-scan NULL fallback", Optional: true},
 				{Kind: "any", Label: "notFoundValue", Description: "optional result when no joined row is emitted", Optional: true},
+				{Kind: "bool", Label: "batchedProbe", Description: "probe inner equality indexes from growing ordered-driver batches instead of materializing inner inputs", Optional: true},
 			},
 			Return:   &scm.TypeDescriptor{Kind: "any"},
 			Optimize: optimizeScanJoinOrder,

--- a/storage/scan_join_order_test.go
+++ b/storage/scan_join_order_test.go
@@ -83,6 +83,7 @@ func TestScanJoinOrderFiltersJoinsAndBrakesInDriverOrder(t *testing.T) {
 		reduceFn:      reduceFn,
 		neutral:       scm.NewNil(),
 		notFoundValue: scm.NewNil(),
+		batchedProbe:  true,
 	})
 
 	want := [][2]int64{{5, 101}, {3, 100}, {3, 101}}

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1334,7 +1334,9 @@ func (t *storageShard) scan_order(boundaries boundaries, lower []scm.Scmer, uppe
 		var survivedBuf, mainIdsBuf, acceptMainIdsBuf []uint32
 		colBufs := make([][]scm.Scmer, len(conditionCols))
 		acceptColBufs := make([][]scm.Scmer, len(acceptCols))
-		t.iterateIndexOrdered(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, usageWeight, limit, func(index *StorageIndex, active bool) {
+		boundaryCoveredLimit := acceptProgram == nil &&
+			sortedBoundariesCoverCondition(conditionCols, condition, boundaries)
+		t.iterateIndexOrdered(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, usageWeight, limit, boundaryCoveredLimit, func(index *StorageIndex, active bool) {
 			if len(sortcols) > 0 {
 				resultAlreadySorted = indexCoversBoundaryOrder(index, active, boundaries, len(lower))
 			}

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -44,3 +44,89 @@ func TestExtendBoundariesRejectsPartiallyCoveredOrder(t *testing.T) {
 		t.Fatalf("partial ORDER BY coverage changed boundaries: got %d, want %d", len(got), len(original))
 	}
 }
+
+func TestCoveredOrderedLimitBrakesInsideIndexBatch(t *testing.T) {
+	const rows = 4096
+	const limit = 20
+	tbl := setupScanParallelTestTable(t, "tcoveredorderedlimit")
+	tbl.CreateColumn("bucket", "VARCHAR(16)", nil, nil)
+	tbl.CreateColumn("rank", "INT", nil, nil)
+	values := make([][]scm.Scmer, rows)
+	for i := range values {
+		values[i] = []scm.Scmer{
+			scm.NewInt(int64(i)),
+			scm.NewString("target"),
+			scm.NewInt(int64(i)),
+		}
+	}
+	tbl.Insert([]string{"id", "bucket", "rank"}, values, nil, scm.NewNil(), false, nil)
+	RebuildTable(tbl, true, false)
+
+	equalSymbol := scm.Symbol("equal?")
+	equalFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
+		return scm.NewBool(scm.Equal(values[0], values[1]))
+	})
+	condition := buildProc([]string{"bucket"}, scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal?"),
+		scm.NewSymbol("bucket"),
+		scm.NewString("target"),
+	}))
+	condition.Proc().En.Vars[equalSymbol] = equalFn
+	_, order := integerOrder(false)
+	bounds := extractBoundaries([]string{"bucket"}, condition)
+	var covered bool
+	bounds, covered = extendBoundariesWithSortCols(bounds,
+		[]scm.Scmer{scm.NewString("rank")}, []func(...scm.Scmer) scm.Scmer{order})
+	if !covered {
+		t.Fatal("bucket/rank index does not cover ORDER BY")
+	}
+	lower, upper := indexFromBoundaries(bounds)
+	shard := tbl.ActiveShards()[0]
+	shard.mu.RLock()
+	var buildBuf [8]uint32
+	shard.iterateIndexForce(nil, bounds, lower, upper, len(shard.inserts), buildBuf[:], false,
+		func([]uint32) bool { return false })
+	shard.mu.RUnlock()
+	run := func(acceptCols []string, accept scm.Scmer) *shardqueue {
+		return shard.scan_order(bounds, lower, upper,
+			[]string{"bucket"}, condition, acceptCols, accept,
+			[]scm.Scmer{scm.NewString("rank")}, []func(...scm.Scmer) scm.Scmer{order},
+			0, 0, limit, nil, nil, nil)
+	}
+	queue := run(nil, scm.NewNil())
+	if queue.candidateCount != limit {
+		t.Fatalf("covered ordered LIMIT examined %d candidates, want %d",
+			queue.candidateCount, limit)
+	}
+
+	// An additional acceptance predicate can still reject index matches, so it
+	// must retain the ordinary scan batch instead of claiming full coverage.
+	acceptAll := buildProc([]string{"bucket"}, scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal?"),
+		scm.NewSymbol("bucket"),
+		scm.NewString("target"),
+	}))
+	acceptAll.Proc().En.Vars[equalSymbol] = equalFn
+	queue = run([]string{"bucket"}, acceptAll)
+	if queue.candidateCount <= limit {
+		t.Fatalf("acceptance predicate incorrectly used covered LIMIT batch: %d candidates",
+			queue.candidateCount)
+	}
+
+	// Visibility is checked after index iteration. A short covered batch may be
+	// refilled, but must still return LIMIT live rows after deleted entries.
+	shard.mu.Lock()
+	for recid := uint(0); recid < 5; recid++ {
+		shard.deletions.Set(recid, true)
+	}
+	shard.mu.Unlock()
+	queue = run(nil, scm.NewNil())
+	if len(queue.items) != limit {
+		t.Fatalf("covered ordered LIMIT returned %d live rows after deletions, want %d",
+			len(queue.items), limit)
+	}
+	if queue.candidateCount <= limit {
+		t.Fatalf("covered ordered LIMIT did not refill deleted candidates: examined %d",
+			queue.candidateCount)
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -852,7 +852,11 @@ func Init(en scm.Env) {
 				if shard == nil {
 					continue
 				}
-				estimate := shard.EstimateFilteredRows(conditionCols, condition, limit, currentTx)
+				estimate := func() filteredRowEstimate {
+					release := shard.GetRead()
+					defer release()
+					return shard.EstimateFilteredRows(conditionCols, condition, limit, currentTx)
+				}()
 				if estimate.examined == 0 {
 					continue
 				}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1340,7 +1340,7 @@ func Init(en scm.Env) {
 			if len(a) > layout.reduce2Idx+sbShift {
 				reduce2 = a[layout.reduce2Idx+sbShift]
 			}
-			return t.scanWithBatchFrom(layout.tx, source, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter, stride, batchdata)
+			return t.scanWithBatchFrom(layout.tx, source, filtercols, a[layout.filterFnIdx], mapcols, a[layout.mapFnIdx], aggregate, neutral, reduce2, isOuter, stride, batchdata, nil)
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "does an unordered parallel filter-map-reduce pass on a single table using batchdata-backed #N pseudo columns and returns the reduced result",
 			Params: []*scm.TypeDescriptor{

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -42,7 +42,7 @@ test_cases:
   - name: "WordPress filtered postmeta join ordered by newest post"
     warmup: 2
     timing_samples: 5
-    threshold_ms: 14
+    threshold_ms: 6
     sql: |
       SELECT p.ID, p.post_title, pm.meta_value
       FROM wordpress_perf_posts p
@@ -68,7 +68,7 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "chosen scan_join_order"
+        - "chosen scan_join_order_batched_probe"
         - "scan_join_order"
         - "legacy_join_tree"
 
@@ -90,7 +90,7 @@ test_cases:
       result_not_contains:
         - '(join_driver \"p\")'
 
-  - name: "WordPress handwritten equivalent-driver scan_join_order"
+  - name: "WordPress handwritten equivalent-driver batched scan_join_order"
     warmup: 2
     timing_samples: 5
     threshold_ms: 8
@@ -113,7 +113,7 @@ test_cases:
             0 0 20
             (list (list 1 "ID") (list 1 "post_title") (list 0 "meta_value"))
             (lambda (_id _title _value) 1)
-            + 0))
+            + 0 nil false 0 true))
         (if (equal? found 20) "ok"
           (error "wrong WordPress scan_join_order row count")))
     expect:

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -1,0 +1,124 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+
+metadata:
+  version: "1.0"
+  description: "WordPress posts and postmeta filtered join with ordered Top-K"
+  isolated: true
+  ci: true
+  restart_after_setup: true
+
+# Reproduces the common WordPress shape which filters postmeta by key, joins
+# matching posts, and returns the newest small page. The cardinalities and
+# distributions match the wordpress2 installation used for the MariaDB A/B.
+setup:
+  - sql: "DROP TABLE IF EXISTS wordpress_perf_postmeta"
+  - sql: "DROP TABLE IF EXISTS wordpress_perf_posts"
+  - sql: "CREATE TABLE wordpress_perf_posts (ID BIGINT PRIMARY KEY, post_title VARCHAR(64), post_status VARCHAR(20), post_type VARCHAR(20)) ENGINE=sloppy"
+  - sql: "CREATE TABLE wordpress_perf_postmeta (meta_id BIGINT PRIMARY KEY, post_id BIGINT, meta_key VARCHAR(255), meta_value VARCHAR(64)) ENGINE=sloppy"
+  - scm: |
+      (insert (table "memcp-tests" "wordpress_perf_posts")
+        '("ID" "post_title" "post_status" "post_type")
+        (map (produceN 8214) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (list id (concat "Benchmark Post " (string id))
+              (if (equal? (mod id 20) 0) "draft" "publish") "post")))))
+  - scm: |
+      (insert (table "memcp-tests" "wordpress_perf_postmeta")
+        '("meta_id" "post_id" "meta_key" "meta_value")
+        (map (produceN 75000) (lambda (i)
+          (begin
+            (define id (+ i 1))
+            (define key_mod (mod i 5))
+            (list id (+ 1 (mod i 8214))
+              (if (equal? key_mod 0) "_edit_lock"
+                (if (equal? key_mod 1) "_thumbnail_id"
+                  (if (equal? key_mod 2) "_yoast_wpseo_title"
+                    (if (equal? key_mod 3) "custom_color" "view_count"))))
+              (concat "meta-value-" (string id)))))))
+  - scm: "(rebuild)"
+
+test_cases:
+  - name: "WordPress filtered postmeta join ordered by newest post"
+    warmup: 2
+    timing_samples: 5
+    threshold_ms: 14
+    sql: |
+      SELECT p.ID, p.post_title, pm.meta_value
+      FROM wordpress_perf_posts p
+      JOIN wordpress_perf_postmeta pm ON pm.post_id = p.ID
+      WHERE p.post_type = 'post'
+        AND p.post_status = 'publish'
+        AND pm.meta_key = 'custom_color'
+      ORDER BY p.ID DESC
+      LIMIT 20
+    expect: {rows: 20}
+
+  - name: "WordPress filtered postmeta join physical plan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT p.ID, p.post_title, pm.meta_value
+      FROM wordpress_perf_posts p
+      JOIN wordpress_perf_postmeta pm ON pm.post_id = p.ID
+      WHERE p.post_type = 'post'
+        AND p.post_status = 'publish'
+        AND pm.meta_key = 'custom_color'
+      ORDER BY p.ID DESC
+      LIMIT 20
+    expect:
+      rows: 1
+      result_contains:
+        - "chosen scan_join_order"
+        - "scan_join_order"
+        - "legacy_join_tree"
+
+  - name: "WordPress ordered join uses the equivalent postmeta driver"
+    sql: |
+      EXPLAIN REORDER
+      SELECT p.ID, p.post_title, pm.meta_value
+      FROM wordpress_perf_posts p
+      JOIN wordpress_perf_postmeta pm ON pm.post_id = p.ID
+      WHERE p.post_type = 'post'
+        AND p.post_status = 'publish'
+        AND pm.meta_key = 'custom_color'
+      ORDER BY p.ID DESC
+      LIMIT 20
+    expect:
+      rows: 1
+      result_contains:
+        - '(join_driver \"pm\")'
+      result_not_contains:
+        - '(join_driver \"p\")'
+
+  - name: "WordPress handwritten equivalent-driver scan_join_order"
+    warmup: 2
+    timing_samples: 5
+    threshold_ms: 8
+    scm: |
+      (begin
+        (define posts (table "memcp-tests" "wordpress_perf_posts"))
+        (define postmeta (table "memcp-tests" "wordpress_perf_postmeta"))
+        (define found
+          (scan_join_order (session "__memcp_tx")
+            (list postmeta posts)
+            (list (list "meta_key") (list "post_type" "post_status"))
+            (list
+              (lambda (meta_key) (equal?? meta_key "custom_color"))
+              (lambda (post_type post_status)
+                (and (equal?? post_type "post") (equal?? post_status "publish"))))
+            (list (list (list 0 "post_id" "ID")))
+            (list) nil
+            (list (list 0 "post_id"))
+            (list (collate "utf8mb4" true))
+            0 0 20
+            (list (list 1 "ID") (list 1 "post_title") (list 0 "meta_value"))
+            (lambda (_id _title _value) 1)
+            + 0))
+        (if (equal? found 20) "ok"
+          (error "wrong WordPress scan_join_order row count")))
+    expect:
+      data: ["ok"]
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS wordpress_perf_postmeta"
+  - sql: "DROP TABLE IF EXISTS wordpress_perf_posts"

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -816,6 +816,19 @@ type calibrationVariantResult struct {
 	err     error
 }
 
+func growingBatchInvocations(rows, batch float64) float64 {
+	if batch < 1 {
+		batch = 1
+	}
+	invocations := 0.0
+	for rows > 0 {
+		rows -= batch
+		batch *= 2
+		invocations++
+	}
+	return invocations
+}
+
 func discoverCalibrationDecision(server *memcpServer, query, decisionName string) (*calibrationDiscovery, map[string]*float64, error) {
 	discoveryPayload, err := server.execute("/sql/"+database,
 		"EXPLAIN PHYSICAL CALIBRATE DISCOVER\n"+query, 10*time.Minute)
@@ -1278,9 +1291,11 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			features[23] = *row.JoinInputRows
 			features[24] = *row.JoinProbeRows
 		} else if row.Plan == "scan_join_order_batched_probe" {
-			if row.JoinDriverRows == nil {
+			if row.JoinDriverRows == nil || row.Limit == nil || row.Offset == nil {
 				return nil, fmt.Errorf("ordered batched probe profile has nil driver rows: %+v", row)
 			}
+			features[0] = *row.JoinTableCount * growingBatchInvocations(
+				*row.JoinDriverRows, *row.Limit+*row.Offset)
 			features[1] = *row.JoinDriverRows
 			features[4] = *row.JoinOutputRows
 			features[22] = 1

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -1277,6 +1277,15 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 			features[22] = 1
 			features[23] = *row.JoinInputRows
 			features[24] = *row.JoinProbeRows
+		} else if row.Plan == "scan_join_order_batched_probe" {
+			if row.JoinDriverRows == nil {
+				return nil, fmt.Errorf("ordered batched probe profile has nil driver rows: %+v", row)
+			}
+			features[1] = *row.JoinDriverRows
+			features[4] = *row.JoinOutputRows
+			features[22] = 1
+			features[23] = *row.JoinDriverRows
+			features[24] = *row.JoinDriverRows * (*row.JoinTableCount - 1)
 		} else if row.Plan == "legacy_join_tree" {
 			if row.JoinLegacyProbeRows == nil {
 				return nil, fmt.Errorf("ordered legacy join profile has nil probe rows: %+v", row)
@@ -2002,7 +2011,7 @@ func decisionAlternatives(rows []observation) (map[string]map[string]observation
 		switch row.plan {
 		case "candidate_keyset", "driver_order_membership_probe", "driver_filter_join_probe", "ordered_batch_accept", "prefiltered_candidate_keyset":
 			groups[row.caseName][row.plan] = row
-		case "legacy_join_tree", "scan_join_order":
+		case "legacy_join_tree", "scan_join_order", "scan_join_order_batched_probe":
 			if row.decision != "scan_join_order" {
 				return nil, fmt.Errorf("plan %q belongs to scan_join_order, got decision %q", row.plan, row.decision)
 			}

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -171,6 +171,8 @@ type calibrationRow struct {
 	DriverExpressionOperations       *float64 `json:"driver_expression_operations"`
 	DriverExpressionDepth            *float64 `json:"driver_expression_depth"`
 	JoinInputRows                    *float64 `json:"join_input_rows"`
+	JoinDriverRows                   *float64 `json:"join_driver_rows"`
+	JoinInnerRows                    *float64 `json:"join_inner_rows"`
 	JoinEstimatedRows                *float64 `json:"join_estimated_rows"`
 	JoinOutputRows                   *float64 `json:"join_output_rows"`
 	JoinTableCount                   *float64 `json:"join_table_count"`
@@ -1054,7 +1056,7 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 		return fmt.Errorf("forced race variant has incomplete measurements: %+v", row)
 	}
 	if row.Decision == "scan_join_order" {
-		if row.JoinInputRows == nil || row.JoinEstimatedRows == nil ||
+		if row.JoinInputRows == nil || row.JoinDriverRows == nil || row.JoinInnerRows == nil || row.JoinEstimatedRows == nil ||
 			row.JoinOutputRows == nil || row.JoinTableCount == nil || row.JoinLegacyProbeRows == nil {
 			return fmt.Errorf("ordered join variant has incomplete measurements: %+v", row)
 		}
@@ -1248,7 +1250,7 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 		return features, nil
 	}
 	if row.Decision == "scan_join_order" {
-		if row.JoinInputRows == nil || row.JoinEstimatedRows == nil ||
+		if row.JoinInputRows == nil || row.JoinDriverRows == nil || row.JoinInnerRows == nil || row.JoinEstimatedRows == nil ||
 			row.JoinOutputRows == nil || row.JoinTableCount == nil {
 			return nil, fmt.Errorf("ordered join work profile contains nil inputs: %+v", row)
 		}

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -473,12 +473,13 @@ func TestDecisionAlternativesAcceptsOrderedJoinFamily(t *testing.T) {
 	rows := []observation{
 		{caseName: "join", decision: "scan_join_order", plan: "legacy_join_tree"},
 		{caseName: "join", decision: "scan_join_order", plan: "scan_join_order"},
+		{caseName: "join", decision: "scan_join_order", plan: "scan_join_order_batched_probe"},
 	}
 	groups, err := decisionAlternatives(rows)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(groups["join"]) != 2 {
+	if len(groups["join"]) != 3 {
 		t.Fatalf("unexpected ordered join alternatives: %+v", groups)
 	}
 }

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -484,6 +484,23 @@ func TestDecisionAlternativesAcceptsOrderedJoinFamily(t *testing.T) {
 	}
 }
 
+func TestOrderedJoinBatchedProbeCountsGrowingScanInvocations(t *testing.T) {
+	value := func(v float64) *float64 { return &v }
+	row := calibrationRow{
+		Decision: "scan_join_order", Plan: "scan_join_order_batched_probe",
+		JoinInputRows: value(28192), JoinDriverRows: value(2560), JoinProbeRows: value(20000),
+		JoinEstimatedRows: value(1), JoinOutputRows: value(1), JoinMapWidth: value(4),
+		JoinTableCount: value(2), Limit: value(5), Offset: value(0),
+	}
+	features, err := rowFeatures(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if features[0] != 20 {
+		t.Fatalf("batched scan invocations = %v, want 20", features[0])
+	}
+}
+
 func TestValidateDecisionOrderingUsesOrderedJoinCostBoundary(t *testing.T) {
 	legacy := func(name string, measured, estimated float64) observation {
 		return observation{

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -116,6 +116,7 @@ func TestRowFeaturesModelsOrderedJoinAlternatives(t *testing.T) {
 	value := func(v float64) *float64 { return &v }
 	base := calibrationRow{
 		Decision: "scan_join_order", JoinInputRows: value(25_000),
+		JoinDriverRows: value(10_000), JoinInnerRows: value(15_000),
 		JoinEstimatedRows: value(4_000), JoinOutputRows: value(72),
 		JoinTableCount: value(2), JoinLegacyProbeRows: value(600),
 	}


### PR DESCRIPTION
What

- Proves when every ordered-scan predicate is covered by sorted index boundaries.
- Shrinks active, order-compatible index batches to LIMIT so braking happens inside the index walk.
- Preserves ordinary batching for residual acceptance predicates and refills across deleted rows.
- Avoids a redundant HTTP with_session frame for ordinary request-local sessions.

Why

The WordPress posts/postmeta ORDER BY ... LIMIT 20 plan selected the right batched join but still materialized 1024 index candidates per shard. A fully covered active ordered index can safely emit LIMIT-sized batches and stop after the first qualifying prefix.

Measurements

Fixture: 8,214 posts, 75,000 postmeta rows, two warmups, five timed samples.

| Measurement | Before this PR | This PR | Change |
| --- | ---: | ---: | ---: |
| Warm SQL query, local runner | about 3.6 ms | 2.6 ms | about -27.8%, 1.38x faster |
| Ordered driver candidates | 2,048 total, 1,024 per shard | 40 total, 20 per shard | -98.0% |
| MariaDB reference | 0.425 ms | 0.425 ms | remaining local gap about 6.1x |

The earlier 30.8x gap was already reduced by the planner and batched-join commits merged in PR #659. This PR reduces the remaining local gap from about 8.5x to about 6.1x. These are warm-plan measurements; MemCP's query-plan cache was warmed before timed samples.

The clean CPU profile attributes roughly 0.4–0.5 ms per query to the index work after this change. The largest remaining cost is Scheme/GLS request-context lookup, including roughly 1 ms per query for the two deep context stack walks. Reaching a stable sub-millisecond result therefore requires removing those dynamic context lookups rather than further changing the join or ORDER/LIMIT operator.

CI master-versus-PR performance result: pending. The performance-ab job will provide the authoritative regression gate and will be added here when complete.

Verification

- Focused storage proof and coverage tests.
- Acceptance-filter batching and deleted-row refill regression tests.
- WordPress performance needle.
- Range-scan coverage: 113/113.
- Native ORDER/LIMIT: 11/11.
- Partitioned ORDER/LIMIT: 5/5.
- Transaction session coverage: 204/204.

Full regression and master-versus-PR performance validation are delegated to CI.
