### PR TITLE
Test multi-shard operational recovery and fix hidden WAL replay

### DIFF
--- a/storage/shard.go
+++ b/storage/shard.go
@@ -407,11 +407,6 @@ func (u *storageShard) load(t *table) {
 	}
 
 	if t.PersistencyMode == Safe || t.PersistencyMode == Logged {
-		// WAL recids follow the persisted main rows. Resolve that boundary before
-		// replaying inserts: with lazy columns main_count is otherwise still zero,
-		// so an insert-hidden entry would tombstone committed main rows and expose
-		// the uncommitted delta rows after a crash.
-		u.ensureMainCount(true)
 		// Replaying the log mutates inserts/deletions; caller holds u.mu.Lock
 		var log chan interface{}
 		log, u.logfile = u.t.schema.persistence.ReplayLog(u.uuid.String())
@@ -424,8 +419,16 @@ func (u *storageShard) load(t *table) {
 			case LogEntryUndelete:
 				u.deletions.Set(uint(l.idx), false)
 			case LogEntryInsert:
+				// WAL insert recids follow the persisted main rows. Resolve that
+				// boundary only when replay actually contains inserts: eager loading
+				// here would defeat cold-column loading for every empty WAL.
+				u.ensureMainCount(true)
 				u.insertDatasetFromLog(l.cols, l.values)
 			case LogEntryInsertHidden:
+				// Hidden transactional inserts use the same RecID namespace. Without
+				// the persisted boundary they would tombstone committed main rows and
+				// expose uncommitted delta rows after a crash.
+				u.ensureMainCount(true)
 				firstRecid := u.main_count + uint32(len(u.inserts))
 				u.insertDatasetFromLog(l.cols, l.values)
 				for i := range l.values {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -407,6 +407,11 @@ func (u *storageShard) load(t *table) {
 	}
 
 	if t.PersistencyMode == Safe || t.PersistencyMode == Logged {
+		// WAL recids follow the persisted main rows. Resolve that boundary before
+		// replaying inserts: with lazy columns main_count is otherwise still zero,
+		// so an insert-hidden entry would tombstone committed main rows and expose
+		// the uncommitted delta rows after a crash.
+		u.ensureMainCount(true)
 		// Replaying the log mutates inserts/deletions; caller holds u.mu.Lock
 		var log chan interface{}
 		log, u.logfile = u.t.schema.persistence.ReplayLog(u.uuid.String())

--- a/storage/shard_rebuild_test.go
+++ b/storage/shard_rebuild_test.go
@@ -1277,6 +1277,49 @@ func TestEphemeralQueryShardLoadIgnoresPersistedHelperContents(t *testing.T) {
 	}
 }
 
+func TestEmptyWALReplayKeepsPersistedColumnsLazy(t *testing.T) {
+	dir, err := os.MkdirTemp("", "memcp-empty-wal-lazy-load-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	oldBasepath := Basepath
+	Basepath = dir
+	defer func() { Basepath = oldBasepath }()
+
+	Init(scm.Globalenv)
+	LoadDatabases()
+	defer databases.Remove("temptywallazy")
+
+	CreateDatabase("temptywallazy", false)
+	tbl, _ := CreateTable("temptywallazy", "items", Safe, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+
+	orig := tbl.Shards[0]
+	column := &StorageConst{count: 2, value: scm.NewInt(1)}
+	f := tbl.schema.persistence.WriteColumn(orig.uuid.String(), "id")
+	column.Serialize(f)
+	f.Close()
+	if orig.logfile != nil {
+		orig.logfile.Close()
+	}
+
+	reloaded := &storageShard{
+		uuid:         orig.uuid,
+		columns:      make(map[string]ColumnStorage),
+		deltaColumns: make(map[string]int),
+	}
+	reloaded.load(tbl)
+	defer reloaded.logfile.Close()
+
+	if reloaded.main_count != 0 {
+		t.Fatalf("empty WAL replay eagerly restored main_count=%d, want lazy zero", reloaded.main_count)
+	}
+	if reloaded.columns["id"] != nil {
+		t.Fatalf("empty WAL replay eagerly loaded id as %T", reloaded.columns["id"])
+	}
+}
+
 func TestCreateColumnBuiltinUpgradesExistingColumnToORC(t *testing.T) {
 	dir, err := os.MkdirTemp("", "memcp-createcolumn-orc-upgrade-*")
 	if err != nil {

--- a/tests/execution/concurrency/multishard-trigger-transaction.yaml
+++ b/tests/execution/concurrency/multishard-trigger-transaction.yaml
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Repeated mutation in one transaction remains live with trigger-maintained caches and multiple shards"
+  isolated: true
+
+setup:
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS mtt_file"
+  - sql: "DROP TABLE IF EXISTS mtt_entry"
+  - sql: |
+      CREATE TABLE mtt_file (
+        id INT PRIMARY KEY,
+        uploaded_at INT NOT NULL
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE mtt_entry (
+        id INT PRIMARY KEY,
+        file_id INT NOT NULL,
+        amount INT NOT NULL,
+        state VARCHAR(16) NOT NULL
+      ) ENGINE=safe
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "mtt_file") '("id" "uploaded_at")
+          (map (produceN 35) (lambda (i)
+            (list (+ i 1) (* (+ i 1) 100)))))
+        (insert (table "memcp-tests" "mtt_entry") '("id" "file_id" "amount" "state")
+          (map (produceN 35) (lambda (i)
+            (list (+ i 1) (+ i 1) (* (+ i 1) 10) "original"))))
+        (rebuild)
+        true)
+
+test_cases:
+  - name: "Materialize scalar order lookup and aggregate caches before transactional mutations"
+    sql: |
+      SELECT entry.id
+      FROM mtt_entry entry
+      ORDER BY (
+        SELECT file.uploaded_at
+        FROM mtt_file file
+        WHERE file.id = entry.file_id
+        LIMIT 1
+      ) DESC
+      LIMIT 1
+    expect:
+      rows: 1
+      data:
+        - id: 35
+
+  - name: "Materialize aggregate cache before transactional mutations"
+    sql: "SELECT COUNT(*) AS cnt, SUM(amount) AS total FROM mtt_entry"
+    expect:
+      rows: 1
+      data:
+        - cnt: 35
+          total: 6300
+
+  - name: "Update then delete replacement rows in the same transaction"
+    timeout: 5
+    steps:
+      - session_id: "mtt_overlap"
+        sql: "START TRANSACTION"
+      - session_id: "mtt_overlap"
+        sql: "UPDATE mtt_entry SET amount = amount + 1, state = 'pending' WHERE id <= 22"
+        expect:
+          affected_rows: 22
+      - session_id: "mtt_overlap"
+        sql: "DELETE FROM mtt_entry WHERE id IN (2, 12, 22, 32)"
+        expect:
+          affected_rows: 4
+      - session_id: "mtt_overlap"
+        sql: "ROLLBACK"

--- a/tests/execution/concurrency/multishard-trigger-transaction.yaml
+++ b/tests/execution/concurrency/multishard-trigger-transaction.yaml
@@ -85,3 +85,6 @@ test_cases:
           affected_rows: 4
       - session_id: "mtt_overlap"
         sql: "ROLLBACK"
+
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'

--- a/tests/integration/query-shapes/multishard-operational-writes.yaml
+++ b/tests/integration/query-shapes/multishard-operational-writes.yaml
@@ -275,6 +275,9 @@ test_cases:
           checksum: 630
           temporary_rows: 0
 
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS mow_seen"
   - sql: "DROP TABLE IF EXISTS mow_document"

--- a/tests/integration/query-shapes/multishard-operational-writes.yaml
+++ b/tests/integration/query-shapes/multishard-operational-writes.yaml
@@ -1,0 +1,283 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Operational notification, lease, upsert, and sparse DML shapes across shard boundaries"
+  isolated: true
+
+setup:
+  # Ten rows per shard makes every 35-45 row fixture exercise main and delta
+  # rows in several shards without making the suite expensive.
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS mow_seen"
+  - sql: "DROP TABLE IF EXISTS mow_document"
+  - sql: "DROP TABLE IF EXISTS mow_file"
+  - sql: "DROP TABLE IF EXISTS mow_lease"
+  - sql: "DROP TABLE IF EXISTS mow_path"
+  - sql: |
+      CREATE TABLE mow_file (
+        id INT PRIMARY KEY,
+        uploaded_at INT NOT NULL
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE mow_document (
+        id INT PRIMARY KEY,
+        file_id INT,
+        tenant_id INT,
+        state VARCHAR(16)
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE mow_seen (
+        account_id INT NOT NULL,
+        channel VARCHAR(32) NOT NULL,
+        view_name VARCHAR(64) NOT NULL,
+        item_id INT NOT NULL,
+        seen_at INT NOT NULL,
+        UNIQUE KEY mow_seen_identity (account_id, channel, view_name, item_id)
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE mow_lease (
+        name VARCHAR(64) PRIMARY KEY,
+        lastrun INT,
+        medianruntime DOUBLE
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE mow_path (
+        id INT PRIMARY KEY,
+        pathname VARCHAR(128) NOT NULL
+      ) ENGINE=safe
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "mow_file") '("id" "uploaded_at")
+          (map (produceN 35) (lambda (i) (list (+ i 1) (* (+ i 1) 10)))))
+        (insert (table "memcp-tests" "mow_document") '("id" "file_id" "tenant_id" "state")
+          (map (produceN 35) (lambda (i)
+            (list (+ i 1) (+ i 1) (+ (mod i 4) 1) "ready"))))
+        (insert (table "memcp-tests" "mow_path") '("id" "pathname")
+          (map (produceN 35) (lambda (i)
+            (list (+ i 1) (concat (if (< i 18) "queue/a/" "queue/b/") i)))))
+        (rebuild)
+        true)
+
+test_cases:
+  - name: "Ordered notification source crosses shards and keeps scalar lookup order"
+    sql: |
+      SELECT current_item.id
+      FROM (
+        SELECT document.id
+        FROM mow_document document
+        WHERE document.tenant_id IN (1, 2, 3, 4)
+        ORDER BY (
+          SELECT file.uploaded_at
+          FROM mow_file file
+          WHERE file.id = document.file_id
+          LIMIT 1
+        ) DESC, document.id DESC
+        LIMIT 1
+      ) current_item
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM mow_seen seen
+        WHERE seen.account_id = 112
+          AND seen.channel = 'mail'
+          AND seen.view_name = 'recent'
+          AND seen.item_id = current_item.id
+      )
+    expect:
+      rows: 1
+      data:
+        - id: 35
+
+  - name: "Insert-select records the current item in a later seen shard"
+    sql: |
+      INSERT INTO mow_seen (account_id, channel, view_name, item_id, seen_at)
+      SELECT 112, 'mail', 'recent', current_item.id, 1000
+      FROM (
+        SELECT document.id
+        FROM mow_document document
+        ORDER BY (
+          SELECT file.uploaded_at
+          FROM mow_file file
+          WHERE file.id = document.file_id
+          LIMIT 1
+        ) DESC, document.id DESC
+        LIMIT 1
+      ) current_item
+      WHERE NOT EXISTS (
+        SELECT 1 FROM mow_seen seen
+        WHERE seen.account_id = 112
+          AND seen.channel = 'mail'
+          AND seen.view_name = 'recent'
+          AND seen.item_id = current_item.id
+      )
+    expect:
+      affected_rows: 1
+
+  - name: "Repeated insert-select is suppressed by the composite identity"
+    sql: |
+      INSERT INTO mow_seen (account_id, channel, view_name, item_id, seen_at)
+      SELECT 112, 'mail', 'recent', current_item.id, 1001
+      FROM (
+        SELECT document.id
+        FROM mow_document document
+        ORDER BY document.id DESC
+        LIMIT 1
+      ) current_item
+      WHERE NOT EXISTS (
+        SELECT 1 FROM mow_seen seen
+        WHERE seen.account_id = 112
+          AND seen.channel = 'mail'
+          AND seen.view_name = 'recent'
+          AND seen.item_id = current_item.id
+      )
+    expect:
+      affected_rows: 0
+
+  - name: "Bulk notification markers span several shards"
+    sql: |
+      INSERT INTO mow_seen (account_id, channel, view_name, item_id, seen_at)
+      SELECT 112, 'mail', 'bulk', document.id, 1100
+      FROM mow_document document
+      WHERE document.id <= 25
+    expect:
+      affected_rows: 25
+
+  - name: "INSERT IGNORE skips duplicates but keeps non-conflicting rows across shards"
+    sql: |
+      INSERT IGNORE INTO mow_seen (account_id, channel, view_name, item_id, seen_at)
+      VALUES (112, 'mail', 'bulk', 10, 1200),
+             (112, 'mail', 'bulk', 26, 1200),
+             (112, 'mail', 'bulk', 27, 1200)
+    expect:
+      affected_rows: 2
+
+  - name: "MySQL upsert updates one composite identity without merging neighbours"
+    sql: |
+      INSERT INTO mow_seen (account_id, channel, view_name, item_id, seen_at)
+      VALUES (112, 'mail', 'bulk', 20, 1300)
+      ON DUPLICATE KEY UPDATE seen_at = VALUES(seen_at)
+    expect:
+      affected_rows: 2
+
+  - name: "Upsert kept every composite-key neighbour intact"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(CASE WHEN item_id = 20 AND seen_at = 1300 THEN 1 ELSE 0 END) AS updated
+      FROM mow_seen
+      WHERE account_id = 112 AND channel = 'mail' AND view_name = 'bulk'
+    expect:
+      rows: 1
+      data:
+        - cnt: 27
+          updated: 1
+
+  - name: "Sparse update reaches rows in every main shard"
+    sql: |
+      UPDATE mow_document
+      SET state = 'sent'
+      WHERE id IN (1, 10, 11, 20, 21, 30, 35)
+    expect:
+      affected_rows: 7
+
+  - name: "Sparse update changes exactly the selected rows"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS checksum FROM mow_document WHERE state = 'sent'"
+    expect:
+      rows: 1
+      data:
+        - cnt: 7
+          checksum: 128
+
+  - name: "Prefix delete crosses a shard boundary"
+    sql: "DELETE FROM mow_path WHERE pathname LIKE 'queue/a/%'"
+    expect:
+      affected_rows: 18
+
+  - name: "Prefix delete preserves the other prefix"
+    sql: "SELECT COUNT(*) AS cnt, MIN(id) AS first_id, MAX(id) AS last_id FROM mow_path"
+    expect:
+      rows: 1
+      data:
+        - cnt: 17
+          first_id: 19
+          last_id: 35
+
+  - name: "Cron-style lease insert runs under a MySQL WRITE lock"
+    steps:
+      - session_id: "mow_cron"
+        sql: "LOCK TABLES mow_lease WRITE"
+      - session_id: "mow_cron"
+        sql: "INSERT IGNORE INTO mow_lease(name, lastrun) VALUES ('notifications', 1005)"
+        expect:
+          affected_rows: 1
+      - session_id: "mow_cron"
+        sql: "UNLOCK TABLES"
+
+  - name: "Cron-style runtime update preserves a null initial average"
+    sql: |
+      UPDATE mow_lease
+      SET medianruntime = COALESCE(0.9 * medianruntime + 0.1 * 2.5, 2.5),
+          lastrun = 1010
+      WHERE name = 'notifications'
+    expect:
+      affected_rows: 1
+
+  - name: "Cron-style lease state is exact"
+    sql: "SELECT name, lastrun, medianruntime FROM mow_lease"
+    expect:
+      rows: 1
+      data:
+        - name: "notifications"
+          lastrun: 1010
+          medianruntime: 2.5
+
+  - name: "Mixed multi-shard DML rolls back as one transaction"
+    steps:
+      - session_id: "mow_rollback"
+        sql: "START TRANSACTION"
+      - session_id: "mow_rollback"
+        sql: "UPDATE mow_document SET state = 'temporary' WHERE id IN (1, 10, 11, 20, 21)"
+        expect:
+          affected_rows: 5
+      - session_id: "mow_rollback"
+        sql: "DELETE FROM mow_document WHERE id IN (2, 12, 22, 32)"
+        expect:
+          affected_rows: 4
+      - session_id: "mow_rollback"
+        sql: "INSERT INTO mow_document VALUES (36, 36, 1, 'temporary')"
+        expect:
+          affected_rows: 1
+      - session_id: "mow_rollback"
+        sql: "ROLLBACK"
+
+  - name: "Rollback restores row count, inserted row, and prior values"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(id) AS checksum,
+             SUM(CASE WHEN state = 'temporary' THEN 1 ELSE 0 END) AS temporary_rows
+      FROM mow_document
+    expect:
+      rows: 1
+      data:
+        - cnt: 35
+          checksum: 630
+          temporary_rows: 0
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS mow_seen"
+  - sql: "DROP TABLE IF EXISTS mow_document"
+  - sql: "DROP TABLE IF EXISTS mow_file"
+  - sql: "DROP TABLE IF EXISTS mow_lease"
+  - sql: "DROP TABLE IF EXISTS mow_path"

--- a/tests/performance/notification-membership-scaling.yaml
+++ b/tests/performance/notification-membership-scaling.yaml
@@ -280,6 +280,9 @@ test_cases:
           data:
             - id: 4000
 
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS nms_seen"
   - sql: "DROP TABLE IF EXISTS nms_assignment"

--- a/tests/performance/notification-membership-scaling.yaml
+++ b/tests/performance/notification-membership-scaling.yaml
@@ -26,6 +26,9 @@ metadata:
   isolated: true
 
 setup:
+  # Force the 4,000-row workload through many shards. Production relations are
+  # multi-shard, and notification planning/lookup bugs can hide in one shard.
+  - scm: '(settings "ShardSize" 100)'
   - sql: "DROP TABLE IF EXISTS nms_seen"
   - sql: "DROP TABLE IF EXISTS nms_assignment"
   - sql: "DROP TABLE IF EXISTS nms_location"

--- a/tests/storage/persistence/multishard-committed-recovery.yaml
+++ b/tests/storage/persistence/multishard-committed-recovery.yaml
@@ -1,0 +1,132 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Committed mixed DML and aggregates survive crash replay and rebuild across SAFE shards"
+  isolated: true
+
+setup:
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS mcr_entry"
+  - sql: |
+      CREATE TABLE mcr_entry (
+        id INT PRIMARY KEY,
+        bucket INT NOT NULL,
+        amount INT NOT NULL,
+        state VARCHAR(16) NOT NULL
+      ) ENGINE=safe
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "mcr_entry") '("id" "bucket" "amount" "state")
+          (map (produceN 35) (lambda (i)
+            (list (+ i 1) (mod i 4) (* (+ i 1) 10) "original"))))
+        (rebuild)
+        true)
+
+test_cases:
+  - name: "Commit mixed DML across main and delta shards"
+    steps:
+      - session_id: "mcr_committed"
+        sql: "START TRANSACTION"
+      - session_id: "mcr_committed"
+        sql: "UPDATE mcr_entry SET amount = amount + 5, state = 'committed' WHERE id IN (1, 10, 11, 20, 21, 30, 35)"
+        expect:
+          affected_rows: 7
+      - session_id: "mcr_committed"
+        sql: "DELETE FROM mcr_entry WHERE id IN (3, 13, 23, 33)"
+        expect:
+          affected_rows: 4
+      - session_id: "mcr_committed"
+        sql: "INSERT INTO mcr_entry VALUES (36, 0, 360, 'committed'), (37, 1, 370, 'committed')"
+        expect:
+          affected_rows: 2
+      - session_id: "mcr_committed"
+        sql: "COMMIT"
+
+  - name: "Committed mixed DML is exact before crash"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(id) AS id_sum,
+             SUM(amount) AS amount_sum,
+             SUM(CASE WHEN state = 'committed' THEN 1 ELSE 0 END) AS committed_rows
+      FROM mcr_entry
+    expect:
+      rows: 1
+      data:
+        - cnt: 33
+          id_sum: 631
+          amount_sum: 6345
+          committed_rows: 9
+
+  - name: "Materialize grouped facts before crash"
+    sql: "SELECT bucket, COUNT(*) AS cnt, SUM(amount) AS total FROM mcr_entry GROUP BY bucket ORDER BY bucket"
+    expect:
+      rows: 4
+
+  - name: "Hard crash after committed multi-shard DML"
+    scm: '(crash)'
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after committed transaction"
+    action: restart
+
+  - name: "Committed rows, updates, and delete masks survive WAL replay"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(id) AS id_sum,
+             SUM(amount) AS amount_sum,
+             SUM(CASE WHEN state = 'committed' THEN 1 ELSE 0 END) AS committed_rows
+      FROM mcr_entry
+    expect:
+      rows: 1
+      data:
+        - cnt: 33
+          id_sum: 631
+          amount_sum: 6345
+          committed_rows: 9
+
+  - name: "Recovered GROUP BY agrees with recovered base rows"
+    sql: |
+      SELECT SUM(bucket_count) AS total_rows, SUM(bucket_amount) AS total_amount
+      FROM (
+        SELECT bucket, COUNT(*) AS bucket_count, SUM(amount) AS bucket_amount
+        FROM mcr_entry
+        GROUP BY bucket
+      ) grouped
+    expect:
+      rows: 1
+      data:
+        - total_rows: 33
+          total_amount: 6345
+
+  - name: "Rebuild recovered main and delta shards"
+    scm: '(rebuild (table "memcp-tests" "mcr_entry") true true)'
+
+  - name: "Publish rebuilt recovery generation"
+    sql: "SHUTDOWN"
+
+  - name: "Rebuilt generation retains exact committed state"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS id_sum, SUM(amount) AS amount_sum FROM mcr_entry"
+    expect:
+      rows: 1
+      data:
+        - cnt: 33
+          id_sum: 631
+          amount_sum: 6345
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS mcr_entry"

--- a/tests/storage/persistence/multishard-committed-recovery.yaml
+++ b/tests/storage/persistence/multishard-committed-recovery.yaml
@@ -128,5 +128,8 @@ test_cases:
           id_sum: 631
           amount_sum: 6345
 
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'
+
 cleanup:
   - sql: "DROP TABLE IF EXISTS mcr_entry"

--- a/tests/storage/persistence/multishard-transaction-recovery.yaml
+++ b/tests/storage/persistence/multishard-transaction-recovery.yaml
@@ -95,3 +95,6 @@ test_cases:
           id_sum: 630
           amount_sum: 6300
           pending_rows: 0
+
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'

--- a/tests/storage/persistence/multishard-transaction-recovery.yaml
+++ b/tests/storage/persistence/multishard-transaction-recovery.yaml
@@ -1,0 +1,97 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Uncommitted ACID DML is discarded after a crash across SAFE shard boundaries"
+  isolated: true
+
+setup:
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS mtr_entry"
+  - sql: |
+      CREATE TABLE mtr_entry (
+        id INT PRIMARY KEY,
+        bucket INT NOT NULL,
+        amount INT NOT NULL,
+        state VARCHAR(16) NOT NULL
+      ) ENGINE=safe
+  - scm: |
+      (insert (table "memcp-tests" "mtr_entry") '("id" "bucket" "amount" "state")
+        (map (produceN 35) (lambda (i)
+          (list (+ i 1) (mod i 4) (* (+ i 1) 10) "original"))))
+  - scm: '(rebuild)'
+
+test_cases:
+  - name: "Seed spans four SAFE shards before restart"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS id_sum, SUM(amount) AS amount_sum FROM mtr_entry"
+    expect:
+      rows: 1
+      data:
+        - cnt: 35
+          id_sum: 630
+          amount_sum: 6300
+
+  - name: "Clean restart preserves every seed shard"
+    sql: "SHUTDOWN"
+
+  - name: "Seed checksums survive clean restart"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS id_sum, SUM(amount) AS amount_sum FROM mtr_entry"
+    expect:
+      rows: 1
+      data:
+        - cnt: 35
+          id_sum: 630
+          amount_sum: 6300
+
+  - name: "Prepare an uncommitted ACID transaction across shards"
+    steps:
+      - session_id: "mtr_uncommitted"
+        sql: "START ACID TRANSACTION"
+      - session_id: "mtr_uncommitted"
+        sql: "UPDATE mtr_entry SET amount = amount + 1000, state = 'pending' WHERE id <= 25"
+        expect:
+          affected_rows: 25
+      - session_id: "mtr_uncommitted"
+        sql: "DELETE FROM mtr_entry WHERE id IN (2, 12, 22, 32)"
+        expect:
+          affected_rows: 4
+      - session_id: "mtr_uncommitted"
+        sql: "INSERT INTO mtr_entry VALUES (36, 0, 360, 'pending'), (37, 1, 370, 'pending')"
+        expect:
+          affected_rows: 2
+
+  - name: "Crash before the transaction commits"
+    scm: '(crash)'
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after uncommitted transaction"
+    action: restart
+
+  - name: "Crash recovery discards the complete uncommitted transaction"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(id) AS id_sum,
+             SUM(amount) AS amount_sum,
+             SUM(CASE WHEN state = 'pending' THEN 1 ELSE 0 END) AS pending_rows
+      FROM mtr_entry
+    expect:
+      rows: 1
+      data:
+        - cnt: 35
+          id_sum: 630
+          amount_sum: 6300
+          pending_rows: 0


### PR DESCRIPTION
## Summary

- exercise operational notification, lease, upsert, sparse update/delete, trigger-cache, and transaction shapes with deliberately tiny shards
- cover committed and uncommitted ACID recovery across several SAFE shards, WAL replay, grouped reads, rebuild, and restart
- run the existing 4,000-row notification performance fixture across many shards instead of a single shard
- fix WAL replay so hidden ACID delta rows use the persisted main-row count as their RecID boundary

All suites which change `ShardSize` are isolated and explicitly restore the default before releasing the shared test process.

## Bug found test-first

The new crash test initially failed after an uncommitted ACID transaction:

- expected: 35 original rows, `amount_sum=6300`, no pending rows
- actual: 35 rows, `amount_sum=31300`, 25 uncommitted update versions visible

Persisted columns are loaded lazily. During shard startup, WAL replay therefore saw `main_count=0`; `insert-hidden` entries tombstoned committed main RecIDs starting at zero and left their uncommitted delta RecIDs visible. Loading one persisted column to establish `main_count` before replay preserves the WAL RecID namespace. The same test now passes and verifies exact pre-transaction checksums after a hard crash.

## Coverage added

- `ShardSize=10` operational DML across four or more shards
- correlated scalar notification ordering and anti-membership
- repeated `INSERT ... SELECT`, `INSERT IGNORE`, composite-key upsert
- sparse cross-shard UPDATE and DELETE
- MySQL WRITE-lock maintenance sequence
- rollback of mixed multi-shard DML
- trigger-maintained scalar/aggregate caches during repeated transaction mutation
- committed SAFE recovery, grouped verification, rebuild, and second restart
- uncommitted ACID UPDATE/DELETE/INSERT followed by hard crash
- notification membership performance with `ShardSize=100` and 4,000 source rows

## Verification

Targeted results:

- new uncommitted ACID recovery: 8/8
- new committed recovery: 11/11
- new operational write shapes: 17/17
- new trigger/transaction coverage: 4/4
- notification performance: 9/9
- existing transaction suite: 204/204
- adjacent SAFE/WAL/invalidation/crash suites: 145/145
- `go build -o memcp .`
- YAML parse and table-name checks

The first CI run exposed a test-environment leak: `isolated` serializes a suite but intentionally reuses the same MemCP process. The tiny `ShardSize` remained active, making the following existing 61,000-row concurrency suite create thousands of shards (`multishard.yaml`: 6m03 instead of about 1s). Every setting-changing suite now restores `ShardSize=60000`. The exact seven-suite shared-process sequence passes in 32.90s, including `multishard.yaml` again at about 1s. CI owns the complete suite.

## Performance regression follow-up

The first A/B run exposed an eager-load regression in the initial WAL fix: cold ungrouped SUM over 1,000,000 rows increased from 23.078ms to 370.996ms. `main_count` is now resolved only when replay encounters an insert entry; an empty WAL leaves all persisted columns cold. A dedicated Go test preserves this invariant.

Manual same-fixture A/B against current master after the fix:

- master: 20.640ms
- candidate: 17.764ms
- change: -13.9%

The multi-shard crash-recovery suite remains green (8/8).