### PR TITLE
Revert match-arm ownership generalization from #739: measured compile-time regression

### DIFF
--- a/scm/optimizer.go
+++ b/scm/optimizer.go
@@ -1138,18 +1138,16 @@ func procOwnershipParameterMask(expr Scmer, paramCount int) uint64 {
 // captured inside a nested closure, and whether at least one reference sits
 // in a position that consumes (transfers) ownership.
 //
-// if-branches, match/match_mut clause results (and the final expression of a
-// top-level begin) are mutually exclusive or sequentially terminal, so a
-// parameter referenced once in each branch/clause is still used at most once
-// per actual execution: branch occurrence counts are combined with max
-// rather than summed, which is what lets the common "return the accumulator
-// on the empty case, otherwise recurse with an extended accumulator" idiom
-// qualify as a single linear use instead of being permanently rejected as
-// "used twice" — whether that dispatch is written as an if or, per this
-// project's own style preference, as a match. A bare parameter reference in
-// the proc's own tail position is itself a consuming use, mirroring passing
-// it to a declared transfer-consuming builtin: returning a value already
-// hands its ownership to the caller.
+// if-branches (and the final expression of a top-level begin) are mutually
+// exclusive or sequentially terminal, so a parameter referenced once in each
+// branch of an if is still used at most once per actual execution: branch
+// occurrence counts are combined with max rather than summed, which is what
+// lets the common "return the accumulator on the empty case, otherwise
+// recurse with an extended accumulator" idiom qualify as a single linear use
+// instead of being permanently rejected as "used twice". A bare parameter
+// reference in the proc's own tail position is itself a consuming use,
+// mirroring passing it to a declared transfer-consuming builtin: returning a
+// value already hands its ownership to the caller.
 func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bool) {
 	uses := make([]int, paramCount)
 	captured := make([]bool, paramCount)
@@ -1216,44 +1214,6 @@ func procParameterOwnershipUses(expr Scmer, paramCount int) ([]int, []bool, []bo
 					cap[idx] = cap[idx] || branchCap[idx]
 					cons[idx] = cons[idx] || branchCons[idx]
 				}
-			}
-			for idx := 0; idx < paramCount; idx++ {
-				u[idx] += maxU[idx]
-			}
-			return
-		}
-		if lambdaDepth == 0 && (scmerIsSymbol(items[0], "match") || scmerIsSymbol(items[0], "match_mut")) && len(items) >= 2 {
-			// The scrutinee always evaluates; patterns are structural
-			// matchers rather than live expressions, so they're visited
-			// generically (summed, non-branch) exactly as before. Only the
-			// per-clause result bodies (and a trailing unpaired default, if
-			// present) are mutually exclusive at runtime — the same
-			// max-instead-of-sum treatment as if-branches, generalized to
-			// match's arbitrary number of arms.
-			visit(items[1], lambdaDepth, throughOuter, false, u, cap, cons)
-			rest := items[2:]
-			hasDefault := len(rest)%2 == 1
-			pairCount := len(rest) / 2
-			maxU := make([]int, paramCount)
-			visitBranch := func(branch Scmer) {
-				branchU := make([]int, paramCount)
-				branchCap := make([]bool, paramCount)
-				branchCons := make([]bool, paramCount)
-				visit(branch, lambdaDepth, throughOuter, tail, branchU, branchCap, branchCons)
-				for idx := 0; idx < paramCount; idx++ {
-					if branchU[idx] > maxU[idx] {
-						maxU[idx] = branchU[idx]
-					}
-					cap[idx] = cap[idx] || branchCap[idx]
-					cons[idx] = cons[idx] || branchCons[idx]
-				}
-			}
-			for i := 0; i < pairCount; i++ {
-				visit(rest[2*i], lambdaDepth, throughOuter, false, u, cap, cons)
-				visitBranch(rest[2*i+1])
-			}
-			if hasDefault {
-				visitBranch(rest[len(rest)-1])
 			}
 			for idx := 0; idx < paramCount; idx++ {
 				u[idx] += maxU[idx]

--- a/scm/optimizer_scheme_return_test.go
+++ b/scm/optimizer_scheme_return_test.go
@@ -726,41 +726,6 @@ func TestRecursiveAccumulatorIfBranchesCountAsSingleUse(t *testing.T) {
 	}
 }
 
-// TestRecursiveAccumulatorMatchArmsCountAsSingleUse is the match-based analog
-// of TestRecursiveAccumulatorIfBranchesCountAsSingleUse. This project's own
-// style convention prefers match over if-cascades, so the same "return the
-// accumulator on the empty case, otherwise recurse with an extended
-// accumulator" idiom commonly shows up as match clauses instead of an if.
-// Before generalizing procParameterOwnershipUses's branch-exclusivity
-// handling from if to match, this was rejected the same way the if case was.
-func TestRecursiveAccumulatorMatchArmsCountAsSingleUse(t *testing.T) {
-	env := newOptimizerTestEnv()
-	EvalAll("recursive accumulator match ownership test", `(define recursive_match_accumulate (lambda (acc remaining)
-		(match remaining
-			'() acc
-			(cons item rest) (recursive_match_accumulate (append acc item) rest))))`, env)
-
-	call := []Scmer{NewSymbol("recursive_match_accumulate"), NewSymbol("fresh")}
-	freshList := &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}
-	meta := newOptimizerMetainfo()
-	variant, ok := trySpecializeProcCall(call, []TypeInfo{tiZero, TypeInfoFromTD(freshList)}, env, &meta)
-	if !ok || !variant.IsProc() {
-		t.Fatal("fresh accumulator did not produce a Proc specialization")
-	}
-	if body := serializedTestExpr(t, env, variant.Proc().Body); !strings.Contains(body, "append_mut") {
-		t.Fatalf("recursive match accumulator did not become append_mut: %s", body)
-	}
-
-	// Call with the proc's real two-parameter arity (a fresh accumulator,
-	// then the remaining items) so the recursive branch is actually
-	// exercised, not just the empty-input base case.
-	got := Apply(variant, NewSlice(nil), NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)}))
-	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
-	if !Equal(got, want) {
-		t.Fatalf("specialized match accumulator returned %s, want %s", String(got), String(want))
-	}
-}
-
 func BenchmarkOptimizeInlinedNestedLambdaHelper(b *testing.B) {
 	env := newOptimizerTestEnv()
 	EvalAll("nested lambda inline benchmark", `(define benchmark_filter_owned (lambda (values) (filter values (lambda (x) (> x 1)))))`, env)


### PR DESCRIPTION
## Summary

#739 (already merged) generalized `procParameterOwnershipUses`'s `if`-branch-exclusivity handling to `match`/`match_mut` clause results, mirroring #738's fix for `if`. It was mechanism-sound (verified by a targeted unit test) and passed the full test suite at merge time. Checking for a real end-to-end win afterward (long string literals, the other half of #739, are a rare case in practice, which prompted a closer look) found this half was actually a **regression**, not an improvement — this PR reverts just that part from master.

## What's wrong, and the evidence

Measuring `EXPLAIN COMPILE` on a query with 30–60 correlated scalar aggregate subqueries (stressing `unique_stages_by_id_acc` in `lib/queryplan-logical.scm`, a match-based recursive accumulator called from 40+ structurally distinct sites during physical planning) showed **~25–30% slower compile time** on master (with #739's match-arm change) versus reverting just that half:

| n subqueries | master (current, with #739 match-arm change) | this revert |
|---:|---:|---:|
| 30 | ~194-205 ms | ~158-165 ms |
| 60 | ~558-571 ms | ~461-475 ms |

(pre-#739 baseline for comparison, measured separately: ~155-163ms / ~445-461ms — this revert reproduces it almost exactly)

Root cause: before #739's match-arm change, `unique_stages_by_id_acc` never qualified for ownership specialization (match arms were summed instead of treated as mutually exclusive, so the accumulator always looked "used twice"). After the change it qualifies — but `procSpecializationKeyForArguments` caches specializations by argument-shape hash, and nearly every one of those 40+ call sites has a different shape, so instead of one shared cached specialization, the optimizer pays for a fresh, expensive `buildProcSpecialization` (a full re-optimization pass) at most of them. That accumulated compile-time cost far outweighs the negligible runtime benefit of `append_mut`/`set_assoc_mut` on the small lists this function actually processes in real queries. Generalizing this idiom to `match` would need a smarter mechanism first (e.g. a cost threshold before attempting specialization, or better cache reuse across near-identical shapes) — not attempting that here, just reverting the regression.

## What's kept

- **#739's O(n²) LIKE-literal scanning fix (`lib/sql.scm`) is untouched and unaffected** — verified still byte-identical to expected output after this revert. It keeps its measured, non-regressing 2-5x end-to-end improvement.
- **The if-branch test's arity bugfix** from #739 (calling the specialized proc with its real two-parameter arity so the recursive branch is actually exercised, not just the empty-input base case) is kept, since it's an independent, correct fix unrelated to the match-arm mechanism.
- Only the match-arm branch-exclusivity generalization in `scm/optimizer.go` and its accompanying test are removed, restoring that function to #738's version.

## Correctness

- `sql_parameterize_select_like_strings` output re-verified byte-identical to master across the same 7 cases as #739 after this revert.
- `go test ./scm/...` passes.
- Per current guidance, not running the full local `make test` suite for this change — CI runs it.

## Test plan

- [x] `go build ./...`
- [x] `go test ./scm/...`
- [x] End-to-end `EXPLAIN COMPILE` A/B measurement confirming the regression is gone
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172eE7icytpNR7bLKB1BbSG