### PR TITLE
JIT: select builtin inlining from specialization value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ jitgen:
 	"$$jitgen_bin" -patch storage/storage-int.go storage/storage-float.go storage/storage-decimal.go storage/storage-string.go storage/storage-prefix.go storage/storage-enum.go storage/storage-scmer.go storage/storage-sparse.go storage/storage-seq.go storage/storage-const.go storage/overlay-blob.go storage/compute_proxy.go; \
 	gofmt -w scm storage
 
+jitgen-policy:
+	@set -eu; \
+	jitgen_bin=$$(mktemp /tmp/memcp-jitgen.XXXXXX); \
+	trap 'rm -f "$$jitgen_bin"' EXIT; \
+	go build -o "$$jitgen_bin" ./tools/jitgen/; \
+	"$$jitgen_bin" -patch -policy-only scm/alu.go scm/list.go scm/strings.go scm/scm.go scm/date.go scm/streams.go scm/sync.go scm/metrics.go scm/scheduler.go scm/window.go scm/vector.go scm/packrat.go scm/jit.go scm/timezone.go scm/processlist.go scm/list_assoc_extra.go scm/sql_literals.go scm/json_functions.go; \
+	gofmt -w scm
+
 costgen:
 	go run ./tools/costgen -patch
 

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -128,6 +128,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -689,6 +690,7 @@ func init_alu() {
 				ctx.FreeStack(int32(16))
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -744,6 +746,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3962,6 +3965,7 @@ func init_alu() {
 				ctx.FreeStack(int32(64))
 				return result
 			},
+			JITInlineCost: 38,
 		},
 		Optimize: optimizeAssociative,
 	})
@@ -5323,6 +5327,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 40,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -12851,6 +12856,7 @@ func init_alu() {
 				ctx.FreeStack(int32(112))
 				return result
 			},
+			JITInlineCost: 72,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -13515,6 +13521,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 41,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -14179,6 +14186,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 41,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -20356,6 +20364,7 @@ func init_alu() {
 				ctx.FreeStack(int32(96))
 				return result
 			},
+			JITInlineCost: 57,
 		},
 		Optimize: optimizeAssociative,
 	})
@@ -22190,6 +22199,7 @@ func init_alu() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  30,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -24237,6 +24247,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 47,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -24823,6 +24834,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 18,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -25373,6 +25385,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 17,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -25923,6 +25936,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 17,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26509,6 +26523,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 18,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26635,6 +26650,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 7,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26779,6 +26795,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -27085,6 +27102,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -30319,6 +30337,7 @@ func init_alu() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  51,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -31011,6 +31030,7 @@ func init_alu() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      26,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -31081,6 +31101,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -31151,6 +31172,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -31196,6 +31218,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 5,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -33007,6 +33030,7 @@ func init_alu() {
 				ctx.FreeStack(int32(32))
 				return result
 			},
+			JITInlineCost: 18,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -34818,6 +34842,7 @@ func init_alu() {
 				ctx.FreeStack(int32(32))
 				return result
 			},
+			JITInlineCost: 18,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -34899,6 +34924,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -34980,6 +35006,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -35048,6 +35075,7 @@ func init_alu() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -41978,6 +42006,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 259,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -43683,6 +43712,7 @@ func init_alu() {
 				ctx.FreeStack(int32(16))
 				return result
 			},
+			JITInlineCost: 33,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -44254,6 +44284,7 @@ func init_alu() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 16,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -45316,6 +45347,7 @@ func init_alu() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      60,
 		},
 	})
 }

--- a/scm/date.go
+++ b/scm/date.go
@@ -2430,6 +2430,7 @@ func init_date() {
 				return result
 				return result
 			},
+			JITInlineCost: 84,
 		},
 	})
 
@@ -2791,6 +2792,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  4,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2841,6 +2843,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  4,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3310,6 +3313,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  11,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -6276,6 +6280,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  38,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -6964,6 +6969,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  22,
 		},
 	})
 
@@ -15938,6 +15944,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  92,
 		},
 	})
 
@@ -25480,6 +25487,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  64,
 		},
 	})
 
@@ -35557,6 +35565,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  71,
 		},
 	})
 
@@ -36578,6 +36587,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  22,
 		},
 	})
 
@@ -64097,6 +64107,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  199,
 		},
 	})
 
@@ -65862,6 +65873,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  47,
 		},
 	})
 
@@ -69407,6 +69419,7 @@ func init_date() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  84,
 		},
 	})
 }

--- a/scm/declare.go
+++ b/scm/declare.go
@@ -98,6 +98,11 @@ type TypeDescriptor struct {
 	// calls as recursive lambda emitters. It is capability metadata, not a
 	// runtime permission gate.
 	JITInlineCallbacks bool
+	// JITInlineCost is jitgen's architecture-neutral estimate of the emitted
+	// builtin body: the builtin's SSA instructions plus recursively inlined Go
+	// helpers. Zero denotes a handwritten emitter without generated cost data;
+	// the maximum value denotes a generated native-call boundary.
+	JITInlineCost uint16
 }
 
 // OptimizerContext is an exported wrapper so packages like storage can use

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -161,15 +161,16 @@ type JITEntryPoint struct {
 	// RecursiveLambdas makes lambda values constructed by this native body
 	// compile their own body before they are returned or passed onward.
 	RecursiveLambdas bool
-	// Coverage counts lowered Scheme expression nodes and calls which still
-	// cross the generic Eval/Apply bridge. It is diagnostic metadata, not a
-	// profile: one dynamic call may perform arbitrarily much runtime work.
+	// Coverage counts lowered Scheme expressions and distinguishes generic
+	// Eval/Apply bridges, compact native builtin calls, and inlined emitters.
+	// It is diagnostic metadata, not a runtime profile.
 	Coverage JITCoverage
 }
 
 type JITCoverage struct {
 	Expressions  int
 	DynamicCalls int
+	NativeCalls  int
 	InlinedCalls int
 }
 
@@ -487,6 +488,7 @@ type JITContext struct {
 	AutoImportSafe        bool
 	RecursiveLambdas      bool
 	ActiveBuiltinEmitters map[*Declaration]uint16
+	BuiltinInlineCost     int
 	NeedsStableArgs       bool
 	SelfSymbols           map[Symbol]struct{}
 	SelfLoopLabel         uint8
@@ -2919,6 +2921,7 @@ func init_jit() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  197,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -4538,6 +4541,7 @@ func init_jit() {
 				ctx.FreeStack(int32(32))
 				return result
 			},
+			JITInlineCost: 27,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -8340,6 +8344,7 @@ func init_jit() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  38,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -8376,6 +8381,7 @@ func init_jit() {
 				return result
 				return result
 			},
+			JITInlineCost: 2,
 		},
 	})
 }

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -19,6 +19,7 @@ package scm
 import (
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"unsafe"
 )
@@ -1603,6 +1604,135 @@ func jitCompileDynamicHigherOrderCall(ctx *JITContext, callableExpr Scmer, opera
 	return jitCompileDynamicCall(ctx, callableExpr, operands, sliceBase, result)
 }
 
+func jitTypeDescriptorTag(td *TypeDescriptor) uint8 {
+	if td == nil {
+		return JITTypeUnknown
+	}
+	switch td.Kind {
+	case "bool":
+		return tagBool
+	case "int":
+		return tagInt
+	case "string":
+		return tagString
+	case "symbol":
+		return tagSymbol
+	case "nil":
+		return tagNil
+	case "list":
+		return tagSlice
+	default:
+		return JITTypeUnknown
+	}
+}
+
+// jitPreviewCallArgument extracts policy facts without writing machine code.
+// The real argument compiler remains the single source of value placement;
+// this preview only carries facts that are already explicit in the optimized
+// Scheme tree or its lexical descriptor environment.
+func jitPreviewCallArgument(ctx *JITContext, decl *Declaration, index int, expr Scmer) JITValueDesc {
+	for expr.IsSourceInfo() {
+		expr = expr.SourceInfo().value
+	}
+	if param := jitDeclarationParam(decl, index); param != nil && param.Kind == "func" {
+		if lambda, ok := jitLambdaTemplate(expr, ctx.Env); ok {
+			return JITValueDesc{Loc: LocLambdaTemplate, Type: tagProc, Lambda: lambda}
+		}
+	}
+	if expr.IsNthLocalVar() {
+		local := int(expr.NthLocalVar())
+		if ctx.Env != nil && local < len(ctx.Env.Numbered) {
+			return ctx.Env.Numbered[local]
+		}
+		if local < ctx.InputArgCount {
+			return JITValueDesc{Loc: LocInputPair, Type: JITTypeUnknown, StackOff: int32(local)}
+		}
+	}
+	if expr.GetTag() != tagSlice {
+		return JITValueDesc{Loc: LocImm, Type: expr.GetTag(), Imm: expr}
+	}
+	parts := expr.Slice()
+	if len(parts) == 2 && parts[0].SymbolEquals("quote") {
+		quoted := parts[1]
+		preview := JITValueDesc{Loc: LocImm, Type: quoted.GetTag(), Imm: quoted}
+		if quoted.IsSlice() {
+			preview.KnownSliceLen = int32(len(quoted.Slice()))
+			preview.SliceSizeKnown = true
+		}
+		return preview
+	}
+	if len(parts) == 0 {
+		return JITValueDesc{Type: JITTypeUnknown}
+	}
+	if nested := DeclarationForValue(parts[0]); nested != nil && nested.Type != nil {
+		preview := JITValueDesc{Type: jitTypeDescriptorTag(nested.Type.Return)}
+		if preview.Type == tagSlice && nested.Type.Return != nil && nested.Type.Return.Length >= 0 {
+			preview.KnownSliceLen = int32(nested.Type.Return.Length)
+			preview.SliceSizeKnown = true
+		}
+		return preview
+	}
+	return JITValueDesc{Type: JITTypeUnknown}
+}
+
+const jitBuiltinInlineBudget = 2048
+
+func jitShouldInlineBuiltin(ctx *JITContext, decl *Declaration, args []JITValueDesc) bool {
+	if decl == nil || decl.Type == nil || decl.Type.JITInlineCost == 0 {
+		return true
+	}
+	knownTypes, knownShapes := 0, 0
+	knownCallback, hasCallback := false, false
+	for index, arg := range args {
+		if arg.Type != JITTypeUnknown {
+			knownTypes++
+		}
+		if arg.Loc == LocImm || arg.SliceSizeKnown || arg.Loc == LocVirtualSlice {
+			knownShapes++
+		}
+		param := jitDeclarationParam(decl, index)
+		if param != nil && param.Kind == "func" {
+			hasCallback = true
+			if (arg.Loc == LocLambdaTemplate && arg.Lambda != nil) ||
+				(arg.Loc == LocImm && (arg.Imm.GetTag() == tagProc || arg.Imm.GetTag() == tagFunc)) {
+				knownCallback = true
+			}
+		}
+	}
+	if hasCallback {
+		// A known callback removes the Apply boundary from every loop iteration;
+		// this dominates the one-time instruction-cache cost for map/reduce-style
+		// operators. Unknown callbacks retain the compact native Go loop.
+		if !decl.Type.JITInlineCallbacks || !knownCallback {
+			return false
+		}
+	} else {
+		cost := int(decl.Type.JITInlineCost)
+		switch {
+		case decl.Type.JITVirtualArgs:
+			// Virtual-list producers and consumers preserve fusion opportunities
+			// which a native Go call would force us to materialize.
+		case len(args) > 0 && knownTypes == len(args) && cost <= 256:
+			// Full type knowledge lets generated emitters discard dynamic type
+			// switches. Partial knowledge did not amortize emitted code in A/B.
+		case knownShapes > 0 && cost <= 32:
+			// Small shape-specialized emitters can eliminate list allocation and
+			// length/tag checks even when element types remain dynamic.
+		default:
+			return false
+		}
+	}
+	cost := int(decl.Type.JITInlineCost)
+	if cost == math.MaxUint16 {
+		return false
+	}
+	if ctx.BuiltinInlineCost+cost > jitBuiltinInlineBudget {
+		return false
+	}
+	ctx.BuiltinInlineCost += cost
+	return true
+}
+
 func jitIsNativeReturnTarget(ctx *JITContext, result JITValueDesc) bool {
 	return result.Loc == LocRegPair && result.Reg == ctx.ResultPtrReg && result.Reg2 == ctx.ResultAuxReg
 }
@@ -1950,6 +2080,14 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 			return jitCompileDynamicCall(ctx, list[0], list[1:], sliceBase, result)
 		}
 		if decl.Type != nil && decl.Type.JITEmit != nil {
+			policyArgs := make([]JITValueDesc, len(list)-1)
+			for i := 1; i < len(list); i++ {
+				policyArgs[i-1] = jitPreviewCallArgument(ctx, decl, i-1, list[i])
+			}
+			if !jitShouldInlineBuiltin(ctx, decl, policyArgs) {
+				ctx.Coverage.NativeCalls++
+				return jitEmitGoVariadicCallFromExprs(ctx, decl.Fn, list[1:], sliceBase, result)
+			}
 			ctx.Coverage.InlinedCalls++
 			if !jitAutoImportReturnSafe(name, decl.Type.Return) {
 				ctx.AutoImportSafe = false

--- a/scm/list.go
+++ b/scm/list.go
@@ -1604,6 +1604,7 @@ func init_list() {
 				return jitMaterializeVirtualSlice(ctx, d0, result)
 				return result
 			},
+			JITInlineCost: 2,
 		},
 		Optimize: optimizeListCall,
 	})
@@ -2630,6 +2631,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  32,
 		},
 		Optimize: optimizeCount,
 	})
@@ -3207,6 +3209,7 @@ func init_list() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 17,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3797,6 +3800,7 @@ func init_list() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 20,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -5766,6 +5770,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  33,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -6458,6 +6463,7 @@ func init_list() {
 				ctx.FreeStack(int32(16))
 				return result
 			},
+			JITInlineCost: 19,
 		},
 		Optimize:                 optimizeFixedLengthInput("reverse_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -6544,6 +6550,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  10,
 		},
 		Optimize:                 optimizeAppend,
 		OptimizeFirstArgTransfer: true,
@@ -8516,6 +8523,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  34,
 		},
 		Optimize:                 FirstParameterMutable("append_unique_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -8911,6 +8919,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  27,
 		},
 		Optimize: optimizeCons,
 	})
@@ -9226,6 +9235,7 @@ func init_list() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 11,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -9684,6 +9694,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  13,
 		},
 		Optimize: optimizeCdr,
 	})
@@ -9999,6 +10010,7 @@ func init_list() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 11,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -13608,6 +13620,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  52,
 		},
 		Optimize: optimizeZip,
 	})
@@ -16040,6 +16053,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  36,
 		},
 		Optimize: optimizeMerge,
 	})
@@ -23355,6 +23369,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  62,
 		},
 		Optimize:                 optimizeMergeUnique,
 		OptimizeFirstArgTransfer: true,
@@ -24197,6 +24212,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -25490,6 +25506,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 		Optimize:                 optimizeFilter,
 		OptimizeFirstArgTransfer: true,
@@ -26874,6 +26891,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      30,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -27654,6 +27672,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      26,
 		},
 		Optimize:                 optimizeMap,
 		OptimizeFirstArgTransfer: true,
@@ -27723,6 +27742,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 		Optimize:                 optimizeFixedLengthInput("parallel_map_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -27791,6 +27811,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -28584,6 +28605,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      30,
 		},
 		Optimize:                 optimizeFixedLengthInput("mapIndex_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -30284,6 +30306,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      36,
 		},
 		Optimize: optimizeReduce,
 	})
@@ -31276,6 +31299,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      33,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -34137,6 +34161,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      46,
 		},
 		Optimize: optimizeProduceN,
 	})
@@ -34211,6 +34236,7 @@ func init_list() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["parallelN"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 		Optimize: optimizeParallelN,
 	})
@@ -38183,6 +38209,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      59,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -38295,6 +38322,7 @@ func init_list() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["parallelN_mut"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -38557,6 +38585,7 @@ func init_list() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 8,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -39397,6 +39426,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -41768,6 +41798,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  33,
 		},
 	})
 
@@ -44990,6 +45021,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      102,
 		},
 		Optimize:                 FirstParameterMutable("filter_assoc_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -49437,6 +49469,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      107,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -52752,6 +52785,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      93,
 		},
 		Optimize: optimizeAssocFixedLengthInput("map_assoc_mut"),
 	})
@@ -55244,6 +55278,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      99,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -57538,6 +57573,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -59365,6 +59401,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -61107,6 +61144,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  32,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -63343,6 +63381,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  39,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -65435,6 +65474,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  35,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -68828,6 +68868,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      92,
 		},
 		Optimize:                 optimizeExtractAssoc,
 		OptimizeFirstArgTransfer: true,
@@ -75250,6 +75291,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      97,
 		},
 		Optimize:                 FirstParameterMutable("set_assoc_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -78903,6 +78945,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      160,
 		},
 		Optimize:                 FirstParameterMutable("merge_assoc_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -83787,6 +83830,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      56,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -85251,6 +85295,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      40,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -86546,6 +86591,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -89472,6 +89518,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      45,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -91063,6 +91110,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -93614,6 +93662,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  133,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -96165,6 +96214,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  133,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -97756,6 +97806,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -111877,6 +111928,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      166,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -125490,6 +125542,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      161,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -126448,6 +126501,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      27,
 		},
 		Optimize: optimizeFindMapNotNull,
 	})
@@ -127864,6 +127918,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      40,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -128760,6 +128815,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      34,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -129631,6 +129687,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      39,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -132097,6 +132154,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      44,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -135166,6 +135224,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      46,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -140864,6 +140923,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      64,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -144164,6 +144224,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      54,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -147417,6 +147478,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      54,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -149277,6 +149339,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      42,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -150168,6 +150231,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -151257,6 +151321,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      34,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -152878,6 +152943,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  41,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -152919,6 +152985,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -156006,6 +156073,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      103,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -157470,6 +157538,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  36,
 		},
 	})
 	// _mut variants: optimizer-only, forbidden from .scm code
@@ -158131,6 +158200,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      24,
 		},
 	})
 
@@ -158803,6 +158873,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      28,
 		},
 	})
 
@@ -161960,6 +162031,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      89,
 		},
 	})
 
@@ -163170,6 +163242,7 @@ func init_list() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      29,
 		},
 	})
 
@@ -163872,6 +163945,7 @@ func init_list() {
 				ctx.FreeStack(int32(32))
 				return result
 			},
+			JITInlineCost: 23,
 		},
 	})
 
@@ -167719,6 +167793,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      103,
 		},
 	})
 
@@ -170127,6 +170202,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      89,
 		},
 	})
 
@@ -176381,6 +176457,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      94,
 		},
 	})
 
@@ -176463,6 +176540,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  7,
 		},
 	})
 
@@ -178394,6 +178472,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  31,
 		},
 	})
 
@@ -204573,6 +204652,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  126,
 		},
 	})
 
@@ -205012,6 +205092,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  13,
 		},
 	})
 
@@ -208665,6 +208746,7 @@ func init_list() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      160,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -209555,6 +209637,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  79,
 		},
 		Optimize:                 FirstParameterMutable("sort_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -210413,6 +210496,7 @@ func init_list() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  75,
 		},
 	})
 }

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -2229,6 +2229,7 @@ func init_list_assoc_extra() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      120,
 		},
 		Optimize: optimizeGroupAssoc,
 	})
@@ -4454,6 +4455,7 @@ func init_list_assoc_extra() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      124,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -6690,6 +6692,7 @@ func init_list_assoc_extra() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      127,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -8717,6 +8720,7 @@ func init_list_assoc_extra() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      105,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -10756,6 +10760,7 @@ func init_list_assoc_extra() {
 				return result
 			},
 			JITInlineCallbacks: true,
+			JITInlineCost:      108,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -12985,6 +12990,7 @@ func init_list_assoc_extra() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      104,
 		},
 		Optimize:                 FirstParameterMutable("mapkey_assoc_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -15789,6 +15795,7 @@ func init_list_assoc_extra() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      108,
 		},
 	})
 }

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -3443,6 +3443,7 @@ func init_processlist() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  97,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3732,6 +3733,7 @@ func init_processlist() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 10,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -3943,6 +3945,7 @@ func init_processlist() {
 				return result
 				return result
 			},
+			JITInlineCost: 16,
 		},
 	})
 }

--- a/scm/scheduler.go
+++ b/scm/scheduler.go
@@ -261,6 +261,7 @@ func init_scheduler() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["setTimeout"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -561,6 +562,7 @@ func init_scheduler() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  15,
 		},
 	})
 }

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1069,6 +1069,7 @@ func init() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	optimizerTelemetryType := &TypeDescriptor{Kind: "assoc", Keys: map[string]*TypeDescriptor{
@@ -1552,6 +1553,7 @@ func init() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  14,
 		},
 		Optimize: func(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer, *TypeDescriptor) {
 			if len(v) == 2 {
@@ -2624,6 +2626,7 @@ func init() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  22,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2652,6 +2655,7 @@ func init() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["try"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2794,6 +2798,7 @@ func init() {
 				return result
 				return result
 			},
+			JITInlineCost: 9,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -4288,6 +4293,7 @@ func init() {
 				return result
 				return result
 			},
+			JITInlineCost: 68,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -4439,6 +4445,7 @@ func init() {
 				return result
 				return result
 			},
+			JITInlineCost: 5,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -5654,6 +5661,7 @@ func init() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      32,
 		},
 		Optimize:                 FirstParameterMutable("for_mut"),
 		OptimizeFirstArgTransfer: true,
@@ -6844,6 +6852,7 @@ func init() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      26,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -6939,6 +6948,7 @@ func init() {
 				return result
 				return result
 			},
+			JITInlineCost: 5,
 		},
 	})
 	DeclareSpecialForm(&Globalenv, &Declaration{
@@ -7232,6 +7242,7 @@ Patterns can be any of:
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  29,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -7248,6 +7259,7 @@ Patterns can be any of:
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["source_coverage_report"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -13732,6 +13744,7 @@ Patterns can be any of:
 				ctx.FreeStack(int32(16))
 				return result
 			},
+			JITInlineCost: 2046,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -13814,6 +13827,7 @@ Patterns can be any of:
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  5,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -14274,6 +14288,7 @@ Patterns can be any of:
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  16,
 		},
 	})
 

--- a/scm/sql_literals.go
+++ b/scm/sql_literals.go
@@ -249,6 +249,7 @@ func declareSQLLiteralParameterizer() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  20,
 		},
 	})
 }

--- a/scm/streams.go
+++ b/scm/streams.go
@@ -281,6 +281,7 @@ func init_streams() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -311,6 +312,7 @@ func init_streams() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["gzip"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -344,6 +346,7 @@ func init_streams() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["xz"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1121,6 +1124,7 @@ func init_streams() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1898,6 +1902,7 @@ func init_streams() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 }

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -3684,6 +3684,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  8,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -12166,6 +12167,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  29,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -12348,6 +12350,7 @@ func init_strings() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -13062,6 +13065,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 25,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -16700,6 +16704,7 @@ func init_strings() {
 				ctx.FreeStack(int32(32))
 				return result
 			},
+			JITInlineCost: 51,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -16851,6 +16856,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 5,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -16971,6 +16977,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 7,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -18991,6 +18998,7 @@ func init_strings() {
 				ctx.FreeStack(int32(16))
 				return result
 			},
+			JITInlineCost: 51,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -19682,6 +19690,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -19807,6 +19816,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -19932,6 +19942,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -22004,6 +22015,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 69,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -22129,6 +22141,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -22283,6 +22296,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -22437,6 +22451,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	// SQL-level NULL-safe wrappers for TRIM/LTRIM/RTRIM
@@ -22797,6 +22812,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -23187,6 +23203,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -23577,6 +23594,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -24957,6 +24975,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  28,
 		},
 	})
 
@@ -25629,6 +25648,7 @@ func init_strings() {
 				ctx.ResolveFixups()
 				return result
 			},
+			JITInlineCost: 22,
 		},
 	})
 
@@ -25891,6 +25911,7 @@ func init_strings() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["collate"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 
@@ -26018,6 +26039,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26143,6 +26165,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26523,6 +26546,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -26848,6 +26872,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  13,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -28694,6 +28719,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  49,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -28743,6 +28769,7 @@ func init_strings() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -29257,6 +29284,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  14,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -29716,6 +29744,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  13,
 		},
 	})
 
@@ -29901,6 +29930,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  14,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -30310,6 +30340,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  21,
 		},
 	})
 	sql_escapings := regexp.MustCompile("\\\\[\\\\'\"nr0]")
@@ -30347,6 +30378,7 @@ func init_strings() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["sql_unescape"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -31379,6 +31411,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  29,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -32411,6 +32444,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  29,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -32798,6 +32832,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  20,
 		},
 	})
 
@@ -33108,6 +33143,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  17,
 		},
 	})
 
@@ -33929,6 +33965,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  30,
 		},
 	})
 
@@ -34768,6 +34805,7 @@ func init_strings() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      27,
 		},
 		Optimize: optimizeRegexpReplace,
 	})
@@ -34895,6 +34933,7 @@ func init_strings() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 		Optimize: optimizeFNVHash,
 	})
@@ -36183,6 +36222,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  33,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -36389,6 +36429,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -36593,6 +36634,7 @@ func init_strings() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  19,
 		},
 	})
 
@@ -37585,6 +37627,7 @@ func init_strings() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: true,
+			JITInlineCost:      28,
 		},
 		Optimize: optimizeRegexpTest,
 	})

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -1602,6 +1602,7 @@ func init_sync() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  51,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1811,6 +1812,7 @@ func init_sync() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1954,6 +1956,7 @@ func init_sync() {
 				return result
 				return result
 			},
+			JITInlineCost: 6,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1971,6 +1974,7 @@ func init_sync() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -1997,6 +2001,7 @@ func init_sync() {
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2237,6 +2242,7 @@ func init_sync() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2288,6 +2294,7 @@ func init_sync() {
 				return jitEmitGoVariadicCallFromDescs(ctx, declarations["mutex"].Fn, args, result)
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2328,6 +2335,7 @@ func init_sync() {
 				return result
 				return result
 			},
+			JITInlineCost: 4,
 		},
 	})
 	Declare(&Globalenv, &Declaration{
@@ -2574,6 +2582,7 @@ func init_sync() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  36,
 		},
 	})
 }

--- a/scm/timezone.go
+++ b/scm/timezone.go
@@ -1078,6 +1078,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  24,
 		},
 	})
 
@@ -1169,6 +1170,7 @@ func init_timezone() {
 				return result
 				return result
 			},
+			JITInlineCost: 4,
 		},
 	})
 
@@ -6257,6 +6259,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  76,
 		},
 	})
 
@@ -11633,6 +11636,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  158,
 		},
 	})
 
@@ -12006,6 +12010,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  5,
 		},
 	})
 
@@ -12466,6 +12471,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  10,
 		},
 	})
 
@@ -12986,6 +12992,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  12,
 		},
 	})
 
@@ -13347,6 +13354,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  4,
 		},
 	})
 
@@ -17444,6 +17452,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  83,
 		},
 	})
 
@@ -26903,6 +26912,7 @@ func init_timezone() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  130,
 		},
 	})
 }

--- a/scm/vector.go
+++ b/scm/vector.go
@@ -7899,6 +7899,7 @@ func init_vector() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  80,
 		},
 	})
 }

--- a/scm/window.go
+++ b/scm/window.go
@@ -238,6 +238,7 @@ func init_window() {
 				return result
 				return result
 			},
+			JITInlineCost: 12,
 		},
 	})
 
@@ -1742,6 +1743,7 @@ func init_window() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  65535,
 		},
 	})
 
@@ -7705,6 +7707,7 @@ func init_window() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  81,
 		},
 	})
 
@@ -11738,6 +11741,7 @@ func init_window() {
 				return result
 			},
 			JITVirtualArgs: true,
+			JITInlineCost:  62,
 		},
 	})
 }

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -54,6 +54,7 @@ var doPatch bool
 var doWipe bool
 var verbose bool
 var missingOnly bool
+var policyOnly bool
 var jobs = runtime.GOMAXPROCS(0)
 
 const generatedBanner = "/* DO NEVER MANUALLY EDIT THIS SECTION. RUN make jitgen TO UPDATE */"
@@ -75,6 +76,8 @@ func main() {
 			doWipe = true
 		} else if arg == "-missing-only" {
 			missingOnly = true
+		} else if arg == "-policy-only" {
+			policyOnly = true
 		} else if arg == "-v" || arg == "--verbose" {
 			verbose = true
 		} else if strings.HasPrefix(arg, "-jobs=") {
@@ -89,7 +92,7 @@ func main() {
 		}
 	}
 	if len(files) == 0 {
-		fmt.Fprintf(os.Stderr, "usage: jitgen [-dump=OP] [-patch] [-missing-only] [-wipe] [-jobs=N] <file.go> ...\n")
+		fmt.Fprintf(os.Stderr, "usage: jitgen [-dump=OP] [-patch] [-missing-only] [-policy-only] [-wipe] [-jobs=N] <file.go> ...\n")
 		os.Exit(1)
 	}
 
@@ -259,6 +262,10 @@ func main() {
 			}
 			newText = generateFallbackClosure(op.name)
 		}
+		inlineCost := generation.inlineCost
+		if usesFallback || usesNativeCall {
+			inlineCost = math.MaxUint16
+		}
 		// Declaration emitters are expressions nested one indentation level below
 		// their TypeDescriptor field. Keep generated output gofmt-stable both when
 		// inserting a new JITEmit field and when replacing an existing closure.
@@ -266,6 +273,18 @@ func main() {
 
 		if doPatch {
 			if missingOnly && !operatorJITEmitMissing(op) {
+				continue
+			}
+			if policyOnly {
+				costText := strconv.FormatUint(uint64(inlineCost), 10)
+				if op.jitInlineCostExpr != nil {
+					pos := fset.Position(op.jitInlineCostExpr.Pos())
+					end := fset.Position(op.jitInlineCostExpr.End())
+					patches[op.path] = append(patches[op.path], patchEntry{startOff: pos.Offset, endOff: end.Offset, newText: costText, opName: op.name + ".JITInlineCost"})
+				} else if op.typeInsertPos.IsValid() {
+					insertPos := fset.Position(op.typeInsertPos)
+					patches[op.path] = append(patches[op.path], patchEntry{startOff: insertPos.Offset, endOff: insertPos.Offset, newText: "\tJITInlineCost: " + costText + ",\n\t\t", opName: op.name + ".JITInlineCost"})
+				}
 				continue
 			}
 			var pos, end token.Position
@@ -323,11 +342,23 @@ func main() {
 					patches[op.path] = append(patches[op.path], patchEntry{startOff: insertPos.Offset, endOff: insertPos.Offset, newText: "\tJITInlineCallbacks: " + value + ",\n\t\t", opName: op.name + ".JITInlineCallbacks"})
 				}
 			}
+			costText := strconv.FormatUint(uint64(inlineCost), 10)
+			if op.jitInlineCostExpr != nil {
+				pos := fset.Position(op.jitInlineCostExpr.Pos())
+				end := fset.Position(op.jitInlineCostExpr.End())
+				patches[op.path] = append(patches[op.path], patchEntry{startOff: pos.Offset, endOff: end.Offset, newText: costText, opName: op.name + ".JITInlineCost"})
+			} else if op.typeInsertPos.IsValid() {
+				insertPos := fset.Position(op.typeInsertPos)
+				patches[op.path] = append(patches[op.path], patchEntry{startOff: insertPos.Offset, endOff: insertPos.Offset, newText: "\tJITInlineCost: " + costText + ",\n\t\t", opName: op.name + ".JITInlineCost"})
+			}
 		}
 	}
 
 	// Process each storage type (pattern 2: ColumnStorage.GetValue → JITEmit)
 	for _, si := range stInfos {
+		if policyOnly {
+			continue
+		}
 		if onlyOp != "" && si.typeName != onlyOp && si.typeName+".GetValue" != onlyOp {
 			continue
 		}
@@ -375,9 +406,10 @@ func main() {
 }
 
 type operatorGeneration struct {
-	ssaFn   *ssa.Function
-	newText string
-	genErr  string
+	ssaFn      *ssa.Function
+	newText    string
+	genErr     string
+	inlineCost uint16
 }
 
 func generateOperators(ops []operatorInfo, ssaFuncs map[token.Pos]*ssa.Function, ssaFuncsByName map[string]*ssa.Function) []operatorGeneration {
@@ -405,7 +437,7 @@ func generateOperators(ops []operatorInfo, ssaFuncs map[token.Pos]*ssa.Function,
 				}
 				result := operatorGeneration{ssaFn: fn}
 				if fn != nil {
-					result.newText, result.genErr = generateClosure(op.name, fn, nil, op.path)
+					result.newText, result.genErr, result.inlineCost = generateClosureCost(op.name, fn, nil, op.path)
 					if result.genErr == "" {
 						if _, err := parser.ParseExpr(result.newText); err != nil {
 							result.genErr = "generated invalid Go expression: " + err.Error()
@@ -618,6 +650,7 @@ type operatorInfo struct {
 	jitExpr                ast.Expr
 	jitVirtualExpr         ast.Expr
 	jitInlineCallbacksExpr ast.Expr
+	jitInlineCostExpr      ast.Expr
 	jitInsertPos           token.Pos
 	typeInsertPos          token.Pos
 	preservedEnd           int
@@ -657,7 +690,7 @@ func collectOperators(fset *token.FileSet, f *ast.File, path string) []operatorI
 			return true
 		}
 
-		var nameExpr, fnExpr, jitExpr, jitVirtualExpr, jitInlineCallbacksExpr ast.Expr
+		var nameExpr, fnExpr, jitExpr, jitVirtualExpr, jitInlineCallbacksExpr, jitInlineCostExpr ast.Expr
 		var jitInsertPos token.Pos
 		var typeInsertPos token.Pos
 		if len(comp.Elts) > 0 {
@@ -674,6 +707,7 @@ func collectOperators(fset *token.FileSet, f *ast.File, path string) []operatorI
 						jitExpr = keyedValue(typeComp, "JITEmit")
 						jitVirtualExpr = keyedValue(typeComp, "JITVirtualArgs")
 						jitInlineCallbacksExpr = keyedValue(typeComp, "JITInlineCallbacks")
+						jitInlineCostExpr = keyedValue(typeComp, "JITInlineCost")
 						typeInsertPos = typeComp.Rbrace
 						if jitExpr == nil {
 							jitInsertPos = typeComp.Rbrace
@@ -707,6 +741,7 @@ func collectOperators(fset *token.FileSet, f *ast.File, path string) []operatorI
 			jitExpr:                jitExpr,
 			jitVirtualExpr:         jitVirtualExpr,
 			jitInlineCallbacksExpr: jitInlineCallbacksExpr,
+			jitInlineCostExpr:      jitInlineCostExpr,
 			jitInsertPos:           jitInsertPos,
 			typeInsertPos:          typeInsertPos,
 		})
@@ -3718,7 +3753,12 @@ func (g *codeGen) emitBody(cfg emitBodyConfig) {
 	g.emit("return result")
 }
 
-func generateClosure(opName string, fn *ssa.Function, rewrite ssaValueRewriter, sourcePath ...string) (code string, errMsg string) {
+func generateClosure(opName string, fn *ssa.Function, rewrite ssaValueRewriter, sourcePath ...string) (string, string) {
+	code, errMsg, _ := generateClosureCost(opName, fn, rewrite, sourcePath...)
+	return code, errMsg
+}
+
+func generateClosureCost(opName string, fn *ssa.Function, rewrite ssaValueRewriter, sourcePath ...string) (code string, errMsg string, inlineCost uint16) {
 	defer func() {
 		if r := recover(); r != nil {
 			if os.Getenv("JITGEN_DEBUG_PANIC") == "1" && (dumpOp == "" || dumpOp == opName) {
@@ -3726,6 +3766,7 @@ func generateClosure(opName string, fn *ssa.Function, rewrite ssaValueRewriter, 
 			}
 			code = ""
 			errMsg = fmt.Sprintf("%v", r)
+			inlineCost = 0
 		}
 	}()
 
@@ -3772,7 +3813,11 @@ func generateClosure(opName string, fn *ssa.Function, rewrite ssaValueRewriter, 
 	guard := fmt.Sprintf("\tif !jitEnabled {\n\t\treturn jitEmitGoVariadicCallFromDescs(ctx, declarations[%q].Fn, args, result)\n\t}\n", opName)
 	result := fmt.Sprintf("func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {\n%s%s%s\t\t}",
 		guard, g.wDecl.String(), injectBindRegCalls(g.w.String()))
-	return result, ""
+	cost := inlineInstructionCount(fn) + g.inlineInstructions
+	if cost >= math.MaxUint16 {
+		cost = math.MaxUint16 - 1
+	}
+	return result, "", uint16(cost)
 }
 
 // generateStorageBody generates the body of a JITEmit method from GetValue SSA.


### PR DESCRIPTION
## Summary

- make builtin lowering choose between generated inline code and a compact native Go call
- keep the combined Scheme control-flow tree and all special forms in JIT code
- always prefer recursive emission for known higher-order callbacks, while unknown callbacks keep the native Go loop
- generate an architecture-neutral SSA cost for every builtin and cap cumulative builtin expansion per compiled Scheme function
- preserve virtual-list fusion and use exact type/shape facts when they eliminate dynamic paths
- add a metadata-only jitgen target so cost regeneration does not rewrite roughly 90,000 unrelated generated emitter lines; the regular jitgen target and its complete storage file list remain unchanged

The policy contains no builtin-name special cases. Jitgen records the builtin SSA instruction count plus recursively inlined Go helpers. Generated native-call boundaries use a sentinel cost. The common Scheme compiler evaluates cost, exact type facts, list shape, callback visibility, virtual arguments, and the per-function expansion budget before selecting the emitter or direct-call path.

## Query-tree verification

I imported the complete planner stack with the patched Go compiler, explicitly compiled the planner procedures, copied the emitted machine code, and disassembled it as raw x86-64.

The representative planner functions remain native control-flow graphs rather than Eval thunks:

| Function | master instructions / calls / jumps | this PR instructions / calls / jumps |
| --- | ---: | ---: |
| `reorder_query_block_with_candidate_strategy_using` | 8,384 / 150 / 173 | 8,415 / 151 / 173 |
| `lower_query_block_core` | 1,645 / 37 / 30 | 1,483 / 33 / 22 |
| `prelimit_sources_for` | 1,665 / 29 / 25 | 1,610 / 28 / 21 |
| `neumann_compile_pipeline` | 619 / 15 / 0 | 619 / 15 / 0 |

The policy also reduces compile-time register pressure: automatic planner import installed 313 JIT procedures instead of 271 on the exact base commit. Installed inner lambdas increased from 39 to 62. Explicit planner compilation still reports unsupported individual helper shapes, but the complete outer reorder/lower/build trees above compile and retain their native branches and inner procedure propagation.

## Manual A/B measurements

Machine: AMD Ryzen 9 7900X3D, linux/amd64. Both sides used the patched `../go-jit` compiler. Baseline was exact PR base `3d1bfc370`; candidate was `0e3cb4edc`. Identical fixtures, process setup, warmup behavior, and sample counts were used on both sides.

### Micro: known callback

`BenchmarkJITKnownMapCallback`, 128 integers, lambda `(+ value 1)`, 8 samples:

| Path | Time | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| master emitted callback | 2,454.9 ns | 2,368 | 4 |
| policy emitted callback | 1,870.9 ns | 2,368 | 4 |
| policy forced native builtin call | 14,934.0 ns | 13,989 | 164 |

The selected known-callback path is 23.8% faster than master and 7.98x faster than the forced call boundary.

Additional policy probes showed why partial dynamic cases should remain calls:

- unknown runtime `map` callback: native loop about 4.29 us versus about 5.33 us for generic inline expansion, with 221 versus 631 code bytes
- partially typed `+`: native call about 23.5 ns versus about 28.0 ns inline, with 207 versus 996 code bytes
- the same partially typed `+` inside a known `map` lambda: call about 1.87 us versus about 2.04 us inline, with 663 versus 1,453 code bytes

### Cold SQL compile, prepared execution, and end-to-end

SQL fixture: `SELECT 1 AS n UNION ALL SELECT 2 AS n UNION ALL SELECT 3 AS n`. Eight samples per side; compile and end-to-end use a fresh parse/plan on every iteration, while execution reuses one prepared formula.

| Measurement | master | this PR | Change |
| --- | ---: | ---: | ---: |
| SQL compile | 2.426 ms, 3,023,544 B, 36,106 allocs | 2.406 ms, 3,015,202 B, 35,985 allocs | -0.83% |
| prepared execution | 778.4 ns, 736 B, 9 allocs | 753.7 ns, 736 B, 9 allocs | -3.17% |
| cold end-to-end | 2.411 ms, 3,023,925 B, 36,114 allocs | 2.429 ms, 3,015,907 B, 35,994 allocs | +0.73% |

The end-to-end delta is within run noise, while compilation allocates less and prepared execution improves.

## Verification

- `make jitgen-policy` twice produced an identical diff
- `go test ./scm ./tools/jitgen`
- patched compiler: `go build ./...`
- patched compiler planner import/inventory/disassembly test
- patched compiler callback and SQL A/B benchmarks above

Two pre-existing local failures reproduce unchanged on the exact base commit:

- patched `go test ./scm` has an old assertion expecting one dynamic `reduce` callback, although #704 now successfully emits that callback (`DynamicCalls: 0`); this PR deliberately does not modify the unit test
- vanilla `go test ./storage` faults in the existing cursor rollback/reload test on both base and candidate; CI remains the authoritative full-suite run
