### PR TITLE
parser: express SQL string unescaping with regexp_replace + a callback

### DIFF
--- a/lib/psql-parser.scm
+++ b/lib/psql-parser.scm
@@ -50,7 +50,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	(atom "INTERVAL" true)
 	(atom "DIV" true)
 )))
-(define psql_identifier_quoted (parser '("\"" (define id (regex "(?:[^\"])+" false false)) "\"") (sql_unescape id))) /* with double quote */
+(define psql_identifier_quoted (parser '("\"" (define id (regex "(?:[^\"])+" false false)) "\"") (regexp_replace id "\\\\[\\\\'\"nr0]" sql_string_unescape))) /* with double quote */
 (define psql_identifier (parser (define x (or psql_identifier_unquoted psql_identifier_quoted)) x))
 
 (define psql_column (parser (or
@@ -84,7 +84,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 (define psql_interval_unit (parser '((define unit psql_identifier_unquoted) (? "(" (regex "[0-9]+") ")")) unit))
 
 (define psql_string (parser (or
-	(parser '((atom "'" false) (define x (regex "(\\\\.|[^\\'])*" false false)) (atom "'" false false)) (sql_unescape x))
+	(parser '((atom "'" false) (define x (regex "(\\\\.|[^\\'])*" false false)) (atom "'" false false)) (regexp_replace x "\\\\[\\\\'\"nr0]" sql_string_unescape))
 )))
 
 /* SQL modulo expression: uses native mod builtin (NULL-safe, div-by-zero returns NULL) */

--- a/lib/sql-parser.scm
+++ b/lib/sql-parser.scm
@@ -122,9 +122,20 @@ Extracts only the username portion; the @host part is accepted but ignored. */
 (define sql_number (parser (define x (regex "-?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e-?[0-9]+)?" true)) (simplify x)))
 (define sql_interval_unit (parser '((define unit sql_identifier_unquoted) (? "(" (regex "[0-9]+") ")")) unit))
 
+/* strip one SQL string escape: doubled delimiter -> single, the six backslash
+   escapes MySQL decodes, everything else (\x) keeps its literal second byte */
+(define sql_string_unescape (lambda (m)
+	(match m
+		"''" "'"
+		"\"\"" "\""
+		"\\n" "\n"
+		"\\r" "\r"
+		"\\0" "\0"
+		(substr m 1))))
+
 (define sql_string (parser (or
-	(parser '((atom "'" false) (define x (regex "(\\\\.|''|[^\\'])*" false false)) (atom "'" false false)) (sql_unescape (replace x "''" "'")))
-	(parser '((atom "\"" false) (define x (regex "(\\\\.|\"\"|[^\\\"])*" false false)) (atom "\"" false false)) (sql_unescape (replace x "\"\"" "\"")))
+	(parser '((atom "'" false) (define x (regex "(\\\\.|''|[^\\'])*" false false)) (atom "'" false false)) (regexp_replace x "''|\\\\[\\\\'\"nr0]" sql_string_unescape))
+	(parser '((atom "\"" false) (define x (regex "(\\\\.|\"\"|[^\\\"])*" false false)) (atom "\"" false false)) (regexp_replace x "\"\"|\\\\[\\\\'\"nr0]" sql_string_unescape))
 )))
 (define sql_hex_literal (parser
 	(define x (regex "0[xX](?:[0-9A-Fa-f]{2})*"))

--- a/lib/test.scm
+++ b/lib/test.scm
@@ -1317,10 +1317,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	/* general_ci heuristic places ASCII before non-ASCII class like leading 'aa' */
 	(assert ((collate "general_ci") "z" "aa") true "general_ci: ASCII first")
 
-	/* SQL unescape */
-	(assert (equal? (bin2hex (sql_unescape "a\\nb")) "610a62") true "sql_unescape newline")
-	(assert (equal? (sql_unescape "a\\'b") "a'b") true "sql_unescape quote")
-	(assert (equal? (bin2hex (sql_unescape "a\\0b")) "610062") true "sql_unescape NUL byte present")
+	/* SQL string escape decoding (regexp_replace with a callback, as the grammar does it) */
+	(define sql_unescape_test (lambda (s) (regexp_replace s "''|\\\\[\\\\'\"nr0]" (lambda (m)
+		(match m
+			"''" "'"
+			"\"\"" "\""
+			"\\n" "\n"
+			"\\r" "\r"
+			"\\0" "\0"
+			(substr m 1))))))
+	(assert (equal? (bin2hex (sql_unescape_test "a\\nb")) "610a62") true "sql string unescape: newline")
+	(assert (equal? (sql_unescape_test "a\\'b") "a'b") true "sql string unescape: quote")
+	(assert (equal? (bin2hex (sql_unescape_test "a\\0b")) "610062") true "sql string unescape: NUL byte present")
 
 	/* json_encode vs json_encode_assoc semantics (master-compatible) */
 	(assert (equal? (json_encode '(1 2 3)) "[1,2,3]") true "json_encode lists as arrays")

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -590,6 +590,17 @@ func ApplyAssoc(procedure Scmer, args []Scmer) (value Scmer) {
 func Apply(procedure Scmer, args ...Scmer) (value Scmer) {
 	return ApplyEx(procedure, args, &Globalenv)
 }
+// scmerCallable reports whether procedure can be invoked with Apply - a lambda,
+// a native func, a closure, or a compiled JIT entry (assoc-list slices are
+// callable too but are not what a "replacement function" argument means).
+func scmerCallable(procedure Scmer) bool {
+	switch procedure.GetTag() {
+	case tagFunc, tagFuncEnv, tagClosure, tagProc, tagJIT:
+		return true
+	}
+	return false
+}
+
 func ApplyEx(procedure Scmer, args []Scmer, en *Env) (value Scmer) {
 	// Native funcs
 	switch procedure.GetTag() {

--- a/scm/strings.go
+++ b/scm/strings.go
@@ -15162,46 +15162,6 @@ func init_strings() {
 			JITInlineCost:  21,
 		},
 	})
-	sql_escapings := regexp.MustCompile("\\\\[\\\\'\"nr0]")
-	Declare(&Globalenv, &Declaration{
-		Name: "sql_unescape",
-
-		Fn: func(a ...Scmer) Scmer {
-			input := String(a[0])
-			out := sql_escapings.ReplaceAllStringFunc(input, func(m string) string {
-				switch m {
-				case "\\\\":
-					return "\\"
-				case "\\'":
-					return "'"
-				case "\\\"":
-					return "\""
-				case "\\n":
-					return "\n"
-				case "\\r":
-					return "\r"
-				case "\\0":
-					return string([]byte{0})
-				}
-				return m
-			})
-			return NewString(out)
-		},
-		Type: &TypeDescriptor{Kind: "func", Description: "unescapes the inner part of a sql string",
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "value", Description: "string to decode"}},
-			Return: &TypeDescriptor{Kind: "string"},
-			Const:  true,
-
-			JITEmit: func(ctx *JITContext, sourceArgs []Scmer, args []JITValueDesc, result JITValueDesc) JITValueDesc {
-				// JITGen native call boundary: static Go callback value.
-				ctx.Coverage.NativeCalls++
-				declaration := declarations["sql_unescape"]
-				return jitEmitGeneratedCallBoundary(ctx, declaration, sourceArgs, args, result)
-			},
-			JITVirtualArgs: true,
-			JITInlineCost:  65535,
-		},
-	})
 	Declare(&Globalenv, &Declaration{
 		Name: "bin2hex",
 
@@ -18685,10 +18645,16 @@ func init_strings() {
 			if err != nil {
 				panic("regexp_replace: invalid pattern: " + err.Error())
 			}
+			if scmerCallable(a[2]) {
+				replacer := a[2]
+				return NewString(re.ReplaceAllStringFunc(String(a[0]), func(match string) string {
+					return String(Apply(replacer, NewString(match)))
+				}))
+			}
 			return NewString(re.ReplaceAllString(String(a[0]), String(a[2])))
 		},
-		Type: &TypeDescriptor{Kind: "func", Description: "replaces matches of a regex pattern in a string",
-			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "regex pattern"}, &TypeDescriptor{Kind: "string", Label: "replacement", Description: "replacement string"}},
+		Type: &TypeDescriptor{Kind: "func", Description: "replaces matches of a regex pattern in a string; the replacement may be a string ($1 expansion) or a function called with each match",
+			Params: []*TypeDescriptor{&TypeDescriptor{Kind: "string", Label: "str", Description: "input string"}, &TypeDescriptor{Kind: "string", Label: "pattern", Description: "regex pattern"}, &TypeDescriptor{Kind: "any", Label: "replacement", Description: "replacement string ($1 expansion) or function (match) -> string"}},
 			Return: &TypeDescriptor{Kind: "string"},
 			Const:  true,
 
@@ -21989,10 +21955,18 @@ func optimizeRegexpReplace(v []Scmer, oc *OptimizerContext, useResult bool) (Scm
 	if err != nil {
 		return result, td // let runtime handle the error
 	}
-	// Replace call with a precompiled closure
+	// Replace call with a precompiled closure. The replacement stays a runtime
+	// argument (arg 1 after the rewrite) so a string ($1 expansion) and a
+	// function (match) -> string are both still accepted.
 	compiled := NewFunc(func(a ...Scmer) Scmer {
 		if a[0].IsNil() {
 			return NewNil()
+		}
+		if scmerCallable(a[1]) {
+			replacer := a[1]
+			return NewString(re.ReplaceAllStringFunc(String(a[0]), func(match string) string {
+				return String(Apply(replacer, NewString(match)))
+			}))
 		}
 		return NewString(re.ReplaceAllString(String(a[0]), String(a[1])))
 	})


### PR DESCRIPTION
The `sql_string` grammar called a bespoke `sql_unescape` builtin whose `Fn` is
`regexp.MustCompile(...).ReplaceAllStringFunc(input, closure)`. jitgen cannot
follow a static Go callback, so every parsed string literal crossed a full call
boundary the JIT could never open up.

Replace it with primitives the compiler already understands:

- `regexp_replace` now accepts a `(match) -> string` function as its third
  argument (Go's `ReplaceAllStringFunc`), alongside the existing string
  (`$1` expansion) form. `scmerCallable` gates the two.
- `optimizeRegexpReplace` precompiles the pattern once for the callback form too.
- `lib/sql-parser.scm` / `lib/psql-parser.scm` express the six MySQL backslash
  escapes plus the doubled delimiter as one `regexp_replace` pass with a shared
  `sql_string_unescape` lambda. **Byte-identical** to the old
  `sql_unescape(replace(...))` chain — verified `it''s`, `C:\path`, `\n`, `\0`,
  `\t` kept literal, backtick idents.
- `sql_unescape` and its call-boundary emitter are removed; the `test.scm`
  coverage moves onto the `regexp_replace` callback form.

Groundwork for making string literals JIT-lowerable without any parser-specific Go.

Tests: full pre-commit green. `go test ./scm` green; psql-parser 64/64,
prepared-stmts 57/57, name-resolution 40/40, group-stage-corners 42/42,
index-delta-merge 35/35, rdf 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV