### PR TITLE
Fix MySQL fields for derived table wildcards

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3054,11 +3054,6 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 (define query_block_has_aggregates? (lambda (block)
 	(not (empty_list? (stage_aggregates_for_fields (qb_fields block))))))
 
-(define table_column_names (lambda (schema tbl)
-	(if (table_function_relation? tbl)
-		(table_function_columns tbl)
-		(map (get_schema schema tbl) (lambda (col) (col "Field"))))))
-
 (define star_expr_alias (lambda (expr)
 	(match expr
 		((symbol get_column) tblvar _ "*" _) tblvar
@@ -3071,10 +3066,13 @@ tools/costgen; this lowering adds no hand-tuned crossover. */
 		((quote get_column) _ _ "*" _) true
 		_ false)))
 
+/* Star expansion must use each source's SQL-visible exported columns. A source
+may be a base table, table function, query block, or union; consulting only the
+base-table schema silently produces empty result metadata for derived.*. */
 (define expand_star_for_sources (lambda (sources requested_alias)
 	(merge (map (coalesceNil sources '()) (lambda (src)
 		(if (or (nil? requested_alias) (equal? requested_alias (source_alias src)))
-			(merge (map (table_column_names (source_schema src) (source_relation src)) (lambda (col)
+			(merge (map (binding_source_columns src) (lambda (col)
 				(list col (list (quote get_column) (source_alias src) false col false)))))
 			'()))))))
 
@@ -3119,7 +3117,7 @@ columns cannot change group cardinality because the primary key is unique. */
 	(merge (map (qb_sources block) (lambda (src)
 		(if (and (fields_request_star_for_source? (qb_fields block) src)
 			(source_primary_key_grouped? block src))
-			(map (table_column_names (source_schema src) (source_relation src)) (lambda (col)
+			(map (binding_source_columns src) (lambda (col)
 				(list (quote get_column) (source_alias src) false col false)))
 			'()))))))
 

--- a/tests/sql/compatibility/mysql-application-sql.yaml
+++ b/tests/sql/compatibility/mysql-application-sql.yaml
@@ -62,6 +62,18 @@ setup:
   - sql: "INSERT INTO sqlcompat_actions VALUES (1, 0, 'pending', 20, '2026-08-26 10:00:00', NULL), (2, 0, 'pending', 10, '2026-08-26 09:00:00', NULL), (3, 0, 'complete', 1, '2026-08-25 09:00:00', NULL)"
 
 test_cases:
+  - name: "Derived-table wildcard publishes MySQL result fields"
+    mysql:
+      statements:
+        - sql: "SELECT t.* FROM (SELECT ID AS item_id, post_name AS label FROM wpcompat_posts WHERE ID <= 2) AS t ORDER BY t.item_id"
+          expect:
+            rows: 2
+            data:
+              - item_id: 1
+                label: "first"
+              - item_id: 2
+                label: "second"
+
   - name: "SET NAMES with COLLATE and leading whitespace work over MySQL"
     mysql:
       statements:


### PR DESCRIPTION
## What

- expand wildcard result fields through the canonical source-binding catalog
- support exported columns from base tables, table functions, derived query blocks, and unions uniformly
- remove the now-redundant base-table-only column helper
- add a native MySQL protocol regression for `SELECT derived.*`

## Why

The compile-owned result metadata introduced in #700 asked the base-table schema for wildcard columns. A derived relation has no base-table schema entry, so the compiler published an empty field list and later streamed rows. The MySQL protocol correctly rejected that inconsistent result and closed the connection.

This fixes the compiler metadata source instead of adding a protocol fallback or reparsing SQL text.

## Verification

- Scheme formatter/check: passed
- startup Scheme tests: 1270/1270
- `tests/sql/compatibility/mysql-application-sql.yaml`: 41/41
- `tests/planner/subqueries/unnesting.yaml`: 25/25
- manual native MySQL query returned columns `x`, `y` and both expected rows
- real-data instance restarted on HTTP 4521 / MySQL 3521 and accepts MySQL queries

The full suite is delegated to CI.
