### PR TITLE
Fix transactionless group cache initialization

### DIFF
--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -6467,7 +6467,7 @@ the costgen threshold. */
 					($update (list "accumulated_ns"
 						(if build 0 next_accumulated_ns)))
 					true))
-			false)
+			false nil nil)
 		(claim "build"))))
 
 (define group_cache_candidate_delete (lambda (current_tx canonical_name)

--- a/storage/cache_initializer.go
+++ b/storage/cache_initializer.go
@@ -26,9 +26,11 @@ type cacheInitializerRun struct {
 
 // initializeCache runs initialize exactly once for the lifetime of a canonical
 // planner cache. Concurrent callers share both completion and failure. A later
-// call retries after a failed run. The caller must pass the owning query session
-// explicitly because initialization may begin inside a shard worker.
-func (t *table) initializeCache(ss *scm.SessionState, initialize func()) (initialized bool) {
+// call retries after a failed run. A SQL query passes its owning query session.
+// Internal cache builders deliberately run outside a client query; for those,
+// use one unregistered SessionState solely as the table-lock owner for the
+// lifetime of this initialization. It is not process-list or cancellation state.
+func (t *table) initializeCache(ss *scm.SessionState, initialize func(*scm.SessionState)) (initialized bool) {
 	if !strings.HasPrefix(t.Name, ".") {
 		panic("cache initialization requires a dot-prefixed cache table")
 	}
@@ -50,8 +52,7 @@ func (t *table) initializeCache(ss *scm.SessionState, initialize func()) (initia
 		done: make(chan struct{}),
 	}
 	if ss == nil {
-		t.cacheInitMu.Unlock()
-		panic("cache initialization requires a query session")
+		ss = &scm.SessionState{}
 	}
 	t.cacheInitializerRun = run
 	t.cacheInitMu.Unlock()
@@ -72,6 +73,6 @@ func (t *table) initializeCache(ss *scm.SessionState, initialize func()) (initia
 		}
 	}()
 
-	initialize()
+	initialize(ss)
 	return true
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2931,10 +2931,11 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			currentTx := scmerToTxContext(a[0])
 			tbl := TableFromScmer(a[1])
-			// Cache preparation can execute inside a shard worker. Like every scan
-			// operator, it receives transaction and session ownership explicitly.
+			// Client-query cache preparation carries its lock owner through the
+			// transaction. An internal transactionless builder receives a local,
+			// unregistered lock owner from initializeCache instead.
 			ss := SessionStateFromTx(currentTx)
-			initialized := tbl.initializeCache(ss, func() {
+			initialized := tbl.initializeCache(ss, func(lockOwner *scm.SessionState) {
 				sources := mustScmerSlice(a[2], "source tables")
 				sourceTables := make([]*table, len(sources))
 				for i, source := range sources {
@@ -2953,7 +2954,7 @@ func Init(en scm.Env) {
 					}
 				}()
 				for _, source := range sourceTables {
-					unlocks = append(unlocks, acquireTableLock(source.schema.Name, source.Name, false, true, ss, querySeqFromTx(currentTx)))
+					unlocks = append(unlocks, acquireTableLock(source.schema.Name, source.Name, false, true, lockOwner, querySeqFromTx(currentTx)))
 				}
 				// Install maintenance while source writes are blocked. Once the
 				// locks are released, every later mutation observes the triggers.

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -20,6 +20,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS `.creation_barrier`"
+  - sql: "DROP TABLE IF EXISTS `.transactionless_cache_init`"
   - sql: "DROP TABLE IF EXISTS aggregate_source"
   - sql: |
       CREATE TABLE aggregate_source (
@@ -29,6 +30,36 @@ setup:
       )
 
 test_cases:
+  - name: "Internal cache initialization needs no client query session"
+    scm: |
+      (begin
+        (define cache
+          (createtable
+            "memcp-tests"
+            ".transactionless_cache_init"
+            (list (list "column" "id" "int" (list) (list)))
+            (list "engine" "cache")
+            true nil))
+        (initialize_cache_table nil
+          (table "memcp-tests" ".transactionless_cache_init")
+          (list (table "memcp-tests" "aggregate_source"))
+          (lambda () true)
+          (lambda ()
+            (insert
+              (table "memcp-tests" ".transactionless_cache_init")
+              (list "id")
+              (list (list 1))
+              (list)
+              (lambda () true)
+              false nil nil)))
+        (scan nil
+          (table "memcp-tests" ".transactionless_cache_init")
+          (list) (lambda () true)
+          (list) (lambda () 1)
+          + 0))
+    expect:
+      data: [1]
+
   - name: "Duplicate logical stage IDs retain every aggregate extension"
     scm: |
       (begin
@@ -170,4 +201,5 @@ test_cases:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS `.creation_barrier`"
+  - sql: "DROP TABLE IF EXISTS `.transactionless_cache_init`"
   - sql: "DROP TABLE IF EXISTS aggregate_source"

--- a/tests/sql/compatibility/mysql-error-recovery.yaml
+++ b/tests/sql/compatibility/mysql-error-recovery.yaml
@@ -59,3 +59,15 @@ test_cases:
             rows: 1
             data:
               - ok: 1
+
+  - name: "MySQL connection survives cold user count cache setup"
+    mysql:
+      statements:
+        - sql: "SELECT COUNT(*) AS user_count FROM system.user"
+          expect:
+            rows: 1
+        - sql: "SELECT 1 AS ok"
+          expect:
+            rows: 1
+            data:
+              - ok: 1


### PR DESCRIPTION
## Summary

- allow internal canonical group-cache initialization without a client query session
- use an unregistered, initializer-local `SessionState` only as the source-table lock owner
- keep the group-cache amortization counter explicitly transactionless (`tx=nil`)
- protect the reported cold MySQL `COUNT(*)` path and subsequent statements on the same connection

## Root cause

The direct-group amortization counter intentionally performs an internal write outside the user's transaction. Once it crossed the build threshold, the asynchronous cache builder could reach `initialize_cache_table` with a valid internal transaction but no client `SessionState`. `initializeCache` rejected that state before acquiring the source snapshot locks, producing HTTP/MySQL error 500: `cache initialization requires a query session`.

The initializer does not need process-list membership or user-query cancellation. It only needs a unique identity while holding its source-table READ locks. This change creates that identity locally for transactionless initialization; normal SQL queries continue using the `SessionState` carried by their explicit transaction.

## Verification

- unchanged master: the new initializer regression fails with the exact reported error
- patched branch: `tests/execution/concurrency/group-cache-initialization.yaml` passes 19/19
- patched branch: `tests/sql/compatibility/mysql-error-recovery.yaml` passes 3/3
- MySQL regression executes `SELECT COUNT(*) FROM system.user` and then `SELECT 1` on the same connection
- `go build -buildvcs=false -o memcp` passes
- Scheme formatter and check completed
