### PR TITLE
Retain cached query plans across statistically similar rebuilds

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -138,6 +138,28 @@ deduplicate immutable ASTs without serializing the growing expressions. */
 						(covered_bindings (if (nil? condition_catalog) (string expr) expr) true)) nil))
 				condition)))))
 
+/* Table statistics use a two-level cache guard: immutable generation tokens
+cover the hot path, while a coarse cost-class fingerprint lets a statistically
+similar REBUILD generation adopt its new token without recompiling the query. */
+(define planner_record_statistics_dependency (lambda (token_expr token fingerprint_expr fingerprint planning_session)
+	(begin
+		(define planning_session (planner_effective_session planning_session))
+		(define dependencies (if (nil? planning_session) nil
+			(planning_session "__memcp_queryplan_statistics_dependencies")))
+		(if (nil? dependencies)
+			nil
+			(begin
+				(define catalog
+					(planning_session "__memcp_queryplan_statistics_dependency_catalog"))
+				(if (catalog token_expr)
+					nil
+					(begin
+						(define count (coalesceNil (dependencies "count") 0))
+						(catalog token_expr true)
+						(dependencies (concat "dependency:" count)
+							(list token_expr token fingerprint_expr fingerprint))
+						(dependencies "count" (+ count 1)))))))))
+
 (define planner_guarded_choice (lambda (chosen condition planning_session)
 	(begin
 		(planner_record_guard_condition

--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -139,9 +139,9 @@ deduplicate immutable ASTs without serializing the growing expressions. */
 				condition)))))
 
 /* Table statistics use a two-level cache guard: immutable generation tokens
-cover the hot path, while a coarse cost-class fingerprint lets a statistically
-similar REBUILD generation adopt its new token without recompiling the query. */
-(define planner_record_statistics_dependency (lambda (token_expr token fingerprint_expr fingerprint planning_session)
+cover the hot path, while a coarse cost-class fingerprint keeps a statistically
+similar REBUILD generation on the cached plan without recompiling the query. */
+(define planner_record_statistics_dependency (lambda (table_expr token fingerprint planning_session)
 	(begin
 		(define planning_session (planner_effective_session planning_session))
 		(define dependencies (if (nil? planning_session) nil
@@ -151,13 +151,13 @@ similar REBUILD generation adopt its new token without recompiling the query. */
 			(begin
 				(define catalog
 					(planning_session "__memcp_queryplan_statistics_dependency_catalog"))
-				(if (catalog token_expr)
+				(if (catalog table_expr)
 					nil
 					(begin
 						(define count (coalesceNil (dependencies "count") 0))
-						(catalog token_expr true)
+						(catalog table_expr true)
 						(dependencies (concat "dependency:" count)
-							(list token_expr token fingerprint_expr fingerprint))
+							(list table_expr token fingerprint))
 						(dependencies "count" (+ count 1)))))))))
 
 (define planner_guarded_choice (lambda (chosen condition planning_session)

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -1710,21 +1710,23 @@ particular star shape. */
 (define planner_record_table_statistics_guards (lambda (sources planning_session)
 	(reduce (filter sources source_is_base_table?) (lambda (_ src)
 		(begin
-			(define token (table_planner_statistics_token
-				(table (source_schema src) (source_relation src))))
-			(planner_record_guard_condition
-				(list (quote equal?)
-					(list (quote table_planner_statistics_token)
-						(list (quote table) (source_schema src) (source_relation src)))
-					token) planning_session))) nil)))
+			(define table_value (table (source_schema src) (source_relation src)))
+			(define table_expr
+				(list (quote table) (source_schema src) (source_relation src)))
+			(planner_record_statistics_dependency
+				(list (quote table_planner_statistics_token) table_expr)
+				(table_planner_statistics_token table_value)
+				(list (quote table_planner_statistics_fingerprint) table_expr)
+				(table_planner_statistics_fingerprint table_value)
+				planning_session))) nil)))
 
 (define planner_table_statistics_aliases (lambda (sources)
 	(map (filter sources source_is_base_table?) source_alias)))
 
 /* Equality and join selectivity depend only on immutable table statistics.
 Text-pattern priors additionally depend on the current pattern value, so keep
-that value in the guard while replacing repeated statistic derivation with one
-O(1) dependency token per base table. */
+that value in the guard. Table dependencies use a token fast path and compare
+their published statistics fingerprint only when REBUILD changes generation. */
 (define planner_selectivity_value_dependent? (lambda (expr)
 	(match expr
 		((symbol strlike) _value _pattern) true
@@ -2948,28 +2950,12 @@ source itself has no known row count (not a base table). */
 				4096
 				0)))))
 
-(define planner_runtime_column_average_value_bytes (lambda (schema relation column)
-	(begin
-		(define stats (table_planner_statistics (table schema relation)))
-		(define columns (if (nil? stats) nil (stats "columns")))
-		(define column_stats (if (nil? columns) nil (columns column)))
-		(planner_column_average_value_bytes_from_statistics column_stats))))
-
-(define planner_column_average_value_bytes (lambda (src column planning_session)
-	(begin
-		(define measured (planner_column_average_value_bytes_from_statistics
-			(planner_column_statistics src column)))
-		(if (source_is_base_table? src)
-			/* Average width is a physical cost input refined by REBUILD. Keep the
-			cached plan while it is unchanged; a different width recompiles the full
-			cost inequality instead of making every guard walk the logical stage AST. */
-			(planner_record_guard_condition
-				(list (quote equal?)
-					(list (quote planner_runtime_column_average_value_bytes)
-						(source_schema src) (source_relation src) column)
-					measured) planning_session)
-			nil)
-		measured)))
+(define planner_column_average_value_bytes (lambda (src column)
+	/* Base-table width is covered by the table's coarse statistics fingerprint.
+	Do not add a second exact-value guard here: small sampling differences inside
+	the same cost class must retain the cached physical plan. */
+	(planner_column_average_value_bytes_from_statistics
+		(planner_column_statistics src column))))
 
 (define planner_group_distinct_estimate (lambda (src keys row_count)
 	(reduce keys (lambda (estimate key)
@@ -3336,7 +3322,7 @@ either physical alternative or sampling the table again. */
 					(if (physical_text_scan_operation? expr)
 						(reduce (extract_columns_for_alias src (car tail)) (lambda (total column)
 							(+ total (coalesceNil
-								(planner_column_average_value_bytes src column planning_session) 0))) 0)
+								(planner_column_average_value_bytes src column) 0))) 0)
 						0)
 					(reduce children (lambda (total child)
 						(+ total (qassoc_get child (quote broad_text_average_bytes) 0))) 0)))))

--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -1714,9 +1714,8 @@ particular star shape. */
 			(define table_expr
 				(list (quote table) (source_schema src) (source_relation src)))
 			(planner_record_statistics_dependency
-				(list (quote table_planner_statistics_token) table_expr)
+				table_expr
 				(table_planner_statistics_token table_value)
-				(list (quote table_planner_statistics_fingerprint) table_expr)
 				(table_planner_statistics_fingerprint table_value)
 				planning_session))) nil)))
 

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -193,6 +193,9 @@ functional planner return value. */
 		(planning_session "__memcp_queryplan_guard_condition_catalog" (make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_guard_bindings" (newsession))
 		(planning_session "__memcp_queryplan_guard_binding_catalog" (make_structural_catalog (quote ast)))
+		(planning_session "__memcp_queryplan_statistics_dependencies" (newsession))
+		(planning_session "__memcp_queryplan_statistics_dependency_catalog"
+			(make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_guarded_session_keys" (make_structural_catalog (quote ast)))
 		(planning_session "__memcp_queryplan_observed_session_keys" (newsession))
 		(planning_session "__memcp_queryplan_preparations" (newsession))
@@ -293,6 +296,40 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 				(or found (sql_queryplan_guard_references_symbol? item target))) false))
 		_ (equal? expr target))))
 
+(define sql_queryplan_statistics_guard_from_session (lambda (planning_session)
+	(begin
+		(define dependency_session
+			(planning_session "__memcp_queryplan_statistics_dependencies"))
+		(define dependencies (if (nil? dependency_session) '() (map
+			(produceN (coalesceNil (dependency_session "count") 0))
+			(lambda (idx) (dependency_session (concat "dependency:" idx))))))
+		(if (empty_list? dependencies)
+			true
+			(begin
+				(define validation_state (newsession))
+				(define compile_tokens (map dependencies cadr))
+				(define compile_fingerprints (map dependencies (lambda (dependency) (nth dependency 3))))
+				(define current_tokens_symbol (quote __queryplan_current_statistics_tokens))
+				(validation_state "tokens" compile_tokens)
+				/* Mutable validation state stays behind apply so formula optimization
+				cannot freeze the generation observed during compilation. Coarse cost
+				fingerprints are read only after a token miss. */
+				(define validated_tokens_expr (list (quote apply)
+					validation_state (list (quote list) "tokens")))
+				(define update_validated_tokens_expr (list (quote apply)
+					validation_state (list (quote list) "tokens" current_tokens_symbol)))
+				(list
+					(list (quote lambda) (list current_tokens_symbol)
+						(list (quote or)
+							(list (quote equal?) current_tokens_symbol validated_tokens_expr)
+							(list (quote if)
+								(list (quote equal?)
+									(cons (quote list) (map dependencies (lambda (dependency) (nth dependency 2))))
+									(cons (quote list) compile_fingerprints))
+								(list (quote begin) update_validated_tokens_expr true)
+								false)))
+					(cons (quote list) (map dependencies car))))))))
+
 (define sql_queryplan_guard_from_session (lambda (planning_session)
 	(begin
 		(define condition_accumulator (planning_session "__memcp_queryplan_guard_conditions"))
@@ -303,10 +340,11 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 				(map (produceN (coalesceNil (condition_accumulator "count") 0))
 					(lambda (idx) (condition_accumulator (concat "condition:" idx)))))
 			(sql_queryplan_uncovered_binding_conditions planning_session))))
+		(define statistics_guard (sql_queryplan_statistics_guard_from_session planning_session))
 		(define raw_guard (match conditions
-			(cons condition '()) condition
-			(cons _head _tail) (cons (quote and) conditions)
-			_ true))
+			(cons condition '()) (list (quote and) condition statistics_guard)
+			(cons _head _tail) (cons (quote and) (append conditions statistics_guard))
+			_ statistics_guard))
 		(define binding_session (planning_session "__memcp_queryplan_guard_bindings"))
 		(define binding_catalog (planning_session "__memcp_queryplan_guard_binding_catalog"))
 		(define all_bindings (if (nil? binding_catalog)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -296,6 +296,14 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 				(or found (sql_queryplan_guard_references_symbol? item target))) false))
 		_ (equal? expr target))))
 
+/* Avoid degenerate generated `and` forms while retaining normal short-circuit
+semantics for multiple independent cache assumptions. */
+(define sql_queryplan_conjoin_guards (lambda (guards)
+	(match guards
+		'() true
+		(cons guard '()) guard
+		_ (cons (quote and) guards))))
+
 (define sql_queryplan_statistics_guard_from_session (lambda (planning_session)
 	(begin
 		(define dependency_session
@@ -306,29 +314,15 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 		(if (empty_list? dependencies)
 			true
 			(begin
-				(define validation_state (newsession))
-				(define compile_tokens (map dependencies cadr))
-				(define compile_fingerprints (map dependencies (lambda (dependency) (nth dependency 3))))
-				(define current_tokens_symbol (quote __queryplan_current_statistics_tokens))
-				(validation_state "tokens" compile_tokens)
-				/* Mutable validation state stays behind apply so formula optimization
-				cannot freeze the generation observed during compilation. Coarse cost
-				fingerprints are read only after a token miss. */
-				(define validated_tokens_expr (list (quote apply)
-					validation_state (list (quote list) "tokens")))
-				(define update_validated_tokens_expr (list (quote apply)
-					validation_state (list (quote list) "tokens" current_tokens_symbol)))
-				(list
-					(list (quote lambda) (list current_tokens_symbol)
-						(list (quote or)
-							(list (quote equal?) current_tokens_symbol validated_tokens_expr)
-							(list (quote if)
-								(list (quote equal?)
-									(cons (quote list) (map dependencies (lambda (dependency) (nth dependency 2))))
-									(cons (quote list) compile_fingerprints))
-								(list (quote begin) update_validated_tokens_expr true)
-								false)))
-					(cons (quote list) (map dependencies car))))))))
+				/* Keep the guard as ordinary literal AST so it remains valid when tools
+				compile it independently from its query plan. The token comparison is the
+				normal hot path. After REBUILD, each dependency performs one cheap atomic
+				fingerprint read; no cost formula or mutable Scheme payload is rebuilt. */
+				(define dependency_guards (map dependencies (lambda (dependency)
+					(list (quote table_planner_statistics_compatible?)
+						(cadr (car dependency)) (nth (car dependency) 2)
+						(cadr dependency) (nth dependency 2)))))
+				(sql_queryplan_conjoin_guards dependency_guards))))))
 
 (define sql_queryplan_guard_from_session (lambda (planning_session)
 	(begin
@@ -341,10 +335,8 @@ current request bindings. Quoted planner/catalog payloads remain data. */
 					(lambda (idx) (condition_accumulator (concat "condition:" idx)))))
 			(sql_queryplan_uncovered_binding_conditions planning_session))))
 		(define statistics_guard (sql_queryplan_statistics_guard_from_session planning_session))
-		(define raw_guard (match conditions
-			(cons condition '()) (list (quote and) condition statistics_guard)
-			(cons _head _tail) (cons (quote and) (append conditions statistics_guard))
-			_ statistics_guard))
+		(define raw_guard (sql_queryplan_conjoin_guards
+			(merge (list conditions (list statistics_guard)))))
 		(define binding_session (planning_session "__memcp_queryplan_guard_bindings"))
 		(define binding_catalog (planning_session "__memcp_queryplan_guard_binding_catalog"))
 		(define all_bindings (if (nil? binding_catalog)
@@ -472,7 +464,13 @@ otherwise side-effect-free guard. */
 (define sql_queryplan_install_variants (lambda (queryplan_cache cache_key entry parse_fn schema parse_query policy variants)
 	(begin
 		(define recent_variants (sql_queryplan_recent_variants variants))
-		(entry "variants" recent_variants)
+		/* Optimize owns and rewrites the dispatcher AST in place. The registry is
+		read again by the miss path, so its guard must not alias the compiler-owned
+		copy or inherit dispatcher-local NthLocalVar slots. */
+		(entry "variants" (map recent_variants (lambda (variant) (list
+			(clone_optimizer_expression (car variant))
+			(cadr variant)
+			(nth variant 2)))))
 		(entry "formula" (sql_queryplan_compile_formula
 			(sql_queryplan_formula queryplan_cache cache_key entry parse_fn schema parse_query policy recent_variants)))
 		(entry "formula"))))
@@ -485,7 +483,7 @@ otherwise side-effect-free guard. */
 			(list (sql_compile_queryplan_variant parse_fn schema parse_query policy source_session tx))))
 		(list entry formula))))
 
-(define sql_queryplan_matching_variant (lambda (variants session tx resultrow)
+(define sql_queryplan_matching_variant (lambda (variants session tx resultrow resultfields)
 	(match variants
 		(cons variant rest) (begin
 			/* This request may hold an older formula while another request prepends a
@@ -493,9 +491,13 @@ otherwise side-effect-free guard. */
 			rechecking its guard; preparation expressions are request-idempotent. */
 			(map (nth variant 2) (lambda (preparation)
 				(eval (sql_queryplan_preparation_expr preparation))))
-			(if (eval (car variant))
+			/* Guards are code, not expressions in this helper's lexical scope. Compile
+			them against the same explicit request boundary as the cached dispatcher;
+			naked eval would couple their symbols/NthLocalVars to this helper's frame. */
+			(if ((sql_queryplan_compile_formula (clone_optimizer_expression (car variant)))
+				session tx resultrow resultfields)
 				variant
-				(sql_queryplan_matching_variant rest session tx resultrow)))
+				(sql_queryplan_matching_variant rest session tx resultrow resultfields)))
 		_ nil)))
 
 /* Called only by the final else branch of a cached plan. Recheck after taking
@@ -508,7 +510,7 @@ the common guard-dispatch path. */
 			(begin
 				(define current_variants (entry "variants"))
 				(define matching (sql_queryplan_matching_variant current_variants
-					session tx resultrow))
+					session tx resultrow resultfields))
 				/* Return the chosen plan directly. Re-entering entry.formula would
 				re-evaluate the guard which just missed and can recurse indefinitely;
 				another request's freshly installed matching variant is already safe to

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -1123,6 +1123,20 @@ func init() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "clone_optimizer_expression",
+
+		Fn: func(a ...Scmer) Scmer {
+			return CloneOptimizerExpression(a[0])
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "copy an AST before transferring a separate copy to the optimizer",
+			Params: []*TypeDescriptor{
+				{Kind: "any", Label: "expression"},
+			},
+			Return:         &TypeDescriptor{Kind: "any"},
+			HasSideEffects: true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "optimize",
 
 		Fn: func(a ...Scmer) Scmer {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -851,6 +851,36 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "table_planner_statistics_compatible?",
+
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			db := GetDatabase(scm.String(a[0]))
+			if db == nil {
+				return scm.NewBool(false)
+			}
+			tbl := db.GetTable(scm.String(a[1]))
+			if tbl == nil {
+				return scm.NewBool(false)
+			}
+			compileToken := uint64(a[2].Int())
+			if tbl.PlannerStatsToken() == compileToken {
+				return scm.NewBool(true)
+			}
+			compileFingerprint := uint64(a[3].Int())
+			return scm.NewBool(tbl.PlannerStatisticsFingerprint() == compileFingerprint)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "check whether cached-plan table statistics remain in the same cost class",
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "schema"},
+				{Kind: "string", Label: "table"},
+				{Kind: "int", Label: "compile_token"},
+				{Kind: "int", Label: "compile_fingerprint"},
+			},
+			Return:         &scm.TypeDescriptor{Kind: "bool"},
+			HasSideEffects: true,
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "table_order_partitioned?",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -835,6 +835,22 @@ func Init(en scm.Env) {
 		},
 	})
 	scm.Declare(&en, &scm.Declaration{
+		Name: "table_planner_statistics_fingerprint",
+
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if a[0].IsNil() {
+				return scm.NewNil()
+			}
+			return scm.NewInt(int64(TableFromScmer(a[0]).PlannerStatisticsFingerprint()))
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return the coarse cost-class fingerprint of a table's immutable planner-statistics snapshot",
+			Params: []*scm.TypeDescriptor{
+				{Kind: "table", Label: "table"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "int"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "table_order_partitioned?",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/storage/table.go
+++ b/storage/table.go
@@ -19,6 +19,7 @@ package storage
 import "context"
 import "fmt"
 import "math"
+import "math/bits"
 import "sync"
 import "time"
 import "errors"
@@ -1261,6 +1262,8 @@ func (t *table) adjustPlannerRows(delta int64) {
 		plannerRoot.Set(scm.NewString("columns"), columns, nil)
 		replacement := *current
 		replacement.plannerValue = scm.NewFastDict(plannerRoot)
+		replacement.plannerFingerprint = plannerStatisticsFingerprint(
+			rowEstimate, replacement.plannerColumnsFingerprint)
 		replacement.rowEstimate = uint(rowEstimate)
 		if t.showColumnsSnapshot.CompareAndSwap(current, &replacement) {
 			t.publishPlannerStatsToken()
@@ -1380,12 +1383,75 @@ func getForeignKeyMode(val scm.Scmer) foreignKeyMode {
 }
 
 type tableShowColumnsSnapshot struct {
-	value        scm.Scmer
-	plannerValue scm.Scmer
-	rowEstimate  uint
-	columns      *tableShowColumnsMetadata
-	columnNames  *tableColumnNamesSnapshot
-	statistics   *tableStatisticsSnapshot
+	value                     scm.Scmer
+	plannerValue              scm.Scmer
+	plannerFingerprint        uint64
+	plannerColumnsFingerprint uint64
+	rowEstimate               uint
+	columns                   *tableShowColumnsMetadata
+	columnNames               *tableColumnNamesSnapshot
+	statistics                *tableStatisticsSnapshot
+}
+
+func plannerFingerprintMix(fingerprint, value uint64) uint64 {
+	fingerprint ^= value + 0x9e3779b97f4a7c15 + (fingerprint << 6) + (fingerprint >> 2)
+	return fingerprint
+}
+
+func plannerFingerprintString(fingerprint uint64, value string) uint64 {
+	for i := 0; i < len(value); i++ {
+		fingerprint = plannerFingerprintMix(fingerprint, uint64(value[i]))
+	}
+	return plannerFingerprintMix(fingerprint, uint64(len(value)))
+}
+
+// plannerMagnitudeBucket groups positive estimates by powers of two. Cost
+// choices should survive ordinary rebuild noise while still being reconsidered
+// when a table, distinct domain, or value width changes order of magnitude.
+func plannerMagnitudeBucket(value uint64) uint64 {
+	return uint64(bits.Len64(value))
+}
+
+func plannerFractionBucket(value float64) uint64 {
+	if math.IsNaN(value) {
+		return 0
+	}
+	if value <= 0 {
+		return 1
+	}
+	if value >= 1 {
+		return 10
+	}
+	return 2 + uint64(value*8)
+}
+
+func plannerWidthBucket(value float64) uint64 {
+	if math.IsNaN(value) || value <= 0 {
+		return 0
+	}
+	if math.IsInf(value, 1) {
+		return ^uint64(0)
+	}
+	_, exponent := math.Frexp(value)
+	return uint64(int64(exponent) + 1<<31)
+}
+
+func plannerColumnFingerprint(fingerprint uint64, c *column, distinctEstimate uint64, stats *columnPlannerStatistics) uint64 {
+	fingerprint = plannerFingerprintString(fingerprint, c.Name)
+	fingerprint = plannerFingerprintString(fingerprint, c.Typ)
+	fingerprint = plannerFingerprintMix(fingerprint, plannerMagnitudeBucket(distinctEstimate))
+	if stats == nil {
+		return plannerFingerprintMix(fingerprint, 0)
+	}
+	fingerprint = plannerFingerprintMix(fingerprint, 1)
+	fingerprint = plannerFingerprintString(fingerprint, stats.Source)
+	fingerprint = plannerFingerprintMix(fingerprint, plannerFractionBucket(stats.Confidence))
+	fingerprint = plannerFingerprintMix(fingerprint, plannerFractionBucket(stats.NullFraction))
+	return plannerFingerprintMix(fingerprint, plannerWidthBucket(stats.AverageValueBytes))
+}
+
+func plannerStatisticsFingerprint(rowEstimate, columnsFingerprint uint64) uint64 {
+	return plannerFingerprintMix(columnsFingerprint, plannerMagnitudeBucket(rowEstimate))
 }
 
 type tableShowColumnsMetadata struct {
@@ -1421,6 +1487,7 @@ func foldIdentifier(name string) string {
 func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnapshot {
 	result := make([]scm.Scmer, len(t.Columns))
 	plannerColumns := scm.NewFastDictValue(len(t.Columns))
+	plannerColumnsFingerprint := uint64(0x6a09e667f3bcc909)
 	distinctEstimates := make([]uint64, len(t.Columns))
 	plannerStatistics := make([]*columnPlannerStatistics, len(t.Columns))
 	columnNames := t.buildColumnNamesSnapshot()
@@ -1443,6 +1510,8 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 		}
 		distinctEstimates[i] = distinctEstimate
 		plannerStatistics[i] = c.PlannerStats.Load()
+		plannerColumnsFingerprint = plannerColumnFingerprint(
+			plannerColumnsFingerprint, c, distinctEstimate, plannerStatistics[i])
 		result[i] = c.show(keyType, distinctEstimate, rowEstimate, plannerStatistics[i])
 		plannerStatsValue := plannerColumnStatisticsValue(distinctEstimate, plannerStatistics[i], c.Typ)
 		plannerColumns.Set(scm.NewString(c.Name), plannerStatsValue, nil)
@@ -1450,13 +1519,17 @@ func (t *table) buildShowColumnsSnapshot(rowEstimate uint) *tableShowColumnsSnap
 			plannerColumns.Set(scm.NewString(folded), plannerStatsValue, nil)
 		}
 	}
+	plannerColumnsValue := scm.NewFastDict(plannerColumns)
 	plannerRoot := scm.NewFastDictValue(2)
 	plannerRoot.Set(scm.NewString("row_count"), scm.NewInt(int64(rowEstimate)), nil)
-	plannerRoot.Set(scm.NewString("columns"), scm.NewFastDict(plannerColumns), nil)
+	plannerRoot.Set(scm.NewString("columns"), plannerColumnsValue, nil)
+	plannerValue := scm.NewFastDict(plannerRoot)
 	snapshot := &tableShowColumnsSnapshot{
-		value:        scm.NewSlice(result),
-		plannerValue: scm.NewFastDict(plannerRoot),
-		rowEstimate:  rowEstimate,
+		value:                     scm.NewSlice(result),
+		plannerValue:              plannerValue,
+		plannerFingerprint:        plannerStatisticsFingerprint(uint64(rowEstimate), plannerColumnsFingerprint),
+		plannerColumnsFingerprint: plannerColumnsFingerprint,
+		rowEstimate:               rowEstimate,
 		columns: &tableShowColumnsMetadata{
 			distinctEstimates: distinctEstimates,
 			plannerStatistics: plannerStatistics,
@@ -1543,6 +1616,22 @@ func (t *table) PlannerStatistics() scm.Scmer {
 		snapshot := t.showColumnsSnapshot.Load()
 		if snapshot != nil {
 			return snapshot.plannerValue
+		}
+		t.publishShowColumnsSnapshot()
+	}
+}
+
+// PlannerStatisticsFingerprint identifies the coarse cost class of immutable
+// statistics independently of its rebuild generation. It is computed once
+// while publishing the snapshot, so cache revalidation remains O(1).
+func (t *table) PlannerStatisticsFingerprint() uint64 {
+	if t == nil {
+		return 0
+	}
+	for {
+		snapshot := t.showColumnsSnapshot.Load()
+		if snapshot != nil {
+			return snapshot.plannerFingerprint
 		}
 		t.publishShowColumnsSnapshot()
 	}

--- a/storage/table_show_test.go
+++ b/storage/table_show_test.go
@@ -191,6 +191,15 @@ func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
 	if publishedToken == 0 {
 		t.Fatal("published planner statistics have no dependency token")
 	}
+	publishedFingerprint := tbl.PlannerStatisticsFingerprint()
+	tbl.publishShowColumnsSnapshot()
+	if tbl.PlannerStatsToken() == publishedToken {
+		t.Fatal("republished planner statistics retained their generation token")
+	}
+	if got := tbl.PlannerStatisticsFingerprint(); got != publishedFingerprint {
+		t.Fatalf("unchanged planner statistics changed fingerprint from %d to %d", publishedFingerprint, got)
+	}
+	publishedToken = tbl.PlannerStatsToken()
 
 	root := tbl.PlannerStatistics().FastDict()
 	rowCount, ok := root.Get(scm.NewString("row_count"))
@@ -231,6 +240,9 @@ func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
 	if adjustedToken == publishedToken {
 		t.Fatal("planner row-count update retained a stale dependency token")
 	}
+	if got := tbl.PlannerStatisticsFingerprint(); got != publishedFingerprint {
+		t.Fatalf("same-magnitude row-count update changed fingerprint from %d to %d", publishedFingerprint, got)
+	}
 	updatedRoot := tbl.PlannerStatistics().FastDict()
 	updatedRows, _ := updatedRoot.Get(scm.NewString("row_count"))
 	if updatedRows.Int() != 100 {
@@ -249,6 +261,38 @@ func TestPlannerStatisticsUsesHashedImmutableSnapshot(t *testing.T) {
 	tbl.adjustPlannerRows(-200)
 	if got := tbl.CountEstimate(); got != 0 {
 		t.Fatalf("saturated CountEstimate() = %d, want 0", got)
+	}
+}
+
+func TestPlannerStatisticsFingerprintUsesMagnitudeBuckets(t *testing.T) {
+	const columnsFingerprint = uint64(12345)
+	if plannerStatisticsFingerprint(91, columnsFingerprint) != plannerStatisticsFingerprint(100, columnsFingerprint) {
+		t.Fatal("ordinary row-count growth crossed a planner fingerprint bucket")
+	}
+	if plannerStatisticsFingerprint(91, columnsFingerprint) == plannerStatisticsFingerprint(182, columnsFingerprint) {
+		t.Fatal("doubling the row count retained the planner fingerprint")
+	}
+	if plannerMagnitudeBucket(17) != plannerMagnitudeBucket(31) {
+		t.Fatal("same-magnitude distinct estimates use different buckets")
+	}
+	if plannerMagnitudeBucket(17) == plannerMagnitudeBucket(34) {
+		t.Fatal("doubled distinct estimate retained its magnitude bucket")
+	}
+	col := &column{Name: "payload", Typ: "VARCHAR"}
+	first := &columnPlannerStatistics{
+		Confidence: 0.91, Source: "rebuild", NullFraction: 0.11, AverageValueBytes: 12.5,
+	}
+	nearby := &columnPlannerStatistics{
+		Confidence: 0.95, Source: "rebuild", NullFraction: 0.12, AverageValueBytes: 15.9,
+	}
+	base := plannerColumnFingerprint(42, col, 17, first)
+	if got := plannerColumnFingerprint(42, col, 31, nearby); got != base {
+		t.Fatalf("nearby column statistics changed cost class from %d to %d", base, got)
+	}
+	wide := *nearby
+	wide.AverageValueBytes = 32
+	if got := plannerColumnFingerprint(42, col, 31, &wide); got == base {
+		t.Fatal("large average-width change retained its column cost class")
 	}
 }
 

--- a/tests/performance/traced-planner-scaling.yaml
+++ b/tests/performance/traced-planner-scaling.yaml
@@ -56,6 +56,34 @@ setup:
   - sql: "INSERT INTO tps_prop SELECT id + 512, CASE WHEN id % 2 = 0 THEN 1 ELSE 2 END, FALSE FROM tps_prop"
 
 test_cases:
+  # This deliberately times the first cache lookup after an unchanged rebuild.
+  # Ordinary warm-query benchmarks cannot detect a periodic statistics-token
+  # invalidation because their warmup has already hidden the recompilation.
+  - name: "Unchanged rebuild retains a complex cached plan"
+    sql: &rebuild_cache_query >-
+      SELECT
+      (SELECT SUM(1) FROM tps_prop item_1 WHERE item_1.id = 1 AND COALESCE((SELECT (parent_1.owner_id = 7 OR EXISTS (SELECT TRUE FROM tps_assignment member_1 WHERE member_1.team_id = parent_1.team_id AND member_1.member_id = 7 LIMIT 1)) FROM tps_parent parent_1 WHERE parent_1.id = item_1.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_1,
+      (SELECT SUM(1) FROM tps_prop item_2 WHERE item_2.id = 1 AND COALESCE((SELECT (parent_2.owner_id = 7 OR EXISTS (SELECT TRUE FROM tps_assignment member_2 WHERE member_2.team_id = parent_2.team_id AND member_2.member_id = 7 LIMIT 1)) FROM tps_parent parent_2 WHERE parent_2.id = item_2.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_2,
+      (SELECT SUM(1) FROM tps_prop item_3 WHERE item_3.id = 1 AND COALESCE((SELECT (parent_3.owner_id = 7 OR EXISTS (SELECT TRUE FROM tps_assignment member_3 WHERE member_3.team_id = parent_3.team_id AND member_3.member_id = 7 LIMIT 1)) FROM tps_parent parent_3 WHERE parent_3.id = item_3.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_3,
+      (SELECT SUM(1) FROM tps_prop item_4 WHERE item_4.id = 1 AND COALESCE((SELECT (parent_4.owner_id = 7 OR EXISTS (SELECT TRUE FROM tps_assignment member_4 WHERE member_4.team_id = parent_4.team_id AND member_4.member_id = 7 LIMIT 1)) FROM tps_parent parent_4 WHERE parent_4.id = item_4.parent_id LIMIT 1), FALSE) LIMIT 1) AS metric_4
+    setup:
+      - scm: |
+          (begin
+            (rebuild (table "memcp-tests" "tps_prop") true false)
+            (rebuild (table "memcp-tests" "tps_parent") true false)
+            (rebuild (table "memcp-tests" "tps_assignment") true false))
+      - sql: *rebuild_cache_query
+      - scm: |
+          (begin
+            (rebuild (table "memcp-tests" "tps_prop") true false)
+            (rebuild (table "memcp-tests" "tps_parent") true false)
+            (rebuild (table "memcp-tests" "tps_assignment") true false))
+    warmup: 0
+    timing_samples: 1
+    threshold_ms: 5000
+    expect:
+      rows: 1
+
   - name: "Independent nested scalar aggregates compile within a linear budget"
     max_time: 1.0
     # The separate 48-stage suite owns the asymptotic gate. Retain this small

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -695,6 +695,31 @@ test_cases:
     expect:
       data: [true]
 
+  - name: "Cached SQL join recompiles after cardinality guard miss"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define resultrow (lambda (_row) nil))
+        (define query "SELECT l.id FROM ps_guard_left l JOIN ps_guard_right r ON r.id = l.rhs ORDER BY l.id")
+        (define first_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
+        (sql_execute_formula sess nil first_formula resultrow (lambda (_fields) nil))
+        (define entry (car (cache (car (cache)))))
+        (define variants_after_first (count (entry "variants")))
+        (insert (table "memcp-tests" "ps_guard_right") '("id")
+          (map (produceN 500) (lambda (i) (list (+ i 2)))))
+        (rebuild (table "memcp-tests" "ps_guard_right") true false)
+        (define second_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
+        (sql_execute_formula sess nil second_formula resultrow (lambda (_fields) nil))
+        (if (and (equal? variants_after_first 1) (equal? (count (entry "variants")) 2))
+          "ok"
+          (error (concat "unexpected statistics variants: first=" variants_after_first
+            " final=" (count (entry "variants"))))))
+    expect:
+      data: ["ok"]
+
   - name: "Cached SQL join survives a rebuild with unchanged statistics"
     scm: |
       (begin

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -11,6 +11,7 @@ metadata:
 
 setup:
   - sql: "DROP TABLE IF EXISTS ps_guard_left"
+  - sql: "DROP TABLE IF EXISTS ps_guard_many"
   - sql: "DROP TABLE IF EXISTS ps_guard_right"
   - sql: "DROP TABLE IF EXISTS ps_search_docs"
   - sql: "DROP TABLE IF EXISTS ps_search_files"
@@ -19,8 +20,10 @@ setup:
   - sql: "DROP TABLE IF EXISTS ps_test"
   - sql: "CREATE TABLE ps_test (id int, name text, score float)"
   - sql: "CREATE TABLE ps_guard_left (id int primary key, rhs int)"
+  - sql: "CREATE TABLE ps_guard_many (id int)"
   - sql: "CREATE TABLE ps_guard_right (id int primary key)"
   - sql: "INSERT INTO ps_guard_left (id, rhs) VALUES (1, 1), (2, 1)"
+  - sql: "INSERT INTO ps_guard_many (id) VALUES (1)"
   - sql: "INSERT INTO ps_guard_right (id) VALUES (1)"
   - sql: "CREATE TABLE ps_search_docs (id int primary key, file int, title text, sort_key int)"
   - sql: "CREATE TABLE ps_search_files (id int primary key, filename text, search text)"
@@ -31,6 +34,7 @@ setup:
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS ps_guard_left"
+  - sql: "DROP TABLE IF EXISTS ps_guard_many"
   - sql: "DROP TABLE IF EXISTS ps_guard_right"
   - sql: "DROP TABLE IF EXISTS ps_search_docs"
   - sql: "DROP TABLE IF EXISTS ps_search_files"
@@ -691,7 +695,7 @@ test_cases:
     expect:
       data: [true]
 
-  - name: "Cached SQL join recompiles after cardinality guard miss"
+  - name: "Cached SQL join survives a rebuild with unchanged statistics"
     scm: |
       (begin
         (define cache (newcachemap))
@@ -699,14 +703,52 @@ test_cases:
         (sess "username" "root")
         (sess "schema" "memcp-tests")
         (define resultrow (lambda (_row) nil))
+        /* ORDER BY fixes the left driver here. Rebuilding the right table changes
+        its immutable statistics token, but cannot change the winning plan. */
         (define query "SELECT l.id FROM ps_guard_left l JOIN ps_guard_right r ON r.id = l.rhs ORDER BY l.id")
+        (define right_table (table "memcp-tests" "ps_guard_right"))
+        (rebuild right_table true false)
+        (define first_token (table_planner_statistics_token right_table))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true)
+          resultrow (lambda (_fields) nil))
+        (define entry (car (cache (car (cache)))))
+        (rebuild right_table true false)
+        (define second_token (table_planner_statistics_token right_table))
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true)
+          resultrow (lambda (_fields) nil))
+        /* A second token miss proves the guard updated its validated generation;
+        it must not accumulate variants merely because REBUILD ran. */
+        (rebuild right_table true false)
+        (sql_execute_formula sess nil
+          (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true)
+          resultrow (lambda (_fields) nil))
+        (if (and
+          (not (equal? first_token second_token))
+          (equal? (count (entry "variants")) 1))
+          "ok"
+          (error (concat "unchanged cost choices recompiled: variants="
+            (count (entry "variants"))))))
+    expect:
+      data: ["ok"]
+
+  - name: "Cached SQL join recompiles after a large cardinality change"
+    scm: |
+      (begin
+        (define cache (newcachemap))
+        (define sess (newsession))
+        (sess "username" "root")
+        (sess "schema" "memcp-tests")
+        (define resultrow (lambda (_row) nil))
+        (define query "SELECT l.id FROM ps_guard_left l JOIN ps_guard_many r ON r.id = l.rhs")
         (define first_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
         (sql_execute_formula sess nil first_formula resultrow (lambda (_fields) nil))
         (define entry (car (cache (car (cache)))))
         (define variants_after_first (count (entry "variants")))
-        (insert (table "memcp-tests" "ps_guard_right") '("id")
+        (insert (table "memcp-tests" "ps_guard_many") '("id")
           (map (produceN 500) (lambda (i) (list (+ i 2)))))
-        (rebuild (table "memcp-tests" "ps_guard_right") true false)
+        (rebuild (table "memcp-tests" "ps_guard_many") true false)
         (define second_formula (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true))
         (sql_execute_formula sess nil second_formula resultrow (lambda (_fields) nil))
         (if (and (equal? variants_after_first 1) (equal? (count (entry "variants")) 2))

--- a/tests/sql/expressions/prepared-stmts.yaml
+++ b/tests/sql/expressions/prepared-stmts.yaml
@@ -743,8 +743,8 @@ test_cases:
         (sql_execute_formula sess nil
           (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true)
           resultrow (lambda (_fields) nil))
-        /* A second token miss proves the guard updated its validated generation;
-        it must not accumulate variants merely because REBUILD ran. */
+        /* Repeated token misses exercise the coarse fingerprint fallback; they
+        must not accumulate variants merely because REBUILD ran. */
         (rebuild right_table true false)
         (sql_execute_formula sess nil
           (cached_parse cache (list parse_sql) "memcp-tests" query nil "root" sess true)


### PR DESCRIPTION
## Summary

- keep the existing statistics-generation token as the constant-time hot path
- after a token change, compare one precomputed coarse cost-class fingerprint per referenced base table
- keep the cached plan when row count, distinct counts, confidence, null fraction, and average width remain in the same planning buckets
- fall through to normal cached-plan recompilation when a cost class changes
- keep revalidation guards as stateless literal AST and clone them at the optimizer ownership boundary
- compile cold-path registry guards against the explicit request parameters instead of evaluating them in the helper's lexical frame

Fingerprints are published with the immutable planner-statistics snapshot. Row-count updates recompute them from the saved column fingerprint in O(1); query execution only performs atomic snapshot reads and integer comparisons. Row counts, distinct estimates, and widths use power-of-two magnitude buckets. Schema-relevant column identity/type and statistics knownness/source remain exact.

## Correctness coverage

- unchanged rebuild generations retain one cached variant despite repeated token misses
- large cardinality growth crosses the fingerprint boundary and adds a newly compiled variant
- cached guard ASTs cannot be mutated into dispatcher-local `NthLocalVar` references
- unit coverage verifies that nearby row/NDV/width values remain together while doubling or a large width change crosses a bucket
- the master `query-cache-growth` regression test now passes through the revalidation miss path

## Manual A/B

Identical trace-shaped four-scalar-subquery fixture and query on master 6cdd79dd4 and this branch. Both sides used warmup 0 and timing_samples 1; fixture setup first established rebuild statistics, warmed the SQL plan, then performed another unchanged rebuild before the measured request.

- master: 92.6 ms, 92.2 ms, 94.1 ms
- branch: 2.1 ms, 2.4 ms, 1.6 ms; final verification after the CI fix: 1.8 ms
- improvement: approximately 97-98 percent for the first request after rebuild

## Local verification

- prepared statement and plan-cache suite: 57/57
- cache-growth regression: 1/1
- traced planner performance suite: 9/9, including 1.8 ms after unchanged rebuild
- targeted storage fingerprint tests: pass
- Scheme startup tests: 1272/1272
- Scheme formatter checks and Go build: pass

The full repository suite is intentionally left to CI.
