### PR TITLE
Cost selective count carriers before ACL probes

### DIFF
--- a/lib/queryplan-optimize.scm
+++ b/lib/queryplan-optimize.scm
@@ -3045,21 +3045,68 @@ their tighter direct bound; this product is only an additional candidate. */
 				nil))
 			(if (nil? estimate) nil (min row_count estimate))))))
 
-(define aggregate_pushdown_cost_preferred? (lambda (driver_rows group_rows)
-	(and (number? driver_rows)
-		(and (>= driver_rows 1024)
-			(and (number? group_rows)
-				(< (* group_rows 4) driver_rows))))))
+(define aggregate_pushdown_direct_cost (lambda (driver_rows stage_count)
+	(planner_direct_presence_probe_cost (* driver_rows stage_count))))
 
-(define planner_aggregate_pushdown_driver_rows (lambda (src residual)
+(define aggregate_pushdown_partition_cost (lambda (driver_rows group_rows stage_count)
+	(planner_cost_add
+		(planner_cost
+			(+ planner_membership_group_cache_startup_ns
+				planner_membership_scan_invocation_ns)
+			(* driver_rows planner_membership_scan_row_ns)
+			0 0 0
+			(* driver_rows planner_group_relation_build_row_ns)
+			(* group_rows 16) 0 group_rows 0.7)
+		(planner_direct_presence_probe_cost (* group_rows stage_count))
+		group_rows 0.7)))
+
+/* Aggregate partitioning and direct row evaluation execute the same residual
+base-table predicate, so that scan work cancels. Partitioning additionally
+builds a grouped relation but evaluates each filtered stage only once per
+distinct key. Keep this as an ordinary Costgen-owned crossover: equality of
+driver and group cardinality makes direct evaluation dominate, while a broad
+fact table with a small FK domain still selects the reusable partition. */
+(define aggregate_pushdown_cost_preferred? (lambda (driver_rows group_rows stage_count)
+	(and (number? driver_rows)
+		(and (number? group_rows)
+			(planner_cost_better?
+				(aggregate_pushdown_partition_cost driver_rows group_rows stage_count)
+				(aggregate_pushdown_direct_cost driver_rows stage_count))))))
+
+(define planner_aggregate_pushdown_driver_rows (lambda (src residual tx planning_session)
 	(begin
 		(define total_rows (planner_source_row_count src))
 		(if (not (number? total_rows))
 			nil
 			(if (literal_true? residual)
 				total_rows
-				(planner_row_count_after_selectivity src (list src)
-					(source_alias src) residual total_rows))))))
+				(planner_estimated_matching_rows
+					(planner_source_filter_estimate src residual 512 tx planning_session)
+					total_rows
+					(planner_row_count_after_selectivity src (list src)
+						(source_alias src) residual total_rows)))))))
+
+/* Aggregate pushdown runs before physical lowering, but its cached decision
+must observe the same source-local statistic that a later access-path choice
+would consume. The emitted expression belongs to the query-plan guard, not to
+logical IR: it samples once per request and is shared by every guard binding. */
+(define aggregate_pushdown_runtime_driver_rows_expr (lambda (src residual)
+	(begin
+		(define total_rows_expr (list (quote planner_source_row_count)
+			(planner_quoted_value src)))
+		(if (literal_true? residual)
+			total_rows_expr
+			(begin
+				(define estimate_expr (query_scoped_source_filter_estimate_expr
+					src residual 512))
+				(define pattern_expr (expr_text_pattern_expr residual))
+				(define enriched_estimate (if (nil? pattern_expr)
+					estimate_expr
+					(list (quote qassoc_set) estimate_expr
+						(list (quote quote) (quote fallback_selectivity))
+						(list (quote text_pattern_selectivity_prior) pattern_expr))))
+				(list (quote planner_estimated_matching_rows)
+					enriched_estimate total_rows_expr total_rows_expr))))))
 
 (define direct_base_group_plan_eligible? (lambda (stage)
 	(and (source_is_base_table? (gs_input stage))
@@ -6361,7 +6408,7 @@ remain ordinary residual predicates. */
 			ir
 			(make_ir (ir_kind ir) outer_block all_stages (ir_context_of ir) (ir_return ir))))))
 
-(define aggregate_pushdown_logical (lambda (ir)
+(define aggregate_pushdown_logical (lambda (ir planning_session tx)
 	(begin
 		(define block (ir_root ir))
 		(if (or (not (equal? (ir_return ir) (quote rows)))
@@ -6385,22 +6432,27 @@ remain ordinary residual predicates. */
 					ir
 					(begin
 						(define residual (combine_where_terms residual_terms true))
-						(define driver_rows (planner_aggregate_pushdown_driver_rows driver residual))
+						(define stage_count (max 1 (count
+							(aggregate_pushdown_filtered_stage_sources block movable_terms))))
+						(define driver_rows (planner_aggregate_pushdown_driver_rows
+							driver residual tx planning_session))
 						(define keys (aggregate_pushdown_keys driver columns))
 						(define group_rows (planner_aggregate_pushdown_group_estimate driver keys driver_rows))
-						(define chosen (aggregate_pushdown_cost_preferred? driver_rows group_rows))
+						(define chosen (aggregate_pushdown_cost_preferred?
+							driver_rows group_rows stage_count))
 						(define driver_rows_expr (planner_guard_runtime_binding
-							(list (quote planner_aggregate_pushdown_driver_rows)
-								(planner_quoted_value driver)
-								(planner_quoted_value residual))))
+							(aggregate_pushdown_runtime_driver_rows_expr driver residual)
+							planning_session))
 						(define group_rows_expr (planner_guard_runtime_binding
 							(list (quote planner_aggregate_pushdown_group_estimate)
 								(planner_quoted_value driver)
 								(planner_quoted_value keys)
-								driver_rows_expr)))
+								driver_rows_expr)
+							planning_session))
 						(if (planner_guarded_choice chosen
 							(list (quote aggregate_pushdown_cost_preferred?)
-								driver_rows_expr group_rows_expr))
+								driver_rows_expr group_rows_expr stage_count)
+							planning_session)
 							(aggregate_pushdown_build_rewrite ir block driver movable_terms residual_terms
 								probe_bindings columns driver_rows group_rows)
 							ir))))))))

--- a/lib/queryplan-physical-plan.scm
+++ b/lib/queryplan-physical-plan.scm
@@ -2305,6 +2305,32 @@ logical window-stage remains unchanged and contains no createcolumn artifact. */
 			(and (empty_list? (coalesceNil (qb_order block) '()))
 				(aggregate_pushdown_count_fields? (qb_fields block)))))))
 
+/* A selected predicate-RecSet is already the exact input relation consumed by
+the count scan. Building a one-row query group on top cannot reduce any work;
+it only materializes the same rows again. This capability check deliberately
+uses the common access-path enumerator and cost comparator, so new descriptor
+kinds inherit the global aggregate consumer without expression-specific code. */
+(define global_row_count_access_path_selected? (lambda (block)
+	(begin
+		(define sources (qb_sources block))
+		(define plan (if (empty_list? sources) nil
+			(query_block_join_plan block sources)))
+		(define driver (if (nil? plan) nil
+			(join_optimizer_source_by_alias sources
+				(join_optimizer_tree_first_alias plan))))
+		(if (or (nil? driver)
+			(or (not (source_is_base_table? driver))
+				(source_unique_point_condition? driver (qb_where block))))
+			false
+			(begin
+				(define default_alias (qassoc_get (qb_facts block) (quote default_alias)
+					(source_alias driver)))
+				(define candidates (scan_access_path_candidates
+					driver sources default_alias (qb_where block) nil
+					(planner_context_session (qb_facts block))
+					(planner_context_tx (qb_facts block))))
+				(not (nil? (scan_access_path_preferred_candidate driver candidates))))))))
+
 (define lower_grouped_query_block_with_stages (lambda (block)
 	(begin
 		(define fused_top_count (lower_row_number_top_count_block block))
@@ -2327,7 +2353,8 @@ logical window-stage remains unchanged and contains no createcolumn artifact. */
 				predicate-specific one-row group table. Selectivity-dependent choices
 				remain inside the ordinary membership and join cost models. */
 				(define direct_row_count (and (not (nil? direct_stage))
-					(expr_contains_driver_membership? (qb_where direct_core))))
+					(or (expr_contains_driver_membership? (qb_where direct_core))
+						(global_row_count_access_path_selected? direct_core))))
 				(if direct_row_count
 					(begin
 						(define direct_prelude (nth direct_prepared 0))
@@ -5924,7 +5951,9 @@ every other carrier instead. Logical join order remains owned by join_plan. */
 		(define alias (source_alias src))
 		(define aliases (source_aliases all_sources))
 		(define input_rows (planner_source_row_count src))
-		(if (or (not (number? input_rows)) (< input_rows 1024))
+		(define downstream_probe_branches (count (expr_probe_stages condition)))
+		(if (or (not (number? input_rows))
+			(< input_rows 1024))
 			'()
 			(filter
 				(map (split_and_terms (coalesceNil condition true)) (lambda (term)
@@ -5944,6 +5973,8 @@ every other carrier instead. Logical join order remains owned by join_plan. */
 									(list (quote rows) rows)
 									(list (quote input_rows) input_rows)
 									(list (quote ordered_window_rows) ordered_window_rows)
+									(list (quote downstream_probe_branches)
+										downstream_probe_branches)
 									(list (quote work) work)
 									(list (quote estimate) estimate))
 								nil)))))
@@ -5982,7 +6013,11 @@ this lowering boundary. */
 	(begin
 		(define input_rows (qassoc_get candidate (quote input_rows) 0))
 		(planner_cost_add
-			(scan_access_path_scan_cost src candidate)
+			(planner_cost_add
+				(scan_access_path_scan_cost src candidate)
+				(planner_membership_downstream_probe_cost (* input_rows
+					(qassoc_get candidate (quote downstream_probe_branches) 0)))
+				input_rows 0.65)
 			(planner_join_work_cost input_rows 0.65)
 			(qassoc_get candidate (quote rows) input_rows) 0.65))))
 
@@ -6015,22 +6050,44 @@ this lowering boundary. */
 		(define consumer (scan_access_path_adaptive_consumer candidate))
 		(planner_cost_add
 			(planner_cost_add
-				(scan_access_path_scan_cost src candidate)
-				(planner_cost planner_membership_recset_startup_ns
-					(+ (* (nth consumer 0) planner_membership_scan_row_ns)
-						(* (nth consumer 1)
-							planner_membership_ordered_recset_sort_unit_ns))
-					(* (nth consumer 2) planner_membership_recset_probe_row_ns) 0 0
-					(* rows planner_membership_recset_build_row_ns)
-					(* rows 8) 0 rows 0.65)
+				(planner_cost_add
+					(scan_access_path_scan_cost src candidate)
+					(planner_cost planner_membership_recset_startup_ns
+						(+ (* (nth consumer 0) planner_membership_scan_row_ns)
+							(* (nth consumer 1)
+								planner_membership_ordered_recset_sort_unit_ns))
+						(* (nth consumer 2) planner_membership_recset_probe_row_ns) 0 0
+						(* rows planner_membership_recset_build_row_ns)
+						(* rows 8) 0 rows 0.65)
+					rows 0.65)
+				(planner_join_work_cost rows 0.65)
 				rows 0.65)
-			(planner_join_work_cost rows 0.65)
+			(planner_membership_downstream_probe_cost (* rows
+				(qassoc_get candidate (quote downstream_probe_branches) 0)))
 			rows 0.65))))
 
 (define scan_access_path_candidate_cost (lambda (src candidate)
 	(match (qassoc_get candidate (quote kind) nil)
 		(quote predicate_recset) (scan_access_path_recset_cost src candidate)
 		_ (neumann_fail "build_queryplan" "unsupported physical scan access-path descriptor"))))
+
+(define best_scan_access_path_candidate (lambda (src candidates)
+	(reduce candidates (lambda (best item)
+		(if (or (nil? best)
+			(planner_cost_better?
+				(scan_access_path_candidate_cost src item)
+				(scan_access_path_candidate_cost src best)))
+			item best)) nil)))
+
+(define scan_access_path_preferred_candidate (lambda (src candidates)
+	(if (empty_list? candidates)
+		nil
+		(begin
+			(define candidate (best_scan_access_path_candidate src candidates))
+			(if (planner_cost_better?
+				(scan_access_path_candidate_cost src candidate)
+				(scan_access_path_base_cost src candidate))
+				candidate nil)))))
 
 (define scan_access_path_crossover_search (lambda (src candidate base_cost low high remaining)
 	(if (or (<= remaining 0) (>= low high))
@@ -6073,12 +6130,7 @@ topology inequality by bounded binary search and guard that crossover. */
 	(if (empty_list? candidates)
 		(list "fused_base_scan" nil)
 		(begin
-			(define candidate (reduce candidates (lambda (best item)
-				(if (or (nil? best)
-					(planner_cost_better?
-						(scan_access_path_candidate_cost src item)
-						(scan_access_path_candidate_cost src best)))
-					item best)) nil))
+			(define candidate (best_scan_access_path_candidate src candidates))
 			(define alias (source_alias src))
 			(define decision_id (concat "scan_access_path:" alias))
 			(define candidate_plan (qassoc_get candidate (quote plan) nil))
@@ -6122,6 +6174,8 @@ topology inequality by bounded binary search and guard that crossover. */
 					(list "candidate_broad_text_match_bytes" (qassoc_get work (quote broad_text_match_bytes) 0))
 					(list "candidate_filter_value_rows" (qassoc_get work (quote filter_value_rows) 0))
 					(list "candidate_expression_operation_rows" (qassoc_get work (quote expression_operation_rows) 0))
+					(list "downstream_probe_branches"
+						(qassoc_get candidate (quote downstream_probe_branches) 0))
 					(list "driver_rows" (qassoc_get candidate (quote rows) nil))
 					(list "driver_input_rows" (qassoc_get candidate (quote input_rows) nil))
 					(list "density" (/ (qassoc_get candidate (quote rows) 0)
@@ -6940,7 +6994,6 @@ carrier remains on the measured direct path and is never built eagerly. */
 				(define access_path_build_allowed (and
 					(not membership_driver)
 					(nil? row_number_stage_filter)
-					(> (count all_sources) 1)
 					(equal? alias (probe_work_context_driver_alias probe_context))))
 				(define access_path_order_window (if (and
 					(not (empty_list? current_order_items))
@@ -9288,8 +9341,38 @@ ordering run. Storage artifacts begin in build_queryplan. */
 (define decorrelate_logical_query (lambda (ast)
 	(untangle_query_term (normalize_sql_syntax ast) nil)))
 
+/* Aggregate partitioning is an equivalent logical alternative whose only
+benefit is reducing repeated stage evaluation. If the common physical
+access-path selector already chooses an exact predicate carrier, later
+lowering can evaluate the stages against that carrier and fuse the global
+count. Partitioning cannot reduce that work and would add a grouped relation.
+
+Run the same selector here rather than recognizing LIKE (or any future hook)
+again. It records its normal crossover guard even when aggregate partitioning
+wins today, so improved runtime statistics can invalidate that cached choice.
+The result is only a choice between equivalent logical trees; no scan or
+RecSet node is written into logical IR. */
+(define aggregate_pushdown_exact_access_dominates? (lambda (ir planning_session tx)
+	(begin
+		(define block (ir_root ir))
+		(if (or (not (query_block? block))
+			(not (aggregate_pushdown_root_shape? block)))
+			false
+			(begin
+				(define driver (car (aggregate_pushdown_base_sources block)))
+				(define candidates (scan_access_path_candidates
+					driver (qb_sources block)
+					(qassoc_get (qb_facts block) (quote default_alias) (source_alias driver))
+					(qb_where block) nil planning_session tx))
+				(not (nil? (cadr
+					(choose_scan_access_path driver candidates planning_session)))))))))
+
 (define optimize_logical_query (lambda (ir planning_session tx)
-	(join_reorder (aggregate_pushdown_logical ir) planning_session tx)))
+	(join_reorder
+		(if (aggregate_pushdown_exact_access_dominates? ir planning_session tx)
+			ir
+			(aggregate_pushdown_logical ir planning_session tx))
+		planning_session tx)))
 
 (define neumann_compile_pipeline (lambda (ast planning_session tx)
 	(begin

--- a/tests/performance/like-acl-query-shapes.yaml
+++ b/tests/performance/like-acl-query-shapes.yaml
@@ -444,3 +444,82 @@ test_cases:
       rows: 1
       data:
         - {total: 700, counted_count: 700}
+
+  - name: "Perf: selective direct LIKE count with compound ACL"
+    setup: *like_acl_fixture
+    performance_rows: 40000
+    threshold_ms: 3000
+    timeout: 30
+    sql: |
+      SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
+      FROM (
+        SELECT d.id, 1 AS _count
+        FROM pla_document d
+        WHERE d.inventory_no LIKE '%inv-special%'
+          AND COALESCE((
+            SELECT CASE WHEN site.direct_flag = 1 THEN TRUE ELSE (
+              EXISTS (
+                SELECT TRUE
+                FROM pla_assignment assignment
+                WHERE assignment.site_id = site.id
+                  AND assignment.actor_id = 7
+                  AND assignment.allowed = 1
+                LIMIT 1
+              ) OR COALESCE((
+                SELECT override.allowed
+                FROM pla_override override
+                WHERE override.site_id = site.id
+                  AND override.actor_id = 7
+                LIMIT 1
+              ), FALSE)
+            ) END
+            FROM pla_site site
+            WHERE site.id = d.site_id
+            LIMIT 1
+          ), FALSE)
+          AND TRUE
+      ) counted
+    expect:
+      rows: 1
+
+  - name: "Plan: selective direct LIKE count uses exact query-local carrier"
+    setup: *like_acl_fixture
+    performance_rows: 40000
+    threshold_ms: 3000
+    timeout: 30
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
+      FROM (
+        SELECT d.id, 1 AS _count
+        FROM pla_document d
+        WHERE d.inventory_no LIKE '%inv-special%'
+          AND COALESCE((
+            SELECT CASE WHEN site.direct_flag = 1 THEN TRUE ELSE (
+              EXISTS (
+                SELECT TRUE
+                FROM pla_assignment assignment
+                WHERE assignment.site_id = site.id
+                  AND assignment.actor_id = 7
+                  AND assignment.allowed = 1
+                LIMIT 1
+              ) OR COALESCE((
+                SELECT override.allowed
+                FROM pla_override override
+                WHERE override.site_id = site.id
+                  AND override.actor_id = 7
+                LIMIT 1
+              ), FALSE)
+            ) END
+            FROM pla_site site
+            WHERE site.id = d.site_id
+            LIMIT 1
+          ), FALSE)
+          AND TRUE
+      ) counted
+    expect:
+      rows: 1
+      result_contains:
+        - "decision global_membership_row_count"
+        - "decision scan_access_path"
+        - "chosen scan_recset"

--- a/tests/planner/aggregates/traced-group-caches.yaml
+++ b/tests/planner/aggregates/traced-group-caches.yaml
@@ -170,8 +170,8 @@ test_cases:
         (and
           (equal? (planner_foreign_key_group_bound driver '("reference_id")) 3)
           (equal? (planner_aggregate_pushdown_group_estimate driver keys 2000) 3)
-          (aggregate_pushdown_cost_preferred? 2000 3)
-          (not (aggregate_pushdown_cost_preferred? 2000 1000))))
+          (aggregate_pushdown_cost_preferred? 2000 3 1)
+          (not (aggregate_pushdown_cost_preferred? 2000 1000 1))))
     expect:
       data: [true]
 
@@ -250,7 +250,7 @@ test_cases:
         (and
           (equal? (planner_foreign_key_product_bound driver columns 2400) 12)
           (equal? (planner_aggregate_pushdown_group_estimate driver keys 2400) 12)
-          (aggregate_pushdown_cost_preferred? 2400 12)))
+          (aggregate_pushdown_cost_preferred? 2400 12 2)))
     expect:
       data: [true]
 

--- a/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
+++ b/tests/planner/subqueries/acl-boolean-membership-scaling.yaml
@@ -27,7 +27,8 @@ setup:
         id INT PRIMARY KEY,
         standort_id INT,
         file_id INT,
-        mandant_id INT
+        mandant_id INT,
+        inventory_no TEXT
       )
   - sql: |
       CREATE TABLE bqm_file (
@@ -76,10 +77,14 @@ setup:
               (if (< i 512)
                 (if (equal? (mod (+ i 1) 3) 0) "needle-C-search" "needle-other")
                 (if (equal? (mod (+ i 1) 3) 0) "C-search" "other"))))))
-        (insert (table "memcp-tests" "bqm_document") (list "id" "standort_id" "file_id" "mandant_id")
+        (insert (table "memcp-tests" "bqm_document")
+          (list "id" "standort_id" "file_id" "mandant_id" "inventory_no")
           (map (produceN 40000) (lambda (i)
             (list (+ i 1) (+ (mod i 4) 1) (+ (mod i 20000) 1)
-              (if (< i 40) 9 1)))))
+              (if (< i 40) 9 1)
+              (if (equal? (mod i 100) 0)
+                (concat "inv-special-" (string i))
+                (concat "inventory-" (string i)))))))
         (rebuild (table "memcp-tests" "bqm_document") true false)
         (rebuild (table "memcp-tests" "bqm_file") true false)
         (rebuild (table "memcp-tests" "bqm_standort") true false)
@@ -90,6 +95,89 @@ setup:
         40000)
 
 test_cases:
+  - name: "Plain selective LIKE count stays on the fused scan"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT COUNT(*) AS total
+      FROM bqm_document d
+      WHERE d.inventory_no LIKE '%inv-special%'
+    expect:
+      result_contains:
+        - "scan_count"
+      result_not_contains:
+        - "decision scan_access_path"
+        - "scan_recset"
+
+  - name: "Direct selective LIKE counts both row-count forms correctly"
+    sql: |
+      SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
+      FROM (
+        SELECT d.id, 1 AS _count
+        FROM bqm_document d
+        WHERE d.inventory_no LIKE '%inv-special%'
+          AND COALESCE((
+            SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+              EXISTS (
+                SELECT TRUE FROM bqm_mandant_assignment ma
+                WHERE ma.standort_id = s.id
+                  AND ma.actor_id = @bqm_actor
+                  AND ma.allowed = TRUE
+                LIMIT 1
+              ) OR COALESCE((
+                SELECT sa.allowed FROM bqm_standort_assignment sa
+                WHERE sa.standort_id = s.id
+                  AND sa.actor_id = @bqm_actor
+                LIMIT 1
+              ), FALSE)
+            ) END
+            FROM bqm_standort s
+            WHERE s.id = d.standort_id
+            LIMIT 1
+          ), FALSE)
+          AND TRUE
+      ) counted
+    expect:
+      rows: 1
+      data:
+        - {total: 400, counted_count: 400}
+
+  - name: "Direct selective LIKE count fuses its exact access carrier"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT COUNT(*) AS total, COUNT(counted._count) AS counted_count
+      FROM (
+        SELECT d.id, 1 AS _count
+        FROM bqm_document d
+        WHERE d.inventory_no LIKE '%inv-special%'
+          AND COALESCE((
+            SELECT CASE WHEN s.direct_flag = 1 THEN TRUE ELSE (
+              EXISTS (
+                SELECT TRUE FROM bqm_mandant_assignment ma
+                WHERE ma.standort_id = s.id
+                  AND ma.actor_id = @bqm_actor
+                  AND ma.allowed = TRUE
+                LIMIT 1
+              ) OR COALESCE((
+                SELECT sa.allowed FROM bqm_standort_assignment sa
+                WHERE sa.standort_id = s.id
+                  AND sa.actor_id = @bqm_actor
+                LIMIT 1
+              ), FALSE)
+            ) END
+            FROM bqm_standort s
+            WHERE s.id = d.standort_id
+            LIMIT 1
+          ), FALSE)
+          AND TRUE
+      ) counted
+    expect:
+      result_contains:
+        - "decision global_membership_row_count"
+        - "decision scan_access_path"
+        - "chosen scan_recset"
+      result_not_contains:
+        - "aggregate_partition"
+
   - name: "Selective search RecSet retains the base order"
     sql: |
       EXPLAIN PHYSICAL SELECT d.id


### PR DESCRIPTION
## What

Make the physical access-path cost model account for correlated probe work that remains after a selective predicate, and let exact query-local carriers feed a fused global row-count consumer.

This keeps the logical/physical boundary intact:

- logical IR remains query blocks, group stages, and union blocks;
- the common physical access-path enumerator compares fused scans and exact predicate carriers;
- aggregate pushdown uses Costgen coefficients instead of a fixed cardinality ratio;
- selectivity-dependent choices emit runtime crossover guards;
- a plain unordered LIKE count remains a single fused scan, because no downstream work is avoided.

## Why

For a selective text predicate followed by a compound correlated ACL, aggregate pushdown hid the cheaper plan. It built a reusable partition before the physical lowerer could see that an exact predicate carrier reduces expensive ACL probes from the full driving relation to the small matching subset.

The new model charges downstream probes on all rows for the fused base path and only on estimated matching rows for the exact-carrier path. The existing physical selector then makes the choice; there is no query-specific lowering rule.

## Manual A/B measurements

Same production-copy fixture (~855k driving rows), exact COUNT query, same warmup:

- baseline warm: **339-372 ms**
- PR cold: **367 ms**
- PR warm: **47-51 ms**
- warm improvement: approximately **7x**
- result: **121 / 121**, unchanged

A hand-written membership plan measured **59.6-64 ms**, so the generated plan reaches and slightly beats the measured manual optimum.

Operator isolation showed that direct LIKE scan/count and RecSet construction/count both cost about **1.05-1.40 ms** for this predicate. The gain therefore does not come from blindly materializing a RecSet; it comes from avoiding correlated ACL work on non-matching rows.

A broad low-cardinality-FK aggregate case remains on aggregate pushdown:

- cold: **116.3 ms**
- warm: **2.9 ms**

Synthetic regression fixture:

- selective compound-ACL COUNT: **125.3 ms at 360,000 rows**
- physical-plan assertion: **1.5 ms**
- the structural assertion fails on master and passes on this branch.

## Validation

- Scheme startup tests: **1276/1276**
- traced group-cache tests: **28/28**
- correlated boolean membership tests: **33/33**
- focused new performance/plan tests: **2/2**
- Scheme lint and diff checks pass
- JIT-enabled Go build passes

The full suite is intentionally delegated to CI.