### PR TITLE
perf: pass query execution context explicitly

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -6442,7 +6442,7 @@ the costgen threshold. */
 							(list (quote lambda) (list (quote __group_cache_build_session))
 								(list (quote with_session) (quote __group_cache_build_session)
 									(list (quote lambda) '()
-										(list (quote with_autocommit) (quote __group_cache_build_session)
+										(list (quote with_autocommit) (quote __group_cache_build_session) nil
 											(list (quote lambda) '()
 												(list (quote !begin)
 													(direct_group_join_eval_prepare_recipe_expr stage)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -436,6 +436,13 @@ On parse error the result is not cached. */
 					(cadr cached_entry))))
 			formula)))))
 
+/* The frontend already owns the executing session and request identity. Pass
+them to with_autocommit so transaction setup does not rediscover either value
+through goroutine-local context lookups. */
+(define sql_execute_formula (lambda (session execution_context formula resultrow)
+	(with_autocommit session execution_context
+		(lambda () (eval (source "SQL Query" 1 1 formula))))))
+
 /* helper: build a policy function for table-level access checks
 usage: create a policy by (set policy (sql_policy "username")),
 then you can query the policy by
@@ -620,6 +627,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					(define resultrow (res "jsonl"))
 					/* Use persistent session if X-Session-Id header is present */
 					(define session_id ((req "header") "X-Session-Id"))
+					(define execution_context (req "__execution_context"))
 					(define session (if session_id
 						(begin
 							(define existing (http_sessions session_id))
@@ -629,7 +637,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 								new_sess
 							))
 						)
-						(context "session")
+						(req "__session")
 					))
 					(session "username" (req "username"))
 					(session "schema" schema)
@@ -646,8 +654,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					the legacy persistent X-Session-Id map can select a different session;
 					avoid a second goroutine-stack lookup for ordinary autocommit queries. */
 					(define execute_formula (lambda ()
-						(with_autocommit session (lambda ()
-							(eval (source "SQL Query" 1 1 formula))))))
+						(sql_execute_formula session execution_context formula resultrow)))
 					(set query_result (if session_id
 						(with_session session execute_formula)
 						(execute_formula)))
@@ -678,7 +685,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 				(try (lambda () (time (begin
 					((res "header") "Content-Type" "text/plain")
 					(define resultrow (res "jsonl"))
-					(define session (context "session"))
+					(define session (req "__session"))
+					(define execution_context (req "__execution_context"))
 					(session "username" (req "username"))
 					(session "schema" schema)
 					(set resultrow_called false)
@@ -706,7 +714,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						before parse/build so session-sensitive planner rewrites see the right values. */
 						(extract_assoc (req "query") (lambda (k v) (session k v)))
 						(define formula (cached_parse psql_queryplan_cache parse_psql schema query (sql_policy (req "username")) (req "username") session false))
-						(with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula))))
+						(sql_execute_formula session execution_context formula resultrow)
 					)))
 					/* If no resultrow was called and we got a number, return it as affected_rows */
 					(if (and (not resultrow_called) (number? query_result)) (begin
@@ -801,7 +809,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
 (set mysql_auth (lambda (username_) (scan nil (table "system" "user") '("username") (lambda (username) (equal? username username_)) '("password") (lambda (password) password) (lambda (a b) b) nil)))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
-(set mysql_handler (lambda (schema sql resultrow_sql session) (begin
+(set mysql_handler (lambda (schema sql resultrow_sql session execution_context) (begin
 	(session "schema" schema)
 	(define resultrow resultrow_sql)
 	(try (lambda () (begin
@@ -818,7 +826,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 				(define formula (if (equal? (session "syntax") "postgresql")
 					(cached_parse psql_queryplan_cache parse_psql schema sql_parse_input (sql_policy mysql_username) mysql_username session false)
 					(cached_parse sql_queryplan_cache parse_sql schema sql_parse_input (sql_policy mysql_username) mysql_username session true)))
-				(with_autocommit session (lambda () (eval (source "SQL Query" 1 1 formula))))
+				(sql_execute_formula session execution_context formula resultrow)
 			) sql))
 	)) (lambda (e) (begin
 			(error_log (concat e) schema (coalesce (session "username") "root") sql)

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -463,7 +463,8 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			"querySeq":        querySeq,
 			"context":         queryCtx,
 		}, func() {
-			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, scmSessionScmer)
+			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, scmSessionScmer,
+				NewAny(&QueryExecutionContext{SessionState: ss, QuerySeq: querySeq}))
 		})
 		return rc
 	}()

--- a/scm/network.go
+++ b/scm/network.go
@@ -315,6 +315,13 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	ss.SetQueryContext(querySeq, ctx)
 	defer cancel()
 	defer ss.EndQuery(querySeq, "Sleep", "")
+	scmSession := ss.GetOrCreateScmSession()
+	req_scm = append(req_scm,
+		NewString("__session"),
+		scmSession,
+		NewString("__execution_context"),
+		NewAny(&QueryExecutionContext{SessionState: ss, QuerySeq: querySeq}),
+	)
 	// Watch for HTTP client disconnect and propagate to session kill
 	reqDone := make(chan struct{})
 	defer close(reqDone)
@@ -325,34 +332,32 @@ func (s *HttpServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		case <-reqDone:
 		}
 	}(querySeq)
-	SetValues(map[string]any{"sessionStatePtr": ss, "querySeq": querySeq}, func() {
-		contextFn := func() {
-			// catch panics and print out 500 Internal Server Error
-			defer func() {
-				if r := recover(); r != nil {
-					if fmt.Sprint(r) != "websocket closed" {
-						PrintError("error in http handler: " + fmt.Sprint(r))
-					}
-					// try to write error response; silently ignore if connection was hijacked (e.g. websocket)
-					func() {
-						defer func() { recover() }()
-						res.Header().Set("Content-Type", "text/plain")
-						res.WriteHeader(500)
-						io.WriteString(res, "500 Internal Server Error: ")
-						io.WriteString(res, fmt.Sprint(r))
-					}()
+	contextFn := func() {
+		// catch panics and print out 500 Internal Server Error
+		defer func() {
+			if r := recover(); r != nil {
+				if fmt.Sprint(r) != "websocket closed" {
+					PrintError("error in http handler: " + fmt.Sprint(r))
 				}
-			}()
-			Apply(s.callback, NewSlice(req_scm), NewSlice(res_scm))
-		}
-		// Persistent HTTP sessions reuse the same Scheme session so that
-		// @variables set in one request are visible in subsequent requests.
-		if req.Header.Get("X-Session-Id") != "" {
-			NewContextWithSession(ctx, ss.GetOrCreateScmSession(), contextFn)
-		} else {
-			NewContext(ctx, contextFn)
-		}
-	})
+				// try to write error response; silently ignore if connection was hijacked (e.g. websocket)
+				func() {
+					defer func() { recover() }()
+					res.Header().Set("Content-Type", "text/plain")
+					res.WriteHeader(500)
+					io.WriteString(res, "500 Internal Server Error: ")
+					io.WriteString(res, fmt.Sprint(r))
+				}()
+			}
+		}()
+		Apply(s.callback, NewSlice(req_scm), NewSlice(res_scm))
+	}
+	// Persistent HTTP sessions reuse the same Scheme session so that
+	// @variables set in one request are visible in subsequent requests. Install
+	// process-list state in the same GLS frame for both session lifetimes.
+	NewContextWithSession(ctx, scmSession, map[string]any{
+		"sessionStatePtr": ss,
+		"querySeq":        querySeq,
+	}, contextFn)
 }
 
 func scmerToGo(v Scmer) any {

--- a/scm/network_test.go
+++ b/scm/network_test.go
@@ -47,3 +47,28 @@ func TestHTTPSQLBodyUpdatesProcesslistInfo(t *testing.T) {
 		t.Fatalf("expected processlist info %q, got %q", query, observed)
 	}
 }
+
+func TestHTTPRequestCarriesExecutionContextInSingleSessionFrame(t *testing.T) {
+	server := &HttpServer{callback: NewFunc(func(a ...Scmer) Scmer {
+		request := a[0]
+		session := Apply(request, NewString("__session"))
+		executionContext, ok := Apply(request, NewString("__execution_context")).Any().(*QueryExecutionContext)
+		if !ok {
+			t.Fatal("expected typed query execution context")
+		}
+		if executionContext.SessionState != GetCurrentSessionState() {
+			t.Fatal("request and goroutine-local session state differ")
+		}
+		if executionContext.QuerySeq != CurrentQuerySeq() {
+			t.Fatal("request and goroutine-local query sequence differ")
+		}
+		if session != executionContext.SessionState.GetOrCreateScmSession() {
+			t.Fatal("request and process-list Scheme sessions differ")
+		}
+		return NewNil()
+	})}
+	req := httptest.NewRequest("POST", "/sql/database", strings.NewReader("SELECT 1"))
+	res := httptest.NewRecorder()
+
+	server.ServeHTTP(res, req)
+}

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -59,6 +59,15 @@ type SessionState struct {
 
 }
 
+// QueryExecutionContext carries request-local state across the Scheme SQL
+// boundary without rediscovering it through goroutine-local stack inspection.
+// The transaction itself remains owned by storage and is attached by
+// with_autocommit after the executing Scheme session has been selected.
+type QueryExecutionContext struct {
+	SessionState *SessionState
+	QuerySeq     uint64
+}
+
 // GetOrCreateScmSession returns the persistent Scheme session for this SessionState,
 // creating it on first call. Used by HTTP sessions to persist @variables across requests.
 func (s *SessionState) GetOrCreateScmSession() Scmer {

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -404,17 +404,21 @@ func NewContext(ctx context.Context, fn func()) {
 	}, fn)
 }
 
-// NewContextWithSession is like NewContext but uses a pre-existing Scheme session
-// instead of creating a fresh one. Used by persistent HTTP sessions so that
-// @variables set in one request are visible in subsequent requests.
-func NewContextWithSession(ctx context.Context, session Scmer, fn func()) {
+// NewContextWithSession installs a pre-existing Scheme session and any
+// request-local values in one GLS frame. Keeping one frame avoids repeating
+// goroutine stack tagging for every HTTP request.
+func NewContextWithSession(ctx context.Context, session Scmer, values map[string]any, fn func()) {
 	if mgr == nil {
 		mgr = gls.NewContextManager()
 	}
-	mgr.SetValues(gls.Values{
+	glsValues := gls.Values{
 		"session": session,
 		"context": ctx,
-	}, fn)
+	}
+	for key, value := range values {
+		glsValues[key] = value
+	}
+	mgr.SetValues(glsValues, fn)
 }
 
 func GetContext() context.Context {

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -92,12 +92,11 @@ func BenchmarkScanFixedCosts_WithAutocommit(b *testing.B) {
 	nilFn := scm.NewNil()
 	neutral := scm.NewNil()
 	session := scm.NewSession()
-	sessionFn := session.Func()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		scm.SetValues(map[string]any{"session": session}, func() {
-			WithAutocommit(sessionFn, scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+			WithAutocommit(session, nil, scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
 				return tbl.scan(
 					CurrentTx(),
 					[]string{"id"}, trueFn,

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -766,17 +766,28 @@ func querySeqFromTx(tx *TxContext) uint64 {
 // is re-raised so the caller's error handler still fires. This guarantees that
 // every SQL statement executed via the HTTP or MySQL frontend runs inside a
 // transaction, enabling a single fsync per statement instead of one per write.
-func WithAutocommit(sessionFn func(...scm.Scmer) scm.Scmer, fn scm.Scmer) scm.Scmer {
+func WithAutocommit(session scm.Scmer, executionContext *scm.QueryExecutionContext, fn scm.Scmer) scm.Scmer {
+	sessionFn := session.Func()
+	var querySeq uint64
+	var sessionState *scm.SessionState
+	if executionContext != nil {
+		querySeq = executionContext.QuerySeq
+		sessionState = executionContext.SessionState
+	} else {
+		querySeq = scm.CurrentQuerySeq()
+		sessionState = scm.GetCurrentSessionState()
+	}
 	if !sessionFn(scm.NewString("transaction")).IsNil() {
 		return scm.Apply(fn)
 	}
 
 	tx := NewTxContext(TxCursorStability)
 	tx.autoCommit = true
-	tx.Session = scm.NewFunc(sessionFn)
-	tx.SessionState = scm.GetCurrentSessionState()
-	tx.querySeq.Store(scm.CurrentQuerySeq())
-	sessionFn(scm.NewString("__memcp_tx"), scm.NewAny(tx))
+	tx.Session = session
+	tx.SessionState = sessionState
+	tx.querySeq.Store(querySeq)
+	txValue := scm.NewAny(tx)
+	sessionFn(scm.NewString("__memcp_tx"), txValue)
 
 	var result scm.Scmer
 	var panicVal any
@@ -913,7 +924,11 @@ func initTransaction(en scm.Env) {
 		Name: "with_autocommit",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			return WithAutocommit(a[0].Func(), a[1])
+			var executionContext *scm.QueryExecutionContext
+			if !a[1].IsNil() {
+				executionContext, _ = a[1].Any().(*scm.QueryExecutionContext)
+			}
+			return WithAutocommit(a[0], executionContext, a[2])
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Executes fn inside an implicit TxCursorStability transaction if no explicit " +
 			"transaction is active in session. Commits on success, rolls back on error, " +
@@ -922,6 +937,7 @@ func initTransaction(en scm.Env) {
 			"fn is executed without any wrapping.", HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "func", Label: "session", Description: "the session function holding tx state", Params: []*scm.TypeDescriptor{{Kind: "string", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "execution_context", Description: "optional request-local execution context; nil retains the legacy goroutine-local fallback"},
 				{Kind: "func", Label: "fn", Description: "zero-argument function to execute", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
 			},
 			Return: &scm.TypeDescriptor{Kind: "any"},

--- a/tests/performance/group-lookup-performance.yaml
+++ b/tests/performance/group-lookup-performance.yaml
@@ -244,7 +244,7 @@ test_cases:
             (lambda (_schema _table _write) true) "root" session true))
         (define elapsed
           (with_session session (lambda ()
-            (with_autocommit session (lambda () (begin
+            (with_autocommit session nil (lambda () (begin
               (eval formula)
               (define started (nanotime))
               (reduce (produceN iterations)


### PR DESCRIPTION
## Summary

This follow-up builds on the merged ORDER/LIMIT braking work and removes two remaining compiler-side costs without changing storage operators:

- carry the existing SessionState and query sequence across the frontend/Scheme boundary as a QueryExecutionContext instead of repeatedly discovering them through goroutine-local stack walks
- distinguish expressions consumed inside `scan_join_order` from values consumed after it
- retain only final projection values in combined-operator tuples; local filters, join keys, and ORDER expressions stay operator-local
- cover the emitted physical plan so filter-only columns cannot silently become live outputs again

For the WordPress query the compiler still chooses `scan_join_order_batched_probe`, but its emitted `map_refs` shrink from seven values to the same three values used by the handwritten plan:

```text
(0 "meta_value"), (1 "ID"), (1 "post_title")
```

## Manual A/B measurements

Measured during development with `tests/performance/wordpress-postmeta-order-limit.yaml`, 8,214 posts and 75,000 postmeta rows. The steady-state comparison used 20 warmups followed by 100 timed samples, so the query-plan cache was warm before measurement.

| Build | Change under test | Median |
| --- | --- | ---: |
| `9e7895698` | explicit execution context, before output liveness pruning | 2.1 ms |
| `786ce8805` | compiler emits only consumer-live tuple values | 2.1 ms |

The liveness patch is performance-neutral end to end on this fixture, while making the generated combined-operator plan structurally match the handwritten core. It must not be presented as a measured speedup.

For diagnosis, the extracted generated `scan_join_order` command itself measured about 0.289 ms/query over 1,000 in-process executions. That is faster than the 0.425 ms MariaDB measurement, but it excludes SQL formula evaluation and HTTP result delivery. The authoritative end-to-end MemCP hand measurement remains 2.1 ms, about 4.9 times slower than MariaDB.

An attempted global cached-callable wrapper was deliberately discarded: it caused Scheme numbered-local failures in group-cache plans. A capability-gated version was also discarded after it regressed the WordPress end-to-end measurement from 2.1 ms to 3.5 ms and made another ORDER/LIMIT needle exceed its 5-second guard.

## Focused verification

- `tests/performance/wordpress-postmeta-order-limit.yaml`: 2/2 normal; 4/4 during manual performance runs
- `tests/performance/session-group-cache.yaml`: 37/37
- `tests/planner/order-window/order-limit.yaml`: 51/51
- `tests/sql/expressions/prepared-stmts.yaml`: 51/51
- `tests/execution/concurrency/transactions.yaml`: 204/204
- `python3 tools/lint_scm.py` completed; check mode reports only the repository's pre-existing warnings
- `git diff --check`

No local full-suite run was performed; the requested optimization workflow delegates broad regression measurement to CI.
