### PR TITLE
CI: wait for a new server generation after shutdown

### DIFF
--- a/git-pre-commit
+++ b/git-pre-commit
@@ -239,6 +239,7 @@ echo ""
 test_port=${MEMCP_TEST_PORT:-$(( (RANDOM % 10000) + 20000 ))}
 test_data_dir="${MEMCP_TEST_DATA_DIR:-/tmp/memcp-sql-tests-$test_port}"
 memcp_log="${MEMCP_LOG:-/tmp/memcp-test.log}"
+supervisor_generation_file="${MEMCP_TEST_SUPERVISOR_GENERATION_FILE:-/tmp/memcp-test-supervisor-$test_port.generation}"
 tmpdir=""
 supervisor_pid=""
 enable_mysql=0
@@ -268,6 +269,7 @@ done
 #   with the same data directory before the suite continues.
 
 run_memcp_forever() {
+  local generation=0
   terminate_memcp_child() {
     if [ -z "${memcp_pid:-}" ]; then
       return
@@ -295,6 +297,9 @@ run_memcp_forever() {
     fi
     ./memcp --no-repl -data "$test_data_dir" --api-port=$test_port --mysql-port=$((test_port + 1000)) "${mysql_args[@]}" lib/main.scm >> "$memcp_log" 2>&1 &
     memcp_pid=$!
+    generation=$((generation + 1))
+    printf '%s\n' "$generation" > "$supervisor_generation_file.tmp"
+    mv "$supervisor_generation_file.tmp" "$supervisor_generation_file"
     wait $memcp_pid
     rc=$?
     if [ $rc -ne 0 ]; then
@@ -305,6 +310,7 @@ run_memcp_forever() {
 }
 
 start_supervisor() {
+  rm -f "$supervisor_generation_file" "$supervisor_generation_file.tmp"
   echo -n > /tmp/memcp-test.log
   run_memcp_forever &
   supervisor_pid=$!
@@ -328,6 +334,7 @@ stop_supervisor() {
     supervisor_pid=""
   fi
   pkill -f "memcp.*--api-port=$test_port" 2>/dev/null || true
+  rm -f "$supervisor_generation_file" "$supervisor_generation_file.tmp"
 }
 
 wait_for_sql_ready() {
@@ -435,6 +442,7 @@ run_one() {
     return
   fi
   MEMCP_TEST_SUPERVISOR_PID="$supervisor_pid" \
+    MEMCP_TEST_SUPERVISOR_GENERATION_FILE="$supervisor_generation_file" \
     python3 -u run_sql_tests.py "$tf" $test_port --connect-only "${runner_args[@]}" > "$out" 2>&1
   rc=$?
   if [ $rc -eq 0 ]; then

--- a/run_sql_tests.py
+++ b/run_sql_tests.py
@@ -1478,6 +1478,7 @@ class SQLTestRunner:
         response: Optional[requests.Response]
         cpu_pct = None  # CPU load percentage, measured during query execution
         if query and query.strip().upper() == "SHUTDOWN":
+            supervisor_generation = shared_supervisor_generation()
             # Issue shutdown
             # A graceful shutdown may close this request before a response reaches
             # the client. Do not wait for that same process to become ready again;
@@ -1495,19 +1496,28 @@ class SQLTestRunner:
                         return self._record_fail(name, "Restart failed after SHUTDOWN", query, None, None, is_noncritical)
                 else:
                     # In connect-only mode the shared test supervisor owns the
-                    # process. Give graceful finalization a bounded window,
-                    # then ask that supervisor to terminate a stuck old process
-                    # and restart the same data directory.
+                    # process. Its generation barrier prevents the old process,
+                    # which may still answer briefly while shutting down, from
+                    # being mistaken for the replacement process.
                     restart_timeout = int(test_case.get("restart_timeout", 120))
                     grace_timeout = min(10, restart_timeout)
-                    ready = wait_for_sql_ready(
-                        self.base_url, tc_user, tc_pass, database,
-                        timeout=grace_timeout,
-                    )
-                    if not ready and request_shared_supervisor_restart():
+                    if supervisor_generation is None:
                         ready = wait_for_sql_ready(
                             self.base_url, tc_user, tc_pass, database,
-                            timeout=max(1, restart_timeout - grace_timeout),
+                            timeout=restart_timeout,
+                        )
+                    else:
+                        replaced = wait_for_shared_supervisor_generation(
+                            supervisor_generation, grace_timeout,
+                        )
+                        if not replaced and request_shared_supervisor_restart():
+                            replaced = wait_for_shared_supervisor_generation(
+                                supervisor_generation,
+                                max(1, restart_timeout - grace_timeout),
+                            )
+                        ready = replaced and wait_for_sql_ready(
+                            self.base_url, tc_user, tc_pass, database,
+                            timeout=restart_timeout,
                         )
                     if not ready:
                         return self._record_fail(name, "Restart timeout: SQL not ready after SHUTDOWN", query, None, None, is_noncritical)
@@ -2171,6 +2181,28 @@ def request_shared_supervisor_restart() -> bool:
         return True
     except OSError:
         return False
+
+
+def shared_supervisor_generation() -> Optional[str]:
+    """Return the current shared-server generation, if the supervisor exposes it."""
+    path = os.environ.get("MEMCP_TEST_SUPERVISOR_GENERATION_FILE", "")
+    if not path:
+        return None
+    try:
+        return Path(path).read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def wait_for_shared_supervisor_generation(previous: str, timeout: int) -> bool:
+    """Wait until the supervisor has started a different MemCP process."""
+    deadline = time.monotonic() + max(0, timeout)
+    while time.monotonic() < deadline:
+        current = shared_supervisor_generation()
+        if current is not None and current != previous:
+            return True
+        time.sleep(0.05)
+    return False
 
 _memcp_log_file: str = ""
 

--- a/tools/test_sql_runner_contract.py
+++ b/tools/test_sql_runner_contract.py
@@ -62,6 +62,7 @@ from run_sql_tests import (  # noqa: E402
     scaled_wall_clock_limit_ms,
     sql_request_is_retry_safe,
     suite_execution_mode,
+    wait_for_shared_supervisor_generation,
 )
 from tools.check_test_table_names import mutable_table_collisions  # noqa: E402
 
@@ -332,19 +333,33 @@ class InterruptedRequestContractTest(unittest.TestCase):
         runner.ensure_database = lambda _database: None
         runner.execute_sql = mock.Mock(return_value=None)
 
-        with mock.patch("run_sql_tests.wait_for_sql_ready", return_value=True) as wait:
+        with mock.patch("run_sql_tests.shared_supervisor_generation", return_value="7"), \
+                mock.patch("run_sql_tests.wait_for_shared_supervisor_generation", return_value=True) as generation_wait, \
+                mock.patch("run_sql_tests.wait_for_sql_ready", return_value=True) as wait:
             self.assertTrue(runner.run_test_case({
                 "name": "shared restart",
                 "sql": "SHUTDOWN",
             }, "memcp-tests"))
 
+        generation_wait.assert_called_once_with("7", 10)
         wait.assert_called_once_with(
             "http://localhost:23456",
             "root",
             "admin",
             "memcp-tests",
-            timeout=10,
+            timeout=120,
         )
+
+    def test_generation_wait_does_not_accept_the_old_server(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            generation = Path(tmp) / "generation"
+            generation.write_text("4\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, {
+                "MEMCP_TEST_SUPERVISOR_GENERATION_FILE": str(generation),
+            }):
+                self.assertFalse(wait_for_shared_supervisor_generation("4", 0))
+                generation.write_text("5\n", encoding="utf-8")
+                self.assertTrue(wait_for_shared_supervisor_generation("4", 1))
 
 
 class AtomicJSONObserverContractTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

Connect-only SQL suites treated a successful readiness probe after `SHUTDOWN`
as proof that the shared supervisor had restarted MemCP. The old process can
still answer during its shutdown window, so that probe could succeed against
the process which was about to exit. The next test then failed with connection
refused while the supervisor started the replacement.

This occurred in `range-scan-coverage.yaml`: its second `SHUTDOWN` was followed
by a successful probe against the old process, then both planner-statistics SCM
checks lost the connection.

## Solution

- Publish an atomically replaced supervisor generation file after every child
  process start.
- Pass its path to connect-only suite workers.
- Capture the generation before issuing `SHUTDOWN`.
- Accept the restart only after the generation changes and the new generation
  becomes SQL-ready.
- Retain the existing forced-restart path for a process which does not finish
  graceful shutdown within the bounded grace period.

The generation barrier identifies process replacement directly. It does not
depend on an arbitrary sleep or on observing a brief connection-refused window.

## Validation

- `python3 -m unittest tools.test_sql_runner_contract` — 47/47
- `bash -n git-pre-commit`
- Exact supervisor-path reproduction:
  `bash git-pre-commit tests/execution/operators/range-scan-coverage.yaml`
  — 113/113, including both `SHUTDOWN` boundaries
