### PR TITLE
ci: run jit-test only for PRs that target master

### DIFF
--- a/.github/workflows/jit-test.yml
+++ b/.github/workflows/jit-test.yml
@@ -5,6 +5,7 @@ name: JIT Test
 
 on:
   pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`jit-test.yml`'s `pull_request:` trigger had no branch filter, so the ~15-minute
JIT suite also ran on branch-to-branch PRs (stacked-PR chains), repeating work
that the base PR already covers when it runs against master. Every other PR
workflow is scoped to `branches: [master]`; this brings jit-test in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014paLYJqwDuFcwo3EmeasYV