### PR TITLE
Directly reduce exact membership row counts

### DIFF
--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -5986,6 +5986,40 @@ join reducer aggregate shard-local states and merge them once at the root. */
 					nil))
 			grouped_scan))))
 
+/* All row-count aggregates over one global group share the same cardinality.
+Reduce the decorrelated input once and bind every COUNT-shaped output to that
+scalar state instead of allocating a one-entry group dictionary and one payload
+slot per syntactically repeated COUNT. */
+(define lower_direct_query_row_count_stage (lambda (stage fields offset_value limit_value)
+	(begin
+		(define input (gs_input stage))
+		(define alias (group_stage_input_alias stage))
+		(define keys '(1))
+		(define key_names (group_key_cols keys))
+		(define ags (gs_aggregates stage))
+		(define aggregate_state (quote __direct_row_count))
+		(define rowassoc_expr (runtime_cons_list_expr (merge (list
+			(list (car key_names) 1)
+			(merge (map ags (lambda (ag)
+				(list (aggregate_col_name ag) aggregate_state))))))))
+		(define emit_expr (list (quote resultrow)
+			(direct_group_result_assoc_expr alias keys key_names ags fields)))
+		(define offset_expr (coalesceNil offset_value 0))
+		(define limit_expr (coalesceNil limit_value -1))
+		(define count_plan (lower_query_block_as_dataset_reduce
+			input '() (list (quote lambda) '() 1) (quote +) 0 (quote +)))
+		(list
+			(list (quote lambda) (list aggregate_state)
+				(list (quote begin)
+					(list (quote define) (quote rowassoc) rowassoc_expr)
+					(list (quote if)
+						(list (quote and) (list (quote equal?) offset_expr 0)
+							(list (quote or) (list (quote equal?) limit_expr -1)
+								(list (quote >) limit_expr 0)))
+						(list (quote begin) emit_expr nil)
+						nil)))
+			count_plan))))
+
 (define aggregate_payload_merge_expr (lambda (ags idx)
 	(if (>= idx (count ags))
 		(quoted_runtime_list '())

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2299,6 +2299,12 @@ logical window-stage remains unchanged and contains no createcolumn artifact. */
 				_ nil))
 		_ nil)))
 
+(define global_membership_row_count_block? (lambda (block)
+	(and (empty_list? (qb_group block))
+		(and (nil? (qb_having block))
+			(and (empty_list? (coalesceNil (qb_order block) '()))
+				(aggregate_pushdown_count_fields? (qb_fields block)))))))
+
 (define lower_grouped_query_block_with_stages (lambda (block)
 	(begin
 		(define fused_top_count (lower_row_number_top_count_block block))
@@ -2310,55 +2316,90 @@ logical window-stage remains unchanged and contains no createcolumn artifact. */
 				(define probe_rewritten (if (expr_contains_session_dependency? (qb_where rewritten))
 					(query_block_with_prepared_sources_using stage_lookup rewritten)
 					rewritten))
-				(define sources (qb_sources probe_rewritten))
-				(define stage_catalog (query_block_stage_catalog rewritten))
-				(define dependency_graph (stage_dependency_graph stage_lookup))
-				(define outer_prepare_stages (filter (qb_stages rewritten) (lambda (stage)
-					(not (group_stage? stage)))))
-				(define physical_sources (physicalize_stage_output_sources stage_lookup sources))
-				(define driver_src (car physical_sources))
-				(if (not (source_is_base_table? driver_src))
-					(neumann_fail "build_queryplan" "group-stage source did not lower to a physical driver")
-					true)
-				(define stage_sources (cdr physical_sources))
-				(define direct_probe_group (and
-					(empty_list? stage_sources)
-					(empty_list? (qb_stages probe_rewritten))
-					(source_is_base_table? driver_src)
-					/* Session-dependent memberships are query-local domains. A base-table
-					group cache uses persistent computed columns and cannot represent that
-					domain as an immutable column recipe; keep the general query-group
-					carrier, whose grouped insert is evaluated inside the query session. */
-					(empty_list? (query_expr_session_reads probe_rewritten))
-					(expr_contains_driver_membership? (qb_where probe_rewritten))))
-				(define final_stage_sources (physicalize_stage_output_sources stage_lookup
-					(filter (cdr sources) (lambda (src)
-						(source_needed_after_group? (source_alias driver_src) probe_rewritten src)))))
-				(define grouped_input_block (make_query_block
-					(qb_schema probe_rewritten)
-					(cons driver_src stage_sources)
-					(qb_fields probe_rewritten)
-					(qb_where probe_rewritten)
-					(qb_group probe_rewritten)
-					(qb_having probe_rewritten)
-					(qb_order probe_rewritten)
-					(qb_limit probe_rewritten)
-					(qb_offset probe_rewritten)
-					(qb_hidden probe_rewritten)
-					'()
-					(qb_facts probe_rewritten)))
-				(define main_stage (make_group_stage_for_query_block grouped_input_block))
-				(define main_stage_lookup (lowering_catalog_with_local_stages stage_lookup (list main_stage)))
-				(if direct_probe_group
-					(lower_query_block_core grouped_input_block)
-					(cons (quote !begin)
-						(merge (list
-							/* The main group prepare owns nested group stages used by its input.
-							Window and ORC stages still require their explicit materialization. */
-							(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup outer_prepare_stages)
-							(lower_stage_materialize_all outer_prepare_stages)
-							(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage true nil))
-							(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources))))))))))))
+				(define direct_prepared (if (global_membership_row_count_block? probe_rewritten)
+					(prepare_simple_query_block_physical_core probe_rewritten) nil))
+				(define direct_core (if (nil? direct_prepared) nil (nth direct_prepared 1)))
+				(define direct_stage (if (nil? direct_core) nil
+					(make_group_stage_for_query_block direct_core)))
+				/* Physical membership preparation is shared with ordinary SELECT
+				lowering. Once it exposes an exact driver carrier, a global row count
+				has no reusable grouping dimension: the fused join reducer dominates a
+				predicate-specific one-row group table. Selectivity-dependent choices
+				remain inside the ordinary membership and join cost models. */
+				(define direct_row_count (and (not (nil? direct_stage))
+					(expr_contains_driver_membership? (qb_where direct_core))))
+				(if direct_row_count
+					(begin
+						(define direct_prelude (nth direct_prepared 0))
+						(define direct_postlude (nth direct_prepared 2))
+						(planner_record_physical_decision
+							(list
+								(list "decision" "global_membership_row_count")
+								(list "chosen" "fused_reduce")
+								(list "selection" "dominance")
+								(list "reason" "exact_membership_already_owns_reusable_carriers")
+								(list "alternatives" (list
+									(list (list "plan" "fused_reduce") (list "status" "chosen"))
+									(list (list "plan" "query_group_cache") (list "status" "rejected")
+										(list "reason" "redundant_single_group_materialization")))))
+							(planner_context_session (qb_facts direct_core)))
+						(cons (quote !begin) (merge (list
+							direct_prelude
+							(list (lower_direct_query_row_count_stage direct_stage
+								(expand_query_block_fields (qb_sources direct_core) (qb_fields direct_core))
+								(qb_offset direct_core) (qb_limit direct_core)))
+							direct_postlude
+							(if (empty_list? direct_postlude) '() (list nil))))))
+					(begin
+						(define sources (qb_sources probe_rewritten))
+						(define stage_catalog (query_block_stage_catalog rewritten))
+						(define dependency_graph (stage_dependency_graph stage_lookup))
+						(define outer_prepare_stages (filter (qb_stages rewritten) (lambda (stage)
+							(not (group_stage? stage)))))
+						(define physical_sources (physicalize_stage_output_sources stage_lookup sources))
+						(define driver_src (car physical_sources))
+						(if (not (source_is_base_table? driver_src))
+							(neumann_fail "build_queryplan" "group-stage source did not lower to a physical driver")
+							true)
+						(define stage_sources (cdr physical_sources))
+						(define direct_probe_group (and
+							(empty_list? stage_sources)
+							(empty_list? (qb_stages probe_rewritten))
+							(source_is_base_table? driver_src)
+							/* Session-dependent memberships are query-local domains. A base-table
+							group cache uses persistent computed columns and cannot represent that
+							domain as an immutable column recipe; keep the general query-group
+							carrier, whose grouped insert is evaluated inside the query session. */
+							(empty_list? (query_expr_session_reads probe_rewritten))
+							(expr_contains_driver_membership? (qb_where probe_rewritten))))
+						(define final_stage_sources (physicalize_stage_output_sources stage_lookup
+							(filter (cdr sources) (lambda (src)
+								(source_needed_after_group? (source_alias driver_src) probe_rewritten src)))))
+						(define grouped_input_block (make_query_block
+							(qb_schema probe_rewritten)
+							(cons driver_src stage_sources)
+							(qb_fields probe_rewritten)
+							(qb_where probe_rewritten)
+							(qb_group probe_rewritten)
+							(qb_having probe_rewritten)
+							(qb_order probe_rewritten)
+							(qb_limit probe_rewritten)
+							(qb_offset probe_rewritten)
+							(qb_hidden probe_rewritten)
+							'()
+							(qb_facts probe_rewritten)))
+						(define main_stage (make_group_stage_for_query_block grouped_input_block))
+						(define main_stage_lookup (lowering_catalog_with_local_stages stage_lookup (list main_stage)))
+						(if direct_probe_group
+							(lower_query_block_core grouped_input_block)
+							(cons (quote !begin)
+								(merge (list
+									/* The main group prepare owns nested group stages used by its input.
+									Window and ORC stages still require their explicit materialization. */
+									(lower_unique_stage_prepares_with_graph dependency_graph stage_lookup outer_prepare_stages)
+									(lower_stage_materialize_all outer_prepare_stages)
+									(list (lower_group_stage_prepare_using (cons main_stage stage_catalog) main_stage_lookup main_stage true nil))
+									(list (lower_query_block_core (group_stage_final_block main_stage final_stage_sources))))))))))))))))
 
 (define query_block_without_stages (lambda (block)
 	(make_query_block

--- a/tests/performance/like-acl-query-shapes.yaml
+++ b/tests/performance/like-acl-query-shapes.yaml
@@ -354,23 +354,24 @@ test_cases:
     expect:
       rows: 72
 
-  - name: "Perf: exact projected LIKE count with compound ACL"
+  - name: "Perf: selective projected LIKE count with compound ACL"
     setup: *like_acl_fixture
+    performance_rows: 40000
     threshold_ms: 3000
     timeout: 30
     sql: |
-      SELECT COUNT(*) AS total
+      SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
       FROM (
-        SELECT d.id
+        SELECT d.id, 1 AS _count
         FROM pla_document d
         WHERE d.file_id IN (
           SELECT filename_file.id
           FROM pla_file filename_file
-          WHERE filename_file.filename LIKE '%common-document%'
+          WHERE filename_file.filename LIKE '%rare-document%'
           UNION
           SELECT search_file.id
           FROM pla_file search_file
-          WHERE search_file.search_text LIKE '%common-document%'
+          WHERE search_file.search_text LIKE '%rare-document%'
         )
           AND COALESCE((
             SELECT CASE WHEN site.direct_flag = 1 THEN TRUE ELSE (
@@ -397,3 +398,5 @@ test_cases:
       ) counted
     expect:
       rows: 1
+      data:
+        - {total: 700, counted_count: 700}

--- a/tests/performance/like-acl-query-shapes.yaml
+++ b/tests/performance/like-acl-query-shapes.yaml
@@ -354,6 +354,50 @@ test_cases:
     expect:
       rows: 72
 
+  - name: "Perf: exact projected LIKE count with compound ACL"
+    setup: *like_acl_fixture
+    threshold_ms: 3000
+    timeout: 30
+    sql: |
+      SELECT COUNT(*) AS total
+      FROM (
+        SELECT d.id
+        FROM pla_document d
+        WHERE d.file_id IN (
+          SELECT filename_file.id
+          FROM pla_file filename_file
+          WHERE filename_file.filename LIKE '%common-document%'
+          UNION
+          SELECT search_file.id
+          FROM pla_file search_file
+          WHERE search_file.search_text LIKE '%common-document%'
+        )
+          AND COALESCE((
+            SELECT CASE WHEN site.direct_flag = 1 THEN TRUE ELSE (
+              EXISTS (
+                SELECT TRUE
+                FROM pla_assignment assignment
+                WHERE assignment.site_id = site.id
+                  AND assignment.actor_id = 7
+                  AND assignment.allowed = 1
+                LIMIT 1
+              ) OR COALESCE((
+                SELECT override.allowed
+                FROM pla_override override
+                WHERE override.site_id = site.id
+                  AND override.actor_id = 7
+                LIMIT 1
+              ), FALSE)
+            ) END
+            FROM pla_site site
+            WHERE site.id = d.site_id
+            LIMIT 1
+          ), FALSE)
+          AND TRUE
+      ) counted
+    expect:
+      rows: 1
+
   - name: "Perf: selective projected LIKE count with compound ACL"
     setup: *like_acl_fixture
     performance_rows: 40000

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -434,6 +434,10 @@ test_cases:
         - "recset_project_join"
         - "recset_project_join_access"
         - "runtime_cost_minimum"
+        - "global_membership_row_count"
+        - "fused_reduce"
+      result_not_contains:
+        - ".grp:query:"
 
   - name: "selective search evaluates compound ACL only on projected documents"
     max_time: 2


### PR DESCRIPTION
## What

- lower global all-row COUNT aggregates over an exact physical membership predicate as one fused dataset reduction
- reuse the ordinary physical membership preparation and its cost-based RecSet, keytable, scan, and join choices
- reject the redundant one-row query group cache as an explicit physical dominance decision
- share one scalar cardinality across repeated COUNT-shaped output expressions
- add physical-plan and correctness assertions plus an additional 40k-row performance regression case matching projected text search plus compound correlated ACLs

This is deliberately below the logical/physical boundary. It does not add a LIKE-specific rule, alter decorrelation, add a new physical operator, or tune cost constants. tools/costgen therefore needs no new calibration: every non-dominant scan, carrier, and join choice still goes through the existing calibrated cost model.

## Mechanical reachability proof

On master, the new planner assertion fails because EXPLAIN PHYSICAL contains a .grp:query carrier. With this commit it reports global_membership_row_count -> fused_reduce and contains no .grp:query carrier. The logical query shape remains unchanged.

The production-copy plan over roughly 855k driving rows likewise changed from three query-group carriers to no outer .grp:query carrier. Its selected search RecSet is consumed by the fused ACL reduction rather than written into and read back from a literal-specific group table.

## Manual A/B

Same machine, data, query text, session binding, JIT build, and process-restart procedure:

- production-copy cold: 2.06 s master -> 0.85 s candidate (58.7% faster)
- production-copy warm steady state: 0.32 s master -> 0.05 s candidate (84.4% faster, 6.4x)
- anonymous 40k selective perf fixture: 2511.8 ms master -> 2495.7 ms candidate (0.6% faster)

The existing broad COUNT performance test remains byte-for-byte unchanged. The new selective fixture adds a separate 3000 ms ceiling, while the structural assertion ensures query-group materialization cannot silently return.

## Local verification

- Scheme lint for both changed planner modules
- go build -o memcp .
- tests/planner/subqueries/acl-boolean-membership-scaling.yaml: 30/30
- PERF_TEST=1 tests/performance/like-acl-query-shapes.yaml: 9/9
- SQL time-limit guard and its 19 guard tests
- SQL runner contract: 52/52

The repository-wide suite is left to CI as requested.