### PR TITLE
jit: trim the per-character overhead in the regex hot path

### DIFF
--- a/scm/jit_regex.go
+++ b/scm/jit_regex.go
@@ -519,14 +519,30 @@ func (emitter *jitRegexEmitter) emitSimpleRepeat(node *syntax.Regexp, width, min
 	done := emitter.ctx.ReserveLabel()
 	retry := emitter.ctx.ReserveLabel()
 	backtrack := emitter.ctx.ReserveLabel()
-	trial := emitter.ctx.AllocStack(8)
 	candidate := emitter.ctx.AllocStack(8)
-	emitter.ctx.MarkLabel(loop)
-	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
-	emitter.emitSimple(node, done)
-	emitter.ctx.EmitJmp(loop)
-	emitter.ctx.MarkLabel(done)
-	emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	// A single, non-Concat atom (a bare char class or any-char - by far the
+	// most common repeated node: [a-z]+, \w*, . anywhere) never advances
+	// the cursor before failing (emitAtom/emitByteClass/emitLiteral only
+	// touch the cursor on the success path, past every failure jump), so
+	// on reaching `done` the cursor already holds exactly the position one
+	// failed attempt short of the loop's current iteration - no separate
+	// "trial" save/restore is needed to revert a partial match, unlike a
+	// Concat of several atoms where an earlier sibling may have already
+	// advanced the cursor before a later one fails.
+	if node.Op != syntax.OpConcat {
+		emitter.ctx.MarkLabel(loop)
+		emitter.emitSimple(node, done)
+		emitter.ctx.EmitJmp(loop)
+		emitter.ctx.MarkLabel(done)
+	} else {
+		trial := emitter.ctx.AllocStack(8)
+		emitter.ctx.MarkLabel(loop)
+		emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+		emitter.emitSimple(node, done)
+		emitter.ctx.EmitJmp(loop)
+		emitter.ctx.MarkLabel(done)
+		emitter.ctx.EmitMovRegMem(emitter.cursor, emitter.ctx.StackReg, trial)
+	}
 	emitter.ctx.MarkLabel(retry)
 	emitter.ctx.EmitStoreRegMem(emitter.cursor, emitter.ctx.StackReg, candidate)
 	emitter.emitSequence(rest, successLabel, backtrack)
@@ -599,6 +615,15 @@ func (emitter *jitRegexEmitter) emitAtom(node *syntax.Regexp, failLabel JITLabel
 }
 
 func (emitter *jitRegexEmitter) emitBounds(width int, failLabel JITLabel) {
+	// The overwhelmingly common case (a single byte class or any-char atom)
+	// needs no scratch register at all: "end - cursor < 1" is exactly
+	// "cursor >= end", checked directly against the two live cursor/end
+	// registers already held throughout the whole regex program.
+	if width == 1 {
+		emitter.ctx.EmitCmpInt64(emitter.cursor, emitter.end)
+		emitter.ctx.EmitJump(CondUnsignedAboveOrEqual, failLabel)
+		return
+	}
 	remaining := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan)
 	emitter.ctx.EmitMovRegReg(remaining, emitter.end)
 	emitter.ctx.EmitSubInt64(remaining, emitter.cursor)
@@ -694,6 +719,21 @@ func (emitter *jitRegexEmitter) emitByteClass(node *syntax.Regexp, failLabel JIT
 	if len(ranges) == 0 {
 		emitter.ctx.FreeReg(char)
 		emitter.ctx.EmitJmp(failLabel)
+		return
+	}
+	if len(ranges) == 1 {
+		// The single-contiguous-range shape ([a-z], [0-9], \w's own ranges,
+		// .) is by far the most common char class in the SQL grammar's
+		// tokenizing rules. It needs no "matched" accumulator at all - just
+		// a direct conditional jump on the one range test.
+		interval := ranges[0]
+		if interval[0] != 0 {
+			emitter.ctx.EmitSubRegImm32(char, int32(interval[0]))
+		}
+		emitter.ctx.EmitCmpRegImm32(char, int32(uint16(interval[1])-uint16(interval[0])))
+		emitter.ctx.FreeReg(char)
+		emitter.ctx.EmitJump(CondUnsignedAbove, failLabel)
+		emitter.ctx.EmitAddRegImm32(emitter.cursor, 1)
 		return
 	}
 	matched := emitter.ctx.AllocRegExcept(emitter.cursor, emitter.end, emitter.scan, char)


### PR DESCRIPTION
## What

The regex JIT's character-recognition core — masked literal compares (up to 8 bytes per compare), branch-free `sub;cmp;setcc` range tests — is already tight. Three pieces of scaffolding around it are not, and they run **once per scanned byte** of every identifier, keyword, whitespace run and string literal:

**`emitBounds(1)`** allocated a scratch register and did `mov`/`sub`/`cmp` to check "at least one byte left". For width 1 that is exactly `cursor >= end` against the two registers already live throughout the regex program — no scratch register, two instructions.

**`emitByteClass`** always built a `matched` accumulator (zero-init, then per range `copy`/`sub`/`cmp`/`setcc`/`or`, then test) even for a single contiguous range. `[a-z]`, `[0-9]`, `\w`'s ranges and `.` are single-range and by far the most common classes in the tokenizer; they need just `sub`/`cmp` and one conditional jump.

**`emitSimpleRepeat`'s greedy loop** saved the cursor to a stack slot on every iteration so a failed match could be reverted. That is only needed when the repeated node is a `Concat` of several atoms (an earlier sibling may advance the cursor before a later one fails). A single atom — the common `[a-z]+`, `\w*`, `.*` — never touches the cursor before failing (the advance is past every failure jump), so on loop exit the cursor is already correct and both the per-iteration store and the exit-time restore drop out.

For a matched character in a `[a-z]+`-style scan this is roughly two-thirds fewer emitted instructions (~16 → ~5). The `Concat` and multi-range paths are unchanged.

## Measured

| | before | after | Δ |
|---|---:|---:|---:|
| `parse_sql` instructions | 844,668 | 842,428 | −0.27% |
| `parse_sql` code size | 3,340,657 B | 3,330,146 B | −0.31% |

**Wall-clock: no measurable change**, at any level tested:

- *Warm* — 800× the same ~7 KB character-heavy `SELECT` via `parse_sql`: ~0.95 s either way, within run-to-run noise.
- *Cold, end-to-end* — 1,200 structurally-distinct never-seen queries (varying column count, expression nesting, predicate shape) against a fresh database, full parse + plan + execute: master mean 5.43–5.57 ms/query, this branch 5.42–5.46 ms/query. Directionally ~1 % faster on average, inside the noise band.
- *Cold, parse only* — 1,500 distinct queries through `parse_sql` (tokenize + build AST, no planning): ~3.6 ms/query on both.

`parse_sql`'s cost is dominated by running each grammar rule's action/generator (a Scheme `Apply` per reduced rule) and by planning downstream; character scanning is a small sliver, and this change — even at a third of its former instruction count — does not move it.

So this is a **code-tightening change, not a speedup** — smaller generated code, less scaffolding per byte, no behavioural change — offered on the "shorter code" merit rather than a performance claim.

## Verified

- `go test ./scm`
- `parse_sql` stays JIT-compiled (`selected=true`)
- targeted LIKE / REGEXP / fulltext-index / string-function / psql-parser suites pass
- the CI-flaky files (`computed-index-cols`, `group-having*`, `nested-exists-not-aggregate`) pass identically on this branch and on master locally — the earlier red jit-test runs were the pre-existing `traceback did not unwind completely` crash-flake (different files each run, empty result bodies from broken setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV