### PR TITLE
Propagate and stabilize JIT-compiled planner lambdas

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1354,6 +1354,37 @@ func jitLambdaFreeSymbols(params, body Scmer) []Symbol {
 	return out
 }
 
+// jitExpressionConsumesRuntimeEnv reports whether delayed syntax can resolve
+// bindings which are not statically visible in its enclosing lambda body.
+// Such lambdas must retain the complete lexical frame rather than only the
+// symbols found by ordinary free-variable analysis.
+func jitExpressionConsumesRuntimeEnv(expr Scmer) bool {
+	for expr.IsSourceInfo() {
+		expr = expr.SourceInfo().value
+	}
+	if !expr.IsSlice() {
+		return false
+	}
+	items := expr.Slice()
+	if len(items) == 0 {
+		return false
+	}
+	if head, ok := scmerSymbol(items[0]); ok {
+		switch string(head) {
+		case "quote":
+			return false
+		case "eval", "parser":
+			return true
+		}
+	}
+	for _, item := range items {
+		if jitExpressionConsumesRuntimeEnv(item) {
+			return true
+		}
+	}
+	return false
+}
+
 func jitCollectLambdaOuterVarIndices(expr Scmer, seen map[NthLocalVar]struct{}, out *[]NthLocalVar) {
 	if expr.IsSourceInfo() {
 		expr = expr.SourceInfo().value
@@ -2137,19 +2168,21 @@ func (ctx *JITContext) EmitGoCallScalar(funcAddr uint64, args []JITValueDesc, nu
 	var resultsBuf [16]Reg
 	words := ctx.flattenArgs(args, &wordsBuf)
 	results := ctx.EmitGoCall(funcAddr, words, numResultWords, &resultsBuf, nil)
-	// Result registers are already allocated by EmitGoCall (removed from FreeRegs).
-	// Set RegOwners to nil — the caller MUST BindReg to a long-lived descriptor.
-	// The nil ownership prevents AllocReg's spill path from evicting the result.
-	for i := 0; i < numResultWords && i < len(results); i++ {
-		ctx.RegOwners[results[i]] = nil
-	}
+	var result JITValueDesc
 	if numResultWords == 1 {
-		return JITValueDesc{Loc: LocReg, Reg: results[0]}
+		result = JITValueDesc{Loc: LocReg, Reg: results[0]}
+	} else if numResultWords == 3 {
+		result = JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: results[0], Reg2: results[1], Reg3: results[2]}
+	} else {
+		result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: results[0], Reg2: results[1]}
 	}
-	if numResultWords == 3 {
-		return JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: results[0], Reg2: results[1], Reg3: results[2]}
+	// A result becomes spillable immediately. Generated emitters may call
+	// ReclaimUntrackedRegs before its next use, so leaving ABI result registers
+	// ownerless would silently release a still-live slice or Scmer value.
+	for _, reg := range jitDescRegs(result) {
+		ctx.BindReg(reg, &result)
 	}
-	return JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: results[0], Reg2: results[1]}
+	return result
 }
 
 // EmitGoCallScalarInto emits a scalar Go call directly into a fixed result
@@ -8427,7 +8460,7 @@ func jitCompileModePublish(recursiveLambdas bool, waitForPublication bool, a ...
 					Arena:             arena,
 					ConstRoots:        roots,
 					Proc:              sourceProc,
-					AutoImportSafe:    autoImportSafe && jitAutoImportSyntaxSafe(sourceProc.Body),
+					AutoImportSafe:    autoImportSafe,
 					RecursiveLambdas:  recursiveLambdas,
 					NeedsStableArgs:   needsStableArgs,
 					Coverage:          coverage,
@@ -8454,38 +8487,6 @@ func jitCompileModePublish(recursiveLambdas bool, waitForPublication bool, a ...
 	default:
 		panic(fmt.Sprintf("jit: cannot compile %v (tag %d)", v, tag))
 	}
-}
-
-// jitAutoImportSyntaxSafe rejects procedures which manufacture callbacks. A
-// compiled top-level procedure may otherwise use every expression the emitter
-// accepted; unsupported expressions already abort compilation atomically.
-// Callback closure compilation remains opt-in until its generated slice paths
-// carry the same complete lifetime contract as the enclosing entry point.
-func jitAutoImportSyntaxSafe(expr Scmer) bool {
-	for expr.IsSourceInfo() {
-		expr = expr.SourceInfo().value
-	}
-	if !expr.IsSlice() {
-		return true
-	}
-	items := expr.Slice()
-	if len(items) == 0 {
-		return true
-	}
-	if head, ok := scmerSymbol(items[0]); ok {
-		switch string(head) {
-		case "quote":
-			return true
-		case "lambda", "optimizer_proc_return":
-			return false
-		}
-	}
-	for _, item := range items {
-		if !jitAutoImportSyntaxSafe(item) {
-			return false
-		}
-	}
-	return true
 }
 
 // execBuf is a small wrapper for writable memory (arena-backed or standalone)

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -391,6 +391,14 @@ func jitApplyCallableSlice(callable, envValue Scmer, args []Scmer) Scmer {
 	return ApplyEx(callable, args, envValue.Any().(*Env))
 }
 
+// jitCallSelfCode preserves a Go unwind frame around a non-tail recursive JIT
+// call. Tail recursion stays inside the generated entry point as a direct jump.
+func jitCallSelfCode(code uintptr, args []Scmer) Scmer {
+	fnData := unsafe.Pointer(&struct{ *byte }{(*byte)(unsafe.Pointer(code))})
+	native := *(*func(...Scmer) Scmer)(unsafe.Pointer(&fnData))
+	return callJIT(native, args...)
+}
+
 func jitInvokeCallback1(callback, arg0 Scmer) Scmer {
 	return callback.Func()(arg0)
 }
@@ -1091,7 +1099,29 @@ func jitMaterializeVirtualGoSlice(ctx *JITContext, elements []JITValueDesc) JITV
 }
 
 func jitCondToBool(ctx *JITContext, cond *JITValueDesc) JITValueDesc {
-	return ctx.EmitBoolDesc(cond, JITValueDesc{Loc: LocAny})
+	ctx.EnsureDesc(cond)
+	regs := jitDescRegs(*cond)
+	for _, reg := range regs {
+		ctx.ProtectReg(reg)
+	}
+	boolean := ctx.EmitBoolDesc(cond, JITValueDesc{Loc: LocAny})
+	for _, reg := range regs {
+		ctx.UnprotectReg(reg)
+	}
+	return boolean
+}
+
+// jitCompileCondition gives an arbitrarily large child CFG a stable producer
+// target before lowering Scheme truthiness. This is shared by every special
+// form so nested map/reduce emitters see the same register-bank contract.
+func jitCompileCondition(ctx *JITContext, expr Scmer, sliceBase Reg) JITValueDesc {
+	target := jitAllocTrackedPair(ctx, JITTypeUnknown)
+	ctx.ProtectReg(target.Reg)
+	ctx.ProtectReg(target.Reg2)
+	condition := jitCompileExpr(ctx, expr, sliceBase, target)
+	ctx.UnprotectReg(target.Reg2)
+	ctx.UnprotectReg(target.Reg)
+	return jitCondToBool(ctx, &condition)
 }
 
 // jitCompileStackList lowers the optimizer-internal
@@ -1605,19 +1635,19 @@ func jitCompileSelfCall(ctx *JITContext, operands []Scmer, sliceBase Reg, result
 	}
 
 	argsPtr := ctx.AllocReg()
+	argsLen := ctx.AllocRegExcept(argsPtr)
+	argsCap := ctx.AllocRegExcept(argsPtr, argsLen)
+	argsSlice := JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: argsPtr, Reg2: argsLen, Reg3: argsCap}
+	ctx.BindReg(argsPtr, &argsSlice)
+	ctx.BindReg(argsLen, &argsSlice)
+	ctx.BindReg(argsCap, &argsSlice)
 	ctx.EmitLeaRegMem(argsPtr, ctx.StackReg, argsOff)
-	words := []goCallArgWord{
-		{loc: LocReg, reg: argsPtr},
-		{loc: LocImm, imm: uint64(ctx.SelfParamCount)},
-		{loc: LocImm, imm: uint64(ctx.SelfParamCount)},
-	}
+	ctx.EmitMovRegImm64(argsLen, uint64(ctx.SelfParamCount))
+	ctx.EmitMovRegImm64(argsCap, uint64(ctx.SelfParamCount))
+	code := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(ctx.Start)))}
 	target := jitEnsureResultPair(ctx, result)
-	var resultsBuf [16]Reg
-	targets := [...]Reg{target.Reg, target.Reg2}
-	results := ctx.EmitGoCall(uint64(uintptr(ctx.Start)), words, 2, &resultsBuf, targets[:])
-	ctx.FreeReg(argsPtr)
-	target.Reg = results[0]
-	target.Reg2 = results[1]
+	target = ctx.EmitGoCallScalarInto(GoFuncAddr(jitCallSelfCode), []JITValueDesc{code, argsSlice}, target)
+	ctx.FreeDesc(&argsSlice)
 	target.Type = JITTypeUnknown
 	ctx.BindReg(target.Reg, &target)
 	ctx.BindReg(target.Reg2, &target)
@@ -1675,8 +1705,11 @@ func jitEmitCondJump(ctx *JITContext, expr Scmer, sliceBase Reg, trueLbl, falseL
 		}
 	}
 
-	cond := jitCompileExpr(ctx, expr, sliceBase, JITValueDesc{Loc: LocAny})
-	b := jitCondToBool(ctx, &cond)
+	// Conditions are consumed immediately, but generated multi-block emitters
+	// still need a stable pair destination while rendering their internal CFG.
+	// Reserving it here prevents a returned spill descriptor from becoming
+	// relative to a later nested emitter's stack frame.
+	b := jitCompileCondition(ctx, expr, sliceBase)
 	if b.Loc == LocImm {
 		if b.Imm.Bool() {
 			ctx.EmitJmp(trueLbl)
@@ -1689,6 +1722,7 @@ func jitEmitCondJump(ctx *JITContext, expr Scmer, sliceBase Reg, trueLbl, falseL
 	ctx.EmitJump(CondNotEqual, trueLbl)
 	ctx.EmitJmp(falseLbl)
 	ctx.FreeDesc(&b)
+	ctx.ReclaimUntrackedRegs()
 }
 
 // jitCompileExpr recursively compiles a Scheme expression to machine code.
@@ -1711,13 +1745,23 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 	}
 	switch expr.GetTag() {
 	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector,
-		tagFunc, tagFuncEnv, tagProc, tagJIT, tagParser, tagFastDict, tagAny,
+		tagFunc, tagFuncEnv, tagJIT, tagParser, tagFastDict, tagAny,
 		tagClosure, tagPromise:
 		// Keep Eval's self-evaluating literal contract. Pointer-bearing constants
 		// are retained through the entry point's ConstRoots for the lifetime of
 		// the generated code.
 		ctx.TrackImm(expr)
 		return JITValueDesc{Loc: LocImm, Type: expr.GetTag(), Imm: expr}
+	case tagProc:
+		if ctx.RecursiveLambdas && expr.Proc() != nil && expr.Proc().Compiled == nil {
+			compiled := jitCompileModeDeferred(true, expr)
+			if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+				panic("jit: embedded procedure could not be compiled")
+			}
+			expr = compiled
+		}
+		ctx.TrackImm(expr)
+		return JITValueDesc{Loc: LocImm, Type: tagProc, Imm: expr}
 	case tagSymbol:
 		sym := expr.Symbol()
 		if string(sym) == "nil" {
@@ -1731,6 +1775,17 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 					ctx.TrackImm(desc.Imm)
 				}
 				return desc
+			}
+		}
+		// A compiled closure keeps its interpreter environment in RuntimeEnv.
+		// Preserve lexical shadowing before considering a same-named global for
+		// static specialization; the global may only be used when it is the
+		// binding the interpreter would resolve as well.
+		if runtimeEnv, ok := ctx.RuntimeEnv.Any().(*Env); ok && runtimeEnv != nil {
+			if binding := runtimeEnv.FindRead(sym); binding != nil && binding != &Globalenv {
+				if _, exists := binding.Vars[sym]; exists {
+					return jitCompileRuntimeSymbol(ctx, expr, result)
+				}
 			}
 		}
 		if v, ok := Globalenv.Vars[sym]; ok {
@@ -1974,6 +2029,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			allocatedBeforeEmitter := ctx.AllRegs &^ ctx.FreeRegs
 			labelsBefore := ctx.LabelNext
 			out := decl.Type.JITEmit(ctx, list[1:], args, result)
+			ctx.SyncDesc(&out)
 			// Generated control-flow emitters may spill their result placement while
 			// rendering sibling blocks and then write the final value back into its
 			// registers. Rebind that placement at the declaration boundary so stale

--- a/scm/jit_special_forms.go
+++ b/scm/jit_special_forms.go
@@ -254,12 +254,17 @@ func jitEmitSpecialIf(ctx *JITContext, args []Scmer, _ []JITValueDesc, result JI
 		return JITValueDesc{Loc: LocImm, Type: tagNil, Imm: imm}
 	}
 	target := jitEnsureResultPair(ctx, result)
+	ctx.ProtectReg(target.Reg)
+	ctx.ProtectReg(target.Reg2)
+	defer func() {
+		ctx.UnprotectReg(target.Reg2)
+		ctx.UnprotectReg(target.Reg)
+	}()
 	var endLabel uint8
 	hasDynamic := false
 	i := 0
 	for i+1 < len(args) {
-		condition := jitCompileExpr(ctx, args[i], ctx.SliceBase, JITValueDesc{Loc: LocAny})
-		boolean := jitCondToBool(ctx, &condition)
+		boolean := jitCompileCondition(ctx, args[i], ctx.SliceBase)
 		if boolean.Loc == LocImm {
 			if boolean.Imm.Bool() {
 				value := jitCompileExpr(ctx, args[i+1], ctx.SliceBase, target)
@@ -352,13 +357,11 @@ func jitEmitSpecialBoolFold(takeWhen bool) func(*JITContext, []Scmer, []JITValue
 			ctx.TrackImm(imm)
 			return JITValueDesc{Loc: LocImm, Type: tagBool, Imm: imm}
 		}
-		target := jitEnsureResultPair(ctx, result)
 		var takeLabel, endLabel uint8
 		hasDynamic := false
 		compileTimeTake := false
 		for _, expression := range args {
-			condition := jitCompileExpr(ctx, expression, ctx.SliceBase, JITValueDesc{Loc: LocAny})
-			boolean := jitCondToBool(ctx, &condition)
+			boolean := jitCompileCondition(ctx, expression, ctx.SliceBase)
 			if boolean.Loc == LocImm {
 				if boolean.Imm.Bool() == takeWhen {
 					compileTimeTake = true
@@ -378,7 +381,14 @@ func jitEmitSpecialBoolFold(takeWhen bool) func(*JITContext, []Scmer, []JITValue
 				ctx.EmitJcc(CcE, takeLabel)
 			}
 			ctx.FreeDesc(&boolean)
+			// A completed condition has no values live into the next short-circuit
+			// operand. Drop path-local CFG temporaries before recursively emitting it.
+			ctx.ReclaimUntrackedRegs()
 		}
+		// Allocate the fold's output only after all child CFGs have been emitted.
+		// The result has no live value before this point, and reserving two
+		// registers for it needlessly raises pressure in nested map/reduce code.
+		target := jitEnsureResultPair(ctx, result)
 		if compileTimeTake {
 			if hasDynamic {
 				ctx.MarkLabel(takeLabel)
@@ -492,7 +502,20 @@ func jitEmitSpecialLambda(ctx *JITContext, args []Scmer, _ []JITValueDesc, resul
 	argExprs = append(argExprs, NewSlice([]Scmer{NewSymbol("quote"), params}))
 	argExprs = append(argExprs, NewSlice([]Scmer{NewSymbol("quote"), body}))
 	argExprs = append(argExprs, NewInt(int64(numVars)))
-	for _, symbol := range jitLambdaFreeSymbols(params, body) {
+	freeSymbols := jitLambdaFreeSymbols(params, body)
+	if jitExpressionConsumesRuntimeEnv(body) {
+		seen := make(map[Symbol]struct{}, len(freeSymbols))
+		for _, symbol := range freeSymbols {
+			seen[symbol] = struct{}{}
+		}
+		for _, symbol := range jitVisibleSymbols(ctx) {
+			if _, exists := seen[symbol]; !exists {
+				freeSymbols = append(freeSymbols, symbol)
+				seen[symbol] = struct{}{}
+			}
+		}
+	}
+	for _, symbol := range freeSymbols {
 		if ctx.Env != nil {
 			if _, ok := ctx.Env.Lookup(symbol); ok {
 				argExprs = append(argExprs, NewSlice([]Scmer{NewSymbol("quote"), NewSymbol(string(symbol))}))
@@ -504,7 +527,20 @@ func jitEmitSpecialLambda(ctx *JITContext, args []Scmer, _ []JITValueDesc, resul
 			continue
 		}
 	}
-	for _, index := range jitLambdaOuterVarIndices(body) {
+	outerIndices := jitLambdaOuterVarIndices(body)
+	if jitExpressionConsumesRuntimeEnv(body) {
+		seen := make(map[NthLocalVar]struct{}, len(outerIndices))
+		for _, index := range outerIndices {
+			seen[index] = struct{}{}
+		}
+		for index := 0; index < ctx.LocalSlotCount; index++ {
+			local := NthLocalVar(index)
+			if _, exists := seen[local]; !exists {
+				outerIndices = append(outerIndices, local)
+			}
+		}
+	}
+	for _, index := range outerIndices {
 		key := NewNthLocalVar(index)
 		argExprs = append(argExprs, NewSlice([]Scmer{NewSymbol("quote"), key}))
 		argExprs = append(argExprs, key)

--- a/scm/jit_unwind_gojit.go
+++ b/scm/jit_unwind_gojit.go
@@ -19,7 +19,11 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 
 package scm
 
-import "runtime/jit"
+import (
+	"runtime"
+	"runtime/jit"
+	"unsafe"
+)
 
 // registerJITArena registers a JIT arena with the Go runtime so the
 // unwinder, GC, and panic/recover can walk through JIT frames.
@@ -63,17 +67,22 @@ func publishJITStackMaps(a *jitArena, maps []jitStackMap) {
 	}
 	runtimeMaps := make([]jit.StackMap, len(maps))
 	for i := range maps {
+		if maps[i].frameWords == 0 {
+			panic("jit: invalid empty unwind frame")
+		}
+		frameBaseOffset := (maps[i].frameWords - 1) * unsafe.Sizeof(uintptr(0))
 		runtimeMaps[i] = jit.StackMap{
-			PCOffset:              maps[i].pcOffset,
-			FrameWords:            maps[i].frameWords,
-			PointerMask:           maps[i].pointerMap,
-			HasUnwind:             true,
-			UnwindBaseOffset:      jitGoSpillBytes + 16,
-			UnwindBaseDeltaOffset: jitGoSpillBytes,
-			UnwindBaseUsesDelta:   true,
-			CallerPCOffset:        8,
-			CallerSPOffset:        16,
-			CallerBPOffset:        0,
+			PCOffset:    maps[i].pcOffset,
+			FrameWords:  maps[i].frameWords,
+			PointerMask: maps[i].pointerMap,
+			HasUnwind:   true,
+			// Each safepoint already carries its final static plus dynamic frame
+			// size. Address the saved frame pointer directly instead of depending
+			// on transient delta words in the outgoing Go-call spill area.
+			UnwindBaseOffset: frameBaseOffset,
+			CallerPCOffset:   8,
+			CallerSPOffset:   16,
+			CallerBPOffset:   0,
 		}
 	}
 	handle.AddStackMaps(runtimeMaps...)
@@ -87,6 +96,13 @@ func jitWrapCallTarget(fn func(...Scmer) Scmer) func(...Scmer) Scmer {
 
 // callJIT invokes a JIT-compiled function directly. With runtime/jit,
 // panics propagate naturally through the unwinder.
+//
+//go:noinline
 func callJIT(native func(...Scmer) Scmer, args ...Scmer) Scmer {
-	return native(args...)
+	result := native(args...)
+	// Keep an ordinary Go frame between independently compiled JIT entries.
+	// The runtime currently resolves one registered foreign frame at a time;
+	// retaining this bridge also gives nested calls an unambiguous Go caller PC.
+	runtime.KeepAlive(native)
+	return result
 }

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -93,14 +93,12 @@ func evalAll(source, s string, en *Env, compileProcedures bool) (expression Scme
 				jitAutoImportCoverageWorthwhile(compiled.Proc().Compiled.Coverage) &&
 				definition {
 				expression = compiled
-				if definition {
-					target := en.definitionTarget()
-					if target.Vars == nil {
-						target.Vars = make(Vars)
-					}
-					target.Vars[sym] = compiled
-					compiled.Proc().Compiled.DebugName = string(sym)
+				target := en.definitionTarget()
+				if target.Vars == nil {
+					target.Vars = make(Vars)
 				}
+				target.Vars[sym] = compiled
+				compiled.Proc().Compiled.DebugName = string(sym)
 				if JITLog {
 					entry := compiled.Proc().Compiled
 					fmt.Printf("JIT: import %s code=%p bytes=%d hidden-args=%d expressions=%d dynamic-calls=%d inlined-calls=%d\n",
@@ -129,10 +127,15 @@ func topLevelDefinitionSymbol(code Scmer) (Symbol, bool) {
 		return "", false
 	}
 	items := code.Slice()
-	if len(items) < 3 || !items[0].IsSymbol() || (!items[0].SymbolEquals("define") && !items[0].SymbolEquals("set")) || !items[1].IsSymbol() {
+	if len(items) < 3 {
 		return "", false
 	}
-	return items[1].Symbol(), true
+	head, headOK := scmerSymbol(items[0])
+	symbol, symbolOK := scmerSymbol(items[1])
+	if !headOK || (head != "define" && head != "set") || !symbolOK {
+		return "", false
+	}
+	return symbol, true
 }
 
 // Syntactic Analysis

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -7191,178 +7191,14 @@ Patterns can be any of:
 				ctx.EmitGoCallVoid(GoFuncAddr(func(base *SourceInfo, value Scmer) { base.value = value }), []JITValueDesc{d0, d12})
 				ctx.FreeDesc(&d12)
 				ctx.EnsureDesc(&d0)
-				d13 := d0
-				_ = d13
-				ctx.StabilizeDescForControlFlow(&d13)
-				bbpos_3_0 := int32(-1)
-				_ = bbpos_3_0
-				bbpos_3_0 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				d14 := ctx.EmitGoCallScalar(GoFuncAddr(func() *SourceInfo { return new(SourceInfo) }), nil, 1)
-				ctx.BindReg(d14.Reg, &d14)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d13)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(dst, src *SourceInfo) { *dst = *src }), []JITValueDesc{d14, d13})
-				ctx.ReclaimUntrackedRegs()
-				d15 := ctx.EmitGoCallScalar(GoFuncAddr(func() []*SourceInfo { return sourceCoverageInfos }), nil, 3)
-				ctx.ReclaimUntrackedRegs()
-				d16 := ctx.EmitGoCallScalar(GoFuncAddr(func() *[1]*SourceInfo { return new([1]*SourceInfo) }), nil, 1)
-				ctx.ReclaimUntrackedRegs()
-				d17 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d14)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(dst *[1]*SourceInfo, index int, value *SourceInfo) { dst[index] = value }), []JITValueDesc{d16, d17, d14})
-				ctx.ReclaimUntrackedRegs()
-				sliceResults18 := JITEmitGoCallResults(ctx, GoFuncAddr(func(value *[1]*SourceInfo) []*SourceInfo { return value[0:1:1] }), []JITValueDesc{d16}, []uint8{3}, []uint8{1})
-				d19 := sliceResults18[0]
-				ctx.ReclaimUntrackedRegs()
-				callResults20 := JITEmitGoCallResults(ctx, GoFuncAddr(func(dst, src []*SourceInfo) []*SourceInfo { return append(dst, src...) }), []JITValueDesc{d15, d19}, []uint8{3}, []uint8{1})
-				d21 := callResults20[0]
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d21)
-				ctx.EmitGoCallVoid(GoFuncAddr(func(value []*SourceInfo) { sourceCoverageInfos = value }), []JITValueDesc{d21})
-				ctx.ReclaimUntrackedRegs()
-				r0 := ctx.AllocReg()
-				r1 := ctx.AllocRegExcept(r0)
-				ctx.EmitMovRegImm64(r0, 0)
-				ctx.EmitMovRegImm64(r1, 0)
-				d22 := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: r0, Reg2: r1}
-				ctx.BindReg(r0, &d22)
-				ctx.BindReg(r1, &d22)
-				ctx.ReclaimUntrackedRegs()
-				d23 := args[0]
-				d23.ID = 0
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d14)
-				ctx.EnsureDesc(&d14)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d14)
-				ctx.EnsureDesc(&d14)
-				ctx.ReclaimUntrackedRegs()
-				d26 := args[0]
-				d26.ID = 0
-				ctx.ReclaimUntrackedRegs()
-				d27 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(14)}
-				d28 := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(0)}
-				d29 := d27
-				_ = d29
-				ctx.StabilizeDescForControlFlow(&d29)
-				d30 := d28
-				_ = d30
-				ctx.StabilizeDescForControlFlow(&d30)
-				bbpos_4_0 := int32(-1)
-				_ = bbpos_4_0
-				bbpos_4_0 = int32(uintptr(ctx.Ptr) - uintptr(ctx.Start))
-				ctx.ReclaimUntrackedRegs()
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d30)
-				var d31 JITValueDesc
-				if d30.Loc == LocImm {
-					d31 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(d30.Imm.Int()) << 8))}
-				} else {
-					ctx.EmitShlRegImm8(d30.Reg, 8)
-					d31 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d30.Reg}
-					ctx.BindReg(d30.Reg, &d31)
-				}
-				if d31.Loc == LocReg && d30.Loc == LocReg && d31.Reg == d30.Reg {
-					ctx.TransferReg(d30.Reg)
-					d30.Loc = LocNone
-				}
-				ctx.FreeDesc(&d30)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d29)
-				var d32 JITValueDesc
-				if d29.Loc == LocImm {
-					d32 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d29.Imm.Int() & 255)}
-				} else {
-					ctx.EmitAndRegImm32(d29.Reg, int32(255))
-					d32 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d29.Reg}
-					ctx.BindReg(d29.Reg, &d32)
-				}
-				if d32.Loc == LocImm {
-					d32 = JITValueDesc{Loc: LocImm, Type: d32.Type, Imm: NewInt(int64(uint64(d32.Imm.Int()) & 0xff))}
-				} else {
-					ctx.EmitShlRegImm8(d32.Reg, 56)
-					ctx.EmitShrRegImm8(d32.Reg, 56)
-				}
-				if d32.Loc == LocReg && d29.Loc == LocReg && d32.Reg == d29.Reg {
-					ctx.TransferReg(d29.Reg)
-					d29.Loc = LocNone
-				}
-				ctx.FreeDesc(&d29)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d32)
-				ctx.EnsureDesc(&d32)
-				var d33 JITValueDesc
-				if d32.Loc == LocImm {
-					d33 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uint64(uint8(d32.Imm.Int()))))}
-				} else {
-					r2 := ctx.AllocReg()
-					ctx.EmitMovRegReg(r2, d32.Reg)
-					ctx.EmitShlRegImm8(r2, 56)
-					ctx.EmitShrRegImm8(r2, 56)
-					d33 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: r2}
-					ctx.BindReg(r2, &d33)
-				}
-				ctx.FreeDesc(&d32)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d31)
-				ctx.EnsureDesc(&d33)
-				var d34 JITValueDesc
-				if d31.Loc == LocImm && d33.Loc == LocImm {
-					d34 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d31.Imm.Int() | d33.Imm.Int())}
-				} else if d31.Loc == LocImm && d31.Imm.Int() == 0 {
-					d34 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d33.Reg}
-					ctx.BindReg(d33.Reg, &d34)
-				} else if d33.Loc == LocImm && d33.Imm.Int() == 0 {
-					d34 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d31.Reg}
-					ctx.BindReg(d31.Reg, &d34)
-				} else if d31.Loc == LocImm {
-					scratch := ctx.AllocRegExcept(d33.Reg)
-					ctx.EmitMovRegImm64(scratch, uint64(d31.Imm.Int()))
-					ctx.EmitOrInt64(scratch, d33.Reg)
-					d34 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: scratch}
-					ctx.BindReg(scratch, &d34)
-				} else if d33.Loc == LocImm {
-					if d33.Imm.Int() >= -2147483648 && d33.Imm.Int() <= 2147483647 {
-						ctx.EmitOrRegImm32(d31.Reg, int32(d33.Imm.Int()))
-					} else {
-						ctx.EmitMovRegImm64(RegR11, uint64(d33.Imm.Int()))
-						ctx.EmitOrInt64(d31.Reg, RegR11)
-					}
-					d34 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d31.Reg}
-					ctx.BindReg(d31.Reg, &d34)
-				} else {
-					ctx.EmitOrInt64(d31.Reg, d33.Reg)
-					d34 = JITValueDesc{Loc: LocReg, Type: tagInt, Reg: d31.Reg}
-					ctx.BindReg(d31.Reg, &d34)
-				}
-				if d34.Loc == LocReg && d31.Loc == LocReg && d34.Reg == d31.Reg {
-					ctx.TransferReg(d31.Reg)
-					d31.Loc = LocNone
-				}
-				ctx.FreeDesc(&d31)
-				ctx.FreeDesc(&d33)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d34)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d14)
-				ctx.EnsureDesc(&d14)
-				ctx.EmitMovToReg(d23.Reg, d14)
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d34)
-				ctx.EnsureDesc(&d34)
-				ctx.EmitMovToReg(d26.Reg2, d34)
-				ctx.FreeDesc(&d34)
-				ctx.ReclaimUntrackedRegs()
-				d35 := d22
-				_ = d35
-				ctx.ReclaimUntrackedRegs()
-				ctx.EnsureDesc(&d35)
-				if d35.Loc == LocImm {
+				ctx.EnsureDesc(&d0)
+				ctx.SyncDesc(&d0)
+				d13 := ctx.EmitGoCallScalar(GoFuncAddr((func(arg0 *SourceInfo) Scmer { return NewSourceInfo(*arg0) })), []JITValueDesc{d0}, 2)
+				ctx.BindReg(d13.Reg, &d13)
+				ctx.BindReg(d13.Reg2, &d13)
+				if d13.Loc == LocImm {
 					if result.Loc == LocAny {
-						return d35
+						return d13
 					}
 				}
 				if result.Loc == LocAny {
@@ -7370,20 +7206,20 @@ Patterns can be any of:
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
-				ctx.EnsureDesc(&d35)
-				if d35.Loc == LocRegPair {
-					ctx.EmitMovPairToResult(&d35, &result)
-					result.Type = d35.Type
+				ctx.EnsureDesc(&d13)
+				if d13.Loc == LocRegPair {
+					ctx.EmitMovPairToResult(&d13, &result)
+					result.Type = d13.Type
 				} else {
-					switch d35.Type {
+					switch d13.Type {
 					case tagBool:
-						ctx.EmitMakeBool(result, d35)
+						ctx.EmitMakeBool(result, d13)
 						result.Type = tagBool
 					case tagInt:
-						ctx.EmitMakeInt(result, d35)
+						ctx.EmitMakeInt(result, d13)
 						result.Type = tagInt
 					case tagFloat:
-						ctx.EmitMakeFloat(result, d35)
+						ctx.EmitMakeFloat(result, d13)
 						result.Type = tagFloat
 					case tagNil:
 						ctx.EmitMakeNil(result)

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -1641,7 +1641,13 @@ func (g *codeGen) emitGenericStaticCall(name string, callee *ssa.Function, args 
 			}
 			return params.At(i - argOffset).Type()
 		}()
-		switch goCallWordCount(paramType) {
+		wordCount := goCallWordCount(paramType)
+		if _, isAggregate := paramType.Underlying().(*types.Struct); isAggregate && resolved[i].marker == "_aggregate_ptr" && wordCount == 0 {
+			indirectArgs[i] = true
+			argVars = append(argVars, resolved[i].goVar)
+			continue
+		}
+		switch wordCount {
 		case 0:
 			// Zero-sized values have no Go internal-ABI words. Keep them in the
 			// source-level signature, but do not invent a machine operand.
@@ -3407,6 +3413,26 @@ func inlineInstructionCount(fn *ssa.Function) int {
 	return count
 }
 
+// functionBuildsScmerStruct reports helpers which assemble Scmer through a
+// local aggregate and FieldAddr stores. Those stores need a descriptor owned
+// by the caller's register namespace; keeping the helper as a native Go call
+// is both smaller and safer than expanding its allocation graph inline.
+func functionBuildsScmerStruct(fn *ssa.Function) bool {
+	for _, block := range fn.Blocks {
+		for _, instruction := range block.Instrs {
+			allocation, ok := instruction.(*ssa.Alloc)
+			if !ok {
+				continue
+			}
+			pointer, ok := allocation.Type().Underlying().(*types.Pointer)
+			if ok && isScmerType(pointer.Elem()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func blockEndsInPanic(block *ssa.BasicBlock) bool {
 	return block != nil && len(block.Instrs) > 0 && func() bool {
 		_, ok := block.Instrs[len(block.Instrs)-1].(*ssa.Panic)
@@ -3422,6 +3448,9 @@ func (g *codeGen) tryInlineCall(callee *ssa.Function, callArgs []ssa.Value) (res
 		return genVal{}, false
 	}
 	if callee.Signature.Results().Len() == 1 && goCallWordCount(callee.Signature.Results().At(0).Type()) == 0 {
+		return genVal{}, false
+	}
+	if functionBuildsScmerStruct(callee) {
 		return genVal{}, false
 	}
 	if cost := inlineInstructionCount(callee); cost > inlineInstructionBudget {


### PR DESCRIPTION
## What and why

This PR makes imported, JIT-compiled Scheme procedures propagate through the planner's higher-order and recursive code instead of silently falling back at the first nested lambda.

No `lib/` or test files are changed. The behavior is driven entirely by normal import-time JIT compilation.

### Runtime and compiler changes

- Allow import-time JIT compilation for procedures which construct lambdas; unsupported expressions still abort compilation atomically.
- Compile a statically known `Proc` found in a JIT AST and dispatch compiled procedures from both interpreter and JIT call sites.
- Preserve the complete lexical frame for delayed `eval`/`parser` syntax, including numbered locals. This reconstructs bindings such as the SQL execution session without planner assistance.
- Give nested condition producers stable result locations before truthiness/phi lowering and reclaim dead condition temporaries between `and`/`or` operands.
- Bind Go ABI result registers to their descriptor immediately, preventing generated emitters from reclaiming live slice/Scmer results.
- Keep tail recursion as a direct loop jump. Route non-tail self recursion through a no-inline Go bridge so nested JIT entries retain a valid foreign-frame unwind boundary.
- Publish each safepoint's final static plus dynamic unwind base directly instead of relying on transient outgoing-call spill words.
- Treat local Scmer aggregate construction as a general SSA non-inline criterion. The generated `source` emitter now uses a compact native helper call rather than expanding an unsafe aggregate allocation graph.

## Disassembly and propagation review

The planner inventory compiles real tree-transformation reducers, not generated query plans. Representative emitted bodies contain native loop backedges, conditional branches, and inline callback bodies:

| Probe | Code bytes | Dynamic calls | Inlined calls |
|---|---:|---:|---:|
| reducer with callback condition | 1,556 | 1 | 2 |
| combined reducers | 4,493 | 5 | 4 |

Import inventory found 1,911 procedures among 1,925 definitions and installed 271 JIT entries. It also found 817 nested lambdas, 39 of which passed the current automatic profitability/safety gate and received installed JIT entries. This confirms propagation reaches inner planner lambdas, while deliberately not claiming that every Scheme expression is already a profitable native body. Remaining calls in the disassembly are dynamic Go/Apply boundaries rather than interpreter fallback inserted for known callback bodies.

Twenty consecutive fresh-process stability runs completed without an unwind failure. Each run performed 15 SQL compile samples, 40 warm executions, and 20 distinct cold statements. Before the non-tail recursion bridge, the same workload failed sporadically while unwinding adjacent JIT frames.

## Manual A/B measurements

All latency comparisons use the same checkout and source, alternating fresh vanilla-Go and patched-Go processes on the same machine. The SQL fixture is a fresh 2,000-row in-memory table; each run uses 15 `EXPLAIN COMPILE` samples, 10 warmups plus 40 cached executions, and 20 distinct cold SQL statements. The table reports the median of seven per-process medians.

| Measurement | Vanilla | JIT | Change |
|---|---:|---:|---:|
| Known-lambda map microbenchmark | 4,622.5 ns/op | 2,238 ns/op | **2.07x faster** |
| Micro allocations | 145 allocs/op, 5,040 B/op | 4 allocs/op, 2,368 B/op | **-97.2% allocs, -53.0% bytes** |
| Internal SQL compile/planner | 6.814 ms | 6.128 ms | **-10.1%** |
| SQL compile over HTTP | 12.649 ms | 11.850 ms | **-6.3%** |
| Cold SQL end-to-end over HTTP | 8.658 ms | 7.808 ms | **-9.8%** |
| Warm cached SQL execution over HTTP | 0.416 ms | 0.478 ms | +14.8% |

The warm cached path remains a measured regression. It is below the repository's 20% regression threshold, but it is recorded explicitly: after correctness and propagation, a follow-up should prefer native call boundaries for fully dynamic cases where additional emitted code only increases instruction-cache pressure.

The generated `source` emitter was regenerated twice with byte-identical output.

## Verification

- `go test -race ./tools/jitgen -count=1`
- patched compiler: repository-wide `go test ./... -run '^$'`
- patched compiler: targeted list, conditional/phi, transferred stack-list, and recursive-result JIT tests
- 20/20 fresh-process SQL compile/execute stability runs
- server startup Scheme suite: 1,270/1,270
- current CI is used for the full SQL suite, per repository workflow
