### PR TITLE
Stabilize performance A/B sampling

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -67,8 +67,9 @@ jobs:
             PERF_AB_MODE=record \
             PERF_BASELINE_FILE="$baseline" \
             PERF_BASELINE_SEED="$seed" \
-            PERF_REPEAT=100 \
-            PERF_MIN_MEASURE_MS=250 \
+            PERF_REPEAT=1000 \
+            PERF_MIN_MEASURE_MS=1000 \
+            PERF_AB_JITTER_MS=50 \
             PERF_SETUP_MAX_TIME_SEC=120 \
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/base" \
@@ -78,8 +79,9 @@ jobs:
           (cd candidate && env \
             PERF_AB_MODE=compare \
             PERF_BASELINE_FILE="$baseline" \
-            PERF_REPEAT=100 \
-            PERF_MIN_MEASURE_MS=250 \
+            PERF_REPEAT=1000 \
+            PERF_MIN_MEASURE_MS=1000 \
+            PERF_AB_JITTER_MS=50 \
             PERF_SETUP_MAX_TIME_SEC=120 \
             MEMCP_TEST_JOBS=4 \
             MEMCP_TEST_WORKTREE="$GITHUB_WORKSPACE/candidate" \

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -232,6 +232,7 @@ PERF_DEFAULT_ROWS = 10000  # default starting row count
 PERF_MAX_RAM_FRACTION = 0.30  # abort when MemAvailable drops below (1 - fraction) of MemTotal
 PERF_REPEAT = int(os.environ.get("PERF_REPEAT", "5"))
 PERF_MIN_MEASURE_MS = float(os.environ.get("PERF_MIN_MEASURE_MS", "250"))
+PERF_AB_JITTER_MS = float(os.environ.get("PERF_AB_JITTER_MS", "0"))
 PERF_SETUP_MAX_TIME_SEC = float(os.environ.get("PERF_SETUP_MAX_TIME_SEC", "120"))
 PERF_GATE_FILE = os.environ.get("PERF_GATE_FILE", ".perf_runner_gate.lock")
 _perf_gate_context = threading.local()
@@ -459,11 +460,13 @@ def performance_ab_threshold_ms(
     max_regression_pct: float,
     baseline_warmup: int,
     candidate_warmup: int,
+    candidate_repetitions: int = 1,
+    jitter_budget_ms: float = 0,
 ) -> float:
     warmup_bonus_pct = 100.0 if baseline_warmup > 0 and candidate_warmup == 0 else 0.0
     return baseline_time_per_repetition_ms * (
         1.0 + (max_regression_pct + warmup_bonus_pct) / 100.0
-    )
+    ) + jitter_budget_ms / candidate_repetitions
 
 
 def adaptive_measurement_complete(repetitions: int, total_ns: int) -> bool:
@@ -1682,6 +1685,14 @@ class SQLTestRunner:
 
         # Check performance threshold
         if is_perf_test and PERF_AB_MODE == "compare" and baseline_time:
+            # Shared runners have a small fixed scheduling/HTTP noise floor.
+            # Amortize it over the complete measurement block instead of
+            # weakening the percentage gate for every individual query run.
+            threshold_ms = performance_ab_threshold_ms(
+                float(baseline_time), max_regression_pct,
+                int(baseline.get("warmup", 2)), warmup_runs,
+                len(samples_ns), PERF_AB_JITTER_MS,
+            )
             change_pct = (elapsed_ms / float(baseline_time) - 1.0) * 100.0
             print(
                 f"PERF_AB {name}: {float(baseline_time):.3f}ms -> "

--- a/tests/performance/unique-insert.yaml
+++ b/tests/performance/unique-insert.yaml
@@ -12,6 +12,9 @@ metadata:
 test_cases:
   # INSERT IGNORE with non-overlapping keys into empty table (fresh delta insert)
   - name: "Perf: UNIQUE INSERT fresh"
+    # Mutations cannot be repeated against one fixture without changing their
+    # workload. Use a sufficiently large independent trial instead.
+    performance_rows: 30000
     setup:
       - sql: "DROP TABLE IF EXISTS `perf_unique`"
       - sql: "DROP TABLE IF EXISTS `perf_source`"
@@ -29,6 +32,7 @@ test_cases:
 
   # INSERT IGNORE with non-overlapping keys into rebuilt table (main + delta)
   - name: "Perf: UNIQUE INSERT after rebuild"
+    performance_rows: 30000
     setup:
       - sql: "DROP TABLE IF EXISTS `perf_unique`"
       - sql: "DROP TABLE IF EXISTS `perf_source`"
@@ -49,6 +53,7 @@ test_cases:
 
   # INSERT IGNORE with all-duplicate keys (unique collision path)
   - name: "Perf: INSERT IGNORE duplicates"
+    performance_rows: 30000
     setup:
       - sql: "DROP TABLE IF EXISTS `perf_unique`"
       - scm: "(rebuild)"

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -112,6 +112,10 @@ class PerformanceScaleContractTest(unittest.TestCase):
         self.assertEqual(performance_ab_threshold_ms(100, 20, 2, 2), 120)
         self.assertAlmostEqual(performance_ab_threshold_ms(100, 20, 2, 0), 220)
 
+    def test_ab_jitter_budget_is_amortized_over_repetitions(self) -> None:
+        self.assertEqual(performance_ab_threshold_ms(100, 20, 2, 2, 1, 50), 170)
+        self.assertEqual(performance_ab_threshold_ms(100, 20, 2, 2, 100, 50), 120.5)
+
     def test_regression_limit_is_bounded_and_case_overrides_suite(self) -> None:
         self.assertEqual(performance_regression_pct({}, {}), 20)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- extend adaptive A/B measurements from at most 100 samples / 250 ms to 1000 samples / 1 s
- model shared-runner jitter as one fixed 50 ms budget for the complete measurement block, amortized across its samples instead of weakening the 20% per-query regression limit
- scale the three non-repeatable INSERT fixtures to 30k rows because repeating a mutation would change the measured workload

The round barriers, correctness checks, RAM guard, and 20% relative regression limit remain unchanged.

## Evidence

The same unchanged #707 candidate produced contradictory `Perf: GROUP BY` results on the same GitHub runner class:

- 1.377 ms -> 1.684 ms (+22.3%, failed)
- 1.390 ms -> 1.379 ms (-0.8%, passed in the complete diagnostic run)
- 1.466 ms -> 1.773 ms (+20.9%, failed)

Those runs were capped at 100 samples, totaling only 138-177 ms despite the configured 250 ms target. The new 1 s target and 1000-sample cap amortize the fixed CI scheduling/HTTP noise. A 50 ms block budget contributes 0.5 ms at 100 samples, but only 0.05 ms at 1000 samples; the relative 20% gate remains the dominant criterion for properly sampled cases.

Single-shot INSERT timing at 300k rows was measured locally as 5.65 s / 9.26 s / 2.99 s. The committed 30k fixture keeps these mutation cases long enough to avoid the former 8-28 ms one-shot measurements without adding that 31-second suite cost.

## Verification

- `python3 -m unittest tools.test_sql_runner_contract` (46 tests, green)
- both edited YAML suites parse successfully
- full SQL suite intentionally left to CI
