### PR TITLE
parser: choice leading-byte dispatch + packrat memo fence for repeats

### DIFF
--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -66,7 +66,8 @@ type jitParserNode struct {
 	regex        *jitRegexProgram
 	skipWS       bool
 	ignoreResult bool
-	noMemo       bool
+	noMemo       bool // repeat body references skip the memo entry check
+	fenceMemo    bool // markFenceableRepeats: also fence+compact the memo table
 	description  string
 }
 
@@ -721,6 +722,7 @@ type jitParserState struct {
 	memoOffsets []uint32
 	memoRules   []uint32
 	memoEntries []jitParserMemoEntry
+	memoFences  []jitParserMemoFence
 	heads       []*jitParserLeftRecursionHead
 	farthest    int
 	expected    []string
@@ -745,6 +747,7 @@ func (program *jitParserProgram) acquireState(inputLength int) *jitParserState {
 	state.mutations = state.mutations[:0]
 	state.checkpoints = state.checkpoints[:0]
 	state.marks = state.marks[:0]
+	state.memoFences = state.memoFences[:0]
 	state.positions = state.positions[:0]
 	memoCapacity := jitParserMemoEntryCapacity(inputLength)
 	if cap(state.memoEntries) < memoCapacity {
@@ -850,6 +853,11 @@ func (state *jitParserState) memoSet(key jitParserMemoKey, entry jitParserMemoEn
 	if entryIndex := state.memoRules[index]; entryIndex != 0 {
 		state.memoEntries[entryIndex-1] = entry
 		return
+	}
+	if n := len(state.memoFences); n > 0 {
+		if fence := &state.memoFences[n-1]; index < fence.rules {
+			fence.dirtySlots = append(fence.dirtySlots, index)
+		}
 	}
 	state.memoEntries = append(state.memoEntries, entry)
 	state.memoRules[index] = uint32(len(state.memoEntries))
@@ -1217,6 +1225,83 @@ func jitParserCommitProgress(stateValue, positionValue Scmer) Scmer {
 	}
 	jitParserCommitCheckpoint(stateValue)
 	return NewBool(true)
+}
+
+// jitParserMemoFence bounds the memo table around one iteration of a `*` node
+// that markFenceableRepeats proved is never rolled back. Once an iteration
+// commits its progress no (rule, position) it memoized strictly ahead of the
+// fence can be consulted again, so jitParserMemoCompactNative rewinds
+// memoEntries/memoRules to the fence and clears memoOffsets/heads for the
+// consumed span. dirtySlots holds memoRules indices in blocks that predate the
+// fence which this iteration nonetheless wrote (the parse backtracked across
+// the loop start, e.g. inside a nested rule); the rewind strips the entry index
+// they point at, so they are zeroed first.
+type jitParserMemoFence struct {
+	entries    int
+	rules      int
+	pos        int
+	dirtySlots []int
+}
+
+func jitParserMemoFencePushNative(state *jitParserState, position int64) {
+	state.memoFences = append(state.memoFences, jitParserMemoFence{
+		entries: len(state.memoEntries), rules: len(state.memoRules), pos: int(position),
+	})
+}
+
+func jitParserMemoFencePopNative(state *jitParserState) {
+	n := len(state.memoFences)
+	if n == 0 {
+		panic("jit: parser memo fence underflow")
+	}
+	popped := state.memoFences[n-1]
+	state.memoFences = state.memoFences[:n-1]
+	if n >= 2 && len(popped.dirtySlots) > 0 {
+		parent := &state.memoFences[n-2]
+		for _, s := range popped.dirtySlots {
+			if s < parent.rules {
+				parent.dirtySlots = append(parent.dirtySlots, s)
+			}
+		}
+	}
+}
+
+// jitParserMemoCompactNative discards the memo a committed fenceable iteration
+// produced.
+func jitParserMemoCompactNative(state *jitParserState, position int64) {
+	n := len(state.memoFences)
+	if n == 0 {
+		return
+	}
+	fence := &state.memoFences[n-1]
+	for _, s := range fence.dirtySlots {
+		if s < len(state.memoRules) {
+			state.memoRules[s] = 0
+		}
+	}
+	fence.dirtySlots = fence.dirtySlots[:0]
+	end := int(position)
+	if end > len(state.memoOffsets) {
+		end = len(state.memoOffsets)
+	}
+	if fence.pos < end {
+		clear(state.memoOffsets[fence.pos:end])
+		hi := end
+		if hi > len(state.heads) {
+			hi = len(state.heads)
+		}
+		if fence.pos < hi {
+			clear(state.heads[fence.pos:hi])
+		}
+	}
+	if fence.entries < len(state.memoEntries) {
+		clear(state.memoEntries[fence.entries:])
+		state.memoEntries = state.memoEntries[:fence.entries]
+	}
+	if fence.rules < len(state.memoRules) {
+		state.memoRules = state.memoRules[:fence.rules]
+	}
+	fence.pos = end
 }
 
 func jitParserPushPosition(stateValue, positionValue Scmer) Scmer {

--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -85,12 +85,14 @@ type jitParserRule struct {
 }
 
 type jitParserProgram struct {
-	rules         []jitParserRule
-	parserRule    map[*ScmParser]int
-	memoRuleIndex []int32
-	memoRuleCount int
-	inlineActions bool
-	pool          sync.Pool
+	rules          []jitParserRule
+	parserRule     map[*ScmParser]int
+	memoRuleIndex  []int32
+	memoRuleCount  int
+	ruleFirstBytes []firstByteSet
+	ruleNullable   []bool
+	inlineActions  bool
+	pool           sync.Pool
 }
 
 type jitParserBuilder struct {
@@ -153,6 +155,7 @@ func jitBuildParserPrograms(parsers []*ScmParser) *jitParserProgram {
 		builder.addScmParser(parser)
 	}
 	program.prepareMemoLayout()
+	program.computeFirstBytes()
 	program.pool.New = func() any { return new(jitParserState) }
 	return program
 }
@@ -165,6 +168,7 @@ func jitBuildParserTemplateProgram(template *JITParserTemplate) (*jitParserProgr
 	}
 	rule := builder.addTemplate(template, -1)
 	program.prepareMemoLayout()
+	program.computeFirstBytes()
 	program.pool.New = func() any { return new(jitParserState) }
 	return program, rule
 }

--- a/scm/jit_parser_analysis.go
+++ b/scm/jit_parser_analysis.go
@@ -137,11 +137,144 @@ func (program *jitParserProgram) analyzeMemoNeed() []bool {
 	}
 	a.flagChoicesAndRepeats()
 	a.propagateToReferrers()
+	a.markFenceableRepeats()
 
 	if os.Getenv("MEMCP_DUMP_MEMO_ANALYSIS") != "" {
 		a.dump()
 	}
 	return a.needMemo
+}
+
+// markFenceableRepeats sets fenceMemo on a `*` node whose committed iterations
+// can never be rolled back: nothing that can fail follows the repeat before an
+// ordered-choice commit, walking the containing rule and every rule that
+// references it. PEG ordered choice is possessive - once the alternative the
+// repeat lives in succeeds it is final - and a repeat only ever advances. The
+// emitter then discards the memo an iteration produced the moment it commits;
+// without it the memo for `... VALUES (row), (row), ...` grows to millions of
+// live entries the GC rescans every cycle.
+func (a *memoNeedAnalysis) markFenceableRepeats() {
+	referrers := make([][]int, a.n)
+	for r := 0; r < a.n; r++ {
+		if a.program.rules[r].root == nil {
+			continue
+		}
+		refs := newParserRuleSet(a.n)
+		a.collectDirectRefs(a.program.rules[r].root, refs)
+		for q := 0; q < a.n; q++ {
+			if refs.has(q) {
+				referrers[q] = append(referrers[q], r)
+			}
+		}
+	}
+	for r := 0; r < a.n; r++ {
+		if a.program.rules[r].root != nil {
+			a.walkFence(a.program.rules[r].root, nil, r, referrers)
+		}
+	}
+}
+
+func (a *memoNeedAnalysis) walkFence(node *jitParserNode, path []*jitParserNode, rule int, referrers [][]int) {
+	if node.kind == jitParserZeroOrMore {
+		if a.noRollbackAfter(node, path, rule, referrers, map[int]bool{}) {
+			node.noMemo = true
+			node.fenceMemo = true
+		}
+	}
+	childPath := append(append([]*jitParserNode(nil), path...), node)
+	for _, c := range node.children {
+		a.walkFence(c, childPath, rule, referrers)
+	}
+}
+
+// noRollbackAfter reports whether, once `node` starts succeeding, no later
+// failure can force it to be parsed again. `path` is node's ancestor chain
+// (root first) inside `rule`.
+func (a *memoNeedAnalysis) noRollbackAfter(node *jitParserNode, path []*jitParserNode, rule int, referrers [][]int, seen map[int]bool) bool {
+	child := node
+	for i := len(path) - 1; i >= 0; i-- {
+		anc := path[i]
+		switch anc.kind {
+		case jitParserChoice:
+			return true // an ordered-choice alternative is final once it succeeds
+		case jitParserSequence:
+			idx := 0
+			for j, c := range anc.children {
+				if c == child {
+					idx = j
+					break
+				}
+			}
+			for _, sib := range anc.children[idx+1:] {
+				if a.failable(sib) {
+					return false
+				}
+			}
+		case jitParserZeroOrMore, jitParserOneOrMore, jitParserOptional, jitParserBind, jitParserCapture:
+			// transparent: a repeat/optional/binder above never re-parses a
+			// committed inner iteration - repeats only advance.
+		default:
+			return false
+		}
+		child = anc
+	}
+	if seen[rule] {
+		return false
+	}
+	seen[rule] = true
+	refs := referrers[rule]
+	if len(refs) == 0 {
+		return true // an entry rule is never retried
+	}
+	for _, r := range refs {
+		ok := true
+		a.forEachRef(a.program.rules[r].root, nil, rule, func(refNode *jitParserNode, refPath []*jitParserNode) {
+			if ok && !a.noRollbackAfter(refNode, refPath, r, referrers, seen) {
+				ok = false
+			}
+		})
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *memoNeedAnalysis) forEachRef(node *jitParserNode, path []*jitParserNode, target int, fn func(*jitParserNode, []*jitParserNode)) {
+	if node.kind == jitParserRuleRef && node.rule == target {
+		fn(node, path)
+	}
+	childPath := append(append([]*jitParserNode(nil), path...), node)
+	for _, c := range node.children {
+		a.forEachRef(c, childPath, target, fn)
+	}
+}
+
+// failable reports whether a node can fail to match, as opposed to always
+// succeeding (possibly matching empty).
+func (a *memoNeedAnalysis) failable(node *jitParserNode) bool {
+	switch node.kind {
+	case jitParserZeroOrMore, jitParserOptional, jitParserEmpty:
+		return false
+	case jitParserBind, jitParserCapture:
+		return a.failable(node.children[0])
+	case jitParserSequence:
+		for _, c := range node.children {
+			if a.failable(c) {
+				return true
+			}
+		}
+		return false
+	case jitParserChoice:
+		for _, c := range node.children {
+			if !a.failable(c) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
 }
 
 func (a *memoNeedAnalysis) computeNullable() {
@@ -492,6 +625,30 @@ func (a *memoNeedAnalysis) dump() {
 	os.Stderr.WriteString("[memo-analysis] non-lexical rules: kept(memoized)=" +
 		itoa(kept) + " freed(no memo)=" + itoa(freed) + "\n")
 	os.Stderr.WriteString("[memo-analysis] freed sample: " + strings.Join(freedNames, ", ") + "\n")
+
+	fenced := 0
+	var fencedIn []string
+	for r := 0; r < a.n; r++ {
+		root := a.program.rules[r].root
+		if root == nil {
+			continue
+		}
+		var walk func(*jitParserNode)
+		walk = func(node *jitParserNode) {
+			if node.fenceMemo {
+				fenced++
+				if len(fencedIn) < 20 {
+					fencedIn = append(fencedIn, ruleDisplayName(&a.program.rules[r], r))
+				}
+			}
+			for _, c := range node.children {
+				walk(c)
+			}
+		}
+		walk(root)
+	}
+	os.Stderr.WriteString("[memo-analysis] fenced repeats: " + itoa(fenced) +
+		" in: " + strings.Join(fencedIn, ", ") + "\n")
 }
 
 func ruleDisplayName(rule *jitParserRule, id int) string {

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -864,6 +864,41 @@ func (emitter *jitParserEmitter) emitLexicalRuleRef(node *jitParserNode, success
 	emitter.ctx.EmitJmp(failure)
 }
 
+// emitMemoFencePush / emitMemoCompact / emitMemoFencePop drive the per-iteration
+// memo compaction for a repeat that markFenceableRepeats proved can never roll
+// back a committed iteration (node.fenceMemo). The fence records the memo table
+// high-water mark at loop entry; every committed iteration's packrat entries are
+// dead the moment the iteration commits, so they are truncated back to that mark
+// instead of accumulating for the whole input.
+func (emitter *jitParserEmitter) emitMemoFencePush() {
+	position := emitter.loadPosition()
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoFencePushNative, statePtr, position)
+	emitter.ctx.FreeDesc(&statePtr)
+	emitter.ctx.FreeDesc(&position)
+}
+
+func (emitter *jitParserEmitter) emitMemoCompact() {
+	position := emitter.loadPosition()
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoCompactNative, statePtr, position)
+	emitter.ctx.FreeDesc(&statePtr)
+	emitter.ctx.FreeDesc(&position)
+}
+
+func (emitter *jitParserEmitter) emitMemoFencePop() {
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoFencePopNative, statePtr)
+	emitter.ctx.FreeDesc(&statePtr)
+}
+
+// emitMemoFenceExit compacts the last iteration's growth away and pops the fence
+// on every path that leaves the repeat.
+func (emitter *jitParserEmitter) emitMemoFenceExit() {
+	emitter.emitMemoCompact()
+	emitter.emitMemoFencePop()
+}
+
 func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, success, failure JITLabel) {
 	if node.noMemo {
 		emitter.noMemoDepth++
@@ -872,6 +907,9 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.pushCheckpoint()
 	if !node.ignoreResult {
 		emitter.emitVoid(jitParserPushMarkNative, emitter.state)
+	}
+	if node.fenceMemo {
+		emitter.emitMemoFencePush()
 	}
 	firstAccepted, firstRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.pushCheckpoint()
@@ -890,11 +928,17 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.restoreCheckpoint()
 	if node.kind == jitParserOneOrMore {
 		emitter.restoreCheckpoint()
+		if node.fenceMemo {
+			emitter.emitMemoFenceExit()
+		}
 		emitter.ctx.EmitJmp(failure)
 	} else {
 		emitter.ctx.EmitJmp(done)
 	}
 	emitter.ctx.MarkLabel(loop)
+	if node.fenceMemo {
+		emitter.emitMemoCompact()
+	}
 	emitter.pushCheckpoint()
 	separatorAccepted, iterationAccepted, iterationRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.emitNode(node.children[1], rule, separatorAccepted, iterationRejected)
@@ -912,6 +956,9 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.restoreCheckpoint()
 	emitter.ctx.EmitJmp(done)
 	emitter.ctx.MarkLabel(done)
+	if node.fenceMemo {
+		emitter.emitMemoFenceExit()
+	}
 	if !node.ignoreResult {
 		emitter.emitVoid(jitParserMergeMarkNative, emitter.state, jitParserBoolScalar(false))
 	}

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -380,16 +380,113 @@ func (emitter *jitParserEmitter) emitSequence(node *jitParserNode, rule int, suc
 }
 
 func (emitter *jitParserEmitter) emitChoice(node *jitParserNode, rule int, success, failure JITLabel) {
-	for _, child := range node.children {
+	if d := emitter.program.choiceDispatchPlan(node); d.useful {
+		emitter.emitChoiceDispatch(node, rule, d, success, failure)
+		return
+	}
+	all := make([]int, len(node.children))
+	for i := range all {
+		all[i] = i
+	}
+	emitter.emitAltCascade(node, rule, all, success, failure)
+}
+
+// emitAltCascade tries the listed alternatives of node in order, each guarded by
+// its own checkpoint; on the last failure it jumps to failure. This is the
+// classic choice lowering, and the tail of every dispatch bucket.
+func (emitter *jitParserEmitter) emitAltCascade(node *jitParserNode, rule int, indices []int, success, failure JITLabel) {
+	for _, i := range indices {
 		emitter.pushCheckpoint()
 		accepted, rejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
-		emitter.emitNode(child, rule, accepted, rejected)
+		emitter.emitNode(node.children[i], rule, accepted, rejected)
 		emitter.ctx.MarkLabel(accepted)
 		emitter.commitCheckpoint()
 		emitter.ctx.EmitJmp(success)
 		emitter.ctx.MarkLabel(rejected)
 		emitter.restoreCheckpoint()
 	}
+	emitter.ctx.EmitJmp(failure)
+}
+
+func altListKey(list []int) string {
+	b := make([]byte, 0, len(list)*2)
+	for _, x := range list {
+		b = append(b, byte(x), byte(x>>8))
+	}
+	return string(b)
+}
+
+// jitParserPeekByteNative returns the byte at position, or -1 at end of input.
+func jitParserPeekByteNative(input Scmer, position int64) int64 {
+	text := input.String()
+	if position < 0 || position >= int64(len(text)) {
+		return -1
+	}
+	return int64(text[position])
+}
+
+// emitPeekByte returns a register with the byte at the current parse position
+// (0..255), or -1 at end of input. No position advance. A Go call keeps this
+// off the register-discipline critical path - it runs once per dispatched
+// choice, replacing dozens of per-alternative helper calls.
+func (emitter *jitParserEmitter) emitPeekByte() JITValueDesc {
+	position := emitter.loadPosition()
+	peek := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserPeekByteNative), []JITValueDesc{emitter.input, position}, 1)
+	peek.Type = tagInt
+	emitter.ctx.FreeDesc(&position)
+	return peek
+}
+
+// emitChoiceDispatch reads the leading byte once and jumps to the small cascade
+// of alternatives that could match it, instead of trying all ~N in turn.
+func (emitter *jitParserEmitter) emitChoiceDispatch(node *jitParserNode, rule int, d choiceDispatch, success, failure JITLabel) {
+	skipped := emitter.ctx.ReserveLabel()
+	emitter.emitSkip(rule, skipped)
+	emitter.ctx.MarkLabel(skipped)
+	peek := emitter.emitPeekByte()
+
+	fail := emitter.ctx.ReserveLabel()
+	wild := fail
+	if len(d.wild) > 0 {
+		wild = emitter.ctx.ReserveLabel()
+	}
+
+	labels := make([]JITLabel, 256)
+	type bucket struct {
+		label JITLabel
+		list  []int
+	}
+	var order []bucket
+	made := map[string]JITLabel{}
+	for b := 0; b < 256; b++ {
+		list := d.buckets[b]
+		if len(list) == 0 {
+			labels[b] = wild
+			continue
+		}
+		key := altListKey(list)
+		if l, ok := made[key]; ok {
+			labels[b] = l
+			continue
+		}
+		l := emitter.ctx.ReserveLabel()
+		made[key] = l
+		labels[b] = l
+		order = append(order, bucket{l, list})
+	}
+
+	emitter.ctx.EmitJumpTable(peek.Reg, labels, wild)
+	emitter.ctx.FreeDesc(&peek)
+
+	for _, bk := range order {
+		emitter.ctx.MarkLabel(bk.label)
+		emitter.emitAltCascade(node, rule, bk.list, success, fail)
+	}
+	if len(d.wild) > 0 {
+		emitter.ctx.MarkLabel(wild)
+		emitter.emitAltCascade(node, rule, d.wild, success, fail)
+	}
+	emitter.ctx.MarkLabel(fail)
 	emitter.ctx.EmitJmp(failure)
 }
 

--- a/scm/jit_parser_firstbytes.go
+++ b/scm/jit_parser_firstbytes.go
@@ -1,0 +1,393 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"fmt"
+	"os"
+	"regexp/syntax"
+	"unicode"
+)
+
+// A parser choice is normally emitted as a linear cascade: every alternative
+// pushes a checkpoint, runs its match, and on failure records a diagnostic and
+// restores. Parsing a literal through sql_expression6's ~40 alternatives means
+// ~38 failed keyword matches, each a handful of Go helper calls. When every
+// alternative's first consumed byte is statically known and no alternative can
+// match empty, the emitter can instead read that one byte and jump straight to
+// the (usually one) alternative that could match it. firstByteSet is the
+// per-node/per-rule set that drives that decision.
+type firstByteSet struct {
+	bits [4]uint64
+	any  bool
+}
+
+func (s *firstByteSet) add(b byte) {
+	if !s.any {
+		s.bits[b>>6] |= 1 << (b & 63)
+	}
+}
+
+func (s *firstByteSet) addRange(lo, hi int) {
+	for b := lo; b <= hi && b < 256; b++ {
+		s.add(byte(b))
+	}
+}
+
+func (s *firstByteSet) markAny() {
+	s.any = true
+	s.bits = [4]uint64{}
+}
+
+func (s firstByteSet) has(b byte) bool {
+	return s.any || s.bits[b>>6]&(1<<(b&63)) != 0
+}
+
+func (s firstByteSet) empty() bool {
+	return !s.any && s.bits == [4]uint64{}
+}
+
+// union folds other into s and reports whether s changed.
+func (s *firstByteSet) union(other firstByteSet) bool {
+	if s.any {
+		return false
+	}
+	if other.any {
+		s.markAny()
+		return true
+	}
+	changed := false
+	for i := range s.bits {
+		merged := s.bits[i] | other.bits[i]
+		if merged != s.bits[i] {
+			s.bits[i] = merged
+			changed = true
+		}
+	}
+	return changed
+}
+
+// computeFirstBytes fills program.ruleFirstBytes and program.ruleNullable by
+// fixpoint. Both are read afterwards, per node, by the emitter.
+func (program *jitParserProgram) computeFirstBytes() {
+	n := len(program.rules)
+	program.ruleFirstBytes = make([]firstByteSet, n)
+	program.ruleNullable = make([]bool, n)
+
+	for changed := true; changed; {
+		changed = false
+		for r := 0; r < n; r++ {
+			root := program.rules[r].root
+			if root == nil {
+				continue
+			}
+			if program.nodeNullableFB(root) && !program.ruleNullable[r] {
+				program.ruleNullable[r] = true
+				changed = true
+			}
+			if program.ruleFirstBytes[r].union(program.nodeFirstBytes(root)) {
+				changed = true
+			}
+		}
+	}
+
+	if os.Getenv("MEMCP_DUMP_DISPATCH") != "" {
+		program.dumpDispatch()
+	}
+}
+
+// choiceDispatch is the plan for emitting a choice as a byte-indexed jump
+// instead of a linear cascade. buckets[b] lists, in original order, the
+// alternatives that could match when the next byte is b (a subset that always
+// includes every "wild" alternative). wild lists alternatives whose leading
+// byte is unknowable or which can match empty - they must be tried for every
+// byte. useful is set only when the dispatch meaningfully shrinks the worst
+// cascade.
+type choiceDispatch struct {
+	buckets [256][]int
+	wild    []int
+	useful  bool
+}
+
+func (program *jitParserProgram) choiceDispatchPlan(node *jitParserNode) choiceDispatch {
+	var d choiceDispatch
+	if program.ruleFirstBytes == nil || node.kind != jitParserChoice || len(node.children) < 6 {
+		return d
+	}
+	fbs := make([]firstByteSet, len(node.children))
+	wildAt := make([]bool, len(node.children))
+	concrete := 0
+	for i, alt := range node.children {
+		f := program.nodeFirstBytes(alt)
+		if program.nodeNullableFB(alt) || f.any || f.empty() {
+			wildAt[i] = true
+			d.wild = append(d.wild, i)
+			continue
+		}
+		fbs[i] = f
+		concrete++
+	}
+	if concrete*3 < len(node.children)*2 { // need most alternatives concrete
+		return d
+	}
+	worst := 0
+	for b := 0; b < 256; b++ {
+		var list []int
+		for i := range node.children {
+			if wildAt[i] || fbs[i].has(byte(b)) {
+				list = append(list, i)
+			}
+		}
+		d.buckets[b] = list
+		if len(list) > worst {
+			worst = len(list)
+		}
+	}
+	d.useful = worst*2 < len(node.children)
+	return d
+}
+
+func (program *jitParserProgram) dumpDispatch() {
+	var walk func(*jitParserNode, int)
+	total, dispatched, altsBefore, altsWorst := 0, 0, 0, 0
+	walk = func(node *jitParserNode, rule int) {
+		if node.kind == jitParserChoice && len(node.children) >= 2 {
+			total++
+			if d := program.choiceDispatchPlan(node); d.useful {
+				dispatched++
+				worst := 0
+				for b := 0; b < 256; b++ {
+					if len(d.buckets[b]) > worst {
+						worst = len(d.buckets[b])
+					}
+				}
+				altsBefore += len(node.children)
+				altsWorst += worst
+				fmt.Fprintf(os.Stderr, "[dispatch] rule#%d: %d alts (%d wild) -> worst bucket %d\n",
+					rule, len(node.children), len(d.wild), worst)
+			}
+		}
+		for _, c := range node.children {
+			walk(c, rule)
+		}
+	}
+	for r := range program.rules {
+		if program.rules[r].root != nil {
+			walk(program.rules[r].root, r)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "[dispatch] %d/%d choices dispatched; summed alternatives tried per hit: %d -> %d\n",
+		dispatched, total, altsBefore, altsWorst)
+}
+
+func (program *jitParserProgram) nodeNullableFB(node *jitParserNode) bool {
+	switch node.kind {
+	case jitParserAtom:
+		return false
+	case jitParserRegex:
+		return regexpNullable(node.regex.root)
+	case jitParserEnd, jitParserEmpty, jitParserRest:
+		return true
+	case jitParserRuleRef:
+		return program.ruleNullable[node.rule]
+	case jitParserSequence:
+		for _, c := range node.children {
+			if !program.nodeNullableFB(c) {
+				return false
+			}
+		}
+		return true
+	case jitParserChoice:
+		for _, c := range node.children {
+			if program.nodeNullableFB(c) {
+				return true
+			}
+		}
+		return false
+	case jitParserZeroOrMore, jitParserOptional:
+		return true
+	case jitParserOneOrMore, jitParserBind, jitParserCapture:
+		return program.nodeNullableFB(node.children[0])
+	case jitParserExclude:
+		if len(node.children) == 0 {
+			return true
+		}
+		return program.nodeNullableFB(node.children[0])
+	}
+	return true
+}
+
+// nodeFirstBytes returns the set of bytes node can begin a match with. `any`
+// means unknowable (a regex the analysis does not model, a rest match, a
+// negative lookahead).
+func (program *jitParserProgram) nodeFirstBytes(node *jitParserNode) firstByteSet {
+	var out firstByteSet
+	switch node.kind {
+	case jitParserAtom, jitParserRegex:
+		fbs, _ := regexpFirstBytes(node.regex.root)
+		out.union(fbs)
+	case jitParserRest, jitParserExclude:
+		out.markAny()
+	case jitParserEnd, jitParserEmpty:
+		// zero width; contributes nothing, nullable cascade handled by caller
+	case jitParserRuleRef:
+		out.union(program.ruleFirstBytes[node.rule])
+	case jitParserSequence:
+		for _, c := range node.children {
+			out.union(program.nodeFirstBytes(c))
+			if !program.nodeNullableFB(c) {
+				break
+			}
+		}
+	case jitParserChoice:
+		for _, c := range node.children {
+			out.union(program.nodeFirstBytes(c))
+		}
+	case jitParserZeroOrMore, jitParserOneOrMore, jitParserOptional, jitParserBind, jitParserCapture:
+		out.union(program.nodeFirstBytes(node.children[0]))
+	}
+	return out
+}
+
+// regexpNullable reports whether an anchored grammar regex can match the empty
+// string.
+func regexpNullable(re *syntax.Regexp) bool {
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpBeginText, syntax.OpEndText,
+		syntax.OpBeginLine, syntax.OpEndLine, syntax.OpWordBoundary,
+		syntax.OpNoWordBoundary, syntax.OpStar, syntax.OpQuest:
+		return true
+	case syntax.OpLiteral:
+		return len(re.Rune) == 0
+	case syntax.OpCapture, syntax.OpPlus:
+		return regexpNullable(re.Sub[0])
+	case syntax.OpConcat:
+		for _, sub := range re.Sub {
+			if !regexpNullable(sub) {
+				return false
+			}
+		}
+		return true
+	case syntax.OpAlternate:
+		for _, sub := range re.Sub {
+			if regexpNullable(sub) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// regexpFirstBytes returns the leading-byte set of an anchored grammar regex
+// and whether it can also match empty. `any` in the set means the shape is not
+// modelled (e.g. a Unicode class the byte walk would misrepresent).
+func regexpFirstBytes(re *syntax.Regexp) (firstByteSet, bool) {
+	var out firstByteSet
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpBeginText, syntax.OpEndText,
+		syntax.OpBeginLine, syntax.OpEndLine, syntax.OpWordBoundary,
+		syntax.OpNoWordBoundary:
+		return out, true
+
+	case syntax.OpLiteral:
+		if len(re.Rune) == 0 {
+			return out, true
+		}
+		addRuneFirstBytes(&out, re.Rune[0], re.Flags&syntax.FoldCase != 0)
+		return out, false
+
+	case syntax.OpCharClass:
+		for i := 0; i+1 < len(re.Rune); i += 2 {
+			lo, hi := re.Rune[i], re.Rune[i+1]
+			if lo > 0x7f {
+				out.markAny() // multi-byte lead bytes; do not model
+				return out, false
+			}
+			if hi > 0x7f {
+				hi = 0x7f
+				out.markAny()
+			}
+			out.addRange(int(lo), int(hi))
+		}
+		return out, false
+
+	case syntax.OpAnyChar, syntax.OpAnyCharNotNL:
+		out.markAny()
+		return out, false
+
+	case syntax.OpCapture:
+		return regexpFirstBytes(re.Sub[0])
+
+	case syntax.OpStar, syntax.OpQuest:
+		fbs, _ := regexpFirstBytes(re.Sub[0])
+		out.union(fbs)
+		return out, true
+
+	case syntax.OpPlus:
+		return regexpFirstBytes(re.Sub[0])
+
+	case syntax.OpConcat:
+		nullable := true
+		for _, sub := range re.Sub {
+			fbs, subNull := regexpFirstBytes(sub)
+			out.union(fbs)
+			if !subNull {
+				nullable = false
+				break
+			}
+		}
+		return out, nullable
+
+	case syntax.OpAlternate:
+		nullable := false
+		for _, sub := range re.Sub {
+			fbs, subNull := regexpFirstBytes(sub)
+			out.union(fbs)
+			nullable = nullable || subNull
+		}
+		return out, nullable
+	}
+	out.markAny()
+	return out, false
+}
+
+func addRuneFirstBytes(out *firstByteSet, r rune, fold bool) {
+	addOne := func(x rune) {
+		if x < 0x80 {
+			out.add(byte(x))
+		} else {
+			// first byte of a multi-byte UTF-8 sequence
+			var buf [4]byte
+			buf[0] = byte(0xC0 | (x >> 6))
+			if x >= 0x800 {
+				buf[0] = byte(0xE0 | (x >> 12))
+			}
+			if x >= 0x10000 {
+				buf[0] = byte(0xF0 | (x >> 18))
+			}
+			out.add(buf[0])
+		}
+	}
+	addOne(r)
+	if fold {
+		for f := unicode.SimpleFold(r); f != r; f = unicode.SimpleFold(f) {
+			addOne(f)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #763 (skip-memo analysis, merged). This branch carries **two** stacked commits — the second landed via #769 whose base was this branch:

1. **choice leading-byte dispatch** (`922699d68`)
2. **packrat memo fence for never-rolled-back repeats** (`365ede5ce`, #769)

---

## 1. Choice leading-byte dispatch

`emitChoice` lowered every ordered choice to a linear cascade: each alternative pushes a checkpoint, runs its match, records a diagnostic on failure, restores. Parsing a bare literal through `sql_expression6`'s ~40 alternatives is ~38 failed keyword matches — the 3.2 MB `parse_sql` had exactly **one** jump table and ~18k `call`s.

`computeFirstBytes` (new `scm/jit_parser_firstbytes.go`) walks the anchored grammar regexes to a per-rule fixpoint leading-byte set (`OpLiteral` + `FoldCase`, char classes, nullable prefixes, alternations). `choiceDispatchPlan` splits alternatives into 256 per-byte buckets + a `wild` list (unknowable or empty-matchable leading byte); wild alternatives are appended to every bucket in original index order, so PEG ordered-choice precedence is exactly preserved. Used only when most alternatives are concrete and the dispatch at least halves the worst bucket.

`emitChoiceDispatch`: skip whitespace once, read the leading byte via `jitParserPeekByteNative` (**one** Go call per choice), `EmitJumpTable` into the per-byte cascade, deduplicated by alt-list. 91-alt top-level statement choice → worst bucket 28; `sql_expression6` 29 → 10. `parse_sql` +1.6 % (3.21 → 3.26 MB).

## 2. Packrat memo fence

`... VALUES (row), (row), ...` memoized every sub-rule at every row position and kept the entries live for the whole parse: a 2000-row INSERT peaked at ~2.9M memo entries the GC rescanned every cycle.

`markFenceableRepeats` (parser pre-stage) proves a `*` node's committed iterations can never be rolled back — nothing failable follows the repeat before an ordered-choice commit, through the containing rule and every rule that transitively references it. The emitter then brackets the loop with `jitParserMemoFencePush` / `…Compact` (after every committed iteration) / `…Pop`; Compact rewinds `memoEntries`/`memoRules` to the fence high-water mark and clears `memoOffsets`/`heads` for the consumed span. `memoSet` records any pre-fence `memoRules` slot a fenced iteration writes into `dirtySlots`, which Compact zeroes before truncating — so no slot is left dangling (an earlier truncation-only spike crashed here on `ALTER TABLE … MODIFY COLUMN … COMMENT`). `OneOrMore` is excluded from fencing.

## A/B (parse-only, `parse_sql` with a policy lambda returning `true`)

2000-row `INSERT INTO t VALUES (…)`, server-reported per-parse:

| build | per-parse |
|---|---|
| master (has #763) | ~785 ms |
| + choice dispatch | ~530 ms (−32 %) |
| + memo fence (this branch) | **~408 ms (−48 % vs master)** |

Also confirmed by CI `performance-ab`: `UNIQUE INSERT fresh` 484 ms → 421 ms (−13 %).

## Tests

`go test ./scm` green. `jit-test` CI green on #769. `exists-session-var` 8/8, `exists-scalar-probe-no-source` 7/7 (#750 class), `name-resolution-scopes` 40/40, DDL/trigger suites green incl. `dbcheck.php` compat 81/81 (the `ALTER TABLE MODIFY COLUMN` path). `deep-correlation-membership` byte-identical between the two commits (3 pre-existing noncritical fails).

## Next

Parse itself is now ~16 % of cost. Next levers: raw `*jitParserState` instead of boxed `Scmer` to the `…Native` helpers (~10–13 %), then constant fast-scan + streaming `[]Scmer` append to turn the VALUES row loop into a native for-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV