### PR TITLE
Cache query plans as explicit JIT-ready callables

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -259,7 +259,7 @@ query generation is the scope that releases them after execution. */
 		(list (quote tx_query) (quote tx))
 		"__memcp_queryplan_observations"
 		(quote tx)
-		(list (quote lambda) '() (list (quote newsession))))))
+		(list (quote lambda) (list (quote tx)) (list (quote newsession))))))
 
 (define planner_queryplan_observation_read_expr (lambda (key)
 	(list
@@ -269,7 +269,7 @@ query generation is the scope that releases them after execution. */
 			(physical_query_scope_symbol)
 			"__memcp_queryplan_observations"
 			(quote tx)
-			(list (quote lambda) '() (list (quote newsession))))
+			(list (quote lambda) (list (quote tx)) (list (quote newsession))))
 		key)))
 
 (define planner_queryplan_observation_current_read_expr (lambda (key)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1765,30 +1765,33 @@ the emitter and failing after the ordinary carrier has been discarded. */
 		(define lookup_key (recset_scalar_first_probe_lookup_key stage))
 		(define lookup_value (symbol (concat "__recset_lookup_value_"
 			(fnv_hash (gs_id stage)))))
+		(define lookup_expr (list (quote apply)
+			(list
+				(physical_query_session_symbol)
+				"get_or_compute_scoped"
+				(physical_query_scope_symbol)
+				lookup_key
+				(quote tx)
+				(list (quote lambda) '()
+					(list (quote recset_key_index)
+						(physical_query_tx_symbol)
+						(cadr source_parts)
+						(quoted_runtime_list (nth source_parts 2)))))
+			(list (quote list) lookup_value)))
 		/* Bind the consumer-row key before entering the producer begin. begin owns a
 		shared numbered scope, while scan adapters may close the producer callbacks
 		independently. Lowering the row key inside that scope would bake its extra
 		outer hop into the cached producer and can escape the actual row closure when
-		several correlated projections share one continuation. The explicit value
-		parameter keeps producer construction closed and makes lexical ownership
-		independent of the surrounding projection shape. */
+		several correlated projections share one continuation. Do not emit that scope
+		when preparation is the literal no-op true: removing it only after nested
+		callbacks were optimized would leave their outer depths one level too large.
+		The explicit value parameter keeps producer construction closed and makes
+		lexical ownership independent of the surrounding projection shape. */
 		(list
 			(list (quote lambda) (list lookup_value)
-				(list (quote begin)
-					(car source_parts)
-					(list (quote apply)
-						(list
-							(physical_query_session_symbol)
-							"get_or_compute_scoped"
-							(physical_query_scope_symbol)
-							lookup_key
-							(quote tx)
-							(list (quote lambda) '()
-								(list (quote recset_key_index)
-									(physical_query_tx_symbol)
-									(cadr source_parts)
-									(quoted_runtime_list (nth source_parts 2)))))
-						(list (quote list) lookup_value))))
+				(if (equal? (car source_parts) true)
+					lookup_expr
+					(list (quote begin) (car source_parts) lookup_expr)))
 			resolved_lookup_key))))
 
 /* Once the consuming scan has selected the RecSet alternative, project the

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -1176,7 +1176,7 @@ both names therefore bind to the same parameter. */
 						(concat (scalar_query_probe_recipe_key stage requested_col) ":")
 						(list (quote serialize) (cons (quote list) params)))
 					(quote tx)
-					(list (quote lambda) '() probe_expr))
+					(list (quote lambda) (list (quote tx)) probe_expr))
 				probe_expr))
 			(list
 				(quote define)
@@ -1491,7 +1491,7 @@ membership set. */
 		(physical_query_scope_symbol)
 		(stage_prepare_key stage)
 		(quote tx)
-		(list (quote lambda) '()
+		(list (quote lambda) (list (quote tx))
 			(list (quote !begin)
 				(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
 				true)))))
@@ -1698,7 +1698,7 @@ the emitter and failing after the ordinary carrier has been discarded. */
 				(physical_query_scope_symbol)
 				(concat "__direct_boolean_recset_" (fnv_hash (gs_id stage)))
 				(quote tx)
-				(list (quote lambda) '() producer))
+				(list (quote lambda) (list (quote tx)) producer))
 			producer))))
 
 (define scalar_first_probe_recset_source_parts (lambda (all_stages stage requested_col share_result allow_direct_presence planning_session)
@@ -1772,7 +1772,7 @@ the emitter and failing after the ordinary carrier has been discarded. */
 				(physical_query_scope_symbol)
 				lookup_key
 				(quote tx)
-				(list (quote lambda) '()
+				(list (quote lambda) (list (quote tx))
 					(list (quote recset_key_index)
 						(physical_query_tx_symbol)
 						(cadr source_parts)
@@ -1877,7 +1877,7 @@ would still have to project that value over the segment. */
 		(physical_query_scope_symbol)
 		(query_invariant_scalar_first_probe_key stage requested_col)
 		(quote tx)
-		(list (quote lambda) '() expr))))
+		(list (quote lambda) (list (quote tx)) expr))))
 
 (define lower_table_scalar_first_probe_expr (lambda (sources default_alias src stage value_expr keys lookup_keys order_exprs dirs offset_value partition_limit tx_expr)
 	(begin
@@ -2013,7 +2013,7 @@ would still have to project that value over the segment. */
 					(concat (query_invariant_scalar_first_probe_key stage requested_col) ":bound:")
 					(list (quote serialize) (cons (quote list) lowered_lookup_keys)))
 				(quote tx)
-				(list (quote lambda) '() lowered))
+				(list (quote lambda) (list (quote tx)) lowered))
 			lowered))
 		(if (scalar_first_probe_query_invariant? stage requested_col)
 			(lower_query_invariant_scalar_first_probe_expr stage requested_col memoized_lowered)
@@ -3519,7 +3519,7 @@ still rechecks current data and autoindex statistics. */
 			(list (quote tx_query) (quote tx))
 			key
 			(quote tx)
-			(list (quote lambda) '() estimate_expr)))))
+			(list (quote lambda) (list (quote tx)) estimate_expr)))))
 
 /* Recreate only the source-local statistic read used for carrier costing. The
 expression is emitted into the cache guard and evaluated against the current
@@ -5323,7 +5323,7 @@ ever-larger subtrees. */
 						(physical_query_scope_symbol)
 						(concat "__group_count_recset_" (stable_structural_hash membership_expr true))
 						(quote tx)
-						(list (quote lambda) '() membership_expr)))
+						(list (quote lambda) (list (quote tx)) membership_expr)))
 				(list (quote scan)
 					/* Computed group columns outlive the request which creates them.
 					applyWithTx rebinds this captured physical slot to the transaction of

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1514,7 +1514,7 @@ outer joins. */
 			(quote !begin)
 			(merge (list ensure_agg_columns agg_plans computed_order_plans))))
 		(define base_group_fill (symbol "__group_base_fill"))
-		(define base_group_fill_call (list base_group_fill))
+		(define base_group_fill_call (list base_group_fill (physical_query_tx_symbol)))
 		(define finalize_group_fill (list (quote rebuild) (list (quote table) schema grouptbl) true false))
 		(define partition_plan (group_cache_partition_plan schema tbl alias src grouptbl keys key_names))
 		(define initial_fill_expr (if (nil? base_group_into_plan)
@@ -1523,10 +1523,10 @@ outer joins. */
 				(physical_query_tx_symbol)
 				(list (quote table) schema grouptbl)
 				(list (quote list) (source_table_expr src))
-				(list (quote lambda) '()
+				(list (quote lambda) (list (physical_query_tx_symbol))
 					(cons (quote !begin) (filter (list partition_plan aggregate_prepare_expr cleanup_plan) (lambda (expr) (not (nil? expr))))))
 				base_group_fill
-				(list (quote lambda) '() finalize_group_fill))))
+				(list (quote lambda) (list (symbol "__group_finalize_tx")) finalize_group_fill))))
 		(define create_options (if (nil? initial_fill_expr)
 			(quoted_runtime_list '("engine" "cache"))
 			(list (quote list)
@@ -1605,7 +1605,7 @@ outer joins. */
 			lowered_plan
 			(list
 				(list (quote lambda) (list base_group_fill) lowered_plan)
-				(list (quote lambda) '() base_group_into_plan))))))
+				(list (quote lambda) (list (physical_query_tx_symbol)) base_group_into_plan))))))
 
 (define lower_orc_stage_prepare (lambda (stage)
 	(begin
@@ -7442,8 +7442,8 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 				(physical_query_tx_symbol)
 				table_expr
 				(cons (quote list) (map sources source_table_expr))
-				(list (quote lambda) '() (cons (quote !begin) (prejoin_trigger_registration_plans block table_name)))
-				(list (quote lambda) '() (prejoin_initial_fill_plan block table_name)))
+				(list (quote lambda) (list (physical_query_tx_symbol)) (cons (quote !begin) (prejoin_trigger_registration_plans block table_name)))
+				(list (quote lambda) (list (physical_query_tx_symbol)) (prejoin_initial_fill_plan block table_name)))
 			(cons (quote !begin) (prejoin_computed_column_plans block fields table_name))
 			(list (quote touch_keytable) table_expr)))
 		(list prepare_plan (prejoin_rewritten_block block fields table_name)))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -7340,7 +7340,9 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 (define prejoin_deferred_trigger (lambda (body)
 	(list (quote quote)
 		(list (quote deferred_trigger)
-			(list (quote lambda) (list (quote OLD) (quote NEW)) body)))))
+			(list (quote lambda)
+				(list (quote OLD) (quote NEW) (quote session) (physical_query_tx_symbol))
+				body)))))
 
 (define prejoin_create_trigger_plan (lambda (src name timing body)
 	(list (quote createtrigger)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -9480,9 +9480,9 @@ opaque implementation detail in EXPLAIN PHYSICAL. */
 (define physical_calibration_input (lambda (decision name)
 	(qassoc_get (qassoc_get decision "inputs" '()) name nil)))
 
-/* Execute one forced plan while shadowing resultrow with a bounded digest
-sink. The outer protocol callback receives only the calibration row, never the
-potentially large calibrated SELECT result. */
+/* Execute one forced plan with explicit result callbacks. The measured plan
+receives a bounded digest sink and a silent field sink, while the outer
+protocol callback receives only the calibration row. */
 (define physical_calibration_runtime_plan (lambda (plan decision variant estimated_ns operator_family suite_var)
 	(begin
 		(define decision_id (qassoc_get decision "decision_id" "unknown"))
@@ -9501,7 +9501,7 @@ potentially large calibrated SELECT result. */
 					(list (quote define) (quote __calibration_capture) (list (quote newsession)))
 					(list (quote __calibration_capture) "count" 0)
 					(list (quote __calibration_capture) "hash" "")
-					(list (quote define) (quote resultrow)
+					(list (quote define) (quote __calibration_resultrow)
 						(list (quote lambda) (list (quote __calibration_row))
 							(list (quote !begin)
 								(list (quote __calibration_capture) "count"
@@ -9512,7 +9512,10 @@ potentially large calibrated SELECT result. */
 										(list (quote serialize) (quote __calibration_row)))))
 								nil)))
 					(list (quote define) (quote __calibration_started_ns) (list (quote nanotime)))
-					plan
+					(list
+						(list (quote lambda) (list (quote resultrow) (quote resultfields)) plan)
+						(quote __calibration_resultrow)
+						(list (quote lambda) (list (quote __calibration_fields)) nil))
 					(list (quote define) (quote __calibration_whole_query_execution_ns)
 						(list (quote -) (list (quote nanotime)) (quote __calibration_started_ns)))
 					(list (quote define) (quote __calibration_rows) (list (quote __calibration_capture) "count"))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -329,6 +329,18 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 		((car parse_fn) schema parse_query policy planning_session tx)
 		(parse_fn schema parse_query policy))))
 
+/* Query plans are closed procedures rather than code evaluated in whichever
+execution environment happens to call them. Keep every request-local input in
+the parameter list: this prevents a cached plan from retaining the compiling
+request and makes the complete dispatcher eligible for native compilation.
+The Proc retains its optimized Scheme body, so cachemap memory accounting and
+serialization still see the complete plan. */
+(define sql_queryplan_compile_formula (lambda (formula)
+	(jit (close_procedure (eval (optimize (list
+		(quote lambda)
+		(list (quote session) (quote tx) (quote resultrow) (quote resultfields))
+		(source "SQL Query" 1 1 formula))))))))
+
 (define sql_compile_queryplan_variant (lambda (parse_fn schema parse_query policy source_session tx)
 	(begin
 		(tx_check tx)
@@ -339,7 +351,8 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 		/* Parsing includes logical and physical planning. Never spend optimizer
 		work or install a variant after its requesting context was cancelled. */
 		(tx_check tx)
-		(define plan (optimize raw_plan))
+		(define plan (sql_queryplan_compile_formula
+			(sql_queryplan_bind_execution_session raw_plan)))
 		(tx_check tx)
 		(list
 			(sql_queryplan_guard_from_session planning_session)
@@ -385,7 +398,8 @@ otherwise side-effect-free guard. */
 					false
 					(begin (prepared_catalog (car preparation) true) true)))))
 			(define tail_expr (sql_queryplan_formula_dispatch rest prepared_catalog miss_expr))
-			(define bound_plan (sql_queryplan_bind_execution_session (cadr variant)))
+			(define bound_plan (list (cadr variant)
+				(quote session) (quote tx) (quote resultrow) (quote resultfields)))
 			(define dispatch (if (equal? (car variant) true)
 				bound_plan
 				(list (quote if)
@@ -399,12 +413,11 @@ otherwise side-effect-free guard. */
 		_ miss_expr)))
 
 (define sql_queryplan_miss_expr (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy)
-	(list (quote eval)
-		(list (quote sql_queryplan_variant_miss)
-			queryplan_cache cache_key entry
-			(if (list? parse_fn) (list (quote quote) parse_fn) parse_fn)
-			schema parse_query policy
-			(quote session) (quote tx) (quote resultrow)))))
+	(list (quote sql_queryplan_variant_miss)
+		queryplan_cache cache_key entry
+		(if (list? parse_fn) (list (quote quote) parse_fn) parse_fn)
+		schema parse_query policy
+		(quote session) (quote tx) (quote resultrow) (quote resultfields))))
 
 (define sql_queryplan_formula (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy variants)
 	(begin
@@ -417,7 +430,8 @@ otherwise side-effect-free guard. */
 	(begin
 		(define recent_variants (sql_queryplan_recent_variants variants))
 		(entry "variants" recent_variants)
-		(entry "formula" (sql_queryplan_formula queryplan_cache cache_key entry parse_fn schema parse_query policy recent_variants))
+		(entry "formula" (sql_queryplan_compile_formula
+			(sql_queryplan_formula queryplan_cache cache_key entry parse_fn schema parse_query policy recent_variants)))
 		(entry "formula"))))
 
 (define sql_queryplan_new_entry (lambda (queryplan_cache cache_key parse_fn schema parse_query policy source_session tx)
@@ -445,27 +459,30 @@ otherwise side-effect-free guard. */
 the entry lock because another request may already have installed a matching
 variant. New variants are prepended so the most recent statistics regime wins
 the common guard-dispatch path. */
-(define sql_queryplan_variant_miss (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy session tx resultrow)
-	((entry "compile_lock") tx (lambda ()
-		(begin
-			(define current_variants (entry "variants"))
-			(define matching (sql_queryplan_matching_variant current_variants
-				session tx resultrow))
-			(if (not (nil? matching))
-				(cadr matching)
-				(begin
-					(define variant (sql_compile_queryplan_variant parse_fn schema parse_query policy session tx))
-					(define formula (sql_queryplan_install_variants queryplan_cache cache_key entry parse_fn schema parse_query policy
-						(cons variant current_variants)))
-					(queryplan_cache cache_key (list entry formula))
-					(cadr variant))))))))
+(define sql_queryplan_variant_miss (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy session tx resultrow resultfields)
+	(begin
+		(define formula ((entry "compile_lock") tx (lambda ()
+			(begin
+				(define current_variants (entry "variants"))
+				(define matching (sql_queryplan_matching_variant current_variants
+					session tx resultrow))
+				(if (not (nil? matching))
+					(entry "formula")
+					(begin
+						(define variant (sql_compile_queryplan_variant parse_fn schema parse_query policy session tx))
+						(define formula (sql_queryplan_install_variants queryplan_cache cache_key entry parse_fn schema parse_query policy
+							(cons variant current_variants)))
+						(queryplan_cache cache_key (list entry formula))
+						formula))))))
+		(formula session tx resultrow resultfields))))
 
 /* cached_parse: wraps SELECT planning with a lazy polymorphic Scheme plan
 cache. DDL, DML and transaction-control formulas retain the original exact
 cache path because their AST may intentionally operate on session state.
 cache_key = username:schema:view-generation:hash(query-shape), retaining policy
 isolation while sharing safe SELECT plans across literal variants. Each entry
-is a variadic if chain of guarded specialized plans plus one compile miss arm.
+is a compiled callable whose dispatcher contains guarded specialized plans and
+one compile-miss arm.
 On parse error the result is not cached. */
 /* Frontends defer the system.user lookup until a cache producer actually
 runs. A warm plan already owns its compiled policy and must not rescan the
@@ -509,7 +526,7 @@ user table merely to discard a newly constructed policy closure. */
 				(begin
 					(define resolved_policy (sql_policy_spec_resolve policy))
 					(define compile_policy (sql_compile_table_policy resolved_policy))
-					(optimize (sql_queryplan_bind_tx_calls
+					(sql_queryplan_compile_formula (sql_queryplan_bind_tx_calls
 						(sql_queryplan_bind_execution_session
 							(with_session session (lambda ()
 								(sql_invoke_parse_fn parse_fn schema parse_query compile_policy session compile_tx)))))))))
@@ -525,7 +542,7 @@ user table merely to discard a newly constructed policy closure. */
 			formula)))))
 
 (define sql_execute_formula (lambda (session tx formula resultrow resultfields)
-	(eval (source "SQL Query" 1 1 formula))))
+	(formula session tx resultrow resultfields)))
 
 /* helper: build a policy function for table-level access checks
 usage: create a policy by (set policy (sql_policy "username")),

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -174,7 +174,7 @@ functional planner return value. */
 			(tx_query tx)
 			"__memcp_queryplan_observations"
 			tx
-			(lambda () (newsession))))
+			(lambda (_tx) (newsession))))
 		(reduce (source_session) (lambda (_ key)
 			(if (match key (regex "^v[0-9]+$" _) true false)
 				(begin
@@ -413,11 +413,16 @@ otherwise side-effect-free guard. */
 		_ miss_expr)))
 
 (define sql_queryplan_miss_expr (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy)
-	(list (quote sql_queryplan_variant_miss)
-		queryplan_cache cache_key entry
-		(if (list? parse_fn) (list (quote quote) parse_fn) parse_fn)
-		schema parse_query policy
-		(quote session) (quote tx) (quote resultrow) (quote resultfields))))
+	/* The miss arm invokes the Scheme compiler, not query work. Keep that cold
+	boundary behind apply so optimizing the hot dispatcher cannot specialize and
+	re-optimize the compiler procedure against cache/session literal arguments. */
+	(list (quote apply)
+		(quote sql_queryplan_variant_miss)
+		(cons (quote list) (list
+			queryplan_cache cache_key entry
+			(if (list? parse_fn) (list (quote quote) parse_fn) parse_fn)
+			schema parse_query policy
+			(quote session) (quote tx) (quote resultrow) (quote resultfields))))))
 
 (define sql_queryplan_formula (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy variants)
 	(begin
@@ -461,20 +466,24 @@ variant. New variants are prepended so the most recent statistics regime wins
 the common guard-dispatch path. */
 (define sql_queryplan_variant_miss (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy session tx resultrow resultfields)
 	(begin
-		(define formula ((entry "compile_lock") tx (lambda ()
+		(define plan ((entry "compile_lock") tx (lambda ()
 			(begin
 				(define current_variants (entry "variants"))
 				(define matching (sql_queryplan_matching_variant current_variants
 					session tx resultrow))
+				/* Return the chosen plan directly. Re-entering entry.formula would
+				re-evaluate the guard which just missed and can recurse indefinitely;
+				another request's freshly installed matching variant is already safe to
+				execute under the current explicit request arguments. */
 				(if (not (nil? matching))
-					(entry "formula")
+					(cadr matching)
 					(begin
 						(define variant (sql_compile_queryplan_variant parse_fn schema parse_query policy session tx))
 						(define formula (sql_queryplan_install_variants queryplan_cache cache_key entry parse_fn schema parse_query policy
 							(cons variant current_variants)))
 						(queryplan_cache cache_key (list entry formula))
-						formula))))))
-		(formula session tx resultrow resultfields))))
+						(cadr variant)))))))
+		(plan session tx resultrow resultfields))))
 
 /* cached_parse: wraps SELECT planning with a lazy polymorphic Scheme plan
 cache. DDL, DML and transaction-control formulas retain the original exact

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -3175,6 +3175,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(define s1_scope_b (newsession))
 	(assert (s1 "get_or_compute_scoped" s1_scope_a "shared" (lambda () 7)) 123 "session: scoped compute reuses first scope")
 	(assert (s1 "get_or_compute_scoped" s1_scope_b "value" (lambda () 9)) 9 "session: scoped compute isolates scopes")
+	(define s1_explicit_tx (newsession))
+	(assert (equal?
+		(s1 "get_or_compute_scoped" s1_scope_b "explicit-tx" s1_explicit_tx (lambda (tx) tx))
+		s1_explicit_tx) true "session: transactional scoped producer receives explicit tx")
+	(assert (equal?
+		(s1 "get_or_compute_scoped" s1_scope_b "explicit-tx" nil (lambda (_tx) false))
+		s1_explicit_tx) true "session: transactional scoped compute reuses the first value")
 	(assert (equal? (try (lambda () (s1 "a" "b" "c")) (lambda (e) "caught")) "caught") true "session: too many args panics")
 
 	/* deep callback signature validation */

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1109,6 +1109,20 @@ func init() {
 		"callback_clones":   {Kind: "int"},
 	}}
 	Declare(&Globalenv, &Declaration{
+		Name: "close_procedure",
+
+		Fn: func(a ...Scmer) Scmer {
+			return CloseProcedure(a[0])
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "closes a procedure over explicit captures without retaining its creation environment",
+			Params: []*TypeDescriptor{
+				{Kind: "func", Label: "procedure", Description: "procedure to close"},
+			},
+			Return: &TypeDescriptor{Kind: "func"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "optimize",
 
 		Fn: func(a ...Scmer) Scmer {

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -237,7 +237,7 @@ func sessionEnsureScopedCleanup(sess *session, scope Scmer, ctx context.Context)
 	})
 }
 
-func sessionGetOrComputeScoped(sess *session, scope Scmer, key string, tx Scmer, producer Scmer) Scmer {
+func sessionGetOrComputeScoped(sess *session, scope Scmer, key string, tx Scmer, producer Scmer, passTx bool) Scmer {
 	computeKey := sessionScopedKey{scope: scope, key: key}
 	sess.Mu.Lock()
 	if value, ok := sess.ScopedValues[computeKey]; ok {
@@ -275,7 +275,11 @@ func sessionGetOrComputeScoped(sess *session, scope Scmer, key string, tx Scmer,
 				flight.failed = true
 			}
 		}()
-		flight.value = Apply(producer)
+		if passTx {
+			flight.value = Apply(producer, tx)
+		} else {
+			flight.value = Apply(producer)
+		}
 	}()
 
 	sess.Mu.Lock()
@@ -317,12 +321,12 @@ func NewSession(a ...Scmer) Scmer {
 			if a[0].String() != "get_or_compute_scoped" {
 				panic("session: unknown 4-argument operation")
 			}
-			return sessionGetOrComputeScoped(sess, a[1], a[2].String(), a[1], a[3])
+			return sessionGetOrComputeScoped(sess, a[1], a[2].String(), a[1], a[3], false)
 		case 5:
 			if a[0].String() != "get_or_compute_scoped" {
 				panic("session: unknown 5-argument operation")
 			}
-			return sessionGetOrComputeScoped(sess, a[1], a[2].String(), a[3], a[4])
+			return sessionGetOrComputeScoped(sess, a[1], a[2].String(), a[3], a[4], true)
 		case 1:
 			sess.Mu.RLock()
 			defer sess.Mu.RUnlock()
@@ -358,8 +362,8 @@ var sessionCallableType = &TypeDescriptor{Kind: "func", Label: "session", Descri
 		{Kind: "any", Label: "key_or_operation", Description: "key, or get_or_compute_scoped", Optional: true},
 		{Kind: "any", Label: "value_or_scope", Description: "value to store, or scope for get_or_compute_scoped", Optional: true},
 		{Kind: "any", Label: "scoped_key", Description: "cache key used by get_or_compute_scoped", Optional: true},
-		{Kind: "func", CallsOnce: true, Label: "scoped_producer", Description: "producer used only by the four-argument get_or_compute_scoped form", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
-		{Kind: "any", Label: "scoped_finalizer", Description: "optional finalizer for scoped cache entries", Optional: true},
+		{Kind: "func", CallsOnce: true, Label: "scoped_producer", Description: "producer used by the four-argument get_or_compute_scoped form", Optional: true, Params: []*TypeDescriptor{}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
+		{Kind: "func", CallsOnce: true, Label: "transactional_scoped_producer", Description: "producer used by the five-argument get_or_compute_scoped form and called with its explicit transaction argument", Optional: true, Params: []*TypeDescriptor{{Kind: "any", Label: "tx"}}, Return: &TypeDescriptor{Kind: "any", Label: "value", Description: "computed value cached for the scope and key"}},
 	},
 	Return: &TypeDescriptor{Kind: "any", Label: "result", Description: "value list, stored value, retrieved value, or shared computed value"},
 }

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -273,6 +273,19 @@ func (c *indexAnalyzeContext) ExtractConstant(v scm.Scmer) (scm.Scmer, bool) {
 // the column-dependent expression while producing a stable, reusable index.
 func (c *indexAnalyzeContext) materializeComputedExpr(expr scm.Scmer) scm.Scmer {
 	expr = expr.WithoutSourceInfo()
+	// A computed column must depend on at least one scanned-row parameter. An
+	// explicit outer capture may itself be a slice; materializing that complete
+	// operand to (for example) integer 1 must not turn it into a constant
+	// computed index named ".1". Only materialize independent descendants once
+	// the complete expression is known to remain row-dependent.
+	if isIndependent(c.params, expr) {
+		return expr
+	}
+	return c.materializeComputedExprParts(expr)
+}
+
+func (c *indexAnalyzeContext) materializeComputedExprParts(expr scm.Scmer) scm.Scmer {
+	expr = expr.WithoutSourceInfo()
 	if isIndependent(c.params, expr) {
 		if value, ok := c.ExtractConstant(expr); ok {
 			return value
@@ -287,7 +300,7 @@ func (c *indexAnalyzeContext) materializeComputedExpr(expr scm.Scmer) scm.Scmer 
 	}
 	var materialized []scm.Scmer
 	for i, item := range items {
-		value := c.materializeComputedExpr(item)
+		value := c.materializeComputedExprParts(item)
 		if materialized == nil && value != item {
 			materialized = make([]scm.Scmer, len(items))
 			copy(materialized, items[:i])

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -254,7 +254,7 @@ func (c *indexAnalyzeContext) ExtractConstant(v scm.Scmer) (scm.Scmer, bool) {
 		}
 	}
 	if isIndependent(c.params, v) {
-		if value, ok := evalIndependentScmer(v, c.proc.En); ok {
+		if value, ok := evalIndependentProcBodyScmer(v, c.proc); ok {
 			if value.IsInt() || value.IsFloat() || value.IsString() || value.IsBool() || value.IsNil() || value.IsCustom(TagRecSet) {
 				return value, true
 			}

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -263,6 +263,45 @@ func (c *indexAnalyzeContext) ExtractConstant(v scm.Scmer) (scm.Scmer, bool) {
 	return scm.NewNil(), false
 }
 
+// materializeComputedExpr replaces request-local constant subexpressions with
+// their values before a computed index is identified and named. Optimized SQL
+// plans represent an explicit session lookup as ((outer n (var i)) key). That
+// lookup is independent of the scanned row, but isRawDataset cannot classify
+// the dynamic callable head as a foldable storage expression. Keeping it in
+// the index formula would also make the canonical name independent of the
+// actual lookup value. Materializing only row-independent subtrees preserves
+// the column-dependent expression while producing a stable, reusable index.
+func (c *indexAnalyzeContext) materializeComputedExpr(expr scm.Scmer) scm.Scmer {
+	expr = expr.WithoutSourceInfo()
+	if isIndependent(c.params, expr) {
+		if value, ok := c.ExtractConstant(expr); ok {
+			return value
+		}
+	}
+	if !expr.IsSlice() {
+		return expr
+	}
+	items := expr.Slice()
+	if len(items) > 0 && scanSymbolIs(items[0], "quote") {
+		return expr
+	}
+	var materialized []scm.Scmer
+	for i, item := range items {
+		value := c.materializeComputedExpr(item)
+		if materialized == nil && value != item {
+			materialized = make([]scm.Scmer, len(items))
+			copy(materialized, items[:i])
+		}
+		if materialized != nil {
+			materialized[i] = value
+		}
+	}
+	if materialized == nil {
+		return expr
+	}
+	return scm.NewSlice(materialized)
+}
+
 func (c *indexAnalyzeContext) FunctionIs(v scm.Scmer, name string) bool {
 	v = v.WithoutSourceInfo()
 	if v.SymbolEquals(name) {
@@ -678,18 +717,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			}
 			// computed col: (equal? rawDataset independent) or reversed
 			if len(params) > 0 && v[1].IsSlice() {
-				if isRawDataset(params, v[1]) && isIndependent(params, v[2]) {
-					if v2, ok2 := evalIndependentScmer(v[2], p.En); ok2 {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[1])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[2]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[2], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[1]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
@@ -697,18 +737,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 				}
 			}
 			if len(params) > 0 && v[2].IsSlice() {
-				if isRawDataset(params, v[2]) && isIndependent(params, v[1]) {
-					if v2, ok2 := evalIndependentScmer(v[1], p.En); ok2 {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[2])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[1]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[1], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[2]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
@@ -737,18 +778,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			}
 			// computed col: rawDataset < independent → rawDataset has upper bound
 			if len(params) > 0 && v[1].IsSlice() {
-				if isRawDataset(params, v[1]) && isIndependent(params, v[2]) {
-					if v2, ok2 := evalIndependentScmer(v[2], p.En); ok2 {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[1])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[2]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[2], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[1]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
@@ -757,18 +799,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			}
 			// reversed computed: independent < rawDataset → rawDataset has lower bound
 			if len(params) > 0 && v[2].IsSlice() {
-				if isRawDataset(params, v[2]) && isIndependent(params, v[1]) {
-					if v2, ok2 := evalIndependentScmer(v[1], p.En); ok2 {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[2])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[1]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[1], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[2]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
@@ -797,18 +840,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			}
 			// computed col: rawDataset > independent → rawDataset has lower bound
 			if len(params) > 0 && v[1].IsSlice() {
-				if isRawDataset(params, v[1]) && isIndependent(params, v[2]) {
-					if v2, ok2 := evalIndependentScmer(v[2], p.En); ok2 {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[1])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[2]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[2], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[1]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-						canon := canonicalColName(v[1], params, conditionCols)
-						mc, mf := buildComputedFn(v[1], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
@@ -817,18 +861,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			}
 			// reversed computed: independent > rawDataset → rawDataset has upper bound
 			if len(params) > 0 && v[2].IsSlice() {
-				if isRawDataset(params, v[2]) && isIndependent(params, v[1]) {
-					if v2, ok2 := evalIndependentScmer(v[1], p.En); ok2 {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+				computedExpr := analyzeContext.materializeComputedExpr(v[2])
+				if isRawDataset(params, computedExpr) && isIndependent(params, v[1]) {
+					if v2, ok2 := evalIndependentProcBodyScmer(v[1], p); ok2 {
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
 						}
 					}
-				} else if isRawDataset(params, v[2]) {
+				} else if isRawDataset(params, computedExpr) {
 					if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-						canon := canonicalColName(v[2], params, conditionCols)
-						mc, mf := buildComputedFn(v[2], p.Params, p.En, conditionCols)
+						canon := canonicalColName(computedExpr, params, conditionCols)
+						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
 							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -117,6 +117,30 @@ func TestComputedBoundaryThroughCapturedCallable(t *testing.T) {
 	}
 }
 
+func TestCapturedConstantDoesNotBecomeComputedColumn(t *testing.T) {
+	outerEnv := &scm.Env{VarsNumbered: []scm.Scmer{scm.NewInt(1)}, Outer: &scm.Globalenv}
+	captured := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("outer"),
+		scm.NewInt(1),
+		scm.NewNthLocalVar(0),
+	})
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("number")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal??"),
+			scm.NewInt(1),
+			captured,
+		}),
+		En:           outerEnv,
+		NumVars:      1,
+		NumberedOnly: true,
+	})
+
+	if bounds := extractBoundaries([]string{"number"}, condition); len(bounds) != 0 {
+		t.Fatalf("captured constant boundary = %#v, want no computed column", bounds)
+	}
+}
+
 func BenchmarkExtractBoundariesEqual(b *testing.B) {
 	body := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -41,6 +41,37 @@ func TestSortedBoundariesCoverCondition(t *testing.T) {
 	}
 }
 
+func TestBoundaryConstantThroughCapturedCallable(t *testing.T) {
+	dictionary := scm.NewFastDictValue(1)
+	dictionary.Set(scm.NewString("id"), scm.NewInt(424), nil)
+	lookup := scm.NewFastDict(dictionary)
+	outerEnv := &scm.Env{VarsNumbered: []scm.Scmer{lookup}, Outer: &scm.Globalenv}
+	body := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("equal??"),
+		scm.NewNthLocalVar(0),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("outer"),
+				scm.NewInt(1),
+				scm.NewNthLocalVar(0),
+			}),
+			scm.NewString("id"),
+		}),
+	})
+	condition := scm.NewProcStruct(scm.Proc{
+		Params:       scm.NewSlice([]scm.Scmer{scm.NewSymbol("id")}),
+		Body:         body,
+		En:           outerEnv,
+		NumVars:      1,
+		NumberedOnly: true,
+	})
+
+	bounds := extractBoundaries([]string{"ID"}, condition)
+	if len(bounds) != 1 || bounds[0].col != "ID" || bounds[0].matcher != EqualMatcher || bounds[0].lower.Int() != 424 {
+		t.Fatalf("captured callable boundary = %#v, want ID = 424", bounds)
+	}
+}
+
 func BenchmarkExtractBoundariesEqual(b *testing.B) {
 	body := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -72,6 +72,51 @@ func TestBoundaryConstantThroughCapturedCallable(t *testing.T) {
 	}
 }
 
+func TestComputedBoundaryThroughCapturedCallable(t *testing.T) {
+	dictionary := scm.NewFastDictValue(2)
+	dictionary.Set(scm.NewString("offset"), scm.NewInt(1), nil)
+	dictionary.Set(scm.NewString("value"), scm.NewInt(18), nil)
+	lookup := scm.NewFastDict(dictionary)
+	outerEnv := &scm.Env{VarsNumbered: []scm.Scmer{lookup}, Outer: &scm.Globalenv}
+	captured := func(key string) scm.Scmer {
+		return scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("outer"),
+				scm.NewInt(1),
+				scm.NewNthLocalVar(0),
+			}),
+			scm.NewString(key),
+		})
+	}
+	computed := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("+"),
+		scm.NewNthLocalVar(0),
+		captured("offset"),
+	})
+	condition := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("number")}),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("equal??"),
+			computed,
+			captured("value"),
+		}),
+		En:           outerEnv,
+		NumVars:      1,
+		NumberedOnly: true,
+	})
+
+	bounds := extractBoundaries([]string{"number"}, condition)
+	if len(bounds) != 1 || bounds[0].matcher != EqualMatcher || bounds[0].lower.Int() != 18 {
+		t.Fatalf("captured computed boundary = %#v, want computed value = 18", bounds)
+	}
+	if bounds[0].col != ".(+ number 1)" {
+		t.Fatalf("computed column = %q, want stable materialized expression", bounds[0].col)
+	}
+	if bounds[0].mapFn.IsNil() || scm.Apply(bounds[0].mapFn, scm.NewInt(17)).Int() != 18 {
+		t.Fatal("computed index mapper did not retain the materialized expression")
+	}
+}
+
 func BenchmarkExtractBoundariesEqual(b *testing.B) {
 	body := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal?"),

--- a/storage/compute_index.go
+++ b/storage/compute_index.go
@@ -252,6 +252,28 @@ func isIndependent(params []scm.Scmer, expr scm.Scmer) bool {
 	return true
 }
 
+// hasExplicitOuterReference reports whether expr contains an optimizer-lowered
+// capture. The expression is part of a procedure body, so evaluating such a
+// capture must start in a synthetic call frame rather than directly in the
+// procedure's creation environment.
+func hasExplicitOuterReference(expr scm.Scmer) bool {
+	if expr.IsProc() {
+		return false
+	}
+	if !expr.IsSlice() {
+		return false
+	}
+	if _, _, ok := scanOuterReference(expr); ok {
+		return true
+	}
+	for _, item := range expr.Slice() {
+		if hasExplicitOuterReference(item) {
+			return true
+		}
+	}
+	return false
+}
+
 // evalIndependentScmer evaluates an expression that doesn't depend on row params.
 // Returns (value, true) when evaluation succeeds with a scalar result.
 func evalIndependentScmer(expr scm.Scmer, env *scm.Env) (result scm.Scmer, ok bool) {
@@ -333,6 +355,19 @@ func evalIndependentScmer(expr scm.Scmer, env *scm.Env) (result scm.Scmer, ok bo
 		return res, true
 	}
 	return scm.NewNil(), false
+}
+
+// evalIndependentProcBodyScmer evaluates an independent fragment extracted
+// from proc.Body. An explicit (outer 1 ...) is relative to the procedure call
+// frame which normally exists while the body runs, not directly to proc.En.
+// Build that otherwise-empty frame only for expressions which need it; common
+// literal and session-read boundaries retain the allocation-free path.
+func evalIndependentProcBodyScmer(expr scm.Scmer, proc *scm.Proc) (scm.Scmer, bool) {
+	if !hasExplicitOuterReference(expr) {
+		return evalIndependentScmer(expr, proc.En)
+	}
+	bodyEnv := scm.Env{Outer: proc.En}
+	return evalIndependentScmer(expr, &bodyEnv)
 }
 
 // canonicalColName builds a stable canonical name for a computed index column.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2958,10 +2958,10 @@ func Init(en scm.Env) {
 				}
 				// Install maintenance while source writes are blocked. Once the
 				// locks are released, every later mutation observes the triggers.
-				scm.Apply(a[3])
-				scm.Apply(a[4])
+				scm.Apply(a[3], a[0])
+				scm.Apply(a[4], a[0])
 				if len(a) > 5 {
-					scm.Apply(a[5])
+					scm.Apply(a[5], a[0])
 				}
 			})
 			return scm.NewBool(initialized)
@@ -2971,9 +2971,9 @@ func Init(en scm.Env) {
 				{Kind: "any", Label: "transaction", Description: "explicit transaction context carrying query-session ownership"},
 				{Kind: "table", Label: "table"},
 				{Kind: "list", Label: "source_tables"},
-				{Kind: "func", Label: "register_maintenance", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Label: "initializer", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}},
-				{Kind: "func", Label: "finalizer", Description: "optional zero-argument finalizer run under the same source-table locks after initialization", Params: []*scm.TypeDescriptor{}, Return: &scm.TypeDescriptor{Kind: "any"}, Optional: true},
+				{Kind: "func", Label: "register_maintenance", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "transaction"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "initializer", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "transaction"}}, Return: &scm.TypeDescriptor{Kind: "any"}},
+				{Kind: "func", Label: "finalizer", Description: "optional finalizer run under the same source-table locks after initialization", Params: []*scm.TypeDescriptor{{Kind: "any", Label: "transaction"}}, Return: &scm.TypeDescriptor{Kind: "any"}, Optional: true},
 			},
 			Return: &scm.TypeDescriptor{Kind: "bool"},
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2766,11 +2766,11 @@ func Init(en scm.Env) {
 				return result
 			}
 
-			// Build count-scan: (scan (session) (table base_schema base_table) (list base_cols...) (lambda (tblvar.col...) (and (equal? tblvar.col (get_assoc OLD "col")) ...)) () (lambda () 1) + 0 nil)
+			// Build count-scan: (scan tx (table base_schema base_table) (list base_cols...) (lambda (tblvar.col...) (and (equal? tblvar.col (get_assoc OLD "col")) ...)) () (lambda () 1) + 0 nil)
 			buildCountScan := func(dictSym string) scm.Scmer {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),
-					scm.NewSymbol("session"),
+					scm.NewSymbol("tx"),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(baseSchema), scm.NewString(baseTable.Name)}),
 					scanFilterCols(baseCols),
 					scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scanFilterParams(tblvar, baseCols)},
@@ -2781,11 +2781,11 @@ func Init(en scm.Env) {
 				})
 			}
 
-			// Build delete-scan: (scan (session) (table kt_schema kt_name) (list kt_cols...) (lambda (kt.col...) (and (equal? kt.col (get_assoc OLD "base_col")) ...)) (list "$update") (lambda ($update) ($update)) + 0 nil)
+			// Build delete-scan: (scan tx (table kt_schema kt_name) (list kt_cols...) (lambda (kt.col...) (and (equal? kt.col (get_assoc OLD "base_col")) ...)) (list "$update") (lambda ($update) ($update)) + 0 nil)
 			buildDeleteScan := func(dictSym string) scm.Scmer {
 				return scm.NewSlice([]scm.Scmer{
 					scm.NewSymbol("scan"),
-					scm.NewSymbol("session"),
+					scm.NewSymbol("tx"),
 					scm.NewSlice([]scm.Scmer{scm.NewSymbol("table"), scm.NewString(ktSchema), scm.NewString(ktName)}),
 					scanFilterCols(ktCols),
 					scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("lambda"), scanFilterParams(ktName, ktCols)},
@@ -4203,10 +4203,15 @@ func initFKBuiltins(en scm.Env) {
 // buildFKProc constructs a serializable Proc that calls a builtin with the given args.
 // body is the Scheme expression as an S-expression (a Scmer list).
 func buildFKProc(body scm.Scmer) scm.Scmer {
+	// Generated trigger bodies may contain optimized child closures which address
+	// these four trigger arguments through outer numbered slots. Persist the
+	// complete frame shape so the closures keep the same lexical layout after a
+	// schema reload, while NumberedOnly remains false for symbolic trigger bodies.
 	return scm.NewProc(&scm.Proc{
-		Params: scm.NewSlice([]scm.Scmer{scm.NewSymbol("OLD"), scm.NewSymbol("NEW"), scm.NewSymbol("session")}),
-		Body:   body,
-		En:     &scm.Globalenv,
+		Params:  scm.NewSlice([]scm.Scmer{scm.NewSymbol("OLD"), scm.NewSymbol("NEW"), scm.NewSymbol("session"), scm.NewSymbol("tx")}),
+		Body:    body,
+		En:      &scm.Globalenv,
+		NumVars: 4,
 	})
 }
 
@@ -4235,7 +4240,7 @@ func fkQuotedList(cols []string) scm.Scmer {
 }
 
 func fkTxExpr() scm.Scmer {
-	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("session"), scm.NewString("__memcp_tx")})
+	return scm.NewSymbol("tx")
 }
 
 // installFKTriggers creates system triggers on child (t1) and parent (t2) tables

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -54,8 +54,8 @@ test_cases:
         (define cache (table "memcp-tests" ".transactionless_stream_cache"))
         (initialize_cache_table nil cache
           (list (table "memcp-tests" "stream_cache_source"))
-          (lambda () true)
-          (lambda ()
+          (lambda (_tx) true)
+          (lambda (_tx)
             (insert cache '("row_count")
               (list (list
                 (stream_window_reduce 0 -1

--- a/tests/execution/concurrency/group-cache-initialization.yaml
+++ b/tests/execution/concurrency/group-cache-initialization.yaml
@@ -43,8 +43,8 @@ test_cases:
         (initialize_cache_table nil
           (table "memcp-tests" ".transactionless_cache_init")
           (list (table "memcp-tests" "aggregate_source"))
-          (lambda () true)
-          (lambda ()
+          (lambda (tx) true)
+          (lambda (tx)
             (insert
               (table "memcp-tests" ".transactionless_cache_init")
               (list "id")

--- a/tests/execution/operators/range-scan-coverage.yaml
+++ b/tests/execution/operators/range-scan-coverage.yaml
@@ -620,11 +620,11 @@ test_cases:
         (define selective_query "SELECT f.id, d.label FROM selective_text_driver f LEFT JOIN selective_text_dim d ON d.id = f.dim_id WHERE f.search LIKE '%needle%' ORDER BY f.id LIMIT 4")
         (define broad_query "SELECT f.id, d.label FROM selective_text_driver f LEFT JOIN selective_text_dim d ON d.id = f.dim_id WHERE f.search LIKE '%asset%' ORDER BY f.id LIMIT 4")
         (define first_formula (cached_parse cache (list parse_sql) "memcp-tests" selective_query nil "root" sess true))
-        (with_session sess (lambda () (eval first_formula)))
+        (sql_execute_formula sess nil first_formula resultrow (lambda (_fields) nil))
         (define entry (car (cache (car (cache)))))
         (define variants_after_first (count (entry "variants")))
         (define second_formula (cached_parse cache (list parse_sql) "memcp-tests" broad_query nil "root" sess true))
-        (with_session sess (lambda () (eval second_formula)))
+        (sql_execute_formula sess nil second_formula resultrow (lambda (_fields) nil))
         (if (and (equal? variants_after_first 1) (equal? (count (entry "variants")) 2))
           "ok"
           (error (concat "unexpected text selectivity variants: first=" variants_after_first

--- a/tests/performance/group-lookup-performance.yaml
+++ b/tests/performance/group-lookup-performance.yaml
@@ -245,10 +245,12 @@ test_cases:
         (define elapsed
           (with_session session (lambda ()
             (with_autocommit session nil 0 "group lookup setup" (lambda (tx) (begin
-              (eval formula)
+              (sql_execute_formula session tx formula resultrow (lambda (_fields) nil))
               (define started (nanotime))
               (reduce (produceN iterations)
-                (lambda (count _index) (begin (eval formula) (+ count 1))) 0)
+                (lambda (count _index) (begin
+                  (sql_execute_formula session tx formula resultrow (lambda (_fields) nil))
+                  (+ count 1))) 0)
               (- (nanotime) started)))))))
         (define average_ns (/ elapsed iterations))
         (if (< average_ns 1000000)

--- a/tests/planner/subqueries/in-subquery.yaml
+++ b/tests/planner/subqueries/in-subquery.yaml
@@ -1056,12 +1056,13 @@ test_cases:
               (cached_parse cache (list parse_sql) "memcp-tests" query
                 (sql_policy "root") "root" session true tx)) sess nil))
             (define eval_guard (lambda (guard guard_session guard_tx)
-              (eval (list
-                (list (quote lambda) (list (quote session) (quote tx) (quote resultrow)) guard)
-                guard_session guard_tx (lambda (_row) nil)))))
-            (define cold_guard (eval_guard (nth formula 1) sess nil))
+              ((sql_queryplan_compile_formula guard)
+                guard_session guard_tx (lambda (_row) nil) (lambda (_fields) nil))))
+            (define entry (car (cache (car (cache)))))
+            (define guard (car (car (entry "variants"))))
+            (define cold_guard (eval_guard guard sess nil))
             (rebuild (table "memcp-tests" "in_dv_file") true false)
-            (define rebuilt_guard (eval_guard (nth formula 1) sess nil))
+            (define rebuilt_guard (eval_guard guard sess nil))
             (if (and cold_guard (not rebuilt_guard))
               "ok"
               (error (concat "membership carrier guard did not follow refined statistics: "

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -671,7 +671,7 @@ test_cases:
     expect:
       data: [true]
 
-  - name: "Exact cached formula is an explicit request callable"
+  - name: "Exact cached formula keeps optimizer-resolved session calls"
     scm: |
       (begin
         (define execution_session (newsession))

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -405,15 +405,18 @@ test_cases:
         (sess "v1" "%C%")
         (define first_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT id FROM ps_test WHERE name LIKE ?" nil "root" sess true))
-        (define first_result (with_session sess (lambda () (eval first_formula))))
+        (define first_result (sql_execute_formula sess nil first_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (sess "v1" "%Needle389%")
         (define second_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT id FROM ps_test WHERE name LIKE ?" nil "root" sess true))
-        (define second_result (with_session sess (lambda () (eval second_formula))))
+        (define second_result (sql_execute_formula sess nil second_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (sess "v1" "%AnotherSelectiveValue%")
         (define third_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT id FROM ps_test WHERE name LIKE ?" nil "root" sess true))
-        (define third_result (with_session sess (lambda () (eval third_formula))))
+        (define third_result (sql_execute_formula sess nil third_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (define entry (car (cache (car (cache)))))
         (define latest_formula (entry "formula"))
         (if (and
@@ -422,8 +425,9 @@ test_cases:
           (equal? third_result "selective")
           (equal? (count (compiles)) 2)
           (equal? (count (entry "variants")) 2)
-          (equal? (car latest_formula) (quote if))
-          (with_session sess (lambda () (eval (nth latest_formula 1)))))
+          (strlike (pretty_print latest_formula 120) "%(lambda (session tx resultrow resultfields)%")
+          ((sql_queryplan_compile_formula (car (car (entry "variants"))))
+            sess nil (lambda (_row) nil) (lambda (_fields) nil)))
           "ok"
           (error (concat "unexpected guarded cache state: " first_result "/" second_result "/" third_result
             " compiles=" (count (compiles)) " values=" (string (map (compiles) (lambda (key) (compiles key))))
@@ -447,13 +451,15 @@ test_cases:
         (define query "SELECT id FROM ps_test WHERE EXISTS (SELECT id FROM ps_test) LIMIT ?")
         (define results (map (produceN 12) (lambda (value) (begin
           (sess "v1" value)
-          (with_session sess (lambda ()
-            (eval (cached_parse cache (list parser) "memcp-tests" query nil "root" sess true))))))))
+          (sql_execute_formula sess nil
+            (cached_parse cache (list parser) "memcp-tests" query nil "root" sess true)
+            (lambda (_row) nil) (lambda (_fields) nil))))))
         (define entry (car (cache (car (cache)))))
         (define bounded_count (count (entry "variants")))
         (sess "v1" 0)
-        (define revisited (with_session sess (lambda ()
-          (eval (cached_parse cache (list parser) "memcp-tests" query nil "root" sess true)))))
+        (define revisited (sql_execute_formula sess nil
+          (cached_parse cache (list parser) "memcp-tests" query nil "root" sess true)
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (if (and
           (equal? results (produceN 12))
           (equal? revisited 0)
@@ -559,11 +565,13 @@ test_cases:
         (sess "v1" "first")
         (define first_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT id FROM ps_test WHERE name LIKE ?" nil "root" sess true))
-        (define first_result (with_session sess (lambda () (eval first_formula))))
+        (define first_result (sql_execute_formula sess nil first_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (sess "v1" "second")
         (define second_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT id FROM ps_test WHERE name LIKE ?" nil "root" sess true))
-        (define second_result (with_session sess (lambda () (eval second_formula))))
+        (define second_result (sql_execute_formula sess nil second_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (define entry (car (cache (car (cache)))))
         (if (and
           (equal? first_result "first")
@@ -663,7 +671,7 @@ test_cases:
     expect:
       data: [true]
 
-  - name: "Exact cached formula keeps optimizer-resolved session calls"
+  - name: "Exact cached formula is an explicit request callable"
     scm: |
       (begin
         (define execution_session (newsession))
@@ -672,8 +680,14 @@ test_cases:
           (cached_parse (newcachemap) (list parse_sql) "memcp-tests" "SELECT ?"
             (lambda (_schema _table _write) true)
             "root" execution_session false))
-        (equal? (pretty_print formula 120)
-          "(resultrow '(\"?\" (session \"v1\")))"))
+        (define resultrow (lambda (row) (cadr row)))
+        (define first (sql_execute_formula execution_session nil formula resultrow (lambda (_fields) nil)))
+        (execution_session "v1" 9)
+        (define second (sql_execute_formula execution_session nil formula resultrow (lambda (_fields) nil)))
+        (and
+          (strlike (pretty_print formula 120) "%(lambda (session tx resultrow resultfields)%")
+          (equal? first 7)
+          (equal? second 9)))
     expect:
       data: [true]
 
@@ -687,14 +701,14 @@ test_cases:
         (define resultrow (lambda (_row) nil))
         (define query "SELECT l.id FROM ps_guard_left l JOIN ps_guard_right r ON r.id = l.rhs ORDER BY l.id")
         (define first_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
-        (with_session sess (lambda () (eval first_formula)))
+        (sql_execute_formula sess nil first_formula resultrow (lambda (_fields) nil))
         (define entry (car (cache (car (cache)))))
         (define variants_after_first (count (entry "variants")))
         (insert (table "memcp-tests" "ps_guard_right") '("id")
           (map (produceN 500) (lambda (i) (list (+ i 2)))))
         (rebuild (table "memcp-tests" "ps_guard_right") true false)
         (define second_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
-        (with_session sess (lambda () (eval second_formula)))
+        (sql_execute_formula sess nil second_formula resultrow (lambda (_fields) nil))
         (if (and (equal? variants_after_first 1) (equal? (count (entry "variants")) 2))
           "ok"
           (error (concat "unexpected statistics variants: first=" variants_after_first
@@ -737,12 +751,14 @@ test_cases:
         (define first_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT EXISTS (SELECT id FROM ps_test LIMIT 1) FROM ps_test LIMIT ?"
           nil "root" sess true))
-        (define first_result (with_session sess (lambda () (eval first_formula))))
+        (define first_result (sql_execute_formula sess nil first_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (sess "v1" 10000)
         (define second_formula (cached_parse cache (list parser) "memcp-tests"
           "SELECT EXISTS (SELECT id FROM ps_test LIMIT 1) FROM ps_test LIMIT ?"
           nil "root" sess true))
-        (define second_result (with_session sess (lambda () (eval second_formula))))
+        (define second_result (sql_execute_formula sess nil second_formula
+          (lambda (_row) nil) (lambda (_fields) nil)))
         (define entry (car (cache (car (cache)))))
         (if (and
           (equal? first_result "probe")


### PR DESCRIPTION
## What

- cache SQL query plans as closed procedures with explicit `session`, `tx`, `resultrow`, and `resultfields` parameters
- optimize the complete lambda and pass it through `jit`, replacing the warm-path `eval`
- compile guarded variant dispatchers as callables, including guards and the cache-miss arm
- preserve the optimized Proc AST for serialization and cache-size accounting
- teach index-boundary extraction to evaluate query-invariant expressions containing optimizer-lowered `outer` captures from the correct procedure-body scope
- materialize row-independent captured values before computed-index classification, canonical naming, and mapper construction
- pass the active transaction explicitly into persisted group/prejoin cache callbacks so their serialized procedures do not retain request-local outer frames

The productive final-plan optimizer call now lives in `sql_queryplan_compile_formula`; plans are no longer optimized once as raw top-level code and then evaluated in an arbitrary request environment.

## Runtime dependencies and frontends

The generated SQL plan has four request-local dependencies: `session`, `tx`, `resultrow`, and `resultfields`. All are explicit lambda parameters, so cached plans do not retain the compiling request environment.

The shared callable path is exercised by HTTP SQL, HTTP PostgreSQL syntax, and the MySQL wire protocol. Raw `/scm` remains an eval frontend. SPARQL/RDF remains deliberately uncached and request-local because its parser currently embeds LIMIT/OFFSET/DISTINCT row-state in the generated formula; the RDF HTTP path is unchanged and covered by a targeted SPARQL test.

Normal Go builds keep the interpreter fallback because `GOEXPERIMENT=jit` is disabled. JIT-enabled builds receive the same optimized lambda through the existing `jit` entry point.

## Manual A/B measurements

Baseline: current `master` (`66a85eb69`). Candidate: `52a7c36e9`. Both binaries used the normal Go 1.24 toolchain, fresh separate data directories, identical one-shard 1,000-row fixtures, serial execution, and alternating candidate/master order. Each formula was cached before timing and every sample had an additional warmup. Values are medians of per-query latency.

| Query | Samples | Master | Candidate | Change |
|---|---:|---:|---:|---:|
| `SELECT payload FROM qpl_bench WHERE ID = 424` | 20 × 20,000 after 2,000 warmup | 7.364 µs | 6.566 µs | -10.8% |
| `SELECT SUM(ID) ... WHERE category >= 0` (1,000 rows) | 40 × 2,000 after 500 warmup | 20.098 µs | 18.790 µs | -6.5% |
| guarded `LIKE` + `ORDER BY ID LIMIT 5` | 24 × 1,000 after 200 warmup | 36.676 µs | 35.787 µs | -2.4% |

The first experimental run exposed a full-scan regression: a captured session lookup appeared as `((outer 1 ...) "v1")`, but the index analyzer evaluated it one scope too far out. The generic procedure-body scope fix restored direct column boundaries.

An additional CI observation exposed the corresponding computed-index path: `JSON_VALUE(doc, '$.tenant' ...) = 17` no longer produced a boundary after its constant path and comparison value became captured calls. `ScanDebugging` showed `lower=[]` on the candidate versus the computed boundary on master. The analyzer now materializes only row-independent capture subtrees before classifying and naming the computed expression. This also makes the persistent index identity depend on the actual JSON path rather than a request-local session-call AST.

After merging the current target master, the JSON performance suite was measured again with fresh separate data directories, 10,000 rows, two warmups, and up to 1,000 serial samples or at least one second per case. Baseline: `5de0c5e57`; candidate: `5ef4419c5`.

| Query | Samples | Master | Candidate | Change |
|---|---:|---:|---:|---:|
| indexed selective row projection | 1,000 | 0.839 ms | 0.833 ms | -0.7% |
| BSON nested path traversal | 1,000 | 0.585 ms | 0.575 ms | -1.6% |
| TEXT parse and nested path traversal | 1,000 | 0.592 ms | 0.598 ms | +1.1% |
| computed path filter | 1,000 | 0.610 ms | 0.601 ms | -1.5% |
| computed path ORDER BY LIMIT | 796 / 786 | 1.258 ms | 1.272 ms | +1.2% |
| JSON_ARRAYAGG object serialization | 267 / 270 | 3.755 ms | 3.706 ms | -1.3% |
| PostgreSQL extraction ORDER BY LIMIT | 931 / 936 | 1.075 ms | 1.069 ms | -0.6% |
| PostgreSQL JSONPath predicate scan | 1,000 | 0.543 ms | 0.587 ms | +8.2% |

## WordPress vs MariaDB 10.11.14

The current PR head (`ba552c1b9`) and MariaDB were measured serially through the MySQL protocol against matching 8,214-post/75,000-postmeta fixtures. MariaDB query cache was OFF. Two runs per engine used 500 warmups followed by seven blocks of 5,000 timed queries; values are medians of the pooled fourteen block means (70,000 timed requests per engine/query).

| Query | MemCP | MariaDB | Result |
|---|---:|---:|---:|
| Point lookup by primary key | 0.06235 ms | 0.06409 ms | MemCP 2.8% faster |
| `ORDER BY post_title LIMIT 5` | 0.15976 ms | 2.34538 ms | MemCP 14.7x faster |
| Posts↔Postmeta filtered join + `ORDER/LIMIT` | 0.25859 ms | 0.26513 ms | MemCP 2.5% faster |

## Targeted verification

- Scheme startup tests: 1270/1270
- `tests/sql/expressions/prepared-stmts.yaml`: 55/55
- `tests/rdf/rdf-optional.yaml`: 4/4
- targeted storage analyzer and procedure/size tests
- `tests/storage/persistence/serialize-round-trip.yaml`: 23/23
- `tests/storage/persistence/safe-shard-restart.yaml`: 19/19
- `tests/execution/concurrency/group-cache-initialization.yaml`: 19/19
- HTTP SQL point lookup, HTTP PSQL point lookup, and MySQL-wire point lookup returned the expected row
- `tests/performance/json-functions.yaml`: 8/8 with the current target master as A/B baseline

Per project workflow, the full SQL suite is left to CI.

- make persisted prejoin and generated storage triggers accept the full `OLD`, `NEW`, `session`, `tx` execution frame; persist `NumVars=4` so already optimized child closures retain the same numbered outer-frame layout after restart
- avoid emitting a redundant RecSet producer `begin` when preparation is the literal no-op `true`; this prevents a removed lexical scope from leaving nested callback `outer` depths one level too large

Additional regression verification after the CI failure:

- `tests/sql/triggers/trigger-persistence.yaml`: 28/28, including internal prejoin INSERT/UPDATE maintenance after a real server restart
- `tests/planner/subqueries/traced-union-scalar-probes.yaml`: 13/13, including positive/negative invariant grants, session changes, and fallback branches

These two suites are the mandatory needles for this failure class: the first protects serialized trigger frame layout, while the second protects live nested RecSet/callback scope layout.

The explicit callback conversion also applies to physical cost calibration. A forced plan now receives dedicated `resultrow` and `resultfields` callbacks through a lexical procedure boundary; its rows feed only the bounded digest sink, while the request callback receives only calibration diagnostics. This avoids relying on symbol shadowing after the forced subplan has already been optimized.

- `tests/execution/operators/range-scan-coverage.yaml`: the selective text carrier CALIBRATE case emits exactly its two diagnostic rows
- `tests/planner/aggregates/group-stage-corners.yaml`: 42/42, including both direct grouped-join calibration variants with equal result hashes
- `tests/planner/subqueries/in-subquery.yaml`: 73/73, including computed, cached/rebound, UNION, and selective-prefilter calibration variants


## Explicit context completion after CI findings

The five-argument `get_or_compute_scoped` form now invokes its producer with the supplied explicit `tx`; every compiler-generated use declares that producer parameter. The legacy four-argument form remains zero-argument and compatible. A Scheme unit regression asserts both exact transaction delivery and scoped value reuse.

The RecSet crossover failure was split at runtime markers: first parse, first execution, and second cache lookup completed; the second execution recursed in the cache-miss arm after installing the new variant. The cold compiler boundary now uses `apply` so dispatcher optimization cannot specialize the Scheme compiler against cache/session literals, and the miss path executes the already selected/new plan directly instead of re-entering the guard that just missed.

Additional targeted verification at `e4890a65a`:

- `tests/execution/operators/range-scan-coverage.yaml`: 113/113, including forced calibration and cached RecSet cost crossover
- `tests/performance/unselective-scalar-order-limit.yaml`: 11/11
- `tests/performance/notification-membership-scaling.yaml`: 8/8
- `tests/planner/aggregates/session-group-reminders.yaml`: 13/13
- `tests/planner/subqueries/acl-boolean-membership-scaling.yaml`: 30/30
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml`: 23/23
- `tests/sql/expressions/prepared-stmts.yaml`: 55/55
- `tests/sql/triggers/trigger-persistence.yaml`: 28/28 after a real restart
- `tests/planner/subqueries/in-subquery.yaml`: 73/73, including computed-index and calibration context rebinding
- targeted Go analyzer and `outer` tests pass

The cost generator needs no parallel AST rewrite: it executes forced `EXPLAIN PHYSICAL CALIBRATE` statements through this same SQL/compiler path. Analyzer extraction already treats `(outer n expr)` relative to the procedure call frame and materializes only row-independent captured subexpressions before computed-index classification.

## Captured-constant computed-index regression

The explicit `outer` analyzer path exposed a second invariant: a fully row-independent captured operand may be evaluated as a boundary constant, but must never itself become a computed index. Before the fix, `(equal? 1 (outer ... k0))` materialized the right side to `1` and built a useless `.1` index over all 30,000 rows during group-cache initialization.

The exact `tests/storage/indexes/fulltext-like-index.yaml` needle was run three times before and after the fix with a freshly started server for every run:

- before: 3/3 failed at 85/86; full scan 5.125–5.253 ms, cached initialization 4.295–4.399 ms
- after: 3/3 passed at 86/86; the constant `.1` computed-index build is absent

A Go-level analyzer regression separately asserts that a complete captured constant produces no computed boundary, while the adjacent captured-computed-expression test still requires row-dependent children such as `(+ number captured-offset)` to materialize and index correctly.
