### PR TITLE
Persist trigger source through registered language compilers

### DIFF
--- a/lib/main.scm
+++ b/lib/main.scm
@@ -39,6 +39,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* global service registry: each module registers itself as (service_registry name (list port route protocols)) */
 (set service_registry (coalesce service_registry (newsession)))
 
+/* Persistent trigger languages are process-local frontend hooks. Scheme is
+available without loading an SQL module; other frontends can register their
+own compiler under any language name. */
+(registertriggerlanguage "scheme" (lambda (source context)
+	(eval (scheme source (concat "trigger:" (context "schema") "." (context "table") ":" (context "name"))))))
+
 (import "sql.scm")
 (import "dashboard.scm")
 (import "rdf.scm")

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -7391,7 +7391,7 @@ remain query-specific and are evaluated over the cached intermediate relation. *
 (define prejoin_create_trigger_plan (lambda (src name timing body)
 	(list (quote createtrigger)
 		(list (quote table) (source_schema src) (source_relation src))
-		name timing "" (prejoin_deferred_trigger body) false)))
+		name timing "" "" (prejoin_deferred_trigger body) false)))
 
 (define prejoin_trigger_registration_plans (lambda (block table_name)
 	(merge (map (qb_sources block) (lambda (src)

--- a/lib/sql-metadata.scm
+++ b/lib/sql-metadata.scm
@@ -73,8 +73,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	)
 )))
 
-/* SHOW CREATE TRIGGER must expose executable SQL. SourceSQL contains the
-original body, while SHOW TRIGGERS supplies the table, timing, and event. */
+/* SHOW CREATE TRIGGER exposes SQL-language source. SHOW TRIGGERS supplies the
+table, timing, and event around that language-neutral persisted source. */
 (define format_create_trigger (lambda (schema trigger_name) (begin
 	(define tr (find (show_triggers schema) (lambda (row)
 		(equal? (row "Trigger") trigger_name))))

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -2133,7 +2133,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 			(define body sql_trigger_body)
 		) (begin
 				(define compiled (compile_trigger_body schema timing (car (cdr body))))
-				(list 'createtrigger (list 'table schema tbl) name timing (car body) (list 'quote (list 'deferred_trigger compiled)) true)
+				(list 'createtrigger (list 'table schema tbl) name timing (car body) "sql" (list 'quote (list 'deferred_trigger compiled)) true)
 		))
 		/* DROP TRIGGER syntax */
 		(parser '((atom "DROP" true) (atom "TRIGGER" true) (define if_exists (? (atom "IF" true) (atom "EXISTS" true))) (define name sql_identifier))
@@ -2160,6 +2160,30 @@ arithmetic; leave expressions containing columns or functions untouched. */
 	)))
 	((parser (define command p) command "^(?:/\\*.*?\\*/|--[^\r\n]*[\r\n]|--[^\r\n]*$|[\r\n\t ]+)+") s)
 )))
+
+/* Trigger source belongs to its language frontend. Storage only persists the
+source and language name, then calls this registered compiler lazily. Keeping
+the SQL reconstruction here lets MemCP start without lib/sql-parser.scm when a
+different frontend (for example RDF) is used. */
+(define sql_trigger_quote_identifier (lambda (id)
+	(concat "`" (replace id "`" "``") "`")))
+(define sql_trigger_source_timing (lambda (timing)
+	(match timing
+		"before_insert" "BEFORE INSERT"
+		"after_insert" "AFTER INSERT"
+		"before_update" "BEFORE UPDATE"
+		"after_update" "AFTER UPDATE"
+		"before_delete" "BEFORE DELETE"
+		"after_delete" "AFTER DELETE"
+		_ (error (concat "unsupported SQL trigger timing " timing)))))
+(define sql_trigger_source_compile (lambda (source context) (begin
+	(define sql (concat
+		"CREATE TRIGGER " (sql_trigger_quote_identifier (context "name")) " "
+		(sql_trigger_source_timing (context "timing")) " ON "
+		(sql_trigger_quote_identifier (context "table")) " FOR EACH ROW " source))
+	(define plan (parse_sql (context "schema") sql (lambda (schema read write) true) nil nil))
+	(nth plan 6))))
+(registertriggerlanguage "sql" sql_trigger_source_compile)
 
 (define load_sql (lambda (schema stream) (begin
 	(set state (newsession))

--- a/storage/database.go
+++ b/storage/database.go
@@ -556,51 +556,6 @@ func (db *database) ensureLoaded() {
 	})
 }
 
-func triggerTimingSQL(timing TriggerTiming) string {
-	switch timing {
-	case BeforeInsert:
-		return "BEFORE INSERT"
-	case AfterInsert:
-		return "AFTER INSERT"
-	case BeforeUpdate:
-		return "BEFORE UPDATE"
-	case AfterUpdate:
-		return "AFTER UPDATE"
-	case BeforeDelete:
-		return "BEFORE DELETE"
-	case AfterDelete:
-		return "AFTER DELETE"
-	case AfterDropTable:
-		return "AFTER DROP TABLE"
-	case AfterDropColumn:
-		return "AFTER DROP COLUMN"
-	case AfterInvalidate:
-		return "AFTER INVALIDATE"
-	case AfterCreateTable:
-		return "AFTER CREATE TABLE"
-	default:
-		panic("unknown trigger timing")
-	}
-}
-
-func loadPersistedTriggerPlan(schemaName, tableName string, trigger *TriggerDescription) {
-	if !triggerScmerMissing(trigger.Func) || !triggerScmerMissing(trigger.FuncPlan) || trigger.SourceSQL == "" {
-		return
-	}
-	parseSQL := scm.Globalenv.Vars[scm.Symbol("parse_sql")]
-	allow := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
-	sql := fmt.Sprintf("CREATE TRIGGER `%s` %s ON `%s` FOR EACH ROW %s", trigger.Name, triggerTimingSQL(trigger.Timing), tableName, trigger.SourceSQL)
-	plan := scm.Apply(parseSQL, scm.NewString(schemaName), scm.NewString(sql), allow)
-	if !plan.IsSlice() {
-		panic("persisted trigger parse did not return an AST")
-	}
-	items := plan.Slice()
-	if len(items) < 6 {
-		panic("persisted trigger AST is incomplete")
-	}
-	trigger.Func, trigger.FuncPlan = unwrapDeferredTriggerBody(items[5])
-}
-
 // SharedResource impl for database
 func (db *database) GetState() SharedState { return db.srState }
 func (db *database) GetRead() func()       { db.ensureLoaded(); return func() {} }

--- a/storage/database.go
+++ b/storage/database.go
@@ -539,8 +539,10 @@ func (db *database) ensureLoaded() {
 			t.initializeLegacyPlannerRowEstimate()
 			t.publishShowColumnsSnapshot()
 		}
-		// FK enforcement triggers are serializable Procs and persist with the table JSON.
-		// No re-installation needed on load.
+		// FK declarations are authoritative, while their system triggers are
+		// generated code. Rebuild that code at the persistence boundary so schema
+		// files written by older binaries cannot retain an obsolete builtin ABI.
+		rebuildFKTriggersAfterLoad(db)
 		db.srState = SHARED
 		// Dot-prefixed cache tables are planner-owned and persisted only so a
 		// warm query cache can survive restart. Re-register their table-level

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bufio"
+	"encoding/json"
 	"os"
 	"strconv"
 	"strings"
@@ -57,25 +58,71 @@ type SettingsT struct {
 }
 
 type CreateTableTriggerRegistration struct {
-	Schema    string    `json:"schema"`
-	Table     string    `json:"table"`
-	Name      string    `json:"name"`
-	SourceSQL string    `json:"source_sql,omitempty"`
-	Hidden    bool      `json:"hidden,omitempty"`
-	Priority  int       `json:"priority,omitempty"`
-	Async     bool      `json:"async,omitempty"`
-	Func      scm.Scmer `json:"func"`
+	Schema   string
+	Table    string
+	Name     string
+	Source   string
+	Language string
+	Hidden   bool
+	Priority int
+	Async    bool
+	Func     scm.Scmer
+}
+
+type persistedCreateTableTriggerRegistration struct {
+	Schema          string     `json:"schema"`
+	Table           string     `json:"table"`
+	Name            string     `json:"name"`
+	Source          string     `json:"source,omitempty"`
+	Language        string     `json:"language,omitempty"`
+	LegacySourceSQL string     `json:"source_sql,omitempty"`
+	Hidden          bool       `json:"hidden,omitempty"`
+	Priority        int        `json:"priority,omitempty"`
+	Async           bool       `json:"async,omitempty"`
+	Func            *scm.Scmer `json:"func,omitempty"`
+}
+
+func (r CreateTableTriggerRegistration) MarshalJSON() ([]byte, error) {
+	persist := persistedCreateTableTriggerRegistration{
+		Schema: r.Schema, Table: r.Table, Name: r.Name,
+		Source: r.Source, Language: r.Language,
+		Hidden: r.Hidden, Priority: r.Priority, Async: r.Async,
+	}
+	if r.Language == "" {
+		fn := r.Func
+		persist.Func = &fn
+	}
+	return json.Marshal(persist)
+}
+
+func (r *CreateTableTriggerRegistration) UnmarshalJSON(data []byte) error {
+	var persist persistedCreateTableTriggerRegistration
+	if err := json.Unmarshal(data, &persist); err != nil {
+		return err
+	}
+	r.Schema, r.Table, r.Name = persist.Schema, persist.Table, persist.Name
+	r.Source, r.Language = persist.Source, persist.Language
+	if r.Source == "" && persist.LegacySourceSQL != "" {
+		r.Source, r.Language = persist.LegacySourceSQL, "sql"
+	}
+	r.Hidden, r.Priority, r.Async = persist.Hidden, persist.Priority, persist.Async
+	r.Func = scm.NewNil()
+	if persist.Func != nil {
+		r.Func = *persist.Func
+	}
+	return nil
 }
 
 func (r CreateTableTriggerRegistration) triggerDescription() TriggerDescription {
 	return TriggerDescription{
-		Name:      r.Name,
-		Timing:    AfterCreateTable,
-		Func:      r.Func,
-		SourceSQL: r.SourceSQL,
-		Hidden:    r.Hidden,
-		Priority:  r.Priority,
-		Async:     r.Async,
+		Name:     r.Name,
+		Timing:   AfterCreateTable,
+		Func:     r.Func,
+		Source:   r.Source,
+		Language: r.Language,
+		Hidden:   r.Hidden,
+		Priority: r.Priority,
+		Async:    r.Async,
 	}
 }
 

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -308,6 +308,7 @@ func TestRegisteredCreateTableTriggerRunsOnCreate(t *testing.T) {
 		scm.NewString(".hook"),
 		scm.NewString("seed"),
 		scm.NewString(""),
+		scm.NewString(""),
 		body,
 		scm.NewBool(false),
 	)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3518,11 +3518,15 @@ func Init(en scm.Env) {
 					if !tr.Func.IsNil() {
 						funcStr = scm.String(tr.Func)
 					}
+					statement := ""
+					if tr.Language == "sql" {
+						statement = tr.Source
+					}
 					rows = append(rows, scm.NewSlice([]scm.Scmer{
 						scm.NewString("Trigger"), scm.NewString(tr.Name),
 						scm.NewString("Event"), scm.NewString(event),
 						scm.NewString("Table"), scm.NewString(t.Name),
-						scm.NewString("Statement"), scm.NewString(tr.SourceSQL),
+						scm.NewString("Statement"), scm.NewString(statement),
 						scm.NewString("Timing"), scm.NewString(timing),
 						scm.NewString("Created"), scm.NewNil(),
 						scm.NewString("sql_mode"), scm.NewString(""),
@@ -3655,33 +3659,53 @@ func Init(en scm.Env) {
 
 	// Trigger management
 	scm.Declare(&en, &scm.Declaration{
+		Name: "registertriggerlanguage",
+
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			registerTriggerLanguage(scm.String(a[0]), a[1])
+			return scm.NewBool(true)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "registers or replaces a process-local compiler for persistent trigger source; compiler is called as (source context)", HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "language", Description: "persistent trigger language identifier"},
+				{Kind: "func", Label: "compiler", Description: "compile lambda accepting source and an assoc context"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "bool"},
+		},
+	})
+	scm.Declare(&en, &scm.Declaration{
 		Name: "createcreatetabletrigger",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			body, deferredPlan := unwrapDeferredTriggerBody(a[4])
+			if (scm.String(a[3]) == "") != (scm.String(a[4]) == "") {
+				panic("trigger source and language must either both be set or both be empty")
+			}
+			body, deferredPlan := unwrapDeferredTriggerBody(a[5])
 			if triggerScmerMissing(body) && !triggerScmerMissing(deferredPlan) {
 				body = scm.Eval(deferredPlan, &scm.Globalenv)
 			}
-			if triggerScmerMissing(body) {
+			if triggerScmerMissing(body) && scm.String(a[4]) == "" {
 				panic("create-table trigger body must not be empty")
 			}
 			trigger := TriggerDescription{
-				Name:      scm.String(a[2]),
-				Timing:    AfterCreateTable,
-				Func:      body,
-				SourceSQL: scm.String(a[3]),
-				Hidden:    !scm.ToBool(a[5]),
+				Name:     scm.String(a[2]),
+				Timing:   AfterCreateTable,
+				Func:     body,
+				Source:   scm.String(a[3]),
+				Language: scm.String(a[4]),
+				Hidden:   !scm.ToBool(a[6]),
 			}
 			finalizeTriggerCompilation(&trigger)
 			registerCreateTableTrigger(CreateTableTriggerRegistration{
-				Schema:    scm.String(a[0]),
-				Table:     scm.String(a[1]),
-				Name:      trigger.Name,
-				SourceSQL: trigger.SourceSQL,
-				Hidden:    trigger.Hidden,
-				Priority:  trigger.Priority,
-				Async:     trigger.Async,
-				Func:      trigger.Func,
+				Schema:   scm.String(a[0]),
+				Table:    scm.String(a[1]),
+				Name:     trigger.Name,
+				Source:   trigger.Source,
+				Language: trigger.Language,
+				Hidden:   trigger.Hidden,
+				Priority: trigger.Priority,
+				Async:    trigger.Async,
+				Func:     trigger.Func,
 			})
 			return scm.NewBool(true)
 		},
@@ -3690,7 +3714,8 @@ func Init(en scm.Env) {
 				{Kind: "string", Label: "schema", Description: "name of the database"},
 				{Kind: "string", Label: "table", Description: "name of the table to watch for creation"},
 				{Kind: "string", Label: "name", Description: "name of the trigger"},
-				{Kind: "string", Label: "source_sql", Description: "original SQL body text (for diagnostics)"},
+				{Kind: "string", Label: "source", Description: "authoritative trigger source, or empty for compiled internal triggers"},
+				{Kind: "string", Label: "language", Description: "registered source language, or empty when body is the durable definition"},
 				{Kind: "any", Label: "body", Description: "trigger body (Scheme procedure or deferred trigger expression)"},
 				{Kind: "bool", Label: "visible", Description: "true = user trigger, false = internal trigger"},
 			},
@@ -3755,21 +3780,26 @@ func Init(en scm.Env) {
 				panic("invalid trigger timing: " + timingStr)
 			}
 
-			sourceSQL := scm.String(a[3])
-			body, deferredPlan := unwrapDeferredTriggerBody(a[4])
-			visible := scm.ToBool(a[5])
+			source := scm.String(a[3])
+			language := scm.String(a[4])
+			if (source == "") != (language == "") {
+				panic("trigger source and language must either both be set or both be empty")
+			}
+			body, deferredPlan := unwrapDeferredTriggerBody(a[5])
+			visible := scm.ToBool(a[6])
 			if visible {
 				requireTableMaintenance(db.Name, t.Name, maintenanceAlter)
 			}
 
 			trigger := TriggerDescription{
-				Name:      name,
-				Timing:    timing,
-				Func:      body,
-				FuncPlan:  deferredPlan,
-				SourceSQL: sourceSQL,
-				Hidden:    !visible,
-				Priority:  0,
+				Name:     name,
+				Timing:   timing,
+				Func:     body,
+				FuncPlan: deferredPlan,
+				Source:   source,
+				Language: language,
+				Hidden:   !visible,
+				Priority: 0,
 			}
 			t.ddlMu.Lock()
 			defer t.ddlMu.Unlock()
@@ -3785,7 +3815,8 @@ func Init(en scm.Env) {
 				{Kind: "table", Label: "table"},
 				{Kind: "string", Label: "name", Description: "name of the trigger"},
 				{Kind: "string", Label: "timing", Description: "one of: before_insert, after_insert, before_update, after_update, before_delete, after_delete"},
-				{Kind: "string", Label: "source_sql", Description: "original SQL body text (for SHOW TRIGGERS)"},
+				{Kind: "string", Label: "source", Description: "authoritative trigger source, or empty for compiled internal triggers"},
+				{Kind: "string", Label: "language", Description: "registered source language, or empty when body is the durable definition"},
 				{Kind: "any", Label: "body", Description: "trigger body (parsed Scheme expression)"},
 				{Kind: "bool", Label: "visible", Description: "true = user trigger (shown in SHOW TRIGGERS), false = internal trigger (hidden)"},
 			},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4068,23 +4068,12 @@ func fkCascadeUpdate(currentTx *TxContext, childTbl *table, cols []string, oldVa
 }
 
 // initFKBuiltins declares the FK enforcement builtins used by trigger Procs.
-func fkTriggerTxArg(args []scm.Scmer, index int) *TxContext {
-	// FK triggers are persisted as compiled Scheme procedures. Releases before
-	// explicit transaction propagation emitted these builtin calls without the
-	// final tx argument, so that argument is part of a backward-compatible ABI.
-	// New triggers pass it; old triggers retain their original nil-tx behavior.
-	if len(args) <= index {
-		return nil
-	}
-	return scmerToTxContext(args[index])
-}
-
 func initFKBuiltins(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "__fk_check_ref",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := fkTriggerTxArg(a, 5)
+			currentTx := scmerToTxContext(a[5])
 			schema := scm.String(a[0])
 			parentTable := scm.String(a[1])
 			parentCols := scmerSliceToStrings(mustScmerSlice(a[2], "parent_cols"))
@@ -4116,7 +4105,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "parent_cols", Description: "parent column names"},
 				{Kind: "list", Label: "values", Description: "FK values to check"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -4127,7 +4116,7 @@ func initFKBuiltins(en scm.Env) {
 		Name: "__fk_on_parent_delete",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := fkTriggerTxArg(a, 6)
+			currentTx := scmerToTxContext(a[6])
 			schema := scm.String(a[0])
 			childTable := scm.String(a[1])
 			childCols := scmerSliceToStrings(mustScmerSlice(a[2], "child_cols"))
@@ -4163,7 +4152,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "parent_vals", Description: "old parent PK values"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
 				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -4174,7 +4163,7 @@ func initFKBuiltins(en scm.Env) {
 		Name: "__fk_on_parent_update",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := fkTriggerTxArg(a, 7)
+			currentTx := scmerToTxContext(a[7])
 			schema := scm.String(a[0])
 			childTable := scm.String(a[1])
 			childCols := scmerSliceToStrings(mustScmerSlice(a[2], "child_cols"))
@@ -4224,7 +4213,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "new_vals", Description: "new parent PK values"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
 				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -4371,6 +4360,43 @@ func installFKTriggers(db *database, t1, t2 *table, fk foreignKey) {
 			scm.NewSymbol("NEW"),
 		})),
 	})
+}
+
+// rebuildFKTriggersAfterLoad replaces persisted FK implementation details with
+// the canonical trigger programs emitted by this binary. Foreign-key metadata
+// is authoritative; its system triggers are derived code and must not retain an
+// obsolete builtin ABI forever merely because schema.json contains an older
+// compiled Proc. User triggers are untouched because only names owned by an
+// actual foreign-key declaration are replaced.
+func rebuildFKTriggersAfterLoad(db *database) {
+	seen := make(map[string]struct{})
+	for _, child := range db.tables.GetAll() {
+		for _, fk := range child.Foreign {
+			if fk.Tbl1 != child.Name {
+				continue
+			}
+			key := fk.Tbl1 + "\x00" + fk.Tbl2 + "\x00" + fk.Id
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+
+			parent := db.tables.Get(fk.Tbl2)
+			if parent == nil {
+				continue
+			}
+			prefix := "__fk_" + fk.Id + "_"
+			for child.RemoveTrigger(prefix + "child_insert") {
+			}
+			for child.RemoveTrigger(prefix + "child_update") {
+			}
+			for parent.RemoveTrigger(prefix + "parent_delete") {
+			}
+			for parent.RemoveTrigger(prefix + "parent_update") {
+			}
+			installFKTriggers(db, child, parent, fk)
+		}
+	}
 }
 
 // showEngineStr returns the engine name string for a table (matches dashboard dropdown values).

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4068,12 +4068,23 @@ func fkCascadeUpdate(currentTx *TxContext, childTbl *table, cols []string, oldVa
 }
 
 // initFKBuiltins declares the FK enforcement builtins used by trigger Procs.
+func fkTriggerTxArg(args []scm.Scmer, index int) *TxContext {
+	// FK triggers are persisted as compiled Scheme procedures. Releases before
+	// explicit transaction propagation emitted these builtin calls without the
+	// final tx argument, so that argument is part of a backward-compatible ABI.
+	// New triggers pass it; old triggers retain their original nil-tx behavior.
+	if len(args) <= index {
+		return nil
+	}
+	return scmerToTxContext(args[index])
+}
+
 func initFKBuiltins(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "__fk_check_ref",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := scmerToTxContext(a[5])
+			currentTx := fkTriggerTxArg(a, 5)
 			schema := scm.String(a[0])
 			parentTable := scm.String(a[1])
 			parentCols := scmerSliceToStrings(mustScmerSlice(a[2], "parent_cols"))
@@ -4105,7 +4116,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "parent_cols", Description: "parent column names"},
 				{Kind: "list", Label: "values", Description: "FK values to check"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -4116,7 +4127,7 @@ func initFKBuiltins(en scm.Env) {
 		Name: "__fk_on_parent_delete",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := scmerToTxContext(a[6])
+			currentTx := fkTriggerTxArg(a, 6)
 			schema := scm.String(a[0])
 			childTable := scm.String(a[1])
 			childCols := scmerSliceToStrings(mustScmerSlice(a[2], "child_cols"))
@@ -4152,7 +4163,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "parent_vals", Description: "old parent PK values"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
 				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,
@@ -4163,7 +4174,7 @@ func initFKBuiltins(en scm.Env) {
 		Name: "__fk_on_parent_update",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			currentTx := scmerToTxContext(a[7])
+			currentTx := fkTriggerTxArg(a, 7)
 			schema := scm.String(a[0])
 			childTable := scm.String(a[1])
 			childCols := scmerSliceToStrings(mustScmerSlice(a[2], "child_cols"))
@@ -4213,7 +4224,7 @@ func initFKBuiltins(en scm.Env) {
 				{Kind: "list", Label: "new_vals", Description: "new parent PK values"},
 				{Kind: "string", Label: "fk_id", Description: "FK constraint name"},
 				{Kind: "string", Label: "mode", Description: "RESTRICT, CASCADE, or SETNULL"},
-				{Kind: "any", Label: "tx", Description: "explicit transaction context"},
+				{Kind: "any", Label: "tx", Description: "explicit transaction context", Optional: true},
 			},
 			Return:    &scm.TypeDescriptor{Kind: "nil"},
 			Forbidden: true,

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -16,12 +16,16 @@ Copyright (C) 2025, 2026  Carl-Philip Hänsch
 */
 package storage
 
-import "fmt"
-import "errors"
-import "sync/atomic"
-import "encoding/json"
-import "strings"
-import "github.com/launix-de/memcp/scm"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/launix-de/memcp/scm"
+)
 
 // TriggerTiming defines when a trigger fires
 type TriggerTiming uint8
@@ -66,33 +70,38 @@ func (tt TriggerTiming) String() string {
 	}
 }
 
-func (tt TriggerTiming) MarshalJSON() ([]byte, error) {
-	var s string
+func (tt TriggerTiming) sourceName() string {
 	switch tt {
 	case BeforeInsert:
-		s = "before_insert"
+		return "before_insert"
 	case AfterInsert:
-		s = "after_insert"
+		return "after_insert"
 	case BeforeUpdate:
-		s = "before_update"
+		return "before_update"
 	case AfterUpdate:
-		s = "after_update"
+		return "after_update"
 	case BeforeDelete:
-		s = "before_delete"
+		return "before_delete"
 	case AfterDelete:
-		s = "after_delete"
+		return "after_delete"
 	case AfterDropTable:
-		s = "after_drop_table"
+		return "after_drop_table"
 	case AfterDropColumn:
-		s = "after_drop_column"
+		return "after_drop_column"
 	case AfterInvalidate:
-		s = "after_invalidate"
+		return "after_invalidate"
 	case AfterCreateTable:
-		s = "after_create_table"
+		return "after_create_table"
 	default:
+		panic("unknown trigger timing")
+	}
+}
+
+func (tt TriggerTiming) MarshalJSON() ([]byte, error) {
+	if tt > AfterCreateTable {
 		return nil, errors.New("unknown trigger timing")
 	}
-	return json.Marshal(s)
+	return json.Marshal(tt.sourceName())
 }
 
 func (tt *TriggerTiming) UnmarshalJSON(data []byte) error {
@@ -139,18 +148,19 @@ func (tt *TriggerTiming) UnmarshalJSON(data []byte) error {
 
 // TriggerDescription holds all information about a trigger
 type TriggerDescription struct {
-	Name       string                `json:"name"`                 // Trigger name (user-defined or auto-generated)
-	Timing     TriggerTiming         `json:"timing"`               // BEFORE/AFTER INSERT/UPDATE/DELETE
-	Func       scm.Scmer             `json:"func"`                 // The trigger function (compiled Scheme procedure)
-	FuncPlan   scm.Scmer             `json:"-"`                    // Unevaluated lambda AST for SQL triggers; compiled lazily on first use
-	SourceSQL  string                `json:"source_sql,omitempty"` // Original SQL body text (for SHOW TRIGGERS)
-	IsSystem   bool                  `json:"is_system,omitempty"`  // True for Go-internal triggers (FK etc.) — not persisted via createtrigger
-	Hidden     bool                  `json:"hidden,omitempty"`     // True for Scheme-internal triggers — persisted but hidden from SHOW TRIGGERS
-	Priority   int                   `json:"priority,omitempty"`   // Execution order (lower = earlier)
-	Async      bool                  `json:"async,omitempty"`      // Run trigger in background goroutine (fire-and-forget, no transaction context)
-	VectorFunc scm.Scmer             `json:"-"`                    // Vectorized trigger: (lambda (OLD_batch NEW_batch) ...) for batch execution
-	Acquire    func(*TxContext) bool `json:"-"`                    // Optional lock-free pin for an ephemeral trigger target
-	Release    func()                `json:"-"`                    // Releases a successful Acquire
+	Name       string                `json:"name"`                // Trigger name (user-defined or auto-generated)
+	Timing     TriggerTiming         `json:"timing"`              // BEFORE/AFTER INSERT/UPDATE/DELETE
+	Func       scm.Scmer             `json:"func"`                // The compiled trigger procedure; omitted when source is authoritative
+	FuncPlan   scm.Scmer             `json:"-"`                   // Unevaluated lambda AST, compiled lazily on first use
+	Source     string                `json:"source,omitempty"`    // Authoritative source code for persistent language-defined triggers
+	Language   string                `json:"language,omitempty"`  // Name resolved through the process-local trigger compiler registry
+	IsSystem   bool                  `json:"is_system,omitempty"` // True for Go-internal triggers (FK etc.) — not persisted via createtrigger
+	Hidden     bool                  `json:"hidden,omitempty"`    // True for Scheme-internal triggers — persisted but hidden from SHOW TRIGGERS
+	Priority   int                   `json:"priority,omitempty"`  // Execution order (lower = earlier)
+	Async      bool                  `json:"async,omitempty"`     // Run trigger in background goroutine (fire-and-forget, no transaction context)
+	VectorFunc scm.Scmer             `json:"-"`                   // Vectorized trigger: (lambda (OLD_batch NEW_batch) ...) for batch execution
+	Acquire    func(*TxContext) bool `json:"-"`                   // Optional lock-free pin for an ephemeral trigger target
+	Release    func()                `json:"-"`                   // Releases a successful Acquire
 }
 
 func acquireCacheUse(users *int64) bool {
@@ -208,31 +218,36 @@ func (tr TriggerDescription) releaseTarget() {
 }
 
 type persistedTriggerDescription struct {
-	Name           string        `json:"name"`
-	Timing         TriggerTiming `json:"timing"`
-	Func           *scm.Scmer    `json:"func,omitempty"`
-	SourceSQL      string        `json:"source_sql,omitempty"`
-	IsSystem       bool          `json:"is_system,omitempty"`
-	Hidden         bool          `json:"hidden,omitempty"`
-	Priority       int           `json:"priority,omitempty"`
-	Async          bool          `json:"async,omitempty"`
-	RequiresTarget bool          `json:"requires_target,omitempty"`
+	Name            string        `json:"name"`
+	Timing          TriggerTiming `json:"timing"`
+	Func            *scm.Scmer    `json:"func,omitempty"`
+	Source          string        `json:"source,omitempty"`
+	Language        string        `json:"language,omitempty"`
+	LegacySourceSQL string        `json:"source_sql,omitempty"`
+	IsSystem        bool          `json:"is_system,omitempty"`
+	Hidden          bool          `json:"hidden,omitempty"`
+	Priority        int           `json:"priority,omitempty"`
+	Async           bool          `json:"async,omitempty"`
+	RequiresTarget  bool          `json:"requires_target,omitempty"`
 }
 
 func (tr TriggerDescription) MarshalJSON() ([]byte, error) {
 	persist := persistedTriggerDescription{
 		Name:           tr.Name,
 		Timing:         tr.Timing,
-		SourceSQL:      tr.SourceSQL,
+		Source:         tr.Source,
+		Language:       tr.Language,
 		IsSystem:       tr.IsSystem,
 		Hidden:         tr.Hidden,
 		Priority:       tr.Priority,
 		Async:          tr.Async,
 		RequiresTarget: tr.Acquire != nil,
 	}
-	// SQL triggers can be restored from source_sql on load; persisting the
-	// compiled Scheme AST would bloat schema.json dramatically.
-	if tr.SourceSQL == "" {
+	// Source plus language is the durable definition. Compiled Scheme is a
+	// process-local artifact and is persisted only for legacy/internal triggers
+	// without source. FK callbacks are generated from FK metadata instead.
+	regeneratedFK := tr.IsSystem && strings.HasPrefix(tr.Name, "__fk_")
+	if tr.Language == "" && !regeneratedFK {
 		fn := tr.Func
 		persist.Func = &fn
 	}
@@ -246,7 +261,15 @@ func (tr *TriggerDescription) UnmarshalJSON(data []byte) error {
 	}
 	tr.Name = persist.Name
 	tr.Timing = persist.Timing
-	tr.SourceSQL = persist.SourceSQL
+	tr.Source = persist.Source
+	tr.Language = persist.Language
+	// Schemas written before trigger-language registration stored SQL source in
+	// source_sql. Import it into the generic representation; new saves emit only
+	// source and language.
+	if tr.Source == "" && persist.LegacySourceSQL != "" {
+		tr.Source = persist.LegacySourceSQL
+		tr.Language = "sql"
+	}
 	tr.IsSystem = persist.IsSystem
 	tr.Hidden = persist.Hidden
 	tr.Priority = persist.Priority
@@ -282,6 +305,55 @@ func triggerScmerMissing(v scm.Scmer) bool {
 	return v.IsNil()
 }
 
+var triggerLanguageCompilers = struct {
+	sync.RWMutex
+	byName map[string]scm.Scmer
+}{byName: make(map[string]scm.Scmer)}
+
+func registerTriggerLanguage(language string, compiler scm.Scmer) {
+	if language == "" {
+		panic("trigger language must not be empty")
+	}
+	if compiler.IsNil() {
+		panic("trigger language compiler must not be empty")
+	}
+	triggerLanguageCompilers.Lock()
+	triggerLanguageCompilers.byName[language] = compiler
+	triggerLanguageCompilers.Unlock()
+}
+
+func triggerLanguageCompiler(language string) (scm.Scmer, bool) {
+	triggerLanguageCompilers.RLock()
+	compiler, ok := triggerLanguageCompilers.byName[language]
+	triggerLanguageCompilers.RUnlock()
+	return compiler, ok
+}
+
+func triggerCompilerContext(schemaName, tableName string, trigger *TriggerDescription) scm.Scmer {
+	context := scm.NewFastDictValue(5)
+	context.Set(scm.NewString("schema"), scm.NewString(schemaName), nil)
+	context.Set(scm.NewString("table"), scm.NewString(tableName), nil)
+	context.Set(scm.NewString("name"), scm.NewString(trigger.Name), nil)
+	context.Set(scm.NewString("timing"), scm.NewString(trigger.Timing.sourceName()), nil)
+	context.Set(scm.NewString("hidden"), scm.NewBool(trigger.Hidden), nil)
+	return scm.NewFastDict(context)
+}
+
+func loadPersistedTriggerPlan(schemaName, tableName string, trigger *TriggerDescription) {
+	if !triggerScmerMissing(trigger.Func) || !triggerScmerMissing(trigger.FuncPlan) || trigger.Language == "" {
+		return
+	}
+	compiler, ok := triggerLanguageCompiler(trigger.Language)
+	if !ok {
+		panic(fmt.Sprintf("trigger %s.%s:%s requires unregistered language %q", schemaName, tableName, trigger.Name, trigger.Language))
+	}
+	compiled := scm.Apply(compiler, scm.NewString(trigger.Source), triggerCompilerContext(schemaName, tableName, trigger))
+	trigger.Func, trigger.FuncPlan = unwrapDeferredTriggerBody(compiled)
+	if triggerScmerMissing(trigger.Func) && triggerScmerMissing(trigger.FuncPlan) {
+		panic(fmt.Sprintf("trigger language %q returned an empty trigger for %s.%s:%s", trigger.Language, schemaName, tableName, trigger.Name))
+	}
+}
+
 func unwrapDeferredTriggerBody(body scm.Scmer) (scm.Scmer, scm.Scmer) {
 	if !body.IsSlice() {
 		return body, scm.NewNil()
@@ -300,7 +372,7 @@ func finalizeTriggerCompilation(trigger *TriggerDescription) {
 	if triggerScmerMissing(trigger.Func) {
 		return
 	}
-	if (trigger.IsSystem || trigger.Hidden || trigger.SourceSQL == "") && trigger.VectorFunc.IsNil() {
+	if (trigger.IsSystem || trigger.Hidden || trigger.Language == "") && trigger.VectorFunc.IsNil() {
 		if vf := VectorizeTrigger(trigger.Func); !vf.IsNil() {
 			trigger.VectorFunc = vf
 		}
@@ -340,7 +412,7 @@ func (t *table) GetTriggers(timing TriggerTiming) []TriggerDescription {
 			continue
 		}
 		result = append(result, tr)
-		if triggerScmerMissing(tr.Func) && (!triggerScmerMissing(tr.FuncPlan) || tr.SourceSQL != "") {
+		if triggerScmerMissing(tr.Func) && (!triggerScmerMissing(tr.FuncPlan) || tr.Language != "") {
 			lazy = append(lazy, lazyTrigger{triggerIndex: i, resultIndex: len(result) - 1})
 		}
 	}
@@ -778,7 +850,7 @@ func executeRegisteredCreateTableTriggers(t *table, tx *TxContext) {
 	session := txSessionScmer(tx)
 	for _, reg := range registrations {
 		trigger := reg.triggerDescription()
-		finalizeTriggerCompilation(&trigger)
+		compileTriggerForUse(t.schema.Name, t.Name, &trigger)
 		if triggerScmerMissing(trigger.Func) {
 			continue
 		}

--- a/storage/trigger_lock_order_test.go
+++ b/storage/trigger_lock_order_test.go
@@ -23,7 +23,97 @@ import (
 	"time"
 
 	"github.com/launix-de/NonLockingReadMap"
+	"github.com/launix-de/memcp/scm"
 )
+
+func TestForeignKeyTriggerPersistenceOmitsRegenerableProc(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:     "__fk_example_child_insert",
+		Timing:   BeforeInsert,
+		Func:     scm.NewBool(true),
+		IsSystem: true,
+	}
+	encoded, err := json.Marshal(trigger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, persisted := fields["func"]; persisted {
+		t.Fatalf("regenerable FK trigger persisted compiled Scheme code: %s", encoded)
+	}
+}
+
+func TestNonRegenerableInternalTriggerPersistenceKeepsProc(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:     ".internal_example",
+		Timing:   BeforeInsert,
+		Func:     scm.NewBool(true),
+		IsSystem: true,
+	}
+	encoded, err := json.Marshal(trigger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, persisted := fields["func"]; !persisted {
+		t.Fatalf("non-regenerable internal trigger lost compiled Scheme code: %s", encoded)
+	}
+}
+
+func TestLanguageTriggerPersistenceKeepsOnlySourceDefinition(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:     "source_defined",
+		Timing:   BeforeInsert,
+		Func:     scm.NewBool(true),
+		Source:   "trigger source",
+		Language: "example",
+	}
+	encoded, err := json.Marshal(trigger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, persisted := fields["func"]; persisted {
+		t.Fatalf("source-defined trigger persisted compiled Scheme code: %s", encoded)
+	}
+	if string(fields["source"]) != `"trigger source"` || string(fields["language"]) != `"example"` {
+		t.Fatalf("source-defined trigger lost its generic definition: %s", encoded)
+	}
+}
+
+func TestLegacySQLTriggerSourceImportsIntoLanguageDefinition(t *testing.T) {
+	encoded := []byte(`{"name":"legacy","timing":"before_insert","source_sql":"SET NEW.value = 1"}`)
+	var trigger TriggerDescription
+	if err := json.Unmarshal(encoded, &trigger); err != nil {
+		t.Fatal(err)
+	}
+	if trigger.Source != "SET NEW.value = 1" || trigger.Language != "sql" {
+		t.Fatalf("legacy SQL source imported as source=%q language=%q", trigger.Source, trigger.Language)
+	}
+	upgraded, err := json.Marshal(trigger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(upgraded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if _, legacy := fields["source_sql"]; legacy {
+		t.Fatalf("upgraded trigger retained legacy source_sql field: %s", upgraded)
+	}
+	if string(fields["language"]) != `"sql"` {
+		t.Fatalf("upgraded trigger did not persist SQL language: %s", upgraded)
+	}
+}
 
 func TestPersistedKeytableTriggerWaitsForRuntimeTarget(t *testing.T) {
 	original := TriggerDescription{

--- a/tests/sql/compatibility/fk-trigger-upgrade.yaml
+++ b/tests/sql/compatibility/fk-trigger-upgrade.yaml
@@ -1,0 +1,81 @@
+# Copyright (C) 2026 Launix GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+metadata:
+  version: "1.0"
+  description: "Backward-compatible FK trigger execution after upgrading persisted schemas"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS fk_upgrade_child"
+  - sql: "DROP TABLE IF EXISTS fk_upgrade_parent"
+  - sql: "CREATE TABLE fk_upgrade_parent (id INT PRIMARY KEY, label VARCHAR(40))"
+  - sql: "CREATE TABLE fk_upgrade_child (id INT PRIMARY KEY, title VARCHAR(40), payload TEXT, parent_id INT, created_at INT, omitted_value VARCHAR(40), CONSTRAINT fk_upgrade_ref FOREIGN KEY (parent_id) REFERENCES fk_upgrade_parent(id))"
+  - sql: "INSERT INTO fk_upgrade_parent (id, label) VALUES (7, 'available')"
+
+test_cases:
+  - name: "Install the five-argument FK trigger shape persisted by older releases"
+    scm: |
+      (createtrigger
+        (table "memcp-tests" "fk_upgrade_child")
+        "legacy_fk_child_insert"
+        "before_insert"
+        "legacy persisted FK trigger"
+        (lambda (OLD NEW session tx)
+          (begin
+            (__fk_check_ref
+              "memcp-tests"
+              "fk_upgrade_parent"
+              '("id")
+              (list (get_assoc NEW "parent_id"))
+              "fk_upgrade_ref")
+            NEW))
+        false)
+    expect:
+      data: [true]
+
+  - name: "Partial upload-shaped insert works through a legacy FK trigger"
+    sql: "INSERT INTO fk_upgrade_child (id, title, payload, parent_id, created_at) VALUES (1, 'upload', 'contents', 7, 1234)"
+    expect:
+      affected_rows: 1
+
+  - name: "Persisted legacy FK check without transaction argument remains executable"
+    scm: |
+      (begin
+        (__fk_check_ref "memcp-tests" "fk_upgrade_parent" '("id") '(7) "fk_upgrade_ref")
+        true)
+    expect:
+      data: [true]
+
+  - name: "Persisted legacy parent-delete callback remains executable"
+    scm: |
+      (begin
+        (__fk_on_parent_delete "memcp-tests" "fk_upgrade_child" '("parent_id") '(999) "fk_upgrade_ref" "RESTRICT")
+        true)
+    expect:
+      data: [true]
+
+  - name: "Persisted legacy parent-update callback remains executable"
+    scm: |
+      (begin
+        (__fk_on_parent_update "memcp-tests" "fk_upgrade_child" '("parent_id") '(999) '(999) "fk_upgrade_ref" "RESTRICT")
+        true)
+    expect:
+      data: [true]
+
+  - name: "Partial upload-shaped row was stored with omitted column null"
+    sql: "SELECT id, title, parent_id, omitted_value FROM fk_upgrade_child WHERE id = 1"
+    expect:
+      rows: 1
+      data:
+        - id: 1
+          title: "upload"
+          parent_id: 7
+          omitted_value: null
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS fk_upgrade_child"
+  - sql: "DROP TABLE IF EXISTS fk_upgrade_parent"

--- a/tests/sql/compatibility/fk-trigger-upgrade.yaml
+++ b/tests/sql/compatibility/fk-trigger-upgrade.yaml
@@ -26,6 +26,7 @@ test_cases:
           "__fk_fk_upgrade_ref_child_insert"
           "before_insert"
           ""
+          ""
           (lambda (OLD NEW session tx)
             (begin
               (__fk_check_ref "memcp-tests" "fk_upgrade_parent" '("id") (list (get_assoc NEW "parent_id")) "fk_upgrade_ref")
@@ -35,6 +36,7 @@ test_cases:
           (table "memcp-tests" "fk_upgrade_child")
           "__fk_fk_upgrade_ref_child_update"
           "before_update"
+          ""
           ""
           (lambda (OLD NEW session tx)
             (begin
@@ -46,6 +48,7 @@ test_cases:
           "__fk_fk_upgrade_ref_parent_delete"
           "before_delete"
           ""
+          ""
           (lambda (OLD NEW session tx)
             (__fk_on_parent_delete "memcp-tests" "fk_upgrade_child" '("parent_id") (list (get_assoc OLD "id")) "fk_upgrade_ref" "CASCADE"))
           false)
@@ -53,6 +56,7 @@ test_cases:
           (table "memcp-tests" "fk_upgrade_parent")
           "__fk_fk_upgrade_ref_parent_update"
           "after_update"
+          ""
           ""
           (lambda (OLD NEW session tx)
             (__fk_on_parent_update "memcp-tests" "fk_upgrade_child" '("parent_id") (list (get_assoc OLD "id")) (list (get_assoc NEW "id")) "fk_upgrade_ref" "CASCADE"))
@@ -89,6 +93,14 @@ test_cases:
           parent_id: 10
           omitted_value: null
 
+  - name: "Force canonical regenerated triggers through a schema save"
+    sql: "CREATE TABLE fk_upgrade_save_marker (id INT PRIMARY KEY)"
+    expect: {}
+
+  - name: "Restart after saving FK triggers without compiled Scheme code"
+    sql: "SHUTDOWN"
+    restart_timeout: 300
+
   - name: "Loaded parent-delete trigger cascades"
     sql: "DELETE FROM fk_upgrade_parent WHERE id = 10"
     expect:
@@ -102,5 +114,6 @@ test_cases:
         - cnt: 0
 
 cleanup:
+  - sql: "DROP TABLE IF EXISTS fk_upgrade_save_marker"
   - sql: "DROP TABLE IF EXISTS fk_upgrade_child"
   - sql: "DROP TABLE IF EXISTS fk_upgrade_parent"

--- a/tests/sql/compatibility/fk-trigger-upgrade.yaml
+++ b/tests/sql/compatibility/fk-trigger-upgrade.yaml
@@ -7,74 +7,99 @@
 
 metadata:
   version: "1.0"
-  description: "Backward-compatible FK trigger execution after upgrading persisted schemas"
+  description: "Canonical FK trigger regeneration when loading schemas from older releases"
+  isolated: true
 
 setup:
   - sql: "DROP TABLE IF EXISTS fk_upgrade_child"
   - sql: "DROP TABLE IF EXISTS fk_upgrade_parent"
   - sql: "CREATE TABLE fk_upgrade_parent (id INT PRIMARY KEY, label VARCHAR(40))"
-  - sql: "CREATE TABLE fk_upgrade_child (id INT PRIMARY KEY, title VARCHAR(40), payload TEXT, parent_id INT, created_at INT, omitted_value VARCHAR(40), CONSTRAINT fk_upgrade_ref FOREIGN KEY (parent_id) REFERENCES fk_upgrade_parent(id))"
-  - sql: "INSERT INTO fk_upgrade_parent (id, label) VALUES (7, 'available')"
+  - sql: "CREATE TABLE fk_upgrade_child (id INT PRIMARY KEY, title VARCHAR(40), payload TEXT, parent_id INT, created_at INT, omitted_value VARCHAR(40), CONSTRAINT fk_upgrade_ref FOREIGN KEY (parent_id) REFERENCES fk_upgrade_parent(id) ON DELETE CASCADE ON UPDATE CASCADE)"
+  - sql: "INSERT INTO fk_upgrade_parent (id, label) VALUES (7, 'available'), (9, 'replacement')"
 
 test_cases:
-  - name: "Install the five-argument FK trigger shape persisted by older releases"
+  - name: "Persist every FK callback with the pre-transaction ABI"
     scm: |
-      (createtrigger
-        (table "memcp-tests" "fk_upgrade_child")
-        "legacy_fk_child_insert"
-        "before_insert"
-        "legacy persisted FK trigger"
-        (lambda (OLD NEW session tx)
-          (begin
-            (__fk_check_ref
-              "memcp-tests"
-              "fk_upgrade_parent"
-              '("id")
-              (list (get_assoc NEW "parent_id"))
-              "fk_upgrade_ref")
-            NEW))
-        false)
+      (begin
+        (createtrigger
+          (table "memcp-tests" "fk_upgrade_child")
+          "__fk_fk_upgrade_ref_child_insert"
+          "before_insert"
+          ""
+          (lambda (OLD NEW session tx)
+            (begin
+              (__fk_check_ref "memcp-tests" "fk_upgrade_parent" '("id") (list (get_assoc NEW "parent_id")) "fk_upgrade_ref")
+              NEW))
+          false)
+        (createtrigger
+          (table "memcp-tests" "fk_upgrade_child")
+          "__fk_fk_upgrade_ref_child_update"
+          "before_update"
+          ""
+          (lambda (OLD NEW session tx)
+            (begin
+              (__fk_check_ref "memcp-tests" "fk_upgrade_parent" '("id") (list (get_assoc NEW "parent_id")) "fk_upgrade_ref")
+              NEW))
+          false)
+        (createtrigger
+          (table "memcp-tests" "fk_upgrade_parent")
+          "__fk_fk_upgrade_ref_parent_delete"
+          "before_delete"
+          ""
+          (lambda (OLD NEW session tx)
+            (__fk_on_parent_delete "memcp-tests" "fk_upgrade_child" '("parent_id") (list (get_assoc OLD "id")) "fk_upgrade_ref" "CASCADE"))
+          false)
+        (createtrigger
+          (table "memcp-tests" "fk_upgrade_parent")
+          "__fk_fk_upgrade_ref_parent_update"
+          "after_update"
+          ""
+          (lambda (OLD NEW session tx)
+            (__fk_on_parent_update "memcp-tests" "fk_upgrade_child" '("parent_id") (list (get_assoc OLD "id")) (list (get_assoc NEW "id")) "fk_upgrade_ref" "CASCADE"))
+          false))
     expect:
       data: [true]
 
-  - name: "Partial upload-shaped insert works through a legacy FK trigger"
+  - name: "Restart with legacy compiled FK procedures on disk"
+    sql: "SHUTDOWN"
+    restart_timeout: 300
+
+  - name: "Partial upload-shaped insert works after load migration"
     sql: "INSERT INTO fk_upgrade_child (id, title, payload, parent_id, created_at) VALUES (1, 'upload', 'contents', 7, 1234)"
     expect:
       affected_rows: 1
 
-  - name: "Persisted legacy FK check without transaction argument remains executable"
-    scm: |
-      (begin
-        (__fk_check_ref "memcp-tests" "fk_upgrade_parent" '("id") '(7) "fk_upgrade_ref")
-        true)
+  - name: "Loaded child-update trigger validates the replacement parent"
+    sql: "UPDATE fk_upgrade_child SET parent_id = 9 WHERE id = 1"
     expect:
-      data: [true]
+      affected_rows: 1
 
-  - name: "Persisted legacy parent-delete callback remains executable"
-    scm: |
-      (begin
-        (__fk_on_parent_delete "memcp-tests" "fk_upgrade_child" '("parent_id") '(999) "fk_upgrade_ref" "RESTRICT")
-        true)
+  - name: "Loaded parent-update trigger cascades"
+    sql: "UPDATE fk_upgrade_parent SET id = 10 WHERE id = 9"
     expect:
-      data: [true]
+      affected_rows: 1
 
-  - name: "Persisted legacy parent-update callback remains executable"
-    scm: |
-      (begin
-        (__fk_on_parent_update "memcp-tests" "fk_upgrade_child" '("parent_id") '(999) '(999) "fk_upgrade_ref" "RESTRICT")
-        true)
-    expect:
-      data: [true]
-
-  - name: "Partial upload-shaped row was stored with omitted column null"
+  - name: "Partial row and update cascade are correct"
     sql: "SELECT id, title, parent_id, omitted_value FROM fk_upgrade_child WHERE id = 1"
     expect:
       rows: 1
       data:
         - id: 1
           title: "upload"
-          parent_id: 7
+          parent_id: 10
           omitted_value: null
+
+  - name: "Loaded parent-delete trigger cascades"
+    sql: "DELETE FROM fk_upgrade_parent WHERE id = 10"
+    expect:
+      affected_rows: 1
+
+  - name: "Delete cascade removed the uploaded child"
+    sql: "SELECT COUNT(*) AS cnt FROM fk_upgrade_child"
+    expect:
+      rows: 1
+      data:
+        - cnt: 0
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS fk_upgrade_child"

--- a/tests/sql/triggers/trigger-persistence.yaml
+++ b/tests/sql/triggers/trigger-persistence.yaml
@@ -18,6 +18,10 @@ cleanup:
     sql: "DROP TABLE IF EXISTS tp_customers"
   - action: "Drop trigger test table"
     sql: "DROP TABLE IF EXISTS tp_vals"
+  - action: "Drop Scheme trigger test table"
+    sql: "DROP TABLE IF EXISTS tp_scheme"
+  - action: "Drop unavailable language test table"
+    sql: "DROP TABLE IF EXISTS tp_unknown_language"
 
 test_cases:
   # ----------------------------------------------------------------
@@ -53,6 +57,22 @@ test_cases:
     expect:
       data:
         - val: 105
+
+  - name: "Create table for language-compiler persistence test"
+    sql: "CREATE TABLE tp_scheme (id INT PRIMARY KEY, val INT)"
+
+  - name: "Create source-defined Scheme trigger"
+    scm: |
+      (createtrigger
+        (table "memcp-tests" "tp_scheme")
+        "tp_scheme_add7"
+        "before_insert"
+        "(lambda (OLD NEW session tx) (set_assoc NEW \"val\" (+ (get_assoc NEW \"val\") 7)))"
+        "scheme"
+        (lambda (OLD NEW session tx) (set_assoc NEW "val" (+ (get_assoc NEW "val") 7)))
+        false)
+    expect:
+      data: [true]
 
   # ----------------------------------------------------------------
   # Part 2: prejoin incremental trigger persistence
@@ -151,6 +171,38 @@ test_cases:
       data:
         - val: 107
 
+  - name: "After restart: Scheme source is compiled by its registered language hook"
+    sql: "INSERT INTO tp_scheme VALUES (1, 5)"
+    expect:
+      affected_rows: 1
+
+  - name: "After restart: Scheme trigger result is correct"
+    sql: "SELECT val FROM tp_scheme WHERE id = 1"
+    expect:
+      data:
+        - val: 12
+
+  - name: "Create table for unavailable language test"
+    sql: "CREATE TABLE tp_unknown_language (id INT PRIMARY KEY)"
+
+  - name: "Persist trigger source whose frontend is not loaded"
+    scm: |
+      (createtrigger
+        (table "memcp-tests" "tp_unknown_language")
+        "tp_unknown_language_trigger"
+        "before_insert"
+        "opaque source"
+        "not-loaded-in-this-process"
+        nil
+        false)
+    expect:
+      data: [true]
+
+  - name: "Unavailable trigger language fails only when trigger is needed"
+    sql: "INSERT INTO tp_unknown_language VALUES (1)"
+    expect:
+      error: true
+
   - name: "After restart: serialized logical view IR is restored"
     sql: "SELECT customer_id, total FROM tp_order_totals ORDER BY customer_id"
     expect:
@@ -211,3 +263,9 @@ test_cases:
 
   - name: "Cleanup tp_vals"
     sql: "DROP TABLE tp_vals"
+
+  - name: "Cleanup tp_scheme"
+    sql: "DROP TABLE tp_scheme"
+
+  - name: "Cleanup unavailable language table"
+    sql: "DROP TABLE tp_unknown_language"


### PR DESCRIPTION
## Summary

- persist frontend-defined triggers as generic `source` plus `language`, never as both source and compiled Scheme
- let arbitrary frontends register a process-local compile lambda with `registertriggerlanguage`
- move SQL trigger restoration out of storage and into the SQL frontend
- ship a Scheme language hook and verify a Scheme-authored trigger survives restart
- regenerate all four canonical FK callbacks from authoritative FK metadata while loading old schemas
- retain compiled procedures only for internal triggers that have no source definition

## Root cause

Persisted FK trigger procedures created before #694 call internal FK builtins without the transaction-context argument introduced there. Loading the obsolete compiled procedure unchanged made an upload-shaped partial INSERT panic with `index out of range [5] with length 5`; the parent callbacks had the corresponding ABI problem.

The broader design problem was that schema persistence stored SQL source alongside a compiled Scheme implementation and the storage loader directly called `parse_sql`. That coupled storage startup to the SQL frontend and let generated implementation details outlive the compiler version which produced them.

## Design

A persistent source-defined trigger now has one authoritative definition:

```text
source + language
```

A frontend registers `(registertriggerlanguage language compile-lambda)`. The compile lambda receives `source` and an associative context containing schema, table, trigger name, timing, and visibility. Compilation is lazy: loading an RDF-only process does not require the SQL library merely because a schema contains an SQL trigger. If that trigger is actually fired without its language frontend loaded, MemCP reports the missing language explicitly.

The SQL compiler hook lives in `lib/sql-parser.scm`; storage contains no `parse_sql` dependency. `lib/main.scm` registers the shipped Scheme compiler, and other libraries may register arbitrary language names. Old `source_sql` schema fields are imported as `source` with `language=sql`, while subsequent saves emit only the generic fields.

Source-less internal triggers keep their compiled procedure because there is no source compiler to reproduce them. FK callbacks are a separate derived-code case: FK declarations are authoritative, so load removes only callback names owned by real FK declarations and recreates their four current canonical programs. User triggers are untouched.

## Test-first evidence

The FK regression test writes all four pre-transaction callback forms to disk, restarts, and exercises partial INSERT, child UPDATE, parent UPDATE CASCADE, a second schema-save/restart, and parent DELETE CASCADE. On unchanged `origin/master` it failed with:

```
index out of range [5] with length 5
index out of range [7] with length 7
```

Targeted results on this branch:

- `fk-trigger-upgrade.yaml`: 10/10
- `trigger-persistence.yaml`: 37/37, including SQL and Scheme source recompilation across restart and lazy failure for an unavailable frontend
- `triggers.yaml`: 330/330
- `mysql-fk-acceptance.yaml`: 52/52
- targeted Go trigger/FK tests: passed
- Scheme formatting checks, `git diff --check`, and `go build -o memcp .`: passed

The full suite is intentionally left to CI.

## Data-safety and compatibility

No table data, shard format, cleanup, or disk-deletion path changes. Legacy `source_sql` remains readable. Compiled internal trigger procedures remain readable. The migration changes only how generated trigger programs are reconstructed in memory and how new schema/settings saves represent source-defined triggers.