### PR TITLE
JIT constant regex matches and captures

### DIFF
--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -1874,7 +1874,7 @@ func jitCompileExpr(ctx *JITContext, expr Scmer, sliceBase Reg, result JITValueD
 		expr = si.value
 	}
 	switch expr.GetTag() {
-	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector,
+	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagRegex, tagVector,
 		tagFunc, tagFuncEnv, tagJIT, tagParser, tagFastDict, tagAny,
 		tagClosure, tagPromise:
 		// Keep Eval's self-evaluating literal contract. Pointer-bearing constants

--- a/scm/jit_match.go
+++ b/scm/jit_match.go
@@ -16,7 +16,11 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 */
 package scm
 
-import "unsafe"
+import (
+	"fmt"
+	"regexp"
+	"unsafe"
+)
 
 // Match lowering is architecture-independent. It describes values, branches,
 // loads, and calls through the common JIT emitter API; only that API's machine
@@ -602,6 +606,29 @@ func jitCompileMatchPattern(ctx *JITContext, value JITValueDesc, pattern Scmer, 
 			return jitMatchOutcome{possible: inner.possible, always: outcome.always && inner.always}
 		case "cons":
 			return jitMatchCons(ctx, value, p[1:], env, failLabel)
+		case "regex":
+			if len(p) < 3 {
+				panic("jit: malformed regex match pattern")
+			}
+			pattern := p[1].WithoutSourceInfo()
+			if pattern.IsString() {
+				compiled, err := regexp.Compile(pattern.String())
+				if err != nil {
+					panic(err)
+				}
+				pattern = NewRegex(compiled)
+			}
+			if !pattern.IsRegex() {
+				panic("regex expects string or precompiled regexp")
+			}
+			if pattern.Regex().NumSubexp() != len(p)-3 {
+				panic(fmt.Sprintf("regex %s contains %d subexpressions, found %d", pattern.Regex(), pattern.Regex().NumSubexp(), len(p)-3))
+			}
+			captures := jitEmitConstantRegexpCaptures(ctx, pattern.Regex(), value, failLabel)
+			for index, capture := range captures {
+				jitMatchBindValue(ctx, env, p[index+2], capture)
+			}
+			return jitMatchOutcome{possible: true, always: false}
 		default:
 			panic("jit: unsupported match pattern " + name)
 		}

--- a/scm/jit_regex.go
+++ b/scm/jit_regex.go
@@ -1,0 +1,229 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import "regexp"
+
+const (
+	jitConstantRegexpTestName      = "jit-constant-regexp-test"
+	jitConstantRegexpPredicateName = "jit-constant-regexp-predicate"
+)
+
+func jitConstantRegexpTest(pattern, value Scmer) Scmer {
+	if value.IsNil() {
+		return NewNil()
+	}
+	return NewBool(pattern.Regex().MatchString(String(value)))
+}
+
+func jitConstantRegexpPredicate(pattern, value Scmer) bool {
+	text, ok := scmerAsString(value)
+	if !ok {
+		panic("regex expects string")
+	}
+	return pattern.Regex().MatchString(text)
+}
+
+func jitConstantRegexpCaptureIndices(pattern, value Scmer) []int {
+	text, ok := scmerAsString(value)
+	if !ok {
+		panic("regex expects string")
+	}
+	return pattern.Regex().FindStringSubmatchIndex(text)
+}
+
+func jitRegexpScmerArg(ctx *JITContext, value JITValueDesc) JITValueDesc {
+	switch value.Loc {
+	case LocRegPair, LocStackPair, LocInputPair:
+		return value
+	case LocImm:
+		return jitCopyScmerToPair(ctx, value)
+	default:
+		ctx.EnsureDesc(&value)
+		if value.Loc != LocRegPair && value.Loc != LocStackPair {
+			panic("jit: regex expects a Scmer value")
+		}
+		return value
+	}
+}
+
+func jitRegexpPatternArg(ctx *JITContext, pattern *regexp.Regexp) JITValueDesc {
+	if pattern == nil {
+		panic("jit: nil constant regex")
+	}
+	value := NewRegex(pattern)
+	ctx.TrackImm(value)
+	return jitCopyScmerToPair(ctx, JITValueDesc{Loc: LocImm, Type: tagRegex, Imm: value})
+}
+
+// jitEmitConstantRegexpTest emits a direct call for a precompiled regular
+// expression. regexp_test's nil result remains distinct from a false match.
+func jitEmitConstantRegexpTest(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, result JITValueDesc) JITValueDesc {
+	patternArg := jitRegexpPatternArg(ctx, pattern)
+	valueArg := jitRegexpScmerArg(ctx, value)
+	target := jitEnsureResultPair(ctx, result)
+	out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitConstantRegexpTest), []JITValueDesc{patternArg, valueArg}, target)
+	ctx.FreeDesc(&patternArg)
+	if value.Loc == LocImm {
+		ctx.FreeDesc(&valueArg)
+	}
+	out.Type = JITTypeUnknown
+	return out
+}
+
+// jitEmitConstantRegexpPredicate emits the branch-friendly boolean form used
+// by match and, later, compiled parser terminals.
+func jitEmitConstantRegexpPredicate(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc) JITValueDesc {
+	patternArg := jitRegexpPatternArg(ctx, pattern)
+	valueArg := jitRegexpScmerArg(ctx, value)
+	out := ctx.EmitGoCallScalar(GoFuncAddr(jitConstantRegexpPredicate), []JITValueDesc{patternArg, valueArg}, 1)
+	ctx.FreeDesc(&patternArg)
+	if value.Loc == LocImm {
+		ctx.FreeDesc(&valueArg)
+	}
+	out.Type = tagBool
+	out.NoHeapPointer = true
+	return out
+}
+
+// jitEmitConstantRegexpCaptures emits one regex execution, branches directly
+// to failLabel when it does not match, and returns stack-backed capture values.
+// Spilling each capture immediately keeps register pressure independent of the
+// number of subexpressions.
+func jitEmitConstantRegexpCaptures(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, failLabel uint8) []JITValueDesc {
+	stableValue := jitMatchStableValue(ctx, value)
+	patternArg := jitRegexpPatternArg(ctx, pattern)
+	valueArg := jitRegexpScmerArg(ctx, stableValue)
+	header := ctx.EmitGoCallScalar(GoFuncAddr(jitConstantRegexpCaptureIndices), []JITValueDesc{patternArg, valueArg}, 3)
+	ctx.FreeDesc(&patternArg)
+
+	ctx.EmitCmpRegImm32(header.Reg, 0)
+	ctx.EmitJump(CondEqual, failLabel)
+	ctx.ProtectReg(header.Reg)
+	ctx.ProtectReg(header.Reg2)
+	ctx.ProtectReg(header.Reg3)
+	text := stableValue
+	ctx.EnsureDesc(&text)
+	if text.Loc != LocRegPair {
+		panic("jit: regex capture input is not a Scmer pair")
+	}
+	ctx.ProtectReg(text.Reg)
+	ctx.ProtectReg(text.Reg2)
+	captures := make([]JITValueDesc, pattern.NumSubexp()+1)
+	for index := range captures {
+		startReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2)
+		endReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2, startReg)
+		ctx.EmitMovRegMem(startReg, header.Reg, int32(index*16))
+		ctx.EmitMovRegMem(endReg, header.Reg, int32(index*16+8))
+		unmatchedLabel := ctx.ReserveLabel()
+		captureLabel := ctx.ReserveLabel()
+		ctx.EmitCmpRegImm32(startReg, -1)
+		ctx.EmitJump(CondEqual, unmatchedLabel)
+		ptrReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2, startReg, endReg)
+		ctx.EmitMovRegReg(ptrReg, text.Reg)
+		ctx.EmitAddInt64(ptrReg, startReg)
+		ctx.EmitSubInt64(endReg, startReg)
+		ctx.EmitShlRegImm8(endReg, 8)
+		ctx.EmitOrRegImm32(endReg, int32(tagString))
+		ctx.EmitJmp(captureLabel)
+		ctx.MarkLabel(unmatchedLabel)
+		ctx.EmitMovRegImm64(ptrReg, 0)
+		ctx.EmitMovRegImm64(endReg, uint64(tagString))
+		ctx.MarkLabel(captureLabel)
+		ctx.FreeReg(startReg)
+		auxReg := endReg
+		capture := JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ptrReg, Reg2: auxReg, Rooted: true}
+		ctx.BindReg(ptrReg, &capture)
+		ctx.BindReg(auxReg, &capture)
+		off := ctx.AllocStack(16)
+		ctx.EmitStoreScmerToStack(capture, off)
+		ctx.FreeDesc(&capture)
+		captures[index] = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: off, Rooted: true}
+	}
+	ctx.UnprotectReg(text.Reg2)
+	ctx.UnprotectReg(text.Reg)
+	ctx.FreeDesc(&text)
+	ctx.UnprotectReg(header.Reg3)
+	ctx.UnprotectReg(header.Reg2)
+	ctx.UnprotectReg(header.Reg)
+	ctx.FreeDesc(&header)
+	return captures
+}
+
+func registerJITRegexBuiltins() {
+	Declare(&Globalenv, &Declaration{
+		Name: jitConstantRegexpTestName,
+		Fn: func(arguments ...Scmer) Scmer {
+			if len(arguments) != 2 || !arguments[0].IsRegex() {
+				panic("jit constant regexp test expects a precompiled regex and a value")
+			}
+			return jitConstantRegexpTest(arguments[0], arguments[1])
+		},
+		Type: &TypeDescriptor{
+			Kind:      "func",
+			Forbidden: true,
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "pattern"},
+				{Kind: "any", Label: "value"},
+			},
+			Return:         &TypeDescriptor{Kind: "any"},
+			Const:          true,
+			JITVirtualArgs: true,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				if len(sourceArgs) != 2 || len(args) != 2 {
+					panic("jit: malformed constant regexp test")
+				}
+				pattern := sourceArgs[0].WithoutSourceInfo()
+				if !pattern.IsRegex() {
+					panic("jit: constant regexp test requires a precompiled regex")
+				}
+				return jitEmitConstantRegexpTest(ctx, pattern.Regex(), args[1], result)
+			},
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: jitConstantRegexpPredicateName,
+		Fn: func(arguments ...Scmer) Scmer {
+			if len(arguments) != 2 || !arguments[0].IsRegex() {
+				panic("jit constant regexp predicate expects a precompiled regex and a value")
+			}
+			return NewBool(jitConstantRegexpPredicate(arguments[0], arguments[1]))
+		},
+		Type: &TypeDescriptor{
+			Kind:      "func",
+			Forbidden: true,
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "pattern"},
+				{Kind: "any", Label: "value"},
+			},
+			Return:         &TypeDescriptor{Kind: "bool"},
+			Const:          true,
+			JITVirtualArgs: true,
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				if len(sourceArgs) != 2 || len(args) != 2 {
+					panic("jit: malformed constant regexp predicate")
+				}
+				pattern := sourceArgs[0].WithoutSourceInfo()
+				if !pattern.IsRegex() {
+					panic("jit: constant regexp predicate requires a precompiled regex")
+				}
+				predicate := jitEmitConstantRegexpPredicate(ctx, pattern.Regex(), args[1])
+				return jitPlaceScmerIntoTarget(ctx, predicate, result)
+			},
+		},
+	})
+}

--- a/scm/jit_regex.go
+++ b/scm/jit_regex.go
@@ -16,13 +16,19 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+	"regexp/syntax"
+)
 
 const (
 	jitConstantRegexpTestName      = "jit-constant-regexp-test"
 	jitConstantRegexpPredicateName = "jit-constant-regexp-predicate"
 )
 
+// jitConstantRegexpTest is the interpreter implementation of the hidden
+// declaration. Its JIT emitter below never calls it or regexp at runtime.
 func jitConstantRegexpTest(pattern, value Scmer) Scmer {
 	if value.IsNil() {
 		return NewNil()
@@ -30,137 +36,846 @@ func jitConstantRegexpTest(pattern, value Scmer) Scmer {
 	return NewBool(pattern.Regex().MatchString(String(value)))
 }
 
-func jitConstantRegexpPredicate(pattern, value Scmer) bool {
-	text, ok := scmerAsString(value)
-	if !ok {
-		panic("regex expects string")
-	}
-	return pattern.Regex().MatchString(text)
+// jitRegexProgram is compile-time-only, architecture-independent regex IR.
+// regexp/syntax is used while producing machine code; generated code contains
+// only the specialized byte walker emitted below.
+type jitRegexProgram struct {
+	root      *syntax.Regexp
+	captures  int
+	beginText bool
+	pattern   string
 }
 
-func jitConstantRegexpCaptureIndices(pattern, value Scmer) []int {
-	text, ok := scmerAsString(value)
-	if !ok {
-		panic("regex expects string")
-	}
-	return pattern.Regex().FindStringSubmatchIndex(text)
+type jitRegexTermKind uint8
+
+const (
+	jitRegexNode jitRegexTermKind = iota
+	jitRegexCaptureBegin
+	jitRegexCaptureEnd
+)
+
+type jitRegexTerm struct {
+	kind    jitRegexTermKind
+	node    *syntax.Regexp
+	capture int
 }
 
-func jitRegexpScmerArg(ctx *JITContext, value JITValueDesc) JITValueDesc {
-	switch value.Loc {
-	case LocRegPair, LocStackPair, LocInputPair:
-		return value
-	case LocImm:
-		return jitCopyScmerToPair(ctx, value)
-	default:
-		ctx.EnsureDesc(&value)
-		if value.Loc != LocRegPair && value.Loc != LocStackPair {
-			panic("jit: regex expects a Scmer value")
-		}
-		return value
-	}
-}
-
-func jitRegexpPatternArg(ctx *JITContext, pattern *regexp.Regexp) JITValueDesc {
+func jitCompileRegexProgram(pattern *regexp.Regexp) *jitRegexProgram {
 	if pattern == nil {
 		panic("jit: nil constant regex")
 	}
-	value := NewRegex(pattern)
-	ctx.TrackImm(value)
-	return jitCopyScmerToPair(ctx, JITValueDesc{Loc: LocImm, Type: tagRegex, Imm: value})
-}
-
-// jitEmitConstantRegexpTest emits a direct call for a precompiled regular
-// expression. regexp_test's nil result remains distinct from a false match.
-func jitEmitConstantRegexpTest(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, result JITValueDesc) JITValueDesc {
-	patternArg := jitRegexpPatternArg(ctx, pattern)
-	valueArg := jitRegexpScmerArg(ctx, value)
-	target := jitEnsureResultPair(ctx, result)
-	out := ctx.EmitGoCallScalarInto(GoFuncAddr(jitConstantRegexpTest), []JITValueDesc{patternArg, valueArg}, target)
-	ctx.FreeDesc(&patternArg)
-	if value.Loc == LocImm {
-		ctx.FreeDesc(&valueArg)
+	source := pattern.String()
+	root, err := syntax.Parse(source, syntax.Perl)
+	if err != nil {
+		panic("jit: parse precompiled regex: " + err.Error())
 	}
-	out.Type = JITTypeUnknown
-	return out
-}
-
-// jitEmitConstantRegexpPredicate emits the branch-friendly boolean form used
-// by match and, later, compiled parser terminals.
-func jitEmitConstantRegexpPredicate(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc) JITValueDesc {
-	patternArg := jitRegexpPatternArg(ctx, pattern)
-	valueArg := jitRegexpScmerArg(ctx, value)
-	out := ctx.EmitGoCallScalar(GoFuncAddr(jitConstantRegexpPredicate), []JITValueDesc{patternArg, valueArg}, 1)
-	ctx.FreeDesc(&patternArg)
-	if value.Loc == LocImm {
-		ctx.FreeDesc(&valueArg)
+	if root.MaxCap() != pattern.NumSubexp() {
+		panic("jit: regex capture inventory changed while lowering")
 	}
-	out.Type = tagBool
-	out.NoHeapPointer = true
-	return out
+	return &jitRegexProgram{
+		root:      root,
+		captures:  pattern.NumSubexp() + 1,
+		beginText: jitRegexBeginsAtText(root),
+		pattern:   source,
+	}
 }
 
-// jitEmitConstantRegexpCaptures emits one regex execution, branches directly
-// to failLabel when it does not match, and returns stack-backed capture values.
-// Spilling each capture immediately keeps register pressure independent of the
-// number of subexpressions.
-func jitEmitConstantRegexpCaptures(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, failLabel uint8) []JITValueDesc {
-	stableValue := jitMatchStableValue(ctx, value)
-	patternArg := jitRegexpPatternArg(ctx, pattern)
-	valueArg := jitRegexpScmerArg(ctx, stableValue)
-	header := ctx.EmitGoCallScalar(GoFuncAddr(jitConstantRegexpCaptureIndices), []JITValueDesc{patternArg, valueArg}, 3)
-	ctx.FreeDesc(&patternArg)
+func jitRegexBeginsAtText(node *syntax.Regexp) bool {
+	switch node.Op {
+	case syntax.OpBeginText:
+		return true
+	case syntax.OpCapture:
+		return jitRegexBeginsAtText(node.Sub[0])
+	case syntax.OpConcat:
+		for _, child := range node.Sub {
+			if child.Op == syntax.OpEmptyMatch {
+				continue
+			}
+			return jitRegexBeginsAtText(child)
+		}
+	}
+	return false
+}
 
-	ctx.EmitCmpRegImm32(header.Reg, 0)
-	ctx.EmitJump(CondEqual, failLabel)
-	ctx.ProtectReg(header.Reg)
-	ctx.ProtectReg(header.Reg2)
-	ctx.ProtectReg(header.Reg3)
-	text := stableValue
-	ctx.EnsureDesc(&text)
+func jitRegexFlatten(node *syntax.Regexp, keepCaptures bool) []jitRegexTerm {
+	switch node.Op {
+	case syntax.OpConcat:
+		var terms []jitRegexTerm
+		for _, child := range node.Sub {
+			terms = append(terms, jitRegexFlatten(child, keepCaptures)...)
+		}
+		return terms
+	case syntax.OpCapture:
+		if !keepCaptures {
+			return jitRegexFlatten(node.Sub[0], false)
+		}
+		terms := []jitRegexTerm{{kind: jitRegexCaptureBegin, capture: node.Cap}}
+		terms = append(terms, jitRegexFlatten(node.Sub[0], true)...)
+		return append(terms, jitRegexTerm{kind: jitRegexCaptureEnd, capture: node.Cap})
+	default:
+		return []jitRegexTerm{{kind: jitRegexNode, node: node}}
+	}
+}
+
+type jitRegexEmitter struct {
+	ctx           *JITContext
+	program       *jitRegexProgram
+	cursor        Reg
+	end           Reg
+	scan          Reg
+	inputStartOff int32
+	captureStarts []int32
+	captures      []JITValueDesc
+}
+
+func (emitter *jitRegexEmitter) reserveMachineState(input JITValueDesc, invalidLabel uint8, nilLabel *uint8, stringify bool) {
+	original := input
+	if stringify {
+		original = jitMatchStableValue(emitter.ctx, input)
+	}
+	text := original
+	emitter.ctx.EnsureDesc(&text)
 	if text.Loc != LocRegPair {
-		panic("jit: regex capture input is not a Scmer pair")
+		panic("jit: native regex expects a Scmer pair")
 	}
-	ctx.ProtectReg(text.Reg)
-	ctx.ProtectReg(text.Reg2)
-	captures := make([]JITValueDesc, pattern.NumSubexp()+1)
-	for index := range captures {
-		startReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2)
-		endReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2, startReg)
-		ctx.EmitMovRegMem(startReg, header.Reg, int32(index*16))
-		ctx.EmitMovRegMem(endReg, header.Reg, int32(index*16+8))
-		unmatchedLabel := ctx.ReserveLabel()
-		captureLabel := ctx.ReserveLabel()
-		ctx.EmitCmpRegImm32(startReg, -1)
-		ctx.EmitJump(CondEqual, unmatchedLabel)
-		ptrReg := ctx.AllocRegExcept(header.Reg, header.Reg2, header.Reg3, text.Reg, text.Reg2, startReg, endReg)
-		ctx.EmitMovRegReg(ptrReg, text.Reg)
-		ctx.EmitAddInt64(ptrReg, startReg)
-		ctx.EmitSubInt64(endReg, startReg)
-		ctx.EmitShlRegImm8(endReg, 8)
-		ctx.EmitOrRegImm32(endReg, int32(tagString))
-		ctx.EmitJmp(captureLabel)
-		ctx.MarkLabel(unmatchedLabel)
-		ctx.EmitMovRegImm64(ptrReg, 0)
-		ctx.EmitMovRegImm64(endReg, uint64(tagString))
-		ctx.MarkLabel(captureLabel)
-		ctx.FreeReg(startReg)
-		auxReg := endReg
-		capture := JITValueDesc{Loc: LocRegPair, Type: tagString, Reg: ptrReg, Reg2: auxReg, Rooted: true}
-		ctx.BindReg(ptrReg, &capture)
-		ctx.BindReg(auxReg, &capture)
+	emitter.cursor = emitter.ctx.AllocRegExcept(text.Reg, text.Reg2)
+	emitter.end = emitter.ctx.AllocRegExcept(text.Reg, text.Reg2, emitter.cursor)
+	emitter.scan = emitter.ctx.AllocRegExcept(text.Reg, text.Reg2, emitter.cursor, emitter.end)
+	emitter.ctx.ProtectReg(emitter.cursor)
+	emitter.ctx.ProtectReg(emitter.end)
+	emitter.ctx.ProtectReg(emitter.scan)
+
+	if text.Type == JITTypeUnknown {
+		tag := emitter.ctx.AllocRegExcept(text.Reg, text.Reg2)
+		emitter.ctx.EmitMovRegReg(tag, text.Reg2)
+		emitter.ctx.EmitAndRegImm32(tag, 0xff)
+		emitter.ctx.EmitCmpRegImm32(tag, int32(tagString))
+		valid := emitter.ctx.ReserveLabel()
+		emitter.ctx.EmitJump(CondEqual, valid)
+		if nilLabel != nil {
+			emitter.ctx.EmitCmpRegImm32(tag, int32(tagNil))
+			emitter.ctx.EmitJump(CondEqual, *nilLabel)
+		}
+		converted := invalidLabel
+		if stringify {
+			converted = emitter.ctx.ReserveLabel()
+		}
+		emitter.ctx.EmitJmp(converted)
+		emitter.ctx.MarkLabel(valid)
+		emitter.ctx.FreeReg(tag)
+		emitter.emitTaggedStringState(text)
+		if stringify {
+			ready := emitter.ctx.ReserveLabel()
+			emitter.ctx.EmitJmp(ready)
+			emitter.ctx.MarkLabel(converted)
+			emitter.ctx.FreeDesc(&text)
+			goString := emitter.ctx.EmitGoCallScalar(GoFuncAddr(String), []JITValueDesc{original}, 2)
+			emitter.emitGoStringState(goString)
+			emitter.ctx.FreeDesc(&goString)
+			emitter.ctx.MarkLabel(ready)
+		} else {
+			emitter.ctx.FreeDesc(&text)
+		}
+	} else if text.Type == tagNil && nilLabel != nil {
+		emitter.ctx.EmitJmp(*nilLabel)
+		emitter.emitTaggedStringState(text)
+		emitter.ctx.FreeDesc(&text)
+	} else if text.Type != tagString {
+		if !stringify {
+			emitter.ctx.EmitJmp(invalidLabel)
+			emitter.emitTaggedStringState(text)
+			emitter.ctx.FreeDesc(&text)
+		} else {
+			emitter.ctx.FreeDesc(&text)
+			goString := emitter.ctx.EmitGoCallScalar(GoFuncAddr(String), []JITValueDesc{original}, 2)
+			emitter.emitGoStringState(goString)
+			emitter.ctx.FreeDesc(&goString)
+		}
+	} else {
+		emitter.emitTaggedStringState(text)
+		emitter.ctx.FreeDesc(&text)
+	}
+
+	emitter.inputStartOff = emitter.ctx.AllocStack(8)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, emitter.inputStartOff)
+	if len(emitter.captures) != 0 {
+		emitter.captureStarts = make([]int32, len(emitter.captures))
+		for index := range emitter.captureStarts {
+			emitter.captureStarts[index] = emitter.ctx.AllocStack(8)
+		}
+	}
+}
+
+func (emitter *jitRegexEmitter) emitTaggedStringState(text JITValueDesc) {
+	emitter.ctx.EmitMovRegReg(emitter.cursor, text.Reg)
+	emitter.ctx.EmitMovRegReg(emitter.end, text.Reg2)
+	emitter.ctx.EmitShrRegImm8(emitter.end, 8)
+	emitter.ctx.EmitAddInt64(emitter.end, emitter.cursor)
+	emitter.ctx.EmitMovRegReg(emitter.scan, emitter.cursor)
+}
+
+func (emitter *jitRegexEmitter) emitGoStringState(text JITValueDesc) {
+	emitter.ctx.EmitMovRegReg(emitter.cursor, text.Reg)
+	emitter.ctx.EmitMovRegReg(emitter.end, text.Reg2)
+	emitter.ctx.EmitAddInt64(emitter.end, emitter.cursor)
+	emitter.ctx.EmitMovRegReg(emitter.scan, emitter.cursor)
+}
+
+func (emitter *jitRegexEmitter) releaseMachineState() {
+	emitter.ctx.UnprotectReg(emitter.scan)
+	emitter.ctx.UnprotectReg(emitter.end)
+	emitter.ctx.UnprotectReg(emitter.cursor)
+	emitter.ctx.FreeReg(emitter.scan)
+	emitter.ctx.FreeReg(emitter.end)
+	emitter.ctx.FreeReg(emitter.cursor)
+}
+
+func (emitter *jitRegexEmitter) emitCaptureEmpty(index int) {
+	if index < 0 || index >= len(emitter.captures) {
+		return
+	}
+	target := emitter.captures[index]
+	if target.Loc != LocStackPair {
+		panic("jit: regex capture target must be a stable JITValueDesc")
+	}
+	emitter.ctx.EmitMovRegImm64(emitter.ctx.ScratchReg, 0)
+	emitter.ctx.EmitStoreRegMem(emitter.ctx.ScratchReg, emitter.ctx.StackReg, target.StackOff)
+	emitter.ctx.EmitMovRegImm64(emitter.ctx.ScratchReg, uint64(tagString))
+	emitter.ctx.EmitStoreRegMem(emitter.ctx.ScratchReg, emitter.ctx.StackReg, target.StackOff+8)
+	emitter.ctx.setStackPointer(jitStackRootFrameSP, target.StackOff-emitter.ctx.DynamicSP, true)
+}
+
+func (emitter *jitRegexEmitter) emitCaptureBegin(index int) {
+	if index < 0 || index >= len(emitter.captureStarts) {
+		return
+	}
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, emitter.captureStarts[index])
+}
+
+func (emitter *jitRegexEmitter) emitCaptureEnd(index int) {
+	if index < 0 || index >= len(emitter.captures) {
+		return
+	}
+	target := emitter.captures[index]
+	if target.Loc != LocStackPair {
+		panic("jit: regex capture target must be a stable JITValueDesc")
+	}
+	start := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	aux := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, start)
+	emitter.ctx.EmitMovRegMem(start, emitter.ctx.StackReg, emitter.captureStarts[index])
+	emitter.ctx.EmitMovRegReg(aux, emitter.cursor)
+	emitter.ctx.EmitSubInt64(aux, start)
+	emitter.ctx.EmitShlRegImm8(aux, 8)
+	emitter.ctx.EmitOrRegImm32(aux, int32(tagString))
+	emitter.ctx.EmitStoreRegMem(start, emitter.ctx.StackReg, target.StackOff)
+	emitter.ctx.EmitStoreRegMem(aux, emitter.ctx.StackReg, target.StackOff+8)
+	emitter.ctx.setStackPointer(jitStackRootFrameSP, target.StackOff-emitter.ctx.DynamicSP, true)
+	emitter.ctx.FreeReg(aux)
+	emitter.ctx.FreeReg(start)
+}
+
+func (emitter *jitRegexEmitter) emitResetCaptures(terms []jitRegexTerm) {
+	if len(emitter.captures) == 0 {
+		return
+	}
+	seen := make([]bool, len(emitter.captures))
+	var visit func([]jitRegexTerm)
+	visit = func(items []jitRegexTerm) {
+		for _, term := range items {
+			if term.kind != jitRegexNode {
+				if term.capture >= 0 && term.capture < len(seen) {
+					seen[term.capture] = true
+				}
+				continue
+			}
+			if term.node.Op == syntax.OpAlternate {
+				for _, branch := range term.node.Sub {
+					visit(jitRegexFlatten(branch, true))
+				}
+			}
+		}
+	}
+	visit(terms)
+	for index, reset := range seen {
+		if reset {
+			emitter.emitCaptureEmpty(index)
+		}
+	}
+}
+
+func (emitter *jitRegexEmitter) emitProgram(successLabel, failLabel uint8) {
+	attemptLabel := emitter.ctx.ReserveLabel()
+	attemptFailLabel := emitter.ctx.ReserveLabel()
+	emitter.ctx.MarkLabel(attemptLabel)
+	emitter.ctx.EmitMovRegReg(emitter.cursor, emitter.scan)
+	for index := range emitter.captures {
+		emitter.emitCaptureEmpty(index)
+	}
+	terms := jitRegexFlatten(emitter.program.root, len(emitter.captures) != 0)
+	if len(emitter.captures) != 0 {
+		terms = append([]jitRegexTerm{{kind: jitRegexCaptureBegin, capture: 0}}, terms...)
+		terms = append(terms, jitRegexTerm{kind: jitRegexCaptureEnd, capture: 0})
+	}
+	emitter.emitSequence(terms, successLabel, attemptFailLabel)
+
+	emitter.ctx.MarkLabel(attemptFailLabel)
+	if emitter.program.beginText {
+		emitter.ctx.EmitJmp(failLabel)
+		return
+	}
+	emitter.ctx.EmitAddRegImm32(emitter.scan, 1)
+	emitter.ctx.EmitCmpInt64(emitter.scan, emitter.end)
+	emitter.ctx.EmitJump(CondUnsignedBelowOrEqual, attemptLabel)
+	emitter.ctx.EmitJmp(failLabel)
+}
+
+func (emitter *jitRegexEmitter) emitSequence(terms []jitRegexTerm, successLabel, failLabel uint8) {
+	for len(terms) != 0 {
+		term := terms[0]
+		terms = terms[1:]
+		switch term.kind {
+		case jitRegexCaptureBegin:
+			emitter.emitCaptureBegin(term.capture)
+			continue
+		case jitRegexCaptureEnd:
+			emitter.emitCaptureEnd(term.capture)
+			continue
+		}
+
+		node := term.node
+		switch node.Op {
+		case syntax.OpAlternate:
+			emitter.emitAlternatives(node.Sub, terms, successLabel, failLabel)
+			return
+		case syntax.OpQuest:
+			emitter.emitOptional(node.Sub[0], terms, successLabel, failLabel, node.Flags&syntax.NonGreedy == 0)
+			return
+		case syntax.OpStar:
+			emitter.emitRepeat(node.Sub[0], 0, -1, node.Flags&syntax.NonGreedy == 0, terms, successLabel, failLabel)
+			return
+		case syntax.OpPlus:
+			emitter.emitRepeat(node.Sub[0], 1, -1, node.Flags&syntax.NonGreedy == 0, terms, successLabel, failLabel)
+			return
+		case syntax.OpRepeat:
+			emitter.emitRepeat(node.Sub[0], node.Min, node.Max, node.Flags&syntax.NonGreedy == 0, terms, successLabel, failLabel)
+			return
+		default:
+			emitter.emitAtom(node, failLabel)
+		}
+	}
+	emitter.ctx.EmitJmp(successLabel)
+}
+
+func (emitter *jitRegexEmitter) emitAlternatives(branches []*syntax.Regexp, rest []jitRegexTerm, successLabel, failLabel uint8) {
+	if len(branches) == 0 {
+		emitter.ctx.EmitJmp(failLabel)
+		return
+	}
+	savedCursor := emitter.ctx.AllocStack(8)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, savedCursor)
+	for index, branch := range branches {
+		branchTerms := append(jitRegexFlatten(branch, len(emitter.captures) != 0), rest...)
+		if index == len(branches)-1 {
+			emitter.emitSequence(branchTerms, successLabel, failLabel)
+			return
+		}
+		next := emitter.ctx.ReserveLabel()
+		emitter.emitSequence(branchTerms, successLabel, next)
+		emitter.ctx.MarkLabel(next)
+		emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, savedCursor)
+		emitter.emitResetCaptures(branchTerms)
+	}
+}
+
+func (emitter *jitRegexEmitter) emitOptional(node *syntax.Regexp, rest []jitRegexTerm, successLabel, failLabel uint8, greedy bool) {
+	empty := &syntax.Regexp{Op: syntax.OpEmptyMatch}
+	branches := []*syntax.Regexp{node, empty}
+	if !greedy {
+		branches[0], branches[1] = branches[1], branches[0]
+	}
+	emitter.emitAlternatives(branches, rest, successLabel, failLabel)
+}
+
+func jitRegexSimpleWidth(node *syntax.Regexp) (int, bool) {
+	switch node.Op {
+	case syntax.OpLiteral:
+		return len(string(node.Rune)), len(node.Rune) != 0
+	case syntax.OpCharClass, syntax.OpAnyCharNotNL, syntax.OpAnyChar:
+		return 1, true
+	case syntax.OpConcat:
+		width := 0
+		for _, child := range node.Sub {
+			childWidth, simple := jitRegexSimpleWidth(child)
+			if !simple {
+				return 0, false
+			}
+			width += childWidth
+		}
+		return width, width != 0
+	}
+	return 0, false
+}
+
+func (emitter *jitRegexEmitter) emitSimple(node *syntax.Regexp, failLabel uint8) {
+	if node.Op == syntax.OpConcat {
+		for _, child := range node.Sub {
+			emitter.emitSimple(child, failLabel)
+		}
+		return
+	}
+	emitter.emitAtom(node, failLabel)
+}
+
+func (emitter *jitRegexEmitter) emitRepeat(node *syntax.Regexp, min, max int, greedy bool, rest []jitRegexTerm, successLabel, failLabel uint8) {
+	if max >= 0 {
+		if max < min {
+			panic("jit: invalid regex repetition")
+		}
+		if min != 0 {
+			required := make([]jitRegexTerm, 0, min+len(rest))
+			for range min {
+				required = append(required, jitRegexFlatten(node, len(emitter.captures) != 0)...)
+			}
+			if max != min {
+				optional := &syntax.Regexp{Op: syntax.OpRepeat, Min: 0, Max: max - min, Flags: syntax.PerlX, Sub: []*syntax.Regexp{node}}
+				if !greedy {
+					optional.Flags |= syntax.NonGreedy
+				}
+				required = append(required, jitRegexTerm{kind: jitRegexNode, node: optional})
+			}
+			emitter.emitSequence(append(required, rest...), successLabel, failLabel)
+			return
+		}
+		if max == 0 {
+			emitter.emitSequence(rest, successLabel, failLabel)
+			return
+		}
+		if max == 1 {
+			emitter.emitOptional(node, rest, successLabel, failLabel, greedy)
+			return
+		}
+		next := &syntax.Regexp{Op: syntax.OpRepeat, Min: 0, Max: max - 1, Flags: syntax.PerlX, Sub: []*syntax.Regexp{node}}
+		if !greedy {
+			next.Flags |= syntax.NonGreedy
+		}
+		combined := &syntax.Regexp{Op: syntax.OpConcat, Sub: []*syntax.Regexp{node, next}}
+		emitter.emitOptional(combined, rest, successLabel, failLabel, greedy)
+		return
+	}
+
+	width, simple := jitRegexSimpleWidth(node)
+	if simple {
+		emitter.emitSimpleRepeat(node, width, min, greedy, rest, successLabel, failLabel)
+		return
+	}
+	if !jitRegexTailOnly(rest) {
+		panic(fmt.Sprintf("jit: regex %q requires a variable-width repetition stack", emitter.program.pattern))
+	}
+	emitter.emitComplexTailRepeat(node, min, rest, successLabel, failLabel)
+}
+
+func jitRegexTailOnly(terms []jitRegexTerm) bool {
+	for _, term := range terms {
+		if term.kind == jitRegexCaptureEnd {
+			continue
+		}
+		if term.kind == jitRegexNode && (term.node.Op == syntax.OpEndText || term.node.Op == syntax.OpEndLine || term.node.Op == syntax.OpEmptyMatch) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func (emitter *jitRegexEmitter) emitSimpleRepeat(node *syntax.Regexp, width, min int, greedy bool, rest []jitRegexTerm, successLabel, failLabel uint8) {
+	for range min {
+		emitter.emitSimple(node, failLabel)
+	}
+	minimumCursor := emitter.ctx.AllocStack(8)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, minimumCursor)
+	if !greedy {
+		retry := emitter.ctx.ReserveLabel()
+		grow := emitter.ctx.ReserveLabel()
+		emitter.ctx.MarkLabel(retry)
+		candidate := emitter.ctx.AllocStack(8)
+		emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, candidate)
+		emitter.emitSequence(rest, successLabel, grow)
+		emitter.ctx.MarkLabel(grow)
+		emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, candidate)
+		emitter.emitSimple(node, failLabel)
+		emitter.ctx.EmitJmp(retry)
+		return
+	}
+
+	loop := emitter.ctx.ReserveLabel()
+	done := emitter.ctx.ReserveLabel()
+	retry := emitter.ctx.ReserveLabel()
+	backtrack := emitter.ctx.ReserveLabel()
+	trial := emitter.ctx.AllocStack(8)
+	candidate := emitter.ctx.AllocStack(8)
+	emitter.ctx.MarkLabel(loop)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	emitter.emitSimple(node, done)
+	emitter.ctx.EmitJmp(loop)
+	emitter.ctx.MarkLabel(done)
+	emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	emitter.ctx.MarkLabel(retry)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, candidate)
+	emitter.emitSequence(rest, successLabel, backtrack)
+	emitter.ctx.MarkLabel(backtrack)
+	emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, candidate)
+	tmp := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegMem(tmp, emitter.ctx.StackReg, minimumCursor)
+	emitter.ctx.EmitCmpInt64(emitter.cursor, tmp)
+	emitter.ctx.FreeReg(tmp)
+	emitter.ctx.EmitJump(CondUnsignedBelowOrEqual, failLabel)
+	emitter.ctx.EmitSubRegImm32(emitter.cursor, int32(width))
+	emitter.ctx.EmitJmp(retry)
+}
+
+func (emitter *jitRegexEmitter) emitComplexTailRepeat(node *syntax.Regexp, min int, rest []jitRegexTerm, successLabel, failLabel uint8) {
+	for range min {
+		next := emitter.ctx.ReserveLabel()
+		emitter.emitSequence(jitRegexFlatten(node, len(emitter.captures) != 0), next, failLabel)
+		emitter.ctx.MarkLabel(next)
+	}
+	loop := emitter.ctx.ReserveLabel()
+	matched := emitter.ctx.ReserveLabel()
+	done := emitter.ctx.ReserveLabel()
+	trial := emitter.ctx.AllocStack(8)
+	emitter.ctx.MarkLabel(loop)
+	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	emitter.emitSequence(jitRegexFlatten(node, len(emitter.captures) != 0), matched, done)
+	emitter.ctx.MarkLabel(matched)
+	tmp := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegMem(tmp, emitter.ctx.StackReg, trial)
+	emitter.ctx.EmitCmpInt64(emitter.cursor, tmp)
+	emitter.ctx.FreeReg(tmp)
+	emitter.ctx.EmitJump(CondEqual, done)
+	emitter.ctx.EmitJmp(loop)
+	emitter.ctx.MarkLabel(done)
+	emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	emitter.emitSequence(rest, successLabel, failLabel)
+}
+
+func (emitter *jitRegexEmitter) emitAtom(node *syntax.Regexp, failLabel uint8) {
+	switch node.Op {
+	case syntax.OpNoMatch:
+		emitter.ctx.EmitJmp(failLabel)
+	case syntax.OpEmptyMatch:
+		return
+	case syntax.OpLiteral:
+		emitter.emitLiteral(node, failLabel)
+	case syntax.OpCharClass, syntax.OpAnyCharNotNL, syntax.OpAnyChar:
+		emitter.emitByteClass(node, failLabel)
+	case syntax.OpBeginText:
+		tmp := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+		emitter.ctx.EmitMovRegMem(tmp, emitter.ctx.StackReg, emitter.inputStartOff)
+		emitter.ctx.EmitCmpInt64(emitter.cursor, tmp)
+		emitter.ctx.FreeReg(tmp)
+		emitter.ctx.EmitJump(CondNotEqual, failLabel)
+	case syntax.OpEndText:
+		emitter.ctx.EmitCmpInt64(emitter.cursor, emitter.end)
+		emitter.ctx.EmitJump(CondNotEqual, failLabel)
+	case syntax.OpBeginLine:
+		emitter.emitBeginLine(failLabel)
+	case syntax.OpEndLine:
+		emitter.emitEndLine(failLabel)
+	case syntax.OpWordBoundary:
+		emitter.emitWordBoundary(failLabel, true)
+	case syntax.OpNoWordBoundary:
+		emitter.emitWordBoundary(failLabel, false)
+	default:
+		panic(fmt.Sprintf("jit: unsupported regex operation %s in %q", node.Op, emitter.program.pattern))
+	}
+}
+
+func (emitter *jitRegexEmitter) emitBounds(width int, failLabel uint8) {
+	remaining := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegReg(remaining, emitter.end)
+	emitter.ctx.EmitSubInt64(remaining, emitter.cursor)
+	emitter.ctx.EmitCmpRegImm32(remaining, int32(width))
+	emitter.ctx.FreeReg(remaining)
+	emitter.ctx.EmitJump(CondUnsignedBelow, failLabel)
+}
+
+func (emitter *jitRegexEmitter) emitLiteral(node *syntax.Regexp, failLabel uint8) {
+	literal := []byte(string(node.Rune))
+	if len(literal) == 0 {
+		return
+	}
+	mask := make([]byte, len(literal))
+	for index := range mask {
+		mask[index] = 0xff
+	}
+	if node.Flags&syntax.FoldCase != 0 {
+		for index, value := range literal {
+			if value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z' {
+				mask[index] = 0xdf
+				literal[index] &= 0xdf
+				continue
+			}
+			if value >= 0x80 {
+				panic(fmt.Sprintf("jit: Unicode case folding is not yet native for %q", emitter.program.pattern))
+			}
+		}
+	}
+	emitter.emitBounds(len(literal), failLabel)
+	for offset := 0; offset < len(literal); {
+		width := 1
+		remaining := len(literal) - offset
+		switch {
+		case remaining >= 8:
+			width = 8
+		case remaining >= 4:
+			width = 4
+		case remaining >= 2:
+			width = 2
+		}
+		emitter.ctx.EmitMaskedLiteralCheck(emitter.cursor, int32(offset), literal[offset:offset+width], mask[offset:offset+width], failLabel)
+		offset += width
+	}
+	emitter.ctx.EmitAddRegImm32(emitter.cursor, int32(len(literal)))
+}
+
+func jitRegexByteRanges(node *syntax.Regexp) [][2]byte {
+	accepted := [256]bool{}
+	switch node.Op {
+	case syntax.OpAnyChar:
+		for index := range accepted {
+			accepted[index] = true
+		}
+	case syntax.OpAnyCharNotNL:
+		for index := range accepted {
+			accepted[index] = byte(index) != '\n'
+		}
+	case syntax.OpCharClass:
+		for value := 0; value < 256; value++ {
+			r := rune(value)
+			for index := 0; index+1 < len(node.Rune); index += 2 {
+				if r >= node.Rune[index] && r <= node.Rune[index+1] {
+					accepted[value] = true
+					break
+				}
+			}
+		}
+	default:
+		panic("jit: byte ranges require a consuming character operation")
+	}
+	var ranges [][2]byte
+	for start := 0; start < len(accepted); {
+		if !accepted[start] {
+			start++
+			continue
+		}
+		end := start
+		for end+1 < len(accepted) && accepted[end+1] {
+			end++
+		}
+		ranges = append(ranges, [2]byte{byte(start), byte(end)})
+		start = end + 1
+	}
+	return ranges
+}
+
+func (emitter *jitRegexEmitter) emitByteClass(node *syntax.Regexp, failLabel uint8) {
+	emitter.emitBounds(1, failLabel)
+	char := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegMemB(char, emitter.cursor, 0)
+	ranges := jitRegexByteRanges(node)
+	if len(ranges) == 0 {
+		emitter.ctx.FreeReg(char)
+		emitter.ctx.EmitJmp(failLabel)
+		return
+	}
+	matched := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, char)
+	emitter.ctx.EmitMovRegImm64(matched, 0)
+	for _, interval := range ranges {
+		candidate := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, char, matched)
+		emitter.ctx.EmitMovRegReg(candidate, char)
+		if interval[0] != 0 {
+			emitter.ctx.EmitSubRegImm32(candidate, int32(interval[0]))
+		}
+		emitter.ctx.EmitCmpRegImm32(candidate, int32(uint16(interval[1])-uint16(interval[0])))
+		emitter.ctx.EmitSetcc(candidate, CondUnsignedBelowOrEqual)
+		emitter.ctx.EmitOrInt64(matched, candidate)
+		emitter.ctx.FreeReg(candidate)
+	}
+	emitter.ctx.FreeReg(char)
+	emitter.ctx.EmitCmpRegImm32(matched, 0)
+	emitter.ctx.FreeReg(matched)
+	emitter.ctx.EmitJump(CondEqual, failLabel)
+	emitter.ctx.EmitAddRegImm32(emitter.cursor, 1)
+}
+
+func (emitter *jitRegexEmitter) emitBeginLine(failLabel uint8) {
+	base := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegMem(base, emitter.ctx.StackReg, emitter.inputStartOff)
+	done := emitter.ctx.ReserveLabel()
+	emitter.ctx.EmitCmpInt64(emitter.cursor, base)
+	emitter.ctx.EmitJump(CondEqual, done)
+	emitter.ctx.EmitMovRegMemB(base, emitter.cursor, -1)
+	emitter.ctx.EmitCmpRegImm32(base, '\n')
+	emitter.ctx.EmitJump(CondEqual, done)
+	emitter.ctx.EmitJmp(failLabel)
+	emitter.ctx.MarkLabel(done)
+	emitter.ctx.FreeReg(base)
+}
+
+func (emitter *jitRegexEmitter) emitEndLine(failLabel uint8) {
+	done := emitter.ctx.ReserveLabel()
+	emitter.ctx.EmitCmpInt64(emitter.cursor, emitter.end)
+	emitter.ctx.EmitJump(CondEqual, done)
+	tmp := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegMemB(tmp, emitter.cursor, 0)
+	emitter.ctx.EmitCmpRegImm32(tmp, '\n')
+	emitter.ctx.FreeReg(tmp)
+	emitter.ctx.EmitJump(CondEqual, done)
+	emitter.ctx.EmitJmp(failLabel)
+	emitter.ctx.MarkLabel(done)
+}
+
+func (emitter *jitRegexEmitter) emitWordClass(pointer Reg, offset int32) Reg {
+	char := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, pointer)
+	emitter.ctx.EmitMovRegMemB(char, pointer, offset)
+	combined := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, pointer, char)
+	emitter.ctx.EmitMovRegImm64(combined, 0)
+	for _, interval := range [][2]byte{{'0', '9'}, {'A', 'Z'}, {'_', '_'}, {'a', 'z'}} {
+		candidate := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, pointer, char, combined)
+		emitter.ctx.EmitMovRegReg(candidate, char)
+		emitter.ctx.EmitSubRegImm32(candidate, int32(interval[0]))
+		emitter.ctx.EmitCmpRegImm32(candidate, int32(interval[1]-interval[0]))
+		emitter.ctx.EmitSetcc(candidate, CondUnsignedBelowOrEqual)
+		emitter.ctx.EmitOrInt64(combined, candidate)
+		emitter.ctx.FreeReg(candidate)
+	}
+	emitter.ctx.FreeReg(char)
+	return combined
+}
+
+func (emitter *jitRegexEmitter) emitWordBoundary(failLabel uint8, expected bool) {
+	prev := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
+	emitter.ctx.EmitMovRegImm64(prev, 0)
+	prevMissing := emitter.ctx.ReserveLabel()
+	prevReady := emitter.ctx.ReserveLabel()
+	base := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, prev)
+	emitter.ctx.EmitMovRegMem(base, emitter.ctx.StackReg, emitter.inputStartOff)
+	emitter.ctx.EmitCmpInt64(emitter.cursor, base)
+	emitter.ctx.FreeReg(base)
+	emitter.ctx.EmitJump(CondEqual, prevMissing)
+	prevWord := emitter.emitWordClass(emitter.cursor, -1)
+	emitter.ctx.EmitMovRegReg(prev, prevWord)
+	emitter.ctx.FreeReg(prevWord)
+	emitter.ctx.EmitJmp(prevReady)
+	emitter.ctx.MarkLabel(prevMissing)
+	emitter.ctx.MarkLabel(prevReady)
+
+	next := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, prev)
+	emitter.ctx.EmitMovRegImm64(next, 0)
+	nextMissing := emitter.ctx.ReserveLabel()
+	nextReady := emitter.ctx.ReserveLabel()
+	emitter.ctx.EmitCmpInt64(emitter.cursor, emitter.end)
+	emitter.ctx.EmitJump(CondEqual, nextMissing)
+	nextWord := emitter.emitWordClass(emitter.cursor, 0)
+	emitter.ctx.EmitMovRegReg(next, nextWord)
+	emitter.ctx.FreeReg(nextWord)
+	emitter.ctx.EmitJmp(nextReady)
+	emitter.ctx.MarkLabel(nextMissing)
+	emitter.ctx.MarkLabel(nextReady)
+	emitter.ctx.EmitXorInt64(prev, next)
+	emitter.ctx.FreeReg(next)
+	emitter.ctx.EmitCmpRegImm32(prev, 0)
+	emitter.ctx.FreeReg(prev)
+	if expected {
+		emitter.ctx.EmitJump(CondEqual, failLabel)
+	} else {
+		emitter.ctx.EmitJump(CondNotEqual, failLabel)
+	}
+}
+
+func jitRegexCaptureTargets(ctx *JITContext, count int) []JITValueDesc {
+	targets := make([]JITValueDesc, count)
+	for index := range targets {
 		off := ctx.AllocStack(16)
-		ctx.EmitStoreScmerToStack(capture, off)
-		ctx.FreeDesc(&capture)
-		captures[index] = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: off, Rooted: true}
+		targets[index] = JITValueDesc{Loc: LocStackPair, Type: tagString, StackOff: off, Rooted: true}
 	}
-	ctx.UnprotectReg(text.Reg2)
-	ctx.UnprotectReg(text.Reg)
-	ctx.FreeDesc(&text)
-	ctx.UnprotectReg(header.Reg3)
-	ctx.UnprotectReg(header.Reg2)
-	ctx.UnprotectReg(header.Reg)
-	ctx.FreeDesc(&header)
+	return targets
+}
+
+func jitEmitNativeRegex(ctx *JITContext, program *jitRegexProgram, value JITValueDesc, captures []JITValueDesc, successLabel, failLabel, invalidLabel uint8, nilLabel *uint8, stringify bool) {
+	emitter := &jitRegexEmitter{ctx: ctx, program: program, captures: captures}
+	emitter.reserveMachineState(value, invalidLabel, nilLabel, stringify)
+	emitter.emitProgram(successLabel, failLabel)
+	emitter.releaseMachineState()
+}
+
+func jitEmitConstantRegexpTest(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, result JITValueDesc) JITValueDesc {
+	if value.Loc == LocImm {
+		out := jitConstantRegexpTest(NewRegex(pattern), value.Imm)
+		return jitPlaceScmerIntoTarget(ctx, JITValueDesc{Loc: LocImm, Type: out.GetTag(), Imm: out}, result)
+	}
+	program := jitCompileRegexProgram(pattern)
+	target := jitEnsureResultPair(ctx, result)
+	success := ctx.ReserveLabel()
+	fail := ctx.ReserveLabel()
+	nilResult := ctx.ReserveLabel()
+	done := ctx.ReserveLabel()
+	jitEmitNativeRegex(ctx, program, value, nil, success, fail, fail, &nilResult, true)
+	ctx.MarkLabel(success)
+	ctx.EmitMakeBool(target, JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(true)})
+	ctx.EmitJmp(done)
+	ctx.MarkLabel(fail)
+	ctx.EmitMakeBool(target, JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(false)})
+	ctx.EmitJmp(done)
+	ctx.MarkLabel(nilResult)
+	ctx.EmitMakeNil(target)
+	ctx.MarkLabel(done)
+	target.Type = JITTypeUnknown
+	return target
+}
+
+func jitEmitConstantRegexpPredicate(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc) JITValueDesc {
+	if value.Loc == LocImm {
+		text, ok := scmerAsString(value.Imm)
+		if !ok {
+			panic("regex expects string")
+		}
+		return JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(pattern.MatchString(text)), NoHeapPointer: true}
+	}
+	program := jitCompileRegexProgram(pattern)
+	result := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: ctx.AllocReg(), NoHeapPointer: true}
+	ctx.BindReg(result.Reg, &result)
+	success := ctx.ReserveLabel()
+	fail := ctx.ReserveLabel()
+	invalid := ctx.ReserveLabel()
+	done := ctx.ReserveLabel()
+	jitEmitNativeRegex(ctx, program, value, nil, success, fail, invalid, nil, false)
+	ctx.MarkLabel(success)
+	ctx.EmitMovRegImm64(result.Reg, 1)
+	ctx.EmitJmp(done)
+	ctx.MarkLabel(fail)
+	ctx.EmitMovRegImm64(result.Reg, 0)
+	ctx.EmitJmp(done)
+	ctx.MarkLabel(invalid)
+	ctx.EmitGoPanic("regex expects string")
+	ctx.EmitMovRegImm64(result.Reg, 0)
+	ctx.MarkLabel(done)
+	return result
+}
+
+// jitEmitConstantRegexpCaptures emits captures directly into their final
+// JITValueDesc slots. No index slice or intermediate capture representation is
+// created at runtime.
+func jitEmitConstantRegexpCaptures(ctx *JITContext, pattern *regexp.Regexp, value JITValueDesc, failLabel uint8) []JITValueDesc {
+	program := jitCompileRegexProgram(pattern)
+	captures := jitRegexCaptureTargets(ctx, program.captures)
+	success := ctx.ReserveLabel()
+	invalid := ctx.ReserveLabel()
+	jitEmitNativeRegex(ctx, program, value, captures, success, failLabel, invalid, nil, false)
+	ctx.MarkLabel(invalid)
+	ctx.EmitGoPanic("regex expects string")
+	ctx.EmitJmp(failLabel)
+	ctx.MarkLabel(success)
 	return captures
 }
 
@@ -201,7 +916,11 @@ func registerJITRegexBuiltins() {
 			if len(arguments) != 2 || !arguments[0].IsRegex() {
 				panic("jit constant regexp predicate expects a precompiled regex and a value")
 			}
-			return NewBool(jitConstantRegexpPredicate(arguments[0], arguments[1]))
+			text, ok := scmerAsString(arguments[1])
+			if !ok {
+				panic("regex expects string")
+			}
+			return NewBool(arguments[0].Regex().MatchString(text))
 		},
 		Type: &TypeDescriptor{
 			Kind:      "func",

--- a/scm/jit_regex_native_test.go
+++ b/scm/jit_regex_native_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+var constantRegexInventory = []string{
+	`(?:[^"])+`,
+	`(\\.|[^\'])*`,
+	`-?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e-?[0-9]+)?`,
+	`-?[0-9]+`,
+	`.*\.sql(?:\.gz)?$`,
+	`[0-9]+`,
+	`[a-zA-Z0-9_]+`,
+	`[a-zA-Z_][a-zA-Z0-9_]*`,
+	`^(.*)/[^/]+$`,
+	`^[\r\n\t ]*ALTER DATABASE (?s:.*)\z`,
+	`^[\r\n\t ]*ALTER FUNCTION (?s:.*)\z`,
+	`^[\r\n\t ]*ALTER SCHEMA (?s:.*)\z`,
+	`^[\r\n\t ]*ALTER SEQUENCE (?s:.*)\z`,
+	`^[\r\n\t ]*ALTER STATISTICS (?s:.*)\z`,
+	`^[\r\n\t ]*COMMENT ON EXTENSION (?s:.*)\z`,
+	`^[\r\n\t ]*COPY (.*) FROM '([^']+)'\z`,
+	`^[\r\n\t ]*CREATE EXTENSION (?s:.*)\z`,
+	`^[\r\n\t ]*CREATE INDEX (?s:.*)\z`,
+	`^[\r\n\t ]*CREATE SEQUENCE (?s:.*)\z`,
+	`^[\r\n\t ]*CREATE STATISTICS (?s:.*)\z`,
+	`^[\r\n\t ]*CREATE TRIGGER (?s:.*)\z`,
+	`^[\r\n\t ]*CREATE UNIQUE INDEX (?s:.*)\z`,
+	`^[^.]+\.(.*)_(.*?)_seq\z`,
+	`^[a-zA-Z_][a-zA-Z0-9_]*$`,
+	`(.*)_(.*?)_seq`,
+	`(?:[^` + "`" + `]|` + "``" + `)+`,
+	`(\\.|''|[^\'])*`,
+	`(\\.|""|[^\"])*`,
+	`0[xX](?:[0-9A-Fa-f]{2})*`,
+	`^(?is:SELECT[\r\n\t ]+DISTINCT[\r\n\t ]+TABLESPACE_NAME.*FROM[\r\n\t ]+INFORMATION_SCHEMA\.FILES.*FILE_TYPE[\r\n\t ]*=[\r\n\t ]*'DATAFILE'.*)\z`,
+	`^(?is:SELECT[\r\n\t ]+LOGFILE_GROUP_NAME.*FROM[\r\n\t ]+INFORMATION_SCHEMA\.FILES.*FILE_TYPE[\r\n\t ]*=[\r\n\t ]*'UNDO LOG'.*)\z`,
+	`^/\*![0-9]+[\r\n\t ]+((?is:CREATE[\r\n\t ]+TRIGGER.*))[\r\n\t ]*\*/$`,
+	`^/\*![0-9]+[\r\n\t ]+CREATE[\r\n\t ]*\*/[\r\n\t ]*/\*![0-9]+[\r\n\t ]+DEFINER=(?is:.*?)[\r\n\t ]*\*/[\r\n\t ]*/\*![0-9]+[\r\n\t ]+((?is:TRIGGER.*))[\r\n\t ]*\*/$`,
+	`^\s*SELECT\b`,
+	`(?s:.*)\bLIKE$`,
+	`\b(?:LIKE|MATCH|JOIN|EXISTS)\b`,
+	`^v[0-9]+$`,
+	`^/sql/([^/]+)/(.*)$`,
+	`^((?s:.*));\s*$`,
+}
+
+var nativeRegexCorpus = []string{
+	"",
+	"abc",
+	"ABC_123",
+	"-17",
+	"-.25e-3",
+	"0xCAFE",
+	"a.sql",
+	"dump.sql.gz",
+	"dir/table_name_seq",
+	"public.table_column_seq",
+	"\n CREATE UNIQUE INDEX idx ON t (id)",
+	"COPY public.t FROM '/tmp/data.csv'",
+	"ALTER DATABASE app OWNER TO admin",
+	"ALTER FUNCTION f() OWNER TO admin",
+	"ALTER SCHEMA app OWNER TO admin",
+	"ALTER SEQUENCE app.seq RESTART WITH 1",
+	"ALTER STATISTICS app.stats OWNER TO admin",
+	"COMMENT ON EXTENSION plpgsql IS 'x'",
+	"CREATE EXTENSION pgcrypto",
+	"CREATE INDEX idx ON t (id)",
+	"CREATE SEQUENCE app.seq",
+	"CREATE STATISTICS app.stats ON id FROM t",
+	"CREATE TRIGGER trg BEFORE INSERT ON t EXECUTE FUNCTION f()",
+	"SELECT DISTINCT TABLESPACE_NAME FROM INFORMATION_SCHEMA.FILES WHERE FILE_TYPE = 'DATAFILE'",
+	"SELECT x FROM t WHERE x LIKE 'a%'",
+	"/sql/example/SELECT%201",
+	"SELECT 1; \t",
+	"v123",
+	"/*!50003 CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @x=1 */",
+	"quoted '' value",
+	"quoted \\\" value",
+	"Grüße",
+}
+
+func nativeRegexDifferentialCorpus() []string {
+	corpus := append([]string(nil), nativeRegexCorpus...)
+	alphabet := []rune("abcXYZ019_./'\"`-+*?! =;\r\n\tä世")
+	state := uint64(0x709c0de)
+	for range 192 {
+		state = state*6364136223846793005 + 1
+		length := int(state>>58) & 31
+		value := make([]rune, length)
+		for index := range value {
+			state = state*6364136223846793005 + 1
+			value[index] = alphabet[int(state%uint64(len(alphabet)))]
+		}
+		corpus = append(corpus, string(value))
+	}
+	return corpus
+}
+
+func compileNativeRegexpTest(t *testing.T, pattern string) Scmer {
+	t.Helper()
+	source := fmt.Sprintf("(lambda (value) (regexp_test value %s))", strconv.Quote(pattern))
+	compiled := compileJITExpressionTestProc(t, source)
+	requireNoDynamicJITCalls(t, compiled)
+	if calls := compiled.Proc().Compiled.Coverage.NativeCalls; calls != 0 {
+		t.Fatalf("constant regex emitted %d native builtin calls", calls)
+	}
+	return compiled
+}
+
+func TestJITNativeRegexSQLParserInventory(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	corpus := nativeRegexDifferentialCorpus()
+	for _, pattern := range constantRegexInventory {
+		t.Run(pattern, func(t *testing.T) {
+			wantMatcher := regexp.MustCompile(pattern)
+			compiled := compileNativeRegexpTest(t, pattern)
+			for _, input := range corpus {
+				got := Apply(compiled, NewString(input))
+				want := wantMatcher.MatchString(input)
+				if !got.IsBool() || got.Bool() != want {
+					t.Fatalf("pattern %q input %q: JIT returned %s, want %t", pattern, input, String(got), want)
+				}
+			}
+		})
+	}
+}
+
+func TestJITNativeRegexpTestPreservesNil(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	compiled := compileNativeRegexpTest(t, `^[a-z]+$`)
+	if got := Apply(compiled, NewNil()); !got.IsNil() {
+		t.Fatalf("regexp_test(nil, pattern) returned %s, want nil", String(got))
+	}
+	compiled = compileNativeRegexpTest(t, `^42$`)
+	if got := Apply(compiled, NewInt(42)); !got.IsBool() || !got.Bool() {
+		t.Fatalf("regexp_test must preserve non-string conversion, got %s", String(got))
+	}
+}
+
+func compileNativeRegexCaptures(t *testing.T, pattern string) Scmer {
+	t.Helper()
+	captureCount := regexp.MustCompile(pattern).NumSubexp() + 1
+	variables := make([]string, captureCount)
+	for index := range variables {
+		variables[index] = fmt.Sprintf("capture%d", index)
+	}
+	source := fmt.Sprintf(
+		"(lambda (value) (match value (regex %s %s) (list %s) _ false))",
+		strconv.Quote(pattern), joinStrings(variables, " "), joinStrings(variables, " "))
+	compiled := compileJITExpressionTestProc(t, source)
+	requireNoDynamicJITCalls(t, compiled)
+	return compiled
+}
+
+func joinStrings(values []string, separator string) string {
+	result := ""
+	for index, value := range values {
+		if index != 0 {
+			result += separator
+		}
+		result += value
+	}
+	return result
+}
+
+func TestJITNativeRegexCaptures(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	tests := []struct {
+		pattern string
+		inputs  []string
+	}{
+		{`^(.*)=(.*)$`, []string{"key=value", "=", "missing"}},
+		{`(.*)_(.*?)_seq`, []string{"table_column_seq", "a_b_c_seq", "no"}},
+		{`^[^.]+\.(.*)_(.*?)_seq\z`, []string{"public.table_column_seq", "table_column_seq"}},
+		{`^(a)?(b*)$`, []string{"", "a", "bbb", "abbb", "x"}},
+		{`^(?:(a)|(b))$`, []string{"a", "b", "x"}},
+		{`^[\r\n\t ]*COPY (.*) FROM '([^']+)'\z`, []string{"COPY public.t FROM '/tmp/data.csv'", "COPY broken"}},
+		{`^((?s:.*));\s*$`, []string{"SELECT 1;", "SELECT\n1; \t", "SELECT 1"}},
+	}
+	corpus := nativeRegexDifferentialCorpus()
+	for _, test := range tests {
+		t.Run(test.pattern, func(t *testing.T) {
+			matcher := regexp.MustCompile(test.pattern)
+			compiled := compileNativeRegexCaptures(t, test.pattern)
+			inputs := append(append([]string(nil), test.inputs...), corpus...)
+			for _, input := range inputs {
+				want := matcher.FindStringSubmatch(input)
+				got := Apply(compiled, NewString(input))
+				if want == nil {
+					if !got.IsBool() || got.Bool() {
+						t.Fatalf("pattern %q input %q: JIT returned %s, want false", test.pattern, input, String(got))
+					}
+					continue
+				}
+				gotCaptures := got.Slice()
+				if len(gotCaptures) != len(want) {
+					t.Fatalf("pattern %q input %q: got %d captures, want %d", test.pattern, input, len(gotCaptures), len(want))
+				}
+				for index := range want {
+					if !gotCaptures[index].IsString() || gotCaptures[index].String() != want[index] {
+						t.Fatalf("pattern %q input %q capture %d: got %s, want %q", test.pattern, input, index, String(gotCaptures[index]), want[index])
+					}
+				}
+			}
+		})
+	}
+}

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -1320,6 +1320,55 @@ func (ctx *JITContext) EmitAndInt64(dst, src Reg) {
 	ctx.emitAluRegReg(0x21, dst, src) // AND r/m64, r64
 }
 
+// EmitXorInt64 emits XOR dst, src (64-bit XOR).
+//
+// XOR is part of the architecture-neutral integer emitter contract. Regex
+// literal lowering uses it to compare an unaligned input word against a
+// compile-time literal before applying the byte significance mask.
+func (ctx *JITContext) EmitXorInt64(dst, src Reg) {
+	ctx.emitAluRegReg(0x31, dst, src) // XOR r/m64, r64
+}
+
+// EmitMaskedLiteralCheck compares one to eight bytes at [base+disp] with a
+// compile-time literal. mask selects significant bits; callers clear bit 5 in
+// ASCII letters for case-insensitive matching. The unaligned load and native
+// byte order intentionally remain in the architecture-specific emitter.
+func (ctx *JITContext) EmitMaskedLiteralCheck(base Reg, disp int32, literal, mask []byte, failLabel uint8) {
+	if len(literal) == 0 || len(literal) > 8 || len(mask) != len(literal) {
+		panic("jit: x86 masked literal check requires one to eight bytes")
+	}
+	loaded := ctx.AllocRegExcept(base)
+	switch len(literal) {
+	case 1:
+		ctx.EmitMovRegMemB(loaded, base, disp)
+	case 2:
+		ctx.EmitMovRegMemW(loaded, base, disp)
+	case 4:
+		ctx.EmitMovRegMemL(loaded, base, disp)
+	case 8:
+		ctx.EmitMovRegMem(loaded, base, disp)
+	default:
+		panic("jit: x86 masked literal check width must be 1, 2, 4, or 8")
+	}
+	want := ctx.AllocRegExcept(base, loaded)
+	var literalWord uint64
+	var maskWord uint64
+	for i := range literal {
+		literalWord |= uint64(literal[i]) << (8 * i)
+		maskWord |= uint64(mask[i]) << (8 * i)
+	}
+	ctx.EmitMovRegImm64(want, literalWord)
+	ctx.EmitXorInt64(loaded, want)
+	if maskWord != ^uint64(0)>>(64-8*len(mask)) {
+		ctx.EmitMovRegImm64(want, maskWord)
+		ctx.EmitAndInt64(loaded, want)
+	}
+	ctx.EmitCmpRegImm32(loaded, 0)
+	ctx.EmitJump(CondNotEqual, failLabel)
+	ctx.FreeReg(want)
+	ctx.FreeReg(loaded)
+}
+
 // --- GetTag ---
 
 // EmitGetTagDesc extracts the type tag from a Scmer value descriptor.

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -3660,14 +3660,11 @@ func optimizeBooleanRegexMatch(v []Scmer, value Scmer) (Scmer, TypeInfo, bool) {
 	if compiled.NumSubexp() != 0 {
 		return NewNil(), tiZero, false
 	}
-	test := NewFunc(func(arguments ...Scmer) Scmer {
-		text, ok := scmerAsString(arguments[0])
-		if !ok {
-			panic("regex expects string")
-		}
-		return NewBool(compiled.MatchString(text))
-	})
-	return NewSlice([]Scmer{test, value}), TypeInfo{kind: KindBool, flags: FlagTransfer, length: UnknownLength}, true
+	return NewSlice([]Scmer{
+		NewSymbol(jitConstantRegexpPredicateName),
+		NewRegex(compiled),
+		value,
+	}), TypeInfo{kind: KindBool, flags: FlagTransfer, length: UnknownLength}, true
 }
 
 func optimizeMatch(v []Scmer, headSym Symbol, env *Env, ome *optimizerMetainfo, useResult bool) (Scmer, TypeInfo) {

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -370,7 +370,7 @@ restart:
 	case tagFunc, tagFuncEnv, tagProc, tagJIT, tagClosure, tagPromise, tagSpecialForm:
 		// Optimizer-resolved native callables.
 		return expression
-	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagVector, tagFastDict, tagParser, tagAny, tagBSON:
+	case tagNil, tagBool, tagInt, tagFloat, tagDate, tagString, tagRegex, tagVector, tagFastDict, tagParser, tagAny, tagBSON:
 		// Self-evaluating literals.
 		return expression
 	case tagNthLocalVar:

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -27578,6 +27578,7 @@ func init_strings() {
 		},
 		Optimize: optimizeRegexpTest,
 	})
+	registerJITRegexBuiltins()
 
 }
 
@@ -27632,12 +27633,11 @@ func optimizeRegexpTest(v []Scmer, oc *OptimizerContext, useResult bool) (Scmer,
 	if err != nil {
 		return result, td
 	}
-	compiled := NewFunc(func(a ...Scmer) Scmer {
-		if a[0].IsNil() {
-			return NewNil()
-		}
-		return NewBool(re.MatchString(String(a[0])))
-	})
-	// Rewrite: (regexp_test str pattern) -> (compiled_fn str)
-	return NewSlice([]Scmer{compiled, rv[1]}), td
+	// Keep a declared callable identity in the optimized AST so both Eval and
+	// the JIT can execute the same precompiled-regex operation directly.
+	return NewSlice([]Scmer{
+		NewSymbol(jitConstantRegexpTestName),
+		NewRegex(re),
+		rv[1],
+	}), td
 }


### PR DESCRIPTION
## Summary

- compile constant regular expressions to an architecture-independent JIT regex program during Scheme JIT compilation
- emit a native byte walker for literals, character classes, alternation, anchors, boundaries, greedy/lazy repetition, and captures
- write every capture directly as a tagged Scmer string into its final `JITValueDesc` slot; unmatched optional groups are the canonical empty string
- keep machine-specific unaligned literal loads and masked word comparisons in the x86 emitter
- remove all runtime calls from the constant-regex JIT path to `regexp.(*Regexp).MatchString`, `FindStringSubmatchIndex`, and the former regex helper functions
- preserve `regexp_test` nil and non-string stringification semantics without calling the Go regex engine

Dynamic regex patterns continue to use the existing runtime implementation. This PR changes no Scheme library files.

## Emitter structure

`scm/jit_regex.go` owns the architecture-independent lowering:

- `regexp/syntax` is consumed only while generating code
- fixed literals are split into 8/4/2/1-byte chunks
- byte classes lower to branch-free `sub`/`cmp`/`setcc` predicates with one final failure edge
- `*` and `+` lower to native cursor loops
- greedy and lazy fixed-width repetitions retry their continuation from stored cursor positions
- alternatives restore the cursor and affected capture descriptors before trying the next branch
- captures write `ptr` and `len<<8 | tagString` directly into caller-provided stack-backed `JITValueDesc` targets

`scm/jit_x86_emitter.go` owns x86 instruction selection. `EmitMaskedLiteralCheck` performs an unaligned load followed by XOR and a byte significance mask. ASCII case-insensitive literal bytes use `0xdf`; non-letter bytes retain `0xff`. No x86 register names or byte-order assumptions occur in the common regex lowering.

Unsupported variable-width repetition shapes and non-ASCII case folding fail explicitly during JIT compilation. All regex shapes currently used by the SQL and PSQL parsers are covered by the native walker.

## Generated-code review

The inspected case-insensitive SQL parser pattern generated direct native code with:

- unaligned 8-byte loads
- literal XOR
- `0xdfdfdfdfdfdfdfdf` significance masks for ASCII case folding
- AND plus a single zero/failure test per literal block
- branch-free range classification via `sub`/`cmp`/`setbe`/`or`
- direct cursor loops for repetitions

The disassembly contains no call to `regexp`, no capture-index helper, and no regex dispatch loop. The only possible calls are cold semantic edges: panic for an invalid `match` operand and `String` conversion for a non-string `regexp_test` operand.

## Manual A/B measurements

AMD Ryzen 9 7900X3D, linux/amd64, patched Go JIT toolchain from `../go-jit`, identical fixtures and sample configuration.

### Constant regex predicate

Pattern: `^\\s*SELECT\\b`; five one-second samples.

| Revision | Median | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| `master` | 105.0 ns/op | 32 | 2 |
| PR | 24.35 ns/op | 16 | 1 |

Result: 4.31x faster and 76.8% lower latency, with one fewer allocation.

### Capturing Scheme match

Pattern: `^(.*)_(.*?)_seq$`; five one-second samples.

| Revision | Median | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| `master` | 982.6 ns/op | 703 | 8 |
| PR | 70.09 ns/op | 48 | 2 |

Result: 14.02x faster and 92.9% lower latency, with six fewer allocations.

### Cold SQL compile and cached end-to-end

Statement: `SELECT 1 AS n UNION ALL SELECT 2 AS n UNION ALL SELECT 3 AS n`; same initialized frontend, fixture, warmup, and five one-second samples.

| Measurement | `master` median | PR median | Change |
| --- | ---: | ---: | ---: |
| SQL compile | 2.207 ms/op | 2.208 ms/op | +0.03% |
| Cached end-to-end | 13.081 µs/op | 13.260 µs/op | +1.37% |

Both end-to-end measurements are neutral within noise. The SQL parser itself is not JIT-compiled by this PR; this native regex emitter is its prerequisite.

## Validation

- differential comparison with Go regexp for every SQL/PSQL parser regex plus commonly used SQL dispatch regexes
- positive fixtures and 192 deterministic adversarial inputs per pattern, including UTF-8 data
- direct capture comparison for greedy, lazy, optional, alternate, COPY, URL, and trailing-semicolon patterns
- 20 repeated patched-toolchain differential runs
- `go test ./scm -count=1` with the vanilla compiler
- patched-toolchain startup suite: 1270/1270 Scheme tests passed
- disassembly review described above

The unrelated storage rebuild timing test currently also fails consistently on unchanged `master`; CI remains the authoritative full-suite run.
