### PR TITLE
Avoid result channels for single-shard scans

### DIFF
--- a/storage/partition.go
+++ b/storage/partition.go
@@ -147,16 +147,16 @@ func runSingleShardScan(currentTx *TxContext, topology *tableShardTopology, shar
 }
 
 func runParallelShardScans(currentTx *TxContext, shards []*storageShard, topology *tableShardTopology, callback func(*storageShard, bool)) <-chan struct{} {
-	return runFanoutTasks(currentTx, len(shards), func(i int, synchronous bool) {
+	return runFanoutTasks(currentTx, len(shards), func(i int, _ bool) {
 		shard := shards[i]
 		defer topology.releaseOperation()
 		defer shard.activeScanners.Add(-1)
 		release := shard.acquireReadForScan(currentTx)
 		defer release()
 		if scm.Trace == nil {
-			callback(shard, synchronous)
+			callback(shard, false)
 		} else {
-			traceShardScanCallback(callback, shard, synchronous)
+			traceShardScanCallback(callback, shard, false)
 		}
 	})
 }

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -477,6 +477,49 @@ type scanResult struct {
 	err            scanError // err.r != nil indicates an error
 }
 
+// scanResultCollector keeps the one-shard path synchronous. Parallel scans
+// lazily allocate their channel on the first non-solo callback; a scan whose
+// selected topology contains one shard writes its sole result directly.
+type scanResultCollector struct {
+	channelSize int
+	once        sync.Once
+	parallel    chan scanResult
+	solo        scanResult
+	soloRead    bool
+}
+
+func (c *scanResultCollector) send(solo bool, result scanResult) {
+	if solo {
+		c.solo = result
+		return
+	}
+	c.once.Do(func() {
+		c.parallel = make(chan scanResult, c.channelSize)
+	})
+	c.parallel <- result
+}
+
+func (c *scanResultCollector) finish(done <-chan struct{}) {
+	if done != nil {
+		<-done
+	}
+	if c.parallel != nil {
+		close(c.parallel)
+	}
+}
+
+func (c *scanResultCollector) next() (scanResult, bool) {
+	if c.parallel != nil {
+		result, ok := <-c.parallel
+		return result, ok
+	}
+	if c.soloRead {
+		return scanResult{}, false
+	}
+	c.soloRead = true
+	return c.solo, true
+}
+
 const (
 	defaultScanBufferSize     = 1024
 	uniquePointScanBufferSize = 8
@@ -587,16 +630,16 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, conditionCo
 		t.AddPartitioningScore([]string{b.col})
 	}
 
-	values := make(chan scanResult, t.shardResultBufferSize())
+	values := scanResultCollector{channelSize: t.shardResultBufferSize()}
 	var found atomic.Bool
 	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		if found.Load() {
-			values <- scanResult{}
+			values.send(solo, scanResult{})
 			return
 		}
 		defer func() {
 			if r := recover(); r != nil {
-				values <- scanResult{err: scanError{r, string(debug.Stack())}}
+				values.send(solo, scanResult{err: scanError{r, string(debug.Stack())}})
 			}
 		}()
 		// Cancellation contract: check only at the scheduling boundary, before entering
@@ -606,18 +649,15 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, conditionCo
 		}
 		if s.scanExists(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, &found) {
 			found.Store(true)
-			values <- scanResult{outCount: 1}
+			values.send(solo, scanResult{outCount: 1})
 			return
 		}
-		values <- scanResult{}
+		values.send(solo, scanResult{})
 	})
-	if done != nil {
-		<-done
-	}
-	close(values)
+	values.finish(done)
 
 	var scanErr scanError
-	for msg := range values {
+	for msg, ok := values.next(); ok; msg, ok = values.next() {
 		if msg.err.r != nil {
 			if scanErr.r == nil {
 				scanErr = msg.err
@@ -699,11 +739,11 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 	var outCount int64
 	var inputCount int64
 	var candidateCount int64
-	values := make(chan scanResult, t.shardResultBufferSize())
+	values := scanResultCollector{channelSize: t.shardResultBufferSize()}
 	done := t.iterateShardsParallel(currentTx, boundaries, func(s *storageShard, solo bool) {
 		defer func() {
 			if r := recover(); r != nil {
-				values <- scanResult{err: scanError{r, string(debug.Stack())}}
+				values.send(solo, scanResult{err: scanError{r, string(debug.Stack())}})
 			}
 		}()
 		// Cancellation contract: check only at the scheduling boundary, before entering
@@ -712,19 +752,16 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 			panic("query killed")
 		}
 		res, shardOutCount, shardCandidateCount := s.scan(boundaries, lower, upperLast, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
-		values <- scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount}
+		values.send(solo, scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount})
 	})
-	if done != nil {
-		<-done
-	}
-	close(values)
+	values.finish(done)
 
 	akkumulator := neutral
 	hadValue := false
 	var scanErr scanError
 	if !combine.IsNil() {
 		fn := scm.OptimizeProcToSerialFunction(combine)
-		for msg := range values {
+		for msg, ok := values.next(); ok; msg, ok = values.next() {
 			if msg.err.r != nil {
 				if scanErr.r == nil {
 					scanErr = msg.err
@@ -748,7 +785,7 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, conditio
 			akkumulator = scm.Apply(mapReduce, nullArgs...)
 		}
 	} else {
-		for msg := range values {
+		for msg, ok := values.next(); ok; msg, ok = values.next() {
 			if msg.err.r != nil {
 				if scanErr.r == nil {
 					scanErr = msg.err

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -485,12 +485,14 @@ type scanResultCollector struct {
 	once        sync.Once
 	parallel    chan scanResult
 	solo        scanResult
+	soloSet     bool
 	soloRead    bool
 }
 
 func (c *scanResultCollector) send(solo bool, result scanResult) {
 	if solo {
 		c.solo = result
+		c.soloSet = true
 		return
 	}
 	c.once.Do(func() {
@@ -513,7 +515,7 @@ func (c *scanResultCollector) next() (scanResult, bool) {
 		result, ok := <-c.parallel
 		return result, ok
 	}
-	if c.soloRead {
+	if !c.soloSet || c.soloRead {
 		return scanResult{}, false
 	}
 	c.soloRead = true

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -172,6 +172,51 @@ func BenchmarkScanUniquePointWithTx(b *testing.B) {
 	benchmarkUniquePointScan(b, "read_tx", NewTxContext(TxCursorStability))
 }
 
+func benchmarkUniqueMainPointScan(b *testing.B, name string, currentTx *TxContext) {
+	dbName := "bench_scan_main_point_" + name
+	databases.Remove(dbName)
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("label", "VARCHAR", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl.Insert([]string{"id", "label"}, rows, nil, scm.NewNil(), false, nil)
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "PRIMARY", Cols: []string{"id"}})
+	result := GetDatabase(dbName).rebuild(true, false, true)
+	if len(result.errors) > 0 {
+		b.Fatalf("rebuild errors: %v", result.errors)
+	}
+
+	condition := scanCondition("id", scm.NewInt(511))
+	mapReduceFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[1] })
+	nilFn := scm.NewNil()
+	// The first two probes cross the adaptive-index threshold and build the
+	// main-storage index. Only steady-state point probes are measured.
+	tbl.scan(currentTx, []string{"id"}, condition, []string{"label"}, mapReduceFn, scm.NewNil(), nilFn, false)
+	tbl.scan(currentTx, []string{"id"}, condition, []string{"label"}, mapReduceFn, scm.NewNil(), nilFn, false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tbl.scan(currentTx, []string{"id"}, condition, []string{"label"}, mapReduceFn, scm.NewNil(), nilFn, false)
+	}
+}
+
+// BenchmarkScanUniqueMainPoint measures a warm unique lookup after rows and
+// the corresponding index have moved to compressed main storage.
+func BenchmarkScanUniqueMainPoint(b *testing.B) {
+	benchmarkUniqueMainPointScan(b, "read", nil)
+}
+
+// BenchmarkScanUniqueMainPointWithTx includes the explicit transaction used
+// by prepared SQL execution while retaining the same warm main-storage probe.
+func BenchmarkScanUniqueMainPointWithTx(b *testing.B) {
+	benchmarkUniqueMainPointScan(b, "read_tx", NewTxContext(TxCursorStability))
+}
+
 func TestOpenMapReducerAllocatesMutationMetadataLazily(t *testing.T) {
 	const dbName = "test_scan_mapper_metadata"
 	databases.Remove(dbName)

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -408,6 +408,36 @@ func TestIterateShardsParallelMarksPartitionMultiShardNonSolo(t *testing.T) {
 	}
 }
 
+func TestIterateShardsParallelMarksSynchronousMultiShardNonSolo(t *testing.T) {
+	tbl := setupScanParallelTestTable(t, "tscanparsyncmulti")
+	tbl.ShardMode = ShardModePartition
+	tbl.PDimensions = []shardDimension{{
+		Column:        "id",
+		NumPartitions: 2,
+		Pivots:        []scm.Scmer{scm.NewInt(10)},
+	}}
+	tbl.PShards = []*storageShard{NewShard(tbl), NewShard(tbl)}
+	tbl.publishTopologyLocked()
+	tx := NewTxContext(TxCursorStability)
+	tx.fanoutLimit.Store(1)
+
+	calls := 0
+	sawSolo := false
+	done := tbl.iterateShardsParallel(tx, nil, func(_ *storageShard, solo bool) {
+		calls++
+		sawSolo = sawSolo || solo
+	})
+	if done != nil {
+		t.Fatal("synchronous multi-shard scan unexpectedly returned a done channel")
+	}
+	if calls != 2 {
+		t.Fatalf("synchronous multi-shard calls = %d, want 2", calls)
+	}
+	if sawSolo {
+		t.Fatal("synchronous multi-shard callback was incorrectly marked as solo")
+	}
+}
+
 func TestIterateShardsParallelAutocommitUsesExplicitContext(t *testing.T) {
 	tbl := setupScanParallelTestTable(t, "tscanparexplicit")
 	tbl.ShardMode = ShardModePartition

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -438,6 +438,23 @@ func TestIterateShardsParallelMarksSynchronousMultiShardNonSolo(t *testing.T) {
 	}
 }
 
+func TestScanResultCollectorDoesNotInventEmptyShardResult(t *testing.T) {
+	collector := scanResultCollector{channelSize: 1}
+	collector.finish(nil)
+	if result, ok := collector.next(); ok {
+		t.Fatalf("empty collector returned an invented result: %#v", result)
+	}
+
+	want := scanResult{outCount: 1}
+	collector.send(true, want)
+	if result, ok := collector.next(); !ok || result.outCount != want.outCount {
+		t.Fatalf("solo collector result = (%#v, %v), want (%#v, true)", result, ok, want)
+	}
+	if result, ok := collector.next(); ok {
+		t.Fatalf("solo collector returned a second result: %#v", result)
+	}
+}
+
 func TestIterateShardsParallelAutocommitUsesExplicitContext(t *testing.T) {
 	tbl := setupScanParallelTestTable(t, "tscanparexplicit")
 	tbl.ShardMode = ShardModePartition


### PR DESCRIPTION
## Summary

- keep single-shard scans synchronous through result collection instead of allocating a channel
- preserve the distinction between a single selected shard and a synchronous multi-shard fanout
- add a warm compressed-main-storage point-probe benchmark

## Manual A/B measurements

Pinned to CPU 2 on an AMD Ryzen 9 7900X3D. Both revisions used the same 1,024-row Memory-engine fixture, an explicit rebuild, two adaptive-index warmups, five 500 ms samples, and the patched Go toolchain.

| Build | master median | PR median | Change | Allocations |
|---|---:|---:|---:|---:|
| `GOEXPERIMENT=jit` | 2,436 ns/op | 2,316 ns/op | -4.9% | 10 -> 9 |
| vanilla | 2,359 ns/op | 2,275 ns/op | -3.6% | 10 -> 9 |

Allocated bytes fall from 992 B/op to 912 B/op in both modes.

The SQL runner's warm end-to-end `SELECT value FROM jit_point WHERE id = 4242` measurement remains 0.5 ms on both revisions because its 0.1 ms output resolution and HTTP request costs are larger than this scan-layer change.

## Validation

- targeted scan, map-reducer, and shard fanout tests pass with `GOEXPERIMENT=jit`
- race-enabled synchronous and parallel multi-shard tests pass
- the full `go test ./storage` run has only the pre-existing `TestRebuildInsideActiveTransactionDoesNotWaitForItself` failure; the exact test fails identically on the merge base

This PR does not change query plans, Scheme code, or JIT compilation policy.
