### PR TITLE
perf: reduce warm SQL request overhead

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -429,6 +429,15 @@ cache_key = username:schema:view-generation:hash(query-shape), retaining policy
 isolation while sharing safe SELECT plans across literal variants. Each entry
 is a variadic if chain of guarded specialized plans plus one compile miss arm.
 On parse error the result is not cached. */
+/* Frontends defer the system.user lookup until a cache producer actually
+runs. A warm plan already owns its compiled policy and must not rescan the
+user table merely to discard a newly constructed policy closure. */
+(define sql_policy_spec_resolve (lambda (policy_spec)
+	(if (and (list? policy_spec)
+		(equal? (car policy_spec) (quote sql-policy-for)))
+		(sql_policy (cadr policy_spec))
+		policy_spec)))
+
 (define cached_parse (lambda (queryplan_cache parse_fn schema query policy username session parameterize_literals)
 	(begin
 		(define explain_query (match (toUpper query)
@@ -460,7 +469,8 @@ On parse error the result is not cached. */
 			previous result into a cache hit. The inspected query is never run. */
 			(define exact_compile (lambda ()
 				(begin
-					(define compile_policy (sql_compile_table_policy policy))
+					(define resolved_policy (sql_policy_spec_resolve policy))
+					(define compile_policy (sql_compile_table_policy resolved_policy))
 					(optimize (with_session session (lambda ()
 						(parse_fn schema parse_query compile_policy)))))))
 			(define formula (if (or compile_diagnostic (not guarded_select))
@@ -469,7 +479,8 @@ On parse error the result is not cached. */
 					(queryplan_cache "get_or_compute" cache_key exact_compile))
 				(begin
 					(define cached_entry (queryplan_cache "get_or_compute" cache_key
-						(lambda () (sql_queryplan_new_entry queryplan_cache cache_key parse_fn schema parse_query policy session))))
+						(lambda () (sql_queryplan_new_entry queryplan_cache cache_key parse_fn schema parse_query
+							(sql_policy_spec_resolve policy) session))))
 					(cadr cached_entry))))
 			formula)))))
 
@@ -683,7 +694,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					/* Bind URL query params (v1=, v2=, ...) as prepared-statement args into the session
 					before parse/build so session-sensitive planner rewrites see the right values. */
 					(extract_assoc (req "query") (lambda (k v) (session k v)))
-					(define formula (cached_parse sql_queryplan_cache parse_sql schema query (sql_policy (req "username")) (req "username") session true))
+					(define formula (cached_parse sql_queryplan_cache parse_sql schema query
+						(list (quote sql-policy-for) (req "username")) (req "username") session true))
 					(set resultrow_called false)
 					(set original_resultrow resultrow)
 					(define resultrow (lambda (row) (begin
@@ -752,7 +764,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						/* Bind URL query params (v1=, v2=, ...) as prepared-statement args into the session
 						before parse/build so session-sensitive planner rewrites see the right values. */
 						(extract_assoc (req "query") (lambda (k v) (session k v)))
-						(define formula (cached_parse psql_queryplan_cache parse_psql schema query (sql_policy (req "username")) (req "username") session false))
+						(define formula (cached_parse psql_queryplan_cache parse_psql schema query
+							(list (quote sql-policy-for) (req "username")) (req "username") session false))
 						(sql_execute_formula session execution_context formula resultrow)
 					)))
 					/* If no resultrow was called and we got a number, return it as affected_rows */
@@ -863,8 +876,10 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 				(set sql_parse_input (match sql_parse_input (regex "^((?s:.*));\\s*$" _ body) body sql_parse_input))
 				(define mysql_username (coalesce (session "username") "root"))
 				(define formula (if (equal? (session "syntax") "postgresql")
-					(cached_parse psql_queryplan_cache parse_psql schema sql_parse_input (sql_policy mysql_username) mysql_username session false)
-					(cached_parse sql_queryplan_cache parse_sql schema sql_parse_input (sql_policy mysql_username) mysql_username session true)))
+					(cached_parse psql_queryplan_cache parse_psql schema sql_parse_input
+						(list (quote sql-policy-for) mysql_username) mysql_username session false)
+					(cached_parse sql_queryplan_cache parse_sql schema sql_parse_input
+						(list (quote sql-policy-for) mysql_username) mysql_username session true)))
 				(sql_execute_formula session execution_context formula resultrow)
 			) sql))
 	)) (lambda (e) (begin

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -439,7 +439,6 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			item := a[0].Slice()
 			resultlock.Lock()
 			defer resultlock.Unlock()
-			updateFlags(session, sessionFunc) // set transaction status
 
 			newitem := appendMySQLResultRow(&result, colmap, item)
 			if len(result.Rows) == cap(result.Rows) {
@@ -479,7 +478,8 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 		result.InsertID = uint64(lastInsertId.Int())
 	}
 	result.RowsAffected = uint64(rowcount.Int())
-	// update status greeting
+	// Transaction and schema status can change once per statement, not once per
+	// emitted result row. Publish the final state before flushing the result.
 	updateFlags(session, sessionFunc)
 	// flush the rest
 	if result.State == sqltypes.RStateFields {

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -96,7 +96,7 @@ func runFanoutTasks(currentTx *TxContext, taskCount int, task func(int, bool)) <
 	startWorker := gls.Go
 	if currentTx != nil {
 		ss := SessionStateFromTx(currentTx)
-		querySeq := scm.CurrentQuerySeq()
+		querySeq := querySeqFromTx(currentTx)
 		startWorker = func(worker func()) {
 			go func() {
 				// A worker needs one complete execution context. Nesting

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -526,7 +526,7 @@ func (t *table) scanExists(currentTx *TxContext, conditionCols []string, conditi
 
 func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, conditionCols []string, condition scm.Scmer) bool {
 	ss := SessionStateFromTx(currentTx)
-	querySeq := scm.CurrentQuerySeq()
+	querySeq := querySeqFromTx(currentTx)
 	touchTempColumns(t, conditionCols, nil)
 	var scratch *scanAnalyzeScratch
 	var boundaries boundaries
@@ -604,7 +604,7 @@ func (t *table) scanWithBatch(currentTx *TxContext, conditionCols []string, cond
 
 func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditionCols []string, condition scm.Scmer, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, aggregate2 scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer, requiredBoundaries boundaries) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
-	querySeq := scm.CurrentQuerySeq()
+	querySeq := querySeqFromTx(currentTx)
 	hasMutationCallback := false
 	for _, c := range callbackCols {
 		if c == "$update" || (len(c) > 11 && c[:11] == "$increment:") {


### PR DESCRIPTION
## What

- defer `sql_policy` construction until a query-plan cache producer actually runs, avoiding a discarded `system.user` scan on warm cache hits
- reuse the statement generation already stored on autocommit transactions instead of rediscovering it through goroutine-local context in scan setup and fanout setup
- publish MySQL transaction/schema flags once after statement execution instead of once per emitted row

These are request-setup changes; the selected physical plan and storage operators are unchanged.

## Manual A/B measurements

The target WordPress query was repeated through the MySQL protocol with PyMySQL against matching 8,214-post/75,000-postmeta datasets. MariaDB used `wordpress_ab_realistic_20260829`; MemCP used the equivalent performance fixture. MariaDB's query cache was off. Each engine received 500 warmups per run. Results pool two alternating runs with seven blocks of 5,000 timed queries: 70,000 timed requests per engine. Values are medians of the fourteen block means.

| Engine | WordPress Posts↔Postmeta join | Relative to PR |
|---|---:|---:|
| MariaDB 10.11.14 | 0.333 ms | 0.83x |
| MemCP master | 0.597 ms | 1.49x |
| MemCP PR | 0.399 ms | 1.00x |

The PR is 33.1% faster than master. MariaDB remains 20.0% faster than the PR for this small query.

Two additional OLTP shapes were measured in a separate alternating master/PR control run with 40,000 timed requests per revision and shape:

| Query shape | master | PR | Change | Speedup |
|---|---:|---:|---:|---:|
| `SELECT ID, post_status, post_type FROM wordpress_perf_posts ORDER BY post_title LIMIT 5` | 0.436 ms | 0.314 ms | -28.0% | 1.39x |
| `SELECT post_title FROM wordpress_perf_posts WHERE ID = 4242` | 0.284 ms | 0.142 ms | -50.0% | 2.00x |

The simple OLTP controls improve alongside the target join, and the smallest point lookup benefits most. This is consistent with removing fixed per-request work rather than specializing one query shape.

## Validation

- `go test ./storage -run 'Test.*(QuerySeq|Parallel|Fanout)' -count=1`
- `go test ./scm -run 'Test.*(Process|Kill|MySQL)' -count=1`
- `tests/sql/security/policy-enforcement.yaml` (15/15)
- `tests/sql/security/grant-revoke.yaml` (64/64)
- `tests/sql/expressions/prepared-stmts.yaml` (54/54)
- `tests/sql/compatibility/mysql-application-sql.yaml` (40/40)
- `tests/sql/compatibility/mysql-error-recovery.yaml` (2/2)
- `tests/sql/compatibility/mysql-prepared-binary.yaml` (1/1)
- `PERF_TEST=1 tests/performance/wordpress-postmeta-order-limit.yaml` (4/4, measured perf case 1.5 ms against its 6 ms threshold)

Per the query-optimization workflow, no local full suite was run; CI is the regression gate.
