### PR TITLE
Stabilize fused mapreducer JIT emission

### DIFF
--- a/scm/alu.go
+++ b/scm/alu.go
@@ -898,6 +898,11 @@ func init_alu() {
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
+				resultRegsProtected := result.Loc == LocRegPair
+				if resultRegsProtected {
+					ctx.ProtectReg(result.Reg)
+					ctx.ProtectReg(result.Reg2)
+				}
 				lbl0 := ctx.ReserveLabel()
 				bbpos_0_0 := int32(-1)
 				_ = bbpos_0_0
@@ -1329,10 +1334,7 @@ func init_alu() {
 					d30 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d2)
 					ctx.EnsureDesc(&d30)
-					ctx.EnsureDesc(&d2)
-					ctx.EnsureDesc(&d30)
-					ctx.EnsureDesc(&d2)
-					ctx.EnsureDesc(&d30)
+					ctx.EnsureDescsTogether(&d2, &d30)
 					var d31 JITValueDesc
 					if d2.Loc == LocImm && d30.Loc == LocImm {
 						d31 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d2.Imm.Int() == d30.Imm.Int())}
@@ -1587,10 +1589,7 @@ func init_alu() {
 					d54 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d2)
 					ctx.EnsureDesc(&d54)
-					ctx.EnsureDesc(&d2)
-					ctx.EnsureDesc(&d54)
-					ctx.EnsureDesc(&d2)
-					ctx.EnsureDesc(&d54)
+					ctx.EnsureDescsTogether(&d2, &d54)
 					var d55 JITValueDesc
 					if d2.Loc == LocImm && d54.Loc == LocImm {
 						d55 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d2.Imm.Int() < d54.Imm.Int())}
@@ -1924,10 +1923,7 @@ func init_alu() {
 					ctx.FreeDesc(&d8)
 					ctx.EnsureDesc(&d1)
 					ctx.EnsureDesc(&d88)
-					ctx.EnsureDesc(&d1)
-					ctx.ProtectReg(d1.Reg)
-					ctx.EnsureDesc(&d88)
-					ctx.UnprotectReg(d1.Reg)
+					ctx.EnsureDescsTogether(&d1, &d88)
 					var d89 JITValueDesc
 					if d1.Loc == LocImm && d88.Loc == LocImm {
 						d89 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d1.Imm.Int() + d88.Imm.Int())}
@@ -3124,10 +3120,7 @@ func init_alu() {
 					d148 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d3)
 					ctx.EnsureDesc(&d148)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d148)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d148)
+					ctx.EnsureDescsTogether(&d3, &d148)
 					var d149 JITValueDesc
 					if d3.Loc == LocImm && d148.Loc == LocImm {
 						d149 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3.Imm.Int() < d148.Imm.Int())}
@@ -3842,8 +3835,7 @@ func init_alu() {
 					ctx.FreeDesc(&d99)
 					ctx.EnsureDesc(&d4)
 					ctx.EnsureDesc(&d205)
-					ctx.EnsureDesc(&d4)
-					ctx.EnsureDesc(&d205)
+					ctx.EnsureDescsTogether(&d4, &d205)
 					var d206 JITValueDesc
 					if d4.Loc == LocImm && d205.Loc == LocImm {
 						d206 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d4.Imm.Float() + d205.Imm.Float())}
@@ -3962,7 +3954,10 @@ func init_alu() {
 				_ = bbs[0].RenderPS(ps209)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
-				ctx.FreeStack(int32(64))
+				if resultRegsProtected {
+					ctx.UnprotectReg(result.Reg2)
+					ctx.UnprotectReg(result.Reg)
+				}
 				return result
 			},
 			JITInlineCost: 38,
@@ -4062,6 +4057,11 @@ func init_alu() {
 					result = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
+				}
+				resultRegsProtected := result.Loc == LocRegPair
+				if resultRegsProtected {
+					ctx.ProtectReg(result.Reg)
+					ctx.ProtectReg(result.Reg2)
 				}
 				lbl0 := ctx.ReserveLabel()
 				bbpos_0_0 := int32(-1)
@@ -4756,10 +4756,7 @@ func init_alu() {
 					ctx.FreeDesc(&d58)
 					ctx.EnsureDesc(&d57)
 					ctx.EnsureDesc(&d59)
-					ctx.EnsureDesc(&d57)
-					ctx.ProtectReg(d57.Reg)
-					ctx.EnsureDesc(&d59)
-					ctx.UnprotectReg(d57.Reg)
+					ctx.EnsureDescsTogether(&d57, &d59)
 					var d60 JITValueDesc
 					if d57.Loc == LocImm && d59.Loc == LocImm {
 						d60 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d57.Imm.Int() + d59.Imm.Int())}
@@ -4938,8 +4935,7 @@ func init_alu() {
 					ctx.FreeDesc(&d64)
 					ctx.EnsureDesc(&d63)
 					ctx.EnsureDesc(&d65)
-					ctx.EnsureDesc(&d63)
-					ctx.EnsureDesc(&d65)
+					ctx.EnsureDescsTogether(&d63, &d65)
 					var d66 JITValueDesc
 					if d63.Loc == LocImm && d65.Loc == LocImm {
 						d66 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d63.Imm.Float() + d65.Imm.Float())}
@@ -5325,6 +5321,10 @@ func init_alu() {
 				_ = bbs[0].RenderPS(ps107)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
+				if resultRegsProtected {
+					ctx.UnprotectReg(result.Reg2)
+					ctx.UnprotectReg(result.Reg)
+				}
 				return result
 			},
 			JITInlineCost: 40,
@@ -14395,6 +14395,11 @@ func init_alu() {
 					ctx.BindReg(result.Reg, &result)
 					ctx.BindReg(result.Reg2, &result)
 				}
+				resultRegsProtected := result.Loc == LocRegPair
+				if resultRegsProtected {
+					ctx.ProtectReg(result.Reg)
+					ctx.ProtectReg(result.Reg2)
+				}
 				lbl0 := ctx.ReserveLabel()
 				bbpos_0_0 := int32(-1)
 				_ = bbpos_0_0
@@ -14601,10 +14606,7 @@ func init_alu() {
 					ctx.FreeDesc(&d1)
 					ctx.EnsureDesc(&d11)
 					ctx.EnsureDesc(&d7)
-					ctx.EnsureDesc(&d11)
-					ctx.EnsureDesc(&d7)
-					ctx.EnsureDesc(&d11)
-					ctx.EnsureDesc(&d7)
+					ctx.EnsureDescsTogether(&d11, &d7)
 					var d12 JITValueDesc
 					if d11.Loc == LocImm && d7.Loc == LocImm {
 						d12 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d11.Imm.Int() < d7.Imm.Int())}
@@ -15850,10 +15852,7 @@ func init_alu() {
 					d102 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d3)
 					ctx.EnsureDesc(&d102)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d102)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d102)
+					ctx.EnsureDescsTogether(&d3, &d102)
 					var d103 JITValueDesc
 					if d3.Loc == LocImm && d102.Loc == LocImm {
 						d103 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3.Imm.Int() == d102.Imm.Int())}
@@ -16245,10 +16244,7 @@ func init_alu() {
 					d141 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d3)
 					ctx.EnsureDesc(&d141)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d141)
-					ctx.EnsureDesc(&d3)
-					ctx.EnsureDesc(&d141)
+					ctx.EnsureDescsTogether(&d3, &d141)
 					var d142 JITValueDesc
 					if d3.Loc == LocImm && d141.Loc == LocImm {
 						d142 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d3.Imm.Int() < d141.Imm.Int())}
@@ -16967,10 +16963,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d2)
 					ctx.EnsureDesc(&d195)
-					ctx.EnsureDesc(&d2)
-					ctx.ProtectReg(d2.Reg)
-					ctx.EnsureDesc(&d195)
-					ctx.UnprotectReg(d2.Reg)
+					ctx.EnsureDescsTogether(&d2, &d195)
 					var d196 JITValueDesc
 					if d2.Loc == LocImm && d195.Loc == LocImm {
 						d196 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2.Imm.Int() * d195.Imm.Int())}
@@ -17769,8 +17762,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d257)
 					ctx.EnsureDesc(&d258)
-					ctx.EnsureDesc(&d257)
-					ctx.EnsureDesc(&d258)
+					ctx.EnsureDescsTogether(&d257, &d258)
 					var d259 JITValueDesc
 					if d257.Loc == LocImm && d258.Loc == LocImm {
 						d259 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d257.Imm.Float() == d258.Imm.Float())}
@@ -18324,10 +18316,7 @@ func init_alu() {
 					ctx.FreeDesc(&d257)
 					ctx.EnsureDesc(&d2)
 					ctx.EnsureDesc(&d315)
-					ctx.EnsureDesc(&d2)
-					ctx.ProtectReg(d2.Reg)
-					ctx.EnsureDesc(&d315)
-					ctx.UnprotectReg(d2.Reg)
+					ctx.EnsureDescsTogether(&d2, &d315)
 					var d316 JITValueDesc
 					if d2.Loc == LocImm && d315.Loc == LocImm {
 						d316 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(d2.Imm.Int() * d315.Imm.Int())}
@@ -19250,8 +19239,7 @@ func init_alu() {
 					}
 					ctx.EnsureDesc(&d6)
 					ctx.EnsureDesc(&d327)
-					ctx.EnsureDesc(&d6)
-					ctx.EnsureDesc(&d327)
+					ctx.EnsureDescsTogether(&d6, &d327)
 					var d328 JITValueDesc
 					if d6.Loc == LocImm && d327.Loc == LocImm {
 						d328 = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(d6.Imm.Float() * d327.Imm.Float())}
@@ -19847,10 +19835,7 @@ func init_alu() {
 					d334 = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(args)))}
 					ctx.EnsureDesc(&d5)
 					ctx.EnsureDesc(&d334)
-					ctx.EnsureDesc(&d5)
-					ctx.EnsureDesc(&d334)
-					ctx.EnsureDesc(&d5)
-					ctx.EnsureDesc(&d334)
+					ctx.EnsureDescsTogether(&d5, &d334)
 					var d335 JITValueDesc
 					if d5.Loc == LocImm && d334.Loc == LocImm {
 						d335 = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(d5.Imm.Int() < d334.Imm.Int())}
@@ -20361,7 +20346,10 @@ func init_alu() {
 				_ = bbs[0].RenderPS(ps414)
 				ctx.MarkLabel(lbl0)
 				ctx.ResolveFixups()
-				ctx.FreeStack(int32(96))
+				if resultRegsProtected {
+					ctx.UnprotectReg(result.Reg2)
+					ctx.UnprotectReg(result.Reg)
+				}
 				return result
 			},
 			JITInlineCost: 57,

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -1096,6 +1096,40 @@ func (ctx *JITContext) EnsureDesc(desc *JITValueDesc) {
 	}
 }
 
+// EnsureDescsTogether materializes a set of operands without allowing a later
+// reload to evict an earlier one. Generated binary operations use this at the
+// final consumption point; otherwise two spilled values can repeatedly evict
+// each other and leave both aliased descriptors naming the same register.
+func (ctx *JITContext) EnsureDescsTogether(descs ...*JITValueDesc) {
+	var protected [16]Reg
+	protectedCount := 0
+	for _, desc := range descs {
+		ctx.EnsureDesc(desc)
+		switch desc.Loc {
+		case LocReg:
+			ctx.ProtectReg(desc.Reg)
+			protected[protectedCount] = desc.Reg
+			protectedCount++
+		case LocRegPair:
+			ctx.ProtectReg(desc.Reg)
+			protected[protectedCount] = desc.Reg
+			protectedCount++
+			ctx.ProtectReg(desc.Reg2)
+			protected[protectedCount] = desc.Reg2
+			protectedCount++
+		case LocRegTriple:
+			for _, reg := range [...]Reg{desc.Reg, desc.Reg2, desc.Reg3} {
+				ctx.ProtectReg(reg)
+				protected[protectedCount] = reg
+				protectedCount++
+			}
+		}
+	}
+	for i := protectedCount - 1; i >= 0; i-- {
+		ctx.UnprotectReg(protected[i])
+	}
+}
+
 // FreeReg returns a register to the free pool.
 func (ctx *JITContext) FreeReg(r Reg) {
 	owner := ctx.RegOwners[r]

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -208,6 +208,23 @@ func jitCopyScmerToPair(ctx *JITContext, src JITValueDesc) JITValueDesc {
 	return target
 }
 
+// JITPrepareScmerGoArg restores the two-word Scmer representation required by
+// Go's ABI after the JIT type system has folded a value to an unboxed scalar.
+// Already boxed register, input, and spill values stay in place so native call
+// boundaries do not introduce copies when both words are already available.
+func JITPrepareScmerGoArg(ctx *JITContext, src JITValueDesc) JITValueDesc {
+	ctx.SyncDesc(&src)
+	switch src.Loc {
+	case LocRegPair, LocStackPair, LocInputPair:
+		return src
+	case LocImm, LocReg, LocStack:
+		target := jitAllocTrackedPair(ctx, src.Type)
+		return jitPlaceIntoPair(ctx, &src, target)
+	default:
+		panic("jit: Go call expects a Scmer argument")
+	}
+}
+
 func jitPlaceScmerIntoTarget(ctx *JITContext, src JITValueDesc, target JITValueDesc) JITValueDesc {
 	if target.Loc == LocAny {
 		return src
@@ -705,7 +722,11 @@ func (ctx *JITContext) EmitCopyDescWords(dst, src *JITValueDesc, words int) {
 			srcBase = ctx.FrameReg
 		}
 		scratch := ctx.AllocReg()
-		for i := 0; i < words; i++ {
+		start, end, step := 0, words, 1
+		if srcBase == dstBase && dst.StackOff > src.StackOff && dst.StackOff < src.StackOff+int32(words*8) {
+			start, end, step = words-1, -1, -1
+		}
+		for i := start; i != end; i += step {
 			off := int32(i * 8)
 			ctx.EmitMovRegMem(scratch, srcBase, src.StackOff+off)
 			ctx.EmitStoreRegMem(scratch, dstBase, dst.StackOff+off)

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -140,6 +140,15 @@ func TestJITExpressionReduceLambdaArgumentOrder(t *testing.T) {
 	}
 }
 
+func TestJITExpressionFusedMapReducerArithmetic(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t,
+		`(lambda (acc value id) (+ acc (+ (* value 3) id)))`)
+	requireNoDynamicJITCalls(t, compiled)
+	if got := Apply(compiled, NewInt(10), NewInt(4), NewInt(2)); !Equal(got, NewInt(24)) {
+		t.Fatalf("unexpected fused arithmetic result: %s", String(got))
+	}
+}
+
 func TestJITExpressionHigherOrderClosureCapture(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (values blocked) (begin
 		(define blocked_set (reduce blocked (lambda (acc item) (set_assoc acc item true)) '()))

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -1816,16 +1816,19 @@ func (ctx *JITContext) EmitGoCallVariadic(f func(...Scmer) Scmer, argslice JITVa
 		panic(fmt.Sprintf("jit: variadic argslice must be LocRegPair/LocStackPair (got %d)", arg.Loc))
 	}
 
-	target := result
-	targetHasRegs := target.Loc == LocRegPair
+	requestedTarget := result
+	targetHasRegs := requestedTarget.Loc == LocRegPair
+	target := requestedTarget
 	if targetHasRegs {
+		targetOff := ctx.AllocSpill(16)
+		target = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: targetOff, Rooted: true}
+		ctx.setStackPointer(jitStackRootFrameBP, targetOff, true)
+	} else if target.Loc == LocStackPair {
 		target.Type = JITTypeUnknown
 	} else {
-		targetReg := ctx.AllocRegExcept(arg.Reg, arg.Reg2)
-		target = JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: targetReg, Reg2: ctx.AllocRegExcept(arg.Reg, arg.Reg2, targetReg)}
-		ctx.BindReg(target.Reg, &target)
-		ctx.BindReg(target.Reg2, &target)
-		targetHasRegs = true
+		targetOff := ctx.AllocSpill(16)
+		target = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: targetOff, Rooted: true}
+		ctx.setStackPointer(jitStackRootFrameBP, targetOff, true)
 	}
 
 	ctx.ReclaimUntrackedRegs()
@@ -1863,7 +1866,7 @@ func (ctx *JITContext) EmitGoCallVariadic(f func(...Scmer) Scmer, argslice JITVa
 			continue
 		}
 		if targetHasRegs {
-			if r == target.Reg || r == target.Reg2 {
+			if r == requestedTarget.Reg || r == requestedTarget.Reg2 {
 				continue
 			}
 		}
@@ -1926,15 +1929,26 @@ func (ctx *JITContext) EmitGoCallVariadic(f func(...Scmer) Scmer, argslice JITVa
 	ctx.EmitAddRSP32(int32(jitGoSpillBytes + 16))
 
 	callResult := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX}
-	ctx.EmitMovPairToResult(&callResult, &target)
+	base := ctx.StackReg
+	if target.StackOff < 0 {
+		base = ctx.FrameReg
+	}
+	ctx.EmitStoreRegMem(callResult.Reg, base, target.StackOff)
+	ctx.EmitStoreRegMem(callResult.Reg2, base, target.StackOff+8)
 	for i, r := range liveRegs {
 		ctx.EmitMovRegMem(r, RegRSP, int32(i*8))
 	}
 	if frameBytes != 0 {
 		ctx.EmitAddRSP32(frameBytes)
 	}
-	ctx.BindReg(target.Reg, &target)
-	ctx.BindReg(target.Reg2, &target)
+	if targetHasRegs {
+		ctx.EmitMovRegMem(requestedTarget.Reg, base, target.StackOff)
+		ctx.EmitMovRegMem(requestedTarget.Reg2, base, target.StackOff+8)
+		requestedTarget.Type = JITTypeUnknown
+		ctx.BindReg(requestedTarget.Reg, &requestedTarget)
+		ctx.BindReg(requestedTarget.Reg2, &requestedTarget)
+		target = requestedTarget
+	}
 
 	if ctx.SliceBaseTracksRSP && ctx.SliceBase != RegRSP {
 		ctx.emitMovRegReg(ctx.SliceBase, RegRSP)
@@ -2116,6 +2130,19 @@ func (ctx *JITContext) EmitStoreScmerToStack(desc JITValueDesc, disp int32) {
 		base := RegRSP
 		if desc.StackOff < 0 {
 			base = RegRBP
+		}
+		if base == RegRSP && desc.StackOff == disp {
+			return
+		}
+		// Stack allocation and phi placement may give the source and destination
+		// overlapping 16-byte ranges. Copy backwards when the destination starts
+		// inside the source; all other layouts are safe in forward order.
+		if base == RegRSP && disp > desc.StackOff && disp < desc.StackOff+16 {
+			ctx.EmitMovRegMem(RegR11, base, desc.StackOff+8)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, disp+8)
+			ctx.EmitMovRegMem(RegR11, base, desc.StackOff)
+			ctx.EmitStoreRegMem(RegR11, RegRSP, disp)
+			return
 		}
 		ctx.EmitMovRegMem(RegR11, base, desc.StackOff)
 		ctx.EmitStoreRegMem(RegR11, RegRSP, disp)

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -130,8 +130,8 @@ test_cases:
             (list (collate "utf8mb4" true))
             0 0 20
             (list (list 1 "ID") (list 1 "post_title") (list 0 "meta_value"))
-            (lambda (_id _title _value) 1)
-            + 0 nil false 0 true))
+            (lambda (acc _id _title _value) (+ acc 1))
+            0 nil false 0 true))
         (if (equal? found 20) "ok"
           (error "wrong WordPress scan_join_order row count")))
     expect:

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -426,9 +426,6 @@ func generateOperators(ops []operatorInfo, ssaFuncs map[token.Pos]*ssa.Function,
 			defer workers.Done()
 			for index := range work {
 				op := ops[index]
-				if onlyOp != "" && op.name != onlyOp {
-					continue
-				}
 				var fn *ssa.Function
 				if op.funcLit != nil {
 					fn = ssaFuncs[op.funcLit.Pos()]
@@ -1696,7 +1693,16 @@ func (g *codeGen) emitGenericStaticCall(name string, callee *ssa.Function, args 
 			g.emit("\tpanic(\"jit: generic call arg expects 1-word value\")")
 			g.emit("}")
 		case 2:
-			// Pair args must be materialized to avoid LocImm flattening to one word.
+			// Scmer values may be folded to one-word scalars by the JIT type
+			// system, but every native Go boundary still requires ptr+aux.
+			if isScmerType(paramType) {
+				prepare := "JITPrepareScmerGoArg"
+				if g.storageMode {
+					prepare = "scm." + prepare
+				}
+				g.emit("%s = %s(ctx, %s)", resolved[i].goVar, prepare, resolved[i].goVar)
+				break
+			}
 			g.emit("ctx.EnsureDesc(&%s)", resolved[i].goVar)
 			g.emit("if %s.Loc == LocImm {", resolved[i].goVar)
 			g.emit("\ttmpPair := JITValueDesc{Loc: LocRegPair, Type: %s.Type, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}", resolved[i].goVar)
@@ -2986,7 +2992,9 @@ func (g *codeGen) allocPhiRegs() {
 	}
 	g.phiStackSize = offset
 
-	// Allocate phi space from the unified frame via AllocStack/FreeStack.
+	// Allocate phi space from the unified frame. Generated CFGs may reserve
+	// additional callback and spill homes after these slots, so the bump
+	// allocator cannot release only this prefix at the emitter epilogue.
 	// No SUB RSP here — the outer compiler owns the frame.
 	if g.phiStackSize > 0 {
 		phiBaseVar := g.allocTemp("phiBase")
@@ -3715,6 +3723,15 @@ func (g *codeGen) emitBody(cfg emitBodyConfig) {
 		g.emit("\tctx.BindReg(result.Reg, &result)")
 		g.emit("\tctx.BindReg(result.Reg2, &result)")
 		g.emit("}")
+		// A multi-block emitter writes every return arm into the caller-selected
+		// pair. Reserve that pair for the complete CFG render: path-local register
+		// reclamation must never recycle an output register before the arm which
+		// actually produces the runtime result has been emitted.
+		g.emit("resultRegsProtected := result.Loc == LocRegPair")
+		g.emit("if resultRegsProtected {")
+		g.emit("\tctx.ProtectReg(result.Reg)")
+		g.emit("\tctx.ProtectReg(result.Reg2)")
+		g.emit("}")
 		if cfg.useReturnPhiRegs {
 			g.returnPhiReg = g.allocReg()
 			g.returnPhiReg2 = g.allocReg()
@@ -3746,8 +3763,11 @@ func (g *codeGen) emitBody(cfg emitBodyConfig) {
 	if g.hasStorageIdx {
 		g.emit("if idxPinned { ctx.UnprotectReg(idxPinnedReg) }")
 	}
-	if g.phiStackSize > 0 {
-		g.emit("ctx.FreeStack(int32(%d))", g.phiStackSize)
+	if g.multiBlock {
+		g.emit("if resultRegsProtected {")
+		g.emit("\tctx.UnprotectReg(result.Reg2)")
+		g.emit("\tctx.UnprotectReg(result.Reg)")
+		g.emit("}")
 	}
 	g.emitUnprotectIncomingArgRegs(pinnedArgRegs)
 	g.emit("return result")
@@ -6346,6 +6366,8 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 			key := g.vals[v.Call.Args[1].Name()]      // Scmer (2 words)
 			val := g.vals[v.Call.Args[2].Name()]      // Scmer (2 words)
 			mergeFn := g.resolveValue(v.Call.Args[3]) // func (1 word)
+			g.emit("%s = JITPrepareScmerGoArg(ctx, %s)", key.goVar, key.goVar)
+			g.emit("%s = JITPrepareScmerGoArg(ctx, %s)", val.goVar, val.goVar)
 			g.emit("ctx.EmitGoCallVoid(GoFuncAddr((*FastDict).Set), []JITValueDesc{%s, %s, %s, %s})", recv.goVar, key.goVar, val.goVar, mergeFn.goVar)
 		case "Sqrt":
 			// math.Sqrt(float64) float64 via bit-helper (Go ABI float args are not marshaled directly).
@@ -6675,12 +6697,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				g.emit("}")
 			} else {
 				yVal := g.resolveValue(v.Y)
-				if xVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", xVal.goVar)
-				}
-				if yVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", yVal.goVar)
-				}
+				g.emit("ctx.EnsureDescsTogether(&%s, &%s)", xVal.goVar, yVal.goVar)
 				g.emit("var %s JITValueDesc", dv)
 				g.emit("if %s {", bothImmCond(xVal.goVar, yVal.goVar))
 				g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagFloat, Imm: NewFloat(%s.Imm.Float() %s %s.Imm.Float())}", dv, xVal.goVar, goOp, yVal.goVar)
@@ -6805,12 +6822,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 					g.emit("}")
 				} else {
 					yVal := g.resolveValue(v.Y)
-					if xVal.isDesc {
-						g.emit("ctx.EnsureDesc(&%s)", xVal.goVar)
-					}
-					if yVal.isDesc {
-						g.emit("ctx.EnsureDesc(&%s)", yVal.goVar)
-					}
+					g.emit("ctx.EnsureDescsTogether(&%s, &%s)", xVal.goVar, yVal.goVar)
 					g.emit("var %s JITValueDesc", dv)
 					g.emit("if %s {", bothImmCond(xVal.goVar, yVal.goVar))
 					g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagBool, Imm: NewBool(%s.Imm.Float() %s %s.Imm.Float())}", dv, xVal.goVar, goOp, yVal.goVar)
@@ -6867,20 +6879,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				g.emit("}")
 			} else {
 				yVal := g.resolveValue(v.Y)
-				// Conservative spill safety: EnsureDesc(y) may spill x when register
-				// pressure is high. Re-ensure both operands before emitting compare code.
-				if xVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", xVal.goVar)
-				}
-				if yVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", yVal.goVar)
-				}
-				if xVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", xVal.goVar)
-				}
-				if yVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", yVal.goVar)
-				}
+				g.emit("ctx.EnsureDescsTogether(&%s, &%s)", xVal.goVar, yVal.goVar)
 				g.emit("var %s JITValueDesc", dv)
 				g.emit("if %s {", bothImmCond(xVal.goVar, yVal.goVar))
 				if unsignedCompare {
@@ -6984,18 +6983,7 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				g.emit("}")
 			} else {
 				yVal := g.resolveValue(v.Y)
-				// Ensure both operands are in registers, protecting each from
-				// eviction while the other is loaded.
-				if xVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", xVal.goVar)
-					g.emit("ctx.ProtectReg(%s.Reg)", xVal.goVar)
-				}
-				if yVal.isDesc {
-					g.emit("ctx.EnsureDesc(&%s)", yVal.goVar)
-				}
-				if xVal.isDesc {
-					g.emit("ctx.UnprotectReg(%s.Reg)", xVal.goVar)
-				}
+				g.emit("ctx.EnsureDescsTogether(&%s, &%s)", xVal.goVar, yVal.goVar)
 				g.emit("var %s JITValueDesc", dv)
 				g.emit("if %s {", bothImmCond(xVal.goVar, yVal.goVar))
 				g.emit("\t%s = JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(%s.Imm.Int() %s %s.Imm.Int())}", dv, xVal.goVar, goOpStr(v.Op), yVal.goVar)
@@ -7877,17 +7865,28 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				g.emit("ctx.EmitMovToReg(%s.Reg2, %s)", base, src.goVar)
 			}
 		} else if strings.HasPrefix(dst.marker, "_stackaddr:") {
-			src := g.resolveValue(v.Val)
+			rewritten := g.rewriteSSAValue(v.Val)
+			src, ok := g.vals[rewritten.Name()]
+			if !ok {
+				src = g.resolveValue(rewritten)
+			} else if src.isDesc {
+				// A full Scmer stack store accepts resident and stack-backed pairs.
+				// Keep cross-block values in their stable homes instead of loading
+				// them into registers that an inlined callback may subsequently use.
+				g.emit("ctx.SyncDesc(&%s)", src.goVar)
+			}
 			if !isScmerType(v.Val.Type()) {
 				panic(fmt.Sprintf("unsupported non-Scmer stack array Store: %s", v))
 			}
-			g.emit("ctx.EnsureDesc(&%s)", src.goVar)
 			switch src.marker {
 			case "_newbool":
+				g.emit("ctx.EnsureDesc(&%s)", src.goVar)
 				g.emit("ctx.EmitStoreTypedScmerToStack(%s, tagBool, %s)", src.goVar, dst.offsetExpr)
 			case "_newint":
+				g.emit("ctx.EnsureDesc(&%s)", src.goVar)
 				g.emit("ctx.EmitStoreTypedScmerToStack(%s, tagInt, %s)", src.goVar, dst.offsetExpr)
 			case "_newfloat":
+				g.emit("ctx.EnsureDesc(&%s)", src.goVar)
 				g.emit("ctx.EmitStoreTypedScmerToStack(%s, tagFloat, %s)", src.goVar, dst.offsetExpr)
 			default:
 				if src.marker == "_newargslice" {
@@ -7982,12 +7981,6 @@ func (g *codeGen) emitInstrLegacy(instr ssa.Instruction) {
 				panic(fmt.Sprintf("MakeClosure unresolved binding %s", binding.Name()))
 			}
 			bindings[i] = closureBinding{outerName: binding.Name(), value: captured, scope: g.bbScope}
-		}
-		if len(bindings) == 1 && isForwardingMergeClosure(closureFn) && bindings[0].value.marker == "_serial_callable" {
-			dv := g.allocDesc()
-			g.emit("%s := ctx.EmitGoCallScalar(GoFuncAddr(JITBuildMergeClosure), []JITValueDesc{%s}, 1)", dv, bindings[0].value.goVar)
-			g.vals[name] = genVal{goVar: dv, isDesc: true, marker: "_gofunc", pinAcrossBlock: true}
-			break
 		}
 		if len(bindings) == 1 && closureFn.Signature.Params().Len() == 1 && closureFn.Signature.Results().Len() == 0 && closureHasStaticCall(closureFn, "Apply") && bindings[0].value.isDesc {
 			dv := g.allocDesc()


### PR DESCRIPTION
## What
- keep paired Scmer ABI values intact across generated Go calls
- stabilize spill-backed operands, overlapping stack copies, phi frames, and variadic results
- compose forwarding merge callbacks in generated emitters instead of forcing a runtime wrapper
- regenerate the arithmetic emitters needed by fused mapreducers

## Scope
This is a JIT correctness/stability change. It makes arithmetic fused mapreducers compile with no dynamic calls; it does not claim a query-performance result yet.

A real `SELECT SUM(value * 7 + id) ...` run with the patched Go JIT confirms that the filter compiles natively. The complete grouped callback still falls back in `set_assoc_mut` with register pressure, and the shard combiner still falls back in `merge_assoc_mut` on an unsupported stack store. Those complete aggregate subtrees are follow-up work; this PR does not claim they are native yet.

## Verification
- `GOEXPERIMENT=jit GOTOOLCHAIN=local /home/carli/projekte/go-jit/goroot/bin/go test ./scm -run ^TestJITExpressionFusedMapReducerArithmetic$ -count=1 -v`
- `go test ./tools/jitgen ./scm -run ^(TestJITExpressionFusedMapReducerArithmetic|TestNonexistent)$ -count=1`
- patched-JIT server startup: 1276/1276 Scheme unit tests
- SQL result check: filtered arithmetic SUM returned the expected 847; `LogJIT` was used to identify the remaining aggregate fallbacks