### PR TITLE
Compile ordered access into scan schemas

### DIFF
--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -114,8 +114,10 @@ func TestCompileScanAccessKeepsRangeEndpointsInAdjacentValues(t *testing.T) {
 
 func TestScanBoundarySurvivesPersistedProcedureRoundTrip(t *testing.T) {
 	registerScanBoundaryFormats()
+	orderValue := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString("utf8mb4"), scm.NewBool(true))
+	order := scm.OptimizeProcToSerialFunction(orderValue)
 	boundary := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
-		"utf8mb4_general_ci", true, 1, []string{"document"}, nil, "", true)
+		"utf8mb4_general_ci", true, 1, []string{"document"}, order, "utf8mb4:desc", true)
 	procedure := scm.NewProcStruct(scm.Proc{
 		Params: scm.NewSlice(nil),
 		Body: scm.NewSlice([]scm.Scmer{
@@ -137,8 +139,11 @@ func TestScanBoundarySurvivesPersistedProcedureRoundTrip(t *testing.T) {
 	if restored.ColumnName() != "tenant" || restored.Analyzer() != EqualMatcher ||
 		restored.LowerSlot() != 0 || restored.UpperSlot() != 0 || !restored.NullSafe() ||
 		restored.MapperSlot() != 1 || len(restored.MapColumns()) != 1 || restored.MapColumns()[0] != "document" ||
-		!restored.Mandatory() {
+		restored.Order() == nil || restored.OrderMetadata() != "utf8mb4:desc" || !restored.Mandatory() {
 		t.Fatalf("persisted boundary was not restored: %#v", restored)
+	}
+	if collation, reverse, ok := scm.LookupCollate(restored.Order()); !ok || collation != "utf8mb4" || !reverse {
+		t.Fatalf("persisted boundary order = (%q, %t, %t), want (utf8mb4, true, true)", collation, reverse, ok)
 	}
 }
 

--- a/storage/analyzer_test.go
+++ b/storage/analyzer_test.go
@@ -153,6 +153,11 @@ func TestScanAccessValuesExprCachesConstantsAndBindsDynamicValues(t *testing.T) 
 	if !ok || len(dynamicItems) != 2 || !scanSymbolIs(dynamicItems[0], "list") {
 		t.Fatalf("dynamic access values = %s, want runtime list", scm.String(dynamic))
 	}
+	local := scanAccessValuesExpr([]scm.Scmer{scm.NewNthLocalVar(1)})
+	localItems, ok := scmerSlice(local)
+	if !ok || len(localItems) != 2 || !scanSymbolIs(localItems[0], "list") {
+		t.Fatalf("optimized local access values = %s, want runtime list", scm.String(local))
+	}
 }
 
 func TestCompileScanAccessCarriesComputedFormulaRuntimeConstants(t *testing.T) {

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -265,7 +265,7 @@ func scanAccessValuesExpr(values []scm.Scmer) scm.Scmer {
 	staticValues := make([]scm.Scmer, len(values))
 	for i, value := range values {
 		value = value.WithoutSourceInfo()
-		if value.IsSymbol() {
+		if value.IsSymbol() || value.IsNthLocalVar() {
 			return scm.NewSlice(append([]scm.Scmer{scm.NewSymbol("list")}, values...))
 		}
 		if value.IsSlice() {

--- a/storage/scan_boundary.go
+++ b/storage/scan_boundary.go
@@ -18,6 +18,7 @@ package storage
 
 import "encoding/json"
 import "fmt"
+import "strings"
 import "unsafe"
 
 import "github.com/launix-de/memcp/scm"
@@ -158,18 +159,51 @@ func scanBoundaryString(pointer unsafe.Pointer) string {
 
 func scanBoundaryJSONEncode(pointer unsafe.Pointer) any {
 	box := (*scanBoundaryBox)(pointer)
-	if box.order != nil || box.orderMetadata != "" {
-		panic("ordered runtime scan boundaries cannot be persisted")
+	orderMetadata := box.orderMetadata
+	if box.order != nil {
+		collation, reverse, ok := scm.LookupCollate(box.order)
+		if !ok {
+			panic("non-collation ordered scan boundaries cannot be persisted")
+		}
+		direction := ":asc"
+		if reverse {
+			direction = ":desc"
+		}
+		persisted := collation + direction
+		if orderMetadata != "" && orderMetadata != persisted {
+			panic("ordered scan boundary metadata does not match its relation")
+		}
+		orderMetadata = persisted
+	} else if orderMetadata != "" {
+		panic("ordered scan boundary metadata has no relation")
 	}
 	mapColumns := box.mapColumns
 	if mapColumns == nil {
 		mapColumns = []string{}
 	}
-	return []any{
+	items := []any{
 		box.analyzer.Kind(), box.column, box.lowerSlot, box.upperSlot,
 		box.lowerInclusive, box.upperInclusive, box.collation, box.nullSafe,
 		box.mapperSlot, mapColumns, box.mandatory,
 	}
+	if orderMetadata == "" {
+		return items
+	}
+	return append(items, orderMetadata)
+}
+
+func scanBoundaryOrderFromMetadata(metadata string) func(...scm.Scmer) scm.Scmer {
+	separator := strings.LastIndexByte(metadata, ':')
+	if separator <= 0 {
+		return nil
+	}
+	direction := metadata[separator:]
+	if direction != ":asc" && direction != ":desc" {
+		return nil
+	}
+	value := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")],
+		scm.NewString(metadata[:separator]), scm.NewBool(direction == ":desc"))
+	return scm.OptimizeProcToSerialFunction(value)
 }
 
 func scanBoundaryJSONInt(value any) int {
@@ -189,7 +223,7 @@ func scanBoundaryJSONInt(value any) int {
 
 func scanBoundaryJSONDecode(value any) unsafe.Pointer {
 	items, ok := value.([]any)
-	if !ok || len(items) != 11 {
+	if !ok || (len(items) != 11 && len(items) != 12) {
 		panic("invalid persisted scan boundary")
 	}
 	kind, kindOK := items[0].(string)
@@ -211,12 +245,28 @@ func scanBoundaryJSONDecode(value any) unsafe.Pointer {
 		}
 		mapColumns[i] = column
 	}
+	orderMetadata := ""
+	var order func(...scm.Scmer) scm.Scmer
+	if len(items) == 12 {
+		var metadataOK bool
+		orderMetadata, metadataOK = items[11].(string)
+		if !metadataOK {
+			panic("invalid persisted scan boundary order metadata")
+		}
+		if orderMetadata != "" {
+			order = scanBoundaryOrderFromMetadata(orderMetadata)
+			if order == nil {
+				panic("invalid persisted scan boundary order relation")
+			}
+		}
+	}
 	return unsafe.Pointer(&scanBoundaryBox{
 		column: column, analyzer: scanBoundaryAnalyzer(kind),
 		lowerSlot: scanBoundaryJSONInt(items[2]), upperSlot: scanBoundaryJSONInt(items[3]),
 		lowerInclusive: lowerInclusive, upperInclusive: upperInclusive,
 		collation: collation, nullSafe: nullSafe,
 		mapperSlot: scanBoundaryJSONInt(items[8]), mapColumns: mapColumns,
+		order: order, orderMetadata: orderMetadata,
 		mandatory: mandatory,
 	})
 }

--- a/storage/scan_family_bench_test.go
+++ b/storage/scan_family_bench_test.go
@@ -131,7 +131,7 @@ func BenchmarkScanOrderPlannerCompiledFixedCosts(b *testing.B) {
 	tbl := benchScanTable(b, "order_planner_compiled")
 	expr := scm.Read(b.Name(), `(lambda (table_value)
 		(scan_order nil table_value '() '() '() (lambda () true)
-			'("id") (list <) 0 0 72
+			'("id") (list (collate "utf8mb4" false)) 0 0 72
 			'("id") (lambda (acc id) acc) nil false nil '() nil))`)
 	proc := scm.Eval(scm.Optimize(expr, &scm.Globalenv, nil), &scm.Globalenv)
 	tableValue := NewTableScmer(tbl)

--- a/storage/scan_family_bench_test.go
+++ b/storage/scan_family_bench_test.go
@@ -122,6 +122,30 @@ func BenchmarkScanFamilyFixedCosts(b *testing.B) {
 	}
 }
 
+// BenchmarkScanOrderPlannerCompiledFixedCosts includes optimizer lowering and
+// SCM dispatch while retaining the resulting cached procedure across calls.
+// It catches regressions where static ORDER BY access requirements fall back to
+// invocation-time boundary construction.
+func BenchmarkScanOrderPlannerCompiledFixedCosts(b *testing.B) {
+	Init(scm.Globalenv)
+	tbl := benchScanTable(b, "order_planner_compiled")
+	expr := scm.Read(b.Name(), `(lambda (table_value)
+		(scan_order nil table_value '() '() '() (lambda () true)
+			'("id") (list <) 0 0 72
+			'("id") (lambda (acc id) acc) nil false nil '() nil))`)
+	proc := scm.Eval(scm.Optimize(expr, &scm.Globalenv, nil), &scm.Globalenv)
+	tableValue := NewTableScmer(tbl)
+	for range 3 {
+		scm.Apply(proc, tableValue)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scm.Apply(proc, tableValue)
+	}
+}
+
 // BenchmarkScanBatchCoveredFixedCosts isolates the steady-state setup of a
 // planner-covered batch scan. Its access schema, batch values and column lists
 // are retained exactly as they are in a cached physical plan.

--- a/storage/scan_join_order.go
+++ b/storage/scan_join_order.go
@@ -49,6 +49,12 @@ func optimizeScanJoinOrder(v []scm.Scmer, oc *scm.OptimizerContext, _ bool) (scm
 	for i := 1; i < mapReduceIdx && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
+	if len(v) > 11 {
+		if schemas, values, compiled := compileScanJoinDriverOrderAccess(v[3], v[4], v[10], v[11]); compiled {
+			v[3] = schemas
+			v[4] = values
+		}
+	}
 	neutralType := unknownScanType()
 	if len(v) > neutralIdx {
 		v[neutralIdx], neutralType = oc.OptimizeSub(v[neutralIdx], true)
@@ -75,6 +81,28 @@ func optimizeScanJoinOrder(v []scm.Scmer, oc *scm.OptimizerContext, _ bool) (scm
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), resultType
+}
+
+func compileScanJoinDriverOrderAccess(schemasExpr, valuesExpr, orderColsExpr, sortDirsExpr scm.Scmer) (scm.Scmer, scm.Scmer, bool) {
+	schemas, schemasStatic := scanStaticListElements(schemasExpr)
+	orderRefs, orderStatic := scanStaticListElements(orderColsExpr)
+	if !schemasStatic || !orderStatic || len(schemas) == 0 || len(orderRefs) == 0 {
+		return schemasExpr, valuesExpr, false
+	}
+	driverColumns := make([]scm.Scmer, len(orderRefs))
+	for i, refValue := range orderRefs {
+		ref, static := scanStaticListElements(refValue)
+		if !static || len(ref) != 2 || !ref[0].IsInt() || scm.ToInt(ref[0]) != 0 || !ref[1].IsString() {
+			return schemasExpr, valuesExpr, false
+		}
+		driverColumns[i] = ref[1]
+	}
+	perTableColumns := make([]scm.Scmer, len(schemas))
+	for i := range perTableColumns {
+		perTableColumns[i] = scm.NewSlice(nil)
+	}
+	perTableColumns[0] = scm.NewSlice(driverColumns)
+	return compileScanOrderAccessList(schemasExpr, valuesExpr, scm.NewSlice(perTableColumns), sortDirsExpr)
 }
 
 // scanJoinOrderColumn identifies one physical column in the joined tuple.

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -283,7 +283,11 @@ func compileScanOrderAccess(schemaExpr, valuesExpr, sortColsExpr, sortDirsExpr s
 	if meta.projections > 0 {
 		result = append(result, schema[boundariesEnd:]...)
 	}
-	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(result)}), scanAccessValuesExpr(newValues), true
+	valuesResult := valuesExpr
+	if len(newValues) != len(values) {
+		valuesResult = scanAccessValuesExpr(newValues)
+	}
+	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(result)}), valuesResult, true
 }
 
 func compileScanOrderAccessList(schemasExpr, valuesExpr, sortColsExpr, sortDirsExpr scm.Scmer) (scm.Scmer, scm.Scmer, bool) {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -214,17 +214,30 @@ func compileScanOrderAccess(schemaExpr, valuesExpr, sortColsExpr, sortDirsExpr s
 			}
 			directionValue = resolved
 		}
-		// Runtime-capturing relation procedures cannot be embedded in a shared
-		// cached schema. Planner-generated collations and global order relations
-		// resolve to immutable native functions here.
-		if !directionValue.IsNativeFunc() {
-			return schemaExpr, valuesExpr, false
+		if items, ok := scmerSlice(directionValue); ok && len(items) == 3 && callHeadIs(items[0], "collate") {
+			collation := items[1].WithoutSourceInfo()
+			reverse := items[2].WithoutSourceInfo()
+			staticReverse := reverse.IsBool() || reverse.IsNil() || reverse.SymbolEquals("false") || reverse.SymbolEquals("true")
+			if !collation.IsString() || !staticReverse {
+				return schemaExpr, valuesExpr, false
+			}
+			directionValue = scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], collation, scm.NewBool(scm.ToBool(reverse)))
 		}
+		// Only canonical collation relations are accepted below. Runtime-capturing
+		// procedures and arbitrary native callbacks retain the runtime fallback.
 		order := scm.OptimizeProcToSerialFunction(directionValue)
 		if order == nil {
 			return schemaExpr, valuesExpr, false
 		}
-		boundary := compiledOrderBoundary{order: order, orderMeta: orderRelationMeta(order)}
+		collation, reverse, persistable := scm.LookupCollate(order)
+		if !persistable {
+			return schemaExpr, valuesExpr, false
+		}
+		orderMeta := collation + ":asc"
+		if reverse {
+			orderMeta = collation + ":desc"
+		}
+		boundary := compiledOrderBoundary{order: order, orderMeta: orderMeta}
 		if sortcol.IsString() {
 			boundary.column = sortcol.String()
 		} else {

--- a/storage/scan_order.go
+++ b/storage/scan_order.go
@@ -48,6 +48,12 @@ func optimizeScanOrderMulti(v []scm.Scmer, oc *scm.OptimizerContext, useResult b
 	for i := 1; i <= 15 && i < len(v); i++ {
 		v[i], _ = oc.OptimizeSub(v[i], true)
 	}
+	if len(v) > 8 {
+		if schemas, values, compiled := compileScanOrderAccessList(v[3], v[4], v[7], v[8]); compiled {
+			v[3] = schemas
+			v[4] = values
+		}
+	}
 	neutralType := unknownScanType()
 	if len(v) > 16 {
 		v[16], neutralType = oc.OptimizeSub(v[16], true)
@@ -101,6 +107,12 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 			v[i], _ = oc.OptimizeSub(v[i], true)
 		}
 	}
+	if len(v) > 8 {
+		if schema, values, compiled := compileScanOrderAccess(v[3], v[4], v[7], v[8]); compiled {
+			v[3] = schema
+			v[4] = values
+		}
+	}
 	neutralType := unknownScanType()
 	if len(v) > neutralIdx {
 		v[neutralIdx], neutralType = oc.OptimizeSub(v[neutralIdx], true)
@@ -133,6 +145,176 @@ func optimizeScanOrder(v []scm.Scmer, oc *scm.OptimizerContext, useResult bool) 
 	}
 	oc.Ome.DecrLoopDepth()
 	return scm.NewSlice(v), nil
+}
+
+// compileScanOrderAccess moves immutable ORDER BY access requirements into the
+// cached scan schema. Runtime execution then only resolves the currently
+// available index and decides whether its order covers the request. Dynamic or
+// otherwise unsupported order expressions retain the ordinary runtime path.
+func compileScanOrderAccess(schemaExpr, valuesExpr, sortColsExpr, sortDirsExpr scm.Scmer) (scm.Scmer, scm.Scmer, bool) {
+	staticList := func(expr scm.Scmer) ([]scm.Scmer, bool) {
+		if expr.IsNil() {
+			return nil, true
+		}
+		return scanStaticListElements(expr)
+	}
+	schema, schemaStatic := staticList(schemaExpr)
+	sortcols, columnsStatic := scanStaticListElements(sortColsExpr)
+	sortdirs, directionsStatic := scanStaticListElements(sortDirsExpr)
+	values, valuesStatic := staticList(valuesExpr)
+	if !schemaStatic || !columnsStatic || !directionsStatic || !valuesStatic || len(sortcols) == 0 || len(sortcols) != len(sortdirs) {
+		return schemaExpr, valuesExpr, false
+	}
+
+	meta := scanAccessSchemaMeta{consumer: scanAccessConsumerScan}
+	if len(schema) > 0 {
+		var valid bool
+		meta, valid = decodeScanAccessHeader(schema[0])
+		if !valid || len(schema) != scanAccessSchemaHeaderSize+meta.count*scanAccessBoundaryStride+meta.projections {
+			return schemaExpr, valuesExpr, false
+		}
+	}
+	for i := 0; i < meta.count; i++ {
+		boundary := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize+i*scanAccessBoundaryStride])
+		if !boundary.Analyzer().IsPointLike() {
+			return schemaExpr, valuesExpr, false
+		}
+	}
+
+	type compiledOrderBoundary struct {
+		column     string
+		mapColumns []string
+		mapper     scm.Scmer
+		order      func(...scm.Scmer) scm.Scmer
+		orderMeta  string
+	}
+	compiled := make([]compiledOrderBoundary, 0, len(sortcols))
+	hasSorted := func(column string) bool {
+		for i := 0; i < meta.count; i++ {
+			boundary := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize+i*scanAccessBoundaryStride])
+			if boundary.ColumnName() == column && boundary.Analyzer().IsSorted() {
+				return true
+			}
+		}
+		for _, boundary := range compiled {
+			if boundary.column == column {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i, sortcol := range sortcols {
+		sortcol = sortcol.WithoutSourceInfo()
+		directionValue := sortdirs[i].WithoutSourceInfo()
+		if name, named := scanSymbolName(directionValue); named {
+			resolved, exists := scm.Globalenv.Vars[scm.Symbol(name)]
+			if !exists {
+				return schemaExpr, valuesExpr, false
+			}
+			directionValue = resolved
+		}
+		// Runtime-capturing relation procedures cannot be embedded in a shared
+		// cached schema. Planner-generated collations and global order relations
+		// resolve to immutable native functions here.
+		if !directionValue.IsNativeFunc() {
+			return schemaExpr, valuesExpr, false
+		}
+		order := scm.OptimizeProcToSerialFunction(directionValue)
+		if order == nil {
+			return schemaExpr, valuesExpr, false
+		}
+		boundary := compiledOrderBoundary{order: order, orderMeta: orderRelationMeta(order)}
+		if sortcol.IsString() {
+			boundary.column = sortcol.String()
+		} else {
+			if !sortcol.IsProc() {
+				return schemaExpr, valuesExpr, false
+			}
+			proc := sortcol.Proc()
+			if proc == nil || !proc.Params.IsSlice() || len(proc.Params.Slice()) == 0 {
+				return schemaExpr, valuesExpr, false
+			}
+			params := proc.Params.Slice()
+			conditionCols := make([]string, len(params))
+			for j, param := range params {
+				conditionCols[j] = scm.String(param)
+			}
+			if !isRawDataset(params, proc.Body) {
+				return schemaExpr, valuesExpr, false
+			}
+			boundary.column = canonicalColName(proc.Body, params, conditionCols)
+			boundary.mapColumns, boundary.mapper = buildComputedFn(proc.Body, proc.Params, proc.En, conditionCols)
+			if boundary.mapper.IsNil() || boundary.mapColumns == nil {
+				return schemaExpr, valuesExpr, false
+			}
+		}
+		if !hasSorted(boundary.column) {
+			compiled = append(compiled, boundary)
+		}
+	}
+	if len(compiled) == 0 {
+		return schemaExpr, valuesExpr, true
+	}
+
+	boundariesEnd := scanAccessSchemaHeaderSize + meta.count*scanAccessBoundaryStride
+	result := make([]scm.Scmer, 0, len(schema)+len(compiled))
+	result = append(result, newScanAccessHeader(meta.count+len(compiled), meta.consumer, meta.projections, meta.mapperSlot))
+	if len(schema) > scanAccessSchemaHeaderSize {
+		result = append(result, schema[scanAccessSchemaHeaderSize:boundariesEnd]...)
+	}
+	newValues := append([]scm.Scmer(nil), values...)
+	for _, boundary := range compiled {
+		mapperSlot := -1
+		if !boundary.mapper.IsNil() {
+			mapperSlot = len(newValues)
+			mapcols := make([]scm.Scmer, len(boundary.mapColumns))
+			for i, column := range boundary.mapColumns {
+				mapcols[i] = scm.NewString(column)
+			}
+			newValues = append(newValues, scm.NewSlice([]scm.Scmer{
+				scm.NewSymbol("compile_scan_computed_index"), boundary.mapper,
+				scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(mapcols)}),
+			}))
+		}
+		result = append(result, newScanBoundarySpec(boundary.column, RangeMatcher, -1, -1,
+			true, true, "", false, mapperSlot, boundary.mapColumns, boundary.order, boundary.orderMeta, false))
+	}
+	if meta.projections > 0 {
+		result = append(result, schema[boundariesEnd:]...)
+	}
+	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(result)}), scanAccessValuesExpr(newValues), true
+}
+
+func compileScanOrderAccessList(schemasExpr, valuesExpr, sortColsExpr, sortDirsExpr scm.Scmer) (scm.Scmer, scm.Scmer, bool) {
+	schemas, schemasStatic := scanStaticListElements(schemasExpr)
+	sortcols, columnsStatic := scanStaticListElements(sortColsExpr)
+	if !schemasStatic || !columnsStatic || len(schemas) != len(sortcols) {
+		return schemasExpr, valuesExpr, false
+	}
+	result := append([]scm.Scmer(nil), schemas...)
+	compiledAny := false
+	for i := range result {
+		columns, static := scanStaticListElements(sortcols[i])
+		if !static || len(columns) == 0 {
+			continue
+		}
+		compiledSchema, compiledValues, compiled := compileScanOrderAccess(result[i], valuesExpr, sortcols[i], sortDirsExpr)
+		if !compiled {
+			continue
+		}
+		items, static := scanStaticListElements(compiledSchema)
+		if !static {
+			continue
+		}
+		result[i] = scm.NewSlice(items)
+		valuesExpr = compiledValues
+		compiledAny = true
+	}
+	if !compiledAny {
+		return schemasExpr, valuesExpr, false
+	}
+	return scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), scm.NewSlice(result)}), valuesExpr, true
 }
 
 // pkEqual compares two partition key slices element-wise.

--- a/storage/scan_order_batch_accept.go
+++ b/storage/scan_order_batch_accept.go
@@ -220,6 +220,12 @@ func optimizeScanOrderBatchAccept(v []scm.Scmer, oc *scm.OptimizerContext, useRe
 			v[i], _ = oc.OptimizeSub(v[i], true)
 		}
 	}
+	if len(v) > 7 {
+		if schema, values, compiled := compileScanOrderAccess(v[3], v[4], v[6], v[7]); compiled {
+			v[3] = schema
+			v[4] = values
+		}
+	}
 	neutralType := unknownScanType()
 	if len(v) > neutralIdx {
 		v[neutralIdx], neutralType = oc.OptimizeSub(v[neutralIdx], true)

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -17,10 +17,37 @@ Copyright (C) 2026  Carl-Philip Haensch
 package storage
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/launix-de/memcp/scm"
 )
+
+func TestScanOrderOptimizerCompilesOrderIntoAccessSchema(t *testing.T) {
+	Init(scm.Globalenv)
+	expr := scm.Read(t.Name(), `(lambda (table_value)
+		(scan_order nil table_value '() '() '() (lambda () true)
+			'("rank") (list <) 0 0 10
+			'("rank") (lambda (acc rank) rank) nil false nil '() nil))`)
+	optimized := scm.Optimize(expr, &scm.Globalenv, nil)
+	plan := scm.SerializeToString(optimized, &scm.Globalenv)
+	if !strings.Contains(plan, `(scan_boundary "range" "rank" -1 -1 true true "" false)`) {
+		t.Fatalf("optimized scan_order has no static order boundary: %s", plan)
+	}
+}
+
+func TestScanOrderBatchAcceptOptimizerCompilesOrderIntoAccessSchema(t *testing.T) {
+	Init(scm.Globalenv)
+	expr := scm.Read(t.Name(), `(lambda (table_value)
+		(scan_order_batch_accept nil table_value '() '()
+			(lambda (input) input) '("rank") (list <) 0 0 10
+			'("rank") (lambda (acc rank) rank) nil false nil))`)
+	optimized := scm.Optimize(expr, &scm.Globalenv, nil)
+	plan := scm.SerializeToString(optimized, &scm.Globalenv)
+	if !strings.Contains(plan, `(scan_boundary "range" "rank" -1 -1 true true "" false)`) {
+		t.Fatalf("optimized scan_order_batch_accept has no static order boundary: %s", plan)
+	}
+}
 
 func TestExtendBoundariesRejectsPartiallyCoveredOrder(t *testing.T) {
 	lookupSort := buildProc([]string{"foreign_id", "$tx"}, scm.NewSlice([]scm.Scmer{
@@ -42,6 +69,171 @@ func TestExtendBoundariesRejectsPartiallyCoveredOrder(t *testing.T) {
 	}
 	if len(got) != len(original) {
 		t.Fatalf("partial ORDER BY coverage changed boundaries: got %d, want %d", len(got), len(original))
+	}
+}
+
+func TestCompileScanOrderAccessStoresOrderInStaticSchema(t *testing.T) {
+	directionValue, direction := integerOrder(false)
+	schemaExpr, valuesExpr, compiled := compileScanOrderAccess(
+		scm.NewSlice(nil), scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("static ORDER BY did not compile into scan access")
+	}
+	schema, ok := scanStaticListElements(schemaExpr)
+	if !ok || len(schema) != scanAccessSchemaHeaderSize+1 {
+		t.Fatalf("compiled schema has invalid shape: %s", scm.String(schemaExpr))
+	}
+	meta, valid := decodeScanAccessHeader(schema[0])
+	if !valid || meta.count != 1 {
+		t.Fatalf("compiled schema boundary count = %d, valid = %t", meta.count, valid)
+	}
+	boundary := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize])
+	if boundary.ColumnName() != "rank" || boundary.Analyzer() != RangeMatcher || boundary.Order() == nil {
+		t.Fatalf("compiled ORDER BY boundary = %#v", boundary)
+	}
+	if boundary.OrderMetadata() != orderRelationMeta(direction) {
+		t.Fatalf("compiled order metadata = %q, want %q", boundary.OrderMetadata(), orderRelationMeta(direction))
+	}
+	values, ok := scanStaticListElements(valuesExpr)
+	if !ok || len(values) != 0 {
+		t.Fatalf("direct ORDER BY added runtime values: %s", scm.String(valuesExpr))
+	}
+
+	access, ok := scanAccessFromScheme(scm.NewSlice(schema), values, nil)
+	if !ok {
+		t.Fatal("compiled ORDER BY schema was rejected by runtime")
+	}
+	access, _ = extendScanAccessWithSortCols(access,
+		[]scm.Scmer{scm.NewString("rank")}, []func(...scm.Scmer) scm.Scmer{direction})
+	if access.runtime != nil {
+		t.Fatal("runtime rebuilt an ORDER BY segment already present in the static schema")
+	}
+}
+
+func TestCompileScanOrderAccessPreservesPointPrefixAndRuntimeValues(t *testing.T) {
+	directionValue, _ := integerOrder(true)
+	point := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
+		"", false, -1, nil, nil, "", false)
+	schema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 0, -1), point,
+	})
+	wantedTenant := scm.NewSymbol("wanted_tenant")
+	values := scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), wantedTenant})
+
+	schemaExpr, valuesExpr, compiled := compileScanOrderAccess(
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema}), values,
+		scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("point-prefix ORDER BY did not compile into scan access")
+	}
+	compiledSchema, _ := scanStaticListElements(schemaExpr)
+	meta, valid := decodeScanAccessHeader(compiledSchema[0])
+	if !valid || meta.count != 2 || meta.consumer != scanAccessConsumerCoveredScan {
+		t.Fatalf("compiled point-prefix metadata = %#v, valid = %t", meta, valid)
+	}
+	if got := ScanBoundaryFromScmer(compiledSchema[1]).ColumnName(); got != "tenant" {
+		t.Fatalf("first boundary = %q, want tenant", got)
+	}
+	if got := ScanBoundaryFromScmer(compiledSchema[2]).ColumnName(); got != "rank" {
+		t.Fatalf("second boundary = %q, want rank", got)
+	}
+	compiledValues, ok := scanStaticListElements(valuesExpr)
+	if !ok || len(compiledValues) != 1 || !compiledValues[0].SymbolEquals("wanted_tenant") {
+		t.Fatalf("runtime values changed: %s", scm.String(valuesExpr))
+	}
+}
+
+func TestCompileScanOrderAccessStoresComputedOrderMapper(t *testing.T) {
+	Init(scm.Globalenv)
+	directionValue, _ := integerOrder(false)
+	computed := scm.Eval(scm.Optimize(scm.Read(t.Name(), `(lambda (rank) (+ rank 1))`), &scm.Globalenv, nil), &scm.Globalenv)
+	proc := computed.Proc()
+	if !isRawDataset(proc.Params.Slice(), proc.Body) {
+		t.Fatal("computed ORDER BY fixture is not indexable")
+	}
+	schemaExpr, valuesExpr, compiled := compileScanOrderAccess(
+		scm.NewSlice(nil), scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{computed}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("computed ORDER BY did not compile into scan access")
+	}
+	schema, _ := scanStaticListElements(schemaExpr)
+	boundary := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize])
+	if boundary.MapperSlot() != 0 || len(boundary.MapColumns()) != 1 || boundary.MapColumns()[0] != "rank" {
+		t.Fatalf("computed order boundary has invalid mapper metadata: slot=%d columns=%v",
+			boundary.MapperSlot(), boundary.MapColumns())
+	}
+	values, ok := scanStaticListElements(valuesExpr)
+	if !ok || len(values) != 1 {
+		t.Fatalf("computed ORDER BY values = %s", scm.String(valuesExpr))
+	}
+	descriptor, ok := scanStaticListElements(values[0])
+	if !ok || len(descriptor) != 3 || !descriptor[0].SymbolEquals("compile_scan_computed_index") {
+		t.Fatalf("computed ORDER BY mapper descriptor = %s", scm.String(values[0]))
+	}
+}
+
+func TestCompileScanOrderAccessListCompilesEveryOrderedInput(t *testing.T) {
+	directionValue, _ := integerOrder(false)
+	emptySchema := scm.NewSlice(nil)
+	schemasExpr, valuesExpr, compiled := compileScanOrderAccessList(
+		scm.NewSlice([]scm.Scmer{emptySchema, emptySchema}), scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+			scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+		}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("multi-source ORDER BY did not compile into scan access")
+	}
+	schemas, ok := scanStaticListElements(schemasExpr)
+	if !ok || len(schemas) != 2 {
+		t.Fatalf("compiled multi-source schemas have invalid shape: %s", scm.String(schemasExpr))
+	}
+	for i, schemaValue := range schemas {
+		schema, static := scanStaticListElements(schemaValue)
+		if !static || len(schema) != scanAccessSchemaHeaderSize+1 {
+			t.Fatalf("compiled schema %d has invalid shape: %s", i, scm.String(schemaValue))
+		}
+		if got := ScanBoundaryFromScmer(schema[scanAccessSchemaHeaderSize]).ColumnName(); got != "rank" {
+			t.Fatalf("compiled schema %d order column = %q, want rank", i, got)
+		}
+	}
+	values, ok := scanStaticListElements(valuesExpr)
+	if !ok || len(values) != 0 {
+		t.Fatalf("direct multi-source ORDER BY added runtime values: %s", scm.String(valuesExpr))
+	}
+}
+
+func TestCompileScanJoinDriverOrderAccessOnlyCompilesDriver(t *testing.T) {
+	directionValue, _ := integerOrder(true)
+	emptySchema := scm.NewSlice(nil)
+	schemasExpr, _, compiled := compileScanJoinDriverOrderAccess(
+		scm.NewSlice([]scm.Scmer{emptySchema, emptySchema}), scm.NewSlice(nil),
+		scm.NewSlice([]scm.Scmer{
+			scm.NewSlice([]scm.Scmer{scm.NewInt(0), scm.NewString("rank")}),
+		}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("join driver ORDER BY did not compile into scan access")
+	}
+	schemas, _ := scanStaticListElements(schemasExpr)
+	driver, _ := scanStaticListElements(schemas[0])
+	if len(driver) != scanAccessSchemaHeaderSize+1 || ScanBoundaryFromScmer(driver[1]).ColumnName() != "rank" {
+		t.Fatalf("compiled join driver schema = %s", scm.String(schemas[0]))
+	}
+	inner, _ := scanStaticListElements(schemas[1])
+	if len(inner) != 0 {
+		t.Fatalf("join inner schema unexpectedly received final order: %s", scm.String(schemas[1]))
 	}
 }
 

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -23,11 +23,16 @@ import (
 	"github.com/launix-de/memcp/scm"
 )
 
+func persistableTestOrder(reverse bool) (scm.Scmer, func(...scm.Scmer) scm.Scmer) {
+	value := scm.Apply(scm.Globalenv.Vars[scm.Symbol("collate")], scm.NewString("utf8mb4"), scm.NewBool(reverse))
+	return value, scm.OptimizeProcToSerialFunction(value)
+}
+
 func TestScanOrderOptimizerCompilesOrderIntoAccessSchema(t *testing.T) {
 	Init(scm.Globalenv)
 	expr := scm.Read(t.Name(), `(lambda (table_value)
 		(scan_order nil table_value '() '() '() (lambda () true)
-			'("rank") (list <) 0 0 10
+			'("rank") (list (collate "utf8mb4" false)) 0 0 10
 			'("rank") (lambda (acc rank) rank) nil false nil '() nil))`)
 	optimized := scm.Optimize(expr, &scm.Globalenv, nil)
 	plan := scm.SerializeToString(optimized, &scm.Globalenv)
@@ -40,7 +45,7 @@ func TestScanOrderBatchAcceptOptimizerCompilesOrderIntoAccessSchema(t *testing.T
 	Init(scm.Globalenv)
 	expr := scm.Read(t.Name(), `(lambda (table_value)
 		(scan_order_batch_accept nil table_value '() '()
-			(lambda (input) input) '("rank") (list <) 0 0 10
+			(lambda (input) input) '("rank") (list (collate "utf8mb4" false)) 0 0 10
 			'("rank") (lambda (acc rank) rank) nil false nil))`)
 	optimized := scm.Optimize(expr, &scm.Globalenv, nil)
 	plan := scm.SerializeToString(optimized, &scm.Globalenv)
@@ -73,7 +78,7 @@ func TestExtendBoundariesRejectsPartiallyCoveredOrder(t *testing.T) {
 }
 
 func TestCompileScanOrderAccessStoresOrderInStaticSchema(t *testing.T) {
-	directionValue, direction := integerOrder(false)
+	directionValue, direction := persistableTestOrder(false)
 	schemaExpr, valuesExpr, compiled := compileScanOrderAccess(
 		scm.NewSlice(nil), scm.NewSlice(nil),
 		scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
@@ -113,8 +118,23 @@ func TestCompileScanOrderAccessStoresOrderInStaticSchema(t *testing.T) {
 	}
 }
 
+func TestCompileScanOrderAccessKeepsUnpersistableOrderAtRuntime(t *testing.T) {
+	directionValue, _ := integerOrder(false)
+	schema := scm.NewSlice(nil)
+	values := scm.NewSlice(nil)
+	schemaExpr, valuesExpr, compiled := compileScanOrderAccess(
+		schema, values,
+		scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if compiled || schemaExpr != schema || valuesExpr != values {
+		t.Fatalf("unpersistable callback order was compiled: schema=%s values=%s",
+			scm.String(schemaExpr), scm.String(valuesExpr))
+	}
+}
+
 func TestCompileScanOrderAccessPreservesPointPrefixAndRuntimeValues(t *testing.T) {
-	directionValue, _ := integerOrder(true)
+	directionValue, _ := persistableTestOrder(true)
 	point := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
 		"", false, -1, nil, nil, "", false)
 	schema := scm.NewSlice([]scm.Scmer{
@@ -149,7 +169,7 @@ func TestCompileScanOrderAccessPreservesPointPrefixAndRuntimeValues(t *testing.T
 }
 
 func TestCompileScanOrderAccessPreservesOptimizedLocalValuesExpression(t *testing.T) {
-	directionValue, _ := integerOrder(true)
+	directionValue, _ := persistableTestOrder(true)
 	point := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
 		"", false, -1, nil, nil, "", false)
 	schema := scm.NewSlice([]scm.Scmer{
@@ -173,7 +193,7 @@ func TestCompileScanOrderAccessPreservesOptimizedLocalValuesExpression(t *testin
 
 func TestCompileScanOrderAccessStoresComputedOrderMapper(t *testing.T) {
 	Init(scm.Globalenv)
-	directionValue, _ := integerOrder(false)
+	directionValue, _ := persistableTestOrder(false)
 	computed := scm.Eval(scm.Optimize(scm.Read(t.Name(), `(lambda (rank) (+ rank 1))`), &scm.Globalenv, nil), &scm.Globalenv)
 	proc := computed.Proc()
 	if !isRawDataset(proc.Params.Slice(), proc.Body) {
@@ -204,7 +224,7 @@ func TestCompileScanOrderAccessStoresComputedOrderMapper(t *testing.T) {
 }
 
 func TestCompileScanOrderAccessListCompilesEveryOrderedInput(t *testing.T) {
-	directionValue, _ := integerOrder(false)
+	directionValue, _ := persistableTestOrder(false)
 	emptySchema := scm.NewSlice(nil)
 	schemasExpr, valuesExpr, compiled := compileScanOrderAccessList(
 		scm.NewSlice([]scm.Scmer{emptySchema, emptySchema}), scm.NewSlice(nil),
@@ -237,7 +257,7 @@ func TestCompileScanOrderAccessListCompilesEveryOrderedInput(t *testing.T) {
 }
 
 func TestCompileScanJoinDriverOrderAccessOnlyCompilesDriver(t *testing.T) {
-	directionValue, _ := integerOrder(true)
+	directionValue, _ := persistableTestOrder(true)
 	emptySchema := scm.NewSlice(nil)
 	schemasExpr, _, compiled := compileScanJoinDriverOrderAccess(
 		scm.NewSlice([]scm.Scmer{emptySchema, emptySchema}), scm.NewSlice(nil),

--- a/storage/scan_order_coverage_test.go
+++ b/storage/scan_order_coverage_test.go
@@ -148,6 +148,29 @@ func TestCompileScanOrderAccessPreservesPointPrefixAndRuntimeValues(t *testing.T
 	}
 }
 
+func TestCompileScanOrderAccessPreservesOptimizedLocalValuesExpression(t *testing.T) {
+	directionValue, _ := integerOrder(true)
+	point := newScanBoundarySpec("tenant", EqualMatcher, 0, 0, true, true,
+		"", false, -1, nil, nil, "", false)
+	schema := scm.NewSlice([]scm.Scmer{
+		newScanAccessHeader(1, scanAccessConsumerCoveredScan, 0, -1), point,
+	})
+	values := scm.NewSlice([]scm.Scmer{scm.NewSymbol("list"), scm.NewNthLocalVar(1)})
+
+	_, valuesExpr, compiled := compileScanOrderAccess(
+		scm.NewSlice([]scm.Scmer{scm.NewSymbol("quote"), schema}), values,
+		scm.NewSlice([]scm.Scmer{scm.NewString("rank")}),
+		scm.NewSlice([]scm.Scmer{directionValue}),
+	)
+	if !compiled {
+		t.Fatal("point-prefix ORDER BY did not compile into scan access")
+	}
+	if valuesExpr != values {
+		t.Fatalf("compiled ORDER BY rewrote optimized local values: got %s, want %s",
+			scm.String(valuesExpr), scm.String(values))
+	}
+}
+
 func TestCompileScanOrderAccessStoresComputedOrderMapper(t *testing.T) {
 	Init(scm.Globalenv)
 	directionValue, _ := integerOrder(false)


### PR DESCRIPTION
## Summary

- compile immutable ORDER BY requirements into cached scan access schemas for `scan_order`, `scan_order_multi`, `scan_order_batch_accept`, and ordered `scan_join_order` drivers
- keep runtime index resolution authoritative while avoiding per-invocation order-boundary construction
- preserve correlated optimized access values verbatim, so planner-local bindings remain runtime values
- persist canonical collation order metadata and reconstruct it on cache load while retaining the existing runtime fallback for arbitrary callbacks
- cover direct, point-prefix, computed, multi-source, join-driver, correlated-value, and persisted-plan layouts

## Manual A/B measurements

Same fixture, three warmups, 100,000 invocations per sample, five samples, one CPU. The benchmark uses the canonical SQL collation relation:

```text
go test ./storage -run '^$' -bench '^BenchmarkScanOrderPlannerCompiledFixedCosts$' -benchmem -benchtime=100000x -count=5 -cpu=1
```

Median results after merging current master:

| revision | latency | bytes/op | allocs/op |
| --- | ---: | ---: | ---: |
| `origin/master` (`64b6f6aaa`) | 4,236 ns | 3,160 B | 38 |
| this PR | 3,629 ns | 2,680 B | 32 |
| change | **-607 ns / -14.3%** | **-480 B / -15.2%** | **-6 / -15.8%** |

Supplemental end-to-end WordPress suite measurements were unchanged at the runner resolution: ordered post limit 0.6 ms -> 0.6 ms, filtered ordered join 0.7 ms -> 0.7 ms.

## Tradeoffs

- cached plans retain one immutable boundary descriptor per usable ORDER BY key, moving a small amount of work and memory from every execution to one-time compilation
- runtime-capturing and arbitrary callback order relations deliberately retain the existing runtime fallback
- persisted canonical orders add one metadata field; old 11-field boundaries remain readable and unordered boundaries retain their existing encoding
- actual index availability remains a runtime decision, so lazy index creation and eviction semantics are unchanged

## Verification

- `go test ./storage -count=1`
- `bash git-pre-commit 'tests/planner/order-window/*.yaml' tests/planner/subqueries/expr-subselects.yaml`
- `python3 run_sql_tests.py tests/performance/ordered-scan-sources.yaml tests/performance/wordpress-postmeta-order-limit.yaml`
- `PERF_TEST=1 python3 run_sql_tests.py tests/performance/json-functions.yaml`
- `PERF_TEST=1 python3 run_sql_tests.py tests/performance/wordpress-postmeta-order-limit.yaml`

The existing protected SO 73024688 assertion remains unchanged. The full suite is intentionally delegated to CI.