### PR TITLE
Remove stale third-party dependency path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@
 !go.sum
 !scm/**
 !storage/**
-!third_party/**
 !lib/**
 !assets/**
 !packaging/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR /build
 RUN apk add --no-cache git
 
 COPY go.mod go.sum ./
-COPY third_party/ ./third_party/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Keep this list explicit in addition to .dockerignore. A MemCP checkout often

--- a/tools/test_packaging.py
+++ b/tools/test_packaging.py
@@ -58,6 +58,22 @@ class ReleaseSourceTests(unittest.TestCase):
 		self.assertNotRegex(dockerfile, r"(?m)^COPY\s+\.\s+\.")
 		self.assertRegex(dockerfile, r"(?m)^USER\s+10001:10001$")
 
+	def test_dependencies_are_not_vendored(self) -> None:
+		self.assertFalse((ROOT / "third_party").exists())
+		self.assertFalse((ROOT / "vendor").exists())
+		for name in ("Dockerfile", ".dockerignore"):
+			self.assertNotIn("third_party", (ROOT / name).read_text(encoding="utf-8"))
+
+		go_mod = (ROOT / "go.mod").read_text(encoding="utf-8")
+		for line in go_mod.splitlines():
+			if "=>" not in line:
+				continue
+			target = line.split("=>", 1)[1].strip().split()[0]
+			self.assertFalse(
+				target.startswith((".", "/")),
+				f"go.mod uses local dependency replacement: {line.strip()}",
+			)
+
 	def test_initializer_is_idempotent_and_keeps_credential(self) -> None:
 		with tempfile.TemporaryDirectory(prefix="memcp-package-test-") as tmp:
 			root = Path(tmp)


### PR DESCRIPTION
## Summary
- remove the obsolete `third_party` copy from the Docker build
- remove `third_party` from the Docker context allow-list
- guard packaging against vendored dependency directories and local Go module replacements

## Dependency audit
Compared the former vendored `go-mysqlstack` tree immediately before #693 with `github.com/launix-de/go-mysqlstack v0.2.0`. The MemCP-specific Unix listener, query lifecycle/cancellation, and prepared TEXT/BLOB decoding changes are present upstream. v0.2.0 additionally contains the ResultWriter and packet-buffer improvements; no MemCP-local workaround needs retaining. Root `go.sum` remains unchanged.

## Local verification
- `python3 tools/test_packaging.py`
- `go mod verify`

The full suite and Docker/release validation are left to CI as requested.