### PR TITLE
Refresh planner cache callbacks after restart

### DIFF
--- a/scm/jit.go
+++ b/scm/jit.go
@@ -3132,8 +3132,10 @@ type jitCodeReservation struct {
 }
 
 // complete publishes arena metadata in allocation order. Compilation itself
-// may run concurrently, but an entry point does not become reachable before
-// every earlier reservation has either published its maps or reported failure.
+// may run concurrently. Before an entry point becomes reachable, complete also
+// waits for every reservation allocated up to that compiler's completion. That
+// set includes deferred lambdas embedded in the entry point even when another
+// compiler's reservation was interleaved between parent and child.
 func (a *jitArena) complete(reservation *jitCodeReservation, maps []jitStackMap) {
 	a.completeMode(reservation, maps, true, nil)
 }
@@ -3154,6 +3156,10 @@ func (a *jitArena) completeMode(reservation *jitCodeReservation, maps []jitStack
 	reservation.maps = maps
 	reservation.onPublish = onPublish
 	reservation.done = true
+	waitThrough := 0
+	if wait {
+		waitThrough = len(a.reservations)
+	}
 	for a.metaNext < len(a.reservations) && a.reservations[a.metaNext].done {
 		ready := a.reservations[a.metaNext]
 		publishJITStackMaps(a, ready.maps)
@@ -3166,7 +3172,7 @@ func (a *jitArena) completeMode(reservation *jitCodeReservation, maps []jitStack
 	}
 	a.metaCond.Broadcast()
 	if wait {
-		for !reservation.published {
+		for a.metaNext < waitThrough {
 			a.metaCond.Wait()
 		}
 	}

--- a/scm/jit_stack_gojit_test.go
+++ b/scm/jit_stack_gojit_test.go
@@ -249,3 +249,33 @@ func TestJITArenaDefersCallbackUntilStackMapPublication(t *testing.T) {
 		t.Fatal("deferred entry was not installed with its stack maps")
 	}
 }
+
+func TestJITArenaParentWaitsForInterleavedDeferredStackMaps(t *testing.T) {
+	parent := &jitCodeReservation{}
+	otherCompiler := &jitCodeReservation{}
+	child := &jitCodeReservation{}
+	arena := &jitArena{reservations: []*jitCodeReservation{parent, otherCompiler, child}}
+	arena.metaCond = sync.NewCond(&arena.metaMu)
+	arena.completeDeferred(child, nil, nil)
+
+	parentComplete := make(chan struct{})
+	go func() {
+		arena.complete(parent, nil)
+		close(parentComplete)
+	}()
+	select {
+	case <-parentComplete:
+		t.Fatal("parent became reachable before its interleaved child stack maps")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	arena.complete(otherCompiler, nil)
+	select {
+	case <-parentComplete:
+	case <-time.After(time.Second):
+		t.Fatal("parent did not become reachable after its child stack maps")
+	}
+	if !parent.published || !otherCompiler.published || !child.published {
+		t.Fatal("interleaved stack maps were not published as one reachable prefix")
+	}
+}

--- a/storage/database.go
+++ b/storage/database.go
@@ -507,6 +507,7 @@ func (db *database) ensureLoaded() {
 		// restore back-references; do not touch on-disk columns yet
 		for _, t := range db.tables.GetAll() {
 			t.schema = db
+			invalidatePersistedPlannerCodeAfterLoad(t)
 			if t.Name == ".blobs" {
 				db.blobRefState().table.Store(t)
 			}
@@ -554,6 +555,17 @@ func (db *database) ensureLoaded() {
 			}
 		}
 	})
+}
+
+// invalidatePersistedPlannerCodeAfterLoad drops executable code derived from a
+// physical query plan. Planner-owned CACHE tables contain no durable rows, and
+// the current createtable guard supplies their authoritative oninit callback on
+// first use. Retaining an older callback across a physical operator ABI change
+// would execute stale generated code before that guard can refresh it.
+func invalidatePersistedPlannerCodeAfterLoad(t *table) {
+	if t.isEphemeralQueryTable() {
+		t.OnInit = nil
+	}
 }
 
 // SharedResource impl for database

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -264,6 +264,88 @@ func TestCreateTableIfNotExistsReturnsFalseWithoutSaving(t *testing.T) {
 	}
 }
 
+func TestSchemaReloadInvalidatesPlannerCacheOnInit(t *testing.T) {
+	stale := scm.NewFunc(func(...scm.Scmer) scm.Scmer {
+		panic("stale planner callback must not run")
+	})
+	plannerCache := &table{Name: ".grp:items:old", PersistencyMode: Cache, OnInit: &stale}
+	invalidatePersistedPlannerCodeAfterLoad(plannerCache)
+	if plannerCache.OnInit != nil {
+		t.Fatal("schema reload retained planner-generated cache oninit")
+	}
+
+	for _, durable := range []*table{
+		{Name: "application_cache", PersistencyMode: Cache, OnInit: &stale},
+		{Name: ".internal", PersistencyMode: Safe, OnInit: &stale},
+		{Name: ".memory_helper", PersistencyMode: Memory, OnInit: &stale},
+	} {
+		invalidatePersistedPlannerCodeAfterLoad(durable)
+		if durable.OnInit == nil {
+			t.Fatalf("schema reload invalidated non-planner table %s", durable.Name)
+		}
+	}
+}
+
+func TestCreateTableRefreshesInvalidatedPlannerCacheOnInit(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-planner-oninit-refresh-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("tplanneroninitrefresh")
+	CreateDatabase("tplanneroninitrefresh", false)
+
+	cols := scm.NewSlice([]scm.Scmer{
+		scm.NewSlice([]scm.Scmer{
+			scm.NewString("column"), scm.NewString("id"), scm.NewString("int"),
+			scm.NewSlice(nil), scm.NewSlice(nil),
+		}),
+	})
+	var staleCalls atomic.Int64
+	stale := scm.NewFunc(func(...scm.Scmer) scm.Scmer {
+		staleCalls.Add(1)
+		return scm.NewNil()
+	})
+	options := scm.NewSlice([]scm.Scmer{
+		scm.NewString("engine"), scm.NewString("cache"),
+		scm.NewString("oninit"), stale,
+	})
+	callBuiltin(t, "createtable",
+		scm.NewString("tplanneroninitrefresh"), scm.NewString(".grp:items:old"),
+		cols, options, scm.NewBool(true), scm.NewNil())
+	if staleCalls.Load() != 1 {
+		t.Fatalf("initial planner callback ran %d times, want 1", staleCalls.Load())
+	}
+
+	plannerCache := GetDatabase("tplanneroninitrefresh").GetTable(".grp:items:old")
+	plannerCache.onInitComplete = false // restart-only state is deliberately not persisted
+	invalidatePersistedPlannerCodeAfterLoad(plannerCache)
+	var currentCalls atomic.Int64
+	current := scm.NewFunc(func(...scm.Scmer) scm.Scmer {
+		currentCalls.Add(1)
+		return scm.NewNil()
+	})
+	options = scm.NewSlice([]scm.Scmer{
+		scm.NewString("engine"), scm.NewString("cache"),
+		scm.NewString("oninit"), current,
+	})
+	created := callBuiltin(t, "createtable",
+		scm.NewString("tplanneroninitrefresh"), scm.NewString(".grp:items:old"),
+		cols, options, scm.NewBool(true), scm.NewNil())
+	if scm.ToBool(created) {
+		t.Fatal("refreshing the planner callback recreated the cache table")
+	}
+	if staleCalls.Load() != 1 || currentCalls.Load() != 1 {
+		t.Fatalf("refresh ran stale=%d current=%d callbacks, want 1 and 1", staleCalls.Load(), currentCalls.Load())
+	}
+}
+
 func TestRegisteredCreateTableTriggerRunsOnCreate(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-createtable-trigger-*")
 	if err != nil {

--- a/storage/trigger.go
+++ b/storage/trigger.go
@@ -298,7 +298,8 @@ func restoredTriggerRequiresRuntimeTarget(name string) bool {
 	// internal trigger families whose bodies address an evictable cache target.
 	return strings.HasPrefix(name, ".kt_cleanup:") ||
 		strings.HasPrefix(name, ".cache:") ||
-		strings.HasPrefix(name, ".orcdep:")
+		strings.HasPrefix(name, ".orcdep:") ||
+		strings.HasPrefix(name, ".prejoin:")
 }
 
 func triggerScmerMissing(v scm.Scmer) bool {

--- a/storage/trigger_lock_order_test.go
+++ b/storage/trigger_lock_order_test.go
@@ -145,13 +145,23 @@ func TestPersistedKeytableTriggerWaitsForRuntimeTarget(t *testing.T) {
 }
 
 func TestLegacyPersistedCacheTriggerWaitsForRuntimeTarget(t *testing.T) {
-	encoded := []byte(`{"name":".cache:.grp:query:test:agg|scan0|items|AFTER DELETE","timing":5,"is_system":true}`)
-	var restored TriggerDescription
-	if err := json.Unmarshal(encoded, &restored); err != nil {
-		t.Fatal(err)
-	}
-	if restored.acquireTarget(nil) {
-		t.Fatal("legacy cache trigger ran before its ephemeral target was rebound")
+	for _, name := range []string{
+		".cache:.grp:query:test:agg|scan0|items|AFTER DELETE",
+		".prejoin:abc|items|after_delete",
+	} {
+		encoded, err := json.Marshal(map[string]any{
+			"name": name, "timing": "after_delete", "is_system": true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var restored TriggerDescription
+		if err := json.Unmarshal(encoded, &restored); err != nil {
+			t.Fatal(err)
+		}
+		if restored.acquireTarget(nil) {
+			t.Fatalf("persisted cache trigger %s ran before its ephemeral target was rebound", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- discard persisted executable `oninit` callbacks for planner-owned dot-prefixed CACHE tables during schema reload
- let the current `createtable(..., ifnotexists=true)` invocation install and execute the authoritative callback before exposing the empty cache generation
- keep restored prejoin maintenance triggers inert until the current planner registers their callback bodies again
- preserve user CACHE tables, MEMORY tables, and durable internal tables unchanged
- publish all JIT stack maps reserved by an enclosing compilation before making its entry point reachable, including deferred lambdas interleaved with another compiler

## Root cause

PR #759 changed the single scan interface by inserting access schema and values before the filter function. A persisted `.grp` CACHE table could still contain an `oninit` closure generated with the previous physical ABI. After restart, `createtable` executed that stale callback before considering the current callback, shifting the old filter procedure into the new access-values argument.

The JIT CI failure exposed a separate metadata publication race. `runtime/jit.Handle.AddStackMaps` requires machine code to be complete and all exact return-PC maps to be published before any goroutine can reach it. MemCP previously waited only for the parent reservation. With concurrent compilation, an unrelated unfinished reservation could sit between a parent and its completed deferred child, so the parent became reachable while the child map was still unpublished. Runtime unwinding then correctly rejected that unmapped return PC.

## JIT unwind audit

- `PCOffset` is recorded immediately after each emitted `CALL`, matching the runtime exact return-PC lookup
- normal frames use the saved RBP as the unwind base, with caller PC at `+8`, caller SP at `+16`, and caller BP at `+0`
- the morestack entry map describes the incoming slice data pointer at `SP+8` and unwinds through the entry return address
- frame and transient call roots are translated into the final static-plus-dynamic frame bitmap
- the go-jit runtime publishes copied maps only after every entry and bitmap is initialized; its nested-frame, stack-growth, GC, and panic/recover tests pass

## Verification

- `go test ./storage -count=1`
- `GOEXPERIMENT=jit go test runtime/jit -count=1`
- `GOEXPERIMENT=jit go test -race ./scm -run TestJITArenaDefersCallbackUntilStackMapPublication\|TestJITArenaParentWaitsForInterleavedDeferredStackMaps\|TestJITRuntimeReduceCallbacksUseDirectBoundary -count=1`
- added regression coverage for reload invalidation, callback replacement without table recreation, protected non-planner tables, restored prejoin triggers, and interleaved nested JIT map publication
- the complete JIT suite is intentionally delegated to CI

## Production-data A/B reproduction

Used separate reflink copies of the same 476 MB production data directory, the same query, fresh processes, and the JIT toolchain. The running PM2 process and original data were not modified.

- master (`0a7365203`): `SELECT COUNT(*) AS cnt FROM user` failed with `scan access values: expected list, got <custom 10>`
- this branch before the JIT publication follow-up (`37b4150ba`): returned `{"cnt":333}` and rebuilt `.grp:user:a944806ac75cb96b` successfully; cold execution trace was 1.122 s

The baseline does not have a latency because it aborts before completing the query.