### PR TITLE
parser: return a numeric literal leaf directly, skipping the rule machinery

### DIFF
--- a/scm/jit_parser.go
+++ b/scm/jit_parser.go
@@ -83,6 +83,10 @@ type jitParserRule struct {
 	lexicalParent  int
 	compiledAction *JITEntryPoint
 	actionCaptures []Symbol
+	// directReturn: set by analyzeLiteralLeaves when this rule is a single
+	// (define x <regex>) whose generator is a pure function of x. Its references
+	// skip the frame / value-stack / bindings / memo machinery entirely.
+	directReturn *directReturnPlan
 }
 
 type jitParserProgram struct {
@@ -157,6 +161,7 @@ func jitBuildParserPrograms(parsers []*ScmParser) *jitParserProgram {
 	}
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
+	program.analyzeLiteralLeaves()
 	program.pool.New = func() any { return new(jitParserState) }
 	return program
 }
@@ -170,6 +175,7 @@ func jitBuildParserTemplateProgram(template *JITParserTemplate) (*jitParserProgr
 	rule := builder.addTemplate(template, -1)
 	program.prepareMemoLayout()
 	program.computeFirstBytes()
+	program.analyzeLiteralLeaves()
 	program.pool.New = func() any { return new(jitParserState) }
 	return program, rule
 }
@@ -445,6 +451,17 @@ func jitParserCallCompiledAction(entryValue Scmer, args []Scmer) Scmer {
 		panic("jit: invalid compiled parser action")
 	}
 	return entry.Call(args...)
+}
+
+// jitParserApplyAction1Native runs a literal-leaf rule's compiled generator on
+// its single argument - the matched text - with no jitMaterializeVirtualGoSlice
+// and no emulated JITEnv.
+func jitParserApplyAction1Native(entryValue, arg Scmer) Scmer {
+	entry, ok := entryValue.Any().(*JITEntryPoint)
+	if !ok || entry == nil {
+		panic("jit: invalid literal-leaf action")
+	}
+	return entry.Call(arg)
 }
 
 func (builder *jitParserBuilder) binding(ruleID int, symbol Symbol) int {

--- a/scm/jit_parser_emit.go
+++ b/scm/jit_parser_emit.go
@@ -576,7 +576,51 @@ func (emitter *jitParserEmitter) continuation(label JITLabel) int64 {
 	return index
 }
 
+// emitDirectReturnLeaf is the fast path for a literal-leaf rule
+// (analyzeLiteralLeaves): match the regex, run the compiled generator on the
+// matched text, push the result. No jitParserPushRuleFrame, no push/bind of the
+// capture through state.values/state.bindings, no memo, no
+// jitMaterializeVirtualGoSlice, no jitParserCompleteRule. The value left on
+// state.values top is identical to what the full path would have produced.
+func (emitter *jitParserEmitter) emitDirectReturnLeaf(p *directReturnPlan, success, failure JITLabel) {
+	ctx := emitter.ctx
+	skipped := ctx.ReserveLabel()
+	emitter.emitSkip(0, skipped)
+	ctx.MarkLabel(skipped)
+
+	matched, failed := ctx.ReserveLabel(), ctx.ReserveLabel()
+	captures := jitRegexCaptureTargets(ctx, p.regex.captures)
+	input := emitter.substringAtPosition()
+	jitEmitNativeRegex(ctx, p.regex, input, captures, matched, failed, failed, nil, false)
+
+	ctx.MarkLabel(matched)
+	emitter.advanceBy(captures[0])
+	entryValue := NewAny(p.action)
+	ctx.TrackImm(entryValue)
+	entry := emitter.immPair(entryValue)
+	value := ctx.EmitGoCallScalar(GoFuncAddr(jitParserApplyAction1Native), []JITValueDesc{entry, captures[0]}, 2)
+	ctx.FreeDesc(&entry)
+	value.Type = JITTypeUnknown
+	value.Rooted = true
+	emitter.pushValue(value)
+	ctx.EmitJmp(success)
+
+	ctx.MarkLabel(failed)
+	expected := emitter.immPair(NewString(p.desc))
+	position := emitter.loadPosition()
+	emitter.emitStateVoid(jitParserRecordFailureNative, position, expected)
+	ctx.FreeDesc(&position)
+	ctx.FreeDesc(&expected)
+	ctx.EmitJmp(failure)
+
+	ctx.FreeStack(int32(len(captures) * 16))
+}
+
 func (emitter *jitParserEmitter) emitRuleRef(node *jitParserNode, success, failure JITLabel) {
+	if p := emitter.program.rules[node.rule].directReturn; p != nil && !node.ignoreResult {
+		emitter.emitDirectReturnLeaf(p, success, failure)
+		return
+	}
 	// A lexical sub-rule (lexicalParent >= 0) is never memoized or left
 	// recursive, and a rule referenced from inside a noMemo-marked unbranched
 	// repeat body provably cannot have been visited at this position before

--- a/scm/jit_parser_literalleaf.go
+++ b/scm/jit_parser_literalleaf.go
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package scm
+
+import (
+	"fmt"
+	"os"
+)
+
+// A value in `INSERT INTO t VALUES (1, 2, 3), ...` bottoms out at a leaf rule
+// like `(define sql_number (parser (define x (regex "...")) (simplify x)))`.
+// The current JIT emits, per parsed value: push a rule frame, jump to the shared
+// rule body, match the regex, push the capture onto state.values, bind it into
+// state.bindings, then in emitRuleReturn marshal the binding, allocate an args
+// slice (jitMaterializeVirtualGoSlice), call the compiled action, and pop the
+// frame through jitParserCompleteRule. The value is a pure function of the
+// matched text - everything else is bookkeeping the caller never observes.
+//
+// analyzeLiteralLeaves marks such rules; emitRuleRef then emits, at each
+// reference site, just: match the regex, run the compiled action on the matched
+// text, pushValue. No frame, no bind, no memo, no alloc.
+type directReturnPlan struct {
+	regex  *jitRegexProgram
+	action *JITEntryPoint
+	desc   string
+}
+
+func (program *jitParserProgram) analyzeLiteralLeaves() {
+	for r := range program.rules {
+		rule := &program.rules[r]
+		if rule.lexicalParent >= 0 || rule.compiledAction == nil ||
+			len(rule.bindings) != 1 || len(rule.actionCaptures) != 0 {
+			continue
+		}
+		node := rule.root
+		if node != nil && node.kind == jitParserSequence && len(node.children) == 1 {
+			node = node.children[0]
+		}
+		if node == nil || node.kind != jitParserBind || node.binding != 0 || len(node.children) != 1 {
+			continue
+		}
+		inner := node.children[0]
+		// v1: regex-bind leaves only. Atoms carry a word-boundary obligation
+		// (atBreak before + after) and are a follow-up.
+		if inner.kind != jitParserRegex || inner.regex == nil || inner.regex.captures != 1 {
+			continue
+		}
+		rule.directReturn = &directReturnPlan{regex: inner.regex, action: rule.compiledAction, desc: inner.description}
+		if os.Getenv("MEMCP_DUMP_LITERAL_LEAVES") != "" {
+			fmt.Fprintf(os.Stderr, "[literal-leaf] rule#%d: %s\n", r, inner.description)
+		}
+	}
+}


### PR DESCRIPTION
## What

A value in `INSERT INTO t VALUES (1, 2, 3), …` bottoms out at a leaf rule like
`(define sql_number (parser (define x (regex "…")) (simplify x)))`. Per parsed
value (~10 000× for a 2000-row INSERT) the JIT emits `jitParserPushRuleFrame` →
jump to the shared rule body → regex match → `jitParserPushValueNative` →
`jitParserBindValueNative` → `emitRuleReturn` (marshal binding,
`jitMaterializeVirtualGoSlice` **alloc**, `jitParserCallCompiledAction`) →
`jitParserCompleteRule` (frame pop).

A profile of the parse (`-profile`, `go tool pprof`) put `jitParserCompleteRule`
+ `jitParserReturnRuleNative` at ~20% of the whole parse and the memo get/set
they drive at another chunk. For these leaves the produced value is a pure
function of the matched text — everything between the regex match and the
compiled action is bookkeeping the caller never observes.

## How

`analyzeLiteralLeaves` (new `scm/jit_parser_literalleaf.go`, run after
`computeFirstBytes`) marks a rule whose root is one `(define x <regex>)` with a
compiled generator (`compiledAction`), exactly one binding and no closure
captures. `emitRuleRef` then emits, at each reference site, just: skip ws, match
the regex, run the compiled action on the matched text
(`jitParserApplyAction1Native` — one call, no arg-slice alloc), `pushValue`. No
frame, no bind through `state.values`/`state.bindings`, no memo, no
`jitParserCompleteRule`.

The value left on `state.values` top is byte-identical to the full path (same
regex, same compiled action, same text). Callers (`(* item sep)`, `emitBind`, …)
are unchanged; other references to the same rule keep the normal path.

Matches `sql_number` / `sql_int` / `sql_hex_literal` across every compiled
grammar (`MEMCP_DUMP_LITERAL_LEAVES=1` prints them). v1 is regex-bind leaves
only — keyword atoms carry a word-boundary obligation (`atBreak` before + after)
and are a follow-up.

## A/B (parse-only, 2000-row `INSERT INTO t VALUES (…)`, 6 rounds)

| build | ms / parse |
|---|---|
| master | ~250.7 |
| this branch | **~236.5 (−5.7%)** |

## Tests

`go test ./scm` green, `go vet ./scm` clean. `psql-parser` 64/64,
`prepared-stmts` 57/57, `name-resolution-scopes` 40/40, `exists-session-var`
8/8, `ddl-operations` 54/54, `fk-pk-group-reuse` 21/21, `group-stage-corners`
42/42. Smoke: `1+2`→3, `5*5`→25, `1e3`→1000, `0x1F`, `'y''s'`, BETWEEN/IN,
`SELECT 7 AS seven` (number followed by alias falls to the full path).

## Next

- keyword-atom leaves (`NULL`/`TRUE`/`FALSE`) with `atBreak`;
- inline `Simplify` for the number leaf instead of `entry.Call` — removes the
  last Go call per numeric value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV