### PR TITLE
optimizer: restore single-use local ownership

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -350,6 +350,7 @@ type optimizerMetainfo struct {
 	variableReplacement     map[Symbol]Scmer
 	variableTypes           map[Symbol]*TypeDescriptor
 	numberedTypes           map[NthLocalVar]*TypeDescriptor
+	ownedLocalBindings      map[Symbol]bool
 	setBlacklist            []Symbol
 	nextSlot                *int // pointer to lambda's slot counter; nil outside lambda
 	pendingCallbackParams   []*TypeDescriptor
@@ -790,6 +791,7 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.variableReplacement = make(map[Symbol]Scmer)
 	result.variableTypes = ome.variableTypes
 	result.numberedTypes = ome.numberedTypes
+	result.ownedLocalBindings = ome.ownedLocalBindings
 	for k, v := range ome.variableReplacement {
 		if v.IsNthLocalVar() {
 			result.variableReplacement[k] = v
@@ -1552,7 +1554,9 @@ type localBindingFacts struct {
 	defineIdx int
 	firstUse  int
 	count     int
+	useCount  int
 	used      bool
+	captured  bool
 }
 
 func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {
@@ -1641,8 +1645,8 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				}
 			}
 		}
-		var visitNode func(x Scmer, depth int, blacklist []Symbol)
-		visitNode = func(x Scmer, depth int, blacklist []Symbol) {
+		var visitNode func(x Scmer, depth int, captured bool, blacklist []Symbol)
+		visitNode = func(x Scmer, depth int, captured bool, blacklist []Symbol) {
 			if stripped, ok := scmerStripSourceInfo(x); ok {
 				x = stripped
 			}
@@ -1653,7 +1657,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				}
 				subHead, subHeadOk := scmerSymbol(subHeadExpr)
 				if subHeadOk && (subHead == Symbol("define") || subHead == Symbol("set")) {
-					visitNode(sub[2], depth, blacklist)
+					visitNode(sub[2], depth, captured, blacklist)
 					if depth == 0 {
 						if sym, ok := scmerSymbol(sub[1]); ok {
 							variableContent[sym] = sub[2]
@@ -1665,7 +1669,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						params = stripped
 					}
 					if sym, ok := scmerSymbol(params); ok {
-						visitNode(sub[2], depth+1, append(append([]Symbol{}, blacklist...), sym))
+						visitNode(sub[2], depth+1, true, append(append([]Symbol{}, blacklist...), sym))
 					} else if list, ok := scmerSlice(params); ok {
 						blacklist2 := append([]Symbol{}, blacklist...)
 						for _, entry := range list {
@@ -1673,7 +1677,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 								blacklist2 = append(blacklist2, s)
 							}
 						}
-						visitNode(sub[2], depth+1, blacklist2)
+						visitNode(sub[2], depth+1, true, blacklist2)
 					}
 				} else if subHeadOk && (subHead == Symbol("begin") || subHead == Symbol("begin_mut")) {
 					start := 1
@@ -1681,22 +1685,22 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						start = 2
 					}
 					for i := start; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, blacklist)
+						visitNode(sub[i], depth+1, captured, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("!begin") {
 					for i := 1; i < len(sub); i++ {
-						visitNode(sub[i], depth, blacklist)
+						visitNode(sub[i], depth, captured, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("eval") {
 					usedVariables[Symbol("eval")] = 1
 					for i := 2; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, blacklist)
+						visitNode(sub[i], depth+1, captured, blacklist)
 					}
 				} else {
 					// Also visit the head — it may be a variable used in call position (e.g., (accsess "key"))
-					visitNode(sub[0], depth+1, blacklist)
+					visitNode(sub[0], depth+1, captured, blacklist)
 					for i := 1; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, blacklist)
+						visitNode(sub[i], depth+1, captured, blacklist)
 					}
 				}
 				return
@@ -1710,9 +1714,15 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 					}
 				}
 				if !isBlacklisted {
-					if facts, tracked := bindings[sym]; tracked && !facts.used {
-						facts.firstUse = currentTopIdx
-						facts.used = true
+					if facts, tracked := bindings[sym]; tracked {
+						facts.useCount++
+						if captured {
+							facts.captured = true
+						}
+						if !facts.used {
+							facts.firstUse = currentTopIdx
+							facts.used = true
+						}
 						bindings[sym] = facts
 					}
 					if depth > 0 {
@@ -1725,10 +1735,24 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		for i := bodyStart; i < len(v); i++ {
 			currentTopIdx = i
-			visitNode(v[i], 0, nil)
+			visitNode(v[i], 0, false, nil)
 		}
 		ome2 := ome.CopySharedScope()
 		ome2.beginDepth++
+		ownedLocalBindings := make(map[Symbol]bool, len(ome.ownedLocalBindings)+len(bindings))
+		for sym, owned := range ome.ownedLocalBindings {
+			ownedLocalBindings[sym] = owned
+		}
+		for sym, facts := range bindings {
+			delete(ownedLocalBindings, sym)
+			if earliestDynamicSyntax < 0 {
+				if facts.count == 1 && facts.used && facts.firstUse > facts.defineIdx &&
+					facts.useCount == 1 && !facts.captured {
+					ownedLocalBindings[sym] = true
+				}
+			}
+		}
+		ome2.ownedLocalBindings = ownedLocalBindings
 		slotLimit := -1
 		if headSym == Symbol("begin_mut") {
 			slotIndex := 0
@@ -1987,8 +2011,10 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 	switch {
 	case headOk && (headSym == Symbol("set") || headSym == Symbol("define")) && len(v) == 3:
 		var hasDefinedSym bool
+		var definedSym Symbol
 		if sym, ok := scmerSymbol(v[1]); ok {
 			hasDefinedSym = true
+			definedSym = sym
 			for _, black := range ome.setBlacklist {
 				if black == sym {
 					if useResult {
@@ -2007,6 +2033,17 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		var returnType TypeInfo
 		v[2], returnType = OptimizeEx(v[2], env, ome, true)
 		transferOwnership = returnType.Transfer()
+		if v[1].IsNthLocalVar() {
+			localType := returnType.ToTypeDescriptor()
+			if localType == nil {
+				localType = &TypeDescriptor{Kind: "any", Length: UnknownLength}
+			}
+			localType.Const = false
+			if !ome.ownedLocalBindings[definedSym] {
+				localType.Transfer = false
+			}
+			ome.numberedTypes[v[1].NthLocalVar()] = localType
+		}
 		if hasDefinedSym && ome.lambdaDepth == 0 && ome.beginDepth == 0 {
 			rhs := v[2]
 			if stripped, ok := scmerStripSourceInfo(rhs); ok {

--- a/scm/slice_alloc_test.go
+++ b/scm/slice_alloc_test.go
@@ -176,6 +176,80 @@ func TestOptimizeNumbersRepeatedLocalBinding(t *testing.T) {
 	}
 }
 
+func TestOptimizeSingleUseLocalTransfersFreshValue(t *testing.T) {
+	expr := Read("single-use local ownership", `(lambda (value)
+		(begin
+			(define values (list value))
+			(append values 2)))`)
+	optimized := Optimize(expr, &Globalenv, nil)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "append_mut") {
+		t.Fatalf("single-use fresh local did not transfer ownership: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(1)); !Equal(got, NewSlice([]Scmer{NewInt(1), NewInt(2)})) {
+		t.Fatalf("optimized single-use binding returned %s", String(got))
+	}
+}
+
+func TestOptimizeMultiUseLocalKeepsFreshValueBorrowed(t *testing.T) {
+	expr := Read("multi-use local ownership", `(lambda (value)
+		(begin
+			(define values (list value))
+			(list (append values 2) values)))`)
+	optimized := Optimize(expr, &Globalenv, nil)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if !strings.Contains(serialized, "setN") {
+		t.Fatalf("multi-use local binding was not retained: %s", serialized)
+	}
+	if strings.Contains(serialized, "append_mut") {
+		t.Fatalf("multi-use local incorrectly transferred ownership: %s", serialized)
+	}
+	want := NewSlice([]Scmer{
+		NewSlice([]Scmer{NewInt(1), NewInt(2)}),
+		NewSlice([]Scmer{NewInt(1)}),
+	})
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(1)); !Equal(got, want) {
+		t.Fatalf("optimized multi-use binding returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeCapturedSingleUseLocalKeepsFreshValueBorrowed(t *testing.T) {
+	expr := Read("captured single-use local ownership", `(lambda (value)
+		(begin
+			(define values (list value))
+			(define extend (lambda () (append values 2)))
+			(extend)))`)
+	optimized := Optimize(expr, &Globalenv, nil)
+	serialized := serializeSliceAllocTestExpr(t, optimized)
+	if strings.Contains(serialized, "append_mut") {
+		t.Fatalf("captured local incorrectly transferred ownership: %s", serialized)
+	}
+	if got := Apply(Eval(optimized, &Globalenv), NewInt(1)); !Equal(got, NewSlice([]Scmer{NewInt(1), NewInt(2)})) {
+		t.Fatalf("optimized captured binding returned %s", String(got))
+	}
+}
+
+func BenchmarkRunSingleUseLocalOwnership(b *testing.B) {
+	expr := Read("single-use local ownership benchmark", `(lambda (value)
+		(begin
+			(define values (list value value value value value value value value
+				value value value value value value value value))
+			(filter values (lambda (value) (> value 0)))))`)
+	optimized := Optimize(expr, &Globalenv, nil)
+	if serialized := serializeSliceAllocTestExpr(b, optimized); !strings.Contains(serialized, "filter_mut") {
+		b.Fatalf("single-use fresh local did not transfer ownership: %s", serialized)
+	}
+	fn := OptimizeProcToSerialFunction(Eval(optimized, &Globalenv))
+	value := NewInt(1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := fn(value); len(got.Slice()) != 16 {
+			b.Fatalf("optimized filter returned %s", String(got))
+		}
+	}
+}
+
 func TestOptimizeNumbersLocalBindingsDeterministically(t *testing.T) {
 	source := `(lambda (value)
 		(begin


### PR DESCRIPTION
## Was wirklich gefehlt hat

Die Usage-Zählung selbst war auf `master` noch vorhanden. Meine frühere Aussage, das Feature fehle, war daher falsch.

Der konkrete Regressionszustand war enger: Seit der Migration der Optimizer-Typinformationen auf `TypeDescriptor`/`numberedTypes` wurde das Ergebnis der vorhandenen Usage-Analyse nicht mehr auf den Typdeskriptor des nummerierten lokalen Slots übertragen. Ein frisch erzeugter Wert mit genau einem Consumer blieb deshalb `Transfer:false`; etwa `append`/`filter` konnten trotz nachgewiesener Ownership nicht zu `append_mut`/`filter_mut` spezialisiert werden.

Dieser PR verbindet die vorhandene Analyse wieder mit dem bereits vorhandenen `TypeDescriptor.Transfer`-Feld. Er führt kein zweites Ownership-Flag ein.

## Umsetzung

- erweitert die bereits laufende `begin`-Analyse um exakte Use-Anzahl und Capture-Information
- markiert nur genau einmal definierte und genau einmal verwendete, nicht von einer Lambda gecapturete lokale Bindings als transferierbar
- schreibt den Typ der RHS in `numberedTypes` und erhält `Transfer:true` nur unter diesem Ownership-Beweis
- bleibt bei dynamischer Syntax, Mehrfachdefinition, Mehrfachverwendung und Capture konservativ
- fügt keinen weiteren AST-Pass und keine zusätzlichen Teilbaum-Analysen hinzu

## Regressionstests

Die neuen Tests sichern drei Fälle ab:

1. frischer Single-Use-Local wählt `append_mut`
2. mehrfach verwendeter Local bleibt borrowed und unverändert
3. gecaptureter Single-Use-Local bleibt borrowed

Der erste Test schlägt auf unverändertem `master` fehl: Der optimierte Ausdruck enthält dort `append` statt `append_mut`.

## A/B-Messung gegen master

Microbenchmark, 10 Läufe pro Variante, `-benchtime=1s`, identischer Benchmark-Harness:

```
go test ./scm -run '^$' -bench '^BenchmarkRunSingleUseLocalOwnership$' -benchmem -count=10 -benchtime=1s
```

| | master | PR | Änderung |
|---|---:|---:|---:|
| Laufzeit | 2300.6 ns/op | 2197.6 ns/op | -4.5% |
| Speicher | 1624 B/op | 1368 B/op | -15.8% |
| Allokationen | 58 allocs/op | 57 allocs/op | -1 |

Cold end-to-end: cache-gebustetes `EXPLAIN COMPILE` einer 10-Tabellen-Join-Kette, 2 Warmups und 20 Messungen je Binary in alternierender Reihenfolge:

| Metrik | master | PR | Änderung |
|---|---:|---:|---:|
| compile_total_ns, Mittel | 71,922,396 | 71,885,288 | -0.1% |
| compile_total_ns, Median | 72,123,379 | 71,853,680 | -0.4% |
| wall_ns, Mittel | — | — | +0.2% |
| wall_ns, Median | — | — | -0.5% |

Die fokussierte, nun tatsächlich aktivierte Mutation spart messbar eine Allokation und 256 Bytes. Die kalte SQL-Kompilierung ist erwartungsgemäß neutral: Dieser PR repariert die lokale Ownership-Weitergabe, erzwingt aber noch keine breitere Stage-Fusion.

## Verifikation

- `make test` auf dem finalen Stand: grün
- fokussierte Optimizer-/Ownership-Tests: grün
- `git diff --check`: grün
