### PR TITLE
JIT: make GC stack maps precise and callbacks direct

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -426,6 +426,24 @@ type JITValueDesc struct {
 	StackFunc bool
 }
 
+// jitValueWordIsPointer reports whether word is a relocatable Go pointer in
+// the descriptor's machine representation. Scalar descriptors are unboxed;
+// unlike a two-word Scmer, their only word is a pointer exclusively when the
+// producer says so explicitly through RelocatablePointer.
+func jitValueWordIsPointer(value JITValueDesc, word int32) bool {
+	if word != 0 {
+		return false
+	}
+	switch value.Loc {
+	case LocReg, LocStack:
+		return value.RelocatablePointer
+	case LocRegPair, LocStackPair, LocInputPair, LocRegTriple, LocStackTriple:
+		return !value.NoHeapPointer
+	default:
+		return false
+	}
+}
+
 type JITLambdaTemplate struct {
 	Proc  Proc
 	Outer *JITEnv

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -831,7 +831,7 @@ func (ctx *JITContext) stabilizeForNested(value JITValueDesc) JITValueDesc {
 	regs := [...]Reg{value.Reg, value.Reg2, value.Reg3}
 	for i := int32(0); i < words; i++ {
 		ctx.EmitStoreRegMem(regs[i], ctx.FrameReg, off+i*8)
-		ctx.setStackPointer(jitStackRootFrameBP, off+i*8, !value.NoHeapPointer && i == 0)
+		ctx.setStackPointer(jitStackRootFrameBP, off+i*8, jitValueWordIsPointer(value, i))
 		if owner := ctx.RegOwners[regs[i]]; owner == nil || owner.ID == originalID {
 			ctx.RegOwners[regs[i]] = nil
 			ctx.FreeRegs |= 1 << uint(regs[i])
@@ -977,7 +977,7 @@ func (ctx *JITContext) StabilizeDescForControlFlow(desc *JITValueDesc) {
 	regs := [...]Reg{desc.Reg, desc.Reg2, desc.Reg3}
 	for i := int32(0); i < words; i++ {
 		ctx.EmitStoreRegMem(regs[i], ctx.StackReg, off+i*8)
-		ctx.setStackPointer(jitStackRootFrameSP, off+i*8-ctx.DynamicSP, !desc.NoHeapPointer && i == 0)
+		ctx.setStackPointer(jitStackRootFrameSP, off+i*8-ctx.DynamicSP, jitValueWordIsPointer(*desc, i))
 		owner := ctx.RegOwners[regs[i]]
 		ownsReg := owner == desc || (owner != nil && desc.ID != 0 && owner.ID == desc.ID)
 		if ownsReg {
@@ -1026,13 +1026,13 @@ func (ctx *JITContext) StabilizeDescAcrossNestedCall(desc *JITValueDesc) {
 		for i := int32(0); i < words; i++ {
 			ctx.EmitMovRegMem(ctx.ScratchReg, ctx.StackReg, desc.StackOff+i*8)
 			ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.FrameReg, off+i*8)
-			ctx.setStackPointer(jitStackRootFrameBP, off+i*8, !desc.NoHeapPointer && i == 0)
+			ctx.setStackPointer(jitStackRootFrameBP, off+i*8, jitValueWordIsPointer(*desc, i))
 		}
 	} else {
 		regs := [...]Reg{desc.Reg, desc.Reg2, desc.Reg3}
 		for i := int32(0); i < words; i++ {
 			ctx.EmitStoreRegMem(regs[i], ctx.FrameReg, off+i*8)
-			ctx.setStackPointer(jitStackRootFrameBP, off+i*8, !desc.NoHeapPointer && i == 0)
+			ctx.setStackPointer(jitStackRootFrameBP, off+i*8, jitValueWordIsPointer(*desc, i))
 			owner := ctx.RegOwners[regs[i]]
 			if owner == desc || (owner != nil && desc.ID != 0 && owner.ID == desc.ID) {
 				ctx.RegOwners[regs[i]] = nil
@@ -1074,7 +1074,7 @@ func (ctx *JITContext) StabilizeCallbackArgs(args []JITValueDesc) []JITValueDesc
 		ctx.EmitMovRegMem(scratch, ctx.StackReg, arg.StackOff+8)
 		ctx.EmitStoreRegMem(scratch, ctx.FrameReg, off+8)
 		ctx.FreeReg(scratch)
-		ctx.setStackPointer(jitStackRootFrameBP, off, true)
+		ctx.setStackPointer(jitStackRootFrameBP, off, jitValueWordIsPointer(arg, 0))
 		stable[i] = JITValueDesc{Loc: LocStackPair, Type: arg.Type, StackOff: off, NoHeapPointer: arg.NoHeapPointer, Rooted: true}
 	}
 	return stable
@@ -1134,8 +1134,8 @@ func (ctx *JITContext) stabilizeJITEnvValue(value JITValueDesc) JITValueDesc {
 		Rooted:             value.Rooted,
 	}
 	ctx.EmitCopyDescWords(&stable, &value, words)
-	if !value.NoHeapPointer {
-		ctx.setStackPointer(jitStackRootFrameBP, off, !value.NoHeapPointer)
+	if jitValueWordIsPointer(value, 0) {
+		ctx.setStackPointer(jitStackRootFrameBP, off, true)
 		stable.Rooted = true
 	}
 	return stable

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -86,7 +86,7 @@ func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 	ctx := &JITContext{
 		Start:      start,
 		Ptr:        start,
-		End:        unsafe.Add(start, len(code)),
+		End:        unsafe.Add(start, len(code)-1),
 		AllRegs:    1 << uint(RegRAX),
 		FrameReg:   RegRBP,
 		StackReg:   RegRSP,
@@ -101,6 +101,84 @@ func TestJITScalarPointerSpillRemainsInStackMap(t *testing.T) {
 	root := jitStackRoot{base: jitStackRootFrameBP, offset: -8}
 	if _, ok := ctx.StackRoots[root]; !ok {
 		t.Fatal("relocatable scalar spill is missing from the stack map")
+	}
+}
+
+func newJITStackMapTestContext(code []byte) *JITContext {
+	start := unsafe.Pointer(&code[0])
+	return &JITContext{
+		Start:      start,
+		Ptr:        start,
+		End:        unsafe.Add(start, len(code)-1),
+		AllRegs:    1<<uint(RegRAX) | 1<<uint(RegRBX),
+		FreeRegs:   1<<uint(RegRAX) | 1<<uint(RegRBX),
+		FrameReg:   RegRBP,
+		StackReg:   RegRSP,
+		ScratchReg: RegR11,
+	}
+}
+
+func TestJITUnboxedScalarStabilizationDoesNotCreateGCStackRoot(t *testing.T) {
+	t.Run("control flow", func(t *testing.T) {
+		code := make([]byte, 128)
+		ctx := newJITStackMapTestContext(code)
+		value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX}
+		ctx.BindReg(RegRAX, &value)
+
+		ctx.StabilizeDescForControlFlow(&value)
+		if _, exists := ctx.StackRoots[jitStackRoot{base: jitStackRootFrameSP, offset: 0}]; exists {
+			t.Fatal("unboxed control-flow scalar is marked as a GC pointer")
+		}
+	})
+
+	t.Run("nested call", func(t *testing.T) {
+		code := make([]byte, 128)
+		ctx := newJITStackMapTestContext(code)
+		value := JITValueDesc{Loc: LocReg, Type: tagBool, Reg: RegRAX}
+		ctx.BindReg(RegRAX, &value)
+
+		ctx.StabilizeDescAcrossNestedCall(&value)
+		if _, exists := ctx.StackRoots[jitStackRoot{base: jitStackRootFrameBP, offset: -8}]; exists {
+			t.Fatal("unboxed nested-call scalar is marked as a GC pointer")
+		}
+	})
+
+	t.Run("parser environment", func(t *testing.T) {
+		code := make([]byte, 128)
+		ctx := newJITStackMapTestContext(code)
+		value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX}
+		ctx.BindReg(RegRAX, &value)
+
+		stable := ctx.StabilizeJITEnv(&JITEnv{Vars: map[Symbol]JITValueDesc{"value": value}})
+		if _, exists := ctx.StackRoots[jitStackRoot{base: jitStackRootFrameBP, offset: -8}]; exists {
+			t.Fatal("unboxed parser-environment scalar is marked as a GC pointer")
+		}
+		if got := stable.Vars["value"]; got.Loc != LocStack || got.RelocatablePointer {
+			t.Fatalf("unexpected stabilized scalar: %+v", got)
+		}
+	})
+}
+
+func TestJITRelocatableScalarStabilizationCreatesGCStackRoot(t *testing.T) {
+	code := make([]byte, 128)
+	ctx := newJITStackMapTestContext(code)
+	value := JITValueDesc{Loc: LocReg, Type: tagInt, Reg: RegRAX, RelocatablePointer: true}
+	ctx.BindReg(RegRAX, &value)
+
+	ctx.StabilizeDescAcrossNestedCall(&value)
+	if _, exists := ctx.StackRoots[jitStackRoot{base: jitStackRootFrameBP, offset: -8}]; !exists {
+		t.Fatal("relocatable nested-call scalar is missing from the GC stack map")
+	}
+}
+
+func TestJITSavedFramePointerIsNotAHeapRoot(t *testing.T) {
+	ctx := &JITContext{Safepoints: []jitSafepoint{{}}}
+	maps := ctx.finalizeStackMaps(16, 0)
+	if len(maps) != 1 || maps[0].frameWords != 3 {
+		t.Fatalf("unexpected stack map: %+v", maps)
+	}
+	if maps[0].pointerMap[0]&(1<<2) != 0 {
+		t.Fatal("saved caller frame pointer is encoded as a GC heap root")
 	}
 }
 

--- a/scm/jit_x86_emitter.go
+++ b/scm/jit_x86_emitter.go
@@ -1974,7 +1974,6 @@ func (ctx *JITContext) finalizeStackMaps(frameSize int32, arenaOffset int) []jit
 				panic("jit: invalid stack root base")
 			}
 		}
-		mark(frameBytes, jitStackRoot{}) // saved Go RBP must move with a growing goroutine stack
 		maps[i] = jitStackMap{
 			pcOffset:   uintptr(arenaOffset) + uintptr(safepoint.pcOffset),
 			frameWords: frameWords,


### PR DESCRIPTION
## Problem

The JIT used `NoHeapPointer` to classify every stabilized value word. That is correct for boxed two-word `Scmer` values, but wrong for `LocReg` and `LocStack`: those descriptors contain unboxed scalars. Loop counters, indexes, and booleans were therefore advertised to the Go runtime as relocatable pointers. The generated maps also advertised the saved caller frame pointer as a GC heap root, mixing unwind metadata with heap liveness.

Generated higher-order builtins had a separate hot-path problem. Their SSA callback sites called fixed Go helpers (`jitInvokeCallback1` through `jitInvokeCallback4`), which called `Apply` and reconstructed a variadic argument slice for every item. That retained an interpreter boundary even when the runtime value was already a JIT Proc or a regular Go funcval.

Known reducer lambdas were also unnecessarily materialized as Procs when a callback parameter declared `Transfer`. `Transfer` describes ownership of the accumulator value; it does not make the lambda body escape.

## Solution

- Centralize descriptor-word pointer classification.
- Mark unboxed scalar words only when `RelocatablePointer` is set.
- Keep boxed `Scmer` and slice pointer words governed by `NoHeapPointer`.
- Apply the same classification to control-flow homes, nested-call spills, callback arguments, and stabilized parser environments.
- Stop encoding the saved caller RBP in `PointerMask`; the patched runtime now relocates it from `CallerBPOffset` unwind metadata.
- Make jitgen route fixed-arity callback sites through the normal dynamic callable emitter.
  - JIT Proc: direct compact-ABI funcval call.
  - Go funcval: direct Go-ABI funcval call.
  - Unsupported callable kinds only: retain the `ApplyEx` fallback.
- Preserve known lambda templates independently of accumulator ownership, allowing fused reducer callbacks to be emitted recursively.
- Regenerate the affected list and grouping emitters; the four fixed `jitInvokeCallbackN` helpers are now dead and removed.

The required runtime fix and its regression tests are published on both `launix-de/go` patch branches:

- `jit-foreign-frames-go1.27.0`: `7672f74704`, `84fe25ee45`
- `jit-foreign-frames-master`: equivalent existing relocation plus `c3e63e0c6e`

## Manual A/B measurements

All microbenchmarks used the same Ryzen 9 7900X3D core, the same patched Go toolchain, `GOEXPERIMENT=jit`, 128 input values, and six measured repetitions after compilation.

| Case | Baseline | PR | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Runtime JIT-Proc reducer callback | ~5.40 us | ~2.01 us | 2.69x faster | 134 -> 6 |
| Runtime Go-func reducer callback | ~4.29 us | ~1.18 us | 3.64x faster | 132 -> 4 |
| Optimizer-fused filter -> map -> reduce | ~6.35 us | ~3.16 us | 2.01x faster | 97 -> 1 |

The allocation delta is exact for the dynamic benchmark: 128 per-item Apply/variadic allocations disappear.

Disassembly of the same generated reduce loop confirms the mechanism. The baseline hot loop calls the fixed Apply helper after a full foreign-call save sequence. The PR emits `call *%r11` directly for JIT Procs and Go funcvals; only the unsupported-tag branch reaches `jitApplyCallable*`.

## Validation

- `make test`: passed for the GC-stack-map commit.
- Vanilla `go test ./tools/jitgen ./scm` and `go build ./...`: passed after the callback change.
- `GOEXPERIMENT=jit go test ./tools/jitgen ./scm` and `go build ./...`: passed after the callback change.
- Direct callback tests force GC and Go stack growth inside the callback and pass under `-race`.
- Fallback-free JIT coverage tests pass for optimizer-produced `filter_map`, `map_filter`, `map_map`, `filter_filter`, `reduce_map`, `reduce_filter`, `reduce_filter_map`, `group_assoc_append_reduce`, and `group_assoc_count_reduce` trees.
- Stack-map and stack-growth needle tests: 100 repetitions passed under the race detector.
- The two suites affected after the previous CI process crash (`order-by-complex.yaml` and `scalar-window-derived.yaml`): 15 fresh JIT processes each, 345/345 SQL cases passed.
- Patched runtime `go test -race runtime/jit`: passed.
- Runtime publication stress: eight active JIT frames with forced GCs while approximately 2,000 stack maps are appended, 10 repetitions under the race detector passed.
- Caller-BP regression test: failed 20/20 on the previous published Go patch and passed 100/100 with the runtime fix.

The full vanilla and JIT SQL suites run in CI for the pushed head.
