### PR TITLE
JIT: call generated callbacks directly

### DIFF
--- a/scm/jit_callback_benchmark_test.go
+++ b/scm/jit_callback_benchmark_test.go
@@ -99,6 +99,32 @@ func TestJITRuntimeReduceCallbacksUseDirectBoundary(t *testing.T) {
 	}
 }
 
+func TestJITRuntimeReduceCallbacksPreserveLiveValues(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	proc := Eval(Optimize(Read(t.Name(), `(lambda (callback values a b c d e f) (+ a b c d e f (reduce values callback 0)))`), &Globalenv, nil), &Globalenv)
+	compiled := jitCompile(proc)
+	if compiled.GetTag() != tagProc || compiled.Proc().Compiled == nil {
+		t.Fatal("runtime callback live-value test did not compile")
+	}
+	values := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3), NewInt(4)})
+	callbacks := []Scmer{
+		jitCompile(Eval(Read(t.Name(), `(lambda (acc value) (+ acc value))`), &Globalenv)),
+		NewFunc(func(args ...Scmer) Scmer {
+			runtime.GC()
+			_ = growJITCallbackStack(64)
+			return NewInt(args[0].Int() + args[1].Int())
+		}),
+	}
+	for _, callback := range callbacks {
+		got := Apply(compiled, callback, values, NewInt(10), NewInt(20), NewInt(30), NewInt(40), NewInt(50), NewInt(60))
+		if !Equal(got, NewInt(220)) {
+			t.Fatalf("runtime callback with live values returned %s, want 220", String(got))
+		}
+	}
+}
+
 func BenchmarkJITRuntimeReduceCallback(b *testing.B) {
 	compiled := compileJITRuntimeReduceBenchmark(b)
 	valuesSlice := make([]Scmer, 128)

--- a/scm/jit_callback_benchmark_test.go
+++ b/scm/jit_callback_benchmark_test.go
@@ -7,7 +7,21 @@ Foundation, either version 3 of the License, or (at your option) any later versi
 */
 package scm
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
+
+func growJITCallbackStack(depth int) byte {
+	var frame [512]byte
+	frame[0] = byte(depth)
+	if depth == 0 {
+		return frame[0]
+	}
+	result := frame[0] ^ growJITCallbackStack(depth-1)
+	runtime.KeepAlive(frame)
+	return result
+}
 
 func compileJITCallbackBenchmark(b *testing.B, source string, inline bool) Scmer {
 	b.Helper()
@@ -42,6 +56,69 @@ func BenchmarkJITKnownMapCallback(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = Apply(compiled, input)
+			}
+		})
+	}
+}
+
+func compileJITRuntimeReduceBenchmark(tb testing.TB) Scmer {
+	tb.Helper()
+	if !jitEnabled {
+		tb.Skip("requires GOEXPERIMENT=jit")
+	}
+	declaration := declarations["reduce"]
+	previous := declaration.RetainsCallArgs
+	declaration.RetainsCallArgs = true
+	defer func() { declaration.RetainsCallArgs = previous }()
+	proc := Eval(Optimize(Read(tb.Name(), `(lambda (callback values) (reduce values callback 0))`), &Globalenv, nil), &Globalenv)
+	compiled := jitCompile(proc)
+	if compiled.GetTag() != tagProc || compiled.Proc().Compiled == nil {
+		tb.Fatal("runtime callback benchmark did not compile")
+	}
+	return compiled
+}
+
+func TestJITRuntimeReduceCallbacksUseDirectBoundary(t *testing.T) {
+	compiled := compileJITRuntimeReduceBenchmark(t)
+	if coverage := compiled.Proc().Compiled.Coverage; coverage.InlinedCalls == 0 || coverage.DynamicCalls == 0 {
+		t.Fatalf("runtime callback did not reach the generated direct boundary: %+v", coverage)
+	}
+	values := NewSlice([]Scmer{NewInt(1), NewInt(2), NewInt(3), NewInt(4)})
+	callbacks := []Scmer{
+		jitCompile(Eval(Read(t.Name(), `(lambda (acc value) (+ acc value))`), &Globalenv)),
+		NewFunc(func(args ...Scmer) Scmer {
+			runtime.GC()
+			_ = growJITCallbackStack(64)
+			return NewInt(args[0].Int() + args[1].Int())
+		}),
+	}
+	for _, callback := range callbacks {
+		if got := Apply(compiled, callback, values); !Equal(got, NewInt(10)) {
+			t.Fatalf("runtime reduce callback returned %s, want 10", String(got))
+		}
+	}
+}
+
+func BenchmarkJITRuntimeReduceCallback(b *testing.B) {
+	compiled := compileJITRuntimeReduceBenchmark(b)
+	valuesSlice := make([]Scmer, 128)
+	for index := range valuesSlice {
+		valuesSlice[index] = NewInt(int64(index))
+	}
+	values := NewSlice(valuesSlice)
+	callbacks := []struct {
+		name  string
+		value Scmer
+	}{
+		{"jit_proc", jitCompile(Eval(Read(b.Name(), `(lambda (acc value) (+ acc value))`), &Globalenv))},
+		{"go_func", NewFunc(func(args ...Scmer) Scmer { return NewInt(args[0].Int() + args[1].Int()) })},
+	}
+	for _, callback := range callbacks {
+		b.Run(callback.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for index := 0; index < b.N; index++ {
+				jitListBenchmarkSink = Apply(compiled, callback.value, values)
 			}
 		})
 	}

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -479,23 +479,6 @@ func jitApplyCallableSlice(callable Scmer, env *Env, args []Scmer) Scmer {
 	return ApplyEx(callable, args, env)
 }
 
-//go:noinline
-func jitInvokeCallback1(callback, arg0 Scmer) Scmer {
-	return Apply(callback, arg0)
-}
-
-func jitInvokeCallback2(callback, arg0, arg1 Scmer) Scmer {
-	return Apply(callback, arg0, arg1)
-}
-
-func jitInvokeCallback3(callback, arg0, arg1, arg2 Scmer) Scmer {
-	return Apply(callback, arg0, arg1, arg2)
-}
-
-func jitInvokeCallback4(callback, arg0, arg1, arg2, arg3 Scmer) Scmer {
-	return Apply(callback, arg0, arg1, arg2, arg3)
-}
-
 func jitInvokeCallbackSlice(callback Scmer, args []Scmer) Scmer {
 	return Apply(callback, args...)
 }
@@ -2015,7 +1998,18 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 		}
 		operandValues[index] = jitCompileRootedCallValueAtResult(ctx, operand, sliceBase, operandOff+int32(index*16), expected)
 	}
+	out := jitEmitDynamicCallableAt(ctx, callable, operandValues, operandOff, result)
+	ctx.FreeStack(ctx.BPOffset - stackStart)
+	return out
+}
 
+// jitEmitDynamicCallableAt lowers a runtime callable whose arguments already
+// occupy a contiguous invocation-frame array. Both Scheme procedures and Go
+// funcvals are called directly; only unsupported callable kinds retain the
+// interpreter boundary. Generated higher-order builtins use this entry point
+// so their dynamic callback path gets the same stack-aware dispatch as an
+// ordinary Scheme call.
+func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandValues []JITValueDesc, operandOff int32, result JITValueDesc) JITValueDesc {
 	resultOff := ctx.AllocSpill(16)
 	callResult := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: resultOff, Rooted: true}
 	ctx.EmitZeroDescWords(&callResult, 2)
@@ -2050,7 +2044,7 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	arityOK := ctx.ReserveLabel()
 	arity := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2, metadata)
 	ctx.EmitMovRegMem(arity, metadata, int32(unsafe.Offsetof(JITEntryPoint{}.JITArity)))
-	ctx.EmitCmpRegImm32(arity, int32(len(operands)))
+	ctx.EmitCmpRegImm32(arity, int32(len(operandValues)))
 	ctx.EmitJcc(CcE, arityOK)
 	ctx.EmitCmpRegImm32(arity, -1)
 	ctx.EmitJcc(CcNE, fallbackLabel)
@@ -2067,7 +2061,7 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	fnValue := JITValueDesc{Loc: LocReg, Type: tagFunc, Reg: fnReg, RelocatablePointer: true}
 	ctx.BindReg(fnReg, &fnValue)
 	ctx.FreeDesc(&callableValue)
-	argsSlice := jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operands))
+	argsSlice := jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operandValues))
 	ctx.EmitProcCall(fnValue, argsSlice, callResult)
 	ctx.FreeDesc(&fnValue)
 	ctx.FreeDesc(&argsSlice)
@@ -2097,7 +2091,7 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	fnValue = JITValueDesc{Loc: LocReg, Type: tagFunc, Reg: fnReg, RelocatablePointer: true}
 	ctx.BindReg(fnReg, &fnValue)
 	ctx.FreeDesc(&nativeCallable)
-	argsSlice = jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operands))
+	argsSlice = jitEmitDynamicCallArgs(ctx, fnReg, operandOff, len(operandValues))
 	ctx.EmitGoFuncCall(fnValue, argsSlice, callResult)
 	ctx.FreeDesc(&fnValue)
 	ctx.FreeDesc(&argsSlice)
@@ -2105,12 +2099,12 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	ctx.EmitJmp(endLabel)
 
 	ctx.MarkLabel(fallbackLabel)
-	args := make([]JITValueDesc, 0, len(operands)+2)
+	args := make([]JITValueDesc, 0, len(operandValues)+2)
 	args = append(args, callable)
 
 	env := jitCurrentRuntimeEnv(ctx)
 	args = append(args, env)
-	if len(operands) <= 2 {
+	if len(operandValues) <= 2 {
 		args = append(args, operandValues...)
 	} else {
 		// Keep the variadic backing array in the invocation-local JIT frame. Its
@@ -2122,7 +2116,7 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 		ctx.EmitLeaRegMem(ptr, ctx.StackReg, operandOff)
 		ctx.EmitStoreRegMem(ptr, ctx.StackReg, sliceOff)
 		ctx.FreeReg(ptr)
-		ctx.EmitMovRegImm64(ctx.ScratchReg, uint64(len(operands)))
+		ctx.EmitMovRegImm64(ctx.ScratchReg, uint64(len(operandValues)))
 		ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.StackReg, sliceOff+8)
 		ctx.EmitStoreRegMem(ctx.ScratchReg, ctx.StackReg, sliceOff+16)
 		ctx.setStackPointer(jitStackRootFrameSP, sliceOff, true)
@@ -2130,7 +2124,7 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 	}
 
 	var fn any
-	switch len(operands) {
+	switch len(operandValues) {
 	case 0:
 		fn = jitApplyCallable0
 	case 1:
@@ -2157,7 +2151,6 @@ func jitCompileDynamicCall(ctx *JITContext, callableExpr Scmer, operands []Scmer
 		out = jitPlaceIntoPair(ctx, &callResult, out)
 		out.Type = JITTypeUnknown
 	}
-	ctx.FreeStack(ctx.BPOffset - stackStart)
 	return out
 }
 
@@ -2897,14 +2890,12 @@ func jitDeclarationHasCallback(decl *Declaration) bool {
 func jitCompileCallArgument(ctx *JITContext, decl *Declaration, index int, expr Scmer, sliceBase Reg) JITValueDesc {
 	param := jitDeclarationParam(decl, index)
 	if param != nil && param.Kind == "func" {
-		transfersInput := false
-		for _, callbackParam := range param.Params {
-			transfersInput = transfersInput || callbackParam != nil && callbackParam.Transfer
-		}
-		if !transfersInput {
-			if lambda, ok := jitLambdaTemplate(expr, ctx.Env); ok {
-				return JITValueDesc{Loc: LocLambdaTemplate, Type: tagProc, Lambda: lambda}
-			}
+		// Transfer describes ownership of the callback's runtime argument; it
+		// does not make the lambda body escape. The optimizer has already encoded
+		// mutable-vs-copying builtin choices in that body, so retain the template
+		// and let the generated callback site inline it like every other lambda.
+		if lambda, ok := jitLambdaTemplate(expr, ctx.Env); ok {
+			return JITValueDesc{Loc: LocLambdaTemplate, Type: tagProc, Lambda: lambda}
 		}
 	}
 	hasCallback := false

--- a/scm/jit_compile.go
+++ b/scm/jit_compile.go
@@ -2014,6 +2014,11 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	callResult := JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: resultOff, Rooted: true}
 	ctx.EmitZeroDescWords(&callResult, 2)
 	ctx.setStackPointer(jitStackRootFrameBP, resultOff, true)
+	// Every dispatch arm must start from the same register state. In particular,
+	// generated higher-order builtins can enter here while most registers hold
+	// loop state. Keep the callable in a branch-stable home, then restore this
+	// snapshot before emitting each mutually exclusive arm.
+	ctx.StabilizeDescAcrossNestedCall(&callable)
 	fallbackLabel := ctx.ReserveLabel()
 	endLabel := ctx.ReserveLabel()
 
@@ -2030,6 +2035,11 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	ctx.EmitCmpRegImm8(tag, tagProc)
 	ctx.FreeReg(tag)
 	ctx.EmitJcc(CcNE, fallbackLabel)
+	ctx.FreeDesc(&callableValue)
+	dispatchState := ctx.SnapshotAllocState()
+
+	callableValue = callable
+	ctx.EnsureDesc(&callableValue)
 	// Scheme procedures need a direct, arity-compatible JIT entry. Their *Proc
 	// pointer is already the funcval context consumed by EmitProcCall.
 	metadata := ctx.AllocRegExcept(callableValue.Reg, callableValue.Reg2)
@@ -2068,6 +2078,7 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	ctx.Coverage.DirectProcs++
 	ctx.EmitJmp(endLabel)
 
+	ctx.RestoreAllocState(dispatchState)
 	ctx.MarkLabel(nativeFuncLabel)
 	nativeCallable := callable
 	ctx.EnsureDesc(&nativeCallable)
@@ -2098,6 +2109,7 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	ctx.Coverage.NativeCalls++
 	ctx.EmitJmp(endLabel)
 
+	ctx.RestoreAllocState(dispatchState)
 	ctx.MarkLabel(fallbackLabel)
 	args := make([]JITValueDesc, 0, len(operandValues)+2)
 	args = append(args, callable)
@@ -2139,6 +2151,7 @@ func jitEmitDynamicCallableAt(ctx *JITContext, callable JITValueDesc, operandVal
 	ctx.FreeDesc(&env)
 	ctx.EmitCopyScmerToDesc(&callResult, &fallbackResult)
 	ctx.FreeDesc(&fallbackResult)
+	ctx.RestoreAllocState(dispatchState)
 	ctx.MarkLabel(endLabel)
 	var out JITValueDesc
 	if result.Loc == LocStackPair {

--- a/scm/jit_expression_test.go
+++ b/scm/jit_expression_test.go
@@ -692,9 +692,7 @@ func TestJITExpressionConditionalBorrowedListResult(t *testing.T) {
 func TestJITExpressionReduceLambdaArgumentOrder(t *testing.T) {
 	compiled := compileJITExpressionTestProc(t,
 		`(lambda (items initial) (reduce items (lambda (acc item) (list acc item)) initial))`)
-	if coverage := compiled.Proc().Compiled.Coverage; coverage.DynamicCalls != 1 {
-		t.Fatalf("expected reduce to use one generic callback fallback, got %+v", coverage)
-	}
+	requireNoDynamicJITCalls(t, compiled)
 	got := Apply(compiled,
 		NewSlice([]Scmer{NewString("a"), NewString("b")}),
 		NewString("initial"))

--- a/scm/list.go
+++ b/scm/list.go
@@ -25553,13 +25553,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d58 := jitCopyScmerToPair(ctx, d11)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d58)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs52...)
-							d51 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d51, int32(callbackResultOff53))
-							ctx.FreeDesc(&d51)
-							d51 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0}
+							d51 = jitEmitDynamicCallableAt(ctx, d58, callbackArgs52, int32(stackArray49), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0})
 						}
 					}
 					d60 = d51
@@ -26777,13 +26771,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d43 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d43)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs37...)
-							d36 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d36, int32(callbackResultOff38))
-							ctx.FreeDesc(&d36)
-							d36 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff38), ID: 0}
+							d36 = jitEmitDynamicCallableAt(ctx, d43, callbackArgs37, int32(stackArray34), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff38), ID: 0})
 						}
 					}
 					d45 = d36
@@ -28344,13 +28332,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d48 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d48)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs42...)
-							d41 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d41, int32(callbackResultOff43))
-							ctx.FreeDesc(&d41)
-							d41 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff43), ID: 0}
+							d41 = jitEmitDynamicCallableAt(ctx, d48, callbackArgs42, int32(stackArray39), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff43), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d14)
@@ -29295,13 +29277,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d49 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d49)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs43...)
-							d42 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d42, int32(callbackResultOff44))
-							ctx.FreeDesc(&d42)
-							d42 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff44), ID: 0}
+							d42 = jitEmitDynamicCallableAt(ctx, d49, callbackArgs43, int32(stackArray40), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff44), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d14)
@@ -30637,13 +30613,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d86 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d86)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs81...)
-							d80 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d80, int32(bbs[6].PhiBase)+int32(0))
-							ctx.FreeDesc(&d80)
-							d80 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[6].PhiBase) + int32(0), ID: 0}
+							d80 = jitEmitDynamicCallableAt(ctx, d86, callbackArgs81, int32(stackArray78), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[6].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d80)
@@ -31802,13 +31772,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d31 := jitCopyScmerToPair(ctx, d10)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d31)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs26...)
-							d25 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d25, int32(bbs[3].PhiBase)+int32(24))
-							ctx.FreeDesc(&d25)
-							d25 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(24), ID: 0}
+							d25 = jitEmitDynamicCallableAt(ctx, d31, callbackArgs26, int32(stackArray23), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(24), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d25)
@@ -32093,13 +32057,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d45 := jitCopyScmerToPair(ctx, d7)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d45)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs39...)
-							d38 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d38, int32(callbackResultOff40))
-							ctx.FreeDesc(&d38)
-							d38 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff40), ID: 0}
+							d38 = jitEmitDynamicCallableAt(ctx, d45, callbackArgs39, int32(stackArray36), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff40), ID: 0})
 						}
 					}
 					d47 = d38
@@ -34385,13 +34343,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d159 := jitCopyScmerToPair(ctx, d64)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d159)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs153...)
-							d152 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d152, int32(callbackResultOff154))
-							ctx.FreeDesc(&d152)
-							d152 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff154), ID: 0}
+							d152 = jitEmitDynamicCallableAt(ctx, d159, callbackArgs153, int32(stackArray150), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff154), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d2)
@@ -37536,13 +37488,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d195 := jitCopyScmerToPair(ctx, d34)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d195)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs189...)
-							d188 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d188, int32(callbackResultOff190))
-							ctx.FreeDesc(&d188)
-							d188 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff190), ID: 0}
+							d188 = jitEmitDynamicCallableAt(ctx, d195, callbackArgs189, int32(stackArray186), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff190), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d2)
@@ -38976,13 +38922,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d276 := jitCopyScmerToPair(ctx, d34)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d276)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs270...)
-							d269 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d269, int32(callbackResultOff271))
-							ctx.FreeDesc(&d269)
-							d269 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff271), ID: 0}
+							d269 = jitEmitDynamicCallableAt(ctx, d276, callbackArgs270, int32(stackArray267), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff271), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d3)
@@ -55184,13 +55124,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d395 := jitCopyScmerToPair(ctx, d48)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d395)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs390...)
-							d389 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d389, int32(bbs[9].PhiBase)+int32(0))
-							ctx.FreeDesc(&d389)
-							d389 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[9].PhiBase) + int32(0), ID: 0}
+							d389 = jitEmitDynamicCallableAt(ctx, d395, callbackArgs390, int32(stackArray387), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[9].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d389)
@@ -56100,13 +56034,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d56)
@@ -56137,13 +56065,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d73 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d73)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs67...)
-							d66 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d66, int32(callbackResultOff68))
-							ctx.FreeDesc(&d66)
-							d66 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff68), ID: 0}
+							d66 = jitEmitDynamicCallableAt(ctx, d73, callbackArgs67, int32(stackArray64), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff68), ID: 0})
 						}
 					}
 					d75 = d66
@@ -57588,13 +57510,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d58 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d58)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs52...)
-							d51 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d51, int32(callbackResultOff53))
-							ctx.FreeDesc(&d51)
-							d51 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0}
+							d51 = jitEmitDynamicCallableAt(ctx, d58, callbackArgs52, int32(stackArray49), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d51)
@@ -59000,13 +58916,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d55 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d55)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs49...)
-							d48 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d48, int32(callbackResultOff50))
-							ctx.FreeDesc(&d48)
-							d48 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff50), ID: 0}
+							d48 = jitEmitDynamicCallableAt(ctx, d55, callbackArgs49, int32(stackArray46), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff50), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d48)
@@ -62052,13 +61962,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d53 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d53)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs47...)
-							d46 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d46, int32(callbackResultOff48))
-							ctx.FreeDesc(&d46)
-							d46 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0}
+							d46 = jitEmitDynamicCallableAt(ctx, d53, callbackArgs47, int32(stackArray44), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d46)
@@ -66833,13 +66737,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d53 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d53)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs47...)
-							d46 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d46, int32(callbackResultOff48))
-							ctx.FreeDesc(&d46)
-							d46 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0}
+							d46 = jitEmitDynamicCallableAt(ctx, d53, callbackArgs47, int32(stackArray44), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d46)
@@ -68561,13 +68459,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d44 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d44)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs38...)
-							d37 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d37, int32(callbackResultOff39))
-							ctx.FreeDesc(&d37)
-							d37 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff39), ID: 0}
+							d37 = jitEmitDynamicCallableAt(ctx, d44, callbackArgs38, int32(stackArray35), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff39), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d37)
@@ -69849,13 +69741,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					d65 = d56
@@ -70457,13 +70343,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d120 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d120)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs114...)
-							d113 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d113, int32(callbackResultOff115))
-							ctx.FreeDesc(&d113)
-							d113 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff115), ID: 0}
+							d113 = jitEmitDynamicCallableAt(ctx, d120, callbackArgs114, int32(stackArray111), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff115), ID: 0})
 						}
 					}
 					stackArray121 = ctx.AllocStack(int32(16))
@@ -71228,13 +71108,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d53 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d53)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs47...)
-							d46 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d46, int32(callbackResultOff48))
-							ctx.FreeDesc(&d46)
-							d46 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0}
+							d46 = jitEmitDynamicCallableAt(ctx, d53, callbackArgs47, int32(stackArray44), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0})
 						}
 					}
 					stackArray54 = ctx.AllocStack(int32(16))
@@ -71265,13 +71139,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d17)
@@ -72147,13 +72015,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d53 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d53)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs47...)
-							d46 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d46, int32(callbackResultOff48))
-							ctx.FreeDesc(&d46)
-							d46 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0}
+							d46 = jitEmitDynamicCallableAt(ctx, d53, callbackArgs47, int32(stackArray44), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff48), ID: 0})
 						}
 					}
 					stackArray54 = ctx.AllocStack(int32(32))
@@ -72188,13 +72050,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					d64 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
@@ -74094,13 +73950,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d131 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d131)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs125...)
-							d124 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d124, int32(callbackResultOff126))
-							ctx.FreeDesc(&d124)
-							d124 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff126), ID: 0}
+							d124 = jitEmitDynamicCallableAt(ctx, d131, callbackArgs125, int32(stackArray122), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff126), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d124)
@@ -75149,13 +74999,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d201 := jitCopyScmerToPair(ctx, d12)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d201)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs196...)
-							d195 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d195, int32(bbs[3].PhiBase)+int32(0))
-							ctx.FreeDesc(&d195)
-							d195 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0}
+							d195 = jitEmitDynamicCallableAt(ctx, d201, callbackArgs196, int32(stackArray193), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d195)
@@ -76946,13 +76790,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d131 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d131)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs125...)
-							d124 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d124, int32(callbackResultOff126))
-							ctx.FreeDesc(&d124)
-							d124 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff126), ID: 0}
+							d124 = jitEmitDynamicCallableAt(ctx, d131, callbackArgs125, int32(stackArray122), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff126), ID: 0})
 						}
 					}
 					d133 = d124
@@ -78716,13 +78554,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d275 := jitCopyScmerToPair(ctx, d12)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d275)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs270...)
-							d269 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d269, int32(bbs[3].PhiBase)+int32(0))
-							ctx.FreeDesc(&d269)
-							d269 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0}
+							d269 = jitEmitDynamicCallableAt(ctx, d275, callbackArgs270, int32(stackArray267), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d269)
@@ -82245,13 +82077,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d233 := jitCopyScmerToPair(ctx, d33)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d233)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs228...)
-							d227 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d227, int32(bbs[5].PhiBase)+int32(0))
-							ctx.FreeDesc(&d227)
-							d227 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[5].PhiBase) + int32(0), ID: 0}
+							d227 = jitEmitDynamicCallableAt(ctx, d233, callbackArgs228, int32(stackArray225), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[5].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d227)
@@ -85011,13 +84837,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d430 := jitCopyScmerToPair(ctx, d33)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d430)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs425...)
-							d424 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d424, int32(bbs[10].PhiBase)+int32(0))
-							ctx.FreeDesc(&d424)
-							d424 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[10].PhiBase) + int32(0), ID: 0}
+							d424 = jitEmitDynamicCallableAt(ctx, d430, callbackArgs425, int32(stackArray422), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[10].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d424)
@@ -86926,13 +86746,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d138 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d138)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs132...)
-							d131 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d131, int32(callbackResultOff133))
-							ctx.FreeDesc(&d131)
-							d131 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff133), ID: 0}
+							d131 = jitEmitDynamicCallableAt(ctx, d138, callbackArgs132, int32(stackArray129), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff133), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d131)
@@ -86963,13 +86777,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d148 := jitCopyScmerToPair(ctx, d12)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d148)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs142...)
-							d141 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d141, int32(callbackResultOff143))
-							ctx.FreeDesc(&d141)
-							d141 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff143), ID: 0}
+							d141 = jitEmitDynamicCallableAt(ctx, d148, callbackArgs142, int32(stackArray139), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff143), ID: 0})
 						}
 					}
 					d150 = d141
@@ -88883,13 +88691,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d304 := jitCopyScmerToPair(ctx, d15)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d304)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs299...)
-							d298 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d298, int32(bbs[3].PhiBase)+int32(0))
-							ctx.FreeDesc(&d298)
-							d298 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0}
+							d298 = jitEmitDynamicCallableAt(ctx, d304, callbackArgs299, int32(stackArray296), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d298)
@@ -90780,13 +90582,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d138 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d138)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs132...)
-							d131 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d131, int32(callbackResultOff133))
-							ctx.FreeDesc(&d131)
-							d131 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff133), ID: 0}
+							d131 = jitEmitDynamicCallableAt(ctx, d138, callbackArgs132, int32(stackArray129), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff133), ID: 0})
 						}
 					}
 					d140 = d131
@@ -91664,13 +91460,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d217 := jitCopyScmerToPair(ctx, d12)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d217)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs211...)
-							d210 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d210, int32(callbackResultOff212))
-							ctx.FreeDesc(&d210)
-							d210 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff212), ID: 0}
+							d210 = jitEmitDynamicCallableAt(ctx, d217, callbackArgs211, int32(stackArray208), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff212), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d210)
@@ -92690,13 +92480,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d300 := jitCopyScmerToPair(ctx, d15)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d300)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs295...)
-							d294 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d294, int32(bbs[3].PhiBase)+int32(0))
-							ctx.FreeDesc(&d294)
-							d294 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0}
+							d294 = jitEmitDynamicCallableAt(ctx, d300, callbackArgs295, int32(stackArray292), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(bbs[3].PhiBase) + int32(0), ID: 0})
 						}
 					}
 					ctx.StabilizeDescForControlFlow(&d294)
@@ -93600,13 +93384,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					d65 = d56
@@ -94452,13 +94230,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d129 := jitCopyScmerToPair(ctx, d9)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d129)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs123...)
-							d122 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d122, int32(callbackResultOff124))
-							ctx.FreeDesc(&d122)
-							d122 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff124), ID: 0}
+							d122 = jitEmitDynamicCallableAt(ctx, d129, callbackArgs123, int32(stackArray120), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff124), ID: 0})
 						}
 					}
 					d131 = d122
@@ -95599,13 +95371,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d61 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d61)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs55...)
-							d54 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d54, int32(callbackResultOff56))
-							ctx.FreeDesc(&d54)
-							d54 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff56), ID: 0}
+							d54 = jitEmitDynamicCallableAt(ctx, d61, callbackArgs55, int32(stackArray52), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff56), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d51)
@@ -96673,13 +96439,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d68 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d68)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs62...)
-							d61 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d61, int32(callbackResultOff63))
-							ctx.FreeDesc(&d61)
-							d61 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff63), ID: 0}
+							d61 = jitEmitDynamicCallableAt(ctx, d68, callbackArgs62, int32(stackArray59), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff63), ID: 0})
 						}
 					}
 					var d69 JITValueDesc
@@ -97617,13 +97377,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d43 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d43)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs37...)
-							d36 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d36, int32(callbackResultOff38))
-							ctx.FreeDesc(&d36)
-							d36 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff38), ID: 0}
+							d36 = jitEmitDynamicCallableAt(ctx, d43, callbackArgs37, int32(stackArray34), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff38), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d11)
@@ -98351,13 +98105,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d44 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d44)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs38...)
-							d37 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d37, int32(callbackResultOff39))
-							ctx.FreeDesc(&d37)
-							d37 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff39), ID: 0}
+							d37 = jitEmitDynamicCallableAt(ctx, d44, callbackArgs38, int32(stackArray35), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff39), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d11)
@@ -99238,13 +98986,7 @@ func init_list() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d51 := jitCopyScmerToPair(ctx, d6)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d51)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs45...)
-							d44 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d44, int32(callbackResultOff46))
-							ctx.FreeDesc(&d44)
-							d44 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff46), ID: 0}
+							d44 = jitEmitDynamicCallableAt(ctx, d51, callbackArgs45, int32(stackArray42), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff46), ID: 0})
 						}
 					}
 					d53 = d44

--- a/scm/list_assoc_extra.go
+++ b/scm/list_assoc_extra.go
@@ -808,13 +808,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d62 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d62)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs56...)
-							d55 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d55, int32(callbackResultOff57))
-							ctx.FreeDesc(&d55)
-							d55 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff57), ID: 0}
+							d55 = jitEmitDynamicCallableAt(ctx, d62, callbackArgs56, int32(stackArray53), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff57), ID: 0})
 						}
 					}
 					d63 = args[3]
@@ -1873,13 +1867,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d62 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d62)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs56...)
-							d55 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d55, int32(callbackResultOff57))
-							ctx.FreeDesc(&d55)
-							d55 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff57), ID: 0}
+							d55 = jitEmitDynamicCallableAt(ctx, d62, callbackArgs56, int32(stackArray53), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff57), ID: 0})
 						}
 					}
 					d63 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
@@ -1915,13 +1903,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d73 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d73)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs67...)
-							d66 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d66, int32(callbackResultOff68))
-							ctx.FreeDesc(&d66)
-							d66 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff68), ID: 0}
+							d66 = jitEmitDynamicCallableAt(ctx, d73, callbackArgs67, int32(stackArray64), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff68), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d16)
@@ -2989,13 +2971,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d63 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d63)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs57...)
-							d56 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d56, int32(callbackResultOff58))
-							ctx.FreeDesc(&d56)
-							d56 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0}
+							d56 = jitEmitDynamicCallableAt(ctx, d63, callbackArgs57, int32(stackArray54), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff58), ID: 0})
 						}
 					}
 					d64 = JITValueDesc{Loc: LocImm, Type: tagNil, Imm: NewNil()}
@@ -3031,13 +3007,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d74 := jitCopyScmerToPair(ctx, d8)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d74)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs68...)
-							d67 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d67, int32(callbackResultOff69))
-							ctx.FreeDesc(&d67)
-							d67 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff69), ID: 0}
+							d67 = jitEmitDynamicCallableAt(ctx, d74, callbackArgs68, int32(stackArray65), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff69), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d16)
@@ -3336,9 +3306,10 @@ func init_list_assoc_extra() {
 			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "list", Transfer: true, Length: UnknownLength}},
 			Const:     true,
 			Forbidden: true,
-			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
-				// JITGen native call boundary: leg count varies per call site.
-				return jitEmitGoVariadicCallFromDescs(ctx, declarations["group_assoc_multi_append_reduce"].Fn, args, result)
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				ctx.Coverage.NativeCalls++
+				declaration := declarations["group_assoc_multi_append_reduce"]
+				return jitEmitGeneratedCallBoundary(ctx, declaration, sourceArgs, args, result)
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
@@ -3370,9 +3341,10 @@ func init_list_assoc_extra() {
 			Return:    &TypeDescriptor{Kind: "assoc", Transfer: true, Length: UnknownLength, Element: &TypeDescriptor{Kind: "int", Transfer: true}},
 			Const:     true,
 			Forbidden: true,
-			JITEmit: func(ctx *JITContext, _ []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
-				// JITGen native call boundary: leg count varies per call site.
-				return jitEmitGoVariadicCallFromDescs(ctx, declarations["group_assoc_multi_count_reduce"].Fn, args, result)
+			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
+				ctx.Coverage.NativeCalls++
+				declaration := declarations["group_assoc_multi_count_reduce"]
+				return jitEmitGeneratedCallBoundary(ctx, declaration, sourceArgs, args, result)
 			},
 			JITVirtualArgs:     true,
 			JITInlineCallbacks: false,
@@ -4111,13 +4083,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d57 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 2)
-							callbackCallArgs = append(callbackCallArgs, d57)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs51...)
-							d50 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback1), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d50, int32(callbackResultOff52))
-							ctx.FreeDesc(&d50)
-							d50 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff52), ID: 0}
+							d50 = jitEmitDynamicCallableAt(ctx, d57, callbackArgs51, int32(stackArray48), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff52), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d13)
@@ -5091,13 +5057,7 @@ func init_list_assoc_extra() {
 						} else {
 							ctx.Coverage.DynamicCalls++
 							d58 := jitCopyScmerToPair(ctx, d5)
-							callbackCallArgs := make([]JITValueDesc, 0, 3)
-							callbackCallArgs = append(callbackCallArgs, d58)
-							callbackCallArgs = append(callbackCallArgs, callbackArgs52...)
-							d51 = ctx.EmitGoCallScalarInto(GoFuncAddr(jitInvokeCallback2), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})
-							ctx.EmitStoreScmerToStack(d51, int32(callbackResultOff53))
-							ctx.FreeDesc(&d51)
-							d51 = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0}
+							d51 = jitEmitDynamicCallableAt(ctx, d58, callbackArgs52, int32(stackArray49), JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: int32(callbackResultOff53), ID: 0})
 						}
 					}
 					ctx.EnsureDesc(&d13)

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -40,12 +40,22 @@ func TestJITFusedListPipelinesInlineKnownCallbacks(t *testing.T) {
 		source string
 	}{
 		{"filter map", "filter_map", `(lambda (values) (filter (map values (lambda (value) (+ value 1))) (lambda (value) (> value 2))))`},
+		{"map filter not null", "map_filter_notnull", `(lambda (values) (filter (map values (lambda (value) (if (> value 1) (* value 10) nil))) (lambda (value) (not (nil? value)))))`},
 		{"map filter", "map_filter", `(lambda (values) (map (filter values (lambda (value) (> value 1))) (lambda (value) (+ value 1))))`},
 		{"map map", "map_map", `(lambda (values) (map (map values (lambda (value) (+ value 1))) (lambda (value) (* value 2))))`},
 		{"filter filter", "filter_filter", `(lambda (values) (filter (filter values (lambda (value) (> value 0))) (lambda (value) (< value 4))))`},
+		{"mapped sum", "sum_map", `(lambda (values) (reduce values (lambda (total value) (+ total (* value 2))) 0))`},
+		{"boolean any", "reduce_any", `(lambda (values) (reduce values (lambda (found value) (or found (> value 2))) false))`},
+		{"boolean all", "reduce_all", `(lambda (values) (reduce values (lambda (valid value) (and valid (> value 2))) true))`},
+		{"find mapped non-null", "find_map_notnull", `(lambda (values) (reduce values (lambda (found value) (if (not (nil? found)) found (if (> value 2) (* value 10) nil))) nil))`},
 		{"reduce map", "reduce_map", `(lambda (values) (reduce (map values (lambda (value) (+ value 1))) (lambda (acc value) (+ acc value))))`},
 		{"reduce filter", "reduce_filter", `(lambda (values) (reduce (filter values (lambda (value) (> value 1))) (lambda (acc value) (+ acc value))))`},
+		{"reduce map filter", "reduce_map_filter", `(lambda (values) (reduce (filter (map values (lambda (value) (* value 2))) (lambda (value) (> value 2))) (lambda (acc value) (+ acc value))))`},
 		{"reduce filter map", "reduce_filter_map", `(lambda (values) (reduce (map (filter values (lambda (value) (> value 1))) (lambda (value) (* value 2))) (lambda (acc value) (+ acc value))))`},
+		{"cons map", "cons_map", `(lambda (head values) (cons head (map values (lambda (value) (+ value 1)))))`},
+		{"flat map", "flat_map", `(lambda (values) (merge (map values (lambda (value) (list value (+ value 10))))))`},
+		{"group append", "group_assoc_append", `(lambda (pairs) (group_assoc pairs (lambda (pair) (car pair)) (lambda (values pair) (append values (cadr pair))) '()))`},
+		{"group count", "group_assoc_count", `(lambda (values) (group_assoc values (lambda (value) value) (lambda (count value) (+ count 1)) 0))`},
 		{"group append reduce", "group_assoc_append_reduce", `(lambda (pairs) (reduce pairs (lambda (dict pair) (set_assoc dict (car pair) (append (get_assoc dict (car pair) '()) (cadr pair)))) '()))`},
 		{"group count reduce", "group_assoc_count_reduce", `(lambda (values) (reduce values (lambda (dict value) (set_assoc dict value (+ (get_assoc dict value 0) 1))) '()))`},
 	}

--- a/scm/list_pipeline_optimizer_test.go
+++ b/scm/list_pipeline_optimizer_test.go
@@ -30,6 +30,67 @@ func optimizeListPipeline(t testing.TB, source string) (Scmer, *Env) {
 	return optimized, env
 }
 
+func TestJITFusedListPipelinesInlineKnownCallbacks(t *testing.T) {
+	if !jitEnabled {
+		t.Skip("requires GOEXPERIMENT=jit")
+	}
+	tests := []struct {
+		name   string
+		fused  string
+		source string
+	}{
+		{"filter map", "filter_map", `(lambda (values) (filter (map values (lambda (value) (+ value 1))) (lambda (value) (> value 2))))`},
+		{"map filter", "map_filter", `(lambda (values) (map (filter values (lambda (value) (> value 1))) (lambda (value) (+ value 1))))`},
+		{"map map", "map_map", `(lambda (values) (map (map values (lambda (value) (+ value 1))) (lambda (value) (* value 2))))`},
+		{"filter filter", "filter_filter", `(lambda (values) (filter (filter values (lambda (value) (> value 0))) (lambda (value) (< value 4))))`},
+		{"reduce map", "reduce_map", `(lambda (values) (reduce (map values (lambda (value) (+ value 1))) (lambda (acc value) (+ acc value))))`},
+		{"reduce filter", "reduce_filter", `(lambda (values) (reduce (filter values (lambda (value) (> value 1))) (lambda (acc value) (+ acc value))))`},
+		{"reduce filter map", "reduce_filter_map", `(lambda (values) (reduce (map (filter values (lambda (value) (> value 1))) (lambda (value) (* value 2))) (lambda (acc value) (+ acc value))))`},
+		{"group append reduce", "group_assoc_append_reduce", `(lambda (pairs) (reduce pairs (lambda (dict pair) (set_assoc dict (car pair) (append (get_assoc dict (car pair) '()) (cadr pair)))) '()))`},
+		{"group count reduce", "group_assoc_count_reduce", `(lambda (values) (reduce values (lambda (dict value) (set_assoc dict value (+ (get_assoc dict value 0) 1))) '()))`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			optimized, env := optimizeListPipeline(t, test.source)
+			serialized := serializedTestExpr(t, env, optimized)
+			if !strings.Contains(serialized, test.fused) {
+				t.Fatalf("pipeline was not fused to %s: %s", test.fused, serialized)
+			}
+			compiled := jitCompile(Eval(optimized, env))
+			if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+				t.Fatal("fused pipeline did not compile")
+			}
+			coverage := compiled.Proc().Compiled.Coverage
+			if coverage.DynamicCalls != 0 || coverage.InlinedCalls == 0 {
+				t.Fatalf("known callbacks were not fully inlined: %+v", coverage)
+			}
+		})
+	}
+}
+
+func BenchmarkJITFusedReduceFilterMap(b *testing.B) {
+	if !jitEnabled {
+		b.Skip("requires GOEXPERIMENT=jit")
+	}
+	optimized, env := optimizeListPipeline(b, `(lambda (values)
+		(reduce (map (filter values (lambda (value) (> value 31))) (lambda (value) (* value 2)))
+			(lambda (acc value) (+ acc value)) 0))`)
+	compiled := jitCompile(Eval(optimized, env))
+	if compiled.Proc() == nil || compiled.Proc().Compiled == nil {
+		b.Fatal("fused reduce/filter/map benchmark did not compile")
+	}
+	valuesSlice := make([]Scmer, 128)
+	for index := range valuesSlice {
+		valuesSlice[index] = NewInt(int64(index))
+	}
+	values := NewSlice(valuesSlice)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		jitListBenchmarkSink = Apply(compiled, values)
+	}
+}
+
 func TestOptimizeFusesFilterOverMap(t *testing.T) {
 	optimized, env := optimizeListPipeline(t, `(lambda (values)
 		(filter (map values (lambda (value) (+ value 1)))

--- a/tools/jitgen/main.go
+++ b/tools/jitgen/main.go
@@ -2092,26 +2092,10 @@ func (g *codeGen) emitSerialCallableCall(name string, producer ssa.Value, callab
 	g.emit("\t\tctx.Coverage.DynamicCalls++")
 	callbackCallable := g.allocDesc()
 	g.emit("\t\t%s := jitCopyScmerToPair(ctx, %s)", callbackCallable, callable.goVar)
-	callbackHelper := ""
-	switch callArgs.stackLen {
-	case 1:
-		callbackHelper = "jitInvokeCallback1"
-	case 2:
-		callbackHelper = "jitInvokeCallback2"
-	case 3:
-		callbackHelper = "jitInvokeCallback3"
-	case 4:
-		callbackHelper = "jitInvokeCallback4"
-	default:
+	if callArgs.stackLen < 1 || callArgs.stackLen > 4 {
 		panic(fmt.Sprintf("dynamic callback with unsupported arity: %d", callArgs.stackLen))
 	}
-	g.emit("\t\tcallbackCallArgs := make([]JITValueDesc, 0, %d)", callArgs.stackLen+1)
-	g.emit("\t\tcallbackCallArgs = append(callbackCallArgs, %s)", callbackCallable)
-	g.emit("\t\tcallbackCallArgs = append(callbackCallArgs, %s...)", argsVar)
-	g.emit("\t\t%s = ctx.EmitGoCallScalarInto(GoFuncAddr(%s), callbackCallArgs, JITValueDesc{Loc: LocRegPair, Type: JITTypeUnknown, Reg: RegRAX, Reg2: RegRBX, ID: 0})", dv, callbackHelper)
-	g.emit("\t\tctx.EmitStoreScmerToStack(%s, %s)", dv, callbackTargetOff)
-	g.emit("\t\tctx.FreeDesc(&%s)", dv)
-	g.emit("\t\t%s = %s", dv, callbackTarget)
+	g.emit("\t\t%s = jitEmitDynamicCallableAt(ctx, %s, %s, int32(%s), %s)", dv, callbackCallable, argsVar, callArgs.stackBase, callbackTarget)
 	g.emit("\t}")
 	g.emit("}")
 	g.vals[name] = genVal{goVar: dv, isDesc: true}


### PR DESCRIPTION
## Problem

Generated higher-order builtins called fixed Go helpers (`jitInvokeCallback1` through `jitInvokeCallback4`) at runtime. Those helpers called `Apply`, reconstructed a variadic argument slice for every item, and retained an interpreter boundary even when the runtime value was already a JIT Proc or a regular Go funcval.

Known reducer lambdas had a second unnecessary boundary: when a callback parameter declared `Transfer`, the compiler refused to retain its lambda template. `Transfer` describes ownership of the accumulator value; it does not make the lambda body escape.

## Solution

- Make jitgen route fixed-arity callback sites through the normal dynamic callable emitter.
  - JIT Proc: direct compact-ABI funcval call.
  - Go funcval: direct Go-ABI funcval call.
  - Unsupported callable kinds only: retain the `ApplyEx` fallback.
- Preserve known lambda templates independently of accumulator ownership, allowing fused reducer callbacks to be emitted recursively.
- Give every runtime dispatch arm the same register-allocation snapshot and keep the callable in a branch-stable spill home. This prevents the Proc arm from invalidating registers assumed by the Go-func or fallback arms under generated-loop register pressure.
- Regenerate the affected list and grouping emitters.
- Remove the now-dead fixed `jitInvokeCallbackN` helpers.

This is generic jitgen behavior, not an operator-name allowlist. It applies to the basic map/filter/reduce family and optimizer-composed forms generated from the same SSA callback sites.

## Manual A/B measurements

All measurements used the same Ryzen 9 7900X3D core, the same patched Go toolchain, `GOEXPERIMENT=jit`, 128 input values, and six measured repetitions after compilation.

| Case | Master | PR | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Runtime JIT-Proc reducer callback | ~5.40 us | ~2.09 us | 2.58x faster | 134 -> 6 |
| Runtime Go-func reducer callback | ~4.29 us | ~1.02 us | 4.21x faster | 132 -> 4 |
| Optimizer-fused filter -> map -> reduce | ~6.35 us | ~3.22 us | 1.97x faster | 97 -> 1 |

The allocation delta is exact for the dynamic benchmark: 128 per-item Apply/variadic allocations disappear.

Disassembly of the generated reduce loop confirms the mechanism. The baseline hot loop calls the fixed Apply helper after a full foreign-call save sequence. The PR emits `call *%r11` directly for JIT Procs and Go funcvals; only the unsupported-tag branch reaches `jitApplyCallable*`.

## Validation

- Vanilla `go test ./tools/jitgen ./scm`: passed.
- `GOEXPERIMENT=jit go test ./tools/jitgen ./scm`: passed.
- Direct callback tests force GC and Go stack growth inside the callback and pass under `-race`.
- Fallback-free JIT coverage tests pass for optimizer-produced `filter_map`, `map_filter_notnull`, `map_filter`, `map_map`, `filter_filter`, `sum_map`, `reduce_any`, `reduce_all`, `find_map_notnull`, `reduce_map`, `reduce_filter`, `reduce_map_filter`, `reduce_filter_map`, `cons_map`, `flat_map`, `group_assoc_append`, `group_assoc_count`, `group_assoc_append_reduce`, and `group_assoc_count_reduce` trees.
- A high-register-pressure callback test keeps six values live across both JIT-Proc and Go-func dispatch; the Go callback forces GC and 64 levels of stack growth.
- Generated list and grouping emitters contain no calls to `jitInvokeCallback1` through `jitInvokeCallback4`.

## Follow-up generator observations

The full jitgen audit also identified the remaining composed-family gaps without adding operator-name special cases: `reduce_range`, `find_range_notnull`, `flat_map_range`, and `flat_map_unique` currently fall back because their `SerialProc.Call` receiver is not represented as a prepared callback; the multi-key group reducers fall back on SSA `[]func(...Scmer) Scmer` construction. These are the next generic SSA shapes to teach jitgen after this direct-boundary change.

The full vanilla and JIT SQL suites run in CI for the pushed head.
