### PR TITLE
Add SQL integer division semantics

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -48,6 +48,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(atom "RTRIM" true)
 	(atom "BETWEEN" true)
 	(atom "INTERVAL" true)
+	(atom "DIV" true)
 )))
 (define psql_identifier_quoted (parser '("\"" (define id (regex "(?:[^\"])+" false false)) "\"") (sql_unescape id))) /* with double quote */
 (define psql_identifier (parser (define x (or psql_identifier_unquoted psql_identifier_quoted)) x))
@@ -106,6 +107,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		'("sub" value) (psql_sub_expr acc value)
 		'("date_add" value unit) '('date_add acc value unit)
 		'("date_sub" value unit) '('date_sub acc value unit))))
+
+(define psql_fold_multiplicative_term (lambda (acc term)
+	(match term
+		'("multiply" value) '((quote *) acc value)
+		'("divide" value) '((quote /) acc value)
+		'("intdiv" value) '((quote intdiv) acc value)
+		'("modulo" value) (psql_mod_expr acc value))))
 
 (define psql_comparison_expr (lambda (op a b)
 	(match op
@@ -256,12 +264,18 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		)) empty true))
 	) (reduce terms psql_fold_additive_term a)))
 
-	(define psql_expression4 (parser (or
-		(parser '((define a psql_expression5) "*" (define b psql_expression4)) '((quote *) a b))
-		(parser '((define a psql_expression5) "/" (define b psql_expression4)) '((quote /) a b))
-		(parser '((define a psql_expression5) "%" (define b psql_expression4)) (psql_mod_expr a b))
-		psql_expression5
-	)))
+	(define psql_expression4 (parser '(
+		(define a psql_expression5)
+		(define terms (* (parser '(
+			(define op (or
+				(parser "*" "multiply")
+				(parser "/" "divide")
+				(parser (atom "DIV" true) "intdiv")
+				(parser "%" "modulo")
+			))
+			(define value psql_expression5)
+		) (list op value)) empty true))
+	) (reduce terms psql_fold_multiplicative_term a)))
 
 	(define psql_expression5 (parser (or
 		/* unary minus: -(expr) */

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -95,6 +95,7 @@ row, avoiding a copy of the complete prefix for each input value. */
 	(atom "RTRIM" true)
 	(atom "REGEXP" true)
 	(atom "RLIKE" true)
+	(atom "DIV" true)
 )))
 (define sql_identifier_quoted (parser '("`" (define id (regex "(?:[^`]|``)+" false false)) "`") (replace id "``" "`"))) /* with backtick */
 (define sql_identifier (parser (define x (or sql_identifier_unquoted sql_identifier_quoted)) x))
@@ -159,6 +160,13 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		'("sub" value) (sql_sub_expr acc value)
 		'("date_add" value unit) '('date_add acc value unit)
 		'("date_sub" value unit) '('date_sub acc value unit))))
+
+(define sql_fold_multiplicative_term (lambda (acc term)
+	(match term
+		'("multiply" value) '((quote *) acc value)
+		'("divide" value) '((quote /) acc value)
+		'("intdiv" value) '((quote intdiv) acc value)
+		'("modulo" value) (sql_mod_expr acc value))))
 
 (define sql_comparison_expr (lambda (op a b)
 	(match op
@@ -762,12 +770,18 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		)) empty true))
 	) (reduce terms sql_fold_additive_term a)))
 
-	(define sql_expression4 (parser (or
-		(parser '((define a sql_expression5) "*" (define b sql_expression4)) '((quote *) a b))
-		(parser '((define a sql_expression5) "/" (define b sql_expression4)) '((quote /) a b))
-		(parser '((define a sql_expression5) "%" (define b sql_expression4)) (sql_mod_expr a b))
-		sql_expression5
-	)))
+	(define sql_expression4 (parser '(
+		(define a sql_expression5)
+		(define terms (* (parser '(
+			(define op (or
+				(parser "*" "multiply")
+				(parser "/" "divide")
+				(parser (atom "DIV" true) "intdiv")
+				(parser "%" "modulo")
+			))
+			(define value sql_expression5)
+		) (list op value)) empty true))
+	) (reduce terms sql_fold_multiplicative_term a)))
 
 	(define sql_expression5 (parser (or
 		/* unary minus: -(expr) */

--- a/scm/alu.go
+++ b/scm/alu.go
@@ -23230,6 +23230,39 @@ func init_alu() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "intdiv",
+
+		Fn: func(a ...Scmer) Scmer {
+			if a[0].IsNil() || a[1].IsNil() {
+				return NewNil()
+			}
+			if a[0].IsInt() && a[1].IsInt() {
+				divisor := a[1].Int()
+				if divisor == 0 || a[0].Int() == math.MinInt64 && divisor == -1 {
+					return NewNil()
+				}
+				return NewInt(a[0].Int() / divisor)
+			}
+			divisor := a[1].Float()
+			if divisor == 0 {
+				return NewNil()
+			}
+			quotient := math.Trunc(a[0].Float() / divisor)
+			if math.IsNaN(quotient) || quotient < math.MinInt64 || quotient >= -float64(math.MinInt64) {
+				return NewNil()
+			}
+			return NewInt(int64(quotient))
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "divides two numbers and truncates the quotient toward zero",
+			Params: []*TypeDescriptor{
+				{Kind: "number", Label: "dividend", Description: "value to divide"},
+				{Kind: "number", Label: "divisor", Description: "value to divide by"},
+			},
+			Return: &TypeDescriptor{Kind: "int"},
+			Const:  true,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "mod",
 
 		Fn: func(a ...Scmer) Scmer {

--- a/tests/sql/compatibility/psql-parser.yaml
+++ b/tests/sql/compatibility/psql-parser.yaml
@@ -46,6 +46,36 @@ setup:
         5000)
 
 test_cases:
+  - name: "PostgreSQL parser division of native integers returns a fractional value"
+    sql: "SELECT LENGTH('abcde') / LENGTH('ab') AS result"
+    expect:
+      rows: 1
+      data:
+        - result: 2.5
+
+  - name: "PostgreSQL parser exact native integer division remains floating-point"
+    sql: "SELECT JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(LENGTH('abcd') / LENGTH('ab')), '$[0]')) AS result_type"
+    expect:
+      rows: 1
+      data:
+        - result_type: "DOUBLE"
+
+  - name: "PostgreSQL parser multiplicative operators are left associative"
+    sql: "SELECT 20 / 5 / 2 AS divided, 20 / 5 * 2 AS mixed"
+    expect:
+      rows: 1
+      data:
+        - divided: 2
+          mixed: 8
+
+  - name: "PostgreSQL parser supports left-associative DIV"
+    sql: "SELECT 20 DIV 3 DIV 2 AS result, JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(5 DIV 2), '$[0]')) AS result_type"
+    expect:
+      rows: 1
+      data:
+        - result: 3
+          result_type: "INTEGER"
+
   - name: "Unaliased aggregates use PostgreSQL result column names"
     sql: "SELECT COUNT(val), SUM(val), AVG(val), MIN(val), MAX(val) FROM psql_data"
     expect:

--- a/tests/sql/expressions/basic-sql.yaml
+++ b/tests/sql/expressions/basic-sql.yaml
@@ -1,3 +1,10 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
 # Basic SQL Operations Test Suite
 # Fundamental SQL functionality: arithmetic, comparisons, literals, basic expressions
 
@@ -45,6 +52,52 @@ test_cases:
       rows: 1
       data:
         - result: 5
+
+  - name: "Division of native integers returns a fractional value"
+    sql: "SELECT LENGTH('abcde') / LENGTH('ab') AS result"
+    expect:
+      rows: 1
+      data:
+        - result: 2.5
+
+  - name: "Exact division of native integers retains floating-point type"
+    sql: "SELECT JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(LENGTH('abcd') / LENGTH('ab')), '$[0]')) AS result_type"
+    expect:
+      rows: 1
+      data:
+        - result_type: "DOUBLE"
+
+  - name: "Multiplicative operators are left associative"
+    sql: "SELECT 20 / 5 / 2 AS divided, 20 / 5 * 2 AS mixed"
+    expect:
+      rows: 1
+      data:
+        - divided: 2
+          mixed: 8
+
+  - name: "DIV truncates native integer division toward zero"
+    sql: "SELECT LENGTH('abcde') DIV LENGTH('ab') AS positive_result, (0 - LENGTH('abcde')) DIV LENGTH('ab') AS negative_result, JSON_TYPE(JSON_EXTRACT(JSON_ARRAY(LENGTH('abcde') DIV LENGTH('ab')), '$[0]')) AS result_type"
+    expect:
+      rows: 1
+      data:
+        - positive_result: 2
+          negative_result: -2
+          result_type: "INTEGER"
+
+  - name: "DIV is left associative"
+    sql: "SELECT 20 DIV 3 DIV 2 AS result"
+    expect:
+      rows: 1
+      data:
+        - result: 3
+
+  - name: "DIV by zero and NULL return NULL"
+    sql: "SELECT 5 DIV 0 AS zero_result, 5 DIV NULL AS null_result"
+    expect:
+      rows: 1
+      data:
+        - zero_result: null
+          null_result: null
 
   - name: "Basic modulo"
     sql: "SELECT 17 % 5 AS result"


### PR DESCRIPTION
## Summary

- keep `/` floating-point for native integer operands and cover the type explicitly
- add a shared `intdiv` runtime operation and `DIV` syntax to both SQL parsers
- parse `*`, `/`, `DIV`, and `%` left-associatively at one precedence level
- cover fractional/exact division, result types, negative truncation, zero/NULL, and associativity

## Targeted tests

- `python3 run_sql_tests.py tests/sql/expressions/basic-sql.yaml` (33/33)
- `python3 run_sql_tests.py tests/sql/compatibility/psql-parser.yaml 4421` (64/64)

The full suite was intentionally left to CI as requested.
