### PR TITLE
Propagate and stabilize JIT-compiled planner lambdas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,11 @@ all:
 jitgen:
 	@set -eu; \
 	jitgen_bin=$$(mktemp /tmp/memcp-jitgen.XXXXXX); \
-	jitgen_names=$$(mktemp /tmp/memcp-jitgen-names.XXXXXX); \
-	trap 'rm -f "$$jitgen_bin" "$$jitgen_names"' EXIT; \
+	trap 'rm -f "$$jitgen_bin"' EXIT; \
 	go build -o "$$jitgen_bin" ./tools/jitgen/; \
-	for file in scm/alu.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; do \
-		sed -n '/Name:[[:space:]]*/s/.*Name:[[:space:]]*"\([^"]*\)".*/\1/p' "$$file" | sort -u > "$$jitgen_names"; \
-		while IFS= read -r op; do "$$jitgen_bin" -only="$$op" -patch "$$file"; done < "$$jitgen_names"; \
-	done; \
-	"$$jitgen_bin" -patch storage/storage-int.go storage/storage-float.go storage/storage-decimal.go storage/storage-string.go storage/storage-prefix.go storage/storage-enum.go storage/storage-scmer.go storage/storage-sparse.go storage/storage-seq.go storage/storage-const.go storage/overlay-blob.go storage/compute_proxy.go
+	"$$jitgen_bin" -patch scm/alu.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
+	"$$jitgen_bin" -patch storage/storage-int.go storage/storage-float.go storage/storage-decimal.go storage/storage-string.go storage/storage-prefix.go storage/storage-enum.go storage/storage-scmer.go storage/storage-sparse.go storage/storage-seq.go storage/storage-const.go storage/overlay-blob.go storage/compute_proxy.go; \
+	gofmt -w scm storage
 
 costgen:
 	go run ./tools/costgen -patch

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -37,9 +37,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
@@ -52,6 +54,7 @@ var doPatch bool
 var doWipe bool
 var verbose bool
 var missingOnly bool
+var jobs = runtime.GOMAXPROCS(0)
 
 const generatedBanner = "/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */"
 const phiSlotBytes = 16
@@ -74,12 +77,19 @@ func main() {
 			missingOnly = true
 		} else if arg == "-v" || arg == "--verbose" {
 			verbose = true
+		} else if strings.HasPrefix(arg, "-jobs=") {
+			parsed, err := strconv.Atoi(strings.TrimPrefix(arg, "-jobs="))
+			if err != nil || parsed < 1 {
+				fmt.Fprintf(os.Stderr, "invalid worker count %q\n", arg)
+				os.Exit(1)
+			}
+			jobs = parsed
 		} else {
 			files = append(files, arg)
 		}
 	}
 	if len(files) == 0 {
-		fmt.Fprintf(os.Stderr, "usage: jitgen [-dump=OP] [-patch] [-missing-only] [-wipe] <file.go> ...\n")
+		fmt.Fprintf(os.Stderr, "usage: jitgen [-dump=OP] [-patch] [-missing-only] [-wipe] [-jobs=N] <file.go> ...\n")
 		os.Exit(1)
 	}
 
@@ -205,18 +215,19 @@ func main() {
 		ops[i].preservedEnd = preservedEmitterOffsets[path][offset]
 	}
 
+	// Generate operator emitters in parallel after the package and SSA graph have
+	// been built once. Patches are still assembled and applied serially below so
+	// source rewriting and diagnostics remain deterministic.
+	generated := generateOperators(ops, ssaFuncs, ssaFuncsByName)
+
 	// Process each operator (pattern 1: Declare)
 	patches := map[string][]patchEntry{}
-	for _, op := range ops {
+	for opIndex, op := range ops {
 		if onlyOp != "" && op.name != onlyOp {
 			continue
 		}
-		var ssaFn *ssa.Function
-		if op.funcLit != nil {
-			ssaFn = ssaFuncs[op.funcLit.Pos()]
-		} else {
-			ssaFn = ssaFuncsByName[op.funcName]
-		}
+		generation := generated[opIndex]
+		ssaFn := generation.ssaFn
 		if ssaFn == nil {
 			fmt.Fprintf(os.Stderr, "  %s: %s — SSA function not found\n", op.path, op.name)
 			continue
@@ -226,15 +237,9 @@ func main() {
 			dumpSSA(ssaFn)
 		}
 
-		// Single-pass: try to generate, recover on failure
-		newText, genErr := generateClosure(op.name, ssaFn, nil, op.path)
-		if genErr == "" {
-			if _, err := parser.ParseExpr(newText); err != nil {
-				genErr = "generated invalid Go expression: " + err.Error()
-				if verbose {
-					fmt.Fprintln(os.Stderr, newText)
-				}
-			}
+		newText, genErr := generation.newText, generation.genErr
+		if genErr != "" && verbose {
+			fmt.Fprintln(os.Stderr, newText)
 		}
 		usesFallback := false
 		usesNativeCall := false
@@ -367,6 +372,56 @@ func main() {
 			applyPatches(path, plist)
 		}
 	}
+}
+
+type operatorGeneration struct {
+	ssaFn   *ssa.Function
+	newText string
+	genErr  string
+}
+
+func generateOperators(ops []operatorInfo, ssaFuncs map[token.Pos]*ssa.Function, ssaFuncsByName map[string]*ssa.Function) []operatorGeneration {
+	results := make([]operatorGeneration, len(ops))
+	work := make(chan int)
+	workerCount := jobs
+	if workerCount > len(ops) {
+		workerCount = len(ops)
+	}
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range work {
+				op := ops[index]
+				if onlyOp != "" && op.name != onlyOp {
+					continue
+				}
+				var fn *ssa.Function
+				if op.funcLit != nil {
+					fn = ssaFuncs[op.funcLit.Pos()]
+				} else {
+					fn = ssaFuncsByName[op.funcName]
+				}
+				result := operatorGeneration{ssaFn: fn}
+				if fn != nil {
+					result.newText, result.genErr = generateClosure(op.name, fn, nil, op.path)
+					if result.genErr == "" {
+						if _, err := parser.ParseExpr(result.newText); err != nil {
+							result.genErr = "generated invalid Go expression: " + err.Error()
+						}
+					}
+				}
+				results[index] = result
+			}
+		}()
+	}
+	for index := range ops {
+		work <- index
+	}
+	close(work)
+	workers.Wait()
+	return results
 }
 
 // generatedEmitterOverlay replaces Declaration emitter expressions only for


### PR DESCRIPTION
## What and why

This PR makes imported, JIT-compiled Scheme procedures propagate through the planner's higher-order and recursive code instead of silently falling back at the first nested lambda. It also makes emitter generation fast enough to remain practical as builtin coverage grows.

No `lib/` or test files are changed. The behavior is driven entirely by normal import-time JIT compilation.

### Runtime and compiler changes

- Allow import-time JIT compilation for procedures which construct lambdas; unsupported expressions still abort compilation atomically.
- Compile a statically known `Proc` found in a JIT AST and dispatch compiled procedures from both interpreter and JIT call sites.
- Preserve the complete lexical frame for delayed `eval`/`parser` syntax, including numbered locals. This reconstructs bindings such as the SQL execution session without planner assistance.
- Give nested condition producers stable result locations before truthiness/phi lowering and reclaim dead condition temporaries between `and`/`or` operands.
- Bind Go ABI result registers to their descriptor immediately, preventing generated emitters from reclaiming live slice/Scmer results.
- Keep tail recursion as a direct loop jump. Route non-tail self recursion through a no-inline Go bridge so nested JIT entries retain a valid foreign-frame unwind boundary.
- Publish each safepoint's final static plus dynamic unwind base directly instead of relying on transient outgoing-call spill words.
- Treat local Scmer aggregate construction as a general SSA non-inline criterion. The generated `source` emitter now uses a compact native helper call rather than expanding an unsafe aggregate allocation graph.

### JITGen throughput

- Load and build package SSA once for all Scheme source files.
- Generate independent operator emitters using a worker pool sized by `runtime.GOMAXPROCS(0)`.
- Assemble and patch output serially for deterministic generated files.
- Retain all storage types in generation and format each generated file once.

## Disassembly and propagation review

The planner inventory compiles real tree-transformation reducers, not generated query plans. Representative emitted bodies contain native loop backedges, conditional branches, and inline callback bodies:

| Probe | Code bytes | Dynamic calls | Inlined calls |
|---|---:|---:|---:|
| reducer with callback condition | 1,556 | 1 | 2 |
| combined reducers | 4,493 | 5 | 4 |

Import inventory found 1,911 procedures among 1,925 definitions and installed 271 JIT entries. It also found 817 nested lambdas, 39 of which passed the current automatic profitability/safety gate and received installed JIT entries. This confirms propagation reaches inner planner lambdas, while deliberately not claiming that every Scheme expression is already a profitable native body. Remaining calls in the disassembly are dynamic Go/Apply boundaries rather than interpreter fallback inserted for known callback bodies.

Twenty consecutive fresh-process stability runs completed without an unwind failure. Each run performed 15 SQL compile samples, 40 warm executions, and 20 distinct cold statements. Before the non-tail recursion bridge, the same workload failed sporadically while unwinding adjacent JIT frames.

## Manual A/B measurements

All latency comparisons use the same checkout and source, alternating fresh vanilla-Go and patched-Go processes on the same machine. The SQL fixture is a fresh 2,000-row in-memory table; each run uses 15 `EXPLAIN COMPILE` samples, 10 warmups plus 40 cached executions, and 20 distinct cold SQL statements. The table reports the median of seven per-process medians.

| Measurement | Vanilla | JIT | Change |
|---|---:|---:|---:|
| Known-lambda map microbenchmark | 4,622.5 ns/op | 2,238 ns/op | **2.07x faster** |
| Micro allocations | 145 allocs/op, 5,040 B/op | 4 allocs/op, 2,368 B/op | **-97.2% allocs, -53.0% bytes** |
| Internal SQL compile/planner | 6.814 ms | 6.128 ms | **-10.1%** |
| SQL compile over HTTP | 12.649 ms | 11.850 ms | **-6.3%** |
| Cold SQL end-to-end over HTTP | 8.658 ms | 7.808 ms | **-9.8%** |
| Warm cached SQL execution over HTTP | 0.416 ms | 0.478 ms | +14.8% |

The warm cached path remains a measured regression. It is below the repository's 20% regression threshold, but it is recorded explicitly: after correctness and propagation, a follow-up should prefer native call boundaries for fully dynamic cases where additional emitted code only increases instruction-cache pressure.

JITGen generation measurements, also with fresh processes:

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| 32 operators from `scm/alu.go` | 74.75 s | 2.30 s | **32.5x faster** |
| Complete Scheme generation, one worker vs automatic workers | 4.48 s | 3.49 s | **22% faster** |

Generated output was identical with `-jobs=1` and `-jobs=8`; regenerating `source` twice was byte-identical.

## Verification

- `go test -race ./tools/jitgen -count=1`
- patched compiler: repository-wide `go test ./... -run '^$'`
- patched compiler: targeted list, conditional/phi, transferred stack-list, and recursive-result JIT tests
- 20/20 fresh-process SQL compile/execute stability runs
- server startup Scheme suite: 1,270/1,270
- current CI is used for the full SQL suite, per repository workflow
