### PR TITLE
Fix O(n^2) LIKE-literal scanning in sql_parameterize_select_like_strings

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -120,17 +120,26 @@ literals, DDL/DML and already-parameterized statements keep exact cache keys. */
 			(match prefix (regex "(?s:.*)\\bAGAINST\\s*\\($" _) true false)))))
 	(define read_string_literal (lambda (q start quote_ch) (begin
 		(define len (strlen q))
-		(for (list (+ start 1) "" false)
-			(lambda (i value done) (and (not done) (< i len)))
-			(lambda (i value done) (begin
+		/* Store each piece under its own session key (O(1) amortized per
+		write, like any dict built incrementally in a loop) instead of
+		concat-in-a-loop, which would copy the whole prefix on every
+		character (O(n^2) for a literal of length n). cons/append aren't an
+		O(1) alternative here either: both are implemented as a full copy of
+		the existing list on this slice-backed representation. */
+		(define pieces (newsession))
+		(match (for (list (+ start 1) 0 false)
+			(lambda (i count done) (and (not done) (< i len)))
+			(lambda (i count done) (begin
 				(define ch (substr q i 1))
 				(if (equal? ch "\\")
 					(if (< (+ i 1) len)
-						(list (+ i 2) (concat value (substr q (+ i 1) 1)) false)
-						(list (+ i 1) value false))
+						(begin (pieces count (substr q (+ i 1) 1)) (list (+ i 2) (+ count 1) false))
+						(list (+ i 1) count false))
 					(if (equal? ch quote_ch)
-						(list (+ i 1) value true)
-						(list (+ i 1) (concat value ch) false)))))))))
+						(list (+ i 1) count true)
+						(begin (pieces count ch) (list (+ i 1) (+ count 1) false)))))))
+			'(next_i count done)
+			(list next_i (apply concat (map (produceN count) (lambda (idx) (pieces idx)))) done)))))
 	(if (or
 		(not enabled)
 		(not (starts_like_select query))
@@ -144,20 +153,24 @@ literals, DDL/DML and already-parameterized statements keep exact cache keys. */
 		(list query '())
 		(begin
 			(define len (strlen query))
-			(define state (for (list 0 "" '() false)
-				(lambda (i out bindings invalid) (and (not invalid) (< i len)))
-				(lambda (i out bindings invalid) (begin
+			/* Same session-backed accumulation as read_string_literal: out
+			collects pieces (single chars or a "?" placeholder) by index
+			instead of concatenating on every character. */
+			(define out (newsession))
+			(define state (for (list 0 0 '() false)
+				(lambda (i out_count bindings invalid) (and (not invalid) (< i len)))
+				(lambda (i out_count bindings invalid) (begin
 					(define ch (substr query i 1))
 					(if (and (or (equal? ch "'") (equal? ch "\"")) (parameterized_rhs_literal? query i))
 						(match (read_string_literal query i ch) '(next_i value done)
 							(if done
-								(list next_i (concat out "?") (merge bindings (list value)) false)
-								(list len query '() true)))
-						(list (+ i 1) (concat out ch) bindings false))))))
-			(match state '(end_i normalized bindings invalid)
+								(begin (out out_count "?") (list next_i (+ out_count 1) (merge bindings (list value)) false))
+								(list len out_count '() true)))
+						(begin (out out_count ch) (list (+ i 1) (+ out_count 1) bindings false)))))))
+			(match state '(end_i out_count bindings invalid)
 				(if (or invalid (equal? bindings '()))
 					(list query '())
-					(list normalized bindings))))))))
+					(list (apply concat (map (produceN out_count) (lambda (idx) (out idx)))) bindings))))))))
 
 /* Copy request bindings and catalog context into an isolated planning session.
 The request transaction is deliberately excluded: cached plans must obtain

--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1138,16 +1138,18 @@ func procOwnershipParameterMask(expr Scmer, paramCount int) uint64 {
 // captured inside a nested closure, and whether at least one reference sits
 // in a position that consumes (transfers) ownership.
 //
-// if-branches (and the final expression of a top-level begin) are mutually
-// exclusive or sequentially terminal, so a parameter referenced once in each
-// branch of an if is still used at most once per actual execution: branch
-// occurrence counts are combined with max rather than summed, which is what
-// lets the common "return the accumulator on the empty case, otherwise
-// recurse with an extended accumulator" idiom qualify as a single linear use
-// instead of being permanently rejected as "used twice". A bare parameter
-// reference in the proc's own tail position is itself a consuming use,
-// mirroring passing it to a declared transfer-consuming builtin: returning a
-// value already hands its ownership to the caller.
+// if-branches, match/match_mut clause results (and the final expression of a
+// top-level begin) are mutually exclusive or sequentially terminal, so a
+// parameter referenced once in each branch/clause is still used at most once
+// per actual execution: branch occurrence counts are combined with max
+// rather than summed, which is what lets the common "return the accumulator
+// on the empty case, otherwise recurse with an extended accumulator" idiom
+// qualify as a single linear use instead of being permanently rejected as
+// "used twice" — whether that dispatch is written as an if or, per this
+// project's own style preference, as a match. A bare parameter reference in
+// the proc's own tail position is itself a consuming use, mirroring passing
+// it to a declared transfer-consuming builtin: returning a value already
+// hands its ownership to the caller.
 func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bool) {
 	uses := make([]int, paramCount)
 	captured := make([]bool, paramCount)
@@ -1214,6 +1216,44 @@ func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bo
 					cap[idx] = cap[idx] || branchCap[idx]
 					cons[idx] = cons[idx] || branchCons[idx]
 				}
+			}
+			for idx := 0; idx < paramCount; idx++ {
+				u[idx] += maxU[idx]
+			}
+			return
+		}
+		if lambdaDepth == 0 && (scmerIsSymbol(items[0], "match") || scmerIsSymbol(items[0], "match_mut")) && len(items) >= 2 {
+			// The scrutinee always evaluates; patterns are structural
+			// matchers rather than live expressions, so they're visited
+			// generically (summed, non-branch) exactly as before. Only the
+			// per-clause result bodies (and a trailing unpaired default, if
+			// present) are mutually exclusive at runtime — the same
+			// max-instead-of-sum treatment as if-branches, generalized to
+			// match's arbitrary number of arms.
+			visit(items[1], lambdaDepth, throughOuter, false, u, cap, cons)
+			rest := items[2:]
+			hasDefault := len(rest)%2 == 1
+			pairCount := len(rest) / 2
+			maxU := make([]int, paramCount)
+			visitBranch := func(branch Scmer) {
+				branchU := make([]int, paramCount)
+				branchCap := make([]bool, paramCount)
+				branchCons := make([]bool, paramCount)
+				visit(branch, lambdaDepth, throughOuter, tail, branchU, branchCap, branchCons)
+				for idx := 0; idx < paramCount; idx++ {
+					if branchU[idx] > maxU[idx] {
+						maxU[idx] = branchU[idx]
+					}
+					cap[idx] = cap[idx] || branchCap[idx]
+					cons[idx] = cons[idx] || branchCons[idx]
+				}
+			}
+			for i := 0; i < pairCount; i++ {
+				visit(rest[2*i], lambdaDepth, throughOuter, false, u, cap, cons)
+				visitBranch(rest[2*i+1])
+			}
+			if hasDefault {
+				visitBranch(rest[len(rest)-1])
 			}
 			for idx := 0; idx < paramCount; idx++ {
 				u[idx] += maxU[idx]

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -701,7 +701,7 @@ func TestRecursiveAccumulatorIfBranchesCountAsSingleUse(t *testing.T) {
 	EvalAll("recursive accumulator ownership test", `(define recursive_append_accumulate (lambda (acc remaining)
 		(if (equal? remaining '())
 			acc
-			(recursive_append_accumulate (append acc (list (car remaining))) (cdr remaining)))))`, env)
+			(recursive_append_accumulate (append acc (car remaining)) (cdr remaining)))))`, env)
 
 	base := env.Vars[Symbol("recursive_append_accumulate")].Proc()
 	call := []Scmer{NewSymbol("recursive_append_accumulate"), NewSymbol("fresh")}
@@ -716,10 +716,48 @@ func TestRecursiveAccumulatorIfBranchesCountAsSingleUse(t *testing.T) {
 	}
 	_ = base
 
-	got := Apply(variant, NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
+	// Call with the proc's real two-parameter arity (a fresh accumulator,
+	// then the remaining items) so the recursive branch is actually
+	// exercised, not just the empty-input base case.
+	got := Apply(variant, NewSlice(nil), NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
 	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
 	if !Equal(got, want) {
 		t.Fatalf("specialized accumulator returned %s, want %s", String(got), String(want))
+	}
+}
+
+// TestRecursiveAccumulatorMatchArmsCountAsSingleUse is the match-based analog
+// of TestRecursiveAccumulatorIfBranchesCountAsSingleUse. This project's own
+// style convention prefers match over if-cascades, so the same "return the
+// accumulator on the empty case, otherwise recurse with an extended
+// accumulator" idiom commonly shows up as match clauses instead of an if.
+// Before generalizing procParameterOwnershipUses's branch-exclusivity
+// handling from if to match, this was rejected the same way the if case was.
+func TestRecursiveAccumulatorMatchArmsCountAsSingleUse(t *testing.T) {
+	env := newOptimizerTestEnv()
+	EvalAll("recursive accumulator match ownership test", `(define recursive_match_accumulate (lambda (acc remaining)
+		(match remaining
+			'() acc
+			(cons item rest) (recursive_match_accumulate (append acc item) rest))))`, env)
+
+	call := []Scmer{NewSymbol("recursive_match_accumulate"), NewSymbol("fresh")}
+	freshList := &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
+	meta := newOptimizerMetainfo()
+	variant, ok := trySpecializeProcCall(call, []TypeInfo{tiZero, TypeInfoFromTD(freshList)}, env, &meta)
+	if !ok || !variant.IsProc() {
+		t.Fatal("fresh accumulator did not produce a Proc specialization")
+	}
+	if body := serializedTestExpr(t, env, variant.Proc().Body); !strings.Contains(body, "append_mut") {
+		t.Fatalf("recursive match accumulator did not become append_mut: %s", body)
+	}
+
+	// Call with the proc's real two-parameter arity (a fresh accumulator,
+	// then the remaining items) so the recursive branch is actually
+	// exercised, not just the empty-input base case.
+	got := Apply(variant, NewSlice(nil), NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
+	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
+	if !Equal(got, want) {
+		t.Fatalf("specialized match accumulator returned %s, want %s", String(got), String(want))
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #738, picking two concrete items from a further review pass of the query-planner Scheme code.

- **`sql_parameterize_select_like_strings` (lib/sql.scm) was O(n²) in the length of a scanned string literal.** It built its normalized query and each string literal char-by-char via repeated `(concat acc ch)`, and `concat` copies the whole existing string on every call — so scanning an n-character LIKE/AGAINST literal did O(n²) character copies. Neither `cons` nor `append` are an O(1) fix here either: both are implemented as a full copy of the existing list on this slice-backed list representation (verified empirically — an earlier attempt using `cons`+reverse was actually *slower* than the original at scale). The fix stores each scanned piece under its own key in a `newsession` (a genuine O(1)-amortized-per-write hashmap, the same pattern this codebase already uses elsewhere for incremental dict building) and joins everything once via `(apply concat ...)` after the scan completes.
- **Generalized `procParameterOwnershipUses`'s branch-exclusivity handling from `if` to `match`/`match_mut` clause results.** #738 fixed the common "return the accumulator on the empty case, otherwise recurse with an extended accumulator" idiom for `if`-based dispatch. Since this project's own style convention prefers `match` over `if`-cascades (AGENTS.md), the same idiom commonly appears as `match` clauses instead — and was hitting the identical "used twice" rejection, permanently blocking `append_mut`/`set_assoc_mut` specialization for that whole class of recursive functions. `lib/queryplan-logical.scm:475`'s `unique_stages_by_id_acc` is a concrete example in the query planner.
- **Fixed a regression-test bug in #738 itself**: `TestRecursiveAccumulatorIfBranchesCountAsSingleUse` called the specialized two-parameter proc with only one argument, so `remaining` was implicitly nil/empty and the test only ever exercised the base case, never the recursive `append_mut` path it claimed to verify. Both this test and its new match-arm counterpart now call with the real two-argument arity and actually exercise recursion.

## A/B measurements

### LIKE-literal scanning (real, scaling win)

Direct timing of `sql_parameterize_select_like_strings` via `nanotime` (isolates the fixed function itself):

| literal length | master | this PR | speedup |
|---:|---:|---:|---:|
| 1,000  | 1.2 ms  | 1.1 ms | ~1.0x |
| 5,000  | 8.9 ms  | 7.1 ms | 1.3x |
| 20,000 | 60.3 ms | 19.6 ms | 3.1x |
| 50,000 | 238 ms  | 61.7 ms | 3.9x |

End-to-end, over the real HTTP SQL endpoint, with a query shape that defeats the fast native-Go literal parameterizer (`SELECT * FROM t2 ORDER BY (CASE WHEN name LIKE '<literal>%' THEN 1 ELSE 2 END)` — ORDER BY isn't in that parameterizer's allowed clause list, so it correctly falls through to this Scheme fallback):

| literal length | master | this PR | speedup |
|---:|---:|---:|---:|
| 20,000  | 70.4 ms | 37.0 ms | 1.9x |
| 50,000  | 261 ms  | 104 ms  | 2.5x |
| 100,000 | 738 ms  | 138 ms  | 5.3x |

The gap grows with n as expected (O(n²) vs. O(n)); a plain top-level `WHERE name LIKE '...'` query doesn't exercise this path at all since the fast native parameterizer already force-handles that shape — this fallback specifically covers LIKE/AGAINST literals outside the parameterizer's normal clause coverage (ORDER BY expressions, certain nested/aggregate contexts).

### match-arm ownership generalization (mechanism verified, no demonstrable large-n win yet)

Verified via two targeted `trySpecializeProcCall` unit tests (one `if`-based, one `match`-based, both now exercising real two-argument recursion) that the accumulator now specializes to `append_mut` in both cases, plus the full SQL/Scheme test suite passing unchanged. I did not find a way to construct a realistic SQL query where this produces a measurable end-to-end timing difference: the concretely identified affected functions in this codebase (`unique_stages_by_id_acc`, join-order candidate dedup) operate on small inputs in real queries (number of query-block stages / join tables, not edge-graph-sized data), so the `set_assoc_mut`/`append_mut` win is real but currently below measurement noise there. Its value is removing a systemic barrier for this idiom generally, not a demonstrated speedup on any one function today — noting this explicitly rather than manufacturing a benchmark that would show noise as signal.

## Correctness

- `sql_parameterize_select_like_strings` output verified byte-identical against master across 7 cases (escaped quotes, empty literal, unterminated literal, `COUNT()`/`GROUP BY` guards, escaped backslash).
- Two new targeted Go tests for the ownership generalization (`TestRecursiveAccumulatorMatchArmsCountAsSingleUse`) plus a correctness fix to the existing if-based one from #738.
- Full `make test` (1276 Scheme unit tests + ~4800 SQL YAML tests) passed clean in this worktree twice (once before, once after the final fix iteration) before committing (`git commit --no-verify` per repo convention, to let CI run the authoritative full suite — an earlier local run hit one unrelated flaky failure, `kill-lock.yaml`, caused by CPU contention from my own concurrent benchmark processes on this machine; confirmed by re-running that suite in isolation, 28/28 pass in 0.4s).

## Test plan

- [x] `go build ./...`
- [x] `go test ./scm/...`
- [x] `make test` (full suite, clean pass twice in this worktree)
- [x] `python3 tools/lint_scm.py --check` on `lib/sql.scm`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172eE7icytpNR7bLKB1BbSG