### PR TITLE
perf: prune combined join pipeline outputs

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -4894,7 +4894,7 @@ has selected a lowerer. */
 
 /* Enumerate metadata only. No scan, RecSet, keytable or callback AST is built
 until the caller has selected this physical alternative. */
-(define scan_join_order_spec (lambda (all_sources plan default_alias needed_exprs final_condition order_items offset_value limit_value stages facts unordered_reduce)
+(define scan_join_order_spec (lambda (all_sources plan default_alias consumer_exprs final_condition order_items offset_value limit_value stages facts unordered_reduce)
 	(begin
 		(define sources (join_optimizer_sources_for_order all_sources
 			(join_optimizer_tree_aliases plan)))
@@ -4972,8 +4972,11 @@ until the caller has selected this physical alternative. */
 			(max 0 (- scan_invocations 1)) nil))
 		(define output_rows (if (and (number? limit) (>= limit 0))
 			(min (coalesceNil joined_rows limit) (+ offset limit)) joined_rows))
+		/* Local filters, join keys and order expressions are consumed inside
+		scan_join_order. Keep only values read by the downstream mapper live in its
+		tuples; carrying the complete scan recipe defeats late materialization. */
 		(define map_width (count (scan_join_order_refs_for_exprs
-			sources default_alias needed_exprs)))
+			sources default_alias consumer_exprs)))
 		(define window_supported ordered_window)
 		(define reduce_supported (and unordered_reduce
 			(and (equal? offset 0) (and (equal? limit -1) (empty_list? order_items)))))
@@ -5002,7 +5005,7 @@ until the caller has selected this physical alternative. */
 				(list (quote residual) (combine_where_terms residual_terms true))
 				(list (quote order_entries) order_entries)
 				(list (quote map_refs) (scan_join_order_refs_for_exprs
-					sources default_alias needed_exprs))
+					sources default_alias consumer_exprs))
 				(list (quote input_rows) input_rows)
 				(list (quote driver_rows) driver_rows)
 				(list (quote inner_rows) inner_rows)
@@ -5258,7 +5261,7 @@ until the caller has selected this physical alternative. */
 			(wrap_membership_keyset_bindings membership_keysets window_expr)
 			window_expr))))
 
-(define scan_join_order_emit_plan (lambda (spec default_alias needed_exprs value_builder reduce_expr neutral_expr shard_reduce_expr stages batched_probe)
+(define scan_join_order_emit_plan (lambda (spec default_alias value_builder reduce_expr neutral_expr shard_reduce_expr stages batched_probe)
 	(begin
 		(define sources (qassoc_get spec (quote sources) '()))
 		(define local_terms (qassoc_get spec (quote local_terms) '()))
@@ -5312,7 +5315,7 @@ until the caller has selected this physical alternative. */
 
 (define join_ordered_streaming_limit_plan (lambda (schema all_sources plan default_alias output_exprs needed_exprs final_condition order_items offset_value limit_value stages facts value_builder reduce_expr neutral_expr)
 	(begin
-		(define spec (scan_join_order_spec all_sources plan default_alias needed_exprs
+		(define spec (scan_join_order_spec all_sources plan default_alias output_exprs
 			final_condition order_items offset_value limit_value stages facts false))
 		(if (nil? spec)
 			(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
@@ -5420,7 +5423,7 @@ until the caller has selected this physical alternative. */
 							(list "cost" (planner_cost_explain batched_probe_cost)))))))
 				(if (or (equal? chosen "scan_join_order")
 					(equal? chosen "scan_join_order_batched_probe"))
-					(scan_join_order_emit_plan spec default_alias needed_exprs
+					(scan_join_order_emit_plan spec default_alias
 						value_builder reduce_expr neutral_expr nil stages
 						(equal? chosen "scan_join_order_batched_probe"))
 					(join_ordered_streaming_limit_legacy_plan schema all_sources plan default_alias
@@ -5431,10 +5434,10 @@ until the caller has selected this physical alternative. */
 reducers: the first combines shard-tuple results locally and the second merges
 those local states globally. The physical choice deliberately shares the
 ordered operator's Costgen-owned scan, map and expression coefficients. */
-(define join_unordered_reduce_plan (lambda (all_sources plan default_alias needed_exprs
+(define join_unordered_reduce_plan (lambda (all_sources plan default_alias consumer_exprs
 	final_condition stages facts value_builder reduce_expr neutral_expr shard_reduce_expr legacy_plan)
 	(begin
-		(define spec (scan_join_order_spec all_sources plan default_alias needed_exprs
+		(define spec (scan_join_order_spec all_sources plan default_alias consumer_exprs
 			final_condition '() 0 -1 stages facts true))
 		(if (nil? spec)
 			legacy_plan
@@ -5488,7 +5491,7 @@ ordered operator's Costgen-owned scan, map and expression coefficients. */
 						(list (list "plan" "scan_join_order")
 							(list "cost" (planner_cost_explain scan_cost)))))))
 				(if (equal? chosen "scan_join_order")
-					(scan_join_order_emit_plan spec default_alias needed_exprs value_builder
+					(scan_join_order_emit_plan spec default_alias value_builder
 						reduce_expr neutral_expr shard_reduce_expr stages false)
 					legacy_plan))))))
 
@@ -7716,7 +7719,7 @@ physical decision and preserve its runtime recompile gate. */
 					(and (equal? (coalesceNil (qb_offset block) 0) 0)
 						(equal? (coalesceNil (qb_limit block) -1) -1)))
 					(join_unordered_reduce_plan
-						scan_sources scan_plan first_alias effective_needed_exprs
+						scan_sources scan_plan first_alias effective_field_exprs
 						effective_condition (query_block_stage_catalog block) (qb_facts block)
 						(lambda (_probe_work_rows _scalar_probe) row_expr)
 						reduce_expr neutral_expr shard_reduce_expr legacy_reduce_plan)

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -71,6 +71,10 @@ test_cases:
         - "chosen scan_join_order_batched_probe"
         - "scan_join_order"
         - "legacy_join_tree"
+      result_not_contains:
+        - '(0 \"meta_key\")'
+        - '(1 \"post_type\")'
+        - '(1 \"post_status\")'
 
   - name: "WordPress ordered join uses the equivalent postmeta driver"
     sql: |


### PR DESCRIPTION
## Summary

This follow-up builds on the merged ORDER/LIMIT braking and explicit execution-context work. It fixes the remaining physical-plan liveness mismatch without changing storage operators:

- distinguish expressions consumed inside `scan_join_order` from values consumed after it
- retain only final projection values in combined-operator tuples; local filters, join keys, and ORDER expressions stay operator-local
- cover the emitted physical plan so filter-only columns cannot silently become live outputs again

For the WordPress query the compiler still chooses `scan_join_order_batched_probe`, but its emitted `map_refs` shrink from seven values to the same three values used by the handwritten plan:

```text
(0 "meta_value"), (1 "ID"), (1 "post_title")
```

## Manual A/B measurements

Measured during development with `tests/performance/wordpress-postmeta-order-limit.yaml`, 8,214 posts and 75,000 postmeta rows. The steady-state comparison used 20 warmups followed by 100 timed samples, so the query-plan cache was warm before measurement.

| Build | Change under test | Median |
| --- | --- | ---: |
| `b213bf02c` (`master`) | explicit execution context, before output liveness pruning | 2.1 ms |
| `de85363fb` | compiler emits only consumer-live tuple values | 2.1 ms |

The liveness patch is performance-neutral end to end on this fixture, while making the generated combined-operator plan structurally match the handwritten core. It must not be presented as a measured speedup.

## Exact value of this change

For the optimized WordPress query, the immediate measured performance value is zero: 2.1 ms remains 2.1 ms. The query returns only 20 rows, so pruning four values from each accepted operator tuple avoids materializing and forwarding just 80 Scheme values per execution. That work is too small to affect the end-to-end result.

The concrete compiler correction is:

- before: `map_refs` included seven values because filter, join, and ORDER expressions were treated as downstream consumers
- after: those expressions remain private inputs of `scan_join_order`; only the three projected values cross the operator/consumer boundary
- the cost model now uses the actual downstream map width, 3 instead of 7, when comparing the combined plan with the legacy plan
- unordered combined reductions receive the same liveness correction; this can avoid carrying dead values across many rows, but no speedup for that broader case is claimed without a separate A/B measurement

Therefore this PR removes a compiler mismatch and puts the handcrafted plan inside the emitted-plan representation, but it does not close any measurable part of the remaining WordPress latency gap. If that structural correction alone is not considered sufficient value, the honest alternative is to close the PR and continue profiling the SQL evaluation/result-delivery boundary before merging another performance change.

For diagnosis, the extracted generated `scan_join_order` command itself measured about 0.289 ms/query over 1,000 in-process executions. That is faster than the 0.425 ms MariaDB measurement, but it excludes SQL formula evaluation and HTTP result delivery. The authoritative end-to-end MemCP hand measurement remains 2.1 ms, about 4.9 times slower than MariaDB.

An attempted global cached-callable wrapper was deliberately discarded: it caused Scheme numbered-local failures in group-cache plans. A capability-gated version was also discarded after it regressed the WordPress end-to-end measurement from 2.1 ms to 3.5 ms and made another ORDER/LIMIT needle exceed its 5-second guard.

## Focused verification

- `tests/performance/wordpress-postmeta-order-limit.yaml`: 2/2 normal; 4/4 during manual performance runs
- `tests/performance/session-group-cache.yaml`: 37/37
- `tests/planner/order-window/order-limit.yaml`: 51/51
- `tests/sql/expressions/prepared-stmts.yaml`: 51/51
- `tests/execution/concurrency/transactions.yaml`: 204/204
- `python3 tools/lint_scm.py` completed; check mode reports only the repository's pre-existing warnings
- `git diff --check`

No local full-suite run was performed; the requested optimization workflow delegates broad regression measurement to CI.
