### PR TITLE
Test AFTER INSERT scalar self lookups

### DIFF
--- a/tests/sql/triggers/trigger-after-insert-self-lookup.yaml
+++ b/tests/sql/triggers/trigger-after-insert-self-lookup.yaml
@@ -81,6 +81,35 @@ test_cases:
           source_id: 31
           label: "Administration"
 
+  - name: "drop the trigger before recompiling the same source"
+    sql: "DROP TRIGGER trigger_self_lookup_source_ai"
+
+  - name: "a cached CREATE TRIGGER plan can install the trigger again"
+    sql: |
+      CREATE TRIGGER trigger_self_lookup_source_ai
+      AFTER INSERT ON trigger_self_lookup_source FOR EACH ROW BEGIN
+        INSERT INTO trigger_self_lookup_child (account_id, source_id, label)
+        VALUES (
+          (SELECT account_id
+             FROM trigger_self_lookup_source
+            WHERE ID = NEW.ID),
+          NEW.ID,
+          'Administration'
+        );
+      END
+
+  - name: "recreated trigger executes the scalar self lookup"
+    sql: "INSERT INTO trigger_self_lookup_source (ID, account_id, label) VALUES (40, 12, 'recreated')"
+
+  - name: "recreated trigger retains source row identity"
+    sql: "SELECT account_id, source_id, label FROM trigger_self_lookup_child WHERE source_id = 40"
+    expect:
+      rows: 1
+      data:
+        - account_id: 12
+          source_id: 40
+          label: "Administration"
+
 cleanup:
   - sql: "DROP TRIGGER IF EXISTS trigger_self_lookup_source_ai"
   - sql: "DROP TABLE IF EXISTS trigger_self_lookup_child"

--- a/tests/sql/triggers/trigger-after-insert-self-lookup.yaml
+++ b/tests/sql/triggers/trigger-after-insert-self-lookup.yaml
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 Carl-Philip Hänsch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+metadata:
+  version: "1.0"
+  description: "AFTER INSERT trigger that copies data through a scalar self lookup"
+
+setup:
+  - sql: "DROP TABLE IF EXISTS trigger_self_lookup_child"
+  - sql: "DROP TABLE IF EXISTS trigger_self_lookup_source"
+  - sql: |
+      CREATE TABLE trigger_self_lookup_source (
+        ID INT PRIMARY KEY AUTO_INCREMENT,
+        account_id INT,
+        label VARCHAR(40)
+      )
+  - sql: |
+      CREATE TABLE trigger_self_lookup_child (
+        ID INT PRIMARY KEY AUTO_INCREMENT,
+        account_id INT,
+        source_id INT,
+        label VARCHAR(40)
+      )
+  - sql: |
+      CREATE TRIGGER trigger_self_lookup_source_ai
+      AFTER INSERT ON trigger_self_lookup_source FOR EACH ROW BEGIN
+        INSERT INTO trigger_self_lookup_child (account_id, source_id, label)
+        VALUES (
+          (SELECT account_id
+             FROM trigger_self_lookup_source
+            WHERE ID = NEW.ID),
+          NEW.ID,
+          'Administration'
+        );
+      END
+
+test_cases:
+  - name: "single inserted row is visible to its AFTER INSERT scalar lookup"
+    sql: "INSERT INTO trigger_self_lookup_source (ID, account_id, label) VALUES (10, 7, 'first')"
+
+  - name: "self lookup feeds the inserted child row"
+    sql: "SELECT account_id, source_id, label FROM trigger_self_lookup_child WHERE source_id = 10"
+    expect:
+      rows: 1
+      data:
+        - account_id: 7
+          source_id: 10
+          label: "Administration"
+
+  - name: "multi-row INSERT fires the lookup trigger once per source row"
+    sql: "INSERT INTO trigger_self_lookup_source (ID, account_id, label) VALUES (20, 8, 'second'), (30, 9, 'third')"
+
+  - name: "multi-row trigger lookups retain row identity"
+    sql: "SELECT account_id, source_id, label FROM trigger_self_lookup_child ORDER BY source_id"
+    expect:
+      rows: 3
+      data:
+        - account_id: 7
+          source_id: 10
+          label: "Administration"
+        - account_id: 8
+          source_id: 20
+          label: "Administration"
+        - account_id: 9
+          source_id: 30
+          label: "Administration"
+
+  - name: "auto increment value is available to the lookup and target insert"
+    sql: "INSERT INTO trigger_self_lookup_source (account_id, label) VALUES (11, 'generated')"
+
+  - name: "generated source identity and looked-up value stay paired"
+    sql: "SELECT account_id, source_id, label FROM trigger_self_lookup_child WHERE account_id = 11"
+    expect:
+      rows: 1
+      data:
+        - account_id: 11
+          source_id: 31
+          label: "Administration"
+
+cleanup:
+  - sql: "DROP TRIGGER IF EXISTS trigger_self_lookup_source_ai"
+  - sql: "DROP TABLE IF EXISTS trigger_self_lookup_child"
+  - sql: "DROP TABLE IF EXISTS trigger_self_lookup_source"


### PR DESCRIPTION
## What

Add an anonymized SQL regression suite for an application trigger shape that was not represented exactly in `tests/`:

- `AFTER INSERT ... FOR EACH ROW`
- `INSERT ... VALUES`
- a scalar subquery reads another column from the just-inserted source row through `WHERE primary_key = NEW.primary_key`
- another target value uses `NEW.primary_key` directly
- a constant target value

The suite covers explicit single-row inserts, multi-row inserts (including row/value pairing), generated auto-increment keys, and dropping/recreating the identical trigger through a cached `CREATE TRIGGER` plan.

## Audit result

The existing scalar-subselect trigger suite covers a related lookup into a different parent table, but not this same-table shape, multi-row identity pairing, or cached trigger recreation.

The current trigger vectorizer does **not** recognize this pattern. It recognizes the internal prejoin DELETE cascade scan only. This PR deliberately does not pretend that a row-wise SQL trigger is vectorized: batching INSERT triggers safely needs to preserve row-major execution order when multiple triggers interact. The current execution remains the correct per-row fallback.

The recreation case is important for future trigger JIT/vectorization work: a compiled procedure must not mutate the cached trigger AST. The current master passes, while the open trigger-JIT branch fails the recreated trigger with an internal `!list ... out of range` error. This test makes that regression mechanically visible before the JIT change can merge.

## Verification

Targeted on current master:

- `trigger-after-insert-self-lookup.yaml` — 10/10 passed
- `trigger-scalar-subselect.yaml` — 7/7 passed
- `trigger-insert-select-subselect.yaml` — 3/3 passed

Regression proof against the open trigger-JIT change:

- first trigger installation and execution pass
- cached recreation fails at execution with `!list start=4 count=1 out of range (len=4)`

Full suite is left to CI.
