### PR TITLE
Publish deferred JIT entries with their stack maps

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -3110,33 +3110,39 @@ type jitCodeReservation struct {
 	done      bool
 	published bool
 	maps      []jitStackMap
+	onPublish func()
 }
 
 // complete publishes arena metadata in allocation order. Compilation itself
 // may run concurrently, but an entry point does not become reachable before
 // every earlier reservation has either published its maps or reported failure.
 func (a *jitArena) complete(reservation *jitCodeReservation, maps []jitStackMap) {
-	a.completeMode(reservation, maps, true)
+	a.completeMode(reservation, maps, true, nil)
 }
 
 // completeDeferred records metadata for code which cannot become reachable
 // before its enclosing reservation is published. Nested special-form thunks
 // use this to avoid waiting on the outer compiler which is currently emitting
 // them; the outer completion publishes both reservations in allocation order.
-func (a *jitArena) completeDeferred(reservation *jitCodeReservation, maps []jitStackMap) {
-	a.completeMode(reservation, maps, false)
+func (a *jitArena) completeDeferred(reservation *jitCodeReservation, maps []jitStackMap, onPublish func()) {
+	a.completeMode(reservation, maps, false, onPublish)
 }
 
-func (a *jitArena) completeMode(reservation *jitCodeReservation, maps []jitStackMap, wait bool) {
+func (a *jitArena) completeMode(reservation *jitCodeReservation, maps []jitStackMap, wait bool, onPublish func()) {
 	if a == nil || reservation == nil {
 		return
 	}
 	a.metaMu.Lock()
 	reservation.maps = maps
+	reservation.onPublish = onPublish
 	reservation.done = true
 	for a.metaNext < len(a.reservations) && a.reservations[a.metaNext].done {
 		ready := a.reservations[a.metaNext]
 		publishJITStackMaps(a, ready.maps)
+		if ready.onPublish != nil {
+			ready.onPublish()
+			ready.onPublish = nil
+		}
 		ready.published = true
 		a.metaNext++
 	}
@@ -7476,18 +7482,18 @@ func jitCompileModePublish(recursiveLambdas bool, waitForPublication, install bo
 		if proc == nil || !atomic.CompareAndSwapUint32(&proc.jitCompiling, 0, 1) {
 			return v
 		}
-		defer atomic.StoreUint32(&proc.jitCompiling, 0)
+		releaseCompiling := true
+		defer func() {
+			if releaseCompiling {
+				atomic.StoreUint32(&proc.jitCompiling, 0)
+			}
+		}()
 		plan := proc.Compiled
 		// Try increasing buffer sizes for overflow retry
 		for _, codeCap := range [...]int{16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024, 16 * 1024 * 1024} {
 			ptr, arena, reservation := globalJITPool.Alloc(codeCap)
 			buf := &execBuf{ptr: ptr, n: codeCap, arena: arena, reservation: reservation}
 			codeLen, roots, dependencies, overflow, hiddenArgs, needsStableArgs, coverage := jitCompileProcToExec(proc, buf, recursiveLambdas)
-			if waitForPublication {
-				arena.complete(reservation, buf.stackMaps)
-			} else {
-				arena.completeDeferred(reservation, buf.stackMaps)
-			}
 			if codeLen > 0 {
 				code := (*[1 << 30]byte)(ptr)[:codeLen:codeLen]
 				if JITLog {
@@ -7522,16 +7528,38 @@ func jitCompileModePublish(recursiveLambdas bool, waitForPublication, install bo
 					arena: arena,
 					code:  uintptr(ptr),
 				})
-				targetProc := proc
-				if !install {
-					copy := sourceProc
-					targetProc = &copy
-				}
-				attachProcJIT(targetProc, jep)
-				if install {
+				if waitForPublication {
+					arena.complete(reservation, buf.stackMaps)
+					targetProc := proc
+					if !install {
+						copy := sourceProc
+						targetProc = &copy
+					}
+					attachProcJIT(targetProc, jep)
 					return Scmer{ptr: (*byte)(unsafe.Pointer(targetProc)), aux: makeAux(tagProc, 0)}
 				}
+
+				// The enclosing reservation is not published yet, so return a
+				// private Proc which only the enclosing compiler can reach. Install
+				// the shared Proc after AddStackMaps publishes this reservation.
+				copy := sourceProc
+				targetProc := &copy
+				attachProcJIT(targetProc, jep)
+				var onPublish func()
+				if install {
+					releaseCompiling = false
+					onPublish = func() {
+						attachProcJIT(proc, jep)
+						atomic.StoreUint32(&proc.jitCompiling, 0)
+					}
+				}
+				arena.completeDeferred(reservation, buf.stackMaps, onPublish)
 				return Scmer{ptr: (*byte)(unsafe.Pointer(targetProc)), aux: makeAux(tagProc, 0)}
+			}
+			if waitForPublication {
+				arena.complete(reservation, buf.stackMaps)
+			} else {
+				arena.completeDeferred(reservation, buf.stackMaps, nil)
 			}
 			globalJITPool.Free(arena)
 			if !overflow {

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -22,6 +22,7 @@ package scm
 import (
 	"bytes"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -132,5 +133,41 @@ func TestJITEntryGrowsStackInPrologue(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("JIT stack growth did not resume the generated procedure")
+	}
+}
+
+func TestJITDeferredCompilationReturnsPrivateProc(t *testing.T) {
+	template := Eval(Read(t.Name(), `(lambda (value) value)`), &Globalenv)
+	if !template.IsProc() || template.Proc() == nil {
+		t.Fatal("lambda did not produce a Proc template")
+	}
+	compiled := jitCompileModeDeferred(true, template)
+	if !compiled.IsProc() || compiled.Proc() == nil {
+		t.Fatal("deferred compilation did not return a Proc")
+	}
+	if compiled.Proc() == template.Proc() {
+		t.Fatal("deferred compilation returned the shared Proc template")
+	}
+	if template.Proc().JITCode == 0 || template.Proc().Compiled == nil {
+		t.Fatal("shared Proc template was not installed after immediate stack-map publication")
+	}
+	if compiled.Proc().JITCode == 0 || compiled.Proc().Compiled == nil {
+		t.Fatal("deferred compilation did not return its private compiled Proc")
+	}
+}
+
+func TestJITArenaDefersCallbackUntilStackMapPublication(t *testing.T) {
+	first := &jitCodeReservation{}
+	second := &jitCodeReservation{}
+	arena := &jitArena{reservations: []*jitCodeReservation{first, second}}
+	arena.metaCond = sync.NewCond(&arena.metaMu)
+	published := false
+	arena.completeDeferred(second, nil, func() { published = true })
+	if published {
+		t.Fatal("deferred entry became visible before the preceding stack maps")
+	}
+	arena.complete(first, nil)
+	if !published || !second.published {
+		t.Fatal("deferred entry was not installed with its stack maps")
 	}
 }


### PR DESCRIPTION
## Problem

JIT code and its Go-compatible stack maps are allocated in one shared arena. Arena reservations must become visible in allocation order because `runtime/jit.AddStackMaps` publishes metadata for a contiguous code range.

Nested compilation creates this order:

1. The outer compiler reserves code range A.
2. While A is still being emitted, it compiles a nested procedure into reservation B.
3. B cannot wait for publication: publication is blocked behind unfinished A, while A cannot finish until the nested compilation returns.

The deferred mode correctly avoided that deadlock, but it attached B's native entry point to the shared template `*Proc` immediately. A concurrent caller could therefore observe `JITCode != 0` and enter B before A completed and before B's stack/unwind maps had reached `runtime/jit`. If that goroutine grew its Go stack at a JIT safepoint, `runtime.copystack` could not unwind the unpublished user frame and terminated with `traceback did not unwind completely`.

This was an application-side publication race, not an incorrectly sized JIT frame and not a missing compiler relocation rule.

## Solution

Deferred compilation now separates private use from global visibility:

- It attaches the compiled entry point immediately to a private copy of the Proc header. Only the still-running enclosing compiler can reach this copy, so it can continue emitting direct calls without waiting.
- It records a publication callback on B's arena reservation instead of mutating the shared Proc.
- Arena completion publishes every reservation's stack maps in allocation order and invokes its callback only after `AddStackMaps` has completed for that reservation.
- The callback then attaches the same entry point to the original shared Proc.
- `jitCompiling` remains held until this callback runs, preventing another compiler or caller from observing an intermediate state.

The original Proc identity is retained once publication is complete, so later global, capture, and session-aware calls keep their existing semantics.

No Go compiler patch is required for this fix. The successful JIT CI run used the published `jit-foreign-frames-go1.27.0` compiler without the local experimental frame-pointer relocation commit.

## Manual A/B measurement

Measured locally with the patched Go compiler and `GOEXPERIMENT=jit`, using the same one-row `constant-false-wide-predicate` fixture, 400 generated predicate branches, a fresh query cache per measured compile, and 20 samples per revision:

| Revision | Median | Min | Max |
| --- | ---: | ---: | ---: |
| master | 695.320 ms | 676.643 ms | 764.196 ms |
| this PR | 689.267 ms | 671.983 ms | 768.889 ms |
| change | **-0.9%** | | |

The change is intentionally a correctness fix rather than a hot-path optimization. The measurement shows no material cold-compilation regression.

The initially contended CI run measured 1.269 s for this fixture and failed its hard-coded in-Scheme 1.2 s assertion despite reporting a machine calibration factor of 1.47x. The isolated rerun passed. That assertion is not scaled by the runner; only runner-owned limits such as `max_time` are currently calibrated. The fixture contains one data row, so this is compiler CPU load and CI contention, not excessive input data.

## Validation

- `GOEXPERIMENT=jit go test ./scm`
- Publication and stack-growth regression tests, 50 repetitions
- Race-enabled publication tests, 20 repetitions
- Previously failing suites:
  - `constant-false-wide-predicate`: 2/2
  - `nested-exists-not-aggregate`: 10/10
  - `session-group-empty-keytable`: 4/4
- 64 parallel runs of the scalar-subselect and subselect-in-clauses suites
- Full JIT CI: 15m00s, including dump/restore compatibility
- Standard CI and performance A/B jobs: green
