### PR TITLE
Run fused mapreducers directly in JIT

### DIFF
--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -272,16 +272,6 @@ func jitEmitKnownDeclaration(ctx *JITContext, callable JITValueDesc, args []JITV
 	return jitPlaceScmerIntoTarget(ctx, emitted, result), true
 }
 
-func jitList0() Scmer                             { return List() }
-func jitList1(a Scmer) Scmer                      { return List(a) }
-func jitList2(a, b Scmer) Scmer                   { return List(a, b) }
-func jitList3(a, b, c Scmer) Scmer                { return List(a, b, c) }
-func jitList4(a, b, c, d Scmer) Scmer             { return List(a, b, c, d) }
-func jitList5(a, b, c, d, e Scmer) Scmer          { return List(a, b, c, d, e) }
-func jitList6(a, b, c, d, e, f Scmer) Scmer       { return List(a, b, c, d, e, f) }
-func jitList7(a, b, c, d, e, f, g Scmer) Scmer    { return List(a, b, c, d, e, f, g) }
-func jitList8(a, b, c, d, e, f, g, h Scmer) Scmer { return List(a, b, c, d, e, f, g, h) }
-
 func jitMakeScmerSlice(length, capacity int) []Scmer {
 	return make([]Scmer, length, capacity)
 }
@@ -1040,61 +1030,34 @@ func jitMaterializeVirtualSlice(ctx *JITContext, virtual JITValueDesc, result JI
 			continue
 		}
 		ctx.EnsureDesc(&src)
-		target := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+		ptrReg := ctx.AllocReg()
+		target := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ptrReg, Reg2: ctx.AllocRegExcept(ptrReg)}
 		pairs[i] = jitPlaceIntoPair(ctx, &src, target)
 		ctx.BindReg(pairs[i].Reg, &pairs[i])
 		ctx.BindReg(pairs[i].Reg2, &pairs[i])
 	}
-	if len(pairs) > 4 {
-		length := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(len(pairs))), NoHeapPointer: true}
-		header := ctx.EmitGoCallScalar(GoFuncAddr(jitMakeScmerSlice), []JITValueDesc{length, length}, 3)
-		header.Type = tagSlice
-		ctx.BindReg(header.Reg, &header)
-		ctx.BindReg(header.Reg2, &header)
-		ctx.BindReg(header.Reg3, &header)
-		for i := range pairs {
-			index := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(i)), NoHeapPointer: true}
-			address := ctx.EmitSliceElementAddress(&header, &index, 16)
-			ctx.EmitStoreScmerAt(&address, &pairs[i])
-			ctx.FreeDesc(&address)
-			ctx.FreeDesc(&pairs[i])
-		}
-		materialized := ctx.EmitNewSliceFromGoSlice(&header)
-		if result.Loc == LocRegPair {
-			return jitPlaceIntoPair(ctx, &materialized, result)
-		}
-		return materialized
+	backingOff := ctx.AllocStack(int32(len(pairs) * 16))
+	for i := range pairs {
+		ctx.EmitStoreScmerToStack(pairs[i], backingOff+int32(i*16))
+		ctx.FreeDesc(&pairs[i])
 	}
-	var addr uint64
-	switch len(pairs) {
-	case 0:
-		addr = GoFuncAddr(jitList0)
-	case 1:
-		addr = GoFuncAddr(jitList1)
-	case 2:
-		addr = GoFuncAddr(jitList2)
-	case 3:
-		addr = GoFuncAddr(jitList3)
-	case 4:
-		addr = GoFuncAddr(jitList4)
-	case 5:
-		addr = GoFuncAddr(jitList5)
-	case 6:
-		addr = GoFuncAddr(jitList6)
-	case 7:
-		addr = GoFuncAddr(jitList7)
-	case 8:
-		addr = GoFuncAddr(jitList8)
-	}
-	if result.Loc == LocRegPair {
-		materialized := ctx.EmitGoCallScalarInto(addr, pairs, result)
-		materialized.Type = tagSlice
-		return materialized
-	}
-	materialized := ctx.EmitGoCallScalar(addr, pairs, 2)
+	ptrReg := ctx.AllocReg()
+	lenReg := ctx.AllocRegExcept(ptrReg)
+	capReg := ctx.AllocRegExcept(ptrReg, lenReg)
+	ctx.EmitLeaRegMem(ptrReg, ctx.StackReg, backingOff)
+	ctx.EmitMovRegImm64(lenReg, uint64(len(pairs)))
+	ctx.EmitMovRegImm64(capReg, uint64(len(pairs)))
+	header := JITValueDesc{Loc: LocRegTriple, Type: tagSlice, Reg: ptrReg, Reg2: lenReg, Reg3: capReg, Rooted: true}
+	ctx.BindReg(ptrReg, &header)
+	ctx.BindReg(lenReg, &header)
+	ctx.BindReg(capReg, &header)
+	materialized := ctx.EmitGoCallScalar(GoFuncAddr(JITNewSliceCopy), []JITValueDesc{header}, 2)
+	ctx.FreeDesc(&header)
 	materialized.Type = tagSlice
-	ctx.BindReg(materialized.Reg, &materialized)
-	ctx.BindReg(materialized.Reg2, &materialized)
+	materialized.Rooted = true
+	if result.Loc == LocRegPair {
+		return jitPlaceIntoPair(ctx, &materialized, result)
+	}
 	return materialized
 }
 
@@ -1169,7 +1132,8 @@ func jitCompileStackList(ctx *JITContext, list []Scmer, sliceBase Reg, result JI
 		value := jitCompileExpr(ctx, list[i+3], sliceBase, JITValueDesc{Loc: LocAny})
 		ctx.EnsureDesc(&value)
 		if value.Loc != LocRegPair && value.Loc != LocImm {
-			target := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ctx.AllocReg(), Reg2: ctx.AllocReg()}
+			ptrReg := ctx.AllocReg()
+			target := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ptrReg, Reg2: ctx.AllocRegExcept(ptrReg)}
 			value = jitPlaceIntoPair(ctx, &value, target)
 		}
 		ctx.EmitStoreScmerToStack(value, int32((start+i)*16))

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -149,6 +149,52 @@ func TestJITExpressionFusedMapReducerArithmetic(t *testing.T) {
 	}
 }
 
+func TestJITExpressionKeepsAdjacentStringLengths(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t,
+		`(lambda () (list "ID" "post_status" "post_type"))`)
+	requireNoDynamicJITCalls(t, compiled)
+	got := Apply(compiled)
+	want := NewSlice([]Scmer{
+		NewString("ID"),
+		NewString("post_status"),
+		NewString("post_type"),
+	})
+	if !Equal(got, want) {
+		t.Fatalf("adjacent string metadata was corrupted: got %s, want %s", String(got), String(want))
+	}
+}
+
+func TestJITExpressionKeepsQueryPlanColumnNames(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	testEnv := &Env{Vars: Vars{
+		Symbol("test_scan_order"): NewFunc(func(args ...Scmer) Scmer { return args[9] }),
+		Symbol("test_table"):      NewFunc(func(...Scmer) Scmer { return NewString("table") }),
+	}, Outer: &Globalenv}
+	expression := Optimize(Read(t.Name(), `(lambda (session tx resultrow resultfields)
+		(!begin
+			(resultfields (quote ("ID" "post_status" "post_type")))
+			(test_scan_order tx (test_table "wpbench" "wp_posts") (quote ()) (lambda () true)
+				(quote ("post_title")) (quote ((collate "utf8mb4" false)))
+				0 0 (session "v1") (list "ID" "post_status" "post_type")
+				(lambda (__scan_acc wp_posts.ID wp_posts.post_status wp_posts.post_type)
+					(resultrow (list "ID" wp_posts.ID "post_status" wp_posts.post_status "post_type" wp_posts.post_type)))
+				4 nil false)))`), testEnv, nil)
+	compiled := jitCompile(Eval(expression, testEnv))
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("query-plan expression did not compile")
+	}
+	session := NewFunc(func(...Scmer) Scmer { return NewInt(5) })
+	resultrow := NewFunc(func(args ...Scmer) Scmer { return args[0] })
+	resultfields := NewFunc(func(...Scmer) Scmer { return NewNil() })
+	got := Apply(compiled, session, NewNil(), resultrow, resultfields)
+	want := NewSlice([]Scmer{NewString("ID"), NewString("post_status"), NewString("post_type")})
+	if !Equal(got, want) {
+		t.Fatalf("query-plan column names were corrupted: got %s, want %s", String(got), String(want))
+	}
+}
+
 func TestJITExpressionHigherOrderClosureCapture(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (values blocked) (begin
 		(define blocked_set (reduce blocked (lambda (acc item) (set_assoc acc item true)) '()))

--- a/scm/serial_proc.go
+++ b/scm/serial_proc.go
@@ -16,8 +16,6 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
-import "runtime"
-
 // SerialProcKind describes callback shapes whose semantics can be consumed by
 // a physical operator without entering Eval. Operators must dispatch on Kind
 // outside their row loops; Call is the compatibility path for code which does
@@ -305,16 +303,6 @@ func (p *SerialProc) Call(args []Scmer) Scmer {
 	default:
 		return p.borrowed(args)
 	}
-}
-
-// CallJIT enters an already classified compiled procedure with an exact
-// argument frame. The physical operator dispatches to this method outside its
-// row loop, so the trampoline contains no shape or arity checks.
-func (p *SerialProc) CallJIT(args []Scmer) Scmer {
-	result := callJIT(p.jitEntry.Native, args...)
-	runtime.KeepAlive(args)
-	runtime.KeepAlive(p.jitEntry)
-	return result
 }
 
 // IsNative reports whether the prepared callback is exactly the named global

--- a/scm/serial_proc.go
+++ b/scm/serial_proc.go
@@ -16,6 +16,8 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
+import "runtime"
+
 // SerialProcKind describes callback shapes whose semantics can be consumed by
 // a physical operator without entering Eval. Operators must dispatch on Kind
 // outside their row loops; Call is the compatibility path for code which does
@@ -28,6 +30,7 @@ const (
 	SerialProcArgument
 	SerialProcNative
 	SerialProcNativeArgConstant
+	SerialProcJIT
 )
 
 // SerialProc exposes trivial executable shapes to physical operators. Callers
@@ -44,6 +47,8 @@ type SerialProc struct {
 	ConstantFirst bool
 	Function      func(...Scmer) Scmer
 	borrowed      func([]Scmer) Scmer
+	jitEntry      *JITEntryPoint
+	jitArity      int
 }
 
 func serialProcBody(v Scmer) Scmer {
@@ -203,6 +208,14 @@ func PrepareSerialProc(source Scmer) SerialProc {
 	// source body is diagnostic input, not necessarily an executable equivalent;
 	// classifying that body could silently bypass code generation semantics.
 	if proc.Compiled != nil {
+		params, fixedArity := scmerSlice(proc.Params)
+		if jitEnabled && fixedArity && len(proc.Compiled.HiddenArgs) == 0 && !proc.Compiled.TransferInputArgs {
+			prepared.Kind = SerialProcJIT
+			prepared.Function = proc.Compiled.Native
+			prepared.jitEntry = proc.Compiled
+			prepared.jitArity = len(params)
+			return prepared
+		}
 		prepared.Kind = SerialProcGeneral
 		prepared.borrowed = optimizeProcToSerialBorrowed(source)
 		return prepared
@@ -254,6 +267,20 @@ func PrepareSerialProc(source Scmer) SerialProc {
 	return prepared
 }
 
+// CallFrameSize validates an operator-provided prefix and returns the exact
+// fixed JIT arity. Extra procedure parameters are initialized as nil once when
+// the physical callback buffer is prepared, matching JITEntryPoint.Call
+// without padding or branching in the row loop.
+func (p *SerialProc) CallFrameSize(provided int) int {
+	if p.Kind != SerialProcJIT {
+		return provided
+	}
+	if provided > p.jitArity {
+		panic("JIT map-reducer received more arguments than declared parameters")
+	}
+	return p.jitArity
+}
+
 // Call evaluates a prepared callback with a caller-owned argument frame. Hot
 // physical loops should dispatch dominant simple Kinds once; compound programs
 // use Call so the prepared expression can reuse its nested native-call frames.
@@ -265,6 +292,8 @@ func (p *SerialProc) Call(args []Scmer) Scmer {
 		return args[int(p.Argument)]
 	case SerialProcNative:
 		return p.Function(args...)
+	case SerialProcJIT:
+		return p.jitEntry.Call(args...)
 	case SerialProcNativeArgConstant:
 		var call [2]Scmer
 		if p.ConstantFirst {
@@ -276,6 +305,16 @@ func (p *SerialProc) Call(args []Scmer) Scmer {
 	default:
 		return p.borrowed(args)
 	}
+}
+
+// CallJIT enters an already classified compiled procedure with an exact
+// argument frame. The physical operator dispatches to this method outside its
+// row loop, so the trampoline contains no shape or arity checks.
+func (p *SerialProc) CallJIT(args []Scmer) Scmer {
+	result := callJIT(p.jitEntry.Native, args...)
+	runtime.KeepAlive(args)
+	runtime.KeepAlive(p.jitEntry)
+	return result
 }
 
 // IsNative reports whether the prepared callback is exactly the named global

--- a/scm/serial_proc_test.go
+++ b/scm/serial_proc_test.go
@@ -18,7 +18,7 @@ package scm
 
 import "testing"
 
-func preparedTestProc(t *testing.T, source string) Scmer {
+func preparedTestProc(t testing.TB, source string) Scmer {
 	t.Helper()
 	return Eval(Optimize(Read("serial proc test", source), &Globalenv, nil), &Globalenv)
 }
@@ -71,8 +71,66 @@ func TestPrepareSerialProcKeepsCompiledEntryPointAuthoritative(t *testing.T) {
 	source := preparedTestProc(t, "(lambda () 7)")
 	source.Proc().Compiled = &JITEntryPoint{Native: func(...Scmer) Scmer { return NewInt(99) }}
 	prepared := PrepareSerialProc(source)
-	if prepared.Kind != SerialProcGeneral {
-		t.Fatalf("compiled procedure shape = %d, want general entry-point dispatch", prepared.Kind)
+	if !jitEnabled {
+		if prepared.Kind != SerialProcGeneral {
+			t.Fatalf("compiled procedure shape = %d, want general without JIT runtime", prepared.Kind)
+		}
+		return
+	}
+	if prepared.Kind != SerialProcJIT {
+		t.Fatalf("compiled procedure shape = %d, want direct JIT dispatch", prepared.Kind)
+	}
+	if got := prepared.Call(nil); !Equal(got, NewInt(99)) {
+		t.Fatalf("direct JIT result = %s, want 99", String(got))
+	}
+}
+
+func TestPrepareSerialProcUsesCompiledJITDirectly(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	source := preparedTestProc(t, "(lambda (acc value) (+ acc value))")
+	compiled := jitCompile(source)
+	if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("map-reducer did not compile")
+	}
+	prepared := PrepareSerialProc(compiled)
+	if prepared.Kind != SerialProcJIT {
+		t.Fatalf("compiled map-reducer shape = %d, want direct JIT dispatch", prepared.Kind)
+	}
+	if got := prepared.Call([]Scmer{NewInt(40), NewInt(2)}); !Equal(got, NewInt(42)) {
+		t.Fatalf("direct JIT map-reducer result = %s, want 42", String(got))
+	}
+}
+
+func BenchmarkSerialProcJITMapReducerDispatch(b *testing.B) {
+	if !jitEnabled {
+		b.Skip("requires GOEXPERIMENT=jit")
+	}
+	source := preparedTestProc(b, "(lambda (acc value) (+ acc value))")
+	compiled := jitCompile(source)
+	if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		b.Fatal("map-reducer did not compile")
+	}
+	direct := PrepareSerialProc(compiled)
+	adapter := SerialProc{
+		Kind:     SerialProcGeneral,
+		borrowed: optimizeProcToSerialBorrowed(compiled),
+	}
+	for _, benchmark := range []struct {
+		name string
+		call func([]Scmer) Scmer
+	}{
+		{name: "general_adapter", call: adapter.Call},
+		{name: "direct_jit", call: direct.CallJIT},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			args := []Scmer{NewInt(1), NewInt(1)}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				args[0] = benchmark.call(args)
+			}
+		})
 	}
 }
 

--- a/scm/serial_proc_test.go
+++ b/scm/serial_proc_test.go
@@ -125,6 +125,15 @@ func BenchmarkSerialProcJITMapReducerDispatch(b *testing.B) {
 			args[0] = adapter.Call(args)
 		}
 	})
+	b.Run("jit_trampoline", func(b *testing.B) {
+		args := []Scmer{NewInt(1), NewInt(1)}
+		jitFn := direct.Function
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			args[0] = callJIT(jitFn, args...)
+		}
+		runtime.KeepAlive(&direct)
+	})
 	b.Run("direct_jit_entry", func(b *testing.B) {
 		args := []Scmer{NewInt(1), NewInt(1)}
 		jitFn := direct.Function

--- a/scm/serial_proc_test.go
+++ b/scm/serial_proc_test.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package scm
 
+import "runtime"
 import "testing"
 
 func preparedTestProc(t testing.TB, source string) Scmer {
@@ -117,21 +118,22 @@ func BenchmarkSerialProcJITMapReducerDispatch(b *testing.B) {
 		Kind:     SerialProcGeneral,
 		borrowed: optimizeProcToSerialBorrowed(compiled),
 	}
-	for _, benchmark := range []struct {
-		name string
-		call func([]Scmer) Scmer
-	}{
-		{name: "general_adapter", call: adapter.Call},
-		{name: "direct_jit", call: direct.CallJIT},
-	} {
-		b.Run(benchmark.name, func(b *testing.B) {
-			args := []Scmer{NewInt(1), NewInt(1)}
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				args[0] = benchmark.call(args)
-			}
-		})
-	}
+	b.Run("general_adapter", func(b *testing.B) {
+		args := []Scmer{NewInt(1), NewInt(1)}
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			args[0] = adapter.Call(args)
+		}
+	})
+	b.Run("direct_jit_entry", func(b *testing.B) {
+		args := []Scmer{NewInt(1), NewInt(1)}
+		jitFn := direct.Function
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			args[0] = jitFn(args...)
+		}
+		runtime.KeepAlive(&direct)
+	})
 }
 
 func TestPrepareSerialProcNativeForwardMatchesInterpreterAdapter(t *testing.T) {

--- a/storage/scan_order_batch_accept_test.go
+++ b/storage/scan_order_batch_accept_test.go
@@ -31,6 +31,48 @@ func setupBatchAcceptTable(t *testing.T, database string, rows int) *table {
 	return table
 }
 
+func TestJITScanOrderPreservesAdjacentMapColumnNames(t *testing.T) {
+	Init(scm.Globalenv)
+	const database = "tjit_scan_order_column_names"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	table, _ := CreateTable(database, "posts", Memory, true)
+	for _, column := range []string{"ID", "post_title", "post_status", "post_type"} {
+		table.CreateColumn(column, "TEXT", nil, nil)
+	}
+	table.Insert([]string{"ID", "post_title", "post_status", "post_type"}, [][]scm.Scmer{{
+		scm.NewString("1"), scm.NewString("title"), scm.NewString("publish"), scm.NewString("post"),
+	}}, nil, scm.NewNil(), false, nil)
+
+	source := `(lambda (session tx resultrow resultfields)
+		(!begin
+			(resultfields (quote ("ID" "post_status" "post_type")))
+			(scan_order tx (table "tjit_scan_order_column_names" "posts")
+				(quote ()) (lambda () true) (quote ("post_title")) (list <) 0 0 (session "v1")
+				(list "ID" "post_status" "post_type")
+				(lambda (__scan_acc ID post_status post_type)
+					(resultrow (list "ID" ID "post_status" post_status "post_type" post_type)))
+				1 nil false)))`
+	proc := scm.Eval(scm.Optimize(scm.Read(t.Name(), source), &scm.Globalenv, nil), &scm.Globalenv)
+	compiled := scm.Apply(scm.Globalenv.Vars[scm.Symbol("jit")], proc)
+	if !compiled.IsProc() || compiled.Proc().Compiled == nil {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	session := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewInt(5) })
+	resultrow := scm.NewFunc(func(args ...scm.Scmer) scm.Scmer { return args[0] })
+	resultfields := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	got := scm.Apply(compiled, session, scm.NewNil(), resultrow, resultfields)
+	want := scm.NewSlice([]scm.Scmer{
+		scm.NewString("ID"), scm.NewString("1"),
+		scm.NewString("post_status"), scm.NewString("publish"),
+		scm.NewString("post_type"), scm.NewString("post"),
+	})
+	if !scm.Equal(got, want) {
+		t.Fatalf("JIT scan_order result = %s, want %s", scm.String(got), scm.String(want))
+	}
+}
+
 func integerOrder(descending bool) (scm.Scmer, func(...scm.Scmer) scm.Scmer) {
 	relation := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 		if descending {
@@ -298,5 +340,34 @@ func TestShardMapReducerBulkReadsFinalMapColumns(t *testing.T) {
 	}
 	if want := []int64{344, 122, 233}; !equalInt64s(got, want) {
 		t.Fatalf("mapped values = %v, want %v", got, want)
+	}
+}
+
+func TestShardMapReducerUsesDirectJITLoop(t *testing.T) {
+	source := scm.Eval(scm.Optimize(
+		scm.Read(t.Name(), `(lambda (acc value) (+ acc value))`),
+		&scm.Globalenv, nil), &scm.Globalenv)
+	compiled := scm.Apply(scm.Globalenv.Vars[scm.Symbol("jit")], source)
+	if !compiled.IsProc() || compiled.Proc().Compiled == nil {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	reader := &countingColumnReader{values: []scm.Scmer{
+		scm.NewInt(10), scm.NewInt(20), scm.NewInt(30),
+	}}
+	mapper := &ShardMapReducer{
+		mainBulkReaders:  []ColumnReader{reader},
+		args:             make([]scm.Scmer, 2),
+		mapReduceProgram: scm.PrepareSerialProc(compiled),
+		mainCount:        3,
+		directRead:       true,
+	}
+	if mapper.mapReduceProgram.Kind != scm.SerialProcJIT {
+		t.Fatalf("map-reducer kind = %d, want direct JIT", mapper.mapReduceProgram.Kind)
+	}
+	if got := mapper.Stream(scm.NewInt(0), []uint32{0, 1, 2}, nil); !scm.Equal(got, scm.NewInt(60)) {
+		t.Fatalf("direct JIT reduction = %s, want 60", scm.String(got))
+	}
+	if reader.multiRead != 1 || reader.singleRead != 0 {
+		t.Fatalf("direct JIT reads: multi=%d single=%d, want one bulk read", reader.multiRead, reader.singleRead)
 	}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2039,19 +2039,22 @@ func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32)
 		return acc
 	}
 	if m.mapReduceProgram.Kind == scm.SerialProcJIT {
+		jitFn := m.mapReduceProgram.Function
 		if recids[0] < m.mainCount && len(m.mainBulkReaders) == 1 {
 			for _, value := range m.mainBulkValues {
 				m.args[0] = acc
 				m.args[1] = value
-				acc = m.mapReduceProgram.CallJIT(m.args)
+				acc = jitFn(m.args...)
 			}
+			runtime.KeepAlive(&m.mapReduceProgram)
 			return acc
 		}
 		for rowOffset, id := range recids {
 			m.loadDirectReadArgs(id, rowOffset, true)
 			m.args[0] = acc
-			acc = m.mapReduceProgram.CallJIT(m.args)
+			acc = jitFn(m.args...)
 		}
+		runtime.KeepAlive(&m.mapReduceProgram)
 		return acc
 	}
 	for rowOffset, id := range recids {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1602,6 +1602,17 @@ func prepareReadMapReducerStorage(mr *ShardMapReducer, workspace *shardMapReduce
 	}
 }
 
+func prepareMapReducerCallFrame(mr *ShardMapReducer) {
+	required := mr.mapReduceProgram.CallFrameSize(len(mr.args))
+	if required <= cap(mr.args) {
+		mr.args = mr.args[:required]
+		return
+	}
+	args := make([]scm.Scmer, required)
+	copy(args, mr.args)
+	mr.args = args
+}
+
 // initReadMapReducer initializes an ordinary read-only mapper without the
 // per-column closures required by pseudo-column and mutation scans.
 func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, mapReduceFn scm.Scmer, alreadyLocked bool, currentTx *TxContext) {
@@ -1610,6 +1621,7 @@ func (t *storageShard) initReadMapReducer(mr *ShardMapReducer, cols []string, ma
 	mr.acidMode = currentTx != nil && currentTx.Mode == TxACID
 	mr.colNames = cols
 	mr.mapReduceProgram = scm.PrepareSerialProc(mapReduceFn)
+	prepareMapReducerCallFrame(mr)
 	mr.mapReduceScmer = mapReduceFn
 	mr.mainCount = t.main_count
 	mr.shardWriteLocked = alreadyLocked
@@ -1658,6 +1670,7 @@ func (t *storageShard) initMapReducer(mr *ShardMapReducer, cols []string, mapRed
 		mainCount:        t.main_count,
 		shardWriteLocked: alreadyLocked,
 	}
+	prepareMapReducerCallFrame(mr)
 	needsMutationMetadata := false
 	for _, col := range cols {
 		if col == "$update" || col == "$break" || len(col) >= 4 && col[:4] == "NEW." ||
@@ -2022,6 +2035,22 @@ func (m *ShardMapReducer) processDirectReadBlock(acc scm.Scmer, recids []uint32)
 			m.loadDirectReadArgs(id, rowOffset, true)
 			m.args[0] = acc
 			acc = m.mapReduceProgram.Function(m.args...)
+		}
+		return acc
+	}
+	if m.mapReduceProgram.Kind == scm.SerialProcJIT {
+		if recids[0] < m.mainCount && len(m.mainBulkReaders) == 1 {
+			for _, value := range m.mainBulkValues {
+				m.args[0] = acc
+				m.args[1] = value
+				acc = m.mapReduceProgram.CallJIT(m.args)
+			}
+			return acc
+		}
+		for rowOffset, id := range recids {
+			m.loadDirectReadArgs(id, rowOffset, true)
+			m.args[0] = acc
+			acc = m.mapReduceProgram.CallJIT(m.args)
 		}
 		return acc
 	}


### PR DESCRIPTION
## What
- classify fixed-arity compiled scan mapreducers as direct JIT programs
- pass the emitted Go value of type `func(...Scmer) Scmer` into a dedicated scan loop and invoke it directly per row
- keep the JIT entry point only as the lifetime owner for code, roots, and stack maps
- remove the remaining `callJIT` and `jitCallSelfCode` Go-frame bridges
- emit non-tail recursive JIT calls directly through their Go-compatible function value
- build JIT `(list ...)` values in a dedicated frame buffer and transfer ownership with one slice call, fixing adjacent string metadata corruption
- pad the reusable mapreducer call frame once at scan setup
- add JIT expression, physical scan, direct-kernel, recursive-panic, and WordPress-shaped column-name regressions

## Runtime prerequisite
The Go fork commit `49b59d7737` was pushed directly to `launix/jit-foreign-frames-go1.27.0`.

The runtime now unwinds arbitrary consecutive user-frame chains. GC and stack copying visit every registered frame map. `runtime.Stack` and `runtime.CallersFrames` expose `UnwindDeclare` JIT frames in logical call order with function, source file, line, and entry address. Normal JIT execution emits no descriptor lookup or callback; existing return PCs identify immutable runtime-owned metadata only when stack inspection is required.

## Hot path
The native, direct-JIT, and general scan loops are separate. Kind dispatch happens before the loops. The JIT scan loop calls the emitted `func(...Scmer) Scmer` value directly; it does not enter `SerialProc.CallJIT`, `scm.callJIT`, Eval, or a per-row kind cascade. Optimized amd64 disassembly shows the scan callsite as an indirect register call to the function value code pointer.

## Manual A/B
Same build, fixture, warmup, and benchmark process; 5 samples on AMD Ryzen 9 7900X3D:

- general compiled-procedure adapter: median 12.88 ns/call, 0 B/op, 0 allocs/op
- removed Go-frame bridge: median 8.264 ns/call, 0 B/op, 0 allocs/op
- direct JIT function value: median 7.254 ns/call, 0 B/op, 0 allocs/op
- direct vs bridge: -12.2% callback latency
- direct vs general adapter: -43.7% callback latency

Command: `GOEXPERIMENT=jit .../go test ./scm -run ^$ -bench ^BenchmarkSerialProcJITMapReducerDispatch$ -benchmem -count=5`

## Correctness
- A binary built with the updated fork returns complete WordPress values for `SELECT ID, post_status, post_type FROM wp_posts ORDER BY post_title LIMIT 5`; `post_status` remains intact.
- A recursive JIT regression creates four directly consecutive JIT frames, panics in the deepest frame, and recovers in the ordinary Go caller.
- Targeted SCM and storage JIT tests pass, including a real `ShardMapReducer` bulk-read reduction through the direct JIT kernel.
- Targeted vanilla tests pass.

The pre-existing `TestJITExpressionRecursiveTransferredMergeStackList` failure is reproducible unchanged at this PRs earlier commit `68c5b894f` with the old Go fork and is unrelated to consecutive frame unwinding.