### PR TITLE
Eliminate scan boundary materialization

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -24,7 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* check admin credentials against system.user table */
 (define dashboard_check_admin (lambda (req) (begin
 	(set pw (scan_lookup nil (table "system" "user")
-		'(373834222010370 "equal" "username" 15032418304 "" "password" "admin")
+		(list 373834222010370 (scan_boundary "equal" "username" 0 0 true true "" false) "password" "admin")
 		(list (req "username") (lambda (password admin) (list password admin)))))
 	(if (not (dashboard_auth_row_present? pw)) false
 		(and (equal? (car pw) (password (req "password"))) (car (cdr pw))))
@@ -33,7 +33,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 /* check any authenticated user (returns admin flag or false) */
 (define dashboard_check_user (lambda (req) (begin
 	(set pw (scan_lookup nil (table "system" "user")
-		'(373834222010370 "equal" "username" 15032418304 "" "password" "admin")
+		(list 373834222010370 (scan_boundary "equal" "username" 0 0 true true "" false) "password" "admin")
 		(list (req "username") (lambda (password admin) (list password admin)))))
 	(if (not (dashboard_auth_row_present? pw)) nil
 		(if (equal? (car pw) (password (req "password"))) (equal? (car (cdr pw)) 1) nil))
@@ -53,7 +53,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		(begin
 			/* build list of db names the user has access to; nil neutral avoids pre-call quirk */
 			(define allowed (scan nil (table "system" "access")
-				'(369436175368192 "equal" "username" 15032418304 "") (list username)
+				(list 369436175368192 (scan_boundary "equal" "username" 0 0 true true "" false)) (list username)
 				'() (lambda () true)
 				'("database") (lambda (acc db) (if (nil? db) acc (cons db (if (nil? acc) (list) acc))))
 				nil (lambda (a b) (merge (list a b)))))
@@ -101,7 +101,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (define dashboard_has_db_access (lambda (username is_admin dbname)
 	(if is_admin true
 		(scan_lookup nil (table "system" "access")
-			'(371635467059200 "equal" "username" 15032418304 "" "equal" "database" 15032483841 "") (list username dbname))
+			(list 371635467059200
+				(scan_boundary "equal" "username" 0 0 true true "" false)
+				(scan_boundary "equal" "database" 1 1 true true "" false)) (list username dbname))
 	)
 ))
 
@@ -135,11 +137,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /* helper: build JSON for a single user entry (takes username string) */
 (define dashboard_build_user_json (lambda (uname) (begin
-	(set is_adm (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "admin") (list uname)))
+	(set is_adm (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "admin") (list uname)))
 	/* get database access for non-admins */
 	(set dbs_csv (if is_adm ""
 		(scan nil (table "system" "access")
-			'(369436175368192 "equal" "username" 15032418304 "") (list uname)
+			(list 369436175368192 (scan_boundary "equal" "username" 0 0 true true "" false)) (list uname)
 			'() (lambda () true)
 			'("database") (lambda (acc db) (if (equal? acc "") (json_encode db) (concat acc "," (json_encode db))))
 			"" (lambda (a b) (if (equal? a "") b (if (equal? b "") a (concat a "," b)))))))
@@ -360,7 +362,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 					(dashboard_send_401 res)
 					(begin
 						(define default_pw (if is_admin
-							(equal? (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") '("root"))
+							(equal? (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") '("root"))
 								(password "admin"))
 							false))
 						(dashboard_send_json res (concat

--- a/lib/queryplan-physical-expr.scm
+++ b/lib/queryplan-physical-expr.scm
@@ -2118,7 +2118,8 @@ probe. */
 (define compiled_scan_lookup_boundaries (lambda (lookup_cols slot)
 	(if (empty_list? lookup_cols)
 		'()
-		(merge (list "equal" (car lookup_cols) (+ 15032418304 (* slot 65537)) "")
+		(merge (list (list (quote scan_boundary) "equal" (car lookup_cols)
+			slot slot true true "" false))
 			(compiled_scan_lookup_boundaries (cdr lookup_cols) (+ slot 1))))))
 
 (define compiled_scan_access_header (lambda (count consumer projections mapper_slot)
@@ -2137,7 +2138,7 @@ probe. */
 	(list (quote scan_lookup)
 		tx
 		table
-		(list (quote quote) (merge
+		(cons (quote list) (merge
 			(list (compiled_scan_access_header (count lookup_cols) consumer (count map_cols)
 				(if (equal? consumer "map") (count lookup_cols) -1)))
 			(compiled_scan_lookup_boundaries lookup_cols 0)

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -6576,7 +6576,7 @@ the costgen threshold. */
 		(if (nil? candidates)
 			0
 			(scan current_tx candidates
-				'(369436175368192 "equal" "canonical_name" 15032418304 "") (list canonical_name)
+				(list 369436175368192 (scan_boundary "equal" "canonical_name" 0 0 true true "" false)) (list canonical_name)
 				'() (lambda () true)
 				'("$update")
 				(lambda (acc $update) (begin ($update) (+ acc 1)))

--- a/lib/rdf-parser.scm
+++ b/lib/rdf-parser.scm
@@ -641,7 +641,7 @@ consumer stage. */
 ))
 (define rdf_relation_targets (lambda (schema subj pred) (begin
 	(define out (newsession))
-	(scan nil (table schema "rdf") '(369436443803648 "equal" "p" 15032418304 "" "equal" "s" 15032483841 "") (list pred subj) '() (lambda () true) '("o") (lambda (acc o) (begin (out o true) acc)))
+	(scan nil (table schema "rdf") (list 369436443803648 (scan_boundary "equal" "p" 0 0 true true "" false) (scan_boundary "equal" "s" 1 1 true true "" false)) (list pred subj) '() (lambda () true) '("o") (lambda (acc o) (begin (out o true) acc)))
 	(out)
 )))
 (define rdf_path_targets (lambda (schema start pred include_self) (begin
@@ -671,7 +671,7 @@ consumer stage. */
 ))
 (define rdf_delete_triples (lambda (schema triples) (begin
 	(map triples (lambda (triple) (match triple '(subj pred obj)
-		(scan nil (table schema "rdf") '(369436712239104 "equal" "o" 15032418304 "" "equal" "p" 15032483841 "" "equal" "s" 15032549378 "") (list obj pred subj) '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update) acc)))
+		(scan nil (table schema "rdf") (list 369436712239104 (scan_boundary "equal" "o" 0 0 true true "" false) (scan_boundary "equal" "p" 1 1 true true "" false) (scan_boundary "equal" "s" 2 2 true true "" false)) (list obj pred subj) '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update) acc)))
 	)))
 	nil
 )))
@@ -1016,7 +1016,7 @@ consumer stage. */
 (define delete_ttl (lambda (schema s) (begin
 	(set triples (parse_ttl_triples schema s))
 	(map triples (lambda (triple) (match triple '(subj pred obj)
-		(scan nil (table schema "rdf") '(369436712239104 "equal" "o" 15032418304 "" "equal" "p" 15032483841 "" "equal" "s" 15032549378 "") (list obj pred subj) '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update) acc)))
+		(scan nil (table schema "rdf") (list 369436712239104 (scan_boundary "equal" "o" 0 0 true true "" false) (scan_boundary "equal" "p" 1 1 true true "" false) (scan_boundary "equal" "s" 2 2 true true "" false)) (list obj pred subj) '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update) acc)))
 	)))
 )))
 

--- a/lib/rdf.scm
+++ b/lib/rdf.scm
@@ -38,7 +38,7 @@ this is how rdf works:
 	(set old_handler (coalesce http_handler handler_404))
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") (list (req "username"))))
+		(set pw (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list (req "username"))))
 		(if (and pw (equal? pw (password (req "password")))) (time (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)
@@ -59,7 +59,7 @@ this is how rdf works:
 	)))
 	(define handle_ttl_load (lambda (req res schema ttl_data) (begin
 		/* check for password */
-		(set pw (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") (list (req "username"))))
+		(set pw (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list (req "username"))))
 		(if (and pw (equal? pw (password (req "password")))) (begin
 			((res "header") "Content-Type" "text/plain")
 			((res "status") 200)

--- a/lib/sql-views.scm
+++ b/lib/sql-views.scm
@@ -59,7 +59,7 @@ derived SELECT before untangle_query sees the complete query. */
 
 (define sql_find_view (lambda (schema name)
 	(scan nil (table "system" "views")
-		'(369436443803648 "equal" "database" 15032418304 "" "equal" "name" 15032483841 "") (list schema name)
+		(list 369436443803648 (scan_boundary "equal" "database" 0 0 true true "" false) (scan_boundary "equal" "name" 1 1 true true "" false)) (list schema name)
 		'() (lambda () true)
 		'("dialect" "sql" "ir")
 		(lambda (acc dialect sql ir) (list dialect sql ir))
@@ -121,7 +121,7 @@ derived SELECT before untangle_query sees the complete query. */
 (define create_sql_view (lambda (tx schema name dialect sql ir mode) (begin
 	(define serialized_ir (json_encode ir))
 	(define existing (scan tx (table "system" "views")
-		'(369436443803648 "equal" "database" 15032418304 "" "equal" "name" 15032483841 "") (list schema name)
+		(list 369436443803648 (scan_boundary "equal" "database" 0 0 true true "" false) (scan_boundary "equal" "name" 1 1 true true "" false)) (list schema name)
 		'() (lambda () true)
 		'() (lambda (acc) (+ acc 1)) 0 +))
 	(define result
@@ -129,7 +129,7 @@ derived SELECT before untangle_query sees the complete query. */
 			(match mode
 				"replace"
 				(scan tx (table "system" "views")
-					'(369436443803648 "equal" "database" 15032418304 "" "equal" "name" 15032483841 "") (list schema name)
+					(list 369436443803648 (scan_boundary "equal" "database" 0 0 true true "" false) (scan_boundary "equal" "name" 1 1 true true "" false)) (list schema name)
 					'() (lambda () true)
 					'("$update")
 					(lambda (acc $update) (begin
@@ -152,7 +152,7 @@ derived SELECT before untangle_query sees the complete query. */
 
 (define drop_sql_view (lambda (tx schema name if_exists) (begin
 	(define removed (scan tx (table "system" "views")
-		'(369436443803648 "equal" "database" 15032418304 "" "equal" "name" 15032483841 "") (list schema name)
+		(list 369436443803648 (scan_boundary "equal" "database" 0 0 true true "" false) (scan_boundary "equal" "name" 1 1 true true "" false)) (list schema name)
 		'() (lambda () true)
 		'("$update")
 		(lambda (acc $update) (begin ($update) (+ acc 1)))
@@ -171,13 +171,13 @@ metadata. */
 	(define dropped (dropdatabase schema if_exists))
 	(if dropped (begin
 		(scan tx (table "system" "access")
-			'(369436175368192 "equal" "database" 15032418304 "") (list schema)
+			(list 369436175368192 (scan_boundary "equal" "database" 0 0 true true "" false)) (list schema)
 			'() (lambda () true)
 			'("$update")
 			(lambda (acc $update) (begin ($update) (+ acc 1)))
 			0 +)
 		(define removed_views (scan tx (table "system" "views")
-			'(369436175368192 "equal" "database" 15032418304 "") (list schema)
+			(list 369436175368192 (scan_boundary "equal" "database" 0 0 true true "" false)) (list schema)
 			'() (lambda () true)
 			'("$update")
 			(lambda (acc $update) (begin ($update) (+ acc 1)))

--- a/lib/sql.scm
+++ b/lib/sql.scm
@@ -618,7 +618,7 @@ if the user is not allowed to access this property, the function will throw an e
 (define sql_policy (lambda (username)
 	(begin
 		(define is_admin (scan_lookup nil (table "system" "user")
-			'(372734710317056 "equal" "username" 15032418304 "" "admin") (list username)))
+			(list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "admin") (list username)))
 		(if is_admin (lambda (schema tblname write) true) /* admin -> allow all */
 			/* else: complicated policy */
 			(lambda (schema tblname write)
@@ -627,7 +627,9 @@ if the user is not allowed to access this property, the function will throw an e
 					(if (equal?? schema "information_schema") true (begin
 						/* Database-level check via system.access */
 						(define has_access (scan_lookup nil (table "system" "access")
-							'(371635467059200 "equal" "username" 15032418304 "" "equal" "database" 15032483841 "") (list username schema)))
+							(list 371635467059200
+								(scan_boundary "equal" "username" 0 0 true true "" false)
+								(scan_boundary "equal" "database" 1 1 true true "" false)) (list username schema)))
 						(if has_access true (error (concat "access denied: user '" username "' may not " (if write "write" "read") " " schema "." tblname)))
 					))
 			))
@@ -672,7 +674,7 @@ if the user is not allowed to access this property, the function will throw an e
 /* migration: ensure root always has admin=true */
 (try (lambda () (begin
 	(if (has? (show "system") "user")
-		(scan nil (table "system" "user") '(369436175368192 "equal" "username" 15032418304 "") '("root") '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update '("admin" true)) acc)))
+		(scan nil (table "system" "user") (list 369436175368192 (scan_boundary "equal" "username" 0 0 true true "" false)) '("root") '() (lambda () true) '("$update") (lambda (acc $update) (begin ($update '("admin" true)) acc)))
 		true)
 )) (lambda (e) true))
 
@@ -775,7 +777,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	(set old_handler http_handler)
 	(define handle_query (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") (list (req "username"))))
+		(set pw (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list (req "username"))))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -820,7 +822,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	)))
 	(define handle_query_postgres (lambda (req res schema query) (begin
 		/* check for password */
-		(set pw (scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") (list (req "username"))))
+		(set pw (scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list (req "username"))))
 		(if (and pw (equal? pw (password (req "password"))))
 			(begin
 				(try (lambda () (time (begin
@@ -882,7 +884,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 	(define handle_scm (lambda (req res code) (begin
 		/* check for password - must be admin */
 		(set pw (scan_lookup nil (table "system" "user")
-			'(373834222010370 "equal" "username" 15032418304 "" "password" "admin")
+			(list 373834222010370 (scan_boundary "equal" "username" 0 0 true true "" false) "password" "admin")
 			(list (req "username") (lambda (password admin) (list password admin)))))
 		(if (and pw (equal? (car pw) (password (req "password"))) (car (cdr pw)))
 			(begin
@@ -953,7 +955,7 @@ Used for @@var resolution so per-session SET affects @@var reads. */
 
 /* shared callbacks for mysql protocol (TCP and Unix socket) */
 (set mysql_auth (lambda (username_)
-	(scan_lookup nil (table "system" "user") '(372734710317056 "equal" "username" 15032418304 "" "password") (list username_))))
+	(scan_lookup nil (table "system" "user") (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") (list username_))))
 (set mysql_schema (lambda (username schema) (or (equal?? schema "information_schema") (list? (show schema)))))
 
 /* Top-level so the interpreter compiles this body once instead of rebuilding a

--- a/scm/scmer.go
+++ b/scm/scmer.go
@@ -111,6 +111,16 @@ var CStringDecompress func(ptr *byte, val uint64) string
 // Registered by the storage package at init time. Key = tag ID.
 var CustomStringer [256]func(ptr unsafe.Pointer) string
 
+// CustomJSONCodec preserves immutable custom values embedded in persisted
+// Scheme procedures. Without a codec, custom values retain the historical
+// string fallback used by API responses.
+type CustomJSONCodec struct {
+	Encode func(ptr unsafe.Pointer) any
+	Decode func(value any) unsafe.Pointer
+}
+
+var CustomJSONCodecs [256]CustomJSONCodec
+
 // NewCString creates a lazy compressed-string Scmer.
 // ptr points into the StorageString dictionary (must stay alive as long as the Scmer).
 // format: storage.StringFormat value (4 bits); nibbleOff: 0 or 1; charLen: original char count.
@@ -1253,6 +1263,10 @@ func (s Scmer) MarshalJSON() ([]byte, error) {
 			}
 			return arr
 		default:
+			tag := v.GetTag()
+			if codec := CustomJSONCodecs[tag]; codec.Encode != nil {
+				return map[string]any{"scmer_custom": int(tag), "value": codec.Encode(unsafe.Pointer(v.ptr))}
+			}
 			// Unknown custom tag -> fall back to string form
 			return v.String()
 		}
@@ -1385,6 +1399,21 @@ func (s *Scmer) UnmarshalJSON(data []byte) error {
 		case string:
 			return NewString(t)
 		case map[string]any:
+			if encodedTag, ok := t["scmer_custom"]; ok && len(t) == 2 {
+				var tag int64 = -1
+				switch value := encodedTag.(type) {
+				case json.Number:
+					tag, _ = value.Int64()
+				case float64:
+					tag = int64(value)
+				}
+				if tag >= 0 && tag < int64(len(CustomJSONCodecs)) {
+					codec := CustomJSONCodecs[tag]
+					if codec.Decode != nil {
+						return NewCustom(uint8(tag), codec.Decode(t["value"]))
+					}
+				}
+			}
 			if sym, ok := t["symbol"]; ok {
 				if name, ok2 := sym.(string); ok2 {
 					return NewSymbol(name)

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -171,6 +171,9 @@ type scanAccessRuntime struct {
 	// decoding and the old materialized boundaries array.
 	firstBoundary    columnboundaries
 	hasFirstBoundary bool
+	batchData        []scm.Scmer
+	batchStride      int
+	batchID          int
 }
 
 // scanAccess is the allocation-free runtime view of the physical access
@@ -232,8 +235,10 @@ func (a scanAccess) len() int {
 }
 
 func (a scanAccess) boundary(index int) columnboundaries {
+	var boundary columnboundaries
 	if a.native != nil {
-		return a.native[index]
+		boundary = a.native[index]
+		return a.resolveBatchBoundary(boundary)
 	}
 	compiled := a.compiledCount
 	insertAt := compiled
@@ -247,18 +252,99 @@ func (a scanAccess) boundary(index int) columnboundaries {
 		insertAt = compiled
 	}
 	if index >= insertAt && index < insertAt+len(inserted) {
-		return inserted[index-insertAt]
+		boundary = inserted[index-insertAt]
+		return a.resolveBatchBoundary(boundary)
 	}
 	if index >= insertAt+len(inserted) {
 		index -= len(inserted)
 	}
 	if index >= compiled {
-		return suffix[index-compiled]
+		boundary = suffix[index-compiled]
+		return a.resolveBatchBoundary(boundary)
 	}
 	if index == 0 && a.runtime != nil && a.runtime.hasFirstBoundary {
-		return a.runtime.firstBoundary
+		boundary = a.runtime.firstBoundary
+		return a.resolveBatchBoundary(boundary)
 	}
-	return a.decodeBoundary(index)
+	return a.resolveBatchBoundary(a.decodeBoundary(index))
+}
+
+func (a scanAccess) resolveBatchBoundary(boundary columnboundaries) columnboundaries {
+	if a.runtime == nil || a.runtime.batchStride <= 0 || len(a.runtime.batchData) == 0 {
+		return boundary
+	}
+	base := a.runtime.batchID * a.runtime.batchStride
+	if boundary.lowerBatch {
+		boundary.lower = a.runtime.batchData[base+boundary.lowerBatchSubidx]
+	}
+	if boundary.upperBatch {
+		boundary.upper = a.runtime.batchData[base+boundary.upperBatchSubidx]
+	}
+	return boundary
+}
+
+func (a scanAccess) withBatch(stride int, data []scm.Scmer, batchID int) scanAccess {
+	runtime := a.ensureRuntime()
+	runtime.batchStride = stride
+	runtime.batchData = data
+	runtime.batchID = batchID
+	return a
+}
+
+func (a scanAccess) boundValue(index int, upper bool) scm.Scmer {
+	if a.native != nil {
+		if upper {
+			return a.resolveBatchValue(a.native[index].upper, a.native[index].upperBatch, a.native[index].upperBatchSubidx)
+		}
+		return a.resolveBatchValue(a.native[index].lower, a.native[index].lowerBatch, a.native[index].lowerBatchSubidx)
+	}
+	compiled := a.compiledCount
+	insertAt := compiled
+	var inserted, suffix boundaries
+	if a.runtime != nil {
+		insertAt = a.runtime.insertAt
+		inserted = a.runtime.inserted
+		suffix = a.runtime.suffix
+	}
+	if insertAt < 0 || insertAt > compiled {
+		insertAt = compiled
+	}
+	if index >= insertAt && index < insertAt+len(inserted) {
+		bound := inserted[index-insertAt]
+		if upper {
+			return a.resolveBatchValue(bound.upper, bound.upperBatch, bound.upperBatchSubidx)
+		}
+		return a.resolveBatchValue(bound.lower, bound.lowerBatch, bound.lowerBatchSubidx)
+	}
+	if index >= insertAt+len(inserted) {
+		index -= len(inserted)
+	}
+	if index >= compiled {
+		bound := suffix[index-compiled]
+		if upper {
+			return a.resolveBatchValue(bound.upper, bound.upperBatch, bound.upperBatchSubidx)
+		}
+		return a.resolveBatchValue(bound.lower, bound.lowerBatch, bound.lowerBatchSubidx)
+	}
+	meta := decodeScanAccessBoundaryMeta(a.schema[scanAccessSchemaHeaderSize+index*scanAccessBoundaryStride+2])
+	slot := meta.lowerSlot
+	if upper {
+		slot = meta.upperSlot
+	}
+	if slot >= 0 {
+		return a.values[slot]
+	}
+	if slot <= -2 {
+		return a.resolveBatchValue(scm.NewNil(), true, -slot-2)
+	}
+	return scm.NewNil()
+}
+
+func (a scanAccess) resolveBatchValue(value scm.Scmer, batched bool, subindex int) scm.Scmer {
+	if !batched || a.runtime == nil || a.runtime.batchStride <= 0 || len(a.runtime.batchData) == 0 {
+		return value
+	}
+	return a.runtime.batchData[a.runtime.batchID*a.runtime.batchStride+subindex]
 }
 
 func (a scanAccess) decodeBoundary(index int) columnboundaries {
@@ -352,49 +438,6 @@ func (a scanAccess) impossibleBatch(stride int, batchdata []scm.Scmer, batchid i
 		}
 	}
 	return false
-}
-
-func materializeScanAccess(access scanAccess) boundaries {
-	result := make(boundaries, access.len())
-	for i := range result {
-		result[i] = access.boundary(i)
-	}
-	return result
-}
-
-func hasBatchScanAccess(access scanAccess) bool {
-	for i := 0; i < access.len(); i++ {
-		boundary := access.boundary(i)
-		if boundary.lowerBatch || boundary.upperBatch {
-			return true
-		}
-	}
-	return false
-}
-
-func materializeBatchScanAccess(access scanAccess, stride int, batchdata []scm.Scmer, batchid uint32) boundaries {
-	return materializeBatchBoundaries(materializeScanAccess(access), stride, batchdata, batchid)
-}
-
-func materializeBatchScanAccessInto(storage []columnboundaries, access scanAccess, stride int, batchdata []scm.Scmer, batchid uint32) boundaries {
-	count := access.len()
-	if cap(storage) < count {
-		storage = make(boundaries, count)
-	} else {
-		storage = storage[:count]
-	}
-	base := int(batchid) * stride
-	for i := range storage {
-		boundary := access.boundary(i)
-		if boundary.lowerBatch {
-			boundary.lower = batchdata[base+boundary.lowerBatchSubidx]
-		}
-		if boundary.upperBatch {
-			boundary.upper = batchdata[base+boundary.upperBatchSubidx]
-		}
-		storage[i] = boundary
-	}
-	return storage
 }
 
 func scanAccessFromScheme(schemaValue scm.Scmer, values []scm.Scmer, suffix boundaries) (scanAccess, bool) {
@@ -1692,53 +1735,18 @@ func scmerStructEqual(a, b scm.Scmer) bool {
 	return false
 }
 
-func indexFromBoundariesInto(storage []scm.Scmer, cols boundaries) (lower []scm.Scmer, upperLast scm.Scmer) {
-	if len(cols) > 0 {
-		sortedEnd := 0
-		for sortedEnd < len(cols) && cols[sortedEnd].matcher.IsSorted() {
-			sortedEnd++
-		}
-		usableSorted := sortedEnd
-		for usableSorted >= 2 {
-			if !boundaryIsPoint(cols[usableSorted-2]) &&
-				!(boundaryIsUnboundedOrder(cols[usableSorted-2]) && boundaryIsUnboundedOrder(cols[usableSorted-1])) {
-				usableSorted--
-			} else {
-				break
-			}
-		}
-		// Hooks form a usable suffix only when no physical boundary between the
-		// retained prefix and that suffix had to be dropped.
-		effectiveLen := usableSorted
-		if usableSorted == sortedEnd {
-			effectiveLen = len(cols)
-		}
-		if effectiveLen == 0 {
-			return nil, scm.NewNil()
-		}
-		if cap(storage) >= effectiveLen {
-			lower = storage[:effectiveLen]
-		} else {
-			lower = make([]scm.Scmer, effectiveLen)
-		}
-		for i, v := range cols[:effectiveLen] {
-			lower[i] = v.lower
-		}
-		if usableSorted > 0 {
-			upperLast = cols[usableSorted-1].upper
-		}
-	}
-	return
+// scanIndexBounds is the allocation-free physical index view of a scan access
+// contract. Values stay in the planner-provided [values...] array (or the
+// caller's batch row) and are fetched by slot; no lower/upper copy is built.
+type scanIndexBounds struct {
+	access       scanAccess
+	effectiveLen int
+	usableSorted int
+	firstLower   scm.Scmer
+	lastUpper    scm.Scmer
 }
 
-func indexFromBoundaries(cols boundaries) ([]scm.Scmer, scm.Scmer) {
-	return indexFromBoundariesInto(nil, cols)
-}
-
-func indexFromScanAccessInto(storage []scm.Scmer, access scanAccess) (lower []scm.Scmer, upperLast scm.Scmer) {
-	if access.len() == 0 {
-		return nil, scm.NewNil()
-	}
+func newScanIndexBounds(access scanAccess) scanIndexBounds {
 	sortedEnd := 0
 	for sortedEnd < access.len() && access.boundary(sortedEnd).matcher.IsSorted() {
 		sortedEnd++
@@ -1750,27 +1758,51 @@ func indexFromScanAccessInto(storage []scm.Scmer, access scanAccess) (lower []sc
 		if !boundaryIsPoint(previous) &&
 			!(boundaryIsUnboundedOrder(previous) && boundaryIsUnboundedOrder(last)) {
 			usableSorted--
-		} else {
-			break
+			continue
 		}
+		break
 	}
 	effectiveLen := usableSorted
 	if usableSorted == sortedEnd {
 		effectiveLen = access.len()
 	}
-	if effectiveLen == 0 {
-		return nil, scm.NewNil()
-	}
-	if cap(storage) >= effectiveLen {
-		lower = storage[:effectiveLen]
-	} else {
-		lower = make([]scm.Scmer, effectiveLen)
-	}
-	for i := 0; i < effectiveLen; i++ {
-		lower[i] = access.boundary(i).lower
+	result := scanIndexBounds{access: access, effectiveLen: effectiveLen, usableSorted: usableSorted}
+	if effectiveLen > 0 {
+		result.firstLower = access.boundValue(0, false)
 	}
 	if usableSorted > 0 {
-		upperLast = access.boundary(usableSorted - 1).upper
+		result.lastUpper = access.boundValue(usableSorted-1, true)
 	}
-	return lower, upperLast
+	return result
+}
+
+func (b scanIndexBounds) len() int { return b.effectiveLen }
+
+func (b scanIndexBounds) lower(index int) scm.Scmer {
+	if index == 0 {
+		return b.firstLower
+	}
+	return b.access.boundValue(index, false)
+}
+
+func (b scanIndexBounds) upperLast() scm.Scmer {
+	if b.usableSorted == 0 {
+		return scm.NewNil()
+	}
+	return b.lastUpper
+}
+
+func (b scanIndexBounds) truncate(length int) scanIndexBounds {
+	if b.effectiveLen > length {
+		b.effectiveLen = length
+	}
+	if b.usableSorted > length {
+		b.usableSorted = length
+		if length > 0 {
+			b.lastUpper = b.access.boundValue(length-1, true)
+		} else {
+			b.lastUpper = scm.NewNil()
+		}
+	}
+	return b
 }

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -16,6 +16,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 */
 package storage
 
+import "fmt"
 import "github.com/carli2/hybridsort"
 import "github.com/launix-de/memcp/scm"
 
@@ -197,6 +198,10 @@ type scanAccess struct {
 	plannerFilterCovered bool
 }
 
+func (a *scanAccess) compiledBoundary(index int) *scanBoundaryBox {
+	return (*scanBoundaryBox)(a.schema[scanAccessSchemaHeaderSize+index].Custom(TagScanBoundary))
+}
+
 func runtimeScanAccess(suffix boundaries) scanAccess {
 	return scanAccess{native: suffix}
 }
@@ -224,7 +229,7 @@ func (a scanAccess) useScratch(scratch *scanAnalyzeScratch) scanAccess {
 	return a
 }
 
-func (a scanAccess) len() int {
+func (a *scanAccess) len() int {
 	if a.native != nil {
 		return len(a.native)
 	}
@@ -234,7 +239,159 @@ func (a scanAccess) len() int {
 	return a.compiledCount + len(a.runtime.inserted) + len(a.runtime.suffix)
 }
 
-func (a scanAccess) boundary(index int) columnboundaries {
+// boundaryParts resolves immutable metadata without materializing or copying a
+// columnboundaries value. Compiled entries return their cached Scheme object;
+// invocation-only legacy entries return a pointer into caller-owned storage.
+func (a *scanAccess) boundaryParts(index int) (*scanBoundaryBox, *columnboundaries) {
+	if a.native != nil {
+		return nil, &a.native[index]
+	}
+	compiled := a.compiledCount
+	insertAt := compiled
+	var inserted, suffix boundaries
+	if a.runtime != nil {
+		insertAt = a.runtime.insertAt
+		inserted = a.runtime.inserted
+		suffix = a.runtime.suffix
+	}
+	if insertAt < 0 || insertAt > compiled {
+		insertAt = compiled
+	}
+	if index >= insertAt && index < insertAt+len(inserted) {
+		return nil, &inserted[index-insertAt]
+	}
+	if index >= insertAt+len(inserted) {
+		index -= len(inserted)
+	}
+	if index >= compiled {
+		return nil, &suffix[index-compiled]
+	}
+	return (*scanBoundaryBox)(a.schema[scanAccessSchemaHeaderSize+index].Custom(TagScanBoundary)), nil
+}
+
+func (a *scanAccess) boundaryColumn(index int) string {
+	if a.native != nil {
+		return a.native[index].col
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).column
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.col
+	}
+	return spec.column
+}
+
+func (a *scanAccess) boundaryAnalyzer(index int) IndexAnalyzer {
+	if a.native != nil {
+		return a.native[index].matcher
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).analyzer
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.matcher
+	}
+	return spec.analyzer
+}
+
+func (a *scanAccess) boundaryLowerInclusive(index int) bool {
+	if a.native != nil {
+		return a.native[index].lowerInclusive
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).lowerInclusive
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.lowerInclusive
+	}
+	return spec.lowerInclusive
+}
+
+func (a *scanAccess) boundaryUpperInclusive(index int) bool {
+	if a.native != nil {
+		return a.native[index].upperInclusive
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).upperInclusive
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.upperInclusive
+	}
+	return spec.upperInclusive
+}
+
+func (a *scanAccess) boundaryCollation(index int) string {
+	if a.native != nil {
+		return a.native[index].collation
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).collation
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.collation
+	}
+	return spec.collation
+}
+
+func (a *scanAccess) boundaryOrder(index int) (func(...scm.Scmer) scm.Scmer, string) {
+	if a.native != nil {
+		return a.native[index].order, a.native[index].orderMeta
+	}
+	if a.runtime == nil {
+		box := a.compiledBoundary(index)
+		return box.order, box.orderMetadata
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.order, legacy.orderMeta
+	}
+	return spec.order, spec.orderMetadata
+}
+
+func (a *scanAccess) boundaryMap(index int) ([]string, scm.Scmer) {
+	if a.native != nil {
+		return a.native[index].mapCols, a.native[index].mapFn
+	}
+	if a.runtime == nil {
+		spec := a.compiledBoundary(index)
+		if spec.mapperSlot < 0 {
+			return spec.mapColumns, scm.NewNil()
+		}
+		descriptor := a.values[spec.mapperSlot].Slice()
+		return spec.mapColumns, descriptor[1]
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.mapCols, legacy.mapFn
+	}
+	if spec.mapperSlot < 0 {
+		return spec.mapColumns, scm.NewNil()
+	}
+	descriptor := a.values[spec.mapperSlot].Slice()
+	return spec.mapColumns, descriptor[1]
+}
+
+func (a *scanAccess) boundaryMandatory(index int) bool {
+	if a.native != nil {
+		return a.native[index].mandatory
+	}
+	if a.runtime == nil {
+		return a.compiledBoundary(index).mandatory
+	}
+	spec, legacy := a.boundaryParts(index)
+	if legacy != nil {
+		return legacy.mandatory
+	}
+	return spec.mandatory
+}
+
+func (a *scanAccess) boundary(index int) columnboundaries {
 	var boundary columnboundaries
 	if a.native != nil {
 		boundary = a.native[index]
@@ -291,7 +448,7 @@ func (a scanAccess) withBatch(stride int, data []scm.Scmer, batchID int) scanAcc
 	return a
 }
 
-func (a scanAccess) boundValue(index int, upper bool) scm.Scmer {
+func (a *scanAccess) boundValue(index int, upper bool) scm.Scmer {
 	if a.native != nil {
 		if upper {
 			return a.resolveBatchValue(a.native[index].upper, a.native[index].upperBatch, a.native[index].upperBatchSubidx)
@@ -326,10 +483,10 @@ func (a scanAccess) boundValue(index int, upper bool) scm.Scmer {
 		}
 		return a.resolveBatchValue(bound.lower, bound.lowerBatch, bound.lowerBatchSubidx)
 	}
-	meta := decodeScanAccessBoundaryMeta(a.schema[scanAccessSchemaHeaderSize+index*scanAccessBoundaryStride+2])
-	slot := meta.lowerSlot
+	boundary := a.compiledBoundary(index)
+	slot := boundary.lowerSlot
 	if upper {
-		slot = meta.upperSlot
+		slot = boundary.upperSlot
 	}
 	if slot >= 0 {
 		return a.values[slot]
@@ -348,18 +505,22 @@ func (a scanAccess) resolveBatchValue(value scm.Scmer, batched bool, subindex in
 }
 
 func (a scanAccess) decodeBoundary(index int) columnboundaries {
-	offset := scanAccessSchemaHeaderSize + index*scanAccessBoundaryStride
-	meta := decodeScanAccessBoundaryMeta(a.schema[offset+2])
+	spec := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+index])
 	boundary := columnboundaries{
-		col:            a.schema[offset+1].String(),
+		col:            spec.ColumnName(),
 		lower:          scm.NewNil(),
-		lowerInclusive: meta.flags&1 != 0,
+		lowerInclusive: spec.LowerInclusive(),
 		upper:          scm.NewNil(),
-		upperInclusive: meta.flags&2 != 0,
-		collation:      a.schema[offset+3].String(),
-		nullSafe:       meta.flags&4 != 0,
+		upperInclusive: spec.UpperInclusive(),
+		collation:      spec.Collation(),
+		nullSafe:       spec.NullSafe(),
+		matcher:        spec.Analyzer(),
+		mapCols:        spec.MapColumns(),
+		order:          spec.Order(),
+		orderMeta:      spec.OrderMetadata(),
+		mandatory:      spec.Mandatory(),
 	}
-	mapperSlot := int(meta.flags>>3) - 1
+	mapperSlot := spec.MapperSlot()
 	if mapperSlot >= 0 {
 		if !a.values[mapperSlot].IsSlice() {
 			panic("scan access computed-index descriptor is invalid")
@@ -369,32 +530,19 @@ func (a scanAccess) decodeBoundary(index int) columnboundaries {
 			panic("scan access computed-index descriptor is invalid")
 		}
 		boundary.col = descriptor[0].String()
-		boundary.mapCols = a.runtime.computedMapCols
 		boundary.mapFn = descriptor[1]
 	}
-	switch a.schema[offset].String() {
-	case "equal":
-		boundary.matcher = EqualMatcher
-	case "range":
-		boundary.matcher = RangeMatcher
-	case "like":
-		boundary.matcher = LikeMatcher
-	case "recset":
-		boundary.matcher = RecSetMatcher
-	default:
-		panic("scan access schema has an unknown matcher")
-	}
-	if meta.lowerSlot >= 0 {
-		boundary.lower = a.values[meta.lowerSlot]
-	} else if meta.lowerSlot <= -2 {
+	if spec.LowerSlot() >= 0 {
+		boundary.lower = a.values[spec.LowerSlot()]
+	} else if spec.LowerSlot() <= -2 {
 		boundary.lowerBatch = true
-		boundary.lowerBatchSubidx = -meta.lowerSlot - 2
+		boundary.lowerBatchSubidx = -spec.LowerSlot() - 2
 	}
-	if meta.upperSlot >= 0 {
-		boundary.upper = a.values[meta.upperSlot]
-	} else if meta.upperSlot <= -2 {
+	if spec.UpperSlot() >= 0 {
+		boundary.upper = a.values[spec.UpperSlot()]
+	} else if spec.UpperSlot() <= -2 {
 		boundary.upperBatch = true
-		boundary.upperBatchSubidx = -meta.upperSlot - 2
+		boundary.upperBatchSubidx = -spec.UpperSlot() - 2
 	}
 	return boundary
 }
@@ -405,13 +553,11 @@ func (a scanAccess) decodeBoundary(index int) columnboundaries {
 func (a scanAccess) impossible() bool {
 	compiled := a.compiledCount
 	for i := 0; i < compiled; i++ {
-		offset := scanAccessSchemaHeaderSize + i*scanAccessBoundaryStride
-		kind := a.schema[offset].String()
-		meta := decodeScanAccessBoundaryMeta(a.schema[offset+2])
-		if meta.lowerSlot >= 0 && a.values[meta.lowerSlot].IsNil() && (kind == "range" || (kind == "equal" && meta.flags&4 == 0)) {
+		boundary := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+i])
+		if boundary.LowerSlot() >= 0 && a.values[boundary.LowerSlot()].IsNil() && (boundary.Analyzer() == RangeMatcher || (boundary.Analyzer() == EqualMatcher && !boundary.NullSafe())) {
 			return true
 		}
-		if meta.upperSlot >= 0 && a.values[meta.upperSlot].IsNil() && kind == "range" {
+		if boundary.UpperSlot() >= 0 && a.values[boundary.UpperSlot()].IsNil() && boundary.Analyzer() == RangeMatcher {
 			return true
 		}
 	}
@@ -424,11 +570,9 @@ func (a scanAccess) impossibleBatch(stride int, batchdata []scm.Scmer, batchid i
 	}
 	compiled := a.compiledCount
 	for i := 0; i < compiled; i++ {
-		offset := scanAccessSchemaHeaderSize + i*scanAccessBoundaryStride
-		kind := a.schema[offset].String()
-		meta := decodeScanAccessBoundaryMeta(a.schema[offset+2])
-		for _, slot := range []int{meta.lowerSlot, meta.upperSlot} {
-			if slot <= -2 && (kind == "range" || (kind == "equal" && meta.flags&4 == 0)) {
+		boundary := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+i])
+		for _, slot := range []int{boundary.LowerSlot(), boundary.UpperSlot()} {
+			if slot <= -2 && (boundary.Analyzer() == RangeMatcher || (boundary.Analyzer() == EqualMatcher && !boundary.NullSafe())) {
 				subindex := -slot - 2
 				position := batchid*stride + subindex
 				if position < 0 || position >= len(batchdata) || batchdata[position].IsNil() {
@@ -458,28 +602,26 @@ func scanAccessFromScheme(schemaValue scm.Scmer, values []scm.Scmer, suffix boun
 	count := meta.count
 	projectionCount := meta.projections
 	if count < 0 || projectionCount < 0 || len(schema) != scanAccessSchemaHeaderSize+count*scanAccessBoundaryStride+projectionCount {
-		panic("scan access schema has an invalid boundary count")
+		panic(fmt.Sprintf("scan access schema has an invalid boundary count: count=%d projections=%d items=%d schema=%s",
+			count, projectionCount, len(schema), scm.String(schemaValue)))
 	}
 	computed := false
+	var computedMapCols []string
 	for offset, remaining := scanAccessSchemaHeaderSize, count; remaining > 0; offset, remaining = offset+scanAccessBoundaryStride, remaining-1 {
-		boundaryMeta := decodeScanAccessBoundaryMeta(schema[offset+2])
-		if boundaryMeta.lowerSlot >= len(values) || boundaryMeta.upperSlot >= len(values) {
+		if !schema[offset].IsCustom(TagScanBoundary) {
+			panic("scan access schema contains a non-boundary item")
+		}
+		boundary := ScanBoundaryFromScmer(schema[offset])
+		if boundary.LowerSlot() >= len(values) || boundary.UpperSlot() >= len(values) {
 			panic("scan access value slot is out of bounds")
 		}
-		mapperSlot := int(boundaryMeta.flags>>3) - 1
+		mapperSlot := boundary.MapperSlot()
 		if mapperSlot >= 0 {
 			if mapperSlot >= len(values) {
 				panic("scan access mapper slot is out of bounds")
 			}
 			computed = true
-		}
-	}
-	var computedMapCols []string
-	if computed {
-		projectionAt := scanAccessSchemaHeaderSize + count*scanAccessBoundaryStride
-		computedMapCols = make([]string, projectionCount)
-		for i := range computedMapCols {
-			computedMapCols[i] = schema[projectionAt+i].String()
+			computedMapCols = boundary.MapColumns()
 		}
 	}
 	access := scanAccess{schema: schema, values: values, compiledCount: count,
@@ -679,6 +821,15 @@ func boundaryIsUnboundedOrder(b columnboundaries) bool {
 
 func boundaryIsUnboundedRange(b columnboundaries) bool {
 	return b.matcher.IsSorted() && !boundaryIsPoint(b) && b.lower.IsNil() && b.upper.IsNil()
+}
+
+func scanAccessBoundaryIsPoint(access scanAccess, index int) bool {
+	return access.boundaryAnalyzer(index).IsPointLike()
+}
+
+func scanAccessBoundaryIsUnboundedOrder(access scanAccess, index int) bool {
+	order, _ := access.boundaryOrder(index)
+	return order != nil && access.boundValue(index, false).IsNil() && access.boundValue(index, true).IsNil()
 }
 
 // addConstraint merges a column boundary into an existing set, narrowing the
@@ -1739,7 +1890,9 @@ func scmerStructEqual(a, b scm.Scmer) bool {
 // contract. Values stay in the planner-provided [values...] array (or the
 // caller's batch row) and are fetched by slot; no lower/upper copy is built.
 type scanIndexBounds struct {
-	access       scanAccess
+	// access is bound only after the compact view has been copied into pooled
+	// index scratch. Delta-tree comparison needs it for non-leading slots.
+	access       *scanAccess
 	effectiveLen int
 	usableSorted int
 	firstLower   scm.Scmer
@@ -1748,15 +1901,13 @@ type scanIndexBounds struct {
 
 func newScanIndexBounds(access scanAccess) scanIndexBounds {
 	sortedEnd := 0
-	for sortedEnd < access.len() && access.boundary(sortedEnd).matcher.IsSorted() {
+	for sortedEnd < access.len() && access.boundaryAnalyzer(sortedEnd).IsSorted() {
 		sortedEnd++
 	}
 	usableSorted := sortedEnd
 	for usableSorted >= 2 {
-		previous := access.boundary(usableSorted - 2)
-		last := access.boundary(usableSorted - 1)
-		if !boundaryIsPoint(previous) &&
-			!(boundaryIsUnboundedOrder(previous) && boundaryIsUnboundedOrder(last)) {
+		if !scanAccessBoundaryIsPoint(access, usableSorted-2) &&
+			!(scanAccessBoundaryIsUnboundedOrder(access, usableSorted-2) && scanAccessBoundaryIsUnboundedOrder(access, usableSorted-1)) {
 			usableSorted--
 			continue
 		}
@@ -1766,7 +1917,7 @@ func newScanIndexBounds(access scanAccess) scanIndexBounds {
 	if usableSorted == sortedEnd {
 		effectiveLen = access.len()
 	}
-	result := scanIndexBounds{access: access, effectiveLen: effectiveLen, usableSorted: usableSorted}
+	result := scanIndexBounds{effectiveLen: effectiveLen, usableSorted: usableSorted}
 	if effectiveLen > 0 {
 		result.firstLower = access.boundValue(0, false)
 	}
@@ -1778,7 +1929,14 @@ func newScanIndexBounds(access scanAccess) scanIndexBounds {
 
 func (b scanIndexBounds) len() int { return b.effectiveLen }
 
-func (b scanIndexBounds) lower(index int) scm.Scmer {
+func (b scanIndexBounds) lower(access scanAccess, index int) scm.Scmer {
+	if index == 0 {
+		return b.firstLower
+	}
+	return access.boundValue(index, false)
+}
+
+func (b scanIndexBounds) referenceLower(index int) scm.Scmer {
 	if index == 0 {
 		return b.firstLower
 	}
@@ -1792,14 +1950,14 @@ func (b scanIndexBounds) upperLast() scm.Scmer {
 	return b.lastUpper
 }
 
-func (b *scanIndexBounds) truncate(length int) {
+func (b *scanIndexBounds) truncate(access scanAccess, length int) {
 	if b.effectiveLen > length {
 		b.effectiveLen = length
 	}
 	if b.usableSorted > length {
 		b.usableSorted = length
 		if length > 0 {
-			b.lastUpper = b.access.boundValue(length-1, true)
+			b.lastUpper = access.boundValue(length-1, true)
 		} else {
 			b.lastUpper = scm.NewNil()
 		}

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -17,6 +17,7 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import "fmt"
+import "unsafe"
 import "github.com/carli2/hybridsort"
 import "github.com/launix-de/memcp/scm"
 
@@ -84,7 +85,7 @@ type IndexAnalyzer interface {
 	Deploy(IndexDeployContext, bool) IndexHook
 }
 
-// Built-in matcher singletons. Every columnboundaries.matcher points to one of these.
+// Built-in matcher singletons. Every analyzer result points to one of these.
 // Created once at startup, never reallocated.
 var (
 	EqualMatcher  IndexAnalyzer = &equalMatcher{}
@@ -126,7 +127,7 @@ func (m *rangeMatcher) Analyze(IndexAnalyzeContext, scm.Scmer) (IndexBoundary, b
 }
 func (m *rangeMatcher) Deploy(IndexDeployContext, bool) IndexHook { return nil }
 
-type columnboundaries struct {
+type analyzedBoundary struct {
 	col              string
 	matcher          IndexAnalyzer // always set: EqualMatcher, RangeMatcher, LikeMatcher, ...
 	lower            scm.Scmer
@@ -149,32 +150,33 @@ type columnboundaries struct {
 	mapFn   scm.Scmer // function: mapFn(mapCols values...) → index value
 	// mandatory marks a physical source constraint which has no duplicate in
 	// the residual SQL predicate. Optimizations may discard advisory candidate
-	// hooks after a unique point lookup, but must retain mandatory boundaries.
+	// hooks after a unique point lookup, but must retain mandatory constraints.
 	mandatory bool
 }
 
-type boundaries []columnboundaries
+type analyzedBoundaries []analyzedBoundary
+
+// scanAccessSegment is a non-owning physical view over Scheme-visible boundary
+// items and their adjacent runtime values. Segments let execution append an
+// order or RecSet constraint without copying the planner-owned prefix.
+type scanAccessSegment struct {
+	items  []scm.Scmer
+	values []scm.Scmer
+}
 
 type scanAccessRuntime struct {
 	// computedMapCols is populated only for compiled computed-index probes.
 	computedMapCols []string
-	// inserted contains runtime-only ordered boundaries. insertAt places them
+	// inserted contains runtime-only ordered constraints. insertAt places them
 	// between the compiled sorted prefix and advisory matchers without copying
 	// either segment.
 	insertAt int
-	inserted boundaries
-	suffix   boundaries
+	inserted scanAccessSegment
+	suffix   scanAccessSegment
+	extra    scanAccessSegment
 	// filterCovered is an unconditional proof supplied by internal callers which
-	// construct mandatory physical boundaries directly.
+	// construct mandatory physical constraints directly.
 	filterCovered bool
-	// The first access dimension is consulted by every physical layer. Keeping
-	// this scalar decode beside the pooled scan scratch avoids both repeated SCM
-	// decoding and the old materialized boundaries array.
-	firstBoundary    columnboundaries
-	hasFirstBoundary bool
-	batchData        []scm.Scmer
-	batchStride      int
-	batchID          int
 }
 
 // scanAccess is the allocation-free runtime view of the physical access
@@ -187,27 +189,30 @@ type scanAccess struct {
 	schema        []scm.Scmer
 	values        []scm.Scmer
 	compiledCount int
+	firstBoundary *scanBoundaryBox
 	runtime       *scanAccessRuntime
-	// native is an invocation-local, already decoded view used only while an
-	// index loop is running (not part of the Scheme scan ABI or cached plan).
-	// Batched probes populate it from bounded scratch so the index hot path has
-	// the same direct slice access as precompiled storage constraints.
-	native boundaries
+	batchValues   *scm.Scmer
 	// plannerFilterCovered records the complete-subtree proof encoded in a
 	// static access schema. Mutating scans still retain their callback.
 	plannerFilterCovered bool
+	exactAdjacent        bool
 }
 
-func (a *scanAccess) compiledBoundary(index int) *scanBoundaryBox {
+func (a scanAccess) compiledBoundary(index int) *scanBoundaryBox {
+	if index == 0 && a.firstBoundary != nil {
+		return a.firstBoundary
+	}
 	return (*scanBoundaryBox)(a.schema[scanAccessSchemaHeaderSize+index].Custom(TagScanBoundary))
 }
 
-func runtimeScanAccess(suffix boundaries) scanAccess {
-	return scanAccess{native: suffix}
+func runtimeScanAccess(suffix analyzedBoundaries) scanAccess {
+	return scanAccessFromAnalyzed(suffix)
 }
 
-func coveredRuntimeScanAccess(suffix boundaries) scanAccess {
-	return scanAccess{native: suffix, plannerFilterCovered: true}
+func coveredRuntimeScanAccess(suffix analyzedBoundaries) scanAccess {
+	access := scanAccessFromAnalyzed(suffix)
+	access.plannerFilterCovered = true
+	return access
 }
 
 func (a *scanAccess) ensureRuntime() *scanAccessRuntime {
@@ -222,141 +227,120 @@ func (a scanAccess) useScratch(scratch *scanAnalyzeScratch) scanAccess {
 		scratch.runtime = *a.runtime
 	}
 	a.runtime = &scratch.runtime
-	if a.compiledCount > 0 {
-		a.runtime.firstBoundary = a.decodeBoundary(0)
-		a.runtime.hasFirstBoundary = true
-	}
 	return a
 }
 
-func (a *scanAccess) len() int {
-	if a.native != nil {
-		return len(a.native)
-	}
+func (a scanAccess) len() int {
 	if a.runtime == nil {
 		return a.compiledCount
 	}
-	return a.compiledCount + len(a.runtime.inserted) + len(a.runtime.suffix)
+	return a.compiledCount + len(a.runtime.inserted.items) + len(a.runtime.suffix.items) + len(a.runtime.extra.items)
 }
 
-// boundaryParts resolves immutable metadata without materializing or copying a
-// columnboundaries value. Compiled entries return their cached Scheme object;
-// invocation-only legacy entries return a pointer into caller-owned storage.
-func (a *scanAccess) boundaryParts(index int) (*scanBoundaryBox, *columnboundaries) {
-	if a.native != nil {
-		return nil, &a.native[index]
-	}
+// boundaryParts resolves one Scheme boundary item and the adjacent value
+// segment addressed by its slots. Runtime order/RecSet segments use exactly
+// the same representation as the planner-owned prefix.
+func (a scanAccess) boundaryParts(index int) (*scanBoundaryBox, []scm.Scmer) {
 	compiled := a.compiledCount
 	insertAt := compiled
-	var inserted, suffix boundaries
+	var inserted, suffix, extra scanAccessSegment
 	if a.runtime != nil {
 		insertAt = a.runtime.insertAt
 		inserted = a.runtime.inserted
 		suffix = a.runtime.suffix
+		extra = a.runtime.extra
 	}
 	if insertAt < 0 || insertAt > compiled {
 		insertAt = compiled
 	}
-	if index >= insertAt && index < insertAt+len(inserted) {
-		return nil, &inserted[index-insertAt]
+	if index >= insertAt && index < insertAt+len(inserted.items) {
+		box := (*scanBoundaryBox)(inserted.items[index-insertAt].Custom(TagScanBoundary))
+		return box, inserted.values
 	}
-	if index >= insertAt+len(inserted) {
-		index -= len(inserted)
+	if index >= insertAt+len(inserted.items) {
+		index -= len(inserted.items)
 	}
 	if index >= compiled {
-		return nil, &suffix[index-compiled]
+		index -= compiled
+		if index < len(suffix.items) {
+			box := (*scanBoundaryBox)(suffix.items[index].Custom(TagScanBoundary))
+			return box, suffix.values
+		}
+		index -= len(suffix.items)
+		box := (*scanBoundaryBox)(extra.items[index].Custom(TagScanBoundary))
+		return box, extra.values
 	}
-	return (*scanBoundaryBox)(a.schema[scanAccessSchemaHeaderSize+index].Custom(TagScanBoundary)), nil
+	return a.compiledBoundary(index), a.values
 }
 
-func (a *scanAccess) boundaryColumn(index int) string {
-	if a.native != nil {
-		return a.native[index].col
-	}
-	if a.runtime == nil {
-		return a.compiledBoundary(index).column
-	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.col
+func (a scanAccess) boundaryColumn(index int) string {
+	spec, values := a.boundaryParts(index)
+	if spec.mapperSlot >= 0 {
+		descriptor := values[spec.mapperSlot].Slice()
+		return descriptor[0].String()
 	}
 	return spec.column
 }
 
-func (a *scanAccess) boundaryAnalyzer(index int) IndexAnalyzer {
-	if a.native != nil {
-		return a.native[index].matcher
+func (a scanAccess) boundaryAnalyzer(index int) IndexAnalyzer {
+	if a.exactAdjacent {
+		return EqualMatcher
 	}
 	if a.runtime == nil {
 		return a.compiledBoundary(index).analyzer
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.matcher
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.analyzer
 }
 
-func (a *scanAccess) boundaryLowerInclusive(index int) bool {
-	if a.native != nil {
-		return a.native[index].lowerInclusive
+func (a scanAccess) boundaryLowerInclusive(index int) bool {
+	if a.exactAdjacent {
+		return true
 	}
 	if a.runtime == nil {
 		return a.compiledBoundary(index).lowerInclusive
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.lowerInclusive
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.lowerInclusive
 }
 
-func (a *scanAccess) boundaryUpperInclusive(index int) bool {
-	if a.native != nil {
-		return a.native[index].upperInclusive
+func (a scanAccess) boundaryUpperInclusive(index int) bool {
+	if a.exactAdjacent {
+		return true
 	}
 	if a.runtime == nil {
 		return a.compiledBoundary(index).upperInclusive
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.upperInclusive
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.upperInclusive
 }
 
-func (a *scanAccess) boundaryCollation(index int) string {
-	if a.native != nil {
-		return a.native[index].collation
+func (a scanAccess) boundaryCollation(index int) string {
+	if a.exactAdjacent {
+		return ""
 	}
 	if a.runtime == nil {
 		return a.compiledBoundary(index).collation
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.collation
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.collation
 }
 
-func (a *scanAccess) boundaryOrder(index int) (func(...scm.Scmer) scm.Scmer, string) {
-	if a.native != nil {
-		return a.native[index].order, a.native[index].orderMeta
+func (a scanAccess) boundaryOrder(index int) (func(...scm.Scmer) scm.Scmer, string) {
+	if a.exactAdjacent {
+		return nil, ""
 	}
 	if a.runtime == nil {
 		box := a.compiledBoundary(index)
 		return box.order, box.orderMetadata
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.order, legacy.orderMeta
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.order, spec.orderMetadata
 }
 
-func (a *scanAccess) boundaryMap(index int) ([]string, scm.Scmer) {
-	if a.native != nil {
-		return a.native[index].mapCols, a.native[index].mapFn
+func (a scanAccess) boundaryMap(index int) ([]string, scm.Scmer) {
+	if a.exactAdjacent {
+		return nil, scm.NewNil()
 	}
 	if a.runtime == nil {
 		spec := a.compiledBoundary(index)
@@ -366,130 +350,42 @@ func (a *scanAccess) boundaryMap(index int) ([]string, scm.Scmer) {
 		descriptor := a.values[spec.mapperSlot].Slice()
 		return spec.mapColumns, descriptor[1]
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.mapCols, legacy.mapFn
-	}
+	spec, values := a.boundaryParts(index)
 	if spec.mapperSlot < 0 {
 		return spec.mapColumns, scm.NewNil()
 	}
-	descriptor := a.values[spec.mapperSlot].Slice()
+	descriptor := values[spec.mapperSlot].Slice()
 	return spec.mapColumns, descriptor[1]
 }
 
-func (a *scanAccess) boundaryMandatory(index int) bool {
-	if a.native != nil {
-		return a.native[index].mandatory
+func (a scanAccess) boundaryMandatory(index int) bool {
+	if a.exactAdjacent {
+		return false
 	}
 	if a.runtime == nil {
 		return a.compiledBoundary(index).mandatory
 	}
-	spec, legacy := a.boundaryParts(index)
-	if legacy != nil {
-		return legacy.mandatory
-	}
+	spec, _ := a.boundaryParts(index)
 	return spec.mandatory
 }
 
-func (a *scanAccess) boundary(index int) columnboundaries {
-	var boundary columnboundaries
-	if a.native != nil {
-		boundary = a.native[index]
-		return a.resolveBatchBoundary(boundary)
-	}
-	compiled := a.compiledCount
-	insertAt := compiled
-	var inserted, suffix boundaries
-	if a.runtime != nil {
-		insertAt = a.runtime.insertAt
-		inserted = a.runtime.inserted
-		suffix = a.runtime.suffix
-	}
-	if insertAt < 0 || insertAt > compiled {
-		insertAt = compiled
-	}
-	if index >= insertAt && index < insertAt+len(inserted) {
-		boundary = inserted[index-insertAt]
-		return a.resolveBatchBoundary(boundary)
-	}
-	if index >= insertAt+len(inserted) {
-		index -= len(inserted)
-	}
-	if index >= compiled {
-		boundary = suffix[index-compiled]
-		return a.resolveBatchBoundary(boundary)
-	}
-	if index == 0 && a.runtime != nil && a.runtime.hasFirstBoundary {
-		boundary = a.runtime.firstBoundary
-		return a.resolveBatchBoundary(boundary)
-	}
-	return a.resolveBatchBoundary(a.decodeBoundary(index))
-}
-
-func (a scanAccess) resolveBatchBoundary(boundary columnboundaries) columnboundaries {
-	if a.runtime == nil || a.runtime.batchStride <= 0 || len(a.runtime.batchData) == 0 {
-		return boundary
-	}
-	base := a.runtime.batchID * a.runtime.batchStride
-	if boundary.lowerBatch {
-		boundary.lower = a.runtime.batchData[base+boundary.lowerBatchSubidx]
-	}
-	if boundary.upperBatch {
-		boundary.upper = a.runtime.batchData[base+boundary.upperBatchSubidx]
-	}
-	return boundary
-}
-
 func (a scanAccess) withBatch(stride int, data []scm.Scmer, batchID int) scanAccess {
-	runtime := a.ensureRuntime()
-	runtime.batchStride = stride
-	runtime.batchData = data
-	runtime.batchID = batchID
+	start := batchID * stride
+	a.batchValues = &data[start]
 	return a
 }
 
-func (a *scanAccess) boundValue(index int, upper bool) scm.Scmer {
-	if a.native != nil {
-		if upper {
-			return a.resolveBatchValue(a.native[index].upper, a.native[index].upperBatch, a.native[index].upperBatchSubidx)
-		}
-		return a.resolveBatchValue(a.native[index].lower, a.native[index].lowerBatch, a.native[index].lowerBatchSubidx)
+func (a scanAccess) boundValue(index int, upper bool) scm.Scmer {
+	if a.exactAdjacent {
+		return a.values[index]
 	}
-	compiled := a.compiledCount
-	insertAt := compiled
-	var inserted, suffix boundaries
-	if a.runtime != nil {
-		insertAt = a.runtime.insertAt
-		inserted = a.runtime.inserted
-		suffix = a.runtime.suffix
-	}
-	if insertAt < 0 || insertAt > compiled {
-		insertAt = compiled
-	}
-	if index >= insertAt && index < insertAt+len(inserted) {
-		bound := inserted[index-insertAt]
-		if upper {
-			return a.resolveBatchValue(bound.upper, bound.upperBatch, bound.upperBatchSubidx)
-		}
-		return a.resolveBatchValue(bound.lower, bound.lowerBatch, bound.lowerBatchSubidx)
-	}
-	if index >= insertAt+len(inserted) {
-		index -= len(inserted)
-	}
-	if index >= compiled {
-		bound := suffix[index-compiled]
-		if upper {
-			return a.resolveBatchValue(bound.upper, bound.upperBatch, bound.upperBatchSubidx)
-		}
-		return a.resolveBatchValue(bound.lower, bound.lowerBatch, bound.lowerBatchSubidx)
-	}
-	boundary := a.compiledBoundary(index)
+	boundary, values := a.boundaryParts(index)
 	slot := boundary.lowerSlot
 	if upper {
 		slot = boundary.upperSlot
 	}
 	if slot >= 0 {
-		return a.values[slot]
+		return values[slot]
 	}
 	if slot <= -2 {
 		return a.resolveBatchValue(scm.NewNil(), true, -slot-2)
@@ -498,66 +394,22 @@ func (a *scanAccess) boundValue(index int, upper bool) scm.Scmer {
 }
 
 func (a scanAccess) resolveBatchValue(value scm.Scmer, batched bool, subindex int) scm.Scmer {
-	if !batched || a.runtime == nil || a.runtime.batchStride <= 0 || len(a.runtime.batchData) == 0 {
+	if !batched || a.batchValues == nil {
 		return value
 	}
-	return a.runtime.batchData[a.runtime.batchID*a.runtime.batchStride+subindex]
-}
-
-func (a scanAccess) decodeBoundary(index int) columnboundaries {
-	spec := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+index])
-	boundary := columnboundaries{
-		col:            spec.ColumnName(),
-		lower:          scm.NewNil(),
-		lowerInclusive: spec.LowerInclusive(),
-		upper:          scm.NewNil(),
-		upperInclusive: spec.UpperInclusive(),
-		collation:      spec.Collation(),
-		nullSafe:       spec.NullSafe(),
-		matcher:        spec.Analyzer(),
-		mapCols:        spec.MapColumns(),
-		order:          spec.Order(),
-		orderMeta:      spec.OrderMetadata(),
-		mandatory:      spec.Mandatory(),
-	}
-	mapperSlot := spec.MapperSlot()
-	if mapperSlot >= 0 {
-		if !a.values[mapperSlot].IsSlice() {
-			panic("scan access computed-index descriptor is invalid")
-		}
-		descriptor := a.values[mapperSlot].Slice()
-		if len(descriptor) != 2 || !descriptor[0].IsString() {
-			panic("scan access computed-index descriptor is invalid")
-		}
-		boundary.col = descriptor[0].String()
-		boundary.mapFn = descriptor[1]
-	}
-	if spec.LowerSlot() >= 0 {
-		boundary.lower = a.values[spec.LowerSlot()]
-	} else if spec.LowerSlot() <= -2 {
-		boundary.lowerBatch = true
-		boundary.lowerBatchSubidx = -spec.LowerSlot() - 2
-	}
-	if spec.UpperSlot() >= 0 {
-		boundary.upper = a.values[spec.UpperSlot()]
-	} else if spec.UpperSlot() <= -2 {
-		boundary.upperBatch = true
-		boundary.upperBatchSubidx = -spec.UpperSlot() - 2
-	}
-	return boundary
+	return *(*scm.Scmer)(unsafe.Add(unsafe.Pointer(a.batchValues), uintptr(subindex)*unsafe.Sizeof(value)))
 }
 
 // impossible reports SQL comparison probes whose runtime operand is NULL.
 // NULL is otherwise also the unbounded-range sentinel, so this check must use
 // the schema slot rather than the materialized boundary value.
 func (a scanAccess) impossible() bool {
-	compiled := a.compiledCount
-	for i := 0; i < compiled; i++ {
-		boundary := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+i])
-		if boundary.LowerSlot() >= 0 && a.values[boundary.LowerSlot()].IsNil() && (boundary.Analyzer() == RangeMatcher || (boundary.Analyzer() == EqualMatcher && !boundary.NullSafe())) {
+	for i := 0; i < a.len(); i++ {
+		boundary, values := a.boundaryParts(i)
+		if boundary.lowerSlot >= 0 && values[boundary.lowerSlot].IsNil() && (boundary.analyzer == RangeMatcher || (boundary.analyzer == EqualMatcher && !boundary.nullSafe)) {
 			return true
 		}
-		if boundary.UpperSlot() >= 0 && a.values[boundary.UpperSlot()].IsNil() && boundary.Analyzer() == RangeMatcher {
+		if boundary.upperSlot >= 0 && values[boundary.upperSlot].IsNil() && boundary.analyzer == RangeMatcher {
 			return true
 		}
 	}
@@ -568,11 +420,10 @@ func (a scanAccess) impossibleBatch(stride int, batchdata []scm.Scmer, batchid i
 	if a.impossible() {
 		return true
 	}
-	compiled := a.compiledCount
-	for i := 0; i < compiled; i++ {
-		boundary := ScanBoundaryFromScmer(a.schema[scanAccessSchemaHeaderSize+i])
-		for _, slot := range []int{boundary.LowerSlot(), boundary.UpperSlot()} {
-			if slot <= -2 && (boundary.Analyzer() == RangeMatcher || (boundary.Analyzer() == EqualMatcher && !boundary.NullSafe())) {
+	for i := 0; i < a.len(); i++ {
+		boundary, _ := a.boundaryParts(i)
+		for _, slot := range [2]int{boundary.lowerSlot, boundary.upperSlot} {
+			if slot <= -2 && (boundary.analyzer == RangeMatcher || (boundary.analyzer == EqualMatcher && !boundary.nullSafe)) {
 				subindex := -slot - 2
 				position := batchid*stride + subindex
 				if position < 0 || position >= len(batchdata) || batchdata[position].IsNil() {
@@ -584,13 +435,21 @@ func (a scanAccess) impossibleBatch(stride int, batchdata []scm.Scmer, batchid i
 	return false
 }
 
-func scanAccessFromScheme(schemaValue scm.Scmer, values []scm.Scmer, suffix boundaries) (scanAccess, bool) {
+func scanAccessFromScheme(schemaValue scm.Scmer, values []scm.Scmer, suffix *scanAccessSegment) (scanAccess, bool) {
+	var suffixValue scanAccessSegment
+	if suffix != nil {
+		suffixValue = *suffix
+	}
 	if !schemaValue.IsSlice() {
 		return scanAccess{}, false
 	}
 	schema := schemaValue.Slice()
 	if len(schema) == 0 {
-		return runtimeScanAccess(suffix), true
+		access := scanAccess{}
+		if len(suffixValue.items) > 0 {
+			access.runtime = &scanAccessRuntime{suffix: suffixValue}
+		}
+		return access, true
 	}
 	if len(schema) < scanAccessSchemaHeaderSize {
 		return scanAccess{}, false
@@ -626,23 +485,26 @@ func scanAccessFromScheme(schemaValue scm.Scmer, values []scm.Scmer, suffix boun
 	}
 	access := scanAccess{schema: schema, values: values, compiledCount: count,
 		plannerFilterCovered: meta.consumer == scanAccessConsumerCoveredScan}
-	if computed || len(suffix) > 0 {
-		access.runtime = &scanAccessRuntime{computedMapCols: computedMapCols, suffix: suffix}
+	if count > 0 {
+		access.firstBoundary = (*scanBoundaryBox)(schema[scanAccessSchemaHeaderSize].Custom(TagScanBoundary))
+	}
+	if computed || len(suffixValue.items) > 0 {
+		access.runtime = &scanAccessRuntime{computedMapCols: computedMapCols, suffix: suffixValue}
 	}
 	return access, true
 }
 
 // IndexBoundary is the public boundary value returned by custom analyzers. Its
 // storage stays equal to the internal boundary representation.
-type IndexBoundary = columnboundaries
+type IndexBoundary = analyzedBoundary
 
 func NewIndexBoundary(column string, analyzer IndexAnalyzer, binding scm.Scmer, collation string) IndexBoundary {
-	return columnboundaries{col: column, matcher: analyzer, lower: binding, upper: binding, lowerInclusive: true, upperInclusive: true, collation: collation}
+	return analyzedBoundary{col: column, matcher: analyzer, lower: binding, upper: binding, lowerInclusive: true, upperInclusive: true, collation: collation}
 }
 
-func (b columnboundaries) ColumnName() string { return b.col }
-func (b columnboundaries) Binding() scm.Scmer { return b.lower }
-func (b columnboundaries) Collation() string  { return b.collation }
+func (b analyzedBoundary) ColumnName() string { return b.col }
+func (b analyzedBoundary) Binding() scm.Scmer { return b.lower }
+func (b analyzedBoundary) Collation() string  { return b.collation }
 
 type indexAnalyzeContext struct {
 	proc          *scm.Proc
@@ -811,15 +673,15 @@ func boundaryValueEqual(a, b scm.Scmer) bool {
 }
 
 // boundaryIsPoint delegates to the matcher's IsPointLike.
-func boundaryIsPoint(b columnboundaries) bool {
+func boundaryIsPoint(b analyzedBoundary) bool {
 	return b.matcher.IsPointLike()
 }
 
-func boundaryIsUnboundedOrder(b columnboundaries) bool {
+func boundaryIsUnboundedOrder(b analyzedBoundary) bool {
 	return b.order != nil && b.lower.IsNil() && b.upper.IsNil()
 }
 
-func boundaryIsUnboundedRange(b columnboundaries) bool {
+func boundaryIsUnboundedRange(b analyzedBoundary) bool {
 	return b.matcher.IsSorted() && !boundaryIsPoint(b) && b.lower.IsNil() && b.upper.IsNil()
 }
 
@@ -834,7 +696,7 @@ func scanAccessBoundaryIsUnboundedOrder(access scanAccess, index int) bool {
 
 // addConstraint merges a column boundary into an existing set, narrowing the
 // range for an already-present column (AND semantics) or appending a new entry.
-func addConstraint(in boundaries, b2 columnboundaries) boundaries {
+func addConstraint(in analyzedBoundaries, b2 analyzedBoundary) analyzedBoundaries {
 	for i, b := range in {
 		if b.col == b2.col {
 			// Non-ordering indexes are independent candidate filters. Preserve
@@ -873,7 +735,7 @@ func addConstraint(in boundaries, b2 columnboundaries) boundaries {
 // widenBounds widens a into the union with b (OR semantics).
 // Keeps only columns present in both; for shared columns, takes the wider range.
 // Modifies a in-place, zero allocations.
-func widenBounds(a, b boundaries) boundaries {
+func widenBounds(a, b analyzedBoundaries) analyzedBoundaries {
 	n := 0
 	for i := range a {
 		found := false
@@ -998,7 +860,7 @@ func conditionMayHaveBoundaries(condition scm.Scmer) bool {
 	return ok
 }
 
-func extractCustomBoundary(ctx indexAnalyzeContext, node scm.Scmer) (columnboundaries, bool) {
+func extractCustomBoundary(ctx indexAnalyzeContext, node scm.Scmer) (analyzedBoundary, bool) {
 	for _, analyzer := range boundaryMatchers {
 		if analyzer == EqualMatcher || analyzer == RangeMatcher {
 			continue
@@ -1007,7 +869,7 @@ func extractCustomBoundary(ctx indexAnalyzeContext, node scm.Scmer) (columnbound
 			return boundary, true
 		}
 	}
-	return columnboundaries{}, false
+	return analyzedBoundary{}, false
 }
 
 func unwrapAnalyzeNode(ctx *indexAnalyzeContext, node scm.Scmer) scm.Scmer {
@@ -1023,18 +885,18 @@ func unwrapAnalyzeNode(ctx *indexAnalyzeContext, node scm.Scmer) scm.Scmer {
 // extractSingleBoundary recognizes one indexable predicate without
 // constructing the recursive general-analyzer closure or an intermediate
 // singleton slice.
-func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (columnboundaries, bool) {
+func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (analyzedBoundary, bool) {
 	node = unwrapAnalyzeNode(ctx, node)
 	v, ok := scmerSlice(node)
 	if !ok || len(v) < 2 {
-		return columnboundaries{}, false
+		return analyzedBoundary{}, false
 	}
-	makeComparison := func(columnNode, valueNode scm.Scmer, matcher IndexAnalyzer, lower bool, inclusive bool) (columnboundaries, bool) {
+	makeComparison := func(columnNode, valueNode scm.Scmer, matcher IndexAnalyzer, lower bool, inclusive bool) (analyzedBoundary, bool) {
 		col, columnOK := ctx.ResolveColumn(columnNode)
 		if !columnOK {
-			return columnboundaries{}, false
+			return analyzedBoundary{}, false
 		}
-		bound := columnboundaries{col: col, matcher: matcher}
+		bound := analyzedBoundary{col: col, matcher: matcher}
 		if value, constant := ctx.ExtractConstant(valueNode); constant {
 			if matcher == EqualMatcher {
 				bound.lower, bound.upper = value, value
@@ -1058,11 +920,11 @@ func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (columnboun
 			}
 			return bound, true
 		}
-		return columnboundaries{}, false
+		return analyzedBoundary{}, false
 	}
 	if len(v) >= 3 && (ctx.FunctionIs(v[0], "equal?") || ctx.FunctionIs(v[0], "equal??")) {
 		nullSafe := ctx.FunctionIs(v[0], "equal??")
-		finish := func(bound columnboundaries, found bool) (columnboundaries, bool) {
+		finish := func(bound analyzedBoundary, found bool) (analyzedBoundary, bool) {
 			if found && nullSafe {
 				bound.nullSafe = true
 				bound.collation = "utf8mb4_general_ci"
@@ -1090,7 +952,7 @@ func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (columnboun
 	}
 	if ctx.FunctionIs(v[0], "nil?") {
 		if col, found := ctx.ResolveColumn(v[1]); found {
-			return columnboundaries{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}, true
+			return analyzedBoundary{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}, true
 		}
 	}
 	return extractCustomBoundary(*ctx, node)
@@ -1099,7 +961,7 @@ func extractSingleBoundary(ctx *indexAnalyzeContext, node scm.Scmer) (columnboun
 // extractSimpleBoundaries appends the dominant simple predicate class directly
 // into caller-owned storage. Flat or nested AND trees remain allocation-free;
 // OR widening and computed-column synthesis retain the complete general path.
-func extractSimpleBoundaries(ctx *indexAnalyzeContext, node scm.Scmer, storage boundaries) (boundaries, bool) {
+func extractSimpleBoundaries(ctx *indexAnalyzeContext, node scm.Scmer, storage analyzedBoundaries) (analyzedBoundaries, bool) {
 	node = unwrapAnalyzeNode(ctx, node)
 	items, sliced := scmerSlice(node)
 	if sliced && len(items) > 1 && items[0].SymbolEquals("and") {
@@ -1120,7 +982,7 @@ func extractSimpleBoundaries(ctx *indexAnalyzeContext, node scm.Scmer, storage b
 	return addConstraint(storage, boundary), true
 }
 
-func extractBoundariesInto(storage boundaries, conditionCols []string, condition scm.Scmer) boundaries {
+func extractBoundariesInto(storage analyzedBoundaries, conditionCols []string, condition scm.Scmer) analyzedBoundaries {
 	ctx, ok := conditionAnalyzeContext(conditionCols, condition)
 	if ok {
 		if result, simple := extractSimpleBoundaries(&ctx, ctx.proc.Body, storage); simple {
@@ -1131,7 +993,7 @@ func extractBoundariesInto(storage boundaries, conditionCols []string, condition
 }
 
 // analyzes a lambda expression for value boundaries, so the best index can be found
-func extractBoundaries(conditionCols []string, condition scm.Scmer) boundaries {
+func extractBoundaries(conditionCols []string, condition scm.Scmer) analyzedBoundaries {
 	return extractBoundariesInto(nil, conditionCols, condition)
 }
 
@@ -1160,20 +1022,20 @@ func sortedBoundariesCoverCondition(conditionCols []string, condition scm.Scmer,
 		covered := false
 		rangeSeen := false
 		for i := 0; i < access.len(); i++ {
-			have := access.boundary(i)
-			if have.matcher == nil || !have.matcher.IsSorted() || rangeSeen {
+			have, _ := access.boundaryParts(i)
+			if have.analyzer == nil || !have.analyzer.IsSorted() || rangeSeen {
 				break
 			}
-			if have.col != want.col || have.matcher == nil ||
-				!matcherKindEqual(have.matcher, want.matcher) ||
-				have.lowerBatch || have.upperBatch ||
+			if have.column != want.col ||
+				!matcherKindEqual(have.analyzer, want.matcher) ||
+				have.lowerSlot <= -2 || have.upperSlot <= -2 ||
 				have.lowerInclusive != want.lowerInclusive ||
 				have.upperInclusive != want.upperInclusive ||
 				have.nullSafe != want.nullSafe ||
 				have.collation != want.collation ||
-				!boundaryValueEqual(have.lower, want.lower) ||
-				!boundaryValueEqual(have.upper, want.upper) {
-				if have.matcher == RangeMatcher {
+				!boundaryValueEqual(access.boundValue(i, false), want.lower) ||
+				!boundaryValueEqual(access.boundValue(i, true), want.upper) {
+				if have.analyzer == RangeMatcher {
 					rangeSeen = true
 				}
 				continue
@@ -1198,7 +1060,7 @@ func scanAccessProvesCondition(conditionCols []string, condition scm.Scmer, acce
 // extractBoundariesGeneral retains the complete recursive analyzer for OR
 // widening, computed columns and any future shape not handled by the simple
 // allocation-free path.
-func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) boundaries {
+func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) analyzedBoundaries {
 	analyzeContextValue, ok := conditionAnalyzeContext(conditionCols, condition)
 	if !ok {
 		// native Go function - no boundary extraction possible (full scan)
@@ -1207,11 +1069,11 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 	analyzeContext := &analyzeContextValue
 	p := analyzeContext.proc
 	params := analyzeContext.params
-	// traverseCondition returns boundaries for a single AST node.
+	// traverseCondition returns analyzed boundaries for a single AST node.
 	// nil means "unknown node, no bounds extractable".
 	// AND: merge children (intersect). OR: widen children (union).
-	var traverseCondition func(scm.Scmer) boundaries
-	traverseCondition = func(node scm.Scmer) boundaries {
+	var traverseCondition func(scm.Scmer) analyzedBoundaries
+	traverseCondition = func(node scm.Scmer) analyzedBoundaries {
 		v, ok := scmerSlice(node)
 		if !ok {
 			return nil
@@ -1224,25 +1086,25 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 		}
 		for _, analyzer := range boundaryMatchers {
 			if boundary, ok := analyzer.Analyze(analyzeContext, node); ok {
-				return boundaries{boundary}
+				return analyzedBoundaries{boundary}
 			}
 		}
 		if analyzeContext.FunctionIs(v[0], "equal?") || analyzeContext.FunctionIs(v[0], "equal??") {
 			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (equal? const col)
 			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// computed col: (equal? rawDataset independent) or reversed
@@ -1253,7 +1115,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1261,7 +1123,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1273,7 +1135,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lower: v2, lowerInclusive: true, upper: v2, upperInclusive: true, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1281,7 +1143,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lowerInclusive: true, upperInclusive: true, lowerBatch: true, lowerBatchSubidx: subidx, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1291,19 +1153,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			incl := v[0].SymbolEquals("<=")
 			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (< const col) means col > const, (<= const col) means col >= const
 			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
 				}
 			}
 			// computed col: rawDataset < independent → rawDataset has upper bound
@@ -1314,7 +1176,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1322,7 +1184,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1335,7 +1197,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1343,7 +1205,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1353,19 +1215,19 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			incl := v[0].SymbolEquals(">=")
 			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[2]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx}}
 				}
 			}
 			// reversed: (> const col) means col < const, (>= const col) means col <= const
 			if col, ok := analyzeContext.ResolveColumn(v[2]); ok {
 				if v2, ok := analyzeContext.ExtractConstant(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl}}
 				}
 				if subidx, ok := analyzeContext.resolveBatchSubidx(v[1]); ok {
-					return boundaries{columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
+					return analyzedBoundaries{analyzedBoundary{col: col, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx}}
 				}
 			}
 			// computed col: rawDataset > independent → rawDataset has lower bound
@@ -1376,7 +1238,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: v2, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1384,7 +1246,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lowerInclusive: incl, upper: scm.NewNil(), upperInclusive: false, lowerBatch: true, lowerBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1397,7 +1259,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upper: v2, upperInclusive: incl, mapCols: mc, mapFn: mf}}
 						}
 					}
 				} else if isRawDataset(params, computedExpr) {
@@ -1405,7 +1267,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 						canon := canonicalColName(computedExpr, params, conditionCols)
 						mc, mf := buildComputedFn(computedExpr, p.Params, p.En, conditionCols)
 						if !mf.IsNil() && mc != nil {
-							return boundaries{columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
+							return analyzedBoundaries{analyzedBoundary{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false, upperInclusive: incl, upperBatch: true, upperBatchSubidx: subidx, mapCols: mc, mapFn: mf}}
 						}
 					}
 				}
@@ -1414,11 +1276,11 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 		} else if analyzeContext.FunctionIs(v[0], "nil?") && len(v) >= 2 {
 			// IS NULL: (nil? col)
 			if col, ok := analyzeContext.ResolveColumn(v[1]); ok {
-				return boundaries{columnboundaries{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}}
+				return analyzedBoundaries{analyzedBoundary{col: col, matcher: EqualMatcher, lower: scm.NewNil(), lowerInclusive: true, upper: scm.NewNil(), upperInclusive: true}}
 			}
 			return nil
 		} else if v[0].SymbolEquals("and") {
-			var result boundaries
+			var result analyzedBoundaries
 			for i := 1; i < len(v); i++ {
 				child := traverseCondition(v[i])
 				if child == nil {
@@ -1440,10 +1302,10 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 				canon := canonicalColName(node, params, conditionCols)
 				mc, mf := buildComputedFn(node, p.Params, p.En, conditionCols)
 				if !mf.IsNil() && mc != nil {
-					return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: scm.NewBool(true), lowerInclusive: true, upper: scm.NewBool(true), upperInclusive: true, mapCols: mc, mapFn: mf}}
+					return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lower: scm.NewBool(true), lowerInclusive: true, upper: scm.NewBool(true), upperInclusive: true, mapCols: mc, mapFn: mf}}
 				}
 			}
-			var result boundaries
+			var result analyzedBoundaries
 			for i := 1; i < len(v); i++ {
 				child := traverseCondition(v[i])
 				if child == nil {
@@ -1472,7 +1334,7 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 			canon := canonicalColName(node, params, conditionCols)
 			mc, mf := buildComputedFn(node, p.Params, p.En, conditionCols)
 			if !mf.IsNil() && mc != nil {
-				return boundaries{columnboundaries{col: canon, matcher: EqualMatcher, lower: scm.NewBool(true), lowerInclusive: true, upper: scm.NewBool(true), upperInclusive: true, mapCols: mc, mapFn: mf}}
+				return analyzedBoundaries{analyzedBoundary{col: canon, matcher: EqualMatcher, lower: scm.NewBool(true), lowerInclusive: true, upper: scm.NewBool(true), upperInclusive: true, mapCols: mc, mapFn: mf}}
 			}
 		}
 		return nil
@@ -1505,8 +1367,8 @@ func extractBoundariesGeneral(conditionCols []string, condition scm.Scmer) bound
 // of the LIKE call represented by bound. An exact main-row match set may bypass
 // residual evaluation only under this structural proof; deltas are never
 // covered because they are not part of the immutable set.
-func singleLikeBoundaryCoversCondition(conditionCols []string, condition scm.Scmer, bound columnboundaries) bool {
-	if bound.matcher != LikeMatcher {
+func singleLikeBoundaryCoversCondition(conditionCols []string, condition scm.Scmer, access scanAccess, boundaryIndex int) bool {
+	if access.boundaryAnalyzer(boundaryIndex) != LikeMatcher {
 		return false
 	}
 	var p scm.Proc
@@ -1543,46 +1405,23 @@ func singleLikeBoundaryCoversCondition(conditionCols []string, condition scm.Scm
 	}
 	if items[1].IsNthLocalVar() {
 		idx := int(items[1].NthLocalVar())
-		return idx < len(conditionCols) && conditionCols[idx] == bound.col
+		return idx < len(conditionCols) && conditionCols[idx] == access.boundaryColumn(boundaryIndex)
 	}
 	if items[1].IsSymbol() {
 		for i, param := range params {
 			if i < len(conditionCols) && param.IsSymbol() && param.String() == items[1].String() {
-				return conditionCols[i] == bound.col
+				return conditionCols[i] == access.boundaryColumn(boundaryIndex)
 			}
 		}
 	}
 	return false
 }
 
-func hasBatchBoundaries(bounds boundaries) bool {
-	for _, b := range bounds {
-		if b.lowerBatch || b.upperBatch {
-			return true
-		}
-	}
-	return false
-}
-
-func materializeBatchBoundaries(template boundaries, stride int, batchdata []scm.Scmer, batchid uint32) boundaries {
-	result := append(boundaries(nil), template...)
-	base := int(batchid) * stride
-	for i := range result {
-		if result[i].lowerBatch {
-			result[i].lower = batchdata[base+result[i].lowerBatchSubidx]
-		}
-		if result[i].upperBatch {
-			result[i].upper = batchdata[base+result[i].upperBatchSubidx]
-		}
-	}
-	return result
-}
-
 // reorderByFrequency keeps exact sorted points ahead of matcher-backed points.
 // A PK equality must be allowed to narrow a nested probe before an expensive LIKE
 // matcher is considered. Frequency only reorders boundaries with the same access
 // characteristics, preserving prefix reuse without overriding that cost property.
-func reorderByFrequency(bounds boundaries, t *table) {
+func reorderByFrequency(bounds analyzedBoundaries, t *table) {
 	for _, b := range bounds {
 		t.bumpColFreq(b.col)
 	}

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -274,6 +274,9 @@ func (a scanAccess) boundaryParts(index int) (*scanBoundaryBox, []scm.Scmer) {
 }
 
 func (a scanAccess) boundaryColumn(index int) string {
+	if a.exactAdjacent {
+		return a.compiledBoundary(index).column
+	}
 	spec, values := a.boundaryParts(index)
 	if spec.mapperSlot >= 0 {
 		descriptor := values[spec.mapperSlot].Slice()
@@ -1734,6 +1737,7 @@ type scanIndexBounds struct {
 	access       *scanAccess
 	effectiveLen int
 	usableSorted int
+	compareCols  int
 	firstLower   scm.Scmer
 	lastUpper    scm.Scmer
 }

--- a/storage/analyzer.go
+++ b/storage/analyzer.go
@@ -1792,7 +1792,7 @@ func (b scanIndexBounds) upperLast() scm.Scmer {
 	return b.lastUpper
 }
 
-func (b scanIndexBounds) truncate(length int) scanIndexBounds {
+func (b *scanIndexBounds) truncate(length int) {
 	if b.effectiveLen > length {
 		b.effectiveLen = length
 	}
@@ -1804,5 +1804,4 @@ func (b scanIndexBounds) truncate(length int) scanIndexBounds {
 			b.lastUpper = scm.NewNil()
 		}
 	}
-	return b
 }

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -924,7 +924,8 @@ func TestEffectiveBoundaryInclusivenessUsesIndexedRange(t *testing.T) {
 		{col: "quantity", matcher: RangeMatcher, lowerInclusive: false, upperInclusive: false},
 	}
 	access := runtimeScanAccess(bounds)
-	lowerInclusive, upperInclusive := effectiveBoundaryInclusiveness(access, newScanIndexBounds(access))
+	indexBounds := newScanIndexBounds(access)
+	lowerInclusive, upperInclusive := effectiveBoundaryInclusiveness(access, &indexBounds)
 	if !lowerInclusive || !upperInclusive {
 		t.Fatalf("effective boundary inclusiveness = (%t, %t), want (true, true)", lowerInclusive, upperInclusive)
 	}
@@ -1022,11 +1023,11 @@ func TestRowWithinBoundsEqual(t *testing.T) {
 	access := runtimeScanAccess(boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), upper: scm.NewInt(5)}})
 	indexBounds := newScanIndexBounds(access)
 
-	inRange, _ := idx.rowWithinBounds(access, indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(5) })
+	inRange, _ := idx.rowWithinBounds(access, &indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(5) })
 	if !inRange {
 		t.Error("expected match for equal value")
 	}
-	inRange, beyond := idx.rowWithinBounds(access, indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(10) })
+	inRange, beyond := idx.rowWithinBounds(access, &indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(10) })
 	if inRange {
 		t.Error("expected no match for different value")
 	}
@@ -1041,7 +1042,8 @@ func TestRowWithinBoundsLike(t *testing.T) {
 	access := runtimeScanAccess(boundaries{{col: "name", matcher: LikeMatcher, lower: scm.NewString("%Klaus%"), upper: scm.NewString("%Klaus%")}})
 
 	// rowWithinBounds skips non-sorted columns entirely
-	inRange, _ := idx.rowWithinBounds(access, newScanIndexBounds(access), 1, -1, 0, 0, true, true, func(i int) scm.Scmer { return scm.NewString("anything") })
+	indexBounds := newScanIndexBounds(access)
+	inRange, _ := idx.rowWithinBounds(access, &indexBounds, 1, -1, 0, 0, true, true, func(i int) scm.Scmer { return scm.NewString("anything") })
 	if !inRange {
 		t.Error("expected inRange=true (LIKE skipped in rowWithinBounds)")
 	}

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -17,12 +17,13 @@ Copyright (C) 2023-2026  Carl-Philip Hänsch
 package storage
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
 )
 
-var benchmarkBoundaries boundaries
+var benchmarkBoundaries analyzedBoundaries
 
 func testEqualScanAccess(column string, value scm.Scmer) (scm.Scmer, []scm.Scmer) {
 	return scm.NewSlice([]scm.Scmer{
@@ -60,17 +61,84 @@ func TestCompileScanAccessReadsRuntimeValuesWithoutAllocation(t *testing.T) {
 	if !valid || access.len() != 2 {
 		t.Fatalf("scanAccessFromScheme returned valid=%v boundaries=%d", valid, access.len())
 	}
-	bound := boundaries{access.boundary(0), access.boundary(1)}
-	if bound[0].col != "tenant" || bound[0].matcher != EqualMatcher || bound[0].lower.Int() != 7 {
-		t.Fatalf("unexpected compiled equality: %#v", bound[0])
+	if access.boundaryColumn(0) != "tenant" || access.boundaryAnalyzer(0) != EqualMatcher || access.boundValue(0, false).Int() != 7 {
+		t.Fatal("unexpected compiled equality")
 	}
-	if bound[1].col != "created_at" || bound[1].matcher != RangeMatcher || bound[1].lower.Int() != 100 || !bound[1].lowerInclusive {
-		t.Fatalf("unexpected compiled range: %#v", bound[1])
+	if access.boundaryColumn(1) != "created_at" || access.boundaryAnalyzer(1) != RangeMatcher ||
+		access.boundValue(1, false).Int() != 100 || !access.boundaryLowerInclusive(1) {
+		t.Fatal("unexpected compiled range")
 	}
 	if allocs := testing.AllocsPerRun(1000, func() {
 		_, _ = scanAccessFromScheme(schema, values, nil)
 	}); allocs != 0 {
 		t.Fatalf("compiled scan access view allocated %.2f times per run, want 0", allocs)
+	}
+}
+
+func TestCompileScanAccessKeepsRangeEndpointsInAdjacentValues(t *testing.T) {
+	columns := scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewString("score")})
+	filter := scm.NewSlice([]scm.Scmer{
+		scm.NewSymbol("lambda"),
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("score")}),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("and"),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol(">="), scm.NewSymbol("score"), scm.NewSymbol("minimum")}),
+			scm.NewSlice([]scm.Scmer{scm.NewSymbol("<"), scm.NewSymbol("score"), scm.NewSymbol("maximum")}),
+		}),
+	})
+	schema, bindingExprs, ok := compileScanAccess(columns, filter)
+	if !ok || len(bindingExprs) != 2 {
+		t.Fatalf("range access compilation returned ok=%v bindings=%d", ok, len(bindingExprs))
+	}
+	items := schema.Slice()
+	if len(items) != scanAccessSchemaHeaderSize+1 || !items[scanAccessSchemaHeaderSize].IsCustom(TagScanBoundary) {
+		t.Fatalf("range schema = %s, want one Scheme boundary object", scm.String(schema))
+	}
+	boundary := ScanBoundaryFromScmer(items[scanAccessSchemaHeaderSize])
+	if boundary.Analyzer() != RangeMatcher || boundary.LowerSlot() != 0 || boundary.UpperSlot() != 1 ||
+		!boundary.LowerInclusive() || boundary.UpperInclusive() {
+		t.Fatalf("range boundary has slots [%d,%d] and inclusiveness [%v,%v]",
+			boundary.LowerSlot(), boundary.UpperSlot(), boundary.LowerInclusive(), boundary.UpperInclusive())
+	}
+	values := []scm.Scmer{scm.NewInt(10), scm.NewInt(20)}
+	access, valid := scanAccessFromScheme(schema, values, nil)
+	if !valid || access.boundValue(0, false).Int() != 10 || access.boundValue(0, true).Int() != 20 {
+		t.Fatal("range endpoints were not resolved from the adjacent values array")
+	}
+	if allocs := testing.AllocsPerRun(1000, func() {
+		_, _ = scanAccessFromScheme(schema, values, nil)
+	}); allocs != 0 {
+		t.Fatalf("range access binding allocated %.2f objects, want 0", allocs)
+	}
+}
+
+func TestScanBoundarySurvivesPersistedProcedureRoundTrip(t *testing.T) {
+	registerScanBoundaryFormats()
+	boundary := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
+		"utf8mb4_general_ci", true, 1, []string{"document"}, nil, "", true)
+	procedure := scm.NewProcStruct(scm.Proc{
+		Params: scm.NewSlice(nil),
+		Body: scm.NewSlice([]scm.Scmer{
+			scm.NewSymbol("quote"),
+			scm.NewSlice([]scm.Scmer{scm.NewInt(1), boundary}),
+		}),
+		En: &scm.Globalenv,
+	})
+	encoded, err := json.Marshal(procedure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded scm.Scmer
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	items := decoded.Proc().Body.Slice()[1].Slice()
+	restored := ScanBoundaryFromScmer(items[1])
+	if restored.ColumnName() != "tenant" || restored.Analyzer() != EqualMatcher ||
+		restored.LowerSlot() != 0 || restored.UpperSlot() != 0 || !restored.NullSafe() ||
+		restored.MapperSlot() != 1 || len(restored.MapColumns()) != 1 || restored.MapColumns()[0] != "document" ||
+		!restored.Mandatory() {
+		t.Fatalf("persisted boundary was not restored: %#v", restored)
 	}
 }
 
@@ -125,10 +193,10 @@ func TestCompileScanAccessCarriesComputedFormulaRuntimeConstants(t *testing.T) {
 	}), &scm.Globalenv)
 	descriptor := compileComputedScanIndex(mapper, []string{"doc"})
 	access, valid := scanAccessFromScheme(schema, []scm.Scmer{scm.NewInt(17), descriptor}, nil)
-	bound := access.boundary(0)
-	if !valid || bound.col != ".(json_value doc \"$.tenant\" \"UNSIGNED\")" ||
-		len(bound.mapCols) != 1 || bound.mapCols[0] != "doc" || !bound.mapFn.IsProc() {
-		t.Fatalf("unexpected computed access boundary: valid=%v boundary=%#v", valid, bound)
+	mapCols, mapFn := access.boundaryMap(0)
+	if !valid || access.boundaryColumn(0) != ".(json_value doc \"$.tenant\" \"UNSIGNED\")" ||
+		len(mapCols) != 1 || mapCols[0] != "doc" || !mapFn.IsProc() {
+		t.Fatalf("unexpected computed access boundary: valid=%v", valid)
 	}
 }
 
@@ -162,14 +230,10 @@ func TestCompileScanAccessEncodesBatchSlots(t *testing.T) {
 		t.Fatalf("batch access compilation returned ok=%v bindings=%d", ok, len(bindings))
 	}
 	access, valid := scanAccessFromScheme(schema, nil, nil)
-	bound := access.boundary(0)
-	if !valid || access.len() != 1 || !bound.lowerBatch || !bound.upperBatch ||
-		bound.lowerBatchSubidx != 0 || bound.upperBatchSubidx != 0 {
-		t.Fatalf("unexpected compiled batch boundary: valid=%v boundary=%#v", valid, bound)
+	bound, _ := access.boundaryParts(0)
+	if !valid || access.len() != 1 || bound.lowerSlot != -2 || bound.upperSlot != -2 {
+		t.Fatalf("unexpected compiled batch boundary: valid=%v", valid)
 	}
-	scratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(scratch)
-	access = access.useScratch(scratch)
 	batchData := []scm.Scmer{scm.NewInt(7), scm.NewInt(11)}
 	boundAccess := access.withBatch(1, batchData, 1)
 	indexBounds := newScanIndexBounds(boundAccess)
@@ -181,6 +245,21 @@ func TestCompileScanAccessEncodesBatchSlots(t *testing.T) {
 		indexBounds = newScanIndexBounds(boundAccess)
 	}); allocs != 0 {
 		t.Fatalf("batch index binding allocated %.2f objects, want zero", allocs)
+	}
+}
+
+func TestRuntimeScanAccessRejectsNullBatchProbe(t *testing.T) {
+	access := runtimeScanAccess(analyzedBoundaries{{
+		col: "id", matcher: EqualMatcher,
+		lowerBatch: true, lowerBatchSubidx: 0,
+		upperBatch: true, upperBatchSubidx: 0,
+		lowerInclusive: true, upperInclusive: true,
+	}})
+	if !access.impossibleBatch(1, []scm.Scmer{scm.NewNil()}, 0) {
+		t.Fatal("runtime batch equality accepted a NULL probe")
+	}
+	if access.impossibleBatch(1, []scm.Scmer{scm.NewInt(7)}, 0) {
+		t.Fatal("runtime batch equality rejected a non-NULL probe")
 	}
 }
 
@@ -207,16 +286,15 @@ func TestCompileScanAccessKeepsCandidateHooksAfterSortedPrefix(t *testing.T) {
 	if !valid || access.len() != 3 {
 		t.Fatalf("compiled hooks returned valid=%v boundaries=%d", valid, access.len())
 	}
-	bound := boundaries{access.boundary(0), access.boundary(1), access.boundary(2)}
-	if bound[0].matcher != EqualMatcher || bound[0].col != "tenant" {
-		t.Fatalf("equality is not the leading physical boundary: %#v", bound)
+	if access.boundaryAnalyzer(0) != EqualMatcher || access.boundaryColumn(0) != "tenant" {
+		t.Fatal("equality is not the leading physical boundary")
 	}
-	if bound[1].matcher != RecSetMatcher {
-		t.Fatalf("compiled access omitted the RecSet hook: %#v", bound)
+	if access.boundaryAnalyzer(1) != RecSetMatcher {
+		t.Fatal("compiled access omitted the RecSet hook")
 	}
-	like := bound[2]
-	if like.matcher != LikeMatcher || like.collation != "utf8mb4_unicode_ci" || like.lower.String() != "prefix%" {
-		t.Fatalf("unexpected LIKE hook: %#v", like)
+	if access.boundaryAnalyzer(2) != LikeMatcher || access.boundaryCollation(2) != "utf8mb4_unicode_ci" ||
+		access.boundValue(2, false).String() != "prefix%" {
+		t.Fatal("unexpected LIKE hook")
 	}
 }
 
@@ -284,7 +362,7 @@ func TestCompileScanAccessKeepsPointProbeWithDuplicatePredicate(t *testing.T) {
 		t.Fatalf("duplicate equality compiled=%v bindings=%d", compiled, len(bindings))
 	}
 	access, valid := scanAccessFromScheme(schema, []scm.Scmer{scm.NewInt(7)}, nil)
-	if !valid || access.len() != 1 || access.boundary(0).col != "id" {
+	if !valid || access.len() != 1 || access.boundaryColumn(0) != "id" {
 		t.Fatalf("duplicate equality access = %#v", access)
 	}
 }
@@ -318,7 +396,7 @@ func TestScanAccessNullProbeIsImpossibleWithoutTreatingNilCheckAsImpossible(t *t
 	if !valid || nilCheck.impossible() {
 		t.Fatal("IS NULL access must remain executable")
 	}
-	if boundary := nilCheck.boundary(0); !boundary.lower.IsNil() || !boundary.upper.IsNil() {
+	if !nilCheck.boundValue(0, false).IsNil() || !nilCheck.boundValue(0, true).IsNil() {
 		t.Fatal("IS NULL access must bind explicit NULL endpoints")
 	}
 	nullSafeCall := scm.Read(t.Name(), `(scan nil table_value
@@ -376,7 +454,7 @@ func TestCompileScanAccessPreservesSQLEqualityCollation(t *testing.T) {
 	if !compiled || !valid || access.len() != 1 {
 		t.Fatalf("SQL equality access compiled=%v valid=%v boundaries=%d", compiled, valid, access.len())
 	}
-	if got := access.boundary(0).collation; got != "utf8mb4_general_ci" {
+	if got := access.boundaryCollation(0); got != "utf8mb4_general_ci" {
 		t.Fatalf("SQL equality access collation = %q, want utf8mb4_general_ci", got)
 	}
 }
@@ -429,7 +507,7 @@ func TestSortedBoundariesDoNotCoverAfterRangeSuffix(t *testing.T) {
 	condition := buildProc([]string{"row_number"}, scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("<="), scm.NewSymbol("row_number"), scm.NewInt(1),
 	}))
-	access := runtimeScanAccess(boundaries{
+	access := runtimeScanAccess(analyzedBoundaries{
 		{col: "ID", matcher: RangeMatcher, upper: scm.NewInt(2), upperInclusive: true},
 		{col: "row_number", matcher: RangeMatcher, upper: scm.NewInt(1), upperInclusive: true},
 	})
@@ -585,7 +663,7 @@ func BenchmarkExtractBoundariesEqual(b *testing.B) {
 	})
 	condition := buildProc([]string{"x"}, body)
 	columns := []string{"id"}
-	var storage [4]columnboundaries
+	var storage [4]analyzedBoundary
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -609,7 +687,7 @@ func BenchmarkExtractBoundariesAnd(b *testing.B) {
 	})
 	condition := buildProc([]string{"tenant", "created"}, body)
 	columns := []string{"tenant", "created"}
-	var storage [4]columnboundaries
+	var storage [4]analyzedBoundary
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -633,7 +711,7 @@ func TestSimpleAndBoundariesReuseCallerStorage(t *testing.T) {
 	})
 	condition := buildProc([]string{"tenant", "created"}, body)
 	columns := []string{"tenant_id", "created_at"}
-	var storage [4]columnboundaries
+	var storage [4]analyzedBoundary
 
 	got := extractBoundariesInto(storage[:0], columns, condition)
 	if len(got) != 2 {
@@ -839,37 +917,37 @@ func TestComputedProcedureRejectsImplicitSessionRead(t *testing.T) {
 
 func TestScanBufferSizeUsesSmallBufferOnlyForBoundUniqueKey(t *testing.T) {
 	tbl := &table{Unique: []uniqueKey{{Id: "PRIMARY", Cols: []string{"tenant_id", "id"}}}}
-	point := func(col string, value scm.Scmer) columnboundaries {
-		return columnboundaries{
+	point := func(col string, value scm.Scmer) analyzedBoundary {
+		return analyzedBoundary{
 			col: col, matcher: EqualMatcher,
 			lower: value, lowerInclusive: true,
 			upper: value, upperInclusive: true,
 		}
 	}
 
-	if got := tbl.scanBufferSize(runtimeScanAccess(boundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewInt(42))})); got != uniquePointScanBufferSize {
+	if got := tbl.scanBufferSize(runtimeScanAccess(analyzedBoundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewInt(42))})); got != uniquePointScanBufferSize {
 		t.Fatalf("fully bound unique key buffer = %d, want %d", got, uniquePointScanBufferSize)
 	}
-	if got := tbl.scanBufferSize(runtimeScanAccess(boundaries{point("id", scm.NewInt(42))})); got != defaultScanBufferSize {
+	if got := tbl.scanBufferSize(runtimeScanAccess(analyzedBoundaries{point("id", scm.NewInt(42))})); got != defaultScanBufferSize {
 		t.Fatalf("partially bound unique key buffer = %d, want %d", got, defaultScanBufferSize)
 	}
-	if got := tbl.scanBufferSize(runtimeScanAccess(boundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewNil())})); got != defaultScanBufferSize {
+	if got := tbl.scanBufferSize(runtimeScanAccess(analyzedBoundaries{point("tenant_id", scm.NewInt(9)), point("id", scm.NewNil())})); got != defaultScanBufferSize {
 		t.Fatalf("NULL unique key buffer = %d, want %d", got, defaultScanBufferSize)
 	}
 	rangeBoundary := point("id", scm.NewInt(42))
 	rangeBoundary.matcher = RangeMatcher
-	if got := tbl.scanBufferSize(runtimeScanAccess(boundaries{point("tenant_id", scm.NewInt(9)), rangeBoundary})); got != defaultScanBufferSize {
+	if got := tbl.scanBufferSize(runtimeScanAccess(analyzedBoundaries{point("tenant_id", scm.NewInt(9)), rangeBoundary})); got != defaultScanBufferSize {
 		t.Fatalf("range-bound unique key buffer = %d, want %d", got, defaultScanBufferSize)
 	}
 }
 
 func TestWidenDistinctEqualityPointsProducesRange(t *testing.T) {
-	left := boundaries{{
+	left := analyzedBoundaries{{
 		col: "actor_id", matcher: EqualMatcher,
 		lower: scm.NewInt(7), lowerInclusive: true,
 		upper: scm.NewInt(7), upperInclusive: true,
 	}}
-	right := boundaries{{
+	right := analyzedBoundaries{{
 		col: "actor_id", matcher: EqualMatcher,
 		lower: scm.NewInt(8), lowerInclusive: true,
 		upper: scm.NewInt(8), upperInclusive: true,
@@ -888,12 +966,12 @@ func TestWidenDistinctEqualityPointsProducesRange(t *testing.T) {
 }
 
 func TestWidenNullAndValueEqualityPointsProducesRange(t *testing.T) {
-	left := boundaries{{
+	left := analyzedBoundaries{{
 		col: "actor_id", matcher: EqualMatcher,
 		lower: scm.NewNil(), lowerInclusive: true,
 		upper: scm.NewNil(), upperInclusive: true,
 	}}
-	right := boundaries{{
+	right := analyzedBoundaries{{
 		col: "actor_id", matcher: EqualMatcher,
 		lower: scm.NewInt(8), lowerInclusive: true,
 		upper: scm.NewInt(8), upperInclusive: true,
@@ -915,7 +993,7 @@ func TestWidenNullAndValueEqualityPointsProducesRange(t *testing.T) {
 }
 
 func TestEffectiveBoundaryInclusivenessUsesIndexedRange(t *testing.T) {
-	bounds := boundaries{
+	bounds := analyzedBoundaries{
 		{col: "discount", matcher: RangeMatcher, lowerInclusive: true, upperInclusive: true},
 		{col: "quantity", matcher: RangeMatcher, lowerInclusive: false, upperInclusive: false},
 	}
@@ -978,11 +1056,11 @@ func TestRecSetFilterBoundariesKeepLikeAndMembershipHooks(t *testing.T) {
 	if access.len() != 2 {
 		t.Fatalf("combined RecSet/LIKE boundaries = %d, want 2", access.len())
 	}
-	if access.boundary(0).matcher != LikeMatcher || access.boundary(1).matcher != RecSetMatcher {
+	if access.boundaryAnalyzer(0) != LikeMatcher || access.boundaryAnalyzer(1) != RecSetMatcher {
 		t.Fatalf("combined matcher order = (%s, %s), want (like, recset)",
-			access.boundary(0).matcher.Kind(), access.boundary(1).matcher.Kind())
+			access.boundaryAnalyzer(0).Kind(), access.boundaryAnalyzer(1).Kind())
 	}
-	if !access.boundary(1).lower.IsCustom(TagRecSet) || RecSetFromScmer(access.boundary(1).lower) != owner {
+	if !access.boundValue(1, false).IsCustom(TagRecSet) || RecSetFromScmer(access.boundValue(1, false)) != owner {
 		t.Fatal("RecSet boundary did not retain the exact input membership")
 	}
 }
@@ -1016,7 +1094,7 @@ func TestMatcherIsSorted(t *testing.T) {
 // TestRowWithinBoundsEqual verifies sorted (equal) column matching via lower/upper.
 func TestRowWithinBoundsEqual(t *testing.T) {
 	idx := &StorageIndex{Cols: []string{"id"}, ColMatchers: []IndexAnalyzer{EqualMatcher}}
-	access := runtimeScanAccess(boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), upper: scm.NewInt(5)}})
+	access := runtimeScanAccess(analyzedBoundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), upper: scm.NewInt(5)}})
 	indexBounds := newScanIndexBounds(access)
 
 	inRange, _ := idx.rowWithinBounds(access, &indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(5) })
@@ -1035,7 +1113,7 @@ func TestRowWithinBoundsEqual(t *testing.T) {
 // TestRowWithinBoundsLike verifies that LIKE columns are skipped in rowWithinBounds.
 func TestRowWithinBoundsLike(t *testing.T) {
 	idx := &StorageIndex{Cols: []string{"name"}, ColMatchers: []IndexAnalyzer{LikeMatcher}}
-	access := runtimeScanAccess(boundaries{{col: "name", matcher: LikeMatcher, lower: scm.NewString("%Klaus%"), upper: scm.NewString("%Klaus%")}})
+	access := runtimeScanAccess(analyzedBoundaries{{col: "name", matcher: LikeMatcher, lower: scm.NewString("%Klaus%"), upper: scm.NewString("%Klaus%")}})
 
 	// rowWithinBounds skips non-sorted columns entirely
 	indexBounds := newScanIndexBounds(access)

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -459,6 +459,29 @@ func TestCompileScanAccessPreservesSQLEqualityCollation(t *testing.T) {
 	}
 }
 
+func TestComputedScanAccessReusesCanonicalBinaryIndexOrder(t *testing.T) {
+	const computedColumn = ".(json_value doc \"$.tenant\" \"UNSIGNED\")"
+	schema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 1, -1),
+		newScanBoundarySpec(computedColumn, EqualMatcher, 0, 0, true, true,
+			"utf8mb4_general_ci", true, 1, []string{"doc"}, nil, "", false),
+		scm.NewString("doc"),
+	})
+	values := []scm.Scmer{
+		scm.NewInt(17),
+		scm.NewSlice([]scm.Scmer{scm.NewString(computedColumn), scm.NewNil()}),
+	}
+	access, valid := scanAccessFromScheme(schema, values, nil)
+	if !valid {
+		t.Fatal("computed scan access did not compile")
+	}
+	table := &table{Name: "documents", Columns: []*column{{Name: "doc", Collation: "utf8mb4_general_ci"}}}
+	index := &StorageIndex{Cols: []string{computedColumn}, ColOrderMeta: []string{"bin:asc"}}
+	if !indexOrderMatchesScanAccess(table, index, 0, access) {
+		t.Fatal("computed access did not reuse its canonical binary index order")
+	}
+}
+
 func TestSortedBoundariesCoverCondition(t *testing.T) {
 	body := scm.NewSlice([]scm.Scmer{
 		scm.NewSymbol("equal??"),

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -64,7 +64,7 @@ func TestCompileScanAccessReadsRuntimeValuesWithoutAllocation(t *testing.T) {
 	if !valid || access.len() != 2 {
 		t.Fatalf("scanAccessFromScheme returned valid=%v boundaries=%d", valid, access.len())
 	}
-	bound := materializeScanAccess(access)
+	bound := boundaries{access.boundary(0), access.boundary(1)}
 	if bound[0].col != "tenant" || bound[0].matcher != EqualMatcher || bound[0].lower.Int() != 7 {
 		t.Fatalf("unexpected compiled equality: %#v", bound[0])
 	}
@@ -171,6 +171,21 @@ func TestCompileScanAccessEncodesBatchSlots(t *testing.T) {
 		bound.lowerBatchSubidx != 0 || bound.upperBatchSubidx != 0 {
 		t.Fatalf("unexpected compiled batch boundary: valid=%v boundary=%#v", valid, bound)
 	}
+	scratch := acquireScanAnalyzeScratch()
+	defer releaseScanAnalyzeScratch(scratch)
+	access = access.useScratch(scratch)
+	batchData := []scm.Scmer{scm.NewInt(7), scm.NewInt(11)}
+	boundAccess := access.withBatch(1, batchData, 1)
+	indexBounds := newScanIndexBounds(boundAccess)
+	if indexBounds.lower(0).Int() != 11 || indexBounds.upperLast().Int() != 11 {
+		t.Fatalf("batch index view = [%v,%v], want [11,11]", indexBounds.lower(0), indexBounds.upperLast())
+	}
+	if allocs := testing.AllocsPerRun(1000, func() {
+		boundAccess = access.withBatch(1, batchData, 1)
+		indexBounds = newScanIndexBounds(boundAccess)
+	}); allocs != 0 {
+		t.Fatalf("batch index binding allocated %.2f objects, want zero", allocs)
+	}
 }
 
 func TestCompileScanAccessKeepsCandidateHooksAfterSortedPrefix(t *testing.T) {
@@ -196,7 +211,7 @@ func TestCompileScanAccessKeepsCandidateHooksAfterSortedPrefix(t *testing.T) {
 	if !valid || access.len() != 3 {
 		t.Fatalf("compiled hooks returned valid=%v boundaries=%d", valid, access.len())
 	}
-	bound := materializeScanAccess(access)
+	bound := boundaries{access.boundary(0), access.boundary(1), access.boundary(2)}
 	if bound[0].matcher != EqualMatcher || bound[0].col != "tenant" {
 		t.Fatalf("equality is not the leading physical boundary: %#v", bound)
 	}
@@ -908,8 +923,8 @@ func TestEffectiveBoundaryInclusivenessUsesIndexedRange(t *testing.T) {
 		{col: "discount", matcher: RangeMatcher, lowerInclusive: true, upperInclusive: true},
 		{col: "quantity", matcher: RangeMatcher, lowerInclusive: false, upperInclusive: false},
 	}
-	lower, _ := indexFromBoundaries(bounds)
-	lowerInclusive, upperInclusive := effectiveBoundaryInclusiveness(runtimeScanAccess(bounds), lower)
+	access := runtimeScanAccess(bounds)
+	lowerInclusive, upperInclusive := effectiveBoundaryInclusiveness(access, newScanIndexBounds(access))
 	if !lowerInclusive || !upperInclusive {
 		t.Fatalf("effective boundary inclusiveness = (%t, %t), want (true, true)", lowerInclusive, upperInclusive)
 	}
@@ -1004,13 +1019,14 @@ func TestMatcherIsSorted(t *testing.T) {
 // TestRowWithinBoundsEqual verifies sorted (equal) column matching via lower/upper.
 func TestRowWithinBoundsEqual(t *testing.T) {
 	idx := &StorageIndex{Cols: []string{"id"}, ColMatchers: []IndexAnalyzer{EqualMatcher}}
-	lower := []scm.Scmer{scm.NewInt(5)}
+	access := runtimeScanAccess(boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), upper: scm.NewInt(5)}})
+	indexBounds := newScanIndexBounds(access)
 
-	inRange, _ := idx.rowWithinBounds(scanAccess{}, 1, 0, 1, 0, lower, scm.NewInt(5), true, true, func(i int) scm.Scmer { return scm.NewInt(5) })
+	inRange, _ := idx.rowWithinBounds(access, indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(5) })
 	if !inRange {
 		t.Error("expected match for equal value")
 	}
-	inRange, beyond := idx.rowWithinBounds(scanAccess{}, 1, 0, 1, 0, lower, scm.NewInt(5), true, true, func(i int) scm.Scmer { return scm.NewInt(10) })
+	inRange, beyond := idx.rowWithinBounds(access, indexBounds, 1, 0, 1, 0, true, true, func(i int) scm.Scmer { return scm.NewInt(10) })
 	if inRange {
 		t.Error("expected no match for different value")
 	}
@@ -1022,10 +1038,10 @@ func TestRowWithinBoundsEqual(t *testing.T) {
 // TestRowWithinBoundsLike verifies that LIKE columns are skipped in rowWithinBounds.
 func TestRowWithinBoundsLike(t *testing.T) {
 	idx := &StorageIndex{Cols: []string{"name"}, ColMatchers: []IndexAnalyzer{LikeMatcher}}
-	lower := []scm.Scmer{scm.NewString("%Klaus%")}
+	access := runtimeScanAccess(boundaries{{col: "name", matcher: LikeMatcher, lower: scm.NewString("%Klaus%"), upper: scm.NewString("%Klaus%")}})
 
 	// rowWithinBounds skips non-sorted columns entirely
-	inRange, _ := idx.rowWithinBounds(scanAccess{}, 1, -1, 0, 0, lower, scm.NewString("%Klaus%"), true, true, func(i int) scm.Scmer { return scm.NewString("anything") })
+	inRange, _ := idx.rowWithinBounds(access, newScanIndexBounds(access), 1, -1, 0, 0, true, true, func(i int) scm.Scmer { return scm.NewString("anything") })
 	if !inRange {
 		t.Error("expected inRange=true (LIKE skipped in rowWithinBounds)")
 	}

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -27,18 +27,14 @@ var benchmarkBoundaries boundaries
 func testEqualScanAccess(column string, value scm.Scmer) (scm.Scmer, []scm.Scmer) {
 	return scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
-		scm.NewString("equal"), scm.NewString(column), newScanAccessBoundaryMeta(0, 0, 3), scm.NewString(""),
+		newScanBoundarySpec(column, EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
 	}), []scm.Scmer{value}
 }
 
 func testUpperScanAccess(column string, value scm.Scmer, inclusive bool) (scm.Scmer, []scm.Scmer) {
-	flags := int64(0)
-	if inclusive {
-		flags = 2
-	}
 	return scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
-		scm.NewString("range"), scm.NewString(column), newScanAccessBoundaryMeta(-1, 0, flags), scm.NewString(""),
+		newScanBoundarySpec(column, RangeMatcher, -1, 0, false, inclusive, "", false, -1, nil, nil, "", false),
 	}), []scm.Scmer{value}
 }
 
@@ -115,8 +111,8 @@ func TestCompileScanAccessCarriesComputedFormulaRuntimeConstants(t *testing.T) {
 	if meta.projections != 1 || items[len(items)-1].String() != "doc" {
 		t.Fatalf("computed access schema omitted mapper columns: %s", scm.String(schema))
 	}
-	boundaryMeta := decodeScanAccessBoundaryMeta(items[scanAccessSchemaHeaderSize+2])
-	if mapperSlot := int(boundaryMeta.flags>>3) - 1; mapperSlot != 1 {
+	boundary := ScanBoundaryFromScmer(items[scanAccessSchemaHeaderSize])
+	if mapperSlot := boundary.MapperSlot(); mapperSlot != 1 {
 		t.Fatalf("computed mapper slot = %d, want 1", mapperSlot)
 	}
 
@@ -177,8 +173,8 @@ func TestCompileScanAccessEncodesBatchSlots(t *testing.T) {
 	batchData := []scm.Scmer{scm.NewInt(7), scm.NewInt(11)}
 	boundAccess := access.withBatch(1, batchData, 1)
 	indexBounds := newScanIndexBounds(boundAccess)
-	if indexBounds.lower(0).Int() != 11 || indexBounds.upperLast().Int() != 11 {
-		t.Fatalf("batch index view = [%v,%v], want [11,11]", indexBounds.lower(0), indexBounds.upperLast())
+	if indexBounds.lower(access, 0).Int() != 11 || indexBounds.upperLast().Int() != 11 {
+		t.Fatalf("batch index view = [%v,%v], want [11,11]", indexBounds.lower(access, 0), indexBounds.upperLast())
 	}
 	if allocs := testing.AllocsPerRun(1000, func() {
 		boundAccess = access.withBatch(1, batchData, 1)
@@ -316,7 +312,7 @@ func TestScanAccessNullProbeIsImpossibleWithoutTreatingNilCheckAsImpossible(t *t
 	}
 	nilCheckSchema := scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
-		scm.NewString("equal"), scm.NewString("id"), newScanAccessBoundaryMeta(-1, -1, 3), scm.NewString(""),
+		newScanBoundarySpec("id", EqualMatcher, -1, -1, true, true, "", false, -1, nil, nil, "", false),
 	})
 	nilCheck, valid := scanAccessFromScheme(nilCheckSchema, nil, nil)
 	if !valid || nilCheck.impossible() {
@@ -976,7 +972,7 @@ func TestRecSetFilterBoundariesKeepLikeAndMembershipHooks(t *testing.T) {
 	owner := &recSet{}
 	schema := scm.NewSlice([]scm.Scmer{
 		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
-		scm.NewString("like"), scm.NewString("search"), newScanAccessBoundaryMeta(0, 0, 3), scm.NewString(""),
+		newScanBoundarySpec("search", LikeMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
 	})
 	access := recSetScanAccess(owner, schema, []scm.Scmer{scm.NewString("%needle%")})
 	if access.len() != 2 {

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -607,11 +607,11 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 	}
 	partCount := analyzeOrcPartition(col)
 
-	// Build boundaries for index-accelerated lookup.
+	// Build analyzer results for index-accelerated lookup.
 	// Partition columns → equality points; order columns → range from mutation key.
-	var bounds boundaries
+	var bounds analyzedBoundaries
 	for i := 0; i < partCount && i < nCols; i++ {
-		bounds = append(bounds, columnboundaries{
+		bounds = append(bounds, analyzedBoundary{
 			col: col.OrcSortCols[i], matcher: EqualMatcher, lower: sortKeys[i], lowerInclusive: true,
 			upper: sortKeys[i], upperInclusive: true,
 		})
@@ -621,12 +621,12 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 	for i := partCount; i < nCols; i++ {
 		desc := i < len(col.OrcSortDirs) && col.OrcSortDirs[i]
 		if desc {
-			bounds = append(bounds, columnboundaries{
+			bounds = append(bounds, analyzedBoundary{
 				col: col.OrcSortCols[i], matcher: RangeMatcher, lower: scm.NewNil(), lowerInclusive: false,
 				upper: sortKeys[i], upperInclusive: true,
 			})
 		} else {
-			bounds = append(bounds, columnboundaries{
+			bounds = append(bounds, analyzedBoundary{
 				col: col.OrcSortCols[i], matcher: RangeMatcher, lower: sortKeys[i], lowerInclusive: true,
 				upper: scm.NewNil(), upperInclusive: false,
 			})

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -954,17 +954,20 @@ func extractCompiledScanEqualityJoins(schemaExpr, valuesExpr scm.Scmer, computor
 	count := meta.count
 	for i := 0; i < count; i++ {
 		offset := scanAccessSchemaHeaderSize + i*scanAccessBoundaryStride
-		if offset+scanAccessBoundaryStride > len(schema) || stripSourceInfo(schema[offset]).String() != "equal" {
+		if offset+scanAccessBoundaryStride > len(schema) || !stripSourceInfo(schema[offset]).IsCustom(TagScanBoundary) {
 			continue
 		}
-		boundaryMeta := decodeScanAccessBoundaryMeta(stripSourceInfo(schema[offset+2]))
-		lowerSlot := boundaryMeta.lowerSlot
-		upperSlot := boundaryMeta.upperSlot
+		boundary := ScanBoundaryFromScmer(stripSourceInfo(schema[offset]))
+		if boundary.Analyzer() != EqualMatcher {
+			continue
+		}
+		lowerSlot := boundary.LowerSlot()
+		upperSlot := boundary.UpperSlot()
 		if lowerSlot < 0 || lowerSlot != upperSlot || lowerSlot >= len(valueItems) {
 			continue
 		}
 		if inputCol, ok := compiledScanOuterColumn(valueItems[lowerSlot], computorParams); ok {
-			srcCols = append(srcCols, stripSourceInfo(schema[offset+1]).String())
+			srcCols = append(srcCols, boundary.ColumnName())
 			inputCols = append(inputCols, inputCol)
 		}
 	}

--- a/storage/compute.go
+++ b/storage/compute.go
@@ -632,7 +632,6 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 			})
 		}
 	}
-	lower, upperLast := indexFromBoundaries(bounds)
 
 	// Build condition function for post-index filtering (index may return superset).
 	condFn := func(rowVals []scm.Scmer) bool {
@@ -683,7 +682,7 @@ func (t *table) invalidateORCFromSortKey(colName string, sortKeys []scm.Scmer) {
 			s.ensureMainCount(false)
 			var buf [1024]uint32
 			rowVals := make([]scm.Scmer, nCols)
-			s.iterateIndex(nil, runtimeScanAccess(bounds), lower, upperLast, len(s.inserts), buf[:], 1, nil, func(batch []uint32) bool {
+			s.iterateIndex(nil, runtimeScanAccess(bounds), len(s.inserts), buf[:], 1, nil, func(batch []uint32) bool {
 				for _, idx := range batch {
 					if s.deletions.Get(uint(idx)) {
 						continue

--- a/storage/compute_trigger_test.go
+++ b/storage/compute_trigger_test.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -255,16 +254,21 @@ func TestLookupComputeTriggersInvalidateMatchingRows(t *testing.T) {
 }
 
 func TestExtractScanJoinInfoUsesCompiledAccessWhenResidualIsEmpty(t *testing.T) {
-	header := scm.ToInt(newScanAccessHeader(1, scanAccessConsumerScan, 0, -1))
-	boundaryMeta := scm.ToInt(newScanAccessBoundaryMeta(0, 0, 3))
-	source := fmt.Sprintf(`(lambda (ref_id)
+	source := `(lambda (ref_id)
 		(scan nil (table "tcompileddependency" "src")
-			'(%d "equal" "source_ref" %d "")
+			'()
 			(list ref_id)
 			'() (lambda () true)
 			'("value") (lambda (acc value) value)
-			nil nil false))`, header, boundaryMeta)
+			nil nil false))`
 	computor := scm.Read(t.Name(), source)
+	root := stripSourceInfo(computor).Slice()
+	scan := stripSourceInfo(root[2]).Slice()
+	schema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
+		newScanBoundarySpec("source_ref", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
+	})
+	scan[3] = scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema})
 	refs := extractScanJoinInfo(computor)
 	if len(refs) != 1 || refs[0].schema != "tcompileddependency" || refs[0].table != "src" ||
 		len(refs[0].srcCols) != 1 || refs[0].srcCols[0] != "source_ref" ||

--- a/storage/index-recset.go
+++ b/storage/index-recset.go
@@ -24,7 +24,7 @@ type recSetMatcher struct{}
 // non-ordering boundary on its backing table. Scan operators retain one common
 // table/index pipeline; choosing whether the base index or this RecSet drives
 // iteration is an execution-kernel decision, not a second relational shape.
-func appendRecSetBoundary(bounds boundaries, source *recSet) boundaries {
+func appendRecSetBoundary(bounds analyzedBoundaries, source *recSet) analyzedBoundaries {
 	if source == nil {
 		return bounds
 	}
@@ -32,7 +32,7 @@ func appendRecSetBoundary(bounds boundaries, source *recSet) boundaries {
 		panic("recset scan source has no backing table")
 	}
 	value := NewRecSetScmer(source)
-	return append(bounds, columnboundaries{
+	return append(bounds, analyzedBoundary{
 		col:            "$recset_contains",
 		matcher:        RecSetMatcher,
 		lower:          value,
@@ -51,11 +51,14 @@ func smallestRecSetBoundary(bounds scanAccess, shard *storageShard) (*recSetShar
 	var smallest *recSetShard
 	found := false
 	for i := 0; i < bounds.len(); i++ {
-		bound := bounds.boundary(i)
-		if !matcherKindEqual(bound.matcher, RecSetMatcher) || !bound.lower.IsCustom(TagRecSet) {
+		if !matcherKindEqual(bounds.boundaryAnalyzer(i), RecSetMatcher) {
 			continue
 		}
-		source := RecSetFromScmer(bound.lower)
+		lower := bounds.boundValue(i, false)
+		if !lower.IsCustom(TagRecSet) {
+			continue
+		}
+		source := RecSetFromScmer(lower)
 		if source == nil || source.table != shard.t {
 			continue
 		}

--- a/storage/index-strlike.go
+++ b/storage/index-strlike.go
@@ -64,7 +64,7 @@ func (m *likeMatcher) Analyze(ctx IndexAnalyzeContext, node scm.Scmer) (IndexBou
 		prefix := pattern[:wildcard]
 		upper := []byte(prefix)
 		upper[len(upper)-1]++
-		return columnboundaries{
+		return analyzedBoundary{
 			col: col, matcher: RangeMatcher, lower: scm.NewString(prefix), upper: scm.NewString(string(upper)),
 			lowerInclusive: true, upperInclusive: false,
 		}, true

--- a/storage/index.go
+++ b/storage/index.go
@@ -82,6 +82,10 @@ type indexGetterScratch struct {
 	indexBounds scanIndexBounds
 }
 
+var scanIndexBoundsPool = sync.Pool{
+	New: func() any { return new(scanIndexBounds) },
+}
+
 var indexGetterScratchPool = sync.Pool{
 	New: func() any { return new(indexGetterScratch) },
 }
@@ -484,7 +488,7 @@ func (s *StorageIndex) boundKernel(bounds scanAccess, cmpCols int) (firstSorted 
 	return
 }
 
-func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds scanIndexBounds, cmpCols int, lastSorted int, sortedMask uint64, unboundedMask uint64, lowerInclusive bool, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
+func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds *scanIndexBounds, cmpCols int, lastSorted int, sortedMask uint64, unboundedMask uint64, lowerInclusive bool, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
 	for i := 0; i < cmpCols; i++ {
 		if i < 64 && sortedMask&(uint64(1)<<i) == 0 {
 			continue // non-sorted: block-skip handles this, scan() filters exact
@@ -540,7 +544,7 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds scanIndexB
 // must never be interpreted as the next column of a longer reusable index.
 // Matching the column and matcher kind here preserves prefix reuse without
 // coupling an invocation-only matcher to an unrelated physical suffix.
-func (s *StorageIndex) queryIndexPrefixLen(bounds scanAccess, indexBounds scanIndexBounds) int {
+func (s *StorageIndex) queryIndexPrefixLen(bounds scanAccess, indexBounds *scanIndexBounds) int {
 	limit := indexBounds.len()
 	if limit > bounds.len() {
 		limit = bounds.len()
@@ -626,7 +630,7 @@ func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols scanAccess, ma
 	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, usageWeight, false, exactMain, nil, nil, nil, callback)
 }
 
-func effectiveBoundaryInclusiveness(cols scanAccess, indexBounds scanIndexBounds) (bool, bool) {
+func effectiveBoundaryInclusiveness(cols scanAccess, indexBounds *scanIndexBounds) (bool, bool) {
 	if indexBounds.len() == 0 {
 		return true, true
 	}
@@ -640,7 +644,12 @@ func effectiveBoundaryInclusiveness(cols scanAccess, indexBounds scanIndexBounds
 }
 
 func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	indexBounds := newScanIndexBounds(cols)
+	indexBounds := scanIndexBoundsPool.Get().(*scanIndexBounds)
+	*indexBounds = newScanIndexBounds(cols)
+	defer func() {
+		*indexBounds = scanIndexBounds{}
+		scanIndexBoundsPool.Put(indexBounds)
+	}()
 	if exactMain != nil {
 		*exactMain = false
 	}
@@ -654,7 +663,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 			sortedEnd++
 		}
 		if sortedEnd < cols.len() && indexBounds.len() > sortedEnd {
-			indexBounds = indexBounds.truncate(sortedEnd)
+			indexBounds.truncate(sortedEnd)
 		}
 	}
 
@@ -1251,7 +1260,7 @@ func unorderedRecSetDominates(recsetRows, indexSpanRows int64) bool {
 // positions, then bulk-decodes the forward permutation back to RecIDs. If no
 // inverse exists yet, the same bounded buffer is sorted by the index key
 // callbacks; this keeps a cold sparse query from degrading to a full scan.
-func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexState, part *recSetShard, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, mainStart int, mainEnd int, maxInsertIndex int, buf []uint32, cols []colGetter, persistent bool, ordered bool, exactMain *bool, callback func([]uint32) bool) {
+func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexState, part *recSetShard, bounds scanAccess, indexBounds *scanIndexBounds, upperInclusive bool, mainStart int, mainEnd int, maxInsertIndex int, buf []uint32, cols []colGetter, persistent bool, ordered bool, exactMain *bool, callback func([]uint32) bool) {
 	if part == nil || part.count == 0 {
 		return
 	}
@@ -1408,7 +1417,7 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 // bindRowMatchers returns only matcher state. The terminal callback deliberately
 // stays outside this value: storing it in a returned wrapper closure makes the
 // complete shard scan state escape even though index iteration is synchronous.
-func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
+func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBounds *scanIndexBounds, upperInclusive bool, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
 	var matchers []IndexRowMatcher
 	if !persistent {
 		matchers = s.bindColdRangeMatcher(tx, bounds, indexBounds, upperInclusive, cols)
@@ -1463,7 +1472,7 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBo
 // persistent-index branch where the closure is never constructed.
 //
 //go:noinline
-func (s *StorageIndex) bindColdRangeMatcher(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, cols []colGetter) []IndexRowMatcher {
+func (s *StorageIndex) bindColdRangeMatcher(tx *TxContext, bounds scanAccess, indexBounds *scanIndexBounds, upperInclusive bool, cols []colGetter) []IndexRowMatcher {
 	cmpCols := s.queryIndexPrefixLen(bounds, indexBounds)
 	if cmpCols == 0 {
 		return nil
@@ -1550,7 +1559,7 @@ func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds scanAccess) 
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds *scanIndexBounds, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -1558,7 +1567,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds sca
 	// concurrent writer is waiting for s.t.mu.Lock() (write-preferring RWMutex).
 	getterScratch := indexGetterScratchPool.Get().(*indexGetterScratch)
 	cols := s.buildGetters(tx, getterScratch.getters[:])
-	getterScratch.indexBounds = indexBounds
+	getterScratch.indexBounds = *indexBounds
 	defer func() {
 		clear(getterScratch.getters[:])
 		getterScratch.indexBounds = scanIndexBounds{}

--- a/storage/index.go
+++ b/storage/index.go
@@ -32,6 +32,7 @@ import "github.com/launix-de/memcp/scm"
 type indexPair struct {
 	itemid      int // -1 for reference items
 	data        []scm.Scmer
+	reference   *scanIndexBounds
 	compareCols int // reference-only prefix length; zero compares the complete key
 }
 
@@ -77,7 +78,8 @@ type colGetter struct {
 const inlineIndexGetters = 8
 
 type indexGetterScratch struct {
-	getters [inlineIndexGetters]colGetter
+	getters     [inlineIndexGetters]colGetter
+	indexBounds scanIndexBounds
 }
 
 var indexGetterScratchPool = sync.Pool{
@@ -482,7 +484,7 @@ func (s *StorageIndex) boundKernel(bounds scanAccess, cmpCols int) (firstSorted 
 	return
 }
 
-func (s *StorageIndex) rowWithinBounds(bounds scanAccess, cmpCols int, lastSorted int, sortedMask uint64, unboundedMask uint64, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
+func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds scanIndexBounds, cmpCols int, lastSorted int, sortedMask uint64, unboundedMask uint64, lowerInclusive bool, upperInclusive bool, getter func(int) scm.Scmer) (inRange bool, beyond bool) {
 	for i := 0; i < cmpCols; i++ {
 		if i < 64 && sortedMask&(uint64(1)<<i) == 0 {
 			continue // non-sorted: block-skip handles this, scan() filters exact
@@ -502,6 +504,7 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, cmpCols int, lastSorte
 			}
 		}
 		if i == lastSorted {
+			upperLast := indexBounds.upperLast()
 			if !upperLast.IsNil() {
 				if upperInclusive {
 					if s.compareAt(i, upperLast, v) < 0 {
@@ -511,15 +514,15 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, cmpCols int, lastSorte
 					return false, true
 				}
 			}
-			if len(lower) > i && !lower[i].IsNil() {
-				comparison := s.compareAt(i, v, lower[i])
+			if indexBounds.len() > i && !indexBounds.lower(i).IsNil() {
+				comparison := s.compareAt(i, v, indexBounds.lower(i))
 				if comparison < 0 || (comparison == 0 && !lowerInclusive) {
 					return false, false
 				}
 			}
 			continue
 		}
-		cmp := s.compareAt(i, v, lower[i])
+		cmp := s.compareAt(i, v, indexBounds.lower(i))
 		if cmp == 0 {
 			continue
 		}
@@ -537,8 +540,8 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, cmpCols int, lastSorte
 // must never be interpreted as the next column of a longer reusable index.
 // Matching the column and matcher kind here preserves prefix reuse without
 // coupling an invocation-only matcher to an unrelated physical suffix.
-func (s *StorageIndex) queryIndexPrefixLen(bounds scanAccess, lower []scm.Scmer) int {
-	limit := len(lower)
+func (s *StorageIndex) queryIndexPrefixLen(bounds scanAccess, indexBounds scanIndexBounds) int {
+	limit := indexBounds.len()
 	if limit > bounds.len() {
 		limit = bounds.len()
 	}
@@ -592,42 +595,42 @@ func (s *StorageIndex) compareMainAndDelta(state *storageIndexState, mainRecid u
 // The callback receives batches of record IDs and returns false to stop iteration.
 // Buffer size controls early-out granularity: use small buffers (e.g. [8]uint32)
 // for existence checks, large buffers (e.g. [1024]uint32) for full scans.
-func (t *storageShard) iterateIndex(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, nil, nil, selected, callback)
+func (t *storageShard) iterateIndex(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, usageWeight float64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, usageWeight, false, nil, nil, nil, selected, callback)
 }
 
 // iterateIndexEstimate additionally reports the complete candidate range found
 // by an active sorted index. Delta rows are included conservatively because
 // they are merged after the main range and may still satisfy the predicate.
-func (t *storageShard) iterateIndexEstimate(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, 0, false, nil, nil, candidateSpan, selected, callback)
+func (t *storageShard) iterateIndexEstimate(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, 0, false, nil, nil, candidateSpan, selected, callback)
 }
 
-func (t *storageShard) iterateIndexOrdered(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, limit int, boundaryCoveredLimit bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit, boundaryCoveredLimit: boundaryCoveredLimit}, nil, selected, callback)
+func (t *storageShard) iterateIndexOrdered(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, usageWeight float64, limit int, boundaryCoveredLimit bool, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, usageWeight, false, nil, &indexIterationOptions{orderedLimit: limit, boundaryCoveredLimit: boundaryCoveredLimit}, nil, selected, callback)
 }
 
-func (t *storageShard) iterateIndexForce(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexForce(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, countUsage bool, callback func([]uint32) bool) {
 	usageWeight := 0.0
 	if countUsage {
 		usageWeight = 1.0
 	}
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, true, nil, nil, nil, nil, callback)
+	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, usageWeight, true, nil, nil, nil, nil, callback)
 }
 
-func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, countUsage bool, exactMain *bool, callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexMatchAware(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, countUsage bool, exactMain *bool, callback func([]uint32) bool) {
 	usageWeight := 0.0
 	if countUsage {
 		usageWeight = 1.0
 	}
-	t.iterateIndexEx(tx, cols, lower, upperLast, maxInsertIndex, buf, usageWeight, false, exactMain, nil, nil, nil, callback)
+	t.iterateIndexEx(tx, cols, maxInsertIndex, buf, usageWeight, false, exactMain, nil, nil, nil, callback)
 }
 
-func effectiveBoundaryInclusiveness(cols scanAccess, lower []scm.Scmer) (bool, bool) {
-	if len(lower) == 0 {
+func effectiveBoundaryInclusiveness(cols scanAccess, indexBounds scanIndexBounds) (bool, bool) {
+	if indexBounds.len() == 0 {
 		return true, true
 	}
-	for i := len(lower) - 1; i >= 0; i-- {
+	for i := indexBounds.len() - 1; i >= 0; i-- {
 		bound := cols.boundary(i)
 		if bound.matcher.IsSorted() {
 			return bound.lowerInclusive, bound.upperInclusive
@@ -636,7 +639,8 @@ func effectiveBoundaryInclusiveness(cols scanAccess, lower []scm.Scmer) (bool, b
 	return true, true
 }
 
-func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, lower []scm.Scmer, upperLast scm.Scmer, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+	indexBounds := newScanIndexBounds(cols)
 	if exactMain != nil {
 		*exactMain = false
 	}
@@ -649,28 +653,28 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, lower []sc
 		for sortedEnd < cols.len() && cols.boundary(sortedEnd).matcher.IsSorted() {
 			sortedEnd++
 		}
-		if sortedEnd < cols.len() && len(lower) > sortedEnd {
-			lower = lower[:sortedEnd]
+		if sortedEnd < cols.len() && indexBounds.len() > sortedEnd {
+			indexBounds = indexBounds.truncate(sortedEnd)
 		}
 	}
 
-	// indexFromBoundaries may shorten lower when more than one range column is
+	// The index view may shorten access when more than one range column is
 	// present because an ordered index can use only one range suffix. Read the
 	// flags from that effective last boundary, not from a later condition that
 	// is evaluated only by the scan predicate.
-	lowerIncl, upperIncl := effectiveBoundaryInclusiveness(cols, lower)
+	lowerIncl, upperIncl := effectiveBoundaryInclusiveness(cols, indexBounds)
 	// Exact RecSet membership is a query-bound overlay. A prepared base index
 	// needs to cover only the sorted/access prefix; RecSetMatcher binds to that
 	// index at invocation time and must not create one index identity per source
 	// carrier. Retain a lone RecSet boundary so unordered scans can still use the
 	// common matcher machinery without a zero-column StorageIndex.
-	indexCols := len(lower)
+	indexCols := indexBounds.len()
 	for indexCols > 1 && indexCols <= cols.len() && matcherKindEqual(cols.boundary(indexCols-1).matcher, RecSetMatcher) {
 		indexCols--
 	}
 
 	// check if we found conditions
-	if len(lower) > 0 {
+	if indexBounds.len() > 0 {
 		// find an index that has at least the columns in that order we're searching for
 		// if the index is inactive, use the other one
 	retry_indexscan:
@@ -697,7 +701,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, lower []sc
 					}
 				}
 				// this index fits!
-				index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
+				index.iterate(tx, cols, indexBounds, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 				return
 			}
 		skip_index:
@@ -737,7 +741,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, lower []sc
 				if covered {
 					// longer index covers this query; use it instead of creating a shorter one
 					t.indexMutex.Unlock()
-					index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
+					index.iterate(tx, cols, indexBounds, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 					return
 				}
 			}
@@ -774,7 +778,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, lower []sc
 		}
 		t.Indexes = append(t.Indexes, index)
 		t.indexMutex.Unlock()
-		index.iterate(tx, cols, lower, upperLast, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
+		index.iterate(tx, cols, indexBounds, lowerIncl, upperIncl, maxInsertIndex, buf, usageWeight, forceBuild, exactMain, options, candidateSpan, selected, callback)
 		return
 	}
 
@@ -1120,14 +1124,14 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			}
 			var av, bv scm.Scmer
 			if a.itemid == -1 {
-				av = a.data[colIdx]
+				av = a.reference.lower(colIdx)
 			} else if state.precomputedDelta {
 				av = a.data[colIdx]
 			} else {
 				av = s.getDeltaColValue(uint32(a.itemid), a.data, colIdx)
 			}
 			if b.itemid == -1 {
-				bv = b.data[colIdx]
+				bv = b.reference.lower(colIdx)
 			} else if state.precomputedDelta {
 				bv = b.data[colIdx]
 			} else {
@@ -1247,7 +1251,7 @@ func unorderedRecSetDominates(recsetRows, indexSpanRows int64) bool {
 // positions, then bulk-decodes the forward permutation back to RecIDs. If no
 // inverse exists yet, the same bounded buffer is sorted by the index key
 // callbacks; this keeps a cold sparse query from degrading to a full scan.
-func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexState, part *recSetShard, bounds scanAccess, lower []scm.Scmer, upperLast scm.Scmer, upperInclusive bool, mainStart int, mainEnd int, maxInsertIndex int, buf []uint32, cols []colGetter, persistent bool, ordered bool, exactMain *bool, callback func([]uint32) bool) {
+func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexState, part *recSetShard, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, mainStart int, mainEnd int, maxInsertIndex int, buf []uint32, cols []colGetter, persistent bool, ordered bool, exactMain *bool, callback func([]uint32) bool) {
 	if part == nil || part.count == 0 {
 		return
 	}
@@ -1318,12 +1322,12 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 			return leftID < rightID
 		}
 		if len(deltaItems) > 0 {
-			cmpCols := s.queryIndexPrefixLen(bounds, lower)
+			cmpCols := s.queryIndexPrefixLen(bounds, indexBounds)
 			_, lastSorted, sortedMask, unboundedMask := s.boundKernel(bounds, cmpCols)
-			lowerInclusive, _ := effectiveBoundaryInclusiveness(bounds, lower)
+			lowerInclusive, _ := effectiveBoundaryInclusiveness(bounds, indexBounds)
 			keptDelta := deltaItems[:0]
 			for _, recid := range deltaItems {
-				inRange, _ := s.rowWithinBounds(bounds, cmpCols, lastSorted, sortedMask, unboundedMask, lower, upperLast, lowerInclusive, upperInclusive, func(col int) scm.Scmer {
+				inRange, _ := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(col int) scm.Scmer {
 					return valueAt(recid, col)
 				})
 				if inRange {
@@ -1382,7 +1386,7 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 		})
 	}
 
-	matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, func() []IndexHook {
+	matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, func() []IndexHook {
 		if persistent && state != nil {
 			return state.indexHooks
 		}
@@ -1404,41 +1408,10 @@ func (s *StorageIndex) iterateRecSetFirst(tx *TxContext, state *storageIndexStat
 // bindRowMatchers returns only matcher state. The terminal callback deliberately
 // stays outside this value: storing it in a returned wrapper closure makes the
 // complete shard scan state escape even though index iteration is synchronous.
-func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, lower []scm.Scmer, upperLast scm.Scmer, upperInclusive bool, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
+func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, cols []colGetter, hooks []IndexHook, persistent bool, exactMain *bool) []IndexRowMatcher {
 	var matchers []IndexRowMatcher
 	if !persistent {
-		cmpCols := s.queryIndexPrefixLen(bounds, lower)
-		if cmpCols > 0 {
-			_, lastSorted, sortedMask, unboundedMask := s.boundKernel(bounds, cmpCols)
-			lowerInclusive, _ := effectiveBoundaryInclusiveness(bounds, lower)
-			matchers = append(matchers, func(ids []uint32) []uint32 {
-				out := 0
-				for _, recid := range ids {
-					valueAt := func(col int) scm.Scmer {
-						if recid < s.t.main_count {
-							return cols[col].get(recid)
-						}
-						return s.getDeltaColValueTx(tx, recid, s.t.inserts[recid-s.t.main_count], col)
-					}
-					inRange, _ := s.rowWithinBounds(bounds, cmpCols, lastSorted, sortedMask, unboundedMask, lower, upperLast, lowerInclusive, upperInclusive, valueAt)
-					if inRange && !lowerInclusive {
-						lastSorted := cmpCols - 1
-						for lastSorted >= 0 && !s.columnIsSorted(lastSorted) {
-							lastSorted--
-						}
-						if lastSorted >= 0 && !lower[lastSorted].IsNil() &&
-							s.compareAt(lastSorted, valueAt(lastSorted), lower[lastSorted]) == 0 {
-							inRange = false
-						}
-					}
-					if inRange {
-						ids[out] = recid
-						out++
-					}
-				}
-				return ids[:out]
-			})
-		}
+		matchers = s.bindColdRangeMatcher(tx, bounds, indexBounds, upperInclusive, cols)
 	}
 	for colIdx := 0; colIdx < bounds.len(); colIdx++ {
 		bound := bounds.boundary(colIdx)
@@ -1483,6 +1456,47 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, lower [
 		*exactMain = false
 	}
 	return matchers
+}
+
+// Keep the capturing cold-index range matcher out of bindRowMatchers. If it is
+// inlined into that function, Go makes the access view escape even for the hot
+// persistent-index branch where the closure is never constructed.
+//
+//go:noinline
+func (s *StorageIndex) bindColdRangeMatcher(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, upperInclusive bool, cols []colGetter) []IndexRowMatcher {
+	cmpCols := s.queryIndexPrefixLen(bounds, indexBounds)
+	if cmpCols == 0 {
+		return nil
+	}
+	_, lastSorted, sortedMask, unboundedMask := s.boundKernel(bounds, cmpCols)
+	lowerInclusive, _ := effectiveBoundaryInclusiveness(bounds, indexBounds)
+	return []IndexRowMatcher{func(ids []uint32) []uint32 {
+		out := 0
+		for _, recid := range ids {
+			valueAt := func(col int) scm.Scmer {
+				if recid < s.t.main_count {
+					return cols[col].get(recid)
+				}
+				return s.getDeltaColValueTx(tx, recid, s.t.inserts[recid-s.t.main_count], col)
+			}
+			inRange, _ := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, valueAt)
+			if inRange && !lowerInclusive {
+				lastSorted := cmpCols - 1
+				for lastSorted >= 0 && !s.columnIsSorted(lastSorted) {
+					lastSorted--
+				}
+				if lastSorted >= 0 && !indexBounds.lower(lastSorted).IsNil() &&
+					s.compareAt(lastSorted, valueAt(lastSorted), indexBounds.lower(lastSorted)) == 0 {
+					inRange = false
+				}
+			}
+			if inRange {
+				ids[out] = recid
+				out++
+			}
+		}
+		return ids[:out]
+	}}
 }
 
 func emitRowMatchers(matchers []IndexRowMatcher, ids []uint32, callback func([]uint32) bool) bool {
@@ -1536,7 +1550,7 @@ func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds scanAccess) 
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scmer, upperLast scm.Scmer, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds scanIndexBounds, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -1544,8 +1558,10 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scm
 	// concurrent writer is waiting for s.t.mu.Lock() (write-preferring RWMutex).
 	getterScratch := indexGetterScratchPool.Get().(*indexGetterScratch)
 	cols := s.buildGetters(tx, getterScratch.getters[:])
+	getterScratch.indexBounds = indexBounds
 	defer func() {
 		clear(getterScratch.getters[:])
+		getterScratch.indexBounds = scanIndexBounds{}
 		indexGetterScratchPool.Put(getterScratch)
 	}()
 	state := &s.baseState
@@ -1592,7 +1608,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scm
 		if selected != nil {
 			selected(s, false)
 		}
-		s.iterateRecSetFirst(tx, nil, recsetPart, bounds, lower, upperLast,
+		s.iterateRecSetFirst(tx, nil, recsetPart, bounds, indexBounds,
 			upperInclusive, 0, int(s.t.main_count), maxInsertIndex, buf, cols, false, false, exactMain, callback)
 		return
 	}
@@ -1605,7 +1621,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scm
 				if selected != nil {
 					selected(s, options != nil)
 				}
-				s.iterateRecSetFirst(tx, nil, recsetPart, bounds, lower, upperLast,
+				s.iterateRecSetFirst(tx, nil, recsetPart, bounds, indexBounds,
 					upperInclusive, 0, int(s.t.main_count), maxInsertIndex, buf, cols, false, options != nil, exactMain, callback)
 				return
 			}
@@ -1613,7 +1629,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scm
 			if selected != nil {
 				selected(s, false)
 			}
-			matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, nil, false, exactMain)
+			matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, nil, false, exactMain)
 			s.fullScan(maxInsertIndex, buf, matchers, callback)
 			return
 		} else {
@@ -1625,7 +1641,7 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, lower []scm.Scm
 				if selected != nil {
 					selected(s, false)
 				}
-				matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, nil, false, exactMain)
+				matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, nil, false, exactMain)
 				s.fullScan(maxInsertIndex, buf, matchers, callback)
 				return
 			}
@@ -1649,7 +1665,7 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, nil, false, exactMain)
+		matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, nil, false, exactMain)
 		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
@@ -1659,7 +1675,7 @@ start_scan:
 		if selected != nil {
 			selected(s, false)
 		}
-		matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, nil, false, exactMain)
+		matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, nil, false, exactMain)
 		s.fullScan(maxInsertIndex, buf, matchers, callback)
 		return
 	}
@@ -1679,7 +1695,7 @@ start_scan:
 	// per callback so LIMIT can brake inside the index walk. The caller-owned
 	// pooled buffer remains allocated at its normal size; only its visible slice
 	// is shortened, so the hot path adds no allocation.
-	cmpCols := s.queryIndexPrefixLen(bounds, lower)
+	cmpCols := s.queryIndexPrefixLen(bounds, indexBounds)
 	firstSorted, lastSorted, sortedMask, unboundedMask := s.boundKernel(bounds, cmpCols)
 	if options != nil && options.boundaryCoveredLimit && options.orderedLimit > 0 &&
 		options.orderedLimit < len(buf) && indexCoversBoundaryOrder(s, true, bounds, cmpCols) {
@@ -1707,43 +1723,43 @@ start_scan:
 	// LIKE columns cannot participate in binary search (pattern doesn't map to sort order).
 	searchLo := 0
 	searchN := int(s.t.main_count)
-	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !lower[firstSorted].IsNil() {
+	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !indexBounds.lower(firstSorted).IsNil() {
 		hintVal := cols[firstSorted].get(getRecid(hint))
 		if !hintVal.IsNil() {
-			if s.compareAt(firstSorted, hintVal, lower[firstSorted]) < 0 {
+			if s.compareAt(firstSorted, hintVal, indexBounds.lower(firstSorted)) < 0 {
 				searchLo = hint
 				searchN -= hint
-			} else if s.compareAt(firstSorted, lower[firstSorted], hintVal) < 0 {
+			} else if s.compareAt(firstSorted, indexBounds.lower(firstSorted), hintVal) < 0 {
 				searchN = hint + 1
 			}
 		}
 	}
 	mainIdx := 0
-	if firstSorted >= 0 && !lower[firstSorted].IsNil() {
+	if firstSorted >= 0 && !indexBounds.lower(firstSorted).IsNil() {
 		if s.usesNaturalAscendingOrder(firstSorted) {
 			var interpMin, interpMax scm.Scmer
 			if len(state.minVals) > firstSorted {
 				interpMin = state.minVals[firstSorted]
 				interpMax = state.maxVals[firstSorted]
 			}
-			mainIdx = interpolationSearch(searchLo, searchN, lower[firstSorted], interpMin, interpMax,
+			mainIdx = interpolationSearch(searchLo, searchN, indexBounds.lower(firstSorted), interpMin, interpMax,
 				func(idx int) scm.Scmer {
 					return cols[firstSorted].get(getRecid(idx))
 				})
 		} else {
 			mainIdx = searchLo + sort.Search(searchN, func(idx int) bool {
 				value := cols[firstSorted].get(getRecid(searchLo + idx))
-				return s.compareAt(firstSorted, value, lower[firstSorted]) >= 0
+				return s.compareAt(firstSorted, value, indexBounds.lower(firstSorted)) >= 0
 			})
 		}
 	}
 	s.lastHit.Store(uint32(mainIdx))
 	// skip past equal values when lower bound is exclusive (col > 5)
 	// LIKE columns don't have lower/upper semantics, so skip this optimization.
-	if !lowerInclusive && lastSorted >= 0 && !lower[lastSorted].IsNil() {
+	if !lowerInclusive && lastSorted >= 0 && !indexBounds.lower(lastSorted).IsNil() {
 		for uint32(mainIdx) < s.t.main_count {
 			recid := getRecid(mainIdx)
-			if s.compareAt(lastSorted, cols[lastSorted].get(recid), lower[lastSorted]) != 0 {
+			if s.compareAt(lastSorted, cols[lastSorted].get(recid), indexBounds.lower(lastSorted)) != 0 {
 				break
 			}
 			mainIdx++
@@ -1755,10 +1771,10 @@ start_scan:
 	// membership walk cheaper even when the RecSet is small relative to the
 	// whole table; whole-table density is therefore the wrong crossover input.
 	mainEnd := int(s.t.main_count)
-	if lastSorted >= 0 && !upperLast.IsNil() && mainIdx < mainEnd {
+	if lastSorted >= 0 && !indexBounds.upperLast().IsNil() && mainIdx < mainEnd {
 		mainEnd = mainIdx + sort.Search(mainEnd-mainIdx, func(offset int) bool {
 			recid := getRecid(mainIdx + offset)
-			_, beyond := s.rowWithinBounds(bounds, cmpCols, lastSorted, sortedMask, unboundedMask, lower, upperLast, lowerInclusive, upperInclusive, func(col int) scm.Scmer {
+			_, beyond := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(col int) scm.Scmer {
 				return cols[col].get(recid)
 			})
 			return beyond
@@ -1795,7 +1811,7 @@ start_scan:
 		if inverseBytes > 0 {
 			GlobalCache.UpdateSizeAsync(s, int64(inverseBytes))
 		}
-		s.iterateRecSetFirst(tx, &sparseState, recsetPart, bounds, lower, upperLast,
+		s.iterateRecSetFirst(tx, &sparseState, recsetPart, bounds, indexBounds,
 			upperInclusive, start, end, maxInsertIndex, buf, cols, true, options != nil, exactMain, target)
 	}
 	if preferRecSet {
@@ -1804,7 +1820,7 @@ start_scan:
 	}
 
 	rawCallback := callback
-	matchers := s.bindRowMatchers(tx, bounds, lower, upperLast, upperInclusive, cols, snapIndexHooks, true, exactMain)
+	matchers := s.bindRowMatchers(tx, bounds, indexBounds, upperInclusive, cols, snapIndexHooks, true, exactMain)
 	// For one constrained sorted key, the two binary searches define the exact
 	// main-row interval. Non-sorted access hooks still run in emitRowMatchers.
 	// Composite prefixes keep their row checks because their lower search uses
@@ -1832,7 +1848,7 @@ start_scan:
 			if mainRangeCovered {
 				return recid, true
 			}
-			inRange, beyond := s.rowWithinBounds(bounds, cmpCols, lastSorted, sortedMask, unboundedMask, lower, upperLast, lowerInclusive, upperInclusive, func(i int) scm.Scmer {
+			inRange, beyond := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(i int) scm.Scmer {
 				return cols[i].get(recid)
 			})
 			if inRange {
@@ -1884,7 +1900,7 @@ start_scan:
 			if recid < s.t.main_count || p.itemid-int(s.t.main_count) >= maxInsertIndex {
 				return true
 			}
-			inRange, beyond := s.rowWithinBounds(bounds, cmpCols, lastSorted, sortedMask, unboundedMask, lower, upperLast, lowerInclusive, upperInclusive, func(i int) scm.Scmer {
+			inRange, beyond := s.rowWithinBounds(bounds, indexBounds, cmpCols, lastSorted, sortedMask, unboundedMask, lowerInclusive, upperInclusive, func(i int) scm.Scmer {
 				if state.precomputedDelta {
 					return p.data[i]
 				}
@@ -1915,7 +1931,7 @@ start_scan:
 		// reference comparator stops at cmpCols, making the missing suffix unbounded.
 		hasUnsearchableInBounds := state.precomputedDelta
 		for i := 0; i < cmpCols; i++ {
-			if lower[i].IsNil() || (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (bounds.len() > i && !bounds.boundary(i).matcher.IsSorted()) {
+			if indexBounds.lower(i).IsNil() || (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (bounds.len() > i && !bounds.boundary(i).matcher.IsSorted()) {
 				hasUnsearchableInBounds = true
 				break
 			}
@@ -1926,7 +1942,7 @@ start_scan:
 			// Reference pairs are marked with itemid -1 and interpreted in
 			// index-column order by the comparator, so lower is directly
 			// seekable without a per-probe reordered copy.
-			snapDeltaBtree.AscendGreaterOrEqual(indexPair{itemid: -1, data: lower, compareCols: cmpCols}, iterFn)
+			snapDeltaBtree.AscendGreaterOrEqual(indexPair{itemid: -1, reference: &getterScratch.indexBounds, compareCols: cmpCols}, iterFn)
 		}
 	}
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -150,7 +150,7 @@ func canonicalColumnOrder(t *table, col string) (func(scm.Scmer, scm.Scmer) bool
 	return scm.OrderRelationLess(order), orderRelationMeta(order)
 }
 
-func boundaryOrder(t *table, boundary columnboundaries) (func(scm.Scmer, scm.Scmer) bool, string) {
+func boundaryOrder(t *table, boundary analyzedBoundary) (func(scm.Scmer, scm.Scmer) bool, string) {
 	if boundary.order != nil {
 		meta := boundary.orderMeta
 		if meta == "" {
@@ -194,7 +194,7 @@ func ascendingOrderMetaMatches(meta, collation string) bool {
 		meta[:len(collation)] == collation && meta[len(collation):] == ":asc"
 }
 
-func indexOrderMatchesBoundary(t *table, index *StorageIndex, column int, boundary columnboundaries) bool {
+func indexOrderMatchesBoundary(t *table, index *StorageIndex, column int, boundary analyzedBoundary) bool {
 	if column >= len(index.ColOrderMeta) {
 		return false
 	}

--- a/storage/index.go
+++ b/storage/index.go
@@ -30,10 +30,9 @@ import "github.com/carli2/hybridsort"
 import "github.com/launix-de/memcp/scm"
 
 type indexPair struct {
-	itemid      int // -1 for reference items
-	data        []scm.Scmer
-	reference   *scanIndexBounds
-	compareCols int // reference-only prefix length; zero compares the complete key
+	itemid    int // -1 for reference items
+	data      []scm.Scmer
+	reference *scanIndexBounds
 }
 
 type storageIndexState struct {
@@ -1158,11 +1157,15 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 	// skip non-sorted matcher columns (they don't participate in sort order)
 	state.deltaBtree = btree.NewG[indexPair](8, func(a, b indexPair) bool {
 		compareCols := len(s.Cols)
-		if a.compareCols > 0 && a.compareCols < compareCols {
-			compareCols = a.compareCols
+		if a.itemid == -1 && a.reference == nil && len(a.data) < compareCols {
+			compareCols = len(a.data)
+		} else if a.reference != nil && a.reference.compareCols > 0 && a.reference.compareCols < compareCols {
+			compareCols = a.reference.compareCols
 		}
-		if b.compareCols > 0 && b.compareCols < compareCols {
-			compareCols = b.compareCols
+		if b.itemid == -1 && b.reference == nil && len(b.data) < compareCols {
+			compareCols = len(b.data)
+		} else if b.reference != nil && b.reference.compareCols > 0 && b.reference.compareCols < compareCols {
+			compareCols = b.reference.compareCols
 		}
 		for colIdx := 0; colIdx < compareCols; colIdx++ {
 			if !s.columnIsSorted(colIdx) {
@@ -1170,14 +1173,22 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			}
 			var av, bv scm.Scmer
 			if a.itemid == -1 {
-				av = a.reference.referenceLower(colIdx)
+				if a.reference == nil {
+					av = a.data[colIdx]
+				} else {
+					av = a.reference.referenceLower(colIdx)
+				}
 			} else if state.precomputedDelta {
 				av = a.data[colIdx]
 			} else {
 				av = s.getDeltaColValue(uint32(a.itemid), a.data, colIdx)
 			}
 			if b.itemid == -1 {
-				bv = b.reference.referenceLower(colIdx)
+				if b.reference == nil {
+					bv = b.data[colIdx]
+				} else {
+					bv = b.reference.referenceLower(colIdx)
+				}
 			} else if state.precomputedDelta {
 				bv = b.data[colIdx]
 			} else {
@@ -1993,7 +2004,12 @@ start_scan:
 			// Reference pairs are marked with itemid -1 and interpreted in
 			// index-column order by the comparator, so lower is directly
 			// seekable without a per-probe reordered copy.
-			snapDeltaBtree.AscendGreaterOrEqual(indexPair{itemid: -1, reference: &getterScratch.indexBounds, compareCols: cmpCols}, iterFn)
+			if bounds.exactAdjacent && cmpCols == 1 {
+				snapDeltaBtree.AscendGreaterOrEqual(indexPair{itemid: -1, data: bounds.values[:1]}, iterFn)
+			} else {
+				getterScratch.indexBounds.compareCols = cmpCols
+				snapDeltaBtree.AscendGreaterOrEqual(indexPair{itemid: -1, reference: &getterScratch.indexBounds}, iterFn)
+			}
 		}
 	}
 

--- a/storage/index.go
+++ b/storage/index.go
@@ -239,6 +239,7 @@ func indexOrderMatchesScanAccess(t *table, index *StorageIndex, column int, acce
 	if collation != "" && strings.HasPrefix(t.Name, ".grp:") && (lower.IsString() || lower.IsSymbol()) {
 		return ascendingOrderMetaMatches(meta, collation)
 	}
+	collation = "bin"
 	for _, definition := range t.Columns {
 		if definition.Name == access.boundaryColumn(column) {
 			if definition.Collation != "" {

--- a/storage/index.go
+++ b/storage/index.go
@@ -79,11 +79,8 @@ const inlineIndexGetters = 8
 
 type indexGetterScratch struct {
 	getters     [inlineIndexGetters]colGetter
+	access      scanAccess
 	indexBounds scanIndexBounds
-}
-
-var scanIndexBoundsPool = sync.Pool{
-	New: func() any { return new(scanIndexBounds) },
 }
 
 var indexGetterScratchPool = sync.Pool{
@@ -174,6 +171,24 @@ func boundaryOrder(t *table, boundary columnboundaries) (func(scm.Scmer, scm.Scm
 	return canonicalColumnOrder(t, boundary.col)
 }
 
+func scanAccessBoundaryOrder(t *table, access scanAccess, column int) (func(scm.Scmer, scm.Scmer) bool, string) {
+	order, meta := access.boundaryOrder(column)
+	if order != nil {
+		if meta == "" {
+			meta = orderRelationMeta(order)
+		}
+		return scm.OrderRelationLess(order), meta
+	}
+	collation := access.boundaryCollation(column)
+	lower := access.boundValue(column, false)
+	if collation != "" && strings.HasPrefix(t.Name, ".grp:") && (lower.IsString() || lower.IsSymbol()) {
+		value := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString(collation), scm.NewBool(false))
+		order = scm.OptimizeProcToSerialFunction(value)
+		return scm.OrderRelationLess(order), orderRelationMeta(order)
+	}
+	return canonicalColumnOrder(t, access.boundaryColumn(column))
+}
+
 func ascendingOrderMetaMatches(meta, collation string) bool {
 	return len(meta) == len(collation)+len(":asc") &&
 		meta[:len(collation)] == collation && meta[len(collation):] == ":asc"
@@ -200,6 +215,36 @@ func indexOrderMatchesBoundary(t *table, index *StorageIndex, column int, bounda
 		if definition.Name == boundary.col {
 			if definition.Collation != "" {
 				collation = definition.Collation
+			}
+			break
+		}
+	}
+	return ascendingOrderMetaMatches(meta, collation)
+}
+
+func indexOrderMatchesScanAccess(t *table, index *StorageIndex, column int, access scanAccess) bool {
+	if column >= len(index.ColOrderMeta) {
+		return false
+	}
+	meta := index.ColOrderMeta[column]
+	order, required := access.boundaryOrder(column)
+	if order != nil {
+		if required == "" {
+			required = orderRelationMeta(order)
+		}
+		return meta == required
+	}
+	collation := access.boundaryCollation(column)
+	lower := access.boundValue(column, false)
+	if collation != "" && strings.HasPrefix(t.Name, ".grp:") && (lower.IsString() || lower.IsSymbol()) {
+		return ascendingOrderMetaMatches(meta, collation)
+	}
+	for _, definition := range t.Columns {
+		if definition.Name == access.boundaryColumn(column) {
+			if definition.Collation != "" {
+				collation = definition.Collation
+			} else {
+				collation = "bin"
 			}
 			break
 		}
@@ -479,8 +524,9 @@ func (s *StorageIndex) boundKernel(bounds scanAccess, cmpCols int) (firstSorted 
 		lastSorted = i
 		if i < 64 {
 			sortedMask |= uint64(1) << i
-			bound := bounds.boundary(i)
-			if boundaryIsUnboundedOrder(bound) || boundaryIsUnboundedRange(bound) {
+			order, _ := bounds.boundaryOrder(i)
+			if (order != nil || bounds.boundaryAnalyzer(i).IsSorted()) &&
+				!scanAccessBoundaryIsPoint(bounds, i) && bounds.boundValue(i, false).IsNil() && bounds.boundValue(i, true).IsNil() {
 				unboundedMask |= uint64(1) << i
 			}
 		}
@@ -502,8 +548,9 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds *scanIndex
 				continue
 			}
 		} else if i < bounds.len() {
-			bound := bounds.boundary(i)
-			if boundaryIsUnboundedOrder(bound) || boundaryIsUnboundedRange(bound) {
+			order, _ := bounds.boundaryOrder(i)
+			if (order != nil || bounds.boundaryAnalyzer(i).IsSorted()) &&
+				!scanAccessBoundaryIsPoint(bounds, i) && bounds.boundValue(i, false).IsNil() && bounds.boundValue(i, true).IsNil() {
 				continue // ordering or residual-only range, not an index restriction
 			}
 		}
@@ -518,15 +565,15 @@ func (s *StorageIndex) rowWithinBounds(bounds scanAccess, indexBounds *scanIndex
 					return false, true
 				}
 			}
-			if indexBounds.len() > i && !indexBounds.lower(i).IsNil() {
-				comparison := s.compareAt(i, v, indexBounds.lower(i))
+			if indexBounds.len() > i && !indexBounds.lower(bounds, i).IsNil() {
+				comparison := s.compareAt(i, v, indexBounds.lower(bounds, i))
 				if comparison < 0 || (comparison == 0 && !lowerInclusive) {
 					return false, false
 				}
 			}
 			continue
 		}
-		cmp := s.compareAt(i, v, indexBounds.lower(i))
+		cmp := s.compareAt(i, v, indexBounds.lower(bounds, i))
 		if cmp == 0 {
 			continue
 		}
@@ -553,15 +600,14 @@ func (s *StorageIndex) queryIndexPrefixLen(bounds scanAccess, indexBounds *scanI
 		limit = len(s.Cols)
 	}
 	for i := 0; i < limit; i++ {
-		bound := bounds.boundary(i)
-		if bound.col != s.Cols[i] {
+		if bounds.boundaryColumn(i) != s.Cols[i] {
 			return i
 		}
 		var indexedMatcher IndexAnalyzer
 		if i < len(s.ColMatchers) {
 			indexedMatcher = s.ColMatchers[i]
 		}
-		if !indexMatcherCompatible(bound.matcher, indexedMatcher) {
+		if !indexMatcherCompatible(bounds.boundaryAnalyzer(i), indexedMatcher) {
 			return i
 		}
 	}
@@ -635,21 +681,15 @@ func effectiveBoundaryInclusiveness(cols scanAccess, indexBounds *scanIndexBound
 		return true, true
 	}
 	for i := indexBounds.len() - 1; i >= 0; i-- {
-		bound := cols.boundary(i)
-		if bound.matcher.IsSorted() {
-			return bound.lowerInclusive, bound.upperInclusive
+		if cols.boundaryAnalyzer(i).IsSorted() {
+			return cols.boundaryLowerInclusive(i), cols.boundaryUpperInclusive(i)
 		}
 	}
 	return true, true
 }
 
 func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
-	indexBounds := scanIndexBoundsPool.Get().(*scanIndexBounds)
-	*indexBounds = newScanIndexBounds(cols)
-	defer func() {
-		*indexBounds = scanIndexBounds{}
-		scanIndexBoundsPool.Put(indexBounds)
-	}()
+	indexBounds := newScanIndexBounds(cols)
 	if exactMain != nil {
 		*exactMain = false
 	}
@@ -659,11 +699,11 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 	// leave the suffix to the mandatory residual predicate.
 	if t.t.hasBoundUniquePoint(cols) {
 		sortedEnd := 0
-		for sortedEnd < cols.len() && cols.boundary(sortedEnd).matcher.IsSorted() {
+		for sortedEnd < cols.len() && cols.boundaryAnalyzer(sortedEnd).IsSorted() {
 			sortedEnd++
 		}
 		if sortedEnd < cols.len() && indexBounds.len() > sortedEnd {
-			indexBounds.truncate(sortedEnd)
+			indexBounds.truncate(cols, sortedEnd)
 		}
 	}
 
@@ -671,14 +711,14 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 	// present because an ordered index can use only one range suffix. Read the
 	// flags from that effective last boundary, not from a later condition that
 	// is evaluated only by the scan predicate.
-	lowerIncl, upperIncl := effectiveBoundaryInclusiveness(cols, indexBounds)
+	lowerIncl, upperIncl := effectiveBoundaryInclusiveness(cols, &indexBounds)
 	// Exact RecSet membership is a query-bound overlay. A prepared base index
 	// needs to cover only the sorted/access prefix; RecSetMatcher binds to that
 	// index at invocation time and must not create one index identity per source
 	// carrier. Retain a lone RecSet boundary so unordered scans can still use the
 	// common matcher machinery without a zero-column StorageIndex.
 	indexCols := indexBounds.len()
-	for indexCols > 1 && indexCols <= cols.len() && matcherKindEqual(cols.boundary(indexCols-1).matcher, RecSetMatcher) {
+	for indexCols > 1 && indexCols <= cols.len() && matcherKindEqual(cols.boundaryAnalyzer(indexCols-1), RecSetMatcher) {
 		indexCols--
 	}
 
@@ -692,19 +732,18 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 			// naive index search algo; TODO: improve
 			if len(index.Cols) >= indexCols {
 				for i := 0; i < indexCols; i++ {
-					bound := cols.boundary(i)
-					if bound.col != index.Cols[i] {
+					if cols.boundaryColumn(i) != index.Cols[i] {
 						goto skip_index // column mismatch
 					}
 					var indexedMatcher IndexAnalyzer
 					if len(index.ColMatchers) > i {
 						indexedMatcher = index.ColMatchers[i]
 					}
-					if !indexMatcherCompatible(bound.matcher, indexedMatcher) {
+					if !indexMatcherCompatible(cols.boundaryAnalyzer(i), indexedMatcher) {
 						goto skip_index // matcher kind mismatch
 					}
-					if bound.matcher.IsSorted() {
-						if !indexOrderMatchesBoundary(t.t, index, i, bound) {
+					if cols.boundaryAnalyzer(i).IsSorted() {
+						if !indexOrderMatchesScanAccess(t.t, index, i, cols) {
 							goto skip_index
 						}
 					}
@@ -727,8 +766,7 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 			if len(index.Cols) >= indexCols {
 				covered := true
 				for i := 0; i < indexCols; i++ {
-					bound := cols.boundary(i)
-					if bound.col != index.Cols[i] {
+					if cols.boundaryColumn(i) != index.Cols[i] {
 						covered = false
 						break
 					}
@@ -736,12 +774,12 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 					if len(index.ColMatchers) > i {
 						indexedMatcher = index.ColMatchers[i]
 					}
-					if !indexMatcherCompatible(bound.matcher, indexedMatcher) {
+					if !indexMatcherCompatible(cols.boundaryAnalyzer(i), indexedMatcher) {
 						covered = false
 						break
 					}
-					if bound.matcher.IsSorted() {
-						if !indexOrderMatchesBoundary(t.t, index, i, bound) {
+					if cols.boundaryAnalyzer(i).IsSorted() {
+						if !indexOrderMatchesScanAccess(t.t, index, i, cols) {
 							covered = false
 							break
 						}
@@ -762,17 +800,15 @@ func (t *storageShard) iterateIndexEx(tx *TxContext, cols scanAccess, maxInsertI
 		index.ColOrder = make([]func(scm.Scmer, scm.Scmer) bool, indexCols)
 		index.ColOrderMeta = make([]string, indexCols)
 		for i := 0; i < indexCols; i++ {
-			bound := cols.boundary(i)
-			index.Cols[i] = bound.col
-			index.ColMapCols[i] = bound.mapCols // nil for raw columns
-			index.ColMapFn[i] = bound.mapFn     // IsNil() for raw columns
-			if bound.matcher.IsSorted() {
-				index.ColOrder[i], index.ColOrderMeta[i] = boundaryOrder(t.t, bound)
+			index.Cols[i] = cols.boundaryColumn(i)
+			index.ColMapCols[i], index.ColMapFn[i] = cols.boundaryMap(i)
+			if cols.boundaryAnalyzer(i).IsSorted() {
+				index.ColOrder[i], index.ColOrderMeta[i] = scanAccessBoundaryOrder(t.t, cols, i)
 			} else {
 				if index.ColMatchers == nil {
 					index.ColMatchers = make([]IndexAnalyzer, indexCols)
 				}
-				index.ColMatchers[i] = bound.matcher
+				index.ColMatchers[i] = cols.boundaryAnalyzer(i)
 			}
 		}
 		index.Savings = 0.0            // count how many cost we wasted so we decide when to build the index
@@ -1133,14 +1169,14 @@ func (s *StorageIndex) buildIndex(state *storageIndexState, cols []colGetter, tx
 			}
 			var av, bv scm.Scmer
 			if a.itemid == -1 {
-				av = a.reference.lower(colIdx)
+				av = a.reference.referenceLower(colIdx)
 			} else if state.precomputedDelta {
 				av = a.data[colIdx]
 			} else {
 				av = s.getDeltaColValue(uint32(a.itemid), a.data, colIdx)
 			}
 			if b.itemid == -1 {
-				bv = b.reference.lower(colIdx)
+				bv = b.reference.referenceLower(colIdx)
 			} else if state.precomputedDelta {
 				bv = b.data[colIdx]
 			} else {
@@ -1423,16 +1459,17 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBo
 		matchers = s.bindColdRangeMatcher(tx, bounds, indexBounds, upperInclusive, cols)
 	}
 	for colIdx := 0; colIdx < bounds.len(); colIdx++ {
-		bound := bounds.boundary(colIdx)
-		if bound.matcher == nil || bound.matcher.IsSorted() {
+		analyzer := bounds.boundaryAnalyzer(colIdx)
+		if analyzer == nil || analyzer.IsSorted() {
 			continue
 		}
 		var hook IndexHook
-		alignedWithIndex := colIdx < len(s.Cols) && s.Cols[colIdx] == bound.col
+		column := bounds.boundaryColumn(colIdx)
+		alignedWithIndex := colIdx < len(s.Cols) && s.Cols[colIdx] == column
 		if alignedWithIndex && colIdx < len(s.ColMatchers) {
-			alignedWithIndex = indexMatcherCompatible(bound.matcher, s.ColMatchers[colIdx])
+			alignedWithIndex = indexMatcherCompatible(analyzer, s.ColMatchers[colIdx])
 		} else if alignedWithIndex {
-			alignedWithIndex = bound.matcher.IsSorted()
+			alignedWithIndex = analyzer.IsSorted()
 		}
 		if persistent && alignedWithIndex && colIdx < len(hooks) {
 			hook = hooks[colIdx]
@@ -1441,10 +1478,10 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBo
 			var reader ColumnReader
 			if alignedWithIndex && colIdx < len(cols) {
 				reader = cols[colIdx].raw
-			} else if !isScanPseudoColName(bound.col) && bound.mapFn.IsNil() {
-				reader = newCachedColumnReaderTx(s.t.getColumnStorageRLocked(bound.col), tx)
+			} else if _, mapFn := bounds.boundaryMap(colIdx); !isScanPseudoColName(column) && mapFn.IsNil() {
+				reader = newCachedColumnReaderTx(s.t.getColumnStorageRLocked(column), tx)
 			}
-			hook = bound.matcher.Deploy(IndexDeployContext{
+			hook = analyzer.Deploy(IndexDeployContext{
 				MainCount: s.t.main_count,
 				Column:    reader,
 				shard:     s.t,
@@ -1453,7 +1490,7 @@ func (s *StorageIndex) bindRowMatchers(tx *TxContext, bounds scanAccess, indexBo
 		if hook == nil {
 			continue
 		}
-		matcher := hook.Bind(bound.lower)
+		matcher := hook.Bind(bounds.boundValue(colIdx, false))
 		if matcher != nil {
 			matchers = append(matchers, matcher)
 		}
@@ -1494,8 +1531,8 @@ func (s *StorageIndex) bindColdRangeMatcher(tx *TxContext, bounds scanAccess, in
 				for lastSorted >= 0 && !s.columnIsSorted(lastSorted) {
 					lastSorted--
 				}
-				if lastSorted >= 0 && !indexBounds.lower(lastSorted).IsNil() &&
-					s.compareAt(lastSorted, valueAt(lastSorted), indexBounds.lower(lastSorted)) == 0 {
+				if lastSorted >= 0 && !indexBounds.lower(bounds, lastSorted).IsNil() &&
+					s.compareAt(lastSorted, valueAt(lastSorted), indexBounds.lower(bounds, lastSorted)) == 0 {
 					inRange = false
 				}
 			}
@@ -1535,15 +1572,15 @@ func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds scanAccess) 
 	var universe uint32
 	found := false
 	for colIdx := 0; colIdx < bounds.len(); colIdx++ {
-		bound := bounds.boundary(colIdx)
-		if bound.matcher == nil || bound.matcher.IsSorted() || colIdx >= len(hooks) {
+		analyzer := bounds.boundaryAnalyzer(colIdx)
+		if analyzer == nil || analyzer.IsSorted() || colIdx >= len(hooks) {
 			continue
 		}
 		estimator, ok := hooks[colIdx].(IndexCandidateEstimator)
 		if !ok {
 			continue
 		}
-		count, hookUniverse, ok := estimator.EstimateCandidates(bound.lower)
+		count, hookUniverse, ok := estimator.EstimateCandidates(bounds.boundValue(colIdx, false))
 		if !ok {
 			continue
 		}
@@ -1559,7 +1596,7 @@ func (s *StorageIndex) estimateHookCandidates(tx *TxContext, bounds scanAccess) 
 }
 
 // iterate over index using a caller-provided buffer for batching
-func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds *scanIndexBounds, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
+func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBoundsValue scanIndexBounds, lowerInclusive bool, upperInclusive bool, maxInsertIndex int, buf []uint32, usageWeight float64, forceBuild bool, exactMain *bool, options *indexIterationOptions, candidateSpan *int64, selected func(*StorageIndex, bool), callback func([]uint32) bool) {
 
 	// Build column getters — use RLocked variant because the caller
 	// (scan, scan_order, GetRecordidForUnique) already holds s.t.mu.RLock().
@@ -1567,9 +1604,13 @@ func (s *StorageIndex) iterate(tx *TxContext, bounds scanAccess, indexBounds *sc
 	// concurrent writer is waiting for s.t.mu.Lock() (write-preferring RWMutex).
 	getterScratch := indexGetterScratchPool.Get().(*indexGetterScratch)
 	cols := s.buildGetters(tx, getterScratch.getters[:])
-	getterScratch.indexBounds = *indexBounds
+	getterScratch.access = bounds
+	getterScratch.indexBounds = indexBoundsValue
+	getterScratch.indexBounds.access = &getterScratch.access
+	indexBounds := &getterScratch.indexBounds
 	defer func() {
 		clear(getterScratch.getters[:])
+		getterScratch.access = scanAccess{}
 		getterScratch.indexBounds = scanIndexBounds{}
 		indexGetterScratchPool.Put(getterScratch)
 	}()
@@ -1732,43 +1773,43 @@ start_scan:
 	// LIKE columns cannot participate in binary search (pattern doesn't map to sort order).
 	searchLo := 0
 	searchN := int(s.t.main_count)
-	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !indexBounds.lower(firstSorted).IsNil() {
+	if hint := int(s.lastHit.Load()); hint > 0 && hint < searchN && firstSorted >= 0 && !indexBounds.lower(bounds, firstSorted).IsNil() {
 		hintVal := cols[firstSorted].get(getRecid(hint))
 		if !hintVal.IsNil() {
-			if s.compareAt(firstSorted, hintVal, indexBounds.lower(firstSorted)) < 0 {
+			if s.compareAt(firstSorted, hintVal, indexBounds.lower(bounds, firstSorted)) < 0 {
 				searchLo = hint
 				searchN -= hint
-			} else if s.compareAt(firstSorted, indexBounds.lower(firstSorted), hintVal) < 0 {
+			} else if s.compareAt(firstSorted, indexBounds.lower(bounds, firstSorted), hintVal) < 0 {
 				searchN = hint + 1
 			}
 		}
 	}
 	mainIdx := 0
-	if firstSorted >= 0 && !indexBounds.lower(firstSorted).IsNil() {
+	if firstSorted >= 0 && !indexBounds.lower(bounds, firstSorted).IsNil() {
 		if s.usesNaturalAscendingOrder(firstSorted) {
 			var interpMin, interpMax scm.Scmer
 			if len(state.minVals) > firstSorted {
 				interpMin = state.minVals[firstSorted]
 				interpMax = state.maxVals[firstSorted]
 			}
-			mainIdx = interpolationSearch(searchLo, searchN, indexBounds.lower(firstSorted), interpMin, interpMax,
+			mainIdx = interpolationSearch(searchLo, searchN, indexBounds.lower(bounds, firstSorted), interpMin, interpMax,
 				func(idx int) scm.Scmer {
 					return cols[firstSorted].get(getRecid(idx))
 				})
 		} else {
 			mainIdx = searchLo + sort.Search(searchN, func(idx int) bool {
 				value := cols[firstSorted].get(getRecid(searchLo + idx))
-				return s.compareAt(firstSorted, value, indexBounds.lower(firstSorted)) >= 0
+				return s.compareAt(firstSorted, value, indexBounds.lower(bounds, firstSorted)) >= 0
 			})
 		}
 	}
 	s.lastHit.Store(uint32(mainIdx))
 	// skip past equal values when lower bound is exclusive (col > 5)
 	// LIKE columns don't have lower/upper semantics, so skip this optimization.
-	if !lowerInclusive && lastSorted >= 0 && !indexBounds.lower(lastSorted).IsNil() {
+	if !lowerInclusive && lastSorted >= 0 && !indexBounds.lower(bounds, lastSorted).IsNil() {
 		for uint32(mainIdx) < s.t.main_count {
 			recid := getRecid(mainIdx)
-			if s.compareAt(lastSorted, cols[lastSorted].get(recid), indexBounds.lower(lastSorted)) != 0 {
+			if s.compareAt(lastSorted, cols[lastSorted].get(recid), indexBounds.lower(bounds, lastSorted)) != 0 {
 				break
 			}
 			mainIdx++
@@ -1940,7 +1981,7 @@ start_scan:
 		// reference comparator stops at cmpCols, making the missing suffix unbounded.
 		hasUnsearchableInBounds := state.precomputedDelta
 		for i := 0; i < cmpCols; i++ {
-			if indexBounds.lower(i).IsNil() || (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (bounds.len() > i && !bounds.boundary(i).matcher.IsSorted()) {
+			if indexBounds.lower(bounds, i).IsNil() || (len(s.ColMapFn) > i && !s.ColMapFn[i].IsNil()) || (bounds.len() > i && !bounds.boundaryAnalyzer(i).IsSorted()) {
 				hasUnsearchableInBounds = true
 				break
 			}

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -61,11 +61,12 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 
 	columns := []string{"id"}
 	values := []scm.Scmer{scm.NewInt(5)}
-	if _, present := shard.GetRecordidForUnique(columns, values, nil); !present {
+	access := exactScanAccess(newExactScanAccessSchema(columns), values)
+	if _, present := shard.GetRecordidForUnique(access, nil); !present {
 		t.Fatal("warm unique point probe did not find its row")
 	}
 	if allocations := testing.AllocsPerRun(1000, func() {
-		if _, present := shard.GetRecordidForUnique(columns, values, nil); !present {
+		if _, present := shard.GetRecordidForUnique(access, nil); !present {
 			t.Fatal("unique point probe did not find its row")
 		}
 	}); allocations != 0 {

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -36,7 +36,7 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 	tbl.Insert([]string{"id"}, rows, nil, scm.NewNil(), false, nil)
 
 	shard := tbl.Shards[0]
-	bounds := boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), lowerInclusive: true, upper: scm.NewInt(5), upperInclusive: true}}
+	bounds := analyzedBoundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), lowerInclusive: true, upper: scm.NewInt(5), upperInclusive: true}}
 	var buf [8]uint32
 	shard.mu.RLock()
 	shard.iterateIndex(nil, runtimeScanAccess(bounds), len(shard.inserts), buf[:], 0, nil, func(batch []uint32) bool {

--- a/storage/index_memory_accounting_test.go
+++ b/storage/index_memory_accounting_test.go
@@ -37,10 +37,9 @@ func TestPlannerIndexProbeDoesNotIncreaseIndexSavings(t *testing.T) {
 
 	shard := tbl.Shards[0]
 	bounds := boundaries{{col: "id", matcher: EqualMatcher, lower: scm.NewInt(5), lowerInclusive: true, upper: scm.NewInt(5), upperInclusive: true}}
-	lower, upperLast := indexFromBoundaries(bounds)
 	var buf [8]uint32
 	shard.mu.RLock()
-	shard.iterateIndex(nil, runtimeScanAccess(bounds), lower, upperLast, len(shard.inserts), buf[:], 0, nil, func(batch []uint32) bool {
+	shard.iterateIndex(nil, runtimeScanAccess(bounds), len(shard.inserts), buf[:], 0, nil, func(batch []uint32) bool {
 		return true
 	})
 	shard.mu.RUnlock()

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -146,6 +146,85 @@ func runSingleShardScan(currentTx *TxContext, topology *tableShardTopology, shar
 	}
 }
 
+// pinSingleShardForScan returns a registered authoritative shard only when the
+// access resolves to exactly one shard. It deliberately avoids building the
+// relevant-shard slice used by the fanout path, allowing concrete scan kernels
+// to execute without an escaping callback frame.
+func (t *table) pinSingleShardForScan(access scanAccess) (*tableShardTopology, *storageShard, bool) {
+	for {
+		topology := t.activeTopology()
+		shard, single := singleRelevantShard(topology.dimensions, access, topology.shards)
+		if !single {
+			return nil, nil, false
+		}
+		if !topology.acquireOperation() {
+			continue
+		}
+		shard.activeScanners.Add(1)
+		if t.topology.Load() == topology {
+			return topology, shard, true
+		}
+		shard.activeScanners.Add(-1)
+		topology.releaseOperation()
+	}
+}
+
+func singleRelevantShard(schema []shardDimension, access scanAccess, shards []*storageShard) (*storageShard, bool) {
+	var first *storageShard
+	count := 0
+	countRelevantShards(schema, access, shards, &first, &count)
+	return first, count == 1
+}
+
+func countRelevantShards(schema []shardDimension, access scanAccess, shards []*storageShard, first **storageShard, count *int) {
+	if *count > 1 {
+		return
+	}
+	if len(schema) == 0 {
+		for _, shard := range shards {
+			if shard == nil {
+				continue
+			}
+			if *count == 0 {
+				*first = shard
+			}
+			*count = *count + 1
+			if *count > 1 {
+				return
+			}
+		}
+		return
+	}
+	blockdim := 1
+	for i := 1; i < len(schema); i++ {
+		blockdim *= schema[i].NumPartitions
+	}
+	for boundaryIndex := 0; boundaryIndex < access.len(); boundaryIndex++ {
+		boundary := access.boundary(boundaryIndex)
+		if boundary.col != schema[0].Column {
+			continue
+		}
+		minimum := 0
+		if !boundary.lower.IsNil() {
+			minimum = partitionForValue(schema[0], boundary.lower)
+			if !boundary.lowerInclusive && valueEqualsPivot(schema[0], minimum, boundary.lower) {
+				minimum++
+			}
+		}
+		maximum := schema[0].NumPartitions - 1
+		if !boundary.upper.IsNil() {
+			maximum = partitionForValue(schema[0], boundary.upper)
+		}
+		for partition := minimum; partition <= maximum; partition++ {
+			countRelevantShards(schema[1:], access, shards[partition*blockdim:(partition+1)*blockdim], first, count)
+		}
+		return
+	}
+	for offset := 0; offset < len(shards); offset += blockdim {
+		countRelevantShards(schema[1:], access, shards[offset:offset+blockdim], first, count)
+	}
+}
+
 func runParallelShardScans(currentTx *TxContext, shards []*storageShard, topology *tableShardTopology, callback func(*storageShard, bool)) <-chan struct{} {
 	return runFanoutTasks(currentTx, len(shards), func(i int, _ bool) {
 		shard := shards[i]

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -200,20 +200,21 @@ func countRelevantShards(schema []shardDimension, access scanAccess, shards []*s
 		blockdim *= schema[i].NumPartitions
 	}
 	for boundaryIndex := 0; boundaryIndex < access.len(); boundaryIndex++ {
-		boundary := access.boundary(boundaryIndex)
-		if boundary.col != schema[0].Column {
+		if access.boundaryColumn(boundaryIndex) != schema[0].Column {
 			continue
 		}
+		lower := access.boundValue(boundaryIndex, false)
+		upper := access.boundValue(boundaryIndex, true)
 		minimum := 0
-		if !boundary.lower.IsNil() {
-			minimum = partitionForValue(schema[0], boundary.lower)
-			if !boundary.lowerInclusive && valueEqualsPivot(schema[0], minimum, boundary.lower) {
+		if !lower.IsNil() {
+			minimum = partitionForValue(schema[0], lower)
+			if !access.boundaryLowerInclusive(boundaryIndex) && valueEqualsPivot(schema[0], minimum, lower) {
 				minimum++
 			}
 		}
 		maximum := schema[0].NumPartitions - 1
-		if !boundary.upper.IsNil() {
-			maximum = partitionForValue(schema[0], boundary.upper)
+		if !upper.IsNil() {
+			maximum = partitionForValue(schema[0], upper)
 		}
 		for partition := minimum; partition <= maximum; partition++ {
 			countRelevantShards(schema[1:], access, shards[partition*blockdim:(partition+1)*blockdim], first, count)
@@ -334,20 +335,21 @@ func collectRelevantShardsIndex(schema []shardDimension, access scanAccess, shar
 	}
 
 	for boundaryIndex := 0; boundaryIndex < access.len(); boundaryIndex++ {
-		b := access.boundary(boundaryIndex)
-		if b.col == schema[0].Column {
+		if access.boundaryColumn(boundaryIndex) == schema[0].Column {
+			lower := access.boundValue(boundaryIndex, false)
+			upper := access.boundValue(boundaryIndex, true)
 			// iterate this axis over boundaries
 			min := 0
-			if !b.lower.IsNil() {
-				min = partitionForValue(schema[0], b.lower)
-				if !b.lowerInclusive && valueEqualsPivot(schema[0], min, b.lower) {
+			if !lower.IsNil() {
+				min = partitionForValue(schema[0], lower)
+				if !access.boundaryLowerInclusive(boundaryIndex) && valueEqualsPivot(schema[0], min, lower) {
 					min++
 				}
 			}
 
 			max := schema[0].NumPartitions - 1 // smaller than max
-			if !b.upper.IsNil() {
-				max = partitionForValue(schema[0], b.upper)
+			if !upper.IsNil() {
+				max = partitionForValue(schema[0], upper)
 			}
 
 			for i := min; i <= max; i++ {

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -456,20 +456,17 @@ type recSetKeyResult struct {
 func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessValues []scm.Scmer, conditionCols []string, condition scm.Scmer) *recSet {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := querySeqFromTx(currentTx)
-	scratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(scratch)
-	boundaries, compiled := scanAccessFromScheme(accessSchema, accessValues, nil)
+	access, compiled := scanAccessFromScheme(accessSchema, accessValues, nil)
 	if !compiled {
 		panic("scan_recset received an invalid compiled access schema")
 	}
-	boundaries = boundaries.useScratch(scratch)
 	result := &recSet{table: t}
-	if boundaries.impossible() {
+	if access.impossible() {
 		return result
 	}
 
 	values := make(chan recSetBuildResult, t.shardResultBufferSize())
-	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
 		withTxSession(currentTx, func() scm.Scmer {
 			defer func() {
 				if rec := recover(); rec != nil {
@@ -482,7 +479,7 @@ func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessV
 				panic("query killed")
 			}
 			values <- recSetBuildResult{
-				part: shard.collectRecSet(boundaries, conditionCols, condition, currentTx, ss),
+				part: shard.collectRecSet(access, conditionCols, condition, currentTx, ss),
 			}
 			return scm.NewNil()
 		})
@@ -512,15 +509,15 @@ func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessV
 	return result
 }
 
-func (t *storageShard) collectRecSet(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+func (t *storageShard) collectRecSet(access scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
 	conditionProgram := scm.PrepareSerialProc(condition)
-	conditionAlwaysTrue := scanAccessCoversResidual(boundaries) ||
+	conditionAlwaysTrue := scanAccessCoversResidual(access) ||
 		conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
-	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
+	t.ensureScanAccessColumns(access, skipShardReadLock, currentTx)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(access, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -574,8 +571,8 @@ func (t *storageShard) collectRecSet(boundaries scanAccess, conditionCols []stri
 	maxInsertIndex := len(t.inserts)
 	visibleUpper := t.main_count + uint32(maxInsertIndex)
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
-	completeTraversal := boundaries.len() == 0
-	singleExactLike := boundaries.len() == 1 && singleLikeBoundaryCoversCondition(conditionCols, condition, boundaries.boundary(0))
+	completeTraversal := access.len() == 0
+	singleExactLike := access.len() == 1 && singleLikeBoundaryCoversCondition(conditionCols, condition, access, 0)
 	exactLikeMain := false
 	builder := newRecSetShardBuilder(t, visibleUpper, completeTraversal, t.main_count)
 	evaluate := func(idx uint32) bool {
@@ -619,7 +616,7 @@ func (t *storageShard) collectRecSet(boundaries scanAccess, conditionCols []stri
 	}
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
-	t.iterateIndexMatchAware(currentTx, boundaries, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
+	t.iterateIndexMatchAware(currentTx, access, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if idx >= visibleUpper {
 				continue
@@ -1116,9 +1113,9 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 	var buf [1024]uint32
 	for keyIndex := 0; keyIndex < keys.count(); keyIndex++ {
 		key := keys.tuple(keyIndex)
-		bounds := make(boundaries, len(targetKeyCols))
+		bounds := make(analyzedBoundaries, len(targetKeyCols))
 		for i, col := range targetKeyCols {
-			bounds[i] = columnboundaries{
+			bounds[i] = analyzedBoundary{
 				col:            col,
 				matcher:        EqualMatcher,
 				lower:          key[i],
@@ -1455,10 +1452,7 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 	// RecSet matcher and approximate hooks such as Bigram LIKE then prune the
 	// same candidate batches before the residual predicate reads any columns.
 	// This is an operator capability, not a planner shape rule: every
-	// scan_recset whose input is a RecSet gets the same combined boundaries.
-	scratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(scratch)
-	access = access.useScratch(scratch)
+	// scan_recset whose input is a RecSet gets the same combined constraints.
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -1565,9 +1559,10 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 }
 
 func recSetScanAccess(owner *recSet, schema scm.Scmer, values []scm.Scmer) scanAccess {
-	access, valid := scanAccessFromScheme(schema, values, boundaries{
+	suffix := scanAccessSegmentFromAnalyzed(analyzedBoundaries{
 		NewIndexBoundary("$recset_contains", RecSetMatcher, NewRecSetScmer(owner), ""),
 	})
+	access, valid := scanAccessFromScheme(schema, values, &suffix)
 	if !valid {
 		panic("scan_recset needs a scan_access schema")
 	}

--- a/storage/recset.go
+++ b/storage/recset.go
@@ -467,7 +467,6 @@ func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessV
 	if boundaries.impossible() {
 		return result
 	}
-	lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], boundaries)
 
 	values := make(chan recSetBuildResult, t.shardResultBufferSize())
 	done := t.iterateShardsParallel(currentTx, boundaries, func(shard *storageShard, solo bool) {
@@ -483,7 +482,7 @@ func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessV
 				panic("query killed")
 			}
 			values <- recSetBuildResult{
-				part: shard.collectRecSet(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss),
+				part: shard.collectRecSet(boundaries, conditionCols, condition, currentTx, ss),
 			}
 			return scm.NewNil()
 		})
@@ -513,7 +512,7 @@ func (t *table) scanRecSet(currentTx *TxContext, accessSchema scm.Scmer, accessV
 	return result
 }
 
-func (t *storageShard) collectRecSet(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
+func (t *storageShard) collectRecSet(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState) recSetShard {
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := scanAccessCoversResidual(boundaries) ||
 		conditionProgram.Kind == scm.SerialProcConstant && scm.ToBool(conditionProgram.Value)
@@ -521,7 +520,7 @@ func (t *storageShard) collectRecSet(boundaries scanAccess, lower []scm.Scmer, u
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -620,7 +619,7 @@ func (t *storageShard) collectRecSet(boundaries scanAccess, lower []scm.Scmer, u
 	}
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
-	t.iterateIndexMatchAware(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
+	t.iterateIndexMatchAware(currentTx, boundaries, maxInsertIndex, buf, true, &exactLikeMain, func(batch []uint32) bool {
 		for _, idx := range batch {
 			if idx >= visibleUpper {
 				continue
@@ -1129,8 +1128,7 @@ func (t *storageShard) projectJoinKeysPart(currentTx *TxContext, targetKeyCols [
 			}
 		}
 		reorderByFrequency(bounds, t.t)
-		lower, upperLast := indexFromBoundaries(bounds)
-		t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), lower, upperLast, maxInsertIndex, buf[:], true, func(batch []uint32) bool {
+		t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), maxInsertIndex, buf[:], true, func(batch []uint32) bool {
 			for _, idx := range batch {
 				if idx >= visibleUpper {
 					continue
@@ -1306,10 +1304,11 @@ func (t *storageShard) scanRecSetPart(part *recSetShard, conditionCols []string,
 	}
 	cdataset := make([]scm.Scmer, len(conditionCols))
 	var mapperStorage ShardMapReducer
-	var mapperWorkspace shardMapReducerWorkspace
 	mapper := &mapperStorage
 	if mapReducerCanUseReadWorkspace(callbackCols) {
-		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		mapperWorkspace := acquireShardMapReducerWorkspace()
+		defer releaseShardMapReducerWorkspace(mapperWorkspace)
+		prepareReadMapReducerStorage(&mapperStorage, mapperWorkspace, len(callbackCols))
 		t.initReadMapReducer(&mapperStorage, callbackCols, mapReduce, skipShardReadLock, currentTx)
 	} else {
 		mapper = t.OpenMapReducer(callbackCols, mapReduce, skipShardReadLock, 0, nil, currentTx)
@@ -1460,7 +1459,6 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 	scratch := acquireScanAnalyzeScratch()
 	defer releaseScanAnalyzeScratch(scratch)
 	access = access.useScratch(scratch)
-	lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], access)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -1561,7 +1559,7 @@ func (t *storageShard) filterRecSetPart(part *recSetShard, conditionCols []strin
 	} else {
 		buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 		defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
-		t.iterateIndexMatchAware(currentTx, access, lower, upperLast, len(t.inserts), buf, true, nil, evaluateBatch)
+		t.iterateIndexMatchAware(currentTx, access, len(t.inserts), buf, true, nil, evaluateBatch)
 	}
 	return builder.finish()
 }

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1341,24 +1341,38 @@ func releaseScanIDBuffer(full *fullScanIDBuffer, point *pointScanIDBuffer) {
 // for the common join case where an exact unique key can yield at most one
 // currently visible row. A few slots remain for stale index entries left by
 // updates; iterateIndex still visits further batches when necessary.
-func (t *table) scanBufferSize(boundaries scanAccess) int {
-	if t.hasBoundUniquePoint(boundaries) {
+func (t *table) scanBufferSize(access scanAccess) int {
+	if t.hasBoundUniquePoint(access) {
 		return uniquePointScanBufferSize
 	}
 	return defaultScanBufferSize
 }
 
-func (t *table) hasBoundUniquePoint(boundaries scanAccess) bool {
+func (t *table) hasBoundUniquePoint(access scanAccess) bool {
 	for _, unique := range t.Unique {
+		if access.exactAdjacent && len(unique.Cols) == access.len() {
+			matched := len(unique.Cols) > 0
+			for i, column := range unique.Cols {
+				if access.boundaryColumn(i) != column || access.values[i].IsNil() {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return true
+			}
+			continue
+		}
 		covered := true
 		for _, col := range unique.Cols {
 			matched := false
-			for i := 0; i < boundaries.len(); i++ {
-				boundary := boundaries.boundary(i)
-				if boundary.col != col || !matcherKindEqual(boundary.matcher, EqualMatcher) ||
-					boundary.lowerBatch || boundary.upperBatch || boundary.lower.IsNil() || boundary.upper.IsNil() ||
-					!boundary.lowerInclusive || !boundary.upperInclusive ||
-					!boundaryValueEqual(boundary.lower, boundary.upper) {
+			for i := 0; i < access.len(); i++ {
+				spec, _ := access.boundaryParts(i)
+				lower := access.boundValue(i, false)
+				upper := access.boundValue(i, true)
+				if spec.column != col || !matcherKindEqual(spec.analyzer, EqualMatcher) ||
+					spec.lowerSlot <= -2 || spec.upperSlot <= -2 || lower.IsNil() || upper.IsNil() ||
+					!spec.lowerInclusive || !spec.upperInclusive || !boundaryValueEqual(lower, upper) {
 					continue
 				}
 				matched = true
@@ -1403,26 +1417,20 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, accessSchem
 	ss := SessionStateFromTx(currentTx)
 	querySeq := querySeqFromTx(currentTx)
 	touchTempColumns(t, conditionCols, nil)
-	suffix := appendRecSetBoundary(nil, source)
-	access, compiled := scanAccessFromScheme(accessSchema, accessValues, suffix)
+	suffix := scanAccessSegmentFromAnalyzed(appendRecSetBoundary(nil, source))
+	access, compiled := scanAccessFromScheme(accessSchema, accessValues, &suffix)
 	if !compiled {
 		panic("scan_exists received an invalid compiled access schema")
 	}
 	if access.impossible() {
 		return false
 	}
-	var scratch *scanAnalyzeScratch
-	if access.len() > 0 {
-		scratch = acquireScanAnalyzeScratch()
-		defer releaseScanAnalyzeScratch(scratch)
-		access = access.useScratch(scratch)
+	executionAccess := access
+	for i := 0; i < executionAccess.len(); i++ {
+		t.AddPartitioningScore([]string{executionAccess.boundaryColumn(i)})
 	}
-	for i := 0; i < access.len(); i++ {
-		b := access.boundary(i)
-		t.AddPartitioningScore([]string{b.col})
-	}
-	if topology, shard, single := t.pinSingleShardForScan(access); single {
-		found, scanErr := runDirectSingleShardExists(currentTx, topology, shard, access, conditionCols, condition, ss, querySeq)
+	if topology, shard, single := t.pinSingleShardForScan(executionAccess); single {
+		found, scanErr := runDirectSingleShardExists(currentTx, topology, shard, executionAccess, conditionCols, condition, ss, querySeq)
 		if scanErr.r != nil {
 			panic(scanErr)
 		}
@@ -1431,7 +1439,7 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, accessSchem
 
 	values := scanResultCollector{channelSize: t.shardResultBufferSize()}
 	var found atomic.Bool
-	done := t.iterateShardsParallel(currentTx, access, func(s *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, executionAccess, func(s *storageShard, solo bool) {
 		if found.Load() {
 			values.send(solo, scanResult{})
 			return
@@ -1550,22 +1558,16 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 	// Measure analysis time (boundary extraction, sharding hints)
 	analyzeStart := time.Now()
 	/* analyze query */
-	var suffix boundaries
-	if requiredAccess.native != nil {
-		suffix = requiredAccess.native
-	} else if requiredAccess.runtime != nil {
-		suffix = requiredAccess.runtime.suffix
-	}
-	if source != nil {
-		// requiredAccess may be shared by every batch invocation. Copy only when
-		// a RecSet boundary must be appended; the common dynamic point probe can
-		// borrow its immutable suffix directly.
-		suffix = append(boundaries(nil), suffix...)
-		suffix = appendRecSetBoundary(suffix, source)
-	}
-	access, compiled := scanAccessFromScheme(accessSchema, accessValues, suffix)
+	access, compiled := scanAccessFromScheme(accessSchema, accessValues, nil)
 	if !compiled {
 		panic("scan received an invalid compiled access schema")
+	}
+	if requiredAccess.len() > 0 || source != nil {
+		runtime := access.ensureRuntime()
+		runtime.suffix = scanAccessAsSegment(requiredAccess)
+		if source != nil {
+			runtime.extra = scanAccessSegmentFromAnalyzed(appendRecSetBoundary(nil, source))
+		}
 	}
 	if access.impossible() {
 		if !isOuter {
@@ -1575,26 +1577,20 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 		nullArgs[0] = neutral
 		return scm.Apply(mapReduce, nullArgs...)
 	}
-	var scratch *scanAnalyzeScratch
-	if access.len() > 0 {
-		scratch = acquireScanAnalyzeScratch()
-		defer releaseScanAnalyzeScratch(scratch)
-		access = access.useScratch(scratch)
-	}
+	executionAccess := access
 	if Settings.ScanDebugging {
 		dbg := fmt.Sprintf("[SCAN] %s.%s", t.schema.Name, t.Name)
-		for i := 0; i < access.len(); i++ {
-			b := access.boundary(i)
-			dbg += fmt.Sprintf(" %s:[%v..%v]", b.col, b.lower, b.upper)
+		for i := 0; i < executionAccess.len(); i++ {
+			dbg += fmt.Sprintf(" %s:[%v..%v]", executionAccess.boundaryColumn(i),
+				executionAccess.boundValue(i, false), executionAccess.boundValue(i, true))
 		}
-		indexBounds := newScanIndexBounds(access)
+		indexBounds := newScanIndexBounds(executionAccess)
 		dbg += fmt.Sprintf(" lower-count=%d upper=%v", indexBounds.len(), indexBounds.upperLast())
 		fmt.Println(dbg)
 	}
 	// give sharding hints
-	for i := 0; i < access.len(); i++ {
-		b := access.boundary(i)
-		t.AddPartitioningScore([]string{b.col})
+	for i := 0; i < executionAccess.len(); i++ {
+		t.AddPartitioningScore([]string{executionAccess.boundaryColumn(i)})
 	}
 
 	analyzeNs := time.Since(analyzeStart).Nanoseconds()
@@ -1606,8 +1602,8 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 	akkumulator := neutral
 	hadValue := false
 	var scanErr scanError
-	if topology, shard, single := t.pinSingleShardForScan(access); single {
-		msg := runDirectSingleShardScan(currentTx, topology, shard, access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, ss, querySeq)
+	if topology, shard, single := t.pinSingleShardForScan(executionAccess); single {
+		msg := runDirectSingleShardScan(currentTx, topology, shard, executionAccess, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, ss, querySeq)
 		if msg.err.r != nil {
 			scanErr = msg.err
 		} else {
@@ -1623,7 +1619,7 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 		}
 	} else {
 		values := scanResultCollector{channelSize: t.shardResultBufferSize()}
-		done := t.iterateShardsParallel(currentTx, access, func(s *storageShard, solo bool) {
+		done := t.iterateShardsParallel(currentTx, executionAccess, func(s *storageShard, solo bool) {
 			defer func() {
 				if r := recover(); r != nil {
 					values.send(solo, scanResult{err: scanError{r, string(debug.Stack())}})
@@ -1634,7 +1630,7 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 			if ss != nil && ss.IsKilledSeq(querySeq) {
 				panic("query killed")
 			}
-			res, shardOutCount, shardCandidateCount := s.scan(access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+			res, shardOutCount, shardCandidateCount := s.scan(executionAccess, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
 			values.send(solo, scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount})
 		})
 		values.finish(done)
@@ -1701,8 +1697,8 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 	return akkumulator
 }
 
-func (t *storageShard) scanExists(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
-	_, found := t.scanFirstRecord(boundaries, conditionCols, condition, currentTx, ss, stop)
+func (t *storageShard) scanExists(access scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
+	_, found := t.scanFirstRecord(access, conditionCols, condition, currentTx, ss, stop)
 	return found
 }
 
@@ -1840,19 +1836,19 @@ func (t *storageShard) filterVisibleBatchedScanBatch(batch []uint32, batchIDs []
 	return outN
 }
 
-func (t *storageShard) scanFirstRecord(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
+func (t *storageShard) scanFirstRecord(access scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := scanConditionAlwaysTrue(&conditionProgram, len(conditionCols)) ||
-		scanAccessProvesCondition(conditionCols, condition, boundaries)
+		scanAccessProvesCondition(conditionCols, condition, access)
 
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
-	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
+	t.ensureScanAccessColumns(access, skipShardReadLock, currentTx)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(access, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -1911,7 +1907,7 @@ func (t *storageShard) scanFirstRecord(boundaries scanAccess, conditionCols []st
 
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(uniquePointScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
-	t.iterateIndex(currentTx, boundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, access, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}
@@ -2002,9 +1998,9 @@ func (t *storageShard) scanFirstRecord(boundaries scanAccess, conditionCols []st
 	return foundID, found
 }
 
-func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scan(access scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
 	if stride > 0 {
-		return t.scanBatch(boundaries, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+		return t.scanBatch(access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
 	}
 	akkumulator := neutral
 	var outCount int64
@@ -2027,7 +2023,7 @@ func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condi
 	// read may trust its exact access proof, but a mutation must recheck the
 	// visible row before applying update/delete pseudo-columns.
 	conditionAlwaysTrue = conditionAlwaysTrue || !hasMutationCallback &&
-		scanAccessProvesCondition(conditionCols, condition, boundaries)
+		scanAccessProvesCondition(conditionCols, condition, access)
 
 	// Ensure shard is loaded from disk before accessing columns.
 	// ensureLoaded() must run before getColumnStorageOrPanic so that COLD
@@ -2035,7 +2031,7 @@ func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condi
 	// ensureMainCount then loads at least one column to initialize main_count.
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	t.ensureScanAccessColumns(boundaries, false, currentTx)
+	t.ensureScanAccessColumns(access, false, currentTx)
 	// Most scans do not read an ordered computed column. Keep discovery on the
 	// caller's stack and inspect the two existing column slices directly, so the
 	// correctness preflight below adds no heap work to an ordinary scan.
@@ -2116,7 +2112,7 @@ func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condi
 		}
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(access, t.t, conditionCols, condition)
 
 	// condition column readers
 	var ccols []ColumnStorage
@@ -2198,11 +2194,11 @@ func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condi
 	}
 
 	// filter phase: iterateIndex fills the reusable buffer, callback filters in-place and flushes to MapReducer
-	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(t.t.scanBufferSize(boundaries))
+	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(t.t.scanBufferSize(access))
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 	hadValue := false
 
-	t.iterateIndex(currentTx, boundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, access, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		candidateCount += int64(len(batch))
 		outN := t.filterVisibleScanBatch(batch, visibleUpper, hasMutationCallback, currentTx, mutationSeen)
 		if !conditionAlwaysTrue && outN > 0 {
@@ -2341,7 +2337,7 @@ func (t *storageShard) hasOrderedScanProxy(cols []string, currentTx *TxContext) 
 	return false
 }
 
-func (t *storageShard) scanBatch(boundaries scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scanBatch(access scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
 	akkumulator := neutral
 	var outCount int64
 	var candidateCount int64
@@ -2359,7 +2355,7 @@ func (t *storageShard) scanBatch(boundaries scanAccess, conditionCols []string, 
 		}
 	}
 	conditionAlwaysTrue = conditionAlwaysTrue || !hasMutationCallback &&
-		scanAccessProvesCondition(conditionCols, condition, boundaries)
+		scanAccessProvesCondition(conditionCols, condition, access)
 
 	t.ensureLoaded()
 	ownsWrite := false
@@ -2380,8 +2376,8 @@ func (t *storageShard) scanBatch(boundaries scanAccess, conditionCols []string, 
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
 	t.ensureMainCount(skipShardReadLock)
-	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
+	t.ensureScanAccessColumns(access, skipShardReadLock, currentTx)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(access, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -2462,14 +2458,11 @@ func (t *storageShard) scanBatch(boundaries scanAccess, conditionCols []string, 
 	var batchBuf [1024]uint32
 	hadValue := false
 	batchCount := len(batchdata) / stride
-	batchAccessScratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(batchAccessScratch)
-	boundaries = boundaries.useScratch(batchAccessScratch)
 	for batchid := 0; batchid < batchCount; batchid++ {
-		if boundaries.impossibleBatch(stride, batchdata, batchid) {
+		if access.impossibleBatch(stride, batchdata, batchid) {
 			continue
 		}
-		currentBoundaries := boundaries.withBatch(stride, batchdata, batchid)
+		currentBoundaries := access.withBatch(stride, batchdata, batchid)
 
 		t.iterateIndex(currentTx, currentBoundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -30,8 +30,6 @@ type scanError struct {
 	stack string
 }
 
-const scanAnalyzeScratchCapacity = 8
-
 const scanAccessSchemaHeaderSize = 1
 const scanAccessBoundaryStride = 4
 
@@ -111,16 +109,11 @@ func decodeScanAccessHeader(value scm.Scmer) (scanAccessSchemaMeta, bool) {
 
 var emptyScanAccessSchema = newScanAccessSchema(scanAccessConsumerScan, nil, -1)
 
-// scanAnalyzeScratch owns the short-lived physical analyzer output until all
-// parallel shard consumers have completed. A pool is preferable to a caller
-// stack array here: the shard callback escapes into goroutines, which would
-// force the complete stack array onto the heap on every scan. Most SQL scans
-// fit in these inline buffers; unusual wide predicates retain the ordinary
-// append fallback without changing analyzer semantics.
+// scanAnalyzeScratch owns invocation-local bindings which must remain valid
+// until all shard consumers have completed. Compiled schema and values remain
+// borrowed; only optional runtime overlays and batch coordinates live here.
 type scanAnalyzeScratch struct {
-	runtime         scanAccessRuntime
-	batchBoundaries [scanAnalyzeScratchCapacity]columnboundaries
-	lower           [scanAnalyzeScratchCapacity]scm.Scmer
+	runtime scanAccessRuntime
 }
 
 var scanAnalyzeScratchPool = sync.Pool{
@@ -133,8 +126,6 @@ func acquireScanAnalyzeScratch() *scanAnalyzeScratch {
 
 func releaseScanAnalyzeScratch(scratch *scanAnalyzeScratch) {
 	scratch.runtime = scanAccessRuntime{}
-	clear(scratch.batchBoundaries[:])
-	clear(scratch.lower[:])
 	scanAnalyzeScratchPool.Put(scratch)
 }
 
@@ -1413,14 +1404,16 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, accessSchem
 		defer releaseScanAnalyzeScratch(scratch)
 		access = access.useScratch(scratch)
 	}
-	var lowerStorage []scm.Scmer
-	if scratch != nil {
-		lowerStorage = scratch.lower[:0]
-	}
-	lower, upperLast := indexFromScanAccessInto(lowerStorage, access)
 	for i := 0; i < access.len(); i++ {
 		b := access.boundary(i)
 		t.AddPartitioningScore([]string{b.col})
+	}
+	if topology, shard, single := t.pinSingleShardForScan(access); single {
+		found, scanErr := runDirectSingleShardExists(currentTx, topology, shard, access, conditionCols, condition, ss, querySeq)
+		if scanErr.r != nil {
+			panic(scanErr)
+		}
+		return found
 	}
 
 	values := scanResultCollector{channelSize: t.shardResultBufferSize()}
@@ -1440,7 +1433,7 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, accessSchem
 		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
-		if s.scanExists(access, lower, upperLast, conditionCols, condition, currentTx, ss, &found) {
+		if s.scanExists(access, conditionCols, condition, currentTx, ss, &found) {
 			found.Store(true)
 			values.send(solo, scanResult{outCount: 1})
 			return
@@ -1467,6 +1460,28 @@ func (t *table) scanExistsFrom(currentTx *TxContext, source *recSet, accessSchem
 	return found.Load()
 }
 
+func runDirectSingleShardExists(currentTx *TxContext, topology *tableShardTopology, shard *storageShard, access scanAccess, conditionCols []string, condition scm.Scmer, ss *scm.SessionState, querySeq uint64) (found bool, scanErr scanError) {
+	defer topology.releaseOperation()
+	defer shard.activeScanners.Add(-1)
+	release := shard.acquireReadForScan(currentTx)
+	defer release()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			scanErr = scanError{recovered, string(debug.Stack())}
+		}
+	}()
+	if ss != nil && ss.IsKilledSeq(querySeq) {
+		panic("query killed")
+	}
+	if scm.Trace == nil {
+		return shard.scanExists(access, conditionCols, condition, currentTx, ss, nil), scanError{}
+	}
+	scm.Trace.Duration(fmt.Sprintf("%p", shard), "shard", func() {
+		found = shard.scanExists(access, conditionCols, condition, currentTx, ss, nil)
+	})
+	return found, scanError{}
+}
+
 // Fused map-reduce implementation based on Scheme callbacks.
 func (t *table) scan(currentTx *TxContext, accessSchema scm.Scmer, accessValues []scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, combine scm.Scmer, isOuter bool) scm.Scmer {
 	return t.scanWithBatchFrom(currentTx, nil, accessSchema, accessValues, scanAccess{}, conditionCols, condition, callbackCols, mapReduce, neutral, combine, isOuter, 0, nil)
@@ -1474,6 +1489,30 @@ func (t *table) scan(currentTx *TxContext, accessSchema scm.Scmer, accessValues 
 
 func (t *table) scanWithBatch(currentTx *TxContext, accessSchema scm.Scmer, accessValues []scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, combine scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
 	return t.scanWithBatchFrom(currentTx, nil, accessSchema, accessValues, scanAccess{}, conditionCols, condition, callbackCols, mapReduce, neutral, combine, isOuter, stride, batchdata)
+}
+
+func runDirectSingleShardScan(currentTx *TxContext, topology *tableShardTopology, shard *storageShard, access scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, ss *scm.SessionState, querySeq uint64) (result scanResult) {
+	defer topology.releaseOperation()
+	defer shard.activeScanners.Add(-1)
+	release := shard.acquireReadForScan(currentTx)
+	defer release()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = scanResult{err: scanError{recovered, string(debug.Stack())}}
+		}
+	}()
+	if ss != nil && ss.IsKilledSeq(querySeq) {
+		panic("query killed")
+	}
+	if scm.Trace == nil {
+		result.res, result.outCount, result.candidateCount = shard.scan(access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+	} else {
+		scm.Trace.Duration(fmt.Sprintf("%p", shard), "shard", func() {
+			result.res, result.outCount, result.candidateCount = shard.scan(access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+		})
+	}
+	result.inputCount = int64(shard.Count())
+	return result
 }
 
 func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSchema scm.Scmer, accessValues []scm.Scmer, requiredAccess scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, combine scm.Scmer, isOuter bool, stride int, batchdata []scm.Scmer) scm.Scmer {
@@ -1529,18 +1568,14 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 		defer releaseScanAnalyzeScratch(scratch)
 		access = access.useScratch(scratch)
 	}
-	var lowerStorage []scm.Scmer
-	if scratch != nil {
-		lowerStorage = scratch.lower[:0]
-	}
-	lower, upperLast := indexFromScanAccessInto(lowerStorage, access)
 	if Settings.ScanDebugging {
 		dbg := fmt.Sprintf("[SCAN] %s.%s", t.schema.Name, t.Name)
 		for i := 0; i < access.len(); i++ {
 			b := access.boundary(i)
 			dbg += fmt.Sprintf(" %s:[%v..%v]", b.col, b.lower, b.upper)
 		}
-		dbg += fmt.Sprintf(" lower=%v upper=%v", lower, upperLast)
+		indexBounds := newScanIndexBounds(access)
+		dbg += fmt.Sprintf(" lower-count=%d upper=%v", indexBounds.len(), indexBounds.upperLast())
 		fmt.Println(dbg)
 	}
 	// give sharding hints
@@ -1555,72 +1590,84 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 	var outCount int64
 	var inputCount int64
 	var candidateCount int64
-	values := scanResultCollector{channelSize: t.shardResultBufferSize()}
-	done := t.iterateShardsParallel(currentTx, access, func(s *storageShard, solo bool) {
-		defer func() {
-			if r := recover(); r != nil {
-				values.send(solo, scanResult{err: scanError{r, string(debug.Stack())}})
-			}
-		}()
-		// Cancellation contract: check only at the scheduling boundary, before entering
-		// the shard. Once entered, a shard runs atomically without cancellation checks.
-		if ss != nil && ss.IsKilledSeq(querySeq) {
-			panic("query killed")
-		}
-		res, shardOutCount, shardCandidateCount := s.scan(access, lower, upperLast, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
-		values.send(solo, scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount})
-	})
-	values.finish(done)
-
 	akkumulator := neutral
 	hadValue := false
 	var scanErr scanError
-	if !combine.IsNil() {
-		fn := scm.OptimizeProcToSerialFunction(combine)
-		for msg, ok := values.next(); ok; msg, ok = values.next() {
-			if msg.err.r != nil {
-				if scanErr.r == nil {
-					scanErr = msg.err
-				}
-				continue
-			}
-			if scanErr.r != nil {
-				continue
-			}
-			inputCount += msg.inputCount
-			candidateCount += msg.candidateCount
-			outCount += msg.outCount
+	if topology, shard, single := t.pinSingleShardForScan(access); single {
+		msg := runDirectSingleShardScan(currentTx, topology, shard, access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, ss, querySeq)
+		if msg.err.r != nil {
+			scanErr = msg.err
+		} else {
+			inputCount = msg.inputCount
+			candidateCount = msg.candidateCount
+			outCount = msg.outCount
 			if msg.outCount > 0 {
-				akkumulator = fn(akkumulator, msg.res)
 				hadValue = true
+				if !combine.IsNil() {
+					akkumulator = scm.OptimizeProcToSerialFunction(combine)(akkumulator, msg.res)
+				}
 			}
-		}
-		if scanErr.r == nil && !hadValue && isOuter {
-			nullArgs := make([]scm.Scmer, len(callbackCols)+1)
-			nullArgs[0] = akkumulator
-			akkumulator = scm.Apply(mapReduce, nullArgs...)
 		}
 	} else {
-		for msg, ok := values.next(); ok; msg, ok = values.next() {
-			if msg.err.r != nil {
-				if scanErr.r == nil {
-					scanErr = msg.err
+		values := scanResultCollector{channelSize: t.shardResultBufferSize()}
+		done := t.iterateShardsParallel(currentTx, access, func(s *storageShard, solo bool) {
+			defer func() {
+				if r := recover(); r != nil {
+					values.send(solo, scanResult{err: scanError{r, string(debug.Stack())}})
 				}
-				continue
+			}()
+			// Cancellation contract: check only at the scheduling boundary, before entering
+			// the shard. Once entered, a shard runs atomically without cancellation checks.
+			if ss != nil && ss.IsKilledSeq(querySeq) {
+				panic("query killed")
 			}
-			if scanErr.r != nil {
-				continue
+			res, shardOutCount, shardCandidateCount := s.scan(access, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+			values.send(solo, scanResult{res: res, outCount: shardOutCount, inputCount: int64(s.Count()), candidateCount: shardCandidateCount})
+		})
+		values.finish(done)
+
+		if !combine.IsNil() {
+			fn := scm.OptimizeProcToSerialFunction(combine)
+			for msg, ok := values.next(); ok; msg, ok = values.next() {
+				if msg.err.r != nil {
+					if scanErr.r == nil {
+						scanErr = msg.err
+					}
+					continue
+				}
+				if scanErr.r != nil {
+					continue
+				}
+				inputCount += msg.inputCount
+				candidateCount += msg.candidateCount
+				outCount += msg.outCount
+				if msg.outCount > 0 {
+					akkumulator = fn(akkumulator, msg.res)
+					hadValue = true
+				}
 			}
-			inputCount += msg.inputCount
-			candidateCount += msg.candidateCount
-			outCount += msg.outCount
-			hadValue = hadValue || msg.outCount > 0
+		} else {
+			for msg, ok := values.next(); ok; msg, ok = values.next() {
+				if msg.err.r != nil {
+					if scanErr.r == nil {
+						scanErr = msg.err
+					}
+					continue
+				}
+				if scanErr.r != nil {
+					continue
+				}
+				inputCount += msg.inputCount
+				candidateCount += msg.candidateCount
+				outCount += msg.outCount
+				hadValue = hadValue || msg.outCount > 0
+			}
 		}
-		if scanErr.r == nil && !hadValue && isOuter {
-			nullArgs := make([]scm.Scmer, len(callbackCols)+1)
-			nullArgs[0] = akkumulator
-			akkumulator = scm.Apply(mapReduce, nullArgs...)
-		}
+	}
+	if scanErr.r == nil && !hadValue && isOuter {
+		nullArgs := make([]scm.Scmer, len(callbackCols)+1)
+		nullArgs[0] = akkumulator
+		akkumulator = scm.Apply(mapReduce, nullArgs...)
 	}
 	if scanErr.r != nil {
 		panic(scanErr)
@@ -1631,26 +1678,18 @@ func (t *table) scanWithBatchFrom(currentTx *TxContext, source *recSet, accessSc
 		// Boundaries may live in pooled scan scratch. Encode them before the
 		// asynchronous logger starts so no reference outlives this scan.
 		indexColsEnc := scanAccessIndexCols(access)
-		go func(anNs, exNs int64, indexColsEnc string) {
-			defer func() { _ = recover() }()
-			filterEnc := ""
-			if proc, ok := condition.Any().(scm.Proc); ok {
-				var params []scm.Scmer
-				if proc.Params.IsSlice() {
-					params = proc.Params.Slice()
-				} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
-					params = arr
-				}
-				filterEnc = encodeScmerToString(proc.Body, conditionCols, params)
-			}
-			safeLogScan(t.schema.Name, t.Name, false, filterEnc, "", indexColsEnc, inputCount, candidateCount, outCount, anNs, exNs)
-		}(analyzeNs, execNs, indexColsEnc)
+		enqueueScanLog(scanLogEvent{
+			schema: t.schema.Name, table: t.Name, indexCols: indexColsEnc,
+			inputCount: inputCount, candidateCount: candidateCount, outputCount: outCount,
+			analyzeNs: analyzeNs, execNs: execNs, condition: condition,
+			conditionCols: conditionCols, encodeCondition: true,
+		})
 	}
 	return akkumulator
 }
 
-func (t *storageShard) scanExists(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
-	_, found := t.scanFirstRecord(boundaries, lower, upperLast, conditionCols, condition, currentTx, ss, stop)
+func (t *storageShard) scanExists(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) bool {
+	_, found := t.scanFirstRecord(boundaries, conditionCols, condition, currentTx, ss, stop)
 	return found
 }
 
@@ -1788,7 +1827,7 @@ func (t *storageShard) filterVisibleBatchedScanBatch(batch []uint32, batchIDs []
 	return outN
 }
 
-func (t *storageShard) scanFirstRecord(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
+func (t *storageShard) scanFirstRecord(boundaries scanAccess, conditionCols []string, condition scm.Scmer, currentTx *TxContext, ss *scm.SessionState, stop *atomic.Bool) (uint32, bool) {
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
@@ -1800,7 +1839,7 @@ func (t *storageShard) scanFirstRecord(boundaries scanAccess, lower []scm.Scmer,
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
 	t.ensureMainCount(skipShardReadLock)
 	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -1859,7 +1898,7 @@ func (t *storageShard) scanFirstRecord(boundaries scanAccess, lower []scm.Scmer,
 
 	buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(uniquePointScanBufferSize)
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		if stop != nil && stop.Load() {
 			return false
 		}
@@ -1950,9 +1989,9 @@ func (t *storageShard) scanFirstRecord(boundaries scanAccess, lower []scm.Scmer,
 	return foundID, found
 }
 
-func (t *storageShard) scan(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scan(boundaries scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
 	if stride > 0 {
-		return t.scanBatch(boundaries, lower, upperLast, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
+		return t.scanBatch(boundaries, conditionCols, condition, callbackCols, mapReduce, neutral, stride, batchdata, currentTx, ss)
 	}
 	akkumulator := neutral
 	var outCount int64
@@ -2064,7 +2103,7 @@ func (t *storageShard) scan(boundaries scanAccess, lower []scm.Scmer, upperLast 
 		}
 	}
 	skipShardReadLock := ownsWrite || lockMutationExclusively
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
 
 	// condition column readers
 	var ccols []ColumnStorage
@@ -2095,10 +2134,11 @@ func (t *storageShard) scan(boundaries scanAccess, lower []scm.Scmer, upperLast 
 
 	// MapReducer for the fused callback phase (builds column readers internally)
 	var mapperStorage ShardMapReducer
-	var mapperWorkspace shardMapReducerWorkspace
 	mapper := &mapperStorage
 	if mapReducerCanUseReadWorkspace(callbackCols) {
-		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		mapperWorkspace := acquireShardMapReducerWorkspace()
+		defer releaseShardMapReducerWorkspace(mapperWorkspace)
+		prepareReadMapReducerStorage(&mapperStorage, mapperWorkspace, len(callbackCols))
 		t.initReadMapReducer(&mapperStorage, callbackCols, mapReduce, skipShardReadLock, currentTx)
 	} else {
 		mapper = t.OpenMapReducer(callbackCols, mapReduce, skipShardReadLock, 0, nil, currentTx)
@@ -2149,7 +2189,7 @@ func (t *storageShard) scan(boundaries scanAccess, lower []scm.Scmer, upperLast 
 	defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 	hadValue := false
 
-	t.iterateIndex(currentTx, boundaries, lower, upperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, boundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 		candidateCount += int64(len(batch))
 		outN := t.filterVisibleScanBatch(batch, visibleUpper, hasMutationCallback, currentTx, mutationSeen)
 		if !conditionAlwaysTrue && outN > 0 {
@@ -2288,7 +2328,7 @@ func (t *storageShard) hasOrderedScanProxy(cols []string, currentTx *TxContext) 
 	return false
 }
 
-func (t *storageShard) scanBatch(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
+func (t *storageShard) scanBatch(boundaries scanAccess, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, stride int, batchdata []scm.Scmer, currentTx *TxContext, ss *scm.SessionState) (scm.Scmer, int64, int64) {
 	akkumulator := neutral
 	var outCount int64
 	var candidateCount int64
@@ -2328,7 +2368,7 @@ func (t *storageShard) scanBatch(boundaries scanAccess, lower []scm.Scmer, upper
 	skipShardReadLock := ownsWrite || lockMutationExclusively
 	t.ensureMainCount(skipShardReadLock)
 	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
 
 	var ccols []ColumnStorage
 	var cReaders []ColumnReader
@@ -2367,10 +2407,11 @@ func (t *storageShard) scanBatch(boundaries scanAccess, lower []scm.Scmer, upper
 	}
 
 	var mapperStorage ShardMapReducer
-	var mapperWorkspace shardMapReducerWorkspace
 	mapper := &mapperStorage
-	if stride == 0 && mapReducerCanUseReadWorkspace(callbackCols) {
-		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+	if mapReducerCanUseReadWorkspace(callbackCols) {
+		mapperWorkspace := acquireShardMapReducerWorkspace()
+		defer releaseShardMapReducerWorkspace(mapperWorkspace)
+		prepareReadMapReducerStorage(&mapperStorage, mapperWorkspace, len(callbackCols))
 		t.initReadMapReducer(&mapperStorage, callbackCols, mapReduce, skipShardReadLock, currentTx)
 	} else {
 		mapper = t.OpenMapReducer(callbackCols, mapReduce, skipShardReadLock, stride, batchdata, currentTx)
@@ -2408,28 +2449,16 @@ func (t *storageShard) scanBatch(boundaries scanAccess, lower []scm.Scmer, upper
 	var batchBuf [1024]uint32
 	hadValue := false
 	batchCount := len(batchdata) / stride
-	batchBoundaries := hasBatchScanAccess(boundaries)
-	var batchAccessScratch *scanAnalyzeScratch
-	if batchBoundaries {
-		batchAccessScratch = acquireScanAnalyzeScratch()
-		defer releaseScanAnalyzeScratch(batchAccessScratch)
-	}
-	activeBoundaries := scanAccess{plannerFilterCovered: scanAccessCoversResidual(boundaries)}
-
+	batchAccessScratch := acquireScanAnalyzeScratch()
+	defer releaseScanAnalyzeScratch(batchAccessScratch)
+	boundaries = boundaries.useScratch(batchAccessScratch)
 	for batchid := 0; batchid < batchCount; batchid++ {
 		if boundaries.impossibleBatch(stride, batchdata, batchid) {
 			continue
 		}
-		currentBoundaries := boundaries
-		activeLower := lower
-		activeUpperLast := upperLast
-		if batchBoundaries {
-			activeBoundaries.native = materializeBatchScanAccessInto(batchAccessScratch.batchBoundaries[:0], boundaries, stride, batchdata, uint32(batchid))
-			currentBoundaries = activeBoundaries
-			activeLower, activeUpperLast = indexFromScanAccessInto(batchAccessScratch.lower[:0], currentBoundaries)
-		}
+		currentBoundaries := boundaries.withBatch(stride, batchdata, batchid)
 
-		t.iterateIndex(currentTx, currentBoundaries, activeLower, activeUpperLast, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
+		t.iterateIndex(currentTx, currentBoundaries, maxInsertIndex, buf, 1, nil, func(batch []uint32) bool {
 			candidateCount += int64(len(batch))
 			outN := t.filterVisibleBatchedScanBatch(batch, batchBuf[:], uint32(batchid), visibleUpper, hasMutationCallback, currentTx, mutationSeen)
 			if !conditionAlwaysTrue {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -31,7 +31,7 @@ type scanError struct {
 }
 
 const scanAccessSchemaHeaderSize = 1
-const scanAccessBoundaryStride = 4
+const scanAccessBoundaryStride = 1
 
 const scanAccessConsumerScan = "scan"
 const scanAccessConsumerCoveredScan = "scan_covered"
@@ -291,17 +291,20 @@ func shiftCompiledScanAccessSlots(schemaValue scm.Scmer, shift int) scm.Scmer {
 		panic("invalid scan access header")
 	}
 	for offset, count := scanAccessSchemaHeaderSize, meta.count; count > 0; offset, count = offset+scanAccessBoundaryStride, count-1 {
-		boundaryMeta := decodeScanAccessBoundaryMeta(shifted[offset+2])
-		if boundaryMeta.lowerSlot >= 0 {
-			boundaryMeta.lowerSlot += shift
+		boundary := ScanBoundaryFromScmer(shifted[offset])
+		lowerSlot, upperSlot, mapperSlot := boundary.LowerSlot(), boundary.UpperSlot(), boundary.MapperSlot()
+		if lowerSlot >= 0 {
+			lowerSlot += shift
 		}
-		if boundaryMeta.upperSlot >= 0 {
-			boundaryMeta.upperSlot += shift
+		if upperSlot >= 0 {
+			upperSlot += shift
 		}
-		if mapperSlot := boundaryMeta.flags >> 3; mapperSlot > 0 {
-			boundaryMeta.flags = boundaryMeta.flags&7 | (mapperSlot+int64(shift))<<3
+		if mapperSlot >= 0 {
+			mapperSlot += shift
 		}
-		shifted[offset+2] = newScanAccessBoundaryMeta(boundaryMeta.lowerSlot, boundaryMeta.upperSlot, boundaryMeta.flags)
+		shifted[offset] = newScanBoundarySpec(boundary.ColumnName(), boundary.Analyzer(), lowerSlot, upperSlot,
+			boundary.LowerInclusive(), boundary.UpperInclusive(), boundary.Collation(), boundary.NullSafe(), mapperSlot,
+			boundary.MapColumns(), boundary.Order(), boundary.OrderMetadata(), boundary.Mandatory())
 	}
 	return scm.NewSlice(shifted)
 }
@@ -872,9 +875,19 @@ func compileScanAccessMode(columnExpr, filterExpr scm.Scmer, allowBatch bool) (s
 			}))
 			flags |= int64(mapperSlot+1) << 3
 		}
-		schema = append(schema,
-			scm.NewString(boundary.kind), scm.NewString(boundary.column),
-			newScanAccessBoundaryMeta(int(lowerSlot), int(upperSlot), flags), scm.NewString(boundary.collation))
+		matcher := EqualMatcher
+		switch boundary.kind {
+		case "range":
+			matcher = RangeMatcher
+		case "like":
+			matcher = LikeMatcher
+		case "recset":
+			matcher = RecSetMatcher
+		}
+		mapperSlot := int(flags>>3) - 1
+		schema = append(schema, newScanBoundarySpec(boundary.column, matcher, int(lowerSlot), int(upperSlot),
+			boundary.lowerInclusive, boundary.upperInclusive, boundary.collation, boundary.nullSafe,
+			mapperSlot, boundary.mapCols, nil, "", false))
 	}
 	for _, column := range mapCols {
 		schema = append(schema, scm.NewString(column))

--- a/storage/scan_batch_rewrite.go
+++ b/storage/scan_batch_rewrite.go
@@ -478,14 +478,17 @@ func rewriteBatchScanAccess(schemaExpr, valuesExpr scm.Scmer, mapping map[string
 		boundaryCount := header.count
 		for boundary := 0; boundary < boundaryCount; boundary++ {
 			base := scanAccessSchemaHeaderSize + boundary*scanAccessBoundaryStride
-			meta := decodeScanAccessBoundaryMeta(rewrittenSchema[base+2])
-			if meta.lowerSlot == valueSlot {
-				meta.lowerSlot = encodedSlot
+			spec := ScanBoundaryFromScmer(rewrittenSchema[base])
+			lowerSlot, upperSlot := spec.LowerSlot(), spec.UpperSlot()
+			if lowerSlot == valueSlot {
+				lowerSlot = encodedSlot
 			}
-			if meta.upperSlot == valueSlot {
-				meta.upperSlot = encodedSlot
+			if upperSlot == valueSlot {
+				upperSlot = encodedSlot
 			}
-			rewrittenSchema[base+2] = newScanAccessBoundaryMeta(meta.lowerSlot, meta.upperSlot, meta.flags)
+			rewrittenSchema[base] = newScanBoundarySpec(spec.ColumnName(), spec.Analyzer(), lowerSlot, upperSlot,
+				spec.LowerInclusive(), spec.UpperInclusive(), spec.Collation(), spec.NullSafe(), spec.MapperSlot(),
+				spec.MapColumns(), spec.Order(), spec.OrderMetadata(), spec.Mandatory())
 		}
 	}
 	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(rewrittenSchema)}),

--- a/storage/scan_boundary.go
+++ b/storage/scan_boundary.go
@@ -16,6 +16,7 @@ Copyright (C) 2026  Carl-Philip Hänsch
 */
 package storage
 
+import "encoding/json"
 import "fmt"
 import "unsafe"
 
@@ -81,7 +82,6 @@ func (b *scanBoundarySpec) Mandatory() bool                     { return b.manda
 // The box is allocated once while constructing a cached plan, never while a
 // scan is executing.
 type scanBoundaryBox struct {
-	boundary       ScanBoundary
 	column         string
 	analyzer       IndexAnalyzer
 	lowerSlot      int
@@ -97,12 +97,26 @@ type scanBoundaryBox struct {
 	mandatory      bool
 }
 
+func (b *scanBoundaryBox) ColumnName() string                  { return b.column }
+func (b *scanBoundaryBox) Analyzer() IndexAnalyzer             { return b.analyzer }
+func (b *scanBoundaryBox) LowerSlot() int                      { return b.lowerSlot }
+func (b *scanBoundaryBox) UpperSlot() int                      { return b.upperSlot }
+func (b *scanBoundaryBox) LowerInclusive() bool                { return b.lowerInclusive }
+func (b *scanBoundaryBox) UpperInclusive() bool                { return b.upperInclusive }
+func (b *scanBoundaryBox) Collation() string                   { return b.collation }
+func (b *scanBoundaryBox) NullSafe() bool                      { return b.nullSafe }
+func (b *scanBoundaryBox) MapperSlot() int                     { return b.mapperSlot }
+func (b *scanBoundaryBox) MapColumns() []string                { return b.mapColumns }
+func (b *scanBoundaryBox) Order() func(...scm.Scmer) scm.Scmer { return b.order }
+func (b *scanBoundaryBox) OrderMetadata() string               { return b.orderMetadata }
+func (b *scanBoundaryBox) Mandatory() bool                     { return b.mandatory }
+
 func NewScanBoundaryScmer(boundary ScanBoundary) scm.Scmer {
 	if boundary == nil || boundary.Analyzer() == nil {
 		panic("scan boundary requires an analyzer")
 	}
 	box := &scanBoundaryBox{
-		boundary: boundary, column: boundary.ColumnName(), analyzer: boundary.Analyzer(),
+		column: boundary.ColumnName(), analyzer: boundary.Analyzer(),
 		lowerSlot: boundary.LowerSlot(), upperSlot: boundary.UpperSlot(),
 		lowerInclusive: boundary.LowerInclusive(), upperInclusive: boundary.UpperInclusive(),
 		collation: boundary.Collation(), nullSafe: boundary.NullSafe(), mapperSlot: boundary.MapperSlot(),
@@ -114,10 +128,10 @@ func NewScanBoundaryScmer(boundary ScanBoundary) scm.Scmer {
 
 func ScanBoundaryFromScmer(value scm.Scmer) ScanBoundary {
 	box := (*scanBoundaryBox)(value.Custom(TagScanBoundary))
-	if box == nil || box.boundary == nil {
+	if box == nil || box.analyzer == nil {
 		panic("invalid scan boundary")
 	}
-	return box.boundary
+	return box
 }
 
 func scanBoundaryAnalyzer(kind string) IndexAnalyzer {
@@ -140,6 +154,79 @@ func scanBoundaryString(pointer unsafe.Pointer) string {
 	return fmt.Sprintf("(scan_boundary %q %q %d %d %t %t %q %t)",
 		box.analyzer.Kind(), box.column, box.lowerSlot, box.upperSlot,
 		box.lowerInclusive, box.upperInclusive, box.collation, box.nullSafe)
+}
+
+func scanBoundaryJSONEncode(pointer unsafe.Pointer) any {
+	box := (*scanBoundaryBox)(pointer)
+	if box.order != nil || box.orderMetadata != "" {
+		panic("ordered runtime scan boundaries cannot be persisted")
+	}
+	mapColumns := box.mapColumns
+	if mapColumns == nil {
+		mapColumns = []string{}
+	}
+	return []any{
+		box.analyzer.Kind(), box.column, box.lowerSlot, box.upperSlot,
+		box.lowerInclusive, box.upperInclusive, box.collation, box.nullSafe,
+		box.mapperSlot, mapColumns, box.mandatory,
+	}
+}
+
+func scanBoundaryJSONInt(value any) int {
+	switch number := value.(type) {
+	case json.Number:
+		result, err := number.Int64()
+		if err == nil {
+			return int(result)
+		}
+	case float64:
+		return int(number)
+	case int:
+		return number
+	}
+	panic("invalid persisted scan boundary slot")
+}
+
+func scanBoundaryJSONDecode(value any) unsafe.Pointer {
+	items, ok := value.([]any)
+	if !ok || len(items) != 11 {
+		panic("invalid persisted scan boundary")
+	}
+	kind, kindOK := items[0].(string)
+	column, columnOK := items[1].(string)
+	lowerInclusive, lowerOK := items[4].(bool)
+	upperInclusive, upperOK := items[5].(bool)
+	collation, collationOK := items[6].(string)
+	nullSafe, nullSafeOK := items[7].(bool)
+	mandatory, mandatoryOK := items[10].(bool)
+	mapItems, mapOK := items[9].([]any)
+	if !kindOK || !columnOK || !lowerOK || !upperOK || !collationOK || !nullSafeOK || !mandatoryOK || !mapOK {
+		panic("invalid persisted scan boundary fields")
+	}
+	mapColumns := make([]string, len(mapItems))
+	for i, item := range mapItems {
+		column, ok := item.(string)
+		if !ok {
+			panic("invalid persisted scan boundary map column")
+		}
+		mapColumns[i] = column
+	}
+	return unsafe.Pointer(&scanBoundaryBox{
+		column: column, analyzer: scanBoundaryAnalyzer(kind),
+		lowerSlot: scanBoundaryJSONInt(items[2]), upperSlot: scanBoundaryJSONInt(items[3]),
+		lowerInclusive: lowerInclusive, upperInclusive: upperInclusive,
+		collation: collation, nullSafe: nullSafe,
+		mapperSlot: scanBoundaryJSONInt(items[8]), mapColumns: mapColumns,
+		mandatory: mandatory,
+	})
+}
+
+func registerScanBoundaryFormats() {
+	scm.CustomStringer[TagScanBoundary] = scanBoundaryString
+	scm.CustomJSONCodecs[TagScanBoundary] = scm.CustomJSONCodec{
+		Encode: scanBoundaryJSONEncode,
+		Decode: scanBoundaryJSONDecode,
+	}
 }
 
 func newScanBoundarySpec(column string, analyzer IndexAnalyzer, lowerSlot, upperSlot int,
@@ -166,5 +253,86 @@ func newExactScanAccessSchema(columns []string) []scm.Scmer {
 
 func exactScanAccess(schema []scm.Scmer, values []scm.Scmer) scanAccess {
 	count := len(schema) - scanAccessSchemaHeaderSize
-	return scanAccess{schema: schema, values: values, compiledCount: count}
+	access := scanAccess{schema: schema, values: values, compiledCount: count, exactAdjacent: true}
+	if count > 0 {
+		access.firstBoundary = (*scanBoundaryBox)(schema[scanAccessSchemaHeaderSize].Custom(TagScanBoundary))
+	}
+	return access
+}
+
+// scanAccessSegmentFromAnalyzed is the phase boundary for the few storage
+// constraints that are still synthesized by Go (ORDER drivers, RecSets, and
+// maintenance probes). The analyzer-only structs never enter scanAccess:
+// execution receives the same Scheme boundary objects and adjacent values as a
+// planner-compiled SQL scan.
+func scanAccessSegmentFromAnalyzed(analyzed analyzedBoundaries) scanAccessSegment {
+	if len(analyzed) == 0 {
+		return scanAccessSegment{}
+	}
+	boxes := make([]scanBoundaryBox, len(analyzed))
+	items := make([]scm.Scmer, len(analyzed))
+	values := make([]scm.Scmer, 0, len(analyzed)*2)
+	for i, boundary := range analyzed {
+		lowerSlot := -1
+		if boundary.lowerBatch {
+			lowerSlot = -2 - boundary.lowerBatchSubidx
+		} else if boundary.matcher != RangeMatcher || !boundary.lower.IsNil() {
+			lowerSlot = len(values)
+			values = append(values, boundary.lower)
+		}
+		upperSlot := -1
+		if boundary.upperBatch {
+			upperSlot = -2 - boundary.upperBatchSubidx
+		} else if boundary.matcher != RangeMatcher || !boundary.upper.IsNil() {
+			if lowerSlot >= 0 && boundaryValueEqual(boundary.lower, boundary.upper) {
+				upperSlot = lowerSlot
+			} else {
+				upperSlot = len(values)
+				values = append(values, boundary.upper)
+			}
+		}
+		mapperSlot := -1
+		if !boundary.mapFn.IsNil() {
+			mapperSlot = len(values)
+			values = append(values, scm.NewSlice([]scm.Scmer{scm.NewString(boundary.col), boundary.mapFn}))
+		}
+		boxes[i] = scanBoundaryBox{
+			column: boundary.col, analyzer: boundary.matcher,
+			lowerSlot: lowerSlot, upperSlot: upperSlot,
+			lowerInclusive: boundary.lowerInclusive, upperInclusive: boundary.upperInclusive,
+			collation: boundary.collation, nullSafe: boundary.nullSafe,
+			mapperSlot: mapperSlot, mapColumns: boundary.mapCols,
+			order: boundary.order, orderMetadata: boundary.orderMeta,
+			mandatory: boundary.mandatory,
+		}
+		items[i] = scm.NewCustom(TagScanBoundary, unsafe.Pointer(&boxes[i]))
+	}
+	return scanAccessSegment{items: items, values: values}
+}
+
+func scanAccessFromAnalyzed(analyzed analyzedBoundaries) scanAccess {
+	segment := scanAccessSegmentFromAnalyzed(analyzed)
+	if len(segment.items) == 0 {
+		return scanAccess{}
+	}
+	schema := make([]scm.Scmer, scanAccessSchemaHeaderSize+len(segment.items))
+	schema[0] = newScanAccessHeader(len(segment.items), scanAccessConsumerScan, 0, -1)
+	copy(schema[scanAccessSchemaHeaderSize:], segment.items)
+	return scanAccess{
+		schema: schema, values: segment.values, compiledCount: len(segment.items),
+		firstBoundary: (*scanBoundaryBox)(segment.items[0].Custom(TagScanBoundary)),
+	}
+}
+
+func scanAccessAsSegment(access scanAccess) scanAccessSegment {
+	if access.runtime != nil {
+		panic("nested runtime scan access cannot be embedded")
+	}
+	if access.compiledCount == 0 {
+		return scanAccessSegment{}
+	}
+	return scanAccessSegment{
+		items:  access.schema[scanAccessSchemaHeaderSize : scanAccessSchemaHeaderSize+access.compiledCount],
+		values: access.values,
+	}
 }

--- a/storage/scan_boundary.go
+++ b/storage/scan_boundary.go
@@ -1,0 +1,170 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import "fmt"
+import "unsafe"
+
+import "github.com/launix-de/memcp/scm"
+
+// TagScanBoundary identifies immutable physical scan constraints. Boundary
+// objects belong to the cached plan; invocation-specific data stays in the
+// adjacent values array.
+const TagScanBoundary = 103
+
+// ScanBoundary is the immutable, Scheme-visible description of one physical
+// access dimension. Slots address the scan's flat runtime values array. A
+// negative slot means unbounded; slots <= -2 address a scan_batch input column.
+// Implementations must be immutable because cached plans share them across
+// concurrent executions.
+type ScanBoundary interface {
+	ColumnName() string
+	Analyzer() IndexAnalyzer
+	LowerSlot() int
+	UpperSlot() int
+	LowerInclusive() bool
+	UpperInclusive() bool
+	Collation() string
+	NullSafe() bool
+	MapperSlot() int
+	MapColumns() []string
+	Order() func(...scm.Scmer) scm.Scmer
+	OrderMetadata() string
+	Mandatory() bool
+}
+
+type scanBoundarySpec struct {
+	column         string
+	analyzer       IndexAnalyzer
+	lowerSlot      int
+	upperSlot      int
+	lowerInclusive bool
+	upperInclusive bool
+	collation      string
+	nullSafe       bool
+	mapperSlot     int
+	mapColumns     []string
+	order          func(...scm.Scmer) scm.Scmer
+	orderMetadata  string
+	mandatory      bool
+}
+
+func (b *scanBoundarySpec) ColumnName() string                  { return b.column }
+func (b *scanBoundarySpec) Analyzer() IndexAnalyzer             { return b.analyzer }
+func (b *scanBoundarySpec) LowerSlot() int                      { return b.lowerSlot }
+func (b *scanBoundarySpec) UpperSlot() int                      { return b.upperSlot }
+func (b *scanBoundarySpec) LowerInclusive() bool                { return b.lowerInclusive }
+func (b *scanBoundarySpec) UpperInclusive() bool                { return b.upperInclusive }
+func (b *scanBoundarySpec) Collation() string                   { return b.collation }
+func (b *scanBoundarySpec) NullSafe() bool                      { return b.nullSafe }
+func (b *scanBoundarySpec) MapperSlot() int                     { return b.mapperSlot }
+func (b *scanBoundarySpec) MapColumns() []string                { return b.mapColumns }
+func (b *scanBoundarySpec) Order() func(...scm.Scmer) scm.Scmer { return b.order }
+func (b *scanBoundarySpec) OrderMetadata() string               { return b.orderMetadata }
+func (b *scanBoundarySpec) Mandatory() bool                     { return b.mandatory }
+
+// scanBoundaryBox keeps the extensible interface behind one custom SCM tag.
+// The box is allocated once while constructing a cached plan, never while a
+// scan is executing.
+type scanBoundaryBox struct {
+	boundary       ScanBoundary
+	column         string
+	analyzer       IndexAnalyzer
+	lowerSlot      int
+	upperSlot      int
+	lowerInclusive bool
+	upperInclusive bool
+	collation      string
+	nullSafe       bool
+	mapperSlot     int
+	mapColumns     []string
+	order          func(...scm.Scmer) scm.Scmer
+	orderMetadata  string
+	mandatory      bool
+}
+
+func NewScanBoundaryScmer(boundary ScanBoundary) scm.Scmer {
+	if boundary == nil || boundary.Analyzer() == nil {
+		panic("scan boundary requires an analyzer")
+	}
+	box := &scanBoundaryBox{
+		boundary: boundary, column: boundary.ColumnName(), analyzer: boundary.Analyzer(),
+		lowerSlot: boundary.LowerSlot(), upperSlot: boundary.UpperSlot(),
+		lowerInclusive: boundary.LowerInclusive(), upperInclusive: boundary.UpperInclusive(),
+		collation: boundary.Collation(), nullSafe: boundary.NullSafe(), mapperSlot: boundary.MapperSlot(),
+		mapColumns: boundary.MapColumns(), order: boundary.Order(), orderMetadata: boundary.OrderMetadata(),
+		mandatory: boundary.Mandatory(),
+	}
+	return scm.NewCustom(TagScanBoundary, unsafe.Pointer(box))
+}
+
+func ScanBoundaryFromScmer(value scm.Scmer) ScanBoundary {
+	box := (*scanBoundaryBox)(value.Custom(TagScanBoundary))
+	if box == nil || box.boundary == nil {
+		panic("invalid scan boundary")
+	}
+	return box.boundary
+}
+
+func scanBoundaryAnalyzer(kind string) IndexAnalyzer {
+	switch kind {
+	case "equal":
+		return EqualMatcher
+	case "range":
+		return RangeMatcher
+	case "like":
+		return LikeMatcher
+	case "recset":
+		return RecSetMatcher
+	default:
+		panic("unknown scan boundary kind " + kind)
+	}
+}
+
+func scanBoundaryString(pointer unsafe.Pointer) string {
+	box := (*scanBoundaryBox)(pointer)
+	return fmt.Sprintf("(scan_boundary %q %q %d %d %t %t %q %t)",
+		box.analyzer.Kind(), box.column, box.lowerSlot, box.upperSlot,
+		box.lowerInclusive, box.upperInclusive, box.collation, box.nullSafe)
+}
+
+func newScanBoundarySpec(column string, analyzer IndexAnalyzer, lowerSlot, upperSlot int,
+	lowerInclusive, upperInclusive bool, collation string, nullSafe bool, mapperSlot int,
+	mapColumns []string, order func(...scm.Scmer) scm.Scmer, orderMetadata string, mandatory bool,
+) scm.Scmer {
+	return NewScanBoundaryScmer(&scanBoundarySpec{
+		column: column, analyzer: analyzer, lowerSlot: lowerSlot, upperSlot: upperSlot,
+		lowerInclusive: lowerInclusive, upperInclusive: upperInclusive,
+		collation: collation, nullSafe: nullSafe, mapperSlot: mapperSlot,
+		mapColumns: mapColumns, order: order, orderMetadata: orderMetadata, mandatory: mandatory,
+	})
+}
+
+func newExactScanAccessSchema(columns []string) []scm.Scmer {
+	schema := make([]scm.Scmer, scanAccessSchemaHeaderSize+len(columns))
+	schema[0] = newScanAccessHeader(len(columns), scanAccessConsumerScan, 0, -1)
+	for i, column := range columns {
+		schema[scanAccessSchemaHeaderSize+i] = newScanBoundarySpec(
+			column, EqualMatcher, i, i, true, true, "", false, -1, nil, nil, "", false)
+	}
+	return schema
+}
+
+func exactScanAccess(schema []scm.Scmer, values []scm.Scmer) scanAccess {
+	count := len(schema) - scanAccessSchemaHeaderSize
+	return scanAccess{schema: schema, values: values, compiledCount: count}
+}

--- a/storage/scan_column_cost_bench_test.go
+++ b/storage/scan_column_cost_bench_test.go
@@ -81,11 +81,10 @@ func TestEstimateFilteredRowsRecognizesCompleteCappedIndexRange(t *testing.T) {
 	})
 	shard := tbl.ActiveShards()[0]
 	bounds := extractBoundaries(cols[:1], condition)
-	lower, upperLast := indexFromBoundaries(bounds)
 	var buf [16]uint32
 	for range 2 {
 		shard.mu.RLock()
-		shard.iterateIndex(nil, runtimeScanAccess(bounds), lower, upperLast, len(shard.inserts), buf[:], 1, nil,
+		shard.iterateIndex(nil, runtimeScanAccess(bounds), len(shard.inserts), buf[:], 1, nil,
 			func([]uint32) bool { return true })
 		shard.mu.RUnlock()
 	}
@@ -124,10 +123,9 @@ func TestScanSelectivityEstimateScalesIndexCandidatesByShardPopulation(t *testin
 	shard := tbl.ActiveShards()[0]
 	for range 2 {
 		bounds := extractBoundaries([]string{"tenant"}, condition)
-		lower, upperLast := indexFromBoundaries(bounds)
 		var buf [128]uint32
 		shard.mu.RLock()
-		shard.iterateIndex(nil, runtimeScanAccess(bounds), lower, upperLast, len(shard.inserts), buf[:], 100, nil,
+		shard.iterateIndex(nil, runtimeScanAccess(bounds), len(shard.inserts), buf[:], 100, nil,
 			func([]uint32) bool { return true })
 		shard.mu.RUnlock()
 	}

--- a/storage/scan_family_bench_test.go
+++ b/storage/scan_family_bench_test.go
@@ -121,3 +121,25 @@ func BenchmarkScanFamilyFixedCosts(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkScanBatchCoveredFixedCosts isolates the steady-state setup of a
+// planner-covered batch scan. Its access schema, batch values and column lists
+// are retained exactly as they are in a cached physical plan.
+func BenchmarkScanBatchCoveredFixedCosts(b *testing.B) {
+	tbl := benchScanTable(b, "batch_covered")
+	accessSchema := newScanAccessSchema(scanAccessConsumerCoveredScan, nil, -1)
+	trueFn := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
+	mapReduceFn := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+	callbackCols := []string{"id"}
+	batchdata := []scm.Scmer{scm.NewInt(1)}
+	neutral := scm.NewNil()
+	tbl.scanWithBatch(nil, accessSchema, nil, nil, trueFn, callbackCols, mapReduceFn,
+		neutral, neutral, false, 1, batchdata)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tbl.scanWithBatch(nil, accessSchema, nil, nil, trueFn, callbackCols, mapReduceFn,
+			neutral, neutral, false, 1, batchdata)
+	}
+}

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -190,8 +190,8 @@ func BenchmarkScanUniquePointCompiledAccessWithTx(b *testing.B) {
 	condition := scanCondition("id", scm.NewInt(511))
 	mapReduceFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[1] })
 	schema := scm.NewSlice([]scm.Scmer{
-		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1), scm.NewString("equal"),
-		scm.NewString("id"), newScanAccessBoundaryMeta(0, 0, 3), scm.NewString(""),
+		newScanAccessHeader(1, scanAccessConsumerScan, 0, -1),
+		newScanBoundarySpec("id", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
 	})
 	values := []scm.Scmer{scm.NewInt(511)}
 	tbl.scanWithBatchFrom(tx, nil, schema, values, scanAccess{}, []string{"id"}, condition, []string{"label"}, mapReduceFn,
@@ -227,8 +227,8 @@ func BenchmarkScanUniquePointCoveredCompiledAccessWithTx(b *testing.B) {
 	condition := scanCondition("id", scm.NewInt(511))
 	mapReduceFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[1] })
 	schema := scm.NewSlice([]scm.Scmer{
-		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 0, -1), scm.NewString("equal"),
-		scm.NewString("id"), newScanAccessBoundaryMeta(0, 0, 3), scm.NewString(""),
+		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 0, -1),
+		newScanBoundarySpec("id", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
 	})
 	values := []scm.Scmer{scm.NewInt(511)}
 	conditionCols := []string{"id"}
@@ -287,6 +287,51 @@ func BenchmarkScanUniqueMainPoint(b *testing.B) {
 // by prepared SQL execution while retaining the same warm main-storage probe.
 func BenchmarkScanUniqueMainPointWithTx(b *testing.B) {
 	benchmarkUniqueMainPointScan(b, "read_tx", NewTxContext(TxCursorStability))
+}
+
+func benchmarkGetRecordIDForUnique(b *testing.B, value int64) {
+	dbName := "bench_unique_record_id"
+	databases.Remove(dbName)
+	b.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("value", "INT", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i * 2))}
+	}
+	tbl.Insert([]string{"id", "value"}, rows, nil, scm.NewNil(), false, nil)
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "PRIMARY", Cols: []string{"id"}})
+	result := GetDatabase(dbName).rebuild(true, false, true)
+	if len(result.errors) > 0 {
+		b.Fatalf("rebuild errors: %v", result.errors)
+	}
+	shard := tbl.Shards[0]
+	columns := []string{"id"}
+	values := []scm.Scmer{scm.NewInt(value)}
+	access := exactScanAccess(newExactScanAccessSchema(columns), values)
+	// Cross the adaptive threshold before measuring the steady-state lookup.
+	shard.GetRecordidForUnique(access, nil)
+	shard.GetRecordidForUnique(access, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		shard.GetRecordidForUnique(access, nil)
+	}
+}
+
+// BenchmarkGetRecordIDForUniqueMainHit isolates the unique-constraint probe
+// used by INSERT and INSERT IGNORE once the main index is warm.
+func BenchmarkGetRecordIDForUniqueMainHit(b *testing.B) {
+	benchmarkGetRecordIDForUnique(b, 511)
+}
+
+// BenchmarkGetRecordIDForUniqueMainMiss measures the corresponding absent-key
+// path used for successful unique inserts.
+func BenchmarkGetRecordIDForUniqueMainMiss(b *testing.B) {
+	benchmarkGetRecordIDForUnique(b, 2048)
 }
 
 func TestOpenMapReducerAllocatesMutationMetadataLazily(t *testing.T) {

--- a/storage/scan_fixcost_bench_test.go
+++ b/storage/scan_fixcost_bench_test.go
@@ -205,6 +205,45 @@ func BenchmarkScanUniquePointCompiledAccessWithTx(b *testing.B) {
 	}
 }
 
+// BenchmarkScanUniquePointCoveredCompiledAccessWithTx models the physical
+// shape emitted after compile_scan_plan proves an exact point predicate. All
+// immutable argument slices are prepared outside the timed loop, so this
+// reports storage execution allocations rather than caller construction.
+func BenchmarkScanUniquePointCoveredCompiledAccessWithTx(b *testing.B) {
+	dbName := "bench_scan_point_covered_compiled"
+	databases.Remove(dbName)
+	b.Cleanup(func() { databases.Remove(dbName) })
+	CreateDatabase(dbName, true)
+	tbl, _ := CreateTable(dbName, "items", Memory, true)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("label", "VARCHAR", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl.Insert([]string{"id", "label"}, rows, nil, scm.NewNil(), false, nil)
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "PRIMARY", Cols: []string{"id"}})
+	tx := NewTxContext(TxCursorStability)
+	condition := scanCondition("id", scm.NewInt(511))
+	mapReduceFn := scm.NewFunc(func(a ...scm.Scmer) scm.Scmer { return a[1] })
+	schema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 0, -1), scm.NewString("equal"),
+		scm.NewString("id"), newScanAccessBoundaryMeta(0, 0, 3), scm.NewString(""),
+	})
+	values := []scm.Scmer{scm.NewInt(511)}
+	conditionCols := []string{"id"}
+	callbackCols := []string{"label"}
+	tbl.scanWithBatchFrom(tx, nil, schema, values, scanAccess{}, conditionCols, condition, callbackCols, mapReduceFn,
+		scm.NewNil(), scm.NewNil(), false, 0, nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tbl.scanWithBatchFrom(tx, nil, schema, values, scanAccess{}, conditionCols, condition, callbackCols, mapReduceFn,
+			scm.NewNil(), scm.NewNil(), false, 0, nil)
+	}
+}
+
 func benchmarkUniqueMainPointScan(b *testing.B, name string, currentTx *TxContext) {
 	dbName := "bench_scan_main_point_" + name
 	databases.Remove(dbName)

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -28,6 +28,47 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+type scanLogEvent struct {
+	schema, table, filter, order, indexCols                    string
+	ordered                                                    bool
+	inputCount, candidateCount, outputCount, analyzeNs, execNs int64
+	condition                                                  scm.Scmer
+	conditionCols                                              []string
+	encodeCondition                                            bool
+}
+
+var scanLogQueue = make(chan scanLogEvent, 1024)
+
+func init() {
+	go func() {
+		for event := range scanLogQueue {
+			if event.encodeCondition {
+				if proc, ok := event.condition.Any().(scm.Proc); ok {
+					var params []scm.Scmer
+					if proc.Params.IsSlice() {
+						params = proc.Params.Slice()
+					} else if arr, ok := proc.Params.Any().([]scm.Scmer); ok {
+						params = arr
+					}
+					event.filter = encodeScmerToString(proc.Body, event.conditionCols, params)
+				}
+			}
+			safeLogScan(event.schema, event.table, event.ordered, event.filter, event.order, event.indexCols,
+				event.inputCount, event.candidateCount, event.outputCount, event.analyzeNs, event.execNs)
+		}
+	}()
+}
+
+// enqueueScanLog keeps statistics off the execution path without creating one
+// goroutine and callback frame per scan. Telemetry is best-effort; a saturated
+// sink must never apply backpressure to query execution.
+func enqueueScanLog(event scanLogEvent) {
+	select {
+	case scanLogQueue <- event:
+	default:
+	}
+}
+
 // encodeScmer prints a compact textual encoding of a Scheme AST to w.
 // Unknowns print as "?".
 // - Unknown symbols (not a global function and not one of the provided column names) => "?".

--- a/storage/scan_helper.go
+++ b/storage/scan_helper.go
@@ -315,9 +315,9 @@ func safeLogScan(schema, table string, ordered bool, filter, order, indexCols st
 	t.Insert(cols, [][]scm.Scmer{row}, nil, scm.NewNil(), false, nil)
 }
 
-// boundaryIndexCols returns a comma-separated list of column names from boundaries,
+// boundaryIndexCols returns a comma-separated list of column names from analyzed boundaries,
 // representing the columns used for index lookup in this scan.
-func boundaryIndexCols(b boundaries) string {
+func boundaryIndexCols(b analyzedBoundaries) string {
 	if len(b) == 0 {
 		return ""
 	}
@@ -340,7 +340,7 @@ func scanAccessIndexCols(access scanAccess) string {
 		if i > 0 {
 			sb.WriteByte(',')
 		}
-		sb.WriteString(access.boundary(i).col)
+		sb.WriteString(access.boundaryColumn(i))
 	}
 	return sb.String()
 }
@@ -363,16 +363,17 @@ func touchTempColumns(t *table, colSets ...[]string) {
 // not relied upon here.
 func (t *storageShard) ensureScanAccessColumns(access scanAccess, alreadyLocked bool, currentTx *TxContext) {
 	for i := 0; i < access.len(); i++ {
-		boundary := access.boundary(i)
-		if len(boundary.mapCols) > 0 {
-			for _, col := range boundary.mapCols {
+		mapCols, _ := access.boundaryMap(i)
+		if len(mapCols) > 0 {
+			for _, col := range mapCols {
 				t.getColumnStorageOrPanic(col, alreadyLocked, currentTx)
 			}
 			continue
 		}
-		if boundary.col == "" || boundary.col[0] == '$' {
+		column := access.boundaryColumn(i)
+		if column == "" || column[0] == '$' {
 			continue
 		}
-		t.getColumnStorageOrPanic(boundary.col, alreadyLocked, currentTx)
+		t.getColumnStorageOrPanic(column, alreadyLocked, currentTx)
 	}
 }

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -1205,7 +1205,6 @@ func collectScanJoinOrderShardStreams(currentTx *TxContext, input *scanJoinOrder
 		return nil
 	}
 	bounds, _ = extendScanAccessWithSortCols(bounds, sortcols, sortdirs)
-	lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], bounds)
 	for i := 0; i < bounds.len(); i++ {
 		boundary := bounds.boundary(i)
 		input.table.AddPartitioningScore([]string{boundary.col})
@@ -1214,7 +1213,7 @@ func collectScanJoinOrderShardStreams(currentTx *TxContext, input *scanJoinOrder
 	values := make(chan *scanJoinOrderShardStream, input.table.shardResultBufferSize())
 	ss := SessionStateFromTx(currentTx)
 	done := input.table.iterateShardsParallel(currentTx, bounds, func(shard *storageShard, _ bool) {
-		queue := shard.scan_order(bounds, lower, upperLast, input.filterCols, input.filter,
+		queue := shard.scan_order(bounds, input.filterCols, input.filter,
 			nil, scm.NewNil(),
 			sortcols, sortdirs, 0, 0, -1, input.readCols, currentTx, ss)
 		refs := make([]orderedBatchRecord, len(queue.items))

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -890,9 +890,9 @@ func probeScanJoinOrderInput(currentTx *TxContext, spec *scanJoinOrderSpec, tupl
 		}
 		return scm.NewBool(true)
 	})
-	required := make(boundaries, keyWidth)
+	required := make(analyzedBoundaries, keyWidth)
 	for keyIndex, column := range input.targetKeyCols {
-		required[keyIndex] = columnboundaries{
+		required[keyIndex] = analyzedBoundary{
 			col: column, matcher: EqualMatcher,
 			lowerBatch: true, lowerBatchSubidx: keyIndex,
 			upperBatch: true, upperBatchSubidx: keyIndex,
@@ -1206,8 +1206,7 @@ func collectScanJoinOrderShardStreams(currentTx *TxContext, input *scanJoinOrder
 	}
 	bounds, _ = extendScanAccessWithSortCols(bounds, sortcols, sortdirs)
 	for i := 0; i < bounds.len(); i++ {
-		boundary := bounds.boundary(i)
-		input.table.AddPartitioningScore([]string{boundary.col})
+		input.table.AddPartitioningScore([]string{bounds.boundaryColumn(i)})
 	}
 
 	values := make(chan *scanJoinOrderShardStream, input.table.shardResultBufferSize())

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -55,30 +55,29 @@ func executeCompiledScanLookup(t *table, currentTx *TxContext, schemaValue, valu
 	// fixed schema offsets. Keep validation and generic multidimensional binding
 	// out of this path so a cached plan adds no allocation or decoder dispatch.
 	if len(values) == 1 && len(schema) >= scanAccessSchemaHeaderSize+scanAccessBoundaryStride &&
-		validHeader && meta.count == 1 &&
-		schema[scanAccessSchemaHeaderSize].String() == "equal" &&
-		scanAccessBoundaryIsExactSlot(schema[scanAccessSchemaHeaderSize+2], 0) {
+		validHeader && meta.count == 1 && schema[scanAccessSchemaHeaderSize].IsCustom(TagScanBoundary) {
+		boundary := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize])
+		if boundary.Analyzer() != EqualMatcher || boundary.LowerSlot() != 0 || boundary.UpperSlot() != 0 ||
+			!boundary.LowerInclusive() || !boundary.UpperInclusive() {
+			return t.executeScanLookup(currentTx, parseScanLookupPlanSlices(schema, values))
+		}
 		if values[0].IsNil() {
 			return scanLookupMiss(meta.consumer != "exists")
 		}
 		projectionAt := scanAccessSchemaHeaderSize + scanAccessBoundaryStride
+		access := scanAccess{schema: schema, values: values, compiledCount: 1}
 		switch meta.consumer {
 		case "exists":
 			if len(schema) == projectionAt && meta.projections == 0 {
-				return t.scanLookupOne(currentTx, schema[scanAccessSchemaHeaderSize+1].String(), values[0], "", false)
+				return t.scanLookupOne(currentTx, access, "", false)
 			}
 		case "value":
 			if len(schema) == projectionAt+1 && meta.projections == 1 {
-				return t.scanLookupOne(currentTx, schema[scanAccessSchemaHeaderSize+1].String(), values[0], schema[projectionAt].String(), true)
+				return t.scanLookupOne(currentTx, access, schema[projectionAt].String(), true)
 			}
 		}
 	}
 	return t.executeScanLookup(currentTx, parseScanLookupPlanSlices(schema, values))
-}
-
-func scanAccessBoundaryIsExactSlot(value scm.Scmer, slot int) bool {
-	meta := decodeScanAccessBoundaryMeta(value)
-	return meta.lowerSlot == slot && meta.upperSlot == slot && meta.flags == 3
 }
 
 func parseScanLookupPlan(schemaValue, valuesValue scm.Scmer) scanLookupPlan {
@@ -98,9 +97,8 @@ func parseScanLookupPlanSlices(schema, values []scm.Scmer) scanLookupPlan {
 		panic("scan_lookup schema has an invalid match-column count")
 	}
 	for i := 0; i < matchCount; i++ {
-		boundary := access.boundary(i)
-		if !matcherKindEqual(boundary.matcher, EqualMatcher) || !boundary.lowerInclusive ||
-			!boundary.upperInclusive || !boundaryValueEqual(boundary.lower, boundary.upper) {
+		if !matcherKindEqual(access.boundaryAnalyzer(i), EqualMatcher) || !access.boundaryLowerInclusive(i) ||
+			!access.boundaryUpperInclusive(i) || !boundaryValueEqual(access.boundValue(i, false), access.boundValue(i, true)) {
 			panic("scan_lookup requires exact equality access entries")
 		}
 	}
@@ -138,30 +136,27 @@ func parseScanLookupPlanSlices(schema, values []scm.Scmer) scanLookupPlan {
 func (t *table) executeScanLookup(currentTx *TxContext, plan scanLookupPlan) scm.Scmer {
 	matchCount := plan.access.len()
 	for i := 0; i < matchCount; i++ {
-		value := plan.access.boundary(i).lower
+		value := plan.access.boundValue(i, false)
 		if value.IsNil() {
 			return scanLookupMiss(plan.consumer != scanLookupExists)
 		}
 	}
 	if matchCount == 1 && plan.consumer != scanLookupMap {
-		boundary := plan.access.boundary(0)
 		resultCol := ""
 		if plan.consumer == scanLookupValue {
 			resultCol = plan.mapCols[0].String()
 		}
 		return t.scanLookupOne(
 			currentTx,
-			boundary.col,
-			boundary.lower,
+			plan.access,
 			resultCol,
 			plan.consumer == scanLookupValue,
 		)
 	}
 	if matchCount == 1 && plan.consumer == scanLookupMap {
-		boundary := plan.access.boundary(0)
 		mapCols := scmerSliceToStrings(plan.mapCols)
 		mappedValues, matches := t.scanLookupMapOne(
-			currentTx, boundary.col, boundary.lower, mapCols)
+			currentTx, plan.access, mapCols)
 		if matches > 1 {
 			panic(scalarSubselectOverflow)
 		}
@@ -171,21 +166,15 @@ func (t *table) executeScanLookup(currentTx *TxContext, plan scanLookupPlan) scm
 		mapProgram := scm.PrepareSerialProc(plan.mapper)
 		return mapProgram.Call(mappedValues)
 	}
-	lookupCols := make([]string, matchCount)
-	lookupValues := make([]scm.Scmer, matchCount)
-	for i := 0; i < matchCount; i++ {
-		boundary := plan.access.boundary(i)
-		lookupCols[i], lookupValues[i] = boundary.col, boundary.lower
-	}
 	switch plan.consumer {
 	case scanLookupExists:
-		return t.scanLookup(currentTx, lookupCols, lookupValues, "", false)
+		return t.scanLookup(currentTx, plan.access, "", false)
 	case scanLookupValue:
-		return t.scanLookup(currentTx, lookupCols, lookupValues, plan.mapCols[0].String(), true)
+		return t.scanLookup(currentTx, plan.access, plan.mapCols[0].String(), true)
 	case scanLookupMap:
 		mapCols := scmerSliceToStrings(plan.mapCols)
 		mapProgram := scm.PrepareSerialProc(plan.mapper)
-		return t.scanLookupMap(currentTx, lookupCols, lookupValues, mapCols, &mapProgram)
+		return t.scanLookupMap(currentTx, plan.access, mapCols, &mapProgram)
 	default:
 		panic("invalid scan_lookup consumer")
 	}
@@ -199,22 +188,22 @@ type scanLookupMapReader struct {
 // scanLookup probes an exact index prefix. Omitting resultCol turns it into a
 // lightweight existence check; scalar value lookups stop after the second
 // visible match to enforce scalar-subselect cardinality.
-func (t *table) scanLookup(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
-	validateScanLookupDimensions(len(lookupCols), len(lookupValues))
+func (t *table) scanLookup(currentTx *TxContext, access scanAccess, resultCol string, returnValue bool) scm.Scmer {
+	matchCount := access.len()
 	// Keep the dominant authentication and scalar-subselect case free of the
 	// per-dimension reader slices needed by composite probes.
-	if len(lookupCols) == 1 {
-		if lookupValues[0].IsNil() {
+	if matchCount == 1 {
+		if access.boundValue(0, false).IsNil() {
 			return scanLookupMiss(returnValue)
 		}
-		return t.scanLookupOne(currentTx, lookupCols[0], lookupValues[0], resultCol, returnValue)
+		return t.scanLookupOne(currentTx, access, resultCol, returnValue)
 	}
-	for _, value := range lookupValues {
-		if value.IsNil() {
+	for i := 0; i < matchCount; i++ {
+		if access.boundValue(i, false).IsNil() {
 			return scanLookupMiss(returnValue)
 		}
 	}
-	return t.scanLookupMany(currentTx, lookupCols, lookupValues, resultCol, returnValue)
+	return t.scanLookupMany(currentTx, access, resultCol, returnValue)
 }
 
 func validateScanLookupDimensions(columnCount, valueCount int) {
@@ -233,19 +222,18 @@ func scanLookupMiss(returnValue bool) scm.Scmer {
 // scanLookupMap keeps row materialization inside the point probe, but invokes
 // the mapper only after global scalar cardinality has been validated and all
 // shard locks have been released.
-func (t *table) scanLookupMap(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, mapCols []string, mapProgram *scm.SerialProc) scm.Scmer {
-	validateScanLookupDimensions(len(lookupCols), len(lookupValues))
-	for _, value := range lookupValues {
-		if value.IsNil() {
+func (t *table) scanLookupMap(currentTx *TxContext, access scanAccess, mapCols []string, mapProgram *scm.SerialProc) scm.Scmer {
+	for i := 0; i < access.len(); i++ {
+		if access.boundValue(i, false).IsNil() {
 			return scm.NewNil()
 		}
 	}
 	var values []scm.Scmer
 	var matches int
-	if len(lookupCols) == 1 {
-		values, matches = t.scanLookupMapOne(currentTx, lookupCols[0], lookupValues[0], mapCols)
+	if access.len() == 1 {
+		values, matches = t.scanLookupMapOne(currentTx, access, mapCols)
 	} else {
-		values, matches = t.scanLookupMapMany(currentTx, lookupCols, lookupValues, mapCols)
+		values, matches = t.scanLookupMapMany(currentTx, access, mapCols)
 	}
 	if matches > 1 {
 		panic(scalarSubselectOverflow)
@@ -256,22 +244,18 @@ func (t *table) scanLookupMap(currentTx *TxContext, lookupCols []string, lookupV
 	return mapProgram.Call(values)
 }
 
-func (t *table) scanLookupMapOne(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, mapCols []string) ([]scm.Scmer, int) {
+func (t *table) scanLookupMapOne(currentTx *TxContext, access scanAccess, mapCols []string) ([]scm.Scmer, int) {
 	if t.hasTableLock() {
 		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
 	}
+	lookupCol := access.boundaryColumn(0)
 	touchTempColumns(t, []string{lookupCol}, mapCols)
-	boundary := columnboundaries{
-		col: lookupCol, matcher: EqualMatcher,
-		lower: lookupValue, lowerInclusive: true,
-		upper: lookupValue, upperInclusive: true,
-	}
 
 	var mu sync.Mutex
 	var values []scm.Scmer
 	matches := 0
 	var panicValue any
-	done := t.iterateShardsParallel(currentTx, runtimeScanAccess(boundaries{boundary}), func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				mu.Lock()
@@ -284,7 +268,7 @@ func (t *table) scanLookupMapOne(currentTx *TxContext, lookupCol string, lookupV
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		localValues, count := shard.scanLookupMapOne(boundary, lookupValue, mapCols, currentTx)
+		localValues, count := shard.scanLookupMapOne(access, mapCols, currentTx)
 		if count == 0 {
 			return
 		}
@@ -308,10 +292,12 @@ func (t *table) scanLookupMapOne(currentTx *TxContext, lookupCol string, lookupV
 	return values, matches
 }
 
-func (t *storageShard) scanLookupMapOne(boundary columnboundaries, lookupValue scm.Scmer, mapCols []string, currentTx *TxContext) ([]scm.Scmer, int) {
+func (t *storageShard) scanLookupMapOne(access scanAccess, mapCols []string, currentTx *TxContext) ([]scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupReader := newCachedColumnReaderTx(t.getColumnStorageOrPanic(boundary.col, false, currentTx), currentTx)
+	lookupCol := access.boundaryColumn(0)
+	lookupValue := access.boundValue(0, false)
+	lookupReader := newCachedColumnReaderTx(t.getColumnStorageOrPanic(lookupCol, false, currentTx), currentTx)
 	var fixedMapReaders [8]scanLookupMapReader
 	mapReaders := fixedMapReaders[:]
 	if len(mapCols) <= len(fixedMapReaders) {
@@ -328,13 +314,13 @@ func (t *storageShard) scanLookupMapOne(boundary columnboundaries, lookupValue s
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(boundaries{boundary}), len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, access, len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		for _, recid := range batch {
 			var actual scm.Scmer
 			if recid < mainCount {
 				actual = lookupReader.GetValue(recid)
 			} else {
-				actual = t.getDelta(int(recid-mainCount), boundary.col)
+				actual = t.getDelta(int(recid-mainCount), lookupCol)
 			}
 			if !scm.Equal(actual, lookupValue) {
 				continue
@@ -379,25 +365,16 @@ func (t *storageShard) scanLookupMapValues(recid, mainCount uint32, mapCols []st
 	return values
 }
 
-func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValue scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
+func (t *table) scanLookupOne(currentTx *TxContext, access scanAccess, resultCol string, returnValue bool) scm.Scmer {
 	if t.hasTableLock() {
 		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
 	}
+	lookupCol := access.boundaryColumn(0)
 	var resultCols []string
 	if returnValue {
 		resultCols = []string{resultCol}
 	}
 	touchTempColumns(t, []string{lookupCol}, resultCols)
-
-	boundary := columnboundaries{
-		col:            lookupCol,
-		matcher:        EqualMatcher,
-		lower:          lookupValue,
-		lowerInclusive: true,
-		upper:          lookupValue,
-		upperInclusive: true,
-	}
-	boundaries := []columnboundaries{boundary}
 
 	state := struct {
 		mu         sync.Mutex
@@ -405,7 +382,7 @@ func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValu
 		matches    int
 		panicValue any
 	}{result: scm.NewNil()}
-	done := t.iterateShardsParallel(currentTx, runtimeScanAccess(boundaries), func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				state.mu.Lock()
@@ -418,7 +395,7 @@ func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValu
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		value, count := shard.scanLookupOne(lookupCol, lookupValue, resultCol, returnValue, currentTx)
+		value, count := shard.scanLookupOne(access, resultCol, returnValue, currentTx)
 		if count == 0 {
 			return
 		}
@@ -449,18 +426,12 @@ func (t *table) scanLookupOne(currentTx *TxContext, lookupCol string, lookupValu
 	return state.result
 }
 
-func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, resultCol string, returnValue bool, currentTx *TxContext) (scm.Scmer, int) {
-	boundary := columnboundaries{
-		col:            lookupCol,
-		matcher:        EqualMatcher,
-		lower:          lookupValue,
-		lowerInclusive: true,
-		upper:          lookupValue,
-		upperInclusive: true,
-	}
+func (t *storageShard) scanLookupOne(access scanAccess, resultCol string, returnValue bool, currentTx *TxContext) (scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupStorage := t.getColumnStorageOrPanic(boundary.col, false, currentTx)
+	lookupCol := access.boundaryColumn(0)
+	lookupValue := access.boundValue(0, false)
+	lookupStorage := t.getColumnStorageOrPanic(lookupCol, false, currentTx)
 	lookupReader := newCachedColumnReaderTx(lookupStorage, currentTx)
 	var resultReader ColumnReader
 	resultComputed := false
@@ -470,7 +441,6 @@ func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, re
 		_, resultComputed = resultStorage.(*StorageComputeProxy)
 	}
 
-	bounds := []columnboundaries{boundary}
 	result := scm.NewBool(false)
 	matches := 0
 
@@ -479,13 +449,13 @@ func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, re
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, access, len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		for _, recid := range batch {
 			var actual scm.Scmer
 			if recid < mainCount {
 				actual = lookupReader.GetValue(recid)
 			} else {
-				actual = t.getDelta(int(recid-mainCount), boundary.col)
+				actual = t.getDelta(int(recid-mainCount), lookupCol)
 			}
 			if !scm.Equal(actual, lookupValue) {
 				continue
@@ -515,35 +485,37 @@ func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, re
 	return result, matches
 }
 
-func exactLookupBoundaries(cols []string, values []scm.Scmer) boundaries {
-	result := make(boundaries, len(cols))
-	for i, col := range cols {
-		result[i] = columnboundaries{
-			col: col, matcher: EqualMatcher,
-			lower: values[i], lowerInclusive: true,
-			upper: values[i], upperInclusive: true,
-		}
+func scanLookupColumns(access scanAccess, inline []string) []string {
+	columns := inline
+	if access.len() <= len(columns) {
+		columns = columns[:access.len()]
+	} else {
+		columns = make([]string, access.len())
 	}
-	return result
+	for i := range columns {
+		columns[i] = access.boundaryColumn(i)
+	}
+	return columns
 }
 
-func (t *table) scanLookupMany(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, resultCol string, returnValue bool) scm.Scmer {
+func (t *table) scanLookupMany(currentTx *TxContext, access scanAccess, resultCol string, returnValue bool) scm.Scmer {
 	if t.hasTableLock() {
 		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
 	}
+	var fixedLookupCols [8]string
+	lookupCols := scanLookupColumns(access, fixedLookupCols[:])
 	var resultCols []string
 	if returnValue {
 		resultCols = []string{resultCol}
 	}
 	touchTempColumns(t, lookupCols, resultCols)
-	boundaries := exactLookupBoundaries(lookupCols, lookupValues)
 
 	var mu sync.Mutex
 	var stop atomic.Bool
 	result := scm.NewBool(false)
 	matches := 0
 	var panicValue any
-	done := t.iterateShardsParallel(currentTx, runtimeScanAccess(boundaries), func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
 		if stop.Load() {
 			return
 		}
@@ -560,7 +532,7 @@ func (t *table) scanLookupMany(currentTx *TxContext, lookupCols []string, lookup
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		value, count := shard.scanLookupMany(boundaries, lookupValues, resultCol, returnValue, currentTx, &stop)
+		value, count := shard.scanLookupMany(access, resultCol, returnValue, currentTx, &stop)
 		if count == 0 {
 			return
 		}
@@ -597,12 +569,12 @@ func (t *table) scanLookupMany(currentTx *TxContext, lookupCols []string, lookup
 	return result
 }
 
-func (t *storageShard) scanLookupMany(bounds boundaries, lookupValues []scm.Scmer, resultCol string, returnValue bool, currentTx *TxContext, stop *atomic.Bool) (scm.Scmer, int) {
+func (t *storageShard) scanLookupMany(access scanAccess, resultCol string, returnValue bool, currentTx *TxContext, stop *atomic.Bool) (scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupReaders := make([]ColumnReader, len(bounds))
-	for i, boundary := range bounds {
-		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(boundary.col, false, currentTx), currentTx)
+	lookupReaders := make([]ColumnReader, access.len())
+	for i := range lookupReaders {
+		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx)
 	}
 	var resultReader ColumnReader
 	resultComputed := false
@@ -619,20 +591,20 @@ func (t *storageShard) scanLookupMany(bounds boundaries, lookupValues []scm.Scme
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, access, len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		if stop.Load() {
 			return false
 		}
 		for _, recid := range batch {
 			exact := true
-			for i, boundary := range bounds {
+			for i := range lookupReaders {
 				var actual scm.Scmer
 				if recid < mainCount {
 					actual = lookupReaders[i].GetValue(recid)
 				} else {
-					actual = t.getDelta(int(recid-mainCount), boundary.col)
+					actual = t.getDelta(int(recid-mainCount), access.boundaryColumn(i))
 				}
-				if !scm.Equal(actual, lookupValues[i]) {
+				if !scm.Equal(actual, access.boundValue(i, false)) {
 					exact = false
 					break
 				}
@@ -664,19 +636,20 @@ func (t *storageShard) scanLookupMany(bounds boundaries, lookupValues []scm.Scme
 	return result, matches
 }
 
-func (t *table) scanLookupMapMany(currentTx *TxContext, lookupCols []string, lookupValues []scm.Scmer, mapCols []string) ([]scm.Scmer, int) {
+func (t *table) scanLookupMapMany(currentTx *TxContext, access scanAccess, mapCols []string) ([]scm.Scmer, int) {
 	if t.hasTableLock() {
 		t.waitTableLock(SessionStateFromTx(currentTx), querySeqFromTx(currentTx), false)
 	}
+	var fixedLookupCols [8]string
+	lookupCols := scanLookupColumns(access, fixedLookupCols[:])
 	touchTempColumns(t, lookupCols, mapCols)
-	boundaries := exactLookupBoundaries(lookupCols, lookupValues)
 
 	var mu sync.Mutex
 	var stop atomic.Bool
 	var values []scm.Scmer
 	matches := 0
 	var panicValue any
-	done := t.iterateShardsParallel(currentTx, runtimeScanAccess(boundaries), func(shard *storageShard, solo bool) {
+	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
 		if stop.Load() {
 			return
 		}
@@ -693,7 +666,7 @@ func (t *table) scanLookupMapMany(currentTx *TxContext, lookupCols []string, loo
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		localValues, count := shard.scanLookupMapMany(boundaries, lookupValues, mapCols, currentTx, &stop)
+		localValues, count := shard.scanLookupMapMany(access, mapCols, currentTx, &stop)
 		if count == 0 {
 			return
 		}
@@ -720,12 +693,12 @@ func (t *table) scanLookupMapMany(currentTx *TxContext, lookupCols []string, loo
 	return values, matches
 }
 
-func (t *storageShard) scanLookupMapMany(bounds boundaries, lookupValues []scm.Scmer, mapCols []string, currentTx *TxContext, stop *atomic.Bool) ([]scm.Scmer, int) {
+func (t *storageShard) scanLookupMapMany(access scanAccess, mapCols []string, currentTx *TxContext, stop *atomic.Bool) ([]scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupReaders := make([]ColumnReader, len(bounds))
-	for i, boundary := range bounds {
-		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(boundary.col, false, currentTx), currentTx)
+	lookupReaders := make([]ColumnReader, access.len())
+	for i := range lookupReaders {
+		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx)
 	}
 	var fixedMapReaders [8]scanLookupMapReader
 	mapReaders := fixedMapReaders[:]
@@ -743,20 +716,20 @@ func (t *storageShard) scanLookupMapMany(bounds boundaries, lookupValues []scm.S
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, access, len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		if stop.Load() {
 			return false
 		}
 		for _, recid := range batch {
 			exact := true
-			for i, boundary := range bounds {
+			for i := range lookupReaders {
 				var actual scm.Scmer
 				if recid < mainCount {
 					actual = lookupReaders[i].GetValue(recid)
 				} else {
-					actual = t.getDelta(int(recid-mainCount), boundary.col)
+					actual = t.getDelta(int(recid-mainCount), access.boundaryColumn(i))
 				}
-				if !scm.Equal(actual, lookupValues[i]) {
+				if !scm.Equal(actual, access.boundValue(i, false)) {
 					exact = false
 					break
 				}

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -328,7 +328,7 @@ func (t *storageShard) scanLookupMapOne(boundary columnboundaries, lookupValue s
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(boundaries{boundary}), []scm.Scmer{lookupValue}, lookupValue, len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, runtimeScanAccess(boundaries{boundary}), len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		for _, recid := range batch {
 			var actual scm.Scmer
 			if recid < mainCount {
@@ -471,7 +471,6 @@ func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, re
 	}
 
 	bounds := []columnboundaries{boundary}
-	lower := []scm.Scmer{lookupValue}
 	result := scm.NewBool(false)
 	matches := 0
 
@@ -480,7 +479,7 @@ func (t *storageShard) scanLookupOne(lookupCol string, lookupValue scm.Scmer, re
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), lower, lookupValue, len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		for _, recid := range batch {
 			var actual scm.Scmer
 			if recid < mainCount {
@@ -620,7 +619,7 @@ func (t *storageShard) scanLookupMany(bounds boundaries, lookupValues []scm.Scme
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), lookupValues, lookupValues[len(lookupValues)-1], len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		if stop.Load() {
 			return false
 		}
@@ -744,7 +743,7 @@ func (t *storageShard) scanLookupMapMany(bounds boundaries, lookupValues []scm.S
 	mainCount := t.main_count
 	acidMode := currentTx != nil && currentTx.Mode == TxACID
 	var ids [8]uint32
-	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), lookupValues, lookupValues[len(lookupValues)-1], len(t.inserts), ids[:], true, func(batch []uint32) bool {
+	t.iterateIndexForce(currentTx, runtimeScanAccess(bounds), len(t.inserts), ids[:], true, func(batch []uint32) bool {
 		if stop.Load() {
 			return false
 		}

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -23,6 +23,16 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+func testLookupAccess(columns []string, values []scm.Scmer) scanAccess {
+	schema := make([]scm.Scmer, scanAccessSchemaHeaderSize+len(columns))
+	schema[0] = newScanAccessHeader(len(columns), "value", 0, -1)
+	for i, column := range columns {
+		schema[scanAccessSchemaHeaderSize+i] = newScanBoundarySpec(
+			column, EqualMatcher, i, i, true, true, "", false, -1, nil, nil, "", false)
+	}
+	return exactScanAccess(schema, values)
+}
+
 func setupScanLookupTable(tb testing.TB, database string, rows [][]scm.Scmer) *table {
 	tb.Helper()
 	databases.Remove(database)
@@ -42,7 +52,7 @@ func testScanLookupSchema(consumer string, matchCols, mapCols []string) scm.Scme
 	}
 	schema := []scm.Scmer{newScanAccessHeader(len(matchCols), consumer, len(mapCols), mapperSlot)}
 	for i, col := range matchCols {
-		schema = append(schema, scm.NewString("equal"), scm.NewString(col), newScanAccessBoundaryMeta(i, i, 3), scm.NewString(""))
+		schema = append(schema, newScanBoundarySpec(col, EqualMatcher, i, i, true, true, "", false, -1, nil, nil, "", false))
 	}
 	for _, col := range mapCols {
 		schema = append(schema, scm.NewString(col))
@@ -60,16 +70,16 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 	})
 	tx := NewTxContext(TxCursorStability)
 
-	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(1)}, "value", true); !scm.Equal(got, scm.NewString("one")) {
+	if got := tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(1)}), "value", true); !scm.Equal(got, scm.NewString("one")) {
 		t.Fatalf("scanLookup existing value = %s, want one", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(2)}, "value", true); !got.IsNil() {
+	if got := tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(2)}), "value", true); !got.IsNil() {
 		t.Fatalf("scanLookup NULL value = %s, want nil", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(99)}, "value", true); !got.IsNil() {
+	if got := tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(99)}), "value", true); !got.IsNil() {
 		t.Fatalf("scanLookup missing value = %s, want nil", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewNil()}, "", false); scm.ToBool(got) {
+	if got := tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewNil()}), "", false); scm.ToBool(got) {
 		t.Fatal("scanLookup matched a SQL NULL key")
 	}
 
@@ -78,7 +88,7 @@ func TestScanLookupReturnsValueNullAndCardinalityError(t *testing.T) {
 			t.Fatalf("scanLookup duplicate panic = %v, want %q", got, scalarSubselectOverflow)
 		}
 	}()
-	tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(3)}, "value", true)
+	tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(3)}), "value", true)
 }
 
 func TestScanLookupSchemeOperator(t *testing.T) {
@@ -135,16 +145,16 @@ func TestScanLookupCompositeValueAndExists(t *testing.T) {
 	tx := NewTxContext(TxCursorStability)
 	cols := []string{"tenant", "key"}
 
-	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}, "value", true); !scm.Equal(got, scm.NewString("two-seven")) {
+	if got := tbl.scanLookup(tx, testLookupAccess(cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}), "value", true); !scm.Equal(got, scm.NewString("two-seven")) {
 		t.Fatalf("composite scanLookup = %s, want two-seven", scm.String(got))
 	}
-	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(9), scm.NewInt(7)}, "", false); scm.ToBool(got) {
+	if got := tbl.scanLookup(tx, testLookupAccess(cols, []scm.Scmer{scm.NewInt(9), scm.NewInt(7)}), "", false); scm.ToBool(got) {
 		t.Fatal("missing composite existence lookup returned true")
 	}
-	if got := tbl.scanLookup(tx, cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}, "", false); !scm.ToBool(got) {
+	if got := tbl.scanLookup(tx, testLookupAccess(cols, []scm.Scmer{scm.NewInt(2), scm.NewInt(7)}), "", false); !scm.ToBool(got) {
 		t.Fatal("matching composite existence lookup returned false")
 	}
-	if got := tbl.scanLookup(tx, []string{"key"}, []scm.Scmer{scm.NewInt(7)}, "", false); !scm.ToBool(got) {
+	if got := tbl.scanLookup(tx, testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(7)}), "", false); !scm.ToBool(got) {
 		t.Fatal("existence lookup with multiple matches returned false")
 	}
 }
@@ -174,8 +184,7 @@ func TestScanLookupMapReturnsComputedValueAfterCardinalityCheck(t *testing.T) {
 	}))
 
 	got := tbl.scanLookupMap(tx,
-		[]string{"tenant", "key"},
-		[]scm.Scmer{scm.NewInt(1), scm.NewInt(7)},
+		testLookupAccess([]string{"tenant", "key"}, []scm.Scmer{scm.NewInt(1), scm.NewInt(7)}),
 		[]string{"left_value", "right_value"},
 		&mapper,
 	)
@@ -184,8 +193,7 @@ func TestScanLookupMapReturnsComputedValueAfterCardinalityCheck(t *testing.T) {
 	}
 	RebuildTable(tbl, true, false)
 	got = tbl.scanLookupMap(tx,
-		[]string{"tenant", "key"},
-		[]scm.Scmer{scm.NewInt(1), scm.NewInt(7)},
+		testLookupAccess([]string{"tenant", "key"}, []scm.Scmer{scm.NewInt(1), scm.NewInt(7)}),
 		[]string{"left_value", "right_value"},
 		&mapper,
 	)
@@ -193,13 +201,13 @@ func TestScanLookupMapReturnsComputedValueAfterCardinalityCheck(t *testing.T) {
 		t.Fatalf("rebuilt scanLookupMap = %s with %d mapper calls, want 30 with two", scm.String(got), calls)
 	}
 	if got := tbl.scanLookupMap(tx,
-		[]string{"key"}, []scm.Scmer{scm.NewInt(99)},
+		testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewInt(99)}),
 		[]string{"left_value", "right_value"}, &mapper,
 	); !got.IsNil() || calls != 2 {
 		t.Fatalf("missing scanLookupMap = %s with %d total mapper calls, want nil and two", scm.String(got), calls)
 	}
 	if got := tbl.scanLookupMap(tx,
-		[]string{"key"}, []scm.Scmer{scm.NewNil()},
+		testLookupAccess([]string{"key"}, []scm.Scmer{scm.NewNil()}),
 		[]string{"left_value", "right_value"}, &mapper,
 	); !got.IsNil() || calls != 2 {
 		t.Fatalf("NULL-key scanLookupMap = %s with %d total mapper calls, want nil and two", scm.String(got), calls)
@@ -212,8 +220,7 @@ func TestScanLookupMapReturnsComputedValueAfterCardinalityCheck(t *testing.T) {
 			}
 		}()
 		tbl.scanLookupMap(tx,
-			[]string{"tenant", "key"},
-			[]scm.Scmer{scm.NewInt(3), scm.NewInt(9)},
+			testLookupAccess([]string{"tenant", "key"}, []scm.Scmer{scm.NewInt(3), scm.NewInt(9)}),
 			[]string{"left_value", "right_value"},
 			&mapper,
 		)
@@ -263,12 +270,13 @@ func BenchmarkScanLookupWithTx(b *testing.B) {
 	cols := []string{"key"}
 	values := []scm.Scmer{key}
 	// Warm the adaptive index before measuring the steady-state operator.
-	tbl.scanLookup(tx, cols, values, "value", true)
+	access := testLookupAccess(cols, values)
+	tbl.scanLookup(tx, access, "value", true)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		tbl.scanLookup(tx, cols, values, "value", true)
+		tbl.scanLookup(tx, access, "value", true)
 	}
 }
 
@@ -324,11 +332,12 @@ func BenchmarkScanLookupDimensions(b *testing.B) {
 	}
 	for _, bench := range cases {
 		b.Run(bench.name, func(b *testing.B) {
-			tbl.scanLookup(tx, bench.cols, bench.values, bench.resultCol, bench.returnValue)
+			access := testLookupAccess(bench.cols, bench.values)
+			tbl.scanLookup(tx, access, bench.resultCol, bench.returnValue)
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				tbl.scanLookup(tx, bench.cols, bench.values, bench.resultCol, bench.returnValue)
+				tbl.scanLookup(tx, access, bench.resultCol, bench.returnValue)
 			}
 		})
 	}
@@ -355,12 +364,13 @@ func BenchmarkScanLookupMap(b *testing.B) {
 	mapProgram := scm.PrepareSerialProc(scm.NewFunc(func(values ...scm.Scmer) scm.Scmer {
 		return scm.NewInt(values[0].Int() + values[1].Int())
 	}))
-	tbl.scanLookupMap(tx, lookupCols, lookupValues, mapCols, &mapProgram)
+	access := testLookupAccess(lookupCols, lookupValues)
+	tbl.scanLookupMap(tx, access, mapCols, &mapProgram)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		tbl.scanLookupMap(tx, lookupCols, lookupValues, mapCols, &mapProgram)
+		tbl.scanLookupMap(tx, access, mapCols, &mapProgram)
 	}
 }
 

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -671,13 +671,14 @@ func recSetBoundaryCallCount(conditionCols []string, condition scm.Scmer) int {
 	return walk(p.Body)
 }
 
-func recSetHooksCoverCondition(bounds scanAccess, lower []scm.Scmer, backingTable *table, conditionCols []string, condition scm.Scmer) bool {
+func recSetHooksCoverCondition(bounds scanAccess, backingTable *table, conditionCols []string, condition scm.Scmer) bool {
 	want := recSetBoundaryCallCount(conditionCols, condition)
 	if want == 0 {
 		return false
 	}
 	covered := 0
-	for i := 0; i < len(lower) && i < bounds.len(); i++ {
+	indexBounds := newScanIndexBounds(bounds)
+	for i := 0; i < indexBounds.len() && i < bounds.len(); i++ {
 		bound := bounds.boundary(i)
 		if !matcherKindEqual(bound.matcher, RecSetMatcher) {
 			continue
@@ -767,15 +768,14 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		bounds, _ = extendScanAccessWithSortCols(bounds, spec.sortcols, sortdirs)
 		runtime := bounds.ensureRuntime()
 		runtime.suffix = appendRecSetBoundary(runtime.suffix, spec.recset)
-		lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], bounds)
-
 		if Settings.ScanDebugging {
 			dbg := fmt.Sprintf("[SCAN_ORDER_MULTI] %s.%s", t.schema.Name, t.Name)
 			for i := 0; i < bounds.len(); i++ {
 				b := bounds.boundary(i)
 				dbg += fmt.Sprintf(" %s:[%v..%v]", b.col, b.lower, b.upper)
 			}
-			dbg += fmt.Sprintf(" lower=%v upper=%v", lower, upperLast)
+			indexBounds := newScanIndexBounds(bounds)
+			dbg += fmt.Sprintf(" lower-count=%d upper=%v", indexBounds.len(), indexBounds.upperLast())
 			fmt.Println(dbg)
 		}
 
@@ -827,7 +827,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 										q_ <- scanOrderResult{err: scanError{r, string(debug.Stack())}}
 									}
 								}()
-								res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+								res := part.shard.scan_order(tableBounds, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 								res.callbackCols = callbackCols
 								res.callback = callback
 								res.tableIdx = tableIdx
@@ -857,7 +857,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 						if ss != nil && ss.IsKilledSeq(querySeq) {
 							panic("query killed")
 						}
-						res := part.shard.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+						res := part.shard.scan_order(tableBounds, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 						res.callbackCols = callbackCols
 						res.callback = callback
 						res.tableIdx = tableIdx
@@ -881,7 +881,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 				if ss != nil && ss.IsKilledSeq(querySeq) {
 					panic("query killed")
 				}
-				res := s.scan_order(tableBounds, lower, upperLast, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
+				res := s.scan_order(tableBounds, conditionCols, condition, acceptCols, accept, sortcols, sortdirs, limitPartitionCols, offset, shardLimit, callbackCols, currentTx, ss)
 				res.callbackCols = callbackCols
 				res.callback = callback
 				res.tableIdx = tableIdx
@@ -1148,7 +1148,12 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		}
 		orderEnc := sb.String()
 		indexColsEnc := scanAccessIndexCols(tableStats.access)
-		go safeLogScan(tbl.schema.Name, tbl.Name, true, filterEnc, orderEnc, indexColsEnc, tableStats.inputCount, tableStats.candidateCount, tableStats.outputCount, tableStats.analyzeNs, execNs)
+		enqueueScanLog(scanLogEvent{
+			schema: tbl.schema.Name, table: tbl.Name, ordered: true,
+			filter: filterEnc, order: orderEnc, indexCols: indexColsEnc,
+			inputCount: tableStats.inputCount, candidateCount: tableStats.candidateCount,
+			outputCount: tableStats.outputCount, analyzeNs: tableStats.analyzeNs, execNs: execNs,
+		})
 	}
 	return akkumulator
 }
@@ -1193,7 +1198,6 @@ func (t *table) scanOrderFirst(currentTx *TxContext, accessSchema scm.Scmer, acc
 		return notFoundValue
 	}
 	bounds = bounds.useScratch(scratch)
-	lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], bounds)
 
 	var mu sync.Mutex
 	var foundShard *storageShard
@@ -1218,7 +1222,7 @@ func (t *table) scanOrderFirst(currentTx *TxContext, accessSchema scm.Scmer, acc
 		if ss != nil && ss.IsKilledSeq(querySeq) {
 			panic("query killed")
 		}
-		recid, present := shard.scanFirstRecord(bounds, lower, upperLast, conditionCols, condition, currentTx, ss, nil)
+		recid, present := shard.scanFirstRecord(bounds, conditionCols, condition, currentTx, ss, nil)
 		if !present {
 			return
 		}
@@ -1240,10 +1244,11 @@ func (t *table) scanOrderFirst(currentTx *TxContext, accessSchema scm.Scmer, acc
 	}
 	mapperAlreadyLocked := false
 	var mapperStorage ShardMapReducer
-	var mapperWorkspace shardMapReducerWorkspace
 	mapper := &mapperStorage
 	if mapReducerCanUseReadWorkspace(callbackCols) {
-		prepareReadMapReducerStorage(&mapperStorage, &mapperWorkspace, len(callbackCols))
+		mapperWorkspace := acquireShardMapReducerWorkspace()
+		defer releaseShardMapReducerWorkspace(mapperWorkspace)
+		prepareReadMapReducerStorage(&mapperStorage, mapperWorkspace, len(callbackCols))
 		foundShard.initReadMapReducer(&mapperStorage, callbackCols, mapReduce, mapperAlreadyLocked, currentTx)
 	} else {
 		mapper = foundShard.OpenMapReducer(callbackCols, mapReduce, mapperAlreadyLocked, 0, nil, currentTx)
@@ -1288,7 +1293,7 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries scanAccess, lower []scm.Scmer, upperLast scm.Scmer, conditionCols []string, condition scm.Scmer, acceptCols []string, accept scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
+func (t *storageShard) scan_order(boundaries scanAccess, conditionCols []string, condition scm.Scmer, acceptCols []string, accept scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	t.ensureLoaded()
@@ -1297,7 +1302,7 @@ func (t *storageShard) scan_order(boundaries scanAccess, lower []scm.Scmer, uppe
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := scanConditionAlwaysTrue(&conditionProgram, len(conditionCols)) ||
 		scanAccessProvesCondition(conditionCols, condition, boundaries)
@@ -1464,9 +1469,10 @@ func (t *storageShard) scan_order(boundaries scanAccess, lower []scm.Scmer, uppe
 		acceptColBufs := make([][]scm.Scmer, len(acceptCols))
 		boundaryCoveredLimit := acceptProgram == nil && conditionAlwaysTrue
 		access := boundaries
-		t.iterateIndexOrdered(currentTx, access, lower, upperLast, maxInsertIndex, buf, usageWeight, limit, boundaryCoveredLimit, func(index *StorageIndex, active bool) {
+		indexBounds := newScanIndexBounds(access)
+		t.iterateIndexOrdered(currentTx, access, maxInsertIndex, buf, usageWeight, limit, boundaryCoveredLimit, func(index *StorageIndex, active bool) {
 			if len(sortcols) > 0 {
-				resultAlreadySorted = indexCoversBoundaryOrder(index, active, access, len(lower))
+				resultAlreadySorted = indexCoversBoundaryOrder(index, active, access, indexBounds.len())
 			}
 		}, func(batch []uint32) bool {
 			result.candidateCount += int64(len(batch))

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -402,7 +402,7 @@ func (s *scanOrderTableSpec) backingTable() *table {
 // extendBoundariesWithSortCols inserts sort columns before candidate matchers
 // when all existing filter boundaries are point lookups. The relation callback
 // is the complete ordering contract, including collation, direction and NULLs.
-func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) (boundaries, bool) {
+func extendBoundariesWithSortCols(b analyzedBoundaries, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) (analyzedBoundaries, bool) {
 	original := b
 	allEq := true
 	for _, bi := range b {
@@ -415,7 +415,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 	if !allEq || !canAppendSortPrefix {
 		return b, false
 	}
-	insertSortedBoundary := func(bound columnboundaries) {
+	insertSortedBoundary := func(bound analyzedBoundary) {
 		at := len(b)
 		for i := range b {
 			if !b[i].matcher.IsSorted() {
@@ -423,7 +423,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 				break
 			}
 		}
-		b = append(b, columnboundaries{})
+		b = append(b, analyzedBoundary{})
 		copy(b[at+1:], b[at:])
 		b[at] = bound
 	}
@@ -442,7 +442,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 				}
 			}
 			if !already {
-				insertSortedBoundary(columnboundaries{col: col, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta})
+				insertSortedBoundary(analyzedBoundary{col: col, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta})
 			}
 			continue
 		}
@@ -485,7 +485,7 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 			}
 		}
 		if !already {
-			insertSortedBoundary(columnboundaries{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta, mapCols: mc, mapFn: mf})
+			insertSortedBoundary(analyzedBoundary{col: canon, matcher: RangeMatcher, lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta, mapCols: mc, mapFn: mf})
 		}
 	}
 	return b, len(sortcols) > 0
@@ -493,21 +493,20 @@ func extendBoundariesWithSortCols(b boundaries, sortcols []scm.Scmer, sortdirs [
 
 // extendScanAccessWithSortCols adds only the runtime ORDER BY portion to the
 // immutable compiled access view. Unlike extendBoundariesWithSortCols it never
-// copies the planner-provided filter boundaries into a runtime array.
+// copies the analyzer-produced filter boundaries into a runtime array.
 func extendScanAccessWithSortCols(access scanAccess, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer) (scanAccess, bool) {
 	for i := 0; i < access.len(); i++ {
-		if !boundaryIsPoint(access.boundary(i)) {
+		if !scanAccessBoundaryIsPoint(access, i) {
 			return access, false
 		}
 	}
 	if len(sortcols) == 0 || len(sortdirs) < len(sortcols) {
 		return access, false
 	}
-	inserted := make(boundaries, 0, len(sortcols))
+	inserted := make(analyzedBoundaries, 0, len(sortcols))
 	hasSorted := func(column string) bool {
 		for i := 0; i < access.len(); i++ {
-			boundary := access.boundary(i)
-			if boundary.col == column && boundary.matcher.IsSorted() {
+			if access.boundaryColumn(i) == column && access.boundaryAnalyzer(i).IsSorted() {
 				return true
 			}
 		}
@@ -526,7 +525,7 @@ func extendScanAccessWithSortCols(access scanAccess, sortcols []scm.Scmer, sortd
 		if sortcol.IsString() {
 			column := sortcol.String()
 			if !hasSorted(column) {
-				inserted = append(inserted, columnboundaries{col: column, matcher: RangeMatcher,
+				inserted = append(inserted, analyzedBoundary{col: column, matcher: RangeMatcher,
 					lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta})
 			}
 			continue
@@ -552,7 +551,7 @@ func extendScanAccessWithSortCols(access scanAccess, sortcols []scm.Scmer, sortd
 			return access, false
 		}
 		if !hasSorted(canonical) {
-			inserted = append(inserted, columnboundaries{col: canonical, matcher: RangeMatcher,
+			inserted = append(inserted, analyzedBoundary{col: canonical, matcher: RangeMatcher,
 				lower: scm.NewNil(), upper: scm.NewNil(), order: sortdirs[i], orderMeta: orderMeta,
 				mapCols: mapCols, mapFn: mapFn})
 		}
@@ -560,7 +559,7 @@ func extendScanAccessWithSortCols(access scanAccess, sortcols []scm.Scmer, sortd
 	compiledCount := access.compiledCount
 	runtime := access.ensureRuntime()
 	runtime.insertAt = compiledCount
-	runtime.inserted = inserted
+	runtime.inserted = scanAccessSegmentFromAnalyzed(inserted)
 	return access, true
 }
 
@@ -570,19 +569,18 @@ func indexCoversBoundaryOrder(index *StorageIndex, active bool, bounds scanAcces
 	}
 	orderCols := 0
 	for i := 0; i < bounds.len(); i++ {
-		boundary := bounds.boundary(i)
-		if boundary.order == nil || boundaryIsPoint(boundary) {
+		order, orderMeta := bounds.boundaryOrder(i)
+		if order == nil || scanAccessBoundaryIsPoint(bounds, i) {
 			continue
 		}
 		orderCols++
 		if i >= effectiveCols || i >= len(index.Cols) || i >= len(index.ColOrder) {
 			return false
 		}
-		orderMeta := boundary.orderMeta
 		if orderMeta == "" {
-			orderMeta = orderRelationMeta(boundary.order)
+			orderMeta = orderRelationMeta(order)
 		}
-		if index.Cols[i] != boundary.col || i >= len(index.ColOrderMeta) || index.ColOrderMeta[i] != orderMeta {
+		if index.Cols[i] != bounds.boundaryColumn(i) || i >= len(index.ColOrderMeta) || index.ColOrderMeta[i] != orderMeta {
 			return false
 		}
 	}
@@ -614,8 +612,7 @@ func orderedIndexUsageWeight(rows, kept int) float64 {
 // build weight above.
 func orderedScanIndexUsageWeight(bounds scanAccess, rows, kept int) float64 {
 	for i := 0; i < bounds.len(); i++ {
-		bound := bounds.boundary(i)
-		if !boundaryIsUnboundedOrder(bound) {
+		if !scanAccessBoundaryIsUnboundedOrder(bounds, i) {
 			return 1
 		}
 	}
@@ -679,14 +676,14 @@ func recSetHooksCoverCondition(bounds scanAccess, backingTable *table, condition
 	covered := 0
 	indexBounds := newScanIndexBounds(bounds)
 	for i := 0; i < indexBounds.len() && i < bounds.len(); i++ {
-		bound := bounds.boundary(i)
-		if !matcherKindEqual(bound.matcher, RecSetMatcher) {
+		if !matcherKindEqual(bounds.boundaryAnalyzer(i), RecSetMatcher) {
 			continue
 		}
-		if !bound.lower.IsCustom(TagRecSet) {
+		lower := bounds.boundValue(i, false)
+		if !lower.IsCustom(TagRecSet) {
 			return false
 		}
-		set := RecSetFromScmer(bound.lower)
+		set := RecSetFromScmer(lower)
 		if set == nil || set.table != backingTable {
 			return false
 		}
@@ -767,12 +764,12 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		bounds = bounds.useScratch(scratch)
 		bounds, _ = extendScanAccessWithSortCols(bounds, spec.sortcols, sortdirs)
 		runtime := bounds.ensureRuntime()
-		runtime.suffix = appendRecSetBoundary(runtime.suffix, spec.recset)
+		runtime.extra = scanAccessSegmentFromAnalyzed(appendRecSetBoundary(nil, spec.recset))
 		if Settings.ScanDebugging {
 			dbg := fmt.Sprintf("[SCAN_ORDER_MULTI] %s.%s", t.schema.Name, t.Name)
 			for i := 0; i < bounds.len(); i++ {
-				b := bounds.boundary(i)
-				dbg += fmt.Sprintf(" %s:[%v..%v]", b.col, b.lower, b.upper)
+				dbg += fmt.Sprintf(" %s:[%v..%v]", bounds.boundaryColumn(i),
+					bounds.boundValue(i, false), bounds.boundValue(i, true))
 			}
 			indexBounds := newScanIndexBounds(bounds)
 			dbg += fmt.Sprintf(" lower-count=%d upper=%v", indexBounds.len(), indexBounds.upperLast())
@@ -780,8 +777,7 @@ func scanOrderMulti(currentTx *TxContext, tables []scanOrderTableSpec, sortdirs 
 		}
 
 		for i := 0; i < bounds.len(); i++ {
-			b := bounds.boundary(i)
-			t.AddPartitioningScore([]string{b.col})
+			t.AddPartitioningScore([]string{bounds.boundaryColumn(i)})
 		}
 		analyzeNs := time.Since(analyzeStart).Nanoseconds()
 		stats[ti].access = bounds
@@ -1188,8 +1184,6 @@ func (t *table) scan_order(currentTx *TxContext, accessSchema scm.Scmer, accessV
 func (t *table) scanOrderFirst(currentTx *TxContext, accessSchema scm.Scmer, accessValues []scm.Scmer, conditionCols []string, condition scm.Scmer, callbackCols []string, mapReduce scm.Scmer, neutral scm.Scmer, notFoundValue scm.Scmer) scm.Scmer {
 	ss := SessionStateFromTx(currentTx)
 	querySeq := querySeqFromTx(currentTx)
-	scratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(scratch)
 	bounds, compiled := scanAccessFromScheme(accessSchema, accessValues, nil)
 	if !compiled {
 		panic("scan_order received an invalid compiled access schema")
@@ -1197,7 +1191,6 @@ func (t *table) scanOrderFirst(currentTx *TxContext, accessSchema scm.Scmer, acc
 	if bounds.impossible() {
 		return notFoundValue
 	}
-	bounds = bounds.useScratch(scratch)
 
 	var mu sync.Mutex
 	var foundShard *storageShard
@@ -1293,19 +1286,19 @@ func streamOrBreak(mapper *ShardMapReducer, acc scm.Scmer, recids []uint32) (res
 	return
 }
 
-func (t *storageShard) scan_order(boundaries scanAccess, conditionCols []string, condition scm.Scmer, acceptCols []string, accept scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
+func (t *storageShard) scan_order(access scanAccess, conditionCols []string, condition scm.Scmer, acceptCols []string, accept scm.Scmer, sortcols []scm.Scmer, sortdirs []func(...scm.Scmer) scm.Scmer, limitPartitionCols int, offset int, limit int, callbackCols []string, currentTx *TxContext, ss *scm.SessionState) (result *shardqueue) {
 	result = new(shardqueue)
 	result.shard = t
 	t.ensureLoaded()
 	skipShardReadLock := t.hasWriteOwnerForTx(currentTx)
-	t.ensureScanAccessColumns(boundaries, skipShardReadLock, currentTx)
+	t.ensureScanAccessColumns(access, skipShardReadLock, currentTx)
 	if ss == nil {
 		ss = SessionStateFromTx(currentTx)
 	}
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(boundaries, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(access, t.t, conditionCols, condition)
 	conditionProgram := scm.PrepareSerialProc(condition)
 	conditionAlwaysTrue := scanConditionAlwaysTrue(&conditionProgram, len(conditionCols)) ||
-		scanAccessProvesCondition(conditionCols, condition, boundaries)
+		scanAccessProvesCondition(conditionCols, condition, access)
 	var acceptProgram *scm.SerialProc
 	if !accept.IsNil() {
 		prepared := scm.PrepareSerialProc(accept)
@@ -1447,7 +1440,7 @@ func (t *storageShard) scan_order(boundaries scanAccess, conditionCols []string,
 		result.universe = visibleUpper
 
 		// iterate over items (indexed)
-		// TODO(memcp): iterateIndexSorted(boundaries, sortcols) to emit tuples in ORDER BY sequence.
+		// TODO(memcp): iterateIndexSorted(access, sortcols) to emit tuples in ORDER BY sequence.
 		buf, pooledFullBuf, pooledPointBuf := acquireScanIDBuffer(defaultScanBufferSize)
 		defer releaseScanIDBuffer(pooledFullBuf, pooledPointBuf)
 		resultCap := 1024
@@ -1459,7 +1452,7 @@ func (t *storageShard) scan_order(boundaries scanAccess, conditionCols []string,
 		}
 		result.items = make([]uint32, resultCap)
 		resultN := 0
-		usageWeight := orderedScanIndexUsageWeight(boundaries, int(visibleUpper), limit)
+		usageWeight := orderedScanIndexUsageWeight(access, int(visibleUpper), limit)
 		// Reused across batches: survived/mainIds scratch lists and one value
 		// buffer per non-getter condition column, so a batch's main-storage rows
 		// are fetched with one GetValueMulti call per column instead of one
@@ -1468,7 +1461,6 @@ func (t *storageShard) scan_order(boundaries scanAccess, conditionCols []string,
 		colBufs := make([][]scm.Scmer, len(conditionCols))
 		acceptColBufs := make([][]scm.Scmer, len(acceptCols))
 		boundaryCoveredLimit := acceptProgram == nil && conditionAlwaysTrue
-		access := boundaries
 		indexBounds := newScanIndexBounds(access)
 		t.iterateIndexOrdered(currentTx, access, maxInsertIndex, buf, usageWeight, limit, boundaryCoveredLimit, func(index *StorageIndex, active bool) {
 			if len(sortcols) > 0 {

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -131,7 +131,6 @@ func collectPartitionOrderedCandidateBatch(currentTx *TxContext, source scanOrde
 			partOrder = make([]*orderedBatchPart, 0)
 			remainingOffset := offset
 			bounds, _ := extendBoundariesWithSortCols(nil, sortcols, sortdirs)
-			lower, upperLast := indexFromBoundaries(bounds)
 			condition := scm.NewFunc(func(...scm.Scmer) scm.Scmer { return scm.NewBool(true) })
 			sessionState := SessionStateFromTx(currentTx)
 			querySeq := querySeqFromTx(currentTx)
@@ -147,7 +146,7 @@ func collectPartitionOrderedCandidateBatch(currentTx *TxContext, source scanOrde
 				queue := func() *shardqueue {
 					defer release()
 					defer shard.activeScanners.Add(-1)
-					return shard.scan_order(runtimeScanAccess(bounds), lower, upperLast, nil, condition,
+					return shard.scan_order(runtimeScanAccess(bounds), nil, condition,
 						nil, scm.NewNil(), sortcols, sortdirs, 0, remainingOffset,
 						limit-len(records), nil, currentTx, sessionState)
 				}()

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -80,15 +80,14 @@ func TestCoveredOrderedLimitBrakesInsideIndexBatch(t *testing.T) {
 	if !covered {
 		t.Fatal("bucket/rank index does not cover ORDER BY")
 	}
-	lower, upper := indexFromBoundaries(bounds)
 	shard := tbl.ActiveShards()[0]
 	shard.mu.RLock()
 	var buildBuf [8]uint32
-	shard.iterateIndexForce(nil, runtimeScanAccess(bounds), lower, upper, len(shard.inserts), buildBuf[:], false,
+	shard.iterateIndexForce(nil, runtimeScanAccess(bounds), len(shard.inserts), buildBuf[:], false,
 		func([]uint32) bool { return false })
 	shard.mu.RUnlock()
 	run := func(acceptCols []string, accept scm.Scmer) *shardqueue {
-		return shard.scan_order(coveredRuntimeScanAccess(bounds), lower, upper,
+		return shard.scan_order(coveredRuntimeScanAccess(bounds),
 			[]string{"bucket"}, condition, acceptCols, accept,
 			[]scm.Scmer{scm.NewString("rank")}, []func(...scm.Scmer) scm.Scmer{order},
 			0, 0, limit, nil, nil, nil)

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -28,7 +28,7 @@ func TestExtendBoundariesRejectsPartiallyCoveredOrder(t *testing.T) {
 		scm.NewSymbol("foreign_id"),
 		scm.NewSymbol("$tx"),
 	}))
-	original := boundaries{{
+	original := analyzedBoundaries{{
 		col: "tenant_id", matcher: EqualMatcher,
 		lower: scm.NewInt(7), lowerInclusive: true,
 		upper: scm.NewInt(7), upperInclusive: true,

--- a/storage/scan_parallel_test.go
+++ b/storage/scan_parallel_test.go
@@ -46,12 +46,12 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		boundary   columnboundaries
+		boundary   analyzedBoundary
 		wantShards []int
 	}{
 		{
 			name: "point between late pivots",
-			boundary: columnboundaries{
+			boundary: analyzedBoundary{
 				col: "id", matcher: EqualMatcher,
 				lower: scm.NewInt(35), lowerInclusive: true,
 				upper: scm.NewInt(35), upperInclusive: true,
@@ -60,7 +60,7 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 		},
 		{
 			name: "point on pivot",
-			boundary: columnboundaries{
+			boundary: analyzedBoundary{
 				col: "id", matcher: EqualMatcher,
 				lower: scm.NewInt(20), lowerInclusive: true,
 				upper: scm.NewInt(20), upperInclusive: true,
@@ -69,7 +69,7 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 		},
 		{
 			name: "closed range",
-			boundary: columnboundaries{
+			boundary: analyzedBoundary{
 				col: "id", matcher: RangeMatcher,
 				lower: scm.NewInt(15), lowerInclusive: true,
 				upper: scm.NewInt(35), upperInclusive: true,
@@ -78,7 +78,7 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 		},
 		{
 			name: "exclusive lower pivot",
-			boundary: columnboundaries{
+			boundary: analyzedBoundary{
 				col: "id", matcher: RangeMatcher,
 				lower: scm.NewInt(20), lowerInclusive: false,
 				upper: scm.NewNil(), upperInclusive: false,
@@ -87,7 +87,7 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 		},
 		{
 			name: "exclusive upper pivot remains conservative",
-			boundary: columnboundaries{
+			boundary: analyzedBoundary{
 				col: "id", matcher: RangeMatcher,
 				lower: scm.NewNil(), lowerInclusive: false,
 				upper: scm.NewInt(20), upperInclusive: false,
@@ -98,7 +98,7 @@ func TestCollectRelevantShardsUsesPartitionBounds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := collectRelevantShards(schema, runtimeScanAccess(boundaries{tt.boundary}), shards)
+			got := collectRelevantShards(schema, runtimeScanAccess(analyzedBoundaries{tt.boundary}), shards)
 			if len(got) != len(tt.wantShards) {
 				t.Fatalf("collectRelevantShards returned %d shards, want %d", len(got), len(tt.wantShards))
 			}
@@ -353,7 +353,7 @@ func TestIterateShardsParallelMarksPartitionSingleShardSolo(t *testing.T) {
 
 	calls := 0
 	sawSolo := false
-	done := tbl.iterateShardsParallel(nil, runtimeScanAccess(boundaries{{
+	done := tbl.iterateShardsParallel(nil, runtimeScanAccess(analyzedBoundaries{{
 		col:            "id",
 		matcher:        EqualMatcher,
 		lower:          scm.NewInt(15),

--- a/storage/scan_recset_boundary_test.go
+++ b/storage/scan_recset_boundary_test.go
@@ -80,12 +80,11 @@ func buildRankOrderIndex(t *testing.T, tbl *table) func(...scm.Scmer) scm.Scmer 
 	if !ok {
 		t.Fatal("rank ORDER boundary was not constructed")
 	}
-	lower, upper := indexFromBoundaries(bounds)
 	shard := tbl.ActiveShards()[0]
 	shard.mu.RLock()
 	defer shard.mu.RUnlock()
 	var buf [8]uint32
-	shard.iterateIndexForce(nil, runtimeScanAccess(bounds), lower, upper, len(shard.inserts), buf[:], false,
+	shard.iterateIndexForce(nil, runtimeScanAccess(bounds), len(shard.inserts), buf[:], false,
 		func([]uint32) bool { return false })
 	return order
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2733,9 +2733,8 @@ func (t *storageShard) insertDatasetFromLog(columns []string, values [][]scm.Scm
 const uniqueLookupInlineColumns = 8
 
 type uniqueLookupScratch struct {
-	mcols  [uniqueLookupInlineColumns]ColumnStorage
-	bounds [uniqueLookupInlineColumns]columnboundaries
-	ids    [8]uint32
+	mcols [uniqueLookupInlineColumns]ColumnStorage
+	ids   [8]uint32
 }
 
 var uniqueLookupScratchPool = sync.Pool{
@@ -2751,34 +2750,23 @@ func releaseUniqueLookupScratch(scratch *uniqueLookupScratch, columns int) {
 		columns = uniqueLookupInlineColumns
 	}
 	clear(scratch.mcols[:columns])
-	clear(scratch.bounds[:columns])
 	uniqueLookupScratchPool.Put(scratch)
 }
 
-func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer, currentTx *TxContext) (result uint32, present bool) {
+func (t *storageShard) GetRecordidForUnique(access scanAccess, currentTx *TxContext) (result uint32, present bool) {
 	// Preload main storages and establish main_count without holding any shard lock
 	t.ensureMainCount(false)
+	columns := access.len()
 	scratch := acquireUniqueLookupScratch()
-	defer releaseUniqueLookupScratch(scratch, len(columns))
+	defer releaseUniqueLookupScratch(scratch, columns)
 	mcols := scratch.mcols[:]
-	if len(columns) <= len(mcols) {
-		mcols = mcols[:len(columns)]
+	if columns <= len(mcols) {
+		mcols = mcols[:columns]
 	} else {
-		mcols = make([]ColumnStorage, len(columns))
+		mcols = make([]ColumnStorage, columns)
 	}
-	for i, col := range columns {
-		mcols[i] = t.getColumnStorageOrPanic(col, false, currentTx)
-	}
-
-	// Build equality boundaries for the index lookup
-	bounds := scratch.bounds[:]
-	if len(columns) <= len(bounds) {
-		bounds = bounds[:len(columns)]
-	} else {
-		bounds = make(boundaries, len(columns))
-	}
-	for i, col := range columns {
-		bounds[i] = columnboundaries{col: col, matcher: EqualMatcher, lower: values[i], lowerInclusive: true, upper: values[i], upperInclusive: true}
+	for i := range mcols {
+		mcols[i] = t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx)
 	}
 
 	// From here on, read under shard read lock for a consistent snapshot of deletions/inserts/deltaColumns
@@ -2790,13 +2778,14 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 
 	// Use iterateIndex for O(log n) lookup (builds index lazily if needed)
 	// Small buffer for existence check: stop early after first match
-	t.iterateIndex(currentTx, runtimeScanAccess(bounds), len(t.inserts), scratch.ids[:], 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, access, len(t.inserts), scratch.ids[:], 1, nil, func(batch []uint32) bool {
 		for _, idx := range batch {
 			// Verify all columns match (iterateIndex may return superset for range boundaries)
 			matched := true
 			if idx < mainCount {
 				// Main storage: use ColumnStorage
-				for j, v := range values {
+				for j := 0; j < columns; j++ {
+					v := access.boundValue(j, false)
 					if !scm.Equal(mcols[j].GetValue(idx), v) {
 						matched = false
 						break
@@ -2804,8 +2793,8 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 				}
 			} else {
 				// Delta storage: use getDelta
-				for j, v := range values {
-					if !scm.Equal(t.getDelta(int(idx-mainCount), columns[j]), v) {
+				for j := 0; j < columns; j++ {
+					if !scm.Equal(t.getDelta(int(idx-mainCount), access.boundaryColumn(j)), access.boundValue(j, false)) {
 						matched = false
 						break
 					}

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -2840,8 +2840,6 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 	t.ensureMainCount(false)
 	ccols := make([]ColumnStorage, len(conditionCols))
 	conditionGetters := make([]mapArgGetter, len(conditionCols))
-	scratch := acquireScanAnalyzeScratch()
-	defer releaseScanAnalyzeScratch(scratch)
 	bounds, compiled := scanAccessFromScheme(accessSchema, accessValues, nil)
 	if !compiled {
 		panic("scan_selectivity_estimate received an invalid compiled access schema")

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1496,6 +1496,12 @@ type mapArgGetter func(uint32, uint32) scm.Scmer
 
 const inlineMapReducerColumns = 8
 
+type mapReducerBulkBuffer struct {
+	values []scm.Scmer
+}
+
+var mapReducerBulkBufferPools [inlineMapReducerColumns]sync.Pool
+
 // shardMapReducerWorkspace supplies bounded caller-owned storage for the common
 // read-only mapper. Wider projections fall back to sized heap slices; mutation
 // pseudo-columns use the retained general mapper because their closures may
@@ -1504,6 +1510,21 @@ type shardMapReducerWorkspace struct {
 	mainCols        [inlineMapReducerColumns]ColumnStorage
 	mainBulkReaders [inlineMapReducerColumns]ColumnReader
 	args            [inlineMapReducerColumns + 1]scm.Scmer
+}
+
+var shardMapReducerWorkspacePool = sync.Pool{
+	New: func() any { return new(shardMapReducerWorkspace) },
+}
+
+func acquireShardMapReducerWorkspace() *shardMapReducerWorkspace {
+	return shardMapReducerWorkspacePool.Get().(*shardMapReducerWorkspace)
+}
+
+func releaseShardMapReducerWorkspace(workspace *shardMapReducerWorkspace) {
+	clear(workspace.mainCols[:])
+	clear(workspace.mainBulkReaders[:])
+	clear(workspace.args[:])
+	shardMapReducerWorkspacePool.Put(workspace)
 }
 
 // ShardMapReducer pre-allocates args and applies a fused map-reducer over batches of record IDs.
@@ -1520,6 +1541,7 @@ type ShardMapReducer struct {
 	mainCols        []ColumnStorage        // direct main storage access (nil for $update/$invalidate/$increment cols)
 	mainBulkReaders []ColumnReader         // physical map columns gathered once per Stream main-record run
 	mainBulkValues  []scm.Scmer            // reusable row-major buffer for every physical map column
+	mainBulkBuffer  *mapReducerBulkBuffer  // non-nil when mainBulkValues belongs to a width bucket
 	colNames        []string               // column names for delta getDelta access
 	isUpdate        []bool                 // true for $update columns
 	isInvalidate    []bool                 // true for $invalidate: columns
@@ -1947,7 +1969,17 @@ func (m *ShardMapReducer) prefetchMainColumns(recids []uint32) {
 	}
 	needed := len(recids) * width
 	if cap(m.mainBulkValues) < needed {
-		m.mainBulkValues = make([]scm.Scmer, needed)
+		if m.mainBulkBuffer == nil && width <= inlineMapReducerColumns && needed <= defaultScanBufferSize*width {
+			pool := &mapReducerBulkBufferPools[width-1]
+			if pooled := pool.Get(); pooled != nil {
+				m.mainBulkBuffer = pooled.(*mapReducerBulkBuffer)
+			} else {
+				m.mainBulkBuffer = &mapReducerBulkBuffer{values: make([]scm.Scmer, defaultScanBufferSize*width)}
+			}
+			m.mainBulkValues = m.mainBulkBuffer.values[:needed]
+		} else {
+			m.mainBulkValues = make([]scm.Scmer, needed)
+		}
 	} else {
 		m.mainBulkValues = m.mainBulkValues[:needed]
 	}
@@ -2291,6 +2323,13 @@ func (m *ShardMapReducer) processDeltaBlockBatch(acc scm.Scmer, recids []uint32,
 // batches — that must happen after all shard locks are released.
 // Call FlushTriggerBatch() separately after the scan completes.
 func (m *ShardMapReducer) Close() {
+	if m.mainBulkBuffer != nil {
+		clear(m.mainBulkBuffer.values)
+		width := cap(m.mainBulkBuffer.values) / defaultScanBufferSize
+		mapReducerBulkBufferPools[width-1].Put(m.mainBulkBuffer)
+		m.mainBulkBuffer = nil
+		m.mainBulkValues = nil
+	}
 }
 
 // FlushSideEffects flushes all batched side effects (triggers, increments,
@@ -2696,7 +2735,6 @@ const uniqueLookupInlineColumns = 8
 type uniqueLookupScratch struct {
 	mcols  [uniqueLookupInlineColumns]ColumnStorage
 	bounds [uniqueLookupInlineColumns]columnboundaries
-	lower  [uniqueLookupInlineColumns]scm.Scmer
 	ids    [8]uint32
 }
 
@@ -2714,7 +2752,6 @@ func releaseUniqueLookupScratch(scratch *uniqueLookupScratch, columns int) {
 	}
 	clear(scratch.mcols[:columns])
 	clear(scratch.bounds[:columns])
-	clear(scratch.lower[:columns])
 	uniqueLookupScratchPool.Put(scratch)
 }
 
@@ -2743,7 +2780,6 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 	for i, col := range columns {
 		bounds[i] = columnboundaries{col: col, matcher: EqualMatcher, lower: values[i], lowerInclusive: true, upper: values[i], upperInclusive: true}
 	}
-	lower, upperLast := indexFromBoundariesInto(scratch.lower[:0], bounds)
 
 	// From here on, read under shard read lock for a consistent snapshot of deletions/inserts/deltaColumns
 	t.mu.RLock()
@@ -2754,7 +2790,7 @@ func (t *storageShard) GetRecordidForUnique(columns []string, values []scm.Scmer
 
 	// Use iterateIndex for O(log n) lookup (builds index lazily if needed)
 	// Small buffer for existence check: stop early after first match
-	t.iterateIndex(currentTx, runtimeScanAccess(bounds), lower, upperLast, len(t.inserts), scratch.ids[:], 1, nil, func(batch []uint32) bool {
+	t.iterateIndex(currentTx, runtimeScanAccess(bounds), len(t.inserts), scratch.ids[:], 1, nil, func(batch []uint32) bool {
 		for _, idx := range batch {
 			// Verify all columns match (iterateIndex may return superset for range boundaries)
 			matched := true
@@ -2825,8 +2861,7 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 		return filteredRowEstimate{population: "shard_rows", coverage: "exact"}
 	}
 	t.ensureScanAccessColumns(bounds, false, currentTx)
-	lower, upperLast := indexFromScanAccessInto(scratch.lower[:0], bounds)
-	recsetBoundaryCoversCondition := recSetHooksCoverCondition(bounds, lower, t.t, conditionCols, condition)
+	recsetBoundaryCoversCondition := recSetHooksCoverCondition(bounds, t.t, conditionCols, condition)
 	for i, col := range conditionCols {
 		if col == "$recset_contains" {
 			fnptr := recSetContainsClosure(t)
@@ -2860,11 +2895,12 @@ func (t *storageShard) EstimateFilteredRows(conditionCols []string, condition sc
 
 	var buf [256]uint32
 	access := bounds
-	t.iterateIndexEstimate(currentTx, access, lower, upperLast, len(t.inserts), buf[:], &candidateSpan, func(index *StorageIndex, active bool) {
+	indexBounds := newScanIndexBounds(access)
+	t.iterateIndexEstimate(currentTx, access, len(t.inserts), buf[:], &candidateSpan, func(index *StorageIndex, active bool) {
 		// Cold-index fallback now enforces the same exact sorted prefix before
 		// invoking the sampling callback, so its candidates have the same
 		// population semantics as an active index range.
-		indexRestricted = len(lower) > 0
+		indexRestricted = indexBounds.len() > 0
 		if active {
 			if candidates, universe, ok := index.estimateHookCandidates(currentTx, access); ok {
 				hookCandidates = int64(candidates) + int64(len(t.inserts))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -765,7 +765,7 @@ func Init(en scm.Env) {
 	scm.CustomStringer[TagRecSet] = func(ptr unsafe.Pointer) string {
 		return (*recSet)(ptr).String()
 	}
-	scm.CustomStringer[TagScanBoundary] = scanBoundaryString
+	registerScanBoundaryFormats()
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "scan_boundary",

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -765,6 +765,25 @@ func Init(en scm.Env) {
 	scm.CustomStringer[TagRecSet] = func(ptr unsafe.Pointer) string {
 		return (*recSet)(ptr).String()
 	}
+	scm.CustomStringer[TagScanBoundary] = scanBoundaryString
+
+	scm.Declare(&en, &scm.Declaration{
+		Name: "scan_boundary",
+		Fn: func(a ...scm.Scmer) scm.Scmer {
+			if len(a) != 8 {
+				panic("scan_boundary expects kind, column, lower slot, upper slot, inclusiveness, collation, and null-safety")
+			}
+			return newScanBoundarySpec(scm.String(a[1]), scanBoundaryAnalyzer(scm.String(a[0])), scm.ToInt(a[2]), scm.ToInt(a[3]),
+				a[4].Bool(), a[5].Bool(), scm.String(a[6]), a[7].Bool(), -1, nil, nil, "", false)
+		},
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "construct an immutable physical scan boundary for a cached access schema",
+			Params: []*scm.TypeDescriptor{
+				{Kind: "string", Label: "kind"}, {Kind: "string", Label: "column"},
+				{Kind: "number", Label: "lower_slot"}, {Kind: "number", Label: "upper_slot"},
+				{Kind: "bool", Label: "lower_inclusive"}, {Kind: "bool", Label: "upper_inclusive"},
+				{Kind: "string", Label: "collation"}, {Kind: "bool", Label: "null_safe"},
+			}, Return: &scm.TypeDescriptor{Kind: "any", Label: "boundary"}},
+	})
 
 	scm.Declare(&en, &scm.Declaration{
 		Name: "table",

--- a/storage/table.go
+++ b/storage/table.go
@@ -395,6 +395,7 @@ type foreignKey struct {
 // the insert-time UNIQUE contract which permits multiple SQL NULL values.
 func (t *table) hasDuplicateUniqueValues(cols []string, currentTx *TxContext) bool {
 	shards := t.ActiveShards()
+	accessSchema := newExactScanAccessSchema(cols)
 	rows := make([]uniqueValidationRow, 0, t.CountEstimate())
 
 	for _, shard := range shards {
@@ -433,7 +434,7 @@ func (t *table) hasDuplicateUniqueValues(cols []string, currentTx *TxContext) bo
 			if shard == nil {
 				continue
 			}
-			recid, present := shard.GetRecordidForUnique(cols, row.key, currentTx)
+			recid, present := shard.GetRecordidForUnique(exactScanAccess(accessSchema, row.key), currentTx)
 			if present && (shard != row.shard || recid != row.recid) {
 				return true
 			}
@@ -2701,6 +2702,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 		return
 	}
 	uniq := t.Unique[idx]
+	accessSchema := newExactScanAccessSchema(uniq.Cols)
 	t.AddPartitioningScore(uniq.Cols) // increases partitioning score, so partitioning is improved
 	{
 		key := make([]scm.Scmer, len(uniq.Cols))
@@ -2807,7 +2809,7 @@ func (t *table) ProcessUniqueCollision(columns []string, values [][]scm.Scmer, m
 			for _, s := range shardlist2 {
 				// ensure shard is loaded for read during unique check
 				r := s.GetRead()
-				uid, present := s.GetRecordidForUnique(uniq.Cols, key, currentTx)
+				uid, present := s.GetRecordidForUnique(exactScanAccess(accessSchema, key), currentTx)
 				if present {
 					// found a unique collision
 					if j != last_j {

--- a/tests/performance/computed-lookup-cache-invalidation.yaml
+++ b/tests/performance/computed-lookup-cache-invalidation.yaml
@@ -44,7 +44,7 @@ test_cases:
           '("source_id")
           (lambda (source_id)
             (scan nil (table "memcp-tests" "lookup_invalidation_source")
-              '(369436175368192 "equal" "id" 15032418304 "") (list source_id)
+              (list 369436175368192 (scan_boundary "equal" "id" 0 0 true true "" false)) (list source_id)
               '("id") (lambda (id) (equal? id (outer 1 source_id)))
               '("val") (lambda (acc val) val)
               0 (lambda (old value) value) false)))

--- a/tests/performance/forum-hierarchy-aggregate-joins.yaml
+++ b/tests/performance/forum-hierarchy-aggregate-joins.yaml
@@ -247,11 +247,11 @@ test_cases:
             (lambda (count forumID)
               (begin
                 (define child_count
-                  (scan tx forums '(369436175368192 "equal" "parentID" 15032418304 "") (list forumID)
+                  (scan tx forums (list 369436175368192 (scan_boundary "equal" "parentID" 0 0 true true "" false)) (list forumID)
                     '("parentID") (lambda (parentID) (equal?? parentID forumID))
                     '() (lambda (acc) (+ acc 1)) 0 + false))
                 (define thread_stats
-                  (scan tx threads '(369436175368192 "equal" "forumID" 15032418304 "") (list forumID)
+                  (scan tx threads (list 369436175368192 (scan_boundary "equal" "forumID" 0 0 true true "" false)) (list forumID)
                     '("forumID") (lambda (threadForumID) (equal?? threadForumID forumID))
                     '("postCount" "lastPostID")
                     (lambda (acc postCount lastPostID)
@@ -260,14 +260,14 @@ test_cases:
                     (lambda (acc row) (list (+ (car acc) (car row)) (max (cadr acc) (cadr row))))
                     false))
                 (define post
-                  (scan tx posts '(369436175368192 "equal" "postID" 15032418304 "") (list (cadr thread_stats))
+                  (scan tx posts (list 369436175368192 (scan_boundary "equal" "postID" 0 0 true true "" false)) (list (cadr thread_stats))
                     '("postID") (lambda (postID) (equal?? postID (cadr thread_stats)))
                     '("authorID" "datePosted")
                     (lambda (_old authorID datePosted) (list authorID datePosted))
                     nil (lambda (_old row) row) true))
                 (define username
                   (if (nil? post) nil
-                    (scan tx users '(369436175368192 "equal" "userID" 15032418304 "") (list (car post))
+                    (scan tx users (list 369436175368192 (scan_boundary "equal" "userID" 0 0 true true "" false)) (list (car post))
                       '("userID") (lambda (userID) (equal?? userID (car post)))
                       '("username") (lambda (_old value) value)
                       nil (lambda (_old value) value) true)))

--- a/tests/performance/wordpress-postmeta-order-limit.yaml
+++ b/tests/performance/wordpress-postmeta-order-limit.yaml
@@ -121,8 +121,10 @@ test_cases:
           (scan_join_order (session "__memcp_tx")
             (list postmeta posts)
             (list
-              '(370535686995968 "equal" "meta_key" 15032418304 "")
-              '(370535955431424 "equal" "post_status" 15032483841 "" "equal" "post_type" 15032549378 ""))
+              (list 370535686995968 (scan_boundary "equal" "meta_key" 0 0 true true "" false))
+              (list 370535955431424
+                (scan_boundary "equal" "post_status" 0 0 true true "" false)
+                (scan_boundary "equal" "post_type" 1 1 true true "" false)))
             (list "custom_color" "publish" "post")
             (list (list) (list))
             (list (lambda () true) (lambda () true))

--- a/tests/sql/security/mysql-auth-tx-nil.yaml
+++ b/tests/sql/security/mysql-auth-tx-nil.yaml
@@ -15,7 +15,7 @@ test_cases:
       (if
         (equal?
           (scan nil (table "system" "user")
-            '(369436175368192 "equal" "username" 15032418304 "") '("auth_scan_nil_repro")
+            (list 369436175368192 (scan_boundary "equal" "username" 0 0 true true "" false)) '("auth_scan_nil_repro")
             '() (lambda () true)
             '("password")
             (lambda (acc password) password)
@@ -37,7 +37,7 @@ test_cases:
       (if
         (equal?
           (scan_lookup nil (table "system" "user")
-            '(372734710317056 "equal" "username" 15032418304 "" "password") '("auth_scan_nil_repro"))
+            (list 372734710317056 (scan_boundary "equal" "username" 0 0 true true "" false) "password") '("auth_scan_nil_repro"))
           (password "secret123"))
         "ok"
         (error "scan_lookup nil over system.user returned wrong password"))

--- a/tests/sql/triggers/orc-trigger-dependencies.yaml
+++ b/tests/sql/triggers/orc-trigger-dependencies.yaml
@@ -56,7 +56,7 @@ test_cases:
                         (begin
                           (define value
                             (scan nil (table "memcp-tests" "orc_dep_src")
-                              '(369436175368192 "equal" "ref_id" 15032418304 "") (list ref_id)
+                              (list 369436175368192 (scan_boundary "equal" "ref_id" 0 0 true true "" false)) (list ref_id)
                               '("ref_id")
                             (lambda (src.ref_id) (equal? src.ref_id (outer 1 ref_id)))
                             '("val")

--- a/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
+++ b/tests/storage/indexes/computed-lookup-cache-invalidation.yaml
@@ -39,7 +39,7 @@ test_cases:
         (lambda (folder_id)
           (scan nil
             (table "memcp-tests" "lookup_cache_folder")
-            '(369436175368192 "equal" "id" 15032418304 "") (list folder_id)
+            (list 369436175368192 (scan_boundary "equal" "id" 0 0 true true "" false)) (list folder_id)
             '("id") (lambda (id) (equal? id (outer 1 folder_id)))
             '("stamp") (lambda (acc stamp) stamp)
             0 (lambda (old value) value) false)))
@@ -53,7 +53,7 @@ test_cases:
         (lambda (folder_id)
           (scan nil
             (table "memcp-tests" "lookup_cache_folder")
-            '(369436175368192 "equal" "id" 15032418304 "") (list folder_id)
+            (list 369436175368192 (scan_boundary "equal" "id" 0 0 true true "" false)) (list folder_id)
             '("id") (lambda (id) (equal? id (outer 1 folder_id)))
             '("stamp" "label_code") (lambda (acc stamp label_code) (+ stamp label_code))
             0 (lambda (old value) value) false)))
@@ -67,7 +67,7 @@ test_cases:
         (lambda (file_id)
           (scan nil
             (table "memcp-tests" "lookup_cache_file")
-            '(369436175368192 "equal" "id" 15032418304 "") (list file_id)
+            (list 369436175368192 (scan_boundary "equal" "id" 0 0 true true "" false)) (list file_id)
             '("id") (lambda (id) (equal? id (outer 1 file_id)))
             '(".lookup:folder_stamp") (lambda (acc folder_stamp) folder_stamp)
             0 (lambda (old value) value) false)))
@@ -81,7 +81,7 @@ test_cases:
         (lambda (file_id)
           (scan nil
             (table "memcp-tests" "lookup_cache_file")
-            '(369436175368192 "equal" "id" 15032418304 "") (list file_id)
+            (list 369436175368192 (scan_boundary "equal" "id" 0 0 true true "" false)) (list file_id)
             '("id") (lambda (id) (equal? id (outer 1 file_id)))
             '(".lookup:folder_pair") (lambda (acc folder_pair) folder_pair)
             0 (lambda (old value) value) false)))


### PR DESCRIPTION
## Summary

- use one physical scan ABI everywhere: `tx`, source, `[schema...]`, `[values...]`, then the residual filter and fused map/reducer arguments
- replace the internal `columnboundaries` execution array with immutable Scheme-visible `scan_boundary` objects plus one adjacent runtime-values array
- resolve point and range endpoints directly from value slots, including `scan_batch` row slots, without copying boundary structs
- bind a batch row through a non-escaping pointer into the caller-owned values array; no `sync.Pool` is involved
- use the same access view across `scan`, `scan_batch`, `scan_order`, RecSets, lookup, unique lookup, selectivity estimation, partition pruning, and index iteration
- preserve boundary objects embedded in persisted Scheme procedures through registered custom-value JSON codecs
- keep analyzer-only structs behind an explicit conversion boundary for uncommon storage-synthesized ORDER, RecSet, maintenance, and join constraints

There is one scan interface throughout the repository. No versioned compatibility wrappers or legacy ABI were added.

## Manual A/B measurements

Hardware: AMD Ryzen 9 7900X3D, Go 1.24.0. Microbenchmarks used `GOMAXPROCS=1`, CPU affinity `taskset -c 0`, identical fixtures, one-second samples, and five repetitions. Values are medians.

| Case | master | branch | Change |
| --- | ---: | ---: | ---: |
| Covered empty `scan_batch` | 1.295 us/op, 1688 B/op, 11 allocs/op | 581.9 ns/op, 0 B/op, 0 allocs/op | -55.1%; allocations eliminated |
| Warm covered unique point scan | 2.769 us/op, 848 B/op, 3 allocs/op | 2.414 us/op, 0 B/op, 0 allocs/op | -12.8%; allocations eliminated |
| Direct unique hit kernel | 1.079 us/op, 0 allocs/op | 1.094 us/op, 0 allocs/op | +1.4%, effectively neutral |
| Direct unique miss kernel | 624.3 ns/op, 0 allocs/op | 592.4 ns/op, 0 allocs/op | -5.1% |
| HTTP WordPress point query | 0.7 ms | 0.6 ms | -14% at runner resolution |
| HTTP WordPress ordered limit | 0.7 ms | 0.7 ms | neutral |
| HTTP WordPress filtered join | 0.8 ms | 0.8 ms | neutral |

Microbenchmark command:

```sh
GOMAXPROCS=1 taskset -c 0 go test ./storage -run "^$" -bench "^(BenchmarkScanBatchCoveredFixedCosts|BenchmarkScanUniquePointCoveredCompiledAccessWithTx|BenchmarkGetRecordIDForUniqueMainHit|BenchmarkGetRecordIDForUniqueMainMiss)$" -benchmem -benchtime=1s -count=5
```

The final end-to-end comparison used the existing `tests/performance/unique-insert.yaml` fixture with identical setup, warmup, and five repetitions:

| Case | master | branch | Change |
| --- | ---: | ---: | ---: |
| UNIQUE INSERT, fresh | 422.909 ms | 333.672 ms | -21.1% |
| UNIQUE INSERT, after rebuild | 460.218 ms | 356.712 ms | -22.5% |
| INSERT IGNORE duplicates | 151.790 ms | 150.272 ms | -1.0% |

Command:

```sh
PERF_AB_MODE=compare PERF_BASELINE_FILE=/tmp/pr766-unique-baseline.json PERF_NORECALIBRATE=1 PERF_REPEAT=5 python3 run_sql_tests.py tests/performance/unique-insert.yaml
```

The WordPress measurements used `tests/performance/wordpress-postmeta-order-limit.yaml` with its declared warmups and samples.

## Trade-offs and remaining work

The measured end-to-end cases are neutral or faster. The direct unique-hit kernel varied by +1.4%, while the complete unique-point scan improved by 12.8%; this is treated as noise rather than claimed as a kernel improvement.

Disassembly still contains allocation calls in cold branches of `scan`, `scanBatch`, and `iterateIndexEx`. The measured warm covered batch and unique-point paths no longer allocate. Runtime ORDER/RecSet/maintenance constraints are converted once into the common Scheme boundary representation; eliminating those setup allocations is separate work. Residual filters, mutations, RecSet construction, cursor setup, and some general scan buffers can also still allocate.

Persisted custom values now have an opt-in codec registry. Existing unregistered custom values retain their historical string fallback.

## Validation

- `go test ./storage -count=1`
- `go test ./... -run "^$"`
- MySQL authentication and direct system-user lookup: 7/7
- ORC trigger dependencies: 17/17
- trigger persistence across restart: 37/37
- computed lookup cache invalidation: 19/19
- full test suite delegated to CI per repository policy

## CI regression investigation

The first performance CI run exposed a real computed-index reuse regression: `Perf JSON: indexed selective row projection` measured 1.211 ms -> 1.804 ms (+49.0%). A pinned local reproduction amplified it to 0.830 ms -> 3.558 ms (+328.8%). CPU profiling showed the query repeatedly entering `bindColdRangeMatcher` and evaluating the JSON expression for all 10,000 rows.

The access-order compatibility check retained the SQL equality collation for a computed column, while computed indexes use canonical binary order. The final commit restores the binary-order normalization and adds a focused reuse test. With the same local fixture and 1,000 repetitions, the corrected result is 0.830 ms -> 0.827 ms (-0.4%). The full JSON performance suite passes 8/8; its changes range from -2.0% to +5.6%. The corrected computed-index commit passed the full test, JIT, and packaging jobs; its performance run then exposed the separate one-shot UNIQUE INSERT case below.

### UNIQUE INSERT follow-up

The next performance run measured the one-shot `UNIQUE INSERT fresh` case at 567.803 ms -> 782.789 ms (+37.9%). The suite stops after that failure, so its remaining two cases were reported as missing rather than executed. This was investigated as a real regression.

CPU profiling and the delta-index layout showed that the copy-free search reference had enlarged every stored B-tree item and that single-column exact probes still resolved the generic boundary view during comparisons. The follow-up restores the previous stored-item size, caches the exact column path, and lets the dominant one-column B-tree reference borrow the adjacent `[values...]` slot directly. It does not reintroduce a boundary copy or another pool.

Three fresh, alternating end-to-end A/B pairs with the exact 30,000-row fixture measured:

| Case | Median change | Individual changes |
| --- | ---: | --- |
| UNIQUE INSERT, fresh | +4.9% | +1.9%, +4.9%, +7.6% |
| UNIQUE INSERT, after rebuild | +2.7% | -1.2%, +2.7%, +3.7% |
| INSERT IGNORE duplicates | +0.2% | +0.2%, +10.6%, -11.8% |

The direct unique hit and miss kernels remain at 0 B/op and 0 allocs/op. The final CI performance matrix passes. Its exact affected results are: computed indexed JSON projection 1.099 ms -> 1.104 ms (+0.5%), UNIQUE INSERT fresh 430.122 ms -> 456.267 ms (+6.1%), UNIQUE INSERT after rebuild 524.053 ms -> 496.159 ms (-5.3%), and INSERT IGNORE duplicates 161.189 ms -> 164.703 ms (+2.2%).

## Join-intensive subscan E2E

The existing `tests/performance/forum-hierarchy-aggregate-joins.yaml` suite was measured separately on the final commit. It uses 10,000 fixture rows and combines a hierarchy self-join, correlated child/thread aggregate subqueries, a correlated scalar MAX lookup, and two downstream LEFT JOINs. Both sides used the same setup, one warmup, and five timing samples.

| Case | master | branch | Change |
| --- | ---: | ---: | ---: |
| Hierarchy with child-count group | 4.191 ms | 4.221 ms | +0.7% |
| Hierarchy with thread group | 5.853 ms | 5.182 ms | -11.5% |
| Full correlated hierarchy query | 5.976 ms | 4.677 ms | -21.7% |

All result and physical-plan assertions in the suite passed.