### PR TITLE
Keep request-local scan hooks separate from index suffixes

### DIFF
--- a/storage/index.go
+++ b/storage/index.go
@@ -537,6 +537,35 @@ func (s *StorageIndex) rowWithinBounds(bounds boundaries, cmpCols int, lower []s
 	return true, false
 }
 
+// queryIndexPrefixLen returns the part of the query boundary list which is
+// physically represented by this index. Query-local hooks are orthogonal to
+// the stored index key: in particular, a trailing $recset_contains boundary
+// must never be interpreted as the next column of a longer reusable index.
+// Matching the column and matcher kind here preserves prefix reuse without
+// coupling an invocation-only matcher to an unrelated physical suffix.
+func (s *StorageIndex) queryIndexPrefixLen(bounds boundaries, lower []scm.Scmer) int {
+	limit := len(lower)
+	if limit > len(bounds) {
+		limit = len(bounds)
+	}
+	if limit > len(s.Cols) {
+		limit = len(s.Cols)
+	}
+	for i := 0; i < limit; i++ {
+		if bounds[i].col != s.Cols[i] {
+			return i
+		}
+		var indexedMatcher IndexAnalyzer
+		if i < len(s.ColMatchers) {
+			indexedMatcher = s.ColMatchers[i]
+		}
+		if !indexMatcherCompatible(bounds[i].matcher, indexedMatcher) {
+			return i
+		}
+	}
+	return limit
+}
+
 func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid uint32, mainGetters []colGetter, delta indexPair) int {
 	for i := range s.Cols {
 		if !s.columnIsSorted(i) {
@@ -1353,10 +1382,7 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 			return leftID < rightID
 		}
 		if len(deltaItems) > 0 {
-			cmpCols := len(lower)
-			if cmpCols > len(s.Cols) {
-				cmpCols = len(s.Cols)
-			}
+			cmpCols := s.queryIndexPrefixLen(bounds, lower)
 			keptDelta := deltaItems[:0]
 			for _, recid := range deltaItems {
 				inRange, _ := s.rowWithinBounds(bounds, cmpCols, lower, upperLast, upperInclusive, func(col int) scm.Scmer {
@@ -1418,7 +1444,7 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 		})
 	}
 
-	matchers := s.bindRowMatchers(bounds, cols, func() []IndexHook {
+	matchers := s.bindRowMatchers(tx, bounds, cols, func() []IndexHook {
 		if persistent && state != nil {
 			return state.indexHooks
 		}
@@ -1440,19 +1466,28 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 // bindRowMatchers returns only matcher state. The terminal callback deliberately
 // stays outside this value: storing it in a returned wrapper closure makes the
 // complete shard scan state escape even though index iteration is synchronous.
-func (s *StorageIndex) bindRowMatchers(bounds boundaries, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
+func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds boundaries, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
 	var matchers []IndexRowMatcher
 	for colIdx, bound := range bounds {
 		if bound.matcher == nil || bound.matcher.IsSorted() {
 			continue
 		}
 		var hook IndexHook
-		if persistent && colIdx < len(hooks) {
+		alignedWithIndex := colIdx < len(s.Cols) && s.Cols[colIdx] == bound.col
+		if alignedWithIndex && colIdx < len(s.ColMatchers) {
+			alignedWithIndex = indexMatcherCompatible(bound.matcher, s.ColMatchers[colIdx])
+		} else if alignedWithIndex {
+			alignedWithIndex = bound.matcher.IsSorted()
+		}
+		if persistent && alignedWithIndex && colIdx < len(hooks) {
 			hook = hooks[colIdx]
-		} else {
+		}
+		if hook == nil {
 			var reader ColumnReader
-			if colIdx < len(cols) {
+			if alignedWithIndex && colIdx < len(cols) {
 				reader = cols[colIdx].raw
+			} else if !isScanPseudoColName(bound.col) && bound.mapFn.IsNil() {
+				reader = newCachedColumnReaderTx(s.t.getColumnStorageRLocked(bound.col), tx)
 			}
 			hook = bound.matcher.Deploy(IndexDeployContext{
 				MainCount: s.t.main_count,
@@ -1600,7 +1635,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 			if selected != nil {
 				selected(s, false)
 			}
-			matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+			matchers := s.bindRowMatchers(tx, bounds, cols, nil, false, exactMain)
 			s.fullScan(maxInsertIndex, buf, matchers, callback)
 			return
 		} else {
@@ -1612,7 +1647,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds boundaries, lower []scm.Scm
 				if selected != nil {
 					selected(s, false)
 				}
-				matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+				matchers := s.bindRowMatchers(tx, bounds, cols, nil, false, exactMain)
 				s.fullScan(maxInsertIndex, buf, matchers, callback)
 				return
 			}
@@ -1636,7 +1671,7 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+		matchers := s.bindRowMatchers(tx, bounds, cols, nil, false, exactMain)
 		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
@@ -1646,7 +1681,7 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		matchers := s.bindRowMatchers(bounds, cols, nil, false, exactMain)
+		matchers := s.bindRowMatchers(tx, bounds, cols, nil, false, exactMain)
 		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
@@ -1666,8 +1701,9 @@ start_scan:
 	// per callback so LIMIT can brake inside the index walk. The caller-owned
 	// pooled buffer remains allocated at its normal size; only its visible slice
 	// is shortened, so the hot path adds no allocation.
+	cmpCols := s.queryIndexPrefixLen(bounds, lower)
 	if options != nil && options.boundaryCoveredLimit && options.orderedLimit > 0 &&
-		options.orderedLimit < len(buf) && indexCoversBoundaryOrder(s, true, bounds, len(lower)) {
+		options.orderedLimit < len(buf) && indexCoversBoundaryOrder(s, true, bounds, cmpCols) {
 		buf = buf[:options.orderedLimit]
 	}
 
@@ -1679,12 +1715,9 @@ start_scan:
 		getRecid = func(idx int) uint32 { return uint32(idx) }
 	}
 
-	// bisect where the lower bound is found
-	// Only compare as many columns as provided in 'lower' (index can have more cols)
-	cmpCols := len(lower)
-	if cmpCols > len(s.Cols) {
-		cmpCols = len(s.Cols)
-	}
+	// Bisect only over the query prefix physically represented by this index.
+	// Invocation-only hooks remain in bounds for bindRowMatchers below, but do
+	// not occupy a key position in a reusable longer index.
 
 	// Find the leading physical sort key. Non-sorted matchers such as LIKE are
 	// deliberately present in the logical boundary list but do not participate
@@ -1806,7 +1839,7 @@ start_scan:
 	}
 
 	rawCallback := callback
-	matchers := s.bindRowMatchers(bounds, cols, snapIndexHooks, true, exactMain)
+	matchers := s.bindRowMatchers(tx, bounds, cols, snapIndexHooks, true, exactMain)
 	adaptiveSwitchRows := int64(0)
 	if options != nil && hasRecSetBoundary && maxInsertIndex == 0 {
 		adaptiveSwitchRows = orderedRecSetSwitchRows(recsetPart.count)

--- a/tests/integration/regressions/deleted-row-carrier-visibility.yaml
+++ b/tests/integration/regressions/deleted-row-carrier-visibility.yaml
@@ -22,16 +22,20 @@ setup:
   - sql: "DROP TABLE IF EXISTS drcv_access"
   - sql: "DROP TABLE IF EXISTS drcv_item"
   - sql: "DROP TABLE IF EXISTS drcv_domain"
-  - sql: "CREATE TABLE drcv_domain (id INT PRIMARY KEY, direct_flag BOOL, label TEXT)"
+  - sql: "DROP TABLE IF EXISTS drcv_tenant"
+  - sql: "CREATE TABLE drcv_tenant (id INT PRIMARY KEY, direct_flag BOOL, label TEXT)"
+  - sql: "CREATE TABLE drcv_domain (id INT PRIMARY KEY, tenant_id INT, direct_flag BOOL, label TEXT)"
   - sql: "CREATE TABLE drcv_item (id INT PRIMARY KEY, domain_id INT, bucket_id INT, sort_key INT)"
-  - sql: "CREATE TABLE drcv_access (id INT PRIMARY KEY, actor_id INT, domain_id INT, allowed BOOL)"
+  - sql: "CREATE TABLE drcv_access (id INT PRIMARY KEY, actor_id INT, tenant_id INT, domain_id INT, allowed BOOL)"
   - sql: "CREATE TABLE drcv_idlist (list_id INT, item_id INT)"
-  - sql: "INSERT INTO drcv_domain (id, direct_flag, label) VALUES (1, FALSE, 'one'), (2, FALSE, 'two'), (3, TRUE, 'three')"
+  - sql: "INSERT INTO drcv_tenant (id, direct_flag, label) VALUES (1, FALSE, 'tenant-one'), (2, FALSE, 'tenant-two')"
+  - sql: "INSERT INTO drcv_domain (id, tenant_id, direct_flag, label) VALUES (1, 1, FALSE, 'one'), (2, 2, FALSE, 'two'), (3, 1, TRUE, 'three')"
   - sql: "INSERT INTO drcv_item (id, domain_id, bucket_id, sort_key) VALUES (11, 1, 7, 40), (12, 1, 7, 30), (21, 2, 7, 20), (31, 3, 7, 10)"
-  - sql: "INSERT INTO drcv_access (id, actor_id, domain_id, allowed) VALUES (1, 101, NULL, TRUE), (2, 202, 2, TRUE)"
+  - sql: "INSERT INTO drcv_access (id, actor_id, tenant_id, domain_id, allowed) VALUES (1, 101, NULL, NULL, TRUE), (2, 202, 2, 2, TRUE)"
   - scm: |
       (begin
       (rebuild (table "memcp-tests" "drcv_domain") true false)
+      (rebuild (table "memcp-tests" "drcv_tenant") true false)
       (rebuild (table "memcp-tests" "drcv_item") true false)
       (rebuild (table "memcp-tests" "drcv_access") true false))
 
@@ -210,6 +214,99 @@ test_cases:
   - <<: *derived_id_projection
     name: "The shared query shape rebinds the unrestricted request again"
 
+  - &nested_acl_id_filter
+    name: "A nested request ACL retains the selected ID list"
+    session_id: "drcv_unrestricted"
+    sql: |
+      SELECT i.id
+      FROM drcv_item i
+      WHERE (
+        EXISTS (
+          SELECT 1
+          FROM drcv_access global_access
+          WHERE global_access.actor_id = @drcv_actor
+            AND global_access.tenant_id IS NULL
+            AND global_access.domain_id IS NULL
+          LIMIT 1
+        )
+        OR NOT EXISTS (
+          SELECT 1
+          FROM drcv_access global_deny_guard
+          WHERE global_deny_guard.actor_id = @drcv_actor
+            AND global_deny_guard.tenant_id IS NULL
+            AND global_deny_guard.domain_id IS NULL
+          LIMIT 1
+        )
+      )
+      AND COALESCE((
+        SELECT
+          (
+            EXISTS (
+              SELECT 1
+              FROM drcv_access repeated_global_access
+              WHERE repeated_global_access.actor_id = @drcv_actor
+                AND repeated_global_access.tenant_id IS NULL
+                AND repeated_global_access.domain_id IS NULL
+              LIMIT 1
+            )
+            OR CASE
+              WHEN d.direct_flag THEN TRUE
+              ELSE EXISTS (
+                SELECT 1
+                FROM drcv_access domain_access
+                WHERE domain_access.actor_id = @drcv_actor
+                  AND COALESCE(domain_access.domain_id, d.id) = d.id
+                  AND domain_access.allowed
+                LIMIT 1
+              )
+            END
+          )
+          AND COALESCE((
+            SELECT
+              EXISTS (
+                SELECT 1
+                FROM drcv_access repeated_tenant_global_access
+                WHERE repeated_tenant_global_access.actor_id = @drcv_actor
+                  AND repeated_tenant_global_access.tenant_id IS NULL
+                  AND repeated_tenant_global_access.domain_id IS NULL
+                LIMIT 1
+              )
+              OR CASE
+                WHEN t.direct_flag THEN TRUE
+                ELSE EXISTS (
+                  SELECT 1
+                  FROM drcv_access tenant_access
+                  WHERE tenant_access.actor_id = @drcv_actor
+                    AND COALESCE(tenant_access.tenant_id, t.id) = t.id
+                    AND tenant_access.allowed
+                  LIMIT 1
+                )
+              END
+            FROM drcv_tenant t
+            WHERE t.id = d.tenant_id
+            LIMIT 1
+          ), FALSE)
+        FROM drcv_domain d
+        WHERE d.id = i.domain_id
+        LIMIT 1
+      ), FALSE)
+      AND i.id IN (11, 12, 21, 31)
+      ORDER BY i.id
+    expect:
+      rows: 3
+      data:
+        - id: 11
+        - id: 21
+        - id: 31
+
+  - <<: *nested_acl_id_filter
+    name: "The nested request ACL rebinds all repeated stages"
+    session_id: "drcv_restricted"
+    expect:
+      rows: 1
+      data:
+        - id: 21
+
   - name: "Delete the selected base row through SQL"
     sql: "DELETE FROM drcv_item WHERE id = 11"
     expect:
@@ -259,3 +356,4 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS drcv_access"
   - sql: "DROP TABLE IF EXISTS drcv_item"
   - sql: "DROP TABLE IF EXISTS drcv_domain"
+  - sql: "DROP TABLE IF EXISTS drcv_tenant"

--- a/tests/integration/regressions/deleted-row-carrier-visibility.yaml
+++ b/tests/integration/regressions/deleted-row-carrier-visibility.yaml
@@ -19,6 +19,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS drcv_idlist"
+  - sql: "DROP TABLE IF EXISTS drcv_warm_index"
   - sql: "DROP TABLE IF EXISTS drcv_access"
   - sql: "DROP TABLE IF EXISTS drcv_item"
   - sql: "DROP TABLE IF EXISTS drcv_domain"
@@ -28,10 +29,16 @@ setup:
   - sql: "CREATE TABLE drcv_item (id INT PRIMARY KEY, domain_id INT, bucket_id INT, sort_key INT)"
   - sql: "CREATE TABLE drcv_access (id INT PRIMARY KEY, actor_id INT, tenant_id INT, domain_id INT, allowed BOOL)"
   - sql: "CREATE TABLE drcv_idlist (list_id INT, item_id INT)"
+  - sql: "CREATE TABLE drcv_warm_index (id INT PRIMARY KEY, acl_visible BOOL, sort_key INT)"
   - sql: "INSERT INTO drcv_tenant (id, direct_flag, label) VALUES (1, FALSE, 'tenant-one'), (2, FALSE, 'tenant-two')"
   - sql: "INSERT INTO drcv_domain (id, tenant_id, direct_flag, label) VALUES (1, 1, FALSE, 'one'), (2, 2, FALSE, 'two'), (3, 1, TRUE, 'three')"
   - sql: "INSERT INTO drcv_item (id, domain_id, bucket_id, sort_key) VALUES (11, 1, 7, 40), (12, 1, 7, 30), (21, 2, 7, 20), (31, 3, 7, 10)"
   - sql: "INSERT INTO drcv_access (id, actor_id, tenant_id, domain_id, allowed) VALUES (1, 101, NULL, NULL, TRUE), (2, 202, 2, 2, TRUE)"
+  - scm: |
+      (begin
+      (define rows (produceN 4096 (lambda (i) (list (+ i 1) true i))))
+      (insert (table "memcp-tests" "drcv_warm_index") '("id" "acl_visible" "sort_key") rows '() (lambda () true) false)
+      (rebuild (table "memcp-tests" "drcv_warm_index") true false))
   - scm: |
       (begin
       (rebuild (table "memcp-tests" "drcv_domain") true false)
@@ -40,6 +47,40 @@ setup:
       (rebuild (table "memcp-tests" "drcv_access") true false))
 
 test_cases:
+  - name: "A warm longer base index cannot consume a request-local RecSet boundary"
+    scm: |
+      (begin
+      (define tbl (table "memcp-tests" "drcv_warm_index"))
+      (define warm (lambda ()
+        (scan_order nil tbl
+          '("acl_visible")
+          (lambda (acl_visible) (equal? acl_visible true))
+          '("sort_key")
+          '(<)
+          0 0 16
+          '("id")
+          (lambda (id) id)
+          +
+          0
+          false)))
+      (warm)
+      (warm)
+      (define selected
+        (scan_recset nil tbl
+          '("acl_visible")
+          (lambda (acl_visible) (equal? acl_visible true))))
+      (define counted
+        (scan nil selected
+          '("acl_visible")
+          (lambda (acl_visible) (equal? acl_visible true))
+          '("id")
+          (lambda (id) 1)
+          +
+          0))
+      (if (equal? counted 4096)
+        "ok"
+        (error "a query-local RecSet boundary was aligned with a longer base-index column")))
+
   - name: "Build a RecSet before deleting one of its rows"
     scm: |
       (begin
@@ -353,6 +394,7 @@ test_cases:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS drcv_idlist"
+  - sql: "DROP TABLE IF EXISTS drcv_warm_index"
   - sql: "DROP TABLE IF EXISTS drcv_access"
   - sql: "DROP TABLE IF EXISTS drcv_item"
   - sql: "DROP TABLE IF EXISTS drcv_domain"


### PR DESCRIPTION
## What

Fixes a correctness bug in reusable prefix indexes: a query-local RecSet boundary appended after a physical access prefix could be interpreted positionally as the next column of an already-warm longer index.

The common index iterator now:

- determines the query boundary prefix actually represented by the selected physical index by matching both column and matcher kind;
- uses only that prefix for bisection and range checks;
- binds invocation-local matcher hooks separately when they are not represented by a persistent index slot.

This applies centrally to the complete scan family rather than special-casing one SQL or planner shape.

## Regression proof

A permanent YAML case builds and warms `(acl_visible, sort_key)`, then consumes a RecSet through a scan constrained only by `acl_visible`. Before the fix the `$recset_contains` boundary was compared as if it constrained `sort_key`, and the test failed. It now returns all 4096 expected rows.

Focused validation:

- `tests/integration/regressions/deleted-row-carrier-visibility.yaml`: 14/14
- `tests/execution/operators/recset.yaml`: 34/34
- startup Scheme tests: 1272/1272

The full suite is left to CI.
