### PR TITLE
Calibrate compile timeout and stabilize performance A/B samples

### DIFF
--- a/git-pre-commit
+++ b/git-pre-commit
@@ -304,6 +304,11 @@ run_memcp_forever() {
     rc=$?
     if [ $rc -ne 0 ]; then
       echo "⚠️  MemCP exited unexpectedly (code=$rc). Restarting..."
+      if [ -f "$memcp_log" ]; then
+        echo "--- MemCP log at unexpected exit (last 200 lines) ---"
+        tail -n 200 "$memcp_log"
+        echo "--- end MemCP log at unexpected exit ---"
+      fi
     fi
     sleep 0.5
   done

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -469,8 +469,12 @@ def performance_ab_threshold_ms(
     ) + jitter_budget_ms / candidate_repetitions
 
 
-def adaptive_measurement_complete(repetitions: int, total_ns: int) -> bool:
-    return repetitions >= 5 and total_ns >= PERF_MIN_MEASURE_MS * 1_000_000
+def adaptive_measurement_complete(samples_ns: List[int]) -> bool:
+    return (
+        len(samples_ns) >= 5
+        and performance_sample_ns(samples_ns) * len(samples_ns)
+        >= PERF_MIN_MEASURE_MS * 1_000_000
+    )
 
 
 def performance_sample_ns(samples_ns: List[int]) -> float:
@@ -1672,9 +1676,7 @@ class SQLTestRunner:
                     measured_total_ns += sample_ns
                     if response is None or response.status_code != 200:
                         break  # don't hammer a broken endpoint
-                    if adaptive_repetitions and adaptive_measurement_complete(
-                        len(samples_ns), measured_total_ns
-                    ):
+                    if adaptive_repetitions and adaptive_measurement_complete(samples_ns):
                         break
 
                 total_ns = measured_total_ns

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -473,6 +473,13 @@ def adaptive_measurement_complete(repetitions: int, total_ns: int) -> bool:
     return repetitions >= 5 and total_ns >= PERF_MIN_MEASURE_MS * 1_000_000
 
 
+def performance_sample_ns(samples_ns: List[int]) -> float:
+    """Return a robust per-repetition latency for a timed sample block."""
+    if not samples_ns:
+        raise ValueError("performance measurement requires at least one sample")
+    return float(statistics.median(samples_ns))
+
+
 def planner_time_limit_with_tolerance_ms(
     reference_budget_ms: float, calibration: Dict[str, Any]
 ) -> float:
@@ -1671,7 +1678,10 @@ class SQLTestRunner:
                         break
 
                 total_ns = measured_total_ns
-                elapsed_ns = total_ns / len(samples_ns)
+                # A/B runs execute the base and candidate in separate processes.
+                # Use the median so one scheduler or background-rebuild outlier
+                # cannot turn otherwise identical binaries into a regression.
+                elapsed_ns = performance_sample_ns(samples_ns)
                 elapsed_ms = elapsed_ns / 1_000_000
                 elapsed_sec = elapsed_ms / 1000
 

--- a/tests/performance/constant-false-wide-predicate.yaml
+++ b/tests/performance/constant-false-wide-predicate.yaml
@@ -31,7 +31,8 @@ setup:
 
 test_cases:
   - name: "A false guard discards a wide schedule predicate before decorrelation"
-    max_time: 5.0
+    # Keep the compile budget in the runner so its machine calibration applies.
+    max_time: 1.2
     scm: |
       (begin
         (define branch (lambda (i)
@@ -50,13 +51,9 @@ test_cases:
         (define session (newsession))
         (session "username" "root")
         (session "schema" "memcp-tests")
-        (define started (nanotime))
         (cached_parse (newcachemap) (list parse_sql) "memcp-tests" query
           (lambda (_schema _table _write) true) "root" session false)
-        (define elapsed (- (nanotime) started))
-        (if (< elapsed 1200000000)
-          "ok"
-          (error (concat "constant-false wide predicate compiled in " elapsed "ns"))))
+        "ok")
     expect:
       data: ["ok"]
 

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -101,9 +101,15 @@ class PerformanceScaleContractTest(unittest.TestCase):
 
     def test_adaptive_measurement_requires_five_runs_and_time_budget(self) -> None:
         with mock.patch("run_sql_tests.PERF_MIN_MEASURE_MS", 250):
-            self.assertFalse(adaptive_measurement_complete(4, 1_000_000_000))
-            self.assertFalse(adaptive_measurement_complete(100, 249_999_999))
-            self.assertTrue(adaptive_measurement_complete(5, 250_000_000))
+            self.assertFalse(adaptive_measurement_complete([250_000_000] * 4))
+            self.assertFalse(adaptive_measurement_complete([2_499_999] * 100))
+            self.assertTrue(adaptive_measurement_complete([50_000_000] * 5))
+
+    def test_adaptive_measurement_ignores_outliers_when_selecting_duration(self) -> None:
+        with mock.patch("run_sql_tests.PERF_MIN_MEASURE_MS", 1000):
+            samples = [60_000_000] * 5 + [700_000_000]
+            self.assertFalse(adaptive_measurement_complete(samples))
+            self.assertTrue(adaptive_measurement_complete([60_000_000] * 17))
 
     def test_performance_sample_uses_median_to_ignore_one_scheduling_outlier(self) -> None:
         self.assertEqual(performance_sample_ns([78, 79, 80, 81, 200]), 80)

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -47,6 +47,7 @@ from run_sql_tests import (  # noqa: E402
     load_performance_scale,
     observe_atomic_json,
     performance_ab_threshold_ms,
+    performance_sample_ns,
     performance_case_fingerprint,
     performance_case_key,
     performance_architecture,
@@ -103,6 +104,12 @@ class PerformanceScaleContractTest(unittest.TestCase):
             self.assertFalse(adaptive_measurement_complete(4, 1_000_000_000))
             self.assertFalse(adaptive_measurement_complete(100, 249_999_999))
             self.assertTrue(adaptive_measurement_complete(5, 250_000_000))
+
+    def test_performance_sample_uses_median_to_ignore_one_scheduling_outlier(self) -> None:
+        self.assertEqual(performance_sample_ns([78, 79, 80, 81, 200]), 80)
+        self.assertEqual(performance_sample_ns([20, 10]), 15)
+        with self.assertRaisesRegex(ValueError, "at least one sample"):
+            performance_sample_ns([])
 
     def test_warmup_accepts_zero_and_counts(self) -> None:
         self.assertEqual(resolve_warmup_runs({}, True), 2)


### PR DESCRIPTION
## Problem

The constant-false compile test enforced the same 1.2-second budget twice. The runner scaled its limit for the measured host, but an embedded Scheme nanotime check remained unscaled and terminated the shared JIT server on slower runners.

A second CI failure exposed a separate measurement flaw: performance A/B averaged five long-running HTTP samples. Base and candidate contained identical executable code, yet one scheduling or background-rebuild outlier moved the forum hierarchy case from 78.220 ms to 104.665 ms. The 20% regression budget plus the amortized 50 ms jitter allowance ended at 103.864 ms, so identical code failed by 0.801 ms and the suite then reported downstream cases as missing.

## Solution

- Keep the 1.2-second compile budget in the calibrated SQL runner and remove the duplicate unscaled Scheme timer.
- Report the last 200 MemCP log lines when the shared supervisor observes an unexpected nonzero exit, so future JIT crashes retain their actual cause.
- Use the median of repeated timed samples for A/B latency. Adaptive duration and the raw total remain unchanged; the percentage budget is not widened. This rejects a single heavy-tail scheduling outlier instead of hiding a sustained regression.

## Verification

- SQL runner contract tests: 48/48 passed.
- Constant-false JIT needle suite: 2/2 passed.
- Formerly coupled JIT suites repeated for 120 rounds against one long-lived server: passed.
- CI before the median commit: vanilla test passed in 10m39s, JIT test passed in 15m18s, packaging passed.
- Same-code CI diagnosis: forum hierarchy 78.220 ms base versus 104.665 ms candidate; the only executable differences in the PR were test/runner files.
- Local same-binary A/B after the median change (10,000-row fixture, warmup 1, five samples): hierarchy child-count 4.049 -> 4.403 ms (+8.7%), thread-group 3.900 -> 3.887 ms (-0.3%), correlated aggregate 3.614 -> 3.943 ms (+9.1%); all passed.
## Follow-up CI diagnosis

The first median-based CI run exposed that adaptive measurement still stopped on the raw total. Heavy-tail samples ended the affected workload after only 7 base and 6 candidate observations: base median 62.304 ms, candidate median 87.485 ms, while both raw totals had already crossed one second. Adaptive completion now uses median latency multiplied by sample count, so outliers cannot shorten the observation window. At those latencies the runner collects roughly 12-17 samples before deciding.
- Local same-binary validation of the formerly failing adaptive workload after the duration fix: base 43.188 ms from 24 samples, candidate 44.371 ms from 23 samples (+2.7%); passed. The old raw-total rule had stopped CI after only 7/6 samples.
- Final CI performance A/B after the adaptive-duration fix: selective dimension workload collected 17 base and 15 candidate samples, 61.289 -> 67.524 ms (+10.2%); the forum workload measured 6.134 -> 6.236 ms (+1.7%). The complete performance job passed in 6m09s.
