### PR TITLE
Initialize precise JIT frame roots

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -570,6 +570,33 @@ type jitSafepoint struct {
 	entry     bool
 }
 
+// jitFrameRootsToInitialize returns reusable frame words which a safepoint may
+// scan before the current control-flow path has written them. Dynamic call-area
+// roots live below the stable stack pointer and are initialized at their call
+// site. Architecture emitters translate these common frame-bank locations into
+// their native stores.
+func jitFrameRootsToInitialize(safepoints []jitSafepoint) []jitStackRoot {
+	unique := make(map[jitStackRoot]struct{})
+	for _, safepoint := range safepoints {
+		for _, root := range safepoint.roots {
+			if root.base == jitStackRootFrameBP || root.base == jitStackRootFrameSP && root.offset >= 0 {
+				unique[root] = struct{}{}
+			}
+		}
+	}
+	roots := make([]jitStackRoot, 0, len(unique))
+	for root := range unique {
+		roots = append(roots, root)
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		if roots[i].base != roots[j].base {
+			return roots[i].base < roots[j].base
+		}
+		return roots[i].offset < roots[j].offset
+	})
+	return roots
+}
+
 // jitStackMap is the runtime-independent form passed through the common JIT
 // code. The goexperiment.jit implementation converts it to runtime/jit maps;
 // the vanilla implementation deliberately ignores it.

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -570,20 +570,10 @@ type jitSafepoint struct {
 	entry     bool
 }
 
-// jitFrameRootsToInitialize returns reusable frame words which a safepoint may
-// scan before the current control-flow path has written them. Dynamic call-area
-// roots live below the stable stack pointer and are initialized at their call
-// site. Architecture emitters translate these common frame-bank locations into
-// their native stores.
-func jitFrameRootsToInitialize(safepoints []jitSafepoint) []jitStackRoot {
-	unique := make(map[jitStackRoot]struct{})
-	for _, safepoint := range safepoints {
-		for _, root := range safepoint.roots {
-			if root.base == jitStackRootFrameBP || root.base == jitStackRootFrameSP && root.offset >= 0 {
-				unique[root] = struct{}{}
-			}
-		}
-	}
+// jitSortedFrameRoots returns the permanent frame words registered by the
+// one-pass emitter in deterministic order. Dynamic call-area roots live below
+// the stable stack pointer and are initialized at their call site.
+func jitSortedFrameRoots(unique map[jitStackRoot]struct{}) []jitStackRoot {
 	roots := make([]jitStackRoot, 0, len(unique))
 	for root := range unique {
 		roots = append(roots, root)
@@ -680,6 +670,10 @@ type JITContext struct {
 	// current emission point. Safepoints copy this set before sibling control
 	// flow can restore a different allocator state.
 	StackRoots map[jitStackRoot]struct{}
+	// FrameRoots accumulates permanent pointer slots as they are first emitted.
+	// Unlike StackRoots it is shared by branch contexts and never removes slots,
+	// avoiding a second traversal over every safepoint after code generation.
+	FrameRoots map[jitStackRoot]struct{}
 	Safepoints []jitSafepoint
 	Coverage   JITCoverage
 
@@ -894,6 +888,12 @@ func (ctx *JITContext) setStackPointer(base jitStackRootBase, offset int32, poin
 			ctx.StackRoots = make(map[jitStackRoot]struct{})
 		}
 		ctx.StackRoots[root] = struct{}{}
+		if base == jitStackRootFrameBP || base == jitStackRootFrameSP && offset >= 0 {
+			if ctx.FrameRoots == nil {
+				ctx.FrameRoots = make(map[jitStackRoot]struct{})
+			}
+			ctx.FrameRoots[root] = struct{}{}
+		}
 		return
 	}
 	delete(ctx.StackRoots, root)

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -51,6 +51,35 @@ func TestJITFrameClearingLimitedToParserControlFlow(t *testing.T) {
 	})
 }
 
+func TestJITFrameRootInitializationIsPreciseAndDeterministic(t *testing.T) {
+	safepoints := []jitSafepoint{
+		{roots: []jitStackRoot{
+			{base: jitStackRootCallSP, offset: 16},
+			{base: jitStackRootFrameBP, offset: -8},
+			{base: jitStackRootFrameSP, offset: -16},
+			{base: jitStackRootFrameSP, offset: 32},
+		}},
+		{roots: []jitStackRoot{
+			{base: jitStackRootFrameSP, offset: 32},
+			{base: jitStackRootFrameBP, offset: -24},
+		}},
+	}
+	want := []jitStackRoot{
+		{base: jitStackRootFrameSP, offset: 32},
+		{base: jitStackRootFrameBP, offset: -24},
+		{base: jitStackRootFrameBP, offset: -8},
+	}
+	got := jitFrameRootsToInitialize(safepoints)
+	if len(got) != len(want) {
+		t.Fatalf("frame roots = %v, want %v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("frame root %d = %v, want %v", index, got[index], want[index])
+		}
+	}
+}
+
 func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 	code := make([]byte, 128)
 	start := unsafe.Pointer(&code[0])

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -52,24 +52,23 @@ func TestJITFrameClearingLimitedToParserControlFlow(t *testing.T) {
 }
 
 func TestJITFrameRootInitializationIsPreciseAndDeterministic(t *testing.T) {
-	safepoints := []jitSafepoint{
-		{roots: []jitStackRoot{
-			{base: jitStackRootCallSP, offset: 16},
-			{base: jitStackRootFrameBP, offset: -8},
-			{base: jitStackRootFrameSP, offset: -16},
-			{base: jitStackRootFrameSP, offset: 32},
-		}},
-		{roots: []jitStackRoot{
-			{base: jitStackRootFrameSP, offset: 32},
-			{base: jitStackRootFrameBP, offset: -24},
-		}},
+	ctx := JITContext{}
+	for _, root := range []jitStackRoot{
+		{base: jitStackRootCallSP, offset: 16},
+		{base: jitStackRootFrameBP, offset: -8},
+		{base: jitStackRootFrameSP, offset: -16},
+		{base: jitStackRootFrameSP, offset: 32},
+		{base: jitStackRootFrameSP, offset: 32},
+		{base: jitStackRootFrameBP, offset: -24},
+	} {
+		ctx.setStackPointer(root.base, root.offset, true)
 	}
 	want := []jitStackRoot{
 		{base: jitStackRootFrameSP, offset: 32},
 		{base: jitStackRootFrameBP, offset: -24},
 		{base: jitStackRootFrameBP, offset: -8},
 	}
-	got := jitFrameRootsToInitialize(safepoints)
+	got := jitSortedFrameRoots(ctx.FrameRoots)
 	if len(got) != len(want) {
 		t.Fatalf("frame roots = %v, want %v", got, want)
 	}

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -185,6 +185,17 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 	ctx.emitByte(0x55)                    // push rbp
 	ctx.emitBytes(0x48, 0x89, 0xE5)       // mov rbp, rsp
 	frameFixup := ctx.EmitSubRSP32Fixup() // sub rsp, <patched>
+	var frameInitLabel, frameBodyLabel JITLabel
+	if !ctx.StackPhiTargets {
+		// Ordinary expressions use precise root-slot initialization instead of
+		// clearing every word in the frame. The root set is known only after the
+		// one-pass body emitter has recorded all safepoints, so enter through a
+		// small initializer emitted after the body and jump back here.
+		frameInitLabel = ctx.ReserveLabel()
+		frameBodyLabel = ctx.ReserveLabel()
+		ctx.EmitJmp(frameInitLabel)
+		ctx.MarkLabel(frameBodyLabel)
+	}
 
 	ctx.emitMovRegReg(RegR12, RegRAX) // save incoming args slice
 	// Parser control flow can enter a shared block whose stack target was
@@ -374,6 +385,21 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 	}
 	ctx.emitByte(0xC9) // leave
 	ctx.emitByte(0xC3) // ret
+	if !ctx.StackPhiTargets {
+		ctx.MarkLabel(frameInitLabel)
+		roots := jitFrameRootsToInitialize(ctx.Safepoints)
+		if len(roots) != 0 {
+			ctx.emitBytes(0x45, 0x31, 0xDB) // xor r11d, r11d
+			for _, root := range roots {
+				base := RegRSP
+				if root.base == jitStackRootFrameBP {
+					base = RegRBP
+				}
+				ctx.EmitStoreRegMem(RegR11, base, root.offset)
+			}
+		}
+		ctx.EmitJmp(frameBodyLabel)
+	}
 	if hasStackCheck {
 		ctx.MarkLabel(stackGrowLabel)
 		// Match Go's regabi prolog: public slice arguments use their caller-owned

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -146,6 +146,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 		UsesRuntimeEnv:   jitExpressionConsumesRuntimeEnv(body),
 		SelfSymbols:      selfSymbols,
 		SelfParamCount:   inputArgCount,
+		FrameRoots:       make(map[jitStackRoot]struct{}),
 		Arena:            buf.arena,
 	}
 	if len(selfSymbols) != 0 && inputArgCount >= 0 {
@@ -387,7 +388,7 @@ func jitCompileExprBodyToExec(proc *Proc, body Scmer, numVars int, buf *execBuf,
 	ctx.emitByte(0xC3) // ret
 	if !ctx.StackPhiTargets {
 		ctx.MarkLabel(frameInitLabel)
-		roots := jitFrameRootsToInitialize(ctx.Safepoints)
+		roots := jitSortedFrameRoots(ctx.FrameRoots)
 		if len(roots) != 0 {
 			ctx.emitBytes(0x45, 0x31, 0xDB) // xor r11d, r11d
 			for _, root := range roots {


### PR DESCRIPTION
## Summary

- initialize only permanent JIT frame words that appear as pointer roots at a safepoint
- keep dynamic call-area roots initialized at their call sites
- preserve blanket frame clearing for parser control flow
- prevent stale pointers from previous invocations from keeping freed ProcJIT closure objects in GC stack maps

## Root cause

Ordinary JIT frames stopped receiving blanket initialization, but stack maps may conservatively contain a spill home produced by a sibling control-flow path. When that path was skipped, the reusable goroutine stack retained a ProcJIT pointer from an older invocation. A later GC marked the already-freed 112-byte Proc-plus-two-captures object and terminated with fatal error: found pointer to free object.

The one-pass emitter knows the complete root set only after emitting the body. The amd64 entry now jumps through a late-emitted initializer containing one zero store per distinct permanent SP/BP root and then enters the body. Common root selection remains architecture-independent.

## Manual A/B measurements

Pinned Ryzen 9 7900X3D, patched Go compiler, GOEXPERIMENT=jit, five 500 ms samples. Medians compare master with this PR:

| Benchmark | master | PR | Change |
|---|---:|---:|---:|
| JIT map, dynamic callback | 3,848 ns/op | 3,861 ns/op | +0.3% |
| JIT map, inline callback | 2,193 ns/op | 2,192 ns/op | unchanged |
| JIT list projection | 32.16 ns/op | 32.27 ns/op | +0.3% |

Allocations are unchanged. Disassembly of the representative projection contains two precise zero stores and no rep stosq.

## Validation

- go test ./scm with the patched compiler and GOEXPERIMENT=jit
- non-JIT go build ./scm
- focused frame-root, escaping closure, and noescape closure tests, 20 repetitions
- relational-benchmark-shapes.yaml: four consecutive 23/23 passes under GOGC=1 and GODEBUG=clobberfree=1; master and PR #744 previously crashed on the first run with a 112-byte free-object GC fatal
