### PR TITLE
optimizer: specialize structural ownership through match

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -347,26 +347,30 @@ type optimizerRewriteState struct {
 const defaultOptimizerRewriteBudget = 64
 
 type optimizerMetainfo struct {
-	variableReplacement     map[Symbol]Scmer
-	variableTypes           map[Symbol]*TypeDescriptor
-	numberedTypes           map[NthLocalVar]*TypeDescriptor
-	ownedLocalBindings      map[Symbol]bool
-	setBlacklist            []Symbol
-	nextSlot                *int // pointer to lambda's slot counter; nil outside lambda
-	pendingCallbackParams   []*TypeDescriptor
-	pendingCallbackReturn   *TypeDescriptor // structured escape information for the next lambda result
-	loopDepth               int             // >0 inside scan/reduce callbacks; prevents hoisted defines from being inlined back into loops
-	lambdaDepth             int             // >0 while optimizing a lambda body; keeps local definitions out of Env hints
-	beginDepth              int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
-	inlineDepth             int
-	inlineStack             map[Symbol]bool
-	specializationStack     map[procSpecializationStackKey]bool
-	specializationParamMask uint64
-	specializationDepth     int
-	specializationUsed      *bool
-	rewrite                 *optimizerRewriteState
-	captureArgumentTypes    bool
-	argumentTypes           []TypeInfo
+	variableReplacement       map[Symbol]Scmer
+	variableTypes             map[Symbol]*TypeDescriptor
+	numberedTypes             map[NthLocalVar]*TypeDescriptor
+	ownedLocalBindings        map[Symbol]bool
+	setBlacklist              []Symbol
+	nextSlot                  *int // pointer to lambda's slot counter; nil outside lambda
+	pendingCallbackParams     []*TypeDescriptor
+	pendingCallbackReturn     *TypeDescriptor // structured escape information for the next lambda result
+	loopDepth                 int             // >0 inside scan/reduce callbacks; prevents hoisted defines from being inlined back into loops
+	lambdaDepth               int             // >0 while optimizing a lambda body; keeps local definitions out of Env hints
+	beginDepth                int             // >0 in lexical begin scopes; their definitions do not reach the caller Env
+	inlineDepth               int
+	inlineStack               map[Symbol]bool
+	specializationStack       map[procSpecializationStackKey]bool
+	specializationParamMask   uint64
+	specializationDepth       int
+	specializationUsed        *bool
+	specializationNestedUsed  *bool
+	specializationRootMutUsed *bool
+	specializationOwnedVars   map[Symbol]bool
+	specializationOwnedSlots  map[NthLocalVar]bool
+	rewrite                   *optimizerRewriteState
+	captureArgumentTypes      bool
+	argumentTypes             []TypeInfo
 }
 
 func newOptimizerMetainfo() (result optimizerMetainfo) {
@@ -789,6 +793,8 @@ func (ome *optimizerMetainfo) Copy() (result optimizerMetainfo) {
 	result.specializationParamMask = ome.specializationParamMask
 	result.specializationDepth = ome.specializationDepth
 	result.specializationUsed = ome.specializationUsed
+	result.specializationNestedUsed = ome.specializationNestedUsed
+	result.specializationRootMutUsed = ome.specializationRootMutUsed
 	result.rewrite = ome.rewrite
 	// nextSlot is NOT propagated across lambda boundaries (each lambda has its own)
 	return
@@ -820,6 +826,10 @@ func (ome *optimizerMetainfo) CopySharedScope() (result optimizerMetainfo) {
 	result.specializationParamMask = ome.specializationParamMask
 	result.specializationDepth = ome.specializationDepth
 	result.specializationUsed = ome.specializationUsed
+	result.specializationNestedUsed = ome.specializationNestedUsed
+	result.specializationRootMutUsed = ome.specializationRootMutUsed
+	result.specializationOwnedVars = ome.specializationOwnedVars
+	result.specializationOwnedSlots = ome.specializationOwnedSlots
 	result.rewrite = ome.rewrite
 	return
 }
@@ -1042,6 +1052,55 @@ func markProcOwnershipSpecializationUse(ome *optimizerMetainfo, expr Scmer) {
 	}
 }
 
+func markNestedProcOwnershipSpecializationUse(ome *optimizerMetainfo, expr Scmer) {
+	if ome.specializationNestedUsed == nil || ome.lambdaDepth != ome.specializationDepth {
+		return
+	}
+	if nestedProcOwnershipExpression(ome, expr) {
+		*ome.specializationNestedUsed = true
+	}
+}
+
+func nestedProcOwnershipExpression(ome *optimizerMetainfo, expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() && ome.specializationOwnedSlots[expr.NthLocalVar()] {
+		return true
+	}
+	if sym, ok := scmerSymbol(expr); ok && ome.specializationOwnedVars[sym] {
+		return true
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) < 2 {
+		return false
+	}
+	if scmerIsSymbol(items[0], "car") || scmerIsSymbol(items[0], "cadr") || scmerIsSymbol(items[0], "nth") || scmerIsSymbol(items[0], "get_assoc") {
+		if procOwnershipParameterMask(items[1], 64)&ome.specializationParamMask != 0 {
+			return true
+		}
+		return nestedProcOwnershipExpression(ome, items[1])
+	}
+	if scmerIsSymbol(items[0], "coalesce") || scmerIsSymbol(items[0], "coalesceNil") {
+		for _, item := range items[1:] {
+			if nestedProcOwnershipExpression(ome, item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func markRootProcOwnershipMutationUse(ome *optimizerMetainfo, expr Scmer) {
+	if ome.specializationRootMutUsed == nil || ome.lambdaDepth != ome.specializationDepth {
+		return
+	}
+	mask := procOwnershipParameterMask(expr, 64)
+	if mask&ome.specializationParamMask != 0 {
+		*ome.specializationRootMutUsed = true
+	}
+}
+
 // procOwnershipParameterMask follows expressions which return one of their
 // arguments unchanged. Ownership can cross such a selector only when the
 // selector's merged return type proves every possible result transferable.
@@ -1219,6 +1278,29 @@ func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
 	return lo, hi
 }
 
+func procSpecializationKeyFromParams(mask uint64, paramTypes []*TypeDescriptor) procSpecializationKey {
+	ownershipLo := uint64(0x6a09e667f3bcc909)
+	ownershipHi := uint64(0xbb67ae8584caa73b)
+	for i, paramType := range paramTypes {
+		if mask&(1<<uint(i)) == 0 {
+			continue
+		}
+		paramLo, paramHi := specializationOwnershipHash(paramType)
+		ownershipLo = combineStructuralHash(ownershipLo, combineStructuralHash(uint64(i), paramLo))
+		ownershipHi = combineStructuralHash(ownershipHi, combineStructuralHash(uint64(i), paramHi))
+	}
+	return procSpecializationKey{paramMask: mask, ownershipLo: ownershipLo, ownershipHi: ownershipHi}
+}
+
+func procSpecializationHasNestedOwnership(paramTypes []*TypeDescriptor) bool {
+	for _, paramType := range paramTypes {
+		if paramType != nil && (descriptorContainsOwnership(paramType.Element) || len(paramType.Keys) > 0) {
+			return true
+		}
+	}
+	return false
+}
+
 func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecializationKey, []*TypeDescriptor, bool) {
 	params, ok := scmerSlice(proc.Params)
 	if !ok || len(params) == 0 || len(params) > 64 || proc.NumVars < len(params) {
@@ -1259,29 +1341,24 @@ func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecia
 		return procSpecializationKey{}, nil, false
 	}
 	paramTypes := make([]*TypeDescriptor, len(params))
-	ownershipLo := uint64(0x6a09e667f3bcc909)
-	ownershipHi := uint64(0xbb67ae8584caa73b)
 	for i := range params {
 		paramTypes[i] = &TypeDescriptor{Kind: "any", Length: UnknownLength}
 		if mask&(1<<uint(i)) == 0 {
 			continue
 		}
 		paramTypes[i] = specializationOwnershipDescriptor(argTypes[i+1].ToTypeDescriptor())
-		paramLo, paramHi := specializationOwnershipHash(paramTypes[i])
-		ownershipLo = combineStructuralHash(ownershipLo, combineStructuralHash(uint64(i), paramLo))
-		ownershipHi = combineStructuralHash(ownershipHi, combineStructuralHash(uint64(i), paramHi))
 	}
-	return procSpecializationKey{paramMask: mask, ownershipLo: ownershipLo, ownershipHi: ownershipHi}, paramTypes, true
+	return procSpecializationKeyFromParams(mask, paramTypes), paramTypes, true
 }
 
-func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, stack map[procSpecializationStackKey]bool) Scmer {
+func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, stack map[procSpecializationStackKey]bool) (Scmer, bool, bool) {
 	paramsValue := proc.Params
 	if stripped, ok := scmerStripSourceInfo(paramsValue); ok {
 		paramsValue = stripped
 	}
 	params := paramsValue.Slice()
 	if len(paramTypes) != len(params) {
-		return NewNil()
+		return NewNil(), false, false
 	}
 	lambda := []Scmer{
 		NewSymbol("lambda"),
@@ -1293,15 +1370,19 @@ func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, par
 	}
 	meta := newOptimizerMetainfo()
 	used := false
+	nestedUsed := false
+	rootMutationUsed := false
 	meta.pendingCallbackParams = paramTypes
 	meta.specializationStack = stack
 	meta.specializationParamMask = key.paramMask
 	meta.specializationDepth = meta.lambdaDepth + 1
 	meta.specializationUsed = &used
+	meta.specializationNestedUsed = &nestedUsed
+	meta.specializationRootMutUsed = &rootMutationUsed
 	optimized, _ := OptimizeEx(NewSlice(lambda), proc.En, &meta, true)
 	parts, ok := scmerSlice(optimized)
 	if !ok || len(parts) < 3 || !scmerIsSymbol(parts[0], "lambda") {
-		return NewNil()
+		return NewNil(), nestedUsed, rootMutationUsed
 	}
 	specialized := *proc
 	specialized.Params = parts[1]
@@ -1314,7 +1395,7 @@ func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, par
 	// with an anonymous Proc literal. Publish a variant only when an ownership-
 	// aware rewrite actually consumes one of the specialized parameters.
 	if !used {
-		return NewNil()
+		return NewNil(), nestedUsed, rootMutationUsed
 	}
 	// Machine code belongs to the exact optimized body. Never inherit the
 	// generic Proc's entry point when publishing a specialized body.
@@ -1328,7 +1409,7 @@ func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, par
 	if proc.Compiled != nil {
 		variant = jitCompileMode(proc.Compiled.RecursiveLambdas, variant)
 	}
-	return variant
+	return variant, nestedUsed, rootMutationUsed
 }
 
 func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimizerMetainfo) (Scmer, bool) {
@@ -1366,6 +1447,10 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 	if !ok {
 		return NewNil(), false
 	}
+	return getProcOwnershipSpecialization(proc, key, paramTypes, ome)
+}
+
+func getProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, ome *optimizerMetainfo) (Scmer, bool) {
 	stackKey := procSpecializationStackKey{meta: proc.OptimizerMeta, key: key}
 	if ome.specializationStack != nil && ome.specializationStack[stackKey] {
 		return NewNil(), false
@@ -1393,7 +1478,11 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 		delete(ome.specializationStack, stackKey)
 		proc.OptimizerMeta.finishSpecialization(key, variant)
 	}()
-	variant = buildProcOwnershipSpecialization(proc, key, paramTypes, ome.specializationStack)
+	var nestedUsed, rootMutationUsed bool
+	variant, nestedUsed, rootMutationUsed = buildProcOwnershipSpecialization(proc, key, paramTypes, ome.specializationStack)
+	if procSpecializationHasNestedOwnership(paramTypes) && !nestedUsed && !rootMutationUsed {
+		variant = NewNil()
+	}
 	return variant, variant.IsProc()
 }
 
@@ -2589,6 +2678,8 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 		}
 		if firstArgFresh && len(v) >= 2 {
 			markProcOwnershipSpecializationUse(ome, v[1])
+			markRootProcOwnershipMutationUse(ome, v[1])
+			markNestedProcOwnershipSpecializationUse(ome, v[1])
 			v[0] = NewSymbol(mutName)
 			firstArgTransferred = true
 		}
@@ -3144,12 +3235,47 @@ func optimizeMatchPattern(pattern Scmer, env *Env, ome *optimizerMetainfo) (Scme
 	return pattern, matchPatternScalarInfo(pattern)
 }
 
-func bindMatchPatternType(pattern Scmer, td *TypeDescriptor, ome *optimizerMetainfo) {
+func cloneDescriptorMap(source map[Symbol]*TypeDescriptor) map[Symbol]*TypeDescriptor {
+	result := make(map[Symbol]*TypeDescriptor, len(source))
+	for symbol, td := range source {
+		result[symbol] = td
+	}
+	return result
+}
+
+func cloneNumberedDescriptorMap(source map[NthLocalVar]*TypeDescriptor) map[NthLocalVar]*TypeDescriptor {
+	result := make(map[NthLocalVar]*TypeDescriptor, len(source))
+	for slot, td := range source {
+		result[slot] = td
+	}
+	return result
+}
+
+func cloneSymbolBoolMap(source map[Symbol]bool) map[Symbol]bool {
+	result := make(map[Symbol]bool, len(source))
+	for symbol, value := range source {
+		result[symbol] = value
+	}
+	return result
+}
+
+func cloneNumberedBoolMap(source map[NthLocalVar]bool) map[NthLocalVar]bool {
+	result := make(map[NthLocalVar]bool, len(source))
+	for slot, value := range source {
+		result[slot] = value
+	}
+	return result
+}
+
+func bindMatchPatternType(pattern Scmer, td *TypeDescriptor, ome *optimizerMetainfo, derived bool) {
 	if stripped, ok := scmerStripSourceInfo(pattern); ok {
 		pattern = stripped
 	}
 	if pattern.IsNthLocalVar() {
 		ome.numberedTypes[pattern.NthLocalVar()] = td
+		if derived && td != nil && td.Transfer {
+			ome.specializationOwnedSlots[pattern.NthLocalVar()] = true
+		}
 		return
 	}
 	if sym, ok := scmerSymbol(pattern); ok {
@@ -3158,8 +3284,14 @@ func bindMatchPatternType(pattern Scmer, td *TypeDescriptor, ome *optimizerMetai
 			return
 		}
 		ome.variableTypes[sym] = td
+		if derived && td != nil && td.Transfer {
+			ome.specializationOwnedVars[sym] = true
+		}
 		if replacement, exists := ome.variableReplacement[sym]; exists && replacement.IsNthLocalVar() {
 			ome.numberedTypes[replacement.NthLocalVar()] = td
+			if derived && td != nil && td.Transfer {
+				ome.specializationOwnedSlots[replacement.NthLocalVar()] = true
+			}
 		}
 		return
 	}
@@ -3170,25 +3302,25 @@ func bindMatchPatternType(pattern Scmer, td *TypeDescriptor, ome *optimizerMetai
 	head, headOK := scmerSymbol(items[0])
 	if !headOK {
 		for i, child := range items {
-			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome)
+			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome, true)
 		}
 		return
 	}
 	switch head {
 	case Symbol("cons"):
 		if len(items) == 3 {
-			bindMatchPatternType(items[1], descriptorProjection(td, "0"), ome)
-			bindMatchPatternType(items[2], matchTailDescriptor(td), ome)
+			bindMatchPatternType(items[1], descriptorProjection(td, "0"), ome, true)
+			bindMatchPatternType(items[2], matchTailDescriptor(td), ome, true)
 		}
 	case Symbol("list"):
 		for i, child := range items[1:] {
-			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome)
+			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome, true)
 		}
 	case Symbol("list?"):
 		if len(items) == 2 {
 			refined := copyTypeDescriptor(td)
 			refined.Kind = "list"
-			bindMatchPatternType(items[1], refined, ome)
+			bindMatchPatternType(items[1], refined, ome, derived)
 		}
 	case Symbol("eval"), Symbol("quote"), Symbol("symbol"), Symbol("string?"), Symbol("number?"), Symbol("regex"), Symbol("ignorecase"), Symbol("merge"):
 		return
@@ -3252,7 +3384,11 @@ func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, 
 		branchOme := ome.CopySharedScope()
 		pattern, info := optimizeMatchPattern(v[i-1], env, &branchOme)
 		if valueDescriptor != nil {
-			bindMatchPatternType(pattern, valueDescriptor, &branchOme)
+			branchOme.variableTypes = cloneDescriptorMap(ome.variableTypes)
+			branchOme.numberedTypes = cloneNumberedDescriptorMap(ome.numberedTypes)
+			branchOme.specializationOwnedVars = cloneSymbolBoolMap(ome.specializationOwnedVars)
+			branchOme.specializationOwnedSlots = cloneNumberedBoolMap(ome.specializationOwnedSlots)
+			bindMatchPatternType(pattern, valueDescriptor, &branchOme, false)
 		}
 		duplicate := false
 		if info.comparable && seen != nil {

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -361,7 +361,7 @@ type optimizerMetainfo struct {
 	inlineDepth             int
 	inlineStack             map[Symbol]bool
 	specializationStack     map[procSpecializationStackKey]bool
-	specializationParamMask procSpecializationKey
+	specializationParamMask uint64
 	specializationDepth     int
 	specializationUsed      *bool
 	rewrite                 *optimizerRewriteState
@@ -661,11 +661,21 @@ func CloneOptimizerExpression(expr Scmer) Scmer {
 	return NewSlice(cloned)
 }
 
-func descriptorKey(td *TypeDescriptor, key string) *TypeDescriptor {
-	if td == nil || td.Keys == nil {
-		return &TypeDescriptor{Kind: "any", Length: UnknownLength}
+func descriptorProjection(td *TypeDescriptor, key string) *TypeDescriptor {
+	if td == nil {
+		return nil
 	}
-	return copyTypeDescriptor(td.Keys[key])
+	if child := td.Keys[key]; child != nil {
+		return child
+	}
+	if td.Element != nil {
+		return td.Element
+	}
+	return nil
+}
+
+func descriptorKey(td *TypeDescriptor, key string) *TypeDescriptor {
+	return copyTypeDescriptor(descriptorProjection(td, key))
 }
 
 func optimizerExpressionDescriptor(expr Scmer, env *Env, ome *optimizerMetainfo) *TypeDescriptor {
@@ -719,10 +729,10 @@ func optimizerExpressionDescriptor(expr Scmer, env *Env, ome *optimizerMetainfo)
 		return returnType
 	}
 	base := optimizerExpressionDescriptor(items[1], env, ome)
-	if base == nil || base.Keys == nil {
+	if base == nil {
 		return returnType
 	}
-	if projected := base.Keys[key]; projected != nil {
+	if projected := descriptorProjection(base, key); projected != nil {
 		return projected
 	}
 	return returnType
@@ -1027,7 +1037,7 @@ func markProcOwnershipSpecializationUse(ome *optimizerMetainfo, expr Scmer) {
 		return
 	}
 	mask := procOwnershipParameterMask(expr, 64)
-	if procSpecializationKey(mask)&ome.specializationParamMask != 0 {
+	if mask&ome.specializationParamMask != 0 {
 		*ome.specializationUsed = true
 	}
 }
@@ -1114,12 +1124,107 @@ func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bo
 	return uses, captured, consumed
 }
 
-func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecializationKey, bool) {
+func specializationOwnershipDescriptor(td *TypeDescriptor) *TypeDescriptor {
+	if td == nil {
+		return &TypeDescriptor{Kind: "any", Length: UnknownLength}
+	}
+	result := &TypeDescriptor{
+		Kind:     "any",
+		Transfer: td.Transfer && !td.Const,
+		Length:   UnknownLength,
+	}
+	element := specializationOwnershipDescriptorOrNil(td.Element)
+	elementOwned := descriptorContainsOwnership(element)
+	if elementOwned {
+		result.Element = element
+	}
+	if len(td.Keys) > 0 {
+		result.Keys = make(map[string]*TypeDescriptor, len(td.Keys))
+		for key, child := range td.Keys {
+			childOwnership := specializationOwnershipDescriptor(child)
+			// A borrowed leaf is indistinguishable from missing information unless
+			// it must override an owned Element fallback.
+			if elementOwned || descriptorContainsOwnership(childOwnership) {
+				result.Keys[key] = childOwnership
+			}
+		}
+		if len(result.Keys) == 0 {
+			result.Keys = nil
+		}
+	}
+	return result
+}
+
+func specializationOwnershipDescriptorOrNil(td *TypeDescriptor) *TypeDescriptor {
+	if td == nil {
+		return nil
+	}
+	return specializationOwnershipDescriptor(td)
+}
+
+func descriptorContainsOwnership(td *TypeDescriptor) bool {
+	if td == nil {
+		return false
+	}
+	if td.Transfer || descriptorContainsOwnership(td.Element) {
+		return true
+	}
+	for _, child := range td.Keys {
+		if descriptorContainsOwnership(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func specializationHashText(seed uint64, value string) uint64 {
+	result := seed
+	for i := 0; i < len(value); i++ {
+		result ^= uint64(value[i])
+		result *= 1099511628211
+	}
+	return result
+}
+
+func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
+	if td == nil {
+		return 0x243f6a8885a308d3, 0x13198a2e03707344
+	}
+	lo := specializationHashText(1469598103934665603, td.Kind)
+	hi := specializationHashText(1099511628211, td.Kind)
+	if td.Transfer {
+		lo = combineStructuralHash(lo, 1)
+		hi = combineStructuralHash(hi, 0x9e3779b97f4a7c15)
+	}
+	lo = combineStructuralHash(lo, uint64(td.Length))
+	hi = combineStructuralHash(hi, uint64(td.Length)^0xa4093822299f31d0)
+	elementLo, elementHi := specializationOwnershipHash(td.Element)
+	lo = combineStructuralHash(lo, elementLo)
+	hi = combineStructuralHash(hi, elementHi)
+	// TypeDescriptor.Keys is a map. Fold separately hashed entries using two
+	// commutative accumulators so identical descriptors produce identical keys
+	// without sorting or allocating a temporary key slice.
+	var keysXor, keysSum, keysXorHi, keysSumHi uint64
+	for key, child := range td.Keys {
+		childLo, childHi := specializationOwnershipHash(child)
+		keyLo := combineStructuralHash(specializationHashText(1469598103934665603, key), childLo)
+		keyHi := combineStructuralHash(specializationHashText(1099511628211, key), childHi)
+		keysXor ^= keyLo
+		keysSum += keyLo * 0x9e3779b97f4a7c15
+		keysXorHi ^= keyHi
+		keysSumHi += keyHi * 0xbf58476d1ce4e5b9
+	}
+	lo = combineStructuralHash(combineStructuralHash(lo, keysXor), keysSum)
+	hi = combineStructuralHash(combineStructuralHash(hi, keysXorHi), keysSumHi)
+	return lo, hi
+}
+
+func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecializationKey, []*TypeDescriptor, bool) {
 	params, ok := scmerSlice(proc.Params)
 	if !ok || len(params) == 0 || len(params) > 64 || proc.NumVars < len(params) {
-		return 0, false
+		return procSpecializationKey{}, nil, false
 	}
-	var candidates procSpecializationKey
+	var candidates uint64
 	for i := range params {
 		argIndex := i + 1
 		if argIndex >= len(argTypes) {
@@ -1136,10 +1241,10 @@ func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecia
 		candidates |= 1 << uint(i)
 	}
 	if candidates == 0 {
-		return 0, false
+		return procSpecializationKey{}, nil, false
 	}
 	uses, captured, consumed := procParameterOwnershipUses(proc.Body, len(params))
-	var key procSpecializationKey
+	var mask uint64
 	for i := range params {
 		if candidates&(1<<uint(i)) == 0 {
 			continue
@@ -1147,24 +1252,36 @@ func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecia
 		// Transfer is linear. A specialized body may consume a parameter only
 		// when that Proc frame has exactly one non-captured use of the value.
 		if uses[i] == 1 && !captured[i] && consumed[i] {
-			key |= 1 << uint(i)
+			mask |= 1 << uint(i)
 		}
 	}
-	return key, key != 0
+	if mask == 0 {
+		return procSpecializationKey{}, nil, false
+	}
+	paramTypes := make([]*TypeDescriptor, len(params))
+	ownershipLo := uint64(0x6a09e667f3bcc909)
+	ownershipHi := uint64(0xbb67ae8584caa73b)
+	for i := range params {
+		paramTypes[i] = &TypeDescriptor{Kind: "any", Length: UnknownLength}
+		if mask&(1<<uint(i)) == 0 {
+			continue
+		}
+		paramTypes[i] = specializationOwnershipDescriptor(argTypes[i+1].ToTypeDescriptor())
+		paramLo, paramHi := specializationOwnershipHash(paramTypes[i])
+		ownershipLo = combineStructuralHash(ownershipLo, combineStructuralHash(uint64(i), paramLo))
+		ownershipHi = combineStructuralHash(ownershipHi, combineStructuralHash(uint64(i), paramHi))
+	}
+	return procSpecializationKey{paramMask: mask, ownershipLo: ownershipLo, ownershipHi: ownershipHi}, paramTypes, true
 }
 
-func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, stack map[procSpecializationStackKey]bool) Scmer {
+func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, stack map[procSpecializationStackKey]bool) Scmer {
 	paramsValue := proc.Params
 	if stripped, ok := scmerStripSourceInfo(paramsValue); ok {
 		paramsValue = stripped
 	}
 	params := paramsValue.Slice()
-	paramTypes := make([]*TypeDescriptor, len(params))
-	for i := range params {
-		paramTypes[i] = &TypeDescriptor{Kind: "any", Length: UnknownLength}
-		if key&(1<<uint(i)) != 0 {
-			paramTypes[i].Transfer = true
-		}
+	if len(paramTypes) != len(params) {
+		return NewNil()
 	}
 	lambda := []Scmer{
 		NewSymbol("lambda"),
@@ -1178,7 +1295,7 @@ func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, sta
 	used := false
 	meta.pendingCallbackParams = paramTypes
 	meta.specializationStack = stack
-	meta.specializationParamMask = key
+	meta.specializationParamMask = key.paramMask
 	meta.specializationDepth = meta.lambdaDepth + 1
 	meta.specializationUsed = &used
 	optimized, _ := OptimizeEx(NewSlice(lambda), proc.En, &meta, true)
@@ -1245,7 +1362,7 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 	if proc == nil || proc.En == nil || proc.OptimizerMeta == nil {
 		return NewNil(), false
 	}
-	key, ok := procOwnershipSpecializationKey(proc, argTypes)
+	key, paramTypes, ok := procOwnershipSpecializationKey(proc, argTypes)
 	if !ok {
 		return NewNil(), false
 	}
@@ -1276,7 +1393,7 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 		delete(ome.specializationStack, stackKey)
 		proc.OptimizerMeta.finishSpecialization(key, variant)
 	}()
-	variant = buildProcOwnershipSpecialization(proc, key, ome.specializationStack)
+	variant = buildProcOwnershipSpecialization(proc, key, paramTypes, ome.specializationStack)
 	return variant, variant.IsProc()
 }
 
@@ -3023,8 +3140,99 @@ func optimizeMatchPattern(pattern Scmer, env *Env, ome *optimizerMetainfo) (Scme
 	return pattern, matchPatternScalarInfo(pattern)
 }
 
+func bindMatchPatternType(pattern Scmer, td *TypeDescriptor, ome *optimizerMetainfo) {
+	if stripped, ok := scmerStripSourceInfo(pattern); ok {
+		pattern = stripped
+	}
+	if pattern.IsNthLocalVar() {
+		ome.numberedTypes[pattern.NthLocalVar()] = td
+		return
+	}
+	if sym, ok := scmerSymbol(pattern); ok {
+		switch sym {
+		case Symbol("_"), Symbol("nil"), Symbol("true"), Symbol("false"):
+			return
+		}
+		ome.variableTypes[sym] = td
+		if replacement, exists := ome.variableReplacement[sym]; exists && replacement.IsNthLocalVar() {
+			ome.numberedTypes[replacement.NthLocalVar()] = td
+		}
+		return
+	}
+	items, ok := scmerSlice(pattern)
+	if !ok || len(items) == 0 {
+		return
+	}
+	head, headOK := scmerSymbol(items[0])
+	if !headOK {
+		for i, child := range items {
+			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome)
+		}
+		return
+	}
+	switch head {
+	case Symbol("cons"):
+		if len(items) == 3 {
+			bindMatchPatternType(items[1], descriptorProjection(td, "0"), ome)
+			bindMatchPatternType(items[2], matchTailDescriptor(td), ome)
+		}
+	case Symbol("list"):
+		for i, child := range items[1:] {
+			bindMatchPatternType(child, descriptorProjection(td, strconv.Itoa(i)), ome)
+		}
+	case Symbol("list?"):
+		if len(items) == 2 {
+			refined := copyTypeDescriptor(td)
+			refined.Kind = "list"
+			bindMatchPatternType(items[1], refined, ome)
+		}
+	case Symbol("eval"), Symbol("quote"), Symbol("symbol"), Symbol("string?"), Symbol("number?"), Symbol("regex"), Symbol("ignorecase"), Symbol("merge"):
+		return
+	default:
+		// Unknown named applications are match operators, not list values.
+		return
+	}
+}
+
+func matchTailDescriptor(td *TypeDescriptor) *TypeDescriptor {
+	if td == nil {
+		return &TypeDescriptor{Kind: "list", Length: UnknownLength}
+	}
+	tail := &TypeDescriptor{
+		Kind:     "list",
+		NoEscape: td.NoEscape,
+		Transfer: td.Transfer,
+		Length:   UnknownLength,
+		Element:  td.Element,
+	}
+	if td.Length > 0 {
+		tail.Length = td.Length - 1
+		if tail.Length == 0 {
+			tail.Length = UnknownLength
+		}
+	}
+	for key, child := range td.Keys {
+		index, err := strconv.Atoi(key)
+		if err != nil || index == 0 {
+			continue
+		}
+		if tail.Keys == nil {
+			tail.Keys = make(map[string]*TypeDescriptor)
+		}
+		tail.Keys[strconv.Itoa(index-1)] = child
+	}
+	return tail
+}
+
 func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {
-	value, transferOwnership, _ := optimizeExCompat(v[1], env, ome, true)
+	value, valueType := OptimizeEx(v[1], env, ome, true)
+	transferOwnership := valueType.Transfer()
+	var valueDescriptor *TypeDescriptor
+	if td := valueType.ToTypeDescriptor(); td != nil && (len(td.Keys) > 0 || td.Element != nil) {
+		// Pattern variables are runtime bindings. Preserve structural ownership,
+		// but never expose Const as if a branch variable had a compile-time value.
+		valueDescriptor = callbackParameterType(td)
+	}
 	head := v[0]
 	if headSym == Symbol("match") && transferOwnership {
 		markProcOwnershipSpecializationUse(ome, value)
@@ -3039,6 +3247,9 @@ func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, 
 	for i := 3; i < len(v); i += 2 {
 		branchOme := ome.CopySharedScope()
 		pattern, info := optimizeMatchPattern(v[i-1], env, &branchOme)
+		if valueDescriptor != nil {
+			bindMatchPatternType(pattern, valueDescriptor, &branchOme)
+		}
 		duplicate := false
 		if info.comparable && seen != nil {
 			for _, previous := range seen[info.hash] {

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -230,8 +230,15 @@ func TestProcOwnershipSpecializationPublishesFullProc(t *testing.T) {
 	if serialized := serializedTestExpr(t, env, variant.Body); !strings.Contains(serialized, "append_unique_mut") {
 		t.Fatalf("specialized Proc body did not consume its transferred parameter: %s", serialized)
 	}
-	cached, exists := base.OptimizerMeta.specialization(1)
-	if !exists || cached != call[0] {
+	snapshot := base.OptimizerMeta.specializations.Load()
+	if snapshot == nil || len(snapshot.variants) != 1 {
+		t.Fatal("base Proc did not retain exactly one Proc specialization")
+	}
+	var cached Scmer
+	for _, variant := range snapshot.variants {
+		cached = variant
+	}
+	if cached != call[0] {
 		t.Fatal("base Proc did not retain the published Proc specialization")
 	}
 	got := Apply(Eval(optimized, env), NewInt(0))
@@ -258,6 +265,79 @@ func TestProcOwnershipSpecializationFollowsCoalesceNilIntoFilter(t *testing.T) {
 	got := Apply(Eval(optimized, env), NewInt(1), NewInt(50), NewInt(99))
 	if !Equal(got, NewSlice([]Scmer{NewInt(1), NewInt(99)})) {
 		t.Fatalf("specialized optional filter returned %s", String(got))
+	}
+}
+
+func TestProcOwnershipSpecializationRetainsNestedOwnershipVariants(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("nested proc specialization test", `(define specialize_nested_child (lambda (wrapper)
+		(match wrapper
+			(cons child _tail) (append child 2 3 4 5 6 7 8 9 10)
+			_ '())))`, env)
+	base := env.Vars[Symbol("specialize_nested_child")].Proc()
+
+	borrowed := optimizeTestSource(t, env, `(lambda (child)
+		(specialize_nested_child (list child)))`)
+	borrowedCall := borrowed.Slice()[2].Slice()
+	if !borrowedCall[0].IsProc() {
+		t.Fatalf("fresh wrapper did not specialize: %s", serializedTestExpr(t, env, borrowed))
+	}
+	if body := serializedTestExpr(t, env, borrowedCall[0].Proc().Body); strings.Contains(body, "append_mut") {
+		t.Fatalf("borrowed child was made mutable: %s", body)
+	}
+
+	transferred := optimizeTestSource(t, env, `(lambda (value)
+		(specialize_nested_child (list (list value))))`)
+	transferredCall := transferred.Slice()[2].Slice()
+	if !transferredCall[0].IsProc() {
+		t.Fatalf("nested fresh child did not specialize: %s", serializedTestExpr(t, env, transferred))
+	}
+	if body := serializedTestExpr(t, env, transferredCall[0].Proc().Body); !strings.Contains(body, "append_mut") {
+		t.Fatalf("nested ownership did not reach the match binding: %s", body)
+	}
+	if transferredCall[0] == borrowedCall[0] {
+		t.Fatal("different nested ownership shapes selected the same Proc")
+	}
+	snapshot := base.OptimizerMeta.specializations.Load()
+	if snapshot == nil || len(snapshot.variants) != 2 {
+		t.Fatalf("expected two retained ownership variants, got %#v", snapshot)
+	}
+
+	child := NewSlice([]Scmer{NewInt(1)})
+	got := Apply(Eval(borrowed, env), child)
+	if len(child.Slice()) != 1 || len(got.Slice()) != 10 {
+		t.Fatalf("borrowed variant changed its input: child=%s result=%s", String(child), String(got))
+	}
+	got = Apply(Eval(transferred, env), NewInt(1))
+	if len(got.Slice()) != 10 {
+		t.Fatalf("transferred variant returned %s", String(got))
+	}
+}
+
+func TestProcOwnershipSpecializationUsesElementOwnershipForEveryChild(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("element ownership specialization test", `(define specialize_element_child (lambda (wrapper)
+		(match wrapper
+			(cons child _tail) (append child 2 3 4 5 6 7 8 9 10)
+			_ '())))`, env)
+	base := env.Vars[Symbol("specialize_element_child")].Proc()
+	call := []Scmer{NewSymbol("specialize_element_child"), NewSymbol("fresh")}
+	allChildrenOwned := &TypeDescriptor{
+		Kind:     "list",
+		Transfer: true,
+		Length:   UnknownLength,
+		Element:  &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength},
+	}
+	meta := newOptimizerMetainfo()
+	variant, ok := trySpecializeProcCall(call, []TypeInfo{tiZero, TypeInfoFromTD(allChildrenOwned)}, env, &meta)
+	if !ok || !variant.IsProc() {
+		t.Fatal("element ownership did not produce a Proc specialization")
+	}
+	if body := serializedTestExpr(t, env, variant.Proc().Body); !strings.Contains(body, "append_mut") {
+		t.Fatalf("Element.Transfer did not reach a projected child: %s", body)
+	}
+	if base.OptimizerMeta.specializations.Load() == nil {
+		t.Fatal("element ownership specialization was not retained")
 	}
 }
 
@@ -375,8 +455,13 @@ func TestConcurrentProcOwnershipSpecializationPublishesOneProc(t *testing.T) {
 		}
 	}
 	snapshot := base.OptimizerMeta.specializations.Load()
-	if snapshot == nil || len(snapshot.variants) != 1 || snapshot.variants[1] != published {
+	if snapshot == nil || len(snapshot.variants) != 1 {
 		t.Fatal("concurrent specialization cache does not contain exactly the published Proc")
+	}
+	for _, variant := range snapshot.variants {
+		if variant != published {
+			t.Fatal("concurrent specialization cache contains a different Proc")
+		}
 	}
 }
 

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -341,6 +341,29 @@ func TestProcOwnershipSpecializationUsesElementOwnershipForEveryChild(t *testing
 	}
 }
 
+func TestProcOwnershipSpecializationRejectsUnusedNestedShape(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("unused nested ownership specialization test", `(define specialize_nested_read_only (lambda (wrapper)
+		(match wrapper
+			(cons child _tail) (car child)
+			_ nil)))`, env)
+
+	borrowed := optimizeTestSource(t, env, `(lambda (child)
+		(specialize_nested_read_only (list child)))`)
+	transferred := optimizeTestSource(t, env, `(lambda (value)
+		(specialize_nested_read_only (list (list value))))`)
+	borrowedVariant := borrowed.Slice()[2].Slice()[0]
+	transferredVariant := transferred.Slice()[2].Slice()[0]
+	if !borrowedVariant.IsProc() || transferredVariant.IsProc() {
+		t.Fatal("unused nested ownership built a redundant structural Proc body")
+	}
+	base := env.Vars[Symbol("specialize_nested_read_only")].Proc()
+	snapshot := base.OptimizerMeta.specializations.Load()
+	if snapshot == nil || len(snapshot.variants) != 1 || len(snapshot.rejected) != 1 {
+		t.Fatalf("unused nested ownership was not rejected: %#v", snapshot)
+	}
+}
+
 func TestProcOwnershipSpecializationRejectsSharedCoalesceFallback(t *testing.T) {
 	env := newOptimizerTestEnv()
 	EvalAll("proc specialization test", `(define shared_filter_fallback (list 7 8 9))`, env)

--- a/scm/recursive_optimizer_experiment_test.go
+++ b/scm/recursive_optimizer_experiment_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+const recursiveSpecializationBenchmarkSource = `(define benchmark_recursive_collect (lambda (expr acc)
+	(match expr
+		((symbol node) child) (benchmark_recursive_collect child acc)
+		((quote node) child) (benchmark_recursive_collect (list (symbol "node") child) acc)
+		((symbol value) value) (append acc value)
+		((quote value) value) (benchmark_recursive_collect (list (symbol "value") value) acc)
+		(cons _head tail) (reduce tail (lambda (state child)
+			(benchmark_recursive_collect child state)) acc)
+		_ acc)))
+(define benchmark_recursive_collect_entry (lambda (expr)
+	(benchmark_recursive_collect (list (quote node) expr) (list))))`
+
+func BenchmarkOptimizeRecursiveOwnershipVariants(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		env := newOptimizerTestEnv()
+		EvalAll(b.Name(), recursiveSpecializationBenchmarkSource, env)
+		if !env.Vars[Symbol("benchmark_recursive_collect_entry")].IsProc() {
+			b.Fatal("recursive benchmark Proc was not defined")
+		}
+	}
+}
+
+const nestedOwnershipBenchmarkSource = `(define benchmark_nested_filter (lambda (wrapper)
+	(match wrapper
+		(cons child _tail) (filter child (lambda (value) (> value 63)))
+		_ '())))
+(define benchmark_nested_filter_entry (lambda (seed)
+	(benchmark_nested_filter (list (map (produceN 128) (lambda (value) (+ value seed)))))))`
+
+func BenchmarkNestedOwnershipMatchFilter(b *testing.B) {
+	env := newOptimizerTestEnv()
+	EvalAll(b.Name(), nestedOwnershipBenchmarkSource, env)
+	fn := OptimizeProcToSerialFunction(env.Vars[Symbol("benchmark_nested_filter_entry")])
+	if got := fn(NewInt(0)); len(got.Slice()) != 64 {
+		b.Fatalf("nested filter returned %s", String(got))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := fn(NewInt(0)); len(got.Slice()) != 64 {
+			b.Fatal("invalid result")
+		}
+	}
+}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -650,7 +650,15 @@ const (
 	procSequenceAndTerms
 )
 
-type procSpecializationKey uint64
+// procSpecializationKey distinguishes both the transferred parameters and the
+// ownership shape below them. A Proc can therefore retain independent full
+// variants for e.g. a fresh list with borrowed elements and a fresh list whose
+// elements are transferable as well.
+type procSpecializationKey struct {
+	paramMask   uint64
+	ownershipLo uint64
+	ownershipHi uint64
+}
 
 type procSpecializationSnapshot struct {
 	variants map[procSpecializationKey]Scmer
@@ -2772,7 +2780,8 @@ func ComputeSize(v Scmer) uint {
 			sz += typeDescriptorRetainedSize(p.OptimizerMeta.Return.Extra, make(map[*TypeDescriptor]struct{}))
 			if snapshot := p.OptimizerMeta.specializations.Load(); snapshot != nil {
 				sz += 2 * goAllocOverhead
-				sz += uint(len(snapshot.variants)+len(snapshot.rejected)) * uint(unsafe.Sizeof(procSpecializationKey(0)))
+				keyCount := len(snapshot.variants) + len(snapshot.rejected)
+				sz += uint(keyCount) * uint(unsafe.Sizeof(procSpecializationKey{}))
 				for _, variant := range snapshot.variants {
 					sz += ComputeSize(variant)
 				}


### PR DESCRIPTION
## What

Teach the Go Scheme optimizer to carry the existing `TypeDescriptor.Transfer` ownership information through nested list/match bindings and use that shape when choosing a Proc specialization.

- `Proc` keeps multiple specializations, and every specialization remains a full `Proc` with its own optimized body, specialization table, and JIT linkage.
- Specialization keys encode root parameters plus nested ownership from `TypeDescriptor.Keys` and the `Element` fallback. No parallel ownership flag was introduced.
- Fixed list, cons, and list? match patterns project the matched descriptor into their branch-local bindings.
- Structural variants are retained only when the information enables a real `_mut` rewrite at the root or through a transferred match binding. This avoids filling recursive Proc graphs with observationally identical variants.
- Ownership provenance is collected in the existing bottom-up optimizer traversal; this adds no separate subtree-analysis pass.

This is a step toward fusing functional compiler-stage code into physical single-pass operations: ownership handed into a helper can now survive destructuring and select destructive operators inside the helper.

## Evidence from query planner code

A serialized inventory of 1,945 Procs from `lib/queryplan*.scm` was compared after optimization. The useful-transform gate leaves 17 bodies changed and reduces their combined serialized size from 22,697 to 20,066 bytes (-11.59%). Redundant recursive match-only specializations are no longer retained.

Experiments that did not win were removed:

- Combining four product reducers into one reducer rebuilt an accumulator tuple for every child. It reduced reducer dispatches but increased bytes and runtime.
- Forcing larger `append_mut` cases did not improve Go slice-growth copies.
- Initially retaining match-only structural variants regressed the 10-table compile benchmark by about 3%; the useful-transform gate removes that regression.

## A/B measurements

Baseline: exact master `7c470f152` (#685). Measurements used the same pinned CPU and alternating A/B rounds. Master moved afterward through #686/#687; those changes affect JIT documentation and MySQL request setup, not the Go optimizer or HTTP planner path, and have been merged into this branch.

### Focused runtime microbenchmark

`BenchmarkNestedOwnershipMatchFilter`, n=15 per side, 1s samples:

| metric | master | branch | delta |
|---|---:|---:|---:|
| time/op | 15.49 us | 14.85 us | -4.12% (p=0.000) |
| bytes/op | 10.156 KiB | 7.906 KiB | -22.15% (p=0.000) |
| allocs/op | 292 | 291 | -0.34% (p=0.000) |

The benchmark models a recursive helper that destructures an owned child and filters it. Master selects `filter`; this branch selects `filter_mut` inside the matched binding.

### Optimizer compile microbenchmark

`BenchmarkOptimizeRecursiveOwnershipVariants`, n=10 per side, 500ms samples:

| metric | master | branch | delta |
|---|---:|---:|---:|
| time/op | 52.22 us | 59.58 us | statistically neutral (p=0.218) |
| bytes/op | 36.26 KiB | 37.69 KiB | +3.93% |
| allocs/op | 453 | 461 | +1.77% |

This quantifies the small compile-time cost of constructing useful nested variants rather than hiding it.

### End-to-end cold SQL compile

Cache-busted 10-table join `EXPLAIN COMPILE`, fresh identical schemas, two reversed-order rounds, n=100 per binary:

| metric | master | branch | delta |
|---|---:|---:|---:|
| reported compile total | 151.377 ms | 151.385 ms | +0.005% |
| request wall time | 154.588 ms | 154.140 ms | -0.29% |
| Go optimizer wall component | 0.520 ms | 0.528 ms | +1.72% / about 9 us |

The end-to-end result is neutral while the hot transferred-child operation becomes faster and materially smaller.

## Validation

- `go test ./scm -count=1`
- focused ownership/specialization tests
- Scheme startup suite: 1,270/1,270
- full repository suite intentionally left to CI, per project workflow for optimizer changes