### PR TITLE
perf: fuse indexed assoc construction

### DIFF
--- a/scm/list.go
+++ b/scm/list.go
@@ -776,6 +776,118 @@ func optimizePlannerReduceFold(rv []Scmer, td *TypeDescriptor) (Scmer, *TypeDesc
 	return NewNil(), nil, false
 }
 
+func optimizerEmptyListLiteral(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	items, ok := scmerSlice(expr)
+	if !ok {
+		return false
+	}
+	if elements, list := listConstructorElements(items); list {
+		return len(elements) == 0
+	}
+	if len(items) != 2 || !scmerIsSymbol(items[0], "quote") {
+		return false
+	}
+	quoted, ok := scmerSlice(items[1])
+	return ok && len(quoted) == 0
+}
+
+func optimizerIndexedAssocProjection(expr Scmer, reducerParams []Scmer, pairBody Scmer, pair []Scmer) (Scmer, [2]int, bool) {
+	var noUses [2]int
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	items, ok := scmerSlice(expr)
+	if !ok {
+		if optimizerLambdaParamReference(expr, reducerParams, 0) {
+			return NewNil(), noUses, false
+		}
+		if optimizerLambdaParamReference(expr, reducerParams, 1) {
+			return pairBody, [2]int{1, 1}, true
+		}
+		return expr, noUses, true
+	}
+	if len(items) == 0 || scmerIsSymbol(items[0], "quote") || scmerIsSymbol(items[0], "outer") {
+		return expr, noUses, true
+	}
+	if scmerIsSymbol(items[0], "lambda") {
+		return NewNil(), noUses, false
+	}
+	if len(items) == 2 && scmerIsSymbol(items[0], "car") && optimizerLambdaParamReference(items[1], reducerParams, 1) {
+		return pair[0], [2]int{1, 0}, true
+	}
+	if len(items) == 2 && scmerIsSymbol(items[0], "cadr") && optimizerLambdaParamReference(items[1], reducerParams, 1) {
+		return pair[1], [2]int{0, 1}, true
+	}
+	rewritten := make([]Scmer, len(items))
+	uses := noUses
+	for i, item := range items {
+		var itemUses [2]int
+		var valid bool
+		rewritten[i], itemUses, valid = optimizerIndexedAssocProjection(item, reducerParams, pairBody, pair)
+		if !valid {
+			return NewNil(), noUses, false
+		}
+		uses[0] += itemUses[0]
+		uses[1] += itemUses[1]
+	}
+	return NewSlice(rewritten), uses, true
+}
+
+// optimizeIndexedAssocFold recognizes a three-stage planner idiom: mapIndex
+// creates a pair and reduce derives an empty assoc's keys and values from it.
+// Reused pair projections must be stable references. Keeping the proof inside
+// reduce's hook lets the physical operator write the FastDict directly without
+// another analysis pass.
+func optimizeIndexedAssocFold(mapper, reducer, neutral Scmer) (Scmer, Scmer, bool) {
+	mapperParams, mapperBody, ok := optimizerLambdaParts(mapper)
+	if !ok || len(mapperParams) < 2 {
+		return NewNil(), NewNil(), false
+	}
+	mapperItems, ok := scmerSlice(mapperBody)
+	if !ok {
+		return NewNil(), NewNil(), false
+	}
+	pair, ok := listConstructorElements(mapperItems)
+	if !ok && len(mapperItems) == 2 && scmerIsSymbol(mapperItems[0], "quote") {
+		pair, ok = scmerSlice(mapperItems[1])
+	}
+	if !ok || len(pair) != 2 {
+		return NewNil(), NewNil(), false
+	}
+
+	reducerParams, reducerBody, ok := optimizerLambdaParts(reducer)
+	if !ok || len(reducerParams) < 2 {
+		return NewNil(), NewNil(), false
+	}
+	reducerItems, ok := scmerSlice(reducerBody)
+	if !ok || len(reducerItems) != 4 ||
+		(!scmerIsSymbol(reducerItems[0], "set_assoc") && !scmerIsSymbol(reducerItems[0], "set_assoc_mut")) ||
+		!optimizerLambdaParamReference(reducerItems[1], reducerParams, 0) ||
+		!optimizerEmptyListLiteral(neutral) {
+		return NewNil(), NewNil(), false
+	}
+	key, keyUses, ok := optimizerIndexedAssocProjection(reducerItems[2], reducerParams, mapperBody, pair)
+	if !ok {
+		return NewNil(), NewNil(), false
+	}
+	value, valueUses, ok := optimizerIndexedAssocProjection(reducerItems[3], reducerParams, mapperBody, pair)
+	if !ok {
+		return NewNil(), NewNil(), false
+	}
+	uses := [2]int{keyUses[0] + valueUses[0], keyUses[1] + valueUses[1]}
+	for i := range pair {
+		if uses[i] < 1 || (uses[i] > 1 && !optimizerStableReference(pair[i])) {
+			return NewNil(), NewNil(), false
+		}
+	}
+	keyMapper, keyOK := optimizerLambdaWithBody(mapper, key)
+	valueMapper, valueOK := optimizerLambdaWithBody(mapper, value)
+	return keyMapper, valueMapper, keyOK && valueOK
+}
+
 // optimizeReduce keeps merge as a segmented producer when its flattened value
 // is consumed exactly once by reduce. reduce_segments validates all segments
 // before invoking the callback, matching merge's existing error order.
@@ -788,6 +900,17 @@ func optimizeReduce(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *Ty
 	if len(rv) >= 3 {
 		if inner, ok := scmerSlice(rv[1]); ok && len(inner) == 3 {
 			switch {
+			case scmerIsSymbol(inner[0], "mapIndex") || scmerIsSymbol(inner[0], "mapIndex_mut"):
+				if exprMayHaveSideEffects(inner[2]) || exprMayHaveSideEffects(rv[2]) || (len(rv) == 4 && exprMayHaveSideEffects(rv[3])) {
+					return result, td
+				}
+				if len(rv) == 4 {
+					if key, value, direct := optimizeIndexedAssocFold(inner[2], rv[2], rv[3]); direct {
+						return NewSlice([]Scmer{NewSymbol("index_assoc"), inner[1], key, value}),
+							&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength}
+					}
+				}
+				return result, td
 			case scmerIsSymbol(inner[0], "map") || scmerIsSymbol(inner[0], "map_mut"):
 				if exprMayHaveSideEffects(inner[2]) || exprMayHaveSideEffects(rv[2]) || (len(rv) == 4 && exprMayHaveSideEffects(rv[3])) {
 					return result, td
@@ -29464,6 +29587,7 @@ func init_list() {
 			},
 			JITInlineCallbacks: false,
 		},
+		Optimize: optimizeFindMapNotNull,
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "map_filter",
@@ -32025,6 +32149,37 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "index_assoc",
+
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "index_assoc")
+			key := OptimizeProcToSerialFunction(a[1])
+			value := OptimizeProcToSerialFunction(a[2])
+			result := NewFastDictValue(len(input))
+			for index, item := range input {
+				position := NewInt(int64(index))
+				result.Set(key(position, item), value(position, item), nil)
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "builds a FastDict directly from indexed key/value callbacks (optimizer-only)",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "value", Params: []*TypeDescriptor{{Kind: "int", Label: "index"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength},
+			Const:     true,
+			Forbidden: true,
+
+			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				return jitEmitGoVariadicCallFromDescs(ctx, declarations["index_assoc"].Fn, args, result)
+			},
+			JITVirtualArgs:     true,
+			JITInlineCallbacks: false,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -56168,7 +56323,6 @@ func init_list() {
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
 		},
-		Optimize: optimizeFindMapNotNull,
 	})
 	Declare(&Globalenv, &Declaration{
 		Name: "flat_map_unique",

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -156,6 +156,24 @@ func TestOptimizeFusesFirstNonNilReducerOverRange(t *testing.T) {
 	}
 }
 
+func TestOptimizeFusesDirectFirstNonNilSearchOverRange(t *testing.T) {
+	if declaration := DeclarationForValue(NewSymbol("find_map_notnull")); declaration == nil || declaration.Optimize == nil {
+		t.Fatal("find_map_notnull declaration has no optimizer hook")
+	}
+	optimized, env := optimizeListPipeline(t, `(lambda (count target)
+		(find_map_notnull (produceN count)
+			(lambda (_ index) (if (equal? index target) index nil))))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "find_range_notnull") || strings.Contains(serialized, "produceN") {
+		t.Fatalf("direct range search was not fused: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if got := fn(NewInt(8), NewInt(5)); !Equal(got, NewInt(5)) {
+		t.Fatalf("direct fused range search returned %s, want 5", String(got))
+	}
+}
+
 func TestOptimizeFusesGeneralReducerOverRange(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (count)
 		(reduce (produceN count) (lambda (values index) (cons index values)) '()))`)
@@ -362,6 +380,63 @@ func TestOptimizeFusesReduceOverMap(t *testing.T) {
 	want := NewInt(9)
 	if !Equal(got, want) {
 		t.Fatalf("fused reduce/map returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeLeavesGeneralIndexedReduceUnfused(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(reduce (mapIndex values (lambda (index value) (+ index value)))
+			(lambda (total value) (+ total value)) 0))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "mapIndex") || !strings.Contains(serialized, "reduce") || strings.Contains(serialized, "index_assoc") {
+		t.Fatalf("general indexed reduce must stay unspecialized: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if got := fn(NewSlice([]Scmer{NewInt(10), NewInt(20), NewInt(30)})); !Equal(got, NewInt(63)) {
+		t.Fatalf("general indexed reduce returned %s, want 63", String(got))
+	}
+}
+
+func TestOptimizeBuildsIndexedAssocWithoutMappedPairs(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (aliases)
+		(reduce (mapIndex aliases (lambda (position alias) (list alias position)))
+			(lambda (index entry) (set_assoc index (car entry) (cadr entry))) '()))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "index_assoc") || strings.Contains(serialized, "mapIndex") || strings.Contains(serialized, "reduce") {
+		t.Fatalf("indexed assoc construction was not fused: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewString("left"), NewString("right"), NewString("left")}))
+	want := NewSlice([]Scmer{NewString("left"), NewInt(2), NewString("right"), NewInt(1)})
+	if !Equal(got, want) {
+		t.Fatalf("fused indexed assoc returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeBuildsIndexedAssocFromOptionalAliases(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(begin
+		(define alias-index (lambda (aliases)
+			(reduce (mapIndex (coalesceNil aliases '()) (lambda (position alias) (list alias position)))
+				(lambda (index entry) (set_assoc index (toLower (car entry)) entry)) '())))
+		alias-index)`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "index_assoc") || strings.Contains(serialized, "mapIndex") || strings.Contains(serialized, "reduce") {
+		t.Fatalf("optional alias index construction was not specialized: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewString("LEFT"), NewString("Right")}))
+	want := NewSlice([]Scmer{
+		NewString("left"), NewSlice([]Scmer{NewString("LEFT"), NewInt(0)}),
+		NewString("right"), NewSlice([]Scmer{NewString("Right"), NewInt(1)}),
+	})
+	if !Equal(got, want) {
+		t.Fatalf("fused optional alias index returned %s, want %s", String(got), String(want))
+	}
+	if got := fn(NewNil()); !Equal(got, NewSlice(nil)) {
+		t.Fatalf("fused optional empty alias index returned %s, want empty assoc", String(got))
 	}
 }
 
@@ -585,6 +660,27 @@ func BenchmarkPlannerReducerLowerings(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkOptimizerIndexedAliasMap(b *testing.B) {
+	optimized, env := optimizeListPipeline(b, `(lambda (aliases)
+		(reduce (mapIndex aliases (lambda (position alias) (list alias position)))
+			(lambda (index entry) (set_assoc index (car entry) (cadr entry))) '()))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	aliases := make([]Scmer, 128)
+	for i := range aliases {
+		aliases[i] = NewString(fmt.Sprintf("alias-%d", i))
+	}
+	input := NewSlice(aliases)
+	last := NewString("alias-127")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := fn(input)
+		if got := declarations["get_assoc"].Fn(result, last); got.Int() != 127 {
+			b.Fatalf("indexed alias map returned %s, want 127", String(got))
+		}
 	}
 }
 


### PR DESCRIPTION
## What

- recognize the three-stage reduce(mapIndex(...)) -> set_assoc pattern inside the reduce declaration optimizer hook
- lower the proven pattern to optimizer-only index_assoc, which writes the FastDict directly
- preserve both planner variants: reducers storing a pair projection and reducers storing the complete mapped pair
- leave general two-stage reduce(mapIndex(...)) pipelines unchanged because their benchmark result was mixed
- restore optimizeFindMapNotNull on the find_map_notnull declaration; it was accidentally attached to flat_map

The matcher consumes the already optimized mapper/reducer roots. It does not start another optimizer or analysis pass over the surrounding tree. Reused mapped projections are accepted only when they are stable references, and callbacks with effects are rejected.

A serialize dump of all 1,945 queryplan bindings shows all three planner instances lowered to index_assoc:

- join_hypergraph_alias_index
- join_order_alias_position_index
- join_order_regular_edges

No reduce(mapIndex(...)) instance remains in executable queryplanner code.

## A/B microbenchmark

Master vs this branch, Ryzen 9 7900X3D, 10 x 1s:

    go test ./scm -run ^$ -bench ^BenchmarkOptimizerIndexedAliasMap$ -benchmem -count=10 -benchtime=1s

    time/op     52.25 us -> 21.61 us   -58.65% (p=0.000)
    bytes/op    43.88 KiB -> 22.55 KiB -48.59% (p=0.000)
    allocs/op   963 -> 283             -70.61% (p=0.000)

## Cold EXPLAIN COMPILE A/B

Cache-busted 32-source SQL query, servers and client pinned to CPU 2, 3 warmups + 30 samples:

    python3 tools/benchmark_compile.py QUERY.sql --cache-bust --warmup 3 --samples 30

Median phase times:

    reorder_ns          63.427 ms -> 61.329 ms  -3.31%
    compile_total_ns   213.138 ms -> 214.245 ms  +0.52%
    wall_ns            220.021 ms -> 224.769 ms  +2.16%

The focused join-reorder phase improves, while full compilation is neutral within run-to-run noise; lowering and serialization still dominate this synthetic plan. This is intentionally reported rather than presenting the p95 improvement as a total-query win.

## Verification

- go test ./scm -run ^TestOptimize -count=1
- real queryplanner serialize dump and runtime equivalence check for join_hypergraph_alias_index
- full suite delegated to CI per optimizer workflow