### PR TITLE
Cover delete masks across scan consumers

### DIFF
--- a/tests/execution/operators/deleted-row-consumers.yaml
+++ b/tests/execution/operators/deleted-row-consumers.yaml
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+metadata:
+  version: "1.0"
+  description: "Delete masks cover every RecSet and index scan consumer for main and delta rows"
+  isolated: true
+setup:
+  - sql: "DROP TABLE IF EXISTS dcm_rows"
+  - sql: "CREATE TABLE dcm_rows (id INT PRIMARY KEY, bucket INT, sort_key INT)"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "dcm_rows") '("id" "bucket" "sort_key")
+          (map (produceN 16) (lambda (i) (list (+ i 1) 7 (+ i 1)))))
+        (rebuild (table "memcp-tests" "dcm_rows") true false)
+        (insert (table "memcp-tests" "dcm_rows") '("id" "bucket" "sort_key")
+          (list (list 17 7 17) (list 18 7 18))))
+test_cases:
+  - name: "Delete masks hide main and delta rows from every consumer"
+    scm: |
+      (begin
+        (define tbl (table "memcp-tests" "dcm_rows"))
+        (define before_delete (scan_recset nil tbl '("bucket") (lambda (bucket) (equal? bucket 7))))
+        (define deleted (scan nil tbl '("id")
+          (lambda (id) (or (equal? id 2) (equal? id 18)))
+          '("$update") (lambda ($update) (if ($update) 1 0)) + 0))
+        (define recset_first_sum (scan nil before_delete '("id") (lambda (_id) true)
+          '("id") (lambda (id) id) + 0))
+        (define base_index_first_count (scan nil tbl '("$recset_contains" "bucket")
+          (lambda (contains bucket) (and (contains before_delete) (equal? bucket 7)))
+          '("id") (lambda (_id) 1) + 0))
+        (define ordered (scan_order nil before_delete '("id") (lambda (_id) true)
+          '("sort_key") '(<) 0 0 20 '("id")
+          (lambda (id) (list id)) (lambda (rows row) (append rows row)) '() false))
+        (define base_ordered (scan_order nil tbl '("$recset_contains" "bucket")
+          (lambda (contains bucket) (and (contains before_delete) (equal? bucket 7)))
+          '("sort_key") '(<) 0 0 20 '("id")
+          (lambda (id) (list id)) (lambda (rows row) (append rows row)) '() false))
+        (define narrowed (scan_recset nil before_delete '("id") (lambda (_id) true)))
+        (if (and (equal? deleted 2)
+          (equal? recset_first_sum 151)
+          (equal? base_index_first_count 16)
+          (equal? (recset_count narrowed) 16)
+          (not (scan_exists nil before_delete '("id") (lambda (id) (equal? id 2))))
+          (not (scan_exists nil before_delete '("id") (lambda (id) (equal? id 18))))
+          (not (scan_exists nil tbl '("$recset_contains" "id")
+            (lambda (contains id) (and (contains before_delete) (or (equal? id 2) (equal? id 18))))))
+          (equal? ordered (map (filter (produceN 18) (lambda (i)
+            (and (not (equal? i 1)) (not (equal? i 17))))) (lambda (i) (list (+ i 1))))))
+          (equal? base_ordered ordered)
+          "ok"
+          (error (concat "delete consumer mismatch: sum=" recset_first_sum
+            " base=" base_index_first_count " count=" (recset_count narrowed)
+            " ordered=" (serialize ordered)))))
+    expect:
+      data: ["ok"]
+
+  - name: "Begin main and delta delete transaction"
+    session_id: "dcm-delete"
+    sql: "START ACID TRANSACTION"
+
+  - name: "Stage one main and one delta delete"
+    session_id: "dcm-delete"
+    sql: "DELETE FROM dcm_rows WHERE id IN (3, 17)"
+    expect:
+      rows_affected: 2
+
+  - &transaction_rows
+    name: "Deleting transaction hides main and delta rows from ordered scans"
+    session_id: "dcm-delete"
+    sql: "SELECT id FROM dcm_rows WHERE bucket = 7 AND id IN (3, 17) ORDER BY sort_key"
+    expect:
+      rows: 0
+      data: []
+
+  - name: "Deleting transaction hides main and delta rows from scan_exists"
+    session_id: "dcm-delete"
+    sql: "SELECT EXISTS (SELECT 1 FROM dcm_rows WHERE bucket = 7 AND id IN (3, 17)) AS present"
+    expect:
+      rows: 1
+      data: [{present: false}]
+
+  - <<: *transaction_rows
+    name: "Other transaction retains main and delta visibility"
+    session_id: "dcm-observer"
+    expect:
+      rows: 2
+      data: [{id: 3}, {id: 17}]
+
+  - name: "Rollback main and delta deletes"
+    session_id: "dcm-delete"
+    sql: "ROLLBACK"
+
+  - <<: *transaction_rows
+    name: "Rollback restores main and delta visibility"
+    expect:
+      rows: 2
+      data: [{id: 3}, {id: 17}]
+cleanup:
+  - sql: "DROP TABLE IF EXISTS dcm_rows"


### PR DESCRIPTION
## Summary
- add direct operator coverage for delete masks on compressed base rows and unrebuilt delta rows
- cover `scan`, `scan_recset`, `scan_exists`, and `scan_order`
- exercise RecSet-first and base-index-first consumption
- verify transaction-local visibility, isolation from another session, and rollback restoration

## Result
The new suite passes on current `master` (8/8), so this PR closes a CI coverage gap rather than changing working storage behavior.

## Targeted validation
- `python3 run_sql_tests.py tests/execution/operators/deleted-row-consumers.yaml` (8/8)

The full repository suite is intentionally left to CI.