### PR TITLE
perf: lower planner membership folds

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -608,6 +608,27 @@ func optimizerLambdaParamReference(expr Scmer, params []Scmer, index int) bool {
 	return ok && scmerIsSymbol(expr, string(param))
 }
 
+// optimizerHoistStableOneLambdaLevel unwraps a stable value captured by the
+// reducer callback when a fused operator consumes it in the parent frame.
+func optimizerHoistStableOneLambdaLevel(expr Scmer) (Scmer, bool) {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if items, ok := scmerSlice(expr); ok {
+		if len(items) == 2 && scmerIsSymbol(items[0], "outer") && optimizerStableReference(expr) {
+			return items[1], true
+		}
+		if len(items) == 2 && scmerIsSymbol(items[0], "quote") {
+			return expr, true
+		}
+		return NewNil(), false
+	}
+	if expr.IsNil() || expr.IsBool() || expr.IsInt() || expr.IsFloat() || expr.IsString() {
+		return expr, true
+	}
+	return NewNil(), false
+}
+
 // optimizerNonNilPredicate recognizes the planner's exact (not (nil? value))
 // filter without analyzing the callback subtree again.
 func optimizerNonNilPredicate(expr Scmer) bool {
@@ -687,6 +708,18 @@ func optimizePlannerReduceFold(rv []Scmer, td *TypeDescriptor) (Scmer, *TypeDesc
 		candidate := bodyItems[2]
 		if len(bodyItems) > 3 {
 			candidate = NewSlice(append([]Scmer{bodyItems[0]}, bodyItems[2:]...))
+		}
+		if containsCall, ok := scmerSlice(candidate); ok && len(containsCall) == 3 &&
+			scmerIsSymbol(containsCall[0], "contains?") &&
+			optimizerLambdaParamReference(containsCall[2], params, 1) &&
+			!exprMayHaveSideEffects(containsCall[1]) {
+			if available, hoisted := optimizerHoistStableOneLambdaLevel(containsCall[1]); hoisted {
+				name := "list_contains_any"
+				if wantNeutral {
+					name = "list_contains_all"
+				}
+				return NewSlice([]Scmer{NewSymbol(name), rv[1], available}), &TypeDescriptor{Kind: "bool"}, true
+			}
 		}
 		callback, ok := optimizerLambdaWithBody(rv[2], candidate)
 		if !ok {
@@ -1081,6 +1114,60 @@ func (builder *orderedUniqueBuilder) result() []Scmer {
 	}
 	clear(pairs[length:])
 	return pairs[:length:length]
+}
+
+func (builder *orderedUniqueBuilder) contains(value Scmer) bool {
+	if builder.dict != nil {
+		if key, domain, ok := orderedUniqueCanonical(value); ok && domain == builder.hashDomain {
+			_, found := builder.dict.Get(key)
+			return found
+		}
+		for index := 1; index < len(builder.dict.Pairs); index += 2 {
+			if Equal(value, builder.dict.Pairs[index]) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, candidate := range builder.linear {
+		if Equal(value, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func listContainsFold(args []Scmer, requireAll bool) Scmer {
+	input := asSlice(args[0], "list membership fold")
+	if len(input) == 0 {
+		return NewBool(requireAll)
+	}
+	available := asSlice(args[1], "list membership fold available")
+	if len(available) < orderedUniqueHashThreshold || len(input)*len(available) < 64 {
+		for _, item := range input {
+			found := false
+			for _, candidate := range available {
+				if Equal(item, candidate) {
+					found = true
+					break
+				}
+			}
+			if found != requireAll {
+				return NewBool(!requireAll)
+			}
+		}
+		return NewBool(requireAll)
+	}
+	index := orderedUniqueBuilder{linear: make([]Scmer, 0, len(available))}
+	for _, candidate := range available {
+		index.add(candidate)
+	}
+	for _, item := range input {
+		if index.contains(item) != requireAll {
+			return NewBool(!requireAll)
+		}
+	}
+	return NewBool(requireAll)
 }
 
 func init_list() {
@@ -10755,6 +10842,36 @@ func init_list() {
 			Forbidden: true,
 
 			JITEmit: nil,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "list_contains_any",
+		Fn: func(a ...Scmer) Scmer {
+			return listContainsFold(a, false)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests whether two lists share a value (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "required", NoEscape: true},
+				{Kind: "list", Label: "available", NoEscape: true},
+			},
+			Return:    &TypeDescriptor{Kind: "bool"},
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "list_contains_all",
+		Fn: func(a ...Scmer) Scmer {
+			return listContainsFold(a, true)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "tests whether one list contains every value from another (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "required", NoEscape: true},
+				{Kind: "list", Label: "available", NoEscape: true},
+			},
+			Return:    &TypeDescriptor{Kind: "bool"},
+			Const:     true,
+			Forbidden: true,
 		},
 	})
 	Declare(&Globalenv, &Declaration{

--- a/scm/list.go
+++ b/scm/list.go
@@ -711,8 +711,7 @@ func optimizePlannerReduceFold(rv []Scmer, td *TypeDescriptor) (Scmer, *TypeDesc
 		}
 		if containsCall, ok := scmerSlice(candidate); ok && len(containsCall) == 3 &&
 			scmerIsSymbol(containsCall[0], "contains?") &&
-			optimizerLambdaParamReference(containsCall[2], params, 1) &&
-			!exprMayHaveSideEffects(containsCall[1]) {
+			optimizerLambdaParamReference(containsCall[2], params, 1) {
 			if available, hoisted := optimizerHoistStableOneLambdaLevel(containsCall[1]); hoisted {
 				name := "list_contains_any"
 				if wantNeutral {

--- a/scm/list_set_optimizer_test.go
+++ b/scm/list_set_optimizer_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestOptimizeLowersListMembershipFolds(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		lowered string
+	}{
+		{
+			name:    "subset",
+			source:  `(lambda (required available) (reduce (coalesceNil required '()) (lambda (ok value) (and ok (contains? available value))) true))`,
+			lowered: "list_contains_all",
+		},
+		{
+			name:    "intersection",
+			source:  `(lambda (left right) (reduce left (lambda (found value) (or found (contains? right value))) false))`,
+			lowered: "list_contains_any",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if !strings.Contains(serialized, tc.lowered) {
+				t.Fatalf("membership fold was not lowered to %s: %s", tc.lowered, serialized)
+			}
+			fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+			got := fn(
+				NewSlice([]Scmer{NewString("a"), NewString("c")}),
+				NewSlice([]Scmer{NewString("a"), NewString("b"), NewString("c")}))
+			if !got.Bool() {
+				t.Fatalf("lowered membership fold returned %s", String(got))
+			}
+		})
+	}
+}
+
+func TestListMembershipFoldPreservesCoerciveEquality(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (required available)
+		(reduce required (lambda (ok value) (and ok (contains? available value))) true))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	required := make([]Scmer, 12)
+	available := make([]Scmer, 16)
+	for index := range available {
+		available[index] = NewString(fmt.Sprintf("%d", index))
+	}
+	for index := range required {
+		required[index] = NewInt(int64(index + 4))
+	}
+	if !fn(NewSlice(required), NewSlice(available)).Bool() {
+		t.Fatal("hashed membership fold lost Equal's numeric/string coercion")
+	}
+}
+
+func TestListMembershipFoldSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		input     []Scmer
+		available []Scmer
+		want      bool
+	}{
+		{
+			name:      "all missing",
+			source:    `(lambda (required available) (reduce required (lambda (ok value) (and ok (contains? available value))) true))`,
+			input:     []Scmer{NewString("a"), NewString("c")},
+			available: []Scmer{NewString("a"), NewString("b")},
+		},
+		{
+			name:      "any missing",
+			source:    `(lambda (left right) (reduce left (lambda (found value) (or found (contains? right value))) false))`,
+			input:     []Scmer{NewString("c"), NewString("d")},
+			available: []Scmer{NewString("a"), NewString("b")},
+		},
+		{
+			name:      "all empty",
+			source:    `(lambda (required available) (reduce required (lambda (ok value) (and ok (contains? available value))) true))`,
+			available: []Scmer{NewString("a")},
+			want:      true,
+		},
+		{
+			name:      "any empty",
+			source:    `(lambda (left right) (reduce left (lambda (found value) (or found (contains? right value))) false))`,
+			available: []Scmer{NewString("a")},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+			got := fn(NewSlice(tc.input), NewSlice(tc.available)).Bool()
+			if got != tc.want {
+				t.Fatalf("got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListMembershipFoldKeepsEmptyInputValidationOrder(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (required available)
+		(reduce required (lambda (ok value) (and ok (contains? available value))) true))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if !fn(NewSlice(nil), NewInt(1)).Bool() {
+		t.Fatal("empty all-fold did not preserve its true neutral")
+	}
+}
+
+func TestOptimizeKeepsComputedMembershipCaptureInsideReducer(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (required available)
+		(reduce required (lambda (ok value) (and ok (contains? (car available) value))) true))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "list_contains_all") {
+		t.Fatalf("computed callback capture was evaluated eagerly: %s", serialized)
+	}
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if !fn(NewSlice(nil), NewSlice(nil)).Bool() {
+		t.Fatal("empty fold lost its neutral value")
+	}
+}
+
+func BenchmarkPlannerJoinSetSubset(b *testing.B) {
+	optimized, env := optimizeListPipeline(b, `(lambda (required available)
+		(reduce (coalesceNil required '()) (lambda (ok alias) (and ok (contains? available alias))) true))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	required := make([]Scmer, 12)
+	available := make([]Scmer, 16)
+	for index := range available {
+		available[index] = NewString(fmt.Sprintf("alias_%02d", index))
+	}
+	for index := range required {
+		required[index] = available[index+4]
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !fn(NewSlice(required), NewSlice(available)).Bool() {
+			b.Fatal("subset unexpectedly failed")
+		}
+	}
+}


### PR DESCRIPTION
## What

Teach the Go optimizer to recognize the planner's functional set folds:

- `reduce` + `and` + `contains?` becomes the optimizer-only `list_contains_all`
- `reduce` + `or` + `contains?` becomes the optimizer-only `list_contains_any`

The Scheme planner remains functional and unchanged. The optimizer derives a native physical operator from the already optimized reducer root. It does not rescan or re-analyze the reducer subtree; matching stays in the existing bottom-up pass.

The native operator short-circuits and uses two representations:

- small join sets: allocation-free nested native loops
- larger products: the existing adaptive `orderedUniqueBuilder` / `FastDict` representation

Stable captured values may be hoisted out of the callback. Computed captures stay inside the reducer, preserving lazy error/evaluation order. Tests also cover empty folds and coercive `Equal` semantics.

## Concrete value

`join_order_set_subset?`, `join_order_set_intersects?`, and `join_optimizer_alias_subset?` use this exact functional pattern. DPHyp, GOO, connected-component expansion, pending outer-join checks, and physical decision construction invoke these helpers repeatedly. The change removes Scheme callback dispatch and intermediate reducer state from that hot path without asking planner authors to write imperative code.

This is deliberately not a duplicate set API for Scheme authors: both new declarations are optimizer-only (`Forbidden`). The value of the PR is the automatic representation change from a general functional fold to a specialized native membership operator.

## A/B microbenchmark

Exact planner expression, including `coalesceNil`; arithmetic mean of 10 runs at 500 ms each on an AMD Ryzen 9 7900X3D:

```text
go test ./scm -run '^$' -bench '^BenchmarkPlannerJoinSetSubset$' -benchmem -count=10 -benchtime=500ms

                         ns/op       B/op   allocs/op
master                   3,325.3     1,128          51
PR                       2,861.7     2,232          12
delta                     -13.9%    +97.9%      -76.5%
```

The focused 12x16 case crosses the FastDict threshold, hence the higher byte count. Small planner sets stay on the nested-loop path and do not build a hash index.

## Cold end-to-end A/B

Seven interleaved runs, each with a fresh process and fresh data directory. The workload creates eight joined tables and executes a cold `EXPLAIN COMPILE` over an eight-way chain with predicates on both ends and `ORDER BY ... LIMIT 10`. The measured field is `planner_total_ns`.

```text
run                         1       2       3       4       5       6       7
master (ms)             128.2   122.4   125.7   118.5   123.9   117.4   119.7
PR (ms)                 109.2   108.7   107.3   104.7   105.8   111.8   112.1

                         mean    median    wins
master (ms)             122.2     122.4       0
PR (ms)                 108.5     108.7       7
delta                   -11.2%    -11.2%
```

Both binaries were built from the same `d88ac073e` master base; the PR binary contains only this optimizer change.

## Verification

- focused optimizer lowering and semantic tests
- complete `git-pre-commit`: all tests passed, commit allowed
