### PR TITLE
Generalize assoc-reducer fold for multi-key updates; fix if-branch ownership counting

### DIFF
--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -358,167 +358,172 @@ arithmetic; leave expressions containing columns or functions untouched. */
 		/* For other statements: returns the statement as-is */
 		(define compile_stmt (lambda (stmt)
 			(if (not (list? stmt)) nil
-				(begin
-					(define tag (car stmt))
-					(if (equal? tag '!set)
-						/* SET NEW.col = expr - stmt is (!set a1 a2 ...) where ai are (col expr) pairs */
-						(if is_after
-							(error "SET NEW is not allowed in AFTER triggers")
-							(compile_set_assignments (cdr stmt)))
-						(if (equal? tag '!if)
-							/* IF condition THEN stmts [ELSE stmts] END IF - stmt is (!if condition then_stmts else_stmts) */
+				(match (car stmt)
+					/* SET NEW.col = expr - stmt is (!set a1 a2 ...) where ai are (col expr) pairs */
+					'!set
+					(if is_after
+						(error "SET NEW is not allowed in AFTER triggers")
+						(compile_set_assignments (cdr stmt)))
+
+					/* IF condition THEN stmts [ELSE stmts] END IF - stmt is (!if condition then_stmts else_stmts) */
+					'!if
+					(begin
+						(define condition (car (cdr stmt)))
+						(define then_stmts (car (cdr (cdr stmt))))
+						(define else_stmts (car (cdr (cdr (cdr stmt)))))
+						/* Compile statements inside IF - flatten nested lists from SET */
+						(define compiled_then (merge (map then_stmts compile_stmt)))
+						(define valid_then (filter compiled_then (lambda (s) (not (nil? s)))))
+						/* Use !begin (no new scope) so set writes to outer changed_rows */
+						(define then_body (if (> (count valid_then) 1)
+							(cons '!begin valid_then)
+							(if (> (count valid_then) 0) (car valid_then) nil)))
+						/* Compile ELSE branch if present */
+						(define else_body (if (nil? else_stmts) nil
 							(begin
-								(define condition (car (cdr stmt)))
-								(define then_stmts (car (cdr (cdr stmt))))
-								(define else_stmts (car (cdr (cdr (cdr stmt)))))
-								/* Compile statements inside IF - flatten nested lists from SET */
-								(define compiled_then (merge (map then_stmts compile_stmt)))
-								(define valid_then (filter compiled_then (lambda (s) (not (nil? s)))))
-								/* Use !begin (no new scope) so set writes to outer changed_rows */
-								(define then_body (if (> (count valid_then) 1)
-									(cons '!begin valid_then)
-									(if (> (count valid_then) 0) (car valid_then) nil)))
-								/* Compile ELSE branch if present */
-								(define else_body (if (nil? else_stmts) nil
-									(begin
-										(define compiled_else (merge (map else_stmts compile_stmt)))
-										(define valid_else (filter compiled_else (lambda (s) (not (nil? s)))))
-										(if (> (count valid_else) 1)
-											(cons '!begin valid_else)
-											(if (> (count valid_else) 0) (car valid_else) nil)))))
-								/* Return as single-element list to be flattened by caller */
-								(list (list (symbol "if") (transform_trigger_expr condition) then_body else_body)))
-							(if (equal? tag '!insert)
-								/* INSERT INTO table - stmt is (!insert tbl cols vals ignore) */
-								(begin
-									(define tbl (car (cdr stmt)))
-									(define cols (car (cdr (cdr stmt))))
-									(define vals (car (cdr (cdr (cdr stmt)))))
-									(define ignore (car (cdr (cdr (cdr (cdr stmt))))))
-									(list (list (symbol "insert") (list (symbol "table") schema tbl)
+								(define compiled_else (merge (map else_stmts compile_stmt)))
+								(define valid_else (filter compiled_else (lambda (s) (not (nil? s)))))
+								(if (> (count valid_else) 1)
+									(cons '!begin valid_else)
+									(if (> (count valid_else) 0) (car valid_else) nil)))))
+						/* Return as single-element list to be flattened by caller */
+						(list (list (symbol "if") (transform_trigger_expr condition) then_body else_body)))
+
+					/* INSERT INTO table - stmt is (!insert tbl cols vals ignore) */
+					'!insert
+					(begin
+						(define tbl (car (cdr stmt)))
+						(define cols (car (cdr (cdr stmt))))
+						(define vals (car (cdr (cdr (cdr stmt)))))
+						(define ignore (car (cdr (cdr (cdr (cdr stmt))))))
+						(list (list (symbol "insert") (list (symbol "table") schema tbl)
+							(cons (symbol "list") cols)
+							(cons (symbol "list") (map vals (lambda (row) (cons (symbol "list") (map row transform_trigger_expr)))))
+							(list (symbol "list")) (if ignore (list (symbol "lambda") '() 0) nil) false nil)))
+
+					/* INSERT INTO tbl (cols) <full SELECT> - stmt is (!insert_select tbl cols inner_select ignore) */
+					/* Reuses sql_select + build_queryplan_term (same as top-level INSERT...SELECT) */
+					'!insert_select
+					(begin
+						(define tbl (car (cdr stmt)))
+						(define cols (car (cdr (cdr stmt))))
+						(define inner (car (cdr (cdr (cdr stmt)))))
+						(define ignore (car (cdr (cdr (cdr (cdr stmt))))))
+						/* Transform: replace NEW/OLD column refs with get_assoc for trigger context */
+						(define transform_new_old (lambda (expr) (match expr
+							((symbol get_column) "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							((quote get_column) "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							((symbol get_column) "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							((quote get_column) "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							(cons h t) (cons (transform_new_old h) (map t transform_new_old))
+							expr)))
+						(define inner_t (transform_new_old inner))
+						/* UNION output names are defined by its first branch. Extract
+						them recursively instead of mistaking a UNION for a SELECT
+						without FROM and synthesizing one empty row. */
+						(define trigger_select_fields (lambda (query) (match query
+							((symbol query-block) _ _ fields _ _ _ _ _ _ _ _ _) fields
+							'(_ _ fields _ _ _ _ _ _) fields
+							((symbol union-block) _ (cons first _) _ _ _ _) (trigger_select_fields first)
+							((symbol union_all) (cons first _) _ _ _) (trigger_select_fields first)
+							((symbol union_distinct) (cons first _) _ _ _) (trigger_select_fields first)
+							_ (error "trigger INSERT SELECT has no output fields"))))
+						(define select_fields (trigger_select_fields inner_t))
+						(define select_names (extract_assoc select_fields (lambda (k v) k)))
+						/* Use the relational plan for every SELECT shape, including
+						SELECT literals without FROM. It alone owns whether zero, one,
+						or many rows are emitted. */
+						(list (list (symbol "begin")
+							(list (symbol "set") (symbol "resultrow")
+								(list (symbol "lambda") (list (symbol "item"))
+									(list (symbol "insert") (list (symbol "table") schema tbl)
 										(cons (symbol "list") cols)
-										(cons (symbol "list") (map vals (lambda (row) (cons (symbol "list") (map row transform_trigger_expr)))))
-										(list (symbol "list")) (if ignore (list (symbol "lambda") '() 0) nil) false nil)))
-								(if (equal? tag '!insert_select)
-									/* INSERT INTO tbl (cols) <full SELECT> - stmt is (!insert_select tbl cols inner_select ignore) */
-									/* Reuses sql_select + build_queryplan_term (same as top-level INSERT...SELECT) */
-									(begin
-										(define tbl (car (cdr stmt)))
-										(define cols (car (cdr (cdr stmt))))
-										(define inner (car (cdr (cdr (cdr stmt)))))
-										(define ignore (car (cdr (cdr (cdr (cdr stmt))))))
-										/* Transform: replace NEW/OLD column refs with get_assoc for trigger context */
-										(define transform_new_old (lambda (expr) (match expr
-											((symbol get_column) "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-											((quote get_column) "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-											((symbol get_column) "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-											((quote get_column) "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-											(cons h t) (cons (transform_new_old h) (map t transform_new_old))
-											expr)))
-										(define inner_t (transform_new_old inner))
-										/* UNION output names are defined by its first branch. Extract
-										them recursively instead of mistaking a UNION for a SELECT
-										without FROM and synthesizing one empty row. */
-										(define trigger_select_fields (lambda (query) (match query
-											((symbol query-block) _ _ fields _ _ _ _ _ _ _ _ _) fields
-											'(_ _ fields _ _ _ _ _ _) fields
-											((symbol union-block) _ (cons first _) _ _ _ _) (trigger_select_fields first)
-											((symbol union_all) (cons first _) _ _ _) (trigger_select_fields first)
-											((symbol union_distinct) (cons first _) _ _ _) (trigger_select_fields first)
-											_ (error "trigger INSERT SELECT has no output fields"))))
-										(define select_fields (trigger_select_fields inner_t))
-										(define select_names (extract_assoc select_fields (lambda (k v) k)))
-										/* Use the relational plan for every SELECT shape, including
-										SELECT literals without FROM. It alone owns whether zero, one,
-										or many rows are emitted. */
-										(list (list (symbol "begin")
-											(list (symbol "set") (symbol "resultrow")
-												(list (symbol "lambda") (list (symbol "item"))
-													(list (symbol "insert") (list (symbol "table") schema tbl)
-														(cons (symbol "list") cols)
-														(list (symbol "list")
-															(cons (symbol "list")
-																(map select_names (lambda (name) (list (symbol "get_assoc") (symbol "item") name)))))
-														(list (symbol "list"))
-														(if ignore (list (symbol "lambda") '() 0) nil)
-														false nil)))
-											(build_queryplan_term (sql_expand_views inner_t policy) planning_session tx))))
-									(if (equal? tag '!update)
-										/* UPDATE table SET ... WHERE ... - stmt is (!update tbl assignments where) */
-										(begin
-											(define tbl (car (cdr stmt)))
-											(define assignments (merge (car (cdr (cdr stmt)))))
-											(define where_raw (car (cdr (cdr (cdr stmt)))))
-											/* Transform NEW/OLD -> get_assoc */
-											(define fix_expr (lambda (expr) (match expr
-												'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-												'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-												(cons h t) (cons (fix_expr h) (map t fix_expr))
-												expr)))
-											(define t_cond (if (nil? where_raw) true (fix_expr where_raw)))
-											(define t_cols (map_assoc assignments (lambda (col expr) (fix_expr expr))))
-											(list (build_dml_plan schema tbl nil (list (list tbl schema tbl false nil)) t_cols t_cond nil nil nil planning_session tx)))
-										(if (equal? tag '!delete)
-											/* DELETE FROM table WHERE ... - stmt is (!delete tbl where) */
-											(begin
-												(define tbl (car (cdr stmt)))
-												(define where_raw (car (cdr (cdr stmt))))
-												(define fix_expr (lambda (expr) (match expr
-													'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-													'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-													(cons h t) (cons (fix_expr h) (map t fix_expr))
-													expr)))
-												(define t_cond (if (nil? where_raw) true (fix_expr where_raw)))
-												(list (build_dml_plan schema tbl nil (list (list tbl schema tbl false nil)) nil t_cond nil nil nil planning_session tx)))
-											(if (equal? tag '!delete_using)
-												/* DELETE FROM target USING target, other [AS alias] WHERE condition */
-												/* stmt is (!delete_using target tabledefs where) */
-												(begin
-													(define target (car (cdr stmt)))
-													(define raw_defs (car (cdr (cdr stmt))))
-													(define where_raw (car (cdr (cdr (cdr stmt)))))
-													(define transform_dml (lambda (expr) (match expr
-														'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-														'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-														(cons head tail) (cons (transform_dml head) (map tail transform_dml))
-														expr
-													)))
-													(define all_defs (transform_dml raw_defs))
-													(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
-														'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
-														acc)) nil))
-													(define target_alias (match target_def '(id _ _ _ _) id))
-													(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
-													(define t_where (if (nil? where_raw) true (transform_dml where_raw)))
-													(list (build_dml_plan schema target_tbl target_alias all_defs nil t_where nil nil nil planning_session tx)))
-												(if (equal? tag '!update_multi)
-													/* UPDATE tbl1, tbl2 [AS alias], ... SET tbl1.col = expr WHERE condition; */
-													/* stmt is (!update_multi tbls assignments where) */
-													(begin
-														(define raw_defs (car (cdr stmt)))
-														(define assignments_raw (merge (car (cdr (cdr stmt)))))
-														(define where_raw (car (cdr (cdr (cdr stmt)))))
-														(define transform_dml (lambda (expr) (match expr
-															'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
-															'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
-															(cons head tail) (cons (transform_dml head) (map tail transform_dml))
-															expr
-														)))
-														(define all_defs (transform_dml raw_defs))
-														(define target_def (car all_defs))
-														(define target_alias (match target_def '(id _ _ _ _) id))
-														(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
-														(define t_where (if (nil? where_raw) true (transform_dml where_raw)))
-														(define t_cols (map_assoc assignments_raw (lambda (col expr) (transform_dml expr))))
-														(list (build_dml_plan schema target_tbl target_alias all_defs t_cols t_where nil nil nil planning_session tx)))
-													(if (equal? tag '!nop)
-														/* No-op statement (e.g. SET @var) - return empty list */
-														'()
-														/* Unknown statement type */
-														nil
-					)))))))))
-				)
-		)))
+										(list (symbol "list")
+											(cons (symbol "list")
+												(map select_names (lambda (name) (list (symbol "get_assoc") (symbol "item") name)))))
+										(list (symbol "list"))
+										(if ignore (list (symbol "lambda") '() 0) nil)
+										false nil)))
+							(build_queryplan_term (sql_expand_views inner_t policy) planning_session tx))))
+
+					/* UPDATE table SET ... WHERE ... - stmt is (!update tbl assignments where) */
+					'!update
+					(begin
+						(define tbl (car (cdr stmt)))
+						(define assignments (merge (car (cdr (cdr stmt)))))
+						(define where_raw (car (cdr (cdr (cdr stmt)))))
+						/* Transform NEW/OLD -> get_assoc */
+						(define fix_expr (lambda (expr) (match expr
+							'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							(cons h t) (cons (fix_expr h) (map t fix_expr))
+							expr)))
+						(define t_cond (if (nil? where_raw) true (fix_expr where_raw)))
+						(define t_cols (map_assoc assignments (lambda (col expr) (fix_expr expr))))
+						(list (build_dml_plan schema tbl nil (list (list tbl schema tbl false nil)) t_cols t_cond nil nil nil planning_session tx)))
+
+					/* DELETE FROM table WHERE ... - stmt is (!delete tbl where) */
+					'!delete
+					(begin
+						(define tbl (car (cdr stmt)))
+						(define where_raw (car (cdr (cdr stmt))))
+						(define fix_expr (lambda (expr) (match expr
+							'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							(cons h t) (cons (fix_expr h) (map t fix_expr))
+							expr)))
+						(define t_cond (if (nil? where_raw) true (fix_expr where_raw)))
+						(list (build_dml_plan schema tbl nil (list (list tbl schema tbl false nil)) nil t_cond nil nil nil planning_session tx)))
+
+					/* DELETE FROM target USING target, other [AS alias] WHERE condition */
+					/* stmt is (!delete_using target tabledefs where) */
+					'!delete_using
+					(begin
+						(define target (car (cdr stmt)))
+						(define raw_defs (car (cdr (cdr stmt))))
+						(define where_raw (car (cdr (cdr (cdr stmt)))))
+						(define transform_dml (lambda (expr) (match expr
+							'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							(cons head tail) (cons (transform_dml head) (map tail transform_dml))
+							expr
+						)))
+						(define all_defs (transform_dml raw_defs))
+						(define target_def (reduce all_defs (lambda (acc tdef) (match tdef
+							'(id _ tbl _ _) (if (or (equal?? target id) (equal?? target tbl)) tdef acc)
+							acc)) nil))
+						(define target_alias (match target_def '(id _ _ _ _) id))
+						(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
+						(define t_where (if (nil? where_raw) true (transform_dml where_raw)))
+						(list (build_dml_plan schema target_tbl target_alias all_defs nil t_where nil nil nil planning_session tx)))
+
+					/* UPDATE tbl1, tbl2 [AS alias], ... SET tbl1.col = expr WHERE condition; */
+					/* stmt is (!update_multi tbls assignments where) */
+					'!update_multi
+					(begin
+						(define raw_defs (car (cdr stmt)))
+						(define assignments_raw (merge (car (cdr (cdr stmt)))))
+						(define where_raw (car (cdr (cdr (cdr stmt)))))
+						(define transform_dml (lambda (expr) (match expr
+							'('get_column "NEW" _ col _) (list (symbol "get_assoc") (symbol "NEW") col)
+							'('get_column "OLD" _ col _) (list (symbol "get_assoc") (symbol "OLD") col)
+							(cons head tail) (cons (transform_dml head) (map tail transform_dml))
+							expr
+						)))
+						(define all_defs (transform_dml raw_defs))
+						(define target_def (car all_defs))
+						(define target_alias (match target_def '(id _ _ _ _) id))
+						(define target_tbl (match target_def '(_ _ tbl _ _) tbl))
+						(define t_where (if (nil? where_raw) true (transform_dml where_raw)))
+						(define t_cols (map_assoc assignments_raw (lambda (col expr) (transform_dml expr))))
+						(list (build_dml_plan schema target_tbl target_alias all_defs t_cols t_where nil nil nil planning_session tx)))
+
+					/* No-op statement (e.g. SET @var) - return empty list */
+					'!nop
+					'()
+
+					/* Unknown statement type */
+					_ nil))))
 
 		(match body
 			/* BEGIN...END block - compile all statements */

--- a/scm/list.go
+++ b/scm/list.go
@@ -921,46 +921,34 @@ func optimizerInlineReducerLocals(body Scmer, params []Scmer) (Scmer, bool) {
 	return optimizerSubstituteReducerLocals(items[len(items)-1], locals)
 }
 
-// optimizeAssocReducerFold recognizes the functional meaning of the common
-// imperative get-transform-set reducer. It performs one bounded root-shape
-// walk over the already optimized callback and never invokes analysis again.
-func optimizeAssocReducerFold(input, reducer, neutral Scmer) (Scmer, *TypeDescriptor, bool) {
-	if !optimizerEmptyListLiteral(neutral) {
-		return NewNil(), nil, false
-	}
-	params, body, ok := optimizerLambdaParts(reducer)
-	if !ok || len(params) != 2 {
-		return NewNil(), nil, false
-	}
-	body, ok = optimizerInlineReducerLocals(body, params)
-	if !ok {
-		return NewNil(), nil, false
-	}
-	setCall, ok := scmerSlice(body)
-	if !ok || len(setCall) != 4 ||
-		(!scmerIsSymbol(setCall[0], "set_assoc") && !scmerIsSymbol(setCall[0], "set_assoc_mut")) ||
-		!optimizerLambdaParamReference(setCall[1], params, 0) ||
-		optimizerExpressionReferencesParam(setCall[2], params, 0) || exprMayHaveSideEffects(setCall[2]) {
-		return NewNil(), nil, false
-	}
+// assocFoldLeg is one recognized (key, update) pair inside a chain of
+// set_assoc[_mut] calls on the reducer's accumulator parameter. kind is either
+// "append" (get_assoc+append per key) or "count" (get_assoc+1 per key).
+type assocFoldLeg struct {
+	key   Scmer
+	kind  string
+	value Scmer // only set for "append" legs
+}
 
+// matchAssocFoldLeg recognizes a single (set_assoc[_mut] _ key update) call as
+// one leg of a hashmap-shaped fold. setCall[1] (the target) is validated by
+// the caller, which also knows whether it is the chain's base case.
+func matchAssocFoldLeg(setCall []Scmer, params []Scmer) (assocFoldLeg, bool) {
+	key := setCall[2]
+	if optimizerExpressionReferencesParam(key, params, 0) || exprMayHaveSideEffects(key) {
+		return assocFoldLeg{}, false
+	}
 	update, ok := scmerSlice(setCall[3])
 	if !ok || len(update) != 3 {
-		return NewNil(), nil, false
+		return assocFoldLeg{}, false
 	}
 	if scmerIsSymbol(update[0], "append") || scmerIsSymbol(update[0], "append_mut") {
 		lookupKey, fallback, lookup := optimizerAssocLookup(update[1], params)
-		if !lookup || !structuralEqual(setCall[2], lookupKey) || !optimizerEmptyListLiteral(fallback) ||
+		if !lookup || !structuralEqual(key, lookupKey) || !optimizerEmptyListLiteral(fallback) ||
 			optimizerExpressionReferencesParam(update[2], params, 0) {
-			return NewNil(), nil, false
+			return assocFoldLeg{}, false
 		}
-		keyFn, keyOK := optimizerLambdaWithBody(reducer, setCall[2])
-		valueFn, valueOK := optimizerLambdaWithBody(reducer, update[2])
-		if !keyOK || !valueOK {
-			return NewNil(), nil, false
-		}
-		return NewSlice([]Scmer{NewSymbol("group_assoc_append_reduce"), input, keyFn, valueFn}),
-			&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}}, true
+		return assocFoldLeg{key: key, kind: "append", value: update[2]}, true
 	}
 	if scmerIsSymbol(update[0], "+") {
 		var lookupExpr Scmer
@@ -970,18 +958,194 @@ func optimizeAssocReducerFold(input, reducer, neutral Scmer) (Scmer, *TypeDescri
 		case optimizerOneLiteral(update[1]):
 			lookupExpr = update[2]
 		default:
-			return NewNil(), nil, false
+			return assocFoldLeg{}, false
 		}
 		lookupKey, fallback, lookup := optimizerAssocLookup(lookupExpr, params)
-		if !lookup || !structuralEqual(setCall[2], lookupKey) || !optimizerZeroLiteral(fallback) {
-			return NewNil(), nil, false
+		if !lookup || !structuralEqual(key, lookupKey) || !optimizerZeroLiteral(fallback) {
+			return assocFoldLeg{}, false
 		}
-		keyFn, ok := optimizerLambdaWithBody(reducer, setCall[2])
+		return assocFoldLeg{key: key, kind: "count"}, true
+	}
+	return assocFoldLeg{}, false
+}
+
+// collectAssocFoldLegs walks a chain of set_assoc[_mut] calls rooted at the
+// accumulator parameter, e.g. (set_assoc (set_assoc acc k1 v1) k2 v2), and
+// collects one leg per nesting level in source order. Any link that isn't a
+// recognized leg, or doesn't eventually bottom out at the bare accumulator
+// parameter, rejects the whole chain.
+func collectAssocFoldLegs(body Scmer, params []Scmer) ([]assocFoldLeg, bool) {
+	setCall, ok := scmerSlice(body)
+	if !ok || len(setCall) != 4 ||
+		(!scmerIsSymbol(setCall[0], "set_assoc") && !scmerIsSymbol(setCall[0], "set_assoc_mut")) {
+		return nil, false
+	}
+	leg, ok := matchAssocFoldLeg(setCall, params)
+	if !ok {
+		return nil, false
+	}
+	if optimizerLambdaParamReference(setCall[1], params, 0) {
+		return []assocFoldLeg{leg}, true
+	}
+	rest, ok := collectAssocFoldLegs(setCall[1], params)
+	if !ok {
+		return nil, false
+	}
+	return append(rest, leg), true
+}
+
+// foldCountLegs lowers one or more "count" legs to a chain of
+// group_assoc_count_reduce calls merged with +. Count is commutative and
+// associative, so running each leg as an independent full pass and merging
+// the resulting maps afterward reproduces the same result as a single
+// interleaved pass would.
+func foldCountLegs(input, reducer Scmer, legs []assocFoldLeg) (Scmer, *TypeDescriptor, bool) {
+	assocType := &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}}
+	if len(legs) == 1 {
+		keyFn, ok := optimizerLambdaWithBody(reducer, legs[0].key)
 		if !ok {
 			return NewNil(), nil, false
 		}
-		return NewSlice([]Scmer{NewSymbol("group_assoc_count_reduce"), input, keyFn}),
-			&TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}}, true
+		return NewSlice([]Scmer{NewSymbol("group_assoc_count_reduce"), input, keyFn}), assocType, true
+	}
+	call := []Scmer{NewSymbol("group_assoc_multi_count_reduce"), input}
+	for _, leg := range legs {
+		keyFn, ok := optimizerLambdaWithBody(reducer, leg.key)
+		if !ok {
+			return NewNil(), nil, false
+		}
+		call = append(call, keyFn)
+	}
+	return NewSlice(call), assocType, true
+}
+
+// foldAppendLegs lowers one or more "append" legs. A single leg keeps the
+// original single-call shape. Multiple legs go through
+// group_assoc_multi_append_reduce, which applies every leg to each item in
+// one item-major/leg-minor pass — unlike the count case, append is not
+// commutative across legs (a key can receive contributions from more than one
+// leg across different items), so legs cannot be folded independently and
+// merged afterward without risking element reordering.
+func foldAppendLegs(input, reducer Scmer, legs []assocFoldLeg) (Scmer, *TypeDescriptor, bool) {
+	assocType := &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}}
+	if len(legs) == 1 {
+		keyFn, keyOK := optimizerLambdaWithBody(reducer, legs[0].key)
+		valueFn, valueOK := optimizerLambdaWithBody(reducer, legs[0].value)
+		if !keyOK || !valueOK {
+			return NewNil(), nil, false
+		}
+		return NewSlice([]Scmer{NewSymbol("group_assoc_append_reduce"), input, keyFn, valueFn}), assocType, true
+	}
+	call := []Scmer{NewSymbol("group_assoc_multi_append_reduce"), input}
+	for _, leg := range legs {
+		keyFn, keyOK := optimizerLambdaWithBody(reducer, leg.key)
+		valueFn, valueOK := optimizerLambdaWithBody(reducer, leg.value)
+		if !keyOK || !valueOK {
+			return NewNil(), nil, false
+		}
+		call = append(call, keyFn, valueFn)
+	}
+	return NewSlice(call), assocType, true
+}
+
+// optimizerAppendNeutralKeyInit recognizes a neutral of the shape
+// (reduce keys (lambda (acc k) (set_assoc[_mut] acc key '())) '()), which
+// pre-populates a fixed key set with an empty list before any real
+// contribution is folded in (e.g. so isolated graph nodes still get an empty
+// adjacency entry instead of being absent from the result). It returns the
+// keys list and a key-extractor lambda so the caller can rebuild an
+// equivalent init map and merge it under the real fold.
+func optimizerAppendNeutralKeyInit(neutral Scmer) (Scmer, Scmer, bool) {
+	items, ok := scmerSlice(neutral)
+	if !ok || len(items) != 4 || !scmerIsSymbol(items[0], "reduce") || !optimizerEmptyListLiteral(items[3]) {
+		return NewNil(), NewNil(), false
+	}
+	keys, initReducer := items[1], items[2]
+	params, body, ok := optimizerLambdaParts(initReducer)
+	if !ok || len(params) != 2 {
+		return NewNil(), NewNil(), false
+	}
+	body, ok = optimizerInlineReducerLocals(body, params)
+	if !ok {
+		return NewNil(), NewNil(), false
+	}
+	setCall, ok := scmerSlice(body)
+	if !ok || len(setCall) != 4 ||
+		(!scmerIsSymbol(setCall[0], "set_assoc") && !scmerIsSymbol(setCall[0], "set_assoc_mut")) ||
+		!optimizerLambdaParamReference(setCall[1], params, 0) ||
+		optimizerExpressionReferencesParam(setCall[2], params, 0) || exprMayHaveSideEffects(setCall[2]) ||
+		!optimizerEmptyListLiteral(setCall[3]) {
+		return NewNil(), NewNil(), false
+	}
+	keyFn, ok := optimizerLambdaWithBody(initReducer, setCall[2])
+	if !ok {
+		return NewNil(), NewNil(), false
+	}
+	return keys, keyFn, true
+}
+
+// foldAppendLegsWithKeyInit lowers the append-leg fold the same way as
+// foldAppendLegs, then merges the result under an init map built from the
+// neutral's key set so every initialized key stays present. Real edge
+// contributions must dominate, matching the original sequential fold where
+// the initializer always ran strictly before any edge could touch the same
+// key — merge_assoc's default "second argument wins" semantics gives
+// exactly that when the edge-derived map is passed second.
+func foldAppendLegsWithKeyInit(input, reducer Scmer, legs []assocFoldLeg, keys, keyFn Scmer) (Scmer, *TypeDescriptor, bool) {
+	edgesCall, assocType, ok := foldAppendLegs(input, reducer, legs)
+	if !ok {
+		return NewNil(), nil, false
+	}
+	emptyValueFn := NewSlice([]Scmer{NewSymbol("lambda"), NewSlice([]Scmer{NewSymbol("index"), NewSymbol("item")}),
+		NewSlice([]Scmer{NewSymbol("quote"), NewSlice([]Scmer{})})})
+	// index_assoc sets each key directly (last-wins), matching the original
+	// (set_assoc acc key '()) semantics exactly. group_assoc_append_reduce
+	// would be wrong here: it appends the value as one bucket element per
+	// occurrence, producing (()) instead of () for a key seen once.
+	initCall := NewSlice([]Scmer{NewSymbol("index_assoc"), keys, keyFn, emptyValueFn})
+	return NewSlice([]Scmer{NewSymbol("merge_assoc_mut"), initCall, edgesCall}), assocType, true
+}
+
+// optimizeAssocReducerFold recognizes the functional meaning of the common
+// imperative get-transform-set reducer, including a chain of several such
+// updates in one reduce step (e.g. updating both endpoints of a graph edge
+// per item). It performs one bounded root-shape walk over the already
+// optimized callback and never invokes analysis again.
+func optimizeAssocReducerFold(input, reducer, neutral Scmer) (Scmer, *TypeDescriptor, bool) {
+	params, body, ok := optimizerLambdaParts(reducer)
+	if !ok || len(params) != 2 {
+		return NewNil(), nil, false
+	}
+	body, ok = optimizerInlineReducerLocals(body, params)
+	if !ok {
+		return NewNil(), nil, false
+	}
+	legs, ok := collectAssocFoldLegs(body, params)
+	if !ok || len(legs) == 0 {
+		return NewNil(), nil, false
+	}
+	kind := legs[0].kind
+	for _, leg := range legs[1:] {
+		if leg.kind != kind {
+			// Mixed append/count legs in one chain aren't lowered here; the
+			// generic _mut rewrite still applies to the un-folded body.
+			return NewNil(), nil, false
+		}
+	}
+	if optimizerEmptyListLiteral(neutral) {
+		if kind == "count" {
+			return foldCountLegs(input, reducer, legs)
+		}
+		return foldAppendLegs(input, reducer, legs)
+	}
+	// A non-literal neutral can still be safe to fold away for append legs
+	// when it is recognized as a plain key-initializer; count legs keep the
+	// strict literal requirement since there's no analogous "count identity
+	// initializer" shape in use anywhere in the codebase today.
+	if kind == "append" {
+		if keys, keyFn, ok := optimizerAppendNeutralKeyInit(neutral); ok {
+			return foldAppendLegsWithKeyInit(input, reducer, legs, keys, keyFn)
+		}
 	}
 	return NewNil(), nil, false
 }

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -3304,6 +3304,76 @@ func init_list_assoc_extra() {
 		},
 	})
 	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_multi_append_reduce",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_multi_append_reduce")
+			legs := (len(a) - 1) / 2
+			keys := make([]func(...Scmer) Scmer, legs)
+			values := make([]func(...Scmer) Scmer, legs)
+			for i := 0; i < legs; i++ {
+				keys[i] = OptimizeProcToSerialFunction(a[1+2*i])
+				values[i] = OptimizeProcToSerialFunction(a[2+2*i])
+			}
+			result := NewFastDictValue(groupAssocCapacity(len(input) * legs))
+			for _, item := range input {
+				for i := 0; i < legs; i++ {
+					result.AppendValue(keys[i](NewNil(), item), values[i](NewNil(), item))
+				}
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only multi-leg append reduction: applies an ordered sequence of (key, value) extractor pairs to every item, preserving item-major/leg-minor insertion order so results match the equivalent chain of set_assoc/append calls",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "extractor...", Description: "alternating key/value extractor functions, one pair per leg", Variadic: true, Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}},
+			Const:     true,
+			Forbidden: true,
+			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				// JITGen native call boundary: leg count varies per call site.
+				return jitEmitGoVariadicCallFromDescs(ctx, declarations["group_assoc_multi_append_reduce"].Fn, args, result)
+			},
+			JITVirtualArgs:     true,
+			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
+		Name: "group_assoc_multi_count_reduce",
+		Fn: func(a ...Scmer) Scmer {
+			input := asSlice(a[0], "group_assoc_multi_count_reduce")
+			legs := len(a) - 1
+			keys := make([]func(...Scmer) Scmer, legs)
+			for i := 0; i < legs; i++ {
+				keys[i] = OptimizeProcToSerialFunction(a[1+i])
+			}
+			result := NewFastDictValue(groupAssocCapacity(len(input) * legs))
+			for _, item := range input {
+				for i := 0; i < legs; i++ {
+					result.IncrementCount(keys[i](NewNil(), item))
+				}
+			}
+			return NewFastDict(result)
+		},
+		Type: &TypeDescriptor{Kind: "func", Description: "optimizer-only multi-leg counting reduction: increments a count per key extractor per item in one pass",
+			Params: []*TypeDescriptor{
+				{Kind: "list", Label: "list", NoEscape: true},
+				{Kind: "func", Label: "key...", Description: "one key extractor per leg", Variadic: true, Params: []*TypeDescriptor{{Kind: "any", Label: "unused_current"}, {Kind: "any", Label: "item"}}, Return: &TypeDescriptor{Kind: "any"}},
+			},
+			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}},
+			Const:     true,
+			Forbidden: true,
+			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				// JITGen native call boundary: leg count varies per call site.
+				return jitEmitGoVariadicCallFromDescs(ctx, declarations["group_assoc_multi_count_reduce"].Fn, args, result)
+			},
+			JITVirtualArgs:     true,
+			JITInlineCallbacks: false,
+			JITInlineCost:      65535,
+		},
+	})
+	Declare(&Globalenv, &Declaration{
 		Name: "group_assoc_count",
 		Fn: func(a ...Scmer) Scmer {
 			input := asSlice(a[0], "group_assoc_count")

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1133,21 +1133,38 @@ func procOwnershipParameterMask(expr Scmer, paramCount int) uint64 {
 	return mask
 }
 
+// procParameterOwnershipUses analyzes how many times each of the first
+// paramCount parameters is referenced in expr, whether any reference is
+// captured inside a nested closure, and whether at least one reference sits
+// in a position that consumes (transfers) ownership.
+//
+// if-branches (and the final expression of a top-level begin) are mutually
+// exclusive or sequentially terminal, so a parameter referenced once in each
+// branch of an if is still used at most once per actual execution: branch
+// occurrence counts are combined with max rather than summed, which is what
+// lets the common "return the accumulator on the empty case, otherwise
+// recurse with an extended accumulator" idiom qualify as a single linear use
+// instead of being permanently rejected as "used twice". A bare parameter
+// reference in the proc's own tail position is itself a consuming use,
+// mirroring passing it to a declared transfer-consuming builtin: returning a
+// value already hands its ownership to the caller.
 func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bool) {
 	uses := make([]int, paramCount)
 	captured := make([]bool, paramCount)
 	consumed := make([]bool, paramCount)
-	var visit func(Scmer, int, bool)
-	visit = func(current Scmer, lambdaDepth int, throughOuter bool) {
+	var visit func(current Scmer, lambdaDepth int, throughOuter bool, tail bool, u []int, cap []bool, cons []bool)
+	visit = func(current Scmer, lambdaDepth int, throughOuter bool, tail bool, u []int, cap []bool, cons []bool) {
 		if stripped, ok := scmerStripSourceInfo(current); ok {
 			current = stripped
 		}
 		if current.IsNthLocalVar() {
 			idx := int(current.NthLocalVar())
 			if idx >= 0 && idx < paramCount && (lambdaDepth == 0 || throughOuter) {
-				uses[idx]++
+				u[idx]++
 				if lambdaDepth > 0 {
-					captured[idx] = true
+					cap[idx] = true
+				} else if tail {
+					cons[idx] = true
 				}
 			}
 			return
@@ -1165,28 +1182,56 @@ func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bo
 				mask := procOwnershipParameterMask(items[1], paramCount)
 				for idx := 0; idx < paramCount && idx < 64; idx++ {
 					if mask&(1<<uint(idx)) != 0 {
-						consumed[idx] = true
+						cons[idx] = true
 					}
 				}
 			}
 		}
 		if scmerIsSymbol(items[0], "lambda") {
 			if len(items) > 2 {
-				visit(items[2], lambdaDepth+1, false)
+				visit(items[2], lambdaDepth+1, false, false, u, cap, cons)
 			}
 			return
 		}
 		if scmerIsSymbol(items[0], "outer") {
 			for _, item := range items[1:] {
-				visit(item, lambdaDepth, true)
+				visit(item, lambdaDepth, true, false, u, cap, cons)
 			}
 			return
 		}
+		if lambdaDepth == 0 && scmerIsSymbol(items[0], "if") && (len(items) == 3 || len(items) == 4) {
+			visit(items[1], lambdaDepth, throughOuter, false, u, cap, cons)
+			maxU := make([]int, paramCount)
+			for _, branch := range items[2:] {
+				branchU := make([]int, paramCount)
+				branchCap := make([]bool, paramCount)
+				branchCons := make([]bool, paramCount)
+				visit(branch, lambdaDepth, throughOuter, tail, branchU, branchCap, branchCons)
+				for idx := 0; idx < paramCount; idx++ {
+					if branchU[idx] > maxU[idx] {
+						maxU[idx] = branchU[idx]
+					}
+					cap[idx] = cap[idx] || branchCap[idx]
+					cons[idx] = cons[idx] || branchCons[idx]
+				}
+			}
+			for idx := 0; idx < paramCount; idx++ {
+				u[idx] += maxU[idx]
+			}
+			return
+		}
+		if lambdaDepth == 0 && scmerIsSymbol(items[0], "begin") && len(items) > 1 {
+			for _, item := range items[1 : len(items)-1] {
+				visit(item, lambdaDepth, throughOuter, false, u, cap, cons)
+			}
+			visit(items[len(items)-1], lambdaDepth, throughOuter, tail, u, cap, cons)
+			return
+		}
 		for _, item := range items {
-			visit(item, lambdaDepth, throughOuter)
+			visit(item, lambdaDepth, throughOuter, false, u, cap, cons)
 		}
 	}
-	visit(expr, 0, false)
+	visit(expr, 0, false, true, uses, captured, consumed)
 	return uses, captured, consumed
 }
 

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -690,6 +690,39 @@ func BenchmarkSchemeHelperOwnedReturnAppend(b *testing.B) {
 	}
 }
 
+// TestRecursiveAccumulatorIfBranchesCountAsSingleUse covers the common
+// "return the accumulator on the empty case, otherwise recurse with an
+// extended accumulator" idiom. Before this fix, procParameterOwnershipUses
+// summed if-branch occurrences instead of treating them as mutually
+// exclusive, so the accumulator was always seen as "used twice" and the
+// recursive call's append could never be promoted to append_mut.
+func TestRecursiveAccumulatorIfBranchesCountAsSingleUse(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("recursive accumulator ownership test", `(define recursive_append_accumulate (lambda (acc remaining)
+		(if (equal? remaining '())
+			acc
+			(recursive_append_accumulate (append acc (list (car remaining))) (cdr remaining)))))`, env)
+
+	base := env.Vars[Symbol("recursive_append_accumulate")].Proc()
+	call := []Scmer{NewSymbol("recursive_append_accumulate"), NewSymbol("fresh")}
+	freshList := &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
+	meta := newOptimizerMetainfo()
+	variant, ok := trySpecializeProcCall(call, []TypeInfo{tiZero, TypeInfoFromTD(freshList)}, env, &meta)
+	if !ok || !variant.IsProc() {
+		t.Fatal("fresh accumulator did not produce a Proc specialization")
+	}
+	if body := serializedTestExpr(t, env, variant.Proc().Body); !strings.Contains(body, "append_mut") {
+		t.Fatalf("recursive accumulator did not become append_mut: %s", body)
+	}
+	_ = base
+
+	got := Apply(variant, NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
+	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
+	if !Equal(got, want) {
+		t.Fatalf("specialized accumulator returned %s, want %s", String(got), String(want))
+	}
+}
+
 func BenchmarkOptimizeInlinedNestedLambdaHelper(b *testing.B) {
 	env := newOptimizerTestEnv()
 	EvalAll("nested lambda inline benchmark", `(define benchmark_filter_owned (lambda (values) (filter values (lambda (x) (> x 1)))))`, env)


### PR DESCRIPTION
## Summary

- Generalize `optimizeAssocReducerFold` (scm/list.go) to recognize a **chain** of `set_assoc`/`set_assoc_mut` updates in one reduce step (e.g. updating both endpoints of a graph edge per item), not just a single update. Count legs lower to a new single-pass `group_assoc_multi_count_reduce`; append legs lower to a new single-pass `group_assoc_multi_append_reduce` (append legs can't be decomposed into independent passes + merge like count legs can, since append isn't commutative across legs when the same key is touched by more than one leg across different items — merging independent passes would reorder list elements relative to the original sequential fold).
- Additionally recognize a neutral element that pre-initializes a fixed key set to the identity value (`join_order_arm_adjacency`'s alias list), merging it under the real fold so keys with no contributions (isolated graph nodes) stay present in the result instead of being dropped.
- Fix `procParameterOwnershipUses` (scm/optimizer.go) to treat `if`-branches as mutually exclusive (`max` instead of sum) when counting parameter occurrences, and to recognize a bare parameter reference in the proc's own tail position as a consuming (ownership-transferring) use. Before this, the very common "return the accumulator on the empty case, otherwise recurse with an extended accumulator" idiom was always counted as *two* uses of the accumulator, permanently blocking ownership specialization (and therefore `append_mut`/`set_assoc_mut` promotion) for that entire class of recursive functions — not just the two join-order functions that motivated this change.
- Convert `compile_stmt` in `lib/sql-parser.scm` (trigger statement compilation) from a 9-level nested `if` dispatch to a flat `match`, per the project's existing style convention.

## Why, and an important correction on the performance story

This started from a review of `lib/queryplan-optimize.scm`'s join-ordering code (`join_order_arm_adjacency`, `join_order_degree_index`), which each update two hashmap keys per input item — a shape `optimizeAssocReducerFold` didn't recognize, so it fell back to the generic `_mut` rewrite instead of the hashmap-backed `group_assoc_*_reduce` lowering.

**The original hypothesis was that this made the whole reduce O(edges²)** (an unfused per-call linear scan over a flat assoc list). Benchmarking this PR (see below) showed that hypothesis was wrong: `set_assoc_mut` already auto-promotes a flat association list to a hash-backed `FastDict` once it exceeds 10 entries, and mutates it in place from then on — so master's *existing* `_mut`-optimized code is already close to linear for realistic sizes. This PR is therefore a **constant-factor** improvement (a tight native Go loop building the hashmap directly, vs. routing every item through a generic multi-arg builtin call inside the interpreted reduce loop), not an asymptotic-complexity fix. Flagging this explicitly since it changes the size of the claimed win versus how this was initially framed during investigation.

### A/B compile-step benchmark

Synthetic path-graph join scenario (N tables chained by join predicates, `n0-n1-n2-...-nN`), calling `join_order_arm_adjacency`/`join_order_degree_index` directly and timing with `nanotime`. Single-shot measurements on this machine; treat as directional, not a precise SLA.

| edges (N) | arm_adjacency master | arm_adjacency this PR | degree_index master | degree_index this PR |
|---:|---:|---:|---:|---:|
| 20,000 | 22.8 ms | 13.1 ms (**1.7x**) | 8.5 ms | 4.5 ms (**1.9x**) |
| 50,000 | 63.1 ms | 34.9 ms (**1.8x**) | 17.2 ms | 17.5 ms (~par) |

Master's timing scales roughly linearly with N across the tested range (500 → 50,000), confirming the FastDict auto-promotion already avoids the quadratic blowup the original diagnosis assumed. Real SQL join graphs rarely approach these sizes (tens of tables, not tens of thousands), so the practical impact on query compile time is small; the more broadly useful part of this PR is the `procParameterOwnershipUses` fix, which applies to any recursive accumulator function in the codebase, not just these two.

## Correctness

- `foldAppendLegs`/`foldCountLegs`/`foldAppendLegsWithKeyInit` were verified against master with a byte-for-byte output comparison on a graph with parallel/shared-key edges (the case most likely to expose ordering or key-collision bugs from decomposing into independent passes) — identical output.
- Added `TestRecursiveAccumulatorIfBranchesCountAsSingleUse` (scm/optimizer_scheme_return_test.go) covering the if-branch ownership fix directly against `trySpecializeProcCall`, asserting the recursive accumulator now specializes to `append_mut` and preserves behavior.
- Full `make test` (1276 Scheme unit tests + ~4800 SQL YAML tests) passed clean in this worktree before committing (`git commit --no-verify` per repo convention, to let CI run the authoritative full suite — a background benchmark process caused one unrelated flaky local re-run failure, a server-restart timeout, immediately after the clean pass).

## Test plan

- [x] `go build ./...`
- [x] `go test ./scm/...`
- [x] `make test` (full suite, clean pass in this worktree)
- [x] `python3 tools/lint_scm.py --check` on `lib/sql-parser.scm`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172eE7icytpNR7bLKB1BbSG