### PR TITLE
perf: specialize and sink closures by callable type

### DIFF
--- a/scm/declare.go
+++ b/scm/declare.go
@@ -73,6 +73,7 @@ type TypeDescriptor struct {
 	Kind           string                     // "any"|"string"|"number"|"int"|"bool"|"nil"|"symbol"|"func"|"list"|"assoc"
 	NoEscape       bool                       // true = value will NOT outlive its scope (safe for stack alloc); default false = may escape (conservative)
 	Transfer       bool                       // callee receives ownership, can mutate
+	CallsOnce      bool                       // for func params: callback is invoked at most once per call; default false = unknown or repeated
 	Const          bool                       // value is a compile-time constant; for func: safe to constant-fold
 	Length         int                        // exact positive list/assoc length; -1 = unknown
 	Optional       bool                       // for func params: parameter is optional
@@ -215,7 +216,7 @@ func TypeInfoFromTD(td *TypeDescriptor) TypeInfo {
 	if td.Length > 0 {
 		ti.length = td.Length
 	}
-	if td.Length > 0 || len(td.Params) > 0 || td.Return != nil || len(td.Keys) > 0 || td.Element != nil {
+	if td.Length > 0 || td.CallsOnce || len(td.Params) > 0 || td.Return != nil || len(td.Keys) > 0 || td.Element != nil {
 		ti.Extra = td
 	}
 	return ti

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -133,17 +133,19 @@ const (
 
 // Flag bits for TypeInfo
 const (
-	FlagTransfer uint8 = 1 << iota // callee receives ownership
-	FlagConst                      // compile-time constant
-	FlagEscape                     // value may outlive scope
+	FlagTransfer  uint8 = 1 << iota // callee receives ownership
+	FlagConst                       // compile-time constant
+	FlagEscape                      // value may outlive scope
+	FlagCallsOnce                   // function value is invoked at most once per callee call
 )
 
 const UnknownLength = -1
 
-func (ti TypeInfo) Transfer() bool { return ti.flags&FlagTransfer != 0 }
-func (ti TypeInfo) Const() bool    { return ti.flags&FlagConst != 0 }
-func (ti TypeInfo) Escape() bool   { return ti.flags&FlagEscape != 0 }
-func (ti TypeInfo) Kind() uint8    { return ti.kind }
+func (ti TypeInfo) Transfer() bool  { return ti.flags&FlagTransfer != 0 }
+func (ti TypeInfo) Const() bool     { return ti.flags&FlagConst != 0 }
+func (ti TypeInfo) Escape() bool    { return ti.flags&FlagEscape != 0 }
+func (ti TypeInfo) CallsOnce() bool { return ti.flags&FlagCallsOnce != 0 }
+func (ti TypeInfo) Kind() uint8     { return ti.kind }
 func (ti TypeInfo) Length() int {
 	if ti.length <= 0 {
 		return UnknownLength
@@ -193,6 +195,9 @@ func TypeInfoFromTD(td *TypeDescriptor) TypeInfo {
 	if td.Const {
 		ti.flags |= FlagConst
 	}
+	if td.CallsOnce {
+		ti.flags |= FlagCallsOnce
+	}
 	switch td.Kind {
 	case "string":
 		ti.kind = KindString
@@ -227,12 +232,13 @@ func (ti TypeInfo) ToTypeDescriptor() *TypeDescriptor {
 	if ti.kind == KindAny && ti.flags == 0 && ti.Extra == nil && ti.Length() == UnknownLength {
 		return nil
 	}
-	td := &TypeDescriptor{Transfer: ti.Transfer(), Const: ti.Const(), NoEscape: !ti.Escape(), Length: ti.Length()}
+	td := &TypeDescriptor{Transfer: ti.Transfer(), Const: ti.Const(), NoEscape: !ti.Escape(), CallsOnce: ti.CallsOnce(), Length: ti.Length()}
 	if ti.Extra != nil {
 		*td = *ti.Extra
 		td.Transfer = ti.Transfer()
 		td.Const = ti.Const()
 		td.NoEscape = !ti.Escape()
+		td.CallsOnce = ti.CallsOnce()
 		td.Length = ti.Length()
 	}
 	if td.Kind == "" {

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -764,7 +764,7 @@ func (ome *optimizerMetainfo) applyPendingCallbackParams(params Scmer, child *op
 			td = callbackParameterType(ome.pendingCallbackParams[i])
 		}
 		if td == nil {
-			continue
+			td = unknownOptimizerParameterType
 		}
 		child.variableTypes[sym] = td
 		if replacement, ok := child.variableReplacement[sym]; ok && replacement.IsNthLocalVar() {
@@ -1245,7 +1245,7 @@ func specializationHashText(seed uint64, value string) uint64 {
 	return result
 }
 
-func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
+func specializationShapeHash(td *TypeDescriptor) (uint64, uint64) {
 	if td == nil {
 		return 0x243f6a8885a308d3, 0x13198a2e03707344
 	}
@@ -1255,9 +1255,29 @@ func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
 		lo = combineStructuralHash(lo, 1)
 		hi = combineStructuralHash(hi, 0x9e3779b97f4a7c15)
 	}
+	if td.CallsOnce {
+		lo = combineStructuralHash(lo, 2)
+		hi = combineStructuralHash(hi, 0xbf58476d1ce4e5b9)
+	}
+	if td.NoEscape {
+		lo = combineStructuralHash(lo, 3)
+		hi = combineStructuralHash(hi, 0x94d049bb133111eb)
+	}
+	if td.Const {
+		lo = combineStructuralHash(lo, 4)
+		hi = combineStructuralHash(hi, 0xd6e8feb86659fd93)
+	}
 	lo = combineStructuralHash(lo, uint64(td.Length))
 	hi = combineStructuralHash(hi, uint64(td.Length)^0xa4093822299f31d0)
-	elementLo, elementHi := specializationOwnershipHash(td.Element)
+	for i, param := range td.Params {
+		paramLo, paramHi := specializationShapeHash(param)
+		lo = combineStructuralHash(lo, combineStructuralHash(uint64(i), paramLo))
+		hi = combineStructuralHash(hi, combineStructuralHash(uint64(i), paramHi))
+	}
+	returnLo, returnHi := specializationShapeHash(td.Return)
+	lo = combineStructuralHash(lo, returnLo)
+	hi = combineStructuralHash(hi, returnHi)
+	elementLo, elementHi := specializationShapeHash(td.Element)
 	lo = combineStructuralHash(lo, elementLo)
 	hi = combineStructuralHash(hi, elementHi)
 	// TypeDescriptor.Keys is a map. Fold separately hashed entries using two
@@ -1265,7 +1285,7 @@ func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
 	// without sorting or allocating a temporary key slice.
 	var keysXor, keysSum, keysXorHi, keysSumHi uint64
 	for key, child := range td.Keys {
-		childLo, childHi := specializationOwnershipHash(child)
+		childLo, childHi := specializationShapeHash(child)
 		keyLo := combineStructuralHash(specializationHashText(1469598103934665603, key), childLo)
 		keyHi := combineStructuralHash(specializationHashText(1099511628211, key), childHi)
 		keysXor ^= keyLo
@@ -1279,17 +1299,17 @@ func specializationOwnershipHash(td *TypeDescriptor) (uint64, uint64) {
 }
 
 func procSpecializationKeyFromParams(mask uint64, paramTypes []*TypeDescriptor) procSpecializationKey {
-	ownershipLo := uint64(0x6a09e667f3bcc909)
-	ownershipHi := uint64(0xbb67ae8584caa73b)
+	shapeLo := uint64(0x6a09e667f3bcc909)
+	shapeHi := uint64(0xbb67ae8584caa73b)
 	for i, paramType := range paramTypes {
 		if mask&(1<<uint(i)) == 0 {
 			continue
 		}
-		paramLo, paramHi := specializationOwnershipHash(paramType)
-		ownershipLo = combineStructuralHash(ownershipLo, combineStructuralHash(uint64(i), paramLo))
-		ownershipHi = combineStructuralHash(ownershipHi, combineStructuralHash(uint64(i), paramHi))
+		paramLo, paramHi := specializationShapeHash(paramType)
+		shapeLo = combineStructuralHash(shapeLo, combineStructuralHash(uint64(i), paramLo))
+		shapeHi = combineStructuralHash(shapeHi, combineStructuralHash(uint64(i), paramHi))
 	}
-	return procSpecializationKey{paramMask: mask, ownershipLo: ownershipLo, ownershipHi: ownershipHi}
+	return procSpecializationKey{paramMask: mask, shapeLo: shapeLo, shapeHi: shapeHi}
 }
 
 func procSpecializationHasNestedOwnership(paramTypes []*TypeDescriptor) bool {
@@ -1301,18 +1321,22 @@ func procSpecializationHasNestedOwnership(paramTypes []*TypeDescriptor) bool {
 	return false
 }
 
-func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecializationKey, []*TypeDescriptor, bool) {
+func procSpecializationKeyForArguments(proc *Proc, argTypes []TypeInfo) (procSpecializationKey, []*TypeDescriptor, bool) {
 	params, ok := scmerSlice(proc.Params)
 	if !ok || len(params) == 0 || len(params) > 64 || proc.NumVars < len(params) {
 		return procSpecializationKey{}, nil, false
 	}
-	var candidates uint64
+	var ownershipCandidates uint64
+	var callableCandidates uint64
 	for i := range params {
 		argIndex := i + 1
 		if argIndex >= len(argTypes) {
 			continue
 		}
 		argType := argTypes[argIndex]
+		if argType.Kind() == KindFunc && argType.Extra != nil {
+			callableCandidates |= 1 << uint(i)
+		}
 		// Transfer on scalar values only describes a fresh result; there is no
 		// mutable ownership for the callee to consume. Specializing those values
 		// would turn transient scalar type facts into an invalid calling contract.
@@ -1320,21 +1344,23 @@ func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecia
 		if !mutableKind || !argType.Transfer() || argType.Const() {
 			continue
 		}
-		candidates |= 1 << uint(i)
+		ownershipCandidates |= 1 << uint(i)
 	}
-	if candidates == 0 {
+	if ownershipCandidates|callableCandidates == 0 {
 		return procSpecializationKey{}, nil, false
 	}
-	uses, captured, consumed := procParameterOwnershipUses(proc.Body, len(params))
-	var mask uint64
-	for i := range params {
-		if candidates&(1<<uint(i)) == 0 {
-			continue
-		}
-		// Transfer is linear. A specialized body may consume a parameter only
-		// when that Proc frame has exactly one non-captured use of the value.
-		if uses[i] == 1 && !captured[i] && consumed[i] {
-			mask |= 1 << uint(i)
+	mask := callableCandidates
+	if ownershipCandidates != 0 {
+		uses, captured, consumed := procParameterOwnershipUses(proc.Body, len(params))
+		for i := range params {
+			if ownershipCandidates&(1<<uint(i)) == 0 {
+				continue
+			}
+			// Transfer is linear. A specialized body may consume a parameter only
+			// when that Proc frame has exactly one non-captured use of the value.
+			if uses[i] == 1 && !captured[i] && consumed[i] {
+				mask |= 1 << uint(i)
+			}
 		}
 	}
 	if mask == 0 {
@@ -1346,12 +1372,19 @@ func procOwnershipSpecializationKey(proc *Proc, argTypes []TypeInfo) (procSpecia
 		if mask&(1<<uint(i)) == 0 {
 			continue
 		}
-		paramTypes[i] = specializationOwnershipDescriptor(argTypes[i+1].ToTypeDescriptor())
+		if callableCandidates&(1<<uint(i)) != 0 {
+			paramTypes[i] = cloneTypeDescriptor(argTypes[i+1].ToTypeDescriptor(), make(map[*TypeDescriptor]*TypeDescriptor))
+			paramTypes[i].Transfer = false
+			paramTypes[i].Const = false
+			paramTypes[i].NoEscape = false
+		} else {
+			paramTypes[i] = specializationOwnershipDescriptor(argTypes[i+1].ToTypeDescriptor())
+		}
 	}
 	return procSpecializationKeyFromParams(mask, paramTypes), paramTypes, true
 }
 
-func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, stack map[procSpecializationStackKey]bool) (Scmer, bool, bool) {
+func buildProcSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, stack map[procSpecializationStackKey]bool) (Scmer, bool, bool) {
 	paramsValue := proc.Params
 	if stripped, ok := scmerStripSourceInfo(paramsValue); ok {
 		paramsValue = stripped
@@ -1363,7 +1396,7 @@ func buildProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, par
 	lambda := []Scmer{
 		NewSymbol("lambda"),
 		CloneOptimizerExpression(proc.Params),
-		DeoptimizeExpr(CloneOptimizerExpression(proc.Body)),
+		deoptimizeProcSpecializationExpr(CloneOptimizerExpression(proc.Body), len(params)),
 	}
 	if proc.NumVars > 0 {
 		lambda = append(lambda, NewInt(int64(proc.NumVars)))
@@ -1416,15 +1449,15 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 	if len(v) < 2 {
 		return NewNil(), false
 	}
-	hasTransferCandidate := false
+	hasTypeCandidate := false
 	for _, argType := range argTypes[1:] {
 		mutableKind := argType.Kind() == KindList || argType.Kind() == KindAssoc
-		if mutableKind && argType.Transfer() && !argType.Const() {
-			hasTransferCandidate = true
+		if (mutableKind && argType.Transfer() && !argType.Const()) || (argType.Kind() == KindFunc && argType.Extra != nil) {
+			hasTypeCandidate = true
 			break
 		}
 	}
-	if !hasTransferCandidate {
+	if !hasTypeCandidate {
 		return NewNil(), false
 	}
 	callee, ok := scmerSymbol(v[0])
@@ -1443,14 +1476,14 @@ func trySpecializeProcCall(v []Scmer, argTypes []TypeInfo, env *Env, ome *optimi
 	if proc == nil || proc.En == nil || proc.OptimizerMeta == nil {
 		return NewNil(), false
 	}
-	key, paramTypes, ok := procOwnershipSpecializationKey(proc, argTypes)
+	key, paramTypes, ok := procSpecializationKeyForArguments(proc, argTypes)
 	if !ok {
 		return NewNil(), false
 	}
-	return getProcOwnershipSpecialization(proc, key, paramTypes, ome)
+	return getProcSpecialization(proc, key, paramTypes, ome)
 }
 
-func getProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, ome *optimizerMetainfo) (Scmer, bool) {
+func getProcSpecialization(proc *Proc, key procSpecializationKey, paramTypes []*TypeDescriptor, ome *optimizerMetainfo) (Scmer, bool) {
 	stackKey := procSpecializationStackKey{meta: proc.OptimizerMeta, key: key}
 	if ome.specializationStack != nil && ome.specializationStack[stackKey] {
 		return NewNil(), false
@@ -1479,7 +1512,7 @@ func getProcOwnershipSpecialization(proc *Proc, key procSpecializationKey, param
 		proc.OptimizerMeta.finishSpecialization(key, variant)
 	}()
 	var nestedUsed, rootMutationUsed bool
-	variant, nestedUsed, rootMutationUsed = buildProcOwnershipSpecialization(proc, key, paramTypes, ome.specializationStack)
+	variant, nestedUsed, rootMutationUsed = buildProcSpecialization(proc, key, paramTypes, ome.specializationStack)
 	if procSpecializationHasNestedOwnership(paramTypes) && !nestedUsed && !rootMutationUsed {
 		variant = NewNil()
 	}
@@ -1645,6 +1678,11 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 		return val, TypeInfo{kind: KindString, flags: FlagTransfer | FlagConst, length: UnknownLength}
 	case tagBSON:
 		return val, TypeInfo{kind: KindAny, flags: FlagTransfer | FlagConst, length: UnknownLength}
+	case tagFunc:
+		if td := val.CallableType(); td != nil {
+			return val, TypeInfoFromTD(td)
+		}
+		return val, tiZero
 	case tagSymbol:
 		sym := mustSymbol(val)
 		varType := ome.variableTypes[sym]
@@ -1671,6 +1709,13 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 		}
 		if varType != nil {
 			return val, TypeInfoFromTD(varType)
+		}
+		if binding := env.FindRead(sym); binding != nil {
+			if bound, exists := binding.Vars[sym]; exists {
+				if td := bound.CallableType(); td != nil {
+					return val, TypeInfoFromTD(td)
+				}
+			}
 		}
 		return val, tiZero
 	case tagSlice:
@@ -1726,9 +1771,10 @@ func OptimizeEx(val Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (Sc
 
 // Common TypeInfo values (stack-allocated, no heap)
 var (
-	tiConstTransfer = TypeInfo{flags: FlagTransfer | FlagConst, length: UnknownLength}
-	tiTransfer      = TypeInfo{flags: FlagTransfer, length: UnknownLength}
-	tiZero          = TypeInfo{length: UnknownLength}
+	tiConstTransfer               = TypeInfo{flags: FlagTransfer | FlagConst, length: UnknownLength}
+	tiTransfer                    = TypeInfo{flags: FlagTransfer, length: UnknownLength}
+	tiZero                        = TypeInfo{length: UnknownLength}
+	unknownOptimizerParameterType = &TypeDescriptor{Kind: "any", Length: UnknownLength}
 )
 
 // optimizeExCompat is a temporary bridge: calls OptimizeEx and unpacks TypeInfo
@@ -1775,6 +1821,17 @@ type localBindingFacts struct {
 	captured        bool
 	repeatedCapture bool
 	leafLambda      bool
+	sinkRegion      *conditionalSinkRegion
+	sinkRegionSeen  bool
+	sinkConflict    bool
+}
+
+// conditionalSinkRegion represents the first exclusive branch below a begin
+// body. Nested conditionals retain the same region, keeping common-region
+// tracking O(1) per use instead of repeatedly comparing ancestor paths.
+type conditionalSinkRegion struct {
+	target     *Scmer
+	hasBinding bool
 }
 
 func optimizerCallType(call []Scmer, env *Env, ome *optimizerMetainfo) *TypeDescriptor {
@@ -1975,8 +2032,8 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		var leafScan *bool
 		var leafScanRoot bool
-		var visitNode func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, blacklist []Symbol)
-		visitNode = func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, blacklist []Symbol) {
+		var visitNode func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, region *conditionalSinkRegion, blacklist []Symbol)
+		visitNode = func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, region *conditionalSinkRegion, blacklist []Symbol) {
 			if stripped, ok := scmerStripSourceInfo(x); ok {
 				x = stripped
 			}
@@ -1991,12 +2048,18 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						leafScanRoot = false
 					} else if subHeadOk {
 						switch subHead {
-						case Symbol("begin"), Symbol("begin_mut"), Symbol("!begin"), Symbol("define"), Symbol("set"), Symbol("lambda"), Symbol("eval"), Symbol("import"):
+						case Symbol("begin"), Symbol("begin_mut"), Symbol("!begin"), Symbol("define"), Symbol("set"), Symbol("setN"), Symbol("lambda"), Symbol("eval"), Symbol("import"):
 							*leafScan = false
 						}
 					}
 				}
+				if region != nil && subHeadOk && subHead == Symbol("setN") {
+					region.hasBinding = true
+				}
 				if subHeadOk && (subHead == Symbol("define") || subHead == Symbol("set")) {
+					if region != nil {
+						region.hasBinding = true
+					}
 					var definedSym Symbol
 					var scansDefinition bool
 					if depth == 0 {
@@ -2007,7 +2070,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 					if scansDefinition {
 						leafScan, leafScanRoot = &leaf, true
 					}
-					visitNode(sub[2], depth, captured, captureOnce, false, blacklist)
+					visitNode(sub[2], depth, captured, captureOnce, false, region, blacklist)
 					if scansDefinition {
 						facts := bindings[definedSym]
 						facts.leafLambda = leaf
@@ -2026,7 +2089,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						params = stripped
 					}
 					if sym, ok := scmerSymbol(params); ok {
-						visitNode(sub[2], depth+1, true, captureOnce, false, append(append([]Symbol{}, blacklist...), sym))
+						visitNode(sub[2], depth+1, true, captureOnce, false, region, append(append([]Symbol{}, blacklist...), sym))
 					} else if list, ok := scmerSlice(params); ok {
 						blacklist2 := append([]Symbol{}, blacklist...)
 						for _, entry := range list {
@@ -2034,7 +2097,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 								blacklist2 = append(blacklist2, s)
 							}
 						}
-						visitNode(sub[2], depth+1, true, captureOnce, false, blacklist2)
+						visitNode(sub[2], depth+1, true, captureOnce, false, region, blacklist2)
 					}
 				} else if subHeadOk && (subHead == Symbol("begin") || subHead == Symbol("begin_mut")) {
 					start := 1
@@ -2042,25 +2105,46 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						start = 2
 					}
 					for i := start; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, captured, captureOnce, false, blacklist)
+						visitNode(sub[i], depth+1, captured, captureOnce, false, region, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("!begin") {
 					for i := 1; i < len(sub); i++ {
-						visitNode(sub[i], depth, captured, captureOnce, false, blacklist)
+						visitNode(sub[i], depth, captured, captureOnce, false, region, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("eval") {
+					if region != nil {
+						region.hasBinding = true
+					}
 					usedVariables[Symbol("eval")] = 1
 					for i := 2; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, captured, captureOnce, false, blacklist)
+						visitNode(sub[i], depth+1, captured, captureOnce, false, region, blacklist)
+					}
+				} else if subHeadOk && subHead == Symbol("if") {
+					i := 1
+					for i+1 < len(sub) {
+						visitNode(sub[i], depth+1, captured, captureOnce, false, region, blacklist)
+						branchRegion := region
+						if branchRegion == nil {
+							branchRegion = &conditionalSinkRegion{target: &sub[i+1]}
+						}
+						visitNode(sub[i+1], depth+1, captured, captureOnce, false, branchRegion, blacklist)
+						i += 2
+					}
+					if i < len(sub) {
+						branchRegion := region
+						if branchRegion == nil {
+							branchRegion = &conditionalSinkRegion{target: &sub[i]}
+						}
+						visitNode(sub[i], depth+1, captured, captureOnce, false, branchRegion, blacklist)
 					}
 				} else {
 					// Also visit the head — it may be a variable used in call position (e.g., (accsess "key"))
-					visitNode(sub[0], depth+1, captured, captureOnce, false, blacklist)
+					visitNode(sub[0], depth+1, captured, captureOnce, false, region, blacklist)
 					callType := optimizerCallType(sub, env, ome)
 					for i := 1; i < len(sub); i++ {
 						param := optimizerCallParam(callType, i-1)
 						argLambdaOnce := optimizerIsLambda(sub[i]) && param != nil && param.Kind == "func" && param.CallsOnce
-						visitNode(sub[i], depth+1, captured, captureOnce, argLambdaOnce, blacklist)
+						visitNode(sub[i], depth+1, captured, captureOnce, argLambdaOnce, region, blacklist)
 					}
 				}
 				return
@@ -2076,6 +2160,13 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				if !isBlacklisted {
 					if facts, tracked := bindings[sym]; tracked {
 						facts.useCount++
+						if !facts.sinkRegionSeen {
+							facts.sinkRegion = region
+							facts.sinkRegionSeen = true
+						} else if facts.sinkRegion != region {
+							facts.sinkConflict = true
+							facts.sinkRegion = nil
+						}
 						if captured {
 							facts.captured = true
 							if !captureOnce {
@@ -2098,7 +2189,35 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		for i := bodyStart; i < len(v); i++ {
 			currentTopIdx = i
-			visitNode(v[i], 0, false, true, false, nil)
+			visitNode(v[i], 0, false, true, false, nil, nil)
+		}
+		// A multi-use closure may still have one exclusive execution region: for
+		// example, both uses can live in the same arm of an outer if. Move its
+		// binding to that arm before normal begin optimization. Reverse definition
+		// order preserves the original ordering when several bindings share a target.
+		if earliestDynamicSyntax < 0 {
+			for i := len(bindingOrder) - 1; i >= 0; i-- {
+				sym := bindingOrder[i]
+				facts := bindings[sym]
+				content, exists := variableContent[sym]
+				if !exists || facts.count != 1 || facts.useCount < 2 || !facts.used ||
+					facts.firstUse <= facts.defineIdx || facts.sinkConflict || facts.sinkRegion == nil ||
+					facts.sinkRegion.target == nil || facts.sinkRegion.hasBinding || facts.repeatedCapture ||
+					!optimizerIsLambda(content) {
+					continue
+				}
+				target := facts.sinkRegion.target
+				original := *target
+				*target = NewSlice([]Scmer{
+					NewSymbol("begin"),
+					NewSlice([]Scmer{NewSymbol("define"), NewSymbol(string(sym)), content}),
+					original,
+				})
+				v[facts.defineIdx] = NewNil()
+				delete(variableContent, sym)
+				delete(bindings, sym)
+				delete(usedVariables, sym)
+			}
 		}
 		ome2 := ome.CopySharedScope()
 		ome2.beginDepth++
@@ -2135,6 +2254,9 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			if facts, tracked := bindings[sym]; tracked && facts.count == 1 && facts.useCount == 1 &&
 				facts.captured && !facts.repeatedCapture && facts.leafLambda {
 				shouldReplace = true
+				if ome.specializationUsed != nil {
+					*ome.specializationUsed = true
+				}
 			}
 			// Convention: symbols starting with "tbl:" are pre-resolved table
 			// pointers that must not be inlined back into inner loops.
@@ -3670,6 +3792,55 @@ func DeoptimizeExpr(expr Scmer) Scmer {
 	}
 	if !changed {
 		return expr
+	}
+	return NewSlice(newItems)
+}
+
+func specializationSlotSymbol(slot NthLocalVar) Scmer {
+	return NewSymbol("__optimizer_slot_" + strconv.Itoa(int(slot)))
+}
+
+// deoptimizeProcSpecializationExpr restores optimizer-created local slots to
+// stable internal names while rebuilding a Proc specialization. Parameters
+// retain their numbered representation; begin-local setN bindings must become
+// visible to the existing usage walk so type-driven rewrites can fire again.
+// This replaces the ordinary DeoptimizeExpr traversal rather than adding a
+// second analysis pass over the body.
+func deoptimizeProcSpecializationExpr(expr Scmer, paramCount int) Scmer {
+	if expr.IsNthLocalVar() {
+		slot := expr.NthLocalVar()
+		if int(slot) >= paramCount {
+			return specializationSlotSymbol(slot)
+		}
+		return expr
+	}
+	if expr.GetTag() == tagSpecialForm {
+		return NewSymbol(expr.SpecialFormName())
+	}
+	if !expr.IsSlice() {
+		return expr
+	}
+	items := expr.Slice()
+	if len(items) >= 3 && scmerIsSymbol(items[0], "!list") {
+		count := int(ToInt(items[2]))
+		if count == len(items)-3 {
+			newItems := make([]Scmer, 1+count)
+			newItems[0] = NewSymbol("list")
+			for i := 0; i < count; i++ {
+				newItems[1+i] = deoptimizeProcSpecializationExpr(items[3+i], paramCount)
+			}
+			return NewSlice(newItems)
+		}
+	}
+	if len(items) == 3 && scmerIsSymbol(items[0], "!!list") && items[1].IsNthLocalVar() {
+		return NewSlice([]Scmer{NewSymbol("list")})
+	}
+	newItems := make([]Scmer, len(items))
+	for i, item := range items {
+		newItems[i] = deoptimizeProcSpecializationExpr(item, paramCount)
+	}
+	if len(newItems) == 3 && scmerIsSymbol(newItems[0], "setN") && items[1].IsNthLocalVar() && int(items[1].NthLocalVar()) >= paramCount {
+		newItems[0] = NewSymbol("define")
 	}
 	return NewSlice(newItems)
 }

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1767,12 +1767,70 @@ func canEliminateFromBegin(val Scmer) bool {
 }
 
 type localBindingFacts struct {
-	defineIdx int
-	firstUse  int
-	count     int
-	useCount  int
-	used      bool
-	captured  bool
+	defineIdx       int
+	firstUse        int
+	count           int
+	useCount        int
+	used            bool
+	captured        bool
+	repeatedCapture bool
+	leafLambda      bool
+}
+
+func optimizerCallType(call []Scmer, env *Env, ome *optimizerMetainfo) *TypeDescriptor {
+	if len(call) == 0 {
+		return nil
+	}
+	if decl := DeclarationForValue(call[0]); decl != nil {
+		return decl.Type
+	}
+	if sym, ok := scmerSymbol(call[0]); ok {
+		if td := ome.variableTypes[sym]; td != nil {
+			return td
+		}
+		if binding := env.FindRead(sym); binding != nil {
+			if value, exists := binding.Vars[sym]; exists {
+				if td := value.CallableType(); td != nil {
+					return td
+				}
+			}
+		}
+		return nil
+	}
+	if call[0].IsNthLocalVar() {
+		return ome.numberedTypes[call[0].NthLocalVar()]
+	}
+	// Resolve an immediately-created native operator from its declared return
+	// type without recursively analysing the call-head subtree. The begin usage
+	// walk must remain linear even for deeply nested generated expressions.
+	callHead := call[0]
+	if stripped, ok := scmerStripSourceInfo(callHead); ok {
+		callHead = stripped
+	}
+	if constructor, ok := scmerSlice(callHead); ok && len(constructor) > 0 {
+		if decl := DeclarationForValue(constructor[0]); decl != nil && decl.Type != nil && decl.Type.Return != nil && decl.Type.Return.Kind == "func" {
+			return decl.Type.Return
+		}
+	}
+	return nil
+}
+
+func optimizerCallParam(callType *TypeDescriptor, argIndex int) *TypeDescriptor {
+	if callType == nil || len(callType.Params) == 0 || argIndex < 0 {
+		return nil
+	}
+	if argIndex >= len(callType.Params) {
+		argIndex = len(callType.Params) - 1
+	}
+	return callType.Params[argIndex]
+}
+
+func optimizerIsLambda(expr Scmer) bool {
+	if stripped, ok := scmerStripSourceInfo(expr); ok {
+		expr = stripped
+	}
+	items, ok := scmerSlice(expr)
+	return ok && len(items) >= 3 && scmerIsSymbol(items[0], "lambda")
 }
 
 func optimizerProcSequenceForDefinition(name Symbol, expression Scmer) procSequenceKind {
@@ -1915,8 +1973,10 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 				}
 			}
 		}
-		var visitNode func(x Scmer, depth int, captured bool, blacklist []Symbol)
-		visitNode = func(x Scmer, depth int, captured bool, blacklist []Symbol) {
+		var leafScan *bool
+		var leafScanRoot bool
+		var visitNode func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, blacklist []Symbol)
+		visitNode = func(x Scmer, depth int, captured bool, captureOnce bool, lambdaOnce bool, blacklist []Symbol) {
 			if stripped, ok := scmerStripSourceInfo(x); ok {
 				x = stripped
 			}
@@ -1926,20 +1986,47 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 					subHeadExpr = stripped
 				}
 				subHead, subHeadOk := scmerSymbol(subHeadExpr)
+				if leafScan != nil {
+					if leafScanRoot {
+						leafScanRoot = false
+					} else if subHeadOk {
+						switch subHead {
+						case Symbol("begin"), Symbol("begin_mut"), Symbol("!begin"), Symbol("define"), Symbol("set"), Symbol("lambda"), Symbol("eval"), Symbol("import"):
+							*leafScan = false
+						}
+					}
+				}
 				if subHeadOk && (subHead == Symbol("define") || subHead == Symbol("set")) {
-					visitNode(sub[2], depth, captured, blacklist)
+					var definedSym Symbol
+					var scansDefinition bool
+					if depth == 0 {
+						definedSym, scansDefinition = scmerSymbol(sub[1])
+					}
+					previousLeafScan, previousLeafRoot := leafScan, leafScanRoot
+					leaf := optimizerIsLambda(sub[2])
+					if scansDefinition {
+						leafScan, leafScanRoot = &leaf, true
+					}
+					visitNode(sub[2], depth, captured, captureOnce, false, blacklist)
+					if scansDefinition {
+						facts := bindings[definedSym]
+						facts.leafLambda = leaf
+						bindings[definedSym] = facts
+						leafScan, leafScanRoot = previousLeafScan, previousLeafRoot
+					}
 					if depth == 0 {
 						if sym, ok := scmerSymbol(sub[1]); ok {
 							variableContent[sym] = sub[2]
 						}
 					}
 				} else if subHeadOk && subHead == Symbol("lambda") {
+					captureOnce = captureOnce && lambdaOnce
 					params := sub[1]
 					if stripped, ok := scmerStripSourceInfo(params); ok {
 						params = stripped
 					}
 					if sym, ok := scmerSymbol(params); ok {
-						visitNode(sub[2], depth+1, true, append(append([]Symbol{}, blacklist...), sym))
+						visitNode(sub[2], depth+1, true, captureOnce, false, append(append([]Symbol{}, blacklist...), sym))
 					} else if list, ok := scmerSlice(params); ok {
 						blacklist2 := append([]Symbol{}, blacklist...)
 						for _, entry := range list {
@@ -1947,7 +2034,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 								blacklist2 = append(blacklist2, s)
 							}
 						}
-						visitNode(sub[2], depth+1, true, blacklist2)
+						visitNode(sub[2], depth+1, true, captureOnce, false, blacklist2)
 					}
 				} else if subHeadOk && (subHead == Symbol("begin") || subHead == Symbol("begin_mut")) {
 					start := 1
@@ -1955,22 +2042,25 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						start = 2
 					}
 					for i := start; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, captured, blacklist)
+						visitNode(sub[i], depth+1, captured, captureOnce, false, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("!begin") {
 					for i := 1; i < len(sub); i++ {
-						visitNode(sub[i], depth, captured, blacklist)
+						visitNode(sub[i], depth, captured, captureOnce, false, blacklist)
 					}
 				} else if subHeadOk && subHead == Symbol("eval") {
 					usedVariables[Symbol("eval")] = 1
 					for i := 2; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, captured, blacklist)
+						visitNode(sub[i], depth+1, captured, captureOnce, false, blacklist)
 					}
 				} else {
 					// Also visit the head — it may be a variable used in call position (e.g., (accsess "key"))
-					visitNode(sub[0], depth+1, captured, blacklist)
+					visitNode(sub[0], depth+1, captured, captureOnce, false, blacklist)
+					callType := optimizerCallType(sub, env, ome)
 					for i := 1; i < len(sub); i++ {
-						visitNode(sub[i], depth+1, captured, blacklist)
+						param := optimizerCallParam(callType, i-1)
+						argLambdaOnce := optimizerIsLambda(sub[i]) && param != nil && param.Kind == "func" && param.CallsOnce
+						visitNode(sub[i], depth+1, captured, captureOnce, argLambdaOnce, blacklist)
 					}
 				}
 				return
@@ -1988,6 +2078,9 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 						facts.useCount++
 						if captured {
 							facts.captured = true
+							if !captureOnce {
+								facts.repeatedCapture = true
+							}
 						}
 						if !facts.used {
 							facts.firstUse = currentTopIdx
@@ -2005,7 +2098,7 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 		}
 		for i := bodyStart; i < len(v); i++ {
 			currentTopIdx = i
-			visitNode(v[i], 0, false, nil)
+			visitNode(v[i], 0, false, true, false, nil)
 		}
 		ome2 := ome.CopySharedScope()
 		ome2.beginDepth++
@@ -2039,6 +2132,10 @@ func optimizeList(v []Scmer, env *Env, ome *optimizerMetainfo, useResult bool) (
 			}
 			// Bring back old criterion: inline if used < 2 OR RHS is not a list
 			shouldReplace := usedVariables[sym] < 2 || !normalized.IsSlice()
+			if facts, tracked := bindings[sym]; tracked && facts.count == 1 && facts.useCount == 1 &&
+				facts.captured && !facts.repeatedCapture && facts.leafLambda {
+				shouldReplace = true
+			}
 			// Convention: symbols starting with "tbl:" are pre-resolved table
 			// pointers that must not be inlined back into inner loops.
 			if strings.HasPrefix(string(sym), "tbl:") {
@@ -2606,6 +2703,12 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 	// Resolve native and symbolic call heads through the same declaration. Code
 	// generated by Scheme commonly contains either representation.
 	callDecl := DeclarationForValue(v[0])
+	var callType *TypeDescriptor
+	if callDecl != nil {
+		callType = callDecl.Type
+	} else {
+		callType = optimizerCallType(v, env, ome)
+	}
 	callName := string(head)
 	if callDecl != nil {
 		callName = callDecl.Name
@@ -2619,15 +2722,15 @@ func (oc *OptimizerContext) applyDefaultOptimization(v []Scmer, useResult bool, 
 			ome.pendingCallbackParams = nil
 		}
 		ome.pendingCallbackReturn = nil
-		if i > 0 && callDecl != nil {
+		if i > 0 && callType != nil {
 			paramIdx := i - 1
-			if callDecl.Type == nil || len(callDecl.Type.Params) == 0 {
+			if len(callType.Params) == 0 {
 				// no type info
-			} else if paramIdx >= len(callDecl.Type.Params) {
-				paramIdx = len(callDecl.Type.Params) - 1
+			} else if paramIdx >= len(callType.Params) {
+				paramIdx = len(callType.Params) - 1
 			}
-			if paramIdx >= 0 && callDecl.Type != nil && paramIdx < len(callDecl.Type.Params) {
-				if ti := callDecl.Type.Params[paramIdx]; ti != nil && ti.Kind == "func" && len(ti.Params) > 0 {
+			if paramIdx >= 0 && paramIdx < len(callType.Params) {
+				if ti := callType.Params[paramIdx]; ti != nil && ti.Kind == "func" {
 					ome.pendingCallbackParams = ti.Params
 					ome.pendingCallbackReturn = ti.Return
 				}

--- a/scm/optimizer_sinking_test.go
+++ b/scm/optimizer_sinking_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOptimizeSinksSingleUseClosureIntoOnceCallback(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (session captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(with_session session (lambda () (helper)))))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "setN") || strings.Contains(serialized, "define helper") {
+		t.Fatalf("single-use closure stayed outside once callback: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	session := Eval(Read(t.Name(), `(newsession)`), env)
+	if got := fn(session, NewInt(8)); !Equal(got, NewInt(9)) {
+		t.Fatalf("sunk closure returned %s, want 9", String(got))
+	}
+}
+
+func TestOptimizeKeepsClosureOutsideRepeatedCallback(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (session values captured)
+		(begin
+			(define helper (lambda (value) (+ captured value)))
+			(map values (lambda (value)
+				(with_session session (lambda () (helper value)))))))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "setN") {
+		t.Fatalf("inner once callback hid its repeated parent: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	session := Eval(Read(t.Name(), `(newsession)`), env)
+	got := fn(session, NewSlice([]Scmer{NewInt(1), NewInt(2)}), NewInt(8))
+	want := NewSlice([]Scmer{NewInt(9), NewInt(10)})
+	if !Equal(got, want) {
+		t.Fatalf("retained closure returned %s, want %s", String(got), String(want))
+	}
+}
+
+func TestOptimizeKeepsBindingClosureAheadOfOnceCallback(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (session captured)
+		(begin
+			(define helper (lambda () (begin
+				(define incremented (+ captured 1))
+				incremented)))
+			(with_session session (lambda () (helper)))))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if helperAt, operatorAt := strings.Index(serialized, "setN"), strings.Index(serialized, "with_session"); helperAt < 0 || operatorAt < 0 || helperAt > operatorAt {
+		t.Fatalf("binding closure crossed callback scope: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	session := Eval(Read(t.Name(), `(newsession)`), env)
+	if got := fn(session, NewInt(8)); !Equal(got, NewInt(9)) {
+		t.Fatalf("retained binding closure returned %s, want 9", String(got))
+	}
+}
+
+func TestOptimizeSinksThroughTypedNativeCallable(t *testing.T) {
+	env := newOptimizerTestEnv()
+	cacheType := &TypeDescriptor{Kind: "func", Params: []*TypeDescriptor{
+		{Kind: "any"},
+		{Kind: "func", CallsOnce: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+	}, Return: &TypeDescriptor{Kind: "any"}}
+	env.Vars[Symbol("typed_cache")] = NewTypedFunc(func(...Scmer) Scmer {
+		return NewInt(11)
+	}, RegisterCallableType(cacheType))
+	optimized := Optimize(Read(t.Name(), `(lambda (captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(typed_cache "key" (lambda () (helper)))))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if strings.Contains(serialized, "setN") || strings.Contains(serialized, "define helper") {
+		t.Fatalf("typed dynamic callable did not expose once callback: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if got := fn(NewInt(8)); !Equal(got, NewInt(11)) {
+		t.Fatalf("typed callable returned %s, want 11", String(got))
+	}
+}
+
+func TestOptimizeKeepsClosureAheadOfTwoExecutedUses(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(list (helper) (helper))))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if !strings.Contains(serialized, "setN") {
+		t.Fatalf("closure used twice on one path was duplicated: %s", serialized)
+	}
+}
+
+func BenchmarkOptimizedOnceCallbackClosureSinking(b *testing.B) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(b.Name(), `(lambda (session captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(with_session session (lambda () (helper)))))`), env, nil)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	session := Eval(Read(b.Name(), `(newsession)`), env)
+	args := []Scmer{session, NewInt(8)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := fn(args...); !Equal(got, NewInt(9)) {
+			b.Fatal(got)
+		}
+	}
+}

--- a/scm/optimizer_sinking_test.go
+++ b/scm/optimizer_sinking_test.go
@@ -104,6 +104,44 @@ func TestOptimizeSinksThroughTypedNativeCallable(t *testing.T) {
 	}
 }
 
+func TestOptimizeSpecializesProcForTypedCallableParameter(t *testing.T) {
+	env := newOptimizerTestEnv()
+	cacheType := &TypeDescriptor{Kind: "func", Params: []*TypeDescriptor{
+		{Kind: "any"},
+		{Kind: "func", CallsOnce: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+	}, Return: &TypeDescriptor{Kind: "any"}}
+	env.Vars[Symbol("typed_cache")] = NewTypedFunc(func(args ...Scmer) Scmer {
+		return Apply(args[1])
+	}, RegisterCallableType(cacheType))
+
+	definition := Optimize(Read(t.Name(), `(define typed_cache_consumer (lambda (cache captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(cache "key" (lambda () (helper))))))`), env, nil)
+	Eval(definition, env)
+	consumer := env.Vars[Symbol("typed_cache_consumer")]
+	if !consumer.IsProc() || consumer.Proc().OptimizerMeta == nil {
+		t.Fatalf("test consumer has no optimizer metadata: %s", serializedTestExpr(t, env, consumer))
+	}
+	meta := newOptimizerMetainfo()
+	_, callableInfo := OptimizeEx(NewSymbol("typed_cache"), env, &meta, true)
+	if callableInfo.Kind() != KindFunc || callableInfo.Extra == nil || callableInfo.Extra.Params[1] == nil || !callableInfo.Extra.Params[1].CallsOnce {
+		t.Fatalf("OptimizeEx lost typed callable metadata: %#v", callableInfo)
+	}
+	optimized := Optimize(Read(t.Name(), `(typed_cache_consumer typed_cache 8)`), env, nil)
+	call, ok := scmerSlice(optimized)
+	if !ok || len(call) == 0 || !call[0].IsProc() {
+		t.Fatalf("typed callable did not create a Proc specialization: %s", serializedTestExpr(t, env, optimized))
+	}
+	serialized := serializedTestExpr(t, env, call[0])
+	if strings.Contains(serialized, "setN") || strings.Contains(serialized, "define helper") {
+		t.Fatalf("callable parameter lost CallsOnce in Proc specialization: %s", serialized)
+	}
+	if got := Eval(optimized, env); !Equal(got, NewInt(9)) {
+		t.Fatalf("specialized callable parameter returned %s, want 9", String(got))
+	}
+}
+
 func TestOptimizeKeepsClosureAheadOfTwoExecutedUses(t *testing.T) {
 	env := newOptimizerTestEnv()
 	optimized := Optimize(Read(t.Name(), `(lambda (captured)
@@ -113,6 +151,46 @@ func TestOptimizeKeepsClosureAheadOfTwoExecutedUses(t *testing.T) {
 	serialized := serializedTestExpr(t, env, optimized)
 	if !strings.Contains(serialized, "setN") {
 		t.Fatalf("closure used twice on one path was duplicated: %s", serialized)
+	}
+}
+
+func TestOptimizeSinksMultiUseClosureIntoExclusiveBranch(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (enabled positive captured)
+		(begin
+			(define helper (lambda () (begin
+				(define result (+ captured 1))
+				result)))
+			(if enabled
+				(if positive (helper) (helper))
+				0)))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if ifAt, helperAt := strings.Index(serialized, "(if "), strings.Index(serialized, "setN"); ifAt < 0 || helperAt < 0 || helperAt < ifAt {
+		t.Fatalf("multi-use closure stayed ahead of its exclusive branch: %s", serialized)
+	}
+
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	if got := fn(NewBool(false), NewBool(true), NewInt(8)); !Equal(got, NewInt(0)) {
+		t.Fatalf("cold branch returned %s, want 0", String(got))
+	}
+	if got := fn(NewBool(true), NewBool(false), NewInt(8)); !Equal(got, NewInt(9)) {
+		t.Fatalf("sunk branch returned %s, want 9", String(got))
+	}
+}
+
+func TestOptimizeKeepsMultiUseClosureAheadOfBindingBranch(t *testing.T) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(t.Name(), `(lambda (enabled positive captured)
+		(begin
+			(define helper (lambda () (+ captured 1)))
+			(if enabled
+				(begin
+					(define branch_value captured)
+					(if positive (helper) (helper)))
+				0)))`), env, nil)
+	serialized := serializedTestExpr(t, env, optimized)
+	if ifAt, helperAt := strings.Index(serialized, "(if "), strings.Index(serialized, "setN"); helperAt < 0 || ifAt < 0 || helperAt > ifAt {
+		t.Fatalf("closure crossed a binding branch: %s", serialized)
 	}
 }
 
@@ -129,6 +207,25 @@ func BenchmarkOptimizedOnceCallbackClosureSinking(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if got := fn(args...); !Equal(got, NewInt(9)) {
+			b.Fatal(got)
+		}
+	}
+}
+
+func BenchmarkOptimizedExclusiveBranchClosureSinking(b *testing.B) {
+	env := newOptimizerTestEnv()
+	optimized := Optimize(Read(b.Name(), `(lambda (captured guarded direct)
+		(begin
+			(define helper (lambda () (begin
+				(define incremented (+ captured 1))
+				incremented)))
+			(if guarded 7 (if direct (helper) (helper)))))`), env, nil)
+	fn := OptimizeProcToSerialFunction(Eval(optimized, env))
+	args := []Scmer{NewInt(8), NewBool(true), NewBool(false)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := fn(args...); !Equal(got, NewInt(7)) {
 			b.Fatal(got)
 		}
 	}

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -650,14 +650,13 @@ const (
 	procSequenceAndTerms
 )
 
-// procSpecializationKey distinguishes both the transferred parameters and the
-// ownership shape below them. A Proc can therefore retain independent full
-// variants for e.g. a fresh list with borrowed elements and a fresh list whose
-// elements are transferable as well.
+// procSpecializationKey distinguishes specialized parameters and the optimizer
+// shape below them. A Proc can therefore retain independent full variants for
+// ownership trees as well as higher-order callable contracts.
 type procSpecializationKey struct {
-	paramMask   uint64
-	ownershipLo uint64
-	ownershipHi uint64
+	paramMask uint64
+	shapeLo   uint64
+	shapeHi   uint64
 }
 
 type procSpecializationSnapshot struct {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1293,8 +1293,8 @@ func init() {
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "tries to execute a function and returns its result. In case of a failure, the error is fed to the second function and its result value will be used",
 			Params: []*TypeDescriptor{
-				{Kind: "func", Label: "func", Description: "function with no parameters that will be called", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Label: "errorhandler", Description: "function that takes the error as parameter", Params: []*TypeDescriptor{{Kind: "any", Label: "error"}}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", CallsOnce: true, Label: "func", Description: "function with no parameters that will be called", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", CallsOnce: true, Label: "errorhandler", Description: "function that takes the error as parameter", Params: []*TypeDescriptor{{Kind: "any", Label: "error"}}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 			Const:  true,

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf8"
 	"unsafe"
 )
@@ -288,6 +289,54 @@ func NewFunc(fn func(...Scmer) Scmer) Scmer {
 	ptr := new(func(...Scmer) Scmer)
 	*ptr = fn
 	return Scmer{(*byte)(unsafe.Pointer(ptr)), makeAux(tagFunc, 0)}
+}
+
+type CallableTypeID uint64
+
+var callableTypeMu sync.RWMutex
+var callableTypes []*TypeDescriptor
+
+// RegisterCallableType creates a compact handle for a shared callable type.
+// Constructors should register once and reuse the returned handle.
+func RegisterCallableType(td *TypeDescriptor) CallableTypeID {
+	if td == nil {
+		return 0
+	}
+	callableTypeMu.Lock()
+	callableTypes = append(callableTypes, td)
+	id := CallableTypeID(len(callableTypes))
+	callableTypeMu.Unlock()
+	return id
+}
+
+// NewTypedFunc attaches the callable's full type to a native closure value.
+// The compact Scmer stores only a small registry id; descriptors are shared by
+// all instances returned from the same constructor.
+func NewTypedFunc(fn func(...Scmer) Scmer, id CallableTypeID) Scmer {
+	result := NewFunc(fn)
+	if id != 0 {
+		result.aux = makeAux(tagFunc, uint64(id))
+	}
+	return result
+}
+
+// CallableType returns type metadata attached to a native closure value.
+func (s Scmer) CallableType() *TypeDescriptor {
+	if s.GetTag() != tagFunc {
+		return nil
+	}
+	id := auxVal(s.aux)
+	if id == 0 {
+		return nil
+	}
+	callableTypeMu.RLock()
+	if id > uint64(len(callableTypes)) {
+		callableTypeMu.RUnlock()
+		return nil
+	}
+	td := callableTypes[id-1]
+	callableTypeMu.RUnlock()
+	return td
 }
 
 // NewClosure creates a zero-allocation-per-row closure Scmer.

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -351,6 +351,16 @@ func NewSession(a ...Scmer) Scmer {
 	})
 }
 
+var sessionCallableType = &TypeDescriptor{Kind: "func", Label: "session", Description: "session accessor accepting exactly zero, one, two, or four arguments", HasSideEffects: true,
+	Params: []*TypeDescriptor{
+		{Kind: "any", Label: "key_or_operation", Description: "key, or get_or_compute_scoped", Optional: true},
+		{Kind: "any", Label: "value_or_scope", Description: "value to store, or scope for get_or_compute_scoped", Optional: true},
+		{Kind: "any", Label: "scoped_key", Description: "cache key used by get_or_compute_scoped", Optional: true},
+		{Kind: "func", CallsOnce: true, Label: "scoped_producer", Description: "producer used only by the four-argument get_or_compute_scoped form", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
+	},
+	Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value list, stored value, retrieved value, or shared computed value"},
+}
+
 var mgr *gls.ContextManager
 
 func Context(a ...Scmer) (result Scmer) {
@@ -517,15 +527,7 @@ func init_sync() {
 
 		Fn: NewSession,
 		Type: &TypeDescriptor{Kind: "func", Description: "Creates a thread-safe key-value session. Call it without arguments to list values, with a key to read, with a key and value to store, or with get_or_compute_scoped, a scope, a key, and a producer to share one concurrent computation.",
-			Return: &TypeDescriptor{Kind: "func", Label: "session", Description: "session accessor accepting exactly zero, one, two, or four arguments", HasSideEffects: true,
-				Params: []*TypeDescriptor{
-					{Kind: "any", Label: "key_or_operation", Description: "key, or get_or_compute_scoped", Optional: true},
-					{Kind: "any", Label: "value_or_scope", Description: "value to store, or scope for get_or_compute_scoped", Optional: true},
-					{Kind: "any", Label: "scoped_key", Description: "cache key used by get_or_compute_scoped", Optional: true},
-					{Kind: "func", Label: "scoped_producer", Description: "producer used only by the four-argument get_or_compute_scoped form", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
-				},
-				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value list, stored value, retrieved value, or shared computed value"},
-			},
+			Return: sessionCallableType,
 			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["newsession"].Fn, args, result)
 			},
@@ -541,7 +543,7 @@ func init_sync() {
 		Type: &TypeDescriptor{Kind: "func", Description: "Executes a function with the given session installed in the execution context, so storage operations can access the session's transaction state.",
 			Params: []*TypeDescriptor{
 				{Kind: "func", Label: "session", Description: "the session to install", Params: []*TypeDescriptor{{Kind: "any", Label: "key", Optional: true}, {Kind: "any", Label: "value", Optional: true}}, Return: &TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Label: "fn", Description: "the function to execute", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
+				{Kind: "func", CallsOnce: true, Label: "fn", Description: "the function to execute", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any"}},
 			},
 			Return: &TypeDescriptor{Kind: "any"},
 
@@ -744,7 +746,7 @@ func init_sync() {
 		},
 		Type: &TypeDescriptor{Kind: "func", Description: "Creates a function wrapper that you can call multiple times but only gets executed once. The result value is cached and returned on a second call. You can add parameters to that resulting function that will be passed to the first run of the wrapped function.",
 			Params: []*TypeDescriptor{
-				{Kind: "func", Label: "f", Description: "function that produces the result value", Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
+				{Kind: "func", CallsOnce: true, Label: "f", Description: "function that produces the result value", Params: []*TypeDescriptor{{Kind: "any", Label: "argument", Variadic: true}}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 			},
 			Return: &TypeDescriptor{Kind: "func", Label: "once_wrapper", Description: "calls the wrapped function once and returns its cached result thereafter",
 				Params: []*TypeDescriptor{
@@ -798,7 +800,7 @@ func init_sync() {
 			Params: []*TypeDescriptor{},
 			Return: &TypeDescriptor{Kind: "func", Label: "locked", Description: "executes one parameterless function while holding the mutex", HasSideEffects: true,
 				Params: []*TypeDescriptor{
-					{Kind: "func", Label: "fn", Description: "parameterless function to execute under the lock", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
+					{Kind: "func", CallsOnce: true, Label: "fn", Description: "parameterless function to execute under the lock", Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "result"}},
 				},
 				Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "result returned by the protected function"},
 			},

--- a/storage/cachemap.go
+++ b/storage/cachemap.go
@@ -51,6 +51,17 @@ type cacheMapFlight struct {
 	waiters    int
 }
 
+var cacheMapCallableType = &scm.TypeDescriptor{Kind: "func", Label: "cachemap", Description: "thread-safe cache accessor",
+	Params: []*scm.TypeDescriptor{
+		{Kind: "any", Label: "key_or_operation", Description: "cache key, or get_or_compute", Optional: true},
+		{Kind: "any", Label: "value_or_key", Description: "value to store, or key for get_or_compute", Optional: true},
+		{Kind: "func", CallsOnce: true, Label: "producer", Description: "zero-argument value producer used by get_or_compute", Optional: true, Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any", Label: "value"}},
+	},
+	Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "cached value, previous value, or key list depending on the operation"},
+}
+
+var cacheMapCallableTypeID = scm.RegisterCallableType(cacheMapCallableType)
+
 // NewCacheMap creates a new cachemap and returns a Scheme function.
 // (cachemap key value) — set entry
 // (cachemap key) — get entry (or nil)
@@ -61,7 +72,7 @@ func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 		entries: make(map[string]*cacheMapEntry),
 		flights: make(map[string]*cacheMapFlight),
 	}
-	return scm.NewFunc(func(a ...scm.Scmer) scm.Scmer {
+	return scm.NewTypedFunc(func(a ...scm.Scmer) scm.Scmer {
 		switch len(a) {
 		case 0:
 			// list all keys
@@ -97,7 +108,7 @@ func NewCacheMap(a ...scm.Scmer) scm.Scmer {
 		default:
 			panic("cachemap: expected 0, 1, 2, or 3 arguments")
 		}
-	})
+	}, cacheMapCallableTypeID)
 }
 
 func newCacheMapEntry(cm *cacheMap, key string, value scm.Scmer) *cacheMapEntry {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3754,14 +3754,7 @@ func Init(en scm.Env) {
 
 		Fn: NewCacheMap,
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "Creates a new cachemap. Returns a threadsafe key-value function with LRU eviction under memory pressure: (cachemap key value) sets, (cachemap key) gets, (cachemap) lists keys, (cachemap \"get_or_compute\" key producer) computes one value for concurrent misses of the same key.",
-			Return: &scm.TypeDescriptor{Kind: "func", Label: "cachemap", Description: "thread-safe cache accessor",
-				Params: []*scm.TypeDescriptor{
-					{Kind: "any", Label: "key_or_operation", Description: "cache key, or get_or_compute", Optional: true},
-					{Kind: "any", Label: "value_or_key", Description: "value to store, or key for get_or_compute", Optional: true},
-					{Kind: "func", Label: "producer", Description: "zero-argument value producer used by get_or_compute", Optional: true, Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any", Label: "value"}},
-				},
-				Return: &scm.TypeDescriptor{Kind: "any", Label: "result", Description: "cached value, previous value, or key list depending on the operation"},
-			},
+			Return: cacheMapCallableType,
 		},
 	})
 	initTransaction(en)


### PR DESCRIPTION
## What

- add `CallsOnce` as a compact `TypeInfo` flag and preserve it in `TypeInfoFromTD` / `ToTypeDescriptor`
- propagate full callable shapes through `OptimizeEx` and the existing multi-variant `Proc` specialization cache
- attach callable descriptors to returned native closures through a compact type id, initially for `newcachemap`
- annotate established once operators (`with_session`, `try`, `once`, mutex callbacks, cache/session producers)
- teach the existing `begin` usage walk to distinguish once captures from repeated captures
- sink a multi-use closure into the one exclusive outer `if` branch containing all uses

There is no producer-name whitelist. `map`/`filter`/`reduce` and unknown callbacks remain repeated, and an inner once operator cannot hide a repeated outer callback.

## Why this now reaches the SQL hot path

`cached_parse` receives its cachemap as a Scheme parameter. `CallsOnce` therefore has to survive `OptimizeEx` and become part of the parameter-specialized `Proc`; keeping the flag only on the native declaration is insufficient.

Specializations start from an already numbered generic Proc body. The existing deoptimization traversal now restores optimizer-created local `setN` slots to stable internal names during that same traversal, allowing the existing usage walk to see local helpers again. This is not an additional subtree-analysis pass.

The optimized `cached_parse` now constructs `exact_compile` only inside its non-guarded/diagnostic branch. Guarded warm SELECTs no longer allocate that unused closure. Unlike an earlier rejected experiment, this moves one binding to the common exclusive branch and does not duplicate the closure body into both inner branches.

Conditional-region tracking records only the first exclusive branch below the current `begin`, so it is O(1) per visited use. A binding in the target region, dynamic syntax, or a repeated callback capture blocks the move.

## Manual A/B measurements

Same AMD Ryzen 9 7900X3D host, master `8b3ffa94e` versus this branch, identical benchmark source, `go test ./scm -run '^$' -bench ... -benchmem -count=12`; values are medians.

### Exclusive branch used by `cached_parse.exact_compile`

`BenchmarkOptimizedExclusiveBranchClosureSinking`

| | master | branch | change |
|---|---:|---:|---:|
| time | 214.6 ns/op | 14.4 ns/op | -93.3% |
| bytes | 176 B/op | 0 B/op | -100% |
| allocations | 3 allocs/op | 0 allocs/op | -100% |

### Once-callback helper

`BenchmarkOptimizedOnceCallbackClosureSinking`

| | master | branch | change |
|---|---:|---:|---:|
| time | 2777.5 ns/op | 1633.5 ns/op | -41.2% |
| bytes | 1304 B/op | 1144 B/op | -12.3% |
| allocations | 19 allocs/op | 16 allocs/op | -15.8% |

### General optimizer guard

`BenchmarkOptimizeSchemeHelperFreshReturn`

| | master | branch |
|---|---:|---:|
| bytes | 1152 B/op | 1152 B/op |
| allocations | 15 allocs/op | 15 allocs/op |

Time was faster in the branch samples but host variance was high; the purpose of this guard is confirming that callable lookup adds no general optimizer allocation.

### End to end

Master and branch servers ran simultaneously, with alternating requests and persistent HTTP connections.

- warm guarded `SELECT 1 WHERE "abc" LIKE "a%"`: 100 warmups, then 40 batches x 2000 requests: 168.44 us master vs 167.29 us branch, **-0.68%**
- cold `EXPLAIN COMPILE SELECT 1 /*unique*/`: 40 paired unique requests: 2526.43 us master vs 2497.81 us branch, **-1.13%** (noise-level, no cold claim)

The HTTP-level warm gain is intentionally reported as small; the material result is that the measured real path now executes the zero-allocation exclusive-branch form rather than constructing `exact_compile` before every guarded cache hit.

## Verification

- `go test ./scm -count=1`
- `go test ./storage -run '^$' -count=1`
- MemCP startup Scheme suite: 1270/1270
- full repository suite: delegated to PR CI per `AGENTS.md`
