### PR TITLE
perf: lower planner folds to fused list operators

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -580,6 +580,146 @@ func mergeValidationSafeDeferredArgument(v Scmer, allowLambda bool) bool {
 	return scmerIsSymbol(inner[0], "quote") || (allowLambda && scmerIsSymbol(inner[0], "lambda"))
 }
 
+// optimizerLambdaWithBody preserves the optimized lambda frame while replacing
+// its body. This avoids another optimization or variable-remapping pass.
+func optimizerLambdaWithBody(expr Scmer, body Scmer) (Scmer, bool) {
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) < 3 || !scmerIsSymbol(items[0], "lambda") {
+		return NewNil(), false
+	}
+	rewritten := append([]Scmer(nil), items...)
+	rewritten[2] = body
+	return NewSlice(rewritten), true
+}
+
+// optimizerLambdaParamReference accepts both source symbols and already lowered
+// local-variable references.
+func optimizerLambdaParamReference(expr Scmer, params []Scmer, index int) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() {
+		return int(expr.NthLocalVar()) == index
+	}
+	if index < 0 || index >= len(params) {
+		return false
+	}
+	param, ok := scmerSymbol(params[index])
+	return ok && scmerIsSymbol(expr, string(param))
+}
+
+// optimizerNonNilPredicate recognizes the planner's exact (not (nil? value))
+// filter without analyzing the callback subtree again.
+func optimizerNonNilPredicate(expr Scmer) bool {
+	params, body, ok := optimizerLambdaParts(expr)
+	if !ok || len(params) != 1 {
+		return false
+	}
+	notCall, ok := scmerSlice(body)
+	if !ok || len(notCall) != 2 || !scmerIsSymbol(notCall[0], "not") {
+		return false
+	}
+	nilCall, ok := scmerSlice(notCall[1])
+	return ok && len(nilCall) == 2 && scmerIsSymbol(nilCall[0], "nil?") &&
+		optimizerLambdaParamReference(nilCall[1], params, 0)
+}
+
+func optimizerBoolLiteral(expr Scmer) (bool, bool) {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsBool() {
+		return expr.Bool(), true
+	}
+	if scmerIsSymbol(expr, "true") {
+		return true, true
+	}
+	if scmerIsSymbol(expr, "false") {
+		return false, true
+	}
+	return false, false
+}
+
+func optimizerNilLiteral(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	return expr.IsNil() || scmerIsSymbol(expr, "nil")
+}
+
+func optimizerZeroLiteral(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	return (expr.IsInt() && expr.Int() == 0) || (expr.IsFloat() && expr.Float() == 0)
+}
+
+// optimizePlannerReduceFold lowers common planner folds to physical loops. It
+// only inspects the already optimized reducer's root shape, keeping the whole
+// optimization pass linear in the expression size.
+func optimizePlannerReduceFold(rv []Scmer, td *TypeDescriptor) (Scmer, *TypeDescriptor, bool) {
+	if len(rv) != 4 {
+		return NewNil(), nil, false
+	}
+	params, body, ok := optimizerLambdaParts(rv[2])
+	if !ok || len(params) < 2 {
+		return NewNil(), nil, false
+	}
+	bodyItems, ok := scmerSlice(body)
+	if !ok || len(bodyItems) < 3 {
+		return NewNil(), nil, false
+	}
+	if len(bodyItems) == 3 && scmerIsSymbol(bodyItems[0], "+") &&
+		optimizerLambdaParamReference(bodyItems[1], params, 0) && optimizerZeroLiteral(rv[3]) {
+		callback, ok := optimizerLambdaWithBody(rv[2], bodyItems[2])
+		if !ok {
+			return NewNil(), nil, false
+		}
+		return NewSlice([]Scmer{NewSymbol("sum_map"), rv[1], callback, rv[3]}), &TypeDescriptor{Kind: "number"}, true
+	}
+	if (scmerIsSymbol(bodyItems[0], "or") || scmerIsSymbol(bodyItems[0], "and")) &&
+		optimizerLambdaParamReference(bodyItems[1], params, 0) {
+		wantNeutral := scmerIsSymbol(bodyItems[0], "and")
+		neutral, ok := optimizerBoolLiteral(rv[3])
+		if !ok || neutral != wantNeutral {
+			return NewNil(), nil, false
+		}
+		candidate := bodyItems[2]
+		if len(bodyItems) > 3 {
+			candidate = NewSlice(append([]Scmer{bodyItems[0]}, bodyItems[2:]...))
+		}
+		callback, ok := optimizerLambdaWithBody(rv[2], candidate)
+		if !ok {
+			return NewNil(), nil, false
+		}
+		name := "reduce_any"
+		if wantNeutral {
+			name = "reduce_all"
+		}
+		return NewSlice([]Scmer{NewSymbol(name), rv[1], callback}), &TypeDescriptor{Kind: "bool"}, true
+	}
+
+	if len(bodyItems) == 4 && scmerIsSymbol(bodyItems[0], "if") && optimizerNilLiteral(rv[3]) {
+		condition, ok := scmerSlice(bodyItems[1])
+		if !ok || len(condition) != 2 || !scmerIsSymbol(condition[0], "not") {
+			return NewNil(), nil, false
+		}
+		nilCall, ok := scmerSlice(condition[1])
+		if !ok || len(nilCall) != 2 || !scmerIsSymbol(nilCall[0], "nil?") ||
+			!optimizerLambdaParamReference(nilCall[1], params, 0) ||
+			!optimizerLambdaParamReference(bodyItems[2], params, 0) {
+			return NewNil(), nil, false
+		}
+		callback, ok := optimizerLambdaWithBody(rv[2], bodyItems[3])
+		if !ok {
+			return NewNil(), nil, false
+		}
+		return NewSlice([]Scmer{NewSymbol("find_map_notnull"), rv[1], callback}), td, true
+	}
+
+	return NewNil(), nil, false
+}
+
 // optimizeReduce keeps merge as a segmented producer when its flattened value
 // is consumed exactly once by reduce. reduce_segments validates all segments
 // before invoking the callback, matching merge's existing error order.
@@ -650,14 +790,17 @@ func optimizeReduce(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Ty
 		return NewSlice(fused), td
 	}
 	segments, ok := optimizedMergeSegments(rv[1])
-	if !ok || !mergeValidationSafeDeferredArgument(rv[2], true) ||
-		(len(rv) == 4 && !mergeValidationSafeDeferredArgument(rv[3], false)) {
-		return result, td
+	if ok && mergeValidationSafeDeferredArgument(rv[2], true) &&
+		(len(rv) != 4 || mergeValidationSafeDeferredArgument(rv[3], false)) {
+		fused := make([]Scmer, 0, len(rv))
+		fused = append(fused, NewSymbol("reduce_segments"), segments)
+		fused = append(fused, rv[2:]...)
+		return NewSlice(fused), td
 	}
-	fused := make([]Scmer, 0, len(rv))
-	fused = append(fused, NewSymbol("reduce_segments"), segments)
-	fused = append(fused, rv[2:]...)
-	return NewSlice(fused), td
+	if fused, fusedType, ok := optimizePlannerReduceFold(rv, td); ok {
+		return fused, fusedType
+	}
+	return result, td
 }
 
 // optimizeMap is the optimizer hook for `map`. It applies default optimization
@@ -736,6 +879,9 @@ func optimizeFilter(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Ty
 	case scmerIsSymbol(inner[0], "map") || scmerIsSymbol(inner[0], "map_mut"):
 		if exprMayHaveSideEffects(inner[2]) || exprMayHaveSideEffects(rv[2]) {
 			return result, td
+		}
+		if optimizerNonNilPredicate(rv[2]) {
+			return NewSlice([]Scmer{NewSymbol("map_filter_notnull"), inner[1], inner[2]}), descriptorWithLength(FreshAlloc, UnknownLength)
 		}
 		return NewSlice([]Scmer{NewSymbol("filter_map"), inner[1], inner[2], rv[2]}), descriptorWithLength(FreshAlloc, UnknownLength)
 	case scmerIsSymbol(inner[0], "filter") || scmerIsSymbol(inner[0], "filter_mut"):
@@ -7068,6 +7214,149 @@ func init_list() {
 				{Kind: "func", Label: "condition", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "bool"}},
 			},
 			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "map_filter_notnull",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "map_filter_notnull")
+			mapper := OptimizeProcToSerialFunction(a[1])
+			result := make([]Scmer, 0, len(input))
+			for _, item := range input {
+				mapped := mapper(item)
+				if !mapped.IsNil() {
+					result = append(result, mapped)
+				}
+			}
+			return NewSlice(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map and non-nil filter (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "sum_map",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "sum_map")
+			mapper := OptimizeProcToSerialFunction(a[1])
+			result := a[2]
+			for _, item := range input {
+				mapped := mapper(result, item)
+				if result.IsNil() || mapped.IsNil() {
+					result = NewNil()
+				} else if result.IsInt() && mapped.IsInt() {
+					result = NewInt(result.Int() + mapped.Int())
+				} else {
+					result = NewFloat(result.Float() + mapped.Float())
+				}
+			}
+			return result
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map and numeric sum reduction (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any", Label: "sum"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "number"}},
+				{Kind: "number", Label: "zero"},
+			},
+			Return:    &TypeDescriptor{Kind: "number"},
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "reduce_any",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "reduce_any")
+			candidate := OptimizeProcToSerialFunction(a[1])
+			state := NewBool(false)
+			for _, item := range input {
+				value := candidate(state, item)
+				if value.IsNil() {
+					state = NewNil()
+				} else if value.Bool() {
+					return NewBool(true)
+				}
+			}
+			return state
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "short-circuiting three-valued OR reduction (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "candidate", Params: []*TypeDescriptor{{Kind: "any", Label: "state"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "bool"},
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "reduce_all",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "reduce_all")
+			candidate := OptimizeProcToSerialFunction(a[1])
+			state := NewBool(true)
+			for _, item := range input {
+				value := candidate(state, item)
+				if value.IsNil() {
+					state = NewNil()
+				} else if !value.Bool() {
+					return NewBool(false)
+				}
+			}
+			return state
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "short-circuiting three-valued AND reduction (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "candidate", Params: []*TypeDescriptor{{Kind: "any", Label: "state"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "bool"},
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "find_map_notnull",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "find_map_notnull")
+			candidate := OptimizeProcToSerialFunction(a[1])
+			for _, item := range input {
+				value := candidate(NewNil(), item)
+				if !value.IsNil() {
+					return value
+				}
+			}
+			return NewNil()
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "maps until the first non-nil result (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "candidate", Params: []*TypeDescriptor{{Kind: "any", Label: "state"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "any"},
 			Const:     true,
 			Forbidden: true,
 

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -45,6 +45,130 @@ func TestOptimizeFusesFilterOverMap(t *testing.T) {
 	}
 }
 
+func TestOptimizeFusesMapAndNonNilFilter(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(filter (map values (lambda (value) (if (> value 1) (* value 10) nil)))
+			(lambda (value) (not (nil? value)))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "map_filter_notnull") {
+		t.Fatalf("map/non-nil filter pipeline was not fused: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(0), NewInt(2), NewInt(3)}))
+	want := NewSlice([]Scmer{NewInt(20), NewInt(30)})
+	if !Equal(got, want) {
+		t.Fatalf("fused map/non-nil filter returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeLowersBooleanReducers(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		fused    string
+		input    []Scmer
+		expected Scmer
+	}{
+		{
+			name:     "or preserves unknown",
+			source:   `(lambda (values) (reduce values (lambda (found value) (or found (if (equal? value 0) nil (> value 2)))) false))`,
+			fused:    "reduce_any",
+			input:    []Scmer{NewInt(0), NewInt(1)},
+			expected: NewNil(),
+		},
+		{
+			name:     "or short circuits true",
+			source:   `(lambda (values) (reduce values (lambda (found value) (or found (if (equal? value 0) nil (> value 2)))) false))`,
+			fused:    "reduce_any",
+			input:    []Scmer{NewInt(0), NewInt(3)},
+			expected: NewBool(true),
+		},
+		{
+			name:     "and preserves unknown",
+			source:   `(lambda (values) (reduce values (lambda (valid value) (and valid (if (equal? value 0) nil (> value 1)))) true))`,
+			fused:    "reduce_all",
+			input:    []Scmer{NewInt(0), NewInt(2)},
+			expected: NewNil(),
+		},
+		{
+			name:     "and short circuits false",
+			source:   `(lambda (values) (reduce values (lambda (valid value) (and valid (if (equal? value 0) nil (> value 1)))) true))`,
+			fused:    "reduce_all",
+			input:    []Scmer{NewInt(0), NewInt(1)},
+			expected: NewBool(false),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if !strings.Contains(serialized, tc.fused) {
+				t.Fatalf("boolean reducer was not lowered to %s: %s", tc.fused, serialized)
+			}
+			fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+			got := fn(NewSlice(tc.input))
+			if !Equal(got, tc.expected) {
+				t.Fatalf("lowered reducer returned %s, want %s", String(got), String(tc.expected))
+			}
+		})
+	}
+}
+
+func TestOptimizeLowersFirstNonNilReducer(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(reduce values
+			(lambda (found value)
+				(if (not (nil? found)) found (if (> value 2) (* value 10) nil)))
+			nil))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "find_map_notnull") {
+		t.Fatalf("first non-nil reducer was not lowered: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(1), NewInt(3), NewInt(4)}))
+	want := NewInt(30)
+	if !Equal(got, want) {
+		t.Fatalf("lowered first non-nil reducer returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeLowersMappedSumReducer(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(reduce values (lambda (total value) (+ total (* value 2))) 0))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "sum_map") {
+		t.Fatalf("mapped sum reducer was not lowered: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
+	want := NewInt(12)
+	if !Equal(got, want) {
+		t.Fatalf("lowered mapped sum returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeKeepsReducerWithWrongNeutral(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(reduce values (lambda (found value) (or found (> value 1))) true))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "reduce_any") {
+		t.Fatalf("OR reducer with non-identity neutral was unsafely lowered: %s", serialized)
+	}
+}
+
+func TestOptimizeKeepsProducerFusionAheadOfBooleanReducer(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(reduce (map values (lambda (value) (> value 1)))
+			(lambda (found value) (or found value)) false))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "reduce_map") || strings.Contains(serialized, "reduce_any") {
+		t.Fatalf("boolean lowering displaced allocation-free producer fusion: %s", serialized)
+	}
+}
+
 func TestOptimizeFusesFixedWidthMergeOverMap(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
 		(merge (map values (lambda (value) (list value (+ value 10))))))`)
@@ -264,6 +388,62 @@ func TestOptimizeKeepsDynamicReducerAfterMergeValidation(t *testing.T) {
 			serialized := serializedTestExpr(t, env, optimized)
 			if strings.Contains(serialized, tc.fused) {
 				t.Fatalf("dynamic reducer moved ahead of merge validation: %s", serialized)
+			}
+		})
+	}
+}
+
+func BenchmarkPlannerReducerLowerings(b *testing.B) {
+	values := make([]Scmer, 128)
+	for i := range values {
+		values[i] = NewInt(int64(i + 1))
+	}
+	input := NewSlice(values)
+	tests := []struct {
+		name   string
+		source string
+		check  func(Scmer) bool
+	}{
+		{
+			name:   "SumMap",
+			source: `(lambda (values) (reduce values (lambda (total value) (+ total (* value 2))) 0))`,
+			check:  func(result Scmer) bool { return result.Int() == 16512 },
+		},
+		{
+			name:   "AnyEarly",
+			source: `(lambda (values) (reduce values (lambda (found value) (or found (> value 0))) false))`,
+			check:  func(result Scmer) bool { return result.Bool() },
+		},
+		{
+			name:   "AllEarly",
+			source: `(lambda (values) (reduce values (lambda (valid value) (and valid (< value 1))) true))`,
+			check:  func(result Scmer) bool { return !result.Bool() },
+		},
+		{
+			name: "FindMapEarly",
+			source: `(lambda (values)
+				(reduce values (lambda (found value)
+					(if (not (nil? found)) found (if (> value 0) value nil))) nil))`,
+			check: func(result Scmer) bool { return result.Int() == 1 },
+		},
+		{
+			name: "MapFilterNotNull",
+			source: `(lambda (values)
+				(filter (map values (lambda (value) (if (> value 64) value nil)))
+					(lambda (value) (not (nil? value)))))`,
+			check: func(result Scmer) bool { return len(result.Slice()) == 64 },
+		},
+	}
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			optimized, env := optimizeListPipeline(b, tc.source)
+			fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if result := fn(input); !tc.check(result) {
+					b.Fatal("unexpected benchmark result")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What

Lower common reducer shapes emitted by the Scheme query planner to optimizer-only physical list operators:

- numeric accumulation: `reduce` + mapped `+` -> `sum_map`
- boolean folds: `or` / `and` -> short-circuiting `reduce_any` / `reduce_all`
- first non-null fold -> `find_map_notnull`
- `filter(map(...), not nil?)` -> `map_filter_notnull`

The existing producer fusions (`reduce_map`, `reduce_filter`, segmented merge lowering) retain priority, so this does not replace already allocation-free pipelines with a weaker lowering.

## Concrete value after #665

#665 made existing `TypeDescriptor.Transfer` ownership information usable by parameter-specialized `Proc` variants. This PR does not add another ownership flag and does not duplicate that feature.

Its separate value is eliminating generic Scheme reducer dispatch in planner analysis code. The Go optimizer recognizes the already-optimized root shape and emits one purpose-built physical loop. That removes intermediate mapped/filter lists where applicable, repeated generic `reduce` callback boundaries, and unnecessary traversal after a terminal boolean/non-null result.

The recognizer does not run another optimizer or analysis pass over subtrees. It consumes the information and code produced by the current recursive pass and only inspects the reducer root, keeping optimization linear rather than introducing an O(N²) re-analysis pattern. The Scheme planner sources remain unchanged; the optimizer handles the existing idiom itself.

## A/B measurements against master (`1529e9081`)

Both variants used the same benchmark harness, 8 samples each, `-benchtime=500ms`.

| focused case | time/op master -> PR | delta | bytes/op master -> PR | allocs/op master -> PR |
|---|---:|---:|---:|---:|
| mapped sum | 8,827.9 -> 7,294.4 ns | -17.4% | 4,800 -> 4,632 | 149 -> 143 |
| boolean any, early hit | 5,806.1 -> 726.8 ns | -87.5% | 4,696 -> 568 | 146 -> 16 |
| boolean all, early miss | 5,827.2 -> 746.2 ns | -87.2% | 4,696 -> 568 | 146 -> 16 |
| first non-null, early hit | 8,761.4 -> 920.2 ns | -89.5% | 5,072 -> 664 | 161 -> 20 |
| map + non-null filter | 15,565.2 -> 8,726.2 ns | -43.9% | 7,600 -> 4,968 | 294 -> 148 |

End-to-end cold compile measurement used `tests/performance/group-lookup-performance.yaml`, case `structural group expression compile scaling`: a 160-key `EXPLAIN COMPILE`. Seven interleaved master/PR pairs were run with `PERF_REPEAT=1` to avoid drift from running all samples of one binary together.

| | master | PR | delta |
|---|---:|---:|---:|
| mean | 655.856 ms | 636.346 ms | -3.0% |
| median | 653.676 ms | 630.204 ms | -3.6% |

The PR won 6 of 7 interleaved pairs.

## Correctness

- preserves Scheme three-valued `nil` behavior for `or` and `and`
- validates identity values before lowering
- preserves the exact numeric zero representation for mapped sums
- adds focused optimizer/result tests for every lowering and for producer-fusion priority
- full `./git-pre-commit`: passed
