### PR TITLE
Make TracePrint truncation explicit and configurable

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -1305,6 +1305,7 @@ var settingsGroups=[
 {key:"Backtrace",desc:"Enable detailed error backtraces (requires restart)",type:"bool"},
 {key:"Trace",desc:"Enable Scheme runtime tracing to file",type:"bool"},
 {key:"TracePrint",desc:"Print trace timing to stdout/log",type:"bool"},
+{key:"TracePrintMaxLength",desc:"TracePrint payload bytes retained before a visible truncation marker (0=unlimited)",type:"number"},
 {key:"ScanDebugging",desc:"Log every scan/scan_order: db+table+boundaries+index",type:"bool"},
 {key:"PrintLog",desc:"Log (print) output to system_statistic.logs (view in Log tab)",type:"bool"},
 {key:"MaxPrintLog",desc:"Max rows to keep in print log (0=unlimited, trimmed every 15min)",type:"number"}

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1659,7 +1659,7 @@ func jitTimeSpecial(args ...Scmer) Scmer {
 		if hasLabel {
 			message += " " + String(jitCallSpecialThunk(label))
 		}
-		TracePrintFunc(message)
+		EmitTracePrint(message)
 	}
 	return timedResult
 }

--- a/scm/processlist.go
+++ b/scm/processlist.go
@@ -267,7 +267,7 @@ func formatKillLog(s *SessionState, action string) string {
 }
 
 func logKill(s *SessionState, action string) {
-	TracePrintFunc(formatKillLog(s, action))
+	EmitTracePrint(formatKillLog(s, action))
 }
 
 // Kill marks the session as killed and fires the cancel function if set.

--- a/scm/special_forms.go
+++ b/scm/special_forms.go
@@ -156,7 +156,7 @@ func specialTime(code []Scmer, en *Env) Scmer {
 		if len(code) > 1 {
 			message += " " + String(Eval(code[1], en))
 		}
-		TracePrintFunc(message)
+		EmitTracePrint(message)
 	}
 	return result
 }

--- a/scm/trace.go
+++ b/scm/trace.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2024  Carl-Philip Hänsch
+Copyright (C) 2024-2026  Carl-Philip Hänsch
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -33,8 +33,15 @@ var Trace *Tracefile // default trace: set to not nil if you want to trace
 var TracePrint bool  // whether to print traces to stdout
 
 // TracePrintFunc is the output function used by (time) when TracePrint is
-// true.  Defaults to fmt.Println.  Override from the application layer to
-// route trace output to a log table or other sink.
+// true. Defaults to fmt.Println. Override from the application layer to route
+// trace output to a log table or other sink.
+//
+// The message is a diagnostic record and must reach the sink byte-for-byte:
+// in particular, never truncate query labels here or in an overriding sink.
+// Full SQL text is required to reproduce planner and correctness failures.
+// A sink may rotate or frame its output only outside an individual message.
+// If bounded output is ever required, expose it as an explicit opt-in setting
+// whose default is unlimited, and visibly mark every truncated record.
 var TracePrintFunc = func(msg string) { fmt.Println(msg) }
 
 func SetTrace(on bool) { // sets Trace to nil or a value

--- a/scm/trace.go
+++ b/scm/trace.go
@@ -20,8 +20,10 @@ import "io"
 import "os"
 import "fmt"
 import "sync"
+import "sync/atomic"
 import "time"
 import "encoding/json"
+import "unicode/utf8"
 
 type Tracefile struct {
 	isFirst bool
@@ -31,18 +33,42 @@ type Tracefile struct {
 
 var Trace *Tracefile // default trace: set to not nil if you want to trace
 var TracePrint bool  // whether to print traces to stdout
+var tracePrintMaxLength atomic.Int64
 
 // TracePrintFunc is the output function used by (time) when TracePrint is
 // true. Defaults to fmt.Println. Override from the application layer to route
 // trace output to a log table or other sink.
 //
-// The message is a diagnostic record and must reach the sink byte-for-byte:
-// in particular, never truncate query labels here or in an overriding sink.
-// Full SQL text is required to reproduce planner and correctness failures.
-// A sink may rotate or frame its output only outside an individual message.
-// If bounded output is ever required, expose it as an explicit opt-in setting
-// whose default is unlimited, and visibly mark every truncated record.
+// The message is a diagnostic record and must reach the sink byte-for-byte
+// unless the user explicitly opted into TracePrintMaxLength. Never add an
+// implicit limit here or in an overriding sink: full SQL text is required to
+// reproduce planner and correctness failures. A sink may rotate or frame its
+// output only outside an individual message. Bounded records are visibly
+// marked by EmitTracePrint; the default limit of zero is unlimited.
 var TracePrintFunc = func(msg string) { fmt.Println(msg) }
+
+func SetTracePrintMaxLength(maxLength int) {
+	if maxLength < 0 {
+		maxLength = 0
+	}
+	tracePrintMaxLength.Store(int64(maxLength))
+}
+
+func TracePrintMaxLength() int {
+	return int(tracePrintMaxLength.Load())
+}
+
+func EmitTracePrint(message string) {
+	maxLength := TracePrintMaxLength()
+	if maxLength > 0 && len(message) > maxLength {
+		end := maxLength
+		for end > 0 && !utf8.RuneStart(message[end]) {
+			end--
+		}
+		message = message[:end] + fmt.Sprintf("... [truncated; original_bytes=%d]", len(message))
+	}
+	TracePrintFunc(message)
+}
 
 func SetTrace(on bool) { // sets Trace to nil or a value
 	if Trace != nil {

--- a/scm/trace_test.go
+++ b/scm/trace_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package scm
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func captureTracePrint(t *testing.T, maxLength int) *string {
+	t.Helper()
+	oldOutput := TracePrintFunc
+	oldMaxLength := TracePrintMaxLength()
+	var captured string
+	TracePrintFunc = func(message string) { captured = message }
+	SetTracePrintMaxLength(maxLength)
+	t.Cleanup(func() {
+		TracePrintFunc = oldOutput
+		SetTracePrintMaxLength(oldMaxLength)
+	})
+	return &captured
+}
+
+func TestEmitTracePrintIsUnlimitedByDefault(t *testing.T) {
+	captured := captureTracePrint(t, 0)
+	message := strings.Repeat("SELECT complete_query_text ", 1000)
+
+	EmitTracePrint(message)
+
+	if *captured != message {
+		t.Fatalf("unlimited TracePrint changed the record: got %d bytes, want %d", len(*captured), len(message))
+	}
+}
+
+func TestEmitTracePrintMarksExplicitTruncation(t *testing.T) {
+	captured := captureTracePrint(t, 6)
+
+	EmitTracePrint("SELECT complete query")
+
+	want := "SELECT... [truncated; original_bytes=21]"
+	if *captured != want {
+		t.Fatalf("unexpected truncated record: got %q, want %q", *captured, want)
+	}
+}
+
+func TestEmitTracePrintKeepsValidUTF8(t *testing.T) {
+	captured := captureTracePrint(t, 2)
+
+	EmitTracePrint("äbc")
+
+	if !utf8.ValidString(*captured) {
+		t.Fatalf("truncated record is not valid UTF-8: %q", *captured)
+	}
+	if !strings.HasPrefix(*captured, "ä... [truncated;") {
+		t.Fatalf("truncated record split a UTF-8 rune: %q", *captured)
+	}
+}
+
+func TestNegativeTracePrintLimitMeansUnlimited(t *testing.T) {
+	captured := captureTracePrint(t, -1)
+
+	EmitTracePrint("complete")
+
+	if *captured != "complete" || TracePrintMaxLength() != 0 {
+		t.Fatalf("negative limit was not normalized to unlimited: limit=%d output=%q", TracePrintMaxLength(), *captured)
+	}
+}

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -32,6 +32,7 @@ type SettingsT struct {
 	Backtrace              bool
 	Trace                  bool
 	TracePrint             bool
+	TracePrintMaxLength    int // max TracePrint record bytes before a visible marker (0 = unlimited)
 	PartitionMaxDimensions int
 	DefaultEngine          string
 	ShardSize              uint
@@ -78,7 +79,7 @@ func (r CreateTableTriggerRegistration) triggerDescription() TriggerDescription 
 	}
 }
 
-var Settings SettingsT = SettingsT{false, false, false, 10, "safe", 60000, 50, 5, 0, 0, 0, 0, false, 0, 0, false, false, 20, 256, false, 0, false, 0, nil}
+var Settings SettingsT = SettingsT{false, false, false, 0, 10, "safe", 60000, 50, 5, 0, 0, 0, 0, false, 0, 0, false, false, 20, 256, false, 0, false, 0, nil}
 var createTableTriggerMu sync.Mutex
 
 func registerCreateTableTrigger(reg CreateTableTriggerRegistration) {
@@ -122,6 +123,7 @@ func InitSettings() {
 	scm.SettingsHaveGoodBacktraces = Settings.Backtrace
 	scm.SetTrace(Settings.Trace)
 	scm.TracePrint = Settings.TracePrint
+	scm.SetTracePrintMaxLength(Settings.TracePrintMaxLength)
 	scm.JITLog = Settings.LogJIT
 	onexit.Register(func() { scm.SetTrace(false) }) // close trace file on exit
 	InitCacheManager()
@@ -134,6 +136,7 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			scm.NewString("Backtrace"), scm.NewBool(Settings.Backtrace),
 			scm.NewString("Trace"), scm.NewBool(Settings.Trace),
 			scm.NewString("TracePrint"), scm.NewBool(Settings.TracePrint),
+			scm.NewString("TracePrintMaxLength"), scm.NewInt(int64(Settings.TracePrintMaxLength)),
 			scm.NewString("PartitionMaxDimensions"), scm.NewInt(int64(Settings.PartitionMaxDimensions)),
 			scm.NewString("DefaultEngine"), scm.NewString(Settings.DefaultEngine),
 			scm.NewString("ShardSize"), scm.NewInt(int64(Settings.ShardSize)),
@@ -163,6 +166,8 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			return scm.NewBool(Settings.Trace)
 		case "TracePrint":
 			return scm.NewBool(Settings.TracePrint)
+		case "TracePrintMaxLength":
+			return scm.NewInt(int64(Settings.TracePrintMaxLength))
 		case "PartitionMaxDimensions":
 			return scm.NewInt(int64(Settings.PartitionMaxDimensions))
 		case "DefaultEngine":
@@ -217,6 +222,12 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 		case "TracePrint":
 			Settings.TracePrint = scm.ToBool(a[1])
 			scm.TracePrint = Settings.TracePrint
+		case "TracePrintMaxLength":
+			Settings.TracePrintMaxLength = scm.ToInt(a[1])
+			if Settings.TracePrintMaxLength < 0 {
+				Settings.TracePrintMaxLength = 0
+			}
+			scm.SetTracePrintMaxLength(Settings.TracePrintMaxLength)
 		case "PartitionMaxDimensions":
 			Settings.PartitionMaxDimensions = scm.ToInt(a[1])
 		case "DefaultEngine":


### PR DESCRIPTION
## What

- keep complete TracePrint records by default
- route every TracePrint emitter through one bounded-output implementation
- add the persisted `TracePrintMaxLength` setting (`0` = unlimited)
- expose the setting in the dashboard
- preserve UTF-8 boundaries and visibly mark every opted-in truncation with the original byte length

## Why

Full SQL labels are diagnostic records needed to reproduce planner and correctness failures. They must never be shortened silently. Operators who explicitly need bounded records can now opt in without making an incomplete query look complete.

## Verification

- focused TracePrint contract tests pass
- `go build -o memcp .` passes
- full integration suite runs in CI