### PR TITLE
Add dominant scan_lookup probes for scalar and ACL reads

### DIFF
--- a/lib/queryplan-logical.scm
+++ b/lib/queryplan-logical.scm
@@ -1886,6 +1886,68 @@ physical membership probe. */
 		(scalar_once_descriptor value_expr '() nil)
 		aggregate_count_descriptor)))
 
+/* A scalar projection over at most one row need not execute inside the scan.
+Read its one raw input column and apply a NULL-propagating calculation to the
+scalar result afterwards. This is a general materialization rule: every
+physical scan can expose the narrower raw-column boundary, while a complete
+indexed leaf may lower that boundary further to scan_lookup. Expressions such
+as COALESCE are intentionally excluded because a missing row and a matching
+row containing NULL must remain distinguishable for non-strict functions. */
+(define scalar_projection_input_columns (lambda (alias expr)
+	(match expr
+		((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
+		(if (or (nil? tblvar) (equal? tblvar alias)) (list expr) '())
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(scalar_projection_input_columns alias
+			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		(cons _head tail) (merge_unique (map tail (lambda (item)
+			(scalar_projection_input_columns alias item))))
+		_ '())))
+
+(define scalar_projection_null_propagating_operator? (lambda (head)
+	(begin
+		(define name (string head))
+		(or (contains? (list json_extract json_unquote json_type
+			json_depth json_length json_keys) head)
+			(contains? '("+" "-" "*" "/" "sql_div" "mod"
+				"json_extract" "json_unquote" "json_type"
+				"json_depth" "json_length" "json_keys") name)))))
+
+(define scalar_projection_null_propagating? (lambda (alias expr)
+	(match expr
+		((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
+		(or (nil? tblvar) (equal? tblvar alias))
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(scalar_projection_null_propagating? alias
+			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		(cons head tail) (and
+			(scalar_projection_null_propagating_operator? head)
+			(reduce tail (lambda (valid item)
+				(if (empty_list? (scalar_projection_input_columns alias item))
+					valid
+					(and valid (scalar_projection_null_propagating? alias item)))) true))
+		_ false)))
+
+(define scalar_projection_lifted_input (lambda (alias expr)
+	(begin
+		(define inputs (scalar_projection_input_columns alias expr))
+		(if (and (single_source? inputs)
+			(scalar_projection_null_propagating? alias expr))
+			(car inputs)
+			nil))))
+
+(define replace_scalar_projection_input (lambda (alias input replacement expr)
+	(match expr
+		((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
+		(if (and (or (nil? tblvar) (equal? tblvar alias)) (equal? expr input))
+			replacement expr)
+		((quote get_column) tblvar tbl_ignorecase col col_ignorecase)
+		(replace_scalar_projection_input alias input replacement
+			(list (quote get_column) tblvar tbl_ignorecase col col_ignorecase))
+		(cons head tail) (cons head (map tail (lambda (item)
+			(replace_scalar_projection_input alias input replacement item))))
+		_ expr)))
+
 (define expr_refs_stage_output_alias? (lambda (expr)
 	(match expr
 		((symbol get_column) tblvar _tbl_ignorecase _col _col_ignorecase)
@@ -3463,7 +3525,13 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 		(define values_for_inner (map value_exprs (lambda (value_expr)
 			(canonical_column_expr_for_alias inner_default
 				(decorrelate_expr_with_pairs inner_default lookup_pairs value_expr)))))
-		(define value_ags (map values_for_inner (lambda (value_for_inner)
+		(define lifted_inputs (map values_for_inner (lambda (value_for_inner)
+			(scalar_projection_lifted_input inner_default value_for_inner))))
+		(define values_for_stage (map (produceN (count values_for_inner)) (lambda (i)
+			(begin
+				(define lifted_input (nth lifted_inputs i))
+				(if (nil? lifted_input) (nth values_for_inner i) lifted_input)))))
+		(define value_ags (map values_for_stage (lambda (value_for_inner)
 			(car (scalar_single_aggregates value_for_inner)))))
 		(define count_ag aggregate_count_descriptor)
 		(define ags (dedupe_aggregates_by_col (merge (list value_ags (list count_ag)))))
@@ -3510,8 +3578,15 @@ IDs. Give each instance its own IDs and source aliases before their plans meet. 
 			(make_stage_output_relation stage_id)
 			(stage_source_outer? outer_sources)
 			(make_exists_stage_join_condition stage_alias key_names lookup_keys)))
-		(define output_exprs (map value_ags (lambda (output_ag)
-			(scalar_single_value_expr stage_input stage_alias output_ag count_ag))))
+		(define output_exprs (map (produceN (count value_ags)) (lambda (i)
+			(begin
+				(define output_ag (nth value_ags i))
+				(define stored (scalar_single_value_expr stage_input stage_alias output_ag count_ag))
+				(define lifted_input (nth lifted_inputs i))
+				(if (nil? lifted_input)
+					stored
+					(replace_scalar_projection_input inner_default lifted_input stored
+						(nth values_for_inner i)))))))
 		(list
 			(nth output_exprs output_index)
 			(list stage)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2094,6 +2094,56 @@ would still have to project that value over the segment. */
 					reduce_expr
 					false)))))))
 
+(define scalar_cardinality_scan_lookup_parts (lambda (sources default_alias src condition value_expr keys lookup_keys)
+	(begin
+		(define lookup_col (if (equal? (count keys) 1)
+			(direct_column_name_for_alias src (car keys)) nil))
+		(define result_col (direct_column_name_for_alias src value_expr))
+		(if (and
+			(source_is_base_table? src)
+			(equal? condition true)
+			(not (nil? lookup_col))
+			(not (nil? result_col))
+			(equal? (count lookup_keys) 1)
+			(not (expr_refs_alias? default_alias (source_alias src) (car lookup_keys))))
+			(list lookup_col
+				(lower_column_expr_for_join sources default_alias (car lookup_keys))
+				result_col)
+			nil))))
+
+(define lower_scalar_cardinality_scan_lookup_choice (lambda (stage lookup_expr scan_expr)
+	(begin
+		(define planning_session (qassoc_get (gs_facts stage) (quote physical_planning_session) nil))
+		/* The complete leaf match is measured dominant, so ordinary compilation
+		does not price or choose between competing scan plans. EXPLAIN CALIBRATE is the
+		only consumer which retains the displaced plan for an explicit A/B guard. */
+		(if (nil? (planner_physical_explain_accumulator planning_session))
+			lookup_expr
+			(begin
+				(define decision_id (concat "scan_lookup:" (gs_id stage)))
+				(define alternatives (list "scan_lookup" "scan_order"))
+				(define chosen (planner_physical_choice decision_id "scan_lookup" alternatives planning_session))
+				(define lookup_cost (planner_direct_presence_probe_cost 1))
+				(define scan_cost (planner_cost
+					planner_membership_scan_invocation_ns
+					planner_membership_scan_row_ns
+					planner_scalar_presence_probe_row_ns
+					0 0 planner_membership_map_column_row_ns 0 0 1 0.75))
+				(planner_record_physical_decision (list
+					(list "decision_id" decision_id)
+					(list "decision" "scan_lookup")
+					(list "decision_site" "scalar_cardinality_probe")
+					(list "chosen" chosen)
+					(list "normally_chosen" "scan_lookup")
+					(list "selection" "dominance")
+					(list "reason" "complete_indexed_scalar_probe_avoids_scan_materialization")
+					(list "inputs" (list (list "probe_invocations" 1)))
+					(list "alternatives" (list
+						(list (list "plan" "scan_lookup") (list "cost" (planner_cost_explain lookup_cost)))
+						(list (list "plan" "scan_order") (list "cost" (planner_cost_explain scan_cost))))))
+					planning_session)
+				(if (equal? chosen "scan_lookup") lookup_expr scan_expr)))))))
+
 (define lower_scalar_cardinality_probe_expr (lambda (sources default_alias stage requested_col)
 	(begin
 		(if (not (scalar_cardinality_probe_stage? stage))
@@ -2132,7 +2182,7 @@ would still have to project that value over the segment. */
 				(define filtercols (merge_unique (list condition_cols key_cols)))
 				(define unset (list (quote quote) (quote __scalar_cardinality_unset)))
 				(define partition_limit (stage_partition_limit stage))
-				(list (quote scan_order)
+				(define scan_expr (list (quote scan_order)
 					(physical_query_tx_symbol)
 					(source_table_expr src)
 					(cons (quote list) filtercols)
@@ -2156,7 +2206,21 @@ would still have to project that value over the segment. */
 							(list (quote error) "scalar subselect returned more than one row")))
 					unset
 					false
-					nil))))))
+					nil))
+				/* This is a complete physical subtree match. Residual predicates,
+				computed projections and compound keys keep the general scan. */
+				(define lookup_parts (scalar_cardinality_scan_lookup_parts
+					sources default_alias src condition value_expr keys lookup_keys))
+				(if (nil? lookup_parts)
+					scan_expr
+					(lower_scalar_cardinality_scan_lookup_choice stage
+						(list (quote scan_lookup)
+							(physical_query_tx_symbol)
+							(source_table_expr src)
+							(nth lookup_parts 0)
+							(nth lookup_parts 1)
+							(nth lookup_parts 2))
+						scan_expr)))))))
 
 (define collect_join_columns_acc (lambda (sources default_alias target_alias expr columns_by_alias)
 	(match expr

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -625,8 +625,16 @@ only partitioned FROM source would erase the block's row multiplicity
 		(define signatures (stage_semantic_signature_index stages))
 		/* Catalog lookups must return the same annotated immutable stage instances
 		that root lowering sees; otherwise nested probe copies derive old names. */
-		(define signature_stages (stages_with_shared_prepare_facts
+		(define canonical_stages (stages_with_shared_prepare_facts
 			(stages_with_canonical_group_caches stages signatures)))
+		/* Attach the compile-only handle after semantic signatures and canonical
+		cache names are complete. Physical expression decisions nested in a stage
+		can then participate in EXPLAIN CALIBRATE without changing its identity. */
+		(define planning_session (planner_context_session (qb_facts block)))
+		(define signature_stages (map canonical_stages (lambda (stage)
+			(if (scalar_cardinality_probe_stage? stage)
+				(group_stage_with_physical_planning_session stage planning_session)
+				stage))))
 		(define catalog (make_lowering_catalog signature_stages))
 		(define cataloged_stages (map (qb_stages block) (lambda (stage)
 			(begin
@@ -9473,7 +9481,11 @@ ordering run. Storage artifacts begin in build_queryplan. */
 				(if (equal? kind "direct_group_join")
 					(if (physical_expr_has_group_relation? plan)
 						"group_carrier" "direct_group_join")
-					"unknown"))))))
+					(if (equal? kind "scan_lookup")
+						(if (physical_expr_has_head? plan (quote scan_lookup))
+							"scan_lookup"
+							(if (physical_expr_has_head? plan (quote scan_order)) "scan_order" "unknown"))
+						"unknown")))))))
 
 (define physical_expr_has_group_relation? (lambda (expr)
 	(match expr

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -1,0 +1,144 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"sync"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+const scalarSubselectOverflow = "scalar subselect returned more than one row"
+
+// scanLookup reads one scalar through an equality-prefix index probe. It stops
+// after the second visible exact match because that is sufficient to enforce
+// scalar-subselect cardinality without constructing a scan reducer.
+func (t *table) scanLookup(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, resultCol string) scm.Scmer {
+	if t.hasTableLock() {
+		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
+	}
+	touchTempColumns(t, []string{lookupCol}, []string{resultCol})
+
+	boundary := columnboundaries{
+		col:            lookupCol,
+		matcher:        EqualMatcher,
+		lower:          lookupValue,
+		lowerInclusive: true,
+		upper:          lookupValue,
+		upperInclusive: true,
+	}
+	boundaries := []columnboundaries{boundary}
+
+	var mu sync.Mutex
+	result := scm.NewNil()
+	matches := 0
+	var panicValue any
+	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				mu.Lock()
+				if panicValue == nil {
+					panicValue = recovered
+				}
+				mu.Unlock()
+			}
+		}()
+		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
+			panic("query killed")
+		}
+		value, count := shard.scanLookup(boundary, lookupValue, resultCol, currentTx)
+		if count == 0 {
+			return
+		}
+		if solo {
+			result = value
+			matches = count
+			return
+		}
+		mu.Lock()
+		if matches == 0 {
+			result = value
+		}
+		matches += count
+		mu.Unlock()
+	})
+	if done != nil {
+		<-done
+	}
+	if panicValue != nil {
+		panic(panicValue)
+	}
+	if matches > 1 {
+		panic(scalarSubselectOverflow)
+	}
+	return result
+}
+
+func (t *storageShard) scanLookup(boundary columnboundaries, lookupValue scm.Scmer, resultCol string, currentTx *TxContext) (scm.Scmer, int) {
+	t.ensureLoaded()
+	t.ensureMainCount(false)
+	lookupStorage := t.getColumnStorageOrPanic(boundary.col, false, currentTx)
+	resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
+	lookupReader := newCachedColumnReaderTx(lookupStorage, currentTx)
+	resultReader := newCachedColumnReaderTx(resultStorage, currentTx)
+	_, resultComputed := resultStorage.(*StorageComputeProxy)
+
+	bounds := []columnboundaries{boundary}
+	lower := []scm.Scmer{lookupValue}
+	result := scm.NewNil()
+	matches := 0
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	mainCount := t.main_count
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	var ids [8]uint32
+	t.iterateIndexForce(currentTx, bounds, lower, lookupValue, len(t.inserts), ids[:], true, func(batch []uint32) bool {
+		for _, recid := range batch {
+			var actual scm.Scmer
+			if recid < mainCount {
+				actual = lookupReader.GetValue(recid)
+			} else {
+				actual = t.getDelta(int(recid-mainCount), boundary.col)
+			}
+			if !scm.Equal(actual, lookupValue) {
+				continue
+			}
+			if acidMode {
+				if !currentTx.IsVisible(t, recid) {
+					continue
+				}
+			} else if t.deletions.Get(uint(recid)) {
+				continue
+			}
+
+			matches++
+			if matches == 1 {
+				if recid < mainCount || resultComputed {
+					result = resultReader.GetValue(recid)
+				} else {
+					result = t.getDelta(int(recid-mainCount), resultCol)
+				}
+			}
+			if matches == 2 {
+				return false
+			}
+		}
+		return true
+	})
+	return result, matches
+}

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func setupScanLookupTable(tb testing.TB, database string, rows [][]scm.Scmer) *table {
+	tb.Helper()
+	databases.Remove(database)
+	tb.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	tbl, _ := CreateTable(database, "items", Memory, true)
+	tbl.CreateColumn("key", "INT", nil, nil)
+	tbl.CreateColumn("value", "VARCHAR", nil, nil)
+	tbl.Insert([]string{"key", "value"}, rows, nil, scm.NewNil(), false, nil)
+	return tbl
+}
+
+func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
+	tbl := setupScanLookupTable(t, "test_scan_lookup", [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewString("one")},
+		{scm.NewInt(2), scm.NewNil()},
+		{scm.NewInt(3), scm.NewString("first")},
+		{scm.NewInt(3), scm.NewString("second")},
+	})
+	tx := NewTxContext(TxCursorStability)
+
+	if got := tbl.scanLookup(tx, "key", scm.NewInt(1), "value"); !scm.Equal(got, scm.NewString("one")) {
+		t.Fatalf("scanLookup existing value = %s, want one", scm.String(got))
+	}
+	if got := tbl.scanLookup(tx, "key", scm.NewInt(2), "value"); !got.IsNil() {
+		t.Fatalf("scanLookup NULL value = %s, want nil", scm.String(got))
+	}
+	if got := tbl.scanLookup(tx, "key", scm.NewInt(99), "value"); !got.IsNil() {
+		t.Fatalf("scanLookup missing value = %s, want nil", scm.String(got))
+	}
+
+	defer func() {
+		if got := recover(); fmt.Sprint(got) != scalarSubselectOverflow {
+			t.Fatalf("scanLookup duplicate panic = %v, want %q", got, scalarSubselectOverflow)
+		}
+	}()
+	tbl.scanLookup(tx, "key", scm.NewInt(3), "value")
+}
+
+func TestScanLookupSchemeOperator(t *testing.T) {
+	Init(scm.Globalenv)
+	tbl := setupScanLookupTable(t, "test_scan_lookup_operator", [][]scm.Scmer{
+		{scm.NewInt(7), scm.NewString("seven")},
+	})
+	got := scm.Apply(
+		scm.Globalenv.Vars[scm.Symbol("scan_lookup")],
+		scm.NewAny(NewTxContext(TxCursorStability)),
+		NewTableScmer(tbl),
+		scm.NewString("key"),
+		scm.NewInt(7),
+		scm.NewString("value"),
+	)
+	if !scm.Equal(got, scm.NewString("seven")) {
+		t.Fatalf("scan_lookup operator = %s, want seven", scm.String(got))
+	}
+}
+
+func BenchmarkScanLookupWithTx(b *testing.B) {
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl := setupScanLookupTable(b, "bench_scan_lookup", rows)
+	tx := NewTxContext(TxCursorStability)
+	key := scm.NewInt(511)
+	// Warm the adaptive index before measuring the steady-state operator.
+	tbl.scanLookup(tx, "key", key, "value")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tbl.scanLookup(tx, "key", key, "value")
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1242,6 +1242,29 @@ func Init(en scm.Env) {
 	})
 
 	scm.Declare(&en, &scm.Declaration{
+		Name: "scan_lookup",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			return TableFromScmer(a[1]).scanLookup(
+				scmerToTxContext(a[0]),
+				a[2].String(),
+				a[3],
+				a[4].String(),
+			)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns one projected value through a direct equality-prefix index lookup; returns NULL for no visible match and errors on multiple matches",
+			HasSideEffects: true,
+			Params: []*scm.TypeDescriptor{
+				{Kind: "any", Label: "tx", Description: "transaction context used for visibility"},
+				{Kind: "table", Label: "table"},
+				{Kind: "string", Label: "lookupColumn", Description: "leading index-prefix column"},
+				{Kind: "any", Label: "lookupValue", Description: "exact value for the index-prefix column"},
+				{Kind: "string", Label: "resultColumn", Description: "column returned from the matching row"},
+			},
+			Return: &scm.TypeDescriptor{Kind: "any"},
+		},
+	})
+
+	scm.Declare(&en, &scm.Declaration{
 		Name: "scan",
 
 		Fn: func(a ...scm.Scmer) scm.Scmer {

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -25,6 +25,8 @@ setup:
   - sql: "DROP TABLE IF EXISTS pc_acl_domain"
   - sql: "DROP TABLE IF EXISTS pc_acl_assignment"
   - sql: "DROP TABLE IF EXISTS pc_acl_override"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_outer"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_values"
   # String-key membership prevents the target-side prefiltered projection and
   # isolates candidate startup from direct probe work.
   - sql: "DROP TABLE IF EXISTS pc_events"
@@ -46,6 +48,8 @@ setup:
   - sql: "CREATE TABLE pc_acl_domain (id INT PRIMARY KEY, direct_flag INT)"
   - sql: "CREATE TABLE pc_acl_assignment (domain_id INT, actor_id INT, allowed INT)"
   - sql: "CREATE TABLE pc_acl_override (domain_id INT, actor_id INT, allowed INT)"
+  - sql: "CREATE TABLE pc_lookup_outer (id INT, lookup_id INT)"
+  - sql: "CREATE TABLE pc_lookup_values (lookup_id INT, value VARCHAR(32), score INT)"
   - sql: "CREATE TABLE pc_events (id INT PRIMARY KEY, entity_key VARCHAR(32), event_time INT, kind VARCHAR(16))"
   - sql: "CREATE TABLE pc_keys (id INT PRIMARY KEY, enabled INT)"
   - sql: "CREATE TABLE pc_files_text (id INT PRIMARY KEY, filename VARCHAR(255), search VARCHAR(255)) ENGINE=memory"
@@ -113,6 +117,14 @@ setup:
             (concat (string_repeat (if (equal? (mod i 10) 0) "c" "x") 8192) (string i))
             (concat (string_repeat (if (equal? (mod i 7) 0) "c" "x") 8192) (string i))))))
   - scm: "(rebuild)"
+  # Keep the point-probe fixture in the delta index, matching the hot path used
+  # by small application lookup tables without perturbing the large rebuilds.
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "pc_lookup_outer") '("id" "lookup_id")
+          (list (list 1 10) (list 2 20) (list 3 30) (list 4 nil)))
+        (insert (table "memcp-tests" "pc_lookup_values") '("lookup_id" "value" "score")
+          (list (list 10 "ten" 100) (list 20 "twenty" 200) (list 30 nil 300))))
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_small"
@@ -124,12 +136,28 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_acl_domain"
   - sql: "DROP TABLE IF EXISTS pc_acl_assignment"
   - sql: "DROP TABLE IF EXISTS pc_acl_override"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_outer"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_values"
   - sql: "DROP TABLE IF EXISTS pc_events"
   - sql: "DROP TABLE IF EXISTS pc_keys"
   - sql: "DROP TABLE IF EXISTS pc_files_text"
   - sql: "DROP TABLE IF EXISTS pc_files_wide"
 
 test_cases:
+  # scan_lookup and scan_order are result-equivalent for this complete scalar
+  # point probe. Costgen forces both plans and rejects the physical dominance
+  # rule unless scan_lookup wins with the same warm fixture and result hash.
+  - name: "scalar point lookup dominance"
+    physical_calibration: true
+    calibration_decision: "scan_lookup"
+    warmup: 2
+    repetitions: 7
+    sql: |
+      SELECT d.id,
+        (SELECT v.score + 1 FROM pc_lookup_values v WHERE v.lookup_id = d.lookup_id) AS value
+      FROM pc_lookup_outer d
+      WHERE d.id = 1
+
   - name: "unordered selective joined reduction"
     physical_calibration: true
     calibration_decision: "scan_join_order"

--- a/tests/planner/joins/join-dedup.yaml
+++ b/tests/planner/joins/join-dedup.yaml
@@ -314,7 +314,7 @@ test_cases:
       contains:
         - "scalar subselect returned more than one row"
 
-  - name: "Scalar cardinality check uses direct lookup and reads at most two rows per key"
+  - name: "Scalar cardinality check physically reads at most two rows per key"
     sql: |
       EXPLAIN
       SELECT id,

--- a/tests/planner/joins/join-dedup.yaml
+++ b/tests/planner/joins/join-dedup.yaml
@@ -16,11 +16,12 @@ setup:
   - sql: |
       INSERT INTO jd_item (id, ref_id) VALUES (1, 10), (2, 20), (3, 10), (4, NULL)
   - sql: |
-      CREATE TABLE jd_ref (id INT, label VARCHAR(40), score INT)
+      CREATE TABLE jd_ref (id INT, label VARCHAR(40), score INT, doc VARCHAR(40))
   - sql: |
-      INSERT INTO jd_ref (id, label, score) VALUES
-        (10, 'Alpha', 100), (20, 'Beta', 200), (30, NULL, 300),
-        (40, NULL, 400), (40, 'duplicate', 401)
+      INSERT INTO jd_ref (id, label, score, doc) VALUES
+        (10, 'Alpha', 100, '{"n":10}'), (20, 'Beta', 200, '{"n":20}'),
+        (30, NULL, 300, NULL), (40, NULL, 400, NULL),
+        (40, 'duplicate', 401, '{"n":40}')
   - sql: |
       CREATE TABLE jd_permission (ref_id INT, allowed INT)
   - sql: |
@@ -313,7 +314,7 @@ test_cases:
       contains:
         - "scalar subselect returned more than one row"
 
-  - name: "Scalar cardinality check physically reads at most two rows per key"
+  - name: "Scalar cardinality check uses direct lookup and reads at most two rows per key"
     sql: |
       EXPLAIN
       SELECT id,
@@ -323,12 +324,72 @@ test_cases:
     expect:
       rows: 1
       result_contains:
-        - "scan_order"
+        - "scan_lookup"
         - "jd_ref"
-        - '\n\t\t\t\t\t0\n\t\t\t\t\t2\n'
       result_not_contains:
+        - "scan_order"
         - "scan_order_point"
         - ".grp:jd_ref"
+
+  - name: "Cost calibration can force scalar lookup alternatives"
+    sql: |
+      EXPLAIN PHYSICAL CALIBRATE DISCOVER
+      SELECT id,
+        (SELECT label FROM jd_ref WHERE jd_ref.id = jd_item.ref_id) AS label
+      FROM jd_item
+      WHERE jd_item.id = 1
+    expect:
+      rows: 1
+      data:
+        - decision: "scan_lookup"
+          alternatives:
+            - "scan_lookup"
+            - "scan_order"
+
+  - name: "Scalar arithmetic is evaluated outside the point lookup"
+    sql: |
+      EXPLAIN
+      SELECT (SELECT score + 2 FROM jd_ref
+              WHERE jd_ref.id = jd_item.ref_id) AS adjusted
+      FROM jd_item
+      WHERE jd_item.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+        - "(+"
+      result_not_contains:
+        - "scan_order"
+
+  - name: "Scalar JSON calculation is evaluated outside the point lookup"
+    sql: |
+      EXPLAIN
+      SELECT (SELECT JSON_EXTRACT(doc, '$.n') FROM jd_ref
+              WHERE jd_ref.id = jd_item.ref_id) AS extracted
+      FROM jd_item
+      WHERE jd_item.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+        - "json_extract"
+      result_not_contains:
+        - "scan_order"
+
+  - name: "Lifted scalar calculations preserve NULL and missing-row semantics"
+    sql: |
+      SELECT id,
+        (SELECT score + 2 FROM jd_ref WHERE jd_ref.id = jd_item.ref_id) AS adjusted
+      FROM jd_item
+      WHERE id IN (1, 4)
+      ORDER BY id
+    expect:
+      rows: 2
+      data:
+        - id: 1
+          adjusted: 102
+        - id: 4
+          adjusted: null
 
   - name: "Explicit scalar LIMIT 1 physically owns an unordered bounded scan"
     sql: |

--- a/tools/costgen/main.go
+++ b/tools/costgen/main.go
@@ -325,6 +325,12 @@ func main() {
 		printModelComparison("direct_group_join", directGroupObservations, c)
 		printDecisionOrdering(directGroupObservations, c)
 	}
+	scanLookupObservations := filterDecisionObservations(observations, "scan_lookup")
+	if len(scanLookupObservations) > 0 {
+		if err := validateScanLookupDominance(scanLookupObservations); err != nil {
+			fatal(fmt.Errorf("scan_lookup: %w", err))
+		}
+	}
 	logStep("selected downstream probe coefficient=%d ns/probe", c.downstreamProbeRowNS)
 	if err := validateDecisionOrdering(training, c); err != nil {
 		fatal(err)
@@ -1091,6 +1097,10 @@ func validateRaceWinner(row calibrationRow, decisionID, plan string) error {
 			row.RowsPerProbe == nil || row.AggregateWidth == nil {
 			return fmt.Errorf("direct grouped join variant has incomplete measurements: %+v", row)
 		}
+	} else if row.Decision == "scan_lookup" {
+		if row.ProbeInvocations == nil {
+			return fmt.Errorf("scan_lookup variant has incomplete measurements: %+v", row)
+		}
 	} else if row.CandidateInputRows == nil || row.CandidateRows == nil ||
 		row.DriverInputRows == nil || row.DriverRows == nil || row.ExpectedDriverRowsVisited == nil {
 		return fmt.Errorf("membership variant has incomplete measurements: %+v", row)
@@ -1251,6 +1261,18 @@ func medianRows(runs [][]calibrationRow) ([]calibrationRow, error) {
 }
 
 func rowFeatures(row calibrationRow) ([]float64, error) {
+	if row.Decision == "scan_lookup" {
+		if row.ProbeInvocations == nil {
+			return nil, fmt.Errorf("scan_lookup work profile contains nil probe count: %+v", row)
+		}
+		if row.Plan != "scan_lookup" && row.Plan != "scan_order" {
+			return nil, fmt.Errorf("unsupported scan_lookup plan %q", row.Plan)
+		}
+		// scan_lookup is a semantic dominance rule rather than another fitted
+		// membership coefficient. Costgen executes both complete plans below and
+		// rejects the model if the specialized operator does not win.
+		return make([]float64, 25), nil
+	}
 	if row.Decision == "direct_group_join" {
 		if row.ProbeInvocations == nil || row.InputRows == nil || row.GroupRows == nil ||
 			row.RowsPerProbe == nil || row.AggregateWidth == nil {
@@ -1476,6 +1498,33 @@ func rowFeatures(row calibrationRow) ([]float64, error) {
 	default:
 		return nil, fmt.Errorf("unsupported plan %q", row.Plan)
 	}
+}
+
+func validateScanLookupDominance(rows []observation) error {
+	byCase := make(map[string]map[string]observation)
+	for _, row := range rows {
+		if byCase[row.caseName] == nil {
+			byCase[row.caseName] = make(map[string]observation)
+		}
+		byCase[row.caseName][row.plan] = row
+	}
+	for caseName, plans := range byCase {
+		lookup, lookupOK := plans["scan_lookup"]
+		scan, scanOK := plans["scan_order"]
+		if !lookupOK || !scanOK {
+			return fmt.Errorf("%q needs scan_lookup and scan_order observations", caseName)
+		}
+		if lookup.censored || scan.censored {
+			return fmt.Errorf("%q dominance comparison was censored", caseName)
+		}
+		if lookup.y >= scan.y {
+			return fmt.Errorf("%q specialized lookup did not win: %.0f ns >= %.0f ns", caseName, lookup.y, scan.y)
+		}
+		improvement := (scan.y - lookup.y) * 100 / scan.y
+		fmt.Printf("scan_lookup %-32s %.0f ns vs %.0f ns (%.1f%% faster)\n",
+			caseName, lookup.y, scan.y, improvement)
+	}
+	return nil
 }
 
 func orderedRecsetSortWork(rows float64) float64 {

--- a/tools/costgen/main_test.go
+++ b/tools/costgen/main_test.go
@@ -647,6 +647,20 @@ func TestResidualRefinementMustImproveDecisionPool(t *testing.T) {
 	}
 }
 
+func TestValidateScanLookupDominance(t *testing.T) {
+	rows := []observation{
+		{caseName: "point", decision: "scan_lookup", plan: "scan_lookup", y: 50},
+		{caseName: "point", decision: "scan_lookup", plan: "scan_order", y: 100},
+	}
+	if err := validateScanLookupDominance(rows); err != nil {
+		t.Fatalf("dominant scan_lookup rejected: %v", err)
+	}
+	rows[0].y = 101
+	if err := validateScanLookupDominance(rows); err == nil {
+		t.Fatal("slower scan_lookup accepted as dominant")
+	}
+}
+
 func TestRaceCalibrationVariantsCancelsSlowerPlan(t *testing.T) {
 	const decisionID = "membership_carrier:test"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What and why

- Add `scan_lookup(tx, table, match_columns, match_values, [result_column])` as a direct, transaction-aware exact index-prefix probe.
- Mark both match lists as non-escaping and retain a dedicated one-column implementation so authentication does not pay for composite-reader setup.
- With a result column, return the projected value directly, return `NULL` when no visible row matches, and reuse the scalar-subselect cardinality error when more than one visible row matches.
- Without a result column, return `true` on the first visible match and `false` when no row matches. Multiple matches are valid for this lightweight EXISTS form.
- Match complete one- and multi-column scalar leaf subtrees during physical planning. The matched lookup remains dominant, so ordinary planning skips costing displaced scan alternatives; `EXPLAIN PHYSICAL CALIBRATE` still retains both variants for measurement.
- Pull null-propagating arithmetic, JSON, and cache-presence calculations out of scans so the storage operator materializes only raw columns. Non-strict expressions such as `COALESCE` remain inside where required to distinguish a missing row from a matching `NULL`.
- Replace eligible password/admin reads in the SQL, MySQL, PostgreSQL, RDF, and dashboard frontends with `scan_lookup`.
- Replace database ACL count scans with a composite `(username, database)` boolean lookup in SQL policy and dashboard checks. The current `system.access` schema has database-level grants only; the operator supports longer `(table, user, mode, ...)` prefixes without another API change.
- Extend Costgen with a composite lookup calibration and add operator, cardinality, planner, authentication, ACL, and performance coverage.

## Manual A/B measurements

All paired comparisons used identical fixtures, warmup/sample settings, and result validation.

- End-to-end Costgen scalar query, 2 warmups and 7 repetitions: one-column `scan_lookup` **12.043 µs** versus `scan_order` **22.182 µs**, **45.7% faster**.
- End-to-end Costgen composite scalar query, 2 warmups and 7 repetitions: two-column `scan_lookup` **13.125 µs** versus `scan_order` **24.186 µs**, **45.7% faster**. This confirms that lookup dominance still holds for the multi-dimensional case, so ordinary planning need not estimate the alternative.
- Authenticated HTTP `SELECT 1`, fresh identical data directories, HTTP keep-alive, concurrency 1, 1,000 warmup requests and five alternating 10,000-request samples: median throughput increased from **10,710.87 to 11,533.83 requests/s** (**+7.68%**); reciprocal request latency fell from **93.363 to 86.701 µs** (**-7.14%**).
- Storage dimension microbenchmark, warm 1,024-row index, cursor-stability transaction, `-benchtime=3s -count=5`: projected value lookup median **1,693 ns/op** for one column and **2,128 ns/op** for two columns (**+25.7% composite overhead**); boolean EXISTS median **1,735 ns/op** and **2,238 ns/op** respectively (**+29.0%**). Composite setup uses **744 B/op and 11 allocations/op** versus **432 B/op and 9 allocations/op** for the dedicated one-column path.
- The original general-scan comparison remains **2,965 ns/op, 1,035 B/op, 13 allocs/op** versus the direct one-column lookup at **1,726 ns/op, 432 B/op, 9 allocs/op** (**41.8% faster**, **58.3% fewer bytes**, **30.8% fewer allocations**).

Costgen rejects calibration when either lookup variant does not beat `scan_order`, a run is censored, or result hashes differ.

## Verification

- Focused pre-commit suites: planner join/scalar probes, MySQL authentication, policy enforcement, RDF helpers, and dashboard regressions (all passed).
- Performance-enabled authentication suite: **0.6 ms / 2 ms** threshold for 100 cached samples (passed).
- `go test ./storage -run 'TestScanLookup' -count=1` (passed).
- `go test ./storage -run '^$' -bench 'BenchmarkScanLookup(Dimensions|WithTx)$' -benchmem -benchtime=3s -count=5` (passed).
- `go run ./tools/costgen` (both scalar lookup dominance checks passed).

The complete storage package currently reproduces the unrelated `TestRebuildInsideActiveTransactionDoesNotWaitForItself` failure on both this branch and the detached pre-change baseline; the focused storage and integration coverage above passes.
