### PR TITLE
optimizer: share foldable scalar expressions

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1868,6 +1868,12 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				}
 			}
 		}
+		var cseBindings int
+		v, cseBindings = optimizeBeginFoldableCSE(v, bodyStart, ome)
+		if headSym == Symbol("begin_mut") && cseBindings > 0 {
+			reserve += cseBindings
+			v[1] = NewInt(int64(reserve))
+		}
 		usedVariables := make(map[Symbol]int)
 		variableContent := make(map[Symbol]Scmer)
 		bindings := make(map[Symbol]localBindingFacts)
@@ -3360,8 +3366,58 @@ func matchTailDescriptor(td *TypeDescriptor) *TypeDescriptor {
 	return tail
 }
 
+// optimizeBooleanRegexMatch lowers the common predicate spelling
+// (match value (regex "pattern" _) true _ false) to one precompiled test.
+// With no captures, constructing a match environment and FindStringSubmatch's
+// result slice cannot contribute to the Scheme result.
+func optimizeBooleanRegexMatch(v []Scmer, value Scmer) (Scmer, TypeInfo, bool) {
+	if len(v) != 6 {
+		return NewNil(), tiZero, false
+	}
+	trueResult := v[3].WithoutSourceInfo()
+	falseResult := v[5].WithoutSourceInfo()
+	trueLiteral := (trueResult.IsBool() && trueResult.Bool()) || scmerIsSymbol(trueResult, "true")
+	falseLiteral := (falseResult.IsBool() && !falseResult.Bool()) || scmerIsSymbol(falseResult, "false")
+	if !trueLiteral || !falseLiteral ||
+		!scmerIsSymbol(v[4], "_") {
+		return NewNil(), tiZero, false
+	}
+	pattern, ok := scmerSlice(v[2])
+	if !ok || len(pattern) != 3 || !scmerIsSymbol(pattern[0], "regex") || !scmerIsSymbol(pattern[2], "_") {
+		return NewNil(), tiZero, false
+	}
+	regexValue := pattern[1].WithoutSourceInfo()
+	var compiled *regexp.Regexp
+	switch {
+	case regexValue.IsRegex():
+		compiled = regexValue.Regex()
+	case regexValue.IsString():
+		var err error
+		compiled, err = regexp.Compile(regexValue.String())
+		if err != nil {
+			return NewNil(), tiZero, false
+		}
+	default:
+		return NewNil(), tiZero, false
+	}
+	if compiled.NumSubexp() != 0 {
+		return NewNil(), tiZero, false
+	}
+	test := NewFunc(func(arguments ...Scmer) Scmer {
+		text, ok := scmerAsString(arguments[0])
+		if !ok {
+			panic("regex expects string")
+		}
+		return NewBool(compiled.MatchString(text))
+	})
+	return NewSlice([]Scmer{test, value}), TypeInfo{kind: KindBool, flags: FlagTransfer, length: UnknownLength}, true
+}
+
 func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {
 	value, valueType := OptimizeEx(v[1], env, ome, true)
+	if result, resultType, optimized := optimizeBooleanRegexMatch(v, value); optimized {
+		return result, resultType
+	}
 	transferOwnership := valueType.Transfer()
 	var valueDescriptor *TypeDescriptor
 	if td := valueType.ToTypeDescriptor(); td != nil && (len(td.Keys) > 0 || td.Element != nil) {

--- a/scm/optimizer_cse.go
+++ b/scm/optimizer_cse.go
@@ -1,0 +1,236 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strconv"
+)
+
+type foldableCSEInfo struct {
+	hash   uint64
+	stable bool
+}
+
+type foldableCSECandidate struct {
+	expression Scmer
+	first      *Scmer
+	firstTop   int
+	symbol     Symbol
+	shared     bool
+}
+
+type foldableCSEScanner struct {
+	byHash      map[uint64][]*foldableCSECandidate
+	candidates  []*foldableCSECandidate
+	generations map[Symbol]uint64
+	shadowed    map[Symbol]bool
+	nextSymbol  uint64
+}
+
+func foldableCSETypeIsImmutable(td *TypeDescriptor) bool {
+	if td == nil {
+		return false
+	}
+	switch td.Kind {
+	case "string", "number", "int", "bool", "nil", "symbol":
+		return true
+	default:
+		return false
+	}
+}
+
+func (scanner *foldableCSEScanner) scalarInfo(value Scmer) foldableCSEInfo {
+	hash := combineStructuralHash(0x510e527fade682d1, uint64(value.GetTag()))
+	hash = combineStructuralHash(hash, HashKey(value))
+	if symbol, ok := scmerSymbol(value); ok {
+		hash = combineStructuralHash(hash, scanner.generations[symbol])
+	}
+	return foldableCSEInfo{hash: hash, stable: true}
+}
+
+func (scanner *foldableCSEScanner) replacementSymbol() Symbol {
+	scanner.nextSymbol++
+	// NUL cannot occur in a parsed Scheme identifier. It keeps the temporary
+	// unobservable even before the normal numbered-local lowering runs.
+	return Symbol("\x00foldable_cse_" + strconv.FormatUint(scanner.nextSymbol, 10))
+}
+
+func (scanner *foldableCSEScanner) share(location *Scmer, expression Scmer, hash uint64, top int, guaranteed bool) {
+	for _, candidate := range scanner.byHash[hash] {
+		if !astStructuralEqual(candidate.expression, expression) {
+			continue
+		}
+		if !candidate.shared {
+			candidate.symbol = scanner.replacementSymbol()
+			*candidate.first = NewSymbol(string(candidate.symbol))
+			candidate.shared = true
+		}
+		*location = NewSymbol(string(candidate.symbol))
+		return
+	}
+	if !guaranteed {
+		return
+	}
+	candidate := &foldableCSECandidate{
+		expression: expression,
+		first:      location,
+		firstTop:   top,
+	}
+	scanner.byHash[hash] = append(scanner.byHash[hash], candidate)
+	scanner.candidates = append(scanner.candidates, candidate)
+}
+
+func (scanner *foldableCSEScanner) walk(location *Scmer, top int, guaranteed bool) foldableCSEInfo {
+	value := *location
+	if value.IsSourceInfo() {
+		return scanner.walk(&value.SourceInfo().value, top, guaranteed)
+	}
+	if !value.IsSlice() {
+		switch value.GetTag() {
+		case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagSymbol, tagNthLocalVar, tagCString, tagBString:
+			return scanner.scalarInfo(value)
+		default:
+			return foldableCSEInfo{}
+		}
+	}
+
+	items := value.Slice()
+	if len(items) == 0 {
+		return foldableCSEInfo{hash: combineStructuralHash(0x1f83d9abfb41bd6b, 0), stable: true}
+	}
+	head, headOK := scmerSymbol(items[0])
+	if headOK {
+		switch head {
+		case "quote":
+			return foldableCSEInfo{hash: hashASTReadonly(value), stable: true}
+		case "lambda", "eval", "parser", "outer", "begin", "begin_mut", "!begin":
+			return foldableCSEInfo{}
+		case "define", "set", "setN":
+			if len(items) >= 3 {
+				scanner.walk(&items[2], top, guaranteed)
+			}
+			return foldableCSEInfo{}
+		case "match", "match_mut":
+			if len(items) >= 2 {
+				scanner.walk(&items[1], top, guaranteed)
+			}
+			for i := 3; i < len(items); i += 2 {
+				scanner.walk(&items[i], top, false)
+			}
+			if len(items)%2 == 1 {
+				scanner.walk(&items[len(items)-1], top, false)
+			}
+			return foldableCSEInfo{}
+		case "if", "and", "or", "coalesce", "coalesceNil":
+			if len(items) >= 2 {
+				scanner.walk(&items[1], top, guaranteed)
+			}
+			for i := 2; i < len(items); i++ {
+				scanner.walk(&items[i], top, false)
+			}
+			return foldableCSEInfo{}
+		}
+	}
+
+	declaration := DeclarationForValue(items[0])
+	if headOK && (scanner.shadowed[head] || scanner.generations[head] > 0) {
+		declaration = nil
+	}
+	if declaration == nil || declaration.IsSpecialForm {
+		return foldableCSEInfo{}
+	}
+	hash := combineStructuralHash(0x5be0cd19137e2179, uint64(len(items)))
+	headInfo := scanner.scalarInfo(items[0])
+	hash = combineStructuralHash(hash, headInfo.hash)
+	stable := declaration.IsFoldable() && !declaration.Type.HasSideEffects
+	for i := 1; i < len(items); i++ {
+		// A nested candidate in a later argument cannot be lifted in front of
+		// arguments that Scheme evaluates before it. The complete outer call may
+		// still become a candidate at its own location below.
+		info := scanner.walk(&items[i], top, guaranteed && i == 1)
+		hash = combineStructuralHash(hash, info.hash)
+		parameterIndex := i - 1
+		if parameterIndex >= len(declaration.Type.Params) {
+			parameterIndex = len(declaration.Type.Params) - 1
+		}
+		var parameter *TypeDescriptor
+		if parameterIndex >= 0 {
+			parameter = declaration.Type.Params[parameterIndex]
+		}
+		stable = stable && info.stable && foldableCSETypeIsImmutable(parameter)
+	}
+	if stable && foldableCSETypeIsImmutable(declaration.Type.Return) {
+		scanner.share(location, value, hash, top, guaranteed)
+		return foldableCSEInfo{hash: hash, stable: true}
+	}
+	return foldableCSEInfo{}
+}
+
+// optimizeBeginFoldableCSE shares deterministic immutable calls within one
+// lexical begin. Discovery, dependency hashing and rewriting happen in the
+// same tree walk; structural comparisons are limited to equal hash buckets.
+func optimizeBeginFoldableCSE(body []Scmer, bodyStart int, ome *optimizerMetainfo) ([]Scmer, int) {
+	scanner := foldableCSEScanner{
+		byHash:      make(map[uint64][]*foldableCSECandidate),
+		generations: make(map[Symbol]uint64),
+		shadowed:    make(map[Symbol]bool),
+	}
+	for symbol := range ome.variableReplacement {
+		scanner.shadowed[symbol] = true
+	}
+	for symbol := range ome.variableTypes {
+		scanner.shadowed[symbol] = true
+	}
+	for top := bodyStart; top < len(body); top++ {
+		scanner.walk(&body[top], top, true)
+		expression := body[top]
+		if stripped, ok := scmerStripSourceInfo(expression); ok {
+			expression = stripped
+		}
+		if items, ok := scmerSlice(expression); ok && len(items) >= 3 &&
+			(scmerIsSymbol(items[0], "define") || scmerIsSymbol(items[0], "set")) {
+			if symbol, ok := scmerSymbol(items[1]); ok {
+				scanner.generations[symbol]++
+			}
+		}
+	}
+
+	insertions := make(map[int][]Scmer)
+	count := 0
+	for _, candidate := range scanner.candidates {
+		if !candidate.shared {
+			continue
+		}
+		definition := NewSlice([]Scmer{
+			NewSymbol("define"),
+			NewSymbol(string(candidate.symbol)),
+			candidate.expression,
+		})
+		insertions[candidate.firstTop] = append(insertions[candidate.firstTop], definition)
+		count++
+	}
+	if count == 0 {
+		return body, 0
+	}
+	rewritten := make([]Scmer, 0, len(body)+count)
+	rewritten = append(rewritten, body[:bodyStart]...)
+	for top := bodyStart; top < len(body); top++ {
+		rewritten = append(rewritten, insertions[top]...)
+		rewritten = append(rewritten, body[top])
+	}
+	return rewritten, count
+}

--- a/scm/optimizer_cse_test.go
+++ b/scm/optimizer_cse_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "testing"
+
+func countOptimizerCalls(expression Scmer, name string) int {
+	if stripped, ok := scmerStripSourceInfo(expression); ok {
+		expression = stripped
+	}
+	items, ok := scmerSlice(expression)
+	if !ok || len(items) == 0 {
+		return 0
+	}
+	count := 0
+	if declaration := DeclarationForValue(items[0]); declaration != nil && declaration.Name == name {
+		count++
+	}
+	if scmerIsSymbol(items[0], "quote") {
+		return count
+	}
+	for _, item := range items {
+		count += countOptimizerCalls(item, name)
+	}
+	return count
+}
+
+func optimizeCSETestProc(t *testing.T, source string) Scmer {
+	t.Helper()
+	environment := newOptimizerTestEnv()
+	return Eval(Optimize(Read(t.Name(), source), environment, nil), environment)
+}
+
+func TestOptimizeSharesFoldableCallAcrossBeginExpressions(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value enabled)
+		(begin
+			(define direct (equal? (toUpper value) "SELECT"))
+			(define conditional (and enabled (equal? (toUpper value) "SELECT")))
+			(define diagnostic (equal? (toUpper value) "EXPLAIN COMPILE"))
+			(list direct conditional diagnostic)))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "toUpper"); calls != 1 {
+		t.Fatalf("optimized body contains %d toUpper calls, want 1: %s", calls, SerializeToString(proc.Proc().Body, nil))
+	}
+	fn := OptimizeProcToSerialFunction(proc)
+	got := fn(NewString("select"), NewBool(true))
+	want := NewSlice([]Scmer{NewBool(true), NewBool(true), NewBool(false)})
+	if !Equal(got, want) {
+		t.Fatalf("shared foldable result = %s, want %s; body: %s", String(got), String(want), SerializeToString(proc.Proc().Body, nil))
+	}
+}
+
+func TestOptimizeDoesNotHoistFoldableCallFromLazyPath(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value enabled)
+		(begin
+			(define conditional (and enabled (equal? (toUpper value) "SELECT")))
+			(define direct (equal? (toUpper value) "SELECT"))
+			(list conditional direct)))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "toUpper"); calls != 2 {
+		t.Fatalf("optimized body contains %d toUpper calls, want 2: %s", calls, SerializeToString(proc.Proc().Body, nil))
+	}
+	fn := OptimizeProcToSerialFunction(proc)
+	got := fn(NewString("select"), NewBool(false))
+	want := NewSlice([]Scmer{NewBool(false), NewBool(true)})
+	if !Equal(got, want) {
+		t.Fatalf("lazy foldable result = %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeDoesNotHoistFoldableCallAcrossEarlierArgument(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (prefix value)
+		(begin
+			(define combined (concat prefix (toUpper value)))
+			(define direct (toUpper value))
+			(list combined direct)))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "toUpper"); calls != 2 {
+		t.Fatalf("optimized body contains %d toUpper calls, want 2: %s", calls, SerializeToString(proc.Proc().Body, nil))
+	}
+}
+
+func TestOptimizeDoesNotTreatShadowedCallableAsDeclaredFoldable(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (toUpper value)
+		(begin
+			(define first (toUpper value))
+			(define second (toUpper value))
+			(list first second)))`)
+	fn := OptimizeProcToSerialFunction(proc)
+	calls := 0
+	callable := NewFunc(func(arguments ...Scmer) Scmer {
+		calls++
+		return arguments[0]
+	})
+	fn(callable, NewString("value"))
+	if calls != 2 {
+		t.Fatalf("shadowed callable ran %d times, want 2", calls)
+	}
+}
+
+func TestOptimizeDoesNotShareFreshFoldableResult(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value)
+		(begin
+			(define first (split value ","))
+			(define second (split value ","))
+			(list first second)))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "split"); calls != 2 {
+		t.Fatalf("optimized body contains %d split calls, want 2: %s", calls, SerializeToString(proc.Proc().Body, nil))
+	}
+}
+
+func TestOptimizeLowersBooleanRegexMatch(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value)
+		(match value (regex "^\\s*SELECT\\b" _) true _ false))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "match"); calls != 0 {
+		t.Fatalf("optimized body retains match: %s", SerializeToString(proc.Proc().Body, nil))
+	}
+}
+
+func TestOptimizeKeepsCapturingRegexMatch(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value)
+		(match value (regex "^(.*)$" _ captured) captured _ false))`)
+	if calls := countOptimizerCalls(proc.Proc().Body, "match"); calls != 1 {
+		t.Fatalf("capturing regex match was lowered: %s", SerializeToString(proc.Proc().Body, nil))
+	}
+}
+
+func TestOptimizeBooleanRegexMatchPreservesTypeFailure(t *testing.T) {
+	proc := optimizeCSETestProc(t, `(lambda (value)
+		(match value (regex "^SELECT" _) true _ false))`)
+	fn := OptimizeProcToSerialFunction(proc)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("lowered regex match accepted a non-string value")
+		}
+	}()
+	fn(NewNil())
+}
+
+func BenchmarkFoldableCSEUpperClassifiers(b *testing.B) {
+	environment := newOptimizerTestEnv()
+	proc := Eval(Optimize(Read(b.Name(), `(lambda (value enabled)
+		(begin
+			(define direct (equal? (toUpper value) "SELECT * FROM ITEMS"))
+			(define guarded (and enabled (equal? (toUpper value) "SELECT * FROM ITEMS")))
+			(define diagnostic (equal? (toUpper value) "EXPLAIN COMPILE SELECT * FROM ITEMS"))
+			(list direct guarded diagnostic)))`), environment, nil), environment)
+	fn := OptimizeProcToSerialFunction(proc)
+	value := NewString("select * from items")
+	enabled := NewBool(true)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fn(value, enabled)
+	}
+}
+
+func BenchmarkOptimizedBooleanRegexMatch(b *testing.B) {
+	environment := newOptimizerTestEnv()
+	proc := Eval(Optimize(Read(b.Name(), `(lambda (value)
+		(match value (regex "^\\s*SELECT\\b" _) true _ false))`), environment, nil), environment)
+	fn := OptimizeProcToSerialFunction(proc)
+	value := NewString("SELECT * FROM items WHERE id = 42")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fn(value)
+	}
+}


### PR DESCRIPTION
## What

- add begin-local common-subexpression elimination for calls whose declaration is `Foldable`
- restrict sharing to immutable scalar parameter/return types, stable bindings, guaranteed execution paths, and non-shadowed declarations
- discover/hash/rewrite in one tree walk; only hash collisions/duplicates receive a structural equality check
- lower the common boolean regex form
  `(match value (regex "pattern" _) true _ false)`
  to a precompiled `MatchString` predicate without a match environment or capture slice

For `cached_parse`, the optimized body now computes `(toUpper parse_query)` once and feeds all three SQL classifiers from that local value. Its three capture-free boolean regex matches lower to precompiled predicates.

Fresh list/assoc results are deliberately not shared: their ownership identity remains observable by mutating consumers. Lazy branches are never selected as the first evaluation site, and calls are not lifted across an earlier argument.

## A/B measurements against `fe6127baa` (master)

Ryzen 9 7900X3D, Linux, `count=10`; same benchmark source on both revisions:

| benchmark | master | PR | delta |
|---|---:|---:|---:|
| repeated uppercase classifiers | 1,097 ns/op, 552 B/op, 11 allocs | 808.5 ns/op, 376 B/op, 7 allocs | **-26.3% time, -31.9% bytes, -36.4% allocs** |
| boolean regex match | 243.6 ns/op, 81 B/op, 3 allocs | 175.0 ns/op, 81 B/op, 2 allocs | **-28.2% time, -33.3% allocs** |

`benchstat` reports `p=0.000`, `n=10` for both time improvements.

Warm SQL cache path, 12 alternating samples of 100,000 calls to the real `cached_parse` with `SELECT 1`:

- master median: **13.44 us/call**
- PR median: **12.29 us/call**
- delta: **-8.5%**

End-to-end HTTP `SELECT 1` remains neutral within frontend/socket noise (CPU-pinned sequential runs: about 151-152 us median/request). Cold `EXPLAIN COMPILE` is likewise neutral (4.174 ms vs 4.168 ms median); parsing/planning dominates that case, as expected.

## Producer-lambda experiment

This PR does not claim a producer-lambda win. Moving a lambda binding closer to an ordinary call does not delay construction because Scheme evaluates call arguments eagerly. Safely sinking captured work through a callback additionally needs parameter metadata distinguishing at-most-once callbacks from repeated callbacks (`map`/`filter`/`reduce`). Adding an unused flag would not improve this path, so callback cardinality plus actual lazy materialization is left as a separate measured follow-up.

## Validation

- `go test ./scm -count=1`
- 1,270/1,270 Scheme startup tests in both A/B binaries
- focused correctness tests for lazy paths, argument order, shadowed callables, ownership-bearing results, regex captures, and regex type errors

The repository-wide SQL full test is left to CI as agreed for optimizer work.
