### PR TITLE
sql: three stacked micro-optimizations on the query hot path

### DIFF
--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -956,6 +956,27 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
 (set mysql_auth (lambda (username_) (scan nil (table "system" "user") '("username") (lambda (username) (equal? username username_)) '("password") (lambda (acc password) password) nil (lambda (a b) b))))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
+
+/* Top-level so the interpreter compiles this body once instead of rebuilding a
+large lambda Proc (and re-walking it via procCanUseNumberedOnly) on every
+statement inside the per-query transaction callback. */
+(define mysql_run_sql_statement (lambda (tx schema sql session resultrow resultfields_sql) (begin
+	(define sql_parse_input (strtrim sql))
+	/* tolerate an optional trailing ';' - input is already trimmed, so a
+	single last-character check replaces a backtracking regex on the hot path */
+	(define sql_parse_input_len (strlen sql_parse_input))
+	(if (and (> sql_parse_input_len 0)
+			(equal? (substr sql_parse_input (- sql_parse_input_len 1) 1) ";"))
+		(set sql_parse_input (substr sql_parse_input 0 (- sql_parse_input_len 1)))
+		nil)
+	(define mysql_username (coalesce (session "username") "root"))
+	(define formula (if (equal? (session "syntax") "postgresql")
+		(cached_parse psql_queryplan_cache (list parse_psql) schema sql_parse_input
+			(list (quote sql-policy-for) mysql_username) mysql_username session false tx)
+		(cached_parse sql_queryplan_cache (list parse_sql) schema sql_parse_input
+			(list (quote sql-policy-for) mysql_username) mysql_username session true tx)))
+	(sql_execute_formula session tx formula resultrow resultfields_sql))))
+
 (set mysql_handler (lambda (schema sql resultrow_sql resultfields_sql session session_state query_seq) (begin
 	(session "schema" schema)
 	(define resultrow resultrow_sql)
@@ -965,24 +986,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 			(set print (lambda args (resultrow '("result" (concat args)))))
 			(resultrow '("result" (eval (scheme sql))))
 		) (time (with_autocommit session session_state query_seq sql
-				(lambda (tx) (begin
-					/* SQL syntax mode */
-					(define sql_parse_input (strtrim sql))
-					/* tolerate an optional trailing ';' - input is already trimmed, so a
-					single last-character check replaces a backtracking regex on the hot path */
-					(define sql_parse_input_len (strlen sql_parse_input))
-					(if (and (> sql_parse_input_len 0)
-							(equal? (substr sql_parse_input (- sql_parse_input_len 1) 1) ";"))
-						(set sql_parse_input (substr sql_parse_input 0 (- sql_parse_input_len 1)))
-						nil)
-					(define mysql_username (coalesce (session "username") "root"))
-					(define formula (if (equal? (session "syntax") "postgresql")
-						(cached_parse psql_queryplan_cache (list parse_psql) schema sql_parse_input
-							(list (quote sql-policy-for) mysql_username) mysql_username session false tx)
-						(cached_parse sql_queryplan_cache (list parse_sql) schema sql_parse_input
-							(list (quote sql-policy-for) mysql_username) mysql_username session true tx)))
-					(sql_execute_formula session tx formula resultrow resultfields_sql)
-			))) sql))
+				(lambda (tx) (mysql_run_sql_statement tx schema sql session resultrow resultfields_sql))) sql))
 	)) (lambda (e) (begin
 			(error_log (concat e) schema (coalesce (session "username") "root") sql)
 			(error e) /* re-throw so MySQL protocol sends proper error packet */

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -968,8 +968,13 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 				(lambda (tx) (begin
 					/* SQL syntax mode */
 					(define sql_parse_input (strtrim sql))
-					/* tolerate an optional trailing ';' - must be at end of string */
-					(set sql_parse_input (match sql_parse_input (regex "^((?s:.*));\\s*$" _ body) body sql_parse_input))
+					/* tolerate an optional trailing ';' - input is already trimmed, so a
+					single last-character check replaces a backtracking regex on the hot path */
+					(define sql_parse_input_len (strlen sql_parse_input))
+					(if (and (> sql_parse_input_len 0)
+							(equal? (substr sql_parse_input (- sql_parse_input_len 1) 1) ";"))
+						(set sql_parse_input (substr sql_parse_input 0 (- sql_parse_input_len 1)))
+						nil)
 					(define mysql_username (coalesce (session "username") "root"))
 					(define formula (if (equal? (session "syntax") "postgresql")
 						(cached_parse psql_queryplan_cache (list parse_psql) schema sql_parse_input

--- a/scm/sync.go
+++ b/scm/sync.go
@@ -306,15 +306,20 @@ func NewSession(a ...Scmer) Scmer {
 	return NewFunc(func(a ...Scmer) (result Scmer) {
 		switch len(a) {
 		case 2:
-			sess.Mu.Lock()
-			defer sess.Mu.Unlock()
+			// No panic path between lock and unlock, so an explicit unlock avoids
+			// the per-call deferred-record cost on this very hot accessor.
 			if a[0].GetTag() >= 100 {
+				sess.Mu.Lock()
 				if sess.Handles == nil {
 					sess.Handles = make(map[Scmer]Scmer)
 				}
 				sess.Handles[a[0]] = a[1]
+				sess.Mu.Unlock()
 			} else {
-				sess.Map[a[0].String()] = a[1]
+				key := a[0].String()
+				sess.Mu.Lock()
+				sess.Map[key] = a[1]
+				sess.Mu.Unlock()
 			}
 			return a[1]
 		case 4:
@@ -328,15 +333,20 @@ func NewSession(a ...Scmer) Scmer {
 			}
 			return sessionGetOrComputeScoped(sess, a[1], a[2].String(), a[3], a[4], true)
 		case 1:
-			sess.Mu.RLock()
-			defer sess.Mu.RUnlock()
 			if a[0].GetTag() >= 100 {
-				if v, ok := sess.Handles[a[0]]; ok {
+				sess.Mu.RLock()
+				v, ok := sess.Handles[a[0]]
+				sess.Mu.RUnlock()
+				if ok {
 					return v
 				}
 				return NewNil()
 			}
-			if v, ok := sess.Map[a[0].String()]; ok {
+			key := a[0].String()
+			sess.Mu.RLock()
+			v, ok := sess.Map[key]
+			sess.Mu.RUnlock()
+			if ok {
 				return v
 			}
 			return NewNil()


### PR DESCRIPTION
Three small, independent reductions of per-statement overhead upstream of and
around query execution. Each isolated with a CPU profile of the MySQL-wire warm
path (persistent connection, plan-cache hit, 200k–600k point selects);
wall-clock A/B on this shared box cannot resolve ~1 µs against run-to-run
noise, so the evidence is the profile delta for the affected functions.

Rebased onto `master` now that #733 has landed.

### 1. `sql: strip trailing ';' without a backtracking regex`

`mysql_handler` ran `^((?s:.*));\s*$` (greedy submatch, backtracks the whole
string) on every statement just to drop an optional trailing `;`. The input is
already `strtrim`'d, so a last-byte check is equivalent.
`regexp.FindStringSubmatch` + `regexp.tryBacktrack`: **~1.5 % → 0** (this was
the only Go `regexp` left on the warm path). `tests/sql/compatibility/trailing-semicolon.yaml` 3/3.

### 2. `sql: hoist the mysql per-statement body out of the tx callback`

The full execution path was a fresh `(lambda (tx) (begin …))` handed to
`with_autocommit` per query; the interpreter rebuilt its Proc and re-ran
`procCanUseNumberedOnly` over the whole body each time. Moved to a top-level
`mysql_run_sql_statement`; the per-query callback is now a one-form forwarder.
`procCanUseNumberedOnly` (cum) **2.38 % → 0.63 %**, `procBodyUsesNamedParam` **→ absent**.

### 3. `scm: drop deferred unlocks from the session accessor`

`NewSession`'s accessor (schema / username / syntax / every `vN` binding go
through it) held its mutex under `defer` in the 1- and 2-arg cases; the defers
aren't open-coded (different switch arms) and `runtime._panic.nextDefer` was
~24 % of its self time. Nothing between lock and unlock can panic.
`NewSession.func1` self time **~1.85 % → ~1.1 %**.

### Combined

≈4–5 % of per-query CPU on a trivial `SELECT … WHERE id = ?`, more on longer
statements (items 1 and 2 scale with body/query length). No effect on planning
or large-query execution. Full `git-pre-commit` SQL suite green (the 3
pre-existing noncritical deeply-nested-correlated-subselect failures are
identical on `master`).

_A fourth change — resolving the delta-B-tree column layout once per index
build instead of two `map[string]` lookups per comparison (~16 % on
`BenchmarkScanUniquePointWithTx`) — was prototyped and reverted: a build-time
snapshot is unsafe because `t.deltaColumns` is populated lazily and the index
is not rebuilt when it grows, so the comparator would read a stale slot. It
needs a generation-guarded re-resolve and will be a separate PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)