### PR TITLE
perf: stream planner unique collectors

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -982,6 +982,107 @@ func asAssoc(v Scmer, ctx string) ([]Scmer, *FastDict) {
 	panic(fmt.Sprintf("%s expects a dictionary", ctx))
 }
 
+const orderedUniqueHashThreshold = 8
+
+type orderedUniqueBuilder struct {
+	linear       []Scmer
+	dict         *FastDict
+	hashDomain   uint8
+	hashDisabled bool
+}
+
+func orderedUniqueCanonical(value Scmer) (Scmer, uint8, bool) {
+	// FastDict hashes type tags while Equal deliberately coerces across types.
+	// Hash only a proven homogeneous domain; add degrades to the exact linear
+	// Equal path as soon as a value leaves that domain.
+	switch value.GetTag() {
+	case tagString, tagSymbol, tagCString, tagBString:
+		return NewString(value.String()), 1, true
+	case tagInt:
+		return value, 2, true
+	case tagFloat:
+		if value.Float() == 0 {
+			return NewFloat(0), 3, true
+		}
+		return value, 3, true
+	case tagBool:
+		return value, 4, true
+	case tagNil:
+		return value, 5, true
+	case tagDate:
+		return value, 6, true
+	default:
+		return NewNil(), 0, false
+	}
+}
+
+func keepOrderedUniqueFirst(oldValue, _ Scmer) Scmer {
+	return oldValue
+}
+
+func (builder *orderedUniqueBuilder) promote() {
+	if builder.hashDisabled || len(builder.linear) < orderedUniqueHashThreshold {
+		return
+	}
+	dict := NewFastDictValue(len(builder.linear))
+	domain := uint8(0)
+	for _, value := range builder.linear {
+		key, valueDomain, ok := orderedUniqueCanonical(value)
+		if !ok || (domain != 0 && domain != valueDomain) {
+			builder.hashDisabled = true
+			return
+		}
+		domain = valueDomain
+		dict.Set(key, value, keepOrderedUniqueFirst)
+	}
+	builder.linear = nil
+	builder.dict = dict
+	builder.hashDomain = domain
+}
+
+func (builder *orderedUniqueBuilder) degrade() {
+	pairs := builder.dict.Pairs
+	builder.linear = make([]Scmer, len(pairs)/2)
+	for i := range builder.linear {
+		builder.linear[i] = pairs[i*2+1]
+	}
+	builder.dict = nil
+	builder.hashDisabled = true
+}
+
+func (builder *orderedUniqueBuilder) add(value Scmer) {
+	if builder.dict != nil {
+		key, domain, ok := orderedUniqueCanonical(value)
+		if ok && domain == builder.hashDomain {
+			builder.dict.Set(key, value, keepOrderedUniqueFirst)
+			return
+		}
+		builder.degrade()
+	}
+	for _, existing := range builder.linear {
+		if Equal(value, existing) {
+			return
+		}
+	}
+	builder.linear = append(builder.linear, value)
+	builder.promote()
+}
+
+func (builder *orderedUniqueBuilder) result() []Scmer {
+	if builder.dict == nil {
+		return builder.linear
+	}
+	pairs := builder.dict.Pairs
+	length := len(pairs) / 2
+	// The builder owns the transient dictionary. Compact its insertion-ordered
+	// values over the disposable keys instead of allocating another result.
+	for i := 0; i < length; i++ {
+		pairs[i] = pairs[i*2+1]
+	}
+	clear(pairs[length:])
+	return pairs[:length:length]
+}
+
 func init_list() {
 	// list functions
 	DeclareTitle("Lists")
@@ -8565,6 +8666,34 @@ func init_list() {
 			JITEmit: nil,
 		},
 	})
+	Declare(&Globalenv, &Declaration{
+		Name: "flat_map_unique",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "flat_map_unique")
+			mapper := PrepareSerialProc(a[1])
+			var mapperArgs [1]Scmer
+			builder := orderedUniqueBuilder{}
+			for _, item := range input {
+				mapperArgs[0] = item
+				for _, mapped := range asSlice(mapper.Call(mapperArgs[:]), "flat_map_unique result") {
+					builder.add(mapped)
+				}
+			}
+			return NewSlice(builder.result())
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "fused serial map, flatten, and stable unique collection (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "map", Params: []*TypeDescriptor{{Kind: "any"}}, Return: &TypeDescriptor{Kind: "list"}},
+			},
+			Return:    FreshAlloc,
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: nil,
+		},
+	})
 	// _mut variants: optimizer-only, forbidden from .scm code
 	// Tier 1: same-length, zero-copy
 
@@ -9855,12 +9984,32 @@ func optimizedSingletonListItem(expr Scmer) (Scmer, bool) {
 	return NewNil(), false
 }
 
-// optimizeMergeUnique keeps merge_unique on the standard variadic path and
-// reuses an exclusively owned first argument. The common mutating-operator
-// pipeline also keeps that transferred argument heap-backed so the returned
-// list cannot alias a numbered lambda frame.
+// optimizeMergeUnique streams a mapped list-of-lists into an ordered unique
+// collector when the existing bottom-up type information proves that every
+// mapper result is a list. It does not revisit the mapper body.
 func optimizeMergeUnique(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
-	return oc.applyDefaultOptimization(v, useResult, "merge_unique_mut")
+	call := oc.applyDefaultOptimizationWithTypes(v, useResult, "merge_unique_mut")
+	result, td, argumentTypes := call.code, call.typeInfo, call.argumentTypes
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) != 2 {
+		return result, td
+	}
+	producer, ok := scmerSlice(rv[1])
+	if !ok || len(producer) != 3 ||
+		(!scmerIsSymbol(producer[0], "map") && !scmerIsSymbol(producer[0], "map_mut")) ||
+		exprMayHaveSideEffects(producer[2]) {
+		return result, td
+	}
+	producerType := optimizedArgumentType(argumentTypes, 1)
+	if producerType.Extra == nil || producerType.Extra.Element == nil || producerType.Extra.Element.Kind != "list" {
+		return result, td
+	}
+	elementType := tiZero
+	if producerType.Extra.Element.Element != nil {
+		elementType = TypeInfoFromTD(producerType.Extra.Element.Element)
+	}
+	return NewSlice([]Scmer{NewSymbol("flat_map_unique"), producer[1], producer[2]}),
+		setOptimizedCallElement(descriptorWithLength(FreshAlloc, UnknownLength), elementType)
 }
 
 func flattenConsList(v []Scmer) ([]Scmer, bool) {

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -17,6 +17,8 @@ Copyright (C) 2026  Carl-Philip Haensch
 package scm
 
 import (
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 )
@@ -306,12 +308,12 @@ func TestOptimizeFusesReduceOverMapThenFilter(t *testing.T) {
 	}
 }
 
-func TestOptimizeKeepsMergeUniqueOverMapOfLists(t *testing.T) {
+func TestOptimizeFusesMergeUniqueOverMapOfLists(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
 		(merge_unique (map values (lambda (value) (list (+ value 1))))))`)
 	serialized := serializedTestExpr(t, env, optimized)
-	if strings.Contains(serialized, "merge_unique_map") {
-		t.Fatalf("merge_unique/map-of-lists pipeline was unsafely fused: %s", serialized)
+	if !strings.Contains(serialized, "flat_map_unique") {
+		t.Fatalf("merge_unique/map-of-lists pipeline was not fused: %s", serialized)
 	}
 
 	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
@@ -322,12 +324,21 @@ func TestOptimizeKeepsMergeUniqueOverMapOfLists(t *testing.T) {
 	}
 }
 
+func TestOptimizeKeepsMergeUniqueOverMapWithUnknownItems(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(merge_unique (map values (lambda (value) value))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "flat_map_unique") {
+		t.Fatalf("merge_unique/map with unproven mapper result was fused: %s", serialized)
+	}
+}
+
 func TestOptimizeKeepsMergeUniqueOverFilterMapOfLists(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
 		(merge_unique (map (filter values (lambda (value) (> value 1))) (lambda (value) (list (* value 2))))))`)
 	serialized := serializedTestExpr(t, env, optimized)
-	if strings.Contains(serialized, "merge_unique_map_filter") {
-		t.Fatalf("merge_unique/map/filter-of-lists pipeline was unsafely fused: %s", serialized)
+	if strings.Contains(serialized, "flat_map_unique") {
+		t.Fatalf("merge_unique/map/filter-of-lists pipeline lost its filter: %s", serialized)
 	}
 
 	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
@@ -335,6 +346,44 @@ func TestOptimizeKeepsMergeUniqueOverFilterMapOfLists(t *testing.T) {
 	want := NewSlice([]Scmer{NewInt(4), NewInt(6)})
 	if !Equal(got, want) {
 		t.Fatalf("merge_unique/map/filter returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOrderedUniqueBuilderPreservesEqualAcrossHashDomains(t *testing.T) {
+	builder := orderedUniqueBuilder{}
+	for i := int64(0); i < orderedUniqueHashThreshold; i++ {
+		builder.add(NewInt(i))
+	}
+	builder.add(NewFloat(3))
+	builder.add(NewString("4"))
+	got := NewSlice(builder.result())
+	want := NewSlice([]Scmer{
+		NewInt(0), NewInt(1), NewInt(2), NewInt(3),
+		NewInt(4), NewInt(5), NewInt(6), NewInt(7),
+	})
+	if !Equal(got, want) {
+		t.Fatalf("ordered unique fallback returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOrderedUniqueBuilderPreservesFirstValueInHashDomain(t *testing.T) {
+	builder := orderedUniqueBuilder{}
+	for i := 0; i < orderedUniqueHashThreshold; i++ {
+		builder.add(NewString(fmt.Sprintf("column-%d", i)))
+	}
+	builder.add(NewSymbol("column-3"))
+	got := builder.result()
+	if len(got) != orderedUniqueHashThreshold || got[3].GetTag() != tagString {
+		t.Fatalf("ordered unique hash path did not preserve the first value: %v", got)
+	}
+
+	floatBuilder := orderedUniqueBuilder{}
+	for i := 0; i < orderedUniqueHashThreshold; i++ {
+		floatBuilder.add(NewFloat(float64(i)))
+	}
+	floatBuilder.add(NewFloat(math.Copysign(0, -1)))
+	if result := floatBuilder.result(); len(result) != orderedUniqueHashThreshold {
+		t.Fatalf("ordered unique hash path treated signed zero as distinct: %v", result)
 	}
 }
 
@@ -446,5 +495,23 @@ func BenchmarkPlannerReducerLowerings(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkPlannerFlatMapUnique(b *testing.B) {
+	values := make([]Scmer, 128)
+	for i := range values {
+		values[i] = NewString(fmt.Sprintf("column-%d", i))
+	}
+	input := NewSlice(values)
+	optimized, env := optimizeListPipeline(b, `(lambda (values)
+		(merge_unique (map values (lambda (value) (list value value)))))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if result := fn(input); len(result.Slice()) != len(values) {
+			b.Fatal("unexpected benchmark result")
+		}
 	}
 }


### PR DESCRIPTION
## What

Lower the common planner pipeline

```scheme
(merge_unique (map input mapper))
```

to the optimizer-only physical operator `flat_map_unique` when the existing bottom-up type descriptor proves that `mapper` returns lists.

The operator streams mapper results directly into an ordered unique builder. Small results retain linear lookup; at eight elements the builder promotes a homogeneous hash domain to the existing `FastDict`. The owned FastDict pair storage is compacted in place into the final insertion-ordered list, so there is no separate result allocation.

This removes the mapped outer list, the separate flatten pass, and the quadratic linear duplicate scan for the dominant planner string/symbol collections.

## Optimizer complexity

The lowering does not analyze the mapper body again. `optimizeMergeUnique` consumes the code and nested element type produced by the existing recursive optimizer call, keeping the optimizer traversal linear. It also propagates the mapped list's element descriptor to the fused result.

## Equality and evaluation safety

`merge_unique` uses coercive `Equal`, while `FastDict.HashKey` is type-sensitive. The builder therefore hashes only homogeneous, compatible domains. If a later value changes domains or cannot be hashed safely, it converts once to the original linear `Equal` path. Tests cover mixed int/float/string values, string/symbol first-value preservation, and signed floating zero.

The fusion is only emitted when the mapper is side-effect-free and its existing return descriptor proves a list result. Unknown mapper results retain the original materialize-then-validate behavior.

## A/B against master (`f6b4abecf`)

Focused benchmark: 128 planner-style column strings, each mapper result containing two duplicate entries. Eight samples per side, `-benchtime=500ms`.

| | master | PR | delta |
|---|---:|---:|---:|
| mean time/op | 182,352 ns | 43,185 ns | -76.3% |
| median time/op | 181,476 ns | 42,890 ns | -76.4% |
| allocs/op | 779 | 672 | -13.7% |
| bytes/op | 19,296 | 31,560 | +63.6% |

The transient byte increase is the FastDict index which replaces quadratic comparisons. It does not survive the operator: its owned pair storage becomes the result list and the hash index is discarded.

End-to-end: cold process and database for every sample; 160-key `structural group expression compile scaling` query from `tests/performance/group-lookup-performance.yaml`; seven interleaved master/PR pairs.

| | master | PR | delta |
|---|---:|---:|---:|
| median `planner_total_ns` | 365.830 ms | 356.774 ms | -2.5% |
| mean `planner_total_ns` | 374.574 ms | 359.298 ms | -4.1% |

The PR won 6 of 7 interleaved pairs. One master sample was an outlier at 436 ms; the median remains positive without relying on it.

## Validation

- focused optimizer and equality-domain tests
- full `./git-pre-commit`: passed
