### PR TITLE
Extend scan_lookup to composite ACL probes

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -95,10 +95,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* check if user has access to a specific database */
 (define dashboard_has_db_access (lambda (username is_admin dbname)
 	(if is_admin true
-		(> (scan nil (table "system" "access")
-			'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db dbname)))
-			'() (lambda (acc) (+ acc 1))
-			0 +) 0)
+		(scan_lookup nil (table "system" "access")
+			'("username" "database") (list username dbname))
 	)
 ))
 
@@ -132,7 +130,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* helper: build JSON for a single user entry (takes username string) */
 (define dashboard_build_user_json (lambda (uname) (begin
-	(set is_adm (scan nil (table "system" "user") '("username") (lambda (u) (equal? u uname)) '("admin") (lambda (acc a) a) false (lambda (a b) b)))
+	(set is_adm (scan_lookup nil (table "system" "user") '("username") (list uname) "admin"))
 	/* get database access for non-admins */
 	(set dbs_csv (if is_adm ""
 		(scan nil (table "system" "access") '("username") (lambda (u) (equal?? u uname))
@@ -353,7 +351,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(dashboard_send_401 res)
 					(begin
 						(define default_pw (if is_admin
-							(scan nil (table "system" "user") '("username") (lambda (username) (equal? username "root")) '("password") (lambda (acc pw) (equal? pw (password "admin"))) false (lambda (a b) b))
+							(equal? (scan_lookup nil (table "system" "user") '("username") '("root") "password")
+								(password "admin"))
 							false))
 						(dashboard_send_json res (concat
 							"{\"admin\":" (if is_admin "true" "false")

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2094,22 +2094,32 @@ would still have to project that value over the segment. */
 					reduce_expr
 					false)))))))
 
-(define scalar_cardinality_scan_lookup_parts (lambda (sources default_alias src condition value_expr keys lookup_keys)
+(define direct_exact_scan_lookup_parts (lambda (sources default_alias src condition keys lookup_keys)
 	(begin
-		(define lookup_col (if (equal? (count keys) 1)
-			(direct_column_name_for_alias src (car keys)) nil))
-		(define result_col (direct_column_name_for_alias src value_expr))
+		(define lookup_cols (map keys (lambda (key)
+			(direct_column_name_for_alias src key))))
 		(if (and
 			(source_is_base_table? src)
 			(equal? condition true)
-			(not (nil? lookup_col))
-			(not (nil? result_col))
-			(equal? (count lookup_keys) 1)
-			(not (expr_refs_alias? default_alias (source_alias src) (car lookup_keys))))
-			(list lookup_col
-				(lower_column_expr_for_join sources default_alias (car lookup_keys))
-				result_col)
+			(not (empty_list? lookup_cols))
+			(not (reduce lookup_cols (lambda (missing col)
+				(or missing (nil? col))) false))
+			(equal? (count lookup_keys) (count lookup_cols))
+			(not (reduce lookup_keys (lambda (dependent key)
+				(or dependent (expr_refs_alias? default_alias (source_alias src) key))) false)))
+			(list lookup_cols
+				(map lookup_keys (lambda (key)
+					(lower_column_expr_for_join sources default_alias key))))
 			nil))))
+
+(define scalar_cardinality_scan_lookup_parts (lambda (sources default_alias src condition value_expr keys lookup_keys)
+	(begin
+		(define lookup_parts (direct_exact_scan_lookup_parts
+			sources default_alias src condition keys lookup_keys))
+		(define result_col (direct_column_name_for_alias src value_expr))
+		(if (or (nil? lookup_parts) (nil? result_col))
+			nil
+			(list (nth lookup_parts 0) (nth lookup_parts 1) result_col)))))
 
 (define lower_scalar_cardinality_scan_lookup_choice (lambda (stage lookup_expr scan_expr)
 	(begin
@@ -2207,8 +2217,8 @@ would still have to project that value over the segment. */
 					unset
 					false
 					nil))
-				/* This is a complete physical subtree match. Residual predicates,
-				computed projections and compound keys keep the general scan. */
+				/* This is a complete physical subtree match. Residual predicates
+				keep the general scan; compound exact keys remain direct probes. */
 				(define lookup_parts (scalar_cardinality_scan_lookup_parts
 					sources default_alias src condition value_expr keys lookup_keys))
 				(if (nil? lookup_parts)
@@ -2217,8 +2227,8 @@ would still have to project that value over the segment. */
 						(list (quote scan_lookup)
 							(physical_query_tx_symbol)
 							(source_table_expr src)
-							(nth lookup_parts 0)
-							(nth lookup_parts 1)
+							(cons (quote list) (nth lookup_parts 0))
+							(cons (quote list) (nth lookup_parts 1))
 							(nth lookup_parts 2))
 						scan_expr)))))))
 
@@ -2841,14 +2851,18 @@ cache identity or a logical fallback. */
 			true)
 		(define key_names (group_key_cols keys))
 		(define value_col (aggregate_col_name_using (gs_input stage) (car (gs_aggregates stage))))
-		(define filtercols (merge_unique (list key_names (list value_col))))
-		(define key_terms (map (produceN (count keys)) (lambda (i)
-			(list (quote equal??)
-				(symbol (nth key_names i))
-				(lower_column_expr_for_join sources default_alias (nth lookup_keys i))))))
-		(define filter_condition (combine_where_terms
-			(cons (stage_recset_value_filter_term stage value_col) key_terms)
-			true))
+		(define lookup_expr (list (quote scan_lookup)
+			(physical_query_tx_symbol)
+			(list (quote table) (group_stage_cache_schema stage) (group_stage_cache_relation stage))
+			(cons (quote list) key_names)
+			(cons (quote list) (map lookup_keys (lambda (key)
+				(lower_column_expr_for_join sources default_alias key))))
+			value_col))
+		/* The cache keys are unique. Read its raw aggregate with one point probe,
+		then apply the presence calculation outside the storage operator. */
+		(define presence_expr (if (presence_probe_stage? stage)
+			(list (quote >) (list (quote coalesceNil) lookup_expr 0) 0)
+			(list (quote equal??) lookup_expr true)))
 		(define raw_input (gs_input stage))
 		(define stamped_catalog (qassoc_get (gs_facts stage) (quote stage_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
@@ -2856,13 +2870,7 @@ cache identity or a logical fallback. */
 				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 		(list (quote begin)
 			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
-			(list (quote scan_exists)
-				(physical_query_tx_symbol)
-				(list (quote table) (group_stage_cache_schema stage) (group_stage_cache_relation stage))
-				(cons (quote list) filtercols)
-				(list (quote lambda)
-					(map filtercols symbol)
-					filter_condition))))))
+			presence_expr))))
 
 /* driver_membership_probe markers reach physical lowering through two
 routes: as a WHERE-term (stripped by driver_membership_for_source, built via
@@ -2902,14 +2910,22 @@ would lose nested-stage and join semantics. */
 						(define filtercols (merge_unique (list
 							(extract_columns_for_alias input_src condition)
 							(merge_unique (map keys (lambda (key) (extract_columns_for_alias input_src key)))))))
-						(list (quote scan_exists)
-							(physical_query_tx_symbol)
-							(source_table_expr input_src)
-							(cons (quote list) filtercols)
-							(list (quote lambda)
-								(map filtercols (lambda (col) (symbol (concat (source_alias input_src) "." col))))
-								(cons (quote and)
-									(cons (lower_column_expr_for_alias input_src condition) key_terms))))))))))))
+						(define lookup_parts (direct_exact_scan_lookup_parts
+							sources default_alias input_src condition keys lookup_keys))
+						(if (nil? lookup_parts)
+							(list (quote scan_exists)
+								(physical_query_tx_symbol)
+								(source_table_expr input_src)
+								(cons (quote list) filtercols)
+								(list (quote lambda)
+									(map filtercols (lambda (col) (symbol (concat (source_alias input_src) "." col))))
+									(cons (quote and)
+										(cons (lower_column_expr_for_alias input_src condition) key_terms))))
+							(list (quote scan_lookup)
+								(physical_query_tx_symbol)
+								(source_table_expr input_src)
+								(cons (quote list) (nth lookup_parts 0))
+								(cons (quote list) (nth lookup_parts 1))))))))))))
 
 (define lower_dml_driver_membership_probe_expr (lambda (sources default_alias fallback_schema stage _probe)
 	(begin

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2851,18 +2851,14 @@ cache identity or a logical fallback. */
 			true)
 		(define key_names (group_key_cols keys))
 		(define value_col (aggregate_col_name_using (gs_input stage) (car (gs_aggregates stage))))
-		(define lookup_expr (list (quote scan_lookup)
-			(physical_query_tx_symbol)
-			(list (quote table) (group_stage_cache_schema stage) (group_stage_cache_relation stage))
-			(cons (quote list) key_names)
-			(cons (quote list) (map lookup_keys (lambda (key)
-				(lower_column_expr_for_join sources default_alias key))))
-			value_col))
-		/* The cache keys are unique. Read its raw aggregate with one point probe,
-		then apply the presence calculation outside the storage operator. */
-		(define presence_expr (if (presence_probe_stage? stage)
-			(list (quote >) (list (quote coalesceNil) lookup_expr 0) 0)
-			(list (quote equal??) lookup_expr true)))
+		(define filtercols (merge_unique (list key_names (list value_col))))
+		(define key_terms (map (produceN (count keys)) (lambda (i)
+			(list (quote equal??)
+				(symbol (nth key_names i))
+				(lower_column_expr_for_join sources default_alias (nth lookup_keys i))))))
+		(define filter_condition (combine_where_terms
+			(cons (stage_recset_value_filter_term stage value_col) key_terms)
+			true))
 		(define raw_input (gs_input stage))
 		(define stamped_catalog (qassoc_get (gs_facts stage) (quote stage_catalog) '()))
 		(define stage_catalog (stage_catalog_with_nested
@@ -2870,7 +2866,13 @@ cache identity or a logical fallback. */
 				(if (query_block? raw_input) (query_block_stage_catalog raw_input) '())))))
 		(list (quote begin)
 			(lower_group_stage_prepare_using stage_catalog stage_catalog stage true nil)
-			presence_expr))))
+			(list (quote scan_exists)
+				(physical_query_tx_symbol)
+				(list (quote table) (group_stage_cache_schema stage) (group_stage_cache_relation stage))
+				(cons (quote list) filtercols)
+				(list (quote lambda)
+					(map filtercols symbol)
+					filter_condition))))))
 
 /* driver_membership_probe markers reach physical lowering through two
 routes: as a WHERE-term (stripped by driver_membership_for_source, built via

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -38,7 +38,7 @@ this is how rdf works:
 	(set old_handler (coalesce http_handler handler_404))
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (acc password) password) nil (lambda (a b) b)))
+		(set pw (scan_lookup nil (table "system" "user") '("username") (list (req "username")) "password"))
 		(if (and pw (equal? pw (password (req "password")))) (time (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)
@@ -59,7 +59,7 @@ this is how rdf works:
 	)))
 	(define handle_ttl_load (lambda (req res schema ttl_data) (begin
 		/* check for password */
-		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (acc password) password) nil (lambda (a b) b)))
+		(set pw (scan_lookup nil (table "system" "user") '("username") (list (req "username")) "password"))
 		(if (and pw (equal? pw (password (req "password")))) (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -617,10 +617,8 @@ if the user is not allowed to access this property, the function will throw an e
 */
 (define sql_policy (lambda (username)
 	(begin
-		(define is_admin (scan nil (table "system" "user")
-			'("username") (lambda (u) (equal?? u username))
-			'("admin") (lambda (acc a) (or acc a))
-			false (lambda (a b) (or a b))))
+		(define is_admin (scan_lookup nil (table "system" "user")
+			'("username") (list username) "admin"))
 		(if is_admin (lambda (schema tblname write) true) /* admin -> allow all */
 			/* else: complicated policy */
 			(lambda (schema tblname write)
@@ -628,11 +626,9 @@ if the user is not allowed to access this property, the function will throw an e
 					/* Allow virtual INFORMATION_SCHEMA for all users */
 					(if (equal?? schema "information_schema") true (begin
 						/* Database-level check via system.access */
-						(define access_count (scan nil (table "system" "access")
-							'("username" "database") (lambda (u db) (and (equal?? u username) (equal?? db schema)))
-							'() (lambda (acc) (+ acc 1))
-							0 +))
-						(if (> access_count 0) true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
+						(define has_access (scan_lookup nil (table "system" "access")
+							'("username" "database") (list username schema)))
+						(if has_access true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
 					))
 			))
 		)
@@ -779,7 +775,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	(set old_handler http_handler)
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (acc password) password) nil (lambda (a b) b)))
+		(set pw (scan_lookup nil (table "system" "user") '("username") (list (req "username")) "password"))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -824,7 +820,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	)))
 	(define handle_query_postgres (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan nil (table "system" "user") '("username") (lambda (username) (equal? username (req "username"))) '("password") (lambda (acc password) password) nil (lambda (a b) b)))
+		(set pw (scan_lookup nil (table "system" "user") '("username") (list (req "username")) "password"))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -954,7 +950,8 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 (service_registry "SCM Frontend" (list (arg "api-port" (env "PORT" "4321")) "/scm" "POST, JSON"))
 
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
-(set mysql_auth (lambda (username_) (scan nil (table "system" "user") '("username") (lambda (username) (equal? username username_)) '("password") (lambda (acc password) password) nil (lambda (a b) b))))
+(set mysql_auth (lambda (username_)
+	(scan_lookup nil (table "system" "user") '("username") (list username_) "password")))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
 
 /* Top-level so the interpreter compiles this body once instead of rebuilding a

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -17,21 +17,39 @@ Copyright (C) 2026  Carl-Philip Hänsch
 package storage
 
 import (
+	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/launix-de/memcp/scm"
 )
 
 const scalarSubselectOverflow = "scalar subselect returned more than one row"
 
-// scanLookup reads one scalar through an equality-prefix index probe. It stops
-// after the second visible exact match because that is sufficient to enforce
-// scalar-subselect cardinality without constructing a scan reducer.
-func (t *table) scanLookup(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, resultCol string) scm.Scmer {
+// scanLookup probes an exact index prefix. Omitting resultCol turns it into a
+// lightweight existence check; scalar value lookups stop after the second
+// visible match to enforce scalar-subselect cardinality.
+func (t *table) scanLookup(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
+	if len(lookupCols) == 0 || len(lookupCols) != len(lookupValues) {
+		panic(fmt.Sprintf("scan_lookup needs equally sized non-empty match column and value lists, got %d and %d", len(lookupCols), len(lookupValues)))
+	}
+	// Keep the dominant authentication and scalar-subselect case free of the
+	// per-dimension reader slices needed by composite probes.
+	if len(lookupCols) == 1 {
+		return t.scanLookupOne(currentTx, lookupCols[0], lookupValues[0], resultCol, returnValue)
+	}
+	return t.scanLookupMany(currentTx, lookupCols, lookupValues, resultCol, returnValue)
+}
+
+func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
 	if t.hasTableLock() {
 		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
 	}
-	touchTempColumns(t, []string{lookupCol}, []string{resultCol})
+	var resultCols []string
+	if returnValue {
+		resultCols = []string{resultCol}
+	}
+	touchTempColumns(t, []string{lookupCol}, resultCols)
 
 	boundary := columnboundaries{
 		col:            lookupCol,
@@ -60,7 +78,7 @@ func (t *table) scanLookup(currentTx *TxContext, lookupCol string, lookupValue s
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		value, count := shard.scanLookup(boundary, lookupValue, resultCol, currentTx)
+		value, count := shard.scanLookupOne(boundary, lookupValue, resultCol, returnValue, currentTx)
 		if count == 0 {
 			return
 		}
@@ -85,21 +103,28 @@ func (t *table) scanLookup(currentTx *TxContext, lookupCol string, lookupValue s
 	if matches > 1 {
 		panic(scalarSubselectOverflow)
 	}
+	if !returnValue {
+		return scm.NewBool(matches != 0)
+	}
 	return result
 }
 
-func (t *storageShard) scanLookup(boundary columnboundaries, lookupValue scm.Scmer, resultCol string, currentTx *TxContext) (scm.Scmer, int) {
+func (t *storageShard) scanLookupOne(boundary columnboundaries, lookupValue scm.Scmer, resultCol string, returnValue bool, currentTx *TxContext) (scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
 	lookupStorage := t.getColumnStorageOrPanic(boundary.col, false, currentTx)
-	resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
 	lookupReader := newCachedColumnReaderTx(lookupStorage, currentTx)
-	resultReader := newCachedColumnReaderTx(resultStorage, currentTx)
-	_, resultComputed := resultStorage.(*StorageComputeProxy)
+	var resultReader ColumnReader
+	resultComputed := false
+	if returnValue {
+		resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
+		resultReader = newCachedColumnReaderTx(resultStorage, currentTx)
+		_, resultComputed = resultStorage.(*StorageComputeProxy)
+	}
 
 	bounds := []columnboundaries{boundary}
 	lower := []scm.Scmer{lookupValue}
-	result := scm.NewNil()
+	result := scm.NewBool(false)
 	matches := 0
 
 	t.mu.RLock()
@@ -127,18 +152,167 @@ func (t *storageShard) scanLookup(boundary columnboundaries, lookupValue scm.Scm
 			}
 
 			matches++
-			if matches == 1 {
+			if matches == 1 && returnValue {
 				if recid < mainCount || resultComputed {
 					result = resultReader.GetValue(recid)
 				} else {
 					result = t.getDelta(int(recid-mainCount), resultCol)
 				}
 			}
-			if matches == 2 {
+			if !returnValue || matches == 2 {
 				return false
 			}
 		}
 		return true
+	})
+	return result, matches
+}
+
+func exactLookupBoundaries(cols []string, values []scm.Scmer) boundaries {
+	result := make(boundaries, len(cols))
+	for i, col := range cols {
+		result[i] = columnboundaries{
+			col: col, matcher: EqualMatcher,
+			lower: values[i], lowerInclusive: true,
+			upper: values[i], upperInclusive: true,
+		}
+	}
+	return result
+}
+
+func (t *table) scanLookupMany(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
+	if t.hasTableLock() {
+		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
+	}
+	var resultCols []string
+	if returnValue {
+		resultCols = []string{resultCol}
+	}
+	touchTempColumns(t, lookupCols, resultCols)
+	boundaries := exactLookupBoundaries(lookupCols, lookupValues)
+
+	var mu sync.Mutex
+	var stop atomic.Bool
+	result := scm.NewBool(false)
+	matches := 0
+	var panicValue any
+	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
+		if stop.Load() {
+			return
+		}
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				mu.Lock()
+				if panicValue == nil {
+					panicValue = recovered
+				}
+				mu.Unlock()
+				stop.Store(true)
+			}
+		}()
+		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
+			panic("query killed")
+		}
+		value, count := shard.scanLookupMany(boundaries, lookupValues, resultCol, returnValue, currentTx, &stop)
+		if count == 0 {
+			return
+		}
+		if solo {
+			result = value
+			matches = count
+			return
+		}
+		mu.Lock()
+		if matches == 0 {
+			result = value
+		}
+		matches += count
+		if !returnValue || matches > 1 {
+			stop.Store(true)
+		}
+		mu.Unlock()
+	})
+	if done != nil {
+		<-done
+	}
+	if panicValue != nil {
+		panic(panicValue)
+	}
+	if !returnValue {
+		return scm.NewBool(matches != 0)
+	}
+	if matches > 1 {
+		panic(scalarSubselectOverflow)
+	}
+	if matches == 0 {
+		return scm.NewNil()
+	}
+	return result
+}
+
+func (t *storageShard) scanLookupMany(bounds boundaries, lookupValues []scm.Scmer, resultCol string, returnValue bool, currentTx *TxContext, stop *atomic.Bool) (scm.Scmer, int) {
+	t.ensureLoaded()
+	t.ensureMainCount(false)
+	lookupReaders := make([]ColumnReader, len(bounds))
+	for i, boundary := range bounds {
+		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(boundary.col, false, currentTx), currentTx)
+	}
+	var resultReader ColumnReader
+	resultComputed := false
+	if returnValue {
+		resultStorage := t.getColumnStorageOrPanic(resultCol, false, currentTx)
+		resultReader = newCachedColumnReaderTx(resultStorage, currentTx)
+		_, resultComputed = resultStorage.(*StorageComputeProxy)
+	}
+
+	result := scm.NewBool(false)
+	matches := 0
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	mainCount := t.main_count
+	acidMode := currentTx != nil && currentTx.Mode == TxACID
+	var ids [8]uint32
+	t.iterateIndexForce(currentTx, bounds, lookupValues, lookupValues[len(lookupValues)-1], len(t.inserts), ids[:], true, func(batch []uint32) bool {
+		if stop.Load() {
+			return false
+		}
+		for _, recid := range batch {
+			exact := true
+			for i, boundary := range bounds {
+				var actual scm.Scmer
+				if recid < mainCount {
+					actual = lookupReaders[i].GetValue(recid)
+				} else {
+					actual = t.getDelta(int(recid-mainCount), boundary.col)
+				}
+				if !scm.Equal(actual, lookupValues[i]) {
+					exact = false
+					break
+				}
+			}
+			if !exact {
+				continue
+			}
+			if acidMode {
+				if !currentTx.IsVisible(t, recid) {
+					continue
+				}
+			} else if t.deletions.Get(uint(recid)) {
+				continue
+			}
+			matches++
+			if matches == 1 && returnValue {
+				if recid < mainCount || resultComputed {
+					result = resultReader.GetValue(recid)
+				} else {
+					result = t.getDelta(int(recid-mainCount), resultCol)
+				}
+			}
+			if !returnValue || matches == 2 {
+				return false
+			}
+		}
+		return !stop.Load()
 	})
 	return result, matches
 }

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -36,9 +36,24 @@ func (t *table) scanLookup(currentTx *TxContext, lookupCols []string, lookupValu
 	// Keep the dominant authentication and scalar-subselect case free of the
 	// per-dimension reader slices needed by composite probes.
 	if len(lookupCols) == 1 {
+		if lookupValues[0].IsNil() {
+			return scanLookupMiss(returnValue)
+		}
 		return t.scanLookupOne(currentTx, lookupCols[0], lookupValues[0], resultCol, returnValue)
 	}
+	for _, value := range lookupValues {
+		if value.IsNil() {
+			return scanLookupMiss(returnValue)
+		}
+	}
 	return t.scanLookupMany(currentTx, lookupCols, lookupValues, resultCol, returnValue)
+}
+
+func scanLookupMiss(returnValue bool) scm.Scmer {
+	if returnValue {
+		return scm.NewNil()
+	}
+	return scm.NewBool(false)
 }
 
 func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, resultCol string, returnValue bool) scm.Scmer {

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -30,9 +30,7 @@ const scalarSubselectOverflow = "scalar subselect returned more than one row"
 // lightweight existence check; scalar value lookups stop after the second
 // visible match to enforce scalar-subselect cardinality.
 func (t *table) scanLookup(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
-	if len(lookupCols) == 0 || len(lookupCols) != len(lookupValues) {
-		panic(fmt.Sprintf("scan_lookup needs equally sized non-empty match column and value lists, got %d and %d", len(lookupCols), len(lookupValues)))
-	}
+	validateScanLookupDimensions(len(lookupCols), len(lookupValues))
 	// Keep the dominant authentication and scalar-subselect case free of the
 	// per-dimension reader slices needed by composite probes.
 	if len(lookupCols) == 1 {
@@ -47,6 +45,12 @@ func (t *table) scanLookup(currentTx *TxContext, lookupCols []string, lookupValu
 		}
 	}
 	return t.scanLookupMany(currentTx, lookupCols, lookupValues, resultCol, returnValue)
+}
+
+func validateScanLookupDimensions(columnCount, valueCount int) {
+	if columnCount == 0 || columnCount != valueCount {
+		panic(fmt.Sprintf("scan_lookup needs equally sized non-empty match column and value lists, got %d and %d", columnCount, valueCount))
+	}
 }
 
 func scanLookupMiss(returnValue bool) scm.Scmer {

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -44,13 +44,13 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 	})
 	tx := NewTxContext(TxCursorStability)
 
-	if got := tbl.scanLookup(tx, "key", scm.NewInt(1), "value"); !scm.Equal(got, scm.NewString("one")) {
+	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(1)}, "value", true); !scm.Equal(got, scm.NewString("one")) {
 		t.Fatalf("scanLookup existing value = %s, want one", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, "key", scm.NewInt(2), "value"); !got.IsNil() {
+	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(2)}, "value", true); !got.IsNil() {
 		t.Fatalf("scanLookup NULL value = %s, want nil", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, "key", scm.NewInt(99), "value"); !got.IsNil() {
+	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(99)}, "value", true); !got.IsNil() {
 		t.Fatalf("scanLookup missing value = %s, want nil", scm.String(got))
 	}
 
@@ -59,7 +59,7 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 			t.Fatalf("scanLookup duplicate panic = %v, want %q", got, scalarSubselectOverflow)
 		}
 	}()
-	tbl.scanLookup(tx, "key", scm.NewInt(3), "value")
+	tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(3)}, "value", true)
 }
 
 func TestScanLookupSchemeOperator(t *testing.T) {
@@ -71,12 +71,53 @@ func TestScanLookupSchemeOperator(t *testing.T) {
 		scm.Globalenv.Vars[scm.Symbol("scan_lookup")],
 		scm.NewAny(NewTxContext(TxCursorStability)),
 		NewTableScmer(tbl),
-		scm.NewString("key"),
-		scm.NewInt(7),
+		scm.NewSlice([]scm.Scmer{scm.NewString("key")}),
+		scm.NewSlice([]scm.Scmer{scm.NewInt(7)}),
 		scm.NewString("value"),
 	)
 	if !scm.Equal(got, scm.NewString("seven")) {
 		t.Fatalf("scan_lookup operator = %s, want seven", scm.String(got))
+	}
+	exists := scm.Apply(
+		scm.Globalenv.Vars[scm.Symbol("scan_lookup")],
+		scm.NewAny(NewTxContext(TxCursorStability)),
+		NewTableScmer(tbl),
+		scm.NewSlice([]scm.Scmer{scm.NewString("key")}),
+		scm.NewSlice([]scm.Scmer{scm.NewInt(7)}),
+	)
+	if !scm.ToBool(exists) {
+		t.Fatal("scan_lookup existence operator returned false")
+	}
+}
+
+func TestScanLookupCompositeValueAndExists(t *testing.T) {
+	database := "test_scan_lookup_composite"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	tbl, _ := CreateTable(database, "items", Memory, true)
+	tbl.CreateColumn("tenant", "INT", nil, nil)
+	tbl.CreateColumn("key", "INT", nil, nil)
+	tbl.CreateColumn("value", "VARCHAR", nil, nil)
+	tbl.Insert([]string{"tenant", "key", "value"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(7), scm.NewString("one-seven")},
+		{scm.NewInt(2), scm.NewInt(7), scm.NewString("two-seven")},
+		{scm.NewInt(2), scm.NewInt(8), scm.NewString("two-eight")},
+	}, nil, scm.NewNil(), false, nil)
+	tx := NewTxContext(TxCursorStability)
+	cols := []string{"tenant", "key"}
+
+	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}, "value", true); !scm.Equal(got, scm.NewString("two-seven")) {
+		t.Fatalf("composite scanLookup = %s, want two-seven", scm.String(got))
+	}
+	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(9), scm.NewInt(7)}, "", false); scm.ToBool(got) {
+		t.Fatal("missing composite existence lookup returned true")
+	}
+	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}, "", false); !scm.ToBool(got) {
+		t.Fatal("matching composite existence lookup returned false")
+	}
+	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(7)}, "", false); !scm.ToBool(got) {
+		t.Fatal("existence lookup with multiple matches returned false")
 	}
 }
 
@@ -88,12 +129,58 @@ func BenchmarkScanLookupWithTx(b *testing.B) {
 	tbl := setupScanLookupTable(b, "bench_scan_lookup", rows)
 	tx := NewTxContext(TxCursorStability)
 	key := scm.NewInt(511)
+	cols := []string{"key"}
+	values := []scm.Scmer{key}
 	// Warm the adaptive index before measuring the steady-state operator.
-	tbl.scanLookup(tx, "key", key, "value")
+	tbl.scanLookup(tx, cols, values, "value", true)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		tbl.scanLookup(tx, "key", key, "value")
+		tbl.scanLookup(tx, cols, values, "value", true)
+	}
+}
+
+func BenchmarkScanLookupDimensions(b *testing.B) {
+	database := "bench_scan_lookup_dimensions"
+	databases.Remove(database)
+	b.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	tbl, _ := CreateTable(database, "items", Memory, true)
+	tbl.CreateColumn("tenant", "INT", nil, nil)
+	tbl.CreateColumn("key", "INT", nil, nil)
+	tbl.CreateColumn("value", "VARCHAR", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i % 16)), scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl.Insert([]string{"tenant", "key", "value"}, rows, nil, scm.NewNil(), false, nil)
+	tx := NewTxContext(TxCursorStability)
+	oneCol := []string{"key"}
+	oneValue := []scm.Scmer{scm.NewInt(511)}
+	twoCols := []string{"tenant", "key"}
+	twoValues := []scm.Scmer{scm.NewInt(15), scm.NewInt(511)}
+
+	cases := []struct {
+		name        string
+		cols        []string
+		values      []scm.Scmer
+		resultCol   string
+		returnValue bool
+	}{
+		{name: "value_one", cols: oneCol, values: oneValue, resultCol: "value", returnValue: true},
+		{name: "value_two", cols: twoCols, values: twoValues, resultCol: "value", returnValue: true},
+		{name: "exists_one", cols: oneCol, values: oneValue},
+		{name: "exists_two", cols: twoCols, values: twoValues},
+	}
+	for _, bench := range cases {
+		b.Run(bench.name, func(b *testing.B) {
+			tbl.scanLookup(tx, bench.cols, bench.values, bench.resultCol, bench.returnValue)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				tbl.scanLookup(tx, bench.cols, bench.values, bench.resultCol, bench.returnValue)
+			}
+		})
 	}
 }

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -41,6 +41,7 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 		{scm.NewInt(2), scm.NewNil()},
 		{scm.NewInt(3), scm.NewString("first")},
 		{scm.NewInt(3), scm.NewString("second")},
+		{scm.NewNil(), scm.NewString("null-key")},
 	})
 	tx := NewTxContext(TxCursorStability)
 
@@ -52,6 +53,9 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 	}
 	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(99)}, "value", true); !got.IsNil() {
 		t.Fatalf("scanLookup missing value = %s, want nil", scm.String(got))
+	}
+	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewNil()}, "", false); scm.ToBool(got) {
+		t.Fatal("scanLookup matched a SQL NULL key")
 	}
 
 	defer func() {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1244,20 +1244,23 @@ func Init(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_lookup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
-			lookupCols := scmerSliceToStrings(mustScmerSlice(a[2], "scan_lookup matchColumns"))
+			lookupColValues := mustScmerSlice(a[2], "scan_lookup matchColumns")
 			lookupValues := mustScmerSlice(a[3], "scan_lookup matchValues")
+			validateScanLookupDimensions(len(lookupColValues), len(lookupValues))
 			resultCol := ""
 			returnValue := len(a) == 5
 			if len(a) == 5 {
 				resultCol = a[4].String()
 			}
-			return TableFromScmer(a[1]).scanLookup(
-				scmerToTxContext(a[0]),
-				lookupCols,
-				lookupValues,
-				resultCol,
-				returnValue,
-			)
+			t := TableFromScmer(a[1])
+			currentTx := scmerToTxContext(a[0])
+			if len(lookupColValues) == 1 {
+				if lookupValues[0].IsNil() {
+					return scanLookupMiss(returnValue)
+				}
+				return t.scanLookupOne(currentTx, lookupColValues[0].String(), lookupValues[0], resultCol, returnValue)
+			}
+			return t.scanLookup(currentTx, scmerSliceToStrings(lookupColValues), lookupValues, resultCol, returnValue)
 		},
 		Type: &scm.TypeDescriptor{Kind: "func", Description: "probes an exact index prefix; with a result column it returns one value, NULL for no visible match, and errors on multiple matches; without a result column it returns whether a match exists",
 			HasSideEffects: true,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1244,23 +1244,31 @@ func Init(en scm.Env) {
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_lookup",
 		Fn: func(a ...scm.Scmer) scm.Scmer {
+			lookupCols := scmerSliceToStrings(mustScmerSlice(a[2], "scan_lookup matchColumns"))
+			lookupValues := mustScmerSlice(a[3], "scan_lookup matchValues")
+			resultCol := ""
+			returnValue := len(a) == 5
+			if len(a) == 5 {
+				resultCol = a[4].String()
+			}
 			return TableFromScmer(a[1]).scanLookup(
 				scmerToTxContext(a[0]),
-				a[2].String(),
-				a[3],
-				a[4].String(),
+				lookupCols,
+				lookupValues,
+				resultCol,
+				returnValue,
 			)
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "returns one projected value through a direct equality-prefix index lookup; returns NULL for no visible match and errors on multiple matches",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "probes an exact index prefix; with a result column it returns one value, NULL for no visible match, and errors on multiple matches; without a result column it returns whether a match exists",
 			HasSideEffects: true,
 			Params: []*scm.TypeDescriptor{
 				{Kind: "any", Label: "tx", Description: "transaction context used for visibility"},
 				{Kind: "table", Label: "table"},
-				{Kind: "string", Label: "lookupColumn", Description: "leading index-prefix column"},
-				{Kind: "any", Label: "lookupValue", Description: "exact value for the index-prefix column"},
-				{Kind: "string", Label: "resultColumn", Description: "column returned from the matching row"},
+				{Kind: "list", NoEscape: true, Label: "matchColumns", Description: "non-empty exact index-prefix columns", Element: &scm.TypeDescriptor{Kind: "string", Label: "column"}},
+				{Kind: "list", NoEscape: true, Label: "matchValues", Description: "one exact value for each match column", Element: &scm.TypeDescriptor{Kind: "any", Label: "value"}},
+				{Kind: "string", Optional: true, Label: "resultColumn", Description: "optional column returned from the matching row; omit for an existence probe"},
 			},
-			Return: &scm.TypeDescriptor{Kind: "any"},
+			Return: &scm.TypeDescriptor{Kind: "any", Description: "projected scalar value or boolean existence result"},
 		},
 	})
 

--- a/tests/performance/physical-cost-calibration.yaml
+++ b/tests/performance/physical-cost-calibration.yaml
@@ -27,6 +27,7 @@ setup:
   - sql: "DROP TABLE IF EXISTS pc_acl_override"
   - sql: "DROP TABLE IF EXISTS pc_lookup_outer"
   - sql: "DROP TABLE IF EXISTS pc_lookup_values"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_composite"
   # String-key membership prevents the target-side prefiltered projection and
   # isolates candidate startup from direct probe work.
   - sql: "DROP TABLE IF EXISTS pc_events"
@@ -50,6 +51,7 @@ setup:
   - sql: "CREATE TABLE pc_acl_override (domain_id INT, actor_id INT, allowed INT)"
   - sql: "CREATE TABLE pc_lookup_outer (id INT, lookup_id INT)"
   - sql: "CREATE TABLE pc_lookup_values (lookup_id INT, value VARCHAR(32), score INT)"
+  - sql: "CREATE TABLE pc_lookup_composite (tenant_id INT, lookup_id INT, score INT)"
   - sql: "CREATE TABLE pc_events (id INT PRIMARY KEY, entity_key VARCHAR(32), event_time INT, kind VARCHAR(16))"
   - sql: "CREATE TABLE pc_keys (id INT PRIMARY KEY, enabled INT)"
   - sql: "CREATE TABLE pc_files_text (id INT PRIMARY KEY, filename VARCHAR(255), search VARCHAR(255)) ENGINE=memory"
@@ -124,7 +126,9 @@ setup:
         (insert (table "memcp-tests" "pc_lookup_outer") '("id" "lookup_id")
           (list (list 1 10) (list 2 20) (list 3 30) (list 4 nil)))
         (insert (table "memcp-tests" "pc_lookup_values") '("lookup_id" "value" "score")
-          (list (list 10 "ten" 100) (list 20 "twenty" 200) (list 30 nil 300))))
+          (list (list 10 "ten" 100) (list 20 "twenty" 200) (list 30 nil 300)))
+        (insert (table "memcp-tests" "pc_lookup_composite") '("tenant_id" "lookup_id" "score")
+          (list (list 1 10 100) (list 2 10 900) (list 1 20 200))))
 
 cleanup:
   - sql: "DROP TABLE IF EXISTS pc_files_small"
@@ -138,6 +142,7 @@ cleanup:
   - sql: "DROP TABLE IF EXISTS pc_acl_override"
   - sql: "DROP TABLE IF EXISTS pc_lookup_outer"
   - sql: "DROP TABLE IF EXISTS pc_lookup_values"
+  - sql: "DROP TABLE IF EXISTS pc_lookup_composite"
   - sql: "DROP TABLE IF EXISTS pc_events"
   - sql: "DROP TABLE IF EXISTS pc_keys"
   - sql: "DROP TABLE IF EXISTS pc_files_text"
@@ -155,6 +160,18 @@ test_cases:
     sql: |
       SELECT d.id,
         (SELECT v.score + 1 FROM pc_lookup_values v WHERE v.lookup_id = d.lookup_id) AS value
+      FROM pc_lookup_outer d
+      WHERE d.id = 1
+
+  - name: "composite scalar point lookup dominance"
+    physical_calibration: true
+    calibration_decision: "scan_lookup"
+    warmup: 2
+    repetitions: 7
+    sql: |
+      SELECT d.id,
+        (SELECT v.score + 1 FROM pc_lookup_composite v
+         WHERE v.tenant_id = d.id AND v.lookup_id = d.lookup_id) AS value
       FROM pc_lookup_outer d
       WHERE d.id = 1
 

--- a/tests/planner/joins/join-dedup.yaml
+++ b/tests/planner/joins/join-dedup.yaml
@@ -12,9 +12,10 @@ setup:
   - sql: "DROP TABLE IF EXISTS jd_ref"
   - sql: "DROP TABLE IF EXISTS jd_permission"
   - sql: |
-      CREATE TABLE jd_item (id INT, ref_id INT)
+      CREATE TABLE jd_item (id INT, ref_id INT, expected_score INT)
   - sql: |
-      INSERT INTO jd_item (id, ref_id) VALUES (1, 10), (2, 20), (3, 10), (4, NULL)
+      INSERT INTO jd_item (id, ref_id, expected_score) VALUES
+        (1, 10, 100), (2, 20, 200), (3, 10, 100), (4, NULL, NULL)
   - sql: |
       CREATE TABLE jd_ref (id INT, label VARCHAR(40), score INT, doc VARCHAR(40))
   - sql: |
@@ -330,6 +331,23 @@ test_cases:
         - "scan_order"
         - "scan_order_point"
         - ".grp:jd_ref"
+
+  - name: "Composite scalar key lowers to one direct lookup"
+    sql: |
+      EXPLAIN
+      SELECT (SELECT label FROM jd_ref
+              WHERE jd_ref.id = jd_item.ref_id
+                AND jd_ref.score = jd_item.expected_score) AS label
+      FROM jd_item
+      WHERE jd_item.id = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+        - "jd_ref"
+        - "expected_score"
+      result_not_contains:
+        - "scan_order"
 
   - name: "Cost calibration can force scalar lookup alternatives"
     sql: |

--- a/tests/sql/security/mysql-auth-tx-nil.yaml
+++ b/tests/sql/security/mysql-auth-tx-nil.yaml
@@ -1,3 +1,4 @@
+# Copyright (C) 2026 Carl-Philip Haensch
 # MySQL auth callback must stay readonly and work with tx=nil
 
 metadata:
@@ -31,12 +32,32 @@ test_cases:
         "ok"
         (error "mysql_auth returned wrong password"))
 
+  - name: "Direct scan_lookup resolves password with nil transaction"
+    scm: |
+      (if
+        (equal?
+          (scan_lookup nil (table "system" "user")
+            '("username") '("auth_scan_nil_repro") "password")
+          (password "secret123"))
+        "ok"
+        (error "scan_lookup nil over system.user returned wrong password"))
+
   - name: "mysql_auth returns nil for missing user"
     scm: |
       (if
         (nil? (mysql_auth "auth_scan_nil_other"))
         "ok"
         (error "mysql_auth should return nil for missing user"))
+
+  - name: "Authenticated constant query hot path"
+    sql: "SELECT 1 AS value"
+    warmup: 10
+    timing_samples: 100
+    threshold_ms: 2
+    expect:
+      rows: 1
+      data:
+        - value: 1
 
   - name: "Dashboard user authentication rejects missing credentials without evaluating an empty row"
     scm: |


### PR DESCRIPTION
## What and why

- Extend the scalar `scan_lookup` introduced by #747 to `scan_lookup(tx, table, match_columns, match_values, [result_column])`, a direct transaction-aware exact index-prefix probe.
- Mark both match lists as non-escaping and retain a dedicated one-column implementation so authentication does not pay for composite-reader setup.
- With a result column, return the projected value directly, return `NULL` when no visible row matches, and reuse the scalar-subselect cardinality error when more than one visible row matches.
- Without a result column, return `true` on the first visible match and `false` when no row matches. Multiple matches are valid for this lightweight EXISTS form.
- Match complete one- and multi-column scalar leaf subtrees during physical planning. The matched lookup remains dominant, so ordinary planning skips costing displaced scan alternatives; `EXPLAIN PHYSICAL CALIBRATE` still retains both variants for measurement.
- Preserve #747's rule that pulls null-propagating arithmetic and JSON calculations out of scalar scans so the storage operator materializes only raw columns. Non-strict expressions such as `COALESCE` remain inside where required to distinguish a missing row from a matching `NULL`.
- Replace eligible password/admin reads in the SQL, MySQL, PostgreSQL, RDF, and dashboard frontends with `scan_lookup`.
- Replace database ACL count scans with a composite `(username, database)` boolean lookup in SQL policy and dashboard checks. The current `system.access` schema has database-level grants only; the operator supports longer `(table, user, mode, ...)` prefixes without another API change.
- Extend Costgen with a composite lookup calibration and add operator, cardinality, planner, authentication, ACL, and performance coverage.
- Move the constant-false compile gate to the runner's calibrated timeout. Its former unscaled in-Scheme timer could raise inside a shared JIT process on slower hosts, terminate that process, and invalidate concurrent MEMORY-table tests.

## Manual A/B measurements

All paired comparisons used identical fixtures, warmup/sample settings, and result validation.

- End-to-end Costgen scalar query, 2 warmups and 7 repetitions: one-column `scan_lookup` **17.574 µs** versus `scan_order` **27.432 µs**, **35.9% faster**.
- End-to-end Costgen composite scalar query, 2 warmups and 7 repetitions: two-column `scan_lookup` **14.167 µs** versus `scan_order` **26.390 µs**, **46.3% faster**. This confirms that lookup dominance still holds for the multi-dimensional case, so ordinary planning need not estimate the alternative.
- Authenticated HTTP `SELECT 1`, pre-change executable tree versus the final executable tree, fresh identical data directories, HTTP keep-alive, concurrency 1, 1,000 warmup requests and five alternating 10,000-request samples: median throughput increased from **6,375.91 to 7,123.85 requests/s** (**+11.73%**); reciprocal request latency fell from **156.840 to 140.374 µs** (**-10.50%**).
- MySQL TCP authentication plus `SELECT 1`, fresh identical data directories, concurrency 1, `mysqlslap --detach=1` to reconnect and authenticate for every query, 1,000 warmups and five alternating 10,000-connection samples: median throughput increased from **3,968.87 to 4,261.02 connections+queries/s** (**+7.36%**); reciprocal end-to-end latency fell from **251.961 to 234.685 µs** (**-6.86%**). Each server and timed run was prevalidated for a successful result so rejected handshakes could not be counted.
- Storage dimension microbenchmark, warm 1,024-row index, cursor-stability transaction, `-benchtime=3s -count=5`: projected value lookup median **2,010 ns/op** for one column and **2,509 ns/op** for two columns (**+24.8% composite overhead**); boolean EXISTS median **1,954 ns/op** and **2,469 ns/op** respectively (**+26.4%**). Composite setup uses **760 B/op and 11 allocations/op** versus **448 B/op and 9 allocations/op** for the dedicated one-column path.
- The #747 general-scan comparison remains **2,965 ns/op, 1,035 B/op, 13 allocs/op** versus the dedicated one-column lookup at **1,726 ns/op, 432 B/op, 9 allocs/op** (**41.8% faster**, **58.3% fewer bytes**, **30.8% fewer allocations**); this PR deliberately preserves that fast path.

Costgen rejects calibration when either lookup variant does not beat `scan_order`, a run is censored, or result hashes differ.

## Verification

- Focused pre-commit suites: planner join/scalar probes, MySQL authentication, policy enforcement, RDF helpers, and dashboard regressions (all passed).
- Performance-enabled authentication suite: **0.6 ms / 2 ms** threshold for 100 cached samples (passed).
- `go test ./storage -run 'TestScanLookup' -count=1` (passed).
- `go test ./storage -run '^$' -bench 'BenchmarkScanLookup(Dimensions|WithTx)$' -benchmem -benchtime=3s -count=5` (passed).
- `go run ./tools/costgen` (both scalar lookup dominance checks passed).
- Complete local pre-commit run with the patched Go 1.27 JIT, four parallel workers, and all restart/crash suites (passed); the formerly coupled constant-false/default/truncate block also passed under JIT after the calibrated timeout change.
- `PERF_TEST=1 python3 run_sql_tests.py tests/performance/forum-hierarchy-aggregate-joins.yaml` (9/9 passed; the hierarchy regression gate measured **95.9 ms / 500 ms** after retaining `scan_exists` for non-leaf group-cache probes).

The complete storage package currently reproduces the unrelated `TestRebuildInsideActiveTransactionDoesNotWaitForItself` failure on both this branch and the detached pre-change baseline; the focused storage and integration coverage above passes.
