### PR TITLE
Modernize README for the beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,124 @@
 <!-- Copyright (C) 2023 - 2026 Carl-Philip Haensch; GPL-3.0-or-later -->
 
-# MemCP — Persistent Main Memory Database with MySQL Compatibility
+# MemCP — persistent columnar SQL database
 
-MemCP is a MySQL-compatible database that keeps your data fully in main memory for maximum speed. **Your data is safe** — it's persisted to disk automatically and survives restarts — but because there's no disk I/O on the query path, reads and aggregations run 10–100× faster than MySQL.
+MemCP is a persistent, column-oriented database for mixed transactional and
+analytical workloads. It combines compact in-memory execution with durable
+storage, automatic indexing, cached intermediate results, and a cost-based SQL
+compiler. Persistent data may be evicted from RAM and loaded again on demand;
+MemCP does not require the complete database to remain resident in memory.
 
-Use your existing MySQL connector, ORMs, and SQL queries. No migration, no rewrite.
+Applications can connect through the MySQL wire protocol or submit MySQL- and
+PostgreSQL-style SQL through separate HTTP endpoints. An RDF/SPARQL engine is
+included as well.
 
-> **Status: Beta.** Core SQL (SELECT, INSERT, UPDATE, DELETE, JOIN, GROUP BY, subqueries, triggers) works well in production. Some advanced SQL edge cases are still being improved — check [open issues](https://github.com/launix-de/memcp/issues) if a specific query doesn't behave as expected.
+> **Status: Beta.** MemCP is suitable for evaluation and controlled beta
+> deployments. Common application SQL is covered by a large regression suite,
+> while advanced dialect edge cases are still being completed. Validate the
+> queries, durability configuration, backup procedure, and result parity of
+> your application before a production cutover.
 
-## Why Switch from MySQL? 💡
+MemCP is licensed under GPL-3.0-or-later.
 
-### ⚡ **10-100x Faster on Aggregations and Reports**
-- **No disk I/O on the query path** — data lives in main memory, always ready
-- **Fast for writes and reads** — handles inserts and complex statistics in the same database
-- **Built-in REST API** — query your database directly over HTTP, no middleware needed
-- **Sub-millisecond response times** even on large tables with GROUP BY and aggregations
+## Why MemCP?
 
-**Why is it so much faster for statistics?** MySQL reads entire rows to compute a `SUM()` or `COUNT()`. MemCP stores each column separately, so `SELECT region, SUM(revenue) FROM orders GROUP BY region` only reads the two columns it actually needs — not every field of every row.
+- **Columnar execution:** scans and aggregates read only the columns they need.
+- **Automatic indexing:** MemCP derives useful compound indexes from real
+  access, filter, and ordering patterns.
+- **Cost-based query planning:** the compiler decorrelates subqueries, reorders
+  joins, and chooses among scans, compact record sets, ordered limit scans, and
+  reusable group caches.
+- **Adaptive plans:** cached plans are retained while cardinalities remain in
+  the same planning range and are reconsidered when relevant statistics cross
+  a cost boundary.
+- **Mixed workloads:** point access, writes, filtered lists, exact counts,
+  full-text-like search, and complex analytics can use the same database.
+- **Operational tooling:** packages, containers, imports, persistent storage,
+  memory budgets, and an administration dashboard are included.
 
-### 🔌 **Drop-in MySQL Compatibility**
+### MySQL client access
+
+Existing MySQL clients and connectors can use MemCP's wire-protocol server.
+SQL compatibility is broad but not yet a claim of complete MySQL equivalence;
+test the exact query shapes used by your application.
+
 ```sql
--- Your existing MySQL queries work immediately
 CREATE TABLE users (id INT, name VARCHAR(100), email VARCHAR(255));
 INSERT INTO users VALUES (1, 'Alice', 'alice@example.com');
 SELECT * FROM users WHERE id = 1;
 ```
 
-### 🌐 **Built-in REST API Server**
+### SQL over HTTP
+
 ```bash
-# Start MemCP with REST API
+# Start MemCP with HTTP and MySQL interfaces
 ./memcp --api-port=4321 lib/main.scm
 
-# Query via HTTP instantly
-curl -X POST http://localhost:4321/sql/mydb \
-  -d "SELECT * FROM users" \
-  -H "Authorization: Basic cm9vdDphZG1pbg=="
+curl -u root:admin http://localhost:4321/sql/mydb \
+  -d 'SELECT * FROM users'
 ```
 
-**API Endpoints:**
+Important HTTP endpoints:
 
 - `/sql/<database>` — MySQL-dialect SQL
 - `/psql/<database>` — PostgreSQL-dialect SQL
 - `/rdf/<database>` — SPARQL queries
 - `/rdf/<database>/load_ttl` — load RDF/Turtle data
-- `/dashboard` — admin dashboard with live CPU/memory/connection gauges, database browser, shard and compression statistics, and user management
+- `/dashboard` — administration, system monitoring, query activity, storage,
+  compression, and users
 
-### 📊 **Perfect for Modern Workloads**
-- **Microservices** - Embedded database per service
-- **APIs and Web Apps** - Ultra-low latency responses  
-- **Real-time Analytics** - Process data as fast as it arrives
-- **Development & Testing** - Instant setup, no configuration
+These are SQL-over-HTTP APIs rather than a resource-oriented REST data model.
 
-## Architecture & Languages 🏗️
+## Architecture
 
-MemCP combines the best of multiple worlds with a carefully chosen tech stack:
+The storage engine and protocol/runtime integration are implemented in Go. SQL
+parsing, logical planning, optimization, and physical-plan generation are
+implemented in Scheme.
 
-### **Go (Storage Engine & Core)**
-- **High-performance storage engine** built in Go
-- **Concurrent request handling** with goroutines
-- **Memory-efficient data structures**
-- **Cross-platform compatibility**
+The planner has an explicit phase boundary:
 
-### **Scheme (SQL Parser & Compiler)**
-- **Advanced SQL parser** written in Scheme
-- **Query optimization and compilation**
-- **Extensible language for complex transformations**
-- **Functional programming advantages for parsing**
-
-### **Flexible Scripting Support**
-- **Command-line argument support** for automation
-- **Dynamic query generation** and processing
-- **Easy integration** with existing workflows
-
-## Key Advantages 🎯
-
-### **🔥 Ultra-Fast REST APIs**
-Traditional setup: `Client → HTTP Server → Database Connection → Disk I/O`
-**MemCP**: `Client → HTTP Server → Main Memory` ✨
-
-```javascript
-// Response times you'll see
-MySQL (with network + disk):  10-50ms
-MemCP (main memory):          0.1-1ms  // 50x faster!
+```text
+SQL parser AST
+    -> decorrelation and logical normalization
+    -> join reorder and logical optimization
+    -> cost-based physical lowering
+    -> fused storage operators
 ```
 
-### **⚡ Docker**
+Logical planning follows the combined query-block/group-stage/union-block model.
+Correlated subqueries are decorrelated before physical lowering rather than
+executed through a per-row fallback. The physical lowerer can then choose a
+carrier and scan strategy independently at each relevant tree node.
+
+The engine stores columns in compact representations, including bit-packed
+integers, dictionaries, ranges, and sparse forms. Hot indexes and cached query
+helpers are memory-managed. Persistent column data remains on disk when its
+in-memory representation is evicted.
+
+The optional JIT compiler is experimental. All benchmark ranges below were
+measured without enabling the JIT.
+
+## Performance
+
+Performance depends on data distribution, query shape, cache state, durability
+mode, and hardware. MemCP is not universally faster than another database.
+
+Current application measurements include:
+
+- **approximately 10x–30x faster than PostgreSQL** on selected list, search,
+  filter, pagination, complex ACL, and full-text workloads over roughly one
+  million records;
+- **from about 3% faster to 15x faster** on selected WordPress-oriented query
+  workloads.
+
+These ranges describe the measured workloads, not a blanket guarantee. Publish
+or compare results together with the fixture, database configuration, indexes,
+hardware, cold/warm state, repetitions, and individual query timings. MemCP's
+repository includes explicit performance suites and CI compares every pull
+request against its exact target revision.
+
+## Docker
+
 ```bash
 docker pull carli2/memcp
 printf '%s\n' 'replace-with-a-long-random-password' > memcp-root-password.txt
@@ -96,19 +130,17 @@ The container intentionally refuses to initialize a fresh data volume without
 an explicit password. See [Container deployment](#container-deployment) for the
 complete Compose configuration.
 
-### **🧠 Persistent and Safe**
-- **Data is written to disk** — restarts and crashes don't lose your data
-- **S3, MinIO, and Ceph backends** for cloud and distributed deployments
-- **Automatic compression** reduces storage footprint significantly vs. MySQL
-- **Configurable data directory** — point it at any local or remote path
+## Memory management
 
-## Memory Management 🧩
+MemCP is designed to share a machine with other services while remaining within
+an explicit RAM budget.
 
-MemCP is designed to run alongside other services on the same machine without blowing up your RAM.
+**Automatic compression** — MemCP selects compact representations per column.
+Actual compression depends on the values and their distribution; benchmark it
+with representative data rather than assuming a fixed compression ratio.
 
-**Automatic compression** — MemCP stores each column in the most compact format that fits the data: small integers get bit-packed, repeated strings become dictionary-encoded, sequential IDs are stored as ranges. A table that takes 10 GB in MySQL often fits in 1–3 GB in MemCP.
-
-**Configurable memory budget** — by default MemCP uses at most 50% of your server's RAM. You can set an exact limit via the dashboard or the Scheme API:
+**Configurable memory budget** — by default MemCP's managed cache budget is 50%
+of system RAM. Set an exact limit through the dashboard or Scheme API:
 
 ```bash
 # Limit to 4 GB total
@@ -120,31 +152,46 @@ curl -u root:admin -X POST http://localhost:4321/scm \
   -d '(settings "MaxRamPercent" 40)'
 ```
 
-**Automatic eviction** — when MemCP approaches its memory limit, it automatically unloads the least recently used data from RAM. That data stays safe on disk and is transparently reloaded the next time a query needs it. Frequently accessed hot data stays in memory; cold data steps aside.
+**Automatic eviction** — when MemCP approaches its memory limit, it unloads
+eligible, less-recently-used representations from RAM. Persistent data remains
+on disk and is transparently loaded when a later query needs it.
 
-**System-wide pressure awareness** — if the whole server runs low on free RAM (below 10%), MemCP detects this and proactively releases its own cache — even if its own budget isn't exhausted yet. This keeps your application, web server, and OS responsive regardless of load spikes.
+**System-wide pressure awareness** — when the host runs low on available RAM,
+MemCP can release cache entries even if its configured budget has not yet been
+reached.
 
-**Separate budget for persistent data** — a second budget (default: 30% of RAM) controls how much space the on-disk data loaded into RAM may occupy, independently of temporary query working memory. Both limits are tunable at runtime without restart.
+**Separate budget for persistent data** — a second managed budget (default: 30%
+of system RAM) controls persisted shards and indexes independently of other
+evictable query helpers. Both limits are tunable at runtime without restart.
 
-### Storage Engines
+### Storage engines
 
 MemCP supports several storage engines, selectable per table via `CREATE TABLE ... ENGINE=<engine>` or `ALTER TABLE ... ENGINE=<engine>`:
 
-| Engine | Data durability | Evictable | Description |
-|--------|----------------|-----------|-------------|
-| `safe` | Persisted to disk (default) | Yes | All writes are immediately durable; data is evicted from RAM when memory is tight and reloaded on demand. |
-| `logged` | Persisted to disk | Yes | Like `safe` but uses a write-ahead log for faster writes with the same durability guarantee. |
-| `sloppy` | Persisted to disk | Yes | Data is written to disk asynchronously; faster writes but brief data loss on crash. |
-| `memory` | RAM only | No | Data lives entirely in RAM and is never written to disk. Its schema and optional `oninit` callback are persisted; the callback can rebuild the empty data generation after restart. Not registered with the memory manager, so data is never evicted. |
-| `cache` | Reconstructible RAM data | Yes | Data lives in RAM and can be cleared under memory pressure. Hidden query-helper table and temporary-column creation buffer their schema update instead of writing the full catalog immediately; the next schema publication or rebuild includes the definition and closed `oninit` callback. The callback rebuilds an empty generation after restart. |
+| Engine | Durability contract | Evictable |
+|--------|---------------------|-----------|
+| `safe` | **Default.** WAL is fsynced at transaction/statement boundaries; committed writes survive process crashes and power loss. | Yes |
+| `logged` | WAL is written without fsync. It survives a process crash or clean shutdown, but recent writes may be lost after power loss. | Yes |
+| `sloppy` | Compressed column files are persisted, but there is no WAL. Deltas since the last rebuild are lost after an unclean shutdown. | Yes |
+| `memory` | Rows exist only in RAM and are lost on restart. Schema and an optional reconstruction callback are persisted. | No |
+| `cache` | Reconstructible RAM data; it may be cleared under memory pressure and rebuilt by its initializer. | Yes |
 
-### **🔧 Developer-Friendly**
-- **Comprehensive test suite** with 2470+ SQL tests across 100+ test suites
-- **YAML-based testing framework**
-- **Extensive error handling and validation**
-- **Built-in performance monitoring**
+> **Data-safety warning:** `ALTER TABLE ... ENGINE=memory` from a persisted
+> engine irreversibly deletes that table's on-disk column files and WAL. Back
+> up or otherwise verify the data is disposable before making this transition.
 
-### Generated Documentation
+For production data, use `safe` unless you have explicitly accepted another
+engine's weaker durability contract.
+
+### Test coverage
+
+The repository currently contains more than 6,000 SQL/YAML cases across more
+than 270 suites, in addition to Scheme runtime and Go storage tests. The SQL
+taxonomy covers language semantics, planning, physical execution, concurrency,
+storage, persistence, recovery, imports, RDF/SPARQL, anonymized integration
+shapes, and performance regressions.
+
+### Generated documentation
 
 The generated API/reference documentation is not versioned. Build it locally when needed:
 
@@ -154,14 +201,14 @@ make docs
 
 This writes the generated files to `docs/`.
 
-## Quick Start 🚀
+## Quick start
 
 ```bash
 # 1. Build MemCP
 go mod download
 make
 
-# 2. Start with REST API
+# 2. Start the HTTP and MySQL interfaces
 ./memcp --api-port=4321 --mysql-port=3307 lib/main.scm
 
 # Run as a background daemon (use --no-repl to avoid exiting when stdin closes)
@@ -172,7 +219,7 @@ curl -X POST http://localhost:4321/sql/system \
   -d "CREATE DATABASE myapp" \
   -u root:admin
 
-# 4. Start building lightning-fast apps!
+# 4. Create a table
 curl -X POST http://localhost:4321/sql/myapp \
   -d "CREATE TABLE products (id INT, name VARCHAR(100), price DECIMAL(10,2))" \
   -u root:admin
@@ -348,10 +395,13 @@ creates SHA256 checksums and build-provenance attestations, and only then create
 the GitHub release. It must not be replaced by manually uploading locally built
 files.
 
-## Importing Existing Data 📥
+## Importing existing data
 
-MemCP can bulk-import schema and data from MySQL or PostgreSQL with a single Scheme call.
-The import drops and recreates the target tables on every run, so it is safe to re-run after schema changes.
+MemCP can bulk-import schema and data from MySQL or PostgreSQL with a single
+Scheme call. The import **drops and recreates the selected target tables** on
+every run. This makes an import reproducible after schema changes, but it is a
+destructive replacement of existing target data. Use a separate target database
+or take a verified backup when that data must be retained.
 
 ### Import from MySQL
 
@@ -392,30 +442,25 @@ Parameters: `host` (nil → 127.0.0.1), `port` (nil → 5432), `username`, `pass
 
 Both functions print a line for each imported table and return `true` on success.
 
-## Performance Comparison 📈
+## Use cases
 
-| Query | MySQL (SSD) | **MemCP** |
-|-------|-------------|-----------|
-| `SELECT * FROM users WHERE id = 1` | 1–5ms | **0.1ms** |
-| `SELECT region, SUM(revenue) FROM orders GROUP BY region` | 200–800ms | **2–10ms** |
-| `SELECT COUNT(*), AVG(price) FROM products WHERE category = ?` | 50–200ms | **0.5ms** |
-| `INSERT INTO events VALUES (...)` | 10–30ms | **0.2ms** |
-| REST API call (HTTP → query → JSON response) | 20–100ms | **1–10ms** |
+MemCP is designed for applications that mix ordinary reads and writes with
+large or structurally complex reads, for example:
 
-*Measured on standard dev hardware. Aggregation queries show the largest speedup because MemCP only reads the columns a query actually uses.*
+- dashboards, reports, and grouped statistics;
+- ordered and paged lists over large datasets;
+- full-text-like searches combined with relational filters;
+- multi-tenant or row-level ACL checks expressed through joins and correlated
+  subqueries;
+- notification and maintenance queries that repeatedly reuse the same grouped
+  facts;
+- RDF/SPARQL datasets alongside relational application data;
+- development and compatibility testing through MySQL clients or SQL-over-HTTP.
 
-## Use Cases 💼
+## Contributing
 
-- **📊 Dashboards and Reports** - GROUP BY queries that take seconds in MySQL run in milliseconds
-- **📡 Realtime Monitoring** - Aggregate metrics and counters over millions of rows without slowing down
-- **🛒 E-commerce** - Product catalog queries, price calculations, and inventory stats at any scale
-- **🎮 Gaming Backends** - Leaderboards, player statistics, and session data with sub-millisecond latency
-- **💰 Financial Applications** - Aggregations, risk calculations, and transaction summaries in real time
-- **🧪 Development & Testing** - Instant database setup, no configuration, throw it away when done
-
-## Contributing 🤝
-
-**We'd love your help making MemCP even better!** 
+Contributions should include focused regression coverage and preserve the
+logical/physical planner boundary documented in `INVARIANTS.md`.
 
 ### CI behavior
 
@@ -423,20 +468,10 @@ Both functions print a line for each imported table and return `true` on success
 - Direct pushes run `test` only on `master` (to avoid duplicate branch + PR runs).
 - If a PR shows pending/old checks, push one fresh commit so the current workflow config is applied.
 
-### 🌟 **Why Contribute?**
-- Work with **cutting-edge database technology**
-- Learn **Go, Scheme, and database internals**
-- Help shape an early-stage project where your contributions have real impact
-- Build **ultra-high-performance systems**
+Useful contributions include SQL compatibility cases, correctness fixes,
+measured performance work, documentation, storage formats, and new operators.
 
-### 🛠️ **Easy Ways to Contribute**
-- **📝 Add test cases** - Expand our comprehensive test suite
-- **🐛 Fix bugs** - Help us squash issues and improve stability  
-- **⚡ Performance optimization** - Make fast even faster
-- **📚 Documentation** - Help other developers get started
-- **🔧 New features** - SQL functions, operators, and capabilities
-
-### 🚀 **Getting Started**
+### Getting started
 ```bash
 # 1. Fork the repository
 # 2. Clone your fork
@@ -453,14 +488,7 @@ python3 run_sql_tests.py tests/sql/expressions/basic-sql.yaml
 # 6. Submit a pull request!
 ```
 
-### 🎯 **Current Contribution Opportunities**
-- **Vector database features** - Advanced similarity search
-- **Additional SQL functions** - String, math, and date functions
-- **Performance benchmarking** - Automated performance testing
-- **Driver development** - Language-specific database drivers
-- **Documentation examples** - Real-world usage scenarios
-
-## Testing 🧪
+## Testing
 
 MemCP includes a comprehensive test framework:
 
@@ -480,11 +508,14 @@ python3 run_sql_tests.py tests/sql/expressions/error-cases.yaml # Error handling
 python3 run_sql_tests.py tests/sql/expressions/basic-sql.yaml 4321 --connect-only
 ```
 
-## Performance Testing 📊
+## Performance testing
 
-MemCP includes an auto-calibrating performance test framework that adapts to your machine.
+MemCP includes an auto-calibrating local performance framework and a required
+CI A/B workflow. Pull requests measure the exact base revision and candidate
+with the same fixtures, warm-up policy, repetitions, and runner. The default CI
+regression allowance is 20% per protected case.
 
-### Running Performance Tests
+### Running performance tests
 
 ```bash
 # Run perf tests (uses calibrated baselines)
@@ -498,9 +529,12 @@ PERF_TEST=1 PERF_NORECALIBRATE=1 make test
 
 # Show query plans for each test
 PERF_TEST=1 PERF_EXPLAIN=1 make test
+
+# Run only the CI performance workload selection
+python3 run_sql_tests.py --perf-ci
 ```
 
-### How Calibration Works
+### How local calibration works
 
 1. **Initial run** starts with 10,000 rows per test
 2. Each calibration run **scales row counts by 30%** up/down
@@ -508,7 +542,11 @@ PERF_TEST=1 PERF_EXPLAIN=1 make test
 4. Baselines are stored in `.perf_baseline.json`
 5. After ~10 runs, row counts stabilize in the target range
 
-### Output Format
+The CI workflow additionally uses `PERF_AB_MODE=record` for the base revision
+and `PERF_AB_MODE=compare` for the candidate. These modes are intended for the
+automated base-versus-candidate protocol rather than ordinary development runs.
+
+### Output format
 
 ```
 ✅ Perf: COUNT (7.9ms / 8700ms, 20,000 rows, 0.39µs/row, 11.4MB heap)
@@ -520,7 +558,7 @@ PERF_TEST=1 PERF_EXPLAIN=1 make test
          └─ Test name
 ```
 
-### Performance Debugging Cookbook
+### Performance debugging cookbook
 
 **Detecting a performance regression:**
 ```bash
@@ -552,7 +590,7 @@ git bisect run bash -c 'PERF_TEST=1 PERF_NORECALIBRATE=1 make test'
 PERF_TEST=1 PERF_EXPLAIN=1 make test
 ```
 
-### Environment Variables
+### Environment variables
 
 | Variable | Values | Description |
 |----------|--------|-------------|
@@ -560,8 +598,10 @@ PERF_TEST=1 PERF_EXPLAIN=1 make test
 | `PERF_CALIBRATE` | `0`/`1` | Update baselines with new times |
 | `PERF_NORECALIBRATE` | `0`/`1` | Freeze row counts (for bisecting) |
 | `PERF_EXPLAIN` | `0`/`1` | Show query plans |
+| `PERF_REPEAT` | integer | Maximum repetitions for stable short-query samples |
+| `PERF_MIN_MEASURE_MS` | milliseconds | Minimum accumulated sample duration |
 
-## Remote Storage Backends 🗄️
+## Remote storage backends
 
 MemCP supports storing databases on remote storage backends instead of the local filesystem. To configure a remote backend, create a JSON configuration file in the data folder instead of a directory.
 
@@ -687,13 +727,9 @@ export CEPH_KEYRING=/path/to/ceph/build/keyring
 | `conf_file` | Ceph | Path to ceph.conf (optional) |
 | `pool` | Ceph | RADOS pool name |
 
-## License 📄
+## License
 
-MemCP is open source software. See the LICENSE file for details.
+MemCP is free software licensed under GPL-3.0-or-later. See [LICENSE](LICENSE).
 
----
-
-**Ready to experience database performance like never before?**
-[Get Started](#quick-start) • [Contribute](#contributing) • [Join our Community](https://github.com/launix-de/memcp/discussions)
-
-*MemCP: Because your applications deserve better than "good enough" performance.* ⚡
+Questions and design discussions are welcome in [GitHub
+Discussions](https://github.com/launix-de/memcp/discussions).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 <!-- Copyright (C) 2023 - 2026 Carl-Philip Haensch; GPL-3.0-or-later -->
 
-# MemCP — persistent columnar SQL database
+# MemCP — transactions, search, and analytics in one open-source database
 
-MemCP is a persistent, column-oriented database for mixed transactional and
-analytical workloads. It combines compact in-memory execution with durable
-storage, automatic indexing, cached intermediate results, and a cost-based SQL
-compiler. Persistent data may be evicted from RAM and loaded again on demand;
-MemCP does not require the complete database to remain resident in memory.
+MemCP is a persistent, column-oriented SQL database built for applications that
+must update data continuously while also searching, filtering, and analyzing
+large datasets. It brings an architecture best known from proprietary in-memory
+ERP systems to a self-hosted GPL-licensed database.
+
+MemCP keeps stable data in compact, read-optimized columns and accepts recent
+changes in a write-friendly delta. Background rebuilds fold those changes back
+into the compressed representation. Persistent data may be evicted from RAM and
+loaded again on demand, so the complete database does not have to remain memory
+resident.
 
 Applications can connect through the MySQL wire protocol or submit MySQL- and
 PostgreSQL-style SQL through separate HTTP endpoints. An RDF/SPARQL engine is
@@ -20,14 +25,30 @@ included as well.
 
 MemCP is licensed under GPL-3.0-or-later.
 
+Read the [MemCP 0.9 beta release overview](https://launix.de/launix/memcp-beta-release-0-9-one-database-for-transactions-search-and-analytics/)
+for the application story behind the current release.
+
+## Why this project exists
+
+During doctoral work at a university database chair, MemCP's initiator kept
+encountering the same gap: open-source databases offered either conventional
+transaction processing or columnar analytics, but no practical columnar
+main/delta in-memory database for an ERP application that needed both. SAP HANA
+demonstrated that the model could work at ERP scale, but the architecture
+remained tied to a proprietary platform.
+
+MemCP was started to make that database model available as ordinary free
+software: run it on your own Linux server, connect an existing SQL application,
+and use the same engine for transactions, full-text search, paged lists, and
+analytics.
+
 ## Why MemCP?
 
 - **Columnar execution:** scans and aggregates read only the columns they need.
 - **Automatic indexing:** MemCP derives useful compound indexes from real
   access, filter, and ordering patterns.
-- **Cost-based query planning:** the compiler decorrelates subqueries, reorders
-  joins, and chooses among scans, compact record sets, ordered limit scans, and
-  reusable group caches.
+- **Cost-based query planning:** the compiler rewrites correlated subqueries,
+  reorders joins, and chooses a physical strategy for each part of a query.
 - **Adaptive plans:** cached plans are retained while cardinalities remain in
   the same planning range and are reconsidered when relevant statistics cross
   a cost boundary.
@@ -85,10 +106,9 @@ SQL parser AST
     -> fused storage operators
 ```
 
-Logical planning follows the combined query-block/group-stage/union-block model.
-Correlated subqueries are decorrelated before physical lowering rather than
-executed through a per-row fallback. The physical lowerer can then choose a
-carrier and scan strategy independently at each relevant tree node.
+Correlated subqueries are converted into reorderable joins before physical
+planning rather than executed once per outer row. The physical planner can then
+choose an execution strategy independently for each relevant part of the query.
 
 The engine stores columns in compact representations, including bit-packed
 integers, dictionaries, ranges, and sparse forms. Hot indexes and cached query
@@ -105,9 +125,10 @@ mode, and hardware. MemCP is not universally faster than another database.
 
 Current application measurements include:
 
-- **approximately 10x–30x faster than PostgreSQL** on selected list, search,
-  filter, pagination, complex ACL, and full-text workloads over roughly one
-  million records;
+- **up to 30x faster than PostgreSQL** for selected real application searches
+  and paged lists over the same dataset of roughly 800,000 documents. These
+  queries combine full-text conditions, sorting, exact counts, pagination, and
+  user-specific access checks;
 - **from about 3% faster to 15x faster** on selected WordPress-oriented query
   workloads.
 


### PR DESCRIPTION
## Summary

- replace the outdated "fully in RAM / no disk I/O" description with MemCP's persistent, memory-managed columnar architecture
- document automatic indexing, decorrelation, cost-based physical lowering, adaptive cached plans, RecSet-style carriers, ordered limit scans, and reusable group caches
- describe MySQL wire access and the separate MySQL/PostgreSQL SQL-over-HTTP dialect endpoints without claiming unsupported full dialect or PostgreSQL-wire equivalence
- add the current measured PostgreSQL and WordPress-oriented performance ranges, explicitly scoped to their workloads and measured without the experimental JIT
- correct the `safe`, `logged`, `sloppy`, `memory`, and `cache` durability contracts and add the destructive persisted-to-memory transition warning
- update test-suite scale and CI performance A/B documentation
- clarify that imports replace target tables and remove unqualified marketing latency claims
- retain and refresh installation, packaging, container, JIT, import, remote-storage, and contribution guidance

## Validation

Documentation-only change:

- `git diff --check`
- verified balanced Markdown code fences
- verified `run_sql_tests.py --help` against the documented performance-runner command
- audited CLI, memory settings, storage-engine semantics, protocol endpoints, test counts, and CI A/B behavior against current source

No executable code or tests changed, so the full SQL suite was not run locally.
