### PR TITLE
Remove JIT call frame bridges

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -225,12 +225,10 @@ func (jep *JITEntryPoint) Call(args ...Scmer) (result Scmer) {
 			panic("JIT: invalid hidden argument kind")
 		}
 	}
-	defer func() {
-		runtime.KeepAlive(args)
-		runtime.KeepAlive(jep)
-		runtime.KeepAlive(jep.Owner)
-	}()
-	result = callJIT(jep.Native, args...)
+	result = jep.Native(args...)
+	runtime.KeepAlive(args)
+	runtime.KeepAlive(jep)
+	runtime.KeepAlive(jep.Owner)
 	return result
 }
 

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -469,14 +469,7 @@ func jitApplyCallableSlice(callable, envValue Scmer, args []Scmer) Scmer {
 	return ApplyEx(callable, args, envValue.Any().(*Env))
 }
 
-// jitCallSelfCode preserves a Go unwind frame around a non-tail recursive JIT
-// call. Tail recursion stays inside the generated entry point as a direct jump.
-func jitCallSelfCode(code uintptr, args []Scmer) Scmer {
-	fnData := unsafe.Pointer(&struct{ *byte }{(*byte)(unsafe.Pointer(code))})
-	native := *(*func(...Scmer) Scmer)(unsafe.Pointer(&fnData))
-	return callJIT(native, args...)
-}
-
+//go:noinline
 func jitInvokeCallback1(callback, arg0 Scmer) Scmer {
 	return Apply(callback, arg0)
 }
@@ -1995,17 +1988,16 @@ func jitCompileSelfCall(ctx *JITContext, operands []Scmer, sliceBase Reg, result
 
 	argsPtr := ctx.AllocReg()
 	argsLen := ctx.AllocRegExcept(argsPtr)
-	argsCap := ctx.AllocRegExcept(argsPtr, argsLen)
-	argsSlice := JITValueDesc{Loc: LocRegTriple, Type: JITTypeUnknown, Reg: argsPtr, Reg2: argsLen, Reg3: argsCap}
+	argsSlice := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: argsPtr, Reg2: argsLen}
 	ctx.BindReg(argsPtr, &argsSlice)
 	ctx.BindReg(argsLen, &argsSlice)
-	ctx.BindReg(argsCap, &argsSlice)
 	ctx.EmitLeaRegMem(argsPtr, ctx.StackReg, argsOff)
 	ctx.EmitMovRegImm64(argsLen, uint64(ctx.SelfParamCount))
-	ctx.EmitMovRegImm64(argsCap, uint64(ctx.SelfParamCount))
-	code := JITValueDesc{Loc: LocImm, Type: tagInt, Imm: NewInt(int64(uintptr(ctx.Start)))}
+	fnData := unsafe.Pointer(&struct{ *byte }{(*byte)(ctx.Start)})
+	native := *(*func(...Scmer) Scmer)(unsafe.Pointer(&fnData))
+	ctx.ConstRoots = append(ctx.ConstRoots, fnData)
 	target := jitEnsureResultPair(ctx, result)
-	target = ctx.EmitGoCallScalarInto(GoFuncAddr(jitCallSelfCode), []JITValueDesc{code, argsSlice}, target)
+	target = ctx.EmitGoCallVariadic(native, argsSlice, target)
 	ctx.FreeDesc(&argsSlice)
 	target.Type = JITTypeUnknown
 	ctx.BindReg(target.Reg, &target)

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -323,3 +323,36 @@ func TestJITExpressionRecursiveNthResult(t *testing.T) {
 		t.Fatalf("unexpected recursive nth result: got ptr=%x aux=%x tag=%d, want %s", gotPtr, gotAux, got.GetTag(), String(want))
 	}
 }
+
+func TestJITExpressionRecursivePanicAcrossDirectFrames(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	const name = Symbol("jit_test_direct_recursive_panic")
+	previous, existed := Globalenv.Vars[name]
+	defer func() {
+		if existed {
+			Globalenv.Vars[name] = previous
+		} else {
+			delete(Globalenv.Vars, name)
+		}
+	}()
+	EvalAll(t.Name(), `(define jit_test_direct_recursive_panic (lambda (depth)
+		(if (> depth 0)
+			(+ 1 (jit_test_direct_recursive_panic (- depth 1)))
+			(error "nested-jit-panic"))))`, &Globalenv)
+	compiled := jitCompile(Globalenv.Vars[name])
+	if compiled.GetTag() != tagProc || compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		t.Fatal("recursive panic procedure was not JIT compiled")
+	}
+	Globalenv.Vars[name] = compiled
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		Apply(compiled, NewInt(4))
+	}()
+	if recovered == nil {
+		t.Fatal("panic did not unwind through consecutive JIT frames")
+	}
+}

--- a/scm/jit_unwind_fallback.go
+++ b/scm/jit_unwind_fallback.go
@@ -27,13 +27,3 @@ func registerJITArena(a *jitArena) interface{} {
 // publishJITStackMaps is a no-op on stock Go. JIT execution is disabled, but
 // keeping the common emitter path buildable makes (jit) retain its stub API.
 func publishJITStackMaps(_ *jitArena, _ []jitStackMap) {}
-
-// jitWrapCallTarget is retained so common code compiles in stock Go builds.
-func jitWrapCallTarget(fn func(...Scmer) Scmer) func(...Scmer) Scmer {
-	return fn
-}
-
-// callJIT must be unreachable: stock Go cannot unwind panics through JIT frames.
-func callJIT(_ func(...Scmer) Scmer, _ ...Scmer) Scmer {
-	panic("JIT support is disabled in this build")
-}

--- a/scm/jit_unwind_gojit.go
+++ b/scm/jit_unwind_gojit.go
@@ -20,7 +20,6 @@ Copyright (C) 2024-2026  Carl-Philip Hänsch
 package scm
 
 import (
-	"runtime"
 	"runtime/jit"
 	"unsafe"
 )
@@ -86,23 +85,4 @@ func publishJITStackMaps(a *jitArena, maps []jitStackMap) {
 		}
 	}
 	handle.AddStackMaps(runtimeMaps...)
-}
-
-// jitWrapCallTarget returns fn unchanged — runtime/jit handles unwinding
-// natively, so no trampoline is needed. Zero overhead.
-func jitWrapCallTarget(fn func(...Scmer) Scmer) func(...Scmer) Scmer {
-	return fn
-}
-
-// callJIT invokes a JIT-compiled function directly. With runtime/jit,
-// panics propagate naturally through the unwinder.
-//
-//go:noinline
-func callJIT(native func(...Scmer) Scmer, args ...Scmer) Scmer {
-	result := native(args...)
-	// Keep an ordinary Go frame between independently compiled JIT entries.
-	// The runtime currently resolves one registered foreign frame at a time;
-	// retaining this bridge also gives nested calls an unambiguous Go caller PC.
-	runtime.KeepAlive(native)
-	return result
 }

--- a/scm/serial_proc_test.go
+++ b/scm/serial_proc_test.go
@@ -125,12 +125,12 @@ func BenchmarkSerialProcJITMapReducerDispatch(b *testing.B) {
 			args[0] = adapter.Call(args)
 		}
 	})
-	b.Run("jit_trampoline", func(b *testing.B) {
+	b.Run("old_go_frame_bridge", func(b *testing.B) {
 		args := []Scmer{NewInt(1), NewInt(1)}
 		jitFn := direct.Function
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			args[0] = callJIT(jitFn, args...)
+			args[0] = benchmarkJITGoFrameBridge(jitFn, args)
 		}
 		runtime.KeepAlive(&direct)
 	})
@@ -143,6 +143,13 @@ func BenchmarkSerialProcJITMapReducerDispatch(b *testing.B) {
 		}
 		runtime.KeepAlive(&direct)
 	})
+}
+
+//go:noinline
+func benchmarkJITGoFrameBridge(native func(...Scmer) Scmer, args []Scmer) Scmer {
+	result := native(args...)
+	runtime.KeepAlive(native)
+	return result
 }
 
 func TestPrepareSerialProcNativeForwardMatchesInterpreterAdapter(t *testing.T) {


### PR DESCRIPTION
## What
- remove the remaining `callJIT` and `jitCallSelfCode` Go-frame bridges
- invoke compiled entry points through their actual Go value of type `func(...Scmer) Scmer`
- emit non-tail recursive JIT calls directly through the Go-compatible function value
- keep arguments, entry ownership, and imported-program ownership alive without a deferred trampoline
- retain a benchmark-only model of the removed bridge for direct A/B measurement
- add a recursive panic regression with four consecutive JIT frames

## Runtime prerequisite
Go fork commit `49b59d7737` is already pushed directly to `launix/jit-foreign-frames-go1.27.0`.

The runtime now:
- unwinds arbitrary consecutive registered user frames
- scans and relocates every JIT frame using its precise stack map
- exposes `UnwindDeclare` frames through both `runtime.Stack` and `runtime.CallersFrames` in logical call order
- resolves immutable metadata from the existing return PC only during unwind, GC, profiling, stack growth, or explicit stack inspection

Normal JIT execution performs no descriptor lookup, callback, or extra metadata store.

## Manual A/B
Rebased on current master, same build and benchmark process; 5 samples on AMD Ryzen 9 7900X3D:

- general compiled-procedure adapter: median 17.22 ns/call, 0 B/op, 0 allocs/op
- removed Go-frame bridge: median 10.77 ns/call, 0 B/op, 0 allocs/op
- direct JIT function value: median 9.823 ns/call, 0 B/op, 0 allocs/op
- direct vs bridge: -8.8% callback latency
- direct vs general adapter: -43.0% callback latency

Command: `GOEXPERIMENT=jit ../go-jit/goroot/bin/go test ./scm -run ^$ -bench ^BenchmarkSerialProcJITMapReducerDispatch$ -benchmem -count=5`

## Validation
- rebuilt the canonical patched compiler at `../go-jit/goroot/bin/go`
- complete Go `runtime` suite passed
- nested panic, GC, stack-growth, `runtime.Stack`, and `runtime.CallersFrames` fork tests passed, including 100 repeated runs
- targeted MemCP JIT and vanilla SCM/storage tests passed after rebasing over PR 726
- recursive JIT panic crosses four directly consecutive JIT frames and is recovered by the ordinary Go caller
- WordPress-shaped column-name and direct mapreducer regressions remain green

The pre-existing recursive transferred-merge test failure is reproducible unchanged at merged commit `68c5b894f` with the old Go fork and is unrelated to this change.