### PR TITLE
optimizer: recognize complete AND splitter shape

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1578,31 +1578,35 @@ func optimizerProcSequenceForDefinition(name Symbol, expression Scmer) procSeque
 		return procSequenceNone
 	}
 	body, ok := scmerSlice(lambda[2])
-	if !ok || len(body) < 8 || (!scmerIsSymbol(body[0], "match") && !scmerIsSymbol(body[0], "match_mut")) {
+	if !ok || len(body) < 8 || len(body)%2 != 0 || (!scmerIsSymbol(body[0], "match") && !scmerIsSymbol(body[0], "match_mut")) {
 		return procSequenceNone
 	}
 	input, ok := scmerSlice(body[1])
 	if !ok || len(input) != 3 || !scmerIsSymbol(input[0], "coalesceNil") {
 		return procSequenceNone
 	}
-	binaryPattern, ok := scmerSlice(body[2])
-	if !ok || len(binaryPattern) != 3 {
-		return procSequenceNone
+	hasBinary, hasVariadic := false, false
+	for i := 2; i+1 < len(body); i += 2 {
+		pattern, patternOK := scmerSlice(body[i])
+		result, resultOK := scmerSlice(body[i+1])
+		if !patternOK || !resultOK {
+			continue
+		}
+		if len(pattern) == 3 {
+			head, headOK := scmerSlice(pattern[0])
+			if headOK && len(head) == 2 &&
+				(scmerIsSymbol(head[0], "symbol") || scmerIsSymbol(head[0], "quote")) &&
+				scmerIsSymbol(head[1], "and") && len(result) >= 2 && scmerIsSymbol(result[0], "merge") {
+				hasBinary = true
+				continue
+			}
+		}
+		if len(pattern) == 3 && scmerIsSymbol(pattern[0], "cons") &&
+			len(result) >= 3 && scmerIsSymbol(result[0], "if") {
+			hasVariadic = true
+		}
 	}
-	binaryHead, ok := scmerSlice(binaryPattern[0])
-	if !ok || len(binaryHead) != 2 || !scmerIsSymbol(binaryHead[0], "symbol") || !scmerIsSymbol(binaryHead[1], "and") {
-		return procSequenceNone
-	}
-	binaryResult, ok := scmerSlice(body[3])
-	if !ok || len(binaryResult) < 2 || !scmerIsSymbol(binaryResult[0], "merge") {
-		return procSequenceNone
-	}
-	variadicPattern, ok := scmerSlice(body[4])
-	if !ok || len(variadicPattern) != 3 || !scmerIsSymbol(variadicPattern[0], "cons") {
-		return procSequenceNone
-	}
-	variadicResult, ok := scmerSlice(body[5])
-	if !ok || len(variadicResult) < 3 || !scmerIsSymbol(variadicResult[0], "if") {
+	if !hasBinary || !hasVariadic {
 		return procSequenceNone
 	}
 	return procSequenceAndTerms

--- a/scm/planner_fusion_optimizer_test.go
+++ b/scm/planner_fusion_optimizer_test.go
@@ -98,6 +98,7 @@ func BenchmarkPlannerFlattenAssoc(b *testing.B) {
 const plannerFusionSplitAndTermsSource = `(define split_and_terms (lambda (expr)
 	(match (coalesceNil expr true)
 		((symbol and) a b) (merge (list (split_and_terms a) (split_and_terms b)))
+		((quote and) a b) (merge (list (split_and_terms a) (split_and_terms b)))
 		(cons head tail) (if (or (equal? head (quote and)) (equal? head (symbol "and")))
 			(merge (map tail split_and_terms))
 			(list expr))


### PR DESCRIPTION
## What

#684 records the `split_and_terms` producer shape once in its Proc metadata so `filter(split_and_terms(...), predicate)` can become one `filter_and_terms` traversal. The initial recognizer covered the simplified unit-test definition, but not the real planner definition: `lib/queryplan-logical.scm` has both `((symbol and) a b)` and `((quote and) a b)` branches before its variadic `(cons head tail)` branch.

The recognizer now walks the direct match branch pairs once, accepts both binary head representations, and requires both a recursive binary `merge` branch and the variadic `cons`/`if` branch. The result is still stored in `ProcOptimizerMeta`; consumers remain O(1) and do not re-analyze subtrees. The test fixture now mirrors the real planner shape.

## Performance evidence

This was found while investigating #684's first CI A/B failure. That run had one primary failure: the single-sample cold aggregate-pushdown case measured 74.61 -> 89.66 ms (+20.2%); later "missing case" failures were consequences of the suite abort. An unchanged rerun passed at 80.47 -> 93.98 ms (+16.8%) cold and 4.459 -> 4.434 ms (-0.6%) warm.

The cold case has `timing_samples: 1`, so I repeated it locally against exact merged-master `fa4dca692`, alternating Base->Candidate and Candidate->Base. Before this fix, six pairs ranged from -5.8% through +13.6%; medians were about 57.3 ms (master) and 58.5 ms (#684), approximately +2%, so the CI outlier was not reproducible.

After activating the real `split_and_terms` shape, four alternating pairs measured:

| metric | master median | fixed median | delta |
|---|---:|---:|---:|
| cold aggregate-pushdown query | ~57.0 ms | ~56.4 ms | **~-1%** |

The two Base->Candidate pairs were -7.7% and -9.7%; reversed order was also measured to control systematic warm-cache advantage. The warm samples remained noisy but showed no consistent regression. Full performance A/B is left to CI.

## Validation

- focused positive test with the complete real two-binary-branch shape;
- focused negative test for a same-named but structurally unrelated Proc;
- full repository suite is left to CI as agreed for optimizer changes.
