### PR TITLE
Share lazy aggregate partitions across bound filters

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -6181,6 +6181,38 @@ accept exactly the same aggregate descriptors. */
 		(filter (split_and_terms (qb_where block)) (lambda (term)
 			(equal? (aggregate_pushdown_stage_filter_term? stage_aliases term) stage_filters))))))
 
+/* A query-local equality on the aggregate driver is a probe binding, not part
+of the reusable aggregate definition. Moving it above the partition makes the
+driver column a group key while retaining the original equality as the lookup
+predicate. The opposite side must be independent of relation columns and
+request-local session state; join equalities and dynamic bindings therefore
+remain ordinary residual predicates. */
+(define aggregate_pushdown_bound_term_binding (lambda (driver term)
+	(match term
+		'(op left right) (if (or (equal? op (quote equal?)) (equal? op (quote equal??)))
+			(begin
+				(define left_col (direct_column_name_for_alias driver left))
+				(define right_col (direct_column_name_for_alias driver right))
+				(if (and (not (nil? left_col))
+					(and (not (expr_contains_column_ref? right))
+						(empty_list? (query_expr_session_reads right))))
+					(list left_col op right)
+					(if (and (not (nil? right_col))
+						(and (not (expr_contains_column_ref? left))
+							(empty_list? (query_expr_session_reads left))))
+						(list right_col op left)
+						nil)))
+			nil)
+		_ nil)))
+
+(define aggregate_pushdown_bound_terms (lambda (driver terms)
+	(filter terms (lambda (term)
+		(not (nil? (aggregate_pushdown_bound_term_binding driver term)))))))
+
+(define aggregate_pushdown_probe_bindings (lambda (driver terms)
+	(map terms (lambda (term)
+		(aggregate_pushdown_bound_term_binding driver term)))))
+
 (define aggregate_pushdown_filtered_stage_sources (lambda (block filter_terms)
 	(filter (aggregate_pushdown_stage_sources block) (lambda (src)
 		(reduce filter_terms (lambda (filtered term)
@@ -6263,7 +6295,7 @@ accept exactly the same aggregate descriptors. */
 			(aggregate_pushdown_rewrite_count_fields rest partition_alias input aggregate)))
 		_ '())))
 
-(define aggregate_pushdown_build_rewrite (lambda (ir block driver movable_terms residual_terms columns driver_rows group_rows)
+(define aggregate_pushdown_build_rewrite (lambda (ir block driver movable_terms residual_terms probe_bindings columns driver_rows group_rows)
 	(begin
 		(define keys (aggregate_pushdown_keys driver columns))
 		(define residual (combine_where_terms residual_terms true))
@@ -6288,6 +6320,7 @@ accept exactly the same aggregate descriptors. */
 				(list (quote preserve_empty_domain) false)
 				(list (quote null_semantics) (quote aggregate))
 				(list (quote partition_by) keys)
+				(list (quote aggregate_probe_bindings) probe_bindings)
 				(list (quote result_max_rows_per_partition) 1))))
 		(define rewritten_stages (map (qb_stages block) (lambda (stage)
 			(aggregate_pushdown_rewrite_stage driver partition_alias columns stage))))
@@ -6334,9 +6367,15 @@ accept exactly the same aggregate descriptors. */
 					(not (aggregate_pushdown_root_shape? block)))))
 			ir
 			(begin
-				(define movable_terms (aggregate_pushdown_terms block true))
-				(define residual_terms (aggregate_pushdown_terms block false))
 				(define driver (car (aggregate_pushdown_base_sources block)))
+				(define stage_terms (aggregate_pushdown_terms block true))
+				(define base_terms (aggregate_pushdown_terms block false))
+				(define bound_terms (aggregate_pushdown_bound_terms driver base_terms))
+				(define movable_terms (merge (list stage_terms bound_terms)))
+				(define residual_terms (filter base_terms (lambda (term)
+					(not (contains? bound_terms term)))))
+				(define probe_bindings
+					(aggregate_pushdown_probe_bindings driver bound_terms))
 				(define columns
 					(aggregate_pushdown_key_columns block driver movable_terms))
 				(if (or (empty_list? movable_terms) (empty_list? columns))
@@ -6360,7 +6399,7 @@ accept exactly the same aggregate descriptors. */
 							(list (quote aggregate_pushdown_cost_preferred?)
 								driver_rows_expr group_rows_expr))
 							(aggregate_pushdown_build_rewrite ir block driver movable_terms residual_terms
-								columns driver_rows group_rows)
+								probe_bindings columns driver_rows group_rows)
 							ir))))))))
 
 (define join_reorder_node_stage_catalog (lambda (node)

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5303,6 +5303,50 @@ ever-larger subtrees. */
 					(lower_column_expr_for_alias src (nth keys i))
 					(list (quote outer) 1 (symbol (nth key_names i))))))))))
 
+/* aggregate_probe_bindings describe query-local equality probes over a shared
+partitioned aggregate. They affect only which computed group rows are eagerly
+repaired by this createcolumn call; the computed column remains defined for
+every group row and its canonical identity stays independent of bound values. */
+(define group_aggregate_probe_filter_parts (lambda (stage src keys key_names)
+	(begin
+		(define bindings
+			(coalesceNil (qassoc_get (gs_facts stage) (quote aggregate_probe_bindings) '()) '()))
+		(define indexed (map bindings (lambda (binding)
+			(match binding
+				'(column op value) (begin
+					(define index (reduce (produceN (count keys)) (lambda (found i)
+						(if (not (nil? found)) found
+							(if (equal?? (direct_column_name_for_alias src (nth keys i)) column)
+								i nil))) nil))
+					(if (nil? index)
+						(neumann_fail "build_queryplan" (concat
+							"aggregate probe binding has no matching group key: " column))
+						(list (nth key_names index) op value)))
+				_ (neumann_fail "build_queryplan" "malformed aggregate probe binding")))))
+		(if (empty_list? indexed)
+			nil
+			(begin
+				(define filter_names (reduce indexed (lambda (names binding)
+					(append_unique names (car binding))) '()))
+				(define filter_terms (map indexed (lambda (binding)
+					(list (nth binding 1)
+						(symbol (car binding))
+						(lower_column_expr_for_alias src (nth binding 2))))))
+				(list filter_names
+					(list (quote lambda) (map filter_names symbol)
+						(combine_where_terms filter_terms true))))))))
+
+(define group_aggregate_column_options (lambda (stage src keys key_names)
+	(begin
+		(define filter_parts
+			(group_aggregate_probe_filter_parts stage src keys key_names))
+		(if (nil? filter_parts)
+			(quoted_runtime_list '("temp" true))
+			(list (quote list)
+				"temp" true
+				"filtercols" (quoted_runtime_list (car filter_parts))
+				"filter" (cadr filter_parts))))))
+
 (define build_group_constant_key_insert_plan (lambda (schema grouptbl)
 	(list (quote insert)
 		(list (quote table) schema grouptbl)
@@ -5513,7 +5557,7 @@ ever-larger subtrees. */
 				agg_col
 				"any"
 				(list (quote list))
-				(quoted_runtime_list '("temp" true))
+				(group_aggregate_column_options stage src keys key_names)
 				(cons (quote list) key_names)
 				(list (quote lambda)
 					(map key_names (lambda (col) (symbol col)))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -1389,6 +1389,8 @@ outer joins. */
 			lowering_ags))
 		(define key_names (group_key_cols keys))
 		(define aggregate_condition (replace_group_session_expr stage keys key_names condition))
+		(define aggregate_probe_bindings
+			(coalesceNil (qassoc_get (gs_facts stage) (quote aggregate_probe_bindings) '()) '()))
 		(define grouptbl (group_cache_relation cache))
 		(define initializer_owner (qassoc_get (gs_facts stage) (quote keytable_initializer_owner) true))
 		(define scalar_single_stage (scalar_value_stage? stage))
@@ -1483,7 +1485,11 @@ outer joins. */
 			(or scalar_order_base_stage (expr_refs_stage_output_alias? condition)))
 			nil
 			(build_base_group_into_plan schema tbl alias src grouptbl keys key_names condition
-				(non_scalar_order_aggregates ags))))
+				/* Probe-bound partitions discover their complete key domain once, but
+				leave aggregate values to the filtered lazy computed columns. */
+				(if (empty_list? aggregate_probe_bindings)
+					(non_scalar_order_aggregates ags)
+					'()))))
 		(define cleanup_plan (if (query_block? src)
 			nil
 			(build_group_keytable_cleanup schema tbl alias grouptbl keys key_names)))

--- a/tests/planner/aggregates/traced-group-caches.yaml
+++ b/tests/planner/aggregates/traced-group-caches.yaml
@@ -117,6 +117,11 @@ setup:
         (insert (table "memcp-tests" "trace_multi_document")
           '("id" "access_id" "tenant_id" "owner_id") documents)
         2400)
+  - scm: |
+      (begin
+        (rebuild (table "memcp-tests" "trace_multi_document") true false)
+        (rebuild (table "memcp-tests" "trace_multi_access") true false)
+        (rebuild (table "memcp-tests" "trace_multi_tenant") true false))
 
 test_cases:
   - name: "COUNT pushes a selective correlated stage above an FK partition"
@@ -167,6 +172,25 @@ test_cases:
           (equal? (planner_aggregate_pushdown_group_estimate driver keys 2000) 3)
           (aggregate_pushdown_cost_preferred? 2000 3)
           (not (aggregate_pushdown_cost_preferred? 2000 1000))))
+    expect:
+      data: [true]
+
+  - name: "Only request-independent equalities become aggregate probe bindings"
+    scm: |
+      (begin
+        (define driver (list "document" "memcp-tests"
+          "trace_multi_document" false nil))
+        (define tenant_col (list (quote get_column)
+          "document" false "tenant_id" true))
+        (and
+          (equal? (aggregate_pushdown_bound_term_binding driver
+            (list (quote equal??) tenant_col 1))
+            (list "tenant_id" (quote equal??) 1))
+          (equal? (aggregate_pushdown_bound_term_binding driver
+            (list (quote equal?) 3 tenant_col))
+            (list "tenant_id" (quote equal?) 3))
+          (nil? (aggregate_pushdown_bound_term_binding driver
+            (list (quote equal??) tenant_col (list (quote session) "trace_tenant"))))))
     expect:
       data: [true]
 
@@ -289,6 +313,198 @@ test_cases:
         - "keys (\"access_id\")"
       not_contains:
         - "keys (\"access_id\" \"owner_id\")"
+
+  - name: "Bound group dimensions preserve filtered COUNT correctness"
+    max_time: 1
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 1
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 400
+
+  - name: "The first bound value uses a lazy base-table aggregate carrier"
+    sql: |
+      EXPLAIN SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 1
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      result_contains:
+        - ".grp:trace_multi_document:"
+        - "createcolumn"
+        - "filtercols"
+
+  - name: "A different bound value reuses the lazy base-table aggregate carrier"
+    sql: |
+      EXPLAIN SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 3
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      result_contains:
+        - ".grp:trace_multi_document:"
+        - "createcolumn"
+        - "filtercols"
+
+  - name: "Bound values keep the base aggregate carrier identity canonical"
+    scm: |
+      (begin
+        (define plan_a (serialize (parse_sql "memcp-tests"
+          "EXPLAIN SELECT COUNT(*) AS total FROM trace_multi_document document WHERE document.tenant_id = 1 AND COALESCE((SELECT access.allowed FROM trace_multi_access access WHERE access.id = document.access_id LIMIT 1), FALSE)")))
+        (define plan_b (serialize (parse_sql "memcp-tests"
+          "EXPLAIN SELECT COUNT(*) AS total FROM trace_multi_document document WHERE document.tenant_id = 3 AND COALESCE((SELECT access.allowed FROM trace_multi_access access WHERE access.id = document.access_id LIMIT 1), FALSE)")))
+        (define carrier_a (regexp_replace plan_a ".*(\\.grp:trace_multi_document:[0-9a-f]+).*" "$1"))
+        (define carrier_b (regexp_replace plan_b ".*(\\.grp:trace_multi_document:[0-9a-f]+).*" "$1"))
+        (and
+          (strlike carrier_a ".grp:trace_multi_document:%")
+          (strlike carrier_b ".grp:trace_multi_document:%")
+          (equal? carrier_a carrier_b)))
+    expect:
+      data: [true]
+
+  - name: "Set the aggregate partition probe from session state"
+    session_id: "trace_group_probe"
+    sql: "SET @trace_tenant = 1"
+    expect:
+      affected_rows: 1
+
+  - name: "Session-bound aggregate probes read the first partition"
+    session_id: "trace_group_probe"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = @trace_tenant
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 400
+
+  - name: "Change the aggregate partition probe in the same session"
+    session_id: "trace_group_probe"
+    sql: "SET @trace_tenant = 3"
+    expect:
+      affected_rows: 3
+
+  - name: "A changed session binding reads the new aggregate partition"
+    session_id: "trace_group_probe"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = @trace_tenant
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 400
+
+  - name: "Insert invalidates the probed aggregate partition"
+    sql: "INSERT INTO trace_multi_document (id, access_id, tenant_id, owner_id) VALUES (3001, 10, 1, 3001)"
+    expect:
+      affected_rows: 1
+
+  - name: "Inserted rows appear in the probed aggregate partition"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 1
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 401
+
+  - name: "Foreign-key updates invalidate old and new aggregate partitions"
+    sql: "UPDATE trace_multi_document SET tenant_id = 3 WHERE id = 3001"
+    expect:
+      affected_rows: 1
+
+  - name: "The old aggregate partition drops a moved row"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 1
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 400
+
+  - name: "The new aggregate partition receives a moved row"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 3
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 401
+
+  - name: "Delete invalidates the probed aggregate partition"
+    sql: "DELETE FROM trace_multi_document WHERE id = 3001"
+    expect:
+      affected_rows: 1
+
+  - name: "Deleted rows disappear from the probed aggregate partition"
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM trace_multi_document document
+      WHERE document.tenant_id = 3
+      AND COALESCE((
+        SELECT access.allowed
+        FROM trace_multi_access access
+        WHERE access.id = document.access_id
+        LIMIT 1
+      ), FALSE)
+    expect:
+      rows: 1
+      data:
+        - total: 400
 
   - name: "A high-cardinality filtered dimension rejects the combined partition"
     sql: |


### PR DESCRIPTION
## What

Turn request-independent equality filters on aggregate drivers into partition probe bindings. The planner now adds the filtered driver column to the aggregate partition key while keeping the bound value outside the canonical carrier identity. Physical lowering uses the existing `createcolumn` `filtercols`/`filter` preparation API, discovers the key domain once, and computes only the probed partition eagerly.

This lets different bound values reuse one `.grp:<base-table>:<canonical-hash>` carrier instead of compiling independent eager aggregate carriers with the literal embedded in their definitions.

The consolidation is a major resource win in its own right: a workload with many tenant/location/filter bindings no longer grows one physical group-cache table per value. One keyed carrier replaces that unbounded family of tables. This reduces cache-table metadata, columns, trigger registrations, rebuild/cleanup work, and memory overhead while preserving per-key lazy computation and invalidation.

## Planner architecture

- The parser/untangle/reorder/physical boundary remains intact: probe bindings are logical group-stage facts; `createcolumn` and cache names appear only during physical lowering.
- The rewrite remains cost-gated by the existing aggregate-pushdown decision and its runtime guard. High-cardinality partitions still reject the rewrite.
- No cost constants were changed by hand. Costgen does not currently own this logical aggregate-pushdown decision, so there is no generated coefficient to patch.
- Session-dependent equality values deliberately remain on the prior dynamic path. Persistent compute callbacks never capture request-local session or transaction state.
- The storage engine is unchanged; this uses its existing complete-but-lazily-prewarmed computed-column contract.

## Correctness and reachability

The expanded trace-derived YAML suite covers:

- the original compound COUNT plus correlated access probe;
- physical `filtercols` reachability for two different bound values;
- identical canonical base-carrier identity across those values;
- INSERT, foreign-key UPDATE (old and new partitions), and DELETE invalidation;
- changed session bindings on the safe dynamic path;
- rejection of high-cardinality partition shapes.

The two new physical reachability assertions fail on current master and pass on this branch.

## Manual A/B

Same local fixture and query on both builds: 5,000 driving rows, 20 bound partitions, 10 correlated ACL keys, rebuilt statistics, separate fresh servers/data directories.

- First cold bound: master **113.8 ms**, branch **51.0 ms** (**55.2% faster**).
- Subsequent previously unseen bounds (tenants 11-20), median: master **36.1 ms**, branch **34.9 ms** (**3.3% faster**).
- Repeated fully cached results stayed sub-millisecond on both builds; differences at that scale were HTTP/scheduler noise.

The structural benefit is independent of those small synthetic timings: master emits one bound-specific aggregate carrier per value, while this branch emits one canonical base-table carrier and prewarms only the requested key partition.

## Validation

- `go build -o memcp .`
- startup Scheme tests: **1276/1276**
- `python3 tools/lint_scm.py --path ... --check` for all three changed Scheme files
- `python3 run_sql_tests.py tests/planner/aggregates/traced-group-caches.yaml 4637 --connect-only`: **28/28**

The full YAML suite is intentionally left to CI.