### PR TITLE
Complete JIT special-form lowering

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -28,7 +28,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 	"unsafe"
+
+	"github.com/jtolds/gls"
 )
 
 /*
@@ -1402,6 +1405,200 @@ func jitBuildCompiledLambdaClosure(args ...Scmer) Scmer {
 	return jitCompile(jitBuildLambdaClosure(args...))
 }
 
+// jitRuntimeEnvFromCaptures reconstructs the visible lexical environment for
+// special forms whose runtime contract consumes Scheme syntax as data. The
+// first argument is the interpreter environment outside the native Proc; the
+// remaining arguments are frame markers and symbol-or-numbered-key/value pairs.
+var jitRuntimeEnvFrameMarker = &struct{}{}
+
+func jitRuntimeEnvFromCaptures(args []Scmer) *Env {
+	if len(args) == 0 || (len(args)-1)%2 != 0 {
+		panic("jit: malformed runtime environment capture")
+	}
+	outer, ok := args[0].Any().(*Env)
+	if !ok || outer == nil {
+		panic("jit: invalid outer runtime environment")
+	}
+	type capturedFrame struct {
+		vars     Vars
+		numbered map[int]Scmer
+	}
+	frames := make([]capturedFrame, 0, 2)
+	current := capturedFrame{}
+	started := false
+	for i := 1; i < len(args); i += 2 {
+		key, value := args[i], args[i+1]
+		if key.GetTag() == tagAny && key.Any() == jitRuntimeEnvFrameMarker {
+			if started {
+				frames = append(frames, current)
+			}
+			current = capturedFrame{}
+			started = true
+			continue
+		}
+		if key.IsNthLocalVar() {
+			if current.numbered == nil {
+				current.numbered = make(map[int]Scmer)
+			}
+			current.numbered[int(key.NthLocalVar())] = value
+			continue
+		}
+		if current.vars == nil {
+			current.vars = make(Vars)
+		}
+		current.vars[mustSymbol(key)] = value
+	}
+	if started || current.vars != nil || current.numbered != nil {
+		frames = append(frames, current)
+	}
+	if len(frames) == 0 {
+		return &Env{Outer: outer}
+	}
+	for i := len(frames) - 1; i >= 0; i-- {
+		frame := frames[i]
+		maxNumbered := -1
+		for index := range frame.numbered {
+			if index > maxNumbered {
+				maxNumbered = index
+			}
+		}
+		var numbered []Scmer
+		if maxNumbered >= 0 {
+			numbered = make([]Scmer, maxNumbered+1)
+			for index, value := range frame.numbered {
+				numbered[index] = value
+			}
+		}
+		outer = &Env{Vars: frame.vars, VarsNumbered: numbered, Outer: outer}
+	}
+	return outer
+}
+
+func jitEvalSpecial(args ...Scmer) Scmer {
+	if len(args) < 2 {
+		panic("eval expects exactly one expression")
+	}
+	return Eval(args[0], jitRuntimeEnvFromCaptures(args[1:]))
+}
+
+func jitParserSpecial(args ...Scmer) Scmer {
+	if len(args) < 5 {
+		panic("parser expects syntax")
+	}
+	en := jitRuntimeEnvFromCaptures(args[4:])
+	return NewScmParser(NewParser(args[0], args[1], args[2], en, args[3].Bool()))
+}
+
+type jitSpecialThunkValue struct {
+	callable Scmer
+	args     []Scmer
+}
+
+func jitMakeSpecialThunk(args ...Scmer) Scmer {
+	if len(args) == 0 {
+		panic("jit: special-form thunk expects a callable")
+	}
+	return NewAny(&jitSpecialThunkValue{callable: args[0], args: append([]Scmer(nil), args[1:]...)})
+}
+
+func jitCallSpecialThunk(thunk Scmer) Scmer {
+	if thunk.GetTag() == tagAny {
+		if value, ok := thunk.Any().(*jitSpecialThunkValue); ok && value != nil {
+			if value.callable.GetTag() == tagProc {
+				if proc := value.callable.Proc(); proc != nil && proc.Compiled != nil {
+					return proc.Compiled.Call(value.args...)
+				}
+			}
+			return Apply(value.callable, value.args...)
+		}
+	}
+	if thunk.GetTag() == tagProc {
+		if proc := thunk.Proc(); proc != nil && proc.Compiled != nil {
+			return proc.Compiled.Call()
+		}
+	}
+	return Apply(thunk)
+}
+
+func jitOptimizerProcReturnSpecial(args ...Scmer) Scmer {
+	if len(args) != 2 {
+		panic("optimizer_proc_return expects procedure and return metadata")
+	}
+	value, metadataThunk := args[0], args[1]
+	if value.GetTag() != tagProc {
+		return value
+	}
+	metadataValue := jitCallSpecialThunk(metadataThunk)
+	if metadataValue.GetTag() != tagAny {
+		panic("optimizer_proc_return expects internal return metadata")
+	}
+	metadata, ok := metadataValue.Any().(optimizerProcReturnTemplate)
+	if !ok {
+		panic("optimizer_proc_return received invalid return metadata")
+	}
+	proc := *value.Proc()
+	proc.OptimizerMeta = &ProcOptimizerMeta{Return: metadata.Return, HasReturn: metadata.HasReturn}
+	return NewProcStruct(proc)
+}
+
+func jitTimeSpecial(args ...Scmer) Scmer {
+	if len(args) != 2 {
+		panic("time expects an expression and optional label")
+	}
+	body, label := args[0], args[1]
+	hasLabel := !label.IsNil()
+	var start time.Time
+	if TracePrint {
+		start = time.Now()
+	}
+	var timedResult Scmer
+	if Trace != nil {
+		traceLabel := "(time)"
+		if hasLabel {
+			traceLabel = String(jitCallSpecialThunk(label))
+		}
+		Trace.Duration(traceLabel, "scm", func() {
+			timedResult = jitCallSpecialThunk(body)
+		})
+	} else {
+		timedResult = jitCallSpecialThunk(body)
+	}
+	if TracePrint {
+		message := "trace " + time.Since(start).String()
+		if hasLabel {
+			message += " " + String(jitCallSpecialThunk(label))
+		}
+		TracePrintFunc(message)
+	}
+	return timedResult
+}
+
+func jitParallelSpecial(thunks ...Scmer) Scmer {
+	if len(thunks) == 0 {
+		return NewNil()
+	}
+	errs := make(chan any, len(thunks))
+	for _, thunk := range thunks {
+		thunk := thunk
+		gls.Go(func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					errs <- recovered
+				} else {
+					errs <- nil
+				}
+			}()
+			jitCallSpecialThunk(thunk)
+		})
+	}
+	for range thunks {
+		if err := <-errs; err != nil {
+			panic(err)
+		}
+	}
+	return NewNil()
+}
+
 // GoFuncAddr returns the entry point address of a Go function value.
 func GoFuncAddr(fn interface{}) uint64 {
 	return uint64(reflect.ValueOf(fn).Pointer())
@@ -1948,6 +2145,18 @@ type jitCodeReservation struct {
 // may run concurrently, but an entry point does not become reachable before
 // every earlier reservation has either published its maps or reported failure.
 func (a *jitArena) complete(reservation *jitCodeReservation, maps []jitStackMap) {
+	a.completeMode(reservation, maps, true)
+}
+
+// completeDeferred records metadata for code which cannot become reachable
+// before its enclosing reservation is published. Nested special-form thunks
+// use this to avoid waiting on the outer compiler which is currently emitting
+// them; the outer completion publishes both reservations in allocation order.
+func (a *jitArena) completeDeferred(reservation *jitCodeReservation, maps []jitStackMap) {
+	a.completeMode(reservation, maps, false)
+}
+
+func (a *jitArena) completeMode(reservation *jitCodeReservation, maps []jitStackMap, wait bool) {
 	if a == nil || reservation == nil {
 		return
 	}
@@ -1961,8 +2170,10 @@ func (a *jitArena) complete(reservation *jitCodeReservation, maps []jitStackMap)
 		a.metaNext++
 	}
 	a.metaCond.Broadcast()
-	for !reservation.published {
-		a.metaCond.Wait()
+	if wait {
+		for !reservation.published {
+			a.metaCond.Wait()
+		}
 	}
 	a.metaMu.Unlock()
 }
@@ -2323,6 +2534,14 @@ func jitCompile(a ...Scmer) Scmer {
 }
 
 func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
+	return jitCompileModePublish(recursiveLambdas, true, a...)
+}
+
+func jitCompileModeDeferred(recursiveLambdas bool, a ...Scmer) Scmer {
+	return jitCompileModePublish(recursiveLambdas, false, a...)
+}
+
+func jitCompileModePublish(recursiveLambdas bool, waitForPublication bool, a ...Scmer) Scmer {
 	if len(a) != 1 {
 		panic("jit: expects exactly 1 argument")
 	}
@@ -2364,7 +2583,11 @@ func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 			ptr, arena, reservation := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena, reservation: reservation}
 			codeLen, roots, overflow, transferInputArgs, hiddenArgs, autoImportSafe, needsStableArgs, coverage := jitCompileProcToExec(proc, buf, recursiveLambdas)
-			arena.complete(reservation, buf.stackMaps)
+			if waitForPublication {
+				arena.complete(reservation, buf.stackMaps)
+			} else {
+				arena.completeDeferred(reservation, buf.stackMaps)
+			}
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
 				if JITLog {

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -19,6 +19,7 @@ package scm
 import (
 	"fmt"
 	"math"
+	"sort"
 	"unsafe"
 )
 
@@ -112,6 +113,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 			coverage = JITCoverage{}
 		}
 	}()
+	numVars = jitRequiredLocalSlots(body, numVars)
 
 	// Free registers: all GPRs except RAX (result ptr), RBX (result aux),
 	// RSP, RBP, R11 (scratch), R12 (slice base), R14 (Go goroutine ptr "g")
@@ -276,6 +278,33 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 	ctx.ResolveFixupsFinal()
 	codeLen = int(uintptr(ctx.Ptr) - uintptr(ctx.Start))
 	return codeLen, ctx.ConstRoots, false, ctx.TransferInputArgs, ctx.HiddenArgs, ctx.AutoImportSafe, ctx.NeedsStableArgs, ctx.Coverage
+}
+
+func jitRequiredLocalSlots(expr Scmer, minimum int) int {
+	for expr.IsSourceInfo() {
+		expr = expr.SourceInfo().value
+	}
+	if expr.IsNthLocalVar() {
+		required := int(expr.NthLocalVar()) + 1
+		if required > minimum {
+			return required
+		}
+		return minimum
+	}
+	if !expr.IsSlice() {
+		return minimum
+	}
+	items := expr.Slice()
+	if len(items) > 0 && items[0].IsSymbol() {
+		switch string(items[0].Symbol()) {
+		case "quote", "parser", "lambda":
+			return minimum
+		}
+	}
+	for _, item := range items {
+		minimum = jitRequiredLocalSlots(item, minimum)
+	}
+	return minimum
 }
 
 func jitEnsureResultPair(ctx *JITContext, result JITValueDesc) JITValueDesc {
@@ -1615,6 +1644,54 @@ func jitEmitGoVariadicCallFromExprs(ctx *JITContext, fn func(...Scmer) Scmer, ar
 	return out
 }
 
+func jitEmitGoVariadicCallFromDescs(ctx *JITContext, fn func(...Scmer) Scmer, values []JITValueDesc, result JITValueDesc) JITValueDesc {
+	argc := len(values)
+	stackStart := ctx.BPOffset
+	argsOff := int32(0)
+	if argc > 0 {
+		argsOff = ctx.AllocStack(int32(argc * 16))
+		for i := range values {
+			value := values[i]
+			ctx.EnsureDesc(&value)
+			if value.Loc != LocImm && value.Loc != LocRegPair && value.Loc != LocStackPair && value.Loc != LocInputPair {
+				pair := jitAllocTrackedPair(ctx, value.Type)
+				value = jitPlaceIntoPair(ctx, &value, pair)
+			}
+			ctx.EmitStoreScmerToStack(value, argsOff+int32(i*16))
+			ctx.FreeDesc(&value)
+		}
+	}
+	argsSlice := jitAllocTrackedPair(ctx, JITTypeUnknown)
+	stackBytes := int32(argc * 16)
+	if argc > 0 {
+		ctx.EmitSubRSP32(stackBytes)
+		for i := range values {
+			slotOff := int32(i * 16)
+			sourceOff := stackBytes + argsOff + slotOff
+			ctx.EmitMovRegMem(RegR11, RegRSP, sourceOff)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, slotOff)
+			ctx.EmitMovRegMem(RegR11, RegRSP, sourceOff+8)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, slotOff+8)
+			ctx.setStackPointer(jitStackRootFrameSP, slotOff-ctx.DynamicSP, true)
+		}
+		ctx.EmitMovRegReg(argsSlice.Reg, RegRSP)
+		ctx.EmitMovRegImm64(argsSlice.Reg2, uint64(argc))
+	} else {
+		ctx.EmitMovRegImm64(argsSlice.Reg, 0)
+		ctx.EmitMovRegImm64(argsSlice.Reg2, 0)
+	}
+	out := ctx.EmitGoCallVariadic(fn, argsSlice, result)
+	ctx.FreeDesc(&argsSlice)
+	if stackBytes != 0 {
+		ctx.EmitAddRSP32(stackBytes)
+		if ctx.SliceBaseTracksRSP && ctx.SliceBase != RegRSP {
+			ctx.EmitMovRegReg(ctx.SliceBase, RegRSP)
+		}
+	}
+	ctx.FreeStack(ctx.BPOffset - stackStart)
+	return out
+}
+
 func jitCompileRootedCallValueAt(ctx *JITContext, expr Scmer, sliceBase Reg, off int32) JITValueDesc {
 	value := jitCompileExpr(ctx, expr, sliceBase, JITValueDesc{Loc: LocAny})
 	// Input values remain reachable through JITEntryPoint.Call's args slice for
@@ -1646,6 +1723,83 @@ func jitCompileRootedCallValueAt(ctx *JITContext, expr Scmer, sliceBase Reg, off
 func jitCompileRootedCallValue(ctx *JITContext, expr Scmer, sliceBase Reg) JITValueDesc {
 	off := ctx.AllocStack(16)
 	return jitCompileRootedCallValueAt(ctx, expr, sliceBase, off)
+}
+
+func jitVisibleSymbols(ctx *JITContext) []Symbol {
+	seen := make(map[Symbol]struct{})
+	symbols := make([]Symbol, 0)
+	for env := ctx.Env; env != nil; env = env.Outer {
+		for symbol := range env.Vars {
+			if _, exists := seen[symbol]; exists {
+				continue
+			}
+			seen[symbol] = struct{}{}
+			symbols = append(symbols, symbol)
+		}
+	}
+	sort.Slice(symbols, func(i, j int) bool { return symbols[i] < symbols[j] })
+	return symbols
+}
+
+func jitRuntimeCaptureArgExprs(ctx *JITContext) []Scmer {
+	args := []Scmer{ctx.RuntimeEnv}
+	depth := 0
+	for env := ctx.Env; env != nil; env = env.Outer {
+		args = append(args, NewAny(jitRuntimeEnvFrameMarker), NewNil())
+		symbols := make([]Symbol, 0, len(env.Vars))
+		for symbol := range env.Vars {
+			symbols = append(symbols, symbol)
+		}
+		sort.Slice(symbols, func(i, j int) bool { return symbols[i] < symbols[j] })
+		for _, symbol := range symbols {
+			key := NewSymbol(string(symbol))
+			value := Scmer(key)
+			for level := 0; level < depth; level++ {
+				value = NewSlice([]Scmer{NewSymbol("outer"), value})
+			}
+			args = append(args, NewSlice([]Scmer{NewSymbol("quote"), key}), value)
+		}
+		if depth == 0 {
+			for index := 0; index < ctx.LocalSlotCount; index++ {
+				key := NewNthLocalVar(NthLocalVar(index))
+				args = append(args, NewSlice([]Scmer{NewSymbol("quote"), key}), key)
+			}
+		}
+		depth++
+	}
+	if ctx.Env == nil {
+		args = append(args, NewAny(jitRuntimeEnvFrameMarker), NewNil())
+	}
+	return args
+}
+
+func jitCompileSpecialThunk(ctx *JITContext, body Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
+	symbols := jitVisibleSymbols(ctx)
+	params := make([]Scmer, 0, ctx.LocalSlotCount+len(symbols))
+	argExprs := make([]Scmer, 0, 1+ctx.LocalSlotCount+len(symbols))
+	for index := 0; index < ctx.LocalSlotCount; index++ {
+		params = append(params, NewSymbol(fmt.Sprintf("\x00jit-slot-%d", index)))
+		argExprs = append(argExprs, NewNthLocalVar(NthLocalVar(index)))
+	}
+	for _, symbol := range symbols {
+		params = append(params, NewSymbol(string(symbol)))
+		argExprs = append(argExprs, NewSymbol(string(symbol)))
+	}
+	outer, ok := ctx.RuntimeEnv.Any().(*Env)
+	if !ok || outer == nil {
+		panic("jit: invalid special-form thunk environment")
+	}
+	callable := jitCompileModeDeferred(true, NewProcStruct(Proc{
+		Params:  NewSlice(params),
+		Body:    body,
+		En:      outer,
+		NumVars: len(params),
+	}))
+	if callable.GetTag() != tagProc || callable.Proc() == nil || callable.Proc().Compiled == nil {
+		panic("jit: special-form child did not compile")
+	}
+	argExprs = append([]Scmer{callable}, argExprs...)
+	return jitEmitGoVariadicCallFromExprs(ctx, jitMakeSpecialThunk, argExprs, sliceBase, result)
 }
 
 func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
@@ -1991,8 +2145,26 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 			ctx.TrackImm(q)
 			return JITValueDesc{Loc: LocImm, Type: q.GetTag(), Imm: q}
-		case "eval", "time":
-			panic("jit: unsupported special form " + name)
+		case "eval":
+			if len(list) < 2 {
+				panic("jit: eval expects an expression")
+			}
+			args := make([]Scmer, 0, 1+2*ctx.LocalSlotCount)
+			args = append(args, list[1])
+			args = append(args, jitRuntimeCaptureArgExprs(ctx)...)
+			return jitEmitGoVariadicCallFromExprs(ctx, jitEvalSpecial, args, sliceBase, result)
+		case "time":
+			if len(list) < 2 {
+				panic("jit: time expects an expression")
+			}
+			body := jitCompileSpecialThunk(ctx, list[1], sliceBase, JITValueDesc{Loc: LocAny})
+			args := []JITValueDesc{body}
+			if len(list) > 2 {
+				args = append(args, jitCompileSpecialThunk(ctx, list[2], sliceBase, JITValueDesc{Loc: LocAny}))
+			} else {
+				args = append(args, JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()})
+			}
+			return jitEmitGoVariadicCallFromDescs(ctx, jitTimeSpecial, args, result)
 		case "define", "set":
 			if len(list) != 3 {
 				panic("jit: malformed " + name)
@@ -2049,8 +2221,35 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 			ctx.EmitStoreScmerToStack(value, int32(idx*16))
 			return value
-		case "parser", "optimizer_proc_return":
-			panic("jit: unsupported special form " + name)
+		case "parser":
+			if len(list) < 2 {
+				panic("jit: parser expects syntax")
+			}
+			generator := NewNil()
+			whitespace := NewNil()
+			ignoreResult := false
+			if len(list) > 2 {
+				generator = list[2]
+				ignoreResult = true
+			}
+			if len(list) > 3 {
+				whitespace = list[3]
+			}
+			args := []Scmer{
+				NewSlice([]Scmer{NewSymbol("quote"), list[1]}),
+				NewSlice([]Scmer{NewSymbol("quote"), generator}),
+				NewSlice([]Scmer{NewSymbol("quote"), whitespace}),
+				NewBool(ignoreResult),
+			}
+			args = append(args, jitRuntimeCaptureArgExprs(ctx)...)
+			return jitEmitGoVariadicCallFromExprs(ctx, jitParserSpecial, args, sliceBase, result)
+		case "optimizer_proc_return":
+			if len(list) != 3 {
+				panic("jit: optimizer_proc_return expects procedure and return metadata")
+			}
+			value := jitCompileExpr(ctx, list[1], sliceBase, JITValueDesc{Loc: LocAny})
+			metadata := jitCompileSpecialThunk(ctx, list[2], sliceBase, JITValueDesc{Loc: LocAny})
+			return jitEmitGoVariadicCallFromDescs(ctx, jitOptimizerProcReturnSpecial, []JITValueDesc{value, metadata}, result)
 		case "begin":
 			if len(list) == 1 {
 				imm := NewNil()
@@ -2066,7 +2265,31 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			}
 			return jitCompileExpr(ctx, list[len(list)-1], sliceBase, result)
 		case "begin_mut":
-			panic("jit: unsupported special form begin_mut")
+			if len(list) < 3 {
+				panic("jit: begin_mut expects a reserve and body")
+			}
+			reserveExpr := list[1]
+			for reserveExpr.IsSourceInfo() {
+				reserveExpr = reserveExpr.SourceInfo().value
+			}
+			if reserveExpr.GetTag() != tagInt && reserveExpr.GetTag() != tagFloat {
+				panic("jit: begin_mut reserve must be optimized to a number")
+			}
+			reserve := int(ToInt(reserveExpr))
+			if reserve < 0 {
+				reserve = 0
+			}
+			if reserve > ctx.LocalSlotCount {
+				panic("jit: begin_mut reserve exceeds invocation frame")
+			}
+			outerEnv := ctx.Env
+			ctx.Env = &JITEnv{Vars: make(map[Symbol]JITValueDesc), Outer: outerEnv}
+			defer func() { ctx.Env = outerEnv }()
+			for _, form := range list[2 : len(list)-1] {
+				value := jitCompileExpr(ctx, form, sliceBase, JITValueDesc{Loc: LocAny})
+				ctx.FreeDesc(&value)
+			}
+			return jitCompileExpr(ctx, list[len(list)-1], sliceBase, result)
 		case "!begin":
 			if len(list) == 1 {
 				imm := NewNil()
@@ -2124,7 +2347,11 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			ctx.FreeStack(ctx.BPOffset - stackStart)
 			return jitRootScmer(ctx, out)
 		case "parallel":
-			panic("jit: unsupported special form parallel")
+			args := make([]JITValueDesc, 0, len(list)-1)
+			for _, child := range list[1:] {
+				args = append(args, jitCompileSpecialThunk(ctx, child, sliceBase, JITValueDesc{Loc: LocAny}))
+			}
+			return jitEmitGoVariadicCallFromDescs(ctx, jitParallelSpecial, args, result)
 		case "match", "match_mut":
 			return jitCompileMatch(ctx, list, sliceBase, result)
 		case "if":


### PR DESCRIPTION
## Ziel

Vervollständigt ausschließlich den Special-Form-Switch des Scheme-JIT-Emitters. Die vorhandenen `jitgen`-Emitter und ihre Fallback-Calls bleiben unverändert; ebenso Import-JIT, Aktivierungsheuristiken und `lib/`.

Neu nativ abgebildet werden die bislang fehlenden Fälle:

- `eval`
- `time`
- `parser`
- `optimizer_proc_return`
- `begin_mut`
- `parallel`

Damit besitzt der JIT-Switch jetzt Gegenstücke für alle Sonderprimitiven des Interpreter-Switches. Nicht unterstützte beziehungsweise malformed Formen brechen weiterhin explizit per `panic` ab.

## Semantik

- `eval` rekonstruiert die lexikalische Laufzeitumgebung frameweise aus den nativen JIT-Slots und Symbolbindungen. Shadowing und `outer` bleiben erhalten; insbesondere ist eine in `lib/sql.scm` gebundene `session`-Variable für das evaluierte Scheme-Fragment sichtbar.
- `parser` erhält dieselbe rekonstruierte Umgebung für seine Generatoren.
- `time`, `parallel` und die Return-Metadaten von `optimizer_proc_return` werden als vorab JIT-kompilierte Child-Thunks emittiert. Es findet keine verschachtelte Laufzeit-Kompilierung im aktiven Native Frame statt.
- `begin_mut` reserviert die vom optimierten Ausdruck referenzierten nummerierten Slots im nativen Frame.

## A/B-Messungen

Alle Builds und Messungen liefen mit `/home/carli/projekte/go-jit/goroot/bin/go` und `GOEXPERIMENT=jit`.

### Mikrobenchmark

Drei Läufe pro Variante; derselbe optimierte Scheme-Ausdruck wurde direkt interpretiert beziehungsweise als bereits kompilierte Proc aufgerufen.

| Fall | Interpreter | JIT | Verhältnis | Allokationen Interpreter → JIT |
| --- | ---: | ---: | ---: | ---: |
| `begin_mut` | 615.4–636.3 ns/op | 62.77–66.00 ns/op | ca. 9.8x schneller | 23 → 1 |
| `eval` mit lexikalischem Capture | 537.1–560.9 ns/op | 359.1–374.4 ns/op | ca. 1.5x schneller | 15 → 10 |

### End-to-End: kaltes SQL

Verglichen wurden `404a16888` (Merge-Stand von #660) und dieser Branch mit demselben gepatchten Compiler. Über eine persistente HTTP-Verbindung liefen 300 paarweise alternierende, durch unterschiedliche `OFFSET`-Werte jeweils kalte Varianten einer WordPress-typischen Planner-Abfrage (`wp_posts` plus `wp_postmeta`, `LEFT JOIN`, Filter, `GROUP BY`, `ORDER BY`, `LIMIT`).

| Stand | Mittel | Median | p90 |
| --- | ---: | ---: | ---: |
| Baseline | 19.503 ms | 19.141 ms | 21.979 ms |
| Branch | 19.447 ms | 19.004 ms | 21.585 ms |

Der mittlere gepaarte Unterschied beträgt -0.056 ms zugunsten dieses Branches; 146 von 300 Paaren waren schneller. Das ist praktisch neutral (ca. 0.3 %) und erwartbar: Dieser PR vervollständigt nur den Emitter-Switch und ändert bewusst keine Aktivierungs-/Import-Heuristik für den Querycompiler.

## JIT-Abdeckung und Disassembly

- Separate Probes für alle sechs neuen Switch-Fälle melden jeweils `Compiled.Coverage.DynamicCalls == 0`.
- Ein `eval`-plus-`define`-Probe erzeugt einen 417 Byte langen nativen x86-64-Codekörper. Die Disassembly zeigt den nativen Ausdruckspfad und genau den erwarteten indirekten Aufruf des dedizierten Go-Helfers für die dynamische `Eval`-Grenze, keinen generischen Scheme-Apply-Fallback.
- Verifiziert: aktuelles und äußeres `session`-Binding (`41` beziehungsweise über `outer` der Wert `10`) sowie Parser-Generator-Capture (`"captured"`).

## Verifikation

- `go test ./scm -count=1`
- Scheme-Bootstrap: 1270/1270 Tests bestanden
- vollständiges `PATH=/home/carli/projekte/go-jit/goroot/bin:$PATH make test`: bestanden
- `git diff origin/master -- lib tests`: leer; bestehende Tests und sämtliche Dateien unter `lib/` bleiben unverändert
- GitHub CI: `test`, `performance-ab`, `protected-regression-policy` und `sql-time-limit-guard` bestanden

Der erste CI-A/B-Versuch enthielt einen einzelnen, nicht reproduzierbaren 5-Sample-Ausreißer beim Hierarchie-Fall (+36.1 %) und brach anschließend ab. Die unveränderte Wiederholung bestand vollständig; derselbe Fall lag dort bei -5.0 % (11.806 → 11.220 ms), der WordPress-Fall bei -3.4 % (3.448 → 3.332 ms).
