### PR TITLE
parser: compact the packrat memo across never-rolled-back repeats

### DIFF
--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -66,7 +66,8 @@ type jitParserNode struct {
 	regex        *jitRegexProgram
 	skipWS       bool
 	ignoreResult bool
-	noMemo       bool
+	noMemo       bool // repeat body references skip the memo entry check
+	fenceMemo    bool // markFenceableRepeats: also fence+compact the memo table
 	description  string
 }
 
@@ -721,6 +722,7 @@ type jitParserState struct {
 	memoOffsets []uint32
 	memoRules   []uint32
 	memoEntries []jitParserMemoEntry
+	memoFences  []jitParserMemoFence
 	heads       []*jitParserLeftRecursionHead
 	farthest    int
 	expected    []string
@@ -745,6 +747,7 @@ func (program *jitParserProgram) acquireState(inputLength int) *jitParserState {
 	state.mutations = state.mutations[:0]
 	state.checkpoints = state.checkpoints[:0]
 	state.marks = state.marks[:0]
+	state.memoFences = state.memoFences[:0]
 	state.positions = state.positions[:0]
 	memoCapacity := jitParserMemoEntryCapacity(inputLength)
 	if cap(state.memoEntries) < memoCapacity {
@@ -850,6 +853,11 @@ func (state *jitParserState) memoSet(key jitParserMemoKey, entry jitParserMemoEn
 	if entryIndex := state.memoRules[index]; entryIndex != 0 {
 		state.memoEntries[entryIndex-1] = entry
 		return
+	}
+	if n := len(state.memoFences); n > 0 {
+		if fence := &state.memoFences[n-1]; index < fence.rules {
+			fence.dirtySlots = append(fence.dirtySlots, index)
+		}
 	}
 	state.memoEntries = append(state.memoEntries, entry)
 	state.memoRules[index] = uint32(len(state.memoEntries))
@@ -1217,6 +1225,83 @@ func jitParserCommitProgress(stateValue, positionValue Scmer) Scmer {
 	}
 	jitParserCommitCheckpoint(stateValue)
 	return NewBool(true)
+}
+
+// jitParserMemoFence bounds the memo table around one iteration of a `*` node
+// that markFenceableRepeats proved is never rolled back. Once an iteration
+// commits its progress no (rule, position) it memoized strictly ahead of the
+// fence can be consulted again, so jitParserMemoCompactNative rewinds
+// memoEntries/memoRules to the fence and clears memoOffsets/heads for the
+// consumed span. dirtySlots holds memoRules indices in blocks that predate the
+// fence which this iteration nonetheless wrote (the parse backtracked across
+// the loop start, e.g. inside a nested rule); the rewind strips the entry index
+// they point at, so they are zeroed first.
+type jitParserMemoFence struct {
+	entries    int
+	rules      int
+	pos        int
+	dirtySlots []int
+}
+
+func jitParserMemoFencePushNative(state *jitParserState, position int64) {
+	state.memoFences = append(state.memoFences, jitParserMemoFence{
+		entries: len(state.memoEntries), rules: len(state.memoRules), pos: int(position),
+	})
+}
+
+func jitParserMemoFencePopNative(state *jitParserState) {
+	n := len(state.memoFences)
+	if n == 0 {
+		panic("jit: parser memo fence underflow")
+	}
+	popped := state.memoFences[n-1]
+	state.memoFences = state.memoFences[:n-1]
+	if n >= 2 && len(popped.dirtySlots) > 0 {
+		parent := &state.memoFences[n-2]
+		for _, s := range popped.dirtySlots {
+			if s < parent.rules {
+				parent.dirtySlots = append(parent.dirtySlots, s)
+			}
+		}
+	}
+}
+
+// jitParserMemoCompactNative discards the memo a committed fenceable iteration
+// produced.
+func jitParserMemoCompactNative(state *jitParserState, position int64) {
+	n := len(state.memoFences)
+	if n == 0 {
+		return
+	}
+	fence := &state.memoFences[n-1]
+	for _, s := range fence.dirtySlots {
+		if s < len(state.memoRules) {
+			state.memoRules[s] = 0
+		}
+	}
+	fence.dirtySlots = fence.dirtySlots[:0]
+	end := int(position)
+	if end > len(state.memoOffsets) {
+		end = len(state.memoOffsets)
+	}
+	if fence.pos < end {
+		clear(state.memoOffsets[fence.pos:end])
+		hi := end
+		if hi > len(state.heads) {
+			hi = len(state.heads)
+		}
+		if fence.pos < hi {
+			clear(state.heads[fence.pos:hi])
+		}
+	}
+	if fence.entries < len(state.memoEntries) {
+		clear(state.memoEntries[fence.entries:])
+		state.memoEntries = state.memoEntries[:fence.entries]
+	}
+	if fence.rules < len(state.memoRules) {
+		state.memoRules = state.memoRules[:fence.rules]
+	}
+	fence.pos = end
 }
 
 func jitParserPushPosition(stateValue, positionValue Scmer) Scmer {

--- a/scm/jit_parser_analysis.go
+++ b/scm/jit_parser_analysis.go
@@ -137,11 +137,144 @@ func (program *jitParserProgram) analyzeMemoNeed() []bool {
 	}
 	a.flagChoicesAndRepeats()
 	a.propagateToReferrers()
+	a.markFenceableRepeats()
 
 	if os.Getenv("MEMCP_DUMP_MEMO_ANALYSIS") != "" {
 		a.dump()
 	}
 	return a.needMemo
+}
+
+// markFenceableRepeats sets fenceMemo on a `*` node whose committed iterations
+// can never be rolled back: nothing that can fail follows the repeat before an
+// ordered-choice commit, walking the containing rule and every rule that
+// references it. PEG ordered choice is possessive - once the alternative the
+// repeat lives in succeeds it is final - and a repeat only ever advances. The
+// emitter then discards the memo an iteration produced the moment it commits;
+// without it the memo for `... VALUES (row), (row), ...` grows to millions of
+// live entries the GC rescans every cycle.
+func (a *memoNeedAnalysis) markFenceableRepeats() {
+	referrers := make([][]int, a.n)
+	for r := 0; r < a.n; r++ {
+		if a.program.rules[r].root == nil {
+			continue
+		}
+		refs := newParserRuleSet(a.n)
+		a.collectDirectRefs(a.program.rules[r].root, refs)
+		for q := 0; q < a.n; q++ {
+			if refs.has(q) {
+				referrers[q] = append(referrers[q], r)
+			}
+		}
+	}
+	for r := 0; r < a.n; r++ {
+		if a.program.rules[r].root != nil {
+			a.walkFence(a.program.rules[r].root, nil, r, referrers)
+		}
+	}
+}
+
+func (a *memoNeedAnalysis) walkFence(node *jitParserNode, path []*jitParserNode, rule int, referrers [][]int) {
+	if node.kind == jitParserZeroOrMore {
+		if a.noRollbackAfter(node, path, rule, referrers, map[int]bool{}) {
+			node.noMemo = true
+			node.fenceMemo = true
+		}
+	}
+	childPath := append(append([]*jitParserNode(nil), path...), node)
+	for _, c := range node.children {
+		a.walkFence(c, childPath, rule, referrers)
+	}
+}
+
+// noRollbackAfter reports whether, once `node` starts succeeding, no later
+// failure can force it to be parsed again. `path` is node's ancestor chain
+// (root first) inside `rule`.
+func (a *memoNeedAnalysis) noRollbackAfter(node *jitParserNode, path []*jitParserNode, rule int, referrers [][]int, seen map[int]bool) bool {
+	child := node
+	for i := len(path) - 1; i >= 0; i-- {
+		anc := path[i]
+		switch anc.kind {
+		case jitParserChoice:
+			return true // an ordered-choice alternative is final once it succeeds
+		case jitParserSequence:
+			idx := 0
+			for j, c := range anc.children {
+				if c == child {
+					idx = j
+					break
+				}
+			}
+			for _, sib := range anc.children[idx+1:] {
+				if a.failable(sib) {
+					return false
+				}
+			}
+		case jitParserZeroOrMore, jitParserOneOrMore, jitParserOptional, jitParserBind, jitParserCapture:
+			// transparent: a repeat/optional/binder above never re-parses a
+			// committed inner iteration - repeats only advance.
+		default:
+			return false
+		}
+		child = anc
+	}
+	if seen[rule] {
+		return false
+	}
+	seen[rule] = true
+	refs := referrers[rule]
+	if len(refs) == 0 {
+		return true // an entry rule is never retried
+	}
+	for _, r := range refs {
+		ok := true
+		a.forEachRef(a.program.rules[r].root, nil, rule, func(refNode *jitParserNode, refPath []*jitParserNode) {
+			if ok && !a.noRollbackAfter(refNode, refPath, r, referrers, seen) {
+				ok = false
+			}
+		})
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *memoNeedAnalysis) forEachRef(node *jitParserNode, path []*jitParserNode, target int, fn func(*jitParserNode, []*jitParserNode)) {
+	if node.kind == jitParserRuleRef && node.rule == target {
+		fn(node, path)
+	}
+	childPath := append(append([]*jitParserNode(nil), path...), node)
+	for _, c := range node.children {
+		a.forEachRef(c, childPath, target, fn)
+	}
+}
+
+// failable reports whether a node can fail to match, as opposed to always
+// succeeding (possibly matching empty).
+func (a *memoNeedAnalysis) failable(node *jitParserNode) bool {
+	switch node.kind {
+	case jitParserZeroOrMore, jitParserOptional, jitParserEmpty:
+		return false
+	case jitParserBind, jitParserCapture:
+		return a.failable(node.children[0])
+	case jitParserSequence:
+		for _, c := range node.children {
+			if a.failable(c) {
+				return true
+			}
+		}
+		return false
+	case jitParserChoice:
+		for _, c := range node.children {
+			if !a.failable(c) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
+	}
 }
 
 func (a *memoNeedAnalysis) computeNullable() {
@@ -492,6 +625,30 @@ func (a *memoNeedAnalysis) dump() {
 	os.Stderr.WriteString("[memo-analysis] non-lexical rules: kept(memoized)=" +
 		itoa(kept) + " freed(no memo)=" + itoa(freed) + "\n")
 	os.Stderr.WriteString("[memo-analysis] freed sample: " + strings.Join(freedNames, ", ") + "\n")
+
+	fenced := 0
+	var fencedIn []string
+	for r := 0; r < a.n; r++ {
+		root := a.program.rules[r].root
+		if root == nil {
+			continue
+		}
+		var walk func(*jitParserNode)
+		walk = func(node *jitParserNode) {
+			if node.fenceMemo {
+				fenced++
+				if len(fencedIn) < 20 {
+					fencedIn = append(fencedIn, ruleDisplayName(&a.program.rules[r], r))
+				}
+			}
+			for _, c := range node.children {
+				walk(c)
+			}
+		}
+		walk(root)
+	}
+	os.Stderr.WriteString("[memo-analysis] fenced repeats: " + itoa(fenced) +
+		" in: " + strings.Join(fencedIn, ", ") + "\n")
 }
 
 func ruleDisplayName(rule *jitParserRule, id int) string {

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -864,6 +864,41 @@ func (emitter *jitParserEmitter) emitLexicalRuleRef(node *jitParserNode, success
 	emitter.ctx.EmitJmp(failure)
 }
 
+// emitMemoFencePush / emitMemoCompact / emitMemoFencePop drive the per-iteration
+// memo compaction for a repeat that markFenceableRepeats proved can never roll
+// back a committed iteration (node.fenceMemo). The fence records the memo table
+// high-water mark at loop entry; every committed iteration's packrat entries are
+// dead the moment the iteration commits, so they are truncated back to that mark
+// instead of accumulating for the whole input.
+func (emitter *jitParserEmitter) emitMemoFencePush() {
+	position := emitter.loadPosition()
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoFencePushNative, statePtr, position)
+	emitter.ctx.FreeDesc(&statePtr)
+	emitter.ctx.FreeDesc(&position)
+}
+
+func (emitter *jitParserEmitter) emitMemoCompact() {
+	position := emitter.loadPosition()
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoCompactNative, statePtr, position)
+	emitter.ctx.FreeDesc(&statePtr)
+	emitter.ctx.FreeDesc(&position)
+}
+
+func (emitter *jitParserEmitter) emitMemoFencePop() {
+	statePtr := emitter.statePointer()
+	emitter.emitVoid(jitParserMemoFencePopNative, statePtr)
+	emitter.ctx.FreeDesc(&statePtr)
+}
+
+// emitMemoFenceExit compacts the last iteration's growth away and pops the fence
+// on every path that leaves the repeat.
+func (emitter *jitParserEmitter) emitMemoFenceExit() {
+	emitter.emitMemoCompact()
+	emitter.emitMemoFencePop()
+}
+
 func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, success, failure JITLabel) {
 	if node.noMemo {
 		emitter.noMemoDepth++
@@ -872,6 +907,9 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.pushCheckpoint()
 	if !node.ignoreResult {
 		emitter.emitVoid(jitParserPushMarkNative, emitter.state)
+	}
+	if node.fenceMemo {
+		emitter.emitMemoFencePush()
 	}
 	firstAccepted, firstRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.pushCheckpoint()
@@ -890,11 +928,17 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.restoreCheckpoint()
 	if node.kind == jitParserOneOrMore {
 		emitter.restoreCheckpoint()
+		if node.fenceMemo {
+			emitter.emitMemoFenceExit()
+		}
 		emitter.ctx.EmitJmp(failure)
 	} else {
 		emitter.ctx.EmitJmp(done)
 	}
 	emitter.ctx.MarkLabel(loop)
+	if node.fenceMemo {
+		emitter.emitMemoCompact()
+	}
 	emitter.pushCheckpoint()
 	separatorAccepted, iterationAccepted, iterationRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.emitNode(node.children[1], rule, separatorAccepted, iterationRejected)
@@ -912,6 +956,9 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.restoreCheckpoint()
 	emitter.ctx.EmitJmp(done)
 	emitter.ctx.MarkLabel(done)
+	if node.fenceMemo {
+		emitter.emitMemoFenceExit()
+	}
 	if !node.ignoreResult {
 		emitter.emitVoid(jitParserMergeMarkNative, emitter.state, jitParserBoolScalar(false))
 	}


### PR DESCRIPTION
## What

Long `*` lists — `... VALUES (row), (row), ...` above all — memoized every
sub-rule at every row position and kept every entry live for the whole parse.
A 2000-row `INSERT` peaked at **~2.9M live memo entries** that the GC rescanned
every cycle; parsing was GC-bound (~40% of parse time in `scanObject`/`scanSpan`).

## How

**Pre-stage analysis** (`jit_parser_analysis.go`, `markFenceableRepeats`): a `*`
node is *fenceable* when its committed iterations can never be rolled back —
nothing that can fail follows the repeat before an ordered-choice commit,
checked through the containing rule **and every rule that transitively
references it**. PEG ordered choice is possessive and a repeat only ever
advances, so once such an iteration commits, nothing it memoized strictly
ahead of the loop entry is reachable again. `OneOrMore` is deliberately
excluded (it broke `@session_user` correlation in an earlier spike).

**Emitter** (`jit_parser_emit.go`): the fenced loop is bracketed with
`jitParserMemoFencePush` / `…Compact` / `…Pop`. `Compact` runs after every
committed iteration and rewinds `memoEntries`/`memoRules` to the fence
high-water mark, clearing `memoOffsets`/`heads` for the consumed span.

**Crash-safety** (`memoSet`): a fenced iteration can still write a `memoRules`
slot in a block that predates the fence (a nested rule that backtracked across
the loop start). Those indices are recorded in `dirtySlots` and zeroed by
`Compact` before truncation, so no slot is ever left pointing past the rewound
entries. (An array-truncation-only spike crashed here on
`ALTER TABLE … MODIFY COLUMN … COMMENT`; this version handles it.)

The JIT emits only the mechanical push/compact/pop calls — all the "is this
safe" logic lives in the parser pre-stage.

## A/B

2000-row `INSERT ... VALUES` parse, `parse_sql` in a tight Scheme loop, 6
interleaved rounds on a loaded box:

| build | ms / parse |
|---|---|
| base (#768) | ~506 |
| **this PR** | **~408** (**−19%**) |

`MEMCP_DUMP_MEMO_ANALYSIS=1` reports 6–9 fenced repeats per compiled grammar.

## Tests

- `go test ./scm` green
- Parser / DDL / trigger suites green, incl. the backtracking-heavy
  `ALTER TABLE MODIFY COLUMN` path (`dbcheck.php` compat 81/81), DDL
  operations 54/54, trigger-body-parsing 37/37
- `deep-correlation-membership` byte-identical to #768 (3 pre-existing
  noncritical fails on both branches)
- Full local pre-commit was run but the box was thrashing (load avg 9+, a
  concurrent test run in another session, RAM-pressure `SIGKILL`s) — relying
  on CI for the authoritative full-suite signal.

Stacked on #768 (`perf/jit-parser-choice-dispatch`); merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV