### PR TITLE
optimizer: eliminate duplicate recursive match branches

### DIFF
--- a/scm/match_optimizer_test.go
+++ b/scm/match_optimizer_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptimizeMatchEliminatesEquivalentSymbolBranches(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("match optimizer test", `(define match_equivalent_symbols (lambda (expr)
+		(match expr
+			((symbol add) left right) (+ left right)
+			((quote add) left right) 991
+			((symbol sub) left right) (- left right)
+			((quote sub) left right) 992
+			_ 0)))`, env)
+	proc := env.FindRead(Symbol("match_equivalent_symbols")).Vars[Symbol("match_equivalent_symbols")]
+	serialized := serializedTestExpr(t, env, proc.Proc().Body)
+	if strings.Contains(serialized, "991") || strings.Contains(serialized, "992") {
+		t.Fatalf("unreachable equivalent match branches survived optimization: %s", serialized)
+	}
+	if strings.Contains(serialized, "(quote add)") || strings.Contains(serialized, "(quote sub)") {
+		t.Fatalf("symbol-literal patterns were not canonicalized: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(proc)
+	add := NewSlice([]Scmer{NewSymbol("add"), NewInt(7), NewInt(5)})
+	sub := NewSlice([]Scmer{NewSymbol("sub"), NewInt(7), NewInt(5)})
+	if got := fn(add); !Equal(got, NewInt(12)) {
+		t.Fatalf("optimized add match returned %s, want 12", String(got))
+	}
+	if got := fn(sub); !Equal(got, NewInt(2)) {
+		t.Fatalf("optimized sub match returned %s, want 2", String(got))
+	}
+}
+
+func TestOptimizeMatchEliminatesNestedEquivalentSymbolBranches(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("match optimizer test", `(define match_nested_equivalent_symbols (lambda (expr)
+		(match expr
+			((symbol not) ((symbol exists) value)) value
+			((quote not) ((quote exists) value)) 991
+			_ 0)))`, env)
+	proc := env.FindRead(Symbol("match_nested_equivalent_symbols")).Vars[Symbol("match_nested_equivalent_symbols")]
+	serialized := serializedTestExpr(t, env, proc.Proc().Body)
+	if strings.Contains(serialized, "991") {
+		t.Fatalf("unreachable nested match branch survived optimization: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(proc)
+	expr := NewSlice([]Scmer{
+		NewSymbol("not"),
+		NewSlice([]Scmer{NewSymbol("exists"), NewInt(42)}),
+	})
+	if got := fn(expr); !Equal(got, NewInt(42)) {
+		t.Fatalf("optimized nested match returned %s, want 42", String(got))
+	}
+}
+
+func TestOptimizeMatchKeepsDynamicEvalBranches(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("match optimizer test", `(define match_dynamic_eval (lambda (expr expected)
+		(match expr
+			(eval expected) 1
+			(eval expected) 2
+			0)))`, env)
+	proc := env.FindRead(Symbol("match_dynamic_eval")).Vars[Symbol("match_dynamic_eval")]
+	serialized := serializedTestExpr(t, env, proc.Proc().Body)
+	if strings.Count(serialized, "(eval ") != 2 {
+		t.Fatalf("dynamic match patterns were incorrectly combined: %s", serialized)
+	}
+}
+
+const recursiveMatchBenchmarkSource = `(define recursive_match_benchmark
+	(lambda (expr)
+		(match expr
+			((symbol leaf) value) value
+			((quote leaf) value) -101
+			((symbol add) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote add) left right) -102
+			((symbol sub) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote sub) left right) -103
+			((symbol and) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote and) left right) -104
+			((symbol or) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote or) left right) -105
+			((symbol equal) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote equal) left right) -106
+			((symbol concat) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote concat) left right) -107
+			((symbol multiply) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
+			((quote multiply) left right) -108
+			_ 0)))`
+
+func recursiveMatchBenchmarkTree(depth int) Scmer {
+	if depth == 0 {
+		return NewSlice([]Scmer{NewSymbol("leaf"), NewInt(1)})
+	}
+	child := recursiveMatchBenchmarkTree(depth - 1)
+	return NewSlice([]Scmer{NewSymbol("multiply"), child, child})
+}
+
+func BenchmarkOptimizeRecursiveMatchWalker(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		env := newOptimizerTestEnv()
+		EvalAll("recursive match benchmark", recursiveMatchBenchmarkSource, env)
+	}
+}
+
+func BenchmarkRecursiveMatchWalker(b *testing.B) {
+	env := newOptimizerTestEnv()
+	EvalAll("recursive match benchmark", recursiveMatchBenchmarkSource, env)
+	fn := OptimizeProcToSerialFunction(env.FindRead(Symbol("recursive_match_benchmark")).Vars[Symbol("recursive_match_benchmark")])
+	tree := recursiveMatchBenchmarkTree(8)
+	want := NewInt(256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := fn(tree); !Equal(got, want) {
+			b.Fatalf("recursive match walker returned %s, want 256", String(got))
+		}
+	}
+}

--- a/scm/match_optimizer_test.go
+++ b/scm/match_optimizer_test.go
@@ -91,21 +91,21 @@ const recursiveMatchBenchmarkSource = `(define recursive_match_benchmark
 	(lambda (expr)
 		(match expr
 			((symbol leaf) value) value
-			((quote leaf) value) -101
+			((quote leaf) value) (+ value 0)
 			((symbol add) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote add) left right) -102
+			((quote add) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol sub) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote sub) left right) -103
+			((quote sub) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol and) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote and) left right) -104
+			((quote and) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol or) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote or) left right) -105
+			((quote or) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol equal) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote equal) left right) -106
+			((quote equal) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol concat) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote concat) left right) -107
+			((quote concat) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			((symbol multiply) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
-			((quote multiply) left right) -108
+			((quote multiply) left right) (+ (recursive_match_benchmark left) (recursive_match_benchmark right))
 			_ 0)))`
 
 func recursiveMatchBenchmarkTree(depth int) Scmer {
@@ -129,13 +129,13 @@ func BenchmarkRecursiveMatchWalker(b *testing.B) {
 	env := newOptimizerTestEnv()
 	EvalAll("recursive match benchmark", recursiveMatchBenchmarkSource, env)
 	fn := OptimizeProcToSerialFunction(env.FindRead(Symbol("recursive_match_benchmark")).Vars[Symbol("recursive_match_benchmark")])
-	tree := recursiveMatchBenchmarkTree(8)
-	want := NewInt(256)
+	tree := recursiveMatchBenchmarkTree(9)
+	want := NewInt(512)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if got := fn(tree); !Equal(got, want) {
-			b.Fatalf("recursive match walker returned %s, want 256", String(got))
+			b.Fatalf("recursive match walker returned %s, want 512", String(got))
 		}
 	}
 }

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -2060,22 +2060,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 		}
 	case headOk && (headSym == Symbol("match") || headSym == Symbol("match_mut")):
-		value, valueTransfer, _ := optimizeExCompat(v[1], env, ome, true)
-		v[1] = value
-		transferOwnership = valueTransfer
-		if headSym == Symbol("match") && valueTransfer {
-			markProcOwnershipSpecializationUse(ome, v[1])
-			v[0] = NewSymbol("match_mut")
-		}
-		for i := 3; i < len(v); i += 2 {
-			ome2 := ome.CopySharedScope()
-			v[i-1] = OptimizeMatchPattern(v[1], v[i-1], env, ome, &ome2)
-			v[i], transferOwnership, _ = optimizeExCompat(v[i], env, &ome2, useResult)
-		}
-		if len(v)%2 == 1 {
-			v[len(v)-1], transferOwnership, _ = optimizeExCompat(v[len(v)-1], env, ome, useResult)
-		}
-		return NewSlice(v), MakeTypeInfo(transferOwnership, false)
+		return optimizeMatch(v, headSym, env, ome, useResult)
 	case headOk && headSym == Symbol("parser"):
 		return OptimizeParser(NewSlice(v), env, ome, false), tiTransfer
 	case !headOk || headSym != Symbol("quote"):
@@ -2885,27 +2870,66 @@ func optimizeAssociative(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer
 	return result, td
 }
 
-func OptimizeMatchPattern(value Scmer, pattern Scmer, env *Env, ome *optimizerMetainfo, ome2 *optimizerMetainfo) Scmer {
+type matchPatternInfo struct {
+	hash       uint64
+	comparable bool
+}
+
+func matchPatternScalarInfo(pattern Scmer) matchPatternInfo {
+	if stripped, ok := scmerStripSourceInfo(pattern); ok {
+		pattern = stripped
+	}
+	switch pattern.GetTag() {
+	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagSymbol, tagNthLocalVar:
+		return matchPatternInfo{hash: combineStructuralHash(uint64(pattern.GetTag()), HashKey(pattern)), comparable: true}
+	default:
+		return matchPatternInfo{}
+	}
+}
+
+// optimizeMatchPattern returns the canonical pattern and its structural hash in
+// the same recursive walk. Callers can therefore recognize unreachable duplicate
+// branches without repeatedly analyzing their pattern trees.
+func optimizeMatchPattern(pattern Scmer, env *Env, ome *optimizerMetainfo) (Scmer, matchPatternInfo) {
 	if stripped, ok := scmerStripSourceInfo(pattern); ok {
 		pattern = stripped
 	}
 
 	if sym, ok := scmerSymbol(pattern); ok {
-		delete(ome2.variableReplacement, sym)
-		return pattern
+		delete(ome.variableReplacement, sym)
+		return pattern, matchPatternScalarInfo(pattern)
 	}
 
 	if slice, ok := scmerSlice(pattern); ok {
 		if len(slice) == 0 {
-			return NewSlice(slice)
+			return NewSlice(slice), matchPatternInfo{hash: combineStructuralHash(0xbb67ae8584caa73b, 0), comparable: true}
+		}
+		if stripped, ok := scmerStripSourceInfo(slice[0]); ok {
+			slice[0] = stripped
 		}
 		headSym, headOk := scmerSymbol(slice[0])
 		if headOk && headSym == Symbol("eval") && len(slice) > 1 {
-			slice[1], _ = OptimizeEx(slice[1], env, ome2, true)
-			return NewSlice(slice)
+			slice[1], _ = OptimizeEx(slice[1], env, ome, true)
+			return NewSlice(slice), matchPatternInfo{}
 		}
 		if headOk && headSym == Symbol("var") && len(slice) == 2 {
-			return NewNthLocalVar(NthLocalVar(ToInt(slice[1])))
+			pattern = NewNthLocalVar(NthLocalVar(ToInt(slice[1])))
+			return pattern, matchPatternScalarInfo(pattern)
+		}
+		if headOk && (headSym == Symbol("symbol") || headSym == Symbol("quote")) && len(slice) == 2 {
+			if _, literal := scmerSymbol(slice[1]); literal {
+				// match implements both spellings as the same symbol-literal pattern.
+				slice[0] = NewSymbol("symbol")
+				if stripped, ok := scmerStripSourceInfo(slice[1]); ok {
+					slice[1] = stripped
+				}
+				pattern = NewSlice(slice)
+				literalInfo := matchPatternScalarInfo(slice[1])
+				hash := combineStructuralHash(0xbb67ae8584caa73b, 2)
+				hash = combineStructuralHash(hash, matchPatternScalarInfo(slice[0]).hash)
+				hash = combineStructuralHash(hash, literalInfo.hash)
+				return pattern, matchPatternInfo{hash: hash, comparable: literalInfo.comparable}
+			}
 		}
 		if headOk && headSym == Symbol("regex") && len(slice) > 1 {
 			// Precompile constant regex patterns at optimization time
@@ -2918,17 +2942,70 @@ func OptimizeMatchPattern(value Scmer, pattern Scmer, env *Env, ome *optimizerMe
 				slice[1] = NewRegex(re)
 			}
 			for i := 2; i < len(slice); i++ {
-				slice[i] = OptimizeMatchPattern(NewNil(), slice[i], env, ome, ome2)
+				slice[i], _ = optimizeMatchPattern(slice[i], env, ome)
 			}
-			return NewSlice(slice)
+			return NewSlice(slice), matchPatternInfo{}
 		}
+		hash := combineStructuralHash(0xbb67ae8584caa73b, uint64(len(slice)))
+		headInfo := matchPatternScalarInfo(slice[0])
+		if !headOk {
+			slice[0], headInfo = optimizeMatchPattern(slice[0], env, ome)
+		}
+		comparable := headInfo.comparable
+		hash = combineStructuralHash(hash, headInfo.hash)
 		for i := 1; i < len(slice); i++ {
-			slice[i] = OptimizeMatchPattern(NewNil(), slice[i], env, ome, ome2)
+			var info matchPatternInfo
+			slice[i], info = optimizeMatchPattern(slice[i], env, ome)
+			hash = combineStructuralHash(hash, info.hash)
+			comparable = comparable && info.comparable
 		}
-		return NewSlice(slice)
+		return NewSlice(slice), matchPatternInfo{hash: hash, comparable: comparable}
 	}
 
-	return pattern
+	return pattern, matchPatternScalarInfo(pattern)
+}
+
+func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {
+	value, transferOwnership, _ := optimizeExCompat(v[1], env, ome, true)
+	head := v[0]
+	if headSym == Symbol("match") && transferOwnership {
+		markProcOwnershipSpecializationUse(ome, value)
+		head = NewSymbol("match_mut")
+	}
+	out := make([]Scmer, 0, len(v))
+	out = append(out, head, value)
+	var seen map[uint64][]Scmer
+	if (len(v)-2)/2 > 1 {
+		seen = make(map[uint64][]Scmer, (len(v)-2)/2)
+	}
+	for i := 3; i < len(v); i += 2 {
+		branchOme := ome.CopySharedScope()
+		pattern, info := optimizeMatchPattern(v[i-1], env, &branchOme)
+		duplicate := false
+		if info.comparable && seen != nil {
+			for _, previous := range seen[info.hash] {
+				if astStructuralEqual(previous, pattern) {
+					duplicate = true
+					break
+				}
+			}
+		}
+		if duplicate {
+			continue
+		}
+		if info.comparable && seen != nil {
+			seen[info.hash] = append(seen[info.hash], pattern)
+		}
+		result, resultTransfer, _ := optimizeExCompat(v[i], env, &branchOme, useResult)
+		transferOwnership = resultTransfer
+		out = append(out, pattern, result)
+	}
+	if len(v)%2 == 1 {
+		fallback, fallbackTransfer, _ := optimizeExCompat(v[len(v)-1], env, ome, useResult)
+		transferOwnership = fallbackTransfer
+		out = append(out, fallback)
+	}
+	return NewSlice(out), MakeTypeInfo(transferOwnership, false)
 }
 
 func OptimizeParser(val Scmer, env *Env, ome *optimizerMetainfo, ignoreResult bool) Scmer {


### PR DESCRIPTION
## What

The Scheme planner contains many self-recursive AST walkers whose `match` forms spell the same symbol literal with both `(symbol x)` and `(quote x)`. The runtime treats those forms identically, so the later branch can never be reached.

This PR:

- canonicalizes both spellings while `optimizeMatchPattern` is already walking the pattern;
- accumulates a structural fingerprint in that same walk (no second subtree analysis);
- verifies hash candidates with structural equality;
- skips optimization and emission of unreachable later branch results;
- keeps dynamic `eval` and `regex` patterns conservative;
- moves the special-form implementation behind the focused `optimizeMatch` helper instead of growing `optimizeList`.

The same path handles `match` and `match_mut`; ownership specialization behavior is unchanged.

## Evidence from `lib/queryplan*.scm`

The optimized planner dump contained 706 branches in self-recursive `match` walkers. 236 (33.4%) were unreachable `symbol`/`quote` duplicates across 103 functions.

Representative serialized optimized Proc bodies (master -> PR):

| Proc | bytes | `(quote ...)` occurrences |
|---|---:|---:|
| `boolean_recset_expr_plan` | 3,240 -> 2,441 (-24.7%) | 17 -> 9 |
| `collect_join_columns_acc` | 21,896 -> 15,110 (-31.0%) | 90 -> 35 |
| `lower_column_expr_for_alias_in_context` | 2,933 -> 1,566 (-46.6%) | 13 -> 2 |
| `untangle_expr_with_stages` | 3,338 -> 1,816 (-45.6%) | 19 -> 5 |

These are hot recursive walkers; removing branches reduces both cold optimization work and every recursive runtime dispatch.

## A/B microbenchmarks

Both sides used the benchmark harness from `dbc5af375`. Baseline optimizer source is `55e9a86cd`; PR source is `df3e57c99`.

```
taskset -c 0 go test ./scm -run '^$' \
  -bench 'Benchmark(Optimize)?RecursiveMatchWalker$' \
  -benchtime=1s -count=10
```

`benchstat`:

| Benchmark | master | PR | delta |
|---|---:|---:|---:|
| `OptimizeRecursiveMatchWalker` | 79.48 us | 60.43 us | **-23.96%** (p=0.023) |
| `RecursiveMatchWalker` | 846.7 us | 624.2 us | **-26.28%** (p<0.001) |
| optimizer allocations | 697 | 658 | **-5.60%** |

Runtime allocations are unchanged, as expected: the speedup comes from fewer pattern checks.

## End-to-end cold SQL A/B

Two binaries from the same commits ran simultaneously on separate ports. Twenty `EXPLAIN COMPILE` requests per binary were interleaved, reversing request order each iteration. The query has one scan but a large nested scalar/boolean expression tree (911 parser AST nodes), so it exercises the recursive expression walkers without join-reorder cost dominating the measurement.

Median, n=20 per binary:

| metric | master | PR | delta |
|---|---:|---:|---:|
| `compile_total_ns` | 38.451 ms | 37.858 ms | **-1.54%** |
| `untangle_ns` | 9.105 ms | 8.984 ms | **-1.32%** |
| `lower_ns` | 10.538 ms | 10.335 ms | **-1.93%** |
| `optimizer_wall_ns` | 0.121 ms | 0.118 ms | **-2.37%** |

As a control, a 10-join query dominated by join reordering only moved 160.0 ms -> 159.4 ms (-0.36%), while its `optimizer_wall_ns` moved 0.554 ms -> 0.527 ms (-4.93%). This matches the expected scope of the change.

## Validation

- `go test ./scm -run '^TestOptimizeMatch' -count=1`
- server startup Scheme suite: 1270/1270 passed for both A/B binaries
- new tests cover flat duplicates, nested duplicates, runtime semantics, and conservative dynamic `eval` handling
- full repository suite is left to CI as agreed for optimizer changes
