### PR TITLE
parser: pass the raw *jitParserState to helpers instead of a boxed Scmer

### DIFF
--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -874,54 +874,29 @@ func jitParserStateValue(value Scmer) *jitParserState {
 	return state
 }
 
-func jitParserPushValue(stateValue, value Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserPushValueNative(state *jitParserState, value Scmer) {
 	state.values = append(state.values, value)
-	return value
 }
 
-func jitParserDiscardValue(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserDiscardValueNative(state *jitParserState) {
 	if len(state.values) == 0 {
 		panic("jit: parser value stack underflow")
 	}
 	state.values[len(state.values)-1] = NewNil()
 	state.values = state.values[:len(state.values)-1]
-	return NewNil()
 }
 
-func jitParserCaptureValue(stateValue, inputValue, startValue, endValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserCaptureValueNative(state *jitParserState, inputValue Scmer, start, end int64) {
 	if len(state.values) == 0 {
 		panic("jit: parser capture without a value")
 	}
 	input := inputValue.String()
-	start, end := int(startValue.Int()), int(endValue.Int())
-	if start < 0 || end < start || end > len(input) {
+	lo, hi := int(start), int(end)
+	if lo < 0 || hi < lo || hi > len(input) {
 		panic("jit: invalid parser capture range")
 	}
-	result := NewSlice([]Scmer{NewString(input[start:end]), state.values[len(state.values)-1]})
+	result := NewSlice([]Scmer{NewString(input[lo:hi]), state.values[len(state.values)-1]})
 	state.values[len(state.values)-1] = result
-	return result
-}
-
-func jitParserEnterRule(stateValue, ruleValue, successValue, failureValue, positionValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
-	ruleID := int(ruleValue.Int())
-	if ruleID < 0 || ruleID >= len(state.program.rules) {
-		panic("jit: parser rule index out of range")
-	}
-	rule := &state.program.rules[ruleID]
-	frame := jitParserCallFrame{
-		rule: ruleID, success: int(successValue.Int()), failure: int(failureValue.Int()),
-		position: int(positionValue.Int()), valueBase: len(state.values), bindingBase: len(state.bindings),
-		mutationBase: len(state.mutations), memoize: state.program.memoRuleIndex[ruleID] >= 0,
-	}
-	state.frames = append(state.frames, frame)
-	for range rule.bindings {
-		state.bindings = append(state.bindings, NewNil())
-	}
-	return NewNil()
 }
 
 func jitParserPushRuleFrame(state *jitParserState, ruleID, success, failure, position int, memoInitial, transient bool) {
@@ -1077,21 +1052,7 @@ func jitParserCompleteRule(state *jitParserState, position int, value Scmer, suc
 	return int64(frame.rule), int64(frame.position), true
 }
 
-func jitParserBindingValueNative(stateValue Scmer, binding int64) Scmer {
-	state := jitParserStateValue(stateValue)
-	if len(state.frames) == 0 {
-		panic("jit: parser binding outside a rule")
-	}
-	frame := state.frames[len(state.frames)-1]
-	index := frame.bindingBase + int(binding)
-	if index < frame.bindingBase || index >= len(state.bindings) {
-		panic("jit: parser binding index outside a rule")
-	}
-	return state.bindings[index]
-}
-
-func jitParserBindingValueForRuleNative(stateValue Scmer, ruleID, binding int64) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserBindingValueForRuleNative(state *jitParserState, ruleID, binding int64) Scmer {
 	for index := len(state.frames) - 1; index >= 0; index-- {
 		frame := state.frames[index]
 		if int64(frame.rule) != ruleID {
@@ -1106,8 +1067,7 @@ func jitParserBindingValueForRuleNative(stateValue Scmer, ruleID, binding int64)
 	panic("jit: parser lexical rule is not active")
 }
 
-func jitParserRuleValueNative(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserRuleValueNative(state *jitParserState) Scmer {
 	if len(state.frames) == 0 {
 		panic("jit: parser value outside a rule")
 	}
@@ -1118,8 +1078,7 @@ func jitParserRuleValueNative(stateValue Scmer) Scmer {
 	return state.values[len(state.values)-1]
 }
 
-func jitParserReturnRuleValueNative(stateValue Scmer, position int64, value Scmer) (int64, int64, bool) {
-	state := jitParserStateValue(stateValue)
+func jitParserReturnRuleValueNative(state *jitParserState, position int64, value Scmer) (int64, int64, bool) {
 	// Parser actions cross from the nested generated expression into the parser
 	// machine state. Lists must own Go-managed backing storage at that boundary;
 	// an inlined variadic producer may otherwise describe its transient call
@@ -1146,40 +1105,34 @@ func jitParserReleaseStateNative(programValue, stateValue Scmer) {
 	program.releaseState(jitParserStateValue(stateValue))
 }
 
-func jitParserFinish(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserFinish(state *jitParserState) Scmer {
 	if len(state.values) != 1 || len(state.frames) != 0 {
 		panic("jit: parser finished with an invalid machine stack")
 	}
 	return state.values[0]
 }
 
-func jitParserBindValue(stateValue Scmer, binding Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserBindValueNative(state *jitParserState, binding int64) {
 	if len(state.frames) == 0 || len(state.values) == 0 {
 		panic("jit: parser binding outside a rule")
 	}
 	frame := &state.frames[len(state.frames)-1]
-	index := frame.bindingBase + int(binding.Int())
+	index := frame.bindingBase + int(binding)
 	if index < frame.bindingBase || index >= len(state.bindings) {
 		panic("jit: parser binding index outside a rule")
 	}
 	state.mutations = append(state.mutations, jitParserMutation{index: index, old: state.bindings[index]})
 	state.bindings[index] = state.values[len(state.values)-1]
-	return state.values[len(state.values)-1]
 }
 
-func jitParserPushCheckpoint(stateValue, position Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserPushCheckpointNative(state *jitParserState, position int64) {
 	state.checkpoints = append(state.checkpoints, jitParserCheckpoint{
-		position: int(position.Int()), valueLen: len(state.values), mutationLen: len(state.mutations), markLen: len(state.marks),
+		position: int(position), valueLen: len(state.values), mutationLen: len(state.mutations), markLen: len(state.marks),
 		positionLen: len(state.positions),
 	})
-	return position
 }
 
-func jitParserRestoreCheckpoint(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserRestoreCheckpointNative(state *jitParserState) int64 {
 	if len(state.checkpoints) == 0 {
 		panic("jit: parser checkpoint underflow")
 	}
@@ -1193,38 +1146,34 @@ func jitParserRestoreCheckpoint(stateValue Scmer) Scmer {
 	state.values = state.values[:checkpoint.valueLen]
 	state.marks = state.marks[:checkpoint.markLen]
 	state.positions = state.positions[:checkpoint.positionLen]
-	return NewInt(int64(checkpoint.position))
+	return int64(checkpoint.position)
 }
 
-func jitParserCommitCheckpoint(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserCommitCheckpointNative(state *jitParserState) {
 	if len(state.checkpoints) == 0 {
 		panic("jit: parser checkpoint underflow")
 	}
 	state.checkpoints = state.checkpoints[:len(state.checkpoints)-1]
-	return NewNil()
 }
 
-func jitParserCheckpointPosition(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserCheckpointPositionNative(state *jitParserState) int64 {
 	if len(state.checkpoints) == 0 {
 		panic("jit: parser checkpoint underflow")
 	}
-	return NewInt(int64(state.checkpoints[len(state.checkpoints)-1].position))
+	return int64(state.checkpoints[len(state.checkpoints)-1].position)
 }
 
-func jitParserCommitProgress(stateValue, positionValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserCommitProgressNative(state *jitParserState, position int64) bool {
 	if len(state.checkpoints) == 0 {
 		panic("jit: parser checkpoint underflow")
 	}
 	checkpoint := state.checkpoints[len(state.checkpoints)-1]
-	if checkpoint.position == int(positionValue.Int()) {
-		jitParserRestoreCheckpoint(stateValue)
-		return NewBool(false)
+	if checkpoint.position == int(position) {
+		jitParserRestoreCheckpointNative(state)
+		return false
 	}
-	jitParserCommitCheckpoint(stateValue)
-	return NewBool(true)
+	jitParserCommitCheckpointNative(state)
+	return true
 }
 
 // jitParserMemoFence bounds the memo table around one iteration of a `*` node
@@ -1304,37 +1253,31 @@ func jitParserMemoCompactNative(state *jitParserState, position int64) {
 	fence.pos = end
 }
 
-func jitParserPushPosition(stateValue, positionValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
-	state.positions = append(state.positions, int(positionValue.Int()))
-	return NewNil()
+func jitParserPushPositionNative(state *jitParserState, position int64) {
+	state.positions = append(state.positions, int(position))
 }
 
-func jitParserPopPosition(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserPopPositionNative(state *jitParserState) int64 {
 	if len(state.positions) == 0 {
 		panic("jit: parser position stack underflow")
 	}
 	position := state.positions[len(state.positions)-1]
 	state.positions = state.positions[:len(state.positions)-1]
-	return NewInt(int64(position))
+	return int64(position)
 }
 
-func jitParserPushMark(stateValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserPushMarkNative(state *jitParserState) {
 	state.marks = append(state.marks, len(state.values))
-	return NewNil()
 }
 
-func jitParserMergeMark(stateValue, ignoreValue Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserMergeMarkNative(state *jitParserState, ignore bool) {
 	if len(state.marks) == 0 {
 		panic("jit: parser value mark underflow")
 	}
 	base := state.marks[len(state.marks)-1]
 	state.marks = state.marks[:len(state.marks)-1]
 	var result Scmer
-	if ignoreValue.Bool() {
+	if ignore {
 		result = NewNil()
 	} else {
 		values := make([]Scmer, len(state.values)-base)
@@ -1343,12 +1286,10 @@ func jitParserMergeMark(stateValue, ignoreValue Scmer) Scmer {
 	}
 	state.values = state.values[:base]
 	state.values = append(state.values, result)
-	return result
 }
 
-func jitParserRecordFailure(stateValue, position, expected Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
-	pos := int(position.Int())
+func jitParserRecordFailureNative(state *jitParserState, position int64, expected Scmer) {
+	pos := int(position)
 	if pos > state.farthest {
 		state.farthest = pos
 		state.expected = state.expected[:0]
@@ -1356,11 +1297,9 @@ func jitParserRecordFailure(stateValue, position, expected Scmer) Scmer {
 	if pos == state.farthest && len(state.expected) < 8 {
 		state.expected = append(state.expected, expected.String())
 	}
-	return NewNil()
 }
 
-func jitParserPanic(stateValue, input Scmer) Scmer {
-	state := jitParserStateValue(stateValue)
+func jitParserPanic(state *jitParserState, input Scmer) Scmer {
 	position := state.farthest
 	if position < 0 {
 		position = 0
@@ -1414,8 +1353,7 @@ func jitParserEnterRuleNative(state *jitParserState, ruleValue, success, failure
 	return 0, position, false
 }
 
-func jitParserReturnRuleNative(stateValue Scmer, position int64, success bool) (int64, int64, bool) {
-	state := jitParserStateValue(stateValue)
+func jitParserReturnRuleNative(state *jitParserState, position int64, success bool) (int64, int64, bool) {
 	value := NewNil()
 	if success {
 		if len(state.frames) == 0 {
@@ -1432,62 +1370,6 @@ func jitParserReturnRuleNative(stateValue Scmer, position int64, success bool) (
 		}
 	}
 	return jitParserCompleteRule(state, int(position), value, success)
-}
-
-func jitParserBindValueNative(state Scmer, binding int64) {
-	jitParserBindValue(state, NewInt(binding))
-}
-
-func jitParserPushCheckpointNative(state Scmer, position int64) {
-	jitParserPushCheckpoint(state, NewInt(position))
-}
-
-func jitParserRestoreCheckpointNative(state Scmer) int64 {
-	return jitParserRestoreCheckpoint(state).Int()
-}
-
-func jitParserCommitCheckpointNative(state Scmer) {
-	jitParserCommitCheckpoint(state)
-}
-
-func jitParserCheckpointPositionNative(state Scmer) int64 {
-	return jitParserCheckpointPosition(state).Int()
-}
-
-func jitParserCommitProgressNative(state Scmer, position int64) bool {
-	return jitParserCommitProgress(state, NewInt(position)).Bool()
-}
-
-func jitParserPushPositionNative(state Scmer, position int64) {
-	jitParserPushPosition(state, NewInt(position))
-}
-
-func jitParserPopPositionNative(state Scmer) int64 {
-	return jitParserPopPosition(state).Int()
-}
-
-func jitParserMergeMarkNative(state Scmer, ignore bool) {
-	jitParserMergeMark(state, NewBool(ignore))
-}
-
-func jitParserCaptureValueNative(state, input Scmer, start, end int64) {
-	jitParserCaptureValue(state, input, NewInt(start), NewInt(end))
-}
-
-func jitParserRecordFailureNative(state Scmer, position int64, expected Scmer) {
-	jitParserRecordFailure(state, NewInt(position), expected)
-}
-
-func jitParserPushValueNative(state, value Scmer) {
-	jitParserPushValue(state, value)
-}
-
-func jitParserDiscardValueNative(state Scmer) {
-	jitParserDiscardValue(state)
-}
-
-func jitParserPushMarkNative(state Scmer) {
-	jitParserPushMark(state)
 }
 
 func jitParserAtBreakNative(input Scmer, position int64) bool {

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -218,12 +218,32 @@ func (emitter *jitParserEmitter) emitVoid(fn any, args ...JITValueDesc) {
 	emitter.ctx.EmitGoCallVoid(GoFuncAddr(fn), args)
 }
 
+// emitStateVoid emits a void Go-helper call taking the raw *jitParserState as
+// its first argument, materialized fresh from the boxed state and released
+// after the call. The parser helpers dropped their boxed-Scmer state parameter
+// (which cost an unbox + type assert on every emitted call) for this pointer.
+func (emitter *jitParserEmitter) emitStateVoid(fn any, args ...JITValueDesc) {
+	sp := emitter.statePointer()
+	emitter.emitVoid(fn, append([]JITValueDesc{sp}, args...)...)
+	emitter.ctx.FreeDesc(&sp)
+}
+
+// emitStateScalar is emitStateVoid for a helper returning result words.
+func (emitter *jitParserEmitter) emitStateScalar(fn any, numResultWords int, args ...JITValueDesc) JITValueDesc {
+	sp := emitter.statePointer()
+	out := emitter.ctx.EmitGoCallScalar(GoFuncAddr(fn), append([]JITValueDesc{sp}, args...), numResultWords)
+	emitter.ctx.FreeDesc(&sp)
+	return out
+}
+
 func (emitter *jitParserEmitter) pushValue(value JITValueDesc) {
 	original := value
 	if value.Loc != LocRegPair && value.Loc != LocStackPair && value.Loc != LocInputPair {
 		value = emitter.immPair(value.Imm)
 	}
-	emitter.emitVoid(jitParserPushValueNative, emitter.state, value)
+	sp := emitter.statePointer()
+	emitter.emitVoid(jitParserPushValueNative, sp, value)
+	emitter.ctx.FreeDesc(&sp)
 	if value.Loc == LocRegPair {
 		emitter.ctx.FreeDesc(&value)
 	}
@@ -233,23 +253,31 @@ func (emitter *jitParserEmitter) pushValue(value JITValueDesc) {
 }
 
 func (emitter *jitParserEmitter) discardValue() {
-	emitter.emitVoid(jitParserDiscardValueNative, emitter.state)
+	sp := emitter.statePointer()
+	emitter.emitVoid(jitParserDiscardValueNative, sp)
+	emitter.ctx.FreeDesc(&sp)
 }
 
 func (emitter *jitParserEmitter) pushCheckpoint() {
 	position := emitter.loadPosition()
-	emitter.emitVoid(jitParserPushCheckpointNative, emitter.state, position)
+	sp := emitter.statePointer()
+	emitter.emitVoid(jitParserPushCheckpointNative, sp, position)
+	emitter.ctx.FreeDesc(&sp)
 	emitter.ctx.FreeDesc(&position)
 }
 
 func (emitter *jitParserEmitter) restoreCheckpoint() {
-	position := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserRestoreCheckpointNative), []JITValueDesc{emitter.state}, 1)
+	sp := emitter.statePointer()
+	position := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserRestoreCheckpointNative), []JITValueDesc{sp}, 1)
+	emitter.ctx.FreeDesc(&sp)
 	position.Type = tagInt
 	emitter.storePosition(position)
 }
 
 func (emitter *jitParserEmitter) commitCheckpoint() {
-	emitter.emitVoid(jitParserCommitCheckpointNative, emitter.state)
+	sp := emitter.statePointer()
+	emitter.emitVoid(jitParserCommitCheckpointNative, sp)
+	emitter.ctx.FreeDesc(&sp)
 }
 
 func (emitter *jitParserEmitter) substringAtPosition() JITValueDesc {
@@ -351,7 +379,7 @@ func (emitter *jitParserEmitter) emitTerminal(node *jitParserNode, rule int, suc
 	emitter.ctx.MarkLabel(failed)
 	expected := emitter.immPair(NewString(node.description))
 	position := emitter.loadPosition()
-	emitter.emitVoid(jitParserRecordFailureNative, emitter.state, position, expected)
+	emitter.emitStateVoid(jitParserRecordFailureNative, position, expected)
 	emitter.ctx.FreeDesc(&position)
 	emitter.ctx.FreeDesc(&expected)
 	emitter.ctx.EmitJmp(failure)
@@ -361,7 +389,7 @@ func (emitter *jitParserEmitter) emitTerminal(node *jitParserNode, rule int, suc
 func (emitter *jitParserEmitter) emitSequence(node *jitParserNode, rule int, success, failure JITLabel) {
 	emitter.pushCheckpoint()
 	if !node.ignoreResult {
-		emitter.emitVoid(jitParserPushMarkNative, emitter.state)
+		emitter.emitStateVoid(jitParserPushMarkNative)
 	}
 	failed := emitter.ctx.ReserveLabel()
 	for _, child := range node.children {
@@ -370,7 +398,7 @@ func (emitter *jitParserEmitter) emitSequence(node *jitParserNode, rule int, suc
 		emitter.ctx.MarkLabel(next)
 	}
 	if !node.ignoreResult {
-		emitter.emitVoid(jitParserMergeMarkNative, emitter.state, jitParserBoolScalar(false))
+		emitter.emitStateVoid(jitParserMergeMarkNative, jitParserBoolScalar(false))
 	}
 	emitter.commitCheckpoint()
 	emitter.ctx.EmitJmp(success)
@@ -509,7 +537,7 @@ func (emitter *jitParserEmitter) emitBind(node *jitParserNode, rule int, success
 	accepted := emitter.ctx.ReserveLabel()
 	emitter.emitNode(node.children[0], rule, accepted, failure)
 	emitter.ctx.MarkLabel(accepted)
-	emitter.emitVoid(jitParserBindValueNative, emitter.state, jitParserScalar(int64(node.binding)))
+	emitter.emitStateVoid(jitParserBindValueNative, jitParserScalar(int64(node.binding)))
 	if node.ignoreResult {
 		emitter.discardValue()
 	}
@@ -522,14 +550,14 @@ func (emitter *jitParserEmitter) emitCapture(node *jitParserNode, rule int, succ
 	emitter.emitSkip(rule, skipped)
 	emitter.ctx.MarkLabel(skipped)
 	start := emitter.loadPosition()
-	emitter.emitVoid(jitParserPushPositionNative, emitter.state, start)
+	emitter.emitStateVoid(jitParserPushPositionNative, start)
 	emitter.ctx.FreeDesc(&start)
 	accepted, rejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 	emitter.emitNode(node.children[0], rule, accepted, rejected)
 	emitter.ctx.MarkLabel(accepted)
-	start = emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserPopPositionNative), []JITValueDesc{emitter.state}, 1)
+	start = emitter.emitStateScalar(jitParserPopPositionNative, 1)
 	end := emitter.loadPosition()
-	emitter.emitVoid(jitParserCaptureValueNative, emitter.state, emitter.input, start, end)
+	emitter.emitStateVoid(jitParserCaptureValueNative, emitter.input, start, end)
 	emitter.ctx.FreeDesc(&start)
 	emitter.ctx.FreeDesc(&end)
 	emitter.commitCheckpoint()
@@ -906,7 +934,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	}
 	emitter.pushCheckpoint()
 	if !node.ignoreResult {
-		emitter.emitVoid(jitParserPushMarkNative, emitter.state)
+		emitter.emitStateVoid(jitParserPushMarkNative)
 	}
 	if node.fenceMemo {
 		emitter.emitMemoFencePush()
@@ -916,7 +944,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.emitNode(node.children[0], rule, firstAccepted, firstRejected)
 	emitter.ctx.MarkLabel(firstAccepted)
 	position := emitter.loadPosition()
-	progress := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserCommitProgressNative), []JITValueDesc{emitter.state, position}, 1)
+	progress := emitter.emitStateScalar(jitParserCommitProgressNative, 1, position)
 	emitter.ctx.FreeDesc(&position)
 	emitter.ctx.EmitCmpRegImm32(progress.Reg, 0)
 	emitter.ctx.FreeDesc(&progress)
@@ -946,7 +974,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 	emitter.emitNode(node.children[0], rule, iterationAccepted, iterationRejected)
 	emitter.ctx.MarkLabel(iterationAccepted)
 	position = emitter.loadPosition()
-	progress = emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserCommitProgressNative), []JITValueDesc{emitter.state, position}, 1)
+	progress = emitter.emitStateScalar(jitParserCommitProgressNative, 1, position)
 	emitter.ctx.FreeDesc(&position)
 	emitter.ctx.EmitCmpRegImm32(progress.Reg, 0)
 	emitter.ctx.FreeDesc(&progress)
@@ -960,7 +988,7 @@ func (emitter *jitParserEmitter) emitRepeat(node *jitParserNode, rule int, succe
 		emitter.emitMemoFenceExit()
 	}
 	if !node.ignoreResult {
-		emitter.emitVoid(jitParserMergeMarkNative, emitter.state, jitParserBoolScalar(false))
+		emitter.emitStateVoid(jitParserMergeMarkNative, jitParserBoolScalar(false))
 	}
 	emitter.commitCheckpoint()
 	emitter.ctx.EmitJmp(success)
@@ -979,24 +1007,24 @@ func (emitter *jitParserEmitter) emitExclude(node *jitParserNode, rule int, succ
 	emitter.ctx.EmitJmp(failure)
 	emitter.ctx.MarkLabel(mainAccepted)
 	continuation := emitter.loadPosition()
-	emitter.emitVoid(jitParserPushPositionNative, emitter.state, continuation)
+	emitter.emitStateVoid(jitParserPushPositionNative, continuation)
 	emitter.ctx.FreeDesc(&continuation)
 	for _, excluded := range node.children[1:] {
-		start := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserCheckpointPositionNative), []JITValueDesc{emitter.state}, 1)
+		start := emitter.emitStateScalar(jitParserCheckpointPositionNative, 1)
 		emitter.storePosition(start)
 		emitter.pushCheckpoint()
 		excludedAccepted, excludedRejected := emitter.ctx.ReserveLabel(), emitter.ctx.ReserveLabel()
 		emitter.emitNode(excluded, rule, excludedAccepted, excludedRejected)
 		emitter.ctx.MarkLabel(excludedAccepted)
 		emitter.restoreCheckpoint()
-		discardedPosition := emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserPopPositionNative), []JITValueDesc{emitter.state}, 1)
+		discardedPosition := emitter.emitStateScalar(jitParserPopPositionNative, 1)
 		emitter.ctx.FreeDesc(&discardedPosition)
 		emitter.restoreCheckpoint()
 		emitter.ctx.EmitJmp(failure)
 		emitter.ctx.MarkLabel(excludedRejected)
 		emitter.restoreCheckpoint()
 	}
-	continuation = emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserPopPositionNative), []JITValueDesc{emitter.state}, 1)
+	continuation = emitter.emitStateScalar(jitParserPopPositionNative, 1)
 	emitter.storePosition(continuation)
 	emitter.commitCheckpoint()
 	emitter.ctx.EmitJmp(success)
@@ -1155,7 +1183,7 @@ func jitEmitParserProgramCore(ctx *JITContext, program *jitParserProgram, input,
 	ctx.EmitJump(CondNotEqual, failed)
 	resultOff := ctx.AllocStack(16)
 	done := ctx.ReserveLabel()
-	out := ctx.EmitGoCallScalar(GoFuncAddr(jitParserFinish), []JITValueDesc{emitter.state}, 2)
+	out := emitter.emitStateScalar(jitParserFinish, 2)
 	out.Type = JITTypeUnknown
 	ctx.EmitStoreScmerToStack(out, resultOff)
 	ctx.FreeDesc(&out)
@@ -1175,7 +1203,7 @@ func jitEmitParserProgramCore(ctx *JITContext, program *jitParserProgram, input,
 	ctx.EmitJmp(failed)
 
 	ctx.MarkLabel(failed)
-	panicResult := ctx.EmitGoCallScalar(GoFuncAddr(jitParserPanic), []JITValueDesc{emitter.state, emitter.input}, 2)
+	panicResult := emitter.emitStateScalar(jitParserPanic, 2, emitter.input)
 	panicResult.Type = JITTypeUnknown
 	ctx.EmitStoreScmerToStack(panicResult, resultOff)
 	ctx.FreeDesc(&panicResult)
@@ -1193,7 +1221,7 @@ func (emitter *jitParserEmitter) emitRuleReturn(ruleID int, success bool) {
 		rule := &emitter.program.rules[ruleID]
 		var value JITValueDesc
 		if rule.generator.IsNil() {
-			value = emitter.ctx.EmitGoCallScalar(GoFuncAddr(jitParserRuleValueNative), []JITValueDesc{emitter.state}, 2)
+			value = emitter.emitStateScalar(jitParserRuleValueNative, 2)
 			value.Type = JITTypeUnknown
 		} else {
 			generatorAlloc := emitter.ctx.SnapshotAllocState()
@@ -1208,14 +1236,16 @@ func (emitter *jitParserEmitter) emitRuleReturn(ruleID int, success bool) {
 				lexicalRule := &emitter.program.rules[lexicalRuleID]
 				args := make([]JITValueDesc, len(lexicalRule.bindings))
 				for index := range args {
+					sp := emitter.statePointer()
 					callArgs := []JITValueDesc{
-						emitter.state, jitParserScalar(int64(lexicalRuleID)), jitParserScalar(int64(index)),
+						sp, jitParserScalar(int64(lexicalRuleID)), jitParserScalar(int64(index)),
 					}
 					var wordsBuf [16]goCallArgWord
 					words := emitter.ctx.flattenArgs(callArgs, &wordsBuf)
 					off := emitter.ctx.AllocSpill(16)
 					emitter.ctx.setStackPointer(jitStackRootFrameBP, off, true)
 					emitter.ctx.EmitGoCallToFrame(GoFuncAddr(jitParserBindingValueForRuleNative), words, []int32{off, off + 8})
+					emitter.ctx.FreeDesc(&sp)
 					args[index] = JITValueDesc{Loc: LocStackPair, Type: JITTypeUnknown, StackOff: off, Rooted: true}
 				}
 				frameEnv := &JITEnv{Vars: make(map[Symbol]JITValueDesc, len(lexicalRule.bindings)), Numbered: args, Outer: bindingEnv}
@@ -1264,10 +1294,12 @@ func (emitter *jitParserEmitter) emitRuleReturn(ruleID int, success bool) {
 			value = jitCopyScmerToPair(emitter.ctx, value)
 		}
 		value = jitRootScmer(emitter.ctx, value)
+		sp := emitter.statePointer()
 		var argsBuf [16]goCallArgWord
-		args := emitter.ctx.flattenArgs([]JITValueDesc{emitter.state, position, value}, &argsBuf)
+		args := emitter.ctx.flattenArgs([]JITValueDesc{sp, position, value}, &argsBuf)
 		var resultsBuf [16]Reg
 		results := emitter.ctx.EmitGoCall(GoFuncAddr(jitParserReturnRuleValueNative), args, 3, &resultsBuf, nil)
+		emitter.ctx.FreeDesc(&sp)
 		emitter.ctx.FreeDesc(&value)
 		emitter.ctx.FreeDesc(&position)
 		emitter.ctx.EmitStoreRegMem(results[0], emitter.ctx.StackReg, emitter.continuationOff)
@@ -1280,10 +1312,12 @@ func (emitter *jitParserEmitter) emitRuleReturn(ruleID int, success bool) {
 		emitter.ctx.EmitJmp(emitter.ruleLabels[ruleID])
 		return
 	}
+	sp := emitter.statePointer()
 	var argsBuf [16]goCallArgWord
-	args := emitter.ctx.flattenArgs([]JITValueDesc{emitter.state, position, jitParserBoolScalar(success)}, &argsBuf)
+	args := emitter.ctx.flattenArgs([]JITValueDesc{sp, position, jitParserBoolScalar(success)}, &argsBuf)
 	var resultsBuf [16]Reg
 	results := emitter.ctx.EmitGoCall(GoFuncAddr(jitParserReturnRuleNative), args, 3, &resultsBuf, nil)
+	emitter.ctx.FreeDesc(&sp)
 	emitter.ctx.FreeDesc(&position)
 	emitter.ctx.EmitStoreRegMem(results[0], emitter.ctx.StackReg, emitter.continuationOff)
 	emitter.ctx.EmitStoreRegMem(results[1], emitter.ctx.StackReg, emitter.positionOff)


### PR DESCRIPTION
Follow-up to #768, toward parsing large `INSERT ... VALUES` faster than MariaDB.

## What

Every emitted parser-helper call took the machine state as a **boxed `Scmer`**
(`tagAny` wrapping `*jitParserState`) and re-derived the real pointer on entry
via `jitParserStateValue`: a tag check, a `*any` dereference, an itab
type-assert and a nil check — on every one of the thousands of helper calls a
single parse makes. `jitParserStateValue` + `Scmer.Any` + `Scmer.GetTag` were
~13–20 % of a 2000-row INSERT parse in the profile.

## How

The ~20 state helpers now take `state *jitParserState` directly. The two-layer
`jitParserPushCheckpoint(stateValue Scmer)` core + `…Native(state Scmer, …)`
wrapper split collapses to one function per helper. The emitter materialises
the raw pointer once per call site from the boxed state — the existing
`statePointer()`, already used by the memo-fence and rule-entry helpers —
through two new helpers `emitStateVoid` / `emitStateScalar`. Dead
`jitParserEnterRule` and `jitParserBindingValueNative` removed. `jit_parser.go`
loses ~85 lines net.

No grammar or generator change — pure JIT-emission + helper plumbing, per the
invariant that the SCM grammar is fixed declaration and the intelligence lives
in the static analysis + JIT.

## A/B (parse-only, `parse_sql` in a loop, 2000-row `INSERT INTO t VALUES (…)`, same lib)

| build | ms / parse |
|---|---|
| master (#768) | 377 (375–381, 5 runs) |
| this branch  | **264 (261–267)** — **−30 %** |

## Tests

`go test ./scm` green, `go vet ./scm` clean. A 117-suite planner/sql/execution
sweep: 2125 assertions, zero critical failures, **zero `bad pointer` / GC
crashes** (the risk class for a pointer-threading change). Targeted:
`exists-session-var` 8/8, `exists-scalar-probe-no-source` 7/7,
`name-resolution-scopes` 40/40, `trigger-session-vars` 11/11. Smoke:
escaped-quote INSERT (`'z''s'` → `z's`), aggregates, `ALTER TABLE MODIFY
COLUMN … COMMENT`, filtered/ordered SELECT — all correct.

## Next

Streaming-repeat emission (drop the per-row merge copy), then a literal
fast-recognizer synthesised from `sql_expression`'s literal alternatives so a
bare `42` in VALUES skips the 7-level precedence machine entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV