### PR TITLE
JIT: call native funcvals directly

### DIFF
--- a/scm/declare.go
+++ b/scm/declare.go
@@ -307,6 +307,17 @@ var declarations map[string]*Declaration = make(map[string]*Declaration)
 // Keying by the complete function identity preserves distinct closure contexts
 // and avoids fmt.Sprintf allocating on every prepared callback lookup.
 var declarationsByFunction map[uintptr]*Declaration = make(map[uintptr]*Declaration)
+var retainingCallArgFunctionIdentities []uintptr
+
+func registerRetainingCallArgFunction(fn func(...Scmer) Scmer) {
+	identity := FunctionIdentity(fn)
+	for _, registered := range retainingCallArgFunctionIdentities {
+		if registered == identity {
+			return
+		}
+	}
+	retainingCallArgFunctionIdentities = append(retainingCallArgFunctionIdentities, identity)
+}
 
 func DeclareTitle(title string) {
 	declaration_titles = append(declaration_titles, "#"+title)
@@ -332,6 +343,9 @@ func Declare(env *Env, def *Declaration) {
 	declarations[def.Name] = def
 	if def.Fn != nil {
 		declarationsByFunction[FunctionIdentity(def.Fn)] = def
+		if def.RetainsCallArgs {
+			registerRetainingCallArgFunction(def.Fn)
+		}
 		env.Vars[Symbol(def.Name)] = NewFunc(def.Fn)
 	}
 }
@@ -344,6 +358,9 @@ func DeclareInSection(section string, env *Env, def *Declaration) {
 	declarations[def.Name] = def
 	if def.Fn != nil {
 		declarationsByFunction[FunctionIdentity(def.Fn)] = def
+		if def.RetainsCallArgs {
+			registerRetainingCallArgFunction(def.Fn)
+		}
 		env.Vars[Symbol(def.Name)] = NewFunc(def.Fn)
 	}
 	if def.IsForbidden() {

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -1976,7 +1976,7 @@ func jitCompileStaticProcCall(ctx *JITContext, callable Scmer, proc *Proc, opera
 	callResult := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: resultOff, Rooted: true}
 	ctx.EmitZeroDescWords(&callResult, 2)
 	ctx.setStackPointer(jitStackRootFrameBP, resultOff, true)
-	ctx.EmitProcJITCall(fnValue, argsSlice, callResult)
+	ctx.EmitProcCall(fnValue, argsSlice, callResult)
 	ctx.FreeDesc(&fnValue)
 	ctx.FreeDesc(&argsSlice)
 	ctx.Coverage.DirectProcs++
@@ -2030,9 +2030,14 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	}
 	tag := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
 	ctx.EmitGetTagRegs(tag, callableValue.Reg, callableValue.Reg2)
+	nativeFuncLabel := ctx.ReserveLabel()
+	ctx.EmitCmpRegImm8(tag, tagFunc)
+	ctx.EmitJcc(CcE, nativeFuncLabel)
 	ctx.EmitCmpRegImm8(tag, tagProc)
 	ctx.FreeReg(tag)
 	ctx.EmitJcc(CcNE, fallbackLabel)
+	// Scheme procedures need a direct, arity-compatible JIT entry. Their *Proc
+	// pointer is already the funcval context consumed by EmitProcCall.
 	metadata := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
 	ctx.EmitMovRegMem(metadata, callableValue.Reg, int32(unsafe.Offsetof(Proc{}.Compiled)))
 	ctx.EmitCmpRegImm32(metadata, 0)
@@ -2052,31 +2057,51 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	ctx.MarkLabel(arityOK)
 	ctx.FreeReg(arity)
 	ctx.FreeReg(metadata)
-	fnReg := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
-	ctx.EmitMovRegReg(fnReg, callableValue.Reg)
-	codeReg := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2, fnReg)
+	codeReg := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
 	ctx.EmitMovRegMem(codeReg, callableValue.Reg, int32(unsafe.Offsetof(Proc{}.JITCode)))
 	ctx.EmitCmpRegImm32(codeReg, 0)
 	ctx.FreeReg(codeReg)
 	ctx.EmitJcc(CcE, fallbackLabel)
+	fnReg := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
+	ctx.EmitMovRegReg(fnReg, callableValue.Reg)
 	fnValue := JITValueDesc{Loc: LocReg, Type: tagFunc, Reg: fnReg, RelocatablePointer: true}
 	ctx.BindReg(fnReg, &fnValue)
 	ctx.FreeDesc(&callableValue)
-	argsPtr := ctx.AllocRegExcept(fnReg)
-	argsLen := ctx.AllocRegExcept(fnReg, argsPtr)
-	argsSlice := JITValueDesc{Loc: LocRegPair, Type: tagSlice, Reg: argsPtr, Reg2: argsLen, NoHeapPointer: false}
-	ctx.BindReg(argsPtr, &argsSlice)
-	ctx.BindReg(argsLen, &argsSlice)
-	if len(operands) == 0 {
-		ctx.EmitMovRegImm64(argsPtr, 0)
-	} else {
-		ctx.EmitLeaRegMem(argsPtr, ctx.StackReg, operandOff)
-	}
-	ctx.EmitMovRegImm64(argsLen, uint64(len(operands)))
-	_ = ctx.EmitProcJITCall(fnValue, argsSlice, callResult)
+	argsSlice := jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operands))
+	ctx.EmitProcCall(fnValue, argsSlice, callResult)
 	ctx.FreeDesc(&fnValue)
 	ctx.FreeDesc(&argsSlice)
 	ctx.Coverage.DirectProcs++
+	ctx.EmitJmp(endLabel)
+
+	ctx.MarkLabel(nativeFuncLabel)
+	nativeCallable := callable
+	ctx.EnsureDesc(&nativeCallable)
+	if nativeCallable.Loc != LocRegPair {
+		panic("jit: dynamic native callable must be a Scmer pair")
+	}
+	// A tagFunc Scmer points at the Go variable holding the funcval pointer,
+	// whereas a compiled Proc is itself laid out as the funcval object.
+	fnReg = ctx.AllocRegExcept(nativeCallable.Reg, nativeCallable.Reg2)
+	ctx.EmitMovRegMem(fnReg, nativeCallable.Reg, 0)
+	// Retaining native functions need the existing owned-argument boundary.
+	// Declarations populate this small identity set; the hot path remains a
+	// sequence of comparisons without a Go helper or a builtin-name policy.
+	for _, retainingIdentityValue := range retainingCallArgFunctionIdentities {
+		retainingIdentity := ctx.AllocRegExcept(nativeCallable.Reg, nativeCallable.Reg2, fnReg)
+		ctx.EmitMovRegImm64(retainingIdentity, uint64(retainingIdentityValue))
+		ctx.EmitCmpInt64(fnReg, retainingIdentity)
+		ctx.FreeReg(retainingIdentity)
+		ctx.EmitJcc(CcE, fallbackLabel)
+	}
+	fnValue = JITValueDesc{Loc: LocReg, Type: tagFunc, Reg: fnReg, RelocatablePointer: true}
+	ctx.BindReg(fnReg, &fnValue)
+	ctx.FreeDesc(&nativeCallable)
+	argsSlice = jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operands))
+	ctx.EmitGoFuncCall(fnValue, argsSlice, callResult)
+	ctx.FreeDesc(&fnValue)
+	ctx.FreeDesc(&argsSlice)
+	ctx.Coverage.NativeCalls++
 	ctx.EmitJmp(endLabel)
 
 	ctx.MarkLabel(fallbackLabel)
@@ -2134,6 +2159,21 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	}
 	ctx.FreeStack(ctx.BPOffset - stackStart)
 	return out
+}
+
+func jitEmitDynamicCallArgs(ctx *JITContext, fnReg Reg, operandOff int32, operandCount int) JITValueDesc {
+	argsPtr := ctx.AllocRegExcept(fnReg)
+	argsLen := ctx.AllocRegExcept(fnReg, argsPtr)
+	argsSlice := JITValueDesc{Loc: LocRegPair, Type: tagSlice, Reg: argsPtr, Reg2: argsLen, NoHeapPointer: false}
+	ctx.BindReg(argsPtr, &argsSlice)
+	ctx.BindReg(argsLen, &argsSlice)
+	if operandCount == 0 {
+		ctx.EmitMovRegImm64(argsPtr, 0)
+	} else {
+		ctx.EmitLeaRegMem(argsPtr, ctx.StackReg, operandOff)
+	}
+	ctx.EmitMovRegImm64(argsLen, uint64(operandCount))
+	return argsSlice
 }
 
 func jitCompileDynamicHigherOrderCall(ctx *JITContext, callableExpr Scmer, operands []Scmer, sliceBase Reg, result JITValueDesc) JITValueDesc {
@@ -2267,7 +2307,7 @@ func jitCompileSelfCall(ctx *JITContext, operands []Scmer, sliceBase Reg, result
 	callResult := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: resultOff, Rooted: true}
 	ctx.EmitZeroDescWords(&callResult, 2)
 	ctx.setStackPointer(jitStackRootFrameBP, resultOff, true)
-	ctx.EmitProcJITCall(fnValue, argsSlice, callResult)
+	ctx.EmitProcCall(fnValue, argsSlice, callResult)
 	ctx.FreeDesc(&argsSlice)
 	target := jitPlaceScmerIntoTarget(ctx, callResult, result)
 	ctx.FreeStack(ctx.BPOffset - stackStart)

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -464,7 +464,7 @@ func callJITExpressionAtDepth(callable, arg Scmer, depth int) Scmer {
 	return result
 }
 
-func compileJITExpressionTestProc(t *testing.T, source string) Scmer {
+func compileJITExpressionTestProc(t testing.TB, source string) Scmer {
 	t.Helper()
 	if !jitEnabled {
 		t.Skip("requires GOEXPERIMENT=jit")
@@ -483,6 +483,31 @@ func requireNoDynamicJITCalls(t *testing.T, compiled Scmer) {
 	coverage := compiled.Proc().Compiled.Coverage
 	if coverage.DynamicCalls != 0 {
 		t.Fatalf("expected complete expression lowering, got %+v", coverage)
+	}
+}
+
+func TestJITDynamicNativeFuncPreservesClosureContextAcrossGC(t *testing.T) {
+	compiled := compileJITExpressionTestProc(t, `(lambda (callback value) (callback value))`)
+	captured := NewString("captured native closure context")
+	callback := NewFunc(func(args ...Scmer) Scmer {
+		_ = jitCallbackTestSafepoint(args...)
+		return NewSlice([]Scmer{captured, args[0]})
+	})
+	argument := NewString("dynamic argument")
+	want := NewSlice([]Scmer{captured, argument})
+	if got := Apply(compiled, callback, argument); !Equal(got, want) {
+		t.Fatalf("dynamic native callback returned %s, want %s", String(got), String(want))
+	}
+}
+
+func BenchmarkJITDynamicNativeFuncCall(b *testing.B) {
+	compiled := compileJITExpressionTestProc(b, `(lambda (callback value) (callback value))`)
+	callback := NewFunc(func(args ...Scmer) Scmer { return args[0] })
+	argument := NewInt(42)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		jitListBenchmarkSink = Apply(compiled, callback, argument)
 	}
 }
 
@@ -550,8 +575,13 @@ func TestJITExpressionListResultOwnsBackingStorage(t *testing.T) {
 
 func TestJITDynamicListCallOwnsBackingStorage(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t, `(lambda (callback value) (callback value 2 3))`)
-	first := Apply(compiled, NewFunc(List), NewInt(1))
-	_ = Apply(compiled, NewFunc(List), NewInt(99))
+	callableType := &TypeDescriptor{Kind: "func", Return: &TypeDescriptor{Kind: "list"}}
+	typedList := NewTypedFunc(List, RegisterCallableType(callableType))
+	if got := typedList.CallableType(); got != callableType {
+		t.Fatalf("retaining function lost callable type metadata: got %p, want %p", got, callableType)
+	}
+	first := Apply(compiled, typedList, NewInt(1))
+	_ = Apply(compiled, typedList, NewInt(99))
 	want := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3)})
 	if !Equal(first, want) {
 		t.Fatalf("dynamic list result changed after frame reuse: got %s, want %s", String(first), String(want))

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -2164,11 +2164,31 @@ func (ctx *JITContext) EmitGoCallVariadic(f func(...Scmer) Scmer, argslice JITVa
 	return target
 }
 
-// EmitProcJITCall performs the compact JIT-to-JIT ABI transition for a native
-// function value loaded from Proc.JIT. Common lowering has already placed the
-// callable and argument array in rooted frame slots, so only the outer slice
-// base needs preservation here.
-func (ctx *JITContext) EmitProcJITCall(fn, argslice, result JITValueDesc) JITValueDesc {
+type jitFuncValueCallKind uint8
+
+const (
+	jitProcCall jitFuncValueCallKind = iota
+	jitGoFuncCall
+)
+
+// EmitProcCall bitcasts a JIT-capable *Proc to func(...Scmer) Scmer and calls
+// it through the compact JIT-to-JIT ABI. The Proc starts with the machine-code
+// pointer and its inline capture context follows the Proc header, exactly like
+// a Go funcval and its closure words.
+func (ctx *JITContext) EmitProcCall(proc, argslice, result JITValueDesc) JITValueDesc {
+	return ctx.emitFuncValueCall(proc, argslice, result, jitProcCall)
+}
+
+// EmitGoFuncCall calls a regular Go func(...Scmer) Scmer value. Unlike a JIT
+// Proc, a Go callee requires the patched runtime's foreign-frame transition.
+func (ctx *JITContext) EmitGoFuncCall(fn, argslice, result JITValueDesc) JITValueDesc {
+	return ctx.emitFuncValueCall(fn, argslice, result, jitGoFuncCall)
+}
+
+// emitFuncValueCall contains only the register-save and shared regabi
+// machinery. The call kind deliberately remains private: common JIT lowering
+// must choose explicitly between EmitProcCall and EmitGoFuncCall.
+func (ctx *JITContext) emitFuncValueCall(fn, argslice, result JITValueDesc, kind jitFuncValueCallKind) JITValueDesc {
 	ctx.EnsureDescsTogether(&fn, &argslice)
 	if fn.Loc != LocReg || argslice.Loc != LocRegPair || result.Loc != LocStackPair || result.StackOff >= 0 {
 		panic("jit: invalid Proc.JIT call placement")
@@ -2220,13 +2240,21 @@ func (ctx *JITContext) EmitProcJITCall(fn, argslice, result JITValueDesc) JITVal
 	ctx.EmitMovRegReg(RegRCX, RegRBX)
 	ctx.EmitMovRegMem(RegR11, RegRDX, 0)
 
+	callAreaBytes := int32(jitGoSpillBytes)
+	if kind == jitGoFuncCall {
+		ctx.EmitMovRegReg(RegR13, RegRBP)
+		ctx.EmitSubInt64(RegR13, RegRSP)
+		ctx.EmitPushReg(RegR13)
+		ctx.EmitPushReg(RegR13)
+		callAreaBytes += 16
+	}
 	// Go callees own spill homes for register arguments in the caller's frame.
 	// A JIT callee uses these homes before runtime.morestack just like compiled
 	// Go code, so reserve the standard call area even on the compact path.
 	ctx.EmitSubRSP32(int32(jitGoSpillBytes))
 	ctx.emitBytes(0x41, 0xFF, 0xD3) // CALL R11
-	ctx.recordSafepoint(transientRoots, int32(jitGoSpillBytes))
-	ctx.EmitAddRSP32(int32(jitGoSpillBytes))
+	ctx.recordSafepoint(transientRoots, callAreaBytes)
+	ctx.EmitAddRSP32(callAreaBytes)
 
 	ctx.EmitStoreRegMem(RegRAX, ctx.FrameReg, result.StackOff)
 	ctx.EmitStoreRegMem(RegRBX, ctx.FrameReg, result.StackOff+8)


### PR DESCRIPTION
## Problem

A runtime-loaded native Go `func(...Scmer) Scmer` still crossed
`jitApplyCallable0/1/2/Slice` and `ApplyEx`. Its argument/result register ABI is
already known to the JIT, so that dispatch and one argument-slice allocation are
unnecessary.

The first revision reused the JIT-to-JIT call sequence. That was incorrect under
GC and stack growth: regular Go callees need the patched runtime's foreign-frame
transition, while a JIT-capable `*Proc` is itself the funcval context and must be
called without that transition.

## Solution

- Keep two explicit architecture-emitter operations:
  - `EmitProcCall` bitcasts the JIT-capable `*Proc` directly to
    `func(...Scmer) Scmer`. The Proc starts with its code pointer and its inline
    capture words follow the Proc header.
  - `EmitGoFuncCall` dereferences a regular `tagFunc` to its Go funcval and emits
    the same foreign-frame bridge used by static Go calls.
- Pass the argument slice through RAX/RBX/RCX and the concrete funcval context
  through RDX.
- Keep the semantic fallback for non-JIT Procs, environment functions, and
  native declarations which retain their variadic argument array.
- Derive the small set of retaining func identities from `Declaration.RetainsCallArgs`.
  No builtin names or callable kinds are hardcoded in JIT policy.
- Test native closure captures across an explicit GC and 64 KiB of recursive
  stack growth. Retaining calls such as `list` remain on the owned-argument
  boundary, including typed func values.

## Disassembly check

The dynamically loaded JIT Proc keeps the concrete `*Proc` as RDX and calls its
first word directly:

```text
mov    %callable,%rdx
mov    (%rdx),%r11
sub    $0x80,%rsp
call   *%r11
add    $0x80,%rsp
```

The regular Go funcval branch dereferences the `tagFunc`, then emits the required
foreign-frame words before the call:

```text
mov    (%callable),%funcval
mov    %args_data,%rax
mov    %args_len,%rbx
mov    %funcval,%rdx
mov    %rbx,%rcx
mov    (%rdx),%r11
mov    %rbp,%r13
sub    %rsp,%r13
push   %r13
push   %r13
sub    $0x80,%rsp
call   *%r11
add    $0x90,%rsp
```

`jitApplyCallable1` remains only in the fallback branch.

## Manual A/B measurements

Both sides used commit `6bf586ee7` as baseline, the same patched Go toolchain
with `GOEXPERIMENT=jit`, CPU 0, identical data snapshots, and identical warmup
and sample counts.

### Dynamic native callback microbenchmark

`BenchmarkJITDynamicNativeFuncCall`, five samples:

- Baseline median: 51.04 ns/op, 48 B/op, 2 allocs/op
- This PR median: 27.47 ns/op, 32 B/op, 1 alloc/op
- Change: 46.2% lower latency, one allocation and 16 bytes removed

### Warm query-cache execution

`SELECT payload FROM qpl_bench WHERE ID = 424`, with native `count` result
callbacks, 2,000 warmups followed by ten samples of 20,000 cached executions:

- Baseline median: 17.320 us/execution
- This PR median: 16.479 us/execution
- Change: 4.9% lower latency

The same benchmark with Scheme Proc callbacks is neutral (17.016 vs 17.002
us/execution), confirming that the change is confined to regular Go funcvals and
does not perturb the already-direct Proc path.

## Validation

- `GOEXPERIMENT=jit go test ./scm ./tools/jitgen`
- non-JIT `go test ./scm ./tools/jitgen`
- `exists-session-var.yaml`: 8/8
- `deleted-row-carrier-visibility.yaml`: 14/14
- direct-call disassembly reviewed for both Proc and Go-funcval branches

The full SQL and JIT suites run in CI as required for performance changes.
