### PR TITLE
Keep transaction state out of query-local RecSets

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -3158,6 +3158,7 @@ rows outside the current batch. */
 					(map filtercols (lambda (col) (symbol (concat alias "." col))))
 					(lower_column_expr_for_alias src condition))))
 			(list (quote recset_intersect)
+				(physical_query_tx_symbol)
 				(cons (quote list) (list
 					batch_expr
 					(list (quote recset_project_join)
@@ -3193,6 +3194,7 @@ rows outside the current batch. */
 						(map filtercols (lambda (col) (symbol (concat alias "." col))))
 						(lower_column_expr_for_alias src condition))))
 				(list (quote recset_intersect)
+					(physical_query_tx_symbol)
 					(cons (quote list) (list
 						batch_expr
 						(list (quote recset_project_join)
@@ -3213,6 +3215,7 @@ rows outside the current batch. */
 			driver. Intersecting a batch with that immutable RecSet is exact and avoids
 			repeating text scans and FK projection for every expanded window. */
 			(list (quote recset_intersect)
+				(physical_query_tx_symbol)
 				(cons (quote list) (list batch_expr
 					(planner_queryplan_observation_read_expr
 						(planner_queryplan_observation_value_key decision_id)))))
@@ -3224,11 +3227,14 @@ rows outside the current batch. */
 						(or unsupported (nil? branch_expr))) false)
 						nil
 						(list (quote recset_intersect)
+							(physical_query_tx_symbol)
 							(cons (quote list) (list
 								batch_expr
 								(if (single_source? branches)
 									(car branches)
-									(list (quote recset_union) (cons (quote list) branches))))))))
+									(list (quote recset_union)
+										(physical_query_tx_symbol)
+										(cons (quote list) branches))))))))
 				(batch_membership_base_expr target_src stage target_col batch_expr))))))
 
 /* A stage's own group-cache is keyed positionally by its gs_keys, named
@@ -3359,7 +3365,9 @@ the auto-index chooses the concrete access path on both tables. */
 					nil
 					(if (single_source? projected)
 						(car projected)
-						(list (quote recset_union) (cons (quote list) projected)))))
+						(list (quote recset_union)
+							(physical_query_tx_symbol)
+							(cons (quote list) projected)))))
 			(if (equal? (qassoc_get (gs_facts stage) (quote purpose) nil) (quote in_membership))
 				(membership_cache_recset_project_join_expr src stage target_col)
 				(if (recset_probe_stage_shape? stage)
@@ -5915,7 +5923,7 @@ ordinary physical carrier choice. */
 (define boolean_recset_combine (lambda (operator plans)
 	(if (equal? (count plans) 1)
 		(car plans)
-		(list operator (cons (quote list) plans)))))
+		(list operator (physical_query_tx_symbol) (cons (quote list) plans)))))
 
 /* RecSet complement represents FALSE as "not in the TRUE set" and is exact
 only for a two-valued operand. SQL NOT must retain UNKNOWN, so nullable probe
@@ -5971,6 +5979,7 @@ one ordinary scan_recset, while stage leaves use the carrier projection above. *
 				((symbol sql_not) inner)
 				(if (boolean_recset_two_valued? inner)
 					(list (quote recset_not)
+						(physical_query_tx_symbol)
 						(boolean_recset_expr_plan stage_catalog domain_src inner))
 					(neumann_fail "build_queryplan"
 						"boolean RecSet complement requires a two-valued operand"))
@@ -6018,7 +6027,8 @@ one ordinary scan_recset, while stage leaves use the carrier projection above. *
 						(boolean_recset_combine (quote recset_intersect)
 							(list condition_set then_set))
 						(boolean_recset_combine (quote recset_intersect)
-							(list (list (quote recset_not) condition_set) else_set)))))
+							(list (list (quote recset_not)
+								(physical_query_tx_symbol) condition_set) else_set)))))
 				((quote if) condition then_expr else_expr)
 				(boolean_recset_expr_plan stage_catalog domain_src
 					(list (symbol "if") condition then_expr else_expr))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -3415,14 +3415,19 @@ path. */
 					(if (nth (nth terms i) 4) (list (nth (nth term_bindings i) 2)) '())))))
 				(define negative_union (if (single_source? negative_exprs)
 					(car negative_exprs)
-					(list (quote recset_union) (cons (quote list) negative_exprs))))
+					(list (quote recset_union)
+						(physical_query_tx_symbol)
+						(cons (quote list) negative_exprs))))
 				(define formula (if (empty_list? positive_exprs)
-					(list (quote recset_not) negative_union)
+					(list (quote recset_not) (physical_query_tx_symbol) negative_union)
 					(begin
 						(define positive_intersection (if (single_source? positive_exprs)
 							(car positive_exprs)
-							(list (quote recset_intersect) (cons (quote list) positive_exprs))))
+							(list (quote recset_intersect)
+								(physical_query_tx_symbol)
+								(cons (quote list) positive_exprs))))
 						(list (quote recset_difference)
+							(physical_query_tx_symbol)
 							(cons (quote list) (cons positive_intersection negative_exprs))))))
 				(list terms formula negative_exprs positive_exprs))))))
 
@@ -3523,6 +3528,7 @@ lookup for each ordered driver candidate. */
 										(source_table_expr (nth first_carrier 0))
 										(nth first_carrier 1)
 										(list (quote recset_union)
+											(physical_query_tx_symbol)
 											(cons (quote list) (map carriers (lambda (carrier)
 												(nth carrier 2))))))))))))
 			(begin
@@ -3566,7 +3572,9 @@ lookup for each ordered driver candidate. */
 					(define candidate_recsets (map parts (lambda (item) (nth item 2))))
 					(define candidate_recset (if (single_source? candidate_recsets)
 						(car candidate_recsets)
-						(list (quote recset_union) (cons (quote list) candidate_recsets))))
+						(list (quote recset_union)
+							(physical_query_tx_symbol)
+							(cons (quote list) candidate_recsets))))
 					(define keyset_expr (if group_cache_probe
 						(nth (car parts) 2)
 						(list (quote recset_key_index)
@@ -3627,6 +3635,7 @@ lookup for each ordered driver candidate. */
 					(if (single_source? branch_bindings)
 						(nth (car branch_bindings) 1)
 						(list (quote recset_union)
+							(physical_query_tx_symbol)
 							(cons (quote list) (map branch_bindings (lambda (binding) (nth binding 1))))))))))))
 
 /* When every OR alternative has a target-table candidate RecSet, the general
@@ -3648,7 +3657,9 @@ factoring, or other proven set transformations without adding SQL-shape cases. *
 				(if (reduce candidates (lambda (missing candidate)
 					(or missing (nil? candidate))) false)
 					nil
-					(list (quote recset_union) (cons (quote list) candidates))))))))
+					(list (quote recset_union)
+						(physical_query_tx_symbol)
+						(cons (quote list) candidates))))))))
 
 (define ordered_batch_membership_terms (lambda (src condition)
 	(filter (map (split_and_terms (coalesceNil condition true)) (lambda (term)
@@ -3745,6 +3756,7 @@ so complex ACL trees receive the same per-node physical choices as any scan. */
 				(define membership_expr (if (equal? (count batch_inputs) 1)
 					input_batch
 					(list (quote recset_intersect)
+						(physical_query_tx_symbol)
 						(cons (quote list) batch_inputs))))
 				(define residual_probe_work_rows
 					(batch_membership_survivor_rows memberships probe_work_rows planning_session))
@@ -4051,6 +4063,7 @@ RecSet; membership edges retain their own physical operators. */
 								(map base_cols (lambda (col) (scan_callback_symbol_for_alias alias col)))
 								(lower_column_expr_for_alias src membership_formula_residual))))
 						(list (quote recset_difference)
+							(physical_query_tx_symbol)
 							(cons (quote list) (cons base_recset (nth membership_formula 2)))))
 					(if membership_formula_driver (nth membership_formula 1) nil)))
 				(define membership_driver (and
@@ -4114,6 +4127,7 @@ RecSet; membership edges retain their own physical operators. */
 					(if (equal? membership_table_expr source_table)
 						effective_scalar_carrier
 						(list (quote recset_intersect)
+							(physical_query_tx_symbol)
 							(cons (quote list) (list
 								effective_scalar_carrier
 								membership_table_expr))))))
@@ -6895,6 +6909,7 @@ carrier remains on the measured direct path and is never built eagerly. */
 					(if (equal? base_table_expr (source_table_expr_using stages src))
 						consumed_scalar_carrier
 						(list (quote recset_intersect)
+							(physical_query_tx_symbol)
 							(cons (quote list) (list
 								consumed_scalar_carrier
 								base_table_expr))))))

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -128,11 +128,19 @@ func (t *storageShard) forEachVisibleRun(part *recSetShard, visibleUpper uint32,
 	})
 }
 
-// recSet is a query-local, non-persistent subset of one table represented by
-// physical record IDs. It is intentionally table-shaped so the planner can swap
-// repeated scans over the same filtered base relation for a scan over this value.
+// recSet is a query-local, non-persistent set of candidate record IDs for one
+// table. It is intentionally table-shaped so the planner can replace repeated
+// scans of the same filtered base relation with scans of this value.
+//
+// A RecSet deliberately does not own transaction, session, cancellation, or
+// visibility state. scan_recset constructs it during one query after applying
+// that query's visibility rules, and every later storage operation receives the
+// same query transaction explicitly. The ordinary scan path then applies
+// visibility again while consuming the candidates. Keeping execution state out
+// of this immutable value prevents a nil transaction from silently acquiring an
+// old context and makes RecSet algebra independent of the former GLS transport.
+// RecSets must never be persisted or reused across queries.
 type recSet struct {
-	tx     *TxContext
 	table  *table
 	shards []recSetShard
 	count  int64
@@ -170,21 +178,22 @@ func (r *recSet) contains(shard *storageShard, recid uint32) bool {
 	return r.shardEntry(shard).contains(recid)
 }
 
-func recSetUnion(items []*recSet) *recSet {
+// RecSet algebra combines immutable candidate IDs only. currentTx is an
+// execution parameter for cancellation and per-session fanout limits; it is
+// neither stored in the result nor consulted to reinterpret membership.
+func recSetUnion(currentTx *TxContext, items []*recSet) *recSet {
 	var base *table
-	var tx *TxContext
 	for _, rs := range items {
 		if rs == nil || rs.table == nil {
 			continue
 		}
 		if base == nil {
 			base = rs.table
-			tx = rs.tx
 		} else if base != rs.table {
 			panic("recset_union: all recsets must belong to the same table")
 		}
 	}
-	result := &recSet{tx: tx, table: base}
+	result := &recSet{table: base}
 	if base == nil {
 		return result
 	}
@@ -218,8 +227,8 @@ func recSetUnion(items []*recSet) *recSet {
 	// its own channel-dispatch overhead is roughly 1µs — well under 1% of a
 	// single combine's cost, let alone many shards' worth done serially.
 	values := make(chan recSetBuildResult, len(tasks))
-	done := runFanoutTasks(tx, len(tasks), func(taskIndex int, _ bool) {
-		withTxSession(tx, func() scm.Scmer {
+	done := runFanoutTasks(currentTx, len(tasks), func(taskIndex int, _ bool) {
+		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {
 					values <- recSetBuildResult{err: scanError{rec, string(debug.Stack())}}
@@ -259,21 +268,19 @@ func recSetUnion(items []*recSet) *recSet {
 	return result
 }
 
-func recSetIntersect(items []*recSet) *recSet {
+func recSetIntersect(currentTx *TxContext, items []*recSet) *recSet {
 	var base *table
-	var tx *TxContext
 	for _, rs := range items {
 		if rs == nil || rs.table == nil {
 			continue
 		}
 		if base == nil {
 			base = rs.table
-			tx = rs.tx
 		} else if base != rs.table {
 			panic("recset_intersect: all recsets must belong to the same table")
 		}
 	}
-	result := &recSet{tx: tx, table: base}
+	result := &recSet{table: base}
 	if base == nil || len(items) == 0 {
 		return result
 	}
@@ -283,8 +290,8 @@ func recSetIntersect(items []*recSet) *recSet {
 	// shard: channel-dispatch overhead (~1µs) is under 1% of a single
 	// combine's cost (~100µs-1ms).
 	values := make(chan recSetBuildResult, len(shards))
-	done := runFanoutTasks(tx, len(shards), func(taskIndex int, _ bool) {
-		withTxSession(tx, func() scm.Scmer {
+	done := runFanoutTasks(currentTx, len(shards), func(taskIndex int, _ bool) {
+		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {
 					values <- recSetBuildResult{err: scanError{rec, string(debug.Stack())}}
@@ -336,7 +343,7 @@ func recSetIntersect(items []*recSet) *recSet {
 
 // recSetDifference returns the records in the first RecSet which occur in none
 // of the following RecSets. All operands must belong to the same base table.
-func recSetDifference(items []*recSet) *recSet {
+func recSetDifference(currentTx *TxContext, items []*recSet) *recSet {
 	if len(items) == 0 || items[0] == nil || items[0].table == nil {
 		panic("recset_difference requires a non-empty list of recsets")
 	}
@@ -346,10 +353,10 @@ func recSetDifference(items []*recSet) *recSet {
 			panic("recset_difference: all recsets must belong to the same table")
 		}
 	}
-	result := &recSet{tx: left.tx, table: left.table}
+	result := &recSet{table: left.table}
 	values := make(chan recSetBuildResult, len(left.shards))
-	done := runFanoutTasks(left.tx, len(left.shards), func(taskIndex int, _ bool) {
-		withTxSession(left.tx, func() scm.Scmer {
+	done := runFanoutTasks(currentTx, len(left.shards), func(taskIndex int, _ bool) {
+		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {
 					values <- recSetBuildResult{err: scanError{rec, string(debug.Stack())}}
@@ -397,17 +404,18 @@ func recSetDifference(items []*recSet) *recSet {
 	return result
 }
 
-// recSetNot complements a RecSet against the currently visible rows of its
-// base table. Building that visible universe through the ordinary scan path is
-// essential: raw recid inversion would resurrect deleted or tx-invisible rows.
-func recSetNot(item *recSet) *recSet {
+// recSetNot complements a RecSet against the rows visible to currentTx. Unlike
+// the pure set operations above it therefore needs a storage scan. Building the
+// universe through that ordinary scan path is essential: raw RecID inversion
+// would resurrect deleted or transaction-invisible rows.
+func recSetNot(currentTx *TxContext, item *recSet) *recSet {
 	if item == nil || item.table == nil {
 		panic("recset_not requires a recset with a base table")
 	}
-	visible := item.table.scanRecSet(item.tx, nil, scm.NewFunc(func(...scm.Scmer) scm.Scmer {
+	visible := item.table.scanRecSet(currentTx, nil, scm.NewFunc(func(...scm.Scmer) scm.Scmer {
 		return scm.NewBool(true)
 	}))
-	return recSetDifference([]*recSet{visible, item})
+	return recSetDifference(currentTx, []*recSet{visible, item})
 }
 
 func recSetContainsClosure(shard *storageShard) *func(uint32, ...scm.Scmer) scm.Scmer {
@@ -451,7 +459,7 @@ func (t *table) scanRecSet(currentTx *TxContext, conditionCols []string, conditi
 	boundaries := extractBoundaries(conditionCols, condition)
 	reorderByFrequency(boundaries, t)
 	lower, upperLast := indexFromBoundaries(boundaries)
-	result := &recSet{tx: currentTx, table: t}
+	result := &recSet{table: t}
 
 	values := make(chan recSetBuildResult, t.shardResultBufferSize())
 	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
@@ -616,13 +624,10 @@ func (t *storageShard) collectRecSet(boundaries boundaries, lower []scm.Scmer, u
 
 func (r *recSet) projectJoin(currentTx *TxContext, sourceKeyCols []string, target *table, targetKeyCols []string) *recSet {
 	if r == nil || r.table == nil {
-		return &recSet{tx: currentTx, table: target}
+		return &recSet{table: target}
 	}
 	if len(sourceKeyCols) == 0 || len(sourceKeyCols) != len(targetKeyCols) {
 		panic("recset_project_join: source and target key columns must have the same non-zero length")
-	}
-	if currentTx == nil {
-		currentTx = r.tx
 	}
 	ss := SessionStateFromTx(currentTx)
 	keys := r.collectProjectJoinKeys(currentTx, sourceKeyCols, ss)
@@ -957,7 +962,7 @@ func (t *storageShard) collectProjectJoinKeys(part *recSetShard, sourceKeyCols [
 }
 
 func (t *table) projectJoinKeysToRecSet(currentTx *TxContext, targetKeyCols []string, keys recSetProjectKeys, ss *scm.SessionState) *recSet {
-	result := &recSet{tx: currentTx, table: t}
+	result := &recSet{table: t}
 	if keys.count() == 0 {
 		return result
 	}
@@ -1201,9 +1206,6 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 			panic("recset scan mutation callbacks are not implemented")
 		}
 	}
-	if currentTx == nil {
-		currentTx = r.tx
-	}
 	return r.table.scanWithBatchFrom(currentTx, r, conditionCols, condition,
 		callbackCols, callback, aggregate, neutral, aggregate2, isOuter, 0, nil, nil)
 }
@@ -1211,9 +1213,6 @@ func (r *recSet) scan(currentTx *TxContext, conditionCols []string, condition sc
 func (r *recSet) scanExists(currentTx *TxContext, conditionCols []string, condition scm.Scmer) bool {
 	if r == nil || r.table == nil {
 		return false
-	}
-	if currentTx == nil {
-		currentTx = r.tx
 	}
 	return r.table.scanExistsFrom(currentTx, r, conditionCols, condition)
 }
@@ -1596,12 +1595,9 @@ func (r *recSet) filterToRecSet(currentTx *TxContext, conditionCols []string, co
 	if r == nil {
 		return nil
 	}
-	if currentTx == nil {
-		currentTx = r.tx
-	}
 	ss := SessionStateFromTx(currentTx)
 	querySeq := querySeqFromTx(currentTx)
-	result := &recSet{tx: currentTx, table: r.table}
+	result := &recSet{table: r.table}
 	values := make(chan recSetBuildResult, len(r.shards))
 	activeParts := make([]int, 0, len(r.shards))
 	for i := range r.shards {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -1128,9 +1128,6 @@ func (t *table) scanOrderFirst(currentTx *TxContext, conditionCols []string, con
 }
 
 func (r *recSet) scan_order(currentTx *TxContext, conditionCols []string, condition scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, callback scm.Scmer, aggregate scm.Scmer, neutral scm.Scmer, isOuter bool, notFoundValue scm.Scmer, postOrderCols []string, postOrderFilter scm.Scmer) scm.Scmer {
-	if currentTx == nil {
-		currentTx = r.tx
-	}
 	return scanOrderMulti(currentTx, []scanOrderTableSpec{{
 		recset:          r,
 		conditionCols:   conditionCols,

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -73,7 +73,7 @@ func collectOrderedCandidateBatch(currentTx *TxContext, source scanOrderTableSpe
 	scanOrderMulti(currentTx, []scanOrderTableSpec{source}, sortdirs, 0, offset, limit,
 		scm.NewNil(), scm.NewNil(), false, scm.NewNil())
 
-	batch := &recSet{tx: currentTx, table: table, shards: make([]recSetShard, 0, len(partOrder))}
+	batch := &recSet{table: table, shards: make([]recSetShard, 0, len(partOrder))}
 	for _, part := range partOrder {
 		sort.Slice(part.recids, func(i, j int) bool { return part.recids[i] < part.recids[j] })
 		shardPart := newRecSetShardFromSortedIDs(part.shard, part.universe, part.recids)
@@ -178,7 +178,7 @@ func collectPartitionOrderedCandidateBatch(currentTx *TxContext, source scanOrde
 			}
 		}()
 
-		batch := &recSet{tx: currentTx, table: table, shards: make([]recSetShard, 0, len(partOrder))}
+		batch := &recSet{table: table, shards: make([]recSetShard, 0, len(partOrder))}
 		for _, part := range partOrder {
 			sort.Slice(part.recids, func(i, j int) bool { return part.recids[i] < part.recids[j] })
 			shardPart := newRecSetShardFromSortedIDs(part.shard, part.universe, part.recids)
@@ -189,16 +189,13 @@ func collectPartitionOrderedCandidateBatch(currentTx *TxContext, source scanOrde
 	}
 }
 
-func validateAcceptedBatch(currentTx *TxContext, batch *recSet, acceptedValue scm.Scmer) *recSet {
+func validateAcceptedBatch(batch *recSet, acceptedValue scm.Scmer) *recSet {
 	if !acceptedValue.IsCustom(TagRecSet) {
 		panic("scan_order_batch_accept: batch filter must return a recset")
 	}
 	accepted := RecSetFromScmer(acceptedValue)
 	if accepted == nil || accepted.table != batch.table {
 		panic("scan_order_batch_accept: batch filter must return a recset of the input table")
-	}
-	if accepted.tx != currentTx {
-		panic("scan_order_batch_accept: batch filter returned a recset from a different transaction")
 	}
 	for i := range accepted.shards {
 		part := &accepted.shards[i]
@@ -260,13 +257,6 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 	if len(sortcols) != len(sortdirs) {
 		panic("scan_order_batch_accept: sortcols and sortdirs must have equal length")
 	}
-	if source.recset != nil {
-		if currentTx == nil {
-			currentTx = source.recset.tx
-		} else if currentTx != source.recset.tx {
-			panic("scan_order_batch_accept: input recset belongs to a different transaction")
-		}
-	}
 	if source.backingTable() == nil {
 		panic("scan_order_batch_accept: input must have a backing table")
 	}
@@ -326,7 +316,7 @@ func scanOrderBatchAccept(currentTx *TxContext, source scanOrderTableSpec, batch
 			break
 		}
 		filterArgs[0] = NewRecSetScmer(batch)
-		accepted := validateAcceptedBatch(currentTx, batch, filterProgram.Call(filterArgs[:]))
+		accepted := validateAcceptedBatch(batch, filterProgram.Call(filterArgs[:]))
 
 		var pendingShard *storageShard
 		pending := make([]uint32, 0, len(records))

--- a/storage/scan_order_batch_accept_bench_test.go
+++ b/storage/scan_order_batch_accept_bench_test.go
@@ -182,9 +182,9 @@ func BenchmarkScanOrderBatchAcceptMillion(b *testing.B) {
 		batchACLFilter := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 			batch := RecSetFromScmer(values[0])
 			candidateFiles := batch.projectJoin(nil, []string{"file_id"}, fixture.files, []string{"id"})
-			acceptedFiles := recSetIntersect([]*recSet{candidateFiles, allowedFiles})
+			acceptedFiles := recSetIntersect(nil, []*recSet{candidateFiles, allowedFiles})
 			projectedDocuments := acceptedFiles.projectJoin(nil, []string{"id"}, fixture.documents, []string{"file_id"})
-			return NewRecSetScmer(recSetIntersect([]*recSet{batch, projectedDocuments}))
+			return NewRecSetScmer(recSetIntersect(nil, []*recSet{batch, projectedDocuments}))
 		})
 		b.Run(fmt.Sprintf("acl_projection_%02dpct", percent), func(b *testing.B) {
 			benchmarkBatchAcceptPair(b,

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -48,7 +48,7 @@ func recSetModuloFilter(batchSizes *[]int64, divisor int, remainder int) scm.Scm
 	return scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 		batch := RecSetFromScmer(values[0])
 		*batchSizes = append(*batchSizes, batch.count)
-		return NewRecSetScmer(batch.filterToRecSet(batch.tx, []string{"id"}, condition))
+		return NewRecSetScmer(batch.filterToRecSet(nil, []string{"id"}, condition))
 	})
 }
 
@@ -202,27 +202,6 @@ func TestScanOrderBatchAcceptRejectsNonSubset(t *testing.T) {
 	}()
 	runBatchAcceptIDs(table, nil, badFilter, []scm.Scmer{scm.NewString("id")},
 		[]func(...scm.Scmer) scm.Scmer{ascending}, 0, 2)
-}
-
-func TestScanOrderBatchAcceptRejectsInputFromDifferentTransaction(t *testing.T) {
-	table := setupBatchAcceptTable(t, "tbatchacceptinputtx", 4)
-	inputTx := &TxContext{}
-	otherTx := &TxContext{}
-	input := table.scanRecSet(nil, nil,
-		scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) }))
-	input.tx = inputTx
-
-	defer func() {
-		if recover() == nil {
-			t.Fatal("input RecSet from another transaction did not panic")
-		}
-	}()
-	scanOrderBatchAccept(otherTx, scanOrderTableSpec{recset: input},
-		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
-		nil, nil, 0, 0, 1, []string{"id"},
-		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] }),
-		scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[1] }),
-		scm.NewNil(), false, scm.NewNil())
 }
 
 func TestScanOrderBatchAcceptDeclarationSignature(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1066,16 +1066,18 @@ func Init(en scm.Env) {
 		Name: "recset_union",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			values := mustScmerSlice(a[0], "recsets")
+			currentTx := scmerToTxContext(a[0])
+			values := mustScmerSlice(a[1], "recsets")
 			recsets := make([]*recSet, 0, len(values))
 			for _, value := range values {
 				recsets = append(recsets, RecSetFromScmer(value))
 			}
-			return NewRecSetScmer(recSetUnion(recsets))
+			return NewRecSetScmer(recSetUnion(currentTx, recsets))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "combines query-local recsets from the same table and removes duplicate record IDs",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "current query transaction used for cancellation and parallelism limits"},
 				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
@@ -1085,16 +1087,18 @@ func Init(en scm.Env) {
 		Name: "recset_intersect",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			values := mustScmerSlice(a[0], "recsets")
+			currentTx := scmerToTxContext(a[0])
+			values := mustScmerSlice(a[1], "recsets")
 			recsets := make([]*recSet, 0, len(values))
 			for _, value := range values {
 				recsets = append(recsets, RecSetFromScmer(value))
 			}
-			return NewRecSetScmer(recSetIntersect(recsets))
+			return NewRecSetScmer(recSetIntersect(currentTx, recsets))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "intersects query-local recsets from the same table",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "current query transaction used for cancellation and parallelism limits"},
 				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
@@ -1104,16 +1108,18 @@ func Init(en scm.Env) {
 		Name: "recset_difference",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			values := mustScmerSlice(a[0], "recsets")
+			currentTx := scmerToTxContext(a[0])
+			values := mustScmerSlice(a[1], "recsets")
 			recsets := make([]*recSet, 0, len(values))
 			for _, value := range values {
 				recsets = append(recsets, RecSetFromScmer(value))
 			}
-			return NewRecSetScmer(recSetDifference(recsets))
+			return NewRecSetScmer(recSetDifference(currentTx, recsets))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the records from the first query-local recset which occur in none of the following same-table recsets",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "current query transaction used for cancellation and parallelism limits"},
 				{Kind: "list", Label: "recsets"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},
@@ -1123,11 +1129,12 @@ func Init(en scm.Env) {
 		Name: "recset_not",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			return NewRecSetScmer(recSetNot(RecSetFromScmer(a[0])))
+			return NewRecSetScmer(recSetNot(scmerToTxContext(a[0]), RecSetFromScmer(a[1])))
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns the complement of a query-local recset relative to the currently visible rows of its base table",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "current query transaction used to build the visible complement"},
 				{Kind: "recset", Label: "recset"},
 			},
 			Return: &scm.TypeDescriptor{Kind: "recset"},

--- a/tests/execution/operators/recset.yaml
+++ b/tests/execution/operators/recset.yaml
@@ -518,7 +518,7 @@ test_cases:
           '("active")
           (lambda (value) (equal? value 1))))
         (define lookup (recset_key_index nil
-          (recset_union (list tenant1 active))
+          (recset_union nil (list tenant1 active))
           '("tenant" "active")))
         (if (and
               (lookup 1 1)
@@ -548,7 +548,7 @@ test_cases:
         (define active (scan_recset nil tbl
           '("active")
           (lambda (active) (equal? active 1))))
-        (define combined (recset_union (list tenant1 active)))
+        (define combined (recset_union nil (list tenant1 active)))
         (define sum_ids
           (scan nil combined
             '()
@@ -583,27 +583,27 @@ test_cases:
               (equal? (recset_count positive) 10)
               (equal? (recset_count negative) 4086)
               (equal? (recset_count even) 2048)
-              (equal? (recset_count (recset_union (list positive positive2))) 14)
-              (equal? (recset_count (recset_intersect (list positive positive2))) 6)
-              (equal? (recset_count (recset_union (list negative negative2))) 4096)
-              (equal? (recset_count (recset_intersect (list negative negative2))) 4076)
-              (equal? (recset_count (recset_union (list negative negative3))) 4091)
-              (equal? (recset_count (recset_intersect (list negative negative3))) 4086)
-              (equal? (recset_count (recset_union (list positive2 negative))) 4092)
-              (equal? (recset_count (recset_intersect (list positive2 negative))) 4)
-              (equal? (recset_count (recset_union (list even third))) 2731)
-              (equal? (recset_count (recset_intersect (list even third))) 682)
-              (equal? (recset_count (recset_union (list positive even))) 2053)
-              (equal? (recset_count (recset_intersect (list positive even))) 5)
-              (equal? (recset_count (recset_union (list negative even))) 4091)
-              (equal? (recset_count (recset_intersect (list negative even))) 2043)
-              (equal? (recset_count (recset_union (list full positive))) 4096)
-              (equal? (recset_count (recset_intersect (list empty negative))) 0)
-              (equal? (recset_count (recset_union (list empty positive))) 10)
-              (equal? (recset_count (recset_intersect (list full negative))) 4086)
-              (equal? (recset_count (recset_not positive)) 4086)
-              (equal? (recset_count (recset_difference (list negative even))) 2043)
-              (equal? (recset_count (recset_difference (list full positive even))) 2043))
+              (equal? (recset_count (recset_union nil (list positive positive2))) 14)
+              (equal? (recset_count (recset_intersect nil (list positive positive2))) 6)
+              (equal? (recset_count (recset_union nil (list negative negative2))) 4096)
+              (equal? (recset_count (recset_intersect nil (list negative negative2))) 4076)
+              (equal? (recset_count (recset_union nil (list negative negative3))) 4091)
+              (equal? (recset_count (recset_intersect nil (list negative negative3))) 4086)
+              (equal? (recset_count (recset_union nil (list positive2 negative))) 4092)
+              (equal? (recset_count (recset_intersect nil (list positive2 negative))) 4)
+              (equal? (recset_count (recset_union nil (list even third))) 2731)
+              (equal? (recset_count (recset_intersect nil (list even third))) 682)
+              (equal? (recset_count (recset_union nil (list positive even))) 2053)
+              (equal? (recset_count (recset_intersect nil (list positive even))) 5)
+              (equal? (recset_count (recset_union nil (list negative even))) 4091)
+              (equal? (recset_count (recset_intersect nil (list negative even))) 2043)
+              (equal? (recset_count (recset_union nil (list full positive))) 4096)
+              (equal? (recset_count (recset_intersect nil (list empty negative))) 0)
+              (equal? (recset_count (recset_union nil (list empty positive))) 10)
+              (equal? (recset_count (recset_intersect nil (list full negative))) 4086)
+              (equal? (recset_count (recset_not nil positive)) 4086)
+              (equal? (recset_count (recset_difference nil (list negative even))) 2043)
+              (equal? (recset_count (recset_difference nil (list full positive even))) 2043))
           "ok"
           (error "adaptive recset algebra returned wrong cardinality")))
 
@@ -614,7 +614,7 @@ test_cases:
         (define tenant1 (scan_recset nil tbl
           '("tenant")
           (lambda (tenant) (equal? tenant 1))))
-        (define complement (recset_not tenant1))
+        (define complement (recset_not nil tenant1))
         (define sum_ids
           (scan nil complement '() (lambda () true) '("id")
             (lambda (id) id) (lambda (acc id) (+ acc id)) 0))
@@ -629,7 +629,7 @@ test_cases:
         (define full (scan_recset nil tbl '() (lambda () true)))
         (define tenant1 (scan_recset nil tbl '("tenant") (lambda (tenant) (equal? tenant 1))))
         (define active (scan_recset nil tbl '("active") (lambda (value) (equal? value 1))))
-        (define remaining (recset_difference (list full tenant1 active)))
+        (define remaining (recset_difference nil (list full tenant1 active)))
         (define sum_ids
           (scan nil remaining '() (lambda () true) '("id")
             (lambda (id) id) (lambda (acc id) (+ acc id)) 0))
@@ -638,7 +638,7 @@ test_cases:
           (error "recset_difference returned wrong row set")))
 
   - name: "recset_difference requires a left operand"
-    scm: "(recset_difference (list))"
+    scm: "(recset_difference nil (list))"
     expect:
       error: true
 
@@ -647,7 +647,7 @@ test_cases:
       (begin
         (define left (scan_recset nil (table "memcp-tests" "recset_items") '() (lambda () true)))
         (define right (scan_recset nil (table "memcp-tests" "recset_other") '() (lambda () true)))
-        (recset_union (list left right)))
+        (recset_union nil (list left right)))
     expect:
       error: true
 
@@ -656,7 +656,7 @@ test_cases:
       (begin
         (define left (scan_recset nil (table "memcp-tests" "recset_items") '() (lambda () true)))
         (define right (scan_recset nil (table "memcp-tests" "recset_other") '() (lambda () true)))
-        (recset_intersect (list left right)))
+        (recset_intersect nil (list left right)))
     expect:
       error: true
 
@@ -665,7 +665,7 @@ test_cases:
       (begin
         (define left (scan_recset nil (table "memcp-tests" "recset_items") '() (lambda () true)))
         (define right (scan_recset nil (table "memcp-tests" "recset_other") '() (lambda () true)))
-        (recset_difference (list left right)))
+        (recset_difference nil (list left right)))
     expect:
       error: true
 

--- a/tests/performance/stackoverflow-query-shapes.yaml
+++ b/tests/performance/stackoverflow-query-shapes.yaml
@@ -351,10 +351,10 @@ test_cases:
                 (define b_from_d
                   (recset_project_join tx d_batch '("bk") b '("bpk")))
                 (define valid_b
-                  (recset_intersect (list b_batch b_from_c b_from_d)))
+                  (recset_intersect tx (list b_batch b_from_c b_from_d)))
                 (define valid_a
                   (recset_project_join tx valid_b '("ak") a '("apk")))
-                (recset_intersect (list a_batch valid_a))))
+                (recset_intersect tx (list a_batch valid_a))))
             '("apk") '(<) 0 0 1 '("apk")
             (lambda (apk) apk) (lambda (_acc value) value) nil false))
         (if (equal? minimum 1) "ok" (error "wrong ordered batch MIN result")))
@@ -409,7 +409,7 @@ test_cases:
           (scan_recset tx measures '("ts")
             (lambda (ts) (and (>= ts 0) (<= ts 120000)))))
         (define selected
-          (recset_intersect (list node_measures sensor_measures time_measures)))
+          (recset_intersect tx (list node_measures sensor_measures time_measures)))
         (define rows
           (scan_order tx selected '() (lambda () true) '("ts") '(>) 0 0 4
             '("ts" "sensor_id" "val")
@@ -449,8 +449,8 @@ test_cases:
         (define excluded1
           (recset_project_join tx other_t1 '("otherpid") t1 '("pid")))
         (define excluded
-          (recset_union (list excluded2 excluded3 excluded1)))
-        (define allowed (recset_difference (list all_t1 excluded)))
+          (recset_union tx (list excluded2 excluded3 excluded1)))
+        (define allowed (recset_difference tx (list all_t1 excluded)))
         (define row_count
           (scan tx allowed '() (lambda () true) '() (lambda () 1) + 0))
         (if (equal? row_count 60000) "ok" (error "wrong anti-membership result")))


### PR DESCRIPTION
## What

- remove the stored transaction pointer from `recSet`
- pass the current query transaction explicitly to RecSet algebra for cancellation and per-session fanout limits
- make `nil` transaction arguments remain genuinely transactionless instead of inheriting context from a RecSet
- update physical plan generation and direct operator callers to the explicit signatures
- document the query-local immutable candidate-set invariant and remove the obsolete cross-transaction identity check

## Why

A RecSet exists only during one query. It is built after that query's visibility checks, and all consuming storage operations run with the same explicitly supplied query transaction and reapply visibility through the normal scan path. Storing a transaction in the RecSet was a leftover implicit-context fallback: it mixed execution state into an immutable candidate set and could silently turn a transactionless call into a transactional one.

Pure union, intersection, and difference use the explicit transaction only for KILL handling and worker limits. `recset_not` additionally needs it to scan the currently visible base-table universe.

## Verification

- `go build ./...`
- focused Go RecSet and scan-order-batch tests
- `tests/execution/operators/recset.yaml`: 34/34
- `tests/integration/regressions/deleted-row-carrier-visibility.yaml`: 14/14
- `tests/execution/concurrency/session-carrier-publication.yaml`: 30/30
- `tests/planner/subqueries/compound-boolean-recset-selection.yaml`: 23/23
- `tests/performance/stackoverflow-query-shapes.yaml`: 15/15 non-perf cases
- Scheme formatting/check and `git diff --check`

The full repository suite is left to CI as requested.
