### PR TITLE
Budget rebuild memory before spawning maintenance workers

### DIFF
--- a/lib/dashboard.scm
+++ b/lib/dashboard.scm
@@ -87,6 +87,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		"mem_available" (s "mem_available")
 		"mem_total" (s "mem_total")
 		"shard" (list "current_memory" (s "shard_memory") "persisted_budget" (s "persisted_budget") "memory_budget" (s "shard_budget") "persisted_memory" (s "persisted_memory") "cache_entry_count" (s "cache_entry_count") "cache_entry_size" (s "cache_entry_size"))
+		"maintenance" (list "current_memory" (s "maintenance_memory") "peak_memory" (s "maintenance_memory_peak") "memory_budget" (s "maintenance_memory_budget"))
 		"process_memory" (s "process_memory")
 		"connections" (active_connections)
 		"max_connections" (max_connections)

--- a/storage/database.go
+++ b/storage/database.go
@@ -651,6 +651,22 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 		}
 		dbs = onlineTables
 	}
+	// Keep the shared blob catalog last. It waits for every blob-producing table;
+	// putting it before an admission-blocked producer could otherwise reserve the
+	// maintenance budget while waiting for work that has not been started yet.
+	orderedTables := make([]*table, 0, len(dbs))
+	var blobTable *table
+	for _, t := range dbs {
+		if t.Name == ".blobs" {
+			blobTable = t
+		} else {
+			orderedTables = append(orderedTables, t)
+		}
+	}
+	if blobTable != nil {
+		orderedTables = append(orderedTables, blobTable)
+	}
+	dbs = orderedTables
 	var blobWriters sync.WaitGroup
 	for _, t := range dbs {
 		if t.Name != ".blobs" {
@@ -659,7 +675,10 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 	}
 	done.Add(len(dbs))
 	for _, t := range dbs {
-		go func(t *table) {
+		tableBytes := estimateTableMaintenanceBytes(t)
+		tableLease := GlobalMaintenanceRAMBudget.Acquire(tableBytes)
+		go func(t *table, tableBytes int64, tableLease *RAMLease) {
+			defer tableLease.Release()
 			if t.Name == ".blobs" {
 				// Rebuilding other tables may update blob refcounts. Rebuild the
 				// shared catalog only after those writes have completed.
@@ -722,61 +741,34 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 			var shardErrMu sync.Mutex
 			var shardErrors []string
 			sdone.Add(len(origShardList))
-			// throttle concurrent shard rebuilds by CPU count
+			// Acquire both CPU and RAM before creating the goroutine. This avoids a
+			// pool of blocked worker goroutines when memory is the tighter limit.
 			workers := runtime.NumCPU()
 			if workers < 1 {
 				workers = 1
 			}
-			type job struct {
-				i int
-				s *storageShard
-			}
-			if len(origShardList) <= workers {
-				for i, s := range origShardList {
-					go func(i int, s *storageShard) {
-						defer func() {
-							if r := recover(); r != nil {
-								errmsg := fmt.Sprintf("shard rebuild failed for %s.%s shard %d: %v", db.Name, t.Name, i, r)
-								fmt.Println("error:", errmsg)
-								shardErrMu.Lock()
-								shardErrors = append(shardErrors, errmsg)
-								shardErrMu.Unlock()
-							}
-							sdone.Done()
-						}()
-						if s != nil {
-							newShardList[i] = s.rebuild(all)
+			workerRights := make(chan struct{}, workers)
+			tableRows := int64(t.CountEstimate())
+			for i, s := range origShardList {
+				workerRights <- struct{}{}
+				shardLease := tableLease.Acquire(estimateShardMaintenanceBytes(tableBytes, estimatedShardRows(s), tableRows))
+				go func(i int, s *storageShard, shardLease *RAMLease) {
+					defer func() { <-workerRights }()
+					defer shardLease.Release()
+					defer func() {
+						if r := recover(); r != nil {
+							errmsg := fmt.Sprintf("shard rebuild failed for %s.%s shard %d: %v", db.Name, t.Name, i, r)
+							fmt.Println("error:", errmsg)
+							shardErrMu.Lock()
+							shardErrors = append(shardErrors, errmsg)
+							shardErrMu.Unlock()
 						}
-					}(i, s)
-				}
-			} else {
-				jobs := make(chan job, workers)
-				// launch workers
-				for w := 0; w < workers; w++ {
-					go func() {
-						for j := range jobs {
-							func(j job) {
-								defer func() {
-									if r := recover(); r != nil {
-										errmsg := fmt.Sprintf("shard rebuild failed for %s.%s shard %d: %v", db.Name, t.Name, j.i, r)
-										fmt.Println("error:", errmsg)
-										shardErrMu.Lock()
-										shardErrors = append(shardErrors, errmsg)
-										shardErrMu.Unlock()
-									}
-									sdone.Done()
-								}()
-								if j.s != nil {
-									newShardList[j.i] = j.s.rebuild(all)
-								}
-							}(j)
-						}
+						sdone.Done()
 					}()
-				}
-				for i, s := range origShardList {
-					jobs <- job{i: i, s: s}
-				}
-				close(jobs)
+					if s != nil {
+						newShardList[i] = s.rebuild(all)
+					}
+				}(i, s, shardLease)
 			}
 			sdone.Wait()
 			if len(shardErrors) > 0 {
@@ -1002,13 +994,13 @@ func (db *database) rebuildWithLifecycle(all bool, repartition bool, includeEphe
 				// maintenanceMu stays locked; repartition generation retirement
 				// releases it after the last old-topology user.
 				rebuildClaimed = false
-				t.repartitionDDLReadLocked(shardCandidates)
+				t.repartitionDDLReadLocked(shardCandidates, tableLease)
 			} else {
 				// No repartition — release maintenanceMu now
 				t.maintenanceMu.Unlock()
 				rebuildClaimed = false
 			}
-		}(t)
+		}(t, tableBytes, tableLease)
 	}
 	done.Wait()
 

--- a/storage/maintenance_budget.go
+++ b/storage/maintenance_budget.go
@@ -1,0 +1,210 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"math"
+	"sync"
+)
+
+const (
+	minimumMaintenanceReservation = int64(1 << 20)
+	maintenanceBytesPerRow        = int64(48)
+)
+
+// RAMBudget limits the estimated temporary memory owned by maintenance work.
+// It is deliberately separate from query fanout rights: queries remain latency
+// oriented while rebuild/repartition workers may wait for memory. A request
+// larger than the complete budget is admitted alone so mandatory maintenance
+// cannot deadlock.
+type RAMBudget struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	capacity int64
+	used     int64
+	peak     int64
+}
+
+type RAMBudgetStat struct {
+	Capacity int64
+	Used     int64
+	Peak     int64
+}
+
+// RAMLease is one slice of a parent budget. Subtasks reserve from its local
+// budget, keeping their lock traffic away from the global maintenance budget.
+type RAMLease struct {
+	parent   *RAMBudget
+	size     int64
+	children RAMBudget
+	once     sync.Once
+}
+
+var GlobalMaintenanceRAMBudget RAMBudget
+
+func (b *RAMBudget) conditionLocked() *sync.Cond {
+	if b.cond == nil {
+		b.cond = sync.NewCond(&b.mu)
+	}
+	return b.cond
+}
+
+func (b *RAMBudget) SetCapacity(capacity int64) {
+	if capacity < 0 {
+		capacity = 0
+	}
+	b.mu.Lock()
+	b.capacity = capacity
+	if b.cond != nil {
+		b.cond.Broadcast()
+	}
+	b.mu.Unlock()
+}
+
+func (b *RAMBudget) Stat() RAMBudgetStat {
+	b.mu.Lock()
+	stat := RAMBudgetStat{Capacity: b.capacity, Used: b.used, Peak: b.peak}
+	b.mu.Unlock()
+	return stat
+}
+
+func normalizeMaintenanceReservation(size int64) int64 {
+	if size < minimumMaintenanceReservation {
+		return minimumMaintenanceReservation
+	}
+	return size
+}
+
+func (b *RAMBudget) Acquire(size int64) *RAMLease {
+	size = normalizeMaintenanceReservation(size)
+	b.mu.Lock()
+	capacity := b.capacity
+	if capacity <= 0 {
+		b.mu.Unlock()
+		return &RAMLease{}
+	}
+	if size > capacity {
+		size = capacity
+	}
+	cond := b.conditionLocked()
+	for b.used != 0 && size > capacity-b.used {
+		cond.Wait()
+		capacity = b.capacity
+		if capacity <= 0 {
+			b.mu.Unlock()
+			return &RAMLease{}
+		}
+		if size > capacity {
+			size = capacity
+		}
+	}
+	b.used += size
+	if b.used > b.peak {
+		b.peak = b.used
+	}
+	b.mu.Unlock()
+
+	lease := &RAMLease{parent: b, size: size}
+	lease.children.SetCapacity(size)
+	return lease
+}
+
+func (l *RAMLease) Release() {
+	if l == nil || l.parent == nil {
+		return
+	}
+	l.once.Do(func() {
+		l.parent.mu.Lock()
+		l.parent.used -= l.size
+		if l.parent.cond != nil {
+			l.parent.cond.Broadcast()
+		}
+		l.parent.mu.Unlock()
+	})
+}
+
+func (l *RAMLease) Acquire(size int64) *RAMLease {
+	if l == nil || l.parent == nil {
+		return &RAMLease{}
+	}
+	return l.children.Acquire(size)
+}
+
+func (l *RAMLease) Capacity() int64 {
+	if l == nil || l.size <= 0 {
+		return math.MaxInt64
+	}
+	return l.size
+}
+
+func saturatingAdd(a, b int64) int64 {
+	if b > 0 && a > math.MaxInt64-b {
+		return math.MaxInt64
+	}
+	return a + b
+}
+
+func saturatingMulDiv(value, multiplier, divisor int64) int64 {
+	if value <= 0 || multiplier <= 0 || divisor <= 0 {
+		return 0
+	}
+	if value > math.MaxInt64/multiplier {
+		return math.MaxInt64
+	}
+	return value * multiplier / divisor
+}
+
+// estimateTableMaintenanceBytes is an O(1), lock-free estimate. In particular,
+// it must never call ComputeSize, collectStatistics, load a shard, or inspect
+// column storage. Published bytes are scaled with the fresher DML-maintained row
+// estimate. The per-row allowance covers recid slices, masks and translation
+// maps allocated by rebuild and repartition.
+func estimateTableMaintenanceBytes(t *table) int64 {
+	stats := t.statistics()
+	rows := int64(t.CountEstimate())
+	bytes := stats.sizeBytes
+	if bytes > 0 && stats.rowCount > 0 && rows > 0 && rows != stats.rowCount {
+		bytes = saturatingMulDiv(bytes, rows, stats.rowCount)
+	}
+	if bytes <= 0 {
+		columns := int64(3)
+		if snapshot := t.showColumnsSnapshot.Load(); snapshot != nil && snapshot.metadata != nil && snapshot.metadata.columns != nil {
+			if count := int64(len(snapshot.metadata.columns.distinctEstimates)); count > columns {
+				columns = count
+			}
+		}
+		// A Scmer slot occupies 16 bytes. This fallback is used before the first
+		// byte statistic is published and intentionally depends only on immutable
+		// metadata, never on the live column storages.
+		bytes = saturatingMulDiv(rows, 16*columns, 1)
+	}
+	return normalizeMaintenanceReservation(saturatingAdd(bytes, saturatingMulDiv(rows, maintenanceBytesPerRow, 1)))
+}
+
+func estimateShardMaintenanceBytes(tableBytes, shardRows, tableRows int64) int64 {
+	if tableRows <= 0 || shardRows <= 0 {
+		return minimumMaintenanceReservation
+	}
+	return normalizeMaintenanceReservation(saturatingMulDiv(tableBytes, shardRows, tableRows))
+}
+
+func estimatedShardRows(shard *storageShard) int64 {
+	if shard == nil {
+		return 0
+	}
+	return int64(shard.plannerMainRows.Load()) + int64(shard.plannerDeltaRows.Load())
+}

--- a/storage/maintenance_budget_test.go
+++ b/storage/maintenance_budget_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright (C) 2026  Carl-Philip Hänsch
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/launix-de/memcp/scm"
+)
+
+func TestRAMBudgetBlocksBeforeStartingExcessWork(t *testing.T) {
+	var budget RAMBudget
+	budget.SetCapacity(2 * minimumMaintenanceReservation)
+	first := budget.Acquire(2 * minimumMaintenanceReservation)
+
+	started := make(chan *RAMLease, 1)
+	go func() { started <- budget.Acquire(minimumMaintenanceReservation) }()
+	select {
+	case lease := <-started:
+		lease.Release()
+		t.Fatal("excess maintenance work acquired an exhausted budget")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	first.Release()
+	select {
+	case lease := <-started:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("maintenance work did not resume after memory was released")
+	}
+}
+
+func TestRAMBudgetOversizedWorkRunsAlone(t *testing.T) {
+	var budget RAMBudget
+	budget.SetCapacity(minimumMaintenanceReservation)
+	lease := budget.Acquire(8 * minimumMaintenanceReservation)
+	stat := budget.Stat()
+	if stat.Used != minimumMaintenanceReservation {
+		t.Fatalf("oversized reservation = %d, want capacity %d", stat.Used, minimumMaintenanceReservation)
+	}
+	lease.Release()
+}
+
+func TestRAMLeaseContainsChildReservations(t *testing.T) {
+	var budget RAMBudget
+	budget.SetCapacity(4 * minimumMaintenanceReservation)
+	parent := budget.Acquire(3 * minimumMaintenanceReservation)
+	child := parent.Acquire(2 * minimumMaintenanceReservation)
+
+	if got := budget.Stat().Used; got != 3*minimumMaintenanceReservation {
+		t.Fatalf("child reservation changed global usage to %d", got)
+	}
+	if got := parent.children.Stat().Used; got != 2*minimumMaintenanceReservation {
+		t.Fatalf("local child usage = %d", got)
+	}
+	child.Release()
+	parent.Release()
+}
+
+func TestMaintenanceEstimateScalesPublishedStatistics(t *testing.T) {
+	tbl := &table{}
+	tbl.PlannerRowEstimate.value.Store(200_000)
+	tbl.showColumnsSnapshot.Store(&tableShowColumnsSnapshot{
+		metadata: &tableShowColumnsSnapshotMetadata{
+			statistics: &tableStatisticsSnapshot{rowCount: 100_000, sizeBytes: 10_000_000},
+		},
+	})
+
+	// 10 MB scales to 20 MB for the newer row estimate; rebuild/repartition
+	// metadata adds another 48 bytes for each of the 200k rows.
+	if got, want := estimateTableMaintenanceBytes(tbl), int64(29_600_000); got != want {
+		t.Fatalf("maintenance estimate = %d, want %d", got, want)
+	}
+}
+
+func TestTotalMemoryBytesHonorsCgroupV2Limit(t *testing.T) {
+	limit := cgroupMemoryLimitBytes()
+	if limit == 0 {
+		t.Skip("no finite cgroup v2 memory limit")
+	}
+	if got := totalMemoryBytes(); got > limit {
+		t.Fatalf("available process memory = %d, exceeds cgroup limit %d", got, limit)
+	}
+}
+
+func BenchmarkMaintenanceEstimatePublishedRead(b *testing.B) {
+	tbl := &table{}
+	tbl.PlannerRowEstimate.value.Store(200_000)
+	tbl.showColumnsSnapshot.Store(&tableShowColumnsSnapshot{
+		metadata: &tableShowColumnsSnapshotMetadata{
+			statistics: &tableStatisticsSnapshot{rowCount: 100_000, sizeBytes: 10_000_000},
+		},
+	})
+	b.ReportAllocs()
+	for b.Loop() {
+		tableStatisticsBenchmarkSink.sizeBytes = estimateTableMaintenanceBytes(tbl)
+	}
+}
+
+func BenchmarkRAMBudgetUncontended(b *testing.B) {
+	var budget RAMBudget
+	budget.SetCapacity(1 << 30)
+	b.ReportAllocs()
+	for b.Loop() {
+		lease := budget.Acquire(minimumMaintenanceReservation)
+		lease.Release()
+	}
+}
+
+func BenchmarkBudgetedTableRebuild(b *testing.B) {
+	oldBasepath := Basepath
+	Basepath = b.TempDir()
+	b.Cleanup(func() { Basepath = oldBasepath })
+	dbName := fmt.Sprintf("maintenance-budget-bench-%d", time.Now().UnixNano())
+	CreateDatabase(dbName, false)
+	b.Cleanup(func() { databases.Remove(dbName) })
+	tbl, _ := CreateTable(dbName, "items", Memory, false)
+	tbl.CreateColumn("id", "INT", nil, nil)
+	tbl.CreateColumn("tenant_id", "INT", nil, nil)
+	tbl.CreateColumn("payload", "TEXT", nil, nil)
+	rows := make([][]scm.Scmer, 10_000)
+	for i := range rows {
+		rows[i] = []scm.Scmer{scm.NewInt(int64(i)), scm.NewInt(int64(i % 128)), scm.NewString(fmt.Sprintf("payload-%d", i))}
+	}
+	tbl.Insert([]string{"id", "tenant_id", "payload"}, rows, nil, scm.NewNil(), false, nil)
+
+	previousCapacity := GlobalMaintenanceRAMBudget.Stat().Capacity
+	GlobalMaintenanceRAMBudget.SetCapacity(64 << 20)
+	b.Cleanup(func() { GlobalMaintenanceRAMBudget.SetCapacity(previousCapacity) })
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		result := tbl.schema.rebuild(true, false, false, tbl)
+		if len(result.errors) != 0 {
+			b.Fatalf("rebuild errors: %v", result.errors)
+		}
+	}
+}

--- a/storage/partition.go
+++ b/storage/partition.go
@@ -616,14 +616,16 @@ func (t *table) proposerepartition(maincount uint) (shardCandidates []shardDimen
 // before invoking repartition). It manages its own shard-level locking.
 // maintenanceMu is already held and maintenanceKind is set to 2 by the caller.
 func (t *table) repartition(shardCandidates []shardDimension) {
+	maintenanceLease := GlobalMaintenanceRAMBudget.Acquire(estimateTableMaintenanceBytes(t))
+	defer maintenanceLease.Release()
 	t.schema.persistenceLifecycle.RLock()
 	defer t.schema.persistenceLifecycle.RUnlock()
 	t.ddlMu.RLock()
 	defer t.ddlMu.RUnlock()
-	t.repartitionDDLReadLocked(shardCandidates)
+	t.repartitionDDLReadLocked(shardCandidates, maintenanceLease)
 }
 
-func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
+func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension, maintenanceLease *RAMLease) {
 	// Safety-net: if somehow called directly without the flag being set.
 	if t.maintenanceKind == 2 && t.PShards != nil {
 		return
@@ -806,139 +808,139 @@ func (t *table) repartitionDDLReadLocked(shardCandidates []shardDimension) {
 	if workers < 1 {
 		workers = 1
 	}
-	progress := make(chan int, workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			for si := range progress {
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							fmt.Println("error: repartition shard build failed for", t.schema.Name+".", t.Name, "shard", si, ":", r)
-							buildErrMu.Lock()
-							buildErrors = append(buildErrors, r)
-							buildErrMu.Unlock()
-						}
-						done.Done()
-					}()
-					s := newshards[si]
-					built := &builtData[si]
-					built.columns = make(map[string]ColumnStorage)
-					// Count main rows for this new shard
-					mainCount := uint32(0)
-					for _, items := range datasetids[si] {
-						mainCount += uint32(len(items))
-					}
-					built.mainCount = mainCount
-					// Allocate column storage and build
-					values := make([]scm.Scmer, mainCount)
-					for _, col := range t.Columns {
-						// Check if ANY old shard has a StorageComputeProxy for this column.
-						// If so, port the proxy (computor + validMask) instead of evaluating values.
-						var proxyTemplate *StorageComputeProxy
-						for _, os := range oldshards {
-							os.mu.RLock()
-							if cs, ok := os.columns[col.Name]; ok {
-								if p, ok := cs.(*StorageComputeProxy); ok {
-									proxyTemplate = p
-									os.mu.RUnlock()
-									break
-								}
-							}
-							os.mu.RUnlock()
-						}
-
-						if proxyTemplate != nil {
-							// Port StorageComputeProxy: create new proxy for this PShard,
-							// copy valid values and validMask, leave invalid rows for lazy recompute.
-							newProxy := &StorageComputeProxy{
-								delta:     make(map[uint32]scm.Scmer),
-								computor:  proxyTemplate.computor,
-								inputCols: proxyTemplate.inputCols,
-								shard:     s, // back-reference to new PShard
-								colName:   proxyTemplate.colName,
-								count:     mainCount,
-								isOrdered: proxyTemplate.isOrdered,
-							}
-							// Port values and validMask from old shards
-							var newIdx uint32
-							for s2id, items := range datasetids[si] {
-								oldShard := oldshards[s2id]
-								oldShard.mu.RLock()
-								oldProxy, isProxy := oldShard.columns[col.Name].(*StorageComputeProxy)
-								oldShard.mu.RUnlock()
-								if !isProxy {
-									// Old shard has plain storage for this column — read values directly
-									reader := oldShard.ColumnReaderTx(nil, col.Name)
-									for _, item := range items {
-										val := reader(uint32(item))
-										newProxy.delta[newIdx] = val
-										newProxy.validMask.Set(uint(newIdx), true)
-										newIdx++
-									}
-								} else {
-									oldRowIDs := make([]uint32, len(items))
-									for i, item := range items {
-										oldRowIDs[i] = uint32(item)
-									}
-									newIdx = appendComputeProxyRows(newProxy, oldProxy, oldRowIDs, newIdx)
-								}
-							}
-							built.columns[col.Name] = newProxy
-							// Compute proxies are not serialized to disk
-						} else {
-							// Normal column: read values and compress
-							var i uint32
-							for s2id, items := range datasetids[si] {
-								reader := oldshards[s2id].ColumnReaderTx(nil, col.Name)
-								for _, item := range items {
-									values[i] = reader(uint32(item))
-									i++
-								}
-							}
-							// Compress into optimal storage format
-							var newcol ColumnStorage = new(StorageSCMER)
-							for {
-								newcol.prepare()
-								for j, v := range values {
-									newcol.scan(uint32(j), v)
-								}
-								newcol2 := newcol.proposeCompression(uint32(i))
-								if newcol2 == nil {
-									break
-								}
-								newcol = newcol2
-							}
-							if blob, ok := newcol.(*OverlayBlob); ok {
-								blob.schema = s.t.schema
-							}
-							// TODO: when source column is OverlayBlob, shuffle raw
-							// compressed blob data without decompressing+recompressing.
-							// Copy hash references and blob files directly to avoid
-							// the gzip round-trip during repartition.
-							newcol.init(uint32(mainCount))
-							for j, v := range values {
-								newcol.build(uint32(j), v)
-							}
-							newcol.finish()
-							// Store in temporary map (NOT on shard — shard is live for dual-write)
-							built.columns[col.Name] = newcol
-							// Write to disk
-							if s.t.PersistencyMode != Memory {
-								f := s.t.schema.persistence.WriteColumn(s.uuid.String(), col.Name)
-								newcol.Serialize(f)
-								finishColumnWrite(f, s.t.PersistencyMode == Safe)
-							}
-						}
-					}
-				}()
-			}
-		}()
-	}
+	workerRights := make(chan struct{}, workers)
 	for si := range newshards {
-		progress <- si
+		shardRows := int64(0)
+		for _, items := range datasetids[si] {
+			shardRows += int64(len(items))
+		}
+		workerRights <- struct{}{}
+		shardLease := maintenanceLease.Acquire(estimateShardMaintenanceBytes(maintenanceLease.Capacity(), shardRows, int64(total_count)))
+		go func(si int, shardLease *RAMLease) {
+			defer func() { <-workerRights }()
+			defer shardLease.Release()
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Println("error: repartition shard build failed for", t.schema.Name+".", t.Name, "shard", si, ":", r)
+					buildErrMu.Lock()
+					buildErrors = append(buildErrors, r)
+					buildErrMu.Unlock()
+				}
+				done.Done()
+			}()
+			s := newshards[si]
+			built := &builtData[si]
+			built.columns = make(map[string]ColumnStorage)
+			// Count main rows for this new shard
+			mainCount := uint32(0)
+			for _, items := range datasetids[si] {
+				mainCount += uint32(len(items))
+			}
+			built.mainCount = mainCount
+			// Allocate column storage and build
+			values := make([]scm.Scmer, mainCount)
+			for _, col := range t.Columns {
+				// Check if ANY old shard has a StorageComputeProxy for this column.
+				// If so, port the proxy (computor + validMask) instead of evaluating values.
+				var proxyTemplate *StorageComputeProxy
+				for _, os := range oldshards {
+					os.mu.RLock()
+					if cs, ok := os.columns[col.Name]; ok {
+						if p, ok := cs.(*StorageComputeProxy); ok {
+							proxyTemplate = p
+							os.mu.RUnlock()
+							break
+						}
+					}
+					os.mu.RUnlock()
+				}
+
+				if proxyTemplate != nil {
+					// Port StorageComputeProxy: create new proxy for this PShard,
+					// copy valid values and validMask, leave invalid rows for lazy recompute.
+					newProxy := &StorageComputeProxy{
+						delta:     make(map[uint32]scm.Scmer),
+						computor:  proxyTemplate.computor,
+						inputCols: proxyTemplate.inputCols,
+						shard:     s, // back-reference to new PShard
+						colName:   proxyTemplate.colName,
+						count:     mainCount,
+						isOrdered: proxyTemplate.isOrdered,
+					}
+					// Port values and validMask from old shards
+					var newIdx uint32
+					for s2id, items := range datasetids[si] {
+						oldShard := oldshards[s2id]
+						oldShard.mu.RLock()
+						oldProxy, isProxy := oldShard.columns[col.Name].(*StorageComputeProxy)
+						oldShard.mu.RUnlock()
+						if !isProxy {
+							// Old shard has plain storage for this column — read values directly
+							reader := oldShard.ColumnReaderTx(nil, col.Name)
+							for _, item := range items {
+								val := reader(uint32(item))
+								newProxy.delta[newIdx] = val
+								newProxy.validMask.Set(uint(newIdx), true)
+								newIdx++
+							}
+						} else {
+							oldRowIDs := make([]uint32, len(items))
+							for i, item := range items {
+								oldRowIDs[i] = uint32(item)
+							}
+							newIdx = appendComputeProxyRows(newProxy, oldProxy, oldRowIDs, newIdx)
+						}
+					}
+					built.columns[col.Name] = newProxy
+					// Compute proxies are not serialized to disk
+				} else {
+					// Normal column: read values and compress
+					var i uint32
+					for s2id, items := range datasetids[si] {
+						reader := oldshards[s2id].ColumnReaderTx(nil, col.Name)
+						for _, item := range items {
+							values[i] = reader(uint32(item))
+							i++
+						}
+					}
+					// Compress into optimal storage format
+					var newcol ColumnStorage = new(StorageSCMER)
+					for {
+						newcol.prepare()
+						for j, v := range values {
+							newcol.scan(uint32(j), v)
+						}
+						newcol2 := newcol.proposeCompression(uint32(i))
+						if newcol2 == nil {
+							break
+						}
+						newcol = newcol2
+					}
+					if blob, ok := newcol.(*OverlayBlob); ok {
+						blob.schema = s.t.schema
+					}
+					// TODO: when source column is OverlayBlob, shuffle raw
+					// compressed blob data without decompressing+recompressing.
+					// Copy hash references and blob files directly to avoid
+					// the gzip round-trip during repartition.
+					newcol.init(uint32(mainCount))
+					for j, v := range values {
+						newcol.build(uint32(j), v)
+					}
+					newcol.finish()
+					// Store in temporary map (NOT on shard — shard is live for dual-write)
+					built.columns[col.Name] = newcol
+					// Write to disk
+					if s.t.PersistencyMode != Memory {
+						f := s.t.schema.persistence.WriteColumn(s.uuid.String(), col.Name)
+						newcol.Serialize(f)
+						finishColumnWrite(f, s.t.PersistencyMode == Safe)
+					}
+				}
+			}
+		}(si, shardLease)
 		fmt.Println("rebuild", t.Name, si+1, "/", len(newshards))
 	}
-	close(progress) // signal workers to exit after processing all items
 	done.Wait()
 	if len(buildErrors) > 0 {
 		err := buildErrors[0]

--- a/storage/settings.go
+++ b/storage/settings.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,6 +44,8 @@ type SettingsT struct {
 	MaxRamBytes            int64 // 0 = use MaxRamPercent; >0 = override total budget in bytes
 	MaxPersistPercent      int   // 0 = default (30%), otherwise 1-100; budget for persisted shards+indexes
 	MaxPersistBytes        int64 // 0 = use MaxPersistPercent; >0 = override persisted budget in bytes
+	MaintenanceRamPercent  int   // 0 = default (50% of MaxRam); maintenance scratch-memory budget
+	MaintenanceRamBytes    int64 // 0 = use MaintenanceRamPercent; >0 = override maintenance budget in bytes
 	MetricsTracing         bool  // when true, periodically insert metrics into system.perf_metrics
 	MetricsTracingInterval int   // interval in seconds (0 = default 60s)
 	ShutdownDrainSeconds   int   // seconds to wait for in-flight requests during shutdown (0 = default 10s)
@@ -126,7 +129,15 @@ func (r CreateTableTriggerRegistration) triggerDescription() TriggerDescription 
 	}
 }
 
-var Settings SettingsT = SettingsT{false, false, false, 0, 10, "safe", 60000, 50, 5, 0, 0, 0, 0, false, 0, 0, false, false, 20, 256, false, 0, false, 0, nil}
+var Settings = SettingsT{
+	PartitionMaxDimensions: 10,
+	DefaultEngine:          "safe",
+	ShardSize:              60000,
+	AnalyzeMinItems:        50,
+	IndexThreshold:         5,
+	ExplainWidth:           20,
+	JoinReorderDPBudget:    256,
+}
 var createTableTriggerMu sync.Mutex
 
 func registerCreateTableTrigger(reg CreateTableTriggerRegistration) {
@@ -193,6 +204,8 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			scm.NewString("MaxRamBytes"), scm.NewInt(Settings.MaxRamBytes),
 			scm.NewString("MaxPersistPercent"), scm.NewInt(int64(Settings.MaxPersistPercent)),
 			scm.NewString("MaxPersistBytes"), scm.NewInt(Settings.MaxPersistBytes),
+			scm.NewString("MaintenanceRamPercent"), scm.NewInt(int64(Settings.MaintenanceRamPercent)),
+			scm.NewString("MaintenanceRamBytes"), scm.NewInt(Settings.MaintenanceRamBytes),
 			scm.NewString("MetricsTracing"), scm.NewBool(Settings.MetricsTracing),
 			scm.NewString("MetricsTracingInterval"), scm.NewInt(int64(Settings.MetricsTracingInterval)),
 			scm.NewString("ShutdownDrainSeconds"), scm.NewInt(int64(Settings.ShutdownDrainSeconds)),
@@ -233,6 +246,10 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(int64(Settings.MaxPersistPercent))
 		case "MaxPersistBytes":
 			return scm.NewInt(Settings.MaxPersistBytes)
+		case "MaintenanceRamPercent":
+			return scm.NewInt(int64(Settings.MaintenanceRamPercent))
+		case "MaintenanceRamBytes":
+			return scm.NewInt(Settings.MaintenanceRamBytes)
 		case "MetricsTracing":
 			return scm.NewBool(Settings.MetricsTracing)
 		case "MetricsTracingInterval":
@@ -289,10 +306,12 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			Settings.MaxRamPercent = scm.ToInt(a[1])
 			total, persisted := computeMemoryBudgets()
 			GlobalCache.UpdateBudget(total, persisted)
+			GlobalMaintenanceRAMBudget.SetCapacity(computeMaintenanceMemoryBudget(total))
 		case "MaxRamBytes":
 			Settings.MaxRamBytes = int64(scm.ToInt(a[1]))
 			total, persisted := computeMemoryBudgets()
 			GlobalCache.UpdateBudget(total, persisted)
+			GlobalMaintenanceRAMBudget.SetCapacity(computeMaintenanceMemoryBudget(total))
 		case "MaxPersistPercent":
 			Settings.MaxPersistPercent = scm.ToInt(a[1])
 			total, persisted := computeMemoryBudgets()
@@ -301,6 +320,14 @@ func ChangeSettings(a ...scm.Scmer) scm.Scmer {
 			Settings.MaxPersistBytes = int64(scm.ToInt(a[1]))
 			total, persisted := computeMemoryBudgets()
 			GlobalCache.UpdateBudget(total, persisted)
+		case "MaintenanceRamPercent":
+			Settings.MaintenanceRamPercent = scm.ToInt(a[1])
+			total, _ := computeMemoryBudgets()
+			GlobalMaintenanceRAMBudget.SetCapacity(computeMaintenanceMemoryBudget(total))
+		case "MaintenanceRamBytes":
+			Settings.MaintenanceRamBytes = int64(scm.ToInt(a[1]))
+			total, _ := computeMemoryBudgets()
+			GlobalMaintenanceRAMBudget.SetCapacity(computeMaintenanceMemoryBudget(total))
 		case "MetricsTracing":
 			Settings.MetricsTracing = scm.ToBool(a[1])
 		case "MetricsTracingInterval":
@@ -361,8 +388,19 @@ func MakePrintLogFunc() func(string) {
 // Always exists as a struct; methods are no-ops until Init() is called.
 var GlobalCache CacheManager
 
-// totalMemoryBytes reads total physical RAM from /proc/meminfo (Linux).
+// totalMemoryBytes returns the memory available to this process. A cgroup-v2
+// hard limit takes precedence over host RAM so percentage budgets remain safe
+// in containers and services with MemoryMax configured.
 func totalMemoryBytes() int64 {
+	physical := physicalMemoryBytes()
+	limit := cgroupMemoryLimitBytes()
+	if limit > 0 && (physical <= 0 || limit < physical) {
+		return limit
+	}
+	return physical
+}
+
+func physicalMemoryBytes() int64 {
 	f, err := os.Open("/proc/meminfo")
 	if err != nil {
 		return 0
@@ -385,12 +423,56 @@ func totalMemoryBytes() int64 {
 	return 0
 }
 
+func cgroupMemoryLimitBytes() int64 {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return 0
+	}
+	var relative string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "0::") {
+			relative = strings.TrimPrefix(line, "0::")
+			break
+		}
+	}
+	if relative == "" {
+		return 0
+	}
+	root := filepath.Clean("/sys/fs/cgroup")
+	dir := filepath.Join(root, filepath.Clean("/"+relative))
+	var limit int64
+	for {
+		value, readErr := os.ReadFile(filepath.Join(dir, "memory.max"))
+		if readErr == nil {
+			trimmed := strings.TrimSpace(string(value))
+			if trimmed != "max" {
+				candidate, parseErr := strconv.ParseInt(trimmed, 10, 64)
+				if parseErr == nil && candidate > 0 && (limit == 0 || candidate < limit) {
+					limit = candidate
+				}
+			}
+		}
+		if dir == root {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir || !strings.HasPrefix(parent, root) {
+			break
+		}
+		dir = parent
+	}
+	return limit
+}
+
 func computeMemoryBudgets() (total, persisted int64) {
 	totalRAM := totalMemoryBytes()
 
 	// total budget
 	if Settings.MaxRamBytes > 0 {
 		total = Settings.MaxRamBytes
+		if totalRAM > 0 && total > totalRAM {
+			total = totalRAM
+		}
 	} else if totalRAM > 0 {
 		pct := Settings.MaxRamPercent
 		if pct == 0 {
@@ -413,9 +495,26 @@ func computeMemoryBudgets() (total, persisted int64) {
 	return
 }
 
+func computeMaintenanceMemoryBudget(total int64) int64 {
+	if Settings.MaintenanceRamBytes > 0 {
+		if total > 0 && Settings.MaintenanceRamBytes > total {
+			return total
+		}
+		return Settings.MaintenanceRamBytes
+	}
+	percent := Settings.MaintenanceRamPercent
+	if percent <= 0 {
+		percent = 50
+	} else if percent > 100 {
+		percent = 100
+	}
+	return total * int64(percent) / 100
+}
+
 // InitCacheManager initializes the global CacheManager. Call from InitSettings().
 func InitCacheManager() {
 	total, persisted := computeMemoryBudgets()
+	GlobalMaintenanceRAMBudget.SetCapacity(computeMaintenanceMemoryBudget(total))
 	if total > 0 || persisted > 0 {
 		GlobalCache.Init(total, persisted)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3367,6 +3367,7 @@ func Init(en scm.Env) {
 				memTotal, memAvail := ReadMemInfo()
 				processMem := ReadProcessRSS()
 				cs := GlobalCache.Stat()
+				maintenance := GlobalMaintenanceRAMBudget.Stat()
 				nonEvictable := processMem - cs.CurrentMemory
 				if nonEvictable < 0 {
 					nonEvictable = 0
@@ -3391,6 +3392,9 @@ func Init(en scm.Env) {
 					scm.NewString("temp_keytable_count"), scm.NewInt(cs.CountByType[TypeTempKeytable]),
 					scm.NewString("string_dictionary_size"), scm.NewInt(cs.SizeByType[TypeStringDict]),
 					scm.NewString("string_dictionary_count"), scm.NewInt(cs.CountByType[TypeStringDict]),
+					scm.NewString("maintenance_memory"), scm.NewInt(maintenance.Used),
+					scm.NewString("maintenance_memory_peak"), scm.NewInt(maintenance.Peak),
+					scm.NewString("maintenance_memory_budget"), scm.NewInt(maintenance.Capacity),
 				})
 			} else if len(a) == 1 && a[0].IsCustom(TagTable) {
 				return scm.NewString(TableFromScmer(a[0]).PrintMemUsage())
@@ -3401,7 +3405,7 @@ func Init(en scm.Env) {
 			}
 			return scm.NewNil()
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc. process_memory is exact process RSS; evictable_memory and its per-owner size/count fields are disjoint estimated Go payload ownership; non_evictable_process_memory is the RSS remainder including allocator, runtime, stacks, and untracked shared overhead. shard_memory remains a compatibility alias for evictable_memory.\n(stat schema) and (stat schema tbl) return disjoint owner-payload estimates, not per-schema RSS.",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "return system statistics as assoc. process_memory is exact process RSS; evictable_memory and its per-owner size/count fields are disjoint estimated Go payload ownership; non_evictable_process_memory is the RSS remainder including allocator, runtime, stacks, and untracked shared overhead. maintenance_memory reports estimated scratch RAM currently reserved by maintenance jobs. shard_memory remains a compatibility alias for evictable_memory.\n(stat schema) and (stat schema tbl) return disjoint owner-payload estimates, not per-schema RSS.",
 			Params: []*scm.TypeDescriptor{
 				{Kind: "string", Label: "schema", Description: "(optional) database name for detailed string output", Optional: true},
 				{Kind: "string", Label: "table", Description: "(optional) table name for detailed string output", Optional: true},
@@ -3415,7 +3419,7 @@ func Init(en scm.Env) {
 		Fn: func(a ...scm.Scmer) scm.Scmer {
 			return scm.NewInt(totalMemoryBytes())
 		},
-		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns total physical memory in bytes (from /proc/meminfo)",
+		Type: &scm.TypeDescriptor{Kind: "func", Description: "Returns memory available to the process in bytes (physical RAM capped by cgroup v2 memory.max)",
 			Return: &scm.TypeDescriptor{Kind: "number"},
 			Const:  true,
 		},
@@ -4098,6 +4102,11 @@ func PrintMemUsage() string {
 	// CacheManager evictable memory breakdown
 	b.WriteString("\n\nCache\n======\n")
 	b.WriteString(GlobalCache.Stat().FormatStat())
+	maintenance := GlobalMaintenanceRAMBudget.Stat()
+	b.WriteString(fmt.Sprintf("MaintenanceBudget = %s\tReserved = %s\tPeak = %s\n",
+		units.BytesSize(float64(maintenance.Capacity)),
+		units.BytesSize(float64(maintenance.Used)),
+		units.BytesSize(float64(maintenance.Peak))))
 
 	for _, db := range databases.GetAll() {
 		b.WriteString("\n\n" + db.Name + " [" + sharedStateStr(db.srState) + "]\n======\n")


### PR DESCRIPTION
## Summary

- add a separate hierarchical RAM budget for rebuild and repartition work while leaving query/session fanout unchanged
- reserve table and shard slices before spawning workers, and admit oversized mandatory jobs alone instead of deadlocking
- estimate reservations in O(1) from atomically published table byte statistics and DML-maintained row estimates; the admission path never calls `ComputeSize`, refreshes statistics, loads columns, or takes shard locks
- derive child reservations locally so shard workers do not contend on the global budget lock
- make percentage budgets respect cgroup v2 `memory.max`, including explicit `MaxRamBytes` caps
- expose current, peak, and maximum maintenance reservations through `(stat)`, `PrintMemUsage`, and the dashboard payload
- add configurable `MaintenanceRamPercent` (default: 50% of the MemCP RAM budget) and `MaintenanceRamBytes`

## Manual A/B measurement

Fixture: one 10,000-row in-memory table with two integer columns and one text column, repeatedly rebuilt through the table coordinator. Both revisions used the same fixture, 50 rebuilds per sample, three samples, `MemoryMax=512M`, `MemorySwapMax=0`, and the same amd64 host.

- master median: **5.421 ms/rebuild**
- this PR median: **5.216 ms/rebuild**
- change: **-0.205 ms (-3.8%)**
- master: about **4.102 MB/op, 324 allocations/op**
- this PR: about **4.103 MB/op, 330 allocations/op**

The six additional allocations are job/lease control objects outside row loops. The latency result shows no measurable uncontended rebuild penalty. A separate 512 MiB cgroup run observed a roughly 18 MiB peak for this small fixture and completed without swap or OOM.

The published-statistics estimator itself measured **3.54-3.73 ns/op, 0 B/op, 0 allocs/op**. An uncontended standalone lease acquire/release measured **36-72 ns/op, 80 B/op, 1 allocation/op**.

## Verification

- `go test ./...`
- `go test -race ./storage -run 'TestRAMBudget|TestRAMLease|TestMaintenanceEstimate' -count=1`
- cgroup-v2 test under `MemoryMax=512M`: `TestTotalMemoryBytesHonorsCgroupV2Limit`
- `tests/storage/persistence/memory-pressure.yaml` under `MemoryMax=1G`, `MemorySwapMax=0` (32/32 passed)
- rebuild benchmark under `MemoryMax=512M`, `MemorySwapMax=0`

## Trade-offs

When concurrent maintenance estimates exceed the configured slice, jobs intentionally wait and maintenance throughput can decrease. Estimates are conservative and may serialize more work than strictly necessary when published byte statistics are stale. Mandatory jobs larger than the complete budget still run, but run alone; the budget is admission control rather than an allocator-level hard limit.
