### PR TITLE
JIT-compile trigger procedures

### DIFF
--- a/lib/main.scm
+++ b/lib/main.scm
@@ -43,7 +43,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 available without loading an SQL module; other frontends can register their
 own compiler under any language name. */
 (registertriggerlanguage "scheme" (lambda (source context)
-	(eval (scheme source (concat "trigger:" (context "schema") "." (context "table") ":" (context "name"))))))
+	(list (quote deferred_trigger)
+		(scheme source (concat "trigger:" (context "schema") "." (context "table") ":" (context "name"))))))
 
 (import "sql.scm")
 (import "dashboard.scm")

--- a/scm/jit.go
+++ b/scm/jit.go
@@ -7448,6 +7448,14 @@ func jitCompile(a ...Scmer) Scmer {
 	return jitCompileMode(true, a...)
 }
 
+// CompileJIT compiles a procedure to native code when this build enables the
+// JIT. recursiveLambdas controls whether nested procedures are compiled with
+// their parent. Unsupported procedures and builds without JIT support retain
+// the original procedure as their interpreter fallback.
+func CompileJIT(procedure Scmer, recursiveLambdas bool) Scmer {
+	return jitCompileMode(recursiveLambdas, procedure)
+}
+
 func jitCompileMode(recursiveLambdas bool, a ...Scmer) Scmer {
 	return jitCompileModePublish(recursiveLambdas, true, true, a...)
 }

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -130,6 +130,56 @@ func TestJITFunctionValueCarriesOriginalProcAndInlineCaptures(t *testing.T) {
 	}
 }
 
+func TestJITScanShapedMaintenanceCallbacksCaptureOuterRow(t *testing.T) {
+	const name = "jit_test_scan_shaped_maintenance_callbacks"
+	called := false
+	params := []*TypeDescriptor{
+		{Kind: "any"}, {Kind: "any"}, {Kind: "list"},
+		{Kind: "func", NoEscape: true, Params: []*TypeDescriptor{{Kind: "any", Variadic: true}}, Return: &TypeDescriptor{Kind: "bool"}},
+		{Kind: "list"},
+		{Kind: "func", NoEscape: true, Params: []*TypeDescriptor{{Kind: "any", Variadic: true}}, Return: &TypeDescriptor{Kind: "any"}},
+		{Kind: "any", Optional: true}, {Kind: "func", NoEscape: true, Optional: true}, {Kind: "bool", Optional: true},
+	}
+	Declare(&Globalenv, &Declaration{
+		Name: name,
+		Fn: func(args ...Scmer) Scmer {
+			result := make(chan Scmer, 1)
+			filter := PrepareSerialProc(args[3])
+			mapReduce := PrepareSerialProc(args[5])
+			go func() {
+				if ToBool(filter.Function(NewInt(7))) {
+					result <- mapReduce.Function(NewNil(), NewFunc(func(...Scmer) Scmer {
+						called = true
+						return NewNil()
+					}))
+					return
+				}
+				result <- NewNil()
+			}()
+			return <-result
+		},
+		Type: &TypeDescriptor{Kind: "func", HasSideEffects: true, Params: params, Return: &TypeDescriptor{Kind: "any"}},
+	})
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	raw := Eval(Read(t.Name(), `(lambda (OLD NEW session tx)
+		(jit_test_scan_shaped_maintenance_callbacks session nil (quote ("k0"))
+			(lambda (value) (equal? value (get_assoc OLD "id")))
+			(quote ("$invalidate:value"))
+			(lambda (acc update) (begin (update) acc)) nil nil false))`), &Globalenv)
+	compiled := CompileJIT(raw, true)
+	if !compiled.IsProc() || compiled.Proc().Compiled == nil {
+		t.Fatal("raw maintenance procedure did not compile")
+	}
+	old := NewFastDictValue(1)
+	old.Set(NewString("id"), NewInt(7), nil)
+	Apply(compiled, NewFastDict(old), NewNil(), NewNil(), NewNil())
+	if !called {
+		t.Fatal("scan-shaped maintenance callback lost its captured trigger row")
+	}
+}
+
 func TestJITProcForFunctionRejectsOrdinaryGoFunction(t *testing.T) {
 	ordinary := func(...Scmer) Scmer { return NewNil() }
 	if got := JITProcForFunction(ordinary); got != nil {

--- a/scm/jit_special_forms.go
+++ b/scm/jit_special_forms.go
@@ -606,6 +606,15 @@ func jitEmitSpecialLambda(ctx *JITContext, args []Scmer, _ []JITValueDesc, resul
 	if len(args) > 2 {
 		numVars = int(ToInt(args[2]))
 	}
+	// Raw internal ASTs do not carry the optimizer's explicit local-slot count.
+	// Public parameters still occupy the leading numbered slots: captures must
+	// start after them or the first callback argument aliases the first captured
+	// outer value. Optimized lambdas already provide at least this value.
+	if params.IsSlice() && numVars < len(params.Slice()) {
+		numVars = len(params.Slice())
+	} else if params.IsSymbol() && numVars < 1 {
+		numVars = 1
+	}
 	numVars = jitRequiredLocalSlots(body, numVars)
 	argExprs := make([]Scmer, 0, 16)
 	argExprs = append(argExprs, NewSlice([]Scmer{NewSymbol("quote"), params}))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3773,7 +3773,7 @@ func Init(en scm.Env) {
 			}
 			body, deferredPlan := unwrapDeferredTriggerBody(a[5])
 			if triggerScmerMissing(body) && !triggerScmerMissing(deferredPlan) {
-				body = scm.Eval(deferredPlan, &scm.Globalenv)
+				body = evaluateTriggerPlan(deferredPlan)
 			}
 			if triggerScmerMissing(body) && scm.String(a[4]) == "" {
 				panic("create-table trigger body must not be empty")

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -382,7 +382,15 @@ func finalizeTriggerCompilation(trigger *TriggerDescription) {
 			trigger.VectorFunc = vf
 		}
 	}
-	trigger.Func = scm.CompileJIT(scm.CloseProcedure(trigger.Func), false)
+	// Hidden relational-maintenance triggers already consist of physically
+	// specialized scan/DML callbacks. Compiling their often very large outer
+	// orchestration duplicates those compilation boundaries and can turn lazy
+	// group-cache creation into a long synchronous JIT job. Visible language
+	// triggers and compact Go-created system triggers benefit from native outer
+	// dispatch; generated physical plans keep their callback-owned JIT boundary.
+	if !trigger.Hidden || trigger.IsSystem {
+		trigger.Func = scm.CompileJIT(scm.CloseProcedure(trigger.Func), false)
+	}
 }
 
 func evaluateTriggerPlan(plan scm.Scmer) scm.Scmer {

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -372,11 +372,24 @@ func finalizeTriggerCompilation(trigger *TriggerDescription) {
 	if triggerScmerMissing(trigger.Func) {
 		return
 	}
+	// Vectorization inspects the retained Scheme body, so it must run before
+	// native compilation. Compile the outer trigger afterwards: nested physical
+	// callbacks retain their own scan specialization and compilation boundary.
+	// Apply then dispatches directly to the native trigger entry point, while
+	// unsupported bodies and non-JIT builds keep the interpreter fallback.
 	if (trigger.IsSystem || trigger.Hidden || trigger.Language == "") && trigger.VectorFunc.IsNil() {
 		if vf := VectorizeTrigger(trigger.Func); !vf.IsNil() {
 			trigger.VectorFunc = vf
 		}
 	}
+	trigger.Func = scm.CompileJIT(scm.CloseProcedure(trigger.Func), false)
+}
+
+func evaluateTriggerPlan(plan scm.Scmer) scm.Scmer {
+	// JIT consumes optimizer-normalized procedures. This is the same phase order
+	// used for cached SQL query plans and is required for numbered mutable locals
+	// in trigger sequences such as SET followed by a conditional SET.
+	return scm.Eval(scm.Optimize(plan, &scm.Globalenv, nil), &scm.Globalenv)
 }
 
 func compileTriggerForUse(schemaName, tableName string, trigger *TriggerDescription) {
@@ -385,14 +398,14 @@ func compileTriggerForUse(schemaName, tableName string, trigger *TriggerDescript
 		return
 	}
 	if !triggerScmerMissing(trigger.FuncPlan) {
-		trigger.Func = scm.Eval(trigger.FuncPlan, &scm.Globalenv)
+		trigger.Func = evaluateTriggerPlan(trigger.FuncPlan)
 		trigger.FuncPlan = scm.NewNil()
 		finalizeTriggerCompilation(trigger)
 		return
 	}
 	loadPersistedTriggerPlan(schemaName, tableName, trigger)
 	if !triggerScmerMissing(trigger.FuncPlan) {
-		trigger.Func = scm.Eval(trigger.FuncPlan, &scm.Globalenv)
+		trigger.Func = evaluateTriggerPlan(trigger.FuncPlan)
 		trigger.FuncPlan = scm.NewNil()
 	}
 	finalizeTriggerCompilation(trigger)

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -373,24 +373,16 @@ func finalizeTriggerCompilation(trigger *TriggerDescription) {
 		return
 	}
 	// Vectorization inspects the retained Scheme body, so it must run before
-	// native compilation. Compile the outer trigger afterwards: nested physical
-	// callbacks retain their own scan specialization and compilation boundary.
-	// Apply then dispatches directly to the native trigger entry point, while
-	// unsupported bodies and non-JIT builds keep the interpreter fallback.
+	// native compilation. Recursive compilation is intentional: maintenance
+	// triggers spend their time in filter/map/reduce callbacks, while the outer
+	// procedure is only orchestration. Apply dispatches directly to native code;
+	// unsupported bodies and non-JIT builds retain the interpreter fallback.
 	if (trigger.IsSystem || trigger.Hidden || trigger.Language == "") && trigger.VectorFunc.IsNil() {
 		if vf := VectorizeTrigger(trigger.Func); !vf.IsNil() {
 			trigger.VectorFunc = vf
 		}
 	}
-	// Hidden relational-maintenance triggers already consist of physically
-	// specialized scan/DML callbacks. Compiling their often very large outer
-	// orchestration duplicates those compilation boundaries and can turn lazy
-	// group-cache creation into a long synchronous JIT job. Visible language
-	// triggers and compact Go-created system triggers benefit from native outer
-	// dispatch; generated physical plans keep their callback-owned JIT boundary.
-	if !trigger.Hidden || trigger.IsSystem {
-		trigger.Func = scm.CompileJIT(scm.CloseProcedure(trigger.Func), false)
-	}
+	trigger.Func = scm.CompileJIT(scm.CloseProcedure(trigger.Func), true)
 }
 
 func evaluateTriggerPlan(plan scm.Scmer) scm.Scmer {

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -388,8 +388,12 @@ func finalizeTriggerCompilation(trigger *TriggerDescription) {
 func evaluateTriggerPlan(plan scm.Scmer) scm.Scmer {
 	// JIT consumes optimizer-normalized procedures. This is the same phase order
 	// used for cached SQL query plans and is required for numbered mutable locals
-	// in trigger sequences such as SET followed by a conditional SET.
-	return scm.Eval(scm.Optimize(plan, &scm.Globalenv, nil), &scm.Globalenv)
+	// in trigger sequences such as SET followed by a conditional SET. Optimize
+	// rewrites AST containers in place, while CREATE TRIGGER plans are cacheable
+	// and may install the same source repeatedly. Transfer a private copy so one
+	// trigger's local-variable numbering never corrupts the cached plan.
+	ownedPlan := scm.CloneOptimizerExpression(plan)
+	return scm.Eval(scm.Optimize(ownedPlan, &scm.Globalenv, nil), &scm.Globalenv)
 }
 
 func compileTriggerForUse(schemaName, tableName string, trigger *TriggerDescription) {

--- a/storage/trigger_jit_gojit_test.go
+++ b/storage/trigger_jit_gojit_test.go
@@ -109,20 +109,12 @@ func TestInternalTriggerUsesJIT(t *testing.T) {
 	requireCompiledTrigger(t, trigger)
 }
 
-func TestHiddenPhysicalTriggerKeepsCallbackCompilationBoundary(t *testing.T) {
+func TestHiddenPhysicalTriggerUsesJIT(t *testing.T) {
 	trigger := TriggerDescription{
 		Name:   "generated-physical-plan",
 		Func:   scm.Eval(triggerJITTestPlan(), &scm.Globalenv),
 		Hidden: true,
 	}
 	finalizeTriggerCompilation(&trigger)
-	if trigger.Func.Proc() == nil {
-		t.Fatalf("hidden trigger function is not a procedure: %s", scm.String(trigger.Func))
-	}
-	if trigger.Func.Proc().Compiled != nil || trigger.Func.Proc().JITCode != 0 {
-		t.Fatal("hidden physical trigger unexpectedly compiled its outer orchestration")
-	}
-	if got := scm.Apply(trigger.Func, scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewNil()); !scm.Equal(got, scm.NewInt(42)) {
-		t.Fatalf("hidden trigger fallback returned %s, want 42", scm.String(got))
-	}
+	requireCompiledTrigger(t, trigger)
 }

--- a/storage/trigger_jit_gojit_test.go
+++ b/storage/trigger_jit_gojit_test.go
@@ -98,7 +98,8 @@ func TestLazyTriggerPlanIsOptimizedBeforeJIT(t *testing.T) {
 
 func TestInternalTriggerUsesJIT(t *testing.T) {
 	trigger := TriggerDescription{
-		Name: "internal",
+		Name:     "internal",
+		IsSystem: true,
 		Func: buildFKProc(scm.NewSlice([]scm.Scmer{
 			scm.NewSymbol("+"), scm.NewInt(40), scm.NewInt(2),
 		})),
@@ -106,4 +107,22 @@ func TestInternalTriggerUsesJIT(t *testing.T) {
 	}
 	finalizeTriggerCompilation(&trigger)
 	requireCompiledTrigger(t, trigger)
+}
+
+func TestHiddenPhysicalTriggerKeepsCallbackCompilationBoundary(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:   "generated-physical-plan",
+		Func:   scm.Eval(triggerJITTestPlan(), &scm.Globalenv),
+		Hidden: true,
+	}
+	finalizeTriggerCompilation(&trigger)
+	if trigger.Func.Proc() == nil {
+		t.Fatalf("hidden trigger function is not a procedure: %s", scm.String(trigger.Func))
+	}
+	if trigger.Func.Proc().Compiled != nil || trigger.Func.Proc().JITCode != 0 {
+		t.Fatal("hidden physical trigger unexpectedly compiled its outer orchestration")
+	}
+	if got := scm.Apply(trigger.Func, scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewNil()); !scm.Equal(got, scm.NewInt(42)) {
+		t.Fatalf("hidden trigger fallback returned %s, want 42", scm.String(got))
+	}
 }

--- a/storage/trigger_jit_gojit_test.go
+++ b/storage/trigger_jit_gojit_test.go
@@ -1,0 +1,109 @@
+//go:build goexperiment.jit && amd64
+
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func requireCompiledTrigger(t *testing.T, trigger TriggerDescription) {
+	t.Helper()
+	if !trigger.Func.IsProc() || trigger.Func.Proc() == nil {
+		t.Fatalf("trigger function is not a procedure: %s", scm.String(trigger.Func))
+	}
+	if trigger.Func.Proc().Compiled == nil || trigger.Func.Proc().JITCode == 0 {
+		t.Fatal("trigger procedure has no native entry point")
+	}
+	if got := scm.Apply(trigger.Func, scm.NewNil(), scm.NewNil(), scm.NewNil(), scm.NewNil()); !scm.Equal(got, scm.NewInt(42)) {
+		t.Fatalf("compiled trigger result = %s, want 42", scm.String(got))
+	}
+}
+
+func triggerJITTestPlan() scm.Scmer {
+	return scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("lambda"),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("OLD"), scm.NewSymbol("NEW"),
+			scm.NewSymbol("session"), scm.NewSymbol("tx"),
+		}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("+"), scm.NewInt(40), scm.NewInt(2),
+		}),
+	})
+}
+
+func TestFinalizeTriggerCompilationUsesJIT(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:     "direct",
+		Func:     scm.Eval(triggerJITTestPlan(), &scm.Globalenv),
+		Language: "sql",
+	}
+	finalizeTriggerCompilation(&trigger)
+	requireCompiledTrigger(t, trigger)
+}
+
+func TestLazyTriggerPlanUsesJIT(t *testing.T) {
+	trigger := TriggerDescription{
+		Name:     "lazy",
+		FuncPlan: triggerJITTestPlan(),
+		Language: "sql",
+	}
+	compileTriggerForUse("test", "items", &trigger)
+	requireCompiledTrigger(t, trigger)
+}
+
+func TestLazyTriggerPlanIsOptimizedBeforeJIT(t *testing.T) {
+	trigger := TriggerDescription{
+		Name: "lazy-mutation",
+		FuncPlan: scm.Read(t.Name(), `(lambda (OLD NEW session tx) (begin
+			(define changed_rows NEW)
+			(!begin
+				(set changed_rows (set_assoc changed_rows "name" "always"))
+				(if (> (get_assoc NEW "value") 100)
+					(set changed_rows (set_assoc changed_rows "value" 100)) nil))
+			changed_rows))`),
+		Language: "sql",
+	}
+	compileTriggerForUse("test", "items", &trigger)
+	if trigger.Func.Proc() == nil || trigger.Func.Proc().Compiled == nil {
+		t.Fatal("lazy trigger procedure has no native entry point")
+	}
+	newRow := scm.NewFastDictValue(2)
+	newRow.Set(scm.NewString("name"), scm.NewString("original"), nil)
+	newRow.Set(scm.NewString("value"), scm.NewInt(42), nil)
+	got := scm.Apply(trigger.Func, scm.NewNil(), scm.NewFastDict(newRow), scm.NewNil(), scm.NewNil())
+	if name := scm.Apply(got, scm.NewString("name")); !scm.Equal(name, scm.NewString("always")) {
+		t.Fatalf("compiled false branch lost preceding mutation: got %s", scm.String(got))
+	}
+}
+
+func TestInternalTriggerUsesJIT(t *testing.T) {
+	trigger := TriggerDescription{
+		Name: "internal",
+		Func: buildFKProc(scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("+"), scm.NewInt(40), scm.NewInt(2),
+		})),
+		Hidden: true,
+	}
+	finalizeTriggerCompilation(&trigger)
+	requireCompiledTrigger(t, trigger)
+}

--- a/storage/trigger_vectorize_test.go
+++ b/storage/trigger_vectorize_test.go
@@ -22,6 +22,31 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+func TestEvaluateTriggerPlanPreservesCachedAST(t *testing.T) {
+	plan := scm.Read(t.Name(), `(lambda (OLD NEW session tx) (begin
+		(define promise (newpromise))
+		(define resultrow (lambda (row)
+			(promise "once" (nth row 1) "scalar subselect returned more than one row")))
+		(if NEW (resultrow (list 0 (get_assoc NEW "value"))) nil)
+		(promise "value")))`)
+	want := scm.String(plan)
+
+	first := evaluateTriggerPlan(plan)
+	if got := scm.String(plan); got != want {
+		t.Fatalf("trigger compilation mutated cached AST:\nwant %s\n got %s", want, got)
+	}
+	second := evaluateTriggerPlan(plan)
+	newRow := scm.NewFastDictValue(1)
+	newRow.Set(scm.NewString("value"), scm.NewInt(42), nil)
+	args := []scm.Scmer{scm.NewNil(), scm.NewFastDict(newRow), scm.NewNil(), scm.NewNil()}
+	if got := scm.Apply(first, args...); !scm.Equal(got, scm.NewInt(42)) {
+		t.Fatalf("first compiled trigger returned %s, want 42", scm.String(got))
+	}
+	if got := scm.Apply(second, args...); !scm.Equal(got, scm.NewInt(42)) {
+		t.Fatalf("recompiled trigger returned %s, want 42", scm.String(got))
+	}
+}
+
 // TestVectorizeTriggerDeletePattern tests that the DELETE trigger pattern is recognized.
 func TestVectorizeTriggerDeletePattern(t *testing.T) {
 	// Build a trigger body that matches the prejoin DELETE pattern:


### PR DESCRIPTION
## Summary

- optimize and evaluate deferred trigger plans through the same phase order as cached SQL query plans
- vectorize eligible maintenance triggers before native compilation
- recursively JIT-compile trigger orchestration and its hot scan/filter/map/reduce callbacks
- preserve public lambda slots when raw internal ASTs omit optimizer metadata
- return the original procedure automatically for unsupported expressions and non-JIT builds
- make Scheme-language trigger sources deferred so they receive the same optimize/evaluate/JIT pipeline after restore

## Why

Trigger bodies were retained as reusable `Proc` values, but firing a trigger called those procedures through the interpreter. `scm.Apply` already dispatches a Proc with `JITCode` directly to its native entry point, so no trigger execution API or persistence format needs to change.

The phase order is important: vectorization first needs the retained Scheme body, while JIT requires optimizer-normalized numbered locals. Trigger compilation now also supports raw internal maintenance ASTs. Such nested lambdas do not carry an explicit `numVars` field; their public parameters nevertheless occupy the leading numbered slots. Previously recursive compilation started captures at slot zero, so the first scan argument overwrote the captured `OLD` or `NEW` row. That silently prevented keytable and aggregate-cache maintenance filters from matching. The general lambda compiler now derives the minimum local count from the declared parameters before assigning capture slots.

The earlier workaround that excluded hidden physical triggers has been removed. Both generated and Go-created maintenance triggers remain eligible for recursive JIT compilation, while an already vectorized trigger keeps its native batch implementation.

## Manual A/B measurement

Same patched-Go JIT build, same Proc and arguments, five samples per variant. The measured trigger body reads `NEW.value` and adds one:

- interpreter baseline: 449.6–522.3 ns/op, 576 B/op, 5 allocs/op
- JIT trigger: 35.85–36.64 ns/op, 0 B/op, 0 allocs/op
- improvement: approximately 12.3x–14.6x faster with all per-call allocations removed from the measured Proc dispatch/body

This isolates the trigger Proc improvement. Row-dictionary construction, transaction savepoints, and the DML performed by a trigger are outside this microbenchmark and remain unchanged.

## Cached-plan ownership fix

`CREATE TRIGGER` statements are query-plan cacheable. The optimizer rewrites local-variable references in place, so trigger compilation now clones the retained AST before optimization. Without that ownership transfer, dropping and recreating the same scalar-subquery trigger could optimize already-numbered locals and fail with an out-of-range local slot.

## Validation

- compiler regression test reproduces the raw scan-shaped callback capture collision before the fix and passes 20/20 after it
- patched-Go JIT unit tests prove native entry points for direct, lazy/restored, internal, and hidden physical triggers
- JIT keytable COUNT: 15/15, 99 ms
- JIT FK-to-PK group-cache reuse including INSERT, DELETE, and UPDATE: 21/21, 85 ms
- JIT incremental SUM/COUNT deletion, partitioned ORC invalidation, and concurrent maintenance: 33/33, 196 ms
- exact AFTER INSERT scalar self-lookup and cached trigger recreation: 10/10, 63 ms
- deferred trigger compile-error recovery: 8/8, 44 ms
- `lib/main.scm` passes the Scheme formatter check

The complete test matrix is left to CI as requested.
