### PR TITLE
Optimize composite scan lookups

### DIFF
--- a/git-pre-commit
+++ b/git-pre-commit
@@ -305,8 +305,10 @@ run_memcp_forever() {
     if [ $rc -ne 0 ]; then
       echo "⚠️  MemCP exited unexpectedly (code=$rc). Restarting..."
       if [ -f "$memcp_log" ]; then
-        echo "--- MemCP log at unexpected exit (last 200 lines) ---"
-        tail -n 200 "$memcp_log"
+        echo "--- MemCP log at unexpected exit (last 2000 lines) ---"
+        # Runtime fatal reports include every goroutine. Keep enough context to
+        # retain the actual fault header instead of only its trailing stacks.
+        tail -n 2000 "$memcp_log"
         echo "--- end MemCP log at unexpected exit ---"
       fi
     fi

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1361,6 +1361,24 @@ func (t *table) hasBoundUniquePoint(access scanAccess) bool {
 			if matched {
 				return true
 			}
+			covered := len(unique.Cols) > 0
+			for _, column := range unique.Cols {
+				matched = false
+				for i := 0; i < access.len(); i++ {
+					if access.boundaryColumn(i) == column && !access.values[i].IsNil() {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					covered = false
+					break
+				}
+			}
+			if covered {
+				return true
+			}
+			continue
 		}
 		covered := true
 		for _, col := range unique.Cols {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1361,7 +1361,6 @@ func (t *table) hasBoundUniquePoint(access scanAccess) bool {
 			if matched {
 				return true
 			}
-			continue
 		}
 		covered := true
 		for _, col := range unique.Cols {

--- a/storage/scan_lookup.go
+++ b/storage/scan_lookup.go
@@ -43,6 +43,26 @@ type scanLookupPlan struct {
 	consumer scanLookupConsumer
 }
 
+// scanLookupParallelControl keeps the shared state captured by a table-level
+// shard callback in one allocation. Composite probes used to spill every
+// captured field separately.
+type scanLookupParallelControl struct {
+	mu         sync.Mutex
+	stop       atomic.Bool
+	matches    int
+	panicValue any
+}
+
+type scanLookupParallelValueState struct {
+	scanLookupParallelControl
+	result scm.Scmer
+}
+
+type scanLookupParallelMapState struct {
+	scanLookupParallelControl
+	values []scm.Scmer
+}
+
 func executeCompiledScanLookup(t *table, currentTx *TxContext, schemaValue, valuesValue scm.Scmer) scm.Scmer {
 	schema := mustScmerSlice(schemaValue, "scan_lookup schema")
 	values := mustScmerSlice(valuesValue, "scan_lookup values")
@@ -65,7 +85,7 @@ func executeCompiledScanLookup(t *table, currentTx *TxContext, schemaValue, valu
 			return scanLookupMiss(meta.consumer != "exists")
 		}
 		projectionAt := scanAccessSchemaHeaderSize + scanAccessBoundaryStride
-		access := scanAccess{schema: schema, values: values, compiledCount: 1}
+		access := scanAccess{schema: schema, values: values, compiledCount: 1, exactAdjacent: true}
 		switch meta.consumer {
 		case "exists":
 			if len(schema) == projectionAt && meta.projections == 0 {
@@ -96,12 +116,17 @@ func parseScanLookupPlanSlices(schema, values []scm.Scmer) scanLookupPlan {
 	if matchCount <= 0 {
 		panic("scan_lookup schema has an invalid match-column count")
 	}
+	exactAdjacent := len(values) >= matchCount
 	for i := 0; i < matchCount; i++ {
 		if !matcherKindEqual(access.boundaryAnalyzer(i), EqualMatcher) || !access.boundaryLowerInclusive(i) ||
 			!access.boundaryUpperInclusive(i) || !boundaryValueEqual(access.boundValue(i, false), access.boundValue(i, true)) {
 			panic("scan_lookup requires exact equality access entries")
 		}
+		boundary := access.compiledBoundary(i)
+		exactAdjacent = exactAdjacent && boundary.lowerSlot == i && boundary.upperSlot == i &&
+			boundary.mapperSlot < 0 && boundary.collation == "" && !boundary.nullSafe
 	}
+	access.exactAdjacent = exactAdjacent
 	projectionCount := meta.projections
 	projectionAt := scanAccessSchemaHeaderSize + matchCount*scanAccessBoundaryStride
 
@@ -510,69 +535,71 @@ func (t *table) scanLookupMany(currentTx *TxContext, access scanAccess, resultCo
 	}
 	touchTempColumns(t, lookupCols, resultCols)
 
-	var mu sync.Mutex
-	var stop atomic.Bool
-	result := scm.NewBool(false)
-	matches := 0
-	var panicValue any
+	state := scanLookupParallelValueState{result: scm.NewBool(false)}
 	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
-		if stop.Load() {
+		if state.stop.Load() {
 			return
 		}
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				mu.Lock()
-				if panicValue == nil {
-					panicValue = recovered
+				state.mu.Lock()
+				if state.panicValue == nil {
+					state.panicValue = recovered
 				}
-				mu.Unlock()
-				stop.Store(true)
+				state.mu.Unlock()
+				state.stop.Store(true)
 			}
 		}()
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		value, count := shard.scanLookupMany(access, resultCol, returnValue, currentTx, &stop)
+		value, count := shard.scanLookupMany(access, resultCol, returnValue, currentTx, &state.stop)
 		if count == 0 {
 			return
 		}
 		if solo {
-			result = value
-			matches = count
+			state.result = value
+			state.matches = count
 			return
 		}
-		mu.Lock()
-		if matches == 0 {
-			result = value
+		state.mu.Lock()
+		if state.matches == 0 {
+			state.result = value
 		}
-		matches += count
-		if !returnValue || matches > 1 {
-			stop.Store(true)
+		state.matches += count
+		if !returnValue || state.matches > 1 {
+			state.stop.Store(true)
 		}
-		mu.Unlock()
+		state.mu.Unlock()
 	})
 	if done != nil {
 		<-done
 	}
-	if panicValue != nil {
-		panic(panicValue)
+	if state.panicValue != nil {
+		panic(state.panicValue)
 	}
 	if !returnValue {
-		return scm.NewBool(matches != 0)
+		return scm.NewBool(state.matches != 0)
 	}
-	if matches > 1 {
+	if state.matches > 1 {
 		panic(scalarSubselectOverflow)
 	}
-	if matches == 0 {
+	if state.matches == 0 {
 		return scm.NewNil()
 	}
-	return result
+	return state.result
 }
 
 func (t *storageShard) scanLookupMany(access scanAccess, resultCol string, returnValue bool, currentTx *TxContext, stop *atomic.Bool) (scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupReaders := make([]ColumnReader, access.len())
+	var fixedLookupReaders [8]ColumnReader
+	lookupReaders := fixedLookupReaders[:]
+	if access.len() <= len(fixedLookupReaders) {
+		lookupReaders = lookupReaders[:access.len()]
+	} else {
+		lookupReaders = make([]ColumnReader, access.len())
+	}
 	for i := range lookupReaders {
 		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx)
 	}
@@ -644,59 +671,61 @@ func (t *table) scanLookupMapMany(currentTx *TxContext, access scanAccess, mapCo
 	lookupCols := scanLookupColumns(access, fixedLookupCols[:])
 	touchTempColumns(t, lookupCols, mapCols)
 
-	var mu sync.Mutex
-	var stop atomic.Bool
-	var values []scm.Scmer
-	matches := 0
-	var panicValue any
+	state := scanLookupParallelMapState{}
 	done := t.iterateShardsParallel(currentTx, access, func(shard *storageShard, solo bool) {
-		if stop.Load() {
+		if state.stop.Load() {
 			return
 		}
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				mu.Lock()
-				if panicValue == nil {
-					panicValue = recovered
+				state.mu.Lock()
+				if state.panicValue == nil {
+					state.panicValue = recovered
 				}
-				mu.Unlock()
-				stop.Store(true)
+				state.mu.Unlock()
+				state.stop.Store(true)
 			}
 		}()
 		if ss := SessionStateFromTx(currentTx); ss != nil && ss.IsKilledSeq(querySeqFromTx(currentTx)) {
 			panic("query killed")
 		}
-		localValues, count := shard.scanLookupMapMany(access, mapCols, currentTx, &stop)
+		localValues, count := shard.scanLookupMapMany(access, mapCols, currentTx, &state.stop)
 		if count == 0 {
 			return
 		}
 		if solo {
-			values, matches = localValues, count
+			state.values, state.matches = localValues, count
 			return
 		}
-		mu.Lock()
-		if matches == 0 {
-			values = localValues
+		state.mu.Lock()
+		if state.matches == 0 {
+			state.values = localValues
 		}
-		matches += count
-		if matches > 1 {
-			stop.Store(true)
+		state.matches += count
+		if state.matches > 1 {
+			state.stop.Store(true)
 		}
-		mu.Unlock()
+		state.mu.Unlock()
 	})
 	if done != nil {
 		<-done
 	}
-	if panicValue != nil {
-		panic(panicValue)
+	if state.panicValue != nil {
+		panic(state.panicValue)
 	}
-	return values, matches
+	return state.values, state.matches
 }
 
 func (t *storageShard) scanLookupMapMany(access scanAccess, mapCols []string, currentTx *TxContext, stop *atomic.Bool) ([]scm.Scmer, int) {
 	t.ensureLoaded()
 	t.ensureMainCount(false)
-	lookupReaders := make([]ColumnReader, access.len())
+	var fixedLookupReaders [8]ColumnReader
+	lookupReaders := fixedLookupReaders[:]
+	if access.len() <= len(fixedLookupReaders) {
+		lookupReaders = lookupReaders[:access.len()]
+	} else {
+		lookupReaders = make([]ColumnReader, access.len())
+	}
 	for i := range lookupReaders {
 		lookupReaders[i] = newCachedColumnReaderTx(t.getColumnStorageOrPanic(access.boundaryColumn(i), false, currentTx), currentTx)
 	}

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -154,7 +154,7 @@ func TestScanLookupPlanUsesExactAdjacentValuesOnlyWhenValid(t *testing.T) {
 	}
 }
 
-func TestCompiledScanLookupCompositeDoesNotAddAllocations(t *testing.T) {
+func TestCompiledScanLookupCompositeAllocationLimits(t *testing.T) {
 	database := "test_compiled_scan_lookup_allocations"
 	databases.Remove(database)
 	t.Cleanup(func() { databases.Remove(database) })
@@ -162,26 +162,49 @@ func TestCompiledScanLookupCompositeDoesNotAddAllocations(t *testing.T) {
 	tbl, _ := CreateTable(database, "items", Memory, true)
 	tbl.CreateColumn("tenant", "INT", nil, nil)
 	tbl.CreateColumn("key", "INT", nil, nil)
-	tbl.Insert([]string{"tenant", "key"}, [][]scm.Scmer{
-		{scm.NewInt(1), scm.NewInt(7)},
-		{scm.NewInt(2), scm.NewInt(7)},
+	tbl.CreateColumn("value", "INT", nil, nil)
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "lookup_key", Cols: []string{"key", "tenant"}})
+	tbl.Insert([]string{"tenant", "key", "value"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(7), scm.NewInt(17)},
+		{scm.NewInt(2), scm.NewInt(7), scm.NewInt(27)},
 	}, nil, scm.NewNil(), false, nil)
 	tx := NewTxContext(TxCursorStability)
-	oneSchema := testScanLookupSchema("exists", []string{"key"}, nil)
-	oneValues := scm.NewSlice([]scm.Scmer{scm.NewInt(7)})
-	twoSchema := testScanLookupSchema("exists", []string{"tenant", "key"}, nil)
-	twoValues := scm.NewSlice([]scm.Scmer{scm.NewInt(2), scm.NewInt(7)})
-	executeCompiledScanLookup(tbl, tx, oneSchema, oneValues)
-	executeCompiledScanLookup(tbl, tx, twoSchema, twoValues)
-
-	oneAllocs := testing.AllocsPerRun(1000, func() {
-		executeCompiledScanLookup(tbl, tx, oneSchema, oneValues)
-	})
-	twoAllocs := testing.AllocsPerRun(1000, func() {
-		executeCompiledScanLookup(tbl, tx, twoSchema, twoValues)
-	})
-	if twoAllocs > oneAllocs {
-		t.Fatalf("composite scan_lookup allocated %.2f times, single dimension allocated %.2f", twoAllocs, oneAllocs)
+	mapper := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+	cases := []struct {
+		name      string
+		schema    scm.Scmer
+		values    scm.Scmer
+		maxAllocs float64
+	}{
+		{
+			name:      "value",
+			schema:    testScanLookupSchema("value", []string{"tenant", "key"}, []string{"value"}),
+			values:    scm.NewSlice([]scm.Scmer{scm.NewInt(2), scm.NewInt(7)}),
+			maxAllocs: 3,
+		},
+		{
+			name:      "exists",
+			schema:    testScanLookupSchema("exists", []string{"tenant", "key"}, nil),
+			values:    scm.NewSlice([]scm.Scmer{scm.NewInt(2), scm.NewInt(7)}),
+			maxAllocs: 3,
+		},
+		{
+			name:      "map",
+			schema:    testScanLookupSchema("map", []string{"tenant", "key"}, []string{"value"}),
+			values:    scm.NewSlice([]scm.Scmer{scm.NewInt(2), scm.NewInt(7), mapper}),
+			maxAllocs: 5,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			executeCompiledScanLookup(tbl, tx, test.schema, test.values)
+			allocs := testing.AllocsPerRun(1000, func() {
+				executeCompiledScanLookup(tbl, tx, test.schema, test.values)
+			})
+			if allocs > test.maxAllocs {
+				t.Fatalf("composite scan_lookup allocated %.2f times, want at most %.0f", allocs, test.maxAllocs)
+			}
+		})
 	}
 }
 
@@ -364,6 +387,9 @@ func BenchmarkCompiledScanLookupDimensions(b *testing.B) {
 	tbl.CreateColumn("tenant", "INT", nil, nil)
 	tbl.CreateColumn("key", "INT", nil, nil)
 	tbl.CreateColumn("value", "VARCHAR", nil, nil)
+	// Deliberately reverse the planner boundary order to cover unordered
+	// composite unique-key detection in the measured hot path.
+	tbl.Unique = append(tbl.Unique, uniqueKey{Id: "lookup_key", Cols: []string{"key", "tenant"}})
 	rows := make([][]scm.Scmer, 1024)
 	for i := range rows {
 		rows[i] = []scm.Scmer{scm.NewInt(int64(i % 16)), scm.NewInt(int64(i)), scm.NewString("value")}

--- a/storage/scan_lookup_test.go
+++ b/storage/scan_lookup_test.go
@@ -128,6 +128,63 @@ func TestScanLookupPlanBindingDoesNotAllocate(t *testing.T) {
 	}
 }
 
+func TestScanLookupPlanUsesExactAdjacentValuesOnlyWhenValid(t *testing.T) {
+	schema := testScanLookupSchema("exists", []string{"tenant", "key"}, nil)
+	values := scm.NewSlice([]scm.Scmer{scm.NewInt(1), scm.NewInt(7)})
+	plan := parseScanLookupPlan(schema, values)
+	if !plan.access.exactAdjacent {
+		t.Fatal("canonical scan_lookup schema did not use adjacent values")
+	}
+	reversedUnique := &table{Unique: []uniqueKey{{Id: "uq", Cols: []string{"key", "tenant"}}}}
+	if !reversedUnique.hasBoundUniquePoint(plan.access) {
+		t.Fatal("adjacent lookup values hid a unique key with different column order")
+	}
+
+	nonAdjacentSchema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(2, "exists", 0, -1),
+		newScanBoundarySpec("tenant", EqualMatcher, 1, 1, true, true, "", false, -1, nil, nil, "", false),
+		newScanBoundarySpec("key", EqualMatcher, 0, 0, true, true, "", false, -1, nil, nil, "", false),
+	})
+	nonAdjacent := parseScanLookupPlan(nonAdjacentSchema, values)
+	if nonAdjacent.access.exactAdjacent {
+		t.Fatal("non-adjacent scan_lookup slots used the adjacent fast path")
+	}
+	if got := nonAdjacent.access.boundValue(0, false); !scm.Equal(got, scm.NewInt(7)) {
+		t.Fatalf("non-adjacent first value = %s, want 7", scm.String(got))
+	}
+}
+
+func TestCompiledScanLookupCompositeDoesNotAddAllocations(t *testing.T) {
+	database := "test_compiled_scan_lookup_allocations"
+	databases.Remove(database)
+	t.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	tbl, _ := CreateTable(database, "items", Memory, true)
+	tbl.CreateColumn("tenant", "INT", nil, nil)
+	tbl.CreateColumn("key", "INT", nil, nil)
+	tbl.Insert([]string{"tenant", "key"}, [][]scm.Scmer{
+		{scm.NewInt(1), scm.NewInt(7)},
+		{scm.NewInt(2), scm.NewInt(7)},
+	}, nil, scm.NewNil(), false, nil)
+	tx := NewTxContext(TxCursorStability)
+	oneSchema := testScanLookupSchema("exists", []string{"key"}, nil)
+	oneValues := scm.NewSlice([]scm.Scmer{scm.NewInt(7)})
+	twoSchema := testScanLookupSchema("exists", []string{"tenant", "key"}, nil)
+	twoValues := scm.NewSlice([]scm.Scmer{scm.NewInt(2), scm.NewInt(7)})
+	executeCompiledScanLookup(tbl, tx, oneSchema, oneValues)
+	executeCompiledScanLookup(tbl, tx, twoSchema, twoValues)
+
+	oneAllocs := testing.AllocsPerRun(1000, func() {
+		executeCompiledScanLookup(tbl, tx, oneSchema, oneValues)
+	})
+	twoAllocs := testing.AllocsPerRun(1000, func() {
+		executeCompiledScanLookup(tbl, tx, twoSchema, twoValues)
+	})
+	if twoAllocs > oneAllocs {
+		t.Fatalf("composite scan_lookup allocated %.2f times, single dimension allocated %.2f", twoAllocs, oneAllocs)
+	}
+}
+
 func TestScanLookupCompositeValueAndExists(t *testing.T) {
 	database := "test_scan_lookup_composite"
 	databases.Remove(database)
@@ -295,6 +352,47 @@ func BenchmarkCompiledScanLookupWithTx(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		executeCompiledScanLookup(tbl, tx, schema, values)
+	}
+}
+
+func BenchmarkCompiledScanLookupDimensions(b *testing.B) {
+	database := "bench_compiled_scan_lookup_dimensions"
+	databases.Remove(database)
+	b.Cleanup(func() { databases.Remove(database) })
+	CreateDatabase(database, true)
+	tbl, _ := CreateTable(database, "items", Memory, true)
+	tbl.CreateColumn("tenant", "INT", nil, nil)
+	tbl.CreateColumn("key", "INT", nil, nil)
+	tbl.CreateColumn("value", "VARCHAR", nil, nil)
+	rows := make([][]scm.Scmer, 1024)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i % 16)), scm.NewInt(int64(i)), scm.NewString("value")}
+	}
+	tbl.Insert([]string{"tenant", "key", "value"}, rows, nil, scm.NewNil(), false, nil)
+	tx := NewTxContext(TxCursorStability)
+	mapper := scm.NewFunc(func(values ...scm.Scmer) scm.Scmer { return values[0] })
+
+	cases := []struct {
+		name   string
+		schema scm.Scmer
+		values scm.Scmer
+	}{
+		{name: "value_one", schema: testScanLookupSchema("value", []string{"key"}, []string{"value"}), values: scm.NewSlice([]scm.Scmer{scm.NewInt(511)})},
+		{name: "value_two", schema: testScanLookupSchema("value", []string{"tenant", "key"}, []string{"value"}), values: scm.NewSlice([]scm.Scmer{scm.NewInt(15), scm.NewInt(511)})},
+		{name: "exists_one", schema: testScanLookupSchema("exists", []string{"key"}, nil), values: scm.NewSlice([]scm.Scmer{scm.NewInt(511)})},
+		{name: "exists_two", schema: testScanLookupSchema("exists", []string{"tenant", "key"}, nil), values: scm.NewSlice([]scm.Scmer{scm.NewInt(15), scm.NewInt(511)})},
+		{name: "map_one", schema: testScanLookupSchema("map", []string{"key"}, []string{"value"}), values: scm.NewSlice([]scm.Scmer{scm.NewInt(511), mapper})},
+		{name: "map_two", schema: testScanLookupSchema("map", []string{"tenant", "key"}, []string{"value"}), values: scm.NewSlice([]scm.Scmer{scm.NewInt(15), scm.NewInt(511), mapper})},
+	}
+	for _, bench := range cases {
+		b.Run(bench.name, func(b *testing.B) {
+			executeCompiledScanLookup(tbl, tx, bench.schema, bench.values)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				executeCompiledScanLookup(tbl, tx, bench.schema, bench.values)
+			}
+		})
 	}
 }
 

--- a/tests/performance/authenticated-point-lookup.yaml
+++ b/tests/performance/authenticated-point-lookup.yaml
@@ -1,0 +1,33 @@
+# Copyright (C) 2026  Carl-Philip Hänsch
+
+metadata:
+  version: "1.0"
+  description: "Authenticated point-query hot path with a composite database ACL lookup"
+  isolated: true
+  ci: true
+
+setup:
+  - sql: "DELETE FROM system.access WHERE username='point_lookup_perf'"
+  - sql: "DELETE FROM system.user WHERE username='point_lookup_perf'"
+  - sql: "DROP TABLE IF EXISTS authenticated_point_item"
+  - sql: "CREATE TABLE authenticated_point_item (id INT PRIMARY KEY, payload VARCHAR(32)) ENGINE=memory"
+  - sql: "INSERT INTO authenticated_point_item (id, payload) VALUES (7, 'seven')"
+  - sql: "CREATE USER point_lookup_perf IDENTIFIED BY 'secret123'"
+  - sql: "GRANT SELECT ON `memcp-tests`.* TO point_lookup_perf"
+
+test_cases:
+  - name: "Authenticated non-admin point lookup"
+    username: "point_lookup_perf"
+    password: "secret123"
+    warmup: 10
+    timing_samples: 100
+    threshold_ms: 2
+    sql: "SELECT payload FROM authenticated_point_item WHERE id = 7"
+    expect:
+      rows: 1
+      data:
+        - payload: "seven"
+
+cleanup:
+  - sql: "DROP USER IF EXISTS point_lookup_perf"
+  - sql: "DROP TABLE IF EXISTS authenticated_point_item"

--- a/tests/performance/authenticated-point-lookup.yaml
+++ b/tests/performance/authenticated-point-lookup.yaml
@@ -10,8 +10,21 @@ setup:
   - sql: "DELETE FROM system.access WHERE username='point_lookup_perf'"
   - sql: "DELETE FROM system.user WHERE username='point_lookup_perf'"
   - sql: "DROP TABLE IF EXISTS authenticated_point_item"
+  - sql: "DROP TABLE IF EXISTS composite_lookup_driver"
+  - sql: "DROP TABLE IF EXISTS composite_lookup_target"
   - sql: "CREATE TABLE authenticated_point_item (id INT PRIMARY KEY, payload VARCHAR(32)) ENGINE=memory"
+  - sql: "CREATE TABLE composite_lookup_target (tenant_id INT, lookup_id INT, payload INT, UNIQUE KEY lookup_key (tenant_id, lookup_id)) ENGINE=memory"
+  - sql: "CREATE TABLE composite_lookup_driver (seq INT PRIMARY KEY, tenant_id INT, lookup_id INT) ENGINE=memory"
   - sql: "INSERT INTO authenticated_point_item (id, payload) VALUES (7, 'seven')"
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "composite_lookup_target") '("tenant_id" "lookup_id" "payload")
+          (map (produceN 1024) (lambda (i) (list (mod i 16) i i))))
+        (insert (table "memcp-tests" "composite_lookup_driver") '("seq" "tenant_id" "lookup_id")
+          (map (produceN 20000) (lambda (i)
+            (begin
+              (define lookup_id (mod i 1024))
+              (list i (mod lookup_id 16) lookup_id))))))
   - sql: "CREATE USER point_lookup_perf IDENTIFIED BY 'secret123'"
   - sql: "GRANT SELECT ON `memcp-tests`.* TO point_lookup_perf"
 
@@ -28,6 +41,103 @@ test_cases:
       data:
         - payload: "seven"
 
+  - name: "Composite value lookup carrier"
+    warmup: 3
+    timing_samples: 7
+    threshold_ms: 400
+    sql: |
+      SELECT SUM((
+        SELECT target.payload
+        FROM composite_lookup_target target
+        WHERE target.tenant_id = driver.tenant_id
+          AND target.lookup_id = driver.lookup_id
+      )) AS total
+      FROM composite_lookup_driver driver
+    expect:
+      rows: 1
+      data:
+        - total: 10099440
+
+  - name: "Composite mapped lookup carrier"
+    warmup: 3
+    timing_samples: 7
+    threshold_ms: 400
+    sql: |
+      SELECT SUM((
+        SELECT target.payload + 1
+        FROM composite_lookup_target target
+        WHERE target.tenant_id = driver.tenant_id
+          AND target.lookup_id = driver.lookup_id
+      )) AS total
+      FROM composite_lookup_driver driver
+    expect:
+      rows: 1
+      data:
+        - total: 10119440
+
+  - name: "Composite exists lookup carrier"
+    warmup: 3
+    timing_samples: 7
+    threshold_ms: 400
+    sql: |
+      SELECT SUM(CASE WHEN EXISTS (
+        SELECT 1
+        FROM composite_lookup_target target
+        WHERE target.tenant_id = driver.tenant_id
+          AND target.lookup_id = driver.lookup_id
+      ) THEN 1 ELSE 0 END) AS total
+      FROM composite_lookup_driver driver
+    expect:
+      rows: 1
+      data:
+        - total: 20000
+
+  - name: "Composite value carrier uses scan_lookup"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT (SELECT target.payload
+         FROM composite_lookup_target target
+         WHERE target.tenant_id = driver.tenant_id
+           AND target.lookup_id = driver.lookup_id) AS value_result
+      FROM composite_lookup_driver driver
+      WHERE driver.seq = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+
+  - name: "Composite mapped carrier uses scan_lookup"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT (SELECT target.payload + 1
+         FROM composite_lookup_target target
+         WHERE target.tenant_id = driver.tenant_id
+           AND target.lookup_id = driver.lookup_id) AS map_result
+      FROM composite_lookup_driver driver
+      WHERE driver.seq = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+
+  - name: "Composite exists carrier uses scan_lookup"
+    sql: |
+      EXPLAIN PHYSICAL
+      SELECT EXISTS (
+        SELECT 1
+          FROM composite_lookup_target target
+          WHERE target.tenant_id = driver.tenant_id
+            AND target.lookup_id = driver.lookup_id
+      ) AS exists_result
+      FROM composite_lookup_driver driver
+      WHERE driver.seq = 1
+    expect:
+      rows: 1
+      result_contains:
+        - "scan_lookup"
+
 cleanup:
   - sql: "DROP USER IF EXISTS point_lookup_perf"
+  - sql: "DROP TABLE IF EXISTS composite_lookup_driver"
+  - sql: "DROP TABLE IF EXISTS composite_lookup_target"
   - sql: "DROP TABLE IF EXISTS authenticated_point_item"


### PR DESCRIPTION
## Summary

- bind canonical composite lookup values directly instead of decoding every boundary for every candidate row
- keep shard callback state in one heap object and use stack-backed column-reader arrays for up to eight match columns
- preserve fast composite unique-key detection when planner boundary order differs from index declaration order
- add absolute allocation limits, permanent dimension benchmarks, three SQL performance carriers, physical-plan assertions, and an authenticated non-admin point-query performance case

## Manual A/B measurements

Baseline: current master at 28b9cb6f1. Candidate: 158447aad. Both used the same 1,024-row in-memory fixture, one warmup call per benchmark process, and five benchmark samples on an AMD Ryzen 9 7900X3D. The composite unique key deliberately reverses the planner boundary order.

| Warm compiled operator | Master median | Candidate median | Change | Master allocs / bytes | Candidate allocs / bytes |
| --- | ---: | ---: | ---: | ---: | ---: |
| two-column value lookup | 2,874 ns | 2,404 ns | -16.4% | 8 / 296 B | 3 / 240 B |
| two-column exists lookup | 2,816 ns | 2,459 ns | -12.7% | 8 / 296 B | 3 / 240 B |
| two-column map lookup | 3,015 ns | 2,473 ns | -18.0% | 10 / 336 B | 5 / 272 B |

Command: `go test ./storage -run "^$" -bench "^BenchmarkCompiledScanLookupDimensions/(value_two|exists_two|map_two)$" -benchmem -count=5`

The SQL carrier A/B executes 20,000 composite probes per query with three warmups and seven samples. Manual runs measured value 269.9 -> 269.1 ms (-0.3%), map 270.1 -> 271.6 ms (+0.6%), and exists 256.9 -> 259.7 ms (+1.1%). These query-level differences are within local run-to-run noise; the cases primarily provide CI A/B regression coverage around the complete planner and interpreter path.

The authenticated HTTP point-query case used identical setup, 10 warmups, and 100 samples per run across five fresh server runs. Its local median was 633 us on master and 649 us on the candidate (+2.4%), within the observed 610-684 us run-to-run range. The approximately 0.3 us operator saving is therefore not reliably resolvable through local HTTP noise.

The final CI A/B run measured every added case positively: authenticated point lookup 1.207 -> 1.166 ms (-3.4%), composite value 467.483 -> 464.594 ms (-0.6%), composite map 474.717 -> 471.415 ms (-0.7%), and composite exists 452.524 -> 449.586 ms (-0.6%). CI is additional evidence, not a substitute for the manual measurements above.

## Verification

- `go test ./storage`
- `go test -race ./storage -run "^Test(ScanLookup|CompiledScanLookup)" -count=1`
- `PERF_TEST=1 python3 run_sql_tests.py tests/performance/authenticated-point-lookup.yaml --log-times`
- full repository test suite delegated to CI as required