### PR TITLE
Support mysqldump recovery through the SQL compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,18 @@
+# Copyright (C) 2026  Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 name: Test
 
 on:
@@ -10,6 +25,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: recovery-test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=12
+
     steps:
       - uses: actions/checkout@v4
 
@@ -18,8 +46,20 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install Python dependencies
-        run: pip install requests PyYAML
+      - name: Install test dependencies
+        run: |
+          pip install requests PyYAML
+          sudo apt-get update
+          sudo apt-get install -y mariadb-client
 
       - name: Run tests
         run: bash git-pre-commit
+
+      - name: Verify dump and restore compatibility
+        env:
+          MEMCP_RECOVERY_MARIADB_PASSWORD: recovery-test
+        run: >-
+          python3 tools/test_mysqldump_recovery.py
+          --mariadb-host=127.0.0.1
+          --mariadb-port=3306
+          --mysqldump=mariadb-dump

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -8210,6 +8210,19 @@ every title. */
 		(cons title (cons _expr rest)) (cons title (projection_titles rest))
 		_ '())))
 
+/* The SQL compiler is the sole owner of result shape. Protocol frontends use
+these titles instead of inspecting or reparsing the original SQL text. Expand
+stars through the same catalog-aware path used by physical lowering. */
+(define queryplan_result_titles (lambda (query)
+	(match query
+		((symbol query-block) _schema sources fields _where _group _having _order _limit _offset _hidden _stages _facts)
+		(projection_titles (expand_query_block_fields sources fields))
+		((symbol union-block) _mode branches _order _limit _offset _facts)
+		(match branches
+			(cons first_branch _rest) (queryplan_result_titles first_branch)
+			_ '())
+		_ '())))
+
 (define projection_exprs (lambda (fields)
 	(match (coalesceNil fields '())
 		(cons _title (cons expr rest)) (cons expr (projection_exprs rest))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -125,6 +125,14 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 	(parser '((atom "'" false) (define x (regex "(\\\\.|''|[^\\'])*" false false)) (atom "'" false false)) (sql_unescape (replace x "''" "'")))
 	(parser '((atom "\"" false) (define x (regex "(\\\\.|\"\"|[^\\\"])*" false false)) (atom "\"" false false)) (sql_unescape (replace x "\"\"" "\"")))
 )))
+(define sql_hex_literal (parser
+	(define x (regex "0[xX](?:[0-9A-Fa-f]{2})*"))
+	'('hex2bin (substr x 2))))
+
+/* Direct users of parse_sql may evaluate a compiled formula without a network
+frontend. The protocol execution path shadows this no-op with its metadata
+consumer, just as it already shadows resultrow. */
+(define resultfields (lambda (_fields) true))
 
 /* SQL modulo expression: NULL-safe, division-by-zero-safe, truncates quotient toward zero */
 (define sql_mod_expr (lambda (a b)
@@ -166,6 +174,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	(parser (atom "NULL" true) (sql_null_literal))
 	(parser (atom "TRUE" true) true)
 	(parser (atom "FALSE" true) false)
+	sql_hex_literal
 	sql_number
 	sql_string
 )))
@@ -927,6 +936,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(define n (placeholder_counter "n"))
 			(placeholder_counter "n" (+ n 1))
 			(list (quote session) (concat "v" (string (+ n 1))))))
+		sql_hex_literal
 		sql_number
 		sql_string
 		sql_column
@@ -1032,8 +1042,9 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		_ false
 	)))
 	(define sql_build_select_plan (lambda (query) (begin
-		(define actual_plan (build_queryplan_term (sql_expand_views query policy)))
-		(if (sql_select_calc_found_rows? query)
+		(define expanded_query (sql_expand_views query policy))
+		(define actual_plan (build_queryplan_term expanded_query))
+		(define execution_plan (if (sql_select_calc_found_rows? query)
 			(begin
 				(define count_plan (build_queryplan_term (sql_expand_views (sql_select_clear_stage query) policy)))
 				(list (quote !begin)
@@ -1044,7 +1055,10 @@ arithmetic; leave expressions containing columns or functions untouched. */
 							(list (quote session) "found_rows"
 								(list (quote +) (list (quote session) "found_rows") 1))))
 					actual_plan))
-			actual_plan)
+			actual_plan))
+		(list (quote !begin)
+			(list (quote resultfields) (list (quote quote) (queryplan_result_titles expanded_query)))
+			execution_plan)
 	)))
 	(define sql_union_all_parts (lambda (query)
 		(match query

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -487,7 +487,7 @@ user table merely to discard a newly constructed policy closure. */
 /* The frontend already owns the executing session and request identity. Pass
 them to with_autocommit so transaction setup does not rediscover either value
 through goroutine-local context lookups. */
-(define sql_execute_formula (lambda (session execution_context formula resultrow)
+(define sql_execute_formula (lambda (session execution_context formula resultrow resultfields)
 	(begin
 		(define __memcp_execution_session session)
 		(with_autocommit session execution_context
@@ -705,7 +705,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 					the legacy persistent X-Session-Id map can select a different session;
 					avoid a second goroutine-stack lookup for ordinary autocommit queries. */
 					(define execute_formula (lambda ()
-						(sql_execute_formula session execution_context formula resultrow)))
+						(sql_execute_formula session execution_context formula resultrow (lambda (_fields) true))))
 					(set query_result (if session_id
 						(with_session session execute_formula)
 						(execute_formula)))
@@ -766,7 +766,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						(extract_assoc (req "query") (lambda (k v) (session k v)))
 						(define formula (cached_parse psql_queryplan_cache parse_psql schema query
 							(list (quote sql-policy-for) (req "username")) (req "username") session false))
-						(sql_execute_formula session execution_context formula resultrow)
+						(sql_execute_formula session execution_context formula resultrow (lambda (_fields) true))
 					)))
 					/* If no resultrow was called and we got a number, return it as affected_rows */
 					(if (and (not resultrow_called) (number? query_result)) (begin
@@ -861,7 +861,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
 (set mysql_auth (lambda (username_) (scan nil (table "system" "user") '("username") (lambda (username) (equal? username username_)) '("password") (lambda (password) password) (lambda (a b) b) nil)))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
-(set mysql_handler (lambda (schema sql resultrow_sql session execution_context) (begin
+(set mysql_handler (lambda (schema sql resultrow_sql resultfields_sql session execution_context) (begin
 	(session "schema" schema)
 	(define resultrow resultrow_sql)
 	(try (lambda () (begin
@@ -880,7 +880,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 						(list (quote sql-policy-for) mysql_username) mysql_username session false)
 					(cached_parse sql_queryplan_cache parse_sql schema sql_parse_input
 						(list (quote sql-policy-for) mysql_username) mysql_username session true)))
-				(sql_execute_formula session execution_context formula resultrow)
+				(sql_execute_formula session execution_context formula resultrow resultfields_sql)
 			) sql))
 	)) (lambda (e) (begin
 			(error_log (concat e) schema (coalesce (session "username") "root") sql)

--- a/scm/mysql.go
+++ b/scm/mysql.go
@@ -341,48 +341,17 @@ func mysqlFieldsResolved(fields []*querypb.Field) bool {
 	return true
 }
 
-func isSelectQuery(query string) bool {
-	trimmed := strings.TrimSpace(query)
-	for {
-		if strings.HasPrefix(trimmed, "/*") {
-			end := strings.Index(trimmed, "*/")
-			if end == -1 {
-				return false
-			}
-			trimmed = strings.TrimSpace(trimmed[end+2:])
-			continue
-		}
-		if strings.HasPrefix(trimmed, "--") {
-			end := strings.Index(trimmed, "\n")
-			if end == -1 {
-				return false
-			}
-			trimmed = strings.TrimSpace(trimmed[end+1:])
-			continue
-		}
-		if strings.HasPrefix(trimmed, "#") {
-			end := strings.Index(trimmed, "\n")
-			if end == -1 {
-				return false
-			}
-			trimmed = strings.TrimSpace(trimmed[end+1:])
-			continue
-		}
-		break
+func prepareMySQLResultFields(titles []Scmer) ([]*querypb.Field, map[string]int, []Scmer) {
+	fields := make([]*querypb.Field, len(titles))
+	colmap := make(map[string]int, len(titles))
+	for i, title := range titles {
+		name := title.String()
+		fields[i] = &querypb.Field{Name: name, Type: querypb.Type_NULL_TYPE}
+		colmap[name] = i
 	}
-	if len(trimmed) < len("select") || !strings.EqualFold(trimmed[:len("select")], "select") {
-		return false
-	}
-	if len(trimmed) == len("select") {
-		return true
-	}
-	switch trimmed[len("select")] {
-	case ' ', '\t', '\r', '\n', '(', '/':
-		return true
-	default:
-		return false
-	}
+	return fields, colmap, make([]Scmer, len(fields))
 }
+
 func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVariables map[string]*querypb.BindVariable, output *driver.ResultWriter) (myerr error) {
 	atomic.AddInt64(&TotalHTTPRequests, 1)
 	var ss *SessionState
@@ -433,12 +402,12 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			},
 		})
 	}
-	selectQuery := isSelectQuery(query)
 	colmap := make(map[string]int)
 	var fields []*querypb.Field
 	var rowValues []Scmer
 	schemaInitialized := false
 	fieldsPublished := false
+	resultSet := false
 	var bufferedRows []Scmer
 	bufferedRowCount := 0
 	var rowStatus driver.RowStatus
@@ -538,6 +507,17 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			}
 			return NewBool(true)
 		})
+		fieldsFn := NewFunc(func(a ...Scmer) Scmer {
+			resultlock.Lock()
+			defer resultlock.Unlock()
+			if schemaInitialized || fieldsPublished || len(a) != 1 {
+				panic("result fields must be declared exactly once before result rows")
+			}
+			fields, colmap, rowValues = prepareMySQLResultFields(a[0].Slice())
+			schemaInitialized = true
+			resultSet = true
+			return NewBool(true)
+		})
 		// Execute query within GLS context so storage layer can access
 		// the session (and its TxContext) via GetCurrentTx().
 		var rc Scmer
@@ -547,7 +527,7 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 			"querySeq":        querySeq,
 			"context":         queryCtx,
 		}, func() {
-			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, scmSessionScmer,
+			rc = Apply(m.querycallback, NewString(session.Schema()), NewString(query), callbackFn, fieldsFn, scmSessionScmer,
 				NewAny(&QueryExecutionContext{SessionState: ss, QuerySeq: querySeq}))
 		})
 		return rc
@@ -572,18 +552,10 @@ func (m *MySQLWrapper) ComQuery(session *driver.Session, query string, bindVaria
 	rowsAffected := uint64(rowcount.Int())
 	// Transaction and schema status can change once per statement, not once per
 	// emitted result row. Publish the final state before flushing the result.
-	// A SELECT cannot change transaction or default-schema protocol flags.
+	// A result-producing SELECT cannot change transaction or default-schema protocol flags.
 	// Avoid three synchronized Scheme-session lookups on this hot path.
-	if !selectQuery {
+	if !resultSet {
 		updateFlags(session, sessionFunc)
-	}
-	if !fieldsPublished && selectQuery {
-		fields = []*querypb.Field{
-			{Name: "_empty", Type: querypb.Type_NULL_TYPE},
-		}
-		if err := output.SetFields(fields); err != nil {
-			return err
-		}
 	}
 	return output.Finish(rowsAffected, lastInsertID, 0)
 }

--- a/scm/mysql_test.go
+++ b/scm/mysql_test.go
@@ -132,21 +132,22 @@ func TestMySQLServerVersionHasClientCompatiblePrefix(t *testing.T) {
 	}
 }
 
-func TestIsSelectQueryHandlesCommentsAndCase(t *testing.T) {
-	for _, query := range []string{
-		"SELECT 1",
-		" select 1",
-		"/* client */ SELECT 1",
-		"-- client\nSELECT 1",
-		"# client\nSeLeCt 1",
-	} {
-		if !isSelectQuery(query) {
-			t.Fatalf("expected SELECT query: %q", query)
+func TestPrepareMySQLResultFieldsPreservesCompilerOrderAndDuplicates(t *testing.T) {
+	fields, colmap, row := prepareMySQLResultFields([]Scmer{
+		NewString("id"), NewString("value"), NewString("value"),
+	})
+	if len(fields) != 3 || len(row) != 3 {
+		t.Fatalf("prepared %d fields and %d row slots, want 3 each", len(fields), len(row))
+	}
+	if fields[0].Name != "id" || fields[1].Name != "value" || fields[2].Name != "value" {
+		t.Fatalf("compiler field order was not preserved: %+v", fields)
+	}
+	for _, field := range fields {
+		if field.Type != querypb.Type_NULL_TYPE {
+			t.Fatalf("unobserved field %q has type %v, want NULL_TYPE", field.Name, field.Type)
 		}
 	}
-	for _, query := range []string{"UPDATE t SET a=1", "/* unfinished", "SELECTED"} {
-		if isSelectQuery(query) {
-			t.Fatalf("unexpected SELECT query: %q", query)
-		}
+	if colmap["id"] != 0 || colmap["value"] != 2 {
+		t.Fatalf("unexpected fallback column map: %+v", colmap)
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2714,13 +2714,16 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 	var Auto_increment uint64
 	var hasAI bool
 	var aiColIdx int = -1
+	var aiInputIdx int = -1
 	for _, c := range t.t.Columns {
 		if c.AutoIncrement {
 			hasAI = true
-			t.t.mu.Lock() // auto increment with global table lock outside the loop for a batch
-			Auto_increment = t.t.Auto_increment
-			t.t.Auto_increment = t.t.Auto_increment + uint64(len(values)) // batch reservation of new IDs
-			t.t.mu.Unlock()
+			for i, name := range columns {
+				if name == c.Name {
+					aiInputIdx = i
+					break
+				}
+			}
 		}
 		if c.AutoIncrement || c.hasDefault() {
 			// column with default or auto increment -> also add to deltacolumns
@@ -2736,8 +2739,28 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 			}
 		}
 	}
+	generatedIDs := 0
+	var maxExplicitID uint64
+	if hasAI {
+		for _, row := range values {
+			if aiInputIdx < 0 || aiInputIdx >= len(row) || row[aiInputIdx].IsNil() {
+				generatedIDs++
+				continue
+			}
+			if explicitID := scm.ToInt(row[aiInputIdx]); explicitID > 0 && uint64(explicitID) > maxExplicitID {
+				maxExplicitID = uint64(explicitID)
+			}
+		}
+		t.t.mu.Lock() // reserve generated IDs once for the complete batch
+		Auto_increment = t.t.Auto_increment
+		if maxExplicitID > Auto_increment {
+			Auto_increment = maxExplicitID
+		}
+		t.t.Auto_increment = Auto_increment + uint64(generatedIDs)
+		t.t.mu.Unlock()
+	}
 	// if requested, notify the first assigned id once per statement
-	if hasAI && onFirstInsertId != nil {
+	if generatedIDs > 0 && onFirstInsertId != nil {
 		onFirstInsertId(int64(Auto_increment) + 1)
 		// do not call again for this shard; table-level wrapper ensures only first shard triggers
 		onFirstInsertId = nil
@@ -2749,10 +2772,13 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 		newrow := make([]scm.Scmer, len(t.deltaColumns))
 		for _, c := range t.t.Columns {
 			if c.AutoIncrement {
-				// fill auto_increment col (lock-free because the lock is outside the loop)
+				// Fill only missing/NULL values; explicit values were accounted for
+				// before reserving the batch's generated range.
 				cidx := t.deltaColumns[c.Name]
-				Auto_increment++ // local increase
-				newrow[cidx] = scm.NewInt(int64(Auto_increment))
+				if aiInputIdx < 0 || aiInputIdx >= len(row) || row[aiInputIdx].IsNil() {
+					Auto_increment++ // local increase within the reserved range
+					newrow[cidx] = scm.NewInt(int64(Auto_increment))
+				}
 			} else if c.hasDefault() {
 				// fill col with default
 				cidx := t.deltaColumns[c.Name]
@@ -2789,28 +2815,6 @@ func (t *storageShard) insertDataset(columns []string, values [][]scm.Scmer, onF
 		}
 	}
 	t.plannerDeltaRows.Store(uint64(len(t.inserts)))
-	// If any row had an explicit AI value exceeding the reserved range, bump the counter.
-	// Auto_increment (local) holds the base before reservation; auto-assigned IDs are
-	// in [Auto_increment+1 .. Auto_increment+len(values)]. Any stored value beyond that
-	// range was explicitly provided by the caller and must advance the counter.
-	if hasAI && aiColIdx >= 0 {
-		reservedTop := Auto_increment + uint64(len(values))
-		var maxExplicit uint64
-		for _, row := range t.inserts[len(t.inserts)-len(values):] {
-			if aiColIdx < len(row) && !row[aiColIdx].IsNil() {
-				if v := uint64(scm.ToInt(row[aiColIdx])); v > reservedTop && v > maxExplicit {
-					maxExplicit = v
-				}
-			}
-		}
-		if maxExplicit > 0 {
-			t.t.mu.Lock()
-			if maxExplicit > t.t.Auto_increment {
-				t.t.Auto_increment = maxExplicit
-			}
-			t.t.mu.Unlock()
-		}
-	}
 	// Charge only the new allocation to each disjoint CacheManager owner. A
 	// rebuild later replaces these deltas with each owner's absolute measured
 	// size; insert must not traverse an ever-growing shard or index here.

--- a/tests/sql/ddl/auto-increment.yaml
+++ b/tests/sql/ddl/auto-increment.yaml
@@ -21,6 +21,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS ai_partitioned"
   - sql: "DROP TABLE IF EXISTS ai_seeded"
   - sql: "DROP TABLE IF EXISTS ai_seeded_copy"
+  - sql: "DROP TABLE IF EXISTS ai_dump_restore"
   - sql: "CREATE TABLE ai_basic (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT)"
   - sql: "CREATE TABLE ai_explicit (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT)"
   - sql: "CREATE TABLE ai_mixed (id INT AUTO_INCREMENT PRIMARY KEY, val INT)"
@@ -39,6 +40,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS ai_partitioned"
   - sql: "DROP TABLE IF EXISTS ai_seeded"
   - sql: "DROP TABLE IF EXISTS ai_seeded_copy"
+  - sql: "DROP TABLE IF EXISTS ai_dump_restore"
 
 test_cases:
 
@@ -319,6 +321,22 @@ test_cases:
         (settings "PartitionMaxDimensions" 0))
 
   # --- Explicit next-value state must survive SHOW CREATE and restart. ---
+
+  - name: "Create table with mysqldump AUTO_INCREMENT state"
+    sql: "CREATE TABLE ai_dump_restore (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT) ENGINE=InnoDB AUTO_INCREMENT=3"
+
+  - name: "Restore explicit rows without consuming generated IDs"
+    sql: "INSERT INTO ai_dump_restore (id, name) VALUES (1, 'one'), (2, 'two')"
+
+  - name: "Generate the next ID after restoring explicit rows"
+    sql: "INSERT INTO ai_dump_restore (name) VALUES ('three')"
+
+  - name: "Restored AUTO_INCREMENT state generates ID three"
+    sql: "SELECT id FROM ai_dump_restore WHERE name = 'three'"
+    expect:
+      rows: 1
+      data:
+        - {id: 3}
 
   - name: "Explicit AUTO_INCREMENT next value is accepted"
     sql: "CREATE TABLE ai_seeded (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT) ENGINE=InnoDB AUTO_INCREMENT=42"

--- a/tests/sql/dml/insert-edge-cases.yaml
+++ b/tests/sql/dml/insert-edge-cases.yaml
@@ -13,6 +13,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS iec_negatives"
   - sql: "DROP TABLE IF EXISTS iec_wide"
   - sql: "DROP TABLE IF EXISTS iec_constants"
+  - sql: "DROP TABLE IF EXISTS iec_hex_blob"
 
 test_cases:
 
@@ -82,6 +83,28 @@ test_cases:
       rows: 1
       data:
         - score: null
+
+  - name: "Create MariaDB dump-style binary fixture"
+    sql: "CREATE TABLE iec_hex_blob (id INT, payload LONGBLOB)"
+
+  - name: "INSERT accepts MariaDB 0x binary literals without a column list"
+    sql: |
+      INSERT INTO iec_hex_blob VALUES
+      (1,0x00FF01803F)
+    expect:
+      affected_rows: 1
+
+  - name: "MariaDB 0x binary literal preserves every byte"
+    sql: "SELECT TO_BASE64(payload) AS encoded FROM iec_hex_blob WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - encoded: "AP8BgD8="
+
+  - name: "Malformed MariaDB 0x binary literal is rejected"
+    sql: "INSERT INTO iec_hex_blob VALUES (2, 0xGG)"
+    expect:
+      error: true
 
   # === Negative integers and bit-width edge cases ===
 
@@ -219,3 +242,4 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS iec_negatives"
   - sql: "DROP TABLE IF EXISTS iec_wide"
   - sql: "DROP TABLE IF EXISTS iec_constants"
+  - sql: "DROP TABLE IF EXISTS iec_hex_blob"

--- a/tools/test_mysqldump_recovery.py
+++ b/tools/test_mysqldump_recovery.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+
+"""
+Copyright (C) 2026 Carl-Philip Haensch
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+
+SOURCE_DATABASE = "memcp_recovery_source"
+
+FIXTURE_SQL = r"""
+CREATE DATABASE `memcp_recovery_source`;
+USE `memcp_recovery_source`;
+
+CREATE TABLE `fop_files` (
+  `ID` INT PRIMARY KEY AUTO_INCREMENT,
+  `filename` TEXT,
+  `data` LONGBLOB,
+  `uploaded_at` BIGINT,
+  UNIQUE KEY `filename_unique` (`filename`(128))
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
+
+CREATE TABLE `dokument` (
+  `ID` INT PRIMARY KEY AUTO_INCREMENT,
+  `file` INT,
+  `kommentar` LONGTEXT,
+  CONSTRAINT `dokument_file_fk` FOREIGN KEY (`file`)
+    REFERENCES `fop_files` (`ID`) ON DELETE CASCADE
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
+
+CREATE TABLE `fop_notification` (
+  `user` BIGINT,
+  `channel` TEXT,
+  `dv` TEXT,
+  `id` BIGINT,
+  `date` BIGINT
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
+
+CREATE TABLE `recovery_audit` (
+  `file_id` INT,
+  `event_name` VARCHAR(32)
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB;
+
+CREATE TABLE `recovery_parent` (`id` INT PRIMARY KEY) ENGINE=INNODB;
+CREATE TABLE `recovery_child` (
+  `id` INT PRIMARY KEY,
+  `parent_id` INT,
+  CONSTRAINT `recovery_child_parent_fk` FOREIGN KEY (`parent_id`)
+    REFERENCES `recovery_parent` (`id`) ON DELETE CASCADE
+) ENGINE=INNODB;
+CREATE TABLE `recovery_unique` (
+  `value` VARCHAR(64),
+  UNIQUE KEY `recovery_value_unique` (`value`)
+) ENGINE=INNODB;
+
+INSERT INTO `fop_files` (`filename`, `data`, `uploaded_at`) VALUES
+  ('Pruefung-Mueller.pdf', FROM_BASE64('AP8BgD8='), 1788172496),
+  ('leer.txt', FROM_BASE64(''), 1788172497);
+
+INSERT INTO `dokument` (`file`, `kommentar`) VALUES
+  (1, 'Zeile 1\nZeile 2 mit Umlauten: äöüß'),
+  (2, NULL);
+
+INSERT INTO `recovery_parent` VALUES (1);
+INSERT INTO `recovery_child` VALUES (1, 1);
+INSERT INTO `recovery_unique` VALUES ('only-once');
+
+CREATE TRIGGER `recovery_fop_files_ai` AFTER INSERT ON `fop_files`
+  FOR EACH ROW INSERT INTO `recovery_audit` (`file_id`, `event_name`)
+  VALUES (NEW.`ID`, 'insert');
+"""
+
+VERIFY_SQL = """
+SELECT COUNT(*), SUM(`uploaded_at`), SUM(LENGTH(`data`)) FROM `fop_files`;
+SELECT COUNT(*), SUM(`kommentar` IS NULL) FROM `dokument`;
+SELECT TO_BASE64(`data`) FROM `fop_files` WHERE `ID` = 1;
+SELECT COUNT(*) FROM `fop_notification`;
+SELECT COUNT(*) FROM `recovery_audit`;
+"""
+
+EXPECTED_VERIFY_LINES = [
+    "2\t3576344993\t5",
+    "2\t1",
+    "AP8BgD8=",
+    "0",
+    "0",
+]
+
+FIXTURE_COLUMNS = {
+    "fop_files": ["ID", "filename", "data", "uploaded_at"],
+    "dokument": ["ID", "file", "kommentar"],
+    "fop_notification": ["user", "channel", "dv", "id", "date"],
+    "recovery_audit": ["file_id", "event_name"],
+    "recovery_parent": ["id"],
+    "recovery_child": ["id", "parent_id"],
+    "recovery_unique": ["value"],
+}
+
+
+class RecoveryError(RuntimeError):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Start a disposable MemCP instance, dump an application-shaped fixture "
+            "with mysqldump, restore it into MariaDB and a fresh MemCP instance, "
+            "and verify both results."
+        )
+    )
+    parser.add_argument("--memcp-binary", default="./memcp")
+    parser.add_argument("--app", default="lib/main.scm")
+    parser.add_argument("--mariadb-client", default="mariadb")
+    parser.add_argument("--mysqldump", default="mysqldump")
+    parser.add_argument("--mariadb-user", default="root")
+    parser.add_argument("--mariadb-host")
+    parser.add_argument("--mariadb-port", type=int)
+    parser.add_argument("--mariadb-socket")
+    parser.add_argument(
+        "--application-schema-json",
+        type=Path,
+        help="create and validate every table described by an application sql_schema.json",
+    )
+    return parser.parse_args()
+
+
+def quote_identifier(value: str) -> str:
+    return "`" + value.replace("`", "``") + "`"
+
+
+def application_fixture(schema_path: Path) -> tuple[str, dict[str, list[str]]]:
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RecoveryError(f"cannot read application schema {schema_path}: {error}") from error
+    if not isinstance(schema, dict) or not schema:
+        raise RecoveryError(f"application schema is empty or invalid: {schema_path}")
+
+    statements = [
+        f"CREATE DATABASE {quote_identifier(SOURCE_DATABASE)}",
+        f"USE {quote_identifier(SOURCE_DATABASE)}",
+    ]
+    expected_columns: dict[str, list[str]] = {}
+    for table_name, table_spec in schema.items():
+        columns = table_spec.get("columns", {})
+        if not isinstance(columns, dict) or not columns:
+            raise RecoveryError(f"application table {table_name} has no columns")
+        expected_columns[table_name] = list(columns)
+        definitions = []
+        for column_name, column_spec in columns.items():
+            definition = f"{quote_identifier(column_name)} {column_spec['type']}"
+            if column_spec.get("primary"):
+                definition += " PRIMARY KEY AUTO_INCREMENT"
+            definitions.append(definition)
+        for unique_name, unique_spec in table_spec.get("uniques", {}).items():
+            unique_columns = ", ".join(
+                quote_identifier(column) for column in unique_spec.values()
+            )
+            definitions.append(
+                f"UNIQUE KEY {quote_identifier(unique_name)} ({unique_columns})"
+            )
+        statements.append(
+            f"CREATE TABLE {quote_identifier(table_name)} ({', '.join(definitions)}) "
+            "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB"
+        )
+
+    for table_name, table_spec in schema.items():
+        for index_name, index_spec in table_spec.get("indexes", {}).items():
+            index_columns = ", ".join(
+                quote_identifier(column) for column in index_spec.values()
+            )
+            statements.append(
+                f"CREATE INDEX {quote_identifier(index_name)} ON "
+                f"{quote_identifier(table_name)} ({index_columns})"
+            )
+        for column_name, column_spec in table_spec.get("columns", {}).items():
+            for reference_name, reference in column_spec.get("references", {}).items():
+                delete_action = "CASCADE" if reference.get("cascades") else "RESTRICT"
+                statements.append(
+                    f"ALTER TABLE {quote_identifier(table_name)} ADD CONSTRAINT "
+                    f"{quote_identifier(reference_name)} FOREIGN KEY "
+                    f"({quote_identifier(column_name)}) REFERENCES "
+                    f"{quote_identifier(reference['table'])} "
+                    f"({quote_identifier(reference['column'])}) "
+                    f"ON UPDATE CASCADE ON DELETE {delete_action}"
+                )
+
+    statements.extend(
+        [
+            "CREATE TABLE `recovery_audit` (`file_id` INT, `event_name` VARCHAR(32)) "
+            "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=INNODB",
+            "CREATE TABLE `recovery_parent` (`id` INT PRIMARY KEY) ENGINE=INNODB",
+            "CREATE TABLE `recovery_child` (`id` INT PRIMARY KEY, `parent_id` INT, "
+            "CONSTRAINT `recovery_child_parent_fk` FOREIGN KEY (`parent_id`) "
+            "REFERENCES `recovery_parent` (`id`) ON DELETE CASCADE) ENGINE=INNODB",
+            "CREATE TABLE `recovery_unique` (`value` VARCHAR(64), "
+            "UNIQUE KEY `recovery_value_unique` (`value`)) ENGINE=INNODB",
+            "INSERT INTO `fop_files` (`filename`, `data`, `uploaded_at`) VALUES "
+            "('Pruefung-Mueller.pdf', FROM_BASE64('AP8BgD8='), 1788172496), "
+            "('leer.txt', FROM_BASE64(''), 1788172497)",
+            "INSERT INTO `dokument` (`file`, `kommentar`) VALUES "
+            "(1, 'Zeile 1\\nZeile 2 mit Umlauten: äöüß'), (2, NULL)",
+            "INSERT INTO `recovery_parent` VALUES (1)",
+            "INSERT INTO `recovery_child` VALUES (1, 1)",
+            "INSERT INTO `recovery_unique` VALUES ('only-once')",
+            "CREATE TRIGGER `recovery_fop_files_ai` AFTER INSERT ON `fop_files` "
+            "FOR EACH ROW INSERT INTO `recovery_audit` (`file_id`, `event_name`) "
+            "VALUES (NEW.`ID`, 'insert')",
+        ]
+    )
+    expected_columns.update(
+        {
+            "recovery_audit": ["file_id", "event_name"],
+            "recovery_parent": ["id"],
+            "recovery_child": ["id", "parent_id"],
+            "recovery_unique": ["value"],
+        }
+    )
+    return ";\n".join(statements) + ";\n", expected_columns
+
+
+def free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def require_command(command: str) -> None:
+    if "/" in command:
+        if not Path(command).is_file():
+            raise RecoveryError(f"required executable does not exist: {command}")
+    elif shutil.which(command) is None:
+        raise RecoveryError(f"required command is not installed: {command}")
+
+
+def run(
+    command: list[str],
+    *,
+    input_text: str | None = None,
+    stdout=None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        input=input_text,
+        stdout=stdout if stdout is not None else subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RecoveryError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{detail}"
+        )
+    return completed
+
+
+def run_with_stdin_file(command: list[str], path: Path) -> None:
+    with path.open("rb") as source:
+        completed = subprocess.run(
+            command,
+            stdin=source,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).decode("utf-8", "replace").strip()
+        raise RecoveryError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{detail}"
+        )
+
+
+def client_auth_file(path: Path, *, host: str | None, port: int | None,
+                     socket_path: str | None, user: str, password: str) -> None:
+    lines = ["[client]", f"user={user}"]
+    if password:
+        lines.append(f"password={password}")
+    if socket_path:
+        lines.extend(["protocol=socket", f"socket={socket_path}"])
+    else:
+        lines.extend(["protocol=tcp", f"host={host or '127.0.0.1'}"])
+        if port is not None:
+            lines.append(f"port={port}")
+    path.write_text("\n".join(lines) + "\n")
+    path.chmod(0o600)
+
+
+def wait_for_memcp(client: str, auth_file: Path, process: subprocess.Popen[str],
+                   server_log: Path) -> None:
+    deadline = time.monotonic() + 60
+    command = [
+        client,
+        f"--defaults-file={auth_file}",
+        "--password=admin",
+        "--batch",
+        "-e",
+        "SELECT 1",
+    ]
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            detail = server_log.read_text(errors="replace")[-4000:]
+            raise RecoveryError(
+                f"MemCP exited during startup with status {process.returncode}\n{detail}"
+            )
+        if run(command, check=False).returncode == 0:
+            return
+        time.sleep(0.2)
+    detail = server_log.read_text(errors="replace")[-4000:]
+    raise RecoveryError(
+        "MemCP MySQL endpoint did not become ready within 60 seconds\n" + detail
+    )
+
+
+def mysql_lines(client: str, auth_file: Path, sql: str,
+                database: str | None = None,
+                password_option: str | None = None) -> list[str]:
+    command = [
+        client,
+        f"--defaults-file={auth_file}",
+        "--batch",
+        "--skip-column-names",
+    ]
+    if password_option:
+        command.insert(2, password_option)
+    if database:
+        command.append(database)
+    completed = run(command, input_text=sql)
+    return completed.stdout.splitlines()
+
+
+def dump_command(dump_tool: str, auth_file: Path, dump_path: Path,
+                 password_option: str | None = None) -> list[str]:
+    command = [
+        dump_tool,
+        f"--defaults-file={auth_file}",
+        "--skip-comments",
+        "--lock-tables",
+        "--hex-blob",
+        "--default-character-set=utf8mb4",
+        "--result-file",
+        str(dump_path),
+        SOURCE_DATABASE,
+    ]
+    if password_option:
+        command.insert(2, password_option)
+    return command
+
+
+def mysql_client_args(client: str, auth_file: Path) -> list[str]:
+    return [client, f"--defaults-file={auth_file}"]
+
+
+def authenticated_client_args(client: str, auth_file: Path,
+                              password_option: str | None) -> list[str]:
+    command = mysql_client_args(client, auth_file)
+    if password_option:
+        command.append(password_option)
+    return command
+
+
+def verify_restore(client: str, auth_file: Path, database: str,
+                   expected_columns: dict[str, list[str]] | None,
+                   password_option: str | None = None) -> None:
+    if expected_columns is not None:
+        restored_tables = set(mysql_lines(
+            client, auth_file, "SHOW TABLES", database, password_option
+        ))
+        if restored_tables != set(expected_columns):
+            raise RecoveryError(
+                "restored application table set differs\n"
+                f"expected: {sorted(expected_columns)}\n"
+                f"actual:   {sorted(restored_tables)}"
+            )
+        for table, columns in expected_columns.items():
+            rows = mysql_lines(
+                client,
+                auth_file,
+                f"SHOW COLUMNS FROM {quote_identifier(table)}",
+                database,
+                password_option,
+            )
+            restored_columns = [row.split("\t", 1)[0] for row in rows]
+            if restored_columns != columns:
+                raise RecoveryError(
+                    f"restored columns for {table} = {restored_columns}, want {columns}"
+                )
+
+    actual = mysql_lines(
+        client, auth_file, VERIFY_SQL, database, password_option
+    )
+    if actual != EXPECTED_VERIFY_LINES:
+        raise RecoveryError(
+            "restored data differs from the MemCP fixture\n"
+            f"expected: {EXPECTED_VERIFY_LINES}\nactual:   {actual}"
+        )
+
+    post_restore = mysql_lines(
+        client,
+        auth_file,
+        """
+        INSERT INTO `fop_files` (`filename`, `data`, `uploaded_at`)
+          VALUES ('nach-restore.txt', FROM_BASE64('AQI='), 1788172498);
+        SELECT LAST_INSERT_ID();
+        DELETE FROM `recovery_parent` WHERE `id` = 1;
+        SELECT COUNT(*) FROM `recovery_child` WHERE `parent_id` = 1;
+        SELECT COUNT(*), MIN(`file_id`), MIN(`event_name`) FROM `recovery_audit`;
+        """,
+        database,
+        password_option,
+    )
+    if post_restore != ["3", "0", "1\t3\tinsert"]:
+        raise RecoveryError(
+            "AUTO_INCREMENT, foreign-key cascade, or restored trigger is incorrect: "
+            f"{post_restore}"
+        )
+
+    duplicate = run(
+        authenticated_client_args(client, auth_file, password_option) + [database],
+        input_text=(
+            "INSERT INTO `recovery_unique` (`value`) VALUES ('only-once')"
+        ),
+        check=False,
+    )
+    if duplicate.returncode == 0:
+        raise RecoveryError("restored unique index accepted a duplicate value")
+    duplicate_detail = duplicate.stderr or duplicate.stdout
+    if "Duplicate entry" not in duplicate_detail or "1062" not in duplicate_detail:
+        raise RecoveryError(
+            "duplicate-value check failed for an unrelated reason:\n"
+            + duplicate_detail.strip()
+        )
+
+
+def restore_and_verify(client: str, auth_file: Path, database: str,
+                       dump_path: Path,
+                       expected_columns: dict[str, list[str]],
+                       password_option: str | None = None) -> None:
+    command = authenticated_client_args(client, auth_file, password_option)
+    run(
+        command,
+        input_text=f"CREATE DATABASE {quote_identifier(database)} CHARACTER SET utf8mb4",
+    )
+    run_with_stdin_file(command + [database], dump_path)
+    verify_restore(
+        client,
+        auth_file,
+        database,
+        expected_columns,
+        password_option,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    require_command(args.memcp_binary)
+    require_command(args.mariadb_client)
+    require_command(args.mysqldump)
+    if not Path(args.app).is_file():
+        raise RecoveryError(f"Scheme application does not exist: {args.app}")
+
+    destination_password = os.environ.get("MEMCP_RECOVERY_MARIADB_PASSWORD", "")
+    run_id = f"{os.getpid()}_{secrets.token_hex(4)}"
+    target_databases = {
+        "memcp_to_mariadb": f"recovery_mmaria_{run_id}",
+        "memcp_to_memcp": f"recovery_mmemcp_{run_id}",
+        "mariadb_to_mariadb": f"recovery_mariamaria_{run_id}",
+        "mariadb_to_memcp": f"recovery_mariamemcp_{run_id}",
+    }
+    source_mysql_port = free_port()
+    source_api_port = free_port()
+    restore_mysql_port = free_port()
+    restore_api_port = free_port()
+    fixture_sql = FIXTURE_SQL
+    expected_columns = FIXTURE_COLUMNS
+    if args.application_schema_json is not None:
+        fixture_sql, expected_columns = application_fixture(args.application_schema_json)
+
+    with tempfile.TemporaryDirectory(prefix="memcp-mysqldump-recovery-") as temp_name:
+        temp = Path(temp_name)
+        source_data_dir = temp / "source-data"
+        source_data_dir.mkdir()
+        restore_data_dir = temp / "restore-data"
+        restore_data_dir.mkdir()
+        source_auth = temp / "source.cnf"
+        destination_auth = temp / "destination.cnf"
+        restore_auth = temp / "restore.cnf"
+        memcp_dump_path = temp / "memcp-recovery.sql"
+        mariadb_dump_path = temp / "mariadb-recovery.sql"
+        source_log = temp / "memcp-source.log"
+        restore_log = temp / "memcp-restore.log"
+        client_auth_file(
+            source_auth,
+            host="127.0.0.1",
+            port=source_mysql_port,
+            socket_path=None,
+            user="root",
+            password="admin",
+        )
+        client_auth_file(
+            destination_auth,
+            host=args.mariadb_host,
+            port=args.mariadb_port,
+            socket_path=args.mariadb_socket,
+            user=args.mariadb_user,
+            password=destination_password,
+        )
+        client_auth_file(
+            restore_auth,
+            host="127.0.0.1",
+            port=restore_mysql_port,
+            socket_path=None,
+            user="root",
+            password="admin",
+        )
+
+        with source_log.open("w") as log:
+            source_process = subprocess.Popen(
+                [
+                    args.memcp_binary,
+                    "-data",
+                    str(source_data_dir),
+                    f"--api-port={source_api_port}",
+                    f"--mysql-port={source_mysql_port}",
+                    "--mysql-socket=",
+                    "--no-repl",
+                    args.app,
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        restore_process: subprocess.Popen[str] | None = None
+        try:
+            wait_for_memcp(
+                args.mariadb_client, source_auth, source_process, source_log
+            )
+            mysql_lines(
+                args.mariadb_client,
+                source_auth,
+                fixture_sql,
+                password_option="--password=admin",
+            )
+            source_values = mysql_lines(
+                args.mariadb_client,
+                source_auth,
+                VERIFY_SQL,
+                SOURCE_DATABASE,
+                "--password=admin",
+            )
+            if source_values != EXPECTED_VERIFY_LINES:
+                raise RecoveryError(f"MemCP fixture verification failed: {source_values}")
+
+            mariadb_client = mysql_client_args(args.mariadb_client, destination_auth)
+            run(
+                mariadb_client,
+                input_text=f"DROP DATABASE IF EXISTS {quote_identifier(SOURCE_DATABASE)}",
+            )
+            run(mariadb_client, input_text=fixture_sql)
+            mariadb_source_values = mysql_lines(
+                args.mariadb_client,
+                destination_auth,
+                VERIFY_SQL,
+                SOURCE_DATABASE,
+            )
+            if mariadb_source_values != EXPECTED_VERIFY_LINES:
+                raise RecoveryError(
+                    f"MariaDB fixture verification failed: {mariadb_source_values}"
+                )
+
+            try:
+                run(dump_command(
+                    args.mysqldump,
+                    source_auth,
+                    memcp_dump_path,
+                    "--password=admin",
+                ))
+            except RecoveryError as error:
+                log_tail = source_log.read_text(errors="replace")[-4000:]
+                raise RecoveryError(
+                    f"{error}\nMemCP log tail:\n{log_tail}"
+                ) from error
+            run(dump_command(
+                args.mysqldump,
+                destination_auth,
+                mariadb_dump_path,
+            ))
+            print("plain dumps from MemCP and MariaDB completed successfully")
+
+            memcp_to_mariadb = target_databases["memcp_to_mariadb"]
+            restore_and_verify(
+                args.mariadb_client,
+                destination_auth,
+                memcp_to_mariadb,
+                memcp_dump_path,
+                expected_columns,
+            )
+            print(
+                "PASS: MemCP dump -> MariaDB restore with complete integrity checks"
+            )
+
+            with restore_log.open("w") as log:
+                restore_process = subprocess.Popen(
+                    [
+                        args.memcp_binary,
+                        "-data",
+                        str(restore_data_dir),
+                        f"--api-port={restore_api_port}",
+                        f"--mysql-port={restore_mysql_port}",
+                        "--mysql-socket=",
+                        "--no-repl",
+                        args.app,
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+            wait_for_memcp(
+                args.mariadb_client, restore_auth, restore_process, restore_log
+            )
+            try:
+                restore_and_verify(
+                    args.mariadb_client,
+                    restore_auth,
+                    target_databases["memcp_to_memcp"],
+                    memcp_dump_path,
+                    expected_columns,
+                    "--password=admin",
+                )
+                print(
+                    "PASS: MemCP dump -> MemCP restore with complete integrity checks"
+                )
+
+                mariadb_to_mariadb = target_databases["mariadb_to_mariadb"]
+                restore_and_verify(
+                    args.mariadb_client,
+                    destination_auth,
+                    mariadb_to_mariadb,
+                    mariadb_dump_path,
+                    expected_columns,
+                )
+                print(
+                    "PASS: MariaDB dump -> MariaDB restore with complete integrity checks"
+                )
+
+                restore_and_verify(
+                    args.mariadb_client,
+                    restore_auth,
+                    target_databases["mariadb_to_memcp"],
+                    mariadb_dump_path,
+                    expected_columns,
+                    "--password=admin",
+                )
+                print(
+                    "PASS: MariaDB dump -> MemCP restore with complete integrity checks"
+                )
+            except RecoveryError as error:
+                log_tail = restore_log.read_text(errors="replace")[-4000:]
+                raise RecoveryError(
+                    f"{error}\nMemCP restore log tail:\n{log_tail}"
+                ) from error
+            return 0
+        finally:
+            for database in [
+                SOURCE_DATABASE,
+                target_databases["memcp_to_mariadb"],
+                target_databases["mariadb_to_mariadb"],
+            ]:
+                run(
+                    mysql_client_args(args.mariadb_client, destination_auth),
+                    input_text=f"DROP DATABASE IF EXISTS {quote_identifier(database)}",
+                    check=False,
+                )
+            if restore_process is not None and restore_process.poll() is None:
+                restore_process.send_signal(signal.SIGTERM)
+                try:
+                    restore_process.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    restore_process.kill()
+                    restore_process.wait(timeout=5)
+            if source_process.poll() is None:
+                source_process.send_signal(signal.SIGTERM)
+                try:
+                    source_process.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    source_process.kill()
+                    source_process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RecoveryError as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Replaces the rejected implementation from PR #699 with a clean single-parser design.

Implements mysqldump and mariadb-dump round-trip compatibility while keeping lib/sql-parser.scm as the sole SQL parser.

Architecture:

- the existing SQL compiler expands the final projection and reports result-field titles through a structured callback before execution
- the MySQL RowWriter consumes that compiled metadata, including for zero-row SELECT results
- all Go-side keyword, identifier, and projection parsing from the rejected revision has been removed
- the older Go-side isSelectQuery classification has also been removed

SQL and storage compatibility fixes:

- accept MariaDB-style 0x binary literals in the existing SQL parser
- preserve restored explicit AUTO_INCREMENT values without consuming generated IDs

The existing CI test job runs one recovery suite covering all four directions:

- MemCP dump -> MariaDB restore
- MemCP dump -> MemCP restore
- MariaDB dump -> MariaDB restore
- MariaDB dump -> MemCP restore

Every restore verifies table and column sets, row counts and aggregates, binary BLOB bytes, empty tables, unique constraints, AUTO_INCREMENT continuation, foreign-key cascade behavior, and restored trigger execution.

Targeted validation on the rebased final commit:

- build: passed
- focused MySQL metadata unit tests: passed
- INSERT edge cases: 31/31 passed
- AUTO_INCREMENT regressions: 64/64 passed
- recovery matrix: all four directions passed with complete integrity checks

The full repository suite is left to PR CI as requested.