### PR TITLE
Preserve transaction atomicity across triggers and rebuild recovery

### DIFF
--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -399,7 +399,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 						(list (list (symbol "insert") (list (symbol "table") schema tbl)
 							(cons (symbol "list") cols)
 							(cons (symbol "list") (map vals (lambda (row) (cons (symbol "list") (map row transform_trigger_expr)))))
-							(list (symbol "list")) (if ignore (list (symbol "lambda") '() 0) nil) false nil)))
+							(list (symbol "list")) (if ignore (list (symbol "lambda") '() 0) nil) false nil (symbol "tx"))))
 
 					/* INSERT INTO tbl (cols) <full SELECT> - stmt is (!insert_select tbl cols inner_select ignore) */
 					/* Reuses sql_select + build_queryplan_term (same as top-level INSERT...SELECT) */
@@ -443,7 +443,7 @@ arithmetic; leave expressions containing columns or functions untouched. */
 												(map select_names (lambda (name) (list (symbol "get_assoc") (symbol "item") name)))))
 										(list (symbol "list"))
 										(if ignore (list (symbol "lambda") '() 0) nil)
-										false nil)))
+										false nil (symbol "tx"))))
 							(build_queryplan_term (sql_expand_views inner_t policy) planning_session tx))))
 
 					/* UPDATE table SET ... WHERE ... - stmt is (!update tbl assignments where) */

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -137,7 +137,7 @@ func (s *storageShard) nextForMaintenanceLocked(deletedRecid *uint32) *storageSh
 
 // syncNextVisibilityLocked mirrors the final visibility of one source recid
 // when transaction commit/rollback changes it after the rebuild snapshot. A
-// A successor already tracked by the same transaction applies its own masks
+// successor already tracked by the same transaction applies its own masks
 // and must not be locked recursively here. Caller must hold s.mu.Lock().
 func (s *storageShard) syncNextVisibilityLocked(oldRecid uint32, trackedByTx map[*storageShard]struct{}) {
 	current := s
@@ -209,10 +209,15 @@ func (s *storageShard) catchUpRebuildLocked(next *storageShard, snapshotInsertCo
 			return
 		}
 		deleted := s.deletions.Get(uint(oldRecid))
+		wasDeleted := next.deletions.Get(uint(newRecid))
 		next.deletions.Set(uint(newRecid), deleted)
 		next.rollbackProtected.Set(uint(newRecid), s.rollbackProtected.Get(uint(oldRecid)))
-		if deleted && (next.t.PersistencyMode == Safe || next.t.PersistencyMode == Logged) && next.logfile != nil {
-			next.logfile.Write(LogEntryDelete{newRecid})
+		// A rebuild may snapshot a row while an ACID transaction still keeps its
+		// replacement hidden. The bounded catch-up then publishes the committed
+		// visibility. Persist both directions: omitting the undelete transition
+		// makes a correct in-memory commit reappear as deleted after WAL replay.
+		if wasDeleted != deleted {
+			next.logVisibilityChangeLocked(newRecid, deleted)
 		}
 	}
 

--- a/tests/execution/concurrency/failed-statement-atomicity.yaml
+++ b/tests/execution/concurrency/failed-statement-atomicity.yaml
@@ -1,0 +1,150 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Failed autocommit statements roll back base and trigger writes across shard boundaries"
+  isolated: true
+
+setup:
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS fsa_trigger_audit"
+  - sql: "DROP TABLE IF EXISTS fsa_trigger_source"
+  - sql: "DROP TABLE IF EXISTS fsa_audit"
+  - sql: "DROP TABLE IF EXISTS fsa_item"
+  - sql: |
+      CREATE TABLE fsa_item (
+        id INT PRIMARY KEY,
+        code VARCHAR(32) NOT NULL,
+        amount INT NOT NULL,
+        UNIQUE KEY fsa_item_code (code)
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE fsa_audit (
+        event_name VARCHAR(16) NOT NULL,
+        item_id INT NOT NULL
+      ) ENGINE=safe
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "fsa_item") '("id" "code" "amount")
+          (map (produceN 25) (lambda (i)
+            (list (+ i 1) (concat "code-" (+ i 1)) (* (+ i 1) 10)))))
+        (rebuild)
+        true)
+  - sql: |
+      CREATE TRIGGER fsa_item_ai AFTER INSERT ON fsa_item FOR EACH ROW
+      INSERT INTO fsa_audit(event_name, item_id) VALUES ('insert', NEW.id)
+  - sql: |
+      CREATE TRIGGER fsa_item_au AFTER UPDATE ON fsa_item FOR EACH ROW
+      INSERT INTO fsa_audit(event_name, item_id) VALUES ('update', NEW.id)
+  - sql: "CREATE TABLE fsa_trigger_source (id INT PRIMARY KEY) ENGINE=safe"
+  - sql: "CREATE TABLE fsa_trigger_audit (marker INT UNIQUE) ENGINE=safe"
+  - sql: |
+      CREATE TRIGGER fsa_trigger_source_ai AFTER INSERT ON fsa_trigger_source FOR EACH ROW
+      INSERT INTO fsa_trigger_audit(marker) SELECT 1
+
+test_cases:
+  - name: "Multi-row insert fails after encountering a duplicate key"
+    sql: |
+      INSERT INTO fsa_item(id, code, amount) VALUES
+        (26, 'code-26', 260),
+        (27, 'code-5', 270),
+        (28, 'code-28', 280)
+    expect:
+      error: true
+
+  - name: "Failed insert retained neither base rows nor trigger effects"
+    sql: |
+      SELECT
+        (SELECT COUNT(*) FROM fsa_item) AS item_count,
+        (SELECT COUNT(*) FROM fsa_item WHERE id IN (26, 27, 28)) AS leaked_items,
+        (SELECT COUNT(*) FROM fsa_audit) AS leaked_audits
+    expect:
+      rows: 1
+      data:
+        - item_count: 25
+          leaked_items: 0
+          leaked_audits: 0
+
+  - name: "Sparse cross-shard update fails on its final unique collision"
+    sql: |
+      UPDATE fsa_item
+      SET code = CASE WHEN id = 22 THEN 'code-1' ELSE CONCAT('changed-', id) END,
+          amount = amount + 1000
+      WHERE id IN (2, 12, 22)
+    expect:
+      error: true
+
+  - name: "Failed update restored every original base and trigger row"
+    sql: |
+      SELECT
+        SUM(CASE WHEN code = CONCAT('code-', id) THEN 1 ELSE 0 END) AS original_codes,
+        SUM(amount) AS amount_sum,
+        (SELECT COUNT(*) FROM fsa_audit) AS leaked_audits
+      FROM fsa_item
+    expect:
+      rows: 1
+      data:
+        - original_codes: 25
+          amount_sum: 3250
+          leaked_audits: 0
+
+  - name: "Failure inside the second trigger invocation aborts the statement"
+    sql: "INSERT INTO fsa_trigger_source VALUES (1), (2)"
+    expect:
+      error: true
+
+  - name: "Trigger failure retained neither source nor target rows"
+    sql: |
+      SELECT
+        (SELECT COUNT(*) FROM fsa_trigger_source) AS source_count,
+        (SELECT COUNT(*) FROM fsa_trigger_audit) AS audit_count
+    expect:
+      rows: 1
+      data:
+        - source_count: 0
+          audit_count: 0
+
+  - name: "Hard crash after rolled-back failures"
+    scm: '(crash)'
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after rolled-back failures"
+    action: restart
+
+  - name: "Rolled-back rows remain absent after WAL replay"
+    sql: |
+      SELECT
+        (SELECT COUNT(*) FROM fsa_item) AS item_count,
+        (SELECT COUNT(*) FROM fsa_audit) AS item_audits,
+        (SELECT COUNT(*) FROM fsa_trigger_source) AS source_count,
+        (SELECT COUNT(*) FROM fsa_trigger_audit) AS trigger_audits
+    expect:
+      rows: 1
+      data:
+        - item_count: 25
+          item_audits: 0
+          source_count: 0
+          trigger_audits: 0
+
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS fsa_trigger_audit"
+  - sql: "DROP TABLE IF EXISTS fsa_trigger_source"
+  - sql: "DROP TABLE IF EXISTS fsa_audit"
+  - sql: "DROP TABLE IF EXISTS fsa_item"

--- a/tests/storage/persistence/acid-trigger-recovery.yaml
+++ b/tests/storage/persistence/acid-trigger-recovery.yaml
@@ -1,0 +1,194 @@
+# Copyright (C) 2026 Carl-Philip Haensch
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+metadata:
+  version: "1.0"
+  description: "Committed ACID DML, trigger effects, and grouped read models recover together across SAFE shards"
+  isolated: true
+
+setup:
+  - scm: '(settings "ShardSize" 10)'
+  - sql: "DROP TABLE IF EXISTS patr_audit"
+  - sql: "DROP TABLE IF EXISTS patr_entry"
+  - sql: |
+      CREATE TABLE patr_entry (
+        id INT PRIMARY KEY,
+        bucket INT NOT NULL,
+        amount INT NOT NULL,
+        state VARCHAR(16) NOT NULL
+      ) ENGINE=safe
+  - sql: |
+      CREATE TABLE patr_audit (
+        event_name VARCHAR(16) NOT NULL,
+        item_id INT NOT NULL,
+        old_amount INT,
+        new_amount INT
+      ) ENGINE=safe
+  - scm: |
+      (begin
+        (insert (table "memcp-tests" "patr_entry") '("id" "bucket" "amount" "state")
+          (map (produceN 25) (lambda (i)
+            (list (+ i 1) (mod i 4) (* (+ i 1) 10) "original"))))
+        (rebuild)
+        true)
+  - sql: |
+      CREATE TRIGGER patr_entry_ai AFTER INSERT ON patr_entry FOR EACH ROW
+      INSERT INTO patr_audit(event_name, item_id, old_amount, new_amount)
+      VALUES ('insert', NEW.id, NULL, NEW.amount)
+  - sql: |
+      CREATE TRIGGER patr_entry_au AFTER UPDATE ON patr_entry FOR EACH ROW
+      INSERT INTO patr_audit(event_name, item_id, old_amount, new_amount)
+      VALUES ('update', NEW.id, OLD.amount, NEW.amount)
+  - sql: |
+      CREATE TRIGGER patr_entry_ad AFTER DELETE ON patr_entry FOR EACH ROW
+      INSERT INTO patr_audit(event_name, item_id, old_amount, new_amount)
+      VALUES ('delete', OLD.id, OLD.amount, NULL)
+
+test_cases:
+  - name: "Materialize the grouped read model before mutation"
+    sql: "SELECT bucket, COUNT(*) AS cnt, SUM(amount) AS total FROM patr_entry GROUP BY bucket ORDER BY bucket"
+    expect:
+      rows: 4
+
+  - name: "Commit mixed ACID DML and trigger writes across shards"
+    steps:
+      - session_id: "patr_writer"
+        sql: "START ACID TRANSACTION"
+      - session_id: "patr_writer"
+        sql: "UPDATE patr_entry SET bucket = bucket + 10, amount = amount + 100, state = 'committed' WHERE id <= 12"
+        expect:
+          affected_rows: 12
+      - session_id: "patr_writer"
+        sql: "DELETE FROM patr_entry WHERE id IN (3, 13, 23)"
+        expect:
+          affected_rows: 3
+      - session_id: "patr_writer"
+        sql: "INSERT INTO patr_entry VALUES (26, 2, 260, 'committed'), (27, 3, 270, 'committed')"
+        expect:
+          affected_rows: 2
+      - session_id: "patr_writer"
+        sql: "COMMIT"
+
+  - name: "Committed base rows are exact before crash"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(id) AS id_sum,
+             SUM(amount) AS amount_sum,
+             SUM(CASE WHEN state = 'committed' THEN 1 ELSE 0 END) AS committed_rows
+      FROM patr_entry
+    expect:
+      rows: 1
+      data:
+        - cnt: 24
+          id_sum: 339
+          amount_sum: 4490
+          committed_rows: 13
+
+  - name: "Every committed row mutation produced one audit row"
+    sql: |
+      SELECT COUNT(*) AS cnt,
+             SUM(CASE WHEN event_name = 'update' THEN 1 ELSE 0 END) AS updates,
+             SUM(CASE WHEN event_name = 'delete' THEN 1 ELSE 0 END) AS deletes,
+             SUM(CASE WHEN event_name = 'insert' THEN 1 ELSE 0 END) AS inserts
+      FROM patr_audit
+    expect:
+      rows: 1
+      data:
+        - cnt: 17
+          updates: 12
+          deletes: 3
+          inserts: 2
+
+  - name: "Grouped cache agrees with base rows before crash"
+    sql: |
+      SELECT SUM(bucket_count) AS total_rows, SUM(bucket_amount) AS total_amount
+      FROM (
+        SELECT bucket, COUNT(*) AS bucket_count, SUM(amount) AS bucket_amount
+        FROM patr_entry
+        GROUP BY bucket
+      ) grouped
+    expect:
+      rows: 1
+      data:
+        - total_rows: 24
+          total_amount: 4490
+
+  - name: "Hard crash after committed ACID transaction"
+    scm: '(crash)'
+    expect:
+      interrupted_ok: true
+
+  - name: "Restart after committed ACID transaction"
+    action: restart
+
+  - name: "Base rows recover as one committed state"
+    sql: "SELECT COUNT(*) AS cnt, SUM(id) AS id_sum, SUM(amount) AS amount_sum FROM patr_entry"
+    expect:
+      rows: 1
+      data:
+        - cnt: 24
+          id_sum: 339
+          amount_sum: 4490
+
+  - name: "Trigger side effects recover with their base transaction"
+    sql: "SELECT COUNT(*) AS cnt, SUM(item_id) AS item_sum FROM patr_audit"
+    expect:
+      rows: 1
+      data:
+        - cnt: 17
+          item_sum: 170
+
+  - name: "Recovered grouped cache still agrees with recovered base rows"
+    sql: |
+      SELECT SUM(bucket_count) AS total_rows, SUM(bucket_amount) AS total_amount
+      FROM (
+        SELECT bucket, COUNT(*) AS bucket_count, SUM(amount) AS bucket_amount
+        FROM patr_entry
+        GROUP BY bucket
+      ) grouped
+    expect:
+      rows: 1
+      data:
+        - total_rows: 24
+          total_amount: 4490
+
+  - name: "Persisted trigger remains executable after restart"
+    sql: "UPDATE patr_entry SET amount = amount + 1 WHERE id = 1"
+    expect:
+      affected_rows: 1
+
+  - name: "Post-restart trigger and grouped invalidation are both visible"
+    sql: |
+      SELECT
+        (SELECT amount FROM patr_entry WHERE id = 1) AS amount,
+        (SELECT COUNT(*) FROM patr_audit WHERE event_name = 'update') AS updates,
+        (SELECT SUM(bucket_amount) FROM (
+          SELECT bucket, SUM(amount) AS bucket_amount
+          FROM patr_entry
+          GROUP BY bucket
+        ) grouped) AS total_amount
+    expect:
+      rows: 1
+      data:
+        - amount: 111
+          updates: 13
+          total_amount: 4491
+
+  - name: "Restore default shard size"
+    scm: '(settings "ShardSize" 60000)'
+
+cleanup:
+  - sql: "DROP TABLE IF EXISTS patr_audit"
+  - sql: "DROP TABLE IF EXISTS patr_entry"


### PR DESCRIPTION
## What

- add isolated multi-shard regression coverage for failed-statement rollback across base rows and trigger side effects
- cover both trigger INSERT VALUES and trigger INSERT SELECT transaction propagation
- add crash/restart coverage for committed ACID updates, inserts, deletes, trigger effects, and grouped reads while a rebuild generation is being published
- pass the parent transaction through generated trigger INSERT operations
- persist both visibility directions during rebuild catch-up so committed hidden replacement rows remain visible after WAL replay

## Test-first evidence

On current master, the new statement-atomicity suite failed 4 of 10 cases: base-table rollback succeeded, but 3 trigger audit rows plus one trigger-failure row leaked and survived restart. The new recovery suite failed 3 correctness checks after restart: two committed updated rows disappeared, changing 24 rows / id sum 339 / amount sum 4490 into 22 / 316 / 4060.

With this branch:

- failed-statement-atomicity.yaml: 10/10 passed
- acid-trigger-recovery.yaml: 13/13 passed
- adjacent targeted suites: transactions 204/204, multi-shard trigger transaction 4/4, triggers 330/330, trigger persistence 37/37, trigger INSERT SELECT 17/17, correlated trigger INSERT SELECT 3/3, committed recovery 11/11, uncommitted recovery 8/8
- Scheme formatter/check passed
- go build passed

The complete suite is intentionally delegated to CI.