### PR TITLE
optimizer: fuse grouped assoc reductions

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -1025,10 +1025,8 @@ plan = (tree aliases cardinality cost size atomic driver-cardinality left right 
 (define join_order_dphyp_connected (lambda (nodes aliases predicates connected required_drivers)
 	(begin
 		(define sorted_connected (join_order_sort_sets connected))
-		(define connected_by_first (reduce connected (lambda (dict subset)
-			(begin
-				(define first (car subset))
-				(set_assoc dict first (append (get_assoc dict first '()) subset)))) '()))
+		(define connected_by_first (group_assoc connected car
+			(lambda (subsets subset) (append subsets subset)) '()))
 		(join_order_dphyp_fill nodes aliases predicates connected_by_first sorted_connected '() 0 required_drivers))))
 
 (define join_order_dphyp_budgeted (lambda (nodes aliases predicates budget required_drivers)

--- a/scm/assoc_fast.go
+++ b/scm/assoc_fast.go
@@ -649,6 +649,19 @@ func (d *FastDict) Get(key Scmer) (Scmer, bool) {
 	return NewNil(), false
 }
 
+func (d *FastDict) insertHashed(key, value Scmer, h uint64) {
+	pos := len(d.Pairs)
+	d.Pairs = append(d.Pairs, key, value)
+	if _, exists := d.index[h]; exists {
+		if d.collisions == nil {
+			d.collisions = make(map[uint64][]int)
+		}
+		d.collisions[h] = append(d.collisions[h], pos)
+	} else {
+		d.index[h] = pos
+	}
+}
+
 // Set sets or merges a value for key. If merge is nil, it overwrites.
 func (d *FastDict) Set(key, value Scmer, merge func(oldV, newV Scmer) Scmer) {
 	if d.index == nil {
@@ -663,16 +676,53 @@ func (d *FastDict) Set(key, value Scmer, merge func(oldV, newV Scmer) Scmer) {
 		}
 		return
 	}
-	pos := len(d.Pairs)
-	d.Pairs = append(d.Pairs, key, value)
-	if _, exists := d.index[h]; exists {
-		if d.collisions == nil {
-			d.collisions = make(map[uint64][]int)
-		}
-		d.collisions[h] = append(d.collisions[h], pos)
-	} else {
-		d.index[h] = pos
+	d.insertHashed(key, value, h)
+}
+
+// ReduceValue updates one bucket from its current value and an input item. A
+// missing bucket starts at neutral. The reducer must treat both arguments as
+// borrowed; only its returned value becomes owned by the dictionary.
+func (d *FastDict) ReduceValue(key, item, neutral Scmer, reduce func(...Scmer) Scmer) {
+	if d.index == nil {
+		d.index = make(map[uint64]int)
 	}
+	h := HashKey(key)
+	if pos, ok := d.findPos(key, h); ok {
+		d.Pairs[pos+1] = reduce(d.Pairs[pos+1], item)
+		return
+	}
+	value := reduce(neutral, item)
+	d.insertHashed(key, value, h)
+}
+
+// AppendValue groups one value below key. The dictionary and every list stored
+// by this method are exclusively owned by the caller, so growing an existing
+// bucket in place is safe. Keeping the lookup and bucket update together avoids
+// the get-transform-set double hash used by functional Scheme reducers.
+func (d *FastDict) AppendValue(key, value Scmer) {
+	if d.index == nil {
+		d.index = make(map[uint64]int)
+	}
+	h := HashKey(key)
+	if pos, ok := d.findPos(key, h); ok {
+		bucket := asSlice(d.Pairs[pos+1], "FastDict.AppendValue")
+		d.Pairs[pos+1] = NewSlice(append(bucket, value))
+		return
+	}
+	d.insertHashed(key, NewSlice([]Scmer{value}), h)
+}
+
+// IncrementCount increments an integer histogram bucket with one hash lookup.
+func (d *FastDict) IncrementCount(key Scmer) {
+	if d.index == nil {
+		d.index = make(map[uint64]int)
+	}
+	h := HashKey(key)
+	if pos, ok := d.findPos(key, h); ok {
+		d.Pairs[pos+1] = NewInt(d.Pairs[pos+1].Int() + 1)
+		return
+	}
+	d.insertHashed(key, NewInt(1), h)
 }
 
 // Copy returns a deep copy of the FastDict (pairs and index).

--- a/scm/group_assoc_optimizer_test.go
+++ b/scm/group_assoc_optimizer_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright (C) 2026  Carl-Philip Haensch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+	"testing"
+)
+
+func requireAssocValue(t *testing.T, dict Scmer, key, want Scmer) {
+	t.Helper()
+	if !dict.IsFastDict() {
+		t.Fatalf("result is not a FastDict: %s", String(dict))
+	}
+	got, ok := dict.FastDict().Get(key)
+	if !ok || !Equal(got, want) {
+		t.Fatalf("group %s = %s, want %s", String(key), String(got), String(want))
+	}
+}
+
+func TestGroupAssocReducesEachKeyFromNeutral(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (values)
+		(group_assoc values
+			(lambda (value) (> value 2))
+			(lambda (sum value) (+ sum value))
+			0))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	got := fn(NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3), NewInt(4)}))
+	requireAssocValue(t, got, NewBool(false), NewInt(3))
+	requireAssocValue(t, got, NewBool(true), NewInt(7))
+}
+
+func TestOptimizeGroupAssocLowersAppendAndCountReducers(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "append",
+			source: `(lambda (pairs) (group_assoc pairs car
+				(lambda (values pair) (append values (cadr pair))) '()))`,
+			want: "group_assoc_append",
+		},
+		{
+			name:   "count",
+			source: `(lambda (values) (group_assoc values (lambda (value) value) (lambda (count value) (+ count 1)) 0))`,
+			want:   "group_assoc_count",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if !strings.Contains(serialized, tc.want) || strings.Contains(serialized, "(group_assoc ") {
+				t.Fatalf("group_assoc reducer was not lowered to %s: %s", tc.want, serialized)
+			}
+		})
+	}
+}
+
+func TestGroupAssocPhysicalLoweringsPreserveResults(t *testing.T) {
+	appendOptimized, appendEnv := optimizeListPipeline(t, `(lambda (pairs) (group_assoc pairs car
+		(lambda (values pair) (append values (cadr pair))) '()))`)
+	appendFn := OptimizeProcToSerialFunction(Eval(appendOptimized, appendEnv))
+	input := NewSlice([]Scmer{
+		NewSlice([]Scmer{NewString("a"), NewInt(1)}),
+		NewSlice([]Scmer{NewString("b"), NewInt(2)}),
+		NewSlice([]Scmer{NewString("a"), NewInt(3)}),
+	})
+	grouped := appendFn(input)
+	requireAssocValue(t, grouped, NewString("a"), NewSlice([]Scmer{NewInt(1), NewInt(3)}))
+	requireAssocValue(t, grouped, NewString("b"), NewSlice([]Scmer{NewInt(2)}))
+
+	countOptimized, countEnv := optimizeListPipeline(t, `(lambda (values)
+		(group_assoc values (lambda (value) value) (lambda (count value) (+ count 1)) 0))`)
+	countFn := OptimizeProcToSerialFunction(Eval(countOptimized, countEnv))
+	counted := countFn(NewSlice([]Scmer{NewString("a"), NewString("b"), NewString("a")}))
+	requireAssocValue(t, counted, NewString("a"), NewInt(2))
+	requireAssocValue(t, counted, NewString("b"), NewInt(1))
+}
+
+func TestGroupAssocBareItemCallbackKeepsNestedFrame(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (nodes aliases connected)
+		(group_assoc connected car (lambda (subsets subset) (append subsets subset)) '()))`)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	subsetA := NewSlice([]Scmer{NewString("a"), NewString("b")})
+	subsetB := NewSlice([]Scmer{NewString("a"), NewString("c")})
+	got := fn(NewNil(), NewString("outer-alias"), NewSlice([]Scmer{subsetA, subsetB}))
+	requireAssocValue(t, got, NewString("a"), NewSlice([]Scmer{subsetA, subsetB}))
+}
+
+func TestOptimizeRecognizesImperativeAssocReducers(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "append",
+			source: `(lambda (pairs) (reduce pairs (lambda (dict pair)
+				(set_assoc dict (car pair)
+					(append (get_assoc dict (car pair) '()) (cadr pair)))) '()))`,
+			want: "group_assoc_append_reduce",
+		},
+		{
+			name: "count",
+			source: `(lambda (values) (reduce values (lambda (dict value)
+				(set_assoc dict value (+ (get_assoc dict value 0) 1))) '()))`,
+			want: "group_assoc_count_reduce",
+		},
+		{
+			name: "append with stable local key",
+			source: `(lambda (pairs) (reduce pairs (lambda (dict pair)
+				(begin
+					(define key (car pair))
+					(set_assoc dict key
+						(append (get_assoc dict key '()) (cadr pair))))) '()))`,
+			want: "group_assoc_append_reduce",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, tc.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if !strings.Contains(serialized, tc.want) || strings.Contains(serialized, "(reduce ") {
+				t.Fatalf("imperative assoc reducer was not normalized to %s: %s", tc.want, serialized)
+			}
+		})
+	}
+}
+
+func TestOptimizeKeepsNonEquivalentAssocReducer(t *testing.T) {
+	optimized, env := optimizeListPipeline(t, `(lambda (pairs) (reduce pairs (lambda (dict pair)
+		(set_assoc dict (car pair)
+			(append (get_assoc dict (cadr pair) '()) pair))) '()))`)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "group_assoc_append_reduce") || !strings.Contains(serialized, "reduce") {
+		t.Fatalf("mismatched get/set keys were incorrectly normalized: %s", serialized)
+	}
+}
+
+var groupAssocBenchmarkSink Scmer
+
+func benchmarkGroupedInput(size, groups int) Scmer {
+	values := make([]Scmer, size)
+	for i := range values {
+		values[i] = NewSlice([]Scmer{NewInt(int64(i % groups)), NewInt(int64(i))})
+	}
+	return NewSlice(values)
+}
+
+func BenchmarkOptimizerGroupedAppend(b *testing.B) {
+	fn := benchmarkPlannerFusionProc(b, `(lambda (pairs) (reduce pairs (lambda (dict pair)
+		(set_assoc dict (car pair)
+			(append (get_assoc dict (car pair) '()) (cadr pair)))) '()))`)
+	input := benchmarkGroupedInput(2048, 32)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		groupAssocBenchmarkSink = fn(input)
+	}
+}
+
+func BenchmarkOptimizerGroupedCount(b *testing.B) {
+	fn := benchmarkPlannerFusionProc(b, `(lambda (pairs) (reduce pairs (lambda (dict pair)
+		(set_assoc dict (car pair) (+ (get_assoc dict (car pair) 0) 1))) '()))`)
+	input := benchmarkGroupedInput(2048, 32)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		groupAssocBenchmarkSink = fn(input)
+	}
+}

--- a/scm/group_assoc_optimizer_test.go
+++ b/scm/group_assoc_optimizer_test.go
@@ -176,6 +176,18 @@ func BenchmarkOptimizerGroupedAppend(b *testing.B) {
 	}
 }
 
+func BenchmarkOptimizerGroupedAppendPlannerScale(b *testing.B) {
+	fn := benchmarkPlannerFusionProc(b, `(lambda (pairs) (reduce pairs (lambda (dict pair)
+		(set_assoc dict (car pair)
+			(append (get_assoc dict (car pair) '()) (cadr pair)))) '()))`)
+	input := benchmarkGroupedInput(55, 10)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		groupAssocBenchmarkSink = fn(input)
+	}
+}
+
 func BenchmarkOptimizerGroupedCount(b *testing.B) {
 	fn := benchmarkPlannerFusionProc(b, `(lambda (pairs) (reduce pairs (lambda (dict pair)
 		(set_assoc dict (car pair) (+ (get_assoc dict (car pair) 0) 1))) '()))`)

--- a/scm/list.go
+++ b/scm/list.go
@@ -678,6 +678,13 @@ func optimizerZeroLiteral(expr Scmer) bool {
 	return (expr.IsInt() && expr.Int() == 0) || (expr.IsFloat() && expr.Float() == 0)
 }
 
+func optimizerOneLiteral(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	return (expr.IsInt() && expr.Int() == 1) || (expr.IsFloat() && expr.Float() == 1)
+}
+
 // optimizedUnmappedRange extracts the bound of an already optimized
 // (produceN n) call. Mapped produceN calls need a separate consumer contract
 // because their mapper must still run before the downstream callback.
@@ -708,6 +715,9 @@ func optimizeFindMapNotNull(v []Scmer, oc *OptimizerContext, useResult bool) (Sc
 func optimizePlannerReduceFold(rv []Scmer, td *TypeDescriptor) (Scmer, *TypeDescriptor, bool) {
 	if len(rv) != 4 {
 		return NewNil(), nil, false
+	}
+	if folded, foldedType, ok := optimizeAssocReducerFold(rv[1], rv[2], rv[3]); ok {
+		return folded, foldedType, true
 	}
 	params, body, ok := optimizerLambdaParts(rv[2])
 	if !ok || len(params) < 2 {
@@ -795,6 +805,211 @@ func optimizerEmptyListLiteral(expr Scmer) bool {
 	}
 	quoted, ok := scmerSlice(items[1])
 	return ok && len(quoted) == 0
+}
+
+// optimizerExpressionReferencesParam checks an already optimized expression
+// without invoking type analysis again. Nested lambdas are rejected because a
+// captured reducer parameter would need frame-aware rewriting.
+func optimizerExpressionReferencesParam(expr Scmer, params []Scmer, index int) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if optimizerLambdaParamReference(expr, params, index) {
+		return true
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 || scmerIsSymbol(items[0], "quote") {
+		return false
+	}
+	if scmerIsSymbol(items[0], "lambda") {
+		return true
+	}
+	for _, item := range items {
+		if optimizerExpressionReferencesParam(item, params, index) {
+			return true
+		}
+	}
+	return false
+}
+
+func optimizerAppendReduction(body Scmer, params []Scmer) (Scmer, bool) {
+	items, ok := scmerSlice(body)
+	if !ok || len(items) != 3 ||
+		(!scmerIsSymbol(items[0], "append") && !scmerIsSymbol(items[0], "append_mut")) ||
+		!optimizerLambdaParamReference(items[1], params, 0) ||
+		optimizerExpressionReferencesParam(items[2], params, 0) {
+		return NewNil(), false
+	}
+	return items[2], true
+}
+
+func optimizerCountReduction(body Scmer, params []Scmer) bool {
+	items, ok := scmerSlice(body)
+	if !ok || len(items) != 3 || !scmerIsSymbol(items[0], "+") {
+		return false
+	}
+	return (optimizerLambdaParamReference(items[1], params, 0) && optimizerOneLiteral(items[2])) ||
+		(optimizerLambdaParamReference(items[2], params, 0) && optimizerOneLiteral(items[1]))
+}
+
+func optimizerAssocLookup(expr Scmer, params []Scmer) (Scmer, Scmer, bool) {
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) != 4 || !scmerIsSymbol(items[0], "get_assoc") ||
+		!optimizerLambdaParamReference(items[1], params, 0) ||
+		optimizerExpressionReferencesParam(items[2], params, 0) {
+		return NewNil(), NewNil(), false
+	}
+	return items[2], items[3], true
+}
+
+func optimizerSubstituteReducerLocals(expr Scmer, locals map[int]Scmer) (Scmer, bool) {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	if expr.IsNthLocalVar() {
+		if replacement, ok := locals[int(expr.NthLocalVar())]; ok {
+			return replacement, true
+		}
+		return expr, true
+	}
+	items, ok := scmerSlice(expr)
+	if !ok || len(items) == 0 || scmerIsSymbol(items[0], "quote") || scmerIsSymbol(items[0], "outer") {
+		return expr, true
+	}
+	if scmerIsSymbol(items[0], "lambda") {
+		return NewNil(), false
+	}
+	rewritten := make([]Scmer, len(items))
+	for i, item := range items {
+		var valid bool
+		rewritten[i], valid = optimizerSubstituteReducerLocals(item, locals)
+		if !valid {
+			return NewNil(), false
+		}
+	}
+	return NewSlice(rewritten), true
+}
+
+// optimizerInlineReducerLocals removes a begin containing only stable local
+// definitions. This lets the semantic matcher see the terminal assoc update
+// without re-optimizing or re-analyzing the callback subtree.
+func optimizerInlineReducerLocals(body Scmer, params []Scmer) (Scmer, bool) {
+	items, ok := scmerSlice(body)
+	if !ok || len(items) < 2 || !scmerIsSymbol(items[0], "begin") {
+		return body, true
+	}
+	locals := make(map[int]Scmer, len(items)-2)
+	for _, prefix := range items[1 : len(items)-1] {
+		definition, ok := scmerSlice(prefix)
+		if !ok || len(definition) != 3 || !scmerIsSymbol(definition[0], "setN") ||
+			!definition[1].IsNthLocalVar() || int(definition[1].NthLocalVar()) < len(params) {
+			return NewNil(), false
+		}
+		value, valid := optimizerSubstituteReducerLocals(definition[2], locals)
+		if !valid || optimizerExpressionReferencesParam(value, params, 0) || exprMayHaveSideEffects(value) {
+			return NewNil(), false
+		}
+		locals[int(definition[1].NthLocalVar())] = value
+	}
+	return optimizerSubstituteReducerLocals(items[len(items)-1], locals)
+}
+
+// optimizeAssocReducerFold recognizes the functional meaning of the common
+// imperative get-transform-set reducer. It performs one bounded root-shape
+// walk over the already optimized callback and never invokes analysis again.
+func optimizeAssocReducerFold(input, reducer, neutral Scmer) (Scmer, *TypeDescriptor, bool) {
+	if !optimizerEmptyListLiteral(neutral) {
+		return NewNil(), nil, false
+	}
+	params, body, ok := optimizerLambdaParts(reducer)
+	if !ok || len(params) != 2 {
+		return NewNil(), nil, false
+	}
+	body, ok = optimizerInlineReducerLocals(body, params)
+	if !ok {
+		return NewNil(), nil, false
+	}
+	setCall, ok := scmerSlice(body)
+	if !ok || len(setCall) != 4 ||
+		(!scmerIsSymbol(setCall[0], "set_assoc") && !scmerIsSymbol(setCall[0], "set_assoc_mut")) ||
+		!optimizerLambdaParamReference(setCall[1], params, 0) ||
+		optimizerExpressionReferencesParam(setCall[2], params, 0) || exprMayHaveSideEffects(setCall[2]) {
+		return NewNil(), nil, false
+	}
+
+	update, ok := scmerSlice(setCall[3])
+	if !ok || len(update) != 3 {
+		return NewNil(), nil, false
+	}
+	if scmerIsSymbol(update[0], "append") || scmerIsSymbol(update[0], "append_mut") {
+		lookupKey, fallback, lookup := optimizerAssocLookup(update[1], params)
+		if !lookup || !structuralEqual(setCall[2], lookupKey) || !optimizerEmptyListLiteral(fallback) ||
+			optimizerExpressionReferencesParam(update[2], params, 0) {
+			return NewNil(), nil, false
+		}
+		keyFn, keyOK := optimizerLambdaWithBody(reducer, setCall[2])
+		valueFn, valueOK := optimizerLambdaWithBody(reducer, update[2])
+		if !keyOK || !valueOK {
+			return NewNil(), nil, false
+		}
+		return NewSlice([]Scmer{NewSymbol("group_assoc_append_reduce"), input, keyFn, valueFn}),
+			&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}}, true
+	}
+	if scmerIsSymbol(update[0], "+") {
+		var lookupExpr Scmer
+		switch {
+		case optimizerOneLiteral(update[2]):
+			lookupExpr = update[1]
+		case optimizerOneLiteral(update[1]):
+			lookupExpr = update[2]
+		default:
+			return NewNil(), nil, false
+		}
+		lookupKey, fallback, lookup := optimizerAssocLookup(lookupExpr, params)
+		if !lookup || !structuralEqual(setCall[2], lookupKey) || !optimizerZeroLiteral(fallback) {
+			return NewNil(), nil, false
+		}
+		keyFn, ok := optimizerLambdaWithBody(reducer, setCall[2])
+		if !ok {
+			return NewNil(), nil, false
+		}
+		return NewSlice([]Scmer{NewSymbol("group_assoc_count_reduce"), input, keyFn}),
+			&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}}, true
+	}
+	return NewNil(), nil, false
+}
+
+// optimizeGroupAssoc preserves group_assoc as the functional API while
+// lowering reducers with stronger semantics to single-lookup physical loops.
+// It inspects only the root of the already optimized reducer.
+func optimizeGroupAssoc(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
+	call := oc.applyDefaultOptimizationWithTypes(v, useResult, "")
+	result, td, argumentTypes := call.code, call.typeInfo, call.argumentTypes
+	if len(v) == 5 {
+		td = setOptimizedCallElement(td, callbackResultType(v[3], optimizedArgumentType(argumentTypes, 3)))
+	}
+	rv, ok := scmerSlice(result)
+	if !ok || len(rv) != 5 || !scmerIsSymbol(rv[0], "group_assoc") {
+		return result, td
+	}
+	params, body, ok := optimizerLambdaParts(rv[3])
+	if !ok || len(params) != 2 {
+		return result, td
+	}
+	if optimizerEmptyListLiteral(rv[4]) {
+		if value, appendReduction := optimizerAppendReduction(body, params); appendReduction {
+			valueFn, ok := optimizerLambdaWithBody(rv[3], value)
+			if ok {
+				return NewSlice([]Scmer{NewSymbol("group_assoc_append"), rv[1], rv[2], valueFn}),
+					&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}}
+			}
+		}
+	}
+	if optimizerZeroLiteral(rv[4]) && optimizerCountReduction(body, params) {
+		return NewSlice([]Scmer{NewSymbol("group_assoc_count"), rv[1], rv[2]}),
+			&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}}
+	}
+	return result, td
 }
 
 func optimizerIndexedAssocProjection(expr Scmer, reducerParams []Scmer, pairBody Scmer, pair []Scmer) (Scmer, [2]int, bool) {

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -16,7 +16,127 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
+func groupAssocCapacity(inputLength int) int {
+	const initialGroups = 32
+	if inputLength < initialGroups {
+		return inputLength
+	}
+	return initialGroups
+}
+
 func init_list_assoc_extra() {
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc")
+			key := OptimizeProcToSerialFunction(a[1])
+			reduce := OptimizeProcToSerialFunction(a[2])
+			result := NewFastDictValue(groupAssocCapacity(len(input)))
+			for _, item := range input {
+				result.ReduceValue(key(item), item, a[3], reduce)
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "groups list elements by key and reduces every group from a neutral value",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "reducer", Params: []*TypeDescriptor{{Kind: "any", Label: "current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "any", Label: "neutral"},
+			},
+			Return: &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength},
+			Const:  true,
+		},
+		Optimize: optimizeGroupAssoc,
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_append",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_append")
+			key := OptimizeProcToSerialFunction(a[1])
+			value := OptimizeProcToSerialFunction(a[2])
+			result := NewFastDictValue(groupAssocCapacity(len(input)))
+			for _, item := range input {
+				result.AppendValue(key(item), value(NewNil(), item))
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only append reduction into grouped lists",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "value", Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}},
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_append_reduce",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_append_reduce")
+			key := OptimizeProcToSerialFunction(a[1])
+			value := OptimizeProcToSerialFunction(a[2])
+			result := NewFastDictValue(groupAssocCapacity(len(input)))
+			for _, item := range input {
+				result.AppendValue(key(NewNil(), item), value(NewNil(), item))
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only append reduction from a normalized two-parameter reducer",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "value", Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}},
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_count",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_count")
+			key := OptimizeProcToSerialFunction(a[1])
+			result := NewFastDictValue(groupAssocCapacity(len(input)))
+			for _, item := range input {
+				result.IncrementCount(key(item))
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only integer counting reduction by key",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}},
+			Const:     true,
+			Forbidden: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_count_reduce",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_count_reduce")
+			key := OptimizeProcToSerialFunction(a[1])
+			result := NewFastDictValue(groupAssocCapacity(len(input)))
+			for _, item := range input {
+				result.IncrementCount(key(NewNil(), item))
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only counting from a normalized two-parameter reducer",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key", Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}},
+			Const:     true,
+			Forbidden: true,
+		},
+	})
 	Declare(&Globalenv, &Declaration{
 		Name: "mapkey_assoc",
 


### PR DESCRIPTION
## What

- add the functional `(group_assoc input key-fn reducer-fn neutral)` API; each key starts at `neutral` and is reduced with `(reducer current item)`
- make the result descriptor carry the reducer's inferred return type so later optimizer hooks can consume the grouped values without another analysis pass
- lower append and integer-count reducers to optimizer-only physical operators that update a `FastDict` with one hash lookup
- recognize the equivalent imperative `reduce -> get_assoc -> append/+ -> set_assoc` shape, including stable local definitions, from the already optimized callback
- reject mismatched keys, accumulator escapes, nested callbacks, effectful keys, and non-matching neutral values
- rewrite `join_order_dphyp_connected` from the imperative dictionary update to functional `group_assoc`

The public API remains general; append/count are physical specializations, not separate public APIs. The reducer matcher is attached to the existing declaration hooks and does not call Optimize or type analysis on a subtree again. A serialize of the loaded planner confirms that `join_order_dphyp_connected` contains `group_assoc_append` rather than `reduce/get_assoc/set_assoc`.

## Micro A/B against master

Ryzen 9 7900X3D, 10 x 1s, same benchmark source on merged master `1f4644218` and this branch:

    go test ./scm -run '^$' -bench 'BenchmarkOptimizerGrouped(Append|Count)$' -benchmem -count=10 -benchtime=1s

| reducer | master | candidate | delta |
|---|---:|---:|---:|
| append, 2048 items / 32 groups | 1110.8 us | 286.5 us | **-74.21%** |
| count, 2048 items / 32 groups | 296.1 us | 158.2 us | **-46.56%** |
| append bytes/op | 1911.4 KiB | 199.9 KiB | **-89.54%** |
| count bytes/op | 70.67 KiB | 67.90 KiB | **-3.92%** |
| append allocs/op | 7172 | 4356 | **-39.26%** |
| count allocs/op | 2109 | 2072 | **-1.75%** |

A planner-scale grouping (55 connected subsets / 10 first-node buckets), also 10 x 1s:

| metric | master | candidate | delta |
|---|---:|---:|---:|
| time/op | 22.52 us | 11.03 us | **-51.02%** |
| bytes/op | 14.961 KiB | 8.383 KiB | **-43.97%** |
| allocs/op | 271 | 182 | **-32.84%** |

## Cold EXPLAIN COMPILE A/B

Cache-busted 10-source chain join, server and client pinned to the same otherwise selected CPU, 5 warmups + 50 cold samples per binary. I ran three sequential pairs and reversed order between pairs to expose order/load effects.

- reorder median deltas: **-2.78%, -2.08%, +1.17%** (median pair: -2.08%)
- compile-total deltas: **-2.64%, -1.00%, +0.00%**
- wall-time deltas: **-1.63%, -1.22%, -0.36%**

The focused grouping is only about 11 us at this realistic scale inside an approximately 90 ms reorder phase, so the end-to-end result is correctly characterized as neutral/no regression rather than claiming the noisy phase deltas as a query-level win. The consistent wall medians and the focused microbenchmark rule out the regression seen in an initial unpinned sequential run; that run was discarded after a competing process was found on the selected CPU.

## Validation

- `go test ./scm -count=1`
- focused semantic, positive serialize, negative near-match, nested-frame, and runtime-result tests
- `python3 tools/lint_scm.py --check`
- loaded `lib/main.scm`: 1270/1270 Scheme unit tests
- full repository suite left to CI as agreed for optimizer changes
