### PR TITLE
Keep imported planner procedures in native JIT code

### DIFF
--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -1312,11 +1312,19 @@ func jitCompileStackList(ctx *JITContext, list []Scmer, sliceBase Reg, result JI
 	}
 	start := int(list[1].NthLocalVar())
 	count := int(list[2].Int())
-	if count < 0 || len(list) != count+3 || start < 0 || start+count > ctx.LocalSlotCount {
+	if count < 0 || len(list) != count+3 || start < 0 || ctx.Env == nil || start+count > len(ctx.Env.Numbered) {
 		panic("jit: !list slots outside invocation frame")
 	}
-	if !ctx.SliceBaseTracksRSP {
-		panic("jit: !list requires an invocation-local stack frame")
+	backingOff := int32(0)
+	for i := 0; i < count; i++ {
+		slot := ctx.Env.Numbered[start+i]
+		ctx.SyncDesc(&slot)
+		if slot.Loc != LocStackPair || (i > 0 && slot.StackOff != backingOff+int32(i*16)) {
+			panic("jit: !list requires contiguous invocation-frame slots")
+		}
+		if i == 0 {
+			backingOff = slot.StackOff
+		}
 	}
 	for i := 0; i < count; i++ {
 		value := jitCompileExpr(ctx, list[i+3], sliceBase, JITValueDesc{Loc: LocAny})
@@ -1326,11 +1334,11 @@ func jitCompileStackList(ctx *JITContext, list []Scmer, sliceBase Reg, result JI
 			target := JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: ptrReg, Reg2: ctx.AllocRegExcept(ptrReg)}
 			value = jitPlaceIntoPair(ctx, &value, target)
 		}
-		ctx.EmitStoreScmerToStack(value, int32((start+i)*16))
+		ctx.EmitStoreScmerToStack(value, backingOff+int32(i*16))
 		ctx.FreeDesc(&value)
 	}
 	target := jitEnsureResultPair(ctx, result)
-	ctx.EmitLeaRegMem(target.Reg, ctx.StackReg, int32(start*16))
+	ctx.EmitLeaRegMem(target.Reg, ctx.StackReg, backingOff)
 	ctx.EmitMovRegImm64(target.Reg2, makeAux(tagSlice, makeSliceAux(count, count)))
 	target.Type = tagSlice
 	target.KnownSliceLen = int32(count)

--- a/scm/jit_special_forms.go
+++ b/scm/jit_special_forms.go
@@ -251,7 +251,7 @@ func jitEmitSpecialReservedList(ctx *JITContext, args []Scmer, _ []JITValueDesc,
 		if capacity < 0 {
 			capacity = 0
 		}
-		if start < 0 || start+capacity > ctx.LocalSlotCount {
+		if start < 0 || ctx.Env == nil || start+capacity > len(ctx.Env.Numbered) {
 			panic("jit: !!list slots outside invocation frame")
 		}
 		capacityExpr = NewInt(int64(capacity))

--- a/scm/parser.go
+++ b/scm/parser.go
@@ -158,7 +158,10 @@ func jitCompileImportProc(sym Symbol, value Scmer) (Scmer, *JITEntryPoint, bool)
 	if compiled.GetTag() == tagProc && compiled.Proc() != nil {
 		entry = compiled.Proc().Compiled
 	}
-	selected := entry != nil && jitAutoImportCoverageWorthwhile(entry.Coverage)
+	// Late-bound calls choose compiled Proc, native builtin, or interpreter
+	// dispatch independently. Keep every successfully emitted outer procedure;
+	// discarding it here would route all of its control flow back through Eval.
+	selected := entry != nil
 	if selected {
 		value.Proc().Compiled = entry
 		compiled = value
@@ -174,14 +177,6 @@ func jitCompileImportProc(sym Symbol, value Scmer) (Scmer, *JITEntryPoint, bool)
 			entry.Coverage.Expressions, entry.Coverage.DynamicCalls, entry.Coverage.InlinedCalls)
 	}
 	return compiled, entry, selected
-}
-
-func jitAutoImportCoverageWorthwhile(coverage JITCoverage) bool {
-	// A generic Apply bridge costs more than a handful of straight-line emitter
-	// nodes. Keep probe compilation universal, but activate only native bodies
-	// whose static coverage can amortize every remaining bridge. This decision is
-	// deliberately independent of module paths and definition names.
-	return coverage.DynamicCalls == 0 || coverage.Expressions >= coverage.DynamicCalls*8
 }
 
 func topLevelDefinitionSymbol(code Scmer) (Symbol, bool) {


### PR DESCRIPTION
## Summary

- retain every successfully emitted imported procedure in `Proc.Compiled`
- let each late-bound call independently dispatch to a compiled Proc, native builtin, or interpreter fallback instead of rejecting the complete outer procedure
- resolve optimizer-owned `!list` and `!!list` slots through the active `JITEnv`, so inline map/reduce callbacks use their actual nested frame offsets

The former import threshold conflated a late-bound call with an interpreted call. A procedure with several dynamic call sites could already have complete native control flow, yet its entry point was discarded and the whole body subsequently ran through `Eval`. This was especially harmful for the many small tree-walking wrappers in the SQL planner.

## Manual A/B measurements

Baseline: `99aec7a7a` (`master`, including #726)  
Candidate: `bb3314f00`  
Toolchain: `/home/carli/projekte/go-jit/goroot`, `GOEXPERIMENT=jit`  
Both binaries used the same checkout, fixture, `GOGC=10`, warmup, and alternating sample order.

### Imported-Proc microbenchmark

The probe executes a compiled reducer 100,000 times. Its callback invokes `unique_stages_by_id`, a representative planner wrapper whose emitted entry point the old threshold discarded. Seven warm samples:

| | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Median | 43.767 ms | 16.981 ms | **2.58x faster / -61.2%** |

Baseline samples (ms): `44.661, 43.788, 40.536, 43.767, 37.307, 56.154, 35.644`  
Candidate samples (ms): `16.981, 16.788, 16.933, 17.175, 19.931, 18.049, 16.838`

### Cold SQL compilation

80 alternating unique `EXPLAIN COMPILE SELECT 17 + 25 AS answer` requests after server warmup:

| Metric | Baseline median | Candidate median | Change |
|---|---:|---:|---:|
| `planner_total_ns` | 646.0 us | 538.9 us | **-16.6%** |
| HTTP end-to-end | 1,440.2 us | 1,292.6 us | **-10.3%** |

A separate 40-pair run measured HTTP end-to-end at 2,811.7 us versus 2,570.2 us (**-8.6%**).

### Warm SQL execution

12 alternating batches of 500 cached `SELECT 1 WHERE "abc" LIKE "a%"` requests:

| Baseline median | Candidate median | Change |
|---:|---:|---:|
| 183.74 us | 184.91 us | +0.6% |

This change targets prepare/compile and does not put compilation into query execution.

## Runtime and disassembly evidence

A CPU profile over 3,000 unique cold SQL compilations reports:

- JIT entry calls: 23.88% cumulative
- JIT machine code (`runtime._ExternalCode`): 2.61% flat
- `Eval`: 0.15% flat

Before this change, a traced simple cold compilation crossed 37 uncompiled Proc fallbacks. Retaining successful entries reduced that to three; fixing nested frame-slot resolution also made `btw2025_scalar_bundle_groups` compile (2,438 bytes, 26 expressions, 3 late-bound calls, 2 native calls, 3 inlined calls).

Its x86-64 disassembly contains the reducer back edge and inlined body. Calls target JIT/native dispatch helpers; there is no direct call to `Eval` or `ApplyEx`.

## Validation

- vanilla `go test ./scm -count=1`
- patched-Go focused JIT parser, lambda, list, transferred-list, and fused-mapreducer tests
- patched-Go storage tests `TestJITScanOrderPreservesAdjacentMapColumnNames` and `TestShardMapReducerUsesDirectJITLoop`
- full Scheme bootstrap: `1276/1276`, all tests succeeded
- cold and warm SQL probes described above

No Scheme library or test files are changed. The complete SQL suite is left to CI as required by the repository workflow.
